### PR TITLE
preserve header for resubmitted tasks

### DIFF
--- a/IPython/parallel/controller/dictdb.py
+++ b/IPython/parallel/controller/dictdb.py
@@ -46,7 +46,7 @@ We support a subset of mongodb operators:
 #  the file COPYING, distributed as part of this software.
 #-----------------------------------------------------------------------------
 
-from copy import copy
+from copy import deepcopy as copy
 from datetime import datetime
 
 from IPython.config.configurable import LoggingConfigurable
@@ -129,7 +129,7 @@ class DictDB(BaseDB):
         d['msg_id'] = rec['msg_id']
         for key in keys:
             d[key] = rec[key]
-        return d
+        return copy(d)
 
     def add_record(self, msg_id, rec):
         """Add a new Task Record, by msg_id."""

--- a/IPython/parallel/controller/hub.py
+++ b/IPython/parallel/controller/hub.py
@@ -1166,7 +1166,11 @@ class Hub(SessionFactory):
             msg = self.session.msg(header['msg_type'])
             msg_id = msg['msg_id']
             msg['content'] = rec['content']
-            header.update(msg['header'])
+            
+            # use the old header, but update msg_id and timestamp
+            fresh = msg['header']
+            header['msg_id'] = fresh['msg_id']
+            header['date'] = fresh['date']
             msg['header'] = header
 
             self.session.send(self.resubmit, msg, buffers=rec['buffers'])

--- a/IPython/parallel/tests/test_db.py
+++ b/IPython/parallel/tests/test_db.py
@@ -197,9 +197,11 @@ class TestDictBackend(TestCase):
         rec = self.db.get_record(msg_id)
         rec.pop('buffers')
         rec['garbage'] = 'hello'
+        rec['header']['msg_id'] = 'fubar'
         rec2 = self.db.get_record(msg_id)
         self.assertTrue('buffers' in rec2)
         self.assertFalse('garbage' in rec2)
+        self.assertEquals(rec2['header']['msg_id'], msg_id)
     
     def test_pop_safe_find(self):
         """editing query results shouldn't affect record [find]"""
@@ -207,19 +209,23 @@ class TestDictBackend(TestCase):
         rec = self.db.find_records({'msg_id' : msg_id})[0]
         rec.pop('buffers')
         rec['garbage'] = 'hello'
+        rec['header']['msg_id'] = 'fubar'
         rec2 = self.db.find_records({'msg_id' : msg_id})[0]
         self.assertTrue('buffers' in rec2)
         self.assertFalse('garbage' in rec2)
+        self.assertEquals(rec2['header']['msg_id'], msg_id)
 
     def test_pop_safe_find_keys(self):
         """editing query results shouldn't affect record [find+keys]"""
         msg_id = self.db.get_history()[-1]
-        rec = self.db.find_records({'msg_id' : msg_id}, keys=['buffers'])[0]
+        rec = self.db.find_records({'msg_id' : msg_id}, keys=['buffers', 'header'])[0]
         rec.pop('buffers')
         rec['garbage'] = 'hello'
+        rec['header']['msg_id'] = 'fubar'
         rec2 = self.db.find_records({'msg_id' : msg_id})[0]
         self.assertTrue('buffers' in rec2)
         self.assertFalse('garbage' in rec2)
+        self.assertEquals(rec2['header']['msg_id'], msg_id)
 
 
 class TestSQLiteBackend(TestDictBackend):


### PR DESCRIPTION
header should be preserved, aside from new msg_id and timestamp.

Also fixes a DictDB clobbering bug.

closes #1834
