### PR TITLE
Add linewrapping to text cells (new feature in CodeMirror).

### DIFF
--- a/IPython/frontend/html/notebook/static/js/textcell.js
+++ b/IPython/frontend/html/notebook/static/js/textcell.js
@@ -34,6 +34,7 @@ var IPython = (function (IPython) {
             theme: 'default',
             value: this.placeholder,
             readOnly: this.read_only,
+            lineWrapping : true,
             onKeyEvent: $.proxy(this.handle_codemirror_keyevent,this)
         });
         // The tabindex=-1 makes this div focusable.


### PR DESCRIPTION
Trivial one-liner, but it makes the editing of text cells much more user-friendly.

The one downside this has is that long paragraphs will be stored as single lines, and are hence less version control-friendly.  But users who want to manually break lines for this reason can still do so (like they did before).

The ideal solution to keep text lines short for VC but reading cleanly is an editor that can _reflow_ paragraphs intelligently, like most high-power editors can.  But I don't think CM is up there yet, and this seems to be the next best thing.
