### PR TITLE
read-only notebook mode

### DIFF
--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -77,7 +77,7 @@ class AuthenticatedHandler(web.RequestHandler):
         if user_id is None:
             # prevent extra Invalid cookie sig warnings:
             self.clear_cookie('username')
-            if not self.application.password:
+            if not self.application.password and not self.application.ipython_app.read_only:
                 user_id = 'anonymous'
         return user_id
 

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -125,8 +125,7 @@ flags['read-only'] = (
     individual notebooks, but not edit them, start kernels, or run
     code.
     
-    This flag only makes sense in conjunction with setting a password,
-    via the ``NotebookApp.password`` configurable.
+    If no password is set, the server will be entirely read-only.
     """
 )
 

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -105,6 +105,7 @@ class NotebookWebApplication(web.Application):
         self.log = log
         self.notebook_manager = notebook_manager
         self.ipython_app = ipython_app
+        self.read_only = self.ipython_app.read_only
 
 
 #-----------------------------------------------------------------------------

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -118,13 +118,22 @@ flags['no-browser']=(
 )
 flags['read-only'] = (
     {'NotebookApp' : {'read_only' : True}},
-    "Launch the Notebook server in read-only mode, not allowing execution or editing"
+    """Allow read-only access to notebooks.
+    
+    When using a password to protect the notebook server, this flag
+    allows unauthenticated clients to view the notebook list, and
+    individual notebooks, but not edit them, start kernels, or run
+    code.
+    
+    This flag only makes sense in conjunction with setting a password,
+    via the ``NotebookApp.password`` configurable.
+    """
 )
 
 # the flags that are specific to the frontend
 # these must be scrubbed before being passed to the kernel,
 # or it will raise an error on unrecognized flags
-notebook_flags = ['no-browser']
+notebook_flags = ['no-browser', 'read-only']
 
 aliases = dict(ipkernel_aliases)
 

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -116,6 +116,10 @@ flags['no-browser']=(
     {'NotebookApp' : {'open_browser' : False}},
     "Don't open the notebook in a browser after startup."
 )
+flags['read-only'] = (
+    {'NotebookApp' : {'read_only' : True}},
+    "Launch the Notebook server in read-only mode, not allowing execution or editing"
+)
 
 # the flags that are specific to the frontend
 # these must be scrubbed before being passed to the kernel,
@@ -203,6 +207,10 @@ class NotebookApp(BaseIPythonApplication):
     
     open_browser = Bool(True, config=True,
                         help="Whether to open in a browser after starting.")
+    
+    read_only = Bool(False, config=True,
+        help="Whether to prevent editing/execution of notebooks."
+    )
 
     def get_ws_url(self):
         """Return the WebSocket URL for this server."""
@@ -282,7 +290,7 @@ class NotebookApp(BaseIPythonApplication):
         # Try random ports centered around the default.
         from random import randint
         n = 50  # Max number of attempts, keep reasonably large.
-        for port in [self.port] + [self.port + randint(-2*n, 2*n) for i in range(n)]:
+        for port in range(self.port, self.port+5) + [self.port + randint(-2*n, 2*n) for i in range(n-5)]:
             try:
                 self.http_server.listen(port, self.ip)
             except socket.error, e:

--- a/IPython/frontend/html/notebook/static/css/base.css
+++ b/IPython/frontend/html/notebook/static/css/base.css
@@ -51,3 +51,12 @@ div#main_app {
     padding: 0.2em 0.8em;
     font-size: 77%;
 }
+
+span#login_widget {
+    float: right;
+}
+
+/* generic class for hidden objects */
+.hidden {
+    display: none;
+}

--- a/IPython/frontend/html/notebook/static/js/cell.js
+++ b/IPython/frontend/html/notebook/static/js/cell.js
@@ -15,6 +15,10 @@ var IPython = (function (IPython) {
 
     var Cell = function (notebook) {
         this.notebook = notebook;
+        this.read_only = false;
+        if (notebook){
+            this.read_only = notebook.read_only;
+        }
         this.selected = false;
         this.element = null;
         this.create_element();

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -37,6 +37,7 @@ var IPython = (function (IPython) {
             indentUnit : 4,
             mode: 'python',
             theme: 'ipython',
+            readOnly: this.read_only,
             onKeyEvent: $.proxy(this.handle_codemirror_keyevent,this)
         });
         input.append(input_area);

--- a/IPython/frontend/html/notebook/static/js/leftpanel.js
+++ b/IPython/frontend/html/notebook/static/js/leftpanel.js
@@ -65,8 +65,10 @@ var IPython = (function (IPython) {
 
     LeftPanel.prototype.create_children = function () {
         this.notebook_section = new IPython.NotebookSection('div#notebook_section');
-        this.cell_section = new IPython.CellSection('div#cell_section');
-        this.kernel_section = new IPython.KernelSection('div#kernel_section');
+        if (! IPython.read_only){
+            this.cell_section = new IPython.CellSection('div#cell_section');
+            this.kernel_section = new IPython.KernelSection('div#kernel_section');
+        }
         this.help_section = new IPython.HelpSection('div#help_section');
     }
 

--- a/IPython/frontend/html/notebook/static/js/loginwidget.js
+++ b/IPython/frontend/html/notebook/static/js/loginwidget.js
@@ -1,0 +1,38 @@
+//----------------------------------------------------------------------------
+//  Copyright (C) 2008-2011  The IPython Development Team
+//
+//  Distributed under the terms of the BSD License.  The full license is in
+//  the file COPYING, distributed as part of this software.
+//----------------------------------------------------------------------------
+
+//============================================================================
+// Login button
+//============================================================================
+
+var IPython = (function (IPython) {
+
+    var LoginWidget = function (selector) {
+        this.selector = selector;
+        if (this.selector !== undefined) {
+            this.element = $(selector);
+            this.style();
+            this.bind_events();
+        }
+    };
+
+    LoginWidget.prototype.style = function () {
+        this.element.find('button#login').button();
+    };
+    LoginWidget.prototype.bind_events = function () {
+        var that = this;
+        this.element.find("button#login").click(function () {
+            window.location = "/login?next="+location.pathname;
+        });
+    };
+
+    // Set module variables
+    IPython.LoginWidget = LoginWidget;
+
+    return IPython;
+
+}(IPython));

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -14,7 +14,7 @@ var IPython = (function (IPython) {
     var utils = IPython.utils;
 
     var Notebook = function (selector) {
-        this.read_only = false;
+        this.read_only = IPython.read_only;
         this.element = $(selector);
         this.element.scroll();
         this.element.data("notebook", this);
@@ -979,13 +979,6 @@ var IPython = (function (IPython) {
 
     Notebook.prototype.notebook_loaded = function (data, status, xhr) {
         var allowed = xhr.getResponseHeader('Allow');
-        if (allowed && allowed.indexOf('PUT') == -1){
-            this.read_only = true;
-            // unhide login button if it's relevant
-            $('span#login_widget').removeClass('hidden');
-        }else{
-            this.read_only = false;
-        }
         this.fromJSON(data);
         if (this.ncells() === 0) {
             this.insert_code_cell_below();
@@ -993,9 +986,7 @@ var IPython = (function (IPython) {
         IPython.save_widget.status_save();
         IPython.save_widget.set_notebook_name(data.metadata.name);
         this.dirty = false;
-        if (this.read_only) {
-            this.handle_read_only();
-        }else{
+        if (! this.read_only) {
             this.start_kernel();
         }
         // fromJSON always selects the last cell inserted. We need to wait
@@ -1005,16 +996,6 @@ var IPython = (function (IPython) {
             IPython.notebook.scroll_to_top();
         }, 50);
     };
-
-
-    Notebook.prototype.handle_read_only = function(){
-        IPython.left_panel.collapse();
-        IPython.save_widget.element.find('button#save_notebook').addClass('hidden');
-        $('button#new_notebook').addClass('hidden');
-        $('div#cell_section').addClass('hidden');
-        $('div#kernel_section').addClass('hidden');
-    }
-
 
     IPython.Notebook = Notebook;
 

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -14,6 +14,7 @@ var IPython = (function (IPython) {
     var utils = IPython.utils;
 
     var Notebook = function (selector) {
+        this.read_only = false;
         this.element = $(selector);
         this.element.scroll();
         this.element.data("notebook", this);
@@ -42,6 +43,7 @@ var IPython = (function (IPython) {
         var that = this;
         var end_space = $('<div class="end_space"></div>').height(150);
         end_space.dblclick(function (e) {
+            if (that.read_only) return;
             var ncells = that.ncells();
             that.insert_code_cell_below(ncells-1);
         });
@@ -54,6 +56,7 @@ var IPython = (function (IPython) {
         var that = this;
         $(document).keydown(function (event) {
             // console.log(event);
+            if (that.read_only) return;
             if (event.which === 38) {
                 var cell = that.selected_cell();
                 if (cell.at_top()) {
@@ -185,11 +188,11 @@ var IPython = (function (IPython) {
         });
 
         $(window).bind('beforeunload', function () {
-            var kill_kernel = $('#kill_kernel').prop('checked');                
+            var kill_kernel = $('#kill_kernel').prop('checked');
             if (kill_kernel) {
                 that.kernel.kill();
             }
-            if (that.dirty) {
+            if (that.dirty && ! that.read_only) {
                 return "You have unsaved changes that will be lost if you leave this page.";
             };
         });
@@ -975,14 +978,26 @@ var IPython = (function (IPython) {
 
 
     Notebook.prototype.notebook_loaded = function (data, status, xhr) {
+        var allowed = xhr.getResponseHeader('Allow');
+        if (allowed && allowed.indexOf('PUT') == -1){
+            this.read_only = true;
+            // unhide login button if it's relevant
+            $('span#login_widget').removeClass('hidden');
+        }else{
+            this.read_only = false;
+        }
         this.fromJSON(data);
         if (this.ncells() === 0) {
             this.insert_code_cell_below();
         };
         IPython.save_widget.status_save();
         IPython.save_widget.set_notebook_name(data.metadata.name);
-        this.start_kernel();
         this.dirty = false;
+        if (this.read_only) {
+            this.handle_read_only();
+        }else{
+            this.start_kernel();
+        }
         // fromJSON always selects the last cell inserted. We need to wait
         // until that is done before scrolling to the top.
         setTimeout(function () {
@@ -990,6 +1005,15 @@ var IPython = (function (IPython) {
             IPython.notebook.scroll_to_top();
         }, 50);
     };
+
+
+    Notebook.prototype.handle_read_only = function(){
+        IPython.left_panel.collapse();
+        IPython.save_widget.element.find('button#save_notebook').addClass('hidden');
+        $('button#new_notebook').addClass('hidden');
+        $('div#cell_section').addClass('hidden');
+        $('div#kernel_section').addClass('hidden');
+    }
 
 
     IPython.Notebook = Notebook;

--- a/IPython/frontend/html/notebook/static/js/notebooklist.js
+++ b/IPython/frontend/html/notebook/static/js/notebooklist.js
@@ -73,6 +73,15 @@ var IPython = (function (IPython) {
 
 
     NotebookList.prototype.list_loaded = function (data, status, xhr) {
+        var allowed = xhr.getResponseHeader('Allow');
+        if (allowed && allowed.indexOf('PUT') == -1){
+            this.read_only = true;
+            $('#new_notebook').addClass('hidden');
+            // unhide login button if it's relevant
+            $('span#login_widget').removeClass('hidden');
+        }else{
+            this.read_only = false;
+        }
         var len = data.length;
         // Todo: remove old children
         for (var i=0; i<len; i++) {
@@ -80,7 +89,10 @@ var IPython = (function (IPython) {
             var nbname = data[i].name;
             var item = this.new_notebook_item(i);
             this.add_link(notebook_id, nbname, item);
-            this.add_delete_button(item);
+            if (!this.read_only){
+                // hide delete buttons when readonly
+                this.add_delete_button(item);
+            }
         };
     };
 

--- a/IPython/frontend/html/notebook/static/js/notebooklist.js
+++ b/IPython/frontend/html/notebook/static/js/notebooklist.js
@@ -73,15 +73,6 @@ var IPython = (function (IPython) {
 
 
     NotebookList.prototype.list_loaded = function (data, status, xhr) {
-        var allowed = xhr.getResponseHeader('Allow');
-        if (allowed && allowed.indexOf('PUT') == -1){
-            this.read_only = true;
-            $('#new_notebook').addClass('hidden');
-            // unhide login button if it's relevant
-            $('span#login_widget').removeClass('hidden');
-        }else{
-            this.read_only = false;
-        }
         var len = data.length;
         // Todo: remove old children
         for (var i=0; i<len; i++) {
@@ -89,7 +80,7 @@ var IPython = (function (IPython) {
             var nbname = data[i].name;
             var item = this.new_notebook_item(i);
             this.add_link(notebook_id, nbname, item);
-            if (!this.read_only){
+            if (!IPython.read_only){
                 // hide delete buttons when readonly
                 this.add_delete_button(item);
             }

--- a/IPython/frontend/html/notebook/static/js/notebookmain.js
+++ b/IPython/frontend/html/notebook/static/js/notebookmain.js
@@ -33,6 +33,7 @@ $(document).ready(function () {
     IPython.left_panel = new IPython.LeftPanel('div#left_panel', 'div#left_panel_splitter');
     IPython.save_widget = new IPython.SaveWidget('span#save_widget');
     IPython.quick_help = new IPython.QuickHelp('span#quick_help_area');
+    IPython.login_widget = new IPython.LoginWidget('span#login_widget');
     IPython.print_widget = new IPython.PrintWidget('span#print_widget');
     IPython.notebook = new IPython.Notebook('div#notebook');
     IPython.kernel_status_widget = new IPython.KernelStatusWidget('#kernel_status');

--- a/IPython/frontend/html/notebook/static/js/notebookmain.js
+++ b/IPython/frontend/html/notebook/static/js/notebookmain.js
@@ -23,6 +23,7 @@ $(document).ready(function () {
         }
     });
     IPython.markdown_converter = new Markdown.Converter();
+    IPython.read_only = $('meta[name=read_only]').attr("content") == 'True';
 
     $('div#header').addClass('border-box-sizing');
     $('div#main_app').addClass('border-box-sizing ui-widget ui-widget-content');
@@ -43,6 +44,21 @@ $(document).ready(function () {
 
     // These have display: none in the css file and are made visible here to prevent FLOUC.
     $('div#header').css('display','block');
+
+    if(IPython.read_only){
+        // hide various elements from read-only view
+        IPython.save_widget.element.find('button#save_notebook').addClass('hidden');
+        IPython.quick_help.element.addClass('hidden'); // shortcuts are disabled in read_only
+        $('button#new_notebook').addClass('hidden');
+        $('div#cell_section').addClass('hidden');
+        $('div#kernel_section').addClass('hidden');
+        $('span#login_widget').removeClass('hidden');
+        // left panel starts collapsed, but the collapse must happen after
+        // elements start drawing.  Don't draw contents of the panel until
+        // after they are collapsed
+        IPython.left_panel.left_panel_element.css('visibility', 'hidden');
+    }
+
     $('div#main_app').css('display','block');
 
     // Perform these actions after the notebook has been loaded.
@@ -53,6 +69,14 @@ $(document).ready(function () {
             IPython.save_widget.update_url();
             IPython.layout_manager.do_resize();
             IPython.pager.collapse();
+            if(IPython.read_only){
+                // collapse the left panel on read-only
+                IPython.left_panel.collapse();
+                // and finally unhide the panel contents after collapse
+                setTimeout(function(){
+                    IPython.left_panel.left_panel_element.css('visibility', 'visible');
+                }, 200)
+            }
         },100);
     });
 

--- a/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
+++ b/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
@@ -27,8 +27,16 @@ $(document).ready(function () {
     $('div#left_panel').addClass('box-flex');
     $('div#right_panel').addClass('box-flex');
 
+    IPython.read_only = $('meta[name=read_only]').attr("content") == 'True';
+    
     IPython.notebook_list = new IPython.NotebookList('div#notebook_list');
     IPython.login_widget = new IPython.LoginWidget('span#login_widget');
+    
+    if (IPython.read_only){
+        $('#new_notebook').addClass('hidden');
+        // unhide login button if it's relevant
+        $('span#login_widget').removeClass('hidden');
+    }
     IPython.notebook_list.load_list();
 
     // These have display: none in the css file and are made visible here to prevent FLOUC.

--- a/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
+++ b/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
@@ -28,6 +28,7 @@ $(document).ready(function () {
     $('div#right_panel').addClass('box-flex');
 
     IPython.notebook_list = new IPython.NotebookList('div#notebook_list');
+    IPython.login_widget = new IPython.LoginWidget('span#login_widget');
     IPython.notebook_list.load_list();
 
     // These have display: none in the css file and are made visible here to prevent FLOUC.

--- a/IPython/frontend/html/notebook/static/js/textcell.js
+++ b/IPython/frontend/html/notebook/static/js/textcell.js
@@ -33,7 +33,8 @@ var IPython = (function (IPython) {
             indentUnit : 4,
             mode: this.code_mirror_mode,
             theme: 'default',
-            value: this.placeholder
+            value: this.placeholder,
+            readOnly: this.read_only,
         });
         // The tabindex=-1 makes this div focusable.
         var render_area = $('<div/>').addClass('text_cell_render').
@@ -65,6 +66,7 @@ var IPython = (function (IPython) {
 
 
     TextCell.prototype.edit = function () {
+        if ( this.read_only ) return;
         if (this.rendered === true) {
             var text_cell = this.element;
             var output = text_cell.find("div.text_cell_render");  

--- a/IPython/frontend/html/notebook/templates/login.html
+++ b/IPython/frontend/html/notebook/templates/login.html
@@ -11,6 +11,8 @@
     <link rel="stylesheet" href="static/css/layout.css" type="text/css" />
     <link rel="stylesheet" href="static/css/base.css" type="text/css" />
 
+    <meta name="read_only" content="{{read_only}}"/>
+
 </head>
 
 <body>

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -40,7 +40,8 @@
     <link rel="stylesheet" href="static/css/base.css" type="text/css" />
     <link rel="stylesheet" href="static/css/notebook.css" type="text/css" />
     <link rel="stylesheet" href="static/css/renderedhtml.css" type="text/css" />
-
+    
+    <meta name="read_only" content="{{read_only}}"/>
 
 </head>
 

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -57,7 +57,10 @@
     </span>
     <span id="quick_help_area">
       <button id="quick_help">Quick<u>H</u>elp</button>
-      </span>
+    </span>
+    <span id="login_widget" class="hidden">
+      <button id="login">Login</button>
+    </span>
     <span id="kernel_status">Idle</span>
 </div>
 
@@ -278,6 +281,7 @@
 <script src="static/js/layout.js" type="text/javascript" charset="utf-8"></script>
 <script src="static/js/savewidget.js" type="text/javascript" charset="utf-8"></script>
 <script src="static/js/quickhelp.js" type="text/javascript" charset="utf-8"></script>
+<script src="static/js/loginwidget.js" type="text/javascript" charset="utf-8"></script>
 <script src="static/js/pager.js" type="text/javascript" charset="utf-8"></script>
 <script src="static/js/panelsection.js" type="text/javascript" charset="utf-8"></script>
 <script src="static/js/printwidget.js" type="text/javascript" charset="utf-8"></script>

--- a/IPython/frontend/html/notebook/templates/projectdashboard.html
+++ b/IPython/frontend/html/notebook/templates/projectdashboard.html
@@ -19,6 +19,9 @@
 
 <div id="header">
     <span id="ipython_notebook"><h1>IPython Notebook</h1></span>
+    <span id="login_widget" class="hidden">
+      <button id="login">Login</button>
+    </span>
 </div>
 
 <div id="header_border"></div>
@@ -54,6 +57,7 @@
 <script src="static/jquery/js/jquery-ui-1.8.14.custom.min.js" type="text/javascript" charset="utf-8"></script>
 <script src="static/js/namespace.js" type="text/javascript" charset="utf-8"></script>
 <script src="static/js/notebooklist.js" type="text/javascript" charset="utf-8"></script>
+<script src="static/js/loginwidget.js" type="text/javascript" charset="utf-8"></script>
 <script src="static/js/projectdashboardmain.js" type="text/javascript" charset="utf-8"></script>
 
 </body>

--- a/IPython/frontend/html/notebook/templates/projectdashboard.html
+++ b/IPython/frontend/html/notebook/templates/projectdashboard.html
@@ -12,6 +12,8 @@
     <link rel="stylesheet" href="static/css/base.css" type="text/css" />
     <link rel="stylesheet" href="static/css/projectdashboard.css" type="text/css" />
 
+    <meta name="read_only" content="{{read_only}}"/>
+
 </head>
 
 <body data-project={{project}} data-base-project-url={{base_project_url}}


### PR DESCRIPTION
As requested by @fperez

When using a password, read-only mode allows unauthenticated users read-only access to notebooks. Editing, execution, etc. are not allowed in read-only mode (the buttons, shortcuts, etc. are removed, but the requests will raise authentication errors if they manage to send the events anyway), but save/print functions are available.

No kernels are started until an authenticated user opens a notebook.
