### PR TITLE
Qtconsole fix racecondition

### DIFF
--- a/IPython/frontend/qt/console/frontend_widget.py
+++ b/IPython/frontend/qt/console/frontend_widget.py
@@ -404,6 +404,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
             self._request_info['execute'].pop(msg_id)
         elif info and info.kind == 'silent_exec_callback' and not self._hidden:
             self._handle_exec_callback(msg)
+            self._request_info['execute'].pop(msg_id)
         else:
             super(FrontendWidget, self)._handle_execute_reply(msg)
 

--- a/IPython/frontend/qt/console/frontend_widget.py
+++ b/IPython/frontend/qt/console/frontend_widget.py
@@ -374,10 +374,8 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         """ Handles replies for code execution.
         """
         self.log.debug("execute: %s", msg.get('content', ''))
-        info_list = self._request_info.get('execute')
         msg_id = msg['parent_header']['msg_id']
-        if msg_id in info_list:
-            info = info_list[msg_id]
+        info = self._request_info['execute'].get(msg_id)
         # unset reading flag, because if execute finished, raw_input can't
         # still be pending.
         self._reading = False
@@ -403,7 +401,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
 
             self._show_interpreter_prompt_for_reply(msg)
             self.executed.emit(msg)
-            info_list.pop(msg_id)
+            self._request_info['execute'].pop(msg_id)
         elif info and info.kind == 'silent_exec_callback' and not self._hidden:
             self._handle_exec_callback(msg)
         else:

--- a/IPython/frontend/qt/console/history_console_widget.py
+++ b/IPython/frontend/qt/console/history_console_widget.py
@@ -216,15 +216,13 @@ class HistoryConsoleWidget(ConsoleWidget):
     def _handle_execute_reply(self, msg):
         """ Handles replies for code execution, here only session history length
         """
-        info_list = self._request_info.get('execute')
         msg_id = msg['parent_header']['msg_id']
-        if msg_id in info_list:
-            info = info_list.pop(msg_id)
-            if info.kind == 'save_magic' and not self._hidden:
-                content = msg['content']
-                status = content['status']
-                if status == 'ok':
-                    self._max_session_history=(int(content['user_expressions']['hlen']))
+        info = self._request_info.get['execute'].pop(msg_id,None)
+        if info and info.kind == 'save_magic' and not self._hidden:
+            content = msg['content']
+            status = content['status']
+            if status == 'ok':
+                self._max_session_history=(int(content['user_expressions']['hlen']))
 
     def save_magic(self):
         # update the session history length

--- a/IPython/frontend/qt/console/history_console_widget.py
+++ b/IPython/frontend/qt/console/history_console_widget.py
@@ -211,18 +211,20 @@ class HistoryConsoleWidget(ConsoleWidget):
                 'hlen':'len(get_ipython().history_manager.input_hist_raw)',
                 }
             )
-        self._request_info['execute'] = self._ExecutionRequest(msg_id, 'save_magic')
+        self._request_info['execute'][msg_id] = self._ExecutionRequest(msg_id, 'save_magic')
 
     def _handle_execute_reply(self, msg):
         """ Handles replies for code execution, here only session history length
         """
-        info = self._request_info.get('execute')
-        if info and info.id == msg['parent_header']['msg_id'] and \
-                info.kind == 'save_magic' and not self._hidden:
-            content = msg['content']
-            status = content['status']
-            if status == 'ok':
-                self._max_session_history=(int(content['user_expressions']['hlen']))
+        info_list = self._request_info.get('execute')
+        msg_id = msg['parent_header']['msg_id']
+        if msg_id in info_list:
+            info = info_list.pop(msg_id)
+            if info.kind == 'save_magic' and not self._hidden:
+                content = msg['content']
+                status = content['status']
+                if status == 'ok':
+                    self._max_session_history=(int(content['user_expressions']['hlen']))
 
     def save_magic(self):
         # update the session history length

--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -165,11 +165,14 @@ class IPythonWidget(FrontendWidget):
     def _handle_execute_reply(self, msg):
         """ Reimplemented to support prompt requests.
         """
-        info = self._request_info.get('execute')
-        if info and info.id == msg['parent_header']['msg_id']:
+        info_list = self._request_info.get('execute')
+        msg_id = msg['parent_header']['msg_id']
+        if msg_id in info_list:
+            info = info_list[msg_id]
             if info.kind == 'prompt':
                 number = msg['content']['execution_count'] + 1
                 self._show_interpreter_prompt(number)
+                info_list.pop(msg_id)
             else:
                 super(IPythonWidget, self)._handle_execute_reply(msg)
 
@@ -358,7 +361,7 @@ class IPythonWidget(FrontendWidget):
         if number is None:
             msg_id = self.kernel_manager.shell_channel.execute('', silent=True)
             info = self._ExecutionRequest(msg_id, 'prompt')
-            self._request_info['execute'] = info
+            self._request_info['execute'][msg_id] = info
             return
 
         # Show a new prompt and save information about it so that it can be

--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -165,16 +165,14 @@ class IPythonWidget(FrontendWidget):
     def _handle_execute_reply(self, msg):
         """ Reimplemented to support prompt requests.
         """
-        info_list = self._request_info.get('execute')
-        msg_id = msg['parent_header']['msg_id']
-        if msg_id in info_list:
-            info = info_list[msg_id]
-            if info.kind == 'prompt':
-                number = msg['content']['execution_count'] + 1
-                self._show_interpreter_prompt(number)
-                info_list.pop(msg_id)
-            else:
-                super(IPythonWidget, self)._handle_execute_reply(msg)
+        msg_id = msg['parent_header'].get('msg_id')
+        info = self._request_info['execute'].get(msg_id)
+        if info and info.kind == 'prompt':
+           number = msg['content']['execution_count'] + 1
+           self._show_interpreter_prompt(number)
+           self._request_info['execute'].pop(msg_id)
+        else:
+           super(IPythonWidget, self)._handle_execute_reply(msg)
 
     def _handle_history_reply(self, msg):
         """ Implemented to handle history tail replies, which are only supported

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -626,17 +626,9 @@ class MainWindow(QtGui.QMainWindow):
         # is updated at first kernel response. Though, it is necessary when
         # connecting through X-forwarding, as in this case, the menu is not
         # auto updated, SO DO NOT DELETE.
-
-        ########################################################################
-        ## TEMPORARILY DISABLED - see #1057 for details.  Uncomment this
-        ## section when a proper fix is found
-        
-        ## self.pop = QtGui.QAction("&Update All Magic Menu ",
-        ##     self, triggered=self.update_all_magic_menu)
-        ## self.add_menu_action(self.all_magic_menu, self.pop)
-
-        ## END TEMPORARY FIX
-        ########################################################################
+        self.pop = QtGui.QAction("&Update All Magic Menu ",
+            self, triggered=self.update_all_magic_menu)
+        self.add_menu_action(self.all_magic_menu, self.pop)
 
         self.reset_action = QtGui.QAction("&Reset",
             self,
@@ -673,49 +665,6 @@ class MainWindow(QtGui.QMainWindow):
             statusTip="List interactive variable with detail",
             triggered=self.whos_magic_active_frontend)
         self.add_menu_action(self.magic_menu, self.whos_action)
-
-
-        ########################################################################
-        ## TEMPORARILY ADDED BACK - see #1057 for details.  The magic menu is
-        ## supposed to be dynamic, but the mechanism merged in #1057 has a race
-        ## condition that locks up the console very often.  We're putting back
-        ## the static list temporarily/ Remove this code when a proper fix is
-        ## found.
-        
-        # allmagics submenu.
-        
-        # for now this is just a copy and paste, but we should get this
-        # dynamically
-        magiclist = ["%alias", "%autocall", "%automagic", "%bookmark", "%cd",
-        "%clear", "%colors", "%debug", "%dhist", "%dirs", "%doctest_mode",
-        "%ed", "%edit", "%env", "%gui", "%guiref", "%hist", "%history",
-        "%install_default_config", "%install_profiles", "%less", "%load_ext",
-        "%loadpy", "%logoff", "%logon", "%logstart", "%logstate", "%logstop",
-        "%lsmagic", "%macro", "%magic", "%man", "%more", "%notebook", "%page",
-        "%pastebin", "%pdb", "%pdef", "%pdoc", "%pfile", "%pinfo", "%pinfo2",
-        "%popd", "%pprint", "%precision", "%profile", "%prun", "%psearch",
-        "%psource", "%pushd", "%pwd", "%pycat", "%pylab", "%quickref",
-        "%recall", "%rehashx", "%reload_ext", "%rep", "%rerun", "%reset",
-        "%reset_selective", "%run", "%save", "%sc", "%sx", "%tb", "%time",
-        "%timeit", "%unalias", "%unload_ext", "%who", "%who_ls", "%whos",
-        "%xdel", "%xmode"]
-
-        def make_dynamic_magic(i):
-                def inner_dynamic_magic():
-                    self.active_frontend.execute(i)
-                inner_dynamic_magic.__name__ = "dynamics_magic_%s" % i
-                return inner_dynamic_magic
-
-        for magic in magiclist:
-            xaction = QtGui.QAction(magic,
-                self,
-                triggered=make_dynamic_magic(magic)
-                )
-            self.all_magic_menu.addAction(xaction)
-
-        ## END TEMPORARY FIX
-        ########################################################################
-
 
     def init_window_menu(self):
         self.window_menu = self.menuBar().addMenu("&Window")

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -629,6 +629,9 @@ class MainWindow(QtGui.QMainWindow):
         self.pop = QtGui.QAction("&Update All Magic Menu ",
             self, triggered=self.update_all_magic_menu)
         self.add_menu_action(self.all_magic_menu, self.pop)
+        # we need to populate the 'Magic Menu' once the kernel has answer at
+        # least once let's do it immedialy, but it's assured to works
+        self.pop.trigger()
 
         self.reset_action = QtGui.QAction("&Reset",
             self,

--- a/IPython/frontend/qt/console/qtconsoleapp.py
+++ b/IPython/frontend/qt/console/qtconsoleapp.py
@@ -452,15 +452,8 @@ class IPythonQtConsoleApp(BaseIPythonApplication):
         self.window.add_tab_with_frontend(self.widget)
         self.window.init_menu_bar()
 
-        # we need to populate the 'Magic Menu' once the kernel has answer at
-        # least once 
-
-        ########################################################################
-        ## TEMPORARILY DISABLED - see #1057 for details, uncomment the next
-        ## line when a proper fix is found:
-        ## self.kernel_manager.shell_channel.first_reply.connect(self.window.pop.trigger)
-        ## END TEMPORARY FIX
-        ########################################################################
+        # we need to populate the 'Magic Menu' once the kernel has answer at least once
+        self.kernel_manager.shell_channel.first_reply.connect(self.window.pop.trigger)
 
         self.window.setWindowTitle('Python' if self.pure else 'IPython')
 

--- a/IPython/frontend/qt/console/qtconsoleapp.py
+++ b/IPython/frontend/qt/console/qtconsoleapp.py
@@ -452,9 +452,6 @@ class IPythonQtConsoleApp(BaseIPythonApplication):
         self.window.add_tab_with_frontend(self.widget)
         self.window.init_menu_bar()
 
-        # we need to populate the 'Magic Menu' once the kernel has answer at least once
-        self.kernel_manager.shell_channel.first_reply.connect(self.window.pop.trigger)
-
         self.window.setWindowTitle('Python' if self.pure else 'IPython')
 
     def init_colors(self):


### PR DESCRIPTION
See deee340f for descripition, 4573b163 just revert @fperez 65546bf which was temporary.

fix race condition in qtconsole due to a race condition beween the population
of the magic menu and the first prompt request. Resolved by upgrading the
logic of the console to handle several executions request in parallel.

Some namedTuple might still carry redundent information but the fix is the
first priority

Fixes #1057 , introduced by #956.

Note that I can't reproduce the bug, so please test carefully as it changes the logic of exec reply handeling in qtconsole
