### PR TITLE
Fix password hashing for Python 3

### DIFF
--- a/IPython/lib/security.py
+++ b/IPython/lib/security.py
@@ -12,6 +12,7 @@ import random
 # Our own
 from IPython.core.error import UsageError
 from IPython.testing.skipdoctest import skip_doctest
+from IPython.utils.py3compat import cast_bytes, str_to_bytes
 
 #-----------------------------------------------------------------------------
 # Globals
@@ -66,7 +67,7 @@ def passwd(passphrase=None, algorithm='sha1'):
 
     h = hashlib.new(algorithm)
     salt = ('%0' + str(salt_len) + 'x') % random.getrandbits(4 * salt_len)
-    h.update(passphrase + salt)
+    h.update(cast_bytes(passphrase, 'utf-8') + str_to_bytes(salt, 'ascii'))
 
     return ':'.join((algorithm, salt, h.hexdigest()))
 
@@ -112,6 +113,6 @@ def passwd_check(hashed_passphrase, passphrase):
     if len(pw_digest) == 0:
         return False
 
-    h.update(passphrase + salt)
+    h.update(cast_bytes(passphrase, 'utf-8') + str_to_bytes(salt, 'ascii'))
 
     return h.hexdigest() == pw_digest


### PR DESCRIPTION
Correctly handle unicode for Python 3. This may also be needed if you want to use non-ascii characters in passwords with Python 2.

I considered pushing this straight to master, but I wanted to remind people how we're handling Python 3 compatibility. I've used `cast_bytes` on password, so it can be passed in either as bytes or unicode. The salt is generated in the native str type for each platform, so it goes through `str_to_bytes`, which is a no-op on Python 2.

I'll merge this tomorrow, unless anyone objects.
