### PR TITLE
Tab completion optionally respects __all__ (+ dir2() cleanup)

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -416,7 +416,7 @@ class IPCompleter(Completer):
         When 0: nothing will be excluded.
         """
     )
-    limit_to__all__ = Enum((0,1), default_value=1, config=True,
+    limit_to__all__ = Enum((0,1), default_value=0, config=True,
         help="""Instruct the completer to use __all__ for the completion
         
         Specifically, when completing on ``object.<tab>``.

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -355,7 +355,10 @@ class Completer(Configurable):
             except:
                 return []
 
-        words = dir2(obj)
+        if self.limit_to__all__ and hasattr(obj, '__all__'):
+            words = get__all__entries(obj)
+        else: 
+            words = dir2(obj)
 
         try:
             words = generics.complete_object(obj, words)
@@ -369,6 +372,16 @@ class Completer(Configurable):
         n = len(attr)
         res = ["%s.%s" % (expr, w) for w in words if w[:n] == attr ]
         return res
+
+
+def get__all__entries(obj):
+    """returns the strings in the __all__ attribute"""
+    try:
+        words = getattr(obj,'__all__')
+    except:
+        return []
+    
+    return [w for w in words if isinstance(w, basestring)]
 
 
 class IPCompleter(Completer):
@@ -401,6 +414,16 @@ class IPCompleter(Completer):
         When 1: all 'magic' names (``__foo__``) will be excluded.
         
         When 0: nothing will be excluded.
+        """
+    )
+    limit_to__all__ = Enum((0,1), default_value=1, config=True,
+        help="""Instruct the completer to use __all__ for the completion
+        
+        Specifically, when completing on ``object.<tab>``.
+        
+        When 1: only those names in obj.__all__ will be included.
+        
+        When 0 [default]: the values in the __all__ attribute are ignored
         """
     )
 

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -3753,6 +3753,13 @@ Defaulting color scheme to 'NoColor'"""
                 Whether to merge completion results into a single list
                 If False, only the completion results from the first non-empty completer
                 will be returned.
+	        IPCompleter.limit_to__all__=<Enum>
+    	        Current: 0
+                Choices: (0, 1)
+                Instruct the completer to use __all__ for the completion
+                Specifically, when completing on ``object.<tab>``.
+                When 1: only those names in obj.__all__ will be included.
+                When 0 [default]: the values in the __all__ attribute are ignored
             IPCompleter.greedy=<CBool>
                 Current: False
                 Activate greedy completion

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -229,4 +229,15 @@ def test_omit__names():
     nt.assert_false('ip.__str__' in matches)
     nt.assert_false('ip._hidden_attr' in matches)
     del ip._hidden_attr
-    
+
+def test_get__all__entries_ok():
+  class A(object):
+    __all__ = ['x', 1]
+  words = completer.get__all__entries(A())
+  nt.assert_equal(words, ['x'])
+
+def test_get__all__entries_no__all__ok():
+  class A(object):
+      pass
+  words = completer.get__all__entries(A())
+  nt.assert_equal(words, [])

--- a/IPython/utils/tests/test_dir2.py
+++ b/IPython/utils/tests/test_dir2.py
@@ -1,0 +1,51 @@
+import nose.tools as nt
+from IPython.utils.dir2 import dir2
+
+
+class Base(object):
+    x = 1
+    z = 23
+
+
+def test_base():
+    res = dir2(Base())
+    assert ('x' in res)
+    assert ('z' in res)
+    assert ('y' not in res)
+    assert ('__class__' in res)
+    nt.assert_equal(res.count('x'), 2)  # duplicates
+    nt.assert_equal(res.count('__class__'), 4) # duplicates
+
+def test_SubClass():
+
+    class SubClass(Base):
+        y = 2
+
+    res = dir2(SubClass())
+    assert ('y' in res)
+    nt.assert_equal(res.count('y'), 2) # duplicates,
+    nt.assert_equal(res.count('x'), 3) # duplicates, but fewer than above!
+
+
+def test_SubClass_with_trait_names_method():
+
+    class SubClass(Base):
+        y = 2
+        def trait_names(self):
+            return ['t', 'umbrella']
+
+    res = dir2(SubClass())
+    assert('trait_names' in res)
+    assert('umbrella' in res)
+    nt.assert_equal(res.count('t'), 1)
+
+
+def test_SubClass_with_trait_names_attr():
+    # usecase: trait_names is used in a class describing psychological classification
+
+    class SubClass(Base):
+        y = 2
+        trait_names = 44
+
+    res = dir2(SubClass())
+    assert('trait_names' in res)

--- a/IPython/utils/tests/test_dir2.py
+++ b/IPython/utils/tests/test_dir2.py
@@ -13,8 +13,8 @@ def test_base():
     assert ('z' in res)
     assert ('y' not in res)
     assert ('__class__' in res)
-    nt.assert_equal(res.count('x'), 2)  # duplicates
-    nt.assert_equal(res.count('__class__'), 4) # duplicates
+    nt.assert_equal(res.count('x'), 1)
+    nt.assert_equal(res.count('__class__'), 1)
 
 def test_SubClass():
 
@@ -23,8 +23,8 @@ def test_SubClass():
 
     res = dir2(SubClass())
     assert ('y' in res)
-    nt.assert_equal(res.count('y'), 2) # duplicates,
-    nt.assert_equal(res.count('x'), 3) # duplicates, but fewer than above!
+    nt.assert_equal(res.count('y'), 1)
+    nt.assert_equal(res.count('x'), 1)
 
 
 def test_SubClass_with_trait_names_method():
@@ -37,6 +37,7 @@ def test_SubClass_with_trait_names_method():
     res = dir2(SubClass())
     assert('trait_names' in res)
     assert('umbrella' in res)
+    nt.assert_equal(res[-6:], ['t', 'trait_names','umbrella', 'x','y','z'])
     nt.assert_equal(res.count('t'), 1)
 
 


### PR DESCRIPTION
Patches sent by @drtimcouper.
- Tab completion of attributes can optionally be limited to names defined in `__all__` (if it is defined).
- Cleanup and tests of dir2() function.

The patches ran together a bit, so I took the easy option and stuck them both in one pull request.
