### PR TITLE
Multiline history

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -308,7 +308,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
         """
     )
     multiline_history = CBool(sys.platform != 'win32', config=True,
-        help="Store multiple line spanning cells as a single entry in history."
+        help="Save multi-line entries as one entry in readline history"
     )
 
     prompt_in1 = Unicode('In [\\#]: ', config=True)

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -233,6 +233,11 @@ class TerminalInteractiveShell(InteractiveShell):
         """Store multiple lines as a single entry in history"""
         if self.multiline_history and self.has_readline and source_raw.rstrip():
             hlen = self.readline.get_current_history_length()
+
+            # nothing changed do nothing, e.g. when rl removes consecutive dups
+            if self.hlen_before_cell == hlen:
+                return
+
             for i in range(hlen - self.hlen_before_cell):
                 self.readline.remove_history_item(hlen - i - 1)
             stdin_encoding = sys.stdin.encoding or "utf-8"

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -322,8 +322,8 @@ class TerminalInteractiveShell(InteractiveShell):
                     self.edit_syntax_error()
                 if not more:
                     source_raw = self.input_splitter.source_raw_reset()[1]
-                    self._replace_rlhist_multiline(source_raw)
                     self.run_cell(source_raw, store_history=True)
+                    self._replace_rlhist_multiline(source_raw)
 
         # We are off again...
         __builtin__.__dict__['__IPYTHON__active'] -= 1

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -231,7 +231,7 @@ class TerminalInteractiveShell(InteractiveShell):
 
     def _replace_rlhist_multiline(self, source_raw):
         """Store multiple lines as a single entry in history"""
-        if self.multiline_history and self.has_readline:
+        if self.multiline_history and self.has_readline and source_raw.rstrip():
             hlen = self.readline.get_current_history_length()
             for i in range(hlen - self.hlen_before_cell):
                 self.readline.remove_history_item(hlen - i - 1)

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -275,6 +275,8 @@ class TerminalInteractiveShell(InteractiveShell):
         if self.has_readline:
             self.readline_startup_hook(self.pre_readline)
             hlen_b4_cell = self.readline.get_current_history_length()
+        else:
+            hlen_b4_cell = 0
         # exit_now is set by a call to %Exit or %Quit, through the
         # ask_exit callback.
 

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -236,6 +236,10 @@ class TerminalInteractiveShell(InteractiveShell):
         if not self.has_readline or not self.multiline_history:
             return hlen_before_cell
 
+        # windows rl has no remove_history_item
+        if not hasattr(self.readline, "remove_history_item"):
+            return hlen_before_cell
+
         # skip empty cells
         if not source_raw.rstrip():
             return hlen_before_cell

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -243,7 +243,7 @@ class TerminalInteractiveShell(InteractiveShell):
         # nothing changed do nothing, e.g. when rl removes consecutive dups
         hlen = self.readline.get_current_history_length()
         if hlen == hlen_before_cell:
-          return hlen_before_cell
+            return hlen_before_cell
 
         for i in range(hlen - hlen_before_cell):
             self.readline.remove_history_item(hlen - i - 1)

--- a/IPython/frontend/terminal/tests/test_interactivshell.py
+++ b/IPython/frontend/terminal/tests/test_interactivshell.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+"""Tests for the key interactiveshell module.
+
+Authors
+-------
+* Julian Taylor
+"""
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2011  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+# stdlib
+import unittest
+
+from IPython.testing.decorators import skipif
+
+class InteractiveShellTestCase(unittest.TestCase):
+    def rl_hist_entries(self, rl, n):
+        """Get last n readline history entries as a list"""
+        return [rl.get_history_item(rl.get_current_history_length() - x)
+                for x in range(n - 1, -1, -1)]
+
+    def test_runs_without_rl(self):
+        """Test that function does not throw without readline"""
+        ip = get_ipython()
+        ip.has_readline = False
+        ip.readline = None
+        ip._replace_rlhist_multiline(u'source')
+
+    @skipif(not get_ipython().has_readline, 'no readline')
+    def test_replace_multiline_hist_disabled(self):
+        """Test that multiline replace does nothing if disabled"""
+        ip = get_ipython()
+        ip.multiline_history = False
+
+        ghist = [u'line1', u'line2']
+        for h in ghist:
+           ip.readline.add_history(h)
+        ip.hlen_before_cell = ip.readline.get_current_history_length()
+        ip._replace_rlhist_multiline(u'sourc€\nsource2')
+
+        self.assertEquals(ip.readline.get_current_history_length(),
+                          ip.hlen_before_cell)
+        hist = self.rl_hist_entries(ip.readline, 2)
+        self.assertEquals(hist, ghist)
+
+    @skipif(not get_ipython().has_readline, 'no readline')
+    def test_replace_multiline_hist_adds(self):
+        """Test that multiline replace function adds history"""
+        ip = get_ipython()
+
+        ip.hlen_before_cell = ip.readline.get_current_history_length()
+        ip._replace_rlhist_multiline(u'sourc€')
+
+        self.assertEquals(ip.hlen_before_cell,
+                          ip.readline.get_current_history_length())
+
+    @skipif(not get_ipython().has_readline, 'no readline')
+    def test_replace_multiline_hist_keeps_history(self):
+        """Test that multiline replace does not delete history"""
+        ip = get_ipython()
+        ip.multiline_history = True
+
+        ghist = [u'line1', u'line2']
+        for h in ghist:
+           ip.readline.add_history(h)
+
+        #start cell
+        ip.hlen_before_cell = ip.readline.get_current_history_length()
+        ip._replace_rlhist_multiline(u'sourc€\nsource2')
+
+        self.assertEquals(ip.readline.get_current_history_length(),
+                          ip.hlen_before_cell)
+        hist = self.rl_hist_entries(ip.readline, 3)
+        self.assertEquals(hist, ghist + ['sourc€\nsource2'])
+
+    @skipif(not get_ipython().has_readline, 'no readline')
+    def test_replace_multiline_hist_replaces(self):
+        """Test that multiline entries are replaced"""
+        ip = get_ipython()
+        ip.multiline_history = True
+
+        ip.readline.add_history(u'line0')
+        #start cell
+        ip.hlen_before_cell = ip.readline.get_current_history_length()
+        ip.readline.add_history('l€ne1')
+        ip.readline.add_history('line2')
+        #replace cell with single line
+        ip._replace_rlhist_multiline(u'l€ne1\nline2')
+
+        self.assertEquals(ip.readline.get_current_history_length(),
+                          ip.hlen_before_cell)
+        hist = self.rl_hist_entries(ip.readline, 2)
+        self.assertEquals(hist, [u'line0', 'l€ne1\nline2'])
+
+    @skipif(not get_ipython().has_readline, 'no readline')
+    def test_replace_multiline_hist_replaces_twice(self):
+        """Test that multiline entries are replaced twice"""
+        ip = get_ipython()
+        ip.multiline_history = True
+
+        ip.readline.add_history(u'line0')
+        #start cell
+        ip.hlen_before_cell = ip.readline.get_current_history_length()
+        ip.readline.add_history('l€ne1')
+        ip.readline.add_history('line2')
+        #replace cell with single line
+        ip._replace_rlhist_multiline(u'l€ne1\nline2')
+        ip.readline.add_history('l€ne3')
+        ip.readline.add_history('line4')
+        #replace cell with single line
+        ip._replace_rlhist_multiline(u'l€ne3\nline4')
+
+        self.assertEquals(ip.readline.get_current_history_length(),
+                          ip.hlen_before_cell)
+        hist = self.rl_hist_entries(ip.readline, 3)
+        self.assertEquals(hist, ['line0', 'l€ne1\nline2', 'l€ne3\nline4'])

--- a/IPython/frontend/terminal/tests/test_interactivshell.py
+++ b/IPython/frontend/terminal/tests/test_interactivshell.py
@@ -34,6 +34,14 @@ class InteractiveShellTestCase(unittest.TestCase):
         ip._replace_rlhist_multiline(u'source', 0)
 
     @skipif(not get_ipython().has_readline, 'no readline')
+    def test_runs_without_remove_history_item(self):
+        """Test that function does not throw on windows without
+           remove_history_item"""
+        ip = get_ipython()
+        del ip.readline.remove_history_item
+        ip._replace_rlhist_multiline(u'source', 0)
+
+    @skipif(not get_ipython().has_readline, 'no readline')
     def test_replace_multiline_hist_disabled(self):
         """Test that multiline replace does nothing if disabled"""
         ip = get_ipython()

--- a/IPython/frontend/terminal/tests/test_interactivshell.py
+++ b/IPython/frontend/terminal/tests/test_interactivshell.py
@@ -80,24 +80,6 @@ class InteractiveShellTestCase(unittest.TestCase):
         hist = self.rl_hist_entries(ip.readline, 3)
         self.assertEquals(hist, ghist + ['sourc€\nsource2'])
 
-    @skipif(not get_ipython().has_readline, 'no readline')
-    def test_replace_multiline_hist_replaces(self):
-        """Test that multiline entries are replaced"""
-        ip = get_ipython()
-        ip.multiline_history = True
-
-        ip.readline.add_history(u'line0')
-        #start cell
-        ip.hlen_before_cell = ip.readline.get_current_history_length()
-        ip.readline.add_history('l€ne1')
-        ip.readline.add_history('line2')
-        #replace cell with single line
-        ip._replace_rlhist_multiline(u'l€ne1\nline2')
-
-        self.assertEquals(ip.readline.get_current_history_length(),
-                          ip.hlen_before_cell)
-        hist = self.rl_hist_entries(ip.readline, 2)
-        self.assertEquals(hist, [u'line0', 'l€ne1\nline2'])
 
     @skipif(not get_ipython().has_readline, 'no readline')
     def test_replace_multiline_hist_replaces_twice(self):

--- a/IPython/frontend/terminal/tests/test_interactivshell.py
+++ b/IPython/frontend/terminal/tests/test_interactivshell.py
@@ -31,7 +31,7 @@ class InteractiveShellTestCase(unittest.TestCase):
         ip = get_ipython()
         ip.has_readline = False
         ip.readline = None
-        ip._replace_rlhist_multiline(u'source')
+        ip._replace_rlhist_multiline(u'source', 0)
 
     @skipif(not get_ipython().has_readline, 'no readline')
     def test_replace_multiline_hist_disabled(self):
@@ -42,11 +42,12 @@ class InteractiveShellTestCase(unittest.TestCase):
         ghist = [u'line1', u'line2']
         for h in ghist:
            ip.readline.add_history(h)
-        ip.hlen_before_cell = ip.readline.get_current_history_length()
-        ip._replace_rlhist_multiline(u'sourc€\nsource2')
+        hlen_b4_cell = ip.readline.get_current_history_length()
+        hlen_b4_cell = ip._replace_rlhist_multiline(u'sourc€\nsource2',
+                                                    hlen_b4_cell)
 
         self.assertEquals(ip.readline.get_current_history_length(),
-                          ip.hlen_before_cell)
+                          hlen_b4_cell)
         hist = self.rl_hist_entries(ip.readline, 2)
         self.assertEquals(hist, ghist)
 
@@ -55,10 +56,10 @@ class InteractiveShellTestCase(unittest.TestCase):
         """Test that multiline replace function adds history"""
         ip = get_ipython()
 
-        ip.hlen_before_cell = ip.readline.get_current_history_length()
-        ip._replace_rlhist_multiline(u'sourc€')
+        hlen_b4_cell = ip.readline.get_current_history_length()
+        hlen_b4_cell = ip._replace_rlhist_multiline(u'sourc€', hlen_b4_cell)
 
-        self.assertEquals(ip.hlen_before_cell,
+        self.assertEquals(hlen_b4_cell,
                           ip.readline.get_current_history_length())
 
     @skipif(not get_ipython().has_readline, 'no readline')
@@ -72,12 +73,13 @@ class InteractiveShellTestCase(unittest.TestCase):
            ip.readline.add_history(h)
 
         #start cell
-        ip.hlen_before_cell = ip.readline.get_current_history_length()
-        # nothing added to rl history, should do nothing
-        ip._replace_rlhist_multiline(u'sourc€\nsource2')
+        hlen_b4_cell = ip.readline.get_current_history_length()
+		# nothing added to rl history, should do nothing
+        hlen_b4_cell = ip._replace_rlhist_multiline(u'sourc€\nsource2',
+                                                    hlen_b4_cell)
 
         self.assertEquals(ip.readline.get_current_history_length(),
-                          ip.hlen_before_cell)
+                          hlen_b4_cell)
         hist = self.rl_hist_entries(ip.readline, 2)
         self.assertEquals(hist, ghist)
 
@@ -90,18 +92,20 @@ class InteractiveShellTestCase(unittest.TestCase):
 
         ip.readline.add_history(u'line0')
         #start cell
-        ip.hlen_before_cell = ip.readline.get_current_history_length()
+        hlen_b4_cell = ip.readline.get_current_history_length()
         ip.readline.add_history('l€ne1')
         ip.readline.add_history('line2')
         #replace cell with single line
-        ip._replace_rlhist_multiline(u'l€ne1\nline2')
+        hlen_b4_cell = ip._replace_rlhist_multiline(u'l€ne1\nline2',
+                                                    hlen_b4_cell)
         ip.readline.add_history('l€ne3')
         ip.readline.add_history('line4')
         #replace cell with single line
-        ip._replace_rlhist_multiline(u'l€ne3\nline4')
+        hlen_b4_cell = ip._replace_rlhist_multiline(u'l€ne3\nline4',
+                                                    hlen_b4_cell)
 
         self.assertEquals(ip.readline.get_current_history_length(),
-                          ip.hlen_before_cell)
+                          hlen_b4_cell)
         hist = self.rl_hist_entries(ip.readline, 3)
         self.assertEquals(hist, ['line0', 'l€ne1\nline2', 'l€ne3\nline4'])
 
@@ -114,24 +118,25 @@ class InteractiveShellTestCase(unittest.TestCase):
 
         ip.readline.add_history(u'line0')
         #start cell
-        ip.hlen_before_cell = ip.readline.get_current_history_length()
+        hlen_b4_cell = ip.readline.get_current_history_length()
         ip.readline.add_history('l€ne1')
         ip.readline.add_history('line2')
-        ip._replace_rlhist_multiline(u'l€ne1\nline2')
+        hlen_b4_cell = ip._replace_rlhist_multiline(u'l€ne1\nline2',
+                                                    hlen_b4_cell)
         ip.readline.add_history('')
-        ip._replace_rlhist_multiline(u'')
+        hlen_b4_cell = ip._replace_rlhist_multiline(u'', hlen_b4_cell)
         ip.readline.add_history('l€ne3')
-        ip._replace_rlhist_multiline(u'l€ne3')
+        hlen_b4_cell = ip._replace_rlhist_multiline(u'l€ne3', hlen_b4_cell)
         ip.readline.add_history('  ')
-        ip._replace_rlhist_multiline('  ')
+        hlen_b4_cell = ip._replace_rlhist_multiline('  ', hlen_b4_cell)
         ip.readline.add_history('\t')
         ip.readline.add_history('\t ')
-        ip._replace_rlhist_multiline('\t')
+        hlen_b4_cell = ip._replace_rlhist_multiline('\t', hlen_b4_cell)
         ip.readline.add_history('line4')
-        ip._replace_rlhist_multiline(u'line4')
+        hlen_b4_cell = ip._replace_rlhist_multiline(u'line4', hlen_b4_cell)
 
         self.assertEquals(ip.readline.get_current_history_length(),
-                          ip.hlen_before_cell)
+                          hlen_b4_cell)
         hist = self.rl_hist_entries(ip.readline, 4)
         # expect no empty cells in history
         self.assertEquals(hist, ['line0', 'l€ne1\nline2', 'l€ne3', 'line4'])

--- a/IPython/frontend/terminal/tests/test_interactivshell.py
+++ b/IPython/frontend/terminal/tests/test_interactivshell.py
@@ -38,10 +38,13 @@ class InteractiveShellTestCase(unittest.TestCase):
         """Test that function does not throw on windows without
            remove_history_item"""
         ip = get_ipython()
-        del ip.readline.remove_history_item
+        if hasattr(ip.readline, 'remove_history_item'):
+            del ip.readline.remove_history_item
         ip._replace_rlhist_multiline(u'source', 0)
 
     @skipif(not get_ipython().has_readline, 'no readline')
+    @skipif(not hasattr(get_ipython().readline, 'remove_history_item'),
+            'no remove_history_item')
     def test_replace_multiline_hist_disabled(self):
         """Test that multiline replace does nothing if disabled"""
         ip = get_ipython()
@@ -60,6 +63,8 @@ class InteractiveShellTestCase(unittest.TestCase):
         self.assertEquals(hist, ghist)
 
     @skipif(not get_ipython().has_readline, 'no readline')
+    @skipif(not hasattr(get_ipython().readline, 'remove_history_item'),
+            'no remove_history_item')
     def test_replace_multiline_hist_adds(self):
         """Test that multiline replace function adds history"""
         ip = get_ipython()
@@ -71,6 +76,8 @@ class InteractiveShellTestCase(unittest.TestCase):
                           ip.readline.get_current_history_length())
 
     @skipif(not get_ipython().has_readline, 'no readline')
+    @skipif(not hasattr(get_ipython().readline, 'remove_history_item'),
+            'no remove_history_item')
     def test_replace_multiline_hist_keeps_history(self):
         """Test that multiline replace does not delete history"""
         ip = get_ipython()
@@ -93,6 +100,8 @@ class InteractiveShellTestCase(unittest.TestCase):
 
 
     @skipif(not get_ipython().has_readline, 'no readline')
+    @skipif(not hasattr(get_ipython().readline, 'remove_history_item'),
+            'no remove_history_item')
     def test_replace_multiline_hist_replaces_twice(self):
         """Test that multiline entries are replaced twice"""
         ip = get_ipython()
@@ -119,6 +128,8 @@ class InteractiveShellTestCase(unittest.TestCase):
 
 
     @skipif(not get_ipython().has_readline, 'no readline')
+    @skipif(not hasattr(get_ipython().readline, 'remove_history_item'),
+            'no remove_history_item')
     def test_replace_multiline_hist_replaces_empty_line(self):
         """Test that multiline history skips empty line cells"""
         ip = get_ipython()

--- a/IPython/frontend/terminal/tests/test_interactivshell.py
+++ b/IPython/frontend/terminal/tests/test_interactivshell.py
@@ -73,12 +73,13 @@ class InteractiveShellTestCase(unittest.TestCase):
 
         #start cell
         ip.hlen_before_cell = ip.readline.get_current_history_length()
+        # nothing added to rl history, should do nothing
         ip._replace_rlhist_multiline(u'sourc€\nsource2')
 
         self.assertEquals(ip.readline.get_current_history_length(),
                           ip.hlen_before_cell)
-        hist = self.rl_hist_entries(ip.readline, 3)
-        self.assertEquals(hist, ghist + ['sourc€\nsource2'])
+        hist = self.rl_hist_entries(ip.readline, 2)
+        self.assertEquals(hist, ghist)
 
 
     @skipif(not get_ipython().has_readline, 'no readline')

--- a/IPython/frontend/terminal/tests/test_interactivshell.py
+++ b/IPython/frontend/terminal/tests/test_interactivshell.py
@@ -103,3 +103,34 @@ class InteractiveShellTestCase(unittest.TestCase):
                           ip.hlen_before_cell)
         hist = self.rl_hist_entries(ip.readline, 3)
         self.assertEquals(hist, ['line0', 'l€ne1\nline2', 'l€ne3\nline4'])
+
+
+    @skipif(not get_ipython().has_readline, 'no readline')
+    def test_replace_multiline_hist_replaces_empty_line(self):
+        """Test that multiline history skips empty line cells"""
+        ip = get_ipython()
+        ip.multiline_history = True
+
+        ip.readline.add_history(u'line0')
+        #start cell
+        ip.hlen_before_cell = ip.readline.get_current_history_length()
+        ip.readline.add_history('l€ne1')
+        ip.readline.add_history('line2')
+        ip._replace_rlhist_multiline(u'l€ne1\nline2')
+        ip.readline.add_history('')
+        ip._replace_rlhist_multiline(u'')
+        ip.readline.add_history('l€ne3')
+        ip._replace_rlhist_multiline(u'l€ne3')
+        ip.readline.add_history('  ')
+        ip._replace_rlhist_multiline('  ')
+        ip.readline.add_history('\t')
+        ip.readline.add_history('\t ')
+        ip._replace_rlhist_multiline('\t')
+        ip.readline.add_history('line4')
+        ip._replace_rlhist_multiline(u'line4')
+
+        self.assertEquals(ip.readline.get_current_history_length(),
+                          ip.hlen_before_cell)
+        hist = self.rl_hist_entries(ip.readline, 4)
+        # expect no empty cells in history
+        self.assertEquals(hist, ['line0', 'l€ne1\nline2', 'l€ne3', 'line4'])


### PR DESCRIPTION
some readline multiline history fixes and tests

fixes crash when readline (gh-911)
do not save input from e.g. raw_input in history
do not add empty lines to the history.
add a testcase for _replace_rlhist_multiline
update the docstring for the configuration variable
