### PR TITLE
(1) Enable IPython.notebook.kernel.execute to publish display_* even it is not called with a code cell and (2) remove empty html element when execute "display_*"

### DIFF
--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -643,9 +643,13 @@ var IPython = (function (IPython) {
 
 
     CodeCell.prototype.append_display_data = function (json, dynamic) {
-        var toinsert = this.create_output_area();
-        this.append_mime_type(json, toinsert, dynamic);
-        this.element.find('div.output').append(toinsert);
+        if (dynamic && json.javascript) {
+            this.append_mime_type(json, null, dynamic);
+        } else {
+            var toinsert = this.create_output_area();
+            this.append_mime_type(json, toinsert, dynamic);
+            this.element.find('div.output').append(toinsert);
+        } 
         // If we just output latex, typeset it.
         if ( (json.latex !== undefined) || (json.html !== undefined) ) {
             this.typeset();
@@ -679,10 +683,12 @@ var IPython = (function (IPython) {
     };
 
 
-    CodeCell.prototype.append_javascript = function (js, e) {
+    CodeCell.prototype.append_javascript = function (js, e, dynamic) {
         // We just eval the JS code, element appears in the local scope.
-        var element = $("<div/>").addClass("box_flex1 output_subarea");
-        e.append(element);
+        if (!dynamic) {
+            var element = $("<div/>").addClass("box_flex1 output_subarea");
+            e.append(element);
+        }
         eval(js);
     }
 

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -932,8 +932,10 @@ var IPython = (function (IPython) {
         // console.log(reply);
         var cell = this.cell_for_msg(reply.parent_header.msg_id);
         if (msg_type === "execute_reply") {
-            cell.set_input_prompt(content.execution_count);
-            cell.element.removeClass("running");
+            if (cell != null) {
+                cell.set_input_prompt(content.execution_count);
+                cell.element.removeClass("running");
+            }    
             this.dirty = true;
         } else if (msg_type === "complete_reply") {
             cell.finish_completing(content.matched_text, content.matches);
@@ -985,6 +987,16 @@ var IPython = (function (IPython) {
             // message not from this notebook, but should be attached to a cell
             // console.log("Received IOPub message not caused by one of my cells");
             // console.log(reply);
+            if (msg_type == "display_data") {
+                var json = {};
+                json.output_type = msg_type;
+                json = this.convert_mime_types(json, content.data);
+                eval(json.javascript);
+            } else {
+                console.log("Received IOPub message not caused by one of my cells");
+                console.log(reply);
+            }
+
             return;
         }
         var output_types = ['stream','display_data','pyout','pyerr'];


### PR DESCRIPTION
(1) If "IPython.notebook.kernel.execute" is called without a cell attached, the "display_javascript" or "display_html" is currently ignored by Notebook.prototype.handle_shell_reply() since there is no cell associated with the python code execution request.  The patch allows the message type "display_data" to be accepted by Notebook.prototype.handle_shell_reply() even there is no "cell" attached with the initial IPython.notebook.kernel.execute() request.  (For a better design, we might consider to assign such call with special cell id, or make a new type of message.) 

(2) Removing html insertion for "display_*" calls. If we put "display_javascript" in a loop, the current noteboot will insert empty html elements and the output cell might become longer (and empty) than necessary. It looks cleaner not generating those empty element. 

The patches can allow to execute python through html element, e.g., a button created with javascript in an ipython html notebook. (one example: https://github.com/cschin/IPython-Notebook---d3.js-mashup/blob/master/GDP_CO2_Example.ipynb )
