### PR TITLE
Make pylab import all configurable

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2416,7 +2416,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
     # Things related to GUI support and pylab
     #-------------------------------------------------------------------------
 
-    def enable_pylab(self, gui=None):
+    def enable_pylab(self, gui=None, inport_all=True):
         raise NotImplementedError('Implement enable_pylab in a subclass')
 
     #-------------------------------------------------------------------------

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -417,7 +417,7 @@ class TerminalInteractiveShell(InteractiveShell):
     # Things related to GUI support and pylab
     #-------------------------------------------------------------------------
 
-    def enable_pylab(self, gui=None):
+    def enable_pylab(self, gui=None, import_all=True):
         """Activate pylab support at runtime.
 
         This turns on support for matplotlib, preloads into the interactive
@@ -440,7 +440,7 @@ class TerminalInteractiveShell(InteractiveShell):
         # code in an empty namespace, and we update *both* user_ns and
         # user_ns_hidden with this information.
         ns = {}
-        gui = pylab_activate(ns, gui)
+        gui = pylab_activate(ns, gui, import_all)
         self.user_ns.update(ns)
         self.user_ns_hidden.update(ns)
         # Now we must activate the gui pylab wants to use, and fix %run to take

--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -232,6 +232,10 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
         selecting a particular matplotlib backend and loop integration.
         """
     )
+    pylab_import_all = Bool(True, config=True,
+        help="""If true, an 'import *' is done from numpy and pylab,
+        when using pylab"""
+    )
     display_banner = Bool(True, config=True,
         help="Whether to display a banner upon starting IPython."
     )
@@ -343,7 +347,10 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
             try:
                 self.log.info("Enabling GUI event loop integration, "
                               "toolkit=%s, pylab=%s" % (gui, self.pylab) )
-                activate(gui)
+                if self.pylab:
+                    activate(gui, import_all=self.pylab_import_all)
+                else:
+                    activate(gui)
             except:
                 self.log.warn("Error in enabling GUI event loop integration:")
                 self.shell.showtraceback()

--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -186,6 +186,7 @@ aliases.update(shell_aliases)
 aliases.update(dict(
     gui='TerminalIPythonApp.gui',
     pylab='TerminalIPythonApp.pylab',
+    pylab_import_all='TerminalIPythonApp.pylab_import_all',
 ))
 
 #-----------------------------------------------------------------------------

--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -178,6 +178,11 @@ flags['pylab'] = (
     """Pre-load matplotlib and numpy for interactive use with
     the default matplotlib backend."""
 )
+flags['no-pylab-import-all'] = (
+    {'TerminalIPythonApp' : {'pylab_import_all' : False}},
+    """Don't 'import *' from numpy and pylab,
+        when using pylab."""
+)
 
 aliases = dict(base_aliases)
 aliases.update(shell_aliases)

--- a/IPython/lib/pylabtools.py
+++ b/IPython/lib/pylabtools.py
@@ -311,7 +311,7 @@ def pylab_activate(user_ns, gui=None, import_all=True):
     """
     gui, backend = find_gui_and_backend(gui)
     activate_matplotlib(backend)
-    import_pylab(user_ns, backend)
+    import_pylab(user_ns, backend, import_all)
 
     print """
 Welcome to pylab, a matplotlib-based Python environment [backend: %s].

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -598,6 +598,10 @@ class IPKernelApp(KernelApp, InteractiveShellApp):
         selecting a particular matplotlib backend and loop integration.
         """
     )
+    pylab_import_all = Bool(True, config=True,
+        help="""If true, an 'import *' is done from numpy and pylab,
+        when using pylab"""
+    )
     def initialize(self, argv=None):
         super(IPKernelApp, self).initialize(argv)
         self.init_shell()
@@ -635,7 +639,8 @@ class IPKernelApp(KernelApp, InteractiveShellApp):
         kernel.record_ports(self.ports)
 
         if self.pylab:
-            pylabtools.import_pylab(kernel.shell.user_ns, backend,
+            import_all = self.pylab_import_all
+            pylabtools.import_pylab(kernel.shell.user_ns, backend, import_all,
                                     shell=kernel.shell)
     
     def init_shell(self):

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -579,6 +579,7 @@ aliases.update(shell_aliases)
 # it's possible we don't want short aliases for *all* of these:
 aliases.update(dict(
     pylab='IPKernelApp.pylab',
+    pylab_import_all='IPKernelApp.pylab_import_all',
 ))
 
 #-----------------------------------------------------------------------------

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -572,6 +572,11 @@ flags['pylab'] = (
     """Pre-load matplotlib and numpy for interactive use with
     the default matplotlib backend."""
 )
+flags['no-pylab-import-all'] = (
+    {'IPKernelApp' : {'pylab_import_all' : False}},
+    """Don't 'import *' from numpy and pylab,
+        when using pylab."""
+)
 
 aliases = dict(kernel_aliases)
 aliases.update(shell_aliases)


### PR DESCRIPTION
The import all option for pylab is not configurable with newapp.
I have now made this configurable in both terminal qtconsole,
however I haven't touched the pylab magic. 
