### PR TITLE
R magic using knitr

### DIFF
--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -460,9 +460,9 @@ class RMagics(Magics):
         A line magic for R to install packages.
 
         '''
-        args = parse_argstring(self.Rpull, line)
+        args = parse_argstring(self.Rinstall, line)
         for package in args.packages:
-            self.r("install.packages('%s')" % package)
+            self.r("install.packages('%s', repos='%s')" % (package, args.repos))
 
     @skip_doctest
     @magic_arguments()

--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -308,7 +308,7 @@ class RMagics(Magics):
 
         for mime, fname in md_output:
             if os.path.splitext(fname)[1] != '.Rerror':
-                data = open(fname).read().strip()
+                data = open(fname).read()
                 os.remove(fname)
                 if data:
                     display_data.append(('RMagic.R', {mime: data}))
@@ -467,25 +467,21 @@ class RMagics(Magics):
         help='Names of variables to be pushed from rpy2 to shell.user_ns after executing cell body and applying self.Rconverter. Multiple names can be passed separated only by commas with no whitespace.'
         )
     @argument(
-        '-w', '--width', type=int, default=7,
-        help='Width of figure as "fig.width" sent to knitr.'
-        )
-    @argument(
-        '-h', '--height', type=int, default=7,
-        help='Height of figure as "fig.height" sent to knitr.'
-        )
-    @argument('--dpi', default=72,
-              type=int,
-              help='Argument "dpi" passed to knitr.'
-              )
-    @argument(
         '-d', '--dataframe', action='append',
         help='Convert these objects to data.frames and return as structured arrays.'
         )
     @argument(
-        '-b', '--bg',
-        help='Background of png plotting device sent as an argument to *png* in R.'
+        '-w', '--width', type=int, default=7,
+        help='Width of figure as "fig.width" sent to knitr as a chunk option.'
         )
+    @argument(
+        '-h', '--height', type=int, default=7,
+        help='Height of figure as "fig.height" sent to knitr as a chunk option.'
+        )
+    @argument('--dpi', default=72,
+              type=int,
+              help='Argument "dpi" passed to knitr as a chunk option.'
+              )
     @argument(
         'code',
         nargs='*',

--- a/docs/examples/notebooks/rmagic_extension.ipynb
+++ b/docs/examples/notebooks/rmagic_extension.ipynb
@@ -23,7 +23,18 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": []
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "Welcome to pylab, a matplotlib-based Python environment [backend: module://IPython.zmq.pylab.backend_inline].\n",
+        "For more information, type 'help(pylab)'.\n"
+       ]
+      }
+     ],
+     "prompt_number": 30
     },
     {
      "cell_type": "heading",
@@ -49,7 +60,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 1
+     "prompt_number": 31
     },
     {
      "cell_type": "markdown",
@@ -74,13 +85,28 @@
      "outputs": [
       {
        "output_type": "pyout",
-       "prompt_number": 2,
+       "prompt_number": 32,
        "text": [
-        "<matplotlib.collections.PathCollection at 0x10f32f610>"
+        "<matplotlib.collections.PathCollection at 0x1085084d0>"
+       ]
+      },
+      {
+       "output_type": "display_data",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAWgAAAD9CAYAAACROe2RAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAENhJREFUeJzt3H9sVGW+x/HPtEWkBApCoA23tsaClCLtSGwJUDJtKgLe\nCkhcfri2BEHUJXtBcW9iyKUmeyFsxYruvcTLJiTVVa6aFdvKD1EzEEFaoAVysdLqUkMNYCmhLR2G\nHzPn/uFaZMWZKUznPEzfr+QkLT195nsS8/bwzBkclmVZAgAYJ8buAQAAN0agAcBQBBoADEWgAcBQ\nBBoADEWgAcBQQQO9adMmTZw4UePHj9fy5csjMRMAQEECfe7cOa1Zs0a7du3SgQMH1NDQoJ07d0Zq\nNgDo1eIC/bBfv36yLEttbW2SJI/Ho8GDB0dkMADo7QLeQffr108bN25UamqqEhMTNWnSJGVnZ0dq\nNgDo3awAfvjhByslJcVqbGy0zp49a+Xl5VlVVVXXnSOJg4ODg+MmjmAC3kHX1NRowoQJSktL05Ah\nQ/T4449rz549vzjPsqyoPVavXm37DFwf19cbry+ar82yrEDp7RIw0Lm5uTp48KDOnTunS5cuafv2\n7Zo6dWpICwMAbk3ANwkHDhyoVatWafbs2fJ4PJo2bZry8vIiNRsA9GoBAy1JCxcu1MKFCyMwiplc\nLpfdI/Qoru/2Fs3XF83XFiqHFepmyK8t4HCEvJ8CAPhRKO3ko94AYCgCDQCGItAAYCgCDQCGItAA\nYCgCDQCGItAAYCgCDQCGItAAYCgCDQCGItAAYCgCDQCGItAAYCgCDQCGItAAYCgCDQCGItAAYCgC\nDQCGItAAYCgCDQCGItAAYCgCDQCGItAAYCgCDQCGItAAYCgCDQCGItAAYKiAgT5+/LicTmfXkZCQ\noNdffz1SswFAr+awLMsK5US/368RI0aopqZGycnJ1xZwOBTiEgAQVGNjo+bPX6LGxq81alS63n13\nk9LS0uweK+xCaWfIWxyffvqp7r333uviDADhdPHiReXmPqza2tlqbz+k2tqZmjJlmrxer92j2SLk\nQG/ZskULFizoyVkA9HJfffWVLl4cIMv6N0kj5PcvV2dnP9XX19s9mi3iQjnp8uXLqqys1Lp16274\n85KSkq6vXS6XXC5XOGYD0MsMHDhQV678IKlTUn9JF3Tlyg9KSEiwebJb53a75Xa7u/U7Ie1Bf/TR\nR9q4caN27NjxywXYgwYQJpZl6cknn9bWrYfV2TlD/ft/rMceG6/y8jftHi3sQmlnSIGeN2+epk+f\nruLi4pt6EQAIlWVZ2rJli776ql4ZGWM0d+5cORwOu8cKu7AEurOzUykpKTpx4oQGDBhwUy8CALhe\n2O6gb/VFAADXC+tjdgCAyCLQAGAoAg0AhiLQAGAoAg0AhiLQAGAoAg0AhiLQAGAoAg0AhiLQAGAo\nAg0AhiLQAGAoAg0AhiLQAGAoAg0AhiLQAGAoAg0AhiLQAGAoAg0AhiLQAGAoAg0AhiLQAGAoAg0A\nhiLQAGAoAg0AhiLQAGAoAg0AhiLQAGCooIHu7OxUcXGxRo0apTFjxmj//v2RmAsAer2ggV69erXu\nvvtuHT16VEePHlV6enok5gLwK3w+n9auLVVu7r9q/vyn9N1339k9EnqIw7IsK9AJWVlZ+vLLL9Wv\nX78bL+BwKMgSAMLo6ad/r7/+9bA8nhcUG1urwYM36+uv6zRkyBC7R0M3hNLOgHfQzc3N8nq9evbZ\nZ5WTk6N169bJ6/WGdUgAofP7/dq8+X/k8WyVNFM+38u6eDFbVVVVdo+GHhAX6Ider1cNDQ0qLS1V\nQUGBli5dqvfee09FRUXXnVdSUtL1tcvlksvl6olZAeC25Xa75Xa7u/U7Qbc40tPTVV9fL0navn27\nysvL9e67715bgC0OIKLY4ogOt7zFIUkjR45UdXW1/H6/Pv74YxUUFIRtQADdt3FjmVatKlRu7ib9\n5jfNOnToC+IcpYLeQTc0NKioqEher1cFBQV6+eWX1b9//2sLcAcNAN0WSjuDBjocLwIAuF5YtjgA\nAPYg0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYi\n0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYi0ABg\nKAINAIYi0ABgqLhgJ6SmpmrgwIGKjY1Vnz59VFNTE4m5AKDXCxpoh8Mht9utu+66KxLzIEJOnz6t\n8vJyeb2X9NhjszV27Fi7RwLwT4IGWpIsy+rpORBBzc3NysycoI6O6fL7B2vdujzt3PmhJk+ebPdo\nAH4m6B60w+FQfn6+Zs2apYqKikjMhB72yisb1NY2T1eubJLP9yd5PBv0/PMldo8F4J8EvYPeu3ev\nkpKSVF9fr8LCQmVnZysxMfG6c0pKSrq+drlccrlc4Z4TYdTa2i6fb9zP/uQenT/fZts8QG/gdrvl\ndru79TsOqxv7F88//7zS09O1ZMmSaws4HGyB3GYqKys1b97v5fG8J2mQ4uOf0ooVBfrjH//D7tGA\nXiOUdgYMtMfjkc/n04ABA9TS0iKXy6UdO3YoOTm5Wy8C87z55iaVlPxJly9fUlHRfJWW/qfi4kJ6\nSwJAGNxyoE+cOKHZs2dLkoYMGaInnnhCixYt6vaLAACud8uBDteLAACuF0o7+SQhABiKQAOAoQg0\nABiKQAOAoQg0ABiKQAOAoQg0ABiKQAOAoQg0ABiKQAOAoQg0ABiKQAOAoQg0ABiKQAOAoQg0ABiK\nQAOAoQg0ABiKQAOAoQg0ABiKQAOAoQg0ABiKQAOAoQg0ABiKQAOAoQg0ABiKQAOAoQg0ABiKQAOA\noUIKtM/nk9PpVGFhYU/PAwD4h7hQTtqwYYPGjBmjjo6Onp4HCIvz589r3759uvPOO5Wbm6s+ffrY\nPRLQbUHvoJubm7Vt2zYtXrxYlmVFYibglnz77bcaNSpT8+ev16xZLyo7O0+dnZ12jwV0W9BAr1ix\nQqWlpYqJYbsat4elS19Qa+vv1N7+mTo6Dujrr0do/frX7B4L6LaAWxxVVVUaNmyYnE6n3G73r55X\nUlLS9bXL5ZLL5QrTeED3/f3vTfL7V/3juxh5vS41NtbZOhPgdrsDdvRGHFaAfYuXXnpJb731luLi\n4uT1etXe3q45c+aovLz82gIOB1sfMMqCBYv1t79Jly69KalT8fHTtH59sZ55ZqndowFdQmlnwED/\n3O7du/XKK6+osrKy2y8CRFJbW5sefvgxHT5cJ7//sn772yL95S9/ZpsORgmlnSE9xfHzBQHTJSQk\n6MsvP1VLS4vuuOMODRo0yO6RgJsS8h30ry7AHTQAdFso7eTvfABgKAINAIYi0ABgKAINAIYi0ABg\nKAINAIYi0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYi0ABgKAIN\nAIYi0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYi0ABgqICB9nq9\nysnJUVZWliZMmKCysrJIzWWEzs5Off/99/L5fHaPAqAXcliWZQU6wePxKD4+XpcuXdL48eO1detW\npaWlXVvA4VCQJW5LGzb8l/7wh39XbGx/DR06WJ99VqmRI0faPRaAKBFKO4NuccTHx0uSLly4oKtX\nr6pv377hmc5g1dXVeumltbp8+f908eIZNTf/ToWF8+weC0AvEzTQfr9fmZmZGj58uJYtW6bk5ORI\nzGWr2tpaWdYMSamSJMt6Vg0Nh9nqABBRccFOiImJ0ZEjR9TU1KQZM2Zo0qRJcjqd151TUlLS9bXL\n5ZLL5Qr3nBGVkpKimJj/luSRFC/JrSFD/kWxsbE2TwbgduV2u+V2u7v1O0H3oH9u5cqVSktL0zPP\nPHNtgSjcg7YsS088sVgVFW7Fxd2nq1cPqKLif5Wfn2/3aACiRCjtDBjos2fPKi4uToMGDVJra6vy\n8vK0c+dOJSUldetFbkeWZammpkZnzpzR+PHjNWLECLtHAhBFQmlnwC2OU6dOqbi4WD6fT4mJiVq5\ncuV1cY5mDodDOTk5do8BoBfr1hbHDReI0jtoAOhJYXnMDgBgDwINAIYi0ABgKAINAIYi0ABgKAIN\nAIYi0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYi\n0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYi0ABgKAINAIYKGOiTJ08qLy9PGRkZ\ncrlceueddyI1lzHcbrfdI/Qoru/2Fs3XF83XFqqAge7Tp4/Kysp07NgxffDBB1q1apU6OjoiNZsR\nov0/Eq7v9hbN1xfN1xaqgIFOTExUVlaWJGno0KHKyMjQwYMHIzIYAPR2Ie9Bf/PNNzp27Jiys7N7\nch4AwE+sELS3t1sPPPCAtXXr1l/8TBIHBwcHx00cwcQpiCtXrmjOnDl68sknNXPmzF/8/MdGAwDC\nzWEFKKxlWSouLtbQoUP16quvRnIuAOj1Agb6iy++0JQpUzRu3Dg5HA5J0tq1azVt2rSIDQgAvVXA\nNwknT54sv9+vw4cPq66uTnV1dTeM8/vvv6+MjAzFxsaqtra2x4aNpD179ig9PV0jR47UG2+8Yfc4\nYbVo0SINHz5c999/v92j9Ihof37f6/UqJydHWVlZmjBhgsrKyuweKex8Pp+cTqcKCwvtHiXsUlNT\nNW7cODmdzuAPXYTyJmEw9fX11vHjxy2Xy2UdOnQoHEvaLisry9q9e7fV1NRk3XfffVZLS4vdI4XN\nnj17rNraWmvs2LF2j9IjTp06ZdXV1VmWZVktLS3WPffcY7W3t9s8VXh1dnZalmVZXq/XysjIsBob\nG22eKLzWr19vLViwwCosLLR7lLBLTU21WltbQzo3LB/1Hj16tEaNGhWOpYzQ1tYmSZoyZYpSUlI0\ndepUVVdX2zxV+OTm5mrw4MF2j9FjesPz+/Hx8ZKkCxcu6OrVq+rbt6/NE4VPc3Oztm3bpsWLF0ft\nQwihXhf/FscNHDhwQKNHj+76fsyYMdq/f7+NE+FmRevz+36/X5mZmRo+fLiWLVum5ORku0cKmxUr\nVqi0tFQxMdGZJ4fDofz8fM2aNUsVFRUBzw36mN1PHnroIZ0+ffoXf75mzZqo3CfC7a+jo0Nz585V\nWVmZ+vfvb/c4YRUTE6MjR46oqalJM2bM0KRJk+R0Ou0e65ZVVVVp2LBhcjqdUftR77179yopKUn1\n9fUqLCxUdna2EhMTb3huyIHetWtX2AY03YMPPqgXX3yx6/tjx47x5MptJtjz+9EiNTVVM2bMUHV1\ndVQEet++faqoqNC2bdvk9XrV3t6uoqIilZeX2z1a2CQlJUmS0tPT9eijj6qyslJLliy54blh/ztE\nNOwZJSQkSPrxSY6mpibt2rVLOTk5Nk+FUFmWpaeeekpjx47V8uXL7R4n7M6ePavz589LklpbW/XJ\nJ59Ezf+E1qxZo5MnT+rEiRPasmWL8vPzoyrOHo+n6x+ca2lp0c6dOwPe/IUl0B9++KGSk5O1f/9+\nPfLII5o+fXo4lrXVa6+9pqVLl6qgoEDPPfechg4davdIYTN//nxNnDhRDQ0NSk5O1ubNm+0eKaz2\n7t2rt99+W59//rmcTqecTqd27Nhh91hhc+rUKeXn5yszM1MLFizQypUru+7Kos1Pn7+IFmfOnFFu\nbq6ysrI0b948vfDCCwHfPwj4QRUAgH2i821SAIgCBBoADEWgAcBQBBoADEWgAcBQBBoADPX/NSZp\nnvUerIEAAAAASUVORK5CYII=\n",
+       "text": [
+        "<matplotlib.figure.Figure at 0x1083e7a50>"
        ]
       }
      ],
-     "prompt_number": 2
+     "prompt_number": 32
+    },
+    {
+     "cell_type": "heading",
+     "level": 3,
+     "metadata": {},
+     "source": [
+      "Putting data into R: %Rpush"
+     ]
     },
     {
      "cell_type": "markdown",
@@ -100,14 +126,22 @@
      "metadata": {},
      "outputs": [
       {
-       "output_type": "pyout",
-       "prompt_number": 3,
+       "output_type": "display_data",
        "text": [
-        "array([ 3.2,  0.9])"
+        "    lm(Y ~ X)$coef\n",
+        "\u0000"
+       ]
+      },
+      {
+       "output_type": "display_data",
+       "text": [
+        "    ## (Intercept)           X \n",
+        "    ##         3.2         0.9\n",
+        "\u0000"
        ]
       }
      ],
-     "prompt_number": 3
+     "prompt_number": 33
     },
     {
      "cell_type": "markdown",
@@ -130,13 +164,21 @@
      "outputs": [
       {
        "output_type": "pyout",
-       "prompt_number": 4,
+       "prompt_number": 34,
        "text": [
         "(3.2000000000000002, 0.90000000000000002)"
        ]
       }
      ],
-     "prompt_number": 4
+     "prompt_number": 34
+    },
+    {
+     "cell_type": "heading",
+     "level": 3,
+     "metadata": {},
+     "source": [
+      "Retrieving data from R: %Rpull and %Rget"
+     ]
     },
     {
      "cell_type": "markdown",
@@ -149,36 +191,96 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "%R resid(lm(Y~X)); coef(lm(X~Y))\n"
+      "%R lm(Y~X);mycoef=coef(lm(Y~X)) \n"
      ],
      "language": "python",
      "metadata": {},
      "outputs": [
       {
-       "output_type": "pyout",
-       "prompt_number": 5,
+       "output_type": "display_data",
        "text": [
-        "array([-2.5,  0.9])"
+        "    lm(Y ~ X)\n",
+        "\u0000"
+       ]
+      },
+      {
+       "output_type": "display_data",
+       "text": [
+        "    ## \n",
+        "    ## Call:\n",
+        "    ## lm(formula = Y ~ X)\n",
+        "    ## \n",
+        "    ## Coefficients:\n",
+        "    ## (Intercept)            X  \n",
+        "    ##         3.2          0.9\n",
+        "\u0000"
+       ]
+      },
+      {
+       "output_type": "display_data",
+       "text": [
+        "    mycoef = coef(lm(Y ~ X))\n",
+        "\u0000"
        ]
       }
      ],
-     "prompt_number": 5
+     "prompt_number": 35
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%R lm(Y~X);mycoef=coef(lm(Y~X)) \n",
+      "%Rpull mycoef\n",
+      "mycoef"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "display_data",
+       "text": [
+        "    lm(Y ~ X)\n",
+        "\u0000"
+       ]
+      },
+      {
+       "output_type": "display_data",
+       "text": [
+        "    ## \n",
+        "    ## Call:\n",
+        "    ## lm(formula = Y ~ X)\n",
+        "    ## \n",
+        "    ## Coefficients:\n",
+        "    ## (Intercept)            X  \n",
+        "    ##         3.2          0.9\n",
+        "\u0000"
+       ]
+      },
+      {
+       "output_type": "display_data",
+       "text": [
+        "    mycoef = coef(lm(Y ~ X))\n",
+        "\u0000"
+       ]
+      },
+      {
+       "output_type": "pyout",
+       "prompt_number": 36,
+       "text": [
+        "array([ 3.2,  0.9])"
+       ]
+      }
+     ],
+     "prompt_number": 36
     },
     {
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "One can also easily capture the results of %R into python objects. Like R, the return value of this multiline expression (multiline in the sense that it is separated by ';') is the final value, which is \n",
-      "the *coef(lm(X~Y))*. To pull other variables from R, there is one more magic."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "There are two more line magics, %Rpull and %Rget. Both are useful after some R code has been executed and there are variables\n",
+      "To retrieve data from R, there is one more magic:  %Rpull and %Rget. Both are useful after some R code has been executed and there are variables\n",
       "in the rpy2 namespace that one would like to retrieve. The main difference is that one\n",
-      " returns the value (%Rget), while the other pulls it to self.shell.user_ns (%Rpull). Imagine we've stored the results\n",
+      "returns the value (%Rget), while the other pulls it to self.shell.user_ns (%Rpull). Imagine we've stored the results\n",
       "of some calculation in the variable \"a\" in rpy2's namespace. By using the %R magic, we can obtain these results and\n",
       "store them in b. We can also pull them directly to user_ns with %Rpull. They are both views on the same data."
      ]
@@ -187,15 +289,22 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "b = %R a=resid(lm(Y~X))\n",
+      "%R a=resid(lm(Y~X))\n",
+      "b = %Rget a\n",
       "%Rpull a\n",
       "print a\n",
-      "assert id(b.data) == id(a.data)\n",
-      "%R -o a"
+      "assert id(b.data) == id(a.data)\n"
      ],
      "language": "python",
      "metadata": {},
      "outputs": [
+      {
+       "output_type": "display_data",
+       "text": [
+        "    a = resid(lm(Y ~ X))\n",
+        "\u0000"
+       ]
+      },
       {
        "output_type": "stream",
        "stream": "stdout",
@@ -204,13 +313,13 @@
        ]
       }
      ],
-     "prompt_number": 6
+     "prompt_number": 37
     },
     {
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "%Rpull is equivalent to calling %R with just -o\n"
+      "%Rpull is equivalent to calling %R with just -o. Multiple variables with one single -o flag as long as they are comma separated with no spaces in between.\n"
      ]
     },
     {
@@ -218,32 +327,44 @@
      "collapsed": false,
      "input": [
       "%R d=resid(lm(Y~X)); e=coef(lm(Y~X))\n",
-      "%R -o d -o e\n",
-      "%Rpull e\n",
-      "print d\n",
+      "%R -o d,e\n",
       "print e\n",
-      "import numpy as np\n",
+      "print d\n",
       "np.testing.assert_almost_equal(d, a)"
      ],
      "language": "python",
      "metadata": {},
      "outputs": [
       {
+       "output_type": "display_data",
+       "text": [
+        "    d = resid(lm(Y ~ X))\n",
+        "\u0000"
+       ]
+      },
+      {
+       "output_type": "display_data",
+       "text": [
+        "    e = coef(lm(Y ~ X))\n",
+        "\u0000"
+       ]
+      },
+      {
        "output_type": "stream",
        "stream": "stdout",
        "text": [
-        "[-0.2  0.9 -1.   0.1  0.2]\n",
-        "[ 3.2  0.9]\n"
+        "[ 3.2  0.9]\n",
+        "[-0.2  0.9 -1.   0.1  0.2]\n"
        ]
       }
      ],
-     "prompt_number": 7
+     "prompt_number": 38
     },
     {
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "On the other hand %Rpush is equivalent to calling %R with just -i and no trailing code."
+      "On the other hand %Rpush is equivalent to calling %R with just -i."
      ]
     },
     {
@@ -258,41 +379,47 @@
      "metadata": {},
      "outputs": [
       {
-       "output_type": "pyout",
-       "prompt_number": 8,
+       "output_type": "display_data",
        "text": [
-        "array([ 9.5])"
+        "    mean(A)\n",
+        "\u0000"
+       ]
+      },
+      {
+       "output_type": "display_data",
+       "text": [
+        "    ## [1] 9.5\n",
+        "\u0000"
        ]
       }
      ],
-     "prompt_number": 8
+     "prompt_number": 39
     },
     {
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "The magic %Rget retrieves one variable from R."
+      "The magic %Rget retrieves something from R, it can be used without assigning the variable a name in `R`. For example:"
      ]
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "%Rget A"
+      "%Rget resid(lm(Y~X))"
      ],
      "language": "python",
      "metadata": {},
      "outputs": [
       {
        "output_type": "pyout",
-       "prompt_number": 9,
+       "prompt_number": 40,
        "text": [
-        "array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,\n",
-        "       17, 18, 19], dtype=int32)"
+        "array([-0.2,  0.9, -1. ,  0.1,  0.2])"
        ]
       }
      ],
-     "prompt_number": 9
+     "prompt_number": 40
     },
     {
      "cell_type": "heading",
@@ -306,16 +433,15 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "R's console (i.e. its stdout() connection) is captured by ipython, as are any plots which are published as PNG files like the notebook with arguments --pylab inline. As a call to %R may produce a return value (see above) we must ask what happens to a magic like the one below. The R code specifies that something is published to the notebook. If anything is published to the notebook, that call to %R returns None."
+      "R's console (i.e. its stdout() connection) is captured by ipython, as are any plots which are published as PNG files like the notebook with arguments --pylab inline."
      ]
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "v1 = %R plot(X,Y); print(summary(lm(Y~X))); vv=mean(X)*mean(Y)\n",
-      "print 'v1 is:', v1\n",
-      "v2 = %R mean(X)*mean(Y)\n",
+      "%R plot(X,Y); print(summary(lm(Y~X))); vv=mean(X)*mean(Y)\n",
+      "v2 = %Rget mean(X)*mean(Y)\n",
       "print 'v2 is:', v2"
      ],
      "language": "python",
@@ -324,41 +450,61 @@
       {
        "output_type": "display_data",
        "text": [
-        "\n",
-        "Call:\n",
-        "lm(formula = Y ~ X)\n",
-        "\n",
-        "Residuals:\n",
-        "   1    2    3    4    5 \n",
-        "-0.2  0.9 -1.0  0.1  0.2 \n",
-        "\n",
-        "Coefficients:\n",
-        "            Estimate Std. Error t value Pr(>|t|)  \n",
-        "(Intercept)   3.2000     0.6164   5.191   0.0139 *\n",
-        "X             0.9000     0.2517   3.576   0.0374 *\n",
-        "---\n",
-        "Signif. codes:  0 \u2018***\u2019 0.001 \u2018**\u2019 0.01 \u2018*\u2019 0.05 \u2018.\u2019 0.1 \u2018 \u2019 1 \n",
-        "\n",
-        "Residual standard error: 0.7958 on 3 degrees of freedom\n",
-        "Multiple R-squared:  0.81,\tAdjusted R-squared: 0.7467 \n",
-        "F-statistic: 12.79 on 1 and 3 DF,  p-value: 0.03739 \n",
-        "\n"
+        "    plot(X, Y)\n",
+        "\u0000"
        ]
       },
       {
        "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAeAAAAHgCAYAAAB91L6VAAAD8GlDQ1BJQ0MgUHJvZmlsZQAAKJGN\nVd1v21QUP4lvXKQWP6Cxjg4Vi69VU1u5GxqtxgZJk6XpQhq5zdgqpMl1bhpT1za2021Vn/YCbwz4\nA4CyBx6QeEIaDMT2su0BtElTQRXVJKQ9dNpAaJP2gqpwrq9Tu13GuJGvfznndz7v0TVAx1ea45hJ\nGWDe8l01n5GPn5iWO1YhCc9BJ/RAp6Z7TrpcLgIuxoVH1sNfIcHeNwfa6/9zdVappwMknkJsVz19\nHvFpgJSpO64PIN5G+fAp30Hc8TziHS4miFhheJbjLMMzHB8POFPqKGKWi6TXtSriJcT9MzH5bAzz\nHIK1I08t6hq6zHpRdu2aYdJYuk9Q/881bzZa8Xrx6fLmJo/iu4/VXnfH1BB/rmu5ScQvI77m+Bkm\nfxXxvcZcJY14L0DymZp7pML5yTcW61PvIN6JuGr4halQvmjNlCa4bXJ5zj6qhpxrujeKPYMXEd+q\n00KR5yNAlWZzrF+Ie+uNsdC/MO4tTOZafhbroyXuR3Df08bLiHsQf+ja6gTPWVimZl7l/oUrjl8O\ncxDWLbNU5D6JRL2gxkDu16fGuC054OMhclsyXTOOFEL+kmMGs4i5kfNuQ62EnBuam8tzP+Q+tSqh\nz9SuqpZlvR1EfBiOJTSgYMMM7jpYsAEyqJCHDL4dcFFTAwNMlFDUUpQYiadhDmXteeWAw3HEmA2s\n15k1RmnP4RHuhBybdBOF7MfnICmSQ2SYjIBM3iRvkcMki9IRcnDTthyLz2Ld2fTzPjTQK+Mdg8y5\nnkZfFO+se9LQr3/09xZr+5GcaSufeAfAww60mAPx+q8u/bAr8rFCLrx7s+vqEkw8qb+p26n11Aru\nq6m1iJH6PbWGv1VIY25mkNE8PkaQhxfLIF7DZXx80HD/A3l2jLclYs061xNpWCfoB6WHJTjbH0mV\n35Q/lRXlC+W8cndbl9t2SfhU+Fb4UfhO+F74GWThknBZ+Em4InwjXIyd1ePnY/Psg3pb1TJNu15T\nMKWMtFt6ScpKL0ivSMXIn9QtDUlj0h7U7N48t3i8eC0GnMC91dX2sTivgloDTgUVeEGHLTizbf5D\na9JLhkhh29QOs1luMcScmBXTIIt7xRFxSBxnuJWfuAd1I7jntkyd/pgKaIwVr3MgmDo2q8x6IdB5\nQH162mcX7ajtnHGN2bov71OU1+U0fqqoXLD0wX5ZM005UHmySz3qLtDqILDvIL+iH6jB9y2x83ok\n898GOPQX3lk3Itl0A+BrD6D7tUjWh3fis58BXDigN9yF8M5PJH4B8Gr79/F/XRm8m241mw/wvur4\nBGDj42bzn+Vmc+NL9L8GcMn8F1kAcXjEKMJAAAAYFklEQVR4nO3de5DVBf3/8TfBKne8MICwqCiQ\nVkg6KuqYETZCkgPYqqGEBSIwgnJRGo0cRxgxw3FGhVJRErLFC4o3GoVNE4JKMhJSoCSlMkZuC0hy\nWXZ/fzQx40/4thTs+3j28ZjZP/bzmf2cFzPMPOd8zjm7DWpqamoCAKhTn8keAAD1kQADQAIBBoAE\nAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEg\ngQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAA\nSCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQY\nABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEgQaPsAXXp\nqaeeiqqqquwZABSINm3aRK9evVIeu0FNTU1NyiPXsblz58bdd98dV199dfYUAArEvffeG4899lh8\n8YtfrPPHrjfPgKuqqmLw4MExfPjw7CkAFIg1a9ZEdXV1ymN7DRgAEggwACQQYABIIMAAkECAASCB\nAANAAgEGgAT15nPAABSnt956K7Zu3Rqf/exn45hjjsmeU2sF8Qz4/fffj71792bPAOBTpKamJm69\n9daYNGlSzJ07N0pLS2Pp0qXZs2qtIALct2/fuOCCC2Lt2rXZUwD4lJg8eXLs2LEjysvLY+rUqfHG\nG2/EDTfcEO+99172tFopmFvQ3bp1i/POOy8mTJgQQ4cOjVatWh30NV577bX49a9/vd9zixYtijZt\n2sSIESP+16kAFIBly5bFjBkz9n1/yimnxJAhQ+JXv/pVnHDCCYnLaqcgngFHRAwbNiwWL14cP//5\nz6O0tDRGjBgRixcvjm3bttX6Gu3atYtu3brt96thw4axYcOGw/gvAKAuNW/ePHbu3PmxY5WVlVFS\nUpK06OAUzDPgiIjOnTvHggULYtWqVTFjxoz41re+FevWrYshQ4bEQw899B9/vmvXrtG1a9f9nnv5\n5Zdj/fr1h3oyAEkGDBgQEyZMiEceeSSaNGkS8+bNi5tvvvmgnrhlKqgA/9spp5wSU6dOjalTp8aO\nHTti06ZN2ZMAKDBlZWWxYcOGOOOMM6Jr167RvHnzeO+996JFixbZ02qlIAI8YcKE6Nix437PNWvW\nLJo1a1bHiwD4NBg5cmSMHDkye8Z/pSACPHDgwOwJAFCnCuZNWABQnwgwACQQYABIIMAAkECAASCB\nAANAAgEGgAQCDAAJBBgAEggwACQQYABIIMAAkECAASCBAANAAgEGgAQCDAAJBBgAEggwACQQYABI\nIMAAkECAASCBAANAAgEGgAQCDAAJBBgAEggwACQQYABIIMAAkECAASCBAANAAgEGgAQCDAAJBBgA\nEggwACQQYABIIMAAkECAASCBAANAAgEGgAQCDAAJBBgAEggwACQQYABIIMAAkECAASCBAANAAgEG\ngAQCDAAJBBgAEggwACQQYABIIMAAkECAASCBAANAAgEGgAQCDAAJBBgAEggwACQQYABIIMAAkECA\nASCBAANAAgEGgAQCDAAJBBgAEggwACQQYABIIMAAkECAASCBAANAAgEGgAQCDAAJGmUPOJCdO3dG\nw4YNo6SkJHsKwEGprq6OGTNmxC9/+cs44ogj4rrrroszzzwzexYFpiCeAa9bty4GDx4cy5Ytiw0b\nNsTQoUOjXbt2cdRRR8WQIUNi9+7d2RMBam3w4MGxYMGCmDx5cowZMya+//3vx4svvpg9iwJTEAG+\n9dZb4/jjj4/Pf/7zcd9990VVVVWsXLky3nzzzdi+fXtMmjSpVteprq6Oqqqq/X5VV1dHTU3NYf6X\nAPXd66+/Hu+++248+eST0alTp+jevXvMmDEj7rvvvuxpFJiCuAX92muvxapVq+KII46IZ555JubN\nmxelpaURETFp0qQYMWJEra4zc+bMmDNnzn7PrV69Ok488cRDNRlgvyorK6N3794fO9ahQ4eorq5O\nWkShKogAd+3aNWbNmhXXXHNN9OzZM+bPnx+jR4+OiIgXXnghunTpUqvrDB06NIYOHbrfc2PHjo31\n69cfss0A+9O1a9e49957Y9OmTXHsscdGRMSiRYviww8/TF5GoSmIAE+bNi2+/vWvx8MPPxydO3eO\nG2+8MR555JH4zGc+E9u2bYvXXnsteyJArZxwwgkxdOjQaN26dcyePTu2bt0azz77bDz55JPZ0ygw\nBRHgk08+Od56661YsGBBrF69Oo4//vg4+uijo0uXLtG3b99o1KggZgLUSv/+/WP58uWxaNGiaNKk\nSZSXl+97Ngz/VjBla9CgQVx00UVx0UUXZU8B+J917949unfvnj2DAlYQ74IGgPpGgAEggQADQAIB\nBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBA\ngAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAk\nEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwA\nCQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQAD\nQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASPCJ\nAN90002xffv2jC3UY5WVlfHyyy/HwoUL46OPPsqeA3DYfSLA69ati9NOOy0WLVqUsWefDRs2RFVV\nVeoG6sbatWvj0ksvjddffz0qKiqiZcuWsX79+uxZAIfVJwL8+OOPxx133BFlZWUxYcKE2L1792Ef\nMXjw4Fi1alVERKxevTr69u0bHTt2jHbt2sWoUaNiz549h30DOT766KM47bTT4rvf/W5873vfiylT\npsTMmTNjwoQJsXfv3ux5AIdNo/0dHDhwYHz1q1+NG2+8Mc4666y4/PLL95079dRT49JLLz2kI1au\nXBk7duyIiIgpU6bEKaecErNnz46NGzfGuHHjYsqUKXHrrbf+x+s899xzsWDBgv2eW7RoURx77LGH\ndDf/uz//+c9x1VVXRe/evfcdGzRoUDz33HPx/vvvR8eOHRPXARw++w1wRESDBg2ipKQk1q9fHytX\nrtx3vHnz5od10EsvvRRr1qyJFi1axDHHHBOTJ0+OcePG1SrAPXr0iJNOOmm/5yorK/dFnsLRuHHj\nqKys/Nix6urqWLt2bTRp0iRpFcDht98Al5eXx/XXXx9f/vKXY8WKFdGmTZvDPmTJkiXRvn37OOec\nc2LTpk3RokWLiIhYsWJFnH766bW6Rtu2baNt27b7Pde6dWuvKRegLl26xMknnxy33357TJgwIaqq\nquIrX/lK9OzZM1q3bp09D+Cw+USAr7jiiqioqIj7778/vvnNb9bJiKuuuiqef/75mDRpUmzdujUa\nN24c5eXlcdttt8W0adOioqKiTnaQY9KkSXH99dfHxRdfHE2bNo0hQ4bE8OHDs2cBHFafCHCrVq3i\nj3/84wGfSR4O48ePj/Hjx0dExN///vfYtm1bRET06dMnbrzxxsN+25tcDRs2jGnTpmXPAKhTnwjw\ngw8+mLFjnw4dOkSHDh0iIuKcc85J3QIAh4vfhAUACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIB\nBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBA\ngAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAk\nEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwA\nCQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQAD\nQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEBRvgnTt3xrZt27JnQFFZtmxZ\nDBw4MPr06RNlZWWxadOm7ElQbxVsgOfOnRvjxo3LngFF469//WvccMMNMX78+Hj22Wdj6NChcfnl\nl8fmzZuzp0G91Ch7QEREly5dYuPGjR87tnv37qiqqoq5c+dG//79Y+bMmf/xOlu2bInKysr9ntu6\ndWvs2bPnkOyFT6O77ror7rjjjjjzzDMjIuJrX/tavPPOO/HYY4/F6NGjk9dB/VMQAZ45c2YMGTIk\nBg0aFFdffXVERMybNy+WLl0aP/jBD6JZs2a1uk5FRUXMnz9/v+d+85vfRNu2bQ/ZZvi0+fDDD6Nd\nu3YfO1ZaWhqrV69OWgT1W0EE+Pzzz49ly5bFqFGjYty4cfHAAw9E69ato3nz5nHCCSfU+jplZWVR\nVla233Njx46N9evXH6rJ8KnTo0eP+OEPfxgzZsyIiH/dZfrOd74Tc+fOTV4G9VNBBDgiomXLljFr\n1qx44okn4oILLogePXpEw4YNs2dB0Rg2bFjMnz8/evfuHf37948FCxbExIkTo1evXtnToF4qmAD/\n2+WXXx7nnXdejBw5Mrp37549B4pGw4YN47nnnouKiorYvHlzTJw4Mc4444zsWVBvFVyAI/71utTz\nzz+fPQOK0oUXXpg9AYgC/hgSABQzAQaABAIMAAkEGAASCDAAJBBgAEggwACQQIABIIEAA0ACAQaA\nBAIMAAkEGAASCDAAJBBgAEggwACQQIABIIEAA0ACAQaABAIMAAkEGAASCDAAJBBgAEggwACQQIAB\nIIEAA0ACAQaABAIMAAkEGAASCDAAJBBgAEggwACQQIABIIEAA0ACAQaABAIMAAkEGAASCDAAJBBg\nAEggwACQQIABIIEAA0ACAQaABAIMAAkEGAASCDAAJBBgAEggwACQQIABIIEAA0ACAQaABAIMAAkE\nGAASCDAAJBBgAEggwACQQIABIIEAA0ACAQaABAIMAAkEGAASCDAAJBBgAEggwACQQIABIIEAA0AC\nAQaABAIMAAkEGAASCDAAJBBgAEggwACQQIABIEGj7AGF7qWXXor3338/jjvuuOjTp0/2HACKRME+\nA967d29s27YtdcPVV18dTz31VJSUlMRdd90Vl112WVRXV6duAqA4FESA9+zZE1OmTIkhQ4bEG2+8\nEXPmzIm2bdvGUUcdFZdeemns2rWrzjeVl5fHW2+9FQ899FAMGjQofvGLX0TLli3jpz/9aZ1vAaD4\nFMQt6JtuuinefvvtOOOMM+KKK66IRo0axdy5c6O0tDTGjh0b8+bNiyuuuOI/Xmf27Nnx9NNP7/fc\nm2++GaWlpbXetHz58rjnnns+dmz48OHx+OOP1/oaAHAgBRHg+fPnx7Jly6Jly5bRpEmT+OCDD+LL\nX/5yRERMnjw5Jk6cWKsAX3bZZXHJJZfs99yTTz4ZO3bsqPWmli1bxurVq+P888/fd+z3v/99tGzZ\nstbXAIADKYgAn3TSSbFq1ao4++yz45prrom//e1v+86tWLEiOnfuXKvrNG7cOBo3brzfcy1btoy9\ne/fWetOwYcOirKws2rVrF2effXYsWrQoRowYEZWVlbW+BgAcSEEEeNy4cdGvX7/48Y9/HP369Yv2\n7dtHRMQtt9wSjzzySCxcuLDON7Vp0ybmzZsXN910U8yaNSvatGkT69ati1atWtX5FgCKT0EE+KKL\nLorVq1d/4hbxJZdcEhMnToymTZum7DrmmGPi4YcfTnlsAIpbQQQ44l+3iP//11fPPffcpDUAcHgV\nxMeQAKC+EWAASCDAAJBAgAEggQADQAIBBoAEAgwACRrU1NTUZI+oC8uXL4++ffvG6aefftA/+8or\nrxzwV1xy6OzevTsaNGgQJSUl2VOK3o4dO6JZs2bZM4rezp07o6SkJBo2bJg9paj9O2PnnXfeQf/s\n2rVrY8GCBdGhQ4dDPes/qjcB/l/07NkzXn311ewZRW/atGnRtm3bKCsry55S9Pyfrhs333xz9OvX\nL84555zsKUXtgw8+iNGjR3/q/lqdW9AAkECAASCBAANAAgEGgAQCDAAJBBgAEvgYUi384x//iOOO\nOy57RtHbtm1bNGzY0OdT64D/03Vj8+bN0axZszjyyCOzpxS16urq2LhxY7Rp0yZ7ykERYABI4BY0\nACQQYABIIMAAkECAASCBAANAAgEGgAQCDAAJBJiCsmfPnuwJAHVCgP8Pr776apx//vnRqVOnGDBg\nQGzZsiV7UlErLy+Pc889N3tGUSsvL49evXpF9+7dY9CgQfH2229nTypKa9asiQEDBkS3bt3i7LPP\njtdffz17UtG79tprY/jw4dkzDooAH8DGjRvjyiuvjOnTp8eaNWuiU6dOMX78+OxZRWnLli0xatSo\nuOGGG8IvZjt81q9fH2PHjo3y8vL4wx/+EBdeeGGMGTMme1ZRGjp0aFx22WWxYsWKmDx5cpSVlWVP\nKmovvvhizJ07N3vGQRPgA1i2bFmceuqpcdppp0VJSUmMHj06nn766exZRamioiKaNm0ajz76aPaU\nolZdXR1PPPFEtG3bNiIiunfvHkuWLEleVZzmzZsXAwcOjIiIqqqqqKqqSl5UvDZt2hSTJ0+O0aNH\nZ085aAJ8AOvWrfvYL6tv27ZtbN26NXbt2pW4qjiVlZXFXXfdFU2aNMmeUtTat28fF1xwwb7vH3zw\nwejbt2/iouJ17LHHRoMGDWLMmDFx7bXXxv333589qWiNHDkybrvttmjevHn2lIMmwAewadOmj/1V\nnn/H4Z///GfWJDhkZsyYEc8//3xMnTo1e0rR2rVrV7Rp0yZKS0tjzpw5sXv37uxJRednP/tZNGnS\nJHr37p095b8iwAfQunXr2LZt277vt2/fHo0bN46jjz46cRX87x544IGYOHFiLFy4MEpLS7PnFK0j\njzwybrnllli8eHG88sorsXjx4uxJRWXTpk0xZsyY6NWrV7zwwgvx9ttvx3vvvRdLly7NnlZrAnwA\npaWl8e677+77/t13342OHTvmDYJD4NFHH43bbrstFi5cGKeeemr2nKK0c+fOmDBhwr6Xqxo1ahRd\nu3aNP/3pT8nLiktlZWV07tw5HnjggbjjjjuioqIili9fHrNnz86eVmsCfAC9evWKtWvXRkVFReza\ntSvuvvvu+MY3vpE9C/5rf/nLX+K6666LOXPmRPv27WPz5s2xefPm7FlFp3HjxvG73/0uZs6cGRH/\nekPnb3/72/jSl76UvKy4nHzyybFkyZJ9X6NGjYp+/frF9OnTs6fVWqPsAYXqyCOPjPvvvz/69+8f\nrVq1iq5du8a0adOyZ8F/bfr06bFjx47o2bPnx47v2LEjmjZtmjOqSE2ZMiXGjRsX99xzT7Rq1Spm\nzZoVn/vc57JnUWAa1Pjg5f+pqqoqtm/f7rVf4KBt3bo1WrVqlT2DAiXAAJDAa8AAkECAASCBAANA\nAgEGgAQCDAAJBBgAEggwACQQYABIIMAAkECAASCBAANAAgEGgAQCDAAJBBgAEggwACQQYABIIMAA\nkECAASCBAEM9sHPnzvjCF74Qt9xyy8eOf/vb344rr7wyaRXUb42yBwCHX+PGjaO8vDx69OgRZ511\nVgwYMCDuvPPOWLp0aSxbtix7HtRLAgz1RLdu3eLOO++MYcOGRUlJSUyaNCmWLFkSLVq0yJ4G9VKD\nmpqamuwRQN25+OKL4+WXX47p06fHtddemz0H6i2vAUM907lz59i7d2+0bt06ewrUawIM9cirr74a\ns2bNittvvz2uu+662LJlS/YkqLfcgoZ64sMPP4xu3brFzTffHMOGDYuePXtGp06d4ic/+Un2NKiX\nBBjqieHDh8c777wTCxYsiAYNGsSaNWuie/fu8cwzz0SfPn2y50G9I8BQD7z00ktRVlYWK1asiBNP\nPHHf8TvvvDN+9KMfxcqVK70bGuqYAANAAm/CAoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQAD\nQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAE/w+5mUYqDkF0XgAAAABJRU5E\nrkJggg==\n"
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAfgAAAH4CAYAAACmKP9/AAAD8GlDQ1BJQ0MgUHJvZmlsZQAAKJGN\nVd1v21QUP4lvXKQWP6Cxjg4Vi69VU1u5GxqtxgZJk6XpQhq5zdgqpMl1bhpT1za2021Vn/YCbwz4\nA4CyBx6QeEIaDMT2su0BtElTQRXVJKQ9dNpAaJP2gqpwrq9Tu13GuJGvfznndz7v0TVAx1ea45hJ\nGWDe8l01n5GPn5iWO1YhCc9BJ/RAp6Z7TrpcLgIuxoVH1sNfIcHeNwfa6/9zdVappwMknkJsVz19\nHvFpgJSpO64PIN5G+fAp30Hc8TziHS4miFhheJbjLMMzHB8POFPqKGKWi6TXtSriJcT9MzH5bAzz\nHIK1I08t6hq6zHpRdu2aYdJYuk9Q/881bzZa8Xrx6fLmJo/iu4/VXnfH1BB/rmu5ScQvI77m+Bkm\nfxXxvcZcJY14L0DymZp7pML5yTcW61PvIN6JuGr4halQvmjNlCa4bXJ5zj6qhpxrujeKPYMXEd+q\n00KR5yNAlWZzrF+Ie+uNsdC/MO4tTOZafhbroyXuR3Df08bLiHsQf+ja6gTPWVimZl7l/oUrjl8O\ncxDWLbNU5D6JRL2gxkDu16fGuC054OMhclsyXTOOFEL+kmMGs4i5kfNuQ62EnBuam8tzP+Q+tSqh\nz9SuqpZlvR1EfBiOJTSgYMMM7jpYsAEyqJCHDL4dcFFTAwNMlFDUUpQYiadhDmXteeWAw3HEmA2s\n15k1RmnP4RHuhBybdBOF7MfnICmSQ2SYjIBM3iRvkcMki9IRcnDTthyLz2Ld2fTzPjTQK+Mdg8y5\nnkZfFO+se9LQr3/09xZr+5GcaSufeAfAww60mAPx+q8u/bAr8rFCLrx7s+vqEkw8qb+p26n11Aru\nq6m1iJH6PbWGv1VIY25mkNE8PkaQhxfLIF7DZXx80HD/A3l2jLclYs061xNpWCfoB6WHJTjbH0mV\n35Q/lRXlC+W8cndbl9t2SfhU+Fb4UfhO+F74GWThknBZ+Em4InwjXIyd1ePnY/Psg3pb1TJNu15T\nMKWMtFt6ScpKL0ivSMXIn9QtDUlj0h7U7N48t3i8eC0GnMC91dX2sTivgloDTgUVeEGHLTizbf5D\na9JLhkhh29QOs1luMcScmBXTIIt7xRFxSBxnuJWfuAd1I7jntkyd/pgKaIwVr3MgmDo2q8x6IdB5\nQH162mcX7ajtnHGN2bov71OU1+U0fqqoXLD0wX5ZM005UHmySz3qLtDqILDvIL+iH6jB9y2x83ok\n898GOPQX3lk3Itl0A+BrD6D7tUjWh3fis58BXDigN9yF8M5PJH4B8Gr79/F/XRm8m241mw/wvur4\nBGDj42bzn+Vmc+NL9L8GcMn8F1kAcXjEKMJAAAATzklEQVR4nO3df8yuBX3f8c8Xj+BgwhyWtNsC\nzoUjrZguHf8UzhYTpSadEphdV7bMjkJlU9J/hlvtqula0zbCQVJqWmsl1NnamqY/srGUZjNqiCsr\nGaijEiq4KVJPB21FOdja7bs/7pvkRM6P5wg81/1879crOeE81xXu8zl3lPdzXdfznFPdHQBgllOW\nHgAAPPsEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEE\nHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngA\nGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAg\ngQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQe\nAAYSeAAYSOABYCCBB4CB9i09YDdV1fdky37PACzqj7v7w0v8wtXdS/y6u66qXp/kXyf5paW3ALA1\nfijJP+vue3f7F96mq9l9Sd7f3e9ZeggA26Gq9mehx+GewQPAQAIPAAMJPAAMJPAAMJDAA8BAAg8A\nAwk8AAwk8AAw0Db9QTcAcFKq6pIkZyd5sLvvW3rPydiIK/iq+htV9byldwDAU6rqYJJrkpyf5I6q\num7hSSdlIwKf5PYkH6uqly49BACq6uokp3T3Vd19MMn+JFdU1YGFp+3YJt2i/1SSj1fVO5O8r7u/\ndLIvUFWXJbn0GKe/I8nnkvz8Nz4RgC1xcZIbnvqguw9X1S3r43cutuokbFLg35vkxiQ/l+TfV9Uv\nJ/lAkk929+M7fI27kjx0jHP/Jsnpz3glANvgcJJzktx/xLHz1sf3hE0KfLr7M0kuraoLsnru8R+S\nnFtVt3b3D+7g3z+U5NDRzlXVY9mw3y8AG+t9SW6uqjd29wNVdXmSm5OctfCuHdvI4HX3/UmuT3J9\nVZ2R1VcwAsCu6O57q+r6JLdV1ZNZ3R0+7yTuKC9uUwL/ziSfP9qJ7n4iyRO7OweAbdfdd2f1zH1P\n2ojAd/cHl94AAJNsyrfJAQDPIoEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CB\nBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4\nABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFg\nIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEE\nHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngA\nGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWCg\nfUsPAODYquqSJGcnebC771t6D3vHxl7BV9ULqur5S+8AWEpVHUxyTZLzk9xRVdctPIk9ZCMCX1Xn\nVtX7q+qiqvqmqnpfki8m+bOqurWqTl16I8Buqqqrk5zS3Vd198Ek+5NcUVUHFp7GHrEpt+h/PMnn\nktyX5K1Z7bowyWlJfjrJ29Y/jquqLkty6TFOH0jy6LMxFmAXXJzkhqc+6O7DVXXL+vidi61iz9iU\nwP+DJBd0919U1RVJLu/uh5Okqt6W5Od3+Dp3JXnoGOfOSnL6M14KsDsOJzknyf1HHDtvfRxOaFMC\n/0CSNyT5xSQfSfLdSW5Zn3ttkj/cyYt096Ekh452rqoey+b8fgFO5H1Jbq6qN3b3A1V1eZKbs7pY\ngRPalOC9Ocl/Wj9z+kySG6vqB5L8vyRnZnWFD7A1uvveqro+yW1V9WRWdyfP6+7HF57GHrERge/u\nB6vq27J6fv6yrJ7H/2lWV+63d/dfLrkPYAndfXdWz9zhpG1E4JOkuzvJ765/AADPwEZ8mxwA8OwS\neAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOAB\nYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CB\nBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4\nABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFg\nIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEE\nHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABnpa4Kvqhqp64RJj4Giq6pKquqyq\nXr70FoC94mhX8Ocm+WRV/f3dHnOkqvqmqtq35AaWV1UHk1yT5Pwkd1TVdQtPAtgTnhb47v4nSX4k\nya9X1Tur6tTnekRVvb+qLlj//GVVdXuSzyf5YlX9bFU9/7newOapqquTnNLdV3X3wST7k1xRVQcW\nngaw8Y56hdzdH6yq/5LkxiS/X1UfOuL0p7v7N57lHRcmOWP987cmuT/JP0/y4iQ3rY/9+IlepKou\nS3LpMU4fSPLoM17Kbro4yQ1PfdDdh6vqlvXxOxdbBbAHHO8WeCf5WpJvzirAT/nKc7ooeU2S/d39\n5SR/UlU/mlXkTxj4JHcleegY585KcvqzM5FdcjjJOVl9wveUl6yPA3AcRw18VV2Z5GeSfDTJK7r7\nj3dhy8VV9UiS30tydpIvr4+/Isk9O3mB7j6U5NDRzlXVYzn+JzRsnluT3FRV13b3A1V1eZJ3ZfXJ\nGgDH8bTgVdWvJXlVkuu6+1d3accvJ3ldkrdl9R/vrya5sqp+LMmb13vYMt19T1W9JcltVfVkVndn\nzuvuxxeeBrDxjnZF+6UkL19fDe+K9RdQHUySqvqbSc5cn/qdJDd293P9WIAN1d13Z/XMHYCT8LTA\nd/cblxhyxK//hSRfWP/895bcAgB7lT/JDgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CB\nBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4\nABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFg\nIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEE\nHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngA\nGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAg\ngQeAgQQeAAbat/QAYLNV1SVJzk7yYHfft/QeYGc29gq+ql5QVWcuvQO2WVUdTHJNkvOT3FFV1y08\nCdihjQ18ktcnuWnpEbCtqurqJKd091XdfTDJ/iRXVNWBhacBO7ARt+ir6g+TvPjrDp+aZF9VvT7J\nb3X3VTt4ncuSXHqM0weSPPqMhsJ2uTjJDU990N2Hq+qW9fE7F1sF7MhGBD7JVUluTfKBJL+0PnZ5\nku9M8m+TPLHD17kryUPHOHdWktOfwUbYNoeTnJPk/iOOnbc+Dmy4jQh8d99ZVRcl+dmsbstfm9XV\n9le6+3+fxOscSnLoaOeq6rFsyO8X9ohbk9xUVdd29wNVdXmSm7P6ZBnYcBsTvO5+PMkbqup7k3ws\nq6vx/7vsKthe3X1PVb0lyW1V9WRWd8fOW/9/FdhwGxP4p3T3h6rq40l+Lsknlt4D26y7787qmTuw\nx2xc4JOkux9O8rqldwDAXrXJ3yYHAHyDBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeA\ngQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYS\neAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOAB\nYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CB\nBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4\nABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFg\nIIEHgIH2LT1gL6iqS5KcneTB7r5v6T0AcCIbewVfVc+rqjM3YMfBJNckOT/JHVV13cKTAOCENiLw\nVfX8qnprVd1aVd9RVd+X5FCSP6uq36iq0xbadXWSU7r7qu4+mGR/kiuq6sASewBgpzblFv0NSb41\nyf9I8mtJ/jLJ65M8nORdSS5fHz+uqrosyaXHOH0gyaMnuevi9bYkSXcfrqpb1sfvPMnXAoBdsymB\n/+4kF3X341X1ZJJzuvujSVJVP5rkHdlB4JPcleShY5z7YpI6yV2Hk5yT5P4jjr1kfRwANtamBP6h\nJBck+e9JfjHJ3zri3CuSfGYnL9Ldh7K6tf80VfXyJC86yV23Jrmpqq7t7geq6vKs7iicdZKvAwC7\nalMCf1OS366qf9ndv53kkSSpqp9M8gNJXr3EqO6+p6rekuS29Z2Fh5Kc192PL7EHAHZqIwLf3b9b\nVS9LcsbXnfqPSd7R3YvdEu/uu7N65g4Ae8ZGBD5J1lfFj3/dsf+20BwA2NM24tvkAIBnl8ADwEAC\nDwADCTwADCTwADCQwAPAQAIPAAMJPAAMVN299IZdUVV/N8ntSe75Bl/iVUmeePYWcZLOiPd/Sd7/\nZXn/l3Vqko99g//uS5Nc2t1feBb37MjWBP6ZqqqPdPcrl96xrbz/y/L+L8v7v6y9+v67RQ8AAwk8\nAAwk8AAwkMADwEACDwADCTwADOTb5Haoqr6lu/9o6R3byvu/LO//srz/y9qr77/AA8BAbtEDwEAC\nDwADCTwADCTwADCQwAPAQAIPAAMJPAAMJPDsCbXyvKV3AOwVAn8CVfXKqrqzqj5bVb9ZVS9aetO2\nqapTknwoyVuW3rJtqurKqvpwVX2iqj5QVd+69KZtUlXft/7vzx9U1Qer6qylN22jqvquqvqTpXec\nLIE/jqp6cZJfSfKmJPuTfDbJwUVHbZmq+ntJPprkVUtv2TZV9c1J3pXkyu7+9iT/NcnNy67aHlX1\n0qze/yu6+9uSfCXJ25ddtX3WF3U3Jqmlt5wsgT++i5J8urs/2d1fS3JLkn+08KZt8/1JfibJB5ce\nsoVOSfK93X1o/fEnkly84J5t89kkF3b3/1l/vC+Jx1S775asPtHac3+u+76lB2y4c5Mc+RcMHEpy\nVlWd1t1/vtCmrdLdP5SsHpUsPGXrdPcjSR454tAbk9y+0Jyt06u/KOSxqrogyU8keXmS1yy7artU\n1T9O8tWs7l7tOa7gj+/sJE8c8fGT63+evsAWWExVXZPkdUmuX3rLFvorSR5I8oII/K5ZP6J6e/bw\n/+YF/vgeTXLmER+/MMlXu/tPF9oDu66qrk3yjiSv7u6Hl96zbbr7nu7+d0l+MMlPVdWeexa8R707\nyZ1JDiR5dZJTq+q1VXXasrN2zi3643s4yUuO+PglST6/yBJYQFV9f5Ifyyrun154zlZZf4HpRd39\nnvWhP0jy4iR/LYmLjOfeXyT59vWP07K6g/IjST6eZE88ovX3wR/H+jO1zyX5p1l9JvcLSR7p7rcu\nOmwLVdW7k3y+u3966S3boqr+dpJPJfmH638mSbp7z3270F5UVd+S5NNJLszqayF+Islr19/RwC6q\nqnOT3Nvdf33pLSfDFfxxdPefV9V1SX4ryZeyeg725mVXwa55U5IzknzkyINVdUZ3H15k0Rbp7j+q\nqrcn+fD60L1ZXWzAjriC34Gq2pfkhZ69A7tt/cz9hd39+NJb2FsEHgAG8lX0ADCQwAPAQAIPAAMJ\nPAAMJPAAMJDAA8BAAg8AAwk8AAwk8AAwkMADwEACDwADCTwADCTwADCQwAPAQAIPAAMJPAAMJPAA\nMJDAA8BAAg88TVW9oKr+Z1X95Ncdv62qfmWpXcDO7Vt6ALB5uvurVXVlkruq6ve7+zer6oeTfGeS\nixaeB+yAwANH1d2fWkf9vVX1tSRvS3Jxd3954WnADlR3L70B2GBV9Z+TfFeSN3X3Lyy9B9gZz+CB\nE/lMkucleXTpIcDOCTxwTFX1yiRvSPL2JO+uqhctuwjYKbfogaOqqr+a5FNJfirJe5N8JMlnu/tf\nLDgL2CGBB46qqt6T5O8kubS7u6r2J/lEkiu6+3eWXQeciMADT1NVr0ny60le0d3/64jjP5zkXyW5\n0FfTw2YTeAAYyBfZAcBAAg8AAwk8AAwk8AAwkMADwEACDwADCTwADCTwADCQwAPAQAIPAAMJPAAM\nJPAAMJDAA8BAAg8AAwk8AAwk8AAwkMADwED/H6UNZxiz2mxPAAAAAElFTkSuQmCC\n"
+      },
+      {
+       "output_type": "display_data",
+       "text": [
+        "    print(summary(lm(Y ~ X)))\n",
+        "\u0000"
+       ]
+      },
+      {
+       "output_type": "display_data",
+       "text": [
+        "    ## \n",
+        "    ## Call:\n",
+        "    ## lm(formula = Y ~ X)\n",
+        "    ## \n",
+        "    ## Residuals:\n",
+        "    ##    1    2    3    4    5 \n",
+        "    ## -0.2  0.9 -1.0  0.1  0.2 \n",
+        "    ## \n",
+        "    ## Coefficients:\n",
+        "    ##             Estimate Std. Error t value Pr(>|t|)  \n",
+        "    ## (Intercept)    3.200      0.616    5.19    0.014 *\n",
+        "    ## X              0.900      0.252    3.58    0.037 *\n",
+        "    ## ---\n",
+        "    ## Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1 \n",
+        "    ## \n",
+        "    ## Residual standard error: 0.796 on 3 degrees of freedom\n",
+        "    ## Multiple R-squared: 0.81,\tAdjusted R-squared: 0.747 \n",
+        "    ## F-statistic: 12.8 on 1 and 3 DF,  p-value: 0.0374\n",
+        "\u0000"
+       ]
+      },
+      {
+       "output_type": "display_data",
+       "text": [
+        "    vv = mean(X) * mean(Y)\n",
+        "\u0000"
+       ]
       },
       {
        "output_type": "stream",
        "stream": "stdout",
        "text": [
-        "v1 is: [ 10.]\n",
         "v2 is: [ 10.]\n"
        ]
       }
      ],
-     "prompt_number": 10
+     "prompt_number": 41
     },
     {
      "cell_type": "heading",
@@ -372,39 +518,14 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Some calls have no particularly interesting return value, the magic %R will not return anything in this case. The return value in rpy2 is actually NULL so %R returns None."
+      "`%R` returns `None` in `knitr` mode. To return something directly to python, use %Rget."
      ]
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "v = %R plot(X,Y)\n",
-      "assert v == None"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAeAAAAHgCAYAAAB91L6VAAAD8GlDQ1BJQ0MgUHJvZmlsZQAAKJGN\nVd1v21QUP4lvXKQWP6Cxjg4Vi69VU1u5GxqtxgZJk6XpQhq5zdgqpMl1bhpT1za2021Vn/YCbwz4\nA4CyBx6QeEIaDMT2su0BtElTQRXVJKQ9dNpAaJP2gqpwrq9Tu13GuJGvfznndz7v0TVAx1ea45hJ\nGWDe8l01n5GPn5iWO1YhCc9BJ/RAp6Z7TrpcLgIuxoVH1sNfIcHeNwfa6/9zdVappwMknkJsVz19\nHvFpgJSpO64PIN5G+fAp30Hc8TziHS4miFhheJbjLMMzHB8POFPqKGKWi6TXtSriJcT9MzH5bAzz\nHIK1I08t6hq6zHpRdu2aYdJYuk9Q/881bzZa8Xrx6fLmJo/iu4/VXnfH1BB/rmu5ScQvI77m+Bkm\nfxXxvcZcJY14L0DymZp7pML5yTcW61PvIN6JuGr4halQvmjNlCa4bXJ5zj6qhpxrujeKPYMXEd+q\n00KR5yNAlWZzrF+Ie+uNsdC/MO4tTOZafhbroyXuR3Df08bLiHsQf+ja6gTPWVimZl7l/oUrjl8O\ncxDWLbNU5D6JRL2gxkDu16fGuC054OMhclsyXTOOFEL+kmMGs4i5kfNuQ62EnBuam8tzP+Q+tSqh\nz9SuqpZlvR1EfBiOJTSgYMMM7jpYsAEyqJCHDL4dcFFTAwNMlFDUUpQYiadhDmXteeWAw3HEmA2s\n15k1RmnP4RHuhBybdBOF7MfnICmSQ2SYjIBM3iRvkcMki9IRcnDTthyLz2Ld2fTzPjTQK+Mdg8y5\nnkZfFO+se9LQr3/09xZr+5GcaSufeAfAww60mAPx+q8u/bAr8rFCLrx7s+vqEkw8qb+p26n11Aru\nq6m1iJH6PbWGv1VIY25mkNE8PkaQhxfLIF7DZXx80HD/A3l2jLclYs061xNpWCfoB6WHJTjbH0mV\n35Q/lRXlC+W8cndbl9t2SfhU+Fb4UfhO+F74GWThknBZ+Em4InwjXIyd1ePnY/Psg3pb1TJNu15T\nMKWMtFt6ScpKL0ivSMXIn9QtDUlj0h7U7N48t3i8eC0GnMC91dX2sTivgloDTgUVeEGHLTizbf5D\na9JLhkhh29QOs1luMcScmBXTIIt7xRFxSBxnuJWfuAd1I7jntkyd/pgKaIwVr3MgmDo2q8x6IdB5\nQH162mcX7ajtnHGN2bov71OU1+U0fqqoXLD0wX5ZM005UHmySz3qLtDqILDvIL+iH6jB9y2x83ok\n898GOPQX3lk3Itl0A+BrD6D7tUjWh3fis58BXDigN9yF8M5PJH4B8Gr79/F/XRm8m241mw/wvur4\nBGDj42bzn+Vmc+NL9L8GcMn8F1kAcXjEKMJAAAAYFklEQVR4nO3de5DVBf3/8TfBKne8MICwqCiQ\nVkg6KuqYETZCkgPYqqGEBSIwgnJRGo0cRxgxw3FGhVJRErLFC4o3GoVNE4JKMhJSoCSlMkZuC0hy\nWXZ/fzQx40/4thTs+3j28ZjZP/bzmf2cFzPMPOd8zjm7DWpqamoCAKhTn8keAAD1kQADQAIBBoAE\nAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEg\ngQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAA\nSCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQY\nABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEgQaPsAXXp\nqaeeiqqqquwZABSINm3aRK9evVIeu0FNTU1NyiPXsblz58bdd98dV199dfYUAArEvffeG4899lh8\n8YtfrPPHrjfPgKuqqmLw4MExfPjw7CkAFIg1a9ZEdXV1ymN7DRgAEggwACQQYABIIMAAkECAASCB\nAANAAgEGgAT15nPAABSnt956K7Zu3Rqf/exn45hjjsmeU2sF8Qz4/fffj71792bPAOBTpKamJm69\n9daYNGlSzJ07N0pLS2Pp0qXZs2qtIALct2/fuOCCC2Lt2rXZUwD4lJg8eXLs2LEjysvLY+rUqfHG\nG2/EDTfcEO+99172tFopmFvQ3bp1i/POOy8mTJgQQ4cOjVatWh30NV577bX49a9/vd9zixYtijZt\n2sSIESP+16kAFIBly5bFjBkz9n1/yimnxJAhQ+JXv/pVnHDCCYnLaqcgngFHRAwbNiwWL14cP//5\nz6O0tDRGjBgRixcvjm3bttX6Gu3atYtu3brt96thw4axYcOGw/gvAKAuNW/ePHbu3PmxY5WVlVFS\nUpK06OAUzDPgiIjOnTvHggULYtWqVTFjxoz41re+FevWrYshQ4bEQw899B9/vmvXrtG1a9f9nnv5\n5Zdj/fr1h3oyAEkGDBgQEyZMiEceeSSaNGkS8+bNi5tvvvmgnrhlKqgA/9spp5wSU6dOjalTp8aO\nHTti06ZN2ZMAKDBlZWWxYcOGOOOMM6Jr167RvHnzeO+996JFixbZ02qlIAI8YcKE6Nix437PNWvW\nLJo1a1bHiwD4NBg5cmSMHDkye8Z/pSACPHDgwOwJAFCnCuZNWABQnwgwACQQYABIIMAAkECAASCB\nAANAAgEGgAQCDAAJBBgAEggwACQQYABIIMAAkECAASCBAANAAgEGgAQCDAAJBBgAEggwACQQYABI\nIMAAkECAASCBAANAAgEGgAQCDAAJBBgAEggwACQQYABIIMAAkECAASCBAANAAgEGgAQCDAAJBBgA\nEggwACQQYABIIMAAkECAASCBAANAAgEGgAQCDAAJBBgAEggwACQQYABIIMAAkECAASCBAANAAgEG\ngAQCDAAJBBgAEggwACQQYABIIMAAkECAASCBAANAAgEGgAQCDAAJBBgAEggwACQQYABIIMAAkECA\nASCBAANAAgEGgAQCDAAJBBgAEggwACQQYABIIMAAkECAASCBAANAAgEGgAQCDAAJGmUPOJCdO3dG\nw4YNo6SkJHsKwEGprq6OGTNmxC9/+cs44ogj4rrrroszzzwzexYFpiCeAa9bty4GDx4cy5Ytiw0b\nNsTQoUOjXbt2cdRRR8WQIUNi9+7d2RMBam3w4MGxYMGCmDx5cowZMya+//3vx4svvpg9iwJTEAG+\n9dZb4/jjj4/Pf/7zcd9990VVVVWsXLky3nzzzdi+fXtMmjSpVteprq6Oqqqq/X5VV1dHTU3NYf6X\nAPXd66+/Hu+++248+eST0alTp+jevXvMmDEj7rvvvuxpFJiCuAX92muvxapVq+KII46IZ555JubN\nmxelpaURETFp0qQYMWJEra4zc+bMmDNnzn7PrV69Ok488cRDNRlgvyorK6N3794fO9ahQ4eorq5O\nWkShKogAd+3aNWbNmhXXXHNN9OzZM+bPnx+jR4+OiIgXXnghunTpUqvrDB06NIYOHbrfc2PHjo31\n69cfss0A+9O1a9e49957Y9OmTXHsscdGRMSiRYviww8/TF5GoSmIAE+bNi2+/vWvx8MPPxydO3eO\nG2+8MR555JH4zGc+E9u2bYvXXnsteyJArZxwwgkxdOjQaN26dcyePTu2bt0azz77bDz55JPZ0ygw\nBRHgk08+Od56661YsGBBrF69Oo4//vg4+uijo0uXLtG3b99o1KggZgLUSv/+/WP58uWxaNGiaNKk\nSZSXl+97Ngz/VjBla9CgQVx00UVx0UUXZU8B+J917949unfvnj2DAlYQ74IGgPpGgAEggQADQAIB\nBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBA\ngAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAk\nEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwA\nCQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQAD\nQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASPCJ\nAN90002xffv2jC3UY5WVlfHyyy/HwoUL46OPPsqeA3DYfSLA69ati9NOOy0WLVqUsWefDRs2RFVV\nVeoG6sbatWvj0ksvjddffz0qKiqiZcuWsX79+uxZAIfVJwL8+OOPxx133BFlZWUxYcKE2L1792Ef\nMXjw4Fi1alVERKxevTr69u0bHTt2jHbt2sWoUaNiz549h30DOT766KM47bTT4rvf/W5873vfiylT\npsTMmTNjwoQJsXfv3ux5AIdNo/0dHDhwYHz1q1+NG2+8Mc4666y4/PLL95079dRT49JLLz2kI1au\nXBk7duyIiIgpU6bEKaecErNnz46NGzfGuHHjYsqUKXHrrbf+x+s899xzsWDBgv2eW7RoURx77LGH\ndDf/uz//+c9x1VVXRe/evfcdGzRoUDz33HPx/vvvR8eOHRPXARw++w1wRESDBg2ipKQk1q9fHytX\nrtx3vHnz5od10EsvvRRr1qyJFi1axDHHHBOTJ0+OcePG1SrAPXr0iJNOOmm/5yorK/dFnsLRuHHj\nqKys/Nix6urqWLt2bTRp0iRpFcDht98Al5eXx/XXXx9f/vKXY8WKFdGmTZvDPmTJkiXRvn37OOec\nc2LTpk3RokWLiIhYsWJFnH766bW6Rtu2baNt27b7Pde6dWuvKRegLl26xMknnxy33357TJgwIaqq\nquIrX/lK9OzZM1q3bp09D+Cw+USAr7jiiqioqIj7778/vvnNb9bJiKuuuiqef/75mDRpUmzdujUa\nN24c5eXlcdttt8W0adOioqKiTnaQY9KkSXH99dfHxRdfHE2bNo0hQ4bE8OHDs2cBHFafCHCrVq3i\nj3/84wGfSR4O48ePj/Hjx0dExN///vfYtm1bRET06dMnbrzxxsN+25tcDRs2jGnTpmXPAKhTnwjw\ngw8+mLFjnw4dOkSHDh0iIuKcc85J3QIAh4vfhAUACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIB\nBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBA\ngAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAk\nEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwA\nCQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQAD\nQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAEBRvgnTt3xrZt27JnQFFZtmxZ\nDBw4MPr06RNlZWWxadOm7ElQbxVsgOfOnRvjxo3LngFF469//WvccMMNMX78+Hj22Wdj6NChcfnl\nl8fmzZuzp0G91Ch7QEREly5dYuPGjR87tnv37qiqqoq5c+dG//79Y+bMmf/xOlu2bInKysr9ntu6\ndWvs2bPnkOyFT6O77ror7rjjjjjzzDMjIuJrX/tavPPOO/HYY4/F6NGjk9dB/VMQAZ45c2YMGTIk\nBg0aFFdffXVERMybNy+WLl0aP/jBD6JZs2a1uk5FRUXMnz9/v+d+85vfRNu2bQ/ZZvi0+fDDD6Nd\nu3YfO1ZaWhqrV69OWgT1W0EE+Pzzz49ly5bFqFGjYty4cfHAAw9E69ato3nz5nHCCSfU+jplZWVR\nVla233Njx46N9evXH6rJ8KnTo0eP+OEPfxgzZsyIiH/dZfrOd74Tc+fOTV4G9VNBBDgiomXLljFr\n1qx44okn4oILLogePXpEw4YNs2dB0Rg2bFjMnz8/evfuHf37948FCxbExIkTo1evXtnToF4qmAD/\n2+WXXx7nnXdejBw5Mrp37549B4pGw4YN47nnnouKiorYvHlzTJw4Mc4444zsWVBvFVyAI/71utTz\nzz+fPQOK0oUXXpg9AYgC/hgSABQzAQaABAIMAAkEGAASCDAAJBBgAEggwACQQIABIIEAA0ACAQaA\nBAIMAAkEGAASCDAAJBBgAEggwACQQIABIIEAA0ACAQaABAIMAAkEGAASCDAAJBBgAEggwACQQIAB\nIIEAA0ACAQaABAIMAAkEGAASCDAAJBBgAEggwACQQIABIIEAA0ACAQaABAIMAAkEGAASCDAAJBBg\nAEggwACQQIABIIEAA0ACAQaABAIMAAkEGAASCDAAJBBgAEggwACQQIABIIEAA0ACAQaABAIMAAkE\nGAASCDAAJBBgAEggwACQQIABIIEAA0ACAQaABAIMAAkEGAASCDAAJBBgAEggwACQQIABIIEAA0AC\nAQaABAIMAAkEGAASCDAAJBBgAEggwACQQIABIEGj7AGF7qWXXor3338/jjvuuOjTp0/2HACKRME+\nA967d29s27YtdcPVV18dTz31VJSUlMRdd90Vl112WVRXV6duAqA4FESA9+zZE1OmTIkhQ4bEG2+8\nEXPmzIm2bdvGUUcdFZdeemns2rWrzjeVl5fHW2+9FQ899FAMGjQofvGLX0TLli3jpz/9aZ1vAaD4\nFMQt6JtuuinefvvtOOOMM+KKK66IRo0axdy5c6O0tDTGjh0b8+bNiyuuuOI/Xmf27Nnx9NNP7/fc\nm2++GaWlpbXetHz58rjnnns+dmz48OHx+OOP1/oaAHAgBRHg+fPnx7Jly6Jly5bRpEmT+OCDD+LL\nX/5yRERMnjw5Jk6cWKsAX3bZZXHJJZfs99yTTz4ZO3bsqPWmli1bxurVq+P888/fd+z3v/99tGzZ\nstbXAIADKYgAn3TSSbFq1ao4++yz45prrom//e1v+86tWLEiOnfuXKvrNG7cOBo3brzfcy1btoy9\ne/fWetOwYcOirKws2rVrF2effXYsWrQoRowYEZWVlbW+BgAcSEEEeNy4cdGvX7/48Y9/HP369Yv2\n7dtHRMQtt9wSjzzySCxcuLDON7Vp0ybmzZsXN910U8yaNSvatGkT69ati1atWtX5FgCKT0EE+KKL\nLorVq1d/4hbxJZdcEhMnToymTZum7DrmmGPi4YcfTnlsAIpbQQQ44l+3iP//11fPPffcpDUAcHgV\nxMeQAKC+EWAASCDAAJBAgAEggQADQAIBBoAEAgwACRrU1NTUZI+oC8uXL4++ffvG6aefftA/+8or\nrxzwV1xy6OzevTsaNGgQJSUl2VOK3o4dO6JZs2bZM4rezp07o6SkJBo2bJg9paj9O2PnnXfeQf/s\n2rVrY8GCBdGhQ4dDPes/qjcB/l/07NkzXn311ewZRW/atGnRtm3bKCsry55S9Pyfrhs333xz9OvX\nL84555zsKUXtgw8+iNGjR3/q/lqdW9AAkECAASCBAANAAgEGgAQCDAAJBBgAEvgYUi384x//iOOO\nOy57RtHbtm1bNGzY0OdT64D/03Vj8+bN0axZszjyyCOzpxS16urq2LhxY7Rp0yZ7ykERYABI4BY0\nACQQYABIIMAAkECAASCBAANAAgEGgAQCDAAJBJiCsmfPnuwJAHVCgP8Pr776apx//vnRqVOnGDBg\nQGzZsiV7UlErLy+Pc889N3tGUSsvL49evXpF9+7dY9CgQfH2229nTypKa9asiQEDBkS3bt3i7LPP\njtdffz17UtG79tprY/jw4dkzDooAH8DGjRvjyiuvjOnTp8eaNWuiU6dOMX78+OxZRWnLli0xatSo\nuOGGG8IvZjt81q9fH2PHjo3y8vL4wx/+EBdeeGGMGTMme1ZRGjp0aFx22WWxYsWKmDx5cpSVlWVP\nKmovvvhizJ07N3vGQRPgA1i2bFmceuqpcdppp0VJSUmMHj06nn766exZRamioiKaNm0ajz76aPaU\nolZdXR1PPPFEtG3bNiIiunfvHkuWLEleVZzmzZsXAwcOjIiIqqqqqKqqSl5UvDZt2hSTJ0+O0aNH\nZ085aAJ8AOvWrfvYL6tv27ZtbN26NXbt2pW4qjiVlZXFXXfdFU2aNMmeUtTat28fF1xwwb7vH3zw\nwejbt2/iouJ17LHHRoMGDWLMmDFx7bXXxv333589qWiNHDkybrvttmjevHn2lIMmwAewadOmj/1V\nnn/H4Z///GfWJDhkZsyYEc8//3xMnTo1e0rR2rVrV7Rp0yZKS0tjzpw5sXv37uxJRednP/tZNGnS\nJHr37p095b8iwAfQunXr2LZt277vt2/fHo0bN46jjz46cRX87x544IGYOHFiLFy4MEpLS7PnFK0j\njzwybrnllli8eHG88sorsXjx4uxJRWXTpk0xZsyY6NWrV7zwwgvx9ttvx3vvvRdLly7NnlZrAnwA\npaWl8e677+77/t13342OHTvmDYJD4NFHH43bbrstFi5cGKeeemr2nKK0c+fOmDBhwr6Xqxo1ahRd\nu3aNP/3pT8nLiktlZWV07tw5HnjggbjjjjuioqIili9fHrNnz86eVmsCfAC9evWKtWvXRkVFReza\ntSvuvvvu+MY3vpE9C/5rf/nLX+K6666LOXPmRPv27WPz5s2xefPm7FlFp3HjxvG73/0uZs6cGRH/\nekPnb3/72/jSl76UvKy4nHzyybFkyZJ9X6NGjYp+/frF9OnTs6fVWqPsAYXqyCOPjPvvvz/69+8f\nrVq1iq5du8a0adOyZ8F/bfr06bFjx47o2bPnx47v2LEjmjZtmjOqSE2ZMiXGjRsX99xzT7Rq1Spm\nzZoVn/vc57JnUWAa1Pjg5f+pqqoqtm/f7rVf4KBt3bo1WrVqlT2DAiXAAJDAa8AAkECAASCBAANA\nAgEGgAQCDAAJBBgAEggwACQQYABIIMAAkECAASCBAANAAgEGgAQCDAAJBBgAEggwACQQYABIIMAA\nkECAASCBAEM9sHPnzvjCF74Qt9xyy8eOf/vb344rr7wyaRXUb42yBwCHX+PGjaO8vDx69OgRZ511\nVgwYMCDuvPPOWLp0aSxbtix7HtRLAgz1RLdu3eLOO++MYcOGRUlJSUyaNCmWLFkSLVq0yJ4G9VKD\nmpqamuwRQN25+OKL4+WXX47p06fHtddemz0H6i2vAUM907lz59i7d2+0bt06ewrUawIM9cirr74a\ns2bNittvvz2uu+662LJlS/YkqLfcgoZ64sMPP4xu3brFzTffHMOGDYuePXtGp06d4ic/+Un2NKiX\nBBjqieHDh8c777wTCxYsiAYNGsSaNWuie/fu8cwzz0SfPn2y50G9I8BQD7z00ktRVlYWK1asiBNP\nPHHf8TvvvDN+9KMfxcqVK70bGuqYAANAAm/CAoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQAD\nQAIBBoAEAgwACQQYABIIMAAkEGAASCDAAJBAgAEggQADQAIBBoAE/w+5mUYqDkF0XgAAAABJRU5E\nrkJggg==\n"
-      }
-     ],
-     "prompt_number": 11
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Also, if the return value of a call to %R (in line mode) has just been printed to the console, then its value is also not returned."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "v = %R print(X)\n",
-      "assert v == None"
+      "%R plot(X,Y)\n"
      ],
      "language": "python",
      "metadata": {},
@@ -412,74 +533,16 @@
       {
        "output_type": "display_data",
        "text": [
-        "[1] 0 1 2 3 4\n"
-       ]
-      }
-     ],
-     "prompt_number": 12
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "But, if the last value did not print anything to console, the value is returned:\n"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "v = %R print(summary(X)); X\n",
-      "print 'v:', v"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "display_data",
-       "text": [
-        "   Min. 1st Qu.  Median    Mean 3rd Qu.    Max. \n",
-        "      0       1       2       2       3       4 \n"
+        "    plot(X, Y)\n",
+        "\u0000"
        ]
       },
       {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "v: [0 1 2 3 4]\n"
-       ]
+       "output_type": "display_data",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAfgAAAH4CAYAAACmKP9/AAAD8GlDQ1BJQ0MgUHJvZmlsZQAAKJGN\nVd1v21QUP4lvXKQWP6Cxjg4Vi69VU1u5GxqtxgZJk6XpQhq5zdgqpMl1bhpT1za2021Vn/YCbwz4\nA4CyBx6QeEIaDMT2su0BtElTQRXVJKQ9dNpAaJP2gqpwrq9Tu13GuJGvfznndz7v0TVAx1ea45hJ\nGWDe8l01n5GPn5iWO1YhCc9BJ/RAp6Z7TrpcLgIuxoVH1sNfIcHeNwfa6/9zdVappwMknkJsVz19\nHvFpgJSpO64PIN5G+fAp30Hc8TziHS4miFhheJbjLMMzHB8POFPqKGKWi6TXtSriJcT9MzH5bAzz\nHIK1I08t6hq6zHpRdu2aYdJYuk9Q/881bzZa8Xrx6fLmJo/iu4/VXnfH1BB/rmu5ScQvI77m+Bkm\nfxXxvcZcJY14L0DymZp7pML5yTcW61PvIN6JuGr4halQvmjNlCa4bXJ5zj6qhpxrujeKPYMXEd+q\n00KR5yNAlWZzrF+Ie+uNsdC/MO4tTOZafhbroyXuR3Df08bLiHsQf+ja6gTPWVimZl7l/oUrjl8O\ncxDWLbNU5D6JRL2gxkDu16fGuC054OMhclsyXTOOFEL+kmMGs4i5kfNuQ62EnBuam8tzP+Q+tSqh\nz9SuqpZlvR1EfBiOJTSgYMMM7jpYsAEyqJCHDL4dcFFTAwNMlFDUUpQYiadhDmXteeWAw3HEmA2s\n15k1RmnP4RHuhBybdBOF7MfnICmSQ2SYjIBM3iRvkcMki9IRcnDTthyLz2Ld2fTzPjTQK+Mdg8y5\nnkZfFO+se9LQr3/09xZr+5GcaSufeAfAww60mAPx+q8u/bAr8rFCLrx7s+vqEkw8qb+p26n11Aru\nq6m1iJH6PbWGv1VIY25mkNE8PkaQhxfLIF7DZXx80HD/A3l2jLclYs061xNpWCfoB6WHJTjbH0mV\n35Q/lRXlC+W8cndbl9t2SfhU+Fb4UfhO+F74GWThknBZ+Em4InwjXIyd1ePnY/Psg3pb1TJNu15T\nMKWMtFt6ScpKL0ivSMXIn9QtDUlj0h7U7N48t3i8eC0GnMC91dX2sTivgloDTgUVeEGHLTizbf5D\na9JLhkhh29QOs1luMcScmBXTIIt7xRFxSBxnuJWfuAd1I7jntkyd/pgKaIwVr3MgmDo2q8x6IdB5\nQH162mcX7ajtnHGN2bov71OU1+U0fqqoXLD0wX5ZM005UHmySz3qLtDqILDvIL+iH6jB9y2x83ok\n898GOPQX3lk3Itl0A+BrD6D7tUjWh3fis58BXDigN9yF8M5PJH4B8Gr79/F/XRm8m241mw/wvur4\nBGDj42bzn+Vmc+NL9L8GcMn8F1kAcXjEKMJAAAATzklEQVR4nO3df8yuBX3f8c8Xj+BgwhyWtNsC\nzoUjrZguHf8UzhYTpSadEphdV7bMjkJlU9J/hlvtqula0zbCQVJqWmsl1NnamqY/srGUZjNqiCsr\nGaijEiq4KVJPB21FOdja7bs/7pvkRM6P5wg81/1879crOeE81xXu8zl3lPdzXdfznFPdHQBgllOW\nHgAAPPsEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEE\nHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngA\nGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAg\ngQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQe\nAAYSeAAYSOABYCCBB4CB9i09YDdV1fdky37PACzqj7v7w0v8wtXdS/y6u66qXp/kXyf5paW3ALA1\nfijJP+vue3f7F96mq9l9Sd7f3e9ZeggA26Gq9mehx+GewQPAQAIPAAMJPAAMJPAAMJDAA8BAAg8A\nAwk8AAwk8AAw0Db9QTcAcFKq6pIkZyd5sLvvW3rPydiIK/iq+htV9byldwDAU6rqYJJrkpyf5I6q\num7hSSdlIwKf5PYkH6uqly49BACq6uokp3T3Vd19MMn+JFdU1YGFp+3YJt2i/1SSj1fVO5O8r7u/\ndLIvUFWXJbn0GKe/I8nnkvz8Nz4RgC1xcZIbnvqguw9X1S3r43cutuokbFLg35vkxiQ/l+TfV9Uv\nJ/lAkk929+M7fI27kjx0jHP/Jsnpz3glANvgcJJzktx/xLHz1sf3hE0KfLr7M0kuraoLsnru8R+S\nnFtVt3b3D+7g3z+U5NDRzlXVY9mw3y8AG+t9SW6uqjd29wNVdXmSm5OctfCuHdvI4HX3/UmuT3J9\nVZ2R1VcwAsCu6O57q+r6JLdV1ZNZ3R0+7yTuKC9uUwL/ziSfP9qJ7n4iyRO7OweAbdfdd2f1zH1P\n2ojAd/cHl94AAJNsyrfJAQDPIoEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CB\nBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4\nABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFg\nIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEE\nHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngA\nGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWCg\nfUsPAODYquqSJGcnebC771t6D3vHxl7BV9ULqur5S+8AWEpVHUxyTZLzk9xRVdctPIk9ZCMCX1Xn\nVtX7q+qiqvqmqnpfki8m+bOqurWqTl16I8Buqqqrk5zS3Vd198Ek+5NcUVUHFp7GHrEpt+h/PMnn\nktyX5K1Z7bowyWlJfjrJ29Y/jquqLkty6TFOH0jy6LMxFmAXXJzkhqc+6O7DVXXL+vidi61iz9iU\nwP+DJBd0919U1RVJLu/uh5Okqt6W5Od3+Dp3JXnoGOfOSnL6M14KsDsOJzknyf1HHDtvfRxOaFMC\n/0CSNyT5xSQfSfLdSW5Zn3ttkj/cyYt096Ekh452rqoey+b8fgFO5H1Jbq6qN3b3A1V1eZKbs7pY\ngRPalOC9Ocl/Wj9z+kySG6vqB5L8vyRnZnWFD7A1uvveqro+yW1V9WRWdyfP6+7HF57GHrERge/u\nB6vq27J6fv6yrJ7H/2lWV+63d/dfLrkPYAndfXdWz9zhpG1E4JOkuzvJ765/AADPwEZ8mxwA8OwS\neAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOAB\nYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CB\nBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4\nABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFg\nIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEE\nHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABnpa4Kvqhqp64RJj4Giq6pKquqyq\nXr70FoC94mhX8Ocm+WRV/f3dHnOkqvqmqtq35AaWV1UHk1yT5Pwkd1TVdQtPAtgTnhb47v4nSX4k\nya9X1Tur6tTnekRVvb+qLlj//GVVdXuSzyf5YlX9bFU9/7newOapqquTnNLdV3X3wST7k1xRVQcW\nngaw8Y56hdzdH6yq/5LkxiS/X1UfOuL0p7v7N57lHRcmOWP987cmuT/JP0/y4iQ3rY/9+IlepKou\nS3LpMU4fSPLoM17Kbro4yQ1PfdDdh6vqlvXxOxdbBbAHHO8WeCf5WpJvzirAT/nKc7ooeU2S/d39\n5SR/UlU/mlXkTxj4JHcleegY585KcvqzM5FdcjjJOVl9wveUl6yPA3AcRw18VV2Z5GeSfDTJK7r7\nj3dhy8VV9UiS30tydpIvr4+/Isk9O3mB7j6U5NDRzlXVYzn+JzRsnluT3FRV13b3A1V1eZJ3ZfXJ\nGgDH8bTgVdWvJXlVkuu6+1d3accvJ3ldkrdl9R/vrya5sqp+LMmb13vYMt19T1W9JcltVfVkVndn\nzuvuxxeeBrDxjnZF+6UkL19fDe+K9RdQHUySqvqbSc5cn/qdJDd293P9WIAN1d13Z/XMHYCT8LTA\nd/cblxhyxK//hSRfWP/895bcAgB7lT/JDgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CB\nBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4\nABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFg\nIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEE\nHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngA\nGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAg\ngQeAgQQeAAbat/QAYLNV1SVJzk7yYHfft/QeYGc29gq+ql5QVWcuvQO2WVUdTHJNkvOT3FFV1y08\nCdihjQ18ktcnuWnpEbCtqurqJKd091XdfTDJ/iRXVNWBhacBO7ARt+ir6g+TvPjrDp+aZF9VvT7J\nb3X3VTt4ncuSXHqM0weSPPqMhsJ2uTjJDU990N2Hq+qW9fE7F1sF7MhGBD7JVUluTfKBJL+0PnZ5\nku9M8m+TPLHD17kryUPHOHdWktOfwUbYNoeTnJPk/iOOnbc+Dmy4jQh8d99ZVRcl+dmsbstfm9XV\n9le6+3+fxOscSnLoaOeq6rFsyO8X9ohbk9xUVdd29wNVdXmSm7P6ZBnYcBsTvO5+PMkbqup7k3ws\nq6vx/7vsKthe3X1PVb0lyW1V9WRWd8fOW/9/FdhwGxP4p3T3h6rq40l+Lsknlt4D26y7787qmTuw\nx2xc4JOkux9O8rqldwDAXrXJ3yYHAHyDBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeA\ngQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYS\neAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOAB\nYCCBB4CBBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CB\nBB4ABhJ4ABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4\nABhI4AFgIIEHgIEEHgAGEngAGEjgAWAggQeAgQQeAAYSeAAYSOABYCCBB4CBBB4ABhJ4ABhI4AFg\nIIEHgIH2LT1gL6iqS5KcneTB7r5v6T0AcCIbewVfVc+rqjM3YMfBJNckOT/JHVV13cKTAOCENiLw\nVfX8qnprVd1aVd9RVd+X5FCSP6uq36iq0xbadXWSU7r7qu4+mGR/kiuq6sASewBgpzblFv0NSb41\nyf9I8mtJ/jLJ65M8nORdSS5fHz+uqrosyaXHOH0gyaMnuevi9bYkSXcfrqpb1sfvPMnXAoBdsymB\n/+4kF3X341X1ZJJzuvujSVJVP5rkHdlB4JPcleShY5z7YpI6yV2Hk5yT5P4jjr1kfRwANtamBP6h\nJBck+e9JfjHJ3zri3CuSfGYnL9Ldh7K6tf80VfXyJC86yV23Jrmpqq7t7geq6vKs7iicdZKvAwC7\nalMCf1OS366qf9ndv53kkSSpqp9M8gNJXr3EqO6+p6rekuS29Z2Fh5Kc192PL7EHAHZqIwLf3b9b\nVS9LcsbXnfqPSd7R3YvdEu/uu7N65g4Ae8ZGBD5J1lfFj3/dsf+20BwA2NM24tvkAIBnl8ADwEAC\nDwADCTwADCTwADCQwAPAQAIPAAMJPAAMVN299IZdUVV/N8ntSe75Bl/iVUmeePYWcZLOiPd/Sd7/\nZXn/l3Vqko99g//uS5Nc2t1feBb37MjWBP6ZqqqPdPcrl96xrbz/y/L+L8v7v6y9+v67RQ8AAwk8\nAAwk8AAwkMADwEACDwADCTwADOTb5Haoqr6lu/9o6R3byvu/LO//srz/y9qr77/AA8BAbtEDwEAC\nDwADCTwADCTwADCQwAPAQAIPAAMJPAAMJPDsCbXyvKV3AOwVAn8CVfXKqrqzqj5bVb9ZVS9aetO2\nqapTknwoyVuW3rJtqurKqvpwVX2iqj5QVd+69KZtUlXft/7vzx9U1Qer6qylN22jqvquqvqTpXec\nLIE/jqp6cZJfSfKmJPuTfDbJwUVHbZmq+ntJPprkVUtv2TZV9c1J3pXkyu7+9iT/NcnNy67aHlX1\n0qze/yu6+9uSfCXJ25ddtX3WF3U3Jqmlt5wsgT++i5J8urs/2d1fS3JLkn+08KZt8/1JfibJB5ce\nsoVOSfK93X1o/fEnkly84J5t89kkF3b3/1l/vC+Jx1S775asPtHac3+u+76lB2y4c5Mc+RcMHEpy\nVlWd1t1/vtCmrdLdP5SsHpUsPGXrdPcjSR454tAbk9y+0Jyt06u/KOSxqrogyU8keXmS1yy7artU\n1T9O8tWs7l7tOa7gj+/sJE8c8fGT63+evsAWWExVXZPkdUmuX3rLFvorSR5I8oII/K5ZP6J6e/bw\n/+YF/vgeTXLmER+/MMlXu/tPF9oDu66qrk3yjiSv7u6Hl96zbbr7nu7+d0l+MMlPVdWeexa8R707\nyZ1JDiR5dZJTq+q1VXXasrN2zi3643s4yUuO+PglST6/yBJYQFV9f5Ifyyrun154zlZZf4HpRd39\nnvWhP0jy4iR/LYmLjOfeXyT59vWP07K6g/IjST6eZE88ovX3wR/H+jO1zyX5p1l9JvcLSR7p7rcu\nOmwLVdW7k3y+u3966S3boqr+dpJPJfmH638mSbp7z3270F5UVd+S5NNJLszqayF+Islr19/RwC6q\nqnOT3Nvdf33pLSfDFfxxdPefV9V1SX4ryZeyeg725mVXwa55U5IzknzkyINVdUZ3H15k0Rbp7j+q\nqrcn+fD60L1ZXWzAjriC34Gq2pfkhZ69A7tt/cz9hd39+NJb2FsEHgAG8lX0ADCQwAPAQAIPAAMJ\nPAAMJPAAMJDAA8BAAg8AAwk8AAwk8AAwkMADwEACDwADCTwADCTwADCQwAPAQAIPAAMJPAAMJPAA\nMJDAA8BAAg88TVW9oKr+Z1X95Ncdv62qfmWpXcDO7Vt6ALB5uvurVXVlkruq6ve7+zer6oeTfGeS\nixaeB+yAwANH1d2fWkf9vVX1tSRvS3Jxd3954WnADlR3L70B2GBV9Z+TfFeSN3X3Lyy9B9gZz+CB\nE/lMkucleXTpIcDOCTxwTFX1yiRvSPL2JO+uqhctuwjYKbfogaOqqr+a5FNJfirJe5N8JMlnu/tf\nLDgL2CGBB46qqt6T5O8kubS7u6r2J/lEkiu6+3eWXQeciMADT1NVr0ny60le0d3/64jjP5zkXyW5\n0FfTw2YTeAAYyBfZAcBAAg8AAwk8AAwk8AAwkMADwEACDwADCTwADCTwADCQwAPAQAIPAAMJPAAM\nJPAAMJDAA8BAAg8AAwk8AAwk8AAwkMADwED/H6UNZxiz2mxPAAAAAElFTkSuQmCC\n"
       }
      ],
-     "prompt_number": 13
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The return value can be suppressed by a trailing ';' or an -n argument.\n"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": true,
-     "input": [
-      "%R -n X"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 14
-    },
-    {
-     "cell_type": "code",
-     "collapsed": true,
-     "input": [
-      "%R X; "
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 15
+     "prompt_number": 42
     },
     {
      "cell_type": "heading",
@@ -511,7 +574,7 @@
       "%%R -i X,Y -o XYcoef\n",
       "XYlm = lm(Y~X)\n",
       "XYcoef = coef(XYlm)\n",
-      "print(summary(XYlm))\n",
+      "summary(XYlm)\n",
       "par(mfrow=c(2,2))\n",
       "plot(XYlm)"
      ],
@@ -521,33 +584,50 @@
       {
        "output_type": "display_data",
        "text": [
-        "\n",
-        "Call:\n",
-        "lm(formula = Y ~ X)\n",
-        "\n",
-        "Residuals:\n",
-        "   1    2    3    4    5 \n",
-        "-0.2  0.9 -1.0  0.1  0.2 \n",
-        "\n",
-        "Coefficients:\n",
-        "            Estimate Std. Error t value Pr(>|t|)  \n",
-        "(Intercept)   3.2000     0.6164   5.191   0.0139 *\n",
-        "X             0.9000     0.2517   3.576   0.0374 *\n",
-        "---\n",
-        "Signif. codes:  0 \u2018***\u2019 0.001 \u2018**\u2019 0.01 \u2018*\u2019 0.05 \u2018.\u2019 0.1 \u2018 \u2019 1 \n",
-        "\n",
-        "Residual standard error: 0.7958 on 3 degrees of freedom\n",
-        "Multiple R-squared:  0.81,\tAdjusted R-squared: 0.7467 \n",
-        "F-statistic: 12.79 on 1 and 3 DF,  p-value: 0.03739 \n",
-        "\n"
+        "    XYlm = lm(Y ~ X)\n",
+        "    XYcoef = coef(XYlm)\n",
+        "    summary(XYlm)\n",
+        "\u0000"
        ]
       },
       {
        "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAeAAAAHgCAYAAAB91L6VAAAD8GlDQ1BJQ0MgUHJvZmlsZQAAKJGN\nVd1v21QUP4lvXKQWP6Cxjg4Vi69VU1u5GxqtxgZJk6XpQhq5zdgqpMl1bhpT1za2021Vn/YCbwz4\nA4CyBx6QeEIaDMT2su0BtElTQRXVJKQ9dNpAaJP2gqpwrq9Tu13GuJGvfznndz7v0TVAx1ea45hJ\nGWDe8l01n5GPn5iWO1YhCc9BJ/RAp6Z7TrpcLgIuxoVH1sNfIcHeNwfa6/9zdVappwMknkJsVz19\nHvFpgJSpO64PIN5G+fAp30Hc8TziHS4miFhheJbjLMMzHB8POFPqKGKWi6TXtSriJcT9MzH5bAzz\nHIK1I08t6hq6zHpRdu2aYdJYuk9Q/881bzZa8Xrx6fLmJo/iu4/VXnfH1BB/rmu5ScQvI77m+Bkm\nfxXxvcZcJY14L0DymZp7pML5yTcW61PvIN6JuGr4halQvmjNlCa4bXJ5zj6qhpxrujeKPYMXEd+q\n00KR5yNAlWZzrF+Ie+uNsdC/MO4tTOZafhbroyXuR3Df08bLiHsQf+ja6gTPWVimZl7l/oUrjl8O\ncxDWLbNU5D6JRL2gxkDu16fGuC054OMhclsyXTOOFEL+kmMGs4i5kfNuQ62EnBuam8tzP+Q+tSqh\nz9SuqpZlvR1EfBiOJTSgYMMM7jpYsAEyqJCHDL4dcFFTAwNMlFDUUpQYiadhDmXteeWAw3HEmA2s\n15k1RmnP4RHuhBybdBOF7MfnICmSQ2SYjIBM3iRvkcMki9IRcnDTthyLz2Ld2fTzPjTQK+Mdg8y5\nnkZfFO+se9LQr3/09xZr+5GcaSufeAfAww60mAPx+q8u/bAr8rFCLrx7s+vqEkw8qb+p26n11Aru\nq6m1iJH6PbWGv1VIY25mkNE8PkaQhxfLIF7DZXx80HD/A3l2jLclYs061xNpWCfoB6WHJTjbH0mV\n35Q/lRXlC+W8cndbl9t2SfhU+Fb4UfhO+F74GWThknBZ+Em4InwjXIyd1ePnY/Psg3pb1TJNu15T\nMKWMtFt6ScpKL0ivSMXIn9QtDUlj0h7U7N48t3i8eC0GnMC91dX2sTivgloDTgUVeEGHLTizbf5D\na9JLhkhh29QOs1luMcScmBXTIIt7xRFxSBxnuJWfuAd1I7jntkyd/pgKaIwVr3MgmDo2q8x6IdB5\nQH162mcX7ajtnHGN2bov71OU1+U0fqqoXLD0wX5ZM005UHmySz3qLtDqILDvIL+iH6jB9y2x83ok\n898GOPQX3lk3Itl0A+BrD6D7tUjWh3fis58BXDigN9yF8M5PJH4B8Gr79/F/XRm8m241mw/wvur4\nBGDj42bzn+Vmc+NL9L8GcMn8F1kAcXjEKMJAAAAgAElEQVR4nOzdd1gU59rH8e8soCLFDiiCBTtW\njFhQNNbEXqKvvWOMxhNLLImJJ4k91ojHY0libKgxtqiJioomaoIxNjxGxcYRFAERpYiUnfcP4h4R\nLMDuDuX+XBdXsjO78/xYdrx3Zp55HkVVVRUhhBBCmJVO6wBCCCFEQSQFWAghhNCAFGAhhBBCA1KA\nhRBCCA1IARZCCCE0IAVYCCGE0IAUYCGEEEIDUoCFEEIIDUgBFkIIITQgBVgIIYTQgBRgIYQQQgNS\ngIUQQggNSAEWQgghNCAFWAghhNCAFGAhhBBCA1KAhRBCCA1IARZCCCE0IAVYCCGE0IAUYCGEEEID\nUoCFEEIIDUgBFkIIITQgBVgIIYTQgBRgIYQQQgNSgIUQQggNSAEWQgghNCAFWAghhNCAFGAhhBBC\nA1KAhRBCCA1IARZCCCE0IAVYCCGE0IAUYCGEEEIDUoCFEEIIDUgBFkIIITQgBVgIIQqwhIQEnjx5\nkqXXqKpKTEyMiRIVHFKAjeDRo0coioKzszMuLi64uLhQvnx5evTowb1797K93cqVK3P+/PkMy3/9\n9Vc8PDyyvd0TJ05Qt27dbL8+q3r27EmRIkWwt7dP9xMWFsbUqVP55JNPADhw4ABHjhwBIDQ0FF9f\n3yy3NW7cOObOnWvU/EK8rlatWtGuXbt0y+7fv4+iKKSmppo9T7ly5bhy5Uqm6/bu3YuXlxdubm5U\nr16dNm3a8Msvv7x0e2FhYfTs2RMnJyc8PT2pW7cuX375pSmiFwhSgI3o/Pnz3L59m9u3bxMUFERq\naioff/xxtrd3/PhxatWqZcSE2pk1axaPHj1K9+Ps7MxHH33E5MmTAVi1ahVhYWFA2peMgwcPahlZ\niGw5fvw4a9eu1TrGS23bto2JEycyZcoUQkJCuHXrFtOnT6dXr14cOnQo09eEhobi7e1Ns2bNCAoK\n4urVq/j7+7Nt2zbGjx9v5t8gf5ACbCIlSpTAy8vLcJpGVVVmzZpF+fLlcXZ2Zvbs2aiqCsCGDRtw\ndXWlVKlS9O7dmwcPHgAwePBgbty4AcCOHTuoU6cOFStWZOfOnYZ25syZw7///W/D41mzZrFq1SoA\nLl26xJtvvkmxYsWoUKECS5YsyZDz6tWrNGnSBDs7Ozw8PPjtt98yPOe9997j+++/Nzz+8ccfGTVq\nFCkpKQwfPpzixYtToUIF5s+fn+X36ZtvvmHt2rV8++23+Pv7M3XqVHx9fZk0aRJHjx5l4MCBABw7\ndox69epRvHhxevbsSVRUlOF9nThxImXLlqVFixaEhoZmOYMQxjRlyhQ++uijF579OnbsGD179qRk\nyZJ0796d8PBwAObPn8/MmTMpX748H3zwAQsWLGDBggU0b94cBwcH5s6dy549e6hcuTKNGzc27KsJ\nCQmMHj0aZ2dnSpYsSe/evYmNjX1pxkWLFjFz5ky6detGoUKFAGjdujUfffQRS5cuzfQ133//PQ0a\nNODDDz/EwcEBAEdHR3bs2IGvry9xcXHZer8KMinARnTs2DEOHTrE/v37WbZsGfPnzzcUkA0bNrBx\n40b27NnDrl272Lx5M6dOnSIxMZExY8bw448/cv36deLj41m5ciUAN27cIDExkRs3bjBq1ChmzpzJ\nnj17OHz4sKHNiIgIQzECuHfvHvfv3wdg4MCBdOzYkTt37rBkyRImT55MdHR0uswff/wxXbt2JSIi\ngmHDhjF27NgMv5enpycbNmwwPN64cSONGjVi+/btXLt2jevXr7N//35mz57NtWvXMn1vAgMDWbNm\njeHn7Nmz6fIPGDCAVq1aMWPGDEaOHMkXX3yBl5cXK1euJDIyki5dujB58mT++usvihUrZjjNvGLF\nCn755RcCAgIYO3YsP/30U5b/bkIYk7u7O0OHDmXcuHEZ1t28eZOuXbvStWtXLly4gLW1NUOGDAHS\n9oWvvvqK5cuXM2DAACIjI5k7dy6LFi1i+/btfPLJJ/j6+nLw4EG6devGV199BcBXX33F9evXOXv2\nLL/99hsXLlxg69atL8yXnJzM+fPnadKkSYZ1DRs25M8//8z0dX/88Uemr3FxcaF06dKGfVq8Pkut\nA+Qnn376KQDXrl2jXr16HDlyhPr16wOwbt06hg0bhpubGwDDhw9nz5491K9fH71ez5EjRxgwYAC7\ndu0yfCN9yt/fH3d3d7p37w7AsGHDWL9+/SvzrF69mgYNGqCqKhUrVsTa2prIyMh0z7G0tOTPP//k\nypUrjB07ltGjR2fYTo8ePRg/fjyxsbFYWlri7+/PypUrOXr0KLdv3+bkyZO0b9+eyMhIChcunGmW\nCxcu8PDhQ8NjGxsbGjRoYHhcuHBhrKyssLGxwdraGhsbG6ysrLC1tWXTpk24u7vTtWtXAKZPn06X\nLl1YtGgRO3bsYOjQodSoUYMaNWqwbNmyV74vQpjajBkzqFWrFrt376Z58+aG5bt27aJ27doMHToU\ngJkzZ1K1alUiIiIA6NKli2E//+GHH+jatSuNGzcGoHz58gwePJgqVarQqVMn1qxZA0D//v0ZOnQo\nDg4OPH78mKpVqxqOqjMTHR1NYmIiJUqUyLCubNmy3Lt3j+TkZKysrNKtCwsLo02bNplu08nJSc4+\nZYMcARvRL7/8wqVLlzh9+jQ3btzg9u3bhnVhYWEsWLCA6tWrU716dRYsWMDZs2cpXLgw33//PevW\nrcPZ2ZlOnTpl6DRx7do1GjZsaHj8dId8lcjISFq0aIGDgwMffvghqamp6PX6dM9ZvHgxycnJeHp6\nUrNmzXSnmp8qXrw4b775Jvv27ePnn3+mWbNmhtNn/fv3Z8SIETg6OjJ58uQX9qb08fHh4MGDhp/+\n/fu/1u8AadeegoKCDO9dixYtiImJISwsjOvXr6d7bzL7hi6EuRUtWhRfX1/GjBmT7otnSEhIus9o\nlSpVKFWqFHfu3AHSiuyzypUrZ/h/a2trqlevDqR9YU1JSQHAwsKCDz74AEdHRzp16kRwcPBLO3w5\nOjri6OjIf//73wzrbt68iaurK1ZWVpQsWZJChQpRqFAh9u/fT7169dL9m/asW7duGQ4uxOuTAmwC\ndevWZdasWQwdOtTwTbRRo0bMnTuXu3fvcvfuXYKDg/Hz80Ov1+Ph4cH58+c5f/489vb2GU4Du7q6\ncunSJcPjmzdvGv5fp9OlK3pPj3Cjo6Pp1asXkyZN4s6dOxw+fBhVVQ3XnZ+ytLRk+/bthIeHM3r0\naAYPHmw4hf2svn37snPnTrZv307fvn0BePLkiWH7fn5+7Nmzh++++y5nb14mPD09adasmeG9u3v3\nLn/++SflypXL8N48vWYuhNa6dOlCo0aNmDJlimFZ6dKl031e7969S3R0NJUqVQLSiumznn+cmdGj\nR1OyZEmCgoK4ePEinp6eGfbz53l6erJlyxbD4x07dpCUlMTWrVvx8vICICAggN9//53ff/+dZs2a\n4enpyffff28o7sePHyc0NJT9+/djYWGRbzqMmpMUYBMZPXo0lStXZurUqQB069aNtWvX8uDBA1RV\nZeDAgSxZsoSoqChq165NaGgo7u7uvP322xm21bJlS37//XeuXr1KYmJiuqNUR0dHAgMDUVWVu3fv\ncvToUQBDh4i2bdtSpEgRNm/eTGJiIsnJyem2PXToUL7++mtKlizJgAEDKFy4cKY7b5cuXThx4gRH\njx41nCLbsmULffr0QVEU3n77bcO38+yysbExdFqzsbExHDm0bduWwMBAwzWmjRs38tZbb6HX62nT\npg3ff/898fHxhISEvPI2CiHMadmyZezfv9/wuEOHDvz666/85z//Qa/Xs2bNGtzd3SlWrFi227h/\n/76ho1ZoaCj+/v4Z9vPnLVy4kLVr1xoOAg4dOkSNGjX4/vvvmTNnDgD16tXDw8MDDw8P7O3t6dev\nH+XLl2fUqFHExcURERFB06ZNGTp0KDNnzsTW1jbbv0NBJQXYRBRFYfny5WzcuJHffvuNjh074uTk\nRMWKFalatSqpqalMnToVBwcHPvnkE5o3b467uzszZ87McB/r0yPqZs2aUaVKFYoUKWJYN3DgQEJD\nQ3F2dqZ169aGAu7q6sqQIUOoV68eDRs25Oeff6ZJkyZcvXo13bZnzpzJqlWrqFmzJjVr1uTzzz+n\ndOnSGX4fGxsbWrRoYegxDTBo0CBsbGxwc3PD1dUVnU6XpVPLz2vRogWTJk1i5syZ1K1bl0uXLlG/\nfn2sra2ZM2cOLVq0oHr16ixcuJCVK1diYWHBxx9/jLW1NVWrVqVp06avfXpeCHNwdXXln//8p+Fx\no0aNmDFjBp6enlSsWJFt27alu6shOyZPnswnn3xCkyZN6NWrFz169CA4OPilr6lWrRp+fn78+9//\npnTp0mzZsgVXV1cqVarE8uXLSUhIyPAaS0tLtm3bRlxcHJUrV2bUqFHY2dnh7u7Ozp07uXz5co5+\nj4JIUV91rkIYVXx8PJBW0J4XGRlJmTJlXvja5ORkEhMTDQXwdV4bHx+PoigULVr0pbkePHiAnZ0d\nlpZZ75eXmJhIUlIS9vb2WX5tZtuysrLCwsICvV7PkydPsLa2BiA1NZWYmBhKlSqV4XUPHz7E1tb2\ntU7ZCaG1lJQUHj58mOlnOTtUVeX+/fuZfnl+lbi4OCwtLSlSpAjJycmsXLmSkSNHGva7zOj1emJi\nYihZsiQAR48excrKynD6WrweKcBCCCGEBuQUtBBCCKEBKcBCCCGEBvLFQBzr1q17Zbd7IcypaNGi\n9OnTR+sYeYLsvyK3Mdf+m+ePgNevX2+Se0+FyInFixezd+9erWOYVGpqaqa9ZbNC9l+RG5lr/9Xs\nCDg5ORmdTpfjXquqqjJkyBDD0G5C5AbR0dH57qjO19eXevXq4e3tzapVqwzT0Hl5ebFmzZoXDkP6\nMrL/itzIXPuvWY+AU1JS+PDDD3FzczOM3Vu7dm1mzZr1yhvHhRDaCgsL4+HDh8THx7N69WrOnj1L\ncHAwlSpVYsWKFVrHEyLPMWsBfjod3uXLl7l+/TrBwcGcOXOG8PBw/Pz8zBlFCJFNcXFx1K9fH3t7\ne3Q6HZ07dzZMJiCEeH1mPQV9584devfunW6WjUKFCtG1a1dOnTplzihCiCxycXFh4sSJuLm5cenS\nJUJDQ4mKimL06NGGOaiFEK/PrAV44MCBjBkzhl69euHi4gLA7du32bBhQ7o5boUQuc/YsWMZO3Ys\nISEhnDt3DhsbGyIiIli/fj3u7u5axxMizzFrAW7YsCG7du1i7969BAUFodfrcXV15fDhwzg4OJgz\nihAimypUqECFChUAMp1TNjMxMTGZTn939epVihcvbtR8QuQVZu8FXbZsWXx8fLL8umPHjjF//vwM\nyy9fvswbb7whvSiF0MjixYtRVZVJkya98Dk3btxg3bp1GZYfPnyYypUrM3nyZFNGFCJXyhUDcbzO\nDty8eXM8PT0zLB8zZgyKopgynhDiJUaNGvXK5zyd1u55Pj4++e52LSFeV64owK+zA1tYWGQ6O4el\npWWe34EfPHhAYGAgXl5emc50JERuJvPACpE9uWIkLFtb2wKzE+/evZsvv/ySLVu2AGnT7w0fPhxL\nS0sGDRpEamqqxgmFECJ/2bp1K5MmTWL69Ono9XoArly5wnfffceOHTs0O4gz6xHwwoULCQgIyHTd\ngAEDcjSZe17w2WefceLECcaPH8/kyZP55ZdfWLhwIcuXL8fZ2ZnVq1fz8OFDwxybQuQmBX3/FXnX\njRs3WLRoEb6+vhw7dgwbGxt69+7NjBkzWLt2Lb6+vhw6dMjs84mbtQAPGjQIPz8/Jk2aRIMGDdKt\ne9lE9PnBvXv32LhxI1evXkWn09GpUyf69evHrVu3qFWrFl9++SVNmjSR4ityrYK8/4q87aOPPiIx\nMRF/f3/eeecd3n77bXbt2kWDBg0YMWIE48aNY+/evXTr1s2sucxagB0dHdm4cSOffvopAwYMMGfT\nmktNTaVx48YoF4JIadAYi3On0Ol06PV6vvjiCxwdHXn33Xe1jinECxXk/VfkbfHx8QwbNoxPPvmE\nsmXL4uLiQrVq1Qzrq1evTnx8vNlzmf0acK1atdi+fbu5m9Vc2bJlcbCz48rwUTxa/CUBUz7i+PHj\nxMTE8M0333Dy5EmGDBnC3bt3tY4qxAsV1P1X5F2qqtK/f3+GDRtGmTJliIuLo2nTpnTv3p3Y2Fj+\n+OMPxo0bR6tWrcyeLVf0gi4IFEXhy5q12XbqTw4eC2Dy9RtcPH0auzJlCAkJ0TqeyGcCAwNp3Lgx\n+/bt4/Tp0/zjH/947UEzhMhPHj58SIMGDQgMDCQwMJCePXsydepUQkJC6NatGy4uLpw7d45y5cqZ\nPZsUYDNRL19Bd+wX+v0SQH9bW1I//hTl7Dlo307raCKfCQgIYPr06ezatYsxY8YwduxYJkyYIPPu\nigKpePHifPbZZxmW54bxy3PFbUj5nZqain7+QpR/jEX5+3YrXYd2qAf8NU4m8qMTJ04we/Zs9u7d\nS+/evZkyZQphYWFaxxJCPEcKsBmoflugrBO6Vi3/t7BZUwi+hhoZqVkukT9VrlyZTZs2sXLlSt55\n5x1Wr15NlSpVtI4lhHiOFGATU2/fRv1hB7oJ/0i3XLGyQnmzFerBQxolE/lVv3798PT0ZOLEiTRp\n0oSUlBTmzp2rdSwhxHPkGrCJ6RcuQRk6GCWT+ySVDu3Qz1sAA/ppkEzkN2fPnmXHjh3pln366acA\n7Nixg+HDh2sRSwjxAlKATUi/Zx+k6lG6d810vVKrJuj1qJevoNSobuZ0Ir+xt7enevXMP0eOjo5m\nTiOEeBUpwCaiRkejfrMW3dKFL52tSXmrPer+g1KARY65ubnh5uaW6bqUlBQzpxFCvIpcAzYR/VJf\nlO5dUSpWfOnzlPZtUQOOoso/kMJIoqKi6NixI+7u7tSsWZOqVasyZMgQrWMJIZ4jR8AmoB4/ASH/\nRfn041c+V3FwALfKcPI38G5hhnQiv9u0aRMeHh54e3tTrVo1Hj16RExMjNaxhBDPkSNgI1MTEtAv\n9UU3eSKKldVrvUZp3xa99IYWRpKQkECrVq1o2rQpFy9eZOjQoRw7dkzrWEKI50gBNjJ15RoUr2Yo\ntd1f+zVKS284dx714UMTJhMFRZs2bfjnP/9JxYoV2bVrFytXrqRw4cJaxxJCPEdOQRuRGnQR9bff\n0a37JkuvU6ytUbyaoR46gtKrh4nSiYLC09OTefPmUbp0aebNm8ehQ4c0vw/48OHDzJw5M8PyK1eu\nUK9ePQ0SCaE9TQtwamoqT548oWjRolrGMAo1ORn9gsXoxo9Dycbvo7Rvi371NyAFWOTQ1q1bmTVr\nVrplcXFxrFixQqNEaUflbdq0ybDcx8cHVVU1SCSE9sx6CtrX15dffvkFSBsIu1q1atSpU4fBgwfz\n5MkTc0YxOnXDJqhUEcWrWfY24NEAoqNRb90yZixRAPXs2ZOTJ09y8uRJAgICmDRpEpUrV9Y6lhDi\nOWYtwGFhYTx8+JD4+HhWr17N2bNnCQ4OplKlSpp+O88p9eZN1B/3ovvg/WxvQ1EUlA7tUPcfNGIy\nURBZWVlhZ2eHnZ0dpUuXZsiQIezevVvrWEKI52hyCjouLo769etjb28PQOfOnTMMoZdXqKqKfsES\nFJ8RKCVL5mhbSod26Md/iDpqJIpO+seJ7Dl16hR79uwBQK/Xc/HiRWrVqqVxKiHE88xagF1cXJg4\ncSJubm5cunSJ0NBQoqKiGD16dK6YmzE71J27oZAVuk5v53hbiosLODrC6T/Bs5ER0omCqHjx4umG\npGzevHmm11+FENoyawEeO3YsY8eOJSQkhHPnzmFjY0NERATr16/H3f31b9vJLdTISNR1G9CtWGa0\nbSrt26IePIQiBVhkU7Vq1ahWrZrWMYQQr6DJKegKFSpQoUIFAEqUKPFar7l+/TqHDx/OsPzy5cs4\nOTkZNd/r0i/+CqXPOyjOzkbbptLmTfRff4uakJCt3tSi4Nq9ezczZszIdF2jRo34+uuvzZxICPEy\nueI+4MWLF6OqKpMmTXrhcywtLbGzs8uw3MrKCp0G10v1RwLgXgTKrM+Nul3Fzg4aeqAGHEMxwmlt\nUXB06tSJ1q1bc+bMGZYuXcrMmTNxdnZm06ZNhv4WQojcQ7MCnJycjE6nw8LCglGjRr3y+c8eNT/r\nyJEjZr+PUI2NRf3XSnSzv0CxsDD69nXt26L//geQAiyy4OmX1MDAQAYNGkTt2rWBtHttu3btyuDB\ngzVOKIR4llkLcEpKCtOmTWPnzp0A6HQ6ChcuTN++fZk6dao5o+SI+q+VKK1bmW4KwSaNYcFi1PBw\nFI1Or4u8q23btvj4+BAeHk6pUqXYsmULrVu31jqWEHlGXFycWdox67nbJUuWAGnXba9fv05wcDBn\nzpwhPDwcPz8/c0bJNvXMWdRz51FGDDNZG4qFBUrb1nJPsMgWDw8P1qxZQ0hICMeOHaN///556guu\nEOZ29+5dLly4YHhcqFAhs7Rr1gJ8584devbsidUzswQVKlSIrl27cvv2bXNGyRY1KQn9wiXoJn6A\nUqSISdtS2rdDlRmSRBacPn2a77//nt9//52tW7cCYGdnx+nTp/PsbX5CmMqDBw8M/3/27FmKFStm\neGyuAmzWU9ADBw5kzJgx9OrVCxcXFwBu377Nhg0bMu3hnNuoa9ehuNcyyy1CSrWqULgwatBFlDq1\nTd6eyPtKly6NXq+nVKlSNGzYMN06BwcHjVIJkXvo9Xp0Oh1//PEH169fp2/fvgB07NhRkzxmPQJu\n2LAhu3btokSJEgQFBXH+/HlsbW05fPhwrv8HQr12DfWAP8r775mtTaVDO9QD/mZrT+RtFStWxNPT\nEzc3NypUqECfPn2wsbHhr7/+MsmMQ6mpqSQkJBh9u0IYW2xsLHv27CE2NhYANzc3Q/HVktnv3ylb\ntiw+Pj7MmTOHefPmMWbMmNxffPV69PMXobw3CuWZ0xSmprRvi3r0GGpSktnaFHlfQEAAEyZMICIi\ngjFjxmBtbc2ECRNyvN38PJmKyH/u3r3LnTt3AIiJiaFKlSqG08wlczhssLHIgMOvQd22HYoXQ9eu\nrVnbVUqWhFo1UY+fMGu7Im87ceIEs2fPZu/evfTu3ZspU6YQFhaW4+3m18lURP7x+PFjABISEjh0\n6JDhWq6Liws1a9bUMlqmXliAAwMDAdi3bx+ff/55ugvWBYl69y6q3xZ0k8Zr0r6chhZZVblyZTZt\n2sTKlSt55513WL16NVWqVDHa9p+dTEWn09G5c2ciIiKMtn0hsuPAgQOGulWkSBEGDRpE6dKlNU71\ncpkWYFOdwsqL9AuXoAzop9n9uEqL5nDpL9ToaE3aF3lPv3798PT0ZPz48dSpU4fk5GTmzp2b4+0+\nnUxlyJAh+Pv7Exoayrlz5xg9ejS9evUyQnIhXl9UVBRHjx41PK5Vqxbe3t4AmoyOmB2ZpjTVKay8\nRr//AMTFo7zTU7MMSqFCKN4tUP1zfy9xkTsoikJwcDCzZs1i8+bN/PTTT1y7di3H2x07dizBwcGs\nWrUKX19fbGxs0Ov1rF+/njfeeMMIyYV4uaioKBITEwG4efNmunkAXFxc8kzhfSrT25CensK6cOEC\ny5YtM/oprLxAjYlBXf0Nui/naD43r9KhHfqlvvB/vTXNIfKGkydPoigKX3zxBTExMSxdupQZM2aw\nefNmo2w/O5OpnDt3jo0bN2ZYHhgYSKVKlYySS+RPKSkpWFpacvPmTQICAhgwYACQNsFIXpdpAe7X\nrx9xcXG0bduWJk2acObMGaOcwspLVN8VKG+1R8kFXzyUunXg8WPUa9dyRR6R5v79+5w9exZ7e3s8\nPT21jmPwn//8hyZNmhjGSC9btqxJeym/zmQqFSpUoF+/fhmWX79+HRsbG5NlE3lXcnIyP/30EzVq\n1KB69eo4OjoyfPhwrWMZVboCfPbsWXbs2JHuCZ9++ikAO3bsyHe//IuogadQL19BN/VDraMYKB3a\noe4/iPK+FODcICQkhC5dutCrVy9++OEHWrZsyfLly7WOBUDfvn3x9vamdu3aWFpasm3bNoYOHWrU\nNrI6mUqJEiUyDA4CaYOHmHsyFWF8jx49Yvny5dy7d4+GDRtme+KPe/fucf/+fWrVqkVycjI1atSg\natWqABTNh9Ozpju3am9vT/Xq1TP9KVeunFYZzUp9/Bj9kmXoPpyAYqbhyF6H0qEd6qEjqKmpWkcR\nQJcuXZgzZw4zxo8nKCiIyMhIDh7MHWN329nZ4e/vT4sWLShXrhxz587N9Ogzq1JSUvjwww9xc3Oj\nRo0a1KhRg9q1a7N06VIKFy5shOQiL3paKC0tLRk0aBAnT57M0pfRp4NjAPz222+GQlu0aFGqV6+e\n567rZkW6I2A3Nzfc3NyIiopi8ODBhISEoNfrSUlJwdPTk7feekurnGajfrMWxaMBSoP6WkdJRylb\nFlxdIfAUNGuqdZwCRY2MhLA7qGF3ICwMNewO8x/E0nbZv9Gf+hOLL/5Jhw4duHfvntZRAbhx4wZ6\nvf61jkyz4tnJVJ6O556UlMTEiRPx8/NjyJAhRm1P5A3Hjh2jU6dOTJkyBYDatWvzzjvv8P7777/y\ntadOneLGjRuGUam6d+9u0qy5TabXgDdt2oSHhwfe3t5Uq1aNR48eERMTY+5sZqf+dRk14Bi6dd9o\nHSVTSod26A/4YyEF2OjSFdnQ0L//GwZ37oKtDTiXQylfHpzLoWvdirO3QwiwteHLL/7JvXv3GDFi\nRLrZVLT0dLrPl12TzY47d+7Qu3fvTCdTOXXqlFHbEnnLs53xVFXl1q1bmT4vNjaWX3/9FW9vb2xt\nbalUqVKB7kGfaQFOSEigVatWWFlZcezYMWbMmEGPHj0YP16bwSjMQU1NRf/lIpRxY1BsbbWOkynl\nzZaoK1aixsXl2oy5mRoR8eIia4yFFJUAACAASURBVG+XVmSdndOKbJs3obwzODtnOvPVBM9GtGjR\ngtatW2NjY8P+/fupU6eOBr9VRk2aNGHgwIFcvXrVMBBBpUqVGDlyZI62m9cnUxGm4eXlxVdffcWa\nNWuoX78+Y8aMoX///ob1TwdpcXBwICoqCldXV2z//verTJkymmTOLTItwG3atGHChAn4+fkxYcIE\nHBwc8v01HtVvC5R1QteqpdZRXkgpWhSlSWPUwwEo3bpoHccs7ty5w+zZs7l16xYlSpTgu+++w9Ly\nxZN4qREREBqWvsiG3clYZMs7o6tV839FNoufb2tra06fPp3TX88kHBwcmD17drpljo6OOd7u08lU\n9u7dS1BQEHq9HldX1zwxmYowHWtra3744Qe++OILrl69yqRJk+jRoweQdsT7008/0blzZwC55ew5\nmf5L5unpybx58yhdujTz5s3j0KFDRr8N6dlelFpTb99G/WEHuq9Xah3llZQO7dB/twEKQAGOj4/H\n2dmZrVu3MnPmTAYPHsynn3zCnAkT/ldkw8LSH8kWs4fyzv8rsrXd04psuXJZLrJ5VdWqVQ09R43t\n6WQqQjyrcOHChi99T4eE9Pb2xtra2ug98POTFx5KtGjRAoD27dvTvn17ozSWkpLCtGnTDNeodDod\nhQsXpm/fvkydOjXdtSVz0i9cgjJ0MEpeOB3yRkOYtwA1NDTtmmQ+durUKSZNmkTvtm3Rz5nP7hIO\nnP1mPfob/01fZOvUBudyaUeyuajnuhAFQXR0NJcvX6ZZs2YAVKtWzTBQy8vOVokXFOCtW7cya9as\ndMtatGiR4xlPcmMvSv2efZCqR+ne1extZ4ei06G0a5M2N/GIYVrHMalChQoRHR2NfvY8lPLleTRo\nAH0CDnLjez+towlRoD148AAbGxsKFSrE5cuX03XCktPMry/TG6x69uzJyZMnOXnyJAEBAUyaNInK\nlSvnuLE7d+7Qs2fPTHtR3r59O8fbzyo1Ohr162/RTZ6Aoihmbz+7lLfao+7PHfecmpKXlxfOIf9l\n//qN7CzrgPeggcz68kutY+Vau3fvpl69epn+5LQDlhCpf49BcP36dbZv325Y3qxZs1w51V9ekOkR\nsJWVlaFI2tnZMWTIELy9vfnww5yNDJXbelHql/qi9OiG8vfpkrxCqVQJSpRAPXMWxaOB1nFMRk1I\n4LOSZTg07UPC799nxYoVNG/eXOtYuVanTp1o3bo1Z86cYenSpcycORNnZ2c2bdqEvb291vGECQUF\nBbFv3z6SkpJ47733jNq7OCkpCX9/f2rUqIGbmxsODg4MHz48Xw+QYS6ZFuBTp06xZ88eAPR6PRcv\nXqRWrVo5biw39aJUj5+AWyEoM6abtV1jUdq3RT14KH8X4FVfozRtQoeJH9BB6zB5gKWlJXZ2dgQG\nBjJo0CBq164NgI+PD127ds328IAid7t8+TJjxoxh2rRpJCYm0q1bN9avX5+jCXQiIyOJiYmhatWq\nPHnyhIoVKxpOLdvZ2RkreoGXaQEuXrw41atXNzxu3rw5bdq0MUqD2e1F+eTJEx49epRh+ePHjylR\nooRhxoyUlBQeP36MtbX1Cx8nREdT+F8rKTR9GqnA49jYlz4/Nz4u8mZLdN+tJznuPRJVVfM8Rv/9\nbt5Cd+Ik+m9XE58H/z5aXtJo27YtPj4+hIeHU6pUKbZs2ULr1q01yyNMa9myZcyaNYuWLdNuoUxJ\nSWH79u1MnTo1S9uJj483TIwREBBgmGDEzs4Od3d344YWwHPXgJ9eQ+rduzcLFiww/EybNo0xY8aY\nLMTixYtZtGjRS59z+vRpxo4dm+Hn5MmTlCtXjoSEBCBtEJEbN268/PH+Azxu7oVS2/31np8LHz+2\nsoJ6dYn/9XiuyGPMx9evXSNuzTfoxo/jMWieJzuPtez96eHhwZo1awgJCeHYsWP0798/y/8Yi7zD\n3t6eQs/0/rezszNcr31dgYGB/PTTT4bHffr0oWLFisaKKF5EfUZycrL66NEj9ejRo2r37t3VoKAg\nNTo6WvX19VXXrVunmkpsbKwaGxubrdeOHDlSHTFixGs/X38hSE15p6+qj4/PVnu5if7oMTVl4mSt\nYxhd6rffqSkzPtc6Ro4sWrRI/fHHHzXNkJqaqsbFxal6vV7THC+T1f1XZPTrr7+qrVu3Vk+cOKEe\nOHBAbdasmRoSEvLS1zx69Eg9cOCA+vjxY1VVVfXu3btqamqqOeLmCebaf9MdAWd2DalEiRL4+Piw\nadMmoxb+5ORkw7c0W1tbw9BkpqQmJ6NfsBjd+HEo+WFqK69mcDU4bRzjfEK9dQt19x50H7x6IHfx\nYpMnT6Z27dps3ryZzp0759pRu0TONW/enPnz5+Pn58eRI0dYvnw5rq6uGZ4XHR1NVFQUAOHh4Tg4\nOFDk72FWnZycpFOVBjI9T2aqa0haD8ShbtgElSqieDUzaTvmolhaorR+M60z1oCcTzenNVVV0S9Y\ngjJyOErJklrHybNOnjyJoih88cUXxMTEsHTpUmbMmMHmzZu1jiZM5I033sh0UoPk5GSsrKx4+PAh\nO3fupFu3bgAmGylNZE2mX3lMdQ3p2YE4rl+/TnBwMGfOnCE8PBw/P9MOrqDevIn64958d2SldGiH\nesBf6xhGoe76ESwt0HXuqHWUPO0///kPTZo0MXQEK1u2LE+ePNE4lTC3AwcOGGapKlq0KMOHDzdM\nziFyhxf2FPHw8MDDw8OojWk1nZnhyMpnRL47slJq1QRVRf3rMkrNGlrHyTY1MhL1u/Xoli/VOkqe\n17dvX7y9valduzaWlpZs27ZN8/F4o6KiuHLlSobl4eHhco+ykTx48IDg4GBD7+WKFSsabkXSaphf\n8XLpCvDp06e5ceMGrq6uhtPET1WuXJl33303R41pNRCHunM3FLJC1+ltk7WhpadHwXm5AOsXf4XS\nuxfK358LkX12dnb4+/uzY8cOQkJCGDdunNG/TGfVnTt3+PnnnzMsDw0NNYwbLLLu0aNH2NjYYGFh\nwYULF9Id4T57K6nIndIV4NKlS6PX6ylVqhQNGzZM90RjDJShxUAcamQk6roN6FYsM8n2cwOlQzv0\nI95Fff89lDw4+Lk+4Cjci0CZ9bnWUfKFo0eP8uDBA0aNGmVYNm7cOHx9fTXLVLduXerWrZth+b17\n91BVVYNEeZder0en0xEcHMyRI0cYMWIEgOE+YJF3pPvXumLFioZ7v6KiomjcuDH79u3j9OnTtGvX\nzigNmmM6s8ePH7N3716SkpLodupPivZ5J23mnHxKKVMGqlaBEyehpbfWcbJEjYtD9V2Bbs5MlFww\nNWV+cOnSJRYtWsSVK1eYNm0aABcvXtQ4lcippKQkjhw5Qo0aNahYsSIODg74+PhI7+U8LNO/XEBA\nABMmTCAiIoIxY8ZgbW3NhAkTzJ0tW1JTU6lfvz7nzp2jyG+BbF7my5V6dbSOZXJK+7boDx7SOkaW\nqStWobRuhVJDTpcZ05IlSwgJCWHEiBEkJSVpHUdkU3R0NDdv3gTSRqoqV66c4RajYsWKSfHN4zL9\n6504cYLZs2ezd+9eevfuzZQpUwgLCzN3tmxZv349LVq0YNa0aXS/ew/3b9fg+/c0ipGRkTm+jp1b\nKS294dx51IcPtY7y2tSz59ImlMjn0ypqwcLCgn//+99Ur16dzp07y7yseUhiYqLh//ft22fozV6i\nRAnq1q0rRTcfyXSvrFy5Mps2beLChQssW7aM1atX52hgb3OKj49PO10eG4tuxTJck5MJ3bmD0NBQ\npk6dmul40vmBUqQISnMv1ENHUHr10DrOK6lJSegXLkE34R8o1tZax8lXatWqRcm/e/tPmTKFChUq\naDLbmMi6wMBAwsLC6NmzJwCDBg3SOJEwpUwLcL9+/YiLi6N169bUqVOHP//8k7lz55o7W7a0aNGC\ndu3aUTsgACcnJ1q3aMHw4cMpV64cmzZtol+/vD9gxYsoHdqhX7kG8kIB/m49Ss0aKI09tY6Sbzx7\nF8OmTZvSjV73fKdKkTvExcURGBiIt7c3VlZWODs7ZzqghsifMi3AiqIQHBzMvn37SEhI4KeffqJx\n48Z54oNRr149fvjhB3x8fChXrhwffPABY8aMMZzGyc89LhWPBvDgAeqtWyi5eCB19do11J8PoPvu\na62j5CumvotBGMfDhw9RVZXixYvz3//+l+LFixvu0y1fvrzG6YQ5ZVqA8/pQdt7e3pw8eVLrGJpQ\nOrRD3X8QZfSoVz9ZA6penzYoymgflGLFtI6Tr5w/f54ZM2Zkuq5Ro0a0atXKvIGEwdPpUqOjo9m+\nfTu9evUCMMo86yLvyvRqfn4eyq53795aRzAppUM7VP/DqHq91lEypf6wA2xt0HVor3WUfKdTp04c\nP36cZcuWGfpxHD16FB8fH7y989btafnJwYMHDZNh2NjYMGLECMM1elGwZXoEnBuHsjOWp9888yvF\nxQUcHeH0n+DZSOs46ajh4aibNqNbuVzrKPlSZrOZAfj4+NC1a1cGDx6sccKC4eHDh9y8eZP69esD\n4OzsbBiVqnDhwlpGE7lMpgU4Nw5lJ16fYWjKXFaA9QuXoPTvi1K2rNZR8jVTzWYmXiw+Ph5ra2t0\nOh2nTp2i7DOfcXd3dw2Tidwswyno4OBgVq9eTWxsLKNGjWL27NlER0cbhjsTuZ/S5k3U3wNRExK0\njmKgP+gPj2JReufvMxC5galmM3teamoqCbnoM2ZuTzt0BgcHs2HDBsPydu3aGc4+CPEy6QrwnTt3\naNu2LefOnaNdu3bcuXOHDz74gFGjRpnk9p2CvgObimJrC280RA04pnUUANSHD1FXrkE3ZSKKDCJg\ncjdu3MDe3p758+ezYsUKo/V78PX15ZdffgFg1apVVKtWjTp16jB48OB800fkdSQlJeHv728YnKhU\nqVI0bdqUH374gRMnTqR77scff8zly5e1iCnygHT/Gp4+fZp33nmHFStWMHPmTFq1akVCQgJBQUG0\nbds2x43JDmw+ulw0T7C6/N8oHdqh5JHBXPK6nTt3snv3bqNvNywsjIcPHxIfH8/q1as5e/YswcHB\nVKpUiRV/jzaXX8XExPDf//4XSLvGW7p0acNp5uPHjzN8+HDu379P165dWbBgAQDTpk0jMDBQhgIV\nL5SuAN+/f5+qVasC4OLiQuXKlVmzZg02NjZGaawg78Bm19gTQkJQw8M1jaGe+gP1P5dQhg3RNEdB\n0qRJE5YvX867777L9OnTmT59Ol9/bbx7ruPi4qhfvz729vbodDo6d+5MRESE0bafWzxbOHfs2IH+\n7zsLypQpQ4MGDbCwsODhw4cMHjyY/fv389577xEeHs7x48e5dOkSc+bMMcqBi8i/XjhArKIouLm5\nmaTRZ3dggM6dO7Njxw6TtFVQKRYWKO3apN0TPFSb3q9qYiL6RUvRTZuMUqiQJhkKIgcHB2bPnp1u\n2bPzxGaXi4sLEydOxM3NjUuXLhEaGkpUVBSjR49m1apVOd5+bhIYGMjdu3fp3r07AMOGDTPclvms\nuLg4OnXqRJkyZYC0ie+rVq1KdHS0jNksXilDAV62bBk7duwgJiaG8PBwgoODgbQRpp6eWsmugrQD\n5wZKh/bo//kFaFWAv/4WxaMBSoP6mrRfUJUoUYKNGzcSEhKCXq8nJSUFT09P2rfP2b3XY8eOZezY\nsYSEhHDu3DlsbGyIiIhg/fr1eb6nb3x8PKdPnzbMqevo6Jjuzo/Mii+Ak5MTVlZWzJ8/nylTpnD4\n8GEWLVr0wgFRhHhWugLcuXPnF47M8vRoNSfy8w6cGylVq0DhwqhBF1HqmLdXpnr5CmrAMRluUgOb\nNm3Cw8MDb29vqlWrxqNHj4iJiTHa9itUqECFChWAtGKfV8XGxgJpt11eu3aNIkWKGNZVfM2hXC0s\nLPD19aVRo0b4+/vj5ORk6AQHaWPTOzo6Gj27yB/SFeAyZcoYTqWYUn7ZgfMC5a32aaehzViA1dRU\n9AsWo4wdjWJnZ7Z2RZqEhARatWqFlZUVx44dY8aMGfTo0YPx48ebpL3FixejqiqTJk0yyfaNSa/X\no9PpiIqKYvv27fTp0wdIO8OXXXZ2di/s6dy8efNsb1fkf7liktC8tAPnNUq7NugHD0f94H2zXYdV\nN28FhzLoWr9plvZEem3atGHChAn4+fkxYcIEHBwcjD4CU3JyMjqdDgsLC0aNevW444cPH2bmzJkZ\nll+5ciVHxS8rDh48SMmSJXnjjTewsbFh5MiRWFhYmKVtITKjWQHOiztwXqSULAm1aqIeP4FihoKo\nhoaibtuO7uuVJm9LZM7T05N58+ZRunRp5s2bx6FDh4wynWhKSgrTpk1j586dAOh0OgoXLkzfvn1f\nOdBHmzZtaNOmTYblPj4+JpuhLDY2lpCQEMOgGA4ODoZLXdYyB7XIBcxagPPaDpxfPD0NjRkKsH7h\nEpShg1HMcClDvFiLFi0AaN++fY47Xz21ZMkSAC5fvmyYPi8pKYmJEyfi5+fHkCHa32qWmJhouJb7\n66+/4urqalj3dGxmIXILs/aTf3YHvn79OsHBwZw5c4bw8HD8/PzMGaVAUZp7waW/UKOjTdqOft/P\nkJSM0r2rSdsRmdu9ezf16tXL9GfkyJE53v6dO3fo2bOnofgCFCpUiK5du3L79u0cbz+nrly5wnff\nfWd43LFjRxkSUuRqZj0CvnPnDr179850Bz516pQ5oxQoSqFCKC29Uf0Po/yfaaZjVKOjUdd8g27J\nghfesiFMq1OnTrRu3ZozZ86wdOlSZs6cibOzM5s2bTLKXQwDBw5kzJgx9OrVCxcXFwBu377Nhg0b\nOHz4cI63n1VJSUmcOHGCGjVqULZsWUqWLClj1os8xawFOLftwAWJ8lZ79Iu/AhMVYP1Xy1G6dkap\nVMkk2xevZurpCBs2bMiuXbvYu3cvQUFB6PV6XF1dOXz4MA4ODsb4FV4pNjaW2NhYypUrR3R0NLa2\ntoa2zXEHhxDGZNYCnBt24IJKqVMbEhNRg6+l3R9sROrxE3DzFsonHxl1uyJ7TDkdYdmyZfHx8THK\ntl5XSkoKlpaWqKqKn58fb731FpA2CIaTk5NZswhhTGbvBa3FDizSpM0TfNCoBVhNSED/1XJ0M6aj\nPHNpQWjn6XSEW7du5eLFi/Tv399oMyI9a/r06dSsWZOBAwcafdtPBQYGEhkZSefOnVEURW4dEvmK\npoOVTp8+nY0bN2oZoUBR3mqP6n8YNTXVaNtUV32N0rSJ2UfaEi/24MEDPv/8c3bv3s2hQ4eYPn06\ngwYN0jrWa0lISODkyZOGx6VKlUrXi1uKr8hPcsVAHMI8FCcnqFABAk9Bs6Y53p568T+oJ06iW/+t\nEdIJY1m7di0NGjTAz8+PQn8PvmKKjnHu7u44OzsbZVvx8fHY2Nhw6dKldJMYVJEpLEU+pmkBNuYO\nLF6P0qEd+gP+WOSwAKvJyei/XIRu/DiUokWNlE4Yg729PSVLljTaNKIv0r9/f6Nsp1ChQqSkpADw\nxhtvGGWbQuQFmhZgY+3A4vUpb7ZEXbESNS4OxdY229tRN/pBpYpp9xiLXKV+/fp0796dn3/+mUp/\n90qvXLnya404p4WkpCSKFSumdQwhzE5OQRcwStGiKE0aox4OQOnWJVvbUG/dQt29B923q42cThhD\n8eLFWbRoUbplcpeBELmPFOACSOnQDv13GyAbBVhVVfQLlqCMHJ42zrTIdapUqZLh2unTU7xCiNxD\n017QQiNvNIR791CzMXyguutHsLJE17mjCYIJY4iKiqJjx464u7tTs2ZNqlatmivGaRZCpCdHwAWQ\notOhtGuDesAfZeTw136dGhmJum4DOt8lJkwncmrTpk14eHjg7e1NtWrVePToETExMVrHEkI8R46A\nCyjlrfaoB/yz9Br94q9Q3umJ8vcwoiJ3SkhIoFWrVjRt2pSLFy8ydOhQjh07pnUsIcRzpAAXUErF\nilCiBOqZs6/1fH3AUbgXgdLv/0wZSxhBmzZt+Oc//0nFihXZtWsXK1eupHDhwlrHEkI8RwpwAZY2\nNOWrj4LVuDhU3xXopkxCkZGIcj1PT0/mzZtH6dKlmTdvHjdu3GDu3LlaxxJCPEcKcAGmtG2NevwE\namLiS5+nrliF0roVSo3q5gkmcuT48eM4OjpiY2ND+/btmTdvHuvXr9c6lhDiOZp1wkpOTkan08nY\nrhpSihWD+vVQj/2C0qF9ps9Rz55DPXMW3do1Zk4nsiohIYERI0Zw6dIlbG1tDdPzxcXFUaJECU2z\n/fHHH3z99dcZlh8/flyGmxQFllkLcEpKCtOmTWPnzp0A6HQ6ChcuTN++fZk6dSpWMpuO2ek6tEO/\n60fIpACrSUnoFy5BN/EDFGtrDdKJrChatCizZs1i9+7dODk5Ubt2bRISEihRogQVK1bUNFuNGjWY\nNGlShuUPHjygSJEiGiQSQntmPQW9ZEna7SuXL1/m+vXrBAcHc+bMGcLDw/Hz8zNnFPFUs6Zw7Tpq\nZGSGVep361Fq1kDxbKRBMJEde/bsITw8nP79+/PDDz/Qp08fevToQVhYmKa57OzsqFatWoafYsWK\nGSaMEKKgMWsBvnPnDj179kx3pFuoUCG6du3K7WwMCiFyTrG0RGn9ZobOWOq1a6g/H0AZN0ajZCKr\nTp48ybZt2xg3bhwhISGsX7+eK1eusGLFCj7++GOt4wkhnmPWU9ADBw5kzJgx9OrVC5e/7yW9ffs2\nGzZs4PDhw+aMIp6hdGiHfs58GJg2OYaq16cNNznaJ+06scgTAgMDGTBgAC4uLqxcuZJu3bphbW2N\nl5cX//jHP7SOJ4R4jlmPgBs2bMiuXbsoUaIEQUFBnD9/HltbWw4fPiyDxWtIqVkDAPWvy2n/3bYd\n7GzRvaBjlsidSpcuTWhoKAB79+6la9euAFy8eJEKFSpoGU0IkQmz94IuW7YsPj4+5m5WvMKl8s4E\nv/seAU5l+CLiAcW3bNA6ksiirl27Mn/+fH777TeSkpJo2bIlhw4dYvz48Xz55ZdaxxNCPCdXjAW9\nePFiVFXNtJekML0TJ06w9PcTrFQVGlkUYum9u/QID6e+k5PW0UQWFCtWjNOnT3Px4kXq1KmDpWXa\n7v3tt9/i6empcTohxPNyRQF+nYnCL1++zL59+zIsv3DhAuXLlzdFrHzr999/Z8uWLej1eubNm4ef\nnx+T58+n2IcfUSzkNp4L5rF//37q16+vdVSRRUWKFOGNN94wPG7btq2GaYQQL5MrCrCtre0rn2Nv\nb0/16hlHYqpTpw7lypUzRax866+//mLhwoX861//4tdff8Xe3p4HDx5g+UtaR7j4778nNTVV45RC\nCJG/5YoC/DrKlSuXaaG9f/8+qqpqkCjvGjZsGDt37mT9+vUcOXIEJycn3nvvPRISEoiNjWXlypXs\n3btX65hCCJGvmbUAL1y4kICAgEzXDRgwgP79+5szToHWo0cPChUqxPLly5k+fTo7duzAz88PVVXZ\nvHkzJUuW1DqiEELka2YtwIMGDcLPz49JkybRoEGDdOuejlsrTO/dd99lxowZRERE4OrqCoCTkxMT\nJ07UOJkQQhQcZi3Ajo6ObNy4kU8//ZQBAwaYs2nxjC+++IJ169ZRsWJFevbsqXUckUelpqby5MkT\nihYtqnUUIfIks09HWKtWLbZv327uZsUzHB0dmTJlCn369DHcqiLEq/j6+vLLL78AsGrVKqpVq0ad\nOnUYPHgwT548MVo7iYmJ/PDDD2zZsoWoqCgAwsLC+OCDD3j33XcJCQkxWltCaEnT+YCnT5/Oxo0b\ntYwghHhNYWFhPHz4kPj4eFavXs3Zs2cJDg6mUqVKrFixwihtpKam0qBBA86cOcPdu3cpU6YMV65c\nISgoiA8//JBBgwaxadMmo7QlhNY0LcBCiLwnLi6O+vXrY29vj06no3PnzkRERBhl2+vXr6dJkybM\nmTOHCRMmcPDgQb766iveeustIiMj+cc//kGXLl2M0pYQWtO0ALu7uxsmZRBC5G4uLi5MnDiRIUOG\n4O/vT2hoKOfOnWP06NH06tXLKG3Ex8fTsWNHw+NatWoZplL08PBg165dzJ492yhtCaE1TS8Aym1H\nQuQdY8eOZezYsYSEhHDu3DlsbGyIiIhg/fr1uLu7G6UNLy8v3n77bWrXro2TkxNt2rRh4MCBLFq0\niIYNG1KsWDEZeEfkG9IDRwiRJRUqVDDMrlSiRAkWL17M/v37jTKWe4MGDdi6dStDhgyhfPnyvP/+\n+4wdO5bExETWrVsHwOeff57jdoTIDaQACyFy5HXGcr979y7nz5/PsPz27duUKFEi3bKWLVty6tSp\ndMusra0ZPXp0zoIKkcvkiwIcERHB1q1bc7ydixcvEh4e/lpjU7+u1NRUIiMjcTLyzEKhoaFGn4Qi\nJiYGS0vLAv37V61aFTc3txxvKyoqiqpVqxohVe73Op+XmJiYTAuwqqpYWVnleP89deoUCQkJFClS\nJEfbyQlTfCazwhT7b1Zp/R7ExcXh5ORE7dq1c7Qdc+2/iprHB1JOTU1l1apV6HQ570+2a9cu4uLi\njPoBSkxM5MyZMzRr1sxo2wQ4cuQIrVu3Nuo2g4ODKVKkiFE7xuW1379q1aq0atUqx9sqXLgwgwcP\nxsLCIufB8jFj7b/fffcdtra2lC5d2kjJss4Un8msMMX+m1VavwehoaHY2trSvXv3HG3HXPtvni/A\nxuTr64uzs7NRR4e6d+8eH3zwAVu2bDHaNgFatWrF0aNHjbrN5cuXU7ZsWaP1aIW0sxPjxo0zyhmK\nZ5ni9//Xv/6Fo6Mj77zzjlG3m1/k5rHcP/74Y7p06ULTpk01y2CKz2RWmGL/zSqt34MdO3YQFhbG\nuHHjNMuQFfniFLQQwvRkLHchjEsKsBDitchY7kIYl4yEJYR4bTKWuxDGIwVYCJEtMpa7EDlj8dln\nn32mdYjcwtbWlgoVKlC8RQ2UIAAAIABJREFUeHGjbdPCwgJHR0cqVapktG0ClC5dmmrVqhl1m/L7\n2+Lq6prhvlSRuSNHjlCmTBnq1q2rdRTs7e2pVKkSNjY2mmUwxWcyK0yx/2aV1u+BtbU15cuXx8HB\nQbMMWSG9oIUQ2eLn54ezszMtW7bUOooQeZIUYCGEEEIDcg1YCCGE0IAUYCGEEEIDUoCFEEIIDUgB\nFkIIITQgBVgIIYTQQIEuwPfv3yc1NTXTdSkpKSQmJhp+tJacnMz9+/czXZeUlGTImZSUZOZk//Oq\n90yv16dbr9frNUj5P9HR0S98v3Lb319kLiYm5qV/n3v37mHKGz2io6NJTk7OdJ2pP0MvaxsgISGB\n2NhYo7f7lF6vJzIy8oXrn/3dU1JSTJbj7t27L1xn6vcgpwpkAU5NTaVbt26MGTOGRo0aERgYmOE5\n48aNo0GDBnh5eeHl5UV8fLwGSf9n8uTJTJ8+PdN1Hh4ehpzDhg0zc7L/edV7tm3bNqpWrWpYf/z4\ncY2SwsiRIxk6dCitW7fOdKaq3Pb3Fxk9ePCAZs2aERQUlGHdw4cPadKkCSNGjKBBgwZEREQYvf3B\ngwczYMAAqlevzokTJzKsN+Vn6FVtr1ixgnbt2tG0aVO++uoro7X7VGBgIA0aNKBPnz706dMnw5ec\ne/fu4eTkZPjdly1bZvQMACtXrmTkyJGZrjP1e2AUagH066+/qnPnzlVVVVV//vlntW/fvhme07Rp\nU/X+/fvmjpapgwcPqvXq1VPffffdDOvi4+PV+vXra5Aqo1e9Z9OmTVO3b99uxkSZO3LkiOFv/ujR\nI/Xjjz/O8Jzc9PcXGZ06dUqtU6eOWr16dfXUqVMZ1k+bNk1dv369qqqq+vXXX2f6N86J/fv3q8OH\nD1dVVVWDg4NVLy+vDM8x1WfoVW0/ePBArVOnjqrX69Xk5GTV3d1djYmJMWqGZs2aqbdu3VJVVVUH\nDhyoHjx4MEPGcePGGbXN540YMUL18vJSO3bsmGGdOd4DYyiQR8DNmzdn2rRpXL58mW+++YY333wz\n3Xq9Xs/t27dZtmwZ77//fqbfsM3l/v37fPnll7xoxNCgoCCsra0ZO3YsM2fO5N69e+YN+LfXec/O\nnTvHH3/8wZAhQ9i/f78GKdMcO3YMT09PZsyYwebNm/nkk0/Src9Nf3+ROXt7ewICAl44DOb58+dp\n1qwZkLa///nnn0Zt/9ntV6lShbCwsHTrTfkZelXbV69epV69eiiKgqWlJXXq1OGvv/4yWvuQ9u9S\nhQoVgMzf33PnzhEdHc2QIUP45ptvTHIKftiwYaxevTrTdeZ4D4yhQBbgp3bv3s3t27extrZOtzw6\nOpoWLVrQu3dvunfvTvfu3Xn8+LEmGd9//33mz5+fIeNTT548oUmTJkyZMoVSpUoxZMgQMydM8zrv\nmaurKy1btmTSpEl89tln/P7775pkDQ8PZ+3atTRp0oTw8HB8fHzSrc9Nf3+RRq/Xk5ycTHJyMqqq\nUr16dUqVKvXC54eHh1OsWDEA7OzsiImJyXGGlJQUkpOTSU1NTbd9ACsrq3RFxpSfoVe1/fx6Y/3+\nTz169AhLy//NZJvZ9m1tbWncuDGfffYZv/32G0uXLjVa+095eXm9cJ2p3wNjKdAFeOrUqfj7+zN1\n6tT/Z+/O42rK/weOv84NkcqWXZK1kCWEIktZa6wTWcIPWWLGboYxY2xjz1jGDGYYW8jYxjbMGGMJ\nWbPvTCPLpJGotJ7P74/L/UpFkU7p83w8eszcc889532P+7nvez5rkk4CFhYW+Pn5Ua1aNVxdXXFy\ncuLPP//M9Ph2797NuXPn2Lp1K6tWreLEiRPJ7hydnZ3x9fXFysoKHx8frly5wpMnTzI91rRcsyVL\nltC6dWtq1KjBgAEDNFvWrmDBgnh6etK2bVu+/PJLjhw5kqQzVlb595f+Z/Xq1dja2mJra5tin41X\nFSlSxFAOnjx5QqlSpd45hvr162Nra4uXl1eS44N+0ZG8efMaHr/Pz9Cbzv3q8xn1/l8wMzNLkvBT\nOv6QIUP45JNPsLa2Zvz48Zle1t/3NcgoOTIBr1+/nvHjxwMQFRVFiRIlkvyi++eff3B1dQVACMHZ\ns2epW7dupsdZo0YNZs+eTYMGDbCxsaF48eKGap8XNmzYYOic9eJXn7m5eabH+qZrpqoqTk5OhIWF\nAXDq1Cnq16+f6XGC/ov0+vXrgL4qTVVV8uTJY3g+q/z7S//Tu3dvbty4wY0bN2jQoMEb93dwcOCv\nv/4C4K+//qJWrVrvHMOpU6e4ceMGfn5+SY5/+fLlZF/u7/Mz9KZzV6tWjbNnzxIXF0dsbCwXL16k\nfPnyGXJuAEVRKFGiBDdv3gRSvr6ffvopu3fvBrQp6+/7GmSUXG/e5cPTqVMnNm/eTMeOHYmKimLG\njBkADB48mNq1azNgwAAaNmyIm5sbd+/epXPnzhQvXjzT4yxdujSlS5cG9L9y7969i62tLQ8ePMDe\n3p579+7RoUMH/P396dChA5cuXXovVT1pUbZs2RSv2fr16/n111/x8/Nj5MiRdO3aFSEEZmZmuLu7\naxJr+/bt2bx5M25ubty5c4dFixYBWe/fX0qfl8vFsGHD+PTTT1m/fj2xsbHs2rUrQ8/VokUL9u7d\nS+vWrbl//z6rV68GMuczlJZzjx49mrZt2/L48WNGjx6Nqalphpz7BV9fX3x8fIiJicHOzg5nZ+ck\n13/w4MEMGzaMxYsXExISwi+//JKh509NZl6DjJCjV0OKiop67fqhcXFxCCEwNjbOxKjeTmRkJCYm\nJuh02lZqpOWaPX36FDMzs0yMKvU4TExMMDIySvH57PTvL6Xs2bNnqfafyIzjv8/P0JvOnZCQgBCC\n3LlzZ/i50xrDkydPNKmReyEzrsG7yNEJWJIkSZK0kiPbgCVJkiRJazIBS5IkSZIGZAKWJEmSJA3I\nBCxJkiRJGpAJWJIkSZI0IBOwJEmSJGlAJmBJkiRJ0oBMwJIkSZKkAZmAJUmSJEkDMgFLkiRJkgZk\nApYkSZIkDcgELEmSJEkakAlYkiRJkjQgE7AkSZIkaSCX1gFIrxcaGkpUVFSSbZaWlkRERGBiYvLW\na50KIbh37x6lS5d+q9eHhYVhampK3rx53+r1kpRV3b59O9k2U1NTdDrdO5W59IqKiiIuLo5ChQql\n+TWvK5fx8fFcvHiRypUrY2JikpGhGryI2dzcnNDQUEqWLPlezvOhkHfAWdygQYPw9PRkyJAhhr//\n/vuPefPmERgYyL///sv48eMBOHDgAKtXr07TcSMjI2nbtu1bx/X5558TEBDw1q+XpKwoMTHRUM4c\nHR3p2rUrQ4YMYdWqVUyYMIEDBw689xj69esHwP79+1myZEm6XptauZw3bx6WlpbMnDmTpk2bMnjw\nYDJyKfhXY75//z5dunTJsON/qGQCzgamT5/Orl27DH/Fixdn6NCh1K1bl9OnTxMYGMi9e/fYs2cP\nly5d4unTpwDExMRw5cqVJMeKjY0lMDCQyMjIZOd58OCB4bUAt27dIjExkYSEBIKCgjh27BjPnj1L\n8pqIiAgePnwIgKqq3Lp1y/BcSue/c+cOhw4dIjw8/N0uiiS9B0ZGRoZy1rhxY6ZOncquXbsYNWqU\nYZ/bt28THByc5HUpfdYBLl68SHR0dJLX3r9/nxs3bgD6mqjz58+jqiqgL4N79uzh1q1bODs707dv\nX8Nrr169yt9//214/Lpy+bLt27fj5+fHtWvXWLduHcePHyc6Oprp06cDGGIB+Pfffw3fAZGRkRw9\nepSzZ88akvX9+/eJiori1KlThrL+uphfCA0N5d69e0m2ye8CWQWdLURERBAWFgZA3rx5MTU1ZfLk\nyXz00UccOXKEkJAQAgMDOXXqFEIIQkJCOH36NOvXr8fa2prr16+zefNmnjx5gqurK82aNePMmTPJ\nzrN3714uXrzIzJkziYiIoH379gQFBdGsWTPq1auXpEC+sH37dq5evcqUKVOIioqiffv2nD9/nrVr\n1yY7/8GDB5kyZQouLi4MHjyYrVu3UrFixUy7jpL0rubMmYO9vT3bt29nzpw5uLm5pfhZNzIyolmz\nZtSqVYvr16/j4eGBt7c3HTt2pFixYlSsWJFBgwYxZswYatSowalTp5g7dy737t0jKiqKXbt2UaxY\nMU6dOsWMGTPo2bMncXFx5M2blxIlSjBjxozXlsuXbd26FU9PT8zNzQ3bxo0bh5eXF+PHj6d169Zc\nvXoVIyMjZs2ahaOjI7Vq1aJLly60adOG48ePU7FiRRYvXszkyZO5cuUKdnZ2/Pnnn0ydOpXcuXMn\ni/mTTz4xnGvkyJE8evQIVVUpVKgQ8+fPZ8+ePfK7AJmAs4WJEydSsGBBANzd3Rk7dqzhOQ8PDy5c\nuEDHjh25c+cOQghsbW3p168fa9euxczMjO+++45du3Zx6dIlunXrxvjx4zl06BBDhw5Ncp6PP/6Y\nGTNmMH36dDZu3IinpydRUVGGQnrz5k2aN2+epl+s3333XbLz//3331SqVInevXvTq1evdLVtSVJW\n4OHhwcCBA6lTpw579uzBzc0txc86QMuWLZk4cSLPnj2jXr16eHt7Ex0dzcKFC6lSpQrDhg1j0KBB\nNG7cmKCgIJYvX87ChQspVKgQQ4cOxd/fH4Bz585x/fp1jh8/DsDPP/+crnJ57dq1ZHelFSpU4OrV\nq6m+T1VVWbZsGXZ2dhw6dIhhw4YZnnNxcWHChAls2bKF33//ne+++y5ZzC+EhYVx/Phxtm7dCkCv\nXr0IDQ3lwoUL8rsAmYCzhW+//ZbmzZunef+nT59y6dIlvvzyS8O2cuXKERwczEcffQRA7dq1k73O\nxMQER0dHDhw4wNq1a1m1ahW5c+dm1apVzJo1Czs7O4QQJCYmpnjeF9VoqZ3/k08+wdfXly5dupCY\nmMjq1aspXLhwmt+XJGnNysoKAAsLC6Kjo1P9rJ84cYKWLVsCkC9fPvLkycPdu3cNzwMEBARw9+5d\nNm3aBECZMmVSPOfdu3epWbOm4XGfPn149uxZmstljRo12LdvH05OToZtN2/epHz58sn2fVGGAcaM\nGUPu3Lmxs7NLcuw6deoA+o5p8fHxqVwpvWPHjvHw4UOGDx8OQOHChfn777/ld8Fzsg04mzMyMjIU\njhf/b2ZmRrVq1Zg1axZr1qzB3d0dKysratSowcGDBwEIDAxM8Xh9+/bF19cXY2NjLC0t2bt3L4qi\nsH//fqZNm0ZUVFSSwpgvXz5CQ0MBOH/+PECq59+2bRuNGzfm5MmT9OjRg3Xr1r3PSyNJ711qn/WW\nLVsaOmw9evSIf/75h1KlSgGg0+m/dl1dXenSpQtr1qxhzJgxhuSuKEqSczg7OxMUFATo233d3d3Z\ntWvXa8vly7p3787GjRu5evUqJ06c4P/+7/8YPXo0gwYNAvTNWi/K8IULFwBYvHgxXbt25bfffqND\nhw5Jjv1qfKltA2jcuDH58+dn9erVrFmzhkqVKmFpaSm/C56Td8DZnKWlJefPn2fq1Kk0adKEnj17\nUqVKFb7++mv69etHvnz5iImJYePGjTRs2JCOHTvSunVrbGxsUiw0jo6OXL9+nYkTJwLQpEkTpk+f\nTs+ePYmNjaVixYqEhIQY9m/WrBmTJk3Czc2NokWLGoY/pHT+e/fu0a9fP4oVK8adO3dYsWJF5lwk\nSXqPUvqs58qVi23btuHu7s7t27f58ccfk5W3gQMHMnbsWNatW0d4eDjz588HoHLlyrRr146ePXsC\n+jvNnj170qZNG4QQdO3aFRcXF2bPnp1quXyZk5MTkyZNonPnzpibmxMTE4OqqkRFRZGQkMCAAQNo\n0aIFZcuWNfw46NSpE2PGjOHw4cPkyZOHhIQEEhISUr0Gr8b8QoECBejTpw+tW7fG2NgYa2trSpYs\nSa1ateR3AaCIjOyLLmlCVVUSExPJnTs38fHxGBkZGQpSdHR0sjF/z549S/dYxoiICAoUKJDu51M6\n/5MnT5J0CJGkD0FqZS1v3ryp3iGm9rrY2FiMjY2TbHuRAHPl+t9905vK5ateLnubN2+mQ4cO6HQ6\noqKiMDY2TnJsVVWJjo7G1NQ0TcdOKeaXjxUfH5/s+Zz+XSATsCRJkiRpQLYBS5IkSZIGZAKWJEmS\nJA3IBCxJkiRJGpAJWJIkSZI0IBOwJEmSJGlAJmBJkiRJ0oBMwJIkSZKkAZmAJUmSJEkDMgFLkiRJ\nkgZkApYkSZIkDcgELEmSJEkakAlYkiRJkjQgE7AkSZIkaUAmYEmSJEnSgEzAkiRJkqQBmYAlSZIk\nSQMyAUuSJEmSBmQCliRJkiQNyAQsSZIkSRqQCViSJEmSNCATsCRJkiRpQCZgSZIkSdKATMCSJEmS\npAGZgCVJkiRJAzIBS5IkSZIGZAKWJEmSJA3IBCxJkiRJGpAJWJIkSZI0IBOwJEmSJGlAJmBJkiRJ\n0oBMwJIkSZKkAZmAJUmSJEkDMgFLkiRJkgZkApYkSZIkDcgELEmSJEkakAlYkiRJkjQgE7AkSZIk\naUAmYEmSJEnSgEzAkiRJkqQBmYAlSZIkSQMyAUuSJEmSBmQCliRJkiQNyAQsSZIkSRqQCViSJEmS\nNCATsCRJkiRpQCZgSZIkSdKATMCSJEmSpAGZgDUUERHBs2fPtA5DkiRJ0oBMwBrYt28flSpVwtbW\nFktLS+rWrcvZs2ff+njDhw9nypQp6XrNP//8g6IoJCYmvvV502rixInExcUBUL58+Xd6r5KUVk+e\nPEFRFEqXLo2lpSWWlpaUKVOGjh078u+//771cVP7DB86dAh7e/u3Pm5AQAA1atR469enV/369Vm3\nbl2mnU9KTibgTBYXF4eHhwdLlizh3r17hIaG4uXlRceOHbUO7b1ITExk8uTJqKoKwOHDh6latarG\nUUk5ydmzZ7lz5w537tzh/PnzJCYmMn78+Lc+nvwMSxlFJuBMpqoq0dHR5MmTBwCdTseQIUNYtmwZ\nCQkJABw8eBAnJydKlSqFj48PMTExAKxcuRJbW1tMTU2xt7fnxIkTyY7/8OFDOnXqRMGCBalZsyYH\nDx58qxi/++47ateuTenSpZk0aZIhgUZERODh4UGxYsVwd3cnKCgIgEuXLtGsWTMKFCiAlZUV8+bN\nA8DT0xOAmjVrEhYWRq9evbh16xYABw4coFOnThQuXJgOHTrw4MEDAGbPns3cuXNp0qQJBQsWpFu3\nbrKqXsoQhQoVwsnJicePHwMghGDq1KmUKVOG0qVLM23aNIQQAKxevZqyZctSpEgRPDw8CA8PB0jy\nGd68eTN2dnaUK1eOLVu2GM7zzTff8P333xseT506lSVLlgCpl5WXXbt2jQYNGmBmZoa9vT1Hjx5N\nts/gwYPx9/c3PP71118ZMGAACQkJ9O3bl4IFC2JlZcXMmTPTfZ0OHDhAzZo1KViwIJ06dSIsLIzI\nyEhq1qxpuHYAPj4+bN68+bXXsVmzZsyYMYPixYvz22+/vfb9b968mVq1alGmTBlmzZqFq6sr8Pp/\np2xNSJluypQpIleuXKJly5Zi/vz54u+//zY8d//+fWFhYSGWL18uwsLChLu7u5g3b564du2ayJ8/\nvzh9+rR49OiR8Pb2Fi1bthRCCDFs2DAxefJkIYQQ7u7uok+fPuL+/fti+fLlonz58inGEBwcLACR\nkJCQ7LmFCxeKatWqicDAQBEQECAqVaokli1bJoQQon379sLLy0vcv39fLFq0SDg6OgohhKhdu7aY\nNWuWiIyMFJs2bRJGRkbiv//+E+Hh4QIQ9+/fF6qqCmtraxEUFCRu3bolzM3NxYoVK8SdO3eEp6en\n4f2MGTNGWFhYiN27d4u///5bVKpUSfz8888Z9w8g5QgRERECEL/88ov4/fffxe7du8X8+fNFoUKF\nxObNm4UQQqxcuVJUqVJFnD59Whw/flxUq1ZNHDt2TDx79kyYmpqKM2fOiPDwcNGmTRvxzTffCCGE\n4TN88+ZNUaRIEbFlyxZx7tw5UaNGDVG7dm0hRNIyKYQQQ4cOFdOmTRNCpF5WDh8+LOzs7IQQQnTu\n3FlMmzZNREdHiwULFhiO+7Lly5cLd3d3w2MPDw+xdOlSsX79etG4cWMRFhYmLl26JMzMzMT169eT\nvd7BwUH4+fkl2x4aGirMzMzE6tWrxb1790SfPn3EyJEjhRBCtG7dWqxatUoIIURUVJQwNzcXDx8+\nTPU6CiFEmTJlRIsWLcT27dvFgwcPUn3/N27cEBYWFmLz5s3i0qVLom7duqJcuXKv/XfK7mQC1khg\nYKD49NNPRbly5YROpxO+vr5CCCE2bNggqlevbtjvzp074syZMyIiIkJcuHBBCCHE48ePxbx58wyF\n9UVh/++//4ROpxOXLl0SERERIiIiQjRq1EicPXs22flfl4AbNmwo5s2bZ3g8bdo04ezsLGJjY0Wu\nXLnE5cuXhRBCqKoqfvvtN5GQkCBOnDghEhISRHx8vDh16pQwNTUVV65cEQkJCQIQz549E0L878vL\n19fXkLyFEOL69esCEP/++68YM2aM8Pb2Njzn4+Mjvv7667e+1lLO9CIB29raCltbW5E7d25Rt25d\ncebMGcM+zZs3FzNmzDCUl7lz54ovvvhCxMTECBMTEzF37lzx4MEDERsba3jNi8/wDz/8IJydnQ3b\n582bl6YEnFpZeTkBd+3aVXTq1EmcOXNGJCYmiri4uGTvLzw8XJibm4snT56I6OhoUbBgQfHff/+J\nTZs2iXLlyolff/1VxMTEiJiYmBSvT2oJ+IcffhANGjQwXJPr168LGxsbIYQ+EbZv314IIcTGjRtF\nq1atXnsdhdAn4J07dxqOn9r7X7hwoWjRooVhv59++smQgF93/OxMVkFnssTERCIjI3FwcGD+/Pnc\nvn2brVu3Mm7cOK5du8bVq1dxcHAw7F+mTBlq1aqFmZkZGzZsoEqVKtjY2LBp0yZDtfALISEhKIpC\n8+bNqVKlClWqVOHGjRscOXIEb29v8uTJQ548efD29n5tjMHBwTRs2NDwuGHDhty7d4/bt2+TL18+\nbGxsAFAUhVatWmFkZMTDhw9p3LgxxYoVY/To0SQmJiaL79VzNGjQwPC4YsWKFClShHv37gFQrFgx\nw3P58+c3VM9LUnodPHiQS5cucfLkSW7dusWdO3cMz929e5fZs2cbysvs2bM5c+YMxsbG+Pv7s3Ll\nSkqXLo2bmxtXr15NctwbN25Qp04dw+P69eunKZ60lBVfX1/i4+NxcHDA1tY2SVXzCwULFqRZs2bs\n3LmT3bt34+joaGjO6d69O/369aN48eKMGTOG2NjYNF+vkJAQzp8/b7gmjRs35vHjx9y9e5cOHTpw\n4MABIiMj+eWXXwxNTKldxxcsLS3f+P5v3bqVpBNbvXr1DP//puNnV7m0DiCn2bZtG9OnT0/SfvvR\nRx9hZ2fH1atXKVy4MHv27DE8d+fOHU6ePMmTJ0/45Zdf2LRpE9WrV+fXX39l3LhxSY5tY2NDgQIF\nOH/+PBYWFoD+w16gQAHatm3L4MGDAShSpMhrY7SwsODixYuGL5Tz589Tvnx5ChUqxNOnT7l//z4l\nS5YEYPny5bi4uNC5c2dWr16Nm5sbxsbGmJiYvLaNxsLCgoCAAMPj+/fv8+jRI6ytrQF9cpekjFSj\nRg2mTp1Knz59uHjxIiVKlKBevXo4OzsbfpRGRkYaEoK9vT1nz57l4sWLfPXVVwwZMoQ//vjDcLyy\nZcuyc+dOw+Pbt28b/l+n0yVJeg8fPqRkyZI8evQoTWUlV65cbNq0iadPn7Jy5Up69epF69atk5Vd\nT09PtmzZQq5cuQzJMDY2llGjRjFp0iT27t3LkCFDqFatGgMHDkzTdXJwcMDR0ZG9e/catt27d4+S\nJUsafuBv27aNffv2Gdq1U7uOLxgZGQG89v07ODjw888/G17zck/zNx0/u5J3wJnMxcWFa9euMWXK\nFCIiIkhMTGTLli1cuXIFR0dHmjVrxunTp7l8+TKg75B09uxZHj16RKVKlahevTpCCH7++Wfi4+OT\nHDtPnjy4uLjw3XffoaoqDx48oGrVqly5coWyZctib2+Pvb09VlZWhtc8evQoyV9CQgKtWrVi3bp1\nRERE8OjRIzZu3IiTkxPFihWjRo0arF69GiEEhw4dwtfX13AsV1dX8ubNy7p164iJiSE+Ph4jIyOM\njY2JiIhIEmurVq04dOgQFy9eRFVVli1bRrVq1ShQoMB7vPpSTjdo0CDKly/PZ599BkD79u1ZsWIF\n4eHhCCHo2bMn8+bNIywsjOrVqxMSEkK1atVo06ZNsmM1adKEY8eOce3aNWJiYpLcpRYvXpzAwECE\nENy/f5+//voL0CcOSLmsvKxPnz78+OOPFC5cmB49emBsbJziD9qPPvqIgIAA/vrrLzp06ADA+vXr\n6dKlC4qi0KZNG6pUqZLq9YiMjExS/qOjo3F1dSUwMNBwh7lmzRpat25tuEv39PTkq6++olGjRoby\nmtp1TOl8qb3/li1bcvToUf78809CQkL46aefDK9L6/GzHa3qvnOy06dPi2rVqolcuXIJY2NjYWVl\nJfbt22d4ft68eSJ//vyiYsWKonXr1iIsLEw8ePBA2Nvbixo1aghbW1sxbdo0YWpqKqKiopK0N50+\nfVpUqlRJlC1bVlhbW4sZM2akGMOLNuBX/w4cOCDCw8OFm5ubKFSokChatKjo0aOHiI+PF0Lo22+s\nra1FuXLlhJ2dndizZ48QQohBgwYJKysrYW9vL3r27CkaNGgg/P39hRD6jhu5cuUSFy5cMLSfCSHE\nzJkzhYmJibC0tBTVq1c3dBQZM2aMmDBhgiHWVx9LUlq8aAN++PBhku3Hjh0TOp1OHDlyRERFRYmO\nHTsKc3NzUaFCBeHu7i6io6OFEEL4+voKKysrUbVqVVG2bFlx/PhxIYRI8hleuHChKFKkiChdurTo\n2rWroQ04JCRE2Nj1D2ISAAAgAElEQVTYiJIlSwobGxvRp08fQxtwamXl5TbgkydPipo1awobGxtR\nuHBhMWvWrFTfp6enp+jUqZPhcXx8vGjXrp2wsrISZcqUEW3atBFPnjxJ9joHB4dk5X/IkCFCCCEW\nLVok8ufPLypXrixq1qwpAgICDK+Ljo4WpqamYv369YZtr7uOZcqUERcvXjTs+7rviuXLlxvi9vb2\nFpUrV37j8bMzRYgPoS939vTs2TOioqIM1cUvS0hIICoqKtkd4X///UehQoXQ6V5fefHw4UMsLCze\nqSr3yZMn5M6dm3z58iV7LiwsLFncUVFRKIqCiYlJsv2joqLInz9/su0JCQlERES8sVpckt6nqKgo\ngBQ/ow8fPqRo0aKpvjY+Pp6YmBjMzMzS/NrXlZWXhYeHY2ZmRq5c6W8tjImJIS4uDnNz83S/FvT9\nVR4/fpyusvm66/jqfq++/9u3b3Pr1i1cXFwA8Pf3Z/HixYbag/QcP7vIEgn4RQiy3U+SJClnio6O\npkqVKvTv3598+fLxww8/sGDBAtzd3bUO7b3J1Dbg8PBwunXrRokSJRg4cKBhcgV/f38mT56cmaFI\nkiRJWYiJiQknTpzA2toaExMTtm/f/kEnX8jkBLxhwwaaNGnC7du3KVWqFB9//HGyzgeSJElSzlSi\nRAl69erF0KFDqVatmtbhvHeZOgzpxo0beHl5kS9fPiZOnMikSZPo168fbdu2fafjrly58sOYlkz6\nYJiYmNClSxetw8gWZPmVsprMKr+ZegfcqVMnBg4cyLFjxwD9KjnFixfnq6++eutjrlq1KsnYMUnK\nCnx9fdmxY4fWYWR5qZVfRVHe2NEwJ7C4eYtG3y/D+Gmk1qEkJQQlz1+k6u69b943G8qs8pupd8CO\njo74+fklGRM6e/ZsateubVicIL2EEPTu3Zs+ffpkUJQfvsTERA4cOECJEiXkqi7vyaNHjz74u7rE\nxERiY2Pf2JP3dVIrvw8fPuTRo0evHcOaU4hxn1MhKgrlNT2xtSISE3F4PskGgLh7F6V0aQ0jyhiZ\nVX4z/Sdm+fLlqV27dpJt3bt35+OPP37t6xISEnj69Gmyv6ioKNmOnE5ffPEFjx8/Zs6cOZw7dw7Q\nt8/36dOHli1bJpkBR5JeWLhwoWF1rSVLllC5cmXs7Ozo1atXuqY6TAtzc3PDbGs5nWJikiT5isDj\niJAQDSP6H+Wl5AsgVq0l8fMvEBcuahRR9pIlpqL09fVFCMGoUaNS3efIkSPMmTMn2fazZ89StWrV\nN85vnJWFh4cTGBiIk5NTimMJM9oXX3xBXFwcu3fvBvTTY/7yyy/MnTuXyMhIGjZsyK5du3Bycnrv\nsUjZx927dylXrhxRUVEsXbqUM2fOYGpqyqRJk1i8eDEjRozIsHMZGxtjbGycYcf7oBQvhvrJCJSW\nrii9eqJkoTGxymej4be9qN/MhPLWGE2dpHVIWVqWSMADBgx44z7Ozs44Ozsn2+7t7Z2tqvq2bdvG\n1atXsbS0pFu3bsTExNC3b1+GDBmCl5cXmzZtMsybmlHEs2cQGan/i4rGNCqKg0ePEHvzJk+3bOXJ\nvv3MrVeP0vMXoZv0FZs2beLPP/+UCVhKUWRkJLVq1TJM8ODu7s7mzZsz9Bzx8fHEx8e/U/X2h0op\nVw7dquWIZctRvf4Pnb8fyltM1PE+KDodStvWiNYt4XDAm1+Qw2WJfzVTU1OtQ8gUEydO5OjRo4wY\nMYJRo0Zx6NAh5syZw6JFiyhdujRLly4lIiKCwoULG14j4uKeJ84oiIzS/zcqChEZlWy7iHq+7aX9\niIoG4zyQPz+YmoKpKVvu3qGTfR0K1KnHxsBAqhcqSHAuI8o4O6P6fMpdlyYZ/iNAyv4sLS0ZOXIk\nFSpU4NKlS4SEhBAWFsagQYMMk/JnlMePH8s24NdQzMxQRg5DdPgIEhIgiyTgFxSdDpwbJ9mmbtkG\nRkYobVqh5M6tUWRZS9b6V/uAhYaGsnbtWq5fv47Y9yetJk/l+zlzCJ8+i5JmZszYuweHhHgKjP+K\nxJcTq04H+U0MyZP8JpA/P8qL/zc1BcsykN8EXf78zxPt82T7/LHySm/SqJUr+ezCBcLDw/ls/rfk\nzp0ba2trZhctQvPr1zl+LohZAYc0ulJSVjVkyBCGDBlCcHAwQUFB5M+fn9DQUFatWpXhYzbNzc1l\nFXQaKOXLJ3msrl6LUsMOpWYNjSJKndLIEXXR94gVK1E+ckPp0yvZd1NOk6kJeM6cOezfvz/F53r0\n6EH37t0zM5xMlZCQoF/e7/gJ1BZu6ObPRUEhvmABJgedoUStGgzs1v15os1vuGN9H1VLvXv3Ji4u\nLknP8/DwcH799VceNG/K7Lv3MclC7UpS1mJlZWVYUatQoUL4+vry22+/vbYPx759+5gyZUqy7dev\nX6dOnTrJekHLNuC3o9jX1re/limNrm8flCqVtQ7JQClaFKNJXyHu3kX8sgUePIBSpbQOS1OZmoC9\nvLzw8/Nj1KhRyXpCv26y8w9ByZIlKZM3Lzf6D8L0wO/8HHCYH+6HUKN+PVYs+JamTZtydMF8ZsyY\nkSm9P18d9lWwYEF69eoFQGKf/ohTp1Hq2Kf0UklKIi19OFxcXAyT7L8stT4csg347SjVqurbh/f8\njvr1FHTfL0QpWFDrsJJQSpdGGTY0yb+7uHcPbt6CRk45ak2ATE3AxYsXZ82aNXz55Zf06NEjM0+d\nJUw1MWdZQXP+WrSQihUrcuHCBczMzAgODtY6tCSUHp6oa9dhJBOwlAbvow+HbAN+e4qREUrb1iS2\ncOHQgQMUt7SkSpUqiMhIfdNVFpEk0RYogOq/Cb77AaVDO5ROHVDecm6I7CRXXFwcd+/exdraOlNO\nWLVqVTZt2pQp58pKxIaN6HQKgw/uxyeL/8JTmjdD/PQz4spVFBv5BShlPtkGnD63b99m165dKIqC\nl5cXZmZmfPHll9SpU4ddf/xBkyZNaG1ZlsQlP6Lz9EBxctQ65CSU/PkxWjgPceMGYsuviE1bULp1\n1Tqs9y5XSEgI06ZN46effsLT0xNVVVPdedGiRRQrViwTw/swiOs3EOv90S37PltUryhGRiieXVDX\n+MlxfJJBZvbhkG3AaXfnzh28vLwYNGgQDx48wNzcnJCQEPr160elSpUwMzPjwoULtGnTBl2Xzqir\n/WDZcnTTJmW5WauUihVRxozUj/54ibrvTxQnR5S8eTWK7P1IUgW9aNGi146plYump5+IjUWd8g3K\nsKFZciq51ChtWyNWrUEEB6M873Aj5WyZ2YdDtgGn3dSpU5k4cSItWrQA9N/Ta9euZezYsVy+fJnF\nixfj5+cHgNK4EUaNGyHOX4Cw/yCLJeAXklU/nzqDOm8BiqsLSnt3lEyqsX3fkvQBt7CwoGjRohQs\nWJCQkBCKFi2Kn58f/v7+WFhYyMnR34L47gcUWxt0zZpqHUq6KHnyoHzcCbF2vdahSFnEiz4cmzdv\npmrVqkn+MjoBP378mDt37mToMT9UZmZmSeYOKFWqFLGxsQQFBTF58mTWrl2brJ1esauebKiS+s1M\nxOUrmRJzeunGjkK3ajlYFEGdNE3rcDJMihl12rRp+Pv7s3XrVjZv3syZM2dYuXJlZseW7YmjxxDH\nT6AM/0TrUN6K0qEd4lgg4t9/tQ5FyiIyqw+HnAs67VxdXfn666+5dOkSJ0+eZObMmXh4eNCrVy9U\nVWXo0KGGO+DXsrVBnT6LxP6DECdOvv/A00kpXBhdz+4Y/fxjku3i4iXExUsaRfVuUuwFffToUXbs\n2EH//v0ZM2YM5cqVY/ny5ZkdW7YmHj1Cne2LbuoklHz5tA7nrSgmJijt3BHrN6IMG6p1OFI6BAYG\nUr9+fXbu3MnJkyf59NNPKVSokNZhpZlsA0671q1bk5iYyKRJkyhSpAgTJ07ExsbGsNBKWuk6toeO\n7RGnTus7YNar+54izmBmpqgTp0BiIkrrligfd8o2PahTvAO2srJi3rx5HDhwACcnJ+bNm6efREJK\nM3XGbJR27ihVbbUO5Z0oHp0Rf+xDhIdrHYqURvv372fEiBGEhobi4+NDvnz5MnShhMwQHx9PdHS0\n1mFkG25ubmzYsIHFixfTpEmTdzqWUsceXY9uSbapPy5H3bZdP698FqOULYvRimXovvgcHvyLCDii\ndUhplmICnj17Nqqqsn79ehRFoX79+m9cLlD6H3XTFoiMQunVU+tQ3plSoABKC1fExpw3dCy7CggI\nYNq0aezYsQMPDw/Gjh3L3bt3tQ4rXWQbcNaiuDSDs+dQu/ZAnTYDEROjdUjJKFUqoxs5DKVp0h8g\n6tIfs2wVdZIq6BftvS/s3LmTnTt3AnDw4EGaNWuWudFlQ+L2bcSqNeiWfPfBzHOqeHqg9h+E6NEt\nSy19JqWsfPnyrF27lnPnzrFgwQKWLl1KxYoVtQ4rXeQ44KxFsbZG+eoLRFQU4s+/4PFjKFECAKGq\nWeq7LtlQz1KlUH3nQ0wMSvuP0HXJOjeTSRJwiRIlUp15pkCBApkSUHYm4uJQJ3+DMmQQyvMP54dA\nKVYMxbEhYuuvKK9UTUlZT7du3YiMjMTV1ZUGDRpw+vRppk+frnVY6SLbgLMmJX9+lI/ckm6MjiZx\n+GiU5k1RWrhkueGWOve24N4WcfMm4tjxJM+JuDhN24uTJGBHR0ccHR05evQoo0aN4vHjxwghiIuL\nY/jw4djby6kJX0cs/RHFuhy6li20DiXDKd27og4fjfDonG06OOQ0Z86cSbYu75dffgnoa7f69u2r\nRVhvRY4Dzj4UU1N0Iz5F7P0DdYAPSptW6Ab01zqsZJQKFVAqVEi68egxEnfs0v9waNzotR1mxZkg\nxI5d6L4cn2ExpVhvMGvWLCZMmICNjQ27du2iTZs2ODpmranLshpx4iTi4GGUkcO0DuW9UMqWherV\nEDt3ax2KlApzc3OqVKmS4p+lpaXW4aWLbAPOXpRqVdGN+BTdZn+UV+Y8EFeuIh4/1iawN3FujM69\nLSLgKGqX7ojjJ1LcTRw8hPrtQsSDjB2SmeIwpNjYWFxcXDhx4gR37txhxIgR/PDDD9SpUydDT/6h\nEBERqDNmo/vqiyw12XlG0/Xohvrl14h27ihGRlqHI72iQoUKVHj1F/5zCQkJmRzNu5FtwNmToihQ\n6ZX+BqGhqJ+NBysrlGZNUNzaZJlaNEVRoIkzRk2cEdHREBYGwPbt26lbty4fffSRfsdGTuiqV0P9\nMmOn5k0xATdr1ozhw4fTqVMn5s2bh7W1teadOPbv388333yTbPulS5ews7PTIKL/UWfO0Y8/y4KL\nYGckpUplsCyD+GMfSquWWocjpSIsLIxevXoRHByMqqokJCTg4ODA2rVrtQ4tzWQb8IdDcW6MzskR\nTp5CHDwM5y9AFlxpTTExgbJlAf3n7+XmD0WnI/VJmt9eigl45MiR/Pnnn7Ro0YLr16/z+PFjvLy8\n3sPp065p06Y0btw42faBAwdqEM3/qL/ugP8eoUz5WtM4MouuRzfU+YtAJuAsa+3atdjb2+Ps7Ezl\nypV58uQJj7NqFWAqZBvwh0UxMoL6Dij1HZI9l/jpSJSqNigNG2SZmxgjIyOMMqGWL8U2YCMjI8PE\n3j4+PowfPx4zM7P3HszrKIpCrly5kv3pdDrNVhgSd+4gflqB7stxOaZKVrGvDSYmiMMBWocipSI6\nOpqmTZvSsGFDLly4QJ8+fThw4IDWYaGqarK/1BZ/kW3AOYdu1DAwNUVdvITEHr21Did1+fKhuLXJ\n0EOmeAc8evRo9uzZY3hsZGTE0KFD6d8/6/Vs04pITNQPOfLuh1KmjNbhZCpdD0/UNeswauSkdShS\nClxcXBgxYgR+fn6MGDGCYsWKaV6du3//fqZOnZps++XLl6lRI/ldj2wDzjkUKyv9ims9uyfrrCXO\nBCEuX0FpWF/zFZCUfPlQ2rbO0GOmmIBfLG8F8OTJE+bMmUPVqlUz9MTZnfhpBRQvph9jlsMojZxg\n2XLE6TP6O2IpS3FwcGDGjBlYWFgwY8YM/vjjD83HATdr1izFiXy8vb1TvAuWbcA5k1KwYNIN5awg\n4AjqV5P1E2n0/z90H1DzV4oJOG/evOR9vvCxmZkZ3bt3Z926dXIo0nMi6Cxi7x/oli/VOhTNKD08\nUdeuw0gm4Cxnw4YNye42IyMjWbx4sUYRpZ9sA5YAlEKFUIb6wFAQd+9C6MMkz4uAI1CoULadcz/F\nBLxhwwYuXLgA6Icv7N27l9GjR2dqYFmViIxEnTYD3bixKObmWoejGcWlOWL5Sv2qKTYpz54maaNT\np060bauvmYmNjWXHjh2EPR9ekV08fvyYR48epTozn5TzKKVLQ+nSSbaJ+HiE73wIDYXatdAN8kbJ\nRstYppiAS5UqRXx8PAA6nY527drRsGHDTA0sq1Jn++rHsmXBbvSZSTEyQvHsgrrGD6OpGTs2Tno3\nuXPnJnfu3IC+Bqt37944Oztnqx/Rsg1YSgtd0ybQtAkiIgJx8hQ8eQovJWAReBwqV0LJoktxJknA\nEyZMYPv27Snu6OPjo/mQH62pv+2BOyEoE8ZpHUqWoLRtjVi1BhEcrO9EIWUJx48fN5RjVVW5cOFC\ntuvDIduApfRQChRAcWmebLs4GoiYOh2KFkWxr4UyeGCWGrGSLAF/9tlnLF68mCdPnuDj40NiYiLf\nfPMNrq6uWsWYJYh79xDfL0U3fy7K87uLnE7Jkwfl404Ivw0o48ZqHY70XMGCBZNU3TZq1AgXFxcN\nI0o/2QYsZQTd8E8Qw4bCjZuI02cgLg6ez/cs4uPh5CmoYffGVd7Epcuo3y6ExER0C3wN+4v791EH\nDdW3Qzd1RtenV7riS5KAX3S+OnjwICtXrsTCwgKAnj17smLFihSHEeQEIjERdeoMlD69UMqV0zqc\nLEXp0A7Vsyfi339RihfXOhwJqFy5MpUrV9Y6jHci24CljPJiekzl1SkyFQV1yzaY8g2ULYtS1x5d\n/5QXLFFnzUX3wyJEwBHE6rUogwYAIE4HoXT3ROny8VvNR5FiG7Cbmxu9e/emR48ePH36lOXLlzNn\nzpx0H/xDIVatAdP86Dq21zqULEcxMUFp545YvxFl2FCtw8nRtm3bxldffZXic/Xq1ePHH3/M5Ije\nnmwDlt43JVcujGZNRyQmwtVriEuXAVCnzYCgszwsX/5/O8fGouTNC7Y2qDt2/W970FnE38GIHbtQ\nunqke1hqignYx8eHUqVK8ccff2BiYsKCBQuoX79++t/hB0BcuIjYvhPdT0u0DiXLUjw6o/bojejd\nM/k4PinTuLm50bx5c06fPs23337LlClTKF26NGvXrsU8m/XYl23A6SeCg/U/hNu5o9jaaB1OtqEY\nGUFVW8NQJmX8Z7B7JwUKFEi+c3w8vFRdrYwbi06nQyQkoHbpDhmRgAE6dOhAhw4d0nWwD42Ijkad\nOh3d2FFZthddVqAUKIDSwhWxcROKdz+tw8mxcuXKhZmZGYGBgXh5eVG9enVAP9lFu3bt6NUrfe1T\nWpJtwOmnTpuJUqc26vRZACgtXfV/xYppHFn2oigKFDAnz8srNllYIM5fQPy+D8WxISIsDGJjEf6b\nEDXt9DcebzEjYpIE7O/vT4UKFbhy5Qrnzp1LsmOLFi3eS0es2NjYLPtLV3y7EKW+A0qDnHn3nx6K\npwfqAB9Ed883dmiQ3i9XV1e8vb158OABRYoUYf369TRvnryHaFYm24DTR/z7L4SGogzoj26gN+Ly\nFcTeP1C9B0N5a5RWLVCaOL92wXkpdboZUxErV0OxoujatkZcvgJPn6IM7K8fCWJigm7uzHQfN0kC\nLleuHEWKFKF8+fKGcYQvlMyAwc3R0dHMnDmTU6dOMWPGDIYOHUpwcDD16tVj5cqV5MtCHw71z/2I\nK1fR/fiD1qFkC0rx4igNGyC2/orSo5vW4eRo9vb2LFu2zDChTvfu3fHw8Mjw8yQmJhIbG/te7lJl\nG3D6iMNHUJwcDR2BFFsbFFsbxJBBcCwQdc/viEXf61ccatUC6thrtohNdqTkz4/iM+h/j1+q4n/R\nIettJFkNycHBgXLlylG3bl0qVapEly5duH//Pg8fPsyQcYTr168HYNy4cbRo0YL+/ftz+/ZtGjdu\nzNatW9/5+BlFhIYi5i9C99X4LLNwdHagdO+K2LQFERendSg50smTJ/H39+fYsWNs2LAB0E/EcfLk\nSZYsefc+DAsXLuTgwYMALFmyhMqVK2NnZ0evXr2IjY195+O/zNjYONu1W2tJHDqM0ij5VMFKrlwo\njZwwmvI1Or9VUNUW9aefUT26oS5ZhggO1iBa6YUU24CnTZtGbGwswcHBbN68mUqVKrFy5Ur69Onz\nTie7dOkSvXr1okaNGhQtWtQwt3STJk3YtGnTOx07owghUKdM13ctr1jxzS+QDJSyZaFaVcTO3Siy\nx3ims7CwQFVVihQpQp06dZI8VywD2gHv3r1LuXLliIqKYunSpZw5cwZTU1MmTZrE4sWLGTFixDuf\n4wXZBpx2IiICbtyEunVeu59ibq4vlx3bI/75R19FPfpzKFxY31bs2hwlpY5H0nuT4nrAR48eZfLk\nyWzZsoUxY8YwfPjwZG3Cb6Nbt254eXnRokUL6tSpw4ABA1ixYgU+Pj54enq+8/Ezgli7DnLnQtc1\n46vscgJdz+6I9f76rv1SpipXrhwODg5UqFABKysrunTpQv78+bl8+TI1a9bMsPNERkZSq1YtzM3N\n0el0uLu7ExoammHHB7kecHqII8dQ6tVN1wRBStmy6Pr3Refvh25gf7h+A7VHbxLHf4k4cFA/SYX0\n3qWYgK2srJg3bx4HDhzAycmJefPmZcgwpDp16nDgwAFmzJjB8uXLGTt2LMHBwfz444/Y2mq/moW4\neg2xaQu68Z9pHUq2pVSpDGVKI/7Yp3UoOdb+/fsZMWIEoaGh+Pj4kC9fvgy5O7W0tGTkyJH07t2b\n33//nZCQEIKCghg0aBCdO3fOgMj/x9zcPEP6neQE4nAApFD9nBaKoqDY10b3+Rh0v6xHadYEdftO\n1I89UX3nIy5eyuBopZelWAU9e/Zsvv/+e37++WcSEhKoX78+H3/8cYacsGDBgobqsZYtW9KyZdrW\ndrxx4wZ79+5Ntv3SpUsZUlBFTAzq5GnoRnyK8nwGMOnt6Hp0Q52/CD6gdTuzk4CAAKZNm8aOHTvw\n8PBg7NixtGjR4p2PO2TIEIYMGUJwcDBBQUHkz5+f0NBQVq1aRbVq1TIg8v+R44DTRsTEwJkglC8+\nf+djKXnzorRwhRauiIcPEb/vQ53tC/Hx+l7ULV1RSpTIgKilF1JMwHFxcZw9e5YFCxawYcMGNm7c\nSKdOnQxTU2Y0X19fhBCMGjUq1X2MjY0pWrRosu158+bFKAMm1xYLF6PUrIHi3Pidj5XTKfa1wcQE\ncTgApZGT1uHkOOXLl2ft2rWcO3eOBQsWsHTpUipmYH8GKysrrJ4vvlEojePjHz9+zD///JNs+6NH\nj1Js55VtwGkUeByqV0PJ4OukFC2K0t0Tunvqawb3/q6f87icFUrLFihNnTP8nDlRigl42bJleHl5\nYWFhQcmSJenevTv+/v74+Phk2Inj4+PR6XQYGRkxYMCbu3FbWlpiaWmZbPvevXsRQrxTLOLQYUTQ\nWTnbVQbS9fBEXbMOI5mAM123bt2IjIykefPm2NnZcerUKaZPn/7ezpeWH9C3bt1i5cqVybZfvXqV\n8i9P+fecHAecNuLwEZTGjd7rOZQqlVGqVEb4PB/StPcPxOIf9HMktGoBdeug6FJszcwybt++zfXr\n1wFo0KBBlulhn2ICvnz5MgMGDGD37t0AWFtbc+TIkXc+WUJCAp9//jlbtmwB9GsNGxsb4+npyWef\nadPuKv77D3Xut+hmfqOf61PKEEojJ1i2HHH6jP6OWMo0iqJw/fp1du7cSXR0NLt27aJ+/frUrVv3\nvZwvLT+g7e3tsbdPvoa2t7d3ij+g5TjgNxOJiYhjgegGv/041PRQjIzAyREjJ0dEZCTiz79Qf14N\nM+foe1C3bolibZ0psaTXrFmzcHR0xMjIiISEBAD27dtHQEAA+fPn59NPP00290VmSPFnS79+/fDw\n8ODChQusWrWKTz75JEOmsZs3bx4AV65c4ebNm1y/fp3Tp0/z4MED/Pz83vn4b0P9ZiZK5476zkNS\nhlJ6eKKuXad1GDnOkSNHUBSFyZMnA/Dtt98yd+7cDD1HfHw8ic97upuammJqapqhx5fjgNPgTBBY\nWaEULpzpp1ZMTdG1c8do8QJ08+dCnjyon08gsf8g1I2bEOHhmR7T69y/f5/w8HBKlixJ4cKF8ff3\np3fv3jRq1AgTExPc3NyIjIzM9LhSTMBNmzZlyZIluLq6UqBAAXbu3EmZt5jn8lX37t2jU6dOSX5p\n5MmTh3bt2mky5ED1/wXi4lF6ds/0c+cEiktzuHsPceWq1qHkKBcvXqRBgwaGmY5KliyZIRNlJCQk\nMHr0aCpUqICNjQ02NjZUr16dqVOnEp/Bw1bi4+OJjo7O0GN+aMShAJTG2jfxKGXKoOv3fxhtWItu\n6GC4/Tdqr74kjpuAuv+vLDExT/PmzenUqRPr1q0jKCiIOXPmcOzYMZo3b87gwYNp2LAhe/bsyfS4\nUqyCPn78OFWqVOGLL77I0JP17NkTHx8fOnfubGjPvXPnDqtXr2bfvswdtiJu3kSsXYdu6WI5Jdt7\nohgZoXh2QV3jh9HUSVqHk2N4enri7OxM9erVyZUrFxs3bnznSXQgaQ3Wix/RcXFxjBw5Ej8/P3r3\n7v3O53hBtgG/mTh0GN2ib7UOIwmlVk2UWjURw4bq+9bs3oPwna+fh7pVCxS76pkek6qqlC9fnjJl\nytCsWTOuXbuGlZVVkg5+iqK8c1+it5FiAp4yZQpff/11stl03lWdOnXYunUrO3bs4Pz586iqStmy\nZdm3b1+GzIIw9AIAACAASURBVNSTViIuDnXyNyifDpGLyL9nStvW+snKg4NRnvecld4vMzMzfv/9\ndzZv3kxwcDCffPJJiu2v6XXv3j08PDxSrME6fvz4Ox//ZbIN+PXEpctQoABKqVJah5IixdgYxdUF\nXF0Qjx7phzT5ztevq9vSVZ+MM2mct06n49ixYxw5coSYmBgmT55MREQEY8aMYeTIkQQFBTFp0iSe\nPn2aKfG8LMUE7OrqSq9evXB1dTW07bi4uGTIiiolS5bE29v7nY/zLsT3S1EqV0Lnkr1WiMmOlDx5\nUD7uhPDbgDJurNbh5Ai3bt1CVdU0dY5Kj8yswZLjgF9PHM4a1c9poRQujNLVA7p6IK7fQOzZi+rz\nKZQpo++41dT5va+g9qKZ5MWPR29vb4yMjPD19aV48eKEhIRkeD+GtEgxAdepUydZ9XNKY3CzIxF4\nHHHkKLoVy7QOJcdQOrRD9eyJ+PdfWeOQCV6MMnjdsKC3kZk1WHIc8OuJg4fRfT1B6zDSTalUEaVS\nRcTggXD8hH6Vpu+XoDjUQ2npCvXq6ntbvwev9nLu27cvffv2fS/nSqsUE3CjRu93XJlWxOPHqDPn\noJv0lRxEnokUExOUdu6I9RtRhg3VOpwPXoMGDejZsyfXrl0zTJ5jbW1N//793/nYmVWDJduAUyf+\n/hsSErL1YjGKkRE0bIBRwwb6IU37D6CuXQ+z5qK4NNNXUWfj95dWKSbgD5U6fRaKe1tNOgLkdIpH\nZ9QevRG9e6IULKh1OB+0YsWKMW3atCTbimezmgfZBpw6cfhIiksPZleKqSnKR27wkRvi3j39Kk1f\nTgITE317cQsXTYZaZYYck4DVLdvgyVOU3l5ah5IjKQUKoLRwRWzchOLdT+twPmiVKlWiUqVKWofx\nTmQbcOrEoYBkk2/ExMRw6tQpABo2bIgui89MlRqlVCmUPr2gTy/EufOIPb+j9u4Htjb69uJGTh/U\nGu1JEvCECRPYvn17ijv6+PgwcODATAkqo4ngYMTPq9B9v/C9tS9Ib6Z4eqAO8EF093zvnS6k7E22\nAadMPHwIDx5ADTvDtpiYGLp160bFihW5efMmwcHBHDlyJNv/gFFq2KHUsNMPaTocgNjzO2LeAhTn\nxvo745o1tA7xnSX5mTRhwgQOHz5M9+7dcXd3Z9euXWzfvp2GDRvi6uqqVYzvRCQkoE6ahjJ4AEqp\nUhk+XEJKO6V4cZSGDRBbf9U6FCmLk+sBp0wcCkBxckwy9/Lo0aNp164ds2fPZvPmzbi6urJ06VIN\no8xYSp486Jo3w2jmN+hW/gRWZVEXLibRsyfqipWIu3e1DvGtJbkDzps3L3nz5uXgwYOsXLnS0IGj\nZ8+erFixgqlTp2oSZHpFR0ezZcsW4uPj6fBvGGaWZVBdXZg+bRq//fYbhw4d0jrEHEvp3hV1+GiE\nR+dsX5V04cIFjh49irm5OR4eHppX+23bto2vvvoqxefq1avHjz/+mMkRvT3ZBpwycTgA3cedkmxL\nTEzEwcHB8Njd3Z3ffvsts0PLFErhwihdPoYuH+snU9rzO+onI6BUKf1dcfOmKBoMJ3pbKX5juLm5\n0bt3b/z8/FiyZAmjRo2iVatWmR3bW0lISMDW1pZr166R/+o19nw+jqttWxEaGkqjRo0yZEpN6e0p\nZctCtaqInbu1DuWdBAQE0Lp1a/Lly8fGjRtxcnLK8OkY08vNzY3Dhw+zYMECw5KEf/31F97e3jg7\nO2saW3rJuaCTE0+fwtVrUDfpBEm1atVizJgxqKpKfHw8K1asoGbNmhpFmXmUChXQ+QxC98t6dF7d\nIegsqmdPEidORhw9hng+V3lWlmIC9vHxwdvbm4MHD3Lt2jUWLFhA48bZY53cVatW4ebmxtejRtHp\nxm0qLlvCghUrKFWqFE2aNNFkujEpKV3P7oj1/tmigKRm6NCh/Pbbb/RwdOSXX36hQYMG7Ny5U9OY\ncuXKhZmZGYGBgXh5eVG9enUKFSqEt7c3a9eu1TS29JJzQScnAo7ol/57pebI29sba2tr6tatS8eO\nHalZsyZdunTRKMrMp+h0KPUd0H31BTp/PxSHeqjr/FE7d0VdtBhx7brWIaYqxV7QDx8+ZMOGDRw4\ncIANGzYwYcIE1q1bZ6iSzsqePXum/7UfHY3uh0UUi47m3q9btQ5LeolSpTKUKY34Yx9Kq5Zah/NW\nKpQsRYXtu1BjYzH6+kvKlSvHs2fPtA4L0M9k5+3tzYMHDyhSpAjr16/PkFnsMpMcB5ycOHwEpWny\nmgydTsd3332nQURZj2JiguLWBtzaIB480FdRT5oKefLoxxa3cEEpUkTrMA1SvANetmwZXl5edO7c\nmZIlS9K9e3f8/f0zO7a34uzszCeffMLpu3f5Nz6eJk2a0LRpU63Dkl6h69EN4bdB6zDeijhylMkh\n91myZAmPB/Tj8OHDDB8+PMskOXt7e5YtW0ZwcDAHDhyge/fumq23/bbMzc0pmUlzBWcHIjYWzgSh\nNKivdSjZhlKiBLreXhitXYlu1HC4ew/1/7xJHPM56u9/6K+pxlK8A758+TIDBgxg9259O521tTVH\njhzJ1MBeFRMTQ3gKa0xGR0cnmWLMzs6OHTt2MHr0aEqUKMG4ceOSzNyzfv36TIlXej3Fvjbky6ef\n07ZR9pjTVoSHo85fBDduUmX1zyz7eQXd/+//KFOmDBcvXsxSk13Y29tTq1Ytnj17liWG8gQHBxMQ\nEJBs+40bN3BwcODZs2fky5ePZ8+eERYWhoWFBebm5kkev/p8Tnpc5NYtjKvaEmNkRNidO5rHk+0e\nVyhPvlHDifbuS9ixQAofCiDf/P9v787DY7reAI5/72SRkITY94g1SOz7HsFPLbE1paQoVRpLhSq1\nK62taKmttNqQ0KqKUlq1iyWCithjaSyVEBEkss/5/TE1TDORbSaT5Xyex9POvXfOeedO7n3n3nPP\nOV8T7/k2Ua1bpdo+p2bI05uAhw8fjoeHB6BpU92+fbs2GZvKX3/9xYoVK1ItDwwMxMnJSWdZ8+bN\nOXjwYE6FJmWRyvNt1L5bMMsDCVi95w/E2nUoPbujTJuCYmGhnZ4vN5o0aRK//fYbEyZMYPv27cyZ\nM4cmTZqYLJ7k5GRiY2P1Lv/vVHBqtZrExESEECiKglqtTrW+oL1WnzqN0rZNroknr75WLCwQtWqi\natMaVWIiyl/n9G6fU5QbN26Izz77jG+//VZnxbVr19i6dStWVlZ4eHhQuXLlHAsqM0aMGIEQIk91\nsZBeShkyHNWHYzRXxLmQuH8f9eKl8DwO1ccTUKpWzdD7li5dSo0aNejZs6eRI0zt+PHj+Pv706xZ\nM6Kjo2nfvj0zZ85k8+bNOR5LetI6fh8+fCjbgP8lUlJQ934T1Q/f5tshGXOb7t2707x58zS79RmK\n3jbgtWvXkpSUxLRp05g4cSKPHj3iu+++M2ogUsGkDBqA2jf3JQahVqP+cSvqUWNQWrZAtWp5hpOv\nqV28eJEWLVpob6OVK1eOhFzQ3pUZsg34FeeCoVIlmXzzIb23oPfv38+aNWtYuHAhXbp04cmTJ3JU\nGskoFLeOiG+/R1y9pnk6OhcQ16+jXrQUbG1QrV2JUrasqUPKlAEDBtCuXTucnZ0xNzdn69atDB06\n1NRhZYocC/olEXA8z8z9K2VOmpMx+Pv7884773Dr1i15G0gyGsXMDGXAW6g3+WE2d7ZJYxGJiYjv\nfRB7/kAZNQJVHu0iZWtry59//skvv/xCWFgYY8eOpVGjRqYOK1PkWNAviaMBqL5aYuowJCNIMwGX\nLFmSvXv34unpib+/P82by8ffJeNQur+B2OiLCAtDcXAwSQwi+DzqRUtQatVEtWFdnp4y8dChQzx+\n/Jj33385Y87YsWP1PsSYW8l+wBri8hWwtUWpUMHUoUhGoLcN2M3NDXNzc6ysrPjpp5+oX7++bI+R\njEaxtER5s69J+gWL2FjUS75EPW8+qjEfoJo5LU8nX4BLly7x0UcfsWDBAu2yCxcumDCizJNtwBqa\nbnr5Z+5fSZfeBDxy5Eht+4tKpWLBggV5dipCKW9Qertrxm+NiMixOkXAMc1co2ZmqHy+Q2nZIsfq\nNrZly5YRFhbG8OHDSUxMNHU4mSbHgtYQR49pux9J+Y/OLeiffvqJatWqceXKFc6fP6+zYefOnfPs\nlIRS7qcULozSsztiy1aUD8cYtS4RFaUZUOPW36hmz0BxrmvU+kzBzMyM1atXs2jRInr06IG5eZqt\nTbmSbAMGcfs2xMej1Kxh6lAkI9E5KqtUqUKJEiWoWrWqzuhSgLwdJBmd4tEP9TvvIoZ4Gu02sHr3\n75oBNXr1RJn+Ccp//s7zgzp16lD83y4rH3/8MQ4ODuzfv9/EUWWObAN+cfUrn37Oz3QS8K+//srO\nnTv1bujl5UXduvnvSkHKPZRixVA6uSG2bkMZMdygZYt79zQDasQnoPryCxRHR4OWnxucPn2amzdv\nUrlyZXx9fXVmQGrcuPFr3pk1KSkpJCQkGOUqVc4HrOl+pHrfsMeBlLvotAFPnz6dgIAABg4cSI8e\nPdi9ezc7d+6kZcuW8vazlCOUAR6Inb8hDDQVnVCrUW/5CbXXOJQ2rVGtXpEvky9oei5UqVKFUqVK\n0bhxY51/hriSXLFiBUeOHAE0g/XUrFkTFxcXBg8ebPCBPgp6G7CIjIR796B+PVOHIhmRzhWwlZUV\nVlZWHDlyhB9++EE7/aCnpycbNmxg3rx5JglSKjiUMmVQWrZA+P+KMnBAtsoS16+jXrgEihXNkwNq\nZFZwcHCaQ+c1bdo027OC3bt3jypVqhAbG8s333zDX3/9hY2NDXPmzGHVqlV4e3tnq/xXFfQ2YHH0\nGEqrligqvc/JSgawfft2jh8/jlqtZtasWSb5waf32+3evTtDhgzBz8+PtWvXMnHiRP73v//ldGxS\nAaUM7I/4+RdEFp/eFYmJqNeuQz3pExSPvpgtXpDvky9ojtuAgACWL19O1apV8fX15dChQ4wYMUIz\nR7aBxMTE0KBBA+zs7FCpVPTo0YMHDx4YrHzQtAEX5NH3RIBs/zWmb775ho8++oj+/fvTtGlT+vTp\nQ3R0dI7HoffRyCZNmlC0aFGOHz9O4cKFWb58udEG4oiNjaVIkSJGKVvKmxQHB6hbB/HbHpQ+vTL1\nXnEuGPXipSi1nVB9vx6laFEjRZn7mJubY2trS2BgIO+88w7Ozs6AZsIDd3d3Bg8enK3yK1WqxIQJ\nE6hWrRqXLl3i7t27REZGMmrUKNauXWuIj6BVkNuARUwMXLkKTU03e1V+98MPP3Dy5ElKlSpFkyZN\nuHXrFgcOHKBv3745GofeBDx37lxmz57NoEGDDFrZkydPiIuL075Wq9V069aN33//HRsbG2xsbAxa\nn5R3qTwHop45B+HeA8XMLN3tRUwMYvU3iFNBqD7yRmneLAeizJ06derEiBEjCA8Pp0SJEmzZsoWO\nHTtmu9zRo0czevRowsLCOHfuHEWKFOHBgwf4+PgY/AHNgjwWtDh+Aho3QrG0NHUo+VaFChVISUnR\nvo6MjKRmzZwfi15vAu7UqRODBw+mU6dO2qTo5uaW7YN44cKFLF68mMaNG2vnAL1+/Tp9+vThvffe\nY/hw+cSfpKHUqgkVKyD2H0Dp0vm124ojR1F/9TVKu7aaATWsrXMoytypUaNGrFu3jh9//JELFy4w\ncOBA7fzehuDg4IDDv0OG2tvbG6zcVxXkNmBx9BhKOzn4hjH16tWLcePGMX78eM6ePcvatWv57LPP\ncjwOvQm4cePGTJs2TWdZqVKlsl3Z559/TsWKFTlw4AArVqygTJkyNG/enBMnTmS7bCn/UQ16WzNg\nRhoJWERFoV62HG7fQTV3Nkqd2jkcYe508+ZN7OzsWLhwYY7Ut3TpUoQQTJw40WBlFtR+wCIxEc6c\nRZn8kalDydcGDRpEiRIl8Pf3p3jx4ty+fRsrK6scj0NvAm7TJvWvr+TkZINU6OXlRceOHRk6dKi8\n4pVeS2nUEKyt/x0PV/eBFPVvexDfrEfp0wtl1nSUPDbSkzFt374dwKAJ8XVenfQhLefPn2fLli2p\nlgcFBVGlSpVUywtsG/CpIKjthCKb44yua9eudO3a1aQx6D1rnThxgokTJxIdHY0QgsTERMaPH8/Y\nsWMNUqmTkxO7du1i5syZlC9f3iBlSvlTdLeuXPIay9JqDpQpU4avp05DWfolJCah+moJip6Td0HX\nokULPD09uXbtmrYroaOjI++9957B6khKSkKlUmFmZpahZzcqVKhAz549Uy2/cOGC3ocwC2obsGbu\nX3n7uaDQm4AXLVrE9OnTWb9+PUuWLGHJkiW0amXYGTksLCyYP38+kLFbWPv372fu3Lmpll+9epX6\n9esbNDYpd4iLi6N0n15cbtmWdaO8WO3tzdUDXam94DPNla+imDrEXKl06dKp2rNeJOLsSE5OZsqU\nKdorbJVKRaFChRgwYACTJ09ONXztq0qUKEHLli1TLS9TpgxCiFTLC2IbsEhJQRw/gWrEMFOHIuUQ\nvQk4ISEBNzc3goKCuHPnDt7e3qxZs8Yow9lBxm5hubm54ebmlmr5iBEj9B7AUt538uRJxo0bR41+\nb5IydASf9HFnaPBZNvXtberQcjV7e3s2bdpEWFgYarWa5ORkmjVrRpcuXbJV7rJlywC4cuWKNtkm\nJiYyYcIE/Pz8GDJkSLZjf6FAtgEHn4eKFVFKlDB1JFIO0ZuAXV1dGT9+PH379mXZsmU4OjpSvXp1\ng1ac2VtYUsFjaWnJs2fPUNq0xsx/KzEOlTku73aky9fXl0aNGtGuXTtq1qzJ06dPDTLIwD///IOH\nh4fOla6lpSXu7u6cOnUq2+W/qiC2AYuA43Lu3wJGbwKeMGECBw4coHPnzoSGhhIdHc0777yT7cqy\ncwtLKnhatWrFokWLcHNzY9y4ccwcNJAZM2aYOqxc7/nz53To0AELCwsOHz7MzJkz6dOnD+PHj89W\nuZ6ennh5edGvXz8qVaoEwJ07d9i4caPBZ1sqiG3A4mgAqqWLTB2GlIP0JmAzMzM6d9Z0/fDy8jJY\nZTl5C0vK+xRFYceOHfj6+nLz5k2+/PJLXF1dTR1Wrufm5oa3tzd+fn54e3tTunRpgySzxo0b4+/v\nz65duwgJCUGtVlO5cmX2799P6dKlDRD5SwWtDVhcvQaFC6P8+8NGKhh0EvD06dNfOx3hyJEjs1VZ\nTt7CkvIPQ4/Ilt81a9aMBQsWULJkSRYsWMC+ffu0DzxmV7ly5RgxYgQA06ZNw87OzuDJFwpeG7A4\nGiDHfi6AUiXgyZMns2rVKp4+fYqXlxcpKSl8/vnnBpmOMCdvYUlSQda2bVsAunTpku2Hr0yhoLUB\ni4DjqKZMMnUYUhqEWg1HA8DeHqWey8vlSUmIg4cAUCpWzPRgQDqzIVlZWWFra8uRI0fw9vamQoUK\nVK5cWTsdYXa9uIVlb29PSEgIwcHB2NjYGOUWliQVNDt27KB+/fp6/xmyD/ALdevW1f6QNrSCNB+w\nuHsXYmNRnArG1X5eJBYvRVy/gXr5SsSpoJcrzocgfvwZIh9BTEymy9XbBvxiOsJBgwbx7Nkzvvvu\nO7744ossB/+qV29hSZJkON27d6djx46cPXuWL7/8krlz51KhQgV8fX2NkswGDhxo8DJfKEhtwOJI\nQKqR3iQTi4klKSlJ+1JcuIjZxg2Idm1R+2zCrFlTzfJzwVCmNDx7BrWdMl2N3gTs5eVF+fLl2bdv\nn9GnI5QkyTCMPR1hTipIbcAi4Diq9941dRgFnvr3PxAnAjVXtddCeezi/HJlQoLmv7Y2mmT7QuVK\nqJxqaeYgnzIds5VfZapOvQn49OnTfPHFFzx8+BAhBP7+/owdO9ZgQ1FKkmQ8xpqOMCcVlDZg8egR\n3L0L9euZOpQCRdy6BXZ2uoOehN1GadsaZdxolMGDdZtFzcw0Az7d+welcuWXy83NoX49FGtrxMo1\nmY5DbwL+9NNPmTVrFu3atUOlUv1bf/pzskqSZHrGno4wJxSUfsAi4DhKyxYZmvNayh5xKgj1b3s0\nI44VLYrq80911qtGpt00qgz2RP3hRLh3D9WarxFHAxCRj1DKlEbtPQnsi6GMynzTqt4EbGdnR/Xq\n1QvEASBJ+c3jx4+ZM2cOV69eRa1Ws2/fPn799Vc2btxo6tAyrKC0AYujAah6u5s6jHxHPHwI0U9Q\narwcwVH8cx+lTSuUD8egFC+eqfJUb/wP0dnt5axrpUrxYiR6VQtN86yiUul/82voTcDt2rWjXbt2\nvPHGGxT/N9BOnToZpCuSJEnGtWHDBho2bIifnx+WlpYAeW7iioLQBixiYuDSZfg89SQzUuaJiAjE\nlq2Is3/BkyeaW8mvJODs/tBJa8rTrCTeF/SW6OzsnOqp53LlymW5EkmSco6dnR3FixfXO81fXlEQ\n2oDFiZPQqCHKvz+SpIwTQkBYGDrTkd76G8qWQTVzKkq1aiaKLHP0JmB9Uw8mJycbPRhJkrKvQYMG\n9O7dmz179uDo6AhA1apVMzTrWG5RENqANXP/yu5HmaH+/Q8IOoMIOo3StAnKjKnadUqL5igt8lZv\nHb0J+MSJE0ycOJHo6GiEECQmJjJ+/Hj5FLQk5QHFihVjyZIlOsvy2kA3+b0NWCQmwukzKB95mzqU\nXEsIAWq19gE18ewZBJ2BZk1QjR6V6Xbc3EhvAl60aBHTp09n/fr1LFmyhCVLlui9KpYkKfepXr16\nqulDTX0H68iRI3oH8wkODqZOnTqpluf7NuCg0+BUC8XW1tSR5CoiLk5za/7YCcTpM6j8fODfphTF\n1lbnijc/0JuAExIScHNzIygoiDt37uDt7c2aNWto3LhxTscnSVImRUZGMnjwYMLCwlCr1SQnJ9Os\nWTN8fX1NFlOrVq301j9mzBi9XRzzexuwZu5fefv5v9SzPgUrK5TmzVCN+QAlDz/HkBF6E7Crqyvj\nx4+nb9++LFu2DEdHx1S/qCVJyp18fX1p1KgR7dq1o2bNmjx9+pTo6GiTxvRilK7/srS01Nxq/I/8\n3AYs1GrE8ROohhXc6VfF1WuIgGPgWAVVx5dTjKrmz8u1faLFX+cQu3ajMuBVuN4EXKJECerVq0fn\nzp0JDQ0lNDQUKysrg1WaFZcvX9Y7VWJwcDAVK1Y0QUSSlDs9f/6cDh06YGFhweHDh5k5cyZ9+vRh\n/Pjxpg4tw/J1G/D5EChXDqVUKVNHkuPEpcuoP/0MChVCadcGpVFDnfW5JvmmpOi8FEeOov72e7Cx\nMWg1Ogk4JCSEGTNmEBQURJMmTVi9ejUAf//9t8mvgIsVK4aLi0uq5QcOHMi3v5QlKSvc3Nzw9vbG\nz88Pb29vSpcuneeOkfzcBlyQ5v4VV6+h1Kr5coGlBaolC1EqVDBdUBlgce060a8+m9CmNSrnuqhn\nzDFoPToJ2MXFhU8//ZTly5czevRobduMra0tVV7tb2UC5cqV09sX+ZdfftF7C0uSCqpmzZqxYMEC\nSpYsyYIFC9i3bx/z5883dViZkp/bgMXRY6i+WGDqMIxGXLiI2H8QceQoSpPGKJ98rF2n5LKmTCEE\nnApCxMWh6tBeu7zDByOp5vRydiNFpcIYWSbVLeh69eqxfv167euYmBhsDHzZLUmS8QQEBFCmTBmK\nFClCly5d6NSpE3PnzmXWrFmmDi3D8msbsLgWqnnI6NUB/fMZ9co1KG1bo1q1HKVMGVOHo5eIiUF8\n+z3i0GGoWBHVB7p95NU5dCtcJwEnJiYyZswYOnTogIeHBz169CA0NJSaNWuyY8eOfHlASFJ+8fz5\nc4YPH86lS5ewsbGh1L9tjDExMdjb25s4uszJr23A4mgASpv80aVTPHyI2LsPpU5tlIYNtMvNVq8w\nYVQZFHodShRHtXYlSkb7yFtbo3R/w6Bh6CTgJUuWYGZmRq9evdi8eTNFixbl5s2bzJ49mw0bNjBq\n1CiDVi5JkuEULlyYefPmsWPHDsqWLYuzszPPnz/H3t7e5E1ImZVf24BFwHFUH080dRjZIq5fR71y\nDdy8heLaAWrkrtvKrxKxsZrb4QHHMFv0shlGadhA50dDRijW1ijduho0Pp1RpE+ePMnYsWMpUqQI\nu3fv5u233wagTZs2XLp0yaAVS5JkeDt37iQ8PJyBAwfy888/89Zbb9GnTx/u3btn6tAyxc7OLt+N\nPy/u3YOnT1FqO6W/cS4mbv2Nqm9vVL/8hGr8WJRc2kSpXrUG9QBPCD6P6u3+pg5HL50r4JIlS3L3\n7l2qVatGQECAti04JCQEBwcHkwQoSVLGHD9+nK1bt7JlyxbCwsLw8fHh6tWrBAYGMnXqVLZs2WLq\nEDMsP7YBi6PHUNq2MXUYGSZiYhC/74VLl1HNnKZdruqcO2fFE8+e6YwspjjXRXl3CIq1tQmjej2d\nK2AvLy/ee+89WrVqxdtvv42NjQ2rV69m1apVeW5Cb0kqaAIDAxk0aBCVKlViz5499OrVC2tra1q3\nbm2UO1gpKSk8f/7c4OWCpg3YWGWbiiYB543uR+ovlqEeOBhCr6MMGmDqcNIk4uJQ7/yNFK9xiGPH\nddYp7drm6uQLem5Bjx49ms6dO1O5cmW+/vprAgMD8fT05Ndff+XZs2emilOSpHS8uIMFsGvXLtzd\nNfOfXrhwwSB3sFasWMGRI0cAWLt2LTVr1sTFxYXBgweTkJCQ7fJfFR0dzZ07dwxapimJqCi4fRsa\n1Dd1KHoJtVp3QbWqqDZvRPXJx7l2aj9x/TrqtwYizpxFNWwIqq7/M3VImWYOaPvRlitXLlWf2p49\ne2r/X9+YrZIk5Q7u7u4sXLiQEydOkJiYSPv27dm3bx/jx49n0aJF2S7/3r17VKlShdjYWL755hv+\n+usvbGxsmDNnDqtWrcLb23Az++SGfsBJSUlcvnyZWrVqZSmW2NhYIiIi+Pbbbylx/CT1VGY0jI7G\nwsIC13j07AAAHUVJREFUOzu7DJcTFxdHXFwcxYoVIzw8nPLly2c6lrSIhw8R/r+iONWCV26Pq/r0\nMlgdhiJiYnTbm4sUQeX7A0om9mVuoypRogShoaEMHjyY8+fP8/z5c8qVK0fr1q3p16+fzr/81iVA\nkvKTokWLcvr0aRYvXsyBAwcwN9c84vHdd9/RrVs3g9UTExNDgwYNsLOzQ6VS0aNHDx48eGCw8kHT\nBpyZJGVoK1eupFGjRixZsoS2bdvy2WefZbqMHTt2ULt2bcqWLcvg6jW4Ua4sPXv2ZMOGDZkqZ9++\nfcyZM4fHjx/j5eWV5nbDhw/PcJkiNhb1ZwtQDx8JycnQtEmmYspJ4uIl1PMXoR48TGe5Uq5cnk6+\nAOZFixblyJEjhIWFcfPmTW7cuMGvv/7KjRs3eP78OdWqVaNq1arY2dkxbNiw9EuUJMlkrKysaNLk\n5cm0UyfDPTBTqVIlJkyYQLVq1bh06RJ3794lMjKSUaNGsXbtWoPVA6btB7x37158fHw4e/YsFhYW\nJCUl0aJFC/r164fTv6MjXbx4EUdHR534nj17xr1797TbXLt2jTp16jDmvfd4OHAwXRfPZ2n37tjb\n2zNp0iTCw8Np3rw5gwYN0ttP+/Hjx1y/fp2Uf8clLlasGMuWLQM000ueOnUKOzs7nJ2dCQ8P548/\n/uDmzZtUrVqV5ORkLly4QHx8PPXr18fa2pr79+9jZ2fHlStXKHbvHxydaqGa8CGKtTVXr16lUKFC\nOt3VHjx4QHJyskGvuDNLvfALxIWLKL3dUY1N+8dHXmUOoCgKVapUoUqVKnTs2FG7MiQkhB07drB1\n61ZSUlJkApakAmz06NGMHj2asLAwzp07R5EiRXjw4AE+Pj7UrVvXoHW92g9Y3L+PCDqjs15p1QKl\nZEmA9Ner1Yhdu8HaKkNP8O7Zs4exY8diYWEBgIWFBadPn0ZRFBITE3F1daVBgwaEhobi4eHBiBEj\n2LBhAz4+PtSpU4dr166xbds2FEVBURSu373L23dusT4mhvj4eBwdHXn48CEBAQGcPXuWNWvW4O/v\nrzPe/qFDhxg9ejQdO3Zk//79dO7cmUePHjFgwAACAwPp3LkzzZo1IywsjJIlS/LGG28QGxvL7t27\n+eCDD3B1daVp06bExMRw4sQJzq34mjm+m7h6/TouLi4cOHCAefPm0cvKikGDBpGYmIiVlRVly5Zl\n8eLFTJgwgaioKNRqNfb29nz11VfZ+j4zSjx+jPLKjxGlX29Ukz/KkbpNQe9sSAB//fUX/fv3Z/bs\n2Wzbto2yZcsatOKkpCRUKpVsV5akPMbBwUH7UJexRtjSaQOOiYUbN3U3aFDv5f+nt14IzXqbjM0t\ne/36dXr06KGzTFEUQNPPukuXLsyaNYu4uDiaNm3KiBEjWLNmDYcOHcLa2po5c+awfft2atasycOH\nD2nTpg2LFy/mvffew9vbm7Zt23LgwAH+/vtvJk+eTM+ePVPtx7lz57Ju3TpatWrF3LlziYyM1K5T\nq9XcunWLSZMm0aFDBy5fvkzjxo2xt7dnzJgxPH36lKlTp9K1a1dCfTbi5uvHo02bwUyFm5sb06dP\nZ/v27fz55584OjoSGhrKqVOnAPj++++JjIzk1KlT+Pv7AzB48GAePHhA6YyOGJUFIvAU6m3bURyr\noHww8uV+z2VjRxtamgm4Xr16vPvuu7Ru3dpgyTc5OZkpU6awfft2AFQqFYUKFWLAgAFMnjxZ+4tT\nkqS8Y+nSpQghmDjRcCM8vdoPWKlRHcV7XJrbprvezOy16/+rbt26hIaG4ubmpl125MgRSpUqxcGD\nB+nSpQsA1tbWWFpaEhISQnJyMtb/dnlp2LAhO3fupHPnzpiZmVGkSBH279/PrFmztA+1fvLJJyiK\nwsyZM/nhhx/YuHEjxYsX19Z3+/Zt7V2FRo0asXfvXu06lUrFjz/+yNdff83IkSMZOHAgjRs31q63\nsLDAx8eHhd7eOFtZI2yKwOefosyapd3OxsaGpKQk7t27R/36L5/MHjp0KLt27eLhw4fa6SuLFy/O\n33//bZQELGJjUb/vBXZ2KH17oXRyS/9N+YgqrRVmZmZ88sknBh2A40X7xZUrV7hx4wahoaGcPXuW\n8PBw/Pz8DFaPJEk55/3332fkyJGv3Wb//v106NAh1b/du3cTERGRantT9gN+8803+frrr4mOjgY0\nbbHDhg3D2tqaLl26cPjwYQCioqK4ffs2zs7OmJmZERUVBWhuH9euXRuA/v37s3fvXgIDA2nfXjPb\nzsGDBxkxYgQNGzakW7duDBo0iM2bN+vE4OLiou3ydfLkSZ11cXFx+Pv7s3HjRq5fv86GDRuIj4/X\nXqXv3bsXRVE4uG8f848e4XlSkrYd+cU2L7Rr145z584BmgukHj160KJFC4oUKcLGjRvZtGkTNWrU\noFKlSobZuYBISnr5IjER1dTJmK1egapzp1Tx5XdpXgEbwz///IOHh4fOla6lpSXu7u7aWyCSJOUt\nGZktzc3NTeeK8oUffvhB73SiphwLukmTJkyZMoXOnTtjbW1NXFwcs2fPpkqVKpQrV44dO3bQo0cP\nbt26xfr161EUhdmzZzNgwADUajXW1tbMmzePXbt2AVC9enWGDRvGxIkTWbduHa6urpw/f55x48ZR\np04dtm7dmurJ6C+++II+ffrg4+ODpaUlJf9tzwbNlbcQgm7dupGUlISnpyeFQq9TQ2i6ovn4+DB/\n/nzemTKFhIQEqlevru0f/l82NjZ4enryxhtvIISgf//+lCxZkqFDh9K1a1cKFSqEo6OjQYYFFTdv\nIn7ahtKjGzhrru4Ve3vIYxOFGJIicnAy3TNnzuDl5UW/fv20v6ju3LnDxo0b2b9/f5ZucYwYMQIh\nhM4UipJkakuXLqVGjRo6/ejzui+++IKDBw/qXTdo0CAGDhyY6TJfJOChQ4fqLE9ISCAhIcGkXZFA\n82Sz7SvDG74QFxeHlZVVqiu22NhYihTJWFszwNOnT1/7GePj47GystK7LikpiaRHjyi0ai1cC0U1\nehSJzZpqb90/efKEokWLZiiO5ORkAG3XNdC0NSclJWW7P7aIikK9aAlcv4Hy1psob/ZFUaV58zVX\nyKnjN0evgBs3boy/vz+7du0iJCQEtVpN5cqVs5x8JUnKOe+88w5+fn5MnDiRhg0b6qx7MfWhoeSW\nsaD1JV9A2977X5lJvkC6PzDSSr6gaes12/kbuDijzJiKYmHBq3sso8kXdBPvCy+e0cm2S5dROnZA\n+exTFPnQrY4cTcCgGW1rxIgRmX5fTEwM9+/fT7X8yZMnr/0jlSTJMMqUKcOmTZuYMWMGgwYNMmpd\n+XU+YENT3hmEksvOf+qDh1C5dtC+Vtq0pmC17GZcjidgfTLyFOXly5dZt25dquWhoaE6T/FJkmQ8\nderUYdu2bUavJ7/OB5wd4uZN1F9+jdnypdpluSn5qv/ch9joB/bF4JUELKUtVyTg999/P91tmjZt\nStOmTVMtT+shDkmS8q7cMBZ0biHUasQ36xF/7kd5P+PDTeYk9ZIvEXfuoPrIG6Wei6nDyTNMloBf\nHYgjI09RSpKUu0ybNo3atWvj6elp8LJzSxtwbiAOHIRHUai+X68z321uovTrjeqVYSyljMnRR9GS\nk5P56KOPqFatGk5OTjg5OeHs7My8efNIerVvmCRJBVp+nA84M16dHlCpXw/VtCm5JvmKU0GkTJ2h\ns0yRyTdLcvQK+NWBOF70BU5MTGTChAn4+fkxZMiQLJX74MEDfvzxx2zHd+HCBcLDww16RZ6SksLD\nhw8NPpTn3bt3qVixokHLjI6OxtzcvEB//ho1alDNAPOfRkZGUqNGDQNElXvVrVuXChUqZLscfcfv\n48ePiYqK4uHDh9ku/3UiIiIoUaKE3qeADenevXsZ3ldlIh+BohBRonj6G7/CGMfvq+xiYnA9fY7k\nx9Gca92cewacfvK/4uPjiYmJ0en/bAwRERG4urqmeho9p47fPD8Qh6enJ2vXruXx48fZji8oKIiY\nmBiDntjj4+M5e/YsrVq1MliZAIcPH9aZOMMQQkNDsbKyMuioN3nt88fFxekMCZhVNWrUMOgUgLlR\nVvr9/ldax+/58+c5dOgQ9erVS+OdhhEYGIizs3Omuw9lhlqt5siRI3To0CHdbRW14IEQpJipQE+v\nj9cxxvH7qgi1mms1q7L/4EE6piRnOr7MePToEXfv3jX6A7anTp2iWrVqqX4c5djxK3LQ6dOnRbNm\nzcTChQuFn5+f8PPzEwsXLhTOzs4iIiIiJ0PRa/ny5WLbtm0GLTM8PFz079/foGUKIUT79u0NXuaK\nFSvEzz//bNAyIyIixFtvvWXQMoUwzuf/+uuvxdatWw1erpR5x44dE1OnTjV6PUOGDBF///23UetI\nSEgQXbp0MWodQhjn+NXHGMfef504cUJMmTLF6PW8++674ubNm0avJy052gb8YiAOe3t7QkJCCA4O\nxsbGRg7EIUmSJBU4eWYgDkmSJEnKT3L3gJySJEmSlE/JBCxJkiRJJmA2e/bs2aYOIrewsbHBwcGB\nYsWKGaxMMzMzypQpg6Ojo8HKBChZsiQ1a9Y0aJny89tQuXJl7Avw9Gi5RaFChShfvjzly5c3aj32\n9vZUq1YNS0tLo9WhKAqlSpUyercWYxy/+hjj2PsvS0tLypcvb5Bubq/z4vs31aAvOTodoSRJkiRJ\nGvIWtCRJkiSZgEzAkiRJkmQCMgFLkiRJkgnIBCxJkiRJJiATsCRJkiSZgEzAkiRJkmQCBToBP3r0\niJSUFL3rkpOTiY+P1/4ztaSkJB49eqR3XWJiojbOxMTEHI7spfT2mVqt1lmvfmXOU1OIiopKc3/l\ntu8/v4uKinrtnOBqtdogUxNGRESQXs/L+9mc5ef58+c8e/YszfVCCIPM3pbePnv27Fm251TO6H7P\n7j573Wcx5Hkjve//decEozDZNBAmlJycLNzd3cVbb70lGjZsKE6ePJlqm1GjRgknJyfRqFEj0ahR\nIxETE2OCSF/68MMPxciRI/Wuq1u3rjbOgQMH5nBkL6W3z7Zs2SIqVqyoXX/48GETRSrE8OHDRc+e\nPUXr1q3F5s2bU63Pbd9/fvbOO++Irl27CkdHRxEQEJBq/cmTJ0W9evVEhw4dhIeHh1Cr1ZmuIzo6\nWjRv3lx0795d1K9fP83Z11avXi26deuW6fJfWLlypWjVqpWoW7eu+PLLL1Ot37Ztm2jfvr3w8PAQ\n7u7uIj4+Pkv1pLfPpk+fLtzd3UXLli3FqlWrslRHRvf79u3bRa1atbJUhxDpfxZDnDcy8v2nd04w\nhgKZgI8ePSrmz58vhBBiz549YsCAAam2admypXj06FFOh6bX3r17Rf369fUm4NjYWNGgQQMTRJVa\nevtsypQpBp/uMSsOHDig/c6fPn2qd9q73PT952e///67GDZsmBBCiNDQUNG6detU27Rq1Uo7ZaCn\np6fYu3dvpuuZMmWK8PHxEUIIsX79er3f+fDhw0Xr1q2znIAfP34sXFxchFqtFklJSaJu3boiOjpa\nZ5tX/64mTZokNm3alOl60ttn0dHR2h/iz549ExUrVszKx8nQfr9//77o2LFjlhNwRr5/Q5w30vv+\nM3JOMIYCeQu6TZs2TJkyhStXrvDtt9/i6uqqs16tVnPnzh2WL1/OmDFjCAkJMVGkmtvkixYtIq0R\nQ0NCQrC2tmb06NHMnTuXiIiInA3wXxnZZ+fOnSMoKIghQ4bw+++/myBKjcOHD9OsWTNmzpzJ5s2b\nmT59us763PT953fBwcG0atUKgOrVq3Pv3r1U2zx69AgHBwdAc+yeOXMmW/WkVca7777LN998k+my\nX7h27Rr169dHURTMzc1xcXHh8uXLOtscP36c4sWLA3Dz5k0sLCwyXU96+6xo0aL4+vry4MEDli1b\nRtu2bbP0eTKy3728vFi6dGmWyoeMff+GOG+k9/2nd04wlgKZgF/YsWMHd+7cwdraWmd5VFQUbdu2\nxcPDg969e9O7d2/i4uJMEuOYMWNYuHBhqhhfSEhIoEWLFnz88ceUKFGCIUOG5HCEGhnZZ5UrV6Z9\n+/ZMnDiR2bNnc/LkSZPEGh4ezoYNG2jRogXh4eGppsfMTd9/fhceHk7RokW1ry0sLHTa3J8+fYq5\n+ctZU21tbYmOjs5WPWmV0bp160yXm1Ydr6sH4PPPPyc2NpY333wz2/X8d5+9cPToUY4fP07p0qXT\nbff+r4zs9xUrVtCxY0ecnJwy+QleyshnMcR5I73vP71zgrEU6AQ8efJk/vzzTyZPnkxycrJ2ecmS\nJfHz86Nu3bp06tSJ1q1bc+DAgRyPb8+ePZw/fx5/f398fHwICgpK9QuwXbt2LF26FAcHB7y8vLhy\n5QpPnz7N8Vgzss/Wrl1L165dqVevHu+//z7btm3L8TgBihUrxoABA+jWrRszZszg+PHjOg9e5Jbv\nvyAoUaKEzt+rmZkZVlZW2te2trapEnJWJmh4tZ6slpGZOl5Xz/Tp0zlz5gz+/v6oVJk/Bae3z17o\n168fe/bs4ezZswQFBWWqjvT2e1RUlPaO25w5c4iMjGT16tVG+SyGOG+k9/2nd04wlgKZgLds2cLU\nqVMBiI2NpWzZsjq/9m7fvk2nTp0AzROLwcHBNGnSJMfjrFevHosXL6ZFixY4OTlRpkwZ7S2hF378\n8UemTZsGvPyVZ2dnl+OxprfP1Go1rVu3JjIyEoAzZ87QvHnzHI8ToHnz5oSGhgKa22xqtVpnNpzc\n8v0XBM2aNePQoUMAXL58OdWJUVEUypYty40bNwA4dOgQDRo0yFY9WS0jPXXr1iU4OJjExEQSEhK4\nePEiVatW1dlm5syZPHz4kK1bt2Z5Bp709tnt27fp0KGD9nVsbCyVKlXKVB3p7Xdra2u+//57WrZs\nSbNmzbC2tsbFxcXgn8VQ5430vv/0zglGkyMtzblMQkKC8PDwEL179xadO3cWf/zxhxBC8+Tr2rVr\nhRCapwi7desm6tevL+bMmWPKcIUQmocVXjyEdf/+fVGuXDkhhBDx8fGib9++olevXqJGjRrit99+\nM1mM+vbZ5s2bxdtvvy2EEOLnn38WHTt2FK6ursLd3V3ExcWZJM6UlBTh6ekpunXrJlxcXMTOnTuF\nELn7+8/PPvroI/G///1P1KtXTwQHBwshdP9uAgMDRZcuXUS7du3E6NGjs1RHRESE6N+/v+jcubNo\n166d9ql2JycncfXqVe12Fy9ezNZT0D4+PsLNzU00btxYfP/99zqf5f79+8Lc3FzUqFFDODk5CScn\nJ/HVV19lqR59++zVv99Zs2aJ7t27iy5duoilS5dmqQ59+/3Vc88L8fHx2XoKOr3v3xDnjfS+/7TO\nCcZWoKcjjI2NpUiRImmuT0xMRAhhsrkiMyMmJobChQtn6ZaWIWVknz179gxbW9scjCrtOAoXLoyZ\nmZne9Xnp+8/r4uLi0nzOITPbGKKe7EpOTkYIkaUHrDIjvc+SkJCAubl5mn/fhqrHEDJShyHOG+nV\nk945wdAKdAKWJEmSJFMpkG3AkiRJkmRqMgFLkiRJkgnIBCxJkiRJJiATsCRJkiSZgEzAkiRJkmQC\nMgFLkiRJkgnIBCxJkiRJJiATsCRJkiSZgEzAkiRJkmQCMgFLkiRJkgnIBCxJkiRJJiATsCRJkiSZ\ngEzAkiRJkmQCMgFLkiRJkgmYmzoA6fUePHhAbGyszrJKlSrx5MkTChcunOV5OoUQ/PPPP1SoUCFL\n74+MjMTGxgYrK6ssvV+SCrr4+HiePn1K6dKlTR2KZCLyCjiXGzVqFAMGDGD06NHaf48ePWLZsmUE\nBgYSERHB1KlTATh8+DAbN27MULkxMTF069Yty3FNmTKFY8eOZfn9klTQHT16FC8vL1OHIZmQTMB5\nwPz589m9e7f2X5kyZRgzZgxNmjTh7NmzBAYG8s8///DHH39w6dIlnj17Bmh+YV+5ckWnrISEBAID\nA4mJiUlVT3h4uPa9ADdv3iQlJYXk5GTOnTvHyZMniYuL03nPkydPePjwIQBqtZqbN29q1+mr/86d\nOxw9epTHjx9nb6dIUj7232MnrWMTIDQ0lOfPn2vX3b9/n6ioKM6dO4cQgpiYGE6cOEFwcDBCCO12\nYWFhhIeHExUVxZMnT7TL/1ueZDzyFnQe8OTJEyIjIwGwsrLCxsaGTz/9lJ49e3L8+HHu3r1LYGAg\nZ86cQQjB3bt3OXv2LFu2bMHR0ZHQ0FB++eUXnj59SqdOnXB1deWvv/5KVc/evXu5ePEiCxcu5MmT\nJ/Tq1Ytz587h6upK06ZNdQ7kF3bu3MnVq1eZO3cusbGx9OrVi5CQEHx9fVPVf+TIEebOnYubmxsf\nfPAB/v7+VK9ePcf2oyTlBfqOHX3HZlBQEL1798bR0ZHr16/Tv39/hgwZwqxZs7hw4QIlSpRg7ty5\nDB8+nDfeeINTp05RvXp1Vq1axbx58zhw4AA1a9YkKCiIcePG0b9/fzw8PFKVJxmPTMB5wKxZsyhW\nrBgAPXr04OOPP9au8/Dw4MKFC/Tp04c7d+4ghKB27doMHz4cX19fbG1tWblyJbt37+bSpUu8/fbb\nTJ06laNHjzJmzBidet58800WLFjA/Pnz2bp1KwMGDCA2NpapU6fStWtXbty4QceOHTN09bpy5cpU\n9f/999/UqFGDIUOGMHjwYOzt7Q27oyQpH9B37Og7Nvfs2UOtWrWYMmUKycnJeHh4aBPmkCFDGDly\nJKGhoaxbtw4XFxeOHj3Khx9+SGJiIl999RX379/H3Nwcd3d3gNeWJxmHTMB5wJdffknHjh0zvP2z\nZ8+4dOkSM2bM0C6rUqUKYWFh9OzZE4CGDRumel/hwoVp1aoVhw8fxtfXFx8fHywsLPDx8WHRokW4\nuLgghNDe+vovtVr92vrHjh3L0qVLeeutt0hJSWHjxo0UL148w59LkvK7tI4dfcfmV199xalTpxg/\nfjwADg4O2tvUVapU0b5/0qRJWFhY4OLiQkpKCpGRkTg4OGBurjn9u7i4AHDs2DG95dna2ubERy+Q\nZBtwHmdmZqZNiC/+39bWlrp167Jo0SI2bdpEjx49cHBwoF69ehw5cgSAwMBAveUNGzaMpUuXUqhQ\nISpVqsTevXtRFIWDBw/y2WefERsbq5OAra2tefDgAQAhISEAada/Y8cO2rZty+nTpxk0aBCbN282\n5q6RpDwnrWMHUh+bnTp1wtnZmU2bNrFmzRrKlStHkSJFAFCpNKf2VatW0b9/f37//Xd69+5NSkoK\n5cuXJyUlhYiICJKTk9m/fz/Aa8uTjENeAedxlSpVIiQkhHnz5tG+fXs8PT2pVasWs2fPZvjw4Vhb\nWxMfH8/WrVtp2bIlffr0oWvXrjg5OaEoSqryWrVqRWhoKLNmzQKgffv2zJ8/H09PTxISEqhevTp3\n797Vbu/q6sqcOXPo3r07pUqV0nZL0lf/P//8w/DhwyldujR37txhw4YNObOTJCmX2rt3L7Vr19a+\n9vf313vsQOpjs1OnTmzfvh13d3diYmIYOnSoNvG+0LdvXyZNmkRAQACWlpYkJyeTnJzMypUref/9\n97G0tKRIkSJYW1tnqDzJsBTx6mNxUp6kVqtJSUnBwsKCpKQkzMzMtAfO8+fPKVy4sM72cXFxme4/\n/OTJE4oWLZrp9frqf/r0KXZ2dpmqX5IKGn3Hjj7x8fEUKlRI7w9q0Jwfnj9/jo2NjXbZmjVrGDly\nJIqi8Oabb/LJJ5/QuHHjDJUnGY68As4HVCqVNuFaWFjorNN3AGdl8I7XJd/XrddXv0y+kpS+jCRf\nIN3BcFQqlU7yBU2S7datG0IIHBwcdJ4JkYPr5Bx5BSxJklQApaSkkJKSgqWlpalDKbBkApYkSZIk\nE5At7JIkSZJkAjIBS5IkSZIJyAQsSZIkSSYgE7AkSZIkmYBMwJIkSZJkAjIBS5IkSZIJyAQsSZIk\nSSYgE7AkSZIkmYBMwJIkSZJkAjIBS5IkSZIJyAQsSZIkSSbwf/WrCZmGNOguAAAAAElFTkSuQmCC\n"
+       "text": [
+        "    ## \n",
+        "    ## Call:\n",
+        "    ## lm(formula = Y ~ X)\n",
+        "    ## \n",
+        "    ## Residuals:\n",
+        "    ##    1    2    3    4    5 \n",
+        "    ## -0.2  0.9 -1.0  0.1  0.2 \n",
+        "    ## \n",
+        "    ## Coefficients:\n",
+        "    ##             Estimate Std. Error t value Pr(>|t|)  \n",
+        "    ## (Intercept)    3.200      0.616    5.19    0.014 *\n",
+        "    ## X              0.900      0.252    3.58    0.037 *\n",
+        "    ## ---\n",
+        "    ## Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1 \n",
+        "    ## \n",
+        "    ## Residual standard error: 0.796 on 3 degrees of freedom\n",
+        "    ## Multiple R-squared: 0.81,\tAdjusted R-squared: 0.747 \n",
+        "    ## F-statistic: 12.8 on 1 and 3 DF,  p-value: 0.0374\n",
+        "\u0000"
+       ]
+      },
+      {
+       "output_type": "display_data",
+       "text": [
+        "    par(mfrow = c(2, 2))\n",
+        "    plot(XYlm)\n",
+        "\u0000"
+       ]
+      },
+      {
+       "output_type": "display_data",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAfgAAAH4CAYAAACmKP9/AAAD8GlDQ1BJQ0MgUHJvZmlsZQAAKJGN\nVd1v21QUP4lvXKQWP6Cxjg4Vi69VU1u5GxqtxgZJk6XpQhq5zdgqpMl1bhpT1za2021Vn/YCbwz4\nA4CyBx6QeEIaDMT2su0BtElTQRXVJKQ9dNpAaJP2gqpwrq9Tu13GuJGvfznndz7v0TVAx1ea45hJ\nGWDe8l01n5GPn5iWO1YhCc9BJ/RAp6Z7TrpcLgIuxoVH1sNfIcHeNwfa6/9zdVappwMknkJsVz19\nHvFpgJSpO64PIN5G+fAp30Hc8TziHS4miFhheJbjLMMzHB8POFPqKGKWi6TXtSriJcT9MzH5bAzz\nHIK1I08t6hq6zHpRdu2aYdJYuk9Q/881bzZa8Xrx6fLmJo/iu4/VXnfH1BB/rmu5ScQvI77m+Bkm\nfxXxvcZcJY14L0DymZp7pML5yTcW61PvIN6JuGr4halQvmjNlCa4bXJ5zj6qhpxrujeKPYMXEd+q\n00KR5yNAlWZzrF+Ie+uNsdC/MO4tTOZafhbroyXuR3Df08bLiHsQf+ja6gTPWVimZl7l/oUrjl8O\ncxDWLbNU5D6JRL2gxkDu16fGuC054OMhclsyXTOOFEL+kmMGs4i5kfNuQ62EnBuam8tzP+Q+tSqh\nz9SuqpZlvR1EfBiOJTSgYMMM7jpYsAEyqJCHDL4dcFFTAwNMlFDUUpQYiadhDmXteeWAw3HEmA2s\n15k1RmnP4RHuhBybdBOF7MfnICmSQ2SYjIBM3iRvkcMki9IRcnDTthyLz2Ld2fTzPjTQK+Mdg8y5\nnkZfFO+se9LQr3/09xZr+5GcaSufeAfAww60mAPx+q8u/bAr8rFCLrx7s+vqEkw8qb+p26n11Aru\nq6m1iJH6PbWGv1VIY25mkNE8PkaQhxfLIF7DZXx80HD/A3l2jLclYs061xNpWCfoB6WHJTjbH0mV\n35Q/lRXlC+W8cndbl9t2SfhU+Fb4UfhO+F74GWThknBZ+Em4InwjXIyd1ePnY/Psg3pb1TJNu15T\nMKWMtFt6ScpKL0ivSMXIn9QtDUlj0h7U7N48t3i8eC0GnMC91dX2sTivgloDTgUVeEGHLTizbf5D\na9JLhkhh29QOs1luMcScmBXTIIt7xRFxSBxnuJWfuAd1I7jntkyd/pgKaIwVr3MgmDo2q8x6IdB5\nQH162mcX7ajtnHGN2bov71OU1+U0fqqoXLD0wX5ZM005UHmySz3qLtDqILDvIL+iH6jB9y2x83ok\n898GOPQX3lk3Itl0A+BrD6D7tUjWh3fis58BXDigN9yF8M5PJH4B8Gr79/F/XRm8m241mw/wvur4\nBGDj42bzn+Vmc+NL9L8GcMn8F1kAcXjEKMJAAAAgAElEQVR4nOzdd5xcVfnH8c93dmdm0wglCYEk\nUoPSRAQVFelgoyuRH01pbshulKogKDZsNDXZDSHSixikiICSgPQW6c3QQklCSAgEUki2zfP749yF\nzWb7lDsz+7xfr3ntzL1zz3lmX3Pn3HLOc2RmOOecc668JOIOwDnnnHO55w28c845V4a8gXfOOefK\nkDfwzjnnXBnyBt4555wrQ97AO+ecc2XIG3jnnHOuDHkD75xzzpUhb+Cdc865MuQNvHPOOVeGvIF3\nzjnnypA38M4551wZ8gbeOeecK0PewDvnnHNlyBt455xzrgx5A++cc86VIW/gnXPOuTLkDbxzzjlX\nhryBd84558qQN/DOOedcGfIG3jnnnCtD3sA755xzZcgbeOecc64MeQPvnHPOlSFv4J1zzrky5A28\nc845V4a8gXfOOefKkDfwzjnnXBnyBt4555wrQ97AO+ecc2XIG3jnnHOuDHkD75xzzpUhb+Cdc865\nMuQNvHPOuaxJGigp3cttJGntfMXU33kDn0eS1pJkkuZLmhs95km6SdL6WZQ7R9J2HSz/iqQnsij3\ny5Ke6ev2fajvRkmrJC1t9xgl6feSfh2976uS9oiej5Y0sQ91TZJ0Rq4/g3P5IOkeSTPbLVsv+j2p\niCGetyR9spN1+0p6EHgVeFHSXZJ26aa8UZJuBN4GZkl6RtKPch95/+YNfGFsZ2ZjzGwMsC1QAfwm\ni/J2Bl7ISWTxO8vM1mr3mA/8Fjg3ek81MCp6/hVgnzgCda7AdpZ0dNxBdEXSIcAFwB+AjcxsY+Ac\n4AZJe3WyzWjgPuAhYFsz2wLYGzhE0h8LEng/4Q18gZnZEuBBYG346BLVWdGZ/XxJZ0pStO5ISW9K\nelfS9ZLWiYq5Etg0es/Bkp6V9DpwUGs9kn4i6YQ2r8+SVB0930rS3ZI+kPSGpJPaxylpC0mPSFom\n6QlJX+zgPVMkjWvzen9JF0uqlHSppPej8n/ch3/VscDRko4h7Py/l1QLnA/sJunqqM5dJT0d1XWj\npGFt/q8XSFog6X5gdB9icC5OfwB+29nVvui7f6Ok9yTdLGlktPzHkn4a/ab8SdJp0eMBSYsknSFp\nv+hK4KOt+7bCJfaLot+h96LfnCHdxHgK8FMz+4eZNQKY2X8IB+gndrLNOOBJMzvPzBZF2ywEDgYm\nShrcy/+T64Q38IWxq6S9JH1N0g+AHwNXR+uOBI4A9gMOBP4P+LykKqAe2B/YDBgEjI+22RSokrQp\ncDHw02j7PdvUOQIY1ub1+sB60fOrgduBDYGTgHMlrdsu5t8At0TlXAbUdfC5ZkXxtzoC+C/wLWDz\nKO6vAWdK2ryT/80XJB3f5rF9u/ivAe4Bfgn8BfgZ4QBpvKThwD8JZ/pbAh8ArZfhJwC7ALtHsX+j\nk/qdK1bPA5cDk9qvkLQJYf+8Bfg0sBK4Ilo9AvghUEvYf4YT9otTCPvmr4GJhCth/4jeS/R3M2B7\n4ItRud/pLDhJSWA74JEOVj8O7NDJpp/raBszmwssjup3OVAZdwD9xK+iv5sDTwN7mNlT0bLvEhrQ\nV6PXlxIa66cIB2B7EHbSA1uPkNvYG3jezG4GkHQZcFQP4vk+8CQg4HXCj8Pwdu9pJuygnyQ0kBd1\nUM5NwB+jo/zmKJ7xwG7AGOBLwAxguJk1dBLLp4GhbV6viGIDwMwaJDUBK8xslaQVQJOZLZd0OOFH\n8Jbo7ecQGvxTCGcDl5vZbGB2dGDlXKn5JfCCpAOAB9osPxB4zswuB5D0U+BlSSOi9f9s87vwbeAW\nM3s0ej0PuNLMXpF0G3B8tM21hH1mkaQBwMvAyC5iWxeoApZ0sG4BsL6kpJk1tVs3CrirkzLfxq+2\n5YyfwRfGLma2FbAj4ex7TJt1o4DTgBejx2nA9lGDOI5wADAfuK2DTi6bE46UWz3aw3iGA/cDi4Dz\nCH0C2n8XTgaShLP0/0WxrMbM3gfuBr4JfB14yMzeA24m/FhcAiwkXCHorHftNDPbp83j2h5+Bgg/\nBNvy8f/ufmBtSaMIZyJt/zcdnWU4V9TM7EPC2XY9qx8Ib0Sb77SZvQK8S7gqBzCvXVFvtXm+krC/\nADTw8YleC/AnSQuB24CxhN+GzmJbSNi/P9HB6k2AN82sKbrc3xg9vkY4yRnTwTYAG/PxyY7Lkjfw\nBWRmzwBnAZe33i8jXNI+w8w2MLMNCDvVYZISwBNmth3hMthS1rxM/iawVZvXm7R5ngHaNqrDAaJL\n8TcQ7mVvSLisr+jRVjPhct5Iwtn7lZLWY03XEe79fyt6TlRva/mHEa5IfK+DbbM1i3BQsUGb/98O\nhB+z9v+bTfNQv3N5Z2b/JPxO/KHN4sW0+X5L2oBwRv1atKilXTHtX3fkIuA9Qse3bQj7V/vfhfZm\nAYe2ieNgSSnCpf0Ho8W7AztFj4eibcYpGg0gaWeF0TFfi+Islw7EsfMGvvAuAuYAv49e/4PQmWyd\nqHPd1YT74sOA5ySNNrPngX91UNa9wE5Rh7gqVj/LXki4v61o598tWt7ageVOM1tFuOdfRThbb+ty\n4LjojPwawpF+Rzv7P4EvR+XfHC07FJgOWBT3ix1s1xsriDolRs9bz2TuJHzG7QEkHQH8m/C9vovw\nIzJI0kaE+/HOlaofEPqztLoD+IqkraOTgeMJt+s+yKKO9YAHokv0owm33Nr/LrR3KuH3q/WkZC9g\nNuG36CcAZva0mT0RPZYCfyVcYbg46lA3AniY8JvzUzNbnsVncG14A19gZmaEzi9HRL1Xbyfcd3qd\ncM+rAvh91Lv018ADkp4ndKQ7o11ZrVcEHgJeAVa1WX014RL2fOA/RAcIZvYmoTPO05IeJ1xafwTY\nol2oPwWqJf2PcIn+bDNb3MHnWUG4NP6ImS2LFl9FaIhfJZxJZwiX7PvqfuD86D7jM8BWkp4ys5WE\nH5H7Jb1I+LEZb2YthE6CKwn/04fp+e0L54pOtN/+os3r/xLuz88i/HYcQptRNH10LvBrSY8QrvLd\nRLii2FVcLxGu0p1AuKpwKGGffw2olTSwg22ao3gHE052LgaWEfrTHCTpU1l+DhdRaG9c3CQNgo8a\nzPbrhpvZO11smwSq2jSw3W4b1WfRPb6u4loHWBbtlL0SXVVIRUftWYnKajKzluhMIR018ESX+tY2\ns3c72G4osDxq9J0rK5IqgaEdfff7WJ6A9To6mO/BtoOB5qgzbJLQ4fYvrftpJ9skCPvue9Hr3Qj7\n+YOdbeN6zht455xzrgz5JXrnnHOuDHkD75xzzpWhskh0I+m7dD+cw7li9qGZTY87iFLg+7srAwXZ\n30v+DF7SUeRnjLVzhXSypH3jDqLY+f7uykRB9vfYzuCjXpaZHPRuFnBFa8pG50pRlICorM9Ko9EO\n6e5GbnRXDL6/uxJXqP29oGfwCrOMnSfpVUIyhNmSnlOY6ay7hArOuRIiaaKiecEVZjJ8CXhW0pVd\npC52zuVIoS/Rt05L+ikz28zMxgKfJaRDPazAsTjn8msUMDTKufB9wixhYwlJUCbEGZhz/UGhG/gN\ngRvbzi4UzZB2C51PPuCcK22DgafMbKmZZYBbCelJnXN5VOh78FcD9ZJuAOZGy8YQ5hTfs9OtnHOl\naC5wASFl8VZRfvNhhPkYquMMzLn+oKANvJk9LulAYF/CNJ8JQt7iPaPc6865MmFmdUBdNNnPZwjz\nE4wAjoomUHLO5VHBe9Gb2QJgWl+2jfIWr7E4u4icc/lkZm8Ab0Qvl/RkG0mfZvXZEVvtTJhO9PKc\nBOdcGSuKRDeSTibkxT+/i/fsTpg5rb1PAs/iO7xzJaEn+zvwFh1PkbwtMCQvgTlXZoqigSdMF9gl\nM7sbuLv9ckkX42fxzpWSnuzviwnTj65G0kJ8f3euR4qigTez5XHH4JwrDN/fnSuMomjg+ytJI4Ad\ngBVmdl+07DvA54FVwE+jYUXOlRxJpwK7d7L6GjO7tpDxOJcPksYAJ0cvrzSzJ6PlY4H1gBfMbGkc\nsRW0gfcd/mOSNgVuA64CDpT0opkdCWxqZqdImgjsSge3JZwrEVcRElidDzzZbt07hQ/HubzYBbgQ\neBeYChwhaTywHyF744mSNjGz1wsdWKHP4H2H/9jfgZPN7F/Ab6L0nfua2W8lVQF7R+9xriSZ2UJJ\nRwC/MrNr4o7HuXxo/W5LOg74r6TPEfI/rGNmDZJuBX4HHFro2Aqayc7MFgJHAAeb2QvtHv2tgV+w\nG9zfpPSDjUofBNwFDI/Sel4J/DoaUuhcyYr27W/FHYdz+RQ17puZ2Z8IydtON7MGADO7C1gnjrgK\nPl2s7/AfeWpvKv5l8MAS7OuEYX7/Ba4FLgPekTQ4zgCdc851TdKhhDlVLpa0AWEitcMlrRetHw9s\nGUdsJT8ffKl6Fq7eCX1yQxp3no3t9xU4BJhHuHXxBeC7wKaxBumcc647SWAR4Tf7a2b2AvAb4DVJ\nlwO7AZ+OIzDvRR8DSWok/cOxtBy12OzfTao66U4SqZQ1vA/8PO74nHPO9YyZXdXBsn9EKZrXAhZE\nk6oVnJ/Bx6CB1IGQWZW2pn8DGDZDsE/ccTnnnMsNM1tiZm/E1biDN/AFt0xaLwHfa6bpozSdKWt4\nHkg1qGpsjKE555wrI97AF1ia1A8Nu2mA2dzV19iMBBk/i3fOOZcT3sAXULOSXxJs8iBNV6+xjqaZ\nQnv+ouMZ85zLK0lfiP5+U9LZkmIZ1uOcyx1vTApknjQAEieCnbebWXP79QPM5hta8BOSO8YRn+u/\nopkaL4xSJ9cDKwmZuZxzJcwb+AJZn+SxwGNJa3y6s/eEznbyy/Su0L4MnAnsC1xvZn8ARuWyAklJ\nSRW5LNM51zVv4AugQVVbCO3xPo1TunrfUhr/A3wxnO07VzBzgMOB8cDfJX0feCXbQiVVSjpP0quE\n5B+zJT0n6SxJyWzLd851zRv4PPuFlEjAaS1kpgwzW9bVe4eZLcvAk8Op3LVQ8TkH/BWYBVxgZo8Q\n8mOckYNyT4r+fsrMNjOzsYSMXyMJc1I45/LIE93k2RmkvgWZpWlrmtmT9yfIzDB0APDvPIfm+jlJ\n2wMHt1v2q+jpwcClWVaxIeGSf1PrAjNrlHQLYUpk51weeQOfR8ul4VWkjmykaXxPr0c+QPNDO5M6\nbZk0bIjZ4rwG6Pq7pcCLnaxbmIPyrwbqJd0AtA4LHQMcCeyZg/Kdc13wBj6PUqROzsDfBpq91dNt\ndjNrblbV3WlSexMunTqXF2b2KvBqR+skZf3bYGaPSzqQ0HlvW8ItwTeBPc1sUbblO+e65g18njQr\nuatIjLyZxrMO6eW2GWym4GS8gXcFIGkYYYrijQiNcCXhnvzh2ZYdTXk8rQ8xjSZMutTeJoBf2XKu\nB7yBz4MF0sDhpGoNfnGIWUtvt09Zw7NNSg9okDZPm2Xdm9m5bhwOPAHcB7xEmCBj7XxVJulkQGZ2\nfhdvGwBs0MlyH27nXA/E2sBH42LTZvZhnHHk2jDSxwMPp2zVc30vxe5IkNyHHAxXcq4bA4F7gCZg\nVzP7paSbgD/mqb6Lu3uDmb0MvNx+uaRPA8pHUM6Vm4IOk5M0UdIu0fNqwtnCs5KulJQuZCz50qj0\nlsJ2WUJDtz9iXWmmaYbQXp661hXAXcAvgNeBAyWNBxryVZmZLTez5fkq3zkXFLrxGAUMlTQI+D6w\nPTAWeA2YUOBYcu56qUJwWjOZycOz/AGLUte+7alrXb6Z2SzgdMK97dOBTcnBOHhJp0q6rZOHj4N3\nLs/iukQ/GHjKzJYCSLqVduNxS9EBpMYZvFNlTXfnojzDZiTQ3oQOT87lhaTvAGe1WzyY7A+6ryIk\ntDkfeLLduneyLNs5141CN/BzgQsIQ3O2inrKDgMuAqoLHEtOrZBGpkkd2kBjdSpXZdJ49xBSx82T\nBow2W5mjYp1r70bg9uh5mjCsbVi2hZrZQklHAL8ys2uyLc851zsFvURvZnVRuspqYCKwIorhKDN7\nrJCx5FoyjHm/dpDZ27kqcx2zDzLw9HAqv5KrMp1rz8yazGxZ9FgMXAEckKOyXzCzb+WiLOdc78Ry\nid7M3gDeiF4u6ck2koYCoztYtTZhesvYrFJyjwoq1r2Zhr/3dsx7d6LUtfsBM3JctHMASPo8sF/0\nMgFsA7wQX0TOuVwoinHwPRwXuzlwdAfLt6KTbFyF8I40eB1SNRnsrL6Mee/O0zQ/tB2pUzx1rcuj\n91k9Ze0DhJ71zrkSVhQNPD0bF/s48Hj75ZIuJsZxseuQrja4L2Wr/peP8ncwa2pW1X1pUnsCf8tH\nHa5/M7OXCENWnXNlJLYx1pKSUaKbkh0X26j0tmA7LcxyzHt3MtgMwT75rMP1P5IOkPR0J4+/xB2f\ncy47BT2Djyaw+B1wULQoI6kBuA74fdtpJYvd9VLFgaROhcyf893DPWUNzzQpPahB2jRtNiefdbl+\n5TbgP4Q52k8EfgrMJ6SuXRpjXM6VpWOOOWb4oEGD6saMGfPy3Llz18jUmGuFPoM/Kfr7KTPbLOpR\n/1lgJGG8bMk4kORhBvMqren+wtRoMxMkv1qYulx/YGbNZraMMKnLVWb2nJktIUwOk/VEM845qKmp\n+VpNTc1+AOl0WqtWrfrx3Llz3y1E3YVu4DcEbmx7pm5mjcAthHmiS8JKaZTQtxtpzFeu7jU003SH\n0N6SPA+3y7U7gTMlTYiS3lxHOLN3zvVBdXX1p1qfJxKJHZqbm58GmDJlyqJp06a9Vqg4Ct3J7mqg\nXtINhKQ3EBr2I4E9CxxLn1WSPCUDVw02K1g2rgFm85pUtbCR5A5ASecMcMXFzJ6QdDzwHcIQuWvN\n7PqYw3KuJNXW1p6RTCYzwGyASZMmnRNXLAVt4M3scUkHEjJlbUu4gvAmsKeZLSpkLH3VoOQ+CSoG\n/ZaGG88ucN1R6tp98Abe5YCkHQl559/k434xy4AdJa1rZlNzXF9Zzh7p+rcJEyZsmkgkTl60aNHJ\n06dPb2xpablkypQpRdGeFXyYnJktINzjKzmLpSFrkxrfAqefbZYpdP0raPzPEFLHvi5VbWy2qtD1\nu7KzmHCQ/S5rDkHN+gdK0kTgaTO7L5o98kfR8geB480sbzPWOZdPEydO3DGTybxfV1f3iqSRmUzm\n6unTpzdCuAwfd3ytfCrSXlib1ATD7krbqljGDEepa5/ZwFPXuhwws9fNbJaZvQq8YWbTCemjtwSe\nzkEVZT17pOtfqqurh0I4Yzez4xobG5cB1NXVPVRfX/9IvNF1zBv4HmpS6jPADvNpuiTOOBJkZoiE\nj4l3OSNpd+BCSSOAekLq5wtzWMVHs0dauPJ1KzAih+U7l1e1tbXnV1ZWHgCwePHieZMnTx4/bdq0\nhXHH1R1v4HvgcSkJOgUyF8Z9afwlmh9KwKeWSuvGGYcrK18GziT0jbnezP5AOPvOVuvskVcAe0sa\nLekzhNkjb8hB+c7lRU1NzeY1NTXHtr6W9Ne6urorAVovxZeCTht4SV+I/n5T0tmS1ilcWMXl0yQP\nN5hTaU0Pxx3LVmaNoPuqSO0ddyyubMwhjHsfD/xd0veBV7IttJxnj3Tlp6amZkx1dXUSQNLeZvbR\nPjBp0qSS/L522MAX4JJdyVgpjRE6qIHGP8cdSysjM1PIG3iXK38FZhH28WcJnW/PyFXhZvaGmf3D\nzJaY2RNm9nx320gaJGnT9g9gCJDMVWyufxs3blwFwAknnLBHIpH4KK/J5MmTp9TX198bX2S50Vkv\n+jUu2UmaWbiwikclyVMzcNkQs4JkHuqJpDU+1aT0kFXSJlVmBUua4MqTmZmkscA3gUHR31nkaThm\nD2eP3Jpw5t/e9vjEOC5L48aNGzBixIjTRowYcQfwaCKReGHy5MmHWAyjo/Kpswa+9ZLdp4Ef5OqS\nXalpUNU3EiSSaRr+YXEHswabWUFyHyCnY5VdfkhKA0cB6wEPmdl9MYf0EUlfAgz4GbA2IS/9L4H/\ny1OVPZk9chbhIGM1cc8e6UrXCSecMKqiouITkydPfni99dZbV9JTCxcufAygrq7u7bq6urhDzLnO\n7sG3XrK7wMweIceX7ErBEmloBXZ8hobzzazo2vcWmmZ46trSICkBPAhsThh+dq+kYpp7YWvgEUIj\nD7AASOeygnKYPdIVjqSUpF9KukXSo5I+0Zdyxo0bN6D1eUVFxUcZ5aZMmTJ/0qRJt0yfPr0lF/EW\nq9XO4CVtDxzcbtmvoqcHA5cWKK7YDSFVa9i/02GMcNGpMnuzSVXvNpL8LGsmKXFFpBL22gQWPE/y\nhkaa3hwM6wBXAtfGHVvkOuA+4DmgGTgEuDzbQstp9khXcDcDbxOuJO8FzJD0ZevFrdKJEycesv76\n6+9C6OBJXV3d0cV4spZP7S/RLwVe7OS9Bcu7HrcmpXYAbfMGTd/bPO5guhClrt0bb+BjJ0nLYf0U\nyVGGRgsbHf4y6g1SW72JJQ19uwKmAO8RZlAsCma2TNLehIP4jYBJZvZEDopuO3tkE4QzM8LQucMI\nw+ec68hawL7RPfGbJG0NfA74d2cb1NTUDCYcEFxTV1e3HHht4cKFt7au72+NO7Rr4KOMVq9KGkY4\nw9iIcBm/knDJ/o6CR1hgL0ipsaROAbtw8yJPpfkhjXcNJnX0K1K62GMtF8ul4WmSozIkRifItDbi\no5tIb2jYErB5CTQ/A/MSZJ5spnnePrD8+Y/Pkg34F+GSeFGIeqcnzKzbe+O9tCGhk+5qs0dKugX4\nfI7rcuXlPWAYH6dM/gawRq/2mpqawc3NzUOmTp26ANgZyNTX16+oq6sr2aFtudRZJ7vDgScIP0gv\nEY6m1i5UUHEaS/IowexKa1yjg0+xWdvs/Ualnx0TUtfeGXc85WKptG4VqVGGVmvEhUZVkVpu2LwK\nmJ9B8xJknm+med4cmB9yFKyuknDdW9L/EYacfgjcFD0vFq2X0Lvq1d4XZTF7pIvFVGChpMOBvYE3\nzez+tm845phjhg8cOPBy4BRgQV1d3b8ByrGzXF911sAPBO4BmoBdzeyXkm4CCjb/eRxWSRtXktpv\nBY3fGxp3MD2UITMzQeJr9OMGXtL6hIPSSuAG60G/iSXS0EGkRhmZ0Qk0Rii6tM6YgaRWGZqXwFob\n8f+00Dx/AczrKJNhJbBVN/VF9w6/05fPVwCPAFdL2oIwAQ3Aa2b2l2wKLYfZI108zOy2qE/YjsA/\nogc1NTVHAcm6urpLBgwYsHLp0qXjrrzyyhVxxlrMOmvg7yIkvTiMkPBmEVD2l4ArSJ/WAtOGmi2J\nO5aemkPzA1uQOmmptO5aZu/FHU+hRROZvE3IwjYfuETSz8zsvnekwWuRHgUtYxJo9MeNuI0eQspC\nI56Yb9jcZjIPiIr579Ewd4MOpjOtBDYu7EcrpEWEvBdt5STPdinPHuniZWZPHX300bOrqqq+NGXK\nFIuWZVauXHkDQHSf3XWhwwbezGZJOp1wNH86oRdjTofJSUoCGTMrimEKDaraPwGZtK26tft3F4+t\nzBqblb6/itSewPVxxxODI4Azl8PNKZL7PAvPvgl1zUq/ug6ppME8kZhn2LwWMrNE4qZlNM5b12xp\n20JaU6NtUPj4Y2dmLwMvxx2HcxCGle62226Ju+++u3nQoEE/NLP3gf8A1NfXXx1zeCWl0/ng29zv\nmBE9slasw2aWSusOJHVMM40nlmIOTMNmiEQN/bOBTwBz06SmALMW0vLkBWS22B07urMrMT5Lj3PF\nafz48VvV1NT82syOApYvWrTowlKa3KXYdNjAS/oOcFa7xfebWbZzOBflsJmBYcz7P6vMXo+j/mwl\nrfGpZqXXXiVtXKqfIQt37I9ungNvbk/jHR/CA8CRpXSbxbn+SpJqamoOzGQyb9bX1z9uZpmGhoYf\nTJs2bTmU1sxtxaizM/gbgduj52lCJ5lhOaiv6IbNNCn1edAnX6bpd911lCpmhs2IUtfmeqhTUVsE\niypIvrUvTU0fwneBQ83sn3HHVQokHUBISduR/5rZcYWMx/UPkhLHHXfcRtOmTXtt/PjxG0raitCp\nm6lTp86ON7ry0tk9+CZCD3qAZZKuIAyZOy/L+opq2MwrUnojUieDndvREKdS0kLTHZWkzpc0rT8l\ndFiHdLXBvx6yzJ/ijqUE3Ua4t/lZQv75nxI6Kh5OSHrl+hlJRwNfJ/wuX2hm03NdR21t7cWZTGYm\n8NpFF130lpmd0+1Grk86u0T/eWC/6GUC2AZ4IdvKim3YzEYkjxY8U2mNJZ8JLkpd+14jye0JOQzK\nXqPS2yZgp4U0HjU67mBKkJk1Ew7gvwBcZWbPAUiaBtxCSHbl+olozPluwASgCnhU0hIzy2om0YkT\nJ+5oZvtNnjz5bIBMJnNWXV3d29A/s8sVUmeX6N9n9ZS1DxCGzmWtr8NmJI0Bdupg1Sb777//wOuu\nu27DQw899K3rrrtuw3Q6vUtDQ8N9Xb3e8tJL39gcfe3RH57w40U33XRod+8vhdcHYzNXbLLpwffc\ndNMWxRBPPl/bu+8+sB+cuuDzO1zz2OmnHfDAddcVVXy9ff2JT3xi8Jtvvpn1/tVHdwLTJI0E3gUO\nJeq17PqVXYHzzWwxrNbg97qBr62t/aKZPRsNZduwubn5b63rWht3l3/tJ5vp8p4ckJd7cj2cHzoN\nDO9g+YCBAwemKyoqKgEqKioqE4nE0O5eD3/2xZoWMhe99eUvr0z14P2l8HoljXepsXF8ZUvLW81F\nEE8+X39+0pRvG8x75NSTnkglEl+PO55sX6dSqc5mdsw7M3tC0vGERDzbANeaWX8ckdHfLQK2A56J\nXm8OrJHYqTM1NTWD6+rqlk+YMGGvioqKA+bMmXMqwKRJk27JfaiuJ9T2Ckk0jG0AndyTM7OcXbJr\nOw5e0mAI00j2oZyLCZ/j+J5u06j0QcJ2TVrjib2tr9g1Kv37DJk7qqypbM/AVkqjkqTqV9F43GCz\nspgEKTrIfTnODoLRtLYDgA+L9QslGVoAACAASURBVNJpX/Z31zOSNgDeAs6OFn2FMOFLl0nOjjrq\nqEFrrbXWBWZ2VV1d3QPV1dUDp06dukayKPexQu3vq501mFmzmS0DPronZ2G40TRCI58VSZWSzpP0\nKjAbmC3pOcLBREEy5S2T1kvA95ppynXe7aKQITMjQWKfuOPIp0qSp2TgqnJp3IuBpHMJafP/D7hV\n0o4xh+QKLLp9OgT4H6HP1cGdNe4TJkzYoba29gCAioqKZCaTubiuru4BAG/ci0dnlwXvBM6UNCEa\nE38dubkn13Yc/GZmNpZwtWAkYRx83qVJ/dCwmwaYze3+3aVnDs33J2CbD6R14o4lHxqU3AcSg35L\n441xx1IuJH2JMMvdz6JFJxIm8HD9jJktN7Przezv0cneR2pqasa0Pk8kEvtLmgNw2WWXvV9fX1/y\nHZXLUWfD5PJ1Ty7WcfDNSn5JJDZ5kKZf7pbvymISpa59YEBIXfv3uOPJpcXSkLVJndACPzo7zBPt\ncmNrwoQzil4vIPR5cf2cJJmZ1dTUfE/SZ4EfALT2iHfFratUtU+Q++FWsY2DnycNGEnqRLBzdgvD\ng8pWlLq2mjJr4NcmNcGwO9PW4HnTc6t1rvrngGbgEODyOANy8YqmYv3B0Ucf/WfgHUl3T548+fK4\n43K9074X/Y7ApoSx6Qe1e+8cM5uaTWVxjoNfn+SxwGNJa3w6n/UUgxRNTzaRWneV9Ikqs9jGXuVS\nk1KfEdphPk1HbRx3MGXGzJZJ2hs4GNgImBQd4MdG0p6ETr7tjeXjXt4uh6qrqzerqKiorK+vfzGd\nTm+SyWQeuvTSS98BmDx58htxx+d6r/0Z/GJCo/su0P6eSk4a4Dimj2xQ1RYVaI/3afxuLvLtFjsz\nsyalZlaQ/CplMFXn41Ly06ROgcyFHc3H7rIjaTdgHTO7uM2ySWY2Ma6YzOwuOsi90dqLvvARladx\n48YNmD59+srjjjtu3QEDBpyTyWTOApgyZcqsuGNz2VutgbcwUcnrAJKGmdmjkr4J7Egfkh0Ug19I\niZ+QPq2FzJRh7TqNlLMWmmZUkjqXMmjgP03ycIM5SWt6OO5YytRWwCmSPmlmv4uWbRNnQC7/amtr\nTx4+fLgBF1ZUVCybNGnSoXHH5HKrw170knYHLpQ0AqgHVgIXFjKwbEhKSKqWNGkVFTc1k1metqaS\nPEDpqyqz1w2936TUZ+KOJRurpE8IHdRA45/jjqXMnQRsJOmSaIZHV2aOOeaY4bW1td9tfZ3JZB5v\nbm6eDDB16tRYpup2+dVZJ7svA2cS7pVfb2Z/kFRKDeTFwLCD4MLDSUz6DE32klRpZd65rj3DZiTQ\nPsBTccfSVxVhzPtlQ8zejTuWMtdiZidI+hFwK6GznStx1dXVQ1euXNl85ZVXrhg0aNBBmUzmvdZ1\n9fX198YZm8u/zhr4OYTENp8GfiDp+8ArBYsqC5KGAjuY2faNSv8K+M1L4YBlO+BxSb8BrjSzsp+W\ncBWNdw0kdcUL0h9Lcba8BlV9I0EimabhH0WZVq18vAC8BxAdzL9BDLM7utwaP378dqlU6pzGxsYj\nACZNmtSvppJ2nTfwfwUGEzq5PEtIRnNGoYLKkoiG4KWsIfTCDZMmSNLvgM8RhgWVvbXM3mtU+n+b\nUrkzJTZ5yBJp6BBS32+h8eRiTZta6tqNmjk8mlyklScuKTHjxo2rGD58+AlmNru+vv5OM1u0cOHC\nQ6ZPn74y7thcPDpLdGOSxgLfBAZFf2cBjxUwtj4xs/clPSypnjDd5XeAYYQfrCeAH8cZX6FZSF27\nNyXWwA8hVWvYv9Jmc+KOpYzlfdSMy69jjz12SCqV2nLKlCmzhg0bthawfPHixQ8CTJ06dUHM4bmY\ndTYffNvUlWsTUlf+kpCnuuiZ2W+jTHwHE0YF/Dg6CzSpf42wmUvz/RuTOvF9ae21zd6PO56eaFJq\nB9A2b9D0vc3jDqa8bUfXs0feU7hQXE+NGzeuYvr06S0AAwYMOM/MbgWor69fgicocm10dom+5FNX\nmlnJDw/Lhc3NGpqVfnAgqT2Aos/f/oKUGkvqFLALN+9mFiuXtdsIV3Y6nD0yxrhcJ2pqanYfMWLE\nUcDRAIsWLZo4ffr0kutf4wqjswa+nFNX3g8sjDuIQopS1x5PCTTwY0keJZhdaY2eaCPPolElyyR9\nNHskgKRpwC2EW1wuRtXV1clUKnXgqlWr7ps2bdpCM1u5cuXKH7Wu98bddaWze/BFl7oyV8zsgbhj\nKLQUTU80kRpW7KlrV0mbVJLadwWNRw+NO5j+5U5gmqSRhPvxh1JifTbKye6771651VZbDaurq3u7\noqJiJzPb9IMPPvgHQH19/SNxx+dKxxoNfNS5bndgZmvqSkl7SbrEzI4tdIAue1Hq2jsrSO4NXBJ3\nPJ2pIH1qC/xlqNmSuGPpT/I4e6TrpXHjxg3YeuutrwN+B7w9ZcqUB83s/rjjcqVptUx2kjYkHM1/\nBpgpaUNJfyIkjvlrDPG5HGmh6Q5C0pui1KCq/YFM2lbdGncs/Y2kTYGlZvZjM5vgjXthTZw48asT\nJ04cD7B8+fJMQ0PD9ydPnvwwgPm0yC4L7VPV7gj83cwmEDrc3AMMBLY1szsLHJvLoSqz10DLmpTa\nLu5Y2lsqrVuBHdtCw3lxx9JPHQQckO9KJFVIGpjveoqdpERtbe0XW1+b2ajGxsbbAW6//faGadOm\nLWzz3s/HEaMrD+0b+PWA1rm25xKmiD3ezFbko3Lf4QvLsJkiUXRn8QPDmPdbqsx8Ssp4PALUSpoq\n6ZzocVy2hUqaKGmX6Hk18BLwrKQrJZXUqJxcGDduXAqgtrb2OOBrrcvr6uquv/jiiw+WdJaknVqX\nS/oOYaSDc33S4WQzEQNezWVlvsPHaxWNM8F2eaGIJhNpUurzBp98maar4o6lH1tEmHviXuD56JGL\ng61RwFBJg4DvA9sT5nN/DZiQg/JLwgknnDCqtrb2svXWW284QCaTuXby5MlnA0QT+7wKJAkHWj+R\n9O1o0wQdTJnrXE911Iv+B5IOJiS4GRl1ugN42sxOy7K+UcDr7Xb45cDZhB2+ZGasK0VR6trZW1D5\nJYogickrUnojUieDnVuKufLLyBLgCMKImQThd2EWuZsiejDwlJktBZB0K2GETtmaMGHCrkBDfX39\nI2Y2UNIFU6ZMmQ9QV1e3vM1b9yNM6HUugKTZwPmEW6V/lZT3WyeufLVv4G8lTDzRkVwmvuh3O3yx\nMDIzMuEy/T1xx7IRyaMFz1Rao+c9j9fhhDTO9xGuqq1FOMDP1lzgAsIZ6laSRhPSRl8EVOeg/KIy\nceLEDSdNmvRWTU3N4EQisb+Z/RHgoosuermbTdumY/4Q2DBvQbp+ZbUG3szeAd7JY339aocvRgto\nvn80qR8ukYauY/ZBXHE0SJtVkPraMhq/u05cQbhWAwkHfE3Armb2S0k3AX/MplAzqwPqJG1EGJmz\nAhgBHGVmz2cXcnGpra39haT3gD/V19evMLNTerjpvcBESS8SGvobAM/C6XKis0x2edGfdvhitbHZ\nqmalHxoUUtfeFEcMktRI+rQWWi6K8yDDfeQuwu2xw4ALJS0CcpYm2ELnydZ7+mWR46C6unqzZDJ5\n+OTJk38JYGZXTZ48+ZXoeY9nPzSzxdE993OBlcCvzeyaNusPzXHorh8paAPfqhx3+FISpa49lpga\n+AZSB0JmVdqa/h1H/W51ZjZL0umE2eVOB/Yij9NDSzoZkJmdn6868mHChAmfXLVq1XuXXnrpO6lU\nauuWlpZ7W9fV1dW90tdyzWwxUW5553Iplga+vVLd4UtViqbHm0j9ZKU0eoDZvELWvUxabwCp7zXR\nVJssZMWuS22ypc2IHjklKQlkzKyFkDiru/fvScjF0d5Y4Jkch9epo48+uuqyyy5bdcIJJ2xfUVFx\nalVVVS3ApEmTbilUDM71VVE08PRsh98G+FYHqz5Lbob09BtR6tqZlSS/SoFT16ZJ/dCwmwaYzS1k\nvW5NUQ/tTqeLNbOsxsJLqiSkXD0oWpSR1ECYzOr3XW1rZnfRwRAxSRfz8SyXeTNu3LiKESNGnDN4\n8OCHgFsaGxtfueSSSw7Pd73O5VJX4+DzSlJSUgWAmS03s+XdbLKI0CGl/WMB4d6V64UMTTNAexey\nzmYlvyTY5EGari5kva5TtwE7Az8gdPA6HNiN0MnrvhyUf1L091NmtpmZjSUckI8k3O8vKieccMLG\nEydO3B9g+fLllZlM5s7JkyffCnDJJZcsizc653qvoA28pEpJ50l6FZgNzJb0XJTBqcsrtma2yMzu\naf/AG/g+SZu9CnzYqPS2hahvnjQAEieCnbdbmKbUxczMms1sGfDRdLEWJvqZRmjss7UhcKOZNbWp\ns5EwFe2YHJSftQkTJnw0iKOiouLYlpaWDyCkjK2vr7/Tc8G7UlboS/Rtj+ib4KNMThcQjuivKHA8\n/ZrBjESYgObZfNe1PsljgceS1vh0vutyvZav6WKvBuol3UAYIguhYT8S2DMH5WdlwoQJ30wkEkcR\nZtFj8uTJHd3zd65kFfoSfdEf0fcnDTTeCbbr491cPcm6HlVtIbTH+zROyWc9rm/M7AngeEImu10J\n08V2eY+8h+U+DhxIGCmzLbAdIXPlnma2KNvye6umpmZwbW3tyTU1NZsDSHpx0aJFRxY6DucKpdBn\n8EV9RN/fDDFb3KTUy9uF1LX3drtBH/xCSvyE9GktZKYMC5eDXZGRtA4hXfQnCQf9e0na38yybvzM\nbAExJm6pra1dr6mpafjUqVNnt7S0bJZMJt9etGjRa5Dd0DbnSkGhE908LulAYF/CEX0CeJOYjugd\nZMKY+L3JUwN/BqlvQWZp2ppyldfc5d7RwJOE22StcwL0OFlLT0k6B/ifmeW1k+W4ceMqpk+f3lJd\nXZ1MJpOXV1RU/BzgoosuehrwW0Su3yh4L3ozW2Bm08zsJ0ALsNQb9/i8Q/N9CfjMe9JauS57uTQ8\nAUc20eT5DYrbUuB1M1thZk3RoyQ7Qk6cOPGwESNGnAlw8cUXtyxatOhb9fX1PteB65eKZRy8i8lo\ns5XNSj88OKSuvTmXZadInZyBvw00eyuX5bqcewq4WdLXCVO5Aswxs27zU/TS88D8XBZYXV09sLKy\ncr+6urq/AWQymcUffPDBrQBRD3ifpdD1W3E38Dnf4V3vGTZTJL5HDhv4ZiV3FYmRN9N41iG5KtTl\ny/tA+8lRcn5VzcyuzUU5FRUVOuKII9a6+uqrl1ZWVn47kUgMbV1XV1eX8yx8zpWqWBv4XO3wLju/\noemxM0mdvlIaNcAs6wOuBdLA4aRqDX5xSEhN6oqYmb0CrNbhLMpCV5QOOuigvQYNGrQ2sPSdd965\nZvr06f4dc64DRbsTu8I52yzTpNSdlST3AS7LtrxhpI8HHk7Zqueyj87lm6RhwJWEYXIJwu/CLHKT\n7Cbn7rjjjvuWLl36JoA37s51zht4B4TUtQlSvyLLBr5R6S0TsMsSGr87PEexubw7HHiCkJ72JWAt\nYO1YI+rCsmXLcjaVrXPlLLZc9K64pMNl2lWNSm/T1zKulyoEpzWTmTy8+7kFXPEYCNwDPAxsY2aX\nExLeOOdKmDfw7iNtUtf2yQGkxhm8U2VNd+cyLpd3dwG/AF4HDpQ0HvCzZOdKnDfw7iMNNM4E2/2e\nPnSwWiGNTMChTTRemI/YXP6Y2SzgdGBx9HdT4IxYg3LOZc0bePeRIWaLDXtp55C6tleSYcz7tYPM\n3s5HbC5/JO0MLIwS3cwgNPJHxRyWcy5L3snOrSYTxsTvQy/mA1+l5B4VVKx7Mw1/9zHvpUPSQOAS\nYCtguaR3olWDCRPEOOdKmDfwbjXv0HzvSFK1i6UhPZkc5h1p8DqkajLYWT7mvbSY2YeSzgIOAN4G\nngMGEBLfvB5jaM65HPBL9G41o81WAo8OIb17T96/DulqQ/elrOF/eQ7N5cd+wMgo6dS3geuBm4BR\nsUblnMuaN/BuDYbNSEC3vekbld4WbKeFNOQ6Z7krAElfAg4BJknaiHDf/ZPABOA3ccbmnMueX6J3\na/gNTf89k9SPu0pde71UcSCpUyHz5+is35WeLwDXmNncaGjcP8xspaQHgT/HGZik7em4o99OwJwC\nh+NcSYqtgZeUBDLm922LTpS69j+VJPcGLu/oPQeSPMxgXtKa7i9sdC6HFgNbRs/3BVqHOG4DvBFL\nRB97Dbiig+WfAFYUOBbnSlJBL9FLqpR0nqRXgdnAbEnPSToravBdkciQmAHau6N1K6VRQt9upPGP\nhY7L5dQtwP6S7gbWAe6VtBdwFTAlzsDM7H0ze6r9A3gXT8LjXI8U+h78SdHfT5nZZmY2FvgsMBI4\nrMCxuC6kbdVLQHOj0lu1X1dJ8pQMXDXY7J0ONnUlwsw+AHYETgP2MLPmaNUxZnZ7fJE553Kh0A38\nhsCNZtbUusDMGglnEmMKHIvrhsEdQl9tu6xByX0gMei3NN4YV1wud8xslZk9ZmYN0es7o8x2zrkS\nV+h78FcD9ZJuAOZGy8YARwJ7FjgW141GGmdWkfrLPdKk3cyaF0tD1iY1vgVOP9ssE3d8zjnnOlfQ\nM3gzexw4kJAla1tgO2A5sKeZLSpkLK57g83eMWzOzlTuBLA2qQmG3RVdvnfOOVfECt6L3swWANMK\nXa/rm7PJpMegv1yhRMU0Kt8fQtNXNo47KOecc90qinHwkk4GZGbnxx1LfyapgjAP+Ntm9oKk8UOg\nchHpN44gsWw/mj53L+xpcFvcsTrnnOtaUTTwQLeZ0KKsWz/sYNWOgKdJzY1zgFnAEZL+CHx2GUyq\nwE6swJbfi/0Z2Atv4J1zrugVRQNvZst78LbHgYkdLD8cWJXbiPqtc4AU8PXo9SJgp6Q1HAuAVAN8\nGE9ozjnneqOgDbykU4HOJjG5JprwokPRMJ41OuJJeg9QbiLs38xsmaSvEBr5QcAfgfmStgAywNbA\nQTGG6JxzrocKfQZ/FSGhzfnAk+3WedKUmEk6yMxukvQBMM7MzpI0FNgjesvP2+YwcM45V7wK2sCb\n2UJJRwC/MrNrClm365G1JJ1LSFv6ewiJUADPauaccyUmjmFyLwDfKnS9rntmdoWkVJRd0LmcikZp\npM3M+3E4VwA+H7xbjTfuLlckTZS0S/S8GngJeFbSlZLSBah/mKR9Ja2V77qcK0axNvCSzoku2Tvn\nys8oYKikQcD3ge2BsYSpYCfkqhJJA6NZKm+T9Kik9SUNBC4ijLC5JFd1OVdK/AzeOZdvg4GnzGyp\nhTkMbgVG5LD8h4BG4BCgjjB5VQXwXcL0sj7KxvVLcY+Dfx6YH3MMzrn8mAtcALwKbCVpNDCMcGZd\nnYsKJK0PLDSzn0SLrpS0FbCtmT0kaQ/gQ0kVZtaSizqdKxWxnsGb2bVmdm+cMTjn8sPM6sxsLKEx\nnwisIPzmHGVmj+WomlVAk6QhbZbtByQl7Rylv15KuF3gXL8S9xm8c67MmdkbwBvRyyU5LvsDSZcB\nSyUdBRwAzATuAy6W9A1ghZm9mct6nSsF3sA75woq15NLmdkNknYCtgEuMbN/RauO92Gfrj/zBt45\nV2g9mVxqY2CXDlaNBRa2X2hmjwKPdrDcG3fXb5VLAz9C0ndyVFYlsC+wIEfltZUChpKftLwDo/Lf\nz0PZQ4EWoCeTAvXWMGAZ0JCHskcS5i/I5KHsDYGbcljeMODlHJZXtHo4uZQIPeHbWwR8kKP9fX3g\ns8B7OSgrW4MJn/eDuAMhv/t7b61LmOCqGCYUGwHcQ/i9ylZB9neZWb7ryKsoO1Y1ufsRHwicBDyQ\no/LaGgpsBjyRh7I3BIYAL+ah7LHASmBeHsrejtDbOh8/sl8izEKYj4OH3YGf57C8BuBK7+ndtRzv\n79sCuwLP5qCsbI0GBlAcB3n53N97a1vCydbiuAMBPgf8ldyM/CrI/l7yDXyuRVmvrjKzA/JQ9rbA\n8Wb2gzyUvS+whZldkIeya4EFZnZDHso+F/hbDntVty17OlBjZjm/YiLpHjPbLdfllpNsZo8sBElf\nBr5uZmfFGUcUy7eB9c2srghiydv+3odYfg38y8weLIJY/gL81sxejTuWniqXS/TOueLjs0c6FyNv\n4J1zeeGzRzoXL2/gnXN547NHOhcfz0XvnCsIn1zKucLyM/g1rSRMWJEP8wi9MPPhGT7OFpZr/yEM\nVcmHvwOv56nsqeRmSEtHzstTua5wXgFujjuIyOOEXvTFIJ/7e2/dTBhlUwyuIAzTLBnei945VxCS\nDgPm+/wTzhWGN/DOOedcGfJ78M4551wZ8gbeOeecK0PewDvnnHNlyBt455xzrgx5A++cc86VoX7f\nwEsaImlgJ+sSkqraPHr9/4rKH9RF+cN7W2ab7UdEs2u1X17ZNu5elplqs22qk/cMlDSkD/G2/V+u\nkYOhJ3V3U/7IbtavKynZh3IrJI3oYn2Xn8sVl+h7tm4X6/v0PeljLOtLUifrstofehFDl5+3r/t7\nH2OJ/f/Rrr6i+J70Vb9u4CX9CrgauFPSCR285RDC9I0PRo+de1l+kpA0Yr8O1n2BMAHHdEnTO/tS\nd1H2RsBLQEcHCJOish8EHuzsAKMTT/Dx572sg3onADOBhyX9sBfxrg+83absjmbU67LuLspeV9Ld\nwIWSHpX0qQ7ecyVwDfBiNItYT8veAXgUmCxpZvsduoefyxWJ6ID4UuDYTtb36XvShziGSnoEuAR4\nspMDyD7tD72Mo8vP29f9vQ9xFMX/o008RfE9yZqZ9csHYW72a6Lng4G5Hbznt8DBWdTxa+Bp4NAO\n1j0IbBQ9vwrYuxflJoB/EjLAjexg/UPAun2IdyDwZBfr1yZkzBMhC+JzwNAelv1V4M99rbubsn8B\nVEfPvwAc0UHdl0TPNwce6EXZ/wG2jJ4fDWzfm8/lj+J5AOtE+8ajwGkdrO/z96QPsfwWODJ6fixw\nTrv1fd4fehFDl583m/29FP8fxfg9yfbRb8/gzewDMzs8OlI8Cbi/g7d9BvicpCskfa035UdHdesD\nt3fylvXMrDW17APADr0o/kfA9cCCDupNAGOAH0iaHM1B31PbAisl1Un6aXR22tYWwNMWNAPPAlv2\nsOzPAOtG/8tjO7h10F3dXdkVmK8wt/x6hCPrtrYj7LCY2SvAqJ4UGh3FjwE2k/R74Akzaz/taXef\nyxUPAccQUo52pE/fkz76qC463v+z2R96HUMnnzeb/b3PsRDf/6NVMX1PstJvG/g2vgJ8CVjUwWXy\nN4F7CfNZ/1zSTj0pUNJawK+Ak7tY39xm0TLC0XJPyv4ssJ2ZXdnJW9YlHKxcT8jjfLOknua4TgOP\nAH8A3mXNL/hI4IO+xA0sJxwR/xz4InBiL+vuykjCDnl79Lf9ZbX2cTf1sCEeDmwA7AHcCVwlaWy7\n93T3uVyMJCWjR8LM3jOz2V28va/fk57EkWgTi9rV1dF+lM3+0FPdfd5s9vdsYonr/wFAnN+TXOv3\nDbyZ3WBmXwc+C3yu3bpqM/u3mT0DXEzPp708kzBpzWnALsAh7e4LLwPafiHWAt7qYdlTgCWSfkk4\nu/yRpHSbmBeb2WFm9ryZ3Um4FbBHTwo2s/vM7GQze8PM6oFPRQcjrd6NYu113GZWZ2aTzOw14De0\n+1/2oO6uvA+cZ2Z3Az8DvtNuffu4W8xsVQ/K/QAw4HQzmwlcBIzrzedy8Yn2uf9Fj4k92KSv35Oe\nOLJNLF9oV9ca+1GW+0NPdfd5+7y/ZxlLXP+Pnsrn9ySn+m0DL+kTku5ps2gQbWYtio64H5Q0LFrU\n2tmqJ64hzEj3CDCfMGvVktaVFm7evC1ps2jRbsBTPSz7dODWqOzlhI4nLe0+153RcxEuJz3Wk4Il\nfUfSOdHzkcAHZra0zVueB7aLepemga2BOT0s+8+Svh69XON/2YO6u/Io0HpmvQWwsN36WYT/MZK2\npOcHJSuBV/n4EtwaZXf3uVx8zGy2mW0ePf7Ug0369D3pYSxXtInlkbZ10cH+n+X+0FPdfd4+7+/Z\nxEJ8/4+eytv3JOfi7gQQ54NwWfVW4A7gpGjZocC10fNvAXcROlr9A6jqQx2/Jepk167sz0f13gtM\n7mP8DxN1siOc2X8/ev4r4DbCTvKzXpSXBm4gXNp/CfhGB2UfSbhc/Rjw3V6UvSUwg9A58Elgs2j5\n/wgNZ4d197DskcA90bZPAJu0LTt6fi7wb0Knx0/3ouwvR5/19ij2dFTfW119Ln8U7wOYQJvOU7n4\nnvQhhhHAddF3515gUNtYstkfehnHGp83F/t7qf4/iu17ku2j388mFx2ZNptZSxfvGWJmeZlXXNIA\nC2eKuS43RZgtsKEP2w4GPjSzTCfrK6Oym/pQ9lrWxZF3d3V3U/baZvZ+F+v79L+OroQM6SbuLj+X\nKx352if7Ulc2+0MOY+jz/p6HWPL+/+ipQn5P+qrfN/DOOedcOeq39+Cdc865cuYNvHPOOVeGvIF3\nzjnnypA38M4551wZ8gbeOeecK0PewDvnnHNlyBt455xzrgx5A++cc86VIW/gnXPOuTLkDbxzzjlX\nhryBd84558qQN/DOOedcGfIG3jnnnCtD3sA755xzZagy7gBc30gaAQxqt3guMJQwX3Kf5imO5j7f\n0Mzm93H7YcByM1vVl+2dKxeSNulg8XIgQxb7aB/iGASkzGxJL7bpdD+WlAS2Bl4ysw9zF+lqdQwC\nUsBSYISZLchHPeXOz+BL10XAdUBdm8d6wEnAFyStL+k3AJJ2lXRkD8sdDNyeRVy/A76cxfbOlTxJ\nFXy8Xz4E/C16fhTwa2DXAsRwSfR0d6C6l5t3uB9LOolwIvFj4B5JU6KTgpzoIOYNgOm5Kr+/8TP4\n0naGmf2n7QJJkwlnCV8hNPQbAF8NqzTEzJZJqgI2NrPZbbZLA58B3mxfiaSRwAozWxa93hR4AxCw\nDVAFPN32jETSUMJZwzuSMUnRIAAAIABJREFUElF9c6J1HdU/BtgYeK43ZxrOFSMzawG+wf+zd95x\nclbV/39/Znee2SQbIEAkkFCUauhFICQiiiJ+UUiCAQkCgmChSRGQJiIo0uWnoFQRMKAhITRFei/B\nIL3XhCIQCGlkp+yc3x/3WTLZ7Gy2zO4zO3ver9fzmp37PM+9Z2bnPufee849B5D0D+AyM7s9fv+n\n+PXzQNHM3mq5r62+EZdvCLzRMmOO720CBpnZq7GS3Qh4zsyKcZ/9ZtxX7weml9S1PpA1szfj9/WU\n6cetZPgOMBFYz8zmxWV/BY4HfitpHTN7NS5fhbBKMV9SI7Ax8CnwtJlZ/FyaB2wAzDGz18vIHLWS\n4XNAvZm9W1Lmz44yuILv2ywfL6UBNJnZAuCXwM3AdsAIYBtgS4IyHiFpC+B7wBuS1gXGA8sBdwL3\nAJu30c5OhCW542LFfSNhMHAP8Dhh1j9K0qYl93wHWB84mWBKuBHYWNLebbS/fXzdXcCfJI1teVA4\nTo3yc+AJ4DuSfm5mt5bpG82EfvYksK6kyWZ2KXAD8AHwqqQ/A2cDTwNbSjoaWI3Q7/4vvm5LSb8A\nriEozSZJ/wN+Qfv9uJSxwHUtyj3mDOBq4LfAbZLWjwc3xwIPS3qSMAP/F7A18CpwMOE5tQHwDPA1\nSScB+dYyA39oaUjSecCKQErSHDP7maRv4s+OsriC79ucCnwS/30LcFbJucnARmY2TdIagMzshXgJ\nbG9gPnAIoTONBK41s99K+jLwx1btXA/8QtLxwASCaWAQcacG1gbuBoZ0QOZD2mh/LeAV4K/AVYCP\nwp1aZ7KZXSxpBmGF7Vba7hsAt5vZqZIGEBTxpcBA4DAze0nSBQST3QOEgfcBZnZYrAT/KGmPuJ5N\ngHXNbGsAST+gc/14PeCKVmWvEQby5UgBBxEU+ZeBC0rO3WVmp0saB3zDzA5pQ2ZiWVcmDBDGxkVX\nxbP5jfBnR1lcwfdtjmi9RN8ekgYTlPlpJcVvAmsSZv0A/219n5l9Kulhgt1wb4IdMR+/HkvovALq\nyjSdWkb7fwCOIoz064B9gI87+rkcpw/Ssiw/GxjYTt/4EnA7gJktkpSTNLzkPARb+XBg9/j922Xa\nHA481fLGzK6MBw0d7cdPAzsCD5WUrQ283sa1pf5dZxOeF8+0qntG/LoASJdps4VtgaHA7+P3HxMm\nBv7saAd3sqtdmlncmZqButiG/hxwrJl9nzDrf4vQcbePr92mTH1XEDpS1sxmEZbtzcy+CpxImAmU\ndt5FwOfivzcmXFyu/d2AB8xsK+BvwF7d+NyO0+dop2/cTuyQJ2lFYA2gxf5cjF/vBP4R33c2iwcP\n1qqZ+wkzfCTVS7oF+Bbt9+NSJgETJK0v6UuS/gKcQ1g9gOAT0NLnN4pfDwb+bmY7A9Na1d1avnJl\nEFYnFgL7xJ/zFYKznz872sFn8LXLLILN+yTgPuAaSS8BvwIul7SI4FQzAXgEuEHSbcCLtNHJzOzh\n2C54alx0H3C8pGuADMG2NqLklnuAUyTdCnxI6PyUaX+1uOwDYHVg/4p8A47Tt/gVS/eNArBbrIw/\nDxwYO6mV3ncxcJakvQjL6z+Ly1+WdBPB7o6ZLZB0jaR/EWbqfycsyR/bTj/+DDN7SNIpwBSCg1wD\nYZI4KHbUuwS4Q9JMFg8+pgJnSxoD5ID6+NpyLCFzSdtzJV1JsPNnCQ6H78U2fn92lEFm5QZMTl8n\n9l6vM7N8vHe12cyK8bmBrfewShrQ2b25kpY3s7mdPV+m/eVaOfA4Tr+jXN8kONKWfWCXuS9jZtlW\nZfUAZlYoKWu3H7fR1md9VdJ4YFrsvT+IsMpXWncKGBg7AXek7qVkblVXuo3P5M+ONnAF7ziO4zg1\niNvgHcdxHKcGcQXvOI7jODWIK3jHcRzHqUFcwTuO4zhODeIK3nEcx3FqEFfwjuM4jlODuIJ3HMdx\nnBrEFbzjOI7j1CCu4B3HcRynBnEF7ziO4zg1iCt4x3Ecx6lBXME7juM4Tg3iCt5xHMdxahBX8I7j\nOI5Tg7iCdxzHcZwaxBW84ziO49QgruAdx3EcpwZxBe84juM4NYgreMdxHMepQVzBO47jOE4N4gre\ncRzHcWoQV/CO4ziOU4O4gnccx3GcGsQVvOM4juPUIK7gHcdxHKcGcQXvOI7jODWIK3jHcRzHqUFc\nwTuO4zhODeIK3nEcx3FqEFfwjuM4jlODuIJ3HMdxnBrEFbzjOI7j1CCu4B3HcRynBnEF7ziO4zg1\niCt4x3Ecx6lBXME7juM4Tg3iCt5xHMdxahBX8I7jOI5Tg7iCdxzHcZwaxBW84ziO49QgruAdx3Ec\npwZxBe84juM4NYgreMdxHMepQVzBO47jOE4N4grecRzHcWoQV/CO4ziOU4O4gnccx3GcGsQVfBUi\naXlJA5KWw3Ecx+m7uIKvIiTtKOkV4AVglqT/SNq0G/X9XtLJnbxnDUkmqa6r7XairVMlRfHfr3fn\nszpOTyFpubhPvCNpVny8LekGSat0o942f/OSvizpiW7UO1rS0129vwvtPSZpr95qz+k4ruCrhFjR\nTQZ+bGarAZ8DrgZuSFSwHiIeQPySxb/BMcDzyUnkOMtkUzNb3cxWBzYG6oDfdqM+/807PYor+Ooh\nBQwEcgBmVgQuBA6SVA8gaXtJD0l6V9JFkhri8v0kvSBpgaQnJH2pdeWShkqaKukTSU9J2r6zAkpK\nSTpE0n/j2cwpklLxueUlTZb0gaRbJG0Wl4+UdI+kuZLeknRkXN118etTklYGrgK+EN/zlVjWjyVN\nkzQsLj9G0tGS7os/x7VuynCSwMzmAA8BKwAocFI8s39H0omSFJ/bR9JMSR/FfWRIXE3pb368pGck\nvQmMa2lH0gmSflry/iRJP47/Lte3KLl+PUmPSpofPxtGtXHNnyTtUfJ+V0mXSKqXdEXc196SdFxn\nv6e4Lz8V1zFV0sqSGuOyFUquuyj+Dtr7Hu+R9AtJ70vaub3PH9f1ZFzPsZLuXNb/qSYxMz+q5ABO\nAvLAv4HDgTVLzg0DPgT2B1YCbgaOANYFFgCbA0OAS4B/x/f8Hjg5/vtm4C9xPfsDr5WRYQ3AgLo2\nzh0KPAtsDWwHvAwcGJ+bRnhgDQMOAR6Ky58AjgEGAeOBArAi4cFo8fUCXgc2BT4PzAV+AIwAri35\nPGfF38HOwJpx+/sl/X/zo7YPYLn4t7o78PX493c48DEwLr5mX+DFuB9+Ke4n2wANwHxgs/g3/0/g\n+Pielt/8F4DZwFjCysBTwBPxNZ/14fj9H4AT4r/L9a3RwNPxNdcDJwADgMNa6m31+fYHbi55/w/g\nIGBP4P74efNFYB6wThv3Pwbs1Ub50Pie7wOrxs+fc+Nz/wL2if8eGPf5lct9j/F1s4DbgW8Dq7Tz\n+deOnxPjYrkfB95o7/+U9G+sx367SQvgR6t/SFCeFwBvAM3AkXH5HsAzJdeNiB8aywEbxmXLE5R+\nS+f+PXBy/KNvjn/sy8XHA8AmbbTfnoJ/GDii5P0JwH1ARBiYbBCXC/gmYQlzq/i1HtiC8LBbPy4z\noCG+p+VhdyTx4CAuXye+7nMEBX9JybkLgVOS/p/5UdsHixX88/GRi5XGZiXX3AUcV9K/jgJOBzLA\nwvj9KkBUck/Lb/7HwH0l5UfQMQVfrm+VKvjrgCnxsyIFpNv4fCsQFOxgwkBgTvzMGB8/h74Tf45M\nme+nnIL/MfBIyXeyDvBCfG5fYFr893eB29r7HuNzs4D/K6m/3Oc/FLi95LoDWKzgy9Zfi4cv0VcJ\nkuokNZrZdDP7mZl9njCiP0PSeoQf7vSW683sbTN7kvCj3lPSS4SR6e4sbXoZQXhA3Q28FB/rANtJ\nulRSLj4uXYaYaxI6bAuPAKsRZt2LzOzFWDYzs3+bWTNhFP8A8AFwDqFDtve7WxN4tORzvgp8FLdD\nXE8LCwmd23F6g+3NbCRBsXwBWL3k3HDCbLKlfx0DbG5mWcLgfD/gHeBWSeu3qncdYEbJ+8c6KE9H\n+tZRQJrw7HghlmUJzOwT4B5gF+BbwMNm9jFhVW4ScDnwPnC2pEwHZYPw3NmYxd/JA8AKkobHdX9F\nUiNBwbeY7Nr8HkvqnNWBz/8Fwuy+hcdL/l5W/TWFPxyrh92A4wnLRgCY2c2SniEo948Js2IAJK1O\neNAsR+ggu5vZs5J2Bc5oVfeLhBH6xmY2O75/aFz2T+BP8XUfLUPG2cCGLH4AbUyYhcwBBkta1cze\ni+s/ALiTMHvYB7gVyAKfEmb47bUxuuRzrkqYTbzR8rUsQ0bH6VHM7GlJJwFXStrQzP5HUCL3m9ml\nALHiqlPwUXnCzDaVtCHwa8LK09dLqpxJUK4tfL7k7yJh9tzCUOA9SSvSsb5VIAz6BxMGGVdJus3M\nWvf16whL2gUWK9sMcC5wCrBTLPdzwMXL+IpamE4YLOzUUiBpNeA9MzNJdxOeezsSZvtQ5nssqbM5\nLm/v808nmPhaKN2psKz6awqfwVcPdwHrSTpZwWGtTtI4YAPC0vg9wBaSvhhffwzhh7si8Eqs3EX4\nYadLKzazXFz/IQqOcsMIS40bmNlMM3siPt4quW1FSaVHPcE3YK9YvhWBCYTl9A+Ap4F9YieWLxNm\nDi3caWZNwF4Em2Q6nt1nCWaFUv4NfFnShvHD8SDgOTOb27Wv1XF6hD8TBrdnxu9vBPaXNCTuh9cQ\nzE0rA89KGmFmzxFsz625D9g2dohrYMlZ9vvANnG/WhXYIS5vjF+X6lut6r6S4CfzMfA3Qp9ra4B9\nM2FgvQNhdg3wPYI93mK5Xyr7bUBjq+fFQMIAfxtJmwNI+j5wG4v1znWEAc+DJf273Pe4VHvtfP7b\ngVGSviZpBPDDkvs6Wn9tkLSNwI/FB2Gp6FmCPbsJeBP4Wsn5IwgOda8QOtxKBLveDIJjzvMEu/h8\nguNKqZPd5gSntLcID6bjysjQYoNvfWxPsNXdQlhN+IDQOerj+7aK632DoOx3isv/FH+OGYRtf48A\nE+Jz/4o/64bxvZvG5ccSlt9nAs8QO/YQbPCnlci6xHs//OiJg8U2+JVblW9DmFGOivvbVMKq2KsE\nhTkgvu7IuA88F/e/L8Xlpb/5QwmrV28TFF+LDX44YWn93fj1Lyy2wbfZt1jSBr8l8GR870fAMe18\nzmuBKSXv6wkK8U3C0vg/gcFt3PdYG8+LP8bnDiE8s16K5diu5L4BxCbGkrL2vsdZwMiSa9t7tuxf\nIvclwEvLqr8WD8Uf2qkiFLZ+DbJ4Ob3Vufr43NxW5SsBcyxsr2uv7qHAbOvGP17SckDezBa1cW7l\n1nJLGkQwzX/axvWDzGxhG+X1wPK29FKi41Qt8W+dMr/poWb2YTv3pglOp/M7em97favVdUOA+WZW\n6MDHaH1vA8E5cF5n743vrwNW6Exfbu97bOO6JT6/pM8DXzCzu+L3ewAHm9kOna2/r+MK3nEcx6kZ\nYvPAS8BlwCLgJ8DhZnZLooIlQFUo+JZAA92ZVTqO4zgOQOxntBPBvHKPBf+HfkevKvh4megi4KsE\n284RZrZI0p4Eh69Te00Yx3Ecx6lhenub3J4Ej9EDCI5U10sa291KJe1H+1uvHKfa+dTM/pG0EH0B\n7+9ODdAr/b23t8mtAzxiZovi2fp0QhCFLndWSfuy5J5Hx+mLHCXp20kLUe20199Hjx69WlvlDpxL\n3VZ3Uv/dDUNY16rkBFIjnyL9k39TP3694O1ey/RKf+/tGfxU4GJJR5jZo2Z2qqSzCXsh/9bFOgX8\n1cyurJSQjtPbxHEFanpWGntTZ5bl8b2saijT32+88capDz744Phu1F3LXJlTZu8nib7bjC7NWNM/\nkxaoLSZLdbsRffsZovrIslOSlqen6K3+3qszeDN7GJhICLbQUnYM8CvCHlEnQSRtq5BD/v/FnqhI\nWkHSbvERJS2j03eQdJjirIUKGdBeBp6RdFUnQ552iObm5nMrXWctEVn2b3lyhwlbKqNctTDBrDmy\n7I1nkFsiTXaTtGZSMvVlej2SnZm9bmb/bVU2ycyub+++OCrR3a0P4FRCdiGn+3wR+DnwGiGa3BBC\nOMgNCBm0ZkkanKB8Tt9iOLB8vOf4R4RgS+sSgiEdXOnGxo8f/1Cl66w1Bpi9HVn25NKyN+O009XE\nKa3iedQRnZVT5rSstE5SMvVFqiJUraSjJB3d3jVmdjchZnHr43ZCLPSaQFKDpJ3ibR69ipn9hZA5\nat8R8PgwOPfrcF0Tmalm9lNCXOqDelsup8/TCDxpZvPiQEy3ELIDVpQpU6ZsWOk6+wOrEf06q4Zd\nk5ajPR4itzfw3zqiM3LKfC9pefoK1ZJs5pKOXNTWPvl4C32fI7ZHHkUIKzkc+FG8snEpIQTsBZKO\nMrN3ulL/29KAFaCxHhpTRIOENRaxRpEaBDTqs7+tsQiNQo1gjXmiQddQ5EmKj+1JXWoNNDSFHZZT\n5jcEp8gdK/MNOP2AWcB5hBWhkXFc8JUJcdx/3N6NXaG+vv40QopTpxMUyJ2fJn1MXpndDM6NLPt8\n0jK1ZocQgW/qZOnGsaQ3SVqevkJVKHgzW5C0DAnwB8LSd0tCmVvjJC2n/gpePwdGbwDbZtXwdIri\nIGGNzdAoUo3CGglKeVBQzjYIUo1gjYJBoMZhZLJgCw0WgBYYLKhDCwwthOICQ3OL8K5RXFCHFhos\nGEbuxJ3hlzfAqCbIXkCxGTjhUNjpDKIrVofsLPh/yX1lTl/CzC4ELlSwn25GyC/wOWDfngg84jb4\nrjEwZIA8qqD0dkZqInBS0jKVY0JIUrWEibeghqOaaX76Jgr3xOedmN4OdPNzQpCbtvibmU3qQp2X\nED5Hn1o6lnQv8J080c8Mrf4kxY0GQf16pD6aRPNqk2leYSrph0ELoLjQ0IIULDBsIbDA0IKgnFlg\naGGR1IJmsguaYOEfYEFrG1YHZVqFkFLyTWCqmRVi08mEX5GK1kdPfc8K+1fye3ACko4iZAW8OWlZ\nqgGFNJ5tmam+R4ipfkEvi9QvmCzVlSrJ+dJKg6s8H0RWDeunKP5IaPUi/C2y7I1Jy7Qsequ/9/YM\n/mqCF/25tBqFAWWTMNQos/5K3Z4Gu0LxoAPInzMQrnkRcvNga+DotGU7raQHEpI3dwUze5+Qoa20\n7Fzg3PnSSgOIrvxQahzaP1dcnAoRP9wU/7bKMZK2/T3GELIpLqXgp0yZsuHuu+/uu3G6QesZcAOZ\nM/JqeO5Tslctb1aVvk4Za3oJODqrhnXroNuB02qJXlXwZvZ+nBP4NDPr6r73mmAn+EsjumschV/e\nSvGHQAa4CXiRkDP5L5IujrcWJs5gs48KyjywAulxhIGa43SVZfrcmNl0gs/HErSs2LV1j9vgK8/H\nZI9ckfQ+g4j+klf0z7TlOuQvlQQZa3oFOLu0LK9oa0PzI8u+kJBYidLrNngzex7YvbfbrTZuIb3L\nc3DErRQ/JsQAONLC6HmVhEUrS4HcdfVEFzwv/X2kWS5peZy+SU/53LgNvvKsEtKp/nmOdG0j6T2T\nlqezFMl/lCL6VV4NC5ppvr7B8nclLVNvUhVOdv2NnDLjRarhRrJ/WFb+9mqiwWxmTpnn1iH6FiFZ\nkONUDb4PvvvEAa5GAQbcZ2bNkkYBe0C+iLRKbMqjoPToHIXXYye9qiRj9hqwT0HpUSlS43LKvNuf\nZvNVsQ++P9EkrZGC/fJkf9MVR7gqYJLge6dK/ttx2kXSzyXdWuaYWOn2fB9894gDEk0GvgYcCDwr\naQCwPSEA1hRg35brDS2MiC4sKHNKVg3rJiFzR6m3/CORZY99ldxrLWVvSwPyijZNUq6exh/Svchk\nqa6OzMnN6JKBZu8mLU9XCHtk7YPjqN8haVmcqudqYFVgEnBMq+OOSjcW2+CdrnM2cK2ZnWhmEwnK\n/kdmdmZsPtwbeKzl4rTlnnyZ3PeK8GwK+/Un0goJyd1hSk2L70MBdHhematyyox/tQfCJyeNK/he\nZCzp/Q37IGNNtyYtSze5to66vZIWwqlu4qXc7wPjzez5VkfFd824Db7bGEvubroDGKrA+cDDZnZ/\n6Q0jzXKRZadE5CbOhkUt5fOkFasxBG4pW5rl05b9ocHZKdhgTTI/TVqmSuMKvpfIKbOh0P8tJHfW\nsq+ubtKWexSsPq9oq6RlcaqbWJn3ilOt2+C7zROEwETpeGn+QOA/wO+AV4GH4yxoS2Fmto7ZZ0nE\n0jBgBNHf84oOXSQN7w3hu0pk2WfqLfvb98leXFqeV7T1+8Fs0WdJSYokfT5pQWqZt6UBgpOgePYQ\ns7lJy1MJihQnAT6Ld6oGt8F3mysIWxOnE5bnHzWzacDHwFBCEKwvdaSiAWbvfEpuf2BRmuiCgtI7\n9IzIlWOE2aLS94aGr0R0XUGZE/uqrb4eGAGcCPxQ0nW0P6s/1Mw+6BXJaohhZA4FZtRb/pGkZakU\nN1G4eyzRgVk1rB8HmnCcRPF98N0jzvVxbBvlZ3alvuXMPgYunyxd+R0YXrplqy9EyIsse8P70u1D\niL4pUoe+J/1sVbNPk5arM7TeJnco7Sehr+p/SDVSUHq0kdr8HXIHrJW0MBVkgllzTpl/CNsL+FXS\n8jiO2+Crkzg63szSsgai3+eUeS9F8eYbKDxcrTHk4zgAU4Gpl0ipliihn0qrRdSv9xSFh7Y0yyco\nYrssMVs3s9mx88snwIj474nAHsDsSu7Zju08dZWqrxqZKw2B1NEGp69l1pS0PJVmJrlbUrBZtdvY\nnP6B2+D7DtPI/aBI8d+GdhtHdF3S8nSE0m3NC2FekdS3NiWamlfDEQukiqc/rgTlluNPBPaQNJaw\n5LU5wf7SLSTVSzpH0muEkKwvSnpW0kmS0t2tv9oYQHScYTdXY/rFSrCOWdawaWk8P7OTPG6D7ztM\nMGtusPxdacv9PEvu0NJzTdIac6Tlk5KtIww1WxBZ9rhF5PY37P2IqCrTaJdT8KOAXxJSmZ4N/B6o\nRA7eI+PXDcxsbTNbF9iCkDWq4oEvkiSrhu8IDZlG/qqkZelJ5pOfCrbDvDLetU7fQNI28esukk6R\nNCRpmTqL74PvmwyKI+O1kCIaNJjoqpwyZ2WV/vrkKl7pHWw2O7LstZFlry0tLyhzYlYNu7wddiMk\nRjkF/xZBGX8FeCj++7Ey13aG1QhpSD+zWVgIPHATsHoF6q8KFknD67ADC2RPr1bbUqVY0WyeYbcP\nIP3dpGVxuoakrwLnKywzXkTYz3x+slJ1HrfB1waRZV94mdyEIsXbRGqHXcl8M2mZOoth/xK29TCi\nyQVlTunIICWvaPOCMidXUo5yseiPAX5KyL1sBOV+fQXauwa4SNIUYFZctjqwD1CVSxyd5VQpdQKZ\nk4rYXwaYzVr2HX2fHPl/ZIgueU+6pq95mToAjCaY5b4NTDazsyRVPNJcT+M2+Nohjjh3N3D3DCm9\nZcm5vKKDgKci8o/Hnv9VR9pyTwBPvC0NGEpmh1EQEQcCaitiXkHp7SH1Q0MVTcS0xAxe0nhJpxHi\nDg8CdgGOJijh7bvbmJnNIOTrnQNsDGwKLAB2rJXtdyeQ3sew+ZFlpyUtS28RL7FNX4lo16RlcbrE\n64QwpD8Brpf0I0Jgkz6F2+Brk9Ze6kXsTUjtkyeaWlDDUQmJ1SFGmC3KWNO/SvfYrwpDdkWHAJ8F\nCvsNhQcXkTuyzUq6QesZ/P+AcnuaP6lEgxYyD13a2fskbU4Ie9mabYA3uitXJciqYf06NHYRuR9G\nSQvTyxTITaonOude6fodzApJy+N0imuBRuBOM3tU0hbA8QnL1Gl8H3z/IGP5O4A75ksrZ4i+XHru\nQ6nxQ8hVczrrQWb/u0+aScmW9FPMivPU3g71rrGEgjezhwnhCEcB5wIrxEJEBEe7/y5VQwWQdBQg\nM2vPhvYm8Lc2yj9PWAVIlFelzJpEJ0Px/DjAQ7+iweyNnDKvjAr2sr4ea79fEA+ax7cqa3FUG0+I\nbNZncBt8/2Kw2WzghtKyRhgyhOjPOWUeN4oPzqLwQGkI3WphLiwEenz/fDkb/LHA6YRYxEfHx8M9\nKMcly7rAzOYQlvaXQNJs2g/O0yusSeanwp6rt/z9y766NhF2reBoSf+sVtuYswTzKL9i936Z8qrF\nbfDOALNZH0p7Lkf9KJH68pqkNwD+mLRcHWEeLMpUeHJUTsFngLsIcYdXJ3jU/gSYUcnGWzCzxGfg\n3SGvaGvQth+SO2DVpIVJkLTlnsqrYUGe+tHAg0nL47SPmb0GvNbWOUnlng29gqQtgR+0cWo7ysg8\nZcqUDXfffffnelIup/oZGvTJHcAdk6W6CSXncspMFNZo6KEMueeraSIS2+n/Wck6y3XiewhL8lMJ\nW+TeoAJON5J+Dny1zOm/mdmk7rbR23wsLbcc0XFFONU9yEE0TzLqJuIKvs8gaWXgKmBNguNtPSHh\nyN4JivUqcHEb5cOANvuZ2+Cd1rTeppwjd0eG9HeEDs8TDWuSftZg9mZC4vU45RT8ecDXzOwOSesS\nbPFXV6C9qwkBbc5laXt+xfND9waNRMcY9u/Ick8nLUs1UG/5B/PK/CivaLO05Z5MWh6nQ+xNSBV6\nP/AysByhzyeGhayLS2VelDSHMiY5t8E7y6IxhF+/ArhifhjYUpq0PqfMdw093UD2lWqa3XeVNgPd\nmFmzmd0R/32Rmf3WzOZ3tzEL26m+D4yP80SXHn1OwWeV3lmw2kPk+5QzUk9TRNcZ8lSyfYeBwL3A\nI8BGZnYlIchVn8Jt8E5nGGw2O3bU+wxhA1LYcXmiGwpq+HlSslWKNhV8HC/+mZLjSUkHVqLBWJnv\nXom6kmShNKyO1E+byZ3u28KW5BGyt6fgC1lp7aRlcTrEXcCphJ0qYyX9BKg6z+Nl4fvgne6SttzV\nacv+sIncQc00L7EqO09aMa9oyxl9KG9KuVC1JxGcWbYDdibY5GsyYUpXkKSIzIlFuKbBrCr24FcT\nO5gVinB9HZEnoemAitiYAAAgAElEQVQDmNl04BfA7Pj1C/TdffCO020azT7MWP720jILUV332ZRo\nWl7RuVk1fDsh8TpMmzZ4C6lNW9Kbzpc0CdiLnt0q12fIEu0FxUJkuclJy1KtfEDupmFE1y2Uhg0y\n+1/S8jjlkbQnYVBfSiNwcALidBm3wTs9yfJhq/YRb0sDhlG/WYriuqXns9LaRWgaYPZOQiIuRZsK\nPu7wG5VcsxNwTm8JVc1kpXXqiPZoIn9Qn1mnSYARZovyim6OyOwJXJC0PE67TGXx9pwMISb9ysmJ\n0zXcBu/0BvF2tkfi4zNSpFdKoSMLytQDMwrkJjWYzexInadKqROp/3KR1JzIsp+ZBmZI6Y2o/yqA\nSL3d2dTj5Zbo3yUEwHgJeAY41MyuLXNtv+F5KUoRnVSg+IfGPugU2NssJH+9sG9Ue27n/o6Z5c1s\nfnzMBv4K7Ja0XJ3FbfBOkqQtNz1t2b3y5I5oRs/UkR5aer6g9KgF0tC27j2R6BhD6wgdHuKqBDYh\nvUmK1J4itbKwxs7KtMQMXtLpwHfaulDSRWbW1r7UfsO6pA8SvN5g+buSlqUvsILZJwU13N1Iejzw\nl6TlcdpG0tYs7vcpwupdn/O58X3wTjUQL9EvtUxvaMsGouPyimZuAms/XdLHDDZKW26frBruF9qX\nEIcCYDOD94UNnkv+hc4uq7WewZ8OjAEmAbcA/0fo+I8Ad3ay7poir2gLoR3mkDsvaVn6Ejmy1wmN\nfVNqWPbVTkJ8wuIVuxeAPwOHJSpRF3AbfGWYIaXzirY+VSq3wut0gbTl/lhv2bF58mfMb7VLRcE0\nRoHsfGGDW8qL2MwUxVubsZeXJ/O7zrbZOtlME9AkaXtgv3i5DknXAPuztCNOv+BDqXEI0fGG/W5o\nHw+r29sMNHu3oMwTqxF9G7g+aXmcpTGzlwkBbvo0boOvDBsT/QpY60SiTF7R7c3kb+uoLdlZNgPN\n3ntDehv4LLaMQbMk5UgPF6mZJeWFORSeuhcWjSN1SGfbKjdCuxX4q6SJkn5MiDz3785WXisMITrK\nsPvSluuRWPy1TjOalII9J0t1ScviLEbSbpKeKnNclrR8ncVt8N3nbWlACm3+PrkDC+SOAqgnOi+v\nhouyatj1Q6nTdmBn2RTRVTkyFwid0ET26oLSX84pM64esiuQOX83ojOaKf65s/WW2yZ3kaR3ga8T\n4j4fbmaPdfMztImkjFVhOr8WmpT+Wh2ptV8h/7uRSQvTR8lY0yt5RTN3pX5H4PZl3uD0FrcCdwNb\nAEcAJxNsh3sTMs31KdwG332GUb9NEXs69hSfCVwi6dIc6S/VoZ2HEP24oMx0w277LfnHTzErJi1z\nLZCxpn/dK92xg1khHkF95sR9qvQohJzxna23bMYoM5sGTOu0pO0gaSBwHLAlIaDGH4E1JT1OMAks\nqmR73WWBNLSB6PBmcj8faZZLWp4+zqQUqUNxBV81WIjAOF/SNsDVZvYsgKRLgZsICWgqhsIKTsZ6\nKCmT2+ArQWq0oSVMHXFM9unA9PelQSuQ+VoK7Xsi0bHxEv6/fAm/+5SLiNqdQVRrL/o9CKkYNwA2\naXXtHWbWXUe7lshmZxDS+R1jZtdIOgwYC1TVVrwM6eOL8I+MWbcz6fV30pabkVdDIa9o27TlHk1a\nHmcJ7gQulTQM+IjQT+/ubqVxv37KzO6PTX3HxuUPAQdVeuXObfDdY7JUN45o2yzZP2XKXLOK2ULg\nZuDmRdLq9aR3jpfwPzTstrnk7nI/peqhtQ3+TUIHf52Q+730eK8C7Y0EppjZQ4QliJbIePcRBhVV\nQ06Z70IqnSFXVYOOvkwzzZMgNTFpOZwlMbMngIMI6WK/AkwyszMrUPVwYHlJg4AfAZsD6xLST1c8\nSp7b4LvHWNKbGpq1nNnHHbl+gNmstOUuTZObAMUrUrDJEKK/F5Q5Ja9oG/fCT54l/gFmNt1Cbtz/\nAK+Y2T+AVYGhVGZf7LXA1ZLuIAwaLpG0P3ARcF0F6q8ITdJaKdgnR/Y3tZAysFo4k8J9YCvllPEH\ncRUgaStJe0jaFtgzLp4PbBXPuCtFI/Ckmc2zsNx4C/C5CtYPeCz67pMaY9iDnb3LzCxtucfrLXva\nR+T2aEZPQGrfE4km5xX9uElasyekdZZNORv8iUBG4R8zHngF2A+4sjuNmdkMSV8B1ibkn/4GIaHN\ngWb2YnfqrhT3SvWjyZzUTPOfPIZ6ZTnFrJhVw9+F7UU/3XJZZcwmDPI/Igy4S/mgAvXPAs4jmP1G\nShpBCIH7Z6CSAwjAbfDdRdiYZnLdSpFaZgn/nLwaZvsSfu9TTsGPIsSjvgw4m7B0f0AlGjSzT1j8\nMLmdDjpdSVqLEISnNetQmYcRAKNJH2DY/zKWv61SdTqLeY3sbesR/aBJWsMdc5IlXq17E0DSymb2\nmKRdgK0IPjLdrf9C4MJ4orAZsJAwc9/XzJ7rbv2tcRt818lK66SIcpXskwPMZhF8Oy7Lkd4qFbzw\nD8op8x8FL/zp7oXfs5SzkbwFHEmwxz0U/90j2+QAJB0l6ehlXJYiRPtpfdRR/nN0ipwyGwt9cyG5\nsytRn7M0I81yRZhaT7RX0rI4AUlfBc6X9DmCuWwRcH6l6jezt8zsRjObY2ZPdFS5S0q1PgCVu95t\n8F0nRXoMWI8MkFot4e9p6D+Q+v6JRNfnFf3El/B7jnIz+GOAnxKW5esIyr2iUcgkpYGimTUDlyzr\nejN7neD817qebWin03eUt6UBqxCdaNhZQ8zmdrc+pzxzyU0bQjRpgTTUk/ZUBaMJZrlvA5PN7KzY\nT6ZHkHQUIDMru6QeDzraMuOsT0iAtRS+D747pMYY1uNZH+Ml/FuAWxZJI0qW8D+Kl/Dv9CX8ylFO\nwUfApsDhBOebCYSUkrO705ikeuB3wLi4qCgpS3Cwq4TXbpcZRvQz0PR6y/bYSoUTGGq2IK/oXxnS\n3wX+lLQ8Dq8TgttsAhwu6UdAT24N7ciA/h7gntblki6hzIDebfBdY4H0uQaioRG5Z3vTo3iA2dvA\nZZIuz5HeMl7CP7CvLeFLWpXgVzIHuNfMrozLlwOWA96LJ7K9Trml7YOAq4EphO1xk4A9KtDekfHr\nBma2tpmtS4iiNQxIbPtUQekxBhu/SfbCpGTobzSRnyz0LQ99WRVcSwhkcj5hdlwPHF/JBiSl40A3\nmNkC64FZmtvgu0ZENAZ4KKkdQ/ES/n/qLXt6mSX8tZKQqxNsQdCR+5co968CfwP+H/A/SSskIVg5\nBf9FFqerg7BvtRICrgZMNbN8S4GFCHE3AatXoP5OM09aEVJHG5y2ThWHzK01BodERg+uQHrcMi92\nepT4wb4uIVTtXsAuBOfVbiGpXtI5kl4DXgRelPSspJNiE11FcRt81xA2GopVMThaxWxhxppuSVvT\noXlyhwOFeqKz82r4c06ZsbOlwcuspPfZjBDW/SpJ35a0PiFQ1A/NbDzwK4Kzeq9TTsFfDkwm5IXe\nF/gDlQlbeQ3BmedYSXvFx7GEZDbLXLbrCRqIfmHYjZFlq2KbXn+iQO46ofHPS1HSsvRnJG0HGPDL\nuOgIYFlOrx2hV1fsfB985/lQahTa4GUKjyctS2sGmL2dttxlaXJ7QPGyFGy0AtG1OWVOLSg9qooC\n6ZxhZgcRMq4eQAjodoSZfQCf7SZZNQnB2vyCzOxewj7VO4G5wC4W7CXdwsxmEELSzgE2Jtj5FwA7\ntnwZvUlOmd2EBk8jf3Vvt+1Ag9nMIjy3DtG3kpaln7Mh8ChByUMwy5WLVtoZenXFzm3wnWc56kcV\n4b/VnGujdAn/Q3J7GJpu1E2Ml/B/WgVL+D+T9DWCD8vbhIRNOyueuMTnNktCsDad7CRtDbxkZr+p\ndINm9h5waaXr7SyLpBFpogPyZA+ekJADhAPAJMHJp0o39wWHmhrlOuB+4FmgQHCqvbIC9V4DXCRp\nCiHoDQTFvg+wYwXqXwK3wXcekRptFDsdvS4pVg2Jim4Fbl0kDY+98M/Oq+Fjw26bR+7Olc3mL6ue\nCnMxYaX7U+BoM8vHu1BmSrqcsHz/lV6WCSi/RH8yFbDBVSuTpbp6Mic3o8sHmL2TtDz9mciyz4N9\ncBz1OyQtS3/FwgPxG8ADwLvA8WbW7RwMvb1i5zb4zjFDSqdgq08pPJK0LF1hgNk7actdHi/hX5KC\nkaVL+JNjp86exsw+NbM/m9lVLatVZnYe8DXgX8C3zOy13pClNeW2yd1JcBi4k9AhAe4ys25nmKoG\nxpLex7BPMpa9KWlZHACuraPuh1Qgg5nTeSR9AUiZWcX9YHpzxc73wXeOTUhvYdhrfT3uR+wkOgOY\n8Z40cEUyXzXqJo4jdUxe0R3N5G9rMHsjAbkqkb+lW5RT8DOA1svzNRGQJKfMF1No10XkDnTPruog\nbblH88r8OK9oy7TlWsdEd3qelp0MfdqG7Tb4ziFSo4s9FL0uKcos4Z+ZV8OcBJfwE6NNBW/W+YxC\nfYE3pYbhRCdB8byOpkR0eocixUkpNJGlk544Pc+jwDWS1mNxMKs3zOyyBGXqNG6D7yw2pkDu0Fqd\n6MTm18slXZEjvUUK7bwC0Q9zysxIUbztBgrTa93/qlq2GfQKI8gcLHi63vI1OYDpy9xE4W6h1bNq\nWC9pWfohHxBC1d4HPBcfvb6k2V3cBt9xcsp80WDuQLN3k5alp4m98GfUW/Y3pV7440I62582SZ9P\nWsaeotwSfc2RV7QtaOv3ye0/ImlhnKWYYNacU+bvwiYSAkM4vYSZvUJICd2ncRt8xxE2BlhqoiPp\nQOCbwJrAeWZ2XW/L1pP0tyX8JWbwkk6X9FSZo+L5m3uLOdLyQscY/GaE2aKk5XHaZia5W1Kw2SJp\neNKyOH0Pt8F3Bo02tIRJQ9J+wHaEGCjjgDMlfSMJ6XqDEi/8PZP0wu9JWi/Rn07IuT6JkPHn/4Dv\nAI8QPOsrjnohitkgomMMuy2y7DOS1pE0pKfbdDrPOmZZw6alyeyZtCxO38Nt8B1jkTRcMLiN6J2j\ngd+b2ccW7Nf7xWU1TS0v4S+h4M2sKd4Tuz1wvpm9Y2YzCQEr9u9uY5KGSpok6QuSxkr6L/CapMmS\nBnW3/pJ2MpJOlXTDRNU90QRrTCN/haRtCfsSE4l77yyb+eSngn015AioHSStIekiSbfEr4nPDiTt\n1s6KXZ9ysAO3wXeUOqIxtJq9x3zAkhHX1gOaekeq6mBVs08z1nRr2poOy5M7DMjVEf0ur4aLc8qM\n+zhkiOszlHOyuxX4q6SJ8dL8ucC/K9De/sAdwFuEXM87AWsAjxOWhSrFHcDK58MJx1OX3orchnuE\n0JvDCRl+nCplRbN5hu4YQHr3pGWpFAoJMt4i9KH9CbGq28p13tvcSlixO5zFKWN3IOxbvz85sbqG\nx6LvGEJjykSv+yPhuf9rSacC3yVkGOyXtCzhR+S+17KEvxzRpJwyvy4ovV1fWMIvF4v+IkIn/zIh\ny9ThZvZABdobDjwFpIEmM/swDlJwLxUKxi9pJaBoZoccSjR+PeyoV0IAlU3MbArgGeOqnBzZvwt9\n+z1pYNKyVIgxwOlZotdzpFcnRI3bOmGZMLNCvGK3DXC1mT1rZnMIfX/vZKXrPG6DXzbBH8k+/xD5\nJ1qfM7P/AY2EZ/RTwHjzDJtLLOH/j9wEQ48add8bF2LhH1zNS/jlYtEPBfYkxM/dEzhd0l4WUnx2\nh0sIOeYvAz6SdA3hh7QfIU1lJWgGFkjKmNlv6gGk3xL8Cpw+wCCz9wvKTF+JaFdCnPQ+zTDg59Tt\nkIINPiX/Y2BFYIOExSrlTuBSScOAj4Dv0QejCroNftkMJLMd2OM7mBXaOm9mCwnPaKcNYiftfwL/\n/FRaLb3YC/8Tw25bQO7OFc3mJS1nC+WW6A8Crib8o98jKMc9utuYmT0HjAIWAa8C82IZvmVmz3S3\n/riNT4DrgSZJ4yVNAp4zs/9Won6ndyiQm5SCCfdKfXorZ17RljOJ9mtGn1uZ3PLLh/jUDwDHJC1b\nC2b2BKHPr0kY1E8yszOTlarzuA1+2Qgb3Vwlud/7OgPN3k1b7op6y+4BxT+nYINqW8Iv9/D8ImG2\n3ZLG8w3C9oluEy8BXtjZ+xScG9rawr4CYcBQ2saVkmYR0mBOAaaWnDujs207vU+D2Rs5ZV4ZReab\nBFtxn+J9adBKZA4GbQl2znEUZhBWqYYB+5lZVSX4MLMnJD0JDCBkxUoUSesTdvG0ZqO99957wLRp\n09YaO3bsm9OmTVuLsNPn5vr6+tOmTZt2VMv71uf7+/uNxo17b6XV1x79wJmnzSlOm/Zq0vLU1Psb\n/nHz2LFjf3vPBResH8355IgNrrnuoHGvvX7Mcz/4wTmvjB27RevrGxsbGxYsaEnz0nOUU/CXA5Pj\nv/cl7InssZzdko4CZGbt2dDWo21P/pHAUpl6zOwu4K7KSOgkgbBrBUdL+mfsq9EnKCg9aiWiowwe\nfJ/c/iPMFsXCV62ZSNLZwC7AecA4SaeY2X8SFGkBbfRrYN5HH31UyOfzTQD5fL6pvr7+nUKh0FRX\nV3duc3PzZ+9bn+/v79ei/kvzi80vNjc0vFFo4/vz991/P3u11ebWr7HGHe9uOPLhXfbYI1WcO3dV\nM1vq+mKx2CupsQV8ATjRzH64xIkQl3oCYZvE5Hi7XM8IITUCmFmnhzSSLiEMDg6quGBO4uTVcJFo\nntQXwgvPkZYfTHSowRcNzows22GzUzzIfcXMbu5BEcu1vR0hret0worYfcCvzaxSfjEVw/t71yko\nc1wRXo4se0PSsvR3JN0CPGZmPbrzo00bfLw1Lm1mv4ln1StJOqCSDUtKt+wFNrMFXVHuTu0jmicZ\ndROTlmNZFJTeYTDRFYZ9/Aq5Azqj3KuADQkJZ1pWSd4jbCvtU7gNvjynSilgVI6c29/7EeWc7HYk\nZJfaKX6/PBUIDiOpXtI5kl4DXgRelPSspJMkpbtbv1N7hJm7Dc4r2jRpWdpinrRiTpnTjNR+RTgx\nbbk/jTTLJS1XJ7kOOJkwix9N8FuZ3O4dVYjvgy/P8UQbGfqg0eyDpGVxeo/2ssmNBU6qcAz6I+PX\nDcxsbTNbF9iC4HhU9bM0JxmK6FoLqWSriqzSOw8kukLY6w+RO6iN0J99gngv/DcI3v3vAseb2bXJ\nStV5fB98eYSNxr3n+x3tKfjZhEhz3wCOI9jru8tqwFQzy7cUWJjt3ISHj3XK8AjZ21Owdlb6QtKy\nACyQPpdT5qwUdeOayR2Vttxfyu0r7gtI2gH4spldYmYnxh71f0hars7i++DbQ2OKVL8fi1NZyin4\nu4CCmTUR9r8/RbDLdZdrgPMlHStpr/g4lhAK95IK1O/UIDuYFYowuY4ocaevrBp2bSC6BHhyGtmD\nM2avJy1TBRgJnCPpFyVlGyUlTFdxG3zbNElrAXUZs7Z2JTg1TLlQtRe3hCg0s6KZ/cLMLu5uY2Y2\ng7D0PwfYGNiUsB1mR3PbkNMOH5C7Cdh6YYi21usskobnFf0+BTsVyB0eWXbSBLPmJGTpIY4E1pR0\neW9keOwJ3AbfNimiMWA+e++HLLEPXtIehL2nGwCbtLr2DjPrdspYM3uPEOvacTrMCLNFeUW3RGT2\nAP5fb7UrSVmiCWmivYtwVYbs1L60J78TNJvZT+MVtVuAPmdycBt82wiNBvMV0n5I60A3bxJiUb8O\n5Fudq8QSveN0mU/JXz+I6Ko50l+HmM3t6faapDVzZI6DYlOW/I8Hmf2vFjU78DzwMYCZnSXpLcJO\nmj6F2+CXZp604kCiETeQf3pC0sI4vU5rBb8rIQxfW1wEPNez4jhOeZY3m1NQwz2NpMcBV/ZUO5Ol\nurGkJ9YT7d4Ml2Usd0st7uGUtBUh0NVMYG9JpRnkZiQjVdeZMmXKhrvvvrs/o0rIkBkD9miNmZOc\nDtLaBn86IbXlJMIy3f8RFP4jhIxTjpMo+ZBKduybUkNP1J+V1hlL5mJDI5vIHZSxplt6op0qYTZh\n1e5DgkIvPV5KTqyu4Tb4pRE2hrZzvzv9gCVm8LHXfJOk7QkJMWYDxGld9wdO6n0RHWcxA8zeySnz\n5GpEu1DBtJYzpPQmpPerI9qlmeaLMpa/o096mnWOTYFflzn3OHBvJRuLI1dmzKxHktm4DX5J3pYG\nDCOz0f8onNJWli6n9im3Te5W4K+SJsaBbs4F/t17YjlOeQxNSsGelUrHmFNm5CZElxsasYDc/hnL\n31GJevsAtxJW7A4n+N3sDexAcIK9v7uVSzosniy0hL9+GXhG0lWSKh4K123wSzKM+m2K2NNxDnOn\nl5H0DUl7KsH4HeUU/H+AvxFSxK4NHG5mD/SaVI7TDhlretmwWbtS3y1HsFelTF7RISn4tSheGln2\nVyuYfVIpOasdMyvEUey2Aa42s2fjdM6XEpR9dxkOLC9pEPAjYHNgXUL66YMrUP8S+D741qRGG/JB\nTwLESZF+AKwMvCZpVBJylFPwJwMvmdmhZnasmT3Wm0I5TgeYlCLV5cA3eUWbrUn0F6HlPiG3f73l\n+/MA9k7gREkHS9qTEJv+7grW3wg8aWbzzKxI8O/5XAXrB9wGX0q8ujUqS9YVfC8TR4b8kpntbWYX\nElKdH52ELOXywd8JXCXpTkIgGoC7zKySnR4ASYPMbGGl63Vqm7TlZuTVUMgr2jZtuUc7et970sCh\nZH4itK1h59RbbvrKPSloHyAOTXsQsCchgt0kM6tEsplZhPzyrwEjJY0gzGj+DFQyxwXgNvhSxpLe\nzNDM5cw+TlqWfshyhKitLbxO+N33OuUU/AzgN63KPuxuY5KWBwaUFKWAf0raGfCUsU6naKZ5Ul1I\nJdshBZ9XtM1QoqOBR/9Hbj+3TQZiG+E8MzuukvXGs5cLJa0JbAYsJMzc9zWzim9ncxt8KanR5tHr\nkuK/wFmSHgSeAC6gMrlcOk2bCt5s6R+GpHKDgc5wHHAMYQBhhA+9DnADcBlweQXacPoJZ1K47wRS\nB+WUGRlZ9vly182WBq9AdChoI8N+m7bsk+5VvATj4tcemQGb2VvAW/HbOT3RBvg++FKEjWkm9/Ok\n5eiPmNksSROA64FXgReAbyYhS5tKO3YIOBdYgaCEI+D3QLcyTJnZCZLeBr4GHAa8DzxmZok4IDh9\nm1PMilk1XCdsImW2cBaU3n4Fop8Zdvdb5A9YJ86x4CzBo8A1ktYj7I0HeMPMLuuJxiQdBcjMKjqg\niG3w4ytZZ18kq4Z1U5BtMJuZtCz9FTN7Blg/aTnKzcqPJQS9OZDgHHA08HAlGjSziyTdTYhE5jN2\np1u8Rva29Yh+0CStUfpAmysNGUB0hEitZXByZLnn10lS0OrmA+DEVmXdNsmVIikNFC1EVFtmXHRJ\nOxKcfVuzLvB0W/e4DT6QojgacHOFU1bBZwgpY79EyNN+PvATKhS+0sxelPRtQpCNdytRp9M/GWmW\nu17pF9+lftrPpLnA7U3U/2cQ0cGG3fI0+dO3NGudV8FZkjnA94E1CX4x9cB0oFvxAGKz3u9YbAIo\nSsoSvPTPbO9eM7uL8AxqXecllLFnug2+hdQYwy5IWgonecop+HsIS/JTCWkk3yDYEiqGhYfu8dCx\nJbuujOid2kfSFwfB8W+Rvmc46ePfpnjzU+jFTckdkDF7dcukBewb7E1wBrqfEIxmOYJ5rrscGb9u\nEPd34lS05wETgb9WoI3PcBs8LJRWyRCtHJF7tkYTIzmdoJyCPw/4mpndIWldQme/ugflWOaSXVdG\n9E6/4BsLYY/BqHk3dPOz8NutyG9RMKvogLTGGUgIS5sHvmJmv5Z0A2GQ3x1WAyZbyQqKmeUk3QRs\n3c26l8Jt8JAmGgN6qEZTGjudpJwXfTPx8pyZXdQTDZfa5Hx7nNMNPgW+GFn214ukxzaHLeiDqU4T\n5i6CGW4icL6kD4BKOCNeA1wkaQphTzwEk98+9MD/yG3wIGw0FK9PWg6nOlhCwUs6nXbSxZrZxd1p\nbFk2OXNbqdN5JgHPSlqdsP/0NGCrZEXqW5jZdEm/IHjQ/wL4OrH5rJv1zpA0Fvg2sDHBvj8T2NHM\nPuhu/a3p7zb4D6XGIUTrv0z+PyOTFsapClrP4E8nOL8cTLDDXQTUASdQmXSxvWqTc2ofM/s03t61\nO0GBbGJm7yQsVp+jJNfE7fFRqXrfI8S273H6uw1+OepHFeG/I81yScviVAe9nS62V21yTv/AzArA\n35OWo68haTfaSRdrZgdWuL3fAC+Y2TXLvLgL9HcbvEiNMc/97pRQzsmuJV3s34DBwAFAJaIi9apN\nznGcdrmVkFRmC+AIwi6Vdwhe9fMSlKtL9Gcb/AwpvSnRVvMonFvxPLxOn6XNbHKxY92lVDhdrJnN\nAMYS9t1uDGxKSGbTIzY5x3HK0wvpYlvzHIsH9hWnP9vgNyG9hWGvrmjW5wZmDpwqpQpKfyWnzCal\n5TOkdFbpnbJK75RTptOuFeVC1W5FmLEPJWxBGyvpD2bWrVC10Ls2OcdxOsSdwKWShgEfAd+jsuli\nATCzSZWus5T+bIMXqdFFrN8OcPo6JxIdY9hsoVF5RZekLTcdYBPSm4D2NLhL2CedrbdcPvhfAqcC\nmwAbxseFXRXecZzqxcyeAA4iRLL7CiFdbLuR5qqR/p0P3sYUyHV7ldXpWT6UGgtKb7dq6GsrtpQb\nbJS23OVFONNQ6U62zQzeFzZ4LvkXOtteORv8POBV88QcjlPzSBoCnEJIjpECvi5pVzPbJ1nJOkd/\ntcHnlBkpmDswrI46VcgiaXg9mV8OIRpRhKfrQvyOT1vOK4SHp0B2fkR6cEt5EZtZh71YgGh5Mr8D\nDulMu+UU/P3A/ZL+BXwcl91pZpXYKuc4TnWxPyGGwESgZYtVn4uE1l9t8CG4De49XwW8KmXWJL0p\nsH7acp9Ffy1CwbDfTyP38gSz5relW4CmlvMGzZKUIz1cpGaWlBfmUHjqXlg0jlSnlDuUV/DPsrTX\nvI8OHac2mWo2q7YAAB9gSURBVAd8bGYLkxakO/RfG7xGWwgg5iRI/v+3d95hdlbV/v98Z+acM+kk\nhCQ0CVIuVZo0E6ToVeGHgnKxAoqKcml2hCsIUUBzUVApigpKAJUOGsqPQCgKSC8R6QIChmoICZmZ\nM2XdP/YecnLm9DpzZn2e5zzzzrvfd629z3n3Xu9uayn5k5kkNzLsSUOrvGyOM3sZeHn/PPcOoHlp\nUj8VtnY3PYd2KrHLAG1TO+Dl1Uidvg+2pJ+BX+Qz2PnI56p2SGjY6IXOcZzW40HgKkl7EgJLAfzD\nzIrGiBhOjMZ98F3S2gmS4xPW81iz8zJa6JZmtpHc/i3SN0w2W5qRNO8h0osqiV6Zsu7rbpEW7GbW\nNz6cejtc8xzprwAnmA2UKzffKvqdgR8TgswISBICT1S9it5xnGHHG8A3ss6NuG2ro3EOvp3k7Oze\nolMf0kp9qg32aye5AvTAYuianJGesPT91USv3C047BpCJYZ9kHy98qMJbmu/SKj43wCG9Oodxxn5\nWIi8t0r0vZE4Yjca5+CFZsNAPSN9jjrmSG3/Q+JdAAlLPzh4vo2BZ3voOzwOtzMS/P3n2yaXIkSY\neojgae50wt7YuqBIveQ7jpMfSVMlXSvpEUmPSnqSERgX4vLLL9+82XloJEukScLWv53e+5udl1Yg\nrdRmaaVO+g7Jq6HtS4b6M9M7rPfOQeM+Usj3ln4zYUj+CkKAmGfIesOvhLgd52xgd+Bq4Ktm1gV8\nHNiEsPfecZzG8hngfsLumScIgaZWa2qOKmC0zcGPJTUL7O58Q7tOfiSpC2Z2mg2uOcEYWNvg5jfp\nmzs1eHgc8eQz8K8BD5nZAkkbARsCXTXQ9wngVoJv+6OBy2I4ScdxmsdY4BagF9jVzL4n6UrCS35T\nkLQ2sH2OpPVYuXV3FUbbHLywWX0MLBxxcylNpFuJ3Ttom91L8t2GLQDOHExLWe8CgM6m5a72ZMeD\n35IQT3t74F5Jh8WkmcDTNdC3IcHndRcwR9IJwLnAtTWQ7ThOZdxEmIb7NHC6pFeAZju5Gkcw5tmM\nJ08gnNE0B/+UlJpJapsl9J3SSgapniyX1kiS3L0f3dVFzxmrWfmuX0ca2eFiF0n6LnAUwTXt4BzE\nMuDZGui7AjhH0lfN7K9mNkfSqYSQlRfVQL7jOGViZndLOoYwcncM8H7g2Cbn6QnCdMEqSNqcsLNn\nCKNpH/xMOrY3Bh6dPsJ9F9SDHmnDNhKzoW32i/QcMTOEQWe82asEN+wMx4h7l0rt+5LYOmHp+2ol\nc8jojpk9TFg9D4Ck8Wa2vBbKzOwOSZ8GJmWc+5akB1jpQctxnAYiaTbwcnR0c4OkGwmhY0fUmpjR\nNQffNtvce90QetX5szaSU8BuNexHg8Z9uLNEmrQvydNBXUB9DLykJGFO4hbgUmA+sJGkJ4B9auGb\n3sz+keP0DPK8lWfk7X2ERiebjYCHq82X44w2JI0lTJFtBiyXNOhcYzwhpPOIYrTMwc+R2r5Dcuc0\n6XOTzc5Mk5CkHpJbCGvP3MrWR8/cMWYvNjNvJTI2fgAYT2IDMfBro72mYZqze/DfIAzLXw18Clhq\nZu+UdCLBX/Uvaqk8g6Ies8zsJsJc4SpI+iVFXg4cxxmKma2QdBywD/ASwUX1GILjm2ebmLWKGC1z\n8MeS3MLQy3HIeVSxRJo0nsRBvSR3N/TKADo9M304G/e0Uu8aYGCNTuu9CXiZjJfohKXvf1OaMob2\nmurM3ge/E3BGHKrbC/h9PP8XaryvX1JCUjuAmS2v1TSA4zhl8WFgRozV/l+EkbsrgbWbmqsKGC37\n4ENwmYFR8TKTzXgSmxh6vZf0kQnrPjRl3Y83O0+FuE9K9Cr5xT6lLhE6oh0NLuy7Byg7/Gu5ZBv4\n14B1JKWA2cCCeH5L4LlqlUnqkPQjSU8DjwGPSfqbpOMkJaqV7zhO6Uh6D7A/cIak9YCDCCFjDwNO\naWbeKmH0xIPXLgP0tnTs9+XStF4lD+xV59mZ5xOWvitpPb8bzj31TDaHNQHrI310wrq/VMsFdKWQ\nbeDPBn5NcEv7ezNbLum/CRX+0hro+1r8u4mZbWBmGwHbEubgP10D+Y7jlM6OwEVm9jywJ3B13MJ6\nOyPDE+cqjIY5+G5pfaAtlXstU0vQq+SPOkn+AtqmDITtm8Oev0vJbiX2SCs1d3FY2wJAp9k/E5Y+\nt9Ps2WIyJpr9O2HdZYeELUT2HPxOhEV2k4EXJR0BbAdcAHxE0vlWnYeftYBLLSPajpmlJf0R2KEK\nuY7jlM9rwKbxeG9WNqZbUIMRu0YzGubg20jOAmup1fNvSlMmmmU6L7r0StL37m/Wn/emYUSvkodu\nTHLvAVjUxsB1a5qtaHaeBhk08IOL1BYzdMHa/Izjar/wC4GzJV0OPB/PrQscCLyvStmO45THH4Fv\nx+iRSeBWSe8neLA7uqk5q4DRsA9eaBaMrDC+uVgmTe0ksRdorzEkTgPuHkxLWPqufHHThwOvSuPX\nyFgzNkDb8z30HJT1kjIs6ABeJ2yFmwf8g+Cx7mlCPOiXaqnMzO6Lrmn3JszrtwH/BN5nZiMuPKXj\njGTMbKmkdxN67IvMrC/GfPq8md1d+O7hR6vvg18mrT6G5Don0/vQCc3OTBX0KrnNGJInGLq5n55j\nM/3BD1dukTp2ouO9bbR9aDUSjxO2lwKQsu5rhqPjHICOWMnfS3AL+U5gA+AjwAZxn+zTBMP/ppmd\nV61CM1sM/KpaOY7jVI8FRyD3Zvx/YxOzUxWtPgefDMFl7qwmPngzeENaLdMtbC+9Lz0K+29n1jsS\nVla/KU2ZTfK8AXiyjYFrTqbvtpHygtUBYGZG2Pf6LLBwMDH6pt+HsNK2HajawDuOMzqJ22JTVqc5\nylafgxc2GwauaXY+SiWt1OZtsN84kpuREW58rNni7ZqYr2I8FXaRsWF07NYP/d2kDxn0OzBSjDvk\njwePpG2Aywm99/3MbKeG5cpxnBGPpCPj6CCSvkzwLb9I0ry4FbemtPI++BekMW1oi5foGxFTJ33q\n/Kbg6AFY9CLpzzU7P6XQI23Qq86vzSR5yWphTQoAk82WjlSnQnkNPMH962+A22s9F+84zqhgbWCS\npHHAl4BtCK6lnyFsva0prbgPXtJ0Sb89At32M/p2Xje4ER52ZG4NAxjA5ies57NJ67lyJPiDTyv1\n6TaSJ8HAa2+R/lyrxIPPa+DNrN/MfmBmI267jOM4w4rxwINm9qaF+eP5wLRaK2n2HHz0zvmuSkcn\nJI2TNDnj/yTwL+CWy0hc3YPOA+ZJ6pQ0VdLekibmkDNG0hRJbZLWqrhAJfCWNL1XnUdNJbGKY6Sk\n9TxWT73Vslxa5fkbIH1nwno+lbD0BZPMRlwchnwU6sE7juNUw/PAacD5wH9KWkfS1oSYFpfXWlkz\n5+AlHQ7cT4jn8WdJ36lAzP8jhOsdZEOCO9NJQPsX6TuBMGW6GeE77CZjNXcG7ydMFU8mOC/Ll+dc\n95ZMn1LHpkieAwMr3qD3uGpkNYpeJXdIKzU3RWqVF5KRsJK/EtzAO45TF8zsrOit8svAkcBbhDbn\nIDO7t+DNFdCsOXhJHyC4+d3WzD4LzAI+JmmTjGs2V9YwtqQJmddkpa1OCPyTBJZ2WM+cacHj50FA\nD/BZwhZnZdwzWdL28HbEkjeI3kOjm/D3SNoi/j8D+KCkd2akby1pJ0lj4rk146jCdoPXDbK6tPl8\n+pa9QPqTCUv/eo3g9XRavUcMqqFXqQug7WBj4Kar6Plys/PTCIbEg3ccx6klcZpvcKqvbsOfg/vg\nV0hrtpPaPjMtTc8dE8xeAyiWPkdqO4bU3tDflbLeBRRnT0KQrl4AM+uV9G4zszjMfjPwIMHfyKVm\n9itJBxOM9d8lbQzsNyhM0kaEQF8HECJt/kbStvH6hcDFwL7AHqE4agd2Ac6K6e8jxBFZHfgDwSXx\nAoIzmfUkvQZcB4wD9pL085jHewjTKTtL2gr4LrAJsCgJH9pT+vn1wQnShUDyowx0A+sZfEvSacAU\noE3SEjP7SgnfW115QRqzTnC9DIDByUnrfgzCtrDRQNMMfAwuM2AjxB2h4zi1QdLXAZlZTefMB+fg\n20mNbwv+PN4mEQwspaRvBgrpKjXC5Yas6vFzcOsxhGh9N5jZnNgzvofgB+RQYDcz65J0AvBRoIuQ\nryuBfc3sKUJArluBo4DbCD3yKcBGZvZjSWcSFjMeDxxiZndIOh6YOpgXSW3A+sCpwC3AptHp2BIz\nOzPO458CXB/1LyQM77MO3Ps0ye5z6H/1BPq3Bt4Vde8QZX9O0lSCq/F9o8p5kqY1y3lZWqktgY/P\noOMG4O2gPMN9XUA9aKiBl9QB/JDwMAMMSOohvGXOzfRR7zhOy1LU1aqkPQhGK5uNCTt8hjA4B5+y\n7ifJClKS6VClWHr0gV5OkJNHCLsDbho8EbcHvgrsDtwAEI15Og6Td9jK3uUDhBeBBYTYH4sJBvmp\neN89kr4AfB24hDAE/7SkXYC3zOyfkt4R8wFhLcAHBvNiZgOSPgEcAZwD/A7IjGrWSxgdOBpYRBj2\nb58AnXNo3xL4ybfo/0tPGGVYG3goQ/ZvJe0NrEHo3QP8G5gJNNTAh3jqqZMEEwbQxSfTd/tI2rNe\nDxo9B+/R5BxnlGNmyy3Dl3eeaxaa2e7ZH+B/CEPUQ2jiPvjLgCMkrQZhLpzgFKyLYNx3jeenAIOG\nuD/+D7AbK2ODX0IwtmdkrZDfB/izmb0buAh4HDjRzL4d0xcB743Hq/gsiSMH+5rZgYTRhoMldQKD\nowwfIAw67D45vFSNA9r7YeCr9M9NWs9lPTDoPe82YOsot0PSfOBOwvqKA83sAOBJVsYaaRidJGfA\nwLyE9RyYsu75I83jXz1o9BC9R5NznFGCpG8SerC5uMjMfldLfc3yRW9m90r6IbBAUhdhcdyJZvas\npMXAPtEQrg98Mc7Nnwj8IQ6fdwHHEWJ0YGZPSToP+DFwSFTzIHCupFcIAboONrN0Rja+CVwp6SAg\nTYgUOJi/LgWuJQxWXGhm3ZKeiG3vQcCx/yHdlgz3PgWssyIcrzKqGkOIXyjpOkJP/2Ize13Sb4Hr\n44jsM9Eled14VRo/ieS+S0hfOd3sLYCk9fy9njpHIlo5VdQAZdJ2hG0bOaPJVTJnI+mXhHIcUvRi\nxxmmxHnpJ83sT83OS62QNJ2wmOvHhGHoTF61CryDSfosob7/NjvtiiuumNVsd7WSJuQKqR170d2W\n1eBKGmfRQJUof6KZvVkgvdPyOJaJ654ypwaQlEqT2AZ05AsM/Ev0HV+KY5o43YqZ9WWcawMSFl28\n1oMXpDHTSRwg9BHQLQl6Tsv+TkcCjarvDe3BezQ5xxk9mNnLkg4Avm9mF9VbX7ONO0Au4x7Pd+U5\nX7Jxj9fnNe4xPa9xjiOnq/TIl8FE0JfATlvfeu/Lc2suWX05zg0QtvDVjekkPgEku0l/frzZqyPO\nsjeYhq+irzSanEJYyy/kSJpFXIziOM7wwsz+TsYWsHoyGuLB14I5Utvg/HQ3dE8g/YXh2gt+U5qS\nGWf9RXr/MNOseyREoRsODIt98CVum3kc+GmO8y8BLeE32HGcymn1ePC1oFfJrY+hYw3Cin2mmi0b\njpY9rog/cAzJncmIRDcS/NoPJ4bLPvii22bi0NeQfYySniXDm5PjOMMTSScDj5rZhfWQ32xf9MOZ\nxdLYNUgeCdqml96jah7Kr4b0qHPPsSQPNQauXUrvIVOL3+LkYVjtg29kXhzHaS2Gwxz8cGUqybMN\nu+9Jeg/abNXV98ORtmWkD5psttSNe3X4PnjHcRrFI9Rxf3Qrx4OvFoO5CUufMdyM+y1SR7cSe2Se\nS1n3NZPNljYrT61Eq+yDnxY9NdWCDsIq/3rs40wSIkOVvT2oBMZG+W/UQfYkoB8o1XVnOUwlrKGo\nx+rbGQRvWvVweLEWwaVorZhKcBDSstRw33vO+j537ty5kq6okY5ijCd4lGuUIVoHeKHUi3eASXdn\n500lz2TWs76/zefROw4mscXJDCw7Sfpz8TtqwhRgBSESX71pI/hEWJgjrSH1vRX2wbcTolXVqhEf\nSxhp+EuN5GUyieDr+f46yF4LmEBYjFhrNiI44yi5gSmDrQjPwr+LXVgB7yG45KzHy8PuwIk1lNcD\nzPPYDIUpVN8lHW9mtzUoK+sQGu9GvZTtQW5DMYR2UDuQXumprlzqWd8BSMZ1UzGPJZetBmxJ6Ly9\nVuzCGpAgeP37UY60htT3hhp4CCEICT3k9Vm5D/6y4bIPPrqHvMDM9qmD7C0JASGOqoPsvYGNzey0\nOsg+AlhsZjWP4S3pVII3rJqHD5V0CXB4JQ5VSpB9i5ntVmu5TuU08jeR9F/AdDM7q0H6Glm2utX3\nPPoaWbaTgOvMrO7rNaLr4t+Y2UeLXlwnRsw+eMdxHMdxSqfRi+wcx3Ecx2kAbuAdx3EcpwVxA+84\njuM4LciwcFU7zOgC6rVw5gXg93WS/TDwXJ1kLyRsLakHlwHP1kn2OdTPjXGulbFOc2nkb3IfYRV9\no2hk2epZ33PRyLJdReNi1a8g7BprGg1fRe84juM4Tv3xIXrHcRzHaUHcwDuO4zhOC+IG3nEcx3Fa\nEDfwjuM4jtOCuIF3HMdxnBbEDbzjOI7jtCCj3sBLmiBpbJ60NkmdGZ+yv68of1wB+WuUKzPj/mkx\nulb2+Y7MfJcpM5lxbzLPNWMlTaggv5nf5RAfDKXoLiJ/RpH0KZISFchtlzStQHrBcjm1p5S6I2m6\nVHqM1CKyij47MZBWLXSVUrbVa6EryipYtkJtZAW6Smo7avhd5n0Gqm1vcsgrWLZi7Ug9GNUGXtL3\ngQuBGyX9d45L9ieEg7w9fmaXKT9BcBrx4RxpOwIPAJdIuqTchkjSesATQK6G4Iwo+3bg9nwvGHm4\nn5Xl/U0OvYcBC4A7JX2ljPxOB17KkJ0rol5B3QVkT5F0M3C6pLskbZLjmnnARcDjkmaVIXs74C7g\nTEkLshvCEsvl1JBidUfSJEl/Bc4FHqi2US3l2YnPyUPV6IlyipVto/isnyXpJkmbV6mvYNlKaCPL\n0VVS2yFpX+DmKnWV8gxU1N7k0VewbMXakbphZqPyQ4jNflE8Hg88n+OaHwAfq0LHSYRK/8kcabcD\n68XjC4D/LENuG/Angge4GTnS7wCmVJDfscADBdJXI3jME8EL4t+ASSXK/iDws0p1F5E9B/hyPN4R\nOCCH7nPj8YbAX8qQvRDYNB4fDGxTTrn8U/tPsboT6+2B8fgLwMlV6Cr67EQddwGvNKBsPwb2jsd7\nAr+qV9lKaSPL0FVS2wHMAG4CHqvyeyz4DFTT3lRStmLtSL0+o7YHb2ZLzewz8c3ua8Cfc1y2NbC9\npPMlfagc+fFteDpwbZ5LVjezQdeyfwG2K0P80cClwOIcetuAdYGjJJ2pEIO+VLYEuiSdJen42DvN\nZGPgIQv0AYuATUuUvTUwJX6XX8gxdVBMdyF2BV5UiC2/OqFHkslWhJcezOwpYO1ShCpMf6wLbCBp\nLnC/mT1QZrmc2lOs7rz9e+dJL4dSnp2HCaN7tXDvWrBsZvYNM5sf/90A6K1CV8GyldhGlkqpbcfZ\nwNer0DNIsWegmvYmm4JlK7EdqQuj1sBnsAvwHuCVHMPk/wRuJbw1nyhpp1IESpoIfJ88D2pM78s4\ntYzwFliK7G2BrcxsXp5LphAq4qUEv8tXSSrVZ3YK+Cvwv8DrwPlZ6TOApZXkG1hO6OWcCOwMfLVM\n3YWYAXye8DL1ecIbe6F895ZoiNcA1gT2AG4ELpC0UdY1xcrl1JAS607m713OM5qLos+Omd1jZtUY\nWqC8dkHS+4HDgO9VobLUelGojaxU15CySTqS0NN9rEId+fTl+h6raW8K6cqlr5R2pC6MegNvZpeb\n2Z7AtsD2WWlfNrPrzexh4JfAfiWK/Q4haM23gPcC+2fNCy8DMivSROBfJcr+ObBE0vcIb4VHS0pl\n5Pk1M/u0mT1iZjcShvz2KEWwmd1mZl83s+fM7Gxgk9joDPJ6zGvZ+Tazs8zsDDN7BjiFrO+yBN2F\neAP4kZndDHwX+ERWena++82suwS5SwEDjjGzBcAvgI+XUy6n5pRSdzJ/73LqVi4qfXYqoaR2QdKH\ngVOBD5rZS1XoK6lshdrIKnStUjZJU4DjCaOeJwBTq5zzL/gMVNneFNKVS1/RdqRejFoDL+kdkm7J\nODWOjChDCitZb5c0NZ4aXCRRChcRItL9FXgReApYMphoYSLmJUkbxFO7AQ+WKPsYYH6UvZywUKQ/\nq1w3xmMRhqruLUWwpE9IOjkezwCWmtmbGZc8AmylsPo0BWwO/KNE2T+TtGf8d8h3WYLuQtwFDL4R\nbwy8nJV+N+E7RtKmlP5S0gU8zcqhyyGyi5XLqS0l1p23f+886eVQ0bNTCaWUTdIHgW8D7zezaqOi\nFSxbsTayTIq1HV3A54A7Y766CEPdlVLwGaiyvcmmYNlKaUfqRiMm+ofrhzCsOh/4/8DX4rlPAr+L\nx/sRFnwsBK4GOivQ8QPiIrss2TtEvbcCZ1aY/zuJi+wIPfsvxePvA9cQHurvliEvBVxOGNp/Atgr\nh+wDCcNM9wKfLUP2psANhMWBDwAbxPOPEh74nLpLlD0DuCXeez+wfqbseHwqcD1h0eO7ypA9K5b1\n2pj3VNT3r0Ll8k/9PrnqTtZvMg34Q/xdbgXGValvyLOTWScyrnu2AWX7GyHs9KPxc2E9y0aONrIK\nXUPajsyyZVyXovpFdjmfgVq0N2WULbO9H9KO1Ko+FPqM+nCx8Y2rz8z6C1wzwczqEldc0hgLb3i1\nlpskhAPuqeDe8cAKMxvIk94RZZc97yhpohV4Uy6mu4js1czsjQLpFX3XcSRkQpF8FyyXU3uK/Z61\nrFv1qqfDQV8J32PRNrIMXRW3HRXqK1a2itubHLIKlq2UdqTWjHoD7ziO4zityKidg3ccx3GcVsYN\nvOM4juO0IG7gHcdxHKcFcQPvOI7jOC2IG3jHcRzHaUHcwDuO4zhOC+IG3nEcx3FaEDfwjuM4jtOC\nuIF3HMdxnBbEDbzjOI7jtCBu4B3HcRynBXED7ziO4zgtiBt4x3Ecx2lB3MA7juM4TgvS0ewMOJUh\naRowLuv088AkQnzjimJJx5jFa5nZixXePxVYbmbdldzvOE55SOoEJprZK83OizO88B78yOUXwB+A\nszI+qwNfA3aUNF3SKQCSdpV0YIlyxwPXVpGvHwKzqrjfcZzy2AU4u9mZcIYf3oMf2RxrZgszT0g6\nE1hOqPQ7SloT+GBI0gQzWxbf+Gea2WMZ96WArYF/ZiuRNAN4y8yWxf/fCTwHCNgC6AQeyhw1kDQJ\nSJrZq5Laor5/xLRc+tcFZgJ/M7Ml1X4xjuMMrWv56rKZ9UvaCHjRzFbEtDWBHuAdwEOEEcMtgRXA\nw2Zm8br14nVpoN/Mlsbzq8hzGo8b+JHNpDgkDtBtZsuB7wJ/At4DrAPsCGxHMMbrSNoW+CTwTKyA\nHwMmAjcCNwPb5NDzAWBz4NvRcF9NeBm4GbiH0OvfWdJWGfd8GPgP4HhCw3A1sKWkz+TQ/9543U3A\nzyXta2ZPVfvlOM5oJk9dy1WXt5d0FfAMsKGki83sfGAO4QX+deA44DzgOmAH4CngMEnHAXsATwDb\nAz+TdDFwaQ55ToNxAz+ymQO8EY/nA/+bkXYpsIWZXSXpHYDM7FFJ5wKfAZYBhwN7AZsBvzezUyTt\nApyZpecy4BhJxwL7E6YGxgGnANcDGwALgckl5PnwHPpnAk8C5wPzAO/BO0715KpruerynsDjhOm1\nDkLbMWiQzzezc+ILwiHAIsLo4E8lJYGvAGuaWZ+kP8Z7CslzGogb+JHNV7OH6AshaQLBmH8/4/Sz\nwHqEXj/AA9n3mdkKSXcAuxIajIOA3vj3aEKlF9CeR3VbEf1nAF8HLokyDgT+XWq5HMdZlXx1LU9d\n/gqhV/6TeN1z8X4I9XOQUwn1fhGhnk4lDO/3xfRF8e+sXPIGpwWcxuGL7FqXflYa3H6gPVawR4Cj\nzewAQq//OeBhwjA5hCH9XJxHMMI9ZvY8YajPzGx34DuEHn2mge8CpsXjLQkX59O/D/BnM3s3cBHw\nqSrK7TijngJ1DYbW5RsJa18OAA4FFgNvxWsH4t/DgIvN7EPAVYT25F9Ae1zQ2wG8L15bSJ7TQLwH\n37o8T5jzPg64FbhQ0uPAicC5kroIi+P2B+4ErpR0PfAYYNnCzOyOOEw3J566FThW0oVAijAnt07G\nLTcDJ0i6BngVGNw2l0v/WvHcK8C6wME1+QYcZ/TwAUmPZvy/L7nrWq66fCPw0TjEPh74rZkNhB2z\nb3MFcKqk2YTFdB3RqB8O/DKee4vwYp9TXh3K7BRBcSGk04LE1evtZtYrKUFY4ToQ08Zmr26VNKbc\n/fOSJg2umi0nPY/+iWb2Zjn6HccpTK66lue6TkKvPqdRiO3J2LiYd/DcocA5ZmaSLgN+YGb3lSLP\nqT/eg29hojEfiMe9WWlDKnwlznEKGfdC6Xn0u3F3nBpT6ja1Ys6pYnuyPOt0J3BtdJD1HBlreNzZ\nVfPxHrzjOI5TMZLaCSOF6WbnxVkVN/CO4ziO04L4KnrHcRzHaUHcwDuO4zhOC+IG3nEcx3FaEDfw\njuM4jtOCuIF3HMdxnBbEDbzjOI7jtCBu4B3HcRynBXED7ziO4zgtiBt4x3Ecx2lB3MA7juM4Tgvi\nBt5xHMdxWpD/A0slJdgNEt3KAAAAAElFTkSuQmCC\n"
       }
      ],
-     "prompt_number": 16
+     "prompt_number": 43
     },
     {
      "cell_type": "heading",
@@ -576,7 +656,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 17
+     "prompt_number": 44
     },
     {
      "cell_type": "code",
@@ -584,7 +664,7 @@
      "input": [
       "%%R -i seq1 -o seq2\n",
       "seq2 = rep(seq1, 2)\n",
-      "print(seq2)"
+      "seq2"
      ],
      "language": "python",
      "metadata": {},
@@ -592,11 +672,20 @@
       {
        "output_type": "display_data",
        "text": [
-        " [1] 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9\n"
+        "    seq2 = rep(seq1, 2)\n",
+        "    seq2\n",
+        "\u0000"
+       ]
+      },
+      {
+       "output_type": "display_data",
+       "text": [
+        "    ##  [1] 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9\n",
+        "\u0000"
        ]
       }
      ],
-     "prompt_number": 18
+     "prompt_number": 45
     },
     {
      "cell_type": "code",
@@ -610,20 +699,20 @@
      "outputs": [
       {
        "output_type": "pyout",
-       "prompt_number": 19,
+       "prompt_number": 46,
        "text": [
         "array([0, 1, 0, 3, 0, 5, 0, 7, 0, 9, 0, 1, 0, 3, 0, 5, 0, 7, 0, 9], dtype=int32)"
        ]
       }
      ],
-     "prompt_number": 19
+     "prompt_number": 46
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
       "%%R\n",
-      "print(seq2)"
+      "seq2"
      ],
      "language": "python",
      "metadata": {},
@@ -631,17 +720,25 @@
       {
        "output_type": "display_data",
        "text": [
-        " [1] 0 1 0 3 0 5 0 7 0 9 0 1 0 3 0 5 0 7 0 9\n"
+        "    seq2\n",
+        "\u0000"
+       ]
+      },
+      {
+       "output_type": "display_data",
+       "text": [
+        "    ##  [1] 0 1 0 3 0 5 0 7 0 9 0 1 0 3 0 5 0 7 0 9\n",
+        "\u0000"
        ]
       }
      ],
-     "prompt_number": 20
+     "prompt_number": 47
     },
     {
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Once the array data has been passed to R, modifring its contents does not modify R's copy of the data."
+      "Once the array data has been passed to R, modifying its contents does not modify R's copy of the data."
      ]
     },
     {
@@ -649,7 +746,7 @@
      "collapsed": false,
      "input": [
       "seq1[0] = 200\n",
-      "%R print(seq1)"
+      "%R seq1"
      ],
      "language": "python",
      "metadata": {},
@@ -657,11 +754,19 @@
       {
        "output_type": "display_data",
        "text": [
-        " [1] 0 1 2 3 4 5 6 7 8 9\n"
+        "    seq1\n",
+        "\u0000"
+       ]
+      },
+      {
+       "output_type": "display_data",
+       "text": [
+        "    ##  [1] 0 1 2 3 4 5 6 7 8 9\n",
+        "\u0000"
        ]
       }
      ],
-     "prompt_number": 21
+     "prompt_number": 48
     },
     {
      "cell_type": "markdown",
@@ -679,8 +784,8 @@
       "%R -i seq1 -o seq1\n",
       "print seq1\n",
       "seq1[0] = 200\n",
-      "%R print(seq1)\n",
-      "seq1_view = %R seq1\n",
+      "%R seq1\n",
+      "seq1_view = %Rget seq1\n",
       "assert(id(seq1_view.data) == id(seq1.data))"
      ],
      "language": "python",
@@ -697,11 +802,19 @@
       {
        "output_type": "display_data",
        "text": [
-        " [1] 200   1   2   3   4   5   6   7   8   9\n"
+        "    seq1\n",
+        "\u0000"
+       ]
+      },
+      {
+       "output_type": "display_data",
+       "text": [
+        "    ##  [1] 200   1   2   3   4   5   6   7   8   9\n",
+        "\u0000"
        ]
       }
      ],
-     "prompt_number": 22
+     "prompt_number": 49
     },
     {
      "cell_type": "heading",
@@ -715,17 +828,37 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Exceptions are handled by passing back rpy2's exception and the line that triggered it."
+      "Exceptions are from `%R`, usually with `R`'s error message. This is the case unless handled a --ingore_errors flag is passed to `%R` in which case it prints `R`'s error message to `stderr`."
      ]
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
+      "%R nosuchvar --ingore_errors"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stderr",
+       "text": [
+        "R error message:     ## Error: object 'nosuchvar' not found\n",
+        "\u0000"
+       ]
+      }
+     ],
+     "prompt_number": 50
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
       "try:\n",
-      "    %R -n nosuchvar\n",
+      "    %R nosuchvar\n",
       "except Exception as e:\n",
-      "    print e.message\n",
+      "    print unicode(e)\n",
       "    pass"
      ],
      "language": "python",
@@ -735,16 +868,12 @@
        "output_type": "stream",
        "stream": "stdout",
        "text": [
-        "parsing and evaluating line \"nosuchvar\".\n",
-        "R error message: \"Error in eval(expr, envir, enclos) : object 'nosuchvar' not found\n",
-        "\"\n",
-        " R stdout:\"Error in eval(expr, envir, enclos) : object 'nosuchvar' not found\n",
-        "\"\n",
-        "\n"
+        "R error message:     ## Error: object 'nosuchvar' not found\n",
+        "\u0000\n"
        ]
       }
      ],
-     "prompt_number": 23
+     "prompt_number": 51
     },
     {
      "cell_type": "heading",
@@ -758,7 +887,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "In R, data frames play an important role as they allow array-like objects of mixed type with column names (and row names). In bumpy, the closest analogy is a structured array with named fields. In future work, it would be nice to use pandas to return full-fledged DataFrames from rpy2. In the mean time, structured arrays can be passed back and forth with the -d flag to %R, %Rpull, and %Rget"
+      "In R, data frames play an important role as they allow array-like objects of mixed type with column names (and row names). In numpy, the closest analogy is a structured array with named fields. In future work, it would be nice to use pandas to return full-fledged DataFrames from rpy2. In the mean time, structured arrays can be passed back and forth with the -d flag to %R, %Rpull, and %Rget"
      ]
     },
     {
@@ -771,7 +900,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 24
+     "prompt_number": 52
     },
     {
      "cell_type": "code",
@@ -782,8 +911,16 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [],
-     "prompt_number": 25
+     "outputs": [
+      {
+       "output_type": "display_data",
+       "text": [
+        "    datar = datapy\n",
+        "\u0000"
+       ]
+      }
+     ],
+     "prompt_number": 53
     },
     {
      "cell_type": "code",
@@ -796,14 +933,14 @@
      "outputs": [
       {
        "output_type": "pyout",
-       "prompt_number": 26,
+       "prompt_number": 54,
        "text": [
         "array([(1, 2.9, 'a'), (2, 3.5, 'b'), (3, 2.1, 'c')], \n",
         "      dtype=[('x', '<i4'), ('y', '<f8'), ('z', '|S1')])"
        ]
       }
      ],
-     "prompt_number": 26
+     "prompt_number": 54
     },
     {
      "cell_type": "code",
@@ -817,15 +954,22 @@
      "metadata": {},
      "outputs": [
       {
+       "output_type": "display_data",
+       "text": [
+        "    datar2 = datapy\n",
+        "\u0000"
+       ]
+      },
+      {
        "output_type": "pyout",
-       "prompt_number": 27,
+       "prompt_number": 55,
        "text": [
         "array([(1, 2.9, 'a'), (2, 3.5, 'b'), (3, 2.1, 'c')], \n",
         "      dtype=[('x', '<i4'), ('y', '<f8'), ('z', '|S1')])"
        ]
       }
      ],
-     "prompt_number": 27
+     "prompt_number": 55
     },
     {
      "cell_type": "code",
@@ -838,14 +982,14 @@
      "outputs": [
       {
        "output_type": "pyout",
-       "prompt_number": 28,
+       "prompt_number": 56,
        "text": [
         "array([(1, 2.9, 'a'), (2, 3.5, 'b'), (3, 2.1, 'c')], \n",
         "      dtype=[('x', '<i4'), ('y', '<f8'), ('z', '|S1')])"
        ]
       }
      ],
-     "prompt_number": 28
+     "prompt_number": 56
     },
     {
      "cell_type": "markdown",
@@ -867,13 +1011,13 @@
      "outputs": [
       {
        "output_type": "pyout",
-       "prompt_number": 29,
+       "prompt_number": 57,
        "text": [
         "array([0, 1, 2, 3, 4, 5], dtype=int32)"
        ]
       }
      ],
-     "prompt_number": 29
+     "prompt_number": 57
     },
     {
      "cell_type": "markdown",
@@ -894,7 +1038,7 @@
      "outputs": [
       {
        "output_type": "pyout",
-       "prompt_number": 30,
+       "prompt_number": 58,
        "text": [
         "array([['1', '2', '3'],\n",
         "       ['2', '3', '2'],\n",
@@ -903,16 +1047,7 @@
        ]
       }
      ],
-     "prompt_number": 30
-    },
-    {
-     "cell_type": "code",
-     "collapsed": true,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 30
+     "prompt_number": 58
     }
    ],
    "metadata": {}


### PR DESCRIPTION
This is a rewrite of the %R magic to produce output that is more like with [knitr](http://yihui.name/knitr/) output.
- R's help can now be accessed in any cell / line that begins with "help" or "?" with an attempt to produce
  stderr when R cannot find help.
- Instead of python exceptions, R's stderr is published.
- The R magic no longer returns anything, but objects can be accessed through -o, -d options, and passed to R through the -i options.
- Wishlist item: if ipython had a markdown mime valid for publish_display_data, then some cells could be passed and returned as markdown through knitr.
- Also, see https://github.com/jonathan-taylor/ipython/pull/new/Ronly for a dedicated R notebook which just passes every cell through the R magic -- only 1 line of code is changed...
- It could be run through a pipe rather than rpy2...
