### PR TITLE
expand line in cell magics

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2112,7 +2112,7 @@ class InteractiveShell(SingletonConfigurable):
             stack_depth = 2
             magic_arg_s = self.var_expand(line, stack_depth)
             with self.builtin_trap:
-                result = fn(line, cell)
+                result = fn(magic_arg_s, cell)
             return result
 
     def find_line_magic(self, magic_name):

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -594,6 +594,21 @@ def test_file():
         nt.assert_in('line1\n', s)
         nt.assert_in('line2', s)
 
+def test_file_var_expand():
+    """%%file $filename"""
+    ip = get_ipython()
+    with TemporaryDirectory() as td:
+        fname = os.path.join(td, 'file1')
+        ip.user_ns['filename'] = fname
+        ip.run_cell_magic("file", '$filename', u'\n'.join([
+            'line1',
+            'line2',
+        ]))
+        with open(fname) as f:
+            s = f.read()
+        nt.assert_in('line1\n', s)
+        nt.assert_in('line2', s)
+
 def test_file_unicode():
     """%%file with unicode cell"""
     ip = get_ipython()


### PR DESCRIPTION
The code was already there to expand it, but the wrong variable was passed to the cell magic.

Previously failing test included for %%file $filename
