### PR TITLE
Emacs completion bugfix

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -456,24 +456,6 @@ class IPCompleter(Completer):
                          self.python_func_kw_matches,
                          ]
     
-    # Code contributed by Alex Schmolck, for ipython/emacs integration
-    def all_completions(self, text):
-        """Return all possible completions for the benefit of emacs."""
-
-        completions = []
-        comp_append = completions.append
-        try:
-            for i in xrange(sys.maxint):
-                res = self.complete(text, i, text)
-                if not res:
-                    break
-                comp_append(res)
-        #XXX workaround for ``notDefined.<tab>``
-        except NameError:
-            pass
-        return completions
-    # /end Alex Schmolck code.
-
     def _clean_glob(self,text):
         return self.glob("%s*" % text)
 

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -456,6 +456,10 @@ class IPCompleter(Completer):
                          self.python_func_kw_matches,
                          ]
     
+    def all_completions(self, text):
+        """Wrapper around the complete method for the benefit of emacs."""
+        return self.complete(text)[1]
+
     def _clean_glob(self,text):
         return self.glob("%s*" % text)
 

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -457,7 +457,10 @@ class IPCompleter(Completer):
                          ]
     
     def all_completions(self, text):
-        """Wrapper around the complete method for the benefit of emacs."""
+        """
+        Wrapper around the complete method for the benefit of emacs
+        and pydb.
+        """
         return self.complete(text)[1]
 
     def _clean_glob(self,text):

--- a/docs/emacs/ipython.el
+++ b/docs/emacs/ipython.el
@@ -311,7 +311,7 @@ gets converted to:
         (replace-match "" t nil)))))
 
 (defvar ipython-completion-command-string
-  "print(';'.join(get_ipython().Completer.complete('%s')[1])) #PYTHON-MODE SILENT\n"
+  "print(';'.join(get_ipython().Completer.all_completions('%s'))) #PYTHON-MODE SILENT\n"
   "The string send to ipython to query for all possible completions")
 
 

--- a/docs/emacs/ipython.el
+++ b/docs/emacs/ipython.el
@@ -311,7 +311,7 @@ gets converted to:
         (replace-match "" t nil)))))
 
 (defvar ipython-completion-command-string
-  "print(';'.join(get_ipython().Completer.all_completions('%s'))) #PYTHON-MODE SILENT\n"
+  "print(';'.join(get_ipython().Completer.complete('%s')[1])) #PYTHON-MODE SILENT\n"
   "The string send to ipython to query for all possible completions")
 
 


### PR DESCRIPTION
Tab completion in ipython.el seems to have stopped working because it calls completer.IPCompleter.all_completions(), which is broken. IPCompleter.complete() now returns a list of all possible completions so it can be used instead of all_completions().
