### PR TITLE
Fix for #875 Never build unicode error messages

### DIFF
--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -106,7 +106,7 @@ def get_py_filename(name, force_win32=None):
     if os.path.isfile(name):
         return name
     else:
-        raise IOError,'File `%s` not found.' % name
+        raise IOError,'File `%r` not found.' % name
 
 
 def filefind(filename, path_dirs=None):

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -406,3 +406,10 @@ def test_get_py_filename():
             else:
                 nt.assert_raises(IOError, path.get_py_filename, '"foo with spaces.py"', force_win32=False)
                 nt.assert_raises(IOError, path.get_py_filename, "'foo with spaces.py'", force_win32=False)
+                
+def test_unicode_in_filename():
+    try:
+        # these calls should not throw unicode encode exceptions
+        path.get_py_filename(u'fooéè.py',  force_win32=False)
+    except IOError as ex:
+        str(ex)


### PR DESCRIPTION
Added a test to cover possible functions that could cause a Unicode encoding error. Changed the given example function get_py_filename to now use %r instead of %s for the IOError message.

The added test should be expanded to cover any additional functions that could create an IOError and contain unicode chaaracters
