### PR TITLE
Clean BG processes created by %%script on kernel exit

### DIFF
--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -18,6 +18,7 @@ import sys
 import signal
 import time
 from subprocess import Popen, PIPE
+import atexit
 
 # Our own packages
 from IPython.config.configurable import Configurable
@@ -135,6 +136,7 @@ class ScriptMagics(Magics, Configurable):
         Magics.__init__(self, shell=shell)
         self.job_manager = BackgroundJobManager()
         self.bg_processes = []
+        atexit.register(self.kill_bg_processes)
 
     def __del__(self):
         self.kill_bg_processes()

--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -205,7 +205,7 @@ class ScriptMagics(Magics, Configurable):
                 self.shell.user_ns[args.out] = p.stdout
             if args.err:
                 self.shell.user_ns[args.err] = p.stderr
-            self.job_manager.new(self._run_script, p, cell)
+            self.job_manager.new(self._run_script, p, cell, daemon=True)
             if args.proc:
                 self.shell.user_ns[args.proc] = p
             return

--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -254,7 +254,12 @@ class ScriptMagics(Magics, Configurable):
         p.wait()
 
     @line_magic("killbgscripts")
-    def kill_bg_processes(self, dummy=None):
+    def killbgscripts(self, _nouse_=''):
+        """Kill all BG processes started by %%script and its family."""
+        self.kill_bg_processes()
+        print "All background processes were killed."
+
+    def kill_bg_processes(self):
         """Kill all BG processes which are still running."""
         for p in self.bg_processes:
             if p.poll() is None:

--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -203,6 +203,7 @@ class ScriptMagics(Magics, Configurable):
         cell = cell.encode('utf8', 'replace')
         if args.bg:
             self.bg_processes.append(p)
+            self._gc_bg_processes()
             if args.out:
                 self.shell.user_ns[args.out] = p.stdout
             if args.err:
@@ -281,3 +282,7 @@ class ScriptMagics(Magics, Configurable):
                     p.kill()
                 except:
                     pass
+        self._gc_bg_processes()
+
+    def _gc_bg_processes(self):
+        self.bg_processes = [p for p in self.bg_processes if p.poll() is None]

--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -251,7 +251,8 @@ class ScriptMagics(Magics, Configurable):
         p.stdin.close()
         p.wait()
 
-    def kill_bg_processes(self):
+    @line_magic("killbgscripts")
+    def kill_bg_processes(self, dummy=None):
         """Kill all BG processes which are still running."""
         for p in self.bg_processes:
             if p.poll() is None:

--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -344,7 +344,7 @@ class KernelHandler(AuthenticatedHandler):
     @web.authenticated
     def delete(self, kernel_id):
         km = self.application.kernel_manager
-        km.kill_kernel(kernel_id)
+        km.shutdown_kernel(kernel_id)
         self.set_status(204)
         self.finish()
 

--- a/IPython/frontend/html/notebook/kernelmanager.py
+++ b/IPython/frontend/html/notebook/kernelmanager.py
@@ -43,7 +43,7 @@ class MultiKernelManager(LoggingConfigurable):
     """A class for managing multiple kernels."""
     
     kernel_manager_class = DottedObjectName(
-        "IPython.zmq.kernelmanager.KernelManager", config=True,
+        "IPython.zmq.blockingkernelmanager.BlockingKernelManager", config=True,
         help="""The kernel manager class.  This is configurable to allow
         subclassing of the KernelManager for customized behavior.
         """
@@ -87,6 +87,8 @@ class MultiKernelManager(LoggingConfigurable):
                     config=self.config,
         )
         km.start_kernel(**kwargs)
+        # start the shell channel, needed for graceful restart
+        km.start_channels(shell=True, sub=False, stdin=False, hb=False)
         self._kernels[kernel_id] = km
         return kernel_id
 
@@ -284,7 +286,7 @@ class MappingKernelManager(MultiKernelManager):
         """Restart a kernel while keeping clients connected."""
         self._check_kernel_id(kernel_id)
         km = self.get_kernel(kernel_id)
-        km.restart_kernel(now=True)
+        km.restart_kernel()
         self.log.info("Kernel restarted: %s" % kernel_id)
         return kernel_id
         

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -532,9 +532,9 @@ class NotebookApp(BaseIPythonApplication):
         """
         self.log.info('Shutting down kernels')
         km = self.kernel_manager
-        # copy list, since kill_kernel deletes keys
+        # copy list, since shutdown_kernel deletes keys
         for kid in list(km.kernel_ids):
-            km.kill_kernel(kid)
+            km.shutdown_kernel(kid)
 
     def start(self):
         ip = self.ip if self.ip else '[all ip addresses on your system]'

--- a/IPython/lib/backgroundjobs.py
+++ b/IPython/lib/backgroundjobs.py
@@ -140,6 +140,8 @@ class BackgroundJobManager(object):
         In both cases, the result is stored in the job.result field of the
         background job object.
 
+        You can set `daemon` attribute of the thread by giving the keyword
+        argument `daemon`.
 
         Notes and caveats:
 
@@ -181,7 +183,9 @@ class BackgroundJobManager(object):
             job = BackgroundJobExpr(func_or_exp, glob, loc)
         else:
             raise TypeError('invalid args for new job')
-        
+
+        if kwargs.get('daemon', False):
+            job.daemon = True
         job.num = len(self.all)+1 if self.all else 0
         self.running.append(job)
         self.all[job.num] = job


### PR DESCRIPTION
This patch does not work yet because `__del__` method is not guaranteed to be called on exit.  Are there any hook in kernel which is called when the kernel exits?
