### PR TITLE
Remove umlauts so py3 installations on LANG=C systems succeed.

### DIFF
--- a/IPython/core/release.py
+++ b/IPython/core/release.py
@@ -114,7 +114,7 @@ authors = {'Fernando' : ('Fernando Perez','fperez.net@gmail.com'),
            'Brian'    : ('Brian E Granger', 'ellisonbg@gmail.com'),
            'Min'      : ('Min Ragan-Kelley', 'benjaminrk@gmail.com'),
            'Thomas'   : ('Thomas A. Kluyver', 'takowl@gmail.com'),
-           'Jörgen'   : ('Jörgen Stenarson', 'jorgen.stenarson@bostream.nu'),
+           'Jorgen'   : ('Jorgen Stenarson', 'jorgen.stenarson@bostream.nu'),
            'Matthias' : ('Matthias Bussonnier', 'bussonniermatthias@gmail.com'),
            }
 


### PR DESCRIPTION
Closes #2057.
