### PR TITLE
Don't attempt to tokenize binary files for tracebacks

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -825,13 +825,16 @@ class VerboseTB(TBTools):
                     call = tpl_call_fail % func
             
             # Don't attempt to tokenize binary files.
-            if file.endswith(('.so', '.pyd', '.dll')):
-                frames.append('%s %s\n' % (link,call))
-                continue
+            if not file.endswith(('.py', '.pyw')):
+                if file.endswith(('.pyc','.pyo')):
+                    # Look up the corresponding source file.
+                    file = pyfile.source_from_cache(file)
+                else:
+                    # .so, .pyd, etc.
+                    frames.append('%s %s\n' % (link,call))
+                    continue
 
             def linereader(file=file, lnum=[lnum], getline=linecache.getline):
-                if file.endswith(('.pyc','.pyo')):
-                    file = pyfile.source_from_cache(file)
                 line = getline(file, lnum[0])
                 lnum[0] += 1
                 return line

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -825,14 +825,12 @@ class VerboseTB(TBTools):
                     call = tpl_call_fail % func
             
             # Don't attempt to tokenize binary files.
-            if not file.endswith(('.py', '.pyw')):
-                if file.endswith(('.pyc','.pyo')):
-                    # Look up the corresponding source file.
-                    file = pyfile.source_from_cache(file)
-                else:
-                    # .so, .pyd, etc.
-                    frames.append('%s %s\n' % (link,call))
-                    continue
+            if file.endswith(('.so', '.pyd', '.dll')):
+                frames.append('%s %s\n' % (link,call))
+                continue
+            elif file.endswith(('.pyc','.pyo')):
+                # Look up the corresponding source file.
+                file = pyfile.source_from_cache(file)
 
             def linereader(file=file, lnum=[lnum], getline=linecache.getline):
                 line = getline(file, lnum[0])

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -823,6 +823,11 @@ class VerboseTB(TBTools):
                     # will illustrate the error, if this exception catch is
                     # disabled.
                     call = tpl_call_fail % func
+            
+            # Don't attempt to tokenize binary files.
+            if file.endswith(('.so', '.pyd', '.dll')):
+                frames.append('%s %s\n' % (link,call))
+                continue
 
             def linereader(file=file, lnum=[lnum], getline=linecache.getline):
                 if file.endswith(('.pyc','.pyo')):


### PR DESCRIPTION
Previously we had been trying and just catching the exception, but in corner cases the tokenizer can run for several seconds before raising an exception (#1317). This skips tokenizing if the file has the extension `.so`, `.pyd` or `.dll` (should I add any more to this list?).

Closes gh-1317
