### PR TITLE
ipcluster broken with any batch launcher (PBS/LSF/SGE)

### DIFF
--- a/IPython/parallel/apps/launcher.py
+++ b/IPython/parallel/apps/launcher.py
@@ -22,6 +22,7 @@ Authors:
 import copy
 import logging
 import os
+import pipes
 import stat
 import sys
 import time
@@ -1141,7 +1142,7 @@ class PBSControllerLauncher(PBSLauncher, BatchClusterAppMixin):
 #PBS -V
 #PBS -N ipcontroller
 %s --log-to-file --profile-dir="{profile_dir}" --cluster-id="{cluster_id}"
-"""%(' '.join(ipcontroller_cmd_argv)))
+"""%(' '.join(map(pipes.quote, ipcontroller_cmd_argv))))
 
 
     def start(self):
@@ -1157,7 +1158,7 @@ class PBSEngineSetLauncher(PBSLauncher, BatchClusterAppMixin):
 #PBS -V
 #PBS -N ipengine
 %s --profile-dir="{profile_dir}" --cluster-id="{cluster_id}"
-"""%(' '.join(ipengine_cmd_argv)))
+"""%(' '.join(map(pipes.quote,ipengine_cmd_argv))))
 
     def start(self, n):
         """Start n engines by profile or profile_dir."""
@@ -1181,7 +1182,7 @@ class SGEControllerLauncher(SGELauncher, BatchClusterAppMixin):
 #$ -S /bin/sh
 #$ -N ipcontroller
 %s --log-to-file --profile-dir="{profile_dir}" --cluster-id="{cluster_id}"
-"""%(' '.join(ipcontroller_cmd_argv)))
+"""%(' '.join(map(pipes.quote, ipcontroller_cmd_argv))))
 
     def start(self):
         """Start the controller by profile or profile_dir."""
@@ -1195,7 +1196,7 @@ class SGEEngineSetLauncher(SGELauncher, BatchClusterAppMixin):
 #$ -S /bin/sh
 #$ -N ipengine
 %s --profile-dir="{profile_dir}" --cluster-id="{cluster_id}"
-"""%(' '.join(ipengine_cmd_argv)))
+"""%(' '.join(map(pipes.quote, ipengine_cmd_argv))))
 
     def start(self, n):
         """Start n engines by profile or profile_dir."""
@@ -1249,7 +1250,7 @@ class LSFControllerLauncher(LSFLauncher, BatchClusterAppMixin):
     #BSUB -oo ipcontroller.o.%%J
     #BSUB -eo ipcontroller.e.%%J
     %s --log-to-file --profile-dir="{profile_dir}" --cluster-id="{cluster_id}"
-    """%(' '.join(ipcontroller_cmd_argv)))
+    """%(' '.join(map(pipes.quote,ipcontroller_cmd_argv))))
 
     def start(self):
         """Start the controller by profile or profile_dir."""
@@ -1264,7 +1265,7 @@ class LSFEngineSetLauncher(LSFLauncher, BatchClusterAppMixin):
     #BSUB -oo ipengine.o.%%J
     #BSUB -eo ipengine.e.%%J
     %s --profile-dir="{profile_dir}" --cluster-id="{cluster_id}"
-    """%(' '.join(ipengine_cmd_argv)))
+    """%(' '.join(map(pipes.quote, ipengine_cmd_argv))))
 
     def start(self, n):
         """Start n engines by profile or profile_dir."""


### PR DESCRIPTION
I have setup ipcluster_config.py to start with LSF:

```
c.IPClusterStart.controller_launcher_class = 'LSF'
c.IPClusterStart.engine_launcher_class = 'LSF'
```

But the ipcluster command fails to start the engines:

```
ipcluster start --profile=lsf -n 10
```

The problem is fixed if I add quotes to the launch command string `cmd` in `launcher.py`.

```
diff --git a/IPython/parallel/apps/launcher.py b/IPython/parallel/apps/launcher.py
index e752d2a..6035303 100644
--- a/IPython/parallel/apps/launcher.py
+++ b/IPython/parallel/apps/launcher.py
@@ -73,7 +73,7 @@ WINDOWS = os.name == 'nt'
 # Paths to the kernel apps
 #-----------------------------------------------------------------------------

-cmd = "from IPython.parallel.apps.%s import launch_new_instance; launch_new_instance()"
+cmd = "\"from IPython.parallel.apps.%s import launch_new_instance; launch_new_instance()\""

 ipcluster_cmd_argv = [sys.executable, "-c", cmd % "ipclusterapp"]

```
