### PR TITLE
Fix: longest_substr([]) -> ''

### DIFF
--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -149,6 +149,9 @@ def test_long_substr2():
     data = ['abc', 'abd', 'abf', 'ab']
     nt.assert_equal(text.long_substr(data), 'ab')
 
+def test_long_substr_empty():
+    data = []
+    nt.assert_equal(text.long_substr(data), '')
 
 def test_strip_email():
     src = """\

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -553,7 +553,7 @@ def long_substr(data):
             for j in range(len(data[0])-i+1):
                 if j > len(substr) and all(data[0][i:i+j] in x for x in data):
                     substr = data[0][i:i+j]
-    else:
+    elif len(data) == 1:
         substr = data[0]
     return substr
 


### PR DESCRIPTION
Previously the algorithm used to find the longest common starting substring 
unintentionally raised an error when it was called on an empty list.

This should fix the issue of an error being raised when running %paste
on an empty clipboard (#2252).
