### PR TITLE
make sdist flags work again (e.g. --manifest-only)

### DIFF
--- a/setup2.py
+++ b/setup2.py
@@ -193,9 +193,9 @@ data_files = find_data_files()
 
 # For some commands, use setuptools.  Note that we do NOT list install here!
 # If you want a setuptools-enhanced install, just run 'setupegg.py install'
-needs_setuptools = set(('develop', 'sdist', 'release', 'bdist_egg', 'bdist_rpm',
+needs_setuptools = set(('develop', 'release', 'bdist_egg', 'bdist_rpm',
            'bdist', 'bdist_dumb', 'bdist_wininst', 'install_egg_info',
-           'build_sphinx', 'egg_info', 'easy_install', 'upload',
+           'egg_info', 'easy_install', 'upload',
             ))
 if sys.platform == 'win32':
     # Depend on setuptools for install on *Windows only*


### PR DESCRIPTION
also removed build_sphinx target, since that was joblib specific.

this follows the discussion on [IPython-dev] "Help needed: stumped by odd MANIFEST.in/distutils behavior"
