### PR TITLE
misc notebook: connection file cleanup, first heartbeat, startup flush

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -184,6 +184,10 @@ class InteractiveShellApp(Configurable):
         self._run_exec_files()
         self._run_cmd_line_code()
         
+        # flush output, so itwon't be attached to the first cell
+        sys.stdout.flush()
+        sys.stderr.flush()
+        
         # Hide variables defined here from %who etc.
         self.shell.user_ns_hidden.update(self.shell.user_ns)
 

--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -487,6 +487,7 @@ class IOPubHandler(AuthenticatedZMQStreamHandler):
 
     def kernel_died(self):
         self.application.kernel_manager.delete_mapping_for_kernel(self.kernel_id)
+        self.application.log.error("Kernel %s failed to respond to heartbeat", self.kernel_id)
         self.write_message(
             {'header': {'msg_type': 'status'},
              'parent_header': {},

--- a/IPython/frontend/html/notebook/kernelmanager.py
+++ b/IPython/frontend/html/notebook/kernelmanager.py
@@ -195,7 +195,10 @@ class MappingKernelManager(MultiKernelManager):
 
     kernel_argv = List(Unicode)
     kernel_manager = Instance(KernelManager)
+    
     time_to_dead = Float(3.0, config=True, help="""Kernel heartbeat interval in seconds.""")
+    first_beat = Float(5.0, config=True, help="Delay (in seconds) before sending first heartbeat.")
+    
     max_msg_size = Integer(65536, config=True, help="""
         The max raw message size accepted from the browser
         over a WebSocket connection.

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -367,8 +367,9 @@ class NotebookApp(BaseIPythonApplication):
         """
         self.log.info('Shutting down kernels')
         km = self.kernel_manager
-        while km.kernel_ids:
-            km.kill_kernel(km.kernel_ids[0])
+        # copy list, since kill_kernel deletes keys
+        for kid in list(km.kernel_ids):
+            km.kill_kernel(kid)
 
     def start(self):
         ip = self.ip if self.ip else '[all ip addresses on your system]'


### PR DESCRIPTION
Kernels would not linger, but the KernelManagers are not garbage-collected on shutdown.  This means that connection files for kernels still running at notebook shutdown would not be removed.

Now, kernels are explicitly killed at server shutdown, allowing the KernelManagers to cleanup files.

Small changes along the way:
- disables the unnecessary (and actively detrimental) SIGINT handler inherited from the original copy/paste from the qt app.
- put webapp initialization in `init_webapp` out of `initialize`, to preserve convention of there being no unique code in `initialize()`.
- don't warn about http on all interfaces if running in 100% read-only mode, because no login or execution is possible.

(Yay, my first PR for 0.13!)
