### PR TITLE
Add SSH tunneling to engines

### DIFF
--- a/IPython/external/ssh/tunnel.py
+++ b/IPython/external/ssh/tunnel.py
@@ -110,6 +110,22 @@ def tunnel_connection(socket, addr, server, keyfile=None, password=None, paramik
     selected local port of the tunnel.
     
     """
+    new_url, tunnel = open_tunnel(addr, server, keyfile=keyfile, password=password, paramiko=paramiko)
+    socket.connect(new_url)
+    return tunnel
+
+
+def open_tunnel(addr, server, keyfile=None, password=None, paramiko=None):
+    """Open a tunneled connection from a 0MQ url.
+    
+    For use inside tunnel_connection.
+    
+    Returns
+    -------
+    
+    (url, tunnel): The 0MQ url that has been forwarded, and the tunnel object
+    """
+    
     lport = select_random_ports(1)[0]
     transport, addr = addr.split('://')
     ip,rport = addr.split(':')
@@ -121,8 +137,7 @@ def tunnel_connection(socket, addr, server, keyfile=None, password=None, paramik
     else:
         tunnelf = openssh_tunnel
     tunnel = tunnelf(lport, rport, server, remoteip=ip, keyfile=keyfile, password=password)
-    socket.connect('tcp://127.0.0.1:%i'%lport)
-    return tunnel
+    return 'tcp://127.0.0.1:%i'%lport, tunnel
 
 def openssh_tunnel(lport, rport, server, remoteip='127.0.0.1', keyfile=None, password=None, timeout=15):
     """Create an ssh tunnel using command-line ssh that connects port lport

--- a/IPython/parallel/apps/launcher.py
+++ b/IPython/parallel/apps/launcher.py
@@ -56,7 +56,7 @@ from zmq.eventloop import ioloop
 from IPython.config.application import Application
 from IPython.config.configurable import LoggingConfigurable
 from IPython.utils.text import EvalFormatter
-from IPython.utils.traitlets import Any, Int, List, Unicode, Dict, Instance
+from IPython.utils.traitlets import Any, Int, CFloat, List, Unicode, Dict, Instance
 from IPython.utils.path import get_ipython_module_path
 from IPython.utils.process import find_cmd, pycmd2argv, FindCmdError
 
@@ -364,6 +364,12 @@ class LocalEngineSetLauncher(BaseLauncher):
         ['--log-to-file','--log-level=%i'%logging.INFO], config=True,
         help="command-line arguments to pass to ipengine"
     )
+    delay = CFloat(0.1, config=True,
+        help="""delay (in seconds) between starting each engine after the first.
+        This can help force the engines to get their ids in order, or limit
+        process flood when starting many engines."""
+    )
+    
     # launcher class
     launcher_class = LocalEngineLauncher
     
@@ -381,6 +387,8 @@ class LocalEngineSetLauncher(BaseLauncher):
         self.profile_dir = unicode(profile_dir)
         dlist = []
         for i in range(n):
+            if i > 0:
+                time.sleep(self.delay)
             el = self.launcher_class(work_dir=self.work_dir, config=self.config, log=self.log)
             # Copy the engine args over to each engine launcher.
             el.engine_args = copy.deepcopy(self.engine_args)
@@ -603,6 +611,8 @@ class SSHEngineSetLauncher(LocalEngineSetLauncher):
             else:
                 user=None
             for i in range(n):
+                if i > 0:
+                    time.sleep(self.delay)
                 el = self.launcher_class(work_dir=self.work_dir, config=self.config, log=self.log)
                 
                 # Copy the engine args over to each engine launcher.

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -171,7 +171,7 @@ class Client(HasTraits):
         A string of the form passed to ssh, i.e. 'server.tld' or 'user@server.tld:port'
         If keyfile or password is specified, and this is not, it will default to
         the ip given in addr.
-    sshkey : str; path to public ssh key file
+    sshkey : str; path to ssh private key file
         This specifies a key to be used in ssh login, default None.
         Regular default ssh keys will be used without specifying this argument.
     password : str 

--- a/IPython/parallel/engine/engine.py
+++ b/IPython/parallel/engine/engine.py
@@ -57,7 +57,7 @@ class EngineFactory(RegistrationFactory):
     sshserver=Unicode(config=True,
         help="""The SSH server to use for tunneling connections to the Controller.""")
     sshkey=Unicode(config=True,
-        help="""The SSH keyfile to use when tunneling connections to the Controller.""")
+        help="""The SSH private key file to use when tunneling connections to the Controller.""")
     paramiko=Bool(sys.platform == 'win32', config=True,
         help="""Whether to use paramiko instead of openssh for tunnels.""")
     

--- a/docs/source/parallel/parallel_process.txt
+++ b/docs/source/parallel/parallel_process.txt
@@ -484,6 +484,49 @@ The ``file`` flag works like this::
     (:file:`~/.ipython/profile_<name>/security` is the same on all of them), then things
     will just work!
 
+SSH Tunnels
+***********
+
+If your engines are not on the same LAN as the controller, or you are on a highly
+restricted network where your nodes cannot see each others ports, then you can
+use SSH tunnels to connect engines to the controller.
+
+.. note::
+
+    This does not work in all cases.  Manual tunnels may be an option, but are
+    highly inconvenient. Support for manual tunnels will be improved.
+
+You can instruct all engines to use ssh, by specifying the ssh server in 
+:file:`ipcontroller-engine.json`:
+
+.. I know this is really JSON, but the example is a subset of Python:
+.. sourcecode:: python
+
+    {
+      "url":"tcp://192.168.1.123:56951",
+      "exec_key":"26f4c040-587d-4a4e-b58b-030b96399584",
+      "ssh":"user@example.com",
+      "location":"192.168.1.123"
+    }
+
+This will be specified if you give the ``--enginessh=use@example.com`` argument when
+starting :command:`ipcontroller`.
+
+Or you can specify an ssh server on the command-line when starting an engine::
+
+    $> ipengine --profile=foo --ssh=my.login.node
+
+For example, if your system is totally restricted, then all connections will actually be
+loopback, and ssh tunnels will be used to connect engines to the controller::
+
+    [node1] $> ipcontroller --enginessh=node1
+    [node2] $> ipengine
+    [node3] $> ipcluster engines --n=4
+
+Or if you want to start many engines on each node, the command `ipcluster engines --n=4`
+without any configuration is equivalent to running ipengine 4 times.
+
+
 Make JSON files persistent
 --------------------------
 

--- a/docs/source/parallel/parallel_security.txt
+++ b/docs/source/parallel/parallel_security.txt
@@ -105,9 +105,6 @@ use OpenSSH or Paramiko, or the tunneling utilities are insufficient, then they 
 construct the tunnels themselves, and simply connect clients and engines as if the
 controller were on loopback on the connecting machine.
 
-.. note::
-
-    There is not currently tunneling available for engines.
 
 Authentication
 --------------


### PR DESCRIPTION
This copies the basic ssh tunneling from the Client to the Engine.  The same semantics apply.  In the controller, the ssh server is configured separately from the client ssh server, to prevent unnecessary tunneling from engines to the controller.
