### PR TITLE
Fixes to the display system

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -119,4 +119,12 @@ def display_json(*objs):
     display(*objs, include=['text/plain','application/json'])
 
 
+def display_javascript(*objs):
+    """Display the Javascript representation of an object.
 
+    Parameters
+    ----------
+    objs : tuple of objects
+        The Python objects to display.
+    """
+    display(*objs, include=['text/plain','application/javascript'])

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -449,6 +449,10 @@ class HTMLFormatter(BaseFormatter):
     objects, define a :meth:`_repr_html_` method or use the :meth:`for_type`
     or :meth:`for_type_by_name` methods to register functions that handle
     this.
+
+    The return value of this formatter should be a valid HTML snippet that
+    could be injected into an existing DOM. It should *not* include the 
+    ```<html>`` or ```<body>`` tags.
     """
     format_type = Str('text/html')
 
@@ -462,6 +466,10 @@ class SVGFormatter(BaseFormatter):
     objects, define a :meth:`_repr_svg_` method or use the :meth:`for_type`
     or :meth:`for_type_by_name` methods to register functions that handle
     this.
+
+    The return value of this formatter should be valid SVG enclosed in
+    ```<svg>``` tags, that could be injected into an existing DOM. It should
+    *not* include the ```<html>`` or ```<body>`` tags.
     """
     format_type = Str('image/svg+xml')
 
@@ -476,7 +484,8 @@ class PNGFormatter(BaseFormatter):
     or :meth:`for_type_by_name` methods to register functions that handle
     this.
 
-    The raw data should be the base64 encoded raw png data.
+    The return value of this formatter should be raw PNG data, *not*
+    base64 encoded.
     """
     format_type = Str('image/png')
 
@@ -490,6 +499,9 @@ class LatexFormatter(BaseFormatter):
     objects, define a :meth:`_repr_latex_` method or use the :meth:`for_type`
     or :meth:`for_type_by_name` methods to register functions that handle
     this.
+
+    The return value of this formatter should be a valid LaTeX equation,
+    enclosed in either ```$``` or ```$$```.
     """
     format_type = Str('text/latex')
 
@@ -503,6 +515,8 @@ class JSONFormatter(BaseFormatter):
     your objects, define a :meth:`_repr_json_` method or use the :meth:`for_type`
     or :meth:`for_type_by_name` methods to register functions that handle
     this.
+
+    The return value of this formatter should be a valid JSON string.
     """
     format_type = Str('application/json')
 
@@ -516,6 +530,9 @@ class JavascriptFormatter(BaseFormatter):
     your objects, define a :meth:`_repr_javascript_` method or use the 
     :meth:`for_type` or :meth:`for_type_by_name` methods to register functions
     that handle this.
+
+    The return value of this formatter should be valid Javascript code and
+    should *not* be enclosed in ```<script>``` tags.
     """
     format_type = Str('application/javascript')
 

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -343,8 +343,8 @@ class PlainTextFormatter(BaseFormatter):
     # something.
     enabled = Bool(True, config=False)
 
-    # Look for a __pretty__ methods to use for pretty printing.
-    print_method = Str('__pretty__')
+    # Look for a _repr_pretty_ methods to use for pretty printing.
+    print_method = Str('_repr_pretty_')
 
     # Whether to pretty-print or not.
     pprint = Bool(True, config=True)

--- a/IPython/core/usage.py
+++ b/IPython/core/usage.py
@@ -458,7 +458,7 @@ Python objects can simply be passed to these functions and the appropriate
 representations will be displayed in the console as long as the objects know
 how to compute those representations. The easiest way of teaching objects how
 to format themselves in various representations is to define special methods
-such as: ``__html``, ``__svg__`` and ``__png__``. IPython's display formatters
+such as: ``_repr_html_``, ``_repr_svg_`` and ``_repr_png_``. IPython's display formatters
 can also be given custom formatter functions for various types::
 
     In [6]: ip = get_ipython()

--- a/IPython/extensions/sympy_printing.py
+++ b/IPython/extensions/sympy_printing.py
@@ -39,7 +39,7 @@ def print_basic_unicode(o, p, cycle):
 
 
 def print_png(o):
-    """A funciton to display sympy expression using LaTex -> PNG."""
+    """A function to display sympy expression using LaTex -> PNG."""
     s = latex(o, mode='inline')
     # mathtext does not understand certain latex flags, so we try to replace
     # them with suitable subs.

--- a/IPython/extensions/sympyprinting.py
+++ b/IPython/extensions/sympyprinting.py
@@ -45,7 +45,7 @@ def print_png(o):
     # them with suitable subs.
     s = s.replace('\\operatorname','')
     s = s.replace('\\overline', '\\bar')
-    png = latex_to_png(s, encode=True)
+    png = latex_to_png(s)
     return png
 
 _loaded = False

--- a/IPython/lib/latextools.py
+++ b/IPython/lib/latextools.py
@@ -45,6 +45,7 @@ def latex_to_png(s, encode=False):
         bin_data = encodestring(bin_data)
     return bin_data
 
+
 _data_uri_template_png = """<img src="data:image/png;base64,%s" alt=%s />"""
 
 def latex_to_html(s, alt='image'):
@@ -59,4 +60,51 @@ def latex_to_html(s, alt='image'):
     """
     base64_data = latex_to_png(s, encode=True)
     return _data_uri_template_png  % (base64_data, alt)
+
+
+# From matplotlib, thanks to mdboom. Once this is in matplotlib releases, we
+# will remove.
+def math_to_image(s, filename_or_obj, prop=None, dpi=None, format=None):
+    """
+    Given a math expression, renders it in a closely-clipped bounding
+    box to an image file.
+
+    *s*
+       A math expression.  The math portion should be enclosed in
+       dollar signs.
+
+    *filename_or_obj*
+       A filepath or writable file-like object to write the image data
+       to.
+
+    *prop*
+       If provided, a FontProperties() object describing the size and
+       style of the text.
+
+    *dpi*
+       Override the output dpi, otherwise use the default associated
+       with the output format.
+
+    *format*
+       The output format, eg. 'svg', 'pdf', 'ps' or 'png'.  If not
+       provided, will be deduced from the filename.
+    """
+    from matplotlib import figure
+    # backend_agg supports all of the core output formats
+    from matplotlib.backends import backend_agg
+    from matplotlib.font_manager import FontProperties
+    from matplotlib.mathtext import MathTextParser
+
+    if prop is None:
+        prop = FontProperties()
+
+    parser = MathTextParser('path')
+    width, height, depth, _, _ = parser.parse(s, dpi=72, prop=prop)
+
+    fig = figure.Figure(figsize=(width / 72.0, height / 72.0))
+    fig.text(0, depth/height, s, fontproperties=prop)
+    backend_agg.FigureCanvasAgg(fig)
+    fig.savefig(filename_or_obj, dpi=dpi, format=format)
+
+    return depth
 

--- a/IPython/lib/latextools.py
+++ b/IPython/lib/latextools.py
@@ -25,7 +25,7 @@ from base64 import encodestring
 #-----------------------------------------------------------------------------
 
 
-def latex_to_png(s, encode=True):
+def latex_to_png(s, encode=False):
     """Render a LaTeX string to PNG using matplotlib.mathtext.
 
     Parameters

--- a/IPython/lib/pylabtools.py
+++ b/IPython/lib/pylabtools.py
@@ -60,7 +60,8 @@ def getfigs(*fig_nums):
             f = Gcf.figs.get(num)
             if f is None:
                 print('Warning: figure %s not available.' % num)
-            figs.append(f.canvas.figure)
+            else:
+                figs.append(f.canvas.figure)
         return figs
 
 

--- a/IPython/zmq/zmqshell.py
+++ b/IPython/zmq/zmqshell.py
@@ -16,6 +16,7 @@ machinery.  This should thus be thought of as scaffolding.
 from __future__ import print_function
 
 # Stdlib
+from base64 import encodestring
 import inspect
 import os
 
@@ -67,6 +68,9 @@ class ZMQDisplayHook(DisplayHook):
             self.msg['content']['execution_count'] = self.prompt_count
 
     def write_format_data(self, format_dict):
+        pngdata = format_dict.get('image/png')
+        if pngdata is not None:
+            format_dict['image/png'] = encodestring(pngdata)
         self.msg['content']['data'] = format_dict
 
     def finish_displayhook(self):

--- a/docs/examples/core/display.py
+++ b/docs/examples/core/display.py
@@ -1,0 +1,26 @@
+"""Code that shows off the IPython display logic.
+"""
+
+from IPython.core.display import (
+    display, display_pretty, display_html,
+    display_svg, display_json
+)
+
+class Circle(object):
+
+    def __init__(self, radius):
+        self.radius = radius
+
+    def _repr_pretty_(self, p, cycle):
+        p.text(u"\u25CB")
+
+    __pretty__ = _repr_pretty_
+
+    def _repr_html_(self):
+        return "<h1>Cirle: radius=%s</h1>" % self.radius
+
+    def _repr_svg_(self):
+        return """<svg>
+<circle cx="100" cy="50" r="40" stroke="black" stroke-width="2" fill="red"/>
+</svg>"""
+

--- a/docs/examples/core/display.py
+++ b/docs/examples/core/display.py
@@ -14,8 +14,6 @@ class Circle(object):
     def _repr_pretty_(self, p, cycle):
         p.text(u"\u25CB")
 
-    __pretty__ = _repr_pretty_
-
     def _repr_html_(self):
         return "<h1>Cirle: radius=%s</h1>" % self.radius
 

--- a/docs/examples/core/display.py
+++ b/docs/examples/core/display.py
@@ -1,9 +1,10 @@
 """Code that shows off the IPython display logic.
 """
 
+from IPython.lib.latextools import latex_to_png
 from IPython.core.display import (
     display, display_pretty, display_html,
-    display_svg, display_json
+    display_svg, display_json, display_png
 )
 
 class Circle(object):
@@ -22,3 +23,5 @@ class Circle(object):
 <circle cx="100" cy="50" r="40" stroke="black" stroke-width="2" fill="red"/>
 </svg>"""
 
+    def _repr_png_(self):
+        return latex_to_png('$\circle$')


### PR DESCRIPTION
The IPython formatters use special methods to compute the format
of objects. These special methods have names like `__html__`, but
with this commit these have been changed to `_repr_html_`.

I have also added a Javascript formatter and fixed a bug in
pylab tools in getfigs.

Some remaining questions:
- We are still using the old logic in pretty.py and the special name `__pretty__`.  Do we want to update pretty.py as well and use `_repr_pretty_`?
- Are we happy with the special names in this branch?
- Should `_repr_png_` return the raw png data or base64 encoded data (required for sending over json).  Currently we base64 encode.
- Should the latex representation include the wrapping $ or $$?
- Should the javascript repr output the raw javascript or include it in a `<script>` tag pair.
