### PR TITLE
Make pylab import all configurable 

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -61,6 +61,7 @@ from IPython.utils.text import LSString, SList, format_screen
 from IPython.utils.timing import clock, clock2
 from IPython.utils.warn import warn, error
 from IPython.utils.ipstruct import Struct
+from IPython.config.application import Application
 
 #-----------------------------------------------------------------------------
 # Utility functions
@@ -3442,7 +3443,17 @@ Defaulting color scheme to 'NoColor'"""
         Backend in use: Qt4Agg
         For more information, type 'help(pylab)'.
         """
-        self.shell.enable_pylab(s)
+        
+        if Application.initialized():
+            app = Application.instance()
+            try:
+                import_all_status = app.pylab_import_all
+            except AttributeError:
+                import_all_status = True 
+        else:
+            import_all_status = True
+        
+        self.shell.enable_pylab(s,import_all=import_all_status)
 
     def magic_tb(self, s):
         """Print the last traceback with the currently active exception mode.

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -29,7 +29,7 @@ from IPython.config.application import boolean_flag
 from IPython.config.configurable import Configurable
 from IPython.config.loader import Config
 from IPython.utils.path import filefind
-from IPython.utils.traitlets import Unicode, Instance, List
+from IPython.utils.traitlets import Unicode, Instance, List, Bool
 
 #-----------------------------------------------------------------------------
 # Aliases and Flags
@@ -132,6 +132,10 @@ class InteractiveShellApp(Configurable):
     )
     code_to_run = Unicode('', config=True,
         help="Execute the given command string."
+    )
+    pylab_import_all = Bool(True, config=True,
+        help="""If true, an 'import *' is done from numpy and pylab,
+        when using pylab"""
     )
     shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
 

--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -346,7 +346,10 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
             try:
                 self.log.info("Enabling GUI event loop integration, "
                               "toolkit=%s, pylab=%s" % (gui, self.pylab) )
-                activate(gui)
+                if self.pylab:
+                    activate(gui, import_all=self.pylab_import_all)
+                else:
+                    activate(gui)
             except:
                 self.log.warn("Error in enabling GUI event loop integration:")
                 self.shell.showtraceback()

--- a/IPython/lib/tests/test_irunner_pylab_magic.py
+++ b/IPython/lib/tests/test_irunner_pylab_magic.py
@@ -1,0 +1,108 @@
+"""Test suite for pylab_import_all magic
+Modified from the irunner module but using regex. 
+"""
+
+# Global to make tests extra verbose and help debugging
+VERBOSE = True
+
+# stdlib imports
+import cStringIO as StringIO
+import sys
+import unittest
+import re
+
+# IPython imports
+from IPython.lib import irunner
+from IPython.testing import decorators
+
+# Testing code begins
+class RunnerTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.out = StringIO.StringIO()
+        #self.out = sys.stdout
+
+    def _test_runner(self,runner,source,output):
+        """Test that a given runner's input/output match."""
+        
+        runner.run_source(source)
+        out = self.out.getvalue()
+        #out = ''
+        # this output contains nasty \r\n lineends, and the initial ipython
+        # banner.  clean it up for comparison, removing lines of whitespace
+        output_l = [l for l in output.splitlines() if l and not l.isspace()]
+        out_l = [l for l in out.splitlines() if l and not l.isspace()]
+        mismatch  = 0
+        if len(output_l) != len(out_l):
+            message = ("Mismatch in number of lines\n\n"
+                       "Expected:\n"
+                       "~~~~~~~~~\n"
+                       "%s\n\n"
+                       "Got:\n"
+                       "~~~~~~~~~\n"
+                       "%s"
+                       ) % ("\n".join(output_l), "\n".join(out_l))
+            self.fail(message)
+        for n in range(len(output_l)):
+            # Do a line-by-line comparison
+            ol1 = output_l[n].strip()
+            ol2 = out_l[n].strip()
+            if not re.match(ol1,ol2):
+                mismatch += 1
+                if VERBOSE:
+                    print '<<< line %s does not match:' % n
+                    print repr(ol1)
+                    print repr(ol2)
+                    print '>>>'
+        self.assert_(mismatch==0,'Number of mismatched lines: %s' %
+                     mismatch)
+
+    @decorators.skipif_not_matplotlib
+    def test_pylab_import_all_enabled(self):
+        "Verify that plot is available when pylab_import_all = True"
+        source = """
+from IPython.config.application import Application
+app = Application.instance()
+app.pylab_import_all = True
+pylab
+ip=get_ipython()
+'plot' in ip.user_ns
+        """
+        output = """
+In \[1\]: from IPython\.config\.application import Application
+In \[2\]: app = Application\.instance\(\)
+In \[3\]: app\.pylab_import_all = True
+In \[4\]: pylab
+^Welcome to pylab, a matplotlib-based Python environment
+For more information, type 'help\(pylab\)'\.
+In \[5\]: ip=get_ipython\(\)
+In \[6\]: \'plot\' in ip\.user_ns
+Out\[6\]: True
+"""
+        runner = irunner.IPythonRunner(out=self.out)
+        self._test_runner(runner,source,output)
+
+    @decorators.skipif_not_matplotlib
+    def test_pylab_import_all_disabled(self):
+        "Verify that plot is not available when pylab_import_all = False"
+        source = """
+from IPython.config.application import Application
+app = Application.instance()
+app.pylab_import_all = False
+pylab
+ip=get_ipython()
+'plot' in ip.user_ns
+        """
+        output = """
+In \[1\]: from IPython\.config\.application import Application
+In \[2\]: app = Application\.instance\(\)
+In \[3\]: app\.pylab_import_all = False
+In \[4\]: pylab
+^Welcome to pylab, a matplotlib-based Python environment
+For more information, type 'help\(pylab\)'\.
+In \[5\]: ip=get_ipython\(\)
+In \[6\]: \'plot\' in ip\.user_ns
+Out\[6\]: False
+"""
+        runner = irunner.IPythonRunner(out=self.out)
+        self._test_runner(runner,source,output)

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -313,6 +313,8 @@ skip_if_not_osx = skipif(sys.platform != 'darwin',
 # Other skip decorators
 skipif_not_numpy = skipif(module_not_available('numpy'),"This test requires numpy")
 
+skipif_not_matplotlib = skipif(module_not_available('matplotlib'),"This test requires matplotlib")
+
 skipif_not_sympy = skipif(module_not_available('sympy'),"This test requires sympy")
 
 skip_known_failure = knownfailureif(True,'This test is known to fail')

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -623,10 +623,6 @@ class IPKernelApp(KernelApp, InteractiveShellApp):
         selecting a particular matplotlib backend and loop integration.
         """
     )
-    pylab_import_all = Bool(True, config=True,
-        help="""If true, an 'import *' is done from numpy and pylab,
-        when using pylab"""
-    )
     def initialize(self, argv=None):
         super(IPKernelApp, self).initialize(argv)
         self.init_shell()


### PR DESCRIPTION
New version of pull request #551 This should of cause not be merged until after 0.11 
I have added a test and changed the magic function to use the import_all setting.

I few issues remain:

I don't like the way that the magic function works as the default value True is hard coded when `get_ipython().TerminalIPythonApp.pylab_import_all` is not set. Is there a simple way to get the default value here?

The test uses the magic function. It results in 2 warnings  because of problems with the gtk hook and because matplotlib.use. It would be better with a test that creates a new instance of IPython only for the test. I tried creating a new instance with code similar to the TerminalIPythonApp launch_new_instance. However this seems to lock the test framework. Any hints for making a better test are welcome. 
