### PR TITLE
updated old scipy.org links, other minor doc fixes

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2509,7 +2509,7 @@ Currently the magic system has the following functions:\n"""
             msg = """\
 Proper color support under MS Windows requires the pyreadline library.
 You can find it at:
-http://ipython.scipy.org/moin/PyReadline/Intro
+http://ipython.org/pyreadline.html
 Gary's readline needs the ctypes module, from:
 http://starship.python.net/crew/theller/ctypes
 (Note that ctypes is already part of Python versions 2.5 and newer).

--- a/IPython/utils/autoattr.py
+++ b/IPython/utils/autoattr.py
@@ -21,7 +21,7 @@ Hettinger. http://users.rcn.com/python/download/Descriptor.htm
 Notes
 -----
 This module is taken from the NiPy project
-(http://neuroimaging.scipy.org/site/index.html), and is BSD licensed.
+(http://nipy.sourceforge.net/nipy/stable/index.html), and is BSD licensed.
 
 Authors
 -------

--- a/docs/source/development/doc_guide.txt
+++ b/docs/source/development/doc_guide.txt
@@ -162,6 +162,6 @@ they're automatically exposed as a website. It works like this:
 .. [Sphinx] Sphinx. http://sphinx.pocoo.org/
 .. [MatplotlibDocGuide] http://matplotlib.sourceforge.net/devel/documenting_mpl.html
 .. [PEP257] PEP 257.  http://www.python.org/peps/pep-0257.html
-.. [NumPyDocGuide] NumPy documentation guide.  http://projects.scipy.org/numpy/wiki/CodingStyleGuidelines
-.. [NumPyExampleDocstring] NumPy example docstring. http://projects.scipy.org/numpy/browser/trunk/doc/EXAMPLE_DOCSTRING.txt
+.. [NumPyDocGuide] NumPy documentation guide. https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
+.. [NumPyExampleDocstring] NumPy example docstring.  https://raw.github.com/numpy/numpy/master/doc/HOWTO_BUILD_DOCS.rst.txt
 

--- a/docs/source/install/install.txt
+++ b/docs/source/install/install.txt
@@ -9,9 +9,8 @@ install all of its dependencies.
 
 
 Please let us know if you have problems installing IPython or any of its
-dependencies. Officially, IPython requires Python version 2.6 or 2.7.  There
-is an experimental port of IPython for Python3 `on GitHub 
-<https://github.com/ipython/ipython-py3k>`_
+dependencies. Officially, IPython requires Python versions 2.6 to 2.7 and 3.1
+to 3.2.
 
 .. warning::
 
@@ -117,7 +116,7 @@ use any of the following alternatives:
 1. Install using :command:`easy_install`.
 
 2. Install using our binary ``.exe`` Windows installer, which can be found
-   `here <http://ipython.scipy.org/dist/>`_
+   `here <http://ipython.org/download.html>`_
 
 3. Install from source, but using :mod:`setuptools` (``python setupegg.py
    install``).
@@ -228,7 +227,8 @@ installed):
     have to do this step.
 
 If needed, the readline egg can be build and installed from source (see the
-wiki page at http://ipython.scipy.org/moin/InstallationOSXLeopard).
+wiki page at
+http://web.archive.org/web/20090614162410/ipython.scipy.org/moin/InstallationOSXLeopard).
 
 On Windows, you will need the PyReadline module. PyReadline is a separate,
 Windows only implementation of readline that uses native Windows calls through

--- a/docs/source/install/install.txt
+++ b/docs/source/install/install.txt
@@ -9,15 +9,15 @@ install all of its dependencies.
 
 
 Please let us know if you have problems installing IPython or any of its
-dependencies. Officially, IPython requires Python versions 2.6 to 2.7 and 3.1
-to 3.2.
+dependencies. Officially, IPython requires Python 2.6, 2.7, 3.1, or 3.2.
 
 .. warning::
 
     Officially, IPython supports Python versions 2.6 and 2.7.
 
     IPython 0.11 has a hard syntax dependency on 2.6, and will no longer work
-    on Python <= 2.5.
+    on Python <= 2.5. You can find older versions of IPython which supported
+    Python <= 2.5 `here <http://archive.ipython.org/release/>`_
 
 Some of the installation approaches use the :mod:`setuptools` package and its
 :command:`easy_install` command line program.  In many scenarios, this provides
@@ -88,7 +88,7 @@ Installation from source
 
 If you don't want to use :command:`easy_install`, or don't have it installed,
 just grab the latest stable build of IPython from `here
-<https://github.com/ipython/ipython/downloads>`_.  Then do the following:
+<http://ipython.org/download.html>`_.  Then do the following:
 
 .. code-block:: bash
 

--- a/docs/source/interactive/htmlnotebook.txt
+++ b/docs/source/interactive/htmlnotebook.txt
@@ -122,8 +122,9 @@ you'll work on a problem in pieces, organizing related pieces into cells and
 moving forward as previous parts work correctly.  This is much more convenient
 for interactive exploration than breaking up a computation into scripts that
 must be executed together, especially if parts of them take a long time to run
-(you can use tricks with namespaces and ``%run -i``, but we think the notebook
-is a more natural solution for  that kind of problem).
+(In the traditional terminal-based IPython, you can use tricks with namespaces
+and ``%run -i`` to achieve this capability, but we think the notebook is a more
+natural solution for  that kind of problem).
 
 The only significant limitation the notebook currently has, compared to the qt
 console, is that it can not run any code that expects input from the kernel
@@ -145,7 +146,7 @@ and then start a qt console pointing to that kernel::
 Text input
 ----------
 
-In addition to code cells and the output they procude (such as figures), you
+In addition to code cells and the output they produce (such as figures), you
 can also type text not meant for execution.  To type text, change the type of a
 cell from ``Code`` to ``Markdown`` by using the button or the :kbd:`Ctrl-m m`
 keybinding (see below).  You can then type any text in Markdown_ syntax, as
@@ -200,7 +201,7 @@ key bindings you need to remember are:
   Selected`` button).
 
 * :kbd:`Ctrl-Enter`: execute the current cell in "terminal mode", where any
-  output is shown but the cursor cursor stays in the current cell, whose input
+  output is shown but the cursor stays in the current cell, whose input
   area is flushed empty.  This is convenient to do quick in-place experiments
   or query things like filesystem content without creating additional cells you
   may not want saved in your notebook.

--- a/docs/source/interactive/tips.txt
+++ b/docs/source/interactive/tips.txt
@@ -4,8 +4,8 @@
 IPython Tips & Tricks
 =====================
 
-The `IPython cookbook <http://wiki.ipython.org/index.php?title=Cookbook>`_ details more
-things you can do with IPython.
+The `IPython cookbook <http://wiki.ipython.org/Cookbook>`_ details more things
+you can do with IPython.
 
 .. This is not in the current version:
 

--- a/docs/source/interactive/tips.txt
+++ b/docs/source/interactive/tips.txt
@@ -4,7 +4,7 @@
 IPython Tips & Tricks
 =====================
 
-The `IPython cookbook <http://ipython.scipy.org/moin/Cookbook>`_ details more
+The `IPython cookbook <http://wiki.ipython.org/index.php?title=Cookbook>`_ details more
 things you can do with IPython.
 
 .. This is not in the current version:

--- a/docs/source/interactive/tutorial.txt
+++ b/docs/source/interactive/tutorial.txt
@@ -8,7 +8,7 @@ You don't need to know anything beyond Python to start using IPython – just ty
 commands as you would at the standard Python prompt. But IPython can do much
 more than the standard prompt. Some key features are described here. For more
 information, check the :ref:`tips page <tips>`, or look at examples in the
-`IPython cookbook <http://ipython.scipy.org/moin/Cookbook>`_.
+`IPython cookbook <http://wiki.ipython.org/index.php?title=Cookbook>`_.
 
 If you've never used Python before, you might want to look at `the official
 tutorial <http://docs.python.org/tutorial/>`_ or an alternative, `Dive into

--- a/docs/source/links.rst
+++ b/docs/source/links.rst
@@ -21,7 +21,7 @@
 .. _`ipython manual`: http://ipython.org/documentation.html
 .. _ipython_github: http://github.com/ipython/ipython/
 .. _ipython_github_repo: http://github.com/ipython/ipython/
-.. _ipython_downloads: http://ipython.scipy.org/dist
+.. _ipython_downloads: http://ipython.org/download.html
 .. _ipython_pypi: http://pypi.python.org/pypi/ipython
 
 .. _ZeroMQ: http://zeromq.org
@@ -35,7 +35,7 @@
 .. _docutils: http://docutils.sourceforge.net
 .. _lyx: http://www.lyx.org
 .. _pep8: http://www.python.org/dev/peps/pep-0008
-.. _numpy_coding_guide: http://projects.scipy.org/numpy/wiki/CodingStyleGuidelines
+.. _numpy_coding_guide: https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
 
 .. Licenses
 .. _GPL: http://www.gnu.org/licenses/gpl.html

--- a/docs/source/whatsnew/version0.10.txt
+++ b/docs/source/whatsnew/version0.10.txt
@@ -275,7 +275,7 @@ New features
 * %edit: If you do '%edit pasted_block', pasted_block variable gets updated
   with new data (so repeated editing makes sense)
 
-.. _Numpy Documentation Standard: http://projects.scipy.org/numpy/wiki/CodingStyleGuidelines#docstring-standard
+.. _Numpy Documentation Standard: https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt#docstring-standard
 
 .. _argparse: http://code.google.com/p/argparse/
 


### PR DESCRIPTION
I updated the docs and moved some old ipython.scipy.org links to point to the relevant new places. 

Also removed references to the defunct separate py3k repo, as per the recent mailing list thread.
