### PR TITLE
ENTER submits the rename notebook dialog.

### DIFF
--- a/IPython/frontend/html/notebook/static/js/savewidget.js
+++ b/IPython/frontend/html/notebook/static/js/savewidget.js
@@ -99,7 +99,7 @@ var IPython = (function (IPython) {
                 var that = $(this);
                 // Upon ENTER, click the OK button.
                 that.find('input[type="text"]').keydown(function (event, ui) {
-                    if (event.which === 13) {
+                    if (event.which === utils.keycodes.ENTER) {
                         that.parent().find('button').first().click();
                     }
                 });

--- a/IPython/frontend/html/notebook/static/js/savewidget.js
+++ b/IPython/frontend/html/notebook/static/js/savewidget.js
@@ -94,6 +94,15 @@ var IPython = (function (IPython) {
                 "Cancel": function () {
                     $(this).dialog('close');
                 }
+            },
+            open : function (event, ui) {
+                var that = $(this);
+                // Upon ENTER, click the OK button.
+                that.keydown(function (event, ui) {
+                    if (event.which === 13) {
+                        that.parent().find('button').first().click();
+                    }
+                });
             }
         });
     }

--- a/IPython/frontend/html/notebook/static/js/savewidget.js
+++ b/IPython/frontend/html/notebook/static/js/savewidget.js
@@ -98,7 +98,7 @@ var IPython = (function (IPython) {
             open : function (event, ui) {
                 var that = $(this);
                 // Upon ENTER, click the OK button.
-                that.keydown(function (event, ui) {
+                that.find('input[type="text"]').keydown(function (event, ui) {
                     if (event.which === 13) {
                         that.parent().find('button').first().click();
                     }


### PR DESCRIPTION
This address issue #1596, but I am not convinced we want this.  I have bound an event handler to `ENTER` that will click the "OK" button when `ENTER` is pressed.  The problem is that we cant' indicate which of the two buttons is in focus - in fact neither of them is in focus because the text area has to be in focus for the user to change the name.

We may want the original behavior, which allowed the user to navigate the focus using `TAB` and then press the focused button using `ENTER`.
