### PR TITLE
DB fixes and Scheduler HWM

### DIFF
--- a/IPython/config/default/ipcontroller_config.py
+++ b/IPython/config/default/ipcontroller_config.py
@@ -71,11 +71,11 @@ c = get_config()
 # dying engines, dependencies, or engine-subset load-balancing.
 # c.ControllerFactory.scheme = 'pure'
 
-# The pure ZMQ scheduler can limit the number of outstanding tasks per engine
-# by using the ZMQ HWM option.  This allows engines with long-running tasks
+# The Python scheduler can limit the number of outstanding tasks per engine
+# by using an HWM option.  This allows engines with long-running tasks
 # to not steal too many tasks from other engines. The default is 0, which
 # means agressively distribute messages, never waiting for them to finish.
-# c.ControllerFactory.hwm = 1
+# c.TaskScheduler.hwm = 0
 
 # Whether to use Threads or Processes to start the Schedulers.  Threads will
 # use less resources, but potentially reduce throughput. Default is to 

--- a/IPython/parallel/controller/hub.py
+++ b/IPython/parallel/controller/hub.py
@@ -27,9 +27,8 @@ from zmq.eventloop.zmqstream import ZMQStream
 from IPython.utils.importstring import import_item
 from IPython.utils.traitlets import HasTraits, Instance, Int, CStr, Str, Dict, Set, List, Bool
 
-from IPython.parallel import error
+from IPython.parallel import error, util
 from IPython.parallel.factory import RegistrationFactory, LoggingFactory
-from IPython.parallel.util import select_random_ports, validate_url_container, ISO8601
 
 from .heartmonitor import HeartMonitor
 
@@ -76,7 +75,7 @@ def init_record(msg):
         'header' : header,
         'content': msg['content'],
         'buffers': msg['buffers'],
-        'submitted': datetime.strptime(header['date'], ISO8601),
+        'submitted': datetime.strptime(header['date'], util.ISO8601),
         'client_uuid' : None,
         'engine_uuid' : None,
         'started': None,
@@ -119,32 +118,32 @@ class HubFactory(RegistrationFactory):
     # port-pairs for monitoredqueues:
     hb = Instance(list, config=True)
     def _hb_default(self):
-        return select_random_ports(2)
+        return util.select_random_ports(2)
     
     mux = Instance(list, config=True)
     def _mux_default(self):
-        return select_random_ports(2)
+        return util.select_random_ports(2)
     
     task = Instance(list, config=True)
     def _task_default(self):
-        return select_random_ports(2)
+        return util.select_random_ports(2)
     
     control = Instance(list, config=True)
     def _control_default(self):
-        return select_random_ports(2)
+        return util.select_random_ports(2)
     
     iopub = Instance(list, config=True)
     def _iopub_default(self):
-        return select_random_ports(2)
+        return util.select_random_ports(2)
     
     # single ports:
     mon_port = Instance(int, config=True)
     def _mon_port_default(self):
-        return select_random_ports(1)[0]
+        return util.select_random_ports(1)[0]
     
     notifier_port = Instance(int, config=True)
     def _notifier_port_default(self):
-        return select_random_ports(1)[0]
+        return util.select_random_ports(1)[0]
     
     ping = Int(1000, config=True) # ping frequency
     
@@ -344,11 +343,11 @@ class Hub(LoggingFactory):
         # validate connection dicts:
         for k,v in self.client_info.iteritems():
             if k == 'task':
-                validate_url_container(v[1])
+                util.validate_url_container(v[1])
             else:
-                validate_url_container(v)
-        # validate_url_container(self.client_info)
-        validate_url_container(self.engine_info)
+                util.validate_url_container(v)
+        # util.validate_url_container(self.client_info)
+        util.validate_url_container(self.engine_info)
         
         # register our callbacks
         self.query.on_recv(self.dispatch_query)
@@ -369,6 +368,8 @@ class Hub(LoggingFactory):
         
         self.query_handlers = {'queue_request': self.queue_status,
                                 'result_request': self.get_results,
+                                'history_request': self.get_history,
+                                'db_request': self.db_query,
                                 'purge_request': self.purge_results,
                                 'load_request': self.check_load,
                                 'resubmit_request': self.resubmit_task,
@@ -606,10 +607,10 @@ class Hub(LoggingFactory):
             return
         # update record anyway, because the unregistration could have been premature
         rheader = msg['header']
-        completed = datetime.strptime(rheader['date'], ISO8601)
+        completed = datetime.strptime(rheader['date'], util.ISO8601)
         started = rheader.get('started', None)
         if started is not None:
-            started = datetime.strptime(started, ISO8601)
+            started = datetime.strptime(started, util.ISO8601)
         result = {
             'result_header' : rheader,
             'result_content': msg['content'],
@@ -618,7 +619,10 @@ class Hub(LoggingFactory):
         }
 
         result['result_buffers'] = msg['buffers']
-        self.db.update_record(msg_id, result)
+        try:
+            self.db.update_record(msg_id, result)
+        except Exception:
+            self.log.error("DB Error updating record %r"%msg_id, exc_info=True)
         
             
     #--------------------- Task Queue Traffic ------------------------------
@@ -653,6 +657,8 @@ class Hub(LoggingFactory):
             self.db.update_record(msg_id, record)
         except KeyError:
             self.db.add_record(msg_id, record)
+        except Exception:
+            self.log.error("DB Error saving task request %r"%msg_id, exc_info=True)
     
     def save_task_result(self, idents, msg):
         """save the result of a completed task."""
@@ -685,10 +691,10 @@ class Hub(LoggingFactory):
                 self.completed[eid].append(msg_id)
                 if msg_id in self.tasks[eid]:
                     self.tasks[eid].remove(msg_id)
-            completed = datetime.strptime(header['date'], ISO8601)
+            completed = datetime.strptime(header['date'], util.ISO8601)
             started = header.get('started', None)
             if started is not None:
-                started = datetime.strptime(started, ISO8601)
+                started = datetime.strptime(started, util.ISO8601)
             result = {
                 'result_header' : header,
                 'result_content': msg['content'],
@@ -698,7 +704,10 @@ class Hub(LoggingFactory):
             }
 
             result['result_buffers'] = msg['buffers']
-            self.db.update_record(msg_id, result)
+            try:
+                self.db.update_record(msg_id, result)
+            except Exception:
+                self.log.error("DB Error saving task request %r"%msg_id, exc_info=True)
             
         else:
             self.log.debug("task::unknown task %s finished"%msg_id)
@@ -723,7 +732,11 @@ class Hub(LoggingFactory):
         
         self.tasks[eid].append(msg_id)
         # self.pending[msg_id][1].update(received=datetime.now(),engine=(eid,engine_uuid))
-        self.db.update_record(msg_id, dict(engine_uuid=engine_uuid))
+        try:
+            self.db.update_record(msg_id, dict(engine_uuid=engine_uuid))
+        except Exception:
+            self.log.error("DB Error saving task destination %r"%msg_id, exc_info=True)
+            
     
     def mia_task_request(self, idents, msg):
         raise NotImplementedError
@@ -772,7 +785,10 @@ class Hub(LoggingFactory):
         else:
             d[msg_type] = content.get('data', '')
         
-        self.db.update_record(msg_id, d)
+        try:
+            self.db.update_record(msg_id, d)
+        except Exception:
+            self.log.error("DB Error saving iopub message %r"%msg_id, exc_info=True)
         
     
             
@@ -904,11 +920,15 @@ class Hub(LoggingFactory):
             # build a fake header:
             header = {}
             header['engine'] = uuid
-            header['date'] = datetime.now().strftime(ISO8601)
+            header['date'] = datetime.now()
             rec = dict(result_content=content, result_header=header, result_buffers=[])
             rec['completed'] = header['date']
             rec['engine_uuid'] = uuid
-            self.db.update_record(msg_id, rec)
+            try:
+                self.db.update_record(msg_id, rec)
+            except Exception:
+                self.log.error("DB Error handling stranded msg %r"%msg_id, exc_info=True)
+                
     
     def finish_registration(self, heart):
         """Second half of engine registration, called after our HeartMonitor
@@ -1017,7 +1037,10 @@ class Hub(LoggingFactory):
         msg_ids = content.get('msg_ids', [])
         reply = dict(status='ok')
         if msg_ids == 'all':
-            self.db.drop_matching_records(dict(completed={'$ne':None}))
+            try:
+                self.db.drop_matching_records(dict(completed={'$ne':None}))
+            except Exception:
+                reply = error.wrap_exception()
         else:
             for msg_id in msg_ids:
                 if msg_id in self.all_completed:
@@ -1044,13 +1067,34 @@ class Hub(LoggingFactory):
                     break
                 msg_ids = self.completed.pop(eid)
                 uid = self.engines[eid].queue
-                self.db.drop_matching_records(dict(engine_uuid=uid, completed={'$ne':None}))
+                try:
+                    self.db.drop_matching_records(dict(engine_uuid=uid, completed={'$ne':None}))
+                except Exception:
+                    reply = error.wrap_exception()
+                    break
         
         self.session.send(self.query, 'purge_reply', content=reply, ident=client_id)
     
     def resubmit_task(self, client_id, msg, buffers):
         """Resubmit a task."""
         raise NotImplementedError
+    
+    def _extract_record(self, rec):
+        """decompose a TaskRecord dict into subsection of reply for get_result"""
+        io_dict = {}
+        for key in 'pyin pyout pyerr stdout stderr'.split():
+                io_dict[key] = rec[key]
+        content = { 'result_content': rec['result_content'],
+                            'header': rec['header'],
+                            'result_header' : rec['result_header'],
+                            'io' : io_dict,
+                          }
+        if rec['result_buffers']:
+            buffers = map(str, rec['result_buffers'])
+        else:
+            buffers = []
+        
+        return content, buffers
     
     def get_results(self, client_id, msg):
         """Get the result of 1 or more messages."""
@@ -1064,25 +1108,28 @@ class Hub(LoggingFactory):
         content['completed'] = completed
         buffers = []
         if not statusonly:
-            content['results'] = {}
-            records = self.db.find_records(dict(msg_id={'$in':msg_ids}))
+            try:
+                matches = self.db.find_records(dict(msg_id={'$in':msg_ids}))
+                # turn match list into dict, for faster lookup
+                records = {}
+                for rec in matches:
+                    records[rec['msg_id']] = rec
+            except Exception:
+                content = error.wrap_exception()
+                self.session.send(self.query, "result_reply", content=content, 
+                                                    parent=msg, ident=client_id)
+                return
+        else:
+            records = {}
         for msg_id in msg_ids:
             if msg_id in self.pending:
                 pending.append(msg_id)
-            elif msg_id in self.all_completed:
+            elif msg_id in self.all_completed or msg_id in records:
                 completed.append(msg_id)
                 if not statusonly:
-                    rec = records[msg_id]
-                    io_dict = {}
-                    for key in 'pyin pyout pyerr stdout stderr'.split():
-                            io_dict[key] = rec[key]
-                    content[msg_id] = { 'result_content': rec['result_content'],
-                                        'header': rec['header'],
-                                        'result_header' : rec['result_header'],
-                                        'io' : io_dict,
-                                      }
-                    if rec['result_buffers']:
-                        buffers.extend(map(str, rec['result_buffers']))
+                    c,bufs = self._extract_record(records[msg_id])
+                    content[msg_id] = c
+                    buffers.extend(bufs)
             else:
                 try:
                     raise KeyError('No such message: '+msg_id)
@@ -1090,6 +1137,57 @@ class Hub(LoggingFactory):
                     content = error.wrap_exception()
                 break
         self.session.send(self.query, "result_reply", content=content, 
+                                            parent=msg, ident=client_id,
+                                            buffers=buffers)
+
+    def get_history(self, client_id, msg):
+        """Get a list of all msg_ids in our DB records"""
+        try:
+            msg_ids = self.db.get_history()
+        except Exception as e:
+            content = error.wrap_exception()
+        else:
+            content = dict(status='ok', history=msg_ids)
+        
+        self.session.send(self.query, "history_reply", content=content, 
+                                            parent=msg, ident=client_id)
+
+    def db_query(self, client_id, msg):
+        """Perform a raw query on the task record database."""
+        content = msg['content']
+        query = content.get('query', {})
+        keys = content.get('keys', None)
+        query = util.extract_dates(query)
+        buffers = []
+        empty = list()
+        
+        try:
+            records = self.db.find_records(query, keys)
+        except Exception as e:
+            content = error.wrap_exception()
+        else:
+            # extract buffers from reply content:
+            if keys is not None:
+                buffer_lens = [] if 'buffers' in keys else None
+                result_buffer_lens = [] if 'result_buffers' in keys else None
+            else:
+                buffer_lens = []
+                result_buffer_lens = []
+            
+            for rec in records:
+                # buffers may be None, so double check
+                if buffer_lens is not None:
+                    b = rec.pop('buffers', empty) or empty
+                    buffer_lens.append(len(b))
+                    buffers.extend(b)
+                if result_buffer_lens is not None:
+                    rb = rec.pop('result_buffers', empty) or empty
+                    result_buffer_lens.append(len(rb))
+                    buffers.extend(rb)
+            content = dict(status='ok', records=records, buffer_lens=buffer_lens,
+                                    result_buffer_lens=result_buffer_lens)
+        
+        self.session.send(self.query, "db_reply", content=content, 
                                             parent=msg, ident=client_id,
                                             buffers=buffers)
 

--- a/IPython/parallel/streamsession.py
+++ b/IPython/parallel/streamsession.py
@@ -28,6 +28,7 @@ from zmq.eventloop.zmqstream import ZMQStream
 from .util import ISO8601
 
 def squash_unicode(obj):
+    """coerce unicode back to bytestrings."""
     if isinstance(obj,dict):
         for key in obj.keys():
             obj[key] = squash_unicode(obj[key])
@@ -40,7 +41,14 @@ def squash_unicode(obj):
         obj = obj.encode('utf8')
     return obj
 
-json_packer = jsonapi.dumps
+def _date_default(obj):
+    if isinstance(obj, datetime):
+        return obj.strftime(ISO8601)
+    else:
+        raise TypeError("%r is not JSON serializable"%obj)
+
+_default_key = 'on_unknown' if jsonapi.jsonmod.__name__ == 'jsonlib' else 'default'
+json_packer = lambda obj: jsonapi.dumps(obj, **{_default_key:_date_default})
 json_unpacker = lambda s: squash_unicode(jsonapi.loads(s))
 
 pickle_packer = lambda o: pickle.dumps(o,-1)

--- a/IPython/parallel/tests/test_db.py
+++ b/IPython/parallel/tests/test_db.py
@@ -1,0 +1,182 @@
+"""Tests for db backends"""
+
+#-------------------------------------------------------------------------------
+#  Copyright (C) 2011  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-------------------------------------------------------------------------------
+
+#-------------------------------------------------------------------------------
+# Imports
+#-------------------------------------------------------------------------------
+
+
+import tempfile
+import time
+
+import uuid
+
+from datetime import datetime, timedelta
+from random import choice, randint
+from unittest import TestCase
+
+from nose import SkipTest
+
+from IPython.parallel import error, streamsession as ss
+from IPython.parallel.controller.dictdb import DictDB
+from IPython.parallel.controller.sqlitedb import SQLiteDB
+from IPython.parallel.controller.hub import init_record, empty_record
+
+#-------------------------------------------------------------------------------
+# TestCases
+#-------------------------------------------------------------------------------
+
+class TestDictBackend(TestCase):
+    def setUp(self):
+        self.session = ss.StreamSession()
+        self.db = self.create_db()
+        self.load_records(16)
+    
+    def create_db(self):
+        return DictDB()
+    
+    def load_records(self, n=1):
+        """load n records for testing"""
+        #sleep 1/10 s, to ensure timestamp is different to previous calls
+        time.sleep(0.1)
+        msg_ids = []
+        for i in range(n):
+            msg = self.session.msg('apply_request', content=dict(a=5))
+            msg['buffers'] = []
+            rec = init_record(msg)
+            msg_ids.append(msg['msg_id'])
+            self.db.add_record(msg['msg_id'], rec)
+        return msg_ids
+    
+    def test_add_record(self):
+        before = self.db.get_history()
+        self.load_records(5)
+        after = self.db.get_history()
+        self.assertEquals(len(after), len(before)+5)
+        self.assertEquals(after[:-5],before)
+        
+    def test_drop_record(self):
+        msg_id = self.load_records()[-1]
+        rec = self.db.get_record(msg_id)
+        self.db.drop_record(msg_id)
+        self.assertRaises(KeyError,self.db.get_record, msg_id)
+    
+    def _round_to_millisecond(self, dt):
+        """necessary because mongodb rounds microseconds"""
+        micro = dt.microsecond
+        extra = int(str(micro)[-3:])
+        return dt - timedelta(microseconds=extra)
+    
+    def test_update_record(self):
+        now = self._round_to_millisecond(datetime.now())
+        # 
+        msg_id = self.db.get_history()[-1]
+        rec1 = self.db.get_record(msg_id)
+        data = {'stdout': 'hello there', 'completed' : now}
+        self.db.update_record(msg_id, data)
+        rec2 = self.db.get_record(msg_id)
+        self.assertEquals(rec2['stdout'], 'hello there')
+        self.assertEquals(rec2['completed'], now)
+        rec1.update(data)
+        self.assertEquals(rec1, rec2)
+    
+    # def test_update_record_bad(self):
+    #     """test updating nonexistant records"""
+    #     msg_id = str(uuid.uuid4())
+    #     data = {'stdout': 'hello there'}
+    #     self.assertRaises(KeyError, self.db.update_record, msg_id, data)
+
+    def test_find_records_dt(self):
+        """test finding records by date"""
+        hist = self.db.get_history()
+        middle = self.db.get_record(hist[len(hist)/2])
+        tic = middle['submitted']
+        before = self.db.find_records({'submitted' : {'$lt' : tic}})
+        after = self.db.find_records({'submitted' : {'$gte' : tic}})
+        self.assertEquals(len(before)+len(after),len(hist))
+        for b in before:
+            self.assertTrue(b['submitted'] < tic)
+        for a in after:
+            self.assertTrue(a['submitted'] >= tic)
+        same = self.db.find_records({'submitted' : tic})
+        for s in same:
+            self.assertTrue(s['submitted'] == tic)
+    
+    def test_find_records_keys(self):
+        """test extracting subset of record keys"""
+        found = self.db.find_records({'msg_id': {'$ne' : ''}},keys=['submitted', 'completed'])
+        for rec in found:
+            self.assertEquals(set(rec.keys()), set(['msg_id', 'submitted', 'completed']))
+    
+    def test_find_records_msg_id(self):
+        """ensure msg_id is always in found records"""
+        found = self.db.find_records({'msg_id': {'$ne' : ''}},keys=['submitted', 'completed'])
+        for rec in found:
+            self.assertTrue('msg_id' in rec.keys())
+        found = self.db.find_records({'msg_id': {'$ne' : ''}},keys=['submitted'])
+        for rec in found:
+            self.assertTrue('msg_id' in rec.keys())
+        found = self.db.find_records({'msg_id': {'$ne' : ''}},keys=['msg_id'])
+        for rec in found:
+            self.assertTrue('msg_id' in rec.keys())
+    
+    def test_find_records_in(self):
+        """test finding records with '$in','$nin' operators"""
+        hist = self.db.get_history()
+        even = hist[::2]
+        odd = hist[1::2]
+        recs = self.db.find_records({ 'msg_id' : {'$in' : even}})
+        found = [ r['msg_id'] for r in recs ]
+        self.assertEquals(set(even), set(found))
+        recs = self.db.find_records({ 'msg_id' : {'$nin' : even}})
+        found = [ r['msg_id'] for r in recs ]
+        self.assertEquals(set(odd), set(found))
+    
+    def test_get_history(self):
+        msg_ids = self.db.get_history()
+        latest = datetime(1984,1,1)
+        for msg_id in msg_ids:
+            rec = self.db.get_record(msg_id)
+            newt = rec['submitted']
+            self.assertTrue(newt >= latest)
+            latest = newt
+        msg_id = self.load_records(1)[-1]
+        self.assertEquals(self.db.get_history()[-1],msg_id)
+    
+    def test_datetime(self):
+        """get/set timestamps with datetime objects"""
+        msg_id = self.db.get_history()[-1]
+        rec = self.db.get_record(msg_id)
+        self.assertTrue(isinstance(rec['submitted'], datetime))
+        self.db.update_record(msg_id, dict(completed=datetime.now()))
+        rec = self.db.get_record(msg_id)
+        self.assertTrue(isinstance(rec['completed'], datetime))
+            
+class TestSQLiteBackend(TestDictBackend):
+    def create_db(self):
+        return SQLiteDB(location=tempfile.gettempdir())
+    
+    def tearDown(self):
+        self.db._db.close()
+
+# optional MongoDB test
+try:
+    from IPython.parallel.controller.mongodb import MongoDB
+except ImportError:
+    pass
+else:
+    class TestMongoBackend(TestDictBackend):
+        def create_db(self):
+            try:
+                return MongoDB(database='iptestdb')
+            except Exception:
+                raise SkipTest("Couldn't connect to mongodb instance")
+            
+        def tearDown(self):
+            self.db._connection.drop_database('iptestdb')

--- a/IPython/parallel/util.py
+++ b/IPython/parallel/util.py
@@ -17,6 +17,7 @@ import re
 import stat
 import socket
 import sys
+from datetime import datetime
 from signal import signal, SIGINT, SIGABRT, SIGTERM
 try:
     from signal import SIGKILL
@@ -41,6 +42,7 @@ from IPython.zmq.log import EnginePUBHandler
 
 # globals
 ISO8601="%Y-%m-%dT%H:%M:%S.%f"
+ISO8601_RE=re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+$")
 
 #-----------------------------------------------------------------------------
 # Classes
@@ -98,6 +100,18 @@ class ReverseDict(dict):
 #-----------------------------------------------------------------------------
 # Functions
 #-----------------------------------------------------------------------------
+
+def extract_dates(obj):
+    """extract ISO8601 dates from unpacked JSON"""
+    if isinstance(obj, dict):
+        for k,v in obj.iteritems():
+            obj[k] = extract_dates(v)
+    elif isinstance(obj, list):
+        obj = [ extract_dates(o) for o in obj ]
+    elif isinstance(obj, basestring):
+        if ISO8601_RE.match(obj):
+            obj = datetime.strptime(obj, ISO8601)
+    return obj
 
 def validate_url(url):
     """validate a url for zeromq"""
@@ -460,3 +474,4 @@ def local_logger(logname, loglevel=logging.DEBUG):
     handler.setLevel(loglevel)
     logger.addHandler(handler)
     logger.setLevel(loglevel)
+


### PR DESCRIPTION
This branch is actually based on my 'windows' branch, so the real diff is here:
https://github.com/minrk/ipython/compare/windows...db

until PR #374 is merged

Basic features:

add HWM to Python scheduler, allowing users to tune level of job queuing. (HWM=1 behaves like old TaskScheduler, HWM=0 is default, and behaves like pure 0MQ).

DB backend changes:  
- add `db.get_history()` method (like `client/view.history`, but returns all known `msg_ids`)  
- `db.find_records` returns list, allows filtering of keys  
- add db_backend tests  

Two new Client methods exposing db backends:  
- `rc.hub_history()` # proxy for db.get_history  
- `rc.db_query()` # proxy for db.find_records  

Up for discussion: These are _Client_ methods, not _View_ methods.  To me, they seem like low-level methods, and thus appropriately bound to the low-level object, but They can be easily propagated up to the Views.

Extra fixes along the way:
- Harder for db issues to crash the Hub  
- Better JSON handling of date objects  
- Don't raise `NoEnginesRegistered` when load-balancing on all engines  
- `rc.get_result` works with whole history if database is persistent  
