### PR TITLE
update tools/release_windows.py

### DIFF
--- a/tools/release_windows.py
+++ b/tools/release_windows.py
@@ -23,10 +23,11 @@ except ImportError:
 
 github = '--github' in sys.argv
 
-cmd_t = "{py} setup.py bdist_wininst --plat-name=py{v}-{plat}"
+cmd_t = "{py} setup.py bdist_wininst --plat-name={plat}"
 
 if '--pypi' in sys.argv:
-    cmd_t += ' --upload'
+    raise NotImplementedError("pypi upload doesn't work yet")
+    cmd_t += ' upload'
 
 for py in ['python', 'python3']:
     # deliberately mangle the name,
@@ -36,11 +37,15 @@ for py in ['python', 'python3']:
         shutil.rmtree('build')
     except OSError:
         pass
-    for plat in ['32b-Windows', '64b-Windows']:
+    for plat in ['win32', 'win-amd64']:
         cmd = cmd_t.format(**locals())
         sh(cmd)
+        orig = glob.glob(os.path.join('dist', 'ipython-*.{plat}.exe'.format(**locals())))[0]
+        mangled = orig.replace('.{plat}.exe'.format(**locals()),
+                               '.py{v}-{plat}.exe'.format(**locals())
+        )
+        os.rename(orig, mangled)
         if github and gh_api:
-            exe = glob.glob(os.path.join("dist", "ipython-*{v}-{plat}.exe".format(**locals())))[0]
-            print ("Uploading %s to GitHub" % exe)
+            print ("Uploading %s to GitHub" % mangled)
             desc = "IPython Installer for Python {v}.x on {plat}".format(**locals())
-            gh_api.post_download('ipython/ipython', exe, description=desc)
+            gh_api.post_download('ipython/ipython', mangled, description=desc)

--- a/tools/release_windows.py
+++ b/tools/release_windows.py
@@ -25,9 +25,8 @@ github = '--github' in sys.argv
 
 cmd_t = "{py} setup.py bdist_wininst --plat-name={plat}"
 
-if '--pypi' in sys.argv:
-    raise NotImplementedError("pypi upload doesn't work yet")
-    cmd_t += ' upload'
+pypi = '--pypi' in sys.argv
+pypi_cmd_t = "python setup.py upload_wininst -f {fname}"
 
 for py in ['python', 'python3']:
     # deliberately mangle the name,
@@ -45,6 +44,8 @@ for py in ['python', 'python3']:
                                '.py{v}-{plat}.exe'.format(**locals())
         )
         os.rename(orig, mangled)
+        if pypi:
+            sh(pypi_cmd_t.format(fname=mangled))
         if github and gh_api:
             print ("Uploading %s to GitHub" % mangled)
             desc = "IPython Installer for Python {v}.x on {plat}".format(**locals())


### PR DESCRIPTION
The first commit is the actual version of the file I used
to build and upload the 0.13 installers to GitHub.

The second commit fixes PyPI upload.
