### PR TITLE
Fixing Cell menu to update cell type select box.

### DIFF
--- a/IPython/frontend/html/notebook/static/js/toolbar.js
+++ b/IPython/frontend/html/notebook/static/js/toolbar.js
@@ -125,7 +125,7 @@ var IPython = (function (IPython) {
                 IPython.notebook.to_heading(undefined, 6);
             };
         });
-        $([IPython.events]).on('selected_cell_type_changed', function (event, data) {
+        $([IPython.events]).on('selected_cell_type_changed.Notebook', function (event, data) {
             if (data.cell_type === 'heading') {
                 that.element.find('#cell_type').val(data.cell_type+data.level);
             } else {


### PR DESCRIPTION
A typo had crept in the was causing the cell type select box to not update when the cell type was changed in the Cell menu.  Fixes this issue only.
