### PR TITLE
disable calltips in PySide < 1.0.7 to prevent segfault

### DIFF
--- a/IPython/frontend/qt/console/frontend_widget.py
+++ b/IPython/frontend/qt/console/frontend_widget.py
@@ -7,6 +7,7 @@ import time
 
 # System library imports
 from pygments.lexers import PythonLexer
+from IPython.external import qt
 from IPython.external.qt import QtCore, QtGui
 
 # Local imports
@@ -118,6 +119,11 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
 
     def __init__(self, *args, **kw):
         super(FrontendWidget, self).__init__(*args, **kw)
+        # forcefully disable calltips if PySide is < 1.0.7, because they crash
+        if qt.QT_API == qt.QT_API_PYSIDE:
+            import PySide
+            if PySide.__version_info__ < (1,0,7):
+                self.enable_calltips = False
 
         # FrontendWidget protected variables.
         self._bracket_matcher = BracketMatcher(self._control)

--- a/IPython/frontend/qt/console/frontend_widget.py
+++ b/IPython/frontend/qt/console/frontend_widget.py
@@ -119,10 +119,12 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
 
     def __init__(self, *args, **kw):
         super(FrontendWidget, self).__init__(*args, **kw)
+        # FIXME: remove this when PySide min version is updated past 1.0.7
         # forcefully disable calltips if PySide is < 1.0.7, because they crash
         if qt.QT_API == qt.QT_API_PYSIDE:
             import PySide
             if PySide.__version_info__ < (1,0,7):
+                self.log.warn("PySide %s < 1.0.7 detected, disabling calltips" % PySide.__version__)
                 self.enable_calltips = False
 
         # FrontendWidget protected variables.


### PR DESCRIPTION
PySide bug caused segfault when `QApplication.topLevelAt(pos)` should return `None`, has been fixed in PySide 1.0.7.

We only call this method in the calltip widget (by _far_ the biggest cause of crashes in the qtconsole), but if we want to call it anywhere else, we should probably just bump the PySide version dependency to 1.0.7 in external.qt.
