### PR TITLE
Add missing external.pexpect to packages

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -116,6 +116,7 @@ def find_packages():
     add_package(packages, 'external.Itpl')
     add_package(packages, 'external.mglob')
     add_package(packages, 'external.path')
+    add_package(packages, 'external.pexpect')
     add_package(packages, 'external.pyparsing')
     add_package(packages, 'external.simplegeneric')
     add_package(packages, 'external.validate')


### PR DESCRIPTION
Now that IPython.external.pexpect is a package, it needs to be in find_packages. (This bit me while building an egg for distribution.)

This was originally filed against ipython-py3k:
https://github.com/ipython/ipython-py3k/pull/5
