### PR TITLE
Catch failure in repr() for %whos

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -953,6 +953,8 @@ Currently the magic system has the following functions:\n"""
                 except UnicodeEncodeError:
                     vstr = unicode(var).encode(DEFAULT_ENCODING,
                                                'backslashreplace')
+                except:
+                    vstr = "<object with id %d (repr failed)>" % id(var)
                 vstr = vstr.replace('\n','\\n')
                 if len(vstr) < 50:
                     print vstr

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -954,7 +954,7 @@ Currently the magic system has the following functions:\n"""
                     vstr = unicode(var).encode(DEFAULT_ENCODING,
                                                'backslashreplace')
                 except:
-                    vstr = "<object with id %d (repr failed)>" % id(var)
+                    vstr = "<object with id %d (str() failed)>" % id(var)
                 vstr = vstr.replace('\n','\\n')
                 if len(vstr) < 50:
                     print vstr

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -376,6 +376,14 @@ def doctest_who():
     Out[7]: ['alpha', 'beta']
     """
 
+def test_whos():
+    """Check that whos is protected against objects where repr() fails."""
+    class A(object):
+        def __repr__(self):
+            raise Exception()
+    _ip.user_ns['a'] = A()
+    _ip.magic("whos")
+
 @py3compat.u_format
 def doctest_precision():
     """doctest for %precision


### PR DESCRIPTION
As recently reported on the mailing list, an object whose repr() fails catches out %whos. This catches the error and uses a fallback representation.
