### PR TITLE
Use breqn.sty in dvipng backend if possible

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -66,6 +66,7 @@ from IPython.core.prefilter import PrefilterManager
 from IPython.core.profiledir import ProfileDir
 from IPython.core.pylabtools import pylab_activate
 from IPython.core.prompts import PromptManager
+from IPython.lib.latextools import LaTeXTool
 from IPython.utils import PyColorize
 from IPython.utils import io
 from IPython.utils import py3compat
@@ -497,6 +498,7 @@ class InteractiveShell(SingletonConfigurable):
         self.init_display_pub()
         self.init_displayhook()
         self.init_reload_doctest()
+        self.init_latextool()
         self.init_magics()
         self.init_logstart()
         self.init_pdb()
@@ -689,7 +691,13 @@ class InteractiveShell(SingletonConfigurable):
             doctest_reload()
         except ImportError:
             warn("doctest module does not exist.")
-    
+
+    def init_latextool(self):
+        """Configure LaTeXTool."""
+        cfg = LaTeXTool(config=self.config)
+        if cfg not in self.configurables:
+            self.configurables.append(cfg)
+
     def init_virtualenv(self):
         """Add a virtualenv to sys.path so the user can import modules from it.
         This isn't perfect: it doesn't use the Python interpreter with which the

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -694,7 +694,7 @@ class InteractiveShell(SingletonConfigurable):
 
     def init_latextool(self):
         """Configure LaTeXTool."""
-        cfg = LaTeXTool(config=self.config)
+        cfg = LaTeXTool.instance(config=self.config)
         if cfg not in self.configurables:
             self.configurables.append(cfg)
 

--- a/IPython/extensions/sympyprinting.py
+++ b/IPython/extensions/sympyprinting.py
@@ -65,7 +65,7 @@ def print_display_png(o):
     s = s.strip('$')
     # As matplotlib does not support display style, dvipng backend is
     # used here.
-    png = latex_to_png('$$%s$$' % s, backend='dvipng')
+    png = latex_to_png(s, backend='dvipng', wrap=True)
     return png
 
 

--- a/IPython/lib/tests/test_latextools.py
+++ b/IPython/lib/tests/test_latextools.py
@@ -1,0 +1,119 @@
+# encoding: utf-8
+"""Tests for IPython.utils.path.py"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2008-2011  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+import nose.tools as nt
+
+from IPython.lib import latextools
+from IPython.testing.decorators import onlyif_cmds_exist
+from IPython.testing.tools import monkeypatch
+from IPython.utils.process import FindCmdError
+
+
+def test_latex_to_png_dvipng_fails_when_no_cmd():
+    """
+    `latex_to_png_dvipng` should return None when there is no required command
+    """
+    for command in ['latex', 'dvipng']:
+        yield (check_latex_to_png_dvipng_fails_when_no_cmd, command)
+
+
+def check_latex_to_png_dvipng_fails_when_no_cmd(command):
+    def mock_find_cmd(arg):
+        if arg == command:
+            raise FindCmdError
+
+    with monkeypatch(latextools, "find_cmd", mock_find_cmd):
+        nt.assert_equals(latextools.latex_to_png_dvipng("whatever", True),
+                         None)
+
+
+@onlyif_cmds_exist('latex', 'dvipng')
+def test_latex_to_png_dvipng_runs():
+    """
+    Test that latex_to_png_dvipng just runs without error.
+    """
+    def mock_kpsewhich(filename):
+        nt.assert_equals(filename, "breqn.sty")
+        return None
+
+    for (s, wrap) in [("$$x^2$$", False), ("x^2", True)]:
+        yield (latextools.latex_to_png_dvipng, s, wrap)
+
+        with monkeypatch(latextools, "kpsewhich", mock_kpsewhich):
+            yield (latextools.latex_to_png_dvipng, s, wrap)
+
+
+def test_genelatex_no_wrap():
+    """
+    Test genelatex with wrap=False.
+    """
+    def mock_kpsewhich(filename):
+        assert False, ("kpsewhich should not be called "
+                       "(called with {0})".format(filename))
+
+    with monkeypatch(latextools, "kpsewhich", mock_kpsewhich):
+        nt.assert_equals(
+            '\n'.join(latextools.genelatex("body text", False)),
+            r'''\documentclass{article}
+\usepackage{amsmath}
+\usepackage{amsthm}
+\usepackage{amssymb}
+\usepackage{bm}
+\pagestyle{empty}
+\begin{document}
+body text
+\end{document}''')
+
+
+def test_genelatex_wrap_with_breqn():
+    """
+    Test genelatex with wrap=True for the case breqn.sty is installed.
+    """
+    def mock_kpsewhich(filename):
+        nt.assert_equals(filename, "breqn.sty")
+        return "path/to/breqn.sty"
+
+    with monkeypatch(latextools, "kpsewhich", mock_kpsewhich):
+        nt.assert_equals(
+            '\n'.join(latextools.genelatex("x^2", True)),
+            r'''\documentclass{article}
+\usepackage{amsmath}
+\usepackage{amsthm}
+\usepackage{amssymb}
+\usepackage{bm}
+\usepackage{breqn}
+\pagestyle{empty}
+\begin{document}
+\begin{dmath*}
+x^2
+\end{dmath*}
+\end{document}''')
+
+
+def test_genelatex_wrap_without_breqn():
+    """
+    Test genelatex with wrap=True for the case breqn.sty is not installed.
+    """
+    def mock_kpsewhich(filename):
+        nt.assert_equals(filename, "breqn.sty")
+        return None
+
+    with monkeypatch(latextools, "kpsewhich", mock_kpsewhich):
+        nt.assert_equals(
+            '\n'.join(latextools.genelatex("x^2", True)),
+            r'''\documentclass{article}
+\usepackage{amsmath}
+\usepackage{amsthm}
+\usepackage{amssymb}
+\usepackage{bm}
+\pagestyle{empty}
+\begin{document}
+$$x^2$$
+\end{document}''')

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -72,6 +72,9 @@ from ipunittest import ipdoctest, ipdocstring
 # numpy.testing.decorators, we expose all of it here.
 from IPython.external.decorators import *
 
+# For onlyif_cmd_exists decorator
+from IPython.utils.process import is_cmd_found
+
 #-----------------------------------------------------------------------------
 # Classes and functions
 #-----------------------------------------------------------------------------
@@ -342,3 +345,14 @@ else:
 
 onlyif_unicode_paths = onlyif(unicode_paths, ("This test is only applicable "
                                     "where we can use unicode in filenames."))
+
+
+def onlyif_cmds_exist(*commands):
+    """
+    Decorator to skip test when at least one of `commands` is not found.
+    """
+    for cmd in commands:
+        if not is_cmd_found(cmd):
+            return skip("This test runs only if command '{0}' "
+                        "is installed".format(cmd))
+    return null_deco

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -390,3 +390,14 @@ def make_tempfile(name):
         yield
     finally:
         os.unlink(name)
+
+
+@contextmanager
+def monkeypatch(obj, name, attr):
+    """
+    Context manager to replace attribute named `name` in `obj` with `attr`.
+    """
+    orig = getattr(obj, name)
+    setattr(obj, name, attr)
+    yield
+    setattr(obj, name, orig)

--- a/IPython/utils/process.py
+++ b/IPython/utils/process.py
@@ -72,6 +72,15 @@ def find_cmd(cmd):
     return os.path.abspath(path)
 
 
+def is_cmd_found(cmd):
+    """Check whether executable `cmd` exists or not and return a bool."""
+    try:
+        find_cmd(cmd)
+        return True
+    except FindCmdError:
+        return False
+
+
 def pycmd2argv(cmd):
     r"""Take the path of a python command and return a list (argv-style).
 


### PR DESCRIPTION
This PR improves dvipng backend for latex_to_png function by using [breqn](http://www.ctan.org/pkg/breqn) when it is installed.

breqn automatically breaks equation so you can view very long equation in Qt console, like this:

<a href="http://www.flickr.com/photos/arataka/7570141644/" title="screenshot-2012-07-14-223303 by takafumi_a, on Flickr"><img src="http://farm9.staticflickr.com/8020/7570141644_6fcf312170_b.jpg" width="690" height="230" alt="screenshot-2012-07-14-223303"></a>

However, this patch is not complete yet because sympyprinting unconditionally use matplotlib backend for non-display equations.  I think configuration to choose matplotlib/dvipng backend is needed.  What do you think?  Also, if having configuration is a right choice, where should I put configuration class?  I can't find any IPython extension using its own configuration.

To check how new latex_to_png works, you can put the following line in `IPython/lib/latextools.py`, just after the definition of `print_display_png`.

``` python
print_png = print_display_png
```
