### PR TITLE
Fix error message in test_irunner

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2130,7 +2130,7 @@ class InteractiveShell(Configurable, Magic):
             prefilter_failed = False
             if len(cell.splitlines()) == 1:
                 try:
-                    cell = self.prefilter_manager.prefilter_lines(cell)
+                    cell = self.prefilter_manager.prefilter_line(cell)
                 except AliasError as e:
                     error(e)
                     prefilter_failed=True

--- a/IPython/lib/tests/test_irunner.py
+++ b/IPython/lib/tests/test_irunner.py
@@ -105,10 +105,10 @@ In [7]: autocall 0
 Automatic calling is: OFF
 
 In [8]: cos pi
-   File "<ipython-input-8-586f1104ea44>", line 1
+   File "<ipython-input-8-6bd7313dd9a9>", line 1
      cos pi
           ^
-SyntaxError: unexpected EOF while parsing
+SyntaxError: invalid syntax
 
 
 In [9]: cos(pi)


### PR DESCRIPTION
This is a third pull request aimed at fixing issue #409, and (hopefully) supersedes PRs #427 and #424.

I'd introduced a subtle bug when I refactored the execution logic, that changed the error message showing in certain `SyntaxError`s. Then I'd been a bit over-eager to get the tests passing, because I changed the failing test to match the new error message. That was really stupid, and I apologise.

When some of us started using Python 2.7, a change in that made the code produce the correct error message again. Specifically, code to be compiled in "exec" mode no longer needs to end in a newline. So the test, expecting the incorrect error message, failed.

This fixes the bug, and puts the message in the test back to the original. I've checked that the test suite passes in both Python 2.6 and 2.7.
