### PR TITLE
warn on nonexistent exclusions in iptest

### DIFF
--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -48,7 +48,7 @@ from nose.core import TestProgram
 
 # Our own imports
 from IPython.utils.importstring import import_item
-from IPython.utils.path import get_ipython_module_path
+from IPython.utils.path import get_ipython_module_path, get_ipython_package_dir
 from IPython.utils.process import find_cmd, pycmd2argv
 from IPython.utils.sysinfo import sys_info
 from IPython.utils.warn import warn
@@ -280,8 +280,10 @@ def make_exclude():
         exclusions = [s.replace('\\','\\\\') for s in exclusions]
     
     # check for any exclusions that don't seem to exist:
+    parent, _ = os.path.split(get_ipython_package_dir())
     for exclusion in exclusions:
-        if not os.path.exists(exclusion) and not os.path.exists(exclusion + '.py'):
+        fullpath = pjoin(parent, exclusion)
+        if not os.path.exists(fullpath) and not os.path.exists(fullpath + '.py'):
             warn("Excluding nonexistent file: %r\n" % exclusion)
 
     return exclusions

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -51,6 +51,7 @@ from IPython.utils.importstring import import_item
 from IPython.utils.path import get_ipython_module_path
 from IPython.utils.process import find_cmd, pycmd2argv
 from IPython.utils.sysinfo import sys_info
+from IPython.utils.warn import warn
 
 from IPython.testing import globalipapp
 from IPython.testing.plugin.ipdoctest import IPythonDoctest
@@ -280,6 +281,11 @@ def make_exclude():
     # This is needed for the reg-exp to match on win32 in the ipdoctest plugin.
     if sys.platform == 'win32':
         exclusions = [s.replace('\\','\\\\') for s in exclusions]
+    
+    # check for any exclusions that don't seem to exist:
+    for exclusion in exclusions:
+        if not os.path.exists(exclusion) and not os.path.exists(exclusion + '.py'):
+            warn("Excluding nonexistent file: %r\n" % exclusion)
 
     return exclusions
 

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -213,10 +213,8 @@ def make_exclude():
     ipjoin = lambda *paths: pjoin('IPython', *paths)
 
     exclusions = [ipjoin('external'),
-                  pjoin('IPython_doctest_plugin'),
                   ipjoin('quarantine'),
                   ipjoin('deathrow'),
-                  ipjoin('testing', 'attic'),
                   # This guy is probably attic material
                   ipjoin('testing', 'mkdoctests'),
                   # Testing inputhook will need a lot of thought, to figure out
@@ -224,7 +222,6 @@ def make_exclude():
                   # loops in the picture
                   ipjoin('lib', 'inputhook'),
                   # Config files aren't really importable stand-alone
-                  ipjoin('config', 'default'),
                   ipjoin('config', 'profile'),
                   ]
     if not have['sqlite3']:


### PR DESCRIPTION
Adds a simple check in iptest that warns if any exclusions point to nonexistent files.

And removes a few stale exclusions revealed on first run.
