### PR TITLE
Do not store file contents in history when running a .ipy file.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2068,7 +2068,7 @@ class InteractiveShell(Configurable, Magic):
                     # raised in user code.  It would be nice if there were
                     # versions of runlines, execfile that did raise, so
                     # we could catch the errors.
-                    self.run_cell(thefile.read())
+                    self.run_cell(thefile.read(), store_history=False)
             except:
                 self.showtraceback()
                 warn('Unknown failure executing file: <%s>' % fname)


### PR DESCRIPTION
Running a .ipy caused an error because it tried to insert the file's contents into the history database, leading to a clash of line number.

closes gh-328
