### PR TITLE
don't check writability in test for get_home_dir when HOME is undefined

### DIFF
--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -159,9 +159,8 @@ def test_get_home_dir_4():
     """get_home_dir() still works if $HOME is not set"""
 
     if 'HOME' in env: del env['HOME']
-    # this should still succeed, but we don't know what the answer should be
-    home = path.get_home_dir(True)
-    nt.assert_true(path._writable_dir(home))
+    # this should still succeed, but we don't care what the answer is
+    home = path.get_home_dir(False)
 
 @with_environment
 def test_get_home_dir_5():


### PR DESCRIPTION
Some pathological environments such as gentoo sandboxes can give invalid results.

The code path is at least executed, but no values are checked.

closes #1998
