### PR TITLE
add `locate` entry points

### DIFF
--- a/IPython/core/profileapp.py
+++ b/IPython/core/profileapp.py
@@ -86,7 +86,7 @@ _main_examples = """
 ipython profile create -h  # show the help string for the create subcommand
 ipython profile list -h    # show the help string for the list subcommand
 
-ipython profile locate foo # print the path to the directory for profile 'foo'
+ipython locate profile foo # print the path to the directory for profile 'foo'
 """
 
 #-----------------------------------------------------------------------------
@@ -293,7 +293,6 @@ class ProfileApp(Application):
     subcommands = Dict(dict(
         create = (ProfileCreate, ProfileCreate.description.splitlines()[0]),
         list = (ProfileList, ProfileList.description.splitlines()[0]),
-        locate = (ProfileLocate, ProfileLocate.description.splitlines()[0]),
     ))
 
     def start(self):

--- a/IPython/core/profileapp.py
+++ b/IPython/core/profileapp.py
@@ -85,6 +85,8 @@ ipython profile create foo --parallel # also stage parallel config files
 _main_examples = """
 ipython profile create -h  # show the help string for the create subcommand
 ipython profile list -h    # show the help string for the list subcommand
+
+ipython profile locate foo # print the path to the directory for profile 'foo'
 """
 
 #-----------------------------------------------------------------------------
@@ -113,6 +115,18 @@ def list_bundled_profiles():
         if os.path.isdir(full_path) and profile != "__pycache__":
             profiles.append(profile)
     return profiles
+
+
+class ProfileLocate(BaseIPythonApplication):
+    description = """print the path an IPython profile dir"""
+    
+    def parse_command_line(self, argv=None):
+        super(ProfileLocate, self).parse_command_line(argv)
+        if self.extra_args:
+            self.profile = self.extra_args[0]
+    
+    def start(self):
+        print self.profile_dir.location
 
 
 class ProfileList(Application):
@@ -277,8 +291,9 @@ class ProfileApp(Application):
     examples = _main_examples
 
     subcommands = Dict(dict(
-        create = (ProfileCreate, "Create a new profile dir with default config files"),
-        list = (ProfileList, "List existing profiles")
+        create = (ProfileCreate, ProfileCreate.description.splitlines()[0]),
+        list = (ProfileList, ProfileList.description.splitlines()[0]),
+        locate = (ProfileLocate, ProfileLocate.description.splitlines()[0]),
     ))
 
     def start(self):

--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -78,6 +78,9 @@ ipython help notebook      # show the help for the notebook subcmd
 
 ipython profile create foo # create profile foo w/ default config files
 ipython help profile       # show the help for the profile subcmd
+
+ipython locate             # print the path to the IPython directory
+ipython locate profile foo # print the path to the directory for profile `foo`
 """
 
 #-----------------------------------------------------------------------------
@@ -191,6 +194,21 @@ aliases.update(dict(
 # Main classes and functions
 #-----------------------------------------------------------------------------
 
+
+class LocateIPythonApp(BaseIPythonApplication):
+    description = """print the path to the IPython dir"""
+    subcommands = Dict(dict(
+        profile=('IPython.core.profileapp.ProfileLocate',
+            "print the path to an IPython profile directory",
+        ),
+    ))
+    def start(self):
+        if self.subapp is not None:
+            return self.subapp.start()
+        else:
+            print self.ipython_dir
+
+
 class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
     name = u'ipython'
     description = usage.cl_usage
@@ -229,6 +247,9 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
         ),
         console=('IPython.frontend.terminal.console.app.ZMQTerminalIPythonApp',
             """Launch the IPython terminal-based Console."""
+        ),
+        locate=('IPython.frontend.terminal.ipapp.LocateIPythonApp',
+            LocateIPythonApp.description
         ),
     ))
 

--- a/docs/source/config/overview.txt
+++ b/docs/source/config/overview.txt
@@ -281,7 +281,7 @@ configuration, and by default, all profiles will be stored in the so called
 "IPython directory". The location of this directory is determined by the
 following algorithm:
 
-* If the ``ipython_dir`` command line flag is given, its value is used.
+* If the ``ipython-dir`` command line flag is given, its value is used.
 
 * If not, the value returned by :func:`IPython.utils.path.get_ipython_dir`
   is used. This function will first look at the :envvar:`IPYTHONDIR`
@@ -323,6 +323,25 @@ and you will have a default :file:`ipython_config.py` in your IPython directory
 under :file:`profile_default`. If you want the default config files for the
 :mod:`IPython.parallel` applications, add ``--parallel`` to the end of the
 command-line args.
+
+
+Locating these files
+--------------------
+
+From the command-line, you can quickly locate the IPYTHONDIR or a specific
+profile with:
+
+.. sourcecode:: bash
+
+    $> ipython locate
+    /home/you/.ipython
+    
+    $> ipython locate profile foo
+    /home/you/.ipython/profile_foo
+
+These map to the utility functions: :func:`IPython.utils.path.get_ipython_dir`
+and :func:`IPython.utils.path.locate_profile` respectively.
+
 
 .. _Profiles:
 


### PR DESCRIPTION
These would be useful for quickly locating IPython directories and profiles from other (non-Python) applications.

Examples:

```
$> ipython locate
/Users/me/.ipython

$> ipython locate profile foo
/Users/me/.ipython/profile_foo

$> ipython locate profile 
/Users/me/.ipython/profile_default

$> ipython locate profile dne
[ProfileLocate] Profile u'dne' not found.
```

<del>`locate profile` is also available as `profile locate`, since that subcommand tree already exists.</del>
