### PR TITLE
Put qtconsole forground when launching

### DIFF
--- a/IPython/frontend/qt/console/qtconsoleapp.py
+++ b/IPython/frontend/qt/console/qtconsoleapp.py
@@ -334,6 +334,7 @@ class IPythonQtConsoleApp(BaseIPythonApplication, IPythonConsoleApp):
 
         # draw the window
         self.window.show()
+        self.window.raise_()
 
         # Start the application main loop.
         self.app.exec_()


### PR DESCRIPTION
That's a one line change, but it is nice to have the qtconsole on top and in focus when you invoke it.
