### PR TITLE
add dirty trick for readline import on OSX

### DIFF
--- a/IPython/utils/rlineimpl.py
+++ b/IPython/utils/rlineimpl.py
@@ -26,7 +26,7 @@ if sys.platform == 'darwin':
     try:
         dynload_idx = sys.path.index(lib_dynload)
     except ValueError:
-        dynload_idx = -1
+        dynload_idx = None
     else:
         sys.path.pop(dynload_idx)
 try:
@@ -43,7 +43,7 @@ except ImportError:
 
 if sys.platform == 'darwin':
     # dirty trick, part II:
-    if dynload_idx != -1:
+    if dynload_idx is not None:
         # restore path
         sys.path.insert(dynload_idx, lib_dynload)
         if not have_readline:
@@ -83,6 +83,7 @@ if sys.platform == 'win32' and have_readline:
 # Test to see if libedit is being used instead of GNU readline.
 # Thanks to Boyd Waters for the original patch.
 uses_libedit = False
+
 if have_readline:
     # Official Python docs state that 'libedit' is in the docstring for libedit readline:
     uses_libedit = 'libedit' in _rl.__doc__
@@ -91,6 +92,7 @@ if have_readline:
     # known culprits of this include: EPD, Fink
     # There is not much we can do to detect this, until we find a specific failure
     # case, rather than relying on the readline module to self-identify as broken.
+
 if uses_libedit and sys.platform == 'darwin':
     _rl.parse_and_bind("bind ^I rl_complete")
     warnings.warn('\n'.join(['', "*"*78,


### PR DESCRIPTION
also made the libedit warning extremely loud, so people don't miss it.

We still get reports of people never having noticed the warning, and getting confused when readline is broken on OSX.

The libedit test is also simplified to just check `libedit in readline.__doc__`, which the official Python docs recommend, rather than the elaborate subprocess/otool method that was not especially reliable.
## The reason for the dirty trick

pip installs to site-packages by default, but site-packages dirs always come _after_ lib-dynload (and extras, etc.), which is where the system readline is installed.

That means that a non-setuptools install (pip or setup.py install) _cannot_ override any package that ships with OSX, including:
- numpy
- readline
- twisted
- pyobjc

without installing to a non-standard path (not even user site-packages via `--user`).

Note that this path issue not unique to OSX - lib-dynload, and patform packages always come before site-packages, including `--user`.  It's just that OSX seems to be the only platform where there's anything in those locations that you would actually want to supplant.
## The method for the dirty trick
1. remove lib-dynload from sys.path before trying to import readline the first time
2. after import, restore lib-dynload to its place in sys.path
3. if import failed without lib-dynload, try it one more time, to get the default module
## This doesn't solve everything

It has also come to my attention that EPD and Fink Pythons _both_ ship with broken readline (logical for EPD, given readline's license).  However, neither of these report as being anything other than GNU readline, so we can't detect that they are broken.

It's possible that we _could_ print a warning if we detect that we are in EPD and we get to step 3 without readline, but if EPD's readline ever does work, then that message would be misleading, and we would have no real way to know that the issue has been fixed.

The answer remains, in all cases (except for possibly Python.org Python and macports, only because they are untested), that the first command OSX Python users should ever do is `easy_install readline`.  Not just the System Python.  After this merge, pip _does_ work to override readline in IPython, but not anywhere else in your Python world, so the warning message does note that pip install will likely not work, even though it does within IPython.
