### PR TITLE
Fix sys.path missing '' as first entry in `ipython kernel`.

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -117,9 +117,10 @@ class InteractiveShellApp(Configurable):
     
     Provides configurables for loading extensions and executing files
     as part of configuring a Shell environment.
-    
-    Provides init_extensions() and init_code() methods, to be called
-    after init_shell(), which must be implemented by subclasses.
+
+    Provides init_path(), to be called before, and init_extensions() and
+    init_code() methods, to be called after init_shell(), which must be
+    implemented by subclasses.
     """
     extensions = List(Unicode, config=True,
         help="A list of dotted module names of IPython extensions to load."
@@ -155,6 +156,11 @@ class InteractiveShellApp(Configurable):
         when using pylab"""
     )
     shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
+
+    def init_path(self):
+        """Add current working directory, '', to sys.path"""
+        if sys.path[0] != '':
+            sys.path.insert(0, '')
 
     def init_shell(self):
         raise NotImplementedError("Override in subclasses")

--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -314,6 +314,7 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
         # print self.extra_args
         if self.extra_args and not self.something_to_run:
             self.file_to_run = self.extra_args[0]
+        self.init_path()
         # create the shell
         self.init_shell()
         # and draw the banner
@@ -325,10 +326,6 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
 
     def init_shell(self):
         """initialize the InteractiveShell instance"""
-        # I am a little hesitant to put these into InteractiveShell itself.
-        # But that might be the place for them
-        sys.path.insert(0, '')
-
         # Create an InteractiveShell instance.
         # shell.display_banner should always be False for the terminal
         # based app, because we call shell.show_banner() by hand below

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -640,6 +640,10 @@ class IPKernelApp(KernelApp, InteractiveShellApp):
                 
 
     def init_shell(self):
+        # I am a little hesitant to put these into InteractiveShell itself.
+        # But that might be the place for them
+        sys.path.insert(0, '')
+
         self.shell = self.kernel.shell
         self.shell.configurables.append(self)
 

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -597,6 +597,7 @@ class IPKernelApp(KernelApp, InteractiveShellApp):
     @catch_config_error
     def initialize(self, argv=None):
         super(IPKernelApp, self).initialize(argv)
+        self.init_path()
         self.init_shell()
         self.init_extensions()
         self.init_code()
@@ -640,10 +641,6 @@ class IPKernelApp(KernelApp, InteractiveShellApp):
                 
 
     def init_shell(self):
-        # I am a little hesitant to put these into InteractiveShell itself.
-        # But that might be the place for them
-        sys.path.insert(0, '')
-
         self.shell = self.kernel.shell
         self.shell.configurables.append(self)
 


### PR DESCRIPTION
The comment is copied from the corresponding code in `TerminalIPythonApp`.

Closes #1240.

As Min suggests in #1240, we should consider gathering up all of these lines and putting them into `InteractiveShell` (or `InteractiveShellApp`?) instead.

To test:

```
$ ipython kernel &
[1] 10069
$ ipython console --existing kernel-10035.json
Python 2.7.3 (default, Apr 20 2012, 22:39:59) 
Type "copyright", "credits" or "license" for more information.

IPython 0.13.dev -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: import sys

In [2]: sys.path[0]
Out[2]: ''
```
