### PR TITLE
Delay flushing softspace until after cell finishes

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2555,14 +2555,19 @@ class InteractiveShell(SingletonConfigurable, Magic):
             for i, node in enumerate(to_run_exec):
                 mod = ast.Module([node])
                 code = self.compile(mod, cell_name, "exec")
-                if self.run_code(code):
+                if self.run_code(code, flush_softspace=False):
                     return True
 
             for i, node in enumerate(to_run_interactive):
                 mod = ast.Interactive([node])
                 code = self.compile(mod, cell_name, "single")
-                if self.run_code(code):
+                if self.run_code(code, flush_softspace=False):
                     return True
+
+            # Flush softspace
+            if softspace(sys.stdout, 0):
+                print
+
         except:
             # It's possible to have exceptions raised here, typically by
             # compilation of odd code (such as a naked 'return' outside a
@@ -2577,7 +2582,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
 
         return False
 
-    def run_code(self, code_obj):
+    def run_code(self, code_obj, flush_softspace=True):
         """Execute a code object.
 
         When an exception occurs, self.showtraceback() is called to display a
@@ -2589,6 +2594,8 @@ class InteractiveShell(SingletonConfigurable, Magic):
           A compiled code object, to be executed
         post_execute : bool [default: True]
           whether to call post_execute hooks after this particular execution.
+        flush_softspace : bool [default: True]
+          whether to flush softspace, i.e., print a new line after this particular execution.
 
         Returns
         -------
@@ -2622,8 +2629,9 @@ class InteractiveShell(SingletonConfigurable, Magic):
             self.showtraceback()
         else:
             outflag = 0
-            if softspace(sys.stdout, 0):
-                print
+            if flush_softspace:
+                if softspace(sys.stdout, 0):
+                    print
 
         return outflag
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2555,13 +2555,13 @@ class InteractiveShell(SingletonConfigurable, Magic):
             for i, node in enumerate(to_run_exec):
                 mod = ast.Module([node])
                 code = self.compile(mod, cell_name, "exec")
-                if self.run_code(code, flush_softspace=False):
+                if self.run_code(code):
                     return True
 
             for i, node in enumerate(to_run_interactive):
                 mod = ast.Interactive([node])
                 code = self.compile(mod, cell_name, "single")
-                if self.run_code(code, flush_softspace=False):
+                if self.run_code(code):
                     return True
 
             # Flush softspace
@@ -2582,7 +2582,7 @@ class InteractiveShell(SingletonConfigurable, Magic):
 
         return False
 
-    def run_code(self, code_obj, flush_softspace=True):
+    def run_code(self, code_obj):
         """Execute a code object.
 
         When an exception occurs, self.showtraceback() is called to display a
@@ -2594,8 +2594,6 @@ class InteractiveShell(SingletonConfigurable, Magic):
           A compiled code object, to be executed
         post_execute : bool [default: True]
           whether to call post_execute hooks after this particular execution.
-        flush_softspace : bool [default: True]
-          whether to flush softspace, i.e., print a new line after this particular execution.
 
         Returns
         -------
@@ -2629,10 +2627,6 @@ class InteractiveShell(SingletonConfigurable, Magic):
             self.showtraceback()
         else:
             outflag = 0
-            if flush_softspace:
-                if softspace(sys.stdout, 0):
-                    print
-
         return outflag
 
     # For backwards compatibility

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -28,6 +28,7 @@ from os.path import join
 import sys
 from StringIO import StringIO
 
+from IPython.testing.decorators import skipif
 from IPython.utils import io
 
 #-----------------------------------------------------------------------------
@@ -254,6 +255,18 @@ class InteractiveShellTestCase(unittest.TestCase):
         # ZeroDivisionError
         self.assertEqual(ip.var_expand(u"{1/0}"), u"{1/0}")
 
+    @skipif(sys.version_info[0] >= 3, "softspace removed in py3")
+    def test_print_softspace(self):
+        """Verify that softspace is handled correctly when executing multiple
+        statements.
+
+        In [1]: print 1; print 2
+        1
+        2
+
+        In [2]: print 1,; print 2
+        1 2
+        """
 
 class TestSafeExecfileNonAsciiPath(unittest.TestCase):
 


### PR DESCRIPTION
Delay flushing softspace (i.e., printing a new line if `sys.stdout.softspace` is True) until after cell finishes executing.

This changes the behavior from

```
In [1]: print 1,; print 2
1
2
```

to the more expected

```
In [1]: print 1,; print 2
1 2
```

Includes a test.  Python 3 remove the notion of softspace, so the test limits itself to Python 2 only.

Closes #1512.
