### PR TITLE
fix bootstrap name conflicts

### DIFF
--- a/IPython/frontend/html/notebook/static/css/page.css
+++ b/IPython/frontend/html/notebook/static/css/page.css
@@ -33,7 +33,7 @@ span#ipython_notebook {
     padding: 2px 2px 2px 5px;
 }
 
-span#ipython_notebook h1 img {
+span#ipython_notebook img {
     font-family: Verdana, "Helvetica Neue", Arial, Helvetica, Geneva, sans-serif;
     height: 24px;
     text-decoration:none;

--- a/IPython/frontend/html/notebook/static/css/tooltip.css
+++ b/IPython/frontend/html/notebook/static/css/tooltip.css
@@ -44,7 +44,7 @@
     opacity: 1;
   }
 }
-.tooltip a {
+.ipython_tooltip a {
   float: right;
 }
 /*properties of tooltip after "expand"*/
@@ -81,7 +81,7 @@
 
   padding-right: 30px;
 }
-.tooltip {
+.ipython_tooltip {
   max-width: 700px;
   border-radius: 4px;
   -moz-box-shadow: 0px 6px 10px -1px #adadad;

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -172,7 +172,7 @@ data-notebook-id={{notebook_id}}
     </div>
 
 </div>
-<div id='tooltip' class='tooltip ui-corner-all' style='display:none'></div>
+<div id='tooltip' class='ipython_tooltip ui-corner-all' style='display:none'></div>
 
 
 {% end %}

--- a/IPython/frontend/html/notebook/templates/page.html
+++ b/IPython/frontend/html/notebook/templates/page.html
@@ -23,7 +23,7 @@
 <body {% block params %}{% end %}>
 
 <div id="header">
-    <span id="ipython_notebook"><h1><a href={{base_project_url}} alt='dashboard'><img src='{{static_url("ipynblogo.png") }}' alt='IPython Notebook'/></a></h1></span>
+    <span id="ipython_notebook"><div><a href={{base_project_url}} alt='dashboard'><img src='{{static_url("ipynblogo.png") }}' alt='IPython Notebook'/></a></div></span>
 
     {% block login_widget %}
 


### PR DESCRIPTION
Change .tooltip to .ipython_tooltip
class name in css to avoid conflic with bootstrap

Don't put header logo in h1 to also avoid conflict.

Pinging @ellisonbg as he might be interested. 
