### PR TITLE
History minus p flag

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -382,13 +382,12 @@ def magic_history(self, parameter_s = ''):
             print('%s:%s' % (str(in_num).ljust(width), line_sep[multiline]),
                   file=outfile)
         if pyprompts:
-            print('>>>', file=outfile)
             if multiline:
-                lines = inline.splitlines()
+                lines =('>>> '+inline).splitlines()
                 print('\n... '.join(lines), file=outfile)
                 print('... ', file=outfile)
             else:
-                print(inline, end='', file=outfile)
+                print(">>> "+inline, end='', file=outfile)
         else:
             print(inline, end='', file=outfile)
         if print_outputs:


### PR DESCRIPTION
This is a very small change . I noticed that %history -p flag adds a newlines to all outputs. Example
In[]: 2*3 
6
In[]: %history -p

> > > 2_3
> > >  Now however with this patch it will be
> > > 2_3 
> > > which is better formatted
