### PR TITLE
fix for #1678, undo no longer clears cells

### DIFF
--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -267,6 +267,9 @@ var IPython = (function (IPython) {
         if (data.cell_type === 'code') {
             if (data.input !== undefined) {
                 this.set_text(data.input);
+                // make this value the starting point, so that we can only undo
+                // to this state, instead of a blank cell
+                this.code_mirror.clearHistory();
             }
             if (data.prompt_number !== undefined) {
                 this.set_input_prompt(data.prompt_number);

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -602,6 +602,9 @@ var IPython = (function (IPython) {
                     text = '';
                 }
                 target_cell.set_text(text);
+                // make this value the starting point, so that we can only undo
+                // to this state, instead of a blank cell
+                target_cell.code_mirror.clearHistory();
                 source_element.remove();
                 this.dirty = true;
             };
@@ -623,6 +626,9 @@ var IPython = (function (IPython) {
                 // The edit must come before the set_text.
                 target_cell.edit();
                 target_cell.set_text(text);
+                // make this value the starting point, so that we can only undo
+                // to this state, instead of a blank cell
+                target_cell.code_mirror.clearHistory();
                 source_element.remove();
                 this.dirty = true;
             };
@@ -645,6 +651,9 @@ var IPython = (function (IPython) {
                 // The edit must come before the set_text.
                 target_cell.edit();
                 target_cell.set_text(text);
+                // make this value the starting point, so that we can only undo
+                // to this state, instead of a blank cell
+                target_cell.code_mirror.clearHistory();
                 source_element.remove();
                 this.dirty = true;
             };
@@ -667,6 +676,9 @@ var IPython = (function (IPython) {
                 // The edit must come before the set_text.
                 target_cell.edit();
                 target_cell.set_text(text);
+                // make this value the starting point, so that we can only undo
+                // to this state, instead of a blank cell
+                target_cell.code_mirror.clearHistory();
                 source_element.remove();
                 this.dirty = true;
             };
@@ -693,6 +705,9 @@ var IPython = (function (IPython) {
                 target_cell.set_level(level);
                 target_cell.edit();
                 target_cell.set_text(text);
+                // make this value the starting point, so that we can only undo
+                // to this state, instead of a blank cell
+                target_cell.code_mirror.clearHistory();
                 source_element.remove();
                 this.dirty = true;
             };

--- a/IPython/frontend/html/notebook/static/js/textcell.js
+++ b/IPython/frontend/html/notebook/static/js/textcell.js
@@ -158,6 +158,9 @@ var IPython = (function (IPython) {
         if (data.cell_type === this.cell_type) {
             if (data.source !== undefined) {
                 this.set_text(data.source);
+                // make this value the starting point, so that we can only undo
+                // to this state, instead of a blank cell
+                this.code_mirror.clearHistory();
                 this.set_rendered(data.rendered || '');
                 this.rendered = false;
                 this.render();


### PR DESCRIPTION
With these changes, `Ctrl-Z` inside of codemirror cells will only undo up to the text that was in the cell when it was loaded from JSON. This fixes #1678.

I found another bug where switching the cell type causes the loss of all
undo history for that cell. With this commit, switching the cell type
simply resets the history to whatever it was at the time of the cell type switch.

For example, if a cell had contents changed from `X -> Y  -> Z`, and then you change the cell type, before this commit, its history becomes `Ø -> Z` (where Ø is just empty), so pressing `Ctrl-Z` once in a changed cell just erases all of it's contents. After this commit, the new cell's history just gets reset to `Z`
