### PR TITLE
Fix some tests for Python 3.3

### DIFF
--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -160,7 +160,7 @@ class Configurable(HasTraits):
         final_help = []
         final_help.append(u'%s options' % cls.__name__)
         final_help.append(len(final_help[0])*u'-')
-        for k,v in cls.class_traits(config=True).iteritems():
+        for k,v in sorted(cls.class_traits(config=True).iteritems()):
             help = cls.class_get_trait_help(v, inst)
             final_help.append(help)
         return '\n'.join(final_help)

--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -417,8 +417,9 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
 
             >>> from IPython.config.loader import KeyValueConfigLoader
             >>> cl = KeyValueConfigLoader()
-            >>> cl.load_config(["--A.name='brian'","--B.number=0"])
-            {'A': {'name': 'brian'}, 'B': {'number': 0}}
+            >>> d = cl.load_config(["--A.name='brian'","--B.number=0"])
+            >>> sorted(d.items())
+            [('A', {'name': 'brian'}), ('B', {'number': 0})]
         """
         self.clear()
         if argv is None:

--- a/IPython/core/excolors.py
+++ b/IPython/core/excolors.py
@@ -31,10 +31,10 @@ def exception_colors():
     >>> ec.set_active_scheme('NoColor')
     >>> ec.active_scheme_name
     'NoColor'
-    >>> ec.active_colors.keys()
-    ['em', 'filenameEm', 'excName', 'valEm', 'nameEm', 'line', 'topline',
-    'name', 'caret', 'val', 'vName', 'Normal', 'filename', 'linenoEm',
-    'lineno', 'normalEm']
+    >>> sorted(ec.active_colors.keys())
+    ['Normal', 'caret', 'em', 'excName', 'filename', 'filenameEm', 'line',
+    'lineno', 'linenoEm', 'name', 'nameEm', 'normalEm', 'topline', 'vName',
+    'val', 'valEm']
     """
 
     ex_colors = ColorSchemeTable()

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -774,7 +774,12 @@ python-profiler package from non-free.""")
             setup = timeit.reindent(stmt, 4)
             stmt = timeit.reindent(cell, 8)
 
-        src = timeit.template % dict(stmt=stmt, setup=setup)
+        # From Python 3.3, this template uses new-style string formatting.
+        if sys.version_info >= (3, 3):
+            src = timeit.template.format(stmt=stmt, setup=setup)
+        else:
+            src = timeit.template % dict(stmt=stmt, setup=setup)
+
         # Track compilation time so it can be reported if too long
         # Minimum time above which compilation time will be reported
         tc_min = 0.1

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -15,6 +15,12 @@ import sys
 from StringIO import StringIO
 from unittest import TestCase
 
+try:
+    from importlib import invalidate_caches   # Required from Python 3.3
+except ImportError:
+    def invalidate_caches():
+        pass
+
 import nose.tools as nt
 
 from IPython.core import magic
@@ -449,6 +455,7 @@ def test_extension():
         url = os.path.join(os.path.dirname(__file__), "daft_extension.py")
         _ip.magic("install_ext %s" % url)
         _ip.user_ns.pop('arq', None)
+        invalidate_caches()   # Clear import caches
         _ip.magic("load_ext daft_extension")
         tt.assert_equal(_ip.user_ns['arq'], 185)
         _ip.magic("unload_ext daft_extension")

--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -372,6 +372,7 @@ def superreload(module, reload=reload, old_objects={}):
         old_name = module.__name__
         module.__dict__.clear()
         module.__dict__['__name__'] = old_name
+        module.__dict__['__loader__'] = old_dict['__loader__']
     except (TypeError, AttributeError, KeyError):
         pass
 

--- a/IPython/testing/globalipapp.py
+++ b/IPython/testing/globalipapp.py
@@ -84,67 +84,6 @@ def _run_ns_sync(self,arg_s,runner=None):
     return get_ipython().magic_run_ori(arg_s, runner, finder)
 
 
-class ipnsdict(dict):
-    """A special subclass of dict for use as an IPython namespace in doctests.
-
-    This subclass adds a simple checkpointing capability so that when testing
-    machinery clears it (we use it as the test execution context), it doesn't
-    get completely destroyed.
-
-    In addition, it can handle the presence of the '_' key in a special manner,
-    which is needed because of how Python's doctest machinery operates with
-    '_'.  See constructor and :meth:`update` for details.
-    """
-
-    def __init__(self,*a):
-        dict.__init__(self,*a)
-        self._savedict = {}
-        # If this flag is True, the .update() method will unconditionally
-        # remove a key named '_'.  This is so that such a dict can be used as a
-        # namespace in doctests that call '_'.
-        self.protect_underscore = False
-
-    def clear(self):
-        dict.clear(self)
-        self.update(self._savedict)
-
-    def _checkpoint(self):
-        self._savedict.clear()
-        self._savedict.update(self)
-
-    def update(self,other):
-        self._checkpoint()
-        dict.update(self,other)
-
-        if self.protect_underscore:
-            # If '_' is in the namespace, python won't set it when executing
-            # code *in doctests*, and we have multiple doctests that use '_'.
-            # So we ensure that the namespace is always 'clean' of it before
-            # it's used for test code execution.
-            # This flag is only turned on by the doctest machinery, so that
-            # normal test code can assume the _ key is updated like any other
-            # key and can test for its presence after cell executions.
-            self.pop('_', None)
-
-        # The builtins namespace must *always* be the real __builtin__ module,
-        # else weird stuff happens.  The main ipython code does have provisions
-        # to ensure this after %run, but since in this class we do some
-        # aggressive low-level cleaning of the execution namespace, we need to
-        # correct for that ourselves, to ensure consitency with the 'real'
-        # ipython.
-        self['__builtins__'] = builtin_mod
-
-    def __delitem__(self, key):
-        """Part of the test suite checks that we can release all
-        references to an object. So we need to make sure that we're not
-        keeping a reference in _savedict."""
-        dict.__delitem__(self, key)
-        try:
-            del self._savedict[key]
-        except KeyError:
-            pass
-
-
 def get_ipython():
     # This will get replaced by the real thing once we start IPython below
     return start_ipython()
@@ -189,7 +128,6 @@ def start_ipython():
 
     # Create and initialize our test-friendly IPython instance.
     shell = TerminalInteractiveShell.instance(config=config,
-                                              user_ns=ipnsdict(),
                                               )
 
     # A few more tweaks needed for playing nicely with doctests...

--- a/IPython/utils/frame.py
+++ b/IPython/utils/frame.py
@@ -39,11 +39,11 @@ def extract_vars(*names,**kw):
 
         In [2]: def func(x):
            ...:     y = 1
-           ...:     print extract_vars('x','y')
+           ...:     print sorted(extract_vars('x','y').items())
            ...:
 
         In [3]: func('hello')
-        {'y': 1, 'x': 'hello'}
+        [('x', 'hello'), ('y', 1)]
     """
 
     depth = kw.get('depth',0)

--- a/IPython/utils/ipstruct.py
+++ b/IPython/utils/ipstruct.py
@@ -59,8 +59,8 @@ class Struct(dict):
         >>> s.b
         30
         >>> s2 = Struct(s,c=30)
-        >>> s2.keys()
-        ['a', 'c', 'b']
+        >>> sorted(s2.keys())
+        ['a', 'b', 'c']
         """
         object.__setattr__(self, '_allownew', True)
         dict.__init__(self, *args, **kw)
@@ -161,8 +161,8 @@ class Struct(dict):
         >>> s = Struct(a=10,b=30)
         >>> s2 = Struct(a=20,c=40)
         >>> s += s2
-        >>> s
-        {'a': 10, 'c': 40, 'b': 30}
+        >>> sorted(s.keys())
+        ['a', 'b', 'c']
         """
         self.merge(other)
         return self
@@ -176,8 +176,8 @@ class Struct(dict):
         >>> s1 = Struct(a=10,b=30)
         >>> s2 = Struct(a=20,c=40)
         >>> s = s1 + s2
-        >>> s
-        {'a': 10, 'c': 40, 'b': 30}
+        >>> sorted(s.keys())
+        ['a', 'b', 'c']
         """
         sout = self.copy()
         sout.merge(other)
@@ -241,10 +241,8 @@ class Struct(dict):
 
         >>> s = Struct(a=10,b=30)
         >>> s2 = s.copy()
-        >>> s2
-        {'a': 10, 'b': 30}
-        >>> type(s2).__name__
-        'Struct'
+        >>> type(s2) is Struct
+        True
         """
         return Struct(dict.copy(self))
 
@@ -348,8 +346,8 @@ class Struct(dict):
         >>> s = Struct(a=10,b=30)
         >>> s2 = Struct(a=20,c=40)
         >>> s.merge(s2)
-        >>> s
-        {'a': 10, 'c': 40, 'b': 30}
+        >>> sorted(s.items())
+        [('a', 10), ('b', 30), ('c', 40)]
 
         Now, show how to specify a conflict dict:
 
@@ -357,8 +355,8 @@ class Struct(dict):
         >>> s2 = Struct(a=20,b=40)
         >>> conflict = {'update':'a','add':'b'}
         >>> s.merge(s2,conflict)
-        >>> s
-        {'a': 20, 'b': 70}
+        >>> sorted(s.items())
+        [('a', 20), ('b', 70)]
         """
 
         data_dict = dict(__loc_data__,**kw)

--- a/IPython/utils/jsonutil.py
+++ b/IPython/utils/jsonutil.py
@@ -118,10 +118,10 @@ def json_clean(obj):
     4
     >>> json_clean(range(10))
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-    >>> json_clean(dict(x=1, y=2))
-    {'y': 2, 'x': 1}
-    >>> json_clean(dict(x=1, y=2, z=[1,2,3]))
-    {'y': 2, 'x': 1, 'z': [1, 2, 3]}
+    >>> sorted(json_clean(dict(x=1, y=2)).items())
+    [('x', 1), ('y', 2)]
+    >>> sorted(json_clean(dict(x=1, y=2, z=[1,2,3])).items())
+    [('x', 1), ('y', 2), ('z', [1, 2, 3])]
     >>> json_clean(True)
     True
     """

--- a/IPython/utils/tests/test_jsonutil.py
+++ b/IPython/utils/tests/test_jsonutil.py
@@ -58,7 +58,8 @@ def test():
 
 def test_lambda():
     jc = json_clean(lambda : 1)
-    nt.assert_true(jc.startswith('<function <lambda> at '))
+    assert isinstance(jc, str)
+    assert '<lambda>' in jc
     json.dumps(jc)
 
 

--- a/IPython/utils/tests/test_module_paths.py
+++ b/IPython/utils/tests/test_module_paths.py
@@ -43,7 +43,6 @@ TMP_TEST_DIR = tempfile.mkdtemp()
 #
 
 old_syspath = sys.path
-sys.path = [TMP_TEST_DIR]
 
 def make_empty_file(fname):
     f = open(fname, 'w')
@@ -62,16 +61,19 @@ def setup():
     make_empty_file(join(TMP_TEST_DIR, "xmod/sub.py"))
     make_empty_file(join(TMP_TEST_DIR, "pack.py"))
     make_empty_file(join(TMP_TEST_DIR, "packpyc.pyc"))
+    sys.path = [TMP_TEST_DIR]
 
 def teardown():
     """Teardown testenvironment for the module:
 
             - Remove tempdir
+            - restore sys.path
     """
     # Note: we remove the parent test dir, which is the root of all test
     # subdirs we may have created.  Use shutil instead of os.removedirs, so
     # that non-empty directories are all recursively removed.
     shutil.rmtree(TMP_TEST_DIR)
+    sys.path = old_syspath
 
 
 def test_get_init_1():

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -370,8 +370,8 @@ class TestHasTraits(TestCase):
             i = Int
             f = Float
         a = A()
-        self.assertEquals(a.trait_names(),['i','f'])
-        self.assertEquals(A.class_trait_names(),['i','f'])
+        self.assertEquals(sorted(a.trait_names()),['f','i'])
+        self.assertEquals(sorted(A.class_trait_names()),['f','i'])
 
     def test_trait_metadata(self):
         class A(HasTraits):


### PR DESCRIPTION
**Update:** All tests are now passing on Python 3.3.

The main change is that, for security reasons, the ordering of dicts is unpredictable. It's never something we should have been relying on, but various doctests did depend on the order.

Most of the remaining test failures seem to be problems with importing things - I'll look more carefully at the documentation, but I think there might be bugs in the new implementation of import.
