### PR TITLE
Fix bug with non-ascii reprs inside pretty-printed lists.

### DIFF
--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -432,6 +432,9 @@ class PlainTextFormatter(BaseFormatter):
         else:
             # This uses use StringIO, as cStringIO doesn't handle unicode.
             stream = StringIO()
+            # self.newline.encode() is a quick fix for issue gh-597. We need to
+            # ensure that stream does not get a mix of unicode and bytestrings,
+            # or it will cause trouble.
             printer = pretty.RepresentationPrinter(stream, self.verbose,
                 self.max_width, self.newline.encode(),
                 singleton_pprinters=self.singleton_printers,

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -433,7 +433,7 @@ class PlainTextFormatter(BaseFormatter):
             # This uses use StringIO, as cStringIO doesn't handle unicode.
             stream = StringIO()
             printer = pretty.RepresentationPrinter(stream, self.verbose,
-                self.max_width, self.newline,
+                self.max_width, self.newline.encode(),
                 singleton_pprinters=self.singleton_printers,
                 type_pprinters=self.type_printers,
                 deferred_pprinters=self.deferred_printers)

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -114,6 +114,8 @@ class InteractiveShellTestCase(unittest.TestCase):
         ip.run_cell('!(true)\n\n\n', False)
     
     def test_gh_597(self):
+        """Pretty-printing lists of objects with non-ascii reprs may cause
+        problems."""
         class Spam(object):
           def __repr__(self):
             return "\xe9"*50

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -112,5 +112,11 @@ class InteractiveShellTestCase(unittest.TestCase):
         ip = get_ipython()
         ip.run_cell('!(true)\n', False)
         ip.run_cell('!(true)\n\n\n', False)
-
-
+    
+    def test_gh_597(self):
+        class Spam(object):
+          def __repr__(self):
+            return "\xe9"*50
+        import IPython.core.formatters
+        f = IPython.core.formatters.PlainTextFormatter()
+        f([Spam(),Spam()])


### PR DESCRIPTION
An ugly but simple fix for a bug with non-ascii reprs. Ideally we'd use unicode in IPython.lib.pretty, but that's a bigger change, and would probably introduce further bugs.

Closes gh-597 (@juliantaylor)
