### PR TITLE
Issue 125

### DIFF
--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -570,7 +570,7 @@ class IPythonApp(Application):
                     try:
                         self.log.info("Running code in user namespace: %s" %
                                       line)
-                        self.shell.run_cell(line)
+                        self.shell.run_cell(line, store_history=False)
                     except:
                         self.log.warn("Error in executing line in user "
                                       "namespace: %s" % line)
@@ -615,7 +615,7 @@ class IPythonApp(Application):
             try:
                 self.log.info("Running code given at command line (-c): %s" %
                               line)
-                self.shell.run_cell(line)
+                self.shell.run_cell(line, store_history=False)
             except:
                 self.log.warn("Error in executing line in user namespace: %s" %
                               line)


### PR DESCRIPTION
run_cell(exec_lines) is now called with 'store_history=False'

This prevents config file defined exec_lines from showing up
in the history, and results in input counter always starting at 1

closes gh-125
