### PR TITLE
Qt editing keybindings

### DIFF
--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -988,6 +988,12 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
                 intercepted = True
 
             elif key in (QtCore.Qt.Key_Backspace, QtCore.Qt.Key_Delete):
+                if key == QtCore.Qt.Key_Backspace:
+                    cursor = self._get_word_start_cursor(position)
+                else: # key == QtCore.Qt.Key_Delete
+                    cursor = self._get_word_end_cursor(position)
+                cursor.setPosition(position, QtGui.QTextCursor.KeepAnchor)
+                self._kill_ring.kill_cursor(cursor)
                 intercepted = True
 
             elif key in (QtCore.Qt.Key_Plus, QtCore.Qt.Key_Equal):


### PR DESCRIPTION
Add Ctrl+Backspace and Ctrl+Del keybindings to delete to start and end of current word. This is what most people (or at least I) expect in a normal text widget. For some reason, Alt+Backspace and Alt+D are the current keybindings for this, which I find a bit strange. Anyone know why? I've left those as they are.

Also, on my local branch, I use Ctrl+D to quickly close the window, ala a normal terminal. Not sure how others would feel about this. Currently, Ctrl+D is bound to QtCore.Qt.Key_Delete.

I don't suppose keybindings will be user configurable in the near future, will they?
