### PR TITLE
Add "--annotate" option to `%%cython` magic.

### DIFF
--- a/IPython/extensions/cythonmagic.py
+++ b/IPython/extensions/cythonmagic.py
@@ -193,7 +193,8 @@ class CythonMagics(Magics):
         self._import_all(module)
 
         if args.annotate:
-            with open(os.path.join(lib_dir, module_name + '.html')) as f:
+            html_file = os.path.join(lib_dir, module_name + '.html')
+            with io.open(html_file, encoding='utf-8') as f:
                 annotated_html = f.read()
             return display.HTML(annotated_html)
 

--- a/IPython/extensions/cythonmagic.py
+++ b/IPython/extensions/cythonmagic.py
@@ -15,6 +15,8 @@ Parts of this code were taken from Cython.inline.
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
+from __future__ import print_function
+
 import io
 import os, sys
 import imp
@@ -194,9 +196,19 @@ class CythonMagics(Magics):
 
         if args.annotate:
             html_file = os.path.join(lib_dir, module_name + '.html')
-            with io.open(html_file, encoding='utf-8') as f:
-                annotated_html = f.read()
-            return display.HTML(annotated_html)
+            try:
+                with io.open(html_file, encoding='utf-8') as f:
+                    annotated_html = f.read()
+            except IOError as e:
+                # File could not be opened. Most likely the user has a version
+                # of Cython before 0.15.1 (when `cythonize` learned the
+                # `force` keyword argument) and has already compiled this
+                # exact source without annotation.
+                print('Cython completed successfully but the annotated '
+                      'source could not be read.', file=sys.stderr)
+                print(e, file=sys.stderr)
+            else:
+                return display.HTML(annotated_html)
 
 _loaded = False
 

--- a/IPython/extensions/cythonmagic.py
+++ b/IPython/extensions/cythonmagic.py
@@ -61,7 +61,7 @@ class CythonMagics(Magics):
         and returns the result. If the variables `a` and `b` are defined
         in the user's namespace, here is a simple example that returns
         their sum::
-        
+
             %%cython_inline
             return a+b
 
@@ -78,14 +78,14 @@ class CythonMagics(Magics):
         The contents of the cell are written to a `.pyx` file in the current
         working directory, which is then imported using `pyximport`. This
         magic requires a module name to be passed::
-        
+
             %%cython_pyximport modulename
             def f(x):
                 return 2.0*x
 
-        The compiled module is then imported and all of its symbols are injected into
-        the user's namespace. For most purposes, we recommend the usage of the
-        `%%cython` magic.
+        The compiled module is then imported and all of its symbols are
+        injected into the user's namespace. For most purposes, we recommend
+        the usage of the `%%cython` magic.
         """
         module_name = line.strip()
         if not module_name:
@@ -108,35 +108,41 @@ class CythonMagics(Magics):
     @magic_arguments.magic_arguments()
     @magic_arguments.argument(
         '-c', '--compile-args', action='append', default=[],
-        help="Extra flags to pass to compiler via the `extra_compile_args` Extension flag (can be specified  multiple times)."
+        help="Extra flags to pass to compiler via the `extra_compile_args` "
+             "Extension flag (can be specified  multiple times)."
     )
     @magic_arguments.argument(
         '-la', '--link-args', action='append', default=[],
-        help="Extra flags to pass to linker via the `extra_link_args` Extension flag (can be specified  multiple times)."
+        help="Extra flags to pass to linker via the `extra_link_args` "
+             "Extension flag (can be specified  multiple times)."
     )
     @magic_arguments.argument(
         '-l', '--lib', action='append', default=[],
-        help="Add a library to link the extension against (can be specified  multiple times)."
+        help="Add a library to link the extension against (can be specified "
+             "multiple times)."
     )
     @magic_arguments.argument(
         '-I', '--include', action='append', default=[],
-        help="Add a path to the list of include directories (can be specified  multiple times)."
+        help="Add a path to the list of include directories (can be specified "
+             "multiple times)."
     )
     @magic_arguments.argument(
         '-f', '--force', action='store_true', default=False,
-        help="Force the compilation of the pyx module even if it hasn't changed"
+        help="Force the compilation of the pyx module even if it hasn't "
+             "changed"
     )
     @magic_arguments.argument(
         '-a', '--annotate', action='store_true', default=False,
-        help="Produce a colorized HTML version of the source. (Implies --force)."
+        help="Produce a colorized HTML version of the source. "
+             "(Implies --force)."
     )
     @cell_magic
     def cython(self, line, cell):
         """Compile and import everything from a Cython code cell.
 
         The contents of the cell are written to a `.pyx` file in the
-        directory `IPYTHONDIR/cython` using a filename with the hash of the code.
-        This file is then cythonized and compiled. The resulting module
+        directory `IPYTHONDIR/cython` using a filename with the hash of the
+        code. This file is then cythonized and compiled. The resulting module
         is imported and all of its symbols are injected into the user's
         namespace. The usage is similar to that of `%%cython_pyximport` but
         you don't have to pass a module name::
@@ -179,7 +185,7 @@ class CythonMagics(Magics):
             )
             dist = Distribution()
             config_files = dist.find_config_files()
-            try: 
+            try:
                 config_files.remove('setup.cfg')
             except ValueError:
                 pass

--- a/IPython/extensions/cythonmagic.py
+++ b/IPython/extensions/cythonmagic.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import imp
 import io
 import os
+import re
 import sys
 import time
 
@@ -232,7 +233,7 @@ class CythonMagics(Magics):
                       'source could not be read.', file=sys.stderr)
                 print(e, file=sys.stderr)
             else:
-                return display.HTML(annotated_html)
+                return display.HTML(self.clean_annotated_html(annotated_html))
 
     @property
     def so_ext(self):
@@ -254,6 +255,17 @@ class CythonMagics(Magics):
         build_extension = build_ext(dist)
         build_extension.finalize_options()
         return build_extension
+
+    @staticmethod
+    def clean_annotated_html(html):
+        """Clean up the annotated HTML source.
+
+        Strips the link to the generated C or C++ file, which we do not
+        present to the user.
+        """
+        r = re.compile('<p>Raw output: <a href="(.*)">(.*)</a>')
+        html = '\n'.join(l for l in html.splitlines() if not r.match(l))
+        return html
 
 _loaded = False
 

--- a/IPython/extensions/cythonmagic.py
+++ b/IPython/extensions/cythonmagic.py
@@ -128,6 +128,10 @@ class CythonMagics(Magics):
              "multiple times)."
     )
     @magic_arguments.argument(
+        '-+', '--cplus', action='store_true', default=False,
+        help="Output a C++ rather than C file."
+    )
+    @magic_arguments.argument(
         '-f', '--force', action='store_true', default=False,
         help="Force the compilation of the pyx module even if it hasn't "
              "changed"
@@ -182,11 +186,16 @@ class CythonMagics(Magics):
                 extra_compile_args = args.compile_args,
                 extra_link_args = args.link_args,
                 libraries = args.lib,
+                language = 'c++' if args.cplus else 'c',
             )
             build_extension = self._get_build_extension()
             try:
-                build_extension.extensions = cythonize([extension], quiet=quiet,
-                                                       annotate=args.annotate, force=args.force)
+                opts = dict(
+                    quiet=quiet,
+                    annotate = args.annotate,
+                    force = args.force,
+                    )
+                build_extension.extensions = cythonize([extension], **opts)
             except CompileError:
                 return
             build_extension.build_temp = os.path.dirname(pyx_file)

--- a/IPython/extensions/cythonmagic.py
+++ b/IPython/extensions/cythonmagic.py
@@ -137,7 +137,6 @@ class CythonMagics(Magics):
         args = magic_arguments.parse_argstring(self.cython, line)
         code = cell if cell.endswith('\n') else cell+'\n'
         lib_dir = os.path.join(self.shell.ipython_dir, 'cython')
-        force = args.force
         quiet = True
         key = code, sys.version_info, sys.executable, Cython.__version__
         module_name = "_cython_magic_" + hashlib.md5(str(key).encode('utf-8')).hexdigest()
@@ -147,7 +146,7 @@ class CythonMagics(Magics):
         if not os.path.exists(lib_dir):
             os.makedirs(lib_dir)
 
-        if force or not os.path.isfile(module_path):
+        if args.force or not os.path.isfile(module_path):
             c_include_dirs = args.include
             if 'numpy' in code:
                 import numpy

--- a/IPython/extensions/cythonmagic.py
+++ b/IPython/extensions/cythonmagic.py
@@ -34,7 +34,6 @@ from IPython.utils import py3compat
 
 import Cython
 from Cython.Compiler.Errors import CompileError
-from Cython.Compiler.Main import Context, default_options
 from Cython.Build.Dependencies import cythonize
 
 
@@ -138,10 +137,8 @@ class CythonMagics(Magics):
         args = magic_arguments.parse_argstring(self.cython, line)
         code = cell if cell.endswith('\n') else cell+'\n'
         lib_dir = os.path.join(self.shell.ipython_dir, 'cython')
-        cython_include_dirs = ['.']
         force = args.force
         quiet = True
-        ctx = Context(cython_include_dirs, default_options)
         key = code, sys.version_info, sys.executable, Cython.__version__
         module_name = "_cython_magic_" + hashlib.md5(str(key).encode('utf-8')).hexdigest()
         so_ext = [ ext for ext,_,mod_type in imp.get_suffixes() if mod_type == imp.C_EXTENSION ][0]
@@ -176,7 +173,7 @@ class CythonMagics(Magics):
             build_extension = build_ext(dist)
             build_extension.finalize_options()
             try:
-                build_extension.extensions = cythonize([extension], ctx=ctx, quiet=quiet)
+                build_extension.extensions = cythonize([extension], quiet=quiet)
             except CompileError:
                 return
             build_extension.build_temp = os.path.dirname(pyx_file)

--- a/IPython/extensions/cythonmagic.py
+++ b/IPython/extensions/cythonmagic.py
@@ -111,6 +111,10 @@ class CythonMagics(Magics):
         help="Extra flags to pass to compiler via the `extra_compile_args` Extension flag (can be specified  multiple times)."
     )
     @magic_arguments.argument(
+        '-la', '--link-args', action='append', default=[],
+        help="Extra flags to pass to linker via the `extra_link_args` Extension flag (can be specified  multiple times)."
+    )
+    @magic_arguments.argument(
         '-l', '--lib', action='append', default=[],
         help="Add a library to link the extension against (can be specified  multiple times)."
     )
@@ -170,6 +174,7 @@ class CythonMagics(Magics):
                 sources = [pyx_file],
                 include_dirs = c_include_dirs,
                 extra_compile_args = args.compile_args,
+                extra_link_args = args.link_args,
                 libraries = args.lib,
             )
             dist = Distribution()

--- a/IPython/extensions/cythonmagic.py
+++ b/IPython/extensions/cythonmagic.py
@@ -27,11 +27,9 @@ except ImportError:
 from distutils.core import Distribution, Extension
 from distutils.command.build_ext import build_ext
 
+from IPython.core import magic_arguments
 from IPython.core.magic import Magics, magics_class, cell_magic
 from IPython.testing.skipdoctest import skip_doctest
-from IPython.core.magic_arguments import (
-    argument, magic_arguments, parse_argstring
-)
 from IPython.utils import py3compat
 
 import Cython
@@ -105,20 +103,20 @@ class CythonMagics(Magics):
             self._reloads[module_name] = module
         self._import_all(module)
 
-    @magic_arguments()
-    @argument(
+    @magic_arguments.magic_arguments()
+    @magic_arguments.argument(
         '-c', '--compile-args', action='append', default=[],
         help="Extra flags to pass to compiler via the `extra_compile_args` Extension flag (can be specified  multiple times)."
     )
-    @argument(
+    @magic_arguments.argument(
         '-l', '--lib', action='append', default=[],
         help="Add a library to link the extension against (can be specified  multiple times)."
     )
-    @argument(
+    @magic_arguments.argument(
         '-I', '--include', action='append', default=[],
         help="Add a path to the list of include directories (can be specified  multiple times)."
     )
-    @argument(
+    @magic_arguments.argument(
         '-f', '--force', action='store_true', default=False,
         help="Force the compilation of the pyx module even if it hasn't changed"
     )
@@ -137,7 +135,7 @@ class CythonMagics(Magics):
         def f(x):
             return 2.0*x
         """
-        args = parse_argstring(self.cython, line)
+        args = magic_arguments.parse_argstring(self.cython, line)
         code = cell if cell.endswith('\n') else cell+'\n'
         lib_dir = os.path.join(self.shell.ipython_dir, 'cython')
         cython_include_dirs = ['.']


### PR DESCRIPTION
Closes #1976 and replaces pull-request #2147 (<del>Windows only</del>).

In addition, I've removed the `ctx` parameter from `cythonize` which is not actually parsed in Cython > 0.13.  The previous coded didn't work with Cython of that age either (as `Cython.Build` didn't exist as a module yet).

With Cython 0.14 and 0.15 there is a bug where the `force` flag to `cythonize` isn't getting picked up, so the annotated HTML isn't being generated if the user already ran `%%cython` for that same bit of code.  To trigger, run something like:

```
%%cython
<CODE>

%%cython -a
<CODE>
```

In my testing, everything seems to work correctly in 0.15.1 and later.
