### PR TITLE
Kernel status/shutdown from dashboard

### DIFF
--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -590,8 +590,19 @@ class NotebookRootHandler(AuthenticatedHandler):
     @authenticate_unless_readonly
     def get(self):
         nbm = self.application.notebook_manager
+        km = self.application.kernel_manager
         files = nbm.list_notebooks()
-        self.finish(jsonapi.dumps(files))
+        #kernel_for_notebook
+        nlist=[]
+        for f in files :
+            nid = f['notebook_id']
+            if km.kernel_for_notebook(nid) is not None:
+                f['kernel_status']='on'
+            else:
+                f['kernel_status']='off'
+            nlist.append(f)
+        print(files)
+        self.finish(jsonapi.dumps(nlist))
 
     @web.authenticated
     def post(self):

--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -593,10 +593,7 @@ class NotebookRootHandler(AuthenticatedHandler):
         km = self.application.kernel_manager
         files = nbm.list_notebooks()
         for f in files :
-            nid = f['notebook_id']
-            kid = km.kernel_for_notebook(nid)
-            if  kid is not None:
-                f['kernel_id'] = kid
+            f['kernel_id'] = km.kernel_for_notebook(f['notebook_id'])
         self.finish(jsonapi.dumps(files))
 
     @web.authenticated

--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -597,8 +597,6 @@ class NotebookRootHandler(AuthenticatedHandler):
             kid = km.kernel_for_notebook(nid)
             if  kid is not None:
                 f['kernel_status']=kid
-            else:
-                f['kernel_status']='off'
         self.finish(jsonapi.dumps(files))
 
     @web.authenticated

--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -338,7 +338,7 @@ class MainKernelHandler(AuthenticatedHandler):
 
 class KernelHandler(AuthenticatedHandler):
 
-    SUPPORTED_METHODS = ('DELETE')
+    SUPPORTED_METHODS = ('POST','DELETE')
 
     @web.authenticated
     def delete(self, kernel_id):
@@ -346,7 +346,6 @@ class KernelHandler(AuthenticatedHandler):
         km.kill_kernel(kernel_id)
         self.set_status(204)
         self.finish()
-
 
 class KernelActionHandler(AuthenticatedHandler):
 
@@ -596,8 +595,9 @@ class NotebookRootHandler(AuthenticatedHandler):
         nlist=[]
         for f in files :
             nid = f['notebook_id']
-            if km.kernel_for_notebook(nid) is not None:
-                f['kernel_status']='on'
+            kid = km.kernel_for_notebook(nid)
+            if  kid is not None:
+                f['kernel_status']=kid
             else:
                 f['kernel_status']='off'
             nlist.append(f)

--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -596,7 +596,7 @@ class NotebookRootHandler(AuthenticatedHandler):
             nid = f['notebook_id']
             kid = km.kernel_for_notebook(nid)
             if  kid is not None:
-                f['kernel_id']=kid
+                f['kernel_id'] = kid
         self.finish(jsonapi.dumps(files))
 
     @web.authenticated

--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -338,7 +338,7 @@ class MainKernelHandler(AuthenticatedHandler):
 
 class KernelHandler(AuthenticatedHandler):
 
-    SUPPORTED_METHODS = ('POST','DELETE')
+    SUPPORTED_METHODS = ('DELETE')
 
     @web.authenticated
     def delete(self, kernel_id):
@@ -346,6 +346,7 @@ class KernelHandler(AuthenticatedHandler):
         km.kill_kernel(kernel_id)
         self.set_status(204)
         self.finish()
+
 
 class KernelActionHandler(AuthenticatedHandler):
 
@@ -591,8 +592,6 @@ class NotebookRootHandler(AuthenticatedHandler):
         nbm = self.application.notebook_manager
         km = self.application.kernel_manager
         files = nbm.list_notebooks()
-        #kernel_for_notebook
-        nlist=[]
         for f in files :
             nid = f['notebook_id']
             kid = km.kernel_for_notebook(nid)
@@ -600,9 +599,7 @@ class NotebookRootHandler(AuthenticatedHandler):
                 f['kernel_status']=kid
             else:
                 f['kernel_status']='off'
-            nlist.append(f)
-        print(files)
-        self.finish(jsonapi.dumps(nlist))
+        self.finish(jsonapi.dumps(files))
 
     @web.authenticated
     def post(self):

--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -596,7 +596,7 @@ class NotebookRootHandler(AuthenticatedHandler):
             nid = f['notebook_id']
             kid = km.kernel_for_notebook(nid)
             if  kid is not None:
-                f['kernel_status']=kid
+                f['kernel_id']=kid
         self.finish(jsonapi.dumps(files))
 
     @web.authenticated

--- a/IPython/frontend/html/notebook/static/js/menubar.js
+++ b/IPython/frontend/html/notebook/static/js/menubar.js
@@ -68,6 +68,10 @@ var IPython = (function (IPython) {
         this.element.find('button#print_notebook').click(function () {
             IPython.print_widget.print_notebook();
         });
+        this.element.find('#kill_and_exit').click(function () {
+            IPython.notebook.kernel.kill();
+            setTimeout(function(){window.close();}, 200);
+        });
         // Edit
         this.element.find('#cut_cell').click(function () {
             IPython.notebook.cut_cell();

--- a/IPython/frontend/html/notebook/static/js/notebooklist.js
+++ b/IPython/frontend/html/notebook/static/js/notebooklist.js
@@ -248,6 +248,7 @@ var IPython = (function (IPython) {
         var that = this;
         var new_buttons = $('<span/>').addClass('item_buttons');
         var upload_button = $('<button>Upload</button>').button().
+            addClass('upload-button').
             click(function (e) {
                 var nbname = item.find('.item_name > input').attr('value');
                 var nbformat = item.data('nbformat');

--- a/IPython/frontend/html/notebook/static/js/notebooklist.js
+++ b/IPython/frontend/html/notebook/static/js/notebooklist.js
@@ -101,7 +101,7 @@ var IPython = (function (IPython) {
             this.add_link(notebook_id, nbname, item);
             if (!IPython.read_only){
                 // hide delete buttons when readonly
-                if(kernel == undefined){
+                if(kernel == null){
                     this.add_delete_button(item);
                 } else {
                     this.add_shutdown_button(item,kernel);

--- a/IPython/frontend/html/notebook/static/js/notebooklist.js
+++ b/IPython/frontend/html/notebook/static/js/notebooklist.js
@@ -101,7 +101,7 @@ var IPython = (function (IPython) {
             this.add_link(notebook_id, nbname, item);
             if (!IPython.read_only){
                 // hide delete buttons when readonly
-                if(kernel == 'off'){
+                if(kernel == undefined){
                     this.add_delete_button(item);
                 } else {
                     this.add_shutdown_button(item,kernel);
@@ -180,7 +180,6 @@ var IPython = (function (IPython) {
                     type : "DELETE",
                     dataType : "json",
                     success : function (data, status, xhr) {
-                        console.log('kernel killed');
                         that.load_list();
                     }
                 };

--- a/IPython/frontend/html/notebook/static/js/notebooklist.js
+++ b/IPython/frontend/html/notebook/static/js/notebooklist.js
@@ -77,7 +77,6 @@ var IPython = (function (IPython) {
 
 
     NotebookList.prototype.load_list = function () {
-        this.clear_list();
         var settings = {
             processData : false,
             cache : false,
@@ -92,15 +91,21 @@ var IPython = (function (IPython) {
 
     NotebookList.prototype.list_loaded = function (data, status, xhr) {
         var len = data.length;
+        this.clear_list();
         // Todo: remove old children
         for (var i=0; i<len; i++) {
             var notebook_id = data[i].notebook_id;
             var nbname = data[i].name;
+            var kernel = data[i].kernel_status;
             var item = this.new_notebook_item(i);
             this.add_link(notebook_id, nbname, item);
             if (!IPython.read_only){
                 // hide delete buttons when readonly
-                this.add_delete_button(item);
+                if(kernel == 'off'){
+                    this.add_delete_button(item);
+                } else {
+                    this.add_shutdown_button(item,kernel);
+                }
             }
         };
     };
@@ -163,6 +168,33 @@ var IPython = (function (IPython) {
         item.data('nbdata',data);
     };
 
+
+    NotebookList.prototype.add_shutdown_button = function (item,kernel) {
+        var new_buttons = $('<span/>').addClass('item_buttons');
+        var that = this;
+        var shutdown_button = $('<button>Shutdown</button>').button().
+            click(function (e) {
+                var settings = {
+                    processData : false,
+                    cache : false,
+                    type : "DELETE",
+                    dataType : "json",
+                    success : function (data, status, xhr) {
+                        console.log('kernel killed');
+                        that.load_list();
+                    }
+                };
+                var url = $('body').data('baseProjectUrl') + 'kernels/'+kernel;
+                $.ajax(url, settings);
+            });
+        new_buttons.append(shutdown_button);
+        var e = item.find('.item_buttons');
+        if (e.length === 0) {
+            item.append(new_buttons);
+        } else {
+            e.replaceWith(new_buttons);
+        };
+    };
 
     NotebookList.prototype.add_delete_button = function (item) {
         var new_buttons = $('<span/>').addClass('item_buttons');

--- a/IPython/frontend/html/notebook/static/js/notebooklist.js
+++ b/IPython/frontend/html/notebook/static/js/notebooklist.js
@@ -96,7 +96,7 @@ var IPython = (function (IPython) {
         for (var i=0; i<len; i++) {
             var notebook_id = data[i].notebook_id;
             var nbname = data[i].name;
-            var kernel = data[i].kernel_status;
+            var kernel = data[i].kernel_id;
             var item = this.new_notebook_item(i);
             this.add_link(notebook_id, nbname, item);
             if (!IPython.read_only){

--- a/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
+++ b/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
@@ -37,12 +37,18 @@ $(document).ready(function () {
 
     var enable_autorefresh = function(){
         //refresh immediately , then start interval
-        IPython.notebook_list.load_list();
-        IPython.cluster_list.load_list();
+        if($('upload_button').length == 0)
+        {
+            IPython.notebook_list.load_list();
+            IPython.cluster_list.load_list();
+        }
         if (!interval_id){
             interval_id = setInterval(function(){
-                    IPython.notebook_list.load_list();
-                    IPython.cluster_list.load_list();
+                    if($('upload_button').length == 0)
+                    {
+                        IPython.notebook_list.load_list();
+                        IPython.cluster_list.load_list();
+                    }
                 }, time_refresh*1000);
             }
     }
@@ -64,6 +70,9 @@ $(document).ready(function () {
 
     // finally start it, it will refresh immediately
     enable_autorefresh();
+
+    IPython.enable_autorefresh = enable_autorefresh;
+    IPython.disable_autorefresh = disable_autorefresh;
 
     IPython.page.show();
 

--- a/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
+++ b/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
@@ -71,10 +71,6 @@ $(document).ready(function () {
     // finally start it, it will refresh immediately
     enable_autorefresh();
 
-    IPython.enable_autorefresh = enable_autorefresh;
-    IPython.disable_autorefresh = disable_autorefresh;
-
     IPython.page.show();
-
 });
 

--- a/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
+++ b/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
@@ -30,8 +30,40 @@ $(document).ready(function () {
     IPython.cluster_list = new IPython.ClusterList('div#cluster_list');
     IPython.login_widget = new IPython.LoginWidget('span#login_widget');
 
-    IPython.notebook_list.load_list();
-    IPython.cluster_list.load_list();
+    var interval_id=0;
+    // auto refresh every xx secondes, no need to be fast,
+    //  update is done at least when page get focus
+    var time_refresh = 60; // in sec
+
+    var enable_autorefresh = function(){
+        //refresh immediately , then start interval
+        IPython.notebook_list.load_list();
+        IPython.cluster_list.load_list();
+        if (!interval_id){
+            interval_id = setInterval(function(){
+                    IPython.notebook_list.load_list();
+                    IPython.cluster_list.load_list();
+                }, time_refresh*1000);
+            }
+    }
+
+    var disable_autorefresh = function(){
+        clearInterval(interval_id);
+        interval_id = 0;
+    }
+
+    // stop autorefresh when page lose focus
+    $(window).blur(function() {
+        disable_autorefresh();
+    })
+
+    //re-enable when page get focus back
+    $(window).focus(function() {
+        enable_autorefresh();
+    });
+
+    // finally start it, it will refresh immediately
+    enable_autorefresh();
 
     IPython.page.show();
 

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -65,6 +65,8 @@ data-notebook-id={{notebook_id}}
                 </li>
                 <hr/>
                 <li id="print_notebook"><a href="/{{notebook_id}}/print" target="_blank">Print View</a></li>
+                <hr/>
+                <li id="kill_and_exit"><a href="#" >Close and halt</a></li>
             </ul>
         </li>
         <li><a href="#">Edit</a>


### PR DESCRIPTION
this is a partial fix for #1515 ,
It replace  the `delete` button by `shutdown` button when kernel are running.
the list is updated when dashboard page get focus, and refresh every 60 seconds.
Refresh stop when page loose focus.

It also move the `clear_list` when clicking on the refresh button to avoid flickering.
