### PR TITLE
don't move old config files, keep nagging the user

### DIFF
--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -434,13 +434,7 @@ def check_for_old_config(ipython_dir=None):
             if filehash(f) == old_config_md5.get(cfg, ''):
                 os.unlink(f)
             else:
-                oldf = f+'.old'
-                i = 0
-                while os.path.exists(oldf):
-                    oldf = f+'.old.%i'%i
-                    i += 1
-                os.rename(f, oldf)
-                warn.warn("Renamed old IPython config file '%s' to '%s'." % (f, oldf))
+                warn.warn("Found old IPython config file %r (modified by user)"%f)
                 warned = True
     
     if warned:
@@ -451,6 +445,6 @@ def check_for_old_config(ipython_dir=None):
   To start configuring IPython, do `ipython profile create`, and edit
   `ipython_config.py` in <ipython_dir>/profile_default.
   If you need to leave the old config files in place for an older version of
-  IPython, set `c.InteractiveShellApp.ignore_old_config=True` in the new config.""")
-        
+  IPython and want to suppress this warning message, set
+  `c.InteractiveShellApp.ignore_old_config=True` in the new config.""")
 


### PR DESCRIPTION
I think it will lead to a better user experience for users
transitioning to 0.11 if old config files are preserved and _not_
moved to get an additional .old extension the first time ipython
sees them.

My rationale is that it's a little _too_ helpful to move the old
files out of the way and not see the warning ever again, because
if the user missed it the first time, it'll never come up again.

The whole point of the "nag" message is to _force_ the user to
acknowledge and accept the presence of a new configuration
system, the first step of which can be as simple as adding
`c.InteractiveShellApp.ignore_old_config=True` to it.
