### PR TITLE
SQLite history

### DIFF
--- a/IPython/config/default/ipython_config.py
+++ b/IPython/config/default/ipython_config.py
@@ -154,8 +154,8 @@ c = get_config()
 #-----------------------------------------------------------------------------
 
 # Enable logging output as well as input to the database.
-# c.HistoryManager.db_log_output = True
+# c.HistoryManager.db_log_output = False
 
-# Only write to the database every 40 commands - this can save disk access (and
-# hence power) over the default of writing on every command.
-# c.HistoryManager.db_cache_size = 40
+# Only write to the database every n commands - this can save disk
+# access (and hence power) over the default of writing on every command.
+# c.HistoryManager.db_cache_size = 0

--- a/IPython/config/default/ipython_config.py
+++ b/IPython/config/default/ipython_config.py
@@ -148,3 +148,14 @@ c = get_config()
 # c.AliasManager.user_aliases = [
 #     ('foo', 'echo Hi')
 # ]
+
+#-----------------------------------------------------------------------------
+# HistoryManager options
+#-----------------------------------------------------------------------------
+
+# Enable logging output as well as input to the database.
+# c.HistoryManager.db_log_output = True
+
+# Only write to the database every 40 commands - this can save disk access (and
+# hence power) over the default of writing on every command.
+# c.HistoryManager.db_cache_size = 40

--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -275,13 +275,15 @@ class DisplayHook(Configurable):
                 new_result = '_'+`self.prompt_count`
                 to_main[new_result] = result
                 self.shell.user_ns.update(to_main)
-                # This is a defaultdict of lists, so we can always append
-                self.shell.user_ns['_oh'][self.prompt_count].append(result)
+                self.shell.user_ns['_oh'][self.prompt_count] = result
 
     def log_output(self, format_dict):
         """Log the output."""
         if self.shell.logger.log_output:
             self.shell.logger.log_write(format_dict['text/plain'], 'output')
+        # This is a defaultdict of lists, so we can always append
+        self.shell.history_manager.output_hist_reprs[self.prompt_count]\
+                                    .append(format_dict['text/plain'])
 
     def finish_displayhook(self):
         """Finish up all displayhook activities."""

--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -275,16 +275,13 @@ class DisplayHook(Configurable):
                 new_result = '_'+`self.prompt_count`
                 to_main[new_result] = result
                 self.shell.user_ns.update(to_main)
-                self.shell.user_ns['_oh'][self.prompt_count] = result
+                # This is a defaultdict of lists, so we can always append
+                self.shell.user_ns['_oh'][self.prompt_count].append(result)
 
     def log_output(self, format_dict):
         """Log the output."""
         if self.shell.logger.log_output:
             self.shell.logger.log_write(format_dict['text/plain'], 'output')
-        # Write output to the database. Does nothing unless history
-        # output logging is enabled.
-        self.shell.history_manager.store_output(self.prompt_count,
-                                                format_dict['text/plain'])
 
     def finish_displayhook(self):
         """Finish up all displayhook activities."""

--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -277,10 +277,14 @@ class DisplayHook(Configurable):
                 self.shell.user_ns.update(to_main)
                 self.shell.user_ns['_oh'][self.prompt_count] = result
 
-    def log_output(self, result):
+    def log_output(self, format_dict):
         """Log the output."""
         if self.shell.logger.log_output:
-            self.shell.logger.log_write(repr(result), 'output')
+            self.shell.logger.log_write(format_dict['text/plain'], 'output')
+        # Write output to the database. Does nothing unless history
+        # output logging is enabled.
+        self.shell.history_manager.store_output(self.prompt_count,
+                                                format_dict['text/plain'])
 
     def finish_displayhook(self):
         """Finish up all displayhook activities."""
@@ -300,7 +304,7 @@ class DisplayHook(Configurable):
             format_dict = self.compute_format_data(result)
             self.write_format_data(format_dict)
             self.update_user_ns(result)
-            self.log_output(result)
+            self.log_output(format_dict)
             self.finish_displayhook()
 
     def flush(self):

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -157,6 +157,7 @@ class HistoryManager(Configurable):
     
     def get_hist_tail(self, n=10, raw=True, output=False):
         """Get the last n lines from the history database."""
+        self.writeout_cache()
         cur = self._get_hist_sql("ORDER BY session DESC, line DESC LIMIT ?",
                                 (n,), raw=raw, output=output)
         return reversed(list(cur))
@@ -172,6 +173,7 @@ class HistoryManager(Configurable):
         tosearch = "source_raw" if raw else "source"
         if output:
             tosearch = "history." + tosearch
+        self.writeout_cache()
         return self._get_hist_sql("WHERE %s GLOB ?" % tosearch, (pattern,),
                                     raw=raw, output=output)
                                 

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -308,8 +308,8 @@ class HistoryManager(Configurable):
         """
         if source_raw is None:
             source_raw = source
-        source = source.rstrip()
-        source_raw = source_raw.rstrip()
+        source = source.rstrip('\n')
+        source_raw = source_raw.rstrip('\n')
             
         # do not store exit/quit commands
         if source_raw.strip() in self._exit_commands:

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -630,18 +630,20 @@ def magic_rerun(self, parameter_s=''):
     opts, args = self.parse_options(parameter_s, 'l:g:', mode='string')
     if "l" in opts:         # Last n lines
         n = int(opts['l'])
-        hist = self.history_manager.get_hist_tail(n, raw=False)
+        hist = self.history_manager.get_hist_tail(n)
     elif "g" in opts:       # Search
         p = "*"+opts['g']+"*"
-        hist = self.history_manager.get_hist_search(p, raw=False)
-        hist = list(hist)
-        if 'magic("rerun' in hist[-1][2]:
-            hist = hist[:-1]   # We can ignore the current line
-        hist = hist[-1:]       # Just get the last match
+        hist = list(self.history_manager.get_hist_search(p))
+        for l in reversed(hist):
+            if "rerun" not in l[2]:
+                hist = [l]     # The last match which isn't a %rerun
+                break
+        else:
+            hist = []          # No matches except %rerun
     elif args:              # Specify history ranges
         hist = self.history_manager.get_hist_from_rangestr(args)
     else:                   # Last line
-        hist = self.history_manager.get_hist_tail(1, raw=False)
+        hist = self.history_manager.get_hist_tail(1)
     hist = [x[2] for x in hist]
     if not hist:
         print("No lines in history match specification")
@@ -650,7 +652,7 @@ def magic_rerun(self, parameter_s=''):
     print("=== Executing: ===")
     print(histlines)
     print("=== Output: ===")
-    self.run_source("\n".join(hist), symbol="exec")
+    self.run_cell("\n".join(hist), store_history=False)
 
 
 def init_ipython(ip):

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -453,15 +453,10 @@ def magic_history(self, parameter_s = ''):
             print('%s:%s' % (str(in_num).ljust(width), line_sep[multiline]),
                   file=outfile, end='')
         if pyprompts:
-            inline = ">>> " + inline
+            print(">>> ", end="", file=outfile)
             if multiline:
-                lines = inline.splitlines()
-                print('\n... '.join(lines), file=outfile)
-                print('... ', file=outfile)
-            else:
-                print(inline, file=outfile)
-        else:
-            print(inline, file=outfile)
+                inline = "\n... ".join(inline.splitlines()) + "\n..."
+        print(inline, file=outfile)
         if print_outputs and output:
             print(repr(output), file=outfile)
 

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -285,6 +285,8 @@ class HistoryManager(object):
         self.output_hist.clear()
         # The directory history can't be completely empty
         self.dir_hist[:] = [os.getcwd()]
+        # Reset session offset to -1, so next command counts as #1
+        self.session_offset = -1
 
 class HistorySaveThread(threading.Thread):
     """This thread makes IPython save history periodically.

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -135,7 +135,7 @@ class HistoryManager(Configurable):
           Parameters passed to the SQL query (to replace "?")
         raw : bool
           If True, get raw input.
-        output : 
+        output : bool
           If True, include output where available.
         
         Returns

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -66,8 +66,11 @@ class HistoryManager(object):
     # call).
     _exit_commands = None
     
-    def __init__(self, shell):
+    def __init__(self, shell, load_history=False):
         """Create a new history manager associated with a shell instance.
+        
+        If load_history is true, it will load the history from file and set the
+        session offset so that the next line typed can be retrieved as #1.
         """
         # We need a pointer back to the shell for various tasks.
         self.shell = shell
@@ -78,6 +81,9 @@ class HistoryManager(object):
         # pre-processing.  This will allow users to retrieve the input just as
         # it was exactly typed in by the user, with %hist -r.
         self.input_hist_raw = []
+        
+        # Offset so the first line of the current session is #1
+        self.session_offset = -1
 
         # list of visited directories
         try:
@@ -105,8 +111,9 @@ class HistoryManager(object):
 
         # Object is fully initialized, we can now call methods on it.
         
-        # Fill the history zero entry, user counter starts at 1
-        self.store_inputs('\n', '\n')
+        if load_history:
+            self.reload_history()
+            self.session_offset = len(self.input_hist_raw) -1
         
         # Create and start the autosaver.
         self.autosave_flag = threading.Event()
@@ -115,6 +122,7 @@ class HistoryManager(object):
         # Register the autosave handler to be triggered as a post execute
         # callback.
         self.shell.register_post_execute(self.autosave_if_due)
+        
 
     def _init_shadow_hist(self):
         try:
@@ -181,7 +189,7 @@ class HistoryManager(object):
         Parameters
         ----------
         index : n or (n1, n2) or None
-            If n, then the last entries. If a tuple, then all in
+            If n, then the last n entries. If a tuple, then all in
             range(n1, n2). If None, then all entries. Raises IndexError if
             the format of index is incorrect.
         raw : bool
@@ -193,8 +201,7 @@ class HistoryManager(object):
         -------
         If output is True, then return a dict of tuples, keyed by the prompt
         numbers and with values of (input, output). If output is False, then
-        a dict, keyed by the prompt number with the values of input. Raises
-        IndexError if no history is found.
+        a dict, keyed by the prompt number with the values of input.
         """
         if raw:
             input_hist = self.input_hist_raw
@@ -202,24 +209,25 @@ class HistoryManager(object):
             input_hist = self.input_hist_parsed
         if output:
             output_hist = self.output_hist
+            
         n = len(input_hist)
+        offset = self.session_offset
         if index is None:
-            start=0; stop=n
+            start=offset+1; stop=n
         elif isinstance(index, int):
             start=n-index; stop=n
-        elif isinstance(index, tuple) and len(index) == 2:
-            start=index[0]; stop=index[1]
+        elif len(index) == 2:
+            start = index[0] + offset
+            stop = index[1] + offset
         else:
             raise IndexError('Not a valid index for the input history: %r'
                              % index)
         hist = {}
         for i in range(start, stop):
             if output:
-                hist[i] = (input_hist[i], output_hist.get(i))
+                hist[i-offset] = (input_hist[i], output_hist.get(i-offset))
             else:
-                hist[i] = input_hist[i]
-        if not hist:
-            raise IndexError('No history for range of indices: %r' % index)
+                hist[i-offset] = input_hist[i]
         return hist
 
     def store_inputs(self, source, source_raw=None):
@@ -364,6 +372,9 @@ def magic_history(self, parameter_s = ''):
         print('This feature is only available if numbered prompts are in use.')
         return
     opts,args = self.parse_options(parameter_s,'gnoptsrf:',mode='list')
+    
+    # For brevity
+    history_manager = self.shell.history_manager
 
     # Check if output to specific file was requested.
     try:
@@ -380,47 +391,41 @@ def magic_history(self, parameter_s = ''):
 
         outfile = open(outfname,'w')
         close_at_end = True
-
-    if 't' in opts:
-        input_hist = self.shell.history_manager.input_hist_parsed
-    elif 'r' in opts:
-        input_hist = self.shell.history_manager.input_hist_raw
-    else:
-        # Raw history is the default
-        input_hist = self.shell.history_manager.input_hist_raw
+    
+    print_nums = 'n' in opts
+    print_outputs = 'o' in opts
+    pyprompts = 'p' in opts
+    # Raw history is the default
+    raw = not('t' in opts)
             
     default_length = 40
     pattern = None
     if 'g' in opts:
-        init = 1
-        final = len(input_hist)
+        index = None
         parts = parameter_s.split(None, 1)
         if len(parts) == 1:
             parts += '*'
         head, pattern = parts
         pattern = "*" + pattern + "*"
     elif len(args) == 0:
-        final = len(input_hist)-1
-        init = max(1,final-default_length)
+        index = None
     elif len(args) == 1:
-        final = len(input_hist)
-        init = max(1, final-int(args[0]))
+        index = int(args[0])
     elif len(args) == 2:
-        init, final = map(int, args)
+        index = map(int, args)
     else:
         warn('%hist takes 0, 1 or 2 arguments separated by spaces.')
         print(self.magic_hist.__doc__, file=IPython.utils.io.Term.cout)
         return
+        
+    hist = history_manager.get_history(index, raw, print_outputs)
     
-    width = len(str(final))
+    width = len(str(max(hist.iterkeys())))
     line_sep = ['','\n']
-    print_nums = 'n' in opts
-    print_outputs = 'o' in opts
-    pyprompts = 'p' in opts
     
     found = False
     if pattern is not None:
-        sh = self.shell.history_manager.shadowhist.all()
+        sh = history_manager.shadow_hist.all()
         for idx, s in sh:
             if fnmatch.fnmatch(s, pattern):
                 print("0%d: %s" %(idx, s.expandtabs(4)), file=outfile)
@@ -432,41 +437,39 @@ def magic_history(self, parameter_s = ''):
               file=outfile)
         print("=== start of normal history ===", file=outfile)
         
-    for in_num in range(init, final):
+    for in_num, inline in sorted(hist.iteritems()):
         # Print user history with tabs expanded to 4 spaces.  The GUI clients
         # use hard tabs for easier usability in auto-indented code, but we want
         # to produce PEP-8 compliant history for safe pasting into an editor.
-        inline = input_hist[in_num].expandtabs(4).rstrip()+'\n'
+        if print_outputs:
+            inline, output = inline
+        inline = inline.expandtabs(4).rstrip()
 
         if pattern is not None and not fnmatch.fnmatch(inline, pattern):
             continue
             
-        multiline = int(inline.count('\n') > 1)
+        multiline = "\n" in inline
         if print_nums:
             print('%s:%s' % (str(in_num).ljust(width), line_sep[multiline]),
-                  file=outfile)
+                  file=outfile, end='')
         if pyprompts:
-            print('>>>', file=outfile)
+            inline = ">>> " + inline
             if multiline:
                 lines = inline.splitlines()
                 print('\n... '.join(lines), file=outfile)
                 print('... ', file=outfile)
             else:
-                print(inline, end='', file=outfile)
+                print(inline, file=outfile)
         else:
-            print(inline, end='', file=outfile)
-        if print_outputs:
-            output = self.shell.history_manager.output_hist.get(in_num)
-            if output is not None:
-                print(repr(output), file=outfile)
+            print(inline, file=outfile)
+        if print_outputs and output:
+            print(repr(output), file=outfile)
 
     if close_at_end:
         outfile.close()
 
-
-def magic_hist(self, parameter_s=''):
-    """Alternate name for %history."""
-    return self.magic_history(parameter_s)
+# %hist is an alternative name
+magic_hist = magic_history
 
 
 def rep_f(self, arg):

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -186,7 +186,7 @@ class HistoryManager(object):
             if self.shell.has_readline:
                 self.populate_readline_history()
         
-    def get_history(self, index=None, raw=False, output=True):
+    def get_history(self, index=None, raw=False, output=True,this_session=True):
         """Get the history list.
 
         Get the input and output history.
@@ -201,6 +201,9 @@ class HistoryManager(object):
             If True, return the raw input.
         output : bool
             If True, then return the output as well.
+        this_session : bool
+            If True, indexing is from 1 at the start of this session.
+            If False, indexing is from 1 at the start of the whole history.
 
         Returns
         -------
@@ -214,9 +217,13 @@ class HistoryManager(object):
             input_hist = self.input_hist_parsed
         if output:
             output_hist = self.output_hist
+        
+        if this_session:
+            offset = self.session_offset
+        else:
+            offset = -1
             
         n = len(input_hist)
-        offset = self.session_offset
         if index is None:
             start=offset+1; stop=n
         elif isinstance(index, int):

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -55,6 +55,10 @@ class HistoryManager(object):
     # ShadowHist instance with the actual shadow history
     shadow_hist = None
     
+    # Offset so the first line of the current session is #1. Can be
+    # updated after loading history from file.
+    session_offset = -1
+    
     # Private interface
     # Variables used to store the three last inputs from the user.  On each new
     # history update, we populate the user's namespace with these, shifted as
@@ -69,8 +73,12 @@ class HistoryManager(object):
     def __init__(self, shell, load_history=False):
         """Create a new history manager associated with a shell instance.
         
-        If load_history is true, it will load the history from file and set the
-        session offset so that the next line typed can be retrieved as #1.
+        Parameters
+        ----------
+        load_history: bool, optional
+            If True, history will be loaded from file, and the session
+            offset set, so that the next line entered can be retrieved
+            as #1.
         """
         # We need a pointer back to the shell for various tasks.
         self.shell = shell
@@ -81,9 +89,6 @@ class HistoryManager(object):
         # pre-processing.  This will allow users to retrieve the input just as
         # it was exactly typed in by the user, with %hist -r.
         self.input_hist_raw = []
-        
-        # Offset so the first line of the current session is #1
-        self.session_offset = -1
 
         # list of visited directories
         try:

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1550,7 +1550,7 @@ class InteractiveShell(Configurable, Magic):
             readline.set_history_length(self.history_length)
             
             # Load the last 1000 lines from history
-            for _, _, cell in self.history_manager.get_hist_tail(1000,
+            for _, _, cell in self.history_manager.get_tail(1000,
                                                 include_latest=True):
                 if cell.strip(): # Ignore blank lines
                     for line in cell.splitlines():

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2060,7 +2060,7 @@ class InteractiveShell(Configurable, Magic):
                 self.showtraceback()
                 warn('Unknown failure executing file: <%s>' % fname)
 
-    def run_cell(self, cell):
+    def run_cell(self, cell, store_history=True):
         """Run the contents of an entire multiline 'cell' of code, and store it
         in the history.
 
@@ -2111,7 +2111,9 @@ class InteractiveShell(Configurable, Magic):
         cell = ''.join(blocks)
 
         # Store raw and processed history
-        self.history_manager.store_inputs(self.execution_count, cell, raw_cell)
+        if store_history:
+            self.history_manager.store_inputs(self.execution_count, 
+                                                        cell, raw_cell)
 
         self.logger.log(cell, raw_cell)
 
@@ -2123,9 +2125,10 @@ class InteractiveShell(Configurable, Magic):
                 out = self.run_source(blocks[0])
                 # Write output to the database. Does nothing unless
                 # history output logging is enabled.
-                self.history_manager.store_output(self.execution_count)
-                # since we return here, we need to update the execution count
-                self.execution_count += 1
+                if store_history:
+                    self.history_manager.store_output(self.execution_count)
+                    # since we return here, we need to update the execution count
+                    self.execution_count += 1
                 return out
 
             # In multi-block input, if the last block is a simple (one-two
@@ -2154,9 +2157,10 @@ class InteractiveShell(Configurable, Magic):
 
         # Write output to the database. Does nothing unless
         # history output logging is enabled.
-        self.history_manager.store_output(self.execution_count)
-        # Each cell is a *single* input, regardless of how many lines it has
-        self.execution_count += 1
+        if store_history:
+            self.history_manager.store_output(self.execution_count)
+            # Each cell is a *single* input, regardless of how many lines it has
+            self.execution_count += 1
 
     # PENDING REMOVAL: this method is slated for deletion, once our new
     # input logic has been 100% moved to frontends and is stable.

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1277,8 +1277,8 @@ class InteractiveShell(Configurable, Magic):
                 self.reload_history()
         return wrapper
     
-    def get_history(self, index=None, raw=False, output=True):
-        return self.history_manager.get_history(index, raw, output)
+    def get_history(self, index=None, raw=False, output=True,this_session=True):
+        return self.history_manager.get_history(index, raw, output,this_session)
     
 
     #-------------------------------------------------------------------------

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1551,7 +1551,7 @@ class InteractiveShell(Configurable, Magic):
             readline.set_history_length(self.history_length)
             
             # Load the last 1000 lines from history
-            for cell in self.history_manager.tail_db_history(1000):
+            for _, _, cell in self.history_manager.get_hist_tail(1000):
                 if cell.strip(): # Ignore blank lines
                     for line in cell.splitlines():
                         readline.add_history(line)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1550,7 +1550,8 @@ class InteractiveShell(Configurable, Magic):
             readline.set_history_length(self.history_length)
             
             # Load the last 1000 lines from history
-            for _, _, cell in self.history_manager.get_hist_tail(1000):
+            for _, _, cell in self.history_manager.get_hist_tail(1000,
+                                                include_latest=True):
                 if cell.strip(): # Ignore blank lines
                     for line in cell.splitlines():
                         readline.add_history(line)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2526,10 +2526,10 @@ class InteractiveShell(Configurable, Magic):
                 os.unlink(tfile)
             except OSError:
                 pass
-                
-        # Write anything in the history cache to the database.
-        self.history_manager.writeout_cache()
-
+        
+        # Close the history session (this stores the end time and line count)
+        self.history_manager.end_session()
+        
         # Clear all user namespaces to release all references cleanly.
         self.reset(new_session=False)
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1248,7 +1248,7 @@ class InteractiveShell(Configurable, Magic):
 
     def init_history(self):
         """Sets up the command history, and starts regular autosaves."""
-        self.history_manager = HistoryManager(shell=self)
+        self.history_manager = HistoryManager(shell=self, load_history=True)
 
     def save_history(self):
         """Save input history to a file (via readline library)."""
@@ -1560,11 +1560,8 @@ class InteractiveShell(Configurable, Magic):
             readline.set_completer_delims(delims)
             # otherwise we end up with a monster history after a while:
             readline.set_history_length(self.history_length)
-            try:
-                #print '*** Reading readline history'  # dbg
-                self.reload_history() 
-            except IOError:
-                pass  # It doesn't exist yet.
+            
+            self.history_manager.populate_readline_history()
 
         # Configure auto-indent for all platforms
         self.set_autoindent(self.autoindent)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1245,7 +1245,7 @@ class InteractiveShell(Configurable, Magic):
 
     def init_history(self):
         """Sets up the command history, and starts regular autosaves."""
-        self.history_manager = HistoryManager(shell=self)
+        self.history_manager = HistoryManager(shell=self, config=self.config)
 
     def history_saving_wrapper(self, func):
         """ Wrap func for readline history saving

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2100,7 +2100,7 @@ class InteractiveShell(Configurable, Magic):
         ipy_cell = ''.join(blocks)
 
         # Store raw and processed history
-        self.history_manager.store_inputs(ipy_cell, cell)
+        self.history_manager.store_inputs(self.execution_count, ipy_cell, cell)
 
         self.logger.log(ipy_cell, cell)
 
@@ -2390,8 +2390,8 @@ class InteractiveShell(Configurable, Magic):
         full_source = '\n'.join(self.buffer)
         more = self.run_source(full_source, self.filename)
         if not more:
-            self.history_manager.store_inputs('\n'.join(self.buffer_raw),
-                                              full_source)
+            self.history_manager.store_inputs(self.execution_count,
+                                        '\n'.join(self.buffer_raw), full_source)
             self.reset_buffer()
             self.execution_count += 1
         return more

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -990,14 +990,16 @@ class InteractiveShell(Configurable, Magic):
         # Finally, update the real user's namespace
         self.user_ns.update(ns)
 
-    def reset(self):
+    def reset(self, new_session=True):
         """Clear all internal namespaces.
 
         Note that this is much more aggressive than %reset, since it clears
         fully all namespaces, as well as all input/output lists.
+        
+        If new_session is True, a new history session will be opened.
         """
         # Clear histories
-        self.history_manager.reset()
+        self.history_manager.reset(new_session)
 
         # Reset counter used to index all histories
         self.execution_count = 0
@@ -1265,9 +1267,6 @@ class InteractiveShell(Configurable, Magic):
             finally:
                 self.reload_history()
         return wrapper
-    
-    def get_history(self, start=1, stop=None, raw=False, output=True):
-        return self.history_manager.get_history(start, stop, raw, output)
     
 
     #-------------------------------------------------------------------------
@@ -2194,8 +2193,8 @@ class InteractiveShell(Configurable, Magic):
         magic calls (%magic), special shell access (!cmd), etc.
         """
         
-        if isinstance(lines, (list, tuple)):
-            lines = '\n'.join(lines)
+        if not isinstance(lines, (list, tuple)):
+            lines = lines.splitlines()
 
         if clean:
             lines = self._cleanup_ipy_script(lines)
@@ -2203,7 +2202,6 @@ class InteractiveShell(Configurable, Magic):
         # We must start with a clean buffer, in case this is run from an
         # interactive IPython session (via a magic, for example).
         self.reset_buffer()
-        lines = lines.splitlines()
 
         # Since we will prefilter all lines, store the user's raw input too
         # before we apply any transformations
@@ -2533,7 +2531,7 @@ class InteractiveShell(Configurable, Magic):
         self.history_manager.writeout_cache()
 
         # Clear all user namespaces to release all references cleanly.
-        self.reset()
+        self.reset(new_session=False)
 
         # Run user hooks
         self.hooks.shutdown_hook()

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2528,6 +2528,9 @@ class InteractiveShell(Configurable, Magic):
                 os.unlink(tfile)
             except OSError:
                 pass
+                
+        # Write anything in the history cache to the database.
+        self.history_manager.writeout_cache()
 
         # Clear all user namespaces to release all references cleanly.
         self.reset()

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2119,8 +2119,11 @@ class InteractiveShell(Configurable, Magic):
 
             # Single-block input should behave like an interactive prompt
             if len(blocks) == 1:
-                # since we return here, we need to update the execution count
                 out = self.run_source(blocks[0])
+                # Write output to the database. Does nothing unless
+                # history output logging is enabled.
+                self.history_manager.store_output(self.execution_count)
+                # since we return here, we need to update the execution count
                 self.execution_count += 1
                 return out
 
@@ -2148,6 +2151,9 @@ class InteractiveShell(Configurable, Magic):
                 # processed input in history
                 self.run_source(ipy_cell, symbol='exec')
 
+        # Write output to the database. Does nothing unless
+        # history output logging is enabled.
+        self.history_manager.store_output(self.execution_count)
         # Each cell is a *single* input, regardless of how many lines it has
         self.execution_count += 1
 

--- a/IPython/core/macro.py
+++ b/IPython/core/macro.py
@@ -21,7 +21,7 @@ class Macro(IPyAutocall):
 
     def __init__(self,data):
         """store the macro value, as a single string which can be executed"""
-        self.value = ''.join(data).rstrip()+'\n'
+        self.value = '\n'.join(data).rstrip()+'\n'
         
     def __str__(self):
         return self.value

--- a/IPython/core/macro.py
+++ b/IPython/core/macro.py
@@ -8,9 +8,8 @@
 #*****************************************************************************
 
 import IPython.utils.io
-from IPython.core.autocall import IPyAutocall
 
-class Macro(IPyAutocall):
+class Macro(object):
     """Simple class to store the value of macros as strings.
 
     Macro is just a callable that executes a string of IPython
@@ -28,11 +27,6 @@ class Macro(IPyAutocall):
 
     def __repr__(self):
         return 'IPython.macro.Macro(%s)' % repr(self.value)
-    
-    def __call__(self,*args):
-        IPython.utils.io.Term.cout.flush()
-        self._ip.user_ns['_margv'] = args
-        self._ip.run_cell(self.value)
     
     def __getstate__(self):
         """ needed for safe pickling via %store """

--- a/IPython/core/macro.py
+++ b/IPython/core/macro.py
@@ -19,9 +19,9 @@ class Macro(IPyAutocall):
     Args to macro are available in _margv list if you need them.
     """
 
-    def __init__(self,data):
+    def __init__(self,code):
         """store the macro value, as a single string which can be executed"""
-        self.value = '\n'.join(data).rstrip()+'\n'
+        self.value = code.rstrip()+'\n'
         
     def __str__(self):
         return self.value

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -171,8 +171,8 @@ python-profiler package from non-free.""")
         Inputs:
 
           - range_str: the set of slices is given as a string, like 
-          "~5#6-~4#2 4:8 9", since this function is for use by magic functions
-          which get their arguments as strings. The number before the # is the
+          "~5/6-~4/2 4:8 9", since this function is for use by magic functions
+          which get their arguments as strings. The number before the / is the
           session number: ~n goes n back from the current session.
 
         Optional inputs:

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -184,11 +184,7 @@ python-profiler package from non-free.""")
         N:M -> standard python form, means including items N...(M-1).
 
         N-M -> include items N..M (closed endpoint)."""
-
-        if raw:
-            hist = self.shell.history_manager.input_hist_raw
-        else:
-            hist = self.shell.history_manager.input_hist_parsed
+        history_manager = self.shell.history_manager
 
         cmds = []
         for chunk in slices:
@@ -200,7 +196,8 @@ python-profiler package from non-free.""")
             else:
                 ini = int(chunk)
                 fin = ini+1
-            cmds.append('\n'.join(hist[ini:fin]))
+            hist = history_manager.get_history((ini,fin), raw=raw, output=False)
+            cmds.append('\n'.join(hist[i] for i in sorted(hist.iterkeys())))
         return cmds
             
     def arg_err(self,func):
@@ -2044,7 +2041,7 @@ Currently the magic system has the following functions:\n"""
         
         #print 'rng',ranges  # dbg
         lines = self.extract_input_slices(ranges,opts.has_key('r'))
-        macro = Macro(lines)
+        macro = Macro("\n".join(lines))
         self.shell.define_macro(name, macro)
         print 'Macro `%s` created. To execute, type its name (without quotes).' % name
         print 'Macro contents:'
@@ -2294,7 +2291,7 @@ Currently the magic system has the following functions:\n"""
             # This means that you can't edit files whose names begin with
             # numbers this way. Tough.
             ranges = args.split()
-            data = ''.join(self.extract_input_slices(ranges,opts_r))
+            data = '\n'.join(self.extract_input_slices(ranges,opts_r))
         elif args.endswith('.py'):
             filename = make_filename(args)
             data = ''

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -57,7 +57,7 @@ import IPython.utils.io
 from IPython.utils.path import get_py_filename
 from IPython.utils.process import arg_split, abbrev_cwd
 from IPython.utils.terminal import set_term_title
-from IPython.utils.text import LSString, SList, StringTypes, format_screen
+from IPython.utils.text import LSString, SList, format_screen
 from IPython.utils.timing import clock, clock2
 from IPython.utils.warn import warn, error
 from IPython.utils.ipstruct import Struct
@@ -2284,9 +2284,10 @@ Currently the magic system has the following functions:\n"""
 
         # by default this is done with temp files, except when the given
         # arg is a filename
-        use_temp = 1
+        use_temp = True
 
-        if re.match(r'\d',args):
+        data = ''
+        if args[0].isdigit():
             # Mode where user specifies ranges of lines, like in %macro.
             # This means that you can't edit files whose names begin with
             # numbers this way. Tough.
@@ -2294,16 +2295,15 @@ Currently the magic system has the following functions:\n"""
             data = '\n'.join(self.extract_input_slices(ranges,opts_r))
         elif args.endswith('.py'):
             filename = make_filename(args)
-            data = ''
-            use_temp = 0
+            use_temp = False
         elif args:
             try:
                 # Load the parameter given as a variable. If not a string,
                 # process it as an object instead (below)
 
                 #print '*** args',args,'type',type(args)  # dbg
-                data = eval(args,self.shell.user_ns)
-                if not type(data) in StringTypes:
+                data = eval(args, self.shell.user_ns)
+                if not isinstance(data, basestring):
                     raise DataIsObject
 
             except (NameError,SyntaxError):
@@ -2313,13 +2313,11 @@ Currently the magic system has the following functions:\n"""
                     warn("Argument given (%s) can't be found as a variable "
                          "or as a filename." % args)
                     return
-
-                data = ''
-                use_temp = 0
+                use_temp = False
+            
             except DataIsObject:
-
                 # macros have a special edit function
-                if isinstance(data,Macro):
+                if isinstance(data, Macro):
                     self._edit_macro(args,data)
                     return
                                 
@@ -2358,9 +2356,7 @@ Currently the magic system has the following functions:\n"""
                             warn('The file `%s` where `%s` was defined cannot '
                                  'be read.' % (filename,data))
                             return
-                use_temp = 0
-        else:
-            data = ''
+                use_temp = False
 
         if use_temp:
             filename = self.shell.mktempfile(data)
@@ -2383,7 +2379,7 @@ Currently the magic system has the following functions:\n"""
         if args.strip() == 'pasted_block':
             self.shell.user_ns['pasted_block'] = file_read(filename)
         
-        if opts.has_key('x'):  # -x prevents actual execution
+        if 'x' in opts:  # -x prevents actual execution
             print
         else:
             print 'done. Executing edited code...'

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -3029,38 +3029,6 @@ Defaulting color scheme to 'NoColor'"""
         if parameter_s:
             return self.shell.getoutput(parameter_s)
 
-    def magic_r(self, parameter_s=''):
-        """Repeat previous input.
-
-        Note: Consider using the more powerfull %rep instead!
-        
-        If given an argument, repeats the previous command which starts with
-        the same string, otherwise it just repeats the previous input.
-
-        Shell escaped commands (with ! as first character) are not recognized
-        by this system, only pure python code and magic commands.
-        """
-
-        start = parameter_s.strip()
-        esc_magic = ESC_MAGIC
-        # Identify magic commands even if automagic is on (which means
-        # the in-memory version is different from that typed by the user).
-        if self.shell.automagic:
-            start_magic = esc_magic+start
-        else:
-            start_magic = start
-        # Look through the input history in reverse
-        for n in range(len(self.shell.history_manager.input_hist_parsed)-2,0,-1):
-            input = self.shell.history_manager.input_hist_parsed[n]
-            # skip plain 'r' lines so we don't recurse to infinity
-            if input != '_ip.magic("r")\n' and \
-                   (input.startswith(start) or input.startswith(start_magic)):
-                #print 'match',`input`  # dbg
-                print 'Executing:',input,
-                self.shell.run_cell(input)
-                return
-        print 'No previous input matching `%s` found.' % start
-
     
     def magic_bookmark(self, parameter_s=''):
         """Manage IPython's bookmark system.

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -200,7 +200,7 @@ python-profiler package from non-free.""")
             else:
                 ini = int(chunk)
                 fin = ini+1
-            cmds.append(''.join(hist[ini:fin]))
+            cmds.append('\n'.join(hist[ini:fin]))
         return cmds
             
     def arg_err(self,func):
@@ -2079,10 +2079,9 @@ Currently the magic system has the following functions:\n"""
             if ans.lower() not in ['y','yes']:
                 print 'Operation cancelled.'
                 return
-        cmds = ''.join(self.extract_input_slices(ranges,opts.has_key('r')))
-        f = file(fname,'w')
-        f.write(cmds)
-        f.close()
+        cmds = '\n'.join(self.extract_input_slices(ranges,opts.has_key('r')))
+        with open(fname,'w') as f:
+            f.write(cmds)
         print 'The following commands were written to file `%s`:' % fname
         print cmds
 

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -186,7 +186,7 @@ python-profiler package from non-free.""")
 
         N-M -> include items N..M (closed endpoint)."""
         lines = self.shell.history_manager.\
-                                    get_hist_from_rangestr(range_str, raw=raw)
+                                    get_range_by_str(range_str, raw=raw)
         return "\n".join(x for _, _, x in lines)
             
     def arg_err(self,func):
@@ -1976,9 +1976,7 @@ Currently the magic system has the following functions:\n"""
         you had typed them. You just type 'name' at the prompt and the code
         executes.
 
-        The notation for indicating number ranges is: n1-n2 means 'use line
-        numbers n1,...n2' (the endpoint is included).  That is, '5-7' means
-        using the lines numbered 5,6 and 7.
+        The syntax for indicating input ranges is described in %history.
 
         Note: as a 'hidden' feature, you can also use traditional python slice
         notation, where N:M means numbers N through M-1.
@@ -2048,9 +2046,8 @@ Currently the magic system has the following functions:\n"""
           Python.  If this option is given, the raw input as typed as the
           command line is used instead.
 
-        This function uses the same syntax as %macro for line extraction, but
-        instead of creating a macro it saves the resulting string to the
-        filename you specify.
+        This function uses the same syntax as %history for input ranges, 
+        then saves the lines to the filename you specify.
 
         It adds a '.py' extension to the file if you don't do so yourself, and
         it asks for confirmation before overwriting existing files."""
@@ -2138,15 +2135,17 @@ Currently the magic system has the following functions:\n"""
         Arguments:
 
         If arguments are given, the following possibilites exist:
+        
+        - If the argument is a filename, IPython will load that into the
+        editor. It will execute its contents with execfile() when you exit,
+        loading any code in the file into your interactive namespace.
 
-        - The arguments are numbers or pairs of colon-separated numbers (like
-        1 4:8 9). These are interpreted as lines of previous input to be
-        loaded into the editor. The syntax is the same of the %macro command.
+        - The arguments are ranges of input history,  e.g. "7 ~1/4-6".
+        The syntax is the same as in the %history magic.
 
-        - If the argument doesn't start with a number, it is evaluated as a
-        variable and its contents loaded into the editor. You can thus edit
-        any string which contains python code (including the result of
-        previous edits).
+        - If the argument is a string variable, its contents are loaded
+        into the editor. You can thus edit any string which contains
+        python code (including the result of previous edits).
 
         - If the argument is the name of an object (other than a string),
         IPython will try to locate the file where it was defined and open the
@@ -2162,11 +2161,6 @@ Currently the magic system has the following functions:\n"""
         editors (like kedit and gedit up to Gnome 2.8) do not understand the
         '+NUMBER' parameter necessary for this feature. Good editors like
         (X)Emacs, vi, jed, pico and joe all do.
-
-        - If the argument is not found as a variable, IPython will look for a
-        file with that name (adding .py if necessary) and load it into the
-        editor. It will execute its contents with execfile() when you exit,
-        loading any code in the file into your interactive namespace.
 
         After executing your code, %edit will return as output the code you
         typed in the editor (except when it was an existing file). This way

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2030,17 +2030,16 @@ Currently the magic system has the following functions:\n"""
           In [60]: exec In[44:48]+In[49]"""
 
         opts,args = self.parse_options(parameter_s,'r',mode='list')
-        if not args:
-            macs = [k for k,v in self.shell.user_ns.items() if isinstance(v, Macro)]
-            macs.sort()
-            return macs
+        if not args:   # List existing macros
+            return sorted(k for k,v in self.shell.user_ns.iteritems() if\
+                                                        isinstance(v, Macro))
         if len(args) == 1:
             raise UsageError(
                 "%macro insufficient args; usage '%macro name n1-n2 n3-4...")
         name,ranges = args[0], args[1:]
         
         #print 'rng',ranges  # dbg
-        lines = self.extract_input_slices(ranges,opts.has_key('r'))
+        lines = self.extract_input_slices(ranges,'r' in opts)
         macro = Macro("\n".join(lines))
         self.shell.define_macro(name, macro)
         print 'Macro `%s` created. To execute, type its name (without quotes).' % name
@@ -2076,7 +2075,7 @@ Currently the magic system has the following functions:\n"""
             if ans.lower() not in ['y','yes']:
                 print 'Operation cancelled.'
                 return
-        cmds = '\n'.join(self.extract_input_slices(ranges,opts.has_key('r')))
+        cmds = '\n'.join(self.extract_input_slices(ranges, 'r' in opts))
         with open(fname,'w') as f:
             f.write(cmds)
         print 'The following commands were written to file `%s`:' % fname

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2369,7 +2369,8 @@ Currently the magic system has the following functions:\n"""
         else:
             print 'done. Executing edited code...'
             if opts_raw:
-                self.shell.run_cell(file_read(filename))
+                self.shell.run_cell(file_read(filename),
+                                                    store_history=False)
             else:
                 self.shell.safe_execfile(filename,self.shell.user_ns,
                                          self.shell.user_ns)

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -1603,7 +1603,7 @@ Currently the magic system has the following functions:\n"""
         
         stats = None
         try:
-            self.shell.save_history()
+            #self.shell.save_history()
 
             if opts.has_key('p'):
                 stats = self.magic_prun('',0,opts,arg_lst,prog_ns)
@@ -1722,7 +1722,7 @@ Currently the magic system has the following functions:\n"""
                 # contained therein.
                 del sys.modules[main_mod_name]
 
-            self.shell.reload_history()
+            #self.shell.reload_history()
                 
         return stats
 

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -83,6 +83,11 @@ def test_history():
             ip.magic_save(testfilename + " ~1/1-3")
             testfile = open(testfilename, "r")
             nt.assert_equal(testfile.read(), "\n".join(hist))
+            
+            # Duplicate line numbers - check that it doesn't crash, and
+            # gets a new session
+            ip.history_manager.store_inputs(1, "rogue")
+            nt.assert_equal(ip.history_manager.session_number, 3)
         finally:
             # Restore history manager
             ip.history_manager = hist_manager_ori

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -52,14 +52,14 @@ def test_history():
             newcmds = ["z=5","class X(object):\n    pass", "k='p'"]
             for i, cmd in enumerate(newcmds, start=1):
                 ip.history_manager.store_inputs(i, cmd)
-            gothist = ip.history_manager.get_history(start=1, stop=4)
+            gothist = ip.history_manager.get_range(start=1, stop=4)
             nt.assert_equal(list(gothist), zip([0,0,0],[1,2,3], newcmds))
             # Previous session:
-            gothist = ip.history_manager.get_history(-1, 1, 4)
+            gothist = ip.history_manager.get_range(-1, 1, 4)
             nt.assert_equal(list(gothist), zip([1,1,1],[1,2,3], hist))
             
             # Check get_hist_tail
-            gothist = ip.history_manager.get_hist_tail(4, output=True,
+            gothist = ip.history_manager.get_tail(4, output=True,
                                                     include_latest=True)
             expected = [(1, 3, (hist[-1], ["spam"])),
                         (2, 1, (newcmds[0], None)),
@@ -67,15 +67,15 @@ def test_history():
                         (2, 3, (newcmds[2], None)),]
             nt.assert_equal(list(gothist), expected)
             
-            gothist = ip.history_manager.get_hist_tail(2)
+            gothist = ip.history_manager.get_tail(2)
             expected = [(2, 1, newcmds[0]),
                         (2, 2, newcmds[1])]
             nt.assert_equal(list(gothist), expected)
             
             # Check get_hist_search
-            gothist = ip.history_manager.get_hist_search("*test*")
+            gothist = ip.history_manager.search("*test*")
             nt.assert_equal(list(gothist), [(1,2,hist[1])] )
-            gothist = ip.history_manager.get_hist_search("b*", output=True)
+            gothist = ip.history_manager.search("b*", output=True)
             nt.assert_equal(list(gothist), [(1,3,(hist[2],["spam"]))] )
             
             # Cross testing: check that magic %save can get previous session.

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -59,11 +59,17 @@ def test_history():
             nt.assert_equal(list(gothist), zip([1,1,1],[1,2,3], hist))
             
             # Check get_hist_tail
-            gothist = ip.history_manager.get_hist_tail(4, output=True)
+            gothist = ip.history_manager.get_hist_tail(4, output=True,
+                                                    include_latest=True)
             expected = [(1, 3, (hist[-1], ["spam"])),
                         (2, 1, (newcmds[0], None)),
                         (2, 2, (newcmds[1], None)),
                         (2, 3, (newcmds[2], None)),]
+            nt.assert_equal(list(gothist), expected)
+            
+            gothist = ip.history_manager.get_hist_tail(2)
+            expected = [(2, 1, newcmds[0]),
+                        (2, 2, newcmds[1])]
             nt.assert_equal(list(gothist), expected)
             
             # Check get_hist_search
@@ -92,3 +98,12 @@ def test_extract_hist_ranges():
                 (-7, 1, 6)]
     actual = list(extract_hist_ranges(instr))
     nt.assert_equal(actual, expected)
+    
+def test_magic_rerun():
+    """Simple test for %rerun (no args -> rerun last line)"""
+    ip = get_ipython()
+    ip.run_cell("a = 10")
+    ip.run_cell("a += 1")
+    nt.assert_equal(ip.user_ns["a"], 11)
+    ip.run_cell("%rerun")
+    nt.assert_equal(ip.user_ns["a"], 12)

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -30,11 +30,11 @@ def test_history():
             ip.history_manager = HistoryManager(ip)
             ip.history_manager.hist_file = histfile
             print 'test',histfile
-            hist = ['a=1\n', 'def f():\n    test = 1\n    return test\n', 'b=2\n']
+            hist = ['a=1', 'def f():\n    test = 1\n    return test', 'b=2']
             # test save and load
             ip.history_manager.input_hist_raw[:] = []
             for h in hist:
-                ip.history_manager.input_hist_raw.append(h)
+                ip.history_manager.store_inputs(h)
             ip.save_history()
             ip.history_manager.input_hist_raw[:] = []
             ip.reload_history()
@@ -43,6 +43,23 @@ def test_history():
             nt.assert_equal(len(ip.history_manager.input_hist_raw), len(hist))
             for i,h in enumerate(hist):
                 nt.assert_equal(hist[i], ip.history_manager.input_hist_raw[i])
+              
+            # Test that session offset works.
+            ip.history_manager.session_offset = \
+                                    len(ip.history_manager.input_hist_raw) -1
+            newcmds = ["z=5","class X(object):\n    pass", "k='p'"]
+            for cmd in newcmds:
+                ip.history_manager.store_inputs(cmd)
+            gothist = ip.history_manager.get_history((1,4),
+                                                        raw=True, output=False)
+            nt.assert_equal(gothist, dict(zip([1,2,3], newcmds)))
+            
+            # Cross testing: check that magic %save picks up on the session
+            # offset.
+            testfilename = os.path.realpath(os.path.join(tmpdir, "test.py"))
+            ip.magic_save(testfilename + " 1-3")
+            testfile = open(testfilename, "r")
+            nt.assert_equal(testfile.read(), "\n".join(newcmds))
         finally:
             # Restore history manager
             ip.history_manager = hist_manager_ori

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -30,6 +30,7 @@ def test_history():
             ip.history_manager = HistoryManager(shell=ip)
             ip.history_manager.hist_file = histfile
             ip.history_manager.init_db()  # Has to be called after changing file
+            ip.history_manager.reset()
             print 'test',histfile
             hist = ['a=1', 'def f():\n    test = 1\n    return test', 'b=2']
             for i, h in enumerate(hist, start=1):

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -14,52 +14,61 @@ import nose.tools as nt
 
 # our own packages
 from IPython.utils.tempdir import TemporaryDirectory
-from IPython.core.history import HistoryManager
+from IPython.core.history import HistoryManager, extract_hist_ranges
 
 def test_history():
 
     ip = get_ipython()
     with TemporaryDirectory() as tmpdir:
         #tmpdir = '/software/temp'
-        histfile = os.path.realpath(os.path.join(tmpdir, 'history.json'))
+        histfile = os.path.realpath(os.path.join(tmpdir, 'history.sqlite'))
         # Ensure that we restore the history management that we mess with in
         # this test doesn't affect the IPython instance used by the test suite
         # beyond this test.
         hist_manager_ori = ip.history_manager
         try:
-            ip.history_manager = HistoryManager(ip)
+            ip.history_manager = HistoryManager(shell=ip)
             ip.history_manager.hist_file = histfile
+            ip.history_manager.init_db()  # Has to be called after changing file
             print 'test',histfile
             hist = ['a=1', 'def f():\n    test = 1\n    return test', 'b=2']
-            # test save and load
-            ip.history_manager.input_hist_raw[:] = []
-            for h in hist:
-                ip.history_manager.store_inputs(h)
-            ip.save_history()
-            ip.history_manager.input_hist_raw[:] = []
-            ip.reload_history()
-            print type(ip.history_manager.input_hist_raw)
-            print ip.history_manager.input_hist_raw
-            nt.assert_equal(len(ip.history_manager.input_hist_raw), len(hist))
-            for i,h in enumerate(hist):
-                nt.assert_equal(hist[i], ip.history_manager.input_hist_raw[i])
-              
-            # Test that session offset works.
-            ip.history_manager.session_offset = \
-                                    len(ip.history_manager.input_hist_raw) -1
-            newcmds = ["z=5","class X(object):\n    pass", "k='p'"]
-            for cmd in newcmds:
-                ip.history_manager.store_inputs(cmd)
-            gothist = ip.history_manager.get_history((1,4),
-                                                        raw=True, output=False)
-            nt.assert_equal(gothist, dict(zip([1,2,3], newcmds)))
+            for i, h in enumerate(hist, start=1):
+                ip.history_manager.store_inputs(i, h)
             
-            # Cross testing: check that magic %save picks up on the session
-            # offset.
+            nt.assert_equal(ip.history_manager.input_hist_raw, [''] + hist)
+            
+            # Check lines were written to DB
+            c = ip.history_manager.db.execute("SELECT source_raw FROM history")
+            nt.assert_equal([x for x, in c], hist)
+              
+            # New session
+            ip.history_manager.reset()
+            newcmds = ["z=5","class X(object):\n    pass", "k='p'"]
+            for i, cmd in enumerate(newcmds):
+                ip.history_manager.store_inputs(i, cmd)
+            gothist = ip.history_manager.get_history(start=1, stop=4)
+            nt.assert_equal(list(gothist), zip([0,0,0],[1,2,3], newcmds))
+            # Previous session:
+            gothist = ip.history_manager.get_history(-1, 1, 4)
+            nt.assert_equal(list(gothist), zip([1,1,1],[1,2,3], hist))
+            
+            # Cross testing: check that magic %save can get previous session.
             testfilename = os.path.realpath(os.path.join(tmpdir, "test.py"))
-            ip.magic_save(testfilename + " 1-3")
+            ip.magic_save(testfilename + " ~1/1-3")
             testfile = open(testfilename, "r")
-            nt.assert_equal(testfile.read(), "\n".join(newcmds))
+            nt.assert_equal(testfile.read(), "\n".join(hist))
         finally:
             # Restore history manager
             ip.history_manager = hist_manager_ori
+
+def test_extract_hist_ranges():
+    instr = "1 2/3 ~4/5-6 ~4/7-~4/9 ~9/2-~7/5"
+    expected = [(0, 1, 2),  # 0 == current session
+                (2, 3, 4),
+                (-4, 5, 7),
+                (-4, 7, 10),
+                (-9, 2, None),  # None == to end
+                (-8, 1, None),
+                (-7, 1, 6)]
+    actual = list(extract_hist_ranges(instr))
+    nt.assert_equal(actual, expected)

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -38,7 +38,7 @@ def test_history():
             
             ip.history_manager.db_log_output = True
             # Doesn't match the input, but we'll just check it's stored.
-            ip.history_manager.output_hist[3].append("spam")
+            ip.history_manager.output_hist_reprs[3].append("spam")
             ip.history_manager.store_output(3)
             
             nt.assert_equal(ip.history_manager.input_hist_raw, [''] + hist)
@@ -60,7 +60,7 @@ def test_history():
             
             # Check get_hist_tail
             gothist = ip.history_manager.get_hist_tail(4, output=True)
-            expected = [(1, 3, (hist[-1], [repr("spam")])),
+            expected = [(1, 3, (hist[-1], ["spam"])),
                         (2, 1, (newcmds[0], None)),
                         (2, 2, (newcmds[1], None)),
                         (2, 3, (newcmds[2], None)),]
@@ -70,7 +70,7 @@ def test_history():
             gothist = ip.history_manager.get_hist_search("*test*")
             nt.assert_equal(list(gothist), [(1,2,hist[1])] )
             gothist = ip.history_manager.get_hist_search("b*", output=True)
-            nt.assert_equal(list(gothist), [(1,3,(hist[2],[repr("spam")]))] )
+            nt.assert_equal(list(gothist), [(1,3,(hist[2],["spam"]))] )
             
             # Cross testing: check that magic %save can get previous session.
             testfilename = os.path.realpath(os.path.join(tmpdir, "test.py"))

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -38,7 +38,8 @@ def test_history():
             
             ip.history_manager.db_log_output = True
             # Doesn't match the input, but we'll just check it's stored.
-            ip.history_manager.store_output(3, "spam")
+            ip.history_manager.output_hist[3].append("spam")
+            ip.history_manager.store_output(3)
             
             nt.assert_equal(ip.history_manager.input_hist_raw, [''] + hist)
             
@@ -59,7 +60,7 @@ def test_history():
             
             # Check get_hist_tail
             gothist = ip.history_manager.get_hist_tail(4, output=True)
-            expected = [(1, 3, (hist[-1], "spam")),
+            expected = [(1, 3, (hist[-1], [repr("spam")])),
                         (2, 1, (newcmds[0], None)),
                         (2, 2, (newcmds[1], None)),
                         (2, 3, (newcmds[2], None)),]
@@ -69,7 +70,7 @@ def test_history():
             gothist = ip.history_manager.get_hist_search("*test*")
             nt.assert_equal(list(gothist), [(1,2,hist[1])] )
             gothist = ip.history_manager.get_hist_search("b*", output=True)
-            nt.assert_equal(list(gothist), [(1,3,(hist[2],"spam"))] )
+            nt.assert_equal(list(gothist), [(1,3,(hist[2],[repr("spam")]))] )
             
             # Cross testing: check that magic %save can get previous session.
             testfilename = os.path.realpath(os.path.join(tmpdir, "test.py"))

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -183,8 +183,8 @@ def test_macro():
     ip.magic("macro test 1-3")
     nt.assert_equal(ip.user_ns["test"].value, "\n".join(cmds)+"\n")
     
-    # List macros. This goes to stdout, so just check it doesn't crash.
-    ip.magic("macro")
+    # List macros.
+    assert "test" in ip.magic("macro")
 
     
 # XXX failing for now, until we get clearcmd out of quarantine.  But we should

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -163,8 +163,6 @@ def test_macro():
     # List macros.
     assert "test" in ip.magic("macro")
 
-# XXX This should be a doctest, but the doctest logic doesn't seem to do
-# dynamic transformations (like expanding macros). Doing it like this for now.
 def test_macro_run():
     """Test that we can run a multi-line macro successfully."""
     ip = get_ipython()

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -173,6 +173,18 @@ def test_shist():
     yield nt.assert_equal,s.get(2),'world'
     
     shutil.rmtree(tfile)
+    
+def test_macro():
+    ip = get_ipython()
+    ip.history_manager.reset()   # Clear any existing history.
+    cmds = ["a=1", "def b():\n  return a**2", "print(a,b())"]
+    for cmd in cmds:
+        ip.history_manager.store_inputs(cmd)
+    ip.magic("macro test 1-3")
+    nt.assert_equal(ip.user_ns["test"].value, "\n".join(cmds)+"\n")
+    
+    # List macros. This goes to stdout, so just check it doesn't crash.
+    ip.magic("macro")
 
     
 # XXX failing for now, until we get clearcmd out of quarantine.  But we should

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -62,7 +62,7 @@ def doctest_hist_f():
 
     In [10]: tfile = tempfile.mktemp('.py','tmp-ipython-')
 
-    In [11]: %hist -n -f $tfile 3
+    In [11]: %hist -nl -f $tfile 3
 
     In [13]: import os; os.unlink(tfile)
     """
@@ -80,7 +80,7 @@ def doctest_hist_r():
 
     In [2]: x=1
 
-    In [3]: %hist -r 2
+    In [3]: %hist -rl 2
     x=1 # random
     %hist -r 2
     """
@@ -150,36 +150,14 @@ def doctest_hist_op():
     <...s instance at ...>
     >>> 
     """
-
-def test_shist():
-    # Simple tests of ShadowHist class - test generator.
-    import os, shutil, tempfile
-
-    from IPython.utils import pickleshare
-    from IPython.core.history import ShadowHist
-    
-    tfile = tempfile.mktemp('','tmp-ipython-')
-    
-    db = pickleshare.PickleShareDB(tfile)
-    s = ShadowHist(db, get_ipython())
-    s.add('hello')
-    s.add('world')
-    s.add('hello')
-    s.add('hello')
-    s.add('karhu')
-
-    yield nt.assert_equals,s.all(),[(1, 'hello'), (2, 'world'), (3, 'karhu')]
-    
-    yield nt.assert_equal,s.get(2),'world'
-    
-    shutil.rmtree(tfile)
-    
+  
 def test_macro():
     ip = get_ipython()
     ip.history_manager.reset()   # Clear any existing history.
     cmds = ["a=1", "def b():\n  return a**2", "print(a,b())"]
-    for cmd in cmds:
-        ip.history_manager.store_inputs(cmd)
+    for i, cmd in enumerate(cmds, start=1):
+        ip.history_manager.store_inputs(i, cmd)
+        print i, cmd
     ip.magic("macro test 1-3")
     nt.assert_equal(ip.user_ns["test"].value, "\n".join(cmds)+"\n")
     

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -163,6 +163,28 @@ def test_macro():
     # List macros.
     assert "test" in ip.magic("macro")
 
+# XXX This should be a doctest, but the doctest logic doesn't seem to do
+# dynamic transformations (like expanding macros). Doing it like this for now.
+def test_macro_run():
+    """Test that we can run a multi-line macro successfully."""
+    ip = get_ipython()
+    ip.history_manager.reset()
+    cmds = ["a=10", "a+=1", "print a", "%macro test 2-3"]
+    for cmd in cmds:
+        ip.run_cell(cmd)
+    nt.assert_equal(ip.user_ns["test"].value, "a+=1\nprint a\n")
+    original_stdout = sys.stdout
+    new_stdout = StringIO()
+    sys.stdout = new_stdout
+    try:
+        ip.run_cell("test")
+        nt.assert_true("12" in new_stdout.getvalue())
+        ip.run_cell("test")
+        nt.assert_true("13" in new_stdout.getvalue())
+    finally:
+        sys.stdout = original_stdout
+        new_stdout.close()
+
     
 # XXX failing for now, until we get clearcmd out of quarantine.  But we should
 # fix this and revert the skip to happen only if numpy is not around.

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -157,7 +157,6 @@ def test_macro():
     cmds = ["a=1", "def b():\n  return a**2", "print(a,b())"]
     for i, cmd in enumerate(cmds, start=1):
         ip.history_manager.store_inputs(i, cmd)
-        print i, cmd
     ip.magic("macro test 1-3")
     nt.assert_equal(ip.user_ns["test"].value, "\n".join(cmds)+"\n")
     

--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -158,15 +158,12 @@ class IPythonWidget(FrontendWidget):
             else:
                 super(IPythonWidget, self)._handle_execute_reply(msg)
 
-    def _handle_history_reply(self, msg):
-        """ Implemented to handle history replies, which are only supported by
-            the IPython kernel.
+    def _handle_history_tail_reply(self, msg):
+        """ Implemented to handle history tail replies, which are only supported
+            by the IPython kernel.
         """
-        history_dict = msg['content']['history']
-        input_history_dict = {}
-        for key,val in history_dict.items():
-            input_history_dict[int(key)] = val
-        items = [ val.rstrip() for _, val in sorted(input_history_dict.items()) ]
+        history_items = msg['content']['history']
+        items = [ line.rstrip() for _, _, line in history_items ]
         self._set_history(items)
 
     def _handle_pyout(self, msg):
@@ -213,8 +210,7 @@ class IPythonWidget(FrontendWidget):
         """ Reimplemented to make a history request.
         """
         super(IPythonWidget, self)._started_channels()
-        self.kernel_manager.xreq_channel.history(raw=True, output=False,
-                                                            this_session=False)
+        self.kernel_manager.xreq_channel.history_tail(1000)
 
     #---------------------------------------------------------------------------
     # 'ConsoleWidget' public interface

--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -213,7 +213,8 @@ class IPythonWidget(FrontendWidget):
         """ Reimplemented to make a history request.
         """
         super(IPythonWidget, self)._started_channels()
-        self.kernel_manager.xreq_channel.history(raw=True, output=False)
+        self.kernel_manager.xreq_channel.history(raw=True, output=False,
+                                                            this_session=False)
 
     #---------------------------------------------------------------------------
     # 'ConsoleWidget' public interface

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -185,10 +185,6 @@ class TerminalInteractiveShell(InteractiveShell):
         
         with nested(self.builtin_trap, self.display_trap):
 
-            # if you run stuff with -c <cmd>, raw hist is not updated
-            # ensure that it's in sync
-            self.history_manager.sync_inputs()
-
             while 1:
                 try:
                     self.interact(display_banner=display_banner)

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -282,67 +282,6 @@ class TerminalInteractiveShell(InteractiveShell):
         # Turn off the exit flag, so the mainloop can be restarted if desired
         self.exit_now = False
 
-    def raw_input(self, prompt='', continue_prompt=False):
-        """Write a prompt and read a line.
-
-        The returned line does not include the trailing newline.
-        When the user enters the EOF key sequence, EOFError is raised.
-
-        Optional inputs:
-
-          - prompt(''): a string to be printed to prompt the user.
-
-          - continue_prompt(False): whether this line is the first one or a
-          continuation in a sequence of inputs.
-        """
-        # Code run by the user may have modified the readline completer state.
-        # We must ensure that our completer is back in place.
-
-        if self.has_readline:
-            self.set_readline_completer()
-        
-        try:
-            line = raw_input_original(prompt).decode(self.stdin_encoding)
-        except ValueError:
-            warn("\n********\nYou or a %run:ed script called sys.stdin.close()"
-                 " or sys.stdout.close()!\nExiting IPython!")
-            self.ask_exit()
-            return ""
-
-        # Try to be reasonably smart about not re-indenting pasted input more
-        # than necessary.  We do this by trimming out the auto-indent initial
-        # spaces, if the user's actual input started itself with whitespace.
-        if self.autoindent:
-            if num_ini_spaces(line) > self.indent_current_nsp:
-                line = line[self.indent_current_nsp:]
-                self.indent_current_nsp = 0
-            
-        # store the unfiltered input before the user has any chance to modify
-        # it.
-        if line.strip():
-            if continue_prompt:
-                if self.has_readline and self.readline_use:
-                    histlen = self.readline.get_current_history_length()
-                    if histlen > 1:
-                        newhist = self.history_manager.input_hist_raw[-1].rstrip()
-                        self.readline.remove_history_item(histlen-1)
-                        self.readline.replace_history_item(histlen-2,
-                                        newhist.encode(self.stdin_encoding))
-            else:
-                self.history_manager.input_hist_raw.append('%s\n' % line)                
-        elif not continue_prompt:
-            self.history_manager.input_hist_raw.append('\n')
-        try:
-            lineout = self.prefilter_manager.prefilter_lines(line,continue_prompt)
-        except:
-            # blanket except, in case a user-defined prefilter crashes, so it
-            # can't take all of ipython with it.
-            self.showtraceback()
-            return ''
-        else:
-            return lineout
-
-
     def raw_input(self, prompt=''):
         """Write a prompt and read a line.
 

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -19,7 +19,6 @@ import __main__
 import os
 import re
 import shutil
-import types
 
 from IPython.external.path import path
 
@@ -29,8 +28,6 @@ from IPython.utils.data import flatten
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
-
-StringTypes = types.StringTypes
 
 
 def unquote_ends(istr):
@@ -325,7 +322,7 @@ def qw(words,flat=0,sep=None,maxsplit=-1):
     ['a', 'b', '1', '2', 'm', 'n', 'p', 'q']
     """
 
-    if type(words) in StringTypes:
+    if isinstance(words, basestring):
         return [word.strip() for word in words.split(sep,maxsplit)
                 if word and not word.isspace() ]
     if flat:
@@ -345,7 +342,7 @@ def qw_lol(indata):
     We need this to make sure the modules_some keys *always* end up as a
     list of lists."""
 
-    if type(indata) in StringTypes:
+    if isinstance(indata, basestring):
         return [qw(indata)]
     else:
         return qw(indata)

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -309,10 +309,9 @@ class Kernel(Configurable):
         logger.debug(msg)
 
     def history_request(self, ident, parent):
-        output = parent['content']['output']
-        index = parent['content']['index']
-        raw = parent['content']['raw']
-        hist = self.shell.get_history(index=index, raw=raw, output=output)
+        # parent['content'] should contain keys "index", "raw", "output" and
+        # "this_session".
+        hist = self.shell.get_history(**parent['content'])
         content = {'history' : hist}
         msg = self.session.send(self.reply_socket, 'history_reply',
                                 content, parent, ident)

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -107,7 +107,7 @@ class Kernel(Configurable):
 
         # Build dict of handlers for message types
         msg_types = [ 'execute_request', 'complete_request', 
-                      'object_info_request', 'history_request',
+                      'object_info_request', 'history_tail_request',
                       'connect_request', 'shutdown_request']
         self.handlers = {}
         for msg_type in msg_types:
@@ -308,12 +308,11 @@ class Kernel(Configurable):
                                 oinfo, parent, ident)
         logger.debug(msg)
 
-    def history_request(self, ident, parent):
-        # parent['content'] should contain keys "index", "raw", "output" and
-        # "this_session".
-        hist = self.shell.get_history(**parent['content'])
-        content = {'history' : hist}
-        msg = self.session.send(self.reply_socket, 'history_reply',
+    def history_tail_request(self, ident, parent):
+        # parent['content'] should contain keys "n", "raw" and "output"
+        hist = self.shell.history_manager.get_hist_tail(**parent['content'])
+        content = {'history' : list(hist)}
+        msg = self.session.send(self.reply_socket, 'history_tail_reply',
                                 content, parent, ident)
         logger.debug(str(msg))
 

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -314,7 +314,7 @@ class Kernel(Configurable):
         n = parent['content']['n']
         raw = parent['content']['raw']
         output = parent['content']['output']
-        hist = self.shell.history_manager.get_hist_tail(n, raw=raw, output=output)
+        hist = self.shell.history_manager.get_tail(n, raw=raw, output=output)
         content = {'history' : list(hist)}
         msg = self.session.send(self.reply_socket, 'history_tail_reply',
                                 content, parent, ident)

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -309,8 +309,12 @@ class Kernel(Configurable):
         logger.debug(msg)
 
     def history_tail_request(self, ident, parent):
-        # parent['content'] should contain keys "n", "raw" and "output"
-        hist = self.shell.history_manager.get_hist_tail(**parent['content'])
+        # We need to pull these out, as passing **kwargs doesn't work with
+        # unicode keys before Python 2.6.5.
+        n = parent['content']['n']
+        raw = parent['content']['raw']
+        output = parent['content']['output']
+        hist = self.shell.history_manager.get_hist_tail(n, raw=raw, output=output)
         content = {'history' : list(hist)}
         msg = self.session.send(self.reply_socket, 'history_tail_reply',
                                 content, parent, ident)

--- a/IPython/zmq/kernelmanager.py
+++ b/IPython/zmq/kernelmanager.py
@@ -282,7 +282,7 @@ class XReqSocketChannel(ZmqSocketChannel):
         self._queue_request(msg)
         return msg['header']['msg_id']
 
-    def history(self, index=None, raw=False, output=True):
+    def history(self, index=None, raw=False, output=True, this_session=True):
         """Get the history list.
 
         Parameters
@@ -295,12 +295,16 @@ class XReqSocketChannel(ZmqSocketChannel):
             If True, return the raw input.
         output : bool
             If True, then return the output as well.
+        this_session : bool
+            If True, returns only history from the current session. Otherwise,
+            includes reloaded history from previous sessions.
 
         Returns
         -------
         The msg_id of the message sent.
         """
-        content = dict(index=index, raw=raw, output=output)
+        content = dict(index=index, raw=raw, output=output, 
+                                                    this_session=this_session)
         msg = self.session.msg('history_request', content)
         self._queue_request(msg)
         return msg['header']['msg_id']

--- a/IPython/zmq/kernelmanager.py
+++ b/IPython/zmq/kernelmanager.py
@@ -282,30 +282,24 @@ class XReqSocketChannel(ZmqSocketChannel):
         self._queue_request(msg)
         return msg['header']['msg_id']
 
-    def history(self, index=None, raw=False, output=True, this_session=True):
+    def history_tail(self, n=10, raw=True, output=False):
         """Get the history list.
 
         Parameters
         ----------
-        index : n or (n1, n2) or None
-            If n, then the last entries. If a tuple, then all in
-            range(n1, n2). If None, then all entries. Raises IndexError if
-            the format of index is incorrect.
+        n : int
+            The number of lines of history to get.
         raw : bool
             If True, return the raw input.
         output : bool
             If True, then return the output as well.
-        this_session : bool
-            If True, returns only history from the current session. Otherwise,
-            includes reloaded history from previous sessions.
 
         Returns
         -------
         The msg_id of the message sent.
         """
-        content = dict(index=index, raw=raw, output=output, 
-                                                    this_session=this_session)
-        msg = self.session.msg('history_request', content)
+        content = dict(n=n, raw=raw, output=output)
+        msg = self.session.msg('history_tail_request', content)
         self._queue_request(msg)
         return msg['header']['msg_id']
 


### PR DESCRIPTION
This was discussed previously on the mailing list. The code will probably still need some refining, but I think it's working well enough to put it forward.

There are two major changes involved:

History is now stored on disk as an SQLite database. This replaces both the JSON history and the "shadow history" database. By default, the input is stored as each line is entered, but (as Fernando suggested), there is a configurable attribute, db_cache_size, which lets you determine how often (in number of commands) it will write to disk. Very large values will cause all input to be written when IPython quits. A separate configurable attribute, db_log_output, causes the plaintext repr of output to be written to a separate table in the file (Robert's suggestion).

Secondly, whereas history was previously treated as one long stream of commands, it is now stored by "sessions", i.e. runs of IPython. So, if you are particularly fond of the fifth command you gave IPython in one session, the next time you start IPython, you can refer to the fifth command of the last session (the syntax for magic commands is `~1/5`). Sessions are consecutively numbered from when they start, so interleaved commands from two shells open at the same time will be kept separate.

This requires somewhat more complicated interfaces. There are now four main interfaces to retrieve history from HistoryManager:
- `get_history`: Retrieves specified ranges of history, either from the database, or the current session.
- `get_hist_from_rangestr`: Is a convenience method for magic functions, which accepts the "~1/3-6  12" style range specifications.
- `get_hist_tail`: Gets the last n items from the database, ordered by session and line. Used to populate readline (and the equivalent in the Qt console).
- `get_hist_search`: Searches the database using glob style matching (i.e. wildcards, not regexen).

All of these return iterators over 3-tuples, `(session, lineno, item)`. If asked for output, `item` will be a 2-tuple of `(input, output)`.

I've also given `%hist` the same range specification parsing as `%save`, `%macro` and `%edit` (it would previously only accept one or two numbers separated by a space). A single numeric argument, such as `%hist 10` previously fetched the last 10 lines; now it gets the 10th line of the current session. So I've added a new option, `-l` (for last), which works with a single numeric argument. This is marginally less convenient if that's what you want, but I think the consistency among magic functions retrieving history is a good thing.
