### PR TITLE
Config5

### DIFF
--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -24,7 +24,7 @@ import sys
 
 from IPython.config.configurable import SingletonConfigurable
 from IPython.utils.traitlets import (
-    Unicode, List, Int
+    Unicode, List, Int, Enum
 )
 from IPython.config.loader import (
     KeyValueConfigLoader, PyFileConfigLoader
@@ -52,7 +52,10 @@ class Application(SingletonConfigurable):
     # The version string of this application.
     version = Unicode(u'0.0')
 
-    log_level = Int(logging.WARN, config=True, shortname="log_level")
+    # The log level for the application
+    log_level = Enum((0,10,20,30,40,50), default_value=logging.WARN,
+                     config=True, shortname="log_level",
+                     help="Set the log level (0,10,20,30,40,50).")
 
     def __init__(self, **kwargs):
         SingletonConfigurable.__init__(self, **kwargs)
@@ -105,8 +108,7 @@ class Application(SingletonConfigurable):
 
     def parse_command_line(self, argv=None):
         """Parse the command line arguments."""
-        if argv is None:
-            argv = sys.argv[1:]
+        argv = sys.argv[1:] if argv is None else argv
 
         if '-h' in argv or '--h' in argv:
             self.print_description()

--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -36,6 +36,7 @@ from IPython.config.loader import (
 
 
 class Application(SingletonConfigurable):
+    """A singleton application with full configuration support."""
 
     # The name of the application, will usually match the name of the command
     # line application
@@ -98,6 +99,7 @@ class Application(SingletonConfigurable):
         print self.version
 
     def update_config(self, config):
+        """Fire the traits events when the config is updated."""
         # Save a copy of the current config.
         newconfig = deepcopy(self.config)
         # Merge the new config into the current one.

--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -1,0 +1,108 @@
+# encoding: utf-8
+"""
+A base class for a configurable application.
+
+Authors:
+
+* Brian Granger
+"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2008-2011  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+from copy import deepcopy
+import sys
+
+from IPython.config.configurable import Configurable
+from IPython.utils.traitlets import (
+    Unicode, List
+)
+from IPython.config.loader import (
+    KeyValueConfigLoader, PyFileConfigLoader
+)
+
+#-----------------------------------------------------------------------------
+# Application class
+#-----------------------------------------------------------------------------
+
+
+class Application(Configurable):
+
+    # The name of the application, will usually match the name of the command
+    # line application
+    app_name = Unicode(u'application')
+
+    # The description of the application that is printed at the beginning
+    # of the help.
+    description = Unicode(u'This is an application.')
+
+    # A sequence of Configurable subclasses whose config=True attributes will
+    # be exposed at the command line (shortnames and help).
+    classes = List([])
+
+    # The version string of this application.
+    version = Unicode(u'0.0')
+
+    def __init__(self, **kwargs):
+        Configurable.__init__(self, **kwargs)
+        # Add my class to self.classes so my attributes appear in command line
+        # options.
+        self.classes.insert(0, self.__class__)
+
+    def print_help(self):
+        """Print the help for each Configurable class in self.classes."""
+        for cls in self.classes:
+            cls.class_print_help()
+            print
+
+    def print_description(self):
+        """Print the application description."""
+        print self.description
+        print
+
+    def print_version(self):
+        """Print the version string."""
+        print self.version
+
+    def update_config(self, config):
+        # Save a copy of the current config.
+        newconfig = deepcopy(self.config)
+        # Merge the new config into the current one.
+        newconfig._merge(config)
+        # Save the combined config as self.config, which triggers the traits
+        # events.
+        self.config = config
+
+    def parse_command_line(self, argv=None):
+        """Parse the command line arguments."""
+        if argv is None:
+            argv = sys.argv[1:]
+
+        if '-h' in argv or '--h' in argv:
+            self.print_description()
+            self.print_help()
+            sys.exit(1)
+
+        if '--version' in argv:
+            self.print_version()
+            sys.exit(1)
+
+        loader = KeyValueConfigLoader(argv=argv, classes=self.classes)
+        config = loader.load_config()
+        self.update_config(config)
+
+    def load_config_file(self, filename, path=None):
+        """Load a .py based config file by filename and path."""
+        # TODO: this raises IOError if filename does not exist.
+        loader = PyFileConfigLoader(filename, path=path)
+        config = loader.load_config()
+        self.update_config(config)
+

--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -232,3 +232,9 @@ class SingletonConfigurable(Configurable):
                 'Multiple incompatible subclass instances of '
                 '%s are being created.' % cls.__name__
             )
+
+    @classmethod
+    def initialized(cls):
+        """Has an instance been created?"""
+        return hasattr(cls, "_instance") and cls._instance is not None
+

--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -22,9 +22,7 @@ Authors:
 
 from copy import deepcopy
 import datetime
-from weakref import WeakValueDictionary
 
-from IPython.utils.importstring import import_item
 from loader import Config
 from IPython.utils.traitlets import HasTraits, Instance
 from IPython.utils.text import indent
@@ -152,13 +150,18 @@ class Configurable(HasTraits):
 
     @classmethod
     def class_get_help(cls):
+        """Get the help string for this class in ReST format."""
         cls_traits = cls.class_traits(config=True)
         final_help = []
-        final_help.append('%s options' % cls.__name__)
-        final_help.append(len(final_help[0])*'-')
+        final_help.append(u'%s options' % cls.__name__)
+        final_help.append(len(final_help[0])*u'-')
         for k, v in cls_traits.items():
             help = v.get_metadata('help')
-            final_help.append(k + " : " + v.__class__.__name__)
+            shortname = v.get_metadata('shortname')
+            header = "%s.%s : %s" % (cls.__name__, k, v.__class__.__name__)
+            if shortname is not None:
+                header += " (shortname=" + shortname + ")"
+            final_help.append(header)
             if help is not None:
                 final_help.append(indent(help))
         return '\n'.join(final_help)

--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -27,6 +27,7 @@ from weakref import WeakValueDictionary
 from IPython.utils.importstring import import_item
 from loader import Config
 from IPython.utils.traitlets import HasTraits, Instance
+from IPython.utils.text import indent
 
 
 #-----------------------------------------------------------------------------
@@ -137,3 +138,33 @@ class Configurable(HasTraits):
                         # shared by all instances, effectively making it a class attribute.
                         setattr(self, k, deepcopy(config_value))
 
+    @classmethod
+    def class_get_shortnames(cls):
+        """Return the shortname to fullname dict for config=True traits."""
+        cls_traits = cls.class_traits(config=True)
+        shortnames = {}
+        for k, v in cls_traits.items():
+            shortname = v.get_metadata('shortname')
+            if shortname is not None:
+                longname = cls.__name__ + '.' + k
+                shortnames[shortname] = longname
+        return shortnames
+
+    @classmethod
+    def class_get_help(cls):
+        cls_traits = cls.class_traits(config=True)
+        final_help = []
+        final_help.append('%s options' % cls.__name__)
+        final_help.append(len(final_help[0])*'-')
+        for k, v in cls_traits.items():
+            help = v.get_metadata('help')
+            final_help.append(k + " : " + v.__class__.__name__)
+            if help is not None:
+                final_help.append(indent(help))
+        return '\n'.join(final_help)
+
+    @classmethod
+    def class_print_help(cls):
+        print cls.class_get_help()
+
+            

--- a/IPython/config/tests/test_application.py
+++ b/IPython/config/tests/test_application.py
@@ -1,0 +1,90 @@
+"""
+Tests for IPython.config.application.Application
+
+Authors:
+
+* Brian Granger
+"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2008-2011  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+from unittest import TestCase
+
+from IPython.config.configurable import Configurable
+
+from IPython.config.application import (
+    Application
+)
+
+from IPython.utils.traitlets import (
+    Bool, Unicode, Int, Float, List
+)
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------
+
+class Foo(Configurable):
+
+    i = Int(0, config=True, shortname='i', help="The integer i.")
+    j = Int(1, config=True, shortname='j', help="The integer j.")
+    name = Unicode(u'Brian', config=True, shortname='name', help="First name.")
+
+
+class Bar(Configurable):
+
+    enabled = Bool(True, config=True, shortname="enabled", help="Enable bar.")
+
+
+class MyApp(Application):
+
+    app_name = Unicode(u'myapp')
+    running = Bool(False, config=True, shortname="running",
+                   help="Is the app running?")
+    classes = List([Bar, Foo])
+    config_file = Unicode(u'', config=True, shortname="config_file",
+                   help="Load this config file")
+
+    def init_foo(self):
+        self.foo = Foo(config=self.config)
+
+    def init_bar(self):
+        self.bar = Bar(config=self.config)
+
+
+class TestApplication(TestCase):
+
+    def test_basic(self):
+        app = MyApp()
+        self.assertEquals(app.app_name, u'myapp')
+        self.assertEquals(app.running, False)
+        self.assertEquals(app.classes, [MyApp,Bar,Foo])
+        self.assertEquals(app.config_file, u'')
+
+    def test_config(self):
+        app = MyApp()
+        app.parse_command_line(["i=10","Foo.j=10","enabled=False","log_level=0"])
+        config = app.config
+        self.assertEquals(config.Foo.i, 10)
+        self.assertEquals(config.Foo.j, 10)
+        self.assertEquals(config.Bar.enabled, False)
+        self.assertEquals(config.MyApp.log_level,0)
+
+    def test_config_propagation(self):
+        app = MyApp()
+        app.parse_command_line(["i=10","Foo.j=10","enabled=False","log_level=0"])
+        app.init_foo()
+        app.init_bar()
+        self.assertEquals(app.foo.i, 10)
+        self.assertEquals(app.foo.j, 10)
+        self.assertEquals(app.bar.enabled, False)
+

--- a/IPython/config/tests/test_configurable.py
+++ b/IPython/config/tests/test_configurable.py
@@ -35,19 +35,26 @@ from IPython.config.loader import Config
 
 
 class MyConfigurable(Configurable):
-    a = Int(1, config=True)
-    b = Float(1.0, config=True)
+    a = Int(1, config=True, shortname="a", help="The integer a.")
+    b = Float(1.0, config=True, shortname="b", help="The integer b.")
     c = Str('no config')
 
 
+mc_help=u"""MyConfigurable options
+----------------------
+MyConfigurable.a : Int (shortname=a)
+    The integer a.
+MyConfigurable.b : Float (shortname=b)
+    The integer b."""
+
 class Foo(Configurable):
-    a = Int(0, config=True)
+    a = Int(0, config=True, shortname="a", help="The integer a.")
     b = Str('nope', config=True)
 
 
 class Bar(Foo):
-    b = Str('gotit', config=False)
-    c = Float(config=True)
+    b = Str('gotit', config=False, shortname="b", help="The string b.")
+    c = Float(config=True, shortname="c", help="The string c.")
 
 
 class TestConfigurableConfig(TestCase):
@@ -122,3 +129,15 @@ class TestConfigurableConfig(TestCase):
         self.assertEquals(c.a, 2)
         self.assertEquals(c.b, 'and')
         self.assertEquals(c.c, 20.0)
+
+    def test_shortnames(self):
+        sn = MyConfigurable.class_get_shortnames()
+        self.assertEquals(sn, {'a': 'MyConfigurable.a', 'b': 'MyConfigurable.b'})
+        sn = Foo.class_get_shortnames()
+        self.assertEquals(sn, {'a': 'Foo.a'})
+        sn = Bar.class_get_shortnames()
+        self.assertEquals(sn, {'a': 'Bar.a', 'c': 'Bar.c'})
+
+    def test_help(self):
+        self.assertEquals(MyConfigurable.class_get_help(), mc_help)
+

--- a/IPython/config/tests/test_configurable.py
+++ b/IPython/config/tests/test_configurable.py
@@ -22,10 +22,15 @@ Authors:
 
 from unittest import TestCase
 
-from IPython.config.configurable import Configurable, ConfigurableError
-from IPython.utils.traitlets import (
-    TraitError, Int, Float, Str
+from IPython.config.configurable import (
+    Configurable, 
+    SingletonConfigurable
 )
+
+from IPython.utils.traitlets import (
+    Int, Float, Str
+)
+
 from IPython.config.loader import Config
 
 
@@ -57,7 +62,7 @@ class Bar(Foo):
     c = Float(config=True, shortname="c", help="The string c.")
 
 
-class TestConfigurableConfig(TestCase):
+class TestConfigurable(TestCase):
 
     def test_default(self):
         c1 = Configurable()
@@ -141,3 +146,23 @@ class TestConfigurableConfig(TestCase):
     def test_help(self):
         self.assertEquals(MyConfigurable.class_get_help(), mc_help)
 
+
+class TestSingletonConfigurable(TestCase):
+
+    def test_instance(self):
+        from IPython.config.configurable import SingletonConfigurable
+        class Foo(SingletonConfigurable): pass
+        foo = Foo.instance()
+        self.assertEquals(foo, Foo.instance())
+        self.assertEquals(SingletonConfigurable._instance, None)
+
+    def test_inheritance(self):
+
+        class Bar(SingletonConfigurable): pass
+        class Bam(Bar): pass
+        bam = Bam.instance()
+        bam == Bar.instance()
+        self.assertEquals(bam, Bam._instance)
+        self.assertEquals(bam, Bar._instance)
+        self.assertEquals(SingletonConfigurable._instance, None)
+        

--- a/IPython/config/tests/test_configurable.py
+++ b/IPython/config/tests/test_configurable.py
@@ -152,17 +152,21 @@ class TestSingletonConfigurable(TestCase):
     def test_instance(self):
         from IPython.config.configurable import SingletonConfigurable
         class Foo(SingletonConfigurable): pass
+        self.assertEquals(Foo.initialized(), False)
         foo = Foo.instance()
+        self.assertEquals(Foo.initialized(), True)
         self.assertEquals(foo, Foo.instance())
         self.assertEquals(SingletonConfigurable._instance, None)
 
     def test_inheritance(self):
-
         class Bar(SingletonConfigurable): pass
         class Bam(Bar): pass
+        self.assertEquals(Bar.initialized(), False)
+        self.assertEquals(Bam.initialized(), False)
         bam = Bam.instance()
         bam == Bar.instance()
+        self.assertEquals(Bar.initialized(), True)
+        self.assertEquals(Bam.initialized(), True)
         self.assertEquals(bam, Bam._instance)
         self.assertEquals(bam, Bar._instance)
         self.assertEquals(SingletonConfigurable._instance, None)
-        

--- a/IPython/config/tests/test_loader.py
+++ b/IPython/config/tests/test_loader.py
@@ -26,7 +26,8 @@ from unittest import TestCase
 
 from IPython.config.loader import (
     Config,
-    PyFileConfigLoader, 
+    PyFileConfigLoader,
+    KeyValueConfigLoader,
     ArgParseConfigLoader,
     ConfigError
 )
@@ -38,11 +39,11 @@ from IPython.config.loader import (
 
 pyfile = """
 c = get_config()
-c.a = 10
-c.b = 20
-c.Foo.Bar.value = 10
-c.Foo.Bam.value = range(10)
-c.D.C.value = 'hi there'
+c.a=10
+c.b=20
+c.Foo.Bar.value=10
+c.Foo.Bam.value=range(10)
+c.D.C.value='hi there'
 """
 
 class TestPyFileCL(TestCase):
@@ -108,6 +109,19 @@ class TestArgParseCL(TestCase):
         self.assertEquals(config.n, True)
         self.assertEquals(config.Global.bam, 'wow')
 
+
+class TestKeyValueCL(TestCase):
+
+    def test_basic(self):
+        cl = KeyValueConfigLoader()
+        argv = [s.strip('c.') for s in pyfile.split('\n')[2:-1]]
+        print argv
+        config = cl.load_config(argv)
+        self.assertEquals(config.a, 10)
+        self.assertEquals(config.b, 20)
+        self.assertEquals(config.Foo.Bar.value, 10)
+        self.assertEquals(config.Foo.Bam.value, range(10))
+        self.assertEquals(config.D.C.value, 'hi there')
 
 class TestConfig(TestCase):
 

--- a/IPython/config/tests/test_loader.py
+++ b/IPython/config/tests/test_loader.py
@@ -117,7 +117,6 @@ class TestKeyValueCL(TestCase):
     def test_basic(self):
         cl = KeyValueConfigLoader()
         argv = [s.strip('c.') for s in pyfile.split('\n')[2:-1]]
-        print argv
         config = cl.load_config(argv)
         self.assertEquals(config.a, 10)
         self.assertEquals(config.b, 20)

--- a/IPython/config/tests/test_loader.py
+++ b/IPython/config/tests/test_loader.py
@@ -24,6 +24,8 @@ import os
 from tempfile import mkstemp
 from unittest import TestCase
 
+from IPython.utils.traitlets import Int, Unicode
+from IPython.config.configurable import Configurable
 from IPython.config.loader import (
     Config,
     PyFileConfigLoader,
@@ -122,6 +124,24 @@ class TestKeyValueCL(TestCase):
         self.assertEquals(config.Foo.Bar.value, 10)
         self.assertEquals(config.Foo.Bam.value, range(10))
         self.assertEquals(config.D.C.value, 'hi there')
+
+    def test_shortname(self):
+        class Foo(Configurable):
+            i = Int(0, config=True, shortname="i")
+            s = Unicode('hi', config=True, shortname="s")
+        cl = KeyValueConfigLoader()
+        config = cl.load_config(["i=20", "s=there"], classes=[Foo])
+        self.assertEquals(config.Foo.i, 20)
+        self.assertEquals(config.Foo.s, "there")
+
+    def test_duplicate(self):
+        class Foo(Configurable):
+            i = Int(0, config=True, shortname="i")
+        class Bar(Configurable):
+            i = Int(0, config=True, shortname="i")
+        cl = KeyValueConfigLoader()
+        self.assertRaises(KeyError, cl.load_config, ["i=20", "s=there"], classes=[Foo, Bar])
+
 
 class TestConfig(TestCase):
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -189,7 +189,16 @@ class InteractiveShell(Configurable, Magic):
     """An enhanced, interactive shell for Python."""
 
     _instance = None
-    autocall = Enum((0,1,2), default_value=1, config=True)
+    autocall = Enum((0,1,2), default_value=1, config=True,
+        help=
+        """Make IPython automatically call any callable object even if you
+        didn't type explicit parentheses. For example, 'str 43' becomes
+        'str(43)' automatically.  The value can be '0' to disable the feature,
+        '1' for 'smart' autocall, where it is not applied if there are no more
+        arguments on the line, and '2' for 'full' autocall, where all callable
+        objects are automatically called (even if no arguments are present).
+        The default is '1'."""
+    )
     # TODO: remove all autoindent logic and put into frontends.
     # We can't do this yet because even runlines uses the autoindent.
     autoindent = CBool(True, config=True)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -181,6 +181,15 @@ class ReadlineNoRecord(object):
         return [ghi(x) for x in range(start, end)]
 
 
+_autocall_help = """
+Make IPython automatically call any callable object even if
+you didn't type explicit parentheses. For example, 'str 43' becomes 'str(43)'
+automatically. The value can be '0' to disable the feature, '1' for 'smart'
+autocall, where it is not applied if there are no more arguments on the line,
+and '2' for 'full' autocall, where all callable objects are automatically
+called (even if no arguments are present). The default is '1'.
+"""
+
 #-----------------------------------------------------------------------------
 # Main IPython class
 #-----------------------------------------------------------------------------
@@ -189,20 +198,30 @@ class InteractiveShell(Configurable, Magic):
     """An enhanced, interactive shell for Python."""
 
     _instance = None
-    autocall = Enum((0,1,2), default_value=1, config=True,
-        help=
-        """Make IPython automatically call any callable object even if you
-        didn't type explicit parentheses. For example, 'str 43' becomes
-        'str(43)' automatically.  The value can be '0' to disable the feature,
-        '1' for 'smart' autocall, where it is not applied if there are no more
+
+    autocall = Enum((0,1,2), default_value=1, config=True, help=
+        """
+        Make IPython automatically call any callable object even if you didn't
+        type explicit parentheses. For example, 'str 43' becomes 'str(43)'
+        automatically. The value can be '0' to disable the feature, '1' for
+        'smart' autocall, where it is not applied if there are no more
         arguments on the line, and '2' for 'full' autocall, where all callable
         objects are automatically called (even if no arguments are present).
-        The default is '1'."""
+        The default is '1'.
+        """
     )
     # TODO: remove all autoindent logic and put into frontends.
     # We can't do this yet because even runlines uses the autoindent.
-    autoindent = CBool(True, config=True)
-    automagic = CBool(True, config=True)
+    autoindent = CBool(True, config=True, help=
+        """
+        Should IPython indent code entered interactively.
+        """
+    )
+    automagic = CBool(True, config=True, help=
+        """
+        Enable magic commands to be called without the leading %.
+        """
+    )
     cache_size = Int(1000, config=True)
     color_info = CBool(True, config=True)
     colors = CaselessStrEnum(('NoColor','LightBG','Linux'), 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -214,7 +214,7 @@ class InteractiveShell(Configurable, Magic):
     # We can't do this yet because even runlines uses the autoindent.
     autoindent = CBool(True, config=True, help=
         """
-        Should IPython indent code entered interactively.
+        Autoindent IPython code entered interactively.
         """
     )
     automagic = CBool(True, config=True, help=
@@ -222,12 +222,37 @@ class InteractiveShell(Configurable, Magic):
         Enable magic commands to be called without the leading %.
         """
     )
-    cache_size = Int(1000, config=True)
-    color_info = CBool(True, config=True)
+    cache_size = Int(1000, config=True, help=
+        """
+        Set the size of the output cache.  The default is 1000, you can
+        change it permanently in your config file.  Setting it to 0 completely
+        disables the caching system, and the minimum value accepted is 20 (if
+        you provide a value less than 20, it is reset to 0 and a warning is
+        issued).  This limit is defined because otherwise you'll spend more
+        time re-flushing a too small cache than working
+        """
+    )
+    color_info = CBool(True, config=True, help=
+        """
+        Use colors for displaying information about objects. Because this
+        information is passed through a pager (like 'less'), and some pagers
+        get confused with color codes, this capability can be turned off.
+        """
+    )
     colors = CaselessStrEnum(('NoColor','LightBG','Linux'), 
                              default_value=get_default_colors(), config=True)
     debug = CBool(False, config=True)
-    deep_reload = CBool(False, config=True)
+    deep_reload = CBool(False, config=True, help=
+        """
+        Enable deep (recursive) reloading by default. IPython can use the
+        deep_reload module which reloads changes in modules recursively (it
+        replaces the reload() function, so you don't need to change anything to
+        use it). deep_reload() forces a full reload of modules whose code may
+        have changed, which the default reload() function does not.  When
+        deep_reload is off, IPython will use the normal reload(), but
+        deep_reload will still be available as dreload().
+        """
+    )
     display_formatter = Instance(DisplayFormatter)
     displayhook_class = Type(DisplayHook)
     display_pub_class = Type(DisplayPublisher)
@@ -245,12 +270,28 @@ class InteractiveShell(Configurable, Magic):
     # interactive statements or whole blocks.
     input_splitter = Instance('IPython.core.inputsplitter.IPythonInputSplitter',
                               (), {})
-    logstart = CBool(False, config=True)
-    logfile = Unicode('', config=True)
-    logappend = Unicode('', config=True)
+    logstart = CBool(False, config=True, help=
+        """
+        Start logging to the default log file.
+        """
+    )
+    logfile = Unicode('', config=True, help=
+        """
+        The name of the logfile to use.
+        """
+    )
+    logappend = Unicode('', config=True, help=
+        """
+        Start logging to the given file in append mode.
+        """
+    )
     object_info_string_level = Enum((0,1,2), default_value=0,
                                     config=True)
-    pdb = CBool(False, config=True)
+    pdb = CBool(False, config=True, help=
+        """
+        Automatically call the pdb debugger after every exception.
+        """
+    )
 
     profile = Unicode('', config=True)
     prompt_in1 = Str('In [\\#]: ', config=True)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -31,7 +31,7 @@ import tempfile
 import types
 from contextlib import nested
 
-from IPython.config.configurable import Configurable
+from IPython.config.configurable import SingletonConfigurable
 from IPython.core import debugger, oinspect
 from IPython.core import history as ipcorehist
 from IPython.core import page
@@ -132,9 +132,7 @@ class SeparateStr(Str):
         value = value.replace('\\n','\n')
         return super(SeparateStr, self).validate(obj, value)
 
-class MultipleInstanceError(Exception):
-    pass
-    
+
 class ReadlineNoRecord(object):
     """Context manager to execute some code, then reload readline history
     so that interactive input to the code doesn't appear when pressing up."""
@@ -194,7 +192,7 @@ called (even if no arguments are present). The default is '1'.
 # Main IPython class
 #-----------------------------------------------------------------------------
 
-class InteractiveShell(Configurable, Magic):
+class InteractiveShell(SingletonConfigurable, Magic):
     """An enhanced, interactive shell for Python."""
 
     _instance = None
@@ -426,31 +424,6 @@ class InteractiveShell(Configurable, Magic):
         self.init_payload()
         self.hooks.late_startup_hook()
         atexit.register(self.atexit_operations)
-
-    @classmethod
-    def instance(cls, *args, **kwargs):
-        """Returns a global InteractiveShell instance."""
-        if cls._instance is None:
-            inst = cls(*args, **kwargs)
-            # Now make sure that the instance will also be returned by
-            # the subclasses instance attribute.
-            for subclass in cls.mro():
-                if issubclass(cls, subclass) and \
-                       issubclass(subclass, InteractiveShell):
-                    subclass._instance = inst
-                else:
-                    break
-        if isinstance(cls._instance, cls):
-            return cls._instance
-        else:
-            raise MultipleInstanceError(
-                'Multiple incompatible subclass instances of '
-                'InteractiveShell are being created.'
-            )
-
-    @classmethod
-    def initialized(cls):
-        return hasattr(cls, "_instance")
 
     def get_ipython(self):
         """Return the currently running IPython instance."""

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -366,6 +366,7 @@ class TestHasTraits(TestCase):
             f = Float
         a = A()
         self.assertEquals(a.trait_names(),['i','f'])
+        self.assertEquals(A.class_trait_names(),['i','f'])
 
     def test_trait_metadata(self):
         class A(HasTraits):
@@ -379,6 +380,7 @@ class TestHasTraits(TestCase):
             f = Float
         a = A()
         self.assertEquals(a.traits(), dict(i=A.i, f=A.f))
+        self.assertEquals(A.class_traits(), dict(i=A.i, f=A.f))
 
     def test_traits_metadata(self):
         class A(HasTraits):

--- a/docs/examples/core/appconfig.py
+++ b/docs/examples/core/appconfig.py
@@ -7,6 +7,27 @@ system works. The main classes are:
 * IPython.config.configurable.SingletonConfigurable
 * IPython.config.loader.Config
 * IPython.config.application.Application
+
+To see the command line option help, run this program from the command line::
+
+    $ python appconfig.py -h
+
+To make one of your classes configurable (from the command line and config
+files) inherit from Configurable and declare class attributes as traits (see
+classes Foo and Bar below). To make the traits configurable, you will need
+to set the following options:
+
+* ``config``: set to ``True`` to make the attribute configurable.
+* ``shortname``: by default, configurable attributes are set using the syntax
+  "Classname.attributename". At the command line, this is a bit verbose, so
+  we allow "shortnames" to be declared. Setting a shortname is optional, but
+  when you do this, you can set the option at the command line using the
+  syntax: "shortname=value".
+* ``help``: set the help string to display a help message when the ``-h``
+  option is given at the command line. The help string should be valid ReST.
+
+When the config attribute of an Application is updated, it will fire all of
+the trait's events for all of the config=True attributes.
 """
 
 import sys
@@ -17,7 +38,11 @@ from IPython.utils.traitlets import (
     Bool, Unicode, Int, Float, List
 )
 
+
 class Foo(Configurable):
+    """A class that has configurable, typed attributes.
+
+    """
 
     i = Int(0, config=True, shortname='i', help="The integer i.")
     j = Int(1, config=True, shortname='j', help="The integer j.")
@@ -39,9 +64,11 @@ class MyApp(Application):
                    help="Load this config file")
 
     def init_foo(self):
+        # Pass config to other classes for them to inherit the config.
         self.foo = Foo(config=self.config)
 
     def init_bar(self):
+        # Pass config to other classes for them to inherit the config.
         self.bar = Bar(config=self.config)
 
 

--- a/docs/examples/core/appconfig.py
+++ b/docs/examples/core/appconfig.py
@@ -1,3 +1,14 @@
+"""A simple example of how to use IPython.config.application.Application.
+
+This should serve as a simple example that shows how the IPython config
+system works. The main classes are:
+
+* IPython.config.configurable.Configurable
+* IPython.config.configurable.SingletonConfigurable
+* IPython.config.loader.Config
+* IPython.config.application.Application
+"""
+
 import sys
 
 from IPython.config.configurable import Configurable
@@ -15,15 +26,24 @@ class Foo(Configurable):
 
 class Bar(Configurable):
 
-    enabled = Bool(True, config=True, shortname="bar-enabled", help="Enable bar.")
+    enabled = Bool(True, config=True, shortname="enabled", help="Enable bar.")
 
 
 class MyApp(Application):
 
     app_name = Unicode(u'myapp')
-    running = Bool(False, config=True, shortname="running", help="Is the app running?")
+    running = Bool(False, config=True, shortname="running",
+                   help="Is the app running?")
     classes = List([Bar, Foo])
-    config_file = Unicode(u'', config=True, shortname="config-file", help="Load this config file")
+    config_file = Unicode(u'', config=True, shortname="config_file",
+                   help="Load this config file")
+
+    def init_foo(self):
+        self.foo = Foo(config=self.config)
+
+    def init_bar(self):
+        self.bar = Bar(config=self.config)
+
 
 
 def main():
@@ -31,6 +51,8 @@ def main():
     app.parse_command_line()
     if app.config_file:
         app.load_config_file(app.config_file)
+    app.init_foo()
+    app.init_bar()
     print "app.config:"
     print app.config
 

--- a/docs/examples/core/appconfig.py
+++ b/docs/examples/core/appconfig.py
@@ -1,10 +1,10 @@
 import sys
 
 from IPython.config.configurable import Configurable
+from IPython.config.application import Application
 from IPython.utils.traitlets import (
     Bool, Unicode, Int, Float, List
 )
-from IPython.config.loader import KeyValueConfigLoader
 
 class Foo(Configurable):
 
@@ -18,35 +18,19 @@ class Bar(Configurable):
     enabled = Bool(True, config=True, shortname="bar-enabled", help="Enable bar.")
 
 
-class MyApp(Configurable):
+class MyApp(Application):
 
-    app_name = Unicode(u'myapp', config=True, shortname="myapp", help="The app name.")
+    app_name = Unicode(u'myapp')
     running = Bool(False, config=True, shortname="running", help="Is the app running?")
     classes = List([Bar, Foo])
-
-    def __init__(self, **kwargs):
-        Configurable.__init__(self, **kwargs)
-        self.classes.insert(0, self.__class__)
-
-    def print_help(self):
-        for cls in self.classes:
-            cls.class_print_help()
-            print
-
-    def parse_command_line(self, argv=None):
-        if argv is None:
-            argv = sys.argv[1:]
-        if '-h' in argv or '--h' in argv:
-            self.print_help()
-            sys.exit(1)
-        loader = KeyValueConfigLoader(argv=argv, classes=self.classes)
-        config = loader.load_config()
-        self.config = config
+    config_file = Unicode(u'', config=True, shortname="config-file", help="Load this config file")
 
 
 def main():
     app = MyApp()
     app.parse_command_line()
+    if app.config_file:
+        app.load_config_file(app.config_file)
     print "app.config:"
     print app.config
 

--- a/docs/examples/core/appconfig.py
+++ b/docs/examples/core/appconfig.py
@@ -1,0 +1,55 @@
+import sys
+
+from IPython.config.configurable import Configurable
+from IPython.utils.traitlets import (
+    Bool, Unicode, Int, Float, List
+)
+from IPython.config.loader import KeyValueConfigLoader
+
+class Foo(Configurable):
+
+    i = Int(0, config=True, shortname='i', help="The integer i.")
+    j = Int(1, config=True, shortname='j', help="The integer j.")
+    name = Unicode(u'Brian', config=True, shortname='name', help="First name.")
+
+
+class Bar(Configurable):
+
+    enabled = Bool(True, config=True, shortname="bar-enabled", help="Enable bar.")
+
+
+class MyApp(Configurable):
+
+    app_name = Unicode(u'myapp', config=True, shortname="myapp", help="The app name.")
+    running = Bool(False, config=True, shortname="running", help="Is the app running?")
+    classes = List([Bar, Foo])
+
+    def __init__(self, **kwargs):
+        Configurable.__init__(self, **kwargs)
+        self.classes.insert(0, self.__class__)
+
+    def print_help(self):
+        for cls in self.classes:
+            cls.class_print_help()
+            print
+
+    def parse_command_line(self, argv=None):
+        if argv is None:
+            argv = sys.argv[1:]
+        if '-h' in argv or '--h' in argv:
+            self.print_help()
+            sys.exit(1)
+        loader = KeyValueConfigLoader(argv=argv, classes=self.classes)
+        config = loader.load_config()
+        self.config = config
+
+
+def main():
+    app = MyApp()
+    app.parse_command_line()
+    print "app.config:"
+    print app.config
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The first stage of updating our configuration system.  I have added a new command line option parser that integrates with our config system. To see how all of this works, look at docs/examples/core/appconfig.py and run it like this:

```
python appconfig.py -h
```

Options can be set using the syntax:

```
python appconfig.py Foo.i=10 Bar.enabled=False log_level=50
```

This branch should be reviewed and merged into trunk and then we all can start to work on updating IPython's main apps to use this new API.
