### PR TITLE
Fix regression in embed() from pull-request #2096.

### DIFF
--- a/IPython/frontend/terminal/embed.py
+++ b/IPython/frontend/terminal/embed.py
@@ -200,7 +200,8 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
             module.__dict__ = global_ns
 
         # Get locals and globals from caller
-        if (local_ns is None or module is None) and self.default_user_namespaces:
+        if ((local_ns is None or module is None or compile_flags is None)
+            and self.default_user_namespaces):
             call_frame = sys._getframe(stack_depth).f_back
 
             if local_ns is None:
@@ -233,7 +234,8 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
             self.init_user_ns()
 
         # Compiler flags
-        self.compile.flags = compile_flags
+        if compile_flags is not None:
+            self.compile.flags = compile_flags
 
         # Patch for global embedding to make sure that things don't overwrite
         # user globals accidentally. Thanks to Richard <rxe@renre-europe.com>


### PR DESCRIPTION
With certain sets of arguments `compile_flags` might be left as `None`. This  caused IPython to internally raise a TypeError when it tried to do a bitwise or between `shell.compile.flags` and `PyCF_ONLY_AST` in [`CachingCompiler.ast_parse`](https://github.com/ipython/ipython/blob/b70ac127e2c3698ea643b15af7d6bb5783ff3e7e/IPython/core/compilerop.py#L100).

The regression was introduced in:
 b70ac12 embed(): Default to the future compile flags of the calling frame.

Closes #2243.
