### PR TITLE
py3compat fixes for %%script and tests

### DIFF
--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -185,7 +185,8 @@ class ScriptMagics(Magics, Configurable):
         args, cmd = self.shebang.parser.parse_known_args(argv)
 
         p = Popen(cmd, stdout=PIPE, stderr=PIPE, stdin=PIPE)
-
+        
+        cell = cell.encode('utf8', 'replace')
         if args.bg:
             if args.out:
                 self.shell.user_ns[args.out] = p.stdout

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -638,20 +638,20 @@ def test_script_out_err():
 def test_script_bg_out():
     ip = get_ipython()
     ip.run_cell_magic("script", "--bg --out output sh", "echo 'hi'")
-    nt.assert_equals(ip.user_ns['output'].read(), 'hi\n')
+    nt.assert_equals(ip.user_ns['output'].read(), b'hi\n')
 
 @dec.skip_win32
 def test_script_bg_err():
     ip = get_ipython()
     ip.run_cell_magic("script", "--bg --err error sh", "echo 'hello' >&2")
-    nt.assert_equals(ip.user_ns['error'].read(), 'hello\n')
+    nt.assert_equals(ip.user_ns['error'].read(), b'hello\n')
 
 @dec.skip_win32
 def test_script_bg_out_err():
     ip = get_ipython()
     ip.run_cell_magic("script", "--bg --out output --err error sh", "echo 'hi'\necho 'hello' >&2")
-    nt.assert_equals(ip.user_ns['output'].read(), 'hi\n')
-    nt.assert_equals(ip.user_ns['error'].read(), 'hello\n')
+    nt.assert_equals(ip.user_ns['output'].read(), b'hi\n')
+    nt.assert_equals(ip.user_ns['error'].read(), b'hello\n')
 
 def test_script_defaults():
     ip = get_ipython()


### PR DESCRIPTION
fixes hang in test_pr, caused by error raised in background thread (%%script --bg), and main thread waiting on the close of an FD that would never close due to the error.
