### PR TITLE
Introduce Notebook Magics

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2035,7 +2035,8 @@ class InteractiveShell(SingletonConfigurable):
         self.register_magics(m.AutoMagics, m.BasicMagics, m.CodeMagics,
             m.ConfigMagics, m.DeprecatedMagics, m.ExecutionMagics,
             m.ExtensionMagics, m.HistoryMagics, m.LoggingMagics,
-            m.NamespaceMagics, m.OSMagics, m.PylabMagics, m.ScriptMagics,
+            m.NamespaceMagics, m.NotebookMagics, m.OSMagics, m.PylabMagics,
+            m.ScriptMagics,
         )
 
         # FIXME: Move the color initialization to the DisplayHook, which

--- a/IPython/core/magics/__init__.py
+++ b/IPython/core/magics/__init__.py
@@ -23,6 +23,7 @@ from .extension import ExtensionMagics
 from .history import HistoryMagics
 from .logging import LoggingMagics
 from .namespace import NamespaceMagics
+from .notebook import NotebookMagics
 from .osm import OSMagics
 from .pylab import PylabMagics
 from .script import ScriptMagics

--- a/IPython/core/magics/notebook.py
+++ b/IPython/core/magics/notebook.py
@@ -1,0 +1,41 @@
+"""
+Notebook related magics.
+"""
+
+import os
+
+from IPython.core.magic import Magics, magics_class, line_magic
+from IPython.core.magic_arguments import (argument, magic_arguments,
+                                          parse_argstring)
+
+
+@magics_class
+class NotebookMagics(Magics):
+
+    def notebook_dir(self):
+        return self.shell.config.get('NotebookManager', {}).get('notebook_dir')
+
+    @line_magic
+    def pnd(self, parameter_s=''):
+        """Return the notebook directory."""
+        ndir = self.notebook_dir()
+        if ndir:
+            return ndir
+        else:
+            print "No associated notebook for this kernel."
+
+    @magic_arguments()
+    @argument(
+        'reldir', default=[], nargs='*',
+        help="Relative path from where notebook file is.")
+    @line_magic
+    def cdnb(self, parameter_s=''):
+        """Change directory to where the notebook locates."""
+        args = parse_argstring(self.cdnb, parameter_s)
+        ndir = self.notebook_dir()
+        if ndir:
+            ncwd = os.path.join(ndir, *args.reldir)
+            os.chdir(ncwd)
+            print ncwd
+        else:
+            print "No associated notebook for this kernel."


### PR DESCRIPTION
This change introduces two notebook magic commands:
1. %pnd -- Return the notebook directory.
   This is like %pwd but returns where the notebook is.
2. %cdnb -- Change directory to where the notebook locates.

These commands are useful when you want to access some supplemental python scripts in the notebook.  Having hard-coded `%cd IPYTHON/NOTEBOOK/DIRECTORY` is not good solution.

These magic commands work only when the notebook is in the directory which is configured by the profile.  If notebook server using different directory than the configured variable (for example, notebook_dir is set via command line option), these magic commands misbehaves.

To fix this issue, I think it's better to send some information about notebook to the kernel from the notebook server when the kernel is started.
