### PR TITLE
forgotten selected_cell -> get_selected_cell

### DIFF
--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -224,7 +224,7 @@ var IPython = (function (IPython) {
         morelink.append(morespan);
         morelink.click(function(){
             var msg_id = IPython.notebook.kernel.execute(name+"?");
-            IPython.notebook.msg_cell_map[msg_id] = IPython.notebook.selected_cell().cell_id;
+            IPython.notebook.msg_cell_map[msg_id] = IPython.notebook.get_selected_cell().cell_id;
             that.remove_and_cancel_tooltip();
             setTimeout(function(){that.code_mirror.focus();}, 50);
         });

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -1014,7 +1014,7 @@ var IPython = (function (IPython) {
         var ncells = this.ncells();
         for (var i=0; i<ncells; i++) {
             this.select(i);
-            this.execute_get_selected_cell({add_new:false});
+            this.execute_selected_cell({add_new:false});
         };
         this.scroll_to_bottom();
     };


### PR DESCRIPTION
somwhere in renaming `selected_cell` to `get_selected_cell` one
occurence has been forgoten in `codecell.js` this was mainly visible by
the fact that the 'show pager' button of the tooltip was non fonctionnal
anymore.
