### PR TITLE
Fix input splitter so that lines after decorators are properly transformed

### DIFF
--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -902,8 +902,8 @@ class IPythonInputSplitter(InputSplitter):
             push = super(IPythonInputSplitter, self).push
             buf = self._buffer
             for line in lines_list:
-                if self._is_complete or not buf or \
-                       (buf and buf[-1].rstrip().endswith((':', ','))):
+                if (self._is_complete or not buf or
+                       buf[-1].rstrip().endswith((':', ',')) or buf[-1].lstrip().startswith('@')):
                     for f in transforms:
                         line = f(line)
 


### PR DESCRIPTION
Before this commit, the "def" line below would not be transformed:

``` python
@interact
def f(n=1):
    print n
```

See http://mail.scipy.org/pipermail/ipython-dev/2012-September/010329.html
