### PR TITLE
protect IPython from bad custom exception handlers

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -27,6 +27,7 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
+import atexit
 import glob
 import logging
 import os
@@ -156,6 +157,9 @@ class BaseIPythonApplication(Application):
         """Create a crash handler, typically setting sys.excepthook to it."""
         self.crash_handler = self.crash_handler_class(self)
         sys.excepthook = self.crash_handler
+        def unset_crashhandler():
+            sys.excepthook = sys.__excepthook__
+        atexit.register(unset_crashhandler)
 
     def _ipython_dir_changed(self, name, old, new):
         if old in sys.path:

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -104,8 +104,8 @@ class Tracer(object):
         """
 
         try:
-            ip = ipapi.get()
-        except:
+            ip = get_ipython()
+        except NameError:
             # Outside of ipython, we set our own exception hook manually
             BdbQuit_excepthook.excepthook_ori = sys.excepthook
             sys.excepthook = BdbQuit_excepthook

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -38,7 +38,7 @@ from IPython.core.excolors import exception_colors
 has_pydb = False
 prompt = 'ipdb> '
 #We have to check this directly from sys.argv, config struct not yet available
-if '-pydb' in sys.argv:
+if '--pydb' in sys.argv:
     try:
         import pydb
         if hasattr(pydb.pydb, "runl") and pydb.version>'1.17':

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -64,7 +64,7 @@ def BdbQuit_excepthook(et,ev,tb):
     else:
         BdbQuit_excepthook.excepthook_ori(et,ev,tb)
 
-def BdbQuit_IPython_excepthook(self,et,ev,tb):
+def BdbQuit_IPython_excepthook(self,et,ev,tb,tb_offset=None):
     print 'Exiting Debugger.'
 
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1447,29 +1447,37 @@ class InteractiveShell(SingletonConfigurable, Magic):
 
         Set a custom exception handler, which will be called if any of the
         exceptions in exc_tuple occur in the mainloop (specifically, in the
-        run_code() method.
+        run_code() method).
 
-        Inputs:
+        Parameters
+        ----------
 
-          - exc_tuple: a *tuple* of valid exceptions to call the defined
-          handler for.  It is very important that you use a tuple, and NOT A
-          LIST here, because of the way Python's except statement works.  If
-          you only want to trap a single exception, use a singleton tuple:
+        exc_tuple : tuple of exception classes
+            A *tuple* of exception classes, for which to call the defined
+            handler.  It is very important that you use a tuple, and NOT A
+            LIST here, because of the way Python's except statement works.  If
+            you only want to trap a single exception, use a singleton tuple::
 
-            exc_tuple == (MyCustomException,)
+                exc_tuple == (MyCustomException,)
 
-          - handler: this must be defined as a function with the following
-          basic interface::
+        handler : callable
+            handler must have the following signature::
 
-            def my_handler(self, etype, value, tb, tb_offset=None)
-                ...
-                # The return value must be
-                return structured_traceback
+                def my_handler(self, etype, value, tb, tb_offset=None):
+                    ...
+                    return structured_traceback
 
-          This will be made into an instance method (via types.MethodType)
-          of IPython itself, and it will be called if any of the exceptions
-          listed in the exc_tuple are caught.  If the handler is None, an
-          internal basic one is used, which just prints basic info.
+            Your handler must return a structured traceback (a list of strings),
+            or None.
+
+            This will be made into an instance method (via types.MethodType)
+            of IPython itself, and it will be called if any of the exceptions
+            listed in the exc_tuple are caught. If the handler is None, an
+            internal basic one is used, which just prints basic info.
+
+            To protect IPython from crashes, if your handler ever raises an
+            exception or returns an invalid result, it will be immediately
+            disabled.
 
         WARNING: by putting in your own exception handler into IPython's main
         execution loop, you run a very good chance of nasty crashes.  This

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1585,9 +1585,11 @@ class InteractiveShell(SingletonConfigurable, Magic):
                         stb = self.InteractiveTB.structured_traceback(etype,
                                                 value, tb, tb_offset=tb_offset)
 
+                        self._showtraceback(etype, value, stb)
                         if self.call_pdb:
                             # drop into debugger
                             self.debugger(force=True)
+                        return
 
                 # Actually show the traceback
                 self._showtraceback(etype, value, stb)

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -50,6 +50,14 @@ addflag('pdb', 'InteractiveShell.pdb',
     "Enable auto calling the pdb debugger after every exception.",
     "Disable auto calling the pdb debugger after every exception."
 )
+# pydb flag doesn't do any config, as core.debugger switches on import,
+# which is before parsing.  This just allows the flag to be passed.
+shell_flags.update(dict(
+    pydb = ({},
+        """"Use the third party 'pydb' package as debugger, instead of pdb.
+        Requires that pydb is installed."""
+    )
+))
 addflag('pprint', 'PlainTextFormatter.pprint',
     "Enable auto pretty printing of results.",
     "Disable auto auto pretty printing of results."

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -146,3 +146,21 @@ class InteractiveShellTestCase(unittest.TestCase):
         finally:
             # Reset compiler flags so we don't mess up other tests.
             ip.compile.reset_compiler_flags()
+
+    def test_bad_custom_tb(self):
+        """Check that InteractiveShell is protected from bad custom exception handlers"""
+        ip = get_ipython()
+        from IPython.utils import io
+        save_stderr = io.stderr
+        try:
+            # capture stderr
+            io.stderr = StringIO()
+            ip.set_custom_exc((IOError,),lambda etype,value,tb: None)
+            self.assertEquals(ip.custom_exceptions, (IOError,))
+            ip.run_cell(u'raise IOError("foo")')
+            self.assertEquals(ip.custom_exceptions, ())
+            self.assertTrue("Custom TB Handler failed" in io.stderr.getvalue())
+        finally:
+            io.stderr = save_stderr
+
+

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -155,9 +155,25 @@ class InteractiveShellTestCase(unittest.TestCase):
         try:
             # capture stderr
             io.stderr = StringIO()
-            ip.set_custom_exc((IOError,),lambda etype,value,tb: None)
+            ip.set_custom_exc((IOError,), lambda etype,value,tb: 1/0)
             self.assertEquals(ip.custom_exceptions, (IOError,))
             ip.run_cell(u'raise IOError("foo")')
+            self.assertEquals(ip.custom_exceptions, ())
+            self.assertTrue("Custom TB Handler failed" in io.stderr.getvalue())
+        finally:
+            io.stderr = save_stderr
+
+    def test_bad_custom_tb_return(self):
+        """Check that InteractiveShell is protected from bad return types in custom exception handlers"""
+        ip = get_ipython()
+        from IPython.utils import io
+        save_stderr = io.stderr
+        try:
+            # capture stderr
+            io.stderr = StringIO()
+            ip.set_custom_exc((NameError,),lambda etype,value,tb, tb_offset=None: 1)
+            self.assertEquals(ip.custom_exceptions, (NameError,))
+            ip.run_cell(u'a=abracadabra')
             self.assertEquals(ip.custom_exceptions, ())
             self.assertTrue("Custom TB Handler failed" in io.stderr.getvalue())
         finally:


### PR DESCRIPTION
Previously, errors in custom handlers would result in the custom exception
handler's error being printed in lieu of the real exception, and certain cases could cause infinite loops.

Now, if CustomTB fails it is unregistered immediately, and the original TB is also displayed.

IPython's own `BdbQuit_IPython_excepthook` had an invalid signature, which revealed this issue, and has also been fixed.

test included.

closes #692
