### PR TITLE
frontend test tweaks

### DIFF
--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -93,7 +93,7 @@ def test_history():
             # Cross testing: check that magic %save can get previous session.
             testfilename = os.path.realpath(os.path.join(tmpdir, "test.py"))
             ip.magic("save " + testfilename + " ~1/1-3")
-            with py3compat.open(testfilename) as testfile:
+            with py3compat.open(testfilename, encoding='utf-8') as testfile:
                 nt.assert_equal(testfile.read(),
                                         u"# coding: utf-8\n" + u"\n".join(hist))
 

--- a/IPython/frontend/terminal/console/tests/test_console.py
+++ b/IPython/frontend/terminal/console/tests/test_console.py
@@ -44,16 +44,16 @@ def test_console_starts():
         raise SkipTest("Could not determine ipython command")
     
     p = pexpect.spawn(ipython_cmd, args=['console', '--colors=NoColor'])
-    idx = p.expect([r'In \[\d+\]', pexpect.EOF], timeout=4)
+    idx = p.expect([r'In \[\d+\]', pexpect.EOF], timeout=15)
     nt.assert_equals(idx, 0, "expected in prompt")
     p.sendline('5')
-    idx = p.expect([r'Out\[\d+\]: 5', pexpect.EOF], timeout=1)
+    idx = p.expect([r'Out\[\d+\]: 5', pexpect.EOF], timeout=5)
     nt.assert_equals(idx, 0, "expected out prompt")
-    idx = p.expect([r'In \[\d+\]', pexpect.EOF], timeout=1)
+    idx = p.expect([r'In \[\d+\]', pexpect.EOF], timeout=5)
     nt.assert_equals(idx, 0, "expected second in prompt")
     # send ctrl-D;ctrl-D to exit
     p.sendeof()
     p.sendeof()
-    p.expect([pexpect.EOF, pexpect.TIMEOUT], timeout=1)
+    p.expect([pexpect.EOF, pexpect.TIMEOUT], timeout=5)
     if p.isalive():
         p.terminate()

--- a/IPython/frontend/terminal/tests/test_interactivshell.py
+++ b/IPython/frontend/terminal/tests/test_interactivshell.py
@@ -19,6 +19,7 @@ Authors
 import unittest
 
 from IPython.testing.decorators import skipif
+from IPython.utils import py3compat
 
 class InteractiveShellTestCase(unittest.TestCase):
     def rl_hist_entries(self, rl, n):
@@ -124,7 +125,10 @@ class InteractiveShellTestCase(unittest.TestCase):
         self.assertEquals(ip.readline.get_current_history_length(),
                           hlen_b4_cell)
         hist = self.rl_hist_entries(ip.readline, 3)
-        self.assertEquals(hist, ['line0', 'l€ne1\nline2', 'l€ne3\nline4'])
+        expected = [u'line0', u'l€ne1\nline2', u'l€ne3\nline4']
+        # perform encoding, in case of casting due to ASCII locale
+        expected = [ py3compat.unicode_to_str(e) for e in expected ]
+        self.assertEquals(hist, expected)
 
 
     @skipif(not get_ipython().has_readline, 'no readline')
@@ -158,4 +162,7 @@ class InteractiveShellTestCase(unittest.TestCase):
                           hlen_b4_cell)
         hist = self.rl_hist_entries(ip.readline, 4)
         # expect no empty cells in history
-        self.assertEquals(hist, ['line0', 'l€ne1\nline2', 'l€ne3', 'line4'])
+        expected = [u'line0', u'l€ne1\nline2', u'l€ne3', u'line4']
+        # perform encoding, in case of casting due to ASCII locale
+        expected = [ py3compat.unicode_to_str(e) for e in expected ]
+        self.assertEquals(hist, expected)

--- a/IPython/utils/sysinfo.py
+++ b/IPython/utils/sysinfo.py
@@ -23,7 +23,7 @@ import subprocess
 from ConfigParser import ConfigParser
 
 from IPython.core import release
-from IPython.utils import py3compat, _sysinfo
+from IPython.utils import py3compat, _sysinfo, encoding
 
 #-----------------------------------------------------------------------------
 # Code
@@ -91,6 +91,7 @@ def pkg_info(pkg_path):
         sys_platform=sys.platform,
         platform=platform.platform(),
         os_name=os.name,
+        default_encoding=encoding.DEFAULT_ENCODING,
         )
 
 


### PR DESCRIPTION
add some encoding to readline history tests that would fail in casting locales (ascii), so that the expected output really matches what should happen.

also relaxes a few timeouts in another test, which were seen to fail while poking around, to avoid spurious failures.

closes #1589
