### PR TITLE
Various Windows-related fixes to IPython.parallel

### DIFF
--- a/IPython/parallel/__init__.py
+++ b/IPython/parallel/__init__.py
@@ -10,9 +10,15 @@
 # Imports
 #-----------------------------------------------------------------------------
 
+import os
 import zmq
 
-if zmq.__version__ < '2.1.4':
+
+if os.name == 'nt':
+    if zmq.__version__ < '2.1dev':
+        raise ImportError("On Windows, IPython.parallel depends on bugfixes only "
+        "in current git master of pyzmq, you appear to have %s"%zmq.__version__)
+elif zmq.__version__ < '2.1.4':
     raise ImportError("IPython.parallel requires pyzmq/0MQ >= 2.1.4, you appear to have %s"%zmq.__version__)
 
 from IPython.utils.pickleutil import Reference

--- a/IPython/parallel/apps/launcher.py
+++ b/IPython/parallel/apps/launcher.py
@@ -591,7 +591,8 @@ def find_job_cmd():
     if os.name=='nt':
         try:
             return find_cmd('job')
-        except FindCmdError:
+        except (FindCmdError, ImportError):
+            # ImportError will be raised if win32api is not installed
             return 'job'
     else:
         return 'job'

--- a/IPython/parallel/apps/launcher.py
+++ b/IPython/parallel/apps/launcher.py
@@ -25,6 +25,7 @@ from signal import SIGINT, SIGTERM
 try:
     from signal import SIGKILL
 except ImportError:
+    # windows
     SIGKILL=SIGTERM
 
 from subprocess import Popen, PIPE, STDOUT
@@ -60,6 +61,14 @@ except ImportError:
     pass
 
 WINDOWS = os.name == 'nt'
+
+if WINDOWS:
+    try:
+        # >= 2.7, 3.2
+        from signal import CTRL_C_EVENT as SIGINT
+    except ImportError:
+        pass
+
 #-----------------------------------------------------------------------------
 # Paths to the kernel apps
 #-----------------------------------------------------------------------------

--- a/IPython/parallel/apps/win32support.py
+++ b/IPython/parallel/apps/win32support.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+"""Utility for forwarding file read events over a zmq socket.
+
+This is necessary because select on Windows only supports"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2011  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+import uuid
+import zmq
+
+from threading import Thread
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------
+
+class ForwarderThread(Thread):
+    def __init__(self, sock, fd):
+        Thread.__init__(self)
+        self.daemon=True
+        self.sock = sock
+        self.fd = fd
+
+    def run(self):
+        """loop through lines in self.fd, and send them over self.sock"""
+        line = self.fd.readline()
+        # allow for files opened in unicode mode
+        if isinstance(line, unicode):
+            send = self.sock.send_unicode
+        else:
+            send = self.sock.send
+        while line:
+            send(line)
+            line = self.fd.readline()
+        # line == '' means EOF
+        self.fd.close()
+        self.sock.close()
+
+def forward_read_events(fd, context=None):
+    """forward read events from an FD over a socket.
+
+    This method wraps a file in a socket pair, so it can
+    be polled for read events by select (specifically zmq.eventloop.ioloop)
+    """
+    if context is None:
+        context = zmq.Context.instance()
+    push = context.socket(zmq.PUSH)
+    push.setsockopt(zmq.LINGER, -1)
+    pull = context.socket(zmq.PULL)
+    addr='inproc://%s'%uuid.uuid4()
+    push.bind(addr)
+    pull.connect(addr)
+    forwarder = ForwarderThread(push, fd)
+    forwarder.start()
+    return pull
+
+
+__all__ = ['forward_read_events']

--- a/IPython/parallel/apps/winhpcjob.py
+++ b/IPython/parallel/apps/winhpcjob.py
@@ -16,8 +16,6 @@ Job and task components for writing .xml files that the Windows HPC Server
 # Imports
 #-----------------------------------------------------------------------------
 
-from __future__ import with_statement
-
 import os
 import re
 import uuid

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -47,19 +47,6 @@ def spin_first(f, self, *args, **kwargs):
     self.spin()
     return f(self, *args, **kwargs)
 
-@decorator
-def default_block(f, self, *args, **kwargs):
-    """Default to self.block; preserve self.block."""
-    block = kwargs.get('block',None)
-    block = self.block if block is None else block
-    saveblock = self.block
-    self.block = block
-    try:
-        ret = f(self, *args, **kwargs)
-    finally:
-        self.block = saveblock
-    return ret
-
 
 #--------------------------------------------------------------------------
 # Classes
@@ -788,14 +775,14 @@ class Client(HasTraits):
     #--------------------------------------------------------------------------
     
     @spin_first
-    @default_block
     def clear(self, targets=None, block=None):
         """Clear the namespace in target(s)."""
+        block = self.block if block is None else block
         targets = self._build_targets(targets)[0]
         for t in targets:
             self.session.send(self._control_socket, 'clear_request', content={}, ident=t)
         error = False
-        if self.block:
+        if block:
             self._flush_ignored_control()
             for i in range(len(targets)):
                 idents,msg = self.session.recv(self._control_socket,0)
@@ -810,7 +797,6 @@ class Client(HasTraits):
         
     
     @spin_first
-    @default_block
     def abort(self, jobs=None, targets=None, block=None):
         """Abort specific jobs from the execution queues of target(s).
         
@@ -825,6 +811,7 @@ class Client(HasTraits):
         
         
         """
+        block = self.block if block is None else block
         targets = self._build_targets(targets)[0]
         msg_ids = []
         if isinstance(jobs, (basestring,AsyncResult)):
@@ -842,7 +829,7 @@ class Client(HasTraits):
             self.session.send(self._control_socket, 'abort_request', 
                     content=content, ident=t)
         error = False
-        if self.block:
+        if block:
             self._flush_ignored_control()
             for i in range(len(targets)):
                 idents,msg = self.session.recv(self._control_socket,0)
@@ -856,9 +843,9 @@ class Client(HasTraits):
             raise error
     
     @spin_first
-    @default_block
     def shutdown(self, targets=None, restart=False, hub=False, block=None):
         """Terminates one or more engine processes, optionally including the hub."""
+        block = self.block if block is None else block
         if hub:
             targets = 'all'
         targets = self._build_targets(targets)[0]
@@ -890,28 +877,8 @@ class Client(HasTraits):
             raise error
     
     #--------------------------------------------------------------------------
-    # Execution methods
+    # Execution related methods
     #--------------------------------------------------------------------------
-    
-    @default_block
-    def _execute(self, code, targets='all', block=None):
-        """Executes `code` on `targets` in blocking or nonblocking manner.
-        
-        ``execute`` is always `bound` (affects engine namespace)
-        
-        Parameters
-        ----------
-        
-        code : str
-                the code string to be executed
-        targets : int/str/list of ints/strs
-                the engines on which to execute
-                default : all
-        block : bool
-                whether or not to wait until done to return
-                default: self.block
-        """
-        return self[targets].execute(code, block=block)
     
     def _maybe_raise(self, result):
         """wrapper for maybe raising an exception if apply failed."""
@@ -1008,38 +975,10 @@ class Client(HasTraits):
         return DirectView(client=self, socket=self._mux_socket, targets=targets)
     
     #--------------------------------------------------------------------------
-    # Data movement (TO BE REMOVED)
-    #--------------------------------------------------------------------------
-    
-    @default_block
-    def _push(self, ns, targets='all', block=None, track=False):
-        """Push the contents of `ns` into the namespace on `target`"""
-        if not isinstance(ns, dict):
-            raise TypeError("Must be a dict, not %s"%type(ns))
-        result = self.apply(util._push, kwargs=ns, targets=targets, block=block, bound=True, balanced=False, track=track)
-        if not block:
-            return result
-    
-    @default_block
-    def _pull(self, keys, targets='all', block=None):
-        """Pull objects from `target`'s namespace by `keys`"""
-        if isinstance(keys, basestring):
-            pass
-        elif isinstance(keys, (list,tuple,set)):
-            for key in keys:
-                if not isinstance(key, basestring):
-                    raise TypeError("keys must be str, not type %r"%type(key))
-        else:
-            raise TypeError("keys must be strs, not %r"%keys)
-        result = self.apply(util._pull, (keys,), targets=targets, block=block, bound=True, balanced=False)
-        return result
-    
-    #--------------------------------------------------------------------------
     # Query methods
     #--------------------------------------------------------------------------
     
     @spin_first
-    @default_block
     def get_result(self, indices_or_msg_ids=None, block=None):
         """Retrieve a result by msg_id or history index, wrapped in an AsyncResult object.
         
@@ -1077,6 +1016,7 @@ class Client(HasTraits):
             A subclass of AsyncResult that retrieves results from the Hub
         
         """
+        block = self.block if block is None else block
         if indices_or_msg_ids is None:
             indices_or_msg_ids = -1
         

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -364,6 +364,11 @@ class Client(HasTraits):
         """Turn valid target IDs or 'all' into two lists:
         (int_ids, uuids).
         """
+        if not self._ids:
+            # flush notification socket if no engines yet, just in case
+            if not self.ids:
+                raise error.NoEnginesRegistered("Can't build targets without any engines")
+        
         if targets is None:
             targets = self._ids
         elif isinstance(targets, str):
@@ -374,7 +379,7 @@ class Client(HasTraits):
         elif isinstance(targets, int):
             if targets < 0:
                 targets = self.ids[targets]
-            if targets not in self.ids:
+            if targets not in self._ids:
                 raise IndexError("No such engine: %i"%targets)
             targets = [targets]
         
@@ -909,13 +914,6 @@ class Client(HasTraits):
             raise TypeError("kwargs must be dict, not %s"%type(kwargs))
         if not isinstance(subheader, dict):
             raise TypeError("subheader must be dict, not %s"%type(subheader))
-        
-        if not self._ids:
-            # flush notification socket if no engines yet
-            any_ids = self.ids
-            if not any_ids:
-                raise error.NoEnginesRegistered("Can't execute without any connected engines.")
-                # enforce types of f,args,kwargs
         
         bufs = util.pack_apply_message(f,args,kwargs)
         

--- a/IPython/parallel/controller/controller.py
+++ b/IPython/parallel/controller/controller.py
@@ -109,8 +109,10 @@ class ControllerFactory(HubFactory):
             
         else:
             self.log.info("task::using Python %s Task scheduler"%self.scheme)
-            sargs = (self.client_info['task'][1], self.engine_info['task'], self.monitor_url, self.client_info['notification'])
-            kwargs = dict(scheme=self.scheme,logname=self.log.name, loglevel=self.log.level, config=self.config)
+            sargs = (self.client_info['task'][1], self.engine_info['task'],
+                                self.monitor_url, self.client_info['notification'])
+            kwargs = dict(scheme=self.scheme,logname=self.log.name, loglevel=self.log.level,
+                                                            config=dict(self.config))
             q = Process(target=launch_scheduler, args=sargs, kwargs=kwargs)
             q.daemon=True
             children.append(q)

--- a/IPython/parallel/controller/scheduler.py
+++ b/IPython/parallel/controller/scheduler.py
@@ -34,6 +34,7 @@ from zmq.eventloop import ioloop, zmqstream
 
 # local imports
 from IPython.external.decorator import decorator
+from IPython.config.loader import Config
 from IPython.utils.traitlets import Instance, Dict, List, Set
 
 from IPython.parallel import error
@@ -557,9 +558,12 @@ def launch_scheduler(in_addr, out_addr, mon_addr, not_addr, config=None,logname=
     from zmq.eventloop import ioloop
     from zmq.eventloop.zmqstream import ZMQStream
     
+    if config:
+        # unwrap dict back into Config
+        config = Config(config)
+
     ctx = zmq.Context()
     loop = ioloop.IOLoop()
-    print (in_addr, out_addr, mon_addr, not_addr)
     ins = ZMQStream(ctx.socket(zmq.XREP),loop)
     ins.setsockopt(zmq.IDENTITY, identity)
     ins.bind(in_addr)

--- a/IPython/parallel/streamsession.py
+++ b/IPython/parallel/streamsession.py
@@ -27,18 +27,6 @@ from zmq.eventloop.zmqstream import ZMQStream
 
 from .util import ISO8601
 
-# packer priority: jsonlib[2], cPickle, simplejson/json, pickle
-json_name = '' if not jsonapi.jsonmod else jsonapi.jsonmod.__name__
-if json_name in ('jsonlib', 'jsonlib2'):
-    use_json = True
-elif json_name:
-    if cPickle is None:
-        use_json = True
-    else:
-        use_json = False
-else:
-    use_json = False
-
 def squash_unicode(obj):
     if isinstance(obj,dict):
         for key in obj.keys():
@@ -58,12 +46,8 @@ json_unpacker = lambda s: squash_unicode(jsonapi.loads(s))
 pickle_packer = lambda o: pickle.dumps(o,-1)
 pickle_unpacker = pickle.loads
 
-if use_json:
-    default_packer = json_packer
-    default_unpacker = json_unpacker
-else:
-    default_packer = pickle_packer
-    default_unpacker = pickle_unpacker
+default_packer = json_packer
+default_unpacker = json_unpacker
 
 
 DELIM="<IDS|MSG>"

--- a/IPython/parallel/tests/clienttest.py
+++ b/IPython/parallel/tests/clienttest.py
@@ -29,6 +29,17 @@ def segfault():
     import ctypes
     ctypes.memset(-1,0,1)
 
+def crash():
+    """from stdlib crashers in the test suite"""
+    import types
+    if sys.platform.startswith('win'):
+        import ctypes
+        ctypes.windll.kernel32.SetErrorMode(0x0002);
+
+    co = types.CodeType(0, 0, 0, 0, b'\x04\x71\x00\x00',
+                             (), (), (), '', '', 1, b'')
+    exec(co)
+
 def wait(n):
     """sleep for a time"""
     import time
@@ -86,7 +97,7 @@ class ClusterTestCase(BaseZMQTestCase):
             except error.CompositeError as e:
                 e.raise_exception()
         except error.RemoteError as e:
-            self.assertEquals(etype.__name__, e.ename, "Should have raised %r, but raised %r"%(e.ename, etype.__name__))
+            self.assertEquals(etype.__name__, e.ename, "Should have raised %r, but raised %r"%(etype.__name__, e.ename))
         else:
             self.fail("should have raised a RemoteError")
             

--- a/IPython/parallel/tests/clienttest.py
+++ b/IPython/parallel/tests/clienttest.py
@@ -20,7 +20,8 @@ from IPython.external.decorator import decorator
 
 from IPython.parallel import error
 from IPython.parallel import Client
-from IPython.parallel.tests import processes,add_engines
+
+from IPython.parallel.tests import launchers, add_engines
 
 # simple tasks for use in apply tests
 
@@ -112,8 +113,8 @@ class ClusterTestCase(BaseZMQTestCase):
     def tearDown(self):
         # self.client.clear(block=True)
         # close fds:
-        for e in filter(lambda e: e.poll() is not None, processes):
-            processes.remove(e)
+        for e in filter(lambda e: e.poll() is not None, launchers):
+            launchers.remove(e)
         
         # allow flushing of incoming messages to prevent crash on socket close
         self.client.wait(timeout=2)

--- a/IPython/parallel/tests/clienttest.py
+++ b/IPython/parallel/tests/clienttest.py
@@ -93,6 +93,8 @@ class ClusterTestCase(BaseZMQTestCase):
     def setUp(self):
         BaseZMQTestCase.setUp(self)
         self.client = self.connect_client()
+        # start every test with clean engine namespaces:
+        self.client.clear(block=True)
         self.base_engine_count=len(self.client.ids)
         self.engines=[]
     

--- a/IPython/parallel/tests/test_asyncresult.py
+++ b/IPython/parallel/tests/test_asyncresult.py
@@ -38,7 +38,6 @@ class AsyncResultTest(ClusterTestCase):
 
     def test_get_after_done(self):
         ar = self.client[-1].apply_async(lambda : 42)
-        self.assertFalse(ar.ready())
         ar.wait()
         self.assertTrue(ar.ready())
         self.assertEquals(ar.get(), 42)

--- a/IPython/parallel/tests/test_client.py
+++ b/IPython/parallel/tests/test_client.py
@@ -85,8 +85,8 @@ class TestClient(ClusterTestCase):
         v.push(dict(a=5))
         v.pull('a')
         id0 = self.client.ids[-1]
-        self.client.clear(targets=id0)
-        self.client[:-1].pull('a')
+        self.client.clear(targets=id0, block=True)
+        a = self.client[:-1].get('a')
         self.assertRaisesRemote(NameError, self.client[id0].get, 'a')
         self.client.clear(block=True)
         for i in self.client.ids:

--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -298,7 +298,8 @@ class TestView(ClusterTestCase):
         def findall(pat, s):
             # this globals() step isn't necessary in real code
             # only to prevent a closure in the test
-            return globals()['re'].findall(pat, s)
+            re = globals()['re']
+            return re.findall(pat, s)
         
         self.assertEquals(view.apply_sync(findall, '\w+', 'hello world'), 'hello world'.split())
     

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -106,7 +106,10 @@ have['pexpect'] = test_for('pexpect')
 have['pymongo'] = test_for('pymongo')
 have['wx'] = test_for('wx')
 have['wx.aui'] = test_for('wx.aui')
-have['zmq'] = test_for('zmq', '2.1.4')
+if os.name == 'nt':
+    have['zmq'] = test_for('zmq', '2.1dev')
+else:
+    have['zmq'] = test_for('zmq', '2.1.4')
 have['qt'] = test_for('IPython.external.qt')
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This is the a pull request containing fixes that, when merged should hopefully close #365.

Issues fixed:
- multiprocessing does not propagate Config objects properly, so they are coerced to dict and back for Scheduler launch
- on Windows, select cannot poll non-socket FDs, so subprocess IO is forwarded over zmq sockets in ipcluster
- `SIGINT` caused a crash when shutting down subprocesses in ipcluster, so it is replaced with `CTRL_C_EVENT` on Windows
- allow win32api to be missing on import of `IPython.parallel.apps.launcher` 

The removal of the module-specific default serialization selection in StreamSession is not Windows specific, but is done for simplicity.  While the stdlib json in 2.6 is _extremely_ slow compared to jsonlib, the chance of having defaults differ between machines is too annoying to keep this behavior.
