### PR TITLE
always perform requested trait assignments

### DIFF
--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -25,10 +25,11 @@ import re
 import sys
 from unittest import TestCase
 
+import nose.tools as nt
 from nose import SkipTest
 
 from IPython.utils.traitlets import (
-    HasTraits, MetaHasTraits, TraitType, Any, CBytes,
+    HasTraits, MetaHasTraits, TraitType, Any, CBytes, Dict,
     Int, Long, Integer, Float, Complex, Bytes, Unicode, TraitError,
     Undefined, Type, This, Instance, TCPAddress, List, Tuple,
     ObjectName, DottedObjectName, CRegExp
@@ -906,3 +907,14 @@ class TestCRegExp(TraitTestBase):
     _default_value = re.compile(r'')
     _good_values = [r'\d+', re.compile(r'\d+')]
     _bad_values = [r'(', None, ()]
+
+class DictTrait(HasTraits):
+    value = Dict()
+
+def test_dict_assignment():
+    d = dict()
+    c = DictTrait()
+    c.value = d
+    d['a'] = 5
+    nt.assert_equal(d, c.value)
+    nt.assert_true(c.value is d)

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -302,8 +302,8 @@ class TraitType(object):
     def __set__(self, obj, value):
         new_value = self._validate(obj, value)
         old_value = self.__get__(obj)
+        obj._trait_values[self.name] = new_value
         if old_value != new_value:
-            obj._trait_values[self.name] = new_value
             obj._notify_trait(self.name, old_value, new_value)
 
     def _validate(self, obj, value):


### PR DESCRIPTION
Some assignments do not change _value_, but do change the object,
and these should not be ignored.

For instance, container objects are currently impossible to assign
if they evaluate as equal, even if their types don't match
(e.g. assigning an empty defaultdict to a Dict trait)
