### PR TITLE
[Notebook] Give some Love to read-only mode 

### DIFF
--- a/IPython/frontend/html/notebook/static/js/cell.js
+++ b/IPython/frontend/html/notebook/static/js/cell.js
@@ -14,9 +14,10 @@ var IPython = (function (IPython) {
     var utils = IPython.utils;
 
 
-    var Cell = function (read_only) {
-        this.placeholder = this.placeholder || '';
-        this.read_only = read_only || IPython.read_only;
+    var Cell = function (dict) {
+        dict = dict ||{}; // create empty dict if function without argument
+        this.placeholder = dict.placeholder || '';
+        this.read_only = dict.read_only || false;
         this.selected = false;
         this.element = null;
         this.metadata = {};
@@ -36,7 +37,7 @@ var IPython = (function (IPython) {
     Cell.prototype.bind_events = function () {
         var that = this;
 
-        if (this.read_only || (IPython.notebook != undefined && IPython.notebook.read_only))
+        if (this.read_only)
             return;
         // We trigger events so that Cell doesn't have to depend on Notebook.
         that.element.click(function (event) {

--- a/IPython/frontend/html/notebook/static/js/cell.js
+++ b/IPython/frontend/html/notebook/static/js/cell.js
@@ -14,9 +14,9 @@ var IPython = (function (IPython) {
     var utils = IPython.utils;
 
 
-    var Cell = function () {
+    var Cell = function (read_only) {
         this.placeholder = this.placeholder || '';
-        this.read_only = false;
+        this.read_only = read_only || IPython.read_only;
         this.selected = false;
         this.element = null;
         this.metadata = {};
@@ -35,6 +35,9 @@ var IPython = (function (IPython) {
 
     Cell.prototype.bind_events = function () {
         var that = this;
+
+        if (this.read_only || (IPython.notebook != undefined && IPython.notebook.read_only))
+            return;
         // We trigger events so that Cell doesn't have to depend on Notebook.
         that.element.click(function (event) {
             if (that.selected === false) {

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -36,11 +36,12 @@ var IPython = (function (IPython) {
         var input = $('<div></div>').addClass('input hbox');
         input.append($('<div/>').addClass('prompt input_prompt'));
         var input_area = $('<div/>').addClass('input_area box-flex1');
+        var ro = this.read_only || IPython.notebook.read_only;
         this.code_mirror = CodeMirror(input_area.get(0), {
             indentUnit : 4,
             mode: 'python',
             theme: 'ipython',
-            readOnly: this.read_only,
+            readOnly: ro ? 'nocursor': false,
             onKeyEvent: $.proxy(this.handle_codemirror_keyevent,this)
         });
         input.append(input_area);

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -15,7 +15,7 @@ var IPython = (function (IPython) {
     var utils = IPython.utils;
     var key   = IPython.utils.keycodes;
 
-    var CodeCell = function (kernel) {
+    var CodeCell = function (kernel,dict) {
         // The kernel doesn't have to be set at creation time, in that case
         // it will be null and set_kernel has to be called later.
         this.kernel = kernel || null;
@@ -23,7 +23,7 @@ var IPython = (function (IPython) {
         this.input_prompt_number = null;
         this.tooltip_on_tab = true;
         this.collapsed = false;
-        IPython.Cell.apply(this, arguments);
+        IPython.Cell.apply(this, dict);
     };
 
 
@@ -36,12 +36,11 @@ var IPython = (function (IPython) {
         var input = $('<div></div>').addClass('input hbox');
         input.append($('<div/>').addClass('prompt input_prompt'));
         var input_area = $('<div/>').addClass('input_area box-flex1');
-        var ro = this.read_only || IPython.notebook.read_only;
         this.code_mirror = CodeMirror(input_area.get(0), {
             indentUnit : 4,
             mode: 'python',
             theme: 'ipython',
-            readOnly: ro ? 'nocursor': false,
+            readOnly: this.read_only ? 'nocursor': false,
             onKeyEvent: $.proxy(this.handle_codemirror_keyevent,this)
         });
         input.append(input_area);

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -420,6 +420,8 @@ var IPython = (function (IPython) {
     // Cell selection.
 
     Notebook.prototype.select = function (index) {
+        if(this.read_only)
+            return;
         if (index !== undefined && index >= 0 && index < this.ncells()) {
             sindex = this.get_selected_index()
             if (sindex !== null && index !== sindex) {
@@ -540,6 +542,7 @@ var IPython = (function (IPython) {
         if (this.ncells() === 0 || this.is_valid_cell_index(index)) {
             if (type === 'code') {
                 cell = new IPython.CodeCell(this.kernel);
+                cell.read_only = true;
                 cell.set_input_prompt();
             } else if (type === 'markdown') {
                 cell = new IPython.MarkdownCell();

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -541,8 +541,7 @@ var IPython = (function (IPython) {
         var cell = null;
         if (this.ncells() === 0 || this.is_valid_cell_index(index)) {
             if (type === 'code') {
-                cell = new IPython.CodeCell(this.kernel);
-                cell.read_only = true;
+                cell = new IPython.CodeCell(this.kernel,{read_only: this.read_only});
                 cell.set_input_prompt();
             } else if (type === 'markdown') {
                 cell = new IPython.MarkdownCell();
@@ -576,7 +575,7 @@ var IPython = (function (IPython) {
         var cell = null;
         if (this.ncells() === 0 || this.is_valid_cell_index(index)) {
             if (type === 'code') {
-                cell = new IPython.CodeCell(this.kernel);
+                cell = new IPython.CodeCell(this.kernel,{read_only : this.read_only});
                 cell.set_input_prompt();
             } else if (type === 'markdown') {
                 cell = new IPython.MarkdownCell();

--- a/IPython/frontend/html/notebook/static/js/savewidget.js
+++ b/IPython/frontend/html/notebook/static/js/savewidget.js
@@ -33,14 +33,16 @@ var IPython = (function (IPython) {
 
     SaveWidget.prototype.bind_events = function () {
         var that = this;
-        this.element.find('span#notebook_name').click(function () {
-            that.rename_notebook();
-        });
-        this.element.find('span#notebook_name').hover(function () {
-            $(this).addClass("ui-state-hover");
-        }, function () {
-            $(this).removeClass("ui-state-hover");
-        });
+        if( IPython.read_only == false) {
+            this.element.find('span#notebook_name').click(function () {
+                that.rename_notebook();
+            });
+            this.element.find('span#notebook_name').hover(function () {
+                $(this).addClass("ui-state-hover");
+            }, function () {
+                $(this).removeClass("ui-state-hover");
+            });
+        }
         $([IPython.events]).on('notebook_loaded.Notebook', function () {
             that.set_last_saved();
             that.update_notebook_name();

--- a/IPython/frontend/html/notebook/static/js/textcell.js
+++ b/IPython/frontend/html/notebook/static/js/textcell.js
@@ -33,7 +33,7 @@ var IPython = (function (IPython) {
             mode: this.code_mirror_mode,
             theme: 'default',
             value: this.placeholder,
-            readOnly: this.read_only,
+            readOnly: this.read_only ? false : 'nocursor',
             lineWrapping : true,
             onKeyEvent: $.proxy(this.handle_codemirror_keyevent,this)
         });

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -142,6 +142,7 @@ data-notebook-id={{notebook_id}}
                 <li id="restart_kernel"><a href="#">Restart</a></li>
             </ul>
         </li>
+        {% end %}
         <li><a href="#">Help</a>
             <ul>
                 <li><a href="http://ipython.org/documentation.html" target="_blank">IPython Help</a></li>
@@ -155,7 +156,6 @@ data-notebook-id={{notebook_id}}
                 <li><a href="http://matplotlib.sourceforge.net/" target="_blank">Matplotlib</a></li>
             </ul>
         </li>
-        {% end %}
     </ul>
 
 </div>

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -44,12 +44,12 @@ data-notebook-id={{notebook_id}}
 
 
 {% block site %}
-
 <div id="menubar_container">
 <div id="menubar">
     <ul id="menus">
         <li><a href="#">File</a>
             <ul>
+                {% if logged_in or not read_only %}
                 <li id="new_notebook"><a href="#">New</a></li>
                 <li id="open_notebook"><a href="#">Open...</a></li>
                 <hr/>
@@ -57,6 +57,7 @@ data-notebook-id={{notebook_id}}
                 <li id="rename_notebook"><a href="#">Rename...</a></li>
                 <li id="save_notebook"><a href="#">Save</a></li>
                 <hr/>
+                {% end %}
                 <li><a href="#">Download as</a>
                     <ul>
                         <li id="download_ipynb"><a href="#">IPython (.ipynb)</a></li>
@@ -65,10 +66,13 @@ data-notebook-id={{notebook_id}}
                 </li>
                 <hr/>
                 <li id="print_notebook"><a href="/{{notebook_id}}/print" target="_blank">Print View</a></li>
+                {% if logged_in or not read_only %}
                 <hr/>
                 <li id="kill_and_exit"><a href="#" >Close and halt</a></li>
+                {% end %}
             </ul>
         </li>
+        {% if logged_in or not read_only %}
         <li><a href="#">Edit</a>
             <ul>
                 <li id="cut_cell"><a href="#">Cut Cell</a></li>
@@ -89,12 +93,16 @@ data-notebook-id={{notebook_id}}
                 <li id="select_next"><a href="#">Select Next Cell</a></li>
             </ul>
         </li>
+        {% end %}
         <li><a href="#">View</a>
             <ul>
                 <li id="toggle_header"><a href="#">Toggle Header</a></li>
+                {% if logged_in or not read_only %}
                 <li id="toggle_toolbar"><a href="#">Toggle Toolbar</a></li>
+                {% end %}
             </ul>
         </li>
+        {% if logged_in or not read_only %}
         <li><a href="#">Insert</a>
             <ul>
                 <li id="insert_cell_above"><a href="#">Insert Cell Above</a></li>
@@ -147,6 +155,7 @@ data-notebook-id={{notebook_id}}
                 <li><a href="http://matplotlib.sourceforge.net/" target="_blank">Matplotlib</a></li>
             </ul>
         </li>
+        {% end %}
     </ul>
 
 </div>
@@ -154,6 +163,7 @@ data-notebook-id={{notebook_id}}
 </div>
 
 
+{% if logged_in or not read_only %}
 <div id="toolbar">
 
     <span>
@@ -191,6 +201,7 @@ data-notebook-id={{notebook_id}}
     </span>
 
 </div>
+{% end %}
 
 <div id="main_app">
 

--- a/IPython/frontend/html/notebook/templates/projectdashboard.html
+++ b/IPython/frontend/html/notebook/templates/projectdashboard.html
@@ -25,7 +25,9 @@ data-read-only={{read_only}}
 <div id="tabs">
     <ul>
         <li><a href="#tab1">Notebooks</a></li>
+        {% if logged_in or not read_only %}
         <li><a href="#tab2">Clusters</a></li>
+        {% end %}
     </ul>
 
     <div id="tab1">
@@ -48,6 +50,8 @@ data-read-only={{read_only}}
             <div id="project_name"><h2>{{project}}</h2></div>
         </div>
     </div>
+
+    {% if logged_in or not read_only %}
     <div id="tab2">
 
         <div id="cluster_toolbar">
@@ -68,6 +72,7 @@ data-read-only={{read_only}}
         </div>
 
     </div>
+    {% end %}
 </div>
 
 </div>


### PR DESCRIPTION
'Just' some if cases in the templates, and same in some key places in the JS to prevent cells to get focus or become edittable. 

Remove Almost all action from menubar when read-only (leave print view, download and toggle header) 
Remove Toolbar from notebook view.
Remove cluster tab in dashborad.
