### PR TITLE
Don't ask for confirmation when stdin isn't available

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -762,8 +762,10 @@ def magic_history(self, parameter_s = ''):
       the default is the last 10 lines.
 
       -f FILENAME: instead of printing the output to the screen, redirect it to
-       the given file.  The file is always overwritten, though IPython asks for
-       confirmation first if it already exists.
+       the given file.  The file is always overwritten, though *when it can*,
+       IPython asks for confirmation first. In particular, running the command
+       "history -f FILENAME" from the IPython Notebook interface will replace
+       FILENAME even if it already exists *without* confirmation.
 
     Examples
     --------
@@ -801,12 +803,11 @@ def magic_history(self, parameter_s = ''):
             try:
                 ans = io.ask_yes_no("File %r exists. Overwrite?" % outfname)
             except StdinNotImplementedError:
-                print("Overwriting file.")
                 ans = True
             if not ans:
                 print('Aborting.')
                 return
-
+            print("Overwriting file.")
         outfile = open(outfname,'w')
         close_at_end = True
 

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -24,6 +24,7 @@ except ImportError:
 import threading
 
 # Our own packages
+from IPython.core.error import StdinNotImplementedError
 from IPython.config.configurable import Configurable
 from IPython.external.decorator import decorator
 from IPython.testing.skipdoctest import skip_doctest
@@ -797,7 +798,12 @@ def magic_history(self, parameter_s = ''):
         close_at_end = False
     else:
         if os.path.exists(outfname):
-            if not io.ask_yes_no("File %r exists. Overwrite?" % outfname):
+            try:
+                ans = io.ask_yes_no("File %r exists. Overwrite?" % outfname)
+            except StdinNotImplementedError:
+                print("Overwriting file.")
+                ans = True
+            if not ans:
                 print('Aborting.')
                 return
 

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -984,6 +984,12 @@ Currently the magic system has the following functions:\n"""
 
         In [1]: 'a' in _ip.user_ns
         Out[1]: False
+
+        Notes
+        -----
+        Calling this magic from clients that do not implement standard input,
+        such as the ipython notebook interface, will reset the namespace
+        without confirmation.
         """
         opts, args = self.parse_options(parameter_s,'sf')
         if 'f' in opts:
@@ -1056,6 +1062,12 @@ Currently the magic system has the following functions:\n"""
 
         In [11]: who_ls
         Out[11]: ['a']
+
+        Notes
+        -----
+        Calling this magic from clients that do not implement standard input,
+        such as the ipython notebook interface, will reset the namespace
+        without confirmation.
         """
 
         opts, regex = self.parse_options(parameter_s,'f')

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -45,6 +45,7 @@ import IPython
 from IPython.core import debugger, oinspect
 from IPython.core.error import TryNext
 from IPython.core.error import UsageError
+from IPython.core.error import StdinNotImplementedError
 from IPython.core.fakemodule import FakeModule
 from IPython.core.profiledir import ProfileDir
 from IPython.core.macro import Macro
@@ -988,8 +989,11 @@ Currently the magic system has the following functions:\n"""
         if 'f' in opts:
             ans = True
         else:
-            ans = self.shell.ask_yes_no(
+            try:
+                ans = self.shell.ask_yes_no(
                 "Once deleted, variables cannot be recovered. Proceed (y/[n])? ", default='n')
+            except StdinNotImplementedError:
+                ans = True
         if not ans:
             print 'Nothing done.'
             return
@@ -1059,9 +1063,12 @@ Currently the magic system has the following functions:\n"""
         if opts.has_key('f'):
             ans = True
         else:
-            ans = self.shell.ask_yes_no(
+            try:
+                ans = self.shell.ask_yes_no(
                 "Once deleted, variables cannot be recovered. Proceed (y/[n])? ",
                 default='n')
+            except StdinNotImplementedError:
+                ans = True
         if not ans:
             print 'Nothing done.'
             return


### PR DESCRIPTION
In the notebook, we can't ask the user to confirm actions with a y/n prompt, because stdin doesn't work. But they probably didn't type %reset by accident, so we may as well go ahead and do it.

Points to consider:
- If the user types "exit", we don't wait for confirmation. reset is no more damaging than exit, so maybe we shouldn't wait for confirmation at all.
- Is there any situation where the user might expect to have a `reset` variable in scope, and try to examine its value? One way round this would be to drop reset in the builtins (as an explanatory string), forcing them to explicitly type %reset. But I suspect this is overkill.

Closes gh-1268
