### PR TITLE
Fixes for parallel code on Python 3

### DIFF
--- a/IPython/parallel/apps/ipcontrollerapp.py
+++ b/IPython/parallel/apps/ipcontrollerapp.py
@@ -273,7 +273,7 @@ class IPControllerApp(BaseParallelApplication):
         if not self.reuse_files:
             # save to new json config files
             f = self.factory
-            cdict = {'exec_key' : f.session.key,
+            cdict = {'exec_key' : f.session.key.decode('ascii'),
                     'ssh' : self.ssh_server,
                     'url' : "%s://%s:%s"%(f.client_transport, f.client_ip, f.regport),
                     'location' : self.location

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -961,7 +961,7 @@ class CComplex(Complex):
 class Bytes(TraitType):
     """A trait for byte strings."""
 
-    default_value = ''
+    default_value = b''
     info_text = 'a string'
 
     def validate(self, obj, value):


### PR DESCRIPTION
Just a couple of minor fixes. Annoyingly, the parallel test suite now hangs (before it just failed) - but doing a basic example using ipcluster3 worked.
