### PR TITLE
Fixed a vcvarsall.bat error on win32/Py2.7 when trying to compile with mingw.

### DIFF
--- a/IPython/extensions/cythonmagic.py
+++ b/IPython/extensions/cythonmagic.py
@@ -156,7 +156,12 @@ class CythonMagics(Magics):
                 include_dirs = c_include_dirs,
                 extra_compile_args = cflags
             )
-            build_extension = build_ext(Distribution())
+            dist = Distribution()
+            config_files = dist.find_config_files()
+            try: config_files.remove('setup.cfg')
+            except ValueError: pass
+            dist.parse_config_files(config_files)
+            build_extension = build_ext(dist)
             build_extension.finalize_options()
             try:
                 build_extension.extensions = cythonize([extension], ctx=ctx, quiet=quiet)


### PR DESCRIPTION
This is the same error as cython pull request 129.

https://github.com/cython/cython/pull/129

This makes `%cython` also work for me but the cython devs have yet to confirm that this is the correct fix.
