### PR TITLE
fix Magic menu in qtconsole, split in groups

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -321,6 +321,16 @@ class MagicsManager(Configurable):
     def auto_status(self):
         """Return descriptive string with automagic status."""
         return self._auto_status[self.auto_magic]
+    
+    def lsmagic_info(self):
+        magic_list = []
+        for m_type in self.magics :
+            for m_name,mgc in self.magics[m_type].items():
+                try :
+                    magic_list.append({'name':m_name,'type':m_type,'class':mgc.im_class.__name__})
+                except AttributeError :
+                    magic_list.append({'name':m_name,'type':m_type,'class':'Other'})
+        return magic_list
 
     def lsmagic(self):
         """Return a dict of currently available magic functions.


### PR DESCRIPTION
partially fixes #1774

alternative to #1776, that also reorganize magic in several menu.
Menu name is decided by inserting space in the CamelCasse name of the class of the magic.

![screencap](http://img205.imageshack.us/img205/4118/capturedcran20120529115.png)

Moreover, if there is a way to know if the magic have to take argument or not (`%logstate` vs `%timeit`), 
I could tweak the menu  to either execute, or to paste the magic at the beginning of the curent line.
