### PR TITLE
changed key map name to match changes to python mode

### DIFF
--- a/docs/emacs/ipython.el
+++ b/docs/emacs/ipython.el
@@ -197,7 +197,7 @@ the second for a 'normal' command, and the third for a multiline command.")
       (define-key py-shell-map "\t" 'ipython-complete)
       ;;XXX this is really just a cheap hack, it only completes symbols in the
       ;;interactive session -- useful nonetheless.
-      (define-key py-mode-map [(meta tab)] 'ipython-complete)
+      (define-key python-mode-map [(meta tab)] 'ipython-complete)
 
       )
     (add-hook 'py-shell-hook 'ipython-shell-hook)


### PR DESCRIPTION
This is a minor change to handling the python-mode key mappings.  In reversion 752
( http://bazaar.launchpad.net/~python-mode-devs/python-mode/python-mode/revision/752 ) the name of the map was changed from py-mode-map to python-mode-map.

This isn't in any distributions yet, so I am not sure how you want to deal with this.
