### PR TITLE
Custom tracebacks

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -186,6 +186,8 @@ def display_latex(*objs, **kwargs):
 
 def display_json(*objs, **kwargs):
     """Display the JSON representation of an object.
+    
+    Note that not many frontends support displaying JSON.
 
     Parameters
     ----------

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -33,6 +33,7 @@ import nose.tools as nt
 
 # Our own
 from IPython.testing.decorators import skipif
+from IPython.testing import tools as tt
 from IPython.utils import io
 
 #-----------------------------------------------------------------------------
@@ -400,6 +401,18 @@ class TestSystemRaw(unittest.TestCase):
         """
         cmd = ur'''python -c "'åäö'"   '''
         ip.system_raw(cmd)
+
+class TestModules(unittest.TestCase, tt.TempFileMixin):
+    def test_extraneous_loads(self):
+        """Test we're not loading modules on startup that we shouldn't.
+        """
+        self.mktmp("import sys\n"
+                   "print('numpy' in sys.modules)\n"
+                   "print('IPython.parallel' in sys.modules)\n"
+                   "print('IPython.zmq' in sys.modules)\n"
+                   )
+        out = "False\nFalse\nFalse\n"
+        tt.ipexec_validate(self.fname, out)
 
 
 def test__IPYTHON__():

--- a/IPython/parallel/error.py
+++ b/IPython/parallel/error.py
@@ -190,9 +190,12 @@ class RemoteError(KernelError):
     def __str__(self):
         return "%s(%s)" % (self.ename, self.evalue)
     
-    def render_traceback(self):
+    def _render_traceback_(self):
         """render traceback to a list of lines"""
         return (self.traceback or "No traceback available").splitlines()
+    
+    # Previous name retained for backwards compatibility.
+    render_traceback = _render_traceback_
 
     def print_traceback(self, excid=None):
         """print my traceback"""

--- a/IPython/parallel/error.py
+++ b/IPython/parallel/error.py
@@ -190,12 +190,12 @@ class RemoteError(KernelError):
     def __str__(self):
         return "%s(%s)" % (self.ename, self.evalue)
     
-    def _render_traceback_(self):
+    def render_traceback(self):
         """render traceback to a list of lines"""
         return (self.traceback or "No traceback available").splitlines()
     
-    # Previous name retained for backwards compatibility.
-    render_traceback = _render_traceback_
+    # Special method for custom tracebacks within IPython
+    _render_traceback_ = render_traceback
 
     def print_traceback(self, excid=None):
         """print my traceback"""

--- a/docs/source/config/index.txt
+++ b/docs/source/config/index.txt
@@ -10,5 +10,6 @@ Configuration and customization
    overview.txt
    extensions/index.txt
    ipython.txt
+   integrating.txt
    editors.txt
    old.txt

--- a/docs/source/config/integrating.txt
+++ b/docs/source/config/integrating.txt
@@ -20,7 +20,7 @@ these are surrounded by single, not double underscores.
 
 Both the notebook and the Qt console can display ``svg``, ``png`` and ``jpeg``
 representations. The notebook can also display ``html``, ``javascript``,
-``json`` and ``latex``. If the methods don't exist, or return ``None``, it falls
+and ``latex``. If the methods don't exist, or return ``None``, it falls
 back to a standard ``repr()``.
 
 For example::

--- a/docs/source/config/integrating.txt
+++ b/docs/source/config/integrating.txt
@@ -1,0 +1,44 @@
+.. _integrating:
+
+=====================================
+Integrating your objects with IPython
+=====================================
+
+Tab completion
+==============
+
+To change the attributes displayed by tab-completing your object, define a
+``__dir__(self)`` method for it. For more details, see the documentation of the
+built-in `dir() function <http://docs.python.org/library/functions.html#dir>`_.
+
+Rich display
+============
+
+The notebook and the Qt console can display richer representations of objects.
+To use this, you can define any of a number of ``_repr_*_()`` methods. Note that
+these are surrounded by single, not double underscores.
+
+Both the notebook and the Qt console can display ``svg``, ``png`` and ``jpeg``
+representations. The notebook can also display ``html``, ``javascript``,
+``json`` and ``latex``. If the methods don't exist, or return ``None``, it falls
+back to a standard ``repr()``.
+
+For example::
+
+    class Shout(object):
+        def __init__(self, text):
+            self.text = text
+        
+        def _repr_html_(self):
+            return "<h1>" + self.text + "</h1>"
+
+Custom exception tracebacks
+===========================
+
+Rarely, you might want to display a different traceback with an exception -
+IPython's own parallel computing framework does this to display errors from the
+engines. To do this, define a ``_render_traceback_(self)`` method which returns
+a list of strings, each containing one line of the traceback.
+
+Please be conservative in using this feature; by replacing the default traceback
+you may hide important information from the user.

--- a/docs/source/whatsnew/development.txt
+++ b/docs/source/whatsnew/development.txt
@@ -6,4 +6,8 @@ This document describes in-flight development work.
 
 The CodeMirror js library has been updated fron 2.23 to 2.32 
 this might induce a few changes in behavior of keymaps in the notebook, 
-especially intenting/deindenting blocks that is now bounded to Ctrl+] and ctr+[
+especially intenting/deindenting blocks that is now bound to Ctrl+] and ctr+[
+
+* Exception types can now be displayed with a custom traceback, by defining a
+  ``_render_traceback_()`` method which returns a list of strings, each
+  containing one line of the traceback.


### PR DESCRIPTION
Rather than special casing IPython.parallel errors (which led to issue #2221), this adds a simple API where exception classes can offer a custom traceback, by defining a `_render_traceback_(self)` method.

It also adds some documentation on how third parties can integrate packages with IPython. 'Configuration & customisation' seemed the most natural home for this.

We should remember to close #2221 when we merge this - I forgot to put it in a commit message.
