### PR TITLE
A hack for auto-complete numpy recarray

### DIFF
--- a/IPython/utils/dir2.py
+++ b/IPython/utils/dir2.py
@@ -81,7 +81,23 @@ def dir2(obj):
         except AttributeError:
             # `obj` lied to hasatter (e.g. Pyro), ignore
             pass
-
+    
+    #hack for numpy recarray auto-complete with no numpy import needed
+    #there should be a place for hook to make a custom list of attribute like this
+    if hasattr(obj, '__array_finalize__'):
+        #guarding other numpy arrays which a.colname is not valid
+        if str(type(obj)) == "<class 'numpy.core.records.recarray'>":
+            try:
+                words.extend(obj.dtype.names) 
+                may_have_dupes = True
+            except TypeError:
+                # This will happen if `obj` is a class and not an instance.
+                pass
+            except AttributeError:
+                # `obj` lied to hasatter (e.g. Pyro), ignore
+                # or dtype doesn't have names attribute
+                pass
+    
     if may_have_dupes:
         # eliminate possible duplicates, as some traits may also
         # appear as normal attributes in the dir() call.
@@ -91,4 +107,3 @@ def dir2(obj):
     # filter out non-string attributes which may be stuffed by dir() calls
     # and poor coding in third-party modules
     return [w for w in words if isinstance(w, basestring)]
-


### PR DESCRIPTION
First of all, I'm not very sure if this is the right place to add this type of functionality.

This hack should be very very useful for those doing data analysis in iPython. When users create a numpy [recarray](http://docs.scipy.org/doc/numpy/reference/generated/numpy.recarray.html), which is basically a table with named row, they probably do not want to remember the field names, especially when the recarray comes out from automagic function like pylab's[csv2rec](http://matplotlib.sourceforge.net/api/mlab_api.html#matplotlib.mlab.csv2rec).

Here is some example

``` python
import numpy as np
r = array([(1.5, 2.5), (3.0, 4.0), (1.0, 3.0)],dtype=[('xxx', '<f4'), ('yyy', '<f4')]).view(np.recarray)
r.<TAB>
```

The tab auto complete will have xxx and yyy in the list.
