### PR TITLE
fix various tests on Windows

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2832,10 +2832,13 @@ Defaulting color scheme to 'NoColor'"""
                     if opts.has_key('b'):
                         raise UsageError("Bookmark '%s' not found.  "
                               "Use '%%bookmark -l' to see your bookmarks." % ps)
-            
+
+        # strip extra quotes on Windows, because os.chdir doesn't like them
+        if sys.platform == 'win32':
+            ps = ps.strip('\'"')
         # at this point ps should point to the target dir
         if ps:
-            try:                
+            try:
                 os.chdir(os.path.expanduser(ps))
                 if hasattr(self.shell, 'term_title') and self.shell.term_title:
                     set_term_title('IPython: ' + abbrev_cwd())

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -301,8 +301,8 @@ def test_parse_options():
     
 def test_dirops():
     """Test various directory handling operations."""
-    curpath = lambda :os.path.splitdrive(os.getcwdu())[1].replace('\\','/')
-
+    # curpath = lambda :os.path.splitdrive(os.getcwdu())[1].replace('\\','/')
+    curpath = os.getcwdu
     startdir = os.getcwdu()
     ipdir = _ip.ipython_dir
     try:

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -101,7 +101,9 @@ def test_info():
     fname = __file__
     if fname.endswith(".pyc"):
         fname = fname[:-1]
-    nt.assert_equal(i['file'], fname)
+    # case-insensitive comparison needed on some filesystems
+    # e.g. Windows:
+    nt.assert_equal(i['file'].lower(), fname.lower())
     nt.assert_equal(i['definition'], 'Call(self, *a, **kw)\n')
     nt.assert_equal(i['docstring'], Call.__doc__)
     nt.assert_equal(i['source'], None)

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -17,6 +17,7 @@ import sys
 import tempfile
 
 import nose.tools as nt
+from nose import SkipTest
 
 from IPython.testing import decorators as dec
 from IPython.testing import tools as tt
@@ -156,7 +157,11 @@ class TestMagicRunSimple(tt.TempFileMixin):
 
     def test_obj_del(self):
         """Test that object's __del__ methods are called on exit."""
-        
+        if sys.platform == 'win32':
+            try:
+                import win32api
+            except ImportError:
+                raise SkipTest("Test requires pywin32")
         src = ("class A(object):\n"
                "    def __del__(self):\n"
                "        print 'object A deleted'\n"

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -143,6 +143,7 @@ def test_get_home_dir_3():
 
 
 @with_environment
+@skip_win32
 def test_get_home_dir_4():
     """Testcase $HOME is not set, os=='posix'. 
     This should fail with HomeDirError"""
@@ -227,9 +228,10 @@ def test_get_home_dir_8():
 @with_environment
 def test_get_ipython_dir_1():
     """test_get_ipython_dir_1, Testcase to see if we can call get_ipython_dir without Exceptions."""
-    env['IPYTHON_DIR'] = "someplace/.ipython"
+    env_ipdir = os.path.join("someplace", ".ipython")
+    env['IPYTHON_DIR'] = env_ipdir
     ipdir = path.get_ipython_dir()
-    nt.assert_equal(ipdir, "someplace/.ipython")
+    nt.assert_equal(ipdir, env_ipdir)
 
 
 @with_environment
@@ -293,8 +295,8 @@ def test_get_ipython_dir_6():
 @with_environment
 def test_get_ipython_dir_7():
     """test_get_ipython_dir_7, test home directory expansion on IPYTHON_DIR"""
-    home_dir = os.path.expanduser('~/')
-    env['IPYTHON_DIR'] = '~/somewhere'
+    home_dir = os.path.expanduser('~')
+    env['IPYTHON_DIR'] = os.path.join('~', 'somewhere')
     ipdir = path.get_ipython_dir()
     nt.assert_equal(ipdir, os.path.join(home_dir, 'somewhere'))
 


### PR DESCRIPTION
Windows had a variety of mostly path-related test failures remaining. With these changes, I have zero failures or errors when I run the test suite on my Windows 7 VM (64b Python 2.7.1).

Most of these were Windows-excluding assumptions in the tests themselves.  The one change to the code itself is stripping quotation marks on Windows in `magic_cd`.  `os.chdir` doesn't seem to like the quotes on Windows in some cases.

Absolute-path completions are now listed as a Known Failure on Windows.  A local-path test that is a copy but wrapped in a cd so the prefix is './foo' instead of 'C:\...\foo' shows that the completion does work for relative paths.
