### PR TITLE
Unicode magic args

### DIFF
--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -370,7 +370,8 @@ class ArgParseConfigLoader(CommandLineConfigLoader):
         for a in args:
             if isinstance(a, str):
                 # don't decode if we already got unicode
-                a = a.decode(sys.stdin.encoding)
+                a = a.decode(sys.stdin.encoding or 
+                                            sys.getdefaultencoding())
             uargs.append(a)
         self.parsed_data, self.extra_args = self.parser.parse_known_args(uargs)
 

--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -857,7 +857,7 @@ class EscapedTransformer(object):
         elif line_info.esc == '??':
             pinfo = 'pinfo2'
 
-        tpl = '%sget_ipython().magic("%s %s")'
+        tpl = '%sget_ipython().magic(u"%s %s")'
         return tpl % (line_info.lspace, pinfo,
                       ' '.join([line_info.fpart, line_info.rest]).strip())
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1730,7 +1730,7 @@ class InteractiveShell(Configurable, Magic):
         args = arg_s.split(' ',1)
         magic_name = args[0]
         magic_name = magic_name.lstrip(prefilter.ESC_MAGIC)
-
+        
         try:
             magic_args = args[1]
         except IndexError:
@@ -2453,12 +2453,11 @@ class InteractiveShell(Configurable, Magic):
         The global namespace for expansion is always the user's interactive
         namespace.
         """
-
-        return str(ItplNS(cmd,
-                          self.user_ns,  # globals
+        res = ItplNS(cmd, self.user_ns,  # globals
                           # Skip our own frame in searching for locals:
                           sys._getframe(depth+1).f_locals # locals
-                          ))
+                          )
+        return str(res).decode(res.codec)
 
     def mktempfile(self, data=None, prefix='ipython_edit_'):
         """Make a new tempfile and return its filename.

--- a/IPython/core/tests/test_handlers.py
+++ b/IPython/core/tests/test_handlers.py
@@ -68,10 +68,10 @@ def test_handlers():
     # These are useful for checking a particular recursive alias issue
     ip.alias_manager.alias_table['top'] = (0, 'd:/cygwin/top')
     ip.alias_manager.alias_table['d'] =   (0, 'true')
-    run([("an_alias",    'get_ipython().system("true ")'),     # alias
+    run([("an_alias",    'get_ipython().system(u"true ")'),     # alias
          # Below: recursive aliases should expand whitespace-surrounded
          # chars, *not* initial chars which happen to be aliases:
-         ("top",         'get_ipython().system("d:/cygwin/top ")'),
+         ("top",         'get_ipython().system(u"d:/cygwin/top ")'),
          ])
     ip.system = old_system_cmd
 
@@ -82,15 +82,15 @@ def test_handlers():
     # turns off the esc char, which it should unless there is a continuation
     # line.
     run([('"no change"', '"no change"'),             # normal
-         ("!true",       'get_ipython().system("true")'),      # shell_escapes
-         ("!! true",     'get_ipython().magic("sx  true")'),   # shell_escapes + magic
-         ("!!true",      'get_ipython().magic("sx true")'),    # shell_escapes + magic
-         ("%lsmagic",    'get_ipython().magic("lsmagic ")'),   # magic
-         ("lsmagic",     'get_ipython().magic("lsmagic ")'),   # magic
+         ("!true",       'get_ipython().system(u"true")'),      # shell_escapes
+         ("!! true",     'get_ipython().magic(u"sx  true")'),   # shell_escapes + magic
+         ("!!true",      'get_ipython().magic(u"sx true")'),    # shell_escapes + magic
+         ("%lsmagic",    'get_ipython().magic(u"lsmagic ")'),   # magic
+         ("lsmagic",     'get_ipython().magic(u"lsmagic ")'),   # magic
          #("a = b # PYTHON-MODE", '_i'),          # emacs -- avoids _in cache
 
          # post-esc-char whitespace goes inside
-         ("! true",   'get_ipython().system(" true")'),  
+         ("! true",   'get_ipython().system(u" true")'),  
 
          # handle_help
 
@@ -113,11 +113,11 @@ def test_handlers():
     ip.prefilter_manager.multi_line_specials = True
     # initial indents must be preserved.
     run([
-         ('if 1:\n    !true',    'if 1:\n    get_ipython().system("true")'),
-         ('if 2:\n    lsmagic',  'if 2:\n    get_ipython().magic("lsmagic ")'),
-         ('if 1:\n    an_alias', 'if 1:\n    get_ipython().system("true ")'),
+         ('if 1:\n    !true',    'if 1:\n    get_ipython().system(u"true")'),
+         ('if 2:\n    lsmagic',  'if 2:\n    get_ipython().magic(u"lsmagic ")'),
+         ('if 1:\n    an_alias', 'if 1:\n    get_ipython().system(u"true ")'),
          # Weird one
-         ('if 1:\n    !!true',   'if 1:\n    get_ipython().magic("sx true")'),
+         ('if 1:\n    !!true',   'if 1:\n    get_ipython().magic(u"sx true")'),
 
          # Even with m_l_s on, autocall is off even with special chars
          ('if 1:\n    /fun 1 2', 'if 1:\n    /fun 1 2'), 

--- a/IPython/core/tests/test_inputsplitter.py
+++ b/IPython/core/tests/test_inputsplitter.py
@@ -439,15 +439,15 @@ def transform_checker(tests, func):
 
 syntax = \
   dict(assign_system =
-       [('a =! ls', 'a = get_ipython().getoutput("ls")'),
-        ('b = !ls', 'b = get_ipython().getoutput("ls")'),
+       [('a =! ls', 'a = get_ipython().getoutput(u"ls")'),
+        ('b = !ls', 'b = get_ipython().getoutput(u"ls")'),
         ('x=1', 'x=1'), # normal input is unmodified
         ('    ','    '),  # blank lines are kept intact
         ],
 
        assign_magic =
-       [('a =% who', 'a = get_ipython().magic("who")'),
-        ('b = %who', 'b = get_ipython().magic("who")'),
+       [('a =% who', 'a = get_ipython().magic(u"who")'),
+        ('b = %who', 'b = get_ipython().magic(u"who")'),
         ('x=1', 'x=1'), # normal input is unmodified
         ('    ','    '),  # blank lines are kept intact
         ],
@@ -474,29 +474,29 @@ syntax = \
 
        # System calls
        escaped_shell =
-       [ ('!ls', 'get_ipython().system("ls")'),
+       [ ('!ls', 'get_ipython().system(u"ls")'),
          # Double-escape shell, this means to capture the output of the
          # subprocess and return it
-         ('!!ls', 'get_ipython().getoutput("ls")'),
+         ('!!ls', 'get_ipython().getoutput(u"ls")'),
          ],
 
        # Help/object info
        escaped_help =
        [ ('?', 'get_ipython().show_usage()'),
-         ('?x1', 'get_ipython().magic("pinfo x1")'),
-         ('??x2', 'get_ipython().magic("pinfo2 x2")'),
-         ('x3?', 'get_ipython().magic("pinfo x3")'),
-         ('x4??', 'get_ipython().magic("pinfo2 x4")'),
-         ('%hist?', 'get_ipython().magic("pinfo %hist")'),
-         ('f*?', 'get_ipython().magic("psearch f*")'),
-         ('ax.*aspe*?', 'get_ipython().magic("psearch ax.*aspe*")'),
+         ('?x1', 'get_ipython().magic(u"pinfo x1")'),
+         ('??x2', 'get_ipython().magic(u"pinfo2 x2")'),
+         ('x3?', 'get_ipython().magic(u"pinfo x3")'),
+         ('x4??', 'get_ipython().magic(u"pinfo2 x4")'),
+         ('%hist?', 'get_ipython().magic(u"pinfo %hist")'),
+         ('f*?', 'get_ipython().magic(u"psearch f*")'),
+         ('ax.*aspe*?', 'get_ipython().magic(u"psearch ax.*aspe*")'),
          ],
 
        # Explicit magic calls
        escaped_magic =
-       [ ('%cd', 'get_ipython().magic("cd")'),
-         ('%cd /home', 'get_ipython().magic("cd /home")'),
-         ('    %magic', '    get_ipython().magic("magic")'),
+       [ ('%cd', 'get_ipython().magic(u"cd")'),
+         ('%cd /home', 'get_ipython().magic(u"cd /home")'),
+         ('    %magic', '    get_ipython().magic(u"magic")'),
          ],
        
        # Quoting with separate arguments

--- a/IPython/core/tests/test_iplib.py
+++ b/IPython/core/tests/test_iplib.py
@@ -155,11 +155,11 @@ Exception reporting mode: Plain
 
 In [18]: %run simpleerr.py exit
 An exception has occurred, use %tb to see the full traceback.
-SystemExit: (1, 'Mode = exit')
+SystemExit: (1, u'Mode = exit')
 
 In [19]: %run simpleerr.py exit 2
 An exception has occurred, use %tb to see the full traceback.
-SystemExit: (2, 'Mode = exit')
+SystemExit: (2, u'Mode = exit')
 
 In [20]: %tb
 Traceback (most recent call last):
@@ -169,7 +169,7 @@ Traceback (most recent call last):
     sysexit(stat, mode)
   File ... line 11, in sysexit
     raise SystemExit(stat, 'Mode = %s' % mode)
-SystemExit: (2, 'Mode = exit')
+SystemExit: (2, u'Mode = exit')
 
 In [21]: %xmode context
 Exception reporting mode: Context
@@ -197,7 +197,7 @@ SystemExit                                Traceback (most recent call last)
      12 
      13 def bar(mode):
 <BLANKLINE>
-SystemExit: (2, 'Mode = exit')
+SystemExit: (2, u'Mode = exit')
 
 In [23]: %xmode verbose
 Exception reporting mode: Verbose
@@ -211,29 +211,29 @@ SystemExit                                Traceback (most recent call last)
      31 
 ---> 32     bar(mode)
         global bar = <function bar at ...>
-        global mode = 'exit'
+        global mode = u'exit'
 <BLANKLINE>
-... in bar(mode='exit')
+... in bar(mode=u'exit')
      20         except:
      21             stat = 1
 ---> 22         sysexit(stat, mode)
         global sysexit = <function sysexit at ...>
         stat = 2
-        mode = 'exit'
+        mode = u'exit'
      23     else:
      24         raise ValueError('Unknown mode')
 <BLANKLINE>
-... in sysexit(stat=2, mode='exit')
+... in sysexit(stat=2, mode=u'exit')
       9 
      10 def sysexit(stat, mode):
 ---> 11     raise SystemExit(stat, 'Mode = %s' % mode)
         global SystemExit = undefined
         stat = 2
-        mode = 'exit'
+        mode = u'exit'
      12 
      13 def bar(mode):
 <BLANKLINE>
-SystemExit: (2, 'Mode = exit')
+SystemExit: (2, u'Mode = exit')
     """
 
 

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -179,8 +179,8 @@ class TestMagicRunSimple(tt.TempFileMixin):
                "%%run '%s' C-second\n") % (tc, tc)
         self.mktmp(src, '.ipy')
         out = """\
-ARGV 1-: ['C-first']
-ARGV 1-: ['C-second']
+ARGV 1-: [u'C-first']
+ARGV 1-: [u'C-second']
 tclass.py: deleting object: C-first
 """
         tt.ipexec_validate(self.fname, out)

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -282,6 +282,7 @@ def make_quoted_expr(s):
     tail = ''
     tailpadding = ''
     raw  = ''
+    ucode = 'u'
     if "\\" in s:
         raw = 'r'
         if s.endswith('\\'):
@@ -298,7 +299,7 @@ def make_quoted_expr(s):
     else:
         # give up, backslash-escaped string will do
         return '"%s"' % esc_quotes(s)
-    res = raw + quote + s + tailpadding + quote + tail
+    res = ucode + raw + quote + s + tailpadding + quote + tail
     return res
 
 


### PR DESCRIPTION
Unicode characters got translated to 8-bit strings on the way to magic functions, causing some problems with %history. This allows unicode to be passed through to magic functions, and fixes up the tests to expect unicode arguments to InteractiveShell.magic().
