### PR TITLE
Permit kernel std* to be redirected

### DIFF
--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -551,6 +551,7 @@ class GTKKernel(Kernel):
 #-----------------------------------------------------------------------------
 
 def launch_kernel(ip=None, xrep_port=0, pub_port=0, req_port=0, hb_port=0,
+                  stdin=None, stdout=None, stderr=None,
                   executable=None, independent=False, pylab=False, colors=None):
     """Launches a localhost kernel, binding to the specified ports.
 
@@ -570,6 +571,9 @@ def launch_kernel(ip=None, xrep_port=0, pub_port=0, req_port=0, hb_port=0,
 
     hb_port : int, optional
         The port to use for the hearbeat REP channel.
+
+    stdin, stdout, stderr : optional (default None)
+        Standards streams, as defined in subprocess.Popen.
 
     executable : str, optional (default sys.executable)
         The Python executable to use for the kernel process.
@@ -608,6 +612,7 @@ def launch_kernel(ip=None, xrep_port=0, pub_port=0, req_port=0, hb_port=0,
         extra_arguments.append(colors)
     return base_launch_kernel('from IPython.zmq.ipkernel import main; main()',
                               xrep_port, pub_port, req_port, hb_port, 
+                              stdin, stdout, stderr,
                               executable, independent, extra_arguments)
 
 

--- a/IPython/zmq/kernelmanager.py
+++ b/IPython/zmq/kernelmanager.py
@@ -835,8 +835,15 @@ class KernelManager(HasTraits):
             except OSError, e:
                 # In Windows, we will get an Access Denied error if the process
                 # has already terminated. Ignore it.
-                if not (sys.platform == 'win32' and e.winerror == 5):
-                    raise
+                if sys.platform == 'win32':
+                    if e.winerror != 5:
+                        raise
+                # On Unix, we may get an ESRCH error if the process has already
+                # terminated. Ignore it.
+                else:
+                    from errno import ESRCH
+                    if e.errno != ESRCH:
+                        raise
             self.kernel = None
         else:
             raise RuntimeError("Cannot kill kernel. No kernel is running!")

--- a/IPython/zmq/kernelmanager.py
+++ b/IPython/zmq/kernelmanager.py
@@ -573,7 +573,8 @@ class HBSocketChannel(ZmqSocketChannel):
                                 # list, poll is working correctly even if it
                                 # returns quickly. Note: poll timeout is in
                                 # milliseconds.
-                                self.poller.poll(1000*until_dead)
+                                if until_dead > 0.0:
+                                    self.poller.poll(1000 * until_dead)
                             
                                 since_last_heartbeat = time.time()-request_time
                                 if since_last_heartbeat > self.time_to_dead:

--- a/IPython/zmq/pykernel.py
+++ b/IPython/zmq/pykernel.py
@@ -248,6 +248,7 @@ class Kernel(HasTraits):
 #-----------------------------------------------------------------------------
 
 def launch_kernel(ip=None, xrep_port=0, pub_port=0, req_port=0, hb_port=0,
+                  stdin=None, stdout=None, stderr=None,
                   executable=None, independent=False):
     """ Launches a localhost kernel, binding to the specified ports.
 
@@ -267,6 +268,9 @@ def launch_kernel(ip=None, xrep_port=0, pub_port=0, req_port=0, hb_port=0,
 
     hb_port : int, optional
         The port to use for the hearbeat REP channel.
+
+    stdin, stdout, stderr : optional (default None)
+        Standards streams, as defined in subprocess.Popen.
 
     executable : str, optional (default sys.executable)
         The Python executable to use for the kernel process.
@@ -291,8 +295,8 @@ def launch_kernel(ip=None, xrep_port=0, pub_port=0, req_port=0, hb_port=0,
     
     return base_launch_kernel('from IPython.zmq.pykernel import main; main()',
                               xrep_port, pub_port, req_port, hb_port,
-                              executable, independent,
-                              extra_arguments=extra_arguments)
+                              stdin, stdout, stderr,
+                              executable, independent, extra_arguments)
 
 main = make_default_main(Kernel)
 


### PR DESCRIPTION
I have added support for redirecting a launched kernel's stdin/stdout/stderr. As usual, Windows caused me some hassle.

I also fixed a few related bugs, the most significant of which was causing the heartbeat channel to poll indefinitely sometimes!
