### PR TITLE
Fix 1px jumping of cells and menus in Notebook.

### DIFF
--- a/IPython/frontend/html/notebook/static/css/notebook.css
+++ b/IPython/frontend/html/notebook/static/css/notebook.css
@@ -35,6 +35,7 @@ span#notebook_name {
 }
 
 .ui-menu .ui-menu-item a {
+    border: 1px solid transparent;
     padding: 2px 1.6em;
 }
 
@@ -111,6 +112,15 @@ div#pager {
     padding: 15px;
     overflow: auto;
     display: none;
+}
+
+div.ui-widget-content {
+    border: 1px solid #aaa;
+    outline: none;
+}
+
+.cell {
+    border: 1px solid transparent;
 }
 
 div.cell {


### PR DESCRIPTION
When cells are selected, their contents shift to the right and down by 1px, because cells are defined with 'border: 0' and when selected, they get a 1px border.  (same with menu items)

Menu: the menu items need a 1px border so that when one is added by jQuery, the menu item doesn't shift by 1px.  (ui-menu and ui-menu-item classes) 

Cell focus: The jQuery class .ui-widget-content draws the border on the focused cell, but the unfocused cell doesn't have a border, causing 1px jumping.  The solution is to add a border for it, but then this will have higher specificity than the jQuery class.  So I also added a redefinition of the focused cell border with div.ui-widget-content, which has higher specificity.  A selected cell was additionally getting an outline from jQuery when active.  I also disabled this by setting 'outline: none', to prevent flashing of the border when a cell is clicked on.
