### PR TITLE
Browser selection

### DIFF
--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -291,11 +291,11 @@ class NotebookApp(BaseIPythonApplication):
                         """)
 
     browser = Unicode(u'', config=True,
-                      help="""Specify which browser to use when opening the
-                      notebook. If not specified, the default browser will be
-                      determined by the `webbrowser` standard library module,
-                      which allows setting of the BROWSER environment variable
-                      to override it.
+                      help="""Specify what command to use to invoke a web
+                      browser when opening the notebook. If not specified, the
+                      default browser will be determined by the `webbrowser`
+                      standard library module, which allows setting of the
+                      BROWSER environment variable to override it.
                       """)
     
     read_only = Bool(False, config=True,
@@ -441,7 +441,7 @@ class NotebookApp(BaseIPythonApplication):
 
         if self.open_browser:
             ip = self.ip or '127.0.0.1'
-            if len(self.browser) == 0:
+            if self.browser:
                 browser = webbrowser.get()
             else:
                 browser = webbrowser.get(self.browser)

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -208,6 +208,7 @@ aliases.update({
     'keyfile': 'NotebookApp.keyfile',
     'certfile': 'NotebookApp.certfile',
     'notebook-dir': 'NotebookManager.notebook_dir',
+    'browser': 'NotebookApp.browser',
 })
 
 # remove ipkernel flags that are singletons, and don't make sense in
@@ -280,22 +281,22 @@ class NotebookApp(BaseIPythonApplication):
                       The string should be of the form type:salt:hashed-password.
                       """
     )
-    
+
     open_browser = Bool(True, config=True,
                         help="""Whether to open in a browser after starting.
                         The specific browser used is platform dependent and
                         determined by the python standard library `webbrowser`
-                        module, which allows setting of the BROWSER
-                        environment variable to override it. As a one-time
-                        change, you can start the notebook using:
-
-                            BROWSER=firefox ipython notebook
-
-                        To make the change more permanent, modify your
-                        ~/.bashrc you can include a line like the following:
-
-                            export BROWSER=firefox
+                        module, unless it is overridden using the --browser
+                        (NotebookApp.browser) configuration option.
                         """)
+
+    browser = Unicode(u'', config=True,
+                      help="""Specify which browser to use when opening the
+                      notebook. If not specified, the default browser will be
+                      determined by the `webbrowser` standard library module,
+                      which allows setting of the BROWSER environment variable
+                      to override it.
+                      """)
     
     read_only = Bool(False, config=True,
         help="Whether to prevent editing/execution of notebooks."
@@ -440,7 +441,11 @@ class NotebookApp(BaseIPythonApplication):
 
         if self.open_browser:
             ip = self.ip or '127.0.0.1'
-            b = lambda : webbrowser.open("%s://%s:%i%s" % (proto, ip, self.port,
+            if len(self.browser) == 0:
+                browser = webbrowser.get()
+            else:
+                browser = webbrowser.get(self.browser)
+            b = lambda : browser.open("%s://%s:%i%s" % (proto, ip, self.port,
                                                            self.base_project_url),
                                          new=2)
             threading.Thread(target=b).start()

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -282,7 +282,20 @@ class NotebookApp(BaseIPythonApplication):
     )
     
     open_browser = Bool(True, config=True,
-                        help="Whether to open in a browser after starting.")
+                        help="""Whether to open in a browser after starting.
+                        The specific browser used is platform dependent and
+                        determined by the python standard library `webbrowser`
+                        module, which allows setting of the BROWSER
+                        environment variable to override it. As a one-time
+                        change, you can start the notebook using:
+
+                            BROWSER=firefox ipython notebook
+
+                        To make the change more permanent, modify your
+                        ~/.bashrc you can include a line like the following:
+
+                            export BROWSER=firefox
+                        """)
     
     read_only = Bool(False, config=True,
         help="Whether to prevent editing/execution of notebooks."


### PR DESCRIPTION
Someone in the Astronomy 250: Python for Scientific Computing class asked how one can specify which browser is used for the notebook interface. I found that this was undocumented, and added a description of how one can do it using environment variable BROWSER, since that's what python standard libarary's `webbrowser` module looks at to override the default. This is the first commit in the PR

In talking with @stefanv about it, we decided it's be more pythonic to be able to specifically specify `--browser=foo`, since the environment solution makes a change for any other code that uses the `webbrowser` standard library module and feels awkward if you want to change it to have to change it at the beginning of every command. That's the second commit, but it does not preclude the first (i.e. `$BROWSER` is still respected when `--browser` is not used)
