### PR TITLE
increase auto-scroll threshold to 100 lines

### DIFF
--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -95,6 +95,9 @@ var IPython = (function (IPython) {
                 // Intercept escape at highest level to avoid closing 
                 // websocket connection with firefox
                 event.preventDefault();
+            } else if (event.which === key.SHIFT) {
+                // ignore shift keydown
+                return true;
             }
             if (event.which === key.UPARROW && !event.shiftKey) {
                 var cell = that.get_selected_cell();

--- a/IPython/frontend/html/notebook/static/js/outputarea.js
+++ b/IPython/frontend/html/notebook/static/js/outputarea.js
@@ -62,7 +62,7 @@ var IPython = (function (IPython) {
 
     OutputArea.prototype._should_scroll = function (lines) {
         if (!lines) {
-            lines = 50;
+            lines = 100;
         }
         // line-height from http://stackoverflow.com/questions/1185151
         var fontSize = this.element.css('font-size');


### PR DESCRIPTION
It is more important that we not be surprising or annoying than we auto-hide moderately long output.  The manual toggle is always available for intermediate outputs.

Also explicitly ignore shift keydown in our keycode handler, which prevented the sequence:

```
<ctrl> M <shift> o
```

from being recognized, as the shift keypress would reset the control-key state.
