### PR TITLE
make clients use 'location' properly (fixes #2361)

### DIFF
--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -418,7 +418,7 @@ class Client(HasTraits):
         location = cfg.setdefault('location', None)
         
         proto,addr = cfg['interface'].split('://')
-        addr = util.disambiguate_ip_address(addr)
+        addr = util.disambiguate_ip_address(addr, location)
         cfg['interface'] = "%s://%s" % (proto, addr)
         
         # turn interface,port into full urls:


### PR DESCRIPTION
This fixes a previous change that removed the location argument from the
call to util.disambiguate_ip_address, which stops it getting used where
interface is \* or 0.0.0.0.
