### PR TITLE
Use LaTeX to print various built-in types with the SymPy printing extension

### DIFF
--- a/IPython/extensions/sympyprinting.py
+++ b/IPython/extensions/sympyprinting.py
@@ -72,7 +72,7 @@ def load_ipython_extension(ip):
     if not _loaded:
         plaintext_formatter = ip.display_formatter.formatters['text/plain']
 
-        for cls in (object, tuple, list, set, frozenset, dict, str):
+        for cls in (object, set, frozenset, str):
             plaintext_formatter.for_type(cls, print_basic_unicode)
 
         plaintext_formatter.for_type_by_name(
@@ -87,6 +87,8 @@ def load_ipython_extension(ip):
         png_formatter.for_type_by_name(
             'sympy.core.basic', 'Basic', print_png
         )
+        for cls in (list, tuple, dict, int, long, float):
+            png_formatter.for_type(cls, print_png)
 
         latex_formatter = ip.display_formatter.formatters['text/latex']
         latex_formatter.for_type_by_name(
@@ -95,5 +97,7 @@ def load_ipython_extension(ip):
         latex_formatter.for_type_by_name(
             'sympy.matrices.matrices', 'Matrix', print_latex
         )
-        _loaded = True
+        for cls in (list, tuple, dict, int, long, float):
+            latex_formatter.for_type(cls, print_latex)
 
+        _loaded = True


### PR DESCRIPTION
SymPy's latex() function supports printing lists, tuples, and dicts using
latex notation (it uses bmatrix, pmatrix, and Bmatrix, respectively).  This
provides a more unified experience with SymPy functions that return these
types (such as solve()).

Also print ints, longs, and floats using LaTeX, to get a more unified printing
experience (so that, e.g., `x/x` will print the same as just `1`).  The string
form can always be obtained by using `print`, or 2d unicode printing using
pprint().

SymPy's latex() function doesn't treat set() or frosenset() correctly
presently (see http://code.google.com/p/sympy/issues/detail?id=3062), so for
the present, we leave those alone.

Currently, the printing of lists, tuples, and dicts does not work correctly in
the qtconsole.  Any help fixing this would be appreciated.
