### PR TITLE
Wx gui example: fixes the broken example for `%gui wx`.

### DIFF
--- a/docs/examples/lib/gui-wx.py
+++ b/docs/examples/lib/gui-wx.py
@@ -1,30 +1,14 @@
 #!/usr/bin/env python
 """
-WARNING: This example is currently broken, see
-https://github.com/ipython/ipython/issues/645 for details on our progress on
-this issue.
-
 A Simple wx example to test IPython's event loop integration.
 
 To run this do:
 
-In [5]: %gui wx
+In [5]: %gui wx  # or start IPython with '--gui wx' or '--pylab wx'
 
 In [6]: %run gui-wx.py
 
 Ref: Modified from wxPython source code wxPython/samples/simple/simple.py
-
-This example can only be run once in a given IPython session because when
-the frame is closed, wx goes through its shutdown sequence, killing further
-attempts.  I am sure someone who knows wx can fix this issue.
-
-Furthermore, once this example is run, the Wx event loop is mostly dead, so
-even other new uses of Wx may not work correctly.  If you know how to better
-handle this, please contact the ipython developers and let us know.
-
-Note however that we will work with the Matplotlib and Enthought developers so
-that the main interactive uses of Wx we are aware of, namely these tools, will
-continue to work well with IPython interactively.
 """
 
 import wx
@@ -105,17 +89,18 @@ class MyApp(wx.App):
 
 
 if __name__ == '__main__':
-    raise NotImplementedError(
-        'Standalone WX GUI support is currently broken. '
-        'See https://github.com/ipython/ipython/issues/645 for details')
 
     app = wx.GetApp()
     if app is None:
         app = MyApp(redirect=False, clearSigInt=False)
+    else:
+        frame = MyFrame(None, "Simple wxPython App")
+        app.SetTopWindow(frame)
+        print "Print statements go to this stdout window by default."
+        frame.Show(True)
 
     try:
         from IPython.lib.inputhook import enable_wx
         enable_wx(app)
     except ImportError:
         app.MainLoop()
-

--- a/docs/source/interactive/reference.txt
+++ b/docs/source/interactive/reference.txt
@@ -870,14 +870,6 @@ Since the details vary slightly between toolkits, we point you to the various
 examples in our source directory :file:`docs/examples/lib` that demonstrate
 these capabilities.
 
-.. warning::
-
-   The WX version of this is currently broken.  While ``--pylab=wx`` works
-   fine, standalone WX apps do not.  See
-   https://github.com/ipython/ipython/issues/645 for details of our progress on
-   this issue.
-
-
 Third, unlike previous versions of IPython, we no longer "hijack" (replace
 them with no-ops) the event loops. This is done to allow applications that
 actually need to run the real event loops to do so. This is often needed to
@@ -938,9 +930,11 @@ Matlab program.
 
 To start IPython with matplotlib support, use the ``--pylab`` switch.  If no
 arguments are given, IPython will automatically detect your choice of
-matplotlib backend.  You can also request a specific backend with
-``--pylab=backend``, where ``backend`` must be one of: 'tk', 'qt', 'wx', 'gtk',
-'osx'.
+matplotlib backend.  You can also request a specific backend with ``--pylab
+backend``, where ``backend`` must be one of: 'tk', 'qt', 'wx', 'gtk', 'osx'.
+In the web notebook and Qt console, 'inline' is also a valid backend value,
+which produces static figures inlined inside the application window instead of
+matplotlib's interactive figures that live in separate windows.
 
 .. _Matplotlib: http://matplotlib.sourceforge.net
 


### PR DESCRIPTION
Applied the fix contributed by @piotradam in #645 and tested that things now work correctly.  It seems our Wx code was OK, it was just a problem with the example.

Many thanks to @piotradam for the key fix!

Closes #645.
