### PR TITLE
Windows workdir

### DIFF
--- a/scripts/ipython_win_post_install.py
+++ b/scripts/ipython_win_post_install.py
@@ -51,26 +51,27 @@ def install():
             
     # Now move onto setting the Start Menu up
     ipybase = pjoin(scripts, 'ipython')
+    workdir = "%HOMEDRIVE%%HOMEPATH%"
 
     link = pjoin(ip_start_menu, 'IPython.lnk')
     cmd = '"%s"' % ipybase
-    mkshortcut(python,'IPython',link,cmd)
+    mkshortcut(python, 'IPython', link, cmd, workdir)
     
     link = pjoin(ip_start_menu, 'pysh.lnk')
     cmd = '"%s" -p sh' % ipybase
-    mkshortcut(python,'IPython (command prompt mode)',link,cmd)
+    mkshortcut(python, 'IPython (command prompt mode)', link, cmd, workdir)
     
     link = pjoin(ip_start_menu, 'scipy.lnk')
     cmd = '"%s" -p scipy' % ipybase
-    mkshortcut(python,'IPython (scipy profile)',link,cmd)
+    mkshortcut(python, 'IPython (scipy profile)', link, cmd, workdir)
         
     link = pjoin(ip_start_menu, 'ipcontroller.lnk')
     cmd = '"%s" -xy' % pjoin(scripts, 'ipcontroller')
-    mkshortcut(python,'IPython controller',link,cmd)
+    mkshortcut(python, 'IPython controller', link, cmd, workdir)
     
     link = pjoin(ip_start_menu, 'ipengine.lnk')
     cmd = '"%s"' % pjoin(scripts, 'ipengine')
-    mkshortcut(python,'IPython engine',link,cmd)
+    mkshortcut(python, 'IPython engine', link, cmd, workdir)
     
     # Create documentation shortcuts ...
     t = prefix + r'\share\doc\ipython\manual\ipython.pdf'

--- a/scripts/ipython_win_post_install.py
+++ b/scripts/ipython_win_post_install.py
@@ -51,6 +51,9 @@ def install():
             
     # Now move onto setting the Start Menu up
     ipybase = pjoin(scripts, 'ipython')
+    if 'setuptools' in sys.modules:
+        # let setuptools take care of the scripts:
+        ipybase = ipybase + '-script.py'
     workdir = "%HOMEDRIVE%%HOMEPATH%"
 
     link = pjoin(ip_start_menu, 'IPython.lnk')

--- a/setup.py
+++ b/setup.py
@@ -232,8 +232,6 @@ if 'setuptools' in sys.modules:
         test='nose>=0.10.1',
         security='pyOpenSSL>=0.6'
     )
-    # Allow setuptools to handle the scripts
-    scripts = []
 else:
     # If we are running without setuptools, call this function which will
     # check for dependencies an inform the user what is needed.  This is

--- a/setupbase.py
+++ b/setupbase.py
@@ -278,7 +278,7 @@ def find_scripts():
                   file=sys.stderr)
             sys.exit(1)
         scripts.append(pjoin('scripts','ipython_win_post_install.py'))
-    
+
     return scripts
 
 #---------------------------------------------------------------------------


### PR DESCRIPTION
The IPython windows installer creates links in the start menu, but the working directory is not specified and defaults to something like C:\Windows . This small patch sets the default working directory to the current user's home directory.
