### PR TITLE
Remove code from prefilter that duplicates functionality in inputsplitter

### DIFF
--- a/IPython/core/tests/test_handlers.py
+++ b/IPython/core/tests/test_handlers.py
@@ -75,49 +75,8 @@ def test_handlers():
     # line.
     run([(i,py3compat.u_format(o)) for i,o in \
         [('"no change"', '"no change"'),             # normal
-         (u"!true",       "get_ipython().system({u}'true')"),      # shell_escapes
-         (u"!! true",     "get_ipython().magic({u}'sx  true')"),   # shell_escapes + magic
-         (u"!!true",      "get_ipython().magic({u}'sx true')"),    # shell_escapes + magic
-         (u"%lsmagic",    "get_ipython().magic({u}'lsmagic ')"),   # magic
          (u"lsmagic",     "get_ipython().magic({u}'lsmagic ')"),   # magic
          #("a = b # PYTHON-MODE", '_i'),          # emacs -- avoids _in cache
-
-         # post-esc-char whitespace goes inside
-         (u"! true",   "get_ipython().system({u}' true')"),
-
-         # handle_help
-
-         # These are weak tests -- just looking at what the help handlers
-         # logs, which is not how it really does its work.  But it still
-         # lets us check the key paths through the handler.
-
-         ("x=1 # what?", "x=1 # what?"), # no help if valid python
-         ]])
-
-    # multi_line_specials
-    ip.prefilter_manager.multi_line_specials = False
-    # W/ multi_line_specials off, leading ws kills esc chars/autoexpansion
-    run([
-        (u'if 1:\n    !true',    u'if 1:\n    !true'),
-        (u'if 1:\n    lsmagic',  u'if 1:\n    lsmagic'),
-        (u'if 1:\n    an_alias', u'if 1:\n    an_alias'),
-        ])
-
-    ip.prefilter_manager.multi_line_specials = True
-    # initial indents must be preserved.
-    run([(i,py3compat.u_format(o)) for i,o in \
-        [(u'if 1:\n    !true',    "if 1:\n    get_ipython().system({u}'true')"),
-         (u'if 2:\n    lsmagic',  "if 2:\n    get_ipython().magic({u}'lsmagic ')"),
-         (u'if 1:\n    an_alias', "if 1:\n    get_ipython().system({u}'true ')"),
-         # Weird one
-         (u'if 1:\n    !!true',   "if 1:\n    get_ipython().magic({u}'sx true')"),
-
-         # Even with m_l_s on, autocall is off even with special chars
-         ('if 1:\n    /fun 1 2', 'if 1:\n    /fun 1 2'),
-         ('if 1:\n    ;fun 1 2', 'if 1:\n    ;fun 1 2'),
-         ('if 1:\n    ,fun 1 2', 'if 1:\n    ,fun 1 2'),
-         ('if 1:\n    ?fun 1 2', 'if 1:\n    ?fun 1 2'),
-         # What about !!
          ]])
 
     # Objects which are instances of IPyAutocall are *always* autocalled
@@ -133,15 +92,9 @@ def test_handlers():
         ('autocallable',    'autocallable()'),
         # Don't add extra brackets (gh-1117)
         ('autocallable()',    'autocallable()'),
-        (",list 1 2 3",     'list("1", "2", "3")'),
-        (";list 1 2 3",     'list("1 2 3")'),
-        ("/len range(1,4)", 'len(range(1,4))'),
         ])
     ip.magic('autocall 1')
     run([
-        (",list 1 2 3", 'list("1", "2", "3")'),
-        (";list 1 2 3", 'list("1 2 3")'),
-        ("/len range(1,4)", 'len(range(1,4))'),
         ('len "abc"', 'len("abc")'),
         ('len "abc";', 'len("abc");'),  # ; is special -- moves out of parens
         # Autocall is turned off if first arg is [] and the object
@@ -153,9 +106,6 @@ def test_handlers():
         ])
     ip.magic('autocall 2')
     run([
-        (",list 1 2 3", 'list("1", "2", "3")'),
-        (";list 1 2 3", 'list("1 2 3")'),
-        ("/len range(1,4)", 'len(range(1,4))'),
         ('len "abc"', 'len("abc")'),
         ('len "abc";', 'len("abc");'),
         ('len [1,2]', 'len([1,2])'),

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -283,22 +283,18 @@ def test_tb_syntaxerror():
     nt.assert_equal(last_line, "SyntaxError: invalid syntax")
 
 
-@py3compat.doctest_refactor_print
-def doctest_time():
-    """
-    In [10]: %time None
-    CPU times: user 0.00 s, sys: 0.00 s, total: 0.00 s
-    Wall time: 0.00 s
+def test_time():
+    ip = get_ipython()
     
-    In [11]: def f(kmjy):
-       ....:    %time print 2*kmjy
-       
-    In [12]: f(3)
-    6
-    CPU times: user 0.00 s, sys: 0.00 s, total: 0.00 s
-    Wall time: 0.00 s
-    """
-
+    with tt.AssertPrints("CPU times: user 0.00 s, sys: 0.00 s, total: 0.00 s"):
+        ip.run_cell("%time None")
+    
+    ip.run_cell("def f(kmjy):\n"
+                "    %time print (2*kmjy)")
+    
+    with tt.AssertPrints("CPU times: user 0.00 s, sys: 0.00 s, total: 0.00 s"):
+        with tt.AssertPrints("hihi", suppress=False):
+            ip.run_cell("f('hi')")
 
 def test_doctest_mode():
     "Toggle doctest_mode twice, it should be a no-op and run without error"

--- a/IPython/core/tests/test_prefilter.py
+++ b/IPython/core/tests/test_prefilter.py
@@ -20,17 +20,6 @@ def test_prefilter():
 
     # pairs of (raw, expected correct) input
     pairs = [ ('2+2','2+2'),
-              ('>>> 2+2','2+2'),
-              ('>>> # This is a comment\n'
-               '... 2+2',
-               '# This is a comment\n'
-               '2+2'),
-              # Some IPython input
-              ('In [1]: 1', '1'),
-              ('In [2]: for i in range(5):\n'
-               '   ...:     print i,',
-               'for i in range(5):\n'
-               '    print i,'),
              ]
 
     for raw, correct in pairs:

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -47,6 +47,12 @@ import nose.core
 from nose.plugins import doctests, Plugin
 from nose.util import anyp, getpackage, test_address, resolve_name, tolist
 
+# Our own imports
+
+# We're temporarily using TerminalMagics.cleanup_input() until the functionality
+# is moved into core.
+from IPython.frontend.terminal.interactiveshell import TerminalMagics
+
 #-----------------------------------------------------------------------------
 # Module globals and other constants
 #-----------------------------------------------------------------------------
@@ -380,17 +386,7 @@ class IPDocTestParser(doctest.DocTestParser):
 
     def ip2py(self,source):
         """Convert input IPython source into valid Python."""
-        out = []
-        newline = out.append
-        #print 'IPSRC:\n',source,'\n###'  # dbg
-        # The input source must be first stripped of all bracketing whitespace
-        # and turned into lines, so it looks to the parser like regular user
-        # input
-        for lnum,line in enumerate(source.strip().splitlines()):
-            newline(_ip.prefilter(line,lnum>0))
-        newline('')  # ensure a closing newline, needed by doctest
-        #print "PYSRC:", '\n'.join(out)  # dbg
-        return '\n'.join(out)
+        return TerminalMagics(_ip).cleanup_input(source)
 
     def parse(self, string, name='<string>'):
         """

--- a/docs/source/whatsnew/development.txt
+++ b/docs/source/whatsnew/development.txt
@@ -11,3 +11,13 @@ especially intenting/deindenting blocks that is now bound to Ctrl+] and ctr+[
 * Exception types can now be displayed with a custom traceback, by defining a
   ``_render_traceback_()`` method which returns a list of strings, each
   containing one line of the traceback.
+
+Backwards incompatible changes
+------------------------------
+
+* Calling :meth:`InteractiveShell.prefilter` will no longer perform static
+  transformations - the processing of escaped commands such as ``%magic`` and
+  ``!system``, and stripping input prompts from code blocks. This functionality
+  was duplicated in :mod:`IPython.core.inputsplitter`, and the latter version
+  was already what IPython relied on. A new API to transform input will be ready
+  before release.


### PR DESCRIPTION
This is the first step towards implementing IPEP 2 (#2293). I have removed all the static transformations from prefilter, because we're relying on the equivalent functionality in inputsplitter.

It turns out that the one part of the code still relying on prefilter for those transformations was the ipython-doctest machinery. For now, I've pointed that to a helper function from the magics for the terminal frontend, but I'll move that function into core later.

My intention is that this is merged before other work on IPEP 2, but if people prefer, I can just do the other bits in this branch and then merge in one go.
