### PR TITLE
%config magic

### DIFF
--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -149,34 +149,47 @@ class Configurable(HasTraits):
         self.config = newconfig
 
     @classmethod
-    def class_get_help(cls):
-        """Get the help string for this class in ReST format."""
+    def class_get_help(cls, inst=None):
+        """Get the help string for this class in ReST format.
+        
+        If `inst` is given, it's current trait values will be used in place of
+        class defaults.
+        """
+        assert inst is None or isinstance(inst, cls)
         cls_traits = cls.class_traits(config=True)
         final_help = []
         final_help.append(u'%s options' % cls.__name__)
         final_help.append(len(final_help[0])*u'-')
         for k,v in cls.class_traits(config=True).iteritems():
-            help = cls.class_get_trait_help(v)
+            help = cls.class_get_trait_help(v, inst)
             final_help.append(help)
         return '\n'.join(final_help)
 
     @classmethod
-    def class_get_trait_help(cls, trait):
-        """Get the help string for a single trait."""
+    def class_get_trait_help(cls, trait, inst=None):
+        """Get the help string for a single trait.
+        
+        If `inst` is given, it's current trait values will be used in place of
+        the class default.
+        """
+        assert inst is None or isinstance(inst, cls)
         lines = []
         header = "--%s.%s=<%s>" % (cls.__name__, trait.name, trait.__class__.__name__)
         lines.append(header)
-        try:
-            dvr = repr(trait.get_default_value())
-        except Exception:
-            dvr = None # ignore defaults we can't construct
-        if dvr is not None:
-            if len(dvr) > 64:
-                dvr = dvr[:61]+'...'
-            lines.append(indent('Default: %s'%dvr, 4))
+        if inst is not None:
+            lines.append(indent('Current: %r' % getattr(inst, trait.name), 4))
+        else:
+            try:
+                dvr = repr(trait.get_default_value())
+            except Exception:
+                dvr = None # ignore defaults we can't construct
+            if dvr is not None:
+                if len(dvr) > 64:
+                    dvr = dvr[:61]+'...'
+                lines.append(indent('Default: %s' % dvr, 4))
         if 'Enum' in trait.__class__.__name__:
             # include Enum choices
-            lines.append(indent('Choices: %r'%(trait.values,)))
+            lines.append(indent('Choices: %r' % (trait.values,)))
 
         help = trait.get_metadata('help')
         if help is not None:
@@ -185,9 +198,9 @@ class Configurable(HasTraits):
         return '\n'.join(lines)
 
     @classmethod
-    def class_print_help(cls):
+    def class_print_help(cls, inst=None):
         """Get the help string for a single trait and print it."""
-        print cls.class_get_help()
+        print cls.class_get_help(inst)
 
     @classmethod
     def class_config_section(cls):

--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -138,6 +138,16 @@ class Configurable(HasTraits):
                         # shared by all instances, effectively making it a class attribute.
                         setattr(self, k, deepcopy(config_value))
 
+    def update_config(self, config):
+        """Fire the traits events when the config is updated."""
+        # Save a copy of the current config.
+        newconfig = deepcopy(self.config)
+        # Merge the new config into the current one.
+        newconfig._merge(config)
+        # Save the combined config as self.config, which triggers the traits
+        # events.
+        self.config = newconfig
+
     @classmethod
     def class_get_help(cls):
         """Get the help string for this class in ReST format."""

--- a/IPython/config/tests/test_configurable.py
+++ b/IPython/config/tests/test_configurable.py
@@ -53,6 +53,15 @@ mc_help=u"""MyConfigurable options
     Default: 1.0
     The integer b."""
 
+mc_help_inst=u"""MyConfigurable options
+----------------------
+--MyConfigurable.a=<Int>
+    Current: 5
+    The integer a.
+--MyConfigurable.b=<Float>
+    Current: 4.0
+    The integer b."""
+
 class Foo(Configurable):
     a = Int(0, config=True, help="The integer a.")
     b = Unicode('nope', config=True)
@@ -138,6 +147,10 @@ class TestConfigurable(TestCase):
 
     def test_help(self):
         self.assertEquals(MyConfigurable.class_get_help(), mc_help)
+
+    def test_help_inst(self):
+        inst = MyConfigurable(a=5, b=4)
+        self.assertEquals(MyConfigurable.class_get_help(inst), mc_help_inst)
 
 
 class TestSingletonConfigurable(TestCase):

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -44,7 +44,7 @@ class DisplayFormatter(Configurable):
 
     # A dict of formatter whose keys are format types (MIME types) and whose
     # values are subclasses of BaseFormatter.
-    formatters = Dict(config=True)
+    formatters = Dict()
     def _formatters_default(self):
         """Activate the default formatters."""
         formatter_classes = [

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -322,8 +322,6 @@ class InteractiveShell(SingletonConfigurable, Magic):
     # The readline stuff will eventually be moved to the terminal subclass
     # but for now, we can't do that as readline is welded in everywhere.
     readline_use = CBool(True, config=True)
-    readline_merge_completions = CBool(True, config=True)
-    readline_omit__names = Enum((0,1,2), default_value=2, config=True)
     readline_remove_delims = Unicode('-/~', config=True)
     # don't use \M- bindings by default, because they
     # conflict with 8-bit encodings. See gh-58,gh-88
@@ -1856,7 +1854,6 @@ class InteractiveShell(SingletonConfigurable, Magic):
         self.Completer = IPCompleter(shell=self,
                                      namespace=self.user_ns,
                                      global_namespace=self.user_global_ns,
-                                     omit__names=self.readline_omit__names,
                                      alias_table=self.alias_manager.alias_table,
                                      use_readline=self.has_readline,
                                      config=self.config,

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -379,6 +379,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
         # This is where traits with a config_key argument are updated
         # from the values on config.
         super(InteractiveShell, self).__init__(config=config)
+        self.configurables = [self]
 
         # These are relatively independent and stateless
         self.init_ipython_dir(ipython_dir)
@@ -602,9 +603,11 @@ class InteractiveShell(SingletonConfigurable, Magic):
 
     def init_display_formatter(self):
         self.display_formatter = DisplayFormatter(config=self.config)
+        self.configurables.append(self.display_formatter)
 
     def init_display_pub(self):
         self.display_pub = self.display_pub_class(config=self.config)
+        self.configurables.append(self.display_pub)
 
     def init_displayhook(self):
         # Initialize displayhook, set in/out prompts and printing system
@@ -620,6 +623,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
             ps_out = self.prompt_out,
             pad_left = self.prompts_pad_left
         )
+        self.configurables.append(self.displayhook)
         # This is a context manager that installs/revmoes the displayhook at
         # the appropriate time.
         self.display_trap = DisplayTrap(hook=self.displayhook)
@@ -1435,6 +1439,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
     def init_history(self):
         """Sets up the command history, and starts regular autosaves."""
         self.history_manager = HistoryManager(shell=self, config=self.config)
+        self.configurables.append(self.history_manager)
 
     #-------------------------------------------------------------------------
     # Things related to exception handling and tracebacks (not debugging)
@@ -1856,6 +1861,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
                                      use_readline=self.has_readline,
                                      config=self.config,
                                      )
+        self.configurables.append(self.Completer)
 
         # Add custom completers to the basic ones built into IPCompleter
         sdisp = self.strdispatchers.get('complete_command', StrDispatch())
@@ -2112,6 +2118,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
 
     def init_alias(self):
         self.alias_manager = AliasManager(shell=self, config=self.config)
+        self.configurables.append(self.alias_manager)
         self.ns_table['alias'] = self.alias_manager.alias_table,
 
     #-------------------------------------------------------------------------
@@ -2120,9 +2127,12 @@ class InteractiveShell(SingletonConfigurable, Magic):
 
     def init_extension_manager(self):
         self.extension_manager = ExtensionManager(shell=self, config=self.config)
+        self.configurables.append(self.extension_manager)
 
     def init_plugin_manager(self):
         self.plugin_manager = PluginManager(config=self.config)
+        self.configurables.append(self.plugin_manager)
+        
 
     #-------------------------------------------------------------------------
     # Things related to payloads
@@ -2130,6 +2140,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
 
     def init_payload(self):
         self.payload_manager = PayloadManager(config=self.config)
+        self.configurables.append(self.payload_manager)
 
     #-------------------------------------------------------------------------
     # Things related to the prefilter
@@ -2137,6 +2148,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
 
     def init_prefilter(self):
         self.prefilter_manager = PrefilterManager(shell=self, config=self.config)
+        self.configurables.append(self.prefilter_manager)
         # Ultimately this will be refactored in the new interpreter code, but
         # for now, we should expose the main prefilter method (there's legacy
         # code out there that may rely on this).

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -3633,17 +3633,12 @@ Defaulting color scheme to 'NoColor'"""
         To see what classes are availabe for config, pass no arguments:
         In [1]: %config
         Available objects for config:
-             TerminalInteractiveShell
-             HistoryManager
-             PrefilterManager
-             AliasManager
-             IPCompleter
-             DisplayFormatter
-             DisplayPublisher
-             DisplayHook
-             ExtensionManager
-             PluginManager
-             PayloadManager
+            TerminalInteractiveShell
+            HistoryManager
+            PrefilterManager
+            AliasManager
+            IPCompleter
+            DisplayFormatter
         
         # To view what is configurable on a given class, just pass the class name
         In [2]: %config IPCompleter
@@ -3665,7 +3660,8 @@ Defaulting color scheme to 'NoColor'"""
         
         """
         from IPython.config.loader import Config
-        classnames = [ c.__class__.__name__ for c in self.configurables ]
+        # get list of class names for configurables that have someting to configure:
+        classnames = [ c.__class__.__name__ for c in self.configurables if c.__class__.class_traits(config=True) ]
         line = s.strip()
         if not line:
             # print available configurable names

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -3455,6 +3455,17 @@ Defaulting color scheme to 'NoColor'"""
         It will import at the top level numpy as np, pyplot as plt, matplotlib,
         pylab and mlab, as well as all names from numpy and pylab.
 
+        If you are using the inline matplotlib backend for embedded figures,
+        you can adjust its behavior via the %config magic::
+
+            # enable SVG figures, necessary for SVG+XHTML export in the qtconsole
+            In [1]: %config InlineBackend.figure_format = 'svg'
+            
+            # change the behavior of closing all figures at the end of each
+            # execution (cell), or allowing reuse of active figures across
+            # cells:
+            In [2]: %config InlineBackend.close_figures = False
+
         Parameters
         ----------
         guiname : optional
@@ -3465,19 +3476,21 @@ Defaulting color scheme to 'NoColor'"""
 
         Examples
         --------
-        In this case, where the MPL default is TkAgg:
-        In [2]: %pylab
+        In this case, where the MPL default is TkAgg::
 
-        Welcome to pylab, a matplotlib-based Python environment.
-        Backend in use: TkAgg
-        For more information, type 'help(pylab)'.
+            In [2]: %pylab
 
-        But you can explicitly request a different backend:
-        In [3]: %pylab qt
+            Welcome to pylab, a matplotlib-based Python environment.
+            Backend in use: TkAgg
+            For more information, type 'help(pylab)'.
 
-        Welcome to pylab, a matplotlib-based Python environment.
-        Backend in use: Qt4Agg
-        For more information, type 'help(pylab)'.
+        But you can explicitly request a different backend::
+
+            In [3]: %pylab qt
+
+            Welcome to pylab, a matplotlib-based Python environment.
+            Backend in use: Qt4Agg
+            For more information, type 'help(pylab)'.
         """
 
         if Application.initialized():
@@ -3614,13 +3627,11 @@ Defaulting color scheme to 'NoColor'"""
     def magic_config(self, s):
         """configure IPython
         
-        %config Class.trait=value
-        or
-        %config Class
+            %config Class[.trait=value]
         
         This magic exposes most of the IPython config system. Any
         Configurable class should be able to be configured with the simple
-        line:
+        line::
         
             %config Class.trait=value
         
@@ -3630,34 +3641,38 @@ Defaulting color scheme to 'NoColor'"""
         Examples
         --------
         
-        To see what classes are availabe for config, pass no arguments:
-        In [1]: %config
-        Available objects for config:
-            TerminalInteractiveShell
-            HistoryManager
-            PrefilterManager
-            AliasManager
-            IPCompleter
-            DisplayFormatter
-        
-        # To view what is configurable on a given class, just pass the class name
-        In [2]: %config IPCompleter
-        IPCompleter options
-        -----------------
-        IPCompleter.greedy=<CBool>
-            Current: False
-            Activate greedy completion
-            This will enable completion on elements of lists, results of function calls,
-            etc., but can be unsafe because the code is actually evaluated on TAB.
-        
-        # but the real use is in setting values:
-        In [3]: %config IPCompleter.greedy = True
-        
-        # and these values are read from the user_ns if they are variables:
-        In [4]: feeling_greedy=False
-        
-        In [5]: %config IPCompleter.greedy = feeling_greedy
-        
+        To see what classes are availabe for config, pass no arguments::
+
+            In [1]: %config
+            Available objects for config:
+                TerminalInteractiveShell
+                HistoryManager
+                PrefilterManager
+                AliasManager
+                IPCompleter
+                DisplayFormatter
+
+        To view what is configurable on a given class, just pass the class name::
+
+            In [2]: %config IPCompleter
+            IPCompleter options
+            -----------------
+            IPCompleter.greedy=<CBool>
+                Current: False
+                Activate greedy completion
+                This will enable completion on elements of lists, results of function calls,
+                etc., but can be unsafe because the code is actually evaluated on TAB.
+
+        but the real use is in setting values::
+
+            In [3]: %config IPCompleter.greedy = True
+
+        and these values are read from the user_ns if they are variables::
+
+            In [4]: feeling_greedy=False
+
+            In [5]: %config IPCompleter.greedy = feeling_greedy
+
         """
         from IPython.config.loader import Config
         # get list of class names for configurables that have someting to configure:

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -3704,7 +3704,7 @@ Defaulting color scheme to 'NoColor'"""
             cls = c.__class__
             help = cls.class_get_help(c)
             # strip leading '--' from cl-args:
-            help = re.sub(r'^\-\-', '', help, flags=re.MULTILINE)
+            help = re.sub(re.compile(r'^--', re.MULTILINE), '', help)
             print help
             return
         elif '=' not in line:

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -3657,6 +3657,19 @@ Defaulting color scheme to 'NoColor'"""
             In [2]: %config IPCompleter
             IPCompleter options
             -----------------
+            IPCompleter.omit__names=<Enum>
+                Current: 2
+                Choices: (0, 1, 2)
+                Instruct the completer to omit private method names
+                Specifically, when completing on ``object.<tab>``.
+                When 2 [default]: all names that start with '_' will be excluded.
+                When 1: all 'magic' names (``__foo__``) will be excluded.
+                When 0: nothing will be excluded.
+            IPCompleter.merge_completions=<CBool>
+                Current: True
+                Whether to merge completion results into a single list
+                If False, only the completion results from the first non-empty completer
+                will be returned.
             IPCompleter.greedy=<CBool>
                 Current: False
                 Activate greedy completion

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -13,6 +13,7 @@ import unittest
 import nose.tools as nt
 
 # our own packages
+from IPython.config.loader import Config
 from IPython.core import completer
 from IPython.external.decorators import knownfailureif
 from IPython.utils.tempdir import TemporaryDirectory
@@ -205,3 +206,27 @@ def test_greedy_completions():
     _,c = ip.complete('.',line='a[0].')
     nt.assert_true('a[0].real' in c, "Should have completed on a[0]: %s"%c)
 
+def test_omit__names():
+    # also happens to test IPCompleter as a configurable
+    ip = get_ipython()
+    ip._hidden_attr = 1
+    c = ip.Completer
+    ip.ex('ip=get_ipython()')
+    cfg = Config()
+    cfg.IPCompleter.omit__names = 0
+    c.update_config(cfg)
+    s,matches = c.complete('ip.')
+    nt.assert_true('ip.__str__' in matches)
+    nt.assert_true('ip._hidden_attr' in matches)
+    cfg.IPCompleter.omit__names = 1
+    c.update_config(cfg)
+    s,matches = c.complete('ip.')
+    nt.assert_false('ip.__str__' in matches)
+    nt.assert_true('ip._hidden_attr' in matches)
+    cfg.IPCompleter.omit__names = 2
+    c.update_config(cfg)
+    s,matches = c.complete('ip.')
+    nt.assert_false('ip.__str__' in matches)
+    nt.assert_false('ip._hidden_attr' in matches)
+    del ip._hidden_attr
+    

--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -35,7 +35,7 @@ from IPython.config.loader import (
 from IPython.config.application import boolean_flag, catch_config_error
 from IPython.core import release
 from IPython.core import usage
-from IPython.core.completer import Completer
+from IPython.core.completer import IPCompleter
 from IPython.core.crashhandler import CrashHandler
 from IPython.core.formatters import PlainTextFormatter
 from IPython.core.application import (
@@ -199,7 +199,7 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
             TerminalInteractiveShell,
             ProfileDir,
             PlainTextFormatter,
-            Completer,
+            IPCompleter,
         ]
 
     subcommands = Dict(dict(

--- a/IPython/lib/pylabtools.py
+++ b/IPython/lib/pylabtools.py
@@ -253,9 +253,9 @@ def import_pylab(user_ns, backend, import_all=True, shell=None):
         # function that will pick up the results for display.  This can only be
         # done with access to the real shell object.
         #
-        from IPython.zmq.pylab.backend_inline import InlineBackendConfig
+        from IPython.zmq.pylab.backend_inline import InlineBackend
 
-        cfg = InlineBackendConfig.instance(config=shell.config)
+        cfg = InlineBackend.instance(config=shell.config)
         cfg.shell = shell
         if cfg not in shell.configurables:
             shell.configurables.append(cfg)

--- a/IPython/lib/pylabtools.py
+++ b/IPython/lib/pylabtools.py
@@ -257,6 +257,8 @@ def import_pylab(user_ns, backend, import_all=True, shell=None):
 
         cfg = InlineBackendConfig.instance(config=shell.config)
         cfg.shell = shell
+        if cfg not in shell.configurables:
+            shell.configurables.append(cfg)
 
         if backend == backends['inline']:
             from IPython.zmq.pylab.backend_inline import flush_figures

--- a/docs/source/interactive/qtconsole.txt
+++ b/docs/source/interactive/qtconsole.txt
@@ -120,6 +120,56 @@ calling :func:`display`, you can specify ``--pylab=inline`` when you start the
 console, and each time you make a plot, it will show up in your document, as if
 you had called :func:`display(fig)`.
 
+The inline backend can use either SVG or PNG figures (PNG being the default).
+To switch between them, set the ``InlineBackend.figure_format`` configurable
+in a config file, or via the ``%config`` magic:
+
+.. sourcecode:: ipython
+
+    In [10]: %config InlineBackend.figure_format = 'svg'
+
+.. note::
+
+    Changing the inline figure format also affects calls to :func:`display` above,
+    even if you are not using the inline backend for all figures.
+
+By default, IPython closes all figures at the completion of each execution. This means you
+don't have to manually close figures, which is less convenient when figures aren't attached
+to windows with an obvious close button.  It also means that the first matplotlib call in
+each cell will always create a new figure:
+
+.. sourcecode:: ipython
+
+    In [11]: plot(range(100))
+    <single-line plot>
+    
+    In [12]: plot([1,3,2])
+    <another single-line plot>
+
+
+However, it does prevent the list of active figures surviving from one input cell to the
+next, so if you want to continue working with a figure, you must hold on to a reference to
+it:
+
+.. sourcecode:: ipython
+
+    In [11]: fig = gcf()
+       ....: fig.plot(rand(100))
+    <plot>
+    In [12]: fig.title('Random Title')
+    <redraw plot with title>
+
+This behavior is controlled by the :attr:`InlineBackend.close_figures` configurable, and
+if you set it to False, via %config or config file, then IPython will *not* close figures,
+and tools like :func:`gcf`, :func:`gca`, :func:`getfigs` will behave the same as they
+do with other backends.  You will, however, have to manually close figures:
+
+.. sourcecode:: ipython
+
+    # close all active figures:
+    In [13]: [ fig.close() for fig in getfigs() ]
+
+
 
 .. _saving:
 
@@ -131,6 +181,22 @@ XHTML. If you have been using :func:`display` or inline_ pylab, your figures
 will be PNG in HTML, or inlined as SVG in XHTML. PNG images have the option to
 be either in an external folder, as in many browsers' "Webpage, Complete"
 option, or inlined as well, for a larger, but more portable file.
+
+.. note::
+
+    Export to SVG+XHTML requires that you are using SVG figures, which is *not*
+    the default.  To switch the inline figure format to use SVG during an active
+    session, do:
+    
+    .. sourcecode:: ipython
+    
+        In [10]: %config InlineBackend.figure_format = 'svg'
+    
+    Or, you can add the same line (c.Inline... instead of %config Inline...) to
+    your config files.
+    
+    This will only affect figures plotted after making this call
+
 
 The widget also exposes the ability to print directly, via the default print
 shortcut or context menu.
@@ -145,6 +211,7 @@ shortcut or context menu.
 See these examples of :download:`png/html<figs/jn.html>` and
 :download:`svg/xhtml <figs/jn.xhtml>` output. Note that syntax highlighting
 does not survive export. This is a known issue, and is being investigated.
+
 
 Colors and Highlighting
 =======================


### PR DESCRIPTION
should close #903

Adds %config magic, which allows `%config Foo.bar = 5` configuration of IPython configurables.

The Magic class keeps a list of configurables which will be updated by the change, so any objects that should be accessible to this magic should be appended to `shell.configurables`.  I started with everything I saw as configurable in InteractiveShell.
### Usage

Use just `%config` to see what classes are available, and `%config Class` to get the trait info for that class.

When setting values via`%config Class.trait = value` It is evaluated with user_ns in globals, so you can do arbitrary things like:

``` python
In [4]: default = 'png'

In [5]: %config InlineBackendConfig.figure_format = raw_input('what figure format should we use? ') or default
```

Of course, this magic reveals just how much we _don't_ use traits/config properly.  Almost everything is attached to the InteractiveShell object, and has an effect exactly once during an `init_foo()` method, rather than allowing config propagation via `_trait_changed()` methods.

For instance, IPCompleter has an `omit__names` attribute, but the configurable is `InteractiveShell.readline_omit__names`, which is clearly wrong.

We've done a good job with config in _new_ code, but I think existing code needs a pretty hefty pass to get configurables attached to the right objects, and getting logic like `%colors` into `shell._colors_changed`.
