### PR TITLE
Reworking qtconsole shortcut, add fullscreen

### DIFF
--- a/IPython/core/usage.py
+++ b/IPython/core/usage.py
@@ -416,6 +416,7 @@ The keybindings themselves are:
 - ``C-.``: force a kernel restart (a confirmation dialog appears).
 - ``C-+``: increase font size.
 - ``C--``: decrease font size.
+- ``C-M-Space``: toggle full screen. (Command-Control-Space on Mac OS X)
 
 The IPython pager
 =================

--- a/IPython/frontend/qt/console/qtconsoleapp.py
+++ b/IPython/frontend/qt/console/qtconsoleapp.py
@@ -98,7 +98,7 @@ class MainWindow(QtGui.QMainWindow):
         self._frontend.exit_requested.connect(self.close)
         self._confirm_exit = confirm_exit
         self.setCentralWidget(frontend)
-    
+
     #---------------------------------------------------------------------------
     # QWidget interface
     #---------------------------------------------------------------------------
@@ -461,6 +461,19 @@ class IPythonQtConsoleApp(BaseIPythonApplication):
         self.init_kernel_manager()
         self.init_qt_elements()
         self.init_colors()
+        self.init_window_shortcut()
+
+    def init_window_shortcut(self):
+        fullScreenAction = QtGui.QAction('Toggle Full Screen', self.window)
+        fullScreenAction.setShortcut('Ctrl+Meta+Space')
+        fullScreenAction.triggered.connect(self.toggleFullScreen)
+        self.window.addAction(fullScreenAction)
+
+    def toggleFullScreen(self):
+        if not self.window.isFullScreen():
+            self.window.showFullScreen()
+        else:
+            self.window.showNormal()
 
     def start(self):
 


### PR DESCRIPTION
Hi, 
As I really like sometime to work in fullScreen (not Maximized), i add this option to the qtconsole through the shortcut ctrl+alt+space.

I also Find that the if-elsif-..-else way to deal with shortcut is a bit complex to read, so i'm rearranging it with {Qt.Key_X: function to call} dictionnary

i'll do the same for ctrl+alt+shift, ctrl+shift ... etc

I conclude with a question about those same shortcut: 
the "pressing return/Enter" event  intercept most of the action and prevent futur treatment by ctrl_down, or alt_down cases.
Do you mind if I change this beaviour ?
