### PR TITLE
Allow pickling objects defined interactively.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1059,17 +1059,13 @@ class InteractiveShell(Configurable, Magic):
         # Restore the user namespaces to minimal usability
         for ns in self.ns_refs_table:
             ns.clear()
-            
-        # In some situations, e.g. testing, our fake main module has a __dict__
-        # separate from the user_ns: if so, we need to clear it manually.
-        if self.user_ns is not self.user_ns_mod.__dict__:
-            self.user_ns_mod.__dict__.clear()
 
         # The main execution namespaces must be cleared very carefully,
         # skipping the deletion of the builtin-related keys, because doing so
         # would cause errors in many object's __del__ methods.
         for ns in [self.user_ns, self.user_global_ns]:
             drop_keys = set(ns.keys())
+            drop_keys.discard('__name__')
             drop_keys.discard('__builtin__')
             drop_keys.discard('__builtins__')
             for k in drop_keys:
@@ -1077,6 +1073,11 @@ class InteractiveShell(Configurable, Magic):
                                         
         # Restore the user namespaces to minimal usability
         self.init_user_ns()
+        
+        # In some situations, e.g. testing, our fake main module has a __dict__
+        # separate from the user_ns: if so, we need to clear it manually.
+        if self.user_ns is not self.user_ns_mod.__dict__:
+            init_fakemod_dict(self.user_ns_mod, self.user_ns)
 
         # Restore the default and user aliases
         self.alias_manager.clear_aliases()

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -102,6 +102,14 @@ class InteractiveShellTestCase(unittest.TestCase):
         from cPickle import dumps
         res = dumps(ip.user_ns["w"])
         self.assertTrue(isinstance(res, bytes))
+        
+    def test_global_ns(self):
+        ip = get_ipython()
+        ip.run_cell("a = 10")
+        ip.run_cell(("def f(x):"
+                     "    return x + a"))
+        ip.run_cell("b = f(12)")
+        self.assertEqual(ip.user_ns["b"], 22)
 
 
 

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -91,3 +91,17 @@ class InteractiveShellTestCase(unittest.TestCase):
         ip = get_ipython()
         ip.run_cell('a = """\n%exit\n"""')
         self.assertEquals(ip.user_ns['a'], '\n%exit\n')
+        
+    def test_can_pickle(self):
+        ip = get_ipython()
+        ip.run_cell(("class Mylist(list):\n"
+                     "    def __init__(self,x=[]):\n"
+                     "        list.__init__(self,x)"))
+        ip.run_cell("w=Mylist([1,2,3])")
+        
+        from cPickle import dumps
+        res = dumps(ip.user_ns["w"])
+        self.assertTrue(isinstance(res, bytes))
+
+
+

--- a/IPython/testing/globalipapp.py
+++ b/IPython/testing/globalipapp.py
@@ -82,6 +82,9 @@ class ipnsdict(dict):
         # namespace in doctests that call '_'.
         self.protect_underscore = False
         
+        # We set this so that the tests don't clash with __main__
+        self["__name__"] = "__test_main__"
+        
     def clear(self):
         dict.clear(self)
         self.update(self._savedict)
@@ -158,7 +161,7 @@ def start_ipython():
     # Create and initialize our test-friendly IPython instance.
     shell = TerminalInteractiveShell.instance(config=config, 
                                               user_ns=ipnsdict(),
-                                              user_global_ns={}
+                                              user_global_ns={'__name__':'__test_main__'}
                                               )
 
     # A few more tweaks needed for playing nicely with doctests...

--- a/IPython/testing/globalipapp.py
+++ b/IPython/testing/globalipapp.py
@@ -161,7 +161,7 @@ def start_ipython():
     # Create and initialize our test-friendly IPython instance.
     shell = TerminalInteractiveShell.instance(config=config, 
                                               user_ns=ipnsdict(),
-                                              user_global_ns={'__name__':'__test_main__'}
+                                              user_global_ns=None
                                               )
 
     # A few more tweaks needed for playing nicely with doctests...

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -271,6 +271,8 @@ class DocTestCase(doctests.DocTestCase):
             # for IPython examples *only*, we swap the globals with the ipython
             # namespace, after updating it with the globals (which doctest
             # fills with the necessary info from the module being tested).
+            self.user_ns_orig = {}
+            self.user_ns_orig.update(_ip.user_ns)
             _ip.user_ns.update(self._dt_test.globs)
             self._dt_test.globs = _ip.user_ns
             # IPython must protect the _ key in the namespace (it can't exist)
@@ -286,6 +288,8 @@ class DocTestCase(doctests.DocTestCase):
         # teardown doesn't destroy the ipython namespace
         if isinstance(self._dt_test.examples[0],IPExample):
             self._dt_test.globs = self._dt_test_globs_ori
+            _ip.user_ns.clear()
+            _ip.user_ns.update(self.user_ns_orig)
             # Restore the behavior of the '_' key in the user namespace to
             # normal after each doctest, so that unittests behave normally
             _ip.user_ns.protect_underscore = False


### PR DESCRIPTION
This whole area is rather complex, so please be blunt if there's a reason the approach I've taken is completely wrong.

Per issue #29, we'd like to be able to pickle objects we define interactively. The reason we can't is that it looks for locally defined variables in the `__main__` module, which doesn't get updated. So we need to make `sys.modules[__name__].__dict__ is ip.user_ns` True. But we can't assign to the module's `__dict__` directly, because it's a read-only attribute.

In the normal case (running a shell), where user_ns is a dict, this creates a FakeModule, and then replaces user_ns with its `__dict__` attribute, so that we're working directly in the module namespace. But that doesn't work with the test suite, where user_ns is a dict subclass (ipnsdict from IPython.core.testing.globalipapp). In that case, we keep user_ns as a separate object, and copy its contents across into the module after executing each cell.

The test suite still passes, at least on my machine, and copying and pasting the example code from #29, I can get the object pickled. I've not really gone looking for corner cases.
