### PR TITLE
Better handling of `__file__` when running scripts.

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -41,6 +41,7 @@ from IPython.core.magic import (Magics, magics_class, line_magic, cell_magic,
                                 line_cell_magic, on_off, needs_local_scope)
 from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils import py3compat
+from IPython.utils.contexts import preserve_keys
 from IPython.utils.io import capture_output
 from IPython.utils.ipstruct import Struct
 from IPython.utils.module_paths import find_mod
@@ -466,7 +467,9 @@ python-profiler package from non-free.""")
             return
 
         if filename.lower().endswith('.ipy'):
-            self.shell.safe_execfile_ipy(filename)
+            with preserve_keys(self.shell.user_ns, '__file__'):
+                self.shell.user_ns['__file__'] = filename
+                self.shell.safe_execfile_ipy(filename)
             return
 
         # Control the response to exit() calls made by the script being run
@@ -624,7 +627,8 @@ python-profiler package from non-free.""")
                     # worry about a possible KeyError.
                     prog_ns.pop('__name__', None)
 
-                    self.shell.user_ns.update(prog_ns)
+                    with preserve_keys(self.shell.user_ns, '__file__'):
+                        self.shell.user_ns.update(prog_ns)
         finally:
             # It's a bit of a mystery why, but __builtins__ can change from
             # being a module to becoming a dict missing some key data after

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -31,6 +31,7 @@ from IPython.config.configurable import Configurable
 from IPython.config.loader import Config
 from IPython.core import pylabtools
 from IPython.utils import py3compat
+from IPython.utils.contexts import preserve_keys
 from IPython.utils.path import filefind
 from IPython.utils.traitlets import (
     Unicode, Instance, List, Bool, CaselessStrEnum
@@ -277,20 +278,18 @@ class InteractiveShellApp(Configurable):
             sys.argv = [ py3compat.cast_bytes(a) for a in sys.argv ]
         try:
             if os.path.isfile(full_filename):
-                if full_filename.endswith('.ipy'):
-                    self.log.info("Running file in user namespace: %s" %
-                                  full_filename)
-                    self.shell.safe_execfile_ipy(full_filename)
-                else:
-                    # default to python, even without extension
-                    self.log.info("Running file in user namespace: %s" %
-                                  full_filename)
-                    # Ensure that __file__ is always defined to match Python behavior
+                self.log.info("Running file in user namespace: %s" %
+                              full_filename)
+                # Ensure that __file__ is always defined to match Python
+                # behavior.
+                with preserve_keys(self.shell.user_ns, '__file__'):
                     self.shell.user_ns['__file__'] = fname
-                    try:
-                        self.shell.safe_execfile(full_filename, self.shell.user_ns)
-                    finally:
-                        del self.shell.user_ns['__file__']
+                    if full_filename.endswith('.ipy'):
+                        self.shell.safe_execfile_ipy(full_filename)
+                    else:
+                        # default to python, even without extension
+                        self.shell.safe_execfile(full_filename,
+                                                 self.shell.user_ns)
         finally:
             sys.argv = save_argv
 

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -248,3 +248,35 @@ tclass.py: deleting object: C-third
         na = os.path.join(mydir, 'nonascii.py')
         _ip.magic('run "%s"' % na)
         nt.assert_equal(_ip.user_ns['u'], u'Ўт№Ф')
+
+    def test_run_py_file_attribute(self):
+        """Test handling of `__file__` attribute in `%run <file>.py`."""
+        src = "t = __file__\n"
+        self.mktmp(src)
+        _missing = object()
+        file1 = _ip.user_ns.get('__file__', _missing)
+        _ip.magic('run %s' % self.fname)
+        file2 = _ip.user_ns.get('__file__', _missing)
+
+        # Check that __file__ was equal to the filename in the script's
+        # namespace.
+        nt.assert_equal(_ip.user_ns['t'], self.fname)
+
+        # Check that __file__ was not leaked back into user_ns.
+        nt.assert_equal(file1, file2)
+
+    def test_run_ipy_file_attribute(self):
+        """Test handling of `__file__` attribute in `%run <file.ipy>`."""
+        src = "t = __file__\n"
+        self.mktmp(src, ext='.ipy')
+        _missing = object()
+        file1 = _ip.user_ns.get('__file__', _missing)
+        _ip.magic('run %s' % self.fname)
+        file2 = _ip.user_ns.get('__file__', _missing)
+
+        # Check that __file__ was equal to the filename in the script's
+        # namespace.
+        nt.assert_equal(_ip.user_ns['t'], self.fname)
+
+        # Check that __file__ was not leaked back into user_ns.
+        nt.assert_equal(file1, file2)

--- a/IPython/core/tests/test_shellapp.py
+++ b/IPython/core/tests/test_shellapp.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""Tests for shellapp module.
+
+Authors
+-------
+* Bradley Froehle
+"""
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2012  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+import unittest
+
+import nose.tools as nt
+
+from IPython.testing import decorators as dec
+from IPython.testing import tools as tt
+
+class TestFileToRun(unittest.TestCase, tt.TempFileMixin):
+    """Test the behavior of the file_to_run parameter."""
+
+    def test_py_script_file_attribute(self):
+        """Test that `__file__` is set when running `ipython file.py`"""
+        src = "print(__file__)\n"
+        self.mktmp(src)
+
+        if dec.module_not_available('sqlite3'):
+            err = 'WARNING: IPython History requires SQLite, your history will not be saved\n'
+        else:
+            err = None
+        tt.ipexec_validate(self.fname, self.fname, err)
+
+    def test_ipy_script_file_attribute(self):
+        """Test that `__file__` is set when running `ipython file.ipy`"""
+        src = "print(__file__)\n"
+        self.mktmp(src, ext='.ipy')
+
+        if dec.module_not_available('sqlite3'):
+            err = 'WARNING: IPython History requires SQLite, your history will not be saved\n'
+        else:
+            err = None
+        tt.ipexec_validate(self.fname, self.fname, err)
+
+    # Ideally we would also test that `__file__` is not set in the
+    # interactive namespace after running `ipython -i <file>`.

--- a/IPython/utils/contexts.py
+++ b/IPython/utils/contexts.py
@@ -1,0 +1,71 @@
+# encoding: utf-8
+"""
+Context managers for temporarily updating dictionaries.
+
+Authors:
+
+* Bradley Froehle
+"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2012  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------
+
+class preserve_keys(object):
+    """Preserve a set of keys in a dictionary.
+
+    Upon entering the context manager the current values of the keys
+    will be saved. Upon exiting, the dictionary will be updated to
+    restore the original value of the preserved keys. Preserved keys
+    which did not exist when entering the context manager will be
+    deleted.
+
+    Example
+    -------
+
+    >>> d = {'a': 1, 'b': 2, 'c': 3}
+    >>> with preserve_keys(d, 'b', 'c', 'd'):
+    ...     del d['a']
+    ...     del d['b']      # will be reset to 2
+    ...     d['c'] = None   # will be reset to 3
+    ...     d['d'] = 4      # will be deleted
+    ...     d['e'] = 5
+    ...     print(sorted(d.items()))
+    ...
+    [('c', None), ('d', 4), ('e', 5)]
+    >>> print(sorted(d.items()))
+    [('b', 2), ('c', 3), ('e', 5)]
+    """
+
+    def __init__(self, dictionary, *keys):
+        self.dictionary = dictionary
+        self.keys = keys
+
+    def __enter__(self):
+        # Actions to perform upon exiting.
+        to_delete = []
+        to_update = {}
+
+        d = self.dictionary
+        for k in self.keys:
+            if k in d:
+                to_update[k] = d[k]
+            else:
+                to_delete.append(k)
+
+        self.to_delete = to_delete
+        self.to_update = to_update
+
+    def __exit__(self, *exc_info):
+        d = self.dictionary
+
+        for k in self.to_delete:
+            d.pop(k, None)
+        d.update(self.to_update)


### PR DESCRIPTION
This pull request should address the issues raised in #1814:
- Set `__file__` when running `ipython filename.ipy`
- Avoid leaking `__file__` back into the main namespace when using `%run` or when running a script interactively (`ipython -i`).
