### PR TITLE
Magic 'range' crash if greater than len(input_hist)

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -303,7 +303,7 @@ class HistoryManager(Configurable):
         n = len(input_hist)
         if start < 0:
             start += n
-        if not stop:
+        if not stop or (stop > n):
             stop = n
         elif stop < 0:
             stop += n


### PR DESCRIPTION
when calling a magic with a range (eg %save filename 1-500) and an history
smaller than 500 `IPython.core.HistoryManager/_get_range_session` will crash.

this commit fix it by setting the stop argument to at maximum len(input_history)

by the way, is there away to use the negative indexing to count from the end...
something like `%save filename 1:-1` to save the whole current session without _thinking_ of the last prompt number ?
