### PR TITLE
BUG: Include the name of the exception type in its pretty format.

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -628,7 +628,7 @@ def _exception_pprint(obj, p, cycle):
             obj.__class__.__name__
         )
     step = len(name) + 1
-    p.begin_group(step, '(')
+    p.begin_group(step, name + '(')
     for idx, arg in enumerate(getattr(obj, 'args', ())):
         if idx:
             p.text(',')


### PR DESCRIPTION
Thanks to @doerwalter for noticing this.

Fixes #1518.
