### PR TITLE
Fix display of SyntaxError in Python 3

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1681,20 +1681,12 @@ class InteractiveShell(SingletonConfigurable, Magic):
         sys.last_traceback = last_traceback
 
         if filename and etype is SyntaxError:
-            # Work hard to stuff the correct filename in the exception
             try:
-                msg, (dummy_filename, lineno, offset, line) = value
+                value.filename = filename
             except:
                 # Not the format we expect; leave it alone
                 pass
-            else:
-                # Stuff in the right filename
-                try:
-                    # Assume SyntaxError is a class exception
-                    value = SyntaxError(msg, (filename, lineno, offset, line))
-                except:
-                    # If that failed, assume SyntaxError is a string
-                    value = msg, (filename, lineno, offset, line)
+        
         stb = self.SyntaxTB.structured_traceback(etype, value, [])
         self._showtraceback(etype, value, stb)
 

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -794,15 +794,7 @@ class VerboseTB(TBTools):
                 # keep the original file string.
                 pass
             link = tpl_link % file
-            try:
-                args, varargs, varkw, locals = inspect.getargvalues(frame)
-            except:
-                # This can happen due to a bug in python2.3.  We should be
-                # able to remove this try/except when 2.4 becomes a
-                # requirement.  Bug details at http://python.org/sf/1005466
-                inspect_error()
-                traceback.print_exc(file=self.ostream)
-                info("\nIPython's exception reporting continues...\n")
+            args, varargs, varkw, locals = inspect.getargvalues(frame)
 
             if func == '?':
                 call = ''

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -100,6 +100,7 @@ from IPython.core.excolors import exception_colors
 from IPython.utils import PyColorize
 from IPython.utils import io
 from IPython.utils import py3compat
+from IPython.utils import pyfile
 from IPython.utils.data import uniq_stable
 from IPython.utils.warn import info, error
 
@@ -873,6 +874,8 @@ class VerboseTB(TBTools):
             tokeneater.name_cont = False
 
             def linereader(file=file, lnum=[lnum], getline=linecache.getline):
+                if file.endswith(('.pyc','.pyo')):
+                    file = pyfile.source_from_cache(file)
                 line = getline(file, lnum[0])
                 lnum[0] += 1
                 return line

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -126,6 +126,14 @@ def inspect_error():
           'Below is the traceback from this internal error.\n')
 
 
+# N.B. This function is a monkeypatch we are currently not applying.
+# It was written some time ago, to fix an apparent Python bug with
+# codeobj.co_firstlineno . Unfortunately, we don't know under what conditions
+# the bug occurred, so we can't tell if it has been fixed. If it reappears, we
+# will apply the monkeypatch again. Also, note that findsource() is not called
+# by our code at this time - we don't know if it was when the monkeypatch was
+# written, or if the monkeypatch is needed for some other code (like a debugger).
+# For the discussion about not applying it, see gh-1229. TK, Jan 2011.
 def findsource(object):
     """Return the entire source file and starting line number for an object.
 
@@ -201,9 +209,10 @@ def findsource(object):
         return lines, lnum
     raise IOError('could not find code object')
 
+# Not applying the monkeypatch - see above the function for details. TK, Jan 2012
 # Monkeypatch inspect to apply our bugfix.  This code only works with py25
-if sys.version_info[:2] >= (2,5):
-    inspect.findsource = findsource
+#if sys.version_info[:2] >= (2,5):
+#    inspect.findsource = findsource
 
 def fix_frame_records_filenames(records):
     """Try to fix the filenames in each record from inspect.getinnerframes().

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -548,44 +548,40 @@ class ListTB(TBTools):
         have_filedata = False
         Colors = self.Colors
         list = []
-        try:
-            stype = Colors.excName + etype.__name__ + Colors.Normal
-        except AttributeError:
-            stype = etype  # String exceptions don't get special coloring
+        stype = Colors.excName + etype.__name__ + Colors.Normal
         if value is None:
+            # Not sure if this can still happen in Python 2.6 and above
             list.append( str(stype) + '\n')
         else:
             if etype is SyntaxError:
-                try:
-                    msg, (filename, lineno, offset, line) = value
-                except:
-                    have_filedata = False
-                else:
-                    have_filedata = True
-                    #print 'filename is',filename  # dbg
-                    if not filename: filename = "<string>"
-                    list.append('%s  File %s"%s"%s, line %s%d%s\n' % \
-                            (Colors.normalEm,
-                             Colors.filenameEm, filename, Colors.normalEm,
-                             Colors.linenoEm, lineno, Colors.Normal  ))
-                    if line is not None:
-                        i = 0
-                        while i < len(line) and line[i].isspace():
-                            i = i+1
-                        list.append('%s    %s%s\n' % (Colors.line,
-                                                      line.strip(),
-                                                      Colors.Normal))
-                        if offset is not None:
-                            s = '    '
-                            for c in line[i:offset-1]:
-                                if c.isspace():
-                                    s = s + c
-                                else:
-                                    s = s + ' '
-                            list.append('%s%s^%s\n' % (Colors.caret, s,
-                                                       Colors.Normal) )
-                        value = msg
-            s = self._some_str(value)
+                have_filedata = True
+                #print 'filename is',filename  # dbg
+                if not value.filename: value.filename = "<string>"
+                list.append('%s  File %s"%s"%s, line %s%d%s\n' % \
+                        (Colors.normalEm,
+                         Colors.filenameEm, value.filename, Colors.normalEm,
+                         Colors.linenoEm, value.lineno, Colors.Normal  ))
+                if value.text is not None:
+                    i = 0
+                    while i < len(value.text) and value.text[i].isspace():
+                        i = i+1
+                    list.append('%s    %s%s\n' % (Colors.line,
+                                                  value.text.strip(),
+                                                  Colors.Normal))
+                    if value.offset is not None:
+                        s = '    '
+                        for c in value.text[i:value.offset-1]:
+                            if c.isspace():
+                                s = s + c
+                            else:
+                                s = s + ' '
+                        list.append('%s%s^%s\n' % (Colors.caret, s,
+                                                   Colors.Normal) )
+
+            try:
+                s = value.msg
+            except Exception:
+                s = self._some_str(value)
             if s:
                 list.append('%s%s:%s %s\n' % (str(stype), Colors.excName,
                                               Colors.Normal, s))
@@ -596,7 +592,7 @@ class ListTB(TBTools):
         if have_filedata:
             ipinst = ipapi.get()
             if ipinst is not None:
-                ipinst.hooks.synchronize_with_editor(filename, lineno, 0)
+                ipinst.hooks.synchronize_with_editor(value.filename, value.lineno, 0)
 
         return list
 

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -514,7 +514,7 @@ class ListTB(TBTools):
                      Colors.lineno, lineno, Colors.Normal,
                      Colors.name, name, Colors.Normal)
             if line:
-                item = item + '    %s\n' % line.strip()
+                item += '    %s\n' % line.strip()
             list.append(item)
         # Emphasize the last entry
         filename, lineno, name, line = extracted_list[-1]
@@ -525,7 +525,7 @@ class ListTB(TBTools):
                  Colors.nameEm, name, Colors.normalEm,
                  Colors.Normal)
         if line:
-            item = item + '%s    %s%s\n' % (Colors.line, line.strip(),
+            item += '%s    %s%s\n' % (Colors.line, line.strip(),
                                             Colors.Normal)
         list.append(item)
         #from pprint import pformat; print 'LISTTB', pformat(list) # dbg
@@ -564,7 +564,7 @@ class ListTB(TBTools):
                 if value.text is not None:
                     i = 0
                     while i < len(value.text) and value.text[i].isspace():
-                        i = i+1
+                        i += 1
                     list.append('%s    %s%s\n' % (Colors.line,
                                                   value.text.strip(),
                                                   Colors.Normal))
@@ -572,9 +572,9 @@ class ListTB(TBTools):
                         s = '    '
                         for c in value.text[i:value.offset-1]:
                             if c.isspace():
-                                s = s + c
+                                s += c
                             else:
-                                s = s + ' '
+                                s += ' '
                         list.append('%s%s^%s\n' % (Colors.caret, s,
                                                    Colors.Normal) )
 

--- a/IPython/lib/tests/test_irunner.py
+++ b/IPython/lib/tests/test_irunner.py
@@ -13,7 +13,6 @@ import unittest
 
 # IPython imports
 from IPython.lib import irunner
-from IPython.testing.decorators import known_failure_py3
 from IPython.utils.py3compat import doctest_refactor_print
 
 # Testing code begins
@@ -58,8 +57,6 @@ class RunnerTestCase(unittest.TestCase):
         self.assert_(mismatch==0,'Number of mismatched lines: %s' %
                      mismatch)
 
-    # The SyntaxError appears differently in Python 3, for some reason.
-    @known_failure_py3
     def testIPython(self):
         """Test the IPython runner."""
         source = doctest_refactor_print("""

--- a/IPython/utils/pyfile.py
+++ b/IPython/utils/pyfile.py
@@ -1,0 +1,23 @@
+"""Utilities for working with Python source files.
+
+Exposes various functions from recent Python standard libraries, along with
+equivalents for older Python versions.
+"""
+import os.path
+
+try:    # Python 3.2
+    from imp import source_from_cache, cache_from_source
+except ImportError:
+    # Python <= 3.1: .pyc files go next to .py
+    def source_from_cache(path):
+        basename, ext = os.path.splitext(path)
+        if ext not in {'.pyc', '.pyo'}:
+            raise ValueError('Not a cached Python file extension', ext)
+        # Should we look for .pyw files?
+        return basename + '.py'
+    
+    def cache_from_source(path, debug_override=None):
+        if debug_override is None:
+            debug_override = __debug__
+        basename, ext = os.path.splitext(path)
+        return basename + '.pyc' if debug_override else '.pyo'


### PR DESCRIPTION
Closes #1225

The code handling exceptions is quite old, and I've cleaned it up a bit. There may be more cleanup that can be done.

The current situation with exceptions:
- String exceptions were removed in Python 2.6, so we no longer need to worry about them.
- In Python 2.6 & 2.7, any old style class can be used as an exception.
- New style classes used as exceptions must inherit from BaseException (on Python 3, this is therefore all exceptions)
