### PR TITLE
The constructor of Client() checks for AssertionError in validate_url to open a file instead of connection to a URL if it fails.

### DIFF
--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -306,9 +306,7 @@ class Client(HasTraits):
         assert url_or_file is not None, "I can't find enough information to connect to a hub!"\
             " Please specify at least one of url_or_file or profile."
 
-        try:
-            util.validate_url(url_or_file)
-        except AssertionError:
+	if not is_url(url_or_file):
             if not os.path.exists(url_or_file):
                 if self._cd:
                     url_or_file = os.path.join(self._cd.security_dir, url_or_file)

--- a/IPython/parallel/util.py
+++ b/IPython/parallel/util.py
@@ -108,6 +108,15 @@ def asbytes(s):
         s = s.encode('ascii')
     return s
 
+def is_url(url):
+    """boolean check for whether a string is a zmq url"""
+    if '://' not in url:
+        return False
+    proto, addr = url.split('://', 1)
+    if proto.lower() not in ['tcp','pgm','epgm','ipc','inproc']:
+        return False
+    return True
+
 def validate_url(url):
     """validate a url for zeromq"""
     if not isinstance(url, basestring):


### PR DESCRIPTION
The constructor of Client() checks for AssertionError in validate_url to open a file instead of connection to a URL if it fails.

When running python -O, this failed, since the assertions were optimized away and other (random) errors were thrown.
These random errors are not catched. IMHO one should not depend on the side effects of assertions, which has been done here.
