### PR TITLE
qtconsole export xhtml/utf8

### DIFF
--- a/IPython/frontend/qt/console/rich_ipython_widget.py
+++ b/IPython/frontend/qt/console/rich_ipython_widget.py
@@ -198,7 +198,7 @@ class RichIPythonWidget(IPythonWidget):
 
         elif format == "svg":
             try:
-                svg = str(self._name_to_svg_map[match.group("name")])
+                svg = self._name_to_svg_map[match.group("name")]
             except KeyError:
                 return "<b>Couldn't find image %s</b>" % match.group("name")
 

--- a/IPython/frontend/qt/rich_text.py
+++ b/IPython/frontend/qt/rich_text.py
@@ -7,6 +7,7 @@
 # Standard library imports.
 import os
 import re
+import codecs
 
 # System library imports.
 from IPython.external.qt import QtGui
@@ -182,8 +183,9 @@ def export_xhtml(html, filename, image_tag=None):
                 html[offset+6:])
 
         html = fix_html(html)
-        f.write(IMG_RE.sub(lambda x: image_tag(x, path = None, format = "svg"),
-                           html))
+        sub=IMG_RE.sub(lambda x: image_tag(x, path = None, format = "svg"), html)
+        f.write( codecs.BOM_UTF8 )
+        f.write( sub.encode("utf-8") )
 
 
 def default_image_tag(match, path = None, format = "png"):


### PR DESCRIPTION
using utf-8 to save the qtconsole export as xhtml/svg, to avoid crash on some
    kinds of plots, mainly when converting svg to str, or when writing the file

```
closes #1087
```

@epatters, 
You seem to be the one who wrote that, could you take a look ? I'm not quite familiar with this part (nor with unicode) and I'm wondering if unicode could mess-up somewhere else...
