### PR TITLE
fix %tb after SyntaxError

### DIFF
--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -9,6 +9,8 @@ from __future__ import absolute_import
 #-----------------------------------------------------------------------------
 
 import os
+import sys
+from StringIO import StringIO
 
 import nose.tools as nt
 
@@ -230,6 +232,23 @@ def test_reset_in_length():
 
 def test_time():
     _ip.magic('time None')
+
+def test_tb_syntaxerror():
+    """test %tb after a SyntaxError"""
+    ip = get_ipython()
+    ip.run_cell("for")
+    
+    # trap and validate stdout
+    save_stdout = sys.stdout
+    try:
+        sys.stdout = StringIO()
+        ip.run_cell("%tb")
+        out = sys.stdout.getvalue()
+    finally:
+        sys.stdout = save_stdout
+    # trim output, and only check the last line
+    last_line = out.rstrip().splitlines()[-1].strip()
+    nt.assert_equals(last_line, "SyntaxError: invalid syntax")
 
 
 @py3compat.doctest_refactor_print


### PR DESCRIPTION
Moves `exc_info` extraction to `Shell._get_exc_info`, since it was done twice in different places, and _differently_.

Synchronizes expectations between `showtraceback()` and `showsyntaxerror()`, and ensures that `sys.last_type`, etc. get the right value.

Previously failing test added.

Bug reported by @thisch
