### PR TITLE
Intercept <esc> avoid closing websocket on Firefox

### DIFF
--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -57,6 +57,11 @@ var IPython = (function (IPython) {
         $(document).keydown(function (event) {
             // console.log(event);
             if (that.read_only) return;
+            if (event.which === 27) {
+                // Intercept escape at highest level to avoid closing 
+                // websocket connexionwith firefox
+                event.preventDefault();
+            }
             if (event.which === 38) {
                 var cell = that.selected_cell();
                 if (cell.at_top()) {


### PR DESCRIPTION
closes #1031

To rephrase what on #1031, default action of `<esc>` on Firefox is to stop the page loading, and it also closes the websocket conexion.
so I intercept it a notebook level and call `event.preventDefault()`
