### PR TITLE
Xunit & KnownFailure

### DIFF
--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -42,6 +42,8 @@ import warnings
 from IPython.testing import nosepatch
 # Now, proceed to import nose itself
 import nose.plugins.builtin
+from nose.plugins.xunit import Xunit
+from nose import SkipTest
 from nose.core import TestProgram
 
 # Our own imports
@@ -52,7 +54,7 @@ from IPython.utils.sysinfo import sys_info
 
 from IPython.testing import globalipapp
 from IPython.testing.plugin.ipdoctest import IPythonDoctest
-from IPython.external.decorators import KnownFailure
+from IPython.external.decorators import KnownFailure, knownfailureif
 
 pjoin = path.join
 
@@ -78,6 +80,27 @@ warnings.filterwarnings('ignore', 'the sha module is deprecated',
 # Wx on Fedora11 spits these out
 warnings.filterwarnings('ignore', 'wxPython/wxWidgets release number mismatch',
                         UserWarning)
+
+# ------------------------------------------------------------------------------
+# Monkeypatch Xunit to count known failures as skipped.
+# ------------------------------------------------------------------------------
+if not hasattr(Xunit, 'orig_addError'):
+    try:
+        knownfailureif(True)(lambda: None)()
+    except Exception as e:
+        KnownFailureTest = type(e)
+
+
+    def addError(self, test, err, capt=None):
+        if issubclass(err[0], KnownFailureTest):
+            err = (SkipTest,) + err[1:]
+        return self.orig_addError(test, err, capt)
+
+    #xunit.Xunit = Xunit
+
+
+    Xunit.orig_addError = Xunit.addError
+    Xunit.addError = addError
 
 #-----------------------------------------------------------------------------
 # Logic for skipping doctests

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -84,20 +84,16 @@ warnings.filterwarnings('ignore', 'wxPython/wxWidgets release number mismatch',
 # ------------------------------------------------------------------------------
 # Monkeypatch Xunit to count known failures as skipped.
 # ------------------------------------------------------------------------------
-if not hasattr(Xunit, 'orig_addError'):
+def monkeypatch_xunit():
     try:
         knownfailureif(True)(lambda: None)()
     except Exception as e:
         KnownFailureTest = type(e)
 
-
     def addError(self, test, err, capt=None):
         if issubclass(err[0], KnownFailureTest):
             err = (SkipTest,) + err[1:]
         return self.orig_addError(test, err, capt)
-
-    #xunit.Xunit = Xunit
-
 
     Xunit.orig_addError = Xunit.addError
     Xunit.addError = addError
@@ -410,6 +406,9 @@ def run_iptest():
     `iptest all`.  It simply calls nose with appropriate command line flags
     and accepts all of the standard nose arguments.
     """
+    # Apply our monkeypatch to Xunit
+    if not hasattr(Xunit, 'orig_addError'):
+        monkeypatch_xunit()
 
     warnings.filterwarnings('ignore',
         'This will be removed soon.  Use IPython.testing.util instead')


### PR DESCRIPTION
For the buildbots, Xunit currently counts KnownFailures as failures. This monkeypatches it to count them as skips, so we get a clean test run, like this:

https://jenkins.shiningpanda.com/ipython/job/ipython-xunit-test/16/
