### PR TITLE
Do not expose variables defined at startup to %who etc.

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -180,6 +180,9 @@ class InteractiveShellApp(Configurable):
         self._run_exec_lines()
         self._run_exec_files()
         self._run_cmd_line_code()
+        
+        # Hide variables defined here from %who etc.
+        self.shell.user_ns_hidden.update(self.shell.user_ns)
 
     def _run_exec_lines(self):
         """Run lines of code in IPythonApp.exec_lines in the user's namespace."""


### PR DESCRIPTION
See #697

This is already fixed in my usermod branch (PR #648), but since that now seems unlikely to be included before 0.12, I thought I'd close this issue separately.
