### PR TITLE
fix&test push/pull recarrays

### DIFF
--- a/IPython/parallel/tests/test_newserialized.py
+++ b/IPython/parallel/tests/test_newserialized.py
@@ -90,14 +90,14 @@ class CanningTestCase(TestCase):
         self.assertEquals(td, 'ndarray')
         md = ser1.getMetadata()
         self.assertEquals(md['shape'], a.shape)
-        self.assertEquals(md['dtype'], a.dtype.str)
+        self.assertEquals(md['dtype'], a.dtype)
         buff = ser1.getData()
         self.assertEquals(buff, buffer(a))
         s = ns.Serialized(buff, td, md)
         final = ns.unserialize(s)
         self.assertEquals(buffer(a), buffer(final))
         self.assertTrue((a==final).all())
-        self.assertEquals(a.dtype.str, final.dtype.str)
+        self.assertEquals(a.dtype, final.dtype)
         self.assertEquals(a.shape, final.shape)
         # test non-copying:
         a[2] = 1e9

--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -287,7 +287,7 @@ class TestView(ClusterTestCase, ParametricTestCase):
             (1, 'hi', 0.),
             (2**30, 'there', 2.5),
             (-99999, 'world', -12345.6789),
-        ], [('n', int), ('s', str), ('f', float)])
+        ], [('n', int), ('s', '|S10'), ('f', float)])
         
         view['RR'] = R
         R2 = view['RR']

--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -275,6 +275,30 @@ class TestView(ClusterTestCase, ParametricTestCase):
             C = view.apply_sync(lambda x:x, B)
             assert_array_equal(B,C)
     
+    @skip_without('numpy')
+    def test_push_pull_recarray(self):
+        """push/pull recarrays"""
+        import numpy
+        from numpy.testing.utils import assert_array_equal
+        
+        view = self.client[-1]
+        
+        R = numpy.array([
+            (1, 'hi', 0.),
+            (2**30, 'there', 2.5),
+            (-99999, 'world', -12345.6789),
+        ], [('n', int), ('s', str), ('f', float)])
+        
+        view['RR'] = R
+        R2 = view['RR']
+        
+        r_dtype, r_shape = view.apply_sync(interactive(lambda : (RR.dtype, RR.shape)))
+        self.assertEquals(r_dtype, R.dtype)
+        self.assertEquals(r_shape, R.shape)
+        self.assertEquals(R2.dtype, R.dtype)
+        self.assertEquals(R2.shape, R.shape)
+        assert_array_equal(R2, R)
+    
     def test_map(self):
         view = self.client[:]
         def f(x):

--- a/IPython/utils/newserialized.py
+++ b/IPython/utils/newserialized.py
@@ -110,7 +110,7 @@ class SerializeIt(object):
                 self.obj = numpy.ascontiguousarray(self.obj, dtype=None)
                 self.typeDescriptor = 'ndarray'
                 self.metadata = {'shape':self.obj.shape,
-                                 'dtype':self.obj.dtype.str}
+                                 'dtype':self.obj.dtype}
         elif isinstance(self.obj, bytes):
             self.typeDescriptor = 'bytes'
             self.metadata = {}


### PR DESCRIPTION
We were only pushing the dtype str for some reason,
which is totally wrong for recarrays.

closes #2033
