### PR TITLE
Saving non-ascii history

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -15,6 +15,7 @@ from __future__ import print_function
 # Stdlib imports
 import atexit
 import datetime
+from io import open as io_open
 import os
 import re
 try:
@@ -808,7 +809,7 @@ def magic_history(self, parameter_s = ''):
                 print('Aborting.')
                 return
             print("Overwriting file.")
-        outfile = open(outfname,'w')
+        outfile = io_open(outfname, 'w', encoding='utf-8')
         close_at_end = True
 
     print_nums = 'n' in opts
@@ -851,10 +852,10 @@ def magic_history(self, parameter_s = ''):
         multiline = "\n" in inline
         line_sep = '\n' if multiline else ' '
         if print_nums:
-            print('%s:%s' % (_format_lineno(session, lineno).rjust(width),
-                    line_sep),  file=outfile, end='')
+            print(u'%s:%s' % (_format_lineno(session, lineno).rjust(width),
+                    line_sep),  file=outfile, end=u'')
         if pyprompts:
-            print(">>> ", end="", file=outfile)
+            print(u">>> ", end=u"", file=outfile)
             if multiline:
                 inline = "\n... ".join(inline.splitlines()) + "\n..."
         print(inline, file=outfile)

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -7,6 +7,7 @@
 
 # stdlib
 import os
+import shutil
 import sys
 import tempfile
 import unittest
@@ -51,6 +52,14 @@ def test_history():
             # Check whether specifying a range beyond the end of the current
             # session results in an error (gh-804)
             ip.magic('%hist 2-500')
+            
+            # Check that we can write non-ascii characters to a file
+            tmpdir = tempfile.mkdtemp()
+            try:
+                ip.magic("%%hist -f %s" % os.path.join(tmpdir, "test1"))
+                ip.magic("%%save %s 1-10" % os.path.join(tmpdir, "test2"))
+            finally:
+                shutil.rmtree(tmpdir)
 
             # New session
             ip.history_manager.reset()

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -32,7 +32,7 @@ def test_history():
         hist_file = os.path.join(tmpdir, 'history.sqlite')
         try:
             ip.history_manager = HistoryManager(shell=ip, hist_file=hist_file)
-            hist = ['a=1', 'def f():\n    test = 1\n    return test', u"b='€Æ¾÷ß'"]
+            hist = [u'a=1', u'def f():\n    test = 1\n    return test', u"b='€Æ¾÷ß'"]
             for i, h in enumerate(hist, start=1):
                 ip.history_manager.store_inputs(i, h)
 
@@ -54,12 +54,10 @@ def test_history():
             ip.magic('%hist 2-500')
             
             # Check that we can write non-ascii characters to a file
-            tmpdir = tempfile.mkdtemp()
-            try:
-                ip.magic("%%hist -f %s" % os.path.join(tmpdir, "test1"))
-                ip.magic("%%save %s 1-10" % os.path.join(tmpdir, "test2"))
-            finally:
-                shutil.rmtree(tmpdir)
+            ip.magic("%%hist -f %s" % os.path.join(tmpdir, "test1"))
+            ip.magic("%%hist -pf %s" % os.path.join(tmpdir, "test2"))
+            ip.magic("%%hist -nf %s" % os.path.join(tmpdir, "test3"))
+            ip.magic("%%save %s 1-10" % os.path.join(tmpdir, "test4"))
 
             # New session
             ip.history_manager.reset()


### PR DESCRIPTION
Non ascii history caused problems for the `%hist` command with the -f option to save to file (#1375). This adds a test and fixes it.
