### PR TITLE
Unicode win process

### DIFF
--- a/IPython/utils/_process_win32.py
+++ b/IPython/utils/_process_win32.py
@@ -88,9 +88,12 @@ def _find_cmd(cmd):
 
 def _system_body(p):
     """Callback for _system."""
+    enc = sys.stdin.encoding
     for line in read_no_interrupt(p.stdout).splitlines():
+        line = line.decode(enc)
         print(line, file=sys.stdout)
     for line in read_no_interrupt(p.stderr).splitlines():
+        line = line.decode(enc)
         print(line, file=sys.stderr)
 
 

--- a/IPython/utils/_process_win32.py
+++ b/IPython/utils/_process_win32.py
@@ -88,12 +88,12 @@ def _find_cmd(cmd):
 
 def _system_body(p):
     """Callback for _system."""
-    enc = sys.stdin.encoding
+    enc = sys.stdin.encoding or sys.getdefaultencoding()
     for line in read_no_interrupt(p.stdout).splitlines():
-        line = line.decode(enc)
+        line = line.decode(enc, 'replace')
         print(line, file=sys.stdout)
     for line in read_no_interrupt(p.stderr).splitlines():
-        line = line.decode(enc)
+        line = line.decode(enc, 'replace')
         print(line, file=sys.stderr)
 
 

--- a/IPython/zmq/iostream.py
+++ b/IPython/zmq/iostream.py
@@ -44,6 +44,10 @@ class OutStream(object):
         else:
             data = self._buffer.getvalue()
             if data:
+                # Make sure that we're handling unicode
+                if not isinstance(data, unicode):
+                    enc = sys.stdin.encoding or sys.getdefaultencoding()
+                    data = data.decode(enc, 'replace')
                 content = {u'name':self.name, u'data':data}
                 msg = self.session.send(self.pub_socket, u'stream',
                                         content=content,


### PR DESCRIPTION
This apparently fixes a bug with non-ascii characters on Windows for Jörgen. I don't know if it's going to work in all cases (it uses the encoding of the kernel's stdin - will that always match the encoding of the stdout of a subprocess?), but it does solve the problem at least in his configuration, and I can't easily test it. The change shouldn't affect kernels running on anything other than Windows.
