### PR TITLE
Refactor %magic into a lsmagic_docs API function.

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -340,6 +340,30 @@ class MagicsManager(Configurable):
         """
         return self.magics
 
+    def lsmagic_docs(self, brief=False, missing=''):
+        """Return dict of documentation of magic functions.
+
+        The return dict has the keys 'line' and 'cell', corresponding to the
+        two types of magics we support. Each value is a dict keyed by magic
+        name whose value is the function docstring. If a docstring is
+        unavailable, the value of `missing` is used instead.
+
+        If brief is True, only the first line of each docstring will be returned.
+        """
+        docs = {}
+        for m_type in self.magics:
+            m_docs = {}
+            for m_name, m_func in self.magics[m_type].iteritems():
+                if m_func.__doc__:
+                    if brief:
+                        m_docs[m_name] = m_func.__doc__.split('\n', 1)[0]
+                    else:
+                        m_docs[m_name] = m_func.__doc__.rstrip()
+                else:
+                    m_docs[m_name] = missing
+            docs[m_type] = m_docs
+        return docs
+
     def register(self, *magic_objects):
         """Register one or more instances of Magics.
 

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -101,8 +101,6 @@ class BasicMagics(Magics):
             return
         else:
             magic_docs = format_screen(magic_docs)
-        if mode == 'brief':
-            return magic_docs
 
         out = ["""
 IPython's 'magic' functions
@@ -294,7 +292,7 @@ Defaulting color scheme to 'NoColor'"""
     def quickref(self,arg):
         """ Show a quick reference sheet """
         from IPython.core.usage import quick_reference
-        qr = quick_reference + self.magic('-brief')
+        qr = quick_reference + self._magic_docs(brief=True)
         page.page(qr)
 
     @line_magic


### PR DESCRIPTION
From @fperez in #1999:

> @bfroehle, I think %magic -brief was added for doc generation at some point, which is obviously a bit of a hack, though I'm not totally sure anymore.
> 
> The right answer now would obviously be to move that functionality into the magics manager as an api call, and let the magic call be strictly for human-friendly use with direct printing.

I've added a `lsmagic_docs` method which returns a dictionary of magic function docstrings.  It optionally takes parameters `brief` (list only first line of the docstring) and `missing` (to use in lieu of an empty docstring).
