### PR TITLE
fix names of notebooks for download/save

### DIFF
--- a/IPython/frontend/html/notebook/nbmanager.py
+++ b/IPython/frontend/html/notebook/nbmanager.py
@@ -117,7 +117,7 @@ class NotebookManager(LoggingConfigurable):
             # should match the Python in-memory format.
             kwargs['split_lines'] = False
         data = current.writes(nb, format, **kwargs)
-        name = nb.get('name','notebook')
+        name = nb.metadata.get('name','notebook')
         return last_modified, name, data
 
     def read_notebook_object(self, notebook_id):


### PR DESCRIPTION
was using notebook.get('name') instead of notebook.metadata.get('name'),
where the name is actually stored.  The result was that all downloaded notebooks were called 'notebook'.

closes #2227
