### PR TITLE
use eval for command-line args instead of exec

### DIFF
--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -334,27 +334,24 @@ class CommandLineConfigLoader(ConfigLoader):
     """
 
     def _exec_config_str(self, lhs, rhs):
-        """execute self.config.<lhs>=<rhs>
+        """execute self.config.<lhs> = <rhs>
         
         * expands ~ with expanduser
-        * tries to assign with raw exec, otherwise assigns with just the string,
+        * tries to assign with raw eval, otherwise assigns with just the string,
           allowing `--C.a=foobar` and `--C.a="foobar"` to be equivalent.  *Not*
           equivalent are `--C.a=4` and `--C.a='4'`.
         """
         rhs = os.path.expanduser(rhs)
-        exec_str = 'self.config.' + lhs + '=' + rhs
         try:
             # Try to see if regular Python syntax will work. This
             # won't handle strings as the quote marks are removed
             # by the system shell.
-            exec exec_str in locals(), globals()
+            value = eval(rhs)
         except (NameError, SyntaxError):
-            # This case happens if the rhs is a string but without
-            # the quote marks. Use repr, to get quote marks, and
-            # 'u' prefix and see if
-            # it succeeds. If it still fails, we let it raise.
-            exec_str = u'self.config.' + lhs + '= rhs'
-            exec exec_str in locals(), globals()
+            # This case happens if the rhs is a string.
+            value = rhs
+
+        exec u'self.config.%s = value' % lhs
 
     def _load_flag(self, cfg):
         """update self.config from a flag, which can be a dict or Config"""

--- a/IPython/config/tests/test_loader.py
+++ b/IPython/config/tests/test_loader.py
@@ -190,6 +190,14 @@ class TestArgParseKVCL(TestKeyValueCL):
         self.assertEquals(config.A.a, os.path.expanduser('~/1/2/3'))
         self.assertEquals(config.A.b, '~/1/2/3')
     
+    def test_eval(self):
+        cl = self.klass()
+        argv = ['-c', 'a=5']
+        with mute_warn():
+            config = cl.load_config(argv, aliases=dict(c='A.c'))
+        self.assertEquals(config.A.c, u"a=5")
+    
+
 class TestConfig(TestCase):
 
     def test_setget(self):


### PR DESCRIPTION
eval has more appropriately strict syntax, which prevents things like 'a=5' from being interpreted as Python code to be run.

Previously-failing test included.
