### PR TITLE
Fix185 (take two)

### DIFF
--- a/IPython/Shell.py
+++ b/IPython/Shell.py
@@ -1149,19 +1149,6 @@ class IPShellMatplotlibQt4(IPShellQt4):
 #-----------------------------------------------------------------------------
 # Factory functions to actually start the proper thread-aware shell
 
-def check_gtk(mode):
-    try:
-        import gtk
-    except (ImportError, RuntimeError):
-        # GTK not present, or can't be started (no X11, happens in console)
-        return mode
-    if hasattr(gtk,'set_interactive'):
-        gtk.set_interactive(False)
-        return 'tkthread'
-    else:
-        return mode
-
-
 def _select_shell(argv):
     """Select a shell from the given argv vector.
 
@@ -1231,10 +1218,6 @@ def _select_shell(argv):
             else:
                 # Any other backend, use plain Tk
                 th_mode = 'tkthread'
-
-            # New versions of pygtk don't need the brittle threaded support.
-            th_mode = check_gtk(th_mode)
-                
         return mpl_shell[th_mode]
     else:
         # No pylab requested, just plain threads
@@ -1242,10 +1225,6 @@ def _select_shell(argv):
             th_mode = special_opts.pop()
         except KeyError:
             th_mode = 'tkthread'
-
-        # New versions of pygtk don't need the brittle threaded support.
-        if th_mode == 'gthread':
-            th_mode = check_gtk(th_mode)
         return th_shell[th_mode]
 
 


### PR DESCRIPTION
The original issue was created by a portion of commit 3e84e9f446b752aef4c798b3a086084b5cdcb679 which I'll refer to as "problematic commit".

My fix185 branch originally undid a portion of the problematic commit, and the outstanding issue relates to other portions of that same commit.

What isn't clear to me is the purpose of the function check_gtk inside Shell.py, which was added in the problematic commit. For some reason, it unconditionally returns mode 'tkthread' if gtk was safely imported and hasattr 'set_interactive', regardless of what mode was passed to it. This "functionality" is not used with the -pylab flag, which is why original one line change did not fix the issue for "ipython -gthread"

I added another commit to the fix185 branch which removes check_gtk() altogether, and see no issues using ipython -gthread, ipython -gthread -pylab, or ipython -pylab. Additionally, the check_gtk() imported gtk regardless of what mode the user selected, and might also be what's been causing the "Why is IPython using X11" threads on the mailing list.

also, I just want to note here that users will see this issue if they use e.g "ipython -gthread" but their matplotlib is set to some other backend by default (say "WX").
