### PR TITLE
use pyzmq tools where appropriate

### DIFF
--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -32,8 +32,7 @@ import zmq
 # Install the pyzmq ioloop. This has to be done before anything else from
 # tornado is imported.
 from zmq.eventloop import ioloop
-import tornado.ioloop
-tornado.ioloop.IOLoop = ioloop.IOLoop
+ioloop.install()
 
 from tornado import httpserver
 from tornado import web

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -32,7 +32,13 @@ import zmq
 # Install the pyzmq ioloop. This has to be done before anything else from
 # tornado is imported.
 from zmq.eventloop import ioloop
-ioloop.install()
+# FIXME: ioloop.install is new in pyzmq-2.1.7, so remove this conditional
+# when pyzmq dependency is updated beyond that.
+if hasattr(ioloop, 'install'):
+    ioloop.install()
+else:
+    import tornado.ioloop
+    tornado.ioloop.IOLoop = ioloop.IOLoop
 
 from tornado import httpserver
 from tornado import web


### PR DESCRIPTION
ZMQStream is the right object to use for event-driven handling of messages, but instead we had a duplication of half of it in KernelManager.

This removes most of the duplicate code, in favor of using ZMQStream.

also use the pyzmq install() function for using the pyzmq eventloop with tornado, instead of copying its contents into notebookapp.
