### PR TITLE
escape minus signs in manpages

### DIFF
--- a/docs/man/ipcluster.1
+++ b/docs/man/ipcluster.1
@@ -20,7 +20,7 @@ files and security files.
 The first positional argument should be one of: {start, stop, engines},
 which are the available subcommands.
 
-For detailed help on each, type "ipcluster CMD --help". Briefly:
+For detailed help on each, type "ipcluster CMD \-\-help". Briefly:
 
   start         start an IPython cluster
   stop          stop a running IPython cluster
@@ -31,7 +31,7 @@ For detailed help on each, type "ipcluster CMD --help". Briefly:
 \-h, \-\-help
 show help message and exit
 .SH EXAMPLE
-ipcluster start --n=4
+ipcluster start \-\-n=4
 
 This command will start 4 IPython engines on the local computer.
 .SH SEE ALSO

--- a/docs/man/ipcontroller.1
+++ b/docs/man/ipcontroller.1
@@ -17,7 +17,7 @@ show this help message and exit
 .TP
 .B
 .TP
-.B \-\-no-secure
+.B \-\-no\-secure
 Don't authenticate messages.
 .TP
 .B \-\-usethreads
@@ -26,7 +26,7 @@ Use threads instead of processes for the schedulers
 .B \-\-init
 Initialize profile with default config files
 .TP
-.B \-\-log-to-file
+.B \-\-log\-to\-file
 send log output to a file
 .TP
 .B \-\-reuse
@@ -70,11 +70,11 @@ Default: '127.0.0.1'
 The IP address for registration.  This is generally either '127.0.0.1' for
 loopback only or '*' for all interfaces. [default: '127.0.0.1']
 .TP
-.B \-\-log-url=<Unicode> (BaseParallelApplication.log_url)
+.B \-\-log\-url=<Unicode> (BaseParallelApplication.log_url)
 Default: ''
 The ZMQ URL of the iplogger to aggregate logging.
 .TP
-.B \-\-work-dir=<Unicode> (BaseParallelApplication.work_dir)
+.B \-\-work\-dir=<Unicode> (BaseParallelApplication.work_dir)
 Default: u'/Users/minrk/dev/ip/mine/docs/man'
 Set the working dir for the process.
 .TP
@@ -82,7 +82,7 @@ Set the working dir for the process.
 Default: 0
 The port on which the Hub listens for registration.
 .TP
-.B \-\-profile-dir=<Unicode> (ProfileDir.location)
+.B \-\-profile\-dir=<Unicode> (ProfileDir.location)
 Default: u''
 Set the profile location directly. This overrides the logic used by the
 `profile` option.
@@ -91,11 +91,11 @@ Set the profile location directly. This overrides the logic used by the
 Default: ''
 The UUID identifying this session.
 .TP
-.B \-\-log-to-file=<Bool> (BaseParallelApplication.log_to_file)
+.B \-\-log\-to\-file=<Bool> (BaseParallelApplication.log_to_file)
 Default: False
 whether to log to a file
 .TP
-.B \-\-ipython-dir=<Unicode> (BaseIPythonApplication.ipython_dir)
+.B \-\-ipython\-dir=<Unicode> (BaseIPythonApplication.ipython_dir)
 Default: u'/Users/minrk/.ipython'
 The name of the IPython directory. This directory is used for logging
 configuration (through profiles), history storage, etc. The default is
@@ -115,7 +115,7 @@ Username for the Session. Default is your system username.
 Default: 1000
 The frequency at which the Hub pings the engines for heartbeats  (in ms)
 .TP
-.B \-\-log-level=<Enum> (Application.log_level)
+.B \-\-log\-level=<Enum> (Application.log_level)
 Default: 30
 Choices: (0, 10, 20, 30, 40, 50, 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL')
 Set the log level by value or name.
@@ -125,7 +125,7 @@ Default: u''
 The external IP or domain name of the Controller, used for disambiguating
 engine and client connections.
 .TP
-.B \-\-clean-logs=<Bool> (BaseParallelApplication.clean_logs)
+.B \-\-clean\-logs=<Bool> (BaseParallelApplication.clean_logs)
 Default: False
 whether to cleanup old logfiles before starting
 .TP

--- a/docs/man/ipython.1
+++ b/docs/man/ipython.1
@@ -35,8 +35,8 @@ more.
 .SH REGULAR OPTIONS
 All options that take values, must be of the form '\-\-name=value', but
 flags that take no arguments are allowed a single '\-' to allow common
-patterns like: 'ipython -i myscript.py'.  To pass arguments to scripts,
-rather than to IPython, specify them after '--'.
+patterns like: 'ipython \-i myscript.py'.  To pass arguments to scripts,
+rather than to IPython, specify them after '\-\-'.
 .br
 .sp 1
 All options can also be set from your ipython_config.py configuration file.
@@ -50,22 +50,22 @@ All options with a [no] prepended can be specified in negated form
 .TP
 .B \-h, \-\-help
 Show summary of options.
-.B \-\-no-autoindent
+.B \-\-no\-autoindent
 Turn off autoindenting.
 .TP
-.B \-\-autoedit-syntax
+.B \-\-autoedit\-syntax
 Turn on auto editing of files with syntax errors.
 .TP
 .B \-\-pylab
 Pre-load matplotlib and numpy for interactive use with
 the default matplotlib backend.
 .TP
-.B \-\-confirm-exit
+.B \-\-confirm\-exit
 Set to confirm when you try to exit IPython with an EOF (Control-D
 in Unix, Control-Z/Enter in Windows). By typing 'exit' or 'quit',
 you can force a direct exit without any confirmation.
 .TP
-.B \-\-deep-reload
+.B \-\-deep\-reload
 Enable deep (recursive) reloading by default. IPython can use the
 deep_reload module which reloads changes in modules recursively (it
 replaces the reload() function, so you don't need to change anything to
@@ -76,13 +76,13 @@ deep_reload will still be available as dreload(). This feature is off
 by default [which means that you have both normal reload() and
 dreload()].
 .TP
-.B \-\-no-autoedit-syntax
+.B \-\-no\-autoedit\-syntax
 Turn off auto editing of files with syntax errors.
 .TP
-.B \-\-term-title
+.B \-\-term\-title
 Enable auto setting the terminal title.
 .TP
-.B \-\-no-confirm-exit
+.B \-\-no\-confirm\-exit
 Don't prompt the user when exiting.
 .TP
 .B \-\-autoindent
@@ -91,7 +91,7 @@ Turn on autoindenting.
 .B \-\-classic
 Gives IPython a similar feel to the classic Python prompt.
 .TP
-.B \-\-no-automagic
+.B \-\-no\-automagic
 Turn off the auto calling of magic commands.
 .TP
 .B \-\-banner
@@ -101,17 +101,17 @@ Display a banner upon starting IPython.
 Turn on the auto calling of magic commands. Type %%magic at the
 IPython  prompt  for  more information.
 .TP
-.B \-\-no-deep-reload
+.B \-\-no\-deep\-reload
 Disable deep (recursive) reloading by default.
 .TP
-.B \-\-no-term-title
+.B \-\-no\-term\-title
 Disable auto setting the terminal title.
 .TP
 .B \-\-nosep
 Eliminate all spacing between prompts.
 .TP
 .B \-\-i
-also works as '-i'
+also works as '\-i'
 If running code from the command line, become interactive afterwards.
 .TP
 .B \-\-debug
@@ -126,7 +126,7 @@ set log level to logging.CRITICAL (minimize logging output)
 .B \-\-pdb
 Enable auto calling the pdb debugger after every exception.
 .TP
-.B \-\-color-info
+.B \-\-color\-info
 IPython can display information about objects via a set of func-
 tions, and optionally can use colors for this, syntax highlighting
 source code and various other elements.  However, because this
@@ -140,19 +140,19 @@ interactively for testing.
 .B \-\-init
 Initialize profile with default config files
 .TP
-.B \-\-no-pdb
+.B \-\-no\-pdb
 Disable auto calling the pdb debugger after every exception.
 .TP
 .B \-\-quick
 Enable quick startup with no config files.
 .TP
-.B \-\-no-color-info
+.B \-\-no\-color\-info
 Disable using colors for info related things.
 .TP
-.B \-\-no-pprint
+.B \-\-no\-pprint
 Disable auto auto pretty printing of results.
 .TP
-.B \-\-no-banner
+.B \-\-no\-banner
 Don't display a banner upon starting IPython.
 .TP
 .B \-\-profile=<Unicode> (BaseIPythonApplication.profile)
@@ -177,7 +177,7 @@ it is not applied if there are no more arguments on the line, and '2' for
 \&'full' autocall, where all callable objects are automatically called (even
 if no arguments are present). The default is '1'.
 .TP
-.B \-\-ipython-dir=<Unicode> (BaseIPythonApplication.ipython_dir)
+.B \-\-ipython\-dir=<Unicode> (BaseIPythonApplication.ipython_dir)
 Default: u'/Users/minrk/.ipython'
 The name of the IPython directory. This directory is used for logging
 configuration (through profiles), history storage, etc. The default is
@@ -199,7 +199,7 @@ matplotlib backend and loop integration.
 Default: ''
 dotted module name of an IPython extension to load.
 .TP
-.B \-\-log-level=<Enum> (Application.log_level)
+.B \-\-log\-level=<Enum> (Application.log_level)
 Default: 30
 Choices: (0, 10, 20, 30, 40, 50, 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL')
 Set the log level by value or name.
@@ -209,7 +209,7 @@ Default: 'LightBG'
 Choices: ('NoColor', 'LightBG', 'Linux')
 Set the color scheme (NoColor, Linux, or LightBG).
 .TP
-.B \-\-cache-size=<Int> (InteractiveShell.cache_size)
+.B \-\-cache\-size=<Int> (InteractiveShell.cache_size)
 Default: 1000
 Set the size of the output cache.  The default is 1000, you can change it
 permanently in your config file.  Setting it to 0 completely disables the

--- a/docs/man/irunner.1
+++ b/docs/man/irunner.1
@@ -42,9 +42,9 @@ irunner.py \-\-ipython \-\- \-\-interact script.ipy
 .BR ipython(1)
 .br
 .SH AUTHOR
-\fBirunner\fP is an extension of Ken Schutte <kschutte-AT-csail.mit.edu>'s
-script contributed on the ipython-user list:
-http://mail.scipy.org/pipermail/ipython-user/2006-May/003539.html
+\fBirunner\fP is an extension of Ken Schutte <kschutte\-AT\-csail.mit.edu>'s
+script contributed on the ipython\-user list:
+http://mail.scipy.org/pipermail/ipython\-user/2006\-May/003539.html
 .PP
 This manual page was written by Bernd Zeimetz <bernd@bzed.de>, for the Debian
 project (but may be used by others).  Modified by Fernando Perez


### PR DESCRIPTION
escape minus signs in options and email adresses.
- is interpreted as hyphen not minus and thus can cause copy paste issues in unicode locals
  http://lintian.debian.org/tags/hyphen-used-as-minus-sign.html
