### PR TITLE
Fix see also in docstrings so API docs build

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -984,7 +984,7 @@ Currently the magic system has the following functions:\n"""
 
         See Also
         --------
-        %reset_selective
+        magic_reset_selective
 
         Examples
         --------
@@ -1095,7 +1095,7 @@ Currently the magic system has the following functions:\n"""
 
         See Also
         --------
-        %reset
+        magic_reset
 
         Examples
         --------


### PR DESCRIPTION
%magic names in See also sections don't seem to agree with Sphinx (or one of our Sphinx extensions), and the docs weren't building.
