### PR TITLE
Don't assume history requests succeed in qtconsole

### DIFF
--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -16,7 +16,7 @@ from unicodedata import category
 from IPython.external.qt import QtCore, QtGui
 
 # Local imports
-from IPython.config.configurable import Configurable
+from IPython.config.configurable import LoggingConfigurable
 from IPython.frontend.qt.rich_text import HtmlExporter
 from IPython.frontend.qt.util import MetaQObjectHasTraits, get_font
 from IPython.utils.text import columnize
@@ -39,7 +39,7 @@ def is_letter_or_number(char):
 # Classes
 #-----------------------------------------------------------------------------
 
-class ConsoleWidget(Configurable, QtGui.QWidget):
+class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
     """ An abstract base class for console-type widgets. This class has 
         functionality for:
 
@@ -170,7 +170,7 @@ class ConsoleWidget(Configurable, QtGui.QWidget):
             The parent for this widget.
         """
         QtGui.QWidget.__init__(self, parent)
-        Configurable.__init__(self, **kw)
+        LoggingConfigurable.__init__(self, **kw)
 
         # Create the layout and underlying text widget.
         layout = QtGui.QStackedLayout(self)

--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -174,7 +174,11 @@ class IPythonWidget(FrontendWidget):
         """ Implemented to handle history tail replies, which are only supported
             by the IPython kernel.
         """
-        history_items = msg['content']['history']
+        content = msg['content']
+        if 'history' not in content:
+            self.log.error("History request failed: %r"%content)
+            return
+        history_items = content['history']
         items = [ line.rstrip() for _, _, line in history_items ]
         self._set_history(items)
 

--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -12,6 +12,7 @@ import os.path
 import re
 from subprocess import Popen
 import sys
+import time
 from textwrap import dedent
 
 # System library imports
@@ -104,6 +105,7 @@ class IPythonWidget(FrontendWidget):
     _payload_source_exit = zmq_shell_source + '.ask_exit'
     _payload_source_next_input = zmq_shell_source + '.set_next_input'
     _payload_source_page = 'IPython.zmq.page.page'
+    _retrying_history_request = False
 
     #---------------------------------------------------------------------------
     # 'object' interface
@@ -177,7 +179,21 @@ class IPythonWidget(FrontendWidget):
         content = msg['content']
         if 'history' not in content:
             self.log.error("History request failed: %r"%content)
+            if content.get('status', '') == 'aborted' and \
+                                            not self._retrying_history_request:
+                # a *different* action caused this request to be aborted, so
+                # we should try again.
+                self.log.error("Retrying aborted history request")
+                # prevent multiple retries of aborted requests:
+                self._retrying_history_request = True
+                # wait out the kernel's queue flush, which is currently timed at 0.1s
+                time.sleep(0.25)
+                self.kernel_manager.shell_channel.history(hist_access_type='tail',n=1000)
+            else:
+                self._retrying_history_request = False
             return
+        # reset retry flag
+        self._retrying_history_request = False
         history_items = content['history']
         items = [ line.rstrip() for _, _, line in history_items ]
         self._set_history(items)


### PR DESCRIPTION
If there was an error in user startup code, the history request will be aborted.  It is generally not acceptable in frontends to assume that requests succeed.  This assumption is made all over our frontend code, and should be be fixed.  For now, this handles a known issue of the qtconsole crashing hard when invalid input is given to startup code (e.g. `ipython qtconsole -c "DNE"`).

If the history request was aborted (this means a _different_ request raised an error, causing the queue to be flushed), it will be tried again, exactly once, after waiting for the abort flush.
