### PR TITLE
don't use crash_handler by default

### DIFF
--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -320,6 +320,7 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
         self.shell = TerminalInteractiveShell.instance(config=self.config,
                         display_banner=False, profile_dir=self.profile_dir,
                         ipython_dir=self.ipython_dir)
+        self.shell.configurables.append(self)
 
     def init_banner(self):
         """optionally display the banner"""

--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -81,8 +81,8 @@ class IPAppCrashHandler(CrashHandler):
 
     def __init__(self, app):
         contact_name = release.authors['Fernando'][0]
-        contact_email = release.authors['Fernando'][1]
-        bug_tracker = 'http://github.com/ipython/ipython/issues'
+        contact_email = release.author_email
+        bug_tracker = 'https://github.com/ipython/ipython/issues'
         super(IPAppCrashHandler,self).__init__(
             app, contact_name, contact_email, bug_tracker
         )

--- a/IPython/parallel/apps/baseapp.py
+++ b/IPython/parallel/apps/baseapp.py
@@ -58,8 +58,8 @@ class ParallelCrashHandler(CrashHandler):
 
     def __init__(self, app):
         contact_name = release.authors['Min'][0]
-        contact_email = release.authors['Min'][1]
-        bug_tracker = 'http://github.com/ipython/ipython/issues'
+        contact_email = release.author_email
+        bug_tracker = 'https://github.com/ipython/ipython/issues'
         super(ParallelCrashHandler,self).__init__(
             app, contact_name, contact_email, bug_tracker
         )

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -780,6 +780,7 @@ class IPKernelApp(KernelApp, InteractiveShellApp):
 
     def init_shell(self):
         self.shell = self.kernel.shell
+        self.shell.configurables.append(self)
 
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Now the excepthook shows a regular traceback, with a brief message about reporting bugs and how to enable to the big crash handler.  Adding a `more/0` to interact inside `if more:`, I get:

```
In [1]: if 1:
Traceback (most recent call last):
  File "/prefix/bin/ipython", line 9, in <module>
    load_entry_point('ipython==0.12.dev', 'console_scripts', 'ipython')()
  File "/prefix/IPython/frontend/terminal/ipapp.py", line 393, in launch_new_instance
    app.start()
  File "/prefix/IPython/frontend/terminal/ipapp.py", line 367, in start
    self.shell.mainloop()
  File "/prefix/IPython/frontend/terminal/interactiveshell.py", line 220, in mainloop
    self.interact(display_banner=display_banner)
  File "/prefix/IPython/frontend/terminal/interactiveshell.py", line 288, in interact
    more/0
ZeroDivisionError: integer division or modulo by zero

If you suspect this is an IPython bug, please report it at:
    https://github.com/ipython/ipython/issues
or send an email to the mailing list at ipython-dev@scipy.org

You can enable a much more verbose crash handler with:
    %config Application.verbose_crash=True
```

small fixes along the way:
- current Application added to configurables list, for use in `%config`.
- email addresses in full crash reports changed to ipython-dev, so they don't go straight to individual users.

Should close #695, and ameliorate #833 (doesn't fix the bug, but the message is more sensible)
