### PR TITLE
Clickable links

### DIFF
--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -434,6 +434,16 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
                 obj == self._page_control:
             self._page_control.repaint()
             return True
+
+        elif etype == QtCore.QEvent.MouseMove:
+            anchor = self._control.anchorAt(event.pos())
+            if len(anchor) == 0:
+                self._anchor = None
+                QtGui.QToolTip.hideText()
+            elif anchor != self._anchor:
+                self._anchor = anchor
+                QtGui.QToolTip.showText(event.globalPos(), self._anchor)
+
         return super(ConsoleWidget, self).eventFilter(obj, event)
 
     #---------------------------------------------------------------------------
@@ -1031,7 +1041,6 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
             control = QtGui.QTextEdit()
             control.setAcceptRichText(False)
             control.setMouseTracking(True)
-            control.mouseMoveEvent = self.mouseMoveEvent
 
         # Install event filters. The filter on the viewport is needed for
         # mouse events and drag events.
@@ -1735,18 +1744,6 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
             self._clear_temporary_buffer()
         else:
             self.input_buffer = ''
-
-    def mouseMoveEvent(self, event):
-        """ Show tooltip if the mouse is hovering over an anchor
-        """
-        pos = event.pos()
-        anchor = self._control.anchorAt(pos)
-        if len(anchor) == 0:
-            self._anchor = None
-            QtGui.QToolTip.hideText()
-        elif anchor != self._anchor:
-            self._anchor = anchor
-            QtGui.QToolTip.showText(pos, self._anchor)
 
     def _page(self, text, html=False):
         """ Displays text using the pager if it exceeds the height of the

--- a/IPython/frontend/qt/console/console_widget.py
+++ b/IPython/frontend/qt/console/console_widget.py
@@ -265,7 +265,6 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
         elif self.gui_completion == 'plain':
             self._completion_widget = CompletionPlain(self)
 
-        self._anchor = None
         self._continuation_prompt = '> '
         self._continuation_prompt_html = None
         self._executing = False
@@ -437,12 +436,7 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
 
         elif etype == QtCore.QEvent.MouseMove:
             anchor = self._control.anchorAt(event.pos())
-            if len(anchor) == 0:
-                self._anchor = None
-                QtGui.QToolTip.hideText()
-            elif anchor != self._anchor:
-                self._anchor = anchor
-                QtGui.QToolTip.showText(event.globalPos(), self._anchor)
+            QtGui.QToolTip.showText(event.globalPos(), anchor)
 
         return super(ConsoleWidget, self).eventFilter(obj, event)
 
@@ -523,11 +517,10 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
         """
         self.layout().currentWidget().copy()
 
-    def copy_anchor(self):
+    def copy_anchor(self, anchor):
         """ Copy anchor text to the clipboard
         """
-        if self._anchor:
-            QtGui.QApplication.clipboard().setText(self._anchor)
+        QtGui.QApplication.clipboard().setText(anchor)
 
     def cut(self):
         """ Copy the currently selected text to the clipboard and delete it
@@ -696,11 +689,10 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
 
     font = property(_get_font, _set_font)
 
-    def open_anchor(self):
+    def open_anchor(self, anchor):
         """ Open selected anchor in the default webbrowser
         """
-        if self._anchor:
-            webbrowser.open( self._anchor )
+        webbrowser.open( anchor )
 
     def paste(self, mode=QtGui.QClipboard.Clipboard):
         """ Paste the contents of the clipboard into the input region.
@@ -995,12 +987,13 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
         self.paste_action.setEnabled(self.can_paste())
         self.paste_action.setShortcut(QtGui.QKeySequence.Paste)
 
-        if self._anchor:
+        anchor = self._control.anchorAt(pos)
+        if anchor:
             menu.addSeparator()
-            self.copy_link_action = menu.addAction('Copy Link Address',
-                                                   self.copy_anchor)
-            self.open_link_action = menu.addAction('Open Link',
-                                                   self.open_anchor)
+            self.copy_link_action = menu.addAction(
+                'Copy Link Address', lambda: self.copy_anchor(anchor=anchor))
+            self.open_link_action = menu.addAction(
+                'Open Link', lambda: self.open_anchor(anchor=anchor))
 
         menu.addSeparator()
         menu.addAction(self.select_all_action)

--- a/IPython/frontend/qt/console/tests/test_console_widget.py
+++ b/IPython/frontend/qt/console/tests/test_console_widget.py
@@ -42,21 +42,32 @@ class TestConsoleWidget(unittest.TestCase):
             cursor.insertText('')
 
     def test_link_handling(self):
-        class event(object):
-            def __init__(self, pos):
-                self._pos = pos
-            def pos(self):
-                return self._pos
-            
+        noKeys = QtCore.Qt
+        noButton = QtCore.Qt.MouseButton(0)
+        noButtons = QtCore.Qt.MouseButtons(0)
+        noModifiers = QtCore.Qt.KeyboardModifiers(0)
+        MouseMove = QtCore.QEvent.MouseMove
+        QMouseEvent = QtGui.QMouseEvent
+        
         w = ConsoleWidget()
         cursor = w._get_prompt_cursor()
         w._insert_html(cursor, '<a href="http://python.org">written in</a>')
+        obj = w._control
         self.assertEqual(w._anchor, None)
+        
         # should be over text
-        w.mouseMoveEvent(event(QtCore.QPoint(1,5)))
+        overTextEvent = QMouseEvent(MouseMove, QtCore.QPoint(1,5),
+                                    noButton, noButtons, noModifiers)
+        w.eventFilter(obj, overTextEvent)
         self.assertEqual(w._anchor, "http://python.org")
+        
         # should still be over text
-        w.mouseMoveEvent(event(QtCore.QPoint(5,5)))
+        stillOverTextEvent = QMouseEvent(MouseMove, QtCore.QPoint(1,5),
+                                         noButton, noButtons, noModifiers)
+        w.eventFilter(obj, stillOverTextEvent)
+        
         # should be somewhere else
-        w.mouseMoveEvent(event(QtCore.QPoint(50,50)))
+        elsewhereEvent = QMouseEvent(MouseMove, QtCore.QPoint(50,50),
+                                         noButton, noButtons, noModifiers)
+        w.eventFilter(obj, elsewhereEvent)
         self.assertEqual(w._anchor, None)

--- a/IPython/frontend/qt/console/tests/test_console_widget.py
+++ b/IPython/frontend/qt/console/tests/test_console_widget.py
@@ -53,21 +53,28 @@ class TestConsoleWidget(unittest.TestCase):
         cursor = w._get_prompt_cursor()
         w._insert_html(cursor, '<a href="http://python.org">written in</a>')
         obj = w._control
-        self.assertEqual(w._anchor, None)
+        tip = QtGui.QToolTip
+        self.assertEqual(tip.text(), u'')
         
+        # should be somewhere else
+        elsewhereEvent = QMouseEvent(MouseMove, QtCore.QPoint(50,50),
+                                     noButton, noButtons, noModifiers)
+        w.eventFilter(obj, elsewhereEvent)
+        self.assertEqual(tip.isVisible(), False)
+        self.assertEqual(tip.text(), u'')
+        
+        #self.assertEqual(tip.text(), u'')
         # should be over text
         overTextEvent = QMouseEvent(MouseMove, QtCore.QPoint(1,5),
                                     noButton, noButtons, noModifiers)
         w.eventFilter(obj, overTextEvent)
-        self.assertEqual(w._anchor, "http://python.org")
+        self.assertEqual(tip.isVisible(), True)
+        self.assertEqual(tip.text(), "http://python.org")
         
         # should still be over text
         stillOverTextEvent = QMouseEvent(MouseMove, QtCore.QPoint(1,5),
                                          noButton, noButtons, noModifiers)
         w.eventFilter(obj, stillOverTextEvent)
+        self.assertEqual(tip.isVisible(), True)
+        self.assertEqual(tip.text(), "http://python.org")
         
-        # should be somewhere else
-        elsewhereEvent = QMouseEvent(MouseMove, QtCore.QPoint(50,50),
-                                         noButton, noButtons, noModifiers)
-        w.eventFilter(obj, elsewhereEvent)
-        self.assertEqual(w._anchor, None)

--- a/IPython/frontend/qt/console/tests/test_console_widget.py
+++ b/IPython/frontend/qt/console/tests/test_console_widget.py
@@ -2,7 +2,7 @@
 import unittest
 
 # System library imports
-from IPython.external.qt import QtGui
+from IPython.external.qt import QtCore, QtGui
 
 # Local imports
 from IPython.frontend.qt.console.console_widget import ConsoleWidget
@@ -40,3 +40,23 @@ class TestConsoleWidget(unittest.TestCase):
             self.assertEqual(expected_outputs[i], selection)
             # clear all the text
             cursor.insertText('')
+
+    def test_link_handling(self):
+        class event(object):
+            def __init__(self, pos):
+                self._pos = pos
+            def pos(self):
+                return self._pos
+            
+        w = ConsoleWidget()
+        cursor = w._get_prompt_cursor()
+        w._insert_html(cursor, '<a href="http://python.org">written in</a>')
+        self.assertEqual(w._anchor, None)
+        # should be over text
+        w.mouseMoveEvent(event(QtCore.QPoint(1,5)))
+        self.assertEqual(w._anchor, "http://python.org")
+        # should still be over text
+        w.mouseMoveEvent(event(QtCore.QPoint(5,5)))
+        # should be somewhere else
+        w.mouseMoveEvent(event(QtCore.QPoint(50,50)))
+        self.assertEqual(w._anchor, None)


### PR DESCRIPTION
This implements a mechanism for selecting hyperlinks in the rich text editor. 

It's using QtGui.QTextEdit's anchorAt to determine the existence of a link, so links that are printed without being wrapped in <a href></a> aren't going to be detected.

The implementation conditionally adds "Open Link" and "Copy Link Anchor" as inspired by gnome-terminal. (I didn't spend very much time thinking about the order of menu options)

A typical browser security feature is  to show the user the target of a link before they can actually select it, I implemented that by adding a tooltop when the mouse hovers over an anchor.

That was implemented by turning on mouseMoveEvent messages on the rich QTextEdit controland checking to see if an anchor is under the current mouse position. If it is and its a different anchor than what we're currently displaying (or not displaying) it'll pop up the tooltip. 

The advantage to storing the displayed anchor in ConsoleWidget._anchor allows me to be sure that the thing the user is opening was displayed to to them, and to prevent the tooltip from constantly getting redrawn as you move the mouse around the link.

The plain text control QPlainTextEdit does have the anchorAt method, but I was imagining lacked any way to receive html text so I didn't bother turning on the mouse move tracking for it.
