### PR TITLE
Cython libs

### DIFF
--- a/IPython/extensions/cythonmagic.py
+++ b/IPython/extensions/cythonmagic.py
@@ -107,6 +107,18 @@ class CythonMagics(Magics):
 
     @magic_arguments()
     @argument(
+        '-c', '--compile-args', action='append', default=[],
+        help="Extra flag to pass to compiler via the `extra_compile_args` Extension flag (can be called  multiple times)."
+    )
+    @argument(
+        '-l', '--lib', action='append', default=[],
+        help="Add a library to link the extension against (can be called  multiple times)."
+    )
+    @argument(
+        '-i', '--include', action='append', default=[],
+        help="Add a path to the list of include directories (can be called  multiple times)."
+    )
+    @argument(
         '-f', '--force', action='store_true', default=False,
         help="Force the compilation of the pyx module even if it hasn't changed"
     )
@@ -127,10 +139,10 @@ class CythonMagics(Magics):
         """
         args = parse_argstring(self.cython, line)
         code = cell if cell.endswith('\n') else cell+'\n'
-        lib_dir=os.path.join(self.shell.ipython_dir, 'cython')
-        cython_include_dirs=['.']
-        force=args.force
-        quiet=True
+        lib_dir = os.path.join(self.shell.ipython_dir, 'cython')
+        cython_include_dirs = ['.']
+        force = args.force
+        quiet = True
         ctx = Context(cython_include_dirs, default_options)
         key = code, sys.version_info, sys.executable, Cython.__version__
         module_name = "_cython_magic_" + hashlib.md5(str(key).encode('utf-8')).hexdigest()
@@ -141,8 +153,7 @@ class CythonMagics(Magics):
             os.makedirs(lib_dir)
 
         if force or not os.path.isfile(module_path):
-            cflags = []
-            c_include_dirs = []
+            c_include_dirs = args.include
             if 'numpy' in code:
                 import numpy
                 c_include_dirs.append(numpy.get_include())
@@ -154,7 +165,8 @@ class CythonMagics(Magics):
                 name = module_name,
                 sources = [pyx_file],
                 include_dirs = c_include_dirs,
-                extra_compile_args = cflags
+                extra_compile_args = args.compile_args,
+                libraries = args.lib,
             )
             dist = Distribution()
             config_files = dist.find_config_files()

--- a/IPython/extensions/cythonmagic.py
+++ b/IPython/extensions/cythonmagic.py
@@ -108,15 +108,15 @@ class CythonMagics(Magics):
     @magic_arguments()
     @argument(
         '-c', '--compile-args', action='append', default=[],
-        help="Extra flag to pass to compiler via the `extra_compile_args` Extension flag (can be called  multiple times)."
+        help="Extra flags to pass to compiler via the `extra_compile_args` Extension flag (can be specified  multiple times)."
     )
     @argument(
         '-l', '--lib', action='append', default=[],
-        help="Add a library to link the extension against (can be called  multiple times)."
+        help="Add a library to link the extension against (can be specified  multiple times)."
     )
     @argument(
         '-I', '--include', action='append', default=[],
-        help="Add a path to the list of include directories (can be called  multiple times)."
+        help="Add a path to the list of include directories (can be specified  multiple times)."
     )
     @argument(
         '-f', '--force', action='store_true', default=False,

--- a/IPython/extensions/cythonmagic.py
+++ b/IPython/extensions/cythonmagic.py
@@ -115,7 +115,7 @@ class CythonMagics(Magics):
         help="Add a library to link the extension against (can be called  multiple times)."
     )
     @argument(
-        '-i', '--include', action='append', default=[],
+        '-I', '--include', action='append', default=[],
         help="Add a path to the list of include directories (can be called  multiple times)."
     )
     @argument(

--- a/IPython/extensions/tests/test_cythonmagic.py
+++ b/IPython/extensions/tests/test_cythonmagic.py
@@ -4,6 +4,7 @@
 import os
 import nose.tools as nt
 
+from IPython.testing import decorators as dec
 from IPython.utils import py3compat
 
 code = py3compat.str_to_unicode("""def f(x):
@@ -43,8 +44,9 @@ def test_cython():
     ip.run_cell_magic('cython', '', code)
     ip.ex('g = f(10)')
     nt.assert_equals(ip.user_ns['g'], 20.0)
-    
 
+
+@dec.skip_win32
 def test_extlibs():
     code = py3compat.str_to_unicode("""
 from libc.math cimport sin

--- a/IPython/extensions/tests/test_cythonmagic.py
+++ b/IPython/extensions/tests/test_cythonmagic.py
@@ -15,19 +15,21 @@ try:
 except:
     __test__ = False
 
+ip = get_ipython()
+
+
 def setup():
-    ip = get_ipython()
     ip.extension_manager.load_extension('cythonmagic')
 
+
 def test_cython_inline():
-    ip = get_ipython()
     ip.ex('a=10; b=20')
     result = ip.run_cell_magic('cython_inline','','return a+b')
     nt.assert_equals(result, 30)
 
+
 def test_cython_pyximport():
     module_name = '_test_cython_pyximport'
-    ip = get_ipython()
     ip.run_cell_magic('cython_pyximport', module_name, code)
     ip.ex('g = f(10)')
     nt.assert_equals(ip.user_ns['g'], 20.0)
@@ -36,12 +38,19 @@ def test_cython_pyximport():
     except OSError:
         pass
 
+
 def test_cython():
-    ip = get_ipython()
     ip.run_cell_magic('cython', '', code)
     ip.ex('g = f(10)')
     nt.assert_equals(ip.user_ns['g'], 20.0)
     
 
-
-
+def test_extlibs():
+    code = py3compat.str_to_unicode("""
+from libc.math cimport sin
+x = sin(0.0)
+    """)
+    ip.user_ns['x'] = 1
+    ip.run_cell_magic('cython', '-l m', code)
+    nt.assert_equals(ip.user_ns['x'], 0)
+    

--- a/docs/examples/notebooks/cython_extension.ipynb
+++ b/docs/examples/notebooks/cython_extension.ipynb
@@ -205,13 +205,13 @@
     {
      "cell_type": "markdown",
      "source": [
-      "Cython allows you to specify additional libraries to be linked with your extension, you can do so with the `-l` flag (also spelled `--lib`).  Note that this flag can be passed more than once to specify multiple libraries, such as `-l lib1 -l lib2`.  Here's a simple example of how to access the system math library:"
+      "Cython allows you to specify additional libraries to be linked with your extension, you can do so with the `-l` flag (also spelled `--lib`).  Note that this flag can be passed more than once to specify multiple libraries, such as `-lm -llib2 --lib lib3`.  Here's a simple example of how to access the system math library:"
      ]
     },
     {
      "cell_type": "code",
      "input": [
-      "%%cython -l m\n",
+      "%%cython -lm\n",
       "from libc.math cimport sin\n",
       "print 'sin(1)=', sin(1)"
      ],
@@ -230,7 +230,7 @@
     {
      "cell_type": "markdown",
      "source": [
-      "You can similarly use the `-i/--include` flag to add include directories to the search path, and `-c/--compile-args` to add extra flags that are passed to Cython via the `extra_compile_args` of the distutils `Extension` class.  Please see [the Cython docs on C library usage](http://docs.cython.org/src/tutorial/clibraries.html) for more details on the use of these flags."
+      "You can similarly use the `-I/--include` flag to add include directories to the search path, and `-c/--compile-args` to add extra flags that are passed to Cython via the `extra_compile_args` of the distutils `Extension` class.  Please see [the Cython docs on C library usage](http://docs.cython.org/src/tutorial/clibraries.html) for more details on the use of these flags."
      ]
     }
    ]

--- a/docs/examples/notebooks/cython_extension.ipynb
+++ b/docs/examples/notebooks/cython_extension.ipynb
@@ -28,7 +28,6 @@
     },
     {
      "cell_type": "code",
-     "collapsed": false,
      "input": [
       "%load_ext cythonmagic"
      ],
@@ -51,9 +50,8 @@
     },
     {
      "cell_type": "code",
-     "collapsed": true,
      "input": [
-      "a = 10",
+      "a = 10\n",
       "b = 20"
      ],
      "language": "python",
@@ -62,9 +60,8 @@
     },
     {
      "cell_type": "code",
-     "collapsed": false,
      "input": [
-      "%%cython_inline",
+      "%%cython_inline\n",
       "return a+b"
      ],
      "language": "python",
@@ -94,10 +91,9 @@
     },
     {
      "cell_type": "code",
-     "collapsed": false,
      "input": [
-      "%%cython_pyximport foo",
-      "def f(x):",
+      "%%cython_pyximport foo\n",
+      "def f(x):\n",
       "    return 4.0*x"
      ],
      "language": "python",
@@ -106,7 +102,6 @@
     },
     {
      "cell_type": "code",
-     "collapsed": false,
      "input": [
       "f(10)"
      ],
@@ -132,42 +127,41 @@
     {
      "cell_type": "markdown",
      "source": [
-      "Probably the most important magic is the `%cython` magic.  This is similar to the `%%cython_pyximport` magic, but doesn't require you to specify a module name. Instead, the `%%cython` magic uses manages everything using temporary files in the `~/.cython/magic` directory.  All of the symbols in the Cython module are imported automatically by the magic.",
-      "",
+      "Probably the most important magic is the `%cython` magic.  This is similar to the `%%cython_pyximport` magic, but doesn't require you to specify a module name. Instead, the `%%cython` magic uses manages everything using temporary files in the `~/.cython/magic` directory.  All of the symbols in the Cython module are imported automatically by the magic.\n",
+      "\n",
       "Here is a simple example of a Black-Scholes options pricing algorithm written in Cython:"
      ]
     },
     {
      "cell_type": "code",
-     "collapsed": false,
      "input": [
-      "%%cython",
-      "cimport cython",
-      "from libc.math cimport exp, sqrt, pow, log, erf",
-      "",
-      "@cython.cdivision(True)",
-      "cdef double std_norm_cdf(double x) nogil:",
-      "    return 0.5*(1+erf(x/sqrt(2.0)))",
-      "",
-      "@cython.cdivision(True)",
-      "def black_scholes(double s, double k, double t, double v,",
-      "                 double rf, double div, double cp):",
-      "    \"\"\"Price an option using the Black-Scholes model.",
-      "    ",
-      "    s : initial stock price",
-      "    k : strike price",
-      "    t : expiration time",
-      "    v : volatility",
-      "    rf : risk-free rate",
-      "    div : dividend",
-      "    cp : +1/-1 for call/put",
-      "    \"\"\"",
-      "    cdef double d1, d2, optprice",
-      "    with nogil:",
-      "        d1 = (log(s/k)+(rf-div+0.5*pow(v,2))*t)/(v*sqrt(t))",
-      "        d2 = d1 - v*sqrt(t)",
-      "        optprice = cp*s*exp(-div*t)*std_norm_cdf(cp*d1) - \\",
-      "            cp*k*exp(-rf*t)*std_norm_cdf(cp*d2)",
+      "%%cython\n",
+      "cimport cython\n",
+      "from libc.math cimport exp, sqrt, pow, log, erf\n",
+      "\n",
+      "@cython.cdivision(True)\n",
+      "cdef double std_norm_cdf(double x) nogil:\n",
+      "    return 0.5*(1+erf(x/sqrt(2.0)))\n",
+      "\n",
+      "@cython.cdivision(True)\n",
+      "def black_scholes(double s, double k, double t, double v,\n",
+      "                 double rf, double div, double cp):\n",
+      "    \"\"\"Price an option using the Black-Scholes model.\n",
+      "    \n",
+      "    s : initial stock price\n",
+      "    k : strike price\n",
+      "    t : expiration time\n",
+      "    v : volatility\n",
+      "    rf : risk-free rate\n",
+      "    div : dividend\n",
+      "    cp : +1/-1 for call/put\n",
+      "    \"\"\"\n",
+      "    cdef double d1, d2, optprice\n",
+      "    with nogil:\n",
+      "        d1 = (log(s/k)+(rf-div+0.5*pow(v,2))*t)/(v*sqrt(t))\n",
+      "        d2 = d1 - v*sqrt(t)\n",
+      "        optprice = cp*s*exp(-div*t)*std_norm_cdf(cp*d1) - \\\n",
+      "            cp*k*exp(-rf*t)*std_norm_cdf(cp*d2)\n",
       "    return optprice"
      ],
      "language": "python",
@@ -176,7 +170,6 @@
     },
     {
      "cell_type": "code",
-     "collapsed": false,
      "input": [
       "black_scholes(100.0, 100.0, 1.0, 0.3, 0.03, 0.0, -1)"
      ],
@@ -194,7 +187,6 @@
     },
     {
      "cell_type": "code",
-     "collapsed": false,
      "input": [
       "%timeit black_scholes(100.0, 100.0, 1.0, 0.3, 0.03, 0.0, -1)"
      ],
@@ -204,21 +196,42 @@
        "output_type": "stream",
        "stream": "stdout",
        "text": [
-        "1000000 loops, best of 3: 621 ns per loop",
-        ""
+        "1000000 loops, best of 3: 621 ns per loop\n"
        ]
       }
      ],
      "prompt_number": 14
     },
     {
+     "cell_type": "markdown",
+     "source": [
+      "Cython allows you to specify additional libraries to be linked with your extension, you can do so with the `-l` flag (also spelled `--lib`).  Note that this flag can be passed more than once to specify multiple libraries, such as `-l lib1 -l lib2`.  Here's a simple example of how to access the system math library:"
+     ]
+    },
+    {
      "cell_type": "code",
-     "collapsed": true,
      "input": [
-      ""
+      "%%cython -l m\n",
+      "from libc.math cimport sin\n",
+      "print 'sin(1)=', sin(1)"
      ],
      "language": "python",
-     "outputs": []
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "sin(1)= 0.841470984808\n"
+       ]
+      }
+     ],
+     "prompt_number": 2
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "You can similarly use the `-i/--include` flag to add include directories to the search path, and `-c/--compile-args` to add extra flags that are passed to Cython via the `extra_compile_args` of the distutils `Extension` class.  Please see [the Cython docs on C library usage](http://docs.cython.org/src/tutorial/clibraries.html) for more details on the use of these flags."
+     ]
     }
    ]
   }


### PR DESCRIPTION
Add support for specifying external library linking as well as compiler parameters and include directories.

I don't know how to portably test include paths and compiler flags, but at least I did add a test that should be fairly robust with the math library.
