### PR TITLE
Add quote to notebook to allow it to load

### DIFF
--- a/docs/examples/notebooks/00_notebook_tour.ipynb
+++ b/docs/examples/notebooks/00_notebook_tour.ipynb
@@ -516,7 +516,7 @@
      "cell_type": "markdown",
      "source": [
       "Today's Google doodle, (at the time I created this notebook). This should also work in the Qtconsole.",
-      "Drawback is that the saved notebook will be larger, but the image will still be present offline. 
+      "Drawback is that the saved notebook will be larger, but the image will still be present offline."
      ]
     },
     {


### PR DESCRIPTION
I can't load the 00 intro notebook, in the most resent 0.13dev version, this seems to be because 
a end " is missing in a markdown cell. This pull request fixes that. 

I guess that on the long term it would be good if a syntax error in a single cell only prevented the rendering of this cell. At present the notebook suggest that the notebook might be to new to load even though it is labelled with a supported version. 
