### PR TITLE
Fix #481 using custom qt4 input hook

### DIFF
--- a/IPython/lib/inputhook.py
+++ b/IPython/lib/inputhook.py
@@ -15,8 +15,13 @@ Inputhook management for GUI event loop integration.
 #-----------------------------------------------------------------------------
 
 import ctypes
+import os
 import sys
 import warnings
+if os.name == 'posix':
+    import select
+elif sys.platform == 'win32':
+    import msvcrt
 
 #-----------------------------------------------------------------------------
 # Constants
@@ -33,8 +38,18 @@ GUI_GLUT = 'glut'
 GUI_PYGLET = 'pyglet'
 
 #-----------------------------------------------------------------------------
-# Utility classes
+# Utilities
 #-----------------------------------------------------------------------------
+
+def stdin_ready():
+    if os.name == 'posix':
+        infds, outfds, erfds = select.select([sys.stdin],[],[],0)
+        if infds:
+            return True
+        else:
+            return False
+    elif sys.platform == 'win32':
+        return msvcrt.kbhit()
 
 
 #-----------------------------------------------------------------------------

--- a/IPython/lib/inputhook.py
+++ b/IPython/lib/inputhook.py
@@ -37,18 +37,27 @@ GUI_PYGLET = 'pyglet'
 # Utilities
 #-----------------------------------------------------------------------------
 
-def stdin_ready():
-    if os.name == 'posix':
-        import select
-        infds, outfds, erfds = select.select([sys.stdin],[],[],0)
-        if infds:
-            return True
-        else:
-            return False
-    elif os.name == 'nt':
-        import msvcrt
-        return msvcrt.kbhit()
-    return True # assume there's something so that we won't wait forever
+def _stdin_ready_posix():
+    """Return True if there's something to read on stdin (posix version)."""
+    infds, outfds, erfds = select.select([sys.stdin],[],[],0)
+    return bool(infds)
+
+def _stdin_ready_nt():
+    """Return True if there's something to read on stdin (nt version)."""
+    return msvcrt.kbhit()
+
+def _stdin_ready_other():
+    """Return True, assuming there's something to read on stdin."""
+    return True #
+
+if os.name == 'posix':
+    import select
+    stdin_ready = _stdin_ready_posix
+elif os.name == 'nt':
+    import msvcrt
+    stdin_ready = _stdin_ready_nt
+else:
+    stdin_ready = _stdin_ready_other
 
 
 #-----------------------------------------------------------------------------

--- a/IPython/lib/inputhook.py
+++ b/IPython/lib/inputhook.py
@@ -18,10 +18,6 @@ import ctypes
 import os
 import sys
 import warnings
-if os.name == 'posix':
-    import select
-elif sys.platform == 'win32':
-    import msvcrt
 
 #-----------------------------------------------------------------------------
 # Constants
@@ -43,13 +39,16 @@ GUI_PYGLET = 'pyglet'
 
 def stdin_ready():
     if os.name == 'posix':
+        import select
         infds, outfds, erfds = select.select([sys.stdin],[],[],0)
         if infds:
             return True
         else:
             return False
-    elif sys.platform == 'win32':
+    elif os.name == 'nt':
+        import msvcrt
         return msvcrt.kbhit()
+    return True # assume there's something so that we won't wait forever
 
 
 #-----------------------------------------------------------------------------

--- a/IPython/lib/inputhook.py
+++ b/IPython/lib/inputhook.py
@@ -32,6 +32,7 @@ GUI_TK = 'tk'
 GUI_OSX = 'osx'
 GUI_GLUT = 'glut'
 GUI_PYGLET = 'pyglet'
+GUI_NONE = 'none' # i.e. disable
 
 #-----------------------------------------------------------------------------
 # Utilities
@@ -417,8 +418,8 @@ def enable_gui(gui=None, app=None):
     Parameters
     ----------
     gui : optional, string or None
-      If None, clears input hook, otherwise it must be one of the recognized
-      GUI names (see ``GUI_*`` constants in module).
+      If None (or 'none'), clears input hook, otherwise it must be one
+      of the recognized GUI names (see ``GUI_*`` constants in module).
 
     app : optional, existing application object.
       For toolkits that have the concept of a global app, you can supply an
@@ -433,6 +434,7 @@ def enable_gui(gui=None, app=None):
     one.
     """
     guis = {None: clear_inputhook,
+            GUI_NONE: clear_inputhook,
             GUI_OSX: lambda app=False: None,
             GUI_TK: enable_tk,
             GUI_GTK: enable_gtk,

--- a/IPython/lib/inputhookqt4.py
+++ b/IPython/lib/inputhookqt4.py
@@ -17,7 +17,7 @@ Author: Christian Boos
 #-----------------------------------------------------------------------------
 
 from IPython.external.qt_for_kernel import QtCore, QtGui
-from IPython.lib.inputhook import stdin_ready
+from IPython.lib.inputhook import allow_CTRL_C, ignore_CTRL_C, stdin_ready
 
 #-----------------------------------------------------------------------------
 # Code
@@ -78,6 +78,7 @@ def create_inputhook_qt4(mgr, app=None):
         back to a clean prompt line.
         """
         try:
+            allow_CTRL_C()
             app = QtCore.QCoreApplication.instance()
             app.processEvents(QtCore.QEventLoop.AllEvents, 300)
             if not stdin_ready():
@@ -88,13 +89,14 @@ def create_inputhook_qt4(mgr, app=None):
                     app.exec_()
                     timer.stop()
         except KeyboardInterrupt:
+            ignore_CTRL_C()
             got_kbdint[0] = True
-            mgr.clear_inputhook()
             print("\nKeyboardInterrupt - qt4 event loop interrupted!"
                   "\n  * hit CTRL+C again to clear the prompt"
                   "\n  * use '%gui none' to disable the event loop"
                   " permanently"
                   "\n    and '%gui qt4' to re-enable it later")
+            mgr.clear_inputhook()
         return 0
 
     def preprompthook_qt4(ishell):

--- a/IPython/lib/inputhookqt4.py
+++ b/IPython/lib/inputhookqt4.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""
+Qt4's inputhook support function
+
+Author: Christian Boos
+"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2011  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+from IPython.core import ipapi
+from IPython.external.qt_for_kernel import QtCore, QtGui
+from IPython.lib.inputhook import stdin_ready
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------
+
+def create_inputhook_qt4(mgr, app=None):
+    """Create an input hook for running the Qt4 application event loop.
+
+    Parameters
+    ----------
+    mgr : an InputHookManager
+
+    app : Qt Application, optional.
+        Running application to use.  If not given, we probe Qt for an
+        existing application object, and create a new one if none is found.
+
+    Returns
+    -------
+    A pair consisting of a Qt Application (either the one given or the
+    one found or created) and a inputhook.
+
+    Notes
+    -----
+    The inputhook function works in tandem with a 'pre_prompt_hook'
+    which automatically restores the hook as an inputhook in case the
+    latter has been temporarily disabled after having intercepted a
+    KeyboardInterrupt.
+    """
+    if app is None:
+        app = QtCore.QCoreApplication.instance()
+        if app is None:
+            app = QtGui.QApplication([" "])
+
+    # Always use a custom input hook instead of PyQt4's default
+    # one, as it interacts better with readline packages (issue
+    # #481).
+
+    # Note that we can't let KeyboardInterrupt escape from that
+    # hook, as no exception can be raised from within a ctypes
+    # python callback. We need to make a compromise: a trapped
+    # KeyboardInterrupt will temporarily disable the input hook
+    # until we start over with a new prompt line with a second
+    # CTRL+C.
+
+    got_kbdint = [False]
+
+    def inputhook_qt4():
+        try:
+            app.processEvents(QtCore.QEventLoop.AllEvents, 300)
+            if not stdin_ready():
+                timer = QtCore.QTimer()
+                timer.timeout.connect(app.quit)
+                while not stdin_ready():
+                    timer.start(50)
+                    app.exec_()
+                    timer.stop()
+        except KeyboardInterrupt:
+            got_kbdint[0] = True
+            mgr.clear_inputhook()
+            print("\n(event loop interrupted - "
+                  "hit CTRL+C again to clear the prompt)")
+        return 0
+
+    def preprompthook_qt4(ishell):
+        if got_kbdint[0]:
+            mgr.set_inputhook(inputhook_qt4)
+    ipapi.get().set_hook('pre_prompt_hook', preprompthook_qt4)
+
+    return app, inputhook_qt4

--- a/IPython/lib/inputhookqt4.py
+++ b/IPython/lib/inputhookqt4.py
@@ -16,7 +16,6 @@ Author: Christian Boos
 # Imports
 #-----------------------------------------------------------------------------
 
-from IPython.core import ipapi
 from IPython.external.qt_for_kernel import QtCore, QtGui
 from IPython.lib.inputhook import stdin_ready
 
@@ -57,7 +56,7 @@ def create_inputhook_qt4(mgr, app=None):
             app = QtGui.QApplication([" "])
 
     # Re-use previously created inputhook if any
-    ip = ipapi.get()
+    ip = get_ipython()
     if hasattr(ip, '_inputhook_qt4'):
         return app, ip._inputhook_qt4
 

--- a/IPython/lib/inputhookqt4.py
+++ b/IPython/lib/inputhookqt4.py
@@ -16,6 +16,7 @@ Author: Christian Boos
 # Imports
 #-----------------------------------------------------------------------------
 
+from IPython.core.interactiveshell import InteractiveShell
 from IPython.external.qt_for_kernel import QtCore, QtGui
 from IPython.lib.inputhook import allow_CTRL_C, ignore_CTRL_C, stdin_ready
 
@@ -56,7 +57,7 @@ def create_inputhook_qt4(mgr, app=None):
             app = QtGui.QApplication([" "])
 
     # Re-use previously created inputhook if any
-    ip = get_ipython()
+    ip = InteractiveShell.instance()
     if hasattr(ip, '_inputhook_qt4'):
         return app, ip._inputhook_qt4
 

--- a/IPython/lib/inputhookqt4.py
+++ b/IPython/lib/inputhookqt4.py
@@ -85,6 +85,7 @@ def create_inputhook_qt4(mgr, app=None):
     def preprompthook_qt4(ishell):
         if got_kbdint[0]:
             mgr.set_inputhook(inputhook_qt4)
+        got_kbdint[0] = False
     ipapi.get().set_hook('pre_prompt_hook', preprompthook_qt4)
 
     return app, inputhook_qt4

--- a/IPython/lib/inputhookqt4.py
+++ b/IPython/lib/inputhookqt4.py
@@ -81,6 +81,8 @@ def create_inputhook_qt4(mgr, app=None):
         try:
             allow_CTRL_C()
             app = QtCore.QCoreApplication.instance()
+            if not app: # shouldn't happen, but safer if it happens anyway...
+                return 0
             app.processEvents(QtCore.QEventLoop.AllEvents, 300)
             if not stdin_ready():
                 timer = QtCore.QTimer()
@@ -99,6 +101,11 @@ def create_inputhook_qt4(mgr, app=None):
                   " permanently"
                   "\n    and '%gui qt4' to re-enable it later")
             mgr.clear_inputhook()
+        except: # NO exceptions are allowed to escape from a ctypes callback
+            mgr.clear_inputhook()
+            from traceback import print_exc
+            print_exc()
+            print("Got exception from inputhook_qt4, unregistering.")
         return 0
 
     def preprompthook_qt4(ishell):

--- a/IPython/lib/inputhookqt4.py
+++ b/IPython/lib/inputhookqt4.py
@@ -88,6 +88,7 @@ def create_inputhook_qt4(mgr, app=None):
                     timer.start(50)
                     app.exec_()
                     timer.stop()
+            ignore_CTRL_C()
         except KeyboardInterrupt:
             ignore_CTRL_C()
             got_kbdint[0] = True

--- a/IPython/lib/inputhookqt4.py
+++ b/IPython/lib/inputhookqt4.py
@@ -90,8 +90,11 @@ def create_inputhook_qt4(mgr, app=None):
         except KeyboardInterrupt:
             got_kbdint[0] = True
             mgr.clear_inputhook()
-            print("\n(event loop interrupted - "
-                  "hit CTRL+C again to clear the prompt)")
+            print("\nKeyboardInterrupt - qt4 event loop interrupted!"
+                  "\n  * hit CTRL+C again to clear the prompt"
+                  "\n  * use '%gui none' to disable the event loop"
+                  " permanently"
+                  "\n    and '%gui qt4' to re-enable it later")
         return 0
 
     def preprompthook_qt4(ishell):

--- a/IPython/lib/inputhookwx.py
+++ b/IPython/lib/inputhookwx.py
@@ -24,25 +24,12 @@ import time
 from timeit import default_timer as clock
 import wx
 
-if os.name == 'posix':
-    import select
-elif sys.platform == 'win32':
-    import msvcrt
+from IPython.lib.inputhook import stdin_ready
+
 
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
-
-def stdin_ready():
-    if os.name == 'posix':
-        infds, outfds, erfds = select.select([sys.stdin],[],[],0)
-        if infds:
-            return True
-        else:
-            return False
-    elif sys.platform == 'win32':
-        return msvcrt.kbhit()
-
 
 def inputhook_wx1():
     """Run the wx event loop by processing pending events only.


### PR DESCRIPTION
This is my tentative fix for issue #481, as discussed in https://github.com/ipython/ipython/issues/481#issuecomment-2161959.

This is not meant to be merged as such, as I only could provide limited testing:
- seems to fix the issue for Windows (at least Win 7 x64)
- no idea about the impact on Linux, Mac; at best it will also fix the issue for Mac ;-)
- couldn't check if the refactoring done in the first cset 3d1dca86 didn't break Wx support (I don't have it installed)

Also, I've currently inlined the hook, as it was small enough it didn't feel appropriate to create a IPython/lib/inputhookqt.py file.

Finally, the behavior with Ctrl-C is currently quite catastrophic, though this is not related to my changes, as it's the same behavior with the original 0.11 install, even without Qt involved. But this probably another topic.

---

See [second iteration](#issuecomment-2338013) for the merge candidate.
