### PR TITLE
Extra xterm identification in set_term_title

### DIFF
--- a/IPython/utils/terminal.py
+++ b/IPython/utils/terminal.py
@@ -81,7 +81,7 @@ def _set_term_title_xterm(title):
 
 if os.name == 'posix':
     TERM = os.environ.get('TERM','')
-    if (TERM == 'xterm') or (TERM == 'xterm-color'):
+    if TERM.startswith('xterm'):
         _set_term_title = _set_term_title_xterm
 
 


### PR DESCRIPTION
Many times, xterm represent itself as "xterm-256color" instead of "xterm-color". This makes set_term_title not work at all. This is a simple patch to add "xterm-256color" in the list of TERM environments that should use the xterm way of changing the title.

Tested on iTerm2 on OSX.
