### PR TITLE
Fix display of errors in compiled code on Python 3

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -879,7 +879,7 @@ class VerboseTB(TBTools):
                 # enclosing scope.
                 for token in generate_tokens(linereader):
                     tokeneater(*token)
-            except IndexError:
+            except (IndexError, UnicodeDecodeError):
                 # signals exit of tokenizer
                 pass
             except tokenize.TokenError,msg:


### PR DESCRIPTION
@juliantaylor, I've checked this, and it appears to solve the issue in Python 3.

Closes gh-1100
