### PR TITLE
increase duration of save messages

### DIFF
--- a/IPython/frontend/html/notebook/static/js/notificationwidget.js
+++ b/IPython/frontend/html/notebook/static/js/notificationwidget.js
@@ -85,10 +85,10 @@ var IPython = (function (IPython) {
             that.set_message("Saving notebook",500);
         });
         $([IPython.events]).on('notebook_saved.Notebook', function () {
-            that.set_message("Notebook saved",500);
+            that.set_message("Notebook saved",2000);
         });
         $([IPython.events]).on('notebook_save_failed.Notebook', function () {
-            that.set_message("Notebook save failed",500);
+            that.set_message("Notebook save failed",2000);
         });
     };
 

--- a/IPython/frontend/html/notebook/static/js/savewidget.js
+++ b/IPython/frontend/html/notebook/static/js/savewidget.js
@@ -52,7 +52,7 @@ var IPython = (function (IPython) {
             that.update_document_title();
         });
         $([IPython.events]).on('notebook_save_failed.Notebook', function () {
-            that.set_save_status('');
+            that.set_save_status('Last Save Failed!');
         });
     };
 


### PR DESCRIPTION
and write permanent 'failed' message to the save status area on failed save.

Not a pop-up as described in #1461, but significantly more prominant, and most importantly _permanent_ when saving fails, at least until the next successful save.
