### PR TITLE
Totally remove pager when read only (notebook)

### DIFF
--- a/IPython/frontend/html/notebook/static/js/notebookmain.js
+++ b/IPython/frontend/html/notebook/static/js/notebookmain.js
@@ -99,6 +99,8 @@ $(document).ready(function () {
         // hide various elements from read-only view
         IPython.save_widget.element.find('button#save_notebook').addClass('hidden');
         IPython.quick_help.element.addClass('hidden'); // shortcuts are disabled in read_only
+        $('div#pager').remove();
+        $('div#pager_splitter').remove();
         $('button#new_notebook').addClass('hidden');
         $('div#cell_section').addClass('hidden');
         $('div#config_section').addClass('hidden');


### PR DESCRIPTION
I don't see any use of having a pager in Read only mode, so I added it to the removed element.
Not 'hidden' because otherwise there is still 2 blank pixel at the bottom of the screen.
