### PR TITLE
Follow-up to 387dcd6a, `_rl.__doc__` is `None` with pyreadline

### DIFF
--- a/IPython/utils/rlineimpl.py
+++ b/IPython/utils/rlineimpl.py
@@ -86,7 +86,7 @@ uses_libedit = False
 
 if have_readline:
     # Official Python docs state that 'libedit' is in the docstring for libedit readline:
-    uses_libedit = 'libedit' in _rl.__doc__
+    uses_libedit = _rl.__doc__ and 'libedit' in _rl.__doc__
     # Note that many non-System Pythons also do not use proper readline,
     # but do not report libedit at all, nor are they linked dynamically against libedit.
     # known culprits of this include: EPD, Fink


### PR DESCRIPTION
Hello, I wanted to test master on Windows, but then got:

```
...
  File "IPython\core\interactiveshell.py", line 1717, in init_readline
    import IPython.utils.rlineimpl as readline
  File "IPython\utils\rlineimpl.py", line 89, in <module>
    uses_libedit = 'libedit' in _rl.__doc__
TypeError: argument of type 'NoneType' is not iterable
```

This is with pyreadline 1.7 installed.
