### PR TITLE
add --no-ff to git pull in test_pr

### DIFF
--- a/tools/test_pr.py
+++ b/tools/test_pr.py
@@ -85,7 +85,7 @@ def get_branch(repo, branch, owner, mergeable):
         # Delete the branch first
         call(['git', 'branch', '-D', merged_branch])
         check_call(['git', 'checkout', '-b', merged_branch])
-        check_call(['git', 'pull', '--no-commit', repo, branch])
+        check_call(['git', 'pull', '--no-ff', '--no-commit', repo, branch])
         check_call(['git', 'commit', '-m', "merge %s/%s" % (repo, branch)])
     else:
         # Fetch the branch without merging it.


### PR DESCRIPTION
fast-forward could result in the subsequent `git commit` call failing due to nothing to commit.
