### PR TITLE
add IPython.embed_kernel() 

### DIFF
--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -48,7 +48,7 @@ try:
     from .zmq.ipkernel import embed_kernel
 except ImportError:
     def embed_kernel(*args, **kwargs):
-        raise ImportError("IPython.embed_kernel requires pyzmq >= 2.14")
+        raise ImportError("IPython.embed_kernel requires pyzmq >= 2.1.4")
 
 from .core.error import TryNext
 from .core.interactiveshell import InteractiveShell

--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -47,7 +47,9 @@ from .frontend.terminal.embed import embed
 try:
     from .zmq.ipkernel import embed_kernel
 except ImportError:
-    pass
+    def embed_kernel(*args, **kwargs):
+        raise ImportError("IPython.embed_kernel requires pyzmq >= 2.14")
+
 from .core.error import TryNext
 from .core.interactiveshell import InteractiveShell
 from .testing import test

--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -49,6 +49,7 @@ from .core.error import TryNext
 from .core.interactiveshell import InteractiveShell
 from .testing import test
 from .utils.sysinfo import sys_info
+from .utils.frame import caller_module_and_locals
 
 # Release data
 __author__ = ''
@@ -56,13 +57,6 @@ for author, email in release.authors.itervalues():
     __author__ += author + ' <' + email + '>\n'
 __license__  = release.license
 __version__  = release.version
-
-def caller_module_and_locals():
-    """Returns (module, locals) of the caller"""
-    caller = sys._getframe(2)
-    global_ns = caller.f_globals
-    module = sys.modules[global_ns['__name__']]
-    return (module, caller.f_locals)
 
 def embed_kernel(module=None, local_ns=None):
     """Call this to embed an IPython kernel at the current point in your program. """

--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -44,6 +44,10 @@ from .config.loader import Config
 from .core import release
 from .core.application import Application
 from .frontend.terminal.embed import embed
+try:
+    from .zmq.ipkernel import embed_kernel
+except ImportError:
+    pass
 from .core.error import TryNext
 from .core.interactiveshell import InteractiveShell
 from .testing import test

--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -49,7 +49,7 @@ from .core.error import TryNext
 from .core.interactiveshell import InteractiveShell
 from .testing import test
 from .utils.sysinfo import sys_info
-from .utils.frame import caller_module_and_locals
+from .utils.frame import extract_module_locals_above
 
 # Release data
 __author__ = ''
@@ -60,7 +60,7 @@ __version__  = release.version
 
 def embed_kernel(module=None, local_ns=None):
     """Call this to embed an IPython kernel at the current point in your program. """
-    (caller_module, caller_locals) = caller_module_and_locals()
+    (caller_module, caller_locals) = extract_module_locals_above()
     if module is None:
         module = caller_module
     if local_ns is None:

--- a/IPython/utils/frame.py
+++ b/IPython/utils/frame.py
@@ -85,3 +85,10 @@ def debugx(expr,pre_msg=''):
 # deactivate it by uncommenting the following line, which makes it a no-op
 #def debugx(expr,pre_msg=''): pass
 
+def caller_module_and_locals():
+    """Returns (module, locals) of the caller"""
+    caller = sys._getframe(2)
+    global_ns = caller.f_globals
+    module = sys.modules[global_ns['__name__']]
+    return (module, caller.f_locals)
+

--- a/IPython/utils/frame.py
+++ b/IPython/utils/frame.py
@@ -85,10 +85,16 @@ def debugx(expr,pre_msg=''):
 # deactivate it by uncommenting the following line, which makes it a no-op
 #def debugx(expr,pre_msg=''): pass
 
-def caller_module_and_locals():
-    """Returns (module, locals) of the caller"""
-    caller = sys._getframe(2)
-    global_ns = caller.f_globals
+def extract_module_locals(depth=0):
+    """Returns (module, locals) of the funciton `depth` frames away from the caller"""
+    f = sys._getframe(depth + 1)
+    global_ns = f.f_globals
     module = sys.modules[global_ns['__name__']]
-    return (module, caller.f_locals)
+    return (module, f.f_locals)
+
+def extract_module_locals_above():
+    """Returns (module, locals) of the funciton calling the caller.
+    Like extract_module_locals() with a specified depth of 1."""
+    # we're one frame away from the target, the function we call would be two frames away
+    return extract_module_locals(1 + 1)
 

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -70,6 +70,8 @@ class Kernel(Configurable):
     iopub_socket = Instance('zmq.Socket')
     stdin_socket = Instance('zmq.Socket')
     log = Instance(logging.Logger)
+    user_module = Instance('types.ModuleType')
+    user_ns     = Dict(default_value=None)
 
     # Private interface
 
@@ -100,7 +102,7 @@ class Kernel(Configurable):
 
 
 
-    def __init__(self, user_module=None, user_ns=None, **kwargs):
+    def __init__(self, **kwargs):
         super(Kernel, self).__init__(**kwargs)
 
         # Before we even start up the shell, register *first* our exit handlers
@@ -110,8 +112,8 @@ class Kernel(Configurable):
         # Initialize the InteractiveShell subclass
         self.shell = ZMQInteractiveShell.instance(config=self.config,
             profile_dir = self.profile_dir,
-            user_module=user_module,
-            user_ns=user_ns,
+            user_module = self.user_module,
+            user_ns     = self.user_ns,
         )
         self.shell.displayhook.session = self.session
         self.shell.displayhook.pub_socket = self.iopub_socket

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -663,7 +663,9 @@ def embed_kernel(module=None, local_ns=None):
 
 def main():
     """Run an IPKernel as an application"""
-    embed_kernel()
+    app = IPKernelApp.instance()
+    app.initialize()
+    app.start()
 
 
 if __name__ == '__main__':

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -660,7 +660,7 @@ def embed_kernel(module=None, local_ns=None):
     if local_ns is None:
         local_ns = caller_locals
     app = IPKernelApp.instance(user_module=module, user_ns=local_ns)
-    app.initialize()
+    app.initialize([])
     app.start()
 
 def main():

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -645,20 +645,7 @@ def launch_kernel(*args, **kwargs):
     return base_launch_kernel('from IPython.zmq.ipkernel import main; main()',
                               *args, **kwargs)
 
-def caller_module_and_locals():
-    """Returns (module, locals) of the caller"""
-    caller = sys._getframe(1).f_back
-    global_ns = caller.f_globals
-    module = sys.modules[global_ns['__name__']]
-    return (module, caller.f_locals)
-
-def embed_kernel(module=None, local_ns=None):
-    """Call this to embed an IPython kernel at the current point in your program. """
-    (caller_module, caller_locals) = caller_module_and_locals()
-    if module is None:
-        module = caller_module
-    if local_ns is None:
-        local_ns = caller_locals
+def embed_kernel(module, local_ns):
     app = IPKernelApp.instance(user_module=module, user_ns=local_ns)
     app.initialize([])
     app.start()


### PR DESCRIPTION
This is the second submission of this patch, revised to address concerns raised in:
https://github.com/ipython/ipython/pull/1351#issuecomment-3727848
1. Allow IPython.zmq import to fail since IPython does not require zmq to exist.
   This disables the feature.
2. Pass the namespace of the function calling embed_kernel() down as user_ns

This patch adds IPython.embed_kernel() as a public API.
Embedding an IPython kernel in an application is useful when you want to
use IPython.embed() but don't have a terminal attached on stdin and stdout.

My use case is a modern gdb with Python API support
 #!/usr/bin/gdb --python
 import IPython; IPython.embed_kernel()
this way I get to use ipython to explore the GDB API without
the readline librarry in gdb and ipython fighting over the terminal settings.

A Google search revealed that other people were interetsted in this use
case as well:
http://mail.scipy.org/pipermail/ipython-dev/2011-July/007928.html
