### PR TITLE
for downloads, replaced window.open with window.location.assign

### DIFF
--- a/IPython/frontend/html/notebook/static/js/menubar.js
+++ b/IPython/frontend/html/notebook/static/js/menubar.js
@@ -58,13 +58,13 @@ var IPython = (function (IPython) {
             var notebook_id = IPython.notebook.get_notebook_id();
             var url = $('body').data('baseProjectUrl') + 'notebooks/' +
                       notebook_id + '?format=json';
-            window.open(url,'_newtab');
+            window.location.assign(url);
         });
         this.element.find('#download_py').click(function () {
             var notebook_id = IPython.notebook.get_notebook_id();
             var url = $('body').data('baseProjectUrl') + 'notebooks/' +
                       notebook_id + '?format=py';
-            window.open(url,'_newtab');
+            window.location.assign(url);
         });
         this.element.find('button#print_notebook').click(function () {
             IPython.print_widget.print_notebook();


### PR DESCRIPTION
`window.location.assign(url)` doesn't actually open a new window, so it's a bit nicer than `window.open(url, '_new')`, even though if not functionally different. 

Not important, though.

Source for idea: [StackOverflow](http://stackoverflow.com/questions/1066452/easiest-way-to-open-a-download-window-without-navigating-away-from-the-page)
