### PR TITLE
allow disabling SQLite history

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -56,7 +56,7 @@ class DummyDB(object):
 @decorator
 def needs_sqlite(f, self, *a, **kw):
     """return an empty list in the absence of sqlite"""
-    if sqlite is None or self.disabled:
+    if sqlite3 is None or self.disabled:
         return []
     else:
         return f(self, *a, **kw)


### PR DESCRIPTION
- adds HistoryAccessor.disabled configurable for turning off the SQLite history
- also provides connection_options configurable dict for relaying kwargs to sqlite3.connect.  This is a just-in-case measure, but I think valuable if people have a reason to adjust the SQLite connection flags.

Mainly for use in situations where threading or filesystem issues can cause problems for sqlite, e.g. embedding in django.

closes #2276
