### PR TITLE
HTML Notebook carriage-return handling, take 2

### DIFF
--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -61,11 +61,11 @@ var IPython = (function (IPython) {
         // handlers and is used to provide custom key handling. Its return
         // value is used to determine if CodeMirror should ignore the event:
         // true = ignore, false = don't ignore.
-        
+
         if (this.read_only){
             return false;
         }
-        
+
         var that = this;
         // whatever key is pressed, first, cancel the tooltip request before
         // they are sent, and remove tooltip if any, except for tab again
@@ -90,7 +90,7 @@ var IPython = (function (IPython) {
                 event.stop();
                 return false;
             } else {
-                return true; 
+                return true;
             };
         } else if (event.which === key.ESC) {
             IPython.tooltip.remove_and_cancel_tooltip(true);
@@ -102,7 +102,7 @@ var IPython = (function (IPython) {
                 event.stop();
                 return false;
             } else {
-                return true; 
+                return true;
             };
         } else if (event.keyCode === key.TAB && event.type == 'keydown') {
             // Tab completion.

--- a/IPython/frontend/html/notebook/static/js/outputarea.js
+++ b/IPython/frontend/html/notebook/static/js/outputarea.js
@@ -181,11 +181,7 @@ var IPython = (function (IPython) {
         if (json.stream == undefined){
             json.stream = 'stdout';
         }
-        if (!utils.fixConsole(json.text)){
-            // fixConsole gives nothing (empty string, \r, etc.)
-            // so don't append any elements, which might add undesirable space
-            return;
-        }
+        var text = utils.fixConsole(json.text);
         var subclass = "output_"+json.stream;
         if (this.outputs.length > 0){
             // have at least one output to consider
@@ -194,15 +190,23 @@ var IPython = (function (IPython) {
                 // latest output was in the same stream,
                 // so append directly into its pre tag
                 // escape ANSI & HTML specials:
-                var text = utils.fixConsole(json.text);
-                this.element.find('div.'+subclass).last().find('pre').append(text);
+                pre = this.element.find('div.'+subclass).last().find('pre');
+                html = utils.fixCarriageReturn(
+                    pre.html() + utils.fixConsole(text));
+                pre.html(html);
                 return;
             }
         }
-        
+
+        if (!text.replace("\r", "")) {
+            // text is nothing (empty string, \r, etc.)
+            // so don't append any elements, which might add undesirable space
+            return;
+        }
+
         // If we got here, attach a new div
         var toinsert = this.create_output_area();
-        this.append_text(json.text, toinsert, "output_stream "+subclass);
+        this.append_text(text, toinsert, "output_stream "+subclass);
         this.element.append(toinsert);
     };
 
@@ -260,6 +264,7 @@ var IPython = (function (IPython) {
         var toinsert = $("<div/>").addClass("box-flex1 output_subarea output_text");
         // escape ANSI & HTML specials in plaintext:
         data = utils.fixConsole(data);
+        data = utils.fixCarriageReturn(data);
         if (extra_class){
             toinsert.addClass(extra_class);
         }
@@ -328,7 +333,7 @@ var IPython = (function (IPython) {
 
     OutputArea.prototype.clear_output_callback = function (stdout, stderr, other) {
         var output_div = this.element;
-        
+
         if (stdout && stderr && other){
             // clear all, no need for logic
             output_div.html("");
@@ -347,7 +352,7 @@ var IPython = (function (IPython) {
         if (other) {
             output_div.find("div.output_subarea").not("div.output_stderr").not("div.output_stdout").parent().remove();
         }
-        
+
         // remove cleared outputs from JSON list:
         for (var i = this.outputs.length - 1; i >= 0; i--) {
             var out = this.outputs[i];

--- a/IPython/frontend/html/notebook/static/js/outputarea.js
+++ b/IPython/frontend/html/notebook/static/js/outputarea.js
@@ -181,7 +181,7 @@ var IPython = (function (IPython) {
         if (json.stream == undefined){
             json.stream = 'stdout';
         }
-        var text = utils.fixConsole(json.text);
+        var text = json.text;
         var subclass = "output_"+json.stream;
         if (this.outputs.length > 0){
             // have at least one output to consider
@@ -190,8 +190,8 @@ var IPython = (function (IPython) {
                 // latest output was in the same stream,
                 // so append directly into its pre tag
                 // escape ANSI & HTML specials:
-                pre = this.element.find('div.'+subclass).last().find('pre');
-                html = utils.fixCarriageReturn(
+                var pre = this.element.find('div.'+subclass).last().find('pre');
+                var html = utils.fixCarriageReturn(
                     pre.html() + utils.fixConsole(text));
                 pre.html(html);
                 return;

--- a/IPython/frontend/html/notebook/static/js/pager.js
+++ b/IPython/frontend/html/notebook/static/js/pager.js
@@ -117,7 +117,7 @@ var IPython = (function (IPython) {
 
     Pager.prototype.append_text = function (text) {
         var toinsert = $("<div/>").addClass("output_area output_stream");
-        toinsert.append($('<pre/>').html(utils.fixConsole(text)));
+        toinsert.append($('<pre/>').html(utils.fixCarriageReturn(utils.fixConsole(text))));
         this.pager_element.append(toinsert);
     };
 

--- a/IPython/frontend/html/notebook/static/js/utils.js
+++ b/IPython/frontend/html/notebook/static/js/utils.js
@@ -47,7 +47,7 @@ IPython.utils = (function (IPython) {
         "37":"ansigrey", "01":"ansibold"
     };
 
-    // Transform ANI color escape codes into HTML <span> tags with css
+    // Transform ANSI color escape codes into HTML <span> tags with css
     // classes listed in the above ansi_colormap object. The actual color used
     // are set in the css file.
     function fixConsole(txt) {
@@ -58,7 +58,6 @@ IPython.utils = (function (IPython) {
         var opener = "";
         var closer = "";
         // \r does nothing, so shouldn't be included
-        txt = txt.replace('\r', '');
         while (re.test(txt)) {
             var cmds = txt.match(re)[1].split(";");
             closer = opened?"</span>":"";
@@ -133,6 +132,7 @@ IPython.utils = (function (IPython) {
         fixConsole : fixConsole,
         keycodes : keycodes,
         grow : grow,
+        fixCarriageReturn : fixCarriageReturn
     };
 
 }(IPython));

--- a/IPython/frontend/html/notebook/static/js/utils.js
+++ b/IPython/frontend/html/notebook/static/js/utils.js
@@ -43,7 +43,7 @@ IPython.utils = (function (IPython) {
     ansi_colormap = {
         "30":"ansiblack", "31":"ansired",
         "32":"ansigreen", "33":"ansiyellow",
-        "34":"ansiblue", "35":"ansipurple","36":"ansicyan", 
+        "34":"ansiblue", "35":"ansipurple","36":"ansicyan",
         "37":"ansigrey", "01":"ansibold"
     };
 
@@ -74,6 +74,16 @@ IPython.utils = (function (IPython) {
         return txt;
     }
 
+    // Remove chunks that should be overridden by the effect of
+    // carriage return characters
+    function fixCarriageReturn(txt) {
+        tmp = txt;
+        do {
+            txt = tmp;
+            tmp = txt.replace(/^.*\r(?!\n)/gm, '');
+        } while (tmp.length < txt.length);
+        return txt;
+    }
 
     grow = function(element) {
         // Grow the cell by hand. This is used upon reloading from JSON, when the
@@ -126,4 +136,3 @@ IPython.utils = (function (IPython) {
     };
 
 }(IPython));
-

--- a/IPython/frontend/html/notebook/static/js/utils.js
+++ b/IPython/frontend/html/notebook/static/js/utils.js
@@ -57,7 +57,6 @@ IPython.utils = (function (IPython) {
         var cmds = [];
         var opener = "";
         var closer = "";
-        // \r does nothing, so shouldn't be included
         while (re.test(txt)) {
             var cmds = txt.match(re)[1].split(";");
             closer = opened?"</span>":"";


### PR DESCRIPTION
This is a fixed version of #1659 that doesn't erase all content returned from shell commands, such as `!ls`.
