### PR TITLE
Add option append (-a) to %save

### DIFF
--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -81,7 +81,8 @@ class CodeMagics(Magics):
         fname, codefrom = unquote_filename(args[0]), " ".join(args[1:])
         if not fname.endswith((u'.py',u'.ipy')):
             fname += ext
-        if os.path.isfile(fname) and not force and not append:
+        file_exists = os.path.isfile(fname)
+        if file_exists and not force and not append:
             try:
                 overwrite = self.shell.ask_yes_no('File `%s` exists. Overwrite (y/[N])? ' % fname, default='n')
             except StdinNotImplementedError:
@@ -97,7 +98,7 @@ class CodeMagics(Magics):
             return
         out = py3compat.cast_unicode(cmds)
         with io.open(fname, mode, encoding="utf-8") as f:
-            if not append:
+            if not file_exists or not append:
                 f.write(u"# coding: utf-8\n")
             f.write(out)
             # make sure we end on a newline

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -61,8 +61,7 @@ class CodeMagics(Magics):
           -f: force overwrite.  If file exists, %save will prompt for overwrite
           unless -f is given.
 
-          -a: append to file.  Open file in append mode and end every write
-          on a newline.
+          -a: open file in append mode.
 
         This function uses the same syntax as %history for input ranges,
         then saves the lines to the filename you specify.
@@ -98,14 +97,12 @@ class CodeMagics(Magics):
             return
         out = py3compat.cast_unicode(cmds)
         with io.open(fname, mode, encoding="utf-8") as f:
-            if append:
-                f.write(out)
-                # make sure we end on a newline
-                if not out.endswith(u'\n'):
-                    f.write(u'\n')
-            else:
+            if not append:
                 f.write(u"# coding: utf-8\n")
-                f.write(out)
+            f.write(out)
+            # make sure we end on a newline
+            if not out.endswith(u'\n'):
+                f.write(u'\n')
         print 'The following commands were written to file `%s`:' % fname
         print cmds
 

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -61,7 +61,7 @@ class CodeMagics(Magics):
           -f: force overwrite.  If file exists, %save will prompt for overwrite
           unless -f is given.
 
-          -a: open file in append mode.
+          -a: append to the file instead of overwriting it.
 
         This function uses the same syntax as %history for input ranges,
         then saves the lines to the filename you specify.

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -95,7 +95,7 @@ def test_history():
             ip.magic("save " + testfilename + " ~1/1-3")
             with py3compat.open(testfilename, encoding='utf-8') as testfile:
                 nt.assert_equal(testfile.read(),
-                                        u"# coding: utf-8\n" + u"\n".join(hist))
+                                        u"# coding: utf-8\n" + u"\n".join(hist)+u"\n")
 
             # Duplicate line numbers - check that it doesn't crash, and
             # gets a new session

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -742,3 +742,23 @@ def test_alias_magic():
     ip.run_line_magic('alias_magic', '--line env_alias env')
     nt.assert_equal(ip.run_line_magic('env', ''),
                     ip.run_line_magic('env_alias', ''))
+
+def test_save():
+    """Test %save."""
+    ip = get_ipython()
+    ip.history_manager.reset()   # Clear any existing history.
+    cmds = [u"a=1", u"def b():\n  return a**2", u"print(a, b())"]
+    for i, cmd in enumerate(cmds, start=1):
+        ip.history_manager.store_inputs(i, cmd)
+    with TemporaryDirectory() as tmpdir:
+        file = os.path.join(tmpdir, "testsave.py")
+        ip.run_line_magic("save", "%s 1-10" % file)
+        with open(file) as f:
+            content = f.read()
+            nt.assert_equal(content.count(cmds[0]), 1)
+            nt.assert_true('coding: utf-8' in content)
+        ip.run_line_magic("save", "-a %s 1-10" % file)
+        with open(file) as f:
+            content = f.read()
+            nt.assert_equal(content.count(cmds[0]), 2)
+            nt.assert_true('coding: utf-8' in content)


### PR DESCRIPTION
inspired by: http://www.reddit.com/r/Python/comments/wc0wp/ipython_how_to_save_code_entered_in_the_shell_to/

:)

I'm not sure if simply writing a `\n` if it isn't there is the best way to handle the case of multiple `save -a` after one another, but i'd think it's than to try and change `find_user_code`.
