### PR TITLE
Usability improvements to history in Qt console

### DIFF
--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -652,13 +652,13 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
         """
         pass
 
-    def _up_pressed(self):
+    def _up_pressed(self, shift_modifier):
         """ Called when the up key is pressed. Returns whether to continue
             processing the event.
         """
         return True
 
-    def _down_pressed(self):
+    def _down_pressed(self, shift_modifier):
         """ Called when the down key is pressed. Returns whether to continue
             processing the event.
         """
@@ -1040,14 +1040,14 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
                 intercepted = True
 
             elif key == QtCore.Qt.Key_Up:
-                if self._reading or not self._up_pressed():
+                if self._reading or not self._up_pressed(shift_down):
                     intercepted = True
                 else:
                     prompt_line = self._get_prompt_cursor().blockNumber()
                     intercepted = cursor.blockNumber() <= prompt_line
 
             elif key == QtCore.Qt.Key_Down:
-                if self._reading or not self._down_pressed():
+                if self._reading or not self._down_pressed(shift_down):
                     intercepted = True
                 else:
                     end_line = self._get_end_cursor().blockNumber()


### PR DESCRIPTION
I have implemented readline-style history saving and optional (off by default) history locking as discussed in #338.

@fperez
I have used Shift as the modifier for overriding the history lock. This is symmetric with the Shift+Enter keybinding, which I like, but it also means that Shift+Up/Down are context-sensitive: they perform text selection if not on the first/last lines. I considered using Ctrl, but then Ctrl+P and Ctrl+N would not be supported properly, which I don't like. That leaves Alt and Meta, but both are more obscure and more difficult to press than Shift or Ctrl. In short, I am paralyzed by indecision :)
