### PR TITLE
Allow type checking on elements of List,Tuple,Set traits

### DIFF
--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -752,6 +752,18 @@ class TestList(TraitTestBase):
     _good_values = [[], [1], range(10)]
     _bad_values = [10, [1,'a'], 'a', (1,2)]
 
+class LenListTrait(HasTraits):
+    
+    value = List(Int, [0], minlen=1, maxlen=2)
+
+class TestLenList(TraitTestBase):
+    
+    obj = LenListTrait()
+    
+    _default_value = [0]
+    _good_values = [[1], range(2)]
+    _bad_values = [10, [1,'a'], 'a', (1,2), [], range(3)]
+
 class TupleTrait(HasTraits):
     
     value = Tuple(Int)

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -27,7 +27,7 @@ from unittest import TestCase
 from IPython.utils.traitlets import (
     HasTraits, MetaHasTraits, TraitType, Any,
     Int, Long, Float, Complex, Str, Unicode, TraitError,
-    Undefined, Type, This, Instance, TCPAddress
+    Undefined, Type, This, Instance, TCPAddress, List
 )
 
 
@@ -739,3 +739,41 @@ class TestTCPAddress(TraitTestBase):
     _default_value = ('127.0.0.1',0)
     _good_values = [('localhost',0),('192.168.0.1',1000),('www.google.com',80)]
     _bad_values = [(0,0),('localhost',10.0),('localhost',-1)]
+
+class TypedListTrait(HasTraits):
+    
+    value = List(Int)
+
+class TestTypedList(TraitTestBase):
+    
+    obj = TypedListTrait()
+    
+    _default_value = []
+    _good_values = [[], [1], range(10)]
+    _bad_values = [10, [1,'a'], 'a', (1,2)]
+
+class LengthTypedListTrait(HasTraits):
+    
+    value = List([Int])
+
+class TestLengthTypedList(TraitTestBase):
+    
+    obj = LengthTypedListTrait()
+    
+    _default_value = None
+    _good_values = [[1], None,[0]]
+    _bad_values = [10, [1,2], (1,),['a'], []]
+
+
+class MultiTypedListTrait(HasTraits):
+    
+    value = List((Int, Str))
+
+class TestMultiTypedList(TraitTestBase):
+    
+    obj = MultiTypedListTrait()
+    
+    _default_value = None
+    _good_values = [[1,'a'], [2,'b']]
+    _bad_values = [[],10, 'a', [1,'a',3], ['a',1]]
+

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -25,9 +25,9 @@ Authors:
 from unittest import TestCase
 
 from IPython.utils.traitlets import (
-    HasTraits, MetaHasTraits, TraitType, Any,
+    HasTraits, MetaHasTraits, TraitType, Any, CStr,
     Int, Long, Float, Complex, Str, Unicode, TraitError,
-    Undefined, Type, This, Instance, TCPAddress, List
+    Undefined, Type, This, Instance, TCPAddress, List, Tuple
 )
 
 
@@ -740,40 +740,62 @@ class TestTCPAddress(TraitTestBase):
     _good_values = [('localhost',0),('192.168.0.1',1000),('www.google.com',80)]
     _bad_values = [(0,0),('localhost',10.0),('localhost',-1)]
 
-class TypedListTrait(HasTraits):
+class ListTrait(HasTraits):
     
     value = List(Int)
 
-class TestTypedList(TraitTestBase):
+class TestList(TraitTestBase):
     
-    obj = TypedListTrait()
+    obj = ListTrait()
     
     _default_value = []
     _good_values = [[], [1], range(10)]
     _bad_values = [10, [1,'a'], 'a', (1,2)]
 
-class LengthTypedListTrait(HasTraits):
+class TupleTrait(HasTraits):
     
-    value = List([Int])
+    value = Tuple(Int)
 
-class TestLengthTypedList(TraitTestBase):
+class TestTupleTrait(TraitTestBase):
     
-    obj = LengthTypedListTrait()
+    obj = TupleTrait()
     
     _default_value = None
-    _good_values = [[1], None,[0]]
-    _bad_values = [10, [1,2], (1,),['a'], []]
+    _good_values = [(1,), None,(0,)]
+    _bad_values = [10, (1,2), [1],('a'), ()]
+    
+    def test_invalid_args(self):
+        self.assertRaises(TypeError, Tuple, 5)
+        self.assertRaises(TypeError, Tuple, default_value='hello')
+        t = Tuple(Int, CStr, default_value=(1,5))
+
+class LooseTupleTrait(HasTraits):
+    
+    value = Tuple((1,2,3))
+
+class TestLooseTupleTrait(TraitTestBase):
+    
+    obj = LooseTupleTrait()
+    
+    _default_value = (1,2,3)
+    _good_values = [(1,), None, (0,), tuple(range(5)), tuple('hello'), ('a',5), ()]
+    _bad_values = [10, 'hello', [1], []]
+    
+    def test_invalid_args(self):
+        self.assertRaises(TypeError, Tuple, 5)
+        self.assertRaises(TypeError, Tuple, default_value='hello')
+        t = Tuple(Int, CStr, default_value=(1,5))
 
 
-class MultiTypedListTrait(HasTraits):
+class MultiTupleTrait(HasTraits):
     
-    value = List((Int, Str))
+    value = Tuple(Int, Str, default_value=[99,'bottles'])
 
-class TestMultiTypedList(TraitTestBase):
+class TestMultiTuple(TraitTestBase):
     
-    obj = MultiTypedListTrait()
+    obj = MultiTupleTrait()
     
-    _default_value = None
-    _good_values = [[1,'a'], [2,'b']]
-    _bad_values = [[],10, 'a', [1,'a',3], ['a',1]]
+    _default_value = (99,'bottles')
+    _good_values = [(1,'a'), (2,'b')]
+    _bad_values = ((),10, 'a', (1,'a',3), ('a',1))
 

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -1117,6 +1117,63 @@ class Container(Instance):
 class List(Container):
     """An instance of a Python list."""
     klass = list
+    
+    def __init__(self, trait=None, default_value=None, minlen=0, maxlen=sys.maxint,
+                allow_none=True, **metadata):
+        """Create a List trait type from a list, set, or tuple.
+
+        The default value is created by doing ``List(default_value)``, 
+        which creates a copy of the ``default_value``.
+        
+        ``trait`` can be specified, which restricts the type of elements
+        in the container to that TraitType.
+        
+        If only one arg is given and it is not a Trait, it is taken as
+        ``default_value``:
+        
+        ``c = List([1,2,3])``
+        
+        Parameters
+        ----------
+        
+        trait : TraitType [ optional ]
+            the type for restricting the contents of the Container.  If unspecified,
+            types are not checked.
+        
+        default_value : SequenceType [ optional ]
+            The default value for the Trait.  Must be list/tuple/set, and
+            will be cast to the container type.
+        
+        minlen : Int [ default 0 ]
+            The minimum length of the input list
+        
+        maxlen : Int [ default sys.maxint ]
+            The maximum length of the input list
+        
+        allow_none : Bool [ default True ]
+            Whether to allow the value to be None
+        
+        **metadata : any
+            further keys for extensions to the Trait (e.g. config)
+        
+        """
+        self._minlen = minlen
+        self._maxlen = maxlen
+        super(List, self).__init__(trait=trait, default_value=default_value, 
+                                allow_none=allow_none, **metadata)
+        
+    def length_error(self, obj, value):
+        e = "The '%s' trait of %s instance must be of length %i <= L <= %i, but a value of %s was specified." \
+            % (self.name, class_of(obj), self._minlen, self._maxlen, value)
+        raise TraitError(e)
+    
+    def validate_elements(self, obj, value):
+        length = len(value)
+        if length < self._minlen or length > self._maxlen:
+            self.length_error(obj, value)
+        
+        return super(List, self).validate_elements(obj, value)
+    
 
 class Set(Container):
     """An instance of a Python set."""


### PR DESCRIPTION
This commit allows checking types of elements in a Container

Ref: https://github.com/ipython/ipython/pull/400#issuecomment-1109601

So you can do:

``` python
class C(HasTraits):
    a = List([Int, Str])
    b = List(Int)
    c = List([0,'a'], types=[Int, Str])
```
- `a` enforces length 2 with Int and Str on elements 0 and 1. Default value is `None`.
- `b` enforces that all elements are Ints, but does not enforce length
- `c` is the same as `a`, but with a default value of `[0,'a']`

The check is only made on assignment, (so index-assignment, or calls to append/extend are not checked), but should cover enough cases to be useful.

Obviously only style `b` makes sense for Sets since they are unordered.

It also fixes an incorrect error message if validation fails in a ClassTypeTrait
