### PR TITLE
always use StringIO, never cStringIO

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -25,7 +25,7 @@ import shutil
 import re
 import time
 import textwrap
-from cStringIO import StringIO
+from StringIO import StringIO
 from getopt import getopt,GetoptError
 from pprint import pformat
 from xmlrpclib import ServerProxy

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -20,7 +20,7 @@ Authors
 #-----------------------------------------------------------------------------
 # stdlib
 import unittest
-from cStringIO import StringIO
+from StringIO import StringIO
 
 from IPython.testing import decorators as dec
 from IPython.utils import io

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -12,7 +12,7 @@ import os
 import sys
 import tempfile
 import types
-from cStringIO import StringIO
+from StringIO import StringIO
 
 import nose.tools as nt
 

--- a/IPython/lib/tests/test_irunner.py
+++ b/IPython/lib/tests/test_irunner.py
@@ -7,7 +7,7 @@ functionality."""
 VERBOSE = True
 
 # stdlib imports
-import cStringIO as StringIO
+import StringIO
 import sys
 import unittest
 

--- a/IPython/lib/tests/test_irunner_pylab_magic.py
+++ b/IPython/lib/tests/test_irunner_pylab_magic.py
@@ -6,7 +6,7 @@ Modified from the irunner module but using regex.
 VERBOSE = True
 
 # stdlib imports
-import cStringIO as StringIO
+import StringIO
 import sys
 import unittest
 import re

--- a/IPython/utils/PyColorize.py
+++ b/IPython/utils/PyColorize.py
@@ -34,7 +34,7 @@ __all__ = ['ANSICodeColors','Parser']
 _scheme_default = 'Linux'
 
 # Imports
-import cStringIO
+import StringIO
 import keyword
 import os
 import optparse
@@ -140,13 +140,13 @@ class Parser:
         
         string_output = 0
         if out == 'str' or self.out == 'str' or \
-           isinstance(self.out,cStringIO.OutputType):
+           isinstance(self.out,StringIO.StringIO):
             # XXX - I don't really like this state handling logic, but at this
             # point I don't want to make major changes, so adding the
             # isinstance() check is the simplest I can do to ensure correct
             # behavior.
             out_old = self.out
-            self.out = cStringIO.StringIO()
+            self.out = StringIO.StringIO()
             string_output = 1
         elif out is not None:
             self.out = out
@@ -180,7 +180,7 @@ class Parser:
 
         # parse the source and write it
         self.pos = 0
-        text = cStringIO.StringIO(self.raw)
+        text = StringIO.StringIO(self.raw)
 
         error = False
         try:

--- a/IPython/utils/tests/test_io.py
+++ b/IPython/utils/tests/test_io.py
@@ -14,7 +14,7 @@
 
 import sys
 
-from cStringIO import StringIO
+from StringIO import StringIO
 from subprocess import Popen, PIPE
 
 import nose.tools as nt

--- a/IPython/utils/tests/test_pycolorize.py
+++ b/IPython/utils/tests/test_pycolorize.py
@@ -1,0 +1,34 @@
+"""Test suite for our color utilities.
+
+Authors
+-------
+
+* Min RK
+"""
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2011  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING.txt, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# third party
+import nose.tools as nt
+
+# our own
+from IPython.utils.PyColorize import Parser
+
+#-----------------------------------------------------------------------------
+# Test functions
+#-----------------------------------------------------------------------------
+
+def test_unicode_colorize():
+    p = Parser()
+    f1 = p.format('1/0', 'str')
+    f2 = p.format(u'1/0', 'str')
+    nt.assert_equals(f1, f2)
+


### PR DESCRIPTION
cStringIO is not unicode-safe, resulting sometimes in incorrect output of PyColorize, among other difficult to discern errors.

This should clean out the last remnants of cStringIO.
