### PR TITLE
Adding -m option to %run, similar to -m for python interpreter.

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -19,6 +19,7 @@ import __builtin__ as builtin_mod
 import __future__
 import bdb
 import inspect
+import imp
 import os
 import sys
 import shutil
@@ -91,11 +92,24 @@ def needs_local_scope(func):
     func.needs_local_scope = True
     return func
 
-import imp, os
-
 def find_module(name, path=None):
     """imp.find_module variant that only return path of module.
-    Return None if module is missing or does not have .py or .pyw extension
+    
+    The `imp.find_module` returns a filehandle that we are not interested in.
+    Also we ignore any bytecode files that `imp.find_module` finds.
+
+    Parameters
+    ----------
+    name : str
+        name of module to locate
+    path : list of str
+        list of paths to search for `name`. If path=None then search sys.path
+
+    Returns
+    -------
+    filename : str
+        Return full path of module or None if module is missing or does not have
+        .py or .pyw extension
     """
     if name is None:
         return None
@@ -113,7 +127,17 @@ def find_module(name, path=None):
         return None
 
 def get_init(dirname):
-    """Get __init__ file path for module with directory dirname
+    """Get __init__ file path for module directory
+    
+    Parameters
+    ----------
+    dirname : str
+        Find the __init__ file in directory `dirname`
+
+    Returns
+    -------
+    init_path : str
+        Path to __init__ file
     """
     fbase =  os.path.join(dirname, "__init__")
     for ext in [".py", ".pyw"]:
@@ -122,10 +146,24 @@ def get_init(dirname):
             return fname
 
 
-def find_mod(name):
-    """Find module *name* on sys.path
+def find_mod(module_name):
+    """Find module `module_name` on sys.path
+    
+    Return the path to module `module_name`. If `module_name` refers to
+    a module directory then return path to __init__ file. Return full 
+    path of module or None if module is missing or does not have .py or .pyw
+    extension. We are not interested in running bytecode.
+    
+    Parameters
+    ----------
+    module_name : str
+    
+    Returns
+    -------
+    modulepath : str
+        Path to module `module_name`.
     """
-    parts = name.split(".")
+    parts = module_name.split(".")
     basepath = find_module(parts[0])
     for submodname in parts[1:]:
         basepath = find_module(submodname, [basepath])

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -55,6 +55,7 @@ from IPython.lib.pylabtools import mpl_runner
 from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils import py3compat
 from IPython.utils.io import file_read, nlprint
+from IPython.utils.module_paths import find_mod
 from IPython.utils.path import get_py_filename, unquote_filename
 from IPython.utils.process import arg_split, abbrev_cwd
 from IPython.utils.terminal import set_term_title
@@ -91,85 +92,6 @@ def needs_local_scope(func):
     """Decorator to mark magic functions which need to local scope to run."""
     func.needs_local_scope = True
     return func
-
-def find_module(name, path=None):
-    """imp.find_module variant that only return path of module.
-    
-    The `imp.find_module` returns a filehandle that we are not interested in.
-    Also we ignore any bytecode files that `imp.find_module` finds.
-
-    Parameters
-    ----------
-    name : str
-        name of module to locate
-    path : list of str
-        list of paths to search for `name`. If path=None then search sys.path
-
-    Returns
-    -------
-    filename : str
-        Return full path of module or None if module is missing or does not have
-        .py or .pyw extension
-    """
-    if name is None:
-        return None
-    try:
-        file, filename, _ = imp.find_module(name, path)
-    except ImportError:
-        return None
-    if file is None:
-        return filename
-    else:
-        file.close()
-    if os.path.splitext(filename)[1] in [".py", "pyc"]:
-        return filename
-    else:
-        return None
-
-def get_init(dirname):
-    """Get __init__ file path for module directory
-    
-    Parameters
-    ----------
-    dirname : str
-        Find the __init__ file in directory `dirname`
-
-    Returns
-    -------
-    init_path : str
-        Path to __init__ file
-    """
-    fbase =  os.path.join(dirname, "__init__")
-    for ext in [".py", ".pyw"]:
-        fname = fbase + ext
-        if os.path.isfile(fname):
-            return fname
-
-
-def find_mod(module_name):
-    """Find module `module_name` on sys.path
-    
-    Return the path to module `module_name`. If `module_name` refers to
-    a module directory then return path to __init__ file. Return full 
-    path of module or None if module is missing or does not have .py or .pyw
-    extension. We are not interested in running bytecode.
-    
-    Parameters
-    ----------
-    module_name : str
-    
-    Returns
-    -------
-    modulepath : str
-        Path to module `module_name`.
-    """
-    parts = module_name.split(".")
-    basepath = find_module(parts[0])
-    for submodname in parts[1:]:
-        basepath = find_module(submodname, [basepath])
-    if basepath and os.path.isdir(basepath):
-        basepath = get_init(basepath)
-    return basepath
 
     
 # Used for exception handling in magic_edit

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -1491,7 +1491,7 @@ Currently the magic system has the following functions:\n"""
             return None
 
     @skip_doctest
-    def magic_run(self, parameter_s ='',runner=None,
+    def magic_run(self, parameter_s ='', runner=None,
                   file_finder=get_py_filename):
         """Run the named file inside IPython as a program.
 
@@ -1614,8 +1614,8 @@ Currently the magic system has the following functions:\n"""
         """
 
         # get arguments and set sys.argv for program to be run.
-        opts,arg_lst = self.parse_options(parameter_s,'nidtN:b:pD:l:rs:T:em:',
-                                          mode='list',list_all=1)
+        opts, arg_lst = self.parse_options(parameter_s, 'nidtN:b:pD:l:rs:T:em:',
+                                           mode='list', list_all=1)
         if "m" in opts:
             modulename = opts["m"][0]
             modpath = find_mod(modulename)
@@ -1627,7 +1627,7 @@ Currently the magic system has the following functions:\n"""
             filename = file_finder(arg_lst[0])
         except IndexError:
             warn('you must provide at least a filename.')
-            print '\n%run:\n',oinspect.getdoc(self.magic_run)
+            print '\n%run:\n', oinspect.getdoc(self.magic_run)
             return
         except IOError as e:
             try:
@@ -1642,7 +1642,7 @@ Currently the magic system has the following functions:\n"""
             return
 
         # Control the response to exit() calls made by the script being run
-        exit_ignore = opts.has_key('e')
+        exit_ignore = 'e' in opts
 
         # Make sure that the running script gets a proper sys.argv as if it
         # were run from a system shell.
@@ -1651,9 +1651,9 @@ Currently the magic system has the following functions:\n"""
         # simulate shell expansion on arguments, at least tilde expansion
         args = [ os.path.expanduser(a) for a in arg_lst[1:] ]
 
-        sys.argv = [filename]+ args  # put in the proper filename
+        sys.argv = [filename] + args  # put in the proper filename
 
-        if opts.has_key('i'):
+        if 'i' in opts:
             # Run in user's interactive namespace
             prog_ns = self.shell.user_ns
             __name__save = self.shell.user_ns['__name__']
@@ -1661,7 +1661,7 @@ Currently the magic system has the following functions:\n"""
             main_mod = self.shell.new_main_mod(prog_ns)
         else:
             # Run in a fresh, empty namespace
-            if opts.has_key('n'):
+            if 'n' in opts:
                 name = os.path.splitext(os.path.basename(filename))[0]
             else:
                 name = '__main__'
@@ -1690,10 +1690,10 @@ Currently the magic system has the following functions:\n"""
         try:
             stats = None
             with self.readline_no_record:
-                if opts.has_key('p'):
-                    stats = self.magic_prun('',0,opts,arg_lst,prog_ns)
+                if 'p' in opts:
+                    stats = self.magic_prun('', 0, opts, arg_lst, prog_ns)
                 else:
-                    if opts.has_key('d'):
+                    if 'd' in opts:
                         deb = debugger.Pdb(self.shell.colors)
                         # reset Breakpoint state, which is moronically kept
                         # in a class
@@ -1702,11 +1702,11 @@ Currently the magic system has the following functions:\n"""
                         bdb.Breakpoint.bpbynumber = [None]
                         # Set an initial breakpoint to stop execution
                         maxtries = 10
-                        bp = int(opts.get('b',[1])[0])
-                        checkline = deb.checkline(filename,bp)
+                        bp = int(opts.get('b', [1])[0])
+                        checkline = deb.checkline(filename, bp)
                         if not checkline:
-                            for bp in range(bp+1,bp+maxtries+1):
-                                if deb.checkline(filename,bp):
+                            for bp in range(bp + 1, bp + maxtries + 1):
+                                if deb.checkline(filename, bp):
                                     break
                             else:
                                 msg = ("\nI failed to find a valid line to set "
@@ -1717,23 +1717,23 @@ Currently the magic system has the following functions:\n"""
                                 error(msg)
                                 return
                         # if we find a good linenumber, set the breakpoint
-                        deb.do_break('%s:%s' % (filename,bp))
+                        deb.do_break('%s:%s' % (filename, bp))
                         # Start file run
                         print "NOTE: Enter 'c' at the",
                         print "%s prompt to start your script." % deb.prompt
                         try:
-                            deb.run('execfile("%s")' % filename,prog_ns)
+                            deb.run('execfile("%s")' % filename, prog_ns)
 
                         except:
                             etype, value, tb = sys.exc_info()
                             # Skip three frames in the traceback: the %run one,
                             # one inside bdb.py, and the command-line typed by the
                             # user (run by exec in pdb itself).
-                            self.shell.InteractiveTB(etype,value,tb,tb_offset=3)
+                            self.shell.InteractiveTB(etype, value, tb, tb_offset=3)
                     else:
                         if runner is None:
                             runner = self.shell.safe_execfile
-                        if opts.has_key('t'):
+                        if 't' in opts:
                             # timed execution
                             try:
                                 nruns = int(opts['N'][0])
@@ -1745,11 +1745,11 @@ Currently the magic system has the following functions:\n"""
                             twall0 = time.time()
                             if nruns == 1:
                                 t0 = clock2()
-                                runner(filename,prog_ns,prog_ns,
+                                runner(filename, prog_ns, prog_ns,
                                        exit_ignore=exit_ignore)
                                 t1 = clock2()
-                                t_usr = t1[0]-t0[0]
-                                t_sys = t1[1]-t0[1]
+                                t_usr = t1[0] - t0[0]
+                                t_sys = t1[1] - t0[1]
                                 print "\nIPython CPU timings (estimated):"
                                 print "  User   : %10.2f s." % t_usr
                                 print "  System : %10.2f s." % t_sys
@@ -1757,30 +1757,30 @@ Currently the magic system has the following functions:\n"""
                                 runs = range(nruns)
                                 t0 = clock2()
                                 for nr in runs:
-                                    runner(filename,prog_ns,prog_ns,
+                                    runner(filename, prog_ns, prog_ns,
                                            exit_ignore=exit_ignore)
                                 t1 = clock2()
-                                t_usr = t1[0]-t0[0]
-                                t_sys = t1[1]-t0[1]
+                                t_usr = t1[0] - t0[0]
+                                t_sys = t1[1] - t0[1]
                                 print "\nIPython CPU timings (estimated):"
-                                print "Total runs performed:",nruns
-                                print "  Times  : %10.2f    %10.2f" % ('Total','Per run')
-                                print "  User   : %10.2f s, %10.2f s." % (t_usr,t_usr/nruns)
-                                print "  System : %10.2f s, %10.2f s." % (t_sys,t_sys/nruns)
+                                print "Total runs performed:", nruns
+                                print "  Times  : %10.2f    %10.2f" % ('Total', 'Per run')
+                                print "  User   : %10.2f s, %10.2f s." % (t_usr, t_usr / nruns)
+                                print "  System : %10.2f s, %10.2f s." % (t_sys, t_sys / nruns)
                             twall1 = time.time()
-                            print "Wall time: %10.2f s." % (twall1-twall0)
+                            print "Wall time: %10.2f s." % (twall1 - twall0)
 
                         else:
                             # regular execution
-                            runner(filename,prog_ns,prog_ns,exit_ignore=exit_ignore)
+                            runner(filename, prog_ns, prog_ns, exit_ignore=exit_ignore)
 
-                if opts.has_key('i'):
+                if 'i' in opts:
                     self.shell.user_ns['__name__'] = __name__save
                 else:
                     # The shell MUST hold a reference to prog_ns so after %run
                     # exits, the python deletion mechanism doesn't zero it out
                     # (leaving dangling references).
-                    self.shell.cache_main_mod(prog_ns,filename)
+                    self.shell.cache_main_mod(prog_ns, filename)
                     # update IPython interactive namespace
 
                     # Some forms of read errors on the file may mean the

--- a/IPython/utils/module_paths.py
+++ b/IPython/utils/module_paths.py
@@ -1,0 +1,125 @@
+"""Utility functions for finding modules
+
+Utility functions for finding modules on sys.path.
+
+`find_mod` finds named module on sys.path.
+
+`get_init` helper function that finds __init__ file in a directory.
+
+`find_module` variant of imp.find_module in std_lib that only returns
+path to module and not an open file object as well.
+
+
+
+"""
+#-----------------------------------------------------------------------------
+# Copyright (c) 2011, the IPython Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+from __future__ import print_function
+
+# Stdlib imports
+import imp
+import os
+
+# Third-party imports
+
+# Our own imports
+
+
+#-----------------------------------------------------------------------------
+# Globals and constants
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Local utilities
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Classes and functions
+#-----------------------------------------------------------------------------
+def find_module(name, path=None):
+    """imp.find_module variant that only return path of module.
+    
+    The `imp.find_module` returns a filehandle that we are not interested in.
+    Also we ignore any bytecode files that `imp.find_module` finds.
+
+    Parameters
+    ----------
+    name : str
+        name of module to locate
+    path : list of str
+        list of paths to search for `name`. If path=None then search sys.path
+
+    Returns
+    -------
+    filename : str
+        Return full path of module or None if module is missing or does not have
+        .py or .pyw extension
+    """
+    if name is None:
+        return None
+    try:
+        file, filename, _ = imp.find_module(name, path)
+    except ImportError:
+        return None
+    if file is None:
+        return filename
+    else:
+        file.close()
+    if os.path.splitext(filename)[1] in [".py", "pyc"]:
+        return filename
+    else:
+        return None
+
+def get_init(dirname):
+    """Get __init__ file path for module directory
+    
+    Parameters
+    ----------
+    dirname : str
+        Find the __init__ file in directory `dirname`
+
+    Returns
+    -------
+    init_path : str
+        Path to __init__ file
+    """
+    fbase =  os.path.join(dirname, "__init__")
+    for ext in [".py", ".pyw"]:
+        fname = fbase + ext
+        if os.path.isfile(fname):
+            return fname
+
+
+def find_mod(module_name):
+    """Find module `module_name` on sys.path
+    
+    Return the path to module `module_name`. If `module_name` refers to
+    a module directory then return path to __init__ file. Return full 
+    path of module or None if module is missing or does not have .py or .pyw
+    extension. We are not interested in running bytecode.
+    
+    Parameters
+    ----------
+    module_name : str
+    
+    Returns
+    -------
+    modulepath : str
+        Path to module `module_name`.
+    """
+    parts = module_name.split(".")
+    basepath = find_module(parts[0])
+    for submodname in parts[1:]:
+        basepath = find_module(submodname, [basepath])
+    if basepath and os.path.isdir(basepath):
+        basepath = get_init(basepath)
+    return basepath

--- a/IPython/utils/tests/test_module_paths.py
+++ b/IPython/utils/tests/test_module_paths.py
@@ -1,0 +1,133 @@
+# encoding: utf-8
+"""Tests for IPython.utils.path.py"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2008  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+from __future__ import with_statement
+
+import os
+import shutil
+import sys
+import tempfile
+import StringIO
+
+from os.path import join, abspath, split
+
+import nose.tools as nt
+
+from nose import with_setup
+
+import IPython
+from IPython.testing import decorators as dec
+from IPython.testing.decorators import skip_if_not_win32, skip_win32
+from IPython.testing.tools import make_tempfile
+from IPython.utils import path, io
+from IPython.utils import py3compat
+
+import IPython.utils.module_paths as mp
+
+env = os.environ
+TEST_FILE_PATH = split(abspath(__file__))[0]
+TMP_TEST_DIR = tempfile.mkdtemp()
+#
+# Setup/teardown functions/decorators
+#
+
+old_syspath = sys.path
+sys.path = [TMP_TEST_DIR]
+
+def make_empty_file(fname):
+    f = open(fname, 'w')
+    f.close()
+
+
+def setup():
+    """Setup testenvironment for the module:
+
+    """
+    # Do not mask exceptions here.  In particular, catching WindowsError is a
+    # problem because that exception is only defined on Windows...
+    os.makedirs(join(TMP_TEST_DIR, "xmod"))
+    os.makedirs(join(TMP_TEST_DIR, "nomod"))
+    make_empty_file(join(TMP_TEST_DIR, "xmod/__init__.py"))
+    make_empty_file(join(TMP_TEST_DIR, "xmod/sub.py"))
+    make_empty_file(join(TMP_TEST_DIR, "pack.py"))
+    make_empty_file(join(TMP_TEST_DIR, "packpyc.pyc"))
+
+def teardown():
+    """Teardown testenvironment for the module:
+
+            - Remove tempdir
+    """
+    # Note: we remove the parent test dir, which is the root of all test
+    # subdirs we may have created.  Use shutil instead of os.removedirs, so
+    # that non-empty directories are all recursively removed.
+    shutil.rmtree(TMP_TEST_DIR)
+
+
+def test_get_init_1():
+    """See if get_init can find __init__.py in this testdir"""
+    with make_tempfile(join(TMP_TEST_DIR, "__init__.py")):
+        assert mp.get_init(TMP_TEST_DIR)
+
+def test_get_init_2():
+    """See if get_init can find __init__.pyw in this testdir"""
+    with make_tempfile(join(TMP_TEST_DIR, "__init__.pyw")):
+        assert mp.get_init(TMP_TEST_DIR)
+
+def test_get_init_3():
+    """get_init can't find __init__.pyc in this testdir"""
+    with make_tempfile(join(TMP_TEST_DIR, "__init__.pyc")):
+        assert mp.get_init(TMP_TEST_DIR) is None
+
+def test_get_init_3():
+    """get_init can't find __init__ in empty testdir"""
+    assert mp.get_init(TMP_TEST_DIR) is None
+
+
+def test_find_mod_1():
+    modpath = join(TMP_TEST_DIR, "xmod", "__init__.py")
+    assert mp.find_mod("xmod") == modpath
+
+def test_find_mod_2():
+    modpath = join(TMP_TEST_DIR, "xmod", "__init__.py")
+    assert mp.find_mod("xmod") == modpath
+
+def test_find_mod_3():
+    modpath = join(TMP_TEST_DIR, "xmod", "sub.py")
+    assert mp.find_mod("xmod.sub") == modpath
+
+def test_find_mod_4():
+    modpath = join(TMP_TEST_DIR, "pack.py")
+    assert mp.find_mod("pack") == modpath
+
+def test_find_mod_5():
+    assert mp.find_mod("packpyc") is None
+
+def test_find_module_1():
+    modpath = join(TMP_TEST_DIR, "xmod")
+    assert mp.find_module("xmod") == modpath
+
+def test_find_module_2():
+    """Testing sys.path that is empty"""
+    assert mp.find_module("xmod", []) is None
+
+def test_find_module_3():
+    """Testing sys.path that is empty"""
+    assert mp.find_module(None, None) is None
+
+def test_find_module_4():
+    """Testing sys.path that is empty"""
+    assert mp.find_module(None) is None
+
+def test_find_module_5():
+    assert mp.find_module("xmod.nopack") is None


### PR DESCRIPTION
I have long been missing an option to %run that is similar to -m for the regular python interpreter.

The -m option searches for a module on the python path and launches that module as a script.

This pull request is a first shot at this implementation. can you see anything that is missing?

I added some helper functions at top-level for locating modules, should they be somewhere else? 

/Jörgen
