### PR TITLE
Magic local scope

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -22,6 +22,7 @@ import __future__
 import abc
 import atexit
 import codeop
+import inspect
 import os
 import re
 import sys
@@ -1727,6 +1728,10 @@ class InteractiveShell(Configurable, Magic):
         valid Python code you can type at the interpreter, including loops and
         compound statements.
         """
+        # Save the scope of the call so magic functions like %time can
+        # evaluate expressions in it.
+        self._magic_locals = inspect.stack()[1][0].f_locals
+        
         args = arg_s.split(' ',1)
         magic_name = args[0]
         magic_name = magic_name.lstrip(prefilter.ESC_MAGIC)

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -1928,17 +1928,18 @@ Currently the magic system has the following functions:\n"""
             tc = clock()-t0
         # skew measurement as little as possible
         glob = self.shell.user_ns
+        locs = self._magic_locals
         clk = clock2
         wtime = time.time
         # time execution
         wall_st = wtime()
         if mode=='eval':
             st = clk()
-            out = eval(code,glob)
+            out = eval(code, glob, locs)
             end = clk()
         else:
             st = clk()
-            exec code in glob
+            exec code in glob, locs
             end = clk()
             out = None
         wall_end = wtime()

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -85,6 +85,10 @@ def compress_dhist(dh):
 
     return newhead + tail        
 
+def needs_local_scope(func):
+    """Decorator to mark magic functions which need to local scope to run."""
+    func.needs_local_scope = True
+    return func
 
 #***************************************************************************
 # Main class implementing Magic functionality
@@ -1863,6 +1867,7 @@ Currently the magic system has the following functions:\n"""
             print "Compiler time: %.2f s" % tc
 
     @testdec.skip_doctest
+    @needs_local_scope
     def magic_time(self,parameter_s = ''):
         """Time execution of a Python statement or expression.
 

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -274,6 +274,14 @@ def doctest_time():
     In [10]: %time None
     CPU times: user 0.00 s, sys: 0.00 s, total: 0.00 s
     Wall time: 0.00 s
+    
+    In [11]: def f(kmjy):
+       ....:    %time print 2*kmjy
+       
+    In [12]: f(3)
+    6
+    CPU times: user 0.00 s, sys: 0.00 s, total: 0.00 s
+    Wall time: 0.00 s
     """
 
 


### PR DESCRIPTION
I'm not sure if this is how we want to do this, or if we want to do it at all, but here it is for consideration.

Sage bug 10933 (http://trac.sagemath.org/sage_trac/ticket/10933) highlighted that we couldn't use the %time magic command inside a function. This captures the stack frame which called magic_time, and uses its local namespace to evaluate or execute the code passed to %time. It could also be used by other magic functions, although so far I've only added it to magic_time.
