### PR TITLE
TaskScheduler.hwm default to 1 instead of 0

### DIFF
--- a/IPython/parallel/controller/scheduler.py
+++ b/IPython/parallel/controller/scheduler.py
@@ -131,13 +131,23 @@ class TaskScheduler(SessionFactory):
 
     """
 
-    hwm = Integer(0, config=True, shortname='hwm',
+    hwm = Integer(1, config=True,
         help="""specify the High Water Mark (HWM) for the downstream
         socket in the Task scheduler. This is the maximum number
-        of allowed outstanding tasks on each engine."""
+        of allowed outstanding tasks on each engine.
+        
+        The default (1) means that only one task can be outstanding on each
+        engine.  Setting TaskScheduler.hwm=0 means there is no limit, and the
+        engines continue to be assigned tasks while they are working,
+        effectively hiding network latency behind computation, but can result
+        in an imbalance of work when submitting many heterogenous tasks all at
+        once.  Any positive value greater than one is a compromise between the
+        two.
+
+        """
     )
     scheme_name = Enum(('leastload', 'pure', 'lru', 'plainrandom', 'weighted', 'twobin'),
-        'leastload', config=True, shortname='scheme', allow_none=False,
+        'leastload', config=True, allow_none=False,
         help="""select the task scheduler scheme  [default: Python LRU]
         Options are: 'pure', 'lru', 'plainrandom', 'weighted', 'twobin','leastload'"""
     )

--- a/docs/source/parallel/parallel_task.txt
+++ b/docs/source/parallel/parallel_task.txt
@@ -415,11 +415,11 @@ assigned to an engine at a given time. This limit is set with the
 .. sourcecode:: python
 
     # the most common choices are:
-    c.TaskSheduler.hwm = 0 # (minimal latency, default)
+    c.TaskSheduler.hwm = 0 # (minimal latency, default in IPython ≤ 0.12)
     # or
-    c.TaskScheduler.hwm = 1 # (most-informed balancing)
+    c.TaskScheduler.hwm = 1 # (most-informed balancing, default in > 0.12)
 
-The default is 0, or no-limit. That is, there is no limit to the number of
+In IPython ≤ 0.12,the default is 0, or no-limit. That is, there is no limit to the number of
 tasks that can be outstanding on a given engine. This greatly benefits the
 latency of execution, because network traffic can be hidden behind computation.
 However, this means that workload is assigned without knowledge of how long
@@ -428,6 +428,11 @@ submitting a collection of heterogeneous tasks all at once. You can limit this
 effect by setting hwm to a positive integer, 1 being maximum load-balancing (a
 task will never be waiting if there is an idle engine), and any larger number
 being a compromise between load-balance and latency-hiding.
+
+In practice, some users have been confused by having this optimization on by
+default, and the default value has been changed to 1. This can be slower,
+but has more obvious behavior and won't result in assigning too many tasks to
+some engines in heterogeneous cases.
 
 
 Pure ZMQ Scheduler


### PR DESCRIPTION
1 has more predictable/intuitive behavior, if often slower, and thus a more logical default.

closes #1293
