### PR TITLE
%%script and %%file magics

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2017,7 +2017,8 @@ class InteractiveShell(SingletonConfigurable):
         self.register_magics(m.AutoMagics, m.BasicMagics, m.CodeMagics,
             m.ConfigMagics, m.DeprecatedMagics, m.ExecutionMagics,
             m.ExtensionMagics, m.HistoryMagics, m.LoggingMagics,
-            m.NamespaceMagics, m.OSMagics, m.PylabMagics )
+            m.NamespaceMagics, m.OSMagics, m.PylabMagics, m.ScriptMagics,
+        )
 
         # FIXME: Move the color initialization to the DisplayHook, which
         # should be split into a prompt manager and displayhook. We probably

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -30,7 +30,7 @@ from IPython.external.decorator import decorator
 from IPython.utils.ipstruct import Struct
 from IPython.utils.process import arg_split
 from IPython.utils.text import dedent
-from IPython.utils.traitlets import Bool, Dict, Instance
+from IPython.utils.traitlets import Bool, Dict, Instance, MetaHasTraits
 from IPython.utils.warn import error, warn
 
 #-----------------------------------------------------------------------------
@@ -355,10 +355,10 @@ class MagicsManager(Configurable):
         for m in magic_objects:
             if not m.registered:
                 raise ValueError("Class of magics %r was constructed without "
-                                 "the @register_macics class decorator")
-            if type(m) is type:
+                                 "the @register_magics class decorator")
+            if type(m) in (type, MetaHasTraits):
                 # If we're given an uninstantiated class
-                m = m(self.shell)
+                m = m(shell=self.shell)
 
             # Now that we have an instance, we can register it and update the
             # table of callables

--- a/IPython/core/magics/__init__.py
+++ b/IPython/core/magics/__init__.py
@@ -25,6 +25,7 @@ from .logging import LoggingMagics
 from .namespace import NamespaceMagics
 from .osm import OSMagics
 from .pylab import PylabMagics
+from .script import ScriptMagics
 
 #-----------------------------------------------------------------------------
 # Magic implementation classes

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -28,7 +28,7 @@ from IPython.core import oinspect
 from IPython.core import page
 from IPython.core.error import UsageError, StdinNotImplementedError
 from IPython.core.magic import  (
-    Magics, compress_dhist, magics_class, line_magic, cell_magic
+    Magics, compress_dhist, magics_class, line_magic, cell_magic, line_cell_magic
 )
 from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.io import file_read, nlprint
@@ -548,8 +548,8 @@ class OSMagics(Magics):
         else:
             return out
 
-    @line_magic
-    def sx(self, parameter_s=''):
+    @line_cell_magic
+    def sx(self, line='', cell=None):
         """Shell execute - run shell command and capture output (!! is short-hand).
 
         %sx command
@@ -589,10 +589,21 @@ class OSMagics(Magics):
 
         This is very useful when trying to use such lists as arguments to
         system commands."""
+        
+        if cell is None:
+            # line magic
+            return self.shell.getoutput(line)
+        else:
+            opts,args = self.parse_options(line, '', 'out=')
+            output = self.shell.getoutput(cell)
+            out_name = opts.get('out', opts.get('o'))
+            if out_name:
+                self.shell.user_ns[out_name] = output
+            else:
+                return output
 
-        if parameter_s:
-            return self.shell.getoutput(parameter_s)
-
+    system = line_cell_magic('system')(sx)
+    bang = cell_magic('!')(sx)
 
     @line_magic
     def bookmark(self, parameter_s=''):

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -681,10 +681,6 @@ class OSMagics(Magics):
 
     @magic_arguments.magic_arguments()
     @magic_arguments.argument(
-        '-f', '--force', action='store_true', default=False,
-        help='Force overwrite without prompting'
-    )
-    @magic_arguments.argument(
         '-a', '--amend', action='store_true', default=False,
         help='Open file for amending if it exists'
     )
@@ -699,30 +695,16 @@ class OSMagics(Magics):
         For frontends that do not support stdin (Notebook), -f is implied.
         """
         args = magic_arguments.parse_argstring(self.file, line)
-        args.filename = unquote_filename(args.filename)
-        force = args.force
+        filename = unquote_filename(args.filename)
         
-        if os.path.exists(args.filename):
+        if os.path.exists(filename):
             if args.amend:
-                print "Amending to %s" % args.filename
+                print "Amending to %s" % filename
             else:
-                if not force:
-                    try:
-                        force = self.shell.ask_yes_no(
-                            "%s exists, overwrite (y/[n])?",
-                            default='n'
-                        )
-                    except StdinNotImplementedError:
-                        force = True
-                
-                if not force:
-                    # prompted, but still no
-                    print "Force overwrite with %%file -f " + args.filename
-                    return
-                print "Overwriting %s" % args.filename
+                print "Overwriting %s" % filename
         else:
-            print "Writing %s" % args.filename
+            print "Writing %s" % filename
         
         mode = 'a' if args.amend else 'w'
-        with io.open(args.filename, mode, encoding='utf-8') as f:
+        with io.open(filename, mode, encoding='utf-8') as f:
             f.write(cell)

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -435,7 +435,7 @@ class OSMagics(Magics):
     @skip_doctest
     @line_magic
     def sc(self, parameter_s=''):
-        """Shell capture - execute a shell command and capture its output.
+        """Shell capture - run shell command and capture output (DEPRECATED use !).
 
         DEPRECATED. Suboptimal, retained for backwards compatibility.
 
@@ -550,7 +550,7 @@ class OSMagics(Magics):
 
     @line_magic
     def sx(self, parameter_s=''):
-        """Shell execute - run a shell command and capture its output.
+        """Shell execute - run shell command and capture output (!! is short-hand).
 
         %sx command
 

--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -1,0 +1,155 @@
+"""Magic functions for running cells in various scripts."""
+#-----------------------------------------------------------------------------
+#  Copyright (c) 2012 The IPython Development Team.
+#
+#  Distributed under the terms of the Modified BSD License.
+#
+#  The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Stdlib
+import os
+import re
+import sys
+from subprocess import Popen, PIPE
+
+# Our own packages
+from IPython.config.configurable import Configurable
+from IPython.core.error import UsageError
+from IPython.core.magic import  (
+    Magics, magics_class, line_magic, cell_magic
+)
+from IPython.testing.skipdoctest import skip_doctest
+from IPython.utils.process import find_cmd, FindCmdError
+from IPython.utils.traitlets import List, Dict
+
+#-----------------------------------------------------------------------------
+# Magic implementation classes
+#-----------------------------------------------------------------------------
+
+@magics_class
+class ScriptMagics(Magics, Configurable):
+    """Magics for talking to scripts
+    
+    This defines a base `%%script` cell magic for running a cell
+    with a program in a subprocess, and registers a few top-level
+    magics that call %%script with common interpreters.
+    """
+    script_magics = List(config=True,
+        help="""Extra script cell magics to define
+        
+        This generates simple wrappers of `%%script foo` as `%%foo`.
+        
+        If you want to add script magics that aren't on your path,
+        specify them in script_paths
+        """,
+    )
+    def _script_magics_default(self):
+        """default to a common list of programs if we find them"""
+        
+        defaults = []
+        to_try = []
+        if os.name == 'nt':
+            defaults.append('cmd')
+            to_try.append('powershell')
+        to_try.extend([
+            'sh',
+            'bash',
+            'perl',
+            'ruby',
+            'python3',
+            'pypy',
+        ])
+        
+        for cmd in to_try:
+            if cmd in self.script_paths:
+                defaults.append(cmd)
+            else:
+                try:
+                    find_cmd(cmd)
+                except FindCmdError:
+                    # command not found, ignore it
+                    pass
+                except ImportError:
+                    # Windows without pywin32, find_cmd doesn't work
+                    pass
+                else:
+                    defaults.append(cmd)
+        return defaults
+    
+    script_paths = Dict(config=True,
+        help="""Dict mapping short 'ruby' names to full paths, such as '/opt/secret/bin/ruby'
+        
+        Only necessary for items in script_magics where the default path will not
+        find the right interpreter.
+        """
+    )
+    
+    def __init__(self, shell=None):
+        Configurable.__init__(self, config=shell.config)
+        self._generate_script_magics()
+        Magics.__init__(self, shell=shell)
+    
+    def _generate_script_magics(self):
+        cell_magics = self.magics['cell']
+        for name in self.script_magics:
+            cell_magics[name] = self._make_script_magic(name)
+    
+    def _make_script_magic(self, name):
+        """make a named magic, that calls %%script with a particular program"""
+        # expand to explicit path if necessary:
+        script = self.script_paths.get(name, name)
+        
+        def named_script_magic(line, cell):
+            # if line, add it as cl-flags
+            if line:
+                 line = "%s %s" % (script, line)
+            else:
+                line = script
+            return self.shebang(line, cell)
+        
+        # write a basic docstring:
+        named_script_magic.__doc__ = \
+        """%%{name} script magic
+        
+        Run cells with {script} in a subprocess.
+        
+        This is a shortcut for `%%script {script}`
+        """.format(**locals())
+        
+        return named_script_magic
+
+    @cell_magic("script")
+    def shebang(self, line, cell):
+        """Run a cell via a shell command
+        
+        The `%%script` line is like the #! line of script,
+        specifying a program (bash, perl, ruby, etc.) with which to run.
+        
+        The rest of the cell is run by that program.
+        
+        Examples
+        --------
+        ::
+        
+            In [1]: %%script bash
+               ...: for i in 1 2 3; do
+               ...:   echo $i
+               ...: done
+            1
+            2
+            3
+        """
+        p = Popen(line, stdout=PIPE, stderr=PIPE, stdin=PIPE)
+        out,err = p.communicate(cell)
+        sys.stdout.write(out)
+        sys.stdout.flush()
+        sys.stderr.write(err)
+        sys.stderr.flush()
+    
+    # expose %%script as %%!
+    cell_magic('!')(shebang)

--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -190,7 +190,7 @@ class ScriptMagics(Magics, Configurable):
             if args.out:
                 self.shell.user_ns[args.out] = p.stdout
             if args.err:
-                self.shell.user_ns[args.out] = p.stderr
+                self.shell.user_ns[args.err] = p.stderr
             self.job_manager.new(self._run_script, p, cell)
             return
         

--- a/docs/examples/notebooks/Script Magics.ipynb
+++ b/docs/examples/notebooks/Script Magics.ipynb
@@ -1,0 +1,448 @@
+{
+ "metadata": {
+  "name": "Script Magics"
+ },
+ "nbformat": 3,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "heading",
+     "level": 1,
+     "source": [
+      "Running Scripts from IPython"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "IPython has a `%%script` cell magic, which lets you run a cell in",
+      "a subprocess of any interpreter on your system, such as: bash, ruby, perl, zsh, R, etc.",
+      "",
+      "It can even be a script of your own, which expects input on stdin."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "import sys"
+     ],
+     "language": "python",
+     "outputs": [],
+     "prompt_number": 1
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "To use it, simply pass a path or shell command to the program you want to run on the `%%script` line,",
+      "and the rest of the cell will be run by that script, and stdout/err from the subprocess are captured and displayed."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "%%script python",
+      "import sys",
+      "print 'hello from Python %s' % sys.version"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "hello from Python 2.7.1 (r271:86832, Jul 31 2011, 19:30:53) ",
+        "[GCC 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2335.15.00)]",
+        ""
+       ]
+      }
+     ],
+     "prompt_number": 2
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "%%script python3",
+      "import sys",
+      "print('hello from Python: %s' % sys.version)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "hello from Python: 3.2.3 (v3.2.3:3d0686d90f55, Apr 10 2012, 11:25:50) ",
+        "[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]",
+        ""
+       ]
+      }
+     ],
+     "prompt_number": 3
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "IPython also creates aliases for a few common interpreters, such as bash, ruby, perl, etc.",
+      "",
+      "These are all equivalent to `%%script <name>`"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "%%ruby",
+      "puts \"Hello from Ruby #{RUBY_VERSION}\""
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "Hello from Ruby 1.8.7",
+        ""
+       ]
+      }
+     ],
+     "prompt_number": 4
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "%%bash",
+      "echo \"hello from $BASH\""
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "hello from /usr/local/bin/bash",
+        ""
+       ]
+      }
+     ],
+     "prompt_number": 5
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "source": [
+      "Capturing output"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "You can also capture stdout/err from these subprocesses into Python variables, instead of letting them go directly to stdout/err"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "%%bash",
+      "echo \"hi, stdout\"",
+      "echo \"hello, stderr\" >&2",
+      ""
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "hi, stdout",
+        ""
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stderr",
+       "text": [
+        "hello, stderr",
+        ""
+       ]
+      }
+     ],
+     "prompt_number": 6
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "%%bash --out output --err error",
+      "echo \"hi, stdout\"",
+      "echo \"hello, stderr\" >&2"
+     ],
+     "language": "python",
+     "outputs": [],
+     "prompt_number": 7
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "print error",
+      "print output"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "hello, stderr",
+        "",
+        "hi, stdout",
+        "",
+        ""
+       ]
+      }
+     ],
+     "prompt_number": 8
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "source": [
+      "Background Scripts"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "These scripts can be run in the background, by adding the `--bg` flag.",
+      "",
+      "When you do this, output is discarded unless you use the `--out/err`",
+      "flags to store output as above."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "%%ruby --bg --out ruby_lines",
+      "for n in 1...10",
+      "    sleep 1",
+      "    puts \"line #{n}\"",
+      "    STDOUT.flush",
+      "end"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "Starting job # 0 in a separate thread.",
+        ""
+       ]
+      }
+     ],
+     "prompt_number": 9
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "When you do store output of a background thread, these are the stdout/err *pipes*,",
+      "rather than the text of the output."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "ruby_lines"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "output_type": "pyout",
+       "prompt_number": 10,
+       "text": [
+        "<open file '<fdopen>', mode 'rb' at 0x10dc651e0>"
+       ]
+      }
+     ],
+     "prompt_number": 10
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "print ruby_lines.read()"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "line 1",
+        "line 2",
+        "line 3",
+        "line 4",
+        "line 5",
+        "line 6",
+        "line 7",
+        "line 8",
+        "line 9",
+        "",
+        ""
+       ]
+      }
+     ],
+     "prompt_number": 11
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "source": [
+      "Arguments to subcommand"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "You can pass arguments the subcommand as well,",
+      "such as  this example instructing Python to use integer division from Python 3:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "%%script python -Qnew",
+      "print 1/3"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "0.333333333333",
+        ""
+       ]
+      }
+     ],
+     "prompt_number": 12
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "You can really specify *any* program for `%%script`,",
+      "for instance here is a 'program' that echos the lines of stdin, with delays between each line."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "%%script --bg --out bashout bash -c \"while read line; do echo $line; sleep 1; done\"",
+      "line 1",
+      "line 2",
+      "line 3",
+      "line 4",
+      "line 5",
+      ""
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "Starting job # 2 in a separate thread.",
+        ""
+       ]
+      }
+     ],
+     "prompt_number": 13
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Remember, since the output of a background script is just the stdout pipe,",
+      "you can read it as lines become available:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "import time",
+      "tic = time.time()",
+      "line = True",
+      "while True:",
+      "    line = bashout.readline()",
+      "    if not line:",
+      "        break",
+      "    sys.stdout.write(\"%.1fs: %s\" %(time.time()-tic, line))",
+      "    sys.stdout.flush()",
+      ""
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "0.0s: line 1",
+        ""
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "1.0s: line 2",
+        ""
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "2.0s: line 3",
+        ""
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "3.0s: line 4",
+        ""
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "4.0s: line 5",
+        ""
+       ]
+      }
+     ],
+     "prompt_number": 14
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "source": [
+      "Configuring the default ScriptMagics"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "The list of aliased script magics is configurable.",
+      "",
+      "The default is to pick from a few common interpreters, and use them if found, but you can specify your own in ipython_config.py:",
+      "",
+      "    c.ScriptMagics.scripts = ['R', 'pypy', 'myprogram']",
+      "",
+      "And if any of these programs do not apear on your default PATH, then you would also need to specify their location with:",
+      "",
+      "    c.ScriptMagics.script_paths = {'myprogram': '/opt/path/to/myprogram'}"
+     ]
+    }
+   ]
+  }
+ ]
+}


### PR DESCRIPTION
As discussed on the ML, a few more basic cell magics, as requested:
- `%%file` writes to a file (-f to force overwrite)
- `%%script` runs a cell with a particular script

The ScriptMagics also defines a few common magics that wrap `%%script` with common interpreters, such as `%%bash` by default, and this list, as well as the full path for each, is configurable.

I still have to do some testing, particularly on Windows, but it seems ready for public eyes anyway.

For fun, the `%%script` magic is also presented as `%%!`, but I am happy to remove that if we don't like it.
