### PR TITLE
[in progress] python 2 and 3 compatibility without 2to3

### DIFF
--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -18,6 +18,7 @@ Authors:
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 import logging
 import os
@@ -239,7 +240,7 @@ class Application(SingletonConfigurable):
                 help[0] = help[0].replace('--%s='%alias, '-%s '%alias)
             lines.extend(help)
         # lines.append('')
-        print os.linesep.join(lines)
+        print(os.linesep.join(lines))
 
     def print_flag_help(self):
         """Print the flag part of the help."""
@@ -252,7 +253,7 @@ class Application(SingletonConfigurable):
             lines.append(prefix+m)
             lines.append(indent(dedent(help.strip())))
         # lines.append('')
-        print os.linesep.join(lines)
+        print(os.linesep.join(lines))
 
     def print_options(self):
         if not self.flags and not self.aliases:
@@ -263,10 +264,10 @@ class Application(SingletonConfigurable):
         for p in wrap_paragraphs(self.option_description):
             lines.append(p)
             lines.append('')
-        print os.linesep.join(lines)
+        print(os.linesep.join(lines))
         self.print_flag_help()
         self.print_alias_help()
-        print
+        print()
 
     def print_subcommands(self):
         """Print the subcommand part of the help."""
@@ -284,7 +285,7 @@ class Application(SingletonConfigurable):
             if help:
                 lines.append(indent(dedent(help.strip())))
         lines.append('')
-        print os.linesep.join(lines)
+        print(os.linesep.join(lines))
 
     def print_help(self, classes=False):
         """Print the help for each Configurable class in self.classes.
@@ -296,25 +297,25 @@ class Application(SingletonConfigurable):
 
         if classes:
             if self.classes:
-                print "Class parameters"
-                print "----------------"
-                print
+                print("Class parameters")
+                print("----------------")
+                print()
                 for p in wrap_paragraphs(self.keyvalue_description):
-                    print p
-                    print
+                    print(p)
+                    print()
 
             for cls in self.classes:
                 cls.class_print_help()
-                print
+                print()
         else:
-            print "To see all available configurables, use `--help-all`"
-            print
+            print("To see all available configurables, use `--help-all`")
+            print()
 
     def print_description(self):
         """Print the application description."""
         for p in wrap_paragraphs(self.description):
-            print p
-            print
+            print(p)
+            print()
 
     def print_examples(self):
         """Print usage and examples.
@@ -323,15 +324,15 @@ class Application(SingletonConfigurable):
         and should contain examples of the application's usage.
         """
         if self.examples:
-            print "Examples"
-            print "--------"
-            print
-            print indent(dedent(self.examples.strip()))
-            print
+            print("Examples")
+            print("--------")
+            print()
+            print(indent(dedent(self.examples.strip())))
+            print()
 
     def print_version(self):
         """Print the version string."""
-        print self.version
+        print(self.version)
 
     def update_config(self, config):
         """Fire the traits events when the config is updated."""

--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -19,6 +19,7 @@ Authors:
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function 
 
 import datetime
 from copy import deepcopy
@@ -200,7 +201,7 @@ class Configurable(HasTraits):
     @classmethod
     def class_print_help(cls, inst=None):
         """Get the help string for a single trait and print it."""
-        print cls.class_get_help(inst)
+        print(cls.class_get_help(inst))
 
     @classmethod
     def class_config_section(cls):

--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -163,19 +163,19 @@ class Config(dict):
     def __getattr__(self, key):
         try:
             return self.__getitem__(key)
-        except KeyError, e:
+        except KeyError as e:
             raise AttributeError(e)
 
     def __setattr__(self, key, value):
         try:
             self.__setitem__(key, value)
-        except KeyError, e:
+        except KeyError as e:
             raise AttributeError(e)
 
     def __delattr__(self, key):
         try:
             dict.__delitem__(self, key)
-        except KeyError, e:
+        except KeyError as e:
             raise AttributeError(e)
 
 

--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -151,7 +151,7 @@ class AliasManager(Configurable):
         """Define an alias, but don't raise on an AliasError."""
         try:
             self.define_alias(name, cmd)
-        except AliasError, e:
+        except AliasError as e:
             error("Invalid alias: %s" % e)
 
     def define_alias(self, name, cmd):

--- a/IPython/core/crashhandler.py
+++ b/IPython/core/crashhandler.py
@@ -18,6 +18,7 @@ Authors:
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 import os
 import sys
@@ -159,18 +160,18 @@ class CrashHandler(object):
 
         # print traceback to screen
         if self.show_crash_traceback:
-            print >> sys.stderr, traceback
+            print(traceback, file=sys.stderr)
 
         # and generate a complete report on disk
         try:
             report = open(report_name,'w')
         except:
-            print >> sys.stderr, 'Could not create crash report on disk.'
+            print('Could not create crash report on disk.', file=sys.stderr)
             return
 
         # Inform user on stderr of what happened
-        print >> sys.stderr, '\n'+'*'*70+'\n'
-        print >> sys.stderr, self.message_template.format(**self.info)
+        print('\n'+'*'*70+'\n', file=sys.stderr)
+        print(self.message_template.format(**self.info), file=sys.stderr)
 
         # Construct report on disk
         report.write(self.make_report(traceback))
@@ -210,5 +211,5 @@ def crash_handler_lite(etype, evalue, tb):
     else:
         # we are not in a shell, show generic config
         config = "c."
-    print >> sys.stderr, _lite_message_template.format(email=author_email, config=config)
+    print(_lite_message_template.format(email=author_email, config=config), file=sys.stderr)
 

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -24,6 +24,7 @@ http://www.python.org/2.2.3/license.html"""
 #
 #
 #*****************************************************************************
+from __future__ import print_function
 
 import bdb
 import linecache
@@ -46,7 +47,7 @@ if '--pydb' in sys.argv:
             # better protect against it.
             has_pydb = True
     except ImportError:
-        print "Pydb (http://bashdb.sourceforge.net/pydb/) does not seem to be available"
+        print("Pydb (http://bashdb.sourceforge.net/pydb/) does not seem to be available")
 
 if has_pydb:
     from pydb import Pdb as OldPdb
@@ -60,12 +61,12 @@ else:
 # the Tracer constructor.
 def BdbQuit_excepthook(et,ev,tb):
     if et==bdb.BdbQuit:
-        print 'Exiting Debugger.'
+        print('Exiting Debugger.')
     else:
         BdbQuit_excepthook.excepthook_ori(et,ev,tb)
 
 def BdbQuit_IPython_excepthook(self,et,ev,tb,tb_offset=None):
-    print 'Exiting Debugger.'
+    print('Exiting Debugger.')
 
 
 class Tracer(object):
@@ -294,7 +295,7 @@ class Pdb(OldPdb):
     def print_stack_entry(self,frame_lineno,prompt_prefix='\n-> ',
                           context = 3):
         #frame, lineno = frame_lineno
-        print >>io.stdout, self.format_stack_entry(frame_lineno, '', context)
+        print(self.format_stack_entry(frame_lineno, '', context), file=io.stdout)
 
         # vds: >>
         frame, lineno = frame_lineno
@@ -434,7 +435,7 @@ class Pdb(OldPdb):
                 src.append(line)
                 self.lineno = lineno
 
-            print >>io.stdout, ''.join(src)
+            print(''.join(src), file=io.stdout)
 
         except KeyboardInterrupt:
             pass
@@ -455,7 +456,7 @@ class Pdb(OldPdb):
                 else:
                     first = max(1, int(x) - 5)
             except:
-                print '*** Error in argument:', `arg`
+                print('*** Error in argument:', `arg`)
                 return
         elif self.lineno is None:
             first = max(1, self.curframe.f_lineno - 5)
@@ -514,12 +515,12 @@ class Pdb(OldPdb):
         #######################################################################
 
         if not line:
-            print >>self.stdout, 'End of file'
+            print('End of file', file=self.stdout)
             return 0
         line = line.strip()
         # Don't allow setting breakpoint at a blank line
         if (not line or (line[0] == '#') or
              (line[:3] == '"""') or line[:3] == "'''"):
-            print >>self.stdout, '*** Blank or comment'
+            print('*** Blank or comment', file=self.stdout)
             return 0
         return lineno

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -456,7 +456,7 @@ class Pdb(OldPdb):
                 else:
                     first = max(1, int(x) - 5)
             except:
-                print('*** Error in argument:', `arg`)
+                print('*** Error in argument:', repr(arg))
                 return
         elif self.lineno is None:
             first = max(1, self.curframe.f_lineno - 5)

--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -21,6 +21,7 @@ Authors:
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 import __builtin__
 
@@ -179,7 +180,7 @@ class DisplayHook(Configurable):
                 # But avoid extraneous empty lines.
                 result_repr = '\n' + result_repr
 
-        print >>io.stdout, result_repr
+        print(result_repr, file=io.stdout)
 
     def update_user_ns(self, result):
         """Update user_ns with various things like _, __, _1, etc."""

--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -189,7 +189,7 @@ class DisplayHook(Configurable):
         if result is not self.shell.user_ns['_oh']:
             if len(self.shell.user_ns['_oh']) >= self.cache_size and self.do_full_cache:
                 warn('Output cache limit (currently '+
-                      `self.cache_size`+' entries) hit.\n'
+                      repr(self.cache_size)+' entries) hit.\n'
                      'Flushing cache and resetting history counter...\n'
                      'The only history variables available will be _,__,___ and _1\n'
                      'with the current result.')
@@ -209,7 +209,7 @@ class DisplayHook(Configurable):
             # hackish access to top-level  namespace to create _1,_2... dynamically
             to_main = {}
             if self.do_full_cache:
-                new_result = '_'+`self.prompt_count`
+                new_result = '_'+repr(self.prompt_count)
                 to_main[new_result] = result
                 self.shell.push(to_main, interactive=False)
                 self.shell.user_ns['_oh'][self.prompt_count] = result
@@ -249,7 +249,7 @@ class DisplayHook(Configurable):
         # delete auto-generated vars from global namespace
 
         for n in range(1,self.prompt_count + 1):
-            key = '_'+`n`
+            key = '_'+repr(n)
             try:
                 del self.shell.user_ns[key]
             except: pass

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2454,7 +2454,7 @@ class InteractiveShell(SingletonConfigurable):
         with prepended_to_syspath(dname):
             try:
                 py3compat.execfile(fname,*where)
-            except SystemExit, status:
+            except SystemExit as status:
                 # If the call was made with 0 or None exit status (sys.exit(0)
                 # or sys.exit() ), don't bother showing a traceback, as both of
                 # these are considered normal by the OS:

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -16,6 +16,7 @@
 
 from __future__ import with_statement
 from __future__ import absolute_import
+from __future__ import print_function
 
 import __builtin__ as builtin_mod
 import __future__
@@ -796,8 +797,8 @@ class InteractiveShell(SingletonConfigurable):
 
         dp = getattr(self.hooks, name, None)
         if name not in IPython.core.hooks.__all__:
-            print "Warning! Hook '%s' is not one of %s" % \
-                  (name, IPython.core.hooks.__all__ )
+            print("Warning! Hook '%s' is not one of %s" % \
+                  (name, IPython.core.hooks.__all__ ))
         if not dp:
             dp = IPython.core.hooks.CommandChainDispatcher()
 
@@ -1318,8 +1319,8 @@ class InteractiveShell(SingletonConfigurable):
                 try:
                     vdict[name] = eval(name, cf.f_globals, cf.f_locals)
                 except:
-                    print ('Could not get variable %s from %s' %
-                           (name,cf.f_code.co_name))
+                    print(('Could not get variable %s from %s' %
+                           (name,cf.f_code.co_name)))
         else:
             raise ValueError('variables must be a dict/str/list/tuple')
 
@@ -1493,7 +1494,7 @@ class InteractiveShell(SingletonConfigurable):
             else:
                 pmethod(info.obj, oname)
         else:
-            print 'Object `%s` not found.' % oname
+            print('Object `%s` not found.' % oname)
             return 'not found'  # so callers can take other action
 
     def object_inspect(self, oname, detail_level=0):
@@ -1587,10 +1588,10 @@ class InteractiveShell(SingletonConfigurable):
                "The custom exceptions must be given AS A TUPLE."
 
         def dummy_handler(self,etype,value,tb,tb_offset=None):
-            print '*** Simple custom exception handler ***'
-            print 'Exception type :',etype
-            print 'Exception value:',value
-            print 'Traceback      :',tb
+            print('*** Simple custom exception handler ***')
+            print('Exception type :',etype)
+            print('Exception value:',value)
+            print('Traceback      :',tb)
             #print 'Source code    :','\n'.join(self.buffer)
         
         def validate_stb(stb):
@@ -1631,11 +1632,11 @@ class InteractiveShell(SingletonConfigurable):
                 except:
                     # clear custom handler immediately
                     self.set_custom_exc((), None)
-                    print >> io.stderr, "Custom TB Handler failed, unregistering"
+                    print("Custom TB Handler failed, unregistering", file=io.stderr)
                     # show the exception in handler first
                     stb = self.InteractiveTB.structured_traceback(*sys.exc_info())
-                    print >> io.stdout, self.InteractiveTB.stb2text(stb)
-                    print >> io.stdout, "The original exception:"
+                    print(self.InteractiveTB.stb2text(stb), file=io.stdout)
+                    print("The original exception:", file=io.stdout)
                     stb = self.InteractiveTB.structured_traceback(
                                             (etype,value,tb), tb_offset=tb_offset
                     )
@@ -1759,7 +1760,7 @@ class InteractiveShell(SingletonConfigurable):
         Subclasses may override this method to put the traceback on a different
         place, like a side channel.
         """
-        print >> io.stdout, self.InteractiveTB.stb2text(stb)
+        print(self.InteractiveTB.stb2text(stb), file=io.stdout)
 
     def showsyntaxerror(self, filename=None):
         """Display the syntax error that just occurred.
@@ -2335,9 +2336,9 @@ class InteractiveShell(SingletonConfigurable):
             # plain ascii works better w/ pyreadline, on some machines, so
             # we use it and only print uncolored rewrite if we have unicode
             rw = str(rw)
-            print >> io.stdout, rw
+            print(rw, file=io.stdout)
         except UnicodeEncodeError:
-            print "------> " + cmd
+            print("------> " + cmd)
 
     #-------------------------------------------------------------------------
     # Things related to extracting values/expressions from kernel and user_ns
@@ -2626,17 +2627,17 @@ class InteractiveShell(SingletonConfigurable):
                         try:
                             func()
                         except KeyboardInterrupt:
-                            print >> io.stderr, "\nKeyboardInterrupt"
+                            print("\nKeyboardInterrupt", file=io.stderr)
                         except Exception:
                             # register as failing:
                             self._post_execute[func] = False
                             self.showtraceback()
-                            print >> io.stderr, '\n'.join([
+                            print('\n'.join([
                                 "post-execution function %r produced an error." % func,
                                 "If this problem persists, you can disable failing post-exec functions with:",
                                 "",
                                 "    get_ipython().disable_failing_post_execute = True"
-                            ])
+                            ]), file=io.stderr)
 
         if store_history:
             # Write output to the database. Does nothing unless
@@ -2698,7 +2699,7 @@ class InteractiveShell(SingletonConfigurable):
 
             # Flush softspace
             if softspace(sys.stdout, 0):
-                print
+                print()
 
         except:
             # It's possible to have exceptions raised here, typically by

--- a/IPython/core/logger.py
+++ b/IPython/core/logger.py
@@ -12,6 +12,7 @@
 #****************************************************************************
 # Modules and globals
 
+from __future__ import print_function
 # Python standard modules
 import glob
 import io
@@ -137,33 +138,33 @@ class Logger(object):
         label = {0:'OFF',1:'ON',False:'OFF',True:'ON'}
 
         if self.logfile is None:
-            print """
+            print("""
 Logging hasn't been started yet (use logstart for that).
 
 %logon/%logoff are for temporarily starting and stopping logging for a logfile
 which already exists. But you must first start the logging process with
-%logstart (optionally giving a logfile name)."""
+%logstart (optionally giving a logfile name).""")
 
         else:
             if self.log_active == val:
-                print 'Logging is already',label[val]
+                print('Logging is already',label[val])
             else:
-                print 'Switching logging',label[val]
+                print('Switching logging',label[val])
                 self.log_active = not self.log_active
                 self.log_active_out = self.log_active
 
     def logstate(self):
         """Print a status message about the logger."""
         if self.logfile is None:
-            print 'Logging has not been activated.'
+            print('Logging has not been activated.')
         else:
             state = self.log_active and 'active' or 'temporarily suspended'
-            print 'Filename       :',self.logfname
-            print 'Mode           :',self.logmode
-            print 'Output logging :',self.log_output
-            print 'Raw input log  :',self.log_raw_input
-            print 'Timestamping   :',self.timestamp
-            print 'State          :',state
+            print('Filename       :',self.logfname)
+            print('Mode           :',self.logmode)
+            print('Output logging :',self.log_output)
+            print('Raw input log  :',self.log_raw_input)
+            print('Timestamping   :',self.timestamp)
+            print('State          :',state)
 
     def log(self, line_mod, line_ori):
         """Write the sources to a log.
@@ -213,7 +214,7 @@ which already exists. But you must first start the logging process with
             self.logfile.close()
             self.logfile = None
         else:
-            print "Logging hadn't been started."
+            print("Logging hadn't been started.")
         self.log_active = False
 
     # For backwards compatibility, in case anyone was using this.

--- a/IPython/core/logger.py
+++ b/IPython/core/logger.py
@@ -118,7 +118,7 @@ class Logger(object):
                     for f in old:
                         root, ext = os.path.splitext(f)
                         num = int(ext[1:-1])+1
-                        os.rename(f, root+'.'+`num`.zfill(3)+'~')
+                        os.rename(f, root+'.'+repr(num).zfill(3)+'~')
                 os.rename(self.logfname, self.logfname+'.001~')
             self.logfile = io.open(self.logfname, 'w', encoding='utf-8')
 

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -584,7 +584,7 @@ class Magics(object):
             # Do regular option processing
             try:
                 opts,args = getopt(argv, opt_str, long_opts)
-            except GetoptError,e:
+            except GetoptError as e:
                 raise UsageError('%s ( allowed: "%s" %s)' % (e.msg,opt_str,
                                         " ".join(long_opts)))
             for o,a in opts:

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -194,14 +194,14 @@ def _method_magic_marker(magic_kind):
         if callable(arg):
             # "Naked" decorator call (just @foo, no args)
             func = arg
-            name = func.func_name
+            name = func.__name__
             retval = decorator(call, func)
             record_magic(magics, magic_kind, name, name)
         elif isinstance(arg, basestring):
             # Decorator called with arguments (@foo('bar'))
             name = arg
             def mark(func, *a, **kw):
-                record_magic(magics, magic_kind, name, func.func_name)
+                record_magic(magics, magic_kind, name, func.__name__)
                 return decorator(call, func)
             retval = mark
         else:
@@ -239,7 +239,7 @@ def _function_magic_marker(magic_kind):
         if callable(arg):
             # "Naked" decorator call (just @foo, no args)
             func = arg
-            name = func.func_name
+            name = func.__name__
             ip.register_magic_function(func, magic_kind, name)
             retval = decorator(call, func)
         elif isinstance(arg, basestring):
@@ -432,7 +432,7 @@ class MagicsManager(Configurable):
         # Create the new method in the user_magics and register it in the
         # global table
         validate_type(magic_kind)
-        magic_name = func.func_name if magic_name is None else magic_name
+        magic_name = func.__name__ if magic_name is None else magic_name
         setattr(self.user_magics, magic_name, func)
         record_magic(self.magics, magic_kind, magic_name, func)
 

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -14,6 +14,7 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 # Stdlib
 import os
 import re
@@ -510,8 +511,8 @@ class Magics(object):
 
     def arg_err(self,func):
         """Print docstring if incorrect arguments were passed"""
-        print 'Error in arguments:'
-        print oinspect.getdoc(func)
+        print('Error in arguments:')
+        print(oinspect.getdoc(func))
 
     def format_latex(self, strng):
         """Format a string for latex inclusion."""

--- a/IPython/core/magics/auto.py
+++ b/IPython/core/magics/auto.py
@@ -11,6 +11,7 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 # Our own packages
 from IPython.core.magic import Bunch, Magics, magics_class, line_magic
@@ -57,7 +58,7 @@ class AutoMagics(Magics):
         else:
             val = not mman.auto_magic
         mman.auto_magic = val
-        print '\n' + self.shell.magics_manager.auto_status()
+        print('\n' + self.shell.magics_manager.auto_status())
 
     @skip_doctest
     @line_magic
@@ -125,4 +126,4 @@ class AutoMagics(Magics):
                 except AttributeError:
                     self.shell.autocall = self._magic_state.autocall_save = 1
 
-        print "Automatic calling is:",['OFF','Smart','Full'][self.shell.autocall]
+        print("Automatic calling is:",['OFF','Smart','Full'][self.shell.autocall])

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -513,7 +513,7 @@ class CodeMagics(Magics):
         if is_temp:
             try:
                 return open(filename).read()
-            except IOError,msg:
+            except IOError as msg:
                 if msg.filename == filename:
                     warn('File not found. Did you forget to save?')
                     return

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -11,6 +11,7 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 # Stdlib
 import inspect
@@ -81,21 +82,21 @@ class CodeMagics(Magics):
             try:
                 overwrite = self.shell.ask_yes_no('File `%s` exists. Overwrite (y/[N])? ' % fname, default='n')
             except StdinNotImplementedError:
-                print "File `%s` exists. Use `%%save -f %s` to force overwrite" % (fname, parameter_s)
+                print("File `%s` exists. Use `%%save -f %s` to force overwrite" % (fname, parameter_s))
                 return
             if not overwrite :
-                print 'Operation cancelled.'
+                print('Operation cancelled.')
                 return
         try:
             cmds = self.shell.find_user_code(codefrom,raw)
         except (TypeError, ValueError) as e:
-            print e.args[0]
+            print(e.args[0])
             return
         with io.open(fname,'w', encoding="utf-8") as f:
             f.write(u"# coding: utf-8\n")
             f.write(py3compat.cast_unicode(cmds))
-        print 'The following commands were written to file `%s`:' % fname
-        print cmds
+        print('The following commands were written to file `%s`:' % fname)
+        print(cmds)
 
     @line_magic
     def pastebin(self, parameter_s=''):
@@ -117,7 +118,7 @@ class CodeMagics(Magics):
         try:
             code = self.shell.find_user_code(args)
         except (ValueError, TypeError) as e:
-            print e.args[0]
+            print(e.args[0])
             return
 
         post_data = json.dumps({
@@ -183,7 +184,7 @@ class CodeMagics(Magics):
                 ans = True
 
             if ans is False :
-                print 'Operation cancelled.'
+                print('Operation cancelled.')
                 return
 
         self.shell.set_next_input(contents)
@@ -308,7 +309,7 @@ class CodeMagics(Magics):
 
         if use_temp:
             filename = shell.mktempfile(data)
-            print 'IPython will make a temporary file named:',filename
+            print('IPython will make a temporary file named:',filename)
 
         return filename, lineno, use_temp
 
@@ -483,7 +484,7 @@ class CodeMagics(Magics):
             return
 
         # do actual editing here
-        print 'Editing...',
+        print('Editing...', end=' ')
         sys.stdout.flush()
         try:
             # Quote filenames that may have spaces in them
@@ -500,9 +501,9 @@ class CodeMagics(Magics):
             self.shell.user_ns['pasted_block'] = file_read(filename)
 
         if 'x' in opts:  # -x prevents actual execution
-            print
+            print()
         else:
-            print 'done. Executing edited code...'
+            print('done. Executing edited code...')
             if 'r' in opts:    # Untranslated IPython code
                 self.shell.run_cell(file_read(filename),
                                                     store_history=False)

--- a/IPython/core/magics/config.py
+++ b/IPython/core/magics/config.py
@@ -11,6 +11,7 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 # Stdlib
 import re
@@ -115,9 +116,9 @@ class ConfigMagics(Magics):
         line = s.strip()
         if not line:
             # print available configurable names
-            print "Available objects for config:"
+            print("Available objects for config:")
             for name in classnames:
-                print "    ", name
+                print("    ", name)
             return
         elif line in classnames:
             # `%config TerminalInteractiveShell` will print trait info for
@@ -127,7 +128,7 @@ class ConfigMagics(Magics):
             help = cls.class_get_help(c)
             # strip leading '--' from cl-args:
             help = re.sub(re.compile(r'^--', re.MULTILINE), '', help)
-            print help
+            print(help)
             return
         elif '=' not in line:
             raise UsageError("Invalid config statement: %r, "

--- a/IPython/core/magics/deprecated.py
+++ b/IPython/core/magics/deprecated.py
@@ -11,6 +11,7 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 # Our own packages
 from IPython.core.magic import Magics, magics_class, line_magic
@@ -26,20 +27,20 @@ class DeprecatedMagics(Magics):
     @line_magic
     def install_profiles(self, parameter_s=''):
         """%install_profiles has been deprecated."""
-        print '\n'.join([
+        print('\n'.join([
             "%install_profiles has been deprecated.",
             "Use `ipython profile list` to view available profiles.",
             "Requesting a profile with `ipython profile create <name>`",
             "or `ipython --profile=<name>` will start with the bundled",
             "profile of that name if it exists."
-        ])
+        ]))
 
     @line_magic
     def install_default_config(self, parameter_s=''):
         """%install_default_config has been deprecated."""
-        print '\n'.join([
+        print('\n'.join([
             "%install_default_config has been deprecated.",
             "Use `ipython profile create <name>` to initialize a profile",
             "with the default config files.",
             "Add `--reset` to overwrite already existing config files with defaults."
-        ])
+        ]))

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -255,14 +255,14 @@ python-profiler package from non-free.""")
             dump_file = unquote_filename(dump_file)
             prof.dump_stats(dump_file)
             print('\n*** Profile stats marshalled to file',\
-                  `dump_file`+'.',sys_exit)
+                  repr(dump_file)+'.',sys_exit)
         if text_file:
             text_file = unquote_filename(text_file)
             pfile = open(text_file,'w')
             pfile.write(output)
             pfile.close()
             print('\n*** Profile printout saved to text file',\
-                  `text_file`+'.',sys_exit)
+                  repr(text_file)+'.',sys_exit)
 
         if opts.has_key('r'):
             return stats

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -11,6 +11,7 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 # Stdlib
 import __builtin__ as builtin_mod
@@ -246,22 +247,22 @@ python-profiler package from non-free.""")
 
         if 'q' not in opts:
             page.page(output)
-        print sys_exit,
+        print(sys_exit, end=' ')
 
         dump_file = opts.D[0]
         text_file = opts.T[0]
         if dump_file:
             dump_file = unquote_filename(dump_file)
             prof.dump_stats(dump_file)
-            print '\n*** Profile stats marshalled to file',\
-                  `dump_file`+'.',sys_exit
+            print('\n*** Profile stats marshalled to file',\
+                  `dump_file`+'.',sys_exit)
         if text_file:
             text_file = unquote_filename(text_file)
             pfile = open(text_file,'w')
             pfile.write(output)
             pfile.close()
-            print '\n*** Profile printout saved to text file',\
-                  `text_file`+'.',sys_exit
+            print('\n*** Profile printout saved to text file',\
+                  `text_file`+'.',sys_exit)
 
         if opts.has_key('r'):
             return stats
@@ -301,7 +302,7 @@ python-profiler package from non-free.""")
 
         # set on the shell
         self.shell.call_pdb = new_pdb
-        print 'Automatic pdb calling has been turned',on_off(new_pdb)
+        print('Automatic pdb calling has been turned',on_off(new_pdb))
 
     @line_magic
     def debug(self, parameter_s=''):
@@ -463,7 +464,7 @@ python-profiler package from non-free.""")
             filename = file_finder(arg_lst[0])
         except IndexError:
             warn('you must provide at least a filename.')
-            print '\n%run:\n', oinspect.getdoc(self.run)
+            print('\n%run:\n', oinspect.getdoc(self.run))
             return
         except IOError as e:
             try:
@@ -558,8 +559,8 @@ python-profiler package from non-free.""")
                         # if we find a good linenumber, set the breakpoint
                         deb.do_break('%s:%s' % (filename, bp))
                         # Start file run
-                        print "NOTE: Enter 'c' at the",
-                        print "%s prompt to start your script." % deb.prompt
+                        print("NOTE: Enter 'c' at the", end=' ')
+                        print("%s prompt to start your script." % deb.prompt)
                         ns = {'execfile': py3compat.execfile, 'prog_ns': prog_ns}
                         try:
                             deb.run('execfile("%s", prog_ns)' % filename, ns)
@@ -592,9 +593,9 @@ python-profiler package from non-free.""")
                                 t1 = clock2()
                                 t_usr = t1[0] - t0[0]
                                 t_sys = t1[1] - t0[1]
-                                print "\nIPython CPU timings (estimated):"
-                                print "  User   : %10.2f s." % t_usr
-                                print "  System : %10.2f s." % t_sys
+                                print("\nIPython CPU timings (estimated):")
+                                print("  User   : %10.2f s." % t_usr)
+                                print("  System : %10.2f s." % t_sys)
                             else:
                                 runs = range(nruns)
                                 t0 = clock2()
@@ -604,13 +605,13 @@ python-profiler package from non-free.""")
                                 t1 = clock2()
                                 t_usr = t1[0] - t0[0]
                                 t_sys = t1[1] - t0[1]
-                                print "\nIPython CPU timings (estimated):"
-                                print "Total runs performed:", nruns
-                                print "  Times  : %10.2f    %10.2f" % ('Total', 'Per run')
-                                print "  User   : %10.2f s, %10.2f s." % (t_usr, t_usr / nruns)
-                                print "  System : %10.2f s, %10.2f s." % (t_sys, t_sys / nruns)
+                                print("\nIPython CPU timings (estimated):")
+                                print("Total runs performed:", nruns)
+                                print("  Times  : %10.2f    %10.2f" % ('Total', 'Per run'))
+                                print("  User   : %10.2f s, %10.2f s." % (t_usr, t_usr / nruns))
+                                print("  System : %10.2f s, %10.2f s." % (t_sys, t_sys / nruns))
                             twall1 = time.time()
-                            print "Wall time: %10.2f s." % (twall1 - twall0)
+                            print("Wall time: %10.2f s." % (twall1 - twall0))
 
                         else:
                             # regular execution
@@ -810,12 +811,12 @@ python-profiler package from non-free.""")
             order = 0
         else:
             order = 3
-        print u"%d loops, best of %d: %.*g %s per loop" % (number, repeat,
+        print(u"%d loops, best of %d: %.*g %s per loop" % (number, repeat,
                                                           precision,
                                                           best * scaling[order],
-                                                          units[order])
+                                                          units[order]))
         if tc > tc_min:
-            print "Compiler time: %.2f s" % tc
+            print("Compiler time: %.2f s" % tc)
 
     @skip_doctest
     @needs_local_scope
@@ -905,11 +906,11 @@ python-profiler package from non-free.""")
         cpu_user = end[0]-st[0]
         cpu_sys = end[1]-st[1]
         cpu_tot = cpu_user+cpu_sys
-        print "CPU times: user %.2f s, sys: %.2f s, total: %.2f s" % \
-              (cpu_user,cpu_sys,cpu_tot)
-        print "Wall time: %.2f s" % wall_time
+        print("CPU times: user %.2f s, sys: %.2f s, total: %.2f s" % \
+              (cpu_user,cpu_sys,cpu_tot))
+        print("Wall time: %.2f s" % wall_time)
         if tc > tc_min:
-            print "Compiler : %.2f s" % tc
+            print("Compiler : %.2f s" % tc)
         return out
 
     @skip_doctest
@@ -983,13 +984,13 @@ python-profiler package from non-free.""")
         try:
             lines = self.shell.find_user_code(codefrom, 'r' in opts)
         except (ValueError, TypeError) as e:
-            print e.args[0]
+            print(e.args[0])
             return
         macro = Macro(lines)
         self.shell.define_macro(name, macro)
-        print 'Macro `%s` created. To execute, type its name (without quotes).' % name
-        print '=== Macro contents: ==='
-        print macro,
+        print('Macro `%s` created. To execute, type its name (without quotes).' % name)
+        print('=== Macro contents: ===')
+        print(macro, end=' ')
     
     @magic_arguments.magic_arguments()
     @magic_arguments.argument('output', type=str, default='', nargs='?',

--- a/IPython/core/magics/extension.py
+++ b/IPython/core/magics/extension.py
@@ -11,6 +11,7 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 # Stdlib
 import os
@@ -45,12 +46,12 @@ class ExtensionMagics(Magics):
             filename = self.shell.extension_manager.install_extension(args,
                                                                  opts.get('n'))
         except ValueError as e:
-            print e
+            print(e)
             return
 
         filename = os.path.basename(filename)
-        print "Installed %s. To use it, type:" % filename
-        print "  %%load_ext %s" % os.path.splitext(filename)[0]
+        print("Installed %s. To use it, type:" % filename)
+        print("  %%load_ext %s" % os.path.splitext(filename)[0])
 
 
     @line_magic

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -113,7 +113,7 @@ class NamespaceMagics(Magics):
         if out == 'not found':
             try:
                 filename = get_py_filename(parameter_s)
-            except IOError,msg:
+            except IOError as msg:
                 print msg
                 return
             page.page(self.shell.inspector.format(open(filename).read()))

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -11,6 +11,7 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 # Stdlib
 import gc
@@ -114,7 +115,7 @@ class NamespaceMagics(Magics):
             try:
                 filename = get_py_filename(parameter_s)
             except IOError as msg:
-                print msg
+                print(msg)
                 return
             page.page(self.shell.inspector.format(open(filename).read()))
 
@@ -201,7 +202,7 @@ class NamespaceMagics(Magics):
         try:
             parameter_s.encode('ascii')
         except UnicodeEncodeError:
-            print 'Python identifiers can only contain ascii characters.'
+            print('Python identifiers can only contain ascii characters.')
             return
 
         # default namespaces to be searched
@@ -323,20 +324,20 @@ class NamespaceMagics(Magics):
         varlist = self.who_ls(parameter_s)
         if not varlist:
             if parameter_s:
-                print 'No variables match your requested type.'
+                print('No variables match your requested type.')
             else:
-                print 'Interactive namespace is empty.'
+                print('Interactive namespace is empty.')
             return
 
         # if we have variables, move on...
         count = 0
         for i in varlist:
-            print i+'\t',
+            print(i+'\t', end=' ')
             count += 1
             if count > 8:
                 count = 0
-                print
-        print
+                print()
+        print()
 
     @skip_doctest
     @line_magic
@@ -374,9 +375,9 @@ class NamespaceMagics(Magics):
         varnames = self.who_ls(parameter_s)
         if not varnames:
             if parameter_s:
-                print 'No variables match your requested type.'
+                print('No variables match your requested type.')
             else:
-                print 'Interactive namespace is empty.'
+                print('Interactive namespace is empty.')
             return
 
         # if we have variables, move on...
@@ -428,15 +429,15 @@ class NamespaceMagics(Magics):
         varwidth = max(max(map(len,varnames)), len(varlabel)) + colsep
         typewidth = max(max(map(len,typelist)), len(typelabel)) + colsep
         # table header
-        print varlabel.ljust(varwidth) + typelabel.ljust(typewidth) + \
-              ' '+datalabel+'\n' + '-'*(varwidth+typewidth+len(datalabel)+1)
+        print(varlabel.ljust(varwidth) + typelabel.ljust(typewidth) + \
+              ' '+datalabel+'\n' + '-'*(varwidth+typewidth+len(datalabel)+1))
         # and the table itself
         kb = 1024
         Mb = 1048576  # kb**2
         for vname,var,vtype in zip(varnames,varlist,typelist):
-            print vformat.format(vname, vtype, varwidth=varwidth, typewidth=typewidth),
+            print(vformat.format(vname, vtype, varwidth=varwidth, typewidth=typewidth), end=' ')
             if vtype in seq_types:
-                print "n="+str(len(var))
+                print("n="+str(len(var)))
             elif vtype == ndarray_type:
                 vshape = str(var.shape).replace(',','').replace(' ','x')[1:-1]
                 if vtype==ndarray_type:
@@ -446,13 +447,13 @@ class NamespaceMagics(Magics):
                     vdtype = var.dtype
 
                 if vbytes < 100000:
-                    print aformat % (vshape, vsize, vdtype, vbytes)
+                    print(aformat % (vshape, vsize, vdtype, vbytes))
                 else:
-                    print aformat % (vshape, vsize, vdtype, vbytes),
+                    print(aformat % (vshape, vsize, vdtype, vbytes), end=' ')
                     if vbytes < Mb:
-                        print '(%s kb)' % (vbytes/kb,)
+                        print('(%s kb)' % (vbytes/kb,))
                     else:
-                        print '(%s Mb)' % (vbytes/Mb,)
+                        print('(%s Mb)' % (vbytes/Mb,))
             else:
                 try:
                     vstr = str(var)
@@ -463,9 +464,9 @@ class NamespaceMagics(Magics):
                     vstr = "<object with id %d (str() failed)>" % id(var)
                 vstr = vstr.replace('\n', '\\n')
                 if len(vstr) < 50:
-                    print vstr
+                    print(vstr)
                 else:
-                    print vstr[:25] + "<...>" + vstr[-25:]
+                    print(vstr[:25] + "<...>" + vstr[-25:])
 
     @line_magic
     def reset(self, parameter_s=''):
@@ -536,7 +537,7 @@ class NamespaceMagics(Magics):
             except StdinNotImplementedError:
                 ans = True
         if not ans:
-            print 'Nothing done.'
+            print('Nothing done.')
             return
 
         if 's' in opts:                     # Soft reset
@@ -553,11 +554,11 @@ class NamespaceMagics(Magics):
         for target in args:
             target = target.lower() # make matches case insensitive
             if target == 'out':
-                print "Flushing output cache (%d entries)" % len(user_ns['_oh'])
+                print("Flushing output cache (%d entries)" % len(user_ns['_oh']))
                 self.shell.displayhook.flush()
 
             elif target == 'in':
-                print "Flushing input history"
+                print("Flushing input history")
                 pc = self.shell.displayhook.prompt_count + 1
                 for n in range(1, pc):
                     key = '_i'+repr(n)
@@ -581,15 +582,15 @@ class NamespaceMagics(Magics):
                         if isinstance(val,ndarray):
                             del user_ns[x]
                 except ImportError:
-                    print "reset array only works if Numpy is available."
+                    print("reset array only works if Numpy is available.")
 
             elif target == 'dhist':
-                print "Flushing directory history"
+                print("Flushing directory history")
                 del user_ns['_dh'][:]
 
             else:
-                print "Don't know how to reset ",
-                print target + ", please run `%reset?` for details"
+                print("Don't know how to reset ", end=' ')
+                print(target + ", please run `%reset?` for details")
 
         gc.collect()
 
@@ -666,11 +667,11 @@ class NamespaceMagics(Magics):
             except StdinNotImplementedError:
                 ans = True
         if not ans:
-            print 'Nothing done.'
+            print('Nothing done.')
             return
         user_ns = self.shell.user_ns
         if not regex:
-            print 'No regex pattern specified. Nothing done.'
+            print('No regex pattern specified. Nothing done.')
             return
         else:
             try:
@@ -697,4 +698,4 @@ class NamespaceMagics(Magics):
         try:
             self.shell.del_var(varname, ('n' in opts))
         except (NameError, ValueError) as e:
-            print type(e).__name__ +": "+ str(e)
+            print(type(e).__name__ +": "+ str(e))

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -14,6 +14,7 @@ builtin.
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 # Stdlib
 import io
@@ -105,7 +106,7 @@ class OSMagics(Magics):
             # for k, v in stored:
             #     atab.append(k, v[0])
 
-            print "Total number of aliases:", len(aliases)
+            print("Total number of aliases:", len(aliases))
             sys.stdout.flush()
             return aliases
 
@@ -113,7 +114,7 @@ class OSMagics(Magics):
         try:
             alias,cmd = par.split(None, 1)
         except:
-            print oinspect.getdoc(self.alias)
+            print(oinspect.getdoc(self.alias))
         else:
             self.shell.alias_manager.soft_define_alias(alias, cmd)
     # end magic_alias
@@ -126,7 +127,7 @@ class OSMagics(Magics):
         self.shell.alias_manager.undefine_alias(aname)
         stored = self.shell.db.get('stored_aliases', {} )
         if aname in stored:
-            print "Removing %stored alias",aname
+            print("Removing %stored alias",aname)
             del stored[aname]
             self.shell.db['stored_aliases'] = stored
 
@@ -272,7 +273,7 @@ class OSMagics(Magics):
             try:
                 ps = self.shell.user_ns['_dh'][nn]
             except IndexError:
-                print 'The requested directory does not exist in history.'
+                print('The requested directory does not exist in history.')
                 return
             else:
                 opts = {}
@@ -295,7 +296,7 @@ class OSMagics(Magics):
                 ps = fallback
 
             if ps is None:
-                print "No matching entry in directory history"
+                print("No matching entry in directory history")
                 return
             else:
                 opts = {}
@@ -319,7 +320,7 @@ class OSMagics(Magics):
 
                 if ps in bkms:
                     target = bkms[ps]
-                    print '(bookmark:%s) -> %s' % (ps, target)
+                    print('(bookmark:%s) -> %s' % (ps, target))
                     ps = target
                 else:
                     if 'b' in opts:
@@ -335,7 +336,7 @@ class OSMagics(Magics):
                 if hasattr(self.shell, 'term_title') and self.shell.term_title:
                     set_term_title('IPython: ' + abbrev_cwd())
             except OSError:
-                print sys.exc_info()[1]
+                print(sys.exc_info()[1])
             else:
                 cwd = os.getcwdu()
                 dhist = self.shell.user_ns['_dh']
@@ -354,7 +355,7 @@ class OSMagics(Magics):
                 dhist.append(cwd)
                 self.shell.db['dhist'] = compress_dhist(dhist)[-100:]
         if not 'q' in opts and self.shell.user_ns['_dh']:
-            print self.shell.user_ns['_dh'][-1]
+            print(self.shell.user_ns['_dh'][-1])
 
 
     @line_magic
@@ -387,7 +388,7 @@ class OSMagics(Magics):
             raise UsageError("%popd on empty stack")
         top = self.shell.dir_stack.pop(0)
         self.cd(top)
-        print "popd ->",top
+        print("popd ->",top)
 
     @line_magic
     def dirs(self, parameter_s=''):
@@ -542,7 +543,7 @@ class OSMagics(Magics):
         split = 'l' in opts
         out = self.shell.getoutput(cmd, split=split)
         if 'v' in opts:
-            print '%s ==\n%s' % (var, pformat(out))
+            print('%s ==\n%s' % (var, pformat(out)))
         if var:
             self.shell.user_ns.update({var:out})
         else:
@@ -654,9 +655,9 @@ class OSMagics(Magics):
             else:
                 size = 0
             fmt = '%-'+str(size)+'s -> %s'
-            print 'Current bookmarks:'
+            print('Current bookmarks:')
             for bk in bks:
-                print fmt % (bk, bkms[bk])
+                print(fmt % (bk, bkms[bk]))
         else:
             if not args:
                 raise UsageError("%bookmark: You must specify the bookmark name")
@@ -685,7 +686,7 @@ class OSMagics(Magics):
         try :
             cont = self.shell.find_user_code(parameter_s)
         except (ValueError, IOError):
-            print "Error: no such file, variable, URL, history range or macro"
+            print("Error: no such file, variable, URL, history range or macro")
             return
 
         page.page(self.shell.pycolorize(cont))
@@ -710,11 +711,11 @@ class OSMagics(Magics):
         
         if os.path.exists(filename):
             if args.amend:
-                print "Amending to %s" % filename
+                print("Amending to %s" % filename)
             else:
-                print "Overwriting %s" % filename
+                print("Overwriting %s" % filename)
         else:
-            print "Writing %s" % filename
+            print("Writing %s" % filename)
         
         mode = 'a' if args.amend else 'w'
         with io.open(filename, mode, encoding='utf-8') as f:

--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -10,6 +10,7 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 # Stdlib
 import os
@@ -220,20 +221,20 @@ class ScriptMagics(Magics, Configurable):
                 p.send_signal(signal.SIGINT)
                 time.sleep(0.1)
                 if p.poll() is not None:
-                    print "Process is interrupted."
+                    print("Process is interrupted.")
                     return
                 p.terminate()
                 time.sleep(0.1)
                 if p.poll() is not None:
-                    print "Process is terminated."
+                    print("Process is terminated.")
                     return
                 p.kill()
-                print "Process is killed."
+                print("Process is killed.")
             except OSError:
                 pass
             except Exception as e:
-                print "Error while terminating subprocess (pid=%i): %s" \
-                    % (p.pid, e)
+                print("Error while terminating subprocess (pid=%i): %s" \
+                    % (p.pid, e))
             return
         out = py3compat.bytes_to_str(out)
         err = py3compat.bytes_to_str(err)
@@ -258,7 +259,7 @@ class ScriptMagics(Magics, Configurable):
     def killbgscripts(self, _nouse_=''):
         """Kill all BG processes started by %%script and its family."""
         self.kill_bg_processes()
-        print "All background processes were killed."
+        print("All background processes were killed.")
 
     def kill_bg_processes(self):
         """Kill all BG processes which are still running."""

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -164,8 +164,8 @@ def getargspec(obj):
         func_obj = obj.__call__
     else:
         raise TypeError('arg is not a Python function')
-    args, varargs, varkw = inspect.getargs(func_obj.func_code)
-    return args, varargs, varkw, func_obj.func_defaults
+    args, varargs, varkw = inspect.getargs(func_obj.__code__)
+    return args, varargs, varkw, func_obj.__defaults__
 
 
 def format_argspec(argspec):

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -15,6 +15,7 @@ reference the name under which an object is being read.
 #*****************************************************************************
 
 __all__ = ['Inspector','InspectColors']
+from __future__ import print_function
 
 # stdlib modules
 import __builtin__
@@ -335,11 +336,11 @@ class Inspector:
 
     def noinfo(self, msg, oname):
         """Generic message when no information is found."""
-        print 'No %s found' % msg,
+        print('No %s found' % msg, end=' ')
         if oname:
-            print 'for %s' % oname
+            print('for %s' % oname)
         else:
-            print
+            print()
 
     def pdef(self, obj, oname=''):
         """Print the definition header for any callable object.
@@ -347,7 +348,7 @@ class Inspector:
         If the object is a class, print the constructor information."""
 
         if not callable(obj):
-            print 'Object is not callable.'
+            print('Object is not callable.')
             return
 
         header = ''
@@ -362,7 +363,7 @@ class Inspector:
         if output is None:
             self.noinfo('definition header',oname)
         else:
-            print >>io.stdout, header,self.format(output),
+            print(header,self.format(output), end=' ', file=io.stdout)
 
     # In Python 3, all classes are new-style, so they all have __init__.
     @skip_doctest_py3
@@ -449,9 +450,9 @@ class Inspector:
         # is defined, as long as the file isn't binary and is actually on the
         # filesystem.
         if ofile.endswith(('.so', '.dll', '.pyd')):
-            print 'File %r is binary, not printing.' % ofile
+            print('File %r is binary, not printing.' % ofile)
         elif not os.path.isfile(ofile):
-            print 'File %r does not exist, not printing.' % ofile
+            print('File %r does not exist, not printing.' % ofile)
         else:
             # Print only text files, not extension binaries.  Note that
             # getsourcelines returns lineno with 1-offset and page() uses

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -13,9 +13,9 @@ reference the name under which an object is being read.
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.
 #*****************************************************************************
+from __future__ import print_function
 
 __all__ = ['Inspector','InspectColors']
-from __future__ import print_function
 
 # stdlib modules
 import __builtin__

--- a/IPython/core/page.py
+++ b/IPython/core/page.py
@@ -221,7 +221,7 @@ def page(strng, start=0, screen_lines=0, pager_cmd=None):
                 pager.write(strng)
                 pager.close()
                 retval = pager.close()  # success returns None
-            except IOError,msg:  # broken pipe when user quits
+            except IOError as msg:  # broken pipe when user quits
                 if msg.args == (32,'Broken pipe'):
                     retval = None
                 else:

--- a/IPython/core/page.py
+++ b/IPython/core/page.py
@@ -251,7 +251,7 @@ def page_file(fname, start=0, pager_cmd=None):
                 start -= 1
             page(open(fname).read(),start)
         except:
-            print('Unable to show file',`fname`)
+            print('Unable to show file',repr(fname))
 
 
 def get_pager_cmd(pager_cmd=None):

--- a/IPython/core/page.py
+++ b/IPython/core/page.py
@@ -25,6 +25,7 @@ rid of that dependency, we could move it there.
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 import os
 import re
@@ -57,18 +58,18 @@ def page_dumb(strng, start=0, screen_lines=25):
     out_ln  = strng.splitlines()[start:]
     screens = chop(out_ln,screen_lines-1)
     if len(screens) == 1:
-        print >>io.stdout, os.linesep.join(screens[0])
+        print(os.linesep.join(screens[0]), file=io.stdout)
     else:
         last_escape = ""
         for scr in screens[0:-1]:
             hunk = os.linesep.join(scr)
-            print >>io.stdout, last_escape + hunk
+            print(last_escape + hunk, file=io.stdout)
             if not page_more():
                 return
             esc_list = esc_re.findall(hunk)
             if len(esc_list) > 0:
                 last_escape = esc_list[-1]
-        print >>io.stdout, last_escape + os.linesep.join(screens[-1])
+        print(last_escape + os.linesep.join(screens[-1]), file=io.stdout)
 
 def _detect_screen_size(use_curses, screen_lines_def):
     """Attempt to work out the number of lines on the screen.
@@ -163,7 +164,7 @@ def page(strng, start=0, screen_lines=0, pager_cmd=None):
     # Ugly kludge, but calling curses.initscr() flat out crashes in emacs
     TERM = os.environ.get('TERM','dumb')
     if TERM in ['dumb','emacs'] and os.name != 'nt':
-        print strng
+        print(strng)
         return
     # chop off the topmost part of the string we don't want to see
     str_lines = strng.splitlines()[start:]
@@ -183,13 +184,13 @@ def page(strng, start=0, screen_lines=0, pager_cmd=None):
         try:
             screen_lines += _detect_screen_size(use_curses, screen_lines_def)
         except (TypeError, UnsupportedOperation):
-            print >>io.stdout, str_toprint
+            print(str_toprint, file=io.stdout)
             return
 
     #print 'numlines',numlines,'screenlines',screen_lines  # dbg
     if numlines <= screen_lines :
         #print '*** normal print'  # dbg
-        print >>io.stdout, str_toprint
+        print(str_toprint, file=io.stdout)
     else:
         # Try to open pager and default to internal one if that fails.
         # All failure modes are tagged as 'retval=1', to match the return
@@ -250,7 +251,7 @@ def page_file(fname, start=0, pager_cmd=None):
                 start -= 1
             page(open(fname).read(),start)
         except:
-            print 'Unable to show file',`fname`
+            print('Unable to show file',`fname`)
 
 
 def get_pager_cmd(pager_cmd=None):
@@ -325,13 +326,13 @@ def snip_print(str,width = 75,print_full = 0,header = ''):
         page(header+str)
         return 0
 
-    print header,
+    print(header, end=' ')
     if len(str) < width:
-        print str
+        print(str)
         snip = 0
     else:
         whalf = int((width -5)/2)
-        print str[:whalf] + ' <...> ' + str[-whalf:]
+        print(str[:whalf] + ' <...> ' + str[-whalf:])
         snip = 1
     if snip and print_full == 2:
         if raw_input(header+' Snipped. View (y/n)? [N]').lower() == 'y':

--- a/IPython/core/profileapp.py
+++ b/IPython/core/profileapp.py
@@ -20,6 +20,7 @@ Authors:
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 import logging
 import os
@@ -126,7 +127,7 @@ class ProfileLocate(BaseIPythonApplication):
             self.profile = self.extra_args[0]
     
     def start(self):
-        print self.profile_dir.location
+        print(self.profile_dir.location)
 
 
 class ProfileList(Application):
@@ -157,35 +158,35 @@ class ProfileList(Application):
     def _print_profiles(self, profiles):
         """print list of profiles, indented."""
         for profile in profiles:
-            print '    %s' % profile
+            print('    %s' % profile)
 
     def list_profile_dirs(self):
         profiles = list_bundled_profiles()
         if profiles:
-            print
-            print "Available profiles in IPython:"
+            print()
+            print("Available profiles in IPython:")
             self._print_profiles(profiles)
-            print
-            print "    The first request for a bundled profile will copy it"
-            print "    into your IPython directory (%s)," % self.ipython_dir
-            print "    where you can customize it."
+            print()
+            print("    The first request for a bundled profile will copy it")
+            print("    into your IPython directory (%s)," % self.ipython_dir)
+            print("    where you can customize it.")
         
         profiles = list_profiles_in(self.ipython_dir)
         if profiles:
-            print
-            print "Available profiles in %s:" % self.ipython_dir
+            print()
+            print("Available profiles in %s:" % self.ipython_dir)
             self._print_profiles(profiles)
         
         profiles = list_profiles_in(os.getcwdu())
         if profiles:
-            print
-            print "Available profiles in current directory (%s):" % os.getcwdu()
+            print()
+            print("Available profiles in current directory (%s):" % os.getcwdu())
             self._print_profiles(profiles)
         
-        print
-        print "To use any of the above profiles, start IPython with:"
-        print "    ipython --profile=<name>"
-        print
+        print()
+        print("To use any of the above profiles, start IPython with:")
+        print("    ipython --profile=<name>")
+        print()
 
     def start(self):
         self.list_profile_dirs()
@@ -297,8 +298,8 @@ class ProfileApp(Application):
 
     def start(self):
         if self.subapp is None:
-            print "No subcommand specified. Must specify one of: %s"%(self.subcommands.keys())
-            print
+            print("No subcommand specified. Must specify one of: %s"%(self.subcommands.keys()))
+            print()
             self.print_description()
             self.print_subcommands()
             self.exit(1)

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -18,6 +18,7 @@ Authors
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 import sys
 from io import BytesIO
@@ -71,7 +72,7 @@ def getfigs(*fig_nums):
         for num in fig_nums:
             f = Gcf.figs.get(num)
             if f is None:
-                print('Warning: figure %s not available.' % num)
+                print(('Warning: figure %s not available.' % num))
             else:
                 figs.append(f.canvas.figure)
         return figs
@@ -332,9 +333,9 @@ def pylab_activate(user_ns, gui=None, import_all=True, shell=None):
     if shell is not None:
         configure_inline_support(shell, backend, user_ns)
         
-    print """
+    print("""
 Welcome to pylab, a matplotlib-based Python environment [backend: %s].
-For more information, type 'help(pylab)'.""" % backend
+For more information, type 'help(pylab)'.""" % backend)
     # flush stdout, just to be safe
     sys.stdout.flush()
     

--- a/IPython/core/tests/refbug.py
+++ b/IPython/core/tests/refbug.py
@@ -16,6 +16,8 @@ test_run.py calls it.
 #-----------------------------------------------------------------------------
 # Module imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
+
 import sys
 
 from IPython.core import ipapi
@@ -44,4 +46,4 @@ if __name__ == '__main__':
 
     def call_f():
         for func in cache:
-            print 'lowercased:',func().lower()
+            print('lowercased:',func().lower())

--- a/IPython/core/tests/test_inputsplitter.py
+++ b/IPython/core/tests/test_inputsplitter.py
@@ -16,6 +16,7 @@ Authors
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 # stdlib
 import unittest
 import sys
@@ -719,10 +720,10 @@ if __name__ == '__main__':
             # real interpreter would instead send it for execution somewhere.
             #src = isp.source; raise EOFError # dbg
             src, raw = isp.source_raw_reset()
-            print 'Input source was:\n', src
-            print 'Raw source was:\n', raw
+            print('Input source was:\n', src)
+            print('Raw source was:\n', raw)
     except EOFError:
-        print 'Bye'
+        print('Bye')
 
 # Tests for cell magics support
 

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -291,7 +291,7 @@ def doctest_time():
     Wall time: 0.00 s
     
     In [11]: def f(kmjy):
-       ....:    %time print 2*kmjy
+       ....:    %time print(2*kmjy)
        
     In [12]: f(3)
     6

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -201,7 +201,7 @@ class TestMagicRunSimple(tt.TempFileMixin):
                "for i in range(5):\n"
                "   try:\n"
                "       ip.magic('run %s')\n"
-               "   except NameError, e:\n"
+               "   except NameError as e:\n"
                "       print i;break\n" % empty.fname)
         self.mktmp(py3compat.doctest_refactor_print(src))
         _ip.magic('run %s' % self.fname)

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -875,7 +875,7 @@ class VerboseTB(TBTools):
             except (IndexError, UnicodeDecodeError):
                 # signals exit of tokenizer
                 pass
-            except tokenize.TokenError,msg:
+            except tokenize.TokenError as msg:
                 _m = ("An unexpected error occurred while tokenizing input\n"
                       "The following traceback may be corrupted or invalid\n"
                       "The error message is: %s\n" % msg)

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -191,7 +191,7 @@ def findsource(object):
     if ismethod(object):
         object = object.im_func
     if isfunction(object):
-        object = object.func_code
+        object = object.__code__
     if istraceback(object):
         object = object.tb_frame
     if isframe(object):

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -70,6 +70,7 @@ possible inclusion in future releases.
 #*****************************************************************************
 
 from __future__ import with_statement
+from __future__ import print_function
 
 import inspect
 import keyword
@@ -1029,7 +1030,7 @@ class VerboseTB(TBTools):
         try:
             self.debugger()
         except KeyboardInterrupt:
-            print "\nKeyboardInterrupt"
+            print("\nKeyboardInterrupt")
 
 #----------------------------------------------------------------------------
 class FormattedTB(VerboseTB, ListTB):
@@ -1160,7 +1161,7 @@ class AutoFormattedTB(FormattedTB):
         try:
             self.debugger()
         except KeyboardInterrupt:
-            print "\nKeyboardInterrupt"
+            print("\nKeyboardInterrupt")
 
     def structured_traceback(self, etype=None, value=None, tb=None,
                              tb_offset=None, context=5):
@@ -1218,27 +1219,27 @@ if __name__ == "__main__":
         i = f - g
         return h / i
 
-    print ''
-    print '*** Before ***'
+    print('')
+    print('*** Before ***')
     try:
-        print spam(1, (2, 3))
+        print(spam(1, (2, 3)))
     except:
         traceback.print_exc()
-    print ''
+    print('')
 
     handler = ColorTB()
-    print '*** ColorTB ***'
+    print('*** ColorTB ***')
     try:
-        print spam(1, (2, 3))
+        print(spam(1, (2, 3)))
     except:
         apply(handler, sys.exc_info() )
-    print ''
+    print('')
 
     handler = VerboseTB()
-    print '*** VerboseTB ***'
+    print('*** VerboseTB ***')
     try:
-        print spam(1, (2, 3))
+        print(spam(1, (2, 3)))
     except:
         apply(handler, sys.exc_info() )
-    print ''
+    print('')
 

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -1232,7 +1232,7 @@ if __name__ == "__main__":
     try:
         print(spam(1, (2, 3)))
     except:
-        apply(handler, sys.exc_info() )
+        handler(*sys.exc_info())
     print('')
 
     handler = VerboseTB()
@@ -1240,6 +1240,6 @@ if __name__ == "__main__":
     try:
         print(spam(1, (2, 3)))
     except:
-        apply(handler, sys.exc_info() )
+        handler(*sys.exc_info())
     print('')
 

--- a/IPython/deathrow/ibrowse.py
+++ b/IPython/deathrow/ibrowse.py
@@ -217,7 +217,7 @@ class _BrowserLevel(object):
                 break
             except (KeyboardInterrupt, SystemExit):
                 raise
-            except Exception, exc:
+            except Exception as exc:
                 have += 1
                 self.items.append(_BrowserCachedItem(exc))
                 self.exhausted = True
@@ -260,7 +260,7 @@ class _BrowserLevel(object):
                 value = attr.value(item)
             except (KeyboardInterrupt, SystemExit):
                 raise
-            except Exception, exc:
+            except Exception as exc:
                 value = exc
             # only store attribute if it exists (or we got an exception)
             if value is not ipipe.noitem:
@@ -652,7 +652,7 @@ class _CommandFind(_CommandInput):
                         break # found something
                 except (KeyboardInterrupt, SystemExit):
                     raise
-                except Exception, exc:
+                except Exception as exc:
                     browser.report(exc)
                     curses.beep()
                     break  # break on error
@@ -677,7 +677,7 @@ class _CommandFindBackwards(_CommandInput):
                         break # found something
                 except (KeyboardInterrupt, SystemExit):
                     raise
-                except Exception, exc:
+                except Exception as exc:
                     browser.report(exc)
                     curses.beep()
                     break # break on error
@@ -946,7 +946,7 @@ class ibrowse(ipipe.Display):
                 )
             except (KeyboardInterrupt, SystemExit):
                 raise
-            except Exception, exc:
+            except Exception as exc:
                 if not self.levels:
                     raise
                 self._calcheaderlines(oldlevels)
@@ -1311,7 +1311,7 @@ class ibrowse(ipipe.Display):
                 item = attr.value(item)
             except (KeyboardInterrupt, SystemExit):
                 raise
-            except Exception, exc:
+            except Exception as exc:
                 self.report(exc)
             else:
                 self.report("entering detail view for attribute %s..." % attr.name())
@@ -1638,7 +1638,7 @@ class ibrowse(ipipe.Display):
                         value = attr.value(item)
                     except (SystemExit, KeyboardInterrupt):
                         raise
-                    except Exception, exc:
+                    except Exception as exc:
                         value = exc
                     if value is not ipipe.noitem:
                         attrstyle = ipipe.xrepr(value, "footer")

--- a/IPython/deathrow/igrid.py
+++ b/IPython/deathrow/igrid.py
@@ -154,7 +154,7 @@ class IGridRenderer(wx.grid.PyGridCellRenderer):
         try:
             value = self.table._displayattrs[col].value(self.table.items[row])
             (align, width, text) = ipipe.xformat(value, "cell", self.maxchars)
-        except Exception, exc:
+        except Exception as exc:
             (align, width, text) = ipipe.xformat(exc, "cell", self.maxchars)
         return (align, text)
 
@@ -292,7 +292,7 @@ class IGridTable(wx.grid.PyGridTableBase):
                 break
             except (KeyboardInterrupt, SystemExit):
                 raise
-            except Exception, exc:
+            except Exception as exc:
                 have += 1
                 self._append(exc)
                 self.iterator = None
@@ -413,7 +413,7 @@ class IGridGrid(wx.grid.Grid):
                 return None
         try:
             self.table.items = ipipe.deque(sorted(self.table.items, key=realkey, reverse=reverse))
-        except TypeError, exc:
+        except TypeError as exc:
             self.error_output("Exception encountered: %s" % exc)
             return
         # Find out where the object under the cursor went
@@ -478,7 +478,7 @@ class IGridGrid(wx.grid.Grid):
             (align, width, text) = ipipe.xformat(value, "cell", self.maxchars)
         except IndexError:
             raise IndexError
-        except Exception, exc:
+        except Exception as exc:
             (align, width, text) = ipipe.xformat(exc, "cell", self.maxchars)
         return text
 
@@ -505,7 +505,7 @@ class IGridGrid(wx.grid.Grid):
                                 break
                         except (KeyboardInterrupt, SystemExit):
                             raise
-                        except Exception, exc:
+                        except Exception as exc:
                             frame.SetStatusText(str(exc))
                             wx.Bell()
                             break  # break on error
@@ -529,7 +529,7 @@ class IGridGrid(wx.grid.Grid):
                                 break
                         except (KeyboardInterrupt, SystemExit):
                             raise
-                        except Exception, exc:
+                        except Exception as exc:
                             frame.SetStatusText(str(exc))
                             wx.Bell()
                             break  # break on error
@@ -739,7 +739,7 @@ class IGridGrid(wx.grid.Grid):
                 for i in xrange(count-1, current, -1): # some tabs don't close if we don't close in *reverse* order
                     nb.DeletePage(i)
                 frame._add_notebook(value)
-        except TypeError, exc:
+        except TypeError as exc:
             if exc.__class__.__module__ == "exceptions":
                 msg = "%s: %s" % (exc.__class__.__name__, exc)
             else:
@@ -750,7 +750,7 @@ class IGridGrid(wx.grid.Grid):
         try:
             attr = self.table._displayattrs[col]
             value = attr.value(self.table.items[row])
-        except Exception, exc:
+        except Exception as exc:
             self.error_output(str(exc))
         else:
             self._doenter(value)
@@ -762,7 +762,7 @@ class IGridGrid(wx.grid.Grid):
     def enter(self, row):
         try:
             value = self.table.items[row]
-        except Exception, exc:
+        except Exception as exc:
             self.error_output(str(exc))
         else:
             self._doenter(value)
@@ -774,7 +774,7 @@ class IGridGrid(wx.grid.Grid):
         try:
             attr = self.table._displayattrs[col]
             item = self.table.items[row]
-        except Exception, exc:
+        except Exception as exc:
             self.error_output(str(exc))
         else:
             attrs = [ipipe.AttributeDetail(item, attr) for attr in ipipe.xattrs(item, "detail")]
@@ -784,7 +784,7 @@ class IGridGrid(wx.grid.Grid):
         try:
             attr = self.table._displayattrs[col]
             item = attr.value(self.table.items[row])
-        except Exception, exc:
+        except Exception as exc:
             self.error_output(str(exc))
         else:
             attrs = [ipipe.AttributeDetail(item, attr) for attr in ipipe.xattrs(item, "detail")]
@@ -819,7 +819,7 @@ class IGridGrid(wx.grid.Grid):
         """
         try:
             value = self.table.items[row]
-        except Exception, exc:
+        except Exception as exc:
             self.error_output(str(exc))
         else:
             self.quit(value)
@@ -827,7 +827,7 @@ class IGridGrid(wx.grid.Grid):
     def pickinput(self, row):
         try:
             value = self.table.items[row]
-        except Exception, exc:
+        except Exception as exc:
             self.error_output(str(exc))
         else:
             api = ipapi.get()
@@ -838,7 +838,7 @@ class IGridGrid(wx.grid.Grid):
         try:
             attr = self.table._displayattrs[col]
             value = attr.value(self.table.items[row])
-        except Exception, exc:
+        except Exception as exc:
             self.error_output(str(exc))
         else:
             api = ipapi.get()
@@ -851,7 +851,7 @@ class IGridGrid(wx.grid.Grid):
         """
         try:
             value = [self.table.items[row] for row in rows]
-        except Exception, exc:
+        except Exception as exc:
             self.error_output(str(exc))
         else:
             self.quit(value)
@@ -870,7 +870,7 @@ class IGridGrid(wx.grid.Grid):
                     raise
                 except Exception:
                     raise #pass
-        except Exception, exc:
+        except Exception as exc:
             self.error_output(str(exc))
         else:
             self.quit(values)
@@ -879,7 +879,7 @@ class IGridGrid(wx.grid.Grid):
         try:
             attr = self.table._displayattrs[col]
             value = attr.value(self.table.items[row])
-        except Exception, exc:
+        except Exception as exc:
             self.error_output(str(exc))
         else:
             self.quit(value)
@@ -959,7 +959,7 @@ class IGridFrame(wx.Frame):
         if dlg.ShowModal() == wx.ID_OK:
             try:
                 milliseconds = int(dlg.GetValue())
-            except ValueError, exc:
+            except ValueError as exc:
                 self.SetStatusText(str(exc))
             else:
                 table.timer.Start(milliseconds=milliseconds, oneShot=False)

--- a/IPython/deathrow/ipipe.py
+++ b/IPython/deathrow/ipipe.py
@@ -1796,7 +1796,7 @@ class ifilter(Pipe):
                 ok += 1
             except (KeyboardInterrupt, SystemExit):
                 raise
-            except Exception, exc:
+            except Exception as exc:
                 if self.errors == "drop":
                     pass # Ignore errors
                 elif self.errors == "keep":
@@ -1869,7 +1869,7 @@ class ieval(Pipe):
                 yield do(item)
             except (KeyboardInterrupt, SystemExit):
                 raise
-            except Exception, exc:
+            except Exception as exc:
                 if self.errors == "drop":
                     pass # Ignore errors
                 elif self.errors == "keep":
@@ -2040,7 +2040,7 @@ class iless(Display):
                     pager.write("\n")
             finally:
                 pager.close()
-        except Exception, exc:
+        except Exception as exc:
             print "%s: %s" % (exc.__class__.__name__, str(exc))
 
 
@@ -2187,7 +2187,7 @@ class idump(Display):
                     value = attr.value(item)
                 except (KeyboardInterrupt, SystemExit):
                     raise
-                except Exception, exc:
+                except Exception as exc:
                     value = exc
                 (align, width, text) = xformat(value, "cell", self.maxattrlength)
                 colwidths[attr] = max(colwidths[attr], width)

--- a/IPython/deathrow/oldfrontend/frontendbase.py
+++ b/IPython/deathrow/oldfrontend/frontendbase.py
@@ -246,7 +246,7 @@ class FrontEndBase(object):
 
         try:
             result = self.shell.execute(block)
-        except Exception,e:
+        except Exception as e:
             e = self._add_block_id_for_failure(e, blockID=blockID)
             e = self.update_cell_prompt(e, blockID=blockID)
             e = self.render_error(e)

--- a/IPython/deathrow/oldfrontend/linefrontendbase.py
+++ b/IPython/deathrow/oldfrontend/linefrontendbase.py
@@ -161,7 +161,7 @@ class LineFrontEndBase(FrontEndBase):
                 is_complete = codeop.compile_command(clean_string,
                             "<string>", "exec")
                 self.release_output()
-            except Exception, e:
+            except Exception as e:
                 # XXX: Hack: return True so that the
                 # code gets executed and the error captured.
                 is_complete = True

--- a/IPython/deathrow/oldfrontend/wx/ipythonx.py
+++ b/IPython/deathrow/oldfrontend/wx/ipythonx.py
@@ -5,7 +5,7 @@ ipython.
 
 try:
     import wx
-except ImportError, e:
+except ImportError as e:
     e.args[0] = """%s
 ________________________________________________________________________________
 You need wxPython to run this application.

--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -105,6 +105,8 @@ skip_doctest = True
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
+
 import atexit
 import imp
 import inspect
@@ -244,8 +246,8 @@ class ModuleReloader(object):
                 if py_filename in self.failed:
                     del self.failed[py_filename]
             except:
-                print >> sys.stderr, "[autoreload of %s failed: %s]" % (
-                        modname, traceback.format_exc(1))
+                print("[autoreload of %s failed: %s]" % (
+                        modname, traceback.format_exc(1)), file=sys.stderr)
                 self.failed[py_filename] = pymtime
 
 #------------------------------------------------------------------------------

--- a/IPython/extensions/storemagic.py
+++ b/IPython/extensions/storemagic.py
@@ -20,6 +20,7 @@ To automatically restore stored variables at startup, add this to your
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 # Stdlib
 import inspect, os, sys, textwrap
@@ -52,8 +53,8 @@ def refresh_variables(ip):
         try:
             obj = db[key]
         except KeyError:
-            print "Unable to restore variable '%s', ignoring (use %%store -d to forget!)" % justkey
-            print "The error was:", sys.exc_info()[0]
+            print("Unable to restore variable '%s', ignoring (use %%store -d to forget!)" % justkey)
+            print("The error was:", sys.exc_info()[0])
         else:
             #print "restored",justkey,"=",obj #dbg
             ip.user_ns[justkey] = obj
@@ -147,13 +148,13 @@ class StoreMagics(Magics):
             else:
                 size = 0
 
-            print 'Stored variables and their in-db values:'
+            print('Stored variables and their in-db values:')
             fmt = '%-'+str(size)+'s -> %s'
             get = db.get
             for var in vars:
                 justkey = os.path.basename(var)
                 # print 30 first characters from every var
-                print fmt % (justkey, repr(get(var, '<unavailable>'))[:50])
+                print(fmt % (justkey, repr(get(var, '<unavailable>'))[:50]))
 
         # default action - store the variable
         else:
@@ -165,8 +166,8 @@ class StoreMagics(Magics):
                 else:
                     fil = open(fnam, 'w')
                 obj = ip.ev(args[0])
-                print "Writing '%s' (%s) to file '%s'." % (args[0],
-                  obj.__class__.__name__, fnam)
+                print("Writing '%s' (%s) to file '%s'." % (args[0],
+                  obj.__class__.__name__, fnam))
 
 
                 if not isinstance (obj, basestring):
@@ -192,23 +193,23 @@ class StoreMagics(Magics):
                     staliases = db.get('stored_aliases',{})
                     staliases[ name ] = cmd
                     db['stored_aliases'] = staliases
-                    print "Alias stored: %s (%s)" % (name, cmd)
+                    print("Alias stored: %s (%s)" % (name, cmd))
                     return
                 else:
                     raise UsageError("Unknown variable '%s'" % args[0])
 
             else:
                 if isinstance(inspect.getmodule(obj), FakeModule):
-                    print textwrap.dedent("""\
+                    print(textwrap.dedent("""\
                     Warning:%s is %s
                     Proper storage of interactively declared classes (or instances
                     of those classes) is not possible! Only instances
                     of classes in real modules on file system can be %%store'd.
-                    """ % (args[0], obj) )
+                    """ % (args[0], obj) ))
                     return
                 #pickled = pickle.dumps(obj)
                 self.db[ 'autorestore/' + args[0] ] = obj
-                print "Stored '%s' (%s)" % (args[0], obj.__class__.__name__)
+                print("Stored '%s' (%s)" % (args[0], obj.__class__.__name__))
 
 
 class StoreMagic(Plugin):

--- a/IPython/extensions/tests/test_octavemagic.py
+++ b/IPython/extensions/tests/test_octavemagic.py
@@ -8,7 +8,7 @@ try:
     import numpy.testing as npt
 
     from IPython.extensions import octavemagic
-except Exception, e:
+except Exception as e:
     __test__ = False
 
 global octave

--- a/IPython/external/decorator/_decorator.py
+++ b/IPython/external/decorator/_decorator.py
@@ -136,7 +136,7 @@ class FunctionMaker(object):
         func.__name__ = self.name
         func.__doc__ = getattr(self, 'doc', None)
         func.__dict__ = getattr(self, 'dict', {})
-        func.func_defaults = getattr(self, 'defaults', ())
+        func.__defaults__ = getattr(self, 'defaults', ())
         func.__kwdefaults__ = getattr(self, 'kwonlydefaults', None)
         func.__annotations__ = getattr(self, 'annotations', None)
         callermodule = sys._getframe(3).f_globals.get('__name__', '?')
@@ -200,7 +200,7 @@ def decorator(caller, func=None):
     decorator(caller, func) decorates a function using a caller.
     """
     if func is not None: # returns a decorated function
-        evaldict = func.func_globals.copy()
+        evaldict = func.__globals__.copy()
         evaldict['_call_'] = caller
         evaldict['_func_'] = func
         return FunctionMaker.create(
@@ -211,7 +211,7 @@ def decorator(caller, func=None):
             return partial(decorator, caller)
         # otherwise assume caller is a function
         first = inspect.getargspec(caller)[0][0] # first arg
-        evaldict = caller.func_globals.copy()
+        evaldict = caller.__globals__.copy()
         evaldict['_call_'] = caller
         evaldict['decorator'] = decorator
         return FunctionMaker.create(

--- a/IPython/external/decorator/_decorator.py
+++ b/IPython/external/decorator/_decorator.py
@@ -31,6 +31,7 @@
 Decorator module, see http://pypi.python.org/pypi/decorator
 for the documentation.
 """
+from __future__ import print_function
 
 __version__ = '3.3.3'
 
@@ -162,8 +163,8 @@ class FunctionMaker(object):
             # print >> sys.stderr, 'Compiling %s' % src
             exec code in evaldict
         except:
-            print >> sys.stderr, 'Error in generated code:'
-            print >> sys.stderr, src
+            print('Error in generated code:', file=sys.stderr)
+            print(src, file=sys.stderr)
             raise
         func = evaldict[name]
         if addsource:

--- a/IPython/external/mathjax.py
+++ b/IPython/external/mathjax.py
@@ -16,6 +16,7 @@ Authors:
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 import os
 import shutil
@@ -60,20 +61,20 @@ def install_mathjax(tag='v1.1', replace=False):
         if replace:
             if not os.access(dest, os.W_OK):
                 raise IOError("Need have write access to %s"%dest)
-            print "removing previous MathJax install"
+            print("removing previous MathJax install")
             shutil.rmtree(dest)
         else:
-            print "offline MathJax apparently already installed"
+            print("offline MathJax apparently already installed")
             return
     
     # download mathjax
-    print "Downloading mathjax source..."
+    print("Downloading mathjax source...")
     response = urllib2.urlopen(mathjax_url)
-    print "done"
+    print("done")
     # use 'r|gz' stream mode, because socket file-like objects can't seek:
     tar = tarfile.open(fileobj=response.fp, mode='r|gz')
     topdir = tar.firstmember.path
-    print "Extracting to %s"%dest
+    print("Extracting to %s"%dest)
     tar.extractall(static)
     # it will be mathjax-MathJax-<sha>, rename to just mathjax
     os.rename(os.path.join(static, topdir), dest)

--- a/IPython/external/pexpect/_pexpect.py
+++ b/IPython/external/pexpect/_pexpect.py
@@ -79,7 +79,7 @@ try:
     import errno
     import traceback
     import signal
-except ImportError, e:
+except ImportError as e:
     raise ImportError (str(e) + """
 
 A critical module was not found. Probably this operating system does not
@@ -265,10 +265,10 @@ def run (command, timeout=-1, withexitstatus=False, events=None, extra_args=None
             else:
                 raise TypeError ('The callback must be a string or function type.')
             event_count = event_count + 1
-        except TIMEOUT, e:
+        except TIMEOUT as e:
             child_result_list.append(child.before)
             break
-        except EOF, e:
+        except EOF as e:
             child_result_list.append(child.before)
             break
     child_result = child._empty_buffer.join(child_result_list)
@@ -552,7 +552,7 @@ class spawnb(object):
         if self.use_native_pty_fork:
             try:
                 self.pid, self.child_fd = pty.fork()
-            except OSError, e:
+            except OSError as e:
                 raise ExceptionPexpect('Error! pty.fork() failed: ' + str(e))
         else: # Use internal __fork_pty
             self.pid, self.child_fd = self.__fork_pty()
@@ -857,7 +857,7 @@ class spawnb(object):
         if self.child_fd in r:
             try:
                 s = os.read(self.child_fd, size)
-            except OSError, e: # Linux does this
+            except OSError as e: # Linux does this
                 self.flag_eof = True
                 raise EOF ('End Of File (EOF) in read_nonblocking(). Exception style platform.')
             if s == b'': # BSD style
@@ -1106,7 +1106,7 @@ class spawnb(object):
                 else:
                     return False
             return False
-        except OSError, e:
+        except OSError as e:
             # I think there are kernel timing issues that sometimes cause
             # this to happen. I think isalive() reports True, but the
             # process is dead to the kernel.
@@ -1177,7 +1177,7 @@ class spawnb(object):
         if pid == 0:
             try:
                 pid, status = os.waitpid(self.pid, waitpid_options) ### os.WNOHANG) # Solaris!
-            except OSError, e: # This should never happen...
+            except OSError as e: # This should never happen...
                 if e[0] == errno.ECHILD:
                     raise ExceptionPexpect ('isalive() encountered condition that should never happen. There was no child process. Did someone else call waitpid() on our process?')
                 else:
@@ -1424,7 +1424,7 @@ class spawnb(object):
                 incoming = incoming + c
                 if timeout is not None:
                     timeout = end_time - time.time()
-        except EOF, e:
+        except EOF as e:
             self.buffer = self._empty_buffer
             self.before = incoming
             self.after = EOF
@@ -1437,7 +1437,7 @@ class spawnb(object):
                 self.match = None
                 self.match_index = None
                 raise EOF (str(e) + '\n' + str(self))
-        except TIMEOUT, e:
+        except TIMEOUT as e:
             self.buffer = incoming
             self.before = incoming
             self.after = TIMEOUT

--- a/IPython/external/ssh/forward.py
+++ b/IPython/external/ssh/forward.py
@@ -45,7 +45,7 @@ class Handler (SocketServer.BaseRequestHandler):
             chan = self.ssh_transport.open_channel('direct-tcpip',
                                                    (self.chain_host, self.chain_port),
                                                    self.request.getpeername())
-        except Exception, e:
+        except Exception as e:
             logger.debug('Incoming request to %s:%d failed: %s' % (self.chain_host,
                                                               self.chain_port,
                                                               repr(e)))

--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -15,6 +15,7 @@ Authors:
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 import logging
 import Cookie
@@ -731,7 +732,7 @@ class RSTHandler(AuthenticatedHandler):
             )
         except:
             raise web.HTTPError(400, u'Invalid RST')
-        print html
+        print(html)
         self.set_header('Content-Type', 'text/html')
         self.finish(html)
 

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -447,7 +447,7 @@ class NotebookApp(BaseIPythonApplication):
         for port in random_ports(self.port, self.port_retries+1):
             try:
                 self.http_server.listen(port, self.ip)
-            except socket.error, e:
+            except socket.error as e:
                 if e.errno != errno.EADDRINUSE:
                     raise
                 self.log.info('The port %i is already in use, trying another random port.' % port)

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -15,6 +15,7 @@ Authors:
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 # stdlib
 import errno
@@ -511,8 +512,8 @@ class NotebookApp(BaseIPythonApplication):
                 ioloop.IOLoop.instance().stop()
                 return
         else:
-            print "No answer for 5s:",
-        print "resuming operation..."
+            print("No answer for 5s:", end=' ')
+        print("resuming operation...")
         # no answer, or answer is no:
         # set it back to original SIGINT handler
         # use IOLoop.add_callback because signal.signal must be called
@@ -589,4 +590,5 @@ def launch_new_instance():
     app = NotebookApp.instance()
     app.initialize()
     app.start()
+
 

--- a/IPython/frontend/qt/rich_text.py
+++ b/IPython/frontend/qt/rich_text.py
@@ -111,7 +111,7 @@ class HtmlExporter(object):
             # Perform the export!
             try:
                 return exporter(html, self.filename, self.image_tag)
-            except Exception, e:
+            except Exception as e:
                 msg = "Error exporting HTML to %s\n" % self.filename + str(e)
                 reply = QtGui.QMessageBox.warning(parent, 'Error', msg,
                     QtGui.QMessageBox.Ok, QtGui.QMessageBox.Ok)

--- a/IPython/frontend/terminal/embed.py
+++ b/IPython/frontend/terminal/embed.py
@@ -23,6 +23,7 @@ Notes
 #-----------------------------------------------------------------------------
 
 from __future__ import with_statement
+from __future__ import print_function
 
 import sys
 import warnings
@@ -159,7 +160,7 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
         self.banner2 = self.old_banner2
 
         if self.exit_msg is not None:
-            print self.exit_msg
+            print(self.exit_msg)
 
     def mainloop(self, local_ns=None, module=None, stack_depth=0,
                  display_banner=None, global_ns=None):

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -13,6 +13,7 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 import bdb
 import os
@@ -59,8 +60,8 @@ def get_default_editor():
 def get_pasted_lines(sentinel, l_input=py3compat.input):
     """ Yield pasted lines until the user enters the given sentinel value.
     """
-    print "Pasting code; enter '%s' alone on the line to stop or use Ctrl-D." \
-          % sentinel
+    print("Pasting code; enter '%s' alone on the line to stop or use Ctrl-D." \
+          % sentinel)
     while True:
         try:
             l = l_input(':')
@@ -69,7 +70,7 @@ def get_pasted_lines(sentinel, l_input=py3compat.input):
             else:
                 yield l
         except EOFError:
-            print '<EOF>'
+            print('<EOF>')
             return
 
 
@@ -153,7 +154,7 @@ class TerminalMagics(Magics):
         if name:
             # If storing it for further editing
             self.shell.user_ns[name] = SList(b.splitlines())
-            print "Block assigned to '%s'" % name
+            print("Block assigned to '%s'" % name)
         else:
             self.shell.user_ns['pasted_block'] = b
             self.shell.run_cell(b)
@@ -170,7 +171,7 @@ class TerminalMagics(Magics):
             raise UsageError(
                 "Variable 'pasted_block' is not a string, can't execute")
 
-        print "Re-executing '%s...' (%d chars)"% (b.split('\n',1)[0], len(b))
+        print("Re-executing '%s...' (%d chars)"% (b.split('\n',1)[0], len(b)))
         self.shell.run_cell(b)
 
     @line_magic
@@ -178,7 +179,7 @@ class TerminalMagics(Magics):
         """Toggle autoindent on/off (if available)."""
 
         self.shell.set_autoindent()
-        print "Automatic indentation is:",['OFF','ON'][self.shell.autoindent]
+        print("Automatic indentation is:",['OFF','ON'][self.shell.autoindent])
 
     @skip_doctest
     @line_magic

--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -24,6 +24,7 @@ Authors
 #-----------------------------------------------------------------------------
 
 from __future__ import absolute_import
+from __future__ import print_function
 
 import logging
 import os
@@ -196,7 +197,7 @@ class LocateIPythonApp(BaseIPythonApplication):
         if self.subapp is not None:
             return self.subapp.start()
         else:
-            print self.ipython_dir
+            print(self.ipython_dir)
 
 
 class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
@@ -345,7 +346,7 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
         if self.display_banner and self.interact:
             self.shell.show_banner()
         # Make sure there is a space below the banner.
-        if self.log_level <= logging.INFO: print
+        if self.log_level <= logging.INFO: print()
 
     def _pylab_changed(self, name, old, new):
         """Replace --pylab='inline' with --pylab='auto'"""

--- a/IPython/lib/backgroundjobs.py
+++ b/IPython/lib/backgroundjobs.py
@@ -28,6 +28,7 @@ use of the system.
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.
 #*****************************************************************************
+from __future__ import print_function
 
 # Code begins
 import sys
@@ -189,7 +190,7 @@ class BackgroundJobManager(object):
         job.num = len(self.all)+1 if self.all else 0
         self.running.append(job)
         self.all[job.num] = job
-        print 'Starting job # %s in a separate thread.' % job.num
+        print('Starting job # %s in a separate thread.' % job.num)
         job.start()
         return job
 
@@ -244,10 +245,10 @@ class BackgroundJobManager(object):
         Return True if the group had any elements."""
 
         if group:
-            print '%s jobs:' % name
+            print('%s jobs:' % name)
             for job in group:
-                print '%s : %s' % (job.num,job)
-            print
+                print('%s : %s' % (job.num,job))
+            print()
             return True
 
     def _group_flush(self,group,name):
@@ -258,7 +259,7 @@ class BackgroundJobManager(object):
         njobs = len(group)
         if njobs:
             plural = {1:''}.setdefault(njobs,'s')
-            print 'Flushing %s %s job%s.' % (njobs,name,plural)
+            print('Flushing %s %s job%s.' % (njobs,name,plural))
             group[:] = []
             return True
         
@@ -324,7 +325,7 @@ class BackgroundJobManager(object):
         fl_comp = self._group_flush(self.completed, 'Completed')
         fl_dead = self._group_flush(self.dead, 'Dead')
         if not (fl_comp or fl_dead):
-            print 'No jobs to flush.'
+            print('No jobs to flush.')
 
     def result(self,num):
         """result(N) -> return the result of job N."""
@@ -344,9 +345,9 @@ class BackgroundJobManager(object):
         if job is None:
             self._update_status()
             for deadjob in self.dead:
-                print "Traceback for: %r" % deadjob
+                print("Traceback for: %r" % deadjob)
                 self._traceback(deadjob)
-                print
+                print()
         else:
             self._traceback(job)
 
@@ -416,7 +417,7 @@ class BackgroundJobBase(threading.Thread):
         return '<BackgroundJob #%d: %s>' % (self.num, self.strform)
 
     def traceback(self):
-        print self._tb
+        print(self._tb)
         
     def run(self):
         try:

--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -23,6 +23,7 @@ re-implementation of hierarchical module import.
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.
 #*****************************************************************************
+from __future__ import print_function
 
 import __builtin__
 from contextlib import contextmanager
@@ -167,7 +168,7 @@ def import_submodule(mod, subname, fullname):
     if fullname in found_now and fullname in sys.modules:
         m = sys.modules[fullname]
     else:
-        print 'Reloading', fullname
+        print('Reloading', fullname)
         found_now[fullname] = 1
         oldm = sys.modules.get(fullname, None)
 

--- a/IPython/lib/demo.py
+++ b/IPython/lib/demo.py
@@ -168,6 +168,7 @@ print 'bye!'
 #  the file COPYING, distributed as part of this software.
 #
 #*****************************************************************************
+from __future__ import print_function
 
 import os
 import re
@@ -318,7 +319,7 @@ class Demo(object):
 
         if index is None:
             if self.finished:
-                print >>io.stdout, 'Demo finished.  Use <demo_name>.reset() if you want to rerun it.'
+                print('Demo finished.  Use <demo_name>.reset() if you want to rerun it.', file=io.stdout)
                 return None
             index = self.block_index
         else:
@@ -387,9 +388,9 @@ class Demo(object):
         if index is None:
             return
 
-        print >>io.stdout, self.marquee('<%s> block # %s (%s remaining)' %
-                           (self.title,index,self.nblocks-index-1))
-        print >>io.stdout,(self.src_blocks_colored[index])
+        print(self.marquee('<%s> block # %s (%s remaining)' %
+                           (self.title,index,self.nblocks-index-1)), file=io.stdout)
+        print((self.src_blocks_colored[index]), file=io.stdout)
         sys.stdout.flush()
 
     def show_all(self):
@@ -402,12 +403,12 @@ class Demo(object):
         marquee = self.marquee
         for index,block in enumerate(self.src_blocks_colored):
             if silent[index]:
-                print >>io.stdout, marquee('<%s> SILENT block # %s (%s remaining)' %
-                              (title,index,nblocks-index-1))
+                print(marquee('<%s> SILENT block # %s (%s remaining)' %
+                              (title,index,nblocks-index-1)), file=io.stdout)
             else:
-                print >>io.stdout, marquee('<%s> block # %s (%s remaining)' %
-                              (title,index,nblocks-index-1))
-            print >>io.stdout, block,
+                print(marquee('<%s> block # %s (%s remaining)' %
+                              (title,index,nblocks-index-1)), file=io.stdout)
+            print(block, end=' ', file=io.stdout)
         sys.stdout.flush()
 
     def run_cell(self,source):
@@ -432,18 +433,18 @@ class Demo(object):
             next_block = self.src_blocks[index]
             self.block_index += 1
             if self._silent[index]:
-                print >>io.stdout, marquee('Executing silent block # %s (%s remaining)' %
-                              (index,self.nblocks-index-1))
+                print(marquee('Executing silent block # %s (%s remaining)' %
+                              (index,self.nblocks-index-1)), file=io.stdout)
             else:
                 self.pre_cmd()
                 self.show(index)
                 if self.auto_all or self._auto[index]:
-                    print >>io.stdout, marquee('output:')
+                    print(marquee('output:'), file=io.stdout)
                 else:
-                    print >>io.stdout, marquee('Press <q> to quit, <Enter> to execute...'),
+                    print(marquee('Press <q> to quit, <Enter> to execute...'), end=' ', file=io.stdout)
                     ans = raw_input().strip()
                     if ans:
-                        print >>io.stdout, marquee('Block NOT executed')
+                        print(marquee('Block NOT executed'), file=io.stdout)
                         return
             try:
                 save_argv = sys.argv
@@ -462,9 +463,9 @@ class Demo(object):
             mq1 = self.marquee('END OF DEMO')
             if mq1:
                 # avoid spurious print >>io.stdout,s if empty marquees are used
-                print >>io.stdout
-                print >>io.stdout, mq1
-                print >>io.stdout, self.marquee('Use <demo_name>.reset() if you want to rerun it.')
+                print(file=io.stdout)
+                print(mq1, file=io.stdout)
+                print(self.marquee('Use <demo_name>.reset() if you want to rerun it.'), file=io.stdout)
             self.finished = True
 
     # These methods are meant to be overridden by subclasses who may wish to

--- a/IPython/lib/inputhookglut.py
+++ b/IPython/lib/inputhookglut.py
@@ -29,6 +29,8 @@ GLUT Inputhook support functions
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
+
 import os
 import sys
 import time
@@ -115,7 +117,7 @@ def glut_close():
 def glut_int_handler(signum, frame):
     # Catch sigint and print the defautl message
     signal.signal(signal.SIGINT, signal.default_int_handler)
-    print '\nKeyboardInterrupt'
+    print('\nKeyboardInterrupt')
     # Need to reprint the prompt at this stage
 
 

--- a/IPython/lib/irunner.py
+++ b/IPython/lib/irunner.py
@@ -29,6 +29,7 @@ NOTES:
  - Because pexpect only works under Unix or Windows-Cygwin, this has the same
  limitations.  This means that it will NOT work under native windows Python.
 """
+from __future__ import print_function
 
 # Stdlib imports
 import optparse
@@ -248,7 +249,7 @@ class InteractiveRunner(object):
         if end_normal:
             if interact:
                 c.send('\n')
-                print '<< Starting interactive mode >>',
+                print('<< Starting interactive mode >>', end=' ')
                 try:
                     c.interact()
                 except OSError:
@@ -261,7 +262,7 @@ class InteractiveRunner(object):
         else:
             if interact:
                 e="Further interaction is not possible: child process is dead."
-                print >> sys.stderr, e
+                print(e, file=sys.stderr)
 
         # Leave the child ready for more input later on, otherwise select just
         # hangs on the second invocation.
@@ -283,7 +284,7 @@ class InteractiveRunner(object):
         opts,args = parser.parse_args(argv)
 
         if len(args) != 1:
-            print >> sys.stderr,"You must supply exactly one file to run."
+            print("You must supply exactly one file to run.", file=sys.stderr)
             sys.exit(1)
 
         self.run_file(args[0],opts.interact)

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -551,7 +551,7 @@ def _dict_pprinter_factory(start, end, basetype=None):
         keys = obj.keys()
         try:
             keys.sort()
-        except Exception, e:
+        except Exception as e:
             # Sometimes the keys don't sort.
             pass
         for idx, key in enumerate(keys):

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -102,6 +102,7 @@
     :license: BSD License.
 """
 from __future__ import with_statement
+from __future__ import print_function
 from contextlib import contextmanager
 import sys
 import types
@@ -729,6 +730,6 @@ if __name__ == '__main__':
             self.list = ["blub", "blah", self]
 
         def get_foo(self):
-            print "foo"
+            print("foo")
 
     pprint(Foo(), verbose=True)

--- a/IPython/lib/tests/test_irunner.py
+++ b/IPython/lib/tests/test_irunner.py
@@ -2,6 +2,7 @@
 
 Not the most elegant or fine-grained, but it does cover at least the bulk
 functionality."""
+from __future__ import print_function
 
 # Global to make tests extra verbose and help debugging
 VERBOSE = True
@@ -50,10 +51,10 @@ class RunnerTestCase(unittest.TestCase):
             if ol1 != ol2:
                 mismatch += 1
                 if VERBOSE:
-                    print '<<< line %s does not match:' % n
-                    print repr(ol1)
-                    print repr(ol2)
-                    print '>>>'
+                    print('<<< line %s does not match:' % n)
+                    print(repr(ol1))
+                    print(repr(ol2))
+                    print('>>>')
         self.assert_(mismatch==0,'Number of mismatched lines: %s' %
                      mismatch)
 

--- a/IPython/lib/tests/test_irunner_pylab_magic.py
+++ b/IPython/lib/tests/test_irunner_pylab_magic.py
@@ -1,6 +1,7 @@
 """Test suite for pylab_import_all magic
 Modified from the irunner module but using regex.
 """
+from __future__ import print_function
 
 # Global to make tests extra verbose and help debugging
 VERBOSE = True
@@ -58,10 +59,10 @@ class RunnerTestCase(unittest.TestCase):
             if not re.match(ol1,ol2):
                 mismatch += 1
                 if VERBOSE:
-                    print '<<< line %s does not match:' % n
-                    print repr(ol1)
-                    print repr(ol2)
-                    print '>>>'
+                    print('<<< line %s does not match:' % n)
+                    print(repr(ol1))
+                    print(repr(ol2))
+                    print('>>>')
         self.assert_(mismatch==0,'Number of mismatched lines: %s' %
                      mismatch)
 

--- a/IPython/parallel/apps/ipclusterapp.py
+++ b/IPython/parallel/apps/ipclusterapp.py
@@ -20,6 +20,7 @@ Authors:
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 import errno
 import logging
@@ -598,8 +599,8 @@ class IPClusterApp(Application):
 
     def start(self):
         if self.subapp is None:
-            print "No subcommand specified. Must specify one of: %s"%(self.subcommands.keys())
-            print
+            print("No subcommand specified. Must specify one of: %s"%(self.subcommands.keys()))
+            print()
             self.print_description()
             self.print_subcommands()
             self.exit(1)

--- a/IPython/parallel/client/asyncresult.py
+++ b/IPython/parallel/client/asyncresult.py
@@ -151,7 +151,7 @@ class AsyncResult(object):
                 else:
                     results = error.collect_exceptions(results, self._fname)
                 self._result = self._reconstruct_result(results)
-            except Exception, e:
+            except Exception as e:
                 self._exception = e
                 self._success = False
             else:
@@ -675,7 +675,7 @@ class AsyncHubResult(AsyncResult):
                 else:
                     results = error.collect_exceptions(results, self._fname)
                 self._result = self._reconstruct_result(results)
-            except Exception, e:
+            except Exception as e:
                 self._exception = e
                 self._success = False
             else:

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -14,6 +14,7 @@ Authors:
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 import os
 import json
@@ -727,9 +728,9 @@ class Client(HasTraits):
         msg_id = parent['msg_id']
         if msg_id not in self.outstanding:
             if msg_id in self.history:
-                print ("got stale result: %s"%msg_id)
+                print(("got stale result: %s"%msg_id))
             else:
-                print ("got unknown result: %s"%msg_id)
+                print(("got unknown result: %s"%msg_id))
         else:
             self.outstanding.remove(msg_id)
 
@@ -763,11 +764,11 @@ class Client(HasTraits):
         msg_id = parent['msg_id']
         if msg_id not in self.outstanding:
             if msg_id in self.history:
-                print ("got stale result: %s"%msg_id)
-                print self.results[msg_id]
-                print msg
+                print(("got stale result: %s"%msg_id))
+                print(self.results[msg_id])
+                print(msg)
             else:
-                print ("got unknown result: %s"%msg_id)
+                print(("got unknown result: %s"%msg_id))
         else:
             self.outstanding.remove(msg_id)
         content = msg['content']

--- a/IPython/parallel/client/magics.py
+++ b/IPython/parallel/client/magics.py
@@ -37,6 +37,7 @@ Usage
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 import ast
 import re
@@ -247,7 +248,7 @@ class ParallelMagics(Magics):
         else:
             str_targets = str(targets)
         if self.verbose:
-            print base + " execution on engine(s): %s" % str_targets
+            print(base + " execution on engine(s): %s" % str_targets)
         
         result = self.view.execute(cell, silent=False, block=False)
         self.last_result = result
@@ -341,7 +342,7 @@ class ParallelMagics(Magics):
         self.shell.run_cell = self.pxrun_cell
 
         self._autopx = True
-        print "%autopx enabled"
+        print("%autopx enabled")
 
     def _disable_autopx(self):
         """Disable %autopx by restoring the original InteractiveShell.run_cell.
@@ -349,7 +350,7 @@ class ParallelMagics(Magics):
         if self._autopx:
             self.shell.run_cell = self._original_run_cell
             self._autopx = False
-            print "%autopx disabled"
+            print("%autopx disabled")
 
     def pxrun_cell(self, raw_cell, store_history=False, silent=False):
         """drop-in replacement for InteractiveShell.run_cell.

--- a/IPython/parallel/client/map.py
+++ b/IPython/parallel/client/map.py
@@ -23,8 +23,10 @@ Authors:
 #-------------------------------------------------------------------------------
 # Imports
 #-------------------------------------------------------------------------------
-
 from __future__ import division
+from __future__ import print_function
+
+
 
 import types
 from itertools import islice
@@ -64,7 +66,7 @@ class Map:
         
         # Test for error conditions here
         if p<0 or p>=q:
-          print "No partition exists."
+          print("No partition exists.")
           return
           
         remainder = len(seq)%q

--- a/IPython/parallel/client/view.py
+++ b/IPython/parallel/client/view.py
@@ -14,6 +14,7 @@ Authors:
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 import imp
 import sys
@@ -467,9 +468,9 @@ class DirectView(View):
                 modules.add(key)
                 if not quiet:
                     if fromlist:
-                        print "importing %s from %s on engine(s)"%(','.join(fromlist), name)
+                        print("importing %s from %s on engine(s)"%(','.join(fromlist), name))
                     else:
-                        print "importing %s on engine(s)"%name
+                        print("importing %s on engine(s)"%name)
                 results.append(self.apply_async(remote_import, name, fromlist, level))
             # restore override
             __builtin__.__import__ = save_import
@@ -817,7 +818,7 @@ class DirectView(View):
             # This is injected into __builtins__.
             ip = get_ipython()
         except NameError:
-            print "The IPython parallel magics (%px, etc.) only work within IPython."
+            print("The IPython parallel magics (%px, etc.) only work within IPython.")
             return
         
         M = ParallelMagics(ip, self, suffix)

--- a/IPython/parallel/controller/scheduler.py
+++ b/IPython/parallel/controller/scheduler.py
@@ -53,7 +53,7 @@ from .dependency import Dependency
 @decorator
 def logged(f,self,*args,**kwargs):
     # print ("#--------------------")
-    self.log.debug("scheduler::%s(*%s,**%s)", f.func_name, args, kwargs)
+    self.log.debug("scheduler::%s(*%s,**%s)", f.__name__, args, kwargs)
     # print ("#--")
     return f(self,*args, **kwargs)
 

--- a/IPython/parallel/tests/__init__.py
+++ b/IPython/parallel/tests/__init__.py
@@ -107,7 +107,7 @@ def teardown():
         if p.poll() is None:
             try:
                 p.stop()
-            except Exception, e:
+            except Exception as e:
                 print e
                 pass
         if p.poll() is None:

--- a/IPython/parallel/tests/__init__.py
+++ b/IPython/parallel/tests/__init__.py
@@ -10,6 +10,7 @@
 #-------------------------------------------------------------------------------
 # Imports
 #-------------------------------------------------------------------------------
+from __future__ import print_function
 
 import os
 import tempfile
@@ -63,7 +64,7 @@ def setup():
     tic = time.time()
     while not os.path.exists(engine_json) or not os.path.exists(client_json):
         if cp.poll() is not None:
-            print cp.poll()
+            print(cp.poll())
             raise RuntimeError("The test controller failed to start.")
         elif time.time()-tic > 15:
             raise RuntimeError("Timeout waiting for the test controller to start.")
@@ -108,15 +109,15 @@ def teardown():
             try:
                 p.stop()
             except Exception as e:
-                print e
+                print(e)
                 pass
         if p.poll() is None:
             time.sleep(.25)
         if p.poll() is None:
             try:
-                print 'cleaning up test process...'
+                print('cleaning up test process...')
                 p.signal(SIGKILL)
             except:
-                print "couldn't shutdown process: ", p
+                print("couldn't shutdown process: ", p)
     blackhole.close()
     

--- a/IPython/parallel/tests/clienttest.py
+++ b/IPython/parallel/tests/clienttest.py
@@ -11,6 +11,7 @@ Authors:
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.
 #-------------------------------------------------------------------------------
+from __future__ import print_function
 
 import sys
 import tempfile
@@ -70,13 +71,13 @@ def generate_output():
     import sys
     from IPython.core.display import display, HTML, Math
     
-    print "stdout"
-    print >> sys.stderr, "stderr"
+    print("stdout")
+    print("stderr", file=sys.stderr)
     
     display(HTML("<b>HTML</b>"))
     
-    print "stdout2"
-    print >> sys.stderr, "stderr2"
+    print("stdout2")
+    print("stderr2", file=sys.stderr)
     
     display(Math(r"\alpha=\beta"))
     
@@ -154,7 +155,7 @@ class ClusterTestCase(BaseZMQTestCase):
             time.sleep(0.1)
             self.client.spin()
         if not f():
-            print "Warning: Awaited condition never arrived"
+            print("Warning: Awaited condition never arrived")
     
     def setUp(self):
         BaseZMQTestCase.setUp(self)
@@ -180,4 +181,4 @@ class ClusterTestCase(BaseZMQTestCase):
         # self.context.term()
         # print tempfile.TemporaryFile().fileno(),
         # sys.stdout.flush()
-        
+

--- a/IPython/quarantine/ledit.py
+++ b/IPython/quarantine/ledit.py
@@ -78,7 +78,7 @@ def line_edit_f(self, cmd ):
         for l in curdata:
             try:
                 l2 = eval(cmd)
-            except Exception,e:
+            except Exception as e:
                 print "Dropping exception",e,"on line:",l
                 continue
             newlines.append(l2)

--- a/IPython/testing/_paramtestpy2.py
+++ b/IPython/testing/_paramtestpy2.py
@@ -22,7 +22,7 @@ from compiler.consts import CO_GENERATOR
 
 def isgenerator(func):
     try:
-        return func.func_code.co_flags & CO_GENERATOR != 0
+        return func.__code__.co_flags & CO_GENERATOR != 0
     except AttributeError:
         return False
 

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -24,6 +24,7 @@ itself from the command line. There are two ways of running this script:
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 # Stdlib
 import glob
@@ -418,7 +419,7 @@ class IPTester(object):
 
         for pid in self.pids:
             try:
-                print 'Cleaning stale PID:', pid
+                print('Cleaning stale PID:', pid)
                 os.kill(pid, signal.SIGKILL)
             except OSError:
                 # This is just a best effort, if we fail or the process was
@@ -522,8 +523,8 @@ def run_iptestall():
     t_start = time.time()
     try:
         for (name, runner) in runners:
-            print '*'*70
-            print 'IPython test group:',name
+            print('*'*70)
+            print('IPython test group:',name)
             res = runner.run()
             if res:
                 failed.append( (name, runner) )
@@ -534,26 +535,26 @@ def run_iptestall():
     nrunners = len(runners)
     nfail = len(failed)
     # summarize results
-    print
-    print '*'*70
-    print 'Test suite completed for system with the following information:'
-    print report()
-    print 'Ran %s test groups in %.3fs' % (nrunners, t_tests)
-    print
-    print 'Status:'
+    print()
+    print('*'*70)
+    print('Test suite completed for system with the following information:')
+    print(report())
+    print('Ran %s test groups in %.3fs' % (nrunners, t_tests))
+    print()
+    print('Status:')
     if not failed:
-        print 'OK'
+        print('OK')
     else:
         # If anything went wrong, point out what command to rerun manually to
         # see the actual errors and individual summary
-        print 'ERROR - %s out of %s test groups failed.' % (nfail, nrunners)
+        print('ERROR - %s out of %s test groups failed.' % (nfail, nrunners))
         for name, failed_runner in failed:
-            print '-'*40
-            print 'Runner failed:',name
-            print 'You may wish to rerun this one individually, with:'
+            print('-'*40)
+            print('Runner failed:',name)
+            print('You may wish to rerun this one individually, with:')
             failed_call_args = [py3compat.cast_unicode(x) for x in failed_runner.call_args]
-            print u' '.join(failed_call_args)
-            print
+            print(u' '.join(failed_call_args))
+            print()
         # Ensure that our exit code indicates failure
         sys.exit(1)
 

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -308,7 +308,7 @@ class DocTestCase(doctests.DocTestCase):
         # and letting any other error propagate.
         try:
             super(DocTestCase, self).tearDown()
-        except AttributeError, exc:
+        except AttributeError as exc:
             if exc.args[0] != self._result_var:
                 raise
 

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -94,7 +94,7 @@ class DocTestFinder(doctest.DocTestFinder):
         if module is None:
             return True
         elif inspect.isfunction(object):
-            return module.__dict__ is object.func_globals
+            return module.__dict__ is object.__globals__
         elif inspect.isbuiltin(object):
             return module.__name__ == object.__module__
         elif inspect.isclass(object):

--- a/IPython/testing/plugin/iptest.py
+++ b/IPython/testing/plugin/iptest.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Nose-based test runner.
 """
+from __future__ import print_function
 
 from nose.core import main
 from nose.plugins.builtin import plugins
@@ -10,8 +11,8 @@ import ipdoctest
 from ipdoctest import IPDocTestRunner
 
 if __name__ == '__main__':
-    print 'WARNING: this code is incomplete!'
-    print
+    print('WARNING: this code is incomplete!')
+    print()
 
     pp = [x() for x in plugins]  # activate all builtin plugins first
     main(testRunner=IPDocTestRunner(),

--- a/IPython/testing/plugin/show_refs.py
+++ b/IPython/testing/plugin/show_refs.py
@@ -2,6 +2,7 @@
 
 This is used by a companion test case.
 """
+from __future__ import print_function
 
 import gc
 
@@ -16,4 +17,4 @@ if __name__ == '__main__':
    c_refs = gc.get_referrers(c)
    ref_ids = map(id,c_refs)
 
-   print 'c referrers:',map(type,c_refs)
+   print('c referrers:',map(type,c_refs))

--- a/IPython/testing/plugin/simplevars.py
+++ b/IPython/testing/plugin/simplevars.py
@@ -1,2 +1,3 @@
+from __future__ import print_function
 x = 1
-print 'x is:',x
+print('x is:',x)

--- a/IPython/testing/tests/test_decorators.py
+++ b/IPython/testing/tests/test_decorators.py
@@ -38,8 +38,8 @@ def getargspec(obj):
         func_obj = obj.im_func
     else:
         raise TypeError, 'arg is not a Python function'
-    args, varargs, varkw = inspect.getargs(func_obj.func_code)
-    return args, varargs, varkw, func_obj.func_defaults
+    args, varargs, varkw = inspect.getargs(func_obj.__code__)
+    return args, varargs, varkw, func_obj.__defaults__
 
 #-----------------------------------------------------------------------------
 # Testing functions

--- a/IPython/testing/tests/test_decorators.py
+++ b/IPython/testing/tests/test_decorators.py
@@ -1,5 +1,6 @@
 """Tests for the decorators we've created for IPython.
 """
+from __future__ import print_function
 
 # Module imports
 # Std lib
@@ -87,9 +88,9 @@ def doctest_bad(x,y=1,**k):
     >>> 1+1
     3
     """
-    print 'x:',x
-    print 'y:',y
-    print 'k:',k
+    print('x:',x)
+    print('y:',y)
+    print('k:',k)
 
 
 def call_doctest_bad():
@@ -137,7 +138,7 @@ class FooClass(object):
         >>> f = FooClass(3)
         junk
         """
-        print 'Making a FooClass.'
+        print('Making a FooClass.')
         self.x = x
         
     @skip_doctest

--- a/IPython/testing/tests/test_tools.py
+++ b/IPython/testing/tests/test_tools.py
@@ -14,6 +14,7 @@ Tests for testing.tools
 # Imports
 #-----------------------------------------------------------------------------
 from __future__ import with_statement
+from __future__ import print_function
 
 import os
 import sys
@@ -76,15 +77,15 @@ def test_temp_pyfile():
 class TestAssertPrints(unittest.TestCase):
     def test_passing(self):
         with tt.AssertPrints("abc"):
-            print "abcd"
-            print "def"
-            print b"ghi"
+            print("abcd")
+            print("def")
+            print(b"ghi")
     
     def test_failing(self):
         def func():
             with tt.AssertPrints("abc"):
-                print "acd"
-                print "def"
-                print b"ghi"
+                print("acd")
+                print("def")
+                print(b"ghi")
         
         self.assertRaises(AssertionError, func)

--- a/IPython/utils/PyColorize.py
+++ b/IPython/utils/PyColorize.py
@@ -282,7 +282,7 @@ If no filename is given, or if filename is -, read standard input."""
     else:
         try:
             stream = open(fname)
-        except IOError,msg:
+        except IOError as msg:
             print >> sys.stderr, msg
             sys.exit(1)
 
@@ -294,7 +294,7 @@ If no filename is given, or if filename is -, read standard input."""
         try:
             # write colorized version to stdout
             parser.format(stream.read(),scheme=opts.scheme_name)
-        except IOError,msg:
+        except IOError as msg:
             # if user reads through a pager and quits, don't print traceback
             if msg.args != (32,'Broken pipe'):
                 raise

--- a/IPython/utils/PyColorize.py
+++ b/IPython/utils/PyColorize.py
@@ -28,6 +28,7 @@ It shows how to use the built-in keyword, token and tokenize modules to
 scan Python source code and re-emit it with no changes to its original
 formatting (which is the hard part).
 """
+from __future__ import print_function
 
 __all__ = ['ANSICodeColors','Parser']
 
@@ -283,7 +284,7 @@ If no filename is given, or if filename is -, read standard input."""
         try:
             stream = open(fname)
         except IOError as msg:
-            print >> sys.stderr, msg
+            print(msg, file=sys.stderr)
             sys.exit(1)
 
     parser = Parser()

--- a/IPython/utils/_process_common.py
+++ b/IPython/utils/_process_common.py
@@ -34,7 +34,7 @@ def read_no_interrupt(p):
 
     try:
         return p.read()
-    except IOError, err:
+    except IOError as err:
         if err.errno != errno.EINTR:
             raise
 

--- a/IPython/utils/autoattr.py
+++ b/IPython/utils/autoattr.py
@@ -117,7 +117,7 @@ class OneTimeProperty(object):
             the value of this computation.
             """
        self.getter = func
-       self.name = func.func_name
+       self.name = func.__name__
 
    def __get__(self,obj,type=None):
        """This will be called on attribute access on the class or instance. """

--- a/IPython/utils/daemonize.py
+++ b/IPython/utils/daemonize.py
@@ -19,7 +19,7 @@ def daemonize():
     for i in range(3):
         try:
             os.dup2(null, i)
-        except OSError, e:
+        except OSError as e:
             if e.errno != errno.EBADF:
                 raise
     os.close(null)

--- a/IPython/utils/frame.py
+++ b/IPython/utils/frame.py
@@ -13,6 +13,7 @@ Utilities for working with stack frames.
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 import sys
 from IPython.utils import py3compat
@@ -39,7 +40,7 @@ def extract_vars(*names,**kw):
 
         In [2]: def func(x):
            ...:     y = 1
-           ...:     print sorted(extract_vars('x','y').items())
+           ...:     print(sorted(extract_vars('x','y').items()))
            ...:
 
         In [3]: func('hello')
@@ -78,8 +79,8 @@ def debugx(expr,pre_msg=''):
     expr->value pair."""
 
     cf = sys._getframe(1)
-    print '[DBG:%s] %s%s -> %r' % (cf.f_code.co_name,pre_msg,expr,
-                                   eval(expr,cf.f_globals,cf.f_locals))
+    print('[DBG:%s] %s%s -> %r' % (cf.f_code.co_name,pre_msg,expr,
+                                   eval(expr,cf.f_globals,cf.f_locals)))
 
 
 # deactivate it by uncommenting the following line, which makes it a no-op

--- a/IPython/utils/ipstruct.py
+++ b/IPython/utils/ipstruct.py
@@ -121,7 +121,7 @@ class Struct(dict):
                 )
         try:
             self.__setitem__(key, value)
-        except KeyError, e:
+        except KeyError as e:
             raise AttributeError(e)
 
     def __getattr__(self, key):

--- a/IPython/utils/pickleshare.py
+++ b/IPython/utils/pickleshare.py
@@ -85,7 +85,7 @@ class PickleShareDB(collections.MutableMapping):
         pickled = pickle.dump(value,fil.open('wb'), protocol=2)
         try:
             self.cache[fil] = (value,fil.mtime)
-        except OSError,e:
+        except OSError as e:
             if e.errno != 2:
                 raise
 

--- a/IPython/utils/pickleshare.py
+++ b/IPython/utils/pickleshare.py
@@ -32,6 +32,7 @@ Author: Ville Vainio <vivainio@gmail.com>
 License: MIT open source license.
 
 """
+from __future__ import print_function
 
 from IPython.external.path import path as Path
 import os,stat,time
@@ -136,7 +137,7 @@ class PickleShareDB(collections.MutableMapping):
             try:
                 all.update(self[f])
             except KeyError:
-                print "Corrupt",f,"deleted - hset is not threadsafe!"
+                print("Corrupt",f,"deleted - hset is not threadsafe!")
                 del self[f]
 
             self.uncache(f)
@@ -278,25 +279,25 @@ class PickleShareLink:
 def test():
     db = PickleShareDB('~/testpickleshare')
     db.clear()
-    print "Should be empty:",db.items()
+    print("Should be empty:",db.items())
     db['hello'] = 15
     db['aku ankka'] = [1,2,313]
     db['paths/nest/ok/keyname'] = [1,(5,46)]
     db.hset('hash', 'aku', 12)
     db.hset('hash', 'ankka', 313)
-    print "12 =",db.hget('hash','aku')
-    print "313 =",db.hget('hash','ankka')
-    print "all hashed",db.hdict('hash')
-    print db.keys()
-    print db.keys('paths/nest/ok/k*')
-    print dict(db) # snapsot of whole db
+    print("12 =",db.hget('hash','aku'))
+    print("313 =",db.hget('hash','ankka'))
+    print("all hashed",db.hdict('hash'))
+    print(db.keys())
+    print(db.keys('paths/nest/ok/k*'))
+    print(dict(db)) # snapsot of whole db
     db.uncache() # frees memory, causes re-reads later
 
     # shorthand for accessing deeply nested files
     lnk = db.getlink('myobjects/test')
     lnk.foo = 2
     lnk.bar = lnk.foo + 5
-    print lnk.bar # 7
+    print(lnk.bar) # 7
 
 def stress():
     db = PickleShareDB('~/fsdbtest')
@@ -314,7 +315,7 @@ def stress():
             db[str(j)] = db.get(str(j), []) + [(i,j,"proc %d" % os.getpid())]
             db.hset('hash',j, db.hget('hash',j,15) + 1 )
 
-        print i,
+        print(i, end=' ')
         sys.stdout.flush()
         if i % 10 == 0:
             db.uncache()
@@ -333,7 +334,7 @@ def main():
     DB = PickleShareDB
     import sys
     if len(sys.argv) < 2:
-        print usage
+        print(usage)
         return
 
     cmd = sys.argv[1]
@@ -353,7 +354,7 @@ def main():
     elif cmd == 'testwait':
         db = DB(args[0])
         db.clear()
-        print db.waitget('250')
+        print(db.waitget('250'))
     elif cmd == 'test':
         test()
         stress()

--- a/IPython/utils/pickleutil.py
+++ b/IPython/utils/pickleutil.py
@@ -62,8 +62,8 @@ class CannedFunction(CannedObject):
 
     def __init__(self, f):
         self._checkType(f)
-        self.code = f.func_code
-        self.defaults = f.func_defaults
+        self.code = f.__code__
+        self.defaults = f.__defaults__
         self.module = f.__module__ or '__main__'
         self.__name__ = f.__name__
 
@@ -148,4 +148,4 @@ def uncanSequence(obj, g=None):
 
 
 def rebindFunctionGlobals(f, glbls):
-    return FunctionType(f.func_code, glbls)
+    return FunctionType(f.__code__, glbls)

--- a/IPython/utils/tests/test_io.py
+++ b/IPython/utils/tests/test_io.py
@@ -11,6 +11,7 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 import sys
 
@@ -33,7 +34,7 @@ def test_tee_simple():
     chan = StringIO()
     text = 'Hello'
     tee = Tee(chan, channel='stdout')
-    print >> chan, text
+    print(text, file=chan)
     nt.assert_equal(chan.getvalue(), text+"\n")
 
 
@@ -48,7 +49,7 @@ class TeeTestCase(dec.ParametricTestCase):
         setattr(sys, channel, trap)
 
         tee = Tee(chan, channel=channel)
-        print >> chan, text,
+        print(text, end='', file=chan)
         setattr(sys, channel, std_ori)
         trap_val = trap.getvalue()
         nt.assert_equals(chan.getvalue(), text)
@@ -78,8 +79,8 @@ def test_capture_output():
     """capture_output() context works"""
     
     with capture_output() as io:
-        print 'hi, stdout'
-        print >> sys.stderr, 'hi, stderr'
+        print('hi, stdout')
+        print('hi, stderr', file=sys.stderr)
     
     nt.assert_equals(io.stdout, 'hi, stdout\n')
     nt.assert_equals(io.stderr, 'hi, stderr\n')

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -11,6 +11,7 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 import os
 import math
@@ -48,11 +49,11 @@ def test_columnize_random():
         longer_line = max([len(x) for x in out.split('\n')])
         longer_element = max(rand_len)
         if longer_line > displaywidth:
-            print "Columnize displayed something lager than displaywidth : %s " % longer_line
-            print "longer element : %s " % longer_element
-            print "displaywidth : %s " % displaywidth
-            print "number of element : %s " % nitems
-            print "size of each element :\n %s" % rand_len
+            print("Columnize displayed something lager than displaywidth : %s " % longer_line)
+            print("longer element : %s " % longer_element)
+            print("displaywidth : %s " % displaywidth)
+            print("number of element : %s " % nitems)
+            print("size of each element :\n %s" % rand_len)
             assert False
 
 def test_columnize_medium():

--- a/IPython/utils/upgradedir.py
+++ b/IPython/utils/upgradedir.py
@@ -6,6 +6,7 @@ new and unedited files.
 
 To be used by "upgrade" feature.
 """
+from __future__ import print_function
 try:
     from IPython.external.path import path
 except ImportError:
@@ -19,7 +20,7 @@ def showdiff(old,new):
     lines = d.compare(old.lines(),new.lines())
     realdiff = False
     for l in lines:
-        print l,
+        print(l, end=' ')
         if not realdiff and not l[0].isspace():
             realdiff = True
     return realdiff
@@ -32,7 +33,7 @@ def upgrade_dir(srcdir, tgtdir):
     """
 
     def pr(s):
-        print s
+        print(s)
     junk = ['.svn','ipythonrc*','*.pyc', '*.pyo', '*~', '.hg']
     
     def ignorable(p):
@@ -82,9 +83,9 @@ def upgrade_dir(srcdir, tgtdir):
         #print rpt
     pickle.dump(rpt, rep.open('w'))
     if modded:
-        print "\n\nDelete the following files manually (and rerun %upgrade)\nif you need a full upgrade:"
+        print("\n\nDelete the following files manually (and rerun %upgrade)\nif you need a full upgrade:")
         for m in modded:
-            print m
+            print(m)
 
 
 import sys

--- a/IPython/utils/warn.py
+++ b/IPython/utils/warn.py
@@ -13,6 +13,7 @@ Utilities for warnings.  Shoudn't we just use the built in warnings module.
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 import sys
 
@@ -43,7 +44,7 @@ def warn(msg,level=2,exit_val=1):
         header = ['','','WARNING: ','ERROR: ','FATAL ERROR: ']
         io.stderr.write('%s%s' % (header[level],msg))
         if level == 4:
-            print >> io.stderr,'Exiting.\n'
+            print('Exiting.\n', file=io.stderr)
             sys.exit(exit_val)
 
             

--- a/IPython/zmq/frontend.py
+++ b/IPython/zmq/frontend.py
@@ -5,6 +5,8 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
+
 # stdlib
 import cPickle as pickle
 import code
@@ -57,25 +59,25 @@ class Console(code.InteractiveConsole):
             return
         c = omsg.content.code.rstrip()
         if c:
-            print '[IN from %s]' % omsg.parent_header.username
-            print c
+            print('[IN from %s]' % omsg.parent_header.username)
+            print(c)
 
     def handle_pyout(self, omsg):
         #print omsg # dbg
         if omsg.parent_header.session == self.session.session:
-            print "%s%s" % (sys.ps3, omsg.content.data)
+            print("%s%s" % (sys.ps3, omsg.content.data))
         else:
-            print '[Out from %s]' % omsg.parent_header.username
-            print omsg.content.data
+            print('[Out from %s]' % omsg.parent_header.username)
+            print(omsg.content.data)
 
     def print_pyerr(self, err):
-        print >> sys.stderr, err.etype,':', err.evalue
-        print >> sys.stderr, ''.join(err.traceback)
+        print(err.etype,':', err.evalue, file=sys.stderr)
+        print(''.join(err.traceback), file=sys.stderr)
 
     def handle_pyerr(self, omsg):
         if omsg.parent_header.session == self.session.session:
             return
-        print >> sys.stderr, '[ERR from %s]' % omsg.parent_header.username
+        print('[ERR from %s]' % omsg.parent_header.username, file=sys.stderr)
         self.print_pyerr(omsg.content)
 
     def handle_stream(self, omsg):
@@ -83,8 +85,8 @@ class Console(code.InteractiveConsole):
             outstream = sys.stdout
         else:
             outstream = sys.stderr
-            print >> outstream, '*ERR*',
-        print >> outstream, omsg.content.data,
+            print('*ERR*', end=' ', file=outstream)
+        print(omsg.content.data, end=' ', file=outstream)
 
     def handle_output(self, omsg):
         handler = self.handlers.get(omsg.msg_type, None)
@@ -107,12 +109,12 @@ class Console(code.InteractiveConsole):
         if rep.content.status == 'error':
             self.print_pyerr(rep.content)
         elif rep.content.status == 'aborted':
-            print >> sys.stderr, "ERROR: ABORTED"
+            print("ERROR: ABORTED", file=sys.stderr)
             ab = self.messages[rep.parent_header.msg_id].content
             if 'code' in ab:
-                print >> sys.stderr, ab.code
+                print(ab.code, file=sys.stderr)
             else:
-                print >> sys.stderr, ab
+                print(ab, file=sys.stderr)
 
     def recv_reply(self):
         ident,rep = self.session.recv(self.request_socket)
@@ -153,7 +155,7 @@ class Console(code.InteractiveConsole):
             time.sleep(0.05)
         else:
             # We exited without hearing back from the kernel!
-            print >> sys.stderr, 'ERROR!!! kernel never got back to us!!!'
+            print('ERROR!!! kernel never got back to us!!!', file=sys.stderr)
 
 
 class InteractiveClient(object):

--- a/IPython/zmq/kernelmanager.py
+++ b/IPython/zmq/kernelmanager.py
@@ -897,7 +897,7 @@ class KernelManager(HasTraits):
             # Attempt to kill the kernel.
             try:
                 self.kernel.kill()
-            except OSError, e:
+            except OSError as e:
                 # In Windows, we will get an Access Denied error if the process
                 # has already terminated. Ignore it.
                 if sys.platform == 'win32':

--- a/IPython/zmq/parentpoller.py
+++ b/IPython/zmq/parentpoller.py
@@ -29,7 +29,7 @@ class ParentPollerUnix(Thread):
                 if os.getppid() == 1:
                     os._exit(1)
                 time.sleep(1.0)
-            except OSError, e:
+            except OSError as e:
                 if e.errno == EINTR:
                     continue
                 raise

--- a/docs/autogen_api.py
+++ b/docs/autogen_api.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Script to auto-generate our API docs.
 """
+from __future__ import print_function
 # stdlib imports
 import os
 import sys
@@ -60,4 +61,4 @@ if __name__ == '__main__':
     docwriter.write_index(outdir, 'gen',
                           relative_to = pjoin('source','api')
                           )
-    print '%d files written' % len(docwriter.written_modules)
+    print('%d files written' % len(docwriter.written_modules))

--- a/docs/do_sphinx.py
+++ b/docs/do_sphinx.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Script to build documentation using Sphinx.
 """
+from __future__ import print_function
 
 import fileinput,os,sys
 
@@ -59,7 +60,7 @@ if sys.platform != 'win32':
         elif 'makechapterhead' in line:
             # Already have altered manual.cls: don't need to again.
             unmodified=False
-        print line,
+        print(line, end=' ')
 
     # Copying the makefile produced by sphinx...
     oscmd('pdflatex ipython.tex')

--- a/docs/examples/core/appconfig.py
+++ b/docs/examples/core/appconfig.py
@@ -29,6 +29,7 @@ to set the following options:
 When the config attribute of an Application is updated, it will fire all of
 the trait's events for all of the config=True attributes.
 """
+from __future__ import print_function
 
 import sys
 
@@ -87,8 +88,8 @@ class MyApp(Application):
         self.init_bar()
     
     def start(self):
-        print "app.config:"
-        print self.config
+        print("app.config:")
+        print(self.config)
 
 
 def main():

--- a/docs/examples/lib/internal_ipkernel.py
+++ b/docs/examples/lib/internal_ipkernel.py
@@ -1,6 +1,7 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 import subprocess
 import sys
@@ -44,7 +45,7 @@ class InternalIPKernel(object):
         print("\n***Variables in User namespace***")
         for k, v in self.namespace.iteritems():
             if k not in self._init_keys and not k.startswith('_'):
-                print('%s -> %r' % (k, v))
+                print(('%s -> %r' % (k, v)))
         sys.stdout.flush()
 
     def new_qt_console(self, evt=None):

--- a/docs/examples/parallel/customresults.py
+++ b/docs/examples/parallel/customresults.py
@@ -9,6 +9,7 @@ Authors
 -------
 * MinRK
 """
+from __future__ import print_function
 import time
 import random
 
@@ -22,13 +23,13 @@ v = rc.load_balanced_view()
 
 # scatter 'id', so id=0,1,2 on engines 0,1,2
 dv.scatter('id', rc.ids, flatten=True)
-print(dv['id'])
+print((dv['id']))
 
 
 def sleep_here(count, t):
     """simple function that takes args, prints a short message, sleeps for a time, and returns the same args"""
     import time,sys
-    print("hi from engine %i" % id)
+    print(("hi from engine %i" % id))
     sys.stdout.flush()
     time.sleep(t)
     return count,t
@@ -49,13 +50,13 @@ while pending:
     for msg_id in finished:
         # we know these are done, so don't worry about blocking
         ar = rc.get_result(msg_id)
-        print("job id %s finished on engine %i" % (msg_id, ar.engine_id))
+        print(("job id %s finished on engine %i" % (msg_id, ar.engine_id)))
         print("with stdout:")
-        print('    ' + ar.stdout.replace('\n', '\n    ').rstrip())
+        print(('    ' + ar.stdout.replace('\n', '\n    ').rstrip()))
         print("and results:")
         
         # note that each job in a map always returns a list of length chunksize
         # even if chunksize == 1
         for (count,t) in ar.result:
-            print("  item %i: slept for %.2fs" % (count, t))
+            print(("  item %i: slept for %.2fs" % (count, t)))
 

--- a/docs/examples/parallel/dagdeps.py
+++ b/docs/examples/parallel/dagdeps.py
@@ -6,6 +6,7 @@ Authors
 -------
 * MinRK
 """
+from __future__ import print_function
 import networkx as nx
 from random import randint, random
 from IPython import parallel
@@ -89,7 +90,7 @@ def main(nodes, edges):
     
     client = parallel.Client()
     view = client.load_balanced_view()
-    print("submitting %i tasks with %i dependencies"%(nodes,edges))
+    print(("submitting %i tasks with %i dependencies"%(nodes,edges)))
     results = submit_jobs(view, G, jobs)
     print("waiting for results")
     view.wait()

--- a/docs/examples/parallel/davinci/pwordfreq.py
+++ b/docs/examples/parallel/davinci/pwordfreq.py
@@ -3,6 +3,7 @@
 
 This only works for a local cluster, because the filenames are local paths.
 """
+from __future__ import print_function
 
 
 import os
@@ -54,7 +55,7 @@ if __name__ == '__main__':
     freqs = wordfreq(text)
     toc = time.time()
     print_wordfreq(freqs, 10)
-    print("Took %.3f s to calcluate"%(toc-tic))
+    print(("Took %.3f s to calcluate"%(toc-tic)))
     
     
     # The parallel version
@@ -75,6 +76,6 @@ if __name__ == '__main__':
     pfreqs = pwordfreq(view,fnames)
     toc = time.time()
     print_wordfreq(freqs)
-    print("Took %.3f s to calcluate on %i engines"%(toc-tic, len(view.targets)))
+    print(("Took %.3f s to calcluate on %i engines"%(toc-tic, len(view.targets))))
     # cleanup split files
     map(os.remove, fnames)

--- a/docs/examples/parallel/demo/noncopying.py
+++ b/docs/examples/parallel/demo/noncopying.py
@@ -1,4 +1,5 @@
 """non-copying sends"""
+from __future__ import print_function
 import zmq
 import numpy
 
@@ -30,14 +31,14 @@ B1 = numpy.frombuffer(msg1.buffer, dtype=A.dtype).reshape(A.shape)
 msg2 = s2.recv(copy=False)
 B2 = numpy.frombuffer(buffer(msg2.bytes), dtype=A.dtype).reshape(A.shape)
 
-print((B1==B2).all())
-print((B1==A).all())
+print(((B1==B2).all()))
+print(((B1==A).all()))
 A[0][0] += 10
 print("~")
 # after changing A in-place, B1 changes too, proving non-copying sends
-print((B1==A).all())
+print(((B1==A).all()))
 # but B2 is fixed, since it called the msg.bytes attr, which copies
-print((B1==B2).all())
+print(((B1==B2).all()))
 
 
 

--- a/docs/examples/parallel/demo/views.py
+++ b/docs/examples/parallel/demo/views.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from IPython.parallel import *
 
 client = Client()
@@ -8,8 +9,8 @@ for id in client.ids:
 v = client[0]
 v['a'] = 5
 
-print(v['a'])
+print((v['a']))
 
 remotes = client[:]
 
-print(remotes['ids'])
+print((remotes['ids']))

--- a/docs/examples/parallel/interengine/bintree.py
+++ b/docs/examples/parallel/interengine/bintree.py
@@ -6,6 +6,7 @@ use from bintree_script.py
 Provides parallel [all]reduce functionality
 
 """
+from __future__ import print_function
 
 import cPickle as pickle
 import re
@@ -92,7 +93,7 @@ def depth(n, tree):
 def print_bintree(tree, indent='  '):
     """print a binary tree"""
     for n in sorted(tree.keys()):
-        print "%s%s" % (indent * depth(n,tree), n)
+        print("%s%s" % (indent * depth(n,tree), n))
 
 #----------------------------------------------------------------------------
 # Communicator class for a binary-tree map

--- a/docs/examples/parallel/interengine/bintree_script.py
+++ b/docs/examples/parallel/interengine/bintree_script.py
@@ -16,6 +16,7 @@ impose the aggregation function to be commutative and distributive. It might
 not be the case if you implement the naive gather / reduce / broadcast strategy 
 where you can reorder the partial data before performing the reduce.
 """
+from __future__ import print_function
 
 from IPython.parallel import Client, Reference
 
@@ -36,7 +37,7 @@ execfile('bintree.py')
 # generate binary tree of parents
 btree = bintree(ids)
 
-print "setting up binary tree interconnect:"
+print("setting up binary tree interconnect:")
 print_bintree(btree)
 
 view.run('bintree.py')
@@ -78,10 +79,10 @@ view.scatter('data', data)
 
 # perform cumulative sum via allreduce
 view.execute("data_sum = com.allreduce(add, data, flat=False)")
-print "allreduce sum of data on all engines:", view['data_sum']
+print("allreduce sum of data on all engines:", view['data_sum'])
 
 # perform cumulative sum *without* final broadcast
 # when not broadcasting with allreduce, the final result resides on the root node:
 view.execute("ids_sum = com.reduce(add, id, flat=True)")
-print "reduce sum of engine ids (not broadcast):", root['ids_sum']
-print "partial result on each engine:", view['ids_sum']
+print("reduce sum of engine ids (not broadcast):", root['ids_sum'])
+print("partial result on each engine:", view['ids_sum'])

--- a/docs/examples/parallel/interengine/communicator.py
+++ b/docs/examples/parallel/interengine/communicator.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import socket
 
 import uuid
@@ -15,7 +16,7 @@ class EngineCommunicator(object):
         
         # configure sockets
         self.identity = identity or bytes(uuid.uuid4())
-        print(self.identity)
+        print((self.identity))
         self.socket.setsockopt(zmq.IDENTITY, self.identity)
         self.sub.setsockopt(zmq.SUBSCRIBE, b'')
         

--- a/docs/examples/parallel/iopubwatcher.py
+++ b/docs/examples/parallel/iopubwatcher.py
@@ -13,6 +13,7 @@ Authors
 -------
 * MinRK
 """
+from __future__ import print_function
 
 import os
 import sys
@@ -65,14 +66,14 @@ def main(connection_file):
             # stdout/stderr
             # stream names are in msg['content']['name'], if you want to handle
             # them differently
-            print("%s: %s" % (topic, msg['content']['data']))
+            print(("%s: %s" % (topic, msg['content']['data'])))
         elif msg['msg_type'] == 'pyerr':
             # Python traceback
             c = msg['content']
-            print(topic + ':')
+            print((topic + ':'))
             for line in c['traceback']:
                 # indent lines
-                print('    ' + line)
+                print(('    ' + line))
 
 if __name__ == '__main__':
     if len(sys.argv) > 1:

--- a/docs/examples/parallel/task2.py
+++ b/docs/examples/parallel/task2.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
+from __future__ import print_function
 
 from IPython.parallel import Client
 import time
@@ -17,7 +18,7 @@ for i in range(24):
 for i in range(6):
     time.sleep(1.0)
     print("Queue status (vebose=False)")
-    print(v.queue_status(verbose=False))
+    print((v.queue_status(verbose=False)))
     flush()
     
 for i in range(24):
@@ -26,14 +27,14 @@ for i in range(24):
 for i in range(6):
     time.sleep(1.0)
     print("Queue status (vebose=True)")
-    print(v.queue_status(verbose=True))
+    print((v.queue_status(verbose=True)))
     flush()
 
 for i in range(12):
     v.apply(time.sleep, 2)
 
 print("Queue status (vebose=True)")
-print(v.queue_status(verbose=True))
+print((v.queue_status(verbose=True)))
 flush()
 
 # qs = v.queue_status(verbose=True)
@@ -45,6 +46,6 @@ for msg_id in v.history[-4:]:
 for i in range(6):
     time.sleep(1.0)
     print("Queue status (vebose=True)")
-    print(v.queue_status(verbose=True))
+    print((v.queue_status(verbose=True)))
     flush()
 

--- a/docs/examples/parallel/task_profiler.py
+++ b/docs/examples/parallel/task_profiler.py
@@ -15,6 +15,7 @@ A good test to run with 16 engines is::
 This should show a speedup of 13-14x.  The limitation here is that the
 overhead of a single task is about 0.001-0.01 seconds.
 """
+from __future__ import print_function
 import random, sys
 from optparse import OptionParser
 
@@ -52,7 +53,7 @@ def main():
     times = [random.random()*(opts.tmax-opts.tmin)+opts.tmin for i in range(opts.n)]
     stime = sum(times)
 
-    print("executing %i tasks, totalling %.1f secs on %i engines"%(opts.n, stime, nengines))
+    print(("executing %i tasks, totalling %.1f secs on %i engines"%(opts.n, stime, nengines)))
     time.sleep(1)
     start = time.time()
     amr = view.map(time.sleep, times)
@@ -62,9 +63,9 @@ def main():
     ptime = stop-start
     scale = stime/ptime
 
-    print("executed %.1f secs in %.1f secs"%(stime, ptime))
-    print("%.3fx parallel performance on %i engines"%(scale, nengines))
-    print("%.1f%% of theoretical max"%(100*scale/nengines))
+    print(("executed %.1f secs in %.1f secs"%(stime, ptime)))
+    print(("%.3fx parallel performance on %i engines"%(scale, nengines)))
+    print(("%.1f%% of theoretical max"%(100*scale/nengines)))
 
 
 if __name__ == '__main__':

--- a/docs/examples/parallel/wave2D/parallelwave-mpi.py
+++ b/docs/examples/parallel/wave2D/parallelwave-mpi.py
@@ -21,6 +21,7 @@ Authors
  * Min Ragan-Kelley
 
 """
+from __future__ import print_function
 
 import sys
 import time
@@ -111,7 +112,7 @@ if __name__ == '__main__':
     assert partition[0]*partition[1] == num_procs, "can't map partition %s to %i engines"%(partition, num_procs)
 
     view = rc[:]
-    print "Running %s system on %s processes until %f"%(grid, partition, tstop)
+    print("Running %s system on %s processes until %f"%(grid, partition, tstop))
 
     # functions defining initial/boundary/source conditions
     def I(x,y):
@@ -170,7 +171,7 @@ if __name__ == '__main__':
         else:
             norm = -1
         t1 = time.time()
-        print 'scalar inner-version, Wtime=%g, norm=%g'%(t1-t0, norm)
+        print('scalar inner-version, Wtime=%g, norm=%g'%(t1-t0, norm))
 
     impl['inner'] = 'vectorized'
     # setup new solvers
@@ -188,7 +189,7 @@ if __name__ == '__main__':
     else:
         norm = -1
     t1 = time.time()
-    print 'vector inner-version, Wtime=%g, norm=%g'%(t1-t0, norm)
+    print('vector inner-version, Wtime=%g, norm=%g'%(t1-t0, norm))
 
     # if ns.save is True, then u_hist stores the history of u as a list
     # If the partion scheme is Nx1, then u can be reconstructed via 'gather':

--- a/docs/examples/parallel/wave2D/parallelwave.py
+++ b/docs/examples/parallel/wave2D/parallelwave.py
@@ -21,6 +21,7 @@ Authors
  * Min Ragan-Kelley
 
 """
+from __future__ import print_function
 #
 import sys
 import time
@@ -114,7 +115,7 @@ if __name__ == '__main__':
 
     # construct the View:
     view = rc[:num_procs]
-    print("Running %s system on %s processes until %f"%(grid, partition, tstop))
+    print(("Running %s system on %s processes until %f"%(grid, partition, tstop)))
 
     # functions defining initial/boundary/source conditions
     def I(x,y):
@@ -179,7 +180,7 @@ if __name__ == '__main__':
         else:
             norm = -1
         t1 = time.time()
-        print('scalar inner-version, Wtime=%g, norm=%g'%(t1-t0, norm))
+        print(('scalar inner-version, Wtime=%g, norm=%g'%(t1-t0, norm)))
 
     # run again with faster numpy-vectorized inner implementation:
     impl['inner'] = 'vectorized'
@@ -197,7 +198,7 @@ if __name__ == '__main__':
     else:
         norm = -1
     t1 = time.time()
-    print('vector inner-version, Wtime=%g, norm=%g'%(t1-t0, norm))
+    print(('vector inner-version, Wtime=%g, norm=%g'%(t1-t0, norm)))
 
     # if ns.save is True, then u_hist stores the history of u as a list
     # If the partion scheme is Nx1, then u can be reconstructed via 'gather':

--- a/docs/examples/parallel/wave2D/wavesolver.py
+++ b/docs/examples/parallel/wave2D/wavesolver.py
@@ -10,6 +10,7 @@ Authors
  * Min Ragan-Kelley
 
 """
+from __future__ import print_function
 import time
 
 from numpy import exp, zeros, newaxis, sqrt, arange
@@ -196,8 +197,8 @@ class WaveSolver(object):
         while t <= tstop:
             t_old = t;  t += dt
             if verbose:
-                print('solving (%s version) at t=%g' % \
-                      (implementation['inner'], t))
+                print(('solving (%s version) at t=%g' % \
+                      (implementation['inner'], t)))
             # update all inner points:
             if implementation['inner'] == 'scalar':
                 for i in xrange(1, nx):
@@ -251,9 +252,9 @@ class WaveSolver(object):
             u_2, u_1, u = u_1, u, u_2
 
         t1 = time.time()
-        print('my_id=%2d, dt=%g, %s version, slice_copy=%s, net Wtime=%g'\
+        print(('my_id=%2d, dt=%g, %s version, slice_copy=%s, net Wtime=%g'\
               %(partitioner.my_id,dt,implementation['inner'],\
-                partitioner.slice_copy,t1-t0))
+                partitioner.slice_copy,t1-t0)))
         # save the us
         self.us = u,u_1,u_2
         # check final results; compute discrete L2-norm of the solution

--- a/docs/examples/tests/heartbeat/hb_gil.py
+++ b/docs/examples/tests/heartbeat/hb_gil.py
@@ -11,6 +11,7 @@ Holding the GIL for too long could disrupt the heartbeat.
 See Issue #1260: https://github.com/ipython/ipython/issues/1260
 
 """
+from __future__ import print_function
 
 import sys
 import time
@@ -25,7 +26,7 @@ def gilsleep(t):
     ])
     while True:
         inline(code, quiet=True, t=t)
-        print(time.time())
+        print((time.time()))
         sys.stdout.flush() # this is important
 
 gilsleep(5)

--- a/docs/gh-pages.py
+++ b/docs/gh-pages.py
@@ -14,6 +14,7 @@ something like 'current' as a stable URL for the most current version of the """
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 import os
 import re
 import shutil
@@ -126,13 +127,13 @@ if __name__ == '__main__':
 
         sh('git add -A %s' % tag)
         sh('git commit -m"Updated doc release: %s"' % tag)
-        print
-        print 'Most recent 3 commits:'
+        print()
+        print('Most recent 3 commits:')
         sys.stdout.flush()
         sh('git --no-pager log --oneline HEAD~3..')
     finally:
         cd(startdir)
 
-    print
-    print 'Now verify the build in: %r' % dest
-    print "If everything looks good, 'git push'"
+    print()
+    print('Now verify the build in: %r' % dest)
+    print("If everything looks good, 'git push'")

--- a/docs/sphinxext/apigen.py
+++ b/docs/sphinxext/apigen.py
@@ -17,6 +17,7 @@ NOTE: this is a modified version of a script originally shipped with the
 PyMVPA project, which we've adapted for NIPY use.  PyMVPA is an MIT-licensed
 project."""
 
+from __future__ import print_function
 # Stdlib imports
 import os
 import re
@@ -206,7 +207,7 @@ class ApiDocWriter(object):
         # get the names of all classes and functions
         functions, classes = self._parse_module(uri)
         if not len(functions) and not len(classes):
-            print 'WARNING: Empty -',uri  # dbg
+            print('WARNING: Empty -',uri)  # dbg
             return ''
 
         # Make a shorter version of the uri that omits the package name for

--- a/docs/sphinxext/docscrape.py
+++ b/docs/sphinxext/docscrape.py
@@ -413,7 +413,7 @@ class FunctionDoc(NumpyDocString):
             doc = inspect.getdoc(func) or ''
         try:
             NumpyDocString.__init__(self, doc)
-        except ValueError, e:
+        except ValueError as e:
             print '*'*78
             print "ERROR: '%s' while parsing `%s`" % (e, self._f)
             print '*'*78
@@ -429,7 +429,7 @@ class FunctionDoc(NumpyDocString):
                 argspec = inspect.formatargspec(*argspec)
                 argspec = argspec.replace('*','\*')
                 signature = '%s%s' % (func_name, argspec)
-            except TypeError, e:
+            except TypeError as e:
                 signature = '%s()' % func_name
             self['Signature'] = signature
 

--- a/docs/sphinxext/docscrape.py
+++ b/docs/sphinxext/docscrape.py
@@ -1,6 +1,7 @@
 """Extract reference documentation from the NumPy source tree.
 
 """
+from __future__ import print_function
 
 import inspect
 import textwrap
@@ -414,9 +415,9 @@ class FunctionDoc(NumpyDocString):
         try:
             NumpyDocString.__init__(self, doc)
         except ValueError as e:
-            print '*'*78
-            print "ERROR: '%s' while parsing `%s`" % (e, self._f)
-            print '*'*78
+            print('*'*78)
+            print("ERROR: '%s' while parsing `%s`" % (e, self._f))
+            print('*'*78)
             #print "Docstring follows:"
             #print doclines
             #print '='*78
@@ -452,7 +453,7 @@ class FunctionDoc(NumpyDocString):
 
         if self._role:
             if not roles.has_key(self._role):
-                print "Warning: invalid role %s" % self._role
+                print("Warning: invalid role %s" % self._role)
             out += '.. %s:: %s\n    \n\n' % (roles.get(self._role,''),
                                              func_name)
 

--- a/docs/sphinxext/github.py
+++ b/docs/sphinxext/github.py
@@ -36,7 +36,7 @@ def make_link_node(rawtext, app, type, slug, options):
             raise AttributeError
         if not base.endswith('/'):
             base += '/'
-    except AttributeError, err:
+    except AttributeError as err:
         raise ValueError('github_project_url configuration value is not set (%s)' % str(err))
 
     ref = base + type + '/' + slug + '/'
@@ -133,7 +133,7 @@ def ghcommit_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
             raise AttributeError
         if not base.endswith('/'):
             base += '/'
-    except AttributeError, err:
+    except AttributeError as err:
         raise ValueError('github_project_url configuration value is not set (%s)' % str(err))
 
     ref = base + text

--- a/docs/sphinxext/inheritance_diagram.py
+++ b/docs/sphinxext/inheritance_diagram.py
@@ -380,7 +380,7 @@ def visit_inheritance_diagram(inner_func):
     def visitor(self, node):
         try:
             content = inner_func(self, node)
-        except DotException, e:
+        except DotException as e:
             # Insert the exception as a warning in the document
             warning = self.document.reporter.warning(str(e), line=node.line)
             warning.parent = node

--- a/docs/sphinxext/ipython_directive.py
+++ b/docs/sphinxext/ipython_directive.py
@@ -55,6 +55,7 @@ Authors
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import print_function
 
 # Stdlib
 import cStringIO
@@ -650,7 +651,7 @@ class IpythonDirective(Directive):
         #print lines
         if len(lines)>2:
             if debug:
-                print '\n'.join(lines)
+                print('\n'.join(lines))
             else: #NOTE: this raises some errors, what's it for?
                 #print 'INSERTING %d lines'%len(lines)
                 self.state_machine.insert_input(
@@ -827,4 +828,4 @@ if __name__=='__main__':
     if not os.path.isdir('_static'):
         os.mkdir('_static')
     test()
-    print 'All OK? Check figures in _static/'
+    print('All OK? Check figures in _static/')

--- a/docs/sphinxext/numpydoc.py
+++ b/docs/sphinxext/numpydoc.py
@@ -15,6 +15,7 @@ It will:
 .. [1] http://projects.scipy.org/scipy/numpy/wiki/CodingStyleGuidelines#docstring-standard
 
 """
+from __future__ import print_function
 
 import os, re, pydoc
 from docscrape_sphinx import get_doc_object, SphinxDocString
@@ -49,7 +50,7 @@ def mangle_docstrings(app, what, name, obj, options, lines,
             try:
                 references.append(int(l[len('.. ['):l.index(']')]))
             except ValueError:
-                print "WARNING: invalid reference in %s docstring" % name
+                print("WARNING: invalid reference in %s docstring" % name)
 
     # Start renaming from the biggest number, otherwise we may
     # overwrite references.
@@ -105,7 +106,7 @@ def monkeypatch_sphinx_ext_autodoc():
     if sphinx.ext.autodoc.format_signature is our_format_signature:
         return
 
-    print "[numpydoc] Monkeypatching sphinx.ext.autodoc ..."
+    print("[numpydoc] Monkeypatching sphinx.ext.autodoc ...")
     _original_format_signature = sphinx.ext.autodoc.format_signature
     sphinx.ext.autodoc.format_signature = our_format_signature
 

--- a/setup.py
+++ b/setup.py
@@ -235,7 +235,7 @@ if 'setuptools' in sys.modules:
     if PY3:
         setuptools_extra_args['use_2to3'] = True
         # we try to make a 2.6, 2.7, and 3.1 to 3.3 python compatible code
-        # so we explicitely disable some 2to3 fixes to be sure we ain't forgetting
+        # so we explicitly disable some 2to3 fixes to be sure we aren't forgetting
         # anything.
         setuptools_extra_args['use_2to3_exclude_fixers'] = [
                 'lib2to3.fixes.fix_except',

--- a/setup.py
+++ b/setup.py
@@ -234,6 +234,12 @@ if 'setuptools' in sys.modules:
     
     if PY3:
         setuptools_extra_args['use_2to3'] = True
+        # we try to make a 2.6, 2.7, and 3.1 to 3.3 python compatible code
+        # so we explicitely disable some 2to3 fixes to be sure we ain't forgetting
+        # anything.
+        setuptools_extra_args['use_2to3_exclude_fixers'] = [
+                'lib2to3.fixes.fix_except',
+                ]
         from setuptools.command.build_py import build_py
         setup_args['cmdclass'] = {'build_py': record_commit_info('IPython', build_cmd=build_py)}
         setuptools_extra_args['entry_points'] = find_scripts(True, suffix='3')

--- a/setup.py
+++ b/setup.py
@@ -239,6 +239,9 @@ if 'setuptools' in sys.modules:
         # anything.
         setuptools_extra_args['use_2to3_exclude_fixers'] = [
                 'lib2to3.fixes.fix_except',
+                'lib2to3.fixes.fix_ne',
+                'lib2to3.fixes.fix_print',
+                'lib2to3.fixes.fix_apply',
                 ]
         from setuptools.command.build_py import build_py
         setup_args['cmdclass'] = {'build_py': record_commit_info('IPython', build_cmd=build_py)}

--- a/setup.py
+++ b/setup.py
@@ -242,6 +242,8 @@ if 'setuptools' in sys.modules:
                 'lib2to3.fixes.fix_ne',
                 'lib2to3.fixes.fix_print',
                 'lib2to3.fixes.fix_apply',
+                'lib2to3.fixes.fix_exitfunc',
+                'lib2to3.fixes.fix_funcattrs',
                 ]
         from setuptools.command.build_py import build_py
         setup_args['cmdclass'] = {'build_py': record_commit_info('IPython', build_cmd=build_py)}

--- a/tools/check_sources.py
+++ b/tools/check_sources.py
@@ -8,6 +8,7 @@ Usage:
 It prints summaries and if chosen, line-by-line info of where \\t or \\r
 characters can be found in our source tree.
 """
+from __future__ import print_function
 
 # Config
 # If true, all lines that have tabs are printed, with line number
@@ -33,22 +34,22 @@ for f in path('..').walkfiles('*.py'):
         rets.append(f)
         
     if errs:
-        print "%3s" % errs, f
+        print("%3s" % errs, f)
 
     if 't' in errs and full_report_tabs:
         for ln,line in enumerate(f.lines()):
             if '\t' in line:
-                print 'TAB:',ln,':',line,
+                print('TAB:',ln,':',line, end=' ')
 
     if 'r' in errs and full_report_rets:
         for ln,line in enumerate(open(f.abspath(),'rb')):
             if '\r' in line:
-                print 'RET:',ln,':',line,
+                print('RET:',ln,':',line, end=' ')
 
 # Summary at the end, to call cleanup tools if necessary
 if tabs:
-    print 'Hard tabs found. These can be cleaned with untabify:'
-    for f in tabs: print f,
+    print('Hard tabs found. These can be cleaned with untabify:')
+    for f in tabs: print(f, end=' ')
 if rets:
-    print 'Carriage returns (\\r) found in:'
-    for f in rets: print f,
+    print('Carriage returns (\\r) found in:')
+    for f in rets: print(f, end=' ')

--- a/tools/gitwash_dumper.py
+++ b/tools/gitwash_dumper.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 ''' Checkout gitwash repo into directory and do search replace on name '''
+from __future__ import print_function
 
 import os
 from os.path import join as pjoin
@@ -84,7 +85,7 @@ def copy_replace(replace_pairs,
     for rep_glob in rep_globs:
         fnames += fnmatch.filter(out_fnames, rep_glob)
     if verbose:
-        print '\n'.join(fnames)
+        print('\n'.join(fnames))
     for fname in fnames:
         filename_search_replace(replace_pairs, fname, False)
         for in_exp, out_exp in renames:

--- a/tools/post_pr_test.py
+++ b/tools/post_pr_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Post the results of a pull request test to Github.
 """
+from __future__ import print_function
 from test_pr import load_results, post_logs, post_results_comment, print_results
 
 num, results, pr, unavailable_pythons = load_results()

--- a/tools/release_windows.py
+++ b/tools/release_windows.py
@@ -9,6 +9,7 @@ Meant to be run on Windows
 
 Requires that you have python and python3 on your PATH
 """
+from __future__ import print_function
 
 import glob
 import os
@@ -41,6 +42,6 @@ for py in ['python', 'python3']:
         sh(cmd)
         if github and gh_api:
             exe = glob.glob(os.path.join("dist", "ipython-*{v}-{plat}.exe".format(**locals())))[0]
-            print ("Uploading %s to GitHub" % exe)
+            print(("Uploading %s to GitHub" % exe))
             desc = "IPython Installer for Python {v}.x on {plat}".format(**locals())
             gh_api.post_download('ipython/ipython', exe, description=desc)

--- a/tools/run_ipy_in_profiler.py
+++ b/tools/run_ipy_in_profiler.py
@@ -4,6 +4,7 @@
 I (fperez) tried it quickly and it doesn't work in its current form.  Either it
 needs to be fixed and documented or removed.
 """
+from __future__ import print_function
 
 import cProfile as profile
 import sys
@@ -11,7 +12,7 @@ import sys
 
 def main():
     import IPython.ipapi
-    print "Entering ipython for profiling. Type 'Exit' for profiler report"
+    print("Entering ipython for profiling. Type 'Exit' for profiler report")
     IPython.ipapi.launch_new_instance()
 
 if len(sys.argv) == 1:


### PR DESCRIPTION
Logical step after #2064 where the discussion started.

Most of the fixes apply by `2to3` when converting the current source tree to python 3 can be applied and are valid python 2.6 and 2.7 (not 2.5 but we don't support it), with minimal changes.

The plan is here to apply theses changes as early as possible ans deactivate them when using `2to3` in order to get a python2 and python3 compatible IPython code.

For what I've seen right now, 2to3 is sometime a little overzealous with `print`, converting 
`print 'xxx',` to `print('xxx', end=' ')`(space) but in some place we should have `end=''`(no space),
and it sometime also change `print ('an'+'expression')` to `print(('an'+'expression'))`. I detected and fixed some by hand because of failling test, but might have missed a few.

The other 2 fixes I added was getting rid of `apply` in some places, and convert `exec` statement to a function.

My guess is the harder part will be unicode strings prefix that  is not valid python 3.0 to 3.2 and valid again python 3.3. One of our option might be `from __future__ import unicode_literals`.

It would be really cool to be able to do `python3 ipython.py` 

Note : This does not merge cleanly right now and is on top of #2064, we can either close #2064 then i'll rebase the all on top of master, or I'll rebase when #2064 is merged.
