### PR TITLE
History request

### DIFF
--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -212,7 +212,7 @@ class IPythonWidget(FrontendWidget):
         """ Reimplemented to make a history request.
         """
         super(IPythonWidget, self)._started_channels()
-        self.kernel_manager.xreq_channel.history_tail(1000)
+        self.kernel_manager.xreq_channel.history(hist_access_type='tail', n=1000)
 
     #---------------------------------------------------------------------------
     # 'ConsoleWidget' public interface

--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -160,7 +160,7 @@ class IPythonWidget(FrontendWidget):
             else:
                 super(IPythonWidget, self)._handle_execute_reply(msg)
 
-    def _handle_history_tail_reply(self, msg):
+    def _handle_history_reply(self, msg):
         """ Implemented to handle history tail replies, which are only supported
             by the IPython kernel.
         """

--- a/IPython/frontend/qt/kernelmanager.py
+++ b/IPython/frontend/qt/kernelmanager.py
@@ -46,7 +46,7 @@ class QtXReqSocketChannel(SocketChannelQObject, XReqSocketChannel):
     execute_reply = QtCore.Signal(object)
     complete_reply = QtCore.Signal(object)
     object_info_reply = QtCore.Signal(object)
-    history_tail_reply = QtCore.Signal(object)
+    history_reply = QtCore.Signal(object)
 
     # Emitted when the first reply comes back.
     first_reply = QtCore.Signal()

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -348,7 +348,7 @@ class Kernel(Configurable):
         else:
             hist = []
         content = {'history' : list(hist)}
-        msg = self.session.send(self.reply_socket, 'history_tail_reply',
+        msg = self.session.send(self.reply_socket, 'history_reply',
                                 content, parent, ident)
         logger.debug(str(msg))
 

--- a/IPython/zmq/kernelmanager.py
+++ b/IPython/zmq/kernelmanager.py
@@ -298,8 +298,8 @@ class XReqSocketChannel(ZmqSocketChannel):
         -------
         The msg_id of the message sent.
         """
-        content = dict(n=n, raw=raw, output=output)
-        msg = self.session.msg('history_tail_request', content)
+        content = dict(n=n, raw=raw, output=output, hist_access_type='tail')
+        msg = self.session.msg('history_request', content)
         self._queue_request(msg)
         return msg['header']['msg_id']
 

--- a/IPython/zmq/kernelmanager.py
+++ b/IPython/zmq/kernelmanager.py
@@ -282,23 +282,40 @@ class XReqSocketChannel(ZmqSocketChannel):
         self._queue_request(msg)
         return msg['header']['msg_id']
 
-    def history_tail(self, n=10, raw=True, output=False):
-        """Get the history list.
+    def history(self, raw=True, output=False, hist_access_type='range', **kwargs):
+        """Get entries from the history list.
 
         Parameters
         ----------
-        n : int
-            The number of lines of history to get.
         raw : bool
             If True, return the raw input.
         output : bool
             If True, then return the output as well.
+        hist_access_type : str
+            'range' (fill in session, start and stop params), 'tail' (fill in n)
+             or 'search' (fill in pattern param).
+        
+        session : int
+            For a range request, the session from which to get lines. Session
+            numbers are positive integers; negative ones count back from the
+            current session.
+        start : int
+            The first line number of a history range.
+        stop : int
+            The final (excluded) line number of a history range.
+        
+        n : int
+            The number of lines of history to get for a tail request.
+            
+        pattern : str
+            The glob-syntax pattern for a search request.
 
         Returns
         -------
         The msg_id of the message sent.
         """
-        content = dict(n=n, raw=raw, output=output, hist_access_type='tail')
+        content = dict(raw=raw, output=output, hist_access_type=hist_access_type,
+                                                                    **kwargs)
         msg = self.session.msg('history_request', content)
         self._queue_request(msg)
         return msg['header']['msg_id']

--- a/docs/source/development/messaging.txt
+++ b/docs/source/development/messaging.txt
@@ -596,21 +596,34 @@ Message type: ``history_request``::
       # If True, return the raw input history, else the transformed input.
       'raw' : bool,
 
-      # This parameter can be one of: A number,  a pair of numbers, None
-      # If not given, last 40 are returned.
-      #  - number n: return the last n entries.
-      #  - pair n1, n2: return entries in the range(n1, n2).
-      #  - None: return all history
-      'index' : n or (n1, n2) or None,
+      # So far, this can be 'range', 'tail' or 'search'.
+      'hist_access_type' : str,
+      
+      # If hist_access_type is 'range', get a range of input cells. session can
+      # be a positive session number, or a negative number to count back from
+      # the current session.
+      'session' : int,
+      # start and stop are line numbers within that session.
+      'start' : int,
+      'stop' : int,
+      
+      # If hist_access_type is 'tail', get the last n cells.
+      'n' : int,
+      
+      # If hist_access_type is 'search', get cells matching the specified glob
+      # pattern (with * and ? as wildcards).
+      'pattern' : str,
+      
     }
 
 Message type: ``history_reply``::
 
     content = {
-      # A dict with prompt numbers as keys and either (input, output) or input
-      # as the value depending on whether output was True or False,
-      # respectively.
-      'history' : dict,
+      # A list of 3 tuples, either:
+      # (session, line_number, input) or
+      # (session, line_number, (input, output)),
+      # depending on whether output was False or True, respectively.
+      'history' : list,
     }
 
 


### PR DESCRIPTION
This relates to issue #402.

This tweaks the messaging spec for making a history_request. The parameter 'hist_access_type' must be one of 'range', 'tail' or 'search', corresponding to the three main parts of the API for accessing history. Then different parameters must be filled in for each one. Additional access options could be added later.

@epatters and I both leaned towards a unified `history_request`, rather than splitting it into three different request types, so I went ahead and implemented it. I'm still open to discussion on that, though - it's easy enough to change.
