### PR TITLE
Pass subprocess test runners a suitable location for xunit output

### DIFF
--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -284,6 +284,11 @@ class IPTester(object):
 
         # Assemble call
         self.call_args = self.runner+self.params
+        
+        print self.call_args
+        if '--with-xunit' in self.call_args:
+            sect = [p for p in self.params if p.startswith('IPython')][0]
+            self.call_args.append('--xunit-file=%s' % path.abspath(sect+'.xunit.xml'))
 
         # Store pids of anything we start to clean up on deletion, if possible
         # (on posix only, since win32 has no os.kill)


### PR DESCRIPTION
Producing xunit reports the easy way. We just need to pass the individual test runners a suitable location to put the output file.

This is what the output looks like: https://jenkins.shiningpanda.com/ipython/job/ipython-xunit-test/3/testReport/

I don't know whether the failing tests in parallel are a new failure, a stochastic thing, or somehow caused by this change (I can't see how it would affect parallel).
