### PR TITLE
Enable cell magic functions in .ipy scripts (perhaps by splitting scripts into multiple cells)

### DIFF
--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -845,7 +845,6 @@ class IPythonInputSplitter(InputSplitter):
         this value is also stored as a private attribute (_is_complete), so it
         can be queried at any time.
         """
-
         if not lines:
             return super(IPythonInputSplitter, self).push(lines)
 

--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -846,7 +846,6 @@ class IPythonInputSplitter(InputSplitter):
         can be queried at any time.
         """
 
-        print 'ROBERT self.input_mode (inputsplitter)= %s' % self.input_mode
         if not lines:
             return super(IPythonInputSplitter, self).push(lines)
 

--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -845,6 +845,8 @@ class IPythonInputSplitter(InputSplitter):
         this value is also stored as a private attribute (_is_complete), so it
         can be queried at any time.
         """
+
+        print 'ROBERT self.input_mode (inputsplitter)= %s' % self.input_mode
         if not lines:
             return super(IPythonInputSplitter, self).push(lines)
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2512,8 +2512,9 @@ class InteractiveShell(SingletonConfigurable):
                         if section != '':
                             if cellsplitter.push(section + '\n\n'):
                                 cells.append(cellsplitter.source_reset())
-                    for cell in cells:    
+                    for cell in cells:
                         self.run_cell(cell, store_history=False)
+                    # self.run_cell(thefile.read(), store_history=False)
             except:
                 self.showtraceback()
                 warn('Unknown failure executing file: <%s>' % fname)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2477,6 +2477,7 @@ class InteractiveShell(SingletonConfigurable):
             The name of the file to execute.  The filename must have a
             .ipy extension.
         """
+        print("ROBERT safe_execfile_ipy interactiveshell.py line 2480%s" % fname)
         fname = os.path.abspath(os.path.expanduser(fname))
 
         # Make sure we can open the file
@@ -2499,7 +2500,11 @@ class InteractiveShell(SingletonConfigurable):
                     # raised in user code.  It would be nice if there were
                     # versions of runlines, execfile that did raise, so
                     # we could catch the errors.
-                    self.run_cell(thefile.read(), store_history=False)
+
+                    # ROBERT MODIFICATION
+                    for cell in thefile.read().split('\n\n'):
+                        self.run_cell(cell, store_history=False)
+                    #self.run_cell(thefile.read(), store_history=False)
             except:
                 self.showtraceback()
                 warn('Unknown failure executing file: <%s>' % fname)


### PR DESCRIPTION
Currently, scripts executed from the command line as a single cell, and cell magic functions are only executed if they are at the very start of the cell. This makes it impossible to have code that intersperses regular python code with cell magics inside of .ipy scripts that are executed from the command line, such as:

``` python
$ cat script.ipy
print "Hello World! (python)"

%%bash
echo "Hello World! (bash)"

print "Hello World! (python)"
```

Which should work like:

```
$ ipython script.ipy
Hello World! (python)
Hello World! (bash)
Hello World! (python)
```

This PR makes this type of code possible, by modifying `IPython.core.InteractiveShell.safe_execfile_ipy()` to split the file into multiple cells before calling `run_cell()`.

**I doubt that this patch is really the _right_ way to solve this issue, but I hope to just get the conversation started.**
