### PR TITLE
Str and Bytes traitlets

### DIFF
--- a/IPython/config/tests/test_configurable.py
+++ b/IPython/config/tests/test_configurable.py
@@ -28,7 +28,7 @@ from IPython.config.configurable import (
 )
 
 from IPython.utils.traitlets import (
-    Int, Float, Str
+    Int, Float, Unicode
 )
 
 from IPython.config.loader import Config
@@ -42,7 +42,7 @@ from IPython.config.loader import Config
 class MyConfigurable(Configurable):
     a = Int(1, config=True, help="The integer a.")
     b = Float(1.0, config=True, help="The integer b.")
-    c = Str('no config')
+    c = Unicode('no config')
 
 
 mc_help=u"""MyConfigurable options
@@ -56,11 +56,11 @@ MyConfigurable.b : Float
 
 class Foo(Configurable):
     a = Int(0, config=True, help="The integer a.")
-    b = Str('nope', config=True)
+    b = Unicode('nope', config=True)
 
 
 class Bar(Foo):
-    b = Str('gotit', config=False, help="The string b.")
+    b = Unicode('gotit', config=False, help="The string b.")
     c = Float(config=True, help="The string c.")
 
 

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -28,7 +28,7 @@ from StringIO import StringIO
 # Our own imports
 from IPython.config.configurable import Configurable
 from IPython.lib import pretty
-from IPython.utils.traitlets import Bool, Dict, Int, Str, CStr
+from IPython.utils.traitlets import Bool, Dict, Int, Unicode, CUnicode
 
 
 #-----------------------------------------------------------------------------
@@ -191,11 +191,11 @@ class BaseFormatter(Configurable):
     returned and this format type is not used.
     """
 
-    format_type = Str('text/plain')
+    format_type = Unicode('text/plain')
 
     enabled = Bool(True, config=True)
 
-    print_method = Str('__repr__')
+    print_method = Unicode('__repr__')
 
     # The singleton printers.
     # Maps the IDs of the builtin singleton objects to the format functions.
@@ -337,14 +337,14 @@ class PlainTextFormatter(BaseFormatter):
     """
 
     # The format type of data returned.
-    format_type = Str('text/plain')
+    format_type = Unicode('text/plain')
 
     # This subclass ignores this attribute as it always need to return
     # something.
     enabled = Bool(True, config=False)
 
     # Look for a _repr_pretty_ methods to use for pretty printing.
-    print_method = Str('_repr_pretty_')
+    print_method = Unicode('_repr_pretty_')
 
     # Whether to pretty-print or not.
     pprint = Bool(True, config=True)
@@ -356,12 +356,12 @@ class PlainTextFormatter(BaseFormatter):
     max_width = Int(79, config=True)
 
     # The newline character.
-    newline = Str('\n', config=True)
+    newline = Unicode('\n', config=True)
     
     # format-string for pprinting floats
-    float_format = Str('%r')
+    float_format = Unicode('%r')
     # setter for float precision, either int or direct format-string
-    float_precision = CStr('', config=True)
+    float_precision = CUnicode('', config=True)
     
     def _float_precision_changed(self, name, old, new):
         """float_precision changed, set float_format accordingly.
@@ -454,9 +454,9 @@ class HTMLFormatter(BaseFormatter):
     could be injected into an existing DOM. It should *not* include the 
     ```<html>`` or ```<body>`` tags.
     """
-    format_type = Str('text/html')
+    format_type = Unicode('text/html')
 
-    print_method = Str('_repr_html_')
+    print_method = Unicode('_repr_html_')
 
 
 class SVGFormatter(BaseFormatter):
@@ -471,9 +471,9 @@ class SVGFormatter(BaseFormatter):
     ```<svg>``` tags, that could be injected into an existing DOM. It should
     *not* include the ```<html>`` or ```<body>`` tags.
     """
-    format_type = Str('image/svg+xml')
+    format_type = Unicode('image/svg+xml')
 
-    print_method = Str('_repr_svg_')
+    print_method = Unicode('_repr_svg_')
 
 
 class PNGFormatter(BaseFormatter):
@@ -487,9 +487,9 @@ class PNGFormatter(BaseFormatter):
     The return value of this formatter should be raw PNG data, *not*
     base64 encoded.
     """
-    format_type = Str('image/png')
+    format_type = Unicode('image/png')
 
-    print_method = Str('_repr_png_')
+    print_method = Unicode('_repr_png_')
 
 
 class LatexFormatter(BaseFormatter):
@@ -503,9 +503,9 @@ class LatexFormatter(BaseFormatter):
     The return value of this formatter should be a valid LaTeX equation,
     enclosed in either ```$``` or ```$$```.
     """
-    format_type = Str('text/latex')
+    format_type = Unicode('text/latex')
 
-    print_method = Str('_repr_latex_')
+    print_method = Unicode('_repr_latex_')
 
 
 class JSONFormatter(BaseFormatter):
@@ -518,9 +518,9 @@ class JSONFormatter(BaseFormatter):
 
     The return value of this formatter should be a valid JSON string.
     """
-    format_type = Str('application/json')
+    format_type = Unicode('application/json')
 
-    print_method = Str('_repr_json_')
+    print_method = Unicode('_repr_json_')
 
 
 class JavascriptFormatter(BaseFormatter):
@@ -534,9 +534,9 @@ class JavascriptFormatter(BaseFormatter):
     The return value of this formatter should be valid Javascript code and
     should *not* be enclosed in ```<script>``` tags.
     """
-    format_type = Str('application/javascript')
+    format_type = Unicode('application/javascript')
 
-    print_method = Str('_repr_javascript_')
+    print_method = Unicode('_repr_javascript_')
 
 FormatterABC.register(BaseFormatter)
 FormatterABC.register(PlainTextFormatter)

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -28,7 +28,7 @@ from StringIO import StringIO
 # Our own imports
 from IPython.config.configurable import Configurable
 from IPython.lib import pretty
-from IPython.utils.traitlets import Bool, Dict, Int, Unicode, CUnicode
+from IPython.utils.traitlets import Bool, Dict, Int, Unicode, CUnicode, ObjectName
 
 
 #-----------------------------------------------------------------------------
@@ -195,7 +195,7 @@ class BaseFormatter(Configurable):
 
     enabled = Bool(True, config=True)
 
-    print_method = Unicode('__repr__')
+    print_method = ObjectName('__repr__')
 
     # The singleton printers.
     # Maps the IDs of the builtin singleton objects to the format functions.
@@ -344,7 +344,7 @@ class PlainTextFormatter(BaseFormatter):
     enabled = Bool(True, config=False)
 
     # Look for a _repr_pretty_ methods to use for pretty printing.
-    print_method = Unicode('_repr_pretty_')
+    print_method = ObjectName('_repr_pretty_')
 
     # Whether to pretty-print or not.
     pprint = Bool(True, config=True)
@@ -456,7 +456,7 @@ class HTMLFormatter(BaseFormatter):
     """
     format_type = Unicode('text/html')
 
-    print_method = Unicode('_repr_html_')
+    print_method = ObjectName('_repr_html_')
 
 
 class SVGFormatter(BaseFormatter):
@@ -473,7 +473,7 @@ class SVGFormatter(BaseFormatter):
     """
     format_type = Unicode('image/svg+xml')
 
-    print_method = Unicode('_repr_svg_')
+    print_method = ObjectName('_repr_svg_')
 
 
 class PNGFormatter(BaseFormatter):
@@ -489,7 +489,7 @@ class PNGFormatter(BaseFormatter):
     """
     format_type = Unicode('image/png')
 
-    print_method = Unicode('_repr_png_')
+    print_method = ObjectName('_repr_png_')
 
 
 class LatexFormatter(BaseFormatter):
@@ -505,7 +505,7 @@ class LatexFormatter(BaseFormatter):
     """
     format_type = Unicode('text/latex')
 
-    print_method = Unicode('_repr_latex_')
+    print_method = ObjectName('_repr_latex_')
 
 
 class JSONFormatter(BaseFormatter):
@@ -520,7 +520,7 @@ class JSONFormatter(BaseFormatter):
     """
     format_type = Unicode('application/json')
 
-    print_method = Unicode('_repr_json_')
+    print_method = ObjectName('_repr_json_')
 
 
 class JavascriptFormatter(BaseFormatter):
@@ -536,7 +536,7 @@ class JavascriptFormatter(BaseFormatter):
     """
     format_type = Unicode('application/javascript')
 
-    print_method = Unicode('_repr_javascript_')
+    print_method = ObjectName('_repr_javascript_')
 
 FormatterABC.register(BaseFormatter)
 FormatterABC.register(PlainTextFormatter)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -70,7 +70,7 @@ from IPython.utils.process import system, getoutput
 from IPython.utils.strdispatch import StrDispatch
 from IPython.utils.syspathcontext import prepended_to_syspath
 from IPython.utils.text import num_ini_spaces, format_screen, LSString, SList
-from IPython.utils.traitlets import (Int, Str, CBool, CaselessStrEnum, Enum,
+from IPython.utils.traitlets import (Int, CBool, CaselessStrEnum, Enum,
                                      List, Unicode, Instance, Type)
 from IPython.utils.warn import warn, error, fatal
 import IPython.core.hooks
@@ -122,16 +122,16 @@ def get_default_colors():
         return 'Linux'
 
 
-class SeparateStr(Str):
-    """A Str subclass to validate separate_in, separate_out, etc.
+class SeparateUnicode(Unicode):
+    """A Unicode subclass to validate separate_in, separate_out, etc.
 
-    This is a Str based trait that converts '0'->'' and '\\n'->'\n'.
+    This is a Unicode based trait that converts '0'->'' and '\\n'->'\n'.
     """
 
     def validate(self, obj, value):
         if value == '0': value = ''
         value = value.replace('\\n','\n')
-        return super(SeparateStr, self).validate(obj, value)
+        return super(SeparateUnicode, self).validate(obj, value)
 
 
 class ReadlineNoRecord(object):
@@ -294,9 +294,9 @@ class InteractiveShell(SingletonConfigurable, Magic):
         """
     )
 
-    prompt_in1 = Str('In [\\#]: ', config=True)
-    prompt_in2 = Str('   .\\D.: ', config=True)
-    prompt_out = Str('Out[\\#]: ', config=True)
+    prompt_in1 = Unicode('In [\\#]: ', config=True)
+    prompt_in2 = Unicode('   .\\D.: ', config=True)
+    prompt_out = Unicode('Out[\\#]: ', config=True)
     prompts_pad_left = CBool(True, config=True)
     quiet = CBool(False, config=True)
 
@@ -307,7 +307,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
     readline_use = CBool(True, config=True)
     readline_merge_completions = CBool(True, config=True)
     readline_omit__names = Enum((0,1,2), default_value=2, config=True)
-    readline_remove_delims = Str('-/~', config=True)
+    readline_remove_delims = Unicode('-/~', config=True)
     # don't use \M- bindings by default, because they
     # conflict with 8-bit encodings. See gh-58,gh-88
     readline_parse_and_bind = List([
@@ -327,9 +327,9 @@ class InteractiveShell(SingletonConfigurable, Magic):
 
     # TODO: this part of prompt management should be moved to the frontends.
     # Use custom TraitTypes that convert '0'->'' and '\\n'->'\n'
-    separate_in = SeparateStr('\n', config=True)
-    separate_out = SeparateStr('', config=True)
-    separate_out2 = SeparateStr('', config=True)
+    separate_in = SeparateUnicode('\n', config=True)
+    separate_out = SeparateUnicode('', config=True)
+    separate_out2 = SeparateUnicode('', config=True)
     wildcards_case_sensitive = CBool(True, config=True)
     xmode = CaselessStrEnum(('Context','Plain', 'Verbose'), 
                             default_value='Context', config=True)
@@ -1670,7 +1670,8 @@ class InteractiveShell(SingletonConfigurable, Magic):
             # Remove some chars from the delimiters list.  If we encounter
             # unicode chars, discard them.
             delims = readline.get_completer_delims().encode("ascii", "ignore")
-            delims = delims.translate(None, self.readline_remove_delims)
+            for d in self.readline_remove_delims:
+                delims = delims.replace(d, "")
             delims = delims.replace(ESC_MAGIC, '')
             readline.set_completer_delims(delims)
             # otherwise we end up with a monster history after a while:

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -3472,25 +3472,25 @@ Defaulting color scheme to 'NoColor'"""
             In [1]: from math import pi
         
             In [2]: %precision 3
-            Out[2]: '%.3f'
+            Out[2]: u'%.3f'
         
             In [3]: pi
             Out[3]: 3.142
         
             In [4]: %precision %i
-            Out[4]: '%i'
+            Out[4]: u'%i'
         
             In [5]: pi
             Out[5]: 3
         
             In [6]: %precision %e
-            Out[6]: '%e'
+            Out[6]: u'%e'
         
             In [7]: pi**10
             Out[7]: 9.364805e+04
         
             In [8]: %precision
-            Out[8]: '%r'
+            Out[8]: u'%r'
         
             In [9]: pi**10
             Out[9]: 93648.047476082982

--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -36,7 +36,7 @@ from IPython.core.macro import Macro
 from IPython.core.splitinput import split_user_input
 from IPython.core import page
 
-from IPython.utils.traitlets import List, Int, Any, Str, CBool, Bool, Instance
+from IPython.utils.traitlets import List, Int, Any, Unicode, CBool, Bool, Instance
 from IPython.utils.text import make_quoted_expr
 from IPython.utils.autoattr import auto_attr
 
@@ -756,7 +756,7 @@ class AutocallChecker(PrefilterChecker):
 
 class PrefilterHandler(Configurable):
 
-    handler_name = Str('normal')
+    handler_name = Unicode('normal')
     esc_strings = List([])
     shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
     prefilter_manager = Instance('IPython.core.prefilter.PrefilterManager')
@@ -797,7 +797,7 @@ class PrefilterHandler(Configurable):
 
 class AliasHandler(PrefilterHandler):
 
-    handler_name = Str('alias')
+    handler_name = Unicode('alias')
 
     def handle(self, line_info):
         """Handle alias input lines. """
@@ -812,7 +812,7 @@ class AliasHandler(PrefilterHandler):
 
 class ShellEscapeHandler(PrefilterHandler):
 
-    handler_name = Str('shell')
+    handler_name = Unicode('shell')
     esc_strings = List([ESC_SHELL, ESC_SH_CAP])
 
     def handle(self, line_info):
@@ -839,7 +839,7 @@ class ShellEscapeHandler(PrefilterHandler):
 
 
 class MacroHandler(PrefilterHandler):
-    handler_name = Str("macro")
+    handler_name = Unicode("macro")
     
     def handle(self, line_info):
         obj = self.shell.user_ns.get(line_info.ifun)
@@ -850,7 +850,7 @@ class MacroHandler(PrefilterHandler):
 
 class MagicHandler(PrefilterHandler):
 
-    handler_name = Str('magic')
+    handler_name = Unicode('magic')
     esc_strings = List([ESC_MAGIC])
 
     def handle(self, line_info):
@@ -864,7 +864,7 @@ class MagicHandler(PrefilterHandler):
 
 class AutoHandler(PrefilterHandler):
 
-    handler_name = Str('auto')
+    handler_name = Unicode('auto')
     esc_strings = List([ESC_PAREN, ESC_QUOTE, ESC_QUOTE2])
 
     def handle(self, line_info):
@@ -924,7 +924,7 @@ class AutoHandler(PrefilterHandler):
 
 class HelpHandler(PrefilterHandler):
 
-    handler_name = Str('help')
+    handler_name = Unicode('help')
     esc_strings = List([ESC_HELP])
 
     def handle(self, line_info):
@@ -962,7 +962,7 @@ class HelpHandler(PrefilterHandler):
 
 class EmacsHandler(PrefilterHandler):
 
-    handler_name = Str('emacs')
+    handler_name = Unicode('emacs')
     esc_strings = List([])
 
     def handle(self, line_info):

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -448,15 +448,15 @@ def doctest_precision():
     In [1]: f = get_ipython().shell.display_formatter.formatters['text/plain']
     
     In [2]: %precision 5
-    Out[2]: '%.5f'
+    Out[2]: u'%.5f'
     
     In [3]: f.float_format
-    Out[3]: '%.5f'
+    Out[3]: u'%.5f'
     
     In [4]: %precision %e
-    Out[4]: '%e'
+    Out[4]: u'%e'
     
     In [5]: f(3.1415927)
-    Out[5]: '3.141593e+00'
+    Out[5]: u'3.141593e+00'
     """
 

--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -21,7 +21,7 @@ from IPython.external.qt import QtCore, QtGui
 from IPython.core.inputsplitter import IPythonInputSplitter, \
     transform_ipy_prompt
 from IPython.core.usage import default_gui_banner
-from IPython.utils.traitlets import Bool, Str, Unicode
+from IPython.utils.traitlets import Bool, Unicode
 from frontend_widget import FrontendWidget
 import styles
 
@@ -82,19 +82,18 @@ class IPythonWidget(FrontendWidget):
             3. IPython: .error, .in-prompt, .out-prompt, etc
         """)
     
-
-    syntax_style = Str(config=True,
+    syntax_style = Unicode(config=True,
         help="""
         If not empty, use this Pygments style for syntax highlighting. Otherwise,
         the style sheet is queried for Pygments style information.
         """)
 
     # Prompts.
-    in_prompt = Str(default_in_prompt, config=True)
-    out_prompt = Str(default_out_prompt, config=True)
-    input_sep = Str(default_input_sep, config=True)
-    output_sep = Str(default_output_sep, config=True)
-    output_sep2 = Str(default_output_sep2, config=True)
+    in_prompt = Unicode(default_in_prompt, config=True)
+    out_prompt = Unicode(default_out_prompt, config=True)
+    input_sep = Unicode(default_input_sep, config=True)
+    output_sep = Unicode(default_output_sep, config=True)
+    output_sep2 = Unicode(default_output_sep2, config=True)
 
     # FrontendWidget protected class variables.
     _input_splitter_class = IPythonInputSplitter

--- a/IPython/frontend/terminal/embed.py
+++ b/IPython/frontend/terminal/embed.py
@@ -33,7 +33,7 @@ from IPython.core import ultratb
 from IPython.frontend.terminal.interactiveshell import TerminalInteractiveShell
 from IPython.frontend.terminal.ipapp import load_default_config
 
-from IPython.utils.traitlets import Bool, Str, CBool, Unicode
+from IPython.utils.traitlets import Bool, CBool, Unicode
 from IPython.utils.io import ask_yes_no
 
 

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -31,7 +31,7 @@ from IPython.utils.terminal import toggle_set_term_title, set_term_title
 from IPython.utils.process import abbrev_cwd
 from IPython.utils.warn import warn
 from IPython.utils.text import num_ini_spaces
-from IPython.utils.traitlets import Int, Str, CBool, Unicode
+from IPython.utils.traitlets import Int, CBool, Unicode
 
 #-----------------------------------------------------------------------------
 # Utilities

--- a/IPython/parallel/apps/ipclusterapp.py
+++ b/IPython/parallel/apps/ipclusterapp.py
@@ -37,7 +37,8 @@ from IPython.core.application import BaseIPythonApplication
 from IPython.core.profiledir import ProfileDir
 from IPython.utils.daemonize import daemonize
 from IPython.utils.importstring import import_item
-from IPython.utils.traitlets import Int, Unicode, Bool, CFloat, Dict, List
+from IPython.utils.traitlets import (Int, Unicode, Bool, CFloat, Dict, List, 
+                                        DottedObjectName)
 
 from IPython.parallel.apps.baseapp import (
     BaseParallelApplication,
@@ -198,7 +199,7 @@ class IPClusterEngines(BaseParallelApplication):
     n = Int(2, config=True,
         help="The number of engines to start.")
 
-    engine_launcher_class = Unicode('LocalEngineSetLauncher',
+    engine_launcher_class = DottedObjectName('LocalEngineSetLauncher',
         config=True,
         help="The class for launching a set of Engines."
         )
@@ -330,7 +331,7 @@ class IPClusterStart(IPClusterEngines):
     delay = CFloat(1., config=True,
         help="delay (in s) between starting the controller and the engines")
 
-    controller_launcher_class = Unicode('LocalControllerLauncher',
+    controller_launcher_class = DottedObjectName('LocalControllerLauncher',
         config=True,
         help="The class for launching a Controller."
         )

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -318,6 +318,8 @@ class Client(HasTraits):
             if os.path.isfile(exec_key):
                 extra_args['keyfile'] = exec_key
             else:
+                if isinstance(exec_key, unicode):
+                    exec_key = exec_key.encode('ascii')
                 extra_args['key'] = exec_key
         self.session = Session(**extra_args)
         

--- a/IPython/parallel/controller/hub.py
+++ b/IPython/parallel/controller/hub.py
@@ -30,7 +30,7 @@ from zmq.eventloop.zmqstream import ZMQStream
 # internal:
 from IPython.utils.importstring import import_item
 from IPython.utils.traitlets import (
-        HasTraits, Instance, Int, Unicode, Dict, Set, Tuple, CStr
+        HasTraits, Instance, Int, Unicode, Dict, Set, Tuple, Bytes
         )
 
 from IPython.parallel import error, util
@@ -111,10 +111,10 @@ class EngineConnector(HasTraits):
     heartbeat (str): identity of heartbeat XREQ socket
     """
     id=Int(0)
-    queue=CStr()
-    control=CStr()
-    registration=CStr()
-    heartbeat=CStr()
+    queue=Bytes()
+    control=Bytes()
+    registration=Bytes()
+    heartbeat=Bytes()
     pending=Set()
 
 class HubFactory(RegistrationFactory):

--- a/IPython/parallel/controller/hub.py
+++ b/IPython/parallel/controller/hub.py
@@ -30,7 +30,7 @@ from zmq.eventloop.zmqstream import ZMQStream
 # internal:
 from IPython.utils.importstring import import_item
 from IPython.utils.traitlets import (
-        HasTraits, Instance, Int, Unicode, Dict, Set, Tuple, Bytes
+        HasTraits, Instance, Int, Unicode, Dict, Set, Tuple, Bytes, DottedObjectName
         )
 
 from IPython.parallel import error, util
@@ -179,8 +179,8 @@ class HubFactory(RegistrationFactory):
     
     monitor_url = Unicode('')
     
-    db_class = Unicode('IPython.parallel.controller.dictdb.DictDB', config=True,
-        help="""The class to use for the DB backend""")
+    db_class = DottedObjectName('IPython.parallel.controller.dictdb.DictDB',
+        config=True, help="""The class to use for the DB backend""")
     
     # not configurable
     db = Instance('IPython.parallel.controller.dictdb.BaseDB')

--- a/IPython/parallel/controller/scheduler.py
+++ b/IPython/parallel/controller/scheduler.py
@@ -39,7 +39,7 @@ from zmq.eventloop import ioloop, zmqstream
 # local imports
 from IPython.external.decorator import decorator
 from IPython.config.loader import Config
-from IPython.utils.traitlets import Instance, Dict, List, Set, Int, Str, Enum
+from IPython.utils.traitlets import Instance, Dict, List, Set, Int, Enum
 
 from IPython.parallel import error
 from IPython.parallel.factory import SessionFactory

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -25,8 +25,8 @@ Authors:
 from unittest import TestCase
 
 from IPython.utils.traitlets import (
-    HasTraits, MetaHasTraits, TraitType, Any, CStr,
-    Int, Long, Float, Complex, Str, Unicode, TraitError,
+    HasTraits, MetaHasTraits, TraitType, Any, CBytes,
+    Int, Long, Float, Complex, Bytes, Unicode, TraitError,
     Undefined, Type, This, Instance, TCPAddress, List, Tuple
 )
 
@@ -700,13 +700,13 @@ class TestComplex(TraitTestBase):
     _bad_values    = [10L, -10L, u'10L', u'-10L', 'ten', [10], {'ten': 10},(10,), None]
 
 
-class StringTrait(HasTraits):
+class BytesTrait(HasTraits):
 
-    value = Str('string')
+    value = Bytes('string')
 
-class TestString(TraitTestBase):
+class TestBytes(TraitTestBase):
 
-    obj = StringTrait()
+    obj = BytesTrait()
 
     _default_value = 'string'
     _good_values   = ['10', '-10', '10L',
@@ -781,7 +781,7 @@ class TestTupleTrait(TraitTestBase):
     def test_invalid_args(self):
         self.assertRaises(TypeError, Tuple, 5)
         self.assertRaises(TypeError, Tuple, default_value='hello')
-        t = Tuple(Int, CStr, default_value=(1,5))
+        t = Tuple(Int, CBytes, default_value=(1,5))
 
 class LooseTupleTrait(HasTraits):
 
@@ -798,12 +798,12 @@ class TestLooseTupleTrait(TraitTestBase):
     def test_invalid_args(self):
         self.assertRaises(TypeError, Tuple, 5)
         self.assertRaises(TypeError, Tuple, default_value='hello')
-        t = Tuple(Int, CStr, default_value=(1,5))
+        t = Tuple(Int, CBytes, default_value=(1,5))
 
 
 class MultiTupleTrait(HasTraits):
 
-    value = Tuple(Int, Str, default_value=[99,'bottles'])
+    value = Tuple(Int, Bytes, default_value=[99,'bottles'])
 
 class TestMultiTuple(TraitTestBase):
 

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -22,12 +22,14 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
+import sys
 from unittest import TestCase
 
 from IPython.utils.traitlets import (
     HasTraits, MetaHasTraits, TraitType, Any, CBytes,
     Int, Long, Float, Complex, Bytes, Unicode, TraitError,
-    Undefined, Type, This, Instance, TCPAddress, List, Tuple
+    Undefined, Type, This, Instance, TCPAddress, List, Tuple,
+    ObjectName, DottedObjectName
 )
 
 
@@ -725,9 +727,40 @@ class TestUnicode(TraitTestBase):
 
     _default_value = u'unicode'
     _good_values   = ['10', '-10', '10L', '-10L', '10.1', 
-                      '-10.1', '', u'', 'string', u'string', ]
+                      '-10.1', '', u'', 'string', u'string', u"€"]
     _bad_values    = [10, -10, 10L, -10L, 10.1, -10.1, 1j,
                       [10], ['ten'], [u'ten'], {'ten': 10},(10,), None]
+
+
+class ObjectNameTrait(HasTraits):
+    value = ObjectName("abc")
+    
+class TestObjectName(TraitTestBase):
+    obj = ObjectNameTrait()
+    
+    _default_value = "abc"
+    _good_values = ["a", "gh", "g9", "g_", "_G", u"a345_"]
+    _bad_values = [1, "", u"€", "9g", "!", "#abc", "aj@", "a.b", "a()", "a[0]",
+                                                            object(), object]
+    if sys.version_info[0] < 3:
+        _bad_values.append(u"þ")
+    else:
+        _good_values.append(u"þ")  # þ=1 is valid in Python 3 (PEP 3131).
+
+
+class DottedObjectNameTrait(HasTraits):
+    value = DottedObjectName("a.b")
+
+class TestDottedObjectName(TraitTestBase):
+    obj = DottedObjectNameTrait()
+    
+    _default_value = "a.b"
+    _good_values = ["A", "y.t", "y765.__repr__", "os.path.join", u"os.path.join"]
+    _bad_values = [1, u"abc.€", "_.@", ".", ".abc", "abc.", ".abc."]
+    if sys.version_info[0] < 3:
+        _bad_values.append(u"t.þ")
+    else:
+        _good_values.append(u"t.þ")
 
 
 class TCPAddressTrait(HasTraits):

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -951,7 +951,9 @@ class CComplex(Complex):
         except:
             self.error(obj, value)
 
-
+# We should always be explicit about whether we're using bytes or unicode, both
+# for Python 3 conversion and for reliable unicode behaviour on Python 2. So
+# we don't have a Str type.
 class Bytes(TraitType):
     """A trait for strings."""
 
@@ -996,11 +998,6 @@ class CUnicode(Unicode):
             return unicode(value)
         except:
             self.error(obj, value)
-            
-if sys.version_info[0] < 3:
-    Str, CStr = Bytes, CBytes
-else:
-    Str, CStr = Unicode, CUnicode
 
 
 class Bool(TraitType):

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -952,24 +952,24 @@ class CComplex(Complex):
             self.error(obj, value)
 
 
-class Str(TraitType):
+class Bytes(TraitType):
     """A trait for strings."""
 
     default_value = ''
     info_text = 'a string'
 
     def validate(self, obj, value):
-        if isinstance(value, str):
+        if isinstance(value, bytes):
             return value
         self.error(obj, value)
 
 
-class CStr(Str):
+class CBytes(Bytes):
     """A casting version of the string trait."""
 
     def validate(self, obj, value):
         try:
-            return str(value)
+            return bytes(value)
         except:
             try:
                 return unicode(value)
@@ -986,7 +986,7 @@ class Unicode(TraitType):
     def validate(self, obj, value):
         if isinstance(value, unicode):
             return value
-        if isinstance(value, str):
+        if isinstance(value, bytes):
             return unicode(value)
         self.error(obj, value)
 
@@ -999,6 +999,11 @@ class CUnicode(Unicode):
             return unicode(value)
         except:
             self.error(obj, value)
+            
+if sys.version_info[0] < 3:
+    Str, CStr = Bytes, CBytes
+else:
+    Str, CStr = Unicode, CUnicode
 
 
 class Bool(TraitType):

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -971,10 +971,7 @@ class CBytes(Bytes):
         try:
             return bytes(value)
         except:
-            try:
-                return unicode(value)
-            except:
-                self.error(obj, value)
+            self.error(obj, value)
 
 
 class Unicode(TraitType):

--- a/IPython/zmq/kernelapp.py
+++ b/IPython/zmq/kernelapp.py
@@ -30,7 +30,8 @@ from IPython.core.application import (
 )
 from IPython.utils import io
 from IPython.utils.localinterfaces import LOCALHOST
-from IPython.utils.traitlets import Any, Instance, Dict, Unicode, Int, Bool
+from IPython.utils.traitlets import (Any, Instance, Dict, Unicode, Int, Bool,
+                                        DottedObjectName)
 from IPython.utils.importstring import import_item
 # local imports
 from IPython.zmq.heartbeat import Heartbeat
@@ -75,7 +76,7 @@ class KernelApp(BaseIPythonApplication):
     flags = Dict(kernel_flags)
     classes = [Session]
     # the kernel class, as an importstring
-    kernel_class = Unicode('IPython.zmq.pykernel.Kernel')
+    kernel_class = DottedObjectName('IPython.zmq.pykernel.Kernel')
     kernel = Any()
     poller = Any() # don't restrict this even though current pollers are all Threads
     heartbeat = Instance(Heartbeat)
@@ -93,10 +94,10 @@ class KernelApp(BaseIPythonApplication):
     # streams, etc.
     no_stdout = Bool(False, config=True, help="redirect stdout to the null device")
     no_stderr = Bool(False, config=True, help="redirect stderr to the null device")
-    outstream_class = Unicode('IPython.zmq.iostream.OutStream', config=True,
-        help="The importstring for the OutStream factory")
-    displayhook_class = Unicode('IPython.zmq.displayhook.DisplayHook', config=True,
-        help="The importstring for the DisplayHook factory")
+    outstream_class = DottedObjectName('IPython.zmq.iostream.OutStream',
+        config=True, help="The importstring for the OutStream factory")
+    displayhook_class = DottedObjectName('IPython.zmq.displayhook.DisplayHook',
+        config=True, help="The importstring for the DisplayHook factory")
 
     # polling
     parent = Int(0, config=True,

--- a/IPython/zmq/session.py
+++ b/IPython/zmq/session.py
@@ -47,7 +47,8 @@ from zmq.eventloop.zmqstream import ZMQStream
 from IPython.config.configurable import Configurable, LoggingConfigurable
 from IPython.utils.importstring import import_item
 from IPython.utils.jsonutil import extract_dates, squash_dates, date_default
-from IPython.utils.traitlets import Bytes, Unicode, Bool, Any, Instance, Set
+from IPython.utils.traitlets import (Bytes, Unicode, Bool, Any, Instance, Set,
+                                        DottedObjectName)
 
 #-----------------------------------------------------------------------------
 # utility functions
@@ -211,7 +212,7 @@ class Session(Configurable):
     
     debug=Bool(False, config=True, help="""Debug output in the Session""")
     
-    packer = Unicode('json',config=True,
+    packer = DottedObjectName('json',config=True,
             help="""The name of the packer for serializing messages.
             Should be one of 'json', 'pickle', or an import name
             for a custom callable serializer.""")
@@ -225,7 +226,7 @@ class Session(Configurable):
         else:
             self.pack = import_item(str(new))
 
-    unpacker = Unicode('json', config=True,
+    unpacker = DottedObjectName('json', config=True,
         help="""The name of the unpacker for unserializing messages.
         Only used with custom functions for `packer`.""")
     def _unpacker_changed(self, name, old, new):

--- a/IPython/zmq/session.py
+++ b/IPython/zmq/session.py
@@ -47,7 +47,7 @@ from zmq.eventloop.zmqstream import ZMQStream
 from IPython.config.configurable import Configurable, LoggingConfigurable
 from IPython.utils.importstring import import_item
 from IPython.utils.jsonutil import extract_dates, squash_dates, date_default
-from IPython.utils.traitlets import CStr, Unicode, Bool, Any, Instance, Set
+from IPython.utils.traitlets import Bytes, Unicode, Bool, Any, Instance, Set
 
 #-----------------------------------------------------------------------------
 # utility functions
@@ -238,7 +238,7 @@ class Session(Configurable):
         else:
             self.unpack = import_item(str(new))
         
-    session = CStr('', config=True,
+    session = Bytes(b'', config=True,
         help="""The UUID identifying this session.""")
     def _session_default(self):
         return bytes(uuid.uuid4())
@@ -247,7 +247,7 @@ class Session(Configurable):
         help="""Username for the Session. Default is your system username.""")
     
     # message signature related traits:
-    key = CStr('', config=True,
+    key = Bytes(b'', config=True,
         help="""execution key, for extra authentication.""")
     def _key_changed(self, name, old, new):
         if new:

--- a/docs/source/config/overview.txt
+++ b/docs/source/config/overview.txt
@@ -126,7 +126,7 @@ subclass::
 
     # Sample component that can be configured.
     from IPython.config.configurable import Configurable
-    from IPython.utils.traitlets import Int, Float, Str, Bool
+    from IPython.utils.traitlets import Int, Float, Unicode, Bool
     
     class MyClass(Configurable):
         name = Unicode(u'defaultname', config=True)
@@ -150,8 +150,8 @@ After this configuration file is loaded, the values set in it will override
 the class defaults anytime a :class:`MyClass` is created.  Furthermore,
 these attributes will be type checked and validated anytime they are set.
 This type checking is handled by the :mod:`IPython.utils.traitlets` module,
-which provides the :class:`Str`, :class:`Int` and :class:`Float` types.  In 
-addition to these traitlets, the :mod:`IPython.utils.traitlets` provides
+which provides the :class:`Unicode`, :class:`Int` and :class:`Float` types.
+In addition to these traitlets, the :mod:`IPython.utils.traitlets` provides
 traitlets for a number of other types.
 
 .. note::
@@ -237,14 +237,14 @@ Sometimes, your classes will have an inheritance hierarchy that you want
 to be reflected in the configuration system.  Here is a simple example::
 
     from IPython.config.configurable import Configurable
-    from IPython.utils.traitlets import Int, Float, Str, Bool
+    from IPython.utils.traitlets import Int, Float, Unicode, Bool
     
     class Foo(Configurable):
-        name = Str('fooname', config=True)
+        name = Unicode(u'fooname', config=True)
         value = Float(100.0, config=True)
     
     class Bar(Foo):
-        name = Str('barname', config=True)
+        name = Unicode(u'barname', config=True)
         othervalue = Int(0, config=True)
 
 Now, we can create a configuration file to configure instances of :class:`Foo`
@@ -253,7 +253,7 @@ and :class:`Bar`::
     # config file
     c = get_config()
     
-    c.Foo.name = 'bestname'
+    c.Foo.name = u'bestname'
     c.Bar.othervalue = 10
 
 This class hierarchy and configuration file accomplishes the following:
@@ -460,7 +460,7 @@ Here are the main requirements we wanted our configuration system to have:
   hierarchical data structures, namely regular attribute access
   (``Foo.Bar.Bam.name``). Third, using Python makes it easy for users to
   import configuration attributes from one configuration file to another.
-  Forth, even though Python is dynamically typed, it does have types that can
+  Fourth, even though Python is dynamically typed, it does have types that can
   be checked at runtime. Thus, a ``1`` in a config file is the integer '1',
   while a ``'1'`` is a string.
 


### PR DESCRIPTION
Arranges Str and Bytes traitlets to simplify automatic conversion to Python 3. As with the equivalent builtin names, on Python 2, Str is a synonym for Bytes. In Python 3, Str will be synonymous with Unicode.

So, like with the built in functions, we can now use:
- `Bytes` for traits that should stay as a bytestring in Python 3
- `Unicode` for anything that should already be unicode (like filenames)
- `Str` for things that should be bytestrings in Python 2 and unicode in Python 3

Casting versions of each follow the same pattern. A quick look at the codebase suggests that we're already using things as we should - I'll need to do some cleaning up on the Python 3 side, because I got it working without much thought for sorting it out like this.
