### PR TITLE
Tell git to ignore __pycache__ directories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ docs/source/api/generated
 docs/gh-pages
 IPython/frontend/html/notebook/static/mathjax
 *.py[co]
+__pycache__
 build
 *.egg-info
 *~


### PR DESCRIPTION
Running `python3.3 setup.py build` creates several `__pycache__` directories which should not accidentally end up in the Git repository.
