### PR TITLE
Add Tooltip to notebook.

### DIFF
--- a/IPython/frontend/html/notebook/static/css/notebook.css
+++ b/IPython/frontend/html/notebook/static/css/notebook.css
@@ -321,7 +321,7 @@ div.text_cell_render {
 .ansigrey {color: grey;}
 .ansibold {font-weight: bold;}
 
-.completions {
+.completions , .tooltip{
     position: absolute;
     z-index: 10;
     overflow: auto;
@@ -333,6 +333,36 @@ div.text_cell_render {
     outline: none;
     border: none;
     padding: 0px;
+    margin: 0px;
+    font-family: monospace;
+}
+
+@-moz-keyframes fadeIn {
+    from {opacity:0;}
+    to {opacity:1;}
+}
+
+@-webkit-keyframes fadeIn {
+    from {opacity:0;}
+    to {opacity:1;}
+}
+
+@keyframes fadeIn {
+    from {opacity:0;}
+    to {opacity:1;}
+}
+
+
+.tooltip{
+	border-radius: 0px 10px 10px 10px;
+    box-shadow: 3px 3px 5px #999;
+    -webkit-animation: fadeIn 200ms;
+    -moz-animation: fadeIn 200ms;
+    animation: fadeIn 200ms;
+    vertical-align: middle;
+    background: #FDFDD8;
+    outline: none;
+    padding: 3px;
     margin: 0px;
     font-family: monospace;
 }

--- a/IPython/frontend/html/notebook/static/css/notebook.css
+++ b/IPython/frontend/html/notebook/static/css/notebook.css
@@ -366,7 +366,7 @@ div.text_cell_render {
 
 /*"close" "expand" and "Open in pager button" of
 /* the tooltip*/
-.tooltip button{
+.tooltip a{
     float:right;
 }
 

--- a/IPython/frontend/html/notebook/static/css/notebook.css
+++ b/IPython/frontend/html/notebook/static/css/notebook.css
@@ -115,6 +115,10 @@ span.section_row_buttons a {
     float: right;
 }
 
+#tooltipontab_span {
+    float: right;
+}
+
 .checkbox_label {
     font-size: 85%;
     float: right;

--- a/IPython/frontend/html/notebook/static/css/notebook.css
+++ b/IPython/frontend/html/notebook/static/css/notebook.css
@@ -119,6 +119,10 @@ span.section_row_buttons a {
     float: right;
 }
 
+#smartcompleter_span {
+    float: right;
+}
+
 .checkbox_label {
     font-size: 85%;
     float: right;

--- a/IPython/frontend/html/notebook/static/css/notebook.css
+++ b/IPython/frontend/html/notebook/static/css/notebook.css
@@ -364,10 +364,36 @@ div.text_cell_render {
     to {opacity:1;}
 }
 
+/*"close" "expand" and "Open in pager button" of
+/* the tooltip*/
+.tooltip button{
+    float:right;
+}
+
+/*properties of tooltip after "expand"*/
+.bigtooltip{
+    height:420px;
+}
+
+/*properties of tooltip before "expand"*/
+.smalltooltip{
+    text-overflow: ellipsis;
+    overflow: hidden;
+    height:100px;
+}
 
 .tooltip{
-	border-radius: 0px 10px 10px 10px;
+    /*transition when "expand"ing tooltip */
+    -webkit-transition-property: height;
+    -webkit-transition-duration: 1s;
+    -moz-transition-property: height;
+    -moz-transition-duration: 1s;
+    transition-property: height;
+    transition-duration: 1s;
+    max-width:700px;
+    border-radius: 0px 10px 10px 10px;
     box-shadow: 3px 3px 5px #999;
+    /*fade-in animation when inserted*/
     -webkit-animation: fadeIn 200ms;
     -moz-animation: fadeIn 200ms;
     animation: fadeIn 200ms;

--- a/IPython/frontend/html/notebook/static/css/notebook.css
+++ b/IPython/frontend/html/notebook/static/css/notebook.css
@@ -372,14 +372,14 @@ div.text_cell_render {
 
 /*properties of tooltip after "expand"*/
 .bigtooltip{
-    height:420px;
+    height:60%;
 }
 
 /*properties of tooltip before "expand"*/
 .smalltooltip{
     text-overflow: ellipsis;
     overflow: hidden;
-    height:100px;
+    height:15%;
 }
 
 .tooltip{
@@ -403,6 +403,7 @@ div.text_cell_render {
     padding: 3px;
     margin: 0px;
     font-family: monospace;
+    min-height:50px;
 }
 
 @media print {

--- a/IPython/frontend/html/notebook/static/css/notebook.css
+++ b/IPython/frontend/html/notebook/static/css/notebook.css
@@ -115,6 +115,10 @@ span.section_row_buttons a {
     float: right;
 }
 
+#timebeforetooltip_span {
+    float: right;
+}
+
 #tooltipontab_span {
     float: right;
 }

--- a/IPython/frontend/html/notebook/static/js/cell.js
+++ b/IPython/frontend/html/notebook/static/js/cell.js
@@ -85,7 +85,6 @@ var IPython = (function (IPython) {
         }
     };
 
-
     // Subclasses must implement create_element.
     Cell.prototype.create_element = function () {};
 

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -64,8 +64,11 @@ var IPython = (function (IPython) {
         // handlers and is used to provide custom key handling. Its return
         // value is used to determine if CodeMirror should ignore the event:
         // true = ignore, false = don't ignore.
-        tooltip_wait_time = 2000;
 
+        // note that we are comparing and setting the time to wait at each key press.
+        // a better wqy might be to generate a new function on each time change and
+        // assign it to CodeCell.prototype.request_tooltip_after_time
+        tooltip_wait_time = this.notebook.time_before_tooltip;
         tooltip_on_tab    = this.notebook.tooltip_on_tab;
         var that = this;
 

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -156,6 +156,7 @@ var IPython = (function (IPython) {
     CodeCell.prototype.finish_tooltip = function (reply) {
         defstring=reply.definition;
         docstring=reply.docstring;
+        if(docstring == null){docstring="<empty docstring>"};
         name=reply.name;
 
         var that = this;

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -71,7 +71,6 @@ var IPython = (function (IPython) {
         tooltip_wait_time = this.notebook.time_before_tooltip;
         tooltip_on_tab    = this.notebook.tooltip_on_tab;
         var that = this;
-
         // whatever key is pressed, first, cancel the tooltip request before
         // they are sent, and remove tooltip if any
         if(event.type === 'keydown' && this.tooltip_timeout != null){
@@ -82,7 +81,9 @@ var IPython = (function (IPython) {
         if (event.keyCode === 13 && (event.shiftKey || event.ctrlKey)) {
             // Always ignore shift-enter in CodeMirror as we handle it.
             return true;
-        }else if (event.keyCode === 53 && event.type === 'keydown' && tooltip_wait_time >= 0) {
+        }else if (event.which === 40 && event.type === 'keypress' && tooltip_wait_time >= 0) {
+            // triger aon keypress (!) otherwise inconsistent event.which depending on plateform
+            // browser and keyboard layout !
             // Pressing '(' , request tooltip, don't forget to reappend it
             var cursor = editor.getCursor();
             var pre_cursor = editor.getRange({line:cursor.line,ch:0},cursor).trim()+'(';

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -65,7 +65,8 @@ var IPython = (function (IPython) {
         // value is used to determine if CodeMirror should ignore the event:
         // true = ignore, false = don't ignore.
         tooltip_wait_time = 2000;
-        tooltip_on_tab    = true;
+
+        tooltip_on_tab    = this.notebook.tooltip_on_tab;
         var that = this;
 
         // whatever key is pressed, first, cancel the tooltip request before
@@ -79,9 +80,9 @@ var IPython = (function (IPython) {
             // Always ignore shift-enter in CodeMirror as we handle it.
             return true;
         }else if (event.keyCode === 53 && event.type === 'keydown' && tooltip_wait_time >= 0) {
-            // Pressing '(' , request tooltip
+            // Pressing '(' , request tooltip, don't forget to reappend it
             var cursor = editor.getCursor();
-            var pre_cursor = editor.getRange({line:cursor.line,ch:0},cursor).trim();
+            var pre_cursor = editor.getRange({line:cursor.line,ch:0},cursor).trim()+'(';
             CodeCell.prototype.request_tooltip_after_time(pre_cursor,tooltip_wait_time,that);
         } else if (event.keyCode === 9 && event.type == 'keydown') {
             // Tab completion.
@@ -92,7 +93,7 @@ var IPython = (function (IPython) {
                 // Don't autocomplete if the part of the line before the cursor
                 // is empty.  In this case, let CodeMirror handle indentation.
                 return false;
-            } else if (pre_cursor.substr(-1) === "(" && tooltip_on_tab ) {
+            } else if ((pre_cursor.substr(-1) === "("|| pre_cursor.substr(-1) === " ") && tooltip_on_tab ) {
                 CodeCell.prototype.request_tooltip_after_time(pre_cursor,0,that);
             } else {
                 pre_cursor.trim();

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -179,6 +179,19 @@ var IPython = (function (IPython) {
 
     CodeCell.prototype.finish_completing = function (matched_text, matches) {
         // console.log("Got matches", matched_text, matches);
+        var newm = new Array();
+        if(this.notebook.smart_completer)
+        {
+            kwargs = new Array();
+            other = new Array();
+            for(var i=0;i<matches.length; ++i){
+                if(matches[i].substr(-1) === '='){
+                    kwargs.push(matches[i]);
+                }else{other.push(matches[i]);}
+            }
+            newm = kwargs.concat(other);
+            matches=newm;
+        }
         if (!this.is_completing || matches.length === 0) {return;}
 
         var that = this;

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -163,34 +163,55 @@ var IPython = (function (IPython) {
         // remove to have the tooltip not Limited in X and Y
         tooltip.addClass('smalltooltip');
         var pre=$('<pre/>').html(utils.fixConsole(docstring));
-        var expand=$('<button/>').text('Expand...')
-        expand.attr('id','expanbutton');
-        expand.addClass('ui-button  ui-state-default ui-corner-all');
-        expand.click(function(){
+        var expandlink=$('<a/>').attr('href',"#");
+            expandlink.addClass("ui-corner-all"); //rounded corner
+            expandlink.attr('role',"button");
+            //expandlink.addClass('ui-button');
+            //expandlink.addClass('ui-state-default');
+        var expandspan=$('<span/>').text('Expand');
+            expandspan.addClass('ui-icon');
+            expandspan.addClass('ui-icon-plus');
+        expandlink.append(expandspan);
+        expandlink.attr('id','expanbutton');
+        expandlink.click(function(){
             tooltip.removeClass('smalltooltip');
             tooltip.addClass('bigtooltip');
             $('#expanbutton').remove();
             setTimeout(function(){that.code_mirror.focus();}, 50);
         });
-        var more=$('<button/>').text('Open in Pager')
-        more.addClass('ui-button  ui-state-default ui-corner-all');
-        more.click(function(){
+        var morelink=$('<a/>').attr('href',"#");
+            morelink.attr('role',"button");
+            morelink.addClass('ui-button');
+            //morelink.addClass("ui-corner-all"); //rounded corner
+            //morelink.addClass('ui-state-default');
+        var morespan=$('<span/>').text('Open in Pager');
+            morespan.addClass('ui-icon');
+            morespan.addClass('ui-icon-arrowstop-l-n');
+        morelink.append(morespan);
+        morelink.click(function(){
             var msg_id = IPython.notebook.kernel.execute(name+"?");
             IPython.notebook.msg_cell_map[msg_id] = IPython.notebook.selected_cell().cell_id;
             CodeCell.prototype.remove_and_cancell_tooltip(that.tooltip_timeout);
             setTimeout(function(){that.code_mirror.focus();}, 50);
         });
 
-        var close=$('<button/>').text('Close')
-        close.addClass('ui-button  ui-state-default ui-corner-all');
-        close.click(function(){
+        var closelink=$('<a/>').attr('href',"#");
+            closelink.attr('role',"button");
+            closelink.addClass('ui-button');
+            //closelink.addClass("ui-corner-all"); //rounded corner
+            //closelink.adClass('ui-state-default'); // grey background and blue cross
+        var closespan=$('<span/>').text('Close');
+            closespan.addClass('ui-icon');
+            closespan.addClass('ui-icon-close');
+        closelink.append(closespan);
+        closelink.click(function(){
             CodeCell.prototype.remove_and_cancell_tooltip(that.tooltip_timeout);
             setTimeout(function(){that.code_mirror.focus();}, 50);
             });
         //construct the tooltip
-        tooltip.append(close);
-        tooltip.append(more);
-        tooltip.append(expand);
+        tooltip.append(closelink);
+        tooltip.append(expandlink);
+        tooltip.append(morelink);
         if(defstring){
             defstring_html= $('<pre/>').html(utils.fixConsole(defstring));
             tooltip.append(defstring_html);

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -224,6 +224,28 @@ var IPython = (function (IPython) {
         }
         if (!this.is_completing || matches.length === 0) {return;}
 
+        //try to check if the user is typing tab at least twice after a word
+        // and completion is "done"
+        fallback_on_tooltip_after=2
+        if(matches.length==1 && matched_text === matches[0])
+        {
+            if(this.npressed >fallback_on_tooltip_after  && this.prevmatch==matched_text)
+            {
+                console.log('Ok, you really want to complete after pressing tab '+this.npressed+' times !');
+                console.log('You should undersand that there is no (more) completion for that !');
+                console.log("I'll show you the tooltip, will you stop bothering me ?");
+                this.request_tooltip_after_time(matched_text+'(',0,this);
+                return;
+            }
+            this.prevmatch=matched_text
+            this.npressed=this.npressed+1;
+        }
+        else
+        {
+            this.prevmatch="";
+            this.npressed=0;
+        }
+
         var that = this;
         var cur = this.completion_cursor;
 

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -254,7 +254,7 @@ var IPython = (function (IPython) {
             if(this.npressed >fallback_on_tooltip_after  && this.prevmatch==matched_text)
             {
                 console.log('Ok, you really want to complete after pressing tab '+this.npressed+' times !');
-                console.log('You should undersand that there is no (more) completion for that !');
+                console.log('You should understand that there is no (more) completion for that !');
                 console.log("I'll show you the tooltip, will you stop bothering me ?");
                 this.request_tooltip_after_time(matched_text+'(',0,this);
                 return;

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -157,20 +157,22 @@ var IPython = (function (IPython) {
         defstring=reply.definition;
         docstring=reply.docstring;
         name=reply.name;
-        shortened = function(string){
-            if(string.length > 200){
-                return string.trim().substring(0,197)+'...';
-            } else { return string.trim() }
-        }
 
         var that = this;
         var tooltip = $('<div/>').attr('id', 'tooltip').addClass('tooltip');
-        if(defstring){
-            defstring_html= $('<pre/>').html(utils.fixConsole(defstring));
-            tooltip.append(defstring_html);
-        }
-        var pre=$('<pre/>').html(utils.fixConsole(shortened(docstring)));
-        var more=$('<button/>').text('more...')
+        // remove to have the tooltip not Limited in X and Y
+        tooltip.addClass('smalltooltip');
+        var pre=$('<pre/>').html(utils.fixConsole(docstring));
+        var expand=$('<button/>').text('Expand...')
+        expand.attr('id','expanbutton');
+        expand.addClass('ui-button  ui-state-default ui-corner-all');
+        expand.click(function(){
+            tooltip.removeClass('smalltooltip');
+            tooltip.addClass('bigtooltip');
+            $('#expanbutton').remove();
+            setTimeout(function(){that.code_mirror.focus();}, 50);
+        });
+        var more=$('<button/>').text('Open in Pager')
         more.addClass('ui-button  ui-state-default ui-corner-all');
         more.click(function(){
             var msg_id = IPython.notebook.kernel.execute(name+"?");
@@ -179,14 +181,20 @@ var IPython = (function (IPython) {
             setTimeout(function(){that.code_mirror.focus();}, 50);
         });
 
-        var close=$('<button/>').text('close')
+        var close=$('<button/>').text('Close')
         close.addClass('ui-button  ui-state-default ui-corner-all');
         close.click(function(){
             CodeCell.prototype.remove_and_cancell_tooltip(that.tooltip_timeout);
             setTimeout(function(){that.code_mirror.focus();}, 50);
             });
-        pre.append(more);
-        pre.append(close);
+        //construct the tooltip
+        tooltip.append(close);
+        tooltip.append(more);
+        tooltip.append(expand);
+        if(defstring){
+            defstring_html= $('<pre/>').html(utils.fixConsole(defstring));
+            tooltip.append(defstring_html);
+        }
         tooltip.append(pre);
         var pos = this.code_mirror.cursorCoords();
         tooltip.css('left',pos.x+'px');

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -153,7 +153,10 @@ var IPython = (function (IPython) {
         $('#tooltip').remove();
     }
 
-    CodeCell.prototype.finish_tooltip = function (defstring,docstring) {
+    CodeCell.prototype.finish_tooltip = function (reply) {
+        defstring=reply.definition;
+        docstring=reply.docstring;
+        name=reply.name;
         shortened = function(string){
             if(string.length > 200){
                 return string.trim().substring(0,197)+'...';
@@ -166,7 +169,25 @@ var IPython = (function (IPython) {
             defstring_html= $('<pre/>').html(utils.fixConsole(defstring));
             tooltip.append(defstring_html);
         }
-        tooltip.append($('<pre/>').html(utils.fixConsole(shortened(docstring))));
+        var pre=$('<pre/>').html(utils.fixConsole(shortened(docstring)));
+        var more=$('<button/>').text('more...')
+        more.addClass('ui-button  ui-state-default ui-corner-all');
+        more.click(function(){
+            var msg_id = IPython.notebook.kernel.execute(name+"?");
+            IPython.notebook.msg_cell_map[msg_id] = IPython.notebook.selected_cell().cell_id;
+            CodeCell.prototype.remove_and_cancell_tooltip(that.tooltip_timeout);
+            setTimeout(function(){that.code_mirror.focus();}, 50);
+        });
+
+        var close=$('<button/>').text('close')
+        close.addClass('ui-button  ui-state-default ui-corner-all');
+        close.click(function(){
+            CodeCell.prototype.remove_and_cancell_tooltip(that.tooltip_timeout);
+            setTimeout(function(){that.code_mirror.focus();}, 50);
+            });
+        pre.append(more);
+        pre.append(close);
+        tooltip.append(pre);
         var pos = this.code_mirror.cursorCoords();
         tooltip.css('left',pos.x+'px');
         tooltip.css('top',pos.yBot+'px');

--- a/IPython/frontend/html/notebook/static/js/kernel.js
+++ b/IPython/frontend/html/notebook/static/js/kernel.js
@@ -170,6 +170,15 @@ var IPython = (function (IPython) {
         };
     };
 
+    Kernel.prototype.object_info_request = function (objname) {
+        var content = {
+            oname : objname.toString(),
+        };
+        var msg = this.get_msg("object_info_request", content);
+        this.shell_channel.send(JSON.stringify(msg));
+        return msg.header.msg_id;
+    }
+
     Kernel.prototype.execute = function (code) {
         var content = {
             code : code,

--- a/IPython/frontend/html/notebook/static/js/kernel.js
+++ b/IPython/frontend/html/notebook/static/js/kernel.js
@@ -171,12 +171,16 @@ var IPython = (function (IPython) {
     };
 
     Kernel.prototype.object_info_request = function (objname) {
-        var content = {
-            oname : objname.toString(),
-        };
-        var msg = this.get_msg("object_info_request", content);
-        this.shell_channel.send(JSON.stringify(msg));
-        return msg.header.msg_id;
+        if(typeof(objname)!=null)
+        {
+            var content = {
+                oname : objname.toString(),
+            };
+            var msg = this.get_msg("object_info_request", content);
+            this.shell_channel.send(JSON.stringify(msg));
+            return msg.header.msg_id;
+        }
+        return;
     }
 
     Kernel.prototype.execute = function (code) {

--- a/IPython/frontend/html/notebook/static/js/leftpanel.js
+++ b/IPython/frontend/html/notebook/static/js/leftpanel.js
@@ -67,6 +67,7 @@ var IPython = (function (IPython) {
         this.notebook_section = new IPython.NotebookSection('div#notebook_section');
         if (! IPython.read_only){
             this.cell_section = new IPython.CellSection('div#cell_section');
+            this.config_section = new IPython.ConfigSection('div#config_section');
             this.kernel_section = new IPython.KernelSection('div#kernel_section');
         }
         this.help_section = new IPython.HelpSection('div#help_section');

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -28,6 +28,7 @@ var IPython = (function (IPython) {
         this.create_elements();
         this.bind_events();
         this.set_tooltipontab(true);
+        this.set_smartcompleter(true);
         this.set_timebeforetooltip(1200);
     };
 
@@ -631,6 +632,11 @@ var IPython = (function (IPython) {
     Notebook.prototype.set_tooltipontab = function (state) {
         console.log("change tooltip on tab to : "+state);
         this.tooltip_on_tab = state;
+    };
+
+    Notebook.prototype.set_smartcompleter = function (state) {
+        console.log("Smart completion (kwargs first) changed to  to : "+state);
+        this.smart_completer = state;
     };
 
     Notebook.prototype.set_autoindent = function (state) {

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -723,7 +723,7 @@ var IPython = (function (IPython) {
             rep = reply.content;
             if(rep.found)
             {
-                cell.finish_tooltip(rep.definition,rep.docstring);
+                cell.finish_tooltip(rep);
             }
         } else {
           //console.log("unknown reply:"+msg_type);

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -28,6 +28,7 @@ var IPython = (function (IPython) {
         this.create_elements();
         this.bind_events();
         this.set_tooltipontab(true);
+        this.set_timebeforetooltip(1200);
     };
 
 
@@ -621,6 +622,11 @@ var IPython = (function (IPython) {
         this.dirty = true;
     };
 
+
+    Notebook.prototype.set_timebeforetooltip = function (time) {
+        console.log("change time before tooltip to : "+time);
+        this.time_before_tooltip = time;
+    };
 
     Notebook.prototype.set_tooltipontab = function (state) {
         console.log("change tooltip on tab to : "+state);

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -705,7 +705,6 @@ var IPython = (function (IPython) {
             rep = reply.content;
             if(rep.found)
             {
-                console.log("object as been found");
                 cell.finish_tooltip(rep.definition,rep.docstring);
             }
         } else {
@@ -884,10 +883,12 @@ var IPython = (function (IPython) {
 
 
     Notebook.prototype.request_tool_tip = function (cell,func) {
-        // select last part of expression
+        //remove ending '(' if any
+        //there should be a way to do it in the regexp 
+        if(func.substr(-1) === '('){func=func.substr(0, func.length-1);}
+        // regexp to select last part of expression
         var re = /[a-zA-Z._]+$/g;
-        var lastpart=re.exec(func);
-        var msg_id = this.kernel.object_info_request(lastpart);
+        var msg_id = this.kernel.object_info_request(re.exec(func));
         this.msg_cell_map[msg_id] = cell.cell_id;
     };
 

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -739,7 +739,6 @@ var IPython = (function (IPython) {
 
     Notebook.prototype.handle_payload = function (cell, payload) {
         var l = payload.length;
-        console.log(payload);
         for (var i=0; i<l; i++) {
             if (payload[i].source === 'IPython.zmq.page.page') {
                 if (payload[i].text.trim() !== '') {
@@ -919,7 +918,9 @@ var IPython = (function (IPython) {
         func = func.replace(endBracket,"");
         var re = /[a-zA-Z._]+$/g;
         var msg_id = this.kernel.object_info_request(re.exec(func));
-        this.msg_cell_map[msg_id] = cell.cell_id;
+        if(typeof(msg_id)!='undefined'){
+            this.msg_cell_map[msg_id] = cell.cell_id;
+            }
     };
 
     Notebook.prototype.complete_cell = function (cell, line, cursor_pos) {

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -27,6 +27,7 @@ var IPython = (function (IPython) {
         this.style();
         this.create_elements();
         this.bind_events();
+        this.set_tooltipontab(true);
     };
 
 
@@ -621,6 +622,11 @@ var IPython = (function (IPython) {
     };
 
 
+    Notebook.prototype.set_tooltipontab = function (state) {
+        console.log("change tooltip on tab to : "+state);
+        this.tooltip_on_tab = state;
+    };
+
     Notebook.prototype.set_autoindent = function (state) {
         var cells = this.cells();
         len = cells.length;
@@ -883,10 +889,22 @@ var IPython = (function (IPython) {
 
 
     Notebook.prototype.request_tool_tip = function (cell,func) {
-        //remove ending '(' if any
-        //there should be a way to do it in the regexp 
-        if(func.substr(-1) === '('){func=func.substr(0, func.length-1);}
-        // regexp to select last part of expression
+        // Feel free to shorten this logic if you are better
+        // than me in regEx
+        // basicaly you shoul be able to get xxx.xxx.xxx from 
+        // something(range(10), kwarg=smth) ; xxx.xxx.xxx( firstarg, rand(234,23), kwarg1=2, 
+        // remove everything between matchin bracket (need to iterate)
+        matchBracket = /\([^\(\)]+\)/g;
+        oldfunc = func;
+        func = func.replace(matchBracket,"");
+        while( oldfunc != func )
+        {
+        oldfunc = func;
+        func = func.replace(matchBracket,"");
+        }
+        // remove everythin after last open bracket
+        endBracket = /\([^\(]*$/g;
+        func = func.replace(endBracket,"");
         var re = /[a-zA-Z._]+$/g;
         var msg_id = this.kernel.object_info_request(re.exec(func));
         this.msg_cell_map[msg_id] = cell.cell_id;

--- a/IPython/frontend/html/notebook/static/js/notebookmain.js
+++ b/IPython/frontend/html/notebook/static/js/notebookmain.js
@@ -51,6 +51,7 @@ $(document).ready(function () {
         IPython.quick_help.element.addClass('hidden'); // shortcuts are disabled in read_only
         $('button#new_notebook').addClass('hidden');
         $('div#cell_section').addClass('hidden');
+        $('div#config_section').addClass('hidden');
         $('div#kernel_section').addClass('hidden');
         $('span#login_widget').removeClass('hidden');
         // left panel starts collapsed, but the collapse must happen after

--- a/IPython/frontend/html/notebook/static/js/panelsection.js
+++ b/IPython/frontend/html/notebook/static/js/panelsection.js
@@ -137,6 +137,9 @@ var IPython = (function (IPython) {
         this.content.find('#tooltipontab').attr('title', 'Show tooltip if yuo press <Tab> after "(" or a white space');
         this.content.find('#tooltipontab_label').attr('title', 'Show Tooltip when pressing Tab');
 
+        this.content.find('#timebeforetooltip').attr('title', 'Time before a tooltip auto-appear when "(" is pressed (negative value supress tooltip)');
+        this.content.find('#timebeforetooltip_label').attr('title', 'Time before a tooltip auto-appear when "(" is pressed (negative value supress tooltip)');
+
     };
 
 
@@ -145,6 +148,10 @@ var IPython = (function (IPython) {
         this.content.find('#tooltipontab').change(function () {
             var state = $('#tooltipontab').prop('checked');
             IPython.notebook.set_tooltipontab(state);
+        });
+        this.content.find('#timebeforetooltip').change(function () {
+            var state = $('#timebeforetooltip').prop('value');
+            IPython.notebook.set_timebeforetooltip(state);
         });
     };
 

--- a/IPython/frontend/html/notebook/static/js/panelsection.js
+++ b/IPython/frontend/html/notebook/static/js/panelsection.js
@@ -140,6 +140,8 @@ var IPython = (function (IPython) {
         this.content.find('#timebeforetooltip').attr('title', 'Time before a tooltip auto-appear when "(" is pressed (negative value supress tooltip)');
         this.content.find('#timebeforetooltip_label').attr('title', 'Time before a tooltip auto-appear when "(" is pressed (negative value supress tooltip)');
 
+        this.content.find('#smartcompleter').attr('title', 'When inside function call, completer try to propose kwargs first');
+        this.content.find('#smartcompleter_label').attr('title', 'When inside function call, completer try to propose kwargs first');
     };
 
 
@@ -152,6 +154,10 @@ var IPython = (function (IPython) {
         this.content.find('#timebeforetooltip').change(function () {
             var state = $('#timebeforetooltip').prop('value');
             IPython.notebook.set_timebeforetooltip(state);
+        });
+        this.content.find('#smartcompleter').change(function () {
+            var state = $('#smartcompleter').prop('checked');
+            IPython.notebook.set_smartcompleter(state);
         });
     };
 

--- a/IPython/frontend/html/notebook/static/js/panelsection.js
+++ b/IPython/frontend/html/notebook/static/js/panelsection.js
@@ -121,12 +121,38 @@ var IPython = (function (IPython) {
         });
     };
 
+    // ConfigSection
+
+    var ConfigSection = function () {
+        PanelSection.apply(this, arguments);
+    };
+
+    ConfigSection.prototype = new PanelSection();
+
+    ConfigSection.prototype.style = function () {
+        PanelSection.prototype.style.apply(this);
+        this.content.addClass('ui-helper-clearfix');
+        this.content.find('div.section_row').addClass('ui-helper-clearfix');
+
+        this.content.find('#tooltipontab').attr('title', 'Show tooltip if yuo press <Tab> after "(" or a white space');
+        this.content.find('#tooltipontab_label').attr('title', 'Show Tooltip when pressing Tab');
+
+    };
+
+
+    ConfigSection.prototype.bind_events = function () {
+        PanelSection.prototype.bind_events.apply(this);
+        this.content.find('#tooltipontab').change(function () {
+            var state = $('#tooltipontab').prop('checked');
+            IPython.notebook.set_tooltipontab(state);
+        });
+    };
+
     // CellSection
 
     var CellSection = function () {
         PanelSection.apply(this, arguments);
     };
-
 
     CellSection.prototype = new PanelSection();
 
@@ -200,6 +226,10 @@ var IPython = (function (IPython) {
         this.content.find('#autoindent').change(function () {
             var state = $('#autoindent').prop('checked');
             IPython.notebook.set_autoindent(state);
+        });
+        this.content.find('#tooltipontab').change(function () {
+            var state = $('#tooltipontab').prop('checked');
+            IPython.notebook.set_tooltipontab(state);
         });
     };
 
@@ -280,6 +310,7 @@ var IPython = (function (IPython) {
     IPython.PanelSection = PanelSection;
     IPython.NotebookSection = NotebookSection;
     IPython.CellSection = CellSection;
+    IPython.ConfigSection = ConfigSection;
     IPython.KernelSection = KernelSection;
     IPython.HelpSection = HelpSection;
 

--- a/IPython/frontend/html/notebook/static/js/panelsection.js
+++ b/IPython/frontend/html/notebook/static/js/panelsection.js
@@ -134,7 +134,7 @@ var IPython = (function (IPython) {
         this.content.addClass('ui-helper-clearfix');
         this.content.find('div.section_row').addClass('ui-helper-clearfix');
 
-        this.content.find('#tooltipontab').attr('title', 'Show tooltip if yuo press <Tab> after "(" or a white space');
+        this.content.find('#tooltipontab').attr('title', 'Show tooltip if you press <Tab> after "(" or a white space');
         this.content.find('#tooltipontab_label').attr('title', 'Show Tooltip when pressing Tab');
 
         this.content.find('#timebeforetooltip').attr('title', 'Time before a tooltip auto-appear when "(" is pressed (negative value supress tooltip)');

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -262,6 +262,12 @@
                     </span>
                     <span class="checkbox_label" id="tooltipontab_label">Tooltip on tab:</span>
                 </div>
+                <div class="section_row">
+                    <span id="tooltipontab_span">
+                        <input type="text" id="timebeforetooltip" value="1200"></input>
+                    </span>
+                    <span class="numeric_input_label" id="timebeforetooltip_label">Time before tooltip : </span>
+                </div>
             </div>
         </div>
 

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -251,6 +251,20 @@
             </div>
         </div>
 
+        <div id="config_section">
+            <div class="section_header">
+                <h3>Config</h3>
+            </div>
+            <div class="section_content">
+                <div class="section_row">
+                    <span id="tooltipontab_span">
+                        <input type="checkbox" id="tooltipontab" checked="true"></input>
+                    </span>
+                    <span class="checkbox_label" id="tooltipontab_label">Tooltip on tab:</span>
+                </div>
+            </div>
+        </div>
+
     </div>
     <div id="left_panel_splitter"></div>
     <div id="notebook_panel">

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -269,7 +269,7 @@
                     <span class="checkbox_label" id="smartcompleter_label">Smart completer:</span>
                 </div>
                 <div class="section_row">
-                    <span id="tooltipontab_span">
+                    <span id="timebeforetooltip_span">
                         <input type="text" id="timebeforetooltip" value="1200"></input>
                     </span>
                     <span class="numeric_input_label" id="timebeforetooltip_label">Time before tooltip : </span>

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -263,6 +263,12 @@
                     <span class="checkbox_label" id="tooltipontab_label">Tooltip on tab:</span>
                 </div>
                 <div class="section_row">
+                    <span id="smartcompleter_span">
+                        <input type="checkbox" id="smartcompleter" checked="true"></input>
+                    </span>
+                    <span class="checkbox_label" id="smartcompleter_label">Smart completer:</span>
+                </div>
+                <div class="section_row">
                     <span id="tooltipontab_span">
                         <input type="text" id="timebeforetooltip" value="1200"></input>
                     </span>


### PR DESCRIPTION
```
When user press '(' and nothing for 1200ms, 'object_info_request' sent to
the kernel. Then tooltip with 'definition' and beggining of 'docstring'
shown to the user if non empty response.

Unlike Completion <select> , <div> is not focusable so event handled in main
cell event handeling function

Add some CSS3 that most browser with websocket should support.
```

I wasn't able to replicate the 'object oriented' way of dismissing the completer with `<div/>` because they are not  'focusable' but it works.

I've also add some CSS3, for tooltip round-corner and fade in, if you agree...
