### PR TITLE
Handle asynchronous output in Qt console

### DIFF
--- a/IPython/frontend/qt/console/frontend_widget.py
+++ b/IPython/frontend/qt/console/frontend_widget.py
@@ -22,8 +22,7 @@ from pygments_highlighter import PygmentsHighlighter
 
 
 class FrontendHighlighter(PygmentsHighlighter):
-    """ A PygmentsHighlighter that can be turned on and off and that ignores
-        prompts.
+    """ A PygmentsHighlighter that understands and ignores prompts.
     """
 
     def __init__(self, frontend):
@@ -50,14 +49,12 @@ class FrontendHighlighter(PygmentsHighlighter):
         else:
             prompt = self._frontend._continuation_prompt
 
-        # Don't highlight the part of the string that contains the prompt.
+        # Only highlight if we can identify a prompt, but make sure not to
+        # highlight the prompt.
         if string.startswith(prompt):
             self._current_offset = len(prompt)
             string = string[len(prompt):]
-        else:
-            self._current_offset = 0
-
-        PygmentsHighlighter.highlightBlock(self, string)
+            super(FrontendHighlighter, self).highlightBlock(string)
 
     def rehighlightBlock(self, block):
         """ Reimplemented to temporarily enable highlighting if disabled.
@@ -71,7 +68,7 @@ class FrontendHighlighter(PygmentsHighlighter):
         """ Reimplemented to highlight selectively.
         """
         start += self._current_offset
-        PygmentsHighlighter.setFormat(self, start, count, format)
+        super(FrontendHighlighter, self).setFormat(start, count, format)
 
 
 class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):

--- a/IPython/frontend/qt/console/frontend_widget.py
+++ b/IPython/frontend/qt/console/frontend_widget.py
@@ -372,14 +372,8 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         """ Handle display hook output.
         """
         if not self._hidden and self._is_from_this_session(msg):
-            data = msg['content']['data']
-            if isinstance(data, basestring):
-                # plaintext data from pure Python kernel
-                text = data
-            else:
-                # formatted output from DisplayFormatter (IPython kernel)
-                text = data.get('text/plain', '')
-            self._append_plain_text(text + '\n')
+            text = msg['content']['data']
+            self._append_plain_text(text + '\n', before_prompt=True)
 
     def _handle_stream(self, msg):
         """ Handle stdout, stderr, and stdin.
@@ -390,7 +384,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
             # widget's tab width.
             text = msg['content']['data'].expandtabs(8)
             
-            self._append_plain_text(text)
+            self._append_plain_text(text, before_prompt=True)
             self._control.moveCursor(QtGui.QTextCursor.End)
 
     def _handle_shutdown_reply(self, msg):

--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -62,16 +62,16 @@ class IPythonWidget(FrontendWidget):
     editor = Unicode(default_editor, config=True,
         help="""
         A command for invoking a system text editor. If the string contains a
-        {filename} format specifier, it will be used. Otherwise, the filename will
-        be appended to the end the command.
+        {filename} format specifier, it will be used. Otherwise, the filename
+        will be appended to the end the command.
         """)
 
     editor_line = Unicode(config=True,
         help="""
         The editor command to use when a specific line number is requested. The
         string should contain two format specifiers: {line} and {filename}. If
-        this parameter is not specified, the line number option to the %edit magic
-        will be ignored.
+        this parameter is not specified, the line number option to the %edit
+        magic will be ignored.
         """)
 
     style_sheet = Unicode(config=True,
@@ -85,8 +85,9 @@ class IPythonWidget(FrontendWidget):
 
     syntax_style = Str(config=True,
         help="""
-        If not empty, use this Pygments style for syntax highlighting. Otherwise,
-        the style sheet is queried for Pygments style information.
+        If not empty, use this Pygments style for syntax highlighting.
+        Otherwise, the style sheet is queried for Pygments style
+        information.
         """)
 
     # Prompts.
@@ -187,20 +188,20 @@ class IPythonWidget(FrontendWidget):
             prompt_number = content['execution_count']
             data = content['data']
             if data.has_key('text/html'):
-                self._append_plain_text(self.output_sep)
-                self._append_html(self._make_out_prompt(prompt_number))
+                self._append_plain_text(self.output_sep, True)
+                self._append_html(self._make_out_prompt(prompt_number), True)
                 html = data['text/html']
-                self._append_plain_text('\n')
-                self._append_html(html + self.output_sep2)
+                self._append_plain_text('\n', True)
+                self._append_html(html + self.output_sep2, True)
             elif data.has_key('text/plain'):
-                self._append_plain_text(self.output_sep)
-                self._append_html(self._make_out_prompt(prompt_number))
+                self._append_plain_text(self.output_sep, True)
+                self._append_html(self._make_out_prompt(prompt_number), True)
                 text = data['text/plain']
                 # If the repr is multiline, make sure we start on a new line,
                 # so that its lines are aligned.
                 if "\n" in text and not self.output_sep.endswith("\n"):
-                    self._append_plain_text('\n')
-                self._append_plain_text(text + self.output_sep2)
+                    self._append_plain_text('\n', True)
+                self._append_plain_text(text + self.output_sep2, True)
 
     def _handle_display_data(self, msg):
         """ The base handler for the ``display_data`` message.
@@ -216,19 +217,19 @@ class IPythonWidget(FrontendWidget):
             # representation.
             if data.has_key('text/html'):
                 html = data['text/html']
-                self._append_html(html)
+                self._append_html(html, before_prompt=True)
             elif data.has_key('text/plain'):
                 text = data['text/plain']
-                self._append_plain_text(text)
+                self._append_plain_text(text, before_prompt=True)
             # This newline seems to be needed for text and html output.
-            self._append_plain_text(u'\n')
+            self._append_plain_text(u'\n', before_prompt=True)
 
     def _started_channels(self):
         """ Reimplemented to make a history request.
         """
         super(IPythonWidget, self)._started_channels()
-        self.kernel_manager.shell_channel.history(hist_access_type='tail', n=1000)
-
+        self.kernel_manager.shell_channel.history(hist_access_type='tail',
+                                                  n=1000)
     #---------------------------------------------------------------------------
     # 'ConsoleWidget' public interface
     #---------------------------------------------------------------------------
@@ -413,8 +414,8 @@ class IPythonWidget(FrontendWidget):
             self.custom_edit_requested.emit(filename, line)
         elif not self.editor:
             self._append_plain_text('No default editor available.\n'
-            'Specify a GUI text editor in the `IPythonWidget.editor` configurable\n'
-            'to enable the %edit magic')
+            'Specify a GUI text editor in the `IPythonWidget.editor` '
+            'configurable to enable the %edit magic')
         else:
             try:
                 filename = '"%s"' % filename

--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -217,12 +217,12 @@ class IPythonWidget(FrontendWidget):
             # representation.
             if data.has_key('text/html'):
                 html = data['text/html']
-                self._append_html(html, before_prompt=True)
+                self._append_html(html, True)
             elif data.has_key('text/plain'):
                 text = data['text/plain']
-                self._append_plain_text(text, before_prompt=True)
+                self._append_plain_text(text, True)
             # This newline seems to be needed for text and html output.
-            self._append_plain_text(u'\n', before_prompt=True)
+            self._append_plain_text(u'\n', True)
 
     def _started_channels(self):
         """ Reimplemented to make a history request.


### PR DESCRIPTION
This is my first cut at having the Qt console place post-execution output before the current prompt. It seems to work based on my testing with threads that print text, although the formatting is sometimes imperfect due to the kernel's buffering. Still, it's an improvement, I think.

This addresses issue #476.
