### PR TITLE
Make all the static files path absolute.

### DIFF
--- a/IPython/frontend/html/notebook/templates/layout.html
+++ b/IPython/frontend/html/notebook/templates/layout.html
@@ -6,10 +6,10 @@
 
     <title>{% block title %}IPython Notebook{% end %}</title>
 
-    <link rel="stylesheet" href="static/jquery/css/themes/aristo/jquery-wijmo.css" type="text/css" />
-    <link rel="stylesheet" href="static/css/boilerplate.css" type="text/css" />
-    <link rel="stylesheet" href="static/css/layout.css" type="text/css" />
-    <link rel="stylesheet" href="static/css/base.css" type="text/css"/>
+    <link rel="stylesheet" href="/static/jquery/css/themes/aristo/jquery-wijmo.css" type="text/css" />
+    <link rel="stylesheet" href="/static/css/boilerplate.css" type="text/css" />
+    <link rel="stylesheet" href="/static/css/layout.css" type="text/css" />
+    <link rel="stylesheet" href="/static/css/base.css" type="text/css"/>
     {% block stylesheet %}
     {% end %}
 
@@ -72,11 +72,11 @@
 
 </div>
 
-<script src="static/jquery/js/jquery-1.6.2.min.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/jquery/js/jquery-ui-1.8.14.custom.min.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/js/namespace.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/js/loginmain.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/js/loginwidget.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/jquery/js/jquery-1.6.2.min.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/jquery/js/jquery-ui-1.8.14.custom.min.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/namespace.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/loginmain.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/loginwidget.js" type="text/javascript" charset="utf-8"></script>
 {% block script %}
 {% end %}
 

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -15,20 +15,20 @@
     window.mathjax_url = "{{mathjax_url}}";
     </script>
 
-    <link rel="stylesheet" href="static/jquery/css/themes/aristo/jquery-wijmo.css" type="text/css" />
-    <link rel="stylesheet" href="static/codemirror/lib/codemirror.css">
-    <link rel="stylesheet" href="static/codemirror/mode/markdown/markdown.css">
-    <link rel="stylesheet" href="static/codemirror/mode/rst/rst.css">
-    <link rel="stylesheet" href="static/codemirror/theme/ipython.css">
-    <link rel="stylesheet" href="static/codemirror/theme/default.css">
+    <link rel="stylesheet" href="/static/jquery/css/themes/aristo/jquery-wijmo.css" type="text/css" />
+    <link rel="stylesheet" href="/static/codemirror/lib/codemirror.css">
+    <link rel="stylesheet" href="/static/codemirror/mode/markdown/markdown.css">
+    <link rel="stylesheet" href="/static/codemirror/mode/rst/rst.css">
+    <link rel="stylesheet" href="/static/codemirror/theme/ipython.css">
+    <link rel="stylesheet" href="/static/codemirror/theme/default.css">
 
-    <link rel="stylesheet" href="static/prettify/prettify.css"/>
+    <link rel="stylesheet" href="/static/prettify/prettify.css"/>
 
-    <link rel="stylesheet" href="static/css/boilerplate.css" type="text/css" />
-    <link rel="stylesheet" href="static/css/layout.css" type="text/css" />
-    <link rel="stylesheet" href="static/css/base.css" type="text/css" />
-    <link rel="stylesheet" href="static/css/notebook.css" type="text/css" />
-    <link rel="stylesheet" href="static/css/renderedhtml.css" type="text/css" />
+    <link rel="stylesheet" href="/static/css/boilerplate.css" type="text/css" />
+    <link rel="stylesheet" href="/static/css/layout.css" type="text/css" />
+    <link rel="stylesheet" href="/static/css/base.css" type="text/css" />
+    <link rel="stylesheet" href="/static/css/notebook.css" type="text/css" />
+    <link rel="stylesheet" href="/static/css/renderedhtml.css" type="text/css" />
 
     {% comment  In the notebook, the read-only flag is used to determine %}
     {% comment  whether to hide the side panels and switch off input %}
@@ -42,7 +42,7 @@
 >
 
 <div id="header">
-    <span id="ipython_notebook"><h1><a href='..' alt='dashboard'><img src='static/ipynblogo.png' alt='IPython Notebook'/></a></h1></span>
+    <span id="ipython_notebook"><h1><a href='..' alt='dashboard'><img src='/static/ipynblogo.png' alt='IPython Notebook'/></a></h1></span>
     <span id="save_widget">
         <input type="text" id="notebook_name" size="20"></textarea>
         <button id="save_notebook"><u>S</u>ave</button>
@@ -258,40 +258,40 @@
 
 </div>
 
-<script src="static/jquery/js/jquery-1.6.2.min.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/jquery/js/jquery-ui-1.8.14.custom.min.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/jquery/js/jquery.autogrow.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/jquery/js/jquery-1.6.2.min.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/jquery/js/jquery-ui-1.8.14.custom.min.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/jquery/js/jquery.autogrow.js" type="text/javascript" charset="utf-8"></script>
 
-<script src="static/codemirror/lib/codemirror.js" charset="utf-8"></script>
-<script src="static/codemirror/mode/python/python.js" charset="utf-8"></script>
-<script src="static/codemirror/mode/htmlmixed/htmlmixed.js" charset="utf-8"></script>
-<script src="static/codemirror/mode/xml/xml.js" charset="utf-8"></script>
-<script src="static/codemirror/mode/javascript/javascript.js" charset="utf-8"></script>
-<script src="static/codemirror/mode/css/css.js" charset="utf-8"></script>
-<script src="static/codemirror/mode/rst/rst.js" charset="utf-8"></script>
-<script src="static/codemirror/mode/markdown/markdown.js" charset="utf-8"></script>
+<script src="/static/codemirror/lib/codemirror.js" charset="utf-8"></script>
+<script src="/static/codemirror/mode/python/python.js" charset="utf-8"></script>
+<script src="/static/codemirror/mode/htmlmixed/htmlmixed.js" charset="utf-8"></script>
+<script src="/static/codemirror/mode/xml/xml.js" charset="utf-8"></script>
+<script src="/static/codemirror/mode/javascript/javascript.js" charset="utf-8"></script>
+<script src="/static/codemirror/mode/css/css.js" charset="utf-8"></script>
+<script src="/static/codemirror/mode/rst/rst.js" charset="utf-8"></script>
+<script src="/static/codemirror/mode/markdown/markdown.js" charset="utf-8"></script>
 
-<script src="static/pagedown/Markdown.Converter.js" charset="utf-8"></script>
+<script src="/static/pagedown/Markdown.Converter.js" charset="utf-8"></script>
 
-<script src="static/prettify/prettify.js" charset="utf-8"></script>
+<script src="/static/prettify/prettify.js" charset="utf-8"></script>
 
-<script src="static/js/namespace.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/js/utils.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/js/cell.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/js/codecell.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/js/textcell.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/js/kernel.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/js/kernelstatus.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/js/layout.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/js/savewidget.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/js/quickhelp.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/js/loginwidget.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/js/pager.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/js/panelsection.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/js/printwidget.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/js/leftpanel.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/js/notebook.js" type="text/javascript" charset="utf-8"></script>
-<script src="static/js/notebookmain.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/namespace.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/utils.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/cell.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/codecell.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/textcell.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/kernel.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/kernelstatus.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/layout.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/savewidget.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/quickhelp.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/loginwidget.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/pager.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/panelsection.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/printwidget.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/leftpanel.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/notebook.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/notebookmain.js" type="text/javascript" charset="utf-8"></script>
 
 </body>
 


### PR DESCRIPTION
This is necessary because, if we don't do it all the paths will be
relative to the current URL and whenever we want to render a notebook
view from the paths other than the root URL of /, the static files path
get appended to that path from where we are asking for static files and
since static files are not mapped to those URLs we get HTTP 404 on all
those static files.

For example: If we render a notebook view from say /kernels/kernel-4444.json,
the static files will be looked at /kernel/static/... without this patch.
But after applying this, irrespective of which URL we are at, the static
files will be looked up at /static/...
