### PR TITLE
Fix jumpy notebook behavior

### DIFF
--- a/IPython/frontend/html/notebook/static/css/notebook.css
+++ b/IPython/frontend/html/notebook/static/css/notebook.css
@@ -35,6 +35,7 @@ span#notebook_name {
 }
 
 .ui-menu .ui-menu-item a {
+    border: 1px solid transparent;
     padding: 2px 1.6em;
 }
 
@@ -111,6 +112,18 @@ div#pager {
     padding: 15px;
     overflow: auto;
     display: none;
+}
+
+/* .ui-widget-content is a jQuery class applied to the focused cell. */
+div.ui-widget-content {
+    border: 1px solid #aaa;
+/* We do our own highlighting of the active element using the border above, so
+ * disable the one jQuery draws using outline. */
+    outline: none;
+}
+
+.cell {
+    border: 1px solid transparent;
 }
 
 div.cell {

--- a/IPython/frontend/html/notebook/static/css/projectdashboard.css
+++ b/IPython/frontend/html/notebook/static/css/projectdashboard.css
@@ -6,8 +6,8 @@
  */
 
 #main_app {
-    width: 920px;
-    margin: 30px auto 0px auto;
+    width: 100%;
+    /*margin: 30px auto 0px auto;*/
 }
 
 #tabs {

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -39,6 +39,9 @@ var IPython = (function (IPython) {
             indentUnit : 4,
             mode: 'python',
             theme: 'ipython',
+            matchBrackets: true,
+            indentWithTabs: true,
+            font-size: '1.2em',
             readOnly: this.read_only,
             onKeyEvent: $.proxy(this.handle_codemirror_keyevent,this)
         });
@@ -182,11 +185,6 @@ var IPython = (function (IPython) {
 
     CodeCell.prototype.select = function () {
         IPython.Cell.prototype.select.apply(this);
-        this.code_mirror.refresh();
-        this.code_mirror.focus();
-        // We used to need an additional refresh() after the focus, but
-        // it appears that this has been fixed in CM. This bug would show
-        // up on FF when a newly loaded markdown cell was edited.
     };
 
 

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -39,6 +39,8 @@ var IPython = (function (IPython) {
             indentUnit : 4,
             mode: 'python',
             theme: 'ipython',
+            matchBrackets: true,
+            indentWithTabs: true,
             readOnly: this.read_only,
             onKeyEvent: $.proxy(this.handle_codemirror_keyevent,this)
         });
@@ -182,11 +184,6 @@ var IPython = (function (IPython) {
 
     CodeCell.prototype.select = function () {
         IPython.Cell.prototype.select.apply(this);
-        this.code_mirror.refresh();
-        this.code_mirror.focus();
-        // We used to need an additional refresh() after the focus, but
-        // it appears that this has been fixed in CM. This bug would show
-        // up on FF when a newly loaded markdown cell was edited.
     };
 
 

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -41,6 +41,10 @@ var IPython = (function (IPython) {
             theme: 'ipython',
             matchBrackets: true,
             indentWithTabs: true,
+<<<<<<< HEAD
+=======
+            font-size: '1.2em',
+>>>>>>> 211f516ab558bffe3f157a0be6a37c0f0bbd01c8
             readOnly: this.read_only,
             onKeyEvent: $.proxy(this.handle_codemirror_keyevent,this)
         });

--- a/IPython/frontend/html/notebook/static/js/textcell.js
+++ b/IPython/frontend/html/notebook/static/js/textcell.js
@@ -258,8 +258,6 @@ var IPython = (function (IPython) {
 
     RawCell.prototype.select = function () {
         IPython.Cell.prototype.select.apply(this);
-        this.code_mirror.refresh();
-        this.code_mirror.focus();
     };
 
 


### PR DESCRIPTION
Menu: the menu items need a 1px border so that when one is added by jQuery, the menu item doesn't shift by 1px.  (ui-menu and ui-menu-item classes)                                                                      

Cell focus: The jQuery class .ui-widget-content draws the border on the focused cell, but the unfocused cell doesn't have a border, causing 1px jumping.  The solution is to add a border for it, but then this will have higher specificity than the jQuery class.  So I also added a redefinition of the focused cell border with div.ui-widget-content, which has higher specificity.  A selected cell was additionally getting an outline from jQuery when :active.  I also disabled this by setting 'outline: none', to prevent flashing of the border when a cell is clicked on.                                                                                                                    

Cell focus scrolling: The CodeMirror focus() call causes the window to scroll to the CodeMirror input cell.  I removed this call from CodeCell.prototype.select() and RawCell.prototype.select().  Additionally, the CodeMirror refresh() call is only required if the input cell changes and must be redrawn.  This doesn't  happen on focus, it happens on edit, and refresh() is properly called in TextCell.prototype.edit(), so isn't required in select().  I removed these superfluous refresh() calls too.                                                                                                         
