### PR TITLE
Revamp API docs

### DIFF
--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -2,6 +2,11 @@
 """
 A base class for objects that are configurable.
 
+Inheritance diagram:
+
+.. inheritance-diagram:: IPython.config.configurable
+   :parts: 3
+
 Authors:
 
 * Brian Granger

--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -1,5 +1,10 @@
 """A simple configuration system.
 
+Inheritance diagram:
+
+.. inheritance-diagram:: IPython.config.loader
+   :parts: 3
+
 Authors
 -------
 * Brian Granger

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 """Display formatters.
 
+Inheritance diagram:
+
+.. inheritance-diagram:: IPython.core.formatters
+   :parts: 3
 
 Authors:
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -64,6 +64,7 @@ from IPython.utils import PyColorize
 from IPython.utils import io
 from IPython.utils import py3compat
 from IPython.utils import openpy
+from IPython.utils.decorators import undoc
 from IPython.utils.doctestreload import doctest_reload
 from IPython.utils.io import ask_yes_no
 from IPython.utils.ipstruct import Struct
@@ -90,6 +91,7 @@ dedent_re = re.compile(r'^\s+raise|^\s+return|^\s+pass')
 # Utilities
 #-----------------------------------------------------------------------------
 
+@undoc
 def softspace(file, newvalue):
     """Copied from code.py, to remove the dependency"""
 
@@ -105,9 +107,10 @@ def softspace(file, newvalue):
         pass
     return oldvalue
 
-
+@undoc
 def no_op(*a, **kw): pass
 
+@undoc
 class NoOpContext(object):
     def __enter__(self): pass
     def __exit__(self, type, value, traceback): pass
@@ -115,6 +118,7 @@ no_op_context = NoOpContext()
 
 class SpaceInInput(Exception): pass
 
+@undoc
 class Bunch: pass
 
 

--- a/IPython/core/magic_arguments.py
+++ b/IPython/core/magic_arguments.py
@@ -37,6 +37,11 @@ arguments::
           -o OPTION, --option OPTION
                                 An optional argument.
 
+Inheritance diagram:
+
+.. inheritance-diagram:: IPython.core.magic_arguments
+   :parts: 3
+
 '''
 #-----------------------------------------------------------------------------
 # Copyright (C) 2010-2011, IPython Development Team.

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -59,6 +59,11 @@ ColorSchemeTable class. Currently the following exist:
 You can implement other color schemes easily, the syntax is fairly
 self-explanatory. Please send back new schemes you develop to the author for
 possible inclusion in future releases.
+
+Inheritance diagram:
+
+.. inheritance-diagram:: IPython.core.ultratb
+   :parts: 3
 """
 
 #*****************************************************************************

--- a/IPython/lib/demo.py
+++ b/IPython/lib/demo.py
@@ -1,6 +1,3 @@
-from __future__ import unicode_literals
-
-
 """Module for interactive demos using IPython.
 
 This module implements a few classes for running Python scripts interactively
@@ -10,7 +7,7 @@ control to IPython.
 
 
 Provided classes
-================
+----------------
 
 The classes are (see their docstrings for further details):
 
@@ -33,9 +30,13 @@ The classes are (see their docstrings for further details):
  - ClearDemo, ClearIPDemo: mixin-enabled versions of the Demo and IPythonDemo
    classes.
 
+Inheritance diagram:
+
+.. inheritance-diagram:: IPython.lib.demo
+   :parts: 3
 
 Subclassing
-===========
+-----------
 
 The classes here all include a few methods meant to make customization by
 subclassing more convenient.  Their docstrings below have some more details:
@@ -50,7 +51,7 @@ subclassing more convenient.  Their docstrings below have some more details:
 
 
 Operation
-=========
+---------
 
 The file is run in its own empty namespace (though you can pass it a string of
 arguments as if in a command line environment, and it will see those as
@@ -123,46 +124,50 @@ an IPython session, and type::
 and then follow the directions.
 
 Example
-=======
+-------
 
 The following is a very simple example of a valid demo file.
 
-#################### EXAMPLE DEMO <ex_demo.py> ###############################
-'''A simple interactive demo to illustrate the use of IPython's Demo class.'''
+::
 
-print 'Hello, welcome to an interactive IPython demo.'
+    #################### EXAMPLE DEMO <ex_demo.py> ###############################
+    '''A simple interactive demo to illustrate the use of IPython's Demo class.'''
 
-# The mark below defines a block boundary, which is a point where IPython will
-# stop execution and return to the interactive prompt. The dashes are actually
-# optional and used only as a visual aid to clearly separate blocks while
-# editing the demo code.
-# <demo> stop
+    print 'Hello, welcome to an interactive IPython demo.'
 
-x = 1
-y = 2
+    # The mark below defines a block boundary, which is a point where IPython will
+    # stop execution and return to the interactive prompt. The dashes are actually
+    # optional and used only as a visual aid to clearly separate blocks while
+    # editing the demo code.
+    # <demo> stop
 
-# <demo> stop
+    x = 1
+    y = 2
 
-# the mark below makes this block as silent
-# <demo> silent
+    # <demo> stop
 
-print 'This is a silent block, which gets executed but not printed.'
+    # the mark below makes this block as silent
+    # <demo> silent
 
-# <demo> stop
-# <demo> auto
-print 'This is an automatic block.'
-print 'It is executed without asking for confirmation, but printed.'
-z = x+y
+    print 'This is a silent block, which gets executed but not printed.'
 
-print 'z=',x
+    # <demo> stop
+    # <demo> auto
+    print 'This is an automatic block.'
+    print 'It is executed without asking for confirmation, but printed.'
+    z = x+y
 
-# <demo> stop
-# This is just another normal block.
-print 'z is now:', z
+    print 'z=',x
 
-print 'bye!'
-################### END EXAMPLE DEMO <ex_demo.py> ############################
+    # <demo> stop
+    # This is just another normal block.
+    print 'z is now:', z
+
+    print 'bye!'
+    ################### END EXAMPLE DEMO <ex_demo.py> ############################
 """
+
+from __future__ import unicode_literals
 
 #*****************************************************************************
 #     Copyright (C) 2005-2006 Fernando Perez. <Fernando.Perez@colorado.edu>

--- a/IPython/lib/demo.py
+++ b/IPython/lib/demo.py
@@ -104,11 +104,11 @@ place a set of stop tags; the other tags are only there to let you fine-tune
 the execution.
 
 This is probably best explained with the simple example file below.  You can
-copy this into a file named ex_demo.py, and try running it via:
+copy this into a file named ex_demo.py, and try running it via::
 
-from IPython.demo import Demo
-d = Demo('ex_demo.py')
-d()  <--- Call the d object (omit the parens if you have autocall set to 2).
+    from IPython.demo import Demo
+    d = Demo('ex_demo.py')
+    d()
 
 Each time you call the demo object, it runs the next block.  The demo object
 has a few useful methods for navigation, like again(), edit(), jump(), seek()

--- a/IPython/lib/irunner.py
+++ b/IPython/lib/irunner.py
@@ -18,16 +18,14 @@ contributed on the ipython-user list:
 
 http://mail.scipy.org/pipermail/ipython-user/2006-May/003539.html
 
-
-NOTES:
+Notes
+-----
 
  - This module requires pexpect, available in most linux distros, or which can
- be downloaded from
-
-    http://pexpect.sourceforge.net
+   be downloaded from http://pexpect.sourceforge.net
 
  - Because pexpect only works under Unix or Windows-Cygwin, this has the same
- limitations.  This means that it will NOT work under native windows Python.
+   limitations.  This means that it will NOT work under native windows Python.
 """
 from __future__ import print_function
 

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -1,105 +1,107 @@
 # -*- coding: utf-8 -*-
 """
-    pretty
-    ~~
+Python advanced pretty printer.  This pretty printer is intended to
+replace the old `pprint` python module which does not allow developers
+to provide their own pretty print callbacks.
 
-    Python advanced pretty printer.  This pretty printer is intended to
-    replace the old `pprint` python module which does not allow developers
-    to provide their own pretty print callbacks.
-
-    This module is based on ruby's `prettyprint.rb` library by `Tanaka Akira`.
+This module is based on ruby's `prettyprint.rb` library by `Tanaka Akira`.
 
 
-    Example Usage
-    =============
+Example Usage
+-------------
 
-    To directly print the representation of an object use `pprint`::
+To directly print the representation of an object use `pprint`::
 
-        from pretty import pprint
-        pprint(complex_object)
+    from pretty import pprint
+    pprint(complex_object)
 
-    To get a string of the output use `pretty`::
+To get a string of the output use `pretty`::
 
-        from pretty import pretty
-        string = pretty(complex_object)
-
-
-    Extending
-    =========
-
-    The pretty library allows developers to add pretty printing rules for their
-    own objects.  This process is straightforward.  All you have to do is to
-    add a `_repr_pretty_` method to your object and call the methods on the
-    pretty printer passed::
-
-        class MyObject(object):
-
-            def _repr_pretty_(self, p, cycle):
-                ...
-
-    Depending on the python version you want to support you have two
-    possibilities.  The following list shows the python 2.5 version and the
-    compatibility one.
+    from pretty import pretty
+    string = pretty(complex_object)
 
 
-    Here the example implementation of a `_repr_pretty_` method for a list
-    subclass for python 2.5 and higher (python 2.5 requires the with statement
-    __future__ import)::
+Extending
+---------
 
-        class MyList(list):
+The pretty library allows developers to add pretty printing rules for their
+own objects.  This process is straightforward.  All you have to do is to
+add a `_repr_pretty_` method to your object and call the methods on the
+pretty printer passed::
 
-            def _repr_pretty_(self, p, cycle):
-                if cycle:
-                    p.text('MyList(...)')
-                else:
-                    with p.group(8, 'MyList([', '])'):
-                        for idx, item in enumerate(self):
-                            if idx:
-                                p.text(',')
-                                p.breakable()
-                            p.pretty(item)
+    class MyObject(object):
 
-    The `cycle` parameter is `True` if pretty detected a cycle.  You *have* to
-    react to that or the result is an infinite loop.  `p.text()` just adds
-    non breaking text to the output, `p.breakable()` either adds a whitespace
-    or breaks here.  If you pass it an argument it's used instead of the
-    default space.  `p.pretty` prettyprints another object using the pretty print
-    method.
+        def _repr_pretty_(self, p, cycle):
+            ...
 
-    The first parameter to the `group` function specifies the extra indentation
-    of the next line.  In this example the next item will either be not
-    breaked (if the items are short enough) or aligned with the right edge of
-    the opening bracked of `MyList`.
+Depending on the python version you want to support you have two
+possibilities.  The following list shows the python 2.5 version and the
+compatibility one.
 
-    If you want to support python 2.4 and lower you can use this code::
 
-        class MyList(list):
+Here the example implementation of a `_repr_pretty_` method for a list
+subclass for python 2.5 and higher (python 2.5 requires the with statement
+__future__ import)::
 
-            def _repr_pretty_(self, p, cycle):
-                if cycle:
-                    p.text('MyList(...)')
-                else:
-                    p.begin_group(8, 'MyList([')
+    class MyList(list):
+
+        def _repr_pretty_(self, p, cycle):
+            if cycle:
+                p.text('MyList(...)')
+            else:
+                with p.group(8, 'MyList([', '])'):
                     for idx, item in enumerate(self):
                         if idx:
                             p.text(',')
                             p.breakable()
                         p.pretty(item)
-                    p.end_group(8, '])')
 
-    If you just want to indent something you can use the group function
-    without open / close parameters.  Under python 2.5 you can also use this
-    code::
+The `cycle` parameter is `True` if pretty detected a cycle.  You *have* to
+react to that or the result is an infinite loop.  `p.text()` just adds
+non breaking text to the output, `p.breakable()` either adds a whitespace
+or breaks here.  If you pass it an argument it's used instead of the
+default space.  `p.pretty` prettyprints another object using the pretty print
+method.
 
-        with p.indent(2):
-            ...
+The first parameter to the `group` function specifies the extra indentation
+of the next line.  In this example the next item will either be not
+breaked (if the items are short enough) or aligned with the right edge of
+the opening bracked of `MyList`.
 
-    Or under python2.4 you might want to modify ``p.indentation`` by hand but
-    this is rather ugly.
+If you want to support python 2.4 and lower you can use this code::
 
-    :copyright: 2007 by Armin Ronacher.
-                Portions (c) 2009 by Robert Kern.
-    :license: BSD License.
+    class MyList(list):
+
+        def _repr_pretty_(self, p, cycle):
+            if cycle:
+                p.text('MyList(...)')
+            else:
+                p.begin_group(8, 'MyList([')
+                for idx, item in enumerate(self):
+                    if idx:
+                        p.text(',')
+                        p.breakable()
+                    p.pretty(item)
+                p.end_group(8, '])')
+
+If you just want to indent something you can use the group function
+without open / close parameters.  Under python 2.5 you can also use this
+code::
+
+    with p.indent(2):
+        ...
+
+Or under python2.4 you might want to modify ``p.indentation`` by hand but
+this is rather ugly.
+
+Inheritance diagram:
+
+.. inheritance-diagram:: IPython.lib.pretty
+   :parts: 3
+
+:copyright: 2007 by Armin Ronacher.
+            Portions (c) 2009 by Robert Kern.
+:license: BSD License.
 """
 from __future__ import with_statement
 from contextlib import contextmanager

--- a/IPython/parallel/error.py
+++ b/IPython/parallel/error.py
@@ -2,6 +2,11 @@
 
 """Classes and functions for kernel related errors and exceptions.
 
+Inheritance diagram:
+
+.. inheritance-diagram:: IPython.parallel.error
+   :parts: 3
+
 Authors:
 
 * Brian Granger

--- a/IPython/utils/decorators.py
+++ b/IPython/utils/decorators.py
@@ -44,3 +44,11 @@ def flag_calls(func):
     wrapper.__doc__ = func.__doc__
     return wrapper
 
+def undoc(func):
+    """Mark a function or class as undocumented.
+    
+    This is found by inspecting the AST, so for now it must be used directly
+    as @undoc, not as e.g. @decorators.undoc
+    """
+    return func
+

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -1,6 +1,11 @@
 # encoding: utf-8
 """
 Utilities for working with strings and text.
+
+Inheritance diagram:
+
+.. inheritance-diagram:: IPython.utils.text
+   :parts: 3
 """
 
 #-----------------------------------------------------------------------------

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -28,6 +28,11 @@ We choose to create this module because we need these capabilities, but
 we need them to be pure Python so they work in all Python implementations,
 including Jython and IronPython.
 
+Inheritance diagram:
+
+.. inheritance-diagram:: IPython.utils.traitlets
+   :parts: 3
+
 Authors:
 
 * Brian Granger

--- a/docs/sphinxext/apigen.py
+++ b/docs/sphinxext/apigen.py
@@ -221,30 +221,24 @@ class ApiDocWriter(object):
 
         ad += '\n.. automodule:: ' + uri + '\n'
         ad += '\n.. currentmodule:: ' + uri + '\n'
-        multi_class = len(classes) > 1
-        multi_fx = len(functions) > 1
-        if multi_class:
-            ad += '\n' + 'Classes' + '\n' + \
-                  self.rst_section_levels[2] * 7 + '\n'
-        elif len(classes) and multi_fx:
-            ad += '\n' + 'Class' + '\n' + \
-                  self.rst_section_levels[2] * 5 + '\n'
+        
+        if classes:
+            subhead = str(len(classes)) + (' Classes' if len(classes) > 1 else ' Class')
+            ad += '\n'+ subhead + '\n' + \
+                  self.rst_section_levels[2] * len(subhead) + '\n'
+
         for c in classes:
-            ad += '\n:class:`' + c.name + '`\n' \
-                  + self.rst_section_levels[multi_class + 2 ] * \
-                  (len(c.name)+9) + '\n\n'
             ad += '\n.. autoclass:: ' + c.name + '\n'
             # must NOT exclude from index to keep cross-refs working
             ad += '  :members:\n' \
                   '  :show-inheritance:\n'
             if c.has_init:
                   ad += '\n  .. automethod:: __init__\n'
-        if multi_fx:
-            ad += '\n' + 'Functions' + '\n' + \
-                  self.rst_section_levels[2] * 9 + '\n\n'
-        elif len(functions) and multi_class:
-            ad += '\n' + 'Function' + '\n' + \
-                  self.rst_section_levels[2] * 8 + '\n\n'
+        
+        if functions:
+            subhead = str(len(functions)) + (' Functions' if len(functions) > 1 else ' Function')
+            ad += '\n'+ subhead + '\n' + \
+                  self.rst_section_levels[2] * len(subhead) + '\n'
         for f in functions:
             # must NOT exclude from index to keep cross-refs working
             ad += '\n.. autofunction:: ' + uri + '.' + f + '\n\n'

--- a/docs/sphinxext/apigen.py
+++ b/docs/sphinxext/apigen.py
@@ -249,9 +249,7 @@ class ApiDocWriter(object):
             ad += '\n.. autoclass:: ' + c + '\n'
             # must NOT exclude from index to keep cross-refs working
             ad += '  :members:\n' \
-                  '  :undoc-members:\n' \
                   '  :show-inheritance:\n' \
-                  '  :inherited-members:\n' \
                   '\n' \
                   '  .. automethod:: __init__\n'
         if multi_fx:

--- a/docs/sphinxext/apigen.py
+++ b/docs/sphinxext/apigen.py
@@ -219,11 +219,6 @@ class ApiDocWriter(object):
             chap_title = ':mod:`' + uri_short + '`'
         ad += chap_title + '\n' + self.rst_section_levels[1] * len(chap_title)
 
-        if len(classes):
-            ad += '\nInheritance diagram for ``%s``:\n\n' % uri
-            ad += '.. inheritance-diagram:: %s \n' % uri
-            ad += '   :parts: 3\n'
-
         ad += '\n.. automodule:: ' + uri + '\n'
         ad += '\n.. currentmodule:: ' + uri + '\n'
         multi_class = len(classes) > 1


### PR DESCRIPTION
This makes the API docs shorter and (hopefully) more useful.
- Don't add inheritance diagrams to all modules. I've manually added them to the docstrings where I think they're useful.
- Don't include undocumented and inherited members in class documentation. Links to base classes are still included.
- Use fewer subheadings, so the overview on [this page](http://ipython.org/ipython-doc/dev/api/index.html) is shorter. Classes can still be found in the index.
- Add an `@undoc` decorator to exclude classes and functions from the documentation.

Alternative to #2383. This should require much less manual maintenance than that one would.
