### PR TITLE
Small fixes for Animation and Progress notebook

### DIFF
--- a/docs/examples/notebooks/Animations_and_Progress.ipynb
+++ b/docs/examples/notebooks/Animations_and_Progress.ipynb
@@ -115,7 +115,7 @@
      "collapsed": false,
      "input": [
       "from scipy.special import jn",
-      "x = linspace(0,5)",
+      "x = np.linspace(0,5)",
       "f, ax = plt.subplots()",
       "ax.set_title(\"Bessel functions\")",
       "",
@@ -244,7 +244,7 @@
       "        all_full = self.width - 2",
       "        num_hashes = int(round((percent_done / 100.0) * all_full))",
       "        self.prog_bar = '[' + self.fill_char * num_hashes + ' ' * (all_full - num_hashes) + ']'",
-      "        pct_place = (len(self.prog_bar) / 2) - len(str(percent_done))",
+      "        pct_place = (len(self.prog_bar) // 2) - len(str(percent_done))",
       "        pct_string = '%d%%' % percent_done",
       "        self.prog_bar = self.prog_bar[0:pct_place] + \\",
       "            (pct_string + self.prog_bar[pct_place + len(pct_string):])",


### PR DESCRIPTION
The new progress notebook example works nicely.

However there are two minor issues, 

When from **future** import division is used 
`len(self.prog_bar) / 2` is not an integer so I changed it to
`len(self.prog_bar) // 2` 

In addition but less important when pylab_import_all is False linspace is not in the global name space 
so I changed that to np.linspace 
