### PR TITLE
Fix completion when importing modules in the cwd.

### DIFF
--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -61,6 +61,9 @@ def module_list(path):
     Return the list containing the names of the modules available in the given
     folder.
     """
+    # sys.path has the cwd as an empty string, but isdir/listdir need it as '.'
+    if path == '':
+        path = '.'
 
     if os.path.isdir(path):
         folder_list = os.listdir(path)


### PR DESCRIPTION
While testing #1447, I found that tab completing `import fo<TAB>` when foo.py is in the current directory wasn't working. There's a mismatch between the representation of the cwd in sys.path (as `''`) and that required for isdir and listdir (`'.'`).
