### PR TITLE
add `ipython kernel` for starting just a kernel

### DIFF
--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -205,7 +205,11 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
             """Launch the IPython Qt Console."""
         ),
         profile = ("IPython.core.profileapp.ProfileApp",
-            "Create and manage IPython profiles.")
+            "Create and manage IPython profiles."
+        ),
+        kernel = ("IPython.zmq.ipkernel.IPKernelApp",
+            "Start a kernel without an attached frontend."
+        ),
     ))
     
     # *do* autocreate requested profile, but don't create the config file.

--- a/docs/examples/lib/internal_ipkernel.py
+++ b/docs/examples/lib/internal_ipkernel.py
@@ -14,10 +14,7 @@ def pylab_kernel(gui):
     """Launch and return an IPython kernel with pylab support for the desired gui
     """
     kernel = IPKernelApp()
-    # FIXME: we're hardcoding the heartbeat port b/c of a bug in IPython 0.11
-    # that will set it to 0 if not specified.  Once this is fixed, the --hb
-    # parameter can be omitted and all ports will be automatic
-    kernel.initialize(['python', '--pylab=%s' % gui, '--hb=19999',
+    kernel.initialize(['python', '--pylab=%s' % gui,
                        #'--log-level=10'
                        ])
     return kernel


### PR DESCRIPTION
Also fixed an issue that the `--existing...` message would be inaccurate if the heartbeat port is unspecified.
