### PR TITLE
Dollar escape

### DIFF
--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -201,7 +201,10 @@ class InteractiveShellTestCase(unittest.TestCase):
 
     def test_var_expand(self):
         ip = get_ipython()
-        ip.user_ns['f'] = 'Ca\xc3\xb1o'
+        ip.user_ns['f'] = u'Ca\xf1o'
+        self.assertEqual(ip.var_expand(u'echo $f'), u'echo Ca\xf1o')
+
+        ip.user_ns['f'] = b'Ca\xc3\xb1o'
         # This should not raise any exception:
         ip.var_expand(u'echo $f')
 

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -107,3 +107,5 @@ def test_dollar_formatter():
     nt.assert_equals(s, "12")
     s = f.format("$n/{stuff[:5]}", **ns)
     nt.assert_equals(s, "12/hello")
+    s = f.format("$n $$HOME", **ns)
+    nt.assert_equals(s, "12 $HOME")

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -109,3 +109,5 @@ def test_dollar_formatter():
     nt.assert_equals(s, "12/hello")
     s = f.format("$n $$HOME", **ns)
     nt.assert_equals(s, "12 $HOME")
+    s = f.format("${foo}", foo="HOME")
+    nt.assert_equals(s, "$HOME")


### PR DESCRIPTION
As pointed out by @stefanv and @minrk on #822, it should be possible to use a raw $ in shell commands, e.g. for environment variables. This allows that, with the "$$HOME" syntax.
