### PR TITLE
Apply 2to3 `import` fixer.

### DIFF
--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -23,7 +23,7 @@ Authors:
 import datetime
 from copy import deepcopy
 
-from loader import Config
+from .loader import Config
 from IPython.utils.traitlets import HasTraits, Instance
 from IPython.utils.text import indent, wrap_paragraphs
 

--- a/IPython/external/argparse/__init__.py
+++ b/IPython/external/argparse/__init__.py
@@ -7,5 +7,5 @@ try:
         from argparse import *
         from argparse import SUPPRESS
 except (ImportError, AttributeError):
-    from _argparse import *
-    from _argparse import SUPPRESS
+    from ._argparse import *
+    from ._argparse import SUPPRESS

--- a/IPython/external/decorator/__init__.py
+++ b/IPython/external/decorator/__init__.py
@@ -1,4 +1,4 @@
 try:
     from decorator import *
 except ImportError:
-    from _decorator import *
+    from ._decorator import *

--- a/IPython/external/decorators/__init__.py
+++ b/IPython/external/decorators/__init__.py
@@ -2,8 +2,8 @@ try:
     from numpy.testing.decorators import *
     from numpy.testing.noseclasses import KnownFailure
 except ImportError:
-    from _decorators import *
+    from ._decorators import *
     try:
-        from _numpy_testing_noseclasses import KnownFailure
+        from ._numpy_testing_noseclasses import KnownFailure
     except ImportError:
         pass

--- a/IPython/external/decorators/_decorators.py
+++ b/IPython/external/decorators/_decorators.py
@@ -20,9 +20,9 @@ import warnings
 #from numpy.testing.utils import \
 #        WarningManager, WarningMessage
 # Our version:
-from _numpy_testing_utils import WarningManager
+from ._numpy_testing_utils import WarningManager
 try:
-    from _numpy_testing_noseclasses import KnownFailureTest
+    from ._numpy_testing_noseclasses import KnownFailureTest
 except:
     pass
 

--- a/IPython/external/path/__init__.py
+++ b/IPython/external/path/__init__.py
@@ -1,4 +1,4 @@
 try:
     from path import *
 except ImportError:
-    from _path import *
+    from ._path import *

--- a/IPython/external/pexpect/__init__.py
+++ b/IPython/external/pexpect/__init__.py
@@ -2,4 +2,4 @@ try:
     import pexpect
     from pexpect import *
 except ImportError:
-    from _pexpect import *
+    from ._pexpect import *

--- a/IPython/external/simplegeneric/__init__.py
+++ b/IPython/external/simplegeneric/__init__.py
@@ -1,4 +1,4 @@
 try:
     from simplegeneric import *
 except ImportError:
-    from _simplegeneric import *
+    from ._simplegeneric import *

--- a/IPython/external/ssh/tunnel.py
+++ b/IPython/external/ssh/tunnel.py
@@ -34,7 +34,7 @@ try:
 except ImportError:
     paramiko = None
 else:
-    from forward import forward_tunnel
+    from .forward import forward_tunnel
 
 try:
     from IPython.external import pexpect

--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -21,11 +21,11 @@ from IPython.frontend.qt.rich_text import HtmlExporter
 from IPython.frontend.qt.util import MetaQObjectHasTraits, get_font
 from IPython.utils.text import columnize
 from IPython.utils.traitlets import Bool, Enum, Integer, Unicode
-from ansi_code_processor import QtAnsiCodeProcessor
-from completion_widget import CompletionWidget
-from completion_html import CompletionHtml
-from completion_plain import CompletionPlain
-from kill_ring import QtKillRing
+from .ansi_code_processor import QtAnsiCodeProcessor
+from .completion_widget import CompletionWidget
+from .completion_html import CompletionHtml
+from .completion_plain import CompletionPlain
+from .kill_ring import QtKillRing
 
 
 #-----------------------------------------------------------------------------

--- a/IPython/frontend/qt/console/frontend_widget.py
+++ b/IPython/frontend/qt/console/frontend_widget.py
@@ -16,11 +16,11 @@ from IPython.core.inputsplitter import InputSplitter, transform_classic_prompt
 from IPython.core.oinspect import call_tip
 from IPython.frontend.qt.base_frontend_mixin import BaseFrontendMixin
 from IPython.utils.traitlets import Bool, Instance, Unicode
-from bracket_matcher import BracketMatcher
-from call_tip_widget import CallTipWidget
-from completion_lexer import CompletionLexer
-from history_console_widget import HistoryConsoleWidget
-from pygments_highlighter import PygmentsHighlighter
+from .bracket_matcher import BracketMatcher
+from .call_tip_widget import CallTipWidget
+from .completion_lexer import CompletionLexer
+from .history_console_widget import HistoryConsoleWidget
+from .pygments_highlighter import PygmentsHighlighter
 
 
 class FrontendHighlighter(PygmentsHighlighter):

--- a/IPython/frontend/qt/console/history_console_widget.py
+++ b/IPython/frontend/qt/console/history_console_widget.py
@@ -3,7 +3,7 @@ from IPython.external.qt import QtGui
 
 # Local imports
 from IPython.utils.traitlets import Bool
-from console_widget import ConsoleWidget
+from .console_widget import ConsoleWidget
 
 
 class HistoryConsoleWidget(ConsoleWidget):

--- a/IPython/frontend/qt/console/ipython_widget.py
+++ b/IPython/frontend/qt/console/ipython_widget.py
@@ -22,8 +22,8 @@ from IPython.external.qt import QtCore, QtGui
 from IPython.core.inputsplitter import IPythonInputSplitter, \
     transform_ipy_prompt
 from IPython.utils.traitlets import Bool, Unicode
-from frontend_widget import FrontendWidget
-import styles
+from .frontend_widget import FrontendWidget
+from . import styles
 
 #-----------------------------------------------------------------------------
 # Constants

--- a/IPython/frontend/qt/console/rich_ipython_widget.py
+++ b/IPython/frontend/qt/console/rich_ipython_widget.py
@@ -17,7 +17,7 @@ from IPython.external.qt import QtCore, QtGui
 # Local imports
 from IPython.utils.traitlets import Bool
 from IPython.frontend.qt.svg import save_svg, svg_to_clipboard, svg_to_image
-from ipython_widget import IPythonWidget
+from .ipython_widget import IPythonWidget
 
 
 class RichIPythonWidget(IPythonWidget):

--- a/IPython/frontend/qt/kernelmanager.py
+++ b/IPython/frontend/qt/kernelmanager.py
@@ -8,7 +8,7 @@ from IPython.external.qt import QtCore
 from IPython.utils.traitlets import Type
 from IPython.zmq.kernelmanager import KernelManager, SubSocketChannel, \
     ShellSocketChannel, StdInSocketChannel, HBSocketChannel
-from util import MetaQObjectHasTraits, SuperQObject
+from .util import MetaQObjectHasTraits, SuperQObject
 
 
 class SocketChannelQObject(SuperQObject):

--- a/IPython/parallel/tests/test_client.py
+++ b/IPython/parallel/tests/test_client.py
@@ -30,7 +30,7 @@ from IPython.parallel import error
 from IPython.parallel import AsyncResult, AsyncHubResult
 from IPython.parallel import LoadBalancedView, DirectView
 
-from clienttest import ClusterTestCase, segfault, wait, add_engines
+from .clienttest import ClusterTestCase, segfault, wait, add_engines
 
 def setup():
     add_engines(4, total=True)

--- a/IPython/testing/__init__.py
+++ b/IPython/testing/__init__.py
@@ -21,7 +21,7 @@ def test(all=False):
 
     # Do the import internally, so that this function doesn't increase total
     # import time
-    from iptest import run_iptestall
+    from .iptest import run_iptestall
     run_iptestall(inc_slow=all)
 
 # So nose doesn't try to run this as a test itself and we end up with an

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -60,12 +60,12 @@ from IPython.external.decorator import decorator
 
 # We already have python3-compliant code for parametric tests
 if sys.version[0]=='2':
-    from _paramtestpy2 import parametric, ParametricTestCase
+    from ._paramtestpy2 import parametric, ParametricTestCase
 else:
-    from _paramtestpy3 import parametric, ParametricTestCase
+    from ._paramtestpy3 import parametric, ParametricTestCase
 
 # Expose the unittest-driven decorators
-from ipunittest import ipdoctest, ipdocstring
+from .ipunittest import ipdoctest, ipdocstring
 
 # Grab the numpy-specific decorators which we keep in a file that we
 # occasionally update from upstream: decorators.py is a copy of

--- a/IPython/testing/plugin/iptest.py
+++ b/IPython/testing/plugin/iptest.py
@@ -6,8 +6,8 @@ from nose.core import main
 from nose.plugins.builtin import plugins
 from nose.plugins.doctests import Doctest
 
-import ipdoctest
-from ipdoctest import IPDocTestRunner
+from . import ipdoctest
+from .ipdoctest import IPDocTestRunner
 
 if __name__ == '__main__':
     print 'WARNING: this code is incomplete!'

--- a/IPython/utils/pickleutil.py
+++ b/IPython/utils/pickleutil.py
@@ -30,9 +30,9 @@ try:
 except:
     numpy = None
 
-import codeutil
-import py3compat
-from importstring import import_item
+from . import codeutil
+from . import py3compat
+from .importstring import import_item
 
 from IPython.config import Application
 

--- a/IPython/utils/upgradedir.py
+++ b/IPython/utils/upgradedir.py
@@ -9,7 +9,7 @@ To be used by "upgrade" feature.
 try:
     from IPython.external.path import path
 except ImportError:
-    from path import path
+    from .path import path
 
 import hashlib, pickle
 

--- a/IPython/zmq/completer.py
+++ b/IPython/zmq/completer.py
@@ -12,7 +12,7 @@ except ImportError:
 import rlcompleter
 import time
 
-import session
+from . import session
 
 class KernelCompleter(object):
     """Kernel-side completion machinery."""

--- a/IPython/zmq/displayhook.py
+++ b/IPython/zmq/displayhook.py
@@ -4,7 +4,7 @@ import sys
 from IPython.core.displayhook import DisplayHook
 from IPython.utils.jsonutil import encode_images
 from IPython.utils.traitlets import Instance, Dict
-from session import extract_header, Session
+from .session import extract_header, Session
 
 class ZMQDisplayHook(object):
     """A simple displayhook that publishes the object's repr over a ZeroMQ

--- a/IPython/zmq/entry_point.py
+++ b/IPython/zmq/entry_point.py
@@ -18,7 +18,7 @@ from IPython.utils.localinterfaces import LOCALHOST
 from IPython.utils.py3compat import bytes_to_str
 
 # Local imports.
-from parentpoller import ParentPollerWindows
+from .parentpoller import ParentPollerWindows
 
 def write_connection_file(fname=None, shell_port=0, iopub_port=0, stdin_port=0, hb_port=0,
                          ip=LOCALHOST, key=b'', transport='tcp'):

--- a/IPython/zmq/frontend.py
+++ b/IPython/zmq/frontend.py
@@ -17,8 +17,8 @@ import uuid
 
 # our own
 import zmq
-import session
-import completer
+from . import session
+from . import completer
 from IPython.utils.localinterfaces import LOCALHOST
 from IPython.zmq.session import Message
 

--- a/IPython/zmq/iostream.py
+++ b/IPython/zmq/iostream.py
@@ -2,7 +2,7 @@ import sys
 import time
 from io import StringIO
 
-from session import extract_header, Message
+from .session import extract_header, Message
 
 from IPython.utils import io, text, encoding
 from IPython.utils import py3compat

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -50,11 +50,11 @@ from IPython.utils.traitlets import (
     Any, Instance, Float, Dict, CaselessStrEnum, List, Set, Integer, Unicode
 )
 
-from entry_point import base_launch_kernel
-from kernelapp import KernelApp, kernel_flags, kernel_aliases
-from serialize import serialize_object, unpack_apply_message
-from session import Session, Message
-from zmqshell import ZMQInteractiveShell
+from .entry_point import base_launch_kernel
+from .kernelapp import KernelApp, kernel_flags, kernel_aliases
+from .serialize import serialize_object, unpack_apply_message
+from .session import Session, Message
+from .zmqshell import ZMQInteractiveShell
 
 
 #-----------------------------------------------------------------------------

--- a/IPython/zmq/kernelmanager.py
+++ b/IPython/zmq/kernelmanager.py
@@ -41,7 +41,7 @@ from IPython.utils.traitlets import (
 )
 from IPython.utils.py3compat import str_to_bytes
 from IPython.zmq.entry_point import write_connection_file
-from session import Session
+from .session import Session
 
 #-----------------------------------------------------------------------------
 # Constants and exceptions
@@ -827,7 +827,7 @@ class KernelManager(HasTraits):
         self._launch_args = kw.copy()
         launch_kernel = kw.pop('launcher', None)
         if launch_kernel is None:
-            from ipkernel import launch_kernel
+            from .ipkernel import launch_kernel
         self.kernel = launch_kernel(fname=self.connection_file, **kw)
 
     def shutdown_kernel(self, restart=False):
@@ -954,7 +954,7 @@ class KernelManager(HasTraits):
         """
         if self.has_kernel:
             if sys.platform == 'win32':
-                from parentpoller import ParentPollerWindows as Poller
+                from .parentpoller import ParentPollerWindows as Poller
                 Poller.send_interrupt(self.kernel.win32_interrupt_event)
             else:
                 self.kernel.send_signal(signal.SIGINT)

--- a/IPython/zmq/zmqshell.py
+++ b/IPython/zmq/zmqshell.py
@@ -47,7 +47,7 @@ from IPython.utils.warn import warn, error
 from IPython.zmq.displayhook import ZMQShellDisplayHook
 from IPython.zmq.datapub import ZMQDataPublisher
 from IPython.zmq.session import extract_header
-from session import Session
+from .session import Session
 
 #-----------------------------------------------------------------------------
 # Functions and classes

--- a/setup.py
+++ b/setup.py
@@ -272,6 +272,7 @@ if 'setuptools' in sys.modules:
                 'lib2to3.fixes.fix_apply',
                 'lib2to3.fixes.fix_except',
                 'lib2to3.fixes.fix_has_key',
+                'lib2to3.fixes.fix_import',
                 'lib2to3.fixes.fix_next',
                 'lib2to3.fixes.fix_repr',
                 'lib2to3.fixes.fix_tuple_params',


### PR DESCRIPTION
As a demonstration what patches from #2440 (Python 2 and 3 compatibility) will look like, I've ran the 2to3 `import` fixer which detects relative imports and converts them to the new syntax.

For example, `from loader import Config` -> `from .loader import Config`.

In addition I've added `from __future__ import absolute_import` to every file which contains an import statement.
