### PR TITLE
fix typo in docs/examples/vim/README.rst

### DIFF
--- a/docs/examples/vim/README.rst
+++ b/docs/examples/vim/README.rst
@@ -15,10 +15,10 @@ execute, and also get back object introspection and word completions in
 Vim, like what you get with: ``object?<enter>`` and ``object.<tab>`` in
 IPython.
 
-The big change from previous versions of ``ipy.vim`` is that it no longer 
-the old requires the brittle ipy_vimserver.py instantiation, and since 
-it uses just vim and python, it is platform independent (i.e. should work
-even on windows, unlike the previous \*nix only solution)
+The big change from previous versions of ``ipy.vim`` is that it no longer
+requires the brittle ipy_vimserver.py instantiation, and since it uses
+just vim and python, it is platform independent (i.e. should work even
+on windows, unlike the previous \*nix only solution)
 
 
 -----------------


### PR DESCRIPTION
removed "the old" before "requires the brittle"
