### PR TITLE
Minor configuration doc fixes

### DIFF
--- a/IPython/config/default/ipython_config.py
+++ b/IPython/config/default/ipython_config.py
@@ -16,7 +16,7 @@ c = get_config()
 # c.Global.log_level = 20
 
 # This should be a list of importable Python modules that have an
-# load_in_ipython(ip) method.  This method gets called when the extension
+# load_ipython_extension(ip) method.  This method gets called when the extension
 # is loaded.  You can put your extensions anywhere they can be imported
 # but we add the extensions subdir of the ipython directory to sys.path
 # during extension loading, so you can put them there as well.

--- a/docs/source/config/ipython.txt
+++ b/docs/source/config/ipython.txt
@@ -13,7 +13,7 @@ The default configuration file for the :command:`ipython` command line applicati
 is :file:`ipython_config.py`.  By setting the attributes in this file, you
 can configure the application.   A sample is provided in
 :mod:`IPython.config.default.ipython_config`.  Simply copy this file to your
-IPython directory to start using it.
+:ref:`IPython directory <ipython_dir>` to start using it.
 
 Most configuration attributes that this file accepts are associated with
 classes that are subclasses of :class:`~IPython.core.component.Component`.


### PR DESCRIPTION
Here are a couple small tweaks to the config documentation that I would have found very helpful.

Also, I wonder if IPython/config/default/ipython_config.py shouldn't be copied into the user's .config/ipython directory if it doesn't already exist there. It was easy enough to find the file, since I am building from sources, but what about folks who install ipython using a package manager?
