### PR TITLE
fix sorting profiles in clustermanager

### DIFF
--- a/IPython/frontend/html/notebook/clustermanager.py
+++ b/IPython/frontend/html/notebook/clustermanager.py
@@ -91,8 +91,7 @@ class ClusterManager(LoggingConfigurable):
 
     def list_profiles(self):
         self.update_profiles()
-        result = [self.profile_info(p) for p in self.profiles.keys()]
-        result.sort()
+        result = [self.profile_info(p) for p in sorted(self.profiles.keys())]
         return result
 
     def check_profile(self, profile):


### PR DESCRIPTION
dicts aren't orderable on Python3.  In any case, these should be sorted by _name_, not by the ordering of the dicts themselves.

closes #1507
