### PR TITLE
adjust division error message checking to account for Python 3

### DIFF
--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -600,7 +600,7 @@ class TestView(ClusterTestCase, ParametricTestCase):
             ip.run_cell("ar.get(2)")
         
         self.assertEqual(io.stdout.count('ZeroDivisionError'), len(view) * 2, io.stdout)
-        self.assertEqual(io.stdout.count('integer division'), len(view), io.stdout)
+        self.assertEqual(io.stdout.count('by zero'), len(view), io.stdout)
         self.assertEqual(io.stdout.count(':execute'), len(view), io.stdout)
     
     @dec.skipif_not_matplotlib


### PR DESCRIPTION
fix Python3-specific typo introduced #2305
