### PR TITLE
Skip notebook 'static' dir in test suite.

### DIFF
--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -232,6 +232,11 @@ def make_exclude():
                   ipjoin('lib', 'inputhook'),
                   # Config files aren't really importable stand-alone
                   ipjoin('config', 'profile'),
+                  # The notebook 'static' directory contains JS, css and other
+                  # files for web serving.  Occasionally projects may put a .py
+                  # file in there (MathJax ships a conf.py), so we might as
+                  # well play it safe and skip the whole thing.
+                  ipjoin('frontend', 'html', 'notebook', 'static')
                   ]
     if not have['sqlite3']:
         exclusions.append(ipjoin('core', 'tests', 'test_history'))


### PR DESCRIPTION
There's nothing there we should be running python tests on, and
occasionally python files may appear there that cause problems to nose
(e.g. mathjax ships a non-py3 valid conf.py that breaks py3 testing).

Closes #2075.
