### PR TITLE
Monkeypatch Tornado 2.1.1 so it works with Google Chrome 16.

### DIFF
--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -35,7 +35,7 @@ except ImportError:
     publish_string = None
 
 #-----------------------------------------------------------------------------
-# Monkeypatch for Tornado 2.1.1 - Remove when no longer necessary!
+# Monkeypatch for Tornado <= 2.1.1 - Remove when no longer necessary!
 #-----------------------------------------------------------------------------
 
 # Google Chrome, as of release 16, changed its websocket protocol number.  The
@@ -56,7 +56,7 @@ except ImportError:
 
 import tornado
 
-if tornado.version == '2.1.1':
+if tornado.version_info <= (2,1,1):
 
     def _execute(self, transforms, *args, **kwargs):
         from tornado.websocket import WebSocketProtocol8, WebSocketProtocol76


### PR DESCRIPTION
We're just applying manually a fix from Tornado itself, see for
details:

https://github.com/facebook/tornado/issues/385
https://github.com/facebook/tornado/commit/84d7b458f956727c3b0d6710

This isn't sufficient to take care of #934 completely, as we should also put out a proper websocket diagnostic message for any connection message.  But it should at least take care of users of the -dev Chrome channel in normal circumstances.

@satra, let us know if this fixes the behavior you saw on Friday; I tested with Chrome 16.... on my linux box and it does fix it for me.
