### PR TITLE
allow %edit <variable> to work when interactively defined

### DIFF
--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -282,7 +282,7 @@ class CodeMagics(Magics):
                     if filename is None:
                         warn("Argument given (%s) can't be found as a variable "
                              "or as a filename." % args)
-                        return
+                        return (None, None, None)
                     use_temp = False
 
                 except DataIsObject:
@@ -318,7 +318,9 @@ class CodeMagics(Magics):
                     if filename is None:
                         filename = make_filename(args)
                         datafile = 1
-                        warn('Could not find file where `%s` is defined.\n'
+                        if filename is not None:
+                            # only warn about this if we get a real name
+                            warn('Could not find file where `%s` is defined.\n'
                              'Opening a file named `%s`' % (args, filename))
                     # Now, make sure we can actually read the source (if it was
                     # in a temp file it's gone by now).
@@ -328,9 +330,9 @@ class CodeMagics(Magics):
                         if lineno is None:
                             filename = make_filename(args)
                             if filename is None:
-                                warn('The file `%s` where `%s` was defined '
-                                     'cannot be read.' % (filename, data))
-                                return
+                                warn('The file where `%s` was defined '
+                                     'cannot be read or found.' % data)
+                                return (None, None, None)
                     use_temp = False
 
         if use_temp:
@@ -508,6 +510,10 @@ class CodeMagics(Magics):
             args = str(e.index)
             filename, lineno, is_temp = self._find_edit_target(self.shell, 
                                                        args, opts, last_call)
+        if filename is None:
+            # nothing was found, warnings have already been issued,
+            # just give up.
+            return
 
         # do actual editing here
         print 'Editing...',

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -326,6 +326,8 @@ def find_source_lines(obj):
             # For instances, try the class object like getsource() does
             if hasattr(obj, '__class__'):
                 lineno = inspect.getsourcelines(obj.__class__)[1]
+            else:
+                lineno = None
     except:
         return None
 

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -296,7 +296,7 @@ def find_file(obj):
                 pass
     except:
         pass
-    return fname
+    return cast_unicode(fname)
 
 
 def find_source_lines(obj):


### PR DESCRIPTION
fixes `%edit foo` for interactively defined variables

Effectively handles cases such as:

```
In [1]: def foo(): return 5
In [2]: %edit foo
```

Where `%edit foo` turns into `%edit 1` by parsing the `<ipython-input-NN-…>` fake filename.
