### PR TITLE
reincarnate -V cmdline option

### DIFF
--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -393,7 +393,7 @@ class Application(SingletonConfigurable):
             self.print_examples()
             self.exit(0)
 
-        if '--version' in argv:
+        if '--version' in argv or '-V' in argv:
             self.print_version()
             self.exit(0)
         


### PR DESCRIPTION
please allow at least to check for version consistently with previous versions.
Since -V is not used by anything else, please let it stay.  You could spit out
deprecation warning meanwhile to discourage its use, but it remains the only way
to check which version of ipython is actually available from the cmdline (might
be useful to scripts/mode wrappers for editors etc)
