### PR TITLE
allow setting HistoryManager.hist_file with config

### DIFF
--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -128,7 +128,11 @@ def test_timestamp_type():
 
 def test_hist_file_config():
     cfg = Config()
-    cfg.HistoryManager.hist_file = tempfile.mktemp()
-    hm = HistoryManager(shell=get_ipython(), config=cfg)
-    nt.assert_equals(hm.hist_file, cfg.HistoryManager.hist_file)
+    tfile = tempfile.NamedTemporaryFile(delete=False)
+    cfg.HistoryManager.hist_file = tfile.name
+    try:
+        hm = HistoryManager(shell=get_ipython(), config=cfg)
+        nt.assert_equals(hm.hist_file, cfg.HistoryManager.hist_file)
+    finally:
+        os.remove(tfile.name)
 

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -8,12 +8,15 @@
 # stdlib
 import os
 import sys
+import tempfile
 import unittest
 from datetime import datetime
+
 # third party
 import nose.tools as nt
 
 # our own packages
+from IPython.config.loader import Config
 from IPython.utils.tempdir import TemporaryDirectory
 from IPython.core.history import HistoryManager, extract_hist_ranges
 from IPython.utils import py3compat
@@ -122,3 +125,10 @@ def test_timestamp_type():
     ip = get_ipython()
     info = ip.history_manager.get_session_info()
     nt.assert_true(isinstance(info[1], datetime))
+
+def test_hist_file_config():
+    cfg = Config()
+    cfg.HistoryManager.hist_file = tempfile.mktemp()
+    hm = HistoryManager(shell=get_ipython(), config=cfg)
+    nt.assert_equals(hm.hist_file, cfg.HistoryManager.hist_file)
+


### PR DESCRIPTION
fixes trait init in HistoryAccessor, which prevented setting `hist_file` via config from having any effect.

Also remove dependency on having a shell object in `HistoryAccessor.__init__`

Associated test included.

as described in #882
