### PR TITLE
update MathJax CDN url for https

### DIFF
--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -349,31 +349,15 @@ class NotebookApp(BaseIPythonApplication):
             self.log.info("Using local MathJax")
             return static_url_prefix+u"mathjax/MathJax.js"
         else:
-            self.log.info("Using MathJax from CDN")
-            hostname = "cdn.mathjax.org"
-            try:
-                # resolve mathjax cdn alias to cloudfront, because Amazon's SSL certificate
-                # only works on *.cloudfront.net
-                true_host, aliases, IPs = socket.gethostbyname_ex(hostname)
-                # I've run this on a few machines, and some put the right answer in true_host,
-                # while others gave it in the aliases list, so we check both.
-                aliases.insert(0, true_host)
-            except Exception:
-                self.log.warn("Couldn't determine MathJax CDN info")
+            if self.certfile:
+                # HTTPS: load from Rackspace CDN, because SSL certificate requires it
+                base = u"https://c328740.ssl.cf1.rackcdn.com"
             else:
-                for alias in aliases:
-                    parts = alias.split('.')
-                    # want static foo.cloudfront.net, not dynamic foo.lax3.cloudfront.net
-                    if len(parts) == 3 and alias.endswith(".cloudfront.net"):
-                        hostname = alias
-                        break
+                base = u"http://cdn.mathjax.org"
             
-            if not hostname.endswith(".cloudfront.net"):
-                self.log.error("Couldn't resolve CloudFront host, required for HTTPS MathJax.")
-                self.log.error("Loading from https://cdn.mathjax.org will probably fail due to invalid certificate.")
-                self.log.error("For unsecured HTTP access to MathJax use config:")
-                self.log.error("NotebookApp.mathjax_url='http://cdn.mathjax.org/mathjax/latest/MathJax.js'")
-            return u"https://%s/mathjax/latest/MathJax.js" % hostname
+            url = base + u"/mathjax/latest/MathJax.js"
+            self.log.info("Using MathJax from CDN: %s", url)
+            return url
     
     def _mathjax_url_changed(self, name, old, new):
         if new and not self.enable_mathjax:


### PR DESCRIPTION
As [discussed on mathjax-users](https://groups.google.com/forum/?fromgroups#!topic/mathjax-users/DTKMWwVe7Yo), the MathJax CDN is moving.  This doesn't affect mathjax from http, which just uses cdn.mathjax.org, but for SSL-certiificates the actual CDN url must be used (formerly cloudfront, now rackcdn).

I also decided to forego my `gethostbyname_ex` hack, which would allow the same code to continue to work if the url changed while on the same CDN, which officially shouldn't happen.  That was me solving a theoretical problem that could not officially happen.

0.12-series is unaffected, as the https-cdn hack was not backported to 0.12.1.
