### PR TITLE
Do not import deprecated functions from external decorators library.

### DIFF
--- a/IPython/external/decorator/__init__.py
+++ b/IPython/external/decorator/__init__.py
@@ -1,8 +1,4 @@
 try:
     from decorator import *
-    from decorator import getinfo, new_wrapper
-    # the following funcion is deprecated so using the python own one
-    from functools import update_wrapper
 except ImportError:
     from _decorator import *
-    from _decorator import getinfo, update_wrapper, new_wrapper

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -56,7 +56,7 @@ import unittest
 # Third-party imports
 
 # This is Michele Simionato's decorator module, kept verbatim.
-from IPython.external.decorator import decorator, update_wrapper
+from IPython.external.decorator import decorator
 
 # We already have python3-compliant code for parametric tests
 if sys.version[0]=='2':


### PR DESCRIPTION
We weren't using these functions anyway, and they've "been deprecated for years" according to the library's docs. I'll merge tomorrow unless anyone objects.

Closes gh-470
