### PR TITLE
RemoteError._render_traceback_ calls self.render_traceback

### DIFF
--- a/IPython/parallel/error.py
+++ b/IPython/parallel/error.py
@@ -195,8 +195,9 @@ class RemoteError(KernelError):
         return (self.traceback or "No traceback available").splitlines()
     
     # Special method for custom tracebacks within IPython
-    _render_traceback_ = render_traceback
-
+    def _render_traceback_(self):
+        return self.render_traceback()
+    
     def print_traceback(self, excid=None):
         """print my traceback"""
         print('\n'.join(self.render_traceback()))

--- a/IPython/parallel/error.py
+++ b/IPython/parallel/error.py
@@ -194,8 +194,13 @@ class RemoteError(KernelError):
         """render traceback to a list of lines"""
         return (self.traceback or "No traceback available").splitlines()
     
-    # Special method for custom tracebacks within IPython
     def _render_traceback_(self):
+        """Special method for custom tracebacks within IPython.
+        
+        This will be called by IPython instead of displaying the local traceback.
+        
+        It should return a traceback rendered as a list of lines.
+        """
         return self.render_traceback()
     
     def print_traceback(self, excid=None):


### PR DESCRIPTION
rather than an alias

There are two options here:
1. `_render_traceback_`  should _call_ render_traceback
2. any subclass that redefines render_traceback must also redefine `_render_traceback_`

I went with 1., which is more efficient code-wise when subclassing RemoteError
(would prevent future cases of this same mistake),
but less efficient execution-wise, because it involves an extra function call.

closes #2303
