### PR TITLE
aesthetics pass on AsyncResult.display_outputs

### DIFF
--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -118,10 +118,14 @@ class ExecuteReply(object):
             out = TermColors.Red
             normal = TermColors.Normal
         
+        if '\n' in text_out and not text_out.startswith('\n'):
+            # add newline for multiline reprs
+            text_out = '\n' + text_out
+        
         p.text(
-            u'[%i] ' % self.metadata['engine_id'] +
-            out + u'Out[%i]: ' % self.execution_count +
-            normal + text_out
+            out + u'Out[%i:%i]: ' % (
+                self.metadata['engine_id'], self.execution_count
+            ) + normal + text_out
         )
     
     def _repr_html_(self):

--- a/IPython/parallel/tests/test_asyncresult.py
+++ b/IPython/parallel/tests/test_asyncresult.py
@@ -212,7 +212,7 @@ class AsyncResultTest(ClusterTestCase):
         with capture_output() as io:
             ar.display_outputs()
         self.assertEquals(io.stderr, '')
-        self.assertTrue('5555' in io.stdout)
+        self.assertEquals('5555\n', io.stdout)
 
         ar = v.execute("a=5")
         ar.get(5)
@@ -232,6 +232,7 @@ class AsyncResultTest(ClusterTestCase):
             ar.display_outputs()
         self.assertEquals(io.stderr, '')
         self.assertEquals(io.stdout.count('5555'), len(v), io.stdout)
+        self.assertFalse('\n\n' in io.stdout, io.stdout)
         self.assertEquals(io.stdout.count('[stdout:'), len(v), io.stdout)
 
         ar = v.execute("a=5")
@@ -252,6 +253,7 @@ class AsyncResultTest(ClusterTestCase):
             ar.display_outputs('engine')
         self.assertEquals(io.stderr, '')
         self.assertEquals(io.stdout.count('5555'), len(v), io.stdout)
+        self.assertFalse('\n\n' in io.stdout, io.stdout)
         self.assertEquals(io.stdout.count('[stdout:'), len(v), io.stdout)
 
         ar = v.execute("a=5")

--- a/docs/examples/parallel/Parallel Magics.ipynb
+++ b/docs/examples/parallel/Parallel Magics.ipynb
@@ -89,6 +89,16 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
+      "with dv.sync_imports():",
+      "    import sys"
+     ],
+     "language": "python",
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
       "%px print >> sys.stderr, \"ERROR\""
      ],
      "language": "python",

--- a/docs/examples/parallel/Parallel Magics.ipynb
+++ b/docs/examples/parallel/Parallel Magics.ipynb
@@ -86,6 +86,15 @@
      "outputs": []
     },
     {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%px print >> sys.stderr, \"ERROR\""
+     ],
+     "language": "python",
+     "outputs": []
+    },
+    {
      "cell_type": "markdown",
      "source": [
       "You don't have to wait for results:"
@@ -207,8 +216,73 @@
       "x = linspace(0,pi,1000)",
       "for n in range(id,12, stride):",
       "    print n",
+      "    plt.figure()",
       "    plt.plot(x,sin(n*x))",
       "plt.title(\"Plot %i\" % id)"
+     ],
+     "language": "python",
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "When you specify 'order', then individual display outputs (e.g. plots) will be interleaved:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%%px --group-outputs=order",
+      "x = linspace(0,pi,1000)",
+      "for n in range(id,12, stride):",
+      "    print n",
+      "    plt.figure()",
+      "    plt.plot(x,sin(n*x))",
+      "plt.title(\"Plot %i\" % id)"
+     ],
+     "language": "python",
+     "outputs": []
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "source": [
+      "Single-engine views"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "When a DirectView has a single target, the output is a bit simpler (no prefixes on stdout/err, etc.):"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": true,
+     "input": [
+      "def generate_output():",
+      "    \"\"\"function for testing output",
+      "    ",
+      "    publishes two outputs of each type, and returns something",
+      "    \"\"\"",
+      "    ",
+      "    import sys,os",
+      "    from IPython.core.display import display, HTML, Math",
+      "    ",
+      "    print \"stdout\"",
+      "    print >> sys.stderr, \"stderr\"",
+      "    ",
+      "    display(HTML(\"<b>HTML</b>\"))",
+      "    ",
+      "    print \"stdout2\"",
+      "    print >> sys.stderr, \"stderr2\"",
+      "    ",
+      "    display(Math(r\"\\alpha=\\beta\"))",
+      "    ",
+      "    return os.getpid()",
+      "",
+      "dv['generate_output'] = generate_output"
      ],
      "language": "python",
      "outputs": []
@@ -217,7 +291,18 @@
      "cell_type": "code",
      "collapsed": true,
      "input": [
-      ""
+      "e0 = rc[-1]",
+      "e0.block = True",
+      "e0.activate()"
+     ],
+     "language": "python",
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%px generate_output()"
      ],
      "language": "python",
      "outputs": []


### PR DESCRIPTION
adds a few delimiters when there are rich outputs, and cleans up a few cases of extra trailing whitespace on stdout/err
