### PR TITLE
Generate "All magics..." menu live

### DIFF
--- a/IPython/frontend/qt/console/frontend_widget.py
+++ b/IPython/frontend/qt/console/frontend_widget.py
@@ -316,11 +316,25 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
     def _silent_exec_callback(self, expr, callback):
         """Silently execute `expr` in the kernel and call `callback` with reply
 
-        `expr` : valid string to be executed by the kernel.
-        `callback` : function accepting one string as argument.
+        the `expr` is evaluated silently in the kernel (without) output in
+        the frontend. Call `callback` with the
+        `repr <http://docs.python.org/library/functions.html#repr> `_ as first argument
+
+        Parameters
+        ----------
+        expr : string
+            valid string to be executed by the kernel.
+        callback : function
+            function accepting one arguement, as a string. The string will be
+            the `repr` of the result of evaluating `expr`
 
         The `callback` is called with the 'repr()' of the result of `expr` as
-        first argument. To get the object, do 'eval()' on the passed value.
+        first argument. To get the object, do 'eval()' onthe passed value.
+
+        See Also
+        --------
+        _handle_exec_callback : private method, deal with calling callback with reply
+
         """
 
         # generate uuid, which would be used as a indication of wether or not
@@ -334,23 +348,26 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
     def _handle_exec_callback(self, msg):
         """Execute `callback` corresonding to `msg` reply, after ``_silent_exec_callback``
 
-        `msg` : raw message send by the kernel containing an `user_expressions`
+        Parameters
+        ----------
+        msg : raw message send by the kernel containing an `user_expressions`
                 and having a 'silent_exec_callback' kind.
 
+        Notes
+        -----
         This fonction will look for a `callback` associated with the
         corresponding message id. Association has been made by
-        ``_silent_exec_callback``. `callback`is then called with the `repr()`
+        `_silent_exec_callback`. `callback` is then called with the `repr()`
         of the value of corresponding `user_expressions` as argument.
         `callback` is then removed from the known list so that any message
         coming again with the same id won't trigger it.
+
         """
 
-        cnt = msg['content']
-        ue = cnt['user_expressions']
-        for i in ue.keys():
-            if i in self._callback_dict:
-                self._callback_dict[i](ue[i])
-                self._callback_dict.pop(i)
+        user_exp = msg['content']['user_expressions']
+        for expression in user_exp:
+            if expression in self._callback_dict:
+                self._callback_dict.pop(expression)(user_exp[expression])
 
     def _handle_execute_reply(self, msg):
         """ Handles replies for code execution.

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -547,15 +547,23 @@ class MainWindow(QtGui.QMainWindow):
     def update_all_magic_menu(self):
         # first define a callback which will get the list of all magic and put it in the menu.
         def populate_all_magic_menu(val=None):
-            alm_magic_menu = self.magic_menu.addMenu("&All Magics...")
+            alm_magic_menu = self.all_magic_menu
+            alm_magic_menu.clear()
             def make_dynamic_magic(i):
                     def inner_dynamic_magic():
                         self.active_frontend.execute(i)
                     inner_dynamic_magic.__name__ = "dynamics_magic_s"
                     return inner_dynamic_magic
 
+            # list of protected magic that don't like to be called without argument
+            # append '?' to the end to print the docstring when called from the menu
+            protected_magic= ["more","less","load_ext","pycat"]
+
             for magic in eval(val):
-                pmagic = '%s%s'%('%',magic)
+                if magic in protected_magic:
+                    pmagic = '%s%s%s'%('%',magic,'?')
+                else:
+                    pmagic = '%s%s'%('%',magic)
                 xaction = QtGui.QAction(pmagic,
                     self,
                     triggered=make_dynamic_magic(pmagic)
@@ -566,12 +574,13 @@ class MainWindow(QtGui.QMainWindow):
     def init_magic_menu(self):
         self.magic_menu = self.menuBar().addMenu("&Magic")
         self.all_magic_menu = self.magic_menu.addMenu("&All Magics")
-        
-        self.pop = QtGui.QAction("&Populate All Magic Menu",
+
+        # this action should not appear as it will be cleard when menu
+        # will be updated at first kernel response.
+        self.pop = QtGui.QAction("&Update All Magic Menu ",
             self,
-            statusTip="Clear all varible from workspace",
             triggered=self.update_all_magic_menu)
-        self.add_menu_action(self.magic_menu, self.pop)
+        self.add_menu_action(self.all_magic_menu, self.pop)
 
         self.reset_action = QtGui.QAction("&Reset",
             self,
@@ -609,33 +618,6 @@ class MainWindow(QtGui.QMainWindow):
             triggered=self.whos_magic_active_frontend)
         self.add_menu_action(self.magic_menu, self.whos_action)
         
-        # allmagics submenu:
-        
-        #for now this is just a copy and paste, but we should get this dynamically
-        magiclist=["%alias", "%autocall", "%automagic", "%bookmark", "%cd", "%clear",
-            "%colors", "%debug", "%dhist", "%dirs", "%doctest_mode", "%ed", "%edit", "%env", "%gui",
-            "%guiref", "%hist", "%history", "%install_default_config", "%install_profiles",
-            "%less", "%load_ext", "%loadpy", "%logoff", "%logon", "%logstart", "%logstate",
-            "%logstop", "%lsmagic", "%macro", "%magic", "%man", "%more", "%notebook", "%page",
-            "%pastebin", "%pdb", "%pdef", "%pdoc", "%pfile", "%pinfo", "%pinfo2", "%popd", "%pprint",
-            "%precision", "%profile", "%prun", "%psearch", "%psource", "%pushd", "%pwd", "%pycat",
-            "%pylab", "%quickref", "%recall", "%rehashx", "%reload_ext", "%rep", "%rerun",
-            "%reset", "%reset_selective", "%run", "%save", "%sc", "%sx", "%tb", "%time", "%timeit",
-            "%unalias", "%unload_ext", "%who", "%who_ls", "%whos", "%xdel", "%xmode"]
-
-        def make_dynamic_magic(i):
-                def inner_dynamic_magic():
-                    self.active_frontend.execute(i)
-                inner_dynamic_magic.__name__ = "dynamics_magic_%s" % i
-                return inner_dynamic_magic
-
-        for magic in magiclist:
-            xaction = QtGui.QAction(magic,
-                self,
-                triggered=make_dynamic_magic(magic)
-                )
-            self.all_magic_menu.addAction(xaction)
-    
     def init_window_menu(self):
         self.window_menu = self.menuBar().addMenu("&Window")
         if sys.platform == 'darwin':

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -20,6 +20,7 @@ Authors:
 
 # stdlib imports
 import sys
+import re
 import webbrowser
 from threading import Thread
 
@@ -547,10 +548,23 @@ class MainWindow(QtGui.QMainWindow):
     def _make_dynamic_magic(self,magic):
         """Return a function `fun` that will execute `magic` on active frontend.
 
-        `magic` : valid python string
+        Parameters
+        ----------
+        magic : string
+            string that will be executed as is when the returned function is called
 
-        return `fun`, function with no parameters
+        Returns
+        -------
+        fun : function
+            function with no parameters, when called will execute `magic` on the
+            current active frontend at call time
 
+        See Also
+        --------
+        populate_all_magic_menu : generate the "All Magics..." menu
+
+        Notes
+        -----
         `fun` execute `magic` an active frontend at the moment it is triggerd,
         not the active frontend at the moment it has been created.
 
@@ -566,8 +580,13 @@ class MainWindow(QtGui.QMainWindow):
     def populate_all_magic_menu(self, listofmagic=None):
         """Clean "All Magics..." menu and repopulate it with `listofmagic`
 
-        `listofmagic` : string, repr() of a list of strings.
+        Parameters
+        ----------
+        listofmagic : string,
+            repr() of a list of strings, send back by the kernel
 
+        Notes
+        -----
         `listofmagic`is a repr() of list because it is fed with the result of
         a 'user_expression'
         """
@@ -577,8 +596,8 @@ class MainWindow(QtGui.QMainWindow):
         # list of protected magic that don't like to be called without argument
         # append '?' to the end to print the docstring when called from the menu
         protected_magic = set(["more","less","load_ext","pycat","loadpy","save"])
-
-        for magic in eval(listofmagic):
+        magics=re.findall('\w+', listofmagic)
+        for magic in magics:
             if magic in protected_magic:
                 pmagic = '%s%s%s'%('%',magic,'?')
             else:
@@ -590,8 +609,14 @@ class MainWindow(QtGui.QMainWindow):
             alm_magic_menu.addAction(xaction)
 
     def update_all_magic_menu(self):
+        """ Update the list on magic in the "All Magics..." Menu
+
+        Request the kernel with the list of availlable magic and populate the
+        menu with the list received back
+
+        """
         # first define a callback which will get the list of all magic and put it in the menu.
-        self.active_frontend._silent_exec_callback('get_ipython().lsmagic()',self.populate_all_magic_menu)
+        self.active_frontend._silent_exec_callback('get_ipython().lsmagic()', self.populate_all_magic_menu)
 
     def init_magic_menu(self):
         self.magic_menu = self.menuBar().addMenu("&Magic")
@@ -638,7 +663,7 @@ class MainWindow(QtGui.QMainWindow):
             statusTip="List interactive variable with detail",
             triggered=self.whos_magic_active_frontend)
         self.add_menu_action(self.magic_menu, self.whos_action)
-        
+
     def init_window_menu(self):
         self.window_menu = self.menuBar().addMenu("&Window")
         if sys.platform == 'darwin':

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -557,7 +557,7 @@ class MainWindow(QtGui.QMainWindow):
 
             # list of protected magic that don't like to be called without argument
             # append '?' to the end to print the docstring when called from the menu
-            protected_magic= ["more","less","load_ext","pycat"]
+            protected_magic= ["more","less","load_ext","pycat","loadpy","save"]
 
             for magic in eval(val):
                 if magic in protected_magic:

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -544,10 +544,35 @@ class MainWindow(QtGui.QMainWindow):
 
         self.kernel_menu.addSeparator()
 
+    def update_all_magic_menu(self):
+        # first define a callback which will get the list of all magic and put it in the menu.
+        def populate_all_magic_menu(val=None):
+            alm_magic_menu = self.magic_menu.addMenu("&All Magics...")
+            def make_dynamic_magic(i):
+                    def inner_dynamic_magic():
+                        self.active_frontend.execute(i)
+                    inner_dynamic_magic.__name__ = "dynamics_magic_s"
+                    return inner_dynamic_magic
+
+            for magic in eval(val):
+                pmagic = '%s%s'%('%',magic)
+                xaction = QtGui.QAction(pmagic,
+                    self,
+                    triggered=make_dynamic_magic(pmagic)
+                    )
+                alm_magic_menu.addAction(xaction)
+        self.active_frontend._silent_exec_callback('get_ipython().lsmagic()',populate_all_magic_menu)
+
     def init_magic_menu(self):
         self.magic_menu = self.menuBar().addMenu("&Magic")
         self.all_magic_menu = self.magic_menu.addMenu("&All Magics")
         
+        self.pop = QtGui.QAction("&Populate All Magic Menu",
+            self,
+            statusTip="Clear all varible from workspace",
+            triggered=self.update_all_magic_menu)
+        self.add_menu_action(self.magic_menu, self.pop)
+
         self.reset_action = QtGui.QAction("&Reset",
             self,
             statusTip="Clear all varible from workspace",

--- a/IPython/frontend/qt/console/qtconsoleapp.py
+++ b/IPython/frontend/qt/console/qtconsoleapp.py
@@ -452,7 +452,7 @@ class IPythonQtConsoleApp(BaseIPythonApplication):
         self.window.add_tab_with_frontend(self.widget)
         self.window.init_menu_bar()
 
-        #we need to populate the 'Magic Menu' once the kernel has answer at least once
+        # we need to populate the 'Magic Menu' once the kernel has answer at least once
         self.kernel_manager.shell_channel.first_reply.connect(self.window.pop.trigger)
 
         self.window.setWindowTitle('Python' if self.pure else 'IPython')

--- a/IPython/frontend/qt/console/qtconsoleapp.py
+++ b/IPython/frontend/qt/console/qtconsoleapp.py
@@ -451,6 +451,10 @@ class IPythonQtConsoleApp(BaseIPythonApplication):
         self.window.log = self.log
         self.window.add_tab_with_frontend(self.widget)
         self.window.init_menu_bar()
+
+        #we need to populate the 'Magic Menu' once the kernel has answer at least once
+        self.kernel_manager.shell_channel.first_reply.connect(self.window.pop.trigger)
+
         self.window.setWindowTitle('Python' if self.pure else 'IPython')
 
     def init_colors(self):


### PR DESCRIPTION
Hi everyone, 

I'm trying to catch up with the merging of the qtconsole. For now constructing the "all magic menu" by querying the kernel about `get_ipython().lsmagic()` through `user_expressions`. I thought it might be a good idea. 

It does work as long as the action is not automatically done at startup, otherwise there is no prompt.
( try adding :`self.window.pop.trigger()` just before `self.app._exec()` in `qtconsole.py` )
You can trigger the action by hand through the `Magics > Populate All Magic Menu` Menu, which create a second `All Magics` Menu.

I don't know why, it's not working at startup, and i'm not sure adding a timer to execute this action later is a good idea.
I was also thinking of updating at each new prompt, or every time the user click on `Magic` Menu.

If can get a little help on this ... 

Otherwise, still not 100% back, still digging in my backups to recover some data, but will do my best.
--
Matthias
