### PR TITLE
Display message from TryNext error in magic_paste

### DIFF
--- a/IPython/core/hooks.py
+++ b/IPython/core/hooks.py
@@ -136,12 +136,13 @@ class CommandChainDispatcher:
             #print "prio",prio,"cmd",cmd #dbg
             try:
                 return cmd(*args, **kw)
-            except TryNext, exc:
+            except TryNext as exc:
+                lastexc = exc
                 if exc.args or exc.kwargs:
                     args = exc.args
                     kw = exc.kwargs
         # if no function will accept it, raise TryNext up to the caller
-        raise TryNext(*args, **kw)
+        raise lastexc
 
     def __str__(self):
         return str(self.chain)

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -636,10 +636,9 @@ class TerminalInteractiveShell(InteractiveShell):
             text = self.shell.hooks.clipboard_get()
             block = strip_email_quotes(text.splitlines())
         except TryNext as clipboard_exc:
-            message = getattr(clipboard_exc, 'args')
-            if message:
-                error(message[0])
-            else:
+            try:
+                error(clipboard_exc.msg)
+            except AttributeError:
                 error('Could not get text from the clipboard.')
             return
 


### PR DESCRIPTION
If you do %paste on a system without Tkinter installed, this makes sure you get the more informative error message.

Closes gh-1736
