### PR TITLE
New keybinding for code cell execution + cell insertion

### DIFF
--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -118,7 +118,7 @@ var IPython = (function (IPython) {
                 // Execute code cell, and insert new in place
                 that.execute_selected_cell();
                  // Only insert a new cell, if we ended up in an already populated cell
-                if (/\S/.test(that.get_selected_cell().toJSON().input) == true) {
+                if (/\S/.test(that.get_selected_cell().get_text()) == true) {
                     that.insert_cell_above('code');
                 }
                 return false;

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -118,7 +118,7 @@ var IPython = (function (IPython) {
                 // Execute code cell, and insert new in place
                 that.execute_selected_cell();
                  // Only insert a new cell, if we ended up in an already populated cell
-                if (that.get_selected_cell().toJSON().input !== "") {
+                if (/\S/.test(that.get_selected_cell().toJSON().input) == true) {
                     that.insert_cell_above('code');
                 }
                 return false;

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -115,8 +115,12 @@ var IPython = (function (IPython) {
                 that.execute_selected_cell();
                 return false;
             } else if (event.which === key.ENTER && event.altKey) {
+                // Execute code cell, and insert new in place
                 that.execute_selected_cell();
-                that.insert_cell_above('code');
+                 // Only insert a new cell, if we ended up in an already populated cell
+                if (that.get_selected_cell().toJSON().input !== "") {
+                    that.insert_cell_above('code');
+                }
                 return false;
             } else if (event.which === key.ENTER && event.ctrlKey) {
                 that.execute_selected_cell({terminal:true});

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -114,6 +114,10 @@ var IPython = (function (IPython) {
             } else if (event.which === key.ENTER && event.shiftKey) {
                 that.execute_selected_cell();
                 return false;
+            } else if (event.which === key.ENTER && event.altKey) {
+                that.execute_selected_cell();
+                that.insert_cell_above('code');
+                return false;
             } else if (event.which === key.ENTER && event.ctrlKey) {
                 that.execute_selected_cell({terminal:true});
                 return false;

--- a/IPython/frontend/html/notebook/static/js/quickhelp.js
+++ b/IPython/frontend/html/notebook/static/js/quickhelp.js
@@ -28,6 +28,7 @@ var IPython = (function (IPython) {
         var shortcuts = [
             {key: 'Shift-Enter', help: 'run cell'},
             {key: 'Ctrl-Enter', help: 'run cell in-place'},
+            {key: 'Alt-Enter', help: 'run cell, insert below'},
             {key: 'Ctrl-m x', help: 'cut cell'},
             {key: 'Ctrl-m c', help: 'copy cell'},
             {key: 'Ctrl-m v', help: 'paste cell'},

--- a/docs/source/interactive/htmlnotebook.txt
+++ b/docs/source/interactive/htmlnotebook.txt
@@ -253,12 +253,19 @@ the notebook can be achieved with minimal mouse intervention.  The main
 key bindings you need to remember are:
 
 * :kbd:`Shift-Enter`: execute the current cell (similar to the Qt console),
-  show output (if any) and create a new cell below.  Note that in the notebook,
-  simply using :kbd:`Enter` *never* forces execution, it simply inserts a new
-  line in the current cell.  Therefore, in the notebook you must always use
-  :kbd:`Shift-Enter` to get execution (or use the mouse and click on the ``Run
-  Selected`` button).
+  show output (if any) and jump to the next cell below. If :kbd:`Shift-Enter` 
+  was invoked on the last input line, a new code cell will also be created. Note 
+  that in the notebook, simply using :kbd:`Enter` *never* forces execution, 
+  it simply inserts a new line in the current cell. Therefore, in the notebook 
+  you must always use :kbd:`Shift-Enter` to get execution (or use the mouse and 
+  click on the ``Run Selected`` button).
 
+* :kbd:`Alt-Enter`: this combination is similar to the previous one, with the 
+  exception that, if the next cell below is not empty, a new code cell will be 
+  added to the notebook, even if the cell execution happens not in the last cell. 
+  In this regard, :kbd:`Alt-Enter`: is simply a shortcut for the :kbd:`Shift-Enter`, 
+  :kbd:`Ctrl-m a` sequence. 
+  
 * :kbd:`Ctrl-Enter`: execute the current cell in "terminal mode", where any
   output is shown but the cursor stays in the current cell, whose input
   area is flushed empty.  This is convenient to do quick in-place experiments


### PR DESCRIPTION
Hi all, 

As discussed in http://mail.scipy.org/pipermail/ipython-dev/2012-July/009844.html and thereafter, I have added a new Alt+Enter combination for executing a cell and inserting a new code cell, even if the present cell is not at the bottom of the notebook. Files notebook.js, and quickhelp.js are affected. Let me know, if this combination is not appropriate for some reason. We could still go with Cntr+Shift+Enter. 

Cheers,
Zoltán
