### PR TITLE
Warning in code. qtconsole ssh -X

### DIFF
--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -622,8 +622,10 @@ class MainWindow(QtGui.QMainWindow):
         self.magic_menu = self.menuBar().addMenu("&Magic")
         self.all_magic_menu = self.magic_menu.addMenu("&All Magics")
 
-        # this action should not appear as it will be cleard when menu
-        # will be updated at first kernel response.
+        # This action should usually not appear as it will be cleard when menu
+        # will be updated at first kernel response. Thought, it is necessary
+        # when connecting through X-forwarding, as in this case, the menu is
+        # not auto updated, SO DO NOT DELETE
         self.pop = QtGui.QAction("&Update All Magic Menu ",
             self, triggered=self.update_all_magic_menu)
         self.add_menu_action(self.all_magic_menu, self.pop)


### PR DESCRIPTION
```
Put warning in code not to remove an action needed when ssh -X.

"All magics..." menu  should be autopopulated at startup, but is not
when X forwarding, Warn in code that inserting  'update all magic menu'
action in this same menu is not as useless as it may seem
```

I can also open an issue "All Magic Menu not populated when X forwarding", but as the workaroud has already been written "juste in case ...",  I just thought adding a warnig in the code for future reader might be a good idea, now that we at least have found one edge case...
