### PR TITLE
Correct stack depth for variable expansion in !system commands

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2179,7 +2179,7 @@ class InteractiveShell(SingletonConfigurable):
         # we explicitly do NOT return the subprocess status code, because
         # a non-None value would trigger :func:`sys.displayhook` calls.
         # Instead, we store the exit_code in user_ns.
-        self.user_ns['_exit_code'] = system(self.var_expand(cmd, depth=2))
+        self.user_ns['_exit_code'] = system(self.var_expand(cmd, depth=1))
 
     def system_raw(self, cmd):
         """Call the given cmd in a subprocess using os.system
@@ -2189,7 +2189,7 @@ class InteractiveShell(SingletonConfigurable):
         cmd : str
           Command to execute.
         """
-        cmd = self.var_expand(cmd, depth=2)
+        cmd = self.var_expand(cmd, depth=1)
         # protect os.system from UNC paths on Windows, which it can't handle:
         if sys.platform == 'win32':
             from IPython.utils._process_win32 import AvoidUNCPath
@@ -2229,7 +2229,7 @@ class InteractiveShell(SingletonConfigurable):
         if cmd.rstrip().endswith('&'):
             # this is *far* from a rigorous test
             raise OSError("Background processes not supported.")
-        out = getoutput(self.var_expand(cmd, depth=2))
+        out = getoutput(self.var_expand(cmd, depth=1))
         if split:
             out = SList(out.splitlines())
         else:

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -239,6 +239,14 @@ class InteractiveShellTestCase(unittest.TestCase):
         # This should not raise any exception:
         ip.var_expand(u'echo $f')
     
+    def test_var_expand_local(self):
+        ip.run_cell('def test():\n'
+                    '    lvar = "ttt"\n'
+                    '    ret = !echo {lvar}\n'
+                    '    return ret[0]\n')
+        res = ip.user_ns['test']()
+        nt.assert_in('ttt', res)
+    
     def test_bad_var_expand(self):
         """var_expand on invalid formats shouldn't raise"""
         # SyntaxError

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -240,12 +240,22 @@ class InteractiveShellTestCase(unittest.TestCase):
         ip.var_expand(u'echo $f')
     
     def test_var_expand_local(self):
+        """Test local variable expansion in !system and %magic calls"""
+        # !system
         ip.run_cell('def test():\n'
                     '    lvar = "ttt"\n'
                     '    ret = !echo {lvar}\n'
                     '    return ret[0]\n')
         res = ip.user_ns['test']()
         nt.assert_in('ttt', res)
+        
+        # %magic
+        ip.run_cell('def makemacro():\n'
+                    '    macroname = "macro_var_expand_locals"\n'
+                    '    %macro {macroname} codestr\n')
+        ip.user_ns['codestr'] = "str(12)"
+        ip.run_cell('makemacro()')
+        nt.assert_in('macro_var_expand_locals', ip.user_ns)
     
     def test_bad_var_expand(self):
         """var_expand on invalid formats shouldn't raise"""


### PR DESCRIPTION
Closes issue #1878.
