### PR TITLE
fix firefox (windows) break line on empty prompt number

### DIFF
--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -15,7 +15,7 @@ var IPython = (function (IPython) {
 
     var CodeCell = function (notebook) {
         this.code_mirror = null;
-        this.input_prompt_number = ' ';
+        this.input_prompt_number = '&nbsp;';
         this.is_completing = false;
         this.completion_cursor = null;
         this.outputs = [];
@@ -588,7 +588,7 @@ var IPython = (function (IPython) {
     };
 
     CodeCell.prototype.set_input_prompt = function (number) {
-        var n = number || ' ';
+        var n = number || '&nbsp;';
         this.input_prompt_number = n
         this.element.find('div.input_prompt').html('In&nbsp;[' + n + ']:');
     };


### PR DESCRIPTION
Firefox on windows sometime put the end of the prompt on a new line. 
This should fix it (hopefully)

Sorry it's github-edited
