### PR TITLE
use system_raw in terminal, even on Windows

### DIFF
--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -112,11 +112,9 @@ class TerminalInteractiveShell(InteractiveShell):
             config=config, profile_dir=profile_dir, user_ns=user_ns,
             user_global_ns=user_global_ns, custom_exceptions=custom_exceptions
         )
-        # use os.system instead of utils.process.system by default, except on Windows
-        if os.name == 'nt':
-            self.system = self.system_piped
-        else:
-            self.system = self.system_raw
+        # use os.system instead of utils.process.system by default,
+        # because piped system doesn't make sense in the Terminal:
+        self.system = self.system_raw
 
         self.init_term_title()
         self.init_usage(usage)


### PR DESCRIPTION
`system_raw` uses `os.system` instead of `utils.process.system`, and makes
more sense in a Terminal session.

There was discussion that it should be otherwise on Windows, but I can't
find any actual reason as to why this would be the case, and there are very
clear disadvantages to not using `os.system` (see #978 and #181).

If someone can actually remember the case for not using os.system, then we can ignore this, but
I can't think of a case where os.system doesn't perform at least as well.

closes gh-978
