### PR TITLE
Fix styling of superscripts and subscripts. Closes #1924.

### DIFF
--- a/IPython/frontend/html/notebook/static/css/boilerplate.css
+++ b/IPython/frontend/html/notebook/static/css/boilerplate.css
@@ -34,6 +34,9 @@ time, mark, audio, video {
   vertical-align: baseline;
 }
 
+sup { vertical-align: super; }
+sub { vertical-align: sub; }
+
 article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
   display: block;


### PR DESCRIPTION
#1924 was caused by the blanket `vertical-align: baseline;` rule at the top of boilerplate.css.
