### PR TITLE
notebook download implies save

### DIFF
--- a/IPython/frontend/html/notebook/static/js/panelsection.js
+++ b/IPython/frontend/html/notebook/static/js/panelsection.js
@@ -106,9 +106,19 @@ var IPython = (function (IPython) {
         });
         this.content.find('#download_notebook').click(function () {
             var format = that.content.find('#download_format').val();
-            var notebook_id = IPython.save_widget.get_notebook_id();
-            var url = '/notebooks/' + notebook_id + '?format=' + format;
-            window.open(url,'_newtab');
+            // save on download
+            IPython.save_widget.save_notebook();
+            // hook into notebook_saved method to download on success:
+            var old_notebook_saved = IPython.save_widget.notebook_saved;
+            IPython.save_widget.notebook_saved = function() {
+                // restore and call original function:
+                IPython.save_widget.notebook_saved = old_notebook_saved;
+                IPython.save_widget.notebook_saved();
+                // now trigger download
+                var notebook_id = IPython.save_widget.get_notebook_id();
+                var url = '/notebooks/' + notebook_id + '?format=' + format;
+                window.open(url,'_newtab');
+            }
         });
     };
 


### PR DESCRIPTION
closes #852

Note that this should get some review, as I'm not certain it's the right way to go.  This change makes download trigger a save, and the save-success callback triggers the actual download.  _However_, at least on Chrome, the fact that opening the download url is no longer triggered directly by the click action means it can get caught by pop-up blockers.
