### PR TITLE
Fix for failing testsuite when using --with-xml-coverage on windows.

### DIFF
--- a/IPython/utils/process.py
+++ b/IPython/utils/process.py
@@ -96,11 +96,7 @@ def pycmd2argv(cmd):
         return [cmd]
     else:
         if sys.platform == 'win32':
-            # The -u option here turns on unbuffered output, which is required
-            # on Win32 to prevent wierd conflict and problems with Twisted.
-            # Also, use sys.executable to make sure we are picking up the
-            # right python exe.
-            return [sys.executable, '-u', cmd]
+            return [sys.executable, cmd]
         else:
             return [sys.executable, cmd]
 

--- a/IPython/utils/process.py
+++ b/IPython/utils/process.py
@@ -95,10 +95,8 @@ def pycmd2argv(cmd):
     if ext in ['.exe', '.com', '.bat']:
         return [cmd]
     else:
-        if sys.platform == 'win32':
-            return [sys.executable, cmd]
-        else:
-            return [sys.executable, cmd]
+        return [sys.executable, cmd]
+
 
 def abbrev_cwd():
     """ Return abbreviated version of cwd, e.g. d:mydir """


### PR DESCRIPTION
This is necessary to get the shiningpanda testing on windows to work. Without the fix all tests fail. Using this fix I ran the tests and the results are up on:
https://jenkins.shiningpanda.com/ipython/job/ipython-windows-py27/1/

See #1428 for discussion.
