### PR TITLE
Point %pastebin to gist

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -2232,15 +2232,29 @@ Currently the magic system has the following functions:\n"""
         print cmds
 
     def magic_pastebin(self, parameter_s = ''):
-        """Upload code to the 'Lodge it' paste bin, returning the URL."""
+        """Upload code to Github's Gist paste bin, returning the URL.
+        
+        Usage:\\
+          %pastebin [-d "Custom description"] 1-7
+          
+        The argument can be an input history range, a filename, or the name of a
+        string or macro.
+        
+        Options:
+        
+          -d: Pass a custom description for the gist. The default will say
+              "Pasted from IPython".
+        """
+        opts, args = self.parse_options(parameter_s, 'd:')
+        
         try:
-            code = self.shell.find_user_code(parameter_s)
+            code = self.shell.find_user_code(args)
         except (ValueError, TypeError) as e:
             print e.args[0]
             return
         
         post_data = json.dumps({
-          "description": "Pasted from IPython",
+          "description": opts.get('d', "Pasted from IPython"),
           "public": True,
           "files": {
             "file1.py": {

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -21,6 +21,7 @@ import bdb
 import inspect
 import imp
 import io
+import json
 import os
 import sys
 import shutil
@@ -30,7 +31,7 @@ import gc
 from StringIO import StringIO
 from getopt import getopt,GetoptError
 from pprint import pformat
-from xmlrpclib import ServerProxy
+from urllib2 import urlopen
 
 # cProfile was added in Python2.5
 try:
@@ -2237,9 +2238,20 @@ Currently the magic system has the following functions:\n"""
         except (ValueError, TypeError) as e:
             print e.args[0]
             return
-        pbserver = ServerProxy('http://paste.pocoo.org/xmlrpc/')
-        id = pbserver.pastes.newPaste("python", code)
-        return "http://paste.pocoo.org/show/" + id
+        
+        post_data = json.dumps({
+          "description": "Pasted from IPython",
+          "public": True,
+          "files": {
+            "file1.py": {
+              "content": code
+            }
+          }
+        }).encode('utf-8')
+        
+        response = urlopen("https://api.github.com/gists", post_data)
+        response_data = json.loads(response.read().decode('utf-8'))
+        return response_data['html_url']
 
     def magic_loadpy(self, arg_s):
         """Load a .py python script into the GUI console.


### PR DESCRIPTION
Unfortunately http://paste.pocoo.org/ has closed down. This updates the %pastebin magic to use gists instead. The results look like this: https://gist.github.com/2521969

We don't try to use any of the advanced features of gist, such as authenticating to make gists associated with your account. That could be added if there's demand for it, but for now we just send some content and return a URL.
