### PR TITLE
HistoryManager.get_session_info()

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2540,15 +2540,17 @@ class InteractiveShell(SingletonConfigurable, Magic):
         code that has the appropriate information, rather than trying to
         clutter 
         """
+        # Close the history session (this stores the end time and line count)
+        # this must be *before* the tempfile cleanup, in case of temporary
+        # history db
+        self.history_manager.end_session()
+        
         # Cleanup all tempfiles left around
         for tfile in self.tempfiles:
             try:
                 os.unlink(tfile)
             except OSError:
                 pass
-        
-        # Close the history session (this stores the end time and line count)
-        self.history_manager.end_session()
         
         # Clear all user namespaces to release all references cleanly.
         self.reset(new_session=False)

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -9,7 +9,7 @@
 import os
 import sys
 import unittest
-
+from datetime import datetime
 # third party
 import nose.tools as nt
 
@@ -107,3 +107,8 @@ def test_magic_rerun():
     nt.assert_equal(ip.user_ns["a"], 11)
     ip.run_cell("%rerun")
     nt.assert_equal(ip.user_ns["a"], 12)
+
+def test_timestamp_type():
+    ip = get_ipython()
+    info = ip.history_manager.get_session_info()
+    nt.assert_true(isinstance(info[1], datetime))

--- a/IPython/testing/globalipapp.py
+++ b/IPython/testing/globalipapp.py
@@ -194,6 +194,9 @@ def start_ipython():
 
     # A few more tweaks needed for playing nicely with doctests...
     
+    # remove history file
+    shell.tempfiles.append(config.HistoryManager.hist_file)
+    
     # These traps are normally only active for interactive use, set them
     # permanently since we'll be mocking interactive sessions.
     shell.builtin_trap.activate()

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -171,7 +171,7 @@ def default_config():
     config.TerminalInteractiveShell.colors = 'NoColor'
     config.TerminalTerminalInteractiveShell.term_title = False,
     config.TerminalInteractiveShell.autocall = 0
-    config.HistoryManager.hist_file = os.path.join(tempfile.mkdtemp(), u'test_hist.sqlite')
+    config.HistoryManager.hist_file = tempfile.mktemp(u'test_hist.sqlite')
     config.HistoryManager.db_cache_size = 10000
     return config
 

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -31,6 +31,7 @@ from __future__ import absolute_import
 import os
 import re
 import sys
+import tempfile
 
 from contextlib import contextmanager
 
@@ -170,7 +171,7 @@ def default_config():
     config.TerminalInteractiveShell.colors = 'NoColor'
     config.TerminalTerminalInteractiveShell.term_title = False,
     config.TerminalInteractiveShell.autocall = 0
-    config.HistoryManager.hist_file = u'test_hist.sqlite'
+    config.HistoryManager.hist_file = os.path.join(tempfile.mkdtemp(), u'test_hist.sqlite')
     config.HistoryManager.db_cache_size = 10000
     return config
 


### PR DESCRIPTION
add simple get_session_info method to HistoryManager for fetching session timestamps, etc.

Also sets detect_types flags on the db connection, so timestamps are retrieved as datetime objects.

The test history file has been moved to a tempdir, so that we don't get test_hist.sqlite files all over the filesystem when running the test suite.
