### PR TITLE
Allow path completion on notebook.

### DIFF
--- a/IPython/frontend/html/notebook/static/js/completer.js
+++ b/IPython/frontend/html/notebook/static/js/completer.js
@@ -104,7 +104,7 @@ var IPython = (function (IPython) {
 
         // we need to check that we are still on a word boundary
         // because while typing the completer is still reinvoking itself
-        if (!/[0-9a-z._]/i.test(pre_cursor)) {
+        if (!/[0-9a-z._/\\:~-]/i.test(pre_cursor)) {
             this.close();
             return;
         }


### PR DESCRIPTION
add -(dash) /(slash) (antislash for windows) : (colon) ~(tilde)
as part of words symbol for notebook completer to help for path
completion

Fixes #1969

@ivanov does it fixes all your issues ? do you see any more characters that should be added, or some that can cause any trouble ? 
