### PR TITLE
History navigation in notebook

### DIFF
--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -36,6 +36,8 @@ var IPython = (function (IPython) {
         this.style();
         this.create_elements();
         this.bind_events();
+        this.history_position = 0;    // Needed for navigating in history
+        this.history_ref = 0;		// History navigation reference cell
     };
 
 
@@ -111,6 +113,34 @@ var IPython = (function (IPython) {
                     event.preventDefault();
                     that.select_next();
                 };
+            } else if (event.which === key.UPARROW && event.shiftKey) {
+                var index = that.get_selected_index();
+                if (index != that.history_ref) {
+    				// We need to check for the last known position, and fix it, if the user navigated to another cell
+					that.history_ref = index;
+					that.history_position = index;
+				}
+				// Jump over current cell
+				if (that.history_position == index+1) that.history_position = index;
+				that.history_position = Math.max(0, that.history_position - 1);
+                var cell = that.get_cell(that.history_position);
+                var current_cell = that.get_selected_cell();
+                current_cell.fromJSON(cell.toJSON());
+                return false;
+            } else if (event.which === key.DOWNARROW && event.shiftKey) {
+                var index = that.get_selected_index();
+                if (index != that.history_ref) {
+					// We need to check for the last known position, and fix it, if the user navigated to another cell
+					that.history_ref = index;
+					that.history_position = index;
+				}
+				// Jump over current cell
+				if (that.history_position == index-1) that.history_position = index;				
+				that.history_position = Math.min(that.ncells()-1, that.history_position + 1);
+                var cell = that.get_cell(that.history_position);
+                var current_cell = that.get_selected_cell();
+                current_cell.fromJSON(cell.toJSON());
+                return false;
             } else if (event.which === key.ENTER && event.shiftKey) {
                 that.execute_selected_cell();
                 return false;

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -116,13 +116,13 @@ var IPython = (function (IPython) {
             } else if (event.which === key.UPARROW && event.shiftKey) {
                 var index = that.get_selected_index();
                 if (index != that.history_ref) {
-    				// We need to check for the last known position, and fix it, if the user navigated to another cell
-					that.history_ref = index;
-					that.history_position = index;
-				}
-				// Jump over current cell
-				if (that.history_position == index+1) that.history_position = index;
-				that.history_position = Math.max(0, that.history_position - 1);
+    		// We need to check for the last known position, and fix it, if the user navigated to another cell
+			that.history_ref = index;
+			that.history_position = index;
+		}
+		// Jump over current cell
+		if (that.history_position == index+1) that.history_position = index;
+		that.history_position = Math.max(0, that.history_position - 1);
                 var cell = that.get_cell(that.history_position);
                 var current_cell = that.get_selected_cell();
                 current_cell.fromJSON(cell.toJSON());
@@ -130,13 +130,13 @@ var IPython = (function (IPython) {
             } else if (event.which === key.DOWNARROW && event.shiftKey) {
                 var index = that.get_selected_index();
                 if (index != that.history_ref) {
-					// We need to check for the last known position, and fix it, if the user navigated to another cell
-					that.history_ref = index;
-					that.history_position = index;
-				}
-				// Jump over current cell
-				if (that.history_position == index-1) that.history_position = index;				
-				that.history_position = Math.min(that.ncells()-1, that.history_position + 1);
+		// We need to check for the last known position, and fix it, if the user navigated to another cell
+			that.history_ref = index;
+			that.history_position = index;
+		}
+		// Jump over current cell
+		if (that.history_position == index-1) that.history_position = index;				
+		that.history_position = Math.min(that.ncells()-1, that.history_position + 1);
                 var cell = that.get_cell(that.history_position);
                 var current_cell = that.get_selected_cell();
                 current_cell.fromJSON(cell.toJSON());


### PR DESCRIPTION
Hi all,

As discussed somewhere on the mailing list (I can dig out the reference, if necessary), I implemented basic history navigation in the notebook. Shift+UpArrow or Shift+DownArrow copies the content of the previous, previous-previous, previous-previous-previous (you get the idea) cells into the current cell. 

I would like to emphasize that this works on notebook cells, and not on the kernel history. My reason for this would be that first, this would work without the kernel, so one could use it when, e.g., updating documentation in the notebook, but not having access to the kernel, and second, it would be visually rather confusing, if the we were paging through the kernel history, for the kernel commands are not necessarily executed in the order given in the notebook. 

Let me know, if there is interest in this feature, and what should be improved upon.
Cheers,
Zoltán
