### PR TITLE
py3k compatibility for setupegg.py

### DIFF
--- a/setupegg.py
+++ b/setupegg.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python
 """Wrapper to run setup.py using setuptools."""
 
+# Python 3 compatibility
+try:
+    execfile
+except:
+    def execfile(filename, globals, locals=None):
+        locals = locals or globals
+        exec(compile(open(filename).read(), filename, "exec"), globals, locals)
+
 # Import setuptools and call the actual setup
 import setuptools
-execfile('setup.py')
+execfile('setup.py', globals())


### PR DESCRIPTION
So I tried to run...

```
$ python3 setupegg.py develop --user
Traceback (most recent call last):
  File "setupegg.py", line 6, in <module>
    execfile('setup.py')
NameError: name 'execfile' is not defined
```

Now I realize this is a silly thing to do, since the raw source won't be run through 2to3, etc.  But I didn't expect the command to just break.

Now setupegg.py isn't really useful in Python 3, as we are already importing setuptools in setup.py.  So maybe we should just print a nicer warning message an abort instead?  Or maybe I'll just be less silly in the future.
