### PR TITLE
Fix 1px margin bouncing of selected menu item.

### DIFF
--- a/IPython/frontend/html/notebook/static/css/notebook.css
+++ b/IPython/frontend/html/notebook/static/css/notebook.css
@@ -39,6 +39,10 @@ span#notebook_name {
     padding: 2px 1.6em;
 }
 
+.ui-menu .ui-menu-item a.ui-state-focus {
+    margin: 0;
+}
+
 .ui-menu hr {
     margin: 0.3em 0;
 }


### PR DESCRIPTION
I missed a case with my last 1px border patch.

jQuery also adds a margin of size -1 to the active menu item, which also causes the selected menu item to bounce around by 1px, but it was only visible if your font is sufficiently large.

Anyway, this fixes the margin of the active menu item to zero, so now the text doesn't shift around, even if you use larger fonts.

To reproduce the original error, zoom your notebook (ctrl-mousewheel, or ctrl-+ in most browsers) and try the menu.
