### PR TITLE
Fix for %pdef on Python 3

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -354,7 +354,7 @@ class Inspector:
         if inspect.isclass(obj):
             header = self.__head('Class constructor information:\n')
             obj = obj.__init__
-        elif type(obj) is types.InstanceType:
+        elif (not py3compat.PY3) and type(obj) is types.InstanceType:
             obj = obj.__call__
 
         output = self._getdef(obj,oname)

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -283,3 +283,8 @@ def test_getdoc():
     nt.assert_equal(oinspect.getdoc(a), "standard docstring")
     nt.assert_equal(oinspect.getdoc(b), "custom docstring")
     nt.assert_equal(oinspect.getdoc(c), "standard docstring")
+
+def test_pdef():
+    # See gh-1914
+    def foo(): pass
+    inspector.pdef(foo, 'foo')


### PR DESCRIPTION
A nice simple one - `types.InstanceType` is for old style classes, so we don't check against it on Python 3.
