### PR TITLE
ipdir unicode

### DIFF
--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -25,13 +25,19 @@ from IPython.utils.importstring import import_item
 # Code
 #-----------------------------------------------------------------------------
 
-# in case filesystemencoding() returns None:
-fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
+fs_encoding = sys.getfilesystemencoding()
+
+def _cast_unicode(s, enc=None):
+    """Turn 8-bit strings into unicode."""
+    if isinstance(s, bytes):
+        enc = enc or sys.getdefaultencoding()
+        return s.decode(enc)
+    return s
+
 
 def _get_long_path_name(path):
     """Dummy no-op."""
     return path
-
 
 if sys.platform == 'win32':
     def _get_long_path_name(path):
@@ -172,7 +178,7 @@ def get_home_dir():
         root=os.path.abspath(root).rstrip('\\')
         if isdir(os.path.join(root, '_ipython')):
             os.environ["IPYKITROOT"] = root
-        return root.decode(fs_encoding)
+        return _cast_unicode(root, fs_encoding)
 
     if os.name == 'posix':
         # Linux, Unix, AIX, OS X
@@ -187,11 +193,11 @@ def get_home_dir():
             homedir = Popen('echo $HOME', shell=True, 
                             stdout=PIPE).communicate()[0].strip()
             if homedir:
-                return homedir.decode(fs_encoding)
+                return _cast_unicode(homedir, fs_encoding)
             else:
                 raise HomeDirError('Undefined $HOME, IPython cannot proceed.')
         else:
-            return homedir.decode(fs_encoding)
+            return _cast_unicode(homedir, fs_encoding)
     elif os.name == 'nt':
         # Now for win9x, XP, Vista, 7?
         # For some strange reason all of these return 'nt' for os.name.
@@ -205,7 +211,7 @@ def get_home_dir():
             pass
         else:
             if isdir(homedir):
-                return homedir.decode(fs_encoding)
+                return _cast_unicode(homedir, fs_encoding)
 
         # Now look for a local home directory
         try:
@@ -214,7 +220,7 @@ def get_home_dir():
             pass
         else:
             if isdir(homedir):
-                return homedir.decode(fs_encoding)
+                return _cast_unicode(homedir, fs_encoding)
 
         # Now the users profile directory
         try:
@@ -223,7 +229,7 @@ def get_home_dir():
             pass
         else:
             if isdir(homedir):
-                return homedir.decode(fs_encoding)
+                return _cast_unicode(homedir, fs_encoding)
 
         # Use the registry to get the 'My Documents' folder.
         try:
@@ -238,7 +244,7 @@ def get_home_dir():
             pass
         else:
             if isdir(homedir):
-                return homedir.decode(fs_encoding)
+                return _cast_unicode(homedir, fs_encoding)
 
         # A user with a lot of unix tools in win32 may have defined $HOME.
         # Try this as a last ditch option.
@@ -248,13 +254,13 @@ def get_home_dir():
             pass
         else:
             if isdir(homedir):
-                return homedir.decode(fs_encoding)
+                return _cast_unicode(homedir, fs_encoding)
 
         # If all else fails, raise HomeDirError
         raise HomeDirError('No valid home directory could be found')
     elif os.name == 'dos':
         # Desperate, may do absurd things in classic MacOS. May work under DOS.
-        return 'C:\\'.decode(fs_encoding)
+        return u'C:\\'
     else:
         raise HomeDirError('No valid home directory could be found for your OS')
 
@@ -272,7 +278,7 @@ def get_xdg_dir():
         # use ~/.config if not set OR empty
         xdg = env.get("XDG_CONFIG_HOME", None) or os.path.join(get_home_dir(), '.config')
         if xdg and isdir(xdg):
-            return xdg.decode(fs_encoding)
+            return _cast_unicode(xdg, fs_encoding)
     
     return None
     
@@ -311,15 +317,13 @@ def get_ipython_dir():
             # not using XDG
             ipdir = home_ipdir
             
-    if isinstance(ipdir, bytes):
-        return ipdir.decode(fs_encoding)
-    return ipdir
+    return _cast_unicode(ipdir, fs_encoding)
 
 
 def get_ipython_package_dir():
     """Get the base directory where IPython itself is installed."""
     ipdir = os.path.dirname(IPython.__file__)
-    return ipdir.decode(fs_encoding)
+    return _cast_unicode(ipdir, fs_encoding)
 
 
 def get_ipython_module_path(module_str):
@@ -334,7 +338,7 @@ def get_ipython_module_path(module_str):
     mod = import_item(module_str)
     the_path = mod.__file__.replace('.pyc', '.py')
     the_path = the_path.replace('.pyo', '.py')
-    return the_path.decode(fs_encoding)
+    return _cast_unicode(the_path, fs_encoding)
 
 
 def expand_path(s):

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -310,8 +310,10 @@ def get_ipython_dir():
         if ipdir is None:
             # not using XDG
             ipdir = home_ipdir
-    
-    return ipdir.decode(fs_encoding)
+            
+    if isinstance(ipdir, bytes):
+        return ipdir.decode(fs_encoding)
+    return ipdir
 
 
 def get_ipython_package_dir():

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -25,6 +25,8 @@ from IPython.utils.importstring import import_item
 # Code
 #-----------------------------------------------------------------------------
 
+# in case filesystemencoding() returns None:
+fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
 
 def _get_long_path_name(path):
     """Dummy no-op."""
@@ -170,7 +172,7 @@ def get_home_dir():
         root=os.path.abspath(root).rstrip('\\')
         if isdir(os.path.join(root, '_ipython')):
             os.environ["IPYKITROOT"] = root
-        return root.decode(sys.getfilesystemencoding())
+        return root.decode(fs_encoding)
 
     if os.name == 'posix':
         # Linux, Unix, AIX, OS X
@@ -185,11 +187,11 @@ def get_home_dir():
             homedir = Popen('echo $HOME', shell=True, 
                             stdout=PIPE).communicate()[0].strip()
             if homedir:
-                return homedir.decode(sys.getfilesystemencoding())
+                return homedir.decode(fs_encoding)
             else:
                 raise HomeDirError('Undefined $HOME, IPython cannot proceed.')
         else:
-            return homedir.decode(sys.getfilesystemencoding())
+            return homedir.decode(fs_encoding)
     elif os.name == 'nt':
         # Now for win9x, XP, Vista, 7?
         # For some strange reason all of these return 'nt' for os.name.
@@ -203,7 +205,7 @@ def get_home_dir():
             pass
         else:
             if isdir(homedir):
-                return homedir.decode(sys.getfilesystemencoding())
+                return homedir.decode(fs_encoding)
 
         # Now look for a local home directory
         try:
@@ -212,7 +214,7 @@ def get_home_dir():
             pass
         else:
             if isdir(homedir):
-                return homedir.decode(sys.getfilesystemencoding())
+                return homedir.decode(fs_encoding)
 
         # Now the users profile directory
         try:
@@ -221,7 +223,7 @@ def get_home_dir():
             pass
         else:
             if isdir(homedir):
-                return homedir.decode(sys.getfilesystemencoding())
+                return homedir.decode(fs_encoding)
 
         # Use the registry to get the 'My Documents' folder.
         try:
@@ -236,7 +238,7 @@ def get_home_dir():
             pass
         else:
             if isdir(homedir):
-                return homedir.decode(sys.getfilesystemencoding())
+                return homedir.decode(fs_encoding)
 
         # A user with a lot of unix tools in win32 may have defined $HOME.
         # Try this as a last ditch option.
@@ -246,13 +248,13 @@ def get_home_dir():
             pass
         else:
             if isdir(homedir):
-                return homedir.decode(sys.getfilesystemencoding())
+                return homedir.decode(fs_encoding)
 
         # If all else fails, raise HomeDirError
         raise HomeDirError('No valid home directory could be found')
     elif os.name == 'dos':
         # Desperate, may do absurd things in classic MacOS. May work under DOS.
-        return 'C:\\'.decode(sys.getfilesystemencoding())
+        return 'C:\\'.decode(fs_encoding)
     else:
         raise HomeDirError('No valid home directory could be found for your OS')
 
@@ -270,7 +272,7 @@ def get_xdg_dir():
         # use ~/.config if not set OR empty
         xdg = env.get("XDG_CONFIG_HOME", None) or os.path.join(get_home_dir(), '.config')
         if xdg and isdir(xdg):
-            return xdg.decode(sys.getfilesystemencoding())
+            return xdg.decode(fs_encoding)
     
     return None
     
@@ -309,13 +311,13 @@ def get_ipython_dir():
             # not using XDG
             ipdir = home_ipdir
     
-    return ipdir.decode(sys.getfilesystemencoding())
+    return ipdir.decode(fs_encoding)
 
 
 def get_ipython_package_dir():
     """Get the base directory where IPython itself is installed."""
     ipdir = os.path.dirname(IPython.__file__)
-    return ipdir.decode(sys.getfilesystemencoding())
+    return ipdir.decode(fs_encoding)
 
 
 def get_ipython_module_path(module_str):
@@ -330,7 +332,7 @@ def get_ipython_module_path(module_str):
     mod = import_item(module_str)
     the_path = mod.__file__.replace('.pyc', '.py')
     the_path = the_path.replace('.pyo', '.py')
-    return the_path.decode(sys.getfilesystemencoding())
+    return the_path.decode(fs_encoding)
 
 
 def expand_path(s):


### PR DESCRIPTION
This builds on Min's pull request #362. Bug #392 revealed that, in some circumstances, ipdir can already be unicode before we try to decode it. That can result in a confusing error as it attempts to re-encode it and decode again.

I've simply added a check whether ipdir is unicode or bytes before doing the conversion. Michał says that this fixes the issue (#392) for him.
