### PR TITLE
nb: up/down arrow keys move to begin/end of line at top/bottom of cell

### DIFF
--- a/IPython/frontend/html/notebook/static/codemirror/README-IPython.rst
+++ b/IPython/frontend/html/notebook/static/codemirror/README-IPython.rst
@@ -7,6 +7,10 @@ is (*please update this information when updating versions*)::
 
     CodeMirror2 4e244d252a26a2dba5446d44eb46adfb3c7f356a , tag : v2.32
 
+The following CodeMirror commits have been cherry-picked into the source:
+
+  * 4ec8a34 Pressing Up while on the first line should move cursor to (0,0)
+
 The current politics is not to ships the following folders of CodeMirrors :
 
   * doc/

--- a/IPython/frontend/html/notebook/static/codemirror/lib/codemirror.js
+++ b/IPython/frontend/html/notebook/static/codemirror/lib/codemirror.js
@@ -1738,7 +1738,7 @@ var CodeMirror = (function() {
     }
     // Coords must be lineSpace-local
     function coordsChar(x, y) {
-      if (y < 0) y = 0;
+      if (y < 0) return {line: 0, ch: 0};
       var th = textHeight(), cw = charWidth(), heightPos = displayOffset + Math.floor(y / th);
       var lineNo = lineAtHeight(doc, heightPos);
       if (lineNo >= doc.size) return {line: doc.size - 1, ch: getLine(doc.size - 1).text.length};

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -234,7 +234,7 @@ var IPython = (function (IPython) {
 
     CodeCell.prototype.at_top = function () {
         var cursor = this.code_mirror.getCursor();
-        if (cursor.line === 0) {
+        if (cursor.line === 0 && cursor.ch === 0) {
             return true;
         } else {
             return false;
@@ -244,7 +244,7 @@ var IPython = (function (IPython) {
 
     CodeCell.prototype.at_bottom = function () {
         var cursor = this.code_mirror.getCursor();
-        if (cursor.line === (this.code_mirror.lineCount()-1)) {
+        if (cursor.line === (this.code_mirror.lineCount()-1) && cursor.ch === this.code_mirror.getLine(cursor.line).length) {
             return true;
         } else {
             return false;

--- a/IPython/frontend/html/notebook/static/js/textcell.js
+++ b/IPython/frontend/html/notebook/static/js/textcell.js
@@ -12,6 +12,7 @@
 var IPython = (function (IPython) {
 
     // TextCell base class
+    var key = IPython.utils.keycodes;
 
     var TextCell = function () {
         this.code_mirror_mode = this.code_mirror_mode || 'htmlmixed';
@@ -269,6 +270,36 @@ var IPython = (function (IPython) {
     };
 
 
+    RawCell.prototype.handle_codemirror_keyevent = function (editor, event) {
+        // This method gets called in CodeMirror's onKeyDown/onKeyPress
+        // handlers and is used to provide custom key handling. Its return
+        // value is used to determine if CodeMirror should ignore the event:
+        // true = ignore, false = don't ignore.
+
+        var that = this;
+        if (event.which === key.UPARROW && event.type === 'keydown') {
+            // If we are not at the top, let CM handle the up arrow and
+            // prevent the global keydown handler from handling it.
+            if (!that.at_top()) {
+                event.stop();
+                return false;
+            } else {
+                return true;
+            };
+        } else if (event.which === key.DOWNARROW && event.type === 'keydown') {
+            // If we are not at the bottom, let CM handle the down arrow and
+            // prevent the global keydown handler from handling it.
+            if (!that.at_bottom()) {
+                event.stop();
+                return false;
+            } else {
+                return true;
+            };
+        };
+        return false;
+    };
+
+
     RawCell.prototype.select = function () {
         IPython.Cell.prototype.select.apply(this);
         this.code_mirror.refresh();
@@ -278,7 +309,7 @@ var IPython = (function (IPython) {
 
     RawCell.prototype.at_top = function () {
         var cursor = this.code_mirror.getCursor();
-        if (cursor.line === 0) {
+        if (cursor.line === 0 && cursor.ch === 0) {
             return true;
         } else {
             return false;
@@ -288,7 +319,7 @@ var IPython = (function (IPython) {
 
     RawCell.prototype.at_bottom = function () {
         var cursor = this.code_mirror.getCursor();
-        if (cursor.line === (this.code_mirror.lineCount()-1)) {
+        if (cursor.line === (this.code_mirror.lineCount()-1) && cursor.ch === this.code_mirror.getLine(cursor.line).length) {
             return true;
         } else {
             return false;


### PR DESCRIPTION
In the notebook while editing a code cell, if the cursor is on the top line of the cell, the up arrow key should move the cursor to the beginning of the line if it is not there already.  If we are already at the beginning of the line it should move to the previous cell.

A similar logic should hold for the bottom line of a cell and the down arrow key.

Closes #2275.
