### PR TITLE
Add psource, pfile, pinfo2 commands to ipdb.

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -477,19 +477,25 @@ class Pdb(OldPdb):
     do_l = do_list
 
     def do_pdef(self, arg):
-        """The debugger interface to magic_pdef"""
+        """Print the definition header for any callable object.
+
+        The debugger interface to %pdef"""
         namespaces = [('Locals', self.curframe.f_locals),
                       ('Globals', self.curframe.f_globals)]
         self.shell.find_line_magic('pdef')(arg, namespaces=namespaces)
 
     def do_pdoc(self, arg):
-        """The debugger interface to magic_pdoc"""
+        """Print the docstring for an object.
+
+        The debugger interface to %pdoc."""
         namespaces = [('Locals', self.curframe.f_locals),
                       ('Globals', self.curframe.f_globals)]
         self.shell.find_line_magic('pdoc')(arg, namespaces=namespaces)
 
     def do_pinfo(self, arg):
-        """The debugger equivalant of ?obj"""
+        """Provide detailed information about an object.
+
+        The debugger interface to %pinfo, i.e., obj?."""
         namespaces = [('Locals', self.curframe.f_locals),
                       ('Globals', self.curframe.f_globals)]
         self.shell.find_line_magic('pinfo')("pinfo %s" % arg,

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -492,6 +492,15 @@ class Pdb(OldPdb):
                       ('Globals', self.curframe.f_globals)]
         self.shell.find_line_magic('pdoc')(arg, namespaces=namespaces)
 
+    def do_pfile(self, arg):
+        """Print (or run through pager) the file where an object is defined.
+
+        The debugger interface to %pfile.
+        """
+        namespaces = [('Locals', self.curframe.f_locals),
+                      ('Globals', self.curframe.f_globals)]
+        self.shell.find_line_magic('pfile')(arg, namespaces=namespaces)
+
     def do_pinfo(self, arg):
         """Provide detailed information about an object.
 

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -507,8 +507,15 @@ class Pdb(OldPdb):
         The debugger interface to %pinfo, i.e., obj?."""
         namespaces = [('Locals', self.curframe.f_locals),
                       ('Globals', self.curframe.f_globals)]
-        self.shell.find_line_magic('pinfo')("pinfo %s" % arg,
-                                            namespaces=namespaces)
+        self.shell.find_line_magic('pinfo')(arg, namespaces=namespaces)
+
+    def do_pinfo2(self, arg):
+        """Provide extra detailed information about an object.
+
+        The debugger interface to %pinfo2, i.e., obj??."""
+        namespaces = [('Locals', self.curframe.f_locals),
+                      ('Globals', self.curframe.f_globals)]
+        self.shell.find_line_magic('pinfo2')(arg, namespaces=namespaces)
 
     def do_psource(self, arg):
         """Print (or run through pager) the source code for an object."""

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -477,7 +477,7 @@ class Pdb(OldPdb):
     do_l = do_list
 
     def do_pdef(self, arg):
-        """Print the definition header for any callable object.
+        """Print the call signature for any callable object.
 
         The debugger interface to %pdef"""
         namespaces = [('Locals', self.curframe.f_locals),

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -510,6 +510,12 @@ class Pdb(OldPdb):
         self.shell.find_line_magic('pinfo')("pinfo %s" % arg,
                                             namespaces=namespaces)
 
+    def do_psource(self, arg):
+        """Print (or run through pager) the source code for an object."""
+        namespaces = [('Locals', self.curframe.f_locals),
+                      ('Globals', self.curframe.f_globals)]
+        self.shell.find_line_magic('psource')(arg, namespaces=namespaces)
+
     def checkline(self, filename, lineno):
         """Check whether specified line seems to be executable.
 

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -98,7 +98,7 @@ class NamespaceMagics(Magics):
         self.shell._inspect('psource',parameter_s, namespaces)
 
     @line_magic
-    def pfile(self, parameter_s=''):
+    def pfile(self, parameter_s='', namespaces=None):
         """Print (or run through pager) the file where an object is defined.
 
         The file opens at the line where the object definition begins. IPython
@@ -111,7 +111,7 @@ class NamespaceMagics(Magics):
         viewer."""
 
         # first interpret argument as an object name
-        out = self.shell._inspect('pfile',parameter_s)
+        out = self.shell._inspect('pfile',parameter_s, namespaces)
         # if not, try the input as a filename
         if out == 'not found':
             try:

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -69,7 +69,7 @@ class NamespaceMagics(Magics):
     @skip_doctest
     @line_magic
     def pdef(self, parameter_s='', namespaces=None):
-        """Print the definition header for any callable object.
+        """Print the call signature for any callable object.
 
         If the object is a class, print the constructor information.
 

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -344,7 +344,7 @@ class Inspector:
         self.set_active_scheme(scheme)
 
     def _getdef(self,obj,oname=''):
-        """Return the definition header for any callable object.
+        """Return the call signature for any callable object.
 
         If any exception is generated, None is returned instead and the
         exception is suppressed."""
@@ -373,7 +373,7 @@ class Inspector:
             print()
 
     def pdef(self, obj, oname=''):
-        """Print the definition header for any callable object.
+        """Print the call signature for any callable object.
 
         If the object is a class, print the constructor information."""
 

--- a/docs/source/interactive/reference.txt
+++ b/docs/source/interactive/reference.txt
@@ -337,7 +337,7 @@ this is just a summary:
     * **%pdoc <object>**: Print (or run through a pager if too long) the
       docstring for an object. If the given object is a class, it will
       print both the class and the constructor docstrings.
-    * **%pdef <object>**: Print the definition header for any callable
+    * **%pdef <object>**: Print the call signature for any callable
       object. If the object is a class, print the constructor information.
     * **%psource <object>**: Print (or run through a pager if too long)
       the source code for an object.


### PR DESCRIPTION
In addition, clean up the docstrings (so that `help <command>` returns more useful information).

One notable change is in the behavior of `pinfo`.  Previously `pinfo object` did the equivalent of `object??`, i.e. what we'd call `pinfo2`.  Is it worth "correcting" this behavior for consistency?  I'll gladly discard the last commit (886a3ee) to preserve the existing behavior.
