### PR TITLE
Warn on old config files

### DIFF
--- a/IPython/config/default/ipython_config.py
+++ b/IPython/config/default/ipython_config.py
@@ -11,6 +11,10 @@ c = get_config()
 
 # c.Global.nosep = True
 
+# If you still use multiple versions of IPytho on the same machine,
+# set this to True to suppress warnings about old configuration files
+# c.Global.ignore_old_config = False
+
 # Set this to determine the detail of what is logged at startup.
 # The default is 30 and possible values are 0,10,20,30,40,50.
 # c.Global.log_level = 20

--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -635,7 +635,8 @@ class IPythonApp(Application):
                 self.shell.showtraceback()
 
     def start_app(self):
-        check_for_old_config(self.ipython_dir)
+        if not getattr(self.master_config.Global, 'ignore_old_config', False):
+            check_for_old_config(self.ipython_dir)
         if self.master_config.Global.interact:
             self.log.debug("Starting IPython's mainloop...")
             self.shell.mainloop()

--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -37,7 +37,7 @@ from IPython.config.loader import (
     PyFileConfigLoader
 )
 from IPython.lib import inputhook
-from IPython.utils.path import filefind, get_ipython_dir
+from IPython.utils.path import filefind, get_ipython_dir, check_for_old_config
 from IPython.core import usage
 
 #-----------------------------------------------------------------------------
@@ -635,6 +635,7 @@ class IPythonApp(Application):
                 self.shell.showtraceback()
 
     def start_app(self):
+        check_for_old_config(self.ipython_dir)
         if self.master_config.Global.interact:
             self.log.debug("Starting IPython's mainloop...")
             self.shell.mainloop()

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -18,6 +18,7 @@ import os
 import sys
 
 import IPython
+from IPython.utils import warn
 from IPython.utils.process import system
 from IPython.utils.importstring import import_item
 
@@ -398,4 +399,24 @@ def target_update(target,deps,cmd):
 
     if target_outdated(target,deps):
         system(cmd)
+
+def check_for_old_config(ipython_dir=None):
+    """Check for old config files, and present a warning if they exist.
+    
+    A link to the docs of the new config is included in the message.
+    
+    This should mitigate confusion with the transition to the new
+    config system in 0.11.
+    """
+    if ipython_dir is None:
+        ipython_dir = get_ipython_dir()
+    
+    old_configs = ['ipy_user_conf.py', 'ipythonrc']
+    for cfg in old_configs:
+        f = os.path.join(ipython_dir, cfg)
+        if os.path.exists(f):
+            warn.warn("""Found old IPython config file %r.
+    The IPython configuration system has changed as of 0.11, and this file will be ignored.
+    See http://ipython.github.com/ipython-doc/dev/config for details on the new config system.
+    The current default config file is 'ipython_config.py'"""%f)
 

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -418,5 +418,6 @@ def check_for_old_config(ipython_dir=None):
             warn.warn("""Found old IPython config file %r.
     The IPython configuration system has changed as of 0.11, and this file will be ignored.
     See http://ipython.github.com/ipython-doc/dev/config for details on the new config system.
-    The current default config file is 'ipython_config.py'"""%f)
+    The current default config file is 'ipython_config.py', where you can suppress these
+    warnings with `Global.ignore_old_config = True`."""%f)
 


### PR DESCRIPTION
add `check_for_old_config()` to `utils.path`, which warns users about old config files, and point them to new ones.  Launching IPython will continue to raise the warning until you update your config files.

Should address #304.  

Are there other config files I should check for besides 'ipy_user_conf.py' and 'ipythonrc'?
