### PR TITLE
updated %quickref to show short-hand for %sc and %sx

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2990,7 +2990,7 @@ Defaulting color scheme to 'NoColor'"""
 
     @skip_doctest
     def magic_sc(self, parameter_s=''):
-        """Shell capture - execute a shell command and capture its output.
+        """Shell capture - execute shell command and capture output (use ! as short-hand).
 
         DEPRECATED. Suboptimal, retained for backwards compatibility.
 
@@ -3106,7 +3106,7 @@ Defaulting color scheme to 'NoColor'"""
             return out
 
     def magic_sx(self, parameter_s=''):
-        """Shell execute - run a shell command and capture its output.
+        """Shell execute - run shell command and capture output (use !! as short-hand).
 
         %sx command
 


### PR DESCRIPTION
I updated the %quickref to show the ! and !! short-hand for %sc and %sx to make it more obvious, otherwise people may not realize there is a short-hand unless they look deeper into the documentation.

Also, I edited the original one-line description to be shorter (but hopefully still grammatically correct) so that it will fit properly within 80-column output.
