### PR TITLE
use self.kernel_manager_class in qtconsoleapp

### DIFF
--- a/IPython/frontend/qt/console/qtconsoleapp.py
+++ b/IPython/frontend/qt/console/qtconsoleapp.py
@@ -178,7 +178,7 @@ class IPythonQtConsoleApp(BaseIPythonApplication, IPythonConsoleApp):
         """ Create and return new frontend attached to new kernel, launched on localhost.
         """
         ip = self.ip if self.ip in LOCAL_IPS else LOCALHOST
-        kernel_manager = QtKernelManager(
+        kernel_manager = self.kernel_manager_class(
                                 ip=ip,
                                 connection_file=self._new_connection_file(),
                                 config=self.config,
@@ -204,7 +204,7 @@ class IPythonQtConsoleApp(BaseIPythonApplication, IPythonConsoleApp):
         current_widget : IPythonWidget
             The IPythonWidget whose kernel this frontend is to share
         """
-        kernel_manager = QtKernelManager(
+        kernel_manager = self.kernel_manager_class(
                                 connection_file=current_widget.kernel_manager.connection_file,
                                 config = self.config,
         )


### PR DESCRIPTION
ShellApp derivatives have a kernel_manager_class, so that it's easier to change what should be used in subclasses.  The QtConsole was not updated to use this for tabs _other than the first_.  This small PR makes that change.
