### PR TITLE
Fix comment which breaks Emacs syntax highlighting.

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -56,7 +56,7 @@ addflag('pdb', 'InteractiveShell.pdb',
 # which is before parsing.  This just allows the flag to be passed.
 shell_flags.update(dict(
     pydb = ({},
-        """"Use the third party 'pydb' package as debugger, instead of pdb.
+        """Use the third party 'pydb' package as debugger, instead of pdb.
         Requires that pydb is installed."""
     )
 ))


### PR DESCRIPTION
My Emacs is really unhappy with the 4 quotation mark characters in a row.
