### PR TITLE
Fix: openssh_tunnel did not parse port in `server`

### DIFF
--- a/IPython/external/ssh/tunnel.py
+++ b/IPython/external/ssh/tunnel.py
@@ -208,7 +208,9 @@ def openssh_tunnel(lport, rport, server, remoteip='127.0.0.1', keyfile=None, pas
     ssh="ssh "
     if keyfile:
         ssh += "-i " + keyfile
-    cmd = ssh + " -f -L 127.0.0.1:%i:%s:%i %s sleep %i"%(lport, remoteip, rport, server, timeout)
+    username, server, port = _split_server(server)
+    cmd = "%s -p %s -f -L 127.0.0.1:%i:%s:%i %s@%s sleep %i" % (
+        ssh, port, lport, remoteip, rport, username, server, timeout)
     tunnel = pexpect.spawn(cmd)
     failed = False
     while True:


### PR DESCRIPTION
Despite what the docstring of openssh_tunnel mentioned, it did not parse
username in port in the `server` argument.  This patch fixes the problem
so that ipython client can connect to the server over port-forwarded ssh
connection.  For example, you can connect the client by the following
code now::

``` python
  c = Client('/path/to/ipcontroller-client.json',
             sshserver='me@localhost:1234')
```
