### PR TITLE
allow multiple instances of a Magic

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -469,13 +469,19 @@ class Magics(object):
         # grab.  Only now, that the instance exists, can we create the proper
         # mapping to bound methods.  So we read the info off the original names
         # table and replace each method name by the actual bound method.
+        # But we mustn't clobber the *class* mapping, in case of multiple instances.
+        class_magics = self.magics
+        self.magics = {}
         for mtype in magic_kinds:
-            tab = self.magics[mtype]
-            # must explicitly use keys, as we're mutating this puppy
-            for magic_name in tab.keys():
-                meth_name = tab[magic_name]
+            tab = self.magics[mtype] = {}
+            cls_tab = class_magics[mtype]
+            for magic_name, meth_name in cls_tab.iteritems():
                 if isinstance(meth_name, basestring):
+                    # it's a method name, grab it
                     tab[magic_name] = getattr(self, meth_name)
+                else:
+                    # it's the real thing
+                    tab[magic_name] = meth_name
 
     def arg_err(self,func):
         """Print docstring if incorrect arguments were passed"""

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -711,3 +711,14 @@ def test_line_cell_info():
     nt.assert_true(oinfo['found'])
     nt.assert_true(oinfo['ismagic'])
     nt.assert_equals(oinfo['docstring'], FooFoo.line_foo.__doc__)
+
+def test_multiple_magics():
+    ip = get_ipython()
+    foo1 = FooFoo(ip)
+    foo2 = FooFoo(ip)
+    mm = ip.magics_manager
+    mm.register(foo1)
+    nt.assert_true(mm.magics['line']['foo'].im_self is foo1)
+    mm.register(foo2)
+    nt.assert_true(mm.magics['line']['foo'].im_self is foo2)
+    


### PR DESCRIPTION
as reported on-list, Magics were using a _class_ magics mapping, bound to the first instance, rather than creating a mapping for each instance.

This may have been by design, but it offers little-to-no benefit, and surprising unchangeable behavior in (admittedly unlikely) cases.
