### PR TITLE
github, merge PR(s) just by number(s) 

### DIFF
--- a/tools/gh_api.py
+++ b/tools/gh_api.py
@@ -84,7 +84,7 @@ def get_pull_request(project, num, github_api=3):
         url = "https://api.github.com/repos/{project}/pulls/{num}".format(project=project, num=num)
     response = requests.get(url)
     response.raise_for_status()
-    if httpv2 :
+    if github_api == 2 :
         return json.loads(response.text)['pull']
     return json.loads(response.text)
 
@@ -99,6 +99,6 @@ def get_pulls_list(project, github_api=3):
         url = "http://github.com/api/v2/json/pulls/{project}".format(project=project)
     response = requests.get(url)
     response.raise_for_status()
-    if httpv2 :
+    if github_api == 2 :
         return json.loads(response.text)['pulls']
     return json.loads(response.text)

--- a/tools/gh_api.py
+++ b/tools/gh_api.py
@@ -73,8 +73,24 @@ def post_gist(content, description='', filename='file', auth=False):
     response_data = json.loads(response.text)
     return response_data['html_url']
     
-def get_pull_request(project, num):
-    url = "https://api.github.com/repos/{project}/pulls/{num}".format(project=project, num=num)
+def get_pull_request(project, num, httpv2=False):
+    if httpv2 :
+        url = "http://github.com/api/v2/json/pulls/{project}/{num}".format(project=project, num=num)
+    else:
+        url = "https://api.github.com/repos/{project}/pulls/{num}".format(project=project, num=num)
     response = requests.get(url)
     response.raise_for_status()
+    if httpv2 :
+        return json.loads(response.text)['pull']
+    return json.loads(response.text)
+
+def get_pulls_list(project,httpv2=False):
+    if not httpv2 :
+        url = "https://api.github.com/repos/{project}/pulls".format(project=project)
+    else :
+        url = "http://github.com/api/v2/json/pulls/{project}".format(project=project)
+    response = requests.get(url)
+    response.raise_for_status()
+    if httpv2 :
+        return json.loads(response.text)['pulls']
     return json.loads(response.text)

--- a/tools/gh_api.py
+++ b/tools/gh_api.py
@@ -73,10 +73,14 @@ def post_gist(content, description='', filename='file', auth=False):
     response_data = json.loads(response.text)
     return response_data['html_url']
     
-def get_pull_request(project, num, httpv2=False):
-    if httpv2 :
+def get_pull_request(project, num, github_api=3):
+    """get pull request info  by number
+
+    github_api : version of github api to use
+    """
+    if github_api==2 :
         url = "http://github.com/api/v2/json/pulls/{project}/{num}".format(project=project, num=num)
-    else:
+    elif github_api == 3:
         url = "https://api.github.com/repos/{project}/pulls/{num}".format(project=project, num=num)
     response = requests.get(url)
     response.raise_for_status()
@@ -84,8 +88,12 @@ def get_pull_request(project, num, httpv2=False):
         return json.loads(response.text)['pull']
     return json.loads(response.text)
 
-def get_pulls_list(project,httpv2=False):
-    if not httpv2 :
+def get_pulls_list(project, github_api=3):
+    """get pull request list
+
+    github_api : version of github api to use
+    """
+    if github_api == 3 :
         url = "https://api.github.com/repos/{project}/pulls".format(project=project)
     else :
         url = "http://github.com/api/v2/json/pulls/{project}".format(project=project)

--- a/tools/git-mpr.py
+++ b/tools/git-mpr.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Usage:
+    python test_pr.py 1657
+"""
+from __future__ import print_function
+
+import re
+import requests
+from subprocess import call, check_call, check_output, CalledProcessError
+import sys
+
+import gh_api
+
+ipy_repository = 'git://github.com/ipython/ipython.git'
+gh_project="ipython/ipython"
+not_merged={}
+
+def get_branch(repo, branch, owner, mergeable):
+    merged_branch = "%s-%s" % (owner, branch)
+    # Delete the branch first
+    try :
+        check_call(['git', 'pull','--no-edit',repo, branch])
+    except CalledProcessError :
+        check_call(['git', 'merge', '--abort'])
+        return False
+    return True
+
+def merge_pr(num,httpv2=False):
+    # Get Github authorisation first, so that the user is prompted straight away
+    # if their login is needed.
+    
+    pr = gh_api.get_pull_request(gh_project, num, httpv2)
+    if(httpv2):
+        repo = pr['head']['repository']['url']
+        owner=pr['head']['user']['name'],
+    else :
+        repo=pr['head']['repo']['clone_url']
+        owner=pr['head']['repo']['owner']['login'],
+
+    branch=pr['head']['ref']
+    mergeable = get_branch(repo=repo, 
+                 branch=branch,
+                 owner=owner,
+                 mergeable=pr['mergeable'],
+              )
+    if not mergeable :
+        cmd = "git pull "+repo+" "+branch
+        not_merged[str(num)]=cmd
+        print("==============================================================================")
+        print("Something went wrong merging this branch, you can try it manually by runngin :")
+        print(cmd)
+        print("==============================================================================")
+        
+    
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(
+            description="""
+                Merge (one|many) github pull request by their number.\
+                
+                If pull request can't be merge as is, cancel merge,
+                and continue to the next if any.
+                """
+            )
+    parser.add_argument('-v2','--githubapiv2', action='store_const', const=True)
+
+    grp = parser.add_mutually_exclusive_group()
+    grp.add_argument(
+            '-l',
+            '--list',
+            action='store_const',
+            const=True,
+            help='list PR, their number and their mergeability')
+    grp.add_argument('-a',
+            '--merge-all',
+            action='store_const',
+            const=True ,
+            help='try to merge as many PR as possible, one by one')
+    grp.add_argument('-m',
+            '--merge',
+            type=int,
+            help="The pull request numbers",
+            nargs='*',
+            metavar='pr-number')
+    not_merged = {}; 
+    args = parser.parse_args()
+    ghv2 = args.githubapiv2
+    if(args.list):
+        pr_list = gh_api.get_pulls_list(gh_project, ghv2)
+        for pr in pr_list :
+            mergeable = gh_api.get_pull_request(gh_project, pr['number'],httpv2=ghv2)['mergeable']
+
+            ismgb = u"√" if mergeable else " "
+            print(u"* #{number} [{ismgb}]:  {title}".format(
+                number=pr['number'],
+                title=pr['title'],
+                ismgb=ismgb))
+
+    if(args.merge_all):
+        pr_list = gh_api.get_pulls_list(gh_project)
+        for pr in pr_list :
+            merge_pr(pr['number'])
+
+
+    elif args.merge:
+        for num in args.merge :
+            merge_pr(num,httpv2=ghv2)
+
+    if not_merged :
+        print('*************************************************************************************')
+        print('the following branch have not been merged automatically, considere doing it by hand :')
+        for num,cmd in not_merged.items() :
+            print( "PR {num}: {cmd}".format(num=num,cmd=cmd))
+        print('*************************************************************************************')

--- a/tools/git-mpr.py
+++ b/tools/git-mpr.py
@@ -49,9 +49,10 @@ def merge_pr(num,github_api=3):
     if github_api == 2:
         repo = pr['head']['repository']['url']
         owner = pr['head']['user']['name']
-    elif github_api == 2 :
+    elif github_api == 3 :
         repo = pr['head']['repo']['clone_url']
         owner = pr['head']['repo']['owner']['login']
+
 
     branch = pr['head']['ref']
     mergeable = merge_branch(repo=repo, 


### PR DESCRIPTION
inspired by git-mrb and test_pr, I thougth it would be usefull to be able to merge PR only by giving their number. Hence `git merge-pull-request`or `git-mpr`. (as it is in tool, the code is not really clean, full of typos...etc) 

usage: 

``` bash
$ git mpr -h                                                                          ~/ipython/tools
usage: git-mpr [-h] [-l | -a | -m [pr-number [pr-number ...]]]

Merge (one|many) github pull request by their number. If pull request can't be
merge as is, cancel merge, and continue to the next if any.

optional arguments:
  -h, --help            show this help message and exit
  -l, --list            list PR, their number and their mergeability
  -a, --merge-all       try to merge as many PR as possible, one by one
  -m [pr-number [pr-number ...]], --merge [pr-number [pr-number ...]]
                        The pull request numbers
```

examples :

``` bash
$ git mpr --list  
* #1758 [√]:  test_pr, fallback on http if git protocol fail, and SSL errors...
* #1755 [√]:  test for pygments before running qt tests
* #1715 [√]:  Fix for #1688, traceback-unicode issue
[...]
* #1493 [√]:  Selenium web tests proof-of-concept
* #1471 [ ]:  simplify IPython.parallel connections and enable Controller Resume
* #1343 [ ]:  Add prototype shutdown button to Notebook dashboard
* #1285 [√]:  Implementation of grepping the input history using several patterns
* #1215 [√]:  updated %quickref to show short-hand for %sc and %sx
```

PR number, mergeability and title
Quite slow, as it does 1 api call by PR, since api does not give mergeability anymore if you ask for the list of all PRs at once.

merge one or more PR (skip the ones with conflict and present a nice list to copy and past to do it by hand) 

``` bash
$ git mpr --merge [pr-number [pr-number ...]]]
[...]
*************************************************************************************
the following branch have not been merged automatically, considere doing it by hand :
PR 1630: git pull https://github.com/minrk/ipython.git mergekernel
PR 1343: git pull https://github.com/takluyver/ipython.git notebook-shutdown
PR 1715: git pull https://github.com/jstenar/ipython.git ultratb-pycolorize-unicode
PR 1732: git pull https://github.com/fperez/ipython.git cellmagics
PR 1471: git pull https://github.com/minrk/ipython.git connection
PR 1674: git pull https://github.com/mdboom/ipython.git notebook-carriage-return
*************************************************************************************
```

And last, 

```
git mpr --merge-all
```

That is pretty self explainatory

Oh, and I also learn that if you have a `git-xxx`(with dash) in your PATH, `git` is smart and call it when you invoke `git xxx`(without dash)
