### PR TITLE
Fix pyhton -> python typos

### DIFF
--- a/IPython/core/usage.py
+++ b/IPython/core/usage.py
@@ -322,7 +322,7 @@ Multiline editing
 
 The graphical console is capable of true multiline editing, but it also tries
 to behave intuitively like a terminal when possible.  If you are used to
-IPyhton's old terminal behavior, you should find the transition painless, and
+IPython's old terminal behavior, you should find the transition painless, and
 once you learn a few basic keybindings it will be a much more efficient
 environment.
 

--- a/IPython/quarantine/ipy_profile_doctest.py
+++ b/IPython/quarantine/ipy_profile_doctest.py
@@ -37,7 +37,7 @@ def main():
     # python as possible
     o.pprint = False
     
-    # Use plain exceptions, to also resemble normal pyhton.
+    # Use plain exceptions, to also resemble normal python.
     o.xmode = 'plain'
 
     # Store the activity flag in the metadata bag from the running shell

--- a/docs/attic/ChangeLog
+++ b/docs/attic/ChangeLog
@@ -6915,7 +6915,7 @@
 
 	* Changed @exit to @abort to reflect the fact that it's pretty
 	brutal (a sys.exit()). The difference between @abort and Ctrl-D
-	becomes significant only when IPyhton is embedded: in that case,
+	becomes significant only when IPython is embedded: in that case,
 	C-D closes IPython only, but @abort kills the enclosing program
 	too (unless it had called IPython inside a try catching
 	SystemExit).
@@ -7038,7 +7038,7 @@
 
 2001-12-04  Fernando Perez  <fperez@colorado.edu>
 
-	* Fixed namespace problems. Now builtin/IPyhton/user names get
+	* Fixed namespace problems. Now builtin/IPython/user names get
 	properly reported in their namespace. Internal namespace handling
 	is finally getting decent (not perfect yet, but much better than
 	the ad-hoc mess we had).

--- a/docs/attic/new_design.lyx
+++ b/docs/attic/new_design.lyx
@@ -925,7 +925,7 @@ This section is meant as a working draft for discussions on the possibility
  user community.
 \layout Standard
 
-While IPyhton is (and will remain) a python shell first, it does offer a
+While IPython is (and will remain) a python shell first, it does offer a
  fair amount of system access functionality:
 \layout Standard
 

--- a/docs/source/about/credits.txt
+++ b/docs/source/about/credits.txt
@@ -243,7 +243,7 @@ let us know if we have omitted your name by accident:
 
 * John Hunter <jdhunter-AT-nitace.bsd.uchicago.edu> Matplotlib
   author, helped with all the development of support for matplotlib
-  in IPyhton, including making necessary changes to matplotlib itself.
+  in IPython, including making necessary changes to matplotlib itself.
 
 * Matthew Arnison <maffew-AT-cat.org.au> Bug reports, '%run -d' idea.
 


### PR DESCRIPTION
Nothing major, but I noticed one of these in

```
$ ipython --help
```

and though I might as well fix them all.
