### PR TITLE
minor notebook startup/notebook-dir adjustments

### DIFF
--- a/IPython/frontend/html/notebook/clustermanager.py
+++ b/IPython/frontend/html/notebook/clustermanager.py
@@ -80,7 +80,7 @@ class ClusterManager(LoggingConfigurable):
             for profile in list_profiles_in(path):
                 pd = self.get_profile_dir(profile, path)
                 if profile not in self.profiles:
-                    self.log.debug("Overwriting profile %s" % profile)
+                    self.log.debug("Adding cluster profile '%s'" % profile)
                     self.profiles[profile] = {
                         'profile': profile,
                         'profile_dir': pd,

--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -330,8 +330,9 @@ class MainKernelHandler(AuthenticatedHandler):
     @web.authenticated
     def post(self):
         km = self.application.kernel_manager
+        nbm = self.application.notebook_manager
         notebook_id = self.get_argument('notebook', default=None)
-        kernel_id = km.start_kernel(notebook_id)
+        kernel_id = km.start_kernel(notebook_id, cwd=nbm.notebook_dir)
         data = {'ws_url':self.ws_url,'kernel_id':kernel_id}
         self.set_header('Location', '/'+kernel_id)
         self.finish(jsonapi.dumps(data))

--- a/IPython/frontend/html/notebook/kernelmanager.py
+++ b/IPython/frontend/html/notebook/kernelmanager.py
@@ -245,7 +245,7 @@ class MappingKernelManager(MultiKernelManager):
         if notebook_id is not None:
             del self._notebook_mapping[notebook_id]
 
-    def start_kernel(self, notebook_id=None):
+    def start_kernel(self, notebook_id=None, **kwargs):
         """Start a kernel for a notebok an return its kernel_id.
 
         Parameters
@@ -257,7 +257,6 @@ class MappingKernelManager(MultiKernelManager):
         """
         kernel_id = self.kernel_for_notebook(notebook_id)
         if kernel_id is None:
-            kwargs = dict()
             kwargs['extra_arguments'] = self.kernel_argv
             kernel_id = super(MappingKernelManager, self).start_kernel(**kwargs)
             self.set_kernel_for_notebook(notebook_id, kernel_id)

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -396,8 +396,13 @@ class NotebookApp(BaseIPythonApplication):
         self.kernel_argv.append("--KernelApp.parent_appname='%s'"%self.name)
 
         if self.extra_args:
-            self.file_to_run = os.path.abspath(self.extra_args[0])
-            self.config.NotebookManager.notebook_dir = os.path.dirname(self.file_to_run)
+            f = os.path.abspath(self.extra_args[0])
+            if os.path.isdir(f):
+                nbdir = f
+            else:
+                self.file_to_run = f
+                nbdir = os.path.dirname(f)
+            self.config.NotebookManager.notebook_dir = nbdir
 
     def init_configurables(self):
         # force Session default to be secure
@@ -408,6 +413,7 @@ class NotebookApp(BaseIPythonApplication):
             connection_dir = self.profile_dir.security_dir,
         )
         self.notebook_manager = NotebookManager(config=self.config, log=self.log)
+        self.log.info("Serving notebooks from %s", self.notebook_manager.notebook_dir)
         self.notebook_manager.list_notebooks()
         self.cluster_manager = ClusterManager(config=self.config, log=self.log)
         self.cluster_manager.update_profiles()
@@ -544,7 +550,7 @@ class NotebookApp(BaseIPythonApplication):
              (proto, ip, self.port,self.base_project_url) )
         info("Use Control-C to stop this server and shut down all kernels.")
 
-        if self.open_browser:
+        if self.open_browser or self.file_to_run:
             ip = self.ip or '127.0.0.1'
             if self.browser:
                 browser = webbrowser.get(self.browser)

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -407,7 +407,6 @@ class NotebookApp(BaseIPythonApplication):
     def init_configurables(self):
         # force Session default to be secure
         default_secure(self.config)
-        # Create a KernelManager and start a kernel.
         self.kernel_manager = MappingKernelManager(
             config=self.config, log=self.log, kernel_argv=self.kernel_argv,
             connection_dir = self.profile_dir.security_dir,

--- a/IPython/frontend/html/notebook/notebookmanager.py
+++ b/IPython/frontend/html/notebook/notebookmanager.py
@@ -26,7 +26,7 @@ from tornado import web
 
 from IPython.config.configurable import LoggingConfigurable
 from IPython.nbformat import current
-from IPython.utils.traitlets import Unicode, List, Dict, Bool
+from IPython.utils.traitlets import Unicode, List, Dict, Bool, TraitError
 
 #-----------------------------------------------------------------------------
 # Classes
@@ -37,6 +37,16 @@ class NotebookManager(LoggingConfigurable):
     notebook_dir = Unicode(os.getcwdu(), config=True, help="""
         The directory to use for notebooks.
     """)
+    def _notebook_dir_changed(self, name, old, new):
+        """do a bit of validation of the notebook dir"""
+        if os.path.exists(new) and not os.path.isdir(new):
+            raise TraitError("notebook dir %r is not a directory" % new)
+        if not os.path.exists(new):
+            self.log.info("Creating notebook dir %s", new)
+            try:
+                os.mkdir(new)
+            except:
+                raise TraitError("Couldn't create notebook dir %r" % new)
     
     save_script = Bool(False, config=True,
         help="""Automatically create a Python script when saving the notebook.

--- a/IPython/frontend/html/notebook/tests/test_nbmanager.py
+++ b/IPython/frontend/html/notebook/tests/test_nbmanager.py
@@ -1,0 +1,34 @@
+"""Tests for the notebook manager."""
+
+import os
+from unittest import TestCase
+from tempfile import NamedTemporaryFile
+
+from IPython.utils.tempdir import TemporaryDirectory
+from IPython.utils.traitlets import TraitError
+
+from IPython.frontend.html.notebook.notebookmanager import NotebookManager
+
+class TestNotebookManager(TestCase):
+
+    def test_nb_dir(self):
+        with TemporaryDirectory() as td:
+            km = NotebookManager(notebook_dir=td)
+            self.assertEquals(km.notebook_dir, td)
+
+    def test_create_nb_dir(self):
+        with TemporaryDirectory() as td:
+            nbdir = os.path.join(td, 'notebooks')
+            km = NotebookManager(notebook_dir=nbdir)
+            self.assertEquals(km.notebook_dir, nbdir)
+
+    def test_missing_nb_dir(self):
+        with TemporaryDirectory() as td:
+            nbdir = os.path.join(td, 'notebook', 'dir', 'is', 'missing')
+            self.assertRaises(TraitError, NotebookManager, notebook_dir=nbdir)
+
+    def test_invalid_nb_dir(self):
+        with NamedTemporaryFile() as tf:
+            self.assertRaises(TraitError, NotebookManager, notebook_dir=tf.name)
+
+

--- a/IPython/zmq/entry_point.py
+++ b/IPython/zmq/entry_point.py
@@ -89,7 +89,8 @@ def write_connection_file(fname=None, shell_port=0, iopub_port=0, stdin_port=0, 
     
 
 def base_launch_kernel(code, fname, stdin=None, stdout=None, stderr=None,
-                        executable=None, independent=False, extra_arguments=[]):
+                        executable=None, independent=False, extra_arguments=[],
+                        cwd=None):
     """ Launches a localhost kernel, binding to the specified ports.
 
     Parameters
@@ -115,8 +116,11 @@ def base_launch_kernel(code, fname, stdin=None, stdout=None, stderr=None,
         when this process dies. Note that in this case it is still good practice
         to kill kernels manually before exiting.
 
-    extra_arguments = list, optional
+    extra_arguments : list, optional
         A list of extra arguments to pass when executing the launch code.
+    
+    cwd : path, optional
+        The working dir of the kernel process (default: cwd of this process).
 
     Returns
     -------
@@ -190,10 +194,10 @@ def base_launch_kernel(code, fname, stdin=None, stdout=None, stderr=None,
     else:
         if independent:
             proc = Popen(arguments, preexec_fn=lambda: os.setsid(),
-                         stdin=_stdin, stdout=_stdout, stderr=_stderr)
+                         stdin=_stdin, stdout=_stdout, stderr=_stderr, cwd=cwd)
         else:
             proc = Popen(arguments + ['--parent=1'],
-                         stdin=_stdin, stdout=_stdout, stderr=_stderr)
+                         stdin=_stdin, stdout=_stdout, stderr=_stderr, cwd=cwd)
 
     # Clean up pipes created to work around Popen bug.
     if redirect_in:


### PR DESCRIPTION
- change inaccurate / distressing "Overwriting profile..." log message
- `ipython notebook path` results in setting notebook-dir if it's a dir,
  rather than unconditionally setting file-to-run
- file-to-run overrides no-browser
- kernels start in the notebook dir, rather than the Server's cwd

The last one is what I always expected, but never realized we didn't do,
because one usually starts the notebook with `ipython notebook` from
a particular location.

closes #1985
