### PR TITLE
Usermod

### DIFF
--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -265,16 +265,16 @@ class DisplayHook(Configurable):
                 self.___ = self.__
                 self.__ = self._
                 self._ = result
-                self.shell.user_ns.update({'_':self._,
-                                           '__':self.__,
-                                           '___':self.___})
+                self.shell.push({'_':self._,
+                                 '__':self.__,
+                                '___':self.___}, interactive=False)
 
             # hackish access to top-level  namespace to create _1,_2... dynamically
             to_main = {}
             if self.do_full_cache:
                 new_result = '_'+`self.prompt_count`
                 to_main[new_result] = result
-                self.shell.user_ns.update(to_main)
+                self.shell.push(to_main, interactive=False)
                 self.shell.user_ns['_oh'][self.prompt_count] = result
 
     def log_output(self, format_dict):

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -559,7 +559,8 @@ class HistoryManager(HistoryAccessor):
                    '_ii': self._ii,
                    '_iii': self._iii,
                    new_i : self._i00 }
-        self.shell.user_ns.update(to_main)
+
+        self.shell.push(to_main, interactive=False)
 
     def store_output(self, line_num):
         """If database output logging is enabled, this saves all the

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -29,6 +29,8 @@ import re
 import sys
 import tempfile
 import types
+from weakref import proxy
+
 try:
     from contextlib import nested
 except:
@@ -1056,7 +1058,8 @@ class InteractiveShell(SingletonConfigurable, Magic):
 
         # Store myself as the public api!!!
         ns['get_ipython'] = self.get_ipython
-
+        ns['_ipy'] = proxy(self)   # Weak ref since this is a circular reference
+        
         ns['exit'] = self.exiter
         ns['quit'] = self.exiter
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -29,7 +29,6 @@ import re
 import sys
 import tempfile
 import types
-from weakref import proxy
 
 try:
     from contextlib import nested
@@ -1058,7 +1057,6 @@ class InteractiveShell(SingletonConfigurable, Magic):
 
         # Store myself as the public api!!!
         ns['get_ipython'] = self.get_ipython
-        ns['_ipy'] = proxy(self)   # Weak ref since this is a circular reference
         
         ns['exit'] = self.exiter
         ns['quit'] = self.exiter

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -978,8 +978,8 @@ class InteractiveShell(SingletonConfigurable, Magic):
         # We must ensure that __builtin__ (without the final 's') is always
         # available and pointing to the __builtin__ *module*.  For more details:
         # http://mail.python.org/pipermail/python-dev/2001-April/014068.html
-        user_module.__dict__.setdefault('__builtin__',__builtin__)
-        user_module.__dict__.setdefault('__builtins__',__builtin__)
+        user_module.__dict__.setdefault('__builtin__', builtin_mod)
+        user_module.__dict__.setdefault('__builtins__', builtin_mod)
         
         if user_ns is None:
             user_ns = user_module.__dict__

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -748,11 +748,10 @@ Currently the magic system has the following functions:\n"""
         """
 
         user_ns = self.shell.user_ns
-        internal_ns = self.shell.internal_ns
         user_ns_hidden = self.shell.user_ns_hidden
         out = [ i for i in user_ns
                 if not i.startswith('_') \
-                and not (i in internal_ns or i in user_ns_hidden) ]
+                and not i in user_ns_hidden ]
 
         typelist = parameter_s.split()
         if typelist:

--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -86,7 +86,7 @@ def is_shadowed(identifier, ip):
     than ifun, because it can not contain a '.' character."""
     # This is much safer than calling ofind, which can change state
     return (identifier in ip.user_ns \
-            or identifier in ip.internal_ns \
+            or identifier in ip.user_global_ns \
             or identifier in ip.ns_table['builtin'])
 
 

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -180,7 +180,7 @@ class InteractiveShellTestCase(unittest.TestCase):
         "Code in functions must be able to access variables outside them."
         ip = get_ipython()
         ip.run_cell("a = 10")
-        ip.run_cell(("def f(x):"
+        ip.run_cell(("def f(x):\n"
                      "    return x + a"))
         ip.run_cell("b = f(12)")
         self.assertEqual(ip.user_ns["b"], 22)

--- a/IPython/core/tests/test_iplib.py
+++ b/IPython/core/tests/test_iplib.py
@@ -28,7 +28,6 @@ ip = get_ipython()
 # Test functions
 #-----------------------------------------------------------------------------
 
-@dec.parametric
 def test_reset():
     """reset must clear most namespaces."""
     # The number of variables in the private user_ns_hidden is not zero, but it
@@ -49,8 +48,8 @@ def test_reset():
     
     # Finally, check that all namespaces have only as many variables as we
     # expect to find in them:
-    yield nt.assert_equals(len(ip.user_ns), nvars_expected)
-    yield nt.assert_equals(len(ip.user_ns_hidden), nvars_hidden)
+    nt.assert_equals(len(ip.user_ns), nvars_user_ns)
+    nt.assert_equals(len(ip.user_ns_hidden), nvars_hidden)
 
 
 # Tests for reporting of exceptions in various modes, handling of SystemExit,

--- a/IPython/core/tests/test_iplib.py
+++ b/IPython/core/tests/test_iplib.py
@@ -30,9 +30,6 @@ ip = get_ipython()
 
 def test_reset():
     """reset must clear most namespaces."""
-    # The number of variables in the private user_ns_hidden is not zero, but it
-    # should be constant regardless of what we do
-    nvars_hidden = len(ip.user_ns_hidden)
 
     # Check that reset runs without error
     ip.reset()
@@ -40,6 +37,7 @@ def test_reset():
     # Once we've reset it (to clear of any junk that might have been there from
     # other tests, we can count how many variables are in the user's namespace
     nvars_user_ns = len(ip.user_ns)
+    nvars_hidden = len(ip.user_ns_hidden)
 
     # Now add a few variables to user_ns, and check that reset clears them
     ip.user_ns['x'] = 1

--- a/IPython/core/tests/test_iplib.py
+++ b/IPython/core/tests/test_iplib.py
@@ -33,7 +33,7 @@ def test_reset():
     """reset must clear most namespaces."""
     # The number of variables in the private user_ns_hidden is not zero, but it
     # should be constant regardless of what we do
-    nvars_config_ns = len(ip.user_ns_hidden)
+    nvars_hidden = len(ip.user_ns_hidden)
 
     # Check that reset runs without error
     ip.reset()
@@ -49,15 +49,8 @@ def test_reset():
     
     # Finally, check that all namespaces have only as many variables as we
     # expect to find in them:
-    for ns in ip.ns_refs_table:
-        if ns is ip.user_ns:
-            nvars_expected = nvars_user_ns
-        elif ns is ip.user_ns_hidden:
-            nvars_expected = nvars_config_ns
-        else:
-            nvars_expected = 0
-            
-        yield nt.assert_equals(len(ns), nvars_expected)
+    yield nt.assert_equals(len(ip.user_ns), nvars_expected)
+    yield nt.assert_equals(len(ip.user_ns_hidden), nvars_hidden)
 
 
 # Tests for reporting of exceptions in various modes, handling of SystemExit,

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -228,3 +228,15 @@ tclass.py: deleting object: C-third
         else:
             err = None
         tt.ipexec_validate(self.fname, out, err)
+
+    def test_run_i_after_reset(self):
+        """Check that %run -i still works after %reset (gh-693)"""
+        src = "yy = zz\n"
+        self.mktmp(src)
+        _ip.run_cell("zz = 23")
+        _ip.magic('run -i %s' % self.fname)
+        tt.assert_equals(_ip.user_ns['yy'], 23)
+        _ip.magic('reset -f')
+        _ip.run_cell("zz = 23")
+        _ip.magic('run -i %s' % self.fname)
+        tt.assert_equals(_ip.user_ns['yy'], 23)

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -172,13 +172,13 @@ class TerminalInteractiveShell(InteractiveShell):
     )
 
     def __init__(self, config=None, ipython_dir=None, profile_dir=None, user_ns=None,
-                 user_global_ns=None, custom_exceptions=((),None),
+                 user_module=None, custom_exceptions=((),None),
                  usage=None, banner1=None, banner2=None,
                  display_banner=None):
 
         super(TerminalInteractiveShell, self).__init__(
             config=config, profile_dir=profile_dir, user_ns=user_ns,
-            user_global_ns=user_global_ns, custom_exceptions=custom_exceptions
+            user_module=user_module, custom_exceptions=custom_exceptions
         )
         # use os.system instead of utils.process.system by default,
         # because piped system doesn't make sense in the Terminal:

--- a/IPython/testing/globalipapp.py
+++ b/IPython/testing/globalipapp.py
@@ -190,7 +190,6 @@ def start_ipython():
     # Create and initialize our test-friendly IPython instance.
     shell = TerminalInteractiveShell.instance(config=config,
                                               user_ns=ipnsdict(),
-                                              user_global_ns={}
                                               )
 
     # A few more tweaks needed for playing nicely with doctests...

--- a/IPython/testing/globalipapp.py
+++ b/IPython/testing/globalipapp.py
@@ -205,8 +205,7 @@ def start_ipython():
     # can capture subcommands and print them to Python's stdout, otherwise the
     # doctest machinery would miss them.
     shell.system = py3compat.MethodType(xsys, shell)
-
-
+    
     shell._showtraceback = py3compat.MethodType(_showtraceback, shell)
 
     # IPython is ready, now clean up some global state...

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -271,6 +271,8 @@ class DocTestCase(doctests.DocTestCase):
             # for IPython examples *only*, we swap the globals with the ipython
             # namespace, after updating it with the globals (which doctest
             # fills with the necessary info from the module being tested).
+            self.user_ns_orig = {}
+            self.user_ns_orig.update(_ip.user_ns)
             _ip.user_ns.update(self._dt_test.globs)
             self._dt_test.globs = _ip.user_ns
             # IPython must protect the _ key in the namespace (it can't exist)
@@ -286,6 +288,8 @@ class DocTestCase(doctests.DocTestCase):
         # teardown doesn't destroy the ipython namespace
         if isinstance(self._dt_test.examples[0],IPExample):
             self._dt_test.globs = self._dt_test_globs_ori
+            _ip.user_ns.clear()
+            _ip.user_ns.update(self.user_ns_orig)
             # Restore the behavior of the '_' key in the user namespace to
             # normal after each doctest, so that unittests behave normally
             _ip.user_ns.protect_underscore = False

--- a/docs/source/whatsnew/development.txt
+++ b/docs/source/whatsnew/development.txt
@@ -97,6 +97,10 @@ Major Bugs fixed
 * IPython no longer crashes when started on recent versions of Python 3 in
   Windows (:ghissue:`737`).
 
+* Instances of classes defined interactively can now be pickled (:ghissue:`29`;
+  :ghpull:`648`). Note that pickling saves a reference to the class definition,
+  so unpickling the instances will only work where the class has been defined.
+
 .. * use bullet list
 
 Backwards incompatible changes
@@ -131,5 +135,11 @@ Backwards incompatible changes
 
   The full path will still work, and is necessary for using custom launchers not in
   IPython's launcher module.
+
+* For embedding a shell, note that the parameter ``user_global_ns`` has been
+  replaced by ``user_module``, and expects a module-like object, rather than
+  a namespace dict. The ``user_ns`` parameter works the same way as before, and
+  calling :func:`~IPython.frontend.terminal.embed.embed` with no arguments still
+  works the same way.
 
 .. * use bullet list


### PR DESCRIPTION
This is intended to supersede my PR #384, where I made it possible to pickle interactively defined objects. While I was working on that, I realised that our distinction between local and global namespaces is a bit unclear (because they're usually the same thing). This goes some way towards clearing that up.

A global namespace should always be tied to a module: pickle accesses classes via the module in which they're defined. So I've changed the arguments for instantiating an InteractiveShell to include `user_module` in place of `user_global_ns`. The global namespace simply becomes a reference to `user_module.__dict__`.

For instantiating InteractiveShell, there are four possibilities:
- Neither `user_ns` nor `user_module` is given. A new (real) module is created named `__main__`, and its `__dict__` becomes the global and local namespace. This is what happens when starting IPython normally.
- Only `user_module` is given. Its `__dict__` becomes the global and local namespace.
- Both `user_ns` and `user_module` are given. `user_module.__dict__` is the global namespace, and `user_ns` is the local namespace. Note that we can't interactively define closures over variables in the local namespace (this seems to be a limitation of Python).
- Only `user_ns` is given. It is treated as the global and local namespace, and a `DummyMod` object is created to refer to it. This is intended as a convenience, especially for the test suite. The recommended way to pass in a single global namespace is as a reference to the module.

`embed()` digs out the locals and the module from the frame in which it's called.

While I was doing namespaces, I also re-included a reference to the InteractiveShell, as a weakref proxy, named `_ipy`.
