### PR TITLE
inline pylab cuts off labels on log plots

### DIFF
--- a/IPython/lib/pylabtools.py
+++ b/IPython/lib/pylabtools.py
@@ -216,13 +216,23 @@ def import_pylab(user_ns, backend, import_all=True, shell=None):
             from IPython.zmq.pylab.backend_inline import flush_svg
             from matplotlib import pyplot
             shell.register_post_execute(flush_svg)
-            # The typical default figure size is too large for inline use.  We
-            # might make this a user-configurable parameter later.
-            figsize(6.0, 4.0)
-            # 12pt labels get cutoff on 6x4 logplots, so use 10pt.
-            pyplot.rcParams['font.size'] = 10
-            # 10pt still needs a little more room on the xlabel:
-            pyplot.rcParams['figure.subplot.bottom'] = .125
+            # The typical default figure size is too large for inline use,
+            # so we shrink the figure size to 6x4, and tweak fonts to
+            # make that fit.  This is configurable via Global.inline_rc,
+            # or rather it will be once the zmq kernel is hooked up to
+            # the config system.
+            
+            default_rc = {
+                'figure.figsize': (6.0,4.0),
+                # 12pt labels get cutoff on 6x4 logplots, so use 10pt.
+                'font.size': 10,
+                # 10pt still needs a little more room on the xlabel:
+                'figure.subplot.bottom' : .125
+            }
+            rc = getattr(shell.config.Global, 'inline_rc', default_rc)
+            pyplot.rcParams.update(rc)
+            shell.config.Global.inline_rc = rc
+            
             # Add 'figsize' to pyplot and to the user's namespace
             user_ns['figsize'] = pyplot.figsize = figsize
             shell.user_ns_hidden['figsize'] = figsize

--- a/IPython/lib/pylabtools.py
+++ b/IPython/lib/pylabtools.py
@@ -219,6 +219,10 @@ def import_pylab(user_ns, backend, import_all=True, shell=None):
             # The typical default figure size is too large for inline use.  We
             # might make this a user-configurable parameter later.
             figsize(6.0, 4.0)
+            # 12pt labels get cutoff on 6x4 logplots, so use 10pt.
+            pyplot.rcParams['font.size'] = 10
+            # 10pt still needs a little more room on the xlabel:
+            pyplot.rcParams['figure.subplot.bottom'] = .125
             # Add 'figsize' to pyplot and to the user's namespace
             user_ns['figsize'] = pyplot.figsize = figsize
             shell.user_ns_hidden['figsize'] = figsize

--- a/IPython/lib/pylabtools.py
+++ b/IPython/lib/pylabtools.py
@@ -218,7 +218,7 @@ def import_pylab(user_ns, backend, import_all=True, shell=None):
             shell.register_post_execute(flush_svg)
             # The typical default figure size is too large for inline use,
             # so we shrink the figure size to 6x4, and tweak fonts to
-            # make that fit.  This is configurable via Global.inline_rc,
+            # make that fit.  This is configurable via Global.pylab_inline_rc,
             # or rather it will be once the zmq kernel is hooked up to
             # the config system.
             
@@ -229,9 +229,9 @@ def import_pylab(user_ns, backend, import_all=True, shell=None):
                 # 10pt still needs a little more room on the xlabel:
                 'figure.subplot.bottom' : .125
             }
-            rc = getattr(shell.config.Global, 'inline_rc', default_rc)
+            rc = getattr(shell.config.Global, 'pylab_inline_rc', default_rc)
             pyplot.rcParams.update(rc)
-            shell.config.Global.inline_rc = rc
+            shell.config.Global.pylab_inline_rc = rc
             
             # Add 'figsize' to pyplot and to the user's namespace
             user_ns['figsize'] = pyplot.figsize = figsize


### PR DESCRIPTION
When using the inline pylab backend, the default figure size is set to 6x4.  This is too small if the fonts are left as 12pt, and x-labels get cut off if you use a log-scale.  This commit tweaks the default font size and bottom padding, so that labels fit.

Adjustments: 
- fontsize 12pt => 10pt
- subplot.bottom .1 => .125

Even though it's a tiny commit, I make this as a pull request rather than doing it directly on master because I imagine there may be some objection to overriding 3 matplotlib defaults instead of just one, and some may consider the font too small (If anything, I would like it still smaller). 

There are also a thousand different ways to make this work, but I don't want to get into a debate of ideal styling, I just wanted to fix a basic error.

Regular scaling of matplotlib 8x6, 12pt defaults by 75% would have:
- figsize: 6x4.5
- fontsize: 9pt

So our figures have a wider aspect ratio being 6x4, and now even slightly wider since I increased the bottom padding a bit.

Here's an after/before image of the two styles:
<a href="http://tinypic.com?ref=4rw389" target="_blank"><img src="http://i51.tinypic.com/4rw389.jpg" border="0" alt="Image and video hosting by TinyPic"></a>
