### PR TITLE
BUG: qtconsole -- non-standard handling of \a and \b. [Fixes #1561]

### DIFF
--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -1553,8 +1553,31 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
                     elif act.action == 'beep':
                         QtGui.qApp.beep()
 
+                    elif act.action == 'backspace':
+                        if not cursor.atBlockStart():
+                            cursor.movePosition(
+                                cursor.PreviousCharacter, cursor.KeepAnchor)
+
+                    elif act.action == 'newline':
+                        cursor.movePosition(cursor.EndOfLine)
+
                 format = self._ansi_processor.get_format()
-                cursor.insertText(substring, format)
+
+                selection = cursor.selectedText()
+                if len(selection) == 0:
+                    cursor.insertText(substring, format)
+                elif substring is not None:
+                    # BS and CR are treated as a change in print
+                    # position, rather than a backwards character
+                    # deletion for output equivalence with (I)Python
+                    # terminal.
+                    if len(substring) >= len(selection):
+                        cursor.insertText(substring, format)
+                    else:
+                        old_text = selection[len(substring):]
+                        cursor.insertText(substring + old_text, format)
+                        cursor.movePosition(cursor.PreviousCharacter,
+                               cursor.KeepAnchor, len(old_text))
         else:
             cursor.insertText(text)
         cursor.endEditBlock()

--- a/IPython/frontend/qt/console/tests/test_console_widget.py
+++ b/IPython/frontend/qt/console/tests/test_console_widget.py
@@ -1,0 +1,40 @@
+# Standard library imports
+import unittest
+
+# System library imports
+from IPython.external.qt import QtGui
+
+# Local imports
+from IPython.frontend.qt.console.console_widget import ConsoleWidget
+
+
+class TestConsoleWidget(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """ Create the application for the test case.
+        """
+        cls._app = QtGui.QApplication([])
+        cls._app.setQuitOnLastWindowClosed(False)
+
+    @classmethod
+    def tearDownClass(cls):
+        """ Exit the application.
+        """
+        QtGui.QApplication.quit()
+
+    def test_special_characters(self):
+        """ Are special characters displayed correctly?
+        """
+        w = ConsoleWidget()
+        cursor = w._get_prompt_cursor()
+
+        test_inputs = ['xyz\b\b=\n', 'foo\b\nbar\n', 'foo\b\nbar\r\n', 'abc\rxyz\b\b=']
+        expected_outputs = [u'x=z\u2029', u'foo\u2029bar\u2029', u'foo\u2029bar\u2029', 'x=z']
+        for i, text in enumerate(test_inputs):
+            w._insert_plain_text(cursor, text)
+            cursor.select(cursor.Document)
+            selection = cursor.selectedText()
+            self.assertEquals(expected_outputs[i], selection)
+            # clear all the text
+            cursor.insertText('')


### PR DESCRIPTION
Fixes #1561 and adds many tests
