### PR TITLE
func_kw_complete for builtin and cython with embededsignature=True using docstring

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -672,11 +672,11 @@ class IPCompleter(Completer):
         return matches
 
     def _default_arguments_from_docstring(self, doc):
-        """Parse first line of docstring for call signature
+        """Parse first line of docstring for call signature.
 
         Docstring should be of the form 'min(iterable[, key=func])\n'.
-        I can also parse cython docstring of the form
-        'Minuit.migrad(self, int ncall=10000, resume=True, int nsplit=1)'
+        It can also parse cython docstring of the form
+        'Minuit.migrad(self, int ncall=10000, resume=True, int nsplit=1)'.
         """
         if doc is None:
             return []

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -76,7 +76,6 @@ import os
 import re
 import shlex
 import sys
-import StringIO
 
 from IPython.config.configurable import Configurable
 from IPython.core.error import TryNext
@@ -672,7 +671,7 @@ class IPCompleter(Completer):
         return matches
 
     def _default_arguments_from_docstring(self, doc):
-        """Parse first line of docstring for call signature.
+        """Parse the first line of docstring for call signature.
 
         Docstring should be of the form 'min(iterable[, key=func])\n'.
         It can also parse cython docstring of the form
@@ -680,10 +679,10 @@ class IPCompleter(Completer):
         """
         if doc is None:
             return []
-        sio = StringIO.StringIO(doc.lstrip())
+
         #care only the firstline
-        #docstring can be long
-        line = sio.readline()
+        line = doc.lstrip().splitlines()[0]
+
         #p = re.compile(r'^[\w|\s.]+\(([^)]*)\).*')
         #'min(iterable[, key=func])\n' -> 'iterable[, key=func]'
         sig = self.docstring_sig_re.search(line)

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -671,10 +671,12 @@ class IPCompleter(Completer):
 
         return matches
 
-    def _default_arguments_from_docstring(self,doc):
-        """Parse first line of docstring of the
-        form 'min(iterable[, key=func])\n' to find
-        keyword argument names.
+    def _default_arguments_from_docstring(self, doc):
+        """Parse first line of docstring for call signature
+
+        Docstring should be of the form 'min(iterable[, key=func])\n'.
+        I can also parse cython docstring of the form
+        'Minuit.migrad(self, int ncall=10000, resume=True, int nsplit=1)'
         """
         if doc is None:
             return []

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -666,6 +666,10 @@ class IPCompleter(Completer):
         return matches
 
     def _default_arguments_from_docstring(self,doc):
+        """Parse first line of docstring of the
+        form 'min(iterable[, key=func])\n' to find
+        keyword argument names.
+        """
         doc = doc.lstrip()
         sio = StringIO.StringIO(doc)
         #care only the firstline
@@ -773,7 +777,7 @@ class IPCompleter(Completer):
         for callableMatch in callableMatches:
             try:
                 namedArgs = self._default_arguments(eval(callableMatch,
-                                                     self.namespace))
+                                                        self.namespace))
             except:
                 continue
 

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -698,11 +698,11 @@ class IPCompleter(Completer):
         if inspect.isbuiltin(obj):
             pass
         elif not (inspect.isfunction(obj) or inspect.ismethod(obj)):
-            #for cython embededsignature=True the docstring belongs to
-            #the object itself not __init__ or __call__
-            ret += self._default_arguments_from_docstring(
-                        getattr(obj,'__doc__',''))
             if inspect.isclass(obj):
+                #for cython embededsignature=True the constructor docstring
+                #belongs to the object itself not __init__
+                ret += self._default_arguments_from_docstring(
+                            getattr(obj,'__doc__',''))
                 # for classes, check for __init__,__new__
                 call_obj = (getattr(obj,'__init__',None) or
                        getattr(obj,'__new__',None))

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -288,10 +288,13 @@ def test_func_kw_completions():
     s, matches = c.complete(None, 'myfunc(1,b')
     nt.assert_in('b=', matches)
     # Simulate completing with cursor right after b (pos==10):
-    s, matches = c.complete(None,'myfunc(1,b)', 10)
+    s, matches = c.complete(None, 'myfunc(1,b)', 10)
     nt.assert_in('b=', matches)
-    s, matches = c.complete(None,'myfunc(a="escaped\\")string",b')
+    s, matches = c.complete(None, 'myfunc(a="escaped\\")string",b')
     nt.assert_in('b=', matches)
+    #builtin function
+    s, matches = c.complete(None, 'min(k, k')
+    nt.assert_in('key=', matches)
 
 
 def test_line_magics():

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -297,6 +297,22 @@ def test_func_kw_completions():
     nt.assert_in('key=', matches)
 
 
+def test_default_arguments_from_docstring():
+    doc = min.__doc__
+    ip = get_ipython()
+    c = ip.Completer
+    kwd = c._default_arguments_from_docstring(
+        'min(iterable[, key=func]) -> value')
+    nt.assert_equal(kwd,['key'])
+    #with cython type etc
+    kwd = c._default_arguments_from_docstring(
+        'Minuit.migrad(self, int ncall=10000, resume=True, int nsplit=1)\n')
+    nt.assert_equal(kwd,['ncall','resume','nsplit'])
+    #white spaces
+    kwd = c._default_arguments_from_docstring(
+        '\n Minuit.migrad(self, int ncall=10000, resume=True, int nsplit=1)\n')
+    nt.assert_equal(kwd,['ncall','resume','nsplit'])
+
 def test_line_magics():
     ip = get_ipython()
     c = ip.Completer

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -303,15 +303,15 @@ def test_default_arguments_from_docstring():
     c = ip.Completer
     kwd = c._default_arguments_from_docstring(
         'min(iterable[, key=func]) -> value')
-    nt.assert_equal(kwd,['key'])
+    nt.assert_equal(kwd, ['key'])
     #with cython type etc
     kwd = c._default_arguments_from_docstring(
         'Minuit.migrad(self, int ncall=10000, resume=True, int nsplit=1)\n')
-    nt.assert_equal(kwd,['ncall','resume','nsplit'])
+    nt.assert_equal(kwd, ['ncall', 'resume', 'nsplit'])
     #white spaces
     kwd = c._default_arguments_from_docstring(
         '\n Minuit.migrad(self, int ncall=10000, resume=True, int nsplit=1)\n')
-    nt.assert_equal(kwd,['ncall','resume','nsplit'])
+    nt.assert_equal(kwd, ['ncall', 'resume', 'nsplit'])
 
 def test_line_magics():
     ip = get_ipython()


### PR DESCRIPTION
``` pyton
np.array([1], su
```

has subok= in completion

``` pyton
min(k, k
```

has key= in completion list or

Cython embded signature works too ( http://wiki.cython.org/enhancements/compilerdirectives ) May be embded signature should be default in %%cython magic?

```
@cython.embdedsignature=True

def cython_func(a, mykwd=''):
    return mykwd
```

When you do

```
cython_func(a, my
```

has mykwd= in completion list

For Cython constructor, it's a little bit tricky since the constructor signature is put in class docstring not **init**. But, it's working

```
@cython.embdedsignature=True

class MyClass:
    def __init__(a, awesome_argument=1):
        pass
```

```
a = MyClass(a, awe
```

has awesome_argument= in the completion list too
