### PR TITLE
Add drop_by_id method to shell, to remove variables added by extensions.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1264,6 +1264,24 @@ class InteractiveShell(SingletonConfigurable, Magic):
         else:
             for name,val in vdict.iteritems():
                 config_ns[name] = val
+    
+    def drop_by_id(self, variables):
+        """Remove a dict of variables from the user namespace, if they are the
+        same as the values in the dictionary.
+        
+        This is intended for use by extensions: variables that they've added can
+        be taken back out if they are unloaded, without removing any that the
+        user has overwritten.
+        
+        Parameters
+        ----------
+        variables : dict
+          A dictionary mapping object names (as strings) to the objects.
+        """
+        for name, obj in variables.iteritems():
+            if name in self.user_ns and self.user_ns[name] is obj:
+                del self.user_ns[name]
+                self.user_ns_hidden.pop(name, None)
 
     #-------------------------------------------------------------------------
     # Things related to object introspection

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -179,4 +179,17 @@ class InteractiveShellTestCase(unittest.TestCase):
         finally:
             io.stderr = save_stderr
 
-
+    def test_drop_by_id(self):
+        ip = get_ipython()
+        myvars = {"a":object(), "b":object(), "c": object()}
+        ip.push(myvars, interactive=False)
+        for name in myvars:
+            assert name in ip.user_ns, name
+            assert name in ip.user_ns_hidden, name
+        ip.user_ns['b'] = 12
+        ip.drop_by_id(myvars)
+        for name in ["a", "c"]:
+            assert name not in ip.user_ns, name
+            assert name not in ip.user_ns_hidden, name
+        assert ip.user_ns['b'] == 12
+        ip.reset()


### PR DESCRIPTION
This was prompted by the revived physics extension. Extensions can drop a lot of variables into the user namespace. Ideally, if the extension is unloaded, those variables should disappear, but only if the names haven't been rebound.

This works as a counterpart to `ip.push()`. The idea is that an extension can work like this:

```
myvars = dict(a=foo(), b=bar(), c=baz())

def load_ipython_extension(ip):
    ip.push(myvars)

def unload_ipython_extension(ip):
    ip.drop_by_id(myvars)
```
