### PR TITLE
Exclude UserDict when deep reloading NumPy.

### DIFF
--- a/IPython/lib/tests/test_deepreload.py
+++ b/IPython/lib/tests/test_deepreload.py
@@ -27,7 +27,7 @@ def test_deepreload_numpy():
         # Standard exclusions:
         'sys', 'os.path', '__builtin__', '__main__',
         # Test-related exclusions:
-        'unittest',
+        'unittest', 'UserDict',
         ]
     dreload(numpy, exclude=exclude)
 


### PR DESCRIPTION
This prevents another test failure in IPython.lib.tests.test_irunner_pylab_magic::

```
Traceback (most recent call last):
...
  File "/usr/lib/python2.7/weakref.py", line 53, in __init__
    UserDict.UserDict.__init__(self, *args, **kw)
TypeError: unbound method __init__() must be called with UserDict instance as first argument (got WeakValueDictionary instance instead)
```

Closes #1636.
