### PR TITLE
Avoid deprecated warnings from ipython-qtconsole.desktop.

### DIFF
--- a/docs/examples/core/ipython-qtconsole.desktop
+++ b/docs/examples/core/ipython-qtconsole.desktop
@@ -13,14 +13,12 @@ Categories=Development;Utility;
 StartupNotify=false
 Terminal=false
 Type=Application
-X-Ayatana-Desktop-Shortcuts=Pylab;Pylabinline
+Actions=Pylab;Pylabinline;
 
-[Pylab Shortcut Group]
+[Desktop Action Pylab]
 Name=Pylab
 Exec=ipython qtconsole --pylab
-TargetEnvironment=Unity
 
-[Pylabinline Shortcut Group]
+[Desktop Action Pylabinline]
 Name=Pylab (inline plots)
 Exec=ipython qtconsole --pylab=inline
-TargetEnvironment=Unity


### PR DESCRIPTION
This fixes the warnings in `.xsession-errors` in Ubuntu 12.04.

Closes #1672.
