### PR TITLE
Add Tab key to list of keys that scroll down the paging widget.

### DIFF
--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -1265,7 +1265,8 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
                 self.layout().setCurrentWidget(self._control)
             return True
 
-        elif key in (QtCore.Qt.Key_Enter, QtCore.Qt.Key_Return):
+        elif key in (QtCore.Qt.Key_Enter, QtCore.Qt.Key_Return,
+                     QtCore.Qt.Key_Tab):
             new_event = QtGui.QKeyEvent(QtCore.QEvent.KeyPress,
                                         QtCore.Qt.Key_PageDown,
                                         QtCore.Qt.NoModifier)


### PR DESCRIPTION
When the RichIPythonWidget is embedded in another app, hitting a <TAB> in the paging widget (during long completion) switches the focus to another Widget in the app where the IPython widget is embedded.  This commit fixes that behaviour, by making the TAB key also scroll a page in the paging widget. 
