### PR TITLE
Multiline input push

### DIFF
--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -310,7 +310,7 @@ class InputSplitter(object):
 
         self._update_indent(lines)
         try:
-            self.code = self._compile(source)
+            self.code = self._compile(source, symbol="exec")
         # Invalid syntax can produce any of a number of different errors from
         # inside the compiler, so we have to catch them all.  Syntax errors
         # immediately produce a 'ready' block, so the invalid Python can be

--- a/IPython/core/tests/test_inputsplitter.py
+++ b/IPython/core/tests/test_inputsplitter.py
@@ -238,6 +238,12 @@ class InputSplitterTestCase(unittest.TestCase):
         for line in ['  x=1', '# a comment', '  y=2']:
             self.assertTrue(isp.push(line))
             
+    def test_push3(self):
+        isp = self.isp
+        isp.push('if True:')
+        isp.push('  a = 1')
+        self.assertFalse(isp.push('b = [1,'))
+            
     def test_replace_mode(self):
         isp = self.isp
         isp.input_mode = 'cell'


### PR DESCRIPTION
To see this bug, start a Qt console and enter something like this (just using the return key, not ctrl-return):

<pre>
if True:
    a = 1
b = [1,
</pre>

(at this point, you get a SyntaxError).

The trouble is codeop.CommandCompiler, the tool we use in inputsplitter to distinguish a syntax error from an incomplete cell. By default, it compiles in "single" mode, which doesn't work properly with multiple statements. This patch uses "exec" mode instead.

The documentation for codeop says that only "single" and "eval" are valid arguments, but a look at the code reveals that the argument is ultimately just passed to `compile`, and using "exec" works with everything I've tried throwing at it. I guess it was invalid in older versions, and the documentation hasn't been updated (the docs for codeop describe backwards compatibility with Python 2.1).

There is also a test (which fails without the patch).
