### PR TITLE
Make default value of interactivity passed to run_ast_nodes configurable

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -368,10 +368,11 @@ class InteractiveShell(SingletonConfigurable):
             '"\C-u": unix-line-discard',
         ], allow_none=False, config=True)
 
-    ast_node_interactivity = Unicode('last_expr', config=True, help="""
+    ast_node_interactivity = Enum(['all', 'last', 'last_expr', 'none'],
+                                  default_value='last_expr', config=True, 
+                                  help="""
         'all', 'last', 'last_expr' or 'none'," specifying which nodes should be
-        run interactively (displaying output from expressions).
-        """)
+        run interactively (displaying output from expressions).""")
 
     # TODO: this part of prompt management should be moved to the frontends.
     # Use custom TraitTypes that convert '0'->'' and '\\n'->'\n'

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -368,6 +368,11 @@ class InteractiveShell(SingletonConfigurable):
             '"\C-u": unix-line-discard',
         ], allow_none=False, config=True)
 
+    ast_node_interactivity = Unicode('last_expr', config=True, help="""
+        'all', 'last', 'last_expr' or 'none'," specifying which nodes should be
+        run interactively (displaying output from expressions).
+        """)
+
     # TODO: this part of prompt management should be moved to the frontends.
     # Use custom TraitTypes that convert '0'->'' and '\\n'->'\n'
     separate_in = SeparateUnicode('\n', config=True)
@@ -2576,7 +2581,7 @@ class InteractiveShell(SingletonConfigurable):
                             self.execution_count += 1
                         return None
                     
-                    interactivity = "none" if silent else "last_expr"
+                    interactivity = "none" if silent else self.ast_node_interactivity
                     self.run_ast_nodes(code_ast.body, cell_name,
                                        interactivity=interactivity)
                     

--- a/docs/source/whatsnew/development.txt
+++ b/docs/source/whatsnew/development.txt
@@ -21,3 +21,7 @@ Other new features
   migrating to this variable is not worth the aesthetic improvement. Please use
   the historical :envvar:`IPYTHONDIR` environment variable instead.
 
+* The default value of *interactivity* passed from
+  :meth:`~IPython.core.interactiveshell.InteractiveShell.run_cell` to
+  :meth:`~IPython.core.interactiveshell.InteractiveShell.run_ast_nodes`
+  is now configurable.


### PR DESCRIPTION
We would like to be able to configure this for Sage.
