### PR TITLE
terminate kernel after embed_kernel tests

### DIFF
--- a/IPython/zmq/tests/test_embed_kernel.py
+++ b/IPython/zmq/tests/test_embed_kernel.py
@@ -87,6 +87,7 @@ def setup_kernel(cmd):
         yield km
     finally:
         km.stop_channels()
+        kernel.terminate()
 
 def test_embed_kernel_basic():
     """IPython.embed_kernel() is basically functional"""


### PR DESCRIPTION
The kernels could be left running after the tests.
