### PR TITLE
Add assert_in method to nose for Python 2.6

### DIFF
--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -40,6 +40,11 @@ import warnings
 # it for actual use.  This should get into nose upstream, but its release cycle
 # is slow and we need it for our parametric tests to work correctly.
 from IPython.testing import nosepatch
+
+# Monkeypatch extra assert methods into nose.tools if they're not already there.
+# This can be dropped once we no longer test on Python 2.6
+from IPython.testing import nose_assert_methods
+
 # Now, proceed to import nose itself
 import nose.plugins.builtin
 from nose.plugins.xunit import Xunit

--- a/IPython/testing/nose_assert_methods.py
+++ b/IPython/testing/nose_assert_methods.py
@@ -1,0 +1,11 @@
+"""Add some assert methods to nose.tools. These were added in Python 2.7/3.1, so
+once we stop testing on Python 2.6, this file can be removed.
+"""
+
+import nose.tools as nt
+
+def assert_in(item, collection):
+    assert item in collection, '%r not in %r' % (item, collection)
+
+if not hasattr(nt, 'assert_in'):
+    nt.assert_in = assert_in


### PR DESCRIPTION
For now I've only added `assert_in`. We can add extra methods to the file when we want to use them.

See #1775
