### PR TITLE
Right justify of 'in' prompt in variable prompt size configurations

### DIFF
--- a/IPython/core/prompts.py
+++ b/IPython/core/prompts.py
@@ -423,7 +423,7 @@ class PromptManager(Configurable):
         self.txtwidth = _lenlastline(res) - invis_chars
         just = self.justify if (just is None) else just
         # If the prompt spans more than one line, don't try to justify it:
-        if just and ('\n' not in res) and ('\r' not in res):
+        if just and name != 'in' and ('\n' not in res) and ('\r' not in res):
             res = res.rjust(self.width + invis_chars)
         self.width = _lenlastline(res) - invis_chars
         return res


### PR DESCRIPTION
This little diff is to avoid rjustify of the 'in' prompt, because in configurations with variable prompt size (e.g. my pysh prompt showing \w), going to a smaller prompt cause only-reversed-by-restart blank spaces addition in beggining of 'in' prompt. Right justify is ok to 'in2' and 'out' prompts, but very ugly and weird in 'in' prompt.
