### PR TITLE
Fix issue 447 - inspecting old-style classes.

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -662,10 +662,8 @@ class Inspector:
         # from its __call__ method.
         
         if inspect.isclass(obj):
-            try:
-                callable_obj = obj.__init__
-            except AttributeError:
-                callable_obj = None
+            # Old-style classes need not have an __init__
+            callable_obj = getattr(obj, "__init__", None)
         elif callable(obj):
             callable_obj = obj
         else:

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -662,7 +662,10 @@ class Inspector:
         # from its __call__ method.
         
         if inspect.isclass(obj):
-            callable_obj = obj.__init__
+            try:
+                callable_obj = obj.__init__
+            except AttributeError:
+                callable_obj = None
         elif callable(obj):
             callable_obj = obj
         else:

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -44,6 +44,10 @@ class Call(object):
 
     def method(self, x, z=2):
         """Some method's docstring"""
+        
+class OldStyle:
+    """An old-style class for testing."""
+    pass
 
 def f(x, y=2, *a, **kw):
     """A simple function."""
@@ -117,3 +121,11 @@ def test_info():
     nt.assert_equal(i['class_docstring'], Call.__doc__)
     nt.assert_equal(i['init_docstring'], Call.__init__.__doc__)
     nt.assert_equal(i['call_docstring'], c.__call__.__doc__)
+    
+    # Test old-style classes, which for example may not have an __init__ method.
+    i = inspector.info(OldStyle)
+    nt.assert_equal(i['type_name'], 'classobj')
+    
+    i = inspector.info(OldStyle())
+    nt.assert_equal(i['type_name'], 'instance')
+    nt.assert_equal(i['docstring'], OldStyle.__doc__)


### PR DESCRIPTION
Tweak Inspector.info() so it doesn't fail on old style classes. Added test.

Closes gh-447
