### PR TITLE
add missing cython exclusion in iptest

### DIFF
--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -272,6 +272,7 @@ def make_exclude():
 
     if not have['cython']:
         exclusions.extend([ipjoin('extensions', 'cythonmagic')])
+        exclusions.extend([ipjoin('extensions', 'tests', 'test_cythonmagic')])
 
     if not have['tornado']:
         exclusions.append(ipjoin('frontend', 'html'))


### PR DESCRIPTION
The extension itself was excluded, but the test file was not.

closes #1802
