### PR TITLE
simulate shell expansion on %run arguments, at least tilde expansion

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -1595,7 +1595,11 @@ Currently the magic system has the following functions:\n"""
         # Make sure that the running script gets a proper sys.argv as if it
         # were run from a system shell.
         save_argv = sys.argv # save it for later restoring
-        sys.argv = [filename]+ arg_lst[1:]  # put in the proper filename
+
+        # simulate shell expansion on arguments, at least tilde expansion
+        args = map(os.path.expanduser, arg_lst[1:])
+
+        sys.argv = [filename]+ args  # put in the proper filename
 
         if opts.has_key('i'):
             # Run in user's interactive namespace


### PR DESCRIPTION
I like to start scripts using %run instead of from the shell, but this prevents the use of paths starting with ~ for my home directory.

This patch simply applies os.path.expanduser to sys.argv; there might be a better place and possibly a more complete expansion implementation, but this really scratches an itch.
