### PR TITLE
use os.getcwdu in NotebookManager

### DIFF
--- a/IPython/frontend/html/notebook/notebookmanager.py
+++ b/IPython/frontend/html/notebook/notebookmanager.py
@@ -34,7 +34,7 @@ from IPython.utils.traitlets import Unicode, List, Dict, Bool
 
 class NotebookManager(LoggingConfigurable):
 
-    notebook_dir = Unicode(os.getcwd(), config=True, help="""
+    notebook_dir = Unicode(os.getcwdu(), config=True, help="""
         The directory to use for notebooks.
     """)
     


### PR DESCRIPTION
prevents unicode error when starting in non-unicode path.

closes #1550
