### PR TITLE
remove `ipython-qtconsole` gui-script

### DIFF
--- a/scripts/ipython_win_post_install.py
+++ b/scripts/ipython_win_post_install.py
@@ -113,10 +113,10 @@ def install():
     mkshortcut(python, 'IPython engine', link, cmd, workdir)
 
     link = pjoin(ip_start_menu, 'ipythonqt.lnk')
-    cmdbase = suffix(pjoin(scripts, 'ipython')) + '-qtconsole'
+    cmdbase = suffix(pjoin(scripts, 'ipython'))
     if have_setuptools:
-        cmdbase += '-script.pyw'
-    cmd = '"%s"' % cmdbase
+        cmdbase += '-script.py'
+    cmd = '"%s" qtconsole' % cmdbase
     mkshortcut(pythonw, 'IPython Qt Console', link, cmd, workdir)
 
     # FIXME: These below are commented out because we don't ship the html built

--- a/setupbase.py
+++ b/setupbase.py
@@ -318,9 +318,7 @@ def find_scripts(entry_points=False, suffix=''):
             'iptest%s = IPython.testing.iptest:main',
             'irunner%s = IPython.lib.irunner:main'
         ]]
-        gui_scripts = [s % suffix for s in [
-            'ipython%s-qtconsole = IPython.frontend.qt.console.qtconsoleapp:main',
-        ]]
+        gui_scripts = []
         scripts = dict(console_scripts=console_scripts, gui_scripts=gui_scripts)
     else:
         parallel_scripts = pjoin('IPython','parallel','scripts')


### PR DESCRIPTION
Always use `ipython qtconsole`

QtConsole entry in the Windows Start Menu is updated appropriately.

closes #1516
