### PR TITLE
BF - allow nose with-doctest setting in environment

### DIFF
--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -355,19 +355,13 @@ def run_iptest():
         # for nose >= 0.11, though unfortunately nose 0.10 doesn't support it.
         argv.append('--traverse-namespace')
 
-    # Construct list of plugins, omitting the existing doctest plugin, which
-    # ours replaces (and extends).
+    # use our plugin for doctesting.  It will remove the standard doctest plugin
+    # if it finds it enabled
     plugins = [IPythonDoctest(make_exclude()), KnownFailure()]
-    for p in nose.plugins.builtin.plugins:
-        plug = p()
-        if plug.name == 'doctest':
-            continue
-        plugins.append(plug)
-
     # We need a global ipython running in this process
     globalipapp.start_ipython()
     # Now nose can run
-    TestProgram(argv=argv, plugins=plugins)
+    TestProgram(argv=argv, addplugins=plugins)
 
 
 def run_iptestall():

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -640,6 +640,9 @@ class ExtensionDoctest(doctests.Doctest):
 
     def configure(self, options, config):
         Plugin.configure(self, options, config)
+        # Pull standard doctest plugin out of config; we will do doctesting
+        config.plugins.plugins = [p for p in config.plugins.plugins
+                                  if p.name != 'doctest']
         self.doctest_tests = options.doctest_tests
         self.extension = tolist(options.doctestExtension)
 
@@ -783,6 +786,9 @@ class IPythonDoctest(ExtensionDoctest):
     def configure(self, options, config):
         #print "Configuring nose plugin:", self.name # dbg
         Plugin.configure(self, options, config)
+        # Pull standard doctest plugin out of config; we will do doctesting
+        config.plugins.plugins = [p for p in config.plugins.plugins
+                                  if p.name != 'doctest']
         self.doctest_tests = options.ipdoctest_tests
         self.extension = tolist(options.ipdoctest_extension)
 


### PR DESCRIPTION
IPDoctest replaces the normal doctest plugin.  Previously we did this by
initializing the builtin plugins but skipping the doctest plugin.
However, if the user has a noserc file with 'with-doctest=1' or the
environment variable 'NOSE_WITH_DOCTEST', then nose will try and
initialize the doctest plugin when it isn't there, and barf.  This
commit defers the removal of the doctest plugin to the configuration
stage, so doctest can be enabled before it is thrown away by us.
