### PR TITLE
edit text cells on double-click instead of single-click

### DIFF
--- a/IPython/frontend/html/notebook/static/js/textcell.js
+++ b/IPython/frontend/html/notebook/static/js/textcell.js
@@ -65,6 +65,13 @@ var IPython = (function (IPython) {
     };
 
 
+    TextCell.prototype.unselect = function() {
+        // render on selection of another cell
+        this.render();
+        IPython.Cell.prototype.unselect.apply(this);
+    };
+
+
     TextCell.prototype.edit = function () {
         if ( this.read_only ) return;
         if (this.rendered === true) {
@@ -91,11 +98,8 @@ var IPython = (function (IPython) {
         var that = this;
         text_cell.dblclick(function () {
             that.edit();
-        }).focusout(function () {
-            that.render();
         });
-        
-        text_cell.trigger("focusout");
+        that.render();
     };
 
 

--- a/IPython/frontend/html/notebook/static/js/textcell.js
+++ b/IPython/frontend/html/notebook/static/js/textcell.js
@@ -89,7 +89,7 @@ var IPython = (function (IPython) {
     TextCell.prototype.config_mathjax = function () {
         var text_cell = this.element;
         var that = this;
-        text_cell.click(function () {
+        text_cell.dblclick(function () {
             that.edit();
         }).focusout(function () {
             that.render();


### PR DESCRIPTION
Single-click to edit interferes with using interactive elements (e.g. non-flash videos), and select/copy of the rendered HTML.  Switching to double-click makes the edit action more intentional.
