### PR TITLE
Fixing #1112 removing failing asserts for test_carriage_return and test_...

### DIFF
--- a/IPython/frontend/qt/console/tests/test_ansi_code_processor.py
+++ b/IPython/frontend/qt/console/tests/test_ansi_code_processor.py
@@ -110,7 +110,6 @@ class TestAnsiCodeProcessor(unittest.TestCase):
         self.assertEquals(len(self.processor.actions), 1)
         action = self.processor.actions[0]
         self.assertEquals(action.action, 'carriage-return')
-        self.assertEquals(action.count, 1)
 
     def test_beep(self):
         """ Are beep characters processed correctly?
@@ -120,7 +119,6 @@ class TestAnsiCodeProcessor(unittest.TestCase):
         self.assertEquals(len(self.processor.actions), 1)
         action = self.processor.actions[0]
         self.assertEquals(action.action, 'beep')
-        self.assertEquals(action.count, 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
...beep.

The failing asserts were checking the count property of the Action
tuple objects there is no count field in these Action tuples so
the count method of the regular tuple class is resolved.
