### PR TITLE
use KernelApp.exec_lines/files in IPEngineApp

### DIFF
--- a/IPython/parallel/apps/ipengineapp.py
+++ b/IPython/parallel/apps/ipengineapp.py
@@ -316,15 +316,22 @@ class IPEngineApp(BaseParallelApplication):
         
         
         try:
-            exec_lines = config.Kernel.exec_lines
+            exec_lines = config.IPKernelApp.exec_lines
         except AttributeError:
-            config.Kernel.exec_lines = []
-            exec_lines = config.Kernel.exec_lines
+            try:
+                exec_lines = config.InteractiveShellApp.exec_lines
+            except AttributeError:
+                exec_lines = config.IPKernelApp.exec_lines = []
+        try:
+            exec_files = config.IPKernelApp.exec_files
+        except AttributeError:
+            try:
+                exec_files = config.InteractiveShellApp.exec_files
+            except AttributeError:
+                exec_files = config.IPKernelApp.exec_files = []
         
         if self.startup_script:
-            enc = sys.getfilesystemencoding() or 'utf8'
-            cmd="execfile(%r)" % self.startup_script.encode(enc)
-            exec_lines.append(cmd)
+            exec_files.append(self.startup_script)
         if self.startup_command:
             exec_lines.append(self.startup_command)
 

--- a/IPython/parallel/engine/engine.py
+++ b/IPython/parallel/engine/engine.py
@@ -34,7 +34,7 @@ from IPython.parallel.factory import RegistrationFactory
 from IPython.parallel.util import disambiguate_url
 
 from IPython.zmq.session import Message
-from IPython.zmq.ipkernel import Kernel
+from IPython.zmq.ipkernel import Kernel, IPKernelApp
 
 class EngineFactory(RegistrationFactory):
     """IPython engine"""
@@ -198,10 +198,15 @@ class EngineFactory(RegistrationFactory):
             self.kernel = Kernel(config=self.config, int_id=self.id, ident=self.ident, session=self.session,
                     control_stream=control_stream, shell_streams=shell_streams, iopub_socket=iopub_socket,
                     loop=loop, user_ns=self.user_ns, log=self.log)
+            
             self.kernel.shell.display_pub.topic = cast_bytes('engine.%i.displaypub' % self.id)
+            
+            # FIXME: This is a hack until IPKernelApp and IPEngineApp can be fully merged
+            app = IPKernelApp(config=self.config, shell=self.kernel.shell, kernel=self.kernel, log=self.log)
+            app.init_profile_dir()
+            app.init_code()
+            
             self.kernel.start()
-
-
         else:
             self.log.fatal("Registration Failed: %s"%msg)
             raise Exception("Registration Failed: %s"%msg)


### PR DESCRIPTION
This change means that all your startup/exec_lines config is inherited by engines.

should be backported for 0.13.1, because engine startup code is impossible to configure in 0.13.

The real long-term fix for this is to make IPEngineApp a subclass of IPKernelApp, but this should be an adequate band-aid until then.

closes #2213
