### PR TITLE
manpage update

### DIFF
--- a/docs/man/ipcluster.1
+++ b/docs/man/ipcluster.1
@@ -35,7 +35,9 @@ ipcluster start --n=4
 
 This command will start 4 IPython engines on the local computer.
 .SH SEE ALSO
-.BR ipython(1), ipcontroller(1), ipengine(1)
+.BR ipython(1),
+.BR ipcontroller(1),
+.BR ipengine(1)
 .br
 .SH AUTHOR
 \fBipcluster\fP is a tool that ships with IPython, created by

--- a/docs/man/ipcontroller.1
+++ b/docs/man/ipcontroller.1
@@ -133,7 +133,7 @@ whether to cleanup old logfiles before starting
 Default: 'leastload'
 Choices: ('leastload', 'pure', 'lru', 'plainrandom', 'weighted', 'twobin')
 select the task scheduler scheme  [default: Python LRU] Options are: 'pure',
-'lru', 'plainrandom', 'weighted', 'twobin','leastload'
+\&'lru', 'plainrandom', 'weighted', 'twobin','leastload'
 .TP
 .B \-\-keyfile=<Unicode> (Session.keyfile)
 Default: ''
@@ -142,7 +142,7 @@ path to file containing execution key.
 .B \-\-transport=<Unicode> (HubFactory.transport)
 Default: 'tcp'
 The 0MQ transport for communications.  This will likely be the default of
-'tcp', but other values include 'ipc', 'epgm', 'inproc'.
+\&'tcp', but other values include 'ipc', 'epgm', 'inproc'.
 .TP
 .B \-\-ssh=<Unicode> (IPControllerApp.ssh_server)
 Default: u''
@@ -150,7 +150,9 @@ ssh url for clients to use when connecting to the Controller processes. It
 should be of the form: [user@]server[:port]. The Controller's listening
 addresses must be accessible from the ssh server
 .SH SEE ALSO
-.BR ipython(1), ipcluster(1), ipengine(1)
+.BR ipython(1),
+.BR ipcluster(1),
+.BR ipengine(1)
 .br
 .SH AUTHOR
 \fBipcontroller\fP is a tool that ships with IPython, created by

--- a/docs/man/iplogger.1
+++ b/docs/man/iplogger.1
@@ -1,0 +1,98 @@
+.TH IPLOGGER 1 "July 21, 2011" "" ""
+.\" Man page generated from reStructeredText.
+.SH NAME
+\fBiplogger \- IPython logger for parallel computing.
+.SH DESCRIPTION
+Start an IPython logger for parallel computing.
+.sp
+IPython controllers and engines (and your own processes) can broadcast log
+messages by registering a \fIzmq.log.handlers.PUBHandler\fP with the \fIlogging\fP
+module. The logger can be configured using command line options or using a
+cluster directory. Cluster directories contain config, log and security files
+and are usually located in your ipython directory and named as "profile_name".
+See the \fIprofile\fP and \fIprofile\-dir\fP options for details.
+.SH OPTIONS
+.sp
+IPython command\-line arguments are passed as \(aq\-\-<flag>\(aq, or \(aq\-\-<name>=<value>\(aq.
+.sp
+Arguments that take values are actually convenience aliases to full
+Configurables, whose aliases are listed on the help line. For more information
+on full configurables, see \(aq\-\-help\-all\(aq.
+.TP
+.B \-\-debug
+.
+set log level to logging.DEBUG (maximize logging output)
+.TP
+.B \-\-init
+.
+Initialize profile with default config files. This is equivalent
+to running \fIipython profile create <profile>\fP prior to startup.
+.TP
+.B \-\-log\-to\-file
+.
+send log output to a file
+.TP
+.B \-\-quiet
+.
+set log level to logging.CRITICAL (minimize logging output)
+.TP
+.B \-\-profile=<Unicode> (BaseIPythonApplication.profile)
+.
+Default: u\(aqdefault\(aq
+The IPython profile to use.
+.TP
+.B \-\-log\-to\-file=<Bool> (BaseParallelApplication.log_to_file)
+.
+Default: False
+whether to log to a file
+.TP
+.B \-\-ipython\-dir=<Unicode> (BaseIPythonApplication.ipython_dir)
+.
+The name of the IPython directory. This directory is used for logging
+configuration (through profiles), history storage, etc. The default is
+usually $XDG_CONFIG_HOME/ipython. This options can also be specified
+through the environment variable IPYTHON_DIR.
+.TP
+.B \-\-url=<Unicode> (LogWatcher.url)
+.
+Default: \(aq\fI\%tcp://127.0.0.1:20202\fP\(aq
+ZMQ url on which to listen for log messages
+.TP
+.B \-\-topics=<List> (LogWatcher.topics)
+.
+Default: [\(aq\(aq]
+The ZMQ topics to subscribe to. Default is to subscribe to all messages
+.TP
+.B \-\-log\-level=<Enum> (Application.log_level)
+.
+Default: 30
+Choices: (0, 10, 20, 30, 40, 50, \(aqDEBUG\(aq, \(aqINFO\(aq, \(aqWARN\(aq, \(aqERROR\(aq, \(aqCRITICAL\(aq)
+Set the log level by value or name.
+.TP
+.B \-\-log\-url=<Unicode> (BaseParallelApplication.log_url)
+.
+Default: \(aq\(aq
+The ZMQ URL of the iplogger to aggregate logging.
+.TP
+.B \-\-clean\-logs=<Bool> (BaseParallelApplication.clean_logs)
+.
+Default: False
+whether to cleanup old logfiles before starting
+.TP
+.B \-\-profile\-dir=<Unicode> (ProfileDir.location)
+.
+Default: u\(aq\(aq
+Set the profile location directly. This overrides the logic used by the
+\fIprofile\fP option.
+.TP
+.B \-\-work\-dir=<Unicode> (BaseParallelApplication.work_dir)
+.
+Set the working dir for the process.
+.SH SEE ALSO
+.BR ipython(1),
+.BR ipcontroller(1),
+.BR ipengine(1)
+.br
+.SH AUTHOR
+\fBiplogger\fP is a tool that ships with IPython, created by
+the IPython Development Team.

--- a/docs/man/ipython.1
+++ b/docs/man/ipython.1
@@ -46,7 +46,7 @@ the default config file, do `ipython profile create`.
 .br
 .sp 1
 All options with a [no] prepended can be specified in negated form
-(\\--no\-option instead of \-\-option) to turn the feature off.
+(\-\-no\-option instead of \-\-option) to turn the feature off.
 .TP
 .B \-h, \-\-help
 Show summary of options.
@@ -174,7 +174,7 @@ Make IPython automatically call any callable object even if you didn't type
 explicit parentheses. For example, 'str 43' becomes 'str(43)' automatically.
 The value can be '0' to disable the feature, '1' for 'smart' autocall, where
 it is not applied if there are no more arguments on the line, and '2' for
-'full' autocall, where all callable objects are automatically called (even
+\&'full' autocall, where all callable objects are automatically called (even
 if no arguments are present). The default is '1'.
 .TP
 .B \-\-ipython-dir=<Unicode> (BaseIPythonApplication.ipython_dir)

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,10 @@ if len(sys.argv) >= 2 and sys.argv[1] in ('sdist','bdist_rpm'):
                   ['docs/man/ipengine.1'],
                   'cd docs/man && gzip -9c ipengine.1 > ipengine.1.gz'),
 
+                 ('docs/man/iplogger.1.gz',
+                  ['docs/man/iplogger.1'],
+                  'cd docs/man && gzip -9c iplogger.1 > iplogger.1.gz'),
+
                  ('docs/man/ipython.1.gz',
                   ['docs/man/ipython.1'],
                   'cd docs/man && gzip -9c ipython.1 > ipython.1.gz'),


### PR DESCRIPTION
fix a few formatting errors and a typo

& (zero-space space) to avoid a unknown macro warning due to ' in the beginning of the line (man --warnings -l file >/dev/null)
