### PR TITLE
reenable multiline history for terminals

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -307,6 +307,9 @@ class InteractiveShell(SingletonConfigurable, Magic):
         Automatically call the pdb debugger after every exception.
         """
     )
+    multiline_history = CBool(False, config=True,
+        help="Store multiple line spanning cells as a single entry in history."
+    )
 
     prompt_in1 = Unicode('In [\\#]: ', config=True)
     prompt_in2 = Unicode('   .\\D.: ', config=True)
@@ -1721,9 +1724,13 @@ class InteractiveShell(SingletonConfigurable, Magic):
         for _, _, cell in self.history_manager.get_tail(1000,
                                                         include_latest=True):
             if cell.strip(): # Ignore blank lines
-                for line in cell.splitlines():
-                    self.readline.add_history(py3compat.unicode_to_str(line,
-                                                                stdin_encoding))
+                if self.multiline_history:
+                      self.readline.add_history(py3compat.unicode_to_str(cell.rstrip(),
+                                                                         stdin_encoding))
+                else:
+                    for line in cell.splitlines():
+                        self.readline.add_history(py3compat.unicode_to_str(line,
+                                                                           stdin_encoding))
 
     def set_next_input(self, s):
         """ Sets the 'default' input string for the next command line.

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -229,11 +229,11 @@ class TerminalInteractiveShell(InteractiveShell):
                     # handling seems rather unpredictable...
                     self.write("\nKeyboardInterrupt in interact()\n")
 
-    def _store_multiline_history(self, source_raw, orig_hlen):
+    def _replace_rlhist_multiline(self, source_raw, hlen_before_cell):
         """Store multiple lines as a single entry in history"""
         if self.multiline_history and self.has_readline:
             hlen = self.readline.get_current_history_length()
-            for i in range(hlen - orig_hlen):
+            for i in range(hlen - hlen_before_cell):
                 self.readline.remove_history_item(hlen - i - 1)
             self.readline.add_history(source_raw.rstrip())
 
@@ -253,7 +253,7 @@ class TerminalInteractiveShell(InteractiveShell):
             self.show_banner()
 
         more = False
-        hlen = self.readline.get_current_history_length()
+        hlen_before_cell = self.readline.get_current_history_length()
 
         # Mark activity in the builtins
         __builtin__.__dict__['__IPYTHON__active'] += 1
@@ -291,8 +291,8 @@ class TerminalInteractiveShell(InteractiveShell):
                 try:
                     self.write('\nKeyboardInterrupt\n')
                     source_raw = self.input_splitter.source_raw_reset()[1]
-                    self._store_multiline_history(source_raw, hlen)
-                    hlen = self.readline.get_current_history_length()
+                    self._replace_rlhist_multiline(source_raw, hlen_before_cell)
+                    hlen_before_cell = self.readline.get_current_history_length()
                     more = False
                 except KeyboardInterrupt:
                     pass
@@ -320,8 +320,8 @@ class TerminalInteractiveShell(InteractiveShell):
                     self.edit_syntax_error()
                 if not more:
                     source_raw = self.input_splitter.source_raw_reset()[1]
-                    self._store_multiline_history(source_raw, hlen)
-                    hlen = self.readline.get_current_history_length()
+                    self._replace_rlhist_multiline(source_raw, hlen_before_cell)
+                    hlen_before_cell = self.readline.get_current_history_length()
                     self.run_cell(source_raw, store_history=True)
 
         # We are off again...


### PR DESCRIPTION
Add configuration variable InteractiveShell.multiline_history.
If it is True cells spanning multiple lines will be saved in history
as a single entry instead of one entry per line, as was the case in
ipython < 0.11.
closes gh-571
