### PR TITLE
Allow starting IPython as `python -m IPython`.

### DIFF
--- a/IPython/__main__.py
+++ b/IPython/__main__.py
@@ -1,0 +1,14 @@
+# encoding: utf-8
+"""Terminal-based IPython entry point.
+"""
+#-----------------------------------------------------------------------------
+#  Copyright (c) 2012, IPython Development Team.
+#
+#  Distributed under the terms of the Modified BSD License.
+#
+#  The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from IPython.frontend.terminal.ipapp import launch_new_instance
+
+launch_new_instance()


### PR DESCRIPTION
Closes #2541.
