### PR TITLE
PromptManager fixes

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -315,10 +315,37 @@ class InteractiveShell(SingletonConfigurable, Magic):
         help="Save multi-line entries as one entry in readline history"
     )
 
-    prompt_in1 = Unicode('In [\\#]: ', config=True)
-    prompt_in2 = Unicode('   .\\D.: ', config=True)
-    prompt_out = Unicode('Out[\\#]: ', config=True)
-    prompts_pad_left = CBool(True, config=True)
+    # deprecated prompt traits:
+    
+    prompt_in1 = Unicode('In [\\#]: ', config=True,
+        help="Deprecated, use PromptManager.in_template")
+    prompt_in2 = Unicode('   .\\D.: ', config=True,
+        help="Deprecated, use PromptManager.in2_template")
+    prompt_out = Unicode('Out[\\#]: ', config=True,
+        help="Deprecated, use PromptManager.out_template")
+    prompts_pad_left = CBool(True, config=True,
+        help="Deprecated, use PromptManager.justify")
+    
+    def _prompt_trait_changed(self, name, old, new):
+        table = {
+            'prompt_in1' : 'in_template',
+            'prompt_in2' : 'in2_template',
+            'prompt_out' : 'out_template',
+            'prompts_pad_left' : 'justify',
+        }
+        warn("InteractiveShell.{name} is deprecated, use PromptManager.{newname}\n".format(
+                name=name, newname=table[name])
+        )
+        # protect against weird cases where self.config may not exist:
+        if self.config is not None:
+            # propagate to corresponding PromptManager trait
+            setattr(self.config.PromptManager, table[name], new)
+    
+    _prompt_in1_changed = _prompt_trait_changed
+    _prompt_in2_changed = _prompt_trait_changed
+    _prompt_out_changed = _prompt_trait_changed
+    _prompt_pad_left_changed = _prompt_trait_changed
+    
     quiet = CBool(False, config=True)
 
     history_length = Integer(10000, config=True)

--- a/IPython/core/prompts.py
+++ b/IPython/core/prompts.py
@@ -254,10 +254,14 @@ class PromptManager(Configurable):
         """)
     def _lazy_evaluate_fields_default(self): return lazily_evaluate.copy()
     
-    in_template = Unicode('In [\\#]: ', config=True)
-    in2_template = Unicode('   .\\D.: ', config=True)
-    out_template = Unicode('Out[\\#]: ', config=True)
-    rewrite_template = Unicode("------> ", config=True)
+    in_template = Unicode('In [\\#]: ', config=True,
+        help="Input prompt.  '\\#' will be transformed to the prompt number")
+    in2_template = Unicode('   .\\D.: ', config=True,
+        help="Continuation prompt.")
+    out_template = Unicode('Out[\\#]: ', config=True,
+        help="Output prompt. '\\#' will be transformed to the prompt number")
+    rewrite_template = Unicode("------> ", config=True,
+        help="Rewrite prompt. When inputs are transformed, the rewritten input will follow this.")
     
     justify = Bool(True, config=True, help="""
         If True (default), each prompt will be right-aligned with the

--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -38,6 +38,7 @@ from IPython.core import usage
 from IPython.core.completer import IPCompleter
 from IPython.core.crashhandler import CrashHandler
 from IPython.core.formatters import PlainTextFormatter
+from IPython.core.prompts import PromptManager
 from IPython.core.application import (
     ProfileDir, BaseIPythonApplication, base_flags, base_aliases
 )
@@ -133,9 +134,9 @@ addflag('term-title', 'TerminalInteractiveShell.term_title',
 classic_config = Config()
 classic_config.InteractiveShell.cache_size = 0
 classic_config.PlainTextFormatter.pprint = False
-classic_config.InteractiveShell.prompt_in1 = '>>> '
-classic_config.InteractiveShell.prompt_in2 = '... '
-classic_config.InteractiveShell.prompt_out = ''
+classic_config.PromptManager.in_template = '>>> '
+classic_config.PromptManager.in2_template = '... '
+classic_config.PromptManager.out_template = ''
 classic_config.InteractiveShell.separate_in = ''
 classic_config.InteractiveShell.separate_out = ''
 classic_config.InteractiveShell.separate_out2 = ''
@@ -197,6 +198,7 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
             InteractiveShellApp, # ShellApp comes before TerminalApp, because
             self.__class__,      # it will also affect subclasses (e.g. QtConsole)
             TerminalInteractiveShell,
+            PromptManager,
             ProfileDir,
             PlainTextFormatter,
             IPCompleter,

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -202,9 +202,9 @@ def ipexec(fname, options=None):
 
     # For these subprocess calls, eliminate all prompt printing so we only see
     # output from script execution
-    prompt_opts = [ '--InteractiveShell.prompt_in1=""',
-                    '--InteractiveShell.prompt_in2=""',
-                    '--InteractiveShell.prompt_out=""'
+    prompt_opts = [ '--PromptManager.in_template=""',
+                    '--PromptManager.in2_template=""',
+                    '--PromptManager.out_template=""'
     ]
     cmdargs = ' '.join(default_argv() + prompt_opts + options)
 

--- a/docs/examples/core/example-embed.py
+++ b/docs/examples/core/example-embed.py
@@ -23,10 +23,10 @@ try:
 except NameError:
     nested = 0
     cfg = Config()
-    shell_config = cfg.InteractiveShellEmbed
-    shell_config.prompt_in1 = 'In <\\#>: '
-    shell_config.prompt_in2 = '   .\\D.: '
-    shell_config.prompt_out = 'Out<\\#>: '
+    prompt_config = cfg.PromptManager
+    prompt_config.in_template = 'In <\\#>: '
+    prompt_config.in2_template = '   .\\D.: '
+    prompt_config.out_template = 'Out<\\#>: '
 else:
     print "Running nested copies of IPython."
     print "The prompts for the nested copy have been modified"
@@ -46,12 +46,12 @@ ipshell = InteractiveShellEmbed(config=cfg,
 
 # Make a second instance, you can have as many as you want.
 cfg2 = cfg.copy()
-shell_config = cfg2.InteractiveShellEmbed
-shell_config.prompt_in1 = 'In2<\\#>: '
+prompt_config = cfg2.PromptManager
+prompt_config.in_template = 'In2<\\#>: '
 if not nested:
-    shell_config.prompt_in1 = 'In2<\\#>: '
-    shell_config.prompt_in2 = '   .\\D.: '
-    shell_config.prompt_out = 'Out<\\#>: '
+    prompt_config.in_template = 'In2<\\#>: '
+    prompt_config.in2_template = '   .\\D.: '
+    prompt_config.out_template = 'Out<\\#>: '
 ipshell2 = InteractiveShellEmbed(config=cfg,
                         banner1 = 'Second IPython instance.')
 

--- a/docs/source/interactive/reference.txt
+++ b/docs/source/interactive/reference.txt
@@ -227,7 +227,7 @@ All options with a [no] prepended can be specified in negated form
 	circular file inclusions, IPython will stop if it reaches 15
 	recursive inclusions.
 
-    ``InteractiveShell.prompt_in1=<string>``
+    ``PromptManager.in_template=<string>``
 
 	Specify the string used for input prompts. Note that if you are using
 	numbered prompts, the number is represented with a '\#' in the
@@ -236,7 +236,7 @@ All options with a [no] prepended can be specified in negated form
 	discusses in detail all the available escapes to customize your
 	prompts.
 
-    ``InteractiveShell.prompt_in2=<string>``
+    ``PromptManager.in2_template=<string>``
 	Similar to the previous option, but used for the continuation
 	prompts. The special sequence '\D' is similar to '\#', but
 	with all digits replaced dots (so you can have your
@@ -244,9 +244,9 @@ All options with a [no] prepended can be specified in negated form
 	' .\D.:' (note three spaces at the start for alignment with
 	'In [\#]').
 
-    ``InteractiveShell.prompt_out=<string>``
+    ``PromptManager.out_template=<string>``
 	String used for output prompts, also uses numbers like
-	prompt_in1. Default: 'Out[\#]:'
+	in_template. Default: 'Out[\#]:'
 
     ``--quick``
         start in bare bones mode (no config file loaded).

--- a/docs/source/interactive/shell.txt
+++ b/docs/source/interactive/shell.txt
@@ -155,8 +155,8 @@ Prompt customization
 
 The sh profile uses the following prompt configurations::
 
-    o.prompt_in1= r'\C_LightBlue[\C_LightCyan\Y2\C_LightBlue]\C_Green|\#>'
-    o.prompt_in2= r'\C_Green|\C_LightGreen\D\C_Green>'
+    o.PromptManager.in_template= r'\C_LightBlue[\C_LightCyan\Y2\C_LightBlue]\C_Green|\#>'
+    o.PromptManager.in2_template= r'\C_Green|\C_LightGreen\D\C_Green>'
 
 You can change the prompt configuration to your liking by editing
 ipython_config.py.


### PR DESCRIPTION
- InteractiveShell.prompt_foo traits show deprecation warning, and map to new PromptManager traits
- PromptManager properly added to IPython App, so it will show up in config
- add helpstrings to PromptManager traits.
- Docs / embed references to Shell.prompt_foo also updated

Should close #1075
