### PR TITLE
test_pr, fallback on http if git protocol fail, and SSL errors...

### DIFF
--- a/tools/test_pr.py
+++ b/tools/test_pr.py
@@ -27,6 +27,7 @@ import gh_api
 basedir = os.path.join(os.path.expanduser("~"), ".ipy_pr_tests")
 repodir = os.path.join(basedir, "ipython")
 ipy_repository = 'git://github.com/ipython/ipython.git'
+ipy_http_repository = 'http://github.com/ipython/ipython.git'
 gh_project="ipython/ipython"
 
 supported_pythons = ['python2.6', 'python2.7', 'python3.1', 'python3.2']
@@ -65,10 +66,16 @@ def setup():
     
     # Check out and update the repository
     if not os.path.exists('ipython'):
-        check_call(['git', 'clone', ipy_repository])
+        try :
+            check_call(['git', 'clone', ipy_repository])
+        except CalledProcessError :
+            check_call(['git', 'clone', ipy_http_repository])
     os.chdir(repodir)
     check_call(['git', 'checkout', 'master'])
-    check_call(['git', 'pull', ipy_repository, 'master'])
+    try :
+        check_call(['git', 'pull', ipy_repository, 'master'])
+    except CalledProcessError :
+        check_call(['git', 'pull', ipy_http_repository, 'master'])
     os.chdir(basedir)
 
 missing_libs_re = re.compile(r"Tools and libraries NOT available at test time:\n"


### PR DESCRIPTION
git protocol is blocked in my lab, 
So I'm trying to modify somes scripts in tools to work with http://

it is partially working now, but `requests` still fails on github api:

```
Traceback (most recent call last):
  File "tools/test_pr.py", line 248, in <module>
    test_pr(args.number, post_results=args.publish)
  File "tools/test_pr.py", line 207, in test_pr
    pr = gh_api.get_pull_request(gh_project, num)
  File "/Users/matthiasbussonnier/ipython/tools/gh_api.py", line 78, in get_pull_request
    response = requests.get(url)
  File "/usr/local/Cellar/python/2.7.3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/requests-0.12.1-py2.7.egg/requests/api.py", line 52, in get
    return request('get', url, **kwargs)
  File "/usr/local/Cellar/python/2.7.3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/requests-0.12.1-py2.7.egg/requests/api.py", line 40, in request
    return s.request(method=method, url=url, **kwargs)
  File "/usr/local/Cellar/python/2.7.3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/requests-0.12.1-py2.7.egg/requests/sessions.py", line 229, in request
    r.send(prefetch=prefetch)
  File "/usr/local/Cellar/python/2.7.3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/requests-0.12.1-py2.7.egg/requests/models.py", line 609, in send
    raise SSLError(e)
requests.exceptions.SSLError: [Errno 1] _ssl.c:504: error:140770FC:SSL routines:SSL23_GET_SERVER_HELLO:unknown protocol
```

Google don't want to be my friend, and no answer on `requests` issues lists on github...

Any clues ?
