### PR TITLE
Fix installation of man pages in Python 3

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -204,12 +204,12 @@ def find_data_files():
     manpagebase = pjoin('share', 'man', 'man1')
 
     # Simple file lists can be made by hand
-    manpages  = filter(isfile, glob(pjoin('docs','man','*.1.gz')))
+    manpages = [f for f in glob(pjoin('docs','man','*.1.gz')) if isfile(f)]
     if not manpages:
         # When running from a source tree, the manpages aren't gzipped
-        manpages = filter(isfile, glob(pjoin('docs','man','*.1')))
-    igridhelpfiles = filter(isfile,
-                            glob(pjoin('IPython','extensions','igrid_help.*')))
+        manpages = [f for f in glob(pjoin('docs','man','*.1')) if isfile(f)]
+
+    igridhelpfiles = [f for f in glob(pjoin('IPython','extensions','igrid_help.*')) if isfile(f)]
 
     # For nested structures, use the utility above
     example_files = make_dir_struct(


### PR DESCRIPTION
This fixes a bug that caused man pages to not be installed in Python 3 when running from the source tree. The issue was that in Python 3, an empty filter is not an empty list, so `if not manpages` could not be satisfied. By using `list()`, we can ensure that we convert the filter iterator to a list in Python 3. This partially fixes #2374.
