### PR TITLE
Literate programming

### DIFF
--- a/IPython/frontend/html/notebook/static/js/textcell.js
+++ b/IPython/frontend/html/notebook/static/js/textcell.js
@@ -329,12 +329,29 @@ var IPython = (function (IPython) {
         var text = this.get_text();
         if (text === "") { text = this.placeholder; }
         text = IPython.mathjaxutils.remove_math(text);
-        var literateRegex = /::([a-z_0-9]+)::/ig,
+        //
+        // {{                           delimiter
+        //  (?:\s*)                     non captured optionnal whitespace
+        //  (\w+)                       variable name
+        //  (?:\s*)                     non captured optionnal whitespace
+        //  (?:                         non captured group
+        //      \|                      first a pipe
+        //      \W*                     maybe whitespaces
+        //      ((?:\w|,| )*)           comma separated list of options
+        //  )
+        // }}
+        // /ig
+        //
+        //
+        //
+        var literateRegex = /{{(?:\s*)(\w+)(?:\s*)(?:\|\W*((?:\w|,| )*))?}}/ig,
                 matches,
                 variables = [];
 
         while (matches = literateRegex.exec(text)) {
             variables.push(matches[1]);
+            // matches[2] would be the list of options,
+            // not implemented yet
         }
         var that = this
         if(this.meta_var_updated_requested == false) {
@@ -364,7 +381,8 @@ var IPython = (function (IPython) {
             // replace ::xxx:: variable if possible:
             if(data != undefined){
                 for (i in data){
-                    text = text.replace(new RegExp('::'+i+'::','g'), data[i]);
+                    var reg = new RegExp('{{\\s*'+i+'\\s*(\\|(\\w|,| )*)?}}','g')
+                    text = text.replace(reg, data[i]);
                 }
             }
 

--- a/docs/examples/notebooks/literate programming.ipynb
+++ b/docs/examples/notebooks/literate programming.ipynb
@@ -8,6 +8,39 @@
   {
    "cells": [
     {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Literate Programming"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {
+      "literate": {
+       "data": {},
+       "execution_count": 6
+      }
+     },
+     "source": [
+      "Citation from [Wikipedia](http://en.wikipedia.org/wiki/Literate_programming) :\n",
+      "> A literate program is an explanation of the program logic in a natural language, such as English, interspersed with snippets of macros and traditional source code. Macros in a literate source file are simply title-like or explanatory phrases in a human language that describe human abstractions created while solving the programming problem, and hiding chunks of code or lower-level macros. These macros are similar to the algorithms in pseudocode typically used in teaching computer science. These arbitrary explanatory phrases become precise new operators, created on the fly by the programmer, forming a meta-language on top of the underlying programming language."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {
+      "literate": {
+       "data": {},
+       "execution_count": 6
+      }
+     },
+     "source": [
+      "To demonstrate the use of literate programming on the notebook let's first defile a few variable and function of different type."
+     ]
+    },
+    {
      "cell_type": "code",
      "collapsed": false,
      "input": [
@@ -20,20 +53,14 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 1
+     "prompt_number": 7
     },
     {
      "cell_type": "markdown",
      "metadata": {
       "literate": {
-       "data": {
-        "a": "set([1, 2])",
-        "f": "<function <lambda> at 0x102383758>",
-        "hello": "'world'",
-        "iDontExist": "[ERROR] KeyError: u'iDontExist'",
-        "x": "16"
-       },
-       "execution_count": 1
+       "data": {},
+       "execution_count": 7
       },
       "literrate": {
        "data": {
@@ -46,33 +73,81 @@
       }
      },
      "source": [
-      "This is a markdown cell, now, markdown can contain references to kernel variable.\n",
+      "With literate programming enabled, markdown cell can contain references to kernel variable.\n",
       "\n",
-      "To do so just write the name of the varaible between 2 double colon like so : <code>&#58;&#58;variable&#58;&#58;</code>. (to write colon that wouldn't be interpretated, use html escape sequence `#&58;` ) now you can list a differentes varaible and their values :\n",
+      "To do so just write the name of the varaible between double brackets like so : {\\{variable\\}}, when the markdown cell will be rendered, the {\\{variable\\}} vill be replaced by it's value if it is defined.\n",
       "\n",
-      "* simple type like float : x=::x::\n",
+      "If you feel the need to write uninterpreted varaible between double bracket, escape at least one of the innermost bracket like so : {\\\\{variable\\\\}}\n",
+      ". You could also simply use invalid syntax like multiple words between bracket : `{{ put your variable name here }}`. \n",
       "\n",
-      "* Strings  hello=::hello::\n",
-      "* more complex like sets a=::a::\n",
+      "Now lets see howit behaves."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {
+      "literate": {
+       "data": {
+        "a": "set([1, 2])",
+        "hello": "'world'",
+        "x": "48"
+       },
+       "execution_count": 7
+      }
+     },
+     "source": [
+      "Now you can list a differentes varaible and their values :\n",
       "\n",
+      "typing the following  in a Markdown cell: \n",
+      "\n",
+      "<!--code environement does not escape \\{\n",
+      "but triple backquote does.\n",
+      "But be carefull this cannot be converted to latex. \n",
+      "-->\n",
+      "<code>\n",
+      "* simple type like float : x={\\{x\\}}\n",
+      "* Strings  hello={\\{hello\\}}\n",
+      "* more complex like sets a={\\{a\\}}\n",
+      "</code>\n",
+      "\n",
+      "Will render like so:\n",
+      "\n",
+      "* simple type like float : x={{x}}\n",
+      "* Strings  hello=:{{hello}}\n",
+      "* more complex like sets a={{a}}"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {
+      "literate": {
+       "data": {
+        "f": "<function <lambda> at 0x10e79e230>",
+        "hello": "'world'",
+        "iDontExist": "[ERROR] KeyError: u'iDontExist'"
+       },
+       "execution_count": 7
+      }
+     },
+     "source": [
       "this also works in code environement (edit the cell to see the difference):\n",
       "\n",
-      "    f=::f::\n",
-      "    hello=::hello::\n",
+      "    f={{f}}\n",
+      "    hello={{hello}}\n",
       "Some object need to be put between backticks, like function because of the presence of angle bracket  :  \n",
       "\n",
-      "f=::f:: \n",
+      "f={{f|}}\n",
       "\n",
       "versus \n",
       "\n",
-      "`f=::f::`\n",
+      "`f={{f}}`\n",
       "\n",
       "\n",
       "Undefined value print that they are undefined.\n",
       "\n",
-      "* undefined=::iDontExist::\n",
+      "* undefined={{iDontExist}}\n",
       "\n",
-      "Value are store in cell metadata updated when markdown cell are edited and reexecuted. This allow different markdown cell to show the evolution of a same value after execution of different cells. This also keep the data across kernel restart and notebook save/loading.\n"
+      "Value are store in cell metadata updated when markdown cell are edited and reexecuted. This allow different markdown cell to show the evolution of a same value after execution of different cells. This also keep the data across kernel restart and notebook save/loading."
      ]
     },
     {
@@ -89,20 +164,20 @@
        "output_type": "stream",
        "stream": "stdout",
        "text": [
-        "x = 16\n"
+        "x = 48\n"
        ]
       }
      ],
-     "prompt_number": 2
+     "prompt_number": 8
     },
     {
      "cell_type": "markdown",
      "metadata": {
       "literate": {
        "data": {
-        "x": "17"
+        "x": "49"
        },
-       "execution_count": 2
+       "execution_count": 8
       },
       "literrate": {
        "data": {
@@ -111,7 +186,7 @@
       }
      },
      "source": [
-      "now,  x=::x::"
+      "now,  x={{x}}"
      ]
     },
     {
@@ -123,7 +198,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 4
+     "prompt_number": 9
     },
     {
      "cell_type": "markdown",
@@ -141,7 +216,60 @@
       }
      },
      "source": [
-      "the content of x is now `::x::`"
+      "the content of x is now `{{x}}`"
+     ]
+    },
+    {
+     "cell_type": "heading",
+     "level": 3,
+     "metadata": {},
+     "source": [
+      "Passing options"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {
+      "literate": {
+       "data": {},
+       "execution_count": 6
+      }
+     },
+     "source": [
+      "The syntax also support passing options, but the effect of option and their exact syntax is not defined yet. Using options you migh later be able to require a specific repr for the variable. Options are passed as a list of space or comma delimited values that are situated after the variable and separated from it by a Pipe like so :\n",
+      "\n",
+      "Variable with option : <code>&#123;&#123;variable | option1 option2 option3&#125;&#125;</code> or <code>&#123;&#123;variable | option1, option2, option3&#125;&#125;</code>"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {
+      "literate": {
+       "data": {
+        "x": "'a string'"
+       },
+       "execution_count": 9
+      }
+     },
+     "source": [
+      "Syntax test that should work:\n",
+      "\n",
+      "* {{x}}\n",
+      "* {{ x }}\n",
+      "* {{ x| }}\n",
+      "* {{ x |}}\n",
+      "* {{ x | }}\n",
+      "* {{x|list of,options }}\n",
+      "\n",
+      "Syntax test that shouldn't match:\n",
+      "\n",
+      "* {{x+1}}\n",
+      "* {{ x+1 }}\n",
+      "* {{ x- }}\n",
+      "* {{ x.y }}\n",
+      "* {{ x()  }}\n",
+      "* {{list of,options|x }}\n",
+      "* {{ this should not be matched}}"
      ]
     },
     {
@@ -150,8 +278,7 @@
      "input": [],
      "language": "python",
      "metadata": {},
-     "outputs": [],
-     "prompt_number": 3
+     "outputs": []
     }
    ],
    "metadata": {}

--- a/docs/examples/notebooks/literate programming.ipynb
+++ b/docs/examples/notebooks/literate programming.ipynb
@@ -1,0 +1,160 @@
+{
+ "metadata": {
+  "name": "literate programming"
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "import random\n",
+      "x=random.randint(1,50)\n",
+      "f= lambda x:x\n",
+      "a = set((1,2))\n",
+      "hello = 'world' "
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 1
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {
+      "literate": {
+       "data": {
+        "a": "set([1, 2])",
+        "f": "<function <lambda> at 0x102383758>",
+        "hello": "'world'",
+        "iDontExist": "[ERROR] KeyError: u'iDontExist'",
+        "x": "16"
+       },
+       "execution_count": 1
+      },
+      "literrate": {
+       "data": {
+        "a": "set([1, 2])",
+        "f": "<function <lambda> at 0x1021b7140>",
+        "hello": "'world'",
+        "iDontExist": "[ERROR] KeyError: u'iDontExist'",
+        "x": "2"
+       }
+      }
+     },
+     "source": [
+      "This is a markdown cell, now, markdown can contain references to kernel variable.\n",
+      "\n",
+      "To do so just write the name of the varaible between 2 double colon like so : <code>&#58;&#58;variable&#58;&#58;</code>. (to write colon that wouldn't be interpretated, use html escape sequence `#&58;` ) now you can list a differentes varaible and their values :\n",
+      "\n",
+      "* simple type like float : x=::x::\n",
+      "\n",
+      "* Strings  hello=::hello::\n",
+      "* more complex like sets a=::a::\n",
+      "\n",
+      "this also works in code environement (edit the cell to see the difference):\n",
+      "\n",
+      "    f=::f::\n",
+      "    hello=::hello::\n",
+      "Some object need to be put between backticks, like function because of the presence of angle bracket  :  \n",
+      "\n",
+      "f=::f:: \n",
+      "\n",
+      "versus \n",
+      "\n",
+      "`f=::f::`\n",
+      "\n",
+      "\n",
+      "Undefined value print that they are undefined.\n",
+      "\n",
+      "* undefined=::iDontExist::\n",
+      "\n",
+      "Value are store in cell metadata updated when markdown cell are edited and reexecuted. This allow different markdown cell to show the evolution of a same value after execution of different cells. This also keep the data across kernel restart and notebook save/loading.\n"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "print 'x =',x\n",
+      "x=x+1"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "x = 16\n"
+       ]
+      }
+     ],
+     "prompt_number": 2
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {
+      "literate": {
+       "data": {
+        "x": "17"
+       },
+       "execution_count": 2
+      },
+      "literrate": {
+       "data": {
+        "x": "3"
+       }
+      }
+     },
+     "source": [
+      "now,  x=::x::"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "x='a string'"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 4
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {
+      "literate": {
+       "data": {
+        "x": "'a string'"
+       },
+       "execution_count": 4
+      },
+      "literrate": {
+       "data": {
+        "x": "'a string'"
+       }
+      }
+     },
+     "source": [
+      "the content of x is now `::x::`"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 3
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}


### PR DESCRIPTION
Ability to show value of kernel variable in MD cell.

Do not view example with nbviewer, it does not support it yet. 

allow to write code like

```
>>> a=1
```

then in MD cell `a=::a::` which will be rendered as `a=1`

This does not allow repr_tex, or anything else as it uses `user_variable`.
Should we consider extending protocol ? Did I missed a clean way to do it ?
