### PR TITLE
Treat __init__.pyc same as __init__.py in module_list

### DIFF
--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 
 # Stdlib imports
 import glob
+import imp
 import inspect
 import os
 import re
@@ -90,7 +91,8 @@ def module_list(path):
 
     # Now find actual path matches for packages or modules
     folder_list = [p for p in folder_list
-                   if isfile(pjoin(path, p,'__init__.py'))
+                   if any(isfile(pjoin(path, p, '__init__' + suffix[0])) for
+                       suffix in imp.get_suffixes())
                    or is_importable_file(p) ]
 
     return [basename(p).split('.')[0] for p in folder_list]

--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -91,6 +91,7 @@ def module_list(path):
     # Now find actual path matches for packages or modules
     folder_list = [p for p in folder_list
                    if isfile(pjoin(path, p,'__init__.py'))
+                   or isfile(pjoin(path, p, '__init__.pyc'))
                    or is_importable_file(p) ]
 
     return [basename(p).split('.')[0] for p in folder_list]


### PR DESCRIPTION
There are some circumstances where packages on disk could only have a .pyc
version of `__init__.py`. It would be nice if ipython would autocomplete them as
well. I've been using this in a production environment for several weeks now.

Test plan:

```
mkdir avtest; touch avtest/__init__.pyc
./ipython.py
from avt<tab>
```

autocomplete worked. Also tested with `__init__.py` to verify no regression.
