### PR TITLE
Fix variable expansion on 'self'

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2841,9 +2841,11 @@ class InteractiveShell(SingletonConfigurable):
         """
         ns = self.user_ns.copy()
         ns.update(sys._getframe(depth+1).f_locals)
-        ns.pop('self', None)
         try:
-            cmd = formatter.format(cmd, **ns)
+            # We have to use .vformat() here, because 'self' is a valid and common
+            # name, and expanding **ns for .format() would make it collide with
+            # the 'self' argument of the method.
+            cmd = formatter.vformat(cmd, args=[], kwargs=ns)
         except Exception:
             # if formatter couldn't format, just let it go untransformed
             pass

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -258,6 +258,18 @@ class InteractiveShellTestCase(unittest.TestCase):
         ip.run_cell('makemacro()')
         nt.assert_in('macro_var_expand_locals', ip.user_ns)
     
+    def test_var_expand_self(self):
+        """Test variable expansion with the name 'self', which was failing.
+        
+        See https://github.com/ipython/ipython/issues/1878#issuecomment-7698218
+        """
+        ip.run_cell('class cTest:\n'
+                    '  classvar="see me"\n'
+                    '  def test(self):\n'
+                    '    res = !echo Variable: {self.classvar}\n'
+                    '    return res\n')
+        nt.assert_in('see me', ip.user_ns['cTest']().test())
+    
     def test_bad_var_expand(self):
         """var_expand on invalid formats shouldn't raise"""
         # SyntaxError

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -267,7 +267,7 @@ class InteractiveShellTestCase(unittest.TestCase):
                     '  classvar="see me"\n'
                     '  def test(self):\n'
                     '    res = !echo Variable: {self.classvar}\n'
-                    '    return res\n')
+                    '    return res[0]\n')
         nt.assert_in('see me', ip.user_ns['cTest']().test())
     
     def test_bad_var_expand(self):


### PR DESCRIPTION
Following discussion on #1878, I found that the variable expansion for magic and system commands dropped 'self' for technical reasons (calling with `**kwargs`, self causes a collision with the method's 'self' variable).

It's fairly important that we can expand `self`, because it's a very common variable. Happily there was an easy workaround - formatters have a `vformat` method, which accepts a dictionary rather than kwargs.

There's also a test, naturally.
