### PR TITLE
Make 'Paste Above' the default paste behavior.

### DIFF
--- a/IPython/frontend/html/notebook/static/js/maintoolbar.js
+++ b/IPython/frontend/html/notebook/static/js/maintoolbar.js
@@ -51,10 +51,10 @@ var IPython = (function (IPython) {
                 },
                 {
                     id : 'paste_b',
-                    label : 'Paste Cell Above',
+                    label : 'Paste Cell Below',
                     icon : 'ui-icon-clipboard',
                     callback : function () {
-                        IPython.notebook.paste_cell_above();
+                        IPython.notebook.paste_cell_below();
                         }
                 }
             ],'cut_copy_paste');

--- a/IPython/frontend/html/notebook/static/js/maintoolbar.js
+++ b/IPython/frontend/html/notebook/static/js/maintoolbar.js
@@ -51,10 +51,10 @@ var IPython = (function (IPython) {
                 },
                 {
                     id : 'paste_b',
-                    label : 'Paste Cell',
+                    label : 'Paste Cell Above',
                     icon : 'ui-icon-clipboard',
                     callback : function () {
-                        IPython.notebook.paste_cell();
+                        IPython.notebook.paste_cell_above();
                         }
                 }
             ],'cut_copy_paste');

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -142,8 +142,8 @@ var IPython = (function (IPython) {
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 86 && that.control_key_active) {
-                // Paste above selected cell = v
-                that.paste_cell_above();
+                // Paste below selected cell = v
+                that.paste_cell_below();
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 68 && that.control_key_active) {

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -142,8 +142,8 @@ var IPython = (function (IPython) {
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 86 && that.control_key_active) {
-                // Paste selected cell = v
-                that.paste_cell();
+                // Paste above selected cell = v
+                that.paste_cell_above();
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 68 && that.control_key_active) {
@@ -778,8 +778,8 @@ var IPython = (function (IPython) {
     Notebook.prototype.enable_paste = function () {
         var that = this;
         if (!this.paste_enabled) {
-            $('#paste_cell').removeClass('ui-state-disabled')
-                .on('click', function () {that.paste_cell();});
+            $('#paste_cell_replace').removeClass('ui-state-disabled')
+                .on('click', function () {that.paste_cell_replace();});
             $('#paste_cell_above').removeClass('ui-state-disabled')
                 .on('click', function () {that.paste_cell_above();});
             $('#paste_cell_below').removeClass('ui-state-disabled')
@@ -791,7 +791,7 @@ var IPython = (function (IPython) {
 
     Notebook.prototype.disable_paste = function () {
         if (this.paste_enabled) {
-            $('#paste_cell').addClass('ui-state-disabled').off('click');
+            $('#paste_cell_replace').addClass('ui-state-disabled').off('click');
             $('#paste_cell_above').addClass('ui-state-disabled').off('click');
             $('#paste_cell_below').addClass('ui-state-disabled').off('click');
             this.paste_enabled = false;
@@ -811,7 +811,7 @@ var IPython = (function (IPython) {
     };
 
 
-    Notebook.prototype.paste_cell = function () {
+    Notebook.prototype.paste_cell_replace = function () {
         if (this.clipboard !== null && this.paste_enabled) {
             var cell_data = this.clipboard;
             var new_cell = this.insert_cell_above(cell_data.cell_type);

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -75,9 +75,9 @@ data-notebook-id={{notebook_id}}
             <ul>
                 <li id="cut_cell"><a href="#">Cut Cell</a></li>
                 <li id="copy_cell"><a href="#">Copy Cell</a></li>
-                <li id="paste_cell" class="ui-state-disabled"><a href="#">Paste Cell</a></li>
                 <li id="paste_cell_above" class="ui-state-disabled"><a href="#">Paste Cell Above</a></li>
                 <li id="paste_cell_below" class="ui-state-disabled"><a href="#">Paste Cell Below</a></li>
+                <li id="paste_cell_replace" class="ui-state-disabled"><a href="#">Paste Cell Replace</a></li>
                 <li id="delete_cell"><a href="#">Delete</a></li>
                 <hr/>
                 <li id="split_cell"><a href="#">Split Cell</a></li>

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -77,7 +77,7 @@ data-notebook-id={{notebook_id}}
                 <li id="copy_cell"><a href="#">Copy Cell</a></li>
                 <li id="paste_cell_above" class="ui-state-disabled"><a href="#">Paste Cell Above</a></li>
                 <li id="paste_cell_below" class="ui-state-disabled"><a href="#">Paste Cell Below</a></li>
-                <li id="paste_cell_replace" class="ui-state-disabled"><a href="#">Paste Cell Replace</a></li>
+                <li id="paste_cell_replace" class="ui-state-disabled"><a href="#">Paste Cell &amp; Replace</a></li>
                 <li id="delete_cell"><a href="#">Delete</a></li>
                 <hr/>
                 <li id="split_cell"><a href="#">Split Cell</a></li>


### PR DESCRIPTION
Destructive paste mapped to Ctrl-M V is a surprising choice given that there was no drag-to-select on the area being replaced (there is a weaker notion of "selected cell" but this does not map to will-be-replaced-
by-paste in the minds of participants in an unscientific poll at PyConCA).

Destructive paste is still available as the last paste option in the Edit menu, qualified as "Paste Cell Replace".
