### PR TITLE
only install ipython-qtconsole gui script on Windows

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -315,9 +315,12 @@ def find_scripts(entry_points=False, suffix=''):
             'iptest%s = IPython.testing.iptest:main',
             'irunner%s = IPython.lib.irunner:main'
         ]]
-        gui_scripts = [s % suffix for s in [
-            'ipython%s-qtconsole = IPython.frontend.qt.console.qtconsoleapp:main',
-        ]]
+        gui_scripts = []
+        if sys.platform == 'win32':
+            gui_scripts.extend([s % suffix for s in [
+                'ipython%s-qtconsole = IPython.frontend.qt.console.qtconsoleapp:main',
+            ]])
+        
         scripts = dict(console_scripts=console_scripts, gui_scripts=gui_scripts)
     else:
         parallel_scripts = pjoin('IPython','parallel','scripts')


### PR DESCRIPTION
We only want it on Windows, so we should only make it on Windows.

closes #1516
