### PR TITLE
handle different SyntaxError messages in test_irunner

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2152,7 +2152,7 @@ class InteractiveShell(Configurable, Magic):
             
                 with self.display_trap:
                     try:
-                        code_ast = ast.parse(cell, filename=cell_name)
+                        code_ast = ast.parse(cell+'\n', filename=cell_name)
                     except (OverflowError, SyntaxError, ValueError, TypeError,
                             MemoryError):
                         self.showsyntaxerror()

--- a/IPython/lib/irunner.py
+++ b/IPython/lib/irunner.py
@@ -263,7 +263,8 @@ class InteractiveRunner(object):
 
         # Leave the child ready for more input later on, otherwise select just
         # hangs on the second invocation.
-        c.send('\n')
+        if c.isalive():
+            c.send('\n')
         
         # Return any requested output
         if get_output:

--- a/IPython/lib/tests/test_irunner.py
+++ b/IPython/lib/tests/test_irunner.py
@@ -108,7 +108,7 @@ In [8]: cos pi
    File "<ipython-input-8-586f1104ea44>", line 1
      cos pi
           ^
-SyntaxError: unexpected EOF while parsing
+SyntaxError: invalid syntax
 
 
 In [9]: cos(pi)


### PR DESCRIPTION
also handle an issue where irunner could send last newline after child exits, raising OSError

This works on Python2.6 and 2.7.

Should fix #409, and supersede #424
