### PR TITLE
Expose store_history to execute_request messages.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2556,7 +2556,7 @@ class InteractiveShell(SingletonConfigurable):
           history. For user code calling back into IPython's machinery, this
           should be set to False.
         silent : bool
-          If True, avoid side-effets, such as implicit displayhooks, history,
+          If True, avoid side-effects, such as implicit displayhooks and
           and logging.  silent=True forces store_history=False.
         """
         if (not raw_cell) or raw_cell.isspace():

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -331,6 +331,7 @@ class Kernel(Configurable):
             content = parent[u'content']
             code = content[u'code']
             silent = content[u'silent']
+            store_history = content.get(u'store_history', not silent)
         except:
             self.log.error("Got bad msg: ")
             self.log.error("%s", parent)
@@ -366,7 +367,7 @@ class Kernel(Configurable):
         reply_content = {}
         try:
             # FIXME: the shell calls the exception handler itself.
-            shell.run_cell(code, store_history=not silent, silent=silent)
+            shell.run_cell(code, store_history=store_history, silent=silent)
         except:
             status = u'error'
             # FIXME: this code right now isn't being used yet by default,

--- a/IPython/zmq/kernelmanager.py
+++ b/IPython/zmq/kernelmanager.py
@@ -233,7 +233,7 @@ class ShellSocketChannel(ZMQSocketChannel):
             will force store_history to be False.
 
         store_history : bool, optional (default True)
-            If set, the kernel will execute store command history.  This is forced
+            If set, the kernel will store command history.  This is forced
             to be False if silent is True.
 
         user_variables : list, optional

--- a/IPython/zmq/kernelmanager.py
+++ b/IPython/zmq/kernelmanager.py
@@ -219,7 +219,7 @@ class ShellSocketChannel(ZMQSocketChannel):
         """
         raise NotImplementedError('call_handlers must be defined in a subclass.')
 
-    def execute(self, code, silent=False,
+    def execute(self, code, silent=False, store_history=True,
                 user_variables=None, user_expressions=None, allow_stdin=None):
         """Execute code in the kernel.
 
@@ -229,7 +229,12 @@ class ShellSocketChannel(ZMQSocketChannel):
             A string of Python code.
 
         silent : bool, optional (default False)
-            If set, the kernel will execute the code as quietly possible.
+            If set, the kernel will execute the code as quietly possible, and
+            will force store_history to be False.
+
+        store_history : bool, optional (default True)
+            If set, the kernel will execute store command history.  This is forced
+            to be False if silent is True.
 
         user_variables : list, optional
             A list of variable names to pull from the user's namespace.  They
@@ -267,7 +272,7 @@ class ShellSocketChannel(ZMQSocketChannel):
 
         # Create class for content/msg creation. Related to, but possibly
         # not in Session.
-        content = dict(code=code, silent=silent,
+        content = dict(code=code, silent=silent, store_history=store_history,
                        user_variables=user_variables,
                        user_expressions=user_expressions,
                        allow_stdin=allow_stdin,

--- a/docs/source/development/messaging.txt
+++ b/docs/source/development/messaging.txt
@@ -158,7 +158,8 @@ Message type: ``execute_request``::
     # A boolean flag which, if True, signals the kernel to execute
     # this code as quietly as possible.  This means that the kernel
     # will compile the code with 'exec' instead of 'single' (so
-    # sys.displayhook will not fire), and will *not*:
+    # sys.displayhook will not fire), forces store_history to be False, 
+    # and will *not*:
     #   - broadcast exceptions on the PUB socket
     #   - do any logging
     #
@@ -166,7 +167,8 @@ Message type: ``execute_request``::
     'silent' : bool,
 
     # A boolean flag which, if True, signals the kernel to populate history
-    # The default is False if silent is True, or True if silent is False.
+    # The default is True if silent is False.  If silent is True, store_history
+    # is forced to be False.
     'store_history' : bool,
 
     # A list of variable names from the user's namespace to be retrieved.  What

--- a/docs/source/development/messaging.txt
+++ b/docs/source/development/messaging.txt
@@ -161,10 +161,13 @@ Message type: ``execute_request``::
     # sys.displayhook will not fire), and will *not*:
     #   - broadcast exceptions on the PUB socket
     #   - do any logging
-    #   - populate any history
     #
     # The default is False.
     'silent' : bool,
+
+    # A boolean flag which, if True, signals the kernel to populate history
+    # The default is False if silent is True, or True if silent is False.
+    'store_history' : bool,
 
     # A list of variable names from the user's namespace to be retrieved.  What
     # returns is a JSON string of the variable's repr(), not a python object.
@@ -308,7 +311,7 @@ Execution counter (old prompt number)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The kernel has a single, monotonically increasing counter of all execution
-requests that are made with ``silent=False``.  This counter is used to populate
+requests that are made with ``store_history=True``.  This counter is used to populate
 the ``In[n]``, ``Out[n]`` and ``_n`` variables, so clients will likely want to
 display it in some form to the user, which will typically (but not necessarily)
 be done in the prompts.  The value of this counter will be returned as the
@@ -325,9 +328,9 @@ Message type: ``execute_reply``::
       # One of: 'ok' OR 'error' OR 'abort'
       'status' : str,
 
-      # The global kernel counter that increases by one with each non-silent
-      # executed request.  This will typically be used by clients to display
-      # prompt numbers to the user.  If the request was a silent one, this will
+      # The global kernel counter that increases by one with each request that 
+      # stores history.  This will typically be used by clients to display
+      # prompt numbers to the user.  If the request did not store history, this will
       # be the current value of the counter in the kernel.
       'execution_count' : int,
     }


### PR DESCRIPTION
The doc changes should definitely be checked by someone who understands the system better.  In particular, is the execution counter incremented if store_history is false, or is that tied to `silent`?

I'm submitting this because Min said it would probably be a good idea: http://mail.scipy.org/pipermail/ipython-dev/2012-July/009937.html
