### PR TITLE
Revert #1831, the `__file__` injection in safe_execfile / safe_execfile_ipy.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2455,9 +2455,6 @@ class InteractiveShell(SingletonConfigurable):
         dname = os.path.dirname(fname)
 
         with prepended_to_syspath(dname):
-            # Ensure that __file__ is always defined to match Python behavior
-            save_fname = self.user_ns.get('__file__',None)
-            self.user_ns['__file__'] = fname
             try:
                 py3compat.execfile(fname,*where)
             except SystemExit as status:
@@ -2478,8 +2475,6 @@ class InteractiveShell(SingletonConfigurable):
                 if kw['raise_exceptions']:
                     raise
                 self.showtraceback()
-            finally:
-                self.user_ns['__file__'] = save_fname
 
     def safe_execfile_ipy(self, fname):
         """Like safe_execfile, but for .ipy files with IPython syntax.
@@ -2506,9 +2501,6 @@ class InteractiveShell(SingletonConfigurable):
         dname = os.path.dirname(fname)
 
         with prepended_to_syspath(dname):
-            # Ensure that __file__ is always defined to match Python behavior
-            save_fname = self.user_ns.get('__file__',None)
-            self.user_ns['__file__'] = fname
             try:
                 with open(fname) as thefile:
                     # self.run_cell currently captures all exceptions
@@ -2519,8 +2511,6 @@ class InteractiveShell(SingletonConfigurable):
             except:
                 self.showtraceback()
                 warn('Unknown failure executing file: <%s>' % fname)
-            finally:
-                self.user_ns['__file__'] = save_fname
 
     def safe_run_module(self, mod_name, where):
         """A safe version of runpy.run_module().

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -277,12 +277,20 @@ class InteractiveShellApp(Configurable):
             sys.argv = [ py3compat.cast_bytes(a) for a in sys.argv ]
         try:
             if os.path.isfile(full_filename):
-                self.log.info("Running file in user namespace: %s" % full_filename)
                 if full_filename.endswith('.ipy'):
+                    self.log.info("Running file in user namespace: %s" %
+                                  full_filename)
                     self.shell.safe_execfile_ipy(full_filename)
                 else:
                     # default to python, even without extension
-                    self.shell.safe_execfile(full_filename, self.shell.user_ns)
+                    self.log.info("Running file in user namespace: %s" %
+                                  full_filename)
+                    # Ensure that __file__ is always defined to match Python behavior
+                    self.shell.user_ns['__file__'] = fname
+                    try:
+                        self.shell.safe_execfile(full_filename, self.shell.user_ns)
+                    finally:
+                        del self.shell.user_ns['__file__']
         finally:
             sys.argv = save_argv
 


### PR DESCRIPTION
This reverts commit 2717febad3ccc64ff8f6d212c70cd73d1fb1e1a0, reversing changes made to ea4f608cc27db0de063ed6f40593ec83db171b8c.

Pull request #1831 (fix #1814 set `__file__` when running .ipy files) has been the source of a lot of grief:
- #2279: Setting `__file__` to `None` breaks Mayavi import
- #2429: Using `warnings.warn()` results in `TypeError`

In general the patch was inappropriate because it:
1. Fails to properly restore the context, by setting `__file__` to None rather than deleting it.
2. Sets `__file__` in the wrong dictionary (`self.user_ns` rather than `where[0]`).

I suggest that we revert pull request #1831 and reopen the original issue (#1814).
