### PR TITLE
Fix %paste in Python 3 on Mac

### DIFF
--- a/IPython/lib/clipboard.py
+++ b/IPython/lib/clipboard.py
@@ -30,7 +30,7 @@ def osx_clipboard_get():
         stdout=subprocess.PIPE)
     text, stderr = p.communicate()
     # Text comes in with old Mac \r line endings. Change them to \n.
-    text = text.replace('\r', '\n')
+    text = text.replace(b'\r', b'\n')
     text = py3compat.cast_unicode(text, py3compat.DEFAULT_ENCODING)
     return text
 


### PR DESCRIPTION
Fixes #2637.
