### PR TITLE
HTML Fixes

### DIFF
--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -527,7 +527,7 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
         dialog = QtGui.QFileDialog(parent, 'Save HTML Document')
         dialog.setAcceptMode(QtGui.QFileDialog.AcceptSave)
         dialog.setDefaultSuffix('html')
-        dialog.setNameFilter('HTML Document (*.htm *.html)')
+        dialog.setNameFilter('HTML Document (*.htm *.html *)')
         if dialog.exec_():
             filename = str(dialog.selectedFiles()[0])
             if(inline):
@@ -568,7 +568,7 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
         dialog = QtGui.QFileDialog(parent, 'Save XHTML Document')
         dialog.setAcceptMode(QtGui.QFileDialog.AcceptSave)
         dialog.setDefaultSuffix('xml')
-        dialog.setNameFilter('XHTML document (*.xml *.xhtml)')
+        dialog.setNameFilter('XHTML document (*.xml *.xhtml *)')
         if dialog.exec_():
             filename = str(dialog.selectedFiles()[0])
             f = open(filename, 'w')

--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -7,6 +7,7 @@
 # Standard library imports
 from os.path import commonprefix
 import re
+import os
 import sys
 from textwrap import dedent
 
@@ -525,8 +526,8 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
         """
         dialog = QtGui.QFileDialog(parent, 'Save HTML Document')
         dialog.setAcceptMode(QtGui.QFileDialog.AcceptSave)
-        dialog.setDefaultSuffix('htm')
-        dialog.setNameFilter('HTML document (*.htm)')
+        dialog.setDefaultSuffix('html')
+        dialog.setNameFilter('HTML Document (*.htm *.html)')
         if dialog.exec_():
             filename = str(dialog.selectedFiles()[0])
             if(inline):
@@ -537,12 +538,14 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
                     path = filename[:offset]+"_files"
                 else:
                     path = filename+"_files"
-                import os
-                try:
-                    os.mkdir(path)
-                except OSError:
-                    # TODO: check that this is an "already exists" error
-                    pass
+                if os.path.isfile(path):
+                    raise OSError("%s exists, but is not a dir"%path)
+                # don't mkdir unless there are images
+                # try:
+                #     os.mkdir(path)
+                # except OSError:
+                #     # TODO: check that this is an "already exists" error
+                #     pass
 
             f = open(filename, 'w')
             try:
@@ -565,7 +568,7 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
         dialog = QtGui.QFileDialog(parent, 'Save XHTML Document')
         dialog.setAcceptMode(QtGui.QFileDialog.AcceptSave)
         dialog.setDefaultSuffix('xml')
-        dialog.setNameFilter('XHTML document (*.xml)')
+        dialog.setNameFilter('XHTML document (*.xml *.xhtml)')
         if dialog.exec_():
             filename = str(dialog.selectedFiles()[0])
             f = open(filename, 'w')
@@ -870,19 +873,21 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
 
         menu.addSeparator()
         menu.addAction('Select All', self.select_all)
-
-        menu.addSeparator()
-        print_action = menu.addAction('Print', self.print_)
-        print_action.setEnabled(True)
-        html_action = menu.addAction('Export HTML (external PNGs)',
-                                     self.export_html)
-        html_action.setEnabled(True)
-        html_inline_action = menu.addAction('Export HTML (inline PNGs)',
-                                            self.export_html_inline)
-        html_inline_action.setEnabled(True)
-        xhtml_action = menu.addAction('Export XHTML (inline SVGs)',
-                                      self.export_xhtml)
-        xhtml_action.setEnabled(True)
+        
+        if self.kind == 'rich':
+            # only the rich frontend can export html/xml
+            menu.addSeparator()
+            print_action = menu.addAction('Print', self.print_)
+            print_action.setEnabled(True)
+            html_action = menu.addAction('Export HTML (external PNGs)',
+                                         self.export_html)
+            html_action.setEnabled(True)
+            html_inline_action = menu.addAction('Export HTML (inline PNGs)',
+                                                self.export_html_inline)
+            html_inline_action.setEnabled(True)
+            xhtml_action = menu.addAction('Export XHTML (inline SVGs)',
+                                          self.export_xhtml)
+            xhtml_action.setEnabled(True)
         return menu
 
     def _control_key_down(self, modifiers, include_command=True):

--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -925,7 +925,7 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
 
         return menu
 
-    def _control_key_down(self, modifiers, include_command=True):
+    def _control_key_down(self, modifiers, include_command=False):
         """ Given a KeyboardModifiers flags object, return whether the Control
         key is down.
 

--- a/IPython/frontend/qt/console/rich_ipython_widget.py
+++ b/IPython/frontend/qt/console/rich_ipython_widget.py
@@ -1,4 +1,6 @@
 # System library imports
+import os
+import re
 from PyQt4 import QtCore, QtGui
 
 # Local imports
@@ -154,7 +156,9 @@ class RichIPythonWidget(IPythonWidget):
                 return "<b>Couldn't find image %s</b>" % match.group("name")
 
             if(path is not None):
-                relpath = path[path.rfind("/")+1:]
+                if not os.path.exists(path):
+                    os.mkdir(path)
+                relpath = os.path.basename(path)
                 if(image.save("%s/qt_img%s.png" % (path,match.group("name")),
                               "PNG")):
                     return '<img src="%s/qt_img%s.png">' % (relpath,
@@ -167,7 +171,6 @@ class RichIPythonWidget(IPythonWidget):
                 buffer_.open(QtCore.QIODevice.WriteOnly)
                 image.save(buffer_, "PNG")
                 buffer_.close()
-                import re
                 return '<img src="data:image/png;base64,\n%s\n" />' % (
                     re.sub(r'(.{60})',r'\1\n',str(ba.toBase64())))
 


### PR DESCRIPTION
Some small issues in the HTML code I noticed when I started playing with it.
- only rich backends support toHtml, so the html/xhtml exports failed
- modules were imported inside functions
- relpath in image_tag was determined in platform-dependent way
- save dialog strictly enforced non-standard '.htm' file extension
- when selecting external PNG, the _files dir was always created, regardless of whether there were any images

Fixes in this commit:
- export options do not appear in non-rich widgets
- module imports all at the top
- relpath uses platform independent os.path
- dialog uses standard '.html' by default, but allows any extension
- no _files dir is created if no images are to be exported

-MinRK
