### PR TITLE
clear_output improvements

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -367,6 +367,11 @@ class Javascript(DisplayObject):
         display function, it will result in the data being displayed
         in the frontend. If the data is a URL, the data will first be
         downloaded and then displayed. 
+        
+        In the Notebook, the containing element will be available as `element`,
+        and jQuery will be available.  The output area starts hidden, so if
+        the js appends content to `element` that should be visible, then
+        it must call `container.show()` to unhide the area.
 
         Parameters
         ----------

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -17,6 +17,8 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
+from __future__ import print_function
+
 from xml.dom import minidom
 
 from .displaypub import (
@@ -496,6 +498,16 @@ def clear_output(stdout=True, stderr=True, other=True):
         (e.g. figures,images,HTML, any result of display()).
     """
     from IPython.core.interactiveshell import InteractiveShell
-    InteractiveShell.instance().display_pub.clear_output(
-        stdout=stdout, stderr=stderr, other=other,
-    )
+    if InteractiveShell.initialized():
+        InteractiveShell.instance().display_pub.clear_output(
+            stdout=stdout, stderr=stderr, other=other,
+        )
+    else:
+        from IPython.utils import io
+        if stdout:
+            print('\033[2K\r', file=io.stdout, end='')
+            io.stdout.flush()
+        if stderr:
+            print('\033[2K\r', file=io.stderr, end='')
+            io.stderr.flush()
+        

--- a/IPython/core/displaypub.py
+++ b/IPython/core/displaypub.py
@@ -30,6 +30,7 @@ Authors:
 from __future__ import print_function
 
 from IPython.config.configurable import Configurable
+from IPython.utils import io
 
 #-----------------------------------------------------------------------------
 # Main payload class
@@ -99,14 +100,20 @@ class DisplayPublisher(Configurable):
             arbitrary key, value pairs that frontends can use to interpret
             the data.
         """
-        from IPython.utils import io
+
         # The default is to simply write the plain text data using io.stdout.
         if data.has_key('text/plain'):
             print(data['text/plain'], file=io.stdout)
 
-        def clear_output(self, stdout=True, stderr=True, other=True):
-            """Clear the output of the cell receiving output."""
-            pass
+    def clear_output(self, stdout=True, stderr=True, other=True):
+        """Clear the output of the cell receiving output."""
+        if stdout:
+            print('\033[2K\r', file=io.stdout, end='')
+            io.stdout.flush()
+        if stderr:
+            print('\033[2K\r', file=io.stderr, end='')
+            io.stderr.flush()
+            
 
 
 def publish_display_data(source, data, metadata=None):

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -690,6 +690,9 @@ var IPython = (function (IPython) {
         // We just eval the JS code, element appears in the local scope.
         var element = $("<div/>").addClass("box_flex1 output_subarea");
         e.append(element);
+        // Div for js shouldn't be drawn, as it will add empty height to the area.
+        e.hide();
+
         eval(js);
     }
 

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -686,13 +686,14 @@ var IPython = (function (IPython) {
     };
 
 
-    CodeCell.prototype.append_javascript = function (js, e) {
+    CodeCell.prototype.append_javascript = function (js, container) {
         // We just eval the JS code, element appears in the local scope.
         var element = $("<div/>").addClass("box_flex1 output_subarea");
-        e.append(element);
+        container.append(element);
         // Div for js shouldn't be drawn, as it will add empty height to the area.
-        e.hide();
-
+        container.hide();
+        // If the Javascript appends content to `element` that should be drawn, then
+        // it must also call `container.show()`.
         eval(js);
     }
 

--- a/IPython/frontend/html/notebook/static/js/utils.js
+++ b/IPython/frontend/html/notebook/static/js/utils.js
@@ -52,12 +52,13 @@ IPython.utils = (function (IPython) {
     // are set in the css file.
     function fixConsole(txt) {
         txt = xmlencode(txt);
-        var re = /\033\[([\d;]*?)m/;
+        var re = /\033\[([\dA-Fa-f;]*?)m/;
         var opened = false;
         var cmds = [];
         var opener = "";
         var closer = "";
-        
+        // \r does nothing, so shouldn't be included
+        txt = txt.replace('\r', '');
         while (re.test(txt)) {
             var cmds = txt.match(re)[1].split(";");
             closer = opened?"</span>":"";

--- a/IPython/zmq/zmqshell.py
+++ b/IPython/zmq/zmqshell.py
@@ -81,8 +81,15 @@ class ZMQDisplayPublisher(DisplayPublisher):
         )
 
     def clear_output(self, stdout=True, stderr=True, other=True):
-        self._flush_streams()
         content = dict(stdout=stdout, stderr=stderr, other=other)
+        
+        if stdout:
+            print('\r', file=sys.stdout, end='')
+        if stderr:
+            print('\r', file=sys.stderr, end='')
+        
+        self._flush_streams()
+        
         self.session.send(
             self.pub_socket, u'clear_output', content,
             parent=self.parent_header


### PR DESCRIPTION
This was a part of PR #1548, but as I kept finding issues, I decided this should be a separate PR.  That PR does depend on this one, and should not be merged before this one.

Changes:
- `clear_output()` clears the line, even in terminal IPython, the QtConsole and plain Python as well, by printing `\r` to streams.
- `clear_output()` avoids the flicker in the notebook by adding a delay, and firing immediately upon the next actual display message.
- `display_javascript` hides its `output_area` element, so using display to run a bunch of javascript doesn't result in ever-growing vertical space.
