### PR TITLE
Execution count after SyntaxError

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2371,12 +2371,14 @@ class InteractiveShell(SingletonConfigurable, Magic):
                         code_ast = self.compile.ast_parse(cell, filename=cell_name)
                     except IndentationError:
                         self.showindentationerror()
-                        self.execution_count += 1
+                        if store_history:
+                            self.execution_count += 1
                         return None
                     except (OverflowError, SyntaxError, ValueError, TypeError,
                             MemoryError):
                         self.showsyntaxerror()
-                        self.execution_count += 1
+                        if store_history:
+                            self.execution_count += 1
                         return None
 
                     self.run_ast_nodes(code_ast.body, cell_name,


### PR DESCRIPTION
After a SyntaxError in code run by run_cell, only increment execution count where we would normally (i.e. if store_history is True).

Trivial change, but it's right in our core machinery, so I thought I'd let someone else have a quick look.

Closes gh-633
