### PR TITLE
Add post_install script to create start menu entries in Python 3

### DIFF
--- a/setup3.py
+++ b/setup3.py
@@ -1,4 +1,5 @@
 import os.path
+import sys
 from setuptools import setup
 from setuptools.command.build_py import build_py
 
@@ -13,6 +14,20 @@ setup_args['entry_points'] = find_scripts(True, suffix='3')
 setup_args['packages'] = find_packages()
 setup_args['package_data'] = find_package_data()
 setup_args['cmdclass'] = {'build_py': record_commit_info('IPython', build_cmd=build_py)}
+
+# Script to be run by the windows binary installer after the default setup
+# routine, to add shortcuts and similar windows-only things.  Windows
+# post-install scripts MUST reside in the scripts/ dir, otherwise distutils
+# doesn't find them.
+if 'bdist_wininst' in sys.argv:
+    if len(sys.argv) > 2 and \
+           ('sdist' in sys.argv or 'bdist_rpm' in sys.argv):
+        print >> sys.stderr, "ERROR: bdist_wininst must be run alone. Exiting."
+        sys.exit(1)
+    setup_args['scripts'] = [os.path.join('scripts','ipython_win_post_install.py')]
+    setup_args['options'] = {"bdist_wininst":
+                             {"install_script":
+                              "ipython_win_post_install.py"}}
 
 def main():
     setup(use_2to3 = True, **setup_args)


### PR DESCRIPTION
This should fix #1119, but I can't test it, because I don't have a Windows machine handy, and Python in Wine seems to be having problems.

Can someone with a Windows machine test it? You'll need Python 3.2 installed. With this branch checked out, run `C:\python32\python.exe setup.py bdist_wininst`. This will produce a .exe installer - run that, and see if it completes without errors and creates start menu entries for IPython on Python 3.
