### PR TITLE
Check for custom_exceptions only once

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1703,23 +1703,20 @@ class InteractiveShell(SingletonConfigurable):
             elif etype is UsageError:
                 self.write_err("UsageError: %s" % value)
             else:
-                if etype in self.custom_exceptions:
-                    stb = self.CustomTB(etype, value, tb, tb_offset)
+                if exception_only:
+                    stb = ['An exception has occurred, use %tb to see '
+                           'the full traceback.\n']
+                    stb.extend(self.InteractiveTB.get_exception_only(etype,
+                                                                     value))
                 else:
-                    if exception_only:
-                        stb = ['An exception has occurred, use %tb to see '
-                               'the full traceback.\n']
-                        stb.extend(self.InteractiveTB.get_exception_only(etype,
-                                                                         value))
-                    else:
-                        stb = self.InteractiveTB.structured_traceback(etype,
-                                                value, tb, tb_offset=tb_offset)
+                    stb = self.InteractiveTB.structured_traceback(etype,
+                                            value, tb, tb_offset=tb_offset)
 
-                        self._showtraceback(etype, value, stb)
-                        if self.call_pdb:
-                            # drop into debugger
-                            self.debugger(force=True)
-                        return
+                    self._showtraceback(etype, value, stb)
+                    if self.call_pdb:
+                        # drop into debugger
+                        self.debugger(force=True)
+                    return
 
                 # Actually show the traceback
                 self._showtraceback(etype, value, stb)

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -337,6 +337,21 @@ class InteractiveShellTestCase(unittest.TestCase):
                     namespace = 'IPython internal', obj= cmagic.__wrapped__,
                     parent = None)
         nt.assert_equal(find, info)
+    
+    def test_custom_exception(self):
+        called = []
+        def my_handler(shell, etype, value, tb, tb_offset=None):
+            called.append(etype)
+            shell.showtraceback((etype, value, tb), tb_offset=tb_offset)
+        
+        ip.set_custom_exc((ValueError,), my_handler)
+        try:
+            ip.run_cell("raise ValueError('test')")
+            # Check that this was called, and only once.
+            self.assertEqual(called, [ValueError])
+        finally:
+            # Reset the custom exception hook
+            ip.set_custom_exc((), None)
 
 
 class TestSafeExecfileNonAsciiPath(unittest.TestCase):


### PR DESCRIPTION
As [reported on the mailing list](http://permalink.gmane.org/gmane.comp.python.ipython.devel/8027), setting a custom exception handler which does something before displaying the default traceback leads to unexpected recursion.

We already catch custom exceptions in `run_code` and call the custom handler, but we were checking for them again in `showtraceback`. This just removes the second check, so custom exception handlers can safely call showtraceback().

This is a slight API change - previously, calling showtraceback would dispatch the custom exception handler if the exception type exactly matched one of those specified (not a subclass). Now it will ignore custom exception handlers. However, I think this change is more intuitive (Min's example code on the mailing list assumed it would work this way), and the use case is reasonable.

I'll look at adding a test for this later.
