### PR TITLE
Make autocall regexp's configurable.

### DIFF
--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -35,7 +35,9 @@ from IPython.core.macro import Macro
 from IPython.core.splitinput import split_user_input, LineInfo
 from IPython.core import page
 
-from IPython.utils.traitlets import List, Integer, Any, Unicode, CBool, Bool, Instance
+from IPython.utils.traitlets import (
+    List, Integer, Any, Unicode, CBool, Bool, Instance, CRegExp
+)
 from IPython.utils.autoattr import auto_attr
 
 #-----------------------------------------------------------------------------
@@ -659,6 +661,11 @@ class AutocallChecker(PrefilterChecker):
 
     priority = Integer(1000, config=True)
 
+    function_name_regexp = CRegExp(re_fun_name, config=True,
+        help="RegExp to identify potential function names.")
+    exclude_regexp = CRegExp(re_exclude_auto, config=True,
+        help="RegExp to exclude strings with this start from autocalling.")
+
     def check(self, line_info):
         "Check if the initial word/function is callable and autocall is on."
         if not self.shell.autocall:
@@ -669,8 +676,8 @@ class AutocallChecker(PrefilterChecker):
             return None
 
         if callable(oinfo['obj']) \
-               and (not re_exclude_auto.match(line_info.the_rest)) \
-               and re_fun_name.match(line_info.ifun):
+               and (not self.exclude_regexp.match(line_info.the_rest)) \
+               and self.function_name_regexp.match(line_info.ifun):
             return self.prefilter_manager.get_handler_by_name('auto')
         else:
             return None

--- a/IPython/core/tests/test_prefilter.py
+++ b/IPython/core/tests/test_prefilter.py
@@ -5,6 +5,7 @@
 #-----------------------------------------------------------------------------
 import nose.tools as nt
 
+from IPython.core.prefilter import AutocallChecker
 from IPython.testing import tools as tt, decorators as dec
 from IPython.testing.globalipapp import get_ipython
 
@@ -46,6 +47,21 @@ def test_autocall_binops():
         yield nt.assert_equals(ip.prefilter('f 1'),'f(1)')
         for t in ['f +1', 'f -1']:
             yield nt.assert_equals(ip.prefilter(t), t)
+
+        # Run tests again with a more permissive exclude_regexp, which will
+        # allow transformation of binary operations ('f -1' -> 'f(-1)').
+        pm = ip.prefilter_manager
+        ac = AutocallChecker(shell=pm.shell, prefilter_manager=pm,
+                             config=pm.config)
+        try:
+            ac.priority = 1
+            ac.exclude_regexp = r'^[,&^\|\*/]|^is |^not |^in |^and |^or '
+            pm.sort_checkers()
+
+            yield nt.assert_equals(ip.prefilter('f -1'), 'f(-1)')
+            yield nt.assert_equals(ip.prefilter('f +1'), 'f(+1)')
+        finally:
+            pm.unregister_checker(ac)
     finally:
         ip.magic('autocall 0')
         del ip.user_ns['f']

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -1411,3 +1411,14 @@ class TCPAddress(TraitType):
                     if port >= 0 and port <= 65535:
                         return value
         self.error(obj, value)
+
+class CRegExp(TraitType):
+    """A trait for a compiled regular expression."""
+
+    info_text = 'a regular expression'
+
+    def validate(self, obj, value):
+        try:
+            return re.compile(value)
+        except:
+            self.error(obj, value)

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -1413,7 +1413,10 @@ class TCPAddress(TraitType):
         self.error(obj, value)
 
 class CRegExp(TraitType):
-    """A trait for a compiled regular expression."""
+    """A casting compiled regular expression trait.
+
+    Accepts both strings and compiled regular expressions. The resulting
+    attribute will be a compiled regular expression."""
 
     info_text = 'a regular expression'
 


### PR DESCRIPTION
As discussed in #81, there is some (small) demand that that the autocall regular expressions be configurable.  For example:

```
$ ipython --AutocallChecker.exclude_regexp='^[,&^\\|\\*/]|^is |^not |^in |^and |^or ' --autocall=2
Python 2.7.3 (default, Apr 20 2012, 22:39:59) 
Type "copyright", "credits" or "license" for more information.

IPython 0.13.dev -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: def f(*args): print args

In [2]: f -1
------> f(-1)
(-1,)
```

The attached pull request:
1. Creates a new trait type "CRegExp" which casts a string or regular expression into a compiled regular expression.
2. Makes the autocall regular expressions, which are only used in AutocallChecker configurable.
