### PR TITLE
use os.system for shell.system in Terminal frontend

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2172,7 +2172,9 @@ class InteractiveShell(SingletonConfigurable, Magic):
             prefilter_failed = False
             if len(cell.splitlines()) == 1:
                 try:
-                    cell = self.prefilter_manager.prefilter_line(cell)
+                    # use prefilter_lines to handle trailing newlines
+                    # restore trailing newline for ast.parse
+                    cell = self.prefilter_manager.prefilter_lines(cell) + '\n'
                 except AliasError as e:
                     error(e)
                     prefilter_failed=True

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1890,8 +1890,10 @@ class InteractiveShell(SingletonConfigurable, Magic):
             # if they really want a background process.
             raise OSError("Background processes not supported.")
         
-        # don't return the result, always return None
-        system(self.var_expand(cmd, depth=2))
+        # we explicitly do NOT return the subprocess status code, because
+        # a non-None value would trigger :func:`sys.displayhook` calls.
+        # Instead, we store the exit_code in user_ns.
+        self.user_ns['_exit_code'] = system(self.var_expand(cmd, depth=2))
     
     def system_raw(self, cmd):
         """Call the given cmd in a subprocess using os.system
@@ -1901,8 +1903,10 @@ class InteractiveShell(SingletonConfigurable, Magic):
         cmd : str
           Command to execute.
         """
-        # don't return the result, always return None
-        os.system(self.var_expand(cmd, depth=2))
+        # We explicitly do NOT return the subprocess status code, because
+        # a non-None value would trigger :func:`sys.displayhook` calls.
+        # Instead, we store the exit_code in user_ns.
+        self.user_ns['_exit_code'] = os.system(self.var_expand(cmd, depth=2))
     
     # use piped system by default, because it is better behaved
     system = system_piped

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -106,4 +106,11 @@ class InteractiveShellTestCase(unittest.TestCase):
         err = io.stderr.getvalue()
         io.stderr = save_err
         self.assertEquals(err.split(':')[0], 'ERROR')
+    
+    def test_trailing_newline(self):
+        """test that running !(command) does not raise a SyntaxError"""
+        ip = get_ipython()
+        ip.run_cell('!(true)\n', False)
+        ip.run_cell('!(true)\n\n\n', False)
+
 

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -86,6 +86,12 @@ class TerminalInteractiveShell(InteractiveShell):
             config=config, ipython_dir=ipython_dir, user_ns=user_ns,
             user_global_ns=user_global_ns, custom_exceptions=custom_exceptions
         )
+        # use os.system instead of utils.process.system by default, except on Windows
+        if os.name == 'nt':
+            self.system = self.system_piped
+        else:
+            self.system = self.system_raw
+        
         self.init_term_title()
         self.init_usage(usage)
         self.init_banner(banner1, banner2, display_banner)

--- a/IPython/utils/_process_posix.py
+++ b/IPython/utils/_process_posix.py
@@ -130,9 +130,7 @@ class ProcessHandler(object):
 
         Returns
         -------
-        None : we explicitly do NOT return the subprocess status code, as this
-        utility is meant to be used extensively in IPython, where any return
-        value would trigger :func:`sys.displayhook` calls.
+        int : child's exitstatus
         """
         pcmd = self._make_cmd(cmd)
         # Patterns to match on the output, for pexpect.  We read input and
@@ -181,6 +179,7 @@ class ProcessHandler(object):
             finally:
                 # Ensure the subprocess really is terminated
                 child.terminate(force=True)
+        return child.exitstatus
 
     def _make_cmd(self, cmd):
         return '%s -c "%s"' % (self.sh, cmd)

--- a/IPython/utils/_process_win32.py
+++ b/IPython/utils/_process_win32.py
@@ -96,6 +96,9 @@ def _system_body(p):
         line = line.decode(enc, 'replace')
         print(line, file=sys.stderr)
 
+    # Wait to finish for returncode
+    return p.wait()
+
 
 def system(cmd):
     """Win32 version of os.system() that works with network shares.
@@ -116,7 +119,7 @@ def system(cmd):
     with AvoidUNCPath() as path:
         if path is not None:
             cmd = '"pushd %s &&"%s' % (path, cmd)
-        process_handler(cmd, _system_body)
+        return process_handler(cmd, _system_body)
 
 
 def getoutput(cmd):


### PR DESCRIPTION
See #457 and #297 for why using pexpect for shell escape is bad in a terminal.  Those should be closed when this is merged.

This commit:
splits `shell.system` into `shell.raw_system/piped_system`, per @takluyver's recommendation.

`raw_system` calls `os.system`, `piped_system` uses `pexpect/utils.platform` magic

Defaults:
`shell.system=raw_system` in Terminal except on Windows and in tests
`shell.system=piped_system` elsewhere

There was also a small bug I found/fixed along the way involving trailing newlines and `prefilter_line`, where doing `!(true)` would raise a `SyntaxError`, because the transformed line would be:

`get_ipython().system(u"(true)
")`

The bug has been fixed, and a test included.
