### PR TITLE
fix another FreeBSD $HOME symlink issue

### DIFF
--- a/IPython/core/prompts.py
+++ b/IPython/core/prompts.py
@@ -137,6 +137,10 @@ def multiple_replace(dict, text):
 
 HOME = py3compat.str_to_unicode(os.environ.get("HOME","//////:::::ZZZZZ,,,~~~"))
 
+# This is needed on FreeBSD, and maybe other systems which symlink /home to
+# /usr/home, but retain the $HOME variable as pointing to /home
+HOME = os.path.realpath(HOME)
+
 # We precompute a few more strings here for the prompt_specials, which are
 # fixed once ipython starts.  This reduces the runtime overhead of computing
 # prompt strings.


### PR DESCRIPTION
without these changes, I get this error in `IPython.core` on FreeBSD 9.0

```
FAIL: test_cwd_x (IPython.core.tests.test_prompts.PromptTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/home/pi/code/ipython/IPython/core/tests/test_prompts.py", line 107, in test_cwd_x
    self.assertEquals(p, '~')
AssertionError: u'/usr~' != '~'
    "u'/usr~' != '~'" = '%s != %s' % (safe_repr(u'/usr~'), safe_repr('~'))
    "u'/usr~' != '~'" = self._formatMessage("u'/usr~' != '~'", "u'/usr~' != '~'")
>>  raise self.failureException("u'/usr~' != '~'")
```

I've verified that this change does not break any tests under Ubuntu when HOME happens to be symlinked.

I don't know how this will affect windows
