### PR TITLE
fix symlinked /home issue for FreeBSD

### DIFF
--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -201,6 +201,9 @@ def get_home_dir(require_writable=False):
         return py3compat.cast_unicode(root, fs_encoding)
     
     homedir = os.path.expanduser('~')
+    # Next line will make things work even when /home/ is a symlink to
+    # /usr/home as it is on FreeBSD, for example
+    homedir = os.path.realpath(homedir)
     
     if not _writable_dir(homedir) and os.name == 'nt':
         # expanduser failed, use the registry to get the 'My Documents' folder.


### PR DESCRIPTION
this is a one-line fix for ipython's pushd and friends on systems which
symlink /home directories to /usr/home. Here's the error I get on
FreeBSD 9.0 without this PR:

```
======================================================================
FAIL: Test various directory handling operations.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/nose-1.1.2-py2.7.egg/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/usr/home/pi/code/ipython/IPython/core/tests/test_magic.py", line 280, in test_dirops
    nt.assert_equal(curpath(), startdir)
AssertionError: u'/usr/home/pi/.ipython' != u'/usr/home/pi/code/ipython'
- /usr/home/pi/.ipython
?              ^
+ /usr/home/pi/code/ipython
?              ^^^^^

    """Fail immediately, with the given message."""
>>  raise self.failureException(u"u'/usr/home/pi/.ipython' != u'/usr/home/pi/code/ipython'\n- /usr/home/pi/.ipython\n?              ^\n+ /usr/home/pi/code/ipython\n?              ^^^^^\n")

-------------------- >> begin captured stdout << ---------------------
/usr/home/pi/.ipython
/usr/home/pi/code/ipython
/usr/home/pi/.ipython
[Errno 2] No such file or directory: '/usr~/code/ipython'
/usr/home/pi/.ipython
popd -> /usr~/code/ipython

--------------------- >> end captured stdout << ----------------------
```

The reason for the above is this:

```
In [1]: pwd
Out[1]: u'/usr/home/pi'

In [2]: !pwd
/home/pi

In [3]: pushd code
/usr/home/pi/code
Out[3]: [u'/usr~']
```

with this commit:

```
In [1]: pushd
Out[1]: [u'~']
```

and the above failing test passes
