### PR TITLE
Separate out skip_doctest decorator

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -23,7 +23,7 @@ import threading
 # Our own packages
 from IPython.config.configurable import Configurable
 
-from IPython.testing import decorators as testdec
+from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils import io
 from IPython.utils.traitlets import Bool, Dict, Instance, Int, List, Unicode
 from IPython.utils.warn import warn
@@ -548,7 +548,7 @@ def _format_lineno(session, line):
         return str(line)
     return "%s#%s" % (session, line)
 
-@testdec.skip_doctest
+@skip_doctest
 def magic_history(self, parameter_s = ''):
     """Print input history (_i<n> variables), with most recent last.
     

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -51,7 +51,7 @@ from IPython.core import page
 from IPython.core.prefilter import ESC_MAGIC
 from IPython.lib.pylabtools import mpl_runner
 from IPython.external.Itpl import itpl, printpl
-from IPython.testing import decorators as testdec
+from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.io import file_read, nlprint
 from IPython.utils.path import get_py_filename
 from IPython.utils.process import arg_split, abbrev_cwd
@@ -435,7 +435,7 @@ Currently the magic system has the following functions:\n"""
             self.shell.automagic = not self.shell.automagic
         print '\n' + Magic.auto_status[self.shell.automagic]
 
-    @testdec.skip_doctest
+    @skip_doctest
     def magic_autocall(self, parameter_s = ''):
         """Make functions callable without having to type parentheses.
 
@@ -564,7 +564,7 @@ Currently the magic system has the following functions:\n"""
         self.shell._inspect('pinfo', parameter_s, detail_level=1,
                             namespaces=namespaces)
 
-    @testdec.skip_doctest
+    @skip_doctest
     def magic_pdef(self, parameter_s='', namespaces=None):
         """Print the definition header for any callable object.
 
@@ -725,7 +725,7 @@ Currently the magic system has the following functions:\n"""
         except:
             shell.showtraceback()
         
-    @testdec.skip_doctest
+    @skip_doctest
     def magic_who_ls(self, parameter_s=''):
         """Return a sorted list of all interactive variables.
 
@@ -766,7 +766,7 @@ Currently the magic system has the following functions:\n"""
         out.sort()
         return out
         
-    @testdec.skip_doctest
+    @skip_doctest
     def magic_who(self, parameter_s=''):
         """Print all interactive variables, with some minimal formatting.
 
@@ -827,7 +827,7 @@ Currently the magic system has the following functions:\n"""
                 print
         print
 
-    @testdec.skip_doctest
+    @skip_doctest
     def magic_whos(self, parameter_s=''):
         """Like %who, but gives some extra information about each variable.
 
@@ -1265,7 +1265,7 @@ Currently the magic system has the following functions:\n"""
         """
         self.shell.debugger(force=True)
 
-    @testdec.skip_doctest
+    @skip_doctest
     def magic_prun(self, parameter_s ='',user_mode=1,
                    opts=None,arg_lst=None,prog_ns=None):
 
@@ -1438,7 +1438,7 @@ Currently the magic system has the following functions:\n"""
         else:
             return None
 
-    @testdec.skip_doctest
+    @skip_doctest
     def magic_run(self, parameter_s ='',runner=None,
                   file_finder=get_py_filename):
         """Run the named file inside IPython as a program.
@@ -1732,7 +1732,7 @@ Currently the magic system has the following functions:\n"""
                 
         return stats
 
-    @testdec.skip_doctest
+    @skip_doctest
     def magic_timeit(self, parameter_s =''):
         """Time execution of a Python statement or expression
 
@@ -1869,7 +1869,7 @@ Currently the magic system has the following functions:\n"""
         if tc > tc_min:
             print "Compiler time: %.2f s" % tc
 
-    @testdec.skip_doctest
+    @skip_doctest
     @needs_local_scope
     def magic_time(self,parameter_s = ''):
         """Time execution of a Python statement or expression.
@@ -1963,7 +1963,7 @@ Currently the magic system has the following functions:\n"""
             print "Compiler : %.2f s" % tc
         return out
 
-    @testdec.skip_doctest
+    @skip_doctest
     def magic_macro(self,parameter_s = ''):
         """Define a macro for future re-execution. It accepts ranges of history,
         filenames or string objects.
@@ -2127,7 +2127,7 @@ Currently the magic system has the following functions:\n"""
         """Alias to %edit."""
         return self.magic_edit(parameter_s)
 
-    @testdec.skip_doctest
+    @skip_doctest
     def magic_edit(self,parameter_s='',last_call=['','']):
         """Bring up an editor and execute the resulting code.
 
@@ -2524,7 +2524,7 @@ Defaulting color scheme to 'NoColor'"""
     #......................................................................
     # Functions to implement unix shell-type things
 
-    @testdec.skip_doctest
+    @skip_doctest
     def magic_alias(self, parameter_s = ''):
         """Define an alias for a system command.
 
@@ -2686,7 +2686,7 @@ Defaulting color scheme to 'NoColor'"""
         finally:
             os.chdir(savedir)
     
-    @testdec.skip_doctest    
+    @skip_doctest    
     def magic_pwd(self, parameter_s = ''):
         """Return the current working directory path.
         
@@ -2699,7 +2699,7 @@ Defaulting color scheme to 'NoColor'"""
         """
         return os.getcwd()
     
-    @testdec.skip_doctest
+    @skip_doctest
     def magic_cd(self, parameter_s=''):
         """Change the current working directory.
 
@@ -2904,7 +2904,7 @@ Defaulting color scheme to 'NoColor'"""
                 header = 'Directory history (kept in _dh)',
                 start=ini,stop=fin)
 
-    @testdec.skip_doctest
+    @skip_doctest
     def magic_sc(self, parameter_s=''):
         """Shell capture - execute a shell command and capture its output.
 
@@ -3328,7 +3328,7 @@ Defaulting color scheme to 'NoColor'"""
         """Reload an IPython extension by its module name."""
         self.extension_manager.reload_extension(module_str)
 
-    @testdec.skip_doctest
+    @skip_doctest
     def magic_install_profiles(self, s):
         """Install the default IPython profiles into the .ipython dir.
 
@@ -3386,14 +3386,14 @@ Defaulting color scheme to 'NoColor'"""
     # Pylab support: simple wrappers that activate pylab, load gui input
     # handling and modify slightly %run
 
-    @testdec.skip_doctest
+    @skip_doctest
     def _pylab_magic_run(self, parameter_s=''):
         Magic.magic_run(self, parameter_s,
                         runner=mpl_runner(self.shell.safe_execfile))
 
     _pylab_magic_run.__doc__ = magic_run.__doc__
 
-    @testdec.skip_doctest
+    @skip_doctest
     def magic_pylab(self, s):
         """Load numpy and matplotlib to work interactively.
 
@@ -3437,7 +3437,7 @@ Defaulting color scheme to 'NoColor'"""
         See %xmode for changing exception reporting modes."""
         self.shell.showtraceback()
     
-    @testdec.skip_doctest
+    @skip_doctest
     def magic_precision(self, s=''):
         """Set floating point precision for pretty printing.
         

--- a/IPython/extensions/parallelmagic.py
+++ b/IPython/extensions/parallelmagic.py
@@ -19,7 +19,7 @@ import re
 
 from IPython.core.plugin import Plugin
 from IPython.utils.traitlets import Bool, Any, Instance
-from IPython.testing import decorators as testdec
+from IPython.testing.skipdoctest import skip_doctest
 
 #-----------------------------------------------------------------------------
 # Definitions of magic functions for use with IPython
@@ -50,7 +50,7 @@ class ParalleMagic(Plugin):
         self.shell.define_magic('px', self.magic_px)
         self.shell.define_magic('autopx', self.magic_autopx)
 
-    @testdec.skip_doctest
+    @skip_doctest
     def magic_result(self, ipself, parameter_s=''):
         """Print the result of command i on all engines..
 
@@ -82,7 +82,7 @@ class ParalleMagic(Plugin):
         result = self.active_view.get_result(index)
         return result
 
-    @testdec.skip_doctest
+    @skip_doctest
     def magic_px(self, ipself, parameter_s=''):
         """Executes the given python command in parallel.
 
@@ -108,7 +108,7 @@ class ParalleMagic(Plugin):
             result.get()
             self._maybe_display_output(result)
 
-    @testdec.skip_doctest
+    @skip_doctest
     def magic_autopx(self, ipself, parameter_s=''):
         """Toggles auto parallel mode.
 

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -26,7 +26,7 @@ from IPython.core.usage import interactive_usage, default_banner
 from IPython.core.interactiveshell import InteractiveShell, InteractiveShellABC
 from IPython.lib.inputhook import enable_gui
 from IPython.lib.pylabtools import pylab_activate
-from IPython.testing import decorators as testdec
+from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.terminal import toggle_set_term_title, set_term_title
 from IPython.utils.process import abbrev_cwd
 from IPython.utils.warn import warn
@@ -448,7 +448,7 @@ class TerminalInteractiveShell(InteractiveShell):
         self.shell.set_autoindent()
         print "Automatic indentation is:",['OFF','ON'][self.shell.autoindent]
 
-    @testdec.skip_doctest
+    @skip_doctest
     def magic_cpaste(self, parameter_s=''):
         """Paste & execute a pre-formatted code block from clipboard.
         

--- a/IPython/parallel/client/remotefunction.py
+++ b/IPython/parallel/client/remotefunction.py
@@ -12,7 +12,7 @@
 
 import warnings
 
-from IPython.testing import decorators as testdec
+from IPython.testing.skipdoctest import skip_doctest
 
 from . import map as Map
 from .asyncresult import AsyncMapResult
@@ -21,7 +21,7 @@ from .asyncresult import AsyncMapResult
 # Decorators
 #-----------------------------------------------------------------------------
 
-@testdec.skip_doctest
+@skip_doctest
 def remote(view, block=None, **flags):
     """Turn a function into a remote function.
     
@@ -36,7 +36,7 @@ def remote(view, block=None, **flags):
         return RemoteFunction(view, f, block=block, **flags)
     return remote_function
 
-@testdec.skip_doctest
+@skip_doctest
 def parallel(view, dist='b', block=None, **flags):
     """Turn a function into a parallel remote function.
     

--- a/IPython/parallel/client/view.py
+++ b/IPython/parallel/client/view.py
@@ -18,9 +18,8 @@ from types import ModuleType
 
 import zmq
 
-from IPython.testing import decorators as testdec
+from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.traitlets import HasTraits, Any, Bool, List, Dict, Set, Int, Instance, CFloat, CInt
-
 from IPython.external.decorator import decorator
 
 from IPython.parallel import util
@@ -69,7 +68,7 @@ def spin_after(f, self, *args, **kwargs):
 # Classes
 #-----------------------------------------------------------------------------
 
-@testdec.skip_doctest
+@skip_doctest
 class View(HasTraits):
     """Base View class for more convenint apply(f,*args,**kwargs) syntax via attributes.
     
@@ -360,7 +359,7 @@ class View(HasTraits):
         block = self.block if block is None else block
         return parallel(self, dist=dist, block=block, **flags)
 
-@testdec.skip_doctest
+@skip_doctest
 class DirectView(View):
     """Direct Multiplexer View of one or more engines.
     
@@ -772,7 +771,7 @@ class DirectView(View):
             pmagic.active_view = self
 
 
-@testdec.skip_doctest
+@skip_doctest
 class LoadBalancedView(View):
     """An load-balancing View that only executes via the Task scheduler.
     

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -292,13 +292,6 @@ def module_not_available(module):
 #-----------------------------------------------------------------------------
 # Decorators for public use
 
-skip_doctest = make_label_dec('skip_doctest',
-    """Decorator - mark a function or method for skipping its doctest.
-
-    This decorator allows you to mark a function whose docstring you wish to
-    omit from testing, while preserving the docstring for introspection, help,
-    etc.""")                              
-
 # Decorators to skip certain tests on specific platforms.
 skip_win32 = skipif(sys.platform == 'win32',
                     "This test does not run under Windows")

--- a/IPython/testing/plugin/test_refs.py
+++ b/IPython/testing/plugin/test_refs.py
@@ -5,7 +5,6 @@
 import inspect
 
 # Our own
-from IPython.testing import decorators as dec
 
 #-----------------------------------------------------------------------------
 # Testing functions
@@ -38,8 +37,7 @@ def doctest_ivars():
     In [6]: zz
     Out[6]: 1
     """
-    
-#@dec.skip_doctest
+
 def doctest_refs():
     """DocTest reference holding issues when running scripts.
 

--- a/IPython/testing/skipdoctest.py
+++ b/IPython/testing/skipdoctest.py
@@ -1,0 +1,15 @@
+"""This decorator marks that a doctest should be skipped.
+
+The IPython.testing.decorators module triggers various extra imports, including
+numpy and sympy if they're present. Since this decorator is used in core parts
+of IPython, it's in a separate module so that running IPython doesn't trigger
+those imports."""
+
+def skip_doctest(f):
+    """Decorator - mark a function or method for skipping its doctest.
+
+    This decorator allows you to mark a function whose docstring you wish to
+    omit from testing, while preserving the docstring for introspection, help,
+    etc."""
+    f.skip_doctest = True
+    return f

--- a/IPython/testing/tests/test_decorators.py
+++ b/IPython/testing/tests/test_decorators.py
@@ -12,6 +12,7 @@ import nose.tools as nt
 
 # Our own
 from IPython.testing import decorators as dec
+from IPython.testing.skipdoctest import skip_doctest
 from IPython.testing.ipunittest import ParametricTestCase
 
 #-----------------------------------------------------------------------------
@@ -79,7 +80,7 @@ def test_deliberately_broken2():
 
 # Verify that we can correctly skip the doctest for a function at will, but
 # that the docstring itself is NOT destroyed by the decorator.
-@dec.skip_doctest
+@skip_doctest
 def doctest_bad(x,y=1,**k):
     """A function whose doctest we need to skip.
 
@@ -127,7 +128,7 @@ class FooClass(object):
     2
     """
 
-    @dec.skip_doctest
+    @skip_doctest
     def __init__(self,x):
         """Make a FooClass.
 
@@ -139,7 +140,7 @@ class FooClass(object):
         print 'Making a FooClass.'
         self.x = x
         
-    @dec.skip_doctest
+    @skip_doctest
     def bar(self,y):
         """Example:
 


### PR DESCRIPTION
Move skip_doctest decorator to separate module, so that it can be used without triggering other imports.

I've checked that the test suite still passes, and that `'numpy' in sys.modules` is now False in both terminal IPython and the Qt console.

Closes #446
