### PR TITLE
Fix for fake filenames in verbose traceback

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -786,13 +786,19 @@ class VerboseTB(TBTools):
         abspath = os.path.abspath
         for frame, file, lnum, func, lines, index in records:
             #print '*** record:',file,lnum,func,lines,index  # dbg
-            try:
-                file = file and abspath(file) or '?'
-            except OSError:
-                # if file is '<console>' or something not in the filesystem,
-                # the abspath call will throw an OSError.  Just ignore it and
-                # keep the original file string.
-                pass
+
+            if not file:
+                file = '?'
+            elif not(file.startswith("<") and file.endswith(">")):
+                # Guess that filenames like <string> aren't real filenames, so
+                # don't call abspath on them.                    
+                try:
+                    file = abspath(file)
+                except OSError:
+                    # Not sure if this can still happen: abspath now works with
+                    # file names like <string>
+                    pass
+
             link = tpl_link % file
             args, varargs, varkw, locals = inspect.getargvalues(frame)
 


### PR DESCRIPTION
While testing PR #1715, I noticed that the verbose traceback mode wasn't displaying variables as it should. This was because the fake filenames we use like `<ipython-input-8-90b61b657670>` were being treated as real filenames. We relied on `os.path.abspath` throwing an `OSError` for them, which it no longer does.

This fix assumes that any filename enclosed by `<>` should be treated as not a real file. It may well be possible to create real files with such names, but it would be very bizarre, and you wouldn't be able to import them.
