### PR TITLE
fix PR #1567

### DIFF
--- a/IPython/external/ssh/tunnel.py
+++ b/IPython/external/ssh/tunnel.py
@@ -208,9 +208,13 @@ def openssh_tunnel(lport, rport, server, remoteip='127.0.0.1', keyfile=None, pas
     ssh="ssh "
     if keyfile:
         ssh += "-i " + keyfile
-    username, server, port = _split_server(server)
-    cmd = "%s -p %s -f -L 127.0.0.1:%i:%s:%i %s@%s sleep %i" % (
-        ssh, port, lport, remoteip, rport, username, server, timeout)
+    
+    if ':' in server:
+        server, port = server.split(':')
+        ssh += " -p %s" % port
+        
+    cmd = "%s -f -L 127.0.0.1:%i:%s:%i %s sleep %i" % (
+        ssh, lport, remoteip, rport, server, timeout)
     tunnel = pexpect.spawn(cmd)
     failed = False
     while True:


### PR DESCRIPTION
PR #1567 fixed an issue where ssh server would not recognize custom ssh server ports.  

However, it broke another case by forcing local username if it is unspecified.

ssh config should be trusted with the default username.
