### PR TITLE
Fix traceback handling of SyntaxErrors without line numbers.

### DIFF
--- a/IPython/core/tests/test_ultratb.py
+++ b/IPython/core/tests/test_ultratb.py
@@ -93,3 +93,9 @@ class IndentationErrorTest(unittest.TestCase):
             with tt.AssertPrints("IndentationError"):
                 with tt.AssertPrints("zoon()", suppress=False):
                     ip.magic('run %s' % fname)
+
+class SyntaxErrorTest(unittest.TestCase):
+    def test_syntaxerror_without_lineno(self):
+        with tt.AssertNotPrints("TypeError"):
+            with tt.AssertPrints("line unknown"):
+                ip.run_cell("raise SyntaxError()")

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -556,12 +556,16 @@ class ListTB(TBTools):
                 have_filedata = True
                 #print 'filename is',filename  # dbg
                 if not value.filename: value.filename = "<string>"
-                if not value.lineno: value.lineno = "unknown"
+                if value.lineno:
+                    lineno = value.lineno
+                    textline = ulinecache.getline(value.filename, value.lineno)
+                else:
+                    lineno = 'unknown'
+                    textline = ''
                 list.append('%s  File %s"%s"%s, line %s%s%s\n' % \
                         (Colors.normalEm,
                          Colors.filenameEm, py3compat.cast_unicode(value.filename), Colors.normalEm,
-                         Colors.linenoEm, value.lineno, Colors.Normal  ))
-                textline = ulinecache.getline(value.filename, value.lineno)
+                         Colors.linenoEm, lineno, Colors.Normal  ))
                 if textline == '':
                     textline = py3compat.cast_unicode(value.text, "utf-8")
 

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -556,7 +556,8 @@ class ListTB(TBTools):
                 have_filedata = True
                 #print 'filename is',filename  # dbg
                 if not value.filename: value.filename = "<string>"
-                list.append('%s  File %s"%s"%s, line %s%d%s\n' % \
+                if not value.lineno: value.lineno = "unknown"
+                list.append('%s  File %s"%s"%s, line %s%s%s\n' % \
                         (Colors.normalEm,
                          Colors.filenameEm, py3compat.cast_unicode(value.filename), Colors.normalEm,
                          Colors.linenoEm, value.lineno, Colors.Normal  ))


### PR DESCRIPTION
E.g. lxml generates such errors.
