### PR TITLE
My exit

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -294,8 +294,6 @@ class InteractiveShell(Configurable, Magic):
         self.init_payload()
         self.hooks.late_startup_hook()
         atexit.register(self.atexit_operations)
-        self.history_thread = HistorySaveThread(self, 60, False)
-        self.history_thread.start()
 
     # While we're trying to have each part of the code directly access what it
     # needs without keeping redundant references to objects, we have too much

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -24,7 +24,6 @@ import sys
 from IPython.core.error import TryNext
 from IPython.core.usage import interactive_usage, default_banner
 from IPython.core.interactiveshell import InteractiveShell, InteractiveShellABC
-from IPython.core.history import HistorySaveThread
 from IPython.lib.inputhook import enable_gui
 from IPython.lib.pylabtools import pylab_activate
 from IPython.utils.terminal import toggle_set_term_title, set_term_title


### PR DESCRIPTION
```
Make exit work in terminal based IPython

This bug was introduced in commit:
46b78b3f4c5baf5704296c875e0e7f3d33d0c08e

Also see:
http://mail.scipy.org/pipermail/ipython-dev/2011-January/007051.html
```
