### PR TITLE
pyin message now have execution_count

### DIFF
--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -226,11 +226,11 @@ class Kernel(Configurable):
     # Kernel request handlers
     #---------------------------------------------------------------------------
 
-    def _publish_pyin(self, code, parent):
+    def _publish_pyin(self, code, parent, execution_count):
         """Publish the code request on the pyin stream."""
 
-        self.session.send(self.iopub_socket, u'pyin', {u'code':code},
-                          parent=parent)
+        self.session.send(self.iopub_socket, u'pyin', {u'code':code,
+                          u'execution_count': execution_count}, parent=parent)
 
     def execute_request(self, ident, parent):
 
@@ -271,7 +271,7 @@ class Kernel(Configurable):
         # Re-broadcast our input for the benefit of listening clients, and
         # start computing output
         if not silent:
-            self._publish_pyin(code, parent)
+            self._publish_pyin(code, parent, shell.execution_count)
 
         reply_content = {}
         try:

--- a/docs/source/development/messaging.txt
+++ b/docs/source/development/messaging.txt
@@ -766,7 +766,12 @@ These messages are the re-broadcast of the ``execute_request``.
 Message type: ``pyin``::
 
     content = {
-        'code' : str  # Source code to be executed, one or more lines
+        'code' : str,  # Source code to be executed, one or more lines
+
+        # The counter for this execution is also provided so that clients can
+        # display it, since IPython automatically creates variables called _iN
+        # (for input prompt In[N]).
+        'execution_count' : int
     }
 
 Python outputs


### PR DESCRIPTION
This addresses #1619.

One remaining instance of a 'pyin' message that currently lacks execution_count is found on line 112 of `IPython/zmq/pykernel.py` - I'm not sure when this code path is used, and what the appropriate way to proceed there is.

@minrk, I'm ping-ponging this one back at you :)
