### PR TITLE
Fix Parallel test

### DIFF
--- a/IPython/parallel/tests/__init__.py
+++ b/IPython/parallel/tests/__init__.py
@@ -51,7 +51,7 @@ def setup():
                 ['profile=iptest', 'log_level=50', '--reuse']
     cp.start()
     launchers.append(cp)
-    cluster_dir = os.path.join(get_ipython_dir(), 'cluster_iptest')
+    cluster_dir = os.path.join(get_ipython_dir(), 'profile_iptest')
     engine_json = os.path.join(cluster_dir, 'security', 'ipcontroller-engine.json')
     client_json = os.path.join(cluster_dir, 'security', 'ipcontroller-client.json')
     tic = time.time()


### PR DESCRIPTION
When running the parallel part of iptest the test fails as it looks for json files in the cluster_iptest folder.
The folder was changed in SHA: 42b88168572d34084e4c. However it only fails if the cluster_iptest dir is not 
present from a previous installations. I.e when deleting the config/.ipython dir or doing a clean install.  
This pull request should make the test look in the correct dir.
