### PR TITLE
Make ipython-qtconsole a GUI script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ from setupbase import (
     find_packages, 
     find_package_data, 
     find_scripts,
+    find_gui_scripts,
     find_data_files,
     check_for_dependencies,
     record_commit_info,
@@ -211,7 +212,8 @@ setuptools_extra_args = {}
 if 'setuptools' in sys.modules:
     setuptools_extra_args['zip_safe'] = False
     setuptools_extra_args['entry_points'] = {
-        'console_scripts': find_scripts(True)
+        'console_scripts': find_scripts(True),
+        'gui_scripts': find_gui_scripts(True),
     }
     setup_args['extras_require'] = dict(
         parallel = 'pyzmq>=2.1.4',
@@ -245,7 +247,7 @@ else:
     # check for dependencies an inform the user what is needed.  This is
     # just to make life easy for users.
     check_for_dependencies()
-    setup_args['scripts'] = find_scripts(False)
+    setup_args['scripts'] = find_scripts(False) + find_gui_scripts(False)
 
 #---------------------------------------------------------------------------
 # Do the actual setup now

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ from setupbase import (
     find_packages, 
     find_package_data, 
     find_scripts,
-    find_gui_scripts,
     find_data_files,
     check_for_dependencies,
     record_commit_info,
@@ -211,10 +210,7 @@ setuptools_extra_args = {}
 
 if 'setuptools' in sys.modules:
     setuptools_extra_args['zip_safe'] = False
-    setuptools_extra_args['entry_points'] = {
-        'console_scripts': find_scripts(True),
-        'gui_scripts': find_gui_scripts(True),
-    }
+    setuptools_extra_args['entry_points'] = find_scripts(True)
     setup_args['extras_require'] = dict(
         parallel = 'pyzmq>=2.1.4',
         zmq = 'pyzmq>=2.0.10.1',
@@ -247,7 +243,7 @@ else:
     # check for dependencies an inform the user what is needed.  This is
     # just to make life easy for users.
     check_for_dependencies()
-    setup_args['scripts'] = find_scripts(False) + find_gui_scripts(False)
+    setup_args['scripts'] = find_scripts(False)
 
 #---------------------------------------------------------------------------
 # Do the actual setup now

--- a/setupbase.py
+++ b/setupbase.py
@@ -269,7 +269,7 @@ def find_scripts(entry_points=False):
         return file paths of plain scripts [default]
     """
     if entry_points:
-        scripts = [
+        console_scripts = [
             'ipython = IPython.frontend.terminal.ipapp:launch_new_instance',
             'pycolor = IPython.utils.PyColorize:main',
             'ipcontroller = IPython.parallel.apps.ipcontrollerapp:launch_new_instance',
@@ -279,6 +279,10 @@ def find_scripts(entry_points=False):
             'iptest = IPython.testing.iptest:main',
             'irunner = IPython.lib.irunner:main'
         ]
+        gui_scripts = [
+            'ipython-qtconsole = IPython.frontend.qt.console.ipythonqt:main',
+        ]
+        scripts = dict(console_scripts=console_scripts, gui_scripts=gui_scripts)
     else:
         parallel_scripts = pjoin('IPython','parallel','scripts')
         main_scripts = pjoin('IPython','scripts')
@@ -288,29 +292,10 @@ def find_scripts(entry_points=False):
                    pjoin(parallel_scripts, 'ipcluster'),
                    pjoin(parallel_scripts, 'iplogger'),
                    pjoin(main_scripts, 'ipython'),
+                   pjoin(main_scripts, 'ipython-qtconsole'),
                    pjoin(main_scripts, 'pycolor'),
                    pjoin(main_scripts, 'irunner'),
                    pjoin(main_scripts, 'iptest')
-        ]
-    return scripts
-
-def find_gui_scripts(entry_points=False):
-    """Find IPython's GUI scripts.
-    
-    if entry_points is True:
-        return setuptools entry_point-style definitions
-    else:
-        return file paths of plain scripts [default]
-    """
-    if entry_points:
-        scripts = [
-            'ipython-qtconsole = IPython.frontend.qt.console.ipythonqt:main',
-        ]
-    else:
-        parallel_scripts = pjoin('IPython','parallel','scripts')
-        main_scripts = pjoin('IPython','scripts')
-        scripts = [
-                   pjoin(main_scripts, 'ipython-qtconsole'),
         ]
     return scripts
 

--- a/setupbase.py
+++ b/setupbase.py
@@ -267,12 +267,10 @@ def find_scripts(entry_points=False):
         return setuptools entry_point-style definitions
     else:
         return file paths of plain scripts [default]
-    
     """
     if entry_points:
         scripts = [
             'ipython = IPython.frontend.terminal.ipapp:launch_new_instance',
-            'ipython-qtconsole = IPython.frontend.qt.console.ipythonqt:main',
             'pycolor = IPython.utils.PyColorize:main',
             'ipcontroller = IPython.parallel.apps.ipcontrollerapp:launch_new_instance',
             'ipengine = IPython.parallel.apps.ipengineapp:launch_new_instance',
@@ -290,12 +288,30 @@ def find_scripts(entry_points=False):
                    pjoin(parallel_scripts, 'ipcluster'),
                    pjoin(parallel_scripts, 'iplogger'),
                    pjoin(main_scripts, 'ipython'),
-                   pjoin(main_scripts, 'ipython-qtconsole'),
                    pjoin(main_scripts, 'pycolor'),
                    pjoin(main_scripts, 'irunner'),
                    pjoin(main_scripts, 'iptest')
-                  ]
+        ]
+    return scripts
+
+def find_gui_scripts(entry_points=False):
+    """Find IPython's GUI scripts.
     
+    if entry_points is True:
+        return setuptools entry_point-style definitions
+    else:
+        return file paths of plain scripts [default]
+    """
+    if entry_points:
+        scripts = [
+            'ipython-qtconsole = IPython.frontend.qt.console.ipythonqt:main',
+        ]
+    else:
+        parallel_scripts = pjoin('IPython','parallel','scripts')
+        main_scripts = pjoin('IPython','scripts')
+        scripts = [
+                   pjoin(main_scripts, 'ipython-qtconsole'),
+        ]
     return scripts
 
 #---------------------------------------------------------------------------


### PR DESCRIPTION
The 'ipython-qtconsole' script is now configured as a GUI script in setuptools.

This only really matters on Windows: it ensures that pythonw is used for the script. This is not a big deal for developers but is a good thing to have for the 0.11 release, I think.
