### PR TITLE
Class `%hierarchy` and graphiz `%%dot` magics

### DIFF
--- a/IPython/extensions/graphvizmagic.py
+++ b/IPython/extensions/graphvizmagic.py
@@ -1,0 +1,70 @@
+from IPython.core.magic import Magics, magics_class, cell_magic
+from IPython.core.magic_arguments import (argument, magic_arguments,
+                                          parse_argstring)
+from IPython.core.display import display_png, display_svg
+
+
+def run_dot(code, options=[], format='png'):
+    # mostly copied from sphinx.ext.graphviz.render_dot
+    from subprocess import Popen, PIPE
+    from sphinx.util.osutil import EPIPE, EINVAL
+
+    dot_args = ['dot'] + options + ['-T', format]
+    p = Popen(dot_args, stdout=PIPE, stdin=PIPE, stderr=PIPE)
+    wentwrong = False
+    try:
+        # Graphviz may close standard input when an error occurs,
+        # resulting in a broken pipe on communicate()
+        stdout, stderr = p.communicate(code)
+    except (OSError, IOError), err:
+        if err.errno != EPIPE:
+            raise
+        wentwrong = True
+    except IOError, err:
+        if err.errno != EINVAL:
+            raise
+        wentwrong = True
+    if wentwrong:
+        # in this case, read the standard output and standard error streams
+        # directly, to get the error message(s)
+        stdout, stderr = p.stdout.read(), p.stderr.read()
+        p.wait()
+    if p.returncode != 0:
+        raise RuntimeError('dot exited with error:\n[stderr]\n{0}'
+                           .format(stderr))
+    return stdout
+
+
+@magics_class
+class GraphvizMagic(Magics):
+
+    @magic_arguments()
+    @argument(
+        '-f', '--format', default='png', choices=('png', 'svg'),
+        help='output format (png/svg)'
+    )
+    @argument(
+        'options', default=[], nargs='*',
+        help='options passed to the `dot` command'
+    )
+    @cell_magic
+    def dot(self, line, cell):
+        """Draw a figure using Graphviz dot command."""
+        args = parse_argstring(self.dot, line)
+
+        image = run_dot(cell, args.options, format=args.format)
+
+        if args.format == 'png':
+            display_png(image, raw=True)
+        elif args.format == 'svg':
+            display_svg(image, raw=True)
+
+
+_loaded = False
+
+def load_ipython_extension(ip):
+    """Load the extension in IPython."""
+    global _loaded
+    if not _loaded:
+        ip.register_magics(GraphvizMagic)
+        _loaded = True

--- a/IPython/extensions/hierarchymagic.py
+++ b/IPython/extensions/hierarchymagic.py
@@ -1,0 +1,86 @@
+from IPython.core.magic import Magics, magics_class, line_magic
+from IPython.core.magic_arguments import (argument, magic_arguments,
+                                          parse_argstring)
+from IPython.core.display import display_png
+
+from sphinx.ext.inheritance_diagram import InheritanceGraph
+
+
+def run_dot(code, options=[], format='png'):
+    # mostly copied from sphinx.ext.graphviz.render_dot
+    from subprocess import Popen, PIPE
+    from sphinx.util.osutil import EPIPE, EINVAL
+
+    dot_args = ['dot'] + options + ['-T', format]
+    p = Popen(dot_args, stdout=PIPE, stdin=PIPE, stderr=PIPE)
+    wentwrong = False
+    try:
+        # Graphviz may close standard input when an error occurs,
+        # resulting in a broken pipe on communicate()
+        stdout, stderr = p.communicate(code)
+    except (OSError, IOError), err:
+        if err.errno != EPIPE:
+            raise
+        wentwrong = True
+    except IOError, err:
+        if err.errno != EINVAL:
+            raise
+        wentwrong = True
+    if wentwrong:
+        # in this case, read the standard output and standard error streams
+        # directly, to get the error message(s)
+        stdout, stderr = p.stdout.read(), p.stderr.read()
+        p.wait()
+    if p.returncode != 0:
+        raise RuntimeError('dot exited with error:\n[stderr]\n{0}'
+                           .format(stderr))
+    return stdout
+
+
+@magics_class
+class HierarchyMagic(Magics):
+
+    @magic_arguments()
+    @argument(
+        '-r', '--rankdir', default='TB',
+        help='direction of the hierarchy graph (default: %(default)s)'
+    )
+    @argument(
+        '-s', '--size', default='5.0, 12.0',
+        help='size of the generated figure (default: %(default)s)',
+    )
+    @argument(
+        'object',
+        help='Class hierarchy of this class or object will be drawn',
+    )
+    @line_magic
+    def hierarchy(self, parameter_s=''):
+        """Draw hierarchy of a given class."""
+        args = parse_argstring(self.hierarchy, parameter_s)
+        obj = self.shell.ev(args.object)
+        if isinstance(obj, type):
+            objclass = obj
+        elif hasattr(obj, "__class__"):
+            objclass = obj.__class__
+        else:
+            raise ValueError(
+                "Given object {0} is not a class or an instance".format(obj))
+        classpath = self.shell.display_formatter.format(
+            objclass, ['text/plain'])['text/plain']
+        (dirpath, basepath) = classpath.rsplit('.', 1)
+        ig = InheritanceGraph([basepath], dirpath)
+        code = ig.generate_dot('inheritance_graph',
+                               graph_attrs={'rankdir': args.rankdir,
+                                            'size': '"{0}"'.format(args.size)})
+        stdout = run_dot(code, format='png')
+        display_png(stdout, raw=True)
+
+
+_loaded = False
+
+def load_ipython_extension(ip):
+    """Load the extension in IPython."""
+    global _loaded
+    if not _loaded:
+        ip.register_magics(HierarchyMagic)
+        _loaded = True

--- a/IPython/extensions/hierarchymagic.py
+++ b/IPython/extensions/hierarchymagic.py
@@ -2,39 +2,9 @@ from IPython.core.magic import Magics, magics_class, line_magic
 from IPython.core.magic_arguments import (argument, magic_arguments,
                                           parse_argstring)
 from IPython.core.display import display_png
+from IPython.extensions.graphvizmagic import run_dot
 
 from sphinx.ext.inheritance_diagram import InheritanceGraph
-
-
-def run_dot(code, options=[], format='png'):
-    # mostly copied from sphinx.ext.graphviz.render_dot
-    from subprocess import Popen, PIPE
-    from sphinx.util.osutil import EPIPE, EINVAL
-
-    dot_args = ['dot'] + options + ['-T', format]
-    p = Popen(dot_args, stdout=PIPE, stdin=PIPE, stderr=PIPE)
-    wentwrong = False
-    try:
-        # Graphviz may close standard input when an error occurs,
-        # resulting in a broken pipe on communicate()
-        stdout, stderr = p.communicate(code)
-    except (OSError, IOError), err:
-        if err.errno != EPIPE:
-            raise
-        wentwrong = True
-    except IOError, err:
-        if err.errno != EINVAL:
-            raise
-        wentwrong = True
-    if wentwrong:
-        # in this case, read the standard output and standard error streams
-        # directly, to get the error message(s)
-        stdout, stderr = p.stdout.read(), p.stderr.read()
-        p.wait()
-    if p.returncode != 0:
-        raise RuntimeError('dot exited with error:\n[stderr]\n{0}'
-                           .format(stderr))
-    return stdout
 
 
 @magics_class


### PR DESCRIPTION
This PR introduces two magics.

First magic is `%hierarchy`.  This magic command draws hierarchy of given class or the class of given instance.  For example, the following shows class hierarchy of currently running IPython shell.

```
%hierarchy get_ipython()
```

Second magic is `%%dot`.  You can write graphiz dot language in a cell using this magic.  Example:

```
%%dot -- -Kfdp
digraph G {
    a->b; b->c; c->d; d->b; d->a;
}
```

I have two concerns:
- The function `run_dot`, which runs the `dot` command to produce the figure, is heavily borrowed from Sphinx extension.  I am not sure if there are any copyright problem.
- I used `self.shell.display_formatter.format` to get "full path" (something like `IPython.zmq.zmqshell.ZMQInteractiveShell`) of a class.  Maybe there is a better way to do that.
