### PR TITLE
BF: Add quotes to the command that gets sent to python.

### DIFF
--- a/IPython/parallel/apps/launcher.py
+++ b/IPython/parallel/apps/launcher.py
@@ -74,7 +74,7 @@ WINDOWS = os.name == 'nt'
 # Paths to the kernel apps
 #-----------------------------------------------------------------------------
 
-cmd = "from IPython.parallel.apps.%s import launch_new_instance; launch_new_instance()"
+cmd = '"from IPython.parallel.apps.%s import launch_new_instance; launch_new_instance()"'
 
 ipcluster_cmd_argv = [sys.executable, "-c", cmd % "ipclusterapp"]
 


### PR DESCRIPTION
This was causing a syntax error from the bash shell to be thrown. I am not sure how specific it is to my setup, but this should always work (I think?)
