### PR TITLE
Add image message handler in ZMQTerminalInteractiveShell

### DIFF
--- a/IPython/frontend/terminal/console/interactiveshell.py
+++ b/IPython/frontend/terminal/console/interactiveshell.py
@@ -21,7 +21,7 @@ import bdb
 import signal
 import sys
 import time
-from cStringIO import StringIO
+from io import BytesIO
 import base64
 
 from Queue import Empty
@@ -203,7 +203,7 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
     def handle_image(self, string):
         if 'PIL' in self.image_handler and PIL:
             data = base64.decodestring(string)
-            img = PIL.Image.open(StringIO(data))
+            img = PIL.Image.open(BytesIO(data))
             img.show()
 
     def handle_stdin_request(self, timeout=0.1):

--- a/IPython/frontend/terminal/console/interactiveshell.py
+++ b/IPython/frontend/terminal/console/interactiveshell.py
@@ -231,6 +231,7 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
         for mime in ['image/png', 'image/jpeg', 'image/svg+xml']:
             if mime in data:
                 self.handle_image(data, mime)
+                return
 
     def handle_image(self, data, mime):
         handler = getattr(

--- a/IPython/frontend/terminal/console/interactiveshell.py
+++ b/IPython/frontend/terminal/console/interactiveshell.py
@@ -265,12 +265,12 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
         if mime not in ('image/png', 'image/jpeg'):
             return
         import PIL
-        raw = base64.decodestring(data[mime])
+        raw = base64.decodestring(data[mime].encode('ascii'))
         img = PIL.Image.open(BytesIO(raw))
         img.show()
 
     def handle_image_stream(self, data, mime):
-        raw = base64.decodestring(data[mime])
+        raw = base64.decodestring(data[mime].encode('ascii'))
         imageformat = self._imagemime[mime]
         fmt = dict(format=imageformat)
         args = [s.format(**fmt) for s in self.stream_image_handler]
@@ -281,7 +281,7 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
             proc.communicate(raw)
 
     def handle_image_tempfile(self, data, mime):
-        raw = base64.decodestring(data[mime])
+        raw = base64.decodestring(data[mime].encode('ascii'))
         imageformat = self._imagemime[mime]
         filename = 'tmp.{0}'.format(imageformat)
         with nested(NamedFileInTemporaryDirectory(filename),

--- a/IPython/frontend/terminal/console/interactiveshell.py
+++ b/IPython/frontend/terminal/console/interactiveshell.py
@@ -22,7 +22,6 @@ import signal
 import os
 import sys
 import time
-import tempfile
 import subprocess
 from io import BytesIO
 import base64
@@ -39,6 +38,7 @@ from IPython.core import page
 from IPython.utils.warn import warn, error, fatal
 from IPython.utils import io
 from IPython.utils.traitlets import List, Enum, Any
+from IPython.utils.tempdir import NamedFileInTemporaryDirectory
 
 from IPython.frontend.terminal.interactiveshell import TerminalInteractiveShell
 from IPython.frontend.terminal.console.completer import ZMQCompleter
@@ -285,7 +285,7 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
         raw = base64.decodestring(data[mime])
         imageformat = self._imagemime[mime]
         ext = '.{0}'.format(imageformat)
-        with nested(tempfile.NamedTemporaryFile(suffix=ext),
+        with nested(NamedFileInTemporaryDirectory('tmp.{0}'.format(ext)),
                     open(os.devnull, 'w')) as (f, devnull):
             f.write(raw)
             f.flush()

--- a/IPython/frontend/terminal/console/interactiveshell.py
+++ b/IPython/frontend/terminal/console/interactiveshell.py
@@ -92,8 +92,7 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
         Callable object called via 'callable' image handler with one
         argument, `data`, which is `msg["content"]["data"]` where
         `msg` is the message from iopub channel.  For exmaple, you can
-        find base64 encoded PNG data as `data['image/png']`. You can
-        use {format} in the string to represent the image format.
+        find base64 encoded PNG data as `data['image/png']`.
         """
     )
 

--- a/IPython/frontend/terminal/console/interactiveshell.py
+++ b/IPython/frontend/terminal/console/interactiveshell.py
@@ -284,8 +284,8 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
     def handle_image_tempfile(self, data, mime):
         raw = base64.decodestring(data[mime])
         imageformat = self._imagemime[mime]
-        ext = '.{0}'.format(imageformat)
-        with nested(NamedFileInTemporaryDirectory('tmp.{0}'.format(ext)),
+        filename = 'tmp.{0}'.format(imageformat)
+        with nested(NamedFileInTemporaryDirectory(filename),
                     open(os.devnull, 'w')) as (f, devnull):
             f.write(raw)
             f.flush()

--- a/IPython/frontend/terminal/console/interactiveshell.py
+++ b/IPython/frontend/terminal/console/interactiveshell.py
@@ -264,7 +264,7 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
     def handle_image_PIL(self, data, mime):
         if mime not in ('image/png', 'image/jpeg'):
             return
-        import PIL
+        import PIL.Image
         raw = base64.decodestring(data[mime].encode('ascii'))
         img = PIL.Image.open(BytesIO(raw))
         img.show()

--- a/IPython/frontend/terminal/console/interactiveshell.py
+++ b/IPython/frontend/terminal/console/interactiveshell.py
@@ -91,6 +91,15 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
         """
     )
 
+    mime_preference = List(
+        default_value=['image/png', 'image/jpeg', 'image/svg+xml'],
+        config=True, allow_none=False, help=
+        """
+        Preferred object representation MIME type in order.  First
+        matched MIME type will be used.
+        """
+    )
+
     def __init__(self, *args, **kwargs):
         self.km = kwargs.pop('kernel_manager')
         self.session_id = self.km.session.session
@@ -236,8 +245,8 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
     }
 
     def handle_rich_data(self, data):
-        for mime in ['image/png', 'image/jpeg', 'image/svg+xml']:
-            if mime in data:
+        for mime in self.mime_preference:
+            if mime in data and mime in self._imagemime:
                 self.handle_image(data, mime)
                 return
 

--- a/IPython/frontend/terminal/console/interactiveshell.py
+++ b/IPython/frontend/terminal/console/interactiveshell.py
@@ -29,6 +29,11 @@ import base64
 
 from Queue import Empty
 
+try:
+    from contextlib import nested
+except:
+    from IPython.utils.nested_context import nested
+
 from IPython.core.alias import AliasManager, AliasError
 from IPython.core import page
 from IPython.utils.warn import warn, error, fatal
@@ -280,8 +285,8 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
         raw = base64.decodestring(data[mime])
         imageformat = self._imagemime[mime]
         ext = '.{0}'.format(imageformat)
-        with tempfile.NamedTemporaryFile(suffix=ext) as f, \
-             open(os.devnull, 'w') as devnull:
+        with nested(tempfile.NamedTemporaryFile(suffix=ext),
+                    open(os.devnull, 'w')) as (f, devnull):
             f.write(raw)
             f.flush()
             fmt = dict(file=f.name, format=imageformat)

--- a/IPython/frontend/terminal/console/tests/test_image_handler.py
+++ b/IPython/frontend/terminal/console/tests/test_image_handler.py
@@ -30,7 +30,7 @@ class ZMQTerminalInteractiveShellTestCase(unittest.TestCase):
         self.shell = ZMQTerminalInteractiveShell(kernel_manager=km)
         self.raw = b'dummy data'
         self.mime = 'image/png'
-        self.data = {self.mime: base64.encodestring(self.raw)}
+        self.data = {self.mime: base64.encodestring(self.raw).decode('ascii')}
 
     def test_no_call_by_default(self):
         def raise_if_called(*args, **kwds):

--- a/IPython/frontend/terminal/console/tests/test_image_handler.py
+++ b/IPython/frontend/terminal/console/tests/test_image_handler.py
@@ -6,6 +6,7 @@
 #-----------------------------------------------------------------------------
 
 import os
+import sys
 import unittest
 import base64
 
@@ -16,7 +17,6 @@ from IPython.utils.tempdir import NamedFileInTemporaryDirectory
 from IPython.testing.tools import monkeypatch
 from IPython.testing.decorators import skip_without
 from IPython.utils.ipstruct import Struct
-from IPython.utils.process import find_cmd
 
 
 SCRIPT_PATH = os.path.join(
@@ -71,7 +71,7 @@ class ZMQTerminalInteractiveShellTestCase(unittest.TestCase):
         assert hasattr(shell, funcname)
 
         with NamedFileInTemporaryDirectory('data') as file:
-            cmd = [find_cmd('python'), SCRIPT_PATH, inpath, file.name]
+            cmd = [sys.executable, SCRIPT_PATH, inpath, file.name]
             setattr(shell, configname, cmd)
             getattr(shell, funcname)(self.data, self.mime)
             transferred = file.read()

--- a/IPython/frontend/terminal/console/tests/test_image_handler.py
+++ b/IPython/frontend/terminal/console/tests/test_image_handler.py
@@ -37,10 +37,10 @@ class ZMQTerminalInteractiveShellTestCase(unittest.TestCase):
             assert False
 
         shell = self.shell
-        shell.handle_image_PIL
-        shell.handle_image_stream
-        shell.handle_image_tempfile
-        shell.handle_image_callable
+        shell.handle_image_PIL = raise_if_called
+        shell.handle_image_stream = raise_if_called
+        shell.handle_image_tempfile = raise_if_called
+        shell.handle_image_callable = raise_if_called
 
         shell.handle_image(None, None)  # arguments are dummy
 

--- a/IPython/frontend/terminal/console/tests/test_image_handler.py
+++ b/IPython/frontend/terminal/console/tests/test_image_handler.py
@@ -13,7 +13,7 @@ import base64
 from IPython.zmq.kernelmanager import KernelManager
 from IPython.frontend.terminal.console.interactiveshell \
     import ZMQTerminalInteractiveShell
-from IPython.utils.tempdir import NamedFileInTemporaryDirectory
+from IPython.utils.tempdir import TemporaryDirectory
 from IPython.testing.tools import monkeypatch
 from IPython.testing.decorators import skip_without
 from IPython.utils.ipstruct import Struct
@@ -70,11 +70,14 @@ class ZMQTerminalInteractiveShellTestCase(unittest.TestCase):
         assert hasattr(shell, configname)
         assert hasattr(shell, funcname)
 
-        with NamedFileInTemporaryDirectory('data') as file:
-            cmd = [sys.executable, SCRIPT_PATH, inpath, file.name]
+        with TemporaryDirectory() as tmpdir:
+            outpath = os.path.join(tmpdir, 'data')
+            cmd = [sys.executable, SCRIPT_PATH, inpath, outpath]
             setattr(shell, configname, cmd)
             getattr(shell, funcname)(self.data, self.mime)
-            transferred = file.read()
+            # cmd is called and file is closed.  So it's safe to open now.
+            with open(outpath, 'rb') as file:
+                transferred = file.read()
 
         self.assertEqual(transferred, self.raw)
 

--- a/IPython/frontend/terminal/console/tests/test_image_handler.py
+++ b/IPython/frontend/terminal/console/tests/test_image_handler.py
@@ -1,0 +1,94 @@
+#-----------------------------------------------------------------------------
+# Copyright (C) 2012 The IPython Development Team
+#
+# Distributed under the terms of the BSD License. The full license is in
+# the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+import os
+import unittest
+import base64
+
+from IPython.zmq.kernelmanager import KernelManager
+from IPython.frontend.terminal.console.interactiveshell \
+    import ZMQTerminalInteractiveShell
+from IPython.utils.tempdir import NamedFileInTemporaryDirectory
+from IPython.testing.tools import monkeypatch
+from IPython.utils.ipstruct import Struct
+from IPython.utils.process import find_cmd
+
+
+SCRIPT_PATH = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)), 'writetofile.py')
+
+
+class ZMQTerminalInteractiveShellTestCase(unittest.TestCase):
+
+    def setUp(self):
+        km = KernelManager()
+        self.shell = ZMQTerminalInteractiveShell(kernel_manager=km)
+        self.raw = b'dummy data'
+        self.mime = 'image/png'
+        self.data = {self.mime: base64.encodestring(self.raw)}
+
+    def test_no_call_by_default(self):
+        def raise_if_called(*args, **kwds):
+            assert False
+
+        shell = self.shell
+        shell.handle_image_PIL
+        shell.handle_image_stream
+        shell.handle_image_tempfile
+        shell.handle_image_callable
+
+        shell.handle_image(None, None)  # arguments are dummy
+
+    def test_handle_image_PIL(self):
+        import PIL.Image
+
+        open_called_with = []
+        show_called_with = []
+
+        def fake_open(arg):
+            open_called_with.append(arg)
+            return Struct(show=lambda: show_called_with.append(None))
+
+        with monkeypatch(PIL.Image, 'open', fake_open):
+            self.shell.handle_image_PIL(self.data, self.mime)
+
+        assert len(open_called_with) == 1
+        assert len(show_called_with) == 1
+        assert open_called_with[0].getvalue() == self.raw
+
+    @staticmethod
+    def get_handler_command(inpath, outpath):
+        return [find_cmd('python'), SCRIPT_PATH, inpath, outpath]
+
+    def check_handler_with_file(self, inpath, handler):
+        shell = self.shell
+        configname = '{0}_image_handler'.format(handler)
+        funcname = 'handle_image_{0}'.format(handler)
+
+        assert hasattr(shell, configname)
+        assert hasattr(shell, funcname)
+
+        with NamedFileInTemporaryDirectory('data') as file:
+            cmd = self.get_handler_command(inpath, file.name)
+            setattr(shell, configname, cmd)
+            getattr(shell, funcname)(self.data, self.mime)
+            transferred = file.read()
+
+        assert transferred == self.raw
+
+    def test_handle_image_stream(self):
+        self.check_handler_with_file('-', 'stream')
+
+    def test_handle_image_tempfile(self):
+        self.check_handler_with_file('{file}', 'tempfile')
+
+    def test_handle_image_callable(self):
+        called_with = []
+        self.shell.callable_image_handler = called_with.append
+        self.shell.handle_image_callable(self.data, self.mime)
+        assert len(called_with) == 1
+        assert called_with[0] is self.data

--- a/IPython/frontend/terminal/console/tests/test_image_handler.py
+++ b/IPython/frontend/terminal/console/tests/test_image_handler.py
@@ -58,9 +58,9 @@ class ZMQTerminalInteractiveShellTestCase(unittest.TestCase):
         with monkeypatch(PIL.Image, 'open', fake_open):
             self.shell.handle_image_PIL(self.data, self.mime)
 
-        assert len(open_called_with) == 1
-        assert len(show_called_with) == 1
-        assert open_called_with[0].getvalue() == self.raw
+        self.assertEqual(len(open_called_with), 1)
+        self.assertEqual(len(show_called_with), 1)
+        self.assertEqual(open_called_with[0].getvalue(), self.raw)
 
     def check_handler_with_file(self, inpath, handler):
         shell = self.shell
@@ -76,7 +76,7 @@ class ZMQTerminalInteractiveShellTestCase(unittest.TestCase):
             getattr(shell, funcname)(self.data, self.mime)
             transferred = file.read()
 
-        assert transferred == self.raw
+        self.assertEqual(transferred, self.raw)
 
     def test_handle_image_stream(self):
         self.check_handler_with_file('-', 'stream')
@@ -88,5 +88,5 @@ class ZMQTerminalInteractiveShellTestCase(unittest.TestCase):
         called_with = []
         self.shell.callable_image_handler = called_with.append
         self.shell.handle_image_callable(self.data, self.mime)
-        assert len(called_with) == 1
+        self.assertEqual(len(called_with), 1)
         assert called_with[0] is self.data

--- a/IPython/frontend/terminal/console/tests/test_image_handler.py
+++ b/IPython/frontend/terminal/console/tests/test_image_handler.py
@@ -62,10 +62,6 @@ class ZMQTerminalInteractiveShellTestCase(unittest.TestCase):
         assert len(show_called_with) == 1
         assert open_called_with[0].getvalue() == self.raw
 
-    @staticmethod
-    def get_handler_command(inpath, outpath):
-        return [find_cmd('python'), SCRIPT_PATH, inpath, outpath]
-
     def check_handler_with_file(self, inpath, handler):
         shell = self.shell
         configname = '{0}_image_handler'.format(handler)
@@ -75,7 +71,7 @@ class ZMQTerminalInteractiveShellTestCase(unittest.TestCase):
         assert hasattr(shell, funcname)
 
         with NamedFileInTemporaryDirectory('data') as file:
-            cmd = self.get_handler_command(inpath, file.name)
+            cmd = [find_cmd('python'), SCRIPT_PATH, inpath, file.name]
             setattr(shell, configname, cmd)
             getattr(shell, funcname)(self.data, self.mime)
             transferred = file.read()

--- a/IPython/frontend/terminal/console/tests/test_image_handler.py
+++ b/IPython/frontend/terminal/console/tests/test_image_handler.py
@@ -14,6 +14,7 @@ from IPython.frontend.terminal.console.interactiveshell \
     import ZMQTerminalInteractiveShell
 from IPython.utils.tempdir import NamedFileInTemporaryDirectory
 from IPython.testing.tools import monkeypatch
+from IPython.testing.decorators import skip_without
 from IPython.utils.ipstruct import Struct
 from IPython.utils.process import find_cmd
 
@@ -43,6 +44,7 @@ class ZMQTerminalInteractiveShellTestCase(unittest.TestCase):
 
         shell.handle_image(None, None)  # arguments are dummy
 
+    @skip_without('PIL')
     def test_handle_image_PIL(self):
         import PIL.Image
 

--- a/IPython/frontend/terminal/console/tests/writetofile.py
+++ b/IPython/frontend/terminal/console/tests/writetofile.py
@@ -1,0 +1,20 @@
+#-----------------------------------------------------------------------------
+# Copyright (C) 2012 The IPython Development Team
+#
+# Distributed under the terms of the BSD License. The full license is in
+# the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+"""
+Copy data from input file to output file for testing.
+"""
+
+import sys
+(inpath, outpath) = sys.argv[1:]
+
+if inpath == '-':
+    infile = sys.stdin
+else:
+    infile = open(inpath)
+
+open(outpath, 'w+b').write(infile.read())

--- a/IPython/frontend/terminal/console/tests/writetofile.py
+++ b/IPython/frontend/terminal/console/tests/writetofile.py
@@ -17,16 +17,17 @@ If INPUT is '-', stdin is used.
 
 """
 
-import sys
-from IPython.utils.py3compat import PY3
-(inpath, outpath) = sys.argv[1:]
+if __name__ == '__main__':
+    import sys
+    from IPython.utils.py3compat import PY3
+    (inpath, outpath) = sys.argv[1:]
 
-if inpath == '-':
-    if PY3:
-        infile = sys.stdin.buffer
+    if inpath == '-':
+        if PY3:
+            infile = sys.stdin.buffer
+        else:
+            infile = sys.stdin
     else:
-        infile = sys.stdin
-else:
-    infile = open(inpath, 'rb')
+        infile = open(inpath, 'rb')
 
-open(outpath, 'w+b').write(infile.read())
+    open(outpath, 'w+b').write(infile.read())

--- a/IPython/frontend/terminal/console/tests/writetofile.py
+++ b/IPython/frontend/terminal/console/tests/writetofile.py
@@ -7,6 +7,14 @@
 
 """
 Copy data from input file to output file for testing.
+
+Command line usage:
+
+    python writetofile.py INPUT OUTPUT
+
+Binary data from INPUT file is copied to OUTPUT file.
+If INPUT is '-', stdin is used.
+
 """
 
 import sys

--- a/IPython/frontend/terminal/console/tests/writetofile.py
+++ b/IPython/frontend/terminal/console/tests/writetofile.py
@@ -10,11 +10,15 @@ Copy data from input file to output file for testing.
 """
 
 import sys
+from IPython.utils.py3compat import PY3
 (inpath, outpath) = sys.argv[1:]
 
 if inpath == '-':
-    infile = sys.stdin
+    if PY3:
+        infile = sys.stdin.buffer
+    else:
+        infile = sys.stdin
 else:
-    infile = open(inpath)
+    infile = open(inpath, 'rb')
 
 open(outpath, 'w+b').write(infile.read())

--- a/IPython/utils/tests/test_tempdir.py
+++ b/IPython/utils/tests/test_tempdir.py
@@ -15,6 +15,6 @@ def test_named_file_in_temporary_directory():
         name = file.name
         assert not file.closed
         assert os.path.exists(name)
-        file.write('test')
+        file.write(b'test')
     assert file.closed
     assert not os.path.exists(name)

--- a/IPython/utils/tests/test_tempdir.py
+++ b/IPython/utils/tests/test_tempdir.py
@@ -1,0 +1,20 @@
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2012-  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+import os
+
+from IPython.utils.tempdir import NamedFileInTemporaryDirectory
+
+
+def test_named_file_in_temporary_directory():
+    with NamedFileInTemporaryDirectory('filename') as file:
+        name = file.name
+        assert not file.closed
+        assert os.path.exists(name)
+        file.write('test')
+    assert file.closed
+    assert not os.path.exists(name)


### PR DESCRIPTION
This change introduces handler for messages which contain image in
ZMQTerminalInteractiveShell.  This is useful, for example, when
connecting to the kernel in which pylab inline backend is activated.
Current image handler only supports PIL backend.

This PR will fix #1575.
