### PR TITLE
fix trailing whitespace from reseting indentation

### DIFF
--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -434,7 +434,7 @@ class InputSplitter(object):
                 #print 'Full dedent in text',self.source # dbg
                 full_dedent = True
 
-        if line[-1] == ':':
+        if line.rstrip()[-1] == ':':
             indent_spaces += 4
         elif dedent_re.match(line):
             indent_spaces -= 4

--- a/IPython/core/tests/test_inputsplitter.py
+++ b/IPython/core/tests/test_inputsplitter.py
@@ -200,6 +200,21 @@ class InputSplitterTestCase(unittest.TestCase):
         isp.push("if 1:")
         isp.push("    x = (1+\n    2)")
         self.assertEqual(isp.indent_spaces, 4)
+    
+    def test_indent4(self):
+        # In cell mode, inputs must be fed in whole blocks, so skip this test
+        if self.isp.input_mode == 'cell': return
+
+        isp = self.isp
+        # whitespace after ':' should not screw up indent level
+        isp.push('if 1: \n    x=1')
+        self.assertEqual(isp.indent_spaces, 4)
+        isp.push('y=2\n')
+        self.assertEqual(isp.indent_spaces, 0)
+        isp.push('if 1:\t\n    x=1')
+        self.assertEqual(isp.indent_spaces, 4)
+        isp.push('y=2\n')
+        self.assertEqual(isp.indent_spaces, 0)
 
     def test_dedent_pass(self):
         isp = self.isp # shorthand


### PR DESCRIPTION
whitespace after ':' caused indentation to be reset. This changes fixes that problem and adds a test for it.

if 1:<space>
    print 1
    print 2
