### PR TITLE
Fix logging on interactive shell.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -469,11 +469,6 @@ class InteractiveShell(SingletonConfigurable):
         self.init_alias()
         self.init_builtins()
 
-        # pre_config_initialization
-
-        # The next section should contain everything that was in ipmaker.
-        self.init_logstart()
-
         # The following was in post_config_initialization
         self.init_inspector()
         # init_readline() must come before init_io(), because init_io uses
@@ -502,6 +497,7 @@ class InteractiveShell(SingletonConfigurable):
         self.init_displayhook()
         self.init_reload_doctest()
         self.init_magics()
+        self.init_logstart()
         self.init_pdb()
         self.init_extension_manager()
         self.init_plugin_manager()
@@ -617,7 +613,7 @@ class InteractiveShell(SingletonConfigurable):
         if self.logappend:
             self.magic('logstart %s append' % self.logappend)
         elif self.logfile:
-            self.magic('logstart %' % self.logfile)
+            self.magic('logstart %s' % self.logfile)
         elif self.logstart:
             self.magic('logstart')
 


### PR DESCRIPTION
Add a missing string format code in init_logs() and move init_logstart() after init_magics(), to fix dependency issues.

This is a proposed fix for the case a log file is given in `ipython_config.py`, eg:

``` python
# Start logging to the given file in append mode.                                                                                         
import os
from time import strftime
f = os.path.join(c.TerminalIPythonApp.ipython_dir, strftime('%Y-%m-%d')+".py")
c.TerminalInteractiveShell.logappend = f
```

which completely breaks in current `master` code
