### PR TITLE
more general fix for #662

### DIFF
--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -217,16 +217,12 @@ def ipexec(fname, options=None):
     full_cmd = '%s %s %s' % (ipython_cmd, cmdargs, full_fname)
     #print >> sys.stderr, 'FULL CMD:', full_cmd # dbg
     out = getoutputerror(full_cmd)
-    # `import readline` causes 'ESC[?1034h' to be the first output sometimes,
-    # so strip that off the front of the first line if it is found
+    # `import readline` causes 'ESC[?1034h' to be output sometimes,
+    # so strip that out before doing comparisons
     if out:
-        first = out[0]
-        m = re.match(r'\x1b\[[^h]+h', first)
-        if m:
-            # strip initial readline escape
-            out = list(out)
-            out[0] = first[len(m.group()):]
-            out = tuple(out)
+        out,err = out
+        out = re.sub(r'\x1b\[[^h]+h', '', out)
+        out = out,err
     return out
 
 

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -216,14 +216,12 @@ def ipexec(fname, options=None):
     full_fname = os.path.join(test_dir, fname)
     full_cmd = '%s %s %s' % (ipython_cmd, cmdargs, full_fname)
     #print >> sys.stderr, 'FULL CMD:', full_cmd # dbg
-    out = getoutputerror(full_cmd)
+    out, err = getoutputerror(full_cmd)
     # `import readline` causes 'ESC[?1034h' to be output sometimes,
     # so strip that out before doing comparisons
     if out:
-        out,err = out
         out = re.sub(r'\x1b\[[^h]+h', '', out)
-        out = out,err
-    return out
+    return out, err
 
 
 def ipexec_validate(fname, expected_out, expected_err='',


### PR DESCRIPTION
Previously, the extra readline output was only stripped from the front, but I have recently seen it (Python 3.2, OSX 10.7) elsewhere, so the replacement is now a general `re.sub`.
