### PR TITLE
Define generic sys.ps{1,2,3}, for use by scripts.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -637,6 +637,11 @@ class InteractiveShell(SingletonConfigurable, Magic):
     def init_prompts(self):
         self.prompt_manager = PromptManager(shell=self, config=self.config)
         self.configurables.append(self.prompt_manager)
+        # Set system prompts, so that scripts can decide if they are running
+        # interactively.
+        sys.ps1 = 'In : '
+        sys.ps2 = '...: '
+        sys.ps3 = 'Out: '
 
     def init_display_formatter(self):
         self.display_formatter = DisplayFormatter(config=self.config)


### PR DESCRIPTION
Issue #123 suggests that we set `sys.ps{1,2}` to be consistent with `python`.  This way scripts can tell that they are being run in an interactive session (when run using execfile or %run).

I'm not sure that I agree with this mentality, but there is likely little lost in setting the values.

Values are clearly irrelevant, but I took the constants from `IPython/zmq/frontend.py`.
