### PR TITLE
Introduce Cell ID persistence.

### DIFF
--- a/IPython/frontend/html/notebook/static/js/cell.js
+++ b/IPython/frontend/html/notebook/static/js/cell.js
@@ -30,6 +30,7 @@ var IPython = (function (IPython) {
         // this.cell_id = undefined create issues
         // with inheritence
         this.cell_id = utils.uuid();
+        this.parents_id = {};
     };
 
 
@@ -98,7 +99,8 @@ var IPython = (function (IPython) {
         var data = {};
         data.metadata = this.metadata;
         if (this.cell_id != undefined){
-            data.metadata.uuid = this.cell_id
+            data.metadata.uuid = this.cell_id;
+            data.metadata.parents_id = this.parents_id;
         }
         return data;
     };
@@ -107,9 +109,14 @@ var IPython = (function (IPython) {
     Cell.prototype.fromJSON = function (data) {
         if (data.metadata !== undefined) {
             this.metadata = data.metadata;
+        } else {
+            data.metadata = {};
         }
         if (data.metadata.uuid !== undefined) {
             this.cell_id = data.metadata.uuid;
+        }
+        if (data.metadata.parents_id !== undefined) {
+            this.parents_id = data.metadata.parents_id;
         }
     };
 

--- a/IPython/frontend/html/notebook/static/js/cell.js
+++ b/IPython/frontend/html/notebook/static/js/cell.js
@@ -25,7 +25,10 @@ var IPython = (function (IPython) {
             this.element.data("cell", this);
             this.bind_events();
         }
-        this.cell_id = utils.uuid();
+        if( this.cell_id == undefined)
+        {
+            this.cell_id = utils.uuid();
+        }
     };
 
 
@@ -93,6 +96,7 @@ var IPython = (function (IPython) {
     Cell.prototype.toJSON = function () {
         var data = {};
         data.metadata = this.metadata;
+        data.uuid = this.cell_id
         return data;
     };
 
@@ -100,6 +104,9 @@ var IPython = (function (IPython) {
     Cell.prototype.fromJSON = function (data) {
         if (data.metadata !== undefined) {
             this.metadata = data.metadata;
+        }
+        if (data.uuid !== undefined) {
+            this.cell_id = data.uuid;
         }
     };
 

--- a/IPython/frontend/html/notebook/static/js/cell.js
+++ b/IPython/frontend/html/notebook/static/js/cell.js
@@ -25,10 +25,11 @@ var IPython = (function (IPython) {
             this.element.data("cell", this);
             this.bind_events();
         }
-        if( this.cell_id == undefined)
-        {
-            this.cell_id = utils.uuid();
-        }
+        // alway create uuid, it will be overwritten
+        // when loading from JSON. Trying to check for
+        // this.cell_id = undefined create issues
+        // with inheritence
+        this.cell_id = utils.uuid();
     };
 
 
@@ -96,7 +97,9 @@ var IPython = (function (IPython) {
     Cell.prototype.toJSON = function () {
         var data = {};
         data.metadata = this.metadata;
-        data.uuid = this.cell_id
+        if (this.cell_id != undefined){
+            data.metadata.uuid = this.cell_id
+        }
         return data;
     };
 
@@ -105,8 +108,8 @@ var IPython = (function (IPython) {
         if (data.metadata !== undefined) {
             this.metadata = data.metadata;
         }
-        if (data.uuid !== undefined) {
-            this.cell_id = data.uuid;
+        if (data.metadata.uuid !== undefined) {
+            this.cell_id = data.metadata.uuid;
         }
     };
 

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -776,8 +776,8 @@ var IPython = (function (IPython) {
 
         // we don't want to have du plicate uuid, so for now, we are carefull
         // of deleting the uuid befor copying.
-        if( json.uuid != undefined){
-            delete  json.uuid
+        if( json.metadata.uuid != undefined){
+            delete  json.metadata.uuid
         }
         this.clipboard = json;
         this.enable_paste();
@@ -789,6 +789,10 @@ var IPython = (function (IPython) {
             var cell_data = this.clipboard;
             var new_cell = this.insert_cell_above(cell_data.cell_type);
             new_cell.fromJSON(cell_data);
+            // generate uuid at cell paste
+            // for a cell can be paste many time and we need unique ids.
+            new.cell.cell_id = utils.uuid();
+
             old_cell = this.get_next_cell(new_cell);
             this.delete_cell(this.find_cell_index(old_cell));
             this.select(this.find_cell_index(new_cell));

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -764,12 +764,22 @@ var IPython = (function (IPython) {
 
     Notebook.prototype.cut_cell = function () {
         this.copy_cell();
+        // note that we might want 
+        // to keep the uuid in this case
+        // if the cell is pasted after.
         this.delete_cell();
     }
 
     Notebook.prototype.copy_cell = function () {
         var cell = this.get_selected_cell();
-        this.clipboard = cell.toJSON();
+        var json = cell.toJSON();
+
+        // we don't want to have du plicate uuid, so for now, we are carefull
+        // of deleting the uuid befor copying.
+        if( json.uuid != undefined){
+            delete  json.uuid
+        }
+        this.clipboard = json;
         this.enable_paste();
     };
 

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -791,7 +791,7 @@ var IPython = (function (IPython) {
             new_cell.fromJSON(cell_data);
             // generate uuid at cell paste
             // for a cell can be paste many time and we need unique ids.
-            new.cell.cell_id = utils.uuid();
+            new_cell.cell_id = utils.uuid();
 
             old_cell = this.get_next_cell(new_cell);
             this.delete_cell(this.find_cell_index(old_cell));
@@ -1086,6 +1086,7 @@ var IPython = (function (IPython) {
 
     Notebook.prototype.fromJSON = function (data) {
         var ncells = this.ncells();
+        var uuid_dict = {};
         var i;
         for (i=0; i<ncells; i++) {
             // Always delete cell 0 as they get renumbered as they are deleted.
@@ -1114,8 +1115,19 @@ var IPython = (function (IPython) {
                 
                 new_cell = this.insert_cell_below(cell_data.cell_type);
                 new_cell.fromJSON(cell_data);
+                // dummy assigment using dict as set does not exist
+                uuid_dict[new_cell.cell_id]=0
+
             };
         };
+
+        if (ncells != uuid_dict.length){
+            console.log('warnng, it seems like you have 2 cells with the same uuid')
+            setTimeout(function(){
+                    IPython.notification_widget.set_message('Warning : Potentially duplicate cell UUID', 2000)
+                },3000);
+        }
+
         if (data.worksheets.length > 1) {
             var dialog = $('<div/>');
             dialog.html("This notebook has " + data.worksheets.length + " worksheets, " +
@@ -1144,9 +1156,17 @@ var IPython = (function (IPython) {
         var cells = this.get_cells();
         var ncells = cells.length;
         var cell_array = new Array(ncells);
+        var uuid_dict = {};
         for (var i=0; i<ncells; i++) {
-            cell_array[i] = cells[i].toJSON();
+            var json = cells[i].toJSON();
+            cell_array[i] = json
+            // dummy assigment using dict as set does not exist
+            uuid_dict[json.metadata.uuid]=0
         };
+        if (cell_array.length != uuid_dict.length){
+            console.log('warnng, it seems like you have 2 cells with the same uuid')
+            IPython.notification_widget.set_message('Potentially dupicate cell UUID', 5000);
+        }
         var data = {
             // Only handle 1 worksheet for now.
             worksheets : [{


### PR DESCRIPTION
## Description

As discussed as SciPy, Doing diff or merge of notebooks would be easier with persistent cell id. 
This introduce cell uuid persistence in metadata, and take care of making it persist through loads/save

This also take care of not duplicating cell id at cell copy/paste

I also have a soft warning in console and notification widget at save/load time about duplicated ID.

Also useful for future by cell syncing
## Question

Do we want cell_id in metadata or at higher level ?
Do we want something like a cell Hash that represent a given version of a cell ? (thinking of syncing also)
Any suggestion ?
## Misc

Do yo think of any other tools that would need special treatment ?
