### PR TITLE
Fix for %tb magic.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1971,14 +1971,9 @@ class InteractiveShell(SingletonConfigurable, Magic):
         if next_input:
             self.set_next_input(next_input)
 
-        args = arg_s.split(' ',1)
-        magic_name = args[0]
+        magic_name, _, magic_args = arg_s.partition(' ')
         magic_name = magic_name.lstrip(prefilter.ESC_MAGIC)
 
-        try:
-            magic_args = args[1]
-        except IndexError:
-            magic_args = ''
         fn = getattr(self,'magic_'+magic_name,None)
         if fn is None:
             error("Magic function `%s` not found." % magic_name)


### PR DESCRIPTION
In order for the %tb magic to work as expected, no other error can be raised by invoking it. Even if an error is caught immediately, it affects the 'last error' values in sys.

This cuts a try/except block out of `ip.magic()`. Happily, in this case there was a simpler way to do the same thing.
