### PR TITLE
Added .inverted in LightBG stylesheet example

### DIFF
--- a/docs/source/interactive/qtconsole.txt
+++ b/docs/source/interactive/qtconsole.txt
@@ -254,6 +254,7 @@ stylesheet:
     QPlainTextEdit, QTextEdit { background-color: white;
             color: black ;
             selection-background-color: #ccc}
+    .inverted { background-color: black ; color: white;}
     .error { color: red; }
     .in-prompt { color: navy; }
     .in-prompt-number { font-weight: bold; }


### PR DESCRIPTION
Without .inverted, there will be no highlight in tab completion suggestions. (See #2330)
