### PR TITLE
Add -l option to %R magic to allow passing in of local namespace

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2088,11 +2088,12 @@ class InteractiveShell(SingletonConfigurable):
             magic_arg_s = self.var_expand(line, stack_depth)
             # Put magic args in a list so we can call with f(*a) syntax
             args = [magic_arg_s]
+            kwargs = {}
             # Grab local namespace if we need it:
             if getattr(fn, "needs_local_scope", False):
-                args.append(sys._getframe(stack_depth).f_locals)
+                kwargs['local_ns'] = sys._getframe(stack_depth).f_locals
             with self.builtin_trap:
-                result = fn(*args)
+                result = fn(*args,**kwargs)
             return result
 
     def run_cell_magic(self, magic_name, line, cell):

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -812,7 +812,7 @@ python-profiler package from non-free.""")
     @skip_doctest
     @needs_local_scope
     @line_magic
-    def time(self,parameter_s, user_locals):
+    def time(self,parameter_s, local_ns=None):
         """Time execution of a Python statement or expression.
 
         The CPU and wall clock times are printed, and the value of the
@@ -884,11 +884,11 @@ python-profiler package from non-free.""")
         wall_st = wtime()
         if mode=='eval':
             st = clock2()
-            out = eval(code, glob, user_locals)
+            out = eval(code, glob, local_ns)
             end = clock2()
         else:
             st = clock2()
-            exec code in glob, user_locals
+            exec code in glob, local_ns
             end = clock2()
             out = None
         wall_end = wtime()

--- a/IPython/extensions/octavemagic.py
+++ b/IPython/extensions/octavemagic.py
@@ -45,7 +45,7 @@ from xml.dom import minidom
 
 from IPython.core.displaypub import publish_display_data
 from IPython.core.magic import (Magics, magics_class, line_magic,
-                                line_cell_magic)
+                                line_cell_magic, needs_local_scope)
 from IPython.testing.skipdoctest import skip_doctest
 from IPython.core.magic_arguments import (
     argument, magic_arguments, parse_argstring
@@ -182,12 +182,13 @@ class OctaveMagics(Magics):
         help='Plot format (png, svg or jpg).'
         )
 
+    @needs_local_scope
     @argument(
         'code',
         nargs='*',
         )
     @line_cell_magic
-    def octave(self, line, cell=None):
+    def octave(self, line, cell=None, local_ns=None):
         '''
         Execute code in Octave, and pull some of the results back into the
         Python namespace.
@@ -237,18 +238,24 @@ class OctaveMagics(Magics):
         if cell is None:
             code = ''
             return_output = True
-            line_mode = True
         else:
             code = cell
             return_output = False
-            line_mode = False
 
         code = ' '.join(args.code) + code
+
+        # if there is no local namespace then default to an empty dict
+        if local_ns is None:
+            local_ns = {}
 
         if args.input:
             for input in ','.join(args.input).split(','):
                 input = unicode_to_str(input)
-                self._oct.put(input, self.shell.user_ns[input])
+                try:
+                    val = local_ns[input]
+                except KeyError:
+                    val = self.shell.user_ns[input]
+                self._oct.put(input, val)
 
         # generate plots in a temporary directory
         plot_dir = tempfile.mkdtemp()

--- a/IPython/extensions/tests/test_octavemagic.py
+++ b/IPython/extensions/tests/test_octavemagic.py
@@ -62,3 +62,24 @@ def test_octave_plot():
                       'plot([1, 2, 3]); figure; plot([4, 5, 6]);')
 
     nt.assert_equal(test_octave_plot.svgs_generated, 2)
+
+def test_octavemagic_localscope():
+    ip = get_ipython()
+    ip.magic('load_ext octavemagic')
+    ip.push({'x':0})
+    ip.run_line_magic('octave', '-i x -o result result = x+1')
+    result = ip.user_ns['result']
+    nt.assert_equal(result, 1)
+
+    ip.run_cell('''def octavemagic_addone(u):
+    %octave -i u -o result result = u+1
+    return result''')
+    ip.run_cell('result = octavemagic_addone(1)')
+    result = ip.user_ns['result']
+    nt.assert_equal(result, 2)
+
+    nt.assert_raises(
+        KeyError,
+        ip.run_line_magic,
+        "octave",
+        "-i var_not_defined 1+1")

--- a/IPython/extensions/tests/test_rmagic.py
+++ b/IPython/extensions/tests/test_rmagic.py
@@ -60,3 +60,23 @@ def test_cell_magic():
     ip.run_cell_magic('R', '-i x,y -o r,xc a=lm(y~x)', snippet)
     np.testing.assert_almost_equal(ip.user_ns['xc'], [3.2, 0.9])
     np.testing.assert_almost_equal(ip.user_ns['r'], np.array([-0.2,  0.9, -1. ,  0.1,  0.2]))
+
+
+def test_rmagic_localscope():
+    ip.push({'x':0})
+    ip.run_line_magic('R', '-i x -o result result <-x+1')
+    result = ip.user_ns['result']
+    nt.assert_equal(result[0], 1)
+
+    ip.run_cell('''def rmagic_addone(u):
+    %R -i u -o result result <- u+1
+    return result[0]''')
+    ip.run_cell('result = rmagic_addone(1)')
+    result = ip.user_ns['result']
+    nt.assert_equal(result, 2)
+
+    nt.assert_raises(
+        KeyError,
+        ip.run_line_magic,
+        "R",
+        "-i var_not_defined 1+1")


### PR DESCRIPTION
Feature request for `rmagic`: It would be great to be able to pass in local variables to the `%R` magic so that you can write functions that invoke R with values from the local scope (not just from user_ns).  For example:

```
%load_ext rmagic
import numpy as np
def fun(values):
    for v in values:
        %R -i v -o prob prob <- pnorm(v)
        print prob
fun(np.arange(-1,1,.25))
```

Right now with `%R -i` magic you can only get variables from user_ns, so the above code won't work.  I have added a `%R -l` argument that works just like `%R -i` except that variables are taken from the local scope.  So the above code would be written:

```
%load_ext rmagic
import numpy as np
def fun(values):
    for v in values:
        %R -l v -o prob prob <- pnorm(v)
        print prob
fun(np.arange(-1,1,.25))
```

And the result would be:

```
[ 0.15865525]
[ 0.22662735]
[ 0.30853754]
[ 0.40129367]
[ 0.5]
[ 0.59870633]
[ 0.69146246]
[ 0.77337265]
```

The following changes to rmagic.py would make this work.

https://github.com/guyhf/ipython/commit/5448c932b8c7f699fc1beabfaa6044921c4fd54b
