### PR TITLE
Reposition alternate upload for firefox [need cross browser/OS/language test]

### DIFF
--- a/IPython/frontend/html/notebook/static/css/alternateuploadform.css
+++ b/IPython/frontend/html/notebook/static/css/alternateuploadform.css
@@ -19,5 +19,7 @@
     position:relative;
     opacity: 0;
     z-index: 2;
-    width: 447px;
+    width: 295px;
+    margin-left:163px;
+    cursor: pointer;
 }


### PR DESCRIPTION
This should bring the click area of the notebook upload more closer to the bold font in dashboard for firefox. 

I don't considere it a real fix for #1806 as is also slightly shorten the area for other browser. 
See also the discusion in #1739.

This include making some part of the click area more visible by changing the cursor when hovering it.

Pinging @fperez and @jenshnielsen.

I have a small technical concern : 

The trick is done by overlaying a invisible  "fileinput form" on top of 'click here'
But the fileinput form is made of a "input" field concatenated with a "browse" button.
I am affraid the width of the  "Browse" (6 letters) button will change with language, for example in french it is a long button named "Parcourir" (9 letters)
