### PR TITLE
Print View

### DIFF
--- a/IPython/frontend/html/notebook/static/css/printnotebook.css
+++ b/IPython/frontend/html/notebook/static/css/printnotebook.css
@@ -2,4 +2,6 @@ body { overflow: visible !important; }
 div#notebook { overflow: visible !important; }
 .ui-widget-content { border: 0px; }
 #save_widget {margin: 0px !important;}
-#header {display: none !important;}
+#header,#pager,#pager_splitter,#menubar,#toolbar {display: none !important;}
+.cell { border:none !important}
+

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -19,6 +19,8 @@ window.mathjax_url = "{{mathjax_url}}";
 <link rel="stylesheet" href="{{ static_url("css/tooltip.css") }}" type="text/css" />
 <link rel="stylesheet" href="{{ static_url("css/renderedhtml.css") }}" type="text/css" />
 
+<link rel="stylesheet" href="{{ static_url("css/printnotebook.css") }}" type="text/css" media="print"/>
+
 {% end %}
 
 


### PR DESCRIPTION
replace 'Print view' by switching to a print 'layout' only in JS/css.

Pager/header/menubar/(...) fade away, trigger print dialog, then fade back. 

The print layout is still editable, but then it makes almost sens as it is the same page as a normal page. 
Is also allow to print unsaved version of the notebook, preventing sending data to get them back.

The animation are superfluous, doing a real `file>print` also works in hidding all the pager and menubar.

Still work in read-only mode

And we don't have to edit two templates in parallel.
