### PR TITLE
Allow IPython to run without sqlite3

### DIFF
--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -55,7 +55,8 @@ def test_magic_parse_options():
         expected = path
     nt.assert_equals(opts['f'], expected)
 
-    
+
+@dec.skip_without('sqlite3')
 def doctest_hist_f():
     """Test %hist -f with temporary filename.
 
@@ -69,6 +70,7 @@ def doctest_hist_f():
     """
 
 
+@dec.skip_without('sqlite3')
 def doctest_hist_r():
     """Test %hist -r
 
@@ -86,6 +88,8 @@ def doctest_hist_r():
     %hist -r 2
     """
 
+
+@dec.skip_without('sqlite3')
 def doctest_hist_op():
     """Test %hist -op
 
@@ -151,7 +155,9 @@ def doctest_hist_op():
     's'
     >>> 
     """
-  
+
+
+@dec.skip_without('sqlite3')
 def test_macro():
     ip = get_ipython()
     ip.history_manager.reset()   # Clear any existing history.
@@ -164,6 +170,8 @@ def test_macro():
     # List macros.
     assert "test" in ip.magic("macro")
 
+
+@dec.skip_without('sqlite3')
 def test_macro_run():
     """Test that we can run a multi-line macro successfully."""
     ip = get_ipython()

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -169,9 +169,13 @@ class TestMagicRunSimple(tt.TempFileMixin):
                "        print 'object A deleted'\n"
                "a = A()\n")
         self.mktmp(py3compat.doctest_refactor_print(src))
-        tt.ipexec_validate(self.fname, 'object A deleted')
-
-    @dec.skip_known_failure
+        if dec.module_not_available('sqlite3'):
+            err = 'WARNING: IPython History requires SQLite, your history will not be saved\n'
+        else:
+            err = None
+        tt.ipexec_validate(self.fname, 'object A deleted', err)
+    
+    @dec.skip_known_failure 
     def test_aggressive_namespace_cleanup(self):
         """Test that namespace cleanup is not too aggressive GH-238
 
@@ -207,4 +211,8 @@ ARGV 1-: ['C-third']
 tclass.py: deleting object: C-second
 tclass.py: deleting object: C-third
 """
-        tt.ipexec_validate(self.fname, out)
+        if dec.module_not_available('sqlite3'):
+            err = 'WARNING: IPython History requires SQLite, your history will not be saved\n'
+        else:
+            err = None
+        tt.ipexec_validate(self.fname, out, err)

--- a/IPython/parallel/controller/sqlitedb.py
+++ b/IPython/parallel/controller/sqlitedb.py
@@ -16,7 +16,10 @@ import os
 import cPickle as pickle
 from datetime import datetime
 
-import sqlite3
+try:
+    import sqlite3
+except ImportError:
+    sqlite3 = None
 
 from zmq.eventloop import ioloop
 
@@ -99,7 +102,10 @@ class SQLiteDB(BaseDB):
         in tasks from previous sessions being available via Clients' db_query and
         get_result methods.""")
 
-    _db = Instance('sqlite3.Connection')
+    if sqlite3 is not None:
+        _db = Instance('sqlite3.Connection')
+    else:
+        _db = None
     # the ordered list of column names
     _keys = List(['msg_id' ,
             'header' ,
@@ -145,6 +151,8 @@ class SQLiteDB(BaseDB):
 
     def __init__(self, **kwargs):
         super(SQLiteDB, self).__init__(**kwargs)
+        if sqlite3 is None:
+            raise ImportError("SQLiteDB requires sqlite3")
         if not self.table:
             # use session, and prefix _, since starting with # is illegal
             self.table = '_'+self.session.replace('-','_')

--- a/IPython/parallel/tests/test_db.py
+++ b/IPython/parallel/tests/test_db.py
@@ -24,13 +24,12 @@ import time
 from datetime import datetime, timedelta
 from unittest import TestCase
 
-from nose import SkipTest
-
 from IPython.parallel import error
 from IPython.parallel.controller.dictdb import DictDB
 from IPython.parallel.controller.sqlitedb import SQLiteDB
 from IPython.parallel.controller.hub import init_record, empty_record
 
+from IPython.testing import decorators as dec
 from IPython.zmq.session import Session
 
 
@@ -171,8 +170,11 @@ class TestDictBackend(TestCase):
         self.db.drop_matching_records(query)
         recs = self.db.find_records(query)
         self.assertEquals(len(recs), 0)
-            
+
+
 class TestSQLiteBackend(TestDictBackend):
+
+    @dec.skip_without('sqlite3')
     def create_db(self):
         return SQLiteDB(location=tempfile.gettempdir())
     

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -311,11 +311,15 @@ skip_if_not_osx = skipif(sys.platform != 'darwin',
                          "This test only runs under OSX")
 
 # Other skip decorators
-skipif_not_numpy = skipif(module_not_available('numpy'),"This test requires numpy")
 
-skipif_not_matplotlib = skipif(module_not_available('matplotlib'),"This test requires matplotlib")
+# generic skip without module
+skip_without = lambda mod: skipif(module_not_available(mod), "This test requires %s" % mod)
 
-skipif_not_sympy = skipif(module_not_available('sympy'),"This test requires sympy")
+skipif_not_numpy = skip_without('numpy')
+
+skipif_not_matplotlib = skip_without('matplotlib')
+
+skipif_not_sympy = skip_without('sympy')
 
 skip_known_failure = knownfailureif(True,'This test is known to fail')
 

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -128,6 +128,7 @@ have['pymongo'] = test_for('pymongo')
 have['wx'] = test_for('wx')
 have['wx.aui'] = test_for('wx.aui')
 have['qt'] = test_for('IPython.external.qt')
+have['sqlite3'] = test_for('sqlite3')
 
 have['tornado'] = test_for('tornado.version_info', (2,1,0), callback=None)
 
@@ -204,7 +205,9 @@ def make_exclude():
                   ipjoin('config', 'default'),
                   ipjoin('config', 'profile'),
                   ]
-
+    if not have['sqlite3']:
+        exclusions.append(ipjoin('core', 'tests', 'test_history'))
+        exclusions.append(ipjoin('core', 'history'))
     if not have['wx']:
         exclusions.append(ipjoin('lib', 'inputhookwx'))
 


### PR DESCRIPTION
It's pretty easy to build your own Python without sqlite (or hashlib, and a few other compiled modules).  This does just enough to avoid ImportErrors, and lets IPython still function as though the history db is always empty.

readline history for a single session works fine.

Also added a generic `skip_without(module)` decorator to the test deco list, so we don't have to keep adding custom ones for each module that might be absent.

The test suite now passes if sqlite3 is not importable.
