### PR TITLE
__future__ environments

### DIFF
--- a/IPython/core/compilerop.py
+++ b/IPython/core/compilerop.py
@@ -90,7 +90,7 @@ class CachingCompiler(codeop.Compile):
         # Now, we must monkeypatch the linecache directly so that parts of the
         # stdlib that call it outside our control go through our codepath
         # (otherwise we'd lose our tracebacks).
-        linecache.checkcache = self.check_cache
+        linecache.checkcache = check_linecache_ipython
         
     def ast_parse(self, source, filename='<unknown>', symbol='exec'):
         """Parse code to an AST with the current compiler flags active.
@@ -134,11 +134,11 @@ class CachingCompiler(codeop.Compile):
         linecache._ipython_cache[name] = entry
         return name
 
-    def check_cache(self, *args):
-        """Call linecache.checkcache() safely protecting our cached values.
-        """
-        # First call the orignal checkcache as intended
-        linecache._checkcache_ori(*args)
-        # Then, update back the cache with our data, so that tracebacks related
-        # to our compiled codes can be produced.
-        linecache.cache.update(linecache._ipython_cache)
+def check_linecache_ipython(*args):
+    """Call linecache.checkcache() safely protecting our cached values.
+    """
+    # First call the orignal checkcache as intended
+    linecache._checkcache_ori(*args)
+    # Then, update back the cache with our data, so that tracebacks related
+    # to our compiled codes can be produced.
+    linecache.cache.update(linecache._ipython_cache)

--- a/IPython/core/tests/test_compilerop.py
+++ b/IPython/core/tests/test_compilerop.py
@@ -67,7 +67,7 @@ def test_compiler_check_cache():
     cp = compilerop.CachingCompiler()
     cp.cache('x=1', 99)
     # Ensure now that after clearing the cache, our entries survive
-    cp.check_cache()
+    linecache.checkcache()
     for k in linecache.cache:
         if k.startswith('<ipython-input-99'):
             break

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -384,6 +384,22 @@ class InteractiveShellTestCase(unittest.TestCase):
         finally:
             # Reset the custom exception hook
             ip.set_custom_exc((), None)
+    
+    @skipif(sys.version_info[0] >= 3, "no differences with __future__ in py3")
+    def test_future_environment(self):
+        "Can we run code with & without the shell's __future__ imports?"
+        ip.run_cell("from __future__ import division")
+        ip.run_cell("a = 1/2", shell_futures=True)
+        self.assertEqual(ip.user_ns['a'], 0.5)
+        ip.run_cell("b = 1/2", shell_futures=False)
+        self.assertEqual(ip.user_ns['b'], 0)
+        
+        ip.compile.reset_compiler_flags()
+        # This shouldn't leak to the shell's compiler
+        ip.run_cell("from __future__ import division \nc=1/2", shell_futures=False)
+        self.assertEqual(ip.user_ns['c'], 0.5)
+        ip.run_cell("d = 1/2", shell_futures=True)
+        self.assertEqual(ip.user_ns['d'], 0)
 
 
 class TestSafeExecfileNonAsciiPath(unittest.TestCase):

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -827,7 +827,7 @@ def test_edit_interactive():
     except code.InteractivelyDefined as e:
         nt.assert_equal(e.index, n)
     else:
-        nt.fail("Should have raised InteractivelyDefined")
+        raise AssertionError("Should have raised InteractivelyDefined")
 
 
 def test_edit_cell():


### PR DESCRIPTION
So far, this just closes the .ipy hole, so .py and .ipy files have the same behaviour with respect to **future**, both for %run and as startup files.

There was some discussion on the mailing list about whether `%run` should share the shell's `__future__`, or only `%run -i`. Either way, this will need a bit more thought, because it interacts with the other options that can be passed to `%run`, especially for profiling and debugging.

`%rerun` and macros will share the shell's futures - I think this is expected.
