### PR TITLE
update tornado dependency to 2.1

### DIFF
--- a/IPython/frontend/html/notebook/__init__.py
+++ b/IPython/frontend/html/notebook/__init__.py
@@ -1,0 +1,12 @@
+"""The IPython HTML Notebook"""
+
+# check for tornado 2.1.0
+msg = "The IPython Notebook requires tornado >= 2.1.0"
+try:
+    import tornado
+except ImportError:
+    raise ImportError(msg)
+else:
+    if tornado.version_info < (2,1,0):
+        raise ImportError(msg+", but you have %s"%tornado.version)
+del msg

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -111,7 +111,15 @@ if os.name == 'nt':
 else:
     have['zmq'] = test_for('zmq', '2.1.4')
 have['qt'] = test_for('IPython.external.qt')
-have['tornado'] = test_for('tornado')
+
+try:
+    import tornado
+    if tornado.version_info < (2,1,0):
+        raise ImportError
+except ImportError:
+    have['tornado'] = False
+else:
+    have['tornado'] = True
 
 #-----------------------------------------------------------------------------
 # Functions and classes

--- a/docs/source/install/install.txt
+++ b/docs/source/install/install.txt
@@ -336,6 +336,7 @@ pygments
 The syntax-highlighting in ``ipython qtconsole`` is done with the pygments_
 project, which is easy_install-able.
 
+.. _installnotebook:
 
 Dependencies for the IPython HTML notebook
 ==========================================
@@ -352,14 +353,11 @@ the HTML notebook requires ZeroMQ and PyZMQ.
 Tornado
 -------
 
-The IPython notebook uses the Tornado_ project for its HTTP server.  As of this
-writing, we require a development version from github, as version 2.0 is *not
-sufficient*.  You can either clone their git repository yourself and install it
-manually, or install directly from github with::
+The IPython notebook uses the Tornado_ project for its HTTP server.  Tornado 2.1
+is required, in order to support current versions of browsers, due to an update
+to the websocket protocol.
 
-    easy_install https://github.com/facebook/tornado/tarball/master
 
-    
 MathJax
 -------
 

--- a/docs/source/interactive/htmlnotebook.txt
+++ b/docs/source/interactive/htmlnotebook.txt
@@ -4,6 +4,10 @@
 An HTML Notebook IPython
 =========================
 
+.. seealso::
+
+    :ref:`Installation requirements <installnotebook>` for the Notebook.
+
 The IPython Notebook consists of two related components:
 
 * An JSON based Notebook document format for recording and distributing


### PR DESCRIPTION
The notebook server will no longer try to launch with 2.0.

Test imports and install doc updated to match.

The only reason I didn't push directly to master is that 2.0 will technically still work with some browser versions.  

But I don't think there's any need to support 2.0.
