### PR TITLE
"cannot set attribute" exception on %paste

### DIFF
--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -324,7 +324,7 @@ class PrefilterManager(Configurable):
         normal_handler = self.get_handler_by_name('normal')
         if not stripped:
             if not continue_prompt:
-                self.shell.displayhook.prompt_count -= 1
+                self.shell.execution_count -= 1
 
             return normal_handler.handle(line_info)
 


### PR DESCRIPTION
Repro: use the %paste magic on lines with inconsistent spacing on
all-whitespace lines.
