### PR TITLE
IndentationError display

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1716,7 +1716,7 @@ class InteractiveShell(SingletonConfigurable):
                 self.write_err('No traceback available to show.\n')
                 return
             
-            if etype is SyntaxError:
+            if issubclass(etype, SyntaxError):
                 # Though this won't be called by syntax errors in the input
                 # line, there may be SyntaxError cases with imported code.
                 self.showsyntaxerror(filename)
@@ -1769,7 +1769,7 @@ class InteractiveShell(SingletonConfigurable):
         """
         etype, value, last_traceback = self._get_exc_info()
 
-        if filename and etype is SyntaxError:
+        if filename and issubclass(etype, SyntaxError):
             try:
                 value.filename = filename
             except:

--- a/IPython/core/tests/test_ultratb.py
+++ b/IPython/core/tests/test_ultratb.py
@@ -73,3 +73,23 @@ class NonAsciiTest(unittest.TestCase):
             with tt.AssertPrints("ZeroDivisionError"):
                 with tt.AssertPrints(u'дбИЖ', suppress=False):
                     ip.run_cell('fail()')
+
+indentationerror_file = """if True:
+zoon()
+"""
+
+class IndentationErrorTest(unittest.TestCase):
+    def test_indentationerror_shows_line(self):
+        # See issue gh-2398
+        with tt.AssertPrints("IndentationError"):
+            with tt.AssertPrints("zoon()", suppress=False):
+                ip.run_cell(indentationerror_file)
+        
+        with TemporaryDirectory() as td:
+            fname = os.path.join(td, "foo.py")
+            with open(fname, "w") as f:
+                f.write(indentationerror_file)
+            
+            with tt.AssertPrints("IndentationError"):
+                with tt.AssertPrints("zoon()", suppress=False):
+                    ip.magic('run %s' % fname)

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -552,7 +552,7 @@ class ListTB(TBTools):
             # Not sure if this can still happen in Python 2.6 and above
             list.append( py3compat.cast_unicode(stype) + '\n')
         else:
-            if etype is SyntaxError:
+            if issubclass(etype, SyntaxError):
                 have_filedata = True
                 #print 'filename is',filename  # dbg
                 if not value.filename: value.filename = "<string>"


### PR DESCRIPTION
IndentationError is a subclass of SyntaxError, and they should display in a similar fashion, with the problematic line and line number shown. We were being over-specific with our type checking.

Closes #2398.
