### PR TITLE
allow map / parallel function for single-engine views

### DIFF
--- a/IPython/parallel/client/remotefunction.py
+++ b/IPython/parallel/client/remotefunction.py
@@ -182,6 +182,9 @@ class ParallelFunction(RemoteFunction):
             # 'all' is lazily evaluated at execution time, which is now:
             if targets == 'all':
                 targets = client._build_targets(targets)[1]
+            elif isinstance(targets, int):
+                # single-engine view, targets must be iterable
+                targets = [targets]
             nparts = len(targets)
 
         msg_ids = []

--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -534,4 +534,10 @@ class TestView(ClusterTestCase):
         echo = lambda x:x
         self.assertRaisesRemote(NameError, v.apply_sync, echo, r)
 
+    def test_single_engine_map(self):
+        e0 = self.client[self.client.ids[0]]
+        r = range(5)
+        check = [ -1*i for i in r ]
+        result = e0.map_sync(lambda x: -1*x, r)
+        self.assertEquals(result, check)
 


### PR DESCRIPTION
it's a bit of a weird thing to do, but I don't see a significant reason not to allow it.  Map/parallel functions are unambiguous in what they should return (a list of length one), as opposed to apply, where there is a distinction between:

```
e0a = e[0] # apply returns single result

e0b = e[:1] # apply returns list of length 1
```

An alternative would be to just give a better error message when trying map/parallel functions on single-engine views.
