### PR TITLE
Allow connection to kernels by files

### DIFF
--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -173,7 +173,13 @@ class ZMQStreamHandler(websocket.WebSocketHandler):
 class AuthenticatedZMQStreamHandler(ZMQStreamHandler):
     def open(self, kernel_id):
         self.kernel_id = kernel_id.decode('ascii')
-        self.session = Session()
+        try:
+            cfg = self.application.ipython_app.config
+        except AttributeError:
+            # protect from the case where this is run from something other than
+            # the notebook app:
+            cfg = None
+        self.session = Session(config=cfg)
         self.save_on_message = self.on_message
         self.on_message = self.on_first_message
 

--- a/IPython/frontend/html/notebook/kernelmanager.py
+++ b/IPython/frontend/html/notebook/kernelmanager.py
@@ -70,7 +70,8 @@ class MultiKernelManager(LoggingConfigurable):
         kernel_id = unicode(uuid.uuid4())
         # use base KernelManager for each Kernel
         km = KernelManager(connection_file=os.path.join(
-                    self.connection_dir, "kernel-%s.json" % kernel_id)
+                    self.connection_dir, "kernel-%s.json" % kernel_id),
+                    config=self.config,
         )
         km.start_kernel(**kwargs)
         self._kernels[kernel_id] = km

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -44,7 +44,7 @@ from .notebookmanager import NotebookManager
 
 from IPython.core.application import BaseIPythonApplication
 from IPython.core.profiledir import ProfileDir
-from IPython.zmq.session import Session
+from IPython.zmq.session import Session, default_secure
 from IPython.zmq.zmqshell import ZMQInteractiveShell
 from IPython.zmq.ipkernel import (
     flags as ipkernel_flags,
@@ -127,6 +127,10 @@ aliases.update({
     'ws-hostname': 'IPythonNotebookApp.ws_hostname',
     'notebook-dir': 'NotebookManager.notebook_dir',
 })
+
+# remove ipkernel flags that are singletons, and don't make sense in
+# multi-kernel evironment:
+aliases.pop('f', None)
 
 notebook_aliases = [u'port', u'ip', u'keyfile', u'certfile', u'ws-hostname',
                     u'notebook-dir']
@@ -231,6 +235,8 @@ class IPythonNotebookApp(BaseIPythonApplication):
         # Don't let Qt or ZMQ swallow KeyboardInterupts.
         signal.signal(signal.SIGINT, signal.SIG_DFL)
 
+        # force Session default to be secure
+        default_secure(self.config)
         # Create a KernelManager and start a kernel.
         self.kernel_manager = MappingKernelManager(
             config=self.config, log=self.log, kernel_argv=self.kernel_argv,

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -233,7 +233,8 @@ class IPythonNotebookApp(BaseIPythonApplication):
 
         # Create a KernelManager and start a kernel.
         self.kernel_manager = MappingKernelManager(
-            config=self.config, log=self.log, kernel_argv=self.kernel_argv
+            config=self.config, log=self.log, kernel_argv=self.kernel_argv,
+            connection_dir = self.profile_dir.security_dir,
         )
         self.notebook_manager = NotebookManager(config=self.config, log=self.log)
         self.notebook_manager.list_notebooks()

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -212,11 +212,20 @@ class IPythonNotebookApp(BaseIPythonApplication):
         for a in argv:
             if a.startswith('-') and a.lstrip('-') in notebook_flags:
                 self.kernel_argv.remove(a)
+        swallow_next = False
         for a in argv:
+            if swallow_next:
+                self.kernel_argv.remove(a)
+                swallow_next = False
+                continue
             if a.startswith('-'):
-                alias = a.lstrip('-').split('=')[0]
+                split = a.lstrip('-').split('=')[0]
+                alias = split[0]
                 if alias in notebook_aliases:
                     self.kernel_argv.remove(a)
+                    if len(split) == 1:
+                        # alias passed with arg via space
+                        swallow_next = True
 
     def init_configurables(self):
         # Don't let Qt or ZMQ swallow KeyboardInterupts.

--- a/IPython/frontend/html/notebook/tests/test_kernelsession.py
+++ b/IPython/frontend/html/notebook/tests/test_kernelsession.py
@@ -2,12 +2,12 @@
 
 from unittest import TestCase
 
-from IPython.frontend.html.notebook.kernelmanager import KernelManager
+from IPython.frontend.html.notebook.kernelmanager import MultiKernelManager
 
 class TestKernelManager(TestCase):
 
     def test_km_lifecycle(self):
-        km = KernelManager()
+        km = MultiKernelManager()
         kid = km.start_kernel()
         self.assert_(kid in km)
         self.assertEquals(len(km),1)
@@ -21,6 +21,6 @@ class TestKernelManager(TestCase):
         self.assert_('iopub_port' in port_dict)
         self.assert_('shell_port' in port_dict)
         self.assert_('hb_port' in port_dict)
-        km.get_kernel_process(kid)
+        km.get_kernel(kid)
 
 

--- a/IPython/frontend/qt/console/qtconsoleapp.py
+++ b/IPython/frontend/qt/console/qtconsoleapp.py
@@ -356,6 +356,17 @@ class IPythonQtConsoleApp(BaseIPythonApplication):
                         swallow_next = True
     
     def init_connection_file(self):
+        """find the connection file, and load the info if found.
+        
+        The current working directory and the current profile's security
+        directory will be searched for the file if it is not given by
+        absolute path.
+        
+        When attempting to connect to an existing kernel and the `--existing`
+        argument does not match an existing file, it will be interpreted as a
+        fileglob, and the matching file in the current profile's security dir
+        with the latest access time will be used.
+        """
         sec = self.profile_dir.security_dir
         if self.existing:
             try:
@@ -368,7 +379,7 @@ class IPythonQtConsoleApp(BaseIPythonApplication):
                     pat = self.existing
                 else:
                     # accept any substring match
-                    pat = '*%s*'
+                    pat = '*%s*' % self.existing
                 matches = glob.glob( os.path.join(sec, pat) )
                 if not matches:
                     self.log.critical("Could not find existing kernel connection file %s", self.existing)
@@ -446,7 +457,7 @@ class IPythonQtConsoleApp(BaseIPythonApplication):
         try:
             cf = filefind(self.connection_file, ['.', sec])
         except IOError:
-            # file might not exist, use 
+            # file might not exist
             if self.connection_file == os.path.basename(self.connection_file):
                 # just shortname, put it in security dir
                 cf = os.path.join(sec, self.connection_file)

--- a/IPython/frontend/qt/console/qtconsoleapp.py
+++ b/IPython/frontend/qt/console/qtconsoleapp.py
@@ -42,6 +42,7 @@ from IPython.frontend.qt.console import styles
 from IPython.frontend.qt.kernelmanager import QtKernelManager
 from IPython.parallel.util import select_random_ports
 from IPython.utils.path import filefind
+from IPython.utils.py3compat import str_to_bytes
 from IPython.utils.traitlets import (
     Dict, List, Unicode, Int, CaselessStrEnum, CBool, Any
 )
@@ -404,7 +405,7 @@ class IPythonQtConsoleApp(BaseIPythonApplication):
                 # not overridden by config or cl_args
                 setattr(self, name, cfg[name])
         if 'key' in cfg:
-            self.config.Session.key = cfg['key']
+            self.config.Session.key = str_to_bytes(cfg['key'])
     
     def init_ssh(self):
         """set up ssh tunnels, if needed."""

--- a/IPython/frontend/qt/console/qtconsoleapp.py
+++ b/IPython/frontend/qt/console/qtconsoleapp.py
@@ -371,12 +371,12 @@ class IPythonQtConsoleApp(BaseIPythonApplication):
         signal.signal(signal.SIGINT, signal.SIG_DFL)
 
         # Create a KernelManager and start a kernel.
-        self.kernel_manager = QtKernelManager(
-                                shell_address=(self.ip, self.shell_port),
-                                sub_address=(self.ip, self.iopub_port),
-                                stdin_address=(self.ip, self.stdin_port),
-                                hb_address=(self.ip, self.hb_port),
-                                config=self.config
+        self.kernel_manager = QtKernelManager(ip=self.ip,
+                                shell_port=self.shell_port,
+                                sub_port=self.iopub_port,
+                                stdin_port=self.stdin_port,
+                                hb_port=self.hb_port,
+                                config=self.config,
         )
         # start the kernel
         if not self.existing:

--- a/IPython/frontend/qt/console/qtconsoleapp.py
+++ b/IPython/frontend/qt/console/qtconsoleapp.py
@@ -455,7 +455,7 @@ class IPythonQtConsoleApp(BaseIPythonApplication):
         self.kernel_manager = QtKernelManager(
                                 ip=self.ip,
                                 shell_port=self.shell_port,
-                                sub_port=self.iopub_port,
+                                iopub_port=self.iopub_port,
                                 stdin_port=self.stdin_port,
                                 hb_port=self.hb_port,
                                 connection_file=cf,

--- a/IPython/frontend/qt/console/qtconsoleapp.py
+++ b/IPython/frontend/qt/console/qtconsoleapp.py
@@ -50,7 +50,7 @@ from IPython.zmq.ipkernel import (
     aliases as ipkernel_aliases,
     IPKernelApp
 )
-from IPython.zmq.session import Session
+from IPython.zmq.session import Session, default_secure
 from IPython.zmq.zmqshell import ZMQInteractiveShell
 
 
@@ -551,6 +551,7 @@ class IPythonQtConsoleApp(BaseIPythonApplication):
     def initialize(self, argv=None):
         super(IPythonQtConsoleApp, self).initialize(argv)
         self.init_connection_file()
+        default_secure(self.config)
         self.init_ssh()
         self.init_kernel_manager()
         self.init_qt_elements()

--- a/IPython/lib/kernel.py
+++ b/IPython/lib/kernel.py
@@ -1,0 +1,99 @@
+"""Utilities for connecting to kernels
+
+Authors:
+
+* Min Ragan-Kelley
+
+"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2011  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+import json
+import sys
+from subprocess import Popen, PIPE
+
+from IPython.utils.path import filefind
+from IPython.utils.py3compat import str_to_bytes
+
+
+#-----------------------------------------------------------------------------
+# Functions
+#-----------------------------------------------------------------------------
+
+def get_connection_file(app=None):
+    """Return the path to the connection file of an app
+    
+    Parameters
+    ----------
+    app : KernelApp instance [optional]
+        If unspecified, the currently running app will be used
+    """
+    if app is None:
+        from IPython.zmq.kernelapp import KernelApp
+        if not KernelApp.initialized():
+            raise RuntimeError("app not specified, and not in a running Kernel")
+
+        app = KernelApp.instance()
+    return filefind(app.connection_file, ['.', app.profile_dir.security_dir])
+        
+def get_connection_info(unpack=False):
+    """Return the connection information for the current Kernel.
+    
+    Parameters
+    ----------
+    unpack : bool [default: False]
+        if True, return the unpacked dict, otherwise just the string contents
+        of the file.
+    
+    Returns
+    -------
+    The connection dictionary of the current kernel, as string or dict,
+    depending on `unpack`.
+    """
+    cf = get_connection_file()
+    with open(cf) as f:
+        info = f.read()
+    
+    if unpack:
+        info = json.loads(info)
+        # ensure key is bytes:
+        info['key'] = str_to_bytes(info.get('key', ''))
+    return info
+
+def connect_qtconsole(argv=None):
+    """Connect a qtconsole to the current kernel.
+    
+    This is useful for connecting a second qtconsole to a kernel, or to a
+    local notebook.
+    
+    Parameters
+    ----------
+    argv : list [optional]
+        Any extra args to be passed to the console.
+    
+    Returns
+    -------
+    subprocess.Popen instance running the qtconsole frontend
+    """
+    argv = [] if argv is None else argv
+    
+    # get connection file from current kernel
+    cf = get_connection_file()
+    
+    cmd = ';'.join([
+        "from IPython.frontend.qt.console import qtconsoleapp",
+        "qtconsoleapp.main()"
+    ])
+    
+    return Popen([sys.executable, '-c', cmd, '--existing', cf] + argv, stdout=PIPE, stderr=PIPE)
+
+

--- a/IPython/lib/kernel.py
+++ b/IPython/lib/kernel.py
@@ -19,8 +19,13 @@ Authors:
 
 import json
 import sys
+from getpass import getpass
 from subprocess import Popen, PIPE
 
+# external imports
+from IPython.external.ssh import tunnel
+
+# IPython imports
 from IPython.utils.path import filefind
 from IPython.utils.py3compat import str_to_bytes
 
@@ -96,4 +101,52 @@ def connect_qtconsole(argv=None):
     
     return Popen([sys.executable, '-c', cmd, '--existing', cf] + argv, stdout=PIPE, stderr=PIPE)
 
+def tunnel_to_kernel(connection_info, sshserver, sshkey=None):
+    """tunnel connections to a kernel via ssh
+    
+    This will open four SSH tunnels from localhost on this machine to the
+    ports associated with the kernel.  They can be either direct
+    localhost-localhost tunnels, or if an intermediate server is necessary,
+    the kernel must be listening on a public IP.
+    
+    Parameters
+    ----------
+    connection_info : dict or str (path)
+        Either a connection dict, or the path to a JSON connection file
+    sshserver : str
+        The ssh sever to use to tunnel to the kernel. Can be a full
+        `user@server:port` string. ssh config aliases are respected.
+    sshkey : str [optional]
+        Path to file containing ssh key to use for authentication.
+        Only necessary if your ssh config does not already associate
+        a keyfile with the host.
+    
+    Returns
+    -------
+    
+    (shell, iopub, stdin, hb) : ints
+        The four ports on localhost that have been forwarded to the kernel.
+    """
+    if isinstance(connection_info, basestring):
+        # it's a path, unpack it
+        with open(connection_info) as f:
+            connection_info = json.loads(f.read())
+    
+    cf = connection_info
+    
+    lports = tunnel.select_random_ports(4)
+    rports = cf['shell_port'], cf['iopub_port'], cf['stdin_port'], cf['hb_port']
+    
+    remote_ip = cf['ip']
+    
+    if tunnel.try_passwordless_ssh(sshserver, sshkey):
+        password=False
+    else:
+        password = getpass("SSH Password for %s: "%sshserver)
+    
+    for lp,rp in zip(lports, rports):
+        tunnel.ssh_tunnel(lp, rp, sshserver, remote_ip, sshkey, password)
+    
+    return tuple(lports)
+    
 

--- a/IPython/lib/kernel.py
+++ b/IPython/lib/kernel.py
@@ -17,7 +17,9 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
+import glob
 import json
+import os
 import sys
 from getpass import getpass
 from subprocess import Popen, PIPE
@@ -26,7 +28,8 @@ from subprocess import Popen, PIPE
 from IPython.external.ssh import tunnel
 
 # IPython imports
-from IPython.utils.path import filefind
+from IPython.core.profiledir import ProfileDir
+from IPython.utils.path import filefind, get_ipython_dir
 from IPython.utils.py3compat import str_to_bytes
 
 
@@ -49,22 +52,108 @@ def get_connection_file(app=None):
 
         app = KernelApp.instance()
     return filefind(app.connection_file, ['.', app.profile_dir.security_dir])
-        
-def get_connection_info(unpack=False):
+
+def find_connection_file(filename, profile=None):
+    """find a connection file, and return its absolute path.
+    
+    The current working directory and the profile's security
+    directory will be searched for the file if it is not given by
+    absolute path.
+    
+    If profile is unspecified, then the current running application's
+    profile will be used, or 'default', if not run from IPython.
+    
+    If the argument does not match an existing file, it will be interpreted as a
+    fileglob, and the matching file in the profile's security dir with
+    the latest access time will be used.
+    
+    Parameters
+    ----------
+    filename : str
+        The connection file or fileglob to search for.
+    profile : str [optional]
+        The name of the profile to use when searching for the connection file,
+        if different from the current IPython session or 'default'.
+    
+    Returns
+    -------
+    str : The absolute path of the connection file.
+    """
+    from IPython.core.application import BaseIPythonApplication as IPApp
+    try:
+        # quick check for absolute path, before going through logic
+        return filefind(filename)
+    except IOError:
+        pass
+    
+    if profile is None:
+        # profile unspecified, check if running from an IPython app
+        if IPApp.initialized():
+            app = IPApp.instance()
+            profile_dir = app.profile_dir
+        else:
+            # not running in IPython, use default profile
+            profile_dir = ProfileDir.find_profile_dir_by_name(get_ipython_dir(), 'default')
+    else:
+        # find profiledir by profile name:
+        profile_dir = ProfileDir.find_profile_dir_by_name(get_ipython_dir(), profile)
+    security_dir = profile_dir.security_dir
+    
+    try:
+        # first, try explicit name
+        return filefind(filename, ['.', security_dir])
+    except IOError:
+        pass
+    
+    # not found by full name
+    
+    if '*' in filename:
+        # given as a glob already
+        pat = filename
+    else:
+        # accept any substring match
+        pat = '*%s*' % filename
+    matches = glob.glob( os.path.join(security_dir, pat) )
+    if not matches:
+        raise IOError("Could not find %r in %r" % (filename, security_dir))
+    elif len(matches) == 1:
+        return matches[0]
+    else:
+        # get most recent match, by access time:
+        return sorted(matches, key=lambda f: os.stat(f).st_atime)[-1]
+
+def get_connection_info(connection_file=None, unpack=False, profile=None):
     """Return the connection information for the current Kernel.
     
     Parameters
     ----------
+    connection_file : str [optional]
+        The connection file to be used. Can be given by absolute path, or
+        IPython will search in the security directory of a given profile.
+        If run from IPython, 
+        
+        If unspecified, the connection file for the currently running
+        IPython Kernel will be used, which is only allowed from inside a kernel.
     unpack : bool [default: False]
         if True, return the unpacked dict, otherwise just the string contents
         of the file.
+    profile : str [optional]
+        The name of the profile to use when searching for the connection file,
+        if different from the current IPython session or 'default'.
+        
     
     Returns
     -------
     The connection dictionary of the current kernel, as string or dict,
     depending on `unpack`.
     """
-    cf = get_connection_file()
+    if connection_file is None:
+        # get connection file from current kernel
+        cf = get_connection_file()
+    else:
+        # connection file specified, allow shortnames:
+        cf = find_connection_file(connection_file, profile=profile)
+    
     with open(cf) as f:
         info = f.read()
     
@@ -74,7 +163,7 @@ def get_connection_info(unpack=False):
         info['key'] = str_to_bytes(info.get('key', ''))
     return info
 
-def connect_qtconsole(argv=None):
+def connect_qtconsole(connection_file=None, argv=None, profile=None):
     """Connect a qtconsole to the current kernel.
     
     This is useful for connecting a second qtconsole to a kernel, or to a
@@ -82,8 +171,19 @@ def connect_qtconsole(argv=None):
     
     Parameters
     ----------
+    connection_file : str [optional]
+        The connection file to be used. Can be given by absolute path, or
+        IPython will search in the security directory of a given profile.
+        If run from IPython, 
+        
+        If unspecified, the connection file for the currently running
+        IPython Kernel will be used, which is only allowed from inside a kernel.
     argv : list [optional]
         Any extra args to be passed to the console.
+    profile : str [optional]
+        The name of the profile to use when searching for the connection file,
+        if different from the current IPython session or 'default'.
+    
     
     Returns
     -------
@@ -91,8 +191,11 @@ def connect_qtconsole(argv=None):
     """
     argv = [] if argv is None else argv
     
-    # get connection file from current kernel
-    cf = get_connection_file()
+    if connection_file is None:
+        # get connection file from current kernel
+        cf = get_connection_file()
+    else:
+        cf = find_connection_file(connection_file, profile=profile)
     
     cmd = ';'.join([
         "from IPython.frontend.qt.console import qtconsoleapp",

--- a/IPython/parallel/apps/ipengineapp.py
+++ b/IPython/parallel/apps/ipengineapp.py
@@ -36,9 +36,12 @@ from IPython.parallel.apps.baseapp import (
     base_flags,
 )
 from IPython.zmq.log import EnginePUBHandler
+from IPython.zmq.session import (
+    Session, session_aliases, session_flags
+)
 
 from IPython.config.configurable import Configurable
-from IPython.zmq.session import Session
+
 from IPython.parallel.engine.engine import EngineFactory
 from IPython.parallel.engine.streamkernel import Kernel
 from IPython.parallel.util import disambiguate_url, asbytes
@@ -113,10 +116,6 @@ aliases = dict(
     c = 'IPEngineApp.startup_command',
     s = 'IPEngineApp.startup_script',
 
-    ident = 'Session.session',
-    user = 'Session.username',
-    keyfile = 'Session.keyfile',
-
     url = 'EngineFactory.url',
     ssh = 'EngineFactory.sshserver',
     sshkey = 'EngineFactory.sshkey',
@@ -131,7 +130,10 @@ aliases = dict(
 
 )
 aliases.update(base_aliases)
-
+aliases.update(session_aliases)
+flags = {}
+flags.update(base_flags)
+flags.update(session_flags)
 
 class IPEngineApp(BaseParallelApplication):
 
@@ -172,6 +174,7 @@ class IPEngineApp(BaseParallelApplication):
         logging to a central location.""")
 
     aliases = Dict(aliases)
+    flags = Dict(flags)
 
     # def find_key_file(self):
     #     """Set the key file.
@@ -214,12 +217,9 @@ class IPEngineApp(BaseParallelApplication):
         with open(self.url_file) as f:
             d = json.loads(f.read())
         
-        try:
-            config.Session.key
-        except AttributeError:
-            if d['exec_key']:
-                config.Session.key = asbytes(d['exec_key'])
-                
+        if 'exec_key' in d:
+            config.Session.key = asbytes(d['exec_key'])
+        
         try:
             config.EngineFactory.location
         except AttributeError:

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -476,3 +476,34 @@ def check_for_old_config(ipython_dir=None):
   IPython and want to suppress this warning message, set
   `c.InteractiveShellApp.ignore_old_config=True` in the new config.""")
 
+def get_security_file(filename, profile='default'):
+    """Return the absolute path of a security file given by filename and profile
+    
+    This allows users and developers to find security files without
+    knowledge of the IPython directory structure. The search path
+    will be ['.', profile.security_dir]
+    
+    Parameters
+    ----------
+    
+    filename : str
+        The file to be found. If it is passed as an absolute path, it will
+        simply be returned.
+    profile : str [default: 'default']
+        The name of the profile to search.  Leaving this unspecified
+        The file to be found. If it is passed as an absolute path, fname will
+        simply be returned.
+    
+    Returns
+    -------
+    Raises :exc:`IOError` if file not found or returns absolute path to file.
+    """
+    # import here, because profiledir also imports from utils.path
+    from IPython.core.profiledir import ProfileDir
+    try:
+        pd = ProfileDir.find_profile_dir_by_name(get_ipython_dir(), profile)
+    except Exception:
+        # will raise ProfileDirError if no such profile
+        raise IOError("Profile %r not found")
+    return filefind(filename, ['.', pd.security_dir])
+

--- a/IPython/zmq/entry_point.py
+++ b/IPython/zmq/entry_point.py
@@ -8,20 +8,26 @@ import os
 import socket
 from subprocess import Popen, PIPE
 import sys
+import tempfile
+
+# System library imports
+from zmq.utils import jsonapi as json
+
+# IPython imports
+from IPython.utils.localinterfaces import LOCALHOST
 
 # Local imports.
 from parentpoller import ParentPollerWindows
 
-
-def base_launch_kernel(code, shell_port=0, iopub_port=0, stdin_port=0, hb_port=0,
-                        ip=None, stdin=None, stdout=None, stderr=None,
-                        executable=None, independent=False, extra_arguments=[]):
-    """ Launches a localhost kernel, binding to the specified ports.
-
+def write_connection_file(fname=None, shell_port=0, iopub_port=0, stdin_port=0, hb_port=0,
+                         ip=LOCALHOST, key=''):
+    """Generates a JSON config file, including the selection of random ports.
+    
     Parameters
     ----------
-    code : str,
-        A string of Python code that imports and executes a kernel entry point.
+
+    fname : unicode
+        The path to the file to write
 
     shell_port : int, optional
         The port to use for XREP channel.
@@ -38,27 +44,14 @@ def base_launch_kernel(code, shell_port=0, iopub_port=0, stdin_port=0, hb_port=0
     ip  : str, optional
         The ip address the kernel will bind to.
 
-    stdin, stdout, stderr : optional (default None)
-        Standards streams, as defined in subprocess.Popen.
+    key : str, optional
+        The Session key used for HMAC authentication.
 
-    executable : str, optional (default sys.executable)
-        The Python executable to use for the kernel process.
-
-    independent : bool, optional (default False)
-        If set, the kernel process is guaranteed to survive if this process
-        dies. If not set, an effort is made to ensure that the kernel is killed
-        when this process dies. Note that in this case it is still good practice
-        to kill kernels manually before exiting.
-
-    extra_arguments = list, optional
-        A list of extra arguments to pass when executing the launch code.
-
-    Returns
-    -------
-    A tuple of form:
-        (kernel_process, shell_port, iopub_port, stdin_port, hb_port)
-    where kernel_process is a Popen object and the ports are integers.
     """
+    # default to temporary connector file
+    if not fname:
+        fname = tempfile.mktemp('.json')
+    
     # Find open ports as necessary.
     ports = []
     ports_needed = int(shell_port <= 0) + int(iopub_port <= 0) + \
@@ -79,15 +72,62 @@ def base_launch_kernel(code, shell_port=0, iopub_port=0, stdin_port=0, hb_port=0
         stdin_port = ports.pop(0)
     if hb_port <= 0:
         hb_port = ports.pop(0)
+    
+    cfg = dict( shell_port=shell_port,
+                iopub_port=iopub_port,
+                stdin_port=stdin_port,
+                hb_port=hb_port,
+              )
+    cfg['ip'] = ip
+    cfg['key'] = key
+    
+    with open(fname, 'wb') as f:
+        f.write(json.dumps(cfg, indent=2))
+    
+    return fname, cfg
+    
 
+def base_launch_kernel(code, fname, stdin=None, stdout=None, stderr=None,
+                        executable=None, independent=False, extra_arguments=[]):
+    """ Launches a localhost kernel, binding to the specified ports.
+
+    Parameters
+    ----------
+    code : str,
+        A string of Python code that imports and executes a kernel entry point.
+
+    stdin, stdout, stderr : optional (default None)
+        Standards streams, as defined in subprocess.Popen.
+
+    fname : unicode, optional
+        The JSON connector file, containing ip/port/hmac key information.
+
+    key : str, optional
+        The Session key used for HMAC authentication.
+
+    executable : str, optional (default sys.executable)
+        The Python executable to use for the kernel process.
+
+    independent : bool, optional (default False)
+        If set, the kernel process is guaranteed to survive if this process
+        dies. If not set, an effort is made to ensure that the kernel is killed
+        when this process dies. Note that in this case it is still good practice
+        to kill kernels manually before exiting.
+
+    extra_arguments = list, optional
+        A list of extra arguments to pass when executing the launch code.
+
+    Returns
+    -------
+    A tuple of form:
+        (kernel_process, shell_port, iopub_port, stdin_port, hb_port)
+    where kernel_process is a Popen object and the ports are integers.
+    """
+    
     # Build the kernel launch command.
     if executable is None:
         executable = sys.executable
-    arguments = [ executable, '-c', code, '--shell=%i'%shell_port,
-                  '--iopub=%i'%iopub_port, '--stdin=%i'%stdin_port,
-                  '--hb=%i'%hb_port ]
-    if ip is not None:
-        arguments.append('--ip=%s'%ip)
+    arguments = [ executable, '-c', code, '-f', fname ]
     arguments.extend(extra_arguments)
 
     # Popen will fail (sometimes with a deadlock) if stdin, stdout, and stderr
@@ -164,4 +204,4 @@ def base_launch_kernel(code, shell_port=0, iopub_port=0, stdin_port=0, hb_port=0
         if stderr is None:
             proc.stderr.close()
 
-    return proc, shell_port, iopub_port, stdin_port, hb_port
+    return proc

--- a/IPython/zmq/entry_point.py
+++ b/IPython/zmq/entry_point.py
@@ -15,12 +15,13 @@ from zmq.utils import jsonapi as json
 
 # IPython imports
 from IPython.utils.localinterfaces import LOCALHOST
+from IPython.utils.py3compat import bytes_to_str
 
 # Local imports.
 from parentpoller import ParentPollerWindows
 
 def write_connection_file(fname=None, shell_port=0, iopub_port=0, stdin_port=0, hb_port=0,
-                         ip=LOCALHOST, key=''):
+                         ip=LOCALHOST, key=b''):
     """Generates a JSON config file, including the selection of random ports.
     
     Parameters
@@ -79,7 +80,7 @@ def write_connection_file(fname=None, shell_port=0, iopub_port=0, stdin_port=0, 
                 hb_port=hb_port,
               )
     cfg['ip'] = ip
-    cfg['key'] = key
+    cfg['key'] = bytes_to_str(key)
     
     with open(fname, 'wb') as f:
         f.write(json.dumps(cfg, indent=2))

--- a/IPython/zmq/kernelapp.py
+++ b/IPython/zmq/kernelapp.py
@@ -31,6 +31,7 @@ from IPython.core.application import (
 from IPython.utils import io
 from IPython.utils.localinterfaces import LOCALHOST
 from IPython.utils.path import filefind
+from IPython.utils.py3compat import str_to_bytes
 from IPython.utils.traitlets import (Any, Instance, Dict, Unicode, Int, Bool,
                                         DottedObjectName)
 from IPython.utils.importstring import import_item
@@ -176,7 +177,7 @@ class KernelApp(BaseIPythonApplication):
                 # not overridden by config or cl_args
                 setattr(self, name, cfg[name])
         if 'key' in cfg:
-            self.config.Session.key = cfg['key']
+            self.config.Session.key = str_to_bytes(cfg['key'])
     
     def write_connection_file(self):
         """write connection info to JSON file"""

--- a/IPython/zmq/kernelapp.py
+++ b/IPython/zmq/kernelapp.py
@@ -38,7 +38,9 @@ from IPython.utils.importstring import import_item
 from IPython.zmq.entry_point import write_connection_file
 from IPython.zmq.heartbeat import Heartbeat
 from IPython.zmq.parentpoller import ParentPollerUnix, ParentPollerWindows
-from IPython.zmq.session import Session
+from IPython.zmq.session import (
+    Session, session_flags, session_aliases, default_secure,
+)
 
 
 #-----------------------------------------------------------------------------
@@ -67,6 +69,11 @@ kernel_flags.update({
             {'KernelApp' : {'no_stderr' : True}},
             "redirect stderr to the null device"),
 })
+
+# inherit flags&aliases for Sessions
+kernel_aliases.update(session_aliases)
+kernel_flags.update(session_flags)
+
 
 
 #-----------------------------------------------------------------------------
@@ -186,7 +193,7 @@ class KernelApp(BaseIPythonApplication):
             self.connection_file = "kernel-%s.json"%os.getpid()
         
         self.load_connection_file()
-
+    
     def init_sockets(self):
         # Create a context, a session, and the kernel sockets.
         self.log.info("Starting the kernel at pid: %i", os.getpid())
@@ -228,6 +235,7 @@ class KernelApp(BaseIPythonApplication):
 
     def init_session(self):
         """create our session object"""
+        default_secure(self.config)
         self.session = Session(config=self.config, username=u'kernel')
 
     def init_blackhole(self):

--- a/IPython/zmq/kernelmanager.py
+++ b/IPython/zmq/kernelmanager.py
@@ -29,6 +29,7 @@ import time
 import zmq
 from zmq import POLLIN, POLLOUT, POLLERR
 from zmq.eventloop import ioloop
+from zmq.utils import jsonapi as json
 
 # Local imports.
 from IPython.config.loader import Config
@@ -36,6 +37,7 @@ from IPython.utils.localinterfaces import LOCALHOST, LOCAL_IPS
 from IPython.utils.traitlets import (
     HasTraits, Any, Instance, Type, Unicode, Int, Bool
 )
+from IPython.utils.py3compat import str_to_bytes
 from IPython.zmq.entry_point import write_connection_file
 from session import Session
 
@@ -788,7 +790,20 @@ class KernelManager(HasTraits):
     # Kernel process management methods:
     #--------------------------------------------------------------------------
     
+    def load_connection_file(self):
+        """load connection info from JSON dict in self.connection_file"""
+        with open(self.connection_file) as f:
+            cfg = json.loads(f.read())
+        
+        self.ip = cfg['ip']
+        self.shell_port = cfg['shell_port']
+        self.stdin_port = cfg['stdin_port']
+        self.iopub_port = cfg['iopub_port']
+        self.hb_port = cfg['hb_port']
+        self.session.key = str_to_bytes(cfg['key'])
+    
     def write_connection_file(self):
+        """write connection info to JSON dict in self.connection_file"""
         if self._connection_file_written:
             return
         self.connection_file,cfg = write_connection_file(self.connection_file,

--- a/IPython/zmq/kernelmanager.py
+++ b/IPython/zmq/kernelmanager.py
@@ -709,7 +709,7 @@ class KernelManager(HasTraits):
     connection_file = Unicode('')
     ip = Unicode(LOCALHOST)
     shell_port = Int(0)
-    sub_port = Int(0)
+    iopub_port = Int(0)
     stdin_port = Int(0)
     hb_port = Int(0)
 
@@ -793,12 +793,12 @@ class KernelManager(HasTraits):
             return
         self.connection_file,cfg = write_connection_file(self.connection_file,
             ip=self.ip, key=self.session.key,
-            stdin_port=self.stdin_port, iopub_port=self.sub_port,
+            stdin_port=self.stdin_port, iopub_port=self.iopub_port,
             shell_port=self.shell_port, hb_port=self.hb_port)
         # write_connection_file also sets default ports:
         self.shell_port = cfg['shell_port']
         self.stdin_port = cfg['stdin_port']
-        self.sub_port = cfg['iopub_port']
+        self.iopub_port = cfg['iopub_port']
         self.hb_port = cfg['hb_port']
         
         self._connection_file_written = True
@@ -1005,7 +1005,7 @@ class KernelManager(HasTraits):
         if self._sub_channel is None:
             self._sub_channel = self.sub_channel_class(self.context,
                                                        self.session,
-                                                       (self.ip, self.sub_port))
+                                                       (self.ip, self.iopub_port))
         return self._sub_channel
 
     @property

--- a/IPython/zmq/zmqshell.py
+++ b/IPython/zmq/zmqshell.py
@@ -471,7 +471,7 @@ class ZMQInteractiveShell(InteractiveShell):
         debugging.
         """
         try:
-            p = connect_qtconsole(arg_split(arg_s, os.name=='posix'))
+            p = connect_qtconsole(argv=arg_split(arg_s, os.name=='posix'))
         except Exception as e:
             error("Could not start qtconsole: %r" % e)
             return

--- a/IPython/zmq/zmqshell.py
+++ b/IPython/zmq/zmqshell.py
@@ -18,6 +18,8 @@ from __future__ import print_function
 # Stdlib
 import inspect
 import os
+import sys
+from subprocess import Popen, PIPE
 
 # Our own
 from IPython.core.interactiveshell import (
@@ -442,7 +444,7 @@ class ZMQInteractiveShell(InteractiveShell):
         """
         from IPython.zmq.kernelapp import KernelApp
         if not KernelApp.initialized():
-            error("Not KernelApp is not initialized. I cannot find the connection info")
+            error("KernelApp is not initialized. I cannot find the connection info")
             return
         app = KernelApp.instance()
         try:
@@ -461,6 +463,27 @@ class ZMQInteractiveShell(InteractiveShell):
             "if this is the most recent IPython session you have started."
             % os.path.basename((app.connection_file))
         )
+
+    def magic_qtconsole(self, arg_s):
+        """Open a qtconsole connected to this kernel.
+        
+        Useful for connecting a qtconsole to running notebooks, for better
+        debugging.
+        """
+        from IPython.zmq.kernelapp import KernelApp
+        
+        if not KernelApp.initialized():
+            error("KernelApp is not initialized. %qtconsole magic must be run from a Kernel")
+            return
+        app = KernelApp.instance()
+        
+        cmd = ';'.join([
+            "from IPython.frontend.qt.console import qtconsoleapp",
+            "qtconsoleapp.main()"
+        ])
+        
+        return Popen([sys.executable, '-c', cmd, '--existing', app.connection_file],
+            stdout=PIPE,stderr=PIPE)
 
     def set_next_input(self, text):
         """Send the specified text to the frontend to be presented at the next


### PR DESCRIPTION
This moves all the connection info for a kernel into JSON files like the parallel code, so there's no need to specify 4 ports to connect to an existing kernel.  In fact, if you just specify `ipython qtconsole --existing`, it will try to connect to the most recent kernel, including those started by the notebook.

It also cleans up some KernelManager code in the notebook, so that changes to the base KernelManager will be inherited in the notebook. The main immediate benefit being that restarting a notebook kernel really does restart it, so attached qtconsoles will remain attached.

I will also turn HMAC signatures on by default before merging.

This should address #688, #806, and even probably #691.
