### PR TITLE
Tell git that *.py files contain Python code, for use in word-diffs.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 IPython/.git_commit_info.ini export-subst
 * text=auto
+*.py diff=python
+*.js diff=javascript
+*.html diff=html


### PR DESCRIPTION
By setting `*.py diff=python` in `.gitattributes`, `git` can know to:
- Produce better hunk headers in the output of `git diff`
- More accurately split words in `git diff --color-words`

For a neat demo, try something like, with and without this patch.

```
git show --color-words 31d0fe14
```
