### PR TITLE
i508

### DIFF
--- a/IPython/zmq/pykernel.py
+++ b/IPython/zmq/pykernel.py
@@ -174,13 +174,11 @@ class Kernel(HasTraits):
 
     def _abort_queue(self):
         while True:
-            try:
-                ident,msg = self.session.recv(self.reply_socket, zmq.NOBLOCK)
-            except zmq.ZMQError, e:
-                if e.errno == zmq.EAGAIN:
-                    break
+            ident,msg = self.session.recv(self.reply_socket, zmq.NOBLOCK)
+            if msg is None:
+                break
             else:
-                assert ident is not None, "Missing message part."
+                assert ident is not None, "Unexpected missing message part."
             print>>sys.__stdout__, "Aborting:"
             print>>sys.__stdout__, Message(msg)
             msg_type = msg['msg_type']


### PR DESCRIPTION
Properly handle nothing to recv in pykernel._abort_queue

Fixes #508

The symptom of nothing to recv changed a while ago, but pykernel's abort_queue method was not updated.

This is yet another reason why pykernel and ipkernel should share a parent class - there is _huge_ code duplication, and changes must be made twice and are often missed.
