### PR TITLE
Fix history magic command's bugs wrt to full history and add -O option to display full history

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -146,8 +146,8 @@ class HistoryManager(object):
 
         with open(self.hist_file,'rt') as hfile:
             hist = json.load(hfile)
-            self.input_hist_parsed = hist['parsed']
-            self.input_hist_raw = hist['raw']
+            self.input_hist_parsed[:] = hist['parsed']
+            self.input_hist_raw[:] = hist['raw']
             if self.shell.has_readline:
                 self.populate_readline_history()
         

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -322,12 +322,15 @@ def magic_history(self, parameter_s = ''):
       -f FILENAME: instead of printing the output to the screen, redirect it to
        the given file.  The file is always overwritten, though IPython asks for
        confirmation first if it already exists.
+
+      -O: prints the full history, i.e. the history persisted from previous
+       sessions. This option cannot be used in combination with -o and -n
     """
 
     if not self.shell.displayhook.do_full_cache:
         print('This feature is only available if numbered prompts are in use.')
         return
-    opts,args = self.parse_options(parameter_s,'gnoptsrf:',mode='list')
+    opts,args = self.parse_options(parameter_s,'gnoptsrOf:',mode='list')
 
     # Check if output to specific file was requested.
     try:
@@ -345,14 +348,22 @@ def magic_history(self, parameter_s = ''):
         outfile = open(outfname,'w')
         close_at_end = True
 
-    if 't' in opts:
-        input_hist = self.shell.history_manager.input_hist_parsed
-    elif 'r' in opts:
-        input_hist = self.shell.history_manager.input_hist_raw
+    if 'O' in opts:
+        if 't' in opts:
+            input_hist = self.shell.history_manager.input_hist_full_parsed
+        elif 'r' in opts:
+            input_hist = self.shell.history_manager.input_hist_full_raw
+        else:
+            input_hist = self.shell.history_manager.input_hist_full_raw
     else:
-        # Raw history is the default
-        input_hist = self.shell.history_manager.input_hist_raw
-            
+        if 't' in opts:
+            input_hist = self.shell.history_manager.input_hist_parsed
+        elif 'r' in opts:
+            input_hist = self.shell.history_manager.input_hist_raw
+        else:
+            # Raw history is the default
+            input_hist = self.shell.history_manager.input_hist_raw
+
     default_length = 40
     pattern = None
     if 'g' in opts:
@@ -381,7 +392,8 @@ def magic_history(self, parameter_s = ''):
     print_nums = 'n' in opts
     print_outputs = 'o' in opts
     pyprompts = 'p' in opts
-    
+    full_hist = 'O' in opts
+
     found = False
     if pattern is not None:
         sh = self.shell.history_manager.shadowhist.all()
@@ -406,7 +418,7 @@ def magic_history(self, parameter_s = ''):
             continue
             
         multiline = int(inline.count('\n') > 1)
-        if print_nums:
+        if print_nums and not full_hist:
             print('%s:%s' % (str(in_num).ljust(width), line_sep[multiline]),
                   file=outfile)
         if pyprompts:
@@ -419,7 +431,7 @@ def magic_history(self, parameter_s = ''):
                 print(inline, end='', file=outfile)
         else:
             print(inline, end='', file=outfile)
-        if print_outputs:
+        if print_outputs and not full_hist:
             output = self.shell.history_manager.output_hist.get(in_num)
             if output is not None:
                 print(repr(output), file=outfile)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2110,8 +2110,8 @@ class InteractiveShell(Configurable, Magic):
                 list.append(self, val)
 
             import new
-            self.history_manager.input_hist_parsed.append = types.MethodType(myapp,
-                                                                            self.history_manager.input_hist_parsed)
+            self.history_manager.input_hist_full_parsed.append = types.MethodType(myapp,
+                                                                            self.history_manager.input_hist_full_parsed)
         # End dbg
 
         # All user code execution must happen with our context managers active

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2980,8 +2980,8 @@ Defaulting color scheme to 'NoColor'"""
         else:
             start_magic = start
         # Look through the input history in reverse
-        for n in range(len(self.shell.history_manager.input_hist_parsed)-2,0,-1):
-            input = self.shell.history_manager.input_hist_parsed[n]
+        for n in range(len(self.shell.history_manager.input_hist_full_parsed)-2,0,-1):
+            input = self.shell.history_manager.input_hist_full_parsed[n]
             # skip plain 'r' lines so we don't recurse to infinity
             if input != '_ip.magic("r")\n' and \
                    (input.startswith(start) or input.startswith(start_magic)):


### PR DESCRIPTION
Hi Fernando, These are my patches for the history magic command's bugs we came across during SciPy.in 2010. I have also added -O option. I have tried my best to make sure that the input_hist_raw/_parsed variables are changed in all the relevant places where they must be changed. But more eyes, the merrier! Just drawing your attention towards it. As you had suggested, I will be adding tests to the changes I have made in the next few days. Sending this pull request before that, so that the patches get reviewed as I spend time writing tests.

Also, would like to add credits to two guys who helped me show one of the bugs with -o option. Their names are '"Vinay Srinivas" srinivasvinay.246@gmail.com' and '"Vishnu SG" sgvishnu777@gmail.com'. I forgot to add their names in the commit. Is it possible to add them elsewhere?
