### PR TITLE
Keep line-endings in ipynb

### DIFF
--- a/IPython/nbformat/v3/tests/nbexamples.py
+++ b/IPython/nbformat/v3/tests/nbexamples.py
@@ -88,6 +88,12 @@ ws.cells.append(new_code_cell(
         etype=u'NameError',
         evalue=u'NameError was here',
         traceback=[u'frame 0', u'frame 1', u'frame 2']
+    ),new_output(
+        output_type=u'stream',
+        output_text='foo\rbar\r\n'
+    ),new_output(
+        output_type=u'stream',
+        output_text='\rfoo\rbar\n'
     )]
 ))
 


### PR DESCRIPTION
Avoids discarding of information, e.g. `foo\rbar` should not be reconstructed as `foo\nbar`.

Implemented in safe manner, where notebooks written by old scheme will load the same as before, and be updated on next save.

Should address notebook loading issue brought up in #1659.
