### PR TITLE
Make import checks more explicit in %whos

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -861,7 +861,7 @@ Currently the magic system has the following functions:\n"""
         # for these types, show len() instead of data:
         seq_types = ['dict', 'list', 'tuple']
 
-        # for numpy/Numeric arrays, display summary info
+        # for numpy arrays, display summary info
         ndarray_type = None
         if 'numpy' in sys.modules:
             try:
@@ -870,15 +870,6 @@ Currently the magic system has the following functions:\n"""
                 pass
             else:
                 ndarray_type = ndarray.__name__
-
-        array_type = None
-        if 'Numeric' in sys.modules:
-            try:
-                from Numeric import ArrayType
-            except ImportError:
-                pass
-            else:
-                array_type = ArrayType.__name__
 
         # Find all variable names and types so we can figure out column sizes
         def get_vars(i):
@@ -923,7 +914,7 @@ Currently the magic system has the following functions:\n"""
             print vformat.format(vname, vtype, varwidth=varwidth, typewidth=typewidth),
             if vtype in seq_types:
                 print "n="+str(len(var))
-            elif vtype in [array_type,ndarray_type]:
+            elif vtype == ndarray_type:
                 vshape = str(var.shape).replace(',','').replace(' ','x')[1:-1]
                 if vtype==ndarray_type:
                     # numpy

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -862,18 +862,23 @@ Currently the magic system has the following functions:\n"""
         seq_types = ['dict', 'list', 'tuple']
 
         # for numpy/Numeric arrays, display summary info
-        try:
-            import numpy
-        except ImportError:
-            ndarray_type = None
-        else:
-            ndarray_type = numpy.ndarray.__name__
-        try:
-            import Numeric
-        except ImportError:
-            array_type = None
-        else:
-            array_type = Numeric.ArrayType.__name__
+        ndarray_type = None
+        if 'numpy' in sys.modules:
+            try:
+                from numpy import ndarray
+            except ImportError:
+                pass
+            else:
+                ndarray_type = ndarray.__name__
+
+        array_type = None
+        if 'Numeric' in sys.modules:
+            try:
+                from Numeric import ArrayType
+            except ImportError:
+                pass
+            else:
+                array_type = ArrayType.__name__
 
         # Find all variable names and types so we can figure out column sizes
         def get_vars(i):


### PR DESCRIPTION
Since PyPy has a fake numpy, checking for 'import numpy' is insufficient

only check if numpy/numeric in use, to prevent unnecessary imports

`%precision` has a similar issue, but I'm actually inclined to let it raise (it doesn't crash, or anything, just shows that numpy is not really numpy).  `%whos` is more important, and was entirely broken on PyPy.

closes #904
