### PR TITLE
History access

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -396,7 +396,7 @@ class HistoryManager(HistoryAccessor):
                 line = input_hist[i]
             yield (0, i, line)
     
-    def get_range(self, session, start=1, stop=None, raw=True,output=False):
+    def get_range(self, session=0, start=1, stop=None, raw=True,output=False):
         """Retrieve input by session.
         
         Parameters

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -33,8 +33,10 @@ from IPython.utils.warn import warn
 #-----------------------------------------------------------------------------
 
 class HistoryAccessor(Configurable):
-    """Access the history database without adding to it. For use by standalone
-    history tools."""
+    """Access the history database without adding to it.
+    
+    This is intended for use by standalone history tools. IPython shells use
+    HistoryManager, below, which is a subclass of this."""
     # String holding the path to the history file
     hist_file = Unicode(config=True)
 

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -38,6 +38,12 @@ def test_history():
             ip.history_manager.store_output(3)
 
             nt.assert_equal(ip.history_manager.input_hist_raw, [''] + hist)
+            
+            # Detailed tests for _get_range_session
+            grs = ip.history_manager._get_range_session
+            nt.assert_equal(list(grs(start=2,stop=-1)), zip([0], [2], hist[1:-1]))
+            nt.assert_equal(list(grs(start=-2)), zip([0,0], [2,3], hist[-2:]))
+            nt.assert_equal(list(grs(output=True)), zip([0,0,0], [1,2,3], zip(hist, [None,None,'spam'])))
 
             # Check whether specifying a range beyond the end of the current
             # session results in an error (gh-804)

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -372,6 +372,18 @@ def get_ipython_module_path(module_str):
     the_path = the_path.replace('.pyo', '.py')
     return py3compat.cast_unicode(the_path, fs_encoding)
 
+def locate_profile(profile='default'):
+    """Find the path to the folder associated with a given profile.
+    
+    I.e. find $IPYTHON_DIR/profile_whatever.
+    """
+    from IPython.core.profiledir import ProfileDir, ProfileDirError
+    try:
+        pd = ProfileDir.find_profile_dir_by_name(get_ipython_dir(), profile)
+    except ProfileDirError:
+        # IOError makes more sense when people are expecting a path
+        raise IOError("Couldn't find profile %r" % profile)
+    return pd.location
 
 def expand_path(s):
     """Expand $VARS and ~names in a string, like a shell

--- a/docs/examples/core/ipython-get-history.py
+++ b/docs/examples/core/ipython-get-history.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""Extract a session from the IPython input history.
+
+Usage:
+  ipython-get-history.py sessionnumber [outputfile]
+
+If outputfile is not given, the relevant history is written to stdout. If
+outputfile has a .py extension, the translated history (without IPython's
+special syntax) will be extracted.
+
+Example:
+  ./ipython-get-history.py 57 record.ipy
+
+
+This script is a simple demonstration of HistoryAccessor. It should be possible
+to build much more flexible and powerful tools to browse and pull from the
+history database.
+"""
+import sys
+import codecs
+
+from IPython.core.history import HistoryAccessor
+
+session_number = int(sys.argv[1])
+if len(sys.argv) > 2:
+    dest = open(sys.argv[2], "w")
+    raw = not sys.argv[2].endswith('.py')
+else:
+    dest = sys.stdout
+    raw = True
+dest.write("# coding: utf-8\n")
+
+# Profiles other than 'default' can be specified here with a profile= argument:
+hist = HistoryAccessor()
+
+for session, lineno, cell in hist.get_range(session=session_number, raw=raw):
+    # To use this in Python 3, remove the .encode() here:
+    dest.write(cell.encode('utf-8') + '\n')


### PR DESCRIPTION
This separates out an `HistoryAccessor` class, which can be used to read the history db without initialising an IPython shell. `HistoryManager` becomes a subclass of that, adding in the methods to write to the database.
