### PR TITLE
Fix for issue #56

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -3194,6 +3194,7 @@ Defaulting color scheme to 'NoColor'"""
                 else:
                     yield l
             except EOFError:
+                print '<EOF>'
                 return
 
     def _strip_pasted_lines_for_code(self, raw_lines):

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -3187,11 +3187,14 @@ Defaulting color scheme to 'NoColor'"""
         from IPython.core import interactiveshell
         print "Pasting code; enter '%s' alone on the line to stop." % sentinel
         while True:
-            l = self.shell.raw_input_original(':')
-            if l == sentinel:
+            try:
+                l = self.shell.raw_input_original(':')
+                if l == sentinel:
+                    return
+                else:
+                    yield l
+            except EOFError:
                 return
-            else:
-                yield l
 
     def _strip_pasted_lines_for_code(self, raw_lines):
         """ Strip non-code parts of a sequence of lines to return a block of

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -487,7 +487,7 @@ class TerminalInteractiveShell(InteractiveShell):
     def magic_cpaste(self, parameter_s=''):
         """Paste & execute a pre-formatted code block from clipboard.
 
-        You must terminate the block with '--' (two minus-signs) alone on the
+        You must terminate the block with '--' (two minus-signs) or Ctrl-D alone on the
         line. You can also provide your own sentinel with '%paste -s %%' ('%%'
         is the new sentinel for this operation)
 


### PR DESCRIPTION
Used a try block to catch ctrl-d (EOFError) as a sentinel. Also added printing of "<EOF>" on the line where ctrl-d was pressed.
