### PR TITLE
Prompt manager

### DIFF
--- a/IPython/config/profile/pysh/ipython_config.py
+++ b/IPython/config/profile/pysh/ipython_config.py
@@ -5,11 +5,11 @@ app = c.InteractiveShellApp
 # and merge it into the current one.
 load_subconfig('ipython_config.py', profile='default')
 
-c.InteractiveShell.prompt_in1 = r'\C_LightGreen\u@\h\C_LightBlue[\C_LightCyan\Y1\C_LightBlue]\C_Green|\#> '
-c.InteractiveShell.prompt_in2 = r'\C_Green|\C_LightGreen\D\C_Green> '
-c.InteractiveShell.prompt_out = r'<\#> '
+c.PromptManager.in_template = r'{color.LightGreen}\u@\h{color.LightBlue}[{color.LightCyan}\Y1{color.LightBlue}]{color.Green}|\#> '
+c.PromptManager.in2_template = r'{color.Green}|{color.LightGreen}\D{color.Green}> '
+c.PromptManager.out_template = r'<\#> '
 
-c.InteractiveShell.prompts_pad_left = True
+c.PromptManager.justify = True
 
 c.InteractiveShell.separate_in = ''
 c.InteractiveShell.separate_out = ''

--- a/IPython/core/hooks.py
+++ b/IPython/core/hooks.py
@@ -51,7 +51,7 @@ from IPython.core.error import TryNext
 
 __all__ = ['editor', 'fix_error_editor', 'synchronize_with_editor',
            'input_prefilter', 'shutdown_hook', 'late_startup_hook',
-           'generate_prompt', 'show_in_pager','pre_prompt_hook',
+           'show_in_pager','pre_prompt_hook',
            'pre_run_code_hook', 'clipboard_get']
 
 def editor(self,filename, linenum=None):

--- a/IPython/core/hooks.py
+++ b/IPython/core/hooks.py
@@ -187,13 +187,6 @@ def late_startup_hook(self):
     #print "default startup hook ok" # dbg
 
 
-def generate_prompt(self, is_continuation):
-    """ calculate and return a string with the prompt to display """
-    if is_continuation:
-        return str(self.displayhook.prompt2)
-    return str(self.displayhook.prompt1)
-
-
 def show_in_pager(self,s):
     """ Run a string through pager """
     # raising TryNext here will use the default paging functionality

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -596,6 +596,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
 
     def init_prompts(self):
         self.prompt_manager = PromptManager(shell=self, config=self.config)
+        self.configurables.append(self.prompt_manager)
 
     def init_display_formatter(self):
         self.display_formatter = DisplayFormatter(config=self.config)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -63,6 +63,7 @@ from IPython.core.plugin import PluginManager
 from IPython.core.prefilter import PrefilterManager, ESC_MAGIC
 from IPython.core.profiledir import ProfileDir
 from IPython.core.pylabtools import pylab_activate
+from IPython.core.prompts import PromptManager
 from IPython.external.Itpl import ItplNS
 from IPython.utils import PyColorize
 from IPython.utils import io
@@ -594,10 +595,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
             io.stderr = io.IOStream(sys.stderr)
 
     def init_prompts(self):
-        # TODO: This is a pass for now because the prompts are managed inside
-        # the DisplayHook. Once there is a separate prompt manager, this
-        # will initialize that object and all prompt related information.
-        pass
+        self.prompt_manager = PromptManager(shell=self, config=self.config)
 
     def init_display_formatter(self):
         self.display_formatter = DisplayFormatter(config=self.config)
@@ -613,13 +611,6 @@ class InteractiveShell(SingletonConfigurable, Magic):
             config=self.config,
             shell=self,
             cache_size=self.cache_size,
-            input_sep = self.separate_in,
-            output_sep = self.separate_out,
-            output_sep2 = self.separate_out2,
-            ps1 = self.prompt_in1,
-            ps2 = self.prompt_in2,
-            ps_out = self.prompt_out,
-            pad_left = self.prompts_pad_left
         )
         self.configurables.append(self.displayhook)
         # This is a context manager that installs/revmoes the displayhook at
@@ -2149,7 +2140,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
         after the user's input prompt.  This helps the user understand that the
         input line was transformed automatically by IPython.
         """
-        rw = self.displayhook.prompt1.auto_rewrite() + cmd
+        rw = self.prompt_manager.render('rewrite') + cmd
 
         try:
             # plain ascii works better w/ pyreadline, on some machines, so

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2554,12 +2554,12 @@ Defaulting color scheme to 'NoColor'"""
 
         # Set prompt colors
         try:
-            shell.displayhook.set_colors(new_scheme)
+            shell.prompt_manager.color_scheme = new_scheme
         except:
             color_switch_err('prompt')
         else:
             shell.colors = \
-                       shell.displayhook.color_table.active_scheme_name
+                   shell.prompt_manager.color_scheme_table.active_scheme_name
         # Set exception colors
         try:
             shell.InteractiveTB.set_colors(scheme = new_scheme)
@@ -3237,7 +3237,7 @@ Defaulting color scheme to 'NoColor'"""
 
         # Shorthands
         shell = self.shell
-        oc = shell.displayhook
+        pm = shell.prompt_manager
         meta = shell.meta
         disp_formatter = self.shell.display_formatter
         ptformatter = disp_formatter.formatters['text/plain']
@@ -3252,23 +3252,23 @@ Defaulting color scheme to 'NoColor'"""
         save_dstore('xmode',shell.InteractiveTB.mode)
         save_dstore('rc_separate_out',shell.separate_out)
         save_dstore('rc_separate_out2',shell.separate_out2)
-        save_dstore('rc_prompts_pad_left',shell.prompts_pad_left)
+        save_dstore('rc_prompts_pad_left',pm.justify)
         save_dstore('rc_separate_in',shell.separate_in)
         save_dstore('rc_plain_text_only',disp_formatter.plain_text_only)
+        save_dstore('prompt_templates',(pm.in_template, pm.in2_template, pm.out_template))
 
         if mode == False:
             # turn on
-            oc.prompt1.p_template = '>>> '
-            oc.prompt2.p_template = '... '
-            oc.prompt_out.p_template = ''
+            pm.in_template = '>>> '
+            pm.in2_template = '... '
+            pm.out_template = ''
 
             # Prompt separators like plain python
-            oc.input_sep = oc.prompt1.sep = ''
-            oc.output_sep = ''
-            oc.output_sep2 = ''
+            shell.separate_in = ''
+            shell.separate_out = ''
+            shell.separate_out2 = ''
 
-            oc.prompt1.pad_left = oc.prompt2.pad_left = \
-                                  oc.prompt_out.pad_left = False
+            pm.justify = False
 
             ptformatter.pprint = False
             disp_formatter.plain_text_only = True
@@ -3276,17 +3276,14 @@ Defaulting color scheme to 'NoColor'"""
             shell.magic_xmode('Plain')
         else:
             # turn off
-            oc.prompt1.p_template = shell.prompt_in1
-            oc.prompt2.p_template = shell.prompt_in2
-            oc.prompt_out.p_template = shell.prompt_out
+            pm.in_template, pm.in2_template, pm.out_template = dstore.prompt_templates
 
-            oc.input_sep = oc.prompt1.sep = dstore.rc_separate_in
+            shell.separate_in = dstore.rc_separate_in
 
-            oc.output_sep = dstore.rc_separate_out
-            oc.output_sep2 = dstore.rc_separate_out2
+            shell.separate_out = dstore.rc_separate_out
+            shell.separate_out2 = dstore.rc_separate_out2
 
-            oc.prompt1.pad_left = oc.prompt2.pad_left = \
-                         oc.prompt_out.pad_left = dstore.rc_prompts_pad_left
+            pm.justify = dstore.rc_prompts_pad_left
 
             ptformatter.pprint = dstore.rc_pprint
             disp_formatter.plain_text_only = dstore.rc_plain_text_only

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -3600,6 +3600,7 @@ Defaulting color scheme to 'NoColor'"""
                 PrefilterManager
                 AliasManager
                 IPCompleter
+                PromptManager
                 DisplayFormatter
 
         To view what is configurable on a given class, just pass the class name::

--- a/IPython/core/prompts.py
+++ b/IPython/core/prompts.py
@@ -158,20 +158,20 @@ prompt_abbreviations = {
     r'\W' : '{cwd_last}',
     # These X<N> are an extension to the normal bash prompts.  They return
     # N terms of the path, after replacing $HOME with '~'
-    r'\X0': '{cwd_x[0])}',
-    r'\X1': '{cwd_x[1])}',
-    r'\X2': '{cwd_x[2])}',
-    r'\X3': '{cwd_x[3])}',
-    r'\X4': '{cwd_x[4])}',
-    r'\X5': '{cwd_x[5])}',
+    r'\X0': '{cwd_x[0]}',
+    r'\X1': '{cwd_x[1]}',
+    r'\X2': '{cwd_x[2]}',
+    r'\X3': '{cwd_x[3]}',
+    r'\X4': '{cwd_x[4]}',
+    r'\X5': '{cwd_x[5]}',
     # Y<N> are similar to X<N>, but they show '~' if it's the directory
     # N+1 in the list.  Somewhat like %cN in tcsh.
-    r'\Y0': '{cwd_y[0])}',
-    r'\Y1': '{cwd_y[1])}',
-    r'\Y2': '{cwd_y[2])}',
-    r'\Y3': '{cwd_y[3])}',
-    r'\Y4': '{cwd_y[4])}',
-    r'\Y5': '{cwd_y[5])}',
+    r'\Y0': '{cwd_y[0]}',
+    r'\Y1': '{cwd_y[1]}',
+    r'\Y2': '{cwd_y[2]}',
+    r'\Y3': '{cwd_y[3]}',
+    r'\Y4': '{cwd_y[4]}',
+    r'\Y5': '{cwd_y[5]}',
     # Hostname up to first .
     r'\h': HOSTNAME_SHORT,
     # Full hostname
@@ -194,7 +194,7 @@ prompt_abbreviations = {
 # More utilities
 #-----------------------------------------------------------------------------
 
-def cwd_filt(self, depth):
+def cwd_filt(depth):
     """Return the last depth elements of the current working directory.
 
     $HOME is always replaced with '~'.
@@ -204,7 +204,7 @@ def cwd_filt(self, depth):
     out = os.sep.join(cwd.split(os.sep)[-depth:])
     return out or os.sep
 
-def cwd_filt2(self, depth):
+def cwd_filt2(depth):
     """Return the last depth elements of the current working directory.
 
     $HOME is always replaced with '~'.

--- a/IPython/core/prompts.py
+++ b/IPython/core/prompts.py
@@ -150,7 +150,7 @@ prompt_abbreviations = {
     r'\D': '{dots}',
 
     # Current time
-    r'\t' : '{time}',
+    r'\T' : '{time}',
     # Current working directory
     r'\w': '{cwd}',
     # Basename of current working directory.

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -148,7 +148,7 @@ class TestMagicRunPass(tt.TempFileMixin):
         """Test that prompts correctly generate after %run"""
         self.run_tmpfile()
         _ip = get_ipython()
-        p2 = str(_ip.displayhook.prompt2).strip()
+        p2 = _ip.prompt_manager.render('in2').strip()
         nt.assert_equals(p2[:3], '...')
         
     def test_run_profile( self ):

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -356,7 +356,7 @@ class TerminalInteractiveShell(InteractiveShell):
             self.hooks.pre_prompt_hook()
             if more:
                 try:
-                    prompt = self.hooks.generate_prompt(True)
+                    prompt = self.prompt_manager.render('in2')
                 except:
                     self.showtraceback()
                 if self.autoindent:
@@ -364,7 +364,7 @@ class TerminalInteractiveShell(InteractiveShell):
 
             else:
                 try:
-                    prompt = self.hooks.generate_prompt(False)
+                    prompt = self.separate_in + self.prompt_manager.render('in')
                 except:
                     self.showtraceback()
             try:

--- a/IPython/utils/coloransi.py
+++ b/IPython/utils/coloransi.py
@@ -15,12 +15,7 @@ import os
 
 from IPython.utils.ipstruct import Struct
 
-def make_color_table(in_class):
-    """Build a set of color attributes in a class.
-
-    Helper function for building the *TermColors classes."""
-
-    color_templates = (
+color_templates = (
         # Dark colors
         ("Black"       , "0;30"),
         ("Red"         , "0;31"),
@@ -49,6 +44,11 @@ def make_color_table(in_class):
         ("BlinkCyan"   , "5;36"),
         ("BlinkLightGray", "5;37"),
         )
+
+def make_color_table(in_class):
+    """Build a set of color attributes in a class.
+
+    Helper function for building the *TermColors classes."""
 
     for name,value in color_templates:
         setattr(in_class,name,in_class._base % value)
@@ -97,6 +97,14 @@ class InputTermColors:
 
 # Build the actual color table as a set of class attributes:
 make_color_table(InputTermColors)
+
+class NoColors:
+    """This defines all the same names as the colour classes, but maps them to
+    empty strings, so it can easily be substituted to turn off colours."""
+    NoColor = ''
+
+for name, value in color_templates:
+    setattr(NoColors, name, '')
 
 class ColorScheme:
     """Generic color scheme class. Just a name and a Struct."""

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -75,13 +75,15 @@ def eval_formatter_slicing_check(f):
     nt.assert_equals(s, ns['stuff'][::2])
     
     nt.assert_raises(SyntaxError, f.format, "{n:x}", **ns)
-    
 
 def eval_formatter_no_slicing_check(f):
     ns = dict(n=12, pi=math.pi, stuff='hello there', os=os)
     
     s = f.format('{n:x} {pi**2:+f}', **ns)
     nt.assert_equals(s, "c +9.869604")
+    
+    s = f.format('{stuff[slice(1,4)]}', **ns)
+    nt.assert_equals(s, 'ell')
     
     nt.assert_raises(SyntaxError, f.format, "{a[:]}")
 

--- a/IPython/zmq/zmqshell.py
+++ b/IPython/zmq/zmqshell.py
@@ -133,7 +133,7 @@ class ZMQInteractiveShell(InteractiveShell):
         FIXME: this payload is currently not correctly processed by the
         frontend.
         """
-        new = self.displayhook.prompt1.auto_rewrite() + cmd
+        new = self.prompt_manager.render('rewrite') + cmd
         payload = dict(
             source='IPython.zmq.zmqshell.ZMQInteractiveShell.auto_rewrite_input',
             transformed_input=new,

--- a/docs/source/config/ipython.txt
+++ b/docs/source/config/ipython.txt
@@ -124,11 +124,12 @@ attributes::
     c.InteractiveShell.confirm_exit = False
     c.InteractiveShell.deep_reload = True
     c.InteractiveShell.editor = 'nano'
-    c.InteractiveShell.prompt_in1 = 'In [\#]: '
-    c.InteractiveShell.prompt_in2 = '   .\D.: '
-    c.InteractiveShell.prompt_out = 'Out[\#]: '
-    c.InteractiveShell.prompts_pad_left = True
     c.InteractiveShell.xmode = 'Context'
+    
+    c.PromptManager.in_template  = 'In [\#]: '
+    c.PromptManager.in2_template = '   .\D.: '
+    c.PromptManager.out_template = 'Out[\#]: '
+    c.PromptManager.justify = True
 
     c.PrefilterManager.multi_line_specials = True
 

--- a/docs/source/whatsnew/development.txt
+++ b/docs/source/whatsnew/development.txt
@@ -117,6 +117,15 @@ Backwards incompatible changes
   traits, rather than several ip/port pair ``_addr`` traits. This better matches the
   rest of the code, where the ip cannot not be set separately for each channel.
 
+* Custom prompts are now configured using a new class,
+  :class:`~IPython.core.prompts.PromptManager`, which has traits for :attr:`in_template`,
+  :attr:`in2_template` (the ``...:`` continuation prompt), :attr:`out_template`
+  and :attr:`rewrite_template`. This uses Python's string formatting system, so
+  you can use ``{time}`` and ``{cwd}``, although we have preserved the abbreviations
+  from previous versions, e.g. ``\#`` (prompt number) and ``\w`` (working 
+  directory). For the list of available fields, refer to the source of
+  :file:`IPython/core/prompts.py`.
+
 * The class inheritance of the Launchers in :mod:`IPython.parallel.apps.launcher`
   used by ipcluster has changed, so that trait names are more consistent across
   batch systems. This may require a few renames in your config files, if you


### PR DESCRIPTION
I'm not expecting this to land before 0.11, but I thought I'd get it on the radar.

Every time I've wondered how prompts were produced, I've ended up rather confused. So this is an attempt at cleaning it up, with a new `PromptManager` class responsible for handling everything to do with the prompts. The critical part is its `render` method, which assembles the necessary information, then uses the string formatting introduced in Python 2.6 to fill in the prompt template.

I've expanded the definition of 'prompts' to include the auto_rewrite prompt (`"------> "` by default). So there are now four prompts: input, continuation, output, and rewrite.

This definition of prompts does not include input/output separators. For now, I've left those as attributes of the main InteractiveShell object.
