### PR TITLE
Make svg, jpeg and png images resizable in notebook.

### DIFF
--- a/IPython/frontend/html/notebook/static/js/outputarea.js
+++ b/IPython/frontend/html/notebook/static/js/outputarea.js
@@ -275,21 +275,35 @@ var IPython = (function (IPython) {
 
     OutputArea.prototype.append_svg = function (svg, element) {
         var toinsert = $("<div/>").addClass("box-flex1 output_subarea output_svg");
-        toinsert.append(svg);
+        var img = $('<div/>');
+        img.append(svg);
+        var h = img.find('svg').attr('height');
+        var w = img.find('svg').attr('width');
+        img.width(w).height(h);
+        img.resizable({'aspectRatio': true});
+        toinsert.append(img);
         element.append(toinsert);
     };
 
 
     OutputArea.prototype.append_png = function (png, element) {
         var toinsert = $("<div/>").addClass("box-flex1 output_subarea output_png");
-        toinsert.append($("<img/>").attr('src','data:image/png;base64,'+png));
+        var img = $("<img/>").attr('src','data:image/png;base64,'+png);
+        img.load(function () {
+            $(this).resizable({'aspectRatio': true})
+        });
+        toinsert.append(img);
         element.append(toinsert);
     };
 
 
     OutputArea.prototype.append_jpeg = function (jpeg, element) {
         var toinsert = $("<div/>").addClass("box-flex1 output_subarea output_jpeg");
-        toinsert.append($("<img/>").attr('src','data:image/jpeg;base64,'+jpeg));
+        var img = $("<img/>").attr('src','data:image/jpeg;base64,'+jpeg);
+        img.load(function () {
+            $(this).resizable({'aspectRatio': true})
+        });
+        toinsert.append(img);
         element.append(toinsert);
     };
 

--- a/IPython/frontend/html/notebook/static/js/outputarea.js
+++ b/IPython/frontend/html/notebook/static/js/outputarea.js
@@ -275,14 +275,37 @@ var IPython = (function (IPython) {
 
     OutputArea.prototype.append_svg = function (svg, element) {
         var toinsert = $("<div/>").addClass("box-flex1 output_subarea output_svg");
+        // The <svg> tag cannot be made resizable so we wrap it in a resizable <div>.
+        // The problem with this is that we need to 1) set the initial size of the
+        // <div> based on the size of the <svg> and 2) we need to tie the size of the
+        // <div> and the <svg>.
         var img = $('<div/>');
-        img.append(svg);
-        var h = img.find('svg').attr('height');
-        var w = img.find('svg').attr('width');
-        img.width(w).height(h);
-        img.resizable({'aspectRatio': true});
+        img.html(svg);
         toinsert.append(img);
-        element.append(toinsert);
+        element.append(toinsert);        
+        svg = img.find('svg');
+        // The width and height returned here will be a string with units. Any units
+        // could be used and there is no way to reliably compute the equivalent pixels.
+        // Because of this the calls to width and height below simply pass on the unit
+        // information.
+        var w = svg.attr('width');
+        var h = svg.attr('height');
+        // Here we remove the attr versions of the width/height and set the css verions
+        // that we will be using later in the resize callback.
+        svg.removeAttr('height').removeAttr('width');
+        img.width(w).height(h);
+        svg.width(w).height(h);
+        img.resizable({
+            // We can't pass the minHeight/maxHeight options as they are required to
+            // be in pixels and we have no way to determining those numbers.
+            'autoHide': true,
+            'aspectRatio': true,
+            'resize': function () {
+                $(this).find('svg').height($(this).height());
+                $(this).find('svg').width($(this).width());
+            }
+        });
+
     };
 
 
@@ -290,7 +313,7 @@ var IPython = (function (IPython) {
         var toinsert = $("<div/>").addClass("box-flex1 output_subarea output_png");
         var img = $("<img/>").attr('src','data:image/png;base64,'+png);
         img.load(function () {
-            $(this).resizable({'aspectRatio': true})
+            $(this).resizable({'aspectRatio': true, 'autoHide': true})
         });
         toinsert.append(img);
         element.append(toinsert);
@@ -301,7 +324,7 @@ var IPython = (function (IPython) {
         var toinsert = $("<div/>").addClass("box-flex1 output_subarea output_jpeg");
         var img = $("<img/>").attr('src','data:image/jpeg;base64,'+jpeg);
         img.load(function () {
-            $(this).resizable({'aspectRatio': true})
+            $(this).resizable({'aspectRatio': true, 'autoHide': true})
         });
         toinsert.append(img);
         element.append(toinsert);

--- a/IPython/frontend/html/notebook/static/js/outputarea.js
+++ b/IPython/frontend/html/notebook/static/js/outputarea.js
@@ -275,37 +275,8 @@ var IPython = (function (IPython) {
 
     OutputArea.prototype.append_svg = function (svg, element) {
         var toinsert = $("<div/>").addClass("box-flex1 output_subarea output_svg");
-        // The <svg> tag cannot be made resizable so we wrap it in a resizable <div>.
-        // The problem with this is that we need to 1) set the initial size of the
-        // <div> based on the size of the <svg> and 2) we need to tie the size of the
-        // <div> and the <svg>.
-        var img = $('<div/>');
-        img.html(svg);
-        toinsert.append(img);
-        element.append(toinsert);        
-        svg = img.find('svg');
-        // The width and height returned here will be a string with units. Any units
-        // could be used and there is no way to reliably compute the equivalent pixels.
-        // Because of this the calls to width and height below simply pass on the unit
-        // information.
-        var w = svg.attr('width');
-        var h = svg.attr('height');
-        // Here we remove the attr versions of the width/height and set the css verions
-        // that we will be using later in the resize callback.
-        svg.removeAttr('height').removeAttr('width');
-        img.width(w).height(h);
-        svg.width(w).height(h);
-        img.resizable({
-            // We can't pass the minHeight/maxHeight options as they are required to
-            // be in pixels and we have no way to determining those numbers.
-            'autoHide': true,
-            'aspectRatio': true,
-            'resize': function () {
-                $(this).find('svg').height($(this).height());
-                $(this).find('svg').width($(this).width());
-            }
-        });
-
+        toinsert.append(svg);
+        element.append(toinsert);
     };
 
 

--- a/IPython/frontend/html/notebook/static/js/utils.js
+++ b/IPython/frontend/html/notebook/static/js/utils.js
@@ -126,12 +126,24 @@ IPython.utils = (function (IPython) {
                 DOWN     : 40,
     };
 
+
+    points_to_pixels = function (points) {
+        // A reasonably good way of converting between points and pixels.
+        var test = $('<div style="display: none; width: 10000pt; padding:0; border:0;"></div>');
+        $(body).append(test);
+        var pixel_per_point = test.width()/10000;
+        test.remove();
+        return Math.floor(points*pixel_per_point);
+    }
+
+
     return {
         uuid : uuid,
         fixConsole : fixConsole,
         keycodes : keycodes,
         grow : grow,
         fixCarriageReturn : fixCarriageReturn
+        points_to_pixels : points_to_pixels
     };
 
 }(IPython));


### PR DESCRIPTION
This addresses #1193.  All images are now resizable in the notebook by dragging handle in the lower R corner of the image.  I am having problems with svg images not working properly, but I don't know enough about svg to fix this this second.  Wondering if any of the matplotlib devs could help on this.
