### PR TITLE
use explicit tuple in exception

### DIFF
--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -684,7 +684,7 @@ class OSMagics(Magics):
 
         try :
             cont = self.shell.find_user_code(parameter_s)
-        except ValueError, IOError:
+        except (ValueError, IOError):
             print "Error: no such file, variable, URL, history range or macro"
             return
 


### PR DESCRIPTION
fixes #2056

Do we want to try enforcing [pep 3110](http://www.python.org/dev/peps/pep-3110/) and use `as` in every exceptions that uses `,` ?
