### PR TITLE
Modifications to profile list

### DIFF
--- a/IPython/core/profileapp.py
+++ b/IPython/core/profileapp.py
@@ -137,31 +137,38 @@ class ProfileList(Application):
                 profiles.append(profile)
         return profiles
     
+    def _print_profiles(self, profiles):
+        """print list of profiles, indented."""
+        for profile in profiles:
+            print '    %s' % profile
+    
     def list_profile_dirs(self):
         profiles = self._list_bundled_profiles()
         if profiles:
             print
             print "Available profiles in IPython:"
-            for profile in profiles:
-                print '    ipython --profile=%s' % profile
+            self._print_profiles(profiles)
             print
             print "    The first request for a bundled profile will copy it"
             print "    into your IPython directory (%s)," % self.ipython_dir
-            print "    where you can customize it to your needs."
+            print "    where you can customize it."
         
         profiles = self._list_profiles_in(self.ipython_dir)
         if profiles:
             print
             print "Available profiles in %s:" % self.ipython_dir
-            for profile in profiles:
-                print '    ipython --profile=%s' % profile
+            self._print_profiles(profiles)
         
         profiles = self._list_profiles_in(os.getcwdu())
         if profiles:
             print
             print "Available profiles in current directory (%s):" % os.getcwdu()
-            for profile in profiles:
-                print '    ipython --profile=%s' % profile
+            self._print_profiles(profiles)
+        
+        print
+        print "To use any of the above profiles, start IPython with:"
+        print "    ipython --profile=<name>"
+        print
 
     def start(self):
         self.list_profile_dirs()


### PR DESCRIPTION
Includes bundled profiles in `ipython profile list` output,
and segments output into: bundled, ipdir, cwd.

Per @fperez [suggestion](https://github.com/ipython/ipython/pull/1174#issuecomment-3197021)

Sample output:

```
minrk@Mercury[14:10]~/dev/ip/mine (profilelist) $ ipython profile list

Available profiles in IPython:
    ipython --profile=cluster
    ipython --profile=math
    ipython --profile=pysh
    ipython --profile=python3
    ipython --profile=sympy

    The first request for a bundled profile will copy it
    into your IPython directory (/Users/minrk/.ipython),
    where you can customize it to your needs.

Available profiles in /Users/minrk/.ipython:
    ipython --profile=0.11
    ipython --profile=cluster
    ipython --profile=default
    ipython --profile=foo
    ipython --profile=food
    ipython --profile=fresh
    ipython --profile=føø
    ipython --profile=go
    ipython --profile=iptest
    ipython --profile=math
    ipython --profile=mpi
    ipython --profile=neuro
    ipython --profile=password
    ipython --profile=pylab
    ipython --profile=pysh
    ipython --profile=python3
    ipython --profile=sge
    ipython --profile=sh
    ipython --profile=ssh
    ipython --profile=sympy
    ipython --profile=temp

Available profiles in current directory (/Users/minrk/dev/ip/mine):
    ipython --profile=carrot
```
