### PR TITLE
lsmagic lists magics in alphabetical order

### DIFF
--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -46,10 +46,10 @@ class BasicMagics(Magics):
         mman = self.shell.magics_manager
         magics = mman.lsmagic()
         out = ['Available line magics:',
-               mesc + ('  '+mesc).join(magics['line']),
+               mesc + ('  '+mesc).join(sorted(magics['line'])),
                '',
                'Available cell magics:',
-               cesc + ('  '+cesc).join(magics['cell']),
+               cesc + ('  '+cesc).join(sorted(magics['cell'])),
                '',
                mman.auto_status()]
         return '\n'.join(out)


### PR DESCRIPTION
Sort the magics before lsmagic displays them instead of showing them in random order. 
