### PR TITLE
add %%capture for capturing stdout/err

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -992,25 +992,31 @@ python-profiler package from non-free.""")
         print macro,
     
     @magic_arguments.magic_arguments()
-    @magic_arguments.argument('-o', '--out', type=str,
-        help="""The name of the variable in which to store stdout
+    @magic_arguments.argument('output', type=str, default='', nargs='?',
+        help="""The name of the variable in which to store output.
+        This is a utils.io.CapturedIO object with stdout/err attributes
+        for the text of the captured output.
         
-        If unspecified: stdout is discarded
+        CapturedOutput also has a show() method for displaying the output,
+        and __call__ as well, so you can use that to quickly display the
+        output.
+        
+        If unspecified, captured output is discarded.
         """
     )
-    @magic_arguments.argument('-e', '--err', type=str,
-        help="""The name of the variable in which to store stderr
-        
-        If unspecified: stderr is discarded
-        """
+    @magic_arguments.argument('--no-stderr', action="store_true",
+        help="""Don't capture stderr."""
+    )
+    @magic_arguments.argument('--no-stdout', action="store_true",
+        help="""Don't capture stdout."""
     )
     @cell_magic
     def capture(self, line, cell):
         """run the cell, capturing stdout/err"""
         args = magic_arguments.parse_argstring(self.capture, line)
-        with capture_output() as io:
+        out = not args.no_stdout
+        err = not args.no_stderr
+        with capture_output(out, err) as io:
             self.shell.run_cell(cell)
-        if args.out:
-            self.shell.user_ns[args.out] = io.stdout
-        if args.err:
-            self.shell.user_ns[args.err] = io.stderr
+        if args.output:
+            self.shell.user_ns[args.output] = io

--- a/IPython/parallel/tests/clienttest.py
+++ b/IPython/parallel/tests/clienttest.py
@@ -100,36 +100,6 @@ def skip_without(*names):
 # Classes
 #-------------------------------------------------------------------------------
 
-class CapturedIO(object):
-    """Simple object for containing captured stdout/err StringIO objects"""
-    
-    def __init__(self, stdout, stderr):
-        self.stdout_io = stdout
-        self.stderr_io = stderr
-    
-    @property
-    def stdout(self):
-        return self.stdout_io.getvalue()
-    
-    @property
-    def stderr(self):
-        return self.stderr_io.getvalue()
-
-
-class capture_output(object):
-    """context manager for capturing stdout/err"""
-    
-    def __enter__(self):
-        self.sys_stdout = sys.stdout
-        self.sys_stderr = sys.stderr
-        stdout = sys.stdout = StringIO()
-        stderr = sys.stderr = StringIO()
-        return CapturedIO(stdout, stderr)
-    
-    def __exit__(self, exc_type, exc_value, traceback):
-        sys.stdout = self.sys_stdout
-        sys.stderr = self.sys_stderr
-
 
 class ClusterTestCase(BaseZMQTestCase):
     

--- a/IPython/parallel/tests/test_asyncresult.py
+++ b/IPython/parallel/tests/test_asyncresult.py
@@ -18,11 +18,12 @@ Authors:
 
 import time
 
-from IPython.parallel.error import TimeoutError
+from IPython.utils.io import capture_output
 
+from IPython.parallel.error import TimeoutError
 from IPython.parallel import error, Client
 from IPython.parallel.tests import add_engines
-from .clienttest import ClusterTestCase, capture_output
+from .clienttest import ClusterTestCase
 
 def setup():
     add_engines(2, total=True)

--- a/IPython/parallel/tests/test_magics.py
+++ b/IPython/parallel/tests/test_magics.py
@@ -25,6 +25,7 @@ from nose import SkipTest
 
 from IPython.testing import decorators as dec
 from IPython.testing.ipunittest import ParametricTestCase
+from IPython.utils.io import capture_output
 
 from IPython import parallel  as pmod
 from IPython.parallel import error
@@ -33,7 +34,7 @@ from IPython.parallel.util import interactive
 
 from IPython.parallel.tests import add_engines
 
-from .clienttest import ClusterTestCase, capture_output, generate_output
+from .clienttest import ClusterTestCase, generate_output
 
 def setup():
     add_engines(3, total=True)

--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 import os
 import sys
 import tempfile
+from StringIO import StringIO
 
 #-----------------------------------------------------------------------------
 # Code
@@ -321,3 +322,36 @@ def raw_print_err(*args, **kw):
 # Short aliases for quick debugging, do NOT use these in production code.
 rprint = raw_print
 rprinte = raw_print_err
+
+
+class CapturedIO(object):
+    """Simple object for containing captured stdout/err StringIO objects"""
+    
+    def __init__(self, stdout, stderr):
+        self.stdout_io = stdout
+        self.stderr_io = stderr
+    
+    @property
+    def stdout(self):
+        return self.stdout_io.getvalue()
+    
+    @property
+    def stderr(self):
+        return self.stderr_io.getvalue()
+
+
+class capture_output(object):
+    """context manager for capturing stdout/err"""
+    
+    def __enter__(self):
+        self.sys_stdout = sys.stdout
+        self.sys_stderr = sys.stderr
+        stdout = sys.stdout = StringIO()
+        stderr = sys.stderr = StringIO()
+        return CapturedIO(stdout, stderr)
+    
+    def __exit__(self, exc_type, exc_value, traceback):
+        sys.stdout = self.sys_stdout
+        sys.stderr = self.sys_stderr
+
+

--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -331,6 +331,9 @@ class CapturedIO(object):
         self._stdout = stdout
         self._stderr = stderr
     
+    def __str__(self):
+        return self.stdout
+    
     @property
     def stdout(self):
         if not self._stdout:

--- a/IPython/utils/tests/test_io.py
+++ b/IPython/utils/tests/test_io.py
@@ -20,7 +20,7 @@ from subprocess import Popen, PIPE
 import nose.tools as nt
 
 from IPython.testing import decorators as dec
-from IPython.utils.io import Tee
+from IPython.utils.io import Tee, capture_output
 from IPython.utils.py3compat import doctest_refactor_print
 
 #-----------------------------------------------------------------------------
@@ -73,3 +73,13 @@ def test_io_init():
         # __class__ is a reference to the class object in Python 3, so we can't
         # just test for string equality.
         assert 'IPython.utils.io.IOStream' in classname, classname
+
+def test_capture_output():
+    """capture_output() context works"""
+    
+    with capture_output() as io:
+        print 'hi, stdout'
+        print >> sys.stderr, 'hi, stderr'
+    
+    nt.assert_equals(io.stdout, 'hi, stdout\n')
+    nt.assert_equals(io.stderr, 'hi, stderr\n')

--- a/docs/examples/notebooks/Capturing Output.ipynb
+++ b/docs/examples/notebooks/Capturing Output.ipynb
@@ -1,0 +1,131 @@
+{
+ "metadata": {
+  "name": "Capturing Output"
+ },
+ "nbformat": 3,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "heading",
+     "level": 1,
+     "source": [
+      "Capturing Output with <tt>%%capture</tt>"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "One of IPython's new cell magics is `%%capture`, which captures stdout/err for a cell,",
+      "and discards them or stores them in variables in your namespace."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "import sys"
+     ],
+     "language": "python",
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "By default, it just swallows it up.  This is a simple way to suppress unwanted output."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "%%capture",
+      "print 'hi, stdout'",
+      "print >> sys.stderr, 'hi, stderr'"
+     ],
+     "language": "python",
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "If you specify `-o` or `-e`, then stdout and/or stderr will be stored in those variables in your namespace."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "%%capture -o my_stdout",
+      "print 'hi, stdout'",
+      "print >> sys.stderr, 'hi, stderr'"
+     ],
+     "language": "python",
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "my_stdout"
+     ],
+     "language": "python",
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "%%capture -o my_stdout2 -e my_stderr",
+      "print 'hi again, stdout'",
+      "print >> sys.stderr, 'hi there, stderr'"
+     ],
+     "language": "python",
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "sys.stdout.write(my_stdout2)",
+      "sys.stderr.write(my_stderr)"
+     ],
+     "language": "python",
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "`%%capture` only captures stdout/err, not displaypub, so you can still do plots and use the display protocol inside %%capture"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "%pylab inline"
+     ],
+     "language": "python",
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "%%capture -o wontshutup",
+      "",
+      "print \"setting up X\"",
+      "x = np.linspace(0,5,1000)",
+      "print \"step 2: constructing y-data\"",
+      "y = np.sin(x)",
+      "print \"step 3: display info about y\"",
+      "plt.plot(x,y)",
+      "print \"okay, I'm done now\""
+     ],
+     "language": "python",
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "print wontshutup"
+     ],
+     "language": "python",
+     "outputs": []
+    }
+   ]
+  }
+ ]
+}

--- a/docs/examples/notebooks/Capturing Output.ipynb
+++ b/docs/examples/notebooks/Capturing Output.ipynb
@@ -47,13 +47,13 @@
     {
      "cell_type": "markdown",
      "source": [
-      "If you specify `-o` or `-e`, then stdout and/or stderr will be stored in those variables in your namespace."
+      "If you specify a name, then stdout and stderr will be stored in an object in your namespace."
      ]
     },
     {
      "cell_type": "code",
      "input": [
-      "%%capture -o my_stdout",
+      "%%capture captured",
       "print 'hi, stdout'",
       "print >> sys.stderr, 'hi, stderr'"
      ],
@@ -63,7 +63,21 @@
     {
      "cell_type": "code",
      "input": [
-      "my_stdout"
+      "captured"
+     ],
+     "language": "python",
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Calling the object writes the output to stdout/err as appropriate."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "captured()"
      ],
      "language": "python",
      "outputs": []
@@ -71,9 +85,7 @@
     {
      "cell_type": "code",
      "input": [
-      "%%capture -o my_stdout2 -e my_stderr",
-      "print 'hi again, stdout'",
-      "print >> sys.stderr, 'hi there, stderr'"
+      "captured.stdout"
      ],
      "language": "python",
      "outputs": []
@@ -81,8 +93,7 @@
     {
      "cell_type": "code",
      "input": [
-      "sys.stdout.write(my_stdout2)",
-      "sys.stderr.write(my_stderr)"
+      "captured.stderr"
      ],
      "language": "python",
      "outputs": []
@@ -104,7 +115,7 @@
     {
      "cell_type": "code",
      "input": [
-      "%%capture -o wontshutup",
+      "%%capture wontshutup",
       "",
       "print \"setting up X\"",
       "x = np.linspace(0,5,1000)",
@@ -120,7 +131,47 @@
     {
      "cell_type": "code",
      "input": [
-      "print wontshutup"
+      "wontshutup()"
+     ],
+     "language": "python",
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "And you can selectively disable capturing stdout or stderr by passing `--no-stdout/err`."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "%%capture cap --no-stderr",
+      "print 'hi, stdout'",
+      "print >> sys.stderr, \"hello, stderr\""
+     ],
+     "language": "python",
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "cap.stdout"
+     ],
+     "language": "python",
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "cap.stderr"
+     ],
+     "language": "python",
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      ""
      ],
      "language": "python",
      "outputs": []


### PR DESCRIPTION
New `%%capture` cell magic captures stdout/err while running a cell.

closes #1863

Uses `capture_output()` context manager, moved to utils.io from IPython.parallel testing utilities, where it originated.

Default behavior: discards stdout/err
Optionally stores stdout/err in variables

Possible alternate behavior: only store the single CapturedIO object in a variable, so both outputs are accessible as io.stdout / io.stderr, rather than having to store them separately.

If we don't want the magic and/or notebook, then I'm fine discarding them, but the capture_output context manager probably does belong in utils.io.
