### PR TITLE
Always use filename as the notebook name.

### DIFF
--- a/IPython/frontend/html/notebook/notebookmanager.py
+++ b/IPython/frontend/html/notebook/notebookmanager.py
@@ -151,8 +151,8 @@ class NotebookManager(LoggingConfigurable):
                 nb = current.reads(s, u'json')
             except:
                 raise web.HTTPError(500, u'Unreadable JSON notebook.')
-        if 'name' not in nb:
-            nb.name = os.path.split(path)[-1].split(u'.')[0]
+        # Always use the filename as the notebook name.
+        nb.metadata.name = os.path.split(path)[-1].split(u'.')[0]
         return last_modified, nb
 
     def save_new_notebook(self, data, name=None, format=u'json'):


### PR DESCRIPTION
When the filename and notebook name (in the JSON data) were in conflict, we used to use the JSON data.  This was leading to problems as described in #1593.  This fixes the problem so that the filename is always used.  Subsequent saves will also set the JSON name to be the same value.
