### PR TITLE
Ready colorize bug

### DIFF
--- a/IPython/utils/PyColorize.py
+++ b/IPython/utils/PyColorize.py
@@ -277,7 +277,11 @@ If no filename is given, or if filename is -, read standard input."""
     if fname == '-':
         stream = sys.stdin
     else:
-        stream = file(fname)
+        try:
+            stream = file(fname)
+        except IOError,msg:
+            print >> sys.stderr, msg
+            sys.exit(1)
 
     parser = Parser()
 


### PR DESCRIPTION
When calling pycolor on a non-existent file, ipython crashes.
This commit tells the user, that the file doesn't exist and exists properly.

Reproducer, e.g. pycolor "HI" from the RH bug:
https://bugzilla.redhat.com/show_bug.cgi?id=628742
