### PR TITLE
Conditional import of ctypes in inputhook

### DIFF
--- a/IPython/lib/inputhook.py
+++ b/IPython/lib/inputhook.py
@@ -14,10 +14,14 @@ Inputhook management for GUI event loop integration.
 # Imports
 #-----------------------------------------------------------------------------
 
-import ctypes
+try:
+    import ctypes
+except ImportError:
+    ctypes = None
 import os
 import sys
-import warnings
+
+from IPython.utils.warn import warn
 
 #-----------------------------------------------------------------------------
 # Constants
@@ -98,6 +102,9 @@ class InputHookManager(object):
     """
     
     def __init__(self):
+        if ctypes is None:
+            warn("IPython GUI event loop requires ctypes, %gui will not be available\n")
+            return
         self.PYFUNC = ctypes.PYFUNCTYPE(ctypes.c_int)
         self._apps = {}
         self._reset()

--- a/IPython/zmq/parentpoller.py
+++ b/IPython/zmq/parentpoller.py
@@ -1,5 +1,8 @@
 # Standard library imports.
-import ctypes
+try:
+    import ctypes
+except:
+    ctypes = None
 import os
 import platform
 import time
@@ -54,6 +57,8 @@ class ParentPollerWindows(Thread):
         """
         assert(interrupt_handle or parent_handle)
         super(ParentPollerWindows, self).__init__()
+        if ctypes is None:
+            raise ImportError("ParentPollerWindows requires ctypes")
         self.daemon = True
         self.interrupt_handle = interrupt_handle
         self.parent_handle = parent_handle


### PR DESCRIPTION
This allows IPython to start without ctypes present.  `%gui qt`, etc. will not be functional, and the qtconsole will not work on Windows, where ParentPollerWindows also uses ctypes.

Closes #1394
