### PR TITLE
Install mathjax for offline use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ _build
 docs/man/*.gz
 docs/source/api/generated
 docs/gh-pages
+IPython/frontend/html/notebook/static/mathjax
 *.py[co]
 build
 *.egg-info

--- a/IPython/external/mathjax.py
+++ b/IPython/external/mathjax.py
@@ -1,0 +1,82 @@
+"""Utility function for installing MathJax javascript library into
+the notebook's 'static' directory, for offline use.
+
+Authors:
+
+* Min RK
+"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2008-2011  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+import os
+import shutil
+import urllib2
+import tempfile
+import tarfile
+
+from IPython.frontend.html import notebook as nbmod
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+def install_mathjax(tag='v1.1', replace=False):
+    """Download and install MathJax for offline use.
+    
+    This will install mathjax to the 'static' dir in the IPython notebook
+    package, so it will fail if the caller does not have write access
+    to that location.
+    
+    MathJax is a ~15MB download, and ~150MB installed.
+    
+    Parameters
+    ----------
+    
+    replace : bool [False]
+        Whether to remove and replace an existing install.
+    tag : str ['v1.1']
+        Which tag to download. Default is 'v1.1', the current stable release,
+        but alternatives include 'v1.1a' and 'master'.
+    """
+    mathjax_url = "https://github.com/mathjax/MathJax/tarball/%s"%tag
+    
+    nbdir = os.path.dirname(os.path.abspath(nbmod.__file__))
+    static = os.path.join(nbdir, 'static')
+    dest = os.path.join(static, 'mathjax')
+    
+    # check for existence and permissions
+    if not os.access(static, os.W_OK):
+        raise IOError("Need have write access to %s"%static)
+    if os.path.exists(dest):
+        if replace:
+            if not os.access(dest, os.W_OK):
+                raise IOError("Need have write access to %s"%dest)
+            print "removing previous MathJax install"
+            shutil.rmtree(dest)
+        else:
+            print "offline MathJax apparently already installed"
+            return
+    
+    # download mathjax
+    print "Downloading mathjax source..."
+    response = urllib2.urlopen(mathjax_url)
+    print "done"
+    # use 'r|gz' stream mode, because socket file-like objects can't seek:
+    tar = tarfile.open(fileobj=response.fp, mode='r|gz')
+    topdir = tar.firstmember.path
+    print "Extracting to %s"%dest
+    tar.extractall(static)
+    # it will be mathjax-MathJax-<sha>, rename to just mathjax
+    os.rename(os.path.join(static, topdir), dest)
+
+
+__all__ = ['install_mathjax']

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -10,12 +10,14 @@
 <!--     <link rel="stylesheet" href="static/jquery/css/themes/rocket/jquery-wijmo.css" type="text/css" /> -->
 <!--    <link rel="stylesheet" href="static/jquery/css/themes/smoothness/jquery-ui-1.8.14.custom.css" type="text/css" />-->
 
-    <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML" charset="utf-8"></script>
-    <!-- <script type='text/javascript' src='static/mathjax/MathJax.js?config=TeX-AMS_HTML' charset='utf-8'></script> -->
+    <!-- <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML" charset="utf-8"></script> -->
+    <script type='text/javascript' src='static/mathjax/MathJax.js?config=TeX-AMS_HTML' charset='utf-8'></script>
     <script type="text/javascript">
     if (typeof MathJax == 'undefined') {
-        console.log("Trying to load local copy of MathJax");
-        document.write(unescape("%3Cscript type='text/javascript' src='static/mathjax/MathJax.js%3Fconfig=TeX-AMS_HTML' charset='utf-8'%3E%3C/script%3E"));
+        console.log("No local MathJax, loading from CDN");
+        document.write(unescape("%3Cscript type='text/javascript' src='http://cdn.mathjax.org/mathjax/latest/MathJax.js%3Fconfig=TeX-AMS_HTML' charset='utf-8'%3E%3C/script%3E"));
+    }else{
+        console.log("Using local MathJax");
     }
     </script>
 


### PR DESCRIPTION
Add simple function to `IPython.external` for installing mathjax to the static dir for offline use.  It checks for permission, existence, etc. and allows for installing from different tags, e.g. if you want to use stable (v1.1) or master.

All you need to do to get offline mathjax is:

``` python
from IPython.external.mathjax import install_mathjax
install_mathjax()
```

This could be located somewhere else, or also called from a magic, but external seemed the most logical place, since it is for bundling an external library.

I also reversed the priority of offline/cdn mathjax, so offline mathjax is preferred, since it is presumably less expensive to load.  Of course, this is only true in the local network case, and a notebook server that's run from a real server would probably prefer to use the cdn.  This is in a separate commit, so it's easy to rollback if we want to keep the CDN priority.
