### PR TITLE
allow change of png DPI in inline backend

### DIFF
--- a/IPython/lib/pylabtools.py
+++ b/IPython/lib/pylabtools.py
@@ -100,9 +100,7 @@ def print_figure(fig, fmt='png'):
     fig.set_edgecolor('white')
     try:
         bytes_io = BytesIO()
-        # use 72 dpi to match QTConsole's dpi
-        fig.canvas.print_figure(bytes_io, format=fmt, dpi=72,
-                                bbox_inches='tight')
+        fig.canvas.print_figure(bytes_io, format=fmt, bbox_inches='tight')
         data = bytes_io.getvalue()
     finally:
         fig.set_facecolor(fc)

--- a/IPython/zmq/pylab/backend_inline.py
+++ b/IPython/zmq/pylab/backend_inline.py
@@ -38,18 +38,20 @@ class InlineBackend(InlineBackendConfig):
 
     # The typical default figure size is too large for inline use,
     # so we shrink the figure size to 6x4, and tweak fonts to
-    # make that fit.  This is configurable via Global.pylab_inline_rc,
-    # or rather it will be once the zmq kernel is hooked up to
-    # the config system.
+    # make that fit.
     rc = Dict({'figure.figsize': (6.0,4.0),
         # 12pt labels get cutoff on 6x4 logplots, so use 10pt.
         'font.size': 10,
+        # 72 dpi matches SVG/qtconsole
+        # this only affects PNG export, as SVG has no dpi setting
+        'savefig.dpi': 72,
         # 10pt still needs a little more room on the xlabel:
         'figure.subplot.bottom' : .125
         }, config=True,
         help="""Subset of matplotlib rcParams that should be different for the
         inline backend."""
     )
+
     figure_format = CaselessStrEnum(['svg', 'png'], default_value='png', config=True,
         help="The image format for figures with the inline backend.")
 


### PR DESCRIPTION
This moves setting the DPI to the rcParams initialization,
so that it can be changed later by the user, setting
`rcParams['savefig.figsize']`.

DPI has no effect on SVG figures, so any other value will result in
mismatch between svg and png figures.  There is already a mismatch in the notebook, where 72 is not the right answer.
