### PR TITLE
Handle carriage return characters ("\r") in HTML notebook output.

### DIFF
--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -623,12 +623,8 @@ var IPython = (function (IPython) {
         if (json.stream == undefined){
             json.stream = 'stdout';
         }
+
         var text = utils.fixConsole(json.text);
-        if (!text){
-            // fixConsole gives nothing (empty string, \r, etc.)
-            // so don't append any elements, which might add undesirable space
-            return;
-        }
         var subclass = "output_"+json.stream;
         if (this.outputs.length > 0){
             // have at least one output to consider
@@ -642,6 +638,12 @@ var IPython = (function (IPython) {
                 pre.text(text);
                 return;
             }
+        }
+
+        if (!text.replace("\r", "")) {
+            // text is nothing (empty string, \r, etc.)
+            // so don't append any elements, which might add undesirable space
+            return;
         }
 
         // If we got here, attach a new div

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -623,7 +623,8 @@ var IPython = (function (IPython) {
         if (json.stream == undefined){
             json.stream = 'stdout';
         }
-        if (!utils.fixConsole(json.text)){
+        var text = utils.fixConsole(json.text);
+        if (!text){
             // fixConsole gives nothing (empty string, \r, etc.)
             // so don't append any elements, which might add undesirable space
             return;
@@ -636,15 +637,16 @@ var IPython = (function (IPython) {
                 // latest output was in the same stream,
                 // so append directly into its pre tag
                 // escape ANSI & HTML specials:
-                var text = utils.fixConsole(json.text);
-                this.element.find('div.'+subclass).last().find('pre').append(text);
+                pre = this.element.find('div.'+subclass).last().find('pre');
+                text = utils.fixCarriageReturn(pre.text() + text);
+                pre.text(text);
                 return;
             }
         }
-        
+
         // If we got here, attach a new div
         var toinsert = this.create_output_area();
-        this.append_text(json.text, toinsert, "output_stream "+subclass);
+        this.append_text(text, toinsert, "output_stream "+subclass);
         this.element.find('div.output').append(toinsert);
     };
 
@@ -702,6 +704,7 @@ var IPython = (function (IPython) {
         var toinsert = $("<div/>").addClass("box_flex1 output_subarea output_text");
         // escape ANSI & HTML specials in plaintext:
         data = utils.fixConsole(data);
+        data = utils.fixCarriageReturn(data);
         if (extra_class){
             toinsert.addClass(extra_class);
         }

--- a/IPython/frontend/html/notebook/static/js/pager.js
+++ b/IPython/frontend/html/notebook/static/js/pager.js
@@ -89,9 +89,9 @@ var IPython = (function (IPython) {
 
     Pager.prototype.append_text = function (text) {
         var toinsert = $("<div/>").addClass("output_area output_stream");
-        toinsert.append($('<pre/>').html(utils.fixConsole(text)));
+        toinsert.append($('<pre/>').html(utils.fixCarriageReturn(utils.fixConsole(text))));
         this.pager_element.append(toinsert);
-    };   
+    };
 
 
     IPython.Pager = Pager;

--- a/IPython/frontend/html/notebook/static/js/utils.js
+++ b/IPython/frontend/html/notebook/static/js/utils.js
@@ -72,8 +72,8 @@ IPython.utils = (function (IPython) {
         return txt;
     }
 
-    // Remove chunks that should be overridden by the effect carriage
-    // return characters
+    // Remove chunks that should be overridden by the effect of
+    // carriage return characters
     function fixCarriageReturn(txt) {
         tmp = txt;
         do {

--- a/IPython/frontend/html/notebook/static/js/utils.js
+++ b/IPython/frontend/html/notebook/static/js/utils.js
@@ -57,7 +57,6 @@ IPython.utils = (function (IPython) {
         var cmds = [];
         var opener = "";
         var closer = "";
-        // \r does nothing, so shouldn't be included
         while (re.test(txt)) {
             var cmds = txt.match(re)[1].split(";");
             closer = opened?"</span>":"";

--- a/IPython/frontend/html/notebook/static/js/utils.js
+++ b/IPython/frontend/html/notebook/static/js/utils.js
@@ -47,7 +47,7 @@ IPython.utils = (function (IPython) {
         "37":"ansigrey", "01":"ansibold"
     };
 
-    // Transform ANI color escape codes into HTML <span> tags with css
+    // Transform ANSI color escape codes into HTML <span> tags with css
     // classes listed in the above ansi_colormap object. The actual color used
     // are set in the css file.
     function fixConsole(txt) {
@@ -58,7 +58,6 @@ IPython.utils = (function (IPython) {
         var opener = "";
         var closer = "";
         // \r does nothing, so shouldn't be included
-        txt = txt.replace('\r', '');
         while (re.test(txt)) {
             var cmds = txt.match(re)[1].split(";");
             closer = opened?"</span>":"";
@@ -74,6 +73,16 @@ IPython.utils = (function (IPython) {
         return txt;
     }
 
+    // Remove chunks that should be overridden by the effect carriage
+    // return characters
+    function fixCarriageReturn(txt) {
+        tmp = txt;
+        do {
+            txt = tmp;
+            tmp = txt.replace(/^.*\r/gm, '');
+        } while (tmp.length < txt.length);
+        return txt;
+    }
 
     grow = function(element) {
         // Grow the cell by hand. This is used upon reloading from JSON, when the
@@ -95,7 +104,8 @@ IPython.utils = (function (IPython) {
     return {
         uuid : uuid,
         fixConsole : fixConsole,
-        grow : grow
+        grow : grow,
+        fixCarriageReturn : fixCarriageReturn
     };
 
 }(IPython));


### PR DESCRIPTION
It does not currently save/restore notebooks correctly.  Any pointers on that?
