### PR TITLE
minor heartbeat tweaks

### DIFF
--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -481,6 +481,8 @@ class IOPubHandler(AuthenticatedZMQStreamHandler):
                 if self._kernel_alive:
                     self._kernel_alive = False
                     self.hb_stream.send(b'ping')
+                    # flush stream to force immediate socket send
+                    self.hb_stream.flush()
                 else:
                     try:
                         callback()

--- a/IPython/parallel/controller/heartmonitor.py
+++ b/IPython/parallel/controller/heartmonitor.py
@@ -124,6 +124,8 @@ class HeartMonitor(LoggingConfigurable):
         # print self.on_probation, self.hearts
         # self.log.debug("heartbeat::beat %.3f, %i beating hearts", self.lifetime, len(self.hearts))
         self.pingstream.send(asbytes(str(self.lifetime)))
+        # flush stream to force immediate socket send
+        self.pingstream.flush()
 
     def handle_new_heart(self, heart):
         if self._new_handlers:

--- a/IPython/parallel/controller/heartmonitor.py
+++ b/IPython/parallel/controller/heartmonitor.py
@@ -64,7 +64,7 @@ class HeartMonitor(LoggingConfigurable):
     pongstream: an XREP stream
     period: the period of the heartbeat in milliseconds"""
 
-    period = Integer(1000, config=True,
+    period = Integer(3000, config=True,
         help='The frequency at which the Hub pings the engines for heartbeats '
         '(in ms)',
     )


### PR DESCRIPTION
two small changes:
- flush outgoing heartbeats:
  - Prevents mismatch between heartbeat timer and actual heartbeat send/recv events.
  - Applied in notebook and parallel.
- relax default heartbeat period in IPython.parallel to 3s from 1s
  - Matches heartbeats elsewhere.  3s should be extremely conservative, as most heartbeat responses are O(1ms) unless there's a bug in our code (like the above flush and previously-discovered GIL issues).

closes #1304
