### PR TITLE
embed(): Default to the future compiler flags of the calling frame.

### DIFF
--- a/IPython/core/compilerop.py
+++ b/IPython/core/compilerop.py
@@ -28,11 +28,24 @@ Authors
 from __future__ import print_function
 
 # Stdlib imports
+import __future__
 from ast import PyCF_ONLY_AST
 import codeop
+import functools
 import hashlib
 import linecache
+import operator
 import time
+
+#-----------------------------------------------------------------------------
+# Constants
+#-----------------------------------------------------------------------------
+
+# Roughtly equal to PyCF_MASK | PyCF_MASK_OBSOLETE as defined in pythonrun.h,
+# this is used as a bitmask to extract future-related code flags.
+PyCF_MASK = functools.reduce(operator.or_,
+                             (getattr(__future__, fname).compiler_flag
+                              for fname in __future__.all_feature_names))
 
 #-----------------------------------------------------------------------------
 # Local utilities

--- a/IPython/frontend/terminal/embed.py
+++ b/IPython/frontend/terminal/embed.py
@@ -34,7 +34,7 @@ try:
 except:
     from IPython.utils.nested_context import nested
 
-from IPython.core import ultratb
+from IPython.core import ultratb, compilerop
 from IPython.core.magic import Magics, magics_class, line_magic
 from IPython.frontend.terminal.interactiveshell import TerminalInteractiveShell
 from IPython.frontend.terminal.ipapp import load_default_config
@@ -162,7 +162,7 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
             print self.exit_msg
 
     def mainloop(self, local_ns=None, module=None, stack_depth=0,
-                 display_banner=None, global_ns=None):
+                 display_banner=None, global_ns=None, compile_flags=None):
         """Embeds IPython into a running python program.
 
         Input:
@@ -179,6 +179,11 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
           allows an intermediate caller to make sure that this function gets
           the namespace from the intended level in the stack.  By default (0)
           it will get its locals and globals from the immediate caller.
+
+          - compile_flags: A bit field identifying the __future__ features
+          that are enabled, as passed to the builtin `compile` function. If
+          given as None, they are automatically taken from the scope where the
+          shell was called.
 
         Warning: it's possible to use this in a program which is being run by
         IPython itself (via %run), but some funny things will happen (a few
@@ -202,11 +207,15 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
             if module is None:
                 global_ns = call_frame.f_globals
                 module = sys.modules[global_ns['__name__']]
+            if compile_flags is None:
+                compile_flags = (call_frame.f_code.co_flags &
+                                 compilerop.PyCF_MASK)
         
         # Save original namespace and module so we can restore them after 
         # embedding; otherwise the shell doesn't shut down correctly.
         orig_user_module = self.user_module
         orig_user_ns = self.user_ns
+        orig_compile_flags = self.compile.flags
         
         # Update namespaces and fire up interpreter
         
@@ -221,6 +230,9 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
         if local_ns is not None:
             self.user_ns = local_ns
             self.init_user_ns()
+
+        # Compiler flags
+        self.compile.flags = compile_flags
 
         # Patch for global embedding to make sure that things don't overwrite
         # user globals accidentally. Thanks to Richard <rxe@renre-europe.com>
@@ -247,6 +259,7 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
         # Restore original namespace so shell can shut down when we exit.
         self.user_module = orig_user_module
         self.user_ns = orig_user_ns
+        self.compile.flags = orig_compile_flags
 
 _embedded_shell = None
 

--- a/IPython/frontend/terminal/embed.py
+++ b/IPython/frontend/terminal/embed.py
@@ -113,7 +113,7 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
         self.register_magics(EmbeddedMagics)
 
     def __call__(self, header='', local_ns=None, module=None, dummy=None,
-                 stack_depth=1, global_ns=None):
+                 stack_depth=1, global_ns=None, compile_flags=None):
         """Activate the interactive interpreter.
 
         __call__(self,header='',local_ns=None,module=None,dummy=None) -> Start
@@ -154,7 +154,8 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
 
         # Call the embedding code with a stack depth of 1 so it can skip over
         # our call and get the original caller's namespaces.
-        self.mainloop(local_ns, module, stack_depth=stack_depth, global_ns=global_ns)
+        self.mainloop(local_ns, module, stack_depth=stack_depth,
+                      global_ns=global_ns, compile_flags=compile_flags)
 
         self.banner2 = self.old_banner2
 
@@ -286,6 +287,7 @@ def embed(**kwargs):
     """
     config = kwargs.get('config')
     header = kwargs.pop('header', u'')
+    compile_flags = kwargs.pop('compile_flags', None)
     if config is None:
         config = load_default_config()
         config.InteractiveShellEmbed = config.TerminalInteractiveShell
@@ -293,4 +295,4 @@ def embed(**kwargs):
     global _embedded_shell
     if _embedded_shell is None:
         _embedded_shell = InteractiveShellEmbed(**kwargs)
-    _embedded_shell(header=header, stack_depth=2)
+    _embedded_shell(header=header, stack_depth=2, compile_flags=compile_flags)

--- a/docs/examples/tests/embed/embed_division.py
+++ b/docs/examples/tests/embed/embed_division.py
@@ -1,0 +1,5 @@
+"""This tests that future compiler flags are passed to the embedded IPython."""
+from __future__ import division
+from IPython import embed
+embed(banner1='', header='check 1/2 == 0.5 in Python 2')
+embed(banner1='', header='check 1/2 = 0 in Python 2', compile_flags=0)

--- a/docs/examples/tests/embed/embed_no_division.py
+++ b/docs/examples/tests/embed/embed_no_division.py
@@ -1,0 +1,6 @@
+"""This tests that future compiler flags are passed to the embedded IPython."""
+from IPython import embed
+import __future__
+embed(banner1='', header='check 1/2 == 0 in Python 2')
+embed(banner1='', header='check 1/2 == 0.5 in Python 2',
+      compile_flags=__future__.division.compiler_flag)


### PR DESCRIPTION
As discussed on the mailing list by Joon Ro:

> I'm using ipython 0.13. I just found that even though my main script has `from __future__ import division`, the embedded ipython session I still get `1/2 = 0`
> 
> It has caused me some confusion and I was wondering if this is a bug.

The attached pull request changes the behavior of embed to, by default, use the future compiler flags from the calling frame.
