### PR TITLE
Rm default old config

### DIFF
--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -435,6 +435,10 @@ def check_for_old_config(ipython_dir=None):
                 os.unlink(f)
             else:
                 oldf = f+'.old'
+                i = 0
+                while os.path.exists(oldf):
+                    oldf = f+'.old.%i'%i
+                    i += 1
                 os.rename(f, oldf)
                 warn.warn("Renamed old IPython config file '%s' to '%s'." % (f, oldf))
                 warned = True

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -434,16 +434,19 @@ def check_for_old_config(ipython_dir=None):
             if filehash(f) == old_config_md5.get(cfg, ''):
                 os.unlink(f)
             else:
+                oldf = f+'.old'
+                os.rename(f, oldf)
+                warn.warn("Renamed old IPython config file '%s' to '%s'." % (f, oldf))
                 warned = True
-                warn.warn("Found old IPython config file %r (modified by user)"%f)
     
     if warned:
-        warn.warn("""
-    The IPython configuration system has changed as of 0.11, and these files
-    will be ignored. See http://ipython.github.com/ipython-doc/dev/config for
-    details on the new config system. To start configuring IPython, do 
-    `ipython profile create`, and edit `ipython_config.py` in
-    <ipython_dir>/profile_default, adding
-    `c.InteractiveShellApp.ignore_old_config=True`""")
+        warn.info("""
+  The IPython configuration system has changed as of 0.11, and these files will
+  be ignored. See http://ipython.github.com/ipython-doc/dev/config for details
+  of the new config system.
+  To start configuring IPython, do `ipython profile create`, and edit
+  `ipython_config.py` in <ipython_dir>/profile_default.
+  If you need to leave the old config files in place for an older version of
+  IPython, set `c.InteractiveShellApp.ignore_old_config=True` in the new config.""")
         
 

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -433,7 +433,6 @@ def check_for_old_config(ipython_dir=None):
         if os.path.exists(f):
             if filehash(f) == old_config_md5.get(cfg, ''):
                 os.unlink(f)
-                warn.info("Removed unmodified old IPython config file %r"%f)
             else:
                 warned = True
                 warn.warn("Found old IPython config file %r (modified by user)"%f)

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -431,7 +431,7 @@ def check_for_old_config(ipython_dir=None):
     for cfg in old_configs:
         f = os.path.join(ipython_dir, cfg)
         if os.path.exists(f):
-            if filehash(f) == old_config_md5[cfg]:
+            if filehash(f) == old_config_md5.get(cfg, ''):
                 os.unlink(f)
                 warn.info("Removed unmodified old IPython config file %r"%f)
             else:


### PR DESCRIPTION
This checks if ipythonrc and ipy_user_conf.py match the 0.10.x defaults, and deletes them if so. There's a message printed out when it happens, but without the "WARNING:" prefix, so it's not too loud.
