### PR TITLE
basic/initial .mailmap for nice shortlog summaries

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,27 @@
+Benjamin Ragan-Kelley <benjaminrk@gmail.com> <minrk@Mercury.local>
+Benjamin Ragan-Kelley <benjaminrk@gmail.com> Min RK
+Benjamin Ragan-Kelley <benjaminrk@gmail.com> MinRK <benjaminrk@gmail.com>
+Brian E. Granger <ellisonbg@gmail.com> Brian Granger
+Brian E. Granger <ellisonbg@gmail.com> Brian Granger <>
+Brian E. Granger <ellisonbg@gmail.com> bgranger <>
+Brian E. Granger <ellisonbg@gmail.com> bgranger <bgranger@red>
+Evan Patterson <epatters@enthought.com> <epatters@EPattersons-MacBook-Pro.local>
+Evan Patterson <epatters@enthought.com> <epatters@caltech.edu>
+Evan Patterson <epatters@enthought.com> epatters <epatters@enthought.com>
+Fernando Perez <Fernando.Perez@berkeley.edu> fperez <>
+Fernando Perez <Fernando.Perez@berkeley.edu> fptest <>
+Fernando Perez <Fernando.Perez@berkeley.edu> fptest1 <>
+Gael Varoquaux <gael.varoquaux@normalesup.org> gael.varoquaux <>
+Gael Varoquaux <gael.varoquaux@normalesup.org> gvaroquaux <gvaroquaux@gvaroquaux-desktop>
+Laurent Dufréchou <laurent.dufrechou@gmail.com> <laurent.dufrechou@gmail.com>
+Laurent Dufréchou <laurent.dufrechou@gmail.com> Laurent Dufréchou <laurent@Pep>
+Laurent Dufréchou <laurent.dufrechou@gmail.com> laurent dufrechou <>
+Laurent Dufréchou <laurent.dufrechou@gmail.com> laurent.dufrechou <>
+Laurent Dufréchou <laurent.dufrechou@gmail.com> laurent.dufrechou@gmail.com <>
+Laurent Dufréchou <laurent.dufrechou@gmail.com> ldufrechou <ldufrechou@PEP>
+Robert Kern <robert.kern@gmail.com> rkern <>
+Ville M. Vainio <vivainio@gmail.com> <vivainio2@WN-W0941>
+Ville M. Vainio <vivainio@gmail.com> vivainio <>
+Ville M. Vainio <vivainio@gmail.com> ville <ville@ville-desktop>
+Ville M. Vainio <vivainio@gmail.com> ville <ville@VILLE-PC>
+Walter Doerwald <walter@livinglogic.de> walter.doerwald <>


### PR DESCRIPTION
Inspired by similar pull request from Valentin against pymvpa git, here is the one for ipython

Now instead of
   785  Fernando Perez
   632  Brian Granger
   572  MinRK
   572  vivainio
   307  Thomas Kluyver
   253  fperez
   250  epatters
   205  Ville M. Vainio
   187  Brian E. Granger
   110  Gael Varoquaux
   106  walter.doerwald
    69  gvaroquaux
    52  Barry Wark
    45  Brian E Granger
    41  ldufrechou
    40  Robert Kern
    25  Jorgen Stenarson
    20  vivainio2
    16  Paul Ivanov
    15  bgranger
    ...

it would look like

  1052  Fernando Perez
   879  Brian E. Granger
   802  Ville M. Vainio
   588  Benjamin Ragan-Kelley
   307  Thomas Kluyver
   262  Evan Patterson
   180  Gael Varoquaux
   108  Walter Doerwald
    70  Laurent Dufréchou
    52  Barry Wark
    42  Robert Kern
...

There are more contributors which haven't yet been added to the mailmap
file
