### PR TITLE
`sys.maxsize` is the maximum length of a container.

### DIFF
--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -1225,7 +1225,7 @@ class List(Container):
     """An instance of a Python list."""
     klass = list
 
-    def __init__(self, trait=None, default_value=None, minlen=0, maxlen=sys.maxint,
+    def __init__(self, trait=None, default_value=None, minlen=0, maxlen=sys.maxsize,
                 allow_none=True, **metadata):
         """Create a List trait type from a list, set, or tuple.
 
@@ -1254,7 +1254,7 @@ class List(Container):
         minlen : Int [ default 0 ]
             The minimum length of the input list
 
-        maxlen : Int [ default sys.maxint ]
+        maxlen : Int [ default sys.maxsize ]
             The maximum length of the input list
 
         allow_none : Bool [ default True ]


### PR DESCRIPTION
From the Python documentation:

> sys.maxsize:
>   The largest positive integer supported by the platform's
>   Py_ssize_t type, and thus the maximum size lists, strings,
>   dicts, and many other containers can have.

From our usage in the traitlet, it's clear that what we really
mean is `sys.maxsize` (not `sys.maxint`). In general
`sys.maxsize >= sys.maxint` so this patch shouldn't have any
actual impact.

I noticed this only because Python 3 has no `sys.maxint` attribute.
This is our only usage of `sys.maxint` which isn't protected by a
`if not PY3` statement.
