### PR TITLE
Jsd3

### DIFF
--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -563,14 +563,15 @@ var IPython = (function (IPython) {
     };
 
 
-    CodeCell.prototype.append_output = function (json) {
+    CodeCell.prototype.append_output = function (json, dynamic) {
+        // If dynamic is true, javascript output will be eval'd.
         this.expand();
         if (json.output_type === 'pyout') {
-            this.append_pyout(json);
+            this.append_pyout(json, dynamic);
         } else if (json.output_type === 'pyerr') {
             this.append_pyerr(json);
         } else if (json.output_type === 'display_data') {
-            this.append_display_data(json);
+            this.append_display_data(json, dynamic);
         } else if (json.output_type === 'stream') {
             this.append_stream(json);
         };
@@ -585,11 +586,11 @@ var IPython = (function (IPython) {
     };
 
 
-    CodeCell.prototype.append_pyout = function (json) {
+    CodeCell.prototype.append_pyout = function (json, dynamic) {
         n = json.prompt_number || ' ';
         var toinsert = this.create_output_area();
         toinsert.find('div.prompt').addClass('output_prompt').html('Out[' + n + ']:');
-        this.append_mime_type(json, toinsert);
+        this.append_mime_type(json, toinsert, dynamic);
         this.element.find('div.output').append(toinsert);
         // If we just output latex, typeset it.
         if ((json.latex !== undefined) || (json.html !== undefined)) {
@@ -641,9 +642,9 @@ var IPython = (function (IPython) {
     };
 
 
-    CodeCell.prototype.append_display_data = function (json) {
+    CodeCell.prototype.append_display_data = function (json, dynamic) {
         var toinsert = this.create_output_area();
-        this.append_mime_type(json, toinsert);
+        this.append_mime_type(json, toinsert, dynamic);
         this.element.find('div.output').append(toinsert);
         // If we just output latex, typeset it.
         if ( (json.latex !== undefined) || (json.html !== undefined) ) {
@@ -652,11 +653,11 @@ var IPython = (function (IPython) {
     };
 
 
-    CodeCell.prototype.append_mime_type = function (json, element) {
-        if (json.html !== undefined) {
+    CodeCell.prototype.append_mime_type = function (json, element, dynamic) {
+        if (json.javascript !== undefined && dynamic) {
+            this.append_javascript(json.javascript, element, dynamic);
+        } else if (json.html !== undefined) {
             this.append_html(json.html, element);
-        } else if (json.javascript !== undefined) {
-            this.append_javascript(json.javascript, element);
         } else if (json.latex !== undefined) {
             this.append_latex(json.latex, element);
         } else if (json.svg !== undefined) {
@@ -678,8 +679,10 @@ var IPython = (function (IPython) {
     };
 
 
-    CodeCell.prototype.append_javascript = function (js, element) {
+    CodeCell.prototype.append_javascript = function (js, e) {
         // We just eval the JS code, element appears in the local scope.
+        var element = $("<div/>").addClass("box_flex1 output_subarea");
+        e.append(element);
         eval(js);
     }
 
@@ -842,7 +845,8 @@ var IPython = (function (IPython) {
             };
             var len = data.outputs.length;
             for (var i=0; i<len; i++) {
-                this.append_output(data.outputs[i]);
+                // append with dynamic=false.
+                this.append_output(data.outputs[i], false);
             };
             if (data.collapsed !== undefined) {
                 if (data.collapsed) {

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -655,6 +655,8 @@ var IPython = (function (IPython) {
     CodeCell.prototype.append_mime_type = function (json, element) {
         if (json.html !== undefined) {
             this.append_html(json.html, element);
+        } else if (json.javascript !== undefined) {
+            this.append_javascript(json.javascript, element);
         } else if (json.latex !== undefined) {
             this.append_latex(json.latex, element);
         } else if (json.svg !== undefined) {
@@ -674,6 +676,12 @@ var IPython = (function (IPython) {
         toinsert.append(html);
         element.append(toinsert);
     };
+
+
+    CodeCell.prototype.append_javascript = function (js, element) {
+        // We just eval the JS code, element appears in the local scope.
+        eval(js);
+    }
 
 
     CodeCell.prototype.append_text = function (data, element, extra_class) {

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -1043,7 +1043,8 @@ var IPython = (function (IPython) {
             json.evalue = content.evalue;
             json.traceback = content.traceback;
         };
-        cell.append_output(json);
+        // append with dynamic=true
+        cell.append_output(json, true);
         this.dirty = true;
     };
 

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -993,7 +993,6 @@ var IPython = (function (IPython) {
         } else if (msg_type === 'status') {
             if (content.execution_state === 'busy') {
                 $([IPython.events]).trigger('status_busy.Kernel');
-                IPython.kernel_status_widget.status_busy();
             } else if (content.execution_state === 'idle') {
                 $([IPython.events]).trigger('status_idle.Kernel');
             } else if (content.execution_state === 'dead') {


### PR DESCRIPTION
Adding handling of dynamic javascript output to the notebook.  I take the JS string and simply call eval on it.  The enclosing scope has the element so the JS code can insert things into the DOM at the right point on the page.  The code is not eval'd when the notebook is loaded or cells are pasted - only when they are executed.

Here is an example:

``` python
from IPython.core.display import Javascript
Javascript("element.html('hi')")
```

Currently, the full jquery/jqueryui libs are available for use.  The JS classes that we use in the client are also available, so users can muck with the notebook itself.  This includes running code in the kernel.  BUT, the kernel will need to be refactored to pull that off.  Once that is done, we should be ready for manipulate/interact style things.

Do we want to ship d3 and load it in the notebook for people to use?  It really needs to be loaded in advance by us.

I can't wait to see how people use this!
