### PR TITLE
Retries and Resubmit (#411 and #412)

### DIFF
--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -1041,6 +1041,68 @@ class Client(HasTraits):
             ar.wait()
         
         return ar
+
+    @spin_first
+    def resubmit(self, indices_or_msg_ids=None, subheader=None, block=None):
+        """Resubmit one or more tasks.
+
+        in-flight tasks may not be resubmitted.
+
+        Parameters
+        ----------
+
+        indices_or_msg_ids : integer history index, str msg_id, or list of either
+            The indices or msg_ids of indices to be retrieved
+
+        block : bool
+            Whether to wait for the result to be done
+
+        Returns
+        -------
+
+        AsyncHubResult
+            A subclass of AsyncResult that retrieves results from the Hub
+
+        """
+        block = self.block if block is None else block
+        if indices_or_msg_ids is None:
+            indices_or_msg_ids = -1
+
+        if not isinstance(indices_or_msg_ids, (list,tuple)):
+            indices_or_msg_ids = [indices_or_msg_ids]
+
+        theids = []
+        for id in indices_or_msg_ids:
+            if isinstance(id, int):
+                id = self.history[id]
+            if not isinstance(id, str):
+                raise TypeError("indices must be str or int, not %r"%id)
+            theids.append(id)
+
+        for msg_id in theids:
+            self.outstanding.discard(msg_id)
+            if msg_id in self.history:
+                self.history.remove(msg_id)
+            self.results.pop(msg_id, None)
+            self.metadata.pop(msg_id, None)
+        content = dict(msg_ids = theids)
+
+        self.session.send(self._query_socket, 'resubmit_request', content)
+
+        zmq.select([self._query_socket], [], [])
+        idents,msg = self.session.recv(self._query_socket, zmq.NOBLOCK)
+        if self.debug:
+            pprint(msg)
+        content = msg['content']
+        if content['status'] != 'ok':
+            raise self._unwrap_exception(content)
+
+        ar = AsyncHubResult(self, msg_ids=theids)
+
+        if block:
+            ar.wait()
+
+        return ar
     
     @spin_first
     def result_status(self, msg_ids, status_only=True):

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -1317,9 +1317,11 @@ class Client(HasTraits):
         query : mongodb query dict
             The search dict. See mongodb query docs for details.
         keys : list of strs [optional]
-            THe subset of keys to be returned.  The default is to fetch everything.
+            The subset of keys to be returned.  The default is to fetch everything but buffers.
             'msg_id' will *always* be included.
         """
+        if isinstance(keys, basestring):
+            keys = [keys]
         content = dict(query=query, keys=keys)
         self.session.send(self._query_socket, "db_request", content=content)
         idents, msg = self.session.recv(self._query_socket, 0)

--- a/IPython/parallel/client/view.py
+++ b/IPython/parallel/client/view.py
@@ -19,7 +19,7 @@ from types import ModuleType
 import zmq
 
 from IPython.testing import decorators as testdec
-from IPython.utils.traitlets import HasTraits, Any, Bool, List, Dict, Set, Int, Instance, CFloat
+from IPython.utils.traitlets import HasTraits, Any, Bool, List, Dict, Set, Int, Instance, CFloat, CInt
 
 from IPython.external.decorator import decorator
 
@@ -791,9 +791,10 @@ class LoadBalancedView(View):
     follow=Any()
     after=Any()
     timeout=CFloat()
+    retries = CInt(0)
     
     _task_scheme = Any()
-    _flag_names = List(['targets', 'block', 'track', 'follow', 'after', 'timeout'])
+    _flag_names = List(['targets', 'block', 'track', 'follow', 'after', 'timeout', 'retries'])
     
     def __init__(self, client=None, socket=None, **flags):
         super(LoadBalancedView, self).__init__(client=client, socket=socket, **flags)
@@ -851,7 +852,7 @@ class LoadBalancedView(View):
             whether to create a MessageTracker to allow the user to 
             safely edit after arrays and buffers during non-copying
             sends.
-        #
+
         after : Dependency or collection of msg_ids
             Only for load-balanced execution (targets=None)
             Specify a list of msg_ids as a time-based dependency.
@@ -869,6 +870,9 @@ class LoadBalancedView(View):
             Specify an amount of time (in seconds) for the scheduler to
             wait for dependencies to be met before failing with a
             DependencyTimeout.
+
+        retries : int
+            Number of times a task will be retried on failure.
         """
         
         super(LoadBalancedView, self).set_flags(**kwargs)
@@ -892,7 +896,7 @@ class LoadBalancedView(View):
     @save_ids
     def _really_apply(self, f, args=None, kwargs=None, block=None, track=None,
                                         after=None, follow=None, timeout=None,
-                                        targets=None):
+                                        targets=None, retries=None):
         """calls f(*args, **kwargs) on a remote engine, returning the result.
         
         This method temporarily sets all of `apply`'s flags for a single call.
@@ -933,10 +937,11 @@ class LoadBalancedView(View):
             raise RuntimeError(msg)
         
         if self._task_scheme == 'pure':
-            # pure zmq scheme doesn't support dependencies
-            msg = "Pure ZMQ scheduler doesn't support dependencies"
-            if (follow or after):
-                # hard fail on DAG dependencies
+            # pure zmq scheme doesn't support extra features
+            msg = "Pure ZMQ scheduler doesn't support the following flags:"
+            "follow, after, retries, targets, timeout"
+            if (follow or after or retries or targets or timeout):
+                # hard fail on Scheduler flags
                 raise RuntimeError(msg)
             if isinstance(f, dependent):
                 # soft warn on functional dependencies
@@ -948,10 +953,14 @@ class LoadBalancedView(View):
         block = self.block if block is None else block
         track = self.track if track is None else track
         after = self.after if after is None else after
+        retries = self.retries if retries is None else retries
         follow = self.follow if follow is None else follow
         timeout = self.timeout if timeout is None else timeout
         targets = self.targets if targets is None else targets
         
+        if not isinstance(retries, int):
+            raise TypeError('retries must be int, not %r'%type(retries))
+
         if targets is None:
             idents = []
         else:
@@ -959,7 +968,7 @@ class LoadBalancedView(View):
         
         after = self._render_dependency(after)
         follow = self._render_dependency(follow)
-        subheader = dict(after=after, follow=follow, timeout=timeout, targets=idents)
+        subheader = dict(after=after, follow=follow, timeout=timeout, targets=idents, retries=retries)
         
         msg = self.client.send_apply_message(self._socket, f, args, kwargs, track=track,
                                 subheader=subheader)

--- a/IPython/parallel/controller/dictdb.py
+++ b/IPython/parallel/controller/dictdb.py
@@ -146,7 +146,7 @@ class DictDB(BaseDB):
         """Remove a record from the DB."""
         matches = self._match(check)
         for m in matches:
-            del self._records[m]
+            del self._records[m['msg_id']]
         
     def drop_record(self, msg_id):
         """Remove a record from the DB."""

--- a/IPython/parallel/streamsession.py
+++ b/IPython/parallel/streamsession.py
@@ -186,6 +186,9 @@ class StreamSession(object):
         elif isinstance(content, bytes):
             # content is already packed, as in a relayed message
             pass
+        elif isinstance(content, unicode):
+            # should be bytes, but JSON often spits out unicode
+            content = content.encode('utf8')
         else:
             raise TypeError("Content incorrect type: %s"%type(content))
 

--- a/IPython/parallel/tests/__init__.py
+++ b/IPython/parallel/tests/__init__.py
@@ -48,7 +48,7 @@ class TestProcessLauncher(LocalProcessLauncher):
 def setup():
     cp = TestProcessLauncher()
     cp.cmd_and_args = ipcontroller_cmd_argv + \
-                ['--profile', 'iptest', '--log-level', '99', '-r', '--usethreads']
+                ['--profile', 'iptest', '--log-level', '99', '-r']
     cp.start()
     launchers.append(cp)
     cluster_dir = os.path.join(get_ipython_dir(), 'cluster_iptest')

--- a/IPython/parallel/tests/test_client.py
+++ b/IPython/parallel/tests/test_client.py
@@ -235,3 +235,10 @@ class TestClient(ClusterTestCase):
     def test_resubmit_badkey(self):
         """ensure KeyError on resubmit of nonexistant task"""
         self.assertRaisesRemote(KeyError, self.client.resubmit, ['invalid'])
+
+    def test_purge_results(self):
+        hist = self.client.hub_history()
+        self.client.purge_results(hist)
+        newhist = self.client.hub_history()
+        self.assertTrue(len(newhist) == 0)
+

--- a/IPython/parallel/tests/test_client.py
+++ b/IPython/parallel/tests/test_client.py
@@ -212,3 +212,26 @@ class TestClient(ClusterTestCase):
         time.sleep(0.25)
         self.assertEquals(self.client.hub_history()[-1:],ar.msg_ids)
     
+    def test_resubmit(self):
+        def f():
+            import random
+            return random.random()
+        v = self.client.load_balanced_view()
+        ar = v.apply_async(f)
+        r1 = ar.get(1)
+        ahr = self.client.resubmit(ar.msg_ids)
+        r2 = ahr.get(1)
+        self.assertFalse(r1 == r2)
+
+    def test_resubmit_inflight(self):
+        """ensure ValueError on resubmit of inflight task"""
+        v = self.client.load_balanced_view()
+        ar = v.apply_async(time.sleep,1)
+        # give the message a chance to arrive
+        time.sleep(0.2)
+        self.assertRaisesRemote(ValueError, self.client.resubmit, ar.msg_ids)
+        ar.get(2)
+
+    def test_resubmit_badkey(self):
+        """ensure KeyError on resubmit of nonexistant task"""
+        self.assertRaisesRemote(KeyError, self.client.resubmit, ['invalid'])

--- a/IPython/parallel/tests/test_lbview.py
+++ b/IPython/parallel/tests/test_lbview.py
@@ -1,0 +1,120 @@
+"""test LoadBalancedView objects"""
+# -*- coding: utf-8 -*-
+#-------------------------------------------------------------------------------
+#  Copyright (C) 2011  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-------------------------------------------------------------------------------
+
+#-------------------------------------------------------------------------------
+# Imports
+#-------------------------------------------------------------------------------
+
+import sys
+import time
+
+import zmq
+
+from IPython import parallel  as pmod
+from IPython.parallel import error
+
+from IPython.parallel.tests import add_engines
+
+from .clienttest import ClusterTestCase, crash, wait, skip_without
+
+def setup():
+    add_engines(3)
+
+class TestLoadBalancedView(ClusterTestCase):
+
+    def setUp(self):
+        ClusterTestCase.setUp(self)
+        self.view = self.client.load_balanced_view()
+
+    def test_z_crash_task(self):
+        """test graceful handling of engine death (balanced)"""
+        # self.add_engines(1)
+        ar = self.view.apply_async(crash)
+        self.assertRaisesRemote(error.EngineError, ar.get)
+        eid = ar.engine_id
+        tic = time.time()
+        while eid in self.client.ids and time.time()-tic < 5:
+            time.sleep(.01)
+            self.client.spin()
+        self.assertFalse(eid in self.client.ids, "Engine should have died")
+
+    def test_map(self):
+        def f(x):
+            return x**2
+        data = range(16)
+        r = self.view.map_sync(f, data)
+        self.assertEquals(r, map(f, data))
+
+    def test_abort(self):
+        view = self.view
+        ar = self.client[:].apply_async(time.sleep, .5)
+        ar2 = view.apply_async(lambda : 2)
+        ar3 = view.apply_async(lambda : 3)
+        view.abort(ar2)
+        view.abort(ar3.msg_ids)
+        self.assertRaises(error.TaskAborted, ar2.get)
+        self.assertRaises(error.TaskAborted, ar3.get)
+
+    def test_retries(self):
+        add_engines(3)
+        view = self.view
+        view.timeout = 1 # prevent hang if this doesn't behave
+        def fail():
+            assert False
+        for r in range(len(self.client)-1):
+            with view.temp_flags(retries=r):
+                self.assertRaisesRemote(AssertionError, view.apply_sync, fail)
+
+        with view.temp_flags(retries=len(self.client), timeout=0.25):
+            self.assertRaisesRemote(error.TaskTimeout, view.apply_sync, fail)
+
+    def test_invalid_dependency(self):
+        view = self.view
+        with view.temp_flags(after='12345'):
+            self.assertRaisesRemote(error.InvalidDependency, view.apply_sync, lambda : 1)
+
+    def test_impossible_dependency(self):
+        if len(self.client) < 2:
+            add_engines(2)
+        view = self.client.load_balanced_view()
+        ar1 = view.apply_async(lambda : 1)
+        ar1.get()
+        e1 = ar1.engine_id
+        e2 = e1
+        while e2 == e1:
+            ar2 = view.apply_async(lambda : 1)
+            ar2.get()
+            e2 = ar2.engine_id
+
+        with view.temp_flags(follow=[ar1, ar2]):
+            self.assertRaisesRemote(error.ImpossibleDependency, view.apply_sync, lambda : 1)
+
+
+    def test_follow(self):
+        ar = self.view.apply_async(lambda : 1)
+        ar.get()
+        ars = []
+        first_id = ar.engine_id
+
+        self.view.follow = ar
+        for i in range(5):
+            ars.append(self.view.apply_async(lambda : 1))
+        self.view.wait(ars)
+        for ar in ars:
+            self.assertEquals(ar.engine_id, first_id)
+
+    def test_after(self):
+        view = self.view
+        ar = view.apply_async(time.sleep, 0.5)
+        with view.temp_flags(after=ar):
+            ar2 = view.apply_async(lambda : 1)
+
+        ar.wait()
+        ar2.wait()
+        self.assertTrue(ar2.started > ar.completed)

--- a/IPython/parallel/tests/test_lbview.py
+++ b/IPython/parallel/tests/test_lbview.py
@@ -36,7 +36,7 @@ class TestLoadBalancedView(ClusterTestCase):
         """test graceful handling of engine death (balanced)"""
         # self.add_engines(1)
         ar = self.view.apply_async(crash)
-        self.assertRaisesRemote(error.EngineError, ar.get)
+        self.assertRaisesRemote(error.EngineError, ar.get, 10)
         eid = ar.engine_id
         tic = time.time()
         while eid in self.client.ids and time.time()-tic < 5:

--- a/IPython/parallel/tests/test_mongodb.py
+++ b/IPython/parallel/tests/test_mongodb.py
@@ -1,0 +1,37 @@
+"""Tests for mongodb backend"""
+
+#-------------------------------------------------------------------------------
+#  Copyright (C) 2011  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-------------------------------------------------------------------------------
+
+#-------------------------------------------------------------------------------
+# Imports
+#-------------------------------------------------------------------------------
+
+from nose import SkipTest
+
+from pymongo import Connection
+from IPython.parallel.controller.mongodb import MongoDB
+
+from . import test_db
+
+try:
+    c = Connection()
+except Exception:
+    c=None
+
+class TestMongoBackend(test_db.TestDictBackend):
+    """MongoDB backend tests"""
+
+    def create_db(self):
+        try:
+            return MongoDB(database='iptestdb', _connection=c)
+        except Exception:
+            raise SkipTest("Couldn't connect to mongodb")
+
+def teardown(self):
+    if c is not None:
+        c.drop_database('iptestdb')

--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -21,7 +21,7 @@ import zmq
 from IPython import parallel  as pmod
 from IPython.parallel import error
 from IPython.parallel import AsyncResult, AsyncHubResult, AsyncMapResult
-from IPython.parallel import LoadBalancedView, DirectView
+from IPython.parallel import DirectView
 from IPython.parallel.util import interactive
 
 from IPython.parallel.tests import add_engines
@@ -32,18 +32,6 @@ def setup():
     add_engines(3)
 
 class TestView(ClusterTestCase):
-    
-    def test_z_crash_task(self):
-        """test graceful handling of engine death (balanced)"""
-        # self.add_engines(1)
-        ar = self.client[-1].apply_async(crash)
-        self.assertRaisesRemote(error.EngineError, ar.get)
-        eid = ar.engine_id
-        tic = time.time()
-        while eid in self.client.ids and time.time()-tic < 5:
-            time.sleep(.01)
-            self.client.spin()
-        self.assertFalse(eid in self.client.ids, "Engine should have died")
     
     def test_z_crash_mux(self):
         """test graceful handling of engine death (direct)"""

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -199,6 +199,7 @@ def make_exclude():
     
     if not have['pymongo']:
         exclusions.append(ipjoin('parallel', 'controller', 'mongodb'))
+        exclusions.append(ipjoin('parallel', 'tests', 'test_mongodb'))
 
     if not have['matplotlib']:
         exclusions.extend([ipjoin('lib', 'pylabtools'),

--- a/docs/source/parallel/index.txt
+++ b/docs/source/parallel/index.txt
@@ -12,6 +12,7 @@ Using IPython for parallel computing
    parallel_multiengine.txt
    parallel_task.txt
    parallel_mpi.txt
+   parallel_db.txt
    parallel_security.txt
    parallel_winhpc.txt
    parallel_demos.txt

--- a/docs/source/parallel/parallel_db.txt
+++ b/docs/source/parallel/parallel_db.txt
@@ -1,0 +1,114 @@
+.. _parallel_db:
+
+=======================
+IPython's Task Database
+=======================
+
+The IPython Hub stores all task requests and results in a database. Currently supported backends
+are: MongoDB, SQLite (the default), and an in-memory DictDB.  The most common use case for
+this is clients requesting results for tasks they did not submit, via:
+
+.. sourcecode:: ipython
+
+    In [1]: rc.get_result(task_id)
+
+However, since we have this DB backend, we provide a direct query method in the :class:`client`
+for users who want deeper introspection into their task history. The :meth:`db_query` method of
+the Client is modeled after MongoDB queries, so if you have used MongoDB it should look
+familiar.  In fact, when the MongoDB backend is in use, the query is relayed directly.  However,
+when using other backends, the interface is emulated and only a subset of queries is possible.
+
+.. seealso::
+
+    MongoDB query docs: http://www.mongodb.org/display/DOCS/Querying
+
+:meth:`Client.db_query` takes a dictionary query object, with keys from the TaskRecord key list,
+and values of either exact values to test, or MongoDB queries, which are dicts of The form:
+``{'operator' : 'argument(s)'}``. There is also an optional `keys` argument, that specifies
+which subset of keys should be retrieved. The default is to retrieve all keys excluding the
+request and result buffers. :meth:`db_query` returns a list of TaskRecord dicts. Also like
+MongoDB, the `msg_id` key will always be included, whether requested or not.
+
+TaskRecord keys:
+
+=============== =============== =============
+Key             Type            Description
+=============== =============== =============
+msg_id          uuid(bytes)     The msg ID
+header          dict            The request header
+content         dict            The request content (likely empty)
+buffers         list(bytes)     buffers containing serialized request objects
+submitted       datetime        timestamp for time of submission (set by client)
+client_uuid     uuid(bytes)     IDENT of client's socket
+engine_uuid     uuid(bytes)     IDENT of engine's socket
+started         datetime        time task began execution on engine
+completed       datetime        time task finished execution (success or failure) on engine
+resubmitted     datetime        time of resubmission (if applicable)
+result_header   dict            header for result
+result_content  dict            content for result
+result_buffers  list(bytes)     buffers containing serialized request objects
+queue           bytes           The name of the queue for the task ('mux' or 'task')
+pyin            <unused>        Python input (unused)
+pyout           <unused>        Python output (unused)
+pyerr           <unused>        Python traceback (unused)
+stdout          str             Stream of stdout data
+stderr          str             Stream of stderr data
+
+=============== =============== =============
+
+MongoDB operators we emulate on all backends:
+
+==========  =================
+Operator    Python equivalent
+==========  =================
+  '$in'       in
+  '$nin'      not in
+  '$eq'       ==
+  '$ne'       !=
+  '$ge'       >
+  '$gte'      >=
+  '$le'       <
+  '$lte'      <=
+==========  =================
+
+
+The DB Query is useful for two primary cases:
+
+1. deep polling of task status or metadata
+2. selecting a subset of tasks, on which to perform a later operation (e.g. wait on result, purge records, resubmit,...)
+
+Example Queries
+===============
+
+
+To get all msg_ids that are not completed, only retrieving their ID and start time:
+
+.. sourcecode:: ipython
+
+    In [1]: incomplete = rc.db_query({'complete' : None}, keys=['msg_id', 'started'])
+
+All jobs started in the last hour by me:
+
+.. sourcecode:: ipython
+
+    In [1]: from datetime import datetime, timedelta
+
+    In [2]: hourago = datetime.now() - timedelta(1./24)
+
+    In [3]: recent = rc.db_query({'started' : {'$gte' : hourago },
+                                    'client_uuid' : rc.session.session})
+
+All jobs started more than an hour ago, by clients *other than me*:
+
+.. sourcecode:: ipython
+
+    In [3]: recent = rc.db_query({'started' : {'$le' : hourago },
+                                    'client_uuid' : {'$ne' : rc.session.session}})
+
+Result headers for all jobs on engine 3 or 4:
+
+.. sourcecode:: ipython
+
+    In [1]: uuids = map(rc._engines.get, (3,4))
+
+    In [2]: hist34 = rc.db_query({'engine_uuid' : {'$in' : uuids }, keys='result_header')

--- a/docs/source/parallel/parallel_task.txt
+++ b/docs/source/parallel/parallel_task.txt
@@ -292,6 +292,7 @@ you can skip using Dependency objects, and just pass msg_ids or AsyncResult obje
 
 
 
+
 Impossible Dependencies
 ***********************
 
@@ -312,6 +313,27 @@ The basic cases that are checked:
 
     This analysis has not been proven to be rigorous, so it is likely possible for tasks
     to become impossible to run in obscure situations, so a timeout may be a good choice.
+
+
+Retries and Resubmit
+====================
+
+Retries
+-------
+
+Another flag for tasks is `retries`.  This is an integer, specifying how many times
+a task should be resubmitted after failure.  This is useful for tasks that should still run
+if their engine was shutdown, or may have some statistical chance of failing.  The default
+is to not retry tasks.
+
+Resubmit
+--------
+
+Sometimes you may want to re-run a task. This could be because it failed for some reason, and
+you have fixed the error, or because you want to restore the cluster to an interrupted state.
+For this, the :class:`Client` has a :meth:`rc.resubmit` method.  This simply takes one or more
+msg_ids, and returns an :class:`AsyncHubResult` for the result(s).  You cannot resubmit
+a task that is pending - only those that have finished, either successful or unsuccessful.
 
 .. _parallel_schedulers:
 
@@ -389,6 +411,8 @@ Disabled features when using the ZMQ Scheduler:
 .. note::
 
     TODO: performance comparisons
+
+
 
 
 More details


### PR DESCRIPTION
Add retries flag to LoadBalancedView, and resubmit method to Client.

Retry behavior is much the same as the previous version.  If tasks fail, they will be retried on other engines up to a limit.  The default limit is 0 (no retries).  `retries` is a flag like everything else, so can be set by `View.retries` attribute, `View.temp_flags()`, `View.set_flags()`, etc.  

Will close #412
