### PR TITLE
ZMQ displayhook

### DIFF
--- a/IPython/parallel/engine/engine.py
+++ b/IPython/parallel/engine/engine.py
@@ -41,9 +41,9 @@ class EngineFactory(RegistrationFactory):
     out_stream_factory=Type('IPython.zmq.iostream.OutStream', config=True,
         help="""The OutStream for handling stdout/err.
         Typically 'IPython.zmq.iostream.OutStream'""")
-    display_hook_factory=Type('IPython.zmq.displayhook.DisplayHook', config=True,
+    display_hook_factory=Type('IPython.zmq.displayhook.ZMQDisplayHook', config=True,
         help="""The class for handling displayhook.
-        Typically 'IPython.zmq.displayhook.DisplayHook'""")
+        Typically 'IPython.zmq.displayhook.ZMQDisplayHook'""")
     location=Unicode(config=True,
         help="""The location (an IP address) of the controller.  This is
         used for disambiguating URLs, to determine whether

--- a/IPython/zmq/displayhook.py
+++ b/IPython/zmq/displayhook.py
@@ -1,9 +1,13 @@
 import __builtin__
+from base64 import encodestring
 
-from session import extract_header
+from IPython.core.displayhook import DisplayHook
+from IPython.utils.traitlets import Instance, Dict
+from session import extract_header, Session
 
-class DisplayHook(object):
-
+class ZMQDisplayHook(object):
+    """A simple displayhook that publishes the object's repr over a ZeroMQ
+    socket."""
     topic=None
 
     def __init__(self, session, pub_socket):
@@ -21,3 +25,40 @@ class DisplayHook(object):
 
     def set_parent(self, parent):
         self.parent_header = extract_header(parent)
+
+
+def _encode_png(data):
+    pngdata = data.get('image/png')
+    if pngdata is not None:
+        data['image/png'] = encodestring(pngdata)
+
+class ZMQShellDisplayHook(DisplayHook):
+    """A displayhook subclass that publishes data using ZeroMQ. This is intended
+    to work with an InteractiveShell instance. It sends a dict of different
+    representations of the object."""
+
+    session = Instance(Session)
+    pub_socket = Instance('zmq.Socket')
+    parent_header = Dict({})
+
+    def set_parent(self, parent):
+        """Set the parent for outbound messages."""
+        self.parent_header = extract_header(parent)
+
+    def start_displayhook(self):
+        self.msg = self.session.msg(u'pyout', {}, parent=self.parent_header)
+
+    def write_output_prompt(self):
+        """Write the output prompt."""
+        if self.do_full_cache:
+            self.msg['content']['execution_count'] = self.prompt_count
+
+    def write_format_data(self, format_dict):
+        pngdata = format_dict.get('image/png')
+        _encode_png(format_dict)
+        self.msg['content']['data'] = format_dict
+
+    def finish_displayhook(self):
+        """Finish up all displayhook activities."""
+        self.session.send(self.pub_socket, self.msg)
+        self.msg = None

--- a/IPython/zmq/entry_point.py
+++ b/IPython/zmq/entry_point.py
@@ -13,7 +13,6 @@ import sys
 from parentpoller import ParentPollerWindows
 
 
-
 def base_launch_kernel(code, shell_port=0, iopub_port=0, stdin_port=0, hb_port=0,
                         ip=None, stdin=None, stdout=None, stderr=None,
                         executable=None, independent=False, extra_arguments=[]):

--- a/IPython/zmq/kernelapp.py
+++ b/IPython/zmq/kernelapp.py
@@ -95,7 +95,7 @@ class KernelApp(BaseIPythonApplication):
     no_stderr = Bool(False, config=True, help="redirect stderr to the null device")
     outstream_class = Unicode('IPython.zmq.iostream.OutStream', config=True,
         help="The importstring for the OutStream factory")
-    displayhook_class = Unicode('IPython.zmq.displayhook.DisplayHook', config=True,
+    displayhook_class = Unicode('IPython.zmq.displayhook.ZMQDisplayHook', config=True,
         help="The importstring for the DisplayHook factory")
 
     # polling

--- a/IPython/zmq/zmqshell.py
+++ b/IPython/zmq/zmqshell.py
@@ -33,7 +33,7 @@ from IPython.utils import io
 from IPython.utils.path import get_py_filename
 from IPython.utils.traitlets import Instance, Type, Dict
 from IPython.utils.warn import warn
-from IPython.zmq.displayhook import ZMQShellDisplayHook
+from IPython.zmq.displayhook import ZMQShellDisplayHook, _encode_png
 from IPython.zmq.session import extract_header
 from session import Session
 

--- a/IPython/zmq/zmqshell.py
+++ b/IPython/zmq/zmqshell.py
@@ -16,7 +16,6 @@ machinery.  This should thus be thought of as scaffolding.
 from __future__ import print_function
 
 # Stdlib
-from base64 import encodestring
 import inspect
 import os
 
@@ -26,7 +25,6 @@ from IPython.core.interactiveshell import (
 )
 from IPython.core import page
 from IPython.core.autocall import ZMQExitAutocall
-from IPython.core.displayhook import DisplayHook
 from IPython.core.displaypub import DisplayPublisher
 from IPython.core.macro import Macro
 from IPython.core.magic import MacroToEdit
@@ -35,6 +33,7 @@ from IPython.utils import io
 from IPython.utils.path import get_py_filename
 from IPython.utils.traitlets import Instance, Type, Dict
 from IPython.utils.warn import warn
+from IPython.zmq.displayhook import ZMQShellDisplayHook
 from IPython.zmq.session import extract_header
 from session import Session
 
@@ -48,42 +47,6 @@ install_payload_page()
 #-----------------------------------------------------------------------------
 # Functions and classes
 #-----------------------------------------------------------------------------
-
-def _encode_png(data):
-    pngdata = data.get('image/png')
-    if pngdata is not None:
-        data['image/png'] = encodestring(pngdata)
-
-
-class ZMQDisplayHook(DisplayHook):
-    """A displayhook subclass that publishes data using ZeroMQ."""
-
-    session = Instance(Session)
-    pub_socket = Instance('zmq.Socket')
-    parent_header = Dict({})
-
-    def set_parent(self, parent):
-        """Set the parent for outbound messages."""
-        self.parent_header = extract_header(parent)
-
-    def start_displayhook(self):
-        self.msg = self.session.msg(u'pyout', {}, parent=self.parent_header)
-
-    def write_output_prompt(self):
-        """Write the output prompt."""
-        if self.do_full_cache:
-            self.msg['content']['execution_count'] = self.prompt_count
-
-    def write_format_data(self, format_dict):
-        pngdata = format_dict.get('image/png')
-        _encode_png(format_dict)
-        self.msg['content']['data'] = format_dict
-
-    def finish_displayhook(self):
-        """Finish up all displayhook activities."""
-        self.session.send(self.pub_socket, self.msg)
-        self.msg = None
-
 
 class ZMQDisplayPublisher(DisplayPublisher):
     """A display publisher that publishes data using a ZeroMQ PUB socket."""
@@ -114,7 +77,7 @@ class ZMQDisplayPublisher(DisplayPublisher):
 class ZMQInteractiveShell(InteractiveShell):
     """A subclass of InteractiveShell for ZMQ."""
 
-    displayhook_class = Type(ZMQDisplayHook)
+    displayhook_class = Type(ZMQShellDisplayHook)
     display_pub_class = Type(ZMQDisplayPublisher)
     
     exiter = Instance(ZMQExitAutocall)


### PR DESCRIPTION
Move displayhook for ZMQ shell to zmq.displayhook, and rename to make the difference clearer.

Straightforward tidying up. Because I went looking for the displayhook used by ZMQInteractiveShell, and spent a while changing the wrong one before I worked out that it was in zmqshell.py. This puts them both in zmq.displayhook, and attempts to clarify the difference.

See #512
