### PR TITLE
Login/out button cleanups

### DIFF
--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -137,17 +137,25 @@ class AuthenticatedHandler(RequestHandler):
             if not self.application.password and not self.application.read_only:
                 user_id = 'anonymous'
         return user_id
-    
+
     @property
     def read_only(self):
-        if self.application.read_only:
+        """Is the notebook read-only?
+
+        None -- notebook is read-only, but the user can log-in to edit
+        True -- notebook is read-only, no log-in available
+        False -- no read-only mode available, user must log in
+
+        """
+        user = self.get_current_user()
+        if user and user != 'anonymous':
+            return False
+        elif self.application.read_only:
             if self.application.password:
-                return self.get_current_user() is None
+                return None
             else:
                 return True
-        else:
-            return False
-    
+
     @property
     def ws_url(self):
         """websocket url matching the current request

--- a/IPython/frontend/html/notebook/static/js/loginwidget.js
+++ b/IPython/frontend/html/notebook/static/js/loginwidget.js
@@ -22,11 +22,15 @@ var IPython = (function (IPython) {
 
     LoginWidget.prototype.style = function () {
         this.element.find('button#logout').button();
+        this.element.find('button#login').button();
     };
     LoginWidget.prototype.bind_events = function () {
         var that = this;
         this.element.find("button#logout").click(function () {
             window.location = "/logout";
+        });
+        this.element.find("button#login").click(function () {
+            window.location = "/login";
         });
     };
 

--- a/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
+++ b/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
@@ -28,18 +28,9 @@ $(document).ready(function () {
     $('div#right_panel').addClass('box-flex');
 
     IPython.read_only = $('meta[name=read_only]').attr("content") == 'True';
-    
     IPython.notebook_list = new IPython.NotebookList('div#notebook_list');
     IPython.login_widget = new IPython.LoginWidget('span#login_widget');
-    
-    if (IPython.read_only){
-        // unhide login button if it's relevant
-        $('span#login_widget').removeClass('hidden');
-        $('#drag_info').remove();
-    } else {
-        $('#new_notebook').removeClass('hidden');
-        $('#drag_info').removeClass('hidden');
-    }
+
     IPython.notebook_list.load_list();
 
     // These have display: none in the css file and are made visible here to prevent FLOUC.

--- a/IPython/frontend/html/notebook/templates/layout.html
+++ b/IPython/frontend/html/notebook/templates/layout.html
@@ -25,6 +25,8 @@
     <span id="login_widget">
       {% if current_user and current_user != 'anonymous' %}
         <button id="logout">Logout</button>
+      {% else %}
+        <button id="login">Login</button>
       {% end %}
     </span>
     {% block header %}

--- a/IPython/frontend/html/notebook/templates/layout.html
+++ b/IPython/frontend/html/notebook/templates/layout.html
@@ -22,13 +22,19 @@
 
 <div id="header">
     <span id="ipython_notebook"><h1><img src='static/ipynblogo.png' alt='IPython Notebook'/></h1></span>
-    <span id="login_widget">
-      {% if logged_in %}
-        <button id="logout">Logout</button>
-      {% elif login_available and not logged_in %}
-        <button id="login">Login</button>
-      {% end %}
-    </span>
+
+    {% block login_widget %}
+
+      <span id="login_widget">
+        {% if logged_in %}
+          <button id="logout">Logout</button>
+        {% elif login_available and not logged_in %}
+          <button id="login">Login</button>
+        {% end %}
+      </span>
+
+    {% end %}
+
     {% block header %}
     {% end %}
 </div>

--- a/IPython/frontend/html/notebook/templates/layout.html
+++ b/IPython/frontend/html/notebook/templates/layout.html
@@ -25,7 +25,7 @@
     <span id="login_widget">
       {% if current_user and current_user != 'anonymous' %}
         <button id="logout">Logout</button>
-      {% else %}
+      {% elif read_only is None %}
         <button id="login">Login</button>
       {% end %}
     </span>

--- a/IPython/frontend/html/notebook/templates/layout.html
+++ b/IPython/frontend/html/notebook/templates/layout.html
@@ -23,9 +23,9 @@
 <div id="header">
     <span id="ipython_notebook"><h1><img src='static/ipynblogo.png' alt='IPython Notebook'/></h1></span>
     <span id="login_widget">
-      {% if current_user and current_user != 'anonymous' %}
+      {% if logged_in %}
         <button id="logout">Logout</button>
-      {% elif read_only is None %}
+      {% elif login_available and not logged_in %}
         <button id="login">Login</button>
       {% end %}
     </span>

--- a/IPython/frontend/html/notebook/templates/login.html
+++ b/IPython/frontend/html/notebook/templates/login.html
@@ -2,7 +2,16 @@
 
 {% block content_panel %}
     <form action="/login?next={{url_escape(next)}}" method="post">
-        Password: <input type="password" name="password">
+        Password: <input type="password" name="password" id="focus">
         <input type="submit" value="Sign in" id="signin">
     </form>
+{% end %}
+
+{% block script %}
+<script type="text/javascript">
+  $(document).ready(function() {
+    IPython.login_widget = new IPython.LoginWidget('span#login_widget');
+    $('#focus').focus();
+  });
+</script>
 {% end %}

--- a/IPython/frontend/html/notebook/templates/login.html
+++ b/IPython/frontend/html/notebook/templates/login.html
@@ -1,10 +1,16 @@
 {% extends layout.html %}
 
 {% block content_panel %}
+
+    {% if login_available %}
+
     <form action="/login?next={{url_escape(next)}}" method="post">
         Password: <input type="password" name="password" id="focus">
         <input type="submit" value="Sign in" id="signin">
     </form>
+
+    {% end %}
+
 {% end %}
 
 {% block script %}

--- a/IPython/frontend/html/notebook/templates/login.html
+++ b/IPython/frontend/html/notebook/templates/login.html
@@ -13,6 +13,9 @@
 
 {% end %}
 
+{% block login_widget %}
+{% end %}
+
 {% block script %}
 <script type="text/javascript">
   $(document).ready(function() {

--- a/IPython/frontend/html/notebook/templates/logout.html
+++ b/IPython/frontend/html/notebook/templates/logout.html
@@ -1,5 +1,9 @@
 {% extends layout.html %}
 
 {% block content_panel %}
-Proceed to the <a href="/login">login page</a>.
+  {% if current_user and current_user != 'anonymous' %}
+    Proceed to the <a href="/">front page</a>.
+  {% else %}
+    Proceed to the <a href="/login">login page</a>.
+  {% end %}
 {% end %}

--- a/IPython/frontend/html/notebook/templates/logout.html
+++ b/IPython/frontend/html/notebook/templates/logout.html
@@ -16,6 +16,9 @@
 
 {% end %}
 
+{% block login_widget %}
+{% end %}
+
 {% block script %}
 <script type="text/javascript">
   $(document).ready(function() {

--- a/IPython/frontend/html/notebook/templates/logout.html
+++ b/IPython/frontend/html/notebook/templates/logout.html
@@ -1,11 +1,19 @@
 {% extends layout.html %}
 
 {% block content_panel %}
-  {% if current_user and current_user != 'anonymous' %}
-    Proceed to the <a href="/">front page</a>.
-  {% else %}
-    Proceed to the <a href="/login">login page</a>.
-  {% end %}
+  <ul>
+    {% if read_only or not login_available %}
+
+    Proceed to the <a href="/">list of notebooks</a>.</li>
+
+    {% else %}
+
+    Proceed to the <a href="/login">login page</a>.</li>
+
+    {% end %}
+
+  </ul>
+
 {% end %}
 
 {% block script %}

--- a/IPython/frontend/html/notebook/templates/logout.html
+++ b/IPython/frontend/html/notebook/templates/logout.html
@@ -7,3 +7,11 @@
     Proceed to the <a href="/login">login page</a>.
   {% end %}
 {% end %}
+
+{% block script %}
+<script type="text/javascript">
+  $(document).ready(function() {
+    IPython.login_widget = new IPython.LoginWidget('span#login_widget');
+  });
+</script>
+{% end %}

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -52,9 +52,9 @@
     <span id="login_widget">
       {% comment  This is a temporary workaround to hide the logout button %}
       {% comment  when appropriate until notebook.html is templated %}
-      {% if current_user and current_user != 'anonymous' %}
+      {% if logged_in %}
         <button id="logout">Logout</button>
-      {% elif read_only is None %}
+      {% elif not logged_in and login_available %}
         <button id="login">Login</button>
       {% end %}
     </span>

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -54,6 +54,8 @@
       {% comment  when appropriate until notebook.html is templated %}
       {% if current_user and current_user != 'anonymous' %}
         <button id="logout">Logout</button>
+      {% else %}
+        <button id="login">Login</button>
       {% end %}
     </span>
 

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -29,8 +29,10 @@
     <link rel="stylesheet" href="static/css/base.css" type="text/css" />
     <link rel="stylesheet" href="static/css/notebook.css" type="text/css" />
     <link rel="stylesheet" href="static/css/renderedhtml.css" type="text/css" />
-    
-    <meta name="read_only" content="{{read_only}}"/>
+
+    {% comment  In the notebook, the read-only flag is used to determine %}
+    {% comment  whether to hide the side panels and switch off input %}
+    <meta name="read_only" content="{{read_only and not logged_in}}"/>
 
 </head>
 

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -54,7 +54,7 @@
       {% comment  when appropriate until notebook.html is templated %}
       {% if current_user and current_user != 'anonymous' %}
         <button id="logout">Logout</button>
-      {% else %}
+      {% elif read_only is None %}
         <button id="login">Login</button>
       {% end %}
     </span>

--- a/IPython/frontend/html/notebook/templates/projectdashboard.html
+++ b/IPython/frontend/html/notebook/templates/projectdashboard.html
@@ -20,10 +20,15 @@ data-base-kernel-url={{base_kernel_url}}
 
 {% block content_panel %}
     <div id="content_toolbar">
-        <span id="drag_info" class="hidden">Drag files onto the list to import notebooks.</span>
-        <span id="notebooks_buttons">
-            <button id="new_notebook" class="hidden">New Notebook</button>
-        </span>
+        <span id="drag_info" class="hidden">Drag files onto the list to import
+        notebooks.</span>
+
+        {% if read_only == False %}
+          <span id="notebooks_buttons">
+              <button id="new_notebook" class="hidden">New Notebook</button>
+          </span>
+        {% end %}
+
     </div>
     <div id="notebook_list">
         <div id="project_name"><h2>{{project}}</h2></div>

--- a/IPython/frontend/html/notebook/templates/projectdashboard.html
+++ b/IPython/frontend/html/notebook/templates/projectdashboard.html
@@ -19,17 +19,19 @@ data-base-kernel-url={{base_kernel_url}}
 {% end %}
 
 {% block content_panel %}
+    {% if logged_in or not read_only %}
+
     <div id="content_toolbar">
-        <span id="drag_info" class="hidden">Drag files onto the list to import
+        <span id="drag_info">Drag files onto the list to import
         notebooks.</span>
 
-        {% if read_only == False %}
-          <span id="notebooks_buttons">
-              <button id="new_notebook" class="hidden">New Notebook</button>
-          </span>
-        {% end %}
-
+        <span id="notebooks_buttons">
+          <button id="new_notebook">New Notebook</button>
+        </span>
     </div>
+
+    {% end %}
+
     <div id="notebook_list">
         <div id="project_name"><h2>{{project}}</h2></div>
     </div>


### PR DESCRIPTION
- Display a login button when viewing the notebook in read-only mode.
- On the login page, focus on the password field by default.
- Correctly style login / logout buttons.
- In read-only mode, redirect to "/" after logout, not "/login".
