### PR TITLE
parallel tests & extra readline escapes

### DIFF
--- a/IPython/parallel/tests/test_client.py
+++ b/IPython/parallel/tests/test_client.py
@@ -228,6 +228,8 @@ class TestClient(ClusterTestCase):
         v = self.client.load_balanced_view()
         ar = v.apply_async(f)
         r1 = ar.get(1)
+        # give the Hub a chance to notice:
+        time.sleep(0.5)
         ahr = self.client.resubmit(ar.msg_ids)
         r2 = ahr.get(1)
         self.assertFalse(r1 == r2)

--- a/IPython/parallel/tests/test_lbview.py
+++ b/IPython/parallel/tests/test_lbview.py
@@ -59,6 +59,7 @@ class TestLoadBalancedView(ClusterTestCase):
     def test_abort(self):
         view = self.view
         ar = self.client[:].apply_async(time.sleep, .5)
+        ar = self.client[:].apply_async(time.sleep, .5)
         ar2 = view.apply_async(lambda : 2)
         ar3 = view.apply_async(lambda : 3)
         view.abort(ar2)

--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -319,7 +319,7 @@ class TestView(ClusterTestCase):
         ip.magic_px('print a')
         sys.stdout = savestdout
         buf = sio.getvalue()
-        self.assertTrue('[stdout:%i]'%v.targets in buf)
+        self.assertTrue('[stdout:' in buf, buf)
         self.assertTrue(buf.rstrip().endswith('10'))
         self.assertRaisesRemote(ZeroDivisionError, ip.magic_px, '1/0')
 

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -213,7 +213,18 @@ def ipexec(fname, options=None):
     full_fname = os.path.join(test_dir, fname)
     full_cmd = '%s %s %s' % (ipython_cmd, cmdargs, full_fname)
     #print >> sys.stderr, 'FULL CMD:', full_cmd # dbg
-    return getoutputerror(full_cmd)
+    out = getoutputerror(full_cmd)
+    # `import readline` causes 'ESC[?1034h' to be the first output sometimes,
+    # so strip that off the front of the first line if it is found
+    if out:
+        first = out[0]
+        m = re.match(r'\x1b\[[^h]+h', first)
+        if m:
+            # strip initial readline escape
+            out = list(out)
+            out[0] = first[len(m.group()):]
+            out = tuple(out)
+    return out
 
 
 def ipexec_validate(fname, expected_out, expected_err='',


### PR DESCRIPTION
See #662

This adds some extra waits, etc. to a few parallel tests, to make them less likely to fail, which they have done on rare occasion.  It's difficult to be conclusive, given the multiprocessing/network nature of the tests.

It has also been revealed that when building python-readline for OSX 10.7 python-2.7, `import readline` prints the escape 'ESC[?1034h' to stdout (not sys.stdout, because it doesn't appear to be redirected, the hardwired process stdout).  Since I've seen reference to this behavior of readline even outside Python (http://www.google.com/search?q=readline+1034h), I added handling to ignore it in the test suite, so `IPython.core.tests.test_run` once again passes all tests on system Python on OSX 10.7.
