### PR TITLE
Examples syntax (avoid errors installing on Python 3)

### DIFF
--- a/docs/examples/core/example-embed.py
+++ b/docs/examples/core/example-embed.py
@@ -9,6 +9,7 @@ embedding which you can cut and paste in your code once you understand how
 things work.
 
 The code in this file is deliberately extra-verbose, meant for learning."""
+from __future__ import print_function
 
 # The basics to get you going:
 
@@ -28,8 +29,8 @@ except NameError:
     prompt_config.in2_template = '   .\\D.: '
     prompt_config.out_template = 'Out<\\#>: '
 else:
-    print "Running nested copies of IPython."
-    print "The prompts for the nested copy have been modified"
+    print("Running nested copies of IPython.")
+    print("The prompts for the nested copy have been modified")
     cfg = Config()
     nested = 1
 
@@ -55,7 +56,7 @@ if not nested:
 ipshell2 = InteractiveShellEmbed(config=cfg,
                         banner1 = 'Second IPython instance.')
 
-print '\nHello. This is printed from the main controller program.\n'
+print('\nHello. This is printed from the main controller program.\n')
 
 # You can then call ipshell() anywhere you need it (with an optional
 # message):
@@ -64,7 +65,7 @@ ipshell('***Called from top level. '
         'Note that if you use %kill_embedded, you can fully deactivate\n'
         'This embedded instance so it will never turn on again')
 
-print '\nBack in caller program, moving along...\n'
+print('\nBack in caller program, moving along...\n')
 
 #---------------------------------------------------------------------------
 # More details:
@@ -101,37 +102,37 @@ ipshell.exit_msg = 'Leaving interpreter - New exit_msg'
 def foo(m):
     s = 'spam'
     ipshell('***In foo(). Try %whos, or print s or m:')
-    print 'foo says m = ',m
+    print('foo says m = ',m)
 
 def bar(n):
     s = 'eggs'
     ipshell('***In bar(). Try %whos, or print s or n:')
-    print 'bar says n = ',n
+    print('bar says n = ',n)
     
 # Some calls to the above functions which will trigger IPython:
-print 'Main program calling foo("eggs")\n'
+print('Main program calling foo("eggs")\n')
 foo('eggs')
 
 # The shell can be put in 'dummy' mode where calls to it silently return. This
 # allows you, for example, to globally turn off debugging for a program with a
 # single call.
 ipshell.dummy_mode = True
-print '\nTrying to call IPython which is now "dummy":'
+print('\nTrying to call IPython which is now "dummy":')
 ipshell()
-print 'Nothing happened...'
+print('Nothing happened...')
 # The global 'dummy' mode can still be overridden for a single call
-print '\nOverriding dummy mode manually:'
+print('\nOverriding dummy mode manually:')
 ipshell(dummy=False)
 
 # Reactivate the IPython shell
 ipshell.dummy_mode = False
 
-print 'You can even have multiple embedded instances:'
+print('You can even have multiple embedded instances:')
 ipshell2()
 
-print '\nMain program calling bar("spam")\n'
+print('\nMain program calling bar("spam")\n')
 bar('spam')
 
-print 'Main program finished. Bye!'
+print('Main program finished. Bye!')
 
 #********************** End of file <example-embed.py> ***********************

--- a/docs/examples/lib/example-demo.py
+++ b/docs/examples/lib/example-demo.py
@@ -5,10 +5,11 @@ it on-screen, syntax-highlighted in one shot.  If you add a little simple
 markup, you can stop at specified intervals and return to the ipython prompt,
 resuming execution later.
 """
+from __future__ import print_function
 
-print 'Hello, welcome to an interactive IPython demo.'
-print 'Executing this block should require confirmation before proceeding,'
-print 'unless auto_all has been set to true in the demo object'
+print('Hello, welcome to an interactive IPython demo.')
+print('Executing this block should require confirmation before proceeding,')
+print('unless auto_all has been set to true in the demo object')
 
 # The mark below defines a block boundary, which is a point where IPython will
 # stop execution and return to the interactive prompt.
@@ -23,18 +24,18 @@ y = 2
 # the mark below makes this block as silent
 # <demo> silent
 
-print 'This is a silent block, which gets executed but not printed.'
+print('This is a silent block, which gets executed but not printed.')
 
 # <demo> --- stop ---
 # <demo> auto
-print 'This is an automatic block.'
-print 'It is executed without asking for confirmation, but printed.'
+print('This is an automatic block.')
+print('It is executed without asking for confirmation, but printed.')
 z = x+y
 
-print 'z=',x
+print('z=',x)
 
 # <demo> --- stop ---
 # This is just another normal block.
-print 'z is now:', z
+print('z is now:', z)
 
-print 'bye!'
+print('bye!')

--- a/docs/examples/lib/gui-gtk.py
+++ b/docs/examples/lib/gui-gtk.py
@@ -14,7 +14,7 @@ import gtk
 
 
 def hello_world(wigdet, data=None):
-    print "Hello World"
+    print("Hello World")
 
 def delete_event(widget, event, data=None):
     return False

--- a/docs/examples/lib/gui-tk.py
+++ b/docs/examples/lib/gui-tk.py
@@ -20,7 +20,7 @@ class MyApp:
         self.button.pack(side=LEFT)
 
     def hello_world(self):
-        print "Hello World!"
+        print("Hello World!")
 
 root = Tk()
 

--- a/docs/examples/lib/gui-wx.py
+++ b/docs/examples/lib/gui-wx.py
@@ -69,12 +69,12 @@ class MyFrame(wx.Frame):
 
     def OnTimeToClose(self, evt):
         """Event handler for the button click."""
-        print "See ya later!"
+        print("See ya later!")
         self.Close()
 
     def OnFunButton(self, evt):
         """Event handler for the button click."""
-        print "Having fun yet?"
+        print("Having fun yet?")
 
 
 class MyApp(wx.App):
@@ -82,7 +82,7 @@ class MyApp(wx.App):
         frame = MyFrame(None, "Simple wxPython App")
         self.SetTopWindow(frame)
 
-        print "Print statements go to this stdout window by default."
+        print("Print statements go to this stdout window by default.")
 
         frame.Show(True)
         return True
@@ -96,7 +96,7 @@ if __name__ == '__main__':
     else:
         frame = MyFrame(None, "Simple wxPython App")
         app.SetTopWindow(frame)
-        print "Print statements go to this stdout window by default."
+        print("Print statements go to this stdout window by default.")
         frame.Show(True)
 
     try:

--- a/docs/examples/lib/internal_ipkernel.py
+++ b/docs/examples/lib/internal_ipkernel.py
@@ -41,10 +41,10 @@ class InternalIPKernel(object):
         #self.namespace['ipkernel'] = self.ipkernel  # dbg
 
     def print_namespace(self, evt=None):
-        print "\n***Variables in User namespace***"
+        print("\n***Variables in User namespace***")
         for k, v in self.namespace.iteritems():
             if k not in self._init_keys and not k.startswith('_'):
-                print '%s -> %r' % (k, v)
+                print('%s -> %r' % (k, v))
         sys.stdout.flush()
 
     def new_qt_console(self, evt=None):

--- a/docs/examples/lib/ipkernel_wxapp.py
+++ b/docs/examples/lib/ipkernel_wxapp.py
@@ -90,7 +90,7 @@ class MyFrame(wx.Frame, InternalIPKernel):
 
     def OnTimeToClose(self, evt):
         """Event handler for the button click."""
-        print "See ya later!"
+        print("See ya later!")
         sys.stdout.flush()
         self.cleanup_consoles(evt)
         self.Close()

--- a/docs/examples/parallel/customresults.py
+++ b/docs/examples/parallel/customresults.py
@@ -22,13 +22,13 @@ v = rc.load_balanced_view()
 
 # scatter 'id', so id=0,1,2 on engines 0,1,2
 dv.scatter('id', rc.ids, flatten=True)
-print dv['id']
+print(dv['id'])
 
 
 def sleep_here(count, t):
     """simple function that takes args, prints a short message, sleeps for a time, and returns the same args"""
     import time,sys
-    print "hi from engine %i" % id
+    print("hi from engine %i" % id)
     sys.stdout.flush()
     time.sleep(t)
     return count,t
@@ -49,13 +49,13 @@ while pending:
     for msg_id in finished:
         # we know these are done, so don't worry about blocking
         ar = rc.get_result(msg_id)
-        print "job id %s finished on engine %i" % (msg_id, ar.engine_id)
-        print "with stdout:"
-        print '    ' + ar.stdout.replace('\n', '\n    ').rstrip()
-        print "and results:"
+        print("job id %s finished on engine %i" % (msg_id, ar.engine_id))
+        print("with stdout:")
+        print('    ' + ar.stdout.replace('\n', '\n    ').rstrip())
+        print("and results:")
         
         # note that each job in a map always returns a list of length chunksize
         # even if chunksize == 1
         for (count,t) in ar.result:
-            print "  item %i: slept for %.2fs" % (count, t)
+            print("  item %i: slept for %.2fs" % (count, t))
 

--- a/docs/examples/parallel/dagdeps.py
+++ b/docs/examples/parallel/dagdeps.py
@@ -79,7 +79,7 @@ def main(nodes, edges):
     from matplotlib import pyplot as plt
     from matplotlib.dates import date2num
     from matplotlib.cm import gist_rainbow
-    print "building DAG"
+    print("building DAG")
     G = random_dag(nodes, edges)
     jobs = {}
     pos = {}
@@ -89,11 +89,11 @@ def main(nodes, edges):
     
     client = parallel.Client()
     view = client.load_balanced_view()
-    print "submitting %i tasks with %i dependencies"%(nodes,edges)
+    print("submitting %i tasks with %i dependencies"%(nodes,edges))
     results = submit_jobs(view, G, jobs)
-    print "waiting for results"
+    print("waiting for results")
     view.wait()
-    print "done"
+    print("done")
     for node in G:
         md = results[node].metadata
         start = date2num(md.started)

--- a/docs/examples/parallel/davinci/pwordfreq.py
+++ b/docs/examples/parallel/davinci/pwordfreq.py
@@ -44,21 +44,21 @@ if __name__ == '__main__':
 
     if not os.path.exists('davinci.txt'):
         # download from project gutenberg
-        print "Downloading Da Vinci's notebooks from Project Gutenberg"
+        print("Downloading Da Vinci's notebooks from Project Gutenberg")
         urllib.urlretrieve(davinci_url, 'davinci.txt')
         
     # Run the serial version
-    print "Serial word frequency count:"
+    print("Serial word frequency count:")
     text = open('davinci.txt').read()
     tic = time.time()
     freqs = wordfreq(text)
     toc = time.time()
     print_wordfreq(freqs, 10)
-    print "Took %.3f s to calcluate"%(toc-tic)
+    print("Took %.3f s to calcluate"%(toc-tic))
     
     
     # The parallel version
-    print "\nParallel word frequency count:"
+    print("\nParallel word frequency count:")
     # split the davinci.txt into one file per engine:
     lines = text.splitlines()
     nlines = len(lines)
@@ -75,6 +75,6 @@ if __name__ == '__main__':
     pfreqs = pwordfreq(view,fnames)
     toc = time.time()
     print_wordfreq(freqs)
-    print "Took %.3f s to calcluate on %i engines"%(toc-tic, len(view.targets))
+    print("Took %.3f s to calcluate on %i engines"%(toc-tic, len(view.targets)))
     # cleanup split files
     map(os.remove, fnames)

--- a/docs/examples/parallel/davinci/wordfreq.py
+++ b/docs/examples/parallel/davinci/wordfreq.py
@@ -1,6 +1,7 @@
 """Count the frequencies of words in a string"""
 
 from __future__ import division
+from __future__ import print_function
 
 import cmath as math
 
@@ -24,7 +25,7 @@ def print_wordfreq(freqs, n=10):
     items = zip(counts, words)
     items.sort(reverse=True)
     for (count, word) in items[:n]:
-        print word, count
+        print(word, count)
 
 
 def wordfreq_to_weightsize(worddict, minsize=25, maxsize=50, minalpha=0.5, maxalpha=1.0):

--- a/docs/examples/parallel/demo/dependencies.py
+++ b/docs/examples/parallel/demo/dependencies.py
@@ -34,12 +34,12 @@ view.block=True
 
 # will run on anything:
 pids1 = [ view.apply(getpid) for i in range(len(client.ids)) ]
-print pids1
+print(pids1)
 # will only run on e0:
 pids2 = [ view.apply(getpid2) for i in range(len(client.ids)) ]
-print pids2
+print(pids2)
 
-print "now test some dependency behaviors"
+print("now test some dependency behaviors")
 
 def wait(t):
     import time
@@ -98,31 +98,31 @@ def should_fail(f):
     except error.KernelError:
         pass
     else:
-        print 'should have raised'
+        print('should have raised')
         # raise Exception("should have raised")
 
-# print r1a.msg_ids
+# print(r1a.msg_ids)
 r1a.get()
-# print r1b.msg_ids
+# print(r1b.msg_ids)
 r1b.get()
-# print r2a.msg_ids
+# print(r2a.msg_ids)
 should_fail(r2a.get)
-# print r2b.msg_ids
+# print(r2b.msg_ids)
 should_fail(r2b.get)
-# print r3.msg_ids
+# print(r3.msg_ids)
 should_fail(r3.get)
-# print r4a.msg_ids
+# print(r4a.msg_ids)
 r4a.get()
-# print r4b.msg_ids
+# print(r4b.msg_ids)
 r4b.get()
-# print r4c.msg_ids
+# print(r4c.msg_ids)
 should_fail(r4c.get)
-# print r5.msg_ids
+# print(r5.msg_ids)
 r5.get()
-# print r5b.msg_ids
+# print(r5b.msg_ids)
 should_fail(r5b.get)
-# print r6.msg_ids
+# print(r6.msg_ids)
 should_fail(r6.get) # assuming > 1 engine
-# print r6b.msg_ids
+# print(r6b.msg_ids)
 should_fail(r6b.get)
-print 'done'
+print('done')

--- a/docs/examples/parallel/demo/map.py
+++ b/docs/examples/parallel/demo/map.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from IPython.parallel import *
 
 client = Client()
@@ -32,5 +34,5 @@ ar = psquare.map(range(42))
 
 # wait for the results to be done:
 squares3 = ar.get()
-print squares == squares2, squares3==squares
+print(squares == squares2, squares3==squares)
 # True

--- a/docs/examples/parallel/demo/noncopying.py
+++ b/docs/examples/parallel/demo/noncopying.py
@@ -30,14 +30,14 @@ B1 = numpy.frombuffer(msg1.buffer, dtype=A.dtype).reshape(A.shape)
 msg2 = s2.recv(copy=False)
 B2 = numpy.frombuffer(buffer(msg2.bytes), dtype=A.dtype).reshape(A.shape)
 
-print (B1==B2).all()
-print (B1==A).all()
+print((B1==B2).all())
+print((B1==A).all())
 A[0][0] += 10
-print "~"
+print("~")
 # after changing A in-place, B1 changes too, proving non-copying sends
-print (B1==A).all()
+print((B1==A).all())
 # but B2 is fixed, since it called the msg.bytes attr, which copies
-print (B1==B2).all()
+print((B1==B2).all())
 
 
 

--- a/docs/examples/parallel/demo/throughput.py
+++ b/docs/examples/parallel/demo/throughput.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import time
 import numpy as np
 from IPython import parallel
@@ -43,7 +45,7 @@ def do_runs(nlist,t=0,f=wait, trials=2, runner=time_throughput):
         t2 /= trials
         A[i] = (t1,t2)
         A[i] = n/A[i]
-        print n,A[i]
+        print(n,A[i])
     return A
 
 def do_echo(n,tlist=[0],f=echo, trials=2, runner=time_throughput):
@@ -59,6 +61,6 @@ def do_echo(n,tlist=[0],f=echo, trials=2, runner=time_throughput):
         t2 /= trials
         A[i] = (t1,t2)
         A[i] = n/A[i]
-        print t,A[i]
+        print(t,A[i])
     return A
     

--- a/docs/examples/parallel/demo/views.py
+++ b/docs/examples/parallel/demo/views.py
@@ -8,8 +8,8 @@ for id in client.ids:
 v = client[0]
 v['a'] = 5
 
-print v['a']
+print(v['a'])
 
 remotes = client[:]
 
-print remotes['ids']
+print(remotes['ids'])

--- a/docs/examples/parallel/fetchparse.py
+++ b/docs/examples/parallel/fetchparse.py
@@ -8,8 +8,10 @@ This module gives an example of how the task interface to the
 IPython controller works.  Before running this script start the IPython controller
 and some engines using something like::
 
-    ipclusterz start -n 4
+    ipcluster start -n 4
 """
+from __future__ import print_function
+
 import sys
 from IPython.parallel import Client, error
 import time
@@ -53,11 +55,11 @@ class DistributedSpider(object):
         if url not in self.allLinks:
             self.allLinks.append(url)
             if url.startswith(self.site):
-                print '    ', url
+                print('    ', url)
                 self.linksWorking[url] = self.view.apply(fetchAndParse, url)
 
     def onVisitDone(self, links, url):
-        print url, ':'
+        print(url, ':')
         self.linksDone[url] = None
         del self.linksWorking[url]
         for link in links:
@@ -66,7 +68,7 @@ class DistributedSpider(object):
     def run(self):
         self.visitLink(self.site)
         while self.linksWorking:
-            print len(self.linksWorking), 'pending...'
+            print(len(self.linksWorking), 'pending...')
             self.synchronize()
             time.sleep(self.pollingDelay)
 
@@ -81,7 +83,7 @@ class DistributedSpider(object):
             except Exception as e:
                 self.linksDone[url] = None
                 del self.linksWorking[url]
-                print url, ':', e.traceback
+                print(url, ':', e.traceback)
             else:
                 self.onVisitDone(links, url)
 

--- a/docs/examples/parallel/helloworld.py
+++ b/docs/examples/parallel/helloworld.py
@@ -7,6 +7,7 @@
 # Originally by Ken Kinder (ken at kenkinder dom com)
 
 # <codecell>
+from __future__ import print_function
 
 from IPython.parallel import Client
 
@@ -29,6 +30,6 @@ hello = view.apply_async(sleep_and_echo, 2, 'Hello')
 
 # <codecell>
 
-print "Submitted tasks:", hello.msg_ids, world.msg_ids
-print hello.get(), world.get()
+print("Submitted tasks:", hello.msg_ids, world.msg_ids)
+print(hello.get(), world.get())
 

--- a/docs/examples/parallel/interengine/communicator.py
+++ b/docs/examples/parallel/interengine/communicator.py
@@ -15,7 +15,7 @@ class EngineCommunicator(object):
         
         # configure sockets
         self.identity = identity or bytes(uuid.uuid4())
-        print self.identity
+        print(self.identity)
         self.socket.setsockopt(zmq.IDENTITY, self.identity)
         self.sub.setsockopt(zmq.SUBSCRIBE, b'')
         

--- a/docs/examples/parallel/iopubwatcher.py
+++ b/docs/examples/parallel/iopubwatcher.py
@@ -65,14 +65,14 @@ def main(connection_file):
             # stdout/stderr
             # stream names are in msg['content']['name'], if you want to handle
             # them differently
-            print "%s: %s" % (topic, msg['content']['data'])
+            print("%s: %s" % (topic, msg['content']['data']))
         elif msg['msg_type'] == 'pyerr':
             # Python traceback
             c = msg['content']
-            print topic + ':'
+            print(topic + ':')
             for line in c['traceback']:
                 # indent lines
-                print '    ' + line
+                print('    ' + line)
 
 if __name__ == '__main__':
     if len(sys.argv) > 1:

--- a/docs/examples/parallel/itermapresult.py
+++ b/docs/examples/parallel/itermapresult.py
@@ -17,6 +17,8 @@ Authors
 -------
 * MinRK
 """
+from __future__ import print_function
+
 import time
 
 from IPython import parallel
@@ -28,15 +30,15 @@ v = rc.load_balanced_view()
 
 # scatter 'id', so id=0,1,2 on engines 0,1,2
 dv.scatter('id', rc.ids, flatten=True)
-print "Engine IDs: ", dv['id']
+print("Engine IDs: ", dv['id'])
 
 # create a Reference to `id`. This will be a different value on each engine
 ref = parallel.Reference('id')
-print "sleeping for `id` seconds on each engine"
+print("sleeping for `id` seconds on each engine")
 tic = time.time()
 ar = dv.apply(time.sleep, ref)
 for i,r in enumerate(ar):
-    print "%i: %.3f"%(i, time.time()-tic)
+    print("%i: %.3f"%(i, time.time()-tic))
 
 def sleep_here(t):
     import time
@@ -44,22 +46,22 @@ def sleep_here(t):
     return id,t
 
 # one call per task
-print "running with one call per task"
+print("running with one call per task")
 amr = v.map(sleep_here, [.01*t for t in range(100)])
 tic = time.time()
 for i,r in enumerate(amr):
-    print "task %i on engine %i: %.3f" % (i, r[0], time.time()-tic)
+    print("task %i on engine %i: %.3f" % (i, r[0], time.time()-tic))
 
-print "running with four calls per task"
+print("running with four calls per task")
 # with chunksize, we can have four calls per task
 amr = v.map(sleep_here, [.01*t for t in range(100)], chunksize=4)
 tic = time.time()
 for i,r in enumerate(amr):
-    print "task %i on engine %i: %.3f" % (i, r[0], time.time()-tic)
+    print("task %i on engine %i: %.3f" % (i, r[0], time.time()-tic))
 
-print "running with two calls per task, with unordered results"
+print("running with two calls per task, with unordered results")
 # We can even iterate through faster results first, with ordered=False
 amr = v.map(sleep_here, [.01*t for t in range(100,0,-1)], ordered=False, chunksize=2)
 tic = time.time()
 for i,r in enumerate(amr):
-    print "slept %.2fs on engine %i: %.3f" % (r[1], r[0], time.time()-tic)
+    print("slept %.2fs on engine %i: %.3f" % (r[1], r[0], time.time()-tic))

--- a/docs/examples/parallel/multiengine2.py
+++ b/docs/examples/parallel/multiengine2.py
@@ -1,6 +1,7 @@
 #-------------------------------------------------------------------------------
 # Imports
 #-------------------------------------------------------------------------------
+from __future__ import print_function
 
 import time
 
@@ -20,9 +21,9 @@ ar1 = mux.apply(time.sleep, 5)
 ar2 = mux.push(dict(a=10,b=30,c=range(20000),d='The dog went swimming.'))
 ar3 = mux.pull(('a','b','d'), block=False)
 
-print "Try a non-blocking get_result"
+print("Try a non-blocking get_result")
 ar4 = mux.get_result()
 
-print "Now wait for all the results"
+print("Now wait for all the results")
 mux.wait([ar1,ar2,ar3,ar4])
-print "The last pull got:", ar4.r
+print("The last pull got:", ar4.r)

--- a/docs/examples/parallel/multienginemap.py
+++ b/docs/examples/parallel/multienginemap.py
@@ -1,17 +1,19 @@
+from __future__ import print_function
+
 from IPython.parallel import Client
 
 rc = Client()
 view = rc[:]
 result = view.map_sync(lambda x: 2*x, range(10))
-print "Simple, default map: ", result
+print("Simple, default map: ", result)
 
 ar = view.map_async(lambda x: 2*x, range(10))
-print "Submitted map, got AsyncResult: ", ar
+print("Submitted map, got AsyncResult: ", ar)
 result = ar.r
-print "Using map_async: ", result
+print("Using map_async: ", result)
 
 @view.parallel(block=True)
 def f(x): return 2*x
 
 result = f.map(range(10))
-print "Using a parallel function: ", result
+print("Using a parallel function: ", result)

--- a/docs/examples/parallel/nwmerge.py
+++ b/docs/examples/parallel/nwmerge.py
@@ -2,6 +2,7 @@
 """
 # Slightly modified version of:
 # http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/511509
+from __future__ import print_function
 
 import heapq
 from IPython.parallel.error import RemoteError
@@ -82,7 +83,7 @@ def remote_iterator(view,name):
         try:
             result = view.apply_sync(lambda x: x.next(), Reference('it'+name))
         # This causes the StopIteration exception to be raised.
-        except RemoteError, e:
+        except RemoteError as e:
             if e.ename == 'StopIteration':
                 raise StopIteration
             else:
@@ -96,7 +97,7 @@ if __name__ == '__main__':
     from IPython.parallel import Client, Reference
     rc = Client()
     view = rc[:]
-    print 'Engine IDs:', rc.ids
+    print('Engine IDs:', rc.ids)
 
     # Make a set of 'sorted datasets'
     a0 = range(5,20)
@@ -116,8 +117,8 @@ if __name__ == '__main__':
     aa2 = remote_iterator(rc[2],'a')
 
     # Let's merge them, both locally and remotely:
-    print 'Merge the local datasets:'
-    print list(mergesort([a0,a1,a2]))
+    print('Merge the local datasets:')
+    print(list(mergesort([a0,a1,a2])))
     
-    print 'Locally merge the remote sets:'
-    print list(mergesort([aa0,aa1,aa2]))
+    print('Locally merge the remote sets:')
+    print(list(mergesort([aa0,aa1,aa2])))

--- a/docs/examples/parallel/options/mcpricer.py
+++ b/docs/examples/parallel/options/mcpricer.py
@@ -9,6 +9,7 @@
 # ## Problem setup
 
 # <codecell>
+from __future__ import print_function
 
 import sys
 import time
@@ -59,8 +60,8 @@ view = c.load_balanced_view()
 
 # <codecell>
 
-print "Strike prices: ", strike_vals
-print "Volatilities: ", sigma_vals
+print("Strike prices: ", strike_vals)
+print("Volatilities: ", sigma_vals)
 
 # <markdowncell>
 
@@ -77,7 +78,7 @@ for strike in strike_vals:
 
 # <codecell>
 
-print "Submitted tasks: ", len(async_results)
+print("Submitted tasks: ", len(async_results))
 
 # <markdowncell>
 
@@ -89,7 +90,7 @@ c.wait(async_results)
 t2 = time.time()
 t = t2-t1
 
-print "Parallel calculation completed, time = %s s" % t
+print("Parallel calculation completed, time = %s s" % t)
 
 # <markdowncell>
 

--- a/docs/examples/parallel/pi/parallelpi.py
+++ b/docs/examples/parallel/pi/parallelpi.py
@@ -15,6 +15,7 @@ ftp://pi.super-computing.org/.2/pi200m/
 and the files used will be downloaded if they are not in the working directory
 of the IPython engines.
 """
+from __future__ import print_function
 
 from IPython.parallel import Client
 from matplotlib import pyplot as plt
@@ -36,16 +37,16 @@ id0 = c.ids[0]
 v = c[:]
 v.block=True
 # fetch the pi-files
-print "downloading %i files of pi"%n
+print("downloading %i files of pi"%n)
 v.map(fetch_pi_file, files[:n])
-print "done"
+print("done")
 
 # Run 10m digits on 1 engine
 t1 = clock()
 freqs10m = c[id0].apply_sync(compute_two_digit_freqs, files[0])
 t2 = clock()
 digits_per_second1 = 10.0e6/(t2-t1)
-print "Digits per second (1 core, 10m digits):   ", digits_per_second1
+print("Digits per second (1 core, 10m digits):   ", digits_per_second1)
 
 
 # Run n*10m digits on all engines
@@ -54,9 +55,9 @@ freqs_all = v.map(compute_two_digit_freqs, files[:n])
 freqs150m = reduce_freqs(freqs_all)
 t2 = clock()
 digits_per_second8 = n*10.0e6/(t2-t1)
-print "Digits per second (%i engines, %i0m digits): "%(n,n), digits_per_second8
+print("Digits per second (%i engines, %i0m digits): "%(n,n), digits_per_second8)
 
-print "Speedup: ", digits_per_second8/digits_per_second1
+print("Speedup: ", digits_per_second8/digits_per_second1)
 
 plot_two_digit_freqs(freqs150m)
 plt.title("2 digit sequences in %i0m digits of pi"%n)

--- a/docs/examples/parallel/plotting/plotting_backend.py
+++ b/docs/examples/parallel/plotting/plotting_backend.py
@@ -17,6 +17,7 @@ When used with IPython.parallel, this code is run on the engines.  Because this
 code doesn't make any plots, the engines don't have to have any plotting
 packages installed.
 """
+from __future__ import print_function
 
 # Imports
 import numpy as N
@@ -51,7 +52,7 @@ downy = downsample(x, d_number)
 downpx = downsample(px, d_number)
 downpy = downsample(py, d_number)
 
-print "downx: ", downx[:10]
-print "downy: ", downy[:10]
-print "downpx: ", downpx[:10]
-print "downpy: ", downpy[:10]
+print("downx: ", downx[:10])
+print("downy: ", downy[:10])
+print("downpx: ", downpx[:10])
+print("downpy: ", downpy[:10])

--- a/docs/examples/parallel/plotting/plotting_frontend.py
+++ b/docs/examples/parallel/plotting/plotting_frontend.py
@@ -15,6 +15,7 @@ Then a simple "run plotting_frontend.py" in IPython will run the
 example.  When this is done, all the variables (such as number, downx, etc.)
 are available in IPython, so for example you can make additional plots.
 """
+from __future__ import print_function
 
 import numpy as N
 from pylab import *
@@ -36,8 +37,8 @@ downpx = view.gather('downpx')
 downpy = view.gather('downpy')
 
 # but we can still iterate through AsyncResults before they are done
-print "number: ", sum(number)
-print "downsampled number: ", sum(d_number)
+print("number: ", sum(number))
+print("downsampled number: ", sum(d_number))
 
 
 # Make a scatter plot of the gathered data

--- a/docs/examples/parallel/plotting/plotting_frontend.py
+++ b/docs/examples/parallel/plotting/plotting_frontend.py
@@ -5,7 +5,7 @@ The two files plotting_frontend.py and plotting_backend.py go together.
 To run this example, first start the IPython controller and 4
 engines::
 
-    ipclusterz start -n 4
+    ipcluster start -n 4
 
 Then start ipython in pylab mode::
 

--- a/docs/examples/parallel/task1.py
+++ b/docs/examples/parallel/task1.py
@@ -5,6 +5,7 @@
 # # Simple task farming example
 
 # <codecell>
+from __future__ import print_function
 
 from IPython.parallel import Client
 
@@ -48,5 +49,5 @@ ar = v.apply(task, 5)
 
 # <codecell>
 
-print "a, b, c: ", ar.get()
+print("a, b, c: ", ar.get())
 

--- a/docs/examples/parallel/task2.py
+++ b/docs/examples/parallel/task2.py
@@ -16,8 +16,8 @@ for i in range(24):
 
 for i in range(6):
     time.sleep(1.0)
-    print "Queue status (vebose=False)"
-    print v.queue_status(verbose=False)
+    print("Queue status (vebose=False)")
+    print(v.queue_status(verbose=False))
     flush()
     
 for i in range(24):
@@ -25,15 +25,15 @@ for i in range(24):
 
 for i in range(6):
     time.sleep(1.0)
-    print "Queue status (vebose=True)"
-    print v.queue_status(verbose=True)
+    print("Queue status (vebose=True)")
+    print(v.queue_status(verbose=True))
     flush()
 
 for i in range(12):
     v.apply(time.sleep, 2)
 
-print "Queue status (vebose=True)"
-print v.queue_status(verbose=True)
+print("Queue status (vebose=True)")
+print(v.queue_status(verbose=True))
 flush()
 
 # qs = v.queue_status(verbose=True)
@@ -44,7 +44,7 @@ for msg_id in v.history[-4:]:
 
 for i in range(6):
     time.sleep(1.0)
-    print "Queue status (vebose=True)"
-    print v.queue_status(verbose=True)
+    print("Queue status (vebose=True)")
+    print(v.queue_status(verbose=True))
     flush()
 

--- a/docs/examples/parallel/task_profiler.py
+++ b/docs/examples/parallel/task_profiler.py
@@ -6,7 +6,7 @@ are basically just a time.sleep(t), where t is a random number between
 two limits that can be configured at the command line.  To run
 the script there must first be an IPython controller and engines running::
 
-    ipclusterz start -n 16
+    ipcluster start -n 16
 
 A good test to run with 16 engines is::
 

--- a/docs/examples/parallel/task_profiler.py
+++ b/docs/examples/parallel/task_profiler.py
@@ -42,7 +42,7 @@ def main():
 
     rc = Client()
     view = rc.load_balanced_view()
-    print view
+    print(view)
     rc.block=True
     nengines = len(rc.ids)
     with rc[:].sync_imports():
@@ -52,7 +52,7 @@ def main():
     times = [random.random()*(opts.tmax-opts.tmin)+opts.tmin for i in range(opts.n)]
     stime = sum(times)
 
-    print "executing %i tasks, totalling %.1f secs on %i engines"%(opts.n, stime, nengines)
+    print("executing %i tasks, totalling %.1f secs on %i engines"%(opts.n, stime, nengines))
     time.sleep(1)
     start = time.time()
     amr = view.map(time.sleep, times)
@@ -62,9 +62,9 @@ def main():
     ptime = stop-start
     scale = stime/ptime
 
-    print "executed %.1f secs in %.1f secs"%(stime, ptime)
-    print "%.3fx parallel performance on %i engines"%(scale, nengines)
-    print "%.1f%% of theoretical max"%(100*scale/nengines)
+    print("executed %.1f secs in %.1f secs"%(stime, ptime))
+    print("%.3fx parallel performance on %i engines"%(scale, nengines))
+    print("%.1f%% of theoretical max"%(100*scale/nengines))
 
 
 if __name__ == '__main__':

--- a/docs/examples/parallel/taskmap.py
+++ b/docs/examples/parallel/taskmap.py
@@ -5,6 +5,7 @@
 # # Load balanced map and parallel function decorator
 
 # <codecell>
+from __future__ import print_function
 
 from IPython.parallel import Client
 
@@ -16,14 +17,14 @@ v = rc.load_balanced_view()
 # <codecell>
 
 result = v.map(lambda x: 2*x, range(10))
-print "Simple, default map: ", list(result)
+print("Simple, default map: ", list(result))
 
 # <codecell>
 
 ar = v.map_async(lambda x: 2*x, range(10))
-print "Submitted tasks, got ids: ", ar.msg_ids
+print("Submitted tasks, got ids: ", ar.msg_ids)
 result = ar.get()
-print "Using a mapper: ", result
+print("Using a mapper: ", result)
 
 # <codecell>
 
@@ -31,5 +32,5 @@ print "Using a mapper: ", result
 def f(x): return 2*x
 
 result = f.map(range(10))
-print "Using a parallel function: ", result
+print("Using a parallel function: ", result)
 

--- a/docs/examples/parallel/wave2D/RectPartitioner.py
+++ b/docs/examples/parallel/wave2D/RectPartitioner.py
@@ -15,6 +15,7 @@ Authors
  * Min Ragan-Kelley
 
 """
+from __future__ import print_function
 import time
 
 from numpy import zeros, ascontiguousarray, frombuffer
@@ -43,10 +44,10 @@ class RectPartitioner:
 
     def redim (self, global_num_cells, num_parts):
         nsd_ = len(global_num_cells)
-#        print "Inside the redim function, nsd=%d" %nsd_
+#        print("Inside the redim function, nsd=%d" %nsd_)
 
         if nsd_<1 | nsd_>3 | nsd_!=len(num_parts):
-            print 'The input global_num_cells is not ok!'
+            print('The input global_num_cells is not ok!')
             return
 
         self.nsd = nsd_
@@ -61,7 +62,7 @@ class RectPartitioner:
         
         nsd_ = self.nsd
         if nsd_<1:
-            print 'Number of space dimensions is %d, nothing to do' %nsd_
+            print('Number of space dimensions is %d, nothing to do' %nsd_)
             return
         
         self.subd_rank = [-1,-1,-1]
@@ -77,7 +78,7 @@ class RectPartitioner:
         for i in range(nsd_):
             num_subds = num_subds*self.num_parts[i]
         if my_id==0:
-            print "# subds=", num_subds
+            print("# subds=", num_subds)
             # should check num_subds againt num_procs
 
         offsets = [1, 0, 0]
@@ -93,9 +94,9 @@ class RectPartitioner:
             self.subd_rank[1] = (my_id%offsets[2])/self.num_parts[0]
             self.subd_rank[2] = my_id/offsets[2]
                     
-        print "my_id=%d, subd_rank: "%my_id, self.subd_rank
+        print("my_id=%d, subd_rank: "%my_id, self.subd_rank)
         if my_id==0:
-            print "offsets=", offsets
+            print("offsets=", offsets)
 
         # find the neighbor ids
         for i in range(nsd_):
@@ -118,11 +119,11 @@ class RectPartitioner:
                 ix = ix+1  # one cell of overlap
             self.subd_hi_ix[i] = ix
 
-        print "subd_rank:",self.subd_rank,\
+        print("subd_rank:",self.subd_rank,\
               "lower_neig:", self.lower_neighbors, \
-              "upper_neig:", self.upper_neighbors
-        print "subd_rank:",self.subd_rank,"subd_lo_ix:", self.subd_lo_ix, \
-              "subd_hi_ix:", self.subd_hi_ix
+              "upper_neig:", self.upper_neighbors)
+        print("subd_rank:",self.subd_rank,"subd_lo_ix:", self.subd_lo_ix, \
+              "subd_hi_ix:", self.subd_hi_ix)
 
         
 class RectPartitioner1D(RectPartitioner):
@@ -199,10 +200,10 @@ class MPIRectPartitioner2D(RectPartitioner2D):
     def update_internal_boundary (self, solution_array):
         nsd_ = self.nsd
         if nsd_!=len(self.in_lower_buffers) | nsd_!=len(self.out_lower_buffers):
-            print "Buffers for communicating with lower neighbors not ready"
+            print("Buffers for communicating with lower neighbors not ready")
             return
         if nsd_!=len(self.in_upper_buffers) | nsd_!=len(self.out_upper_buffers):
-            print "Buffers for communicating with upper neighbors not ready"
+            print("Buffers for communicating with upper neighbors not ready")
             return
 
         loc_nx = self.subd_hi_ix[0]-self.subd_lo_ix[0]
@@ -299,10 +300,10 @@ class ZMQRectPartitioner2D(RectPartitioner2D):
         nsd_ = self.nsd
         dtype = solution_array.dtype
         if nsd_!=len(self.in_lower_buffers) | nsd_!=len(self.out_lower_buffers):
-            print "Buffers for communicating with lower neighbors not ready"
+            print("Buffers for communicating with lower neighbors not ready")
             return
         if nsd_!=len(self.in_upper_buffers) | nsd_!=len(self.out_upper_buffers):
-            print "Buffers for communicating with upper neighbors not ready"
+            print("Buffers for communicating with upper neighbors not ready")
             return
 
         loc_nx = self.subd_hi_ix[0]-self.subd_lo_ix[0]
@@ -390,10 +391,10 @@ class ZMQRectPartitioner2D(RectPartitioner2D):
         nsd_ = self.nsd
         dtype = solution_array.dtype
         if nsd_!=len(self.in_lower_buffers) | nsd_!=len(self.out_lower_buffers):
-            print "Buffers for communicating with lower neighbors not ready"
+            print("Buffers for communicating with lower neighbors not ready")
             return
         if nsd_!=len(self.in_upper_buffers) | nsd_!=len(self.out_upper_buffers):
-            print "Buffers for communicating with upper neighbors not ready"
+            print("Buffers for communicating with upper neighbors not ready")
             return
 
         loc_nx = self.subd_hi_ix[0]-self.subd_lo_ix[0]

--- a/docs/examples/parallel/wave2D/parallelwave.py
+++ b/docs/examples/parallel/wave2D/parallelwave.py
@@ -114,7 +114,7 @@ if __name__ == '__main__':
 
     # construct the View:
     view = rc[:num_procs]
-    print "Running %s system on %s processes until %f"%(grid, partition, tstop)
+    print("Running %s system on %s processes until %f"%(grid, partition, tstop))
 
     # functions defining initial/boundary/source conditions
     def I(x,y):
@@ -179,7 +179,7 @@ if __name__ == '__main__':
         else:
             norm = -1
         t1 = time.time()
-        print 'scalar inner-version, Wtime=%g, norm=%g'%(t1-t0, norm)
+        print('scalar inner-version, Wtime=%g, norm=%g'%(t1-t0, norm))
 
     # run again with faster numpy-vectorized inner implementation:
     impl['inner'] = 'vectorized'
@@ -197,7 +197,7 @@ if __name__ == '__main__':
     else:
         norm = -1
     t1 = time.time()
-    print 'vector inner-version, Wtime=%g, norm=%g'%(t1-t0, norm)
+    print('vector inner-version, Wtime=%g, norm=%g'%(t1-t0, norm))
 
     # if ns.save is True, then u_hist stores the history of u as a list
     # If the partion scheme is Nx1, then u can be reconstructed via 'gather':

--- a/docs/examples/parallel/wave2D/wavesolver.py
+++ b/docs/examples/parallel/wave2D/wavesolver.py
@@ -160,7 +160,7 @@ class WaveSolver(object):
 
         if user_action is not None:
             user_action(u_1, x, y, t)  # allow user to plot etc.
-        # print list(self.us[2][2])
+        # print(list(self.us[2][2]))
         self.us = (u,u_1,u_2)
 
 
@@ -196,8 +196,8 @@ class WaveSolver(object):
         while t <= tstop:
             t_old = t;  t += dt
             if verbose:
-                print 'solving (%s version) at t=%g' % \
-                      (implementation['inner'], t)
+                print('solving (%s version) at t=%g' % \
+                      (implementation['inner'], t))
             # update all inner points:
             if implementation['inner'] == 'scalar':
                 for i in xrange(1, nx):
@@ -251,9 +251,9 @@ class WaveSolver(object):
             u_2, u_1, u = u_1, u, u_2
 
         t1 = time.time()
-        print 'my_id=%2d, dt=%g, %s version, slice_copy=%s, net Wtime=%g'\
+        print('my_id=%2d, dt=%g, %s version, slice_copy=%s, net Wtime=%g'\
               %(partitioner.my_id,dt,implementation['inner'],\
-                partitioner.slice_copy,t1-t0)
+                partitioner.slice_copy,t1-t0))
         # save the us
         self.us = u,u_1,u_2
         # check final results; compute discrete L2-norm of the solution

--- a/docs/examples/tests/heartbeat/hb_gil.py
+++ b/docs/examples/tests/heartbeat/hb_gil.py
@@ -25,7 +25,7 @@ def gilsleep(t):
     ])
     while True:
         inline(code, quiet=True, t=t)
-        print time.time()
+        print(time.time())
         sys.stdout.flush() # this is important
 
 gilsleep(5)


### PR DESCRIPTION
Installing on Python 3 attempts to byte-compile the example files for some reason (#1470), mostly just choking on print statements. This just updates the print statements. It doesn't get rid of all the errors, but it's half a dozen, rather than filling up the terminal with errors. The remainder are harder to clear up without adding an abstraction layer, which runs counter to the point of examples.

For a single argument, the brackets don't make any difference on Python 2: `print(x)` will work exactly like `print x`. Where it's called with multiple arguments, I've put `from __future__ import print_function` at the top of the file.

I also spotted a couple of lingering references to `ipclusterz`, which was the name of the new `ipcluster` before we dropped the old parallel framework, so I cleaned them up.
