### PR TITLE
I617

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -650,6 +650,7 @@ def magic_history(self, parameter_s = ''):
     if 'g' in opts:         # Glob search
         pattern = "*" + args + "*" if args else "*"
         hist = history_manager.search(pattern, raw=raw, output=get_output)
+        print_nums = True
     elif 'l' in opts:       # Get 'tail'
         try:
             n = int(args)

--- a/IPython/zmq/zmqshell.py
+++ b/IPython/zmq/zmqshell.py
@@ -80,6 +80,9 @@ class ZMQInteractiveShell(InteractiveShell):
     displayhook_class = Type(ZMQShellDisplayHook)
     display_pub_class = Type(ZMQDisplayPublisher)
     
+    # Override the traitlet in the parent class, because there's no point using
+    # readline for the kernel. Can be removed when the readline code is moved
+    # to the terminal frontend.
     readline_use = CBool(False)
     
     exiter = Instance(ZMQExitAutocall)

--- a/IPython/zmq/zmqshell.py
+++ b/IPython/zmq/zmqshell.py
@@ -31,7 +31,7 @@ from IPython.core.magic import MacroToEdit
 from IPython.core.payloadpage import install_payload_page
 from IPython.utils import io
 from IPython.utils.path import get_py_filename
-from IPython.utils.traitlets import Instance, Type, Dict
+from IPython.utils.traitlets import Instance, Type, Dict, CBool
 from IPython.utils.warn import warn
 from IPython.zmq.displayhook import ZMQShellDisplayHook, _encode_png
 from IPython.zmq.session import extract_header
@@ -79,6 +79,8 @@ class ZMQInteractiveShell(InteractiveShell):
 
     displayhook_class = Type(ZMQShellDisplayHook)
     display_pub_class = Type(ZMQDisplayPublisher)
+    
+    readline_use = CBool(False)
     
     exiter = Instance(ZMQExitAutocall)
     def _exiter_default(self):


### PR DESCRIPTION
Don't try to load readline when using the ZMQ shell. (Fixes #617)

Also, when using `%history -g pattern`, always show the numbers, because it's not much use if we don't.
