### PR TITLE
Kernel event loop is robust against random SIGINT.

### DIFF
--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -167,8 +167,12 @@ class Kernel(Configurable):
         """ Start the kernel main loop.
         """
         while True:
-            time.sleep(self._poll_interval)
-            self.do_one_iteration()
+            try:
+                time.sleep(self._poll_interval)
+                self.do_one_iteration()
+            except KeyboardInterrupt:
+                # Ctrl-C shouldn't crash the kernel
+                continue
 
     def record_ports(self, xrep_port, pub_port, req_port, hb_port):
         """Record the ports that this kernel is using.

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -172,7 +172,7 @@ class Kernel(Configurable):
                 self.do_one_iteration()
             except KeyboardInterrupt:
                 # Ctrl-C shouldn't crash the kernel
-                continue
+                io.raw_print("KeyboardInterrupt caught in kernel")
 
     def record_ports(self, xrep_port, pub_port, req_port, hb_port):
         """Record the ports that this kernel is using.


### PR DESCRIPTION
Kernel event loop catches KeyboardInterrupt (i.e. SIGINT, Ctrl-C) and carries on running. This was prompted by trouble we were having with the zmqterminal frontend (#433). This doesn't prevent us from interrupting execution of user code.
