### PR TITLE
Fix pretty print of types when `__module__` is not available.

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -604,10 +604,16 @@ def _re_pattern_pprint(obj, p, cycle):
 
 def _type_pprint(obj, p, cycle):
     """The pprint for classes and types."""
-    if obj.__module__ in ('__builtin__', 'exceptions'):
+    try:
+        mod = obj.__module__
+    except AttributeError:
+        # Heap allocated types might not have the module attribute.
+        return p.text(obj.__name__)
+
+    if mod in ('__builtin__', 'exceptions'):
         name = obj.__name__
     else:
-        name = obj.__module__ + '.' + obj.__name__
+        name = mod + '.' + obj.__name__
     p.text(name)
 
 

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -18,6 +18,7 @@ import nose.tools as nt
 
 # Our own imports
 from IPython.lib import pretty
+from IPython.testing.decorators import skip_without
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -82,3 +83,12 @@ def test_callability_checking():
     expectedoutput = "Dummy1(...)"
 
     nt.assert_equal(gotoutput, expectedoutput)
+
+@skip_without('xxlimited')
+def test_pprint_heap_allocated_type():
+    """
+    Test that pprint works for heap allocated types.
+    """
+    import xxlimited
+    output = pretty.pretty(xxlimited.Null)
+    nt.assert_equal(output, 'xxlimited.Null')


### PR DESCRIPTION
In Python 3, heap allocated types -- for example those created using
PyType_FromSpec -- lack the `__module__` attribute.

Closes #2684
