### PR TITLE
Fix IPython.lib.latextools for Python 3

### DIFF
--- a/IPython/lib/latextools.py
+++ b/IPython/lib/latextools.py
@@ -17,7 +17,7 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
-from StringIO import StringIO
+from io import BytesIO
 from base64 import encodestring
 import os
 import tempfile
@@ -27,6 +27,7 @@ import subprocess
 from IPython.utils.process import find_cmd, FindCmdError
 from IPython.config.configurable import SingletonConfigurable
 from IPython.utils.traitlets import Instance, List, CBool, CUnicode
+from IPython.utils.py3compat import bytes_to_str
 
 #-----------------------------------------------------------------------------
 # Tools
@@ -111,7 +112,7 @@ def latex_to_png_mpl(s, wrap):
     if wrap:
         s = '${0}$'.format(s)
     mt = mathtext.MathTextParser('bitmap')
-    f = StringIO()
+    f = BytesIO()
     mt.to_png(f, s, fontsize=12)
     return f.getvalue()
 
@@ -140,7 +141,7 @@ def latex_to_png_dvipng(s, wrap):
              "-bg", "transparent", "-o", outfile, dvifile], cwd=workdir,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-        with open(outfile) as f:
+        with open(outfile, "rb") as f:
             bin_data = f.read()
     finally:
         shutil.rmtree(workdir)
@@ -197,7 +198,7 @@ def latex_to_html(s, alt='image'):
     alt : str
         The alt text to use for the HTML.
     """
-    base64_data = latex_to_png(s, encode=True)
+    base64_data = bytes_to_str(latex_to_png(s, encode=True), 'ascii')
     if base64_data:
         return _data_uri_template_png  % (base64_data, alt)
 

--- a/IPython/lib/tests/test_latextools.py
+++ b/IPython/lib/tests/test_latextools.py
@@ -11,7 +11,7 @@
 import nose.tools as nt
 
 from IPython.lib import latextools
-from IPython.testing.decorators import onlyif_cmds_exist
+from IPython.testing.decorators import onlyif_cmds_exist, skipif_not_matplotlib
 from IPython.testing.tools import monkeypatch
 from IPython.utils.process import FindCmdError
 
@@ -48,6 +48,26 @@ def test_latex_to_png_dvipng_runs():
 
         with monkeypatch(latextools, "kpsewhich", mock_kpsewhich):
             yield (latextools.latex_to_png_dvipng, s, wrap)
+
+@skipif_not_matplotlib
+def test_latex_to_png_mpl_runs():
+    """
+    Test that latex_to_png_mpl just runs without error.
+    """
+    def mock_kpsewhich(filename):
+        nt.assert_equals(filename, "breqn.sty")
+        return None
+
+    for (s, wrap) in [("$x^2$", False), ("x^2", True)]:
+        yield (latextools.latex_to_png_mpl, s, wrap)
+
+        with monkeypatch(latextools, "kpsewhich", mock_kpsewhich):
+            yield (latextools.latex_to_png_mpl, s, wrap)
+
+@skipif_not_matplotlib
+def test_latex_to_html():
+    img = latextools.latex_to_html("$x^2$")
+    nt.assert_in("data:image/png;base64,iVBOR", img) 
 
 
 def test_genelatex_no_wrap():


### PR DESCRIPTION
We weren't quite being careful enough about binary data. This also adds a couple of tests for functions that were missing coverage.

(Test failures seen testing another PR: https://gist.github.com/3163508 )
