### PR TITLE
Raise repr limit for strings to 80 characters (from 30).

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -123,6 +123,22 @@ class Tracer(object):
 
         if colors is None:
             colors = def_colors
+
+        # The stdlib debugger internally uses a modified repr from the `repr`
+        # module, that limits the length of printed strings to a hardcoded
+        # limit of 30 characters.  That much trimming is too aggressive, let's
+        # at least raise that limit to 80 chars, which should be enough for
+        # most interactive uses.
+        try:
+            from repr import aRepr
+            aRepr.maxstring = 80
+        except:
+            # This is only a user-facing convenience, so any error we encounter
+            # here can be warned about but can be otherwise ignored.  These
+            # printouts will tell us about problems if this API changes 
+            import traceback
+            traceback.print_exc()
+
         self.debugger = Pdb(colors)
 
     def __call__(self):

--- a/IPython/core/tests/test_debugger.py
+++ b/IPython/core/tests/test_debugger.py
@@ -1,0 +1,35 @@
+"""Tests for debugging machinery.
+"""
+#-----------------------------------------------------------------------------
+#  Copyright (c) 2012, The IPython Development Team.
+#
+#  Distributed under the terms of the Modified BSD License.
+#
+#  The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# third-party
+import nose.tools as nt
+
+# Our own
+from IPython.core import debugger
+
+#-----------------------------------------------------------------------------
+# Tests
+#-----------------------------------------------------------------------------
+
+def test_longer_repr():
+    from repr import repr as trepr
+    
+    a = '1234567890'* 7
+    ar = "'1234567890123456789012345678901234567890123456789012345678901234567890'"
+    a_trunc = "'123456789012...8901234567890'"
+    nt.assert_equals(trepr(a), a_trunc)
+    # The creation of our tracer modifies the repr module's repr function
+    # in-place, since that global is used directly by the stdlib's pdb module.
+    t = debugger.Tracer()
+    nt.assert_equals(trepr(a), ar)


### PR DESCRIPTION
The python pdb debugger doesn't call the builtin `repr` function but
instead a custom one from the `repr` _module_ that limits strings to
30 characters.  Raise this limit to 80 for more informative printouts.

Closes #1788.
