### PR TITLE
Fix zero-copy push

### DIFF
--- a/IPython/parallel/client/view.py
+++ b/IPython/parallel/client/view.py
@@ -656,7 +656,7 @@ class DirectView(View):
         # applier = self.apply_sync if block else self.apply_async
         if not isinstance(ns, dict):
             raise TypeError("Must be a dict, not %s"%type(ns))
-        return self._really_apply(util._push, (ns,), block=block, track=track, targets=targets)
+        return self._really_apply(util._push, kwargs=ns, block=block, track=track, targets=targets)
 
     def get(self, key_s):
         """get object(s) by `key_s` from remote namespace

--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -233,6 +233,23 @@ class TestView(ClusterTestCase):
         view.scatter('a', a)
         b = view.gather('a', block=True)
         assert_array_equal(b, a)
+
+    @skip_without('numpy')
+    def test_push_numpy_nocopy(self):
+        import numpy
+        view = self.client[:]
+        a = numpy.arange(64)
+        view['A'] = a
+        @interactive
+        def check_writeable(x):
+            return x.flags.writeable
+        
+        for flag in view.apply_sync(check_writeable, pmod.Reference('A')):
+            self.assertFalse(flag, "array is writeable, push shouldn't have pickled it")
+        
+        view.push(dict(B=a))
+        for flag in view.apply_sync(check_writeable, pmod.Reference('B')):
+            self.assertFalse(flag, "array is writeable, push shouldn't have pickled it")
     
     def test_map(self):
         view = self.client[:]

--- a/IPython/parallel/util.py
+++ b/IPython/parallel/util.py
@@ -351,7 +351,7 @@ def interactive(f):
     return f
 
 @interactive
-def _push(ns):
+def _push(**ns):
     """helper method for implementing `client.push` via `client.apply`"""
     globals().update(ns)
 


### PR DESCRIPTION
zero-copy of numpy arrays only applies to first-level in args/kwargs, but push took a dict as arg.  This simply changes push to pass the same ns as kwargs, so numpy arrays will be properly recognized by the serialization machinery.

Test included.
