### PR TITLE
print is a function, this allows to properly exit ipython

### DIFF
--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -232,7 +232,7 @@ def ask_yes_no(prompt,default=None):
         except EOFError:
             if default in answers.keys():
                 ans = default
-                print
+                print()
             else:
                 raise
 


### PR DESCRIPTION
Under Fedora 15 a single print seems to be not allowed in ipython,
so we need to use print as a function here.

After this commit, there is a proper newline on exiting with CTRL+d
