### PR TITLE
exit notebook cleanly on SIGINT, SIGTERM

### DIFF
--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -449,11 +449,20 @@ class NotebookApp(BaseIPythonApplication):
                 self.port = port
                 break
     
+    def init_signal(self):
+        signal.signal(signal.SIGINT, self._handle_signal)
+        signal.signal(signal.SIGTERM, self._handle_signal)
+    
+    def _handle_signal(self, sig, frame):
+        self.log.critical("received signal %s, stopping", sig)
+        ioloop.IOLoop.instance().stop()
+    
     @catch_config_error
     def initialize(self, argv=None):
         super(NotebookApp, self).initialize(argv)
         self.init_configurables()
         self.init_webapp()
+        self.init_signal()
 
     def cleanup_kernels(self):
         """shutdown all kernels


### PR DESCRIPTION
makes it a bit more likely security files, etc. will be cleaned up.

We already handled SIGINT, but now SIGTERM results in clean exit as well.

Closes #1601
