### PR TITLE
Py3k: Octal (0777 -> 0o777)

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -181,7 +181,7 @@ class BaseIPythonApplication(Application):
             sys.path.remove(old)
         sys.path.append(os.path.abspath(new))
         if not os.path.isdir(new):
-            os.makedirs(new, mode=0777)
+            os.makedirs(new, mode=0o777)
         readme = os.path.join(new, 'README')
         if not os.path.exists(readme):
             path = os.path.join(get_ipython_package_dir(), u'config', u'profile')

--- a/IPython/core/extensions.py
+++ b/IPython/core/extensions.py
@@ -75,7 +75,7 @@ class ExtensionManager(Configurable):
 
     def _on_ipython_dir_changed(self):
         if not os.path.isdir(self.ipython_extension_dir):
-            os.makedirs(self.ipython_extension_dir, mode = 0777)
+            os.makedirs(self.ipython_extension_dir, mode = 0o777)
 
     def load_extension(self, module_str):
         """Load an IPython extension by its module name.
@@ -138,7 +138,7 @@ class ExtensionManager(Configurable):
         """
         # Ensure the extension directory exists
         if not os.path.isdir(self.ipython_extension_dir):
-            os.makedirs(self.ipython_extension_dir, mode = 0777)
+            os.makedirs(self.ipython_extension_dir, mode = 0o777)
         
         if os.path.isfile(url):
             src_filename = os.path.basename(url)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -501,7 +501,7 @@ class InteractiveShell(SingletonConfigurable):
 
     def _ipython_dir_changed(self, name, new):
         if not os.path.isdir(new):
-            os.makedirs(new, mode = 0777)
+            os.makedirs(new, mode = 0o777)
 
     def set_autoindent(self,value=None):
         """Set the autoindent flag, checking for readline support.

--- a/IPython/core/profiledir.py
+++ b/IPython/core/profiledir.py
@@ -110,10 +110,10 @@ class ProfileDir(LoggingConfigurable):
 
     def check_security_dir(self):
         if not os.path.isdir(self.security_dir):
-            os.mkdir(self.security_dir, 0700)
+            os.mkdir(self.security_dir, 0o700)
         else:
             try:
-                os.chmod(self.security_dir, 0700)
+                os.chmod(self.security_dir, 0o700)
             except OSError:
                 self.log.warn("Could not set security dir permissions to private.")
 
@@ -122,10 +122,10 @@ class ProfileDir(LoggingConfigurable):
 
     def check_pid_dir(self):
         if not os.path.isdir(self.pid_dir):
-            os.mkdir(self.pid_dir, 0700)
+            os.mkdir(self.pid_dir, 0o700)
         else:
             try:
-                os.chmod(self.pid_dir, 0700)
+                os.chmod(self.pid_dir, 0o700)
             except OSError:
                 self.log.warn("Could not set pid dir permissions to private.")
 

--- a/IPython/external/path/_path.py
+++ b/IPython/external/path/_path.py
@@ -860,10 +860,10 @@ class path(unicode):
 
     # --- Create/delete operations on directories
 
-    def mkdir(self, mode=0777):
+    def mkdir(self, mode=0o777):
         os.mkdir(self, mode)
 
-    def makedirs(self, mode=0777):
+    def makedirs(self, mode=0o777):
         os.makedirs(self, mode)
 
     def rmdir(self):
@@ -879,7 +879,7 @@ class path(unicode):
         """ Set the access/modified times of this file to the current time.
         Create the file if it does not exist.
         """
-        fd = os.open(self, os.O_WRONLY | os.O_CREAT, 0666)
+        fd = os.open(self, os.O_WRONLY | os.O_CREAT, 0o666)
         os.close(fd)
         os.utime(self, None)
 


### PR DESCRIPTION
Python 3 uses octal literals of the form `0o...`.  From the [Python 3.0 changelog](http://docs.python.org/release/3.0.1/whatsnew/3.0.html), we see that support for this syntax is already in Python 2.6.

> New octal literals, e.g. 0o720 (already in 2.6). The old octal literals (0720) are gone.
