### PR TITLE
Expose Pygments styles as options

### DIFF
--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -25,32 +25,12 @@ from IPython.core.inputsplitter import IPythonInputSplitter, \
 from IPython.core.usage import default_gui_banner
 from IPython.utils.traitlets import Bool, Str
 from frontend_widget import FrontendWidget
+from styles import (default_light_style_sheet,  default_dark_style_sheet,
+                    default_light_syntax_style, default_dark_syntax_style)
 
 #-----------------------------------------------------------------------------
 # Constants
 #-----------------------------------------------------------------------------
-
-# The default light style sheet: black text on a white background.
-default_light_style_sheet = '''
-    .error { color: red; }
-    .in-prompt { color: navy; }
-    .in-prompt-number { font-weight: bold; }
-    .out-prompt { color: darkred; }
-    .out-prompt-number { font-weight: bold; }
-'''
-default_light_syntax_style = 'default'
-
-# The default dark style sheet: white text on a black background.
-default_dark_style_sheet = '''
-    QPlainTextEdit, QTextEdit { background-color: black; color: white }
-    QFrame { border: 1px solid grey; }
-    .error { color: red; }
-    .in-prompt { color: lime; }
-    .in-prompt-number { color: lime; font-weight: bold; }
-    .out-prompt { color: red; }
-    .out-prompt-number { color: red; font-weight: bold; }
-'''
-default_dark_syntax_style = 'monokai'
 
 # Default strings to build and display input and output prompts (and separators
 # in between)

--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -25,8 +25,9 @@ from IPython.core.inputsplitter import IPythonInputSplitter, \
 from IPython.core.usage import default_gui_banner
 from IPython.utils.traitlets import Bool, Str
 from frontend_widget import FrontendWidget
-from styles import (default_light_style_sheet,  default_dark_style_sheet,
-                    default_light_syntax_style, default_dark_syntax_style)
+from styles import (default_light_style_sheet,  default_light_syntax_style,
+                    default_dark_style_sheet, default_dark_syntax_style,
+                    default_bw_style_sheet, default_bw_syntax_style)
 
 #-----------------------------------------------------------------------------
 # Constants
@@ -329,21 +330,24 @@ class IPythonWidget(FrontendWidget):
     # 'IPythonWidget' interface
     #---------------------------------------------------------------------------
 
-    def set_default_style(self, lightbg=True):
+    def set_default_style(self, colors='light'):
         """ Sets the widget style to the class defaults.
 
         Parameters:
         -----------
-        lightbg : bool, optional (default True)
+        colors : str, optional (default light)
             Whether to use the default IPython light background or dark
-            background style.
+            background or B&W style.
         """
-        if lightbg:
+        if colors=='light':
             self.style_sheet = default_light_style_sheet
             self.syntax_style = default_light_syntax_style
-        else:
+        elif colors=='dark':
             self.style_sheet = default_dark_style_sheet
             self.syntax_style = default_dark_syntax_style
+        elif colors=='bw':
+            self.style_sheet = default_bw_style_sheet
+            self.syntax_style = default_bw_syntax_style
 
     #---------------------------------------------------------------------------
     # 'IPythonWidget' protected interface

--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -330,24 +330,27 @@ class IPythonWidget(FrontendWidget):
     # 'IPythonWidget' interface
     #---------------------------------------------------------------------------
 
-    def set_default_style(self, colors='light'):
+    def set_default_style(self, colors='lightbg'):
         """ Sets the widget style to the class defaults.
 
         Parameters:
         -----------
-        colors : str, optional (default light)
+        colors : str, optional (default lightbg)
             Whether to use the default IPython light background or dark
             background or B&W style.
         """
-        if colors=='light':
+        colors = colors.lower()
+        if colors=='lightbg':
             self.style_sheet = default_light_style_sheet
             self.syntax_style = default_light_syntax_style
-        elif colors=='dark':
+        elif colors=='linux':
             self.style_sheet = default_dark_style_sheet
             self.syntax_style = default_dark_syntax_style
-        elif colors=='bw':
+        elif colors=='nocolor':
             self.style_sheet = default_bw_style_sheet
             self.syntax_style = default_bw_syntax_style
+        else:
+            raise KeyError("No such color scheme: %s"%colors)
 
     #---------------------------------------------------------------------------
     # 'IPythonWidget' protected interface

--- a/IPython/frontend/qt/console/styles.py
+++ b/IPython/frontend/qt/console/styles.py
@@ -43,6 +43,17 @@ default_dark_style_sheet = default_dark_style_template%dict(
                 bgcolor='black', fgcolor='white', select="#555")
 default_dark_syntax_style = 'monokai'
 
+# The default monochrome
+default_bw_style_sheet = '''
+    QPlainTextEdit, QTextEdit { background-color: white;
+            color: black ;
+            selection-background-color: #cccccc}
+    .in-prompt-number { font-weight: bold; }
+    .out-prompt-number { font-weight: bold; }
+'''
+default_bw_syntax_style = 'bw'
+
+
 def hex_to_rgb(color):
     """Convert a hex color to rgb integer tuple."""
     if color.startswith('#'):
@@ -76,7 +87,8 @@ def dark_style(stylename):
     return dark_color(get_style_by_name(stylename).background_color)
 
 def get_colors(stylename):
-    """Construct the keys to be used building the base stylesheet."""
+    """Construct the keys to be used building the base stylesheet
+    from a templatee."""
     style = get_style_by_name(stylename)
     fgcolor = style.style_for_token(Token.Text)['color'] or ''
     if len(fgcolor) in (3,6):
@@ -94,9 +106,14 @@ def get_colors(stylename):
         fgcolor = fgcolor
     )
 
-def sheet_from_template(name, lightbg=True):
+def sheet_from_template(name, colors='light'):
     """Use one of the base templates, and set bg/fg/select colors."""
-    if lightbg:
+    colors = colors.lower()
+    if colors=='light':
         return default_light_style_template%get_colors(name)
-    else:
+    elif colors=='dark':
         return default_dark_style_template%get_colors(name)
+    elif colors=='nocolor':
+        return default_bw_style_sheet
+    else:
+        raise KeyError("No such color scheme: %s"%colors)

--- a/IPython/frontend/qt/console/styles.py
+++ b/IPython/frontend/qt/console/styles.py
@@ -106,12 +106,12 @@ def get_colors(stylename):
         fgcolor = fgcolor
     )
 
-def sheet_from_template(name, colors='light'):
+def sheet_from_template(name, colors='lightbg'):
     """Use one of the base templates, and set bg/fg/select colors."""
     colors = colors.lower()
-    if colors=='light':
+    if colors=='lightbg':
         return default_light_style_template%get_colors(name)
-    elif colors=='dark':
+    elif colors=='linux':
         return default_dark_style_template%get_colors(name)
     elif colors=='nocolor':
         return default_bw_style_sheet

--- a/IPython/frontend/qt/console/styles.py
+++ b/IPython/frontend/qt/console/styles.py
@@ -1,0 +1,102 @@
+""" Style utilities, templates, and defaults for syntax highlighting widgets.
+"""
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+from colorsys import rgb_to_hls
+from pygments.styles import get_style_by_name
+from pygments.token import Token
+
+#-----------------------------------------------------------------------------
+# Constants
+#-----------------------------------------------------------------------------
+
+# The default light style sheet: black text on a white background.
+default_light_style_template = '''
+    QPlainTextEdit, QTextEdit { background-color: %(bgcolor)s;
+            color: %(fgcolor)s ;
+            selection-background-color: %(select)s}
+    .error { color: red; }
+    .in-prompt { color: navy; }
+    .in-prompt-number { font-weight: bold; }
+    .out-prompt { color: darkred; }
+    .out-prompt-number { font-weight: bold; }
+'''
+default_light_style_sheet = default_light_style_template%dict(
+                bgcolor='white', fgcolor='black', select="#ccc")
+default_light_syntax_style = 'default'
+
+# The default dark style sheet: white text on a black background.
+default_dark_style_template = '''
+    QPlainTextEdit, QTextEdit { background-color: %(bgcolor)s;
+            color: %(fgcolor)s ;
+            selection-background-color: %(select)s}
+    QFrame { border: 1px solid grey; }
+    .error { color: red; }
+    .in-prompt { color: lime; }
+    .in-prompt-number { color: lime; font-weight: bold; }
+    .out-prompt { color: red; }
+    .out-prompt-number { color: red; font-weight: bold; }
+'''
+default_dark_style_sheet = default_dark_style_template%dict(
+                bgcolor='black', fgcolor='white', select="#555")
+default_dark_syntax_style = 'monokai'
+
+def hex_to_rgb(color):
+    """Convert a hex color to rgb integer tuple."""
+    if color.startswith('#'):
+        color = color[1:]
+    if len(color) == 3:
+        color = ''.join([c*2 for c in color])
+    if len(color) != 6:
+        return False
+    try:
+        r = int(color[:2],16)
+        g = int(color[:2],16)
+        b = int(color[:2],16)
+    except ValueError:
+        return False
+    else:
+        return r,g,b
+
+def dark_color(color):
+    """Check whether a color is 'dark'.
+
+    Currently, this is simply whether the luminance is <50%"""
+    rgb = hex_to_rgb(color)
+    if rgb:
+        return rgb_to_hls(*rgb)[1] < 128
+    else: # default to False
+        return False
+
+def dark_style(stylename):
+    """Guess whether the background of the style with name 'stylename'
+    counts as 'dark'."""
+    return dark_color(get_style_by_name(stylename).background_color)
+
+def get_colors(stylename):
+    """Construct the keys to be used building the base stylesheet."""
+    style = get_style_by_name(stylename)
+    fgcolor = style.style_for_token(Token.Text)['color'] or ''
+    if len(fgcolor) in (3,6):
+        # could be 'abcdef' or 'ace' hex, which needs '#' prefix
+        try:
+            int(fgcolor, 16)
+        except TypeError:
+            pass
+        else:
+            fgcolor = "#"+fgcolor
+
+    return dict(
+        bgcolor = style.background_color,
+        select = style.highlight_color,
+        fgcolor = fgcolor
+    )
+
+def sheet_from_template(name, lightbg=True):
+    """Use one of the base templates, and set bg/fg/select colors."""
+    if lightbg:
+        return default_light_style_template%get_colors(name)
+    else:
+        return default_dark_style_template%get_colors(name)

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -535,7 +535,7 @@ class GTKKernel(Kernel):
 #-----------------------------------------------------------------------------
 
 def launch_kernel(ip=None, xrep_port=0, pub_port=0, req_port=0, hb_port=0,
-                  independent=False, pylab=False):
+                  independent=False, pylab=False, colors=None):
     """Launches a localhost kernel, binding to the specified ports.
 
     Parameters
@@ -566,6 +566,9 @@ def launch_kernel(ip=None, xrep_port=0, pub_port=0, req_port=0, hb_port=0,
         string is passed, matplotlib will use the specified backend. Otherwise,
         matplotlib's default backend will be used.
 
+    colors : None or string, optional (default None)
+        If not None, specify the color scheme. One of (NoColor, LightBG, Linux)
+
     Returns
     -------
     A tuple of form:
@@ -581,6 +584,9 @@ def launch_kernel(ip=None, xrep_port=0, pub_port=0, req_port=0, hb_port=0,
         extra_arguments.append('--ip')
         if isinstance(ip, basestring):
             extra_arguments.append(ip)
+    if colors is not None:
+        extra_arguments.append('--colors')
+        extra_arguments.append(colors)
     return base_launch_kernel('from IPython.zmq.ipkernel import main; main()',
                               xrep_port, pub_port, req_port, hb_port, 
                               independent, extra_arguments)
@@ -595,6 +601,10 @@ def main():
 "Pre-load matplotlib and numpy for interactive use. If GUI is not \
 given, the GUI backend is matplotlib's, otherwise use one of: \
 ['tk', 'gtk', 'qt', 'wx', 'inline'].")
+    parser.add_argument('--colors',
+        type=str, dest='colors',
+        help="Set the color scheme (NoColor, Linux, and LightBG).",
+        metavar='ZMQInteractiveShell.colors')
     namespace = parser.parse_args()
 
     kernel_class = Kernel
@@ -616,6 +626,8 @@ given, the GUI backend is matplotlib's, otherwise use one of: \
         if kernel_class is None:
             raise ValueError('GUI is not supported: %r' % gui)
         pylabtools.activate_matplotlib(backend)
+    if namespace.colors:
+        ZMQInteractiveShell.colors=namespace.colors
 
     kernel = make_kernel(namespace, kernel_class, OutStream)
 


### PR DESCRIPTION
IPythonWidget already supported using various pygments styles.  I just added some flags to ipythonqt, and tweaked the default style code, so that they can be set at launch:

ipythonqt --dark will run IPython with the default dark theme
ipythonqt --style <name> will run IPython using the specific style. Anything pygments accepts will work.
e.g.
    ipythonqt --style fruity

The style code also guesses whether a theme is dark or light, and chooses the right stylesheet. This can be overridden if --dark is manually specified.

If you want to use your own css stylesheet, you can pass that with --stylesheet.

No logic was added to the widgets themselves, just the ipythonqt script and a styles file that sets up the defaults.
