### PR TITLE
Make it easy to resize jpeg/png images back to original size.

### DIFF
--- a/IPython/frontend/html/notebook/static/js/outputarea.js
+++ b/IPython/frontend/html/notebook/static/js/outputarea.js
@@ -284,7 +284,14 @@ var IPython = (function (IPython) {
         var toinsert = $("<div/>").addClass("box-flex1 output_subarea output_png");
         var img = $("<img/>").attr('src','data:image/png;base64,'+png);
         img.load(function () {
-            $(this).resizable({'aspectRatio': true, 'autoHide': true})
+            var h = $(this).height();
+            var w = $(this).width()
+            $(this).resizable({
+                'aspectRatio': true,
+                'autoHide': true,
+                'minHeight': h,
+                'minWidth': w
+            });
         });
         toinsert.append(img);
         element.append(toinsert);
@@ -295,7 +302,14 @@ var IPython = (function (IPython) {
         var toinsert = $("<div/>").addClass("box-flex1 output_subarea output_jpeg");
         var img = $("<img/>").attr('src','data:image/jpeg;base64,'+jpeg);
         img.load(function () {
-            $(this).resizable({'aspectRatio': true, 'autoHide': true})
+            var h = $(this).height();
+            var w = $(this).width()
+            $(this).resizable({
+                'aspectRatio': true,
+                'autoHide': true,
+                'minHeight': h,
+                'minWidth': w
+            });
         });
         toinsert.append(img);
         element.append(toinsert);


### PR DESCRIPTION
This should fix the issue brought up by @minrk about users not having an easy way of getting resized images back to their original size.  Can you test this Min.

Also, I created a notebook with an image and then kept reloading it from disk.  I could not reproduce the other error you were finding.  Can you send me a notebook that shows this error?  Also what browser (I tried latest stable FF+Chrome).
