### PR TITLE
Fix for bad command line argument to latex

### DIFF
--- a/IPython/lib/latextools.py
+++ b/IPython/lib/latextools.py
@@ -132,14 +132,15 @@ def latex_to_png_dvipng(s, wrap):
         with open(tmpfile, "w") as f:
             f.writelines(genelatex(s, wrap))
 
-        subprocess.check_call(
-            ["latex", "-halt-on-errror", tmpfile], cwd=workdir,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        with open(os.devnull, 'w') as devnull:
+            subprocess.check_call(
+                ["latex", "-halt-on-error", tmpfile], cwd=workdir,
+                stdout=devnull, stderr=devnull)
 
-        subprocess.check_call(
-            ["dvipng", "-T", "tight", "-x", "1500", "-z", "9",
-             "-bg", "transparent", "-o", outfile, dvifile], cwd=workdir,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            subprocess.check_call(
+                ["dvipng", "-T", "tight", "-x", "1500", "-z", "9",
+                 "-bg", "transparent", "-o", outfile, dvifile], cwd=workdir,
+                stdout=devnull, stderr=devnull)
 
         with open(outfile, "rb") as f:
             bin_data = f.read()


### PR DESCRIPTION
When running "iptest IPython.lib" on master dafe88e I get the errors below. I'm using Windows 7 python2.7.

The option to latex is bad it should be -halt-on-error not -halt-on-errror.
However when changing the option the test suite locks up on the third
"Test that latex_to_png_dvipng just runs without error." test.

I suspect it is related to the warning in the documentation of check_call

"Like Popen.wait(), this will deadlock when using stdout=PIPE and/or stderr=PIPE and the child process generates   enough output to a pipe such that it blocks waiting for the OS pipe buffer to accept more data."

Errors:

```
C:\python27\external> iptest IPython.lib
..............................EEEE..............
======================================================================
ERROR: Test that latex_to_png_dvipng just runs without error.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\python27\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "c:\python27\lib\site-packages\ipython-0.14.dev-py2.7.egg\IPython\lib\latextools.py", line 137, in latex_to_png_dvipng
    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File "c:\python27\lib\subprocess.py", line 504, in check_call
    raise CalledProcessError(retcode, cmd)
CalledProcessError: Command '['latex', '-halt-on-errror', 'c:\\users\\jorgenst\\appdata\\local\\temp\\tmp0u_vjx\\tmp.tex']' returned non-zero exit status 1

======================================================================
ERROR: Test that latex_to_png_dvipng just runs without error.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\python27\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "c:\python27\lib\site-packages\ipython-0.14.dev-py2.7.egg\IPython\lib\latextools.py", line 137, in latex_to_png_dvipng
    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File "c:\python27\lib\subprocess.py", line 504, in check_call
    raise CalledProcessError(retcode, cmd)
CalledProcessError: Command '['latex', '-halt-on-errror', 'c:\\users\\jorgenst\\appdata\\local\\temp\\tmpqf0hbq\\tmp.tex']' returned non-zero exit status 1

======================================================================
ERROR: Test that latex_to_png_dvipng just runs without error.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\python27\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "c:\python27\lib\site-packages\ipython-0.14.dev-py2.7.egg\IPython\lib\latextools.py", line 137, in latex_to_png_dvipng
    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File "c:\python27\lib\subprocess.py", line 504, in check_call
    raise CalledProcessError(retcode, cmd)
CalledProcessError: Command '['latex', '-halt-on-errror', 'c:\\users\\jorgenst\\appdata\\local\\temp\\tmpczi2ji\\tmp.tex']' returned non-zero exit status 1

======================================================================
ERROR: Test that latex_to_png_dvipng just runs without error.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\python27\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "c:\python27\lib\site-packages\ipython-0.14.dev-py2.7.egg\IPython\lib\latextools.py", line 137, in latex_to_png_dvipng
    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File "c:\python27\lib\subprocess.py", line 504, in check_call
    raise CalledProcessError(retcode, cmd)
CalledProcessError: Command '['latex', '-halt-on-errror', 'c:\\users\\jorgenst\\appdata\\local\\temp\\tmpvmepft\\tmp.tex']' returned non-zero exit status 1

----------------------------------------------------------------------
Ran 49 tests in 0.610s

FAILED (errors=4)
```
