### PR TITLE
add Integer traitlet

### DIFF
--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -34,7 +34,7 @@ from IPython.config.loader import (
 )
 
 from IPython.utils.traitlets import (
-    Unicode, List, Int, Enum, Dict, Instance, TraitError
+    Unicode, List, Enum, Dict, Instance, TraitError
 )
 from IPython.utils.importstring import import_item
 from IPython.utils.text import indent, wrap_paragraphs, dedent

--- a/IPython/config/tests/test_application.py
+++ b/IPython/config/tests/test_application.py
@@ -28,7 +28,7 @@ from IPython.config.application import (
 )
 
 from IPython.utils.traitlets import (
-    Bool, Unicode, Int, Float, List, Dict
+    Bool, Unicode, Integer, Float, List, Dict
 )
 
 #-----------------------------------------------------------------------------
@@ -37,14 +37,14 @@ from IPython.utils.traitlets import (
 
 class Foo(Configurable):
 
-    i = Int(0, config=True, help="The integer i.")
-    j = Int(1, config=True, help="The integer j.")
+    i = Integer(0, config=True, help="The integer i.")
+    j = Integer(1, config=True, help="The integer j.")
     name = Unicode(u'Brian', config=True, help="First name.")
 
 
 class Bar(Configurable):
 
-    b = Int(0, config=True, help="The integer b.")
+    b = Integer(0, config=True, help="The integer b.")
     enabled = Bool(True, config=True, help="Enable bar.")
 
 

--- a/IPython/config/tests/test_configurable.py
+++ b/IPython/config/tests/test_configurable.py
@@ -27,7 +27,7 @@ from IPython.config.configurable import (
 )
 
 from IPython.utils.traitlets import (
-    Int, Float, Unicode
+    Integer, Float, Unicode
 )
 
 from IPython.config.loader import Config
@@ -39,14 +39,14 @@ from IPython.config.loader import Config
 
 
 class MyConfigurable(Configurable):
-    a = Int(1, config=True, help="The integer a.")
+    a = Integer(1, config=True, help="The integer a.")
     b = Float(1.0, config=True, help="The integer b.")
     c = Unicode('no config')
 
 
 mc_help=u"""MyConfigurable options
 ----------------------
---MyConfigurable.a=<Int>
+--MyConfigurable.a=<Integer>
     Default: 1
     The integer a.
 --MyConfigurable.b=<Float>
@@ -55,7 +55,7 @@ mc_help=u"""MyConfigurable options
 
 mc_help_inst=u"""MyConfigurable options
 ----------------------
---MyConfigurable.a=<Int>
+--MyConfigurable.a=<Integer>
     Current: 5
     The integer a.
 --MyConfigurable.b=<Float>
@@ -63,7 +63,7 @@ mc_help_inst=u"""MyConfigurable options
     The integer b."""
 
 class Foo(Configurable):
-    a = Int(0, config=True, help="The integer a.")
+    a = Integer(0, config=True, help="The integer a.")
     b = Unicode('nope', config=True)
 
 

--- a/IPython/config/tests/test_loader.py
+++ b/IPython/config/tests/test_loader.py
@@ -28,7 +28,7 @@ from nose import SkipTest
 
 from IPython.testing.tools import mute_warn
 
-from IPython.utils.traitlets import Int, Unicode
+from IPython.utils.traitlets import Unicode
 from IPython.config.configurable import Configurable
 from IPython.config.loader import (
     Config,

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -28,7 +28,7 @@ from StringIO import StringIO
 # Our own imports
 from IPython.config.configurable import Configurable
 from IPython.lib import pretty
-from IPython.utils.traitlets import Bool, Dict, Int, Unicode, CUnicode, ObjectName
+from IPython.utils.traitlets import Bool, Dict, Integer, Unicode, CUnicode, ObjectName
 from IPython.utils.py3compat import unicode_to_str
 
 
@@ -357,7 +357,7 @@ class PlainTextFormatter(BaseFormatter):
     verbose = Bool(False, config=True)
 
     # The maximum width.
-    max_width = Int(79, config=True)
+    max_width = Integer(79, config=True)
 
     # The newline character.
     newline = Unicode('\n', config=True)

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -29,7 +29,7 @@ from IPython.external.decorator import decorator
 from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils import io
 from IPython.utils.path import locate_profile
-from IPython.utils.traitlets import Bool, Dict, Instance, Int, CInt, List, Unicode
+from IPython.utils.traitlets import Bool, Dict, Instance, Integer, List, Unicode
 from IPython.utils.warn import warn
 
 #-----------------------------------------------------------------------------
@@ -361,12 +361,12 @@ class HistoryManager(HistoryAccessor):
     output_hist_reprs = Dict()
 
     # The number of the current session in the history database
-    session_number = CInt()
+    session_number = Integer()
     # Should we log output to the database? (default no)
     db_log_output = Bool(False, config=True)
     # Write to database every x commands (higher values save disk access & power)
     #  Values of 1 or less effectively disable caching. 
-    db_cache_size = Int(0, config=True)
+    db_cache_size = Integer(0, config=True)
     # The input and output caches
     db_input_cache = List()
     db_output_cache = List()

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -74,7 +74,7 @@ from IPython.utils.process import system, getoutput
 from IPython.utils.strdispatch import StrDispatch
 from IPython.utils.syspathcontext import prepended_to_syspath
 from IPython.utils.text import num_ini_spaces, format_screen, LSString, SList
-from IPython.utils.traitlets import (Int, CBool, CaselessStrEnum, Enum,
+from IPython.utils.traitlets import (Integer, CBool, CaselessStrEnum, Enum,
                                      List, Unicode, Instance, Type)
 from IPython.utils.warn import warn, error, fatal
 import IPython.core.hooks
@@ -226,7 +226,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
         Enable magic commands to be called without the leading %.
         """
     )
-    cache_size = Int(1000, config=True, help=
+    cache_size = Integer(1000, config=True, help=
         """
         Set the size of the output cache.  The default is 1000, you can
         change it permanently in your config file.  Setting it to 0 completely
@@ -277,7 +277,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
     def _exiter_default(self):
         return ExitAutocall(self)
     # Monotonically increasing execution counter
-    execution_count = Int(1)
+    execution_count = Integer(1)
     filename = Unicode("<ipython console>")
     ipython_dir= Unicode('', config=True) # Set to get_ipython_dir() in __init__
 
@@ -317,7 +317,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
     prompts_pad_left = CBool(True, config=True)
     quiet = CBool(False, config=True)
 
-    history_length = Int(10000, config=True)
+    history_length = Integer(10000, config=True)
 
     # The readline stuff will eventually be moved to the terminal subclass
     # but for now, we can't do that as readline is welded in everywhere.

--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -35,7 +35,7 @@ from IPython.core.macro import Macro
 from IPython.core.splitinput import split_user_input, LineInfo
 from IPython.core import page
 
-from IPython.utils.traitlets import List, Int, Any, Unicode, CBool, Bool, Instance
+from IPython.utils.traitlets import List, Integer, Any, Unicode, CBool, Bool, Instance
 from IPython.utils.text import make_quoted_expr
 from IPython.utils.autoattr import auto_attr
 
@@ -369,7 +369,7 @@ class PrefilterManager(Configurable):
 class PrefilterTransformer(Configurable):
     """Transform a line of user input."""
 
-    priority = Int(100, config=True)
+    priority = Integer(100, config=True)
     # Transformers don't currently use shell or prefilter_manager, but as we
     # move away from checkers and handlers, they will need them.
     shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
@@ -398,7 +398,7 @@ _assign_system_re = re.compile(r'(?P<lhs>(\s*)([\w\.]+)((\s*,\s*[\w\.]+)*))'
 class AssignSystemTransformer(PrefilterTransformer):
     """Handle the `files = !ls` syntax."""
 
-    priority = Int(100, config=True)
+    priority = Integer(100, config=True)
 
     def transform(self, line, continue_prompt):
         m = _assign_system_re.match(line)
@@ -417,7 +417,7 @@ _assign_magic_re = re.compile(r'(?P<lhs>(\s*)([\w\.]+)((\s*,\s*[\w\.]+)*))'
 class AssignMagicTransformer(PrefilterTransformer):
     """Handle the `a = %who` syntax."""
 
-    priority = Int(200, config=True)
+    priority = Integer(200, config=True)
 
     def transform(self, line, continue_prompt):
         m = _assign_magic_re.match(line)
@@ -435,7 +435,7 @@ _classic_prompt_re = re.compile(r'(^[ \t]*>>> |^[ \t]*\.\.\. )')
 class PyPromptTransformer(PrefilterTransformer):
     """Handle inputs that start with '>>> ' syntax."""
 
-    priority = Int(50, config=True)
+    priority = Integer(50, config=True)
 
     def transform(self, line, continue_prompt):
 
@@ -456,7 +456,7 @@ _ipy_prompt_re = re.compile(r'(^[ \t]*In \[\d+\]: |^[ \t]*\ \ \ \.\.\.+: )')
 class IPyPromptTransformer(PrefilterTransformer):
     """Handle inputs that start classic IPython prompt syntax."""
 
-    priority = Int(50, config=True)
+    priority = Integer(50, config=True)
 
     def transform(self, line, continue_prompt):
 
@@ -479,7 +479,7 @@ class IPyPromptTransformer(PrefilterTransformer):
 class PrefilterChecker(Configurable):
     """Inspect an input line and return a handler for that line."""
 
-    priority = Int(100, config=True)
+    priority = Integer(100, config=True)
     shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
     prefilter_manager = Instance('IPython.core.prefilter.PrefilterManager')
     enabled = Bool(True, config=True)
@@ -501,7 +501,7 @@ class PrefilterChecker(Configurable):
 
 class EmacsChecker(PrefilterChecker):
 
-    priority = Int(100, config=True)
+    priority = Integer(100, config=True)
     enabled = Bool(False, config=True)
 
     def check(self, line_info):
@@ -514,7 +514,7 @@ class EmacsChecker(PrefilterChecker):
 
 class ShellEscapeChecker(PrefilterChecker):
 
-    priority = Int(200, config=True)
+    priority = Integer(200, config=True)
 
     def check(self, line_info):
         if line_info.line.lstrip().startswith(ESC_SHELL):
@@ -523,7 +523,7 @@ class ShellEscapeChecker(PrefilterChecker):
 
 class MacroChecker(PrefilterChecker):
 
-    priority = Int(250, config=True)
+    priority = Integer(250, config=True)
 
     def check(self, line_info):
         obj = self.shell.user_ns.get(line_info.ifun)
@@ -535,7 +535,7 @@ class MacroChecker(PrefilterChecker):
 
 class IPyAutocallChecker(PrefilterChecker):
 
-    priority = Int(300, config=True)
+    priority = Integer(300, config=True)
 
     def check(self, line_info):
         "Instances of IPyAutocall in user_ns get autocalled immediately"
@@ -549,7 +549,7 @@ class IPyAutocallChecker(PrefilterChecker):
 
 class MultiLineMagicChecker(PrefilterChecker):
 
-    priority = Int(400, config=True)
+    priority = Integer(400, config=True)
 
     def check(self, line_info):
         "Allow ! and !! in multi-line statements if multi_line_specials is on"
@@ -566,7 +566,7 @@ class MultiLineMagicChecker(PrefilterChecker):
 
 class EscCharsChecker(PrefilterChecker):
 
-    priority = Int(500, config=True)
+    priority = Integer(500, config=True)
 
     def check(self, line_info):
         """Check for escape character and return either a handler to handle it,
@@ -586,7 +586,7 @@ class EscCharsChecker(PrefilterChecker):
 
 class AssignmentChecker(PrefilterChecker):
 
-    priority = Int(600, config=True)
+    priority = Integer(600, config=True)
 
     def check(self, line_info):
         """Check to see if user is assigning to a var for the first time, in
@@ -604,7 +604,7 @@ class AssignmentChecker(PrefilterChecker):
 
 class AutoMagicChecker(PrefilterChecker):
 
-    priority = Int(700, config=True)
+    priority = Integer(700, config=True)
 
     def check(self, line_info):
         """If the ifun is magic, and automagic is on, run it.  Note: normal,
@@ -628,7 +628,7 @@ class AutoMagicChecker(PrefilterChecker):
 
 class AliasChecker(PrefilterChecker):
 
-    priority = Int(800, config=True)
+    priority = Integer(800, config=True)
 
     def check(self, line_info):
         "Check if the initital identifier on the line is an alias."
@@ -644,7 +644,7 @@ class AliasChecker(PrefilterChecker):
 
 class PythonOpsChecker(PrefilterChecker):
 
-    priority = Int(900, config=True)
+    priority = Integer(900, config=True)
 
     def check(self, line_info):
         """If the 'rest' of the line begins with a function call or pretty much
@@ -659,7 +659,7 @@ class PythonOpsChecker(PrefilterChecker):
 
 class AutocallChecker(PrefilterChecker):
 
-    priority = Int(1000, config=True)
+    priority = Integer(1000, config=True)
 
     def check(self, line_info):
         "Check if the initial word/function is callable and autocall is on."

--- a/IPython/frontend/html/notebook/kernelmanager.py
+++ b/IPython/frontend/html/notebook/kernelmanager.py
@@ -29,7 +29,7 @@ from tornado import web
 from IPython.config.configurable import LoggingConfigurable
 from IPython.zmq.ipkernel import launch_kernel
 from IPython.zmq.kernelmanager import KernelManager
-from IPython.utils.traitlets import Instance, Dict, List, Unicode, Float, Int
+from IPython.utils.traitlets import Instance, Dict, List, Unicode, Float, Integer
 
 #-----------------------------------------------------------------------------
 # Classes
@@ -196,7 +196,7 @@ class MappingKernelManager(MultiKernelManager):
     kernel_argv = List(Unicode)
     kernel_manager = Instance(KernelManager)
     time_to_dead = Float(3.0, config=True, help="""Kernel heartbeat interval in seconds.""")
-    max_msg_size = Int(65536, config=True, help="""
+    max_msg_size = Integer(65536, config=True, help="""
         The max raw message size accepted from the browser
         over a WebSocket connection.
     """)

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -57,7 +57,7 @@ from IPython.zmq.ipkernel import (
     aliases as ipkernel_aliases,
     IPKernelApp
 )
-from IPython.utils.traitlets import Dict, Unicode, Int, List, Enum, Bool
+from IPython.utils.traitlets import Dict, Unicode, Integer, List, Enum, Bool
 
 #-----------------------------------------------------------------------------
 # Module globals
@@ -195,7 +195,7 @@ class NotebookApp(BaseIPythonApplication):
     def _ip_changed(self, name, old, new):
         if new == u'*': self.ip = u''
 
-    port = Int(8888, config=True,
+    port = Integer(8888, config=True,
         help="The port the notebook server will listen on."
     )
 

--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -20,7 +20,7 @@ from IPython.config.configurable import LoggingConfigurable
 from IPython.frontend.qt.rich_text import HtmlExporter
 from IPython.frontend.qt.util import MetaQObjectHasTraits, get_font
 from IPython.utils.text import columnize
-from IPython.utils.traitlets import Bool, Enum, Int, Unicode
+from IPython.utils.traitlets import Bool, Enum, Integer, Unicode
 from ansi_code_processor import QtAnsiCodeProcessor
 from completion_widget import CompletionWidget
 from kill_ring import QtKillRing
@@ -59,7 +59,7 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
     ansi_codes = Bool(True, config=True,
         help="Whether to process ANSI escape codes."
     )
-    buffer_size = Int(500, config=True,
+    buffer_size = Integer(500, config=True,
         help="""
         The maximum number of lines of text before truncation. Specifying a
         non-positive number disables text truncation (not recommended).
@@ -112,7 +112,7 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
             # Monospace should always exist, no need for a fallback
             return 'Monospace'
 
-    font_size = Int(config=True,
+    font_size = Integer(config=True,
         help="""The font size. If unconfigured, Qt will be entrusted
         with the size of the font.
         """)

--- a/IPython/frontend/qt/console/qtconsoleapp.py
+++ b/IPython/frontend/qt/console/qtconsoleapp.py
@@ -42,7 +42,7 @@ from IPython.frontend.qt.kernelmanager import QtKernelManager
 from IPython.utils.path import filefind
 from IPython.utils.py3compat import str_to_bytes
 from IPython.utils.traitlets import (
-    Dict, List, Unicode, Int, CaselessStrEnum, CBool, Any
+    Dict, List, Unicode, Integer, CaselessStrEnum, CBool, Any
 )
 from IPython.zmq.ipkernel import (
     flags as ipkernel_flags,
@@ -168,13 +168,13 @@ class IPythonQtConsoleApp(BaseIPythonApplication):
     sshkey = Unicode('', config=True,
         help="""Path to the ssh key to use for logging in to the ssh server.""")
     
-    hb_port = Int(0, config=True,
+    hb_port = Integer(0, config=True,
         help="set the heartbeat port [default: random]")
-    shell_port = Int(0, config=True,
+    shell_port = Integer(0, config=True,
         help="set the shell (XREP) port [default: random]")
-    iopub_port = Int(0, config=True,
+    iopub_port = Integer(0, config=True,
         help="set the iopub (PUB) port [default: random]")
-    stdin_port = Int(0, config=True,
+    stdin_port = Integer(0, config=True,
         help="set the stdin (XREQ) port [default: random]")
     connection_file = Unicode('', config=True,
         help="""JSON file in which to store connection info [default: kernel-<pid>.json]

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -36,7 +36,7 @@ from IPython.utils.terminal import toggle_set_term_title, set_term_title
 from IPython.utils.process import abbrev_cwd
 from IPython.utils.warn import warn
 from IPython.utils.text import num_ini_spaces
-from IPython.utils.traitlets import Int, CBool, Unicode
+from IPython.utils.traitlets import Integer, CBool, Unicode
 
 #-----------------------------------------------------------------------------
 # Utilities
@@ -87,7 +87,7 @@ class TerminalInteractiveShell(InteractiveShell):
     pager = Unicode('less', config=True,
         help="The shell program to be used for paging.")
 
-    screen_length = Int(0, config=True,
+    screen_length = Integer(0, config=True,
         help=
         """Number of lines of your screen, used to control printing of very
         long strings.  Strings longer than this number of lines will be sent

--- a/IPython/parallel/apps/ipclusterapp.py
+++ b/IPython/parallel/apps/ipclusterapp.py
@@ -38,7 +38,7 @@ from IPython.core.profiledir import ProfileDir
 from IPython.utils.daemonize import daemonize
 from IPython.utils.importstring import import_item
 from IPython.utils.sysinfo import num_cpus
-from IPython.utils.traitlets import (Int, Unicode, Bool, CFloat, Dict, List, Any,
+from IPython.utils.traitlets import (Integer, Unicode, Bool, CFloat, Dict, List, Any,
                                         DottedObjectName)
 
 from IPython.parallel.apps.baseapp import (
@@ -151,7 +151,7 @@ class IPClusterStop(BaseParallelApplication):
     examples = _stop_examples
     config_file_name = Unicode(default_config_file_name)
 
-    signal = Int(signal.SIGINT, config=True,
+    signal = Integer(signal.SIGINT, config=True,
         help="signal to use for stopping processes.")
 
     aliases = Dict(stop_aliases)
@@ -229,7 +229,7 @@ class IPClusterEngines(BaseParallelApplication):
         eslaunchers = [ l for l in launchers if 'EngineSet' in l.__name__]
         return [ProfileDir]+eslaunchers
 
-    n = Int(num_cpus(), config=True,
+    n = Integer(num_cpus(), config=True,
         help="""The number of engines to start. The default is to use one for each
         CPU on your machine""")
 
@@ -282,7 +282,7 @@ class IPClusterEngines(BaseParallelApplication):
         if new:
             self.log_to_file = True
 
-    early_shutdown = Int(30, config=True, help="The timeout (in seconds)")
+    early_shutdown = Integer(30, config=True, help="The timeout (in seconds)")
     _stopping = False
     
     aliases = Dict(engine_aliases)

--- a/IPython/parallel/apps/launcher.py
+++ b/IPython/parallel/apps/launcher.py
@@ -58,7 +58,7 @@ from IPython.config.application import Application
 from IPython.config.configurable import LoggingConfigurable
 from IPython.utils.text import EvalFormatter
 from IPython.utils.traitlets import (
-    Any, Int, CFloat, List, Unicode, Dict, Instance, HasTraits,
+    Any, Integer, CFloat, List, Unicode, Dict, Instance, HasTraits,
 )
 from IPython.utils.path import get_ipython_module_path
 from IPython.utils.process import find_cmd, pycmd2argv, FindCmdError
@@ -258,7 +258,7 @@ class LocalProcessLauncher(BaseLauncher):
     # This is used to to construct self.args, which is passed to
     # spawnProcess.
     cmd_and_args = List([])
-    poll_frequency = Int(100) # in ms
+    poll_frequency = Integer(100) # in ms
 
     def __init__(self, work_dir=u'.', config=None, **kwargs):
         super(LocalProcessLauncher, self).__init__(
@@ -458,7 +458,7 @@ class MPIExecLauncher(LocalProcessLauncher):
     program_args = List([],
         help="The command line argument to the program."
     )
-    n = Int(1)
+    n = Integer(1)
 
     def find_args(self):
         """Build self.args using all the fields."""
@@ -854,7 +854,7 @@ class BatchSystemLauncher(BaseLauncher):
     def _queue_changed(self, name, old, new):
         self.context[name] = new
 
-    n = Int(1)
+    n = Integer(1)
     _n_changed = _queue_changed
 
     # not configurable, override in subclasses
@@ -1121,7 +1121,7 @@ class IPClusterLauncher(LocalProcessLauncher):
         ['--clean-logs', '--log-to-file', '--log-level=%i'%logging.INFO], config=True,
         help="Command line arguments to pass to ipcluster.")
     ipcluster_subcommand = Unicode('start')
-    ipcluster_n = Int(2)
+    ipcluster_n = Integer(2)
 
     def find_args(self):
         return self.ipcluster_cmd + [self.ipcluster_subcommand] + \

--- a/IPython/parallel/apps/winhpcjob.py
+++ b/IPython/parallel/apps/winhpcjob.py
@@ -29,7 +29,7 @@ from xml.etree import ElementTree as ET
 
 from IPython.config.configurable import Configurable
 from IPython.utils.traitlets import (
-    Unicode, Int, List, Instance,
+    Unicode, Integer, List, Instance,
     Enum, Bool
 )
 
@@ -81,12 +81,12 @@ class WinHPCJob(Configurable):
 
     job_id = Unicode('')
     job_name = Unicode('MyJob', config=True)
-    min_cores = Int(1, config=True)
-    max_cores = Int(1, config=True)
-    min_sockets = Int(1, config=True)
-    max_sockets = Int(1, config=True)
-    min_nodes = Int(1, config=True)
-    max_nodes = Int(1, config=True)
+    min_cores = Integer(1, config=True)
+    max_cores = Integer(1, config=True)
+    min_sockets = Integer(1, config=True)
+    max_sockets = Integer(1, config=True)
+    min_nodes = Integer(1, config=True)
+    max_nodes = Integer(1, config=True)
     unit_type = Unicode("Core", config=True)
     auto_calculate_min = Bool(True, config=True)
     auto_calculate_max = Bool(True, config=True)
@@ -173,12 +173,12 @@ class WinHPCTask(Configurable):
     task_id = Unicode('')
     task_name = Unicode('')
     version = Unicode("2.000")
-    min_cores = Int(1, config=True)
-    max_cores = Int(1, config=True)
-    min_sockets = Int(1, config=True)
-    max_sockets = Int(1, config=True)
-    min_nodes = Int(1, config=True)
-    max_nodes = Int(1, config=True)
+    min_cores = Integer(1, config=True)
+    max_cores = Integer(1, config=True)
+    min_sockets = Integer(1, config=True)
+    max_sockets = Integer(1, config=True)
+    min_nodes = Integer(1, config=True)
+    max_nodes = Integer(1, config=True)
     unit_type = Unicode("Core", config=True)
     command_line = Unicode('', config=True)
     work_directory = Unicode('', config=True)
@@ -255,12 +255,12 @@ class IPControllerTask(WinHPCTask):
     # I don't want these to be configurable
     std_out_file_path = Unicode('', config=False)
     std_err_file_path = Unicode('', config=False)
-    min_cores = Int(1, config=False)
-    max_cores = Int(1, config=False)
-    min_sockets = Int(1, config=False)
-    max_sockets = Int(1, config=False)
-    min_nodes = Int(1, config=False)
-    max_nodes = Int(1, config=False)
+    min_cores = Integer(1, config=False)
+    max_cores = Integer(1, config=False)
+    min_sockets = Integer(1, config=False)
+    max_sockets = Integer(1, config=False)
+    min_nodes = Integer(1, config=False)
+    max_nodes = Integer(1, config=False)
     unit_type = Unicode("Core", config=False)
     work_directory = Unicode('', config=False)
 
@@ -283,12 +283,12 @@ class IPEngineTask(WinHPCTask):
     # I don't want these to be configurable
     std_out_file_path = Unicode('', config=False)
     std_err_file_path = Unicode('', config=False)
-    min_cores = Int(1, config=False)
-    max_cores = Int(1, config=False)
-    min_sockets = Int(1, config=False)
-    max_sockets = Int(1, config=False)
-    min_nodes = Int(1, config=False)
-    max_nodes = Int(1, config=False)
+    min_cores = Integer(1, config=False)
+    max_cores = Integer(1, config=False)
+    min_sockets = Integer(1, config=False)
+    max_sockets = Integer(1, config=False)
+    min_nodes = Integer(1, config=False)
+    max_nodes = Integer(1, config=False)
     unit_type = Unicode("Core", config=False)
     work_directory = Unicode('', config=False)
 

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -35,7 +35,7 @@ from IPython.core.application import BaseIPythonApplication
 from IPython.utils.jsonutil import rekey
 from IPython.utils.localinterfaces import LOCAL_IPS
 from IPython.utils.path import get_ipython_dir
-from IPython.utils.traitlets import (HasTraits, Int, Instance, Unicode,
+from IPython.utils.traitlets import (HasTraits, Integer, Instance, Unicode,
                                     Dict, List, Bool, Set)
 from IPython.external.decorator import decorator
 from IPython.external.ssh import tunnel
@@ -279,8 +279,8 @@ class Client(HasTraits):
     _task_socket=Instance('zmq.Socket')
     _task_scheme=Unicode()
     _closed = False
-    _ignored_control_replies=Int(0)
-    _ignored_hub_replies=Int(0)
+    _ignored_control_replies=Integer(0)
+    _ignored_hub_replies=Integer(0)
 
     def __new__(self, *args, **kw):
         # don't raise on positional args

--- a/IPython/parallel/client/view.py
+++ b/IPython/parallel/client/view.py
@@ -24,7 +24,9 @@ from types import ModuleType
 import zmq
 
 from IPython.testing.skipdoctest import skip_doctest
-from IPython.utils.traitlets import HasTraits, Any, Bool, List, Dict, Set, Int, Instance, CFloat, CInt
+from IPython.utils.traitlets import (
+    HasTraits, Any, Bool, List, Dict, Set, Instance, CFloat, Integer
+)
 from IPython.external.decorator import decorator
 
 from IPython.parallel import util
@@ -795,7 +797,7 @@ class LoadBalancedView(View):
     follow=Any()
     after=Any()
     timeout=CFloat()
-    retries = CInt(0)
+    retries = Integer(0)
 
     _task_scheme = Any()
     _flag_names = List(['targets', 'block', 'track', 'follow', 'after', 'timeout', 'retries'])

--- a/IPython/parallel/controller/hub.py
+++ b/IPython/parallel/controller/hub.py
@@ -29,7 +29,7 @@ from zmq.eventloop.zmqstream import ZMQStream
 # internal:
 from IPython.utils.importstring import import_item
 from IPython.utils.traitlets import (
-        HasTraits, Instance, Int, Unicode, Dict, Set, Tuple, CBytes, DottedObjectName
+        HasTraits, Instance, Integer, Unicode, Dict, Set, Tuple, CBytes, DottedObjectName
         )
 
 from IPython.parallel import error, util
@@ -109,7 +109,7 @@ class EngineConnector(HasTraits):
     registration (str): identity of registration XREQ socket
     heartbeat (str): identity of heartbeat XREQ socket
     """
-    id=Int(0)
+    id=Integer(0)
     queue=CBytes()
     control=CBytes()
     registration=CBytes()
@@ -120,42 +120,42 @@ class HubFactory(RegistrationFactory):
     """The Configurable for setting up a Hub."""
 
     # port-pairs for monitoredqueues:
-    hb = Tuple(Int,Int,config=True,
+    hb = Tuple(Integer,Integer,config=True,
         help="""XREQ/SUB Port pair for Engine heartbeats""")
     def _hb_default(self):
         return tuple(util.select_random_ports(2))
 
-    mux = Tuple(Int,Int,config=True,
+    mux = Tuple(Integer,Integer,config=True,
         help="""Engine/Client Port pair for MUX queue""")
 
     def _mux_default(self):
         return tuple(util.select_random_ports(2))
 
-    task = Tuple(Int,Int,config=True,
+    task = Tuple(Integer,Integer,config=True,
         help="""Engine/Client Port pair for Task queue""")
     def _task_default(self):
         return tuple(util.select_random_ports(2))
 
-    control = Tuple(Int,Int,config=True,
+    control = Tuple(Integer,Integer,config=True,
         help="""Engine/Client Port pair for Control queue""")
 
     def _control_default(self):
         return tuple(util.select_random_ports(2))
 
-    iopub = Tuple(Int,Int,config=True,
+    iopub = Tuple(Integer,Integer,config=True,
         help="""Engine/Client Port pair for IOPub relay""")
 
     def _iopub_default(self):
         return tuple(util.select_random_ports(2))
 
     # single ports:
-    mon_port = Int(config=True,
+    mon_port = Integer(config=True,
         help="""Monitor (SUB) port for queue traffic""")
 
     def _mon_port_default(self):
         return util.select_random_ports(1)[0]
 
-    notifier_port = Int(config=True,
+    notifier_port = Integer(config=True,
         help="""PUB port for sending engine status notifications""")
 
     def _notifier_port_default(self):
@@ -331,8 +331,8 @@ class Hub(SessionFactory):
     dead_engines=Set() # completed msg_ids keyed by engine_id
     unassigned=Set() # set of task msg_ds not yet assigned a destination
     incoming_registrations=Dict()
-    registration_timeout=Int()
-    _idcounter=Int(0)
+    registration_timeout=Integer()
+    _idcounter=Integer(0)
 
     # objects from constructor:
     query=Instance(ZMQStream)

--- a/IPython/parallel/controller/scheduler.py
+++ b/IPython/parallel/controller/scheduler.py
@@ -40,7 +40,7 @@ from zmq.eventloop import ioloop, zmqstream
 from IPython.external.decorator import decorator
 from IPython.config.application import Application
 from IPython.config.loader import Config
-from IPython.utils.traitlets import Instance, Dict, List, Set, Int, Enum, CBytes
+from IPython.utils.traitlets import Instance, Dict, List, Set, Integer, Enum, CBytes
 
 from IPython.parallel import error
 from IPython.parallel.factory import SessionFactory
@@ -131,7 +131,7 @@ class TaskScheduler(SessionFactory):
 
     """
 
-    hwm = Int(0, config=True, shortname='hwm',
+    hwm = Integer(0, config=True, shortname='hwm',
         help="""specify the High Water Mark (HWM) for the downstream
         socket in the Task scheduler. This is the maximum number
         of allowed outstanding tasks on each engine."""

--- a/IPython/parallel/engine/engine.py
+++ b/IPython/parallel/engine/engine.py
@@ -25,7 +25,7 @@ from zmq.eventloop import ioloop, zmqstream
 from IPython.external.ssh import tunnel
 # internal
 from IPython.utils.traitlets import (
-    Instance, Dict, Int, Type, CFloat, Unicode, CBytes, Bool
+    Instance, Dict, Integer, Type, CFloat, Unicode, CBytes, Bool
 )
 # from IPython.utils.localinterfaces import LOCALHOST
 
@@ -63,7 +63,7 @@ class EngineFactory(RegistrationFactory):
 
     # not configurable:
     user_ns=Dict()
-    id=Int(allow_none=True)
+    id=Integer(allow_none=True)
     registrar=Instance('zmq.eventloop.zmqstream.ZMQStream')
     kernel=Instance(Kernel)
 

--- a/IPython/parallel/engine/streamkernel.py
+++ b/IPython/parallel/engine/streamkernel.py
@@ -34,7 +34,7 @@ import zmq
 from zmq.eventloop import ioloop, zmqstream
 
 # Local imports.
-from IPython.utils.traitlets import Instance, List, Int, Dict, Set, Unicode, CBytes
+from IPython.utils.traitlets import Instance, List, Integer, Dict, Set, Unicode, CBytes
 from IPython.zmq.completer import KernelCompleter
 
 from IPython.parallel.error import wrap_exception
@@ -74,7 +74,7 @@ class Kernel(SessionFactory):
         help="List of lines to execute")
 
     # identities:
-    int_id = Int(-1)
+    int_id = Integer(-1)
     bident = CBytes()
     ident = Unicode()
     def _ident_changed(self, name, old, new):

--- a/IPython/parallel/factory.py
+++ b/IPython/parallel/factory.py
@@ -24,7 +24,7 @@ import zmq
 from zmq.eventloop.ioloop import IOLoop
 
 from IPython.config.configurable import Configurable
-from IPython.utils.traitlets import Int, Instance, Unicode
+from IPython.utils.traitlets import Integer, Instance, Unicode
 
 from IPython.parallel.util import select_random_ports
 from IPython.zmq.session import Session, SessionFactory
@@ -48,7 +48,7 @@ class RegistrationFactory(SessionFactory):
         help="""The IP address for registration.  This is generally either
         '127.0.0.1' for loopback only or '*' for all interfaces.
         [default: '127.0.0.1']""")
-    regport = Int(config=True,
+    regport = Integer(config=True,
         help="""The port on which the Hub listens for registration.""")
     def _regport_default(self):
         return select_random_ports(1)[0]

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -26,11 +26,12 @@ from unittest import TestCase
 
 from IPython.utils.traitlets import (
     HasTraits, MetaHasTraits, TraitType, Any, CBytes,
-    Int, Long, Float, Complex, Bytes, Unicode, TraitError,
+    Int, Long, Integer, Float, Complex, Bytes, Unicode, TraitError,
     Undefined, Type, This, Instance, TCPAddress, List, Tuple,
     ObjectName, DottedObjectName
 )
 from IPython.utils import py3compat
+from IPython.testing.decorators import skipif
 
 #-----------------------------------------------------------------------------
 # Helper classes for testing
@@ -630,6 +631,11 @@ class TraitTestBase(TestCase):
     def test_default_value(self):
         if hasattr(self, '_default_value'):
             self.assertEquals(self._default_value, self.obj.value)
+    
+    def tearDown(self):
+        # restore default value after tests, if set
+        if hasattr(self, '_default_value'):
+            self.obj.value = self._default_value
 
 
 class AnyTrait(HasTraits):
@@ -658,7 +664,7 @@ class TestInt(TraitTestBase):
                       10.1, -10.1, '10L', '-10L', '10.1', '-10.1', u'10L',
                       u'-10L', u'10.1', u'-10.1',  '10', '-10', u'10', u'-10']
     if not py3compat.PY3:
-        _bad_values.extend([10L, -10L])
+        _bad_values.extend([10L, -10L, 10*sys.maxint, -10*sys.maxint])
 
 
 class LongTrait(HasTraits):
@@ -675,6 +681,35 @@ class TestLong(TraitTestBase):
                       None, 1j, 10.1, -10.1, '10', '-10', '10L', '-10L', '10.1',
                       '-10.1', u'10', u'-10', u'10L', u'-10L', u'10.1',
                       u'-10.1']
+    if not py3compat.PY3:
+        # maxint undefined on py3, because int == long
+        _good_values.extend([10*sys.maxint, -10*sys.maxint])
+    
+    @skipif(py3compat.PY3, "not relevant on py3")
+    def test_cast_small(self):
+        """Long casts ints to long"""
+        self.obj.value = 10
+        self.assertEquals(type(self.obj.value), long)
+        
+
+class IntegerTrait(HasTraits):
+    value = Integer(1)
+    
+class TestInteger(TestLong):
+    obj = IntegerTrait()
+    _default_value = 1
+    
+    def coerce(self, n):
+        return int(n)
+    
+    @skipif(py3compat.PY3, "not relevant on py3")
+    def test_cast_small(self):
+        """Integer casts small longs to int"""
+        if py3compat.PY3:
+            raise SkipTest("not relevant on py3")
+        
+        self.obj.value = 100L
+        self.assertEquals(type(self.obj.value), int)
 
 
 class FloatTrait(HasTraits):

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -863,10 +863,10 @@ class Any(TraitType):
 
 
 class Int(TraitType):
-    """A integer trait."""
+    """An int trait."""
 
     default_value = 0
-    info_text = 'an integer'
+    info_text = 'an int'
 
     def validate(self, obj, value):
         if isinstance(value, int):
@@ -884,6 +884,7 @@ class CInt(Int):
 
 if py3compat.PY3:
     Long, CLong = Int, CInt
+    Integer = Int
 else:
     class Long(TraitType):
         """A long integer trait."""
@@ -907,6 +908,24 @@ else:
                 return long(value)
             except:
                 self.error(obj, value)
+
+    class Integer(TraitType):
+        """An integer trait.
+        
+        Longs that are unnecessary (<= sys.maxint) are cast to ints."""
+
+        default_value = 0
+        info_text = 'an integer'
+
+        def validate(self, obj, value):
+            if isinstance(value, int):
+                return value
+            elif isinstance(value, long):
+                # downcast longs that fit in int:
+                # note that int(n > sys.maxint) returns a long, so
+                # we don't need a condition on this cast
+                return int(value)
+            self.error(obj, value)
 
 
 class Float(TraitType):

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -39,7 +39,7 @@ from IPython.utils import py3compat
 from IPython.utils.jsonutil import json_clean
 from IPython.lib import pylabtools
 from IPython.utils.traitlets import (
-    Any, List, Instance, Float, Dict, Bool, Int, Unicode, CaselessStrEnum
+    Any, List, Instance, Float, Dict, Bool, Unicode, CaselessStrEnum
 )
 
 from entry_point import base_launch_kernel

--- a/IPython/zmq/kernelapp.py
+++ b/IPython/zmq/kernelapp.py
@@ -32,7 +32,7 @@ from IPython.utils import io
 from IPython.utils.localinterfaces import LOCALHOST
 from IPython.utils.path import filefind
 from IPython.utils.py3compat import str_to_bytes
-from IPython.utils.traitlets import (Any, Instance, Dict, Unicode, Int, Bool,
+from IPython.utils.traitlets import (Any, Instance, Dict, Unicode, Integer, Bool,
                                         DottedObjectName)
 from IPython.utils.importstring import import_item
 # local imports
@@ -107,10 +107,10 @@ class KernelApp(BaseIPythonApplication):
     # connection info:
     ip = Unicode(LOCALHOST, config=True,
         help="Set the IP or interface on which the kernel will listen.")
-    hb_port = Int(0, config=True, help="set the heartbeat port [default: random]")
-    shell_port = Int(0, config=True, help="set the shell (XREP) port [default: random]")
-    iopub_port = Int(0, config=True, help="set the iopub (PUB) port [default: random]")
-    stdin_port = Int(0, config=True, help="set the stdin (XREQ) port [default: random]")
+    hb_port = Integer(0, config=True, help="set the heartbeat port [default: random]")
+    shell_port = Integer(0, config=True, help="set the shell (XREP) port [default: random]")
+    iopub_port = Integer(0, config=True, help="set the iopub (PUB) port [default: random]")
+    stdin_port = Integer(0, config=True, help="set the stdin (XREQ) port [default: random]")
     connection_file = Unicode('', config=True, 
     help="""JSON file in which to store connection info [default: kernel-<pid>.json]
     
@@ -128,11 +128,11 @@ class KernelApp(BaseIPythonApplication):
         config=True, help="The importstring for the DisplayHook factory")
 
     # polling
-    parent = Int(0, config=True,
+    parent = Integer(0, config=True,
         help="""kill this process if its parent dies.  On Windows, the argument
         specifies the HANDLE of the parent process, otherwise it is simply boolean.
         """)
-    interrupt = Int(0, config=True,
+    interrupt = Integer(0, config=True,
         help="""ONLY USED ON WINDOWS
         Interrupt this process when the parent is signalled.
         """)

--- a/IPython/zmq/kernelmanager.py
+++ b/IPython/zmq/kernelmanager.py
@@ -35,7 +35,7 @@ from zmq.eventloop import ioloop
 from IPython.config.loader import Config
 from IPython.utils.localinterfaces import LOCALHOST, LOCAL_IPS
 from IPython.utils.traitlets import (
-    HasTraits, Any, Instance, Type, Unicode, Int, Bool
+    HasTraits, Any, Instance, Type, Unicode, Integer, Bool
 )
 from IPython.utils.py3compat import str_to_bytes
 from IPython.zmq.entry_point import write_connection_file
@@ -713,10 +713,10 @@ class KernelManager(HasTraits):
     def _ip_changed(self, name, old, new):
         if new == '*':
             self.ip = '0.0.0.0'
-    shell_port = Int(0)
-    iopub_port = Int(0)
-    stdin_port = Int(0)
-    hb_port = Int(0)
+    shell_port = Integer(0)
+    iopub_port = Integer(0)
+    stdin_port = Integer(0)
+    hb_port = Integer(0)
 
     # The classes to use for the various channels.
     shell_channel_class = Type(ShellSocketChannel)


### PR DESCRIPTION
Most `Int` traits are now `Integers`

Integer differs from Long only in that small `long`s are cast to `int`, rather than
all `int`s being cast to `long`:

```
Integer(4L) => 4
Long(4) => 4L
```

closes gh-942
