### PR TITLE
Notebook: Store the username in a cookie whose name is unique.

### DIFF
--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -146,13 +146,13 @@ class AuthenticatedHandler(RequestHandler):
     """A RequestHandler with an authenticated user."""
 
     def get_current_user(self):
-        user_id = self.get_secure_cookie("username")
+        user_id = self.get_secure_cookie(self.settings['cookie_name'])
         # For now the user_id should not return empty, but it could eventually
         if user_id == '':
             user_id = 'anonymous'
         if user_id is None:
             # prevent extra Invalid cookie sig warnings:
-            self.clear_cookie('username')
+            self.clear_cookie(self.settings['cookie_name'])
             if not self.application.password and not self.application.read_only:
                 user_id = 'anonymous'
         return user_id
@@ -242,7 +242,7 @@ class LoginHandler(AuthenticatedHandler):
         pwd = self.get_argument('password', default=u'')
         if self.application.password:
             if passwd_check(self.application.password, pwd):
-                self.set_secure_cookie('username', str(uuid.uuid4()))
+                self.set_secure_cookie(self.settings['cookie_name'], str(uuid.uuid4()))
             else:
                 self._render(message={'error': 'Invalid password'})
                 return
@@ -253,7 +253,7 @@ class LoginHandler(AuthenticatedHandler):
 class LogoutHandler(AuthenticatedHandler):
 
     def get(self):
-        self.clear_cookie('username')
+        self.clear_cookie(self.settings['cookie_name'])
         if self.login_available:
             message = {'info': 'Successfully logged out.'}
         else:
@@ -427,7 +427,7 @@ class AuthenticatedZMQStreamHandler(ZMQStreamHandler):
         self.on_message = self.on_first_message
 
     def get_current_user(self):
-        user_id = self.get_secure_cookie("username")
+        user_id = self.get_secure_cookie(self.settings['cookie_name'])
         if user_id == '' or (user_id is None and not self.application.password):
             user_id = 'anonymous'
         return user_id

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -28,6 +28,7 @@ import socket
 import sys
 import threading
 import time
+import uuid
 import webbrowser
 
 # Third party
@@ -164,6 +165,7 @@ class NotebookWebApplication(web.Application):
             static_handler_class = FileFindHandler,
             cookie_secret=os.urandom(1024),
             login_url="%s/login"%(base_project_url.rstrip('/')),
+            cookie_name='username-%s' % uuid.uuid4(),
         )
 
         # allow custom overrides for the tornado web app.


### PR DESCRIPTION
Cookies cannot be saved on a per-port basis, so a cookie "username" is shared
across all running IPython notebooks with the same hostname. Using a unique
cookie name prevents this collision.

This allows a user to start multiple IPython notebooks and be logged into
each.

Closes #1459 & #2351.
