### PR TITLE
cleanup sqlitedb temporary db file after tests

### DIFF
--- a/IPython/parallel/tests/test_db.py
+++ b/IPython/parallel/tests/test_db.py
@@ -18,6 +18,7 @@ Authors:
 
 from __future__ import division
 
+import os
 import tempfile
 import time
 
@@ -222,3 +223,11 @@ class TestSQLiteBackend(TestDictBackend):
     
     def tearDown(self):
         self.db._db.close()
+
+
+def teardown():
+    """cleanup task db file after all tests have run"""
+    try:
+        os.remove(os.path.join(tempfile.gettempdir(), 'tasks.db'))
+    except:
+        pass

--- a/IPython/parallel/tests/test_db.py
+++ b/IPython/parallel/tests/test_db.py
@@ -38,6 +38,12 @@ from IPython.zmq.session import Session
 # TestCases
 #-------------------------------------------------------------------------------
 
+
+def setup():
+    global temp_db
+    temp_db = tempfile.NamedTemporaryFile(suffix='.db').name
+
+
 class TestDictBackend(TestCase):
     def setUp(self):
         self.session = Session()
@@ -219,7 +225,8 @@ class TestSQLiteBackend(TestDictBackend):
 
     @dec.skip_without('sqlite3')
     def create_db(self):
-        return SQLiteDB(location=tempfile.gettempdir())
+        location, fname = os.path.split(temp_db)
+        return SQLiteDB(location=location, fname=fname)
     
     def tearDown(self):
         self.db._db.close()
@@ -228,6 +235,6 @@ class TestSQLiteBackend(TestDictBackend):
 def teardown():
     """cleanup task db file after all tests have run"""
     try:
-        os.remove(os.path.join(tempfile.gettempdir(), 'tasks.db'))
+        os.remove(temp_db)
     except:
         pass


### PR DESCRIPTION
Avoids 

```
...
[Application] Table _ exists and doesn't match db format, trying __1
[Application] keys mismatch
```

messages in the test suite, which could happen if the test suite was run in relatively quick succession across db-format changes.
