### PR TITLE
Don't build sphinx docs for sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -26,6 +26,7 @@ exclude docs/man/*.1
 prune docs/attic
 prune docs/build
 prune docs/gh-pages
+prune docs/dist
 
 # Patterns to exclude from any directory
 global-exclude *~

--- a/setup.py
+++ b/setup.py
@@ -154,35 +154,6 @@ if len(sys.argv) >= 2 and sys.argv[1] in ('sdist','bdist_rpm'):
                   'cd docs/man && gzip -9c pycolor.1 > pycolor.1.gz'),
                  ]
 
-    # Only build the docs if sphinx is present
-    try:
-        import sphinx
-    except ImportError:
-        pass
-    else:
-        # The Makefile calls the do_sphinx scripts to build html and pdf, so
-        # just one target is enough to cover all manual generation
-
-        # First, compute all the dependencies that can force us to rebuild the
-        # docs.  Start with the main release file that contains metadata
-        docdeps = ['IPython/core/release.py']
-        # Inculde all the reST sources
-        pjoin = os.path.join
-        for dirpath,dirnames,filenames in os.walk('docs/source'):
-            if dirpath in ['_static','_templates']:
-                continue
-            docdeps += [ pjoin(dirpath,f) for f in filenames
-                         if f.endswith('.txt') ]
-        # and the examples
-        for dirpath,dirnames,filenames in os.walk('docs/example'):
-            docdeps += [ pjoin(dirpath,f) for f in filenames
-                         if not f.endswith('~') ]
-        # then, make them all dependencies for the main html docs
-        to_update.append(
-            ('docs/dist/index.html',
-             docdeps,
-             "cd docs && make dist")
-            )
 
     [ target_update(*t) for t in to_update ]
 

--- a/setupbase.py
+++ b/setupbase.py
@@ -287,7 +287,7 @@ def target_update(target,deps,cmd):
     command if target is outdated."""
 
     if target_outdated(target,deps):
-        system(cmd)
+        os.system(cmd)
 
 #---------------------------------------------------------------------------
 # Find scripts


### PR DESCRIPTION
sphinx docs can be fetched separately from [ipython-doc](https://www.github.com/ipython/ipython-doc/tree/gh-pages), as suggested in #64, so there is really no reason anymore to double the size of IPython sdists by including built docs.  This dramatically reduces the time to build an sdist, and shrinks the download size of IPython by half.
