### PR TITLE
Fix (some) Python 3.2 ResourceWarnings

### DIFF
--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -489,6 +489,7 @@ def test_extension():
         assert 'arq' not in _ip.user_ns
     finally:
         _ip.ipython_dir = orig_ipython_dir
+        tmpdir.cleanup()
         
 def test_notebook_export_json():
     with TemporaryDirectory() as td:

--- a/IPython/utils/pickleshare.py
+++ b/IPython/utils/pickleshare.py
@@ -67,7 +67,8 @@ class PickleShareDB(collections.MutableMapping):
             return self.cache[fil][0]
         try:
             # The cached item has expired, need to read
-            obj = pickle.loads(fil.open("rb").read())
+            with fil.open("rb") as f:
+                obj = pickle.loads(f.read())
         except:
             raise KeyError(key)
 
@@ -82,7 +83,8 @@ class PickleShareDB(collections.MutableMapping):
             parent.makedirs()
         # We specify protocol 2, so that we can mostly go between Python 2
         # and Python 3. We can upgrade to protocol 3 when Python 2 is obsolete.
-        pickled = pickle.dump(value,fil.open('wb'), protocol=2)
+        with fil.open('wb') as f:
+            pickled = pickle.dump(value, f, protocol=2)
         try:
             self.cache[fil] = (value,fil.mtime)
         except OSError,e:

--- a/IPython/utils/py3compat.py
+++ b/IPython/utils/py3compat.py
@@ -73,7 +73,8 @@ if sys.version_info[0] >= 3:
     
     def execfile(fname, glob, loc=None):
         loc = loc if (loc is not None) else glob
-        exec compile(open(fname, 'rb').read(), fname, 'exec') in glob, loc
+        with open(fname, 'rb') as f:
+            exec compile(f.read(), fname, 'exec') in glob, loc
     
     # Refactor print statements in doctests.
     _print_statement_re = re.compile(r"\bprint (?P<expr>.*)$", re.MULTILINE)


### PR DESCRIPTION
To fix the test errors in gh-2083, it was necessary to replace one instance of
`exec compile(open(..., 'rb').read(), ...) in ...` with

```
with open(..., 'rb') as f:
    exec compile(f.read(), ...) in ...
```

In addition I've tackled several other resource warnings that come from running iptest with `PYTHONWARNINGS="d"`.
