### PR TITLE
rename plaintext cell -> raw cell

### DIFF
--- a/IPython/frontend/html/notebook/static/js/menubar.js
+++ b/IPython/frontend/html/notebook/static/js/menubar.js
@@ -130,8 +130,8 @@ var IPython = (function (IPython) {
         this.element.find('#to_markdown').click(function () {
             IPython.notebook.to_markdown();
         });
-        this.element.find('#to_plaintext').click(function () {
-            IPython.notebook.to_plaintext();
+        this.element.find('#to_raw').click(function () {
+            IPython.notebook.to_raw();
         });
         this.element.find('#to_heading1').click(function () {
             IPython.notebook.to_heading(undefined, 1);

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -140,8 +140,8 @@ var IPython = (function (IPython) {
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 84 && that.control_key_active) {
-                // To Plaintext = t
-                that.to_plaintext();
+                // To Raw = t
+                that.to_raw();
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 49 && that.control_key_active) {
@@ -523,8 +523,8 @@ var IPython = (function (IPython) {
                 cell = new IPython.MarkdownCell(this);
             } else if (type === 'html') {
                 cell = new IPython.HTMLCell(this);
-            } else if (type === 'plaintext') {
-                cell = new IPython.PlaintextCell(this);
+            } else if (type === 'raw') {
+                cell = new IPython.RawCell(this);
             } else if (type === 'heading') {
                 cell = new IPython.HeadingCell(this);
             };
@@ -557,8 +557,8 @@ var IPython = (function (IPython) {
                 cell = new IPython.MarkdownCell(this);
             } else if (type === 'html') {
                 cell = new IPython.HTMLCell(this);
-            } else if (type === 'plaintext') {
-                cell = new IPython.PlaintextCell(this);
+            } else if (type === 'raw') {
+                cell = new IPython.RawCell(this);
             } else if (type === 'heading') {
                 cell = new IPython.HeadingCell(this);
             };
@@ -640,14 +640,14 @@ var IPython = (function (IPython) {
     };
 
 
-    Notebook.prototype.to_plaintext = function (index) {
+    Notebook.prototype.to_raw = function (index) {
         var i = this.index_or_selected(index);
         if (this.is_valid_cell_index(i)) {
             var source_element = this.get_cell_element(i);
             var source_cell = source_element.data("cell");
             var target_cell = null;
-            if (!(source_cell instanceof IPython.PlaintextCell)) {
-                target_cell = this.insert_cell_below('plaintext',i);
+            if (!(source_cell instanceof IPython.RawCell)) {
+                target_cell = this.insert_cell_below('raw',i);
                 var text = source_cell.get_text();
                 if (text === source_cell.placeholder) {
                     text = '';

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -1197,6 +1197,11 @@ var IPython = (function (IPython) {
             var new_cell = null;
             for (i=0; i<ncells; i++) {
                 cell_data = new_cells[i];
+                // handle short-lived plaintext name for raw cells
+                if (cell_data.cell_type === 'plaintext'){
+                    cell_data.cell_type = 'raw';
+                }
+                
                 new_cell = this.insert_cell_below(cell_data.cell_type);
                 new_cell.fromJSON(cell_data);
             };

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -1197,7 +1197,8 @@ var IPython = (function (IPython) {
             var new_cell = null;
             for (i=0; i<ncells; i++) {
                 cell_data = new_cells[i];
-                // handle short-lived plaintext name for raw cells
+                // VERSIONHACK: plaintext -> raw
+                // handle never-released plaintext name for raw cells
                 if (cell_data.cell_type === 'plaintext'){
                     cell_data.cell_type = 'raw';
                 }

--- a/IPython/frontend/html/notebook/static/js/quickhelp.js
+++ b/IPython/frontend/html/notebook/static/js/quickhelp.js
@@ -41,7 +41,7 @@ var IPython = (function (IPython) {
             {key: 'Ctrl-m k', help: 'move cell up'},
             {key: 'Ctrl-m y', help: 'code cell'},
             {key: 'Ctrl-m m', help: 'markdown cell'},
-            {key: 'Ctrl-m t', help: 'plaintext cell'},
+            {key: 'Ctrl-m t', help: 'raw cell'},
             {key: 'Ctrl-m 1-6', help: 'heading 1-6 cell'},
             {key: 'Ctrl-m p', help: 'select previous'},
             {key: 'Ctrl-m n', help: 'select next'},

--- a/IPython/frontend/html/notebook/static/js/textcell.js
+++ b/IPython/frontend/html/notebook/static/js/textcell.js
@@ -237,33 +237,33 @@ var IPython = (function (IPython) {
     };
 
 
-    // PlaintextCell
+    // RawCell
 
-    var PlaintextCell = function (notebook) {
+    var RawCell = function (notebook) {
         this.placeholder = "Type plain text and LaTeX: $\\alpha^2$";
         this.code_mirror_mode = 'rst';
         IPython.TextCell.apply(this, arguments);
-        this.cell_type = 'plaintext';
+        this.cell_type = 'raw';
     };
 
 
-    PlaintextCell.prototype = new TextCell();
+    RawCell.prototype = new TextCell();
 
 
-    PlaintextCell.prototype.render = function () {
+    RawCell.prototype.render = function () {
         this.rendered = true;
         this.edit();
     };
 
 
-    PlaintextCell.prototype.select = function () {
+    RawCell.prototype.select = function () {
         IPython.Cell.prototype.select.apply(this);
         this.code_mirror.refresh();
         this.code_mirror.focus();
     };
 
 
-    PlaintextCell.prototype.at_top = function () {
+    RawCell.prototype.at_top = function () {
         var cursor = this.code_mirror.getCursor();
         if (cursor.line === 0) {
             return true;
@@ -273,7 +273,7 @@ var IPython = (function (IPython) {
     };
 
 
-    PlaintextCell.prototype.at_bottom = function () {
+    RawCell.prototype.at_bottom = function () {
         var cursor = this.code_mirror.getCursor();
         if (cursor.line === (this.code_mirror.lineCount()-1)) {
             return true;
@@ -353,7 +353,7 @@ var IPython = (function (IPython) {
     IPython.TextCell = TextCell;
     IPython.HTMLCell = HTMLCell;
     IPython.MarkdownCell = MarkdownCell;
-    IPython.PlaintextCell = PlaintextCell;
+    IPython.RawCell = RawCell;
     IPython.HeadingCell = HeadingCell;
 
 

--- a/IPython/frontend/html/notebook/static/js/toolbar.js
+++ b/IPython/frontend/html/notebook/static/js/toolbar.js
@@ -113,8 +113,8 @@ var IPython = (function (IPython) {
                 IPython.notebook.to_code();
             } else if (cell_type === 'markdown')  {
                 IPython.notebook.to_markdown();
-            } else if (cell_type === 'plaintext')  {
-                IPython.notebook.to_plaintext();
+            } else if (cell_type === 'raw')  {
+                IPython.notebook.to_raw();
             } else if (cell_type === 'heading1')  {
                 IPython.notebook.to_heading(undefined, 1);
             } else if (cell_type === 'heading2')  {

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -107,7 +107,7 @@ data-notebook-id={{notebook_id}}
                 <hr/>
                 <li id="to_code"><a href="#">Code</a></li>
                 <li id="to_markdown"><a href="#">Markdown </a></li>
-                <li id="to_raw"><a href="#">Raw</a></li>
+                <li id="to_raw"><a href="#">Raw Text</a></li>
                 <li id="to_heading1"><a href="#">Heading 1</a></li>
                 <li id="to_heading2"><a href="#">Heading 2</a></li>
                 <li id="to_heading3"><a href="#">Heading 3</a></li>
@@ -171,7 +171,7 @@ data-notebook-id={{notebook_id}}
         <select id="cell_type">
              <option value="code">Code</option>
              <option value="markdown">Markdown</option>
-             <option value="raw">Raw</option>
+             <option value="raw">Raw Text</option>
              <option value="heading1">Heading 1</option>
              <option value="heading2">Heading 2</option>
              <option value="heading3">Heading 3</option>

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -107,7 +107,7 @@ data-notebook-id={{notebook_id}}
                 <hr/>
                 <li id="to_code"><a href="#">Code</a></li>
                 <li id="to_markdown"><a href="#">Markdown </a></li>
-                <li id="to_plaintext"><a href="#">Plaintext</a></li>
+                <li id="to_raw"><a href="#">Raw</a></li>
                 <li id="to_heading1"><a href="#">Heading 1</a></li>
                 <li id="to_heading2"><a href="#">Heading 2</a></li>
                 <li id="to_heading3"><a href="#">Heading 3</a></li>
@@ -171,7 +171,7 @@ data-notebook-id={{notebook_id}}
         <select id="cell_type">
              <option value="code">Code</option>
              <option value="markdown">Markdown</option>
-             <option value="plaintext">Plaintext</option>
+             <option value="raw">Raw</option>
              <option value="heading1">Heading 1</option>
              <option value="heading2">Heading 2</option>
              <option value="heading3">Heading 3</option>

--- a/IPython/nbformat/v3/nbbase.py
+++ b/IPython/nbformat/v3/nbbase.py
@@ -114,6 +114,9 @@ def new_code_cell(input=None, prompt_number=None, outputs=None,
 def new_text_cell(cell_type, source=None, rendered=None):
     """Create a new text cell."""
     cell = NotebookNode()
+    # handle short-lived plaintext name for raw cells
+    if cell_type == 'plaintext':
+        cell_type = 'raw'
     if source is not None:
         cell.source = unicode(source)
     if rendered is not None:

--- a/IPython/nbformat/v3/nbbase.py
+++ b/IPython/nbformat/v3/nbbase.py
@@ -114,7 +114,8 @@ def new_code_cell(input=None, prompt_number=None, outputs=None,
 def new_text_cell(cell_type, source=None, rendered=None):
     """Create a new text cell."""
     cell = NotebookNode()
-    # handle short-lived plaintext name for raw cells
+    # VERSIONHACK: plaintext -> raw
+    # handle never-released plaintext name for raw cells
     if cell_type == 'plaintext':
         cell_type = 'raw'
     if source is not None:

--- a/IPython/nbformat/v3/nbpy.py
+++ b/IPython/nbformat/v3/nbpy.py
@@ -68,6 +68,7 @@ class PyReader(NotebookReader):
                 state = u'markdowncell'
                 cell_lines = []
                 kwargs = {}
+            # VERSIONHACK: plaintext -> raw
             elif line.startswith(u'# <rawcell>') or line.startswith(u'# <plaintextcell>'):
                 cell = self.new_cell(state, cell_lines, **kwargs)
                 if cell is not None:

--- a/IPython/nbformat/v3/nbpy.py
+++ b/IPython/nbformat/v3/nbpy.py
@@ -68,7 +68,7 @@ class PyReader(NotebookReader):
                 state = u'markdowncell'
                 cell_lines = []
                 kwargs = {}
-            elif line.startswith(u'# <rawcell>'):
+            elif line.startswith(u'# <rawcell>') or line.startswith(u'# <plaintextcell>'):
                 cell = self.new_cell(state, cell_lines, **kwargs)
                 if cell is not None:
                     cells.append(cell)

--- a/IPython/nbformat/v3/nbpy.py
+++ b/IPython/nbformat/v3/nbpy.py
@@ -68,11 +68,11 @@ class PyReader(NotebookReader):
                 state = u'markdowncell'
                 cell_lines = []
                 kwargs = {}
-            elif line.startswith(u'# <plaintextcell>'):
+            elif line.startswith(u'# <rawcell>'):
                 cell = self.new_cell(state, cell_lines, **kwargs)
                 if cell is not None:
                     cells.append(cell)
-                state = u'plaintextcell'
+                state = u'rawcell'
                 cell_lines = []
                 kwargs = {}
             elif line.startswith(u'# <headingcell'):
@@ -113,10 +113,10 @@ class PyReader(NotebookReader):
             text = self._remove_comments(lines)
             if text:
                 return new_text_cell(u'markdown',source=text)
-        elif state == u'plaintextcell':
+        elif state == u'rawcell':
             text = self._remove_comments(lines)
             if text:
-                return new_text_cell(u'plaintext',source=text)
+                return new_text_cell(u'raw',source=text)
         elif state == u'headingcell':
             text = self._remove_comments(lines)
             level = kwargs.get('level',1)
@@ -172,10 +172,10 @@ class PyWriter(NotebookWriter):
                         lines.extend([u'# <markdowncell>',u''])
                         lines.extend([u'# ' + line for line in input.splitlines()])
                         lines.append(u'')
-                elif cell.cell_type == u'plaintext':
+                elif cell.cell_type == u'raw':
                     input = cell.get(u'source')
                     if input is not None:
-                        lines.extend([u'# <plaintextcell>',u''])
+                        lines.extend([u'# <rawcell>',u''])
                         lines.extend([u'# ' + line for line in input.splitlines()])
                         lines.append(u'')
                 elif cell.cell_type == u'heading':

--- a/IPython/nbformat/v3/tests/nbexamples.py
+++ b/IPython/nbformat/v3/tests/nbexamples.py
@@ -33,7 +33,7 @@ ws.cells.append(new_text_cell(
 ))
 
 ws.cells.append(new_text_cell(
-    u'plaintext',
+    u'raw',
     source='A random array',
 ))
 
@@ -106,7 +106,7 @@ import numpy
 
 # A random array
 
-# <plaintextcell>
+# <rawcell>
 
 # A random array
 

--- a/IPython/nbformat/v3/tests/test_nbbase.py
+++ b/IPython/nbformat/v3/tests/test_nbbase.py
@@ -59,14 +59,14 @@ class TestCell(TestCase):
         self.assertEquals(tc.source, u'hi')
         self.assertEquals(tc.rendered, u'hi')
 
-    def test_empty_plaintext_cell(self):
-        tc = new_text_cell(u'plaintext')
-        self.assertEquals(tc.cell_type, u'plaintext')
+    def test_empty_raw_cell(self):
+        tc = new_text_cell(u'raw')
+        self.assertEquals(tc.cell_type, u'raw')
         self.assertEquals(u'source' not in tc, True)
         self.assertEquals(u'rendered' not in tc, True)
 
-    def test_plaintext_cell(self):
-        tc = new_text_cell(u'plaintext', 'hi', 'hi')
+    def test_raw_cell(self):
+        tc = new_text_cell(u'raw', 'hi', 'hi')
         self.assertEquals(tc.source, u'hi')
         self.assertEquals(tc.rendered, u'hi')
 


### PR DESCRIPTION
'raw' makes more sense to me as a name for these cells, regarding what we actually intend them to mean.

Raw cells should be _untransformed_ when writing various output formats, as the point of them is to let users pass through IPython to their rendered document format (rst, latex, etc.).  This is different from what is the logical meaning of 'plaintext', which would suggest that the contents should be preserved as unformatted plaintext (e.g. in a `<pre>` tag, or literal block).

Before merging, we should decide what we should do about existing v3 notebooks which use plaintext cells.  As this PR currently stands, these cells will simply be unrecognized.
