### PR TITLE
Restore pspersistence, including %store magic, as an extension.

### DIFF
--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -174,7 +174,7 @@ class AliasManager(Configurable):
                                     "because it is a keyword or builtin." % name)
         if not (isinstance(cmd, basestring)):
             raise InvalidAliasError("An alias command must be a string, "
-                                    "got: %r" % name)
+                                    "got: %r" % cmd)
         nargs = cmd.count('%s')
         if nargs>0 and cmd.find('%l')>=0:
             raise InvalidAliasError('The %s and %l specifiers are mutually '


### PR DESCRIPTION
We've had quite a few requests to bring back the `%store` magic of earlier versions.

This simply restores variables when the extension is loaded, so if it's specified in a config file, it will behave the same way as before.
