### PR TITLE
relax profile regex in notebook

### DIFF
--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -75,7 +75,7 @@ from IPython.utils import py3compat
 _kernel_id_regex = r"(?P<kernel_id>\w+-\w+-\w+-\w+-\w+)"
 _kernel_action_regex = r"(?P<action>restart|interrupt)"
 _notebook_id_regex = r"(?P<notebook_id>\w+-\w+-\w+-\w+-\w+)"
-_profile_regex = r"(?P<profile>[a-zA-Z0-9]+)"
+_profile_regex = r"(?P<profile>[^\/]+)" # there is almost no text that is invalid
 _cluster_action_regex = r"(?P<action>start|stop)"
 
 


### PR DESCRIPTION
Almost any text is a valid profile name, and the previous code only included ascii alphanumeric strings.

closes #2011
