### PR TITLE
InteractiveShell.run_code: Update docstring.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2587,8 +2587,6 @@ class InteractiveShell(SingletonConfigurable, Magic):
         ----------
         code_obj : code object
           A compiled code object, to be executed
-        post_execute : bool [default: True]
-          whether to call post_execute hooks after this particular execution.
 
         Returns
         -------


### PR DESCRIPTION
The docstring refers to a non-existant `post_execute` parameter which was moved to the
class level in 54e4e463.
