### PR TITLE
Namespaces

### DIFF
--- a/IPython/config/__init__.py
+++ b/IPython/config/__init__.py
@@ -3,7 +3,7 @@
 __docformat__ = "restructuredtext en"
 
 #-------------------------------------------------------------------------------
-#  Copyright (C) 2008-2011  The IPython Development Team
+#  Copyright (C) 2008  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.
@@ -12,3 +12,7 @@ __docformat__ = "restructuredtext en"
 #-------------------------------------------------------------------------------
 # Imports
 #-------------------------------------------------------------------------------
+
+from .application import *
+from .configurable import *
+from .loader import Config

--- a/IPython/display.py
+++ b/IPython/display.py
@@ -1,0 +1,17 @@
+"""Public API for display tools in IPython.
+"""
+
+#-----------------------------------------------------------------------------
+#       Copyright (C) 2012 The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+from IPython.core.display import *
+from IPython.core.displaypub import *
+from IPython.lib.display import *

--- a/IPython/zmq/__init__.py
+++ b/IPython/zmq/__init__.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010-2011  The IPython Development Team
+#  Copyright (C) 2010  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING.txt, distributed as part of this software.
@@ -66,3 +66,8 @@ def check_for_zmq(minimum_version, module='IPython.zmq'):
 
 check_for_zmq('2.1.4')
 patch_pyzmq()
+
+from .blockingkernelmanager import BlockingKernelManager
+from .kernelmanager import *
+from .session import Session
+


### PR DESCRIPTION
This is the first step towards #1537

Further (more important) things I haven't worked out yet:
1. single import for all display-related functions (currently in core.display, lib.display)
2. InteractiveShellEmbed, InteractiveShell, etc. somewhere so that simple entry points / handles are readily accessible.

Possible options:
1. top-level IPython.display has all our display apis 
2. IPython.api defines our general public interface - display, anything else
3. IPython.api is a _package_, where we put various categorized public APIs (e.g. IPython.api.display)

Any suggestions?  This seems a pretty general issue we have, where we haven't really thought about public APIs at all, aside from magics and methods on the InteractiveShell object.  Users need to be much too familiar with our code layout to use it.
