### PR TITLE
Better selection of Qt bindings when QT_API is not specified

### DIFF
--- a/IPython/external/qt.py
+++ b/IPython/external/qt.py
@@ -7,10 +7,7 @@ import os
 QT_API_PYQT = 'pyqt'
 QT_API_PYSIDE = 'pyside'
 
-# Use PyQt by default until PySide is stable.
-QT_API = os.environ.get('QT_API', QT_API_PYQT)
-
-if QT_API == QT_API_PYQT:
+def prepare_pyqt4():
     # For PySide compatibility, use the new-style string API that automatically
     # converts QStrings to Unicode Python strings. Also, automatically unpack
     # QVariants to their underlying objects.
@@ -18,6 +15,26 @@ if QT_API == QT_API_PYQT:
     sip.setapi('QString', 2)
     sip.setapi('QVariant', 2)
 
+# Select Qt binding, using the QT_API environment variable if available.
+QT_API = os.environ.get('QT_API')
+if QT_API is None:
+    try:
+        import PySide
+        QT_API = QT_API_PYSIDE
+    except ImportError:
+        try:
+            prepare_pyqt4()
+            import PyQt4
+            QT_API = QT_API_PYQT
+        except ImportError:
+            raise ImportError('Cannot import PySide or PyQt4')
+        
+elif QT_API == QT_API_PYQT:
+    # Note: This must be called *before* PyQt4 is imported.
+    prepare_pyqt4()
+
+# Now peform the imports.
+if QT_API == QT_API_PYQT:
     from PyQt4 import QtCore, QtGui, QtSvg
 
     # Alias PyQt-specific functions for PySide compatibility.


### PR DESCRIPTION
When the user has only PySide or only PyQt4 installed, importing from IPython.external.qt will now do the sensible thing.
