### PR TITLE
Apidocs

### DIFF
--- a/IPython/core/error.py
+++ b/IPython/core/error.py
@@ -7,9 +7,6 @@ Authors:
 * Brian Granger
 * Fernando Perez
 * Min Ragan-Kelley
-
-Notes
------
 """
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -721,10 +721,10 @@ $""", re.VERBOSE)
 def extract_hist_ranges(ranges_str):
     """Turn a string of history ranges into 3-tuples of (session, start, stop).
 
-    Examples
-    --------
-    list(extract_input_ranges("~8/5-~7/4 2"))
-    [(-8, 5, None), (-7, 1, 4), (0, 2, 3)]
+    Example::
+    
+        >>> list(extract_input_ranges("~8/5-~7/4 2"))
+        [(-8, 5, None), (-7, 1, 4), (0, 2, 3)]
     """
     for range_str in ranges_str.split():
         rmatch = range_re.match(range_str)

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -724,7 +724,7 @@ def extract_hist_ranges(ranges_str):
     Example::
     
         >>> list(extract_hist_ranges("~8/5-~7/4 2"))
-        [(-8, 5, None), (-7, 1, 4), (0, 2, 3)]
+        [(-8, 5, None), (-7, 1, 5), (0, 2, 3)]
     """
     for range_str in ranges_str.split():
         rmatch = range_re.match(range_str)

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -723,7 +723,7 @@ def extract_hist_ranges(ranges_str):
 
     Example::
     
-        >>> list(extract_input_ranges("~8/5-~7/4 2"))
+        >>> list(extract_hist_ranges("~8/5-~7/4 2"))
         [(-8, 5, None), (-7, 1, 4), (0, 2, 3)]
     """
     for range_str in ranges_str.split():

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -49,7 +49,7 @@ dist: html
 	cp -al build/html .
 	@echo "Build finished.  Final docs are in html/"
 
-html: api
+html:
 	mkdir -p build/html build/doctrees
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) build/html
 	@echo
@@ -78,7 +78,7 @@ htmlhelp:
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      ".hhp project file in build/htmlhelp."
 
-latex: api
+latex:
 	mkdir -p build/latex build/doctrees
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) build/latex
 	@echo

--- a/docs/source/api/core/alias.txt
+++ b/docs/source/api/core/alias.txt
@@ -1,0 +1,38 @@
+.. AUTO-GENERATED FILE -- DO NOT EDIT!
+
+alias
+=====
+
+.. automodule:: IPython.core.alias
+
+.. currentmodule:: IPython.core.alias
+
+:class:`AliasManager`
+~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: AliasManager
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+:class:`AliasError`
+~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: AliasError
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+:class:`InvalidAliasError`
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: InvalidAliasError
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+:func:`default_aliases`
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: IPython.core.alias.default_aliases
+

--- a/docs/source/api/core/alias.txt
+++ b/docs/source/api/core/alias.txt
@@ -1,5 +1,3 @@
-.. AUTO-GENERATED FILE -- DO NOT EDIT!
-
 alias
 =====
 

--- a/docs/source/api/core/application.txt
+++ b/docs/source/api/core/application.txt
@@ -1,0 +1,19 @@
+application
+===========
+
+Inheritance diagram for ``IPython.core.application``:
+
+.. inheritance-diagram:: IPython.core.application 
+   :parts: 3
+
+.. automodule:: IPython.core.application
+
+.. currentmodule:: IPython.core.application
+
+:class:`BaseIPythonApplication`
+-------------------------------
+
+.. autoclass:: BaseIPythonApplication
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/docs/source/api/core/compilerop.txt
+++ b/docs/source/api/core/compilerop.txt
@@ -1,0 +1,20 @@
+compilerop
+==========
+
+.. automodule:: IPython.core.compilerop
+
+.. currentmodule:: IPython.core.compilerop
+
+:class:`CachingCompiler`
+------------------------
+
+.. autoclass:: CachingCompiler
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+:func:`code_name`
+-----------------
+
+.. autofunction:: IPython.core.compilerop.code_name
+

--- a/docs/source/api/core/displayhook.txt
+++ b/docs/source/api/core/displayhook.txt
@@ -1,0 +1,15 @@
+displayhook
+===========
+
+.. automodule:: IPython.core.displayhook
+
+.. currentmodule:: IPython.core.displayhook
+
+:class:`DisplayHook`
+--------------------
+
+
+.. autoclass:: DisplayHook
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/docs/source/api/core/error.txt
+++ b/docs/source/api/core/error.txt
@@ -1,0 +1,43 @@
+error
+=====
+
+.. automodule:: IPython.core.error
+
+Inheritance diagram for ``IPython.core.error``:
+
+.. inheritance-diagram:: IPython.core.error 
+   :parts: 1
+
+.. currentmodule:: IPython.core.error
+
+:class:`IPythonCoreError`
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: IPythonCoreError
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+:class:`StdinNotImplementedError`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: StdinNotImplementedError
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+:class:`TryNext`
+~~~~~~~~~~~~~~~~
+
+.. autoclass:: TryNext
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+:class:`UsageError`
+~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: UsageError
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/docs/source/api/core/extensions.txt
+++ b/docs/source/api/core/extensions.txt
@@ -1,0 +1,14 @@
+extensions
+==========
+
+.. automodule:: IPython.core.extensions
+
+.. currentmodule:: IPython.core.extensions
+
+:class:`ExtensionManager`
+-------------------------
+
+.. autoclass:: ExtensionManager
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/docs/source/api/core/history.txt
+++ b/docs/source/api/core/history.txt
@@ -1,0 +1,56 @@
+.. AUTO-GENERATED FILE -- DO NOT EDIT!
+
+history
+=======
+
+Module: :mod:`IPython.core.history`
+-----------------------------------
+Inheritance diagram for ``IPython.core.history``:
+
+.. inheritance-diagram:: IPython.core.history 
+   :parts: 3
+
+.. automodule:: IPython.core.history
+
+.. currentmodule:: IPython.core.history
+
+Classes
+-------
+
+:class:`HistoryAccessor`
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+.. autoclass:: HistoryAccessor
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+  .. automethod:: __init__
+
+:class:`HistoryManager`
+~~~~~~~~~~~~~~~~~~~~~~~
+
+
+.. autoclass:: HistoryManager
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+  .. automethod:: __init__
+
+:class:`HistorySavingThread`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+.. autoclass:: HistorySavingThread
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+Functions
+---------
+
+
+.. autofunction:: IPython.core.history.extract_hist_ranges
+

--- a/docs/source/api/core/history.txt
+++ b/docs/source/api/core/history.txt
@@ -3,8 +3,6 @@
 history
 =======
 
-Module: :mod:`IPython.core.history`
------------------------------------
 Inheritance diagram for ``IPython.core.history``:
 
 .. inheritance-diagram:: IPython.core.history 
@@ -13,9 +11,6 @@ Inheritance diagram for ``IPython.core.history``:
 .. automodule:: IPython.core.history
 
 .. currentmodule:: IPython.core.history
-
-Classes
--------
 
 :class:`HistoryAccessor`
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -48,9 +43,8 @@ Classes
   :undoc-members:
   :show-inheritance:
 
-Functions
----------
-
+:func:`extract_hist_ranges`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: IPython.core.history.extract_hist_ranges
 

--- a/docs/source/api/core/index.txt
+++ b/docs/source/api/core/index.txt
@@ -1,0 +1,8 @@
+.. _api-IPython-core:
+
+IPython.core
+============
+
+.. toctree::
+   
+   history.txt

--- a/docs/source/api/core/index.txt
+++ b/docs/source/api/core/index.txt
@@ -5,6 +5,9 @@ IPython.core
 
 .. toctree::
    
+   interactiveshell.txt
+   alias.txt
    application.txt
    history.txt
+   magic.txt
    magics/index.txt

--- a/docs/source/api/core/index.txt
+++ b/docs/source/api/core/index.txt
@@ -20,3 +20,4 @@ IPython.core
    displayhook.txt
    page.txt
    compilerop.txt
+   error.txt

--- a/docs/source/api/core/index.txt
+++ b/docs/source/api/core/index.txt
@@ -6,3 +6,4 @@ IPython.core
 .. toctree::
    
    history.txt
+   magics/index.txt

--- a/docs/source/api/core/index.txt
+++ b/docs/source/api/core/index.txt
@@ -8,7 +8,10 @@ IPython.core
    interactiveshell.txt
    alias.txt
    application.txt
+   shellapp.txt
+   profileapp.txt
    history.txt
    magic.txt
    magics/index.txt
    prompts.txt
+   extensions.txt

--- a/docs/source/api/core/index.txt
+++ b/docs/source/api/core/index.txt
@@ -18,3 +18,5 @@ IPython.core
    ultratb.txt
    oinspect.txt
    displayhook.txt
+   page.txt
+   compilerop.txt

--- a/docs/source/api/core/index.txt
+++ b/docs/source/api/core/index.txt
@@ -5,5 +5,6 @@ IPython.core
 
 .. toctree::
    
+   application.txt
    history.txt
    magics/index.txt

--- a/docs/source/api/core/index.txt
+++ b/docs/source/api/core/index.txt
@@ -15,3 +15,6 @@ IPython.core
    magics/index.txt
    prompts.txt
    extensions.txt
+   ultratb.txt
+   oinspect.txt
+   displayhook.txt

--- a/docs/source/api/core/index.txt
+++ b/docs/source/api/core/index.txt
@@ -11,3 +11,4 @@ IPython.core
    history.txt
    magic.txt
    magics/index.txt
+   prompts.txt

--- a/docs/source/api/core/interactiveshell.txt
+++ b/docs/source/api/core/interactiveshell.txt
@@ -1,0 +1,54 @@
+interactiveshell - The heart of IPython
+=======================================
+
+.. automodule:: IPython.core.interactiveshell
+
+.. currentmodule:: IPython.core.interactiveshell
+
+:class:`InteractiveShell`
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: InteractiveShell
+  :members:
+  :show-inheritance:
+
+  .. automethod:: __init__
+
+:class:`InteractiveShellABC`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: InteractiveShellABC
+  :members:
+  :show-inheritance:
+
+:class:`ReadlineNoRecord`
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: ReadlineNoRecord
+  :members:
+  :undoc-members:
+
+:class:`SeparateUnicode`
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+.. autoclass:: SeparateUnicode
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+:class:`SpaceInInput`
+~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: SpaceInInput
+  :show-inheritance:
+
+:func:`get_default_colors`
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: IPython.core.interactiveshell.get_default_colors
+
+:func:`softspace`
+~~~~~~~~~~~~~~~~~
+
+.. autofunction:: IPython.core.interactiveshell.softspace

--- a/docs/source/api/core/magic.txt
+++ b/docs/source/api/core/magic.txt
@@ -1,0 +1,50 @@
+magic
+=====
+
+.. automodule:: IPython.core.magic
+
+.. currentmodule:: IPython.core.magic
+
+:class:`MagicAlias`
+~~~~~~~~~~~~~~~~~~~
+
+
+.. autoclass:: MagicAlias
+  :members:
+  :undoc-members:
+
+:class:`MagicsManager`
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: MagicsManager
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+:class:`Magics`
+~~~~~~~~~~~~~~~
+
+.. autoclass:: Magics
+  :members:
+  :undoc-members:
+  
+:func:`magics_class` decorator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: IPython.core.magic.magics_class
+
+:func:`needs_local_scope` decorator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: IPython.core.magic.needs_local_scope
+
+Other functions
+~~~~~~~~~~~~~~~
+
+.. autofunction:: IPython.core.magic.compress_dhist
+
+.. autofunction:: IPython.core.magic.on_off
+
+.. autofunction:: IPython.core.magic.record_magic
+
+.. autofunction:: IPython.core.magic.validate_type

--- a/docs/source/api/core/magics/auto.txt
+++ b/docs/source/api/core/magics/auto.txt
@@ -1,0 +1,11 @@
+auto
+====
+
+.. automodule:: IPython.core.magics.auto
+
+.. currentmodule:: IPython.core.magics.auto
+
+.. autoclass:: AutoMagics
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/docs/source/api/core/magics/basic.txt
+++ b/docs/source/api/core/magics/basic.txt
@@ -1,0 +1,11 @@
+basic
+=====
+
+.. automodule:: IPython.core.magics.basic
+
+.. currentmodule:: IPython.core.magics.basic
+
+.. autoclass:: BasicMagics
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/docs/source/api/core/magics/code.txt
+++ b/docs/source/api/core/magics/code.txt
@@ -1,0 +1,11 @@
+code
+====
+
+.. automodule:: IPython.core.magics.code
+
+.. currentmodule:: IPython.core.magics.code
+
+.. autoclass:: CodeMagics
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/docs/source/api/core/magics/config.txt
+++ b/docs/source/api/core/magics/config.txt
@@ -1,0 +1,11 @@
+config
+======
+
+.. automodule:: IPython.core.magics.config
+
+.. currentmodule:: IPython.core.magics.config
+
+.. autoclass:: ConfigMagics
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/docs/source/api/core/magics/display.txt
+++ b/docs/source/api/core/magics/display.txt
@@ -1,0 +1,11 @@
+display
+=======
+
+.. automodule:: IPython.core.magics.display
+
+.. currentmodule:: IPython.core.magics.display
+
+.. autoclass:: DisplayMagics
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/docs/source/api/core/magics/execution.txt
+++ b/docs/source/api/core/magics/execution.txt
@@ -1,0 +1,11 @@
+execution
+=========
+
+.. automodule:: IPython.core.magics.execution
+
+.. currentmodule:: IPython.core.magics.execution
+
+.. autoclass:: ExecutionMagics
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/docs/source/api/core/magics/extension.txt
+++ b/docs/source/api/core/magics/extension.txt
@@ -1,0 +1,11 @@
+extension
+=========
+
+.. automodule:: IPython.core.magics.extension
+
+.. currentmodule:: IPython.core.magics.extension
+
+.. autoclass:: ExtensionMagics
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/docs/source/api/core/magics/history.txt
+++ b/docs/source/api/core/magics/history.txt
@@ -1,0 +1,11 @@
+history
+=======
+
+.. automodule:: IPython.core.magics.history
+
+.. currentmodule:: IPython.core.magics.history
+
+.. autoclass:: HistoryMagics
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/docs/source/api/core/magics/index.txt
+++ b/docs/source/api/core/magics/index.txt
@@ -1,0 +1,27 @@
+magics
+======
+
+.. automodule:: IPython.core.magics
+
+.. toctree::
+
+   auto.txt
+   basic.txt
+   code.txt
+   config.txt
+   display.txt
+   execution.txt
+   extension.txt
+   history.txt
+   logging.txt
+   namespace.txt
+   osm.txt
+   pylab.txt
+   script.txt
+
+.. currentmodule:: IPython.core.magics
+
+.. autoclass:: UserMagics
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/docs/source/api/core/magics/logging.txt
+++ b/docs/source/api/core/magics/logging.txt
@@ -1,0 +1,11 @@
+logging
+=======
+
+.. automodule:: IPython.core.magics.logging
+
+.. currentmodule:: IPython.core.magics.logging
+
+.. autoclass:: LoggingMagics
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/docs/source/api/core/magics/namespace.txt
+++ b/docs/source/api/core/magics/namespace.txt
@@ -1,0 +1,11 @@
+namespace
+=========
+
+.. automodule:: IPython.core.magics.namespace
+
+.. currentmodule:: IPython.core.magics.namespace
+
+.. autoclass:: NamespaceMagics
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/docs/source/api/core/magics/osm.txt
+++ b/docs/source/api/core/magics/osm.txt
@@ -1,0 +1,11 @@
+osm
+===
+
+.. automodule:: IPython.core.magics.osm
+
+.. currentmodule:: IPython.core.magics.osm
+
+.. autoclass:: OSMagics
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/docs/source/api/core/magics/pylab.txt
+++ b/docs/source/api/core/magics/pylab.txt
@@ -1,0 +1,11 @@
+pylab
+=====
+
+.. automodule:: IPython.core.magics.pylab
+
+.. currentmodule:: IPython.core.magics.pylab
+
+.. autoclass:: PylabMagics
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/docs/source/api/core/magics/script.txt
+++ b/docs/source/api/core/magics/script.txt
@@ -1,0 +1,11 @@
+script
+======
+
+.. automodule:: IPython.core.magics.script
+
+.. currentmodule:: IPython.core.magics.script
+
+.. autoclass:: ScriptMagics
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/docs/source/api/core/oinspect.txt
+++ b/docs/source/api/core/oinspect.txt
@@ -1,0 +1,41 @@
+oinspect
+========
+
+.. automodule:: IPython.core.oinspect
+
+.. currentmodule:: IPython.core.oinspect
+
+:class:`Inspector`
+------------------
+
+.. autoclass:: Inspector
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+Functions
+---------
+
+.. autofunction:: IPython.core.oinspect.call_tip
+
+
+.. autofunction:: IPython.core.oinspect.find_file
+
+
+.. autofunction:: IPython.core.oinspect.find_source_lines
+
+
+.. autofunction:: IPython.core.oinspect.format_argspec
+
+
+.. autofunction:: IPython.core.oinspect.getargspec
+
+
+.. autofunction:: IPython.core.oinspect.getdoc
+
+
+.. autofunction:: IPython.core.oinspect.getsource
+
+
+.. autofunction:: IPython.core.oinspect.object_info
+

--- a/docs/source/api/core/page.txt
+++ b/docs/source/api/core/page.txt
@@ -1,0 +1,19 @@
+page
+====
+
+.. automodule:: IPython.core.page
+
+.. currentmodule:: IPython.core.page
+
+.. autofunction:: IPython.core.page.get_pager_cmd
+
+.. autofunction:: IPython.core.page.get_pager_start
+
+.. autofunction:: IPython.core.page.page
+
+.. autofunction:: IPython.core.page.page_dumb
+
+.. autofunction:: IPython.core.page.page_file
+
+.. autofunction:: IPython.core.page.snip_print
+

--- a/docs/source/api/core/profileapp.txt
+++ b/docs/source/api/core/profileapp.txt
@@ -1,0 +1,54 @@
+profileapp
+==========
+
+Inheritance diagram for ``IPython.core.profileapp``:
+
+.. inheritance-diagram:: IPython.core.profileapp 
+   :parts: 3
+
+.. automodule:: IPython.core.profileapp
+
+.. currentmodule:: IPython.core.profileapp
+
+:class:`ProfileApp`
+~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: ProfileApp
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+:class:`ProfileCreate`
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: ProfileCreate
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+:class:`ProfileList`
+~~~~~~~~~~~~~~~~~~~~
+
+
+.. autoclass:: ProfileList
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+:class:`ProfileLocate`
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: ProfileLocate
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+:func:`list_bundled_profiles`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: IPython.core.profileapp.list_bundled_profiles
+
+:func:`list_profiles_in`
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. autofunction:: IPython.core.profileapp.list_profiles_in
+

--- a/docs/source/api/core/prompts.txt
+++ b/docs/source/api/core/prompts.txt
@@ -1,0 +1,40 @@
+prompts
+=======
+
+.. automodule:: IPython.core.prompts
+
+.. currentmodule:: IPython.core.prompts
+
+:class:`PromptManager`
+~~~~~~~~~~~~~~~~~~~~~~
+
+
+.. autoclass:: PromptManager
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+:class:`LazyEvaluate`
+~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: LazyEvaluate
+  :members:
+  :undoc-members:
+
+:class:`UserNSFormatter`
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+.. autoclass:: UserNSFormatter
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+Functions
+~~~~~~~~~
+
+.. autofunction:: IPython.core.prompts.cwd_filt
+
+.. autofunction:: IPython.core.prompts.cwd_filt2
+
+.. autofunction:: IPython.core.prompts.multiple_replace

--- a/docs/source/api/core/shellapp.txt
+++ b/docs/source/api/core/shellapp.txt
@@ -1,0 +1,14 @@
+shellapp
+========
+
+.. automodule:: IPython.core.shellapp
+
+.. currentmodule:: IPython.core.shellapp
+
+:class:`InteractiveShellApp`
+----------------------------
+
+.. autoclass:: InteractiveShellApp
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/docs/source/api/core/ultratb.txt
+++ b/docs/source/api/core/ultratb.txt
@@ -1,7 +1,5 @@
-.. AUTO-GENERATED FILE -- DO NOT EDIT!
-
-core.ultratb
-============
+ultratb
+=======
 
 .. automodule:: IPython.core.ultratb
 

--- a/docs/source/api/core/ultratb.txt
+++ b/docs/source/api/core/ultratb.txt
@@ -1,0 +1,79 @@
+.. AUTO-GENERATED FILE -- DO NOT EDIT!
+
+core.ultratb
+============
+
+.. automodule:: IPython.core.ultratb
+
+Inheritance diagram for ``IPython.core.ultratb``:
+
+.. inheritance-diagram:: IPython.core.ultratb 
+   :parts: 1
+
+.. currentmodule:: IPython.core.ultratb
+
+:class:`AutoFormattedTB`
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: AutoFormattedTB
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+:class:`ColorTB`
+~~~~~~~~~~~~~~~~
+
+.. autoclass:: ColorTB
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+:class:`FormattedTB`
+~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: FormattedTB
+  :members:
+  :undoc-members:
+  :show-inheritance:
+  
+:class:`SyntaxTB`
+~~~~~~~~~~~~~~~~~
+
+.. autoclass:: SyntaxTB
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+:class:`ListTB`
+~~~~~~~~~~~~~~~
+
+.. autoclass:: ListTB
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+:class:`VerboseTB`
+~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: VerboseTB
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+  .. automethod:: __init__
+
+:class:`TBTools`
+~~~~~~~~~~~~~~~~
+
+.. autoclass:: TBTools
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+Functions
+~~~~~~~~~
+
+.. autofunction:: IPython.core.ultratb.fix_frame_records_filenames
+
+.. autofunction:: IPython.core.ultratb.inspect_error
+

--- a/docs/source/api/index.txt
+++ b/docs/source/api/index.txt
@@ -9,4 +9,7 @@
    :Release: |version|
    :Date: |today|
 
-.. include:: generated/gen.txt
+.. toctree::
+   :maxdepth: 2
+   
+   core/index.txt


### PR DESCRIPTION
Not ready for merge.

This is something we discussed briefly a couple of weeks ago - should we move from fully auto-generated API docs to something a bit more manual, forcing us to be clearer about what is the public API?

I made a start towards that, but I wanted to check what we think of the idea and the details before I spend more time on it. I used the auto-generated API docs with some modifications:
- Rearranged into a hierarchical structure matching the package structure (`core/history.txt` rather than `IPython.core.history.txt`)
- Simplifying subheadings
- Not describing local utility functions and classes (like `Bunch`).
- Removing inheritance diagrams except where they're interesting (e.g. that for `ultratb` is interesting)
- Removing the `:inherited-members:` option from autoclass documentation (classes that derive from Configurable, for example, inherit a lot of confusing methods)
- Removing the `.. automethod:: __init__` documentation where `__init__` doesn't have a docstring.
