### PR TITLE
Hook to add alternative notebook managers

### DIFF
--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -227,6 +227,7 @@ notebook_flags = ['no-browser', 'no-mathjax', 'read-only', 'script', 'no-script'
 aliases = dict(ipkernel_aliases)
 
 aliases.update({
+    'nbmgr': 'NotebookApp.nbmgr',
     'ip': 'NotebookApp.ip',
     'port': 'NotebookApp.port',
     'port-retries': 'NotebookApp.port_retries',
@@ -276,6 +277,9 @@ class NotebookApp(BaseIPythonApplication):
 
     # file to be opened in the notebook server
     file_to_run = Unicode('')
+
+    # Which alternative NotebookManager to use
+    nbmgr = Unicode(u'', config=True, help="""Alternative notebook manager module""")
 
     # Network related information.
 
@@ -430,7 +434,14 @@ class NotebookApp(BaseIPythonApplication):
             config=self.config, log=self.log, kernel_argv=self.kernel_argv,
             connection_dir = self.profile_dir.security_dir,
         )
-        self.notebook_manager = NotebookManager(config=self.config, log=self.log)
+
+        # added option to load alternative notebook
+        if self.nbmgr and self.nbmgr != "":
+          loader = __import__(self.nbmgr, globals(), locals(), ['get_notebook_manager'], -1)
+          self.notebook_manager = loader.get_notebook_manager()
+        else:
+          self.notebook_manager = NotebookManager(config=self.config, log=self.log)
+
         self.log.info("Serving notebooks from %s", self.notebook_manager.notebook_dir)
         self.notebook_manager.list_notebooks()
         self.cluster_manager = ClusterManager(config=self.config, log=self.log)

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -242,7 +242,7 @@ aliases.update({
 aliases.pop('f', None)
 
 notebook_aliases = [u'port', u'port-retries', u'ip', u'keyfile', u'certfile',
-                    u'notebook-dir']
+                    u'notebook-dir', u'nbmgr']
 
 #-----------------------------------------------------------------------------
 # NotebookApp

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -239,7 +239,7 @@ aliases.update({
 aliases.pop('f', None)
 
 notebook_aliases = [u'port', u'port-retries', u'ip', u'keyfile', u'certfile',
-                    u'notebook-dir']
+                    u'notebook-dir', u'nbmgr']
 
 #-----------------------------------------------------------------------------
 # NotebookApp

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -224,6 +224,7 @@ notebook_flags = ['no-browser', 'no-mathjax', 'read-only', 'script', 'no-script'
 aliases = dict(ipkernel_aliases)
 
 aliases.update({
+    'nbmgr': 'NotebookApp.nbmgr',
     'ip': 'NotebookApp.ip',
     'port': 'NotebookApp.port',
     'port-retries': 'NotebookApp.port_retries',
@@ -273,6 +274,9 @@ class NotebookApp(BaseIPythonApplication):
 
     # file to be opened in the notebook server
     file_to_run = Unicode('')
+
+    # Which alternative NotebookManager to use
+    nbmgr = Unicode(u'', config=True, help="""Alternative notebook manager module""")
 
     # Network related information.
 
@@ -412,7 +416,14 @@ class NotebookApp(BaseIPythonApplication):
             config=self.config, log=self.log, kernel_argv=self.kernel_argv,
             connection_dir = self.profile_dir.security_dir,
         )
-        self.notebook_manager = NotebookManager(config=self.config, log=self.log)
+
+        # added option to load alternative notebook
+        if self.nbmgr and self.nbmgr != "":
+          loader = __import__(self.nbmgr, globals(), locals(), ['get_notebook_manager'], -1)
+          self.notebook_manager = loader.get_notebook_manager()
+        else:
+          self.notebook_manager = NotebookManager(config=self.config, log=self.log)
+
         self.log.info("Serving notebooks from %s", self.notebook_manager.notebook_dir)
         self.notebook_manager.list_notebooks()
         self.cluster_manager = ClusterManager(config=self.config, log=self.log)

--- a/IPython/frontend/terminal/embed.py
+++ b/IPython/frontend/terminal/embed.py
@@ -200,7 +200,8 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
             module.__dict__ = global_ns
 
         # Get locals and globals from caller
-        if (local_ns is None or module is None) and self.default_user_namespaces:
+        if ((local_ns is None or module is None or compile_flags is None)
+            and self.default_user_namespaces):
             call_frame = sys._getframe(stack_depth).f_back
 
             if local_ns is None:
@@ -233,7 +234,8 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
             self.init_user_ns()
 
         # Compiler flags
-        self.compile.flags = compile_flags
+        if compile_flags is not None:
+            self.compile.flags = compile_flags
 
         # Patch for global embedding to make sure that things don't overwrite
         # user globals accidentally. Thanks to Richard <rxe@renre-europe.com>

--- a/docs/source/development/testing.txt
+++ b/docs/source/development/testing.txt
@@ -66,6 +66,8 @@ the full test suite.  You can then run the suite with:
 
    iptest  [args]
 
+By default, this excludes the relatively slow tests for ``IPython.parallel``. To
+run these, use ``iptest --all``.
 
 Regardless of how you run things, you should eventually see something like:
 
@@ -138,6 +140,23 @@ point of the error or failure respectively.
        print sys_info()
 
    and include the resulting information in your query.
+
+Testing pull requests
+---------------------
+
+We have a script that fetches a pull request from Github, merges it with master,
+and runs the test suite on different versions of Python. This uses a separate
+copy of the repository, so you can keep working on the code while it runs. To
+run it::
+
+    python tools/test_pr.py -p 1234
+
+The number is the pull request number from Github; the ``-p`` flag makes it post
+the results to a comment on the pull request. Any further arguments are passed
+to ``iptest``.
+
+This requires the `requests <http://pypi.python.org/pypi/requests>`_ and
+`keyring <http://pypi.python.org/pypi/keyring>`_ packages.
 
 For developers: writing tests
 =============================

--- a/tools/test_pr.py
+++ b/tools/test_pr.py
@@ -91,6 +91,7 @@ class TestRun(object):
             check_call(['git', 'pull', 'origin', 'master'])
         except CalledProcessError :
             check_call(['git', 'pull', ipy_http_repository, 'master'])
+        self.master_sha = check_output(['git', 'log', '-1', '--format=%h']).decode('ascii').strip()
         os.chdir(basedir)
     
     def get_branch(self):
@@ -125,7 +126,7 @@ class TestRun(object):
             return s
         
         if self.pr['mergeable']:
-            com = self.pr['head']['sha'][:7] + " merged into master"
+            com = self.pr['head']['sha'][:7] + " merged into master (%s)" % self.master_sha
         else:
             com = self.pr['head']['sha'][:7] + " (can't merge cleanly)"
         lines = ["**Test results for commit %s**" % com,
@@ -146,10 +147,12 @@ class TestRun(object):
         pr = self.pr
         
         print("\n")
+        msg = "**Test results for commit %s" % pr['head']['sha'][:7]
         if pr['mergeable']:
-            print("**Test results for commit %s merged into master**" % pr['head']['sha'][:7])
+            msg += " merged into master (%s)**" % self.master_sha
         else:
-            print("**Test results for commit %s (can't merge cleanly)**" % pr['head']['sha'][:7])
+            msg += " (can't merge cleanly)**"
+        print(msg)
         print("Platform:", sys.platform)
         for result in self.results:
             if result.passed:


### PR DESCRIPTION
I added a hook to add alternative notebook managers. See https://github.com/benjiec/django-ipy-nbmgr for an example of a notebook manager that stores notebooks in database, and versions them.
