### PR TITLE
%xdel magic

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1079,7 +1079,49 @@ class InteractiveShell(Configurable, Magic):
         
         # Clear out the namespace from the last %run
         self.new_main_mod()
-
+    
+    def del_var(self, varname, by_name=False):
+        """Delete a variable from the various namespaces, so that, as
+        far as possible, we're not keeping any hidden references to it.
+        
+        Parameters
+        ----------
+        varname : str
+            The name of the variable to delete.
+        by_name : bool
+            If True, delete variables with the given name in each
+            namespace. If False (default), find the variable in the user
+            namespace, and delete references to it.
+        """
+        if varname in ('__builtin__', '__builtins__'):
+            raise ValueError("Refusing to delete %s" % varname)
+        ns_refs = self.ns_refs_table + [self.user_ns,
+                self.user_global_ns, self._user_main_module.__dict__] +\
+                self._main_ns_cache.values()
+        
+        if by_name:                    # Delete by name
+            for ns in ns_refs:
+                try:
+                    del ns[varname]
+                except KeyError:
+                    pass
+        else:                         # Delete by object
+            try:
+                obj = self.user_ns[varname]
+            except KeyError:
+                raise NameError("name '%s' is not defined" % varname)
+            # Also check in output history
+            ns_refs.append(self.history_manager.output_hist)
+            for ns in ns_refs:
+                to_delete = [n for n, o in ns.iteritems() if o is obj]
+                for name in to_delete:
+                    del ns[name]
+                    
+            # displayhook keeps extra references, but not in a dictionary
+            for name in ('_', '__', '___'):
+                if getattr(self.displayhook, name) is obj:
+                    setattr(self.displayhook, name, None)
+    
     def reset_selective(self, regex=None):
         """Clear selective variables from internal namespaces based on a
         specified regular expression.

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -1081,7 +1081,24 @@ Currently the magic system has the following functions:\n"""
                 raise TypeError('regex must be a string or compiled pattern')
             for i in self.magic_who_ls():
                 if m.search(i): 
-                    del(user_ns[i])        
+                    del(user_ns[i])
+                    
+    def magic_xdel(self, parameter_s=''):
+        """Delete a variable, trying to clear it from anywhere that
+        IPython's machinery has references to it. By default, this uses
+        the identity of the named object in the user namespace to remove
+        references held under other names. The object is also removed
+        from the output history.
+        
+        Options
+          -n : Delete the specified name from all namespaces, without
+          checking their identity.
+        """
+        opts, varname = self.parse_options(parameter_s,'n')
+        try:
+            self.shell.del_var(varname, ('n' in opts))
+        except (NameError, ValueError) as e:
+            print type(e).__name__ +": "+ str(e)
         
     def magic_logstart(self,parameter_s=''):
         """Start logging anywhere in a session.

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -404,11 +404,26 @@ class TestXdel(tt.TempFileMixin):
                "        self.monitor.append(1)\n"
                "a = A()\n")
         self.mktmp(src)
+        # %run creates some hidden references...
         _ip.magic("run %s" % self.fname)
+        # ... as does the displayhook.
         _ip.run_cell("a")
+        a = _ip.user_ns["a"]
         monitor = _ip.user_ns["A"].monitor
         nt.assert_equal(monitor, [])
         _ip.magic("xdel a")
+        
+        # The testing framework stores extra references - we kill those
+        # here. See IPython.testing.globalipapp.ipnsdict.
+        _ip.user_ns.killrefs(a)
+        del a
+        
+        # For some reason the test doesn't pass if this is removed.
+        # TODO: Work out why, and improve the test.
+        f = sys._getframe()
+        print f.f_locals
+        
+        # Check that a's __del__ method has been called.
         nt.assert_equal(monitor, [1])
 
 def doctest_who():

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -408,20 +408,11 @@ class TestXdel(tt.TempFileMixin):
         _ip.magic("run %s" % self.fname)
         # ... as does the displayhook.
         _ip.run_cell("a")
-        a = _ip.user_ns["a"]
+        
         monitor = _ip.user_ns["A"].monitor
         nt.assert_equal(monitor, [])
+        
         _ip.magic("xdel a")
-        
-        # The testing framework stores extra references - we kill those
-        # here. See IPython.testing.globalipapp.ipnsdict.
-        _ip.user_ns.killrefs(a)
-        del a
-        
-        # For some reason the test doesn't pass if this is removed.
-        # TODO: Work out why, and improve the test.
-        f = sys._getframe()
-        print f.f_locals
         
         # Check that a's __del__ method has been called.
         nt.assert_equal(monitor, [1])

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -394,6 +394,22 @@ def test_reset_hard():
     nt.assert_equal(monitor, [])
     _ip.magic_reset("-f")
     nt.assert_equal(monitor, [1])
+    
+class TestXdel(tt.TempFileMixin):
+    def test_xdel(self):
+        """Test that references from %run are cleared by xdel."""
+        src = ("class A(object):\n"
+               "    monitor = []\n"
+               "    def __del__(self):\n"
+               "        self.monitor.append(1)\n"
+               "a = A()\n")
+        self.mktmp(src)
+        _ip.magic("run %s" % self.fname)
+        _ip.run_cell("a")
+        monitor = _ip.user_ns["A"].monitor
+        nt.assert_equal(monitor, [])
+        _ip.magic("xdel a")
+        nt.assert_equal(monitor, [1])
 
 def doctest_who():
     """doctest for %who

--- a/IPython/testing/globalipapp.py
+++ b/IPython/testing/globalipapp.py
@@ -132,6 +132,15 @@ class ipnsdict(dict):
         # correct for that ourselves, to ensure consitency with the 'real'
         # ipython.
         self['__builtins__'] = __builtin__
+        
+    def killrefs(self, obj):
+        """For part of the testing, we need to be able to remove
+        references to an object, which would otherwise be kept in
+        _savedict."""
+        todel = [n for n, o in self._savedict.iteritems() if o is obj]
+        for n in todel:
+            del self._savedict[n]
+        
 
 
 def get_ipython():

--- a/IPython/testing/globalipapp.py
+++ b/IPython/testing/globalipapp.py
@@ -133,14 +133,15 @@ class ipnsdict(dict):
         # ipython.
         self['__builtins__'] = __builtin__
         
-    def killrefs(self, obj):
-        """For part of the testing, we need to be able to remove
-        references to an object, which would otherwise be kept in
-        _savedict."""
-        todel = [n for n, o in self._savedict.iteritems() if o is obj]
-        for n in todel:
-            del self._savedict[n]
-        
+    def __delitem__(self, key):
+        """Part of the test suite checks that we can release all
+        references to an object. So we need to make sure that we're not
+        keeping a reference in _savedict."""
+        dict.__delitem__(self, key)
+        try:
+            del self._savedict[key]
+        except KeyError:
+            pass
 
 
 def get_ipython():


### PR DESCRIPTION
Fernando suggested this on issue #141. The %xdel magic hunts out the references to an object in the IPython machinery, removing them so that the object can be released from memory. I'm fairly satisfied with the implementation, although please tell me if I've overlooked somewhere that we can keep references.

The trickiest bit of this was writing the test. We have to eliminate extra references kept by the testing framework (fair enough). Then it still doesn't work unless I print the test function's frame's local variables before checking that the object was released. I've no idea what difference that makes (and calling `gc.collect()` doesn't work instead), but I've put it in until we can find a better way to make the test work. Obviously please make sure that this passes on other systems.

I've also manually checked it interactively, which works without any extra trickery.
