### PR TITLE
If object has a getdoc() method, override its normal docstring.

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -105,7 +105,7 @@ def getdoc(obj):
     else:
         # if we get extra info, we add it to the normal docstring.
         if isinstance(ds, basestring):
-            return ds
+            return inspect.cleandoc(ds)
     
     try:
         return inspect.getdoc(obj)

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -97,26 +97,22 @@ def getdoc(obj):
     It also attempts to call a getdoc() method on the given object.  This
     allows objects which provide their docstrings via non-standard mechanisms
     (like Pyro proxies) to still be inspected by ipython's ? system."""
-
-    ds = None  # default return value
-    try:
-        ds = inspect.getdoc(obj)
-    except:
-        # Harden against an inspect failure, which can occur with
-        # SWIG-wrapped extensions.
-        pass
     # Allow objects to offer customized documentation via a getdoc method:
     try:
-        ds2 = obj.getdoc()
-    except:
+        ds = obj.getdoc()
+    except Exception:
         pass
     else:
         # if we get extra info, we add it to the normal docstring.
-        if ds is None:
-            ds = ds2
-        else:
-            ds = '%s\n%s' % (ds,ds2)
-    return ds
+        if isinstance(ds, basestring):
+            return ds
+    
+    try:
+        return inspect.getdoc(obj)
+    except Exception:
+        # Harden against an inspect failure, which can occur with
+        # SWIG-wrapped extensions.
+        return None
 
 
 def getsource(obj,is_binary=False):

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -134,3 +134,19 @@ def test_info():
         i = inspector.info(OldStyle())
         nt.assert_equal(i['type_name'], 'instance')
         nt.assert_equal(i['docstring'], OldStyle.__doc__)
+
+def test_getdoc():
+    class A(object):
+        """standard docstring"""
+        pass
+    
+    class B(object):
+        """standard docstring"""
+        def getdoc(self):
+            return "custom docstring"
+    
+    a = A()
+    b = B()
+    
+    nt.assert_equal(oinspect.getdoc(a), "standard docstring")
+    nt.assert_equal(oinspect.getdoc(b), "custom docstring")

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -145,8 +145,15 @@ def test_getdoc():
         def getdoc(self):
             return "custom docstring"
     
+    class C(object):
+        """standard docstring"""
+        def getdoc(self):
+            return None
+    
     a = A()
     b = B()
+    c = C()
     
     nt.assert_equal(oinspect.getdoc(a), "standard docstring")
     nt.assert_equal(oinspect.getdoc(b), "custom docstring")
+    nt.assert_equal(oinspect.getdoc(c), "standard docstring")


### PR DESCRIPTION
Closes gh-89
