### PR TITLE
fix SSH passwordless check for OpenSSH

### DIFF
--- a/IPython/external/ssh/tunnel.py
+++ b/IPython/external/ssh/tunnel.py
@@ -97,7 +97,7 @@ def _try_passwordless_openssh(server, keyfile):
     p = pexpect.spawn(cmd)
     while True:
         try:
-            p.expect('[Ppassword]:', timeout=.1)
+            p.expect('[Pp]assword:', timeout=.1)
         except pexpect.TIMEOUT:
             continue
         except pexpect.EOF:


### PR DESCRIPTION
pexpect takes a regular expression, so we want '[Pp]assword:', not
'[Ppassword]:'.
