### PR TITLE
Don't use readline in the ZMQShell

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2496,7 +2496,8 @@ Currently the magic system has the following functions:\n"""
 
         import IPython.utils.rlineimpl as readline
 
-        if not readline.have_readline and sys.platform == "win32":
+        if not shell.colors_force and \
+                not readline.have_readline and sys.platform == "win32":
             msg = """\
 Proper color support under MS Windows requires the pyreadline library.
 You can find it at:
@@ -2510,7 +2511,7 @@ Defaulting color scheme to 'NoColor'"""
             warn(msg)
         
         # readline option is 0
-        if not shell.has_readline:
+        if not shell.colors_force and not shell.has_readline:
             new_scheme = 'NoColor'
             
         # Set prompt colors

--- a/IPython/zmq/zmqshell.py
+++ b/IPython/zmq/zmqshell.py
@@ -84,13 +84,8 @@ class ZMQInteractiveShell(InteractiveShell):
     # Override the traitlet in the parent class, because there's no point using
     # readline for the kernel. Can be removed when the readline code is moved
     # to the terminal frontend.
-
-    # FIXME.  This is disabled for now, even though it may cause problems under
-    # Windows, because it breaks %run in the Qt console.  See gh-617 for more
-    # details.  Re-enable once we've fully tested that %run works in the Qt
-    # console with syntax highlighting in tracebacks.
-    # readline_use = CBool(False)
-    # /FIXME
+    colors_force = CBool(True)
+    readline_use = CBool(False)
     
     exiter = Instance(ZMQExitAutocall)
     def _exiter_default(self):


### PR DESCRIPTION
This is another attempt to fix #617. Since I'm not very familiar with the IPython core, I would like some review on this one. Thanks!

(I have tested that colors work under Windows.)
