### PR TITLE
Base of an as you type completer.

### DIFF
--- a/IPython/frontend/html/notebook/static/css/notebook.css
+++ b/IPython/frontend/html/notebook/static/css/notebook.css
@@ -406,6 +406,15 @@ div.text_cell_render {
     min-height:50px;
 }
 
+.completions p{
+    background: #DDF;
+    /*outline: none;
+    padding: 0px;*/
+    border-bottom: black solid 1px;
+    padding: 1px;
+    font-family: monospace;
+}
+
 @media print {
     body { overflow: visible !important; }
     .ui-widget-content { border: 0px; }

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -357,6 +357,10 @@ var IPython = (function (IPython) {
         typed_characters = "";
         select.keydown(function (event) {
             var code = event.which;
+            if (code === 16) {
+                // nothing on Shift
+                return;
+            }
             if (code === 13 || code === 32) {
                 // Pressing SPACE or ENTER will cause a pick
                 event.stopPropagation();
@@ -366,7 +370,7 @@ var IPython = (function (IPython) {
                 // We don't want the document keydown handler to handle UP/DOWN,
                 // but we want the default action.
                 event.stopPropagation();
-            } else if (code>64 && code <90 || code==8){
+            } else if (code>64 && code <=122 || code==8){
                 // issues with _-.. on chrome at least
                 if(code != 8)
                 {

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -248,6 +248,20 @@ var IPython = (function (IPython) {
         }
         // end sort kwargs
 
+        function sharedStart(A){
+            if(A.length > 1 ){
+            var tem1, tem2, s, A= A.slice(0).sort();
+            tem1= A[0];
+            s= tem1.length;
+            tem2= A.pop();
+            while(s && tem2.indexOf(tem1)== -1){
+                tem1= tem1.substring(0, --s);
+            }
+            return tem1;
+            }
+            return "";
+        }
+
         if (!this.is_completing || matches.length === 0) {return;}
 
         //try to check if the user is typing tab at least twice after a word
@@ -377,12 +391,19 @@ var IPython = (function (IPython) {
                 // We don't want the document keydown handler to handle UP/DOWN,
                 // but we want the default action.
                 event.stopPropagation();
-            } else if ((code>64 && code <=122)|| (code==8 && down)){
+            } else if ((code>64 && code <=122)|| (code==8 && down)||(code==9 && down)){
                 // issues with _-.. on chrome at least
                 if(code != 8 && press)
                 {
                     var newchar = String.fromCharCode(code);
                     typed_characters=typed_characters+newchar;
+                } else if (code == 9) {
+                    fastForward = sharedStart(filterd)
+                    ffsub = fastForward.substr(matched_text.length+typed_characters.length);
+                    typed_characters=typed_characters+ffsub;
+                    console.log("Fast forded by :"+ffsub);
+                    event.stopPropagation();
+                    event.preventDefault();
                 } else if (code == 8) {
                     // 8 is backspace remove 1 char cancel if
                     // user have erase everything, otherwise

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -355,7 +355,14 @@ var IPython = (function (IPython) {
         // Give focus to select, and make it filter the match as the user type
         // by filtering the previous matches
         typed_characters = "";
-        select.keydown(function (event) {
+        var downandpress = function (event,press_or_down) {
+            if (press_or_down === 0){
+                press=true;
+                down=false;
+            } else if (press_or_down == 1){
+                press=false;
+                down=true;
+            }
             var code = event.which;
             if (code === 16) {
                 // nothing on Shift
@@ -370,13 +377,13 @@ var IPython = (function (IPython) {
                 // We don't want the document keydown handler to handle UP/DOWN,
                 // but we want the default action.
                 event.stopPropagation();
-            } else if (code>64 && code <=122 || code==8){
+            } else if ((code>64 && code <=122)|| (code==8 && down)){
                 // issues with _-.. on chrome at least
-                if(code != 8)
+                if(code != 8 && press)
                 {
-                    var newchar = String.fromCharCode(code).toLowerCase();
+                    var newchar = String.fromCharCode(code);
                     typed_characters=typed_characters+newchar;
-                } else {
+                } else if (code == 8) {
                     // 8 is backspace remove 1 char cancel if
                     // user have erase everything, otherwise
                     // decrease what we filter with
@@ -386,14 +393,20 @@ var IPython = (function (IPython) {
                     }
                     typed_characters=typed_characters.substr(0,typed_characters.length-1);
                 }
-                re = new RegExp("^"+"\%?"+matched_text+typed_characters,"i");
+                re = new RegExp("^"+"\%?"+matched_text+typed_characters,"");
                 filterd= matches.filter(function(x){return re.test(x)});
                 complete_with(filterd,matched_text+typed_characters);
-            } else {
+            } else if(down){ // abort only on press
                 // abort with what the user have pressed until now
                 console.log('aborting with keycode : '+code);
                 insert(matched_text+typed_characters);
             }
+        }
+        select.keydown(function (event) {
+            downandpress(event,1)
+        });
+        select.keypress(function (event) {
+            downandpress(event,0)
         });
         // Double click also causes a pick.
         // and bind the last actions.

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -73,8 +73,8 @@ var IPython = (function (IPython) {
         var that = this;
         // whatever key is pressed, first, cancel the tooltip request before
         // they are sent, and remove tooltip if any
-        if(event.type === 'keydown' && this.tooltip_timeout != null){
-            CodeCell.prototype.remove_and_cancell_tooltip(that.tooltip_timeout);
+        if(event.type === 'keydown' ){
+            CodeCell.prototype.remove_and_cancel_tooltip(that.tooltip_timeout);
             that.tooltip_timeout=null;
         }
 
@@ -145,12 +145,13 @@ var IPython = (function (IPython) {
         return false;
     };
 
-    CodeCell.prototype.remove_and_cancell_tooltip = function(timeout)
+    CodeCell.prototype.remove_and_cancel_tooltip = function(timeout)
     {
         // note that we don't handle closing directly inside the calltip
         // as in the completer, because it is not focusable, so won't
         // get the event.
-        clearTimeout(timeout);
+        if(timeout != null)
+        { clearTimeout(timeout);}
         $('#tooltip').remove();
     }
 

--- a/IPython/frontend/html/notebook/static/js/kernel.js
+++ b/IPython/frontend/html/notebook/static/js/kernel.js
@@ -171,7 +171,7 @@ var IPython = (function (IPython) {
     };
 
     Kernel.prototype.object_info_request = function (objname) {
-        if(typeof(objname)!=null)
+        if(typeof(objname)!=null && objname!=null)
         {
             var content = {
                 oname : objname.toString(),


### PR DESCRIPTION
when invoking the completer, instead of having to chose/dismiss, you can
continue typing, it will filter the result "as you type" and dismiss itself
if ther is no match left.

As it is now, it's only works with lowercase letters, I need to find a workaroud
for this.

for example
if you type :

```
* P-y-<tab>-S-o-m-e-t-h-i-n-g
* it will propose PySide, but will dismiss when 'o' is pressed and pasting Pyso with a lower case 's'
```

I've rebase and squash everything (the code was quite old), so not sure if it perfectly works with the tooltip merged of a few hours ago ... and there are still edge case annoying for a merged on master
