### PR TITLE
Add coding header when notebook exported to .py file.

### DIFF
--- a/IPython/nbformat/v2/nbpy.py
+++ b/IPython/nbformat/v2/nbpy.py
@@ -16,12 +16,15 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
+import re
 from .rwbase import NotebookReader, NotebookWriter
 from .nbbase import new_code_cell, new_text_cell, new_worksheet, new_notebook
 
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
+
+_encoding_declaration_re = re.compile(r"^#\s*coding[:=]\s*([-\w.]+)")
 
 class PyReaderError(Exception):
     pass
@@ -38,7 +41,7 @@ class PyReader(NotebookReader):
         cell_lines = []
         state = u'codecell'
         for line in lines:
-            if line.startswith(u'# <nbformat>'):
+            if line.startswith(u'# <nbformat>') or _encoding_declaration_re.match(line):
                 pass
             elif line.startswith(u'# <codecell>'):
                 cell = self.new_cell(state, cell_lines)

--- a/IPython/nbformat/v2/nbpy.py
+++ b/IPython/nbformat/v2/nbpy.py
@@ -111,7 +111,7 @@ class PyWriter(NotebookWriter):
 
     def writes(self, nb, **kwargs):
         lines = []
-        lines.extend([u'# <nbformat>2</nbformat>',''])
+        lines.extend([u'# coding: utf-8', u'# <nbformat>2</nbformat>',''])
         for ws in nb.worksheets:
             for cell in ws.cells:
                 if cell.cell_type == u'code':

--- a/IPython/nbformat/v2/nbpy.py
+++ b/IPython/nbformat/v2/nbpy.py
@@ -24,7 +24,7 @@ from .nbbase import new_code_cell, new_text_cell, new_worksheet, new_notebook
 # Code
 #-----------------------------------------------------------------------------
 
-_encoding_declaration_re = re.compile(r"^#\s*coding[:=]\s*([-\w.]+)")
+_encoding_declaration_re = re.compile(r"^#.*coding[:=]\s*([-\w.]+)")
 
 class PyReaderError(Exception):
     pass
@@ -113,7 +113,7 @@ class PyReader(NotebookReader):
 class PyWriter(NotebookWriter):
 
     def writes(self, nb, **kwargs):
-        lines = [u'# coding: utf-8']
+        lines = [u'# -*- coding: utf-8 -*-']
         lines.extend([u'# <nbformat>2</nbformat>',''])
         for ws in nb.worksheets:
             for cell in ws.cells:

--- a/IPython/nbformat/v2/nbpy.py
+++ b/IPython/nbformat/v2/nbpy.py
@@ -113,8 +113,8 @@ class PyReader(NotebookReader):
 class PyWriter(NotebookWriter):
 
     def writes(self, nb, **kwargs):
-        lines = []
-        lines.extend([u'# coding: utf-8', u'# <nbformat>2</nbformat>',''])
+        lines = [u'# coding: utf-8']
+        lines.extend([u'# <nbformat>2</nbformat>',''])
         for ws in nb.worksheets:
             for cell in ws.cells:
                 if cell.cell_type == u'code':

--- a/IPython/nbformat/v2/tests/nbexamples.py
+++ b/IPython/nbformat/v2/tests/nbexamples.py
@@ -81,7 +81,7 @@ nb0 = new_notebook(
     metadata=md
 )
 
-nb0_py = """# coding: utf-8
+nb0_py = """# -*- coding: utf-8 -*-
 # <nbformat>2</nbformat>
 
 # <htmlcell>

--- a/IPython/nbformat/v2/tests/nbexamples.py
+++ b/IPython/nbformat/v2/tests/nbexamples.py
@@ -81,7 +81,8 @@ nb0 = new_notebook(
     metadata=md
 )
 
-nb0_py = """# <nbformat>2</nbformat>
+nb0_py = """# coding: utf-8
+# <nbformat>2</nbformat>
 
 # <htmlcell>
 


### PR DESCRIPTION
Closes gh-1156

We probably want to strip the encoding declaration out when we load a .py file, as well. I'll add that to this PR.
