### PR TITLE
removed references to h5py dependence in octave magic documentation

### DIFF
--- a/IPython/extensions/octavemagic.py
+++ b/IPython/extensions/octavemagic.py
@@ -8,8 +8,8 @@ Magics for interacting with Octave via oct2py.
 
 .. note::
 
-  The ``oct2py`` module needs to be installed separately, and in turn depends
-  on ``h5py``.  Both can be obtained using ``easy_install`` or ``pip``.
+  The ``oct2py`` module needs to be installed separately and
+  can be obtained using ``easy_install`` or ``pip``.
 
 Usage
 =====

--- a/docs/examples/notebooks/octavemagic_extension.ipynb
+++ b/docs/examples/notebooks/octavemagic_extension.ipynb
@@ -27,7 +27,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "The `octavemagic` extension provides the ability to interact with Octave.  It depends on the `oct2py` and `h5py` packages,\n",
+      "The `octavemagic` extension provides the ability to interact with Octave.  It depends on the `oct2py` package,\n",
       "which may be installed using `easy_install`.\n",
       "\n",
       "To enable the extension, load it as follows:"

--- a/docs/source/whatsnew/version0.13.txt
+++ b/docs/source/whatsnew/version0.13.txt
@@ -304,7 +304,7 @@ extremely useful.  The following extensions are provided:
     or whole blocks of Octave code, capture both output and figures inline
     (just like matplotlib plots), and have variables automatically converted
     between the two languages.  To use this extension, you must have Octave
-    installed as well as the oct2py_ and h5py_ packages.  The examples
+    installed as well as the oct2py_ package.  The examples
     directory in the source distribution ships with a full notebook
     demonstrating these capabilities:
 
@@ -316,7 +316,6 @@ extremely useful.  The following extensions are provided:
 
 .. _octave: http://www.gnu.org/software/octave
 .. _oct2py: http://pypi.python.org/pypi/oct2py
-.. _h5py: http://code.google.com/p/h5py
 
 **R magics** (extension :ref:`rmagic <extensions_rmagic>`)
     This extension provides several magics that support calling code written in


### PR DESCRIPTION
There were two spots that I found: the version 0.13 file in the whatsnew directory, and the octavemagic_extension notebook.  If there are others I've missed, I'd be happy to go back and fix those too.

closes #2173
