### PR TITLE
store_history=False default for run_cell

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2252,7 +2252,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
                 self.showtraceback()
                 warn('Unknown failure executing file: <%s>' % fname)
 
-    def run_cell(self, raw_cell, store_history=True):
+    def run_cell(self, raw_cell, store_history=False):
         """Run a complete IPython cell.
 
         Parameters

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -3246,7 +3246,7 @@ Defaulting color scheme to 'NoColor'"""
         if not par:
             b = textwrap.dedent(block)
             self.user_ns['pasted_block'] = b
-            exec b in self.user_ns
+            self.run_cell(b)
         else:
             self.user_ns[par] = SList(block.splitlines())
             print "Block assigned to '%s'" % par

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -112,10 +112,10 @@ def test_extract_hist_ranges():
 def test_magic_rerun():
     """Simple test for %rerun (no args -> rerun last line)"""
     ip = get_ipython()
-    ip.run_cell("a = 10")
-    ip.run_cell("a += 1")
+    ip.run_cell("a = 10", store_history=True)
+    ip.run_cell("a += 1", store_history=True)
     nt.assert_equal(ip.user_ns["a"], 11)
-    ip.run_cell("%rerun")
+    ip.run_cell("%rerun", store_history=True)
     nt.assert_equal(ip.user_ns["a"], 12)
 
 def test_timestamp_type():

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -73,11 +73,11 @@ class InteractiveShellTestCase(unittest.TestCase):
         "Ending a line with semicolon should not cache the returned object (GH-307)"
         ip = get_ipython()
         oldlen = len(ip.user_ns['Out'])
-        a = ip.run_cell('1;')
+        a = ip.run_cell('1;', store_history=True)
         newlen = len(ip.user_ns['Out'])
         self.assertEquals(oldlen, newlen)
         #also test the default caching behavior
-        ip.run_cell('1')
+        ip.run_cell('1', store_history=True)
         newlen = len(ip.user_ns['Out'])
         self.assertEquals(oldlen+1, newlen)
 
@@ -85,7 +85,7 @@ class InteractiveShellTestCase(unittest.TestCase):
         "Verify that In variable grows with user input (GH-284)"
         ip = get_ipython()
         oldlen = len(ip.user_ns['In'])
-        ip.run_cell('1;')
+        ip.run_cell('1;', store_history=True)
         newlen = len(ip.user_ns['In'])
         self.assertEquals(oldlen+1, newlen)
         self.assertEquals(ip.user_ns['In'][-1],'1;')

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -326,15 +326,12 @@ def check_cpaste(code, should_fail=False):
     sys.stdin = src
     
     try:
-        _ip.magic('cpaste')
-    except:
+        context = tt.AssertPrints if should_fail else tt.AssertNotPrints
+        with context("Traceback (most recent call last)"):
+                _ip.magic('cpaste')
+        
         if not should_fail:
-            raise AssertionError("Failure not expected : '%s'" %
-                                 code)
-    else:
-        assert _ip.user_ns['code_ran']
-        if should_fail:
-            raise AssertionError("Failure expected : '%s'" % code)
+            assert _ip.user_ns['code_ran']
     finally:
         sys.stdin = stdin_save
 

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -316,6 +316,7 @@ def check_cpaste(code, should_fail=False):
     _ip.user_ns['code_ran'] = False
 
     src = StringIO()
+    src.encoding = None   # IPython expects stdin to have an encoding attribute
     src.write('\n')
     src.write(code)
     src.write('\n--\n')

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -171,7 +171,7 @@ def test_macro_run():
     cmds = ["a=10", "a+=1", py3compat.doctest_refactor_print("print a"),
                                                             "%macro test 2-3"]
     for cmd in cmds:
-        ip.run_cell(cmd)
+        ip.run_cell(cmd, store_history=True)
     nt.assert_equal(ip.user_ns["test"].value,
                             py3compat.doctest_refactor_print("a+=1\nprint a\n"))
     with tt.AssertPrints("12"):

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -309,7 +309,7 @@ class TerminalInteractiveShell(InteractiveShell):
                     self.edit_syntax_error()
                 if not more:
                     source_raw = self.input_splitter.source_raw_reset()[1]
-                    self.run_cell(source_raw)
+                    self.run_cell(source_raw, store_history=True)
 
         # We are off again...
         __builtin__.__dict__['__IPYTHON__active'] -= 1

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -250,7 +250,7 @@ class Kernel(Configurable):
                 shell.run_code(code)
             else:
                 # FIXME: the shell calls the exception handler itself.
-                shell.run_cell(code)
+                shell.run_cell(code, store_history=True)
         except:
             status = u'error'
             # FIXME: this code right now isn't being used yet by default,


### PR DESCRIPTION
We should only call run_cell with store_history=True as part of the main user interaction loop (and in the test suite), so this makes the default False.

I've also fixed #865 (following @minrk's suggestion). That meant the tests for %cpaste had to be changed, because errors from pasted code are caught before they reach the test code. We now check that the traceback is printed, although that's a more brittle check.
