### PR TITLE
simplify IPython.parallel connections and enable Controller Resume

### DIFF
--- a/IPython/parallel/apps/ipcontrollerapp.py
+++ b/IPython/parallel/apps/ipcontrollerapp.py
@@ -367,7 +367,7 @@ class IPControllerApp(BaseParallelApplication):
         # IOPub relay (in a Process)
         q = mq(zmq.PUB, zmq.SUB, zmq.PUB, b'N/A',b'iopub')
         q.bind_in(f.client_url('iopub'))
-        q.setsockopt_in(zmq.IDENTITY, ident+"_iopub")
+        q.setsockopt_in(zmq.IDENTITY, ident + b"_iopub")
         q.bind_out(f.engine_url('iopub'))
         q.setsockopt_out(zmq.SUBSCRIBE, b'')
         q.connect_mon(monitor_url)

--- a/IPython/parallel/apps/ipengineapp.py
+++ b/IPython/parallel/apps/ipengineapp.py
@@ -45,7 +45,7 @@ from IPython.zmq.session import (
 from IPython.config.configurable import Configurable
 
 from IPython.parallel.engine.engine import EngineFactory
-from IPython.parallel.util import disambiguate_url
+from IPython.parallel.util import disambiguate_ip_address
 
 from IPython.utils.importstring import import_item
 from IPython.utils.py3compat import cast_bytes
@@ -225,14 +225,15 @@ class IPEngineApp(BaseParallelApplication):
         
         location = config.EngineFactory.location
         
-        for key in ('registration', 'hb_ping', 'hb_pong', 'mux', 'task', 'control'):
-            d[key] = disambiguate_url(d[key], location)
+        proto, ip = d['interface'].split('://')
+        ip = disambiguate_ip_address(ip)
+        d['interface'] = '%s://%s' % (proto, ip)
         
         # DO NOT allow override of basic URLs, serialization, or exec_key
         # JSON file takes top priority there
-        config.Session.key = asbytes(d['exec_key'])
+        config.Session.key = cast_bytes(d['exec_key'])
         
-        config.EngineFactory.url = d['registration']
+        config.EngineFactory.url = d['interface'] + ':%i' % d['registration']
         
         config.Session.packer = d['pack']
         config.Session.unpacker = d['unpack']

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -449,7 +449,7 @@ class Client(HasTraits):
         # configure and construct the session
         extra_args['packer'] = cfg['pack']
         extra_args['unpacker'] = cfg['unpack']
-        extra_args['key'] = cfg['exec_key']
+        extra_args['key'] = cast_bytes(cfg['exec_key'])
         
         self.session = Session(**extra_args)
 

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -508,8 +508,9 @@ class Client(HasTraits):
         """Update our engines dict and _ids from a dict of the form: {id:uuid}."""
         for k,v in engines.iteritems():
             eid = int(k)
+            if eid not in self._engines:
+                self._ids.append(eid)
             self._engines[eid] = v
-            self._ids.append(eid)
         self._ids = sorted(self._ids)
         if sorted(self._engines.keys()) != range(len(self._engines)) and \
                         self._task_scheme == 'pure' and self._task_socket:
@@ -652,7 +653,7 @@ class Client(HasTraits):
         """Register a new engine, and update our connection info."""
         content = msg['content']
         eid = content['id']
-        d = {eid : content['queue']}
+        d = {eid : content['uuid']}
         self._update_engines(d)
 
     def _unregister_engine(self, msg):

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -466,7 +466,7 @@ class Client(HasTraits):
         self.session = Session(**extra_args)
 
         self._query_socket = self._context.socket(zmq.DEALER)
-        self._query_socket.setsockopt(zmq.IDENTITY, self.session.bsession)
+
         if self._ssh:
             tunnel.tunnel_connection(self._query_socket, url, sshserver, **ssh_kwargs)
         else:
@@ -607,29 +607,21 @@ class Client(HasTraits):
             ident = self.session.bsession
             if content.mux:
                 self._mux_socket = self._context.socket(zmq.DEALER)
-                self._mux_socket.setsockopt(zmq.IDENTITY, ident)
                 connect_socket(self._mux_socket, content.mux)
             if content.task:
                 self._task_scheme, task_addr = content.task
                 self._task_socket = self._context.socket(zmq.DEALER)
-                self._task_socket.setsockopt(zmq.IDENTITY, ident)
                 connect_socket(self._task_socket, task_addr)
             if content.notification:
                 self._notification_socket = self._context.socket(zmq.SUB)
                 connect_socket(self._notification_socket, content.notification)
                 self._notification_socket.setsockopt(zmq.SUBSCRIBE, b'')
-            # if content.query:
-            #     self._query_socket = self._context.socket(zmq.DEALER)
-            #     self._query_socket.setsockopt(zmq.IDENTITY, self.session.bsession)
-            #     connect_socket(self._query_socket, content.query)
             if content.control:
                 self._control_socket = self._context.socket(zmq.DEALER)
-                self._control_socket.setsockopt(zmq.IDENTITY, ident)
                 connect_socket(self._control_socket, content.control)
             if content.iopub:
                 self._iopub_socket = self._context.socket(zmq.SUB)
                 self._iopub_socket.setsockopt(zmq.SUBSCRIBE, b'')
-                self._iopub_socket.setsockopt(zmq.IDENTITY, ident)
                 connect_socket(self._iopub_socket, content.iopub)
             self._update_engines(dict(content.engines))
         else:

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -217,7 +217,9 @@ class Client(HasTraits):
     Parameters
     ----------
 
-    url_or_file : bytes or unicode; zmq url or path to ipcontroller-client.json
+    url_file : str/unicode; path to ipcontroller-client.json
+        This JSON file should contain all the information needed to connect to a cluster,
+        and is likely the only argument needed.
         Connection information for the Hub's registration.  If a json connector
         file is given, then likely no further configuration is necessary.
         [Default: use profile]
@@ -239,14 +241,6 @@ class Client(HasTraits):
         If specified, this will be relayed to the Session for configuration
     username : str
         set username for the session object
-    packer : str (import_string) or callable
-        Can be either the simple keyword 'json' or 'pickle', or an import_string to a
-        function to serialize messages. Must support same input as
-        JSON, and output must be bytes.
-        You can pass a callable directly as `pack`
-    unpacker : str (import_string) or callable
-        The inverse of packer.  Only necessary if packer is specified as *not* one
-        of 'json' or 'pickle'.
 
     #-------------- ssh related args ----------------
     # These are args for configuring the ssh tunnel to be used
@@ -270,17 +264,6 @@ class Client(HasTraits):
     paramiko : bool
         flag for whether to use paramiko instead of shell ssh for tunneling.
         [default: True on win32, False else]
-
-    ------- exec authentication args -------
-    If even localhost is untrusted, you can have some protection against
-    unauthorized execution by signing messages with HMAC digests.
-    Messages are still sent as cleartext, so if someone can snoop your
-    loopback traffic this will not protect your privacy, but will prevent
-    unauthorized execution.
-
-    exec_key : str
-        an authentication key or file containing a key
-        default: None
 
 
     Attributes
@@ -378,8 +361,8 @@ class Client(HasTraits):
         # don't raise on positional args
         return HasTraits.__new__(self, **kw)
 
-    def __init__(self, url_or_file=None, profile=None, profile_dir=None, ipython_dir=None,
-            context=None, debug=False, exec_key=None,
+    def __init__(self, url_file=None, profile=None, profile_dir=None, ipython_dir=None,
+            context=None, debug=False,
             sshserver=None, sshkey=None, password=None, paramiko=None,
             timeout=10, **extra_args
             ):
@@ -391,38 +374,38 @@ class Client(HasTraits):
             context = zmq.Context.instance()
         self._context = context
         self._stop_spinning = Event()
+        
+        if 'url_or_file' in extra_args:
+            url_file = extra_args['url_or_file']
+            warnings.warn("url_or_file arg no longer supported, use url_file", DeprecationWarning)
+        
+        if url_file and util.is_url(url_file):
+            raise ValueError("single urls cannot be specified, url-files must be used.")
 
         self._setup_profile_dir(self.profile, profile_dir, ipython_dir)
+        
         if self._cd is not None:
-            if url_or_file is None:
-                url_or_file = pjoin(self._cd.security_dir, 'ipcontroller-client.json')
-        if url_or_file is None:
+            if url_file is None:
+                url_file = pjoin(self._cd.security_dir, 'ipcontroller-client.json')
+        if url_file is None:
             raise ValueError(
                 "I can't find enough information to connect to a hub!"
-                " Please specify at least one of url_or_file or profile."
+                " Please specify at least one of url_file or profile."
             )
-
-        if not util.is_url(url_or_file):
-            # it's not a url, try for a file
-            if not os.path.exists(url_or_file):
-                if self._cd:
-                    url_or_file = os.path.join(self._cd.security_dir, url_or_file)
-                if not os.path.exists(url_or_file):
-                    raise IOError("Connection file not found: %r" % url_or_file)
-            with open(url_or_file) as f:
-                cfg = json.loads(f.read())
-        else:
-            cfg = {'url':url_or_file}
+        
+        with open(url_file) as f:
+            cfg = json.load(f)
+        
+        self._task_scheme = cfg['task_scheme']
 
         # sync defaults from args, json:
         if sshserver:
             cfg['ssh'] = sshserver
-        if exec_key:
-            cfg['exec_key'] = exec_key
-        exec_key = cfg['exec_key']
+
         location = cfg.setdefault('location', None)
-        cfg['url'] = util.disambiguate_url(cfg['url'], location)
-        url = cfg['url']
+        for key in ('control', 'task', 'mux', 'notification', 'registration'):
+            cfg[key] = util.disambiguate_url(cfg[key], location)
+        url = cfg['registration']
         proto,addr,port = util.split_url(url)
         if location is not None and addr == '127.0.0.1':
             # location specified, and connection is expected to be local
@@ -457,12 +440,10 @@ class Client(HasTraits):
         ssh_kwargs = dict(keyfile=sshkey, password=password, paramiko=paramiko)
 
         # configure and construct the session
-        if exec_key is not None:
-            if os.path.isfile(exec_key):
-                extra_args['keyfile'] = exec_key
-            else:
-                exec_key = cast_bytes(exec_key)
-                extra_args['key'] = exec_key
+        extra_args['packer'] = cfg['pack']
+        extra_args['unpacker'] = cfg['unpack']
+        extra_args['key'] = cfg['exec_key']
+        
         self.session = Session(**extra_args)
 
         self._query_socket = self._context.socket(zmq.DEALER)
@@ -583,7 +564,7 @@ class Client(HasTraits):
         self._connected=True
 
         def connect_socket(s, url):
-            url = util.disambiguate_url(url, self._config['location'])
+            # url = util.disambiguate_url(url, self._config['location'])
             if self._ssh:
                 return tunnel.tunnel_connection(s, url, sshserver, **ssh_kwargs)
             else:
@@ -600,30 +581,28 @@ class Client(HasTraits):
         idents,msg = self.session.recv(self._query_socket,mode=0)
         if self.debug:
             pprint(msg)
-        msg = Message(msg)
-        content = msg.content
-        self._config['registration'] = dict(content)
-        if content.status == 'ok':
-            ident = self.session.bsession
-            if content.mux:
-                self._mux_socket = self._context.socket(zmq.DEALER)
-                connect_socket(self._mux_socket, content.mux)
-            if content.task:
-                self._task_scheme, task_addr = content.task
-                self._task_socket = self._context.socket(zmq.DEALER)
-                connect_socket(self._task_socket, task_addr)
-            if content.notification:
-                self._notification_socket = self._context.socket(zmq.SUB)
-                connect_socket(self._notification_socket, content.notification)
-                self._notification_socket.setsockopt(zmq.SUBSCRIBE, b'')
-            if content.control:
-                self._control_socket = self._context.socket(zmq.DEALER)
-                connect_socket(self._control_socket, content.control)
-            if content.iopub:
-                self._iopub_socket = self._context.socket(zmq.SUB)
-                self._iopub_socket.setsockopt(zmq.SUBSCRIBE, b'')
-                connect_socket(self._iopub_socket, content.iopub)
-            self._update_engines(dict(content.engines))
+        content = msg['content']
+        # self._config['registration'] = dict(content)
+        cfg = self._config
+        if content['status'] == 'ok':
+            self._mux_socket = self._context.socket(zmq.DEALER)
+            connect_socket(self._mux_socket, cfg['mux'])
+
+            self._task_socket = self._context.socket(zmq.DEALER)
+            connect_socket(self._task_socket, cfg['task'])
+
+            self._notification_socket = self._context.socket(zmq.SUB)
+            self._notification_socket.setsockopt(zmq.SUBSCRIBE, b'')
+            connect_socket(self._notification_socket, cfg['notification'])
+
+            self._control_socket = self._context.socket(zmq.DEALER)
+            connect_socket(self._control_socket, cfg['control'])
+
+            self._iopub_socket = self._context.socket(zmq.SUB)
+            self._iopub_socket.setsockopt(zmq.SUBSCRIBE, b'')
+            connect_socket(self._iopub_socket, cfg['iopub'])
+
+            self._update_engines(dict(content['engines']))
         else:
             self._connected = False
             raise Exception("Failed to connect!")

--- a/IPython/parallel/controller/hub.py
+++ b/IPython/parallel/controller/hub.py
@@ -896,7 +896,7 @@ class Hub(SessionFactory):
 
         content = dict(id=eid,status='ok')
         # check if requesting available IDs:
-        if uuid in self.by_ident:
+        if cast_bytes(uuid) in self.by_ident:
             try:
                 raise KeyError("uuid %r in use" % uuid)
             except:
@@ -1014,7 +1014,7 @@ class Hub(SessionFactory):
         self.ids.add(eid)
         self.keytable[eid] = ec.uuid
         self.engines[eid] = ec
-        self.by_ident[ec.uuid] = ec.id
+        self.by_ident[cast_bytes(ec.uuid)] = ec.id
         self.queues[eid] = list()
         self.tasks[eid] = list()
         self.completed[eid] = list()

--- a/IPython/parallel/controller/hub.py
+++ b/IPython/parallel/controller/hub.py
@@ -923,7 +923,7 @@ class Hub(SessionFactory):
                 content=content,
                 ident=reg)
 
-        heart = util.asbytes(uuid)
+        heart = cast_bytes(uuid)
 
         if content['status'] == 'ok':
             if heart in self.heartmonitor.hearts:

--- a/IPython/parallel/controller/hub.py
+++ b/IPython/parallel/controller/hub.py
@@ -585,7 +585,7 @@ class Hub(SessionFactory):
         self.log.info("queue::client %r submitted request %r to %s", client_id, msg_id, eid)
         # Unicode in records
         record['engine_uuid'] = queue_id.decode('ascii')
-        record['client_uuid'] = client_id.decode('ascii')
+        record['client_uuid'] = msg['header']['session']
         record['queue'] = 'mux'
 
         try:
@@ -677,7 +677,7 @@ class Hub(SessionFactory):
             return
         record = init_record(msg)
 
-        record['client_uuid'] = client_id.decode('ascii')
+        record['client_uuid'] = msg['header']['session']
         record['queue'] = 'task'
         header = msg['header']
         msg_id = header['msg_id']
@@ -1205,6 +1205,7 @@ class Hub(SessionFactory):
                 self.db.add_record(msg_id, init_record(msg))
             except Exception:
                 self.log.error("db::DB Error updating record: %s", msg_id, exc_info=True)
+                return finish(error.wrap_exception())
 
         finish(dict(status='ok', resubmitted=resubmitted))
         

--- a/IPython/parallel/controller/scheduler.py
+++ b/IPython/parallel/controller/scheduler.py
@@ -756,11 +756,11 @@ def launch_scheduler(in_addr, out_addr, mon_addr, not_addr, reg_addr, config=Non
         ctx = zmq.Context()
         loop = ioloop.IOLoop()
     ins = ZMQStream(ctx.socket(zmq.ROUTER),loop)
-    ins.setsockopt(zmq.IDENTITY, identity+'_in')
+    ins.setsockopt(zmq.IDENTITY, identity + b'_in')
     ins.bind(in_addr)
 
     outs = ZMQStream(ctx.socket(zmq.ROUTER),loop)
-    outs.setsockopt(zmq.IDENTITY, identity+'_out')
+    outs.setsockopt(zmq.IDENTITY, identity + b'_out')
     outs.bind(out_addr)
     mons = zmqstream.ZMQStream(ctx.socket(zmq.PUB),loop)
     mons.connect(mon_addr)

--- a/IPython/parallel/controller/scheduler.py
+++ b/IPython/parallel/controller/scheduler.py
@@ -189,6 +189,7 @@ class TaskScheduler(SessionFactory):
     engine_stream = Instance(zmqstream.ZMQStream) # engine-facing stream
     notifier_stream = Instance(zmqstream.ZMQStream) # hub-facing sub stream
     mon_stream = Instance(zmqstream.ZMQStream) # hub-facing pub stream
+    query_stream = Instance(zmqstream.ZMQStream) # hub-facing DEALER stream
 
     # internals:
     graph = Dict() # dict by msg_id of [ msg_ids that depend on key ]
@@ -216,6 +217,9 @@ class TaskScheduler(SessionFactory):
         return self.session.bsession
 
     def start(self):
+        self.query_stream.on_recv(self.dispatch_query_reply)
+        self.session.send(self.query_stream, "connection_request", {})
+        
         self.engine_stream.on_recv(self.dispatch_result, copy=False)
         self.client_stream.on_recv(self.dispatch_submission, copy=False)
 
@@ -240,6 +244,24 @@ class TaskScheduler(SessionFactory):
     #-----------------------------------------------------------------------
     # [Un]Registration Handling
     #-----------------------------------------------------------------------
+    
+    
+    def dispatch_query_reply(self, msg):
+        """handle reply to our initial connection request"""
+        try:
+            idents,msg = self.session.feed_identities(msg)
+        except ValueError:
+            self.log.warn("task::Invalid Message: %r",msg)
+            return
+        try:
+            msg = self.session.unserialize(msg)
+        except ValueError:
+            self.log.warn("task::Unauthorized message from: %r"%idents)
+            return
+        
+        content = msg['content']
+        for uuid in content.get('engines', {}).values():
+            self._register_engine(asbytes(uuid))
 
     
     @util.log_errors
@@ -263,7 +285,7 @@ class TaskScheduler(SessionFactory):
             self.log.error("Unhandled message type: %r"%msg_type)
         else:
             try:
-                handler(cast_bytes(msg['content']['queue']))
+                handler(cast_bytes(msg['content']['uuid']))
             except Exception:
                 self.log.error("task::Invalid notification msg: %r", msg, exc_info=True)
 
@@ -714,7 +736,7 @@ class TaskScheduler(SessionFactory):
 
 
 
-def launch_scheduler(in_addr, out_addr, mon_addr, not_addr, config=None,
+def launch_scheduler(in_addr, out_addr, mon_addr, not_addr, reg_addr, config=None,
                         logname='root', log_url=None, loglevel=logging.DEBUG,
                         identity=b'task', in_thread=False):
 
@@ -734,18 +756,21 @@ def launch_scheduler(in_addr, out_addr, mon_addr, not_addr, config=None,
         ctx = zmq.Context()
         loop = ioloop.IOLoop()
     ins = ZMQStream(ctx.socket(zmq.ROUTER),loop)
-    ins.setsockopt(zmq.IDENTITY, identity)
+    ins.setsockopt(zmq.IDENTITY, identity+'_in')
     ins.bind(in_addr)
 
     outs = ZMQStream(ctx.socket(zmq.ROUTER),loop)
-    outs.setsockopt(zmq.IDENTITY, identity)
+    outs.setsockopt(zmq.IDENTITY, identity+'_out')
     outs.bind(out_addr)
     mons = zmqstream.ZMQStream(ctx.socket(zmq.PUB),loop)
     mons.connect(mon_addr)
     nots = zmqstream.ZMQStream(ctx.socket(zmq.SUB),loop)
     nots.setsockopt(zmq.SUBSCRIBE, b'')
     nots.connect(not_addr)
-
+    
+    querys = ZMQStream(ctx.socket(zmq.DEALER),loop)
+    querys.connect(reg_addr)
+    
     # setup logging.
     if in_thread:
         log = Application.instance().log
@@ -757,6 +782,7 @@ def launch_scheduler(in_addr, out_addr, mon_addr, not_addr, config=None,
 
     scheduler = TaskScheduler(client_stream=ins, engine_stream=outs,
                             mon_stream=mons, notifier_stream=nots,
+                            query_stream=querys,
                             loop=loop, log=log,
                             config=config)
     scheduler.start()

--- a/IPython/parallel/controller/scheduler.py
+++ b/IPython/parallel/controller/scheduler.py
@@ -261,7 +261,7 @@ class TaskScheduler(SessionFactory):
         
         content = msg['content']
         for uuid in content.get('engines', {}).values():
-            self._register_engine(asbytes(uuid))
+            self._register_engine(cast_bytes(uuid))
 
     
     @util.log_errors

--- a/IPython/parallel/engine/engine.py
+++ b/IPython/parallel/engine/engine.py
@@ -129,7 +129,7 @@ class EngineFactory(RegistrationFactory):
         self.registrar = zmqstream.ZMQStream(reg, self.loop)
 
 
-        content = dict(queue=self.ident, heartbeat=self.ident, control=self.ident)
+        content = dict(uuid=self.ident)
         self.registrar.on_recv(lambda msg: self.complete_registration(msg, connect, maybe_tunnel))
         # print (self.session.key)
         self.session.send(self.registrar, "registration_request", content=content)

--- a/IPython/zmq/session.py
+++ b/IPython/zmq/session.py
@@ -257,9 +257,11 @@ class Session(Configurable):
         if new.lower() == 'json':
             self.pack = json_packer
             self.unpack = json_unpacker
+            self.unpacker = new
         elif new.lower() == 'pickle':
             self.pack = pickle_packer
             self.unpack = pickle_unpacker
+            self.unpacker = new
         else:
             self.pack = import_item(str(new))
 
@@ -270,9 +272,11 @@ class Session(Configurable):
         if new.lower() == 'json':
             self.pack = json_packer
             self.unpack = json_unpacker
+            self.packer = new
         elif new.lower() == 'pickle':
             self.pack = pickle_packer
             self.unpack = pickle_unpacker
+            self.packer = new
         else:
             self.unpack = import_item(str(new))
 

--- a/docs/source/development/parallel_messages.txt
+++ b/docs/source/development/parallel_messages.txt
@@ -43,9 +43,7 @@ monitor the survival of the Engine process.
 Message type: ``registration_request``::
 
     content = {
-        'queue'   : 'abcd-1234-...', # the MUX queue zmq.IDENTITY
-        'control'   : 'abcd-1234-...', # the control queue zmq.IDENTITY
-        'heartbeat' : 'abcd-1234-...' # the heartbeat zmq.IDENTITY
+        'uuid'   : 'abcd-1234-...', # the zmq.IDENTITY of the engine's sockets
     }
 
 .. note::
@@ -63,10 +61,6 @@ Message type: ``registration_reply``::
         'status' : 'ok', # or 'error'
         # if ok:
         'id' : 0, # int, the engine id
-        'queue' : 'tcp://127.0.0.1:12345', # connection for engine side of the queue
-        'control' : 'tcp://...', # addr for control queue
-        'heartbeat' : ('tcp://...','tcp://...'), # tuple containing two interfaces needed for heartbeat
-        'task' : 'tcp://...', # addr for task queue, or None if no task queue running
     }
 
 Clients use the same socket as engines to start their connections. Connection requests
@@ -84,11 +78,6 @@ Message type: ``connection_reply``::
 
     content = {
         'status' : 'ok', # or 'error'
-        # if ok:
-        'queue' : 'tcp://127.0.0.1:12345', # connection for client side of the MUX queue
-        'task' : ('lru','tcp...'), # routing scheme and addr for task queue (len 2 tuple)
-        'query' : 'tcp...', # addr for methods to query the hub, like queue_request, etc.
-        'control' : 'tcp...', # addr for control methods, like abort, etc.
     }
 
 Heartbeat
@@ -110,13 +99,14 @@ Message type: ``registration_notification``::
 
     content = {
         'id' : 0, # engine ID that has been registered
-        'queue' : 'engine_id' # the IDENT for the engine's queue
+        'uuid' : 'engine_id' # the IDENT for the engine's sockets
     }
 
 Message type : ``unregistration_notification``::
 
     content = {
         'id' : 0 # engine ID that has been unregistered
+        'uuid' : 'engine_id' # the IDENT for the engine's sockets
     }
 
 


### PR DESCRIPTION
Rolls back two-stage connection info, putting more information into the connection files.  This makes it easier to use hand-crafted ssh tunnels, as all ports are read from the file, rather than from the reply to registration/connection requests.

It is no longer possible to connect to the Controller without a connection file.

Adding the serialization method to the connection file also makes it harder for custom serialization to result in a mismatch in configuration between the various objects.
