### PR TITLE
Catch sqlite DatabaseErrors in more places when reading the history database

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -221,7 +221,6 @@ class HistoryAccessor(Configurable):
     ## -------------------------------
     ## Methods for retrieving history:
     ## -------------------------------
-    @catch_corrupt_db
     def _run_sql(self, sql, params, raw=True, output=False):
         """Prepares and runs an SQL query for the history database.
 
@@ -278,6 +277,7 @@ class HistoryAccessor(Configurable):
         query = "SELECT * from sessions where session == ?"
         return self.db.execute(query, (session,)).fetchone()
 
+    @catch_corrupt_db
     def get_tail(self, n=10, raw=True, output=False, include_latest=False):
         """Get the last n lines from the history database.
 
@@ -305,6 +305,7 @@ class HistoryAccessor(Configurable):
             return reversed(list(cur)[1:])
         return reversed(list(cur))
 
+    @catch_corrupt_db
     def search(self, pattern="*", raw=True, search_raw=True,
                output=False, n=None):
         """Search the database using unix glob-style matching (wildcards
@@ -339,7 +340,8 @@ class HistoryAccessor(Configurable):
         if n is not None:
             return reversed(list(cur))
         return cur
-
+    
+    @catch_corrupt_db
     def get_range(self, session, start=1, stop=None, raw=True,output=False):
         """Retrieve input by session.
 

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -71,8 +71,8 @@ else:
 @decorator
 def catch_corrupt_db(f, self, *a, **kw):
     """A decorator which wraps HistoryAccessor method calls to catch errors from
-    a corrupt SQLite database, move the old database out of the way, create a
-    new one, and optionally retry the function.
+    a corrupt SQLite database, move the old database out of the way, and create
+    a new one.
     """
     try:
         return f(self, *a, **kw)


### PR DESCRIPTION
It seems sqlite can encounter corruption and throw an error when reading the database, although it has connected successfully. This borrows the move-and-recreate machinery we already had on connecting to the database.

I can't test the actual bug, because I don't have a suitably corrupt file, but I've checked with a file it can't connect to that it still moves and recreates correctly.

Closes gh-2097
