### PR TITLE
read-only notebook mode

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -35,7 +35,7 @@ import sys
 
 from IPython.config.application import Application
 from IPython.config.configurable import Configurable
-from IPython.config.loader import Config
+from IPython.config.loader import Config, ConfigFileNotFound
 from IPython.core import release, crashhandler
 from IPython.core.profiledir import ProfileDir, ProfileDirError
 from IPython.utils.path import get_ipython_dir, get_ipython_package_dir
@@ -186,7 +186,7 @@ class BaseIPythonApplication(Application):
                 base_config,
                 path=self.config_file_paths
             )
-        except IOError:
+        except ConfigFileNotFound:
             # ignore errors loading parent
             self.log.debug("Config file %s not found", base_config)
             pass
@@ -201,7 +201,7 @@ class BaseIPythonApplication(Application):
                 self.config_file_name,
                 path=self.config_file_paths
             )
-        except IOError:
+        except ConfigFileNotFound:
             # Only warn if the default config file was NOT being used.
             if self.config_file_specified:
                 msg = self.log.warn

--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -30,7 +30,7 @@ import os
 import sys
 
 from IPython.config.loader import (
-    Config, PyFileConfigLoader
+    Config, PyFileConfigLoader, ConfigFileNotFound
 )
 from IPython.config.application import boolean_flag
 from IPython.core import release
@@ -378,7 +378,7 @@ def load_default_config(ipython_dir=None):
     cl = PyFileConfigLoader(default_config_file_name, profile_dir)
     try:
         config = cl.load_config()
-    except IOError:
+    except ConfigFileNotFound:
         # no config found
         config = Config()
     return config


### PR DESCRIPTION
As requested by @fperez

When using a password, read-only mode allows unauthenticated users read-only access to notebooks.  Editing, execution, etc. are not allowed in read-only mode (the buttons, shortcuts, etc. are removed, but the requests will raise authentication errors if they manage to send the events anyway), but save/print functions are available.

No kernels are started until an authenticated user opens a notebook.
