### PR TITLE
update parallel code for py3k

### DIFF
--- a/IPython/config/tests/test_loader.py
+++ b/IPython/config/tests/test_loader.py
@@ -21,8 +21,11 @@ Authors:
 #-----------------------------------------------------------------------------
 
 import os
+import sys
 from tempfile import mkstemp
 from unittest import TestCase
+
+from nose import SkipTest
 
 from IPython.utils.traitlets import Int, Unicode
 from IPython.config.configurable import Configurable
@@ -130,6 +133,23 @@ class TestKeyValueCL(TestCase):
         self.assertEquals(cl.extra_args, ['b', 'd'])
         self.assertEquals(config.a, 5)
         self.assertEquals(config.c, 10)
+    
+    def test_unicode_args(self):
+        cl = KeyValueConfigLoader()
+        argv = [u'a=épsîlön']
+        config = cl.load_config(argv)
+        self.assertEquals(config.a, u'épsîlön')
+    
+    def test_unicode_bytes_args(self):
+        uarg = u'a=é'
+        try:
+            barg = uarg.encode(sys.stdin.encoding)
+        except (TypeError, UnicodeEncodeError):
+            raise SkipTest("sys.stdin.encoding can't handle 'é'")
+        
+        cl = KeyValueConfigLoader()
+        config = cl.load_config([barg])
+        self.assertEquals(config.a, u'é')
 
 
 class TestConfig(TestCase):

--- a/IPython/parallel/apps/ipcontrollerapp.py
+++ b/IPython/parallel/apps/ipcontrollerapp.py
@@ -54,7 +54,7 @@ from IPython.parallel.controller.hub import HubFactory
 from IPython.parallel.controller.scheduler import TaskScheduler,launch_scheduler
 from IPython.parallel.controller.sqlitedb import SQLiteDB
 
-from IPython.parallel.util import signal_children, split_url, ensure_bytes
+from IPython.parallel.util import signal_children, split_url, asbytes
 
 # conditional import of MongoDB backend class
 
@@ -202,7 +202,7 @@ class IPControllerApp(BaseParallelApplication):
         # load from engine config
         with open(os.path.join(self.profile_dir.security_dir, 'ipcontroller-engine.json')) as f:
             cfg = json.loads(f.read())
-        key = c.Session.key = ensure_bytes(cfg['exec_key'])
+        key = c.Session.key = asbytes(cfg['exec_key'])
         xport,addr = cfg['url'].split('://')
         c.HubFactory.engine_transport = xport
         ip,ports = addr.split(':')
@@ -239,7 +239,7 @@ class IPControllerApp(BaseParallelApplication):
             # with open(keyfile, 'w') as f:
             #     f.write(key)
             # os.chmod(keyfile, stat.S_IRUSR|stat.S_IWUSR)
-            c.Session.key = ensure_bytes(key)
+            c.Session.key = asbytes(key)
         else:
             key = c.Session.key = b''
         

--- a/IPython/parallel/apps/ipcontrollerapp.py
+++ b/IPython/parallel/apps/ipcontrollerapp.py
@@ -54,7 +54,7 @@ from IPython.parallel.controller.hub import HubFactory
 from IPython.parallel.controller.scheduler import TaskScheduler,launch_scheduler
 from IPython.parallel.controller.sqlitedb import SQLiteDB
 
-from IPython.parallel.util import signal_children, split_url
+from IPython.parallel.util import signal_children, split_url, ensure_bytes
 
 # conditional import of MongoDB backend class
 
@@ -202,14 +202,13 @@ class IPControllerApp(BaseParallelApplication):
         # load from engine config
         with open(os.path.join(self.profile_dir.security_dir, 'ipcontroller-engine.json')) as f:
             cfg = json.loads(f.read())
-        key = c.Session.key = cfg['exec_key']
+        key = c.Session.key = ensure_bytes(cfg['exec_key'])
         xport,addr = cfg['url'].split('://')
         c.HubFactory.engine_transport = xport
         ip,ports = addr.split(':')
         c.HubFactory.engine_ip = ip
         c.HubFactory.regport = int(ports)
         self.location = cfg['location']
-        
         # load client config
         with open(os.path.join(self.profile_dir.security_dir, 'ipcontroller-client.json')) as f:
             cfg = json.loads(f.read())
@@ -240,9 +239,9 @@ class IPControllerApp(BaseParallelApplication):
             # with open(keyfile, 'w') as f:
             #     f.write(key)
             # os.chmod(keyfile, stat.S_IRUSR|stat.S_IWUSR)
-            c.Session.key = key
+            c.Session.key = ensure_bytes(key)
         else:
-            key = c.Session.key = ''
+            key = c.Session.key = b''
         
         try:
             self.factory = HubFactory(config=c, log=self.log)
@@ -273,27 +272,27 @@ class IPControllerApp(BaseParallelApplication):
         hub = self.factory
         # maybe_inproc = 'inproc://monitor' if self.use_threads else self.monitor_url
         # IOPub relay (in a Process)
-        q = mq(zmq.PUB, zmq.SUB, zmq.PUB, 'N/A','iopub')
+        q = mq(zmq.PUB, zmq.SUB, zmq.PUB, b'N/A',b'iopub')
         q.bind_in(hub.client_info['iopub'])
         q.bind_out(hub.engine_info['iopub'])
-        q.setsockopt_out(zmq.SUBSCRIBE, '')
+        q.setsockopt_out(zmq.SUBSCRIBE, b'')
         q.connect_mon(hub.monitor_url)
         q.daemon=True
         children.append(q)
 
         # Multiplexer Queue (in a Process)
-        q = mq(zmq.XREP, zmq.XREP, zmq.PUB, 'in', 'out')
+        q = mq(zmq.XREP, zmq.XREP, zmq.PUB, b'in', b'out')
         q.bind_in(hub.client_info['mux'])
-        q.setsockopt_in(zmq.IDENTITY, 'mux')
+        q.setsockopt_in(zmq.IDENTITY, b'mux')
         q.bind_out(hub.engine_info['mux'])
         q.connect_mon(hub.monitor_url)
         q.daemon=True
         children.append(q)
 
         # Control Queue (in a Process)
-        q = mq(zmq.XREP, zmq.XREP, zmq.PUB, 'incontrol', 'outcontrol')
+        q = mq(zmq.XREP, zmq.XREP, zmq.PUB, b'incontrol', b'outcontrol')
         q.bind_in(hub.client_info['control'])
-        q.setsockopt_in(zmq.IDENTITY, 'control')
+        q.setsockopt_in(zmq.IDENTITY, b'control')
         q.bind_out(hub.engine_info['control'])
         q.connect_mon(hub.monitor_url)
         q.daemon=True
@@ -305,10 +304,10 @@ class IPControllerApp(BaseParallelApplication):
         # Task Queue (in a Process)
         if scheme == 'pure':
             self.log.warn("task::using pure XREQ Task scheduler")
-            q = mq(zmq.XREP, zmq.XREQ, zmq.PUB, 'intask', 'outtask')
+            q = mq(zmq.XREP, zmq.XREQ, zmq.PUB, b'intask', b'outtask')
             # q.setsockopt_out(zmq.HWM, hub.hwm)
             q.bind_in(hub.client_info['task'][1])
-            q.setsockopt_in(zmq.IDENTITY, 'task')
+            q.setsockopt_in(zmq.IDENTITY, b'task')
             q.bind_out(hub.engine_info['task'])
             q.connect_mon(hub.monitor_url)
             q.daemon=True

--- a/IPython/parallel/apps/ipengineapp.py
+++ b/IPython/parallel/apps/ipengineapp.py
@@ -41,7 +41,7 @@ from IPython.config.configurable import Configurable
 from IPython.zmq.session import Session
 from IPython.parallel.engine.engine import EngineFactory
 from IPython.parallel.engine.streamkernel import Kernel
-from IPython.parallel.util import disambiguate_url, ensure_bytes
+from IPython.parallel.util import disambiguate_url, asbytes
 
 from IPython.utils.importstring import import_item
 from IPython.utils.traitlets import Bool, Unicode, Dict, List, Float
@@ -217,7 +217,7 @@ class IPEngineApp(BaseParallelApplication):
             with open(self.url_file) as f:
                 d = json.loads(f.read())
             if d['exec_key']:
-                config.Session.key = ensure_bytes(d['exec_key'])
+                config.Session.key = asbytes(d['exec_key'])
             d['url'] = disambiguate_url(d['url'], d['location'])
             config.EngineFactory.url = d['url']
             config.EngineFactory.location = d['location']

--- a/IPython/parallel/apps/ipengineapp.py
+++ b/IPython/parallel/apps/ipengineapp.py
@@ -41,7 +41,7 @@ from IPython.config.configurable import Configurable
 from IPython.zmq.session import Session
 from IPython.parallel.engine.engine import EngineFactory
 from IPython.parallel.engine.streamkernel import Kernel
-from IPython.parallel.util import disambiguate_url
+from IPython.parallel.util import disambiguate_url, ensure_bytes
 
 from IPython.utils.importstring import import_item
 from IPython.utils.traitlets import Bool, Unicode, Dict, List, Float
@@ -216,11 +216,8 @@ class IPEngineApp(BaseParallelApplication):
             self.log.info("Loading url_file %r"%self.url_file)
             with open(self.url_file) as f:
                 d = json.loads(f.read())
-                for k,v in d.iteritems():
-                    if isinstance(v, unicode):
-                        d[k] = v.encode()
             if d['exec_key']:
-                config.Session.key = d['exec_key']
+                config.Session.key = ensure_bytes(d['exec_key'])
             d['url'] = disambiguate_url(d['url'], d['location'])
             config.EngineFactory.url = d['url']
             config.EngineFactory.location = d['location']

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -50,7 +50,7 @@ from IPython.core.profiledir import ProfileDir, ProfileDirError
 from .view import DirectView, LoadBalancedView
 
 if sys.version_info[0] >= 3:
-    # xrange is used in a coupe 'isinstance' tests in py2
+    # xrange is used in a couple 'isinstance' tests in py2
     # should be just 'range' in 3k
     xrange = range
 
@@ -362,12 +362,12 @@ class Client(HasTraits):
             if os.path.isfile(exec_key):
                 extra_args['keyfile'] = exec_key
             else:
-                exec_key = util.ensure_bytes(exec_key)
+                exec_key = util.asbytes(exec_key)
                 extra_args['key'] = exec_key
         self.session = Session(**extra_args)
         
         self._query_socket = self._context.socket(zmq.XREQ)
-        self._query_socket.setsockopt(zmq.IDENTITY, util.ensure_bytes(self.session.session))
+        self._query_socket.setsockopt(zmq.IDENTITY, util.asbytes(self.session.session))
         if self._ssh:
             tunnel.tunnel_connection(self._query_socket, url, sshserver, **ssh_kwargs)
         else:
@@ -460,7 +460,7 @@ class Client(HasTraits):
         if not isinstance(targets, (tuple, list, xrange)):
             raise TypeError("targets by int/slice/collection of ints only, not %s"%(type(targets)))
             
-        return [util.ensure_bytes(self._engines[t]) for t in targets], list(targets)
+        return [util.asbytes(self._engines[t]) for t in targets], list(targets)
     
     def _connect(self, sshserver, ssh_kwargs, timeout):
         """setup all our socket connections to the cluster. This is called from
@@ -493,7 +493,7 @@ class Client(HasTraits):
         content = msg.content
         self._config['registration'] = dict(content)
         if content.status == 'ok':
-            ident = util.ensure_bytes(self.session.session)
+            ident = util.asbytes(self.session.session)
             if content.mux:
                 self._mux_socket = self._context.socket(zmq.XREQ)
                 self._mux_socket.setsockopt(zmq.IDENTITY, ident)

--- a/IPython/parallel/client/map.py
+++ b/IPython/parallel/client/map.py
@@ -13,8 +13,6 @@ Authors:
 
 """
 
-__docformat__ = "restructuredtext en"
-
 #-------------------------------------------------------------------------------
 #  Copyright (C) 2008-2011  The IPython Development Team
 #
@@ -25,6 +23,8 @@ __docformat__ = "restructuredtext en"
 #-------------------------------------------------------------------------------
 # Imports
 #-------------------------------------------------------------------------------
+
+from __future__ import division
 
 import types
 
@@ -67,7 +67,7 @@ class Map:
           return
           
         remainder = len(seq)%q
-        basesize = len(seq)/q
+        basesize = len(seq)//q
         hi = []
         lo = []
         for n in range(q):

--- a/IPython/parallel/client/remotefunction.py
+++ b/IPython/parallel/client/remotefunction.py
@@ -16,6 +16,8 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
+from __future__ import division
+
 import warnings
 
 from IPython.testing.skipdoctest import skip_doctest
@@ -142,7 +144,7 @@ class ParallelFunction(RemoteFunction):
         balanced = 'Balanced' in self.view.__class__.__name__
         if balanced:
             if self.chunksize:
-                nparts = len_0/self.chunksize + int(len_0%self.chunksize > 0)
+                nparts = len_0//self.chunksize + int(len_0%self.chunksize > 0)
             else:
                 nparts = len_0
             targets = [None]*nparts
@@ -169,7 +171,10 @@ class ParallelFunction(RemoteFunction):
             
             # print (args)
             if hasattr(self, '_map'):
-                f = map
+                if sys.version_info[0] >= 3:
+                    f = lambda f, *sequences: list(map(f, *sequences))
+                else:
+                    f = map
                 args = [self.func]+args
             else:
                 f=self.func

--- a/IPython/parallel/client/remotefunction.py
+++ b/IPython/parallel/client/remotefunction.py
@@ -18,6 +18,7 @@ Authors:
 
 from __future__ import division
 
+import sys
 import warnings
 
 from IPython.testing.skipdoctest import skip_doctest

--- a/IPython/parallel/client/view.py
+++ b/IPython/parallel/client/view.py
@@ -969,6 +969,8 @@ class LoadBalancedView(View):
             idents = []
         else:
             idents = self.client._build_targets(targets)[0]
+            # ensure *not* bytes
+            idents = [ ident.decode() for ident in idents ]
         
         after = self._render_dependency(after)
         follow = self._render_dependency(follow)

--- a/IPython/parallel/controller/heartmonitor.py
+++ b/IPython/parallel/controller/heartmonitor.py
@@ -46,7 +46,7 @@ class Heart(object):
         if in_type == zmq.SUB:
             self.device.setsockopt_in(zmq.SUBSCRIBE, b"")
         if heart_id is None:
-            heart_id = ensure_bytes(uuid.uuid4())
+            heart_id = uuid.uuid4().bytes
         self.device.setsockopt_out(zmq.IDENTITY, heart_id)
         self.id = heart_id
     

--- a/IPython/parallel/controller/heartmonitor.py
+++ b/IPython/parallel/controller/heartmonitor.py
@@ -25,7 +25,7 @@ from zmq.eventloop import ioloop, zmqstream
 from IPython.config.configurable import LoggingConfigurable
 from IPython.utils.traitlets import Set, Instance, CFloat
 
-from IPython.parallel.util import ensure_bytes
+from IPython.parallel.util import asbytes
 
 class Heart(object):
     """A basic heart object for responding to a HeartMonitor.
@@ -117,7 +117,7 @@ class HeartMonitor(LoggingConfigurable):
         self.responses = set()
         # print self.on_probation, self.hearts
         # self.log.debug("heartbeat::beat %.3f, %i beating hearts"%(self.lifetime, len(self.hearts)))
-        self.pingstream.send(ensure_bytes(str(self.lifetime)))
+        self.pingstream.send(asbytes(str(self.lifetime)))
     
     def handle_new_heart(self, heart):
         if self._new_handlers:
@@ -142,8 +142,8 @@ class HeartMonitor(LoggingConfigurable):
     
     def handle_pong(self, msg):
         "a heart just beat"
-        current = ensure_bytes(str(self.lifetime))
-        last = ensure_bytes(str(self.last_ping))
+        current = asbytes(str(self.lifetime))
+        last = asbytes(str(self.last_ping))
         if msg[1] == current:
             delta = time.time()-self.tic
             # self.log.debug("heartbeat::heart %r took %.2f ms to respond"%(msg[0], 1000*delta))

--- a/IPython/parallel/controller/hub.py
+++ b/IPython/parallel/controller/hub.py
@@ -563,8 +563,8 @@ class Hub(SessionFactory):
         record = init_record(msg)
         msg_id = record['msg_id']
         # Unicode in records
-        record['engine_uuid'] = queue_id.decode('utf8', 'replace')
-        record['client_uuid'] = client_id.decode('utf8', 'replace')
+        record['engine_uuid'] = queue_id.decode('ascii')
+        record['client_uuid'] = client_id.decode('ascii')
         record['queue'] = 'mux'
 
         try:
@@ -834,7 +834,7 @@ class Hub(SessionFactory):
         jsonable = {}
         for k,v in self.keytable.iteritems():
             if v not in self.dead_engines:
-                jsonable[str(k)] = v.decode()
+                jsonable[str(k)] = v.decode('ascii')
         content['engines'] = jsonable
         self.session.send(self.query, 'connection_reply', content, parent=msg, ident=client_id)
     

--- a/IPython/parallel/controller/hub.py
+++ b/IPython/parallel/controller/hub.py
@@ -289,7 +289,7 @@ class HubFactory(RegistrationFactory):
         # resubmit stream
         r = ZMQStream(ctx.socket(zmq.XREQ), loop)
         url = util.disambiguate_url(self.client_info['task'][-1])
-        r.setsockopt(zmq.IDENTITY, self.session.session)
+        r.setsockopt(zmq.IDENTITY, util.ensure_bytes(self.session.session))
         r.connect(url)
 
         self.hub = Hub(loop=loop, session=self.session, monitor=sub, heartmonitor=self.heartmonitor,
@@ -380,14 +380,14 @@ class Hub(SessionFactory):
         self.heartmonitor.add_heart_failure_handler(self.handle_heart_failure)
         self.heartmonitor.add_new_heart_handler(self.handle_new_heart)
         
-        self.monitor_handlers = { 'in' : self.save_queue_request,
-                                'out': self.save_queue_result,
-                                'intask': self.save_task_request,
-                                'outtask': self.save_task_result,
-                                'tracktask': self.save_task_destination,
-                                'incontrol': _passer,
-                                'outcontrol': _passer,
-                                'iopub': self.save_iopub_message,
+        self.monitor_handlers = {b'in' : self.save_queue_request,
+                                b'out': self.save_queue_result,
+                                b'intask': self.save_task_request,
+                                b'outtask': self.save_task_result,
+                                b'tracktask': self.save_task_destination,
+                                b'incontrol': _passer,
+                                b'outcontrol': _passer,
+                                b'iopub': self.save_iopub_message,
         }
         
         self.query_handlers = {'queue_request': self.queue_status,
@@ -562,8 +562,9 @@ class Hub(SessionFactory):
             return
         record = init_record(msg)
         msg_id = record['msg_id']
-        record['engine_uuid'] = queue_id
-        record['client_uuid'] = client_id
+        # Unicode in records
+        record['engine_uuid'] = queue_id.decode('utf8', 'replace')
+        record['client_uuid'] = client_id.decode('utf8', 'replace')
         record['queue'] = 'mux'
 
         try:
@@ -751,7 +752,7 @@ class Hub(SessionFactory):
         # print (content)
         msg_id = content['msg_id']
         engine_uuid = content['engine_id']
-        eid = self.by_ident[engine_uuid]
+        eid = self.by_ident[util.ensure_bytes(engine_uuid)]
         
         self.log.info("task::task %r arrived on %r"%(msg_id, eid))
         if msg_id in self.unassigned:
@@ -833,7 +834,7 @@ class Hub(SessionFactory):
         jsonable = {}
         for k,v in self.keytable.iteritems():
             if v not in self.dead_engines:
-                jsonable[str(k)] = v
+                jsonable[str(k)] = v.decode()
         content['engines'] = jsonable
         self.session.send(self.query, 'connection_reply', content, parent=msg, ident=client_id)
     
@@ -841,11 +842,13 @@ class Hub(SessionFactory):
         """Register a new engine."""
         content = msg['content']
         try:
-            queue = content['queue']
+            queue = util.ensure_bytes(content['queue'])
         except KeyError:
             self.log.error("registration::queue not specified", exc_info=True)
             return
         heart = content.get('heartbeat', None)
+        if heart:
+            heart = util.ensure_bytes(heart)
         """register a new engine, and create the socket(s) necessary"""
         eid = self._next_id
         # print (eid, queue, reg, heart)
@@ -912,7 +915,7 @@ class Hub(SessionFactory):
         self.log.info("registration::unregister_engine(%r)"%eid)
         # print (eid)
         uuid = self.keytable[eid]
-        content=dict(id=eid, queue=uuid)
+        content=dict(id=eid, queue=uuid.decode())
         self.dead_engines.add(uuid)
         # self.ids.remove(eid)
         # uuid = self.keytable.pop(eid)
@@ -980,7 +983,7 @@ class Hub(SessionFactory):
         self.tasks[eid] = list()
         self.completed[eid] = list()
         self.hearts[heart] = eid
-        content = dict(id=eid, queue=self.engines[eid].queue)
+        content = dict(id=eid, queue=self.engines[eid].queue.decode())
         if self.notifier:
             self.session.send(self.notifier, "registration_notification", content=content)
         self.log.info("engine::Engine Connected: %i"%eid)
@@ -1054,9 +1057,9 @@ class Hub(SessionFactory):
                 queue = len(queue)
                 completed = len(completed)
                 tasks = len(tasks)
-            content[bytes(t)] = {'queue': queue, 'completed': completed , 'tasks': tasks}
+            content[str(t)] = {'queue': queue, 'completed': completed , 'tasks': tasks}
         content['unassigned'] = list(self.unassigned) if verbose else len(self.unassigned)
-        
+        # print (content)
         self.session.send(self.query, "queue_reply", content=content, ident=client_id)
     
     def purge_results(self, client_id, msg):
@@ -1179,7 +1182,7 @@ class Hub(SessionFactory):
                             'io' : io_dict,
                           }
         if rec['result_buffers']:
-            buffers = map(str, rec['result_buffers'])
+            buffers = map(bytes, rec['result_buffers'])
         else:
             buffers = []
         
@@ -1281,7 +1284,7 @@ class Hub(SessionFactory):
                     buffers.extend(rb)
             content = dict(status='ok', records=records, buffer_lens=buffer_lens,
                                     result_buffer_lens=result_buffer_lens)
-        
+        # self.log.debug (content)
         self.session.send(self.query, "db_reply", content=content, 
                                             parent=msg, ident=client_id,
                                             buffers=buffers)

--- a/IPython/parallel/controller/scheduler.py
+++ b/IPython/parallel/controller/scheduler.py
@@ -40,11 +40,11 @@ from zmq.eventloop import ioloop, zmqstream
 from IPython.external.decorator import decorator
 from IPython.config.application import Application
 from IPython.config.loader import Config
-from IPython.utils.traitlets import Instance, Dict, List, Set, Int, Enum
+from IPython.utils.traitlets import Instance, Dict, List, Set, Int, Enum, CBytes
 
 from IPython.parallel import error
 from IPython.parallel.factory import SessionFactory
-from IPython.parallel.util import connect_logger, local_logger
+from IPython.parallel.util import connect_logger, local_logger, ensure_bytes
 
 from .dependency import Dependency
 
@@ -174,6 +174,10 @@ class TaskScheduler(SessionFactory):
     blacklist = Dict() # dict by msg_id of locations where a job has encountered UnmetDependency
     auditor = Instance('zmq.eventloop.ioloop.PeriodicCallback')
     
+    ident = CBytes() # ZMQ identity. This should just be self.session.session
+                     # but ensure Bytes
+    def _ident_default(self):
+        return ensure_bytes(self.session.session)
     
     def start(self):
         self.engine_stream.on_recv(self.dispatch_result, copy=False)
@@ -204,7 +208,7 @@ class TaskScheduler(SessionFactory):
         try:
             idents,msg = self.session.feed_identities(msg)
         except ValueError:
-            self.log.warn("task::Invalid Message: %r"%msg)
+            self.log.warn("task::Invalid Message: %r",msg)
             return
         try:
             msg = self.session.unpack_message(msg)
@@ -219,15 +223,16 @@ class TaskScheduler(SessionFactory):
             self.log.error("Unhandled message type: %r"%msg_type)
         else:
             try:
-                handler(str(msg['content']['queue']))
-            except KeyError:
-                self.log.error("task::Invalid notification msg: %r"%msg)
+                handler(ensure_bytes(msg['content']['queue']))
+            except Exception:
+                self.log.error("task::Invalid notification msg: %r",msg)
     
     def _register_engine(self, uid):
         """New engine with ident `uid` became available."""
         # head of the line:
         self.targets.insert(0,uid)
         self.loads.insert(0,0)
+
         # initialize sets
         self.completed[uid] = set()
         self.failed[uid] = set()
@@ -309,14 +314,18 @@ class TaskScheduler(SessionFactory):
         
         
         # send to monitor
-        self.mon_stream.send_multipart(['intask']+raw_msg, copy=False)
+        self.mon_stream.send_multipart([b'intask']+raw_msg, copy=False)
         
         header = msg['header']
         msg_id = header['msg_id']
         self.all_ids.add(msg_id)
         
-        # targets
-        targets = set(header.get('targets', []))
+        # get targets as a set of bytes objects
+        # from a list of unicode objects
+        targets = header.get('targets', [])
+        targets = map(ensure_bytes, targets)
+        targets = set(targets)
+            
         retries = header.get('retries', 0)
         self.retries[msg_id] = retries
         
@@ -412,7 +421,7 @@ class TaskScheduler(SessionFactory):
         
         msg = self.session.send(self.client_stream, 'apply_reply', content, 
                                                 parent=header, ident=idents)
-        self.session.send(self.mon_stream, msg, ident=['outtask']+idents)
+        self.session.send(self.mon_stream, msg, ident=[b'outtask']+idents)
         
         self.update_graph(msg_id, success=False)
     
@@ -494,9 +503,9 @@ class TaskScheduler(SessionFactory):
         self.add_job(idx)
         self.pending[target][msg_id] = (raw_msg, targets, MET, follow, timeout)
         # notify Hub
-        content = dict(msg_id=msg_id, engine_id=target)
+        content = dict(msg_id=msg_id, engine_id=target.decode())
         self.session.send(self.mon_stream, 'task_destination', content=content, 
-                        ident=['tracktask',self.session.session])
+                        ident=[b'tracktask',self.ident])
         
     
     #-----------------------------------------------------------------------
@@ -533,7 +542,7 @@ class TaskScheduler(SessionFactory):
                 # relay to client and update graph
                 self.handle_result(idents, parent, raw_msg, success)
                 # send to Hub monitor
-                self.mon_stream.send_multipart(['outtask']+raw_msg, copy=False)
+                self.mon_stream.send_multipart([b'outtask']+raw_msg, copy=False)
         else:
             self.handle_unmet_dependency(idents, parent)
         

--- a/IPython/parallel/controller/scheduler.py
+++ b/IPython/parallel/controller/scheduler.py
@@ -44,7 +44,7 @@ from IPython.utils.traitlets import Instance, Dict, List, Set, Int, Enum, CBytes
 
 from IPython.parallel import error
 from IPython.parallel.factory import SessionFactory
-from IPython.parallel.util import connect_logger, local_logger, ensure_bytes
+from IPython.parallel.util import connect_logger, local_logger, asbytes
 
 from .dependency import Dependency
 
@@ -177,7 +177,7 @@ class TaskScheduler(SessionFactory):
     ident = CBytes() # ZMQ identity. This should just be self.session.session
                      # but ensure Bytes
     def _ident_default(self):
-        return ensure_bytes(self.session.session)
+        return asbytes(self.session.session)
     
     def start(self):
         self.engine_stream.on_recv(self.dispatch_result, copy=False)
@@ -223,7 +223,7 @@ class TaskScheduler(SessionFactory):
             self.log.error("Unhandled message type: %r"%msg_type)
         else:
             try:
-                handler(ensure_bytes(msg['content']['queue']))
+                handler(asbytes(msg['content']['queue']))
             except Exception:
                 self.log.error("task::Invalid notification msg: %r",msg)
     
@@ -323,7 +323,7 @@ class TaskScheduler(SessionFactory):
         # get targets as a set of bytes objects
         # from a list of unicode objects
         targets = header.get('targets', [])
-        targets = map(ensure_bytes, targets)
+        targets = map(asbytes, targets)
         targets = set(targets)
             
         retries = header.get('retries', 0)

--- a/IPython/parallel/controller/scheduler.py
+++ b/IPython/parallel/controller/scheduler.py
@@ -503,7 +503,7 @@ class TaskScheduler(SessionFactory):
         self.add_job(idx)
         self.pending[target][msg_id] = (raw_msg, targets, MET, follow, timeout)
         # notify Hub
-        content = dict(msg_id=msg_id, engine_id=target.decode())
+        content = dict(msg_id=msg_id, engine_id=target.decode('ascii'))
         self.session.send(self.mon_stream, 'task_destination', content=content, 
                         ident=[b'tracktask',self.ident])
         

--- a/IPython/parallel/controller/sqlitedb.py
+++ b/IPython/parallel/controller/sqlitedb.py
@@ -28,6 +28,12 @@ from IPython.utils.jsonutil import date_default, extract_dates, squash_dates
 # SQLite operators, adapters, and converters
 #-----------------------------------------------------------------------------
 
+try:
+    buffer
+except NameError:
+    # py3k
+    buffer = memoryview
+
 operators = {
  '$lt' : "<",
  '$gt' : ">",
@@ -54,7 +60,11 @@ def _convert_dict(ds):
     if ds is None:
         return ds
     else:
-        return extract_dates(json.loads(ds))
+        if isinstance(ds, bytes):
+            # If I understand the sqlite doc correctly, this will always be utf8
+            ds = ds.decode('utf8')
+        d = json.loads(ds)
+        return extract_dates(d)
 
 def _adapt_bufs(bufs):
     # this is *horrible*

--- a/IPython/parallel/controller/sqlitedb.py
+++ b/IPython/parallel/controller/sqlitedb.py
@@ -63,8 +63,7 @@ def _convert_dict(ds):
         if isinstance(ds, bytes):
             # If I understand the sqlite doc correctly, this will always be utf8
             ds = ds.decode('utf8')
-        d = json.loads(ds)
-        return extract_dates(d)
+        return extract_dates(json.loads(ds))
 
 def _adapt_bufs(bufs):
     # this is *horrible*

--- a/IPython/parallel/engine/engine.py
+++ b/IPython/parallel/engine/engine.py
@@ -28,7 +28,7 @@ from IPython.utils.traitlets import Instance, Dict, Int, Type, CFloat, Unicode
 
 from IPython.parallel.controller.heartmonitor import Heart
 from IPython.parallel.factory import RegistrationFactory
-from IPython.parallel.util import disambiguate_url
+from IPython.parallel.util import disambiguate_url, ensure_bytes
 
 from IPython.zmq.session import Message
 
@@ -65,7 +65,7 @@ class EngineFactory(RegistrationFactory):
         ctx = self.context
         
         reg = ctx.socket(zmq.XREQ)
-        reg.setsockopt(zmq.IDENTITY, self.ident)
+        reg.setsockopt(zmq.IDENTITY, ensure_bytes(self.ident))
         reg.connect(self.url)
         self.registrar = zmqstream.ZMQStream(reg, self.loop)
         
@@ -83,7 +83,7 @@ class EngineFactory(RegistrationFactory):
         self._abort_dc.stop()
         ctx = self.context
         loop = self.loop
-        identity = self.ident
+        identity = ensure_bytes(self.ident)
         
         idents,msg = self.session.feed_identities(msg)
         msg = Message(self.session.unpack_message(msg))

--- a/IPython/parallel/engine/engine.py
+++ b/IPython/parallel/engine/engine.py
@@ -28,7 +28,7 @@ from IPython.utils.traitlets import Instance, Dict, Int, Type, CFloat, Unicode, 
 
 from IPython.parallel.controller.heartmonitor import Heart
 from IPython.parallel.factory import RegistrationFactory
-from IPython.parallel.util import disambiguate_url, ensure_bytes
+from IPython.parallel.util import disambiguate_url, asbytes
 
 from IPython.zmq.session import Message
 
@@ -61,7 +61,7 @@ class EngineFactory(RegistrationFactory):
     bident = CBytes()
     ident = Unicode()
     def _ident_changed(self, name, old, new):
-        self.bident = ensure_bytes(new)
+        self.bident = asbytes(new)
     
     
     def __init__(self, **kwargs):

--- a/IPython/parallel/engine/streamkernel.py
+++ b/IPython/parallel/engine/streamkernel.py
@@ -40,7 +40,7 @@ from IPython.zmq.completer import KernelCompleter
 
 from IPython.parallel.error import wrap_exception
 from IPython.parallel.factory import SessionFactory
-from IPython.parallel.util import serialize_object, unpack_apply_message, ensure_bytes
+from IPython.parallel.util import serialize_object, unpack_apply_message, asbytes
 
 def printer(*args):
     pprint(args, stream=sys.__stdout__)
@@ -79,7 +79,7 @@ class Kernel(SessionFactory):
     bident = CBytes()
     ident = Unicode()
     def _ident_changed(self, name, old, new):
-        self.bident = ensure_bytes(new)
+        self.bident = asbytes(new)
     
     user_ns = Dict(config=True,  help="""Set the user's namespace of the Kernel""")
     
@@ -255,7 +255,7 @@ class Kernel(SessionFactory):
             self.log.error("Got bad msg: %s"%parent, exc_info=True)
             return
         self.session.send(self.iopub_stream, u'pyin', {u'code':code},parent=parent,
-                            ident=ensure_bytes('%s.pyin'%self.prefix))
+                            ident=asbytes('%s.pyin'%self.prefix))
         started = datetime.now()
         try:
             comp_code = self.compiler(code, '<zmq-kernel>')
@@ -269,7 +269,7 @@ class Kernel(SessionFactory):
             exc_content = self._wrap_exception('execute')
             # exc_msg = self.session.msg(u'pyerr', exc_content, parent)
             self.session.send(self.iopub_stream, u'pyerr', exc_content, parent=parent,
-                            ident=ensure_bytes('%s.pyerr'%self.prefix))
+                            ident=asbytes('%s.pyerr'%self.prefix))
             reply_content = exc_content
         else:
             reply_content = {'status' : 'ok'}
@@ -348,7 +348,7 @@ class Kernel(SessionFactory):
             exc_content = self._wrap_exception('apply')
             # exc_msg = self.session.msg(u'pyerr', exc_content, parent)
             self.session.send(self.iopub_stream, u'pyerr', exc_content, parent=parent,
-                                ident=ensure_bytes('%s.pyerr'%self.prefix))
+                                ident=asbytes('%s.pyerr'%self.prefix))
             reply_content = exc_content
             result_buf = []
             

--- a/IPython/parallel/engine/streamkernel.py
+++ b/IPython/parallel/engine/streamkernel.py
@@ -35,12 +35,12 @@ import zmq
 from zmq.eventloop import ioloop, zmqstream
 
 # Local imports.
-from IPython.utils.traitlets import Instance, List, Int, Dict, Set, Unicode
+from IPython.utils.traitlets import Instance, List, Int, Dict, Set, Unicode, CBytes
 from IPython.zmq.completer import KernelCompleter
 
 from IPython.parallel.error import wrap_exception
 from IPython.parallel.factory import SessionFactory
-from IPython.parallel.util import serialize_object, unpack_apply_message
+from IPython.parallel.util import serialize_object, unpack_apply_message, ensure_bytes
 
 def printer(*args):
     pprint(args, stream=sys.__stdout__)
@@ -73,8 +73,14 @@ class Kernel(SessionFactory):
     # kwargs:
     exec_lines = List(Unicode, config=True,
         help="List of lines to execute")
-
+    
+    # identities:
     int_id = Int(-1)
+    bident = CBytes()
+    ident = Unicode()
+    def _ident_changed(self, name, old, new):
+        self.bident = ensure_bytes(new)
+    
     user_ns = Dict(config=True,  help="""Set the user's namespace of the Kernel""")
     
     control_stream = Instance(zmqstream.ZMQStream)
@@ -193,6 +199,8 @@ class Kernel(SessionFactory):
         except:
             self.log.error("Invalid Message", exc_info=True)
             return
+        else:
+            self.log.debug("Control received, %s", msg)
         
         header = msg['header']
         msg_id = header['msg_id']
@@ -247,7 +255,7 @@ class Kernel(SessionFactory):
             self.log.error("Got bad msg: %s"%parent, exc_info=True)
             return
         self.session.send(self.iopub_stream, u'pyin', {u'code':code},parent=parent,
-                            ident='%s.pyin'%self.prefix)
+                            ident=ensure_bytes('%s.pyin'%self.prefix))
         started = datetime.now()
         try:
             comp_code = self.compiler(code, '<zmq-kernel>')
@@ -261,7 +269,7 @@ class Kernel(SessionFactory):
             exc_content = self._wrap_exception('execute')
             # exc_msg = self.session.msg(u'pyerr', exc_content, parent)
             self.session.send(self.iopub_stream, u'pyerr', exc_content, parent=parent,
-                            ident='%s.pyerr'%self.prefix)
+                            ident=ensure_bytes('%s.pyerr'%self.prefix))
             reply_content = exc_content
         else:
             reply_content = {'status' : 'ok'}
@@ -285,7 +293,6 @@ class Kernel(SessionFactory):
     def apply_request(self, stream, ident, parent):
         # flush previous reply, so this request won't block it
         stream.flush(zmq.POLLOUT)
-        
         try:
             content = parent[u'content']
             bufs = parent[u'buffers']
@@ -341,7 +348,7 @@ class Kernel(SessionFactory):
             exc_content = self._wrap_exception('apply')
             # exc_msg = self.session.msg(u'pyerr', exc_content, parent)
             self.session.send(self.iopub_stream, u'pyerr', exc_content, parent=parent,
-                                ident='%s.pyerr'%self.prefix)
+                                ident=ensure_bytes('%s.pyerr'%self.prefix))
             reply_content = exc_content
             result_buf = []
             
@@ -370,6 +377,8 @@ class Kernel(SessionFactory):
         except:
             self.log.error("Invalid Message", exc_info=True)
             return
+        else:
+            self.log.debug("Message received, %s", msg)
             
         
         header = msg['header']

--- a/IPython/parallel/tests/clienttest.py
+++ b/IPython/parallel/tests/clienttest.py
@@ -41,9 +41,11 @@ def crash():
     if sys.platform.startswith('win'):
         import ctypes
         ctypes.windll.kernel32.SetErrorMode(0x0002);
-
-    co = types.CodeType(0, 0, 0, 0, b'\x04\x71\x00\x00',
-                             (), (), (), '', '', 1, b'')
+    args = [ 0, 0, 0, 0, b'\x04\x71\x00\x00', (), (), (), '', '', 1, b'']
+    if sys.version_info[0] >= 3:
+        args.insert(1, 0)
+        
+    co = types.CodeType(*args)
     exec(co)
 
 def wait(n):

--- a/IPython/parallel/tests/clienttest.py
+++ b/IPython/parallel/tests/clienttest.py
@@ -43,6 +43,7 @@ def crash():
         ctypes.windll.kernel32.SetErrorMode(0x0002);
     args = [ 0, 0, 0, 0, b'\x04\x71\x00\x00', (), (), (), '', '', 1, b'']
     if sys.version_info[0] >= 3:
+        # Python3 adds 'kwonlyargcount' as the second argument to Code
         args.insert(1, 0)
         
     co = types.CodeType(*args)

--- a/IPython/parallel/tests/test_asyncresult.py
+++ b/IPython/parallel/tests/test_asyncresult.py
@@ -57,7 +57,7 @@ class AsyncResultTest(ClusterTestCase):
 
     def test_get_after_error(self):
         ar = self.client[-1].apply_async(lambda : 1/0)
-        ar.wait()
+        ar.wait(10)
         self.assertRaisesRemote(ZeroDivisionError, ar.get)
         self.assertRaisesRemote(ZeroDivisionError, ar.get)
         self.assertRaisesRemote(ZeroDivisionError, ar.get_dict)

--- a/IPython/parallel/tests/test_client.py
+++ b/IPython/parallel/tests/test_client.py
@@ -16,6 +16,8 @@ Authors:
 # Imports
 #-------------------------------------------------------------------------------
 
+from __future__ import division
+
 import time
 from datetime import datetime
 from tempfile import mktemp
@@ -132,7 +134,9 @@ class TestClient(ClusterTestCase):
         self.assertEquals(sorted(qs.keys()), ['completed', 'queue', 'tasks'])
         allqs = self.client.queue_status()
         self.assertTrue(isinstance(allqs, dict))
-        self.assertEquals(sorted(allqs.keys()), sorted(self.client.ids + ['unassigned']))
+        intkeys = list(allqs.keys())
+        intkeys.remove('unassigned')
+        self.assertEquals(sorted(intkeys), sorted(self.client.ids))
         unassigned = allqs.pop('unassigned')
         for eid,qs in allqs.items():
             self.assertTrue(isinstance(qs, dict))
@@ -156,7 +160,7 @@ class TestClient(ClusterTestCase):
     def test_db_query_dt(self):
         """test db query by date"""
         hist = self.client.hub_history()
-        middle = self.client.db_query({'msg_id' : hist[len(hist)/2]})[0]
+        middle = self.client.db_query({'msg_id' : hist[len(hist)//2]})[0]
         tic = middle['submitted']
         before = self.client.db_query({'submitted' : {'$lt' : tic}})
         after = self.client.db_query({'submitted' : {'$gte' : tic}})

--- a/IPython/parallel/tests/test_db.py
+++ b/IPython/parallel/tests/test_db.py
@@ -16,6 +16,7 @@ Authors:
 # Imports
 #-------------------------------------------------------------------------------
 
+from __future__ import division
 
 import tempfile
 import time
@@ -100,7 +101,7 @@ class TestDictBackend(TestCase):
     def test_find_records_dt(self):
         """test finding records by date"""
         hist = self.db.get_history()
-        middle = self.db.get_record(hist[len(hist)/2])
+        middle = self.db.get_record(hist[len(hist)//2])
         tic = middle['submitted']
         before = self.db.find_records({'submitted' : {'$lt' : tic}})
         after = self.db.find_records({'submitted' : {'$gte' : tic}})
@@ -168,7 +169,7 @@ class TestDictBackend(TestCase):
         query = {'msg_id' : {'$in':msg_ids}}
         self.db.drop_matching_records(query)
         recs = self.db.find_records(query)
-        self.assertTrue(len(recs)==0)
+        self.assertEquals(len(recs), 0)
             
 class TestSQLiteBackend(TestDictBackend):
     def create_db(self):

--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -43,7 +43,7 @@ class TestView(ClusterTestCase):
         # self.add_engines(1)
         eid = self.client.ids[-1]
         ar = self.client[eid].apply_async(crash)
-        self.assertRaisesRemote(error.EngineError, ar.get)
+        self.assertRaisesRemote(error.EngineError, ar.get, 10)
         eid = ar.engine_id
         tic = time.time()
         while eid in self.client.ids and time.time()-tic < 5:
@@ -413,7 +413,10 @@ class TestView(ClusterTestCase):
         """test executing unicode strings"""
         v = self.client[-1]
         v.block=True
-        code=u"a=u'é'"
+        if sys.version_info[0] >= 3:
+            code="a='é'"
+        else:
+            code=u"a=u'é'"
         v.execute(code)
         self.assertEquals(v['a'], u'é')
         
@@ -433,7 +436,7 @@ class TestView(ClusterTestCase):
             assert isinstance(check, bytes), "%r is not bytes"%check
             assert a.encode('utf8') == check, "%s != %s"%(a,check)
         
-        for s in [ u'é', u'ßø®∫','asdf'.decode() ]:
+        for s in [ u'é', u'ßø®∫',u'asdf' ]:
             try:
                 v.apply_sync(check_unicode, s, s.encode('utf8'))
             except error.RemoteError as e:

--- a/IPython/parallel/util.py
+++ b/IPython/parallel/util.py
@@ -101,7 +101,7 @@ class ReverseDict(dict):
 # Functions
 #-----------------------------------------------------------------------------
 
-def ensure_bytes(s):
+def asbytes(s):
     """ensure that an object is ascii bytes"""
     if isinstance(s, unicode):
         s = s.encode('ascii')

--- a/IPython/parallel/util.py
+++ b/IPython/parallel/util.py
@@ -102,9 +102,9 @@ class ReverseDict(dict):
 #-----------------------------------------------------------------------------
 
 def ensure_bytes(s):
-    """ensure that an object is bytes"""
+    """ensure that an object is ascii bytes"""
     if isinstance(s, unicode):
-        s = s.encode(sys.getdefaultencoding(), 'replace')
+        s = s.encode('ascii')
     return s
 
 def validate_url(url):

--- a/IPython/parallel/util.py
+++ b/IPython/parallel/util.py
@@ -101,6 +101,12 @@ class ReverseDict(dict):
 # Functions
 #-----------------------------------------------------------------------------
 
+def ensure_bytes(s):
+    """ensure that an object is bytes"""
+    if isinstance(s, unicode):
+        s = s.encode(sys.getdefaultencoding(), 'replace')
+    return s
+
 def validate_url(url):
     """validate a url for zeromq"""
     if not isinstance(url, basestring):

--- a/IPython/utils/codeutil.py
+++ b/IPython/utils/codeutil.py
@@ -24,10 +24,10 @@ __docformat__ = "restructuredtext en"
 #-------------------------------------------------------------------------------
 
 import sys
-import new, types, copy_reg
+import types, copy_reg
 
 def code_ctor(*args):
-    return new.code(*args)
+    return types.CodeType(*args)
     
 def reduce_code(co):
     if co.co_freevars or co.co_cellvars:

--- a/IPython/utils/codeutil.py
+++ b/IPython/utils/codeutil.py
@@ -23,6 +23,7 @@ __docformat__ = "restructuredtext en"
 # Imports
 #-------------------------------------------------------------------------------
 
+import sys
 import new, types, copy_reg
 
 def code_ctor(*args):
@@ -31,9 +32,12 @@ def code_ctor(*args):
 def reduce_code(co):
     if co.co_freevars or co.co_cellvars:
         raise ValueError("Sorry, cannot pickle code objects with closures")
-    return code_ctor, (co.co_argcount, co.co_nlocals, co.co_stacksize,
-        co.co_flags, co.co_code, co.co_consts, co.co_names,
-        co.co_varnames, co.co_filename, co.co_name, co.co_firstlineno,
-        co.co_lnotab)
+    args =  [co.co_argcount, co.co_nlocals, co.co_stacksize,
+            co.co_flags, co.co_code, co.co_consts, co.co_names,
+            co.co_varnames, co.co_filename, co.co_name, co.co_firstlineno,
+            co.co_lnotab]
+    if sys.version_info[0] >= 3:
+        args.insert(1, co.co_kwonlyargcount)
+    return code_ctor, tuple(args)
 
 copy_reg.pickle(types.CodeType, reduce_code)

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -1099,7 +1099,7 @@ class CaselessStrEnum(Enum):
             if self._allow_none:
                 return value
 
-        if not isinstance(value, str):
+        if not isinstance(value, basestring):
             self.error(obj, value)
 
         for v in self.values:

--- a/docs/source/whatsnew/development.txt
+++ b/docs/source/whatsnew/development.txt
@@ -54,8 +54,9 @@ Python 3 support
 
 A Python 3 version of IPython has been prepared. For the time being, this is
 maintained separately and updated from the main codebase. Its code can be found
-`here <https://github.com/ipython/ipython-py3k>`_. Note that the parallel
-computing features do not yet work in Python 3.
+`here <https://github.com/ipython/ipython-py3k>`_. The parallel computing
+components are not perfect on Python3, but most functionality appears to be
+working.
 
 Unicode
 -------


### PR DESCRIPTION
This is primarily tweaks of bytes/unicode, but other fixes include:
- some integer division
- added co_kwonlyargcount to code objects
- a few places to handle map/range being objects

non-copying numpy is disabled on py3k, because arrays are not reconstructed properly on the other side (see #478). They are just pickled instead for now.

With these changes, almost all parallel tests pass on my Python 3.2.  Notable exceptions are: sync_imports, and MUX engine death for some reason. But in general, everything behaves as expected.

I made the changes in my branch of ipython-py3k [here](https://github.com/minrk/ipython-py3k/tree/parallel), and backported the changes to master.
