### PR TITLE
Links launchpad -> github

### DIFF
--- a/IPython/core/tests/refbug.py
+++ b/IPython/core/tests/refbug.py
@@ -1,6 +1,6 @@
 """Minimal script to reproduce our nasty reference counting bug.
 
-The problem is related to https://bugs.launchpad.net/ipython/+bug/269966
+The problem is related to https://github.com/ipython/ipython/issues/141
 
 The original fix for that appeared to work, but John D. Hunter found a
 matplotlib example which, when run twice in a row, would break.  The problem
@@ -9,8 +9,8 @@ were references held by open figures to internals of Tkinter.
 This code reproduces the problem that John saw, without matplotlib.
 
 This script is meant to be called by other parts of the test suite that call it
-via %run as if it were executed interactively by the user.  As of 2009-04-13,
-test_magic.py calls it.
+via %run as if it were executed interactively by the user. As of 2011-05-29,
+test_run.py calls it.
 """
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/tests/test_prefilter.py
+++ b/IPython/core/tests/test_prefilter.py
@@ -37,7 +37,7 @@ def test_prefilter():
 
 @dec.parametric
 def test_autocall_binops():
-    """See https://bugs.launchpad.net/ipython/+bug/315706"""
+    """See https://github.com/ipython/ipython/issues/81"""
     ip.magic('autocall 2')
     f = lambda x: x
     ip.user_ns['f'] = f

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -27,7 +27,7 @@ from IPython.testing import tools as tt
 
 def doctest_refbug():
     """Very nasty problem with references held by multiple runs of a script.
-    See: https://bugs.launchpad.net/ipython/+bug/269966
+    See: https://github.com/ipython/ipython/issues/141
 
     In [1]: _ip.clear_main_mod_cache()
     # random
@@ -157,8 +157,6 @@ class TestMagicRunSimple(tt.TempFileMixin):
     def test_obj_del(self):
         """Test that object's __del__ methods are called on exit."""
         
-        # This test is known to fail on win32.
-        # See ticket https://bugs.launchpad.net/bugs/366334
         src = ("class A(object):\n"
                "    def __del__(self):\n"
                "        print 'object A deleted'\n"

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -180,7 +180,7 @@ def make_exclude():
     exclusions.append(ipjoin('lib', 'inputhookgtk'))
 
     # These have to be skipped on win32 because the use echo, rm, cd, etc.
-    # See ticket https://bugs.launchpad.net/bugs/366982
+    # See ticket https://github.com/ipython/ipython/issues/87
     if sys.platform == 'win32':
         exclusions.append(ipjoin('testing', 'plugin', 'test_exampleip'))
         exclusions.append(ipjoin('testing', 'plugin', 'dtexample'))


### PR DESCRIPTION
See issue #168.

I'm doing the pull request mainly to ask what to do with the two remaining ones I haven't cleaned up:
- core/magic.py : https://bugs.launchpad.net/ipython/+bug/348466
- core/tests/test_run.py : https://bugs.launchpad.net/bugs/366353

Both are potentially still informative, but were closed before migrating to Github. There's a third in quarantine that I'm ignoring.
