### PR TITLE
%prun: Restore `stats.stream` after running `print_stream`.

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -226,20 +226,12 @@ python-profiler package from non-free.""")
 
         # Trap output.
         stdout_trap = StringIO()
-
-        if hasattr(stats,'stream'):
-            # In newer versions of python, the stats object has a 'stream'
-            # attribute to write into.
+        stats_stream = stats.stream
+        try:
             stats.stream = stdout_trap
             stats.print_stats(*lims)
-        else:
-            # For older versions, we manually redirect stdout during printing
-            sys_stdout = sys.stdout
-            try:
-                sys.stdout = stdout_trap
-                stats.print_stats(*lims)
-            finally:
-                sys.stdout = sys_stdout
+        finally:
+            stats.stream = stats_stream
 
         output = stdout_trap.getvalue()
         output = output.rstrip()


### PR DESCRIPTION
When profiling, the output from `print_stream` is captured so that the output can be paged. To do so, the `stream` attribute is set to a `StringIO` object but was not restored after the output was captured. As a result, the stats object returned by `%prun -r` did not display any output when calling its `print_stream` method.

In addition, the `pstats.Stats` class has the `stream` attribute for all currently supported Python versions (2.6, 2.7, and 3.2, at least), so the extra branch of code can be removed.

Closes #2091.
