### PR TITLE
better flush iopub with AsyncResults

### DIFF
--- a/IPython/parallel/client/asyncresult.py
+++ b/IPython/parallel/client/asyncresult.py
@@ -166,7 +166,8 @@ class AsyncResult(object):
             else:
                 self._success = True
             finally:
-                if timeout is not None and timeout < 0:
+                if timeout is None or timeout < 0:
+                    # cutoff infinite wait at 10s
                     timeout = 10
                 self._wait_for_outputs(timeout)
 


### PR DESCRIPTION
requesting metadata (e.g. ar.data or ar.stdout) will result in flushing iopub if the outputs are incomplete, so separate wait(0) need not be called.

This also applies the workaround discussed in #2215

I'm not sure if it should close #2215, because the underlying cause there remains unknown.
