### PR TITLE
avoid duplicate "Websockets closed" dialog on ws close

### DIFF
--- a/IPython/frontend/html/notebook/static/js/kernel.js
+++ b/IPython/frontend/html/notebook/static/js/kernel.js
@@ -98,8 +98,10 @@ var IPython = (function (IPython) {
             " or if the url does not look right, there could be an error in the" +
             " server's configuration.";
         } else {
- 	    this.start_channels();
- 	}
+            IPython.notification_widget.set_message('Reconnecting Websockets', 1000);
+            this.start_channels();
+            return;
+        }
         var dialog = $('<div/>');
         dialog.html(msg);
         parent_item.append(dialog);


### PR DESCRIPTION
Actual ws close (nb shutdown) would show the real message,
immediately followed by an empty dialog.

A reconnecting message is written to the notification area
when reconnect is attempted.
