### PR TITLE
add missing location when disambiguating controller IP

### DIFF
--- a/IPython/parallel/apps/ipengineapp.py
+++ b/IPython/parallel/apps/ipengineapp.py
@@ -226,7 +226,7 @@ class IPEngineApp(BaseParallelApplication):
         location = config.EngineFactory.location
         
         proto, ip = d['interface'].split('://')
-        ip = disambiguate_ip_address(ip)
+        ip = disambiguate_ip_address(ip, location)
         d['interface'] = '%s://%s' % (proto, ip)
         
         # DO NOT allow override of basic URLs, serialization, or exec_key


### PR DESCRIPTION
prevented ip=\* from resolving correctly engine-side (would always give loopback)

This bug was introduced in the connection cleanup after 0.13, so does not need backporting.
