### PR TITLE
Replace "from (.|..) import" with absolute imports.

### DIFF
--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 import nose.tools as nt
 
 # Our own imports
-from .. import oinspect
+from IPython.core import oinspect
 from IPython.utils import py3compat
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/tests/test_pylabtools.py
+++ b/IPython/core/tests/test_pylabtools.py
@@ -24,7 +24,7 @@ import numpy as np
 
 # Our own imports
 from IPython.testing import decorators as dec
-from .. import pylabtools as pt
+from IPython.core import pylabtools as pt
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/IPython/parallel/client/remotefunction.py
+++ b/IPython/parallel/client/remotefunction.py
@@ -23,7 +23,7 @@ import warnings
 
 from IPython.testing.skipdoctest import skip_doctest
 
-from . import map as Map
+from IPython.parallel.client import map as Map
 from .asyncresult import AsyncMapResult
 
 #-----------------------------------------------------------------------------

--- a/IPython/parallel/client/view.py
+++ b/IPython/parallel/client/view.py
@@ -32,7 +32,7 @@ from IPython.external.decorator import decorator
 from IPython.parallel import util
 from IPython.parallel.controller.dependency import Dependency, dependent
 
-from . import map as Map
+from IPython.parallel.client import map as Map
 from .asyncresult import AsyncResult, AsyncMapResult
 from .remotefunction import ParallelFunction, parallel, remote
 

--- a/IPython/parallel/tests/test_mongodb.py
+++ b/IPython/parallel/tests/test_mongodb.py
@@ -21,7 +21,7 @@ from nose import SkipTest
 from pymongo import Connection
 from IPython.parallel.controller.mongodb import MongoDB
 
-from . import test_db
+from IPython.parallel.tests import test_db
 
 try:
     c = Connection()

--- a/IPython/testing/globalipapp.py
+++ b/IPython/testing/globalipapp.py
@@ -25,7 +25,7 @@ import os
 import sys
 
 # our own
-from . import tools
+from IPython.testing import tools
 
 from IPython.core import page
 from IPython.utils import io

--- a/IPython/testing/ipunittest.py
+++ b/IPython/testing/ipunittest.py
@@ -76,7 +76,7 @@ class IPython2PythonConverter(object):
 
     def __call__(self, ds):
         """Convert IPython prompts to python ones in a string."""
-        from . import globalipapp
+        from IPython.testing import globalipapp
 
         pyps1 = '>>> '
         pyps2 = '... '

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -51,8 +51,8 @@ from IPython.utils.text import list_strings, getdefaultencoding
 from IPython.utils.io import temp_pyfile, Tee
 from IPython.utils import py3compat
 
-from . import decorators as dec
-from . import skipdoctest
+from IPython.testing import decorators as dec
+from IPython.testing import skipdoctest
 
 #-----------------------------------------------------------------------------
 # Globals

--- a/IPython/utils/_process_win32.py
+++ b/IPython/utils/_process_win32.py
@@ -26,8 +26,8 @@ from subprocess import STDOUT
 
 # our own imports
 from ._process_common import read_no_interrupt, process_handler, arg_split as py_arg_split
-from . import py3compat
-from . import text
+from IPython.utils import py3compat
+from IPython.utils import text
 
 #-----------------------------------------------------------------------------
 # Function definitions


### PR DESCRIPTION
2to3 in Python 3.1 mangles the "from . import" syntax, so it's best just to avoid it.

Somebody with Python 3.1 should probably give this a test -- I've only verified that the tests still pass in Python 2.7.

Closes gh-1251.
