### PR TITLE
Fix sympy profile to work with sympy 0.7.

### DIFF
--- a/IPython/config/profile/sympy/ipython_config.py
+++ b/IPython/config/profile/sympy/ipython_config.py
@@ -8,8 +8,8 @@ load_subconfig('ipython_config.py', profile='default')
 lines = """
 from __future__ import division
 from sympy import *
-x, y, z = symbols('xyz')
-k, m, n = symbols('kmn', integer=True)
+x, y, z = symbols('x,y,z')
+k, m, n = symbols('k,m,n', integer=True)
 f, g, h = map(Function, 'fgh')
 """
 


### PR DESCRIPTION
Sympy 0.7 no longer supports x,y,z = symbols('xyz').
symbols ('xyz') is now a single symbol 'xyz'.

This changes the sympy profile to use symbols(x,y,z) instead.
I have tested that this also works using sympy 0.6.7
