### PR TITLE
use new _winapi instead of removed _subprocess

### DIFF
--- a/IPython/zmq/entry_point.py
+++ b/IPython/zmq/entry_point.py
@@ -189,8 +189,12 @@ def base_launch_kernel(code, fname, stdin=None, stdout=None, stderr=None,
                          creationflags=512, # CREATE_NEW_PROCESS_GROUP
                          stdin=_stdin, stdout=_stdout, stderr=_stderr)
         else:
-            from _subprocess import DuplicateHandle, GetCurrentProcess, \
-                DUPLICATE_SAME_ACCESS
+            try:
+                from _winapi import DuplicateHandle, GetCurrentProcess, \
+                    DUPLICATE_SAME_ACCESS
+            except:
+                from _subprocess import DuplicateHandle, GetCurrentProcess, \
+                    DUPLICATE_SAME_ACCESS
             pid = GetCurrentProcess()
             handle = DuplicateHandle(pid, pid, pid, 0,
                                      True, # Inheritable by new processes.

--- a/IPython/zmq/parentpoller.py
+++ b/IPython/zmq/parentpoller.py
@@ -100,7 +100,10 @@ class ParentPollerWindows(Thread):
     def run(self):
         """ Run the poll loop. This method never returns.
         """
-        from _subprocess import WAIT_OBJECT_0, INFINITE
+        try:
+            from _winapi import WAIT_OBJECT_0, INFINITE
+        except ImportError:
+            from _subprocess import WAIT_OBJECT_0, INFINITE
 
         # Build the list of handle to listen on.
         handles = []


### PR DESCRIPTION
`_subprocess` is removed in Python 3.3, and the relevant names relocated to a new `_winapi` module.

closes #2471

should be back ported to 0.13.1 because all zmq-based IPython will fail on win/py3.3 without it.

ref: http://bugs.python.org/issue11750
