### PR TITLE
Adding clear_output to kernel and HTML notebook.

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -381,3 +381,9 @@ class Image(DisplayObject):
 
     def _find_ext(self, s):
         return unicode(s.split('.')[-1].lower())
+
+
+def clear_output():
+    """Clear the output of the current cell receiving output."""
+    from IPython.core.interactiveshell import InteractiveShell
+    InteractiveShell.instance().display_pub.clear_output()

--- a/IPython/core/displaypub.py
+++ b/IPython/core/displaypub.py
@@ -104,6 +104,10 @@ class DisplayPublisher(Configurable):
         if data.has_key('text/plain'):
             print(data['text/plain'], file=io.stdout)
 
+        def clear_output(self):
+            """Clear the output of the cell receiving output."""
+            pass
+
 
 def publish_display_data(source, data, metadata=None):
     """Publish data and metadata to all frontends.

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -679,7 +679,9 @@ var IPython = (function (IPython) {
             } else if (content.execution_state === 'dead') {
                 this.handle_status_dead();
             };
-        }
+        } else if (msg_type === 'clear_output') {
+            cell.clear_output();
+        };
     };
 
 

--- a/IPython/zmq/zmqshell.py
+++ b/IPython/zmq/zmqshell.py
@@ -74,6 +74,11 @@ class ZMQDisplayPublisher(DisplayPublisher):
             parent=self.parent_header
         )
 
+    def clear_output(self):
+        self.session.send(
+            self.pub_socket, u'clear_output', {},
+            parent=self.parent_header
+        )
 
 class ZMQInteractiveShell(InteractiveShell):
     """A subclass of InteractiveShell for ZMQ."""

--- a/docs/examples/notebooks/clear_output.ipynb
+++ b/docs/examples/notebooks/clear_output.ipynb
@@ -1,0 +1,56 @@
+{
+    "worksheets": [
+        {
+            "cells": [
+                {
+                    "source": "A demonstration of the ability to clear the output of a cell during execution.", 
+                    "cell_type": "markdown"
+                }, 
+                {
+                    "cell_type": "code", 
+                    "language": "python", 
+                    "outputs": [], 
+                    "collapsed": true, 
+                    "prompt_number": 8, 
+                    "input": "from IPython.core.display import clear_output, display"
+                }, 
+                {
+                    "cell_type": "code", 
+                    "language": "python", 
+                    "outputs": [], 
+                    "collapsed": false, 
+                    "prompt_number": 4, 
+                    "input": "import time"
+                }, 
+                {
+                    "source": "First we show how this works with ``display``:", 
+                    "cell_type": "markdown"
+                }, 
+                {
+                    "cell_type": "code", 
+                    "language": "python", 
+                    "outputs": [], 
+                    "collapsed": false, 
+                    "prompt_number": 17, 
+                    "input": "for i in range(10):\n    display(\"Time step: %i\" % i)\n    time.sleep(0.5)\n    clear_output()"
+                }, 
+                {
+                    "source": "Next, we show that ``clear_output`` can also be used to create a primitive form of animation using\nmatplotlib:", 
+                    "cell_type": "markdown"
+                }, 
+                {
+                    "cell_type": "code", 
+                    "language": "python", 
+                    "outputs": [], 
+                    "collapsed": false, 
+                    "prompt_number": 20, 
+                    "input": "for i in range(10):\n    figure()\n    plot(rand(100))\n    show()\n    time.sleep(0.1)\n    clear_output()"
+                }
+            ]
+        }
+    ], 
+    "metadata": {
+        "name": "clear_output"
+    }, 
+    "nbformat": 2
+}


### PR DESCRIPTION
This enables the clearing of output during the execution of a cell.  It can be used for simple forms of animation in the notebook.
