### PR TITLE
Writing unicode characters to a log file. (IPython 0.10.2.git)

### DIFF
--- a/IPython/Logger.py
+++ b/IPython/Logger.py
@@ -18,6 +18,7 @@ Logger class for IPython's logging facilities.
 import glob
 import os
 import time
+import sys
 
 #****************************************************************************
 # FIXME: This class isn't a mixin anymore, but it still needs attributes from
@@ -241,7 +242,7 @@ which already exists. But you must first start the logging process with
                 if self.timestamp:
                     write(time.strftime('# %a, %d %b %Y %H:%M:%S\n',
                                         time.localtime()))
-                write('%s\n' % data)
+                write('%s\n' % data.encode(sys.stdin.encoding))
             elif kind=='output' and self.log_output:
                 odata = '\n'.join(['#[Out]# %s' % s
                                    for s in data.split('\n')])

--- a/IPython/Magic.py
+++ b/IPython/Magic.py
@@ -1164,7 +1164,7 @@ Currently the magic system has the following functions:\n"""
         if logfname:
             logfname = os.path.expanduser(logfname)
         rc.opts.logfile = logfname
-        loghead = self.shell.loghead_tpl % (rc.opts,rc.args)
+        loghead = self.shell.loghead_tpl % (sys.stdin.encoding, rc.opts, rc.args)
         try:
             started  = logger.logstart(logfname,loghead,logmode,
                                        log_output,timestamp,log_raw_input)

--- a/IPython/iplib.py
+++ b/IPython/iplib.py
@@ -670,7 +670,7 @@ class InteractiveShell(object,Magic):
         # logstart method.
         self.loghead_tpl = \
 """#log# Automatic Logger file. *** THIS MUST BE THE FIRST LINE ***
-#log# DO NOT CHANGE THIS LINE OR THE TWO BELOW
+#log# DO NOT CHANGE THIS LINE OR THE TWO BELOW -* coding: %s *-
 #log# opts = %s
 #log# args = %s
 #log# It is safe to make manual edits below here.


### PR DESCRIPTION
Example:

When trying to log a statements like this during logging:

<pre>
In [2]: logstart -o logtest.py over
In [3]: t = 'žćčšđ'
...
UnicodeEncodeError: 'ascii' codec can't encode characters in position 5-9: ordinal not in range(128)
</pre>


The supplied patch fixes the problem. At least temporary.

Also, changed the log header to contain the encoding definition for the source file. 
Useful for rerunning the log file outside IPython.
