### PR TITLE
History save thread

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -486,13 +486,17 @@ class HistorySavingThread(threading.Thread):
         
     def run(self):
         # We need a separate db connection per thread:
-        self.db = sqlite3.connect(self.history_manager.hist_file)
-        while True:
-            self.history_manager.save_flag.wait()
-            if self.stop_now:
-                return
-            self.history_manager.save_flag.clear()
-            self.history_manager.writeout_cache(self.db)
+        try:
+            self.db = sqlite3.connect(self.history_manager.hist_file)
+            while True:
+                self.history_manager.save_flag.wait()
+                if self.stop_now:
+                    return
+                self.history_manager.save_flag.clear()
+                self.history_manager.writeout_cache(self.db)
+        except Exception as e:
+            print(("The history saving thread hit an unexpected error (%s)."
+                   "History will not be written to the database.") % repr(e))
         
     def stop(self):
         """This can be called from the main thread to safely stop this thread.

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -80,6 +80,7 @@ class HistoryManager(Configurable):
     
     # History saving in separate thread
     save_thread = Instance('IPython.core.history.HistorySavingThread')
+    # N.B. Event is a function returning an instance of _Event.
     save_flag = Instance(threading._Event)
     
     # Private interface

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -152,10 +152,13 @@ class HistoryManager(Configurable):
                         PRIMARY KEY (session, line))""")
         self.db.commit()
     
-    def new_session(self):
+    def new_session(self, conn=None):
         """Get a new session number."""
-        with self.db:
-            cur = self.db.execute("""INSERT INTO sessions VALUES (NULL, ?, NULL,
+        if conn is None:
+            conn = self.db
+        
+        with conn:
+            cur = conn.execute("""INSERT INTO sessions VALUES (NULL, ?, NULL,
                             NULL, "") """, (datetime.datetime.now(),))
             self.session_number = cur.lastrowid
             
@@ -446,7 +449,7 @@ class HistoryManager(Configurable):
             try:
                 self._writeout_input_cache(conn)
             except sqlite3.IntegrityError:
-                self.new_session()
+                self.new_session(conn)
                 print("ERROR! Session/line number was not unique in",
                       "database. History logging moved to new session",
                                                 self.session_number)

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -22,7 +22,6 @@ import sqlite3
 import threading
 
 from collections import defaultdict
-from contextlib import nested
 
 # Our own packages
 from IPython.config.configurable import Configurable

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -167,7 +167,8 @@ def default_config():
     config.TerminalInteractiveShell.colors = 'NoColor'
     config.TerminalTerminalInteractiveShell.term_title = False,
     config.TerminalInteractiveShell.autocall = 0
-    config.HistoryManager.hist_file = u':memory:'
+    config.HistoryManager.hist_file = u'test_hist.sqlite'
+    config.HistoryManager.db_cache_size = 10000
     return config
 
 


### PR DESCRIPTION
OK, I think this is tidy enough to bring forward now.

@fperez requested that history be saved in a separate thread, so the UI was more responsive. Despite some initial reservations, that's what I implemented. When I test, I can actually see a difference on my computer (without the aggressive HDD spin down Fernando experiences). So I'm on board with the value of this now.

That said, this is still introducing an extra thread, so please go over it with a fine toothcomb looking for possible multithreading issues. So far, I've dealt with:
- SQLite connections can't be shared across threads, so we need a separate connection for the main thread and the save thread. This also means we can't use in-memory databases for the tests, because you can't have more than one connection to them. I've set a large cache size for the tests, so the performance hit is negligible.
- The input and output caches have locks surrounding their access (so if you execute a cell while it's writing out the cache, you'll still see a small hang while it finishes. There are ways round this, but it shouldn't be a common problem).
- We have to be sure to stop the thread safely when we close, or a mysterious thread traceback appears.
