### PR TITLE
use eval to uncan References

### DIFF
--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -490,4 +490,18 @@ class TestView(ClusterTestCase):
         result = v.apply_sync(rf, 5)
         expected = [ 5*id for id in self.client.ids ]
         self.assertEquals(result, expected)
+    
+    def test_eval_reference(self):
+        v = self.client[self.client.ids[0]]
+        v['g'] = range(5)
+        rg = pmod.Reference('g[0]')
+        echo = lambda x:x
+        self.assertEquals(v.apply_sync(echo, rg), 0)
+    
+    def test_reference_nameerror(self):
+        v = self.client[self.client.ids[0]]
+        r = pmod.Reference('elvis_has_left')
+        echo = lambda x:x
+        self.assertRaisesRemote(NameError, v.apply_sync, echo, r)
+
 

--- a/IPython/utils/pickleutil.py
+++ b/IPython/utils/pickleutil.py
@@ -54,10 +54,8 @@ class Reference(CannedObject):
     def getObject(self, g=None):
         if g is None:
             g = globals()
-        try:
-            return g[self.name]
-        except KeyError:
-            raise NameError("name %r is not defined"%self.name)
+        
+        return eval(self.name, g)
 
 
 class CannedFunction(CannedObject):


### PR DESCRIPTION
as opposed to `dict.get()`

This allows things like `Reference('obj.attr')` or `Reference('obj[item]')`, or even `view.map(Reference('obj.method'), seq)`, rather than requiring an assignment into the global namespace via `execute` before Reference can be used to point to any of these objects.
