### PR TITLE
Implement noninvoking attribute get for pinfo

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -28,6 +28,7 @@ import runpy
 import sys
 import tempfile
 import types
+import inspect
 
 # We need to use nested to support python 2.6, once we move to >=2.7, we can
 # use the with keyword's new builtin support for nested managers
@@ -1379,15 +1380,16 @@ class InteractiveShell(SingletonConfigurable):
         # found, then we look for all the remaining parts as members, and only
         # declare success if we can find them all.
         oname_parts = oname.split('.')
-        oname_head, oname_rest = oname_parts[0],oname_parts[1:]
+        oname_head, oname_middle, oname_last = oname_parts[0],oname_parts[1:-1],\
+                                               oname_parts[-1]
         for nsname,ns in namespaces:
             try:
                 obj = ns[oname_head]
             except KeyError:
                 continue
             else:
-                #print 'oname_rest:', oname_rest  # dbg
-                for part in oname_rest:
+                #print 'oname_middle:', oname_middle  # dbg
+                for part in oname_middle:
                     try:
                         parent = obj
                         obj = getattr(obj,part)
@@ -1397,7 +1399,15 @@ class InteractiveShell(SingletonConfigurable):
                         # AttributeError, which then crashes IPython.
                         break
                 else:
-                    # If we finish the for loop (no break), we got all members
+                    # If we finish the for loop (no break), we reached the
+                    # penultimate member. If the last member is a descriptor, we
+                    # don't want to call its __get__ method, so we retrieve it
+                    # via introspection.
+                    if len(oname_parts) > 1:
+                        obj = self._get_noinvoke(obj, oname_last)
+                        if obj is None:
+                            continue
+
                     found = True
                     ospace = nsname
                     if ns == alias_ns:
@@ -1424,6 +1434,44 @@ class InteractiveShell(SingletonConfigurable):
 
         return {'found':found, 'obj':obj, 'namespace':ospace,
                 'ismagic':ismagic, 'isalias':isalias, 'parent':parent}
+
+    def _get_noinvoke(self, obj, oname):
+        '''
+        Retrieve an object's property, taking care not to trigger __get__() if
+        the property is a descriptor. We seek to emulate object.__getattribute__'s
+        behavior here.
+        '''
+        mro = inspect.getmro(obj if inspect.isclass(obj) else obj.__class__)
+        closest_class_member = None
+        closest_metaclass_member = None
+
+        for cls in mro:
+            # we have a user-defined lookup function, give up
+            if '__getattribute__' in cls.__dict__ and cls is not object:
+                return cls.__getattribute__(obj, oname)
+
+        for cls in mro:
+            member = cls.__dict__.get(oname, None)
+            # data descriptors get highest priority
+            if inspect.isdatadescriptor(member):
+                return member
+            # cache the property lowest in the class tree for use later
+            closest_class_member = closest_class_member or member
+
+            if hasattr(cls, '__metaclass__') and oname in cls.__metaclass__:
+                closest_metaclass_member = closest_metaclass_member or \
+                    cls.__metaclass__[oname]
+
+        # instance properties get higher priority than class properties
+        if hasattr(obj, '__dict__') and oname in obj.__dict__:
+            return obj.__dict__[oname]
+        elif closest_class_member is not None:
+            return closest_class_member
+        elif closest_metaclass_member is not None:
+            return closest_metaclass_member
+        elif hasattr(obj, oname):
+            # if we have a user-defined __getattr__, this should catch it
+            return getattr(obj, oname)
 
     def _ofind_property(self, oname, info):
         """Second part of object finding, to look for property details."""


### PR DESCRIPTION
Right now if `a.x` is a data descriptor, `a.x?` evaluates the descriptor and returns its result, instead of returning the descriptor itself. This patch fixes that by emulating Python's native property resolution lookup instead of calling `getattr` directly.

Demo:

```
class Test2(object):

    """testing 1 2 3"""

    def __get__(self, inst, owner):
        print "you called __get__"
        return 3

    def __set__(self, inst, owner):
        print "you called __set__"

class Test3(object):

    x = Test2()

a = Test3()
```

Running this script under IPython, `a.x?` gives us

```
you called __get__
you called __get__
Type:       int
Base Class: <type 'int'>
String Form:3
Namespace:  Interactive
Docstring:
int(x[, base]) -> integer

Convert a string or number to an integer, if possible. ...
```

With the new patch, we get

```
Type:       Test2
Base Class: <class '__main__.Test2'>
String Form:<__main__.Test2 object at 0x102efdfd0>
Namespace:  Interactive
Docstring:  testing 1 2 3
```

I have yet to write tests, but I wanted to bring this up for discussion to make sure it's really wanted -- there will probably be quite a number of tests necessary to make sure that our emulation of `object.__getattribute___()` is correct.

This deals with the 'executing the function' problem in issue #1555.

There's also the question of whether we want to print the contents of `__get__()` and `__set__()` for these descriptors, or if we want to leave it to the user to manually look up `Test2.__get__()`. If we do print these out, note that we will have to special-case it for Python's `@property` descriptors -- `__get__()` is natively implemented for them, so it makes more sense to print out the contents of `fget` in their case.
