### PR TITLE
Py3 notebook

### DIFF
--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -172,7 +172,7 @@ class ZMQStreamHandler(websocket.WebSocketHandler):
 
 class AuthenticatedZMQStreamHandler(ZMQStreamHandler):
     def open(self, kernel_id):
-        self.kernel_id = kernel_id
+        self.kernel_id = kernel_id.decode('ascii')
         self.session = Session()
         self.save_on_message = self.on_message
         self.on_message = self.on_first_message

--- a/IPython/frontend/html/notebook/notebookmanager.py
+++ b/IPython/frontend/html/notebook/notebookmanager.py
@@ -150,7 +150,7 @@ class NotebookManager(LoggingConfigurable):
             raise web.HTTPError(415, u'Invalid notebook format: %s' % format)
 
         try:
-            nb = current.reads(data, format)
+            nb = current.reads(data.decode('utf-8'), format)
         except:
             raise web.HTTPError(400, u'Invalid JSON data')
 
@@ -171,7 +171,7 @@ class NotebookManager(LoggingConfigurable):
             raise web.HTTPError(415, u'Invalid notebook format: %s' % format)
 
         try:
-            nb = current.reads(data, format)
+            nb = current.reads(data.decode('utf-8'), format)
         except:
             raise web.HTTPError(400, u'Invalid JSON data')
 

--- a/setup3.py
+++ b/setup3.py
@@ -1,10 +1,11 @@
 import os.path
 from setuptools import setup
 
-from setupbase import (setup_args, find_scripts, find_packages)
+from setupbase import (setup_args, find_scripts, find_packages, find_package_data)
     
 setup_args['entry_points'] = find_scripts(True, suffix='3')
 setup_args['packages'] = find_packages()
+setup_args['package_data'] = find_package_data()
 
 def main():
     setup(use_2to3 = True, **setup_args)


### PR DESCRIPTION
It was surprisingly easy to get the notebook code running under Python 3.

@ellisonbg, there was a bytestring/unicode mismatch somewhere that I didn't properly investigate - I just stuck in the quick fix you can see in handlers.py. Let me know if there's a better place to solve it.

Saving the notebook isn't working (it complains about invalid JSON), and my testing was rather brief, but this does at least allow the notebook to start under Python 3.
