### PR TITLE
minimize manpages

### DIFF
--- a/docs/man/ipcluster.1
+++ b/docs/man/ipcluster.1
@@ -1,48 +1,21 @@
-.TH IPCLUSTER 1 "July 15, 2011" "" ""
+.TH IPCLUSTER 1 "June 10, 2012" "" ""
 .SH NAME
-\fBipcluster \- IPython parallel computing cluster control tool
+\fBipcluster \- start a cluster for IPython parallel computing
 .SH SYNOPSIS
-.nf
-.fam C
-\fBipcluster\fP {\fmpiexec,local,mpirun,pbs,ssh\fP} [\fIoptions\fP]
-.fam T
-.fi
+
+.B ipcluster subcommand
+.RI [ options ]
+
 .SH DESCRIPTION
-ipcluster is a control tool for IPython's parallel computing functions.
+Start an IPython cluster for parallel computing.
 
-IPython cluster startup. This starts a controller and engines using various
-approaches. Use the IPYTHONDIR environment variable to change your IPython
-directory from the default of ~/.ipython or ~/.config/ipython. The log and security
-subdirectories of your IPython directory will be used by this script for log
-files and security files.
-.SH POSITIONAL ARGUMENTS
+For more information on how to use ipcluster, see 'ipcluster --help',
+or 'ipcluster --help-all' for all available command-line options.
 
-The first positional argument should be one of: {start, stop, engines},
-which are the available subcommands.
-
-For detailed help on each, type "ipcluster CMD \-\-help". Briefly:
-
-  start         start an IPython cluster
-  stop          stop a running IPython cluster
-  engines       add a number of engines to a running cluster
-.SH OPTIONS
-.TP
-.B
-\-h, \-\-help
-show help message and exit
-.SH EXAMPLE
-ipcluster start \-\-n=4
-
-This command will start 4 IPython engines on the local computer.
-.SH SEE ALSO
+.SH "SEE ALSO"
 .BR ipython(1),
 .BR ipcontroller(1),
-.BR ipengine(1)
+.BR ipengine(1),
 .br
-.SH AUTHOR
-\fBipcluster\fP is a tool that ships with IPython, created by
-the IPython Development Team.
-.PP
-This manual page was written by Stephan Peijnik <debian@sp.or.at>,
-for the Debian project (but may be used by others).  Modified by Fernando Perez
-<Fernando.Perez@berkeley.edu> for inclusion in IPython.
+.SH AUTHORS
+\fBipcluster\fP ships with IPython, maintained by the IPython Development Team.

--- a/docs/man/ipcontroller.1
+++ b/docs/man/ipcontroller.1
@@ -1,164 +1,21 @@
-.TH IPCONTROLLER 1 "October 29, 2008" "" ""
+.TH IPCONTROLLER 1 "June 10, 2012" "" ""
 .SH NAME
-\fBipcontroller \- IPython parallel computing controller control tool
+\fBipcontroller \- start a controller for IPython parallel computing
+
 .SH SYNOPSIS
-.nf
-.fam C
-\fBipengine\fP [\fIoptions\fP]
-.fam T
-.fi
+.B ipcontroller
+.RI [ options ]
+
 .SH DESCRIPTION
-ipcontroller is a control tool for IPython's parallel computing functions.
-.SH OPTIONS
-.TP
-.B
-\-h, \-\-help
-show this help message and exit
-.TP
-.B
-.TP
-.B \-\-no\-secure
-Don't authenticate messages.
-.TP
-.B \-\-usethreads
-Use threads instead of processes for the schedulers
-.TP
-.B \-\-init
-Initialize profile with default config files
-.TP
-.B \-\-log\-to\-file
-send log output to a file
-.TP
-.B \-\-reuse
-reuse existing json connection files
-.TP
-.B \-\-mongodb
-use the MongoDB backend
-.TP
-.B \-\-quiet
-set log level to logging.CRITICAL (minimize logging output)
-.TP
-.B \-\-debug
-set log level to logging.DEBUG (maximize logging output)
-.TP
-.B \-\-sqlitedb
-use the SQLiteDB backend
-.TP
-.B \-\-dictdb
-use the in-memory DictDB backend
-.TP
-.B \-\-secure
-Use HMAC digests for authentication of messages.
-.TP
-.B \-\-profile=<Unicode> (BaseIPythonApplication.profile)
-Default: u'default'
-The IPython profile to use.
-.TP
-.B \-\-hwm=<Int> (TaskScheduler.hwm)
-Default: 0
-.br
-specify the High Water Mark (HWM) for the downstream socket in the Task
-scheduler. This is the maximum number of allowed outstanding tasks on each
-engine.
-.TP
-.B \-\-secure=<Bool> (IPControllerApp.secure)
-Default: True
-Whether to use HMAC digests for extra message authentication.
-.TP
-.B \-\-ip=<Unicode> (HubFactory.ip)
-Default: '127.0.0.1'
-The IP address for registration.  This is generally either '127.0.0.1' for
-loopback only or '*' for all interfaces. [default: '127.0.0.1']
-.TP
-.B \-\-log\-url=<Unicode> (BaseParallelApplication.log_url)
-Default: ''
-The ZMQ URL of the iplogger to aggregate logging.
-.TP
-.B \-\-work\-dir=<Unicode> (BaseParallelApplication.work_dir)
-Default: u'/Users/minrk/dev/ip/mine/docs/man'
-Set the working dir for the process.
-.TP
-.B \-\-port=<Int> (HubFactory.regport)
-Default: 0
-The port on which the Hub listens for registration.
-.TP
-.B \-\-profile\-dir=<Unicode> (ProfileDir.location)
-Default: u''
-Set the profile location directly. This overrides the logic used by the
-`profile` option.
-.TP
-.B \-\-ident=<CBytes> (Session.session)
-Default: ''
-The UUID identifying this session.
-.TP
-.B \-\-log\-to\-file=<Bool> (BaseParallelApplication.log_to_file)
-Default: False
-whether to log to a file
-.TP
-.B \-\-ipython\-dir=<Unicode> (BaseIPythonApplication.ipython_dir)
-Default: u'/Users/minrk/.ipython'
-The name of the IPython directory. This directory is used for logging
-configuration (through profiles), history storage, etc. The default is
-usually $HOME/.ipython. This options can also be specified through the
-environment variable IPYTHONDIR.
-.TP
-.B \-\-url=<Unicode> (HubFactory.url)
-Default: ''
-The 0MQ url used for registration. This sets transport, ip, and port in one
-variable. For example: url='tcp://127.0.0.1:12345' or url='epgm://*:90210'
-.TP
-.B \-\-user=<Unicode> (Session.username)
-Default: 'minrk'
-Username for the Session. Default is your system username.
-.TP
-.B \-\-ping=<CFloat> (HeartMonitor.period)
-Default: 1000
-The frequency at which the Hub pings the engines for heartbeats  (in ms)
-.TP
-.B \-\-log\-level=<Enum> (Application.log_level)
-Default: 30
-Choices: (0, 10, 20, 30, 40, 50, 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL')
-Set the log level by value or name.
-.TP
-.B \-\-location=<Unicode> (IPControllerApp.location)
-Default: u''
-The external IP or domain name of the Controller, used for disambiguating
-engine and client connections.
-.TP
-.B \-\-clean\-logs=<Bool> (BaseParallelApplication.clean_logs)
-Default: False
-whether to cleanup old logfiles before starting
-.TP
-.B \-\-scheme=<Enum> (TaskScheduler.scheme_name)
-Default: 'leastload'
-Choices: ('leastload', 'pure', 'lru', 'plainrandom', 'weighted', 'twobin')
-select the task scheduler scheme  [default: Python LRU] Options are: 'pure',
-\&'lru', 'plainrandom', 'weighted', 'twobin','leastload'
-.TP
-.B \-\-keyfile=<Unicode> (Session.keyfile)
-Default: ''
-path to file containing execution key.
-.TP
-.B \-\-transport=<Unicode> (HubFactory.transport)
-Default: 'tcp'
-The 0MQ transport for communications.  This will likely be the default of
-\&'tcp', but other values include 'ipc', 'epgm', 'inproc'.
-.TP
-.B \-\-ssh=<Unicode> (IPControllerApp.ssh_server)
-Default: u''
-ssh url for clients to use when connecting to the Controller processes. It
-should be of the form: [user@]server[:port]. The Controller's listening
-addresses must be accessible from the ssh server
-.SH SEE ALSO
+ipcontroller starts a controller for the IPython cluster
+
+For more information on how to use ipcontroller, see 'ipcontroller --help',
+or 'ipcontroller --help-all' for all available command-line options.
+
+.SH "SEE ALSO"
 .BR ipython(1),
-.BR ipcluster(1),
-.BR ipengine(1)
+.BR ipengine(1),
+.BR ipcluster(1)
 .br
-.SH AUTHOR
-\fBipcontroller\fP is a tool that ships with IPython, created by
-the IPython Development Team.
-.PP
-This manual page was written by Stephan Peijnik <debian@sp.or.at>,
-for the Debian project (but may be used by others).  Modified by Fernando Perez
-<Fernando.Perez@berkeley.edu> for inclusion in IPython, and updated by
-Min Ragan-Kelley <benjaminrk@gmail.com> for 0.11.
+.SH AUTHORS
+\fBipcontroller\fP ships with IPython, maintained by the IPython Development Team.

--- a/docs/man/ipengine.1
+++ b/docs/man/ipengine.1
@@ -1,42 +1,20 @@
-.TH IPENGINE 1 "July 15, 2011" "" ""
+.TH IPENGINE 1 "June 10, 2012" "" ""
 .SH NAME
-\fBipengine \- IPython parallel computing engine control tool
+\fBipengine \- IPython parallel computing engine
 .SH SYNOPSIS
-.nf
-.fam C
-\fBipengine\fP [\fIoptions\fP]
-.fam T
-.fi
+.B ipengine
+.RI [ options ]
+
 .SH DESCRIPTION
-ipengine is a control tool for IPython's parallel computing functions.
-.SH OPTIONS
-.TP
-.B
-\-h, \-\-help
-show this help message and exit
-.TP
-.B
-\-\-profile=name
-The name of the IPython configuration profile to use.
-.TP
-.B
-\-\-file=URL_FILE
-The JSON file containing the connection information of the controller.
-.TP
-.B
-\-\-mpi=MPI
-How to enable MPI (mpi4py, pytrilions, or empty string to disable)
-.TP
-.B
-\-l LOGFILE, \-\-logfile=LOGFILE
-log file name (defaults to stdout)
-.SH SEE ALSO
-.BR ipython(1), ipcluster(1), ipcontroller(1)
+ipengine starts an engine for the IPython cluster
+
+For more information on how to use ipengine, see 'ipengine --help',
+or 'ipengine --help-all' for all available command-line options.
+
+.SH "SEE ALSO"
+.BR ipython(1),
+.BR ipcontroller(1),
+.BR ipcluster(1)
 .br
-.SH AUTHOR
-\fBipengine\fP is a tool that ships with IPython, created by
-the IPython Development Team.
-.PP
-This manual page was written by Stephan Peijnik <debian@sp.or.at>,
-for the Debian project (but may be used by others).  Modified by Fernando Perez
-<Fernando.Perez@berkeley.edu> for inclusion in IPython.
+.SH AUTHORS
+\fBipengine\fP ships with IPython, maintained by the IPython Development Team.

--- a/docs/man/iplogger.1
+++ b/docs/man/iplogger.1
@@ -1,97 +1,24 @@
-.TH IPLOGGER 1 "July 21, 2011" "" ""
-.\" Man page generated from reStructeredText.
+.TH IPLOGGER 1 "June 10, 2012" "" ""
 .SH NAME
-\fBiplogger \- IPython logger for parallel computing.
+iplogger \- IPython logging utility for parallel computing.
+.SH SYNOPSIS
+.B iplogger
+.RI [ options ]
+
 .SH DESCRIPTION
-Start an IPython logger for parallel computing.
-.sp
+Start an IPython log aggregator.
+
 IPython controllers and engines (and your own processes) can broadcast log
-messages by registering a \fIzmq.log.handlers.PUBHandler\fP with the \fIlogging\fP
-module. The logger can be configured using command line options or using a
-cluster directory. Cluster directories contain config, log and security files
-and are usually located in your ipython directory and named as "profile_name".
-See the \fIprofile\fP and \fIprofile\-dir\fP options for details.
-.SH OPTIONS
-.sp
-IPython command\-line arguments are passed as \(aq\-\-<flag>\(aq, or \(aq\-\-<name>=<value>\(aq.
-.sp
-Arguments that take values are actually convenience aliases to full
-Configurables, whose aliases are listed on the help line. For more information
-on full configurables, see \(aq\-\-help\-all\(aq.
-.TP
-.B \-\-debug
-.
-set log level to logging.DEBUG (maximize logging output)
-.TP
-.B \-\-init
-.
-Initialize profile with default config files. This is equivalent
-to running \fIipython profile create <profile>\fP prior to startup.
-.TP
-.B \-\-log\-to\-file
-.
-send log output to a file
-.TP
-.B \-\-quiet
-.
-set log level to logging.CRITICAL (minimize logging output)
-.TP
-.B \-\-profile=<Unicode> (BaseIPythonApplication.profile)
-.
-Default: u\(aqdefault\(aq
-The IPython profile to use.
-.TP
-.B \-\-log\-to\-file=<Bool> (BaseParallelApplication.log_to_file)
-.
-Default: False
-whether to log to a file
-.TP
-.B \-\-ipython\-dir=<Unicode> (BaseIPythonApplication.ipython_dir)
-.
-The name of the IPython directory. This directory is used for logging
-configuration (through profiles), history storage, etc. The default is
-usually $XDG_CONFIG_HOME/ipython. This options can also be specified
-through the environment variable IPYTHONDIR.
-.TP
-.B \-\-url=<Unicode> (LogWatcher.url)
-.
-Default: \(aq\fI\%tcp://127.0.0.1:20202\fP\(aq
-ZMQ url on which to listen for log messages
-.TP
-.B \-\-topics=<List> (LogWatcher.topics)
-.
-Default: [\(aq\(aq]
-The ZMQ topics to subscribe to. Default is to subscribe to all messages
-.TP
-.B \-\-log\-level=<Enum> (Application.log_level)
-.
-Default: 30
-Choices: (0, 10, 20, 30, 40, 50, \(aqDEBUG\(aq, \(aqINFO\(aq, \(aqWARN\(aq, \(aqERROR\(aq, \(aqCRITICAL\(aq)
-Set the log level by value or name.
-.TP
-.B \-\-log\-url=<Unicode> (BaseParallelApplication.log_url)
-.
-Default: \(aq\(aq
-The ZMQ URL of the iplogger to aggregate logging.
-.TP
-.B \-\-clean\-logs=<Bool> (BaseParallelApplication.clean_logs)
-.
-Default: False
-whether to cleanup old logfiles before starting
-.TP
-.B \-\-profile\-dir=<Unicode> (ProfileDir.location)
-.
-Default: u\(aq\(aq
-Set the profile location directly. This overrides the logic used by the
-\fIprofile\fP option.
-.TP
-.B \-\-work\-dir=<Unicode> (BaseParallelApplication.work_dir)
-.
-Set the working dir for the process.
-.SH SEE ALSO
+messages over zeromq to a single logger instance.
+
+For more information on how to use iplogger, see 'iplogger --help',
+or 'iplogger --help-all' for all available command-line options.
+
+.SH "SEE ALSO"
 .BR ipython(1),
 .BR ipcontroller(1),
-.BR ipengine(1)
+.BR ipengine(1),
+.BR ipcluster(1)
 .br
 .SH AUTHOR
 \fBiplogger\fP is a tool that ships with IPython, created by

--- a/docs/man/ipython.1
+++ b/docs/man/ipython.1
@@ -26,216 +26,36 @@ ipython \- Tools for Interactive Computing in Python.
 .SH SYNOPSIS
 .B ipython
 .RI [ options ] " files" ...
+
+.B ipython subcommand
+.RI [ options ] ...
+
 .SH DESCRIPTION
 An interactive Python shell with automatic history (input and output), dynamic
 object introspection, easier configuration, command completion, access to the
-system shell, integration with numerical and scientific computing tools, and
-more.
-.
-.SH REGULAR OPTIONS
-All options that take values, must be of the form '\-\-name=value', but
-flags that take no arguments are allowed a single '\-' to allow common
-patterns like: 'ipython \-i myscript.py'.  To pass arguments to scripts,
-rather than to IPython, specify them after '\-\-'.
-.br
-.sp 1
-All options can also be set from your ipython_config.py configuration file.
-See the provided examples for assistance.  Options given on the
-commandline override the values set in ipython_config.py.  To generate
-the default config file, do `ipython profile create`.
-.br
-.sp 1
-All options with a [no] prepended can be specified in negated form
-(\-\-no\-option instead of \-\-option) to turn the feature off.
-.TP
-.B \-h, \-\-help
-Show summary of options.
-.B \-\-no\-autoindent
-Turn off autoindenting.
-.TP
-.B \-\-autoedit\-syntax
-Turn on auto editing of files with syntax errors.
-.TP
-.B \-\-pylab
-Pre-load matplotlib and numpy for interactive use with
-the default matplotlib backend.
-.TP
-.B \-\-confirm\-exit
-Set to confirm when you try to exit IPython with an EOF (Control-D
-in Unix, Control-Z/Enter in Windows). By typing 'exit' or 'quit',
-you can force a direct exit without any confirmation.
-.TP
-.B \-\-deep\-reload
-Enable deep (recursive) reloading by default. IPython can use the
-deep_reload module which reloads changes in modules recursively (it
-replaces the reload() function, so you don't need to change anything to
-use it). deep_reload() forces a full reload of modules whose code may
-have changed, which the default reload() function does not.  When
-deep_reload is off, IPython will use the normal reload(), but
-deep_reload will still be available as dreload(). This feature is off
-by default [which means that you have both normal reload() and
-dreload()].
-.TP
-.B \-\-no\-autoedit\-syntax
-Turn off auto editing of files with syntax errors.
-.TP
-.B \-\-term\-title
-Enable auto setting the terminal title.
-.TP
-.B \-\-no\-confirm\-exit
-Don't prompt the user when exiting.
-.TP
-.B \-\-autoindent
-Turn on autoindenting.
-.TP
-.B \-\-classic
-Gives IPython a similar feel to the classic Python prompt.
-.TP
-.B \-\-no\-automagic
-Turn off the auto calling of magic commands.
-.TP
-.B \-\-banner
-Display a banner upon starting IPython.
-.TP
-.B \-\-automagic
-Turn on the auto calling of magic commands. Type %%magic at the
-IPython  prompt  for  more information.
-.TP
-.B \-\-no\-deep\-reload
-Disable deep (recursive) reloading by default.
-.TP
-.B \-\-no\-term\-title
-Disable auto setting the terminal title.
-.TP
-.B \-\-nosep
-Eliminate all spacing between prompts.
-.TP
-.B \-\-i
-also works as '\-i'
-If running code from the command line, become interactive afterwards.
-.TP
-.B \-\-debug
-set log level to logging.DEBUG (maximize logging output)
-.TP
-.B \-\-pprint
-Enable auto pretty printing of results.
-.TP
-.B \-\-quiet
-set log level to logging.CRITICAL (minimize logging output)
-.TP
-.B \-\-pdb
-Enable auto calling the pdb debugger after every exception.
-.TP
-.B \-\-color\-info
-IPython can display information about objects via a set of func-
-tions, and optionally can use colors for this, syntax highlighting
-source code and various other elements.  However, because this
-information is passed through a pager (like 'less') and many pagers get
-confused with color codes, this option is off by default.  You can test
-it and turn it on permanently in your ipython_config.py file if it
-works for you.  Test it and turn it on permanently if it works with
-your system.  The magic function %%color_info allows you to toggle this
-interactively for testing.
-.TP
-.B \-\-init
-Initialize profile with default config files
-.TP
-.B \-\-no\-pdb
-Disable auto calling the pdb debugger after every exception.
-.TP
-.B \-\-quick
-Enable quick startup with no config files.
-.TP
-.B \-\-no\-color\-info
-Disable using colors for info related things.
-.TP
-.B \-\-no\-pprint
-Disable auto auto pretty printing of results.
-.TP
-.B \-\-no\-banner
-Don't display a banner upon starting IPython.
-.TP
-.B \-\-profile=<Unicode> (BaseIPythonApplication.profile)
-Default: u'default'
-The IPython profile to use.
-.TP
-.B \-\-c=<Unicode> (InteractiveShellApp.code_to_run)
-Default: ''
-Execute the given command string.
-.TP
-.B \-\-logappend=<Unicode> (InteractiveShell.logappend)
-Default: ''
-Start logging to the given file in append mode.
-.TP
-.B \-\-autocall=<Enum> (InteractiveShell.autocall)
-Default: 1
-Choices: (0, 1, 2)
-Make IPython automatically call any callable object even if you didn't type
-explicit parentheses. For example, 'str 43' becomes 'str(43)' automatically.
-The value can be '0' to disable the feature, '1' for 'smart' autocall, where
-it is not applied if there are no more arguments on the line, and '2' for
-\&'full' autocall, where all callable objects are automatically called (even
-if no arguments are present). The default is '1'.
-.TP
-.B \-\-ipython\-dir=<Unicode> (BaseIPythonApplication.ipython_dir)
-Default: u'/Users/minrk/.ipython'
-The name of the IPython directory. This directory is used for logging
-configuration (through profiles), history storage, etc. The default is
-usually $HOME/.ipython. This options can also be specified through the
-environment variable IPYTHONDIR.
-.TP
-.B \-\-gui=<CaselessStrEnum> (TerminalIPythonApp.gui)
-Default: None
-Choices: ('qt', 'wx', 'gtk')
-Enable GUI event loop integration ('qt', 'wx', 'gtk').
-.TP
-.B \-\-pylab=<CaselessStrEnum> (TerminalIPythonApp.pylab)
-Default: None
-Choices: ['tk', 'qt', 'wx', 'gtk', 'osx', 'auto']
-Pre-load matplotlib and numpy for interactive use, selecting a particular
-matplotlib backend and loop integration.
-.TP
-.B \-\-ext=<Unicode> (InteractiveShellApp.extra_extension)
-Default: ''
-dotted module name of an IPython extension to load.
-.TP
-.B \-\-log\-level=<Enum> (Application.log_level)
-Default: 30
-Choices: (0, 10, 20, 30, 40, 50, 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL')
-Set the log level by value or name.
-.TP
-.B \-\-colors=<CaselessStrEnum> (InteractiveShell.colors)
-Default: 'LightBG'
-Choices: ('NoColor', 'LightBG', 'Linux')
-Set the color scheme (NoColor, Linux, or LightBG).
-.TP
-.B \-\-cache\-size=<Int> (InteractiveShell.cache_size)
-Default: 1000
-Set the size of the output cache.  The default is 1000, you can change it
-permanently in your config file.  Setting it to 0 completely disables the
-caching system, and the minimum value accepted is 20 (if you provide a value
-less than 20, it is reset to 0 and a warning is issued).  This limit is
-defined because otherwise you'll spend more time re-flushing a too small
-cache than working
-.TP
-.B \-\-logfile=<Unicode> (InteractiveShell.logfile)
-Default: ''
-The name of the logfile to use.
-.
-.SH EMBEDDING
-It is possible to start an IPython instance inside your own Python
-programs.  In the documentation example files there are some
-illustrations on how to do this.
-.br
-.sp 1
-This feature allows you to evalutate dynamically the state of your
-code, operate with your variables, analyze them, etc.  Note however
-that any changes you make to values while in the shell do NOT
-propagate back to the running code, so it is safe to modify your
-values because you won't break your code in bizarre ways by doing so.
-.SH AUTHOR
-IPython was written by Fernando Perez <fperez@colorado.edu>, based on earlier
-code by Janko Hauser <jh@comunit.de> and Nathaniel Gray
-<n8gray@caltech.edu>.  This manual page was written by Jack Moffitt
-<jack@xiph.org>, for the Debian project (but may be used by others), and updated by
-Min Ragan-Kelley <benjaminrk@gmail.com> for 0.11.
+system shell, integration with numerical and scientific computing tools,
+web notebook, Qt console, and more.
+
+For more information on how to use IPython, see 'ipython --help',
+or 'ipython --help-all' for all available command-line options.
+
+.SH "ENVIRONMENT VARIABLES"
+.sp
+.PP
+\fIIPYTHONDIR\fR
+.RS 4
+This is the location where IPython stores all its configuration files.  The default
+on most platforms is $HOME/.ipython, but on Linux IPython respects the XDG config
+specification, which will put IPYTHONDIR in $HOME/.config/ipython by default.
+
+You can see the computed value of IPYTHONDIR with `ipython locate`.
+
+.SH FILES
+
+IPython uses various configuration files stored in profiles within IPYTHONDIR.
+To generate the default configuration files and start configuring IPython,
+do 'ipython profile create', and edit '*_config.py' files located in
+IPYTHONDIR/profile_default.
+
+.SH AUTHORS
+IPython is written by the IPython Development Team <https://github.com/ipython/ipython>.


### PR DESCRIPTION
leaves ENVIRONMENT_VARIABLES and FILES sections on the main ipython manpage, per recommendation of @juliantaylor, but points to `<prog>--help` for the rest.

I didn't touch the manpages for irunner or pycolor because we haven't touched those entrypoints in a long time.

closes #1618
