### PR TITLE
Fix for copy action (Ctrl+C) when there is no pager defined in qtconsole

### DIFF
--- a/IPython/frontend/qt/console/frontend_widget.py
+++ b/IPython/frontend/qt/console/frontend_widget.py
@@ -178,7 +178,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
     def copy(self):
         """ Copy the currently selected text to the clipboard, removing prompts.
         """
-        if self._page_control.hasFocus():
+        if self._page_control is not None and self._page_control.hasFocus():
             self._page_control.copy()
         elif self._control.hasFocus():
             text = self._control.textCursor().selection().toPlainText()


### PR DESCRIPTION
- The absence of a pager was generating an ugly traceback when
  trying to copy text and no pager was created.
- This issue was reported by a Spyder user because all tracebacks
  appear in its internal console, and this one was breaking his workflow.
