### PR TITLE
Adapt magic commands to new history system.

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -185,7 +185,7 @@ class HistoryManager(object):
             if self.shell.has_readline:
                 self.populate_readline_history()
         
-    def get_history(self, index=None, raw=False, output=True):
+    def get_history(self, index=None, raw=False, output=True,this_session=True):
         """Get the history list.
 
         Get the input and output history.
@@ -200,6 +200,9 @@ class HistoryManager(object):
             If True, return the raw input.
         output : bool
             If True, then return the output as well.
+        this_session : bool
+            If True, indexing is from 1 at the start of this session.
+            If False, indexing is from 1 at the start of the whole history.
 
         Returns
         -------
@@ -213,9 +216,13 @@ class HistoryManager(object):
             input_hist = self.input_hist_parsed
         if output:
             output_hist = self.output_hist
+        
+        if this_session:
+            offset = self.session_offset
+        else:
+            offset = -1
             
         n = len(input_hist)
-        offset = self.session_offset
         if index is None:
             start=offset+1; stop=n
         elif isinstance(index, int):

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -284,6 +284,8 @@ class HistoryManager(object):
         self.output_hist.clear()
         # The directory history can't be completely empty
         self.dir_hist[:] = [os.getcwd()]
+        # Reset session offset to -1, so next command counts as #1
+        self.session_offset = -1
 
 class HistorySaveThread(threading.Thread):
     """This thread makes IPython save history periodically.

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -442,15 +442,10 @@ def magic_history(self, parameter_s = ''):
             print('%s:%s' % (str(in_num).ljust(width), line_sep[multiline]),
                   file=outfile, end='')
         if pyprompts:
-            inline = ">>> " + inline
+            print(">>> ", end="", file=outfile)
             if multiline:
-                lines = inline.splitlines()
-                print('\n... '.join(lines), file=outfile)
-                print('... ', file=outfile)
-            else:
-                print(inline, file=outfile)
-        else:
-            print(inline, file=outfile)
+                inline = "\n... ".join(inline.splitlines()) + "\n..."
+        print(inline, file=outfile)
         if print_outputs and output:
             print(repr(output), file=outfile)
 

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -54,6 +54,10 @@ class HistoryManager(object):
     # ShadowHist instance with the actual shadow history
     shadow_hist = None
     
+    # Offset so the first line of the current session is #1. Can be
+    # updated after loading history from file.
+    session_offset = -1
+    
     # Private interface
     # Variables used to store the three last inputs from the user.  On each new
     # history update, we populate the user's namespace with these, shifted as
@@ -68,8 +72,12 @@ class HistoryManager(object):
     def __init__(self, shell, load_history=False):
         """Create a new history manager associated with a shell instance.
         
-        If load_history is true, it will load the history from file and set the
-        session offset so that the next line typed can be retrieved as #1.
+        Parameters
+        ----------
+        load_history: bool, optional
+            If True, history will be loaded from file, and the session
+            offset set, so that the next line entered can be retrieved
+            as #1.
         """
         # We need a pointer back to the shell for various tasks.
         self.shell = shell
@@ -80,9 +88,6 @@ class HistoryManager(object):
         # pre-processing.  This will allow users to retrieve the input just as
         # it was exactly typed in by the user, with %hist -r.
         self.input_hist_raw = []
-        
-        # Offset so the first line of the current session is #1
-        self.session_offset = -1
 
         # list of visited directories
         try:

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1277,8 +1277,8 @@ class InteractiveShell(Configurable, Magic):
                 self.reload_history()
         return wrapper
     
-    def get_history(self, index=None, raw=False, output=True):
-        return self.history_manager.get_history(index, raw, output)
+    def get_history(self, index=None, raw=False, output=True,this_session=True):
+        return self.history_manager.get_history(index, raw, output,this_session)
     
 
     #-------------------------------------------------------------------------

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1248,7 +1248,7 @@ class InteractiveShell(Configurable, Magic):
 
     def init_history(self):
         """Sets up the command history, and starts regular autosaves."""
-        self.history_manager = HistoryManager(shell=self)
+        self.history_manager = HistoryManager(shell=self, load_history=True)
 
     def save_history(self):
         """Save input history to a file (via readline library)."""
@@ -1560,11 +1560,8 @@ class InteractiveShell(Configurable, Magic):
             readline.set_completer_delims(delims)
             # otherwise we end up with a monster history after a while:
             readline.set_history_length(self.history_length)
-            try:
-                #print '*** Reading readline history'  # dbg
-                self.reload_history() 
-            except IOError:
-                pass  # It doesn't exist yet.
+            
+            self.history_manager.populate_readline_history()
 
         # Configure auto-indent for all platforms
         self.set_autoindent(self.autoindent)

--- a/IPython/core/macro.py
+++ b/IPython/core/macro.py
@@ -21,7 +21,7 @@ class Macro(IPyAutocall):
 
     def __init__(self,data):
         """store the macro value, as a single string which can be executed"""
-        self.value = ''.join(data).rstrip()+'\n'
+        self.value = '\n'.join(data).rstrip()+'\n'
         
     def __str__(self):
         return self.value

--- a/IPython/core/macro.py
+++ b/IPython/core/macro.py
@@ -19,9 +19,9 @@ class Macro(IPyAutocall):
     Args to macro are available in _margv list if you need them.
     """
 
-    def __init__(self,data):
+    def __init__(self,code):
         """store the macro value, as a single string which can be executed"""
-        self.value = '\n'.join(data).rstrip()+'\n'
+        self.value = code.rstrip()+'\n'
         
     def __str__(self):
         return self.value

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -1964,17 +1964,16 @@ Currently the magic system has the following functions:\n"""
           In [60]: exec In[44:48]+In[49]"""
 
         opts,args = self.parse_options(parameter_s,'r',mode='list')
-        if not args:
-            macs = [k for k,v in self.shell.user_ns.items() if isinstance(v, Macro)]
-            macs.sort()
-            return macs
+        if not args:   # List existing macros
+            return sorted(k for k,v in self.shell.user_ns.iteritems() if\
+                                                        isinstance(v, Macro))
         if len(args) == 1:
             raise UsageError(
                 "%macro insufficient args; usage '%macro name n1-n2 n3-4...")
         name,ranges = args[0], args[1:]
         
         #print 'rng',ranges  # dbg
-        lines = self.extract_input_slices(ranges,opts.has_key('r'))
+        lines = self.extract_input_slices(ranges,'r' in opts)
         macro = Macro("\n".join(lines))
         self.shell.define_macro(name, macro)
         print 'Macro `%s` created. To execute, type its name (without quotes).' % name
@@ -2010,7 +2009,7 @@ Currently the magic system has the following functions:\n"""
             if ans.lower() not in ['y','yes']:
                 print 'Operation cancelled.'
                 return
-        cmds = '\n'.join(self.extract_input_slices(ranges,opts.has_key('r')))
+        cmds = '\n'.join(self.extract_input_slices(ranges, 'r' in opts))
         with open(fname,'w') as f:
             f.write(cmds)
         print 'The following commands were written to file `%s`:' % fname

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -184,11 +184,7 @@ python-profiler package from non-free.""")
         N:M -> standard python form, means including items N...(M-1).
 
         N-M -> include items N..M (closed endpoint)."""
-
-        if raw:
-            hist = self.shell.history_manager.input_hist_raw
-        else:
-            hist = self.shell.history_manager.input_hist_parsed
+        history_manager = self.shell.history_manager
 
         cmds = []
         for chunk in slices:
@@ -200,7 +196,8 @@ python-profiler package from non-free.""")
             else:
                 ini = int(chunk)
                 fin = ini+1
-            cmds.append('\n'.join(hist[ini:fin]))
+            hist = history_manager.get_history((ini,fin), raw=raw, output=False)
+            cmds.append('\n'.join(hist[i] for i in sorted(hist.iterkeys())))
         return cmds
             
     def arg_err(self,func):
@@ -1978,7 +1975,7 @@ Currently the magic system has the following functions:\n"""
         
         #print 'rng',ranges  # dbg
         lines = self.extract_input_slices(ranges,opts.has_key('r'))
-        macro = Macro(lines)
+        macro = Macro("\n".join(lines))
         self.shell.define_macro(name, macro)
         print 'Macro `%s` created. To execute, type its name (without quotes).' % name
         print 'Macro contents:'
@@ -2228,7 +2225,7 @@ Currently the magic system has the following functions:\n"""
             # This means that you can't edit files whose names begin with
             # numbers this way. Tough.
             ranges = args.split()
-            data = ''.join(self.extract_input_slices(ranges,opts_r))
+            data = '\n'.join(self.extract_input_slices(ranges,opts_r))
         elif args.endswith('.py'):
             filename = make_filename(args)
             data = ''

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -200,7 +200,7 @@ python-profiler package from non-free.""")
             else:
                 ini = int(chunk)
                 fin = ini+1
-            cmds.append(''.join(hist[ini:fin]))
+            cmds.append('\n'.join(hist[ini:fin]))
         return cmds
             
     def arg_err(self,func):
@@ -2013,10 +2013,9 @@ Currently the magic system has the following functions:\n"""
             if ans.lower() not in ['y','yes']:
                 print 'Operation cancelled.'
                 return
-        cmds = ''.join(self.extract_input_slices(ranges,opts.has_key('r')))
-        f = file(fname,'w')
-        f.write(cmds)
-        f.close()
+        cmds = '\n'.join(self.extract_input_slices(ranges,opts.has_key('r')))
+        with open(fname,'w') as f:
+            f.write(cmds)
         print 'The following commands were written to file `%s`:' % fname
         print cmds
 

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -57,7 +57,7 @@ import IPython.utils.io
 from IPython.utils.path import get_py_filename
 from IPython.utils.process import arg_split, abbrev_cwd
 from IPython.utils.terminal import set_term_title
-from IPython.utils.text import LSString, SList, StringTypes, format_screen
+from IPython.utils.text import LSString, SList, format_screen
 from IPython.utils.timing import clock, clock2
 from IPython.utils.warn import warn, error
 from IPython.utils.ipstruct import Struct
@@ -2218,9 +2218,10 @@ Currently the magic system has the following functions:\n"""
 
         # by default this is done with temp files, except when the given
         # arg is a filename
-        use_temp = 1
+        use_temp = True
 
-        if re.match(r'\d',args):
+        data = ''
+        if args[0].isdigit():
             # Mode where user specifies ranges of lines, like in %macro.
             # This means that you can't edit files whose names begin with
             # numbers this way. Tough.
@@ -2228,16 +2229,15 @@ Currently the magic system has the following functions:\n"""
             data = '\n'.join(self.extract_input_slices(ranges,opts_r))
         elif args.endswith('.py'):
             filename = make_filename(args)
-            data = ''
-            use_temp = 0
+            use_temp = False
         elif args:
             try:
                 # Load the parameter given as a variable. If not a string,
                 # process it as an object instead (below)
 
                 #print '*** args',args,'type',type(args)  # dbg
-                data = eval(args,self.shell.user_ns)
-                if not type(data) in StringTypes:
+                data = eval(args, self.shell.user_ns)
+                if not isinstance(data, basestring):
                     raise DataIsObject
 
             except (NameError,SyntaxError):
@@ -2247,13 +2247,11 @@ Currently the magic system has the following functions:\n"""
                     warn("Argument given (%s) can't be found as a variable "
                          "or as a filename." % args)
                     return
-
-                data = ''
-                use_temp = 0
+                use_temp = False
+            
             except DataIsObject:
-
                 # macros have a special edit function
-                if isinstance(data,Macro):
+                if isinstance(data, Macro):
                     self._edit_macro(args,data)
                     return
                                 
@@ -2292,9 +2290,7 @@ Currently the magic system has the following functions:\n"""
                             warn('The file `%s` where `%s` was defined cannot '
                                  'be read.' % (filename,data))
                             return
-                use_temp = 0
-        else:
-            data = ''
+                use_temp = False
 
         if use_temp:
             filename = self.shell.mktempfile(data)
@@ -2317,7 +2313,7 @@ Currently the magic system has the following functions:\n"""
         if args.strip() == 'pasted_block':
             self.shell.user_ns['pasted_block'] = file_read(filename)
         
-        if opts.has_key('x'):  # -x prevents actual execution
+        if 'x' in opts:  # -x prevents actual execution
             print
         else:
             print 'done. Executing edited code...'

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -30,11 +30,11 @@ def test_history():
             ip.history_manager = HistoryManager(ip)
             ip.history_manager.hist_file = histfile
             print 'test',histfile
-            hist = ['a=1\n', 'def f():\n    test = 1\n    return test\n', 'b=2\n']
+            hist = ['a=1', 'def f():\n    test = 1\n    return test', 'b=2']
             # test save and load
             ip.history_manager.input_hist_raw[:] = []
             for h in hist:
-                ip.history_manager.input_hist_raw.append(h)
+                ip.history_manager.store_inputs(h)
             ip.save_history()
             ip.history_manager.input_hist_raw[:] = []
             ip.reload_history()
@@ -43,6 +43,23 @@ def test_history():
             nt.assert_equal(len(ip.history_manager.input_hist_raw), len(hist))
             for i,h in enumerate(hist):
                 nt.assert_equal(hist[i], ip.history_manager.input_hist_raw[i])
+              
+            # Test that session offset works.
+            ip.history_manager.session_offset = \
+                                    len(ip.history_manager.input_hist_raw) -1
+            newcmds = ["z=5","class X(object):\n    pass", "k='p'"]
+            for cmd in newcmds:
+                ip.history_manager.store_inputs(cmd)
+            gothist = ip.history_manager.get_history((1,4),
+                                                        raw=True, output=False)
+            nt.assert_equal(gothist, dict(zip([1,2,3], newcmds)))
+            
+            # Cross testing: check that magic %save picks up on the session
+            # offset.
+            testfilename = os.path.realpath(os.path.join(tmpdir, "test.py"))
+            ip.magic_save(testfilename + " 1-3")
+            testfile = open(testfilename, "r")
+            nt.assert_equal(testfile.read(), "\n".join(newcmds))
         finally:
             # Restore history manager
             ip.history_manager = hist_manager_ori

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -183,8 +183,8 @@ def test_macro():
     ip.magic("macro test 1-3")
     nt.assert_equal(ip.user_ns["test"].value, "\n".join(cmds)+"\n")
     
-    # List macros. This goes to stdout, so just check it doesn't crash.
-    ip.magic("macro")
+    # List macros.
+    assert "test" in ip.magic("macro")
 
     
 # XXX failing for now, until we get clearcmd out of quarantine.  But we should

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -173,6 +173,18 @@ def test_shist():
     yield nt.assert_equal,s.get(2),'world'
     
     shutil.rmtree(tfile)
+    
+def test_macro():
+    ip = get_ipython()
+    ip.history_manager.reset()   # Clear any existing history.
+    cmds = ["a=1", "def b():\n  return a**2", "print(a,b())"]
+    for cmd in cmds:
+        ip.history_manager.store_inputs(cmd)
+    ip.magic("macro test 1-3")
+    nt.assert_equal(ip.user_ns["test"].value, "\n".join(cmds)+"\n")
+    
+    # List macros. This goes to stdout, so just check it doesn't crash.
+    ip.magic("macro")
 
     
 # XXX failing for now, until we get clearcmd out of quarantine.  But we should

--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -217,7 +217,8 @@ class IPythonWidget(FrontendWidget):
         """ Reimplemented to make a history request.
         """
         super(IPythonWidget, self)._started_channels()
-        self.kernel_manager.xreq_channel.history(raw=True, output=False)
+        self.kernel_manager.xreq_channel.history(raw=True, output=False,
+                                                            this_session=False)
 
     #---------------------------------------------------------------------------
     # 'ConsoleWidget' public interface

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -19,7 +19,6 @@ import __main__
 import os
 import re
 import shutil
-import types
 
 from IPython.external.path import path
 
@@ -29,8 +28,6 @@ from IPython.utils.data import flatten
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
-
-StringTypes = types.StringTypes
 
 
 def unquote_ends(istr):
@@ -325,7 +322,7 @@ def qw(words,flat=0,sep=None,maxsplit=-1):
     ['a', 'b', '1', '2', 'm', 'n', 'p', 'q']
     """
 
-    if type(words) in StringTypes:
+    if isinstance(words, basestring):
         return [word.strip() for word in words.split(sep,maxsplit)
                 if word and not word.isspace() ]
     if flat:
@@ -345,7 +342,7 @@ def qw_lol(indata):
     We need this to make sure the modules_some keys *always* end up as a
     list of lists."""
 
-    if type(indata) in StringTypes:
+    if isinstance(indata, basestring):
         return [qw(indata)]
     else:
         return qw(indata)

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -301,10 +301,9 @@ class Kernel(Configurable):
         io.raw_print(msg)
 
     def history_request(self, ident, parent):
-        output = parent['content']['output']
-        index = parent['content']['index']
-        raw = parent['content']['raw']
-        hist = self.shell.get_history(index=index, raw=raw, output=output)
+        # parent['content'] should contain keys "index", "raw", "output" and
+        # "this_session".
+        hist = self.shell.get_history(**parent['content'])
         content = {'history' : hist}
         msg = self.session.send(self.reply_socket, 'history_reply',
                                 content, parent, ident)

--- a/IPython/zmq/kernelmanager.py
+++ b/IPython/zmq/kernelmanager.py
@@ -281,7 +281,7 @@ class XReqSocketChannel(ZmqSocketChannel):
         self._queue_request(msg)
         return msg['header']['msg_id']
 
-    def history(self, index=None, raw=False, output=True):
+    def history(self, index=None, raw=False, output=True, this_session=True):
         """Get the history list.
 
         Parameters
@@ -294,12 +294,16 @@ class XReqSocketChannel(ZmqSocketChannel):
             If True, return the raw input.
         output : bool
             If True, then return the output as well.
+        this_session : bool
+            If True, returns only history from the current session. Otherwise,
+            includes reloaded history from previous sessions.
 
         Returns
         -------
         The msg_id of the message sent.
         """
-        content = dict(index=index, raw=raw, output=output)
+        content = dict(index=index, raw=raw, output=output, 
+                                                    this_session=this_session)
         msg = self.session.msg('history_request', content)
         self._queue_request(msg)
         return msg['header']['msg_id']


### PR DESCRIPTION
This grew from issue ipython/ipython#245. Various magic commands weren't working properly with the new history system: %edit, %macro, and %hist.

Among various minor troubles, selecting a range of lines (`%macro test 2-5`) numbered from the beginning of the history, so didn't match up with the current line numbers. I've approached this by adding a session_offset attribute to the history manager. This has the added benefit that we no longer need to store a blank history entry so we can count lines from 1.

Along the way, I simplified and modernised parts of the code, including using `basestring` over `StringTypes` and `.isdigit()` over an equivalent regex.
