### PR TITLE
Don't catch ImportError when trying to unpack module functions

### DIFF
--- a/IPython/utils/pickleutil.py
+++ b/IPython/utils/pickleutil.py
@@ -98,12 +98,8 @@ class CannedFunction(CannedObject):
     def get_object(self, g=None):
         # try to load function back into its module:
         if not self.module.startswith('__'):
-            try:
-                __import__(self.module)
-            except ImportError:
-                pass
-            else:
-                g = sys.modules[self.module].__dict__
+            __import__(self.module)
+            g = sys.modules[self.module].__dict__
 
         if g is None:
             g = {}


### PR DESCRIPTION
If the ImportError is encountered, it is more informative to raise it rather than hide it, possibly resulting in confusing NameErrors due to the import failure.
