### PR TITLE
make readline a dependency on OSX

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -218,6 +218,11 @@ if 'setuptools' in sys.modules:
         doc='Sphinx>=0.3',
         test='nose>=0.10.1',
     )
+    requires = setup_args.setdefault('install_requires', [])
+    if sys.platform == 'darwin':
+        requires.append('readline')
+    elif sys.platform.startswith('win'):
+        requires.append('pyreadline')
     
     # Script to be run by the windows binary installer after the default setup
     # routine, to add shortcuts and similar windows-only things.  Windows

--- a/setupbase.py
+++ b/setupbase.py
@@ -310,7 +310,7 @@ def check_for_dependencies():
         print_line, print_raw, print_status,
         check_for_sphinx, check_for_pygments,
         check_for_nose, check_for_pexpect,
-        check_for_pyzmq
+        check_for_pyzmq, check_for_readline
     )
     print_line()
     print_raw("BUILDING IPYTHON")
@@ -327,7 +327,7 @@ def check_for_dependencies():
     check_for_nose()
     check_for_pexpect()
     check_for_pyzmq()
-
+    check_for_readline()
 
 def record_commit_info(pkg_dir, build_cmd=build_py):
     """ Return extended build command class for recording commit

--- a/setupext/setupext.py
+++ b/setupext/setupext.py
@@ -140,3 +140,18 @@ def check_for_pyzmq():
             print_status("pyzmq", zmq.__version__)
             return True
 
+def check_for_readline():
+    try:
+        import readline
+    except ImportError:
+        try:
+            import pyreadline
+        except ImportError:
+            print_status('readline', "no (required for good interactive behavior)")
+            return False
+        else:
+            print_status('readline', "yes pyreadline-"+pyreadline.release.version)
+            return True
+    else:
+        print_status('readline', "yes")
+        return True


### PR DESCRIPTION
This commit makes readline a setuptools install dependency on OSX (so easy_installed ipython will always install it), and adds readline/pyreadline to the check_dependencies on OSX/Windows.

If merged, this should probably close #20, unless we really do want to bundle readline.
