### PR TITLE
add qt config option to clear_on_kernel_restart

### DIFF
--- a/IPython/frontend/qt/console/frontend_widget.py
+++ b/IPython/frontend/qt/console/frontend_widget.py
@@ -595,7 +595,8 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
             self.reset()
         else:
             self._append_before_prompt_pos = self._get_cursor().position()
-            self._append_plain_text("# restarting kernel...\n#" + "-"*42)
+            self._append_plain_text("# restarting kernel...")
+            self._append_html("<hr><br>")
             # XXX: Reprinting the full banner may be too much, but once #1680 is
             # addressed, that will mitigate it.
             #self._append_plain_text(self.banner)

--- a/IPython/frontend/qt/console/frontend_widget.py
+++ b/IPython/frontend/qt/console/frontend_widget.py
@@ -534,7 +534,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         """ Called when the KernelManager channels have started listening or
             when the frontend is assigned an already listening KernelManager.
         """
-        self.reset(force=True)
+        self.reset(clear=True)
 
     #---------------------------------------------------------------------------
     # 'FrontendWidget' public interface
@@ -568,12 +568,12 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
             self._append_plain_text('Kernel process is either remote or '
                                     'unspecified. Cannot interrupt.\n')
 
-    def reset(self, force=False):
-        """ Resets the widget to its initial state if ``force`` parameter or
+    def reset(self, clear=False):
+        """ Resets the widget to its initial state if ``clear`` parameter or
         ``clear_on_kernel_restart`` configuration setting is True, otherwise
         prints a visual indication of the fact that the kernel restarted, but
         does not clear the traces from previous usage of the kernel before it
-        was restarted.  With ``force=True``, it is similar to ``clear``, but
+        was restarted.  With ``clear=True``, it is similar to ``%clear``, but
         also re-writes the banner and aborts execution if necessary.
         """
         if self._executing:
@@ -582,7 +582,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         self._reading = False
         self._highlighter.highlighting_on = False
 
-        if self.clear_on_kernel_restart or force:
+        if self.clear_on_kernel_restart or clear:
             self._control.clear()
             self._append_plain_text(self.banner)
         else:


### PR DESCRIPTION
Previously, restarting a kernel in the qtconsole always cleared the
entire session. Since qtconsole has a %clear command, it makes sense to
allow users to decouple the two activities - the restarting of kernels,
and clearing the console. This PR adds a configuration option which allows for the restarting of kernels without losing console history. The default value for `clear_on_kernel_restart` is set to True to stay consistent with the way things worked before this functionality was added.

To test, run:

```
ipython qtconsole --IPythonWidget.clear_on_kernel_restart=False
```

Here's what it looks like when the user restarts the kernel on `In[3]`:

```
Python 2.6.5 (r265:79063, Apr 16 2010, 13:57:41)
Type "copyright", "credits" or "license" for more information.

IPython 0.13.dev -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.
%guiref   -> A brief reference about the graphical user interface.

In [1]: 0x42
Out[1]: 66

In [2]: 042
Out[2]: 34

In [3]: # restarting kernel...
#------------------------------------------

In [1]:
```
