### PR TITLE
Add `wait` optional argument to `hooks.editor`

### DIFF
--- a/IPython/core/hooks.py
+++ b/IPython/core/hooks.py
@@ -42,6 +42,7 @@ somewhere in your configuration files or ipython command line.
 #*****************************************************************************
 
 import os, bisect
+import subprocess
 import sys
 
 from IPython.core.error import TryNext
@@ -54,7 +55,7 @@ __all__ = ['editor', 'fix_error_editor', 'synchronize_with_editor',
            'show_in_pager','pre_prompt_hook',
            'pre_run_code_hook', 'clipboard_get']
 
-def editor(self,filename, linenum=None):
+def editor(self, filename, linenum=None, wait=True):
     """Open the default editor at the given filename and linenumber.
 
     This is IPython's default editor hook, you can use it as an example to
@@ -76,7 +77,9 @@ def editor(self,filename, linenum=None):
         editor = '"%s"' % editor
 
     # Call the actual editor
-    if os.system('%s %s %s' % (editor,linemark,filename)) != 0:
+    proc = subprocess.Popen('%s %s %s' % (editor, linemark, filename),
+                            shell=True)
+    if wait and proc.wait() != 0:
         raise TryNext()
 
 import tempfile


### PR DESCRIPTION
subprocess.Popen is used instead of os.system in order to spawn editor process in non-blocking manner.

See also: #1655

I think there are two ways to improve this patch (as @takluyver suggested):
1. When `wait == False`, sleep short time (0.1 sec) right after starting editor process to check if the editor exits with non-zero exit code.
2. Catch stdout/err when `wait == False` so that message will not be printed in unexpected way (like after the next `In[]` prompt).  If we add sleep, error message can be printed only when editor exits immediately with an error.

Please tell me if you want to implement these.
