### PR TITLE
New option `n` to limit history search hits

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -321,7 +321,7 @@ class HistoryAccessor(Configurable):
             params += (n,)
         cur = self._run_sql(sqlform, params, raw=raw, output=output)
         if n is not None:
-            cur = iter(reversed(list(cur)))
+            return reversed(list(cur))
         return cur
 
     def get_range(self, session, start=1, stop=None, raw=True,output=False):

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -290,7 +290,7 @@ class HistoryAccessor(Configurable):
         return reversed(list(cur))
 
     def search(self, pattern="*", raw=True, search_raw=True,
-                                                        output=False):
+               output=False, n=None):
         """Search the database using unix glob-style matching (wildcards
         * and ?).
 
@@ -302,6 +302,9 @@ class HistoryAccessor(Configurable):
           If True, search the raw input, otherwise, the parsed input
         raw, output : bool
           See :meth:`get_range`
+        n : None or int
+          If an integer is given, it defines the limit of
+          returned entries.
 
         Returns
         -------
@@ -311,9 +314,16 @@ class HistoryAccessor(Configurable):
         if output:
             tosearch = "history." + tosearch
         self.writeout_cache()
-        return self._run_sql("WHERE %s GLOB ?" % tosearch, (pattern,),
-                                    raw=raw, output=output)
-    
+        sqlform = "WHERE %s GLOB ?" % tosearch
+        params = (pattern,)
+        if n is not None:
+            sqlform += " ORDER BY session DESC, line DESC LIMIT ?"
+            params += (n,)
+        cur = self._run_sql(sqlform, params, raw=raw, output=output)
+        if n is not None:
+            cur = iter(reversed(list(cur)))
+        return cur
+
     def get_range(self, session, start=1, stop=None, raw=True,output=False):
         """Retrieve input by session.
 

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -87,6 +87,18 @@ def test_history():
             # Check get_hist_search
             gothist = ip.history_manager.search("*test*")
             nt.assert_equal(list(gothist), [(1,2,hist[1])] )
+            gothist = ip.history_manager.search("*=*")
+            nt.assert_equal(list(gothist),
+                            [(1, 1, hist[0]),
+                             (1, 2, hist[1]),
+                             (1, 3, hist[2]),
+                             (2, 1, newcmds[0]),
+                             (2, 3, newcmds[2])])
+            gothist = ip.history_manager.search("*=*", n=3)
+            nt.assert_equal(list(gothist),
+                            [(1, 3, hist[2]),
+                             (2, 1, newcmds[0]),
+                             (2, 3, newcmds[2])])
             gothist = ip.history_manager.search("b*", output=True)
             nt.assert_equal(list(gothist), [(1,3,(hist[2],"spam"))] )
 

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -486,7 +486,7 @@ class Kernel(Configurable):
                                                         raw=raw, output=output)
 
         elif hist_access_type == 'search':
-            n = parent['content']['n']
+            n = parent['content'].get('n')
             pattern = parent['content']['pattern']
             hist = self.shell.history_manager.search(pattern, raw=raw,
                                                      output=output, n=n)

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -486,9 +486,10 @@ class Kernel(Configurable):
                                                         raw=raw, output=output)
 
         elif hist_access_type == 'search':
+            n = parent['content']['n']
             pattern = parent['content']['pattern']
             hist = self.shell.history_manager.search(pattern, raw=raw,
-                                                     output=output) 
+                                                     output=output, n=n)
 
         else:
             hist = []

--- a/docs/source/development/messaging.txt
+++ b/docs/source/development/messaging.txt
@@ -627,7 +627,7 @@ Message type: ``history_request``::
       'start' : int,
       'stop' : int,
       
-      # If hist_access_type is 'tail', get the last n cells.
+      # If hist_access_type is 'tail' or 'search', get the last n cells.
       'n' : int,
       
       # If hist_access_type is 'search', get cells matching the specified glob


### PR DESCRIPTION
To make `n` to get the new histories, not oldest ones, the default behavior is changed.  Now the order of the result returned by history search is reversed.

I can add another boolean option `desc` to control this behavior but I rather avoid introducing a change in the messaging protocol.  Seeing recent result makes sense most of the time, right?  But if keeping the current result makes sense, I will add the new option.

I will next make this option available for the kernel messaging protocol.
