### PR TITLE
switch between hsplit and vsplit paging (request for feedback)

### DIFF
--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -1674,6 +1674,32 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
         else:
             self._append_plain_text(text)
 
+    def _set_paging(self, paging):
+        """
+        Change the pager to `paging` style.
+
+        XXX: currently, this is limited to switching between 'hsplit' and
+        'vsplit'.
+
+        Parameters:
+        -----------
+        paging : string
+            Either "hsplit", "vsplit", or "inside"
+        """
+        if self._splitter is None:
+            raise NotImplementedError("""can only switch if --paging=hsplit or
+                    --paging=vsplit is used.""")
+        if paging == 'hsplit':
+            self._splitter.setOrientation(QtCore.Qt.Horizontal)
+        elif paging == 'vsplit':
+            self._splitter.setOrientation(QtCore.Qt.Vertical)
+        elif paging == 'inside':
+            raise NotImplementedError("""switching to 'inside' paging not
+                    supported yet.""")
+        else:
+            raise ValueError("unknown paging method '%s'" % paging)
+        self.paging = paging
+
     def _prompt_finished(self):
         """ Called immediately after a prompt is finished, i.e. when some input
             will be processed and a new prompt displayed.

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -522,20 +522,25 @@ class MainWindow(QtGui.QMainWindow):
             statusTip="Clear the console",
             triggered=self.clear_magic_active_frontend)
         self.add_menu_action(self.view_menu, self.clear_action)
-        self.pager_menu = self.view_menu.addMenu("Pager")
 
+        self.pager_menu = self.view_menu.addMenu("&Pager")
 
-        self.hsplit_action = QtGui.QAction(".. &Horizontal Split",
+        hsplit_action = QtGui.QAction(".. &Horizontal Split",
             self,
-            triggered=self.pager_hsplit)
+            triggered=lambda: self.set_paging_active_frontend('hsplit'))
 
-        self.vsplit_action = QtGui.QAction(" : &Vertical Split",
+        vsplit_action = QtGui.QAction(" : &Vertical Split",
             self,
-            triggered=self.pager_vsplit)
+            triggered=lambda: self.set_paging_active_frontend('vsplit'))
 
-        self.pager_menu.addAction(self.hsplit_action)
-        self.pager_menu.addAction(self.vsplit_action)
-    
+        inside_action = QtGui.QAction("   &Inside Pager",
+            self,
+            triggered=lambda: self.set_paging_active_frontend('inside'))
+
+        self.pager_menu.addAction(hsplit_action)
+        self.pager_menu.addAction(vsplit_action)
+        self.pager_menu.addAction(inside_action)
+
     def init_kernel_menu(self):
         self.kernel_menu = self.menuBar().addMenu("&Kernel")
         # Qt on OSX maps Ctrl to Cmd, and Meta to Ctrl
@@ -794,13 +799,8 @@ class MainWindow(QtGui.QMainWindow):
                 self.maximizeAct.setEnabled(True)
                 self.minimizeAct.setEnabled(True)
 
-    def pager_vsplit(self):
-        self.active_frontend.paging = "vsplit"
-        self.active_frontend._splitter.setOrientation(QtCore.Qt.Vertical)
-
-    def pager_hsplit(self):
-        self.active_frontend.paging = "hsplit"
-        self.active_frontend._splitter.setOrientation(QtCore.Qt.Horizontal)
+    def set_paging_active_frontend(self, paging):
+        self.active_frontend._set_paging(paging)
 
     def close_active_frontend(self):
         self.close_tab(self.active_frontend)

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -522,6 +522,19 @@ class MainWindow(QtGui.QMainWindow):
             statusTip="Clear the console",
             triggered=self.clear_magic_active_frontend)
         self.add_menu_action(self.view_menu, self.clear_action)
+        self.pager_menu = self.view_menu.addMenu("Pager")
+
+
+        self.hsplit_action = QtGui.QAction(".. &Horizontal Split",
+            self,
+            triggered=self.pager_hsplit)
+
+        self.vsplit_action = QtGui.QAction(" : &Vertical Split",
+            self,
+            triggered=self.pager_vsplit)
+
+        self.pager_menu.addAction(self.hsplit_action)
+        self.pager_menu.addAction(self.vsplit_action)
     
     def init_kernel_menu(self):
         self.kernel_menu = self.menuBar().addMenu("&Kernel")
@@ -780,6 +793,14 @@ class MainWindow(QtGui.QMainWindow):
             if sys.platform == 'darwin':
                 self.maximizeAct.setEnabled(True)
                 self.minimizeAct.setEnabled(True)
+
+    def pager_vsplit(self):
+        self.active_frontend.paging = "vsplit"
+        self.active_frontend._splitter.setOrientation(QtCore.Qt.Vertical)
+
+    def pager_hsplit(self):
+        self.active_frontend.paging = "hsplit"
+        self.active_frontend._splitter.setOrientation(QtCore.Qt.Horizontal)
 
     def close_active_frontend(self):
         self.close_tab(self.active_frontend)


### PR DESCRIPTION
So I hacked this together, and as long as the qtconsole was started in either `hsplit` or `vsplit` modes, you can switch between them using a new "Pager" submenu.

I wanted to get feedback if I should continue by trying to make it possible to switch to the default `inside` paging mode as well. It looks like it'll be a little bit involved, but doable, if it's worth having.

Otherwise, I can scale this PR back to just be hsplit and vsplit switching
