### PR TITLE
Allow latex formulas in HTML output

### DIFF
--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -243,7 +243,7 @@ var IPython = (function (IPython) {
         this.append_mime_type(json, toinsert);
         this.element.find('div.output').append(toinsert);
         // If we just output latex, typeset it.
-        if (json.latex !== undefined) {
+        if ((json.latex !== undefined) || (json.html !== undefined)) {
             MathJax.Hub.Queue(["Typeset",MathJax.Hub]);
         };
     };
@@ -295,7 +295,7 @@ var IPython = (function (IPython) {
         this.append_mime_type(json, toinsert)
         this.element.find('div.output').append(toinsert);
         // If we just output latex, typeset it.
-        if (json.latex !== undefined) {
+        if ( (json.latex !== undefined) || (json.html !== undefined) ) {
             MathJax.Hub.Queue(["Typeset",MathJax.Hub]);
         };
     };


### PR DESCRIPTION
Currently latex rendering works for markdown cells and latex output.
However, HTML output containing latex formulas will not be processed until a true latex content is detected (or when  _entering_ a markdown cell). Given that HTML output may well contain formulas (e.g a table whose columns are latex variables), it seems natural to call the mathjax renderer after html output too. This is what this patch does.
It looks like Mathjax is caching already computed results, so the overhead may be small even if there are many formulas around.
