### PR TITLE
Add show() method to figure objects.

### DIFF
--- a/docs/examples/tests/pylab_figshow.py
+++ b/docs/examples/tests/pylab_figshow.py
@@ -1,0 +1,23 @@
+"""Manual test for figure.show() in the inline matplotlib backend.
+
+This script should be loaded for interactive use (via %load) into a qtconsole
+or notebook initialized with the pylab inline backend.  
+
+Expected behavior: only *one* copy of the figure is shown.
+
+
+For further details:
+https://github.com/ipython/ipython/issues/1612
+https://github.com/matplotlib/matplotlib/issues/835
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+plt.ioff()                                                                      
+x = np.random.uniform(-5, 5, size=(100))
+y = np.random.uniform(-5, 5, size=(100))
+f = plt.figure()
+plt.scatter(x, y)
+plt.plot(y)
+f.show()


### PR DESCRIPTION
This is a hack, but needed to match the monkeypatching applied by mpl in some backends (not all).

See #1612 and https://github.com/matplotlib/matplotlib/issues/835 for more.

Closes #1612.
