### PR TITLE
Better error messages for common magic commands.

### DIFF
--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -21,7 +21,7 @@ import sys
 from urllib2 import urlopen
 
 # Our own packages
-from IPython.core.error import TryNext, StdinNotImplementedError
+from IPython.core.error import TryNext, StdinNotImplementedError, UsageError
 from IPython.core.macro import Macro
 from IPython.core.magic import Magics, magics_class, line_magic
 from IPython.core.oinspect import find_file, find_source_lines
@@ -73,6 +73,8 @@ class CodeMagics(Magics):
         """
 
         opts,args = self.parse_options(parameter_s,'fra',mode='list')
+        if not args:
+            raise UsageError('Missing filename.')
         raw = 'r' in opts
         force = 'f' in opts
         append = 'a' in opts
@@ -178,6 +180,9 @@ class CodeMagics(Magics):
         %load http://www.example.com/myscript.py
         """
         opts,args = self.parse_options(arg_s,'y')
+        if not args:
+            raise UsageError('Missing filename, URL, input history range, '
+                             'or macro.')
 
         contents = self.shell.find_user_code(args)
         l = len(contents)

--- a/IPython/core/magics/extension.py
+++ b/IPython/core/magics/extension.py
@@ -16,6 +16,7 @@
 import os
 
 # Our own packages
+from IPython.core.error import UsageError
 from IPython.core.magic import Magics, magics_class, line_magic
 
 #-----------------------------------------------------------------------------
@@ -56,14 +57,20 @@ class ExtensionMagics(Magics):
     @line_magic
     def load_ext(self, module_str):
         """Load an IPython extension by its module name."""
+        if not module_str:
+            raise UsageError('Missing module name.')
         return self.shell.extension_manager.load_extension(module_str)
 
     @line_magic
     def unload_ext(self, module_str):
         """Unload an IPython extension by its module name."""
+        if not module_str:
+            raise UsageError('Missing module name.')
         self.shell.extension_manager.unload_extension(module_str)
 
     @line_magic
     def reload_ext(self, module_str):
         """Reload an IPython extension by its module name."""
+        if not module_str:
+            raise UsageError('Missing module name.')
         self.shell.extension_manager.reload_extension(module_str)

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -19,7 +19,7 @@ import sys
 
 # Our own packages
 from IPython.core import page
-from IPython.core.error import StdinNotImplementedError
+from IPython.core.error import StdinNotImplementedError, UsageError
 from IPython.core.magic import Magics, magics_class, line_magic
 from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.encoding import DEFAULT_ENCODING
@@ -92,6 +92,8 @@ class NamespaceMagics(Magics):
     @line_magic
     def psource(self, parameter_s='', namespaces=None):
         """Print (or run through pager) the source code for an object."""
+        if not parameter_s:
+            raise UsageError('Missing object name.')
         self.shell._inspect('psource',parameter_s, namespaces)
 
     @line_magic

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -681,6 +681,9 @@ class OSMagics(Magics):
         %pycat myMacro
         %pycat http://www.example.com/myscript.py
         """
+        if not parameter_s:
+            raise UsageError('Missing filename, URL, input history range, '
+                             'or macro.')
 
         try :
             cont = self.shell.find_user_code(parameter_s)

--- a/IPython/frontend/qt/console/mainwindow.py
+++ b/IPython/frontend/qt/console/mainwindow.py
@@ -613,7 +613,6 @@ class MainWindow(QtGui.QMainWindow):
         self.all_magic_menu.clear()
 
 
-        protected_magic = set(["more","less","load_ext","pycat","loadpy","load","save","psource"])
         mlist=ast.literal_eval(listofmagic)
         for magic in mlist:
             cell = (magic['type'] == 'cell')
@@ -625,11 +624,7 @@ class MainWindow(QtGui.QMainWindow):
                 prefix='%'
             magic_menu = self._get_magic_menu(mclass)
 
-            if name in protected_magic:
-                suffix = '?'
-            else :
-                suffix = ''
-            pmagic = '%s%s%s'%(prefix,name,suffix)
+            pmagic = '%s%s'%(prefix,name)
 
             xaction = QtGui.QAction(pmagic,
                 self,

--- a/IPython/zmq/zmqshell.py
+++ b/IPython/zmq/zmqshell.py
@@ -30,6 +30,7 @@ from IPython.core.interactiveshell import (
 from IPython.core import page
 from IPython.core.autocall import ZMQExitAutocall
 from IPython.core.displaypub import DisplayPublisher
+from IPython.core.error import UsageError
 from IPython.core.magics import MacroToEdit, CodeMagics
 from IPython.core.magic import magics_class, line_magic, Magics
 from IPython.core.payloadpage import install_payload_page
@@ -349,6 +350,9 @@ class KernelMagics(Magics):
         """Show a file through the pager.
 
         Files ending in .py are syntax-highlighted."""
+        if not arg_s:
+            raise UsageError('Missing filename.')
+
         cont = open(arg_s).read()
         if arg_s.endswith('.py'):
             cont = self.shell.pycolorize(cont)


### PR DESCRIPTION
Print a helpful message when the user calls a magic command with a missing argument, rather than a long traceback.

In addition, I have removed the 'protected' magic list from qtconsole .. these are the magic whose name shows up like `%load?`.  I think it's visually confusing to have some magics show up with a question mark, and it seems irrelevant if running the magic command prints a short usage error message.  One small issue is this might prevent the discovery of the `%magic?` syntax for getting help.  Perhaps we should catch `UsageError` in `run_line_magic` and `run_cell_magic` and suggest the user run `%{magic_name}?` for help.
