### PR TITLE
Remove importlib dependency which not available in Python 2.6.

### DIFF
--- a/IPython/extensions/cythonmagic.py
+++ b/IPython/extensions/cythonmagic.py
@@ -17,7 +17,6 @@ Parts of this code were taken from Cython.inline.
 
 import io
 import os, sys
-from importlib import import_module
 import imp
 
 try:
@@ -101,7 +100,8 @@ class CythonMagics(Magics):
             module = self._reloads[module_name]
             reload(module)
         else:
-            module = import_module(module_name)
+            __import__(module_name)
+            module = sys.modules[module_name]
             self._reloads[module_name] = module
         self._import_all(module)
 


### PR DESCRIPTION
Since we are only doing an absolute import, it suffices to just run
`__import__(name)` and then find the module in `sys.modules`.

Compare to the `import_module` [source](http://svn.python.org/projects/python/trunk/Lib/importlib/__init__.py):

```
def import_module(name, package=None):
    if name.startswith('.'):
        # ...
    __import__(name)
    return sys.modules[name]
```

Closes #1874.
