### PR TITLE
Add %precision magic

### DIFF
--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -20,8 +20,8 @@ Authors:
 #-----------------------------------------------------------------------------
 
 # Stdlib imports
-import sys
 import abc
+import sys
 # We must use StringIO, as cStringIO doesn't handle unicode properly.
 from StringIO import StringIO
 

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -3504,15 +3504,15 @@ Defaulting color scheme to 'NoColor'"""
             fmt = s
             try:
                 fmt%3.14159
-            except:
-                raise TypeError("Precision must be int or format string, not %r"%s)
+            except Exception:
+                raise ValueError("Precision must be int or format string, not %r"%s)
         elif s:
             # otherwise, should be an int
             try:
                 i = int(s)
                 assert i >= 0
-            except:
-                raise TypeError("Precision must be non-negative int or format string, not %r"%s)
+            except (ValueError, AssertionError):
+                raise ValueError("Precision must be non-negative int or format string, not %r"%s)
             
             fmt = '%%.%if'%i
             if 'numpy' in sys.modules:

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -3478,58 +3478,33 @@ Defaulting color scheme to 'NoColor'"""
             In [1]: from math import pi
         
             In [2]: %precision 3
+            Out[2]: '%.3f'
         
             In [3]: pi
             Out[3]: 3.142
         
             In [4]: %precision %i
+            Out[4]: '%i'
         
             In [5]: pi
             Out[5]: 3
         
             In [6]: %precision %e
+            Out[6]: '%e'
         
             In [7]: pi**10
             Out[7]: 9.364805e+04
         
             In [8]: %precision
+            Out[8]: '%r'
         
             In [9]: pi**10
             Out[9]: 93648.047476082982
         
         """
         
-        if '%' in s:
-            # got explicit format string
-            fmt = s
-            try:
-                fmt%3.14159
-            except Exception:
-                raise ValueError("Precision must be int or format string, not %r"%s)
-        elif s:
-            # otherwise, should be an int
-            try:
-                i = int(s)
-                assert i >= 0
-            except (ValueError, AssertionError):
-                raise ValueError("Precision must be non-negative int or format string, not %r"%s)
-            
-            fmt = '%%.%if'%i
-            if 'numpy' in sys.modules:
-                import numpy
-                numpy.set_printoptions(precision=i)
-        else:
-            # default back to repr
-            fmt = '%r'
-            if 'numpy' in sys.modules:
-                import numpy
-                # numpy default is 8
-                numpy.set_printoptions(precision=8)
-        
-        def _pretty_float(obj,p,cycle):
-            p.text(fmt%obj)
-        
         ptformatter = self.shell.display_formatter.formatters['text/plain']
-        ptformatter.for_type(float, _pretty_float)
+        ptformatter.float_precision = s
+        return ptformatter.float_format
 
 # end Magic

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -3459,5 +3459,77 @@ Defaulting color scheme to 'NoColor'"""
 
         See %xmode for changing exception reporting modes."""
         self.shell.showtraceback()
+    
+    @testdec.skip_doctest
+    def magic_precision(self, s=''):
+        """Set floating point precision for pretty printing.
+        
+        Can set either integer precision or a format string.
+        
+        If numpy has been imported and precision is an int,
+        numpy display precision will also be set, via ``numpy.set_printoptions``.
+        
+        If no argument is given, defaults will be restored.
+        
+        Examples
+        --------
+        ::
+        
+            In [1]: from math import pi
+        
+            In [2]: %precision 3
+        
+            In [3]: pi
+            Out[3]: 3.142
+        
+            In [4]: %precision %i
+        
+            In [5]: pi
+            Out[5]: 3
+        
+            In [6]: %precision %e
+        
+            In [7]: pi**10
+            Out[7]: 9.364805e+04
+        
+            In [8]: %precision
+        
+            In [9]: pi**10
+            Out[9]: 93648.047476082982
+        
+        """
+        
+        if '%' in s:
+            # got explicit format string
+            fmt = s
+            try:
+                fmt%3.14159
+            except:
+                raise TypeError("Precision must be int or format string, not %r"%s)
+        elif s:
+            # otherwise, should be an int
+            try:
+                i = int(s)
+                assert i >= 0
+            except:
+                raise TypeError("Precision must be non-negative int or format string, not %r"%s)
+            
+            fmt = '%%.%if'%i
+            if 'numpy' in sys.modules:
+                import numpy
+                numpy.set_printoptions(precision=i)
+        else:
+            # default back to repr
+            fmt = '%r'
+            if 'numpy' in sys.modules:
+                import numpy
+                # numpy default is 8
+                numpy.set_printoptions(precision=8)
+        
+        def _pretty_float(obj,p,cycle):
+            p.text(fmt%obj)
+        
+        ptformatter = self.shell.display_formatter.formatters['text/plain']
+        ptformatter.for_type(float, _pretty_float)
 
 # end Magic

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -387,3 +387,22 @@ def doctest_who():
     In [7]: %who_ls
     Out[7]: ['alpha', 'beta']
     """
+
+def doctest_precision():
+    """doctest for %precision
+    
+    In [1]: f = get_ipython().shell.display_formatter.formatters['text/plain']
+    
+    In [2]: %precision 5
+    Out[2]: '%.5f'
+    
+    In [3]: f.float_format
+    Out[3]: '%.5f'
+    
+    In [4]: %precision %e
+    Out[4]: '%e'
+    
+    In [5]: f(3.1415927)
+    Out[5]: '3.141593e+00'
+    """
+


### PR DESCRIPTION
As requested in #190, this adds a magic `%precision`, which sets floating point precision for use in pretty printing.  Argument can be an integer or a raw format string. If it's an integer and numpy has been imported, numpy printing precision will also be set. If no argument is given, precision will be restored to defaults (repr for float, 8 for numpy).

Examples:

```
    In [1]: from math import pi

    In [2]: %precision 3

    In [3]: pi
    Out[3]: 3.142

    In [4]: %precision %i

    In [5]: pi
    Out[5]: 3

    In [6]: %precision %e

    In [7]: pi**10
    Out[7]: 9.364805e+04

    In [8]: %precision

    In [9]: pi**10
    Out[9]: 93648.047476082982
```
