### PR TITLE
Fix indentation bug in IPython/lib/pretty.py

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -155,8 +155,7 @@ class _PrettyPrinterBase(object):
         """like begin_group / end_group but for the with statement."""
         self.begin_group(indent, open)
         try:
-            with self.indent(indent):
-                yield
+            yield
         finally:
             self.end_group(indent, close)
 

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -1,0 +1,49 @@
+"""Tests for IPython.lib.pretty.
+"""
+#-----------------------------------------------------------------------------
+# Copyright (c) 2011, the IPython Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+from __future__ import print_function
+
+# Third-party imports
+import nose.tools as nt
+
+# Our own imports
+from IPython.lib import pretty
+
+#-----------------------------------------------------------------------------
+# Classes and functions
+#-----------------------------------------------------------------------------
+
+class MyList(object):
+    def __init__(self, content):
+        self.content = content
+    def _repr_pretty_(self, p, cycle):
+        if cycle:
+            p.text("MyList(...)")
+        else:
+            with p.group(3, "MyList(", ")"):
+                for (i, child) in enumerate(self.content):
+                    if i:
+                        p.text(",")
+                        p.breakable()
+                    else:
+                        p.breakable("")
+                    p.pretty(child)
+
+
+def test_indentation():
+    """Test correct indentation in groups"""
+    count = 40
+    gotoutput = pretty.pretty(MyList(range(count)))
+    expectedoutput = "MyList(\n" + ",\n".join("   %d" % i for i in range(count)) + ")"
+
+    nt.assert_equals(gotoutput, expectedoutput)


### PR DESCRIPTION
_PrettyPrinterBase.group() was increasing the indentation twice
(once in the call to begin_group() and once in the call to indent()).
Fixed by removing the call to indent().
