### PR TITLE
Add a new line before displaying multiline strings in the Qt console.

### DIFF
--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -184,6 +184,10 @@ class IPythonWidget(FrontendWidget):
                 self._append_plain_text(self.output_sep)
                 self._append_html(self._make_out_prompt(prompt_number))
                 text = data['text/plain']
+                # If the repr is multiline, make sure we start on a new line,
+                # so that its lines are aligned.
+                if "\n" in text and not self.output_sep.endswith("\n"):
+                    self._append_plain_text('\n')
                 self._append_plain_text(text + self.output_sep2)
 
     def _handle_display_data(self, msg):


### PR DESCRIPTION
This is more or less copied from the code used by terminal IPython, in IPython/core/displayhook.py, line 230.

Closes gh-510
