### PR TITLE
pexpect & Python 3

### DIFF
--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -47,7 +47,7 @@ def getdefaultencoding():
     and usually ASCII.
     """
     enc = sys.stdin.encoding
-    if not enc:
+    if not enc or enc=='ascii':
         try:
             # There are reports of getpreferredencoding raising errors
             # in some cases, which may well be fixed, but let's be conservative here.


### PR DESCRIPTION
Changes to pexpect so running external processes from the Qt console works in Python 3.
