### PR TITLE
Mark test_push_numpy_nocopy as a known failure for Python 3

### DIFF
--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -234,6 +234,7 @@ class TestView(ClusterTestCase):
         b = view.gather('a', block=True)
         assert_array_equal(b, a)
 
+    @dec.known_failure_py3
     @skip_without('numpy')
     def test_push_numpy_nocopy(self):
         import numpy


### PR DESCRIPTION
See #1699
