### PR TITLE
minor improvements to text placement in qtconsole

### DIFF
--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -772,7 +772,7 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
         """
         # Determine where to insert the content.
         cursor = self._control.textCursor()
-        if before_prompt and not self._executing:
+        if before_prompt and (self._reading or not self._executing):
             cursor.setPosition(self._append_before_prompt_pos)
         else:
             cursor.movePosition(QtGui.QTextCursor.End)

--- a/IPython/frontend/qt/console/frontend_widget.py
+++ b/IPython/frontend/qt/console/frontend_widget.py
@@ -597,7 +597,9 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
                     self.kernel_manager.restart_kernel(now=now)
                 except RuntimeError:
                     self._append_plain_text('Kernel started externally. '
-                                            'Cannot restart.\n')
+                                            'Cannot restart.\n',
+                                            before_prompt=True
+                                            )
                 else:
                     self.reset()
             else:
@@ -605,7 +607,9 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
 
         else:
             self._append_plain_text('Kernel process is either remote or '
-                                    'unspecified. Cannot restart.\n')
+                                    'unspecified. Cannot restart.\n',
+                                    before_prompt=True
+                                    )
 
     #---------------------------------------------------------------------------
     # 'FrontendWidget' protected interface


### PR DESCRIPTION
- allow `before_prompt=True` behavior to have effect during raw_input
- append 'cannot restart' message before the prompt, so it doesn't
  get mixed up with input.

This isn't quite there yet.  A known issue - subsequent prints during raw_input are inserted _above_ the previous print, rather than below.  While these messages do not get into the input area, they can still prevent raw_input from accepting Enter for submission or Esc for clearing.  I presume the issue is simply improperly updating the prompt cursor location during raw input.

A background printer, to get stdout coming at peculiar times during input:

``` python
import threading
def printer():
    while True:
        time.sleep(1)
        print time.time()
t = threading.Thread(target=printer)
t.start()
```

This branch is ipython-owned, so people with more qtconsole knowledge (e.g. @epatters) are welcome to commit the parts I'm missing.
