### PR TITLE
Start webbrowser in a thread.  Prevents lockup with Chrome.

### DIFF
--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -16,14 +16,17 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
+# stdlib
 import errno
 import logging
 import os
 import signal
 import socket
 import sys
+import threading
 import webbrowser
 
+# Third party
 import zmq
 
 # Install the pyzmq ioloop. This has to be done before anything else from
@@ -35,6 +38,7 @@ tornado.ioloop.IOLoop = ioloop.IOLoop
 from tornado import httpserver
 from tornado import web
 
+# Our own libraries
 from .kernelmanager import MappingKernelManager
 from .handlers import (LoginHandler,
     ProjectDashboardHandler, NewHandler, NamedNotebookHandler,
@@ -301,7 +305,10 @@ class NotebookApp(BaseIPythonApplication):
                                                                           self.port))
         if self.open_browser:
             ip = self.ip or '127.0.0.1'
-            webbrowser.open("%s://%s:%i" % (proto, ip, self.port), new=2)
+            b = lambda : webbrowser.open("%s://%s:%i" % (proto, ip, self.port),
+                                         new=2)
+            threading.Thread(target=b).start()
+            
         ioloop.IOLoop.instance().start()
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
If a user has Chrome set as their default browser (system-wide or via
the `BROWSER` environment variable), opening the notebook hangs
because the chrome call doesn't return immediately.  This solves the
issue by opening the browser in a thread.

Note that there remains an issue where killing the notebook will kill
Chrome if the Chrome session was started by us.  I haven't found a way
to work around that despite attempts by making the webbrowser.open()
call in a subprocess.
