### PR TITLE
Track which extensions are loaded

### DIFF
--- a/IPython/core/extensions.py
+++ b/IPython/core/extensions.py
@@ -26,6 +26,9 @@ from urlparse import urlparse
 from IPython.core.error import UsageError
 from IPython.config.configurable import Configurable
 from IPython.utils.traitlets import Instance
+from IPython.utils.py3compat import PY3
+if PY3:
+    from imp import reload
 
 #-----------------------------------------------------------------------------
 # Main class

--- a/IPython/core/extensions.py
+++ b/IPython/core/extensions.py
@@ -87,7 +87,8 @@ class ExtensionManager(Configurable):
         """Load an IPython extension by its module name.
 
         Returns the string "already loaded" if the extension is already loaded,
-        otherwise None.
+        "no load function" if the module doesn't have a load_ipython_extension
+        function, or None if it succeeded.
         """
         if module_str in self.loaded:
             return "already loaded"
@@ -100,6 +101,8 @@ class ExtensionManager(Configurable):
         mod = sys.modules[module_str]
         if self._call_load_ipython_extension(mod):
             self.loaded.add(module_str)
+        else:
+            return "no load function"
 
     def unload_extension(self, module_str):
         """Unload an IPython extension by its module name.

--- a/IPython/core/extensions.py
+++ b/IPython/core/extensions.py
@@ -114,13 +114,15 @@ class ExtensionManager(Configurable):
         """
         from IPython.utils.syspathcontext import prepended_to_syspath
 
-        with prepended_to_syspath(self.ipython_extension_dir):
-            if module_str in sys.modules:
-                mod = sys.modules[module_str]
+        if (module_str in self.loaded) and (module_str in sys.modules):
+            self.unload_extension(module_str)
+            mod = sys.modules[module_str]
+            with prepended_to_syspath(self.ipython_extension_dir):
                 reload(mod)
-                self._call_load_ipython_extension(mod)
-            else:
-                self.load_extension(module_str)
+            if self._call_load_ipython_extension(mod):
+                self.loaded.add(module_str)
+        else:
+            self.load_extension(module_str)
 
     def _call_load_ipython_extension(self, mod):
         if hasattr(mod, 'load_ipython_extension'):

--- a/IPython/core/extensions.py
+++ b/IPython/core/extensions.py
@@ -23,6 +23,7 @@ import sys
 from urllib import urlretrieve
 from urlparse import urlparse
 
+from IPython.core.error import UsageError
 from IPython.config.configurable import Configurable
 from IPython.utils.traitlets import Instance
 
@@ -44,10 +45,11 @@ class ExtensionManager(Configurable):
     the only argument.  You can do anything you want with IPython at
     that point, including defining new magic and aliases, adding new
     components, etc.
-
-    The :func:`load_ipython_extension` will be called again is you
-    load or reload the extension again.  It is up to the extension
-    author to add code to manage that.
+    
+    You can also optionaly define an :func:`unload_ipython_extension(ipython)`
+    function, which will be called if the user unloads or reloads the extension.
+    The extension manager will only call :func:`load_ipython_extension` again
+    if the extension is reloaded.
 
     You can put your extension modules anywhere you want, as long as
     they can be imported by Python's standard import mechanism.  However,
@@ -81,9 +83,12 @@ class ExtensionManager(Configurable):
     def load_extension(self, module_str):
         """Load an IPython extension by its module name.
 
-        If :func:`load_ipython_extension` returns anything, this function
-        will return that object.
+        Returns the string "already loaded" if the extension is already loaded,
+        otherwise None.
         """
+        if module_str in self.loaded:
+            return "already loaded"
+        
         from IPython.utils.syspathcontext import prepended_to_syspath
 
         if module_str not in sys.modules:
@@ -98,11 +103,20 @@ class ExtensionManager(Configurable):
 
         This function looks up the extension's name in ``sys.modules`` and
         simply calls ``mod.unload_ipython_extension(self)``.
+        
+        Returns the string "no unload function" if the extension doesn't define
+        a function to unload itself, "not loaded" if the extension isn't loaded,
+        otherwise None.
         """
+        if module_str not in self.loaded:
+            return "not loaded"
+        
         if module_str in sys.modules:
             mod = sys.modules[module_str]
             if self._call_unload_ipython_extension(mod):
                 self.loaded.discard(module_str)
+            else:
+                return "no unload function"
 
     def reload_extension(self, module_str):
         """Reload an IPython extension by calling reload.

--- a/IPython/core/magics/extension.py
+++ b/IPython/core/magics/extension.py
@@ -59,9 +59,13 @@ class ExtensionMagics(Magics):
         """Load an IPython extension by its module name."""
         if not module_str:
             raise UsageError('Missing module name.')
-        if self.shell.extension_manager.load_extension(module_str) == 'already loaded':
+        res = self.shell.extension_manager.load_extension(module_str)
+        
+        if res == 'already loaded':
             print "The %s extension is already loaded. To reload it, use:" % module_str
             print "  %reload_ext", module_str
+        elif res == 'no load function':
+            print "The %s module is not an IPython extension." % module_str
 
     @line_magic
     def unload_ext(self, module_str):

--- a/IPython/core/magics/extension.py
+++ b/IPython/core/magics/extension.py
@@ -59,7 +59,7 @@ class ExtensionMagics(Magics):
         """Load an IPython extension by its module name."""
         if not module_str:
             raise UsageError('Missing module name.')
-        return self.shell.extension_manager.load_extension(module_str)
+        self.shell.extension_manager.load_extension(module_str)
 
     @line_magic
     def unload_ext(self, module_str):

--- a/IPython/core/magics/extension.py
+++ b/IPython/core/magics/extension.py
@@ -59,14 +59,26 @@ class ExtensionMagics(Magics):
         """Load an IPython extension by its module name."""
         if not module_str:
             raise UsageError('Missing module name.')
-        self.shell.extension_manager.load_extension(module_str)
+        if self.shell.extension_manager.load_extension(module_str) == 'already loaded':
+            print "The %s extension is already loaded. To reload it, use:" % module_str
+            print "  %reload_ext", module_str
 
     @line_magic
     def unload_ext(self, module_str):
-        """Unload an IPython extension by its module name."""
+        """Unload an IPython extension by its module name.
+        
+        Not all extensions can be unloaded, only those which define an
+        ``unload_ipython_extension`` function.
+        """
         if not module_str:
             raise UsageError('Missing module name.')
-        self.shell.extension_manager.unload_extension(module_str)
+        
+        res = self.shell.extension_manager.unload_extension(module_str)
+        
+        if res == 'no unload function':
+            print "The %s extension doesn't define how to unload it." % module_str
+        elif res == "not loaded":
+            print "The %s extension is not loaded." % module_str
 
     @line_magic
     def reload_ext(self, module_str):

--- a/IPython/core/tests/test_extension.py
+++ b/IPython/core/tests/test_extension.py
@@ -1,0 +1,69 @@
+import os.path
+
+import nose.tools as nt
+
+import IPython.testing.tools as tt
+from IPython.utils.syspathcontext import prepended_to_syspath
+from IPython.utils.tempdir import TemporaryDirectory
+
+ext1_content = """
+def load_ipython_extension(ip):
+    print("Running ext1 load")
+
+def unload_ipython_extension(ip):
+    print("Running ext1 unload")
+"""
+
+ext2_content = """
+def load_ipython_extension(ip):
+    print("Running ext2 load")
+"""
+
+def test_extension_loading():
+    em = get_ipython().extension_manager
+    with TemporaryDirectory() as td:
+        ext1 = os.path.join(td, 'ext1.py')
+        with open(ext1, 'w') as f:
+            f.write(ext1_content)
+        
+        ext2 = os.path.join(td, 'ext2.py')
+        with open(ext2, 'w') as f:
+            f.write(ext2_content)
+        
+        with prepended_to_syspath(td):
+            assert 'ext1' not in em.loaded
+            assert 'ext2' not in em.loaded
+            
+            # Load extension
+            with tt.AssertPrints("Running ext1 load"):
+                assert em.load_extension('ext1') is None
+            assert 'ext1' in em.loaded
+            
+            # Should refuse to load it again
+            with tt.AssertNotPrints("Running ext1 load"):
+                assert em.load_extension('ext1') == 'already loaded'
+            
+            # Reload
+            with tt.AssertPrints("Running ext1 unload"):
+                with tt.AssertPrints("Running ext1 load", suppress=False):
+                    em.reload_extension('ext1')
+            
+            # Unload
+            with tt.AssertPrints("Running ext1 unload"):
+                assert em.unload_extension('ext1') is None
+            
+            # Can't unload again
+            with tt.AssertNotPrints("Running ext1 unload"):
+                assert em.unload_extension('ext1') == 'not loaded'
+            assert em.unload_extension('ext2') == 'not loaded'
+            
+            # Load extension 2
+            with tt.AssertPrints("Running ext2 load"):
+                assert em.load_extension('ext2') is None
+            
+            # Can't unload this
+            assert em.unload_extension('ext2') == 'no unload function'
+            
+            # But can reload it
+            with tt.AssertPrints("Running ext2 load"):
+                em.reload_extension('ext2')

--- a/IPython/core/tests/test_extension.py
+++ b/IPython/core/tests/test_extension.py
@@ -67,3 +67,7 @@ def test_extension_loading():
             # But can reload it
             with tt.AssertPrints("Running ext2 load"):
                 em.reload_extension('ext2')
+
+def test_non_extension():
+    em = get_ipython().extension_manager
+    nt.assert_equal(em.load_extension('sys'), "no load function")

--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -516,7 +516,6 @@ class AutoreloadMagics(Magics):
 
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
-    if 'autoreload' not in ip.extension_manager.loaded:
-        auto_reload = AutoreloadMagics(ip)
-        ip.register_magics(auto_reload)
-        ip.set_hook('pre_run_code_hook', auto_reload.pre_run_code_hook)
+    auto_reload = AutoreloadMagics(ip)
+    ip.register_magics(auto_reload)
+    ip.set_hook('pre_run_code_hook', auto_reload.pre_run_code_hook)

--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -514,14 +514,9 @@ class AutoreloadMagics(Magics):
             pass
 
 
-_loaded = False
-
-
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
-    global _loaded
-    if not _loaded:
+    if 'autoreload' not in ip.extension_manager.loaded:
         auto_reload = AutoreloadMagics(ip)
         ip.register_magics(auto_reload)
         ip.set_hook('pre_run_code_hook', auto_reload.pre_run_code_hook)
-        _loaded = True

--- a/IPython/extensions/cythonmagic.py
+++ b/IPython/extensions/cythonmagic.py
@@ -273,11 +273,8 @@ class CythonMagics(Magics):
         html = '\n'.join(l for l in html.splitlines() if not r.match(l))
         return html
 
-_loaded = False
 
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
-    global _loaded
-    if not _loaded:
+    if 'cythonmagic' not in ip.extension_manager.loaded:
         ip.register_magics(CythonMagics)
-        _loaded = True

--- a/IPython/extensions/cythonmagic.py
+++ b/IPython/extensions/cythonmagic.py
@@ -276,5 +276,4 @@ class CythonMagics(Magics):
 
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
-    if 'cythonmagic' not in ip.extension_manager.loaded:
-        ip.register_magics(CythonMagics)
+    ip.register_magics(CythonMagics)

--- a/IPython/extensions/octavemagic.py
+++ b/IPython/extensions/octavemagic.py
@@ -364,5 +364,4 @@ __doc__ = __doc__.format(
 
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
-    if 'octavemagic' not in ip.extension_manager.loaded:
-        ip.register_magics(OctaveMagics)
+    ip.register_magics(OctaveMagics)

--- a/IPython/extensions/octavemagic.py
+++ b/IPython/extensions/octavemagic.py
@@ -362,10 +362,7 @@ __doc__ = __doc__.format(
     )
 
 
-_loaded = False
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
-    global _loaded
-    if not _loaded:
+    if 'octavemagic' not in ip.extension_manager.loaded:
         ip.register_magics(OctaveMagics)
-        _loaded = True

--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -590,5 +590,4 @@ __doc__ = __doc__.format(
 
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
-    if 'rmagic' not in ip.extension_manager.loaded:
-        ip.register_magics(RMagics)
+    ip.register_magics(RMagics)

--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -588,10 +588,7 @@ __doc__ = __doc__.format(
 )
 
 
-_loaded = False
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
-    global _loaded
-    if not _loaded:
+    if 'rmagic' not in ip.extension_manager.loaded:
         ip.register_magics(RMagics)
-        _loaded = True

--- a/IPython/extensions/storemagic.py
+++ b/IPython/extensions/storemagic.py
@@ -209,12 +209,7 @@ class StoreMagics(Magics):
                 print "Stored '%s' (%s)" % (args[0], obj.__class__.__name__)
 
 
-_loaded = False
-
-
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
-    global _loaded
-    if not _loaded:
+    if 'storemagic' not in ip.extension_manager.loaded:
         ip.register_magics(StoreMagics)
-        _loaded = True

--- a/IPython/extensions/storemagic.py
+++ b/IPython/extensions/storemagic.py
@@ -211,5 +211,4 @@ class StoreMagics(Magics):
 
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
-    if 'storemagic' not in ip.extension_manager.loaded:
-        ip.register_magics(StoreMagics)
+    ip.register_magics(StoreMagics)


### PR DESCRIPTION
As discussed on the mailing list, extensions should track whether they are loaded per-shell, not per-process. For now, this still leaves it up to extensions what they do if the same shell attempts to load them a second time.

We could easily adjust that so that the shell will only load them once. If you try `%load_ext` with an already loaded extension, there are several possible behaviours we could implement:
- It tells the user "The 'foo' extension is already loaded. To reload it, use %reload_ext foo".
- It reloads the extension, with or without saying anything. We could optionally remove `%reload_ext` in this case.

There could also be a flag to force loading an extension, but it's not clear how this would differ from the current `%reload_ext`.

Update: This now also tries to call `unload_ipython_extension()` before it reloads a module, so it should be possible to avoid any problems from loading things twice.
