### PR TITLE
Fix Windows pathname issue in 'odd encoding' test.

### DIFF
--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -246,5 +246,5 @@ tclass.py: deleting object: C-third
         """Check that files in odd encodings are accepted."""
         mydir = os.path.dirname(__file__)
         na = os.path.join(mydir, 'nonascii.py')
-        _ip.magic('run %s' % na)
+        _ip.magic('run "%s"' % na)
         tt.assert_equals(_ip.user_ns['u'], u'Ўт№Ф')


### PR DESCRIPTION
Fixes #2017
