### PR TITLE
Win32 shlex

### DIFF
--- a/IPython/utils/_process_common.py
+++ b/IPython/utils/_process_common.py
@@ -15,6 +15,7 @@ of subprocess utilities, and it contains tools that are common to all of them.
 # Imports
 #-----------------------------------------------------------------------------
 import subprocess
+import shlex
 import sys
 
 from IPython.utils import py3compat
@@ -143,3 +144,27 @@ def getoutputerror(cmd):
         return '', ''
     out, err = out_err
     return py3compat.bytes_to_str(out), py3compat.bytes_to_str(err)
+
+
+def arg_split(s, posix=False):
+    """Split a command line's arguments in a shell-like manner.
+
+    This is a modified version of the standard library's shlex.split()
+    function, but with a default of posix=False for splitting, so that quotes
+    in inputs are respected."""
+
+    # Unfortunately, python's shlex module is buggy with unicode input:
+    # http://bugs.python.org/issue1170
+    # At least encoding the input when it's unicode seems to help, but there
+    # may be more problems lurking.  Apparently this is fixed in python3.
+    is_unicode = False
+    if (not py3compat.PY3) and isinstance(s, unicode):
+        is_unicode = True
+        s = s.encode('utf-8')
+    lex = shlex.shlex(s, posix=posix)
+    lex.whitespace_split = True
+    tokens = list(lex)
+    if is_unicode:
+        # Convert the tokens back to unicode.
+        tokens = [x.decode('utf-8') for x in tokens]
+    return tokens

--- a/IPython/utils/_process_posix.py
+++ b/IPython/utils/_process_posix.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 # Stdlib
 import subprocess as sp
 import sys
+import shlex
 
 from IPython.external import pexpect
 
@@ -192,3 +193,29 @@ class ProcessHandler(object):
 # programs think they are talking to a tty and produce highly formatted output
 # (ls is a good example) that makes them hard.
 system = ProcessHandler().system
+
+def arg_split(s, posix=False):
+    """Split a command line's arguments in a shell-like manner.
+
+    This is a modified version of the standard library's shlex.split()
+    function, but with a default of posix=False for splitting, so that quotes
+    in inputs are respected."""
+
+    # Unfortunately, python's shlex module is buggy with unicode input:
+    # http://bugs.python.org/issue1170
+    # At least encoding the input when it's unicode seems to help, but there
+    # may be more problems lurking.  Apparently this is fixed in python3.
+    is_unicode = False
+    if (not py3compat.PY3) and isinstance(s, unicode):
+        is_unicode = True
+        s = s.encode('utf-8')
+    lex = shlex.shlex(s, posix=posix)
+    lex.whitespace_split = True
+    tokens = list(lex)
+    if is_unicode:
+        # Convert the tokens back to unicode.
+        tokens = [x.decode('utf-8') for x in tokens]
+    return tokens
+
+
+

--- a/IPython/utils/_process_posix.py
+++ b/IPython/utils/_process_posix.py
@@ -18,13 +18,12 @@ from __future__ import print_function
 # Stdlib
 import subprocess as sp
 import sys
-import shlex
 
 from IPython.external import pexpect
 
 # Our own
 from .autoattr import auto_attr
-from ._process_common import getoutput
+from ._process_common import getoutput, arg_split
 from IPython.utils import text
 from IPython.utils import py3compat
 
@@ -193,29 +192,6 @@ class ProcessHandler(object):
 # programs think they are talking to a tty and produce highly formatted output
 # (ls is a good example) that makes them hard.
 system = ProcessHandler().system
-
-def arg_split(s, posix=False):
-    """Split a command line's arguments in a shell-like manner.
-
-    This is a modified version of the standard library's shlex.split()
-    function, but with a default of posix=False for splitting, so that quotes
-    in inputs are respected."""
-
-    # Unfortunately, python's shlex module is buggy with unicode input:
-    # http://bugs.python.org/issue1170
-    # At least encoding the input when it's unicode seems to help, but there
-    # may be more problems lurking.  Apparently this is fixed in python3.
-    is_unicode = False
-    if (not py3compat.PY3) and isinstance(s, unicode):
-        is_unicode = True
-        s = s.encode('utf-8')
-    lex = shlex.shlex(s, posix=posix)
-    lex.whitespace_split = True
-    tokens = list(lex)
-    if is_unicode:
-        # Convert the tokens back to unicode.
-        tokens = [x.decode('utf-8') for x in tokens]
-    return tokens
 
 
 

--- a/IPython/utils/_process_win32.py
+++ b/IPython/utils/_process_win32.py
@@ -175,27 +175,4 @@ try:
         retval = LocalFree(result_pointer)
         return result
 except AttributeError:
-    import shlex
-    #alternative if CommandLineToArgvW is not available
-    def arg_split(s, posix=False):
-        """Split a command line's arguments in a shell-like manner.
-
-        This is a modified version of the standard library's shlex.split()
-        function, but with a default of posix=False for splitting, so that quotes
-        in inputs are respected."""
-
-        # Unfortunately, python's shlex module is buggy with unicode input:
-        # http://bugs.python.org/issue1170
-        # At least encoding the input when it's unicode seems to help, but there
-        # may be more problems lurking.  Apparently this is fixed in python3.
-        is_unicode = False
-        if (not py3compat.PY3) and isinstance(s, unicode):
-            is_unicode = True
-            s = s.encode('utf-8')
-        lex = shlex.shlex(s, posix=posix)
-        lex.whitespace_split = True
-        tokens = list(lex)
-        if is_unicode:
-            # Convert the tokens back to unicode.
-            tokens = [x.decode('utf-8') for x in tokens]
-        return tokens
+    from ._process_common import arg_split

--- a/IPython/utils/process.py
+++ b/IPython/utils/process.py
@@ -22,7 +22,16 @@ import shlex
 
 # Our own
 if sys.platform == 'win32':
+    import ctypes
+    from ctypes.wintypes import LPCWSTR, HLOCAL
+    from ctypes import c_int, POINTER
     from ._process_win32 import _find_cmd, system, getoutput, AvoidUNCPath
+    CommandLineToArgvW = ctypes.windll.shell32.CommandLineToArgvW
+    CommandLineToArgvW.arg_types = [LPCWSTR, POINTER(c_int)]
+    CommandLineToArgvW.res_types = [POINTER(LPCWSTR)]
+    LocalFree = ctypes.windll.kernel32.LocalFree
+    LocalFree.res_type = HLOCAL
+    LocalFree.arg_types = [HLOCAL]
 else:
     from ._process_posix import _find_cmd, system, getoutput
 
@@ -103,29 +112,42 @@ def pycmd2argv(cmd):
         else:
             return [sys.executable, cmd]
 
+if sys.platform == 'win32':
+    def arg_split(commandline, posix=False):
+        """Split a command line's arguments in a shell-like manner.
 
-def arg_split(s, posix=False):
-    """Split a command line's arguments in a shell-like manner.
+        This is a special version for windows that use a ctypes call to CommandLineToArgvW
+        to do the argv splitting. The posix paramter is ignored.
+        """
+        argvn = c_int()
+        result_pointer = CommandLineToArgvW(py3compat.str_to_unicode(commandline.lstrip()), ctypes.byref(argvn))
+        result_array_type = LPCWSTR * argvn.value
+        result = [arg for arg in result_array_type.from_address(result_pointer)]
+        retval = LocalFree(result_pointer)
+        return result
+else:
+    def arg_split(s, posix=False):
+        """Split a command line's arguments in a shell-like manner.
 
-    This is a modified version of the standard library's shlex.split()
-    function, but with a default of posix=False for splitting, so that quotes
-    in inputs are respected."""
+        This is a modified version of the standard library's shlex.split()
+        function, but with a default of posix=False for splitting, so that quotes
+        in inputs are respected."""
 
-    # Unfortunately, python's shlex module is buggy with unicode input:
-    # http://bugs.python.org/issue1170
-    # At least encoding the input when it's unicode seems to help, but there
-    # may be more problems lurking.  Apparently this is fixed in python3.
-    is_unicode = False
-    if (not py3compat.PY3) and isinstance(s, unicode):
-        is_unicode = True
-        s = s.encode('utf-8')
-    lex = shlex.shlex(s, posix=posix)
-    lex.whitespace_split = True
-    tokens = list(lex)
-    if is_unicode:
-        # Convert the tokens back to unicode.
-        tokens = [x.decode('utf-8') for x in tokens]
-    return tokens
+        # Unfortunately, python's shlex module is buggy with unicode input:
+        # http://bugs.python.org/issue1170
+        # At least encoding the input when it's unicode seems to help, but there
+        # may be more problems lurking.  Apparently this is fixed in python3.
+        is_unicode = False
+        if (not py3compat.PY3) and isinstance(s, unicode):
+            is_unicode = True
+            s = s.encode('utf-8')
+        lex = shlex.shlex(s, posix=posix)
+        lex.whitespace_split = True
+        tokens = list(lex)
+        if is_unicode:
+            # Convert the tokens back to unicode.
+            tokens = [x.decode('utf-8') for x in tokens]
+        return tokens
 
 
 def abbrev_cwd():

--- a/IPython/utils/process.py
+++ b/IPython/utils/process.py
@@ -22,18 +22,10 @@ import shlex
 
 # Our own
 if sys.platform == 'win32':
-    import ctypes
-    from ctypes.wintypes import LPCWSTR, HLOCAL
-    from ctypes import c_int, POINTER
-    from ._process_win32 import _find_cmd, system, getoutput, AvoidUNCPath
-    CommandLineToArgvW = ctypes.windll.shell32.CommandLineToArgvW
-    CommandLineToArgvW.arg_types = [LPCWSTR, POINTER(c_int)]
-    CommandLineToArgvW.res_types = [POINTER(LPCWSTR)]
-    LocalFree = ctypes.windll.kernel32.LocalFree
-    LocalFree.res_type = HLOCAL
-    LocalFree.arg_types = [HLOCAL]
+    from ._process_win32 import _find_cmd, system, getoutput, AvoidUNCPath, arg_split
 else:
-    from ._process_posix import _find_cmd, system, getoutput
+    from ._process_posix import _find_cmd, system, getoutput, arg_split
+
 
 from ._process_common import getoutputerror
 from IPython.utils import py3compat
@@ -111,44 +103,6 @@ def pycmd2argv(cmd):
             return [sys.executable, '-u', cmd]
         else:
             return [sys.executable, cmd]
-
-if sys.platform == 'win32':
-    def arg_split(commandline, posix=False):
-        """Split a command line's arguments in a shell-like manner.
-
-        This is a special version for windows that use a ctypes call to CommandLineToArgvW
-        to do the argv splitting. The posix paramter is ignored.
-        """
-        argvn = c_int()
-        result_pointer = CommandLineToArgvW(py3compat.str_to_unicode(commandline.lstrip()), ctypes.byref(argvn))
-        result_array_type = LPCWSTR * argvn.value
-        result = [arg for arg in result_array_type.from_address(result_pointer)]
-        retval = LocalFree(result_pointer)
-        return result
-else:
-    def arg_split(s, posix=False):
-        """Split a command line's arguments in a shell-like manner.
-
-        This is a modified version of the standard library's shlex.split()
-        function, but with a default of posix=False for splitting, so that quotes
-        in inputs are respected."""
-
-        # Unfortunately, python's shlex module is buggy with unicode input:
-        # http://bugs.python.org/issue1170
-        # At least encoding the input when it's unicode seems to help, but there
-        # may be more problems lurking.  Apparently this is fixed in python3.
-        is_unicode = False
-        if (not py3compat.PY3) and isinstance(s, unicode):
-            is_unicode = True
-            s = s.encode('utf-8')
-        lex = shlex.shlex(s, posix=posix)
-        lex.whitespace_split = True
-        tokens = list(lex)
-        if is_unicode:
-            # Convert the tokens back to unicode.
-            tokens = [x.decode('utf-8') for x in tokens]
-        return tokens
-
 
 def abbrev_cwd():
     """ Return abbreviated version of cwd, e.g. d:mydir """

--- a/IPython/utils/tests/test_process.py
+++ b/IPython/utils/tests/test_process.py
@@ -62,12 +62,25 @@ def test_find_cmd_fail():
     nt.assert_raises(FindCmdError,find_cmd,'asdfasdf')
 
     
+@dec.skip_win32
 def test_arg_split():
     """Ensure that argument lines are correctly split like in a shell."""
     tests = [['hi', ['hi']],
              [u'hi', [u'hi']],
              ['hello there', ['hello', 'there']],
-             [u'h\N{LATIN SMALL LETTER A WITH CARON}llo', [u'h\N{LATIN SMALL LETTER A WITH CARON}llo']],
+#             [u'h\N{LATIN SMALL LETTER A WITH CARON}llo', [u'h\N{LATIN SMALL LETTER A WITH CARON}llo']],
+             ['something "with quotes"', ['something', '"with quotes"']],
+             ]
+    for argstr, argv in tests:
+        nt.assert_equal(arg_split(argstr), argv)
+    
+@dec.skip_win32
+def test_arg_split_win32():
+    """Ensure that argument lines are correctly split like in a shell."""
+    tests = [['hi', ['hi']],
+             [u'hi', [u'hi']],
+             ['hello there', ['hello', 'there']],
+           #  [u'h\N{LATIN SMALL LETTER A WITH CARON}llo', [u'h\N{LATIN SMALL LETTER A WITH CARON}llo']],
              ['something "with quotes"', ['something', '"with quotes"']],
              ]
     for argstr, argv in tests:

--- a/IPython/utils/tests/test_process.py
+++ b/IPython/utils/tests/test_process.py
@@ -100,6 +100,10 @@ class SubProcessTestCase(TestCase, tt.TempFileMixin):
     def test_getoutput_quoted(self):
         out = getoutput('python -c "print (1)"')
         self.assertEquals(out.strip(), '1')
+
+    #Invalid quoting on windows
+    @dec.skip_win32
+    def test_getoutput_quoted2(self):
         out = getoutput("python -c 'print (1)'")
         self.assertEquals(out.strip(), '1')
         out = getoutput("python -c 'print (\"1\")'")

--- a/IPython/utils/tests/test_process.py
+++ b/IPython/utils/tests/test_process.py
@@ -68,7 +68,10 @@ def test_arg_split():
     tests = [['hi', ['hi']],
              [u'hi', [u'hi']],
              ['hello there', ['hello', 'there']],
-#             [u'h\N{LATIN SMALL LETTER A WITH CARON}llo', [u'h\N{LATIN SMALL LETTER A WITH CARON}llo']],
+             # \u01ce == \N{LATIN SMALL LETTER A WITH CARON}
+             # Do not use \N because the tests crash with syntax error in
+             # some cases, for example windows python2.6.
+             [u'h\u01cello', [u'h\u01cello']],
              ['something "with quotes"', ['something', '"with quotes"']],
              ]
     for argstr, argv in tests:
@@ -80,7 +83,7 @@ def test_arg_split_win32():
     tests = [['hi', ['hi']],
              [u'hi', [u'hi']],
              ['hello there', ['hello', 'there']],
-           #  [u'h\N{LATIN SMALL LETTER A WITH CARON}llo', [u'h\N{LATIN SMALL LETTER A WITH CARON}llo']],
+             [u'h\u01cello', [u'h\u01cello']],
              ['something "with quotes"', ['something', 'with quotes']],
              ]
     for argstr, argv in tests:

--- a/IPython/utils/tests/test_process.py
+++ b/IPython/utils/tests/test_process.py
@@ -74,14 +74,14 @@ def test_arg_split():
     for argstr, argv in tests:
         nt.assert_equal(arg_split(argstr), argv)
     
-@dec.skip_win32
+@dec.skip_if_not_win32
 def test_arg_split_win32():
     """Ensure that argument lines are correctly split like in a shell."""
     tests = [['hi', ['hi']],
              [u'hi', [u'hi']],
              ['hello there', ['hello', 'there']],
            #  [u'h\N{LATIN SMALL LETTER A WITH CARON}llo', [u'h\N{LATIN SMALL LETTER A WITH CARON}llo']],
-             ['something "with quotes"', ['something', '"with quotes"']],
+             ['something "with quotes"', ['something', 'with quotes']],
              ]
     for argstr, argv in tests:
         nt.assert_equal(arg_split(argstr), argv)


### PR DESCRIPTION
Suggested more complete fix for issue #592. Using ctypes to call a windows function for doing shlex like splitting.

Had to comment out the unicode strings in test_arg_split to get the tests to run (see #1063).
