### PR TITLE
make config-loading debug messages more explicit

### DIFF
--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -373,10 +373,14 @@ class Application(SingletonConfigurable):
             # problem with the file (probably doesn't exist), raise
             raise
         except Exception:
+            # try to get the full filename, but it will be empty in the
+            # unlikely event that the error raised before filefind finished
+            filename = loader.full_filename or filename
             # problem while running the file
-            self.log.error("Exception while loading config file %s [path=%s]"%
-                            (filename, path), exc_info=True)
+            self.log.error("Exception while loading config file %s",
+                            filename, exc_info=True)
         else:
+            self.log.debug("Loaded config file: %s", loader.full_filename)
             self.update_config(config)
     
     def generate_config_file(self):

--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -172,6 +172,7 @@ class BaseIPythonApplication(Application):
         printed on screen. For testing, the suppress_errors option is set
         to False, so errors will make tests fail.
         """
+        self.log.debug("Searching path %s for config files", self.config_file_paths)
         base_config = 'ipython_config.py'
         self.log.debug("Attempting to load config file: %s" %
                        base_config)
@@ -183,6 +184,7 @@ class BaseIPythonApplication(Application):
             )
         except IOError:
             # ignore errors loading parent
+            self.log.debug("Config file %s not found", base_config)
             pass
         if self.config_file_name == base_config:
             # don't load secondary config
@@ -198,8 +200,10 @@ class BaseIPythonApplication(Application):
         except IOError:
             # Only warn if the default config file was NOT being used.
             if self.config_file_specified:
-                self.log.warn("Config file not found, skipping: %s" %
-                               self.config_file_name)
+                msg = self.log.warn
+            else:
+                msg = self.log.debug
+            msg("Config file not found, skipping: %s", self.config_file_name)
         except:
             # For testing purposes.
             if not suppress_errors:


### PR DESCRIPTION
It was never clear in debug messages that the cwd is searched
for config files.  This adjusts various debug messages during
config-file loading to make things more clear.

The following debug messages were added:
- specify search-path at start of load-config routine
- on success, full path of loaded config files
- always note when config files are not found
