### PR TITLE
QtConsole zoom adjustments

### DIFF
--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -990,7 +990,7 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
             elif key in (QtCore.Qt.Key_Backspace, QtCore.Qt.Key_Delete):
                 intercepted = True
 
-            elif key == QtCore.Qt.Key_Plus:
+            elif key in (QtCore.Qt.Key_Plus, QtCore.Qt.Key_Equal):
                 self.change_font_size(1)
                 intercepted = True
 

--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -598,7 +598,8 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
         """Change the font size by the specified amount (in points).
         """
         font = self.font
-        font.setPointSize(font.pointSize() + delta)
+        size = max(font.pointSize() + delta, 1) # minimum 1 point
+        font.setPointSize(size)
         self._set_font(font)
 
     def select_all(self):

--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -998,6 +998,10 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
                 self.change_font_size(-1)
                 intercepted = True
 
+            elif key == QtCore.Qt.Key_0:
+                self.reset_font()
+                intercepted = True
+
         #------ Alt modifier ---------------------------------------------------
 
         elif alt_down:


### PR DESCRIPTION
don't set point size less than 1 in ConsoleWidget: fixes #493
adjust/add key binding for zoom out/reset.
