### PR TITLE
don't use XDG path on OS X

### DIFF
--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -227,13 +227,13 @@ def get_home_dir(require_writable=False):
 def get_xdg_dir():
     """Return the XDG_CONFIG_HOME, if it is defined and exists, else None.
 
-    This is only for posix (Linux,Unix,OS X, etc) systems.
+    This is only for non-OS X posix (Linux,Unix,etc.) systems.
     """
 
     env = os.environ
 
-    if os.name == 'posix':
-        # Linux, Unix, AIX, OS X
+    if os.name == 'posix' and sys.platform != 'darwin':
+        # Linux, Unix, AIX, etc.
         # use ~/.config if empty OR not set
         xdg = env.get("XDG_CONFIG_HOME", None) or os.path.join(get_home_dir(), '.config')
         if xdg and _writable_dir(xdg):


### PR DESCRIPTION
This should never have been used on OS X.

A few relevant tests adjusted and added appropriately.

It would rarely come up, but occasional bad OS X citizens would create a ~/.config dir, and new OS X installs of IPython after this point would use this dir.

It's entirely possible that zero users have been affected by this so far.
