### PR TITLE
Don't enable pylab mode, when matplotlib is not importable

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2864,6 +2864,10 @@ class InteractiveShell(SingletonConfigurable):
         except KeyError:
             error("Backend %r not supported" % gui)
             return
+        except ImportError:
+            error("pylab mode doesn't work as matplotlib could not be found." + \
+                  "\nIs it installed on the system?")
+            return
         self.user_ns.update(ns)
         self.user_ns_hidden.update(ns)
         # Now we must activate the gui pylab wants to use, and fix %run to take

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -203,6 +203,10 @@ class InteractiveShellApp(Configurable):
                     self.log.info("Enabling GUI event loop integration, "
                                   "toolkit=%s" % self.gui)
                     shell.enable_gui(self.gui)
+            except ImportError:
+                self.log.warn("pylab mode doesn't work as matplotlib could not be found." + \
+                              "\nIs it installed on the system?")
+                self.shell.showtraceback()
             except Exception:
                 self.log.warn("GUI event loop or pylab initialization failed")
                 self.shell.showtraceback()


### PR DESCRIPTION
On a headless server, matplotlib is a unnecessary dependency and the ipython
console will crash badly, when tring to enable %pylab there.
In that case, just don't enable %pylab and ask the user to install matplotlib.

Original bug report: https://bugzilla.redhat.com/show_bug.cgi?id=872176
