### PR TITLE
flush stdout/stderr at the end of kernel init

### DIFF
--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -726,6 +726,11 @@ var IPython = (function (IPython) {
         // console.log(reply);
         var msg_type = reply.header.msg_type;
         var cell = this.cell_for_msg(reply.parent_header.msg_id);
+        if (!cell){
+            // message not from this notebook
+            console.log("Received IOPub message not caused by one of my cells");
+            return;
+        }
         var output_types = ['stream','display_data','pyout','pyerr'];
         if (output_types.indexOf(msg_type) >= 0) {
             this.handle_output(cell, msg_type, content);

--- a/IPython/frontend/qt/base_frontend_mixin.py
+++ b/IPython/frontend/qt/base_frontend_mixin.py
@@ -106,4 +106,9 @@ class BaseFrontendMixin(object):
             from this frontend.
         """
         session = self._kernel_manager.session.session
-        return msg['parent_header']['session'] == session
+        parent = msg['parent_header']
+        if not parent:
+            # if the message has no parent, assume it is meant for all frontends
+            return True
+        else:
+            return parent.get('session') == session

--- a/IPython/lib/pylabtools.py
+++ b/IPython/lib/pylabtools.py
@@ -19,6 +19,7 @@ Authors
 # Imports
 #-----------------------------------------------------------------------------
 
+import sys
 from io import BytesIO
 
 from IPython.utils.decorators import flag_calls
@@ -317,6 +318,8 @@ def pylab_activate(user_ns, gui=None, import_all=True, shell=None):
     print """
 Welcome to pylab, a matplotlib-based Python environment [backend: %s].
 For more information, type 'help(pylab)'.""" % backend
+    # flush stdout, just to be safe
+    sys.stdout.flush()
     
     return gui
 

--- a/IPython/zmq/kernelapp.py
+++ b/IPython/zmq/kernelapp.py
@@ -287,6 +287,10 @@ class KernelApp(BaseIPythonApplication):
         self.write_connection_file()
         self.init_io()
         self.init_kernel()
+        # flush stdout/stderr, so that anything written to these streams during
+        # initialization do not get associated with the first execution request
+        sys.stdout.flush()
+        sys.stderr.flush()
 
     def start(self):
         self.heartbeat.start()


### PR DESCRIPTION
call `stdout/stderr.flush()` to prevent print statements, etc. made during initialization from being associated with the first execution.

It turns out that the qtconsole actually depended on this behavior, so a small change was made there, which associates any messages having no parent as being meant for all frontends.  The only messages for which this would normally be true are print statements made during initialization.

This draws an essential difference between the qt frontend and the notebook - in Qt, like the terminal, print statements during init _do_ arrive in the console, below the banner.  In the notebook, they are ignored.

closes #1022
