### PR TITLE
Adapt inline backend to changes in matplotlib

### DIFF
--- a/IPython/zmq/pylab/backend_inline.py
+++ b/IPython/zmq/pylab/backend_inline.py
@@ -222,4 +222,7 @@ def send_figure(fig):
         {mime : data}
     )
 
+# Changes to matplotlib in version 1.2 requires a mpl backend to supply a default
+# figurecanvas. This is set here to a Agg canvas
+# See https://github.com/matplotlib/matplotlib/pull/1125
 FigureCanvas = FigureCanvasAgg

--- a/IPython/zmq/pylab/backend_inline.py
+++ b/IPython/zmq/pylab/backend_inline.py
@@ -10,7 +10,7 @@ import sys
 
 # Third-party imports
 import matplotlib
-from matplotlib.backends.backend_agg import new_figure_manager
+from matplotlib.backends.backend_agg import new_figure_manager, FigureCanvasAgg
 from matplotlib._pylab_helpers import Gcf
 
 # Local imports.
@@ -222,3 +222,4 @@ def send_figure(fig):
         {mime : data}
     )
 
+FigureCanvas = FigureCanvasAgg


### PR DESCRIPTION
Matplotlib recently merged https://github.com/matplotlib/matplotlib/pull/1125 that makes it simpler to use 
objective oriented figure creation by automatically creating the right canvas for the backend. To solve that 
all backends must provide a backend_xxx.FigureCanvas. This is obviosly missing from the inline backend. 

The change is needed to make the inline backend work with mpl's 1.2.x branch which is due to released soon. Simply setting the default canvas equal to a Agg canvas appears to work for both svg and png figures but I'm not sure weather that  is the right approach. Should the canvas depend on the figure format and provide a svg canvas for a svg figure? (Note that before this change to matplotlib the canvas from a plt.figure call seams to be a agg type in all cases) 

Edit: I made the pull request against 0.13.1 since it would be good to have this in the stable branch for when mpl is released.
Just let me know and I can rebase it against master 
