### PR TITLE
Fix a bug in renaming notebook

### DIFF
--- a/IPython/frontend/html/notebook/notebookmanager.py
+++ b/IPython/frontend/html/notebook/notebookmanager.py
@@ -228,6 +228,7 @@ class NotebookManager(LoggingConfigurable):
                     os.unlink(old_pypath)
             self.mapping[notebook_id] = new_name
             self.rev_mapping[new_name] = notebook_id
+            del self.rev_mapping[old_name]
 
     def delete_notebook(self, notebook_id):
         """Delete notebook by notebook_id."""


### PR DESCRIPTION
There was a bug in NotebookManager.save_notebook_object.
Here is how to reproduce:
1. Make sure you don't have Untitled0.
2. Open new notebook Untitled0.
3. Rename it to something else.
4. Copy Untitled0.ipynb to the notebook dir from somewhere.
   (Do not use notebook UI.)
5. New copied Untitled0 cannot be opened.
   The renamed notebook is opened when tried.
   Indeed, accessing to http://localhost:XXXX/notebooks shows
   duplicated notebook_id.

The problem was that NotebookManager.rev_mapping keeps old notebook
name after renaming.
