### PR TITLE
Rewrite quit()/exit()/Quit()/Exit() calls as magic

### DIFF
--- a/IPython/core/tests/test_handlers.py
+++ b/IPython/core/tests/test_handlers.py
@@ -42,8 +42,9 @@ def run(tests):
     transformed (i.e. ipython's notion of _i)"""
     for pre, post in tests:
         global num_tests
-        num_tests += 1        
-        actual = ip.prefilter_manager.prefilter_lines(pre)
+        num_tests += 1
+        with ip.shell.builtin_trap:
+            actual = ip.prefilter_manager.prefilter_lines(pre)
         if actual != None:
             actual = actual.rstrip('\n')
         if actual != post:
@@ -169,4 +170,10 @@ def test_handlers():
         ])
     ip.magic('autocall 1')
 
+    for quit_str in ['quit', 'Quit', 'exit', 'Exit']:
+        run([
+            ("%s()" % quit_str,  'get_ipython().magic(u"%s")' % quit_str),
+            ("%s(  )" % quit_str,  'get_ipython().magic(u"%s")' % quit_str),
+            ("%s(0)" % quit_str,  'get_ipython().magic(u"%s")' % quit_str),
+        ])
     nt.assert_equals(failures, [])


### PR DESCRIPTION
This is a resubmit of #345, GitHub wasn't updating the range, perhaps because I pushed those changes while the pull request was closed. #352 was an alternate plan that was decided against.

This attempts to resolve the complaint in #142 about quit() and exit() and their capitalized counterparts, by explicitly checking for these forms (with a regexp, for speed) and rewriting them as their corresponding magics. Just checks for at least one pair of parens following the initial token, with anything in between; nothing fancy. See the commit message of d0e797be8f93758497878a444c7de972b1037d8a for details.
