### PR TITLE
Update iptest exclusions (fix #375)

### DIFF
--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -107,6 +107,7 @@ have['pymongo'] = test_for('pymongo')
 have['wx'] = test_for('wx')
 have['wx.aui'] = test_for('wx.aui')
 have['zmq'] = test_for('zmq', '2.1.4')
+have['qt'] = test_for('IPython.external.qt')
 
 #-----------------------------------------------------------------------------
 # Functions and classes
@@ -183,11 +184,15 @@ def make_exclude():
 
     if not have['pexpect']:
         exclusions.extend([ipjoin('scripts', 'irunner'),
-                           ipjoin('lib', 'irunner')])
+                           ipjoin('lib', 'irunner'),
+                           ipjoin('lib', 'tests', 'test_irunner')])
 
     if not have['zmq']:
         exclusions.append(ipjoin('zmq'))
+        exclusions.append(ipjoin('frontend', 'qt'))
         exclusions.append(ipjoin('parallel'))
+    elif not have['qt']:
+        exclusions.append(ipjoin('frontend', 'qt'))
     
     if not have['pymongo']:
         exclusions.append(ipjoin('parallel', 'controller', 'mongodb'))


### PR DESCRIPTION
exclude test_irunner w/o pexpect
exclude frontend/qt w/o pyzmq or qt
