### PR TITLE
Allow docs to build on http://readthedocs.org/

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,6 +17,33 @@
 
 import sys, os
 
+ON_RTD = os.environ.get('READTHEDOCS', None) == 'True'
+
+if ON_RTD:
+    # Mock the presence of matplotlib, which we don't have on RTD
+    # see
+    # http://read-the-docs.readthedocs.org/en/latest/faq.html
+
+    class Mock(object):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __call__(self, *args, **kwargs):
+            return Mock()
+
+        @classmethod
+        def __getattr__(self, name):
+            if name in ('__file__', '__path__'):
+                return '/dev/null'
+            elif name[0] == name[0].upper():
+                return type(name, (), {})
+            else:
+                return Mock()
+
+    MOCK_MODULES = ['matplotlib', 'matplotlib.sphinxext', 'numpy']
+    for mod_name in MOCK_MODULES:
+        sys.modules[mod_name] = Mock()
+
 # If your extensions are in another directory, add it here. If the directory
 # is relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
@@ -47,6 +74,11 @@ extensions = [
     'numpydoc',  # to preprocess docstrings
     'github',  # for easy GitHub links
 ]
+
+if ON_RTD:
+    # Remove extensions not currently supported on RTD
+    extensions.remove('matplotlib.sphinxext.only_directives')
+    extensions.remove('ipython_directive')
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ if ON_RTD:
     # Mock the presence of matplotlib, which we don't have on RTD
     # see
     # http://read-the-docs.readthedocs.org/en/latest/faq.html
-
+    tags.add('rtd')
     class Mock(object):
         def __init__(self, *args, **kwargs):
             pass

--- a/docs/source/development/ipython_directive.txt
+++ b/docs/source/development/ipython_directive.txt
@@ -1,7 +1,7 @@
 .. _ipython_directive:
 
 ========================
-Ipython Sphinx Directive
+IPython Sphinx Directive
 ========================
 
 The ipython directive is a stateful ipython shell for embedding in

--- a/docs/source/index.txt
+++ b/docs/source/index.txt
@@ -7,7 +7,13 @@ IPython Documentation
    :Release: |release|
    :Date: |today|
 
-Welcome to the official IPython documentation.
+.. only:: not rtd
+
+    Welcome to the official IPython documentation.
+
+.. only:: rtd
+
+    This is a partial copy of IPython documentation, please visit `IPython official documentation <http://ipython.org/documentation.html>`_.
 
 Contents
 ========


### PR DESCRIPTION
Read The Doc try to build our docs for quite some time now... but fails

http://readthedocs.org/projects/ipython/

this should allow it to build :
cf http://readthedocs.org/projects/ipython-clone/

we sould just find a way to change `Welcome to the official IPython documentation.`
to something like 
`This is a partial copy of  IPython documentation, please visit...` in the introduction when building through RTD.

Also, once this is merged, there is a hook in github pref pannel to activate to trigger rebuild on RTD when merging PRs.
