### PR TITLE
fix magics history in two-process ipython console

### DIFF
--- a/IPython/frontend/terminal/console/interactiveshell.py
+++ b/IPython/frontend/terminal/console/interactiveshell.py
@@ -333,7 +333,7 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
                     self.autoedit_syntax):
                     self.edit_syntax_error()
                 if not more:
-                    source_raw = self.input_splitter.source_reset()
+                    source_raw = self.input_splitter.source_raw_reset()[1]
                     hlen_b4_cell = self._replace_rlhist_multiline(source_raw, hlen_b4_cell)
                     self.run_cell(source_raw)
                 


### PR DESCRIPTION
Hey, I was going to comment about this issue on #864, but it's now merged! :)

Before this commit, magics were store as "translated" for `ipython console`

```
In [1]: %hist
get_ipython().magic(u'hist')

In [2]: a?
Object `a` not found.

In [3]: hist
get_ipython().magic(u'hist')
get_ipython().magic(u'pinfo a')
hist
```

After this commit:

```
In [1]: %hist
%hist

In [2]: a?
Object `a` not found.

In [3]: hist
%hist
a?
hist
```
