### PR TITLE
clear In[ ] prompt numbers again

### DIFF
--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -247,9 +247,7 @@ var IPython = (function (IPython) {
         if( this.code_mirror != undefined) {
            nline = this.code_mirror.lineCount();
         }
-        if (number){
-            this.input_prompt_number = number;
-        }
+        this.input_prompt_number = number;
         var prompt_html = CodeCell.input_prompt_function(this.input_prompt_number, nline);
         this.element.find('div.input_prompt').html(prompt_html);
     };


### PR DESCRIPTION
this stopped worked in trunk recently, which makes for an annoyance when version controling notebooks, where clearing output used to also clear the In[] prompt numbers.

This is a simple fix, but I just wanted to ping @Carreau, since he was the last to make changes here, to make sure I haven't overlooked some case where this won't work.
