### PR TITLE
redirect_in/redirect_out should be constrained to windows only

### DIFF
--- a/IPython/zmq/entry_point.py
+++ b/IPython/zmq/entry_point.py
@@ -3,7 +3,6 @@ launchers.
 """
 
 # Standard library imports.
-import atexit
 import os
 import socket
 from subprocess import Popen, PIPE


### PR DESCRIPTION
creating a PIPE for stdin breaks unicode symbols in e.g. !ls magic when inside
qtconsole (at least under Ubuntu)

To verify, make a new file or directory with a unicode character, say `mkdir
tmp€`

Now in qtconsole, `ls` will list that directory as `tmp���/` in trunk. This PL fixes the
issue.

In Ubuntu 10.04, I see no issues with stdin being invalid when a process is
backgrounded (neither via `&` at the end of ipython command, nor via
`Ctrl-Z` followed by `bg`), and given the nature of `redirect_out`, and
the Popen bug referenced, I presume this may be a Windows-only issue. So I moved
all of the redirect_in/redirect_out logic to the `sys.platform == 'win32'`
section.

@epatters - can you take a look at this and verify that it still works on
windows as intended?
## update

The original issue described is also solved by #770 without having to remove the stdin PIPE.
Evan says the stdin PIPE solves deadlock issues that arise on OS X, so at least that portion of the change is not windows-only (but is it OS X only?)
