### PR TITLE
fix dangling `buffer` in IPython.parallel.util

### DIFF
--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -234,6 +234,19 @@ class TestView(ClusterTestCase):
         b = view.gather('a', block=True)
         assert_array_equal(b, a)
     
+    @skip_without('numpy')
+    def test_apply_numpy(self):
+        """view.apply(f, ndarray)"""
+        import numpy
+        from numpy.testing.utils import assert_array_equal, assert_array_almost_equal
+        
+        A = numpy.random.random((100,100))
+        view = self.client[-1]
+        for dt in [ 'int32', 'uint8', 'float32', 'float64' ]:
+            B = A.astype(dt)
+            C = view.apply_sync(lambda x:x, B)
+            assert_array_equal(B,C)
+    
     def test_map(self):
         view = self.client[:]
         def f(x):

--- a/IPython/parallel/util.py
+++ b/IPython/parallel/util.py
@@ -41,9 +41,13 @@ from zmq.log import handlers
 
 # IPython imports
 from IPython.config.application import Application
+from IPython.utils import py3compat
 from IPython.utils.pickleutil import can, uncan, canSequence, uncanSequence
 from IPython.utils.newserialized import serialize, unserialize
 from IPython.zmq.log import EnginePUBHandler
+
+if py3compat.PY3:
+    buffer = memoryview
 
 #-----------------------------------------------------------------------------
 # Classes


### PR DESCRIPTION
Prevented numpy arrays from being passed as arguments to view.apply in Python 3.

Previously failing test included.

closes #1401
