### PR TITLE
Avoid stopping in ipdb until we reach the main script.

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -563,6 +563,11 @@ python-profiler package from non-free.""")
                                 return
                         # if we find a good linenumber, set the breakpoint
                         deb.do_break('%s:%s' % (filename, bp))
+
+                        # Mimic Pdb._runscript(...)
+                        deb._wait_for_mainpyfile = True
+                        deb.mainpyfile = deb.canonic(filename)
+
                         # Start file run
                         print "NOTE: Enter 'c' at the",
                         print "%s prompt to start your script." % deb.prompt


### PR DESCRIPTION
For example:

```
In [1]: %run -d -b 52 setup.py
Breakpoint 1 at /tmp/ipython/setup.py:52
NOTE: Enter 'c' at the ipdb>  prompt to start your script.
> /tmp/ipython/setup.py(7)<module>()
      6 Under Windows, the command sdist is not supported, since IPython
----> 7 requires utilities which are not available under Windows."""
      8
```

compared to the previous behavior:

```
In [1]: %run -d -b 52 setup.py
Breakpoint 1 at /tmp/ipython/setup.py:52
NOTE: Enter 'c' at the ipdb>  prompt to start your script.
> <string>(1)<module>()
```

Closes #1679 ("List command desn't work in ipdb debugger the first time")
