### PR TITLE
Qt frontend shutdown behavior fixes and enhancements

### DIFF
--- a/IPython/frontend/qt/console/frontend_widget.py
+++ b/IPython/frontend/qt/console/frontend_widget.py
@@ -144,7 +144,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         document.contentsChange.connect(self._document_contents_change)
         
         # set flag for whether we are connected via localhost
-        self._local_kernel = kw.get('local_kernel', False)
+        self._local_kernel = kw.get('local_kernel', FrontendWidget._local_kernel)
 
     #---------------------------------------------------------------------------
     # 'ConsoleWidget' public interface

--- a/IPython/frontend/qt/console/ipythonqt.py
+++ b/IPython/frontend/qt/console/ipythonqt.py
@@ -67,9 +67,9 @@ class MainWindow(QtGui.QMainWindow):
             if self._may_close:
                 msg = "You are closing this Console window."
                 info = "Would you like to quit the Kernel and all attached Consoles as well?"
-                justthis = QtGui.QPushButton("No, just this Console", self)
+                justthis = QtGui.QPushButton("&No, just this Console", self)
                 justthis.setShortcut('N')
-                closeall = QtGui.QPushButton("Yes, quit everything", self)
+                closeall = QtGui.QPushButton("&Yes, quit everything", self)
                 closeall.setShortcut('Y')
                 box = QtGui.QMessageBox(QtGui.QMessageBox.Question, title, msg)
                 box.setInformativeText(info)

--- a/IPython/frontend/qt/console/ipythonqt.py
+++ b/IPython/frontend/qt/console/ipythonqt.py
@@ -62,16 +62,28 @@ class MainWindow(QtGui.QMainWindow):
         kernel_manager = self._frontend.kernel_manager
         if kernel_manager and kernel_manager.channels_running:
             title = self.window().windowTitle()
+            cancel = QtGui.QMessageBox.Cancel
+            okay = QtGui.QMessageBox.Ok
             if self._may_close:
-                reply = QtGui.QMessageBox.question(self, title,
-                    "You are closing this Console window."+
-                    "\nWould you like to quit the Kernel and all attached Consoles as well?",
-                    'Cancel', 'No, just this Console', 'Yes, quit everything')
-                if reply == 2: # close All
+                msg = "You are closing this Console window."
+                info = "Would you like to quit the Kernel and all attached Consoles as well?"
+                justthis = QtGui.QPushButton("No, just this Console", self)
+                justthis.setShortcut(QtGui.QKeySequence.Close)
+                closeall = QtGui.QPushButton("Yes, quit everything", self)
+                closeall.setShortcut('A')
+                box = QtGui.QMessageBox(QtGui.QMessageBox.Question, title, msg)
+                box.setInformativeText(info)
+                box.addButton(cancel)
+                box.addButton(justthis, QtGui.QMessageBox.NoRole)
+                box.addButton(closeall, QtGui.QMessageBox.YesRole)
+                box.setDefaultButton(closeall)
+                box.setEscapeButton(cancel)
+                reply = box.exec_()
+                if reply == 1: # close All
                     kernel_manager.shutdown_kernel()
                     #kernel_manager.stop_channels()
                     event.accept()
-                elif reply == 1: # close Console
+                elif reply == 0: # close Console
                     if not self._existing:
                         # I have the kernel: don't quit, just close the window
                         self._app.setQuitOnLastWindowClosed(False)
@@ -81,11 +93,12 @@ class MainWindow(QtGui.QMainWindow):
                     event.ignore()
             else:
                 reply = QtGui.QMessageBox.question(self, title,
-                    "Are you sure you want to close this Console?\n"+
-                    "The Kernel and other Consoles will remain active.",
-                    QtGui.QMessageBox.Cancel, QtGui.QMessageBox.Ok
+                    "Are you sure you want to close this Console?"+
+                    "\nThe Kernel and other Consoles will remain active.",
+                    okay|cancel,
+                    defaultButton=okay
                     )
-                if reply == QtGui.QMessageBox.Ok:
+                if reply == okay:
                     event.accept()
                 else:
                     event.ignore()

--- a/IPython/frontend/qt/console/ipythonqt.py
+++ b/IPython/frontend/qt/console/ipythonqt.py
@@ -83,9 +83,9 @@ class MainWindow(QtGui.QMainWindow):
                 reply = QtGui.QMessageBox.question(self, title,
                     "Are you sure you want to close this Console?\n"+
                     "The Kernel and other Consoles will remain active.",
-                    QtGui.QMessageBox.Yes, QtGui.QMessageBox.No
+                    QtGui.QMessageBox.Cancel, QtGui.QMessageBox.Ok
                     )
-                if reply == QtGui.QMessageBox.Yes:
+                if reply == QtGui.QMessageBox.Ok:
                     event.accept()
                 else:
                     event.ignore()

--- a/IPython/frontend/qt/console/ipythonqt.py
+++ b/IPython/frontend/qt/console/ipythonqt.py
@@ -16,10 +16,10 @@ from IPython.frontend.qt.console.rich_ipython_widget import RichIPythonWidget
 from IPython.frontend.qt.kernelmanager import QtKernelManager
 
 #-----------------------------------------------------------------------------
-# Constants
+# Network Constants
 #-----------------------------------------------------------------------------
 
-LOCALHOST = '127.0.0.1'
+from IPython.utils.localinterfaces import LOCALHOST, LOCAL_IPS
 
 #-----------------------------------------------------------------------------
 # Classes
@@ -45,7 +45,7 @@ class MainWindow(QtGui.QMainWindow):
         self._app = app
         self._frontend = frontend
         self._existing = existing
-        if not existing:
+        if existing:
             self._may_close = may_close
         else:
             self._may_close = True
@@ -144,12 +144,16 @@ def main():
                                      rep_address=(args.ip, args.rep),
                                      hb_address=(args.ip, args.hb))
     if not args.existing:
+        # if not args.ip in LOCAL_IPS+ALL_ALIAS:
+        #     raise ValueError("Must bind a local ip, such as: %s"%LOCAL_IPS)
+        
+        kwargs = dict(ip=args.ip)
         if args.pure:
-            kernel_manager.start_kernel(ipython=False)
+            kwargs['ipython']=False
         elif args.pylab:
-            kernel_manager.start_kernel(pylab=args.pylab)
-        else:
-            kernel_manager.start_kernel()
+            kwargs['pylab']=args.pylab
+            
+        kernel_manager.start_kernel(**kwargs)
     kernel_manager.start_channels()
 
     local_kernel = (not args.existing) or args.ip == LOCALHOST

--- a/IPython/frontend/qt/console/ipythonqt.py
+++ b/IPython/frontend/qt/console/ipythonqt.py
@@ -57,9 +57,9 @@ class MainWindow(QtGui.QMainWindow):
         if kernel_manager and kernel_manager.channels_running:
             title = self.window().windowTitle()
             reply = QtGui.QMessageBox.question(self, title,
-                "Close just this console, or shutdown the kernel and close "+
-                "all windows attached to it?", 
-                'Cancel', 'Close Console', 'Close All')
+                "You are closing this Console window."+
+                "\nWould you like to quit the Kernel and all attached Consoles as well?",
+                'Cancel', 'No, just this Console', 'Yes, quit everything')
             if reply == 2: # close All
                 kernel_manager.shutdown_kernel()
                 #kernel_manager.stop_channels()
@@ -68,6 +68,7 @@ class MainWindow(QtGui.QMainWindow):
                 if not self._existing:
                     # I have the kernel: don't quit, just close the window
                     self._app.setQuitOnLastWindowClosed(False)
+                    self.deleteLater()
                 event.accept()
             else:
                 event.ignore()
@@ -133,15 +134,16 @@ def main():
             kernel_manager.start_kernel()
     kernel_manager.start_channels()
 
+    local_kernel = (args.ip == LOCALHOST)
     # Create the widget.
     app = QtGui.QApplication([])
     if args.pure:
         kind = 'rich' if args.rich else 'plain'
-        widget = FrontendWidget(kind=kind, paging=args.paging)
+        widget = FrontendWidget(kind=kind, paging=args.paging, local_kernel=local_kernel)
     elif args.rich or args.pylab:
-        widget = RichIPythonWidget(paging=args.paging)
+        widget = RichIPythonWidget(paging=args.paging, local_kernel=local_kernel)
     else:
-        widget = IPythonWidget(paging=args.paging)
+        widget = IPythonWidget(paging=args.paging, local_kernel=local_kernel)
     widget.gui_completion = args.gui_completion
     widget.kernel_manager = kernel_manager
 

--- a/IPython/frontend/qt/console/ipythonqt.py
+++ b/IPython/frontend/qt/console/ipythonqt.py
@@ -68,9 +68,9 @@ class MainWindow(QtGui.QMainWindow):
                 msg = "You are closing this Console window."
                 info = "Would you like to quit the Kernel and all attached Consoles as well?"
                 justthis = QtGui.QPushButton("No, just this Console", self)
-                justthis.setShortcut(QtGui.QKeySequence.Close)
+                justthis.setShortcut('N')
                 closeall = QtGui.QPushButton("Yes, quit everything", self)
-                closeall.setShortcut('A')
+                closeall.setShortcut('Y')
                 box = QtGui.QMessageBox(QtGui.QMessageBox.Question, title, msg)
                 box.setInformativeText(info)
                 box.addButton(cancel)

--- a/IPython/frontend/qt/console/ipythonqt.py
+++ b/IPython/frontend/qt/console/ipythonqt.py
@@ -104,7 +104,11 @@ def main():
     kgroup.add_argument('-e', '--existing', action='store_true',
                         help='connect to an existing kernel')
     kgroup.add_argument('--ip', type=str, default=LOCALHOST,
-                        help='set the kernel\'s IP address [default localhost]')
+                        help=\
+            "set the kernel\'s IP address [default localhost].\
+            If the IP address is something other than localhost, then \
+            Consoles on other machines will be able to connect\
+            to the Kernel, so be careful!")
     kgroup.add_argument('--xreq', type=int, metavar='PORT', default=0,
                         help='set the XREQ channel port [default random]')
     kgroup.add_argument('--sub', type=int, metavar='PORT', default=0,

--- a/IPython/frontend/qt/console/ipythonqt.py
+++ b/IPython/frontend/qt/console/ipythonqt.py
@@ -156,7 +156,7 @@ def main():
         kernel_manager.start_kernel(**kwargs)
     kernel_manager.start_channels()
 
-    local_kernel = (not args.existing) or args.ip == LOCALHOST
+    local_kernel = (not args.existing) or args.ip in LOCAL_IPS
     # Create the widget.
     app = QtGui.QApplication([])
     if args.pure:

--- a/IPython/utils/localinterfaces.py
+++ b/IPython/utils/localinterfaces.py
@@ -1,0 +1,40 @@
+"""Simple utility for building a list of local IPs using the socket module.
+This module defines two constants:
+
+LOCALHOST : The loopback interface, or the first interface that points to this 
+            machine.  It will *almost* always be '127.0.0.1'
+
+LOCAL_IPS : A list of IP addresses, loopback first, that point to this machine.
+"""
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2010  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+import socket
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------
+
+LOCAL_IPS = []
+try:
+    LOCAL_IPS = socket.gethostbyname_ex('localhost')[2]
+except socket.gaierror:
+    pass
+
+try:
+    LOCAL_IPS.extend(socket.gethostbyname_ex(socket.gethostname())[2])
+except socket.gaierror:
+    pass
+
+# include all-interface aliases: 0.0.0.0 and ''
+LOCAL_IPS.extend(['0.0.0.0', ''])
+
+LOCALHOST = LOCAL_IPS[0]

--- a/IPython/zmq/entry_point.py
+++ b/IPython/zmq/entry_point.py
@@ -16,6 +16,7 @@ import zmq
 from IPython.core.ultratb import FormattedTB
 from IPython.external.argparse import ArgumentParser
 from IPython.utils import io
+from IPython.utils.localinterfaces import LOCALHOST
 from displayhook import DisplayHook
 from heartbeat import Heartbeat
 from iostream import OutStream
@@ -40,7 +41,7 @@ def make_argument_parser():
     kernel entry points.
     """
     parser = ArgumentParser()
-    parser.add_argument('--ip', type=str, default='127.0.0.1',
+    parser.add_argument('--ip', type=str, default=LOCALHOST,
                         help='set the kernel\'s IP address [default: local]')
     parser.add_argument('--xrep', type=int, metavar='PORT', default=0,
                         help='set the XREP channel port [default: random]')

--- a/IPython/zmq/frontend.py
+++ b/IPython/zmq/frontend.py
@@ -17,6 +17,7 @@ import uuid
 import zmq
 import session
 import completer
+from IPython.utils.localinterfaces import LOCALHOST
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -168,7 +169,7 @@ class InteractiveClient(object):
 def main():
     # Defaults
     #ip = '192.168.2.109'
-    ip = '127.0.0.1'
+    ip = LOCALHOST
     #ip = '99.146.222.252'
     port_base = 5575
     connection = ('tcp://%s' % ip) + ':%i'

--- a/IPython/zmq/heartbeat.py
+++ b/IPython/zmq/heartbeat.py
@@ -17,6 +17,8 @@ from threading import Thread
 
 import zmq
 
+from IPython.utils.localinterfaces import LOCALHOST
+
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
@@ -25,7 +27,7 @@ import zmq
 class Heartbeat(Thread):
     "A simple ping-pong style heartbeat that runs in a thread."
 
-    def __init__(self, context, addr=('127.0.0.1', 0)):
+    def __init__(self, context, addr=(LOCALHOST, 0)):
         Thread.__init__(self)
         self.context = context
         self.addr = addr

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -534,12 +534,15 @@ class GTKKernel(Kernel):
 # Kernel main and launch functions
 #-----------------------------------------------------------------------------
 
-def launch_kernel(xrep_port=0, pub_port=0, req_port=0, hb_port=0,
+def launch_kernel(ip=None, xrep_port=0, pub_port=0, req_port=0, hb_port=0,
                   independent=False, pylab=False):
     """Launches a localhost kernel, binding to the specified ports.
 
     Parameters
     ----------
+    ip  : str, optional
+        The ip address the kernel will bind to.
+    
     xrep_port : int, optional
         The port to use for XREP channel.
 
@@ -574,6 +577,10 @@ def launch_kernel(xrep_port=0, pub_port=0, req_port=0, hb_port=0,
         extra_arguments.append('--pylab')
         if isinstance(pylab, basestring):
             extra_arguments.append(pylab)
+    if ip is not None:
+        extra_arguments.append('--ip')
+        if isinstance(ip, basestring):
+            extra_arguments.append(ip)
     return base_launch_kernel('from IPython.zmq.ipkernel import main; main()',
                               xrep_port, pub_port, req_port, hb_port, 
                               independent, extra_arguments)

--- a/IPython/zmq/pykernel.py
+++ b/IPython/zmq/pykernel.py
@@ -256,12 +256,15 @@ class Kernel(HasTraits):
 # Kernel main and launch functions
 #-----------------------------------------------------------------------------
 
-def launch_kernel(xrep_port=0, pub_port=0, req_port=0, hb_port=0,
+def launch_kernel(ip=None, xrep_port=0, pub_port=0, req_port=0, hb_port=0,
                   independent=False):
     """ Launches a localhost kernel, binding to the specified ports.
 
     Parameters
     ----------
+    ip  : str, optional
+        The ip address the kernel will bind to.
+    
     xrep_port : int, optional
         The port to use for XREP channel.
 
@@ -286,9 +289,15 @@ def launch_kernel(xrep_port=0, pub_port=0, req_port=0, hb_port=0,
         (kernel_process, xrep_port, pub_port, req_port)
     where kernel_process is a Popen object and the ports are integers.
     """
+    extra_arguments = []
+    if ip is not None:
+        extra_arguments.append('--ip')
+        if isinstance(ip, basestring):
+            extra_arguments.append(ip)
+    
     return base_launch_kernel('from IPython.zmq.pykernel import main; main()',
                               xrep_port, pub_port, req_port, hb_port,
-                              independent)
+                              independent, extra_arguments=extra_arguments)
 
 main = make_default_main(Kernel)
 


### PR DESCRIPTION
Ready for review.

) fixed error when resetting pykernel (it still reset, but printed an error)
2) fixed issue where closing a frontend, even secondary ones, always shutdown the kernel
3) shutdown_reply now goes out on the pub socket, so all clients are notified
   3.a) this means that all clients can (and do) refresh the screen when a reset is called, just like the master frontend
4) kernel can stay alive after consoles are shutdown, and can be shutdown by any frontend at any point 
   4.a) this means that a shutdown request from any frontend can close all open frontends and the kernel, even if the kernel is detached, leaving no processes zombified.
   4.b) 4.a required that a 'reset' element be added to shutdown_request/reply messages to identify the difference between a real shutdown message and stage 1 of a reset.
