### PR TITLE
Heartbeat no longer shares the app's Context

### DIFF
--- a/IPython/parallel/controller/heartmonitor.py
+++ b/IPython/parallel/controller/heartmonitor.py
@@ -40,6 +40,10 @@ class Heart(object):
     id=None
     def __init__(self, in_addr, out_addr, in_type=zmq.SUB, out_type=zmq.DEALER, heart_id=None):
         self.device = ThreadDevice(zmq.FORWARDER, in_type, out_type)
+        # do not allow the device to share global Context.instance,
+        # which is the default behavior in pyzmq > 2.1.10
+        self.device.context_factory = zmq.Context
+        
         self.device.daemon=True
         self.device.connect_in(in_addr)
         self.device.connect_out(out_addr)

--- a/IPython/zmq/kernelapp.py
+++ b/IPython/zmq/kernelapp.py
@@ -216,8 +216,11 @@ class KernelApp(BaseIPythonApplication):
         self.stdin_socket = context.socket(zmq.ROUTER)
         self.stdin_port = self._bind_socket(self.stdin_socket, self.stdin_port)
         self.log.debug("stdin ROUTER Channel on port: %i"%self.stdin_port)
-
-        self.heartbeat = Heartbeat(context, (self.ip, self.hb_port))
+        
+        # heartbeat doesn't share context, because it mustn't be blocked
+        # by the GIL, which is accessed by libzmq when freeing zero-copy messages
+        hb_ctx = zmq.Context()
+        self.heartbeat = Heartbeat(hb_ctx, (self.ip, self.hb_port))
         self.hb_port = self.heartbeat.port
         self.log.debug("Heartbeat REP Channel on port: %i"%self.hb_port)
 

--- a/docs/examples/tests/heartbeat/gilsleep.ipynb
+++ b/docs/examples/tests/heartbeat/gilsleep.ipynb
@@ -1,0 +1,56 @@
+{
+ "metadata": {
+  "name": "gilsleep"
+ }, 
+ "nbformat": 2, 
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "markdown", 
+     "source": [
+      "Holding the GIL for too long could disrupt the heartbeat due to non-copying sends.", 
+      "", 
+      "The following cell repeatedly calls a function that holds the GIL for five seconds.", 
+      "", 
+      "The heartbeat will fail after a few iterations prior to fixing Issue [#1260](https://github.com/ipython/ipython/issues/1260)."
+     ]
+    }, 
+    {
+     "cell_type": "code", 
+     "collapsed": false, 
+     "input": [
+      "import sys", 
+      "import time", 
+      "", 
+      "from cython import inline", 
+      "", 
+      "def gilsleep(t):", 
+      "    \"\"\"gil-holding sleep with cython.inline\"\"\"", 
+      "    code = '\\n'.join([", 
+      "        'from posix cimport unistd',", 
+      "        'unistd.sleep(t)',", 
+      "    ])", 
+      "    while True:", 
+      "        inline(code, quiet=True, t=t)", 
+      "        print time.time()", 
+      "        sys.stdout.flush() # this is important", 
+      "", 
+      "gilsleep(5)"
+     ], 
+     "language": "python", 
+     "outputs": [], 
+     "prompt_number": 1
+    }, 
+    {
+     "cell_type": "code", 
+     "collapsed": true, 
+     "input": [], 
+     "language": "python", 
+     "outputs": [], 
+     "prompt_number": "&nbsp;"
+    }
+   ]
+  }
+ ]
+}

--- a/docs/examples/tests/heartbeat/hb_gil.py
+++ b/docs/examples/tests/heartbeat/hb_gil.py
@@ -1,0 +1,31 @@
+"""
+Run this script in the qtconsole with one of:
+
+    %loadpy hb_gil.py
+
+or
+    %run hb_gil.py
+
+Holding the GIL for too long could disrupt the heartbeat.
+
+See Issue #1260: https://github.com/ipython/ipython/issues/1260
+
+"""
+
+import sys
+import time
+
+from cython import inline
+
+def gilsleep(t):
+    """gil-holding sleep with cython.inline"""
+    code = '\n'.join([
+        'from posix cimport unistd',
+        'unistd.sleep(t)',
+    ])
+    while True:
+        inline(code, quiet=True, t=t)
+        print time.time()
+        sys.stdout.flush() # this is important
+
+gilsleep(5)


### PR DESCRIPTION
This is the chosen solution 2. in #1260.  I couldn't see any of the extra bookkeeping that I thought might be necessary, so simply creating a new context is all there was to do.

Test script and notebook added to examples directory for easier confirmation, as described in #1127

closes #1260
