### PR TITLE
allow draft76 websockets (Safari)

### DIFF
--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -393,6 +393,14 @@ class ZMQStreamHandler(websocket.WebSocketHandler):
         else:
             self.write_message(msg)
 
+    def allow_draft76(self):
+        """Allow draft 76, until browsers such as Safari update to RFC 6455.
+        
+        This has been disabled by default in tornado in release 2.2.0, and
+        support will be removed in later versions.
+        """
+        return True
+
 
 class AuthenticatedZMQStreamHandler(ZMQStreamHandler):
 


### PR DESCRIPTION
Safari still uses draft76, and Tornado 2.2.0 release disables access from the draft version by default for security reasons.  This simply sets the tornado flag to True, so we can continue to support Safari until it upgrades to the RFC 6455 implementation.
