### PR TITLE
Win py3fixes

### DIFF
--- a/IPython/utils/_process_win32.py
+++ b/IPython/utils/_process_win32.py
@@ -154,7 +154,7 @@ def getoutput(cmd):
         out = process_handler(cmd, lambda p: p.communicate()[0], STDOUT)
 
     if out is None:
-        out = ''
+        out = b''
     return py3compat.bytes_to_str(out)
 
 try:

--- a/IPython/utils/_process_win32.py
+++ b/IPython/utils/_process_win32.py
@@ -155,7 +155,7 @@ def getoutput(cmd):
 
     if out is None:
         out = ''
-    return out
+    return py3compat.bytes_to_str(out)
 
 try:
     CommandLineToArgvW = ctypes.windll.shell32.CommandLineToArgvW

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -21,10 +21,10 @@ import warnings
 from hashlib import md5
 
 import IPython
+from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.process import system
 from IPython.utils.importstring import import_item
 from IPython.utils import py3compat
-
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
@@ -40,7 +40,7 @@ def _writable_dir(path):
     return os.path.isdir(path) and os.access(path, os.W_OK)
 
 if sys.platform == 'win32':
-    @py3compat.u_format
+    @skip_doctest
     def _get_long_path_name(path):
         """Get a long path name (expand ~) on Windows using ctypes.
 
@@ -48,7 +48,7 @@ if sys.platform == 'win32':
         --------
 
         >>> get_long_path_name('c:\\docume~1')
-        {u}'c:\\\\Documents and Settings'
+        u'c:\\\\Documents and Settings'
 
         """
         try:

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -40,6 +40,7 @@ def _writable_dir(path):
     return os.path.isdir(path) and os.access(path, os.W_OK)
 
 if sys.platform == 'win32':
+    @py3compat.u_format
     def _get_long_path_name(path):
         """Get a long path name (expand ~) on Windows using ctypes.
 
@@ -47,7 +48,7 @@ if sys.platform == 'win32':
         --------
 
         >>> get_long_path_name('c:\\docume~1')
-        u'c:\\\\Documents and Settings'
+        {u}'c:\\\\Documents and Settings'
 
         """
         try:


### PR DESCRIPTION
There are currently four test failures on shiningpanda for python3.2 on windows (https://jenkins.shiningpanda.com/ipython/job/ipython-windows-py32/1/)

This PR fixes the last three. The history_manager bug is more involved and I will not have time to look into it until the last week of june.

There are no failures using python2.7
