### PR TITLE
iostream._newbuffer starts auto-flush clock

### DIFF
--- a/IPython/zmq/iostream.py
+++ b/IPython/zmq/iostream.py
@@ -78,9 +78,7 @@ class OutStream(object):
             
             self._buffer.write(string)
             current_time = time.time()
-            if self._start <= 0:
-                self._start = current_time
-            elif current_time - self._start > self.flush_interval:
+            if current_time - self._start > self.flush_interval:
                 self.flush()
 
     def writelines(self, sequence):
@@ -92,4 +90,4 @@ class OutStream(object):
 
     def _new_buffer(self):
         self._buffer = StringIO()
-        self._start = -1
+        self._start = time.time()


### PR DESCRIPTION
This means that the timer runs between flush calls, rather than the previous logic where the timer started on the first print after each flush.  The problem with the previous logic was that it meant the first message after any flush could _never_ be displayed immediately without an explicit manual `stdout.flush()`.

The disadvantage of the new approach is that most cells with two or more print statements will result in at least two stdout messages, because when used interactively the first print statement will ~always trigger the flush_timeout logic.
