### PR TITLE
use bundled argparse if system argparse is < 1.1

### DIFF
--- a/IPython/external/argparse/__init__.py
+++ b/IPython/external/argparse/__init__.py
@@ -1,13 +1,11 @@
 try:
     import argparse
-    # Workaround an argparse bug, FIXED in argparse 1.1.0
-    if 'RawTextHelpFormatterArgumentDefaultsHelpFormatter' in argparse.__all__:
-        import itertools
-        argparse.__all__ = list(itertools.chain( [i for i in argparse.__all__
-            if i != 'RawTextHelpFormatterArgumentDefaultsHelpFormatter'],
-            ['RawTextHelpFormatter', 'ArgumentDefaultsHelpFormatter']))
-    argparse.__all__.append('SUPPRESS')
-    from argparse import *
-except ImportError:
+    # don't use system argparse if older than 1.1:
+    if argparse.__version__ < '1.1':
+        raise ImportError
+    else:
+        from argparse import *
+        from argparse import SUPPRESS
+except (ImportError, AttributeError):
     from _argparse import *
     from _argparse import SUPPRESS


### PR DESCRIPTION
argparse 1.0.1 has issues and is super old, but might be installed on some systems.  external.argparse should use the bundled version if system argparse is older than 1.1.
