### PR TITLE
DOC: extensions: add documentation for the bundled extensions

### DIFF
--- a/IPython/extensions/parallelmagic.py
+++ b/IPython/extensions/parallelmagic.py
@@ -1,6 +1,27 @@
 # encoding: utf-8
+"""
+=============
+parallelmagic
+=============
 
-"""Magic command interface for interactive parallel work."""
+Magic command interface for interactive parallel work.
+
+Usage
+=====
+
+``%autopx``
+
+@AUTOPX_DOC@
+
+``%px``
+
+@PX_DOC@
+
+``%result``
+
+@RESULT_DOC@
+
+"""
 
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2008-2009  The IPython Development Team
@@ -284,6 +305,12 @@ class ParalleMagic(Plugin):
                 return False
 
 
+__doc__ = __doc__.replace('@AUTOPX_DOC@',
+                          "        " + ParalleMagic.magic_autopx.__doc__)
+__doc__ = __doc__.replace('@PX_DOC@',
+                          "        " + ParalleMagic.magic_px.__doc__)
+__doc__ = __doc__.replace('@RESULT_DOC@',
+                          "        " + ParalleMagic.magic_result.__doc__)
 
 
 _loaded = False

--- a/IPython/extensions/sympyprinting.py
+++ b/IPython/extensions/sympyprinting.py
@@ -1,7 +1,14 @@
-"""A print function that pretty prints sympy Basic objects.
+"""
+A print function that pretty prints sympy Basic objects.
 
-Authors:
-* Brian Granger
+:moduleauthor: Brian Granger
+
+Usage
+=====
+
+Once the extension is loaded, Sympy Basic objects are automatically
+pretty-printed.
+
 """
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2008-2011  The IPython Development Team

--- a/docs/source/config/extensions/autoreload.txt
+++ b/docs/source/config/extensions/autoreload.txt
@@ -1,0 +1,7 @@
+.. _extensions_autoreload:
+
+==========
+autoreload
+==========
+
+.. automodule:: IPython.extensions.autoreload

--- a/docs/source/config/extensions/index.txt
+++ b/docs/source/config/extensions/index.txt
@@ -59,3 +59,13 @@ To load that same extension at runtime, use the ``%load_ext`` magic:
 To summarize, in conjunction with configuration files and profiles, IPython
 extensions give you complete and flexible control over your IPython
 setup.
+
+Extensions bundled with IPython
+===============================
+
+.. toctree::
+   :maxdepth: 1
+
+   autoreload
+   parallelmagic
+   sympyprinting

--- a/docs/source/config/extensions/parallelmagic.txt
+++ b/docs/source/config/extensions/parallelmagic.txt
@@ -1,0 +1,7 @@
+.. _extensions_parallelmagic:
+
+=============
+parallelmagic
+=============
+
+.. automodule:: IPython.extensions.parallelmagic

--- a/docs/source/config/extensions/sympyprinting.txt
+++ b/docs/source/config/extensions/sympyprinting.txt
@@ -1,0 +1,7 @@
+.. _extensions_sympyprinting:
+
+=============
+sympyprinting
+=============
+
+.. automodule:: IPython.extensions.sympyprinting

--- a/docs/source/config/index.txt
+++ b/docs/source/config/index.txt
@@ -8,7 +8,7 @@ Configuration and customization
    :maxdepth: 2
 
    overview.txt
-   extensions.txt
+   extensions/index.txt
    plugins.txt
    ipython.txt
    editors.txt


### PR DESCRIPTION
The extensions bundled with IPython are not currently listed in the documentation. Such a list would probably be quite useful for the users, so it's probably a good idea to add it.

Here's one way to do this. (You might want to remove the `autoreload.txt` part, unless #746 is merged first.)
