### PR TITLE
fix error in doc (arg->kwarg) and pep-8

### DIFF
--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -51,7 +51,7 @@ class MultipleInstanceError(ConfigurableError):
 
 class Configurable(HasTraits):
 
-    config = Instance(Config,(),{})
+    config = Instance(Config, (), {})
     created = None
 
     def __init__(self, **kwargs):
@@ -72,7 +72,7 @@ class Configurable(HasTraits):
 
             class MyConfigurable(Configurable):
                 def __init__(self, config=None):
-                    super(MyConfigurable, self).__init__(config)
+                    super(MyConfigurable, self).__init__(config=config)
                     # Then any other code you need to finish initialization.
 
         This ensures that instances will be configured properly.
@@ -165,7 +165,7 @@ class Configurable(HasTraits):
         final_help = []
         final_help.append(u'%s options' % cls.__name__)
         final_help.append(len(final_help[0])*u'-')
-        for k,v in sorted(cls.class_traits(config=True).iteritems()):
+        for k, v in sorted(cls.class_traits(config=True).iteritems()):
             help = cls.class_get_trait_help(v, inst)
             final_help.append(help)
         return '\n'.join(final_help)
@@ -218,7 +218,7 @@ class Configurable(HasTraits):
 
         # section header
         breaker = '#' + '-'*78
-        s = "# %s configuration"%cls.__name__
+        s = "# %s configuration" % cls.__name__
         lines = [breaker, s, breaker, '']
         # get the description trait
         desc = cls.class_traits().get('description')
@@ -245,7 +245,7 @@ class Configurable(HasTraits):
             lines.append(c('%s will inherit config from: %s'%(cls.__name__, pstr)))
             lines.append('')
 
-        for name,trait in cls.class_traits(config=True).iteritems():
+        for name, trait in cls.class_traits(config=True).iteritems():
             help = trait.get_metadata('help') or ''
             lines.append(c(help))
             lines.append('# c.%s.%s = %r'%(cls.__name__, name, trait.get_default_value()))

--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -35,13 +35,11 @@ import shutil
 import sys
 
 from IPython.config.application import Application, catch_config_error
-from IPython.config.configurable import Configurable
-from IPython.config.loader import Config, ConfigFileNotFound
+from IPython.config.loader import ConfigFileNotFound
 from IPython.core import release, crashhandler
 from IPython.core.profiledir import ProfileDir, ProfileDirError
 from IPython.utils.path import get_ipython_dir, get_ipython_package_dir
 from IPython.utils.traitlets import List, Unicode, Type, Bool, Dict
-from IPython.utils import py3compat
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -245,7 +243,7 @@ class BaseIPythonApplication(Application):
                 p = ProfileDir.find_profile_dir_by_name(self.ipython_dir, self.profile, self.config)
             except ProfileDirError:
                 # not found, maybe create it (always create default profile)
-                if self.auto_create or self.profile=='default':
+                if self.auto_create or self.profile == 'default':
                     try:
                         p = ProfileDir.create_profile_dir_by_name(self.ipython_dir, self.profile, self.config)
                     except ProfileDirError:


### PR DESCRIPTION
Fix error in doc : 

``` diff
"""
-            super(MyConfigurable, self).__init__(config)
+            super(MyConfigurable, self).__init__(config=config)
"""
```

Use this as an occasion to pep-8 the files a little and remove useless imports. 
