### PR TITLE
Clear window title when kernel is restarted

### DIFF
--- a/IPython/frontend/html/notebook/static/js/notificationwidget.js
+++ b/IPython/frontend/html/notebook/static/js/notificationwidget.js
@@ -65,8 +65,7 @@ var IPython = (function (IPython) {
                 title: "Dead kernel",
                 buttons : {
                     "Restart": function () {
-                        IPython.save_widget.update_document_title();
-                        that.set_message("Restarting kernel",500);
+                        $([IPython.events]).trigger('status_restarting.Kernel');
                         IPython.notebook.start_kernel();
                         $(this).dialog('close');
                     },

--- a/IPython/frontend/html/notebook/static/js/notificationwidget.js
+++ b/IPython/frontend/html/notebook/static/js/notificationwidget.js
@@ -48,6 +48,7 @@ var IPython = (function (IPython) {
             that.set_message("Kernel busy");
         });
         $([IPython.events]).on('status_restarting.Kernel',function () {
+            IPython.save_widget.update_document_title();
             that.set_message("Restarting kernel",500);
         });
         $([IPython.events]).on('status_interrupting.Kernel',function () {
@@ -64,6 +65,7 @@ var IPython = (function (IPython) {
                 title: "Dead kernel",
                 buttons : {
                     "Restart": function () {
+                        IPython.save_widget.update_document_title();
                         that.set_message("Restarting kernel",500);
                         IPython.notebook.start_kernel();
                         $(this).dialog('close');


### PR DESCRIPTION
When kernel is died and restarted, or restarted while it is in the busy state, message "(Busy)" on the window title is not updated.  This problem is fixed by updating document title when restarting.

---

Although I didn't make a change in the PR, I noticed that `IPython.notebook.kernel.stop_channels` is called twice in `"status_dead.Kernel"` hook (in notificationwidget.js) and in `Kernel.prototype._handle_iopub_reply`.  I guess it's better to remove one of them.
