### PR TITLE
Fix templates for CrashHandler

### DIFF
--- a/IPython/core/crashhandler.py
+++ b/IPython/core/crashhandler.py
@@ -37,14 +37,14 @@ Oops, {app_name} crashed. We do our best to make it stable, but...
 A crash report was automatically generated with the following information:
   - A verbatim copy of the crash traceback.
   - A copy of your input history during this session.
-  - Data on your current $self.app_name configuration.
+  - Data on your current {app_name} configuration.
 
 It was left in the file named:
 \t'{crash_report_fname}'
 If you can email this file to the developers, the information in it will help
 them in understanding and correcting the problem.
 
-You can mail it to: $self.contact_name at {contact_email}
+You can mail it to: {contact_name} at {contact_email}
 with the subject '{app_name} Crash Report'.
 
 If you want to do it now, the following command will work (under Unix):
@@ -126,6 +126,7 @@ class CrashHandler(object):
         # write the report filename into the instance dict so it can get
         # properly expanded out in the user message template
         self.crash_report_fname = report_name
+        self.info['crash_report_fname'] = report_name
         TBhandler = ultratb.VerboseTB(
             color_scheme=color_scheme,
             long_header=1,

--- a/IPython/parallel/apps/baseapp.py
+++ b/IPython/parallel/apps/baseapp.py
@@ -53,33 +53,8 @@ class PIDFileError(Exception):
 # Crash handler for this application
 #-----------------------------------------------------------------------------
 
-
-_message_template = """\
-Oops, $self.app_name crashed. We do our best to make it stable, but...
-
-A crash report was automatically generated with the following information:
-  - A verbatim copy of the crash traceback.
-  - Data on your current $self.app_name configuration.
-
-It was left in the file named:
-\t'$self.crash_report_fname'
-If you can email this file to the developers, the information in it will help
-them in understanding and correcting the problem.
-
-You can mail it to: $self.contact_name at $self.contact_email
-with the subject '$self.app_name Crash Report'.
-
-If you want to do it now, the following command will work (under Unix):
-mail -s '$self.app_name Crash Report' $self.contact_email < $self.crash_report_fname
-
-To ensure accurate tracking of this issue, please file a report about it at:
-$self.bug_tracker
-"""
-
 class ParallelCrashHandler(CrashHandler):
     """sys.excepthook for IPython itself, leaves a detailed report on disk."""
-
-    message_template = _message_template
 
     def __init__(self, app):
         contact_name = release.authors['Min'][0]


### PR DESCRIPTION
The default template for CrashHandler needed some updating to work with the .format() method of strings. Also, the parallel app no longer needed to define its own template.

Also, should profileapp.py define a CrashHandler and specify:

```
contact_name = release.authors['Fernando'][0]
contact_email = release.authors['Fernando'][1]
bug_tracker = 'http://github.com/ipython/ipython/issues'
```

for the contact information?  Presently, if you receive an import error during the creation of a profile (eg creating a parallel profile without having zeromq), then none of this information is set.
