### PR TITLE
Fix %prun input parsing for escaped characters (closes #1302)

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -1391,12 +1391,10 @@ Currently the magic system has the following functions:\n"""
         """
 
         opts_def = Struct(D=[''],l=[],s=['time'],T=[''])
-        # protect user quote marks
-        parameter_s = parameter_s.replace('"',r'\"').replace("'",r"\'")
 
         if user_mode:  # regular user call
             opts,arg_str = self.parse_options(parameter_s,'D:l:rs:T:q',
-                                              list_all=1)
+                                              list_all=1, posix=False)
             namespace = self.shell.user_ns
         else:  # called to run a program by %run -p
             try:

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -358,3 +358,9 @@ def test_timeit_shlex():
 def test_timeit_arguments():
     "Test valid timeit arguments, should not cause SyntaxError (GH #1269)"
     _ip.magic("timeit ('#')")
+
+@dec.skipif(_ip.magic_prun == _ip.profile_missing_notice)
+def test_prun_quotes():
+    "Test that prun does not clobber string escapes (GH #1302)"
+    _ip.magic("prun -q x = '\t'")
+    nt.assert_equal(_ip.user_ns['x'], '\t')


### PR DESCRIPTION
this fixes the issue reported in #1302
