### PR TITLE
Add event to kernel execution/shell reply.

### DIFF
--- a/IPython/frontend/html/notebook/static/js/kernel.js
+++ b/IPython/frontend/html/notebook/static/js/kernel.js
@@ -245,7 +245,8 @@ var IPython = (function (IPython) {
             user_expressions : {},
             allow_stdin : false
         };
-		$.extend(true, content, options)
+        $.extend(true, content, options)
+        $([IPython.events]).trigger({type: 'Kernel.execution_request', kernel: this, content:content});
         var msg = this._get_msg("execute_request", content);
         this.shell_channel.send(JSON.stringify(msg));
         this.set_callbacks_for_msg(msg.header.msg_id, callbacks);
@@ -312,6 +313,7 @@ var IPython = (function (IPython) {
 
     Kernel.prototype._handle_shell_reply = function (e) {
         reply = $.parseJSON(e.data);
+        $([IPython.events]).trigger({type: 'Kernel.shell_reply', kernel: this, reply:reply});
         var header = reply.header;
         var content = reply.content;
         var metadata = reply.metadata;

--- a/IPython/frontend/html/notebook/static/js/kernel.js
+++ b/IPython/frontend/html/notebook/static/js/kernel.js
@@ -64,7 +64,7 @@ var IPython = (function (IPython) {
 
 
     Kernel.prototype.restart = function () {
-        $([IPython.events]).trigger({type: 'status_restarting.Kernel', kernel: this});
+        $([IPython.events]).trigger('status_restarting.Kernel', {kernel: this});
         var that = this;
         if (this.running) {
             this.stop_channels();
@@ -246,7 +246,7 @@ var IPython = (function (IPython) {
             allow_stdin : false
         };
         $.extend(true, content, options)
-        $([IPython.events]).trigger({type: 'execution_request.Kernel', kernel: this, content:content});
+        $([IPython.events]).trigger('execution_request.Kernel', {kernel: this, content:content});
         var msg = this._get_msg("execute_request", content);
         this.shell_channel.send(JSON.stringify(msg));
         this.set_callbacks_for_msg(msg.header.msg_id, callbacks);
@@ -280,7 +280,7 @@ var IPython = (function (IPython) {
 
     Kernel.prototype.interrupt = function () {
         if (this.running) {
-            $([IPython.events]).trigger({type: 'status_interrupting.Kernel', kernel: this});
+            $([IPython.events]).trigger('status_interrupting.Kernel', {kernel: this});
             $.post(this.kernel_url + "/interrupt");
         };
     };
@@ -313,7 +313,7 @@ var IPython = (function (IPython) {
 
     Kernel.prototype._handle_shell_reply = function (e) {
         reply = $.parseJSON(e.data);
-        $([IPython.events]).trigger({type: 'shell_reply.Kernel', kernel: this, reply:reply});
+        $([IPython.events]).trigger('shell_reply.Kernel', {kernel: this, reply:reply});
         var header = reply.header;
         var content = reply.content;
         var metadata = reply.metadata;
@@ -369,12 +369,12 @@ var IPython = (function (IPython) {
             }
         } else if (msg_type === 'status') {
             if (content.execution_state === 'busy') {
-                $([IPython.events]).trigger({type: 'status_busy.Kernel', kernel: this});
+                $([IPython.events]).trigger('status_busy.Kernel', {kernel: this});
             } else if (content.execution_state === 'idle') {
-                $([IPython.events]).trigger({type: 'status_idle.Kernel', kernel: this});
+                $([IPython.events]).trigger('status_idle.Kernel', {kernel: this});
             } else if (content.execution_state === 'dead') {
                 this.stop_channels();
-                $([IPython.events]).trigger({type: 'status_dead.Kernel', kernel: this});
+                $([IPython.events]).trigger('status_dead.Kernel', {kernel: this});
             };
         } else if (msg_type === 'clear_output') {
             var cb = callbacks['clear_output'];

--- a/IPython/frontend/html/notebook/static/js/kernel.js
+++ b/IPython/frontend/html/notebook/static/js/kernel.js
@@ -86,6 +86,7 @@ var IPython = (function (IPython) {
         this.start_channels();
         this.shell_channel.onmessage = $.proxy(this._handle_shell_reply,this);
         this.iopub_channel.onmessage = $.proxy(this._handle_iopub_reply,this);
+        $([IPython.events]).trigger('status_started.Kernel', {kernel: this});
     };
 
 

--- a/IPython/frontend/html/notebook/static/js/kernel.js
+++ b/IPython/frontend/html/notebook/static/js/kernel.js
@@ -246,7 +246,7 @@ var IPython = (function (IPython) {
             allow_stdin : false
         };
         $.extend(true, content, options)
-        $([IPython.events]).trigger({type: 'Kernel.execution_request', kernel: this, content:content});
+        $([IPython.events]).trigger({type: 'execution_request.Kernel', kernel: this, content:content});
         var msg = this._get_msg("execute_request", content);
         this.shell_channel.send(JSON.stringify(msg));
         this.set_callbacks_for_msg(msg.header.msg_id, callbacks);
@@ -313,7 +313,7 @@ var IPython = (function (IPython) {
 
     Kernel.prototype._handle_shell_reply = function (e) {
         reply = $.parseJSON(e.data);
-        $([IPython.events]).trigger({type: 'Kernel.shell_reply', kernel: this, reply:reply});
+        $([IPython.events]).trigger({type: 'shell_reply.Kernel', kernel: this, reply:reply});
         var header = reply.header;
         var content = reply.content;
         var metadata = reply.metadata;


### PR DESCRIPTION
This should allow to hook more easily phantomjs for testing.

(also convert tabs to space).

Main goal is to be able to know when all cell have been executed when testing with phantomJS.
