### PR TITLE
1107 - Tab autocompletion can suggest invalid syntax

### DIFF
--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -80,10 +80,15 @@ def module_list(path):
     pjoin = os.path.join
     basename = os.path.basename
 
+    def is_importable_file(path):
+        """Returns True if the provided path is a valid importable module"""
+        name, extension = os.path.splitext( path )
+        return import_re.match(path) and py3compat.isidentifier(name)
+
     # Now find actual path matches for packages or modules
     folder_list = [p for p in folder_list
                    if isfile(pjoin(path, p,'__init__.py'))
-                   or import_re.match(p) ]
+                   or is_importable_file(p) ]
 
     return [basename(p).split('.')[0] for p in folder_list]
 

--- a/IPython/core/tests/test_completerlib.py
+++ b/IPython/core/tests/test_completerlib.py
@@ -76,4 +76,5 @@ class Test_magic_run_completer(unittest.TestCase):
                 open(filename, 'w').close()
 
             s = set( module_completion('import foo') )
-            self.assertFalse( s.intersection(invalid_module_names) )
+            intersection = s.intersection(invalid_module_names)
+            self.assertFalse(intersection, intersection)

--- a/IPython/core/tests/test_completerlib.py
+++ b/IPython/core/tests/test_completerlib.py
@@ -18,8 +18,9 @@ from os.path import join
 import nose.tools as nt
 from nose import SkipTest
 
-from IPython.core.completerlib import magic_run_completer
+from IPython.core.completerlib import magic_run_completer, module_completion
 from IPython.utils import py3compat
+from IPython.utils.tempdir import TemporaryDirectory
 
 
 class MockEvent(object):
@@ -65,3 +66,14 @@ class Test_magic_run_completer(unittest.TestCase):
         match = set(magic_run_completer(mockself, event))
         self.assertEqual(match, set([u"a.py", u"aaø.py"]))
 
+    def test_import_invalid_module(self):
+        """Testing of issue https://github.com/ipython/ipython/issues/1107"""
+        invalid_module_names = set(['foo-bar', 'foo:bar', '10foo'])
+        with TemporaryDirectory() as tmpdir:
+            sys.path.insert( 0, tmpdir )
+            for name in invalid_module_names:
+                filename = os.path.join(tmpdir, name + '.py')
+                open(filename, 'w').close()
+
+            s = set( module_completion('import foo') )
+            self.assertFalse( s.intersection(invalid_module_names) )


### PR DESCRIPTION
We (Python Sheffield - drj11, garym) implemented a fix for #1107 although we are unsure about whether the preference is for is_importable_file in completerlib.module_test to be inside or outside of the function.
