### PR TITLE
install IPython.zmq.gui

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -136,6 +136,7 @@ def find_packages():
     add_package(packages, 'utils', tests=True)
     add_package(packages, 'zmq')
     add_package(packages, 'zmq.pylab')
+    add_package(packages, 'zmq.gui')
     return packages
 
 #---------------------------------------------------------------------------


### PR DESCRIPTION
"ipython --pylab gtk" doesn't work for me using ubuntu 11.04 latest git master. This seems to
be because the zmq.gui module is not installed. This should fix that.
