### PR TITLE
Add a metadata attribute to messages

### DIFF
--- a/IPython/frontend/html/notebook/static/js/kernel.js
+++ b/IPython/frontend/html/notebook/static/js/kernel.js
@@ -351,7 +351,7 @@ var IPython = (function (IPython) {
         var reply = $.parseJSON(e.data);
         var content = reply.content;
         var msg_type = reply.header.msg_type;
-        var metadata = reply.metadata || {};
+        var metadata = reply.metadata;
         var callbacks = this.get_callbacks_for_msg(reply.parent_header.msg_id);
         if (msg_type !== 'status' && callbacks === undefined) {
             // Message not from one of this notebook's cells and there are no

--- a/IPython/frontend/html/notebook/static/js/kernel.js
+++ b/IPython/frontend/html/notebook/static/js/kernel.js
@@ -43,6 +43,7 @@ var IPython = (function (IPython) {
                 session : this.session_id,
                 msg_type : msg_type
             },
+            metadata : {},
             content : content,
             parent_header : {}
         };

--- a/IPython/frontend/html/notebook/static/js/kernel.js
+++ b/IPython/frontend/html/notebook/static/js/kernel.js
@@ -220,19 +220,19 @@ var IPython = (function (IPython) {
         //  'set_next_input': set_next_input_callback
         // }
         //
-        // The execute_reply_callback will be passed the content object of the execute_reply
+        // The execute_reply_callback will be passed the content and metadata objects of the execute_reply
         // message documented here:
         //
         // http://ipython.org/ipython-doc/dev/development/messaging.html#execute
         //
         // The output_callback will be passed msg_type ('stream','display_data','pyout','pyerr')
-        // of the output and the content and header objects of the PUB/SUB channel that contains the
+        // of the output and the content and metadata objects of the PUB/SUB channel that contains the
         // output:
         //
         // http://ipython.org/ipython-doc/dev/development/messaging.html#messages-on-the-pub-sub-socket
         //
         // The clear_output_callback will be passed a content object that contains
-        // stdout, stderr and other fields that are booleans, as well as the header object.
+        // stdout, stderr and other fields that are booleans, as well as the metadata object.
         //
         // The set_next_input_callback will be passed the text that should become the next
         // input cell.
@@ -313,12 +313,13 @@ var IPython = (function (IPython) {
         reply = $.parseJSON(e.data);
         var header = reply.header;
         var content = reply.content;
+        var metadata = reply.metadata;
         var msg_type = header.msg_type;
         var callbacks = this.get_callbacks_for_msg(reply.parent_header.msg_id);
         if (callbacks !== undefined) {
             var cb = callbacks[msg_type];
             if (cb !== undefined) {
-                cb(content);
+                cb(content, metadata);
             }
         };
 
@@ -347,10 +348,10 @@ var IPython = (function (IPython) {
 
 
     Kernel.prototype._handle_iopub_reply = function (e) {
-        reply = $.parseJSON(e.data);
+        var reply = $.parseJSON(e.data);
         var content = reply.content;
         var msg_type = reply.header.msg_type;
-        var header = reply.header;
+        var metadata = reply.metadata;
         var callbacks = this.get_callbacks_for_msg(reply.parent_header.msg_id);
         if (msg_type !== 'status' && callbacks === undefined) {
             // Message not from one of this notebook's cells and there are no
@@ -361,7 +362,7 @@ var IPython = (function (IPython) {
         if (output_types.indexOf(msg_type) >= 0) {
             var cb = callbacks['output'];
             if (cb !== undefined) {
-                cb(msg_type, content, header);
+                cb(msg_type, content, metadata);
             }
         } else if (msg_type === 'status') {
             if (content.execution_state === 'busy') {
@@ -375,7 +376,7 @@ var IPython = (function (IPython) {
         } else if (msg_type === 'clear_output') {
             var cb = callbacks['clear_output'];
             if (cb !== undefined) {
-                cb(content, header);
+                cb(content, metadata);
             }
         };
     };

--- a/IPython/frontend/html/notebook/static/js/kernel.js
+++ b/IPython/frontend/html/notebook/static/js/kernel.js
@@ -226,15 +226,15 @@ var IPython = (function (IPython) {
         // http://ipython.org/ipython-doc/dev/development/messaging.html#execute
         //
         // The output_callback will be passed msg_type ('stream','display_data','pyout','pyerr')
-        // of the output and the content object of the PUB/SUB channel that contains the
+        // of the output and the content and header objects of the PUB/SUB channel that contains the
         // output:
         //
         // http://ipython.org/ipython-doc/dev/development/messaging.html#messages-on-the-pub-sub-socket
         //
         // The clear_output_callback will be passed a content object that contains
-        // stdout, stderr and other fields that are booleans.
+        // stdout, stderr and other fields that are booleans, as well as the header object.
         //
-        // The set_next_input_callback will bepassed the text that should become the next
+        // The set_next_input_callback will be passed the text that should become the next
         // input cell.
 
         var content = {
@@ -350,6 +350,7 @@ var IPython = (function (IPython) {
         reply = $.parseJSON(e.data);
         var content = reply.content;
         var msg_type = reply.header.msg_type;
+        var header = reply.header;
         var callbacks = this.get_callbacks_for_msg(reply.parent_header.msg_id);
         if (msg_type !== 'status' && callbacks === undefined) {
             // Message not from one of this notebook's cells and there are no
@@ -360,7 +361,7 @@ var IPython = (function (IPython) {
         if (output_types.indexOf(msg_type) >= 0) {
             var cb = callbacks['output'];
             if (cb !== undefined) {
-                cb(msg_type, content);
+                cb(msg_type, content, header);
             }
         } else if (msg_type === 'status') {
             if (content.execution_state === 'busy') {
@@ -374,7 +375,7 @@ var IPython = (function (IPython) {
         } else if (msg_type === 'clear_output') {
             var cb = callbacks['clear_output'];
             if (cb !== undefined) {
-                cb(content);
+                cb(content, header);
             }
         };
     };

--- a/IPython/frontend/html/notebook/static/js/kernel.js
+++ b/IPython/frontend/html/notebook/static/js/kernel.js
@@ -351,7 +351,7 @@ var IPython = (function (IPython) {
         var reply = $.parseJSON(e.data);
         var content = reply.content;
         var msg_type = reply.header.msg_type;
-        var metadata = reply.metadata;
+        var metadata = reply.metadata || {};
         var callbacks = this.get_callbacks_for_msg(reply.parent_header.msg_id);
         if (msg_type !== 'status' && callbacks === undefined) {
             // Message not from one of this notebook's cells and there are no

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -650,12 +650,16 @@ class Client(HasTraits):
             e.engine_info['engine_id'] = eid
         return e
 
-    def _extract_metadata(self, header, parent, content):
+    def _extract_metadata(self, msg):
+        header = msg['header']
+        parent = msg['parent_header']
+        msg_meta = msg['metadata']
+        content = msg['content']
         md = {'msg_id' : parent['msg_id'],
               'received' : datetime.now(),
-              'engine_uuid' : header.get('engine', None),
-              'follow' : parent.get('follow', []),
-              'after' : parent.get('after', []),
+              'engine_uuid' : msg_meta.get('engine', None),
+              'follow' : msg_meta.get('follow', []),
+              'after' : msg_meta.get('after', []),
               'status' : content['status'],
             }
 
@@ -664,8 +668,8 @@ class Client(HasTraits):
 
         if 'date' in parent:
             md['submitted'] = parent['date']
-        if 'started' in header:
-            md['started'] = header['started']
+        if 'started' in msg_meta:
+            md['started'] = msg_meta['started']
         if 'date' in header:
             md['completed'] = header['date']
         return md
@@ -738,7 +742,7 @@ class Client(HasTraits):
 
         # construct metadata:
         md = self.metadata[msg_id]
-        md.update(self._extract_metadata(header, parent, content))
+        md.update(self._extract_metadata(msg))
         # is this redundant?
         self.metadata[msg_id] = md
         
@@ -775,7 +779,7 @@ class Client(HasTraits):
 
         # construct metadata:
         md = self.metadata[msg_id]
-        md.update(self._extract_metadata(header, parent, content))
+        md.update(self._extract_metadata(msg))
         # is this redundant?
         self.metadata[msg_id] = md
 
@@ -1201,7 +1205,7 @@ class Client(HasTraits):
 
         return result
 
-    def send_apply_request(self, socket, f, args=None, kwargs=None, subheader=None, track=False,
+    def send_apply_request(self, socket, f, args=None, kwargs=None, metadata=None, track=False,
                             ident=None):
         """construct and send an apply message via a socket.
 
@@ -1214,7 +1218,7 @@ class Client(HasTraits):
         # defaults:
         args = args if args is not None else []
         kwargs = kwargs if kwargs is not None else {}
-        subheader = subheader if subheader is not None else {}
+        metadata = metadata if metadata is not None else {}
 
         # validate arguments
         if not callable(f) and not isinstance(f, Reference):
@@ -1223,13 +1227,13 @@ class Client(HasTraits):
             raise TypeError("args must be tuple or list, not %s"%type(args))
         if not isinstance(kwargs, dict):
             raise TypeError("kwargs must be dict, not %s"%type(kwargs))
-        if not isinstance(subheader, dict):
-            raise TypeError("subheader must be dict, not %s"%type(subheader))
+        if not isinstance(metadata, dict):
+            raise TypeError("metadata must be dict, not %s"%type(metadata))
 
         bufs = util.pack_apply_message(f,args,kwargs)
 
         msg = self.session.send(socket, "apply_request", buffers=bufs, ident=ident,
-                            subheader=subheader, track=track)
+                            metadata=metadata, track=track)
 
         msg_id = msg['header']['msg_id']
         self.outstanding.add(msg_id)
@@ -1245,7 +1249,7 @@ class Client(HasTraits):
 
         return msg
 
-    def send_execute_request(self, socket, code, silent=True, subheader=None, ident=None):
+    def send_execute_request(self, socket, code, silent=True, metadata=None, ident=None):
         """construct and send an execute request via a socket.
 
         """
@@ -1254,19 +1258,19 @@ class Client(HasTraits):
             raise RuntimeError("Client cannot be used after its sockets have been closed")
         
         # defaults:
-        subheader = subheader if subheader is not None else {}
+        metadata = metadata if metadata is not None else {}
 
         # validate arguments
         if not isinstance(code, basestring):
             raise TypeError("code must be text, not %s" % type(code))
-        if not isinstance(subheader, dict):
-            raise TypeError("subheader must be dict, not %s" % type(subheader))
+        if not isinstance(metadata, dict):
+            raise TypeError("metadata must be dict, not %s" % type(metadata))
         
         content = dict(code=code, silent=bool(silent), user_variables=[], user_expressions={})
 
 
         msg = self.session.send(socket, "execute_request", content=content, ident=ident,
-                            subheader=subheader)
+                            metadata=metadata)
 
         msg_id = msg['header']['msg_id']
         self.outstanding.add(msg_id)
@@ -1401,7 +1405,7 @@ class Client(HasTraits):
         return ar
 
     @spin_first
-    def resubmit(self, indices_or_msg_ids=None, subheader=None, block=None):
+    def resubmit(self, indices_or_msg_ids=None, metadata=None, block=None):
         """Resubmit one or more tasks.
 
         in-flight tasks may not be resubmitted.
@@ -1539,7 +1543,13 @@ class Client(HasTraits):
                     rcontent = self.session.unpack(rcontent)
 
                 md = self.metadata[msg_id]
-                md.update(self._extract_metadata(header, parent, rcontent))
+                md_msg = dict(
+                    content=rcontent,
+                    parent_header=parent,
+                    header=header,
+                    metadata=rec['result_metadata'],
+                )
+                md.update(self._extract_metadata(md_msg))
                 if rec.get('received'):
                     md['received'] = rec['received']
                 md.update(iodict)

--- a/IPython/parallel/client/view.py
+++ b/IPython/parallel/client/view.py
@@ -1022,10 +1022,10 @@ class LoadBalancedView(View):
 
         after = self._render_dependency(after)
         follow = self._render_dependency(follow)
-        subheader = dict(after=after, follow=follow, timeout=timeout, targets=idents, retries=retries)
+        metadata = dict(after=after, follow=follow, timeout=timeout, targets=idents, retries=retries)
 
         msg = self.client.send_apply_request(self._socket, f, args, kwargs, track=track,
-                                subheader=subheader)
+                                metadata=metadata)
         tracker = None if track is False else msg['tracker']
 
         ar = AsyncResult(self.client, msg['header']['msg_id'], fname=getname(f), targets=None, tracker=tracker)

--- a/IPython/parallel/controller/sqlitedb.py
+++ b/IPython/parallel/controller/sqlitedb.py
@@ -109,6 +109,7 @@ class SQLiteDB(BaseDB):
     # the ordered list of column names
     _keys = List(['msg_id' ,
             'header' ,
+            'metadata',
             'content',
             'buffers',
             'submitted',
@@ -119,6 +120,7 @@ class SQLiteDB(BaseDB):
             'resubmitted',
             'received',
             'result_header' ,
+            'result_metadata',
             'result_content' ,
             'result_buffers' ,
             'queue' ,
@@ -131,6 +133,7 @@ class SQLiteDB(BaseDB):
     # sqlite datatypes for checking that db is current format
     _types = Dict({'msg_id' : 'text' ,
             'header' : 'dict text',
+            'metadata' : 'dict text',
             'content' : 'dict text',
             'buffers' : 'bufs blob',
             'submitted' : 'timestamp',
@@ -141,6 +144,7 @@ class SQLiteDB(BaseDB):
             'resubmitted' : 'text',
             'received' : 'timestamp',
             'result_header' : 'dict text',
+            'result_metadata' : 'dict text',
             'result_content' : 'dict text',
             'result_buffers' : 'bufs blob',
             'queue' : 'text',
@@ -240,6 +244,7 @@ class SQLiteDB(BaseDB):
         self._db.execute("""CREATE TABLE IF NOT EXISTS %s
                 (msg_id text PRIMARY KEY,
                 header dict text,
+                metadata dict text,
                 content dict text,
                 buffers bufs blob,
                 submitted timestamp,
@@ -250,6 +255,7 @@ class SQLiteDB(BaseDB):
                 resubmitted text,
                 received timestamp,
                 result_header dict text,
+                result_metadata dict text,
                 result_content dict text,
                 result_buffers bufs blob,
                 queue text,

--- a/IPython/zmq/iostream.py
+++ b/IPython/zmq/iostream.py
@@ -28,9 +28,14 @@ class OutStream(object):
         self.name = name
         self.parent_header = {}
         self._new_buffer()
+        self.metadata = {}
 
     def set_parent(self, parent):
         self.parent_header = extract_header(parent)
+
+    def set_metadata(self, metadata):
+        self.flush()
+        self.metadata = metadata
 
     def close(self):
         self.pub_socket = None
@@ -43,6 +48,8 @@ class OutStream(object):
             data = self._buffer.getvalue()
             if data:
                 content = {u'name':self.name, u'data':data}
+                if self.metadata:
+                    content['metadata'] = self.metadata
                 msg = self.session.send(self.pub_socket, u'stream', content=content,
                                        parent=self.parent_header, ident=self.topic)
 

--- a/IPython/zmq/iostream.py
+++ b/IPython/zmq/iostream.py
@@ -28,14 +28,9 @@ class OutStream(object):
         self.name = name
         self.parent_header = {}
         self._new_buffer()
-        self.metadata = {}
 
     def set_parent(self, parent):
         self.parent_header = extract_header(parent)
-
-    def set_metadata(self, metadata):
-        self.flush()
-        self.metadata = metadata
 
     def close(self):
         self.pub_socket = None
@@ -48,8 +43,6 @@ class OutStream(object):
             data = self._buffer.getvalue()
             if data:
                 content = {u'name':self.name, u'data':data}
-                if self.metadata:
-                    content['metadata'] = self.metadata
                 msg = self.session.send(self.pub_socket, u'stream', content=content,
                                        parent=self.parent_header, ident=self.topic)
 

--- a/IPython/zmq/session.py
+++ b/IPython/zmq/session.py
@@ -405,7 +405,7 @@ class Session(Configurable):
     def msg_header(self, msg_type):
         return msg_header(self.msg_id, msg_type, self.username, self.session)
 
-    def msg(self, msg_type, content=None, parent=None, subheader=None, header=None, metadata=None):
+    def msg(self, msg_type, content=None, parent=None, header=None, metadata=None):
         """Return the nested message dict.
 
         This format is different from what is sent over the wire. The
@@ -415,8 +415,6 @@ class Session(Configurable):
         msg = {}
         header = self.msg_header(msg_type) if header is None else header
         msg['header'] = header
-        if subheader is not None:
-            msg['header'].update(subheader)
         msg['msg_id'] = header['msg_id']
         msg['msg_type'] = header['msg_type']
         msg['parent_header'] = {} if parent is None else extract_header(parent)
@@ -499,7 +497,7 @@ class Session(Configurable):
         return to_send
 
     def send(self, stream, msg_or_type, content=None, parent=None, ident=None,
-             buffers=None, subheader=None, track=False, header=None, metadata=None):
+             buffers=None, track=False, header=None, metadata=None):
         """Build and send a message via stream or socket.
 
         The message format used by this function internally is as follows:
@@ -529,9 +527,6 @@ class Session(Configurable):
             (ignored if msg_or_type is a message).
         ident : bytes or list of bytes
             The zmq.IDENTITY routing path.
-        subheader : dict or None
-            Extra header keys for this message's header (ignored if msg_or_type
-            is a message).
         metadata : dict or None
             The metadata describing the message
         buffers : list or None
@@ -563,7 +558,7 @@ class Session(Configurable):
             msg = msg_or_type
         else:
             msg = self.msg(msg_or_type, content=content, parent=parent,
-                           subheader=subheader, header=header, metadata=metadata)
+                           header=header, metadata=metadata)
 
         buffers = [] if buffers is None else buffers
         to_send = self.serialize(msg, ident)
@@ -730,9 +725,9 @@ class Session(Configurable):
             if signature in self.digest_history:
                 raise ValueError("Duplicate Signature: %r"%signature)
             self.digest_history.add(signature)
-            check = self.sign(msg_list[1:4])
+            check = self.sign(msg_list[1:5])
             if not signature == check:
-                raise ValueError("Invalid Signature: %r"%signature)
+                raise ValueError("Invalid Signature: %r" % signature)
         if not len(msg_list) >= minlen:
             raise TypeError("malformed message, must have at least %i elements"%minlen)
         header = self.unpack(msg_list[1])

--- a/IPython/zmq/session.py
+++ b/IPython/zmq/session.py
@@ -49,7 +49,7 @@ from IPython.utils.importstring import import_item
 from IPython.utils.jsonutil import extract_dates, squash_dates, date_default
 from IPython.utils.py3compat import str_to_bytes
 from IPython.utils.traitlets import (CBytes, Unicode, Bool, Any, Instance, Set,
-                                        DottedObjectName, CUnicode)
+                                        DottedObjectName, CUnicode, Dict)
 
 #-----------------------------------------------------------------------------
 # utility functions
@@ -292,6 +292,9 @@ class Session(Configurable):
     username = Unicode(os.environ.get('USER',u'username'), config=True,
         help="""Username for the Session. Default is your system username.""")
 
+    subheader = Dict({}, config=True,
+        help="""Subheader dictionary, which serves as the default subheader fields for each message.""")
+
     # message signature related traits:
     
     key = CBytes(b'', config=True,
@@ -416,8 +419,9 @@ class Session(Configurable):
         msg['msg_type'] = header['msg_type']
         msg['parent_header'] = {} if parent is None else extract_header(parent)
         msg['content'] = {} if content is None else content
-        sub = {} if subheader is None else subheader
-        msg['header'].update(sub)
+        msg['header'].update(self.subheader)
+        if subheader is not None:
+            msg['header'].update(subheader)
         return msg
 
     def sign(self, msg_list):

--- a/IPython/zmq/session.py
+++ b/IPython/zmq/session.py
@@ -292,8 +292,8 @@ class Session(Configurable):
     username = Unicode(os.environ.get('USER',u'username'), config=True,
         help="""Username for the Session. Default is your system username.""")
 
-    subheader = Dict({}, config=True,
-        help="""Subheader dictionary, which serves as the default subheader fields for each message.""")
+    metadata = Dict({}, config=True,
+        help="""Metadata dictionary, which serves as the default top-level metadata dict for each message.""")
 
     # message signature related traits:
     
@@ -405,7 +405,7 @@ class Session(Configurable):
     def msg_header(self, msg_type):
         return msg_header(self.msg_id, msg_type, self.username, self.session)
 
-    def msg(self, msg_type, content=None, parent=None, subheader=None, header=None):
+    def msg(self, msg_type, content=None, parent=None, subheader=None, header=None, metadata=None):
         """Return the nested message dict.
 
         This format is different from what is sent over the wire. The
@@ -415,13 +415,17 @@ class Session(Configurable):
         msg = {}
         header = self.msg_header(msg_type) if header is None else header
         msg['header'] = header
+        if subheader is not None:
+            msg['header'].update(subheader)
         msg['msg_id'] = header['msg_id']
         msg['msg_type'] = header['msg_type']
         msg['parent_header'] = {} if parent is None else extract_header(parent)
         msg['content'] = {} if content is None else content
-        msg['header'].update(self.subheader)
-        if subheader is not None:
-            msg['header'].update(subheader)
+        metadata_dict = self.metadata.copy()
+        if metadata is not None:
+            metadata_dict.update(metadata)
+        if metadata_dict:
+            msg['metadata'] = metadata_dict
         return msg
 
     def sign(self, msg_list):
@@ -496,7 +500,7 @@ class Session(Configurable):
         return to_send
 
     def send(self, stream, msg_or_type, content=None, parent=None, ident=None,
-             buffers=None, subheader=None, track=False, header=None):
+             buffers=None, subheader=None, track=False, header=None, metadata=None):
         """Build and send a message via stream or socket.
 
         The message format used by this function internally is as follows:
@@ -520,7 +524,7 @@ class Session(Configurable):
         content : dict or None
             The content of the message (ignored if msg_or_type is a message).
         header : dict or None
-            The header dict for the message (ignores if msg_to_type is a message).
+            The header dict for the message (ignored if msg_to_type is a message).
         parent : Message or dict or None
             The parent or parent header describing the parent of this message
             (ignored if msg_or_type is a message).
@@ -529,11 +533,14 @@ class Session(Configurable):
         subheader : dict or None
             Extra header keys for this message's header (ignored if msg_or_type
             is a message).
+        metadata : dict or None
+            The metadata describing the message
         buffers : list or None
             The already-serialized buffers to be appended to the message.
         track : bool
             Whether to track.  Only for use with Sockets, because ZMQStream
             objects cannot track messages.
+            
 
         Returns
         -------
@@ -557,7 +564,7 @@ class Session(Configurable):
             msg = msg_or_type
         else:
             msg = self.msg(msg_or_type, content=content, parent=parent,
-                           subheader=subheader, header=header)
+                           subheader=subheader, header=header, metadata=metadata)
 
         buffers = [] if buffers is None else buffers
         to_send = self.serialize(msg, ident)

--- a/IPython/zmq/tests/test_session.py
+++ b/IPython/zmq/tests/test_session.py
@@ -47,10 +47,11 @@ class TestSession(SessionTestCase):
     def test_msg(self):
         """message format"""
         msg = self.session.msg('execute')
-        thekeys = set('header parent_header content msg_type msg_id'.split())
+        thekeys = set('header parent_header metadata content msg_type msg_id'.split())
         s = set(msg.keys())
         self.assertEqual(s, thekeys)
         self.assertTrue(isinstance(msg['content'],dict))
+        self.assertTrue(isinstance(msg['metadata'],dict))
         self.assertTrue(isinstance(msg['header'],dict))
         self.assertTrue(isinstance(msg['parent_header'],dict))
         self.assertTrue(isinstance(msg['msg_id'],str))
@@ -69,6 +70,7 @@ class TestSession(SessionTestCase):
         self.assertEqual(new_msg['header'],msg['header'])
         self.assertEqual(new_msg['content'],msg['content'])
         self.assertEqual(new_msg['parent_header'],msg['parent_header'])
+        self.assertEqual(new_msg['metadata'],msg['metadata'])
         # ensure floats don't come out as Decimal:
         self.assertEqual(type(new_msg['content']['b']),type(new_msg['content']['b']))
 
@@ -85,6 +87,7 @@ class TestSession(SessionTestCase):
         self.assertEqual(new_msg['header'],msg['header'])
         self.assertEqual(new_msg['content'],msg['content'])
         self.assertEqual(new_msg['parent_header'],msg['parent_header'])
+        self.assertEqual(new_msg['metadata'],msg['metadata'])
         self.assertEqual(new_msg['buffers'],[b'bar'])
 
         socket.data = []
@@ -92,9 +95,10 @@ class TestSession(SessionTestCase):
         content = msg['content']
         header = msg['header']
         parent = msg['parent_header']
+        metadata = msg['metadata']
         msg_type = header['msg_type']
         self.session.send(socket, None, content=content, parent=parent,
-            header=header, ident=b'foo', buffers=[b'bar'])
+            header=header, metadata=metadata, ident=b'foo', buffers=[b'bar'])
         ident, msg_list = self.session.feed_identities(socket.data)
         new_msg = self.session.unserialize(msg_list)
         self.assertEqual(ident[0], b'foo')
@@ -102,6 +106,7 @@ class TestSession(SessionTestCase):
         self.assertEqual(new_msg['msg_type'],msg['msg_type'])
         self.assertEqual(new_msg['header'],msg['header'])
         self.assertEqual(new_msg['content'],msg['content'])
+        self.assertEqual(new_msg['metadata'],msg['metadata'])
         self.assertEqual(new_msg['parent_header'],msg['parent_header'])
         self.assertEqual(new_msg['buffers'],[b'bar'])
 
@@ -114,6 +119,7 @@ class TestSession(SessionTestCase):
         self.assertEqual(new_msg['msg_type'],msg['msg_type'])
         self.assertEqual(new_msg['header'],msg['header'])
         self.assertEqual(new_msg['content'],msg['content'])
+        self.assertEqual(new_msg['metadata'],msg['metadata'])
         self.assertEqual(new_msg['parent_header'],msg['parent_header'])
         self.assertEqual(new_msg['buffers'],[b'bar'])
 

--- a/docs/source/development/messaging.txt
+++ b/docs/source/development/messaging.txt
@@ -81,7 +81,7 @@ representation of all the data, we can communicate with such clients.
 General Message Format
 ======================
 
-A message is defined by the following three-dictionary structure::
+A message is defined by the following four-dictionary structure::
 
     {
       # The message header contains a pair of unique identifiers for the
@@ -105,6 +105,9 @@ A message is defined by the following three-dictionary structure::
       # The actual content of the message must be a dict, whose structure
       # depends on the message type.
       'content' : dict,
+      
+      # Any metadata associated with the message; this dictionary is optional.
+      'metadata' : dict,
     }
 
    
@@ -127,6 +130,7 @@ messages upon deserialization to the following form for convenience::
       'msg_type' : str,
       'parent_header' : dict,
       'content' : dict,
+      'metadata' : dict, # optional
     }
 
 All messages sent to or received by any IPython process should have this

--- a/docs/source/development/messaging.txt
+++ b/docs/source/development/messaging.txt
@@ -106,7 +106,7 @@ A message is defined by the following four-dictionary structure::
       # depends on the message type.
       'content' : dict,
       
-      # Any metadata associated with the message; this dictionary is optional.
+      # Any metadata associated with the message.
       'metadata' : dict,
     }
 
@@ -130,7 +130,7 @@ messages upon deserialization to the following form for convenience::
       'msg_type' : str,
       'parent_header' : dict,
       'content' : dict,
-      'metadata' : dict, # optional
+      'metadata' : dict,
     }
 
 All messages sent to or received by any IPython process should have this


### PR DESCRIPTION
We'd like to easily add metadata to messages.  Adding an optional top-level metadata attribute to messages seems like a natural solution.

With this pull request, we can add metadata to a session using a context handler like:

``` python
@contextmanager
def session_metadata(metadata):
    # flush any messages waiting in buffers
    sys.stdout.flush()
    sys.stderr.flush()

    session = sys.stdout.session
    old_metadata = session.metadata
    new_metadata = old_metadata.copy()
    new_metadata.update(metadata)
    session.metadata = new_metadata
    try:
        yield None
    finally:
        sys.stdout.flush()
        sys.stderr.flush()
        session.metadata = old_metadata

with session_metadata({'location': 4}):
     print 'hello world' # goes to location 4

```

(is there a better way to get the session object than to get it from sys.stdout?)
# Old Description

We'd like to attach some metadata to stdout and stderr messages, for example, indicating where 
the frontend should put the output.  It would be really convenient if sys.stdout and sys.stderr (which I think is 
IPython.zmq.iostream.OutStream, right?) had a 'metadata' attribute that could be set and would be added to each outgoing message.  This would also change the messaging spec to add a 'metadata' attribute to the 
content dict for stream messages (just like display_data messages already have).

```
@contextmanager
def stream_metadata(metadata):
    sys.stdout.flush()
    stdout_metadata = sys.stdout.metadata
    old_stdout_metadata = stdout_metadata.copy()
    stdout_metadata.update(metadata)
    sys.stdout.set_metadata(stdout_metadata)

    sys.stderr.flush()
    stderr_metadata = sys.stderr.metadata
    old_stderr_metadata = stderr_metadata.copy()
    stderr_metadata.update(metadata)
    sys.stderr.set_metadata(stderr_metadata)
    try:
        yield None
    finally:
        sys.stdout.set_metadata(old_stdout_metadata)
        sys.stdout.set_metadata(old_stderr_metadata)

with stream_metadata({'location': 4}):
     print 'hello world' # goes to location 4
```
