### PR TITLE
Irunner test failure

### DIFF
--- a/IPython/lib/tests/test_irunner.py
+++ b/IPython/lib/tests/test_irunner.py
@@ -108,7 +108,7 @@ In [8]: cos pi
    File "<ipython-input-8-586f1104ea44>", line 1
      cos pi
           ^
-SyntaxError: unexpected EOF while parsing
+SyntaxError: invalid syntax
 
 
 In [9]: cos(pi)


### PR DESCRIPTION
When running the iptest I get a failure in test_irunner because the  execution of "cos pi"
with autocall off now gives a syntax error and not a EOF error. This pull request fixes it. 
However it is unclear why this is changed. For me the change happened when upgrading from
ubuntu10.10 to ubuntu11.04 (python2.6 to python2.). However in plain python shells I 
get a syntax error in both 2.6 and 2.7 so I don't know how to properly fix this. 
