### PR TITLE
Adding time offsets to the video

### DIFF
--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -2,6 +2,7 @@
 
 Authors : MinRK
 """
+from datetime import timedelta, datetime
 
 class YouTubeVideo(object):
     """Class for embedding a YouTube Video in an IPython session, based on its video id.
@@ -14,12 +15,18 @@ class YouTubeVideo(object):
 
     vid = YouTubeVideo("foo")
     display(vid)
+    
+    To start from a particular time offset:
+    
+    vid = YouTubeVideo("abc", start=timedelta(hours=1, minutes=47, seconds=3))
+    display(vid)
     """
 
-    def __init__(self, id, width=400, height=300):
+    def __init__(self, id, width=400, height=300, start=timedelta()):
         self.id = id
         self.width = width
         self.height = height
+        self.start = start.total_seconds()
 
     def _repr_html_(self):
         """return YouTube embed iframe for this video id"""
@@ -27,9 +34,9 @@ class YouTubeVideo(object):
             <iframe
                 width="%i"
                 height="%i"
-                src="http://www.youtube.com/embed/%s"
+                src="http://www.youtube.com/embed/%s?start=%i"
                 frameborder="0"
                 allowfullscreen
             ></iframe>
-        """%(self.width, self.height, self.id)
+        """%(self.width, self.height, self.id, self.start)
 

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -21,6 +21,8 @@ class YouTubeVideo(object):
     vid = YouTubeVideo("abc", start=30)
     display(vid)
     
+    To calculate seconds from time as hours, minutes, seconds use int(timedelta(hours=1, minutes=46, seconds=40).total_seconds())
+
     Other parameters can be provided as documented at 
     https://developers.google.com/youtube/player_parameters#parameter-subheader
     """
@@ -29,7 +31,7 @@ class YouTubeVideo(object):
         self.id = id
         self.width = width
         self.height = height
-        self.params = **kwargs
+        self.params = kwargs
 
     def _repr_html_(self):
         """return YouTube embed iframe for this video id"""
@@ -45,5 +47,4 @@ class YouTubeVideo(object):
                 frameborder="0"
                 allowfullscreen
             ></iframe>
-        """%(self.width, self.height, self.id, self.start, params)
-
+        """%(self.width, self.height, self.id, params)

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -2,7 +2,7 @@
 
 Authors : MinRK
 """
-from datetime import timedelta
+import urllib
 
 class YouTubeVideo(object):
     """Class for embedding a YouTube Video in an IPython session, based on its video id.
@@ -16,27 +16,34 @@ class YouTubeVideo(object):
     vid = YouTubeVideo("foo")
     display(vid)
     
-    To start from a particular time offset:
+    To start from 30 seconds:
     
-    vid = YouTubeVideo("abc", start=timedelta(hours=1, minutes=47, seconds=3))
+    vid = YouTubeVideo("abc", start=30)
     display(vid)
+    
+    Other parameters can be provided as documented at 
+    https://developers.google.com/youtube/player_parameters#parameter-subheader
     """
 
-    def __init__(self, id, width=400, height=300, start=timedelta()):
+    def __init__(self, id, width=400, height=300, **kwargs):
         self.id = id
         self.width = width
         self.height = height
-        self.start = start.total_seconds()
+        self.params = **kwargs
 
     def _repr_html_(self):
         """return YouTube embed iframe for this video id"""
+        if self.params:
+            params = "?" + urllib.urlencode(self.params)
+        else:
+            params = ""
         return """
             <iframe
                 width="%i"
                 height="%i"
-                src="http://www.youtube.com/embed/%s?start=%i"
+                src="http://www.youtube.com/embed/%s%s"
                 frameborder="0"
                 allowfullscreen
             ></iframe>
-        """%(self.width, self.height, self.id, self.start)
+        """%(self.width, self.height, self.id, self.start, params)
 

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -2,7 +2,7 @@
 
 Authors : MinRK
 """
-from datetime import timedelta, datetime
+from datetime import timedelta
 
 class YouTubeVideo(object):
     """Class for embedding a YouTube Video in an IPython session, based on its video id.

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -21,7 +21,8 @@ class YouTubeVideo(object):
     vid = YouTubeVideo("abc", start=30)
     display(vid)
     
-    To calculate seconds from time as hours, minutes, seconds use int(timedelta(hours=1, minutes=46, seconds=40).total_seconds())
+    To calculate seconds from time as hours, minutes, seconds use:
+    start=int(timedelta(hours=1, minutes=46, seconds=40).total_seconds())
 
     Other parameters can be provided as documented at 
     https://developers.google.com/youtube/player_parameters#parameter-subheader

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -1,6 +1,6 @@
 """Various display related classes.
 
-Authors : MinRK
+Authors : MinRK, dannystaple
 """
 import urllib
 

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -48,4 +48,4 @@ class YouTubeVideo(object):
                 frameborder="0"
                 allowfullscreen
             ></iframe>
-        """%(self.width, self.height, self.id, params)
+        """ % (self.width, self.height, self.id, params)


### PR DESCRIPTION
These changes allow a youtube video to be embedded with a start time offset.

This is based on the suggestions here - http://stackoverflow.com/questions/13119791/can-the-ipython-notebook-youtubevideo-class-play-from-time-offset.
