### PR TITLE
support html representations in the notebook frontend

### DIFF
--- a/IPython/frontend/html/notebook/static/css/notebook.css
+++ b/IPython/frontend/html/notebook/static/css/notebook.css
@@ -285,6 +285,9 @@ div.output_latex {
     font-size: 116%;
 }
 
+div.output_html {
+}
+
 div.output_png {
 }
 

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -175,7 +175,9 @@ var IPython = (function (IPython) {
 
 
     CodeCell.prototype.append_display_data = function (data, element) {
-        if (data["text/latex"] !== undefined) {
+        if (data["text/html"] !== undefined) {
+            this.append_html(data["text/html"], element);
+        } else if (data["text/latex"] !== undefined) {
             this.append_latex(data["text/latex"], element);
             // If it is undefined, then we just appended to div.output, which
             // makes the latex visible and we can typeset it. The typesetting
@@ -192,6 +194,15 @@ var IPython = (function (IPython) {
         };
         return element;
     };
+
+
+    CodeCell.prototype.append_html = function (html, element) {
+        element = element || this.element.find("div.output");
+        var toinsert = $("<div/>").addClass("output_area output_html");
+        toinsert.append(html);
+        element.append(toinsert);
+        return element;
+    }
 
 
     CodeCell.prototype.append_stream = function (data, element) {


### PR DESCRIPTION
html repr was inserted has highest priority, because it is the native language of the web frontend.

quick example for embedding YouTube videos in a notebook:

https://gist.github.com/1114390
