### PR TITLE
Fixes for %paste with special transformations

### DIFF
--- a/IPython/core/tests/test_magic_terminal.py
+++ b/IPython/core/tests/test_magic_terminal.py
@@ -182,10 +182,24 @@ class PasteTestCase(TestCase):
     def test_paste_leading_commas(self):
         "Test multiline strings with leading commas"
         tm = ip.magics_manager.registry['TerminalMagics']
-        s = '''\                        
+        s = '''\
 a = """
 ,1,2,3
 """'''
         ip.user_ns.pop('foo', None)
         tm.store_or_execute(s, 'foo')
         nt.assert_in('foo', ip.user_ns)
+
+
+    def test_paste_trailing_question(self):
+        "Test pasting sources with trailing question marks"
+        tm = ip.magics_manager.registry['TerminalMagics']
+        s = '''\
+def funcfoo():
+   if True: #am i true?
+       return 'fooresult'
+'''
+        ip.user_ns.pop('funcfoo', None)
+        tm.store_or_execute(s, 'foosrc')
+        nt.assert_in('foosrc', ip.user_ns)
+        nt.assert_equals(ip.user_ns['funcfoo'](), 'fooresult')

--- a/IPython/core/tests/test_magic_terminal.py
+++ b/IPython/core/tests/test_magic_terminal.py
@@ -29,7 +29,7 @@ def check_cpaste(code, should_fail=False):
     """Execute code via 'cpaste' and ensure it was executed, unless
     should_fail is set.
     """
-    _ip.user_ns['code_ran'] = False
+    ip.user_ns['code_ran'] = False
 
     src = StringIO()
     if not hasattr(src, 'encoding'):
@@ -45,10 +45,10 @@ def check_cpaste(code, should_fail=False):
     try:
         context = tt.AssertPrints if should_fail else tt.AssertNotPrints
         with context("Traceback (most recent call last)"):
-                _ip.magic('cpaste')
+                ip.magic('cpaste')
 
         if not should_fail:
-            assert _ip.user_ns['code_ran']
+            assert ip.user_ns['code_ran']
     finally:
         sys.stdin = stdin_save
 
@@ -60,7 +60,7 @@ def test_cpaste():
     def runf():
         """Marker function: sets a flag when executed.
         """
-        _ip.user_ns['code_ran'] = True
+        ip.user_ns['code_ran'] = True
         return 'runf' # return string so '+ runf()' doesn't result in success
 
     tests = {'pass': ["runf()",
@@ -80,7 +80,7 @@ def test_cpaste():
     if not PY31:
         tests['fail'].append("++ runf()")
 
-    _ip.user_ns['runf'] = runf
+    ip.user_ns['runf'] = runf
 
     for code in tests['pass']:
         check_cpaste(code)

--- a/IPython/core/tests/test_magic_terminal.py
+++ b/IPython/core/tests/test_magic_terminal.py
@@ -179,3 +179,13 @@ class PasteTestCase(TestCase):
         nt.assert_equal(ip.user_ns['b'], 200)
         nt.assert_equal(out, code+"\n## -- End pasted text --\n")
 
+    def test_paste_leading_commas(self):
+        "Test multiline strings with leading commas"
+        tm = ip.magics_manager.registry['TerminalMagics']
+        s = '''\                        
+a = """
+,1,2,3
+"""'''
+        ip.user_ns.pop('foo', None)
+        tm.store_or_execute(s, 'foo')
+        nt.assert_in('foo', ip.user_ns)

--- a/IPython/core/tests/test_magic_terminal.py
+++ b/IPython/core/tests/test_magic_terminal.py
@@ -10,10 +10,16 @@ from __future__ import absolute_import
 
 import sys
 from StringIO import StringIO
+from unittest import TestCase
 
 import nose.tools as nt
 
 from IPython.testing import tools as tt
+
+#-----------------------------------------------------------------------------
+# Globals
+#-----------------------------------------------------------------------------
+ip = get_ipython()
 
 #-----------------------------------------------------------------------------
 # Test functions begin
@@ -84,87 +90,92 @@ def test_cpaste():
         check_cpaste(code, should_fail=True)
 
 
-# Multiple tests for clipboard pasting
-def test_paste():
-    _ip = get_ipython()
+class PasteTestCase(TestCase):
+    """Multiple tests for clipboard pasting"""
 
-    def paste(txt, flags='-q'):
+    def paste(self, txt, flags='-q'):
         """Paste input text, by default in quiet mode"""
-        hooks.clipboard_get = lambda : txt
-        _ip.magic('paste '+flags)
+        ip.hooks.clipboard_get = lambda : txt
+        ip.magic('paste '+flags)
 
-    # Inject fake clipboard hook but save original so we can restore it later
-    hooks = _ip.hooks
-    user_ns = _ip.user_ns
-    original_clip = hooks.clipboard_get
+    def setUp(self):
+        # Inject fake clipboard hook but save original so we can restore it later
+        self.original_clip = ip.hooks.clipboard_get
 
-    try:
-        # Run tests with fake clipboard function
-        user_ns.pop('x', None)
-        paste('x=1')
-        nt.assert_equal(user_ns['x'], 1)
+    def tearDown(self): 
+        # Restore original hook
+        ip.hooks.clipboard_get = self.original_clip
+       
+    def test_paste(self):
+        ip.user_ns.pop('x', None)
+        self.paste('x=1')
+        nt.assert_equal(ip.user_ns['x'], 1)
 
-        user_ns.pop('x', None)
-        paste('>>> x=2')
-        nt.assert_equal(user_ns['x'], 2)
+    def test_paste_pyprompt(self):
+        ip.user_ns.pop('x', None)
+        self.paste('>>> x=2')
+        nt.assert_equal(ip.user_ns['x'], 2)
 
-        paste("""
+    def test_paste_py_multi(self):
+        self.paste("""
         >>> x = [1,2,3]
         >>> y = []
         >>> for i in x:
         ...     y.append(i**2)
         ...
         """)
-        nt.assert_equal(user_ns['x'], [1,2,3])
-        nt.assert_equal(user_ns['y'], [1,4,9])
+        nt.assert_equal(ip.user_ns['x'], [1,2,3])
+        nt.assert_equal(ip.user_ns['y'], [1,4,9])
 
-        # Now, test that paste -r works
-        user_ns.pop('x', None)
-        nt.assert_false('x' in user_ns)
-        _ip.magic('paste -r')
-        nt.assert_equal(user_ns['x'], [1,2,3])
+    def test_paste_py_multi_r(self):
+        "Now, test that self.paste -r works"
+        ip.user_ns.pop('x', None)
+        nt.assert_false('x' in ip.user_ns)
+        ip.magic('paste -r')
+        nt.assert_equal(ip.user_ns['x'], [1,2,3])
 
-        # Test pasting of email-quoted contents
-        paste("""
+    def test_paste_email(self):
+        "Test pasting of email-quoted contents"
+        self.paste("""
         >> def foo(x):
         >>     return x + 1
         >> x = foo(1.1)
         """)
-        nt.assert_equal(user_ns['x'], 2.1)
+        nt.assert_equal(ip.user_ns['x'], 2.1)
 
-        # Email again; some programs add a space also at each quoting level
-        paste("""
+    def test_paste_email2(self):
+        "Email again; some programs add a space also at each quoting level"
+        self.paste("""
         > > def foo(x):
         > >     return x + 1
         > > x = foo(2.1)
         """)
-        nt.assert_equal(user_ns['x'], 3.1)
+        nt.assert_equal(ip.user_ns['x'], 3.1)
 
-        # Email quoting of interactive input
-        paste("""
+    def test_paste_email_py(self):
+        "Email quoting of interactive input"
+        self.paste("""
         >> >>> def f(x):
         >> ...   return x+1
         >> ...
         >> >>> x = f(2.5)
         """)
-        nt.assert_equal(user_ns['x'], 3.5)
+        nt.assert_equal(ip.user_ns['x'], 3.5)
 
-        # Also test paste echoing, by temporarily faking the writer
+    def test_paste_echo(self):
+        "Also test self.paste echoing, by temporarily faking the writer"
         w = StringIO()
-        writer = _ip.write
-        _ip.write = w.write
+        writer = ip.write
+        ip.write = w.write
         code = """
         a = 100
         b = 200"""
         try:
-            paste(code,'')
+            self.paste(code,'')
             out = w.getvalue()
         finally:
-            _ip.write = writer
-        nt.assert_equal(user_ns['a'], 100)
-        nt.assert_equal(user_ns['b'], 200)
+            ip.write = writer
+        nt.assert_equal(ip.user_ns['a'], 100)
+        nt.assert_equal(ip.user_ns['b'], 200)
         nt.assert_equal(out, code+"\n## -- End pasted text --\n")
 
-    finally:
-        # Restore original hook
-        hooks.clipboard_get = original_clip

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -29,6 +29,7 @@ except:
 
 from IPython.core.error import TryNext, UsageError
 from IPython.core.usage import interactive_usage, default_banner
+from IPython.core.inputsplitter import IPythonInputSplitter
 from IPython.core.interactiveshell import InteractiveShell, InteractiveShellABC
 from IPython.core.magic import Magics, magics_class, line_magic
 from IPython.testing.skipdoctest import skip_doctest
@@ -37,7 +38,7 @@ from IPython.utils import py3compat
 from IPython.utils.terminal import toggle_set_term_title, set_term_title
 from IPython.utils.process import abbrev_cwd
 from IPython.utils.warn import warn, error
-from IPython.utils.text import num_ini_spaces, SList
+from IPython.utils.text import num_ini_spaces, SList, strip_email_quotes
 from IPython.utils.traitlets import Integer, CBool, Unicode
 
 #-----------------------------------------------------------------------------
@@ -72,38 +73,90 @@ def get_pasted_lines(sentinel, l_input=py3compat.input):
             return
 
 
-def strip_email_quotes(raw_lines):
-    """ Strip email quotation marks at the beginning of each line.
-
-    We don't do any more input transofrmations here because the main shell's
-    prefiltering handles other cases.
-    """
-    lines = [re.sub(r'^\s*(\s?>)+', '', l) for l in raw_lines]
-    return '\n'.join(lines) + '\n'
-
-
 #------------------------------------------------------------------------
 # Terminal-specific magics
 #------------------------------------------------------------------------
 
 @magics_class
 class TerminalMagics(Magics):
+    def __init__(self, shell):
+        super(TerminalMagics, self).__init__(shell)
+        self.input_splitter = IPythonInputSplitter(input_mode='line')
 
+    def cleanup_input(block):
+        """Apply all possible IPython cleanups to an input block.
+
+        This means:
+
+        - remove any global leading whitespace (dedent)
+        - remove any email quotes ('>') if they are present in *all* lines
+        - apply all static inputsplitter transforms and break into sub-blocks
+        - apply prefilter() to each sub-block that is a single line.
+
+        Parameters
+        ----------
+        block : str
+          A possibly multiline input string of code.
+
+        Returns
+        -------
+        transformed block : str
+          The input, with all transformations above applied.
+        """
+        # We have to effectively implement client-side the loop that is done by
+        # the terminal frontend, and furthermore do it on a block that can
+        # possibly contain multiple statments pasted in one go.
+
+        # First, run the input through the block splitting code.  We should
+        # eventually make this a self-contained method in the inputsplitter.
+        isp = self.input_splitter
+        isp.reset()
+        b = textwrap.dedent(block)
+
+        # Remove email quotes first.  These must be consistently applied to
+        # *all* lines to be removed
+        b = strip_email_quotes(b)
+
+        # Split the input into independent sub-blocks so we can later do
+        # prefiltering (which must be done *only* to single-line inputs)
+        blocks = []
+        last_block = []
+        for line in b.splitlines():
+            isp.push(line)
+            last_block.append(line)
+            if not isp.push_accepts_more():
+                blocks.append(isp.source_reset())
+                last_block = []
+        if last_block:
+            blocks.append('\n'.join(last_block))
+
+        # Now, apply prefiltering to any one-line block to match the behavior
+        # of the interactive terminal
+        final_blocks = []
+        for block in blocks:
+            lines = block.splitlines()
+            if len(lines) == 1:
+                final_blocks.append(self.shell.prefilter(lines[0]))
+            else:
+                final_blocks.append(block)
+
+        # We now have the final version of the input code as a list of blocks,
+        # with all inputsplitter transformations applied and single-line blocks
+        # run through prefilter.  For further processing, turn into a single
+        # string as the rest of our apis use string inputs.
+        return '\n'.join(final_blocks)
+        
     def store_or_execute(self, block, name):
         """ Execute a block, or store it in a variable, per the user's request.
         """
-        # Dedent and prefilter so what we store matches what is executed by
-        # run_cell.
-        b = self.shell.prefilter(textwrap.dedent(block))
-
+        b = self.cleanup_input(block)
         if name:
-            # If storing it for further editing, run the prefilter on it
+            # If storing it for further editing
             self.shell.user_ns[name] = SList(b.splitlines())
             print "Block assigned to '%s'" % name
         else:
             self.shell.user_ns['pasted_block'] = b
             self.shell.run_cell(b)
-
 
     def rerun_pasted(self, name='pasted_block'):
         """ Rerun a previously pasted command.
@@ -170,14 +223,13 @@ class TerminalMagics(Magics):
           :--
           Hello world!
         """
-
         opts, name = self.parse_options(parameter_s, 'rs:', mode='string')
         if 'r' in opts:
             self.rerun_pasted()
             return
 
         sentinel = opts.get('s', '--')
-        block = strip_email_quotes(get_pasted_lines(sentinel))
+        block = '\n'.join(get_pasted_lines(sentinel))
         self.store_or_execute(block, name)
 
     @line_magic
@@ -197,7 +249,7 @@ class TerminalMagics(Magics):
 
         You can also pass a variable name as an argument, e.g. '%paste foo'.
         This assigns the pasted block to variable 'foo' as string, without
-        dedenting or executing it (preceding >>> and + is still stripped)
+        executing it (preceding >>> and + is still stripped).
 
         Options
         -------
@@ -217,8 +269,7 @@ class TerminalMagics(Magics):
             self.rerun_pasted()
             return
         try:
-            text = self.shell.hooks.clipboard_get()
-            block = strip_email_quotes(text.splitlines())
+            block = self.shell.hooks.clipboard_get()
         except TryNext as clipboard_exc:
             message = getattr(clipboard_exc, 'args')
             if message:

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -83,7 +83,7 @@ class TerminalMagics(Magics):
         super(TerminalMagics, self).__init__(shell)
         self.input_splitter = IPythonInputSplitter(input_mode='line')
 
-    def cleanup_input(block):
+    def cleanup_input(self, block):
         """Apply all possible IPython cleanups to an input block.
 
         This means:

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -138,3 +138,17 @@ def test_dollar_formatter():
     nt.assert_equals(s, "12 $HOME")
     s = f.format("${foo}", foo="HOME")
     nt.assert_equals(s, "$HOME")
+
+
+def test_strip_email():
+    src = """\
+        >> >>> def f(x):
+        >> ...   return x+1
+        >> ...
+        >> >>> zz = f(2.5)"""
+    cln = """\
+>>> def f(x):
+...   return x+1
+...
+>>> zz = f(2.5)"""
+    nt.assert_equals(text.strip_email_quotes(src), cln)

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -140,6 +140,16 @@ def test_dollar_formatter():
     nt.assert_equals(s, "$HOME")
 
 
+def test_long_substr():
+    data = ['hi']
+    nt.assert_equals(text.long_substr(data), 'hi')
+
+
+def test_long_substr2():
+    data = ['abc', 'abd', 'abf', 'ab']
+    nt.assert_equals(text.long_substr(data), 'ab')
+
+
 def test_strip_email():
     src = """\
         >> >>> def f(x):
@@ -151,4 +161,10 @@ def test_strip_email():
 ...   return x+1
 ... 
 >>> zz = f(2.5)"""
+    nt.assert_equals(text.strip_email_quotes(src), cln)
+
+
+def test_strip_email2():
+    src = '> > > list()'
+    cln = 'list()'
     nt.assert_equals(text.strip_email_quotes(src), cln)

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -144,11 +144,11 @@ def test_strip_email():
     src = """\
         >> >>> def f(x):
         >> ...   return x+1
-        >> ...
+        >> ... 
         >> >>> zz = f(2.5)"""
     cln = """\
 >>> def f(x):
 ...   return x+1
-...
+... 
 >>> zz = f(2.5)"""
     nt.assert_equals(text.strip_email_quotes(src), cln)

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -553,6 +553,8 @@ def long_substr(data):
             for j in range(len(data[0])-i+1):
                 if j > len(substr) and all(data[0][i:i+j] in x for x in data):
                     substr = data[0][i:i+j]
+    else:
+        substr = data[0]
     return substr
 
 

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -576,19 +576,19 @@ def strip_email_quotes(text):
         In [2]: strip_email_quotes('> > text')
         Out[2]: 'text'
 
-        In [3]: strip_email_quotes('> > text\n> > more')
-        Out[3]: 'text\nmore'
+        In [3]: strip_email_quotes('> > text\\n> > more')
+        Out[3]: 'text\\nmore'
 
     Note how only the common prefix that appears in all lines is stripped::
 
-        In [4]: strip_email_quotes('> > text\n> > more\n> more...')
-        Out[4]: '> text\n> more\nmore...'
+        In [4]: strip_email_quotes('> > text\\n> > more\\n> more...')
+        Out[4]: '> text\\n> more\\nmore...'
 
     So if any line has no quote marks ('>') , then none are stripped from any
     of them ::
     
-        In [5]: strip_email_quotes('> > text\n> > more\nlast different')
-        Out[5]: '> > text\n> > more\nlast different'
+        In [5]: strip_email_quotes('> > text\\n> > more\\nlast different')
+        Out[5]: '> > text\\n> > more\\nlast different'
     """
     lines = text.splitlines()
     matches = set()

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -488,6 +488,7 @@ def format_screen(strng):
     strng = par_re.sub('',strng)
     return strng
 
+
 def dedent(text):
     """Equivalent of textwrap.dedent that ignores unindented first line.
 
@@ -514,6 +515,7 @@ def dedent(text):
     rest = textwrap.dedent(rest)
     return '\n'.join([first, rest])
 
+
 def wrap_paragraphs(text, ncols=80):
     """Wrap multiple paragraphs to fit a specified width.
 
@@ -538,6 +540,39 @@ def wrap_paragraphs(text, ncols=80):
             p = textwrap.fill(p, ncols)
         out_ps.append(p)
     return out_ps
+
+
+def long_substr(data):
+    """Return the longest common substring in a list of strings.
+    
+    Credit: http://stackoverflow.com/questions/2892931/longest-common-substring-from-more-than-two-strings-python
+    """
+    substr = ''
+    if len(data) > 1 and len(data[0]) > 0:
+        for i in range(len(data[0])):
+            for j in range(len(data[0])-i+1):
+                if j > len(substr) and all(data[0][i:i+j] in x for x in data):
+                    substr = data[0][i:i+j]
+    return substr
+
+
+def strip_email_quotes(text):
+    """Strip leading email quotation characters ('>').
+    """
+    lines = text.splitlines()
+    matches = set()
+    for line in lines:
+        prefix = re.match(r'^(\s*>[ >]*)', line)
+        if prefix:
+            matches.add(prefix.group(1))
+        else:
+            break
+    else:
+        prefix = long_substr(list(matches))
+        if prefix:
+            strip = len(prefix)
+            text = '\n'.join([ ln[strip:] for ln in lines])
+    return text
 
 
 class EvalFormatter(Formatter):

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -560,6 +560,35 @@ def long_substr(data):
 
 def strip_email_quotes(text):
     """Strip leading email quotation characters ('>').
+
+    Removes any combination of leading '>' interspersed with whitespace that
+    appears *identically* in all lines of the input text.
+
+    Parameters
+    ----------
+    text : str
+
+    Examples
+    --------
+
+    Simple uses::
+
+        In [2]: strip_email_quotes('> > text')
+        Out[2]: 'text'
+
+        In [3]: strip_email_quotes('> > text\n> > more')
+        Out[3]: 'text\nmore'
+
+    Note how only the common prefix that appears in all lines is stripped::
+
+        In [4]: strip_email_quotes('> > text\n> > more\n> more...')
+        Out[4]: '> text\n> more\nmore...'
+
+    So if any line has no quote marks ('>') , then none are stripped from any
+    of them ::
+    
+        In [5]: strip_email_quotes('> > text\n> > more\nlast different')
+        Out[5]: '> > text\n> > more\nlast different'
     """
     lines = text.splitlines()
     matches = set()
@@ -600,6 +629,7 @@ class EvalFormatter(Formatter):
     def get_field(self, name, args, kwargs):
         v = eval(name, kwargs)
         return v, name
+
 
 @skip_doctest_py3
 class FullEvalFormatter(Formatter):
@@ -658,6 +688,7 @@ class FullEvalFormatter(Formatter):
 
         return u''.join(py3compat.cast_unicode(s) for s in result)
 
+
 @skip_doctest_py3
 class DollarFormatter(FullEvalFormatter):
     """Formatter allowing Itpl style $foo replacement, for names and attribute
@@ -700,10 +731,12 @@ class DollarFormatter(FullEvalFormatter):
 #-----------------------------------------------------------------------------
 # Utils to columnize a list of string
 #-----------------------------------------------------------------------------
+
 def _chunks(l, n):
     """Yield successive n-sized chunks from l."""
     for i in xrange(0, len(l), n):
         yield l[i:i+n]
+
 
 def _find_optimal(rlist , separator_size=2 , displaywidth=80):
     """Calculate optimal info to columnize a list of string"""
@@ -719,12 +752,14 @@ def _find_optimal(rlist , separator_size=2 , displaywidth=80):
             'columns_width' : chk
            }
 
+
 def _get_or_default(mylist, i, default=None):
     """return list item number, or default if don't exist"""
     if i >= len(mylist):
         return default
     else :
         return mylist[i]
+
 
 @skip_doctest
 def compute_item_matrix(items, empty=None, *args, **kwargs) :
@@ -782,6 +817,7 @@ def compute_item_matrix(items, empty=None, *args, **kwargs) :
     info = _find_optimal(map(len, items), *args, **kwargs)
     nrow, ncol = info['rows_numbers'], info['columns_numbers']
     return ([[ _get_or_default(items, c*nrow+i, default=empty) for c in range(ncol) ] for i in range(nrow) ], info)
+
 
 def columnize(items, separator='  ', displaywidth=80):
     """ Transform a list of strings into a single string with columns.


### PR DESCRIPTION
**NOTE: ready for review/merge**

I'm just creating the PR for now with one failing test, need to add a second failing test for the `?` case, and then actually fix things...

Fix the fact that we use prefilter too aggressively in `%paste`, which results in applying single-line transformations inside of strings and function definitions.

Closes #1258.
