### PR TITLE
BUG: Look up the `_repr_pretty_` method on the class within the MRO rath...

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -353,8 +353,8 @@ class RepresentationPrinter(PrettyPrinter):
                         # Some objects automatically create any requested
                         # attribute. Try to ignore most of them by checking for
                         # callability.
-                        if '_repr_pretty_' in obj_class.__dict__:
-                            meth = obj_class._repr_pretty_
+                        if '_repr_pretty_' in cls.__dict__:
+                            meth = cls._repr_pretty_
                             if callable(meth):
                                 return meth(obj, self, cycle)
             return _default_pprint(obj, self, cycle)

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -45,6 +45,14 @@ class MyDict(dict):
         p.text("MyDict(...)")
 
 
+class Dummy1(object):
+    def _repr_pretty_(self, p, cycle):
+        p.text("Dummy1(...)")
+
+class Dummy2(Dummy1):
+    _repr_pretty_ = None
+
+
 def test_indentation():
     """Test correct indentation in groups"""
     count = 40
@@ -61,5 +69,16 @@ def test_dispatch():
     """
     gotoutput = pretty.pretty(MyDict())
     expectedoutput = "MyDict(...)"
+
+    nt.assert_equals(gotoutput, expectedoutput)
+
+
+def test_callability_checking():
+    """
+    Test that the _repr_pretty_ method is tested for callability and skipped if
+    not.
+    """
+    gotoutput = pretty.pretty(Dummy2())
+    expectedoutput = "Dummy1(...)"
 
     nt.assert_equals(gotoutput, expectedoutput)


### PR DESCRIPTION
...er than the original leaf class.

Thanks, @doerwalter for finding this and suggesting the fix.

fixes #2122
