### PR TITLE
make Ctrl-D in qtconsole act same as in terminal (ready to merge)

### DIFF
--- a/IPython/core/usage.py
+++ b/IPython/core/usage.py
@@ -407,13 +407,14 @@ The keybindings themselves are:
 - ``C-l``: clear terminal.
 - ``C-a``: go to beginning of line.
 - ``C-e``: go to end of line.
+- ``C-u``: kill from cursor to the begining of the line.
 - ``C-k``: kill from cursor to the end of the line.
 - ``C-y``: yank (paste)
 - ``C-p``: previous line (like up arrow)
 - ``C-n``: next line (like down arrow)
 - ``C-f``: forward (like right arrow)
 - ``C-b``: back (like left arrow)
-- ``C-d``: delete next character.
+- ``C-d``: delete next character, or exits if input is empty
 - ``M-<``: move to the beginning of the input region.
 - ``M->``: move to the end of the input region.
 - ``M-d``: delete next word.

--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -1114,9 +1114,16 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
                 cursor.setPosition(position, QtGui.QTextCursor.KeepAnchor)
                 self._kill_ring.kill_cursor(cursor)
                 intercepted = True
+
             elif key == QtCore.Qt.Key_D:
                 if len(self.input_buffer) == 0:
                     self.exit_requested.emit(self)
+                else:
+                    new_event = QtGui.QKeyEvent(QtCore.QEvent.KeyPress,
+                                                QtCore.Qt.Key_Delete,
+                                                QtCore.Qt.NoModifier)
+                    QtGui.qApp.sendEvent(self._control, new_event)
+                    intercepted = True
 
         #------ Alt modifier ---------------------------------------------------
 

--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -144,8 +144,7 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
                          QtCore.Qt.Key_A : QtCore.Qt.Key_Home,
                          QtCore.Qt.Key_P : QtCore.Qt.Key_Up,
                          QtCore.Qt.Key_N : QtCore.Qt.Key_Down,
-                         QtCore.Qt.Key_H : QtCore.Qt.Key_Backspace,
-                         QtCore.Qt.Key_D : QtCore.Qt.Key_Delete, }
+                         QtCore.Qt.Key_H : QtCore.Qt.Key_Backspace, }
     if not sys.platform == 'darwin':
         # On OS X, Ctrl-E already does the right thing, whereas End moves the
         # cursor to the bottom of the buffer.
@@ -1115,6 +1114,9 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
                 cursor.setPosition(position, QtGui.QTextCursor.KeepAnchor)
                 self._kill_ring.kill_cursor(cursor)
                 intercepted = True
+            elif key == QtCore.Qt.Key_D:
+                if len(self.input_buffer) == 0:
+                    self.exit_requested.emit(self)
 
         #------ Alt modifier ---------------------------------------------------
 

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -188,6 +188,8 @@ class MainWindow(QtGui.QMainWindow):
                     justthis.setShortcut('N')
                     closeall = QtGui.QPushButton("&Yes, close all", self)
                     closeall.setShortcut('Y')
+                    # allow ctrl-d ctrl-d exit, like in terminal
+                    closeall.setShortcut('Ctrl+D')
                     box = QtGui.QMessageBox(QtGui.QMessageBox.Question,
                                             title, msg)
                     box.setInformativeText(info)


### PR DESCRIPTION
my muscle memory refuses to accept the current functionality of `CTRL-D` in qt console - because everywhere else i can use it to end a current line of input, or, when type at the beginning of an otherwise empty prompt - asks if I want to exit (the way IPython single process terminal and console do it, the way most unix shells do it, as well).

With this PR, the functionality in qtconsole matches the terminal. Pressing `Ctrl-D` when the input prompt is ~~non-empty will just send the entire input to IPython (so you don't get a continuation prompt if you do something like):
    In [1]: 'asdfa'<CTRL-D>
    Out[1]: 'asdfa'
whereas if you type in~~ on an empty line you get

```
In [5]: <CTRL-D>
Do you really want to exit ([y]/n)?
```

In the terminal, typing `<CTRL-D>` again at that prompt will exit, and I've carried that over to the prompt that pops up in the qtconsole.

**Update 2012-01-24**
Being a naive vi guy, my fingers rarely venture away from the home row keys, so I didn't realize that the full behavior I describe is a function of my vi addiction. Repenting, I've re-pushed a smaller change that everyone agrees on: `CTRL-D` on an empty line prompts to exit. If anyone (including myself) needs the fuller vi-mode implementation (as described at the top of), it can be found in here: ivanov@fb8ce6ded7e3f3aaf61dc79c81c8f0ab018837aa
