### PR TITLE
Fix %autopx magic

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2211,15 +2211,20 @@ class InteractiveShell(Configurable, Magic):
             
         exec_count = self.execution_count
         if to_run_exec:
-            mod = ast.Module(to_run_exec)
-            self.code_to_run = code = self.compile(mod, cell_name, "exec")
-            if self.run_code(code) == 1:
-                return
-                
+            for i, node in enumerate(to_run_exec):
+                mod = ast.Module([node])
+                self.code_to_run = code = self.compile(mod, cell_name+str(i), "exec")
+                if self.run_code(code) == 1:
+                    return 1
+
         if to_run_interactive:
-            mod = ast.Interactive(to_run_interactive)
-            self.code_to_run = code = self.compile(mod, cell_name, "single")
-            return self.run_code(code)
+            for i, node in enumerate(to_run_interactive):
+                mod = ast.Interactive([node])
+                self.code_to_run = code = self.compile(mod, cell_name, "single")
+                if self.run_code(code) == 1:
+                    return 1
+
+        return 0
     
     
     # PENDING REMOVAL: this method is slated for deletion, once our new
@@ -2336,11 +2341,17 @@ class InteractiveShell(Configurable, Magic):
         When an exception occurs, self.showtraceback() is called to display a
         traceback.
 
-        Return value: a flag indicating whether the code to be run completed
-        successfully:
+        Parameters
+        ----------
+        code_obj : code object
+          A compiled code object, to be executed
+        post_execute : bool [default: True]
+          whether to call post_execute hooks after this particular execution.
 
-          - 0: successful execution.
-          - 1: an error occurred.
+        Returns
+        -------
+        0 : successful execution.
+        1 : an error occurred.
         """
 
         # Set our own excepthook in case the user code tries to call it

--- a/IPython/extensions/parallelmagic.py
+++ b/IPython/extensions/parallelmagic.py
@@ -185,17 +185,21 @@ class ParalleMagic(Plugin):
                 print '[stdout:%i]'%eid, stdout[i]
 
 
-    def pxrun_cell(self, cell, store_history=True):
+    def pxrun_cell(self, raw_cell, store_history=True):
         """drop-in replacement for InteractiveShell.run_cell.
         
         This executes code remotely, instead of in the local namespace.
 
         See InteractiveShell.run_cell for details.
         """
+        
+        if (not raw_cell) or raw_cell.isspace():
+            return
+        
         ipself = self.shell
-        raw_cell = cell
+        
         with ipself.builtin_trap:
-            cell = ipself.prefilter_manager.prefilter_lines(cell)
+            cell = ipself.prefilter_manager.prefilter_lines(raw_cell)
         
             # Store raw and processed history
             if store_history:
@@ -244,7 +248,7 @@ class ParalleMagic(Plugin):
                         self._maybe_display_output(result)
                 return False
 
-    def pxrun_code(self, code_obj, post_execute=True):
+    def pxrun_code(self, code_obj):
         """drop-in replacement for InteractiveShell.run_code.
 
         This executes code remotely, instead of in the local namespace.

--- a/IPython/parallel/client/view.py
+++ b/IPython/parallel/client/view.py
@@ -765,11 +765,11 @@ class DirectView(View):
             print "The IPython parallel magics (%result, %px, %autopx) only work within IPython."
         else:
             pmagic = ip.plugin_manager.get_plugin('parallelmagic')
-            if pmagic is not None:
-                pmagic.active_view = self
-            else:
-                print "You must first load the parallelmagic extension " \
-                      "by doing '%load_ext parallelmagic'"
+            if pmagic is None:
+                ip.magic_load_ext('parallelmagic')
+                pmagic = ip.plugin_manager.get_plugin('parallelmagic')
+
+            pmagic.active_view = self
 
 
 @testdec.skip_doctest


### PR DESCRIPTION
run_ast_nodes previously called one big `run_code` for the whole cell.  This broke %autopx, which hijacks execution.

Previously, there was no call to override if %autopx was called inside a single cell (e.g. %run script.ipy). This commit splits run_ast_nodes, so that each node gets a separate call to run_code, and overriding run_code successfully hijacks execution.
