### PR TITLE
remove numpy install from travis/tox scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
     - 2.7
     - 3.2
 before_install:
-    - pip install --use-mirrors numpy
     - easy_install -q pyzmq
 install:
     - python setup.py install -q 

--- a/tox.ini
+++ b/tox.ini
@@ -8,12 +8,12 @@ envlist = py26, py27, py32
 
 [testenv]
 commands =
-    pip install -q --use-mirrors numpy nose
+    pip install -q --use-mirrors nose
     easy_install -q pyzmq
     iptest -w /tmp
 
 [testenv:py32]
 commands =
-    pip install -q --use-mirrors numpy nose
+    pip install -q --use-mirrors nose
     easy_install -q pyzmq
     iptest3 -w /tmp


### PR DESCRIPTION
travis builds could fail due to timeout building numpy
