### PR TITLE
Fix tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,13 +7,20 @@
 envlist = py26, py27, py32
 
 [testenv]
+deps =
+    nose
+
+# To avoid loading IPython module in the current directory, change
+# current directory to ".tox/py*/tmp" before running test.
+changedir = {envtmpdir}
+
 commands =
-    pip install -q --use-mirrors nose
+    # As pip does not treat egg, use easy_install to install PyZMQ.
+    # See also: https://github.com/zeromq/pyzmq
     easy_install -q pyzmq
-    iptest -w /tmp
+    iptest []
 
 [testenv:py32]
 commands =
-    pip install -q --use-mirrors nose
     easy_install -q pyzmq
-    iptest3 -w /tmp
+    iptest3 []


### PR DESCRIPTION
Prior to this patch, test for Python 3.2 failed.

Also, arguments can be passed to iptest via tox command now.
e.g.: `tox -- IPython.core`

Probably it makes sense to change .travis.yml to something like:

```
language: python
before_install:
    - pip install tox
script:
    - tox
```

Or you can use `tox -e ...` to run the tests parallel for each Python version.
