### PR TITLE
Hard reset

### DIFF
--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -319,6 +319,9 @@ class DisplayHook(Configurable):
             except: pass
         self.shell.user_ns['_oh'].clear()
         
+        # Release our own references to objects:
+        self._, self.__, self.___ = '', '', ''
+        
         if '_' not in __builtin__.__dict__:
             self.shell.user_ns.update({'_':None,'__':None, '___':None})
         import gc

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1044,6 +1044,9 @@ class InteractiveShell(Configurable, Magic):
         """
         # Clear histories
         self.history_manager.reset(new_session)
+        
+        # Flush cached output items
+        self.displayhook.flush()
 
         # Reset counter used to index all histories
         self.execution_count = 0
@@ -1068,6 +1071,10 @@ class InteractiveShell(Configurable, Magic):
         # Restore the default and user aliases
         self.alias_manager.clear_aliases()
         self.alias_manager.init_aliases()
+        
+        # Flush the private list of module references kept for script
+        # execution protection
+        self.clear_main_mod_cache()
 
     def reset_selective(self, regex=None):
         """Clear selective variables from internal namespaces based on a

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -991,7 +991,7 @@ Currently the magic system has the following functions:\n"""
         In [1]: 'a' in _ip.user_ns
         Out[1]: False
         """
-        opts, args = self.parse_options(parameter_s,'fh')
+        opts, args = self.parse_options(parameter_s,'sh')
         if 'f' in opts:
             ans = True
         else:

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -967,12 +967,15 @@ Currently the magic system has the following functions:\n"""
     def magic_reset(self, parameter_s=''):
         """Resets the namespace by removing all names defined by the user.
 
-        Input/Output history are left around in case you need them.
-
         Parameters
         ----------
           -f : force reset without asking for confirmation.
-
+          
+          -h : 'Hard' reset: gives you a new session and removes all
+          references to objects from the current session. By default, we
+          do a 'soft' reset, which only clears out your namespace, and
+          leaves input and output history around.
+        
         Examples
         --------
         In [6]: a = 1
@@ -988,8 +991,8 @@ Currently the magic system has the following functions:\n"""
         In [10]: 'a' in _ip.user_ns
         Out[10]: False
         """
-
-        if parameter_s == '-f':
+        opts, args = self.parse_options(parameter_s,'fh')
+        if 'f' in opts:
             ans = True
         else:
             ans = self.shell.ask_yes_no(
@@ -997,13 +1000,14 @@ Currently the magic system has the following functions:\n"""
         if not ans:
             print 'Nothing done.'
             return
-        user_ns = self.shell.user_ns
-        for i in self.magic_who_ls():
-            del(user_ns[i])
             
-        # Also flush the private list of module references kept for script
-        # execution protection
-        self.shell.clear_main_mod_cache()
+        if 'h' in opts:                     # Hard reset
+            self.shell.reset(new_session = True)
+            
+        else:                               # Soft reset
+            user_ns = self.shell.user_ns
+            for i in self.magic_who_ls():
+                del(user_ns[i])
 
     def magic_reset_selective(self, parameter_s=''):
         """Resets the namespace by removing names defined by the user.

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -971,10 +971,10 @@ Currently the magic system has the following functions:\n"""
         ----------
           -f : force reset without asking for confirmation.
           
-          -h : 'Hard' reset: gives you a new session and removes all
-          references to objects from the current session. By default, we
-          do a 'soft' reset, which only clears out your namespace, and
-          leaves input and output history around.
+          -s : 'Soft' reset: Only clears your namespace, leaving history intact.
+          References to objects may be kept. By default (without this option),
+          we do a 'hard' reset, giving you a new session and removing all
+          references to objects from the current session.
         
         Examples
         --------
@@ -988,8 +988,8 @@ Currently the magic system has the following functions:\n"""
 
         In [9]: %reset -f
 
-        In [10]: 'a' in _ip.user_ns
-        Out[10]: False
+        In [1]: 'a' in _ip.user_ns
+        Out[1]: False
         """
         opts, args = self.parse_options(parameter_s,'fh')
         if 'f' in opts:
@@ -1000,14 +1000,16 @@ Currently the magic system has the following functions:\n"""
         if not ans:
             print 'Nothing done.'
             return
-            
-        if 'h' in opts:                     # Hard reset
-            self.shell.reset(new_session = True)
-            
-        else:                               # Soft reset
+        
+        if 's' in opts:                     # Soft reset
             user_ns = self.shell.user_ns
             for i in self.magic_who_ls():
                 del(user_ns[i])
+            
+        else:                     # Hard reset
+            self.shell.reset(new_session = True)
+            
+        
 
     def magic_reset_selective(self, parameter_s=''):
         """Resets the namespace by removing names defined by the user.

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -392,7 +392,7 @@ def test_reset_hard():
     _ip.run_cell("a")
     
     nt.assert_equal(monitor, [])
-    _ip.magic_reset("-hf")
+    _ip.magic_reset("-f")
     nt.assert_equal(monitor, [1])
 
 def doctest_who():

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -379,6 +379,21 @@ def test_xmode():
     for i in range(3):
         _ip.magic("xmode")
     nt.assert_equal(_ip.InteractiveTB.mode, xmode)
+    
+def test_reset_hard():
+    monitor = []
+    class A(object):
+        def __del__(self):
+            monitor.append(1)
+        def __repr__(self):
+            return "<A instance>"
+            
+    _ip.user_ns["a"] = A()
+    _ip.run_cell("a")
+    
+    nt.assert_equal(monitor, [])
+    _ip.magic_reset("-hf")
+    nt.assert_equal(monitor, [1])
 
 def doctest_who():
     """doctest for %who


### PR DESCRIPTION
As requested in issue #49, this is a "hard reset", which should release any references we have to things, and completely reset the shell.

I've implemented this with a -h option to %reset. I've left %reset just clearing the user namespace by default. If this was being written from scratch, I think I would make %reset do a hard reset by default, but a soft reset is consistent with what it was already doing.
