### PR TITLE
In %magic help, remove duplicate aliases

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -25,7 +25,7 @@ from getopt import getopt, GetoptError
 from IPython.config.configurable import Configurable
 from IPython.core import oinspect
 from IPython.core.error import UsageError
-from IPython.core.inputsplitter import ESC_MAGIC
+from IPython.core.inputsplitter import ESC_MAGIC, ESC_MAGIC2
 from IPython.external.decorator import decorator
 from IPython.utils.ipstruct import Struct
 from IPython.utils.process import arg_split
@@ -47,6 +47,7 @@ magics = dict(line={}, cell={})
 
 magic_kinds = ('line', 'cell')
 magic_spec = ('line', 'cell', 'line_cell')
+magic_escapes = {'line': ESC_MAGIC, 'cell': ESC_MAGIC2}
 
 #-----------------------------------------------------------------------------
 # Utility classes and functions
@@ -353,12 +354,18 @@ class MagicsManager(Configurable):
         docs = {}
         for m_type in self.magics:
             m_docs = {}
+            escape = magic_escapes[m_type]
             for m_name, m_func in self.magics[m_type].iteritems():
-                if m_func.__doc__:
+                if hasattr(m_func, '_magic_alias'):
+                    doc = "Alias for `%s%s`." % (escape, m_func._magic_alias)
+                else:
+                    doc = m_func.__doc__
+
+                if doc:
                     if brief:
-                        m_docs[m_name] = m_func.__doc__.split('\n', 1)[0]
+                        m_docs[m_name] = doc.split('\n', 1)[0]
                     else:
-                        m_docs[m_name] = m_func.__doc__.rstrip()
+                        m_docs[m_name] = doc.rstrip()
                 else:
                     m_docs[m_name] = missing
             docs[m_type] = m_docs

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -135,16 +135,6 @@ class CodeMagics(Magics):
         return response_data['html_url']
 
     @line_magic
-    def loadpy(self, arg_s):
-        """Alias of `%load`
-
-        `%loadpy` has gained some flexibility and droped the requirement of a `.py`
-        extension. So it has been renamed simply into %load. You can look at
-        `%load`'s docstring for more info.
-        """
-        self.load(arg_s)
-
-    @line_magic
     def load(self, arg_s):
         """Load code into the current frontend.
 
@@ -187,6 +177,17 @@ class CodeMagics(Magics):
                 return
 
         self.shell.set_next_input(contents)
+
+    @line_magic
+    def loadpy(self, arg_s):
+        self.load(arg_s)
+
+    loadpy.__doc__ = load.__doc__ + """
+        `%loadpy` has gained some flexibility and droped the requirement of a `.py`
+        extension. So it has been renamed simply into %load. You can look at
+        `%load`'s docstring for more info.
+        """
+    loadpy._magic_alias = 'load'
 
     @staticmethod
     def _find_edit_target(shell, args, opts, last_call):

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -323,11 +323,6 @@ class CodeMagics(Magics):
         mfile.close()
         self.shell.user_ns[mname] = Macro(mvalue)
 
-    @line_magic
-    def ed(self, parameter_s=''):
-        """Alias to %edit."""
-        return self.edit(parameter_s)
-
     @skip_doctest
     @line_magic
     def edit(self, parameter_s='',last_call=['','']):
@@ -519,3 +514,8 @@ class CodeMagics(Magics):
                     return
                 else:
                     self.shell.showtraceback()
+    @line_magic
+    def ed(self, parameter_s=''):
+        return self.edit(parameter_s)
+    ed.__doc__ = edit.__doc__
+    ed._magic_alias = 'edit'

--- a/IPython/core/magics/history.py
+++ b/IPython/core/magics/history.py
@@ -193,6 +193,7 @@ class HistoryMagics(Magics):
         return self.history(arg)
 
     hist.__doc__ = history.__doc__
+    hist._magic_alias = 'history'
 
     @line_magic
     def rep(self, arg):
@@ -298,4 +299,4 @@ class HistoryMagics(Magics):
         self.rep(arg)
 
     recall.__doc__ = rep.__doc__
-
+    recall._magic_alias = 'rep'


### PR DESCRIPTION
This pull request removes duplicate aliases from `%magic` help, while still preserving the regular docstrings.

This means that `%ed?` and `%edit` both return usage instructions, but `%magic` returns:

```
%ed:
        Alias for `%edit`.
%edit:
        Bring up an editor and execute the resulting code.
...
```

To create an alias, you need only to set the `_magic_alias` attribute to the name of the primary magic function.

I've gone through and attempted to locate most aliases (`%ed`, `%loadpy`, `%hist`, `%recall`) and set this attribute.
