### PR TITLE
Show message about %paste magic on an IndentationError

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2273,6 +2273,11 @@ class InteractiveShell(SingletonConfigurable, Magic):
                 with self.display_trap:
                     try:
                         code_ast = ast.parse(cell, filename=cell_name)
+                    except IndentationError:
+                        self.showsyntaxerror()
+                        print("If you want to paste code into IPython, try the %paste magic function.")
+                        self.execution_count += 1
+                        return None
                     except (OverflowError, SyntaxError, ValueError, TypeError,
                             MemoryError):
                         self.showsyntaxerror()

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1605,6 +1605,10 @@ class InteractiveShell(SingletonConfigurable, Magic):
                     value = msg, (filename, lineno, offset, line)
         stb = self.SyntaxTB.structured_traceback(etype, value, [])
         self._showtraceback(etype, value, stb)
+    
+    # This is overridden in TerminalInteractiveShell to show a message about
+    # the %paste magic.
+    showindentationerror = showsyntaxerror
 
     #-------------------------------------------------------------------------
     # Things related to readline
@@ -2274,8 +2278,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
                     try:
                         code_ast = ast.parse(cell, filename=cell_name)
                     except IndentationError:
-                        self.showsyntaxerror()
-                        print("If you want to paste code into IPython, try the %paste magic function.")
+                        self.showindentationerror()
                         self.execution_count += 1
                         return None
                     except (OverflowError, SyntaxError, ValueError, TypeError,

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1608,7 +1608,13 @@ class InteractiveShell(SingletonConfigurable, Magic):
     
     # This is overridden in TerminalInteractiveShell to show a message about
     # the %paste magic.
-    showindentationerror = showsyntaxerror
+    def showindentationerror(self):
+        """Called by run_cell when there's an IndentationError in code entered
+        at the prompt.
+        
+        This is overridden in TerminalInteractiveShell to show a message about
+        the %paste magic."""
+        self.showsyntaxerror()
 
     #-------------------------------------------------------------------------
     # Things related to readline

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -588,6 +588,10 @@ class TerminalInteractiveShell(InteractiveShell):
             write("## -- End pasted text --\n")
             
         self._execute_block(block, par)
+    
+    def showindentationerror(self):
+        super(TerminalInteractiveShell, self).showindentationerror()
+        print("If you want to paste code into IPython, try the %paste magic function.")
 
 
 InteractiveShellABC.register(TerminalInteractiveShell)


### PR DESCRIPTION
Show message about %paste magic on an IndentationError from code in the prompt.

Only when we parse code from the prompt, so it won't show up if there's an IndentationError from code that's imported.

Sort of closes #572.
