### PR TITLE
Small typos in zmq/blockingkernelmanager.py

### DIFF
--- a/IPython/zmq/blockingkernelmanager.py
+++ b/IPython/zmq/blockingkernelmanager.py
@@ -47,7 +47,7 @@ class BlockingSubSocketChannel(SubSocketChannel):
 
     def get_msg(self, block=True, timeout=None):
         """Get a message if there is one that is ready."""
-        return self.in_queue.get(block, timeout)
+        return self._in_queue.get(block, timeout)
 
     def get_msgs(self):
         """Get all messages that are currently ready."""
@@ -79,7 +79,7 @@ class BlockingXReqSocketChannel(XReqSocketChannel):
 
     def get_msg(self, block=True, timeout=None):
         """Get a message if there is one that is ready."""
-        return self.in_queue.get(block, timeout)
+        return self._in_queue.get(block, timeout)
 
     def get_msgs(self):
         """Get all messages that are currently ready."""


### PR DESCRIPTION
I seem to have found a minor error.  There are two references to "self.in_queue" instead of the actual variable,  "self._in_queue".

Thanks for the great work that you all do.
