### PR TITLE
#342: Try to recover as intelligently as possible if user calls magic().

### DIFF
--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -881,7 +881,7 @@ class MagicHandler(PrefilterHandler):
             # will make clear that the input was rewritten, and individual
             # magics should print a useful error message that show how to call.
             the_rest = ''
-            self.shell.auto_rewrite_input(ifun)
+            self.shell.auto_rewrite_input(ESC_MAGIC + ifun)
 
         cmd = '%sget_ipython().magic(%s)' % (line_info.pre_whitespace,
                                    make_quoted_expr(ifun + " " + the_rest))


### PR DESCRIPTION
This was annoying me from the perspective of force-of-habit typing quit() (system install at the lab of IPython 0.8.3 (!!!!!) requires it) but in general, people typing some_magic() with automagic on and expecting results might be awfully surprised by the NameError that results.

This attempts to address the problem in the following way:
- Check if whatever precedes the first paren in line_info.ifun is a magic, and of course is not shadowed by something in the user namespace
- Throw out everything after the first paren, as well as the contents of line_info.the_rest (trying to sensibly convert function call syntax to magic-calling syntax in a general way doesn't seem prudent or possible)
- Visually rewrite as `----> %some_magic` so that the user has some clue that what he typed was interpreted as a magic but that the subsequent parenthesized arguments were ignored.

The result looks something like this:

```
In [6]: quit(5, 4, 3)
------> %quit
dwf@strafe:~$ 
```

Ideally then, individual magics, if they require arguments, will complain about not receiving them, _and in the process_ demonstrate their usage with the correct `%foo bar baz` way of calling them.

This pull request replaces #345.
