### PR TITLE
protect CRLF from carriage-return action

### DIFF
--- a/IPython/frontend/qt/console/ansi_code_processor.py
+++ b/IPython/frontend/qt/console/ansi_code_processor.py
@@ -38,7 +38,7 @@ CSI_SUBPATTERN = '\[(.*?)([%s])' % CSI_COMMANDS
 OSC_SUBPATTERN = '\](.*?)[\x07\x1b]'
 ANSI_PATTERN = ('\x01?\x1b(%s|%s)\x02?' % \
                 (CSI_SUBPATTERN, OSC_SUBPATTERN))
-ANSI_OR_SPECIAL_PATTERN = re.compile('(\b|\r)|(?:%s)' % ANSI_PATTERN)
+ANSI_OR_SPECIAL_PATTERN = re.compile('(\b|\r(?!\n))|(?:%s)' % ANSI_PATTERN)
 SPECIAL_PATTERN = re.compile('([\f])')
 
 #-----------------------------------------------------------------------------

--- a/IPython/frontend/qt/console/tests/test_ansi_code_processor.py
+++ b/IPython/frontend/qt/console/tests/test_ansi_code_processor.py
@@ -105,8 +105,17 @@ class TestAnsiCodeProcessor(unittest.TestCase):
     def test_carriage_return(self):
         """ Are carriage return characters processed correctly?
         """
-        string = 'foo\rbar' # form feed
+        string = 'foo\rbar' # carriage return
         self.assertEquals(list(self.processor.split_string(string)), ['foo', '', 'bar'])
+        self.assertEquals(len(self.processor.actions), 1)
+        action = self.processor.actions[0]
+        self.assertEquals(action.action, 'carriage-return')
+
+    def test_carriage_return_newline(self):
+        """transform CRLF to LF"""
+        string = 'foo\rbar\r\ncat\r\n' # carriage return and newline
+        # only one CR action should occur, and '\r\n' should transform to '\n'
+        self.assertEquals(list(self.processor.split_string(string)), ['foo', '', 'bar\r\ncat\r\n'])
         self.assertEquals(len(self.processor.actions), 1)
         action = self.processor.actions[0]
         self.assertEquals(action.action, 'carriage-return')


### PR DESCRIPTION
Carriage return action introduced in PR #1089 clears a line in the qtconsole, which means that CRLF line endings would replace whole lines with '\n', thus hiding the output of `ls` and ~all system calls.

This changes the behavior to only act on CR if it is not followed by LF.

Test included.

closes #1111
