### PR TITLE
Add cluster-id for multiple cluster instances per profile

### DIFF
--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -207,8 +207,9 @@ class Configurable(HasTraits):
         for parent in cls.mro():
             # only include parents that are not base classes
             # and are not the class itself
-            if issubclass(parent, Configurable) and \
-                    not parent in (Configurable, SingletonConfigurable, cls):
+            # and have some configurable traits to inherit
+            if parent is not cls and issubclass(parent, Configurable) and \
+                    parent.class_traits(config=True):
                 parents.append(parent)
         
         if parents:

--- a/IPython/parallel/apps/baseapp.py
+++ b/IPython/parallel/apps/baseapp.py
@@ -119,9 +119,13 @@ class BaseParallelApplication(BaseIPythonApplication):
 
     cluster_id = Unicode('', config=True,
         help="""String id to add to runtime files, to prevent name collisions when
-        using multiple clusters with a single profile.
+        using multiple clusters with a single profile simultaneously.
         
         When set, files will be named like: 'ipcontroller-<cluster_id>-engine.json'
+        
+        Since this is text inserted into filenames, typical recommendations apply:
+        Simple character strings are ideal, and spaces are not recommended (but should
+        generally work).
         """
     )
     def _cluster_id_changed(self, name, old, new):

--- a/IPython/parallel/apps/baseapp.py
+++ b/IPython/parallel/apps/baseapp.py
@@ -75,6 +75,7 @@ base_aliases.update({
     'log-to-file' : 'BaseParallelApplication.log_to_file',
     'clean-logs' : 'BaseParallelApplication.clean_logs',
     'log-url' : 'BaseParallelApplication.log_url',
+    'cluster-id' : 'BaseParallelApplication.cluster_id',
 })
 
 base_flags = {
@@ -116,6 +117,18 @@ class BaseParallelApplication(BaseIPythonApplication):
     log_url = Unicode('', config=True,
         help="The ZMQ URL of the iplogger to aggregate logging.")
 
+    cluster_id = Unicode('', config=True,
+        help="""String id to add to runtime files, to prevent name collisions when
+        using multiple clusters with a single profile.
+        
+        When set, files will be named like: 'ipcontroller-<cluster_id>-engine.json'
+        """
+    )
+    def _cluster_id_changed(self, name, old, new):
+        self.name = self.__class__.name
+        if new:
+            self.name += '-%s'%new
+    
     def _config_files_default(self):
         return ['ipcontroller_config.py', 'ipengine_config.py', 'ipcluster_config.py']
     

--- a/IPython/parallel/apps/ipclusterapp.py
+++ b/IPython/parallel/apps/ipclusterapp.py
@@ -275,19 +275,22 @@ class IPClusterEngines(BaseParallelApplication):
         self.init_launchers()
     
     def init_launchers(self):
-        self.engine_launcher = self.build_launcher(self.engine_launcher_class)
+        self.engine_launcher = self.build_launcher(self.engine_launcher_class, 'EngineSet')
         self.engine_launcher.on_stop(lambda r: self.loop.stop())
     
     def init_signal(self):
         # Setup signals
         signal.signal(signal.SIGINT, self.sigint_handler)
     
-    def build_launcher(self, clsname):
+    def build_launcher(self, clsname, kind=None):
         """import and instantiate a Launcher based on importstring"""
         if '.' not in clsname:
             # not a module, presume it's the raw name in apps.launcher
+            if kind and kind not in clsname:
+                # doesn't match necessary full class name, assume it's
+                # just 'PBS' or 'MPIExec' prefix:
+                clsname = clsname + kind + 'Launcher'
             clsname = 'IPython.parallel.apps.launcher.'+clsname
-        # print repr(clsname)
         try:
             klass = import_item(clsname)
         except (ImportError, KeyError):
@@ -422,8 +425,8 @@ class IPClusterStart(IPClusterEngines):
     aliases = Dict(start_aliases)
 
     def init_launchers(self):
-        self.controller_launcher = self.build_launcher(self.controller_launcher_class)
-        self.engine_launcher = self.build_launcher(self.engine_launcher_class)
+        self.controller_launcher = self.build_launcher(self.controller_launcher_class, 'Controller')
+        self.engine_launcher = self.build_launcher(self.engine_launcher_class, 'EngineSet')
         self.controller_launcher.on_stop(self.stop_launchers)
     
     def start_controller(self):

--- a/IPython/parallel/apps/ipclusterapp.py
+++ b/IPython/parallel/apps/ipclusterapp.py
@@ -295,16 +295,14 @@ class IPClusterEngines(BaseParallelApplication):
             self.exit(1)
 
         launcher = klass(
-            work_dir=u'.', config=self.config, log=self.log
+            work_dir=u'.', config=self.config, log=self.log,
+            profile_dir=self.profile_dir.location, cluster_id=self.cluster_id,
         )
         return launcher
     
     def start_engines(self):
         self.log.info("Starting %i engines"%self.n)
-        self.engine_launcher.start(
-            self.n,
-            self.profile_dir.location
-        )
+        self.engine_launcher.start(self.n)
 
     def stop_engines(self):
         self.log.info("Stopping Engines...")
@@ -429,9 +427,7 @@ class IPClusterStart(IPClusterEngines):
         self.controller_launcher.on_stop(self.stop_launchers)
     
     def start_controller(self):
-        self.controller_launcher.start(
-            self.profile_dir.location
-        )
+        self.controller_launcher.start()
         
     def stop_controller(self):
         # self.log.info("In stop_controller")

--- a/IPython/parallel/apps/ipcontrollerapp.py
+++ b/IPython/parallel/apps/ipcontrollerapp.py
@@ -183,8 +183,8 @@ class IPControllerApp(BaseParallelApplication):
     
     def _cluster_id_changed(self, name, old, new):
         super(IPControllerApp, self)._cluster_id_changed(name, old, new)
-        self.engine_json_file = "%s-engine.json"%self.name
-        self.client_json_file = "%s-client.json"%self.name
+        self.engine_json_file = "%s-engine.json" % self.name
+        self.client_json_file = "%s-client.json" % self.name
 
 
     # internal

--- a/IPython/parallel/apps/ipcontrollerapp.py
+++ b/IPython/parallel/apps/ipcontrollerapp.py
@@ -174,7 +174,18 @@ class IPControllerApp(BaseParallelApplication):
 
     use_threads = Bool(False, config=True,
         help='Use threads instead of processes for the schedulers',
-        )
+    )
+
+    engine_json_file = Unicode('ipcontroller-engine.json', config=True,
+        help="JSON filename where engine connection info will be stored.")
+    client_json_file = Unicode('ipcontroller-client.json', config=True,
+        help="JSON filename where client connection info will be stored.")
+    
+    def _cluster_id_changed(self, name, old, new):
+        super(IPControllerApp, self)._cluster_id_changed(name, old, new)
+        self.engine_json_file = "%s-engine.json"%self.name
+        self.client_json_file = "%s-client.json"%self.name
+
 
     # internal
     children = List()
@@ -215,7 +226,7 @@ class IPControllerApp(BaseParallelApplication):
         """load config from existing json connector files."""
         c = self.config
         # load from engine config
-        with open(os.path.join(self.profile_dir.security_dir, 'ipcontroller-engine.json')) as f:
+        with open(os.path.join(self.profile_dir.security_dir, self.engine_json_file)) as f:
             cfg = json.loads(f.read())
         key = c.Session.key = asbytes(cfg['exec_key'])
         xport,addr = cfg['url'].split('://')
@@ -227,7 +238,7 @@ class IPControllerApp(BaseParallelApplication):
         if not self.engine_ssh_server:
             self.engine_ssh_server = cfg['ssh']
         # load client config
-        with open(os.path.join(self.profile_dir.security_dir, 'ipcontroller-client.json')) as f:
+        with open(os.path.join(self.profile_dir.security_dir, self.client_json_file)) as f:
             cfg = json.loads(f.read())
         assert key == cfg['exec_key'], "exec_key mismatch between engine and client keys"
         xport,addr = cfg['url'].split('://')
@@ -277,11 +288,11 @@ class IPControllerApp(BaseParallelApplication):
                     'url' : "%s://%s:%s"%(f.client_transport, f.client_ip, f.regport),
                     'location' : self.location
                     }
-            self.save_connection_dict('ipcontroller-client.json', cdict)
+            self.save_connection_dict(self.client_json_file, cdict)
             edict = cdict
             edict['url']="%s://%s:%s"%((f.client_transport, f.client_ip, f.regport))
             edict['ssh'] = self.engine_ssh_server
-            self.save_connection_dict('ipcontroller-engine.json', edict)
+            self.save_connection_dict(self.engine_json_file, edict)
 
     #
     def init_schedulers(self):

--- a/IPython/parallel/apps/ipengineapp.py
+++ b/IPython/parallel/apps/ipengineapp.py
@@ -135,8 +135,8 @@ aliases.update(base_aliases)
 
 class IPEngineApp(BaseParallelApplication):
 
-    name = Unicode(u'ipengine')
-    description = Unicode(_description)
+    name = 'ipengine'
+    description = _description
     examples = _examples
     config_file_name = Unicode(default_config_file_name)
     classes = List([ProfileDir, Session, EngineFactory, Kernel, MPI])
@@ -158,7 +158,15 @@ class IPEngineApp(BaseParallelApplication):
         controller and engine are started at the same time and it
         may take a moment for the controller to write the connector files.""")
 
-    url_file_name = Unicode(u'ipcontroller-engine.json')
+    url_file_name = Unicode(u'ipcontroller-engine.json', config=True)
+
+    def _cluster_id_changed(self, name, old, new):
+        if new:
+            base = 'ipcontroller-%s'%new
+        else:
+            base = 'ipcontroller'
+        self.url_file_name = "%s-engine.json"%base
+
     log_url = Unicode('', config=True,
         help="""The URL for the iploggerapp instance, for forwarding
         logging to a central location.""")

--- a/IPython/parallel/apps/ipengineapp.py
+++ b/IPython/parallel/apps/ipengineapp.py
@@ -93,7 +93,7 @@ class MPI(Configurable):
         help='How to enable MPI (mpi4py, pytrilinos, or empty string to disable).'
         )
 
-    def _on_use_changed(self, old, new):
+    def _use_changed(self, name, old, new):
         # load default init script if it's not set
         if not self.init_script:
             self.init_script = self.default_inits.get(new, '')
@@ -162,10 +162,10 @@ class IPEngineApp(BaseParallelApplication):
 
     def _cluster_id_changed(self, name, old, new):
         if new:
-            base = 'ipcontroller-%s'%new
+            base = 'ipcontroller-%s' % new
         else:
             base = 'ipcontroller'
-        self.url_file_name = "%s-engine.json"%base
+        self.url_file_name = "%s-engine.json" % base
 
     log_url = Unicode('', config=True,
         help="""The URL for the iploggerapp instance, for forwarding

--- a/IPython/parallel/apps/launcher.py
+++ b/IPython/parallel/apps/launcher.py
@@ -232,14 +232,14 @@ class ControllerMixin(ClusterAppMixin):
     controller_cmd = List(ipcontroller_cmd_argv, config=True,
         help="""Popen command to launch ipcontroller.""")
     # Command line arguments to ipcontroller.
-    controller_args = List(['--log-to-file','--log-level=%i'%logging.INFO], config=True,
+    controller_args = List(['--log-to-file','--log-level=%i' % logging.INFO], config=True,
         help="""command-line args to pass to ipcontroller""")
 
 class EngineMixin(ClusterAppMixin):
     engine_cmd = List(ipengine_cmd_argv, config=True,
         help="""command to launch the Engine.""")
     # Command line arguments for ipengine.
-    engine_args = List(['--log-to-file','--log-level=%i'%logging.INFO], config=True,
+    engine_args = List(['--log-to-file','--log-level=%i' % logging.INFO], config=True,
         help="command-line arguments to pass to ipengine"
     )
 
@@ -807,11 +807,18 @@ class WindowsHPCEngineSetLauncher(WindowsHPCLauncher, ClusterAppMixin):
 #-----------------------------------------------------------------------------
 
 class BatchClusterAppMixin(ClusterAppMixin):
-    """ClusterApp mixin that updates context dict, rather than args"""
-    context = Dict({'profile_dir':'', 'cluster_id':''})
+    """ClusterApp mixin that updates the self.context dict, rather than cl-args."""
     def _profile_dir_changed(self, name, old, new):
         self.context[name] = new
     _cluster_id_changed = _profile_dir_changed
+
+    def _profile_dir_default(self):
+        self.context['profile_dir'] = ''
+        return ''
+    def _cluster_id_default(self):
+        self.context['cluster_id'] = ''
+        return ''
+
 
 class BatchSystemLauncher(BaseLauncher):
     """Launch an external process using a batch system.
@@ -956,7 +963,7 @@ class PBSLauncher(BatchSystemLauncher):
     queue_template = Unicode('#PBS -q {queue}')
 
 
-class PBSControllerLauncher(BatchClusterAppMixin, PBSLauncher):
+class PBSControllerLauncher(PBSLauncher, BatchClusterAppMixin):
     """Launch a controller using PBS."""
 
     batch_file_name = Unicode(u'pbs_controller', config=True,
@@ -974,7 +981,7 @@ class PBSControllerLauncher(BatchClusterAppMixin, PBSLauncher):
         return super(PBSControllerLauncher, self).start(1)
 
 
-class PBSEngineSetLauncher(BatchClusterAppMixin, PBSLauncher):
+class PBSEngineSetLauncher(PBSLauncher, BatchClusterAppMixin):
     """Launch Engines using PBS"""
     batch_file_name = Unicode(u'pbs_engines', config=True,
         help="batch file name for the engine(s) job.")
@@ -998,7 +1005,7 @@ class SGELauncher(PBSLauncher):
     queue_regexp = Unicode('#\$\W+-q\W+\$?\w+')
     queue_template = Unicode('#$ -q {queue}')
 
-class SGEControllerLauncher(BatchClusterAppMixin, SGELauncher):
+class SGEControllerLauncher(SGELauncher, BatchClusterAppMixin):
     """Launch a controller using SGE."""
 
     batch_file_name = Unicode(u'sge_controller', config=True,
@@ -1014,7 +1021,7 @@ class SGEControllerLauncher(BatchClusterAppMixin, SGELauncher):
         self.log.info("Starting PBSControllerLauncher: %r" % self.args)
         return super(SGEControllerLauncher, self).start(1)
 
-class SGEEngineSetLauncher(BatchClusterAppMixin, SGELauncher):
+class SGEEngineSetLauncher(SGELauncher, BatchClusterAppMixin):
     """Launch Engines with SGE"""
     batch_file_name = Unicode(u'sge_engines', config=True,
         help="batch file name for the engine(s) job.")
@@ -1066,7 +1073,7 @@ class LSFLauncher(BatchSystemLauncher):
         return job_id
 
 
-class LSFControllerLauncher(BatchClusterAppMixin, LSFLauncher):
+class LSFControllerLauncher(LSFLauncher, BatchClusterAppMixin):
     """Launch a controller using LSF."""
     
     batch_file_name = Unicode(u'lsf_controller', config=True,
@@ -1084,7 +1091,7 @@ class LSFControllerLauncher(BatchClusterAppMixin, LSFLauncher):
         return super(LSFControllerLauncher, self).start(1)
 
 
-class LSFEngineSetLauncher(BatchClusterAppMixin, LSFLauncher):
+class LSFEngineSetLauncher(LSFLauncher, BatchClusterAppMixin):
     """Launch Engines using LSF"""
     batch_file_name = Unicode(u'lsf_engines', config=True,
                               help="batch file name for the engine(s) job.")


### PR DESCRIPTION
Default behavior is unchanged, but specifying a '--cluster-id' arg will allow starting additional clusters within a single profile.

I also cleaned up the code in parallel.apps.launchers a fair amount, by adding a few Mixin classes to consolidate some of the extremely repetitive code.

This will need some testing in various environments, to catch possible typos from the changes, but it's a major improvement overall.

The consolidation also fixes a few inconsistencies, such as the MPI launchers using `program/program_args`, while the local launchers used `controller_cmd/controller_args`.  Now the names are more sensible and consistent across launcher types.

When checking the generated config files, I also fixed a small aesthetic issue when printing the class list from which a Configurable will inherit configuration.  It now excludes any base class that doesn't have anything to inherit.

Should close #794
