### PR TITLE
load header with engine id when engine dies in TaskScheduler

### DIFF
--- a/IPython/parallel/controller/scheduler.py
+++ b/IPython/parallel/controller/scheduler.py
@@ -298,7 +298,13 @@ class TaskScheduler(SessionFactory):
                 raise error.EngineError("Engine %r died while running task %r"%(engine, msg_id))
             except:
                 content = error.wrap_exception()
-            msg = self.session.msg('apply_reply', content, parent=parent, subheader={'status':'error'})
+            # build fake header
+            header = dict(
+                status='error',
+                engine=engine,
+                date=datetime.now(),
+            )
+            msg = self.session.msg('apply_reply', content, parent=parent, subheader=header)
             raw_reply = map(zmq.Message, self.session.serialize(msg, ident=idents))
             # and dispatch it
             self.dispatch_result(raw_reply)


### PR DESCRIPTION
This ensures that the metadata dict on the _Client_ has the engine_uuid of the engine on which the task failed. Previously, this entry would remain empty.

It is identical to code elsewhere (Hub, Client) for constructing the dummy reply when engines die.
