### PR TITLE
Add an API for registering magic aliases.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2045,6 +2045,12 @@ class InteractiveShell(SingletonConfigurable):
             m.NamespaceMagics, m.OSMagics, m.PylabMagics, m.ScriptMagics,
         )
 
+        # Register Magic Aliases
+        mman = self.magics_manager
+        mman.register_alias('ed', 'edit')
+        mman.register_alias('hist', 'history')
+        mman.register_alias('rep', 'recall')
+
         # FIXME: Move the color initialization to the DisplayHook, which
         # should be split into a prompt manager and displayhook. We probably
         # even need a centralize colors management object.

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -65,6 +65,8 @@ class BasicMagics(Magics):
         --------
         ::
           In [1]: %alias_magic t timeit
+          Created `%t` as an alias for `%timeit`.
+          Created `%%t` as an alias for `%%timeit`.
 
           In [2]: %t -n1 pass
           1 loops, best of 3: 954 ns per loop
@@ -77,6 +79,7 @@ class BasicMagics(Magics):
           In [4]: %alias_magic --cell whereami pwd
           UsageError: Cell magic function `%%pwd` not found.
           In [5]: %alias_magic --line whereami pwd
+          Created `%whereami` as an alias for `%pwd`.
 
           In [6]: %whereami
           Out[6]: u'/home/testuser'
@@ -111,9 +114,15 @@ class BasicMagics(Magics):
 
         if args.line:
             mman.register_alias(name, target, 'line')
+            print('Created `%s%s` as an alias for `%s%s`.' % (
+                magic_escapes['line'], name,
+                magic_escapes['line'], target))
 
         if args.cell:
             mman.register_alias(name, target, 'cell')
+            print('Created `%s%s` as an alias for `%s%s`.' % (
+                magic_escapes['cell'], name,
+                magic_escapes['cell'], target))
 
     def _lsmagic(self):
         mesc = magic_escapes['line']

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -83,6 +83,7 @@ class BasicMagics(Magics):
         """
         args = magic_arguments.parse_argstring(self.alias_magic, line)
         shell = self.shell
+        mman = self.shell.magics_manager
         escs = ''.join(magic_escapes.values())
 
         target = args.target.lstrip(escs)
@@ -109,18 +110,10 @@ class BasicMagics(Magics):
             args.cell = bool(m_cell)
 
         if args.line:
-            def wrapper(line): return m_line(line)
-            wrapper.__name__ = str(name)
-            wrapper.__doc__ = "Alias for `%s%s`." % \
-                              (magic_escapes['line'], target)
-            shell.register_magic_function(wrapper, 'line', name)
+            mman.register_alias(name, target, 'line')
 
         if args.cell:
-            def wrapper(line, cell): return m_cell(line, cell)
-            wrapper.__name__ = str(name)
-            wrapper.__doc__ = "Alias for `%s%s`." % \
-                              (magic_escapes['cell'], target)
-            shell.register_magic_function(wrapper, 'cell', name)
+            mman.register_alias(name, target, 'cell')
 
     def _lsmagic(self):
         mesc = magic_escapes['line']

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -333,11 +333,6 @@ class CodeMagics(Magics):
         mfile.close()
         self.shell.user_ns[mname] = Macro(mvalue)
 
-    @line_magic
-    def ed(self, parameter_s=''):
-        """Alias to %edit."""
-        return self.edit(parameter_s)
-
     @skip_doctest
     @line_magic
     def edit(self, parameter_s='',last_call=['','']):
@@ -431,7 +426,7 @@ class CodeMagics(Magics):
         This is an example of creating a simple function inside the editor and
         then modifying it. First, start up the editor::
 
-          In [1]: ed
+          In [1]: edit
           Editing... done. Executing edited code...
           Out[1]: 'def foo():\\n    print "foo() was defined in an editing
           session"\\n'
@@ -444,7 +439,7 @@ class CodeMagics(Magics):
         Now we edit foo.  IPython automatically loads the editor with the
         (temporary) file where foo() was previously defined::
 
-          In [3]: ed foo
+          In [3]: edit foo
           Editing... done. Executing edited code...
 
         And if we call foo() again we get the modified version::
@@ -455,21 +450,21 @@ class CodeMagics(Magics):
         Here is an example of how to edit a code snippet successive
         times. First we call the editor::
 
-          In [5]: ed
+          In [5]: edit
           Editing... done. Executing edited code...
           hello
           Out[5]: "print 'hello'\\n"
 
         Now we call it again with the previous output (stored in _)::
 
-          In [6]: ed _
+          In [6]: edit _
           Editing... done. Executing edited code...
           hello world
           Out[6]: "print 'hello world'\\n"
 
         Now we call it with the output #8 (stored in _8, also as Out[8])::
 
-          In [7]: ed _8
+          In [7]: edit _8
           Editing... done. Executing edited code...
           hello again
           Out[7]: "print 'hello again'\\n"

--- a/IPython/core/magics/history.py
+++ b/IPython/core/magics/history.py
@@ -91,10 +91,10 @@ class HistoryMagics(Magics):
         --------
         ::
 
-          In [6]: %hist -n 4-6
+          In [6]: %history -n 4-6
           4:a = 12
           5:print a**2
-          6:%hist -n 4-6
+          6:%history -n 4-6
 
         """
 
@@ -187,15 +187,8 @@ class HistoryMagics(Magics):
         if close_at_end:
             outfile.close()
 
-    # For a long time we've had %hist as well as %history
     @line_magic
-    def hist(self, arg):
-        return self.history(arg)
-
-    hist.__doc__ = history.__doc__
-
-    @line_magic
-    def rep(self, arg):
+    def recall(self, arg):
         r"""Repeat a command, or get command to input line for editing.
 
         %recall and %rep are equivalent.
@@ -209,7 +202,7 @@ class HistoryMagics(Magics):
              In[1]: l = ["hei", "vaan"]
              In[2]: "".join(l)
             Out[2]: heivaan
-             In[3]: %rep
+             In[3]: %recall
              In[4]: heivaan_ <== cursor blinking
 
         %recall 45
@@ -244,7 +237,7 @@ class HistoryMagics(Magics):
         except Exception:           # Search for term in history
             histlines = self.shell.history_manager.search("*"+arg+"*")
             for h in reversed([x[2] for x in histlines]):
-                if 'rep' in h:
+                if 'recall' in h or 'rep' in h:
                     continue
                 self.shell.set_next_input(h.rstrip())
                 return
@@ -292,10 +285,3 @@ class HistoryMagics(Magics):
         print(histlines)
         print("=== Output: ===")
         self.shell.run_cell("\n".join(hist), store_history=False)
-
-    @line_magic
-    def recall(self,arg):
-        self.rep(arg)
-
-    recall.__doc__ = rep.__doc__
-

--- a/IPython/zmq/zmqshell.py
+++ b/IPython/zmq/zmqshell.py
@@ -575,7 +575,7 @@ class ZMQInteractiveShell(InteractiveShell):
     def init_magics(self):
         super(ZMQInteractiveShell, self).init_magics()
         self.register_magics(KernelMagics)
-        self.run_line_magic('alias_magic', 'ed edit')
+        self.magics_manager.register_alias('ed', 'edit')
 
 
 


### PR DESCRIPTION
### Original Issue:

Following up on #2086, we can also use `%alias_magic` to register `%ed`, `%hist` and `%recall`.

Since the coupling between the original function (`%edit`) and alias (`%ed`) is a bit looser now, I've modified the docstring examples for `%edit` to use `edit` instead of `ed`.

New idea, as @fperez wrote in #2144:

> I actually agree with @takluyver here, if we need to use this both internally (programatically) and in a mode with user-friendly output, the best thing to do is to split it into a python funcitonal API and the magic entry point being only a thin wrapper. This also has the side benefit of letting us test things without worrying about stdout side effects.
### Current Issue:

Add a method `register_alias` to `MagicsManager` which can be used to register new magic aliases.  Each magic alias is an instance of `MagicAlias`, a helper class whose `__call__` looks up the target of the alias (at call time) and dispatches the magic call.

As a future benefit, this could be easily extended to allow for new aliases which contain some flags to pass to the function.  For example, it would be easy to change the behavior to allow the creation of an `%ex` alias for `%edit -x`.
