### PR TITLE
Normalize line endings for ipexec_validate, fix for #2315.

### DIFF
--- a/IPython/testing/tests/test_tools.py
+++ b/IPython/testing/tests/test_tools.py
@@ -88,3 +88,27 @@ class TestAssertPrints(unittest.TestCase):
                 print b"ghi"
         
         self.assertRaises(AssertionError, func)
+
+
+class Test_ipexec_validate(unittest.TestCase, tt.TempFileMixin):
+    def test_main_path(self):
+        """Test with only stdout results.
+        """
+        self.mktmp("print('A')\n"
+                   "print('B')\n"
+                   )
+        out = "A\nB"
+        tt.ipexec_validate(self.fname, out)
+
+    def test_exception_path(self):
+        """Test exception path in exception_validate.
+        """
+        self.mktmp("from __future__ import print_function\n"
+                   "import sys\n"
+                   "print('A')\n"
+                   "print('B')\n"
+                   "print('C', file=sys.stderr)\n"
+                   "print('D', file=sys.stderr)\n"
+                   )
+        out = "A\nB"
+        tt.ipexec_validate(self.fname, expected_out=out, expected_err="C\nD")

--- a/IPython/testing/tests/test_tools.py
+++ b/IPython/testing/tests/test_tools.py
@@ -100,6 +100,15 @@ class Test_ipexec_validate(unittest.TestCase, tt.TempFileMixin):
         out = "A\nB"
         tt.ipexec_validate(self.fname, out)
 
+    def test_main_path2(self):
+        """Test with only stdout results, expecting windows line endings.
+        """
+        self.mktmp("print('A')\n"
+                   "print('B')\n"
+                   )
+        out = "A\r\nB"
+        tt.ipexec_validate(self.fname, out)
+
     def test_exception_path(self):
         """Test exception path in exception_validate.
         """
@@ -112,3 +121,16 @@ class Test_ipexec_validate(unittest.TestCase, tt.TempFileMixin):
                    )
         out = "A\nB"
         tt.ipexec_validate(self.fname, expected_out=out, expected_err="C\nD")
+
+    def test_exception_path(self):
+        """Test exception path in exception_validate, expecting windows line endings.
+        """
+        self.mktmp("from __future__ import print_function\n"
+                   "import sys\n"
+                   "print('A')\n"
+                   "print('B')\n"
+                   "print('C', file=sys.stderr)\n"
+                   "print('D', file=sys.stderr)\n"
+                   )
+        out = "A\r\nB"
+        tt.ipexec_validate(self.fname, expected_out=out, expected_err="C\r\nD")

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -235,7 +235,7 @@ def ipexec_validate(fname, expected_out, expected_err='',
     # more informative than simply having an empty stdout.
     if err:
         if expected_err:
-            nt.assert_equal(err.strip(), expected_err.strip())
+            nt.assert_equal("\n".join(err.strip().splitlines()), "\n".join(expected_err.strip().splitlines()))
         else:
             raise ValueError('Running file %r produced error: %r' %
                              (fname, err))

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -240,7 +240,7 @@ def ipexec_validate(fname, expected_out, expected_err='',
             raise ValueError('Running file %r produced error: %r' %
                              (fname, err))
     # If no errors or output on stderr was expected, match stdout
-    nt.assert_equal(out.strip(), expected_out.strip())
+    nt.assert_equal("\n".join(out.strip().splitlines()), "\n".join(expected_out.strip().splitlines()))
 
 
 class TempFileMixin(object):


### PR DESCRIPTION
Make sure line endings are the same both in the ipexec result and
in the expected result.
