### PR TITLE
re-enter kernel.eventloop after catching SIGINT

### DIFF
--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -201,12 +201,17 @@ class Kernel(Configurable):
         # stop ignoring sigint, now that we are out of our own loop,
         # we don't want to prevent future code from handling it
         signal(SIGINT, default_int_handler)
-        if self.eventloop is not None:
+        while self.eventloop is not None:
             try:
                 self.eventloop(self)
             except KeyboardInterrupt:
                 # Ctrl-C shouldn't crash the kernel
                 io.raw_print("KeyboardInterrupt caught in kernel")
+                continue
+            else:
+                # eventloop exited cleanly, this means we should stop (right?)
+                self.eventloop = None
+                break
 
 
     def record_ports(self, ports):


### PR DESCRIPTION
As requested by @fperez

This protects the kernel from exiting due to bugs failing to catch SIGINT properly in the eventloop integration 
functions, as described in #1228.  It does not fix those bugs, only reduces the severity of their consequences.
