### PR TITLE
Fix terminal exit

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -257,29 +257,24 @@ class HistorySaveThread(threading.Thread):
     """Thread to save history periodically"""
     daemon = True
     
-    def __init__(self, IPython_object, time_interval, exit_now):
+    def __init__(self, IPython_object, time_interval):
         threading.Thread.__init__(self)
         self.IPython_object = IPython_object
         self.time_interval = time_interval
-        self.exit_now = exit_now
-        self.cond = threading.Condition()
+        self.exit_now = threading.Event()
 
     def run(self):
-        while 1:
-            self.cond.acquire()
-            self.cond.wait(self.time_interval)
-            self.cond.release()
-            if self.exit_now==True:
+        while True:
+            self.exit_now.wait(self.time_interval)
+            if self.exit_now.is_set():
                 break
             #printing for debug
             #print("Saving...")
             self.IPython_object.save_history()
             
     def stop(self):
-        self.exit_now=True
-        self.cond.acquire()
-        self.cond.notify()
-        self.cond.release()
+        self.exit_now.set()
+        self.join()
 
 def magic_history(self, parameter_s = ''):
     """Print input history (_i<n> variables), with most recent last.

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -255,7 +255,8 @@ class HistoryManager(object):
 
 class HistorySaveThread(threading.Thread):
     """Thread to save history periodically"""
-
+    daemon = True
+    
     def __init__(self, IPython_object, time_interval, exit_now):
         threading.Thread.__init__(self)
         self.IPython_object = IPython_object
@@ -273,6 +274,12 @@ class HistorySaveThread(threading.Thread):
             #printing for debug
             #print("Saving...")
             self.IPython_object.save_history()
+            
+    def stop(self):
+        self.exit_now=True
+        self.cond.acquire()
+        self.cond.notify()
+        self.cond.release()
 
 def magic_history(self, parameter_s = ''):
     """Print input history (_i<n> variables), with most recent last.

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -254,10 +254,13 @@ class HistoryManager(object):
         self.dir_hist[:] = [os.getcwd()]
 
 class HistorySaveThread(threading.Thread):
-    """Thread to save history periodically"""
+    """This thread saves history periodically (the current default is once per
+    minute), so that it is not lost in the event of a crash. It also allows the
+    commands in the current IPython shell to be accessed in a newly started
+    instance."""
     daemon = True
     
-    def __init__(self, IPython_object, time_interval):
+    def __init__(self, IPython_object, time_interval=60):
         threading.Thread.__init__(self)
         self.IPython_object = IPython_object
         self.time_interval = time_interval
@@ -268,11 +271,12 @@ class HistorySaveThread(threading.Thread):
             self.exit_now.wait(self.time_interval)
             if self.exit_now.is_set():
                 break
-            #printing for debug
-            #print("Saving...")
+            #print("Autosaving history...")   # DEBUG
             self.IPython_object.save_history()
             
     def stop(self):
+        """Safely and quickly stop the autosave thread. This will not cause the
+        history to be saved before stopping."""
         self.exit_now.set()
         self.join()
 

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -147,7 +147,10 @@ class HistoryManager(object):
         """Reload the input history from disk file."""
 
         with open(self.hist_file,'rt') as hfile:
-            hist = json.load(hfile)
+            try:
+                hist = json.load(hfile)
+            except ValueError:    # Ignore it if JSON is corrupt.
+                return
             self.input_hist_parsed = hist['parsed']
             self.input_hist_raw = hist['raw']
             if self.shell.has_readline:

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -294,8 +294,6 @@ class InteractiveShell(Configurable, Magic):
         self.init_payload()
         self.hooks.late_startup_hook()
         atexit.register(self.atexit_operations)
-        self.history_thread = HistorySaveThread(self, 60)
-        self.history_thread.start()
 
     # While we're trying to have each part of the code directly access what it
     # needs without keeping redundant references to objects, we have too much
@@ -1238,7 +1236,10 @@ class InteractiveShell(Configurable, Magic):
     #-------------------------------------------------------------------------
 
     def init_history(self):
+        """Sets up the command history, and starts regular autosaves."""
         self.history_manager = HistoryManager(shell=self)
+        self.history_thread = HistorySaveThread(self, time_interval=60)
+        self.history_thread.start()
 
     def save_history(self):
         """Save input history to a file (via readline library)."""

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -45,7 +45,6 @@ from IPython.core.error import TryNext, UsageError
 from IPython.core.extensions import ExtensionManager
 from IPython.core.fakemodule import FakeModule, init_fakemod_dict
 from IPython.core.history import HistoryManager
-from IPython.core.history import HistorySaveThread
 from IPython.core.inputsplitter import IPythonInputSplitter
 from IPython.core.logger import Logger
 from IPython.core.magic import Magic
@@ -1238,8 +1237,6 @@ class InteractiveShell(Configurable, Magic):
     def init_history(self):
         """Sets up the command history, and starts regular autosaves."""
         self.history_manager = HistoryManager(shell=self)
-        self.history_thread = HistorySaveThread(self, time_interval=60)
-        self.history_thread.start()
 
     def save_history(self):
         """Save input history to a file (via readline library)."""
@@ -2527,7 +2524,6 @@ class InteractiveShell(Configurable, Magic):
             except OSError:
                 pass
 
-        self.history_thread.stop()
         self.save_history()
 
         # Clear all user namespaces to release all references cleanly.

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -294,7 +294,7 @@ class InteractiveShell(Configurable, Magic):
         self.init_payload()
         self.hooks.late_startup_hook()
         atexit.register(self.atexit_operations)
-        self.history_thread = HistorySaveThread(self, 60, False)
+        self.history_thread = HistorySaveThread(self, 60)
         self.history_thread.start()
 
     # While we're trying to have each part of the code directly access what it
@@ -2526,6 +2526,7 @@ class InteractiveShell(Configurable, Magic):
             except OSError:
                 pass
 
+        self.history_thread.stop()
         self.save_history()
 
         # Clear all user namespaces to release all references cleanly.

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -499,10 +499,6 @@ class TerminalInteractiveShell(InteractiveShell):
         This method calls the ask_exit callback."""
         if self.confirm_exit:
             if self.ask_yes_no('Do you really want to exit ([y]/n)?','y'):
-                self.shell.history_thread.exit_now=True
-                self.shell.history_thread.cond.acquire()
-                self.shell.history_thread.cond.notify()
-                self.shell.history_thread.cond.release()
                 self.ask_exit()
         else:
             self.ask_exit()

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -24,7 +24,6 @@ import sys
 from IPython.core.error import TryNext
 from IPython.core.usage import interactive_usage, default_banner
 from IPython.core.interactiveshell import InteractiveShell, InteractiveShellABC
-from IPython.core.history import HistorySaveThread
 from IPython.lib.inputhook import enable_gui
 from IPython.lib.pylabtools import pylab_activate
 from IPython.utils.terminal import toggle_set_term_title, set_term_title


### PR DESCRIPTION
This fixes the failure to exit in IPython terminal interpreter.

The problem was the history autosave thread: if a y/n confirmation of exiting was used (i.e. following Ctrl-D), the commands to stop the thread were called, but if "exit" was used, which doesn't require confirmation, they weren't.

I've overcome this simply by setting the thread to daemon mode, which means that Python doesn't attempt to wait for it after the main thread has exited. At present, I've removed the code that stops the autosave thread on shutdown, as it seems superfluous.

I've also refactored the sequence of commands used to stop it into a `.stop()` method on the thread object, although it's not currently used anywhere.
