### PR TITLE
Do not unescape backslashes in Windows (shellglob)

### DIFF
--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -373,8 +373,11 @@ def shellglob(args):
 
     """
     expanded = []
+    # Do not unescape backslash in Windows as it is interpreted as
+    # path separator:
+    unescape = unescape_glob if sys.platform != 'win32' else lambda x: x
     for a in args:
-        expanded.extend(glob.glob(a) or [unescape_glob(a)])
+        expanded.extend(glob.glob(a) or [unescape(a)])
     return expanded
 
 


### PR DESCRIPTION
hopefully finally fixes #2477

https://github.com/ipython/ipython/issues/2477#issuecomment-9910112

not tested on windows
