### PR TITLE
kernel.js consistency with generic IPython message format.

### DIFF
--- a/IPython/frontend/html/notebook/static/js/kernel.js
+++ b/IPython/frontend/html/notebook/static/js/kernel.js
@@ -36,13 +36,16 @@ var IPython = (function (IPython) {
 
 
     Kernel.prototype._get_msg = function (msg_type, content) {
+        var uuid = utils.uuid()
         var msg = {
             header : {
-                msg_id : utils.uuid(),
+                msg_id : uuid,
                 username : this.username,
                 session : this.session_id,
                 msg_type : msg_type
             },
+            msg_id : uuid,
+            msg_type : msg_type,
             content : content,
             parent_header : {}
         };


### PR DESCRIPTION
Messages sent by the notebook js currently only include the id and type in the header of the message, not the top level of the message. This is inconsistent with the documented generic message format found at http://ipython.org/ipython-doc/dev/development/messaging.html#general-message-format :

"A message's unique identifier and type are stored in the header but are also accessible at the top-level for convenience."

The inconsistency currently doesn't have any impact on the functionality of the ipython notebook, but could create issues for other people trying to use portions of the notebook's javascript files for managing an IPython kernel independent of the notebook, while also attempting to do other things with the generated messages.
