### PR TITLE
allow customized template and static file paths for the notebook web app

### DIFF
--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -89,6 +89,10 @@ ipython notebook --port=5555 --ip=*    # Listen on port 5555, all interfaces
 
 class NotebookWebApplication(web.Application):
 
+    settings = Dict(config=True,
+            help="Supply overrides for the tornado.web.Application, that the "
+                 "IPython notebook uses.")
+
     def __init__(self, ipython_app, kernel_manager, notebook_manager, log):
         handlers = [
             (r"/", ProjectDashboardHandler),
@@ -111,7 +115,11 @@ class NotebookWebApplication(web.Application):
             cookie_secret=os.urandom(1024),
             login_url="/login",
         )
-        web.Application.__init__(self, handlers, **settings)
+
+        # allow custom overrides for the tornado web app.
+        settings.update(self.settings)
+
+        super(NotebookWebApplication, self).__init__(self, handlers, **settings)
 
         self.kernel_manager = kernel_manager
         self.log = log

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -272,7 +272,7 @@ class NotebookApp(BaseIPythonApplication):
     def _mathjax_url_default(self):
         if not self.enable_mathjax:
             return u''
-        static_path = os.path.join(os.path.dirname(__file__), "static")
+        static_path = self.webapp_settings.get("static_path", os.path.join(os.path.dirname(__file__), "static"))
         if os.path.exists(os.path.join(static_path, 'mathjax', "MathJax.js")):
             self.log.info("Using local MathJax")
             return u"static/mathjax/MathJax.js"


### PR DESCRIPTION
Hello,

I'd like to distribute a few notebooks with my library that form kind of an interactive tutorial. I want to use images and styles from my website and do a few other small things. Thus it's very helpful to be able to specify overrides to the paths the notebook web app uses. Since it's buried in the NotebookApp, I thought using a global overrides dictionary might be a more elegant solution than to add parameters everywhere.

Please let me know what you think.
