### PR TITLE
qt_for_kernel: use matplotlib rcParams to decide between PyQt4 and PySide

### DIFF
--- a/IPython/external/qt_for_kernel.py
+++ b/IPython/external/qt_for_kernel.py
@@ -6,7 +6,11 @@ import sys
 # Older versions of matplotlib do not support PyQt4 v2 APIs or PySide, so we
 # cannot go through the preferred mechanism.
 matplotlib = sys.modules.get('matplotlib')
-if matplotlib and matplotlib.__version__ <= '1.0.1':
-    from PyQt4 import QtCore, QtGui
+if matplotlib:
+    mqt = matplotlib.rcParams.get('backend.qt4', 'PyQt4')
+    if mqt == 'PyQt4':
+        from PyQt4 import QtCore, QtGui
+    else:
+        from PySide import QtCore, QtGui
 else:
     from IPython.external.qt import QtCore, QtGui


### PR DESCRIPTION
qt_for_kernel: use matplotlib rcParams to decide between PyQt4 and PySide

This is a companion to a possible change in mpl, adding
rcParams['backend.qt4'], but should work as well with earlier
mpl versions.
(There is still a problem with mpl in the ipython console when
PySide is selected.)
