### PR TITLE
Fix irunner tests when $PYTHONSTARTUP is set

### DIFF
--- a/IPython/lib/tests/test_irunner.py
+++ b/IPython/lib/tests/test_irunner.py
@@ -137,7 +137,7 @@ In [12]: exit
 
     def testPython(self):
         """Test the Python runner."""
-        runner = irunner.PythonRunner(out=self.out)
+        runner = irunner.PythonRunner(out=self.out, args=['-E'])
         source = doctest_refactor_print("""
 print 'hello, this is python'
 


### PR DESCRIPTION
Closes gh-2655
