### PR TITLE
Confirm restart (configuration option, and checkbox UI)

### DIFF
--- a/IPython/frontend/qt/console/frontend_widget.py
+++ b/IPython/frontend/qt/console/frontend_widget.py
@@ -98,6 +98,9 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
     clear_on_kernel_restart = Bool(True, config=True,
         help="Whether to clear the console when the kernel is restarted")
 
+    confirm_restart = Bool(True, config=True,
+        help="Whether to ask for user confirmation when restarting kernel")
+
     # Emitted when a user visible 'execute_request' has been submitted to the
     # kernel from the FrontendWidget. Contains the code to be executed.
     executing = QtCore.Signal(object)
@@ -615,10 +618,16 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
             # Prompt the user to restart the kernel. Un-pause the heartbeat if
             # they decline. (If they accept, the heartbeat will be un-paused
             # automatically when the kernel is restarted.)
-            buttons = QtGui.QMessageBox.Yes | QtGui.QMessageBox.No
-            result = QtGui.QMessageBox.question(self, 'Restart kernel?',
-                                                message, buttons)
-            if result == QtGui.QMessageBox.Yes:
+            if self.confirm_restart:
+                buttons = QtGui.QMessageBox.Yes | QtGui.QMessageBox.No
+                result = QtGui.QMessageBox.question(self, 'Restart kernel?',
+                                                    message, buttons)
+                do_restart = result == QtGui.QMessageBox.Yes
+            else:
+                # confirm_restart is False, so we don't need to ask user
+                # anything, just do the restart
+                do_restart = True
+            if do_restart:
                 try:
                     self.kernel_manager.restart_kernel(now=now)
                 except RuntimeError:

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -552,6 +552,15 @@ class MainWindow(QtGui.QMainWindow):
 
         self.kernel_menu.addSeparator()
 
+        self.confirm_restart_kernel_action = QtGui.QAction("Confirm kernel restart",
+            self,
+            checkable=True,
+            checked=self.active_frontend.confirm_restart,
+            triggered=self.toggle_confirm_restart_active_frontend
+            )
+
+        self.add_menu_action(self.kernel_menu, self.confirm_restart_kernel_action)
+
     def _make_dynamic_magic(self,magic):
         """Return a function `fun` that will execute `magic` on active frontend.
 
@@ -831,6 +840,16 @@ class MainWindow(QtGui.QMainWindow):
 
     def interrupt_kernel_active_frontend(self):
         self.active_frontend.request_interrupt_kernel()
+
+    def toggle_confirm_restart_active_frontend(self):
+        widget = self.active_frontend
+        widget.confirm_restart = not widget.confirm_restart
+        # XXX: whenever tabs are switched, the checkbox may not be
+        # representative of the state of the active widget. The next line
+        # ensures that at least after toggling, the checkbox represents the
+        # state this widget is in.
+        self.confirm_restart_kernel_action.setChecked(widget.confirm_restart)
+
 
     def cut_active_frontend(self):
         widget = self.active_frontend

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -11,6 +11,7 @@ Authors:
 * Fernando Perez
 * Bussonnier Matthias
 * Thomas Kluyver
+* Paul Ivanov
 
 """
 
@@ -77,6 +78,7 @@ class MainWindow(QtGui.QMainWindow):
         self.tab_widget.setDocumentMode(True)
         self.tab_widget.setTabsClosable(True)
         self.tab_widget.tabCloseRequested[int].connect(self.close_tab)
+        self.tab_widget.currentChanged.connect(self.update_restart_checkbox)
 
         self.setCentralWidget(self.tab_widget)
         # hide tab bar at first, since we have no tabs:
@@ -844,12 +846,11 @@ class MainWindow(QtGui.QMainWindow):
     def toggle_confirm_restart_active_frontend(self):
         widget = self.active_frontend
         widget.confirm_restart = not widget.confirm_restart
-        # XXX: whenever tabs are switched, the checkbox may not be
-        # representative of the state of the active widget. The next line
-        # ensures that at least after toggling, the checkbox represents the
-        # state this widget is in.
         self.confirm_restart_kernel_action.setChecked(widget.confirm_restart)
 
+    def update_restart_checkbox(self):
+        widget = self.active_frontend
+        self.confirm_restart_kernel_action.setChecked(widget.confirm_restart)
 
     def cut_active_frontend(self):
         widget = self.active_frontend

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -78,7 +78,6 @@ class MainWindow(QtGui.QMainWindow):
         self.tab_widget.setDocumentMode(True)
         self.tab_widget.setTabsClosable(True)
         self.tab_widget.tabCloseRequested[int].connect(self.close_tab)
-        self.tab_widget.currentChanged.connect(self.update_restart_checkbox)
 
         self.setCentralWidget(self.tab_widget)
         # hide tab bar at first, since we have no tabs:
@@ -562,6 +561,7 @@ class MainWindow(QtGui.QMainWindow):
             )
 
         self.add_menu_action(self.kernel_menu, self.confirm_restart_kernel_action)
+        self.tab_widget.currentChanged.connect(self.update_restart_checkbox)
 
     def _make_dynamic_magic(self,magic):
         """Return a function `fun` that will execute `magic` on active frontend.

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -536,14 +536,14 @@ class MainWindow(QtGui.QMainWindow):
 
         ctrl = "Meta" if sys.platform == 'darwin' else "Ctrl"
 
-        self.interrupt_kernel_action = QtGui.QAction("Interrupt current Kernel",
+        self.interrupt_kernel_action = QtGui.QAction("&Interrupt current Kernel",
             self,
             triggered=self.interrupt_kernel_active_frontend,
             shortcut=ctrl+"+C",
             )
         self.add_menu_action(self.kernel_menu, self.interrupt_kernel_action)
 
-        self.restart_kernel_action = QtGui.QAction("Restart current Kernel",
+        self.restart_kernel_action = QtGui.QAction("&Restart current Kernel",
             self,
             triggered=self.restart_kernel_active_frontend,
             shortcut=ctrl+"+.",
@@ -552,7 +552,7 @@ class MainWindow(QtGui.QMainWindow):
 
         self.kernel_menu.addSeparator()
 
-        self.confirm_restart_kernel_action = QtGui.QAction("Confirm kernel restart",
+        self.confirm_restart_kernel_action = QtGui.QAction("&Confirm kernel restart",
             self,
             checkable=True,
             checked=self.active_frontend.confirm_restart,


### PR DESCRIPTION
Now, one can use the following to not get nagged for confirmation every
kernel restart:

```
    ipython qtconsole --IPythonWidget.confirm_restart=False
```

As with all configuration settings, setting this permanently requires editing one's profile.

I also added code to expose `confirm_restart` via checkbox menu item in the Kernel menu.

<del>Note: There's a limitation to this implementation where the checkbox may not represent the state of confirm_restart for the current tab, but it does get set to the appropriate value if it is ever toggled.
</del>


**update:** This issue was fixed in a41db72

<del>
Finally, I did a bunch of typo clean up in the two related files.
</del>


**update:** these were committed directly to master, so now this PR is only the relevant code 
