### PR TITLE
Make the ipengine monitor the ipcontroller heartbeat and die if the ipcontroller goes down

### DIFF
--- a/IPython/parallel/controller/heartmonitor.py
+++ b/IPython/parallel/controller/heartmonitor.py
@@ -19,7 +19,7 @@ import time
 import uuid
 
 import zmq
-from zmq.devices import ThreadDevice
+from zmq.devices import ThreadDevice, ThreadMonitoredQueue
 from zmq.eventloop import ioloop, zmqstream
 
 from IPython.config.configurable import LoggingConfigurable
@@ -39,8 +39,11 @@ class Heart(object):
     You can specify the DEALER's IDENTITY via the optional heart_id argument."""
     device=None
     id=None
-    def __init__(self, in_addr, out_addr, in_type=zmq.SUB, out_type=zmq.DEALER, heart_id=None):
-        self.device = ThreadDevice(zmq.FORWARDER, in_type, out_type)
+    def __init__(self, in_addr, out_addr, mon_addr=None, in_type=zmq.SUB, out_type=zmq.DEALER, mon_type=zmq.PUB, heart_id=None):
+        if mon_addr is None:
+            self.device = ThreadDevice(zmq.FORWARDER, in_type, out_type)
+        else:
+            self.device = ThreadMonitoredQueue(in_type, out_type, mon_type, in_prefix=b"", out_prefix=b"")
         # do not allow the device to share global Context.instance,
         # which is the default behavior in pyzmq > 2.1.10
         self.device.context_factory = zmq.Context
@@ -48,6 +51,8 @@ class Heart(object):
         self.device.daemon=True
         self.device.connect_in(in_addr)
         self.device.connect_out(out_addr)
+        if mon_addr is not None:
+            self.device.connect_mon(mon_addr)
         if in_type == zmq.SUB:
             self.device.setsockopt_in(zmq.SUBSCRIBE, b"")
         if heart_id is None:
@@ -122,7 +127,7 @@ class HeartMonitor(LoggingConfigurable):
         map(self.handle_heart_failure, heartfailures)
         self.on_probation = missed_beats.intersection(self.hearts)
         self.responses = set()
-        # print self.on_probation, self.hearts
+        #print self.on_probation, self.hearts
         # self.log.debug("heartbeat::beat %.3f, %i beating hearts", self.lifetime, len(self.hearts))
         self.pingstream.send(str_to_bytes(str(self.lifetime)))
         # flush stream to force immediate socket send
@@ -177,6 +182,8 @@ if __name__ == '__main__':
     outstream = zmqstream.ZMQStream(pub, loop)
     instream = zmqstream.ZMQStream(router, loop)
 
-    hb = HeartMonitor(loop, outstream, instream)
-
+    hb = HeartMonitor(loop=loop, pingstream=outstream, pongstream=instream)
+    import logging
+    hb.log.setLevel(logging.DEBUG)
+    hb.start()
     loop.start()

--- a/IPython/parallel/controller/heartmonitor.py
+++ b/IPython/parallel/controller/heartmonitor.py
@@ -170,20 +170,3 @@ class HeartMonitor(LoggingConfigurable):
         else:
             self.log.warn("heartbeat::got bad heartbeat (possibly old?): %s (current=%.3f)", msg[1], self.lifetime)
 
-
-if __name__ == '__main__':
-    loop = ioloop.IOLoop.instance()
-    context = zmq.Context()
-    pub = context.socket(zmq.PUB)
-    pub.bind('tcp://127.0.0.1:5555')
-    router = context.socket(zmq.ROUTER)
-    router.bind('tcp://127.0.0.1:5556')
-
-    outstream = zmqstream.ZMQStream(pub, loop)
-    instream = zmqstream.ZMQStream(router, loop)
-
-    hb = HeartMonitor(loop=loop, pingstream=outstream, pongstream=instream)
-    import logging
-    hb.log.setLevel(logging.DEBUG)
-    hb.start()
-    loop.start()

--- a/IPython/parallel/controller/hub.py
+++ b/IPython/parallel/controller/hub.py
@@ -904,7 +904,7 @@ class Hub(SessionFactory):
 
         self.log.debug("registration::register_engine(%i, %r)", eid, uuid)
 
-        content = dict(id=eid,status='ok')
+        content = dict(id=eid,status='ok',hb_period=self.heartmonitor.period)
         # check if requesting available IDs:
         if cast_bytes(uuid) in self.by_ident:
             try:

--- a/IPython/parallel/engine/engine.py
+++ b/IPython/parallel/engine/engine.py
@@ -74,8 +74,10 @@ class EngineFactory(RegistrationFactory):
     kernel = Instance(Kernel)
     
     # States for the heartbeat monitoring
-    _hb_last_pinged = None
-    _hb_last_monitored = None
+    # Initial values for monitored and pinged must satisfy "monitored > pinged == False" so that 
+    # during the first check no "missed" ping is reported. Must be floats for Python 3 compatibility.
+    _hb_last_pinged = 0.0
+    _hb_last_monitored = 0.0
     _hb_missed_beats = 0
     # The zmq Stream which receives the pings from the Heart
     _hb_listener = None

--- a/IPython/parallel/engine/engine.py
+++ b/IPython/parallel/engine/engine.py
@@ -53,7 +53,7 @@ class EngineFactory(RegistrationFactory):
     timeout=Float(5.0, config=True,
         help="""The time (in seconds) to wait for the Controller to respond
         to registration requests before giving up.""")
-    max_heartbeat_misses=Integer(0, config=True,
+    max_heartbeat_misses=Integer(50, config=True,
         help="""The maximum number of times a check for the heartbeat ping of a 
         controller can be missed before shutting down the engine.
         

--- a/IPython/parallel/engine/engine.py
+++ b/IPython/parallel/engine/engine.py
@@ -178,15 +178,16 @@ class EngineFactory(RegistrationFactory):
             hb_ping = maybe_tunnel(url('hb_ping'))
             hb_pong = maybe_tunnel(url('hb_pong'))
             
-            # Add a monitor socket which will record the last time a ping was seen
-            mon = self.context.socket(zmq.SUB)
-            mport = mon.bind_to_random_port('tcp://127.0.0.1')
-            mon.setsockopt(zmq.SUBSCRIBE, b"")
-            self._hb_listener = zmqstream.ZMQStream(mon, self.loop)
-            self._hb_listener.on_recv(self._report_ping)
-            
             hb_monitor = None
             if self.max_heartbeat_misses > 0:
+                # Add a monitor socket which will record the last time a ping was seen
+                mon = self.context.socket(zmq.SUB)
+                mport = mon.bind_to_random_port('tcp://127.0.0.1')
+                mon.setsockopt(zmq.SUBSCRIBE, b"")
+                self._hb_listener = zmqstream.ZMQStream(mon, self.loop)
+                self._hb_listener.on_recv(self._report_ping)
+            
+            
                 hb_monitor = "tcp://127.0.0.1:%i"%mport
 
             heart = Heart(hb_ping, hb_pong, hb_monitor , heart_id=identity)


### PR DESCRIPTION
This is for #1453: "make engines reconnect/die when controller was restarted"
