### PR TITLE
Add prototype shutdown button to Notebook dashboard

### DIFF
--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -314,6 +314,7 @@ class PrintNotebookHandler(AuthenticatedHandler):
 
 class ShutdownHandler(AuthenticatedHandler):
     def get(self):
+        self.render('shutdown.html', logged_in=False, login_available=False)
         self.application.ipython_app.ioloop.stop()
 
 #-----------------------------------------------------------------------------

--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -312,6 +312,10 @@ class PrintNotebookHandler(AuthenticatedHandler):
             mathjax_url=self.application.ipython_app.mathjax_url,
         )
 
+class ShutdownHandler(AuthenticatedHandler):
+    def get(self):
+        self.application.ipython_app.ioloop.stop()
+
 #-----------------------------------------------------------------------------
 # Kernel handlers
 #-----------------------------------------------------------------------------

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -49,7 +49,7 @@ from .handlers import (LoginHandler, LogoutHandler,
     ProjectDashboardHandler, NewHandler, NamedNotebookHandler,
     MainKernelHandler, KernelHandler, KernelActionHandler, IOPubHandler,
     ShellHandler, NotebookRootHandler, NotebookHandler, NotebookCopyHandler,
-    RSTHandler, AuthenticatedFileHandler, PrintNotebookHandler
+    RSTHandler, AuthenticatedFileHandler, PrintNotebookHandler, ShutdownHandler
 )
 from .notebookmanager import NotebookManager
 
@@ -106,6 +106,7 @@ class NotebookWebApplication(web.Application):
             (r"/", ProjectDashboardHandler),
             (r"/login", LoginHandler),
             (r"/logout", LogoutHandler),
+            (r"/shutdown", ShutdownHandler),
             (r"/new", NewHandler),
             (r"/%s" % _notebook_id_regex, NamedNotebookHandler),
             (r"/%s/copy" % _notebook_id_regex, NotebookCopyHandler),
@@ -419,8 +420,10 @@ class NotebookApp(BaseIPythonApplication):
             b = lambda : webbrowser.open("%s://%s:%i" % (proto, ip, self.port),
                                          new=2)
             threading.Thread(target=b).start()
+            
+        self.ioloop = ioloop.IOLoop.instance()
         try:
-            ioloop.IOLoop.instance().start()
+            self.ioloop.start()
         except KeyboardInterrupt:
             info("Interrupted...")
         finally:

--- a/IPython/frontend/html/notebook/static/css/projectdashboard.css
+++ b/IPython/frontend/html/notebook/static/css/projectdashboard.css
@@ -49,8 +49,12 @@ body {
     float: left;
 }
 
-#notebooks_buttons {
+#notebooks_buttons, #control_buttons {
     float: right;
+}
+
+#control_toolbar {
+    padding-top: 0.5em;
 }
 
 #project_name {

--- a/IPython/frontend/html/notebook/static/js/menubar.js
+++ b/IPython/frontend/html/notebook/static/js/menubar.js
@@ -67,6 +67,7 @@ var IPython = (function (IPython) {
         this.element.find('button#print_notebook').click(function () {
             IPython.print_widget.print_notebook();
         });
+        this.element.find('#shutdown_server').click(confirm_shutdown);
         // Edit
         this.element.find('#cut_cell').click(function () {
             IPython.notebook.cut_cell();

--- a/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
+++ b/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
@@ -10,7 +10,7 @@
 //============================================================================
 
 
-confirm_shutdown = function (e) {
+confirm_shutdown = function () {
     var dialog = $('<div/>');
     dialog.html('Do you want to shut down the notebook server? ' +
                 'You will lose any unsaved work and all running kernels.');
@@ -61,7 +61,9 @@ $(document).ready(function () {
     $('div#header').css('display','block');
     $('div#main_app').css('display','block');
 
-    $('#shutdown').button().click(confirm_shutdown);
+    $('#shutdown').button().click(function(e) {
+        confirm_shutdown();
+    });
 
 });
 

--- a/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
+++ b/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
@@ -10,6 +10,30 @@
 //============================================================================
 
 
+confirm_shutdown = function (e) {
+    var dialog = $('<div/>');
+    dialog.html('Do you want to shut down the notebook server? ' +
+                'You will lose any unsaved work and all running kernels.');
+    $(document).append(dialog);
+    dialog.dialog({
+        resizable: false,
+        modal: true,
+        title: "Shutdown IPython Notebook?",
+        closeText: '',
+        buttons : {
+            "Shutdown": function () {
+                window.location.href = $('body').data('baseProjectUrl')+'shutdown';
+                $(this).dialog('close');
+            },
+            "Continue running": function () {
+                $(this).dialog('close');
+            }
+        }
+    });
+    
+};
+
+
 $(document).ready(function () {
 
     $('div#header').addClass('border-box-sizing');
@@ -37,28 +61,7 @@ $(document).ready(function () {
     $('div#header').css('display','block');
     $('div#main_app').css('display','block');
 
-    $('#shutdown').button().click(function (e) {
-        var dialog = $('<div/>');
-        dialog.html('Do you want to shut down the notebook server? ' +
-                    'You will lose any unsaved work and all running kernels.');
-        $(document).append(dialog);
-        dialog.dialog({
-            resizable: false,
-            modal: true,
-            title: "Shutdown IPython Notebook?",
-            closeText: '',
-            buttons : {
-                "Shutdown": function () {
-                    window.location.href = $('body').data('baseProjectUrl')+'shutdown';
-                    $(this).dialog('close');
-                },
-                "Continue running": function () {
-                    $(this).dialog('close');
-                }
-            }
-        });
-        
-    });
+    $('#shutdown').button().click(confirm_shutdown);
 
 });
 

--- a/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
+++ b/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
@@ -37,6 +37,9 @@ $(document).ready(function () {
     $('div#header').css('display','block');
     $('div#main_app').css('display','block');
 
+    $('#shutdown').button().click(function (e) {
+        window.location.href = $('body').data('baseProjectUrl')+'shutdown';
+    });
 
 });
 

--- a/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
+++ b/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
@@ -38,7 +38,26 @@ $(document).ready(function () {
     $('div#main_app').css('display','block');
 
     $('#shutdown').button().click(function (e) {
-        window.location.href = $('body').data('baseProjectUrl')+'shutdown';
+        var dialog = $('<div/>');
+        dialog.html('Do you want to shut down the notebook server? ' +
+                    'You will lose any unsaved work and all running kernels.');
+        $(document).append(dialog);
+        dialog.dialog({
+            resizable: false,
+            modal: true,
+            title: "Shutdown IPython Notebook?",
+            closeText: '',
+            buttons : {
+                "Shutdown": function () {
+                    window.location.href = $('body').data('baseProjectUrl')+'shutdown';
+                    $(this).dialog('close');
+                },
+                "Continue running": function () {
+                    $(this).dialog('close');
+                }
+            }
+        });
+        
     });
 
 });

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -77,6 +77,8 @@
                 </li>
                 <hr/>
                 <li id="print_notebook"><a href="/{{notebook_id}}/print" target="_blank">Print View</a></li>
+                <hr/>
+                <li id="shutdown_server"><a href="#">Shutdown Notebooks</a></li>
             </ul>
         </li>
         <li><a href="#">Edit</a>
@@ -221,6 +223,7 @@
 <script src="{{ static_url("js/toolbar.js") }}" type="text/javascript" charset="utf-8"></script>
 <script src="{{ static_url("js/notebook.js") }}" type="text/javascript" charset="utf-8"></script>
 <script src="{{ static_url("js/notebookmain.js") }}" type="text/javascript" charset="utf-8"></script>
+<script src="{{ static_url("js/projectdashboardmain.js") }}" type="text/javascript" charset="utf-8"></script>
 
 </body>
 

--- a/IPython/frontend/html/notebook/templates/projectdashboard.html
+++ b/IPython/frontend/html/notebook/templates/projectdashboard.html
@@ -36,8 +36,10 @@ data-base-kernel-url={{base_kernel_url}}
         <div id="project_name"><h2>{{project}}</h2></div>
     </div>
     
-    <div id="control_buttons">
-        <button id="shutdown">Shutdown Notebook Server</button>
+    <div id="control_toolbar">
+        <span id="control_buttons">
+          <button id="shutdown">Shutdown Notebook Server</button>
+        </span>
     </div>
 {% end %}
 

--- a/IPython/frontend/html/notebook/templates/projectdashboard.html
+++ b/IPython/frontend/html/notebook/templates/projectdashboard.html
@@ -35,6 +35,10 @@ data-base-kernel-url={{base_kernel_url}}
     <div id="notebook_list">
         <div id="project_name"><h2>{{project}}</h2></div>
     </div>
+    
+    <div id="control_buttons">
+        <button id="shutdown">Shutdown Notebook Server</button>
+    </div>
 {% end %}
 
 {% block script %}

--- a/IPython/frontend/html/notebook/templates/shutdown.html
+++ b/IPython/frontend/html/notebook/templates/shutdown.html
@@ -1,0 +1,39 @@
+{% extends layout.html %}
+
+{% block stylesheet %}
+<style type="text/css">
+#app_hbox {
+    width: 100%
+}
+
+#content_panel {
+    width: 800px;
+    margin-left: auto;
+    margin-right: auto;
+    padding-top: 1em;
+}
+
+h1 {
+    font-size: 2em;
+    padding-bottom: 1em;
+}
+
+p {
+    padding-bottom: 1em;
+}
+    
+</style>
+{% end %}
+
+{% block title %}
+(Shutdown) IPython Notebook
+{% end %}
+
+{% block content_panel %}
+<h1>Notebook Shutdown</h1>
+
+<p>The IPython Notebook server has been stopped. You can close this tab.</p>
+
+<p><a href="http://ipython.org/">IPython homepage</a></p>
+
+{% end %}


### PR DESCRIPTION
This adds a shutdown button on the notebook dashboard, which is a prerequisite to be able to run it without a terminal to Ctrl-C it.

It's pretty rough, and there's still quite a bit of work to be done. I thought I'd get it in so people could start telling me better ways to do things.
