### PR TITLE
Add home directory expansion to IPYTHON_DIR environment variables.

### DIFF
--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -317,8 +317,8 @@ def get_ipython_dir():
         if ipdir is None:
             # not using XDG
             ipdir = home_ipdir
-    elif ipdir.startswith('~'):
-        ipdir = os.path.expanduser(ipdir).rstrip('/')
+
+    ipdir = os.path.expanduser(ipdir).rstrip('/')
 
     return _cast_unicode(ipdir, fs_encoding)
 

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -28,7 +28,6 @@ from IPython.utils.importstring import import_item
 
 fs_encoding = sys.getfilesystemencoding()
 
-
 def _cast_unicode(s, enc=None):
     """Turn 8-bit strings into unicode."""
     if isinstance(s, bytes):
@@ -55,11 +54,10 @@ if sys.platform == 'win32':
         try:
             import ctypes
         except ImportError:
-            raise ImportError('you need to have ctypes installed '
-                              'for this to work')
+            raise ImportError('you need to have ctypes installed for this to work')
         _GetLongPathName = ctypes.windll.kernel32.GetLongPathNameW
         _GetLongPathName.argtypes = [ctypes.c_wchar_p, ctypes.c_wchar_p,
-            ctypes.c_uint]
+            ctypes.c_uint ]
 
         buf = ctypes.create_unicode_buffer(260)
         rv = _GetLongPathName(path, buf, 260)
@@ -90,7 +88,7 @@ def get_py_filename(name):
     if os.path.isfile(name):
         return name
     else:
-        raise IOError('File `%s` not found.' % name)
+        raise IOError,'File `%s` not found.' % name
 
 
 def filefind(filename, path_dirs=None):
@@ -109,7 +107,7 @@ def filefind(filename, path_dirs=None):
 
     Will find the file in the users home directory.  This function does not
     automatically try any paths, such as the cwd or the user's home directory.
-
+    
     Parameters
     ----------
     filename : str
@@ -120,32 +118,31 @@ def filefind(filename, path_dirs=None):
         put into a sequence and the searched.  If a sequence, walk through
         each element and join with ``filename``, calling :func:`expandvars`
         and :func:`expanduser` before testing for existence.
-
+        
     Returns
     -------
     Raises :exc:`IOError` or returns absolute path to file.
     """
-
+    
     # If paths are quoted, abspath gets confused, strip them...
     filename = filename.strip('"').strip("'")
     # If the input is an absolute path, just check it exists
     if os.path.isabs(filename) and os.path.isfile(filename):
         return filename
-
+        
     if path_dirs is None:
         path_dirs = ("",)
     elif isinstance(path_dirs, basestring):
         path_dirs = (path_dirs,)
-
+        
     for path in path_dirs:
-        if path == '.':
-            path = os.getcwd()
+        if path == '.': path = os.getcwd()
         testname = expand_path(os.path.join(path, filename))
         if os.path.isfile(testname):
             return os.path.abspath(testname)
-
-    raise IOError("File %r does not exist in any of the search paths: %r" %
-                  (filename, path_dirs))
+        
+    raise IOError("File %r does not exist in any of the search paths: %r" % 
+                  (filename, path_dirs) )
 
 
 class HomeDirError(Exception):
@@ -163,7 +160,7 @@ def get_home_dir():
       - Registry hack for My Documents
       - %HOME%: rare, but some people with unix-like setups may have defined it
     * On Dos C:\
-
+ 
     Currently only Posix and NT are implemented, a HomeDirError exception is
     raised for all other OSes.
     """
@@ -174,13 +171,12 @@ def get_home_dir():
     # first, check py2exe distribution root directory for _ipython.
     # This overrides all. Normally does not exist.
 
-    if hasattr(sys, "frozen"):  # Is frozen by py2exe
-        # libraries compressed to zip-file
-        if '\\library.zip\\' in IPython.__file__.lower():
+    if hasattr(sys, "frozen"): #Is frozen by py2exe
+        if '\\library.zip\\' in IPython.__file__.lower():#libraries compressed to zip-file
             root, rest = IPython.__file__.lower().split('library.zip')
-        else:
-            root = os.path.join(os.path.split(IPython.__file__)[0], "../../")
-        root = os.path.abspath(root).rstrip('\\')
+        else: 
+            root=os.path.join(os.path.split(IPython.__file__)[0],"../../")
+        root=os.path.abspath(root).rstrip('\\')
         if isdir(os.path.join(root, '_ipython')):
             os.environ["IPYKITROOT"] = root
         return _cast_unicode(root, fs_encoding)
@@ -195,7 +191,7 @@ def get_home_dir():
             # still knows it - reported once as:
             # https://github.com/ipython/ipython/issues/154
             from subprocess import Popen, PIPE
-            homedir = Popen('echo $HOME', shell=True,
+            homedir = Popen('echo $HOME', shell=True, 
                             stdout=PIPE).communicate()[0].strip()
             if homedir:
                 return _cast_unicode(homedir, fs_encoding)
@@ -208,7 +204,7 @@ def get_home_dir():
         # For some strange reason all of these return 'nt' for os.name.
         # First look for a network home directory. This will return the UNC
         # path (\\server\\Users\%username%) not the mapped path (Z:\). This
-        # is needed when running IPython on cluster where all paths have to
+        # is needed when running IPython on cluster where all paths have to 
         # be UNC.
         try:
             homedir = env['HOMESHARE']
@@ -220,7 +216,7 @@ def get_home_dir():
 
         # Now look for a local home directory
         try:
-            homedir = os.path.join(env['HOMEDRIVE'], env['HOMEPATH'])
+            homedir = os.path.join(env['HOMEDRIVE'],env['HOMEPATH'])
         except KeyError:
             pass
         else:
@@ -243,7 +239,7 @@ def get_home_dir():
                 wreg.HKEY_CURRENT_USER,
                 "Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders"
             )
-            homedir = wreg.QueryValueEx(key, 'Personal')[0]
+            homedir = wreg.QueryValueEx(key,'Personal')[0]
             key.Close()
         except:
             pass
@@ -267,44 +263,41 @@ def get_home_dir():
         # Desperate, may do absurd things in classic MacOS. May work under DOS.
         return u'C:\\'
     else:
-        raise HomeDirError('No valid home directory could be found '
-                           'for your OS')
-
+        raise HomeDirError('No valid home directory could be found for your OS')
 
 def get_xdg_dir():
     """Return the XDG_CONFIG_HOME, if it is defined and exists, else None.
-
+    
     This is only for posix (Linux,Unix,OS X, etc) systems.
     """
 
     isdir = os.path.isdir
     env = os.environ
-
+    
     if os.name == 'posix':
         # Linux, Unix, AIX, OS X
         # use ~/.config if not set OR empty
-        xdg = env.get("XDG_CONFIG_HOME", None) or \
-              os.path.join(get_home_dir(), '.config')
+        xdg = env.get("XDG_CONFIG_HOME", None) or os.path.join(get_home_dir(), '.config')
         if xdg and isdir(xdg):
             return _cast_unicode(xdg, fs_encoding)
-
+    
     return None
-
+    
 
 def get_ipython_dir():
     """Get the IPython directory for this platform and user.
-
+    
     This uses the logic in `get_home_dir` to find the home directory
     and the adds .ipython to the end of the path.
     """
-
+    
     env = os.environ
     pjoin = os.path.join
     exists = os.path.exists
-
+    
     ipdir_def = '.ipython'
     xdg_def = 'ipython'
-
+    
     home_dir = get_home_dir()
     xdg_dir = get_xdg_dir()
     # import pdb; pdb.set_trace()  # dbg
@@ -315,12 +308,12 @@ def get_ipython_dir():
         if xdg_dir:
             # use XDG, as long as the user isn't already
             # using $HOME/.ipython and *not* XDG/ipython
-
+            
             xdg_ipdir = pjoin(xdg_dir, xdg_def)
-
+        
             if exists(xdg_ipdir) or not exists(home_ipdir):
                 ipdir = xdg_ipdir
-
+        
         if ipdir is None:
             # not using XDG
             ipdir = home_ipdir
@@ -355,7 +348,7 @@ def expand_path(s):
     """Expand $VARS and ~names in a string, like a shell
 
     :Examples:
-
+    
        In [2]: os.environ['FOO']='test'
 
        In [3]: expand_path('variable FOO is $FOO')
@@ -366,18 +359,18 @@ def expand_path(s):
     # the $ to get (\\server\share\%username%). I think it considered $
     # alone an empty var. But, we need the $ to remains there (it indicates
     # a hidden share).
-    if os.name == 'nt':
+    if os.name=='nt':
         s = s.replace('$\\', 'IPYTHON_TEMP')
     s = os.path.expandvars(os.path.expanduser(s))
-    if os.name == 'nt':
+    if os.name=='nt':
         s = s.replace('IPYTHON_TEMP', '$\\')
     return s
 
 
-def target_outdated(target, deps):
+def target_outdated(target,deps):
     """Determine whether a target is out of date.
 
-    target_outdated(target, deps) -> 1/0
+    target_outdated(target,deps) -> 1/0
 
     deps: list of filenames which MUST exist.
     target: single filename which may or may not exist.
@@ -398,17 +391,16 @@ def target_outdated(target, deps):
     return 0
 
 
-def target_update(target, deps, cmd):
+def target_update(target,deps,cmd):
     """Update a target with a given command given a list of dependencies.
 
-    target_update(target, deps, cmd) -> runs cmd if target is outdated.
+    target_update(target,deps,cmd) -> runs cmd if target is outdated.
 
     This is just a wrapper around target_outdated() which calls the given
     command if target is outdated."""
 
-    if target_outdated(target, deps):
+    if target_outdated(target,deps):
         system(cmd)
-
 
 def check_for_old_config(ipython_dir=None):
     """Check for old config files, and present a warning if they exist.
@@ -429,4 +421,5 @@ def check_for_old_config(ipython_dir=None):
     The IPython configuration system has changed as of 0.11, and this file will be ignored.
     See http://ipython.github.com/ipython-doc/dev/config for details on the new config system.
     The current default config file is 'ipython_config.py', where you can suppress these
-    warnings with `Global.ignore_old_config = True`.""" % f)
+    warnings with `Global.ignore_old_config = True`."""%f)
+

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -28,6 +28,7 @@ from IPython.utils.importstring import import_item
 
 fs_encoding = sys.getfilesystemencoding()
 
+
 def _cast_unicode(s, enc=None):
     """Turn 8-bit strings into unicode."""
     if isinstance(s, bytes):
@@ -54,10 +55,11 @@ if sys.platform == 'win32':
         try:
             import ctypes
         except ImportError:
-            raise ImportError('you need to have ctypes installed for this to work')
+            raise ImportError('you need to have ctypes installed '
+                              'for this to work')
         _GetLongPathName = ctypes.windll.kernel32.GetLongPathNameW
         _GetLongPathName.argtypes = [ctypes.c_wchar_p, ctypes.c_wchar_p,
-            ctypes.c_uint ]
+            ctypes.c_uint]
 
         buf = ctypes.create_unicode_buffer(260)
         rv = _GetLongPathName(path, buf, 260)
@@ -88,7 +90,7 @@ def get_py_filename(name):
     if os.path.isfile(name):
         return name
     else:
-        raise IOError,'File `%s` not found.' % name
+        raise IOError('File `%s` not found.' % name)
 
 
 def filefind(filename, path_dirs=None):
@@ -107,7 +109,7 @@ def filefind(filename, path_dirs=None):
 
     Will find the file in the users home directory.  This function does not
     automatically try any paths, such as the cwd or the user's home directory.
-    
+
     Parameters
     ----------
     filename : str
@@ -118,31 +120,32 @@ def filefind(filename, path_dirs=None):
         put into a sequence and the searched.  If a sequence, walk through
         each element and join with ``filename``, calling :func:`expandvars`
         and :func:`expanduser` before testing for existence.
-        
+
     Returns
     -------
     Raises :exc:`IOError` or returns absolute path to file.
     """
-    
+
     # If paths are quoted, abspath gets confused, strip them...
     filename = filename.strip('"').strip("'")
     # If the input is an absolute path, just check it exists
     if os.path.isabs(filename) and os.path.isfile(filename):
         return filename
-        
+
     if path_dirs is None:
         path_dirs = ("",)
     elif isinstance(path_dirs, basestring):
         path_dirs = (path_dirs,)
-        
+
     for path in path_dirs:
-        if path == '.': path = os.getcwd()
+        if path == '.':
+            path = os.getcwd()
         testname = expand_path(os.path.join(path, filename))
         if os.path.isfile(testname):
             return os.path.abspath(testname)
-        
-    raise IOError("File %r does not exist in any of the search paths: %r" % 
-                  (filename, path_dirs) )
+
+    raise IOError("File %r does not exist in any of the search paths: %r" %
+                  (filename, path_dirs))
 
 
 class HomeDirError(Exception):
@@ -160,7 +163,7 @@ def get_home_dir():
       - Registry hack for My Documents
       - %HOME%: rare, but some people with unix-like setups may have defined it
     * On Dos C:\
- 
+
     Currently only Posix and NT are implemented, a HomeDirError exception is
     raised for all other OSes.
     """
@@ -171,12 +174,13 @@ def get_home_dir():
     # first, check py2exe distribution root directory for _ipython.
     # This overrides all. Normally does not exist.
 
-    if hasattr(sys, "frozen"): #Is frozen by py2exe
-        if '\\library.zip\\' in IPython.__file__.lower():#libraries compressed to zip-file
+    if hasattr(sys, "frozen"):  # Is frozen by py2exe
+        # libraries compressed to zip-file
+        if '\\library.zip\\' in IPython.__file__.lower():
             root, rest = IPython.__file__.lower().split('library.zip')
-        else: 
-            root=os.path.join(os.path.split(IPython.__file__)[0],"../../")
-        root=os.path.abspath(root).rstrip('\\')
+        else:
+            root = os.path.join(os.path.split(IPython.__file__)[0], "../../")
+        root = os.path.abspath(root).rstrip('\\')
         if isdir(os.path.join(root, '_ipython')):
             os.environ["IPYKITROOT"] = root
         return _cast_unicode(root, fs_encoding)
@@ -191,7 +195,7 @@ def get_home_dir():
             # still knows it - reported once as:
             # https://github.com/ipython/ipython/issues/154
             from subprocess import Popen, PIPE
-            homedir = Popen('echo $HOME', shell=True, 
+            homedir = Popen('echo $HOME', shell=True,
                             stdout=PIPE).communicate()[0].strip()
             if homedir:
                 return _cast_unicode(homedir, fs_encoding)
@@ -204,7 +208,7 @@ def get_home_dir():
         # For some strange reason all of these return 'nt' for os.name.
         # First look for a network home directory. This will return the UNC
         # path (\\server\\Users\%username%) not the mapped path (Z:\). This
-        # is needed when running IPython on cluster where all paths have to 
+        # is needed when running IPython on cluster where all paths have to
         # be UNC.
         try:
             homedir = env['HOMESHARE']
@@ -216,7 +220,7 @@ def get_home_dir():
 
         # Now look for a local home directory
         try:
-            homedir = os.path.join(env['HOMEDRIVE'],env['HOMEPATH'])
+            homedir = os.path.join(env['HOMEDRIVE'], env['HOMEPATH'])
         except KeyError:
             pass
         else:
@@ -239,7 +243,7 @@ def get_home_dir():
                 wreg.HKEY_CURRENT_USER,
                 "Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders"
             )
-            homedir = wreg.QueryValueEx(key,'Personal')[0]
+            homedir = wreg.QueryValueEx(key, 'Personal')[0]
             key.Close()
         except:
             pass
@@ -263,41 +267,44 @@ def get_home_dir():
         # Desperate, may do absurd things in classic MacOS. May work under DOS.
         return u'C:\\'
     else:
-        raise HomeDirError('No valid home directory could be found for your OS')
+        raise HomeDirError('No valid home directory could be found '
+                           'for your OS')
+
 
 def get_xdg_dir():
     """Return the XDG_CONFIG_HOME, if it is defined and exists, else None.
-    
+
     This is only for posix (Linux,Unix,OS X, etc) systems.
     """
 
     isdir = os.path.isdir
     env = os.environ
-    
+
     if os.name == 'posix':
         # Linux, Unix, AIX, OS X
         # use ~/.config if not set OR empty
-        xdg = env.get("XDG_CONFIG_HOME", None) or os.path.join(get_home_dir(), '.config')
+        xdg = env.get("XDG_CONFIG_HOME", None) or \
+              os.path.join(get_home_dir(), '.config')
         if xdg and isdir(xdg):
             return _cast_unicode(xdg, fs_encoding)
-    
+
     return None
-    
+
 
 def get_ipython_dir():
     """Get the IPython directory for this platform and user.
-    
+
     This uses the logic in `get_home_dir` to find the home directory
     and the adds .ipython to the end of the path.
     """
-    
+
     env = os.environ
     pjoin = os.path.join
     exists = os.path.exists
-    
+
     ipdir_def = '.ipython'
     xdg_def = 'ipython'
-    
+
     home_dir = get_home_dir()
     xdg_dir = get_xdg_dir()
     # import pdb; pdb.set_trace()  # dbg
@@ -308,12 +315,12 @@ def get_ipython_dir():
         if xdg_dir:
             # use XDG, as long as the user isn't already
             # using $HOME/.ipython and *not* XDG/ipython
-            
+
             xdg_ipdir = pjoin(xdg_dir, xdg_def)
-        
+
             if exists(xdg_ipdir) or not exists(home_ipdir):
                 ipdir = xdg_ipdir
-        
+
         if ipdir is None:
             # not using XDG
             ipdir = home_ipdir
@@ -348,7 +355,7 @@ def expand_path(s):
     """Expand $VARS and ~names in a string, like a shell
 
     :Examples:
-    
+
        In [2]: os.environ['FOO']='test'
 
        In [3]: expand_path('variable FOO is $FOO')
@@ -359,18 +366,18 @@ def expand_path(s):
     # the $ to get (\\server\share\%username%). I think it considered $
     # alone an empty var. But, we need the $ to remains there (it indicates
     # a hidden share).
-    if os.name=='nt':
+    if os.name == 'nt':
         s = s.replace('$\\', 'IPYTHON_TEMP')
     s = os.path.expandvars(os.path.expanduser(s))
-    if os.name=='nt':
+    if os.name == 'nt':
         s = s.replace('IPYTHON_TEMP', '$\\')
     return s
 
 
-def target_outdated(target,deps):
+def target_outdated(target, deps):
     """Determine whether a target is out of date.
 
-    target_outdated(target,deps) -> 1/0
+    target_outdated(target, deps) -> 1/0
 
     deps: list of filenames which MUST exist.
     target: single filename which may or may not exist.
@@ -391,16 +398,17 @@ def target_outdated(target,deps):
     return 0
 
 
-def target_update(target,deps,cmd):
+def target_update(target, deps, cmd):
     """Update a target with a given command given a list of dependencies.
 
-    target_update(target,deps,cmd) -> runs cmd if target is outdated.
+    target_update(target, deps, cmd) -> runs cmd if target is outdated.
 
     This is just a wrapper around target_outdated() which calls the given
     command if target is outdated."""
 
-    if target_outdated(target,deps):
+    if target_outdated(target, deps):
         system(cmd)
+
 
 def check_for_old_config(ipython_dir=None):
     """Check for old config files, and present a warning if they exist.
@@ -421,5 +429,4 @@ def check_for_old_config(ipython_dir=None):
     The IPython configuration system has changed as of 0.11, and this file will be ignored.
     See http://ipython.github.com/ipython-doc/dev/config for details on the new config system.
     The current default config file is 'ipython_config.py', where you can suppress these
-    warnings with `Global.ignore_old_config = True`."""%f)
-
+    warnings with `Global.ignore_old_config = True`.""" % f)

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -325,7 +325,7 @@ def get_ipython_dir():
             # not using XDG
             ipdir = home_ipdir
 
-    ipdir = os.path.expanduser(ipdir).rstrip('/')
+    ipdir = os.path.normpath(os.path.expanduser(ipdir))
 
     return _cast_unicode(ipdir, fs_encoding)
 

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -317,6 +317,8 @@ def get_ipython_dir():
         if ipdir is None:
             # not using XDG
             ipdir = home_ipdir
+    elif ipdir.startswith('~'):
+        ipdir = os.path.expanduser(ipdir).rstrip('/')
 
     return _cast_unicode(ipdir, fs_encoding)
 

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -301,7 +301,7 @@ def test_get_ipython_dir_6():
 
 @with_environment
 def test_get_ipython_dir_7():
-    """test_get_ipython_dir_2, test home directory expansion on IPYTHON_DIR"""
+    """test_get_ipython_dir_7, test home directory expansion on IPYTHON_DIR"""
     home_dir = os.path.expanduser('~/')
     env['IPYTHON_DIR'] = '~/somewhere'
     ipdir = path.get_ipython_dir()

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -47,15 +47,14 @@ TEST_FILE_PATH = split(abspath(__file__))[0]
 TMP_TEST_DIR = tempfile.mkdtemp()
 HOME_TEST_DIR = join(TMP_TEST_DIR, "home_test_dir")
 XDG_TEST_DIR = join(HOME_TEST_DIR, "xdg_test_dir")
-IP_TEST_DIR = join(HOME_TEST_DIR, '.ipython')
+IP_TEST_DIR = join(HOME_TEST_DIR,'.ipython')
 #
 # Setup/teardown functions/decorators
 #
 
-
 def setup():
     """Setup testenvironment for the module:
-
+    
             - Adds dummy home dir tree
     """
     # Do not mask exceptions here.  In particular, catching WindowsError is a
@@ -66,7 +65,7 @@ def setup():
 
 def teardown():
     """Teardown testenvironment for the module:
-
+    
             - Remove dummy home dir tree
     """
     # Note: we remove the parent test dir, which is the root of all test
@@ -76,10 +75,10 @@ def teardown():
 
 
 def setup_environment():
-    """Setup testenvironment for some functions that are tested
+    """Setup testenvironment for some functions that are tested 
     in this module. In particular this functions stores attributes
     and other things that we need to stub in some test functions.
-    This needs to be done on a function level and not module level because
+    This needs to be done on a function level and not module level because 
     each testfunction needs a pristine environment.
     """
     global oldstuff, platformstuff
@@ -93,7 +92,7 @@ def teardown_environment():
     """Restore things that were remebered by the setup_environment function
     """
     (oldenv, os.name, path.get_home_dir, IPython.__file__,) = oldstuff
-
+        
     for key in env.keys():
         if key not in oldenv:
             del env[key]
@@ -113,10 +112,10 @@ def test_get_home_dir_1():
     """Testcase for py2exe logic, un-compressed lib
     """
     sys.frozen = True
-
+    
     #fake filename for IPython.__init__
     IPython.__file__ = abspath(join(HOME_TEST_DIR, "Lib/IPython/__init__.py"))
-
+    
     home_dir = path.get_home_dir()
     nt.assert_equal(home_dir, abspath(HOME_TEST_DIR))
 
@@ -128,9 +127,8 @@ def test_get_home_dir_2():
     """
     sys.frozen = True
     #fake filename for IPython.__init__
-    IPython.__file__ = abspath(join(
-        HOME_TEST_DIR, "Library.zip/IPython/__init__.py")).lower()
-
+    IPython.__file__ = abspath(join(HOME_TEST_DIR, "Library.zip/IPython/__init__.py")).lower()
+    
     home_dir = path.get_home_dir()
     nt.assert_equal(home_dir, abspath(HOME_TEST_DIR).lower())
 
@@ -146,12 +144,11 @@ def test_get_home_dir_3():
 
 @with_environment
 def test_get_home_dir_4():
-    """Testcase $HOME is not set, os=='posix'.
+    """Testcase $HOME is not set, os=='posix'. 
     This should fail with HomeDirError"""
-
+    
     os.name = 'posix'
-    if 'HOME' in env:
-        del env['HOME']
+    if 'HOME' in env: del env['HOME']
     nt.assert_raises(path.HomeDirError, path.get_home_dir)
 
 
@@ -197,13 +194,13 @@ def test_get_home_dir_7():
     home_dir = path.get_home_dir()
     nt.assert_equal(home_dir, abspath(HOME_TEST_DIR))
 
-
+    
 # Should we stub wreg fully so we can run the test on all platforms?
 @skip_if_not_win32
 @with_environment
 def test_get_home_dir_8():
     """Using registry hack for 'My Documents', os=='nt'
-
+    
     HOMESHARE, HOMEDRIVE, HOMEPATH, USERPROFILE and others are missing.
     """
     os.name = 'nt'
@@ -217,7 +214,6 @@ def test_get_home_dir_8():
             def Close(self):
                 pass
         return key()
-
     def QueryValueEx(x, y):
         return [abspath(HOME_TEST_DIR)]
 
@@ -239,7 +235,7 @@ def test_get_ipython_dir_1():
 @with_environment
 def test_get_ipython_dir_2():
     """test_get_ipython_dir_2, Testcase to see if we can call get_ipython_dir without Exceptions."""
-    path.get_home_dir = lambda: "someplace"
+    path.get_home_dir = lambda : "someplace"
     os.name = "posix"
     env.pop('IPYTHON_DIR', None)
     env.pop('IPYTHONDIR', None)
@@ -247,11 +243,10 @@ def test_get_ipython_dir_2():
     ipdir = path.get_ipython_dir()
     nt.assert_equal(ipdir, os.path.join("someplace", ".ipython"))
 
-
 @with_environment
 def test_get_ipython_dir_3():
     """test_get_ipython_dir_3, use XDG if defined, and .ipython doesn't exist."""
-    path.get_home_dir = lambda: "someplace"
+    path.get_home_dir = lambda : "someplace"
     os.name = "posix"
     env.pop('IPYTHON_DIR', None)
     env.pop('IPYTHONDIR', None)
@@ -259,11 +254,10 @@ def test_get_ipython_dir_3():
     ipdir = path.get_ipython_dir()
     nt.assert_equal(ipdir, os.path.join(XDG_TEST_DIR, "ipython"))
 
-
 @with_environment
 def test_get_ipython_dir_4():
     """test_get_ipython_dir_4, use XDG if both exist."""
-    path.get_home_dir = lambda: HOME_TEST_DIR
+    path.get_home_dir = lambda : HOME_TEST_DIR
     os.name = "posix"
     env.pop('IPYTHON_DIR', None)
     env.pop('IPYTHONDIR', None)
@@ -272,11 +266,10 @@ def test_get_ipython_dir_4():
     ipdir = path.get_ipython_dir()
     nt.assert_equal(ipdir, xdg_ipdir)
 
-
 @with_environment
 def test_get_ipython_dir_5():
     """test_get_ipython_dir_5, use .ipython if exists and XDG defined, but doesn't exist."""
-    path.get_home_dir = lambda: HOME_TEST_DIR
+    path.get_home_dir = lambda : HOME_TEST_DIR
     os.name = "posix"
     env.pop('IPYTHON_DIR', None)
     env.pop('IPYTHONDIR', None)
@@ -285,19 +278,17 @@ def test_get_ipython_dir_5():
     ipdir = path.get_ipython_dir()
     nt.assert_equal(ipdir, IP_TEST_DIR)
 
-
 @with_environment
 def test_get_ipython_dir_6():
     """test_get_ipython_dir_6, use XDG if defined and neither exist."""
-    path.get_home_dir = lambda: 'somehome'
-    path.get_xdg_dir = lambda: 'somexdg'
+    path.get_home_dir = lambda : 'somehome'
+    path.get_xdg_dir = lambda : 'somexdg'
     os.name = "posix"
     env.pop('IPYTHON_DIR', None)
     env.pop('IPYTHONDIR', None)
     xdg_ipdir = os.path.join("somexdg", "ipython")
     ipdir = path.get_ipython_dir()
     nt.assert_equal(ipdir, xdg_ipdir)
-
 
 @with_environment
 def test_get_ipython_dir_7():
@@ -312,12 +303,12 @@ def test_get_ipython_dir_7():
 def test_get_xdg_dir_1():
     """test_get_xdg_dir_1, check xdg_dir"""
     reload(path)
-    path.get_home_dir = lambda: 'somewhere'
+    path.get_home_dir = lambda : 'somewhere'
     os.name = "posix"
     env.pop('IPYTHON_DIR', None)
     env.pop('IPYTHONDIR', None)
     env.pop('XDG_CONFIG_HOME', None)
-
+    
     nt.assert_equal(path.get_xdg_dir(), os.path.join('somewhere', '.config'))
 
 
@@ -325,28 +316,26 @@ def test_get_xdg_dir_1():
 def test_get_xdg_dir_1():
     """test_get_xdg_dir_1, check nonexistant xdg_dir"""
     reload(path)
-    path.get_home_dir = lambda: HOME_TEST_DIR
+    path.get_home_dir = lambda : HOME_TEST_DIR
     os.name = "posix"
     env.pop('IPYTHON_DIR', None)
     env.pop('IPYTHONDIR', None)
     env.pop('XDG_CONFIG_HOME', None)
     nt.assert_equal(path.get_xdg_dir(), None)
 
-
 @with_environment
 def test_get_xdg_dir_2():
     """test_get_xdg_dir_2, check xdg_dir default to ~/.config"""
     reload(path)
-    path.get_home_dir = lambda: HOME_TEST_DIR
+    path.get_home_dir = lambda : HOME_TEST_DIR
     os.name = "posix"
     env.pop('IPYTHON_DIR', None)
     env.pop('IPYTHONDIR', None)
     env.pop('XDG_CONFIG_HOME', None)
-    cfgdir = os.path.join(path.get_home_dir(), '.config')
+    cfgdir=os.path.join(path.get_home_dir(), '.config')
     os.makedirs(cfgdir)
-
+    
     nt.assert_equal(path.get_xdg_dir(), cfgdir)
-
 
 def test_filefind():
     """Various tests for filefind"""
@@ -363,18 +352,18 @@ def test_get_ipython_package_dir():
 
 
 def test_get_ipython_module_path():
-    ipapp_path = path.get_ipython_module_path(
-        'IPython.frontend.terminal.ipapp')
+    ipapp_path = path.get_ipython_module_path('IPython.frontend.terminal.ipapp')
     nt.assert_true(os.path.isfile(ipapp_path))
 
 
 @dec.skip_if_not_win32
 def test_get_long_path_name_win32():
     p = path.get_long_path_name('c:\\docume~1')
-    nt.assert_equals(p, u'c:\\Documents and Settings')
+    nt.assert_equals(p,u'c:\\Documents and Settings') 
 
 
 @dec.skip_win32
 def test_get_long_path_name():
     p = path.get_long_path_name('/usr/local')
-    nt.assert_equals(p, '/usr/local')
+    nt.assert_equals(p,'/usr/local')
+

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -290,6 +290,15 @@ def test_get_ipython_dir_6():
     nt.assert_equal(ipdir, xdg_ipdir)
 
 @with_environment
+def test_get_ipython_dir_7():
+    """test_get_ipython_dir_2, test home directory expansion on IPYTHON_DIR"""
+    home_dir = os.path.expanduser('~/')
+    env['IPYTHON_DIR'] = '~/somewhere'
+    ipdir = path.get_ipython_dir()
+    nt.assert_equal(ipdir, os.path.join(home_dir, 'somewhere'))
+
+
+@with_environment
 def test_get_xdg_dir_1():
     """test_get_xdg_dir_1, check xdg_dir"""
     reload(path)

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -91,7 +91,7 @@ def setup_environment():
 def teardown_environment():
     """Restore things that were remebered by the setup_environment function
     """
-    (oldenv, os.name, get_home_dir, IPython.__file__,) = oldstuff
+    (oldenv, os.name, path.get_home_dir, IPython.__file__,) = oldstuff
         
     for key in env.keys():
         if key not in oldenv:
@@ -269,6 +269,7 @@ def test_get_ipython_dir_4():
 @with_environment
 def test_get_ipython_dir_5():
     """test_get_ipython_dir_5, use .ipython if exists and XDG defined, but doesn't exist."""
+    path.get_home_dir = lambda : HOME_TEST_DIR
     os.name = "posix"
     env.pop('IPYTHON_DIR', None)
     env.pop('IPYTHONDIR', None)

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -47,14 +47,15 @@ TEST_FILE_PATH = split(abspath(__file__))[0]
 TMP_TEST_DIR = tempfile.mkdtemp()
 HOME_TEST_DIR = join(TMP_TEST_DIR, "home_test_dir")
 XDG_TEST_DIR = join(HOME_TEST_DIR, "xdg_test_dir")
-IP_TEST_DIR = join(HOME_TEST_DIR,'.ipython')
+IP_TEST_DIR = join(HOME_TEST_DIR, '.ipython')
 #
 # Setup/teardown functions/decorators
 #
 
+
 def setup():
     """Setup testenvironment for the module:
-    
+
             - Adds dummy home dir tree
     """
     # Do not mask exceptions here.  In particular, catching WindowsError is a
@@ -65,7 +66,7 @@ def setup():
 
 def teardown():
     """Teardown testenvironment for the module:
-    
+
             - Remove dummy home dir tree
     """
     # Note: we remove the parent test dir, which is the root of all test
@@ -75,10 +76,10 @@ def teardown():
 
 
 def setup_environment():
-    """Setup testenvironment for some functions that are tested 
+    """Setup testenvironment for some functions that are tested
     in this module. In particular this functions stores attributes
     and other things that we need to stub in some test functions.
-    This needs to be done on a function level and not module level because 
+    This needs to be done on a function level and not module level because
     each testfunction needs a pristine environment.
     """
     global oldstuff, platformstuff
@@ -92,7 +93,7 @@ def teardown_environment():
     """Restore things that were remebered by the setup_environment function
     """
     (oldenv, os.name, path.get_home_dir, IPython.__file__,) = oldstuff
-        
+
     for key in env.keys():
         if key not in oldenv:
             del env[key]
@@ -112,10 +113,10 @@ def test_get_home_dir_1():
     """Testcase for py2exe logic, un-compressed lib
     """
     sys.frozen = True
-    
+
     #fake filename for IPython.__init__
     IPython.__file__ = abspath(join(HOME_TEST_DIR, "Lib/IPython/__init__.py"))
-    
+
     home_dir = path.get_home_dir()
     nt.assert_equal(home_dir, abspath(HOME_TEST_DIR))
 
@@ -127,8 +128,9 @@ def test_get_home_dir_2():
     """
     sys.frozen = True
     #fake filename for IPython.__init__
-    IPython.__file__ = abspath(join(HOME_TEST_DIR, "Library.zip/IPython/__init__.py")).lower()
-    
+    IPython.__file__ = abspath(join(
+        HOME_TEST_DIR, "Library.zip/IPython/__init__.py")).lower()
+
     home_dir = path.get_home_dir()
     nt.assert_equal(home_dir, abspath(HOME_TEST_DIR).lower())
 
@@ -144,11 +146,12 @@ def test_get_home_dir_3():
 
 @with_environment
 def test_get_home_dir_4():
-    """Testcase $HOME is not set, os=='posix'. 
+    """Testcase $HOME is not set, os=='posix'.
     This should fail with HomeDirError"""
-    
+
     os.name = 'posix'
-    if 'HOME' in env: del env['HOME']
+    if 'HOME' in env:
+        del env['HOME']
     nt.assert_raises(path.HomeDirError, path.get_home_dir)
 
 
@@ -194,13 +197,13 @@ def test_get_home_dir_7():
     home_dir = path.get_home_dir()
     nt.assert_equal(home_dir, abspath(HOME_TEST_DIR))
 
-    
+
 # Should we stub wreg fully so we can run the test on all platforms?
 @skip_if_not_win32
 @with_environment
 def test_get_home_dir_8():
     """Using registry hack for 'My Documents', os=='nt'
-    
+
     HOMESHARE, HOMEDRIVE, HOMEPATH, USERPROFILE and others are missing.
     """
     os.name = 'nt'
@@ -214,6 +217,7 @@ def test_get_home_dir_8():
             def Close(self):
                 pass
         return key()
+
     def QueryValueEx(x, y):
         return [abspath(HOME_TEST_DIR)]
 
@@ -235,7 +239,7 @@ def test_get_ipython_dir_1():
 @with_environment
 def test_get_ipython_dir_2():
     """test_get_ipython_dir_2, Testcase to see if we can call get_ipython_dir without Exceptions."""
-    path.get_home_dir = lambda : "someplace"
+    path.get_home_dir = lambda: "someplace"
     os.name = "posix"
     env.pop('IPYTHON_DIR', None)
     env.pop('IPYTHONDIR', None)
@@ -243,10 +247,11 @@ def test_get_ipython_dir_2():
     ipdir = path.get_ipython_dir()
     nt.assert_equal(ipdir, os.path.join("someplace", ".ipython"))
 
+
 @with_environment
 def test_get_ipython_dir_3():
     """test_get_ipython_dir_3, use XDG if defined, and .ipython doesn't exist."""
-    path.get_home_dir = lambda : "someplace"
+    path.get_home_dir = lambda: "someplace"
     os.name = "posix"
     env.pop('IPYTHON_DIR', None)
     env.pop('IPYTHONDIR', None)
@@ -254,10 +259,11 @@ def test_get_ipython_dir_3():
     ipdir = path.get_ipython_dir()
     nt.assert_equal(ipdir, os.path.join(XDG_TEST_DIR, "ipython"))
 
+
 @with_environment
 def test_get_ipython_dir_4():
     """test_get_ipython_dir_4, use XDG if both exist."""
-    path.get_home_dir = lambda : HOME_TEST_DIR
+    path.get_home_dir = lambda: HOME_TEST_DIR
     os.name = "posix"
     env.pop('IPYTHON_DIR', None)
     env.pop('IPYTHONDIR', None)
@@ -266,10 +272,11 @@ def test_get_ipython_dir_4():
     ipdir = path.get_ipython_dir()
     nt.assert_equal(ipdir, xdg_ipdir)
 
+
 @with_environment
 def test_get_ipython_dir_5():
     """test_get_ipython_dir_5, use .ipython if exists and XDG defined, but doesn't exist."""
-    path.get_home_dir = lambda : HOME_TEST_DIR
+    path.get_home_dir = lambda: HOME_TEST_DIR
     os.name = "posix"
     env.pop('IPYTHON_DIR', None)
     env.pop('IPYTHONDIR', None)
@@ -278,17 +285,19 @@ def test_get_ipython_dir_5():
     ipdir = path.get_ipython_dir()
     nt.assert_equal(ipdir, IP_TEST_DIR)
 
+
 @with_environment
 def test_get_ipython_dir_6():
     """test_get_ipython_dir_6, use XDG if defined and neither exist."""
-    path.get_home_dir = lambda : 'somehome'
-    path.get_xdg_dir = lambda : 'somexdg'
+    path.get_home_dir = lambda: 'somehome'
+    path.get_xdg_dir = lambda: 'somexdg'
     os.name = "posix"
     env.pop('IPYTHON_DIR', None)
     env.pop('IPYTHONDIR', None)
     xdg_ipdir = os.path.join("somexdg", "ipython")
     ipdir = path.get_ipython_dir()
     nt.assert_equal(ipdir, xdg_ipdir)
+
 
 @with_environment
 def test_get_ipython_dir_7():
@@ -303,12 +312,12 @@ def test_get_ipython_dir_7():
 def test_get_xdg_dir_1():
     """test_get_xdg_dir_1, check xdg_dir"""
     reload(path)
-    path.get_home_dir = lambda : 'somewhere'
+    path.get_home_dir = lambda: 'somewhere'
     os.name = "posix"
     env.pop('IPYTHON_DIR', None)
     env.pop('IPYTHONDIR', None)
     env.pop('XDG_CONFIG_HOME', None)
-    
+
     nt.assert_equal(path.get_xdg_dir(), os.path.join('somewhere', '.config'))
 
 
@@ -316,26 +325,28 @@ def test_get_xdg_dir_1():
 def test_get_xdg_dir_1():
     """test_get_xdg_dir_1, check nonexistant xdg_dir"""
     reload(path)
-    path.get_home_dir = lambda : HOME_TEST_DIR
+    path.get_home_dir = lambda: HOME_TEST_DIR
     os.name = "posix"
     env.pop('IPYTHON_DIR', None)
     env.pop('IPYTHONDIR', None)
     env.pop('XDG_CONFIG_HOME', None)
     nt.assert_equal(path.get_xdg_dir(), None)
 
+
 @with_environment
 def test_get_xdg_dir_2():
     """test_get_xdg_dir_2, check xdg_dir default to ~/.config"""
     reload(path)
-    path.get_home_dir = lambda : HOME_TEST_DIR
+    path.get_home_dir = lambda: HOME_TEST_DIR
     os.name = "posix"
     env.pop('IPYTHON_DIR', None)
     env.pop('IPYTHONDIR', None)
     env.pop('XDG_CONFIG_HOME', None)
-    cfgdir=os.path.join(path.get_home_dir(), '.config')
+    cfgdir = os.path.join(path.get_home_dir(), '.config')
     os.makedirs(cfgdir)
-    
+
     nt.assert_equal(path.get_xdg_dir(), cfgdir)
+
 
 def test_filefind():
     """Various tests for filefind"""
@@ -352,18 +363,18 @@ def test_get_ipython_package_dir():
 
 
 def test_get_ipython_module_path():
-    ipapp_path = path.get_ipython_module_path('IPython.frontend.terminal.ipapp')
+    ipapp_path = path.get_ipython_module_path(
+        'IPython.frontend.terminal.ipapp')
     nt.assert_true(os.path.isfile(ipapp_path))
 
 
 @dec.skip_if_not_win32
 def test_get_long_path_name_win32():
     p = path.get_long_path_name('c:\\docume~1')
-    nt.assert_equals(p,u'c:\\Documents and Settings') 
+    nt.assert_equals(p, u'c:\\Documents and Settings')
 
 
 @dec.skip_win32
 def test_get_long_path_name():
     p = path.get_long_path_name('/usr/local')
-    nt.assert_equals(p,'/usr/local')
-
+    nt.assert_equals(p, '/usr/local')


### PR DESCRIPTION
If you set IPYTHON_DIR to '~/something/' then run ipython, a '~/something/' directory is created in whatever path you've called ipython from, which is probably not the expected behavior for most people.
