### PR TITLE
add IPython.embed_kernel() 

### DIFF
--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -44,6 +44,10 @@ from .config.loader import Config
 from .core import release
 from .core.application import Application
 from .frontend.terminal.embed import embed
+try:
+    from .zmq.ipkernel import embed_kernel
+except ImportError:
+    pass
 from .core.error import TryNext
 from .core.interactiveshell import InteractiveShell
 from .testing import test


### PR DESCRIPTION
This patch adds IPython.embed_kernel() as a public API.
Embedding an IPython kernel in an application is useful when you want to
use IPython.embed() but don't have a terminal attached on stdin and stdout.

My use case is a modern gdb with Python API support
 #!/usr/bin/gdb --python
 import IPython; IPython.embed_kernel()
this way I get to use ipython to explore the GDB API without
the readline librarry in gdb and ipython fighting over the terminal settings.

A Google search revealed that other people were interetsted in this use
case as well:
http://mail.scipy.org/pipermail/ipython-dev/2011-July/007928.html
