### PR TITLE
import Binary from bson instead of pymongo

### DIFF
--- a/IPython/parallel/controller/mongodb.py
+++ b/IPython/parallel/controller/mongodb.py
@@ -12,7 +12,7 @@ Authors:
 #-----------------------------------------------------------------------------
 
 from pymongo import Connection
-from pymongo.binary import Binary
+from bson import Binary
 
 from IPython.utils.traitlets import Dict, List, Unicode, Instance
 


### PR DESCRIPTION
This is where it should have come from all along, anyway.

closes #1683
