### PR TITLE
Cancel in qt console closeevent should trigger event.ignore()

### DIFF
--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -835,6 +835,7 @@ class MainWindow(QtGui.QMainWindow):
             reply = okay
         
         if reply == cancel:
+            event.ignore()
             return
         if reply == okay:
             while self.tab_widget.count() >= 1:
@@ -842,6 +843,5 @@ class MainWindow(QtGui.QMainWindow):
                 widget = self.active_frontend
                 widget._confirm_exit = False
                 self.close_tab(widget)
-        
-        event.accept()
+            event.accept()
 


### PR DESCRIPTION
When quitting ipython using for example the file quit option ipython quits even if you press cancel.
This pull request fixes that by inserting event.ignore() in the code the runs when cancel is pressed
and indenting the event.accept() so that it is only triggered when the yes button is pressed. 

From the qt documentation and tutorials that I could find this seems to be the right way of using closeevent.
