### PR TITLE
Add IPython syntax support to the %timeit magic, in line and cell mode

### DIFF
--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -809,6 +809,13 @@ class IPythonInputSplitter(InputSplitter):
         self._is_complete = last_blank(last_block) and lines.isspace()
         return self._is_complete
 
+    def transform_cell(self, cell):
+        """Process and translate a cell of input.
+        """
+        self.reset()
+        self.push(cell)
+        return self.source_reset()
+
     def push(self, lines):
         """Push one or more lines of IPython input.
 

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -767,14 +767,14 @@ python-profiler package from non-free.""")
         # this code has tight coupling to the inner workings of timeit.Timer,
         # but is there a better way to achieve that the code stmt has access
         # to the shell namespace?
-
+        transform  = self.shell.input_splitter.transform_cell
         if cell is None:
             # called as line magic
             setup = 'pass'
-            stmt = timeit.reindent(stmt, 8)
+            stmt = timeit.reindent(transform(stmt), 8)
         else:
-            setup = timeit.reindent(stmt, 4)
-            stmt = timeit.reindent(cell, 8)
+            setup = timeit.reindent(transform(stmt), 4)
+            stmt = timeit.reindent(transform(cell), 8)
 
         # From Python 3.3, this template uses new-style string formatting.
         if sys.version_info >= (3, 3):

--- a/IPython/core/tests/test_inputsplitter.py
+++ b/IPython/core/tests/test_inputsplitter.py
@@ -675,6 +675,17 @@ class BlockIPythonInputTestCase(IPythonInputTestCase):
                 self.assertEqual(out.rstrip(), out_t.rstrip())
                 self.assertEqual(out_raw.rstrip(), raw.rstrip())
 
+    def test_syntax_multiline_cell(self):
+        isp = self.isp
+        for example in syntax_ml.itervalues():
+            
+            out_t_parts = []
+            for line_pairs in example:
+                raw = '\n'.join(r for r, _ in line_pairs)
+                out_t = '\n'.join(t for _,t in line_pairs)
+                out = isp.transform_cell(raw)
+                # Match ignoring trailing whitespace
+                self.assertEqual(out.rstrip(), out_t.rstrip())
 
 #-----------------------------------------------------------------------------
 # Main - use as a script, mostly for developer experiments

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -450,8 +450,8 @@ def test_timeit_arguments():
     _ip.magic("timeit ('#')")
 
 
-def test_timeit_cell():
-    "Test %%timeit called in cell mode"
+def test_timeit_special_syntax():
+    "Test %%timeit with IPython special syntax"
     from IPython.core.magic import register_line_magic
 
     @register_line_magic
@@ -459,8 +459,12 @@ def test_timeit_cell():
         ip = get_ipython()
         ip.user_ns['lmagic_out'] = line
 
-    _ip.run_cell_magic('timeit', '-n1 -r1', '%lmagic my line')
+    # line mode test
+    _ip.run_line_magic('timeit', '-n1 -r1 %lmagic my line')
     nt.assert_equal(_ip.user_ns['lmagic_out'], 'my line')
+    # cell mode test
+    _ip.run_cell_magic('timeit', '-n1 -r1', '%lmagic my line2')
+    nt.assert_equal(_ip.user_ns['lmagic_out'], 'my line2')
     
 
 @dec.skipif(execution.profile is None)

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -450,6 +450,19 @@ def test_timeit_arguments():
     _ip.magic("timeit ('#')")
 
 
+def test_timeit_cell():
+    "Test %%timeit called in cell mode"
+    from IPython.core.magic import register_line_magic
+
+    @register_line_magic
+    def lmagic(line):
+        ip = get_ipython()
+        ip.user_ns['lmagic_out'] = line
+
+    _ip.run_cell_magic('timeit', '-n1 -r1', '%lmagic my line')
+    nt.assert_equal(_ip.user_ns['lmagic_out'], 'my line')
+    
+
 @dec.skipif(execution.profile is None)
 def test_prun_quotes():
     "Test that prun does not clobber string escapes (GH #1302)"


### PR DESCRIPTION
Allows the `%%timeit` magic to understand IPython special syntax, so the following both work:

```
%timeit %lmagic a+3
```

and

```
%%timeit
%lmagic a+3
```

It became clear to me that this would make a huge difference in the polish of the experience when timing parallel codes using the `%px` magic.
