### PR TITLE
import pexpect from IPython.external in irunner

### DIFF
--- a/IPython/lib/irunner.py
+++ b/IPython/lib/irunner.py
@@ -36,7 +36,10 @@ import os
 import sys
 
 # Third-party modules.
-import pexpect
+try:
+    import pexpect
+except ImportError:
+    from IPython.external import pexpect
 
 # Global usage strings, to avoid indentation issues when typing it below.
 USAGE = """


### PR DESCRIPTION
This is a trivial fix, but since it's technically a code change, I'm making it a PR.  irunner unconditionally imports pexpect, rather than falling back on IPython.external.pexpect, so it won't work in cases where it should.  I only noticed because I just cleaned out my whole environment and hadn't reinstalled pexpect yet.  You can't even build the docs if you don't have pexpect, because the import fails.
