### PR TITLE
One liner to fix debugger printing stack traces when lines of context are larger than source.

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -352,8 +352,8 @@ class Pdb(OldPdb):
 
         start = lineno - 1 - context//2
         lines = ulinecache.getlines(filename)
-        start = max(start, 0)
         start = min(start, len(lines) - context)
+        start = max(start, 0)
         lines = lines[start : start + context]
 
         for i,line in enumerate(lines):


### PR DESCRIPTION
Correctly print stack traces when context is larger than lines of source.
