### PR TITLE
always use Session.send

### DIFF
--- a/IPython/zmq/completer.py
+++ b/IPython/zmq/completer.py
@@ -54,7 +54,8 @@ class ClientCompleter(object):
 
         # Give the kernel up to 0.5s to respond
         for i in range(5):
-            rep = self.session.recv(self.socket)
+            ident,rep = self.session.recv(self.socket)
+            rep = Message(rep)
             if rep is not None and rep.msg_type == 'complete_reply':
                 matches = rep.content.matches
                 break

--- a/IPython/zmq/displayhook.py
+++ b/IPython/zmq/displayhook.py
@@ -14,9 +14,8 @@ class DisplayHook(object):
             return
 
         __builtin__._ = obj
-        msg = self.session.msg(u'pyout', {u'data':repr(obj)},
+        msg = self.session.send(self.pub_socket, u'pyout', {u'data':repr(obj)},
                                parent=self.parent_header)
-        self.pub_socket.send_json(msg)
 
     def set_parent(self, parent):
         self.parent_header = extract_header(parent)

--- a/IPython/zmq/frontend.py
+++ b/IPython/zmq/frontend.py
@@ -92,10 +92,10 @@ class Console(code.InteractiveConsole):
 
     def recv_output(self):
         while True:
-            omsg = self.session.recv(self.sub_socket)
-            if omsg is None:
+            ident,msg = self.session.recv(self.sub_socket)
+            if msg is None:
                 break
-            self.handle_output(omsg)
+            self.handle_output(Message(msg))
 
     def handle_reply(self, rep):
         # Handle any side effects on output channels
@@ -114,9 +114,10 @@ class Console(code.InteractiveConsole):
                 print >> sys.stderr, ab
 
     def recv_reply(self):
-        rep = self.session.recv(self.request_socket)
-        self.handle_reply(rep)
-        return rep
+        ident,rep = self.session.recv(self.request_socket)
+        mrep = Message(rep)
+        self.handle_reply(mrep)
+        return mrep
 
     def runcode(self, code):
         # We can't pickle code objects, so fetch the actual source

--- a/IPython/zmq/iostream.py
+++ b/IPython/zmq/iostream.py
@@ -37,10 +37,9 @@ class OutStream(object):
             data = self._buffer.getvalue()
             if data:
                 content = {u'name':self.name, u'data':data}
-                msg = self.session.msg(u'stream', content=content,
+                msg = self.session.send(self.pub_socket, u'stream', content=content,
                                        parent=self.parent_header)
                 io.raw_print(msg)
-                self.pub_socket.send_json(msg)
                 
                 self._buffer.close()
                 self._new_buffer()

--- a/IPython/zmq/pykernel.py
+++ b/IPython/zmq/pykernel.py
@@ -69,9 +69,8 @@ class Kernel(HasTraits):
         """ Start the kernel main loop.
         """
         while True:
-            ident = self.reply_socket.recv()
-            assert self.reply_socket.rcvmore(), "Missing message part."
-            msg = self.reply_socket.recv_json()
+            ident,msg = self.session.recv(self.reply_socket,0)
+            assert ident is not None, "Missing message part."
             omsg = Message(msg)
             print>>sys.__stdout__
             print>>sys.__stdout__, omsg
@@ -105,8 +104,7 @@ class Kernel(HasTraits):
             print>>sys.__stderr__, "Got bad msg: "
             print>>sys.__stderr__, Message(parent)
             return
-        pyin_msg = self.session.msg(u'pyin',{u'code':code}, parent=parent)
-        self.pub_socket.send_json(pyin_msg)
+        pyin_msg = self.session.send(self.pub_socket, u'pyin',{u'code':code}, parent=parent)
 
         try:
             comp_code = self.compiler(code, '<zmq-kernel>')
@@ -131,8 +129,7 @@ class Kernel(HasTraits):
                 u'ename' : unicode(etype.__name__),
                 u'evalue' : unicode(evalue)
             }
-            exc_msg = self.session.msg(u'pyerr', exc_content, parent)
-            self.pub_socket.send_json(exc_msg)
+            exc_msg = self.session.send(self.pub_socket, u'pyerr', exc_content, parent)
             reply_content = exc_content
         else:
             reply_content = { 'status' : 'ok', 'payload' : {} }
@@ -142,10 +139,8 @@ class Kernel(HasTraits):
         sys.stdout.flush()
 
         # Send the reply.
-        reply_msg = self.session.msg(u'execute_reply', reply_content, parent)
+        reply_msg = self.session.send(self.reply_socket, u'execute_reply', reply_content, parent, ident=ident)
         print>>sys.__stdout__, Message(reply_msg)
-        self.reply_socket.send(ident, zmq.SNDMORE)
-        self.reply_socket.send_json(reply_msg)
         if reply_msg['content']['status'] == u'error':
             self._abort_queue()
 
@@ -180,21 +175,18 @@ class Kernel(HasTraits):
     def _abort_queue(self):
         while True:
             try:
-                ident = self.reply_socket.recv(zmq.NOBLOCK)
+                ident,msg = self.session.recv(self.reply_socket, zmq.NOBLOCK)
             except zmq.ZMQError, e:
                 if e.errno == zmq.EAGAIN:
                     break
             else:
-                assert self.reply_socket.rcvmore(), "Missing message part."
-                msg = self.reply_socket.recv_json()
+                assert ident is not None, "Missing message part."
             print>>sys.__stdout__, "Aborting:"
             print>>sys.__stdout__, Message(msg)
             msg_type = msg['msg_type']
             reply_type = msg_type.split('_')[0] + '_reply'
-            reply_msg = self.session.msg(reply_type, {'status':'aborted'}, msg)
+            reply_msg = self.session.send(self.reply_socket, reply_type, {'status':'aborted'}, msg, ident=ident)
             print>>sys.__stdout__, Message(reply_msg)
-            self.reply_socket.send(ident,zmq.SNDMORE)
-            self.reply_socket.send_json(reply_msg)
             # We need to wait a bit for requests to come in. This can probably
             # be set shorter for true asynchronous clients.
             time.sleep(0.1)
@@ -206,11 +198,10 @@ class Kernel(HasTraits):
 
         # Send the input request.
         content = dict(prompt=prompt)
-        msg = self.session.msg(u'input_request', content, parent)
-        self.req_socket.send_json(msg)
+        msg = self.session.send(self.req_socket, u'input_request', content, parent)
 
         # Await a response.
-        reply = self.req_socket.recv_json()
+        ident,reply = self.session.recv(self.req_socket, 0)
         try:
             value = reply['content']['value']
         except:

--- a/IPython/zmq/zmqshell.py
+++ b/IPython/zmq/zmqshell.py
@@ -71,7 +71,7 @@ class ZMQDisplayHook(DisplayHook):
 
     def finish_displayhook(self):
         """Finish up all displayhook activities."""
-        self.pub_socket.send_json(self.msg)
+        self.session.send(self.pub_socket, self.msg)
         self.msg = None
 
 
@@ -126,10 +126,9 @@ class ZMQInteractiveShell(InteractiveShell):
         }
 
         dh = self.displayhook
-        exc_msg = dh.session.msg(u'pyerr', exc_content, dh.parent_header)
         # Send exception info over pub socket for other clients than the caller
         # to pick up
-        dh.pub_socket.send_json(exc_msg)
+        exc_msg = dh.session.send(dh.pub_socket, u'pyerr', exc_content, dh.parent_header)
 
         # FIXME - Hack: store exception info in shell object.  Right now, the
         # caller is reading this info after the fact, we need to fix this logic


### PR DESCRIPTION
This commit removes all explicit calls to socket.send/socket.recv, and replaces them with session.send/recv.  This allows for later expansion of the send/recv protocols, and eases eventual migration to StreamSession object developed in newparallel.

Some adjustments were made to the Session to accomodate this:
- Session.send can take a Message or dict to allow for multiple sending of the same message
- Session.send returns a dict instead of wrapping it in a Message
- Session.recv always returns a tuple of length two: (ident,msg), where ident is None if there was no identity prefix, and msg is None if EAGAIN was raised (indicating no message).

Everything else should function the same.
