### PR TITLE
fix for #1809, failing tests in IPython.zmq

### DIFF
--- a/IPython/zmq/tests/test_embed_kernel.py
+++ b/IPython/zmq/tests/test_embed_kernel.py
@@ -36,9 +36,13 @@ def setup():
     global save_get_ipython_dir
     
     IPYTHONDIR = tempfile.mkdtemp()
+
     env = dict(IPYTHONDIR=IPYTHONDIR)
     if 'PYTHONPATH' in os.environ:
         env['PYTHONPATH'] = os.environ['PYTHONPATH']
+    if sys.platform == 'win32':
+        env["SYSTEMROOT"] = os.environ["SYSTEMROOT"]
+
     save_get_ipython_dir = path.get_ipython_dir
     path.get_ipython_dir = lambda : IPYTHONDIR
 

--- a/IPython/zmq/tests/test_embed_kernel.py
+++ b/IPython/zmq/tests/test_embed_kernel.py
@@ -37,11 +37,8 @@ def setup():
     
     IPYTHONDIR = tempfile.mkdtemp()
 
-    env = dict(IPYTHONDIR=IPYTHONDIR)
-    if 'PYTHONPATH' in os.environ:
-        env['PYTHONPATH'] = os.environ['PYTHONPATH']
-    if sys.platform == 'win32':
-        env["SYSTEMROOT"] = os.environ["SYSTEMROOT"]
+    env = os.environ.copy()
+    env["IPYTHONDIR"] = IPYTHONDIR
 
     save_get_ipython_dir = path.get_ipython_dir
     path.get_ipython_dir = lambda : IPYTHONDIR


### PR DESCRIPTION
on windows the env parameter to Popen needs to contain SYSTEMROOT
