### PR TITLE
Ensure consistent indentation in `%magic`.

### DIFF
--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -22,7 +22,7 @@ from pprint import pformat
 from IPython.core import magic_arguments
 from IPython.core.error import UsageError
 from IPython.core.magic import Magics, magics_class, line_magic, magic_escapes
-from IPython.utils.text import format_screen
+from IPython.utils.text import format_screen, dedent, indent
 from IPython.core import magic_arguments, page
 from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.ipstruct import Struct
@@ -147,15 +147,17 @@ class BasicMagics(Magics):
         docs = mman.lsmagic_docs(brief, missing='No documentation')
 
         if rest:
-            format_string = '**%s%s**::\n\n\t%s\n\n'
+            format_string = '**%s%s**::\n\n%s\n\n'
         else:
-            format_string = '%s%s:\n\t%s\n'
+            format_string = '%s%s:\n%s\n'
 
         return ''.join(
-            [format_string % (magic_escapes['line'], fname, fndoc)
+            [format_string % (magic_escapes['line'], fname,
+                              indent(dedent(fndoc)))
              for fname, fndoc in sorted(docs['line'].items())]
             +
-            [format_string % (magic_escapes['cell'], fname, fndoc)
+            [format_string % (magic_escapes['cell'], fname,
+                              indent(dedent(fndoc)))
              for fname, fndoc in sorted(docs['cell'].items())]
         )
 

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -232,7 +232,7 @@ of any of them, type %magic_name?, e.g. '%cd?'.
 
 Currently the magic system has the following functions:""",
        magic_docs,
-       "Summary of magic functions (from %slsmagic):",
+       "Summary of magic functions (from %slsmagic):" % magic_escapes['line'],
        self._lsmagic(),
        ]
         page.page('\n'.join(out))


### PR DESCRIPTION
Right now `%magic` inconsistently indents help text because it does not
dedent/indent the `__doc__` strings. Doc text produced by `@magic_arguments`
generally shows as unindented, whereas conventional docstrings are properly
indented.

In addition, there is an instance of `%slsmagic` which I've corrected to 
`%lsmagic`.
