### PR TITLE
Quick fix for os.system requiring str parameter

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2082,7 +2082,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
             with AvoidUNCPath() as path:
                 if path is not None:
                     cmd = '"pushd %s &&"%s' % (path, cmd)
-                cmd = cmd.encode(sys.stdin.encoding)
+                cmd = py3compat.unicode_to_str(cmd)
                 ec = os.system(cmd)
         else:
             ec = os.system(cmd)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2082,6 +2082,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
             with AvoidUNCPath() as path:
                 if path is not None:
                     cmd = '"pushd %s &&"%s' % (path, cmd)
+                cmd = cmd.encode(sys.stdin.encoding)
                 ec = os.system(cmd)
         else:
             ec = os.system(cmd)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2085,6 +2085,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
                 cmd = py3compat.unicode_to_str(cmd)
                 ec = os.system(cmd)
         else:
+            cmd = py3compat.unicode_to_str(cmd)
             ec = os.system(cmd)
         
         # We explicitly do NOT return the subprocess status code, because

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -220,3 +220,11 @@ class TestSafeExecfileNonAsciiPath(unittest.TestCase):
         """Test safe_execfile with non-ascii path
         """
         _ip.shell.safe_execfile(self.fname, {}, raise_exceptions=True)
+
+
+class TestSystemRaw(unittest.TestCase):
+    def test_1(self):
+        """Test system_raw with non-ascii cmd
+        """
+        cmd = ur'''python -c "u'åäö'"   '''
+        _ip.shell.system_raw(cmd)


### PR DESCRIPTION
This is work in progress that needs some feedback

os.system seems to require a str parameter, unicode is converted using ascii.

How should we handle this in a python3 compatible way? Should we extract system_raw to utils/py3compat.py?
