### PR TITLE
Prevent jumping of window to input when output is clicked.

### DIFF
--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -182,11 +182,6 @@ var IPython = (function (IPython) {
 
     CodeCell.prototype.select = function () {
         IPython.Cell.prototype.select.apply(this);
-        this.code_mirror.refresh();
-        this.code_mirror.focus();
-        // We used to need an additional refresh() after the focus, but
-        // it appears that this has been fixed in CM. This bug would show
-        // up on FF when a newly loaded markdown cell was edited.
     };
 
 

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -435,6 +435,8 @@ var IPython = (function (IPython) {
         var index = this.get_selected_index();
         if (index !== null && index >= 0 && (index+1) < this.ncells()) {
             this.select(index+1);
+            var cell = this.get_cell(index+1)
+            cell.code_mirror.focus()
         };
         return this;
     };
@@ -444,6 +446,10 @@ var IPython = (function (IPython) {
         var index = this.get_selected_index();
         if (index !== null && index >= 0 && (index-1) < this.ncells()) {
             this.select(index-1);
+            if(index > 0) {
+                var cell = this.get_cell(index-1)
+                cell.code_mirror.focus()
+            }
         };
         return this;
     };
@@ -942,13 +948,16 @@ var IPython = (function (IPython) {
         if (default_options.terminal) {
             cell.select_all();
         } else {
+            var next_cell;
             if ((cell_index === (that.ncells()-1)) && default_options.add_new) {
-                that.insert_cell_below('code');
+                next_cell = that.insert_cell_below('code');
                 // If we are adding a new cell at the end, scroll down to show it.
                 that.scroll_to_bottom();
             } else {
                 that.select(cell_index+1);
+                next_cell = this.get_cell(cell_index+1);
             };
+            next_cell.code_mirror.focus();
         };
         this.dirty = true;
     };

--- a/IPython/frontend/html/notebook/static/js/textcell.js
+++ b/IPython/frontend/html/notebook/static/js/textcell.js
@@ -258,7 +258,6 @@ var IPython = (function (IPython) {
 
     RawCell.prototype.select = function () {
         IPython.Cell.prototype.select.apply(this);
-        this.code_mirror.refresh();
         this.code_mirror.focus();
     };
 


### PR DESCRIPTION
When the user clicks on the output portion of a cell, the window will scroll to the corresponding input portion of the cell. This is very disruptive when you have multi-page output and makes examining or cutting/selecting output very tedious.

This patch fixes that by explicitly calling calling code_mirror.focus() when it is necessary (on keypress up/down and execute) and removing the corresponding call from CodeCell.protototype.select().

I also removed the code_mirror.refresh() calls, as they are unnecessary.

(This is the same code as #1857, I have reorganized my repository to have a branch 'jumpy_output' following @fperez 's recommendation.  Sorry for being a git neophyte...)
