### PR TITLE
Added HTML export

### DIFF
--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -508,14 +508,20 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
         self._control.print_(printer)
 
     def export_html_inline(self, parent = None):
+        """ Export the contents of the ConsoleWidget as HTML with inline PNGs.
+        """
         self.export_html(parent, inline = True)
         
     def export_html(self, parent = None, inline = False):
-        """ Export the contents of the ConsoleWidget as an HTML file.
+        """ Export the contents of the ConsoleWidget as HTML.
 
-        If inline == True, include images as inline PNGs.  Otherwise,
-        include them as links to external PNG files, mimicking the
-        Firefox's "Web Page, complete" behavior.
+        Parameters:
+        -----------
+        inline : bool, optional [default True]
+
+            If True, include images as inline PNGs.  Otherwise,
+            include them as links to external PNG files, mimicking
+            Firefox's "Web Page, complete" behavior.
         """
         dialog = QtGui.QFileDialog(parent, 'Save HTML Document')
         dialog.setAcceptMode(QtGui.QFileDialog.AcceptSave)
@@ -552,8 +558,7 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
         return None
 
     def export_xhtml(self, parent = None):
-        """ Export the contents of the ConsoleWidget as an XHTML file
-        with figures as inline SVG.
+        """ Export the contents of the ConsoleWidget as XHTML with inline SVGs.
         """
         dialog = QtGui.QFileDialog(parent, 'Save XHTML Document')
         dialog.setAcceptMode(QtGui.QFileDialog.AcceptSave)
@@ -581,11 +586,26 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
             return filename
         return None
 
-    def image_tag(self, match, path = None):
-        """ Given an re.match object matching an image name in an HTML export,
-        return an appropriate substitution string for the image tag
-        (e.g., link, embedded image, ...).  As a side effect, files may
-        be generated in the directory given by path."""
+    def image_tag(self, match, path = None, format = "png"):
+        """ Return (X)HTML mark-up for the image-tag given by match.
+
+        Parameters
+        ----------
+        match : re.SRE_Match 
+            A match to an HTML image tag as exported by Qt, with
+            match.group("Name") containing the matched image ID.
+
+        path : string|None, optional [default None]
+            If not None, specifies a path to which supporting files
+            may be written (e.g., for linked images).
+            If None, all images are to be included inline.
+
+        format : "png"|"svg", optional [default "png"]
+            Format for returned or referenced images.
+
+        Subclasses supporting image display should override this
+        method.
+        """
 
         # Default case -- not enough information to generate tag
         return ""

--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -507,10 +507,10 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
                 return
         self._control.print_(printer)
 
-    def exportHtmlInline(self, parent = None):
-        self.exportHtml(parent, inline = True)
+    def export_html_inline(self, parent = None):
+        self.export_html(parent, inline = True)
         
-    def exportHtml(self, parent = None, inline = False):
+    def export_html(self, parent = None, inline = False):
         """ Export the contents of the ConsoleWidget as an HTML file.
 
         If inline == True, include images as inline PNGs.  Otherwise,
@@ -544,14 +544,14 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
                 # predictable...
                 img_re = re.compile(r'<img src="(?P<name>[\d]+)" />')
                 f.write(img_re.sub(
-                    lambda x: self.imagetag(x, path = path, format = "PNG"),
+                    lambda x: self.image_tag(x, path = path, format = "PNG"),
                     str(self._control.toHtml().toUtf8())))
             finally:
                 f.close()
             return filename
         return None
 
-    def exportXhtml(self, parent = None):
+    def export_xhtml(self, parent = None):
         """ Export the contents of the ConsoleWidget as an XHTML file
         with figures as inline SVG.
         """
@@ -574,14 +574,14 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
                 html = ('<html xmlns="http://www.w3.org/1999/xhtml">\n'+
                         html[offset+6:])
                 f.write(img_re.sub(
-                    lambda x: self.imagetag(x, path = None, format = "SVG"),
+                    lambda x: self.image_tag(x, path = None, format = "SVG"),
                     html))
             finally:
                 f.close()
             return filename
         return None
 
-    def imagetag(self, match, path = None):
+    def image_tag(self, match, path = None):
         """ Given an re.match object matching an image name in an HTML export,
         return an appropriate substitution string for the image tag
         (e.g., link, embedded image, ...).  As a side effect, files may
@@ -828,13 +828,13 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
         print_action = menu.addAction('Print', self.print_)
         print_action.setEnabled(True)
         html_action = menu.addAction('Export HTML (external PNGs)',
-                                     self.exportHtml)
+                                     self.export_html)
         html_action.setEnabled(True)
         html_inline_action = menu.addAction('Export HTML (inline PNGs)',
-                                            self.exportHtmlInline)
+                                            self.export_html_inline)
         html_inline_action.setEnabled(True)
         xhtml_action = menu.addAction('Export XHTML (inline SVGs)',
-                                      self.exportXhtml)
+                                      self.export_xhtml)
         xhtml_action.setEnabled(True)
         return menu
 

--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -544,7 +544,7 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
                 # predictable...
                 img_re = re.compile(r'<img src="(?P<name>[\d]+)" />')
                 f.write(img_re.sub(
-                    lambda x: self.image_tag(x, path = path, format = "PNG"),
+                    lambda x: self.image_tag(x, path = path, format = "png"),
                     str(self._control.toHtml().toUtf8())))
             finally:
                 f.close()
@@ -574,7 +574,7 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
                 html = ('<html xmlns="http://www.w3.org/1999/xhtml">\n'+
                         html[offset+6:])
                 f.write(img_re.sub(
-                    lambda x: self.image_tag(x, path = None, format = "SVG"),
+                    lambda x: self.image_tag(x, path = None, format = "svg"),
                     html))
             finally:
                 f.close()

--- a/IPython/frontend/qt/console/rich_ipython_widget.py
+++ b/IPython/frontend/qt/console/rich_ipython_widget.py
@@ -132,7 +132,7 @@ class RichIPythonWidget(IPythonWidget):
         (e.g., link, embedded image, ...).  As a side effect, files may
         be generated in the directory given by path."""
 
-        if(format == "PNG"):
+        if(format == "png"):
             try:
                 image = self._get_image(match.group("name"))
             except KeyError:
@@ -156,7 +156,7 @@ class RichIPythonWidget(IPythonWidget):
                 return '<img src="data:image/png;base64,\n%s\n" />' % (
                     re.sub(r'(.{60})',r'\1\n',str(ba.toBase64())))
 
-        elif(format == "SVG"):
+        elif(format == "svg"):
             try:
                 svg = str(self._name_to_svg[match.group("name")])
             except KeyError:

--- a/IPython/frontend/qt/console/rich_ipython_widget.py
+++ b/IPython/frontend/qt/console/rich_ipython_widget.py
@@ -126,11 +126,26 @@ class RichIPythonWidget(IPythonWidget):
             image = self._get_image(name)
             image.save(filename, format)
 
-    def image_tag(self, match, path = None, format = "PNG"):
-        """ Given an re.match object matching an image name in an HTML dump,
-        return an appropriate substitution string for the image tag
-        (e.g., link, embedded image, ...).  As a side effect, files may
-        be generated in the directory given by path."""
+    def image_tag(self, match, path = None, format = "png"):
+        """ Return (X)HTML mark-up for the image-tag given by match.
+
+        Parameters
+        ----------
+        match : re.SRE_Match 
+            A match to an HTML image tag as exported by Qt, with
+            match.group("Name") containing the matched image ID.
+
+        path : string|None, optional [default None]
+            If not None, specifies a path to which supporting files
+            may be written (e.g., for linked images).
+            If None, all images are to be included inline.
+
+        format : "png"|"svg", optional [default "png"]
+            Format for returned or referenced images.
+
+        Subclasses supporting image display should override this
+        method.
+        """
 
         if(format == "png"):
             try:

--- a/IPython/frontend/qt/console/rich_ipython_widget.py
+++ b/IPython/frontend/qt/console/rich_ipython_widget.py
@@ -27,7 +27,7 @@ class RichIPythonWidget(IPythonWidget):
         super(RichIPythonWidget, self).__init__(*args, **kw)
         # Dictionary for resolving Qt names to images when
         # generating XHTML output
-        self._name2svg = {}
+        self._name_to_svg = {}
 
     #---------------------------------------------------------------------------
     # 'ConsoleWidget' protected interface
@@ -71,7 +71,7 @@ class RichIPythonWidget(IPythonWidget):
                     self._append_plain_text('Received invalid plot data.')
                 else:
                     format = self._add_image(image)
-                    self._name2svg[str(format.name())] = svg
+                    self._name_to_svg[str(format.name())] = svg
                     format.setProperty(self._svg_text_format_property, svg)
                     cursor = self._get_end_cursor()
                     cursor.insertBlock()
@@ -126,7 +126,7 @@ class RichIPythonWidget(IPythonWidget):
             image = self._get_image(name)
             image.save(filename, format)
 
-    def imagetag(self, match, path = None, format = "PNG"):
+    def image_tag(self, match, path = None, format = "PNG"):
         """ Given an re.match object matching an image name in an HTML dump,
         return an appropriate substitution string for the image tag
         (e.g., link, embedded image, ...).  As a side effect, files may
@@ -158,7 +158,7 @@ class RichIPythonWidget(IPythonWidget):
 
         elif(format == "SVG"):
             try:
-                svg = str(self._name2svg[match.group("name")])
+                svg = str(self._name_to_svg[match.group("name")])
             except KeyError:
                 return "<b>Couldn't find image %s</b>" % match.group("name")
 


### PR DESCRIPTION
This is my first pass at adding HTML export to ipython.  Here's the description that I'm
sending to ipython-dev:

I tried three approaches (available as three context menu options):

1) Export HTML (external PNGs):
   This mimics Firefox's "Save as Web Page, complete" behavior.
   Saving "mypath/test.htm" gives an HTML file with links to PNGs in
   "mypath/test_files/".  The PNGs are named relative to format.name()
   to avoid collisions.

   Works in Firefox 3.6.10, Konqueror 4.4.2/KHTML, and Konqueror 4.4.2/WebKit

2) Export HTML (inline PNGs):
   Saves a single HTML file with images as inline base64 PNGs
   (c.f. http://en.wikipedia.org/wiki/Data_URI_scheme#HTML)

   Works in Firefox 3.6.10, Konqueror 4.4.2/KHTML, and Konqueror 4.4.2/WebKit

3) Export XHTML (inline SVGs):
   Saves a single XHTML file with images as inline SVG.  The "XML" is generated
   by overwriting the Qt-generated document header, so it is not guaranteed to
   be valid XML (but Firefox does validate my test case).

   Works in Firefox 3.6.10 and Konqueror 4.4.2/WebKit.
   Image placement is incorrect for Konqueror 4.4.2/KHTML.

(all tests run on a Dell Latitude D630 w/ Kubuntu Lucid:
mvoorhie@virgil:~$ uname -a
Linux virgil 2.6.32-24-generic #43-Ubuntu SMP Thu Sep 16 14:17:33 UTC 2010 i686 GNU/Linux)

It may be possible to link external SVG images via an <embed> or <object> tag,
but I couldn't find a clean/portable way to do this.

Current issues:
- I'm doing lots of string coercion in order to use re.sub on Qt's HTML.  I mostly
  get away with it, but we wind up with a few bad character encodings in the
  output (e.g., the tabs for multi-line inputs).  Would be good for someone who
  knows more about unicode to take a look at this...
- The file name generation for "Export HTML (external PNGs)" is a bit hacky.  Should
  probably be rewritten to use os.path.
- Haven't tested with anything other than the Qt front end.  In theory, other front
  ends will export HTML with the images stripped, unless they implement their own
  version of imagetag().

Feel free to take/hack what you like and ditch the rest.

Happy hacking,

--Mark
