### PR TITLE
Websocket Adjustments

### DIFF
--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -144,10 +144,11 @@ class AuthenticatedHandler(web.RequestHandler):
     def ws_url(self):
         """websocket url matching the current request
         
-        turns http[s]://host[:port]/foo/bar into
-                ws[s]://host[:port]/foo/bar
+        turns http[s]://host[:port] into
+                ws[s]://host[:port]
         """
-        return self.request.headers.get('Origin').replace('http', 'ws', 1)
+        proto = self.request.protocol.replace('http', 'ws')
+        return "%s://%s" % (proto, self.request.host)
 
 
 class ProjectDashboardHandler(AuthenticatedHandler):

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -147,7 +147,6 @@ aliases.update({
     'port': 'NotebookApp.port',
     'keyfile': 'NotebookApp.keyfile',
     'certfile': 'NotebookApp.certfile',
-    'ws-hostname': 'NotebookApp.ws_hostname',
     'notebook-dir': 'NotebookManager.notebook_dir',
 })
 
@@ -155,7 +154,7 @@ aliases.update({
 # multi-kernel evironment:
 aliases.pop('f', None)
 
-notebook_aliases = [u'port', u'ip', u'keyfile', u'certfile', u'ws-hostname',
+notebook_aliases = [u'port', u'ip', u'keyfile', u'certfile',
                     u'notebook-dir']
 
 #-----------------------------------------------------------------------------
@@ -200,13 +199,6 @@ class NotebookApp(BaseIPythonApplication):
         help="The port the notebook server will listen on."
     )
 
-    ws_hostname = Unicode(LOCALHOST, config=True,
-        help="""The FQDN or IP for WebSocket connections. The default will work
-                fine when the server is listening on localhost, but this needs to
-                be set if the ip option is used. It will be used as the hostname part
-                of the WebSocket url: ws://hostname/path."""
-    )
-
     certfile = Unicode(u'', config=True, 
         help="""The full path to an SSL/TLS certificate file."""
     )
@@ -225,14 +217,6 @@ class NotebookApp(BaseIPythonApplication):
     read_only = Bool(False, config=True,
         help="Whether to prevent editing/execution of notebooks."
     )
-
-    def get_ws_url(self):
-        """Return the WebSocket URL for this server."""
-        if self.certfile:
-            prefix = u'wss://'
-        else:
-            prefix = u'ws://'
-        return prefix + self.ws_hostname + u':' + unicode(self.port)
 
     def parse_command_line(self, argv=None):
         super(NotebookApp, self).parse_command_line(argv)

--- a/IPython/frontend/html/notebook/static/js/kernel.js
+++ b/IPython/frontend/html/notebook/static/js/kernel.js
@@ -87,6 +87,34 @@ var IPython = (function (IPython) {
         IPython.kernel_status_widget.status_idle();
     };
 
+    Kernel.prototype._websocket_closed = function(ws_url, early){
+        var msg;
+        var parent_item = $('body');
+        if (early) {
+            msg = "Websocket connection to " + ws_url + " could not be established.<br/>" +
+            " You will NOT be able to run code.<br/>" +
+            " Your browser may not be compatible with the websocket version in the server," +
+            " or if the url does not look right, there could be an error in the" +
+            " server's configuration."
+        } else {
+            msg = "Websocket connection closed unexpectedly.<br/>" +
+            " The kernel will no longer be responsive."
+        }
+        var dialog = $('<div/>');
+        dialog.html(msg);
+        parent_item.append(dialog);
+        dialog.dialog({
+            resizable: false,
+            modal: true,
+            title: "Websocket closed",
+            buttons : {
+                "Okay": function () {
+                    $(this).dialog('close');
+                }
+            }
+        });
+        
+    }
 
     Kernel.prototype.start_channels = function () {
         var that = this;
@@ -105,11 +133,7 @@ var IPython = (function (IPython) {
             }
             already_called_onclose = true;
             if ( ! evt.wasClean ){
-                alert("Websocket connection to " + ws_url + " could not be established." +
-                " You will not be able to run code." +
-                " Your browser may not be compatible with the websocket version in the server," +
-                " or if the url does not look right, there could be an error in the" +
-                " server's configuration.");
+                that._websocket_closed(ws_url, true);
             }
         }
         ws_closed_late = function(evt){
@@ -118,8 +142,7 @@ var IPython = (function (IPython) {
             }
             already_called_onclose = true;
             if ( ! evt.wasClean ){
-                alert("Websocket connection has closed unexpectedly." +
-                " The kernel will no longer be responsive.");
+                that._websocket_closed(ws_url, false);
             }
         }
         this.shell_channel.onopen = send_cookie;


### PR DESCRIPTION
Two principal changes:
1. alert client on failed and lost web socket connections

A long message is given if the connection fails within 1s, which assumes the connection did not succeed. Otherwise, it is a short 'connection closed unexpectedly'.

This also means that clients are notified on server termination (for better or worse).
1. remove superfluous ws-hostname parameter from notebook

This made the notebook server artificially and unnecessarily brittle against tunneling and explicit hostname resolution.  Now, the ws_url is defined based on the Origin of the request for the url, so it always matches the http[s] url.  This means that it will follow the same tunnel, and the hostname will be already resolved.  Resolving the hostname twice makes no sense at all unless the websockets are going to a different server than the http requests.

Implemented as a property, so it should still be easy to change for future cases where it might behave differently (e.g. websockets on a different host, or at a non-root url).

This is one approach to closing #952, but there might be better ways to do it (e.g. dialogs that are not base `alert` calls, which block window interaction).
