### PR TITLE
don't ignore ctrl-C during `%gui qt`

### DIFF
--- a/IPython/lib/inputhookqt4.py
+++ b/IPython/lib/inputhookqt4.py
@@ -94,11 +94,7 @@ def create_inputhook_qt4(mgr, app=None):
         except KeyboardInterrupt:
             ignore_CTRL_C()
             got_kbdint[0] = True
-            print("\nKeyboardInterrupt - qt4 event loop interrupted!"
-                  "\n  * hit CTRL+C again to clear the prompt"
-                  "\n  * use '%gui none' to disable the event loop"
-                  " permanently"
-                  "\n    and '%gui qt4' to re-enable it later")
+            print("\nKeyboardInterrupt - Ctrl-C again for new prompt")
             mgr.clear_inputhook()
         except: # NO exceptions are allowed to escape from a ctypes callback
             ignore_CTRL_C()

--- a/IPython/lib/inputhookqt4.py
+++ b/IPython/lib/inputhookqt4.py
@@ -91,7 +91,6 @@ def create_inputhook_qt4(mgr, app=None):
                     timer.start(50)
                     app.exec_()
                     timer.stop()
-            ignore_CTRL_C()
         except KeyboardInterrupt:
             ignore_CTRL_C()
             got_kbdint[0] = True
@@ -102,10 +101,13 @@ def create_inputhook_qt4(mgr, app=None):
                   "\n    and '%gui qt4' to re-enable it later")
             mgr.clear_inputhook()
         except: # NO exceptions are allowed to escape from a ctypes callback
+            ignore_CTRL_C()
             mgr.clear_inputhook()
             from traceback import print_exc
             print_exc()
             print("Got exception from inputhook_qt4, unregistering.")
+        finally:
+            allow_CTRL_C()
         return 0
 
     def preprompthook_qt4(ishell):


### PR DESCRIPTION
See #1157

PR #815 ignores ctrl-C during normal code execution, this restores the sigint handler outside the inputhook.
