### PR TITLE
Make : invalid in filenames in the Notebook JS code.

### DIFF
--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -28,7 +28,7 @@ var IPython = (function (IPython) {
         this.control_key_active = false;
         this.notebook_id = null;
         this.notebook_name = null;
-        this.notebook_name_blacklist_re = /[\/\\]/;
+        this.notebook_name_blacklist_re = /[\/\\:]/;
         this.nbformat = 3 // Increment this when changing the nbformat
         this.style();
         this.create_elements();

--- a/IPython/frontend/html/notebook/static/js/savewidget.js
+++ b/IPython/frontend/html/notebook/static/js/savewidget.js
@@ -83,7 +83,7 @@ var IPython = (function (IPython) {
                         $(this).find('h3').html(
                             "Invalid notebook name. Notebook names must "+
                             "have 1 or more characters and can contain any characters " +
-                            "except / and \\. Please enter a new notebook name:"
+                            "except :/\\. Please enter a new notebook name:"
                         );
                     } else {
                         IPython.notebook.set_notebook_name(new_name);


### PR DESCRIPTION
This only prevents `:` in the filenames on the JavaScript side of things.  Handling this on the server side will be a separate issue that is related to other open issue.  I will update those to reflect this. Covers #1781.
