### PR TITLE
Add %open magic command to open editor in non-blocking manner

### DIFF
--- a/IPython/core/hooks.py
+++ b/IPython/core/hooks.py
@@ -42,6 +42,7 @@ somewhere in your configuration files or ipython command line.
 #*****************************************************************************
 
 import os, bisect
+import subprocess
 import sys
 
 from IPython.core.error import TryNext
@@ -54,7 +55,7 @@ __all__ = ['editor', 'fix_error_editor', 'synchronize_with_editor',
            'show_in_pager','pre_prompt_hook',
            'pre_run_code_hook', 'clipboard_get']
 
-def editor(self,filename, linenum=None):
+def editor(self, filename, linenum=None, wait=True):
     """Open the default editor at the given filename and linenumber.
 
     This is IPython's default editor hook, you can use it as an example to
@@ -76,7 +77,9 @@ def editor(self,filename, linenum=None):
         editor = '"%s"' % editor
 
     # Call the actual editor
-    if os.system('%s %s %s' % (editor,linemark,filename)) != 0:
+    proc = subprocess.Popen('%s %s %s' % (editor, linemark, filename),
+                            shell=True)
+    if wait and proc.wait() != 0:
         raise TryNext()
 
 import tempfile

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2592,6 +2592,41 @@ Currently the magic system has the following functions:\n"""
                 else:
                     self.shell.showtraceback()
 
+    @skip_doctest
+    def magic_open(self, parameter_s='', last_call=['', '']):
+        """Open editor in non-blocking manner.
+
+        Usage:
+          %open [options] [args]
+
+        %open acts similarly as %edit.  However, it does not block
+        IPython so that you can continue interaction with IPython and
+        view code at the same time.  See the document of %edit for
+        more information.  Options '-p', '-r' and '-n' are available
+        and same as %edit.
+
+        """
+        opts, args = self.parse_options(parameter_s,'prn:')
+
+        try:
+            (filename, lineno, is_temp) = self._find_edit_target(
+                args, opts, last_call)
+        except MacroToEdit as e:
+            filename = self.shell.mktempfile(e.args[0].value)
+            self.shell.hooks.editor(filename)
+            return
+
+        print 'Opening...',
+        sys.stdout.flush()
+        try:
+            # Quote filenames that may have spaces in them
+            if ' ' in filename:
+                filename = "'%s'" % filename
+            self.shell.hooks.editor(filename, lineno, wait=False)
+        except TryNext:
+            warn('Could not open editor')
+            return
+
     def magic_xmode(self,parameter_s = ''):
         """Switch modes for the exception handlers.
 


### PR DESCRIPTION
```
    Open editor in non-blocking manner.

    Usage:
      %open [options] [args]

    %open acts similarly as %edit.  However, it does not block
    IPython so that you can continue interaction with IPython and
    view code at the same time.  See the document of %edit for
    more information.  Options '-p', '-r' and '-n' are available
    and same as %edit.
```

It is probably better to make open command configurable instead of using edit command, but I think it is a good starting point.
