### PR TITLE
make ENTER on a previous input field replace current input buffer

### DIFF
--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -645,7 +645,7 @@ def transform_classic_prompt(line):
 _ipy_prompt_re = re.compile(r'^([ \t]*In \[\d+\]: |^[ \t]*\ \ \ \.\.\.+: )')
 
 def transform_ipy_prompt(line):
-    """Handle inputs that start classic IPython prompt syntax."""
+    """Handle inputs that start with classic IPython prompt syntax."""
 
     if not line or line.isspace():
         return line

--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -665,6 +665,11 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
         """
         pass
 
+    def _transform_prompt(self, line):
+        """ Strip prompt from line.
+        """
+        pass
+
     def _up_pressed(self, shift_modifier):
         """ Called when the up key is pressed. Returns whether to continue
             processing the event.

--- a/IPython/frontend/qt/console/frontend_widget.py
+++ b/IPython/frontend/qt/console/frontend_widget.py
@@ -160,7 +160,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         """
         text = self._control.textCursor().selection().toPlainText()
         if text:
-            lines = map(transform_classic_prompt, text.splitlines())
+            lines = map(self._transform_prompt, text.splitlines())
             text = '\n'.join(lines)
             QtGui.QApplication.clipboard().setText(text)
 
@@ -205,6 +205,11 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
 
         if not self._reading:
             self._highlighter.highlighting_on = False
+
+    def _transform_prompt(self, line):
+        """ Strip prompt from line.
+        """
+        return transform_classic_prompt(line)
 
     def _tab_pressed(self):
         """ Called when the tab key is pressed. Returns whether to continue

--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -227,9 +227,18 @@ class IPythonWidget(FrontendWidget):
         """
         text = self._control.textCursor().selection().toPlainText()
         if text:
-            lines = map(transform_ipy_prompt, text.splitlines())
+            lines = map(self._transform_prompt, text.splitlines())
             text = '\n'.join(lines)
             QtGui.QApplication.clipboard().setText(text)
+
+    #---------------------------------------------------------------------------
+    # 'ConsoleWidget' abstract interface
+    #---------------------------------------------------------------------------
+
+    def _transform_prompt(self, line):
+        """ Strip prompt from line.
+        """
+        return transform_ipy_prompt(line)
 
     #---------------------------------------------------------------------------
     # 'FrontendWidget' public interface

--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -218,20 +218,6 @@ class IPythonWidget(FrontendWidget):
         self.kernel_manager.xreq_channel.history(hist_access_type='tail', n=1000)
 
     #---------------------------------------------------------------------------
-    # 'ConsoleWidget' public interface
-    #---------------------------------------------------------------------------
-
-    def copy(self):
-        """ Copy the currently selected text to the clipboard, removing prompts
-            if possible.
-        """
-        text = self._control.textCursor().selection().toPlainText()
-        if text:
-            lines = map(self._transform_prompt, text.splitlines())
-            text = '\n'.join(lines)
-            QtGui.QApplication.clipboard().setText(text)
-
-    #---------------------------------------------------------------------------
     # 'ConsoleWidget' abstract interface
     #---------------------------------------------------------------------------
 


### PR DESCRIPTION
I found this kind of functionality really handy in pycrust/pyshell under wx. To quickly replace the current input buffer with the contents of a previous input field, just click on the previous input field and hit enter. Then you can edit it before executing it.
