### PR TITLE
Bug tests for GH Issues 238, 284, 306, 307. Skip module machinery if not installed. Known failures reported as 'K'

### DIFF
--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -35,14 +35,14 @@ class InteractiveShellTestCase(unittest.TestCase):
         # And also multi-line cells
         ip.run_cell('"""a\nb"""\n')
         self.assertEquals(ip.user_ns['_'], 'a\nb')
-        
+
     def test_run_empty_cell(self):
         """Just make sure we don't get a horrible error with a blank
         cell of input. Yes, I did overlook that."""
         ip = get_ipython()
         ip.run_cell('')
 
-    def test_run_cell_multilne(self):
+    def test_run_cell_multiline(self):
         """Multi-block, multi-line cells must execute correctly.
         """
         ip = get_ipython()
@@ -54,4 +54,11 @@ class InteractiveShellTestCase(unittest.TestCase):
         ip.run_cell(src)
         self.assertEquals(ip.user_ns['x'], 2)
         self.assertEquals(ip.user_ns['y'], 3)
-        
+
+    def test_multiline_string_cells(self):
+        """Code sprinkled with multiline strings should execute (GH-306)"""
+        ip = get_ipython()
+        ip.run_cell('tmp=0')
+        self.assertEquals(ip.user_ns['tmp'], 0)
+        ip.run_cell('tmp=1;"""a\nb"""\n')
+        self.assertEquals(ip.user_ns['tmp'], 1)

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -71,6 +71,15 @@ class InteractiveShellTestCase(unittest.TestCase):
         newlen = len(ip.user_ns['Out'])
         self.assertEquals(oldlen, newlen)
         #also test the default caching behavior
-        a = ip.run_cell('1')
+        ip.run_cell('1')
         newlen = len(ip.user_ns['Out'])
         self.assertEquals(oldlen+1, newlen)
+    
+    def test_In_variable(self):
+        "Verify that In variable grows with user input (GH-284)"
+        ip = get_ipython()
+        oldlen = len(ip.user_ns['In'])
+        ip.run_cell('1;')
+        newlen = len(ip.user_ns['In'])
+        self.assertEquals(oldlen+1, newlen)
+        self.assertEquals(ip.user_ns['In'][-1],'1;')

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -56,9 +56,21 @@ class InteractiveShellTestCase(unittest.TestCase):
         self.assertEquals(ip.user_ns['y'], 3)
 
     def test_multiline_string_cells(self):
-        """Code sprinkled with multiline strings should execute (GH-306)"""
+        "Code sprinkled with multiline strings should execute (GH-306)"
         ip = get_ipython()
         ip.run_cell('tmp=0')
         self.assertEquals(ip.user_ns['tmp'], 0)
         ip.run_cell('tmp=1;"""a\nb"""\n')
         self.assertEquals(ip.user_ns['tmp'], 1)
+
+    def test_dont_cache_with_semicolon(self):
+        "Ending a line with semicolon should not cache the returned object (GH-307)"
+        ip = get_ipython()
+        oldlen = len(ip.user_ns['Out'])
+        a = ip.run_cell('1;')
+        newlen = len(ip.user_ns['Out'])
+        self.assertEquals(oldlen, newlen)
+        #also test the default caching behavior
+        a = ip.run_cell('1')
+        newlen = len(ip.user_ns['Out'])
+        self.assertEquals(oldlen+1, newlen)

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -20,6 +20,7 @@ Authors
 #-----------------------------------------------------------------------------
 # stdlib
 import unittest
+from IPython.testing import decorators as dec
 
 #-----------------------------------------------------------------------------
 # Tests
@@ -55,6 +56,7 @@ class InteractiveShellTestCase(unittest.TestCase):
         self.assertEquals(ip.user_ns['x'], 2)
         self.assertEquals(ip.user_ns['y'], 3)
 
+    @dec.skip_known_failure
     def test_multiline_string_cells(self):
         "Code sprinkled with multiline strings should execute (GH-306)"
         ip = get_ipython()
@@ -63,6 +65,7 @@ class InteractiveShellTestCase(unittest.TestCase):
         ip.run_cell('tmp=1;"""a\nb"""\n')
         self.assertEquals(ip.user_ns['tmp'], 1)
 
+    @dec.skip_known_failure
     def test_dont_cache_with_semicolon(self):
         "Ending a line with semicolon should not cache the returned object (GH-307)"
         ip = get_ipython()
@@ -74,7 +77,7 @@ class InteractiveShellTestCase(unittest.TestCase):
         ip.run_cell('1')
         newlen = len(ip.user_ns['Out'])
         self.assertEquals(oldlen+1, newlen)
-    
+
     def test_In_variable(self):
         "Verify that In variable grows with user input (GH-284)"
         ip = get_ipython()

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -171,10 +171,11 @@ class TestMagicRunSimple(tt.TempFileMixin):
         self.mktmp(src)
         tt.ipexec_validate(self.fname, 'object A deleted')
     
+    @dec.skip_known_failure 
     def test_aggressive_namespace_cleanup(self):
         """Test that namespace cleanup is not too aggressive GH-238
-        
-        returning from another run magic deletes the namespace"""
+
+        Returning from another run magic deletes the namespace"""
         # see ticket https://github.com/ipython/ipython/issues/238
         class secondtmp(tt.TempFileMixin): pass
         empty = secondtmp()

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -170,6 +170,25 @@ class TestMagicRunSimple(tt.TempFileMixin):
                "a = A()\n")
         self.mktmp(src)
         tt.ipexec_validate(self.fname, 'object A deleted')
+    
+    def test_aggressive_namespace_cleanup(self):
+        """Test that namespace cleanup is not too aggressive GH-238
+        
+        returning from another run magic deletes the namespace"""
+        # see ticket https://github.com/ipython/ipython/issues/238
+        class secondtmp(tt.TempFileMixin): pass
+        empty = secondtmp()
+        empty.mktmp('')
+        src = ("ip = get_ipython()\n"
+               "for i in range(5):\n"
+               "   try:\n"
+               "       ip.magic('run %s')\n"
+               "   except NameError, e:\n"
+               "       print i;break\n" % empty.fname)
+        self.mktmp(src)
+        _ip.magic('run %s' % self.fname)
+        _ip.runlines('ip == get_ipython()')
+        tt.assert_equals(_ip.user_ns['i'], 5)
 
     @dec.skip_win32
     def test_tclass(self):

--- a/IPython/extensions/sympy_printing.py
+++ b/IPython/extensions/sympy_printing.py
@@ -16,6 +16,7 @@ Authors:
 
 from IPython.lib.latextools import latex_to_png
 from IPython.testing import decorators as dec
+# use @dec.skipif_not_sympy to skip tests requiring sympy
 
 try:
     from sympy import pretty, latex
@@ -27,7 +28,6 @@ except ImportError:
 # Definitions of magic functions for use with IPython
 #-----------------------------------------------------------------------------
 
-@dec.skipif_not_sympy
 def print_basic_unicode(o, p, cycle):
     """A function to pretty print sympy Basic objects."""
     if cycle:
@@ -38,7 +38,6 @@ def print_basic_unicode(o, p, cycle):
     p.text(out)
 
 
-@dec.skipif_not_sympy
 def print_png(o):
     """A funciton to display sympy expression using LaTex -> PNG."""
     s = latex(o, mode='inline')
@@ -51,7 +50,6 @@ def print_png(o):
 
 _loaded = False
 
-@dec.skipif_not_sympy
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
     global _loaded

--- a/IPython/extensions/sympy_printing.py
+++ b/IPython/extensions/sympy_printing.py
@@ -15,13 +15,19 @@ Authors:
 #-----------------------------------------------------------------------------
 
 from IPython.lib.latextools import latex_to_png
+from IPython.testing import decorators as dec
 
-from sympy import pretty, latex
+try:
+    from sympy import pretty, latex
+except ImportError:
+    pass
+
 
 #-----------------------------------------------------------------------------
 # Definitions of magic functions for use with IPython
 #-----------------------------------------------------------------------------
 
+@dec.skipif_not_sympy
 def print_basic_unicode(o, p, cycle):
     """A function to pretty print sympy Basic objects."""
     if cycle:
@@ -32,6 +38,7 @@ def print_basic_unicode(o, p, cycle):
     p.text(out)
 
 
+@dec.skipif_not_sympy
 def print_png(o):
     """A funciton to display sympy expression using LaTex -> PNG."""
     s = latex(o, mode='inline')
@@ -44,7 +51,7 @@ def print_png(o):
 
 _loaded = False
 
-
+@dec.skipif_not_sympy
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
     global _loaded

--- a/IPython/external/decorators/__init__.py
+++ b/IPython/external/decorators/__init__.py
@@ -1,4 +1,7 @@
 try:
     from numpy.testing.decorators import *
+    from numpy.testing.noseclasses import KnownFailure
 except ImportError:
     from _decorators import *
+    # KnownFailure imported in _decorators from local version of
+    # noseclasses which is in _numpy_testing_noseclasses

--- a/IPython/external/decorators/__init__.py
+++ b/IPython/external/decorators/__init__.py
@@ -3,5 +3,4 @@ try:
     from numpy.testing.noseclasses import KnownFailure
 except ImportError:
     from _decorators import *
-    # KnownFailure imported in _decorators from local version of
-    # noseclasses which is in _numpy_testing_noseclasses
+    from _numpy_testing_noseclasses import KnownFailure

--- a/IPython/external/decorators/_decorators.py
+++ b/IPython/external/decorators/_decorators.py
@@ -20,15 +20,8 @@ import warnings
 #from numpy.testing.utils import \
 #        WarningManager, WarningMessage
 # Our version:
-try:
-    from numpy.testing.utils import WarningManager, WarningMessage
-except ImportError:
-    from _numpy_testing_utils import WarningManager, WarningMessage
-
-try:
-    from numpy.testing.noseclasses import KnownFailure, KnownFailureTest
-except ImportError:
-    from _numpy_testing_noseclasses import KnownFailure, KnownFailureTest
+from _numpy_testing_utils import WarningManager
+from _numpy_testing_noseclasses import KnownFailureTest
 
 # End IPython changes
 

--- a/IPython/external/decorators/_decorators.py
+++ b/IPython/external/decorators/_decorators.py
@@ -14,7 +14,6 @@ function name, setup and teardown functions and so on - see
 
 """
 import warnings
-import sys
 
 # IPython changes: make this work if numpy not available
 # Original code:
@@ -25,7 +24,12 @@ try:
     from numpy.testing.utils import WarningManager, WarningMessage
 except ImportError:
     from _numpy_testing_utils import WarningManager, WarningMessage
-    
+
+try:
+    from numpy.testing.noseclasses import KnownFailure, KnownFailureTest
+except ImportError:
+    from _numpy_testing_noseclasses import KnownFailure, KnownFailureTest
+
 # End IPython changes
 
 def slow(t):
@@ -34,7 +38,7 @@ def slow(t):
 
     The exact definition of a slow test is obviously both subjective and
     hardware-dependent, but in general any individual test that requires more
-    than a second or two should be labeled as slow (the whole suite consits of
+    than a second or two should be labeled as slow (the whole suite consists of
     thousands of tests, so even a second is significant).
 
     Parameters
@@ -172,7 +176,6 @@ def skipif(skip_condition, msg=None):
 
     return skip_decorator
 
-
 def knownfailureif(fail_condition, msg=None):
     """
     Make function raise KnownFailureTest exception if given condition is true.
@@ -216,7 +219,6 @@ def knownfailureif(fail_condition, msg=None):
         # Local import to avoid a hard nose dependency and only incur the
         # import time overhead at actual test-time.
         import nose
-        from noseclasses import KnownFailureTest
         def knownfailer(*args, **kwargs):
             if fail_val():
                 raise KnownFailureTest, msg
@@ -255,7 +257,6 @@ def deprecated(conditional=True):
         # Local import to avoid a hard nose dependency and only incur the
         # import time overhead at actual test-time.
         import nose
-        from noseclasses import KnownFailureTest
 
         def _deprecated_imp(*args, **kwargs):
             # Poor man's replacement for the with statement

--- a/IPython/external/decorators/_numpy_testing_noseclasses.py
+++ b/IPython/external/decorators/_numpy_testing_noseclasses.py
@@ -1,0 +1,41 @@
+# IPython: modified copy of numpy.testing.noseclasses, so
+# IPython.external._decorators works without numpy being installed.
+
+# These classes implement a "known failure" error class.
+
+import os
+
+from nose.plugins.errorclass import ErrorClass, ErrorClassPlugin
+
+class KnownFailureTest(Exception):
+    '''Raise this exception to mark a test as a known failing test.'''
+    pass
+
+
+class KnownFailure(ErrorClassPlugin):
+    '''Plugin that installs a KNOWNFAIL error class for the
+    KnownFailureClass exception.  When KnownFailureTest is raised,
+    the exception will be logged in the knownfail attribute of the
+    result, 'K' or 'KNOWNFAIL' (verbose) will be output, and the
+    exception will not be counted as an error or failure.'''
+    enabled = True
+    knownfail = ErrorClass(KnownFailureTest,
+                           label='KNOWNFAIL',
+                           isfailure=False)
+
+    def options(self, parser, env=os.environ):
+        env_opt = 'NOSE_WITHOUT_KNOWNFAIL'
+        parser.add_option('--no-knownfail', action='store_true',
+                          dest='noKnownFail', default=env.get(env_opt, False),
+                          help='Disable special handling of KnownFailureTest '
+                               'exceptions')
+
+    def configure(self, options, conf):
+        if not self.can_configure:
+            return
+        self.conf = conf
+        disable = getattr(options, 'noKnownFail', False)
+        if disable:
+            self.enabled = False
+
+

--- a/IPython/external/decorators/_numpy_testing_utils.py
+++ b/IPython/external/decorators/_numpy_testing_utils.py
@@ -1,14 +1,10 @@
-# IPython: modified copy of numpy.testing.utils, so numpy.testing.decorators
-# works without numpy being installed.
+# IPython: modified copy of numpy.testing.utils, so
+# IPython.external._decorators works without numpy being installed.
 """
 Utility function to facilitate testing.
 """
 
-import os
 import sys
-import re
-import operator
-import types
 import warnings
 
 # The following two classes are copied from python 2.6 warnings module (context

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -274,19 +274,19 @@ def onlyif(condition, msg):
 
 #-----------------------------------------------------------------------------
 # Utility functions for decorators
-def numpy_not_available():
-    """Can numpy be imported?  Returns true if numpy does NOT import.
+def module_not_available(module):
+    """Can module be imported?  Returns true if module does NOT import.
 
-    This is used to make a decorator to skip tests that require numpy to be
+    This is used to make a decorator to skip tests that require module to be
     available, but delay the 'import numpy' to test execution time.
     """
     try:
-        import numpy
-        np_not_avail = False
+        mod = __import__(module)
+        mod_not_avail = False
     except ImportError:
-        np_not_avail = True
+        mod_not_avail = True
 
-    return np_not_avail
+    yield mod_not_avail
 
 #-----------------------------------------------------------------------------
 # Decorators for public use
@@ -315,9 +315,11 @@ skip_if_not_osx = skipif(sys.platform != 'darwin',
                          "This test only runs under OSX")
 
 # Other skip decorators
-skipif_not_numpy = skipif(numpy_not_available,"This test requires numpy")
+skipif_not_numpy = skipif(module_not_available('numpy'),"This test requires numpy")
 
-skip_known_failure = skip('This test is known to fail')
+skipif_not_sympy = skipif(module_not_available('sympy'),"This test requires sympy")
+
+skip_known_failure = knownfailureif(True,'This test is known to fail')
 
 # A null 'decorator', useful to make more readable code that needs to pick
 # between different decorators based on OS or other conditions

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -286,7 +286,7 @@ def module_not_available(module):
     except ImportError:
         mod_not_avail = True
 
-    yield mod_not_avail
+    return mod_not_avail
 
 #-----------------------------------------------------------------------------
 # Decorators for public use

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -319,7 +319,7 @@ skipif_not_numpy = skipif(module_not_available('numpy'),"This test requires nump
 
 skipif_not_sympy = skipif(module_not_available('sympy'),"This test requires sympy")
 
-skip_known_failure = knownfailureif(True,'This test is known to fail')
+skip_known_failure = skip('This test is known to fail')
 
 # A null 'decorator', useful to make more readable code that needs to pick
 # between different decorators based on OS or other conditions

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -24,9 +24,10 @@ Lightweight testing that remains unittest-compatible.
   recognize it as such.  This will make it easier to migrate away from Nose if
   we ever need/want to while maintaining very lightweight tests.
 
-NOTE: This file contains IPython-specific decorators and imports the
-numpy.testing.decorators file, which we've copied verbatim.  Any of our own
-code will be added at the bottom if we end up extending this.
+NOTE: This file contains IPython-specific decorators. Using the machinery in
+IPython.external.decorators, we import either numpy.testing.decorators if numpy is
+available, OR use equivalent code in IPython.external._decorators, which
+we've copied verbatim from numpy.
 
 Authors
 -------
@@ -319,7 +320,7 @@ skipif_not_numpy = skipif(module_not_available('numpy'),"This test requires nump
 
 skipif_not_sympy = skipif(module_not_available('sympy'),"This test requires sympy")
 
-skip_known_failure = skip('This test is known to fail')
+skip_known_failure = knownfailureif(True,'This test is known to fail')
 
 # A null 'decorator', useful to make more readable code that needs to pick
 # between different decorators based on OS or other conditions

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -53,6 +53,7 @@ from IPython.utils.sysinfo import sys_info
 
 from IPython.testing import globalipapp
 from IPython.testing.plugin.ipdoctest import IPythonDoctest
+from IPython.external.decorators import KnownFailure
 
 pjoin = path.join
 
@@ -357,7 +358,7 @@ def run_iptest():
 
     # Construct list of plugins, omitting the existing doctest plugin, which
     # ours replaces (and extends).
-    plugins = [IPythonDoctest(make_exclude())]
+    plugins = [IPythonDoctest(make_exclude()), KnownFailure()]
     for p in nose.plugins.builtin.plugins:
         plug = p()
         if plug.name == 'doctest':


### PR DESCRIPTION
Three of the four currently fail on trunk, the one that passes is a test that the **In** variable is properly modified with every line (it was fixed by the Thomas' sqlite work). The failing tests have been marked with a skip_known_failure decorator which will provide a well defined "entry point" for newcomer developers: "here's the bug, here's the test for it, remove the skip decorator and try to make the test pass"

I refactored the numpy_not_available function to be module_not_available generator which can be used for checking availability of other modules (sympy, in this case). I'd appreciate feedback on that.

i also added the necessary machinery from numpy.testing to make the KnownFailures reported as 'K' by nose
