### PR TITLE
Switch to simple `__IPYTHON__` global

### DIFF
--- a/IPython/core/builtin_trap.py
+++ b/IPython/core/builtin_trap.py
@@ -102,11 +102,6 @@ class BuiltinTrap(Configurable):
         for name, func in self.auto_builtins.iteritems():
             add_builtin(name, func)
 
-        # Keep in the builtins a flag for when IPython is active.  We set it
-        # with setdefault so that multiple nested IPythons don't clobber one
-        # another.
-        __builtin__.__dict__.setdefault('__IPYTHON__active', 0)
-
     def deactivate(self):
         """Remove any builtins which might have been added by add_builtins, or
         restore overwritten ones to their previous values."""
@@ -115,7 +110,3 @@ class BuiltinTrap(Configurable):
             remove_builtin(key, val)
         self._orig_builtins.clear()
         self._builtins_added = False
-        try:
-            del __builtin__.__dict__['__IPYTHON__active']
-        except KeyError:
-            pass

--- a/IPython/core/builtin_trap.py
+++ b/IPython/core/builtin_trap.py
@@ -88,17 +88,12 @@ class BuiltinTrap(Configurable):
             self._orig_builtins[key] = orig
             bdict[key] = value
 
-    def remove_builtin(self, key):
+    def remove_builtin(self, key, orig):
         """Remove an added builtin and re-set the original."""
-        try:
-            orig = self._orig_builtins.pop(key)
-        except KeyError:
-            pass
+        if orig is BuiltinUndefined:
+            del __builtin__.__dict__[key]
         else:
-            if orig is BuiltinUndefined:
-                del __builtin__.__dict__[key]
-            else:
-                __builtin__.__dict__[key] = orig
+            __builtin__.__dict__[key] = orig
 
     def activate(self):
         """Store ipython references in the __builtin__ namespace."""
@@ -115,11 +110,9 @@ class BuiltinTrap(Configurable):
     def deactivate(self):
         """Remove any builtins which might have been added by add_builtins, or
         restore overwritten ones to their previous values."""
-        # Note: must iterate over a static keys() list because we'll be
-        # mutating the dict itself
         remove_builtin = self.remove_builtin
-        for key in self._orig_builtins.keys():
-            remove_builtin(key)
+        for key, val in self._orig_builtins.iteritems():
+            remove_builtin(key, val)
         self._orig_builtins.clear()
         self._builtins_added = False
         try:

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -573,6 +573,20 @@ class InteractiveShell(SingletonConfigurable, Magic):
             self.magic_logstart()
 
     def init_builtins(self):
+        # A single, static flag that we set to True.  Its presence indicates
+        # that an IPython shell has been created, and we make no attempts at
+        # removing on exit or representing the existence of more than one
+        # IPython at a time.
+        builtin_mod.__dict__['__IPYTHON__'] = True
+
+        # In 0.11 we introduced '__IPYTHON__active' as an integer we'd try to
+        # manage on enter/exit, but with all our shells it's virtually
+        # impossible to get all the cases right.  We're leaving the name in for
+        # those who adapted their codes to check for this flag, but will
+        # eventually remove it after a few more releases.
+        builtin_mod.__dict__['__IPYTHON__active'] = \
+                                          'Deprecated, check for __IPYTHON__'
+
         self.builtin_trap = BuiltinTrap(shell=self)
 
     def init_inspector(self):

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -271,3 +271,8 @@ class TestSystemRaw(unittest.TestCase):
         """
         cmd = ur'''python -c "'åäö'"   '''
         _ip.shell.system_raw(cmd)
+
+
+def test__IPYTHON__():
+    # This shouldn't raise a NameError, that's all
+    __IPYTHON__

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -341,9 +341,6 @@ class TerminalInteractiveShell(InteractiveShell):
 
         more = False
 
-        # Mark activity in the builtins
-        __builtin__.__dict__['__IPYTHON__active'] += 1
-
         if self.has_readline:
             self.readline_startup_hook(self.pre_readline)
             hlen_b4_cell = self.readline.get_current_history_length()
@@ -412,9 +409,6 @@ class TerminalInteractiveShell(InteractiveShell):
                     self.run_cell(source_raw, store_history=True)
                     hlen_b4_cell = \
                         self._replace_rlhist_multiline(source_raw, hlen_b4_cell)
-
-        # We are off again...
-        __builtin__.__dict__['__IPYTHON__active'] -= 1
 
         # Turn off the exit flag, so the mainloop can be restarted if desired
         self.exit_now = False


### PR DESCRIPTION
In 0.11 we added `__IPYTHON__active` as a global, managed with the builtin trap, to try and detect nested ipythons.  But in reality that mechanism is very fragile, the values aren't always right, and I think it's just unnecessary complexity.  People do ask often, however, for some way of knowing whether they're running in ipython or not.

So this pr proposes that we simply create a global flag in `__builtin__`, called `__IPYTHON__` (like the name we used to have and that it turns out people were already relying on).  This flag will just be set to True at shell creation, with no attempt to delete it, or otherwise manage 'activity' (in event driven contexts this is a futile battle).  I think this is the simplest thing we can do that will reasonable cover most cases without making promises we can't keep.

I'd like this merged before 0.12 so we're back to an api similar to what we had for most of our life from now on.  I have the feeling that 0.12 will be when many people start really porting their codes forward, so minimizing api breakage here is worthwhile.
