### PR TITLE
Wrap JS published by %%javascript in try/catch

### DIFF
--- a/IPython/frontend/html/notebook/static/js/outputarea.js
+++ b/IPython/frontend/html/notebook/static/js/outputarea.js
@@ -360,7 +360,19 @@ var IPython = (function (IPython) {
         container.hide();
         // If the Javascript appends content to `element` that should be drawn, then
         // it must also call `container.show()`.
-        eval(js);
+        try {
+            eval(js);
+        } catch(err) {
+            console.log('Error in Javascript!');
+            console.log(err);
+            container.show();
+            element.append($('<div/>')
+                .html("Error in Javascript !<br/>"+
+                    err.toString()+
+                    '<br/>See your browser Javascript console for more details.')
+                .addClass('js-error')
+                );
+        }
     }
 
 


### PR DESCRIPTION
by default %%javascript will publish it's content in a try/catch and
display a warning in cell output if the expression raises.

This is should prevent some sneeky JS to prevent notebook to load.
and give more feedback to the user.

```
%%javascript
a.a=1
```

shows

```
ReferenceError: a is not defined
See your frontend Javascript console for more details.
```
