### PR TITLE
Drop consecutive duplicates when refilling readline history

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1798,15 +1798,16 @@ class InteractiveShell(SingletonConfigurable, Magic):
         for _, _, cell in self.history_manager.get_tail(1000,
                                                         include_latest=True):
             # Ignore blank lines and consecutive duplicates
-            if cell.strip() and cell.rstrip()!=last_cell:
+            cell = cell.rstrip()
+            if cell and (cell != last_cell):
                 if self.multiline_history:
-                      self.readline.add_history(py3compat.unicode_to_str(cell.rstrip(),
-                                                                         stdin_encoding))
+                      self.readline.add_history(py3compat.unicode_to_str(cell,
+                                                                stdin_encoding))
                 else:
                     for line in cell.splitlines():
                         self.readline.add_history(py3compat.unicode_to_str(line,
-                                                                           stdin_encoding))
-                last_cell = cell.rstrip()
+                                                                stdin_encoding))
+                last_cell = cell
 
     def set_next_input(self, s):
         """ Sets the 'default' input string for the next command line.

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1818,9 +1818,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
         [D:\ipython]|1> _ip.set_next_input("Hello Word")
         [D:\ipython]|2> Hello Word_  # cursor is here
         """
-        if isinstance(s, unicode):
-            s = s.encode(self.stdin_encoding, 'replace')
-        self.rl_next_input = s
+        self.rl_next_input = py3compat.cast_bytes_py2(s)
 
     # Maybe move this to the terminal subclass?
     def pre_readline(self):

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1794,9 +1794,11 @@ class InteractiveShell(SingletonConfigurable, Magic):
         # Load the last 1000 lines from history
         self.readline.clear_history()
         stdin_encoding = sys.stdin.encoding or "utf-8"
+        last_cell = u""
         for _, _, cell in self.history_manager.get_tail(1000,
                                                         include_latest=True):
-            if cell.strip(): # Ignore blank lines
+            # Ignore blank lines and consecutive duplicates
+            if cell.strip() and cell.rstrip()!=last_cell:
                 if self.multiline_history:
                       self.readline.add_history(py3compat.unicode_to_str(cell.rstrip(),
                                                                          stdin_encoding))
@@ -1804,6 +1806,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
                     for line in cell.splitlines():
                         self.readline.add_history(py3compat.unicode_to_str(line,
                                                                            stdin_encoding))
+                last_cell = cell.rstrip()
 
     def set_next_input(self, s):
         """ Sets the 'default' input string for the next command line.

--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -197,7 +197,13 @@ class IPythonWidget(FrontendWidget):
         # reset retry flag
         self._retrying_history_request = False
         history_items = content['history']
-        items = [ line.rstrip() for _, _, line in history_items ]
+        items = []
+        last_cell = u""
+        for _, _, cell in history_items:
+            cell = cell.rstrip()
+            if cell != last_cell:
+                items.append(cell)
+                last_cell = cell
         self._set_history(items)
 
     def _handle_pyout(self, msg):


### PR DESCRIPTION
I'd better fix that bug if I'm getting a tshirt for it.

This operates at the cell level, even if the user disables multiline_history in the terminal, so you can define a multiline function twice, and only have to flip through it once after you start a new session.

There's an added bonus fix for setting the next input at the terminal on Python 3.
