### PR TITLE
Show class init and call tooltips in notebook

### DIFF
--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -162,9 +162,16 @@ var IPython = (function (IPython) {
     }
 
     CodeCell.prototype.finish_tooltip = function (reply) {
-        defstring=reply.definition;
-        docstring=reply.docstring;
-        if(docstring == null){docstring="<empty docstring>"};
+        // Extract call tip data; the priority is call, init, main.
+        defstring = reply.call_def;
+        if (defstring == null) { defstring = reply.init_definition; }
+        if (defstring == null) { defstring = reply.definition; }
+
+        docstring = reply.call_docstring;
+        if (docstring == null) { docstring = reply.init_docstring; }
+        if (docstring == null) { docstring = reply.docstring; }
+        if (docstring == null) { docstring = "<empty docstring>"; }
+
         name=reply.name;
 
         var that = this;


### PR DESCRIPTION
Just like in Qt console, this patch shows the docstring and definition of the first match among the call, constructor, and main methods.
