### PR TITLE
Share code for %pycat and %loadpy, make %pycat aware of URLs

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -22,8 +22,6 @@ import __future__
 import abc
 import ast
 import atexit
-import codeop
-import inspect
 import os
 import re
 import runpy
@@ -31,16 +29,10 @@ import sys
 import tempfile
 import types
 import urllib
-from io import BytesIO,TextIOWrapper
-
-try:
-    from contextlib import nested
-except:
-    from IPython.utils.nested_context import nested
+from io import BytesIO
 
 from IPython.config.configurable import SingletonConfigurable
 from IPython.core import debugger, oinspect
-from IPython.core import history as ipcorehist
 from IPython.core import page
 from IPython.core import prefilter
 from IPython.core import shadowns
@@ -52,7 +44,7 @@ from IPython.core.compilerop import CachingCompiler
 from IPython.core.display_trap import DisplayTrap
 from IPython.core.displayhook import DisplayHook
 from IPython.core.displaypub import DisplayPublisher
-from IPython.core.error import TryNext, UsageError
+from IPython.core.error import UsageError
 from IPython.core.extensions import ExtensionManager
 from IPython.core.fakemodule import FakeModule, init_fakemod_dict
 from IPython.core.formatters import DisplayFormatter
@@ -72,18 +64,18 @@ from IPython.utils import io
 from IPython.utils import py3compat
 from IPython.utils import openpy
 from IPython.utils.doctestreload import doctest_reload
-from IPython.utils.io import ask_yes_no, rprint
+from IPython.utils.io import ask_yes_no
 from IPython.utils.ipstruct import Struct
-from IPython.utils.path import get_home_dir, get_ipython_dir, HomeDirError, get_py_filename, unquote_filename
+from IPython.utils.path import get_home_dir, get_ipython_dir, get_py_filename, unquote_filename
 from IPython.utils.pickleshare import PickleShareDB
 from IPython.utils.process import system, getoutput
 from IPython.utils.strdispatch import StrDispatch
 from IPython.utils.syspathcontext import prepended_to_syspath
-from IPython.utils.text import (num_ini_spaces, format_screen, LSString, SList,
+from IPython.utils.text import (format_screen, LSString, SList,
                                 DollarFormatter)
 from IPython.utils.traitlets import (Integer, CBool, CaselessStrEnum, Enum,
                                      List, Unicode, Instance, Type)
-from IPython.utils.warn import warn, error, fatal
+from IPython.utils.warn import warn, error
 import IPython.core.hooks
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2768,19 +2768,21 @@ class InteractiveShell(SingletonConfigurable, Magic):
         code = self.extract_input_lines(target, raw=raw)  # Grab history
         if code:
             return code
-
-        utarget = unquote_filename(target)
-        if utarget.startswith(('http://', 'https://')):
-            return openpy.read_py_url(utarget, skip_encoding_cookie=True)
+        try:
+            utarget = unquote_filename(target)
+            if utarget.startswith(('http://', 'https://')):
+                return openpy.read_py_url(utarget, skip_encoding_cookie=True)
+        except:
+            raise ValueError(("'%s': no such URL, or URL innaccessible.") % utarget)
 
         try :
             pyfile = get_py_filename(target)
-            return open(pyfile, "r").read()
+            return openpy.read_py_url(pyfile, skip_encoding_cookie=True)
         except IOError:
             pass
 
         if os.path.isfile(target):                        # Read file
-            return open(target, "r").read()
+            return openpy.read_py_url(target, skip_encoding_cookie=True)
 
         try:                                              # User namespace
             codeobj = eval(target, self.user_ns)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2780,31 +2780,26 @@ class InteractiveShell(SingletonConfigurable, Magic):
                 return text.read()
             raise ValueError(("'%s' seem to be unreadable.") % utarget)
 
+        potential_target = [target]
         try :
-            pyfile = get_py_filename(target)
-            return openpy.read_py_file(pyfile, skip_encoding_cookie=True)
+            potential_target.insert(0,get_py_filename(target))
         except IOError:
-            #py file don't exist... we just made a bad guess, don't raise
             pass
-        except UnicodeDecodeError :
-            if not py_only :
-                with io_open(pyfile,'r', encoding='latin1') as f :
-                    return f.read()
-            raise ValueError(("'%s' seem to be unreadable.") % target)
 
-        if os.path.isfile(target):                        # Read file
-            try :
-                return openpy.read_py_file(target, skip_encoding_cookie=True)
-            except UnicodeDecodeError :
-                if not py_only :
-                    with io_open(pyfile,'r', encoding='latin1') as f :
-                        return f.read()
-                raise ValueError(("'%s' seem to be unreadable.") % target)
+        for tgt in potential_target :
+            if os.path.isfile(tgt):                        # Read file
+                try :
+                    return openpy.read_py_file(tgt, skip_encoding_cookie=True)
+                except UnicodeDecodeError :
+                    if not py_only :
+                        with io_open(tgt,'r', encoding='latin1') as f :
+                            return f.read()
+                    raise ValueError(("'%s' seem to be unreadable.") % target)
 
         try:                                              # User namespace
             codeobj = eval(target, self.user_ns)
         except Exception:
-            raise ValueError(("'%s' was not found in history, as a file, url,"
+            raise ValueError(("'%s' was not found in history, as a file, url, "
                                 "nor in the user namespace.") % target)
         if isinstance(codeobj, basestring):
             return codeobj

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -29,7 +29,6 @@ import sys
 import tempfile
 import types
 import urllib
-from io import BytesIO,TextIOWrapper
 from io import open as io_open
 
 from IPython.config.configurable import SingletonConfigurable

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2777,12 +2777,12 @@ class InteractiveShell(SingletonConfigurable, Magic):
 
         try :
             pyfile = get_py_filename(target)
-            return openpy.read_py_url(pyfile, skip_encoding_cookie=True)
+            return openpy.read_py_file(pyfile, skip_encoding_cookie=True)
         except IOError:
             pass
 
         if os.path.isfile(target):                        # Read file
-            return openpy.read_py_url(target, skip_encoding_cookie=True)
+            return openpy.read_py_file(target, skip_encoding_cookie=True)
 
         try:                                              # User namespace
             codeobj = eval(target, self.user_ns)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2750,7 +2750,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
 
           A string specifying code to retrieve. This will be tried respectively
           as: ranges of input history (see %history for syntax), url,
-          correspnding .py file,filename, or an expression evaluating to a
+          correspnding .py file, filename, or an expression evaluating to a
           string or Macro in the user namespace.
 
         raw : bool
@@ -2772,8 +2772,8 @@ class InteractiveShell(SingletonConfigurable, Magic):
             utarget = unquote_filename(target)
             if utarget.startswith(('http://', 'https://')):
                 return openpy.read_py_url(utarget, skip_encoding_cookie=True)
-        except:
-            raise ValueError(("'%s': no such URL, or URL innaccessible.") % utarget)
+        except UnicodeDecodeError:
+            raise ValueError(("'%s' seem to be unredable.") % utarget)
 
         try :
             pyfile = get_py_filename(target)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2774,10 +2774,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
         except UnicodeDecodeError:
             if not py_only :
                 response = urllib.urlopen(target)
-                buffer = BytesIO(response.read())
-                text = TextIOWrapper(buffer, 'latin1', errors='replace', line_buffering=True)
-                text.mode = 'r'
-                return text.read()
+                return response.read().decode('latin1')
             raise ValueError(("'%s' seem to be unreadable.") % utarget)
 
         potential_target = [target]

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2269,12 +2269,24 @@ Currently the magic system has the following functions:\n"""
         return response_data['html_url']
 
     def magic_loadpy(self, arg_s):
-        """Load a .py python script into the GUI console.
+        """Alias of `%load`
+        
+        `%loadpy` has gain some flexibility and drop the requirement of `.py`
+        extension. So it has been rename simply into %load. You can look at
+        `%load`'s docstring for more info.
+        """
+        self.magic_load(arg_s)
 
-        This magic command can either take a local filename or a url::
+    def magic_load(self, arg_s):
+        """Load code into the current frontend.
 
-        %loadpy myscript.py
-        %loadpy http://www.example.com/myscript.py
+        This magic command can either take a local filename, an url,
+        an history range (see %history) or a macro as argument ::
+
+        %pycat myscript.py
+        %pycat 7-27
+        %pycat myMacro
+        %pycat http://www.example.com/myscript.py
         """
  
         contents = self.shell.find_user_code(arg_s)

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2283,10 +2283,10 @@ Currently the magic system has the following functions:\n"""
         This magic command can either take a local filename, an url,
         an history range (see %history) or a macro as argument ::
 
-        %pycat myscript.py
-        %pycat 7-27
-        %pycat myMacro
-        %pycat http://www.example.com/myscript.py
+        %load myscript.py
+        %load 7-27
+        %load myMacro
+        %load http://www.example.com/myscript.py
         """
  
         contents = self.shell.find_user_code(arg_s)

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2293,8 +2293,7 @@ Currently the magic system has the following functions:\n"""
         %load myMacro
         %load http://www.example.com/myscript.py
         """
-        opts,args = self.parse_options(arg_s,'y',mode='list')
-        args = " ".join(args)
+        opts,args = self.parse_options(arg_s,'y')
 
         contents = self.shell.find_user_code(args)
         l = len(contents)

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2280,16 +2280,41 @@ Currently the magic system has the following functions:\n"""
     def magic_load(self, arg_s):
         """Load code into the current frontend.
 
-        This magic command can either take a local filename, an url,
-        an history range (see %history) or a macro as argument ::
+        Usage:\\
+          %load [options] source
+
+          where source can be a filename,URL, history patern or macro 
+
+        Options:
+        --------
+          -y : Don't ask confirmation for loading source above 1600 caracters.
+               Usefull for Frontend not supporting `raw_input`
+
+        This magic command can either take a local filename, an url, an history
+        range (see %history) or a macro as argument, it will prompt for
+        confirmation before loading source with more than 1600 caracters, unless
+        -y flag is passed ::
 
         %load myscript.py
         %load 7-27
         %load myMacro
         %load http://www.example.com/myscript.py
         """
- 
-        contents = self.shell.find_user_code(arg_s)
+        opts,args = self.parse_options(arg_s,'y',mode='list')
+        args = " ".join(args)
+
+        contents = self.shell.find_user_code(args)
+        l = len(contents)
+
+        # 1600 is ~ 20 full 80 caracter lines
+        # so in average, more than 40 lines
+        # this might be made configurable
+        if l > 1600 and 'y' not in opts:
+            ans = raw_input("The text you'r trying to load seem pretty big ( %d characters). Continue (y/[N])?" % l )
+            if ans.lower() not in ('y','yes') :
+                print 'Operation cancelled.'
+                return
+
         self.set_next_input(contents)
 
     def _find_edit_target(self, args, opts, last_call):

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -19,12 +19,10 @@ import __builtin__ as builtin_mod
 import __future__
 import bdb
 import inspect
-import imp
 import io
 import json
 import os
 import sys
-import shutil
 import re
 import time
 import gc
@@ -44,27 +42,23 @@ except ImportError:
     except ImportError:
         profile = pstats = None
 
-import IPython
 from IPython.core import debugger, oinspect
 from IPython.core.error import TryNext
 from IPython.core.error import UsageError
 from IPython.core.error import StdinNotImplementedError
-from IPython.core.fakemodule import FakeModule
-from IPython.core.profiledir import ProfileDir
 from IPython.core.macro import Macro
 from IPython.core import magic_arguments, page
 from IPython.core.prefilter import ESC_MAGIC
 from IPython.core.pylabtools import mpl_runner
 from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils import py3compat
-from IPython.utils import openpy
 from IPython.utils.encoding import DEFAULT_ENCODING
 from IPython.utils.io import file_read, nlprint
 from IPython.utils.module_paths import find_mod
 from IPython.utils.path import get_py_filename, unquote_filename
 from IPython.utils.process import arg_split, abbrev_cwd
 from IPython.utils.terminal import set_term_title
-from IPython.utils.text import LSString, SList, format_screen
+from IPython.utils.text import format_screen
 from IPython.utils.timing import clock, clock2
 from IPython.utils.warn import warn, error
 from IPython.utils.ipstruct import Struct

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2283,16 +2283,16 @@ Currently the magic system has the following functions:\n"""
         Usage:\\
           %load [options] source
 
-          where source can be a filename,URL, history patern or macro 
+          where source can be a filename, URL, input history range or macro
 
         Options:
         --------
-          -y : Don't ask confirmation for loading source above 1600 caracters.
+          -y : Don't ask confirmation for loading source above 200 000 caracters.
                Usefull for Frontend not supporting `raw_input`
 
-        This magic command can either take a local filename, an url, an history
+        This magic command can either take a local filename, a URL, an history
         range (see %history) or a macro as argument, it will prompt for
-        confirmation before loading source with more than 1600 caracters, unless
+        confirmation before loading source with more than 200 000 caracters, unless
         -y flag is passed ::
 
         %load myscript.py
@@ -2306,11 +2306,16 @@ Currently the magic system has the following functions:\n"""
         contents = self.shell.find_user_code(args)
         l = len(contents)
 
-        # 1600 is ~ 20 full 80 caracter lines
-        # so in average, more than 40 lines
-        # this might be made configurable
-        if l > 1600 and 'y' not in opts:
-            ans = raw_input("The text you'r trying to load seem pretty big ( %d characters). Continue (y/[N])?" % l )
+        # 200 000 is ~ 2500 full 80 caracter lines
+        # so in average, more than 5000 lines
+        if l > 200000 and 'y' not in opts:
+            try:
+                ans = raw_input("The text you'r trying to load seem pretty big\
+                ( %d characters).Continue (y/[N])?" % l )
+            except StdinNotImplementedError:
+                #asume yes if raw input not implemented
+                ans = 'yes'
+
             if ans.lower() not in ('y','yes') :
                 print 'Operation cancelled.'
                 return

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2309,13 +2309,13 @@ Currently the magic system has the following functions:\n"""
         # so in average, more than 5000 lines
         if l > 200000 and 'y' not in opts:
             try:
-                ans = raw_input("The text you'r trying to load seem pretty big\
-                ( %d characters).Continue (y/[N])?" % l )
+                ans = self.shell.ask_yes_no(("The text you'r trying to load seem pretty big"\
+                " (%d characters). Continue (y/[N]) ?" % l), default='n' )
             except StdinNotImplementedError:
                 #asume yes if raw input not implemented
-                ans = 'yes'
+                ans = True
 
-            if ans.lower() not in ('y','yes') :
+            if ans is False :
                 print 'Operation cancelled.'
                 return
 

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2288,12 +2288,11 @@ Currently the magic system has the following functions:\n"""
         Options:
         --------
           -y : Don't ask confirmation for loading source above 200 000 caracters.
-               Usefull for Frontend not supporting `raw_input`
 
         This magic command can either take a local filename, a URL, an history
         range (see %history) or a macro as argument, it will prompt for
         confirmation before loading source with more than 200 000 caracters, unless
-        -y flag is passed ::
+        -y flag is passed or if the frontend does not support raw_input::
 
         %load myscript.py
         %load 7-27

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2265,8 +2265,8 @@ Currently the magic system has the following functions:\n"""
     def magic_loadpy(self, arg_s):
         """Alias of `%load`
         
-        `%loadpy` has gain some flexibility and drop the requirement of `.py`
-        extension. So it has been rename simply into %load. You can look at
+        `%loadpy` has gained some flexibility and droped the requirement of a `.py`
+        extension. So it has been renamed simply into %load. You can look at
         `%load`'s docstring for more info.
         """
         self.magic_load(arg_s)
@@ -2281,11 +2281,11 @@ Currently the magic system has the following functions:\n"""
 
         Options:
         --------
-          -y : Don't ask confirmation for loading source above 200 000 caracters.
+          -y : Don't ask confirmation for loading source above 200 000 characters.
 
         This magic command can either take a local filename, a URL, an history
         range (see %history) or a macro as argument, it will prompt for
-        confirmation before loading source with more than 200 000 caracters, unless
+        confirmation before loading source with more than 200 000 characters, unless
         -y flag is passed or if the frontend does not support raw_input::
 
         %load myscript.py
@@ -2303,7 +2303,7 @@ Currently the magic system has the following functions:\n"""
         # so in average, more than 5000 lines
         if l > 200000 and 'y' not in opts:
             try:
-                ans = self.shell.ask_yes_no(("The text you'r trying to load seem pretty big"\
+                ans = self.shell.ask_yes_no(("The text you're trying to load seems pretty big"\
                 " (%d characters). Continue (y/[N]) ?" % l), default='n' )
             except StdinNotImplementedError:
                 #asume yes if raw input not implemented

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2217,8 +2217,8 @@ Currently the magic system has the following functions:\n"""
         if not fname.endswith('.py'):
             fname += '.py'
         if os.path.isfile(fname):
-            ans = raw_input('File `%s` exists. Overwrite (y/[N])? ' % fname)
-            if ans.lower() not in ['y','yes']:
+            overwrite = self.shell.ask_yes_no('File `%s` exists. Overwrite (y/[N])? ' % fname, default='n')
+            if not overwrite :
                 print 'Operation cancelled.'
                 return
         try:

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2277,21 +2277,7 @@ Currently the magic system has the following functions:\n"""
         %loadpy http://www.example.com/myscript.py
         """
  
-        fileorurl = self._get_file_or_url(arg_s)
-        contents = fileorurl['content']
-        local_url = fileorurl['local']
-        filename = fileorurl['filename']
-
-        if local_url and not filename.endswith('.py'):
-            # Local files must be .py; for remote URLs it's possible that the
-            # fetch URL doesn't have a .py in it (many servers have an opaque
-            # URL, such as scipy-central.org).
-            raise ValueError('%%loadpy only works with .py files: %s' % arg_s)
-
-        if not contents : 
-            print "Error: no such file, variable or URL"
-            return
-        
+        contents = self.shell.find_user_code(arg_s)
         self.set_next_input(contents)
 
     def _find_edit_target(self, args, opts, last_call):
@@ -3322,38 +3308,6 @@ Defaulting color scheme to 'NoColor'"""
                 bkms[args[0]] = args[1]
         self.db['bookmarks'] = bkms
 
-    def _get_file_or_url(self, parameter_s=''):
-        """Try to find the content of a file or URL
-
-        return dict with key:
-        ====================
-        content : file or url content
-        filename : filename if local
-        local : (bool) true if local file
-
-        """
-
-        parameter_s = unquote_filename(parameter_s)
-        remote_url = parameter_s.startswith(('http://', 'https://'))
-
-        # openpy takes care of finding the source encoding (per PEP 263)
-        filename = None
-        if remote_url:
-            try :
-                cont = openpy.read_py_url(parameter_s, skip_encoding_cookie=True)
-            except IOError :
-                cont = None
-        else:
-            try:
-                filename = get_py_filename(parameter_s)
-                cont = file_read(filename)
-            except IOError:
-                try:
-                    cont = eval(parameter_s,self.user_ns)
-                except NameError:
-                    cont = None
-        return {'content': cont, 'filename':filename , 'local': not remote_url}
-
 
     def magic_pycat(self, parameter_s=''):
         """Show a syntax-highlighted file through a pager.
@@ -3361,15 +3315,19 @@ Defaulting color scheme to 'NoColor'"""
         This magic is similar to the cat utility, but it will assume the file
         to be Python source and will show it with syntax highlighting.
 
-        This magic command can either take a local filename or a url::
+        This magic command can either take a local filename, an url,
+        an history range (see %history) or a macro as argument ::
 
         %pycat myscript.py
+        %pycat 7-27
+        %pycat myMacro
         %pycat http://www.example.com/myscript.py
         """
 
-        cont = self._get_file_or_url(parameter_s)['content']
-        if cont is None:
-            print "Error: no such file, variable or URL"
+        try :
+            cont = self.shell.find_user_code(parameter_s)
+        except ValueError, IOError:
+            print "Error: no such file, variable, URL, history range or macro"
             return
 
         page.page(self.shell.pycolorize(cont))

--- a/IPython/frontend/html/notebook/notebookmanager.py
+++ b/IPython/frontend/html/notebook/notebookmanager.py
@@ -41,7 +41,7 @@ class NotebookManager(LoggingConfigurable):
     save_script = Bool(False, config=True,
         help="""Automatically create a Python script when saving the notebook.
         
-        For easier use of import, %run and %loadpy across notebooks, a
+        For easier use of import, %run and %load across notebooks, a
         <notebook-name>.py script will be created next to any
         <notebook-name>.ipynb on each save.  This can also be set with the
         short `--script` flag.

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -597,7 +597,7 @@ class MainWindow(QtGui.QMainWindow):
 
         # list of protected magic that don't like to be called without argument
         # append '?' to the end to print the docstring when called from the menu
-        protected_magic = set(["more","less","load_ext","pycat","loadpy","save"])
+        protected_magic = set(["more","less","load_ext","pycat","loadpy","load","save"])
         magics=re.findall('\w+', listofmagic)
         for magic in magics:
             if magic in protected_magic:

--- a/IPython/utils/openpy.py
+++ b/IPython/utils/openpy.py
@@ -189,3 +189,4 @@ def read_py_url(url, errors='replace', skip_encoding_cookie=True):
         return "".join(strip_encoding_cookie(text))
     else:
         return text.read()
+

--- a/IPython/utils/openpy.py
+++ b/IPython/utils/openpy.py
@@ -6,7 +6,6 @@ Much of the code is taken from the tokenize module in Python 3.2.
 """
 from __future__ import absolute_import
 
-import __builtin__
 import io
 from io import TextIOWrapper
 import re

--- a/docs/examples/notebooks/00_notebook_tour.ipynb
+++ b/docs/examples/notebooks/00_notebook_tour.ipynb
@@ -1014,7 +1014,7 @@
      "source": [
       "# Loading external codes",
       "* Drag and drop a ``.py`` in the dashboard",
-      "* Use ``%loadpy`` with any local or remote url: [the Matplotlib Gallery!](http://matplotlib.sourceforge.net/gallery.html)",
+      "* Use ``%load`` with any local or remote url: [the Matplotlib Gallery!](http://matplotlib.sourceforge.net/gallery.html)",
       "",
       "In this notebook we've kept the output saved so you can see the result, but you should run the next",
       "cell yourself (with an active internet connection)."
@@ -1024,7 +1024,7 @@
      "cell_type": "code",
      "collapsed": true,
      "input": [
-      "%loadpy http://matplotlib.sourceforge.net/mpl_examples/pylab_examples/integral_demo.py"
+      "%load http://matplotlib.sourceforge.net/mpl_examples/pylab_examples/integral_demo.py"
      ],
      "language": "python",
      "outputs": [],

--- a/docs/examples/tests/heartbeat/hb_gil.py
+++ b/docs/examples/tests/heartbeat/hb_gil.py
@@ -1,7 +1,7 @@
 """
 Run this script in the qtconsole with one of:
 
-    %loadpy hb_gil.py
+    %load hb_gil.py
 
 or
     %run hb_gil.py

--- a/docs/source/interactive/qtconsole.txt
+++ b/docs/source/interactive/qtconsole.txt
@@ -33,18 +33,18 @@ is not yet configurable.
    point in a multiline block, you can force its execution (without having to
    go to the bottom) with :kbd:`Shift-Enter`.
 
-``%loadpy``
-===========
+``%load``
+=========
 
-The new ``%loadpy`` magic takes any python script (must end in '.py'), and
-pastes its contents as your next input, so you can edit it before
-executing. The script may be on your machine, but you can also specify a url,
-and it will download the script from the web. This is particularly useful for
-playing with examples from documentation, such as matplotlib.
+The new ``%load`` magic (previously ``%loadpy``) takes any script, and pastes
+its contents as your next input, so you can edit it before executing. The
+script may be on your machine, but you can also specify an history range, or a
+url, and it will download the script from the web. This is particularly useful
+for playing with examples from documentation, such as matplotlib.
 
 .. sourcecode:: ipython
 
-    In [6]: %loadpy http://matplotlib.sourceforge.net/plot_directive/mpl_examples/mplot3d/contour3d_demo.py
+    In [6]: %load http://matplotlib.sourceforge.net/plot_directive/mpl_examples/mplot3d/contour3d_demo.py
 
     In [7]: from mpl_toolkits.mplot3d import axes3d
        ...: import matplotlib.pyplot as plt


### PR DESCRIPTION
this make %pycat aware of URLs and %loadpy able to load file with the user not
having to write the py extension.

%loadpy is  still verifying that the loaded file as a
.py extension
