### PR TITLE
Reset execution counter after cache is cleared

### DIFF
--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -327,3 +327,5 @@ class DisplayHook(Configurable):
         # TODO: Is this really needed?
         gc.collect()
 
+        self.shell.execution_count = 0
+


### PR DESCRIPTION
This is to prevent the counter from shooting up much above 1000 (the cache limit).  If the counter is not reset, it keeps growing forever.

Please review this change carefully: I do not know if changing the execution counter has any other effect, and can simply verify that this brings the prompt back to 1 after clearing the cache (but I do believe this is the right thing to do, given that the cache is cleared out).
