### PR TITLE
Add bracket matching to code cells in notebook

### DIFF
--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -42,7 +42,8 @@ var IPython = (function (IPython) {
             theme: 'ipython',
             readOnly: this.read_only,
             extraKeys: {"Tab": "indentMore","Shift-Tab" : "indentLess",'Backspace':"delSpaceToPrevTabStop"},
-            onKeyEvent: $.proxy(this.handle_codemirror_keyevent,this)
+            onKeyEvent: $.proxy(this.handle_codemirror_keyevent,this),
+            matchBrackets: true
         });
         input.append(input_area);
         var output = $('<div></div>');


### PR DESCRIPTION
This brings the notebook in line with the behavior of the qt console.
