### PR TITLE
emacs freezes when tab is hit in ipython with latest python-mode

### DIFF
--- a/docs/emacs/ipython.el
+++ b/docs/emacs/ipython.el
@@ -221,7 +221,7 @@ the second for a 'normal' command, and the third for a multiline command.")
           py-shell-input-prompt-2-regexp "^   [.][.][.]+: *" )
     ;; select a suitable color-scheme
     (unless (delq nil
-                  (mapcar (lambda (x) (eq (string-match "^--colors=*" x) 0))
+                  (mapcar (lambda (x) (eq (string-match "^--colors*" x) 0))
                           py-python-command-args))
       (setq-default py-python-command-args
 		    (cons (format "--colors=%s"

--- a/docs/emacs/ipython.el
+++ b/docs/emacs/ipython.el
@@ -229,10 +229,12 @@ the second for a 'normal' command, and the third for a multiline command.")
                      (t ; default (backg-mode isn't always set by XEmacs)
                       "LightBG")))
             py-python-command-args))
-    (unless (equal ipython-backup-of-py-python-command py-python-command)
-      (setq ipython-backup-of-py-python-command py-python-command))
-    (setq py-python-command ipython-command))
-
+    (when (boundp 'py-python-command)
+      (unless (equal ipython-backup-of-py-python-command py-python-command)
+        (setq ipython-backup-of-py-python-command py-python-command)))
+    (setq py-python-command ipython-command)
+    (when (boundp 'py-shell-name)
+      (setq py-shell-name ipython-command)))
 
 ;; MODIFY py-shell so that it loads the editing history
 (defadvice py-shell (around py-shell-with-history)

--- a/docs/emacs/ipython.el
+++ b/docs/emacs/ipython.el
@@ -423,6 +423,14 @@ in the current *Python* session."
              (message "Making completion list...%s" "done")))))
 )
 
+;;; if python-mode's keybinding for the tab key wins then py-shell-complete is called
+;;; instead of ipython-complete which result in hanging emacs since there is no shell
+;;; process for python-mode to communicate with
+(defadvice py-shell-complete
+  (around avoid-py-shell-complete activate)
+  (ipython-complete))
+
+
 ;;; autoindent support: patch sent in by Jin Liu <m.liu.jin@gmail.com>,
 ;;; originally written by doxgen@newsmth.net
 ;;; Minor modifications by fperez for xemacs compatibility.


### PR DESCRIPTION
This relates to the issue I filed: https://github.com/ipython/ipython/issues/1010

python-mode has it's own completion function mapped to the tab key. When that mapping wins, the tab will cause that function to fire and it will hang emacs. I've used a defadvice to redirect every call to python-mode's completion function instead to ipython's. 

Honestly, I'm not sure if this is the best way since python-mode seems to try to make all configuration buffer-local and this is more of a global solution. But to get ipython working with python-mode you current have to bypass that anyway. 

Suggestions welcome.

(I've got @deftpunk's patch in here too because I needed that to get ipython working with the most recent python-mode. Sorry if that's messy.)
