### PR TITLE
Fix displaying history when output cache is disabled.

### DIFF
--- a/IPython/core/magics/history.py
+++ b/IPython/core/magics/history.py
@@ -121,10 +121,6 @@ class HistoryMagics(Magics):
 
         """
 
-        if not self.shell.displayhook.do_full_cache:
-            print('This feature is only available if numbered prompts '
-                  'are in use.')
-            return
         args = parse_argstring(self.history, parameter_s)
 
         # For brevity


### PR DESCRIPTION
Previously, disabling the output cache disabled all history. These were separated, but the `%hist` magic was left with an unnecessary check, where if the output cache was disabled, it would refuse to work.

Closes gh-2581
