### PR TITLE
Fix del method exit test

### DIFF
--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -88,12 +88,13 @@ def doctest_reset_del():
 
     In [2]: class A(object):
        ...:     def __del__(self):
-       ...:         str("Hi")
+       ...:         print str("Hi")
        ...: 
 
     In [3]: a = A()
 
     In [4]: get_ipython().reset()
+    Hi
 
     In [5]: 1+1
     Out[5]: 2


### PR DESCRIPTION
This fixes a recent test that __del__ methods, called on exit, are able to access built-in functions such as str(), so that the test will fail if that code is broken. It then reapplies Fernando's fix for the bug, which was removed by another commit in the meantime.
