### PR TITLE
i658

### DIFF
--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -143,9 +143,10 @@ class Application(SingletonConfigurable):
 
     def __init__(self, **kwargs):
         SingletonConfigurable.__init__(self, **kwargs)
-        # Add my class to self.classes so my attributes appear in command line
-        # options.
-        self.classes.insert(0, self.__class__)
+        # Ensure my class is in self.classes, so my attributes appear in command line
+        # options and config files.
+        if self.__class__ not in self.classes:
+            self.classes.insert(0, self.__class__)
         
         self.init_logging()
 

--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -48,7 +48,7 @@ from IPython.lib import inputhook
 from IPython.utils import warn
 from IPython.utils.path import get_ipython_dir, check_for_old_config
 from IPython.utils.traitlets import (
-    Bool, Dict, CaselessStrEnum
+    Bool, List, Dict, CaselessStrEnum
 )
 
 #-----------------------------------------------------------------------------
@@ -189,8 +189,17 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
 
     flags = Dict(flags)
     aliases = Dict(aliases)
-    classes = [InteractiveShellApp, TerminalInteractiveShell, ProfileDir,
-               PlainTextFormatter]
+    classes = List()
+    def _classes_default(self):
+        """This has to be in a method, for TerminalIPythonApp to be available."""
+        return [
+            InteractiveShellApp, # ShellApp comes before TerminalApp, because
+            self.__class__,      # it will also affect subclasses (e.g. QtConsole)
+            TerminalInteractiveShell,
+            ProfileDir,
+            PlainTextFormatter,
+        ]
+    
     subcommands = Dict(dict(
         qtconsole=('IPython.frontend.qt.console.qtconsoleapp.IPythonQtConsoleApp',
             """Launch the IPython Qt Console."""


### PR DESCRIPTION
move InteractiveShellApp before TerminalIPythonApp in TerminalApp class list

This is useful because InteractiveShellApp is a parent that affects
all IPython apps, so it makes sense to come first.

The change affects auto generated ipython_config.py and the output
of `ipython --help-all`.

Also prevents duplicate entries for `self.__class__`

closes gh-658
