### PR TITLE
New attempt to close 2053

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -421,8 +421,11 @@ class Javascript(DisplayObject):
 class Image(DisplayObject):
 
     _read_flags = 'rb'
+    _FMT_JPEG = u'jpeg'
+    _FMT_PNG = u'png'
+    _ACCEPTABLE_EMBEDDINGS = [_FMT_JPEG, _FMT_PNG]
 
-    def __init__(self, data=None, url=None, filename=None, format=u'png', embed=None):
+    def __init__(self, data=None, url=None, filename=None, format=u'png', embed=None, width=None, height=None):
         """Create a display an PNG/JPEG image given raw data.
 
         When this object is returned by an expression or passed to the
@@ -449,6 +452,10 @@ class Image(DisplayObject):
             default value is `False`.
 
             Note that QtConsole is not able to display images if `embed` is set to `False`
+        width : int
+            Width to which to constrain the image in html
+        height : int
+            Height to which to constrain the image in html
 
         Examples
         --------
@@ -464,17 +471,27 @@ class Image(DisplayObject):
             ext = self._find_ext(filename)
         elif url is not None:
             ext = self._find_ext(url)
+        elif data is None:
+            raise ValueError("No image data found. Expecting filename, url, or data.")
         elif data.startswith('http'):
             ext = self._find_ext(data)
         else:
             ext = None
+
         if ext is not None:
+            format = ext.lower()
             if ext == u'jpg' or ext == u'jpeg':
-                format = u'jpeg'
+                format = self._FMT_JPEG
             if ext == u'png':
-                format = u'png'
+                format = self._FMT_PNG
+
         self.format = unicode(format).lower()
         self.embed = embed if embed is not None else (url is None)
+
+        if self.embed and self.format not in self._ACCEPTABLE_EMBEDDINGS:
+            raise ValueError("Cannot embed the '%s' image format" % (self.format))
+        self.width = width
+        self.height = height
         super(Image, self).__init__(data=data, url=url, filename=filename)
 
     def reload(self):
@@ -484,7 +501,12 @@ class Image(DisplayObject):
 
     def _repr_html_(self):
         if not self.embed:
-            return u'<img src="%s" />' % self.url
+            width = height = ''
+            if self.width:
+                width = ' width="%d"' % self.width
+            if self.height:
+                height = ' height="%d"' % self.height
+            return u'<img src="%s"%s%s/>' % (self.url, width, height)
 
     def _repr_png_(self):
         if self.embed and self.format == u'png':

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -1,0 +1,38 @@
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2010-2011 The IPython Development Team.
+#
+#  Distributed under the terms of the BSD License.
+#
+#  The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+import os
+
+import nose.tools as nt
+
+from IPython.core import display
+from IPython.utils import path as ipath
+
+def test_image_size():
+    """Simple test for display.Image(args, width=x,height=y)"""
+    thisurl = 'http://www.google.fr/images/srpr/logo3w.png'
+    img = display.Image(url=thisurl, width=200, height=200)
+    nt.assert_equal(u'<img src="%s" width="200" height="200"/>' % (thisurl), img._repr_html_())
+    img = display.Image(url=thisurl, width=200)
+    nt.assert_equal(u'<img src="%s" width="200"/>' % (thisurl), img._repr_html_())
+    img = display.Image(url=thisurl)
+    nt.assert_equal(u'<img src="%s"/>' % (thisurl), img._repr_html_())
+
+def test_image_filename_defaults():
+    '''test format constraint, and validity of jpeg and png'''
+    tpath = ipath.get_ipython_package_dir()
+    nt.assert_raises(ValueError, display.Image, filename=os.path.join(tpath, 'testing/tests/badformat.gif'),
+                     embed=True)
+    nt.assert_raises(ValueError, display.Image)
+    nt.assert_raises(ValueError, display.Image, data='this is not an image', format='badformat', embed=True)
+    imgfile = os.path.join(tpath, 'frontend/html/notebook/static/ipynblogo.png')
+    img = display.Image(filename=imgfile)
+    nt.assert_equal('png', img.format)
+    nt.assert_is_not_none(img._repr_png_())
+    img = display.Image(filename=os.path.join(tpath, 'testing/tests/logo.jpg'), embed=False)
+    nt.assert_equal('jpeg', img.format)
+    nt.assert_is_none(img._repr_jpeg_())


### PR DESCRIPTION
Image now complains if it receives neither filename, url, nor data (param1)
Image honors width and height on html.
tests/test_display.pl exhibits this new behavior

This is a new take on the code I wrote with min and coaxed into a pull request with Mathieu's help.
I put myself into remote-hell with my previous attempt, trying to make the improvement
suggested by @bfroehle. To comment on that, I can find no html usage in ipython that behaves
as he suggests. Doing so for this single simple example seems like overkill.

I did clean up the code so that it is more elegant per bfroehle's suggestion

I will shortly close my other pull request on this if this meets your approval.

Closes issue #2053
