### PR TITLE
Run PyOs_InputHook in pager to keep plot windows interactive.

### DIFF
--- a/IPython/core/page.py
+++ b/IPython/core/page.py
@@ -226,6 +226,7 @@ def page(strng, start=0, screen_lines=0, pager_cmd=None):
                     if retval <=0:  # normally 0; negative for signal;
                                     # pager ran, so we have finished.
                         retval = None
+                        io.stdout.flush()   # This gets the prompt back.
                     else:
                         retval = 1
                     break
@@ -239,6 +240,8 @@ def page(strng, start=0, screen_lines=0, pager_cmd=None):
 
     if retval is not None:
         page_dumb(strng,screen_lines=screen_lines)
+
+
 
 
 def page_file(fname, start=0, pager_cmd=None):


### PR DESCRIPTION
This is implemented here only for posix platforms, but probably
could be generalized.

It has only one minor ill effect that I am aware of: upon exiting the pager, one must hit CR to get a prompt back. I have been unable to figure out why that is, or how to fix it, but it is a consequence of running the PyOs_InputHook, not of the change from popen to subprocess.Popen.
