### PR TITLE
workaround spawnb missing from pexpect.__all__

### DIFF
--- a/IPython/external/pexpect/__init__.py
+++ b/IPython/external/pexpect/__init__.py
@@ -1,5 +1,9 @@
 try:
     import pexpect
     from pexpect import *
+    # pexpect-u-2.5 has a spawnb, but version 2.5 excludes it from __all__,
+    # so we must explicitly fetch it
+    if hasattr(pexpect, 'spawnb'):
+        spawnb = pexpect.spawnb
 except ImportError:
     from _pexpect import *


### PR DESCRIPTION
@takluyver's pexpect-u is unicode-ready, and we handle it, but
spawnb is not in `__all__` (at least in the 2.5 release), so our
check for it [here](https://github.com/ipython/ipython/blob/master/IPython/utils/_process_posix.py#L151)
fails, and we use the unicode output, calling `decode` on it directly,
which would raise UnicodeError on things like `ls` in a dir with unicode files.

This manually assigns `pexpect.spawnb`, not trusting that it will be included in
`from pexpect import *`.
