### PR TITLE
Add version_request/reply messaging protocol

### DIFF
--- a/IPython/core/release.py
+++ b/IPython/core/release.py
@@ -38,6 +38,9 @@ __version__ = '.'.join(map(str, _ver))
 version = __version__  # backwards compatibility name
 version_info = (_version_major, _version_minor, _version_micro, _version_extra)
 
+# Change this when incrementing the kernel protocol version
+kernel_protocol_version_info = (4, 0)
+
 description = "IPython: Productive Interactive Computing"
 
 long_description = \

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -61,6 +61,12 @@ from zmqshell import ZMQInteractiveShell
 # Main kernel class
 #-----------------------------------------------------------------------------
 
+# Change this when incrementing the kernel protocol version
+version_major = 1
+version_minor = 1
+version = '{0}.{1}'.format(version_major, version_minor)
+
+
 class Kernel(Configurable):
 
     #---------------------------------------------------------------------------
@@ -156,6 +162,7 @@ class Kernel(Configurable):
         # Build dict of handlers for message types
         msg_types = [ 'execute_request', 'complete_request',
                       'object_info_request', 'history_request',
+                      'version_request',
                       'connect_request', 'shutdown_request',
                       'apply_request',
                     ]
@@ -507,6 +514,16 @@ class Kernel(Configurable):
             content = {}
         msg = self.session.send(stream, 'connect_reply',
                                 content, parent, ident)
+        self.log.debug("%s", msg)
+
+    def version_request(self, stream, ident, parent):
+        vinfo = {
+            'version': version,
+            'version_major': version_major,
+            'version_minor': version_minor,
+        }
+        msg = self.session.send(stream, 'version_reply',
+                                vinfo, parent, ident)
         self.log.debug("%s", msg)
 
     def shutdown_request(self, stream, ident, parent):

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -35,6 +35,7 @@ from zmq.eventloop import ioloop
 from zmq.eventloop.zmqstream import ZMQStream
 
 # Local imports
+import IPython
 from IPython.config.configurable import Configurable
 from IPython.config.application import boolean_flag, catch_config_error
 from IPython.core.application import ProfileDir
@@ -53,7 +54,7 @@ from IPython.utils.traitlets import (
 from entry_point import base_launch_kernel
 from kernelapp import KernelApp, kernel_flags, kernel_aliases
 from serialize import serialize_object, unpack_apply_message
-from session import Session, Message
+from session import Session, Message, protocol_version
 from zmqshell import ZMQInteractiveShell
 
 
@@ -61,10 +62,8 @@ from zmqshell import ZMQInteractiveShell
 # Main kernel class
 #-----------------------------------------------------------------------------
 
-# Change this when incrementing the kernel protocol version
-version_major = 1
-version_minor = 1
-version = '{0}.{1}'.format(version_major, version_minor)
+ipython_version = list(IPython.version_info)
+language_version = list(sys.version_info[:3])
 
 
 class Kernel(Configurable):
@@ -518,9 +517,10 @@ class Kernel(Configurable):
 
     def version_request(self, stream, ident, parent):
         vinfo = {
-            'version': version,
-            'version_major': version_major,
-            'version_minor': version_minor,
+            'protocol_version': protocol_version,
+            'ipython_version': ipython_version,
+            'language_version': language_version,
+            'language': 'python',
         }
         msg = self.session.send(stream, 'version_reply',
                                 vinfo, parent, ident)

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -161,7 +161,7 @@ class Kernel(Configurable):
         # Build dict of handlers for message types
         msg_types = [ 'execute_request', 'complete_request',
                       'object_info_request', 'history_request',
-                      'version_request',
+                      'kernel_info_request',
                       'connect_request', 'shutdown_request',
                       'apply_request',
                     ]
@@ -515,14 +515,14 @@ class Kernel(Configurable):
                                 content, parent, ident)
         self.log.debug("%s", msg)
 
-    def version_request(self, stream, ident, parent):
+    def kernel_info_request(self, stream, ident, parent):
         vinfo = {
             'protocol_version': protocol_version,
             'ipython_version': ipython_version,
             'language_version': language_version,
             'language': 'python',
         }
-        msg = self.session.send(stream, 'version_reply',
+        msg = self.session.send(stream, 'kernel_info_reply',
                                 vinfo, parent, ident)
         self.log.debug("%s", msg)
 

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -35,11 +35,11 @@ from zmq.eventloop import ioloop
 from zmq.eventloop.zmqstream import ZMQStream
 
 # Local imports
-import IPython
 from IPython.config.configurable import Configurable
 from IPython.config.application import boolean_flag, catch_config_error
 from IPython.core.application import ProfileDir
 from IPython.core.error import StdinNotImplementedError
+from IPython.core import release
 from IPython.core.shellapp import (
     InteractiveShellApp, shell_flags, shell_aliases
 )
@@ -54,7 +54,7 @@ from IPython.utils.traitlets import (
 from entry_point import base_launch_kernel
 from kernelapp import KernelApp, kernel_flags, kernel_aliases
 from serialize import serialize_object, unpack_apply_message
-from session import Session, Message, protocol_version
+from session import Session, Message
 from zmqshell import ZMQInteractiveShell
 
 
@@ -62,7 +62,8 @@ from zmqshell import ZMQInteractiveShell
 # Main kernel class
 #-----------------------------------------------------------------------------
 
-ipython_version = list(IPython.version_info)
+protocol_version = list(release.kernel_protocol_version_info)
+ipython_version = list(release.version_info)
 language_version = list(sys.version_info[:3])
 
 

--- a/IPython/zmq/kernelmanager.py
+++ b/IPython/zmq/kernelmanager.py
@@ -363,8 +363,8 @@ class ShellSocketChannel(ZMQSocketChannel):
         self._queue_send(msg)
         return msg['header']['msg_id']
 
-    def version(self):
-        """Request kernel version info."""
+    def kernel_info(self):
+        """Request kernel info."""
         msg = self.session.msg('kernel_info_request')
         self._queue_send(msg)
         return msg['header']['msg_id']

--- a/IPython/zmq/kernelmanager.py
+++ b/IPython/zmq/kernelmanager.py
@@ -363,6 +363,12 @@ class ShellSocketChannel(ZMQSocketChannel):
         self._queue_send(msg)
         return msg['header']['msg_id']
 
+    def version(self):
+        """Request kernel version info."""
+        msg = self.session.msg('version_request')
+        self._queue_send(msg)
+        return msg['header']['msg_id']
+
     def shutdown(self, restart=False):
         """Request an immediate kernel shutdown.
 

--- a/IPython/zmq/kernelmanager.py
+++ b/IPython/zmq/kernelmanager.py
@@ -365,7 +365,7 @@ class ShellSocketChannel(ZMQSocketChannel):
 
     def version(self):
         """Request kernel version info."""
-        msg = self.session.msg('version_request')
+        msg = self.session.msg('kernel_info_request')
         self._queue_send(msg)
         return msg['header']['msg_id']
 

--- a/IPython/zmq/session.py
+++ b/IPython/zmq/session.py
@@ -43,7 +43,6 @@ from zmq.utils import jsonapi
 from zmq.eventloop.ioloop import IOLoop
 from zmq.eventloop.zmqstream import ZMQStream
 
-import IPython
 from IPython.config.application import Application, boolean_flag
 from IPython.config.configurable import Configurable, LoggingConfigurable
 from IPython.utils.importstring import import_item
@@ -78,7 +77,6 @@ def squash_unicode(obj):
 # Change this when incrementing the kernel protocol version
 protocol_version = [1, 1]
 
-_version_info_list = list(IPython.version_info)
 # ISO8601-ify datetime objects
 json_packer = lambda obj: jsonapi.dumps(obj, default=date_default)
 json_unpacker = lambda s: extract_dates(jsonapi.loads(s))
@@ -191,7 +189,6 @@ class Message(object):
 
 def msg_header(msg_id, msg_type, username, session):
     date = datetime.now()
-    version = _version_info_list
     return locals()
 
 def extract_header(msg_or_header):

--- a/IPython/zmq/session.py
+++ b/IPython/zmq/session.py
@@ -75,6 +75,9 @@ def squash_unicode(obj):
 # globals and defaults
 #-----------------------------------------------------------------------------
 
+# Change this when incrementing the kernel protocol version
+protocol_version = [1, 1]
+
 _version_info_list = list(IPython.version_info)
 # ISO8601-ify datetime objects
 json_packer = lambda obj: jsonapi.dumps(obj, default=date_default)

--- a/IPython/zmq/session.py
+++ b/IPython/zmq/session.py
@@ -75,7 +75,7 @@ def squash_unicode(obj):
 #-----------------------------------------------------------------------------
 
 # Change this when incrementing the kernel protocol version
-protocol_version = [1, 1]
+protocol_version = [4, 0]
 
 # ISO8601-ify datetime objects
 json_packer = lambda obj: jsonapi.dumps(obj, default=date_default)

--- a/IPython/zmq/session.py
+++ b/IPython/zmq/session.py
@@ -74,9 +74,6 @@ def squash_unicode(obj):
 # globals and defaults
 #-----------------------------------------------------------------------------
 
-# Change this when incrementing the kernel protocol version
-protocol_version = [4, 0]
-
 # ISO8601-ify datetime objects
 json_packer = lambda obj: jsonapi.dumps(obj, default=date_default)
 json_unpacker = lambda s: extract_dates(jsonapi.loads(s))

--- a/IPython/zmq/tests/test_message_spec.py
+++ b/IPython/zmq/tests/test_message_spec.py
@@ -460,7 +460,7 @@ def test_kernel_info_request():
 
     shell = KM.shell_channel
 
-    msg_id = shell.version()
+    msg_id = shell.kernel_info()
     reply = shell.get_msg(timeout=2)
     for tst in validate_message(reply, 'kernel_info_reply', msg_id):
         yield tst

--- a/IPython/zmq/tests/test_message_spec.py
+++ b/IPython/zmq/tests/test_message_spec.py
@@ -16,6 +16,7 @@ from Queue import Empty
 import nose.tools as nt
 
 from ..blockingkernelmanager import BlockingKernelManager
+from .. import ipkernel
 
 
 from IPython.testing import decorators as dec
@@ -195,6 +196,12 @@ class CompleteReply(Reference):
     matches = List(Unicode)
 
 
+class VersionReply(Reference):
+    version = Enum((ipkernel.version))
+    version_major = Enum((ipkernel.version_major,))
+    version_minor = Enum((ipkernel.version_minor,))
+
+
 # IOPub messages
 
 class PyIn(Reference):
@@ -236,6 +243,7 @@ references = {
     'object_info_reply' : OInfoReply(),
     'status' : Status(),
     'complete_reply' : CompleteReply(),
+    'version_reply': VersionReply(),
     'pyin' : PyIn(),
     'pyout' : PyOut(),
     'pyerr' : PyErr(),
@@ -432,6 +440,18 @@ def test_complete():
     matches = reply['content']['matches']
     for name in ('alpha', 'albert'):
         yield nt.assert_true(name in matches, "Missing match: %r" % name)
+
+
+@dec.parametric
+def test_version_request():
+    flush_channels()
+
+    shell = KM.shell_channel
+
+    msg_id = shell.version()
+    reply = shell.get_msg(timeout=2)
+    for tst in validate_message(reply, 'version_reply', msg_id):
+        yield tst
 
 
 # IOPub channel

--- a/IPython/zmq/tests/test_message_spec.py
+++ b/IPython/zmq/tests/test_message_spec.py
@@ -83,7 +83,17 @@ def execute(code='', **kwargs):
 
 
 class Reference(HasTraits):
-    
+
+    """
+    Base class for message spec specification testing.
+
+    This class is the core of the message specification test.  The
+    idea is that child classes implement trait attributes for each
+    message keys, so that message keys can be tested against these
+    traits using :meth:`check` method.
+
+    """
+
     def check(self, d):
         """validate a dict against our traits"""
         for key in self.trait_names():
@@ -232,6 +242,9 @@ references = {
     'stream' : Stream(),
     'display_data' : DisplayData(),
 }
+"""
+Specifications of `content` part of the reply messages.
+"""
 
 
 def validate_message(msg, msg_type=None, parent=None):

--- a/IPython/zmq/tests/test_message_spec.py
+++ b/IPython/zmq/tests/test_message_spec.py
@@ -199,7 +199,7 @@ def Version(num, trait=Integer):
     return List(trait, default_value=[0] * num, minlen=num, maxlen=num)
 
 
-class VersionReply(Reference):
+class KernelInfoReply(Reference):
 
     protocol_version = Version(2)
     ipython_version = Version(4, Any)
@@ -255,7 +255,7 @@ references = {
     'object_info_reply' : OInfoReply(),
     'status' : Status(),
     'complete_reply' : CompleteReply(),
-    'version_reply': VersionReply(),
+    'kernel_info_reply': KernelInfoReply(),
     'pyin' : PyIn(),
     'pyout' : PyOut(),
     'pyerr' : PyErr(),
@@ -455,14 +455,14 @@ def test_complete():
 
 
 @dec.parametric
-def test_version_request():
+def test_kernel_info_request():
     flush_channels()
 
     shell = KM.shell_channel
 
     msg_id = shell.version()
     reply = shell.get_msg(timeout=2)
-    for tst in validate_message(reply, 'version_reply', msg_id):
+    for tst in validate_message(reply, 'kernel_info_reply', msg_id):
         yield tst
 
 

--- a/IPython/zmq/tests/test_message_spec.py
+++ b/IPython/zmq/tests/test_message_spec.py
@@ -197,9 +197,10 @@ class CompleteReply(Reference):
 
 
 class VersionReply(Reference):
-    version = Enum((ipkernel.version))
-    version_major = Enum((ipkernel.version_major,))
-    version_minor = Enum((ipkernel.version_minor,))
+    protocol_version = Enum((ipkernel.protocol_version,))
+    ipython_version = Enum((ipkernel.ipython_version,))
+    language_version = Enum((ipkernel.language_version,))
+    language = Enum(("python",))
 
 
 # IOPub messages

--- a/IPython/zmq/tests/test_message_spec.py
+++ b/IPython/zmq/tests/test_message_spec.py
@@ -210,7 +210,7 @@ class VersionReply(Reference):
         for v in new:
             nt.assert_true(
                 isinstance(v, int) or isinstance(v, basestring),
-                'expected int or string as version component, got {!r}'
+                'expected int or string as version component, got {0!r}'
                 .format(v))
 
 

--- a/IPython/zmq/tests/test_message_spec.py
+++ b/IPython/zmq/tests/test_message_spec.py
@@ -16,13 +16,12 @@ from Queue import Empty
 import nose.tools as nt
 
 from ..blockingkernelmanager import BlockingKernelManager
-from .. import ipkernel
 
 
 from IPython.testing import decorators as dec
 from IPython.utils import io
 from IPython.utils.traitlets import (
-    HasTraits, TraitError, Bool, Unicode, Dict, Integer, List, Enum,
+    HasTraits, TraitError, Bool, Unicode, Dict, Integer, List, Enum, Any,
 )
 
 #-----------------------------------------------------------------------------
@@ -196,11 +195,23 @@ class CompleteReply(Reference):
     matches = List(Unicode)
 
 
+def Version(num, trait=Integer):
+    return List(trait, default_value=[0] * num, minlen=num, maxlen=num)
+
+
 class VersionReply(Reference):
-    protocol_version = Enum((ipkernel.protocol_version,))
-    ipython_version = Enum((ipkernel.ipython_version,))
-    language_version = Enum((ipkernel.language_version,))
-    language = Enum(("python",))
+
+    protocol_version = Version(2)
+    ipython_version = Version(4, Any)
+    language_version = Version(3)
+    language = Unicode()
+
+    def _ipython_version_changed(self, name, old, new):
+        for v in new:
+            nt.assert_true(
+                isinstance(v, int) or isinstance(v, basestring),
+                'expected int or string as version component, got {!r}'
+                .format(v))
 
 
 # IOPub messages

--- a/docs/source/development/messaging.txt
+++ b/docs/source/development/messaging.txt
@@ -670,6 +670,44 @@ Message type: ``connect_reply``::
     }
 
 
+Version
+-------
+
+If a client needs to know what protocol the kernel supports, it can
+ask version number of the messaging protocol supported by the kernel.
+This message can be used to fetch other core information of the
+kernel, including language (e.g., Python), language version number and
+IPython version number.
+
+Message type: ``version_request``::
+
+    content = {
+    }
+
+Message type: ``version_reply``::
+
+    content = {
+        # Version of messaging protocol (mandatory).
+        # The first integer indicates major version.  It is incremented when
+        # there is any backward incompatible change.
+        # The second integer indicates minor version.  It is incremented when
+        # there is any backward compatible change.
+        'protocol_version': [int, int],
+
+        # IPython version number (optional).
+        # Non-python kernel backend may not have this version number.
+        'ipython_version': [int, int, int, str],
+
+        # Language version number (mandatory).
+        # It is Python version number (e.g., [2, 7, 3]) for the kernel
+        # included in IPython.
+        'language_version': [int, ...],
+
+        # Programming language in which kernel is implemented (mandatory).
+        # Kernel included in IPython returns 'python'.
+        'language': str,
+    }
+
 
 Kernel shutdown
 ---------------

--- a/docs/source/development/messaging.txt
+++ b/docs/source/development/messaging.txt
@@ -696,6 +696,9 @@ Message type: ``version_reply``::
 
         # IPython version number (optional).
         # Non-python kernel backend may not have this version number.
+        # The last component is an extra field, which may be 'dev' or
+        # 'rc1' in development version.  It is an empty string for
+        # released version.
         'ipython_version': [int, int, int, str],
 
         # Language version number (mandatory).

--- a/docs/source/development/messaging.txt
+++ b/docs/source/development/messaging.txt
@@ -670,8 +670,8 @@ Message type: ``connect_reply``::
     }
 
 
-Version
--------
+Kernel info
+-----------
 
 If a client needs to know what protocol the kernel supports, it can
 ask version number of the messaging protocol supported by the kernel.
@@ -679,12 +679,12 @@ This message can be used to fetch other core information of the
 kernel, including language (e.g., Python), language version number and
 IPython version number.
 
-Message type: ``version_request``::
+Message type: ``kernel_info_request``::
 
     content = {
     }
 
-Message type: ``version_reply``::
+Message type: ``kernel_info_reply``::
 
     content = {
         # Version of messaging protocol (mandatory).


### PR DESCRIPTION
Test in test_message_spec.py passes.  No real world test is done yet.

Do we need user visible change (e.g., `%kernelversion` magic)?
