### PR TITLE
added key handler for control-s to notebook, seems to work pretty well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build
 *.egg-info
 *~
 *.bak
+*.ipynb

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ build
 *.egg-info
 *~
 *.bak
-*.ipynb

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -70,7 +70,7 @@ var IPython = (function (IPython) {
         if (this.read_only){
             return false;
         }
-
+        
         // note that we are comparing and setting the time to wait at each key press.
         // a better wqy might be to generate a new function on each time change and
         // assign it to CodeCell.prototype.request_tooltip_after_time
@@ -82,7 +82,8 @@ var IPython = (function (IPython) {
         if(event.type === 'keydown' ){
             that.remove_and_cancel_tooltip();
         }
-
+        
+         
         if (event.keyCode === 13 && (event.shiftKey || event.ctrlKey)) {
             // Always ignore shift-enter in CodeMirror as we handle it.
             return true;

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -68,6 +68,7 @@ var IPython = (function (IPython) {
             if ((event.ctrlKey || event.metaKey) && event.keyCode==83) { 
                 IPython.save_widget.save_notebook();
                 event.preventDefault();
+                return false;
             } else if (event.which === 27) {
                 // Intercept escape at highest level to avoid closing 
                 // websocket connection with firefox

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -62,7 +62,13 @@ var IPython = (function (IPython) {
         $(document).keydown(function (event) {
             // console.log(event);
             if (that.read_only) return true;
-            if (event.which === 27) {
+            
+            // Save (CTRL+S) or (AppleKey+S) 
+            //metaKey = applekey on mac
+            if ((event.ctrlKey || event.metaKey) && event.keyCode==83) { 
+                IPython.save_widget.save_notebook();
+                event.preventDefault();
+            } else if (event.which === 27) {
                 // Intercept escape at highest level to avoid closing 
                 // websocket connection with firefox
                 event.preventDefault();

--- a/IPython/frontend/html/notebook/static/js/textcell.js
+++ b/IPython/frontend/html/notebook/static/js/textcell.js
@@ -67,7 +67,7 @@ var IPython = (function (IPython) {
         // handlers and is used to provide custom key handling. Its return
         // value is used to determine if CodeMirror should ignore the event:
         // true = ignore, false = don't ignore.
-
+        
         if (event.keyCode === 13 && (event.shiftKey || event.ctrlKey)) {
             // Always ignore shift-enter in CodeMirror as we handle it.
             return true;


### PR DESCRIPTION
Hi,

There was a thread on the dev list about key bindings and hooking ctrl-save to trigger a new save (http://mail.scipy.org/pipermail/ipython-dev/2012-January/008674.html).

What makes this hard is that the browser will only trigger keyboard events for the element that currently has focus. To see what this means, open a google docs spreadsheet. Hit ctrl-s, and you'll see a quick status in the header that your doc is being saved. Now, click on a menu and leave the menu dropped down - ctrl-s now will ask you to (completely pointlessly) save the html of the page. In google's spreadsheet this oddity is almost never an issue, because you almost never notice this discrepancy as you're almost always keyboard focused on the sheet. 

In the updated UI, notebook's layout has the same convenient property as google docs, where focus is almost always in the notebook element or a child. The only way I was able to end up without focus in the notebook was to click the menu. As long as a menu is dropped down, the ctrl-s triggers the browser's dialog. 

thanks,
fawce

p.s.
This PR is from a branch based on a pull from ellisonbg/master. 
