### PR TITLE
The prun and time magics should use input_splitter

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -183,6 +183,7 @@ python-profiler package from non-free.""")
             namespace = self.shell.user_ns
             if cell is not None:
                 arg_str += '\n' + cell
+            arg_str = self.shell.input_splitter.transform_cell(arg_str)
         else:  # called to run a program by %run -p
             try:
                 filename = get_py_filename(arg_lst[0])
@@ -864,7 +865,7 @@ python-profiler package from non-free.""")
 
         # fail immediately if the given expression can't be compiled
 
-        expr = self.shell.prefilter(parameter_s,False)
+        expr = self.shell.input_splitter.transform_cell(parameter_s)
 
         # Minimum time above which compilation time will be reported
         tc_min = 0.1


### PR DESCRIPTION
Right now, either the code is not transformed, or it uses the prefilter (which is deprecated now, right?)
