### PR TITLE
Add test decorator onlyif_unicode_paths.

### DIFF
--- a/IPython/core/tests/test_application.py
+++ b/IPython/core/tests/test_application.py
@@ -5,7 +5,9 @@ import os
 import tempfile
 
 from IPython.core.application import Application
+from IPython.testing import decorators as testdec
 
+@testdec.onlyif_unicode_paths
 def test_unicode_cwd():
     """Check that IPython starts with non-ascii characters in the path."""
     wd = tempfile.mkdtemp(suffix=u"€")
@@ -32,7 +34,8 @@ def test_unicode_cwd():
         app.load_file_config(suppress_errors=False)
     finally:
         os.chdir(old_wd)
-        
+
+@testdec.onlyif_unicode_paths
 def test_unicode_ipdir():
     """Check that IPython starts with non-ascii characters in the IP dir."""
     ipdir = tempfile.mkdtemp(suffix=u"€")

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Decorators for labeling test objects.
 
 Decorators that merely return a modified version of the original function
@@ -323,11 +324,12 @@ null_deco = lambda f: f
 # Some tests only run where we can use unicode paths. Note that we can't just
 # check os.path.supports_unicode_filenames, which is always False on Linux.
 try:
-    tempfile.mkdtemp(u"€")
+    f = tempfile.NamedTemporaryFile(prefix=u"tmp€")
 except UnicodeEncodeError:
     unicode_paths = False
 else:
     unicode_paths = True
+    f.close()
 
 onlyif_unicode_paths = onlyif(unicode_paths, ("This test is only applicable "
                                     "where we can use unicode in filenames."))

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -49,6 +49,7 @@ Authors
 # Stdlib imports
 import inspect
 import sys
+import tempfile
 import unittest
 
 # Third-party imports
@@ -318,3 +319,15 @@ skip_known_failure = knownfailureif(True,'This test is known to fail')
 # A null 'decorator', useful to make more readable code that needs to pick
 # between different decorators based on OS or other conditions
 null_deco = lambda f: f
+
+# Some tests only run where we can use unicode paths. Note that we can't just
+# check os.path.supports_unicode_filenames, which is always False on Linux.
+try:
+    tempfile.mkdtemp(u"€")
+except UnicodeEncodeError:
+    unicode_paths = False
+else:
+    unicode_paths = True
+
+onlyif_unicode_paths = onlyif(unicode_paths, ("This test is only applicable "
+                                    "where we can use unicode in filenames."))


### PR DESCRIPTION
Some of our tests hit an error where unicode paths weren't supported. Since they're specifically to test unicode paths, it didn't make sense to change them. This adds a decorator which skips them in those circumstances.

Closes gh-466
