### PR TITLE
No sys.stdout.encoding in kernel based IPython

### DIFF
--- a/IPython/zmq/iostream.py
+++ b/IPython/zmq/iostream.py
@@ -1,6 +1,6 @@
 import sys
 import time
-from io import StringIO
+from io import StringIO, IOBase
 
 from session import extract_header, Message
 
@@ -15,7 +15,7 @@ from IPython.utils import py3compat
 # Stream classes
 #-----------------------------------------------------------------------------
 
-class OutStream(object):
+class OutStream(IOBase):
     """A file like object that publishes the stream to a 0MQ PUB socket."""
 
     # The time interval between automatic flushes, in seconds.
@@ -58,6 +58,14 @@ class OutStream(object):
     @property
     def encoding(self):
         return encoding.DEFAULT_ENCODING
+
+    @property
+    def mode(self):
+        return 'w'
+
+    @property
+    def errors(self):
+        return None
 
     def __next__(self):
         raise IOError('Read not supported on a write only stream.')

--- a/IPython/zmq/iostream.py
+++ b/IPython/zmq/iostream.py
@@ -55,6 +55,10 @@ class OutStream(object):
     def isatty(self):
         return False
 
+    @property
+    def encoding(self):
+        return encoding.DEFAULT_ENCODING
+
     def __next__(self):
         raise IOError('Read not supported on a write only stream.')
 


### PR DESCRIPTION
### Kernel-based IPython

``` python
% ./ipython.py console                       
Python 2.7.2+ (default, Oct  4 2011, 20:06:09) 
Type "copyright", "credits" or "license" for more information.

IPython 0.14.dev -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.
[IPKernelApp] To connect another client to this kernel, use:
[IPKernelApp] --existing kernel-8616.json

In [1]: import sys

In [2]: sys.stdout.encoding
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-18fba92f6a6c> in <module>()
----> 1 sys.stdout.encoding

AttributeError: 'OutStream' object has no attribute 'encoding'
```
### Normal IPython

Same in pure Python console.

``` python
% ./ipython.py        
Python 2.7.2+ (default, Oct  4 2011, 20:06:09) 
Type "copyright", "credits" or "license" for more information.

IPython 0.14.dev -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: import sys

In [2]: sys.stdout.encoding
Out[2]: 'UTF-8'
```
