### PR TITLE
ignore errors in shell.var_expand

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2675,7 +2675,12 @@ class InteractiveShell(SingletonConfigurable, Magic):
         ns = self.user_ns.copy()
         ns.update(sys._getframe(depth+1).f_locals)
         ns.pop('self', None)
-        return formatter.format(cmd, **ns)
+        try:
+            cmd = formatter.format(cmd, **ns)
+        except Exception:
+            # if formatter couldn't format, just let it go untransformed
+            pass
+        return cmd
 
     def mktempfile(self, data=None, prefix='ipython_edit_'):
         """Make a new tempfile and return its filename.

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -235,10 +235,24 @@ class InteractiveShellTestCase(unittest.TestCase):
         ip = get_ipython()
         ip.user_ns['f'] = u'Ca\xf1o'
         self.assertEqual(ip.var_expand(u'echo $f'), u'echo Ca\xf1o')
+        self.assertEqual(ip.var_expand(u'echo {f}'), u'echo Ca\xf1o')
+        self.assertEqual(ip.var_expand(u'echo {f[:-1]}'), u'echo Ca\xf1')
+        self.assertEqual(ip.var_expand(u'echo {1*2}'), u'echo 2')
 
         ip.user_ns['f'] = b'Ca\xc3\xb1o'
         # This should not raise any exception:
         ip.var_expand(u'echo $f')
+    
+    def test_bad_var_expand(self):
+        """var_expand on invalid formats shouldn't raise"""
+        ip = get_ipython()
+        
+        # SyntaxError
+        self.assertEqual(ip.var_expand(u"{'a':5}"), u"{'a':5}")
+        # NameError
+        self.assertEqual(ip.var_expand(u"{asdf}"), u"{asdf}")
+        # ZeroDivisionError
+        self.assertEqual(ip.var_expand(u"{1/0}"), u"{1/0}")
 
 
 class TestSafeExecfileNonAsciiPath(unittest.TestCase):


### PR DESCRIPTION
If an error is raised in the formatter, leave it untransformed.  This means that var_expand("$foo") will return "$foo" if `foo` is undefined, but more importantly it will _not_ raise when var_expand is used on literal code that doesn't expect to be expanded (e.g. %prun arguments).

A few tests included.

The _real_ answer to this problem is to not call var_expand where it shouldn't be called, just as with the argument split.  We really treat all magics as shell options, and we shouldn't, but until we get that whole logic cleaned up, this is a temporary solution.  The only drawback is that `ls $files` will result in `ls $files` instead of NameError if `files` is undefined, which is the most logical behavior.  But valid calls to `%prun` are more important than raising the right error in invalid calls to `ls`.

closes #1412
