### PR TITLE
Locate URLs in text output and convert them to hyperlinks.

### DIFF
--- a/IPython/frontend/html/notebook/static/js/outputarea.js
+++ b/IPython/frontend/html/notebook/static/js/outputarea.js
@@ -379,8 +379,10 @@ var IPython = (function (IPython) {
     OutputArea.prototype.append_text = function (data, element, extra_class) {
         var toinsert = $("<div/>").addClass("box-flex1 output_subarea output_text");
         // escape ANSI & HTML specials in plaintext:
+        data = utils.wrapUrls(data);
         data = utils.fixConsole(data);
         data = utils.fixCarriageReturn(data);
+        data = utils.autoLinkUrls(data);
         if (extra_class){
             toinsert.addClass(extra_class);
         }

--- a/IPython/frontend/html/notebook/static/js/utils.js
+++ b/IPython/frontend/html/notebook/static/js/utils.js
@@ -83,6 +83,24 @@ IPython.utils = (function (IPython) {
         return txt;
     }
 
+    // Locate URLs in plain text and wrap them in spaces so that they can be
+    // better picked out by autoLinkUrls even after the text has been
+    // converted to HTML
+    function wrapUrls(txt) {
+        // Note this regexp is a modified version of one from
+        // Markdown.Converter For now it only supports http(s) and ftp URLs,
+        // but could easily support others (though file:// should maybe be
+        // avoided)
+        var url_re = /(^|\W)(https?|ftp)(:\/\/[-A-Z0-9+&@#\/%?=~_|\[\]\(\)!:,\.;]*[-A-Z0-9+&@#\/%=~_|\[\]])($|\W)/gi;
+        return txt.replace(url_re, "$1 $2$3 $4");
+    }
+
+    // Locate a URL with spaces around it and convert that to a anchor tag
+    function autoLinkUrls(txt) {
+        return txt.replace(/ ((https?|ftp):[^'">\s]+) /gi,
+            "<a target=\"_blank\" href=\"$1\">$1</a>");
+    }
+
     grow = function(element) {
         // Grow the cell by hand. This is used upon reloading from JSON, when the
         // autogrow handler is not called.
@@ -143,6 +161,8 @@ IPython.utils = (function (IPython) {
         keycodes : keycodes,
         grow : grow,
         fixCarriageReturn : fixCarriageReturn,
+        wrapUrls : wrapUrls,
+        autoLinkUrls : autoLinkUrls,
         points_to_pixels : points_to_pixels
     };
 


### PR DESCRIPTION
The subject of this PR came up in a discussion on the Astropy mailing list, in which we were discussing including URLs to help pages in some exception messages.  The question came up as to how different terminals handle URLs, and which ones render them as hyperlinks.

The question also came up in the context of IPython Notebook. I knew that Markdown cells already detect and render URLs, but that is not true for the output from normal code cells, so this fixes that.  Is there any good reason _not_ to do this?  I've tried several cases and this seems to work pretty well.
