### PR TITLE
Cell tweaks

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2106,24 +2106,28 @@ class InteractiveShell(Configurable, Magic):
                 self.showtraceback()
                 warn('Unknown failure executing file: <%s>' % fname)
                 
-    def run_cell(self, cell, store_history=True):
+    def run_cell(self, raw_cell, store_history=True):
         """Run a complete IPython cell.
         
         Parameters
         ----------
-        cell : str
+        raw_cell : str
           The code (including IPython code such as %magic functions) to run.
         store_history : bool
           If True, the raw and translated cell will be stored in IPython's
           history. For user code calling back into IPython's machinery, this
           should be set to False.
         """
-        if not cell.strip():
+        if not raw_cell.strip():
             return
         
-        raw_cell = cell
+        for line in raw_cell.splitlines():
+            self.input_splitter.push(line)
+        cell = self.input_splitter.source_reset()
+        
         with self.builtin_trap:
-            cell = self.prefilter_manager.prefilter_lines(cell)
+            if len(cell.splitlines()) == 1:
+                cell = self.prefilter_manager.prefilter_lines(cell)
             
             # Store raw and processed history
             if store_history:

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2118,7 +2118,7 @@ class InteractiveShell(Configurable, Magic):
           history. For user code calling back into IPython's machinery, this
           should be set to False.
         """
-        if not raw_cell.strip():
+        if (not raw_cell) or raw_cell.isspace():
             return
         
         for line in raw_cell.splitlines():

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2118,6 +2118,9 @@ class InteractiveShell(Configurable, Magic):
           history. For user code calling back into IPython's machinery, this
           should be set to False.
         """
+        if not cell.strip():
+            return
+        
         raw_cell = cell
         with self.builtin_trap:
             cell = self.prefilter_manager.prefilter_lines(cell)

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -89,5 +89,5 @@ class InteractiveShellTestCase(unittest.TestCase):
         
     def test_magic_names_in_string(self):
         ip = get_ipython()
-        ip.run_cell('"""\n%exit\n"""')
-        self.assertEquals(ip.user_ns['In'][-1], '\n%exit\n')
+        ip.run_cell('a = """\n%exit\n"""')
+        self.assertEquals(ip.user_ns['a'], '\n%exit\n')

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -86,3 +86,8 @@ class InteractiveShellTestCase(unittest.TestCase):
         newlen = len(ip.user_ns['In'])
         self.assertEquals(oldlen+1, newlen)
         self.assertEquals(ip.user_ns['In'][-1],'1;')
+        
+    def test_magic_names_in_string(self):
+        ip = get_ipython()
+        ip.run_cell('"""\n%exit\n"""')
+        self.assertEquals(ip.user_ns['In'][-1], '\n%exit\n')

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -41,7 +41,9 @@ class InteractiveShellTestCase(unittest.TestCase):
         """Just make sure we don't get a horrible error with a blank
         cell of input. Yes, I did overlook that."""
         ip = get_ipython()
+        old_xc = ip.execution_count
         ip.run_cell('')
+        self.assertEquals(ip.execution_count, old_xc)
 
     def test_run_cell_multiline(self):
         """Multi-block, multi-line cells must execute correctly.

--- a/IPython/lib/tests/test_irunner.py
+++ b/IPython/lib/tests/test_irunner.py
@@ -33,6 +33,9 @@ class RunnerTestCase(unittest.TestCase):
         out_l = [l for l in out.splitlines() if l and not l.isspace()]
         mismatch  = 0
         if len(output_l) != len(out_l):
+            print "\n".join(output_l)
+            print "==================="
+            print "\n".join(out_l)
             self.fail('mismatch in number of lines')
         for n in range(len(output_l)):
             # Do a line-by-line comparison

--- a/IPython/lib/tests/test_irunner.py
+++ b/IPython/lib/tests/test_irunner.py
@@ -33,10 +33,15 @@ class RunnerTestCase(unittest.TestCase):
         out_l = [l for l in out.splitlines() if l and not l.isspace()]
         mismatch  = 0
         if len(output_l) != len(out_l):
-            print "\n".join(output_l)
-            print "==================="
-            print "\n".join(out_l)
-            self.fail('mismatch in number of lines')
+            message = ("Mismatch in number of lines\n\n"
+                       "Expected:\n"
+                       "~~~~~~~~~\n"
+                       "%s\n\n"
+                       "Got:\n"
+                       "~~~~~~~~~\n"
+                       "%s"
+                       ) % ("\n".join(output_l), "\n".join(out_l))
+            self.fail(message)
         for n in range(len(output_l)):
             # Do a line-by-line comparison
             ol1 = output_l[n].strip()


### PR DESCRIPTION
This fixes and adds tests for a couple of bugs my ast refactor had introduced:
1. Pressing return in a blank cell shouldn't increment the execution_count.
2. We shouldn't do transformations inside multi-line strings, so entering:

<pre>
"""
%lsmagic
"""
</pre>


should get you the same string back.
