### PR TITLE
Fixes for byte-compilation on Python 3

### DIFF
--- a/IPython/core/tests/nonascii.py
+++ b/IPython/core/tests/nonascii.py
@@ -1,4 +1,4 @@
-# encoding: iso-8859-5
+# coding: iso-8859-5
 # (Unlikely to be the default encoding for most testers.)
 # ±¶ÿאבגדהוזחטיךכלםמן <- Cyrillic characters
 from __future__ import unicode_literals

--- a/setup.py
+++ b/setup.py
@@ -237,6 +237,7 @@ if 'setuptools' in sys.modules:
         from setuptools.command.build_py import build_py
         setup_args['cmdclass'] = {'build_py': record_commit_info('IPython', build_cmd=build_py)}
         setuptools_extra_args['entry_points'] = find_scripts(True, suffix='3')
+        setuptools._dont_write_bytecode = True
 else:
     # If we are running without setuptools, call this function which will
     # check for dependencies an inform the user what is needed.  This is


### PR DESCRIPTION
Two distinct but related fixes:
- A slight hack so setuptools refrains from trying to byte-compile everything - issue #1470. The actual modules are still compiled by another step when I do `python3 setup.py install`, but that step is smart enough not to try to compile the examples as well.
- A workaround for a bug in Python 3.1 - py_compile had only partly implemented PEP 263, so it recognises `coding:`, but not `encoding:` to specify a file encoding. This was causing build failures since my `nonascii.py` test sample was merged.
