### PR TITLE
Fix for tornado check for tornado < 1.1.0

### DIFF
--- a/IPython/frontend/html/notebook/__init__.py
+++ b/IPython/frontend/html/notebook/__init__.py
@@ -6,7 +6,10 @@ try:
     import tornado
 except ImportError:
     raise ImportError(msg)
-else:
-    if tornado.version_info < (2,1,0):
-        raise ImportError(msg+", but you have %s"%tornado.version)
+try:
+    version_info = tornado.version_info
+except AttributeError:
+    raise ImportError(msg + ", but you have < 1.1.0")
+if version_info < (2,1,0):
+    raise ImportError(msg + ", but you have %s" % tornado.version)
 del msg


### PR DESCRIPTION
Tornado < 1.1.0 does not have the `version_info` variable to check.
Debian squeeze has tornado 1.0.1.
