### PR TITLE
clear In[] prompt numbers on "Clear All Output"

### DIFF
--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -874,6 +874,9 @@ var IPython = (function (IPython) {
         for (var i=0; i<ncells; i++) {
             if (cells[i] instanceof IPython.CodeCell) {
                 cells[i].clear_output(true,true,true);
+                // Make all In[] prompts blank, as well
+                // TODO: make this configurable (via checkbox?)
+                cells[i].set_input_prompt();
             }
         };
         this.dirty = true;


### PR DESCRIPTION
For more version-control-friendly `.ipynb` files, I've found it useful to strip the `In[]` prompt numbers when doing a "Clear all output".

I noted in the commit here that this should be a configurable behavior, and would love a pointer for how to proceed with making it configurable (using some javascript checkbox widget?)

I'm equally happy with amending this commit to just be the default, and punting on the configurability until a later date.
