### PR TITLE
Apply 2to3 `next` fix.

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -718,10 +718,10 @@ class IPCompleter(Completer):
         isId = re.compile(r'\w+$').match
         while True:
             try:
-                ids.append(iterTokens.next())
+                ids.append(next(iterTokens))
                 if not isId(ids[-1]):
                     ids.pop(); break
-                if not iterTokens.next() == '.':
+                if not next(iterTokens) == '.':
                     break
             except StopIteration:
                 break

--- a/IPython/external/pexpect/_pexpect.py
+++ b/IPython/external/pexpect/_pexpect.py
@@ -930,7 +930,7 @@ class spawnb(object):
 
         return self
 
-    def next (self):    # File-like object.
+    def __next__ (self):    # File-like object.
 
         """This is to support iterators over a file-like object.
         """
@@ -939,6 +939,9 @@ class spawnb(object):
         if result == self._empty_buffer:
             raise StopIteration
         return result
+
+    if not PY3:
+        next = __next__    # File-like object.
 
     def readlines (self, sizehint = -1):    # File-like object.
 

--- a/IPython/frontend/qt/console/pygments_highlighter.py
+++ b/IPython/frontend/qt/console/pygments_highlighter.py
@@ -174,7 +174,7 @@ class PygmentsHighlighter(QtGui.QSyntaxHighlighter):
     def _get_format_from_document(self, token, document):
         """ Returns a QTextCharFormat for token by
         """
-        code, html = self._formatter._format_lines([(token, u'dummy')]).next()
+        code, html = next(self._formatter._format_lines([(token, u'dummy')]))
         self._document.setHtml(html)
         return QtGui.QTextCursor(self._document).charFormat()
 

--- a/IPython/testing/_paramtestpy2.py
+++ b/IPython/testing/_paramtestpy2.py
@@ -51,7 +51,7 @@ class ParametricTestCase(unittest.TestCase):
                 # Test execution
                 ok = False
                 try:
-                    testgen.next()
+                    next(testgen)
                     ok = True
                 except StopIteration:
                     # We stop the loop

--- a/IPython/utils/_process_common.py
+++ b/IPython/utils/_process_common.py
@@ -179,7 +179,7 @@ def arg_split(s, posix=False, strict=True):
     tokens = []
     while True:
         try:
-            tokens.append(lex.next())
+            tokens.append(next(lex))
         except StopIteration:
             break
         except ValueError:

--- a/IPython/zmq/iostream.py
+++ b/IPython/zmq/iostream.py
@@ -5,6 +5,7 @@ from io import StringIO
 from session import extract_header, Message
 
 from IPython.utils import io, text, encoding
+from IPython.utils import py3compat
 
 #-----------------------------------------------------------------------------
 # Globals
@@ -54,8 +55,11 @@ class OutStream(object):
     def isatty(self):
         return False
 
-    def next(self):
+    def __next__(self):
         raise IOError('Read not supported on a write only stream.')
+
+    if not py3compat.PY3:
+        next = __next__
 
     def read(self, size=-1):
         raise IOError('Read not supported on a write only stream.')

--- a/setup.py
+++ b/setup.py
@@ -272,6 +272,7 @@ if 'setuptools' in sys.modules:
                 'lib2to3.fixes.fix_except',
                 'lib2to3.fixes.fix_apply',
                 'lib2to3.fixes.fix_repr',
+                'lib2to3.fixes.fix_next',
                 ]
         from setuptools.command.build_py import build_py
         setup_args['cmdclass'] = {'build_py': record_commit_info('IPython', build_cmd=build_py)}


### PR DESCRIPTION
Continuing on the Python 2/3 compatibility (which I'll refer to as '2and3') from #2095 and #2100, I propose to include the changes from running `2to3 -f next`:

> Converts the use of iterator’s `next()` methods to the `next()` function. It also renames `next()` methods to `__next__()`.

One small issue is the behavior of `next(x)` on user defined classes:

Consider `test_next.py`

```
class X(object):
    def __init__(self, iterable):
        self.iterator = iter(iterable)
    def __iter__(self):
        return self
    def __next__(self):
        print("__next__ called")
        return next(self.iterator)
    def next(self):
        print("next called")
        return next(self.iterator)

x = X([1,2,3])
next(x)
```

And run it in Python 2.7 and 3.2:

```
$ python2.7 next_test.py
next called
$ python3.2 next_test.py
__next__ called
```

To work around this difference, I've just set `next = __next__` manually after applying the 2to3 fix. This also maintains compatibility with any third party code which calls `x.next()`.
