### PR TITLE
add wantDirectory to ipdoctest, so that directories will be checked for e

### DIFF
--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -737,6 +737,17 @@ class ExtensionDoctest(doctests.Doctest):
         else:
             return doctests.Doctest.wantFile(self,filename)
 
+    def wantDirectory(self, directory):
+        """Return whether the given directory should be scanned for tests.
+
+        Modified version that supports exclusions.
+        """
+
+        for pat in self.exclude_patterns:
+            if pat.search(directory):
+                return False
+        return True
+
 
 class IPythonDoctest(ExtensionDoctest):
     """Nose Plugin that supports doctests in extension modules.


### PR DESCRIPTION
add wantDirectory to ipdoctest, so that directories will be checked for exclusion

This prevents ImportErrors raised in `__init__` checks from causing a failure when they should have been excluded.

closes gh-918
