### PR TITLE
enable %gui/%pylab magics in the Kernel

### DIFF
--- a/IPython/frontend/qt/console/frontend_widget.py
+++ b/IPython/frontend/qt/console/frontend_widget.py
@@ -485,6 +485,9 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
 
         self._control.clear()
         self._append_plain_text(self.banner)
+        # update output marker for stdout/stderr, so that startup
+        # messages appear after banner:
+        self._append_before_prompt_pos = self._get_cursor().position()
         self._show_interpreter_prompt()
 
     def restart_kernel(self, message, now=False):

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -458,7 +458,11 @@ class TerminalInteractiveShell(InteractiveShell):
         # code in an empty namespace, and we update *both* user_ns and
         # user_ns_hidden with this information.
         ns = {}
-        gui = pylab_activate(ns, gui, import_all)
+        try:
+            gui = pylab_activate(ns, gui, import_all)
+        except KeyError:
+            error("Backend %r not supported" % gui)
+            return
         self.user_ns.update(ns)
         self.user_ns_hidden.update(ns)
         # Now we must activate the gui pylab wants to use, and fix %run to take

--- a/IPython/lib/pylabtools.py
+++ b/IPython/lib/pylabtools.py
@@ -196,7 +196,7 @@ def find_gui_and_backend(gui=None):
 
     import matplotlib
 
-    if gui:
+    if gui and gui != 'auto':
         # select backend based on requested gui
         backend = backends[gui]
     else:

--- a/IPython/lib/pylabtools.py
+++ b/IPython/lib/pylabtools.py
@@ -289,7 +289,7 @@ def import_pylab(user_ns, backend, import_all=True, shell=None):
             exec s in shell.user_ns_hidden
 
 
-def pylab_activate(user_ns, gui=None, import_all=True):
+def pylab_activate(user_ns, gui=None, import_all=True, shell=None):
     """Activate pylab mode in the user's namespace.
 
     Loads and initializes numpy, matplotlib and friends for interactive use.
@@ -312,7 +312,7 @@ def pylab_activate(user_ns, gui=None, import_all=True):
     """
     gui, backend = find_gui_and_backend(gui)
     activate_matplotlib(backend)
-    import_pylab(user_ns, backend, import_all)
+    import_pylab(user_ns, backend, import_all, shell)
 
     print """
 Welcome to pylab, a matplotlib-based Python environment [backend: %s].

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -740,8 +740,7 @@ class IPKernelApp(KernelApp, InteractiveShellApp):
         kernel_factory = Kernel
 
         if self.pylab:
-            key = None if self.pylab == 'auto' else self.pylab
-            gui, backend = pylabtools.find_gui_and_backend(key)
+            gui, backend = pylabtools.find_gui_and_backend(self.pylab)
 
         kernel = kernel_factory(config=self.config, session=self.session,
                                 shell_socket=self.shell_socket,

--- a/IPython/zmq/zmqshell.py
+++ b/IPython/zmq/zmqshell.py
@@ -31,6 +31,7 @@ from IPython.core.displaypub import DisplayPublisher
 from IPython.core.macro import Macro
 from IPython.core.magic import MacroToEdit
 from IPython.core.payloadpage import install_payload_page
+from IPython.lib import pylabtools
 from IPython.lib.kernel import (
     get_connection_file, get_connection_info, connect_qtconsole
 )
@@ -389,13 +390,65 @@ class ZMQInteractiveShell(InteractiveShell):
         }
         self.payload_manager.write_payload(payload)
 
-    def magic_gui(self, *args, **kwargs):
-        raise NotImplementedError(
-            'Kernel GUI support is not implemented yet, except for --pylab.')
+    def magic_gui(self, parameter_s=''):
+        """Enable or disable IPython GUI event loop integration.
 
-    def magic_pylab(self, *args, **kwargs):
-        raise NotImplementedError(
-            'pylab support must be enabled in command line options.')
+        %gui [GUINAME]
+
+        This magic replaces IPython's threaded shells that were activated
+        using the (pylab/wthread/etc.) command line flags.  GUI toolkits
+        can now be enabled at runtime and keyboard
+        interrupts should work without any problems.  The following toolkits
+        are supported:  wxPython, PyQt4, PyGTK, Cocoa, and Tk::
+
+            %gui wx      # enable wxPython event loop integration
+            %gui qt4|qt  # enable PyQt4 event loop integration
+            %gui gtk     # enable PyGTK event loop integration
+            %gui OSX     # enable Cocoa event loop integration (requires matplotlib 1.1)
+            %gui tk      # enable Tk event loop integration
+
+        WARNING:  after any of these has been called you can simply create
+        an application object, but DO NOT start the event loop yourself, as
+        we have already handled that.
+        """
+        from IPython.zmq.ipkernel import enable_gui
+        opts, arg = self.parse_options(parameter_s, '')
+        if arg=='': arg = None
+        return enable_gui(arg)
+
+    def enable_pylab(self, gui=None, import_all=True):
+        """Activate pylab support at runtime.
+
+        This turns on support for matplotlib, preloads into the interactive
+        namespace all of numpy and pylab, and configures IPython to correcdtly
+        interact with the GUI event loop.  The GUI backend to be used can be
+        optionally selected with the optional :param:`gui` argument.
+
+        Parameters
+        ----------
+        gui : optional, string [default: inline]
+
+          If given, dictates the choice of matplotlib GUI backend to use
+          (should be one of IPython's supported backends, 'inline', 'qt', 'osx',
+          'tk', or 'gtk'), otherwise we use the default chosen by matplotlib
+          (as dictated by the matplotlib build-time options plus the user's
+          matplotlibrc configuration file).
+        """
+        from IPython.zmq.ipkernel import enable_gui
+        # We want to prevent the loading of pylab to pollute the user's
+        # namespace as shown by the %who* magics, so we execute the activation
+        # code in an empty namespace, and we update *both* user_ns and
+        # user_ns_hidden with this information.
+        ns = {}
+        # override default to inline, from auto-detect
+        gui = pylabtools.pylab_activate(ns, gui or 'inline', import_all, self)
+        self.user_ns.update(ns)
+        self.user_ns_hidden.update(ns)
+        # Now we must activate the gui pylab wants to use, and fix %run to take
+        # plot updates into account
+        enable_gui(gui)
+        self.magic_run = self._pylab_magic_run
+
 
     # A few magics that are adapted to the specifics of using pexpect and a
     # remote terminal


### PR DESCRIPTION
This isn't as significant as it looks, as it's principally a big dedent in `zmq.ipkernel`.  All the single-method Kernel subclasses were just dedented, and are used as functions.  This lets them be plugged into the existing kernel's event loop.

The `enable_pylab` and `magic_gui` methods in zmqshell only differ from the originals in the source of the `enable_gui` function, and the change of the default pylab backend to `inline`, from `auto`.

So you can now activate pylab mode after launch, in the QtConsole or Notebook.
