### PR TITLE
Bugfix with logger

### DIFF
--- a/IPython/core/logger.py
+++ b/IPython/core/logger.py
@@ -69,8 +69,6 @@ class Logger(object):
             raise RuntimeError('Log file is already active: %s' %
                                self.logfname)
         
-        self.log_active = True
-
         # The parameters can override constructor defaults
         if logfname is not None: self.logfname = logfname
         if loghead is not None: self.loghead = loghead
@@ -124,6 +122,7 @@ class Logger(object):
             self.logfile.write(self.loghead)
 
         self.logfile.flush()
+        self.log_active = True
 
     def switch_log(self,val):
         """Switch logging on/off. val should be ONLY a boolean."""


### PR DESCRIPTION
Previously, if there was an error opening the file (e.g., permission denied),
then the object would end up in a state where log_active was True, but there
was no logfile. The result was constant errors.

Test case is attempting to use %logstart in a directory where you do not have permission to create a file.
