### PR TITLE
update copyright to 2011/20xx-2011

### DIFF
--- a/IPython/config/__init__.py
+++ b/IPython/config/__init__.py
@@ -3,7 +3,7 @@
 __docformat__ = "restructuredtext en"
 
 #-------------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/config/tests/test_configurable.py
+++ b/IPython/config/tests/test_configurable.py
@@ -9,7 +9,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2010  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/config/tests/test_loader.py
+++ b/IPython/config/tests/test_loader.py
@@ -9,7 +9,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -9,7 +9,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2010  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.
 #

--- a/IPython/core/autocall.py
+++ b/IPython/core/autocall.py
@@ -13,7 +13,7 @@ Notes
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/core/builtin_trap.py
+++ b/IPython/core/builtin_trap.py
@@ -7,7 +7,7 @@ Authors:
 * Fernando Perez
 """
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010  The IPython Development Team.
+#  Copyright (C) 2010-2011  The IPython Development Team.
 #
 #  Distributed under the terms of the BSD License.
 #

--- a/IPython/core/compilerop.py
+++ b/IPython/core/compilerop.py
@@ -15,7 +15,7 @@ Authors
 # weird problems (often with third-party tools).
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010 The IPython Development Team.
+#  Copyright (C) 2010-2011 The IPython Development Team.
 #
 #  Distributed under the terms of the BSD License.
 #

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -53,7 +53,7 @@ used, and this module (and the readline module) are silently inactive.
 # proper procedure is to maintain its copyright as belonging to the Python
 # Software Foundation (in addition to my own, for all new code).
 #
-#       Copyright (C) 2008-2010 IPython Development Team
+#       Copyright (C) 2008-2011 IPython Development Team
 #       Copyright (C) 2001-2007 Fernando Perez. <fperez@colorado.edu>
 #       Copyright (C) 2001 Python Software Foundation, www.python.org
 #

--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -3,7 +3,7 @@
 These are all loaded by default by IPython.
 """
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010 The IPython Development Team.
+#  Copyright (C) 2010-2011 The IPython Development Team.
 #
 #  Distributed under the terms of the BSD License.
 #

--- a/IPython/core/crashhandler.py
+++ b/IPython/core/crashhandler.py
@@ -9,7 +9,7 @@ Authors:
 
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2001-2007 Fernando Perez. <fperez@colorado.edu>
-#  Copyright (C) 2008-2010  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -7,7 +7,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#       Copyright (C) 2008-2010 The IPython Development Team
+#       Copyright (C) 2008-2011 The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/core/display_trap.py
+++ b/IPython/core/display_trap.py
@@ -9,7 +9,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -11,7 +11,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#       Copyright (C) 2008-2010 The IPython Development Team
+#       Copyright (C) 2008-2011 The IPython Development Team
 #       Copyright (C) 2001-2007 Fernando Perez <fperez@colorado.edu>
 #
 #  Distributed under the terms of the BSD License.  The full license is in

--- a/IPython/core/displaypub.py
+++ b/IPython/core/displaypub.py
@@ -17,7 +17,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#       Copyright (C) 2008-2010 The IPython Development Team
+#       Copyright (C) 2008-2011 The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/core/error.py
+++ b/IPython/core/error.py
@@ -13,7 +13,7 @@ Notes
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/core/extensions.py
+++ b/IPython/core/extensions.py
@@ -7,7 +7,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010  The IPython Development Team
+#  Copyright (C) 2010-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -8,7 +8,7 @@ Authors:
 * Brian Granger
 """
 #-----------------------------------------------------------------------------
-# Copyright (c) 2010, IPython Development Team.
+# Copyright (C) 2010-2011, IPython Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -1,6 +1,6 @@
 """ History related magics and functionality """
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010 The IPython Development Team.
+#  Copyright (C) 2010-2011 The IPython Development Team.
 #
 #  Distributed under the terms of the BSD License.
 #

--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -55,7 +55,7 @@ Authors
 * Brian Granger
 """
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010  The IPython Development Team
+#  Copyright (C) 2010-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/core/ipapi.py
+++ b/IPython/core/ipapi.py
@@ -7,7 +7,7 @@ has been made into a component, this module will be sent to deathrow.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -5,7 +5,7 @@
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2001 Janko Hauser <jhauser@zscout.de> and
 #  Copyright (C) 2001-2007 Fernando Perez <fperez@colorado.edu>
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/core/magic_arguments.py
+++ b/IPython/core/magic_arguments.py
@@ -39,7 +39,7 @@ arguments::
 
 '''
 #-----------------------------------------------------------------------------
-# Copyright (c) 2010, IPython Development Team.
+# Copyright (C) 2010-2011, IPython Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/IPython/core/page.py
+++ b/IPython/core/page.py
@@ -16,7 +16,7 @@ rid of that dependency, we could move it there.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/core/payload.py
+++ b/IPython/core/payload.py
@@ -8,7 +8,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#       Copyright (C) 2008-2010 The IPython Development Team
+#       Copyright (C) 2008-2011 The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/core/payloadpage.py
+++ b/IPython/core/payloadpage.py
@@ -9,7 +9,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2010  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/core/plugin.py
+++ b/IPython/core/plugin.py
@@ -7,7 +7,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010  The IPython Development Team
+#  Copyright (C) 2010-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -14,7 +14,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/core/prompts.py
+++ b/IPython/core/prompts.py
@@ -8,7 +8,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#       Copyright (C) 2008-2010 The IPython Development Team
+#       Copyright (C) 2008-2011 The IPython Development Team
 #       Copyright (C) 2001-2007 Fernando Perez <fperez@colorado.edu>
 #
 #  Distributed under the terms of the BSD License.  The full license is in

--- a/IPython/core/splitinput.py
+++ b/IPython/core/splitinput.py
@@ -10,7 +10,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/core/tests/test_compilerop.py
+++ b/IPython/core/tests/test_compilerop.py
@@ -2,7 +2,7 @@
 """Tests for the compilerop module.
 """
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010 The IPython Development Team.
+#  Copyright (C) 2010-2011 The IPython Development Team.
 #
 #  Distributed under the terms of the BSD License.
 #

--- a/IPython/core/tests/test_inputsplitter.py
+++ b/IPython/core/tests/test_inputsplitter.py
@@ -7,7 +7,7 @@ Authors
 * Robert Kern
 """
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010  The IPython Development Team
+#  Copyright (C) 2010-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/core/tests/test_magic_arguments.py
+++ b/IPython/core/tests/test_magic_arguments.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-# Copyright (c) 2010, IPython Development Team.
+# Copyright (C) 2010-2011, IPython Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -1,7 +1,7 @@
 """Tests for the object inspection functionality.
 """
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010 The IPython Development Team.
+#  Copyright (C) 2010-2011 The IPython Development Team.
 #
 #  Distributed under the terms of the BSD License.
 #

--- a/IPython/core/tests/test_page.py
+++ b/IPython/core/tests/test_page.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010 The IPython Development Team.
+#  Copyright (C) 2010-2011 The IPython Development Team.
 #
 #  Distributed under the terms of the BSD License.
 #

--- a/IPython/core/usage.py
+++ b/IPython/core/usage.py
@@ -2,7 +2,7 @@
 """Usage information for the main IPython applications.
 """
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2010  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #  Copyright (C) 2001-2007 Fernando Perez. <fperez@colorado.edu>
 #
 #  Distributed under the terms of the BSD License.  The full license is in

--- a/IPython/deathrow/PhysicalQInput.py
+++ b/IPython/deathrow/PhysicalQInput.py
@@ -18,7 +18,7 @@ Authors
 - Fernando Perez <Fernando.Perez@berkeley.edu>
 """
 #*****************************************************************************
-#       Copyright (C) 2008-2009 The IPython Development Team
+#       Copyright (C) 2008-2011 The IPython Development Team
 #       Copyright (C) 2001-2007 Fernando Perez <fperez@colorado.edu>
 #
 #  Distributed under the terms of the BSD License.  The full license is in

--- a/IPython/deathrow/PhysicalQInteractive.py
+++ b/IPython/deathrow/PhysicalQInteractive.py
@@ -14,7 +14,7 @@ Authors
 """
 
 #*****************************************************************************
-#       Copyright (C) 2008-2009 The IPython Development Team
+#       Copyright (C) 2008-2011 The IPython Development Team
 #       Copyright (C) 2001-2007 Fernando Perez <fperez@colorado.edu>
 #
 #  Distributed under the terms of the BSD License.  The full license is in

--- a/IPython/deathrow/Shell.py
+++ b/IPython/deathrow/Shell.py
@@ -10,7 +10,7 @@ the new code in IPython.core.shell.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/deathrow/iplib.py
+++ b/IPython/deathrow/iplib.py
@@ -10,7 +10,7 @@ the new code in IPython.core.iplib.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/deathrow/oldfrontend/asyncfrontendbase.py
+++ b/IPython/deathrow/oldfrontend/asyncfrontendbase.py
@@ -7,7 +7,7 @@ __docformat__ = "restructuredtext en"
 __test__ = {}
 
 #-------------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/deathrow/oldfrontend/cocoa/cocoa_frontend.py
+++ b/IPython/deathrow/oldfrontend/cocoa/cocoa_frontend.py
@@ -14,7 +14,7 @@ Author: Barry Wark
 __docformat__ = "restructuredtext en"
 
 #-----------------------------------------------------------------------------
-#       Copyright (C) 2008  The IPython Development Team
+#       Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/deathrow/oldfrontend/cocoa/plugin/IPythonCocoaFrontendLoader.py
+++ b/IPython/deathrow/oldfrontend/cocoa/plugin/IPythonCocoaFrontendLoader.py
@@ -7,7 +7,7 @@ Author: Barry Wark
 __docformat__ = "restructuredtext en"
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/deathrow/oldfrontend/cocoa/plugin/setup.py
+++ b/IPython/deathrow/oldfrontend/cocoa/plugin/setup.py
@@ -10,7 +10,7 @@ Author: Barry Wark
 __docformat__ = "restructuredtext en"
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/deathrow/oldfrontend/cocoa/tests/test_cocoa_frontend.py
+++ b/IPython/deathrow/oldfrontend/cocoa/tests/test_cocoa_frontend.py
@@ -5,7 +5,7 @@ IPython.frontend.cocoa.cocoa_frontend module.
 __docformat__ = "restructuredtext en"
 
 #---------------------------------------------------------------------------
-#       Copyright (C) 2005  The IPython Development Team
+#       Copyright (C) 2005-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/deathrow/oldfrontend/frontendbase.py
+++ b/IPython/deathrow/oldfrontend/frontendbase.py
@@ -11,7 +11,7 @@ Author: Barry Wark
 __docformat__ = "restructuredtext en"
 
 #-------------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/deathrow/oldfrontend/linefrontendbase.py
+++ b/IPython/deathrow/oldfrontend/linefrontendbase.py
@@ -7,7 +7,7 @@ Currently this focuses on synchronous frontends.
 __docformat__ = "restructuredtext en"
 
 #-------------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/deathrow/oldfrontend/prefilterfrontend.py
+++ b/IPython/deathrow/oldfrontend/prefilterfrontend.py
@@ -11,7 +11,7 @@ refactoring.
 """
 
 #-------------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/deathrow/oldfrontend/process/pipedprocess.py
+++ b/IPython/deathrow/oldfrontend/process/pipedprocess.py
@@ -6,7 +6,7 @@ stderr and stdin.
 __docformat__ = "restructuredtext en"
 
 #-------------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/deathrow/oldfrontend/tests/test_asyncfrontendbase.py
+++ b/IPython/deathrow/oldfrontend/tests/test_asyncfrontendbase.py
@@ -2,7 +2,7 @@
 """This file contains unittests for the asyncfrontendbase module."""
 
 #---------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/deathrow/oldfrontend/tests/test_frontendbase.py
+++ b/IPython/deathrow/oldfrontend/tests/test_frontendbase.py
@@ -6,7 +6,7 @@ Test the basic functionality of frontendbase.
 __docformat__ = "restructuredtext en"
 
 #-------------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is
 #  in the file COPYING, distributed as part of this software.

--- a/IPython/deathrow/oldfrontend/tests/test_linefrontend.py
+++ b/IPython/deathrow/oldfrontend/tests/test_linefrontend.py
@@ -6,7 +6,7 @@ Test the LineFrontEnd
 __docformat__ = "restructuredtext en"
 
 #-------------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is
 #  in the file COPYING, distributed as part of this software.

--- a/IPython/deathrow/oldfrontend/tests/test_prefilterfrontend.py
+++ b/IPython/deathrow/oldfrontend/tests/test_prefilterfrontend.py
@@ -6,7 +6,7 @@ Test process execution and IO redirection.
 __docformat__ = "restructuredtext en"
 
 #-------------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is
 #  in the file COPYING, distributed as part of this software.

--- a/IPython/deathrow/oldfrontend/tests/test_process.py
+++ b/IPython/deathrow/oldfrontend/tests/test_process.py
@@ -6,7 +6,7 @@ Test process execution and IO redirection.
 __docformat__ = "restructuredtext en"
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is
 #  in the file COPYING, distributed as part of this software.

--- a/IPython/deathrow/oldfrontend/wx/console_widget.py
+++ b/IPython/deathrow/oldfrontend/wx/console_widget.py
@@ -9,7 +9,7 @@ restricted to after the last prompt.
 __docformat__ = "restructuredtext en"
 
 #-------------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is
 #  in the file COPYING, distributed as part of this software.

--- a/IPython/deathrow/oldfrontend/wx/wx_frontend.py
+++ b/IPython/deathrow/oldfrontend/wx/wx_frontend.py
@@ -12,7 +12,7 @@ widget to provide a text-rendering widget suitable for a terminal.
 __docformat__ = "restructuredtext en"
 
 #-------------------------------------------------------------------------------
-#       Copyright (C) 2008  The IPython Development Team
+#       Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/deathrow/oldfrontend/zopeinterface.py
+++ b/IPython/deathrow/oldfrontend/zopeinterface.py
@@ -10,7 +10,7 @@ Interface, Attribute, implements, classProvides
 __docformat__ = "restructuredtext en"
 
 #-------------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/deathrow/quitter.py
+++ b/IPython/deathrow/quitter.py
@@ -9,7 +9,7 @@ Authors
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/extensions/parallelmagic.py
+++ b/IPython/extensions/parallelmagic.py
@@ -24,7 +24,7 @@ Usage
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/frontend/terminal/embed.py
+++ b/IPython/frontend/terminal/embed.py
@@ -12,7 +12,7 @@ Notes
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -4,7 +4,7 @@
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2001 Janko Hauser <jhauser@zscout.de>
 #  Copyright (C) 2001-2007 Fernando Perez. <fperez@colorado.edu>
-#  Copyright (C) 2008-2010  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -13,7 +13,7 @@ Authors
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2010  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/lib/__init__.py
+++ b/IPython/lib/__init__.py
@@ -4,7 +4,7 @@ Extra capabilities for IPython
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/lib/guisupport.py
+++ b/IPython/lib/guisupport.py
@@ -58,7 +58,7 @@ so you don't have to depend on IPython.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2010  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/lib/inputhook.py
+++ b/IPython/lib/inputhook.py
@@ -4,7 +4,7 @@ Inputhook management for GUI event loop integration.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/lib/inputhookglut.py
+++ b/IPython/lib/inputhookglut.py
@@ -4,7 +4,7 @@ GLUT Inputhook support functions
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/lib/inputhookgtk.py
+++ b/IPython/lib/inputhookgtk.py
@@ -6,7 +6,7 @@ Authors: Brian Granger
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/lib/inputhookpyglet.py
+++ b/IPython/lib/inputhookpyglet.py
@@ -10,7 +10,7 @@ Authors
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/lib/inputhookwx.py
+++ b/IPython/lib/inputhookwx.py
@@ -7,7 +7,7 @@ Authors:  Robin Dunn, Brian Granger, Ondrej Certik
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/lib/latextools.py
+++ b/IPython/lib/latextools.py
@@ -6,7 +6,7 @@ Authors:
 * Brian Granger
 """
 #-----------------------------------------------------------------------------
-# Copyright (c) 2010, IPython Development Team.
+# Copyright (C) 2010-2011, IPython Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/IPython/lib/pylabtools.py
+++ b/IPython/lib/pylabtools.py
@@ -9,7 +9,7 @@ Authors
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2009  The IPython Development Team
+#  Copyright (C) 2009-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/parallel/controller/hub.py
+++ b/IPython/parallel/controller/hub.py
@@ -7,7 +7,7 @@ Authors:
 * Min RK
 """
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010  The IPython Development Team
+#  Copyright (C) 2010-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/parallel/scripts/__init__.py
+++ b/IPython/parallel/scripts/__init__.py
@@ -5,7 +5,7 @@
 __docformat__ = "restructuredtext en"
 
 #-------------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/testing/__init__.py
+++ b/IPython/testing/__init__.py
@@ -2,7 +2,7 @@
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2009  The IPython Development Team
+#  Copyright (C) 2009-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/testing/_paramtestpy2.py
+++ b/IPython/testing/_paramtestpy2.py
@@ -2,7 +2,7 @@
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2009  The IPython Development Team
+#  Copyright (C) 2009-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/testing/_paramtestpy3.py
+++ b/IPython/testing/_paramtestpy3.py
@@ -5,7 +5,7 @@ mailing list.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2009  The IPython Development Team
+#  Copyright (C) 2009-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -37,7 +37,7 @@ Authors
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2009-2010  The IPython Development Team
+#  Copyright (C) 2009-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/testing/globalipapp.py
+++ b/IPython/testing/globalipapp.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2009-2010  The IPython Development Team
+#  Copyright (C) 2009-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -15,7 +15,7 @@ itself from the command line. There are two ways of running this script:
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2009  The IPython Development Team
+#  Copyright (C) 2009-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/testing/ipunittest.py
+++ b/IPython/testing/ipunittest.py
@@ -25,7 +25,7 @@ Authors
 from __future__ import absolute_import
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2009  The IPython Development Team
+#  Copyright (C) 2009-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/testing/nosepatch.py
+++ b/IPython/testing/nosepatch.py
@@ -6,7 +6,7 @@ Once this is fixed in upstream nose we can disable it.
 Note: merely importing this module causes the monkeypatch to be applied."""
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2009  The IPython Development Team
+#  Copyright (C) 2009-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/testing/tests/test_ipunittest.py
+++ b/IPython/testing/tests/test_ipunittest.py
@@ -34,7 +34,7 @@ Authors
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2009  The IPython Development Team
+#  Copyright (C) 2009-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/testing/tests/test_tools.py
+++ b/IPython/testing/tests/test_tools.py
@@ -4,7 +4,7 @@ Tests for testing.tools
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -18,7 +18,7 @@ Authors
 from __future__ import absolute_import
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2009  The IPython Development Team
+#  Copyright (C) 2009-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/_process_common.py
+++ b/IPython/utils/_process_common.py
@@ -5,7 +5,7 @@ of subprocess utilities, and it contains tools that are common to all of them.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010  The IPython Development Team
+#  Copyright (C) 2010-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/_process_posix.py
+++ b/IPython/utils/_process_posix.py
@@ -4,7 +4,7 @@ This file is only meant to be imported by process.py, not by end-users.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010  The IPython Development Team
+#  Copyright (C) 2010-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/_process_win32.py
+++ b/IPython/utils/_process_win32.py
@@ -4,7 +4,7 @@ This file is only meant to be imported by process.py, not by end-users.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010  The IPython Development Team
+#  Copyright (C) 2010-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/attic.py
+++ b/IPython/utils/attic.py
@@ -7,7 +7,7 @@ TO ANOTHER APPROPRIATE MODULE IN IPython.utils.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/codeutil.py
+++ b/IPython/utils/codeutil.py
@@ -13,7 +13,7 @@ Reference: A. Tremols, P Cogolo, "Python Cookbook," p 302-305
 __docformat__ = "restructuredtext en"
 
 #-------------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/cursesimport.py
+++ b/IPython/utils/cursesimport.py
@@ -4,7 +4,7 @@ See if we have curses.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/data.py
+++ b/IPython/utils/data.py
@@ -3,7 +3,7 @@
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/decorators.py
+++ b/IPython/utils/decorators.py
@@ -7,7 +7,7 @@ go into another topical module in :mod:`IPython.utils`.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/dir2.py
+++ b/IPython/utils/dir2.py
@@ -3,7 +3,7 @@
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/doctestreload.py
+++ b/IPython/utils/doctestreload.py
@@ -4,7 +4,7 @@ A utility for handling the reloading of doctest.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/frame.py
+++ b/IPython/utils/frame.py
@@ -4,7 +4,7 @@ Utilities for working with stack frames.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/generics.py
+++ b/IPython/utils/generics.py
@@ -5,7 +5,7 @@ See http://cheeseshop.python.org/pypi/simplegeneric.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/growl.py
+++ b/IPython/utils/growl.py
@@ -4,7 +4,7 @@ Utilities using Growl on OS X for notifications.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/importstring.py
+++ b/IPython/utils/importstring.py
@@ -8,7 +8,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -4,7 +4,7 @@ IO related utilities.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/ipstruct.py
+++ b/IPython/utils/ipstruct.py
@@ -8,7 +8,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/jsonutil.py
+++ b/IPython/utils/jsonutil.py
@@ -1,7 +1,7 @@
 """Utilities to manipulate JSON objects.
 """
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010  The IPython Development Team
+#  Copyright (C) 2010-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING.txt, distributed as part of this software.

--- a/IPython/utils/localinterfaces.py
+++ b/IPython/utils/localinterfaces.py
@@ -7,7 +7,7 @@ LOCALHOST : The loopback interface, or the first interface that points to this
 LOCAL_IPS : A list of IP addresses, loopback first, that point to this machine.
 """
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010  The IPython Development Team
+#  Copyright (C) 2010-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/newserialized.py
+++ b/IPython/utils/newserialized.py
@@ -9,7 +9,7 @@ __docformat__ = "restructuredtext en"
 __test__ = {}
 
 #-------------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/notification.py
+++ b/IPython/utils/notification.py
@@ -12,7 +12,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -4,7 +4,7 @@ Utilities for path handling.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/pickleutil.py
+++ b/IPython/utils/pickleutil.py
@@ -5,7 +5,7 @@
 __docformat__ = "restructuredtext en"
 
 #-------------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/process.py
+++ b/IPython/utils/process.py
@@ -4,7 +4,7 @@ Utilities for working with external processes.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/sysinfo.py
+++ b/IPython/utils/sysinfo.py
@@ -4,7 +4,7 @@ Utilities for getting information about IPython and the system it's running in.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/syspathcontext.py
+++ b/IPython/utils/syspathcontext.py
@@ -8,7 +8,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/terminal.py
+++ b/IPython/utils/terminal.py
@@ -10,7 +10,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/tests/test_io.py
+++ b/IPython/utils/tests/test_io.py
@@ -2,7 +2,7 @@
 """Tests for io.py"""
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/tests/test_jsonutil.py
+++ b/IPython/utils/tests/test_jsonutil.py
@@ -1,7 +1,7 @@
 """Test suite for our JSON utilities.
 """
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010  The IPython Development Team
+#  Copyright (C) 2010-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING.txt, distributed as part of this software.

--- a/IPython/utils/tests/test_module_paths.py
+++ b/IPython/utils/tests/test_module_paths.py
@@ -2,7 +2,7 @@
 """Tests for IPython.utils.path.py"""
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/tests/test_notification.py
+++ b/IPython/utils/tests/test_notification.py
@@ -3,7 +3,7 @@
 """This file contains unittests for the notification.py module."""
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is
 #  in the file COPYING, distributed as part of this software.

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -2,7 +2,7 @@
 """Tests for IPython.utils.path.py"""
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/tests/test_process.py
+++ b/IPython/utils/tests/test_process.py
@@ -4,7 +4,7 @@ Tests for platutils.py
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -11,7 +11,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -4,7 +4,7 @@ Utilities for working with strings and text.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/timing.py
+++ b/IPython/utils/timing.py
@@ -4,7 +4,7 @@ Utilities for timing code execution.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -37,7 +37,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/utils/warn.py
+++ b/IPython/utils/warn.py
@@ -4,7 +4,7 @@ Utilities for warnings.  Shoudn't we just use the built in warnings module.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2009  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/zmq/__init__.py
+++ b/IPython/zmq/__init__.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010  The IPython Development Team
+#  Copyright (C) 2010-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING.txt, distributed as part of this software.

--- a/IPython/zmq/blockingkernelmanager.py
+++ b/IPython/zmq/blockingkernelmanager.py
@@ -3,7 +3,7 @@
 Useful for test suites and blocking terminal interfaces.
 """
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010  The IPython Development Team
+#  Copyright (C) 2010-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING.txt, distributed as part of this software.

--- a/IPython/zmq/gui/__init__.py
+++ b/IPython/zmq/gui/__init__.py
@@ -6,7 +6,7 @@ toolkits.
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010  The IPython Development Team.
+#  Copyright (C) 2010-2011  The IPython Development Team.
 #
 #  Distributed under the terms of the BSD License.
 #

--- a/IPython/zmq/gui/gtkembed.py
+++ b/IPython/zmq/gui/gtkembed.py
@@ -1,7 +1,7 @@
 """GUI support for the IPython ZeroMQ kernel - GTK toolkit support.
 """
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010  The IPython Development Team
+#  Copyright (C) 2010-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING.txt, distributed as part of this software.

--- a/IPython/zmq/heartbeat.py
+++ b/IPython/zmq/heartbeat.py
@@ -2,7 +2,7 @@
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2010  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/zmq/kernelmanager.py
+++ b/IPython/zmq/kernelmanager.py
@@ -5,7 +5,7 @@ TODO
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2010  The IPython Development Team
+#  Copyright (C) 2008-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.

--- a/IPython/zmq/tests/test_message_spec.py
+++ b/IPython/zmq/tests/test_message_spec.py
@@ -1,7 +1,7 @@
 """Test suite for our zeromq-based messaging specification.
 """
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010  The IPython Development Team
+#  Copyright (C) 2010-2011  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING.txt, distributed as part of this software.


### PR DESCRIPTION
(Note, partially solve number #2 )

```
    459  *.py files in :
 39  empty files
176  files without copyright
 36  have copyright but don't cite the dev team
208  have copyright and cite the dev team
-----------------------------------------
  0  not up to date (cite dev team but not right year)

  FYI, list of files that don't have copyright (and are not empty..)
```

 [
 'IPython/config/profile/cluster/ipython_config.py',
 'IPython/config/profile/math/ipython_config.py',
 'IPython/config/profile/pylab/ipython_config.py',
 'IPython/config/profile/pysh/ipython_config.py',
 'IPython/config/profile/python3/ipython_config.py',
 'IPython/config/profile/sympy/ipython_config.py',
 'IPython/core/shadowns.py',
 'IPython/core/tests/refbug.py',
 'IPython/core/tests/simpleerr.py',
 'IPython/core/tests/tclass.py',
 'IPython/core/tests/test_application.py',
 'IPython/core/tests/test_autocall.py',
 'IPython/core/tests/test_completer.py',
 'IPython/core/tests/test_fakemodule.py',
 'IPython/core/tests/test_formatters.py',
 'IPython/core/tests/test_handlers.py',
 'IPython/core/tests/test_history.py',
 'IPython/core/tests/test_imports.py',
 'IPython/core/tests/test_iplib.py',
 'IPython/core/tests/test_logger.py',
 'IPython/core/tests/test_magic.py',
 'IPython/core/tests/test_plugin.py',
 'IPython/core/tests/test_prefilter.py',
 'IPython/core/tests/test_profile.py',
 'IPython/core/tests/test_run.py',
 'IPython/core/tests/test_splitinput.py',
 'IPython/deathrow/astyle.py',
 'IPython/deathrow/dtutils.py',
 'IPython/deathrow/Gnuplot2.py',
 'IPython/deathrow/GnuplotInteractive.py',
 'IPython/deathrow/GnuplotRuntime.py',
 'IPython/deathrow/gui/wx/ipshell_nonblocking.py',
 'IPython/deathrow/gui/wx/ipython_history.py',
 'IPython/deathrow/gui/wx/thread_ex.py',
 'IPython/deathrow/ibrowse.py',
 'IPython/deathrow/igrid.py',
 'IPython/deathrow/ipipe.py',
 'IPython/deathrow/ipy_defaults.py',
 'IPython/deathrow/ipy_kitcfg.py',
 'IPython/deathrow/ipy_legacy.py',
 'IPython/deathrow/ipy_p4.py',
 'IPython/deathrow/ipy_profile_none.py',
 'IPython/deathrow/ipy_profile_numpy.py',
 'IPython/deathrow/ipy_profile_scipy.py',
 'IPython/deathrow/ipy_profile_sh.py',
 'IPython/deathrow/ipy_traits_completer.py',
 'IPython/deathrow/ipy_vimserver.py',
 'IPython/deathrow/numeric_formats.py',
 'IPython/deathrow/oldfrontend/process/**init**.py',
 'IPython/deathrow/oldfrontend/wx/ipythonx.py',
 'IPython/deathrow/scitedirector.py',
 'IPython/deathrow/tests/test_prefilter.py',
 'IPython/deathrow/twshell.py',
 'IPython/extensions/**init**.py',
 'IPython/extensions/autoreload.py',
 'IPython/extensions/storemagic.py',
 'IPython/extensions/tests/test_autoreload.py',
 'IPython/external/**init**.py',
 'IPython/external/argparse/**init**.py',
 'IPython/external/decorator/**init**.py',
 'IPython/external/decorators/**init**.py',
 'IPython/external/decorators/_decorators.py',
 'IPython/external/decorators/_numpy_testing_noseclasses.py',
 'IPython/external/decorators/_numpy_testing_utils.py',
 'IPython/external/guid/__init__.py',
 'IPython/external/Itpl/**init**.py',
 'IPython/external/mglob/**init**.py',
 'IPython/external/mglob/_mglob.py',
 'IPython/external/path/__init__.py',
 'IPython/external/path/_path.py',
 'IPython/external/pexpect/__init__.py',
 'IPython/external/pyparsing/**init**.py',
 'IPython/external/qt.py',
 'IPython/external/qt_for_kernel.py',
 'IPython/external/simplegeneric/**init**.py',
 'IPython/external/simplegeneric/_simplegeneric.py',
 'IPython/frontend/html/notebook/__init__.py',
 'IPython/frontend/html/notebook/tests/test_kernelsession.py',
 'IPython/frontend/qt/base_frontend_mixin.py',
 'IPython/frontend/qt/console/ansi_code_processor.py',
 'IPython/frontend/qt/console/bracket_matcher.py',
 'IPython/frontend/qt/console/call_tip_widget.py',
 'IPython/frontend/qt/console/completion_lexer.py',
 'IPython/frontend/qt/console/completion_widget.py',
 'IPython/frontend/qt/console/console_widget.py',
 'IPython/frontend/qt/console/history_console_widget.py',
 'IPython/frontend/qt/console/ipython_widget.py',
 'IPython/frontend/qt/console/kill_ring.py',
 'IPython/frontend/qt/console/mainwindow.py',
 'IPython/frontend/qt/console/pygments_highlighter.py',
 'IPython/frontend/qt/console/qtconsoleapp.py',
 'IPython/frontend/qt/console/rich_ipython_widget.py',
 'IPython/frontend/qt/console/styles.py',
 'IPython/frontend/qt/console/tests/test_ansi_code_processor.py',
 'IPython/frontend/qt/console/tests/test_completion_lexer.py',
 'IPython/frontend/qt/console/tests/test_kill_ring.py',
 'IPython/frontend/qt/kernelmanager.py',
 'IPython/frontend/qt/rich_text.py',
 'IPython/frontend/qt/svg.py',
 'IPython/frontend/qt/util.py',
 'IPython/kernel/**init**.py',
 'IPython/lib/clipboard.py',
 'IPython/lib/display.py',
 'IPython/lib/irunner.py',
 'IPython/lib/security.py',
 'IPython/lib/tests/test_imports.py',
 'IPython/lib/tests/test_irunner.py',
 'IPython/lib/tests/test_irunner_pylab_magic.py',
 'IPython/lib/tests/test_security.py',
 'IPython/nbformat/v1/tests/nbexamples.py',
 'IPython/nbformat/v1/tests/test_json.py',
 'IPython/nbformat/v1/tests/test_nbbase.py',
 'IPython/nbformat/v2/tests/nbexamples.py',
 'IPython/nbformat/v2/tests/test_json.py',
 'IPython/nbformat/v2/tests/test_nbbase.py',
 'IPython/nbformat/v2/tests/test_nbpy.py',
 'IPython/quarantine/clearcmd.py',
 'IPython/quarantine/envpersist.py',
 'IPython/quarantine/ext_rescapture.py',
 'IPython/quarantine/ipy_app_completers.py',
 'IPython/quarantine/ipy_completers.py',
 'IPython/quarantine/ipy_editors.py',
 'IPython/quarantine/ipy_exportdb.py',
 'IPython/quarantine/ipy_extutil.py',
 'IPython/quarantine/ipy_fsops.py',
 'IPython/quarantine/ipy_gnuglobal.py',
 'IPython/quarantine/ipy_jot.py',
 'IPython/quarantine/ipy_lookfor.py',
 'IPython/quarantine/ipy_profile_doctest.py',
 'IPython/quarantine/ipy_pydb.py',
 'IPython/quarantine/ipy_rehashdir.py',
 'IPython/quarantine/ipy_render.py',
 'IPython/quarantine/ipy_server.py',
 'IPython/quarantine/ipy_signals.py',
 'IPython/quarantine/ipy_synchronize_with.py',
 'IPython/quarantine/ipy_system_conf.py',
 'IPython/quarantine/ipy_which.py',
 'IPython/quarantine/ipy_winpdb.py',
 'IPython/quarantine/ipy_workdir.py',
 'IPython/quarantine/jobctrl.py',
 'IPython/quarantine/ledit.py',
 'IPython/quarantine/win32clip.py',
 'IPython/testing/mkdoctests.py',
 'IPython/testing/plugin/dtexample.py',
 'IPython/testing/plugin/ipdoctest.py',
 'IPython/testing/plugin/iptest.py',
 'IPython/testing/plugin/setup.py',
 'IPython/testing/plugin/show_refs.py',
 'IPython/testing/plugin/simple.py',
 'IPython/testing/plugin/simplevars.py',
 'IPython/testing/plugin/test_ipdoctest.py',
 'IPython/testing/plugin/test_refs.py',
 'IPython/testing/skipdoctest.py',
 'IPython/testing/tests/test_decorators.py',
 'IPython/utils/autoattr.py',
 'IPython/utils/nested_context.py',
 'IPython/utils/pickleshare.py',
 'IPython/utils/py3compat.py',
 'IPython/utils/PyColorize.py',
 'IPython/utils/rlineimpl.py',
 'IPython/utils/strdispatch.py',
 'IPython/utils/tempdir.py',
 'IPython/utils/tests/test_imports.py',
 'IPython/utils/tests/test_wildcard.py',
 'IPython/utils/upgradedir.py',
 'IPython/zmq/completer.py',
 'IPython/zmq/displayhook.py',
 'IPython/zmq/entry_point.py',
 'IPython/zmq/frontend.py',
 'IPython/zmq/iostream.py',
 'IPython/zmq/ipkernel.py',
 'IPython/zmq/log.py',
 'IPython/zmq/parentpoller.py',
 'IPython/zmq/pykernel.py',
 'IPython/zmq/pylab/backend_inline.py',
 'IPython/zmq/zmqshell.py'
 ]
