### PR TITLE
Skip notebook testing if jinja2 is not available.

### DIFF
--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -162,6 +162,7 @@ have['sqlite3'] = test_for('sqlite3')
 have['cython'] = test_for('Cython')
 have['oct2py'] = test_for('oct2py')
 have['tornado'] = test_for('tornado.version_info', (2,1,0), callback=None)
+have['jinja2'] = test_for('jinja2')
 have['wx'] = test_for('wx')
 have['wx.aui'] = test_for('wx.aui')
 have['azure'] = test_for('azure')
@@ -299,6 +300,9 @@ def make_exclude():
 
     if not have['tornado']:
         exclusions.append(ipjoin('frontend', 'html'))
+
+    if not have['jinja2']:
+        exclusions.append(ipjoin('frontend', 'html', 'notebook', 'notebookapp'))
 
     if not have['rpy2'] or not have['numpy']:
         exclusions.append(ipjoin('extensions', 'rmagic'))


### PR DESCRIPTION
I'm getting test errors in Python 3 because I don't have jinja2 installed.  For example:

```
E.......................S............
======================================================================
ERROR: Failure: ImportError (No module named jinja2)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/failure.py", line 37, in runTest
    raise self.exc_class(self.exc_val).with_traceback(self.tb)
  File "/usr/lib/python3/dist-packages/nose/loader.py", line 390, in loadTestsFromName
    addr.filename, addr.module)
  File "/usr/lib/python3/dist-packages/nose/importer.py", line 39, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/usr/lib/python3/dist-packages/nose/importer.py", line 86, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/home/bfroehle/.ipy_pr_tests/venv-python3.2/lib/python3.2/site-packages/ipython-0.14.dev-py3.2.egg/IPython/frontend/html/notebook/notebookapp.py", line 36, in <module>
    from jinja2 import Environment, FileSystemLoader
ImportError: No module named jinja2

----------------------------------------------------------------------
Ran 37 tests in 6.388s

FAILED (SKIP=1, errors=1)
```

I think the attached patch should fix this by skipping the frontend/html directory if jinja2 is not available.
