### PR TITLE
qtconsole ipython widget's execute_file fails if filename contains spaces or quotes

### DIFF
--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -254,15 +254,16 @@ class IPythonWidget(FrontendWidget):
             path = os.path.normpath(path).replace('\\', '/')
 
         # Perhaps we should not be using %run directly, but while we
-        # are, it is necessary to quote filenames containing spaces.
-        if ' ' in path:
-            if '"' not in path:
-                path = '"%s"' % path
-            elif "'" not in path:
-                path = "'%s'" % path
-            else:
+        # are, it is necessary to quote filenames containing spaces or quotes.
+        # Escaping quotes in filename in %run seems tricky and inconsistent,
+        # so not trying it at present.
+        if '"' in path:
+            if "'" in path:
                 raise ValueError("Can't run filename containing both single "
                                  "and double quotes: %s" % path)
+            path = "'%s'" % path
+        elif ' ' in path or "'" in path:
+            path = '"%s"' % path
 
         self.execute('%%run %s' % path, hidden=hidden)
 

--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -253,6 +253,17 @@ class IPythonWidget(FrontendWidget):
         if sys.platform == 'win32':
             path = os.path.normpath(path).replace('\\', '/')
 
+        # Perhaps we should not be using %run directly, but while we
+        # are, it is necessary to quote filenames containing spaces.
+        if ' ' in path:
+            if '"' not in path:
+                path = '"%s"' % path
+            elif "'" not in path:
+                path = "'%s'" % path
+            else:
+                raise ValueError("Can't run filename containing both single "
+                                 "and double quotes: %s" % path)
+
         self.execute('%%run %s' % path, hidden=hidden)
 
     #---------------------------------------------------------------------------


### PR DESCRIPTION
Issue #755. Yet another patchwork path hack. Tested on Windows XP and OSX. 
