### PR TITLE
defer to stdlib for path.get_home_dir()

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -552,10 +552,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
 
     def init_pushd_popd_magic(self):
         # for pushd/popd management
-        try:
-            self.home_dir = get_home_dir()
-        except HomeDirError, msg:
-            fatal(msg)
+        self.home_dir = get_home_dir()
 
         self.dir_stack = []
 
@@ -1751,12 +1748,10 @@ class InteractiveShell(SingletonConfigurable, Magic):
             # Or if libedit is used, load editrc.
             inputrc_name = os.environ.get('INPUTRC')
             if inputrc_name is None:
-                home_dir = get_home_dir()
-                if home_dir is not None:
-                    inputrc_name = '.inputrc'
-                    if readline.uses_libedit:
-                        inputrc_name = '.editrc'
-                    inputrc_name = os.path.join(home_dir, inputrc_name)
+                inputrc_name = '.inputrc'
+                if readline.uses_libedit:
+                    inputrc_name = '.editrc'
+                inputrc_name = os.path.join(self.home_dir, inputrc_name)
             if os.path.isfile(inputrc_name):
                 try:
                     readline.read_init_file(inputrc_name)

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -141,7 +141,7 @@ def test_get_home_dir_2():
     #fake filename for IPython.__init__
     IPython.__file__ = abspath(join(HOME_TEST_DIR, "Library.zip/IPython/__init__.py")).lower()
 
-    home_dir = path.get_home_dir()
+    home_dir = path.get_home_dir(True)
     nt.assert_equal(home_dir, abspath(HOME_TEST_DIR).lower())
 
 
@@ -149,7 +149,7 @@ def test_get_home_dir_2():
 def test_get_home_dir_3():
     """get_home_dir() uses $HOME if set"""
     env["HOME"] = HOME_TEST_DIR
-    home_dir = path.get_home_dir()
+    home_dir = path.get_home_dir(True)
     nt.assert_equal(home_dir, env["HOME"])
 
 
@@ -159,14 +159,14 @@ def test_get_home_dir_4():
 
     if 'HOME' in env: del env['HOME']
     # this should still succeed, but we don't know what the answer should be
-    home = path.get_home_dir()
+    home = path.get_home_dir(True)
     nt.assert_true(path._writable_dir(home))
 
 @with_environment
 def test_get_home_dir_5():
     """raise HomeDirError if $HOME is specified, but not a writable dir"""
     env['HOME'] = abspath(HOME_TEST_DIR+'garbage')
-    nt.assert_raises(path.HomeDirError, path.get_home_dir)
+    nt.assert_raises(path.HomeDirError, path.get_home_dir, True)
 
 @with_environment
 def test_get_ipython_dir_1():


### PR DESCRIPTION
We have elaborate and fragile logic for determining
home dir, and it is ultimately less reliable than the stdlib behavior
used for `os.path.expanduser('~')`.  This commit defers to that in
all cases other than a bundled Python in py2exe/py2app environments.

The one case where the default guess will _not_ be correct, based on
inline comments, is on WinHPC, where all paths must be UNC (`\\foo`), and
thus HOMESHARE is the logical first choice.  However, HOMESHARE is
the wrong answer in approximately all other cases where it is defined,
and the fix for WinHPC users is the trivial `HOME=%HOMESHARE%`.

This removes the various tests of our Windows path resolution logic,
which are no longer relevant. Further, $HOME is used by the stdlib
as first priority on _all_ platforms, so tests for this behavior are
no longer posix-specific.

closes gh-970
closes gh-747
