### PR TITLE
fixups for alternate URL prefix stuff

### DIFF
--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -410,13 +410,14 @@ class NotebookApp(BaseIPythonApplication):
         ip = self.ip if self.ip else '[all ip addresses on your system]'
         proto = 'https' if self.certfile else 'http'
         info = self.log.info
-        info("The IPython Notebook is running at: %s://%s:%i" % 
-             (proto, ip, self.port) )
+        info("The IPython Notebook is running at: %s://%s:%i%s" %
+             (proto, ip, self.port,self.base_project_url) )
         info("Use Control-C to stop this server and shut down all kernels.")
 
         if self.open_browser:
             ip = self.ip or '127.0.0.1'
-            b = lambda : webbrowser.open("%s://%s:%i" % (proto, ip, self.port),
+            b = lambda : webbrowser.open("%s://%s:%i%s" % (proto, ip, self.port,
+                                                           self.base_project_url),
                                          new=2)
             threading.Thread(target=b).start()
         try:

--- a/docs/source/interactive/htmlnotebook.txt
+++ b/docs/source/interactive/htmlnotebook.txt
@@ -364,13 +364,13 @@ The notebook dashboard (i.e. the default landing page with an overview
 of all your notebooks) typically lives at a URL path of
 "http://localhost:8888/". If you want to have it, and the rest of the
 notebook, live under a sub-directory,
-e.g. "http://localhost:8888/ipython/", you can do so with command-line
-options like these:
+e.g. "http://localhost:8888/ipython/", you can do so with
+configuration options like these (see above for instructions about
+modifying ``ipython_notebook_config.py``)::
 
-  $ ipython notebook --NotebookApp.webapp_settings="\
-         {'base_project_url':'/ipython/', \
-          'base_kernel_url':'/ipython/', \
-          'static_url_prefix':'/ipython/static/'}"
+    c.NotebookApp.base_project_url = '/ipython/'
+    c.NotebookApp.base_kernel_url = '/ipython/'
+    c.NotebookApp.webapp_settings = {'static_url_prefix':'/ipython/static/'}
 
 .. _notebook_format:
 


### PR DESCRIPTION
This fixes a couple of little things that slipped through in the alternate URL prefix branch that was just merged in. (Sorry I didn't notice these before the merge.) 1) update the docs now that some variables are config traits and 2) show and use the correct URL when using a base_project_url other than default.
