### PR TITLE
Issue 290

### DIFF
--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -444,18 +444,22 @@ class InputSplitter(object):
             return True
 
         # If we already have complete input and we're flush left, the answer
-        # depends.  In line mode, we're done.  But in cell mode, we need to
-        # check how many blocks the input so far compiles into, because if
-        # there's already more than one full independent block of input, then
-        # the client has entered full 'cell' mode and is feeding lines that
-        # each is complete.  In this case we should then keep accepting.
-        # The Qt terminal-like console does precisely this, to provide the
-        # convenience of terminal-like input of single expressions, but
-        # allowing the user (with a separate keystroke) to switch to 'cell'
-        # mode and type multiple expressions in one shot.
+        # depends.  In line mode, if there hasn't been any indentation,
+        # that's it. If we've come back from some indentation, we need
+        # the blank final line to finish.
+        # In cell mode, we need to check how many blocks the input so far
+        # compiles into, because if there's already more than one full
+        # independent block of input, then the client has entered full
+        # 'cell' mode and is feeding lines that each is complete.  In this
+        # case we should then keep accepting. The Qt terminal-like console
+        # does precisely this, to provide the convenience of terminal-like
+        # input of single expressions, but allowing the user (with a
+        # separate keystroke) to switch to 'cell' mode and type multiple
+        # expressions in one shot.
         if self.indent_spaces==0:
             if self.input_mode=='line':
-                return False
+                if not self._full_dedent:
+                    return False
             else:
                 nblocks = len(split_blocks(''.join(self._buffer)))
                 if nblocks==1:

--- a/IPython/core/tests/test_inputsplitter.py
+++ b/IPython/core/tests/test_inputsplitter.py
@@ -259,6 +259,17 @@ class InputSplitterTestCase(unittest.TestCase):
         self.assertTrue(isp.push_accepts_more())
         isp.push('')
         self.assertFalse(isp.push_accepts_more())
+        
+    def test_push_accepts_more5(self):
+        # In cell mode, inputs must be fed in whole blocks, so skip this test
+        if self.isp.input_mode == 'cell': return
+
+        isp = self.isp
+        isp.push('try:')
+        isp.push('    a = 5')
+        isp.push('except:')
+        isp.push('    raise')
+        self.assertTrue(isp.push_accepts_more())
 
     def test_continuation(self):
         isp = self.isp


### PR DESCRIPTION
This changes when inputsplitter will ask for another line. In line mode, it now needs a blank line to end a block if there has been any dedent. So:

```
 a = (1,2,
 3)
```

Is still accepted without a blank line, but:

```
 def f():
      pass
```

will need a blank line after it.
