### PR TITLE
Don't pass unicode sys.argv with %run or `ipython script.py`

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -1612,6 +1612,9 @@ Currently the magic system has the following functions:\n"""
         args = [ os.path.expanduser(a) for a in arg_lst[1:] ]
 
         sys.argv = [filename] + args  # put in the proper filename
+        # protect sys.argv from potential unicode strings on Python 2:
+        if not py3compat.PY3:
+            sys.argv = [ py3compat.cast_bytes(a) for a in sys.argv ]
 
         if 'i' in opts:
             # Run in user's interactive namespace

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -28,6 +28,7 @@ import sys
 from IPython.config.application import boolean_flag
 from IPython.config.configurable import Configurable
 from IPython.config.loader import Config
+from IPython.utils import py3compat
 from IPython.utils.path import filefind
 from IPython.utils.traitlets import Unicode, Instance, List, Bool
 
@@ -207,6 +208,9 @@ class InteractiveShellApp(Configurable):
         # were run from a system shell.
         save_argv = sys.argv
         sys.argv = [full_filename] + self.extra_args[1:]
+        # protect sys.argv from potential unicode strings on Python 2:
+        if not py3compat.PY3:
+            sys.argv = [ py3compat.cast_bytes(a) for a in sys.argv ]
         try:
             if os.path.isfile(full_filename):
                 if full_filename.endswith('.ipy'):


### PR DESCRIPTION
only affects Python 2.x

closes #710
