### PR TITLE
re-write columnize, with intermediate step.

### DIFF
--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -14,6 +14,7 @@
 
 import os
 import math
+import random
 
 import nose.tools as nt
 
@@ -32,13 +33,37 @@ def test_columnize():
     items = [l*size for l in 'abc']
     out = text.columnize(items, displaywidth=80)
     nt.assert_equals(out, 'aaaaa  bbbbb  ccccc\n')
-    out = text.columnize(items, displaywidth=10)
+    out = text.columnize(items, displaywidth=12)
     nt.assert_equals(out, 'aaaaa  ccccc\nbbbbb\n')
+    out = text.columnize(items, displaywidth=10)
+    nt.assert_equals(out, 'aaaaa\nbbbbb\nccccc\n')
 
+def test_columnize_random():
+    """Test with random input to hopfully catch edge case """
+    for nitems in [random.randint(2,70) for i in range(2,20)]:
+        displaywidth = random.randint(20,200)
+        rand_len = [random.randint(2,displaywidth) for i in range(nitems)]
+        items = ['x'*l for l in rand_len]
+        out = text.columnize(items, displaywidth=displaywidth)
+        longer_line = max([len(x) for x in out.split('\n')])
+        longer_element = max(rand_len)
+        if longer_line > displaywidth:
+            print "Columnize displayed something lager than displaywidth : %s " % longer_line
+            print "longer element : %s " % longer_element
+            print "displaywidth : %s " % displaywidth
+            print "number of element : %s " % nitems
+            print "size of each element :\n %s" % rand_len
+            assert False
+
+def test_columnize_medium():
+    """Test with inputs than shouldn't be wider tahn 80 """
+    size = 40
+    items = [l*size for l in 'abc']
+    out = text.columnize(items, displaywidth=80)
+    nt.assert_equals(out, '\n'.join(items+['']))
 
 def test_columnize_long():
     """Test columnize with inputs longer than the display window"""
-    text.columnize(['a'*81, 'b'*81], displaywidth=80)
     size = 11
     items = [l*size for l in 'abc']
     out = text.columnize(items, displaywidth=size-1)


### PR DESCRIPTION
fix test that where wrong, add some others.

fix #1860
## 

Maybe not the fastest implementation ever, but allow some granularity, and intermediate state i'll need for #1851. More over, it does more in less lines (docstrings and test excluded :-)  ). 
Nice thing with this granularity is that we could add stretching separators in one line if necessary.

Right now, it finds the right number of columns by bruteforcing,
we could try to bisect if we start hitting high number of items, but i'm not sure it is necessary.

Output of the new and old function were identical on around 20000 random test case, except when the old columnize was wrong (wider output than displaywidth).

I added a random test to hopefully catch edges cases (fail with a few percent probability on old columnize, haven't failed with new in thousand of sample) . 

As it is a random test, I wasn't sure on how to keep information about it, so I added print statements and `assert False` is there a better way ?
