### PR TITLE
Remove ipythonrc references from documentation

### DIFF
--- a/IPython/core/hooks.py
+++ b/IPython/core/hooks.py
@@ -13,7 +13,7 @@ itself, so hooks have full access to the entire IPython object.
 
 If you wish to define a new hook and activate it, you need to put the
 necessary code into a python file which can be either imported or execfile()'d
-from within your ipythonrc configuration.
+from within your profile's ipython_config.py configuration.
 
 For example, suppose that you have a module called 'myiphooks' in your
 PYTHONPATH, which contains the following definition:

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -641,9 +641,9 @@ Currently the magic system has the following functions:\n"""
 
           -i/-c: make the pattern case insensitive/sensitive.  If neither of
           these options are given, the default is read from your configuration
-          file, with the option name 'wildcards_case_sensitive'. If this option
-          is not specified in your configuration file, IPython's internal 
-          default is to do a case sensitive search.
+          file, with the option ``InteractiveShell.wildcards_case_sensitive``. 
+          If this option is not specified in your configuration file, IPython's 
+          internal default is to do a case sensitive search.
 
           -e/-s NAMESPACE: exclude/search a given namespace.  The pattern you
           specifiy can be searched in any of the following namespaces:
@@ -1230,7 +1230,7 @@ Currently the magic system has the following functions:\n"""
         this feature on and off.
 
         The initial state of this feature is set in your configuration
-        file (the option is called 'pdb').
+        file (the option is ``InteractiveShell.pdb``).
 
         If you want to just activate the debugger AFTER an exception has fired,
         without having to type '%pdb on' and rerunning your code, you can use
@@ -2269,10 +2269,11 @@ Currently the magic system has the following functions:\n"""
         docstring for how to change the editor hook.
 
         You can also set the value of this editor via the command line option
-        '-editor' or in your configuration file. This is useful if you wish to 
-        use specifically for IPython an editor different from your typical 
-        default (and for Windows users who typically don't set environment 
-        variables).
+        '-editor' or in your configuration file (via the 
+        ``TerminalInteractiveShell.editor`` option). This is useful if you wish 
+        to use an editor specifcally for  IPython that is different from your  
+        typical default (and for Windows users who typically don't set  
+        environment variables).
 
         This command allows you to conveniently edit multi-line code right in
         your IPython session.

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -640,11 +640,10 @@ Currently the magic system has the following functions:\n"""
           search.
 
           -i/-c: make the pattern case insensitive/sensitive.  If neither of
-          these options is given, the default is read from your ipythonrc
-          file.  The option name which sets this value is
-          'wildcards_case_sensitive'.  If this option is not specified in your
-          ipythonrc file, IPython's internal default is to do a case sensitive
-          search.
+          these options are given, the default is read from your configuration
+          file, with the option name 'wildcards_case_sensitive'. If this option
+          is not specified in your configuration file, IPython's internal 
+          default is to do a case sensitive search.
 
           -e/-s NAMESPACE: exclude/search a given namespace.  The pattern you
           specifiy can be searched in any of the following namespaces:
@@ -1230,8 +1229,8 @@ Currently the magic system has the following functions:\n"""
         interactive pdb debugger after the traceback printout. %pdb toggles
         this feature on and off.
 
-        The initial state of this feature is set in your ipythonrc
-        configuration file (the variable is called 'pdb').
+        The initial state of this feature is set in your configuration
+        file (the option is called 'pdb').
 
         If you want to just activate the debugger AFTER an exception has fired,
         without having to type '%pdb on' and rerunning your code, you can use
@@ -2270,9 +2269,10 @@ Currently the magic system has the following functions:\n"""
         docstring for how to change the editor hook.
 
         You can also set the value of this editor via the command line option
-        '-editor' or in your ipythonrc file. This is useful if you wish to use
-        specifically for IPython an editor different from your typical default
-        (and for Windows users who typically don't set environment variables).
+        '-editor' or in your configuration file. This is useful if you wish to 
+        use specifically for IPython an editor different from your typical 
+        default (and for Windows users who typically don't set environment 
+        variables).
 
         This command allows you to conveniently edit multi-line code right in
         your IPython session.

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2268,11 +2268,10 @@ Currently the magic system has the following functions:\n"""
         vi under Linux/Unix and to notepad under Windows.  See the end of this
         docstring for how to change the editor hook.
 
-        You can also set the value of this editor via the command line option
-        '-editor' or in your configuration file (via the 
-        ``TerminalInteractiveShell.editor`` option). This is useful if you wish 
-        to use an editor specifcally for  IPython that is different from your  
-        typical default (and for Windows users who typically don't set  
+        You can also set the value of this editor via the 
+        ``TerminalInteractiveShell.editor`` option in your configuration file. 
+        This is useful if you wish to use a different editor from your typical 
+        default with IPython (and for Windows users who typically don't set 
         environment variables).
 
         This command allows you to conveniently edit multi-line code right in

--- a/IPython/core/usage.py
+++ b/IPython/core/usage.py
@@ -81,7 +81,7 @@ MAIN FEATURES
 
 * Magic commands: type %magic for information on the magic subsystem.
 
-* System command aliases, via the %alias command or the ipythonrc config file.
+* System command aliases, via the %alias command or the configuration file(s).
 
 * Dynamic object information:
 

--- a/IPython/lib/irunner.py
+++ b/IPython/lib/irunner.py
@@ -328,9 +328,10 @@ class PythonRunner(InteractiveRunner):
 class SAGERunner(InteractiveRunner):
     """Interactive SAGE runner.
     
-    WARNING: this runner only works if you manually configure your SAGE copy
-    to use 'colors NoColor' in the ipythonrc config file, since currently the
-    prompt matching regexp does not identify color sequences."""
+    WARNING: this runner only works if you manually adjust your SAGE 
+    configuration so that the 'color' option in the configuration file is set to
+    'NoColor', because currently the prompt matching regexp does not identify 
+    color sequences."""
 
     def __init__(self,program='sage',args=None,out=sys.stdout,echo=True):
         """New runner, optionally passing the sage command to use."""

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -3,11 +3,10 @@
 Limitations:
 
 - When generating examples for use as doctests, make sure that you have
-  pretty-printing OFF.  This can be done either by starting ipython with the
-  flag '--nopprint', by setting pprint to 0 in your ipythonrc file, or by
-  interactively disabling it with %Pprint.  This is required so that IPython
-  output matches that of normal Python, which is used by doctest for internal
-  execution.
+  pretty-printing OFF.  This can be done either by setting the 'pprint' option 
+  in your configuration file to  'False', or by interactively disabling it with 
+  %Pprint.  This is required so that IPython output matches that of normal 
+  Python, which is used by doctest for internal execution.
 
 - Do not rely on specific prompt numbers for results (such as using
   '_34==True', for example).  For IPython tests run via an external process the

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -3,10 +3,11 @@
 Limitations:
 
 - When generating examples for use as doctests, make sure that you have
-  pretty-printing OFF.  This can be done either by setting the 'pprint' option 
-  in your configuration file to  'False', or by interactively disabling it with 
-  %Pprint.  This is required so that IPython output matches that of normal 
-  Python, which is used by doctest for internal execution.
+  pretty-printing OFF.  This can be done either by setting the 
+  ``PlainTextFormatter.pprint`` option in your configuration file to  False, or 
+  by interactively disabling it with  %Pprint.  This is required so that IPython
+  output matches that of normal Python, which is used by doctest for internal 
+  execution.
 
 - Do not rely on specific prompt numbers for results (such as using
   '_34==True', for example).  For IPython tests run via an external process the

--- a/IPython/zmq/zmqshell.py
+++ b/IPython/zmq/zmqshell.py
@@ -242,9 +242,10 @@ class ZMQInteractiveShell(InteractiveShell):
         docstring for how to change the editor hook.
 
         You can also set the value of this editor via the command line option
-        '-editor' or in your ipythonrc file. This is useful if you wish to use
-        specifically for IPython an editor different from your typical default
-        (and for Windows users who typically don't set environment variables).
+        '-editor' or via the 'editor' option in your configuration file. 
+        This is useful if you wish to use  specifically for IPython an editor 
+        different from your typical default (and for Windows users who typically
+        don't set environment variables).
 
         This command allows you to conveniently edit multi-line code right in
         your IPython session.

--- a/IPython/zmq/zmqshell.py
+++ b/IPython/zmq/zmqshell.py
@@ -236,16 +236,16 @@ class ZMQInteractiveShell(InteractiveShell):
           %edit [options] [args]
 
         %edit runs IPython's editor hook.  The default version of this hook is
-        set to call the __IPYTHON__.rc.editor command.  This is read from your
+        set to call the __IPYTHON__.rc.dditor command.  This is read from your
         environment variable $EDITOR.  If this isn't found, it will default to
         vi under Linux/Unix and to notepad under Windows.  See the end of this
         docstring for how to change the editor hook.
 
-        You can also set the value of this editor via the command line option
-        '-editor' or via the 'editor' option in your configuration file. 
-        This is useful if you wish to use  specifically for IPython an editor 
-        different from your typical default (and for Windows users who typically
-        don't set environment variables).
+        You can also set the value of this editor via the 
+        ``TerminalInteractiveShell.editor`` option in your configuration file. 
+        This is useful if you wish to use a different editor from your typical 
+        default with IPython (and for Windows users who typically don't set 
+        environment variables).
 
         This command allows you to conveniently edit multi-line code right in
         your IPython session.

--- a/docs/source/interactive/reference.txt
+++ b/docs/source/interactive/reference.txt
@@ -19,10 +19,12 @@ file and ignore your configuration setup.
 
 Please note that some of the configuration options are not available at
 the command line, simply because they are not practical here. Look into
-your ipythonrc configuration file for details on those. This file is typically 
-installed in the IPYTHON_DIR directory. For Linux
-users, this will be $HOME/.config/ipython, and for other users it will be
-$HOME/.ipython.  For Windows users, $HOME resolves to C:\\Documents and
+your configuration files for details on those. There are separate configuration 
+files for each profile, and the files look like "ipython_config.py" or 
+"ipython_config_<frontendname>.py".  Profile directories look like 
+"profile_profilename" and are typically installed in the IPYTHON_DIR directory. 
+For Linux users, this will be $HOME/.config/ipython, and for other users it 
+will be $HOME/.ipython.  For Windows users, $HOME resolves to C:\\Documents and
 Settings\\YourUserName in most instances.
 
 
@@ -46,9 +48,9 @@ follow in any order. All options can be abbreviated to their shortest
 non-ambiguous form and are case-sensitive. One or two dashes can be
 used. Some options have an alternate short form, indicated after a ``|``.
 
-Most options can also be set from your ipythonrc configuration file. See
-the provided example for more details on what the options do. Options
-given at the command line override the values set in the ipythonrc file.
+Most options can also be set from your configuration file. See the provided
+example for more details on what the options do. Options given at the command
+line override the values set in the configuration file.
 
 All options with a [no] prepended can be specified in negated form
 (--no-option instead of --option) to turn the feature off.
@@ -110,7 +112,7 @@ All options with a [no] prepended can be specified in negated form
 	code and various other elements.  However, because this information is
 	passed through a pager (like 'less') and many pagers get confused with
 	color codes, this option is off by default. You can test it and turn
-	it on permanently in your ipythonrc file if it works for you. As a
+	it on permanently in your configuration file if it works for you. As a
 	reference, the 'less' pager supplied with Mandrake 8.2 works ok, but
 	that in RedHat 7.2 doesn't.
 
@@ -569,7 +571,7 @@ syntax for this can be found in the readline documentation available
 with your system or on the Internet. IPython doesn't read this file (if
 it exists) directly, but it does support passing to readline valid
 options via a simple interface. In brief, you can customize readline by
-setting the following options in your ipythonrc configuration file (note
+setting the following options in your configuration file (note
 that these options can not be specified at the command line):
 
     * **readline_parse_and_bind**: this option can appear as many times as
@@ -594,8 +596,7 @@ that these options can not be specified at the command line):
       This option is off by default so that new users see all
       attributes of any objects they are dealing with.
 
-You will find the default values along with a corresponding detailed
-explanation in your ipythonrc file.
+You will find the default values in your configuration file.
 
 
 Session logging and restoring
@@ -696,8 +697,7 @@ Even object attributes can be expanded::
 System command aliases
 ----------------------
 
-The %alias magic function and the alias option in the ipythonrc
-configuration file allow you to define magic functions which are in fact
+The %alias magic functionallows you to define magic functions which are in fact
 system shell commands. These aliases can have parameters.
 
 ``%alias alias_name cmd`` defines 'alias_name' as an alias for 'cmd'
@@ -828,7 +828,7 @@ accidentally overwrite the Out variable you can recover it by typing
 This system obviously can potentially put heavy memory demands on your
 system, since it prevents Python's garbage collector from removing any
 previously computed results. You can control how many results are kept
-in memory with the option (at the command line or in your ipythonrc
+in memory with the option (at the command line or in your configuration
 file) cache_size. If you set it to 0, the whole system is completely
 disabled and the prompts revert to the classic '>>>' of normal Python.
 

--- a/docs/source/interactive/reference.txt
+++ b/docs/source/interactive/reference.txt
@@ -697,7 +697,7 @@ Even object attributes can be expanded::
 System command aliases
 ----------------------
 
-The %alias magic functionallows you to define magic functions which are in fact
+The %alias magic function allows you to define magic functions which are in fact
 system shell commands. These aliases can have parameters.
 
 ``%alias alias_name cmd`` defines 'alias_name' as an alias for 'cmd'

--- a/docs/source/interactive/tips.txt
+++ b/docs/source/interactive/tips.txt
@@ -127,5 +127,9 @@ the IPython user list.
 .. Now I have a nice little directory with everything I ever type in,
    organized by project and date.
 
+.. warning::
+   
+   This example uses the outdated ipythonrc-style configuration files, which no
+   longer work as of IPython 0.11
 
 


### PR DESCRIPTION
This pull request should remove all references to the old-style ipythonrc from the ipython documentation and docstrings (except where it is intentionally referring to an old version).

Note that I've left everything in quarantine and deathrow untouched, as well as docs/source/config/old.txt .

There was one reference to setting aliases in ipythonrc that I simply deleted, as the new ipython_config.py file does not seem to mention aliases.  If there's some way of adding aliases that isn't in the default ipython_config.py, I can easily add that in. 
