### PR TITLE
respect encoding of display data from urls

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -268,6 +268,16 @@ class DisplayObject(object):
                 import urllib2
                 response = urllib2.urlopen(self.url)
                 self.data = response.read()
+                # extract encoding from header, if there is one:
+                encoding = None
+                for sub in response.headers['content-type'].split(';'):
+                    sub = sub.strip()
+                    if sub.startswith('charset'):
+                        encoding = sub.split('=')[-1].strip()
+                        break
+                # decode data, if an encoding was specified
+                if encoding:
+                    self.data = self.data.decode(encoding, 'replace')
             except:
                 self.data = None
 


### PR DESCRIPTION
previously, loading a display object from a URL would just be bytes, ignoring page encoding, causing a UnicodeDecodeError when json tried to serialize the data.  This respects the encoding if the header specifies one.
