### PR TITLE
documentation build broken in bb429da5b

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -647,7 +647,7 @@ class Magics(object):
         self.options_table[fn] = optstr
 
 class MagicAlias(object):
-    """Store a magic alias.
+    """An alias to another magic function.
 
     An alias is determined by its magic name and magic kind. Lookup
     is done at call time, so if the underlying magic changes the alias
@@ -661,16 +661,10 @@ class MagicAlias(object):
         self.magic_name = magic_name
         self.magic_kind = magic_kind
 
+        self.pretty_target = '%s%s' % (magic_escapes[self.magic_kind], self.magic_name)
+        self.__doc__ = "Alias for `%s`." % self.pretty_target
+
         self._in_call = False
-
-    @property
-    def pretty_target(self):
-        """A formatted version of the target of the alias."""
-        return '%s%s' % (magic_escapes[self.magic_kind], self.magic_name)
-
-    @property
-    def __doc__(self):
-        return "Alias for `%s`." % self.pretty_target
 
     def __call__(self, *args, **kwargs):
         """Call the magic alias."""


### PR DESCRIPTION
commit bb429da5b (#2124) broke the documentation build
see https://launchpadlibrarian.net/111097427/buildlog_ubuntu-quantal-i386.ipython_0.13%2B2735-0~26~quantal1_FAILEDTOBUILD.txt.gz for a failure on ubuntu 12.10, same failure on 12.04 ans 11.10

```
  File "/usr/lib/python2.7/dist-packages/sphinx/util/docstrings.py", line 24, in prepare_docstring
    lines = s.expandtabs().splitlines()
AttributeError: 'property' object has no attribute 'expandtabs'
```
