### PR TITLE
conform to pep 3110

### DIFF
--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -163,19 +163,19 @@ class Config(dict):
     def __getattr__(self, key):
         try:
             return self.__getitem__(key)
-        except KeyError, e:
+        except KeyError as e:
             raise AttributeError(e)
 
     def __setattr__(self, key, value):
         try:
             self.__setitem__(key, value)
-        except KeyError, e:
+        except KeyError as e:
             raise AttributeError(e)
 
     def __delattr__(self, key):
         try:
             dict.__delitem__(self, key)
-        except KeyError, e:
+        except KeyError as e:
             raise AttributeError(e)
 
 

--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -151,7 +151,7 @@ class AliasManager(Configurable):
         """Define an alias, but don't raise on an AliasError."""
         try:
             self.define_alias(name, cmd)
-        except AliasError, e:
+        except AliasError as e:
             error("Invalid alias: %s" % e)
 
     def define_alias(self, name, cmd):

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2454,7 +2454,7 @@ class InteractiveShell(SingletonConfigurable):
         with prepended_to_syspath(dname):
             try:
                 py3compat.execfile(fname,*where)
-            except SystemExit, status:
+            except SystemExit as status:
                 # If the call was made with 0 or None exit status (sys.exit(0)
                 # or sys.exit() ), don't bother showing a traceback, as both of
                 # these are considered normal by the OS:

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -584,7 +584,7 @@ class Magics(object):
             # Do regular option processing
             try:
                 opts,args = getopt(argv, opt_str, long_opts)
-            except GetoptError,e:
+            except GetoptError as e:
                 raise UsageError('%s ( allowed: "%s" %s)' % (e.msg,opt_str,
                                         " ".join(long_opts)))
             for o,a in opts:

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -513,7 +513,7 @@ class CodeMagics(Magics):
         if is_temp:
             try:
                 return open(filename).read()
-            except IOError,msg:
+            except IOError as msg:
                 if msg.filename == filename:
                     warn('File not found. Did you forget to save?')
                     return

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -113,7 +113,7 @@ class NamespaceMagics(Magics):
         if out == 'not found':
             try:
                 filename = get_py_filename(parameter_s)
-            except IOError,msg:
+            except IOError as msg:
                 print msg
                 return
             page.page(self.shell.inspector.format(open(filename).read()))

--- a/IPython/core/page.py
+++ b/IPython/core/page.py
@@ -221,7 +221,7 @@ def page(strng, start=0, screen_lines=0, pager_cmd=None):
                 pager.write(strng)
                 pager.close()
                 retval = pager.close()  # success returns None
-            except IOError,msg:  # broken pipe when user quits
+            except IOError as msg:  # broken pipe when user quits
                 if msg.args == (32,'Broken pipe'):
                     retval = None
                 else:

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -201,7 +201,7 @@ class TestMagicRunSimple(tt.TempFileMixin):
                "for i in range(5):\n"
                "   try:\n"
                "       ip.magic('run %s')\n"
-               "   except NameError, e:\n"
+               "   except NameError as e:\n"
                "       print i;break\n" % empty.fname)
         self.mktmp(py3compat.doctest_refactor_print(src))
         _ip.magic('run %s' % self.fname)

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -875,7 +875,7 @@ class VerboseTB(TBTools):
             except (IndexError, UnicodeDecodeError):
                 # signals exit of tokenizer
                 pass
-            except tokenize.TokenError,msg:
+            except tokenize.TokenError as msg:
                 _m = ("An unexpected error occurred while tokenizing input\n"
                       "The following traceback may be corrupted or invalid\n"
                       "The error message is: %s\n" % msg)

--- a/IPython/deathrow/ibrowse.py
+++ b/IPython/deathrow/ibrowse.py
@@ -217,7 +217,7 @@ class _BrowserLevel(object):
                 break
             except (KeyboardInterrupt, SystemExit):
                 raise
-            except Exception, exc:
+            except Exception as exc:
                 have += 1
                 self.items.append(_BrowserCachedItem(exc))
                 self.exhausted = True
@@ -260,7 +260,7 @@ class _BrowserLevel(object):
                 value = attr.value(item)
             except (KeyboardInterrupt, SystemExit):
                 raise
-            except Exception, exc:
+            except Exception as exc:
                 value = exc
             # only store attribute if it exists (or we got an exception)
             if value is not ipipe.noitem:
@@ -652,7 +652,7 @@ class _CommandFind(_CommandInput):
                         break # found something
                 except (KeyboardInterrupt, SystemExit):
                     raise
-                except Exception, exc:
+                except Exception as exc:
                     browser.report(exc)
                     curses.beep()
                     break  # break on error
@@ -677,7 +677,7 @@ class _CommandFindBackwards(_CommandInput):
                         break # found something
                 except (KeyboardInterrupt, SystemExit):
                     raise
-                except Exception, exc:
+                except Exception as exc:
                     browser.report(exc)
                     curses.beep()
                     break # break on error
@@ -946,7 +946,7 @@ class ibrowse(ipipe.Display):
                 )
             except (KeyboardInterrupt, SystemExit):
                 raise
-            except Exception, exc:
+            except Exception as exc:
                 if not self.levels:
                     raise
                 self._calcheaderlines(oldlevels)
@@ -1311,7 +1311,7 @@ class ibrowse(ipipe.Display):
                 item = attr.value(item)
             except (KeyboardInterrupt, SystemExit):
                 raise
-            except Exception, exc:
+            except Exception as exc:
                 self.report(exc)
             else:
                 self.report("entering detail view for attribute %s..." % attr.name())
@@ -1638,7 +1638,7 @@ class ibrowse(ipipe.Display):
                         value = attr.value(item)
                     except (SystemExit, KeyboardInterrupt):
                         raise
-                    except Exception, exc:
+                    except Exception as exc:
                         value = exc
                     if value is not ipipe.noitem:
                         attrstyle = ipipe.xrepr(value, "footer")

--- a/IPython/deathrow/igrid.py
+++ b/IPython/deathrow/igrid.py
@@ -154,7 +154,7 @@ class IGridRenderer(wx.grid.PyGridCellRenderer):
         try:
             value = self.table._displayattrs[col].value(self.table.items[row])
             (align, width, text) = ipipe.xformat(value, "cell", self.maxchars)
-        except Exception, exc:
+        except Exception as exc:
             (align, width, text) = ipipe.xformat(exc, "cell", self.maxchars)
         return (align, text)
 
@@ -292,7 +292,7 @@ class IGridTable(wx.grid.PyGridTableBase):
                 break
             except (KeyboardInterrupt, SystemExit):
                 raise
-            except Exception, exc:
+            except Exception as exc:
                 have += 1
                 self._append(exc)
                 self.iterator = None
@@ -413,7 +413,7 @@ class IGridGrid(wx.grid.Grid):
                 return None
         try:
             self.table.items = ipipe.deque(sorted(self.table.items, key=realkey, reverse=reverse))
-        except TypeError, exc:
+        except TypeError as exc:
             self.error_output("Exception encountered: %s" % exc)
             return
         # Find out where the object under the cursor went
@@ -478,7 +478,7 @@ class IGridGrid(wx.grid.Grid):
             (align, width, text) = ipipe.xformat(value, "cell", self.maxchars)
         except IndexError:
             raise IndexError
-        except Exception, exc:
+        except Exception as exc:
             (align, width, text) = ipipe.xformat(exc, "cell", self.maxchars)
         return text
 
@@ -505,7 +505,7 @@ class IGridGrid(wx.grid.Grid):
                                 break
                         except (KeyboardInterrupt, SystemExit):
                             raise
-                        except Exception, exc:
+                        except Exception as exc:
                             frame.SetStatusText(str(exc))
                             wx.Bell()
                             break  # break on error
@@ -529,7 +529,7 @@ class IGridGrid(wx.grid.Grid):
                                 break
                         except (KeyboardInterrupt, SystemExit):
                             raise
-                        except Exception, exc:
+                        except Exception as exc:
                             frame.SetStatusText(str(exc))
                             wx.Bell()
                             break  # break on error
@@ -739,7 +739,7 @@ class IGridGrid(wx.grid.Grid):
                 for i in xrange(count-1, current, -1): # some tabs don't close if we don't close in *reverse* order
                     nb.DeletePage(i)
                 frame._add_notebook(value)
-        except TypeError, exc:
+        except TypeError as exc:
             if exc.__class__.__module__ == "exceptions":
                 msg = "%s: %s" % (exc.__class__.__name__, exc)
             else:
@@ -750,7 +750,7 @@ class IGridGrid(wx.grid.Grid):
         try:
             attr = self.table._displayattrs[col]
             value = attr.value(self.table.items[row])
-        except Exception, exc:
+        except Exception as exc:
             self.error_output(str(exc))
         else:
             self._doenter(value)
@@ -762,7 +762,7 @@ class IGridGrid(wx.grid.Grid):
     def enter(self, row):
         try:
             value = self.table.items[row]
-        except Exception, exc:
+        except Exception as exc:
             self.error_output(str(exc))
         else:
             self._doenter(value)
@@ -774,7 +774,7 @@ class IGridGrid(wx.grid.Grid):
         try:
             attr = self.table._displayattrs[col]
             item = self.table.items[row]
-        except Exception, exc:
+        except Exception as exc:
             self.error_output(str(exc))
         else:
             attrs = [ipipe.AttributeDetail(item, attr) for attr in ipipe.xattrs(item, "detail")]
@@ -784,7 +784,7 @@ class IGridGrid(wx.grid.Grid):
         try:
             attr = self.table._displayattrs[col]
             item = attr.value(self.table.items[row])
-        except Exception, exc:
+        except Exception as exc:
             self.error_output(str(exc))
         else:
             attrs = [ipipe.AttributeDetail(item, attr) for attr in ipipe.xattrs(item, "detail")]
@@ -819,7 +819,7 @@ class IGridGrid(wx.grid.Grid):
         """
         try:
             value = self.table.items[row]
-        except Exception, exc:
+        except Exception as exc:
             self.error_output(str(exc))
         else:
             self.quit(value)
@@ -827,7 +827,7 @@ class IGridGrid(wx.grid.Grid):
     def pickinput(self, row):
         try:
             value = self.table.items[row]
-        except Exception, exc:
+        except Exception as exc:
             self.error_output(str(exc))
         else:
             api = ipapi.get()
@@ -838,7 +838,7 @@ class IGridGrid(wx.grid.Grid):
         try:
             attr = self.table._displayattrs[col]
             value = attr.value(self.table.items[row])
-        except Exception, exc:
+        except Exception as exc:
             self.error_output(str(exc))
         else:
             api = ipapi.get()
@@ -851,7 +851,7 @@ class IGridGrid(wx.grid.Grid):
         """
         try:
             value = [self.table.items[row] for row in rows]
-        except Exception, exc:
+        except Exception as exc:
             self.error_output(str(exc))
         else:
             self.quit(value)
@@ -870,7 +870,7 @@ class IGridGrid(wx.grid.Grid):
                     raise
                 except Exception:
                     raise #pass
-        except Exception, exc:
+        except Exception as exc:
             self.error_output(str(exc))
         else:
             self.quit(values)
@@ -879,7 +879,7 @@ class IGridGrid(wx.grid.Grid):
         try:
             attr = self.table._displayattrs[col]
             value = attr.value(self.table.items[row])
-        except Exception, exc:
+        except Exception as exc:
             self.error_output(str(exc))
         else:
             self.quit(value)
@@ -959,7 +959,7 @@ class IGridFrame(wx.Frame):
         if dlg.ShowModal() == wx.ID_OK:
             try:
                 milliseconds = int(dlg.GetValue())
-            except ValueError, exc:
+            except ValueError as exc:
                 self.SetStatusText(str(exc))
             else:
                 table.timer.Start(milliseconds=milliseconds, oneShot=False)

--- a/IPython/deathrow/ipipe.py
+++ b/IPython/deathrow/ipipe.py
@@ -1796,7 +1796,7 @@ class ifilter(Pipe):
                 ok += 1
             except (KeyboardInterrupt, SystemExit):
                 raise
-            except Exception, exc:
+            except Exception as exc:
                 if self.errors == "drop":
                     pass # Ignore errors
                 elif self.errors == "keep":
@@ -1869,7 +1869,7 @@ class ieval(Pipe):
                 yield do(item)
             except (KeyboardInterrupt, SystemExit):
                 raise
-            except Exception, exc:
+            except Exception as exc:
                 if self.errors == "drop":
                     pass # Ignore errors
                 elif self.errors == "keep":
@@ -2040,7 +2040,7 @@ class iless(Display):
                     pager.write("\n")
             finally:
                 pager.close()
-        except Exception, exc:
+        except Exception as exc:
             print "%s: %s" % (exc.__class__.__name__, str(exc))
 
 
@@ -2187,7 +2187,7 @@ class idump(Display):
                     value = attr.value(item)
                 except (KeyboardInterrupt, SystemExit):
                     raise
-                except Exception, exc:
+                except Exception as exc:
                     value = exc
                 (align, width, text) = xformat(value, "cell", self.maxattrlength)
                 colwidths[attr] = max(colwidths[attr], width)

--- a/IPython/deathrow/oldfrontend/frontendbase.py
+++ b/IPython/deathrow/oldfrontend/frontendbase.py
@@ -246,7 +246,7 @@ class FrontEndBase(object):
 
         try:
             result = self.shell.execute(block)
-        except Exception,e:
+        except Exception as e:
             e = self._add_block_id_for_failure(e, blockID=blockID)
             e = self.update_cell_prompt(e, blockID=blockID)
             e = self.render_error(e)

--- a/IPython/deathrow/oldfrontend/linefrontendbase.py
+++ b/IPython/deathrow/oldfrontend/linefrontendbase.py
@@ -161,7 +161,7 @@ class LineFrontEndBase(FrontEndBase):
                 is_complete = codeop.compile_command(clean_string,
                             "<string>", "exec")
                 self.release_output()
-            except Exception, e:
+            except Exception as e:
                 # XXX: Hack: return True so that the
                 # code gets executed and the error captured.
                 is_complete = True

--- a/IPython/deathrow/oldfrontend/wx/ipythonx.py
+++ b/IPython/deathrow/oldfrontend/wx/ipythonx.py
@@ -5,7 +5,7 @@ ipython.
 
 try:
     import wx
-except ImportError, e:
+except ImportError as e:
     e.args[0] = """%s
 ________________________________________________________________________________
 You need wxPython to run this application.

--- a/IPython/extensions/tests/test_octavemagic.py
+++ b/IPython/extensions/tests/test_octavemagic.py
@@ -8,7 +8,7 @@ try:
     import numpy.testing as npt
 
     from IPython.extensions import octavemagic
-except Exception, e:
+except Exception as e:
     __test__ = False
 
 global octave

--- a/IPython/external/pexpect/_pexpect.py
+++ b/IPython/external/pexpect/_pexpect.py
@@ -79,7 +79,7 @@ try:
     import errno
     import traceback
     import signal
-except ImportError, e:
+except ImportError as e:
     raise ImportError (str(e) + """
 
 A critical module was not found. Probably this operating system does not
@@ -265,10 +265,10 @@ def run (command, timeout=-1, withexitstatus=False, events=None, extra_args=None
             else:
                 raise TypeError ('The callback must be a string or function type.')
             event_count = event_count + 1
-        except TIMEOUT, e:
+        except TIMEOUT as e:
             child_result_list.append(child.before)
             break
-        except EOF, e:
+        except EOF as e:
             child_result_list.append(child.before)
             break
     child_result = child._empty_buffer.join(child_result_list)
@@ -552,7 +552,7 @@ class spawnb(object):
         if self.use_native_pty_fork:
             try:
                 self.pid, self.child_fd = pty.fork()
-            except OSError, e:
+            except OSError as e:
                 raise ExceptionPexpect('Error! pty.fork() failed: ' + str(e))
         else: # Use internal __fork_pty
             self.pid, self.child_fd = self.__fork_pty()
@@ -857,7 +857,7 @@ class spawnb(object):
         if self.child_fd in r:
             try:
                 s = os.read(self.child_fd, size)
-            except OSError, e: # Linux does this
+            except OSError as e: # Linux does this
                 self.flag_eof = True
                 raise EOF ('End Of File (EOF) in read_nonblocking(). Exception style platform.')
             if s == b'': # BSD style
@@ -1106,7 +1106,7 @@ class spawnb(object):
                 else:
                     return False
             return False
-        except OSError, e:
+        except OSError as e:
             # I think there are kernel timing issues that sometimes cause
             # this to happen. I think isalive() reports True, but the
             # process is dead to the kernel.
@@ -1177,7 +1177,7 @@ class spawnb(object):
         if pid == 0:
             try:
                 pid, status = os.waitpid(self.pid, waitpid_options) ### os.WNOHANG) # Solaris!
-            except OSError, e: # This should never happen...
+            except OSError as e: # This should never happen...
                 if e[0] == errno.ECHILD:
                     raise ExceptionPexpect ('isalive() encountered condition that should never happen. There was no child process. Did someone else call waitpid() on our process?')
                 else:
@@ -1424,7 +1424,7 @@ class spawnb(object):
                 incoming = incoming + c
                 if timeout is not None:
                     timeout = end_time - time.time()
-        except EOF, e:
+        except EOF as e:
             self.buffer = self._empty_buffer
             self.before = incoming
             self.after = EOF
@@ -1437,7 +1437,7 @@ class spawnb(object):
                 self.match = None
                 self.match_index = None
                 raise EOF (str(e) + '\n' + str(self))
-        except TIMEOUT, e:
+        except TIMEOUT as e:
             self.buffer = incoming
             self.before = incoming
             self.after = TIMEOUT

--- a/IPython/external/ssh/forward.py
+++ b/IPython/external/ssh/forward.py
@@ -45,7 +45,7 @@ class Handler (SocketServer.BaseRequestHandler):
             chan = self.ssh_transport.open_channel('direct-tcpip',
                                                    (self.chain_host, self.chain_port),
                                                    self.request.getpeername())
-        except Exception, e:
+        except Exception as e:
             logger.debug('Incoming request to %s:%d failed: %s' % (self.chain_host,
                                                               self.chain_port,
                                                               repr(e)))

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -447,7 +447,7 @@ class NotebookApp(BaseIPythonApplication):
         for port in random_ports(self.port, self.port_retries+1):
             try:
                 self.http_server.listen(port, self.ip)
-            except socket.error, e:
+            except socket.error as e:
                 if e.errno != errno.EADDRINUSE:
                     raise
                 self.log.info('The port %i is already in use, trying another random port.' % port)

--- a/IPython/frontend/qt/rich_text.py
+++ b/IPython/frontend/qt/rich_text.py
@@ -111,7 +111,7 @@ class HtmlExporter(object):
             # Perform the export!
             try:
                 return exporter(html, self.filename, self.image_tag)
-            except Exception, e:
+            except Exception as e:
                 msg = "Error exporting HTML to %s\n" % self.filename + str(e)
                 reply = QtGui.QMessageBox.warning(parent, 'Error', msg,
                     QtGui.QMessageBox.Ok, QtGui.QMessageBox.Ok)

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -551,7 +551,7 @@ def _dict_pprinter_factory(start, end, basetype=None):
         keys = obj.keys()
         try:
             keys.sort()
-        except Exception, e:
+        except Exception as e:
             # Sometimes the keys don't sort.
             pass
         for idx, key in enumerate(keys):

--- a/IPython/parallel/client/asyncresult.py
+++ b/IPython/parallel/client/asyncresult.py
@@ -151,7 +151,7 @@ class AsyncResult(object):
                 else:
                     results = error.collect_exceptions(results, self._fname)
                 self._result = self._reconstruct_result(results)
-            except Exception, e:
+            except Exception as e:
                 self._exception = e
                 self._success = False
             else:
@@ -675,7 +675,7 @@ class AsyncHubResult(AsyncResult):
                 else:
                     results = error.collect_exceptions(results, self._fname)
                 self._result = self._reconstruct_result(results)
-            except Exception, e:
+            except Exception as e:
                 self._exception = e
                 self._success = False
             else:

--- a/IPython/parallel/tests/__init__.py
+++ b/IPython/parallel/tests/__init__.py
@@ -107,7 +107,7 @@ def teardown():
         if p.poll() is None:
             try:
                 p.stop()
-            except Exception, e:
+            except Exception as e:
                 print e
                 pass
         if p.poll() is None:

--- a/IPython/quarantine/ledit.py
+++ b/IPython/quarantine/ledit.py
@@ -78,7 +78,7 @@ def line_edit_f(self, cmd ):
         for l in curdata:
             try:
                 l2 = eval(cmd)
-            except Exception,e:
+            except Exception as e:
                 print "Dropping exception",e,"on line:",l
                 continue
             newlines.append(l2)

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -308,7 +308,7 @@ class DocTestCase(doctests.DocTestCase):
         # and letting any other error propagate.
         try:
             super(DocTestCase, self).tearDown()
-        except AttributeError, exc:
+        except AttributeError as exc:
             if exc.args[0] != self._result_var:
                 raise
 

--- a/IPython/utils/PyColorize.py
+++ b/IPython/utils/PyColorize.py
@@ -282,7 +282,7 @@ If no filename is given, or if filename is -, read standard input."""
     else:
         try:
             stream = open(fname)
-        except IOError,msg:
+        except IOError as msg:
             print >> sys.stderr, msg
             sys.exit(1)
 
@@ -294,7 +294,7 @@ If no filename is given, or if filename is -, read standard input."""
         try:
             # write colorized version to stdout
             parser.format(stream.read(),scheme=opts.scheme_name)
-        except IOError,msg:
+        except IOError as msg:
             # if user reads through a pager and quits, don't print traceback
             if msg.args != (32,'Broken pipe'):
                 raise

--- a/IPython/utils/_process_common.py
+++ b/IPython/utils/_process_common.py
@@ -34,7 +34,7 @@ def read_no_interrupt(p):
 
     try:
         return p.read()
-    except IOError, err:
+    except IOError as err:
         if err.errno != errno.EINTR:
             raise
 

--- a/IPython/utils/daemonize.py
+++ b/IPython/utils/daemonize.py
@@ -19,7 +19,7 @@ def daemonize():
     for i in range(3):
         try:
             os.dup2(null, i)
-        except OSError, e:
+        except OSError as e:
             if e.errno != errno.EBADF:
                 raise
     os.close(null)

--- a/IPython/utils/ipstruct.py
+++ b/IPython/utils/ipstruct.py
@@ -121,7 +121,7 @@ class Struct(dict):
                 )
         try:
             self.__setitem__(key, value)
-        except KeyError, e:
+        except KeyError as e:
             raise AttributeError(e)
 
     def __getattr__(self, key):

--- a/IPython/utils/pickleshare.py
+++ b/IPython/utils/pickleshare.py
@@ -85,7 +85,7 @@ class PickleShareDB(collections.MutableMapping):
         pickled = pickle.dump(value,fil.open('wb'), protocol=2)
         try:
             self.cache[fil] = (value,fil.mtime)
-        except OSError,e:
+        except OSError as e:
             if e.errno != 2:
                 raise
 

--- a/IPython/zmq/kernelmanager.py
+++ b/IPython/zmq/kernelmanager.py
@@ -897,7 +897,7 @@ class KernelManager(HasTraits):
             # Attempt to kill the kernel.
             try:
                 self.kernel.kill()
-            except OSError, e:
+            except OSError as e:
                 # In Windows, we will get an Access Denied error if the process
                 # has already terminated. Ignore it.
                 if sys.platform == 'win32':

--- a/IPython/zmq/parentpoller.py
+++ b/IPython/zmq/parentpoller.py
@@ -29,7 +29,7 @@ class ParentPollerUnix(Thread):
                 if os.getppid() == 1:
                     os._exit(1)
                 time.sleep(1.0)
-            except OSError, e:
+            except OSError as e:
                 if e.errno == EINTR:
                     continue
                 raise

--- a/docs/sphinxext/docscrape.py
+++ b/docs/sphinxext/docscrape.py
@@ -413,7 +413,7 @@ class FunctionDoc(NumpyDocString):
             doc = inspect.getdoc(func) or ''
         try:
             NumpyDocString.__init__(self, doc)
-        except ValueError, e:
+        except ValueError as e:
             print '*'*78
             print "ERROR: '%s' while parsing `%s`" % (e, self._f)
             print '*'*78
@@ -429,7 +429,7 @@ class FunctionDoc(NumpyDocString):
                 argspec = inspect.formatargspec(*argspec)
                 argspec = argspec.replace('*','\*')
                 signature = '%s%s' % (func_name, argspec)
-            except TypeError, e:
+            except TypeError as e:
                 signature = '%s()' % func_name
             self['Signature'] = signature
 

--- a/docs/sphinxext/github.py
+++ b/docs/sphinxext/github.py
@@ -36,7 +36,7 @@ def make_link_node(rawtext, app, type, slug, options):
             raise AttributeError
         if not base.endswith('/'):
             base += '/'
-    except AttributeError, err:
+    except AttributeError as err:
         raise ValueError('github_project_url configuration value is not set (%s)' % str(err))
 
     ref = base + type + '/' + slug + '/'
@@ -133,7 +133,7 @@ def ghcommit_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
             raise AttributeError
         if not base.endswith('/'):
             base += '/'
-    except AttributeError, err:
+    except AttributeError as err:
         raise ValueError('github_project_url configuration value is not set (%s)' % str(err))
 
     ref = base + text

--- a/docs/sphinxext/inheritance_diagram.py
+++ b/docs/sphinxext/inheritance_diagram.py
@@ -380,7 +380,7 @@ def visit_inheritance_diagram(inner_func):
     def visitor(self, node):
         try:
             content = inner_func(self, node)
-        except DotException, e:
+        except DotException as e:
             # Insert the exception as a warning in the document
             warning = self.document.reporter.warning(str(e), line=node.line)
             warning.parent = node

--- a/setup.py
+++ b/setup.py
@@ -235,7 +235,7 @@ if 'setuptools' in sys.modules:
     if PY3:
         setuptools_extra_args['use_2to3'] = True
         # we try to make a 2.6, 2.7, and 3.1 to 3.3 python compatible code
-        # so we explicitely disable some 2to3 fixes to be sure we ain't forgetting
+        # so we explicitly disable some 2to3 fixes to be sure we aren't forgetting
         # anything.
         setuptools_extra_args['use_2to3_exclude_fixers'] = [
                 'lib2to3.fixes.fix_except',

--- a/setup.py
+++ b/setup.py
@@ -234,6 +234,12 @@ if 'setuptools' in sys.modules:
     
     if PY3:
         setuptools_extra_args['use_2to3'] = True
+        # we try to make a 2.6, 2.7, and 3.1 to 3.3 python compatible code
+        # so we explicitely disable some 2to3 fixes to be sure we ain't forgetting
+        # anything.
+        setuptools_extra_args['use_2to3_exclude_fixers'] = [
+                'lib2to3.fixes.fix_except',
+                ]
         from setuptools.command.build_py import build_py
         setup_args['cmdclass'] = {'build_py': record_commit_info('IPython', build_cmd=build_py)}
         setuptools_extra_args['entry_points'] = find_scripts(True, suffix='3')


### PR DESCRIPTION
brutally replace all `exeption <type>, <name>:` by
`exception <type> as <name> :`

`exception <type>, <type> :` should not be present anywhere in the code
anymore, or should be present with explicit tuple as
`exception (<type>, <type>) :`

see also  #2061
