### PR TITLE
add missing 'qtconsole' extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -230,6 +230,7 @@ if 'setuptools' in sys.modules:
     setuptools_extra_args['entry_points'] = find_scripts(True)
     setup_args['extras_require'] = dict(
         parallel = 'pyzmq>=2.1.4',
+        qtconsole = 'pygments',
         zmq = 'pyzmq>=2.1.4',
         doc = 'Sphinx>=0.3',
         test = 'nose>=0.10.1',


### PR DESCRIPTION
The docs mention `easy_install ipython[qtconsole]`, but that would fail because it was undefined. The alternative would be to change the docs, but then we would have no expression of the pygments optional dependency.

should be back ported to 0.13.1
