### PR TITLE
Make BG color of inline plot configurable

### DIFF
--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -97,15 +97,10 @@ def print_figure(fig, fmt='png'):
 
     fc = fig.get_facecolor()
     ec = fig.get_edgecolor()
-    fig.set_facecolor('white')
-    fig.set_edgecolor('white')
-    try:
-        bytes_io = BytesIO()
-        fig.canvas.print_figure(bytes_io, format=fmt, bbox_inches='tight')
-        data = bytes_io.getvalue()
-    finally:
-        fig.set_facecolor(fc)
-        fig.set_edgecolor(ec)
+    bytes_io = BytesIO()
+    fig.canvas.print_figure(bytes_io, format=fmt, bbox_inches='tight',
+                            facecolor=fc, edgecolor=ec)
+    data = bytes_io.getvalue()
     return data
 
 

--- a/IPython/zmq/pylab/backend_inline.py
+++ b/IPython/zmq/pylab/backend_inline.py
@@ -40,6 +40,9 @@ class InlineBackend(InlineBackendConfig):
     # so we shrink the figure size to 6x4, and tweak fonts to
     # make that fit.
     rc = Dict({'figure.figsize': (6.0,4.0),
+        # play nicely with white background in the Qt and notebook frontend
+        'figure.facecolor': 'white',
+        'figure.edgecolor': 'white',
         # 12pt labels get cutoff on 6x4 logplots, so use 10pt.
         'font.size': 10,
         # 72 dpi matches SVG/qtconsole


### PR DESCRIPTION
pylabtools.print_figure respects the facecolor/edgecolor setting in
the figure instance, instead of overriding by hard-coded color.
Now user can set color by matplotlibt API (e.g., fig.set_facecolor)
or IPython configuration.

When this patch applied, you can tweak matplotlib.rcParams to make the inline plot in dark BG Qt console looks better (just for fun):

<a href="http://www.flickr.com/photos/arataka/7479083258/" title="screenshot-2012-07-01-155555 by takafumi_a, on Flickr"><img src="http://farm9.staticflickr.com/8014/7479083258_2b76d1f849.jpg" width="474" height="408" alt="screenshot-2012-07-01-155555"></a>
