### PR TITLE
Fix some minor color/style config issues in the qtconsole

### DIFF
--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -137,7 +137,12 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
     font_changed = QtCore.Signal(QtGui.QFont)
 
     #------ Protected class variables ------------------------------------------
-
+    
+    # control handles
+    _control = None
+    _page_control = None
+    _splitter = None
+    
     # When the control key is down, these keys are mapped.
     _ctrl_down_remap = { QtCore.Qt.Key_B : QtCore.Qt.Key_Left,
                          QtCore.Qt.Key_F : QtCore.Qt.Key_Right,
@@ -182,8 +187,6 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
         layout = QtGui.QStackedLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         self._control = self._create_control()
-        self._page_control = None
-        self._splitter = None
         if self.paging in ('hsplit', 'vsplit'):
             self._splitter = QtGui.QSplitter()
             if self.paging == 'hsplit':

--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -533,12 +533,14 @@ class IPythonWidget(FrontendWidget):
         """ Set the style sheets of the underlying widgets.
         """
         self.setStyleSheet(self.style_sheet)
-        self._control.document().setDefaultStyleSheet(self.style_sheet)
-        if self._page_control:
+        if self._control is not None:
+            self._control.document().setDefaultStyleSheet(self.style_sheet)
+            bg_color = self._control.palette().window().color()
+            self._ansi_processor.set_background_color(bg_color)
+        
+        if self._page_control is not None:
             self._page_control.document().setDefaultStyleSheet(self.style_sheet)
 
-        bg_color = self._control.palette().window().color()
-        self._ansi_processor.set_background_color(bg_color)
 
 
     def _syntax_style_changed(self):

--- a/IPython/frontend/qt/console/pygments_highlighter.py
+++ b/IPython/frontend/qt/console/pygments_highlighter.py
@@ -174,7 +174,7 @@ class PygmentsHighlighter(QtGui.QSyntaxHighlighter):
     def _get_format_from_document(self, token, document):
         """ Returns a QTextCharFormat for token by
         """
-        code, html = self._formatter._format_lines([(token, 'dummy')]).next()
+        code, html = self._formatter._format_lines([(token, u'dummy')]).next()
         self._document.setHtml(html)
         return QtGui.QTextCursor(self._document).charFormat()
 

--- a/IPython/frontend/qt/console/styles.py
+++ b/IPython/frontend/qt/console/styles.py
@@ -64,8 +64,8 @@ def hex_to_rgb(color):
         return False
     try:
         r = int(color[:2],16)
-        g = int(color[:2],16)
-        b = int(color[:2],16)
+        g = int(color[2:4],16)
+        b = int(color[4:],16)
     except ValueError:
         return False
     else:


### PR DESCRIPTION
The tabbed code changed a few things about loading styles and stylesheets in the qtconsole, which this resolves, among a couple other small color-related issues:
- tabs other than the first get colors
- IPythonWidget.style_sheet configurable is not clobbered by defaults
- style_sheet configurable would cause a crash, because _style_sheet_changed could be called before _control existed
- fix str->unicode token preventing stylesheets without syntax highlighting from working
- fix typo in the function used to detect whether a bgcolor is dark or light
