### PR TITLE
issue 440

### DIFF
--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -161,7 +161,12 @@ class Application(SingletonConfigurable):
         """
         self.log = logging.getLogger(self.__class__.__name__)
         self.log.setLevel(self.log_level)
-        self._log_handler = logging.StreamHandler()
+        if sys.executable.endswith('pythonw.exe'):
+            # this should really go to a file, but file-logging is only
+            # hooked up in parallel applications
+            self._log_handler = logging.StreamHandler(open(os.devnull, 'w'))
+        else:
+            self._log_handler = logging.StreamHandler()
         self._log_formatter = logging.Formatter("[%(name)s] %(message)s")
         self._log_handler.setFormatter(self._log_formatter)
         self.log.addHandler(self._log_handler)

--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -68,7 +68,8 @@ def shlex_split(x):
 
     # shlex.split has unicode bugs, so encode first to str
     if isinstance(x, unicode):
-        x = x.encode(sys.stdin.encoding)
+        # don't raise errors on encoding:
+        x = x.encode(sys.stdin.encoding or sys.getdefaultencoding(), 'replace')
 
     endofline = []
     while x != '':

--- a/IPython/zmq/kernelapp.py
+++ b/IPython/zmq/kernelapp.py
@@ -166,18 +166,17 @@ class KernelApp(BaseIPythonApplication):
         """create our session object"""
         self.session = Session(config=self.config, username=u'kernel')
 
-    def init_io(self):
-        """redirects stdout/stderr, and installs a display hook"""
-        # Re-direct stdout/stderr, if necessary.
+    def init_blackhole(self):
+        """redirects stdout/stderr to devnull if necessary"""
         if self.no_stdout or self.no_stderr:
             blackhole = file(os.devnull, 'w')
             if self.no_stdout:
                 sys.stdout = sys.__stdout__ = blackhole
             if self.no_stderr:
                 sys.stderr = sys.__stderr__ = blackhole
-
-        # Redirect input streams and set a display hook.
-
+    
+    def init_io(self):
+        """Redirect input streams and set a display hook."""
         if self.outstream_class:
             outstream_factory = import_item(str(self.outstream_class))
             sys.stdout = outstream_factory(self.session, self.iopub_socket, u'stdout')
@@ -199,6 +198,7 @@ class KernelApp(BaseIPythonApplication):
 
     def initialize(self, argv=None):
         super(KernelApp, self).initialize(argv)
+        self.init_blackhole()
         self.init_session()
         self.init_poller()
         self.init_sockets()


### PR DESCRIPTION
this should resolve #440

The `run <tab>` crash in the qtconsole was caused by another uncaught `sys.stdin.encoding`, which is `None` when there is no Terminal.

The remaining fixes prevent logging from being hooked up to stderr when under pythonw.exe, which prevented the kernel from starting.
