### PR TITLE
Specify encoding for io.open in notebook_reformat tests

### DIFF
--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -451,7 +451,7 @@ def test_notebook_export_py():
 def test_notebook_reformat_py():
     with TemporaryDirectory() as td:
         infile = os.path.join(td, "nb.ipynb")
-        with io.open(infile, 'w') as f:
+        with io.open(infile, 'w', encoding='utf-8') as f:
             current.write(nb0, f, 'json')
             
         _ip.ex(py3compat.u_format(u"u = {u}'héllo'"))
@@ -460,7 +460,7 @@ def test_notebook_reformat_py():
 def test_notebook_reformat_json():
     with TemporaryDirectory() as td:
         infile = os.path.join(td, "nb.py")
-        with io.open(infile, 'w') as f:
+        with io.open(infile, 'w', encoding='utf-8') as f:
             current.write(nb0, f, 'py')
             
         _ip.ex(py3compat.u_format(u"u = {u}'héllo'"))


### PR DESCRIPTION
This should fix the OS X test failure seen here:

https://jenkins.shiningpanda.com/ipython/job/ipython-mac/76/testReport/junit/IPython.core.tests/test_magic/test_notebook_reformat_json/
