### PR TITLE
remove remaining references to deprecated XREP/XREQ names

### DIFF
--- a/IPython/frontend/consoleapp.py
+++ b/IPython/frontend/consoleapp.py
@@ -166,11 +166,11 @@ class IPythonConsoleApp(Configurable):
     hb_port = Int(0, config=True,
         help="set the heartbeat port [default: random]")
     shell_port = Int(0, config=True,
-        help="set the shell (XREP) port [default: random]")
+        help="set the shell (ROUTER) port [default: random]")
     iopub_port = Int(0, config=True,
         help="set the iopub (PUB) port [default: random]")
     stdin_port = Int(0, config=True,
-        help="set the stdin (XREQ) port [default: random]")
+        help="set the stdin (DEALER) port [default: random]")
     connection_file = Unicode('', config=True,
         help="""JSON file in which to store connection info [default: kernel-<pid>.json]
 

--- a/IPython/frontend/html/notebook/kernelmanager.py
+++ b/IPython/frontend/html/notebook/kernelmanager.py
@@ -193,7 +193,7 @@ class MultiKernelManager(LoggingConfigurable):
     def create_shell_stream(self, kernel_id):
         ip = self.get_kernel_ip(kernel_id)
         ports = self.get_kernel_ports(kernel_id)
-        shell_stream = self.create_connected_stream(ip, ports['shell_port'], zmq.XREQ)
+        shell_stream = self.create_connected_stream(ip, ports['shell_port'], zmq.DEALER)
         return shell_stream
 
     def create_hb_stream(self, kernel_id):

--- a/IPython/frontend/html/notebook/zmqhttp.py
+++ b/IPython/frontend/html/notebook/zmqhttp.py
@@ -76,7 +76,7 @@ class ZMQSubHandler(ZMQHandler):
         self.get_stream().on_recv(self._handle_msgs)
 
 
-class ZMQXReqHandler(ZMQHandler):
+class ZMQDealerHandler(ZMQHandler):
 
     SUPPORTED_METHODS = ("POST",)
 

--- a/IPython/parallel/apps/ipcontrollerapp.py
+++ b/IPython/parallel/apps/ipcontrollerapp.py
@@ -365,7 +365,7 @@ class IPControllerApp(BaseParallelApplication):
             scheme = TaskScheduler.scheme_name.get_default_value()
         # Task Queue (in a Process)
         if scheme == 'pure':
-            self.log.warn("task::using pure XREQ Task scheduler")
+            self.log.warn("task::using pure DEALER Task scheduler")
             q = mq(zmq.ROUTER, zmq.DEALER, zmq.PUB, b'intask', b'outtask')
             # q.setsockopt_out(zmq.HWM, hub.hwm)
             q.bind_in(hub.client_info['task'][1])

--- a/IPython/parallel/controller/heartmonitor.py
+++ b/IPython/parallel/controller/heartmonitor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
-A multi-heart Heartbeat system using PUB and XREP sockets. pings are sent out on the PUB,
-and hearts are tracked based on their XREQ identities.
+A multi-heart Heartbeat system using PUB and ROUTER sockets. pings are sent out on the PUB,
+and hearts are tracked based on their DEALER identities.
 
 Authors:
 
@@ -34,9 +34,9 @@ class Heart(object):
     Device model for responding to heartbeats.
 
     It simply builds a threadsafe zmq.FORWARDER Device, defaulting to using
-    SUB/XREQ for in/out.
+    SUB/DEALER for in/out.
 
-    You can specify the XREQ's IDENTITY via the optional heart_id argument."""
+    You can specify the DEALER's IDENTITY via the optional heart_id argument."""
     device=None
     id=None
     def __init__(self, in_addr, out_addr, in_type=zmq.SUB, out_type=zmq.DEALER, heart_id=None):
@@ -62,7 +62,7 @@ class Heart(object):
 class HeartMonitor(LoggingConfigurable):
     """A basic HeartMonitor class
     pingstream: a PUB stream
-    pongstream: an XREP stream
+    pongstream: an ROUTER stream
     period: the period of the heartbeat in milliseconds"""
 
     period = Integer(3000, config=True,
@@ -171,11 +171,11 @@ if __name__ == '__main__':
     context = zmq.Context()
     pub = context.socket(zmq.PUB)
     pub.bind('tcp://127.0.0.1:5555')
-    xrep = context.socket(zmq.ROUTER)
-    xrep.bind('tcp://127.0.0.1:5556')
+    router = context.socket(zmq.ROUTER)
+    router.bind('tcp://127.0.0.1:5556')
 
     outstream = zmqstream.ZMQStream(pub, loop)
-    instream = zmqstream.ZMQStream(xrep, loop)
+    instream = zmqstream.ZMQStream(router, loop)
 
     hb = HeartMonitor(loop, outstream, instream)
 

--- a/IPython/parallel/controller/hub.py
+++ b/IPython/parallel/controller/hub.py
@@ -108,9 +108,9 @@ class EngineConnector(HasTraits):
     Attributes are:
     id (int): engine ID
     uuid (str): uuid (unused?)
-    queue (str): identity of queue's XREQ socket
-    registration (str): identity of registration XREQ socket
-    heartbeat (str): identity of heartbeat XREQ socket
+    queue (str): identity of queue's DEALER socket
+    registration (str): identity of registration DEALER socket
+    heartbeat (str): identity of heartbeat DEALER socket
     """
     id=Integer(0)
     queue=CBytes()
@@ -124,7 +124,7 @@ class HubFactory(RegistrationFactory):
 
     # port-pairs for monitoredqueues:
     hb = Tuple(Integer,Integer,config=True,
-        help="""XREQ/SUB Port pair for Engine heartbeats""")
+        help="""DEALER/SUB Port pair for Engine heartbeats""")
     def _hb_default(self):
         return tuple(util.select_random_ports(2))
 
@@ -309,7 +309,7 @@ class Hub(SessionFactory):
     session: Session object
     <removed> context: zmq context for creating new connections (?)
     queue: ZMQStream for monitoring the command queue (SUB)
-    query: ZMQStream for engine registration and client queries requests (XREP)
+    query: ZMQStream for engine registration and client queries requests (ROUTER)
     heartbeat: HeartMonitor object checking the pulse of the engines
     notifier: ZMQStream for broadcasting engine registration changes (PUB)
     db: connection to db for out of memory logging of commands

--- a/IPython/parallel/controller/scheduler.py
+++ b/IPython/parallel/controller/scheduler.py
@@ -609,7 +609,7 @@ class TaskScheduler(SessionFactory):
         # first, relay result to client
         engine = idents[0]
         client = idents[1]
-        # swap_ids for XREP-XREP mirror
+        # swap_ids for ROUTER-ROUTER mirror
         raw_msg[:2] = [client,engine]
         # print (map(str, raw_msg[:4]))
         self.client_stream.send_multipart(raw_msg, copy=False)

--- a/IPython/zmq/__init__.py
+++ b/IPython/zmq/__init__.py
@@ -33,9 +33,9 @@ def patch_pyzmq():
     
     # fix missing DEALER/ROUTER aliases in pyzmq < 2.1.9
     if not hasattr(zmq, 'DEALER'):
-        zmq.DEALER = zmq.XREQ
+        zmq.DEALER = zmq.DEALER
     if not hasattr(zmq, 'ROUTER'):
-        zmq.ROUTER = zmq.XREP
+        zmq.ROUTER = zmq.ROUTER
     
     # fallback on stdlib json if jsonlib is selected, because jsonlib breaks things.
     # jsonlib support is removed from pyzmq >= 2.2.0

--- a/IPython/zmq/entry_point.py
+++ b/IPython/zmq/entry_point.py
@@ -31,7 +31,7 @@ def write_connection_file(fname=None, shell_port=0, iopub_port=0, stdin_port=0, 
         The path to the file to write
 
     shell_port : int, optional
-        The port to use for XREP channel.
+        The port to use for ROUTER channel.
 
     iopub_port : int, optional
         The port to use for the SUB channel.

--- a/IPython/zmq/kernelapp.py
+++ b/IPython/zmq/kernelapp.py
@@ -112,9 +112,9 @@ class KernelApp(BaseIPythonApplication):
     ip = Unicode(LOCALHOST, config=True,
         help="Set the IP or interface on which the kernel will listen.")
     hb_port = Integer(0, config=True, help="set the heartbeat port [default: random]")
-    shell_port = Integer(0, config=True, help="set the shell (XREP) port [default: random]")
+    shell_port = Integer(0, config=True, help="set the shell (ROUTER) port [default: random]")
     iopub_port = Integer(0, config=True, help="set the iopub (PUB) port [default: random]")
-    stdin_port = Integer(0, config=True, help="set the stdin (XREQ) port [default: random]")
+    stdin_port = Integer(0, config=True, help="set the stdin (DEALER) port [default: random]")
     connection_file = Unicode('', config=True, 
     help="""JSON file in which to store connection info [default: kernel-<pid>.json]
     

--- a/IPython/zmq/kernelmanager.py
+++ b/IPython/zmq/kernelmanager.py
@@ -181,7 +181,7 @@ class ZMQSocketChannel(Thread):
 
 
 class ShellSocketChannel(ZMQSocketChannel):
-    """The XREQ channel for issues request/replies to the kernel.
+    """The DEALER channel for issues request/replies to the kernel.
     """
 
     command_queue = None


### PR DESCRIPTION
There was only one actual use of the deprecated constants in code, but numerous mentions in docstrings, etc.

These names have been removed from the next libzmq release, and will presumably be removed from pyzmq someday.
