### PR TITLE
Infinite loop when multiple debuggers have been attached.

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -59,11 +59,11 @@ else:
 # Allow the set_trace code to operate outside of an ipython instance, even if
 # it does so with some limitations.  The rest of this support is implemented in
 # the Tracer constructor.
-def BdbQuit_excepthook(et,ev,tb):
+def BdbQuit_excepthook(et,ev,tb,orig_hook):
     if et==bdb.BdbQuit:
         print('Exiting Debugger.')
     else:
-        BdbQuit_excepthook.excepthook_ori(et,ev,tb)
+        orig_hook(et,ev,tb)
 
 def BdbQuit_IPython_excepthook(self,et,ev,tb,tb_offset=None):
     print('Exiting Debugger.')
@@ -108,8 +108,8 @@ class Tracer(object):
             ip = get_ipython()
         except NameError:
             # Outside of ipython, we set our own exception hook manually
-            BdbQuit_excepthook.excepthook_ori = sys.excepthook
-            sys.excepthook = BdbQuit_excepthook
+            sys.excepthook = lambda et, ev, tb, orig_hook=sys.excepthook: \
+              BdbQuit_excepthook(et, ev, tb, orig_hook)
             def_colors = 'NoColor'
             try:
                 # Limited tab completion support
@@ -136,7 +136,7 @@ class Tracer(object):
         except:
             # This is only a user-facing convenience, so any error we encounter
             # here can be warned about but can be otherwise ignored.  These
-            # printouts will tell us about problems if this API changes 
+            # printouts will tell us about problems if this API changes
             import traceback
             traceback.print_exc()
 
@@ -423,7 +423,7 @@ class Pdb(OldPdb):
             src = []
             if filename == "<string>" and hasattr(self, "_exec_filename"):
                 filename = self._exec_filename
-            
+
             for lineno in range(first, last+1):
                 line = ulinecache.getline(filename, lineno)
                 if not line:


### PR DESCRIPTION
Replaces pull-request #2388.

Fixed infinite loop on exit in the event of where multiple debuggers have been attached an there is an uncaught exception.

Test code:

``` python
from IPython.core.debugger import Tracer;
Tracer()
Tracer()
raise Exception
```

Pinging @DamianHeard to review.
