### PR TITLE
Reintroduce recall

### DIFF
--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -128,7 +128,7 @@ class CodeMagics(Magics):
         extension. So it has been renamed simply into %load. You can look at
         `%load`'s docstring for more info.
         """
-        self.magic_load(arg_s)
+        self.load(arg_s)
 
     @line_magic
     def load(self, arg_s):

--- a/IPython/core/magics/history.py
+++ b/IPython/core/magics/history.py
@@ -292,3 +292,10 @@ class HistoryMagics(Magics):
         print(histlines)
         print("=== Output: ===")
         self.shell.run_cell("\n".join(hist), store_history=False)
+
+    @line_magic
+    def recall(self,arg):
+        self.rerun(arg)
+
+    recall.__doc__ = rerun.__doc__
+

--- a/IPython/core/magics/history.py
+++ b/IPython/core/magics/history.py
@@ -295,7 +295,7 @@ class HistoryMagics(Magics):
 
     @line_magic
     def recall(self,arg):
-        self.rerun(arg)
+        self.rep(arg)
 
-    recall.__doc__ = rerun.__doc__
+    recall.__doc__ = rep.__doc__
 


### PR DESCRIPTION
`%recall`had disapeared when refactoring magics, so re add the alias.

and a small bugfix, where the alias between `load` and `loadpy`was wrong, because there still was the leading `magic_` prefix. 
