### PR TITLE
fallback on defaultencoding if filesystemencoding is None

### DIFF
--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -25,6 +25,8 @@ from IPython.utils.importstring import import_item
 # Code
 #-----------------------------------------------------------------------------
 
+# in case filesystemencoding() returns None:
+fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
 
 def _get_long_path_name(path):
     """Dummy no-op."""
@@ -170,7 +172,7 @@ def get_home_dir():
         root=os.path.abspath(root).rstrip('\\')
         if isdir(os.path.join(root, '_ipython')):
             os.environ["IPYKITROOT"] = root
-        return root.decode(sys.getfilesystemencoding())
+        return root.decode(fs_encoding)
 
     if os.name == 'posix':
         # Linux, Unix, AIX, OS X
@@ -185,11 +187,11 @@ def get_home_dir():
             homedir = Popen('echo $HOME', shell=True, 
                             stdout=PIPE).communicate()[0].strip()
             if homedir:
-                return homedir.decode(sys.getfilesystemencoding())
+                return homedir.decode(fs_encoding)
             else:
                 raise HomeDirError('Undefined $HOME, IPython cannot proceed.')
         else:
-            return homedir.decode(sys.getfilesystemencoding())
+            return homedir.decode(fs_encoding)
     elif os.name == 'nt':
         # Now for win9x, XP, Vista, 7?
         # For some strange reason all of these return 'nt' for os.name.
@@ -203,7 +205,7 @@ def get_home_dir():
             pass
         else:
             if isdir(homedir):
-                return homedir.decode(sys.getfilesystemencoding())
+                return homedir.decode(fs_encoding)
 
         # Now look for a local home directory
         try:
@@ -212,7 +214,7 @@ def get_home_dir():
             pass
         else:
             if isdir(homedir):
-                return homedir.decode(sys.getfilesystemencoding())
+                return homedir.decode(fs_encoding)
 
         # Now the users profile directory
         try:
@@ -221,7 +223,7 @@ def get_home_dir():
             pass
         else:
             if isdir(homedir):
-                return homedir.decode(sys.getfilesystemencoding())
+                return homedir.decode(fs_encoding)
 
         # Use the registry to get the 'My Documents' folder.
         try:
@@ -236,7 +238,7 @@ def get_home_dir():
             pass
         else:
             if isdir(homedir):
-                return homedir.decode(sys.getfilesystemencoding())
+                return homedir.decode(fs_encoding)
 
         # A user with a lot of unix tools in win32 may have defined $HOME.
         # Try this as a last ditch option.
@@ -246,13 +248,13 @@ def get_home_dir():
             pass
         else:
             if isdir(homedir):
-                return homedir.decode(sys.getfilesystemencoding())
+                return homedir.decode(fs_encoding)
 
         # If all else fails, raise HomeDirError
         raise HomeDirError('No valid home directory could be found')
     elif os.name == 'dos':
         # Desperate, may do absurd things in classic MacOS. May work under DOS.
-        return 'C:\\'.decode(sys.getfilesystemencoding())
+        return 'C:\\'.decode(fs_encoding)
     else:
         raise HomeDirError('No valid home directory could be found for your OS')
 
@@ -270,7 +272,7 @@ def get_xdg_dir():
         # use ~/.config if not set OR empty
         xdg = env.get("XDG_CONFIG_HOME", None) or os.path.join(get_home_dir(), '.config')
         if xdg and isdir(xdg):
-            return xdg.decode(sys.getfilesystemencoding())
+            return xdg.decode(fs_encoding)
     
     return None
     
@@ -309,13 +311,13 @@ def get_ipython_dir():
             # not using XDG
             ipdir = home_ipdir
     
-    return ipdir.decode(sys.getfilesystemencoding())
+    return ipdir.decode(fs_encoding)
 
 
 def get_ipython_package_dir():
     """Get the base directory where IPython itself is installed."""
     ipdir = os.path.dirname(IPython.__file__)
-    return ipdir.decode(sys.getfilesystemencoding())
+    return ipdir.decode(fs_encoding)
 
 
 def get_ipython_module_path(module_str):
@@ -330,7 +332,7 @@ def get_ipython_module_path(module_str):
     mod = import_item(module_str)
     the_path = mod.__file__.replace('.pyc', '.py')
     the_path = the_path.replace('.pyo', '.py')
-    return the_path.decode(sys.getfilesystemencoding())
+    return the_path.decode(fs_encoding)
 
 
 def expand_path(s):


### PR DESCRIPTION
closes gh-137

`sys.getfilesystemencoding()` could be `None`, which when passed to decode would raise.  `filesystemencoding` now falls back to `defaultencoding` if `None`, which can't (as far as I can tell) be undefined.  I could add a secondary 'ascii' fallback, if that is possible.
