### PR TITLE
fix message built for engine dying during task

### DIFF
--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -694,12 +694,9 @@ class Client(HasTraits):
             except:
                 content = error.wrap_exception()
             # build a fake message:
-            parent = {}
-            header = {}
-            parent['msg_id'] = msg_id
-            header['engine'] = uuid
-            header['date'] = datetime.now()
-            msg = dict(parent_header=parent, header=header, content=content)
+            msg = self.session.msg('apply_reply', content=content)
+            msg['parent_header']['msg_id'] = msg_id
+            msg['metadata']['engine'] = uuid
             self._handle_apply_reply(msg)
 
     def _handle_execute_reply(self, msg):

--- a/IPython/parallel/tests/test_lbview.py
+++ b/IPython/parallel/tests/test_lbview.py
@@ -21,6 +21,7 @@ import time
 
 import zmq
 from nose import SkipTest
+from nose.plugins.attrib import attr
 
 from IPython import parallel  as pmod
 from IPython.parallel import error
@@ -38,9 +39,9 @@ class TestLoadBalancedView(ClusterTestCase):
         ClusterTestCase.setUp(self)
         self.view = self.client.load_balanced_view()
 
+    @attr('crash')
     def test_z_crash_task(self):
         """test graceful handling of engine death (balanced)"""
-        raise SkipTest("crash tests disabled, due to undesirable crash reports")
         # self.add_engines(1)
         ar = self.view.apply_async(crash)
         self.assertRaisesRemote(error.EngineError, ar.get, 10)

--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -24,6 +24,7 @@ from StringIO import StringIO
 
 import zmq
 from nose import SkipTest
+from nose.plugins.attrib import attr
 
 from IPython.testing import decorators as dec
 from IPython.testing.ipunittest import ParametricTestCase
@@ -50,9 +51,9 @@ class TestView(ClusterTestCase, ParametricTestCase):
             time.sleep(2)
         super(TestView, self).setUp()
 
+    @attr('crash')
     def test_z_crash_mux(self):
         """test graceful handling of engine death (direct)"""
-        raise SkipTest("crash tests disabled, due to undesirable crash reports")
         # self.add_engines(1)
         eid = self.client.ids[-1]
         ar = self.client[eid].apply_async(crash)

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -476,6 +476,8 @@ def run_iptest():
                         # setuptools devs refuse to fix this problem!
                         '--exe',
                         ]
+    if '-a' not in argv and '-A' not in argv:
+        argv = argv + ['-a', '!crash']
 
     if nose.__version__ >= '0.11':
         # I don't fully understand why we need this one, but depending on what


### PR DESCRIPTION
The `test_z_<foo>_crash` tests actually test this, but they have long-since been skipped because people don't like the crash dialogs some OSes give.
