### PR TITLE
%reset doesn't reset prompt number.

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -164,15 +164,15 @@ class HistoryManager(Configurable):
     def reset(self, new_session=True):
         """Clear the session history, releasing all object references, and
         optionally open a new session."""
-        if self.session_number:
-            self.end_session()
-        self.input_hist_parsed[:] = [""]
-        self.input_hist_raw[:] = [""]
         self.output_hist.clear()
         # The directory history can't be completely empty
         self.dir_hist[:] = [os.getcwd()]
         
         if new_session:
+            if self.session_number:
+                self.end_session()
+            self.input_hist_parsed[:] = [""]
+            self.input_hist_raw[:] = [""]
             self.new_session()
     
     ## -------------------------------

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1045,12 +1045,12 @@ class InteractiveShell(Configurable, Magic):
         """
         # Clear histories
         self.history_manager.reset(new_session)
+        # Reset counter used to index all histories
+        if new_session:
+            self.execution_count = 1
         
         # Flush cached output items
         self.displayhook.flush()
-
-        # Reset counter used to index all histories
-        self.execution_count = 0
         
         # Restore the user namespaces to minimal usability
         for ns in self.ns_refs_table:

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -1007,7 +1007,7 @@ Currently the magic system has the following functions:\n"""
                 del(user_ns[i])
             
         else:                     # Hard reset
-            self.shell.reset(new_session = True)
+            self.shell.reset(new_session = False)
             
         
 


### PR DESCRIPTION
Also, calling ip.reset() in tests puts the execution_count back to 1 (its starting point), not 0.
