### PR TITLE
allow `ipython help subcommand` syntax

### DIFF
--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -404,6 +404,10 @@ class Application(SingletonConfigurable):
     def parse_command_line(self, argv=None):
         """Parse the command line arguments."""
         argv = sys.argv[1:] if argv is None else argv
+        
+        if argv and argv[0] == 'help':
+            # turn `ipython help notebook` into `ipython notebook -h`
+            argv = argv[1:] + ['-h']
 
         if self.subcommands and len(argv) > 0:
             # we have subcommands, and one may have been specified

--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -67,13 +67,16 @@ ipython --log-level=DEBUG  # set logging to DEBUG
 ipython --profile=foo      # start with profile foo
 
 ipython qtconsole          # start the qtconsole GUI application
-ipython qtconsole -h       # show the help string for the qtconsole subcmd
+ipython help qtconsole     # show the help for the qtconsole subcmd
 
 ipython console            # start the terminal-based console application
-ipython console -h         # show the help string for the console subcmd
+ipython help console       # show the help for the console subcmd
 
 ipython profile create foo # create profile foo w/ default config files
-ipython profile -h         # show the help string for the profile subcmd
+ipython help profile       # show the help for the profile subcmd
+
+ipython notebook           # start the IPython notebook
+ipython help notebook      # show the help for the notebook subcmd
 """
 
 #-----------------------------------------------------------------------------

--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -72,11 +72,11 @@ ipython help qtconsole     # show the help for the qtconsole subcmd
 ipython console            # start the terminal-based console application
 ipython help console       # show the help for the console subcmd
 
-ipython profile create foo # create profile foo w/ default config files
-ipython help profile       # show the help for the profile subcmd
-
 ipython notebook           # start the IPython notebook
 ipython help notebook      # show the help for the notebook subcmd
+
+ipython profile create foo # create profile foo w/ default config files
+ipython help profile       # show the help for the profile subcmd
 """
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
We use git-style subcommands, and should support git-style help to match.

Implementation-wise, simply transforms `ipython help subcommand` to `ipython subcommand -h`

As requested by @jdh2358
