### PR TITLE
Add parsing retry for first-line indent-failing copy-pasted code

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2611,13 +2611,20 @@ class InteractiveShell(SingletonConfigurable):
 
                 with self.display_trap:
                     try:
-                        code_ast = self.compile.ast_parse(cell,
-                                                          filename=cell_name)
-                    except IndentationError:
-                        self.showindentationerror()
-                        if store_history:
-                            self.execution_count += 1
-                        return None
+                        try:  # try a few ways of handling indentation errors
+                            code_ast = self.compile.ast_parse(cell,
+                                                            filename=cell_name)
+                        except IndentationError:
+                            #import ipdb; ipdb.set_trace()
+                            indent_safe_cell = 'if True:\n' + cell
+                            try:
+                                code_ast = self.compile.ast_parse(indent_safe_cell,
+                                                            filename=cell_name)
+                            except IndentationError:
+                                self.showindentationerror()
+                                if store_history:
+                                    self.execution_count += 1
+                                return None
                     except (OverflowError, SyntaxError, ValueError, TypeError,
                             MemoryError):
                         self.showsyntaxerror()

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -30,6 +30,7 @@ import sys
 import tempfile
 import types
 import urllib
+import textwrap
 from io import open as io_open
 
 from IPython.config.configurable import SingletonConfigurable
@@ -2582,6 +2583,11 @@ class InteractiveShell(SingletonConfigurable):
             self._current_cell_magic_body = \
                                ''.join(self.input_splitter.cell_magic_parts)
         cell = self.input_splitter.source_reset()
+        
+        # remove common leading whitespace from all lines of the cell,
+        # letting pasted text run without IndentationError's.
+        #   Does this need a try/catch block as well?
+        cell = textwrap.dedent(cell)
 
         with self.builtin_trap:
             prefilter_failed = False
@@ -2611,20 +2617,13 @@ class InteractiveShell(SingletonConfigurable):
 
                 with self.display_trap:
                     try:
-                        try:  # try a few ways of handling indentation errors
-                            code_ast = self.compile.ast_parse(cell,
-                                                            filename=cell_name)
-                        except IndentationError:
-                            #import ipdb; ipdb.set_trace()
-                            indent_safe_cell = 'if True:\n' + cell
-                            try:
-                                code_ast = self.compile.ast_parse(indent_safe_cell,
-                                                            filename=cell_name)
-                            except IndentationError:
-                                self.showindentationerror()
-                                if store_history:
-                                    self.execution_count += 1
-                                return None
+                        code_ast = self.compile.ast_parse(cell,
+                                                          filename=cell_name)
+                    except IndentationError:
+                        self.showindentationerror()
+                        if store_history:
+                            self.execution_count += 1
+                        return None
                     except (OverflowError, SyntaxError, ValueError, TypeError,
                             MemoryError):
                         self.showsyntaxerror()

--- a/IPython/core/tests/test_ultratb.py
+++ b/IPython/core/tests/test_ultratb.py
@@ -99,8 +99,9 @@ indentationerror_file2 = """    class PastedClass:
         foo = 1
         bar = 3
 
-print PastedClass.__name__
-print 'foo is', PastedClass.foo
+from __future__ import print_function
+print(PastedClass.__name__)
+print('foo is', PastedClass.foo)
 """
 
 class IndentationErrorRetryTest(unittest.TestCase):

--- a/IPython/core/tests/test_ultratb.py
+++ b/IPython/core/tests/test_ultratb.py
@@ -93,3 +93,19 @@ class IndentationErrorTest(unittest.TestCase):
             with tt.AssertPrints("IndentationError"):
                 with tt.AssertPrints("zoon()", suppress=False):
                     ip.magic('run %s' % fname)
+
+
+indentationerror_file2 = """    class PastedClass:
+        foo = 1
+        bar = 3
+
+print PastedClass.__name__
+print 'foo is', PastedClass.foo
+"""
+
+class IndentationErrorRetryTest(unittest.TestCase):
+    def test_no_indentationerror_on_pasted_text(self):
+        # See issue gh-995
+        with tt.AssertPrints("PastedClass", suppress=False):
+            with tt.AssertPrints("foo is 1", suppress=False):
+                ip.run_cell(indentationerror_file2)


### PR DESCRIPTION
If the parsing fails with an IndentationError, try to parse one more time by adding an `if True:\n` block before the cell.

Too hacky?  Should close #995, but perhaps a real plugin is preferred?
