### PR TITLE
allow Unicode Command-Line options

### DIFF
--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -365,7 +365,14 @@ class ArgParseConfigLoader(CommandLineConfigLoader):
 
     def _parse_args(self, args):
         """self.parser->self.parsed_data"""
-        self.parsed_data, self.extra_args = self.parser.parse_known_args(args)
+        # decode sys.argv to support unicode command-line options
+        uargs = []
+        for a in args:
+            if isinstance(a, str):
+                # don't decode if we already got unicode
+                a = a.decode(sys.stdin.encoding)
+            uargs.append(a)
+        self.parsed_data, self.extra_args = self.parser.parse_known_args(uargs)
 
     def _convert_to_config(self):
         """self.parsed_data->self.config"""

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -158,7 +158,7 @@ class InteractiveShell(Configurable, Magic):
     exit_now = CBool(False)
     # Monotonically increasing execution counter
     execution_count = Int(1)
-    filename = Str("<ipython console>")
+    filename = Unicode("<ipython console>")
     ipython_dir= Unicode('', config=True) # Set to get_ipython_dir() in __init__
 
     # Input splitter, to split entire cells of input into either individual
@@ -166,13 +166,13 @@ class InteractiveShell(Configurable, Magic):
     input_splitter = Instance('IPython.core.inputsplitter.IPythonInputSplitter',
                               (), {})
     logstart = CBool(False, config=True)
-    logfile = Str('', config=True)
-    logappend = Str('', config=True)
+    logfile = Unicode('', config=True)
+    logappend = Unicode('', config=True)
     object_info_string_level = Enum((0,1,2), default_value=0,
                                     config=True)
     pdb = CBool(False, config=True)
 
-    profile = Str('', config=True)
+    profile = Unicode('', config=True)
     prompt_in1 = Str('In [\\#]: ', config=True)
     prompt_in2 = Str('   .\\D.: ', config=True)
     prompt_out = Str('Out[\\#]: ', config=True)
@@ -1987,7 +1987,6 @@ class InteractiveShell(Configurable, Magic):
         kw.setdefault('exit_ignore', False)
 
         fname = os.path.abspath(os.path.expanduser(fname))
-
         # Make sure we have a .py file
         if not fname.endswith('.py'):
             warn('File must end with .py to be run using execfile: <%s>' % fname)
@@ -2004,6 +2003,11 @@ class InteractiveShell(Configurable, Magic):
         # behavior of running a script from the system command line, where
         # Python inserts the script's directory into sys.path
         dname = os.path.dirname(fname)
+        
+        if isinstance(fname, unicode):
+            # execfile uses default encoding instead of filesystem encoding
+            # so unicode filenames will fail
+            fname = fname.encode(sys.getfilesystemencoding() or sys.getdefaultencoding())
 
         with prepended_to_syspath(dname):
             try:

--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -19,7 +19,7 @@ from IPython.external.qt import QtCore, QtGui
 from IPython.core.inputsplitter import IPythonInputSplitter, \
     transform_ipy_prompt
 from IPython.core.usage import default_gui_banner
-from IPython.utils.traitlets import Bool, Str
+from IPython.utils.traitlets import Bool, Str, Unicode
 from frontend_widget import FrontendWidget
 from styles import (default_light_style_sheet,  default_light_syntax_style,
                     default_dark_style_sheet, default_dark_syntax_style,
@@ -57,19 +57,19 @@ class IPythonWidget(FrontendWidget):
     # A command for invoking a system text editor. If the string contains a
     # {filename} format specifier, it will be used. Otherwise, the filename will
     # be appended to the end the command.
-    editor = Str('default', config=True)
+    editor = Unicode('default', config=True)
 
     # The editor command to use when a specific line number is requested. The
     # string should contain two format specifiers: {line} and {filename}. If
     # this parameter is not specified, the line number option to the %edit magic
     # will be ignored.
-    editor_line = Str(config=True)
+    editor_line = Unicode(config=True)
 
     # A CSS stylesheet. The stylesheet can contain classes for:
     #     1. Qt: QPlainTextEdit, QFrame, QWidget, etc
     #     2. Pygments: .c, .k, .o, etc (see PygmentsHighlighter)
     #     3. IPython: .error, .in-prompt, .out-prompt, etc
-    style_sheet = Str(config=True)
+    style_sheet = Unicode(config=True)
     
     # If not empty, use this Pygments style for syntax highlighting. Otherwise,
     # the style sheet is queried for Pygments style information.

--- a/IPython/frontend/terminal/embed.py
+++ b/IPython/frontend/terminal/embed.py
@@ -33,7 +33,7 @@ from IPython.core import ultratb
 from IPython.frontend.terminal.interactiveshell import TerminalInteractiveShell
 from IPython.frontend.terminal.ipapp import load_default_config
 
-from IPython.utils.traitlets import Bool, Str, CBool
+from IPython.utils.traitlets import Bool, Str, CBool, Unicode
 from IPython.utils.io import ask_yes_no
 
 
@@ -62,7 +62,7 @@ def kill_embedded(self,parameter_s=''):
 class InteractiveShellEmbed(TerminalInteractiveShell):
 
     dummy_mode = Bool(False)
-    exit_msg = Str('')
+    exit_msg = Unicode('')
     embedded = CBool(True)
     embedded_active = CBool(True)
     # Like the base class display_banner is not configurable, but here it

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -31,7 +31,7 @@ from IPython.utils.terminal import toggle_set_term_title, set_term_title
 from IPython.utils.process import abbrev_cwd
 from IPython.utils.warn import warn
 from IPython.utils.text import num_ini_spaces
-from IPython.utils.traitlets import Int, Str, CBool
+from IPython.utils.traitlets import Int, Str, CBool, Unicode
 
 #-----------------------------------------------------------------------------
 # Utilities
@@ -59,9 +59,9 @@ raw_input_original = raw_input
 class TerminalInteractiveShell(InteractiveShell):
 
     autoedit_syntax = CBool(False, config=True)
-    banner = Str('')
-    banner1 = Str(default_banner, config=True)
-    banner2 = Str('', config=True)
+    banner = Unicode('')
+    banner1 = Unicode(default_banner, config=True)
+    banner2 = Unicode('', config=True)
     confirm_exit = CBool(True, config=True)
     # This display_banner only controls whether or not self.show_banner()
     # is called when mainloop/interact are called.  The default is False
@@ -71,8 +71,8 @@ class TerminalInteractiveShell(InteractiveShell):
     display_banner = CBool(False) # This isn't configurable!
     embedded = CBool(False)
     embedded_active = CBool(False)
-    editor = Str(get_default_editor(), config=True)
-    pager = Str('less', config=True)
+    editor = Unicode(get_default_editor(), config=True)
+    pager = Unicode('less', config=True)
 
     screen_length = Int(0, config=True)
     term_title = CBool(False, config=True)


### PR DESCRIPTION
This fixes a couple of unicode-related bugs from the command-line

Of particular note is that (in config/loader.py) `argparse.parse_args` will now always get a list of `unicode` objects, and never `str`s.

There is also a fix in `InteractiveShell._safe_exec_file`, where `execfile` (at least in 2.6.1) does not encode with the filesystemencoding, but rather the defaultencoding, so a unicode string will raise a UnicodeEncodeError.

Things that should now work that did not before:

<pre>
ipython -p épsiløn
ipython ømqtést.py
</pre>
