### PR TITLE
don't close figures every cycle with inline matplotlib backend

### DIFF
--- a/IPython/zmq/pylab/backend_inline.py
+++ b/IPython/zmq/pylab/backend_inline.py
@@ -17,7 +17,7 @@ from matplotlib._pylab_helpers import Gcf
 from IPython.config.configurable import SingletonConfigurable
 from IPython.core.displaypub import publish_display_data
 from IPython.lib.pylabtools import print_figure, select_figure_format
-from IPython.utils.traitlets import Dict, Instance, CaselessStrEnum
+from IPython.utils.traitlets import Dict, Instance, CaselessStrEnum, CBool
 #-----------------------------------------------------------------------------
 # Configurable for inline backend options
 #-----------------------------------------------------------------------------
@@ -47,6 +47,23 @@ class InlineBackendConfig(SingletonConfigurable):
             return
         else:
             select_figure_format(self.shell, new)
+    
+    close_figures = CBool(True, config=True,
+        help="""Close all figures at the end of each cell.
+        
+        When True, ensures that each cell starts with no active figures, but it
+        also means that one must keep track of references in order to edit or
+        redraw figures in subsequent cells. This mode is ideal for the notebook,
+        where residual plots from other cells might be surprising.
+        
+        When False, one must call figure() to create new figures. This means
+        that gcf() and getfigs() can reference figures created in other cells,
+        and the active figure can continue to be edited with pylab/pyplot
+        methods that reference the current active figure. This mode facilitates
+        iterative editing of figures, and behaves most consistently with
+        other matplotlib backends, but figure barriers between cells must
+        be explicit.
+        """)
 
     shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
 
@@ -55,8 +72,8 @@ class InlineBackendConfig(SingletonConfigurable):
 # Functions
 #-----------------------------------------------------------------------------
 
-def show(close=False):
-    """Show all figures as SVG payloads sent to the IPython clients.
+def show(close=None):
+    """Show all figures as SVG/PNG payloads sent to the IPython clients.
 
     Parameters
     ----------
@@ -65,12 +82,14 @@ def show(close=False):
       sending all the figures. If this is set, the figures will entirely
       removed from the internal list of figures.
     """
+    if close is None:
+        close = InlineBackendConfig.instance().close_figures
     for figure_manager in Gcf.get_all_fig_managers():
         send_figure(figure_manager.canvas.figure)
     if close:
         matplotlib.pyplot.close('all')
     show._to_draw = []
-        
+
 
 
 # This flag will be reset by draw_if_interactive when called
@@ -109,6 +128,11 @@ def flush_figures():
     """
     if not show._draw_called:
         return
+    
+    if InlineBackendConfig.instance().close_figures:
+        # ignore the tracking, just draw and close all figures
+        return show(True)
+    
     # exclude any figures that were closed:
     active = set([fm.canvas.figure for fm in Gcf.get_all_fig_managers()])
     for fig in [ fig for fig in show._to_draw if fig in active ]:


### PR DESCRIPTION
See #638

This allows `gcf()`, `getfigs()`, etc. to be useful again in the qtconsole and notebook.

`draw_if_interactive()` signals that the current figure is to be drawn.

Figures that are created and closed in the same cell will not be drawn.

I would like some testing of this, to see cases where it doesn't do as well as the current closing-everything model.
