### PR TITLE
BUG: Completion widget position and pager focus.

### DIFF
--- a/IPython/frontend/qt/console/completion_widget.py
+++ b/IPython/frontend/qt/console/completion_widget.py
@@ -86,10 +86,11 @@ class CompletionWidget(QtGui.QListWidget):
         text_edit = self._text_edit
         point = text_edit.cursorRect(cursor).bottomRight()
         point = text_edit.mapToGlobal(point)
+        height = self.sizeHint().height()
         screen_rect = QtGui.QApplication.desktop().availableGeometry(self)
-        if screen_rect.size().height() - point.y() - self.height() < 0:
+        if screen_rect.size().height() - point.y() - height < 0:
             point = text_edit.mapToGlobal(text_edit.cursorRect().topRight())
-            point.setY(point.y() - self.height())
+            point.setY(point.y() - height)
         self.move(point)
 
         self._start_position = cursor.position()

--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -1261,6 +1261,7 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
         elif key in (QtCore.Qt.Key_Q, QtCore.Qt.Key_Escape):
             if self._splitter:
                 self._page_control.hide()
+                self._control.setFocus()
             else:
                 self.layout().setCurrentWidget(self._control)
             return True


### PR DESCRIPTION
When the console widget is used with gui-completion, the positioning of
the completion widget was incorrect the first time a completion was
performed since the size of the widget is initially bogus.  Using
sizeHint fixes this.  If the paging mode is set to vsplit/hsplit, the
focus was lost after the pager is quit.
