### PR TITLE
Don't log complete contents of history replies, even in debug

### DIFF
--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -179,7 +179,6 @@ class IPythonWidget(FrontendWidget):
         """ Implemented to handle history tail replies, which are only supported
             by the IPython kernel.
         """
-        self.log.debug("history: %s", msg.get('content', ''))
         content = msg['content']
         if 'history' not in content:
             self.log.error("History request failed: %r"%content)
@@ -199,6 +198,7 @@ class IPythonWidget(FrontendWidget):
         # reset retry flag
         self._retrying_history_request = False
         history_items = content['history']
+        self.log.debug("Received history reply with %i entries", len(history_items))
         items = []
         last_cell = u""
         for _, _, cell in history_items:

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -391,11 +391,12 @@ class Kernel(Configurable):
 
         else:
             hist = []
-        content = {'history' : list(hist)}
+        hist = list(hist)
+        content = {'history' : hist}
         content = json_clean(content)
         msg = self.session.send(self.shell_socket, 'history_reply',
                                 content, parent, ident)
-        self.log.debug(str(msg))
+        self.log.debug("Sending history reply with %i entries", len(hist))
 
     def connect_request(self, ident, parent):
         if self._recorded_ports is not None:


### PR DESCRIPTION
This changes the debug message to include only the length of the history reply, rather than its entire contents, which gets _huge_, and is an impediment to the legibility of debugging output.
