### PR TITLE
ofind finds non-unique cell magics

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -79,7 +79,7 @@ import sys
 
 from IPython.config.configurable import Configurable
 from IPython.core.error import TryNext
-from IPython.core.prefilter import ESC_MAGIC
+from IPython.core.inputsplitter import ESC_MAGIC
 from IPython.utils import generics
 from IPython.utils import io
 from IPython.utils.dir2 import dir2

--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -91,6 +91,7 @@ ESC_SH_CAP = '!!'    # Send line to system shell and capture output
 ESC_HELP   = '?'     # Find information about object
 ESC_HELP2  = '??'    # Find extra-detailed information about object
 ESC_MAGIC  = '%'     # Call magic function
+ESC_MAGIC2 = '%%'    # Call cell-magic function
 ESC_QUOTE  = ','     # Split args on whitespace, quote each as string and call
 ESC_QUOTE2 = ';'     # Quote all args as a single string, call
 ESC_PAREN  = '/'     # Call first argument with rest of line as arguments

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -56,12 +56,12 @@ from IPython.core.extensions import ExtensionManager
 from IPython.core.fakemodule import FakeModule, init_fakemod_dict
 from IPython.core.formatters import DisplayFormatter
 from IPython.core.history import HistoryManager
-from IPython.core.inputsplitter import IPythonInputSplitter
+from IPython.core.inputsplitter import IPythonInputSplitter, ESC_MAGIC, ESC_MAGIC2
 from IPython.core.logger import Logger
 from IPython.core.macro import Macro
 from IPython.core.payload import PayloadManager
 from IPython.core.plugin import PluginManager
-from IPython.core.prefilter import PrefilterManager, ESC_MAGIC, ESC_CELL_MAGIC
+from IPython.core.prefilter import PrefilterManager
 from IPython.core.profiledir import ProfileDir
 from IPython.core.pylabtools import pylab_activate
 from IPython.core.prompts import PromptManager
@@ -1349,7 +1349,7 @@ class InteractiveShell(SingletonConfigurable):
         oname = oname.strip()
         #print '1- oname: <%r>' % oname  # dbg
         if not oname.startswith(ESC_MAGIC) and \
-            not oname.startswith(ESC_CELL_MAGIC) and \
+            not oname.startswith(ESC_MAGIC2) and \
             not py3compat.isidentifier(oname, dotted=True):
             return dict(found=False)
 
@@ -1409,8 +1409,8 @@ class InteractiveShell(SingletonConfigurable):
         # Try to see if it's magic
         if not found:
             obj = None
-            if oname.startswith(ESC_CELL_MAGIC):
-                oname = oname.lstrip(ESC_CELL_MAGIC)
+            if oname.startswith(ESC_MAGIC2):
+                oname = oname.lstrip(ESC_MAGIC2)
                 obj = self.find_cell_magic(oname)
             elif oname.startswith(ESC_MAGIC):
                 oname = oname.lstrip(ESC_MAGIC)

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -25,7 +25,7 @@ from getopt import getopt, GetoptError
 from IPython.config.configurable import Configurable
 from IPython.core import oinspect
 from IPython.core.error import UsageError
-from IPython.core.prefilter import ESC_MAGIC
+from IPython.core.inputsplitter import ESC_MAGIC
 from IPython.external.decorator import decorator
 from IPython.utils.ipstruct import Struct
 from IPython.utils.process import arg_split

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -20,8 +20,8 @@ from pprint import pformat
 
 # Our own packages
 from IPython.core.error import UsageError
+from IPython.core.inputsplitter import ESC_MAGIC
 from IPython.core.magic import Magics, magics_class, line_magic
-from IPython.core.prefilter import ESC_MAGIC
 from IPython.utils.text import format_screen
 from IPython.core import magic_arguments, page
 from IPython.testing.skipdoctest import skip_doctest

--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -50,6 +50,7 @@ ESC_SHELL  = '!'
 ESC_SH_CAP = '!!'
 ESC_HELP   = '?'
 ESC_MAGIC  = '%'
+ESC_CELL_MAGIC = ESC_MAGIC * 2
 ESC_QUOTE  = ','
 ESC_QUOTE2 = ';'
 ESC_PAREN  = '/'

--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -31,6 +31,16 @@ import re
 from IPython.core.alias import AliasManager
 from IPython.core.autocall import IPyAutocall
 from IPython.config.configurable import Configurable
+from IPython.core.inputsplitter import (
+    ESC_SHELL,
+    ESC_SH_CAP,
+    ESC_HELP,
+    ESC_MAGIC,
+    ESC_MAGIC2,
+    ESC_QUOTE,
+    ESC_QUOTE2,
+    ESC_PAREN,
+)
 from IPython.core.macro import Macro
 from IPython.core.splitinput import split_user_input, LineInfo
 from IPython.core import page
@@ -43,17 +53,6 @@ from IPython.utils.autoattr import auto_attr
 #-----------------------------------------------------------------------------
 # Global utilities, errors and constants
 #-----------------------------------------------------------------------------
-
-# Warning, these cannot be changed unless various regular expressions
-# are updated in a number of places.  Not great, but at least we told you.
-ESC_SHELL  = '!'
-ESC_SH_CAP = '!!'
-ESC_HELP   = '?'
-ESC_MAGIC  = '%'
-ESC_CELL_MAGIC = ESC_MAGIC * 2
-ESC_QUOTE  = ','
-ESC_QUOTE2 = ';'
-ESC_PAREN  = '/'
 
 
 class PrefilterError(Exception):

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -662,3 +662,35 @@ def test_script_defaults():
             pass
         else:
             nt.assert_in(cmd, ip.magics_manager.magics['cell'])
+
+
+@magics_class
+class FooFoo(Magics):
+    """class with both %foo and %%foo magics"""
+    @line_magic('foo')
+    def line_foo(self, line):
+        "I am line foo"
+        pass
+            
+    @cell_magic("foo")
+    def cell_foo(self, line, cell):
+        "I am cell foo, not line foo"
+        pass
+
+def test_line_cell_info():
+    """%%foo and %foo magics are distinguishable to inspect"""
+    ip = get_ipython()
+    ip.magics_manager.register(FooFoo)
+    oinfo = ip.object_inspect('foo')
+    nt.assert_true(oinfo['found'])
+    nt.assert_true(oinfo['ismagic'])
+    
+    oinfo = ip.object_inspect('%%foo')
+    nt.assert_true(oinfo['found'])
+    nt.assert_true(oinfo['ismagic'])
+    nt.assert_equals(oinfo['docstring'], FooFoo.cell_foo.__doc__)
+
+    oinfo = ip.object_inspect('%foo')
+    nt.assert_true(oinfo['found'])
+    nt.assert_true(oinfo['ismagic'])
+    nt.assert_equals(oinfo['docstring'], FooFoo.line_foo.__doc__)


### PR DESCRIPTION
Fixes logic in `Shell._ofind` to differentiate cell magics from line magics

defines ESC_CELL_MAGIC in prefilter, rather than making the assumption that ESC_CELL_MAGIC == ESC_MAGIC \* 2, but I don't have to do that.

also changes preemptive not-found to not fire in case of magics, as it has been pointed out elsewhere that magic names need only not contain spaces, they need not be valid identifiers.

closes #1904
