### PR TITLE
Include the kernel object in the event object passed to kernel events

### DIFF
--- a/IPython/frontend/html/notebook/static/js/kernel.js
+++ b/IPython/frontend/html/notebook/static/js/kernel.js
@@ -64,7 +64,7 @@ var IPython = (function (IPython) {
 
 
     Kernel.prototype.restart = function () {
-        $([IPython.events]).trigger('status_restarting.Kernel');
+        $([IPython.events]).trigger({type: 'status_restarting.Kernel', kernel: this});
         var that = this;
         if (this.running) {
             this.stop_channels();
@@ -279,7 +279,7 @@ var IPython = (function (IPython) {
 
     Kernel.prototype.interrupt = function () {
         if (this.running) {
-            $([IPython.events]).trigger('status_interrupting.Kernel');
+            $([IPython.events]).trigger({type: 'status_interrupting.Kernel', kernel: this});
             $.post(this.kernel_url + "/interrupt");
         };
     };
@@ -367,12 +367,12 @@ var IPython = (function (IPython) {
             }
         } else if (msg_type === 'status') {
             if (content.execution_state === 'busy') {
-                $([IPython.events]).trigger('status_busy.Kernel');
+                $([IPython.events]).trigger({type: 'status_busy.Kernel', kernel: this});
             } else if (content.execution_state === 'idle') {
-                $([IPython.events]).trigger('status_idle.Kernel');
+                $([IPython.events]).trigger({type: 'status_idle.Kernel', kernel: this});
             } else if (content.execution_state === 'dead') {
                 this.stop_channels();
-                $([IPython.events]).trigger('status_dead.Kernel');
+                $([IPython.events]).trigger({type: 'status_dead.Kernel', kernel: this});
             };
         } else if (msg_type === 'clear_output') {
             var cb = callbacks['clear_output'];


### PR DESCRIPTION
It is really useful to us to have the kernel object that triggered an event when an event handler is called.  This seems to do it.

See the last example in the jquery trigger docs: http://api.jquery.com/trigger/
