### PR TITLE
  - There is a bug when running the profiler in the magic command (prun) with python3

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -1382,7 +1382,11 @@ Currently the magic system has the following functions:\n"""
                 return
 
             arg_str = 'execfile(filename,prog_ns)'
-            namespace = locals()
+            namespace = {
+                'execfile': self.shell.safe_execfile,
+                'filename': filename,
+                'prog_ns': prog_ns
+            } 
 
         opts.merge(opts_def)
 


### PR DESCRIPTION
```
%run -p <...> . And this is an attempt to solve it.
```

I'm not sure if this is the correct way to handle it. 

Regards.
