### PR TITLE
optionally ignore  shlex's ValueError in arg_split

### DIFF
--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -77,13 +77,18 @@ def shlex_split(x):
             comps = shlex.split(x)
             if len(endofline) >= 1:
                 comps.append(''.join(endofline))
+            if not py3compat.PY3:
+                comps = [py3compat.cast_unicode(x) for x in comps]
             return comps
 
         except ValueError:
             endofline = [x[-1:]]+endofline
             x = x[:-1]
 
-    return [''.join(endofline)]
+    x = ''.join(endofline)
+    if not py3compat.PY3:
+        x = py3compat.cast_unicode(x)
+    return [x]
 
 def module_list(path):
     """

--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -236,7 +236,7 @@ def module_completer(self,event):
 def magic_run_completer(self, event):
     """Complete files that end in .py or .ipy for the %run command.
     """
-    comps = arg_split(event.line)
+    comps = arg_split(event.line, strict=False)
     relpath = (len(comps) > 1 and comps[-1] or '').strip("'\"")
 
     #print("\nev=", event)  # dbg

--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -20,7 +20,6 @@ import glob
 import inspect
 import os
 import re
-import shlex
 import sys
 
 # Third-party imports
@@ -31,6 +30,7 @@ from zipimport import zipimporter
 from IPython.core.completer import expand_user, compress_user
 from IPython.core.error import TryNext
 from IPython.utils import py3compat
+from IPython.utils._process_common import arg_split
 
 # FIXME: this should be pulled in with the right call via the component system
 from IPython.core.ipapi import get as get_ipython
@@ -55,40 +55,6 @@ magic_run_re = re.compile(r'.*(\.ipy|\.py[w]?)$')
 #-----------------------------------------------------------------------------
 # Local utilities
 #-----------------------------------------------------------------------------
-
-def shlex_split(x):
-    """Helper function to split lines into segments.
-    """
-    # shlex.split raises an exception if there is a syntax error in sh syntax
-    # for example if no closing " is found. This function keeps dropping the
-    # last character of the line until shlex.split does not raise
-    # an exception. It adds end of the line to the result of shlex.split
-    #
-    # Example:
-    # %run "c:/python -> ['%run','"c:/python']
-
-    # shlex.split has unicode bugs in Python 2, so encode first to str
-    if not py3compat.PY3:
-        x = py3compat.cast_bytes(x)
-
-    endofline = []
-    while x != '':
-        try:
-            comps = shlex.split(x)
-            if len(endofline) >= 1:
-                comps.append(''.join(endofline))
-            if not py3compat.PY3:
-                comps = [py3compat.cast_unicode(x) for x in comps]
-            return comps
-
-        except ValueError:
-            endofline = [x[-1:]]+endofline
-            x = x[:-1]
-
-    x = ''.join(endofline)
-    if not py3compat.PY3:
-        x = py3compat.cast_unicode(x)
-    return [x]
 
 def module_list(path):
     """
@@ -270,7 +236,7 @@ def module_completer(self,event):
 def magic_run_completer(self, event):
     """Complete files that end in .py or .ipy for the %run command.
     """
-    comps = shlex_split(event.line)
+    comps = arg_split(event.line)
     relpath = (len(comps) > 1 and comps[-1] or '').strip("'\"")
 
     #print("\nev=", event)  # dbg

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -266,6 +266,7 @@ python-profiler package from non-free.""")
         # Get options
         list_all = kw.get('list_all',0)
         posix = kw.get('posix', os.name == 'posix')
+        strict = kw.get('strict', True)
 
         # Check if we have more than one argument to warrant extra processing:
         odict = {}  # Dictionary with options
@@ -273,7 +274,7 @@ python-profiler package from non-free.""")
         if len(args) >= 1:
             # If the list of inputs only has 0 or 1 thing in it, there's no
             # need to look for options
-            argv = arg_split(arg_str,posix)
+            argv = arg_split(arg_str, posix, strict)
             # Do regular option processing
             try:
                 opts,args = getopt(argv,opt_str,*long_opts)
@@ -1865,7 +1866,7 @@ Currently the magic system has the following functions:\n"""
         scaling = [1, 1e3, 1e6, 1e9]
 
         opts, stmt = self.parse_options(parameter_s,'n:r:tcp:',
-                                        posix=False)
+                                        posix=False, strict=False)
         if stmt == "":
             return
         timefunc = timeit.default_timer

--- a/IPython/core/tests/test_completerlib.py
+++ b/IPython/core/tests/test_completerlib.py
@@ -59,3 +59,11 @@ class Test_magic_run_completer(unittest.TestCase):
         mockself = None
         match = magic_run_completer(mockself, event) 
         self.assertEqual(match, [u"aaå.py",])
+
+    def test_3(self):
+        """Test '%run "a<tab>' completion"""
+        event = MockEvent(u'%run "a')
+        mockself = None
+        match = magic_run_completer(mockself, event)
+        self.assertEqual(match, [u"a.py", u"aaå.py"])
+

--- a/IPython/core/tests/test_completerlib.py
+++ b/IPython/core/tests/test_completerlib.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""Tests for completerlib.
+
+"""
+from __future__ import absolute_import
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from os.path import join
+
+import nose.tools as nt
+from nose import SkipTest
+
+from IPython.core.completerlib import magic_run_completer
+from IPython.testing import decorators as dec
+from IPython.testing import tools as tt
+from IPython.utils import py3compat
+
+
+class MockEvent(object):
+    def __init__(self, line):
+        self.line = line
+
+#-----------------------------------------------------------------------------
+# Test functions begin
+#-----------------------------------------------------------------------------
+class Test_magic_run_completer(unittest.TestCase):
+    def setUp(self):
+        self.BASETESTDIR = tempfile.mkdtemp()
+        for fil in [u"aaå.py", u"a.py", u"b.py"]:
+            with open(join(self.BASETESTDIR, fil), "w") as sfile:
+                sfile.write("pass\n")
+        self.oldpath = os.getcwdu()
+        os.chdir(self.BASETESTDIR)
+
+    def tearDown(self):
+        os.chdir(self.oldpath)
+        shutil.rmtree(self.BASETESTDIR)
+
+    def test_1(self):
+        """Test magic_run_completer, should match two alterntives
+        """
+        event = MockEvent(u"%run a")
+        mockself = None
+        match = magic_run_completer(mockself, event) 
+        self.assertEqual(match, [u"a.py", u"aaå.py",])
+
+    def test_2(self):
+        """Test magic_run_completer, should match one alterntive
+        """
+        event = MockEvent(u"%run aa")
+        mockself = None
+        match = magic_run_completer(mockself, event) 
+        self.assertEqual(match, [u"aaå.py",])

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -344,3 +344,12 @@ def test_psearch():
     with tt.AssertPrints("dict.fromkeys"):
         _ip.run_cell("dict.fr*?")
 
+def test_timeit_shlex():
+    """test shlex issues with timeit (#1109)"""
+    _ip.ex("def f(*a,**kw): pass")
+    _ip.magic('timeit -n1 "this is a bug".count(" ")')
+    _ip.magic('timeit -r1 -n1 f(" ", 1)')
+    _ip.magic('timeit -r1 -n1 f(" ", 1, " ", 2, " ")')
+    _ip.magic('timeit -r1 -n1 ("a " + "b")')
+    _ip.magic('timeit -r1 -n1 f("a " + "b")')
+    _ip.magic('timeit -r1 -n1 f("a " + "b ")')


### PR DESCRIPTION
Sometimes we pass things that aren't really command-line args to arg_split, e.g:

```
%timeit python_code(" ")
```

These things probably shouldn't be parsed as command-line args, but they are.
So we should at least prevent them from raising, when shlex doesn't think they are valid shell args.

This commit protects this sort of thing from raising errors. Another
approach would be to use a different function when parsing things that
are clearly not command-line args (like Python code), but this works for now.

closes #1109
