### PR TITLE
Dedent prefix bugfix + tests: #142

### DIFF
--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -103,7 +103,13 @@ ESC_PAREN  = '/'     # Call first argument with rest of line as arguments
 # while developing.
 
 # compiled regexps for autoindent management
-dedent_re = re.compile(r'^\s+raise|^\s+return|^\s+pass')
+dedent_re = re.compile('|'.join([
+    r'^\s+raise(\s.*)?$', # raise statement (+ space + other stuff, maybe)
+    r'^\s+raise\([^\)]*\).*$', # wacky raise with immediate open paren
+    r'^\s+return(\s.*)?$', # normal return (+ space + other stuff, maybe)
+    r'^\s+return\([^\)]*\).*$', # wacky return with immediate open paren
+    r'^\s+pass\s*$' # pass (optionally followed by trailing spaces)
+]))
 ini_spaces_re = re.compile(r'^([ \t\r\f\v]+)')
 
 # regexp to match pure comment lines so we don't accidentally insert 'if 1:'

--- a/IPython/core/tests/test_inputsplitter.py
+++ b/IPython/core/tests/test_inputsplitter.py
@@ -192,13 +192,42 @@ class InputSplitterTestCase(unittest.TestCase):
         isp.push("    x = (1+\n    2)")
         self.assertEqual(isp.indent_spaces, 4)
 
-    def test_dedent(self):
+    def test_dedent_pass(self):
         isp = self.isp # shorthand
-        isp.push('if 1:')
+        # should NOT cause dedent
+        isp.push('if 1:\n    passes = 5')
         self.assertEqual(isp.indent_spaces, 4)
-        isp.push('    pass')
+        isp.push('if 1:\n     pass')
         self.assertEqual(isp.indent_spaces, 0)
-        
+        isp.push('if 1:\n     pass   ')
+        self.assertEqual(isp.indent_spaces, 0)
+
+    def test_dedent_raise(self):
+        isp = self.isp # shorthand
+        # should NOT cause dedent
+        isp.push('if 1:\n    raised = 4')
+        self.assertEqual(isp.indent_spaces, 4)
+        isp.push('if 1:\n     raise TypeError()')
+        self.assertEqual(isp.indent_spaces, 0)
+        isp.push('if 1:\n     raise')
+        self.assertEqual(isp.indent_spaces, 0)
+        isp.push('if 1:\n     raise      ')
+        self.assertEqual(isp.indent_spaces, 0)
+
+    def test_dedent_return(self):
+        isp = self.isp # shorthand
+        # should NOT cause dedent
+        isp.push('if 1:\n    returning = 4')
+        self.assertEqual(isp.indent_spaces, 4)
+        isp.push('if 1:\n     return 5 + 493')
+        self.assertEqual(isp.indent_spaces, 0)
+        isp.push('if 1:\n     return')
+        self.assertEqual(isp.indent_spaces, 0)
+        isp.push('if 1:\n     return      ')
+        self.assertEqual(isp.indent_spaces, 0)
+        isp.push('if 1:\n     return(0)')
+        self.assertEqual(isp.indent_spaces, 0)
+
     def test_push(self):
         isp = self.isp
         self.assertTrue(isp.push('x=1'))


### PR DESCRIPTION
Re: issue #142, this expands the inputsplitter regex for 'dedentation' to correctly handle ignore lines such as "passes += 1", which should not dedent even though it begins with "pass". It's fine with arbitrary trailing whitespace and a few other wacky corner cases (return() is valid Python, as is return(0), same with raise(TypeError()), etc. -- these only dedent if you at least have a close paren after the open paren.)

Also adds tests for these new behaviours.
