### PR TITLE
Open a new notebook while connecting to an existing kernel (opened by qtconsole or terminal or standalone)

### DIFF
--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -299,7 +299,23 @@ class MainKernelHandler(AuthenticatedHandler):
 
 class KernelHandler(AuthenticatedHandler):
 
-    SUPPORTED_METHODS = ('DELETE')
+    @web.authenticated
+    def get(self, kernel_id):
+        nbm = self.application.notebook_manager
+        project = nbm.notebook_dir
+        notebook_id = self.get_argument('notebook', nbm.new_notebook())
+
+        km = self.application.kernel_manager
+        kernel_id = km.start_kernel(notebook_id=notebook_id,
+                                    connection_file=kernel_id)
+        self.render(
+            'notebook.html', project=project,
+            notebook_id=notebook_id,
+            base_project_url=u'/', base_kernel_url=u'/',
+            kill_kernel=False,
+            read_only=False,
+            mathjax_url=self.application.ipython_app.mathjax_url,
+        )
 
     @web.authenticated
     def delete(self, kernel_id):

--- a/IPython/frontend/html/notebook/kernelmanager.py
+++ b/IPython/frontend/html/notebook/kernelmanager.py
@@ -273,7 +273,7 @@ class MappingKernelManager(MultiKernelManager):
         if notebook_id is not None:
             del self._notebook_mapping[notebook_id]
 
-    def start_kernel(self, notebook_id=None):
+    def start_kernel(self, notebook_id=None, connection_file=None):
         """Start a kernel for a notebok an return its kernel_id.
 
         Parameters
@@ -287,6 +287,7 @@ class MappingKernelManager(MultiKernelManager):
         if kernel_id is None:
             kwargs = dict()
             kwargs['extra_arguments'] = self.kernel_argv
+            kwargs['connection_file'] = connection_file
             kernel_id = super(MappingKernelManager, self).start_kernel(**kwargs)
             self.set_kernel_for_notebook(notebook_id, kernel_id)
             self.log.info("Kernel started: %s" % kernel_id)

--- a/IPython/frontend/html/notebook/kernelmanager.py
+++ b/IPython/frontend/html/notebook/kernelmanager.py
@@ -16,6 +16,7 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
+import json
 import os
 import signal
 import sys
@@ -29,6 +30,8 @@ from tornado import web
 from IPython.config.configurable import LoggingConfigurable
 from IPython.zmq.ipkernel import launch_kernel
 from IPython.zmq.kernelmanager import KernelManager
+from IPython.utils.path import filefind
+from IPython.utils.py3compat import str_to_bytes
 from IPython.utils.traitlets import Instance, Dict, List, Unicode, Float, Integer
 
 #-----------------------------------------------------------------------------
@@ -65,14 +68,54 @@ class MultiKernelManager(LoggingConfigurable):
         else:
             return False
 
+    def load_connection_file(self, connection_file):
+        """load ip/port/hmac config from JSON connection file"""
+        # this is identical to KernelApp.load_connection_file
+        # perhaps it can be centralized somewhere?
+        try:
+            fname = filefind(connection_file, [self.connection_dir])
+        except IOError:
+            self.log.debug("Connection File not found: %s", connection_file)
+            return
+        self.log.debug(u"Loading connection file %s", fname)
+        with open(fname) as f:
+            s = f.read()
+        cfg = json.loads(s)
+        if 'ip' in cfg:
+            # not overridden by config or cl_args
+            self.ip = cfg['ip']
+        for channel in ('hb', 'shell', 'iopub', 'stdin'):
+            name = channel + '_port'
+            if getattr(self, name, 0) == 0 and name in cfg:
+                # not overridden by config or cl_args
+                setattr(self, name, cfg[name])
+        if 'key' in cfg:
+            self.config.Session.key = str_to_bytes(cfg['key'])
+
     def start_kernel(self, **kwargs):
         """Start a new kernel."""
-        kernel_id = unicode(uuid.uuid4())
-        # use base KernelManager for each Kernel
-        km = KernelManager(connection_file=os.path.join(
-                    self.connection_dir, "kernel-%s.json" % kernel_id),
-                    config=self.config,
-        )
+        if 'connection_file' in kwargs:
+            connection_file = kwargs.pop('connection_file')
+            self.load_connection_file(connection_file)
+
+            kernel_id = self.config.Session.key
+            # use base KernelManager for each Kernel
+            km = KernelManager(ip=self.ip,
+                        shell_port=self.shell_port,
+                        iopub_port=self.iopub_port,
+                        stdin_port=self.stdin_port,
+                        hb_port=self.hb_port,
+                        connection_file=os.path.join(
+                        self.connection_dir, connection_file),
+                        config=self.config,
+            )
+        else:
+            kernel_id = unicode(uuid.uuid4())
+            # use base KernelManager for each Kernel
+            km = KernelManager(connection_file=os.path.join(
+                        self.connection_dir, "kernel-%s.json" % kernel_id),
+                        config=self.config,
+            )
         km.start_kernel(**kwargs)
         self._kernels[kernel_id] = km
         return kernel_id

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -69,7 +69,7 @@ from IPython.utils.traitlets import Dict, Unicode, Integer, List, Enum, Bool
 # Module globals
 #-----------------------------------------------------------------------------
 
-_kernel_id_regex = r"(?P<kernel_id>\w+-\w+-\w+-\w+-\w+)"
+_kernel_id_regex = r"(?P<kernel_id>\w+-\w+-\w+-\w+-\w+|\w+-\d+.json)"
 _kernel_action_regex = r"(?P<action>restart|interrupt)"
 _notebook_id_regex = r"(?P<notebook_id>\w+-\w+-\w+-\w+-\w+)"
 

--- a/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
+++ b/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
@@ -21,7 +21,25 @@ $(document).ready(function () {
     $('div#content_toolbar').addClass('ui-widget ui-helper-clearfix');    
 
     $('#new_notebook').button().click(function (e) {
-        window.open($('body').data('baseProjectUrl')+'new');
+      $('#dialog-form').dialog({
+          resizable: false,
+          modal: true,
+          title: "Delete notebook",
+          buttons : {
+              "New": function () {
+                var kernel = $('#kernel').val();
+                if (kernel) {
+                  window.open($('body').data('baseProjectUrl')+'kernels/'+ kernel);
+                } else {
+                  window.open($('body').data('baseProjectUrl')+'new');
+                }
+                $(this).dialog('close');
+              },
+              "Cancel": function () {
+                  $(this).dialog('close');
+              }
+          }
+      });
     });
 
     $('div#left_panel').addClass('box-flex');

--- a/IPython/frontend/html/notebook/templates/projectdashboard.html
+++ b/IPython/frontend/html/notebook/templates/projectdashboard.html
@@ -27,6 +27,12 @@ data-base-kernel-url={{base_kernel_url}}
 
         <span id="notebooks_buttons">
           <button id="new_notebook">New Notebook</button>
+            <div id="dialog-form" title="Create new notebook" style="display: none;">
+              <form>
+                <label for="name">Kernel</label>
+                <input type="text" name="kernel" id="kernel" />
+              </form>
+            </div>
         </span>
     </div>
 


### PR DESCRIPTION
This adds a new GET handler for the /kernels/<kernel_id> RequestHandler which opens the new notebook based on the kernel file name specified as the value for the kernel_id argument in the URL.

On the UI side, it looks like this. The main dashboard already has a New button. Upon clicking it, a dialog opens with a text box with the label "kernel". It is not a mandatory field. One can leave it blank in which case it opens up a new notebook with new kernel and it is the same as the action that happens when we click the new button as of now. But if we choose to put the name of the kernel file, say "kernel-5151.json", it redirects to the URL /kernels/kernel-5151.json and opens a new notebook with that kernel.

This is not a perfect patch. I do not even expect this to be merged right away. It needs a lot of changes. So it is a first cut. Sending a pull request just to draw some attention for discussion.
