### PR TITLE
Fix error in test suite with ip.system()

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2210,7 +2210,7 @@ class InteractiveShell(SingletonConfigurable):
     # use piped system by default, because it is better behaved
     system = system_piped
 
-    def getoutput(self, cmd, split=True, _depth=0):
+    def getoutput(self, cmd, split=True, depth=0):
         """Get output (possibly including stderr) from a subprocess.
 
         Parameters
@@ -2219,17 +2219,20 @@ class InteractiveShell(SingletonConfigurable):
           Command to execute (can not end in '&', as background processes are
           not supported.
         split : bool, optional
-
           If True, split the output into an IPython SList.  Otherwise, an
           IPython LSString is returned.  These are objects similar to normal
           lists and strings, with a few convenience attributes for easier
           manipulation of line-based output.  You can use '?' on them for
           details.
-          """
+        depth : int, optional
+          How many frames above the caller are the local variables which should
+          be expanded in the command string? The default (0) assumes that the
+          expansion variables are in the stack frame calling this function.
+        """
         if cmd.rstrip().endswith('&'):
             # this is *far* from a rigorous test
             raise OSError("Background processes not supported.")
-        out = getoutput(self.var_expand(cmd, depth=_depth+1))
+        out = getoutput(self.var_expand(cmd, depth=depth+1))
         if split:
             out = SList(out.splitlines())
         else:

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2210,7 +2210,7 @@ class InteractiveShell(SingletonConfigurable):
     # use piped system by default, because it is better behaved
     system = system_piped
 
-    def getoutput(self, cmd, split=True):
+    def getoutput(self, cmd, split=True, _depth=0):
         """Get output (possibly including stderr) from a subprocess.
 
         Parameters
@@ -2229,7 +2229,7 @@ class InteractiveShell(SingletonConfigurable):
         if cmd.rstrip().endswith('&'):
             # this is *far* from a rigorous test
             raise OSError("Background processes not supported.")
-        out = getoutput(self.var_expand(cmd, depth=1))
+        out = getoutput(self.var_expand(cmd, depth=_depth+1))
         if split:
             out = SList(out.splitlines())
         else:

--- a/IPython/testing/globalipapp.py
+++ b/IPython/testing/globalipapp.py
@@ -98,7 +98,7 @@ def xsys(self, cmd):
     """
     # We use getoutput, but we need to strip it because pexpect captures
     # the trailing newline differently from commands.getoutput
-    print(self.getoutput(cmd, split=False, _depth=1).rstrip(), end='', file=sys.stdout)
+    print(self.getoutput(cmd, split=False, depth=1).rstrip(), end='', file=sys.stdout)
     sys.stdout.flush()
 
 

--- a/IPython/testing/globalipapp.py
+++ b/IPython/testing/globalipapp.py
@@ -98,7 +98,7 @@ def xsys(self, cmd):
     """
     # We use getoutput, but we need to strip it because pexpect captures
     # the trailing newline differently from commands.getoutput
-    print(self.getoutput(cmd, split=False).rstrip(), end='', file=sys.stdout)
+    print(self.getoutput(cmd, split=False, _depth=1).rstrip(), end='', file=sys.stdout)
     sys.stdout.flush()
 
 


### PR DESCRIPTION
As discussed in #1878. Another case of looking the wrong depth through the stack.

There's still some other problem with the doctesting machinery - `a` should be turning up in the user namespace in this test, but it isn't. I've tried to understand the code to run doctests before, though, and it gives me a headache.
