### PR TITLE
Start to document Javascript

### DIFF
--- a/IPython/frontend/html/notebook/static/js/README.md
+++ b/IPython/frontend/html/notebook/static/js/README.md
@@ -1,0 +1,48 @@
+Documentation
+=============
+
+How to Build/ view the doc for javascript.
+
+Javascript documentation should follow a style close to JSDoc one, so you
+should be able to build them with your favorite documentation builder.
+
+Still the documentation comment are mainly written to be read with YUI doc. 
+
+You can either build a static version, or start a YUIdoc server that will live
+update the doc at every page request. 
+
+To do so, you will need to install YUIdoc.
+
+## Install NodeJS
+
+Node is a browser less javascript interpreter. To install it please refer to
+the documentation for your platform. Install also NPM (node package manager) if
+it does not come bundled with it.  
+
+## Get YUIdoc
+
+npm does by default install package in `./node_modules` instead of doing a
+system wide install. I'll leave you to yuidoc docs if you want to make a system
+wide install.
+
+First, cd into js directory :
+```bash
+cd IPython/frontend/html/notebook/static/js/
+# install yuidoc
+npm install yuidoc
+```
+
+
+## Run YUIdoc server
+
+From IPython/frontend/html/notebook/static/js/
+```bash
+# run yuidoc for install dir 
+./node_modules/yuidocjs/lib/cli.js --server .
+```
+
+Follow the instruction and the documentation should be available on localhost:3000
+
+Omitting `--server` will build a static version in the `out` folder by default.
+
+

--- a/IPython/frontend/html/notebook/static/js/cell.js
+++ b/IPython/frontend/html/notebook/static/js/cell.js
@@ -9,8 +9,10 @@
 // Cell
 //============================================================================
 /**
- * @module Cell
  * An extendable module that provide base functionnality to create cell for notebook.
+ * @module IPython
+ * @namespace IPython
+ * @submodule Cell
  */
 
 var IPython = (function (IPython) {
@@ -102,28 +104,50 @@ var IPython = (function (IPython) {
         this.selected = false;
     };
 
-
+    /**
+     * should be overritten by subclass
+     * @method get_text
+     */
     Cell.prototype.get_text = function () {
     };
 
-
+    /**
+     * should be overritten by subclass
+     * @method set_text
+     * @param {string} text
+     */
     Cell.prototype.set_text = function (text) {
     };
 
-
+    /**
+     * Refresh codemirror instance
+     * @method refresh
+     */
     Cell.prototype.refresh = function () {
         this.code_mirror.refresh();
     };
 
 
+    /**
+     * should be overritten by subclass
+     * @method  edit
+     **/
     Cell.prototype.edit = function () {
     };
 
 
+    /**
+     * should be overritten by subclass
+     * @method render
+     **/
     Cell.prototype.render = function () {
     };
 
-
+    /**
+     * should be overritten by subclass
+     * serialise cell to json.
+     * @method toJSON
+     **/
     Cell.prototype.toJSON = function () {
         var data = {};
         data.metadata = this.metadata;
@@ -131,6 +155,10 @@ var IPython = (function (IPython) {
     };
 
 
+    /**
+     * should be overritten by subclass
+     * @method fromJSON
+     **/
     Cell.prototype.fromJSON = function (data) {
         if (data.metadata !== undefined) {
             this.metadata = data.metadata;
@@ -138,11 +166,19 @@ var IPython = (function (IPython) {
     };
 
 
+    /**
+     * can the cell be splitted in 2 cells.
+     * @method is_splittable
+     **/
     Cell.prototype.is_splittable = function () {
         return true;
     };
 
 
+    /**
+     * @return {String} - the text before the cursor
+     * @method get_pre_cursor
+     **/
     Cell.prototype.get_pre_cursor = function () {
         var cursor = this.code_mirror.getCursor();
         var text = this.code_mirror.getRange({line:0,ch:0}, cursor);
@@ -151,6 +187,10 @@ var IPython = (function (IPython) {
     }
 
 
+    /**
+     * @return {String} - the text after the cursor
+     * @method get_post_cursor
+     **/
     Cell.prototype.get_post_cursor = function () {
         var cursor = this.code_mirror.getCursor();
         var last_line_num = this.code_mirror.lineCount()-1;
@@ -162,9 +202,15 @@ var IPython = (function (IPython) {
     };
 
 
+    /** Grow the cell by hand. This is used upon reloading from JSON, when the
+     *  autogrow handler is not called.
+     *
+     *  could be made static
+     *
+     *  @param {Dom element} - element
+     *  @method grow
+     **/
     Cell.prototype.grow = function(element) {
-        // Grow the cell by hand. This is used upon reloading from JSON, when the
-        // autogrow handler is not called.
         var dom = element.get(0);
         var lines_count = 0;
         // modified split rule from
@@ -178,7 +224,10 @@ var IPython = (function (IPython) {
         }
     };
 
-
+    /**
+     * Toggle  CodeMirror LineNumber
+     * @method toggle_line_numbers
+     **/
     Cell.prototype.toggle_line_numbers = function () {
         if (this.code_mirror.getOption('lineNumbers') == false) {
             this.code_mirror.setOption('lineNumbers', true);
@@ -188,11 +237,22 @@ var IPython = (function (IPython) {
         this.code_mirror.refresh();
     };
 
+    /**
+     * force codemirror highlight mode
+     * @method force_highlight
+     * @param {object} - CodeMirror mode
+     **/
     Cell.prototype.force_highlight = function(mode) {
         this.user_highlight = mode;
         this.auto_highlight();
     };
 
+    /**
+     * Try to autodetect cell highlight mode, or use selected mode
+     * @methods _auto_highlight
+     * @private
+     * @param {String|object|undefined} - CodeMirror mode | 'auto'
+     **/
     Cell.prototype._auto_highlight = function (modes) {
         //Here we handle manually selected modes
         if( this.user_highlight != undefined &&  this.user_highlight != 'auto' )

--- a/IPython/frontend/html/notebook/static/js/cell.js
+++ b/IPython/frontend/html/notebook/static/js/cell.js
@@ -8,12 +8,23 @@
 //============================================================================
 // Cell
 //============================================================================
+/**
+ * @module Cell
+ * An extendable module that provide base functionnality to create cell for notebook.
+ */
 
 var IPython = (function (IPython) {
 
     var utils = IPython.utils;
 
+    /**
+     * The Base `Cell` class from which to inherit 
+     * @class Cell
+     */
 
+    /*
+     * @constructor
+     */
     var Cell = function () {
         this.placeholder = this.placeholder || '';
         this.read_only = false;
@@ -31,10 +42,21 @@ var IPython = (function (IPython) {
     };
 
 
-    // Subclasses must implement create_element.
+    /**
+     * Empty. Subclasses must implement create_element.
+     * This should contain all the code to create the DOM element in notebook 
+     * and will be called by Base Class constructor.
+     * @method create_element
+     */
     Cell.prototype.create_element = function () {};
 
 
+    /**
+     * Empty. Subclasses must implement create_element.
+     * This should contain all the code to create the DOM element in notebook 
+     * and will be called by Base Class constructor.
+     * @method bind_events
+     */
     Cell.prototype.bind_events = function () {
         var that = this;
         // We trigger events so that Cell doesn't have to depend on Notebook.

--- a/IPython/frontend/html/notebook/static/js/cell.js
+++ b/IPython/frontend/html/notebook/static/js/cell.js
@@ -18,7 +18,7 @@ var IPython = (function (IPython) {
     var utils = IPython.utils;
 
     /**
-     * The Base `Cell` class from which to inherit 
+     * The Base `Cell` class from which to inherit
      * @class Cell
      */
 
@@ -44,7 +44,7 @@ var IPython = (function (IPython) {
 
     /**
      * Empty. Subclasses must implement create_element.
-     * This should contain all the code to create the DOM element in notebook 
+     * This should contain all the code to create the DOM element in notebook
      * and will be called by Base Class constructor.
      * @method create_element
      */
@@ -52,9 +52,9 @@ var IPython = (function (IPython) {
 
 
     /**
-     * Empty. Subclasses must implement create_element.
-     * This should contain all the code to create the DOM element in notebook 
-     * and will be called by Base Class constructor.
+     * Subclasses can implement override bind_events.
+     * Be carefull to call the parent method when overwriting as it fires event.
+     * this will be triggerd after create_element in constructor.
      * @method bind_events
      */
     Cell.prototype.bind_events = function () {
@@ -72,6 +72,10 @@ var IPython = (function (IPython) {
         });
     };
 
+    /**
+     * Triger typsetting of math by mathjax on current cell element
+     * @method typeset
+     */
     Cell.prototype.typeset = function () {
         if (window.MathJax){
             var cell_math = this.element.get(0);
@@ -79,12 +83,20 @@ var IPython = (function (IPython) {
         }
     };
 
+    /**
+     * should be triggerd when cell is selected
+     * @method select
+     */
     Cell.prototype.select = function () {
         this.element.addClass('ui-widget-content ui-corner-all');
         this.selected = true;
     };
 
 
+    /**
+     * should be triggerd when cell is unselected
+     * @method unselect
+     */
     Cell.prototype.unselect = function () {
         this.element.removeClass('ui-widget-content ui-corner-all');
         this.selected = false;

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -8,6 +8,12 @@
 //============================================================================
 // CodeCell
 //============================================================================
+/**
+ * An extendable module that provide base functionnality to create cell for notebook.
+ * @module IPython
+ * @namespace IPython
+ * @submodule CodeCell
+ */
 
 var IPython = (function (IPython) {
     "use strict";
@@ -16,9 +22,18 @@ var IPython = (function (IPython) {
     var key   = IPython.utils.keycodes;
     CodeMirror.modeURL = "/static/codemirror/mode/%N/%N.js";
 
+    /**
+     * A Cell conceived to write code.
+     *
+     * The kernel doesn't have to be set at creation time, in that case
+     * it will be null and set_kernel has to be called later.
+     * @class CodeCell
+     * @extends IPython.Cell
+     *
+     * @constructor
+     * @param {Object|null} kernel
+     */
     var CodeCell = function (kernel) {
-        // The kernel doesn't have to be set at creation time, in that case
-        // it will be null and set_kernel has to be called later.
         this.kernel = kernel || null;
         this.code_mirror = null;
         this.input_prompt_number = null;
@@ -36,11 +51,14 @@ var IPython = (function (IPython) {
 
     CodeCell.prototype = new IPython.Cell();
 
-
+    /**
+     * @method auto_highlight
+     */
     CodeCell.prototype.auto_highlight = function () {
         this._auto_highlight(IPython.config.cell_magic_highlight)
     };
 
+    /** @method create_element */
     CodeCell.prototype.create_element = function () {
         var cell =  $('<div></div>').addClass('cell border-box-sizing code_cell vbox');
         cell.attr('tabindex','2');
@@ -69,11 +87,14 @@ var IPython = (function (IPython) {
         }
     };
 
+    /**
+     *  This method gets called in CodeMirror's onKeyDown/onKeyPress
+     *  handlers and is used to provide custom key handling. Its return
+     *  value is used to determine if CodeMirror should ignore the event:
+     *  true = ignore, false = don't ignore.
+     *  @method handle_codemirror_keyevent
+     */
     CodeCell.prototype.handle_codemirror_keyevent = function (editor, event) {
-        // This method gets called in CodeMirror's onKeyDown/onKeyPress
-        // handlers and is used to provide custom key handling. Its return
-        // value is used to determine if CodeMirror should ignore the event:
-        // true = ignore, false = don't ignore.
 
         if (this.read_only){
             return false;
@@ -155,7 +176,10 @@ var IPython = (function (IPython) {
         this.kernel = kernel;
     }
 
-
+    /**
+     * Execute current code cell to the kernel
+     * @method execute
+     */
     CodeCell.prototype.execute = function () {
         this.output_area.clear_output(true, true, true);
         this.set_input_prompt('*');
@@ -169,7 +193,10 @@ var IPython = (function (IPython) {
         var msg_id = this.kernel.execute(this.get_text(), callbacks, {silent: false});
     };
 
-
+    /**
+     * @method _handle_execute_reply
+     * @private
+     */
     CodeCell.prototype._handle_execute_reply = function (content) {
         this.set_input_prompt(content.execution_count);
         this.element.removeClass("running");
@@ -226,20 +253,17 @@ var IPython = (function (IPython) {
     };
 
 
-
-
-
     CodeCell.input_prompt_classical = function (prompt_value, lines_number) {
         var ns = prompt_value || "&nbsp;";
         return 'In&nbsp;[' + ns + ']:'
     };
-    
+
     CodeCell.input_prompt_continuation = function (prompt_value, lines_number) {
         var html = [CodeCell.input_prompt_classical(prompt_value, lines_number)];
         for(var i=1; i < lines_number; i++){html.push(['...:'])};
         return html.join('</br>')
     };
-    
+
     CodeCell.input_prompt_function = CodeCell.input_prompt_classical;
 
 

--- a/IPython/frontend/html/notebook/static/js/config.js
+++ b/IPython/frontend/html/notebook/static/js/config.js
@@ -9,9 +9,45 @@
 // Notebook
 //============================================================================
 
-var IPython = (function (IPython) {
+/**
+ * @module IPython
+ * @namespace IPython
+ **/
 
+var IPython = (function (IPython) {
+        /**
+         * A place where some stuff can be confugured.
+         *
+         * @class config
+         * @static
+         *
+         **/
     var config = {
+        /**
+         * Dictionary of object to autodetect highlight mode for code cell.
+         * Item of the dictionnary should take the form :
+         *
+         *     key : {'reg':[list_of_regexp]}
+         *
+         * where `key` will be the code mirror mode name
+         * and `list_of_regexp` should be a list of regext that should match
+         * the first line of the cell to trigger this mode.
+         *
+         * if `key` is prefixed by the `magic_` prefix the codemirror `mode`
+         * will be applied only at the end of the first line
+         *
+         * @attribute cell_magic_highlight
+         * @example
+         * This would trigger javascript mode
+         * from the second line if first line start with `%%javascript` or `%%jsmagic`
+         *
+         *     cell_magic_highlight['magic_javascript'] = {'reg':[/^%%javascript/,/^%%jsmagic/]}
+         * @example
+         * This would trigger javascript mode
+         * from the second line if first line start with `var`
+         *
+         *     cell_magic_highlight['javascript'] = {'reg':[/^var/]}
+         */
         cell_magic_highlight : {
               'magic_javascript':{'reg':[/^%%javascript/]}
              ,'magic_perl'      :{'reg':[/^%%perl/]}
@@ -20,6 +56,11 @@ var IPython = (function (IPython) {
              ,'magic_shell'      :{'reg':[/^%%bash/]}
              ,'magic_r'         :{'reg':[/^%%R/]}
             },
+
+        /**
+         * same as `cell_magic_highlight` but for raw cells
+         * @attribute raw_cell_highlight
+         */
         raw_cell_highlight : {
              'diff'         :{'reg':[/^diff/]}
             }

--- a/IPython/frontend/html/notebook/static/js/custom.js
+++ b/IPython/frontend/html/notebook/static/js/custom.js
@@ -10,7 +10,10 @@
  * (and should create it if it does not exist).
  * It will be executed by the ipython notebook at load time.
  *
- * Example
+ * Same thing with `profile/static/css/custom.css` to inject custom css into the notebook.
+ *
+ * Example :
+ *
  * Create a custom button in toolbar that execute `%qtconsole` in kernel
  * and hence open a qtconsole attached to the same kernel as the current notebook
  *

--- a/IPython/frontend/html/notebook/static/js/custom.js
+++ b/IPython/frontend/html/notebook/static/js/custom.js
@@ -1,7 +1,32 @@
-/*
-Placeholder for custom user javascript
-
-mainly to be overridden in profile/static/js/custom.js
-
-This will always be an empty file in IPython
-*/
+// leave at least 2 line with only a star on it below, or doc generation fails
+/**
+ *
+ *
+ * Placeholder for custom user javascript
+ * mainly to be overridden in profile/static/js/custom.js
+ * This will always be an empty file in IPython
+ *
+ * User could add any javascript in the `profile/static/js/custom.js` file
+ * (and should create it if it does not exist).
+ * It will be executed by the ipython notebook at load time.
+ *
+ * Example
+ * Create a custom button in toolbar that execute `%qtconsole` in kernel
+ * and hence open a qtconsole attached to the same kernel as the current notebook
+ *
+ *    $([IPython.events]).on('notebook_loaded.Notebook', function(){
+ *        IPython.toolbar.add_buttons_group([
+ *            {
+ *                 'label'   : 'run qtconsole',
+ *                 'icon'    : 'ui-icon-calculator', // select your icon from http://jqueryui.com/themeroller/
+ *                 'callback': function(){IPython.notebook.kernel.execute('%qtconsole')}
+ *            }
+ *            // add more button here if needed.
+ *            ]);
+ *    });
+ *
+ * @module IPython
+ * @namespace IPython
+ * @class customjs
+ * @static
+ */

--- a/IPython/frontend/html/notebook/static/js/kernel.js
+++ b/IPython/frontend/html/notebook/static/js/kernel.js
@@ -10,7 +10,6 @@
 //============================================================================
 
 /**
- * An extendable module that provide base functionnality to create cell for notebook.
  * @module IPython
  * @namespace IPython
  * @submodule Kernel

--- a/IPython/frontend/html/notebook/static/js/kernel.js
+++ b/IPython/frontend/html/notebook/static/js/kernel.js
@@ -9,12 +9,22 @@
 // Kernel
 //============================================================================
 
+/**
+ * An extendable module that provide base functionnality to create cell for notebook.
+ * @module IPython
+ * @namespace IPython
+ * @submodule Kernel
+ */
+
 var IPython = (function (IPython) {
 
     var utils = IPython.utils;
 
     // Initialization and connection.
-
+    /**
+     * A Kernel Class to communicate with the Python kernel
+     * @Class Kernel
+     */
     var Kernel = function (base_url) {
         this.kernel_id = null;
         this.shell_channel = null;
@@ -50,6 +60,10 @@ var IPython = (function (IPython) {
         return msg;
     };
 
+    /**
+     * Start the Python kernel
+     * @method start
+     */
     Kernel.prototype.start = function (notebook_id) {
         var that = this;
         if (!this.running) {
@@ -62,7 +76,14 @@ var IPython = (function (IPython) {
         };
     };
 
-
+    /**
+     * Restart the python kernel.
+     *
+     * Emit a 'status_restarting.Kernel' event with
+     * the current object as parameter
+     *
+     * @method restart
+     */
     Kernel.prototype.restart = function () {
         $([IPython.events]).trigger('status_restarting.Kernel', {kernel: this});
         var that = this;
@@ -122,6 +143,12 @@ var IPython = (function (IPython) {
 
     };
 
+    /**
+     * Start the `shell`and `iopub` channels.
+     * Will stop and restart them if they already exist.
+     *
+     * @method start_channels
+     */
     Kernel.prototype.start_channels = function () {
         var that = this;
         this.stop_channels();
@@ -162,7 +189,10 @@ var IPython = (function (IPython) {
         }, 1000);
     };
 
-
+    /**
+     * Start the `shell`and `iopub` channels.
+     * @method stop_channels
+     */
     Kernel.prototype.stop_channels = function () {
         if (this.shell_channel !== null) {
             this.shell_channel.onclose = function (evt) {};
@@ -178,17 +208,28 @@ var IPython = (function (IPython) {
 
     // Main public methods.
 
+    /**
+     * Get info on object asynchronoulsy
+     *
+     * @async
+     * @param objname {string}
+     * @param callback {dict}
+     * @method object_info_request
+     *
+     * @example
+     *
+     * When calling this method pass a callbacks structure of the form:
+     *
+     *     callbacks = {
+     *      'object_info_reply': object_info_reply_callback
+     *     }
+     *
+     * The `object_info_reply_callback` will be passed the content object of the
+     *
+     * `object_into_reply` message documented in
+     * [IPython dev documentation](http://ipython.org/ipython-doc/dev/development/messaging.html#object-information)
+     */
     Kernel.prototype.object_info_request = function (objname, callbacks) {
-        // When calling this method pass a callbacks structure of the form:
-        //
-        // callbacks = {
-        //  'object_info_reply': object_into_reply_callback
-        // }
-        //
-        // The object_info_reply_callback will be passed the content object of the
-        // object_into_reply message documented here:
-        //
-        // http://ipython.org/ipython-doc/dev/development/messaging.html#object-information
         if(typeof(objname)!=null && objname!=null)
         {
             var content = {
@@ -202,42 +243,61 @@ var IPython = (function (IPython) {
         return;
     }
 
+    /**
+     * Execute given code into kernel, and pass result to callback.
+     *
+     * @async
+     * @method execute
+     * @param {string} code
+     * @param callback {Object} With the following keys
+     *      @param callback.'execute_reply' {function}
+     *      @param callback.'output' {function}
+     *      @param callback.'clear_output' {function}
+     *      @param callback.'set_next_input' {function}
+     * @param {object} [options]
+     *      @param [options.silent=false] {Boolean}
+     *      @param [options.user_expressions=empty_dict] {Dict}
+     *      @param [options.user_variables=empty_list] {List od Strings}
+     *      @param [options.allow_stdin=false] {Boolean} true|false
+     *
+     * @example
+     *
+     * The options object should contain the options for the execute call. Its default
+     * values are:
+     *
+     *      options = {
+     *        silent : true,
+     *        user_variables : [],
+     *        user_expressions : {},
+     *        allow_stdin : false
+     *      }
+     *
+     * When calling this method pass a callbacks structure of the form:
+     *
+     *      callbacks = {
+     *       'execute_reply': execute_reply_callback,
+     *       'output': output_callback,
+     *       'clear_output': clear_output_callback,
+     *       'set_next_input': set_next_input_callback
+     *      }
+     *
+     * The `execute_reply_callback` will be passed the content and metadata
+     * objects of the `execute_reply` message documented
+     * [here](http://ipython.org/ipython-doc/dev/development/messaging.html#execute)
+     *
+     * The `output_callback` will be passed `msg_type` ('stream','display_data','pyout','pyerr')
+     * of the output and the content and metadata objects of the PUB/SUB channel that contains the
+     * output:
+     *
+     * http://ipython.org/ipython-doc/dev/development/messaging.html#messages-on-the-pub-sub-socket
+     *
+     * The `clear_output_callback` will be passed a content object that contains
+     * stdout, stderr and other fields that are booleans, as well as the metadata object.
+     *
+     * The `set_next_input_callback` will be passed the text that should become the next
+     * input cell.
+     */
     Kernel.prototype.execute = function (code, callbacks, options) {
-        // The options object should contain the options for the execute call. Its default
-        // values are:
-        //
-        // options = {
-        //   silent : true,
-        //   user_variables : [],
-        //   user_expressions : {},
-        //   allow_stdin : false
-        // }
-        //
-        // When calling this method pass a callbacks structure of the form:
-        //
-        // callbacks = {
-        //  'execute_reply': execute_reply_callback,
-        //  'output': output_callback,
-        //  'clear_output': clear_output_callback,
-        //  'set_next_input': set_next_input_callback
-        // }
-        //
-        // The execute_reply_callback will be passed the content and metadata objects of the execute_reply
-        // message documented here:
-        //
-        // http://ipython.org/ipython-doc/dev/development/messaging.html#execute
-        //
-        // The output_callback will be passed msg_type ('stream','display_data','pyout','pyerr')
-        // of the output and the content and metadata objects of the PUB/SUB channel that contains the
-        // output:
-        //
-        // http://ipython.org/ipython-doc/dev/development/messaging.html#messages-on-the-pub-sub-socket
-        //
-        // The clear_output_callback will be passed a content object that contains
-        // stdout, stderr and other fields that are booleans, as well as the metadata object.
-        //
-        // The set_next_input_callback will be passed the text that should become the next
-        // input cell.
 
         var content = {
             code : code,
@@ -254,18 +314,25 @@ var IPython = (function (IPython) {
         return msg.header.msg_id;
     };
 
-
+    /**
+     * When calling this method pass a callbacks structure of the form:
+     *
+     *      callbacks = {
+     *       'complete_reply': complete_reply_callback
+     *      }
+     *
+     * The `complete_reply_callback` will be passed the content object of the
+     * `complete_reply` message documented
+     * [here](http://ipython.org/ipython-doc/dev/development/messaging.html#complete)
+     *
+     * @method complete
+     * @param line {integer}
+     * @param cursor_pos {integer}
+     * @param {dict} callbacks
+     *      @param callbacks.complete_reply {function} `complete_reply_callback`
+     *
+     */
     Kernel.prototype.complete = function (line, cursor_pos, callbacks) {
-        // When calling this method pass a callbacks structure of the form:
-        //
-        // callbacks = {
-        //  'complete_reply': complete_reply_callback
-        // }
-        //
-        // The complete_reply_callback will be passed the content object of the
-        // complete_reply message documented here:
-        //
-        // http://ipython.org/ipython-doc/dev/development/messaging.html#complete
         callbacks = callbacks || {};
         var content = {
             text : '',

--- a/IPython/frontend/html/notebook/static/js/textcell.js
+++ b/IPython/frontend/html/notebook/static/js/textcell.js
@@ -18,8 +18,11 @@ var IPython = (function (IPython) {
     var key = IPython.utils.keycodes;
 
     /**
+     * Construct a new TextCell, codemirror mode is by default 'htmlmixed', and cell type is 'text'
+     * cell start as not redered.
+     *
      * @class TextCell
-     * @constructs TextCell
+     * @constructor TextCell
      */
     var TextCell = function () {
         this.code_mirror_mode = this.code_mirror_mode || 'htmlmixed';
@@ -30,7 +33,8 @@ var IPython = (function (IPython) {
 
     TextCell.prototype = new IPython.Cell();
 
-    /** create the DOM element of the TextCell
+    /**
+     * Create the DOM element of the TextCell
      * @method create_element
      * @private
      */
@@ -56,7 +60,8 @@ var IPython = (function (IPython) {
     };
 
 
-    /** bind the DOM evet to cell actions
+    /**
+     * Bind the DOM evet to cell actions
      * Need to be called after TextCell.create_element
      * @private
      * @method bind_event
@@ -77,13 +82,16 @@ var IPython = (function (IPython) {
         });
     };
 
-    /** This method gets called in CodeMirror's onKeyDown/onKeyPress
+    /**
+     * This method gets called in CodeMirror's onKeyDown/onKeyPress
      * handlers and is used to provide custom key handling.
      *
+     * Subclass should override this method to have custom handeling
+     *
      * @method handle_codemirror_keyevent
-     * @param {CodeMirror } editor - The codemirror instance bound to the cell
+     * @param {CodeMirror} editor - The codemirror instance bound to the cell
      * @param {event} event -
-     * @return {Boolean} <tt>true</tt> if CodeMirror should ignore the event, `false` Otherwise
+     * @return {Boolean} `true` if CodeMirror should ignore the event, `false` Otherwise
      */
     TextCell.prototype.handle_codemirror_keyevent = function (editor, event) {
 
@@ -95,7 +103,7 @@ var IPython = (function (IPython) {
     };
 
     /**
-     * Select the current cell
+     * Select the current cell and trigger 'focus'
      * @method select
      */
     TextCell.prototype.select = function () {
@@ -104,7 +112,8 @@ var IPython = (function (IPython) {
         output.trigger('focus');
     };
 
-    /** unselect the current cell
+    /**
+     * unselect the current cell and `render` it
      * @method unselect
      */
     TextCell.prototype.unselect = function() {
@@ -113,7 +122,9 @@ var IPython = (function (IPython) {
         IPython.Cell.prototype.unselect.apply(this);
     };
 
-    /** put the current cell in edition mode
+    /**
+     *
+     * put the current cell in edition mode
      * @method edit
      */
     TextCell.prototype.edit = function () {
@@ -137,7 +148,8 @@ var IPython = (function (IPython) {
     };
 
 
-    /** Subclasses must define render.
+    /**
+     * Empty, Subclasses must define render.
      * @method render
      */
     TextCell.prototype.render = function () {};
@@ -211,8 +223,10 @@ var IPython = (function (IPython) {
         }
     };
 
-    /** Create Text cell from JSON
+    /**
+     * Create Text cell from JSON
      * @param {json} data - JSON serialized text-cell
+     * @method fromJSON
      */
     TextCell.prototype.fromJSON = function (data) {
         IPython.Cell.prototype.fromJSON.apply(this, arguments);
@@ -229,7 +243,9 @@ var IPython = (function (IPython) {
         }
     };
 
-
+    /** Generate JSON from cell
+     * @return {object} cell data serialised to json
+     */
     TextCell.prototype.toJSON = function () {
         var data = IPython.Cell.prototype.toJSON.apply(this);
         data.cell_type = this.cell_type;
@@ -239,7 +255,7 @@ var IPython = (function (IPython) {
 
 
     /**
-     * @constructs HtmlCell
+     * @constructor HtmlCell
      * @class HtmlCell
      * @extends TextCell
      */
@@ -252,7 +268,9 @@ var IPython = (function (IPython) {
 
     HTMLCell.prototype = new TextCell();
 
-
+    /**
+     * @method render
+     */
     HTMLCell.prototype.render = function () {
         if (this.rendered === false) {
             var text = this.get_text();
@@ -266,9 +284,9 @@ var IPython = (function (IPython) {
     };
 
 
-    // MarkdownCell
-    /** @class MarkdownCell
-     * @constructs MarkdownCell
+    /**
+     * @class MarkdownCell
+     * @constructor MarkdownCell
      * @extends HtmlCell
      */
     var MarkdownCell = function () {
@@ -280,7 +298,9 @@ var IPython = (function (IPython) {
 
     MarkdownCell.prototype = new TextCell();
 
-
+    /**
+     * @method render
+     */
     MarkdownCell.prototype.render = function () {
         if (this.rendered === false) {
             var text = this.get_text();
@@ -319,7 +339,9 @@ var IPython = (function (IPython) {
 
     // RawCell
 
-    /** @construct RawCell
+    /**
+     * @class RawCell
+     * @constructor RawCell
      * @extends TextCell
      */
     var RawCell = function () {
@@ -337,21 +359,23 @@ var IPython = (function (IPython) {
 
     RawCell.prototype = new TextCell();
 
+    /**
+     * Trigger autodetection of highlight scheme for current cell
+     * @method auto_highlight
+     */
     RawCell.prototype.auto_highlight = function () {
         this._auto_highlight(IPython.config.raw_cell_highlight);
     };
 
+    /** @method render **/
     RawCell.prototype.render = function () {
         this.rendered = true;
         this.edit();
     };
 
 
+    /** @method handle_codemirror_keyevent **/
     RawCell.prototype.handle_codemirror_keyevent = function (editor, event) {
-        // This method gets called in CodeMirror's onKeyDown/onKeyPress
-        // handlers and is used to provide custom key handling. Its return
-        // value is used to determine if CodeMirror should ignore the event:
-        // true = ignore, false = don't ignore.
 
         var that = this;
         if (event.which === key.UPARROW && event.type === 'keydown') {
@@ -376,14 +400,14 @@ var IPython = (function (IPython) {
         return false;
     };
 
-
+    /** @method select **/
     RawCell.prototype.select = function () {
         IPython.Cell.prototype.select.apply(this);
         this.code_mirror.refresh();
         this.code_mirror.focus();
     };
 
-
+    /** @method at_top **/
     RawCell.prototype.at_top = function () {
         var cursor = this.code_mirror.getCursor();
         if (cursor.line === 0 && cursor.ch === 0) {
@@ -394,6 +418,7 @@ var IPython = (function (IPython) {
     };
 
 
+    /** @method at_bottom **/
     RawCell.prototype.at_bottom = function () {
         var cursor = this.code_mirror.getCursor();
         if (cursor.line === (this.code_mirror.lineCount()-1) && cursor.ch === this.code_mirror.getLine(cursor.line).length) {
@@ -404,20 +429,30 @@ var IPython = (function (IPython) {
     };
 
 
-    /** @constructs HeadingCell
+    /** 
+     * @class HeadingCell
+     * @extends TextCell
+     */
+
+    /**
+     * @constructor HeadingCell
      * @extends TextCell
      */
     var HeadingCell = function () {
         this.placeholder = "Type Heading Here";
         IPython.TextCell.apply(this, arguments);
-        this.cell_type = 'heading';
+        /**
+         * heading level of the cell, use getter and setter to access
+         * @property level
+         */
         this.level = 1;
+        this.cell_type = 'heading';
     };
 
 
     HeadingCell.prototype = new TextCell();
 
-    /** from json */
+    /** @method fromJSON */
     HeadingCell.prototype.fromJSON = function (data) {
         if (data.level != undefined){
             this.level = data.level;
@@ -426,6 +461,7 @@ var IPython = (function (IPython) {
     };
 
 
+    /** @method toJSON */
     HeadingCell.prototype.toJSON = function () {
         var data = IPython.TextCell.prototype.toJSON.apply(this);
         data.level = this.get_level();
@@ -433,6 +469,10 @@ var IPython = (function (IPython) {
     };
 
 
+    /**
+     * Change heading level of cell, and re-render
+     * @method set_level
+     */
     HeadingCell.prototype.set_level = function (level) {
         this.level = level;
         if (this.rendered) {
@@ -442,6 +482,7 @@ var IPython = (function (IPython) {
     };
 
     /** The depth of header cell, based on html (h1 to h6)
+     * @method get_level
      * @return {integer} level - for 1 to 6
      */
     HeadingCell.prototype.get_level = function () {

--- a/IPython/frontend/html/notebook/static/js/textcell.js
+++ b/IPython/frontend/html/notebook/static/js/textcell.js
@@ -25,7 +25,7 @@ var IPython = (function (IPython) {
      *
      * @class TextCell
      * @constructor TextCell
-     * @extend Cell
+     * @extend Ipython.Cell
      */
     var TextCell = function () {
         this.code_mirror_mode = this.code_mirror_mode || 'htmlmixed';
@@ -260,7 +260,7 @@ var IPython = (function (IPython) {
     /**
      * @constructor HtmlCell
      * @class HtmlCell
-     * @extends TextCell
+     * @extends Ipython.TextCell
      */
     var HTMLCell = function () {
         this.placeholder = "Type <strong>HTML</strong> and LaTeX: $\\alpha^2$";
@@ -290,7 +290,7 @@ var IPython = (function (IPython) {
     /**
      * @class MarkdownCell
      * @constructor MarkdownCell
-     * @extends HtmlCell
+     * @extends Ipython.HtmlCell
      */
     var MarkdownCell = function () {
         this.placeholder = "Type *Markdown* and LaTeX: $\\alpha^2$";
@@ -345,7 +345,7 @@ var IPython = (function (IPython) {
     /**
      * @class RawCell
      * @constructor RawCell
-     * @extends TextCell
+     * @extends Ipython.TextCell
      */
     var RawCell = function () {
         this.placeholder = "Type plain text and LaTeX: $\\alpha^2$";
@@ -434,12 +434,12 @@ var IPython = (function (IPython) {
 
     /**
      * @class HeadingCell
-     * @extends TextCell
+     * @extends Ipython.TextCell
      */
 
     /**
      * @constructor HeadingCell
-     * @extends TextCell
+     * @extends Ipython.TextCell
      */
     var HeadingCell = function () {
         this.placeholder = "Type Heading Here";

--- a/IPython/frontend/html/notebook/static/js/textcell.js
+++ b/IPython/frontend/html/notebook/static/js/textcell.js
@@ -11,6 +11,8 @@
 
 /**
     A module that allow to create different type of Text Cell
+    @module IPython
+    @namespace IPython
  */
 var IPython = (function (IPython) {
 

--- a/IPython/frontend/html/notebook/static/js/textcell.js
+++ b/IPython/frontend/html/notebook/static/js/textcell.js
@@ -9,11 +9,18 @@
 // TextCell
 //============================================================================
 
+/**
+    A module that allow to create different type of Text Cell
+ */
 var IPython = (function (IPython) {
 
     // TextCell base class
     var key = IPython.utils.keycodes;
 
+    /**
+     * @class TextCell
+     * @constructs TextCell
+     */
     var TextCell = function () {
         this.code_mirror_mode = this.code_mirror_mode || 'htmlmixed';
         IPython.Cell.apply(this, arguments);
@@ -21,10 +28,12 @@ var IPython = (function (IPython) {
         this.cell_type = this.cell_type || 'text';
     };
 
-
     TextCell.prototype = new IPython.Cell();
 
-
+    /** create the DOM element of the TextCell
+     * @method create_element
+     * @private
+     */
     TextCell.prototype.create_element = function () {
         var cell = $("<div>").addClass('cell text_cell border-box-sizing');
         cell.attr('tabindex','2');
@@ -47,6 +56,11 @@ var IPython = (function (IPython) {
     };
 
 
+    /** bind the DOM evet to cell actions
+     * Need to be called after TextCell.create_element
+     * @private
+     * @method bind_event
+     */
     TextCell.prototype.bind_events = function () {
         IPython.Cell.prototype.bind_events.apply(this);
         var that = this;
@@ -63,13 +77,16 @@ var IPython = (function (IPython) {
         });
     };
 
-
+    /** This method gets called in CodeMirror's onKeyDown/onKeyPress
+     * handlers and is used to provide custom key handling.
+     *
+     * @method handle_codemirror_keyevent
+     * @param {CodeMirror } editor - The codemirror instance bound to the cell
+     * @param {event} event -
+     * @return {Boolean} <tt>true</tt> if CodeMirror should ignore the event, `false` Otherwise
+     */
     TextCell.prototype.handle_codemirror_keyevent = function (editor, event) {
-        // This method gets called in CodeMirror's onKeyDown/onKeyPress
-        // handlers and is used to provide custom key handling. Its return
-        // value is used to determine if CodeMirror should ignore the event:
-        // true = ignore, false = don't ignore.
-        
+
         if (event.keyCode === 13 && (event.shiftKey || event.ctrlKey)) {
             // Always ignore shift-enter in CodeMirror as we handle it.
             return true;
@@ -77,26 +94,33 @@ var IPython = (function (IPython) {
         return false;
     };
 
-
+    /**
+     * Select the current cell
+     * @method select
+     */
     TextCell.prototype.select = function () {
         IPython.Cell.prototype.select.apply(this);
         var output = this.element.find("div.text_cell_render");
         output.trigger('focus');
     };
 
-
+    /** unselect the current cell
+     * @method unselect
+     */
     TextCell.prototype.unselect = function() {
         // render on selection of another cell
         this.render();
         IPython.Cell.prototype.unselect.apply(this);
     };
 
-
+    /** put the current cell in edition mode
+     * @method edit
+     */
     TextCell.prototype.edit = function () {
         if ( this.read_only ) return;
         if (this.rendered === true) {
             var text_cell = this.element;
-            var output = text_cell.find("div.text_cell_render");  
+            var output = text_cell.find("div.text_cell_render");
             output.hide();
             text_cell.find('div.text_cell_input').show();
             this.code_mirror.refresh();
@@ -113,31 +137,55 @@ var IPython = (function (IPython) {
     };
 
 
-    // Subclasses must define render.
+    /** Subclasses must define render.
+     * @method render
+     */
     TextCell.prototype.render = function () {};
 
 
+    /**
+     * setter: {{#crossLink "TextCell/set_text"}}{{/crossLink}}
+     * @method get_text
+     * @retrun {string} CodeMirror current text value
+     */
     TextCell.prototype.get_text = function() {
         return this.code_mirror.getValue();
     };
 
-
+    /**
+     * @param {string} text - Codemiror text value
+     * @see TextCell#get_text
+     * @method set_text
+     * */
     TextCell.prototype.set_text = function(text) {
         this.code_mirror.setValue(text);
         this.code_mirror.refresh();
     };
 
-
+    /**
+     * setter :{{#crossLink "TextCell/set_rendered"}}{{/crossLink}}
+     * @method get_rendered
+     * @return {html} html of rendered element
+     * */
     TextCell.prototype.get_rendered = function() {
         return this.element.find('div.text_cell_render').html();
     };
 
-
+    /**
+     * @method set_rendered
+     */
     TextCell.prototype.set_rendered = function(text) {
         this.element.find('div.text_cell_render').html(text);
     };
 
-
+    /**
+     * not deprecated, but implementation wrong
+     * @method at_top
+     * @deprecated
+     * @return {Boolean} true is cell rendered, false otherwise
+     * I doubt this is what it is supposed to do
+     * this implementation is completly false
+     */
     TextCell.prototype.at_top = function () {
         if (this.rendered) {
             return true;
@@ -147,6 +195,14 @@ var IPython = (function (IPython) {
     };
 
 
+    /**
+     * not deprecated, but implementation wrong
+     * @method at_bottom
+     * @deprecated
+     * @return {Boolean} true is cell rendered, false otherwise
+     * I doubt this is what it is supposed to do
+     * this implementation is completly false
+     * */
     TextCell.prototype.at_bottom = function () {
         if (this.rendered) {
             return true;
@@ -155,7 +211,9 @@ var IPython = (function (IPython) {
         }
     };
 
-
+    /** Create Text cell from JSON
+     * @param {json} data - JSON serialized text-cell
+     */
     TextCell.prototype.fromJSON = function (data) {
         IPython.Cell.prototype.fromJSON.apply(this, arguments);
         if (data.cell_type === this.cell_type) {
@@ -180,8 +238,11 @@ var IPython = (function (IPython) {
     };
 
 
-    // HTMLCell
-
+    /**
+     * @constructs HtmlCell
+     * @class HtmlCell
+     * @extends TextCell
+     */
     var HTMLCell = function () {
         this.placeholder = "Type <strong>HTML</strong> and LaTeX: $\\alpha^2$";
         IPython.TextCell.apply(this, arguments);
@@ -206,7 +267,10 @@ var IPython = (function (IPython) {
 
 
     // MarkdownCell
-
+    /** @class MarkdownCell
+     * @constructs MarkdownCell
+     * @extends HtmlCell
+     */
     var MarkdownCell = function () {
         this.placeholder = "Type *Markdown* and LaTeX: $\\alpha^2$";
         IPython.TextCell.apply(this, arguments);
@@ -255,6 +319,9 @@ var IPython = (function (IPython) {
 
     // RawCell
 
+    /** @construct RawCell
+     * @extends TextCell
+     */
     var RawCell = function () {
         this.placeholder = "Type plain text and LaTeX: $\\alpha^2$";
         this.code_mirror_mode = 'rst';
@@ -337,8 +404,9 @@ var IPython = (function (IPython) {
     };
 
 
-    // HTMLCell
-
+    /** @constructs HeadingCell
+     * @extends TextCell
+     */
     var HeadingCell = function () {
         this.placeholder = "Type Heading Here";
         IPython.TextCell.apply(this, arguments);
@@ -349,7 +417,7 @@ var IPython = (function (IPython) {
 
     HeadingCell.prototype = new TextCell();
 
-
+    /** from json */
     HeadingCell.prototype.fromJSON = function (data) {
         if (data.level != undefined){
             this.level = data.level;
@@ -373,7 +441,9 @@ var IPython = (function (IPython) {
         };
     };
 
-
+    /** The depth of header cell, based on html (h1 to h6)
+     * @return {integer} level - for 1 to 6
+     */
     HeadingCell.prototype.get_level = function () {
         return this.level;
     };

--- a/IPython/frontend/html/notebook/static/js/textcell.js
+++ b/IPython/frontend/html/notebook/static/js/textcell.js
@@ -23,6 +23,7 @@ var IPython = (function (IPython) {
      *
      * @class TextCell
      * @constructor TextCell
+     * @extend Cell
      */
     var TextCell = function () {
         this.code_mirror_mode = this.code_mirror_mode || 'htmlmixed';
@@ -429,7 +430,7 @@ var IPython = (function (IPython) {
     };
 
 
-    /** 
+    /**
      * @class HeadingCell
      * @extends TextCell
      */

--- a/IPython/frontend/html/notebook/static/js/toolbar.js
+++ b/IPython/frontend/html/notebook/static/js/toolbar.js
@@ -8,9 +8,20 @@
 //============================================================================
 // ToolBar
 //============================================================================
+/**
+ * @module IPython
+ * @namespace IPython
+ * @submodule ToolBar
+ */
 
 var IPython = (function (IPython) {
 
+    /**
+     * A generic toolbar on which one can add button
+     * @class ToolBar
+     * @constructor
+     * @param {Dom object} selector
+     */
     var ToolBar = function (selector) {
         this.selector = selector;
         if (this.selector !== undefined) {
@@ -19,37 +30,38 @@ var IPython = (function (IPython) {
         }
     };
 
-    // add a group of button into the current toolbar.
-    //
-    // First argument : Mandatory
-    //      list of dict as argument, each dict should contain
-    //      3 mandatory keys and values :
-    //      label : string -- the text to show on hover
-    //      icon  : string -- the jQuery-ui icon to add on this button
-    //      callback : function -- the callback to execute on a click
-    //
-    //      and optionally an 'id' key that is assigned to the button element
-    //
-    // Second Argument, optional,
-    //      string reprensenting the id to give to the button group.
-    //
-    // Example
-    //
-    // IPython.toolbar.add_button_group([
-    //  {label:'my button',
-    //   icon:'ui-icon-disk',
-    //   callback:function(){alert('hoho'),
-    //   id : 'my_button_id',                 // this is optional
-    //   }
-    //  },
-    //  {label:'my second button',
-    //   icon:'ui-icon-scissors',
-    //   callback:function(){alert('be carefull I cut')}
-    //  }
-    //  ],
-    //  "my_button_group_id"
-    //  )
-    //
+    /**
+     *  add a group of button into the current toolbar.
+     *
+     *
+     *  @example
+     *
+     *      IPython.toolbar.add_button_group([
+     *          {
+     *            label:'my button',
+     *            icon:'ui-icon-disk',
+     *            callback:function(){alert('hoho'),
+     *            id : 'my_button_id',    // this is optional
+     *          },
+     *          {
+     *            label:'my second button',
+     *            icon:'ui-icon-scissors',
+     *            callback:function(){alert('be carefull I cut')}
+     *          }
+     *        ],
+     *        "my_button_group_id"
+     *      )
+     *
+     *  @method add_buttons_group
+     *  @param list {List}
+     *      List of button of the group, with the following paramter for each :
+     *      @param list.label {string} text to show on button hover
+     *      @param list.icon {string} icon to choose from [jQuery ThemeRoller](http://jqueryui.com/themeroller/)
+     *      @param list.callback {function} function to be called on button click
+     *      @param [list.id] {String} id to give to the button
+     *  @param [group_id] {String} optionnal id to give to the group
+     *
+     */
     ToolBar.prototype.add_buttons_group = function (list, group_id) {
         var span_group = $('<span/>');
         if( group_id != undefined ) {
@@ -80,7 +92,10 @@ var IPython = (function (IPython) {
             css('border-right-style','none');
     };
 
-
+    /**
+     * Show and hide toolbar
+     * @method toggle
+     */
     ToolBar.prototype.toggle = function () {
         this.element.toggle();
         if (IPython.layout_manager != undefined) {


### PR DESCRIPTION
Ok, 
I looked at documenting javascript. 

The 2 main school are : 
- structured comment designed for JS
- inline comment with markdown/html

Or a mixed of the two.

I choose the first so that you could explicitely add things like `@deprecated`, `@class` ,  `@static`.

Among those the difference in language is minimal. with most of the keywords in common and a few difference here and there like you to make crosslink. 

lots of people like JsDoc and show it by forking it and adding incompatible option, so that v2 is almost 2 years old and has 4 implementation with different behavior. And the official one is deprecated. 

v3 is "on it's way" with bugs like template not working. Exception about parsing command line after outputing half of the doc. Link in the doc not working. 
But it is the one that require the less human work as it figures out itself if stuff are methods, static, ...Etc

The other good one I found was YUI doc, which more duplicate work (retype `@method methodname` for each methods), but
work out of the box. Is maintained. Has lots of users. **Has good docs** ! support markdown in comment. Works in general better.

So this is mostly targetting YUIdoc (http://yui.github.com/yuidoc/)

Comment starting with `/**` (**2** stars) , keyword beginnig with `@`, **above** each function.

Does this suite everyone ? 
Should we start forcing ourselves do document every JS function that we modify in this way ? 

I'll add doc building with yuidoc on a separate PR. 
([YIU doc docs](http://yui.github.com/yuidoc/api/) are build with yui doc, if you want to see) 
