### PR TITLE
Storemagic plugin

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -130,6 +130,9 @@ class InteractiveShellApp(Configurable):
         if new:
             # add to self.extensions
             self.extensions.append(new)
+    
+    # Extensions that are always loaded (not configurable)
+    default_extensions = List(Unicode, [u'storemagic'], config=False)
 
     exec_files = List(Unicode, config=True,
         help="""List of files to run at IPython startup."""
@@ -158,11 +161,9 @@ class InteractiveShellApp(Configurable):
         This uses the :meth:`ExtensionManager.load_extensions` to load all
         the extensions listed in ``self.extensions``.
         """
-        if not self.extensions:
-            return
         try:
             self.log.debug("Loading IPython extensions...")
-            extensions = self.extensions
+            extensions = self.default_extensions + self.extensions
             for ext in extensions:
                 try:
                     self.log.info("Loading IPython extension: %s" % ext)

--- a/IPython/extensions/storemagic.py
+++ b/IPython/extensions/storemagic.py
@@ -2,17 +2,12 @@
 """
 %store magic for lightweight persistence.
 
-Stores variables, aliases and macros in IPython's database. Stored values will
-be automatically restored whenever the extension is loaded.
+Stores variables, aliases and macros in IPython's database.
 
-To enable this functionality, list it in your default profile
-`ipython_config.py` file::
+To automatically restore stored variables at startup, add this to your
+:file:`ipython_config.py` file::
 
-  c.InteractiveShellApp.extensions = ['storemagic']
-
-Or to use it temporarily, run this in your IPython session::
-
-  %load_ext storemagic
+  c.StoreMagic.autorestore = True
 
 """
 

--- a/IPython/extensions/storemagic.py
+++ b/IPython/extensions/storemagic.py
@@ -13,6 +13,7 @@ To automatically restore stored variables at startup, add this to your
 
 from IPython.core.error import TryNext, UsageError
 from IPython.core.plugin import Plugin
+from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils import pickleshare
 from IPython.utils.traitlets import Bool, Instance
 
@@ -50,6 +51,7 @@ def restore_data(ip):
     restore_aliases(ip)
     restore_dhist(ip)
 
+@skip_doctest
 def magic_store(self, parameter_s=''):
     """Lightweight persistence for python variables.
 

--- a/docs/source/whatsnew/development.txt
+++ b/docs/source/whatsnew/development.txt
@@ -62,8 +62,9 @@ New features
   Terminal frontend by default (:ghpull:`838`).
 
 * **%store**: The ``%store`` magic from earlier versions has been updated and
-  placed in an extension, :ref:`extensions_storemagic`. Add 'storemagic' to ``c.InteractiveShellApp.extensions``
-  in ipython_config.py to enable it (:ghpull:`1029`).
+  re-enabled (:ref:`extensions_storemagic`; :ghpull:`1029`). To autorestore
+  stored variables on startup, specify ``c.StoreMagic.autorestore = True`` in
+  :file:`ipython_config.py`.
 
 
 


### PR DESCRIPTION
This makes the storemagic extension a plugin, so there's a configurable option for autorestoring variables on startup (default False).

It also adds a non-configurable `default_extensions` trait to InteractiveShellApp, for extensions we want to always load as part of IPython. I considered just having a default value for the `extensions` trait, but I think that's too easy to clobber unintentionally in config, e.g. `c.InteractiveShellApp.extensions = ['sympyprinting']`.

I think this is a shortcoming of the extension system, that there isn't a simple way to add values to a container - you have to do the little dance with hasattr, and then assign or use `extend`.
