### PR TITLE
pylab_not_importable: Catch all exceptions, not just RuntimeErrors.

### DIFF
--- a/IPython/lib/tests/test_irunner_pylab_magic.py
+++ b/IPython/lib/tests/test_irunner_pylab_magic.py
@@ -17,11 +17,11 @@ from IPython.lib import irunner
 from IPython.testing import decorators
 
 def pylab_not_importable():
-    """Test if importing pylab fails with RuntimeError (true when having no display)"""
+    """Test if importing pylab fails. (For example, when having no display)"""
     try:
         import pylab
         return False
-    except RuntimeError:
+    except:
         return True
 
 # Testing code begins


### PR DESCRIPTION
This catches situations when `pylab` isn't installed or fails for another
reason like:

  ImportError: No module named backend_tkagg

Closes gh-2646.
