### PR TITLE
Namespaces for embedding

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -881,6 +881,8 @@ class InteractiveShell(SingletonConfigurable, Magic):
     #-------------------------------------------------------------------------
     # Things related to IPython's various namespaces
     #-------------------------------------------------------------------------
+    default_user_ns = True
+    default_user_module = True
 
     def init_create_namespaces(self, user_module=None, user_ns=None):
         # Create the namespace where the user will operate.  user_ns is
@@ -919,6 +921,10 @@ class InteractiveShell(SingletonConfigurable, Magic):
         # These routines return a properly built module and dict as needed by
         # the rest of the code, and can also be used by extension writers to
         # generate properly initialized namespaces.
+        if user_ns is not None:
+            self.default_user_ns = False
+        if user_module is not None:
+            self.default_user_module = False
         self.user_module, self.user_ns = self.prepare_user_module(user_module, user_ns)
 
         # A record of hidden variables we have added to the user namespace, so

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -881,8 +881,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
     #-------------------------------------------------------------------------
     # Things related to IPython's various namespaces
     #-------------------------------------------------------------------------
-    default_user_ns = True
-    default_user_module = True
+    default_user_namespaces = True
 
     def init_create_namespaces(self, user_module=None, user_ns=None):
         # Create the namespace where the user will operate.  user_ns is
@@ -921,10 +920,8 @@ class InteractiveShell(SingletonConfigurable, Magic):
         # These routines return a properly built module and dict as needed by
         # the rest of the code, and can also be used by extension writers to
         # generate properly initialized namespaces.
-        if user_ns is not None:
-            self.default_user_ns = False
-        if user_module is not None:
-            self.default_user_module = False
+        if (user_ns is not None) or (user_module is not None):
+            self.default_user_namespaces = False
         self.user_module, self.user_ns = self.prepare_user_module(user_module, user_ns)
 
         # A record of hidden variables we have added to the user namespace, so

--- a/IPython/frontend/terminal/embed.py
+++ b/IPython/frontend/terminal/embed.py
@@ -75,7 +75,11 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
     def __init__(self, config=None, ipython_dir=None, user_ns=None,
                  user_module=None, custom_exceptions=((),None),
                  usage=None, banner1=None, banner2=None,
-                 display_banner=None, exit_msg=u''):
+                 display_banner=None, exit_msg=u'', user_global_ns=None):
+    
+        if user_global_ns is not None:
+            warnings.warn("user_global_ns has been replaced by user_module. The\
+                           parameter will be ignored.", DeprecationWarning)
 
         super(InteractiveShellEmbed,self).__init__(
             config=config, ipython_dir=ipython_dir, user_ns=user_ns,

--- a/IPython/frontend/terminal/embed.py
+++ b/IPython/frontend/terminal/embed.py
@@ -104,21 +104,18 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
                  stack_depth=1, global_ns=None):
         """Activate the interactive interpreter.
 
-        __call__(self,header='',local_ns=None,global_ns,dummy=None) -> Start
+        __call__(self,header='',local_ns=None,module=None,dummy=None) -> Start
         the interpreter shell with the given local and global namespaces, and
         optionally print a header string at startup.
 
         The shell can be globally activated/deactivated using the
-        set/get_dummy_mode methods. This allows you to turn off a shell used
+        dummy_mode attribute. This allows you to turn off a shell used
         for debugging globally.
 
         However, *each* time you call the shell you can override the current
         state of dummy_mode with the optional keyword parameter 'dummy'. For
-        example, if you set dummy mode on with IPShell.set_dummy_mode(1), you
-        can still have a specific call work by making it as IPShell(dummy=0).
-
-        The optional keyword parameter dummy controls whether the call
-        actually does anything.
+        example, if you set dummy mode on with IPShell.dummy_mode = True, you
+        can still have a specific call work by making it as IPShell(dummy=False).
         """
 
         # If the user has turned it off, go away
@@ -160,13 +157,13 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
 
           - header: An optional header message can be specified.
 
-          - local_ns, global_ns: working namespaces. If given as None, the
-          IPython-initialized one is updated with __main__.__dict__, so that
-          program variables become visible but user-specific configuration
-          remains possible.
+          - local_ns, module: working local namespace (a dict) and module (a
+          module or similar object). If given as None, they are automatically
+          taken from the scope where the shell was called, so that
+          program variables become visible.
 
           - stack_depth: specifies how many levels in the stack to go to
-          looking for namespaces (when local_ns and global_ns are None).  This
+          looking for namespaces (when local_ns or module is None).  This
           allows an intermediate caller to make sure that this function gets
           the namespace from the intended level in the stack.  By default (0)
           it will get its locals and globals from the immediate caller.

--- a/IPython/frontend/terminal/embed.py
+++ b/IPython/frontend/terminal/embed.py
@@ -172,12 +172,12 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
         there is no fundamental reason why it can't work perfectly."""
 
         # Get locals and globals from caller
-        if local_ns is None or module is None:
+        if (local_ns is None or module is None) and self.default_user_namespaces:
             call_frame = sys._getframe(stack_depth).f_back
 
-            if local_ns is None and self.default_user_ns:
+            if local_ns is None:
                 local_ns = call_frame.f_locals
-            if module is None and self.default_user_module:
+            if module is None:
                 global_ns = call_frame.f_globals
                 module = sys.modules[global_ns['__name__']]
         

--- a/IPython/frontend/terminal/embed.py
+++ b/IPython/frontend/terminal/embed.py
@@ -175,9 +175,9 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
         if local_ns is None or module is None:
             call_frame = sys._getframe(stack_depth).f_back
 
-            if local_ns is None and not self.default_user_ns:
+            if local_ns is None and self.default_user_ns:
                 local_ns = call_frame.f_locals
-            if module is None and not self.default_user_module:
+            if module is None and self.default_user_module:
                 global_ns = call_frame.f_globals
                 module = sys.modules[global_ns['__name__']]
         

--- a/IPython/frontend/terminal/embed.py
+++ b/IPython/frontend/terminal/embed.py
@@ -30,6 +30,7 @@ try:
     from contextlib import nested
 except:
     from IPython.utils.nested_context import nested
+import warnings
 
 from IPython.core import ultratb
 from IPython.frontend.terminal.interactiveshell import TerminalInteractiveShell
@@ -96,7 +97,7 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
         pass
 
     def __call__(self, header='', local_ns=None, module=None, dummy=None,
-                 stack_depth=1):
+                 stack_depth=1, global_ns=None):
         """Activate the interactive interpreter.
 
         __call__(self,header='',local_ns=None,global_ns,dummy=None) -> Start
@@ -140,7 +141,7 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
 
         # Call the embedding code with a stack depth of 1 so it can skip over
         # our call and get the original caller's namespaces.
-        self.mainloop(local_ns, module, stack_depth=stack_depth)
+        self.mainloop(local_ns, module, stack_depth=stack_depth, global_ns=global_ns)
 
         self.banner2 = self.old_banner2
 
@@ -148,7 +149,7 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
             print self.exit_msg
 
     def mainloop(self, local_ns=None, module=None, stack_depth=0,
-                 display_banner=None):
+                 display_banner=None, global_ns=None):
         """Embeds IPython into a running python program.
 
         Input:
@@ -170,6 +171,14 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
         IPython itself (via %run), but some funny things will happen (a few
         globals get overwritten). In the future this will be cleaned up, as
         there is no fundamental reason why it can't work perfectly."""
+        
+        if (global_ns is not None) and (module is None):
+            class DummyMod(object):
+                """A dummy module object for embedded IPython."""
+                pass
+            warnings.warn("global_ns is deprecated, use module instead.", DeprecationWarning)
+            module = DummyMod()
+            module.__dict__ = global_ns
 
         # Get locals and globals from caller
         if (local_ns is None or module is None) and self.default_user_namespaces:

--- a/docs/examples/test_embed/embed1.py
+++ b/docs/examples/test_embed/embed1.py
@@ -1,0 +1,10 @@
+"""This tests standard embedding, automatically detecting the module and
+local namespaces."""
+
+f = set([1,2,3,4,5])
+
+def bar(foo):
+    import IPython
+    IPython.embed(banner1='check f in globals, foo in locals')
+
+bar(f)

--- a/docs/examples/test_embed/embed2.py
+++ b/docs/examples/test_embed/embed2.py
@@ -1,0 +1,5 @@
+"""This tests passing a dict for the user_ns at shell instantiation."""
+from IPython import embed
+
+user_ns = dict(cookie='monster')
+embed(user_ns=user_ns, banner1="check 'cookie' present, locals and globals equivalent")

--- a/docs/examples/test_embed/embed3.py
+++ b/docs/examples/test_embed/embed3.py
@@ -1,0 +1,7 @@
+"""This tests passing local_ns and global_ns (for backwards compatibility only)
+at activation of an embedded shell."""
+from IPython.frontend.terminal.embed import InteractiveShellEmbed
+
+user_ns = dict(cookie='monster')
+ISE = InteractiveShellEmbed(banner1='check cookie in locals, and globals empty')
+ISE(local_ns=user_ns, global_ns={})

--- a/docs/source/whatsnew/development.txt
+++ b/docs/source/whatsnew/development.txt
@@ -145,10 +145,12 @@ Backwards incompatible changes
   The full path will still work, and is necessary for using custom launchers not in
   IPython's launcher module.
 
-* For embedding a shell, note that the parameter ``user_global_ns`` has been
-  replaced by ``user_module``, and expects a module-like object, rather than
-  a namespace dict. The ``user_ns`` parameter works the same way as before, and
+* For embedding a shell, note that the parameters ``user_global_ns`` and ``global_ns``
+  have been deprectated in favour of ``user_module`` and ``module`` respsectively.
+  The new parameters expect a module-like object, rather than a namespace dict.
+  The old parameters remain for backwards compatibility, although ``user_global_ns``
+  is now ignored. The ``user_ns`` parameter works the same way as before, and
   calling :func:`~IPython.frontend.terminal.embed.embed` with no arguments still
-  works the same way.
+  works as before.
 
 .. * use bullet list


### PR DESCRIPTION
This should fix the embedding problem in #1136.

One additional complexity: if you specify only one of `user_ns` or `user_module` when instantiating the embedded shell, they are hooked up so that you have a single namespace (i.e. `ip.user_ns is ip.user_global_ns`). So, the logic at activation time to auto-detect the module and local namespace will only kick in if neither were specified at instantiation.

You should still be able to pass `local_ns` or `module` at activation to override them separately.
