### PR TITLE
contiguous stdout/stderr in notebook

### DIFF
--- a/IPython/frontend/html/notebook/static/css/notebook.css
+++ b/IPython/frontend/html/notebook/static/css/notebook.css
@@ -198,6 +198,8 @@ div.input {
 div.input_area {
     color: black;
     border: 1px solid #ddd;
+    border-radius: 3px;
+    background: #fafafa;
 }
 
 div.input_prompt {

--- a/IPython/frontend/html/notebook/static/css/notebook.css
+++ b/IPython/frontend/html/notebook/static/css/notebook.css
@@ -232,6 +232,9 @@ div.output_stream {
     color: black;
     font-family: monospace;
 }
+div.output_stderr {
+    color: darkred;
+}
 
 div.output_latex {
     text-align: left;

--- a/IPython/frontend/html/notebook/static/css/notebook.css
+++ b/IPython/frontend/html/notebook/static/css/notebook.css
@@ -195,6 +195,7 @@ div.input {
     page-break-inside: avoid;
 }
 
+/* input_area and input_prompt must match in top border and margin for alignment */
 div.input_area {
     color: black;
     border: 1px solid #ddd;
@@ -204,6 +205,7 @@ div.input_area {
 
 div.input_prompt {
     color: navy;
+    border-top: 1px solid transparent;
 }
 
 div.output {

--- a/IPython/frontend/html/notebook/static/css/notebook.css
+++ b/IPython/frontend/html/notebook/static/css/notebook.css
@@ -197,6 +197,7 @@ div.input {
 
 div.input_area {
     color: black;
+    border: 1px solid #ddd;
 }
 
 div.input_prompt {
@@ -227,13 +228,22 @@ div.output_subarea {
 /* The rest of the output_* classes are for special styling of the different
    output types */
 
-div.output_stream {
+/* all text output has this class: */
+div.output_text {
     text-align: left;
     color: black;
     font-family: monospace;
 }
+
+/* stdout/stderr are 'text' as well as 'stream', but pyout/pyerr are *not* streams */
+div.output_stream {
+    padding-top: 0.0em;
+    padding-bottom: 0.0em;
+}
+div.output_stdout {
+}
 div.output_stderr {
-    color: darkred;
+    background: #fdd; /* very light red background for stderr */
 }
 
 div.output_latex {

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -270,7 +270,7 @@ var IPython = (function (IPython) {
         
         // If we got here, attach a new div
         var toinsert = this.create_output_area();
-        this.append_text(json.text, toinsert, subclass);
+        this.append_text(json.text, toinsert, "output_stream "+subclass);
         this.element.find('div.output').append(toinsert);
     };
 
@@ -311,7 +311,7 @@ var IPython = (function (IPython) {
 
 
     CodeCell.prototype.append_text = function (data, element, extra_class) {
-        var toinsert = $("<div/>").addClass("box_flex1 output_subarea output_stream");
+        var toinsert = $("<div/>").addClass("box_flex1 output_subarea output_text");
         if (extra_class){
             toinsert.addClass(extra_class);
         }

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -256,20 +256,21 @@ var IPython = (function (IPython) {
         if (json.stream == undefined){
             json.stream = 'stdout';
         }
+        var subclass = "output_"+json.stream;
         if (this.outputs.length > 0){
             // have at least one output to consider
             var last = this.outputs[this.outputs.length-1];
             if (last.output_type == 'stream' && json.stream == last.stream){
                 // latest output was in the same stream,
                 // so append directly into its pre tag
-                this.element.find('div.output_stream').last().find('pre').append(json.text);
+                this.element.find('div.'+subclass).last().find('pre').append(json.text);
                 return;
             }
         }
         
         // If we got here, attach a new div
         var toinsert = this.create_output_area();
-        this.append_text(json.text, toinsert);
+        this.append_text(json.text, toinsert, subclass);
         this.element.find('div.output').append(toinsert);
     };
 
@@ -309,8 +310,11 @@ var IPython = (function (IPython) {
     }
 
 
-    CodeCell.prototype.append_text = function (data, element) {
+    CodeCell.prototype.append_text = function (data, element, extra_class) {
         var toinsert = $("<div/>").addClass("box_flex1 output_subarea output_stream");
+        if (extra_class){
+            toinsert.addClass(extra_class);
+        }
         toinsert.append($("<pre/>").html(data));
         element.append(toinsert);
     };
@@ -419,7 +423,7 @@ var IPython = (function (IPython) {
 
 
     CodeCell.prototype.fromJSON = function (data) {
-        // console.log('Import from JSON:', data);
+        console.log('Import from JSON:', data);
         if (data.cell_type === 'code') {
             if (data.input !== undefined) {
                 this.set_code(data.input);

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -251,6 +251,23 @@ var IPython = (function (IPython) {
 
 
     CodeCell.prototype.append_stream = function (json) {
+        // temporary fix: if stream undefined (json file written prior to this patch),
+        // default to most likely stdout:
+        if (json.stream == undefined){
+            json.stream = 'stdout';
+        }
+        if (this.outputs.length > 0){
+            // have at least one output to consider
+            var last = this.outputs[this.outputs.length-1];
+            if (last.output_type == 'stream' && json.stream == last.stream){
+                // latest output was in the same stream,
+                // so append directly into its pre tag
+                this.element.find('div.output_stream').last().find('pre').append(json.text);
+                return;
+            }
+        }
+        
+        // If we got here, attach a new div
         var toinsert = this.create_output_area();
         this.append_text(json.text, toinsert);
         this.element.find('div.output').append(toinsert);

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -710,7 +710,8 @@ var IPython = (function (IPython) {
         var json = {};
         json.output_type = msg_type;
         if (msg_type === "stream") {
-            json.text = utils.fixConsole(content.data + '\n');
+            json.text = utils.fixConsole(content.data);
+            json.stream = content.name;
         } else if (msg_type === "display_data") {
             json = this.convert_mime_types(json, content.data);
         } else if (msg_type === "pyout") {


### PR DESCRIPTION
See #829

Previously stdout and stderr were perfectly indistinguishable (logically as well as aesthetically), so this also adds that distinction - I will happily rollback the aesthetic distinction, but I think the logical distinction is important.

Now you can do:

``` python
for i in range(10):
    print i,
    sys.stdout.flush()
```

And you will get your elements on a single line.
