### PR TITLE
Add custom_control and custom_page_control variables to override the Qt widgets used by qtconsole

### DIFF
--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -997,7 +997,7 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
         """
         # Create the underlying control.
         if self.custom_control:
-            control = self.custom_control
+            control = self.custom_control()
         elif self.kind == 'plain':
             control = QtGui.QPlainTextEdit()
         elif self.kind == 'rich':
@@ -1036,7 +1036,7 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
         """ Creates and connects the underlying paging widget.
         """
         if self.custom_page_control:
-            control = self.custom_page_control
+            control = self.custom_page_control()
         elif self.kind == 'plain':
             control = QtGui.QPlainTextEdit()
         elif self.kind == 'rich':

--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -158,6 +158,13 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
     # widget (Ctrl+n, Ctrl+a, etc). Enable this if you want this widget to take
     # priority (when it has focus) over, e.g., window-level menu shortcuts.
     override_shortcuts = Bool(False)
+    
+    # ------ Custom Qt Widgets -------------------------------------------------
+    
+    # For other projects to easily override the Qt widgets used by the console
+    # (e.g. Spyder)
+    custom_control = None
+    custom_page_control = None
 
     #------ Signals ------------------------------------------------------------
 
@@ -989,7 +996,9 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
         """ Creates and connects the underlying text widget.
         """
         # Create the underlying control.
-        if self.kind == 'plain':
+        if self.custom_control:
+            control = self.custom_control
+        elif self.kind == 'plain':
             control = QtGui.QPlainTextEdit()
         elif self.kind == 'rich':
             control = QtGui.QTextEdit()
@@ -1026,7 +1035,9 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
     def _create_page_control(self):
         """ Creates and connects the underlying paging widget.
         """
-        if self.kind == 'plain':
+        if self.custom_page_control:
+            control = self.custom_page_control
+        elif self.kind == 'plain':
             control = QtGui.QPlainTextEdit()
         elif self.kind == 'rich':
             control = QtGui.QTextEdit()


### PR DESCRIPTION
- This will let other project to easily provide its own widgets
- Try to fix #1920
