### PR TITLE
Updating string formatting

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -51,7 +51,6 @@ from IPython.core.macro import Macro
 from IPython.core import page
 from IPython.core.prefilter import ESC_MAGIC
 from IPython.lib.pylabtools import mpl_runner
-from IPython.external.Itpl import itpl, printpl
 from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.io import file_read, nlprint
 from IPython.utils.path import get_py_filename
@@ -915,8 +914,7 @@ Currently the magic system has the following functions:\n"""
         datalabel = 'Data/Info'
         colsep = 3
         # variable format strings
-        vformat    = "$vname.ljust(varwidth)$vtype.ljust(typewidth)"
-        vfmt_short = '$vstr[:25]<...>$vstr[-25:]'
+        vformat    = "{0:<{varwidth}}{1:<{typewidth}}"
         aformat    = "%s: %s elems, type `%s`, %s bytes"
         # find the size of the columns to format the output nicely
         varwidth = max(max(map(len,varnames)), len(varlabel)) + colsep
@@ -928,7 +926,7 @@ Currently the magic system has the following functions:\n"""
         kb = 1024
         Mb = 1048576  # kb**2
         for vname,var,vtype in zip(varnames,varlist,typelist):
-            print itpl(vformat),
+            print vformat.format(vname, vtype, varwidth=varwidth, typewidth=typewidth),
             if vtype in seq_types:
                 print "n="+str(len(var))
             elif vtype in [array_type,ndarray_type]:
@@ -962,7 +960,7 @@ Currently the magic system has the following functions:\n"""
                 if len(vstr) < 50:
                     print vstr
                 else:
-                    printpl(vfmt_short)
+                    print vstr[:25] + "<...>" + vstr[-25:]
                 
     def magic_reset(self, parameter_s=''):
         """Resets the namespace by removing all names defined by the user.

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -28,7 +28,6 @@ from itertools import izip_longest
 
 # IPython's own
 from IPython.core import page
-from IPython.external.Itpl import itpl
 from IPython.utils import PyColorize
 from IPython.utils import io
 from IPython.utils.text import indent
@@ -298,22 +297,24 @@ class Inspector:
         -formatter: a function to run the docstring through for specially
         formatted docstrings."""
 
-        head = self.__head  # so that itpl can find it even if private
+        head = self.__head  # For convenience
         ds = getdoc(obj)
         if formatter:
             ds = formatter(ds)
         if inspect.isclass(obj):
             init_ds = getdoc(obj.__init__)
-            output = itpl('$head("Class Docstring:")\n'
-                          '$indent(ds)\n'
-                          '$head("Constructor Docstring"):\n'
-                          '$indent(init_ds)')
+            output = "\n".join([head("Class Docstring:"),
+                                indent(ds),
+                                head("Constructor Docstring:"),
+                                indent(init_ds)])
         elif (type(obj) is types.InstanceType or isinstance(obj,object)) \
                  and hasattr(obj,'__call__'):
             call_ds = getdoc(obj.__call__)
             if call_ds:
-                output = itpl('$head("Class Docstring:")\n$indent(ds)\n'
-                              '$head("Calling Docstring:")\n$indent(call_ds)')
+                output = "\n".join([head("Class Docstring:"),
+                                    indent(ds),
+                                    head("Calling Docstring:"),
+                                    indent(call_ds)])
             else:
                 output = ds
         else:

--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -62,33 +62,8 @@ default_config_file_name = u'ipython_config.py'
 # Crash handler for this application
 #-----------------------------------------------------------------------------
 
-_message_template = """\
-Oops, $self.app_name crashed. We do our best to make it stable, but...
-
-A crash report was automatically generated with the following information:
-  - A verbatim copy of the crash traceback.
-  - A copy of your input history during this session.
-  - Data on your current $self.app_name configuration.
-
-It was left in the file named:
-\t'$self.crash_report_fname'
-If you can email this file to the developers, the information in it will help
-them in understanding and correcting the problem.
-
-You can mail it to: $self.contact_name at $self.contact_email
-with the subject '$self.app_name Crash Report'.
-
-If you want to do it now, the following command will work (under Unix):
-mail -s '$self.app_name Crash Report' $self.contact_email < $self.crash_report_fname
-
-To ensure accurate tracking of this issue, please file a report about it at:
-$self.bug_tracker
-"""
-
 class IPAppCrashHandler(CrashHandler):
     """sys.excepthook for IPython itself, leaves a detailed report on disk."""
-
-    message_template = _message_template
 
     def __init__(self, app):
         contact_name = release.authors['Fernando'][0]

--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -17,8 +17,6 @@ from __future__ import print_function
 import sys
 import tempfile
 
-from IPython.external.Itpl import itpl, printpl
-
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
@@ -268,12 +266,13 @@ class NLprinter:
 
         for idx in range(start,stop):
             elem = lst[idx]
+            newpos = pos + str(idx)
             if type(elem)==type([]):
                 self.depth += 1
-                self.__call__(elem,itpl('$pos$idx,'),**kw)
+                self.__call__(elem, newpos+",", **kw)
                 self.depth -= 1
             else:
-                printpl(kw['indent']*self.depth+'$pos$idx$kw["sep"]$elem')
+                print(kw['indent']*self.depth + newpos + kw["sep"] + repr(elem))
 
 nlprint = NLprinter()
 


### PR DESCRIPTION
This replaces most of the uses of the old Itpl library with built-in string formatting (fancy string formatting was new in Python 2.6). I'd like to also tidy up the remaining cases (prompt generation and magic/system calls), but these are trickier, so are probably best done separately.
