### PR TITLE
don't rely on setuptools for readline dependency check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ from setupbase import (
     check_for_dependencies,
     record_commit_info,
 )
+from setupext.setupext import check_for_readline
 
 isfile = os.path.isfile
 pjoin = os.path.join
@@ -219,10 +220,14 @@ if 'setuptools' in sys.modules:
         test='nose>=0.10.1',
     )
     requires = setup_args.setdefault('install_requires', [])
-    if sys.platform == 'darwin':
-        requires.append('readline')
-    elif sys.platform.startswith('win'):
-        requires.append('pyreadline')
+    if not check_for_readline():
+        if sys.platform == 'darwin':
+                requires.append('readline')
+        elif sys.platform.startswith('win'):
+            requires.append('pyreadline')
+        else:
+            pass
+            # do we want to install readline here?
     
     # Script to be run by the windows binary installer after the default setup
     # routine, to add shortcuts and similar windows-only things.  Windows

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ from setupbase import (
     check_for_dependencies,
     record_commit_info,
 )
-from setupext.setupext import check_for_readline
+from setupext import setupext
 
 isfile = os.path.isfile
 pjoin = os.path.join
@@ -220,9 +220,10 @@ if 'setuptools' in sys.modules:
         test='nose>=0.10.1',
     )
     requires = setup_args.setdefault('install_requires', [])
-    if not check_for_readline():
+    setupext.display_status = False
+    if not setupext.check_for_readline():
         if sys.platform == 'darwin':
-                requires.append('readline')
+            requires.append('readline')
         elif sys.platform.startswith('win'):
             requires.append('pyreadline')
         else:

--- a/setupext/setupext.py
+++ b/setupext/setupext.py
@@ -18,29 +18,35 @@ from textwrap import fill
 
 display_status=True
 
-if display_status:
-    def print_line(char='='):
-        print char * 76
+def check_display(f):
+    """decorator to allow display methods to be muted by mod.display_status"""
+    def maybe_display(*args, **kwargs):
+        if display_status:
+            return f(*args, **kwargs)
+    return maybe_display
 
-    def print_status(package, status):
-        initial_indent = "%22s: " % package
-        indent = ' ' * 24
-        print fill(str(status), width=76,
-                   initial_indent=initial_indent,
-                   subsequent_indent=indent)
+@check_display
+def print_line(char='='):
+    print char * 76
 
-    def print_message(message):
-        indent = ' ' * 24 + "* "
-        print fill(str(message), width=76,
-                   initial_indent=indent,
-                   subsequent_indent=indent)
+@check_display
+def print_status(package, status):
+    initial_indent = "%22s: " % package
+    indent = ' ' * 24
+    print fill(str(status), width=76,
+               initial_indent=initial_indent,
+               subsequent_indent=indent)
 
-    def print_raw(section):
-        print section
-else:
-    def print_line(*args, **kwargs):
-        pass
-    print_status = print_message = print_raw = print_line
+@check_display
+def print_message(message):
+    indent = ' ' * 24 + "* "
+    print fill(str(message), width=76,
+               initial_indent=indent,
+               subsequent_indent=indent)
+
+@check_display
+def print_raw(section):
+    print section
 
 #-------------------------------------------------------------------------------
 # Tests for specific packages


### PR DESCRIPTION
ddale reported (https://github.com/ipython/ipython/pull/343#issuecomment-983404) an issue with the readline dependency.

I imagine this is because setuptools does not actually know about packages that it did not install, so readline installed by other means (my guess from his path is that he uses macports) will not show up.

This commit does explicit import checks, rather than trusting setuptools to find the dependency.
