### PR TITLE
Qtconsole, multiwindow

### DIFF
--- a/IPython/core/usage.py
+++ b/IPython/core/usage.py
@@ -433,12 +433,12 @@ tabs and windows attached to different kernels.
 - ``C-n`` : create a new window with a fresh kernel
 - ``C-S-t`` : create a new tab attached to the same kernel, but not owning it.
 - ``C-S-n`` : create a new window attached to the same kernel, but not owning it.
-- ``C-d`` : detach a tab into a new window
-- ``C-r`` : reattach the last tab you (try to) detatach to the curent window
+- ``M-d`` : separate a tab from it's current window* into a new window
+- ``M-r`` : merge the last tab you (try to) detatach to the curent window
 
-Note that if a window contain only one frontend, detaching it make no sens,
-unless you try to reattach to another window, in which case the lonely frontend
-will be merged with the new window
+Note that if a window contain only one frontend, separating it make no sens,
+but will remember the frontend as beeing the one to be pull the next time you
+try a merge
 
 
 The IPython pager

--- a/IPython/core/usage.py
+++ b/IPython/core/usage.py
@@ -423,6 +423,24 @@ The keybindings themselves are:
 - ``C--``: decrease font size.
 - ``C-M-Space``: toggle full screen. (Command-Control-Space on Mac OS X)
 
+Working with tabs and windows
+=============================
+
+The IPython graphical console also allow convenient shortcut to create/move
+tabs and windows attached to different kernels.
+
+- ``C-t`` : create a new tab with a fresh kernel
+- ``C-n`` : create a new window with a fresh kernel
+- ``C-S-t`` : create a new tab attached to the same kernel, but not owning it.
+- ``C-S-n`` : create a new window attached to the same kernel, but not owning it.
+- ``C-d`` : detach a tab into a new window
+- ``C-r`` : reattach the last tab you (try to) detatach to the curent window
+
+Note that if a window contain only one frontend, detaching it make no sens,
+unless you try to reattach to another window, in which case the lonely frontend
+will be merged with the new window
+
+
 The IPython pager
 =================
 

--- a/IPython/frontend/qt/console/frontend_widget.py
+++ b/IPython/frontend/qt/console/frontend_widget.py
@@ -406,10 +406,15 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
                 self._process_execute_error(msg)
             elif status == 'aborted':
                 self._process_execute_abort(msg)
-
-            self._show_interpreter_prompt_for_reply(msg)
-            self.executed.emit(msg)
-            self._request_info['execute'].pop(msg_id)
+            try:
+                self._show_interpreter_prompt_for_reply(msg)
+                self.executed.emit(msg)
+                self._request_info['execute'].pop(msg_id)
+            except RuntimeError as e:
+                # there are chance of having a race condition between the exit payload
+                # closing the gui before this block is executed
+                self.log.debug("""Catched RuntimeError after message reply. Certainly due to frontend shutdown after receiving 'exit'""")
+                pass
         elif info and info.kind == 'silent_exec_callback' and not self._hidden:
             self._handle_exec_callback(msg)
             self._request_info['execute'].pop(msg_id)

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -13,7 +13,12 @@ Authors:
 * Thomas Kluyver
 
 """
-
+#-----------------------------------------------------------------------------
+# Copyright (c) 2011, IPython Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
@@ -23,24 +28,6 @@ import sys
 import re
 import webbrowser
 from threading import Thread
-
-
-import warnings
-
-def deprecated(func):
-    """This is a decorator which can be used to mark functions
-    as deprecated. It will result in a warning being emitted
-    when the function is used."""
-    def new_func(*args, **kwargs):
-        warnings.warn("Call to deprecated function %s." % func.__name__,
-                      category=DeprecationWarning)
-        return func(*args, **kwargs)
-    new_func.__name__ = func.__name__
-    new_func.__doc__ = func.__doc__
-    new_func.__dict__.update(func.__dict__)
-    return new_func
-
-
 
 # System library imports
 from IPython.external.qt import QtGui,QtCore
@@ -146,9 +133,11 @@ class MainWindow(QtGui.QMainWindow):
 
     @property
     def active_frontend(self):
+        """@property, return the current widet"""
         return self.tab_widget.currentWidget()
 
     def setTitle(self,title):
+        """ set prefix to use in window title"""
         self._title = title
         self.update_win_title()
 
@@ -316,6 +305,15 @@ class MainWindow(QtGui.QMainWindow):
         self.tab_widget.setCurrentIndex((self.tab_widget.currentIndex()-1)%mod)
 
     def update_win_title(self) :
+        """update some window gui element
+        
+        -Title to contain current connexion file name
+        -Title to have 'Python' or 'IPython' prefix
+        -Window icon
+        -The all magic menu to be in sync with current frontend
+
+        Because of the last, it does trigger a kernel request in a callback
+        """
         frontend = self.active_frontend
         if frontend:
             cfile = frontend.kernel_manager.connection_file
@@ -375,8 +373,10 @@ class MainWindow(QtGui.QMainWindow):
                 for win in self._windows_manager.windows ]
             widget_list = [num for sublist in widget_listnested for num in sublist]
 
-        # widget that are candidate to be the owner of the kernel does have all the same port of the curent widget
-        # And should have a _may_close attribute
+        # widget that are candidate to be the owner of the kernel does have the
+        # same connexion file of the curent widget And should have a _may_close
+        # attribute
+
         filtered_widget_list = [ widget for widget in widget_list if
                                 widget.kernel_manager.connection_file == km.connection_file and
                                 hasattr(widget,'_may_close') ]
@@ -459,6 +459,11 @@ class MainWindow(QtGui.QMainWindow):
     #-----------------------------------------------------------------------------
 
     def init_menu_bar(self):
+        """Initialize the menuBar of current window
+
+        magic menu need to be finished of initializing/updated separately and
+        later, see `init_magic_menu` docstring
+        """
         #create menu in the order they should appear in the menu bar
         self.init_file_menu()
         self.init_edit_menu()
@@ -752,11 +757,22 @@ class MainWindow(QtGui.QMainWindow):
         Request the kernel with the list of availlable magic and populate the
         menu with the list received back
 
+        see `populate_all_magic_menu` for lower level control
         """
         # first define a callback which will get the list of all magic and put it in the menu.
         self.active_frontend._silent_exec_callback('get_ipython().lsmagic()', self.populate_all_magic_menu)
 
     def init_magic_menu(self):
+        """Initialize the magic menu in the menu bar
+
+        The all magic menu containig the list of magic availlable in curent
+        frontend have to be populated later by trigering it's `pop` action when
+        a frontend widget is availlable, and trigerring menu update is also
+        user responsability
+        
+        see `update_all_magic_menu`
+        """
+
         self.magic_menu = self.menuBar().addMenu("&Magic")
         self.all_magic_menu = self.magic_menu.addMenu("&All Magics")
 

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -77,7 +77,7 @@ class MainWindow(QtGui.QMainWindow):
         super(MainWindow, self).__init__()
         self._kernel_counter = 0
         self._app = app
-        self._title='IPython'
+        self._title = 'IPython'
         self.confirm_exit = confirm_exit
         self._windows_manager = windows_manager
 
@@ -126,18 +126,18 @@ class MainWindow(QtGui.QMainWindow):
         use it's own
         """
         if self._windows_manager:
-                return self._windows_manager.next_kernel_id
+            return self._windows_manager.next_kernel_id
         else :
-                c = self._kernel_counter
-                self._kernel_counter += 1
-                return c
+            c = self._kernel_counter
+            self._kernel_counter += 1
+            return c
 
     @property
     def active_frontend(self):
         """@property, return the current widet"""
         return self.tab_widget.currentWidget()
 
-    def setTitle(self,title):
+    def setTitle(self, title):
         """ set prefix to use in window title"""
         self._title = title
         self.update_win_title()
@@ -148,7 +148,7 @@ class MainWindow(QtGui.QMainWindow):
         self.add_tab_with_frontend(widget)
 
     def create_tab_with_current_kernel(self):
-        """create a new frontend attached to the same kernel as the current tab"""
+        """create a new frontend attached to the same kernel """
         current_widget = self.tab_widget.currentWidget()
         current_widget_index = self.tab_widget.indexOf(current_widget)
         current_widget_name = self.tab_widget.tabText(current_widget_index)
@@ -158,17 +158,17 @@ class MainWindow(QtGui.QMainWindow):
             name = current_widget_name
         else:
             name = '(%s) slave' % current_widget_name
-        self.add_tab_with_frontend(widget,name=name)
+        self.add_tab_with_frontend(widget, name=name)
 
-    def close_tab(self,current_tab):
+    def close_tab(self, current_tab):
         """ Called when you need to try to close a tab.
 
         It takes the number of the tab to be closed as argument, or a referece
         to the wiget inside this tab
         """
 
-        # let's be sure "tab" and "closing widget are respectivey the index of the tab to close
-        # and a reference to the trontend to close
+        # let's be sure "tab" and "closing widget are respectivey the index of
+        # the tab to close and a reference to the frontend to close
         if type(current_tab) is not int :
             current_tab = self.tab_widget.indexOf(current_tab)
         closing_widget=self.tab_widget.widget(current_tab)
@@ -185,7 +185,7 @@ class MainWindow(QtGui.QMainWindow):
         slave_tabs = self.find_slave_widgets(closing_widget)
 
         keepkernel = None #Use the prompt by default
-        if hasattr(closing_widget,'_keep_kernel_on_exit'): #set by exit magic
+        if hasattr(closing_widget, '_keep_kernel_on_exit'): #set by exit magic
             keepkernel = closing_widget._keep_kernel_on_exit
             # If signal sent by exit magic (_keep_kernel_on_exit, exist and not None)
             # we set local slave tabs._hidden to True to avoid prompting for kernel
@@ -318,7 +318,7 @@ class MainWindow(QtGui.QMainWindow):
         frontend = self.active_frontend
         if frontend:
             cfile = frontend.kernel_manager.connection_file
-            shownName = QtCore.QFileInfo(cfile).fileName();
+            shownName = QtCore.QFileInfo(cfile).fileName()
             pth = QtCore.QFileInfo(cfile).filePath()
             #semm not to work on mac for thr proxy icon
             self.setWindowFilePath(pth)
@@ -478,21 +478,21 @@ class MainWindow(QtGui.QMainWindow):
         self.file_menu = self.menuBar().addMenu("&File")
 
         if self._windows_manager :
-                # if got a windows_manager which handle multi windows, propose
-                # thoses actions
-                self.new_kernel_win_act = QtGui.QAction(
-                    "New &Window with New kernel",
-                    self,
-                    shortcut="Ctrl+N",
-                    triggered=self._windows_manager.create_window_with_new_frontend)
-                self.add_menu_action(self.file_menu, self.new_kernel_win_act)
+            # if got a windows_manager which handle multi windows, propose
+            # thoses actions
+            self.new_kernel_win_act = QtGui.QAction(
+                "New &Window with New kernel",
+                self,
+                shortcut="Ctrl+N",
+                triggered=self._windows_manager.create_window_with_new_frontend)
+            self.add_menu_action(self.file_menu, self.new_kernel_win_act)
 
-                self.slave_kernel_win_act = QtGui.QAction(
-                     "New Window with S&ame kernel",
-                    self,
-                    shortcut="Ctrl+Shift+N",
-                    triggered=self._windows_manager.create_window_with_current_kernel)
-                self.add_menu_action(self.file_menu, self.slave_kernel_win_act)
+            self.slave_kernel_win_act = QtGui.QAction(
+                    "New Window with S&ame kernel",
+                self,
+                shortcut="Ctrl+Shift+N",
+                triggered=self._windows_manager.create_window_with_current_kernel)
+            self.add_menu_action(self.file_menu, self.slave_kernel_win_act)
 
         self.new_kernel_tab_act = QtGui.QAction("New Tab with &New kernel",
             self,
@@ -855,19 +855,19 @@ class MainWindow(QtGui.QMainWindow):
         self.add_menu_action(self.window_menu, self.next_tab_act)
 
         if self._windows_manager:
-                self.window_menu.addSeparator()
+            self.window_menu.addSeparator()
 
-                self.reattach_act = QtGui.QAction("Me&rge Frontend",
-                    self,
-                    shortcut="Alt+R",
-                    triggered=self._windows_manager.reattach_frontend)
-                self.add_menu_action(self.window_menu, self.reattach_act)
+            self.reattach_act = QtGui.QAction("Me&rge Frontend",
+                self,
+                shortcut="Alt+R",
+                triggered=self._windows_manager.reattach_frontend)
+            self.add_menu_action(self.window_menu, self.reattach_act)
 
-                self.detach_act = QtGui.QAction("Separate Fronten&d",
-                    self,
-                    shortcut="Alt+D",
-                    triggered=self._windows_manager.detach_frontend)
-                self.add_menu_action(self.window_menu, self.detach_act)
+            self.detach_act = QtGui.QAction("Separate Fronten&d",
+                self,
+                shortcut="Alt+D",
+                triggered=self._windows_manager.detach_frontend)
+            self.add_menu_action(self.window_menu, self.detach_act)
 
 
     def init_help_menu(self):
@@ -1032,7 +1032,7 @@ class MainWindow(QtGui.QMainWindow):
         if self.tab_widget.count() == 0:
             # no tabs, just close
             if self._windows_manager:
-               self._windows_manager.closing_windows(self)
+                self._windows_manager.closing_windows(self)
             event.accept()
             return
         # Do Not loop on the widget count as it change while closing

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -740,9 +740,10 @@ class MainWindow(QtGui.QMainWindow):
                 triggered=self._make_dynamic_magic(pmagic)
                 )
             alm_magic_menu.addAction(xaction)
+        alm_magic_menu.addAction(self.pop)
 
     def update_all_magic_menu(self):
-        """ Update the list on magic in the "All Magics..." Menu
+        """ Update the list of magics in the "All Magics..." Menu
 
         Request the kernel with the list of availlable magic and populate the
         menu with the list received back
@@ -755,11 +756,7 @@ class MainWindow(QtGui.QMainWindow):
         self.magic_menu = self.menuBar().addMenu("&Magic")
         self.all_magic_menu = self.magic_menu.addMenu("&All Magics")
 
-        # This action should usually not appear as it will be cleared when menu
-        # is updated at first kernel response. Though, it is necessary when
-        # connecting through X-forwarding, as in this case, the menu is not
-        # auto updated, SO DO NOT DELETE.
-        self.pop = QtGui.QAction("&Update All Magic Menu ",
+        self.pop = QtGui.QAction("&Update this menu ",
             self, triggered=self.update_all_magic_menu)
         self.add_menu_action(self.all_magic_menu, self.pop)
         # we need to populate the 'Magic Menu' once the kernel has answer at

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -859,13 +859,13 @@ class MainWindow(QtGui.QMainWindow):
 
                 self.reattach_act = QtGui.QAction("Me&rge Frontend",
                     self,
-                    shortcut="Ctrl+R",
+                    shortcut="Alt+R",
                     triggered=self._windows_manager.reattach_frontend)
                 self.add_menu_action(self.window_menu, self.reattach_act)
 
                 self.detach_act = QtGui.QAction("Separate Fronten&d",
                     self,
-                    shortcut="Ctrl+D",
+                    shortcut="Alt+D",
                     triggered=self._windows_manager.detach_frontend)
                 self.add_menu_action(self.window_menu, self.detach_act)
 

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -304,10 +304,12 @@ class MainWindow(QtGui.QMainWindow):
         frontend.exit_requested.connect(self.close_tab)
 
     def next_tab(self):
-        self.tab_widget.setCurrentIndex((self.tab_widget.currentIndex()+1))
+        mod = self.tab_widget.count()
+        self.tab_widget.setCurrentIndex((self.tab_widget.currentIndex()+1)%mod)
 
     def prev_tab(self):
-        self.tab_widget.setCurrentIndex((self.tab_widget.currentIndex()-1))
+        mod = self.tab_widget.count()
+        self.tab_widget.setCurrentIndex((self.tab_widget.currentIndex()-1)%mod)
 
     def update_win_title(self) :
         frontend = self.active_frontend

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -121,8 +121,12 @@ class MainWindow(QtGui.QMainWindow):
         #TODO : unactivate prev/next tab
         if self.tab_widget.count() <= 1:
             self.tab_widget.tabBar().setVisible(False)
+            self.prev_tab_act.setEnabled(False)
+            self.next_tab_act.setEnabled(False)
         else:
             self.tab_widget.tabBar().setVisible(True)
+            self.prev_tab_act.setEnabled(True)
+            self.next_tab_act.setEnabled(True)
         if self.tab_widget.count()==0 :
             self.close()
 

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -27,6 +27,7 @@ Authors:
 import sys
 import re
 import webbrowser
+import weakref
 from threading import Thread
 
 # System library imports
@@ -714,8 +715,9 @@ class MainWindow(QtGui.QMainWindow):
         """
         # need to level nested function  to be sure to past magic
         # on active frontend **at run time**.
+        wr = weakref.ref(self)
         def inner_dynamic_magic():
-            self.active_frontend.execute(magic)
+            wr().active_frontend.execute(magic)
         inner_dynamic_magic.__name__ = "dynamics_magic_s"
         return inner_dynamic_magic
 
@@ -745,7 +747,7 @@ class MainWindow(QtGui.QMainWindow):
             else:
                 pmagic = '%s%s'%('%',magic)
             xaction = QtGui.QAction(pmagic,
-                self,
+                alm_magic_menu,
                 triggered=self._make_dynamic_magic(pmagic)
                 )
             alm_magic_menu.addAction(xaction)
@@ -777,8 +779,8 @@ class MainWindow(QtGui.QMainWindow):
         self.all_magic_menu = self.magic_menu.addMenu("&All Magics")
 
         self.pop = QtGui.QAction("&Update this menu ",
-            self, triggered=self.update_all_magic_menu)
-        self.add_menu_action(self.all_magic_menu, self.pop)
+            self._app, triggered=self.update_all_magic_menu)
+        self.all_magic_menu.addAction(self.pop)
 
         self.reset_action = QtGui.QAction("&Reset",
             self,

--- a/IPython/frontend/qt/console/qtconsoleapp.py
+++ b/IPython/frontend/qt/console/qtconsoleapp.py
@@ -38,7 +38,7 @@ from IPython.frontend.qt.console.frontend_widget import FrontendWidget
 from IPython.frontend.qt.console.ipython_widget import IPythonWidget
 from IPython.frontend.qt.console.rich_ipython_widget import RichIPythonWidget
 from IPython.frontend.qt.console import styles
-from IPython.frontend.qt.console.mainwindow import MainWindow
+from IPython.frontend.qt.console.windowManager import WindowManager
 from IPython.frontend.qt.kernelmanager import QtKernelManager
 from IPython.utils.path import filefind
 from IPython.utils.py3compat import str_to_bytes
@@ -235,16 +235,14 @@ class IPythonQtConsoleApp(BaseIPythonApplication, IPythonConsoleApp):
         self.widget._confirm_exit = self.confirm_exit
 
         self.widget.kernel_manager = self.kernel_manager
-        self.window = MainWindow(self.app,
+        self.window_manager = WindowManager(self.app,
                                 confirm_exit=self.confirm_exit,
                                 new_frontend_factory=self.new_frontend_master,
                                 slave_frontend_factory=self.new_frontend_slave,
+                                init_widget=self.widget,
                                 )
-        self.window.log = self.log
-        self.window.add_tab_with_frontend(self.widget)
-        self.window.init_menu_bar()
-
-        self.window.setWindowTitle('Python' if self.pure else 'IPython')
+        self.window_manager.log = self.log
+        #self.window_manager.setWindowTitle('Python' if self.pure else 'IPython')
 
     def init_colors(self):
         """Configure the coloring of the widget"""
@@ -331,11 +329,6 @@ class IPythonQtConsoleApp(BaseIPythonApplication, IPythonConsoleApp):
         self.init_signal()
 
     def start(self):
-
-        # draw the window
-        self.window.show()
-        self.window.raise_()
-
         # Start the application main loop.
         self.app.exec_()
 

--- a/IPython/frontend/qt/console/qtconsoleapp.py
+++ b/IPython/frontend/qt/console/qtconsoleapp.py
@@ -242,7 +242,7 @@ class IPythonQtConsoleApp(BaseIPythonApplication, IPythonConsoleApp):
                                 init_widget=self.widget,
                                 )
         self.window_manager.log = self.log
-        #self.window_manager.setWindowTitle('Python' if self.pure else 'IPython')
+        self.window_manager.setTitle('Python' if self.pure else 'IPython')
 
     def init_colors(self):
         """Configure the coloring of the widget"""

--- a/IPython/frontend/qt/console/qtconsoleapp.py
+++ b/IPython/frontend/qt/console/qtconsoleapp.py
@@ -38,7 +38,7 @@ from IPython.frontend.qt.console.frontend_widget import FrontendWidget
 from IPython.frontend.qt.console.ipython_widget import IPythonWidget
 from IPython.frontend.qt.console.rich_ipython_widget import RichIPythonWidget
 from IPython.frontend.qt.console import styles
-from IPython.frontend.qt.console.windowManager import WindowManager
+from IPython.frontend.qt.console.window_manager import WindowManager
 from IPython.frontend.qt.kernelmanager import QtKernelManager
 from IPython.utils.path import filefind
 from IPython.utils.py3compat import str_to_bytes

--- a/IPython/frontend/qt/console/qtconsoleapp.py
+++ b/IPython/frontend/qt/console/qtconsoleapp.py
@@ -14,7 +14,12 @@ Authors:
 * Paul Ivanov
 
 """
-
+#-----------------------------------------------------------------------------
+# Copyright (c) 2011, IPython Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------

--- a/IPython/frontend/qt/console/windowManager.py
+++ b/IPython/frontend/qt/console/windowManager.py
@@ -1,0 +1,203 @@
+# -*- coding: utf-8 -*-
+"""The Qt MainWindow Manager for the QtConsole
+
+Proxy to be able to have only one QApplication dealing with several windows and
+be able to pass tabs from one window to another, create windows, keep a
+monotonic kernel number etc
+
+"""
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# stdlib imports
+import sys
+
+# System library imports
+from IPython.external.qt import QtGui
+from IPython.frontend.qt.console.mainwindow import MainWindow
+
+#-----------------------------------------------------------------------------
+# Classes
+#-----------------------------------------------------------------------------
+
+class WindowManager:
+
+    #---------------------------------------------------------------------------
+    # 'object' interface
+    #---------------------------------------------------------------------------
+
+    def __init__(self, app,
+                    confirm_exit=True,
+                    new_frontend_factory=None,
+                    slave_frontend_factory=None,
+                    init_widget = None,
+                ):
+        """ Create a MainWindow Manager for managing IPython FrontendWidgets
+        
+        Parameters
+        ----------
+        
+        app : reference to QApplication parent
+        confirm_exit : bool, optional
+            Whether we should prompt on close of tabs
+        new_frontend_factory : callable
+            A callable that returns a new IPythonWidget instance, attached to
+            its own running kernel.
+        slave_frontend_factory : callable
+            A callable that takes an existing IPythonWidget, and  returns a new 
+            IPythonWidget instance, attached to the same kernel.
+        init_widget :  IPython.frontend.qt.console.MainWindow
+            Widget used to init the first window
+
+        """
+        #TODO : list availlable kernel from secure/kernel
+        #TODO : Support init_widget=None ?
+        
+        self._kernel_counter = 0
+        self._app = app
+        self.confirm_exit = confirm_exit
+        self.new_frontend_factory = new_frontend_factory
+        self.slave_frontend_factory = slave_frontend_factory
+       
+        #reference to last detached frontend to be able to reattach it
+        self.last_d_frontend = None
+
+        self.windows = [] 
+        win = self._spawn_new_window()
+        if not init_widget:
+            raise NotImplementedError,"For now you have to build the first widget yourself"
+        win.add_tab_with_frontend(init_widget);
+        win.show()
+        win.raise_()
+
+    @property
+    def next_kernel_id(self):
+        """constantly increasing counter for kernel IDs"""
+        c = self._kernel_counter
+        self._kernel_counter += 1
+        return c
+
+    @property
+    def active_frontend(self):
+        """frontmost active frontend across all window
+        
+        Return the active frontened of the active window if any
+        """
+        #TODO return none if no window ?
+        return self.active_window.active_frontend
+    
+    #TODO : support none if no windows ?
+    @property
+    def active_window(self):
+        """return the current active window
+        
+        Return the current active window if any, otherwise return the first
+        window created
+        """
+        windows = [w for w in self.windows if w.isActiveWindow()]
+        if len(windows) is not 1 :
+            print "probleme de longueur (",len(windows),")";
+            return self.windows[0]
+        else :
+            return windows[0]
+    
+
+    def _spawn_new_window(self):
+        """create a new window and return it
+
+        """
+        win = MainWindow(self._app,
+                confirm_exit=self.confirm_exit,
+                new_frontend_factory=self.new_frontend_factory,
+                slave_frontend_factory=self.slave_frontend_factory,
+                parent=self
+                )
+        win.init_menu_bar()
+        #TODO register closing with removing from self.windows
+        self.windows.append(win)
+        return win
+
+    def _owning_window(self,frontend):
+        """return the window that own the given frontend"""
+        for w in self.windows :
+            if w.tab_widget.indexOf(frontend) is not -1:
+                return w
+        return None
+
+
+    def _move_frontend(self,frontend=None,toWindow=None):
+        """move taget frontend to given window """
+        if not frontend or not toWindow :
+            raise NotImplementedError
+        detach_win = self._owning_window(frontend)
+        if detach_win == toWindow or not detach_win :
+            return
+        current_tab = detach_win.tab_widget.indexOf(frontend)
+        tab_name = detach_win.tab_widget.tabText(current_tab)
+
+        detach_win.tab_widget.removeTab(current_tab)
+        detach_win.update_tab_bar_visibility()
+
+        toWindow.add_tab_with_frontend(frontend,name=tab_name)
+
+    
+    def detach_frontend(self):
+        """ detach the current frontend in a new window 
+        
+        Try to detach the current active frontend. 
+        Abort if only one frontend in current window
+
+        last frontend to tried to be detached will be the one reattachable
+        """
+        self.last_d_frontend = self.active_frontend
+        if (self.active_window.tab_widget.count() <= 1):
+            #don't try to detach if only one
+            return
+        frontend = self.active_frontend
+
+        win = self._spawn_new_window()
+        self._move_frontend(frontend,win)
+        win.show()
+
+    def reattach_frontend(self):
+        if not self.last_d_frontend:
+            return
+        self._move_frontend(self.last_d_frontend,self.active_window)
+
+
+    def create_window_with_new_frontend(self):
+        """create a new frontend and attach it to a new tab of new window
+        
+        convenient method, that just call
+        `create_tab_with_new_frontend(newWindow=True)`
+        """
+        widget = self.new_frontend_factory()
+        win = self._spawn_new_window()
+        win.add_tab_with_frontend(widget)
+        win.show()
+    
+    def create_window_with_current_kernel(self):
+        """create a slave frontend and attach it to a new tab of new window
+        
+        convenient method, that just calls
+        `create_tab_with_current_kernel` with  `newWindow=True`
+        """
+        current_widget = self.active_window.tab_widget.currentWidget()
+        current_widget_index = self.active_window.tab_widget.indexOf(current_widget)
+        current_widget_name = self.active_window.tab_widget.tabText(current_widget_index)
+        widget = self.slave_frontend_factory(current_widget)
+        if 'slave' in current_widget_name:
+            # don't keep stacking slaves
+            name = current_widget_name
+        else:
+            name = '(%s) slave' % current_widget_name
+
+        win = self._spawn_new_window()
+        win.add_tab_with_frontend(widget,name=name)
+        win.show()
+    
+    def remove_tab_of_widget(self,frontend):
+        """Ask every winows to try to remove a tab with `frontend`"""
+        for w in self.windows:
+            w.remove_tab_of_widget(frontend)

--- a/IPython/frontend/qt/console/window_manager.py
+++ b/IPython/frontend/qt/console/window_manager.py
@@ -56,6 +56,7 @@ class WindowManager:
 
         self._kernel_counter = 0
         self._app = app
+        self._title = 'IPython'
         self.confirm_exit = confirm_exit
         self.new_frontend_factory = new_frontend_factory
         self.slave_frontend_factory = slave_frontend_factory
@@ -102,6 +103,13 @@ class WindowManager:
         else :
             return windows[0]
 
+    def setTitle(self,title):
+        self._title = title
+        for w in self.windows:
+            w.setTitle(self._title)
+
+    def closing_windows(self,win):
+	self.windows.remove(win)
 
     def _spawn_new_window(self):
         """create a new window and return it"""
@@ -111,6 +119,7 @@ class WindowManager:
                 slave_frontend_factory=self.slave_frontend_factory,
                 windows_manager=self
                 )
+        win.setTitle(self._title)
         win.init_menu_bar()
         #TODO register closing with removing from self.windows
         self.windows.append(win)

--- a/IPython/frontend/qt/console/window_manager.py
+++ b/IPython/frontend/qt/console/window_manager.py
@@ -7,6 +7,12 @@ monotonic kernel number etc
 
 """
 #-----------------------------------------------------------------------------
+# Copyright (c) 2011, IPython Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
 
@@ -45,7 +51,7 @@ class WindowManager:
             A callable that returns a new IPythonWidget instance, attached to
             its own running kernel.
         slave_frontend_factory : callable
-            A callable that takes an existing IPythonWidget, and  returns a new 
+            A callable that takes an existing IPythonWidget, and  returns a new
             IPythonWidget instance, attached to the same kernel.
         init_widget :  IPython.frontend.qt.console.MainWindow
             Widget used to init the first window
@@ -85,10 +91,10 @@ class WindowManager:
         
         Return the active frontened of the active window if any
         """
-        #TODO return none if no window ?
+        #TODO return none if no window ? is it even possible to have no active windows ?
         return self.active_window.active_frontend
 
-    #TODO : support none if no windows ?
+    #TODO return none if no window ? is it even possible to have no active windows ?
     @property
     def active_window(self):
         """return the current active window
@@ -104,12 +110,14 @@ class WindowManager:
             return windows[0]
 
     def setTitle(self,title):
+        """Set title prefix to use in every windows"""
         self._title = title
         for w in self.windows:
             w.setTitle(self._title)
 
     def closing_windows(self,win):
-	self.windows.remove(win)
+        """unregister windows because it's about to close"""
+        self.windows.remove(win)
 
     def _spawn_new_window(self):
         """create a new window and return it"""
@@ -121,7 +129,6 @@ class WindowManager:
                 )
         win.setTitle(self._title)
         win.init_menu_bar()
-        #TODO register closing with removing from self.windows
         self.windows.append(win)
         return win
 


### PR DESCRIPTION
[edit] Issues with linux so changed most of the implementation rebased and push, please see first commit message for updated info [/edit]
Now that 0.12 is out, let's add new functionality.

Draft of improving qtconsole.

A little in the idea of multitab, but with multiple windows, `Ctrl+(shift)+N` open a new window with a new kernel/slave frontend in it.

This is "working", still some regression, lot's of code to clean/to regroup, but I won't touch it a lot during the next week or so.

My main concern is about the QMenuBar shared between all the windows (futur plan that need it to be shared, or I will emulate a sharing), and wether the shortcut are handeld correctly on windows and linux, or if it totally crash because of QMainWindow taking property of QMenuBar.

Need to be careful with embedding also.

Why one qtconsole instance and not launch several console ? To allow passing tabs between windows without "loosing widget content" (coming soon hopefully).

--
Matthias
