### PR TITLE
promote aliases and flags, to ensure they have priority over config files

### DIFF
--- a/IPython/parallel/apps/ipclusterapp.py
+++ b/IPython/parallel/apps/ipclusterapp.py
@@ -374,12 +374,6 @@ start_aliases.update(dict(
 ))
 start_aliases['clean-logs'] = 'IPClusterStart.clean_logs'
 
-# set inherited Start keys directly, to ensure command-line args get higher priority
-# than config file options.
-for key,value in start_aliases.items():
-    if value.startswith('IPClusterEngines'):
-        start_aliases[key] = value.replace('IPClusterEngines', 'IPClusterStart')
-
 class IPClusterStart(IPClusterEngines):
 
     name = u'ipcluster'


### PR DESCRIPTION
See #849

adds `Application.flatten_flags()` method, which adjusts the alias
and flag dicts, such that they point to the subclass in the Application.classes list when passed to the argv parser.

This prevents `TerminalInteractiveShell.colors` in a config file overriding
`--colors` on the command-line, which points to `InteractiveShell.colors`.

Flattening is only done when the answer is unambiguous, so multiply inherited classes (e.g. Launchers in ipcluster) are not touched.

also removes now-obsolete manual workaround for exactly this in IPClusterStart

closes gh-849
