### PR TITLE
set auto_create flag for notebook apps

### DIFF
--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -215,6 +215,9 @@ class NotebookApp(BaseIPythonApplication):
                     config=True,
                     help="Set the log level by value or name.")
 
+    # create requested profiles by default, if they don't exist:
+    auto_create = Bool(True)
+
     # Network related information.
 
     ip = Unicode(LOCALHOST, config=True,


### PR DESCRIPTION
This is one way to fix the recent [mailing list report](http://mail.scipy.org/pipermail/ipython-user/2012-January/009069.html).

```
$ rm -fr  ~/.ipython/profile_sympy/
$ ipython notebook --profile=sympy
[NotebookApp] Profile u'sympy' not found.
```

whereas

```
 $ ipython --profile=sympy
```

works fine, and `ipython notebook --profile=sympy` will work thereafter. In this PR, I added set the auto_create flag for notebook apps to True, which makes the top code block work just fine.

An alternative would be to make `auto_create = True` for the base application. I'm not sure which one should be done, but would be happy to change this pull request to the alternative, which would look like this:

```
diff --git a/IPython/core/application.py b/IPython/core/application.py
index 4b49a94..cf099bb 100644
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -124,7 +124,7 @@ class BaseIPythonApplication(Application):

     overwrite = Bool(False, config=True,
         help="""Whether to overwrite existing config files when copying""")
-    auto_create = Bool(False, config=True,
+    auto_create = Bool(True, config=True,
         help="""Whether to create profile dir if it doesn't exist""")
```
