### PR TITLE
allow the notebook to run without MathJax

### DIFF
--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -219,6 +219,7 @@ class NewHandler(AuthenticatedHandler):
             base_project_url=u'/', base_kernel_url=u'/',
             kill_kernel=False,
             read_only=False,
+            enable_mathjax=self.application.ipython_app.enable_mathjax,
         )
 
 
@@ -237,6 +238,7 @@ class NamedNotebookHandler(AuthenticatedHandler):
             base_project_url=u'/', base_kernel_url=u'/',
             kill_kernel=False,
             read_only=self.read_only,
+            enable_mathjax=self.application.ipython_app.enable_mathjax,
         )
 
 

--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -219,7 +219,7 @@ class NewHandler(AuthenticatedHandler):
             base_project_url=u'/', base_kernel_url=u'/',
             kill_kernel=False,
             read_only=False,
-            enable_mathjax=self.application.ipython_app.enable_mathjax,
+            mathjax_url=self.application.ipython_app.mathjax_url,
         )
 
 
@@ -238,7 +238,7 @@ class NamedNotebookHandler(AuthenticatedHandler):
             base_project_url=u'/', base_kernel_url=u'/',
             kill_kernel=False,
             read_only=self.read_only,
-            enable_mathjax=self.application.ipython_app.enable_mathjax,
+            mathjax_url=self.application.ipython_app.mathjax_url,
         )
 
 

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -128,6 +128,17 @@ flags['no-browser']=(
     {'NotebookApp' : {'open_browser' : False}},
     "Don't open the notebook in a browser after startup."
 )
+flags['no-mathjax']=(
+    {'NotebookApp' : {'enable_mathjax' : False}},
+    """Disable MathJax
+    
+    MathJax is the javascript library IPython uses to render math/LaTeX. It is
+    very large, so you may want to disable it if you have a slow internet
+    connection, or for offline use of the notebook.
+    
+    When disabled, equations etc. will appear as their untransformed TeX source.
+    """
+)
 flags['read-only'] = (
     {'NotebookApp' : {'read_only' : True}},
     """Allow read-only access to notebooks.
@@ -144,7 +155,7 @@ flags['read-only'] = (
 # the flags that are specific to the frontend
 # these must be scrubbed before being passed to the kernel,
 # or it will raise an error on unrecognized flags
-notebook_flags = ['no-browser', 'read-only']
+notebook_flags = ['no-browser', 'no-mathjax', 'read-only']
 
 aliases = dict(ipkernel_aliases)
 
@@ -229,6 +240,17 @@ class NotebookApp(BaseIPythonApplication):
     
     read_only = Bool(False, config=True,
         help="Whether to prevent editing/execution of notebooks."
+    )
+    
+    enable_mathjax = Bool(True, config=True,
+        help="""Whether to enable MathJax for typesetting math/TeX
+
+        MathJax is the javascript library IPython uses to render math/LaTeX. It is
+        very large, so you may want to disable it if you have a slow internet
+        connection, or for offline use of the notebook.
+
+        When disabled, equations etc. will appear as their untransformed TeX source.
+        """
     )
 
     def parse_command_line(self, argv=None):

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -252,6 +252,31 @@ class NotebookApp(BaseIPythonApplication):
         When disabled, equations etc. will appear as their untransformed TeX source.
         """
     )
+    def _enable_mathjax_changed(self, name, old, new):
+        """set mathjax url to empty if mathjax is disabled"""
+        if not new:
+            self.mathjax_url = u''
+    
+    mathjax_url = Unicode("", config=True,
+        help="""The url for MathJax.js."""
+    )
+    def _mathjax_url_default(self):
+        if not self.enable_mathjax:
+            return u''
+        static_path = os.path.join(os.path.dirname(__file__), "static")
+        if os.path.exists(os.path.join(static_path, 'mathjax', "MathJax.js")):
+            self.log.info("Using local MathJax")
+            return u"static/mathjax/MathJax.js"
+        else:
+            self.log.info("Using MathJax from CDN")
+            return u"http://cdn.mathjax.org/mathjax/latest/MathJax.js"
+    
+    def _mathjax_url_changed(self, name, old, new):
+        if new and not self.enable_mathjax:
+            # enable_mathjax=False overrides mathjax_url
+            self.mathjax_url = u''
+        else:
+            self.log.info("Using MathJax: %s", new)
 
     def parse_command_line(self, argv=None):
         super(NotebookApp, self).parse_command_line(argv)

--- a/IPython/frontend/html/notebook/static/css/notebook.css
+++ b/IPython/frontend/html/notebook/static/css/notebook.css
@@ -415,6 +415,18 @@ div.text_cell_render {
     font-family: monospace;
 }
 
+pre.dialog {
+    background-color: #f7f7f7;
+    border: 1px solid #ddd;
+    border-radius: 3px;
+    padding: 0.4em;
+    padding-left: 2em;
+}
+
+p.dialog{
+    padding : 0.2em;
+}
+
 @media print {
     body { overflow: visible !important; }
     .ui-widget-content { border: 0px; }

--- a/IPython/frontend/html/notebook/static/js/cell.js
+++ b/IPython/frontend/html/notebook/static/js/cell.js
@@ -88,6 +88,13 @@ var IPython = (function (IPython) {
     // Subclasses must implement create_element.
     Cell.prototype.create_element = function () {};
 
+    // typeset with MathJax if MathJax is available
+    Cell.prototype.typeset = function () {
+        if (window.MathJax){
+            MathJax.Hub.Queue(["Typeset",MathJax.Hub]);
+        }
+    };
+
     IPython.Cell = Cell;
 
     return IPython;

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -520,7 +520,7 @@ var IPython = (function (IPython) {
         this.element.find('div.output').append(toinsert);
         // If we just output latex, typeset it.
         if ((json.latex !== undefined) || (json.html !== undefined)) {
-            MathJax.Hub.Queue(["Typeset",MathJax.Hub]);
+            this.typeset();
         };
     };
 
@@ -572,7 +572,7 @@ var IPython = (function (IPython) {
         this.element.find('div.output').append(toinsert);
         // If we just output latex, typeset it.
         if ( (json.latex !== undefined) || (json.html !== undefined) ) {
-            MathJax.Hub.Queue(["Typeset",MathJax.Hub]);
+            this.typeset();
         };
     };
 

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -59,7 +59,7 @@ var IPython = (function (IPython) {
         var that = this;
         $(document).keydown(function (event) {
             // console.log(event);
-            if (that.read_only) return false;
+            if (that.read_only) return true;
             if (event.which === 27) {
                 // Intercept escape at highest level to avoid closing 
                 // websocket connection with firefox

--- a/IPython/frontend/html/notebook/static/js/notebookmain.js
+++ b/IPython/frontend/html/notebook/static/js/notebookmain.js
@@ -28,13 +28,14 @@ $(document).ready(function () {
         var dialog = $('<div></div>')
             .append(
                 $("<p></p>").addClass('dialog').html(
-                    "Math/LaTeX equation rendering will be disabled."
+                    "Math/LaTeX rendering will be disabled."
                 )
             ).append(
                 $("<p></p>").addClass('dialog').html(
-                    "With a working internet connection, you can install a local copy" +
-                    " of MathJax for offline use with the following command at a Python" +
-                    " or IPython prompt:"
+                    "If you have administrative access to the notebook server and" +
+                    " a working internet connection, you can install a local copy" +
+                    " of MathJax for offline use with the following command on the server" +
+                    " at a Python or IPython prompt:"
                 )
             ).append(
                 $("<pre></pre>").addClass('dialog').html(
@@ -42,14 +43,17 @@ $(document).ready(function () {
                 )
             ).append(
                 $("<p></p>").addClass('dialog').html(
-                    "This will try to install MathJax into the directory where you installed"+
-                    " IPython. If you installed IPython to a location that requires"+
-                    " administrative privileges to write, you will need to make this call as"+
+                    "This will try to install MathJax into the IPython source directory."
+                )
+            ).append(
+                $("<p></p>").addClass('dialog').html(
+                    "If IPython is installed to a location that requires" +
+                    " administrative privileges to write, you will need to make this call as" +
                     " an administrator, via 'sudo'."
                 )
             ).append(
                 $("<p></p>").addClass('dialog').html(
-                    "Or you can instruct the notebook server to disable MathJax support altogether:"
+                    "When you start the notebook server, you can instruct it to disable MathJax support altogether:"
                 )
             ).append(
                 $("<pre></pre>").addClass('dialog').html(

--- a/IPython/frontend/html/notebook/static/js/notebookmain.js
+++ b/IPython/frontend/html/notebook/static/js/notebookmain.js
@@ -12,16 +12,62 @@
 
 $(document).ready(function () {
 
-    MathJax.Hub.Config({
-        tex2jax: {
-            inlineMath: [ ['$','$'], ["\\(","\\)"] ],
-            displayMath: [ ['$$','$$'], ["\\[","\\]"] ]
-        },
-        displayAlign: 'left', // Change this to 'center' to center equations.
-        "HTML-CSS": {
-            styles: {'.MathJax_Display': {"margin": 0}}
-        }
-    });
+    if (window.MathJax == undefined){
+        // MathJax undefined, but expected.  Draw warning.
+        window.MathJax = null;
+        var dialog = $('<div></div>').html(
+            "<p class='dialog'>"+
+            "We were unable to retrieve MathJax. Math/LaTeX rendering will be disabled."+
+            "</p>"+
+            "<p class='dialog'>"+
+            "With a working internet connection, you can run the following at a Python"+
+            " or IPython prompt, which will install a local copy of MathJax:"+
+            "</p>"+
+            "<pre class='dialog'>"+
+            ">>> from IPython.external import mathjax; mathjax.install_mathjax()"+
+            "</pre>"+
+            "<p class='dialog'>"+
+            "This will try to install MathJax into the directory where you installed"+
+            " IPython. If you installed IPython to a location that requires"+
+            " administrative privileges to write, you will need to make this call as"+
+            " an administrator."+
+            "</p>"+
+            "<p class='dialog'>"+
+            "On OSX/Linux/Unix, this can be done at the command-line via:"+
+            "</p>"+
+            "<pre class='dialog'>"+
+            "$ sudo python -c 'from IPython.external import mathjax; mathjax.install_mathjax()'"+
+            "</pre>"+
+            "<p class='dialog'>"+
+            "Or you can instruct the notebook server to start without MathJax support, with:"+
+            "<pre class='dialog'>"+
+            "</p>"+
+            "$ ipython notebook --no-mathjax"+
+            "</pre>"+
+            "<p class='dialog'>"+
+            "in which case, equations will not be rendered."+
+            "</p>"
+            ).dialog({
+                title: 'MathJax disabled',
+                width: "70%",
+                modal: true,
+            })
+    }else if (window.MathJax){
+        MathJax.Hub.Config({
+            tex2jax: {
+                inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+                displayMath: [ ['$$','$$'], ["\\[","\\]"] ]
+            },
+            displayAlign: 'left', // Change this to 'center' to center equations.
+            "HTML-CSS": {
+                styles: {'.MathJax_Display': {"margin": 0}}
+            }
+        });
+    }else{
+        // window.MathJax == null
+        // --no-mathjax mode
+    }
+    
     IPython.markdown_converter = new Markdown.Converter();
     IPython.read_only = $('meta[name=read_only]').attr("content") == 'True';
 

--- a/IPython/frontend/html/notebook/static/js/notebookmain.js
+++ b/IPython/frontend/html/notebook/static/js/notebookmain.js
@@ -11,48 +11,8 @@
 
 
 $(document).ready(function () {
-
-    if (window.MathJax == undefined){
-        // MathJax undefined, but expected.  Draw warning.
-        window.MathJax = null;
-        var dialog = $('<div></div>').html(
-            "<p class='dialog'>"+
-            "We were unable to retrieve MathJax. Math/LaTeX rendering will be disabled."+
-            "</p>"+
-            "<p class='dialog'>"+
-            "With a working internet connection, you can run the following at a Python"+
-            " or IPython prompt, which will install a local copy of MathJax:"+
-            "</p>"+
-            "<pre class='dialog'>"+
-            ">>> from IPython.external import mathjax; mathjax.install_mathjax()"+
-            "</pre>"+
-            "<p class='dialog'>"+
-            "This will try to install MathJax into the directory where you installed"+
-            " IPython. If you installed IPython to a location that requires"+
-            " administrative privileges to write, you will need to make this call as"+
-            " an administrator."+
-            "</p>"+
-            "<p class='dialog'>"+
-            "On OSX/Linux/Unix, this can be done at the command-line via:"+
-            "</p>"+
-            "<pre class='dialog'>"+
-            "$ sudo python -c 'from IPython.external import mathjax; mathjax.install_mathjax()'"+
-            "</pre>"+
-            "<p class='dialog'>"+
-            "Or you can instruct the notebook server to start without MathJax support, with:"+
-            "<pre class='dialog'>"+
-            "</p>"+
-            "$ ipython notebook --no-mathjax"+
-            "</pre>"+
-            "<p class='dialog'>"+
-            "in which case, equations will not be rendered."+
-            "</p>"
-            ).dialog({
-                title: 'MathJax disabled',
-                width: "70%",
-                modal: true,
-            })
-    }else if (window.MathJax){
+    if (window.MathJax){ 
+        // MathJax loaded
         MathJax.Hub.Config({
             tex2jax: {
                 inlineMath: [ ['$','$'], ["\\(","\\)"] ],
@@ -63,9 +23,49 @@ $(document).ready(function () {
                 styles: {'.MathJax_Display': {"margin": 0}}
             }
         });
+    }else if (window.mathjax_url != ""){
+        // Don't have MathJax, but should. Show dialog.
+        var dialog = $('<div></div>')
+            .append(
+                $("<p></p>").addClass('dialog').html(
+                    "Math/LaTeX equation rendering will be disabled."
+                )
+            ).append(
+                $("<p></p>").addClass('dialog').html(
+                    "With a working internet connection, you can install a local copy" +
+                    " of MathJax for offline use with the following command at a Python" +
+                    " or IPython prompt:"
+                )
+            ).append(
+                $("<pre></pre>").addClass('dialog').html(
+                    ">>> from IPython.external import mathjax; mathjax.install_mathjax()"
+                )
+            ).append(
+                $("<p></p>").addClass('dialog').html(
+                    "This will try to install MathJax into the directory where you installed"+
+                    " IPython. If you installed IPython to a location that requires"+
+                    " administrative privileges to write, you will need to make this call as"+
+                    " an administrator, via 'sudo'."
+                )
+            ).append(
+                $("<p></p>").addClass('dialog').html(
+                    "Or you can instruct the notebook server to disable MathJax support altogether:"
+                )
+            ).append(
+                $("<pre></pre>").addClass('dialog').html(
+                    "$ ipython notebook --no-mathjax"
+                )
+            ).append(
+                $("<p></p>").addClass('dialog').html(
+                    "which will prevent this dialog from appearing."
+                )
+            ).dialog({
+                title: "Failed to retrieve MathJax from '" + window.mathjax_url + "'",
+                width: "70%",
+                modal: true,
+            })
     }else{
-        // window.MathJax == null
-        // --no-mathjax mode
+        // No MathJax, but none expected. No dialog.
     }
     
     IPython.markdown_converter = new Markdown.Converter();

--- a/IPython/frontend/html/notebook/static/js/textcell.js
+++ b/IPython/frontend/html/notebook/static/js/textcell.js
@@ -175,7 +175,7 @@ var IPython = (function (IPython) {
             var text = this.get_source();
             if (text === "") { text = this.placeholder; }
             this.set_rendered(text);
-            MathJax.Hub.Queue(["Typeset",MathJax.Hub]);
+            this.typeset();
             this.element.find('div.text_cell_input').hide();
             this.element.find("div.text_cell_render").show();
             this.rendered = true;
@@ -201,7 +201,7 @@ var IPython = (function (IPython) {
             if (text === "") { text = this.placeholder; }
             var html = IPython.markdown_converter.makeHtml(text);
             this.set_rendered(html);
-            MathJax.Hub.Queue(["Typeset",MathJax.Hub]);
+            this.typeset()
             this.element.find('div.text_cell_input').hide();
             this.element.find("div.text_cell_render").show();
             var code_snippets = this.element.find("pre > code");
@@ -255,7 +255,7 @@ var IPython = (function (IPython) {
 
     RSTCell.prototype.handle_render = function (data, status, xhr) {
         this.set_rendered(data);
-        MathJax.Hub.Queue(["Typeset",MathJax.Hub]);
+        this.typeset();
         this.rendered = true;
     };
 

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -6,24 +6,14 @@
 
     <title>IPython Notebook</title>
 
-    {% if enable_mathjax %}
-    <!-- <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML" charset="utf-8"></script> -->
-    <script type='text/javascript' src='static/mathjax/MathJax.js?config=TeX-AMS_HTML' charset='utf-8'></script>
-    <script type="text/javascript">
-    if (typeof(MathJax) == 'undefined') {
-        console.log("No local MathJax, loading from CDN");
-        document.write(unescape("%3Cscript type='text/javascript' src='http://cdn.mathjax.org/mathjax/latest/MathJax.js%3Fconfig=TeX-AMS_HTML' charset='utf-8'%3E%3C/script%3E"));
-    }else{
-        console.log("Using local MathJax");
-    }
-    </script>
-    {% else %}
+    {% if mathjax_url %}
+    <script type="text/javascript" src="{{mathjax_url}}?config=TeX-AMS_HTML" charset="utf-8"></script>
+    {% end %}
     <script type="text/javascript">
     // MathJax disabled, set as null to distingish from *missing* MathJax,
     // where it will be undefined, and should prompt a dialog later.
-    window.MathJax = null;
+    window.mathjax_url = "{{mathjax_url}}";
     </script>
-    {% end %}
 
     <link rel="stylesheet" href="static/jquery/css/themes/aristo/jquery-wijmo.css" type="text/css" />
     <link rel="stylesheet" href="static/codemirror/lib/codemirror.css">

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -6,25 +6,24 @@
 
     <title>IPython Notebook</title>
 
+    {% if enable_mathjax %}
     <!-- <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML" charset="utf-8"></script> -->
     <script type='text/javascript' src='static/mathjax/MathJax.js?config=TeX-AMS_HTML' charset='utf-8'></script>
     <script type="text/javascript">
-    function CheckMathJax(){
-        var div=document.getElementById("MathJaxFetchingWarning")
-        if(window.MathJax){
-            document.body.removeChild(div)
-        }
-        else{
-           div.style.display = "block";
-        }
-    }
-    if (typeof MathJax == 'undefined') {
+    if (typeof(MathJax) == 'undefined') {
         console.log("No local MathJax, loading from CDN");
         document.write(unescape("%3Cscript type='text/javascript' src='http://cdn.mathjax.org/mathjax/latest/MathJax.js%3Fconfig=TeX-AMS_HTML' charset='utf-8'%3E%3C/script%3E"));
     }else{
         console.log("Using local MathJax");
     }
     </script>
+    {% else %}
+    <script type="text/javascript">
+    // MathJax disabled, set as null to distingish from *missing* MathJax,
+    // where it will be undefined, and should prompt a dialog later.
+    window.MathJax = null;
+    </script>
+    {% end %}
 
     <link rel="stylesheet" href="static/jquery/css/themes/aristo/jquery-wijmo.css" type="text/css" />
     <link rel="stylesheet" href="static/codemirror/lib/codemirror.css">
@@ -45,7 +44,7 @@
 
 </head>
 
-<body onload='CheckMathJax();'
+<body
     data-project={{project}} data-notebook-id={{notebook_id}}
     data-base-project-url={{base_project_url}} data-base-kernel-url={{base_kernel_url}}
 >
@@ -69,29 +68,6 @@
     </span>
 
     <span id="kernel_status">Idle</span>
-</div>
-
-<div id="MathJaxFetchingWarning"
-      style="width:80%; margin:auto;padding-top:20%;text-align: justify; display:none">
-      <p style="font-size:26px;">There was an issue trying to fetch MathJax.js
-        from the internet.</p>
-
-      <p style="padding:0.2em"> With a working internet connection, you can run
-    the following at a Python or IPython prompt, which will install a local
-    copy of MathJax:</p>
-      
-        <pre style="background-color:lightblue;border:thin silver solid;padding:0.4em">
-            from IPython.external import mathjax; mathjax.install_mathjax()
-        </pre>
-        This will try to install MathJax into the directory where you installed
-        IPython. If you installed IPython to a location that requires
-        administrative privileges to write, you will need to make this call as
-        an administrator. On OSX/Linux/Unix, this can be done at the
-        command-line via:
-        <pre style="background-color:lightblue;border:thin silver solid;padding:0.4em">
-            sudo python -c "from IPython.external import mathjax; mathjax.install_mathjax()"
-        </pre>
-    </p>
 </div>
 
 <div id="main_app">


### PR DESCRIPTION
- add `--no-mathjax` flag  (and corresponding `NotebookApp.enable_mathjax` configurable)for disabling mathjax in the notebook server
- A jQuery dialog with our 'no mathjax' message will appear if mathjax is unavailable, but the notebook will be fully functional after dismissal.
- Various calls to MathJax.Hub.typeset moved to Cell.typeset, which checks for MathJax existence and is a no-op without it.
- also a tiny fix where read-only mode swallowed all keyboard events, rather than allowing them to have their regular effect (e.g refresh).

closes #1071
