### PR TITLE
function specific tab completion via annotations

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -740,10 +740,12 @@ class IPCompleter(Completer):
         function_chain = last_function_chain(self.tokens)
 
         # resolve the final type of the function chain using gettattr and
-        # return annoations
+        # return annoations.
         try:
             obj = None
-            iter_function_chain = iter(function_chain)
+            # skip the final element in the function chain, since that
+            # is only a partial match
+            iter_function_chain = iter(function_chain[:-1])
             while 1:
                 try:
                     token = iter_function_chain.next()
@@ -833,7 +835,6 @@ class IPCompleter(Completer):
             functions that annotate specific function arguments with possible
             tab completions.
         """
-
         try:
             ids, post_tokens = last_open_identifier(self.tokens)
         except ValueError:
@@ -883,7 +884,7 @@ class IPCompleter(Completer):
             # create the namedtuple type, and stash it in self
             self.__func_argcomplete_Event = collections.namedtuple('Event',
                 ['text', 'tokens', 'line', 'ipcompleter'])
-        event = self.__func_argcomplete_Event(text=self.tokens[-1],
+        event = self.__func_argcomplete_Event(text=text,
             tokens=self.tokens, line=self.text_until_cursor,
             ipcompleter=self)
 
@@ -990,7 +991,6 @@ class IPCompleter(Completer):
         # if text is either None or an empty string, rely on the line buffer
         if not text:
             text = self.splitter.split_line(line_buffer, cursor_pos)
-
         # If no line buffer is given, assume the input text is all there was
         if line_buffer is None:
             line_buffer = text

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -551,8 +551,7 @@ class IPCompleter(Completer):
         text_until_cursor = self.text_until_cursor
         text_before_split = text_until_cursor[:text_until_cursor.rindex(text)]
         if text.startswith('.') and text_before_split.endswith(')'):
-            # RTM addition to not show file completion on f().<TAB>
-            # even though text == '.'
+            # do not show file completion on f().<TAB> even though text == '.'
             return []
 
         # track strings with open quotes
@@ -997,6 +996,8 @@ class IPCompleter(Completer):
 
         self.line_buffer = line_buffer
         self.text_until_cursor = self.line_buffer[:cursor_pos]
+
+        # tokenize the input line. these tokens are used by multiple matchers
         self.tokens = tokenize(self.text_until_cursor)
         #io.rprint('COMP2 %r %r %r' % (text, line_buffer, cursor_pos))  # dbg
 
@@ -1089,8 +1090,8 @@ class IPCompleter(Completer):
             # this flag on temporarily by uncommenting the second form (don't
             # flip the value in the first line, as the '# dbg' marker can be
             # automatically detected and is used elsewhere).
-            #DEBUG = False
-            DEBUG = True # dbg
+            DEBUG = False
+            #DEBUG = True # dbg
             if DEBUG:
                 try:
                     self.complete(text, line_buffer, cursor_pos)

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -735,7 +735,6 @@ class IPCompleter(Completer):
         if self.greedy:
             return super(IPCompleter, self).attr_matches(text)
 
-        # rmcgibbo
         function_chain = last_function_chain(self.tokens)
 
         # resolve the final type of the function chain using gettattr and
@@ -754,7 +753,8 @@ class IPCompleter(Completer):
                             pass
                         # and now resolve the return type of the function using
                         # its tab completion annotation
-                        obj = obj._tab_completions['return']
+                        if not inspect.isclass(obj):
+                            obj = obj._tab_completions['return']
                     elif token == '.':
                         # attribute access on a dot -- do a getattr
                         # call on the next token w.r.t. base

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -754,13 +754,21 @@ class IPCompleter(Completer):
             # skip the final element in the function chain, since that
             # is only a partial match
             iter_function_chain = iter(function_chain[:-1])
+            n_open_parens = 0
             while 1:
                 try:
                     token = next(iter_function_chain)
                     if token == '(':
+                        n_open_parens = 1
                         # skip ahead to matching close parentheses
-                        while next(iter_function_chain) != ')':
-                            pass
+                        while 1:
+                            next_token = next(iter_function_chain)
+                            if next_token == '(':
+                                n_open_parens += 1
+                            elif next_token == ')':
+                                n_open_parens -= 1
+                                if n_open_parens == 0:
+                                    break
                         # and now resolve the return type of the function using
                         # its tab completion annotation
                         if not inspect.isclass(obj):

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -557,7 +557,7 @@ class IPCompleter(Completer):
                 return []
         except ValueError:
             # when text is malformed and isn't a subsring of text_until_cursor
-            return []
+            pass
 
         # track strings with open quotes
         open_quotes = has_open_quotes(text_until_cursor)

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -748,10 +748,10 @@ class IPCompleter(Completer):
             iter_function_chain = iter(function_chain[:-1])
             while 1:
                 try:
-                    token = iter_function_chain.next()
+                    token = next(iter_function_chain)
                     if token == '(':
                         # skip ahead to matching close parentheses
-                        while iter_function_chain.next() != ')':
+                        while next(iter_function_chain) != ')':
                             pass
                         # and now resolve the return type of the function using
                         # its tab completion annotation
@@ -759,7 +759,7 @@ class IPCompleter(Completer):
                     elif token == '.':
                         # attribute access on a dot -- do a getattr
                         # call on the next token w.r.t. base
-                        obj = getattr(obj, iter_function_chain.next())
+                        obj = getattr(obj, next(iter_function_chain))
                     elif obj is None:
                         # if none of the above, but base is None, then we
                         # need to eval it

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -549,9 +549,14 @@ class IPCompleter(Completer):
             text_prefix = ''
 
         text_until_cursor = self.text_until_cursor
-        text_before_split = text_until_cursor[:text_until_cursor.rindex(text)]
-        if text.startswith('.') and text_before_split.endswith(')'):
-            # do not show file completion on f().<TAB> even though text == '.'
+
+        try:
+            text_before_split = text_until_cursor[:text_until_cursor.rindex(text)]
+            if text.startswith('.') and text_before_split.endswith(')'):
+                # do not show file completion on f().<TAB> even though text == '.'
+                return []
+        except ValueError:
+            # when text is malformed and isn't a subsring of text_until_cursor
             return []
 
         # track strings with open quotes

--- a/IPython/extensions/completion.py
+++ b/IPython/extensions/completion.py
@@ -1,4 +1,5 @@
-"""IPython extension annotate functions for tab completion
+# encoding: utf-8
+"" + """"IPython extension annotate functions for tab completion
 
 The ``tab_complete`` decorator enables argument specific tab completion
 for python functions as well as tab completion on the return value of functions

--- a/IPython/extensions/completion.py
+++ b/IPython/extensions/completion.py
@@ -133,11 +133,44 @@ def tab_complete(*args, **kwargs):
                     warnings.warn('Overwriting tab completion on %s' % key,
                         RuntimeWarning)
 
+        completers = _init_completers(kwargs)
         try:
-            f._tab_completions.update(_init_completers(kwargs))
+            f._tab_completions.update(completers)
         except AttributeError:
-            f._tab_completions = _init_completers(kwargs)
+            f._tab_completions = completers
+        return f
 
+    return wrapper
+
+
+def tab_complete_return(return_type):
+    """Convenience decorator to annotate the return value of a function for tab
+    completion.
+
+    The following two syntax are equivalent
+
+    In[1]: @tab_complete_return(str)
+      ...: def f():
+      ...:    return 'hello world'
+      ...:
+
+    In[2]: @tab_complete(**{'return': str})
+      ...: def f():
+      ...:    return 'hello world'
+      ...:
+    """
+    def wrapper(f):
+        annotations = {'return': return_type}
+        if hasattr(f, '_tab_completions'):
+            if 'return' in f._tab_completions:
+                warnings.warn('Overwriting tab completion on %s' % key,
+                    RuntimeWarning)
+
+        completers = _init_completers(annotations)
+        try:
+            f._tab_completions.update(completers)
+        except AttributeError:
+            f._tab_completions = completers
         return f
 
     return wrapper
@@ -184,6 +217,7 @@ class AnnotationCompleterBase(object):
         """
         pass
 
+
 class LiteralCompleter(AnnotationCompleterBase):
     """Annotation for function arguments that recommends completions from a
     set of enumerated literals. This is useful if you have an argumnet for a
@@ -219,6 +253,7 @@ class LiteralCompleter(AnnotationCompleterBase):
 
 literal = LiteralCompleter
 
+
 class GlobsToCompleter(AnnotationCompleterBase):
     """Annotation for function arguments that recommends completions which are
     filenames matching a glob pattern.
@@ -248,6 +283,7 @@ class GlobsToCompleter(AnnotationCompleterBase):
         return file_matches + dir_matches
 
 globs_to = GlobsToCompleter
+
 
 class InstanceOfCompleter(AnnotationCompleterBase):
     """Annotation for function arguments that recommends python variables in

--- a/IPython/extensions/completion.py
+++ b/IPython/extensions/completion.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-"" + """"IPython extension annotate functions for tab completion
+"""IPython extension annotate functions for tab completion
 
 The ``tab_complete`` decorator enables argument specific tab completion
 for python functions as well as tab completion on the return value of functions
@@ -47,6 +47,8 @@ This makes for example the following workflow possible:
     .endswith    .isdigit     .lower       .rpartition  .swapcase
     .expandtabs  .islower     .lstrip      .rsplit      .title
 """
+skip_doctest = True  # skip the doctest on the module level docstring
+
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2012  The IPython Development Team
 #

--- a/IPython/extensions/completion.py
+++ b/IPython/extensions/completion.py
@@ -1,0 +1,243 @@
+import inspect
+import functools
+import warnings
+import types
+import glob
+import abc
+import re
+
+from IPython.core.completer import has_open_quotes
+__all__ = ['tab_complete', 'globs_to', 'literal', 'instance_of']
+
+def _init_completers(annotations):
+    tab_completers = {}
+    for key, value in annotations.iteritems():
+        error = ValueError("I could not understand the "
+            "annotation %s on argument %s" % (value, key))
+        
+        # the return value annotation must be just a straight class
+        if key == 'return':
+            if inspect.isclass(value):
+                tab_completers[key] = value
+            else:
+                raise error
+        elif isinstance(value, AnnotationCompleterBase):
+            tab_completers[key] = value
+        elif inspect.isclass(value):
+            # instance_of is the default
+            tab_completers[key] = instance_of(value)
+        else:
+            raise error
+    return tab_completers
+
+
+def tab_complete(*args, **kwargs):
+    if (len(args) == 1 and len(kwargs.keys()) == 0 and
+        hasattr(args[0], '__call__')):
+        # this decorator was called with no arguments and is
+        # wrapping a function where the annotations are defined
+        # with py3k syntax
+        f = args[0] # rename
+        if not hasattr(f, '__annotations__'):
+            raise ValueError('f is not annotated')
+            
+        f._tab_completions = _init_completers(f.__annotations__)
+        return f
+
+    # otherwise, this decorator is being called with arguments, indicating
+    # python2 syntax
+    def wrapper(f):
+        argspec = inspect.getargspec(f)
+        for key in kwargs.keys():
+            if (key not in argspec.args) and (key != argspec.varargs) \
+                    and (key != argspec.keywords) and key != 'return':
+                raise ValueError('%s is not an argument taken by %s' \
+                    % (key, wrapper.__name__))
+
+            if hasattr(f, '_tab_completions'):
+                # check that the annotations being provided don't already exist
+                # if they do, we warn and overwrite. this decorator does not
+                # implement any scheme for composing annotations.
+                if key in f.__annotations__:
+                    warnings.warn('Overwriting tab completion on %s' % key,
+                        RuntimeWarning)
+        
+        try:
+            f._tab_completions.update(_init_completers(kwargs))
+        except AttributeError:
+            f._tab_completions = _init_completers(kwargs)
+
+        return f
+
+    return wrapper
+
+
+class AnnotationCompleterBase(object):
+    """Abstract base class for IPython annotation based tab completion
+    annotators
+    """
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def tab_matches(self, event):
+        """Callback for the function-annotation tab completion system.
+
+        If the user attempts to do a tab completion on an argument
+        (to a function/method) that is annotated for tab completion,
+        this callback will be executed.
+
+        Parameters
+        ----------
+        event : nametuple
+            event is a namedtuple containing four keys: 'text', 'tokens',
+            'line', and 'ipcompleter'
+
+        `Event` Attributes
+        ------------------
+        event.line : str
+            event.line contains the full line entered by the IPython user.
+        event.text : str
+            event.text is the last portion of the line, formed by splitting
+            the line on a set of python-language delimiters, and returning you
+            the last portion.
+        event.tokens : list of strings
+            event.tokens is the result of running the python standard library
+            tokenizer on event.line. This is similar to splitting on
+            delimiters as above, but slightly different for string literals in
+            particular, where, for instance, '''a''' would be a single token.
+        event.ipcompleter : IPython.core.completer.IPCompleter
+            This is a reference back to the caller's class. You can use this
+            to get access to more functions to aid in parsing the line,
+            namespaces, to get configuration options from the IPython
+            configuration system, etc.
+        """
+        pass
+
+class literal(AnnotationCompleterBase):
+    """Annotation for function arguments that recommends completions from a
+    set of enumerated literals. This is useful if you have an argumnet for a
+    function that is designed to be called only with a small handful of possible
+    values"""
+
+    def __init__(self, *completions):
+        """Set up a tab completion callback.
+
+        Example (python 3)
+        ------------------
+        In[3]: def f(x : tab_literal(100, 200, 300)):
+        ...        pass
+        In[4]: f(1<HIT_THE_TAB_KEY>
+        will fill in the 100
+        """
+        self.completions = completions
+
+    def tab_matches(self, event):
+        """Callback for the IPython annoation tab-completion system
+        """
+        # the complicated stuff here is handling string literals, because we want
+        # to make readline see the quotation marks, which it usually thinks are
+        # just delimiters and doesn't deal with.
+        matches = []
+        for cb in self.completions:
+            if isinstance(cb, basestring):
+                if event.tokens[-1] in [' ', '=', '(']:
+                    matches.append("'%s'" % cb)
+                elif event.tokens[-1] == ',':
+                    matches.append(" '%s'" % cb)
+                elif has_open_quotes(event.line) and cb.startswith(event.text):
+                    matches.append(cb)
+            else:
+                str_cb = str(cb)
+                if str_cb.startswith(event.text):
+                    matches.append(str_cb)
+
+        return matches
+
+class globs_to(AnnotationCompleterBase):
+    """Annotation for function arguments that recommends completions which are
+    filenames matching a glob pattern.
+    """
+
+    def __init__(self, glob_pattern):
+        """Set up a tab completion callback with glob matching
+
+        Example (python 3)
+        ------------------
+        In[5]: def f(x : tab_glob("*.txt")):
+        ...        pass
+
+        In[6]: f(<HIT_THE_TAB_KEY>
+        will show you files ending in .txt
+        """
+        self.glob_pattern = glob_pattern
+
+    def tab_matches(self, event):
+        """Callback for the IPython annoation tab-completion system
+        """
+
+        matches = []
+
+        if event.tokens[-1] in [' ', '=', '(']:
+            fmt = "'%s'"
+        elif event.tokens[-1] == ',':
+            fmt = " '%s'"
+        else:
+            fmt = '%s'
+
+        file_matches = [fmt % m for m in glob.glob(event.text + self.glob_pattern)]
+        dir_matches = [fmt % m for m in glob.glob(event.text + '*/')]
+        
+        return file_matches + dir_matches
+
+
+class instance_of(AnnotationCompleterBase):
+    """Annotation for function arguments that recommends python variables in
+    your namespace that an instance of supplied types"""
+
+    def __init__(self, *klasses):
+        """Set up a tab completion callback with isinstance matching
+
+        Parameters
+        ----------
+        klasses : the classes you'd like to match on
+
+        Example (python 3)
+        ------------------
+        In[7]: x, y = 1, 2
+        In[8]: def f(x : tab_instance(int)):
+        ...        pass
+
+        In[9]: f(<TAB>
+        will show you files ending in .txt
+
+        Limitations
+        -----------
+        Because of python's dynamic typing, this can't check the type of the
+        return value of functions, so this won't be able to recommend something
+        like max(1,2) in the previous example.
+        """
+        self.klasses = set(klasses)
+        self._omit__names_1 = re.compile(r'__.*?__')
+        self._omit__names_2 = re.compile(r'_.*?')
+        
+    def tab_matches(self, event):
+        """Callback for the IPython annoation tab-completion system
+        """
+        matches = []
+        for key in event.ipcompleter.python_matches(event.text):
+            try:
+                if any(isinstance(eval(key, event.ipcompleter.namespace), klass)
+                        for klass in self.klasses):
+                    matches.append(key)
+            except:
+                continue
+
+        if event.ipcompleter.omit__names:
+            if event.ipcompleter.omit__names == 1:
+                no__name = (lambda txt: self._omit__names_1.match(txt) is None)
+            else:
+                # true if txt is _not_ a _ name, false otherwise:
+                no__name = (lambda txt: self._omit__names_2.match(txt) is None)
+
+            matches = filter(no__name, matches)
+        return matches

--- a/IPython/extensions/completion.py
+++ b/IPython/extensions/completion.py
@@ -33,9 +33,9 @@ This makes for example the following workflow possible:
     string1  string2
 
     In [6]: @tab_complete
-      ...: def baz(x) -> str:
-      ...:     pass
-      ...:
+       ...: def baz(x) -> str:
+       ...:     pass
+       ...:
 
     In [7]: baz(notevaluated).<TAB>
     .capitalize  .find        .isspace     .partition   .rstrip      .translate

--- a/IPython/extensions/tests/test_completion.py
+++ b/IPython/extensions/tests/test_completion.py
@@ -1,0 +1,120 @@
+"""
+tab completion api
+
+@tab_completion
+def f(x : int, y : dict) -> int:
+    pass
+"""
+from IPython.extensions.completion import (tab_complete, globs_to,
+    instance_of, literal)
+
+from IPython.utils.tempdir import TemporaryDirectory
+from IPython.testing.decorators import skipif
+import nose.tools as nt
+import sys, os
+
+
+# @skipif(sys.version_info.major == 2)
+# def test_decorator():
+#     # test that two ways of annotating give the same result
+#     for ann in [tab_glob('.txt'), tab_instance(int, set), tab_literal(1,2)]:
+#         @tab_completion
+#         def f1(arg1 : ann, arg2):
+#             pass
+#         @tab_completion(arg1=ann)
+#         def f2(arg1, arg2):
+#             pass
+#     
+#         yield lambda : nt.assert_equal(f1.__tab_completions__, f2.__tab_completions__)
+# 
+# 
+# 
+#     # test that the (unfortunate) python 2 style sytax for annotating the return
+#     # value puts the data in the same place as the py3k syntax
+#     for ann in [tab_glob('.txt'), tab_instance(int, set), tab_literal(1,2)]:
+#         @tab_completion
+#         def f1(arg1, arg2) -> ann:
+#             pass
+#         
+#         @tab_completion_return(ann)
+#         def f2(arg1, arg2):
+#             pass
+#             
+#         yield lambda : nt.assert_equal(f1.__tab_completions__, f2.__tab_completions__)
+
+
+def test_literal1():
+    ip = get_ipython()
+    @tab_complete(a=literal('aaaaaaaaaa'))
+    def f(a):
+        pass
+    ip.user_ns['f'] = f
+    yield lambda : nt.assert_equal(ip.complete(None, "f(")[1],
+        ["'aaaaaaaaaa'"])
+        
+    yield lambda : nt.assert_equal(ip.complete(None, "f('a")[1],
+        ['aaaaaaaaaa'])
+
+
+def test_default_instance():
+    ip = get_ipython()
+    @tab_complete(a=int)
+    def f(a):
+        pass
+    ip.user_ns['f'] = f
+    ip.user_ns['longint1'] = 1
+    ip.user_ns['longint2'] = 1
+    nt.assert_equal(ip.complete(None, "f(l")[1], ['longint1', 'longint2'])
+    
+def test_literal2():
+    ip = get_ipython()
+    # easy tab completion on two literal strings
+    @tab_complete(arg1=literal('completion1', 'completion2'))
+    def f(arg1 , arg2):
+        pass
+    ip.user_ns['f'] = f
+    yield lambda : nt.assert_equal(ip.complete(None, "f('complet")[1],
+            ['completion1', 'completion2'])
+    
+    # this is slightly harder because under normal circumstances the
+    # complex builtin would match, but in this case it should be excluded
+    yield lambda : nt.assert_equal(ip.complete(None, "f('comple")[1],
+        ['completion1', 'completion2'])
+
+
+def test_glob1():
+    ip = get_ipython()
+    @tab_complete(x=globs_to('*.txt'))
+    def f(x):
+        pass
+    ip.user_ns['f'] = f
+    
+    with TemporaryDirectory() as tmpdir:
+        names = [os.path.join(tmpdir, e) for e in ['a.txt', 'b.jpg', 'c.txt']]
+        for n in names:
+            open(n, 'w').close()
+        
+        # Check simple completion
+        c = ip.complete(None, 'f(%s/' % tmpdir)[1]
+        nt.assert_equal(c, ["%s/a.txt" % tmpdir, "%s/c.txt" % tmpdir])
+
+def test_method():
+    ip = get_ipython()
+    class F(object):
+        @tab_complete(arg1=literal('bar_baz_qux'))
+        def foo(self, arg1):
+            pass
+    ip.user_ns['f'] = F()
+    
+    nt.assert_equal(ip.complete(None, 'f.foo(')[1],
+        ["'bar_baz_qux'"])
+
+
+def test_constructor():
+    ip = get_ipython()
+    class F(object):
+        @tab_complete(arg1=literal('bar_baz_qux'))
+        def __init__(self, arg1):
+            pass
+    ip.user_ns['F'] = F
+    nt.assert_equal(ip.complete(None, 'F(')[1], ["'bar_baz_qux'"])

--- a/IPython/utils/tests/test_tokens.py
+++ b/IPython/utils/tests/test_tokens.py
@@ -1,0 +1,155 @@
+# encoding: utf-8
+"""Tests for IPython.utils.tokens"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2012  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+from IPython.utils import tokens
+
+# third party
+import nose.tools as nt
+
+#-----------------------------------------------------------------------------
+# Test tokenize
+#-----------------------------------------------------------------------------
+
+def test_tokenize_1():
+    got = tokens.tokenize('a + b = ["cdefg" + 10]')
+    correct = ['a', '+', 'b', '=', '[', '"cdefg"', '+', '10', ']']
+    
+    nt.assert_equal(got, correct)
+    
+def test_tokenize_2():
+    # make sure the contents of string literals ges parsed as a single tokens
+    # including inside of tripple quotes.
+    got = tokens.tokenize("'a/b' + '''b\nc'''")
+    correct = ["'a/b'", "+", "'''b\nc'''"]
+    
+    nt.assert_equal(got, correct)
+
+
+#-----------------------------------------------------------------------------
+# Test last_open_identifier
+#-----------------------------------------------------------------------------
+
+def test_last_open_identifier_1():
+    src = "f(a, b, c"
+    identifier, call_tokens = tokens.last_open_identifier(tokens.tokenize(src))
+    correct_identifier = ['f']
+    correct_call_tokens = ['(', 'a', ',', 'b', ',', 'c']
+    
+    nt.assert_equal(identifier, correct_identifier)
+    nt.assert_equal(call_tokens, correct_call_tokens)
+    
+def test_last_open_identifier_2():
+    src = "foo.bar(a, b, c"
+    identifier, call_tokens = tokens.last_open_identifier(tokens.tokenize(src))
+    correct_identifier = ['foo', 'bar']
+    correct_call_tokens = ['(', 'a', ',', 'b', ',', 'c']
+    
+    nt.assert_equal(identifier, correct_identifier)
+    nt.assert_equal(call_tokens, correct_call_tokens)
+    
+def test_last_open_identifier_3():
+    src = 'foo((a,b), c'
+    identifier, call_tokens = tokens.last_open_identifier(tokens.tokenize(src))
+    correct_identifier = ['foo']
+    correct_call_tokens = ['(', '(', 'a', ',', 'b', ')', ',', 'c']
+    
+    nt.assert_equal(identifier, correct_identifier)
+    nt.assert_equal(call_tokens, correct_call_tokens)
+
+def test_last_open_identifier_4():
+    src = 'foo("a,b", c'
+    identifier, call_tokens = tokens.last_open_identifier(tokens.tokenize(src))
+    correct_identifier = ['foo']
+    correct_call_tokens = ['(', '"a,b"', ',', 'c']
+    
+    nt.assert_equal(identifier, correct_identifier)
+    nt.assert_equal(call_tokens, correct_call_tokens)
+
+#-----------------------------------------------------------------------------
+# Test last_function_chain
+#-----------------------------------------------------------------------------
+
+def test_last_function_chain_1():
+    src = "var = foobar(bar().qux().baz"
+    got = tokens.last_function_chain(tokens.tokenize(src))
+    correct = ['bar', '(', ')', '.', 'qux', '(', ')', '.', 'baz']
+    nt.assert_equal(got, correct)
+
+def test_last_function_chain_2():
+    src = 'var = bar("(abc").qux.baz'
+    got = tokens.last_function_chain(tokens.tokenize(src))
+    correct = ['bar', '(', '"(abc"', ')', '.', 'qux', '.', 'baz']
+    nt.assert_equal(got, correct)
+
+def test_last_function_chain_3():
+    src = 'bar().qux.baz'
+    got = tokens.last_function_chain(tokens.tokenize(src))
+    correct = ['bar', '(', ')', '.', 'qux', '.', 'baz']
+    nt.assert_equal(got, correct)
+
+def test_last_function_chain_4():
+    src = '{"a": bar().qux.baz'
+    got = tokens.last_function_chain(tokens.tokenize(src))
+    correct = ['bar', '(', ')', '.', 'qux', '.', 'baz']
+    nt.assert_equal(got, correct)
+
+def test_last_function_chain_5():
+    src = '{bar().qux.baz'
+    got = tokens.last_function_chain(tokens.tokenize(src))
+    correct = ['bar', '(', ')', '.', 'qux', '.', 'baz']
+    nt.assert_equal(got, correct)
+
+def test_last_function_chain_6():
+    src = '(bar().qux.baz'
+    got = tokens.last_function_chain(tokens.tokenize(src))
+    correct = ['bar', '(', ')', '.', 'qux', '.', 'baz']
+    nt.assert_equal(got, correct)
+
+#-----------------------------------------------------------------------------
+# Test cursor_argument
+#-----------------------------------------------------------------------------
+
+def test_cursor_argument_1():
+    def f(aa, bb=1, cc=1):
+        pass
+    call_src = "(a, b, c"
+    call_tokens = tokens.tokenize(call_src)
+    nt.assert_equal('cc', tokens.cursor_argument(call_tokens, f))
+
+def test_cursor_argument_2():
+    def f(aa, bb=1, cc=1):
+        pass
+    call_src = "(a, cc="
+    call_tokens = tokens.tokenize(call_src)
+    nt.assert_equal('cc', tokens.cursor_argument(call_tokens, f))
+
+def test_cursor_argument_3():
+    def f(aa, bb=1, cc=1):
+        pass
+    call_src = "(a, {a:b, c"
+    call_tokens = tokens.tokenize(call_src)
+    nt.assert_equal('bb', tokens.cursor_argument(call_tokens, f))
+
+def test_cursor_argument_4():
+    def f(aa, bb=1, cc=1):
+        pass
+    call_src = "(a, (a, b"
+    call_tokens = tokens.tokenize(call_src)
+    nt.assert_equal('bb', tokens.cursor_argument(call_tokens, f))
+
+def test_cursor_argument_5():
+    def f(aa, bb=1, cc=1):
+        pass
+    call_src = "(a, (a, b), c"
+    call_tokens = tokens.tokenize(call_src)
+    nt.assert_equal('cc', tokens.cursor_argument(call_tokens, f))

--- a/IPython/utils/tokens.py
+++ b/IPython/utils/tokens.py
@@ -1,0 +1,283 @@
+# encoding: utf-8
+"""
+Utilities for tokenizing source code and processesing those tolens
+"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2012  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+import StringIO
+import inspect
+import tokenize as _tokenizelib
+import re
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------
+
+def tokenize(src):
+    """Tokenize a block of python source code using the stdlib's tokenizer.
+
+    Parameters
+    ----------
+    src : str
+        A string of potential python source code. The code isn't evaled, it's
+        just split into its representive tokens
+
+    Returns
+    -------
+    tokens : list of strings
+        A list of tokens. Tokenizer errors from invalid python source (like
+        unclosed string delimiters) are supressed.
+
+    Examples
+    --------
+    In [1]: tokenize('a + b = ["cdefg" + 10]')
+    ['a', '+', 'b', '=', '[', '"cdefg"', '+', '10', ']']
+
+    Notes
+    -----
+    This serves a similar function to simply splitting the source on delmiters
+    (as done by CompletionSplitter) but is slightly more sophisticated. In
+    particular, characters that are delmiters are never returned in the tokens
+    by CompletionSplitter (or its regular expression engine), so something
+    like this happens:
+
+    In[2]: a = CompletionSplitter()._delim_re.split('a+ "hello')
+    In[3]: b = CompletionSplitter()._delim_re.split('a+= hello')
+    In[4]: a == b
+    True
+
+    This makes it very tricky to do complicated types of tab completion.
+
+    This tokenizer instead uses the stdlib's tokenize, which is a little
+    bit more knowledgeable about python syntax. In particular, string literals
+    e.g. `tokenize("'a' + '''bc'''") == ["'a'", "+", "'''bc'''"]` get parsed
+    as single tokens.
+    """
+    rawstr = StringIO.StringIO(src)
+    iter_tokens = _tokenizelib.generate_tokens(rawstr.readline)
+    def run():
+        try:
+            for toktype, toktext, (srow,scol), (erow,ecol), line  in iter_tokens:
+                if toktype != _tokenizelib.ENDMARKER:
+                    yield toktext
+        except _tokenizelib.TokenError:
+            pass
+    tokens = list(run())
+    return tokens
+
+
+def last_open_identifier(tokens):
+    """Find the the nearest identifier (function/method/callable name)
+    that comes before the last unclosed parentheses
+
+    Parameters
+    ----------
+    tokens : list of strings
+        tokens should be a list of python tokens produced by splitting
+        a line of input
+
+    Returns
+    -------
+    identifiers : list
+        A list of tokens from `tokens` that are identifiers for the function
+        or method that comes before an unclosed partentheses
+    call_tokens : list
+        The subset of the tokens that occur after `identifiers` in the input,
+        starting with the open parentheses of the function call
+
+    Raises
+    ------
+    ValueError if the line doesn't match
+
+    See Also
+    --------
+    tokenize : to generate `tokens`
+    cursor_argument
+    """
+
+    # 1. pop off the tokens until we get to the first unclosed parens
+    # as we pop them off, store them in a list
+    iterTokens = iter(reversed(tokens))
+    tokens_after_identifier = []
+
+    openPar = 0 # number of open parentheses
+    for token in iterTokens:
+        print openPar, token
+        tokens_after_identifier.insert(0, token)
+        if token == ')':
+            openPar -= 1
+        elif token == '(':
+            openPar += 1
+            if openPar > 0:
+                # found the last unclosed parenthesis
+                break
+    else:
+        return None
+
+    # 2. Concatenate dotted names ("foo.bar" for "foo.bar(x, pa" )
+    identifiers = []
+    isId = re.compile(r'\w+$').match
+    while True:
+        try:
+            identifiers.append(next(iterTokens))
+            if not isId(identifiers[-1]):
+                identifiers.pop(); break
+            if not next(iterTokens) == '.':
+                break
+        except StopIteration:
+            break
+
+    return identifiers[::-1], tokens_after_identifier
+
+
+def last_function_chain(tokens):
+    """Find the last open chain of function/method/callables in a set of tokens.
+    
+    Examples
+    --------
+    In [8]: src = "var = foo(bar().qux().baz"
+
+    In [9]: last_function_chain(tokenize(src))
+    Out[9]: ['bar', '(', ')', '.', 'qux', '(', ')', '.', 'baz']
+    """
+    last_chain = []
+    n_open_parens = 0
+    for token in iter(reversed(tokens)):
+        if token == '(':
+            n_open_parens += 1
+        elif token == ')':
+            n_open_parens -= 1
+        if n_open_parens > 0:
+            break
+        if token in set(['=', ':', '{']) and n_open_parens == 0:
+            break
+        last_chain.insert(0, token)
+        
+    return last_chain
+
+
+class MatchingDelimiterCounter(object):
+    """Little utility class for counting the current
+    number of various types of matching delimiters in
+    tokenized input.
+    
+    Attributes
+    ----------
+    n_open_parens : int
+        Current number of open parentheses
+    n_open_braces : int
+        Current number of open curly braces 
+    n_open_bracket : int
+        Current number of open square brackets
+    """
+
+    def __init__(self):
+        self.n_open_parens = 0
+        self.n_open_braces = 0
+        self.n_open_brackets = 0
+        self._dispatch = {
+            '(': self._open_paren,
+            ')': self._close_paren,
+            '{': self._open_brace,
+            '}': self._close_brace,
+            '[': self._open_bracket,
+            ']': self._close_bracket
+        }
+    
+    def push(self, token):
+        """Push a new token onto the counter
+        
+        Returns
+        -------
+        matched : bool
+            True if the token was matched, false otherwise.
+        """
+        if token in self._dispatch:
+            self._dispatch[token]()
+            return True
+        return False
+    
+    def _open_paren(self):
+        self.n_open_parens += 1
+    def _close_paren(self):
+        self.n_open_parens -= 1
+    def _open_bracket(self):
+        self.n_open_brackets += 1
+    def _close_bracket(self):
+        self.n_open_brackets -= 1
+    def _open_brace(self):
+        self.n_open_braces += 1
+    def _close_brace(self):
+        self.n_open_braces -= 1
+
+
+def cursor_argument(call_tokens, obj):
+    """Determine which argument the cursor is currently entering
+
+    Parameters
+    ----------
+    call_tokens : str
+        Tokens after the last unclosed parentheses on the current
+        line, starting with an open parens
+    obj : callable
+        The function or method being called
+
+    Returns
+    -------
+    argname : str, None
+        the name of one of the arguments to the function, or None
+
+    Examples
+    --------
+    In[5]: def foo(x, y, z):
+    ...        pass
+    In[6]: call_tokens == ['(', '1', ',', 'bar']
+    True
+    In[7]: cursor_argument(call_tokens, foo)
+    'y'
+
+    See ALso
+    --------
+    tokenize
+    """
+    try:
+        argspec = inspect.getargspec(obj)
+    except ValueError:
+        # python3
+        argspec = inspect.getfullargspec(obj)
+    
+    if call_tokens[0] != '(':
+        raise ValueError('The first token must be "(". You supplied %s' \
+            % call_tokens[0])
+    n_commas = 0
+    counter = MatchingDelimiterCounter()
+    prev_token = None
+    
+    for token in call_tokens[1:]:  # ignore first open parens
+        if (counter.n_open_parens == 0) and (counter.n_open_braces == 0) and \
+                (counter.n_open_brackets == 0):
+            if token == '=':
+                # short circuit this stuff, they're using a named argument, so we'll
+                # just take that name
+                return prev_token
+            if token == ',':
+                n_commas += 1
+
+        counter.push(token)
+        prev_token = token
+        
+    if inspect.ismethod(obj):
+        # need to ignore self
+        return argspec.args[n_commas+1]
+
+    return argspec.args[n_commas]

--- a/IPython/utils/tokens.py
+++ b/IPython/utils/tokens.py
@@ -112,7 +112,6 @@ def last_open_identifier(tokens):
 
     openPar = 0 # number of open parentheses
     for token in iterTokens:
-        print openPar, token
         tokens_after_identifier.insert(0, token)
         if token == ')':
             openPar -= 1
@@ -122,7 +121,7 @@ def last_open_identifier(tokens):
                 # found the last unclosed parenthesis
                 break
     else:
-        return None
+        raise ValueError()
 
     # 2. Concatenate dotted names ("foo.bar" for "foo.bar(x, pa" )
     identifiers = []


### PR DESCRIPTION
This is a new attempt at #2636. The feature enables custom tab completion for different arguments of a function, and also for the return value of a function (without calling it).

It's easier to show in action though. Check it out!

---

Here's tab completion on the return value of a function, without ever `eval`ing the function

```
In [1]: from IPython.extensions.completion import tab_complete, globs_to,  literal

In [2]: @tab_complete
  ...: def baz(x) -> str:
  ...:     pass
  ...:

In [3]: baz(notevaluated).<TAB>
.capitalize  .find        .isspace     .partition   .rstrip      .translate
.center      .format      .istitle     .replace     .split       .upper
.count       .index       .isupper     .rfind       .splitlines  .zfill
.decode      .isalnum     .join        .rindex      .startswith
.encode      .isalpha     .ljust       .rjust       .strip
.endswith    .isdigit     .lower       .rpartition  .swapcase
.expandtabs  .islower     .lstrip      .rsplit      .title
```

Note that sense this never calls the function, all the tab completion is based on methods defined on the `str` class. If you notate the return value as some class that dynamically defines its methods when it is
instantiated, the tab complete engine is not going to be able to find them. There's no way around this without actually invoking the code on the TAB keypress, which is not desired (and is already possible by configuring your ipython config file).

---

Here, tab completion on the first argument only shows literal strings and directories that match a `glob` pattern. For the second argument, it shows some string literals.

```
In [4]: @tab_complete
   ...: def foo(x : globs_to('*.txt'), mode : literal('r', 'w')):
   ...:     pass
   ...:

In [5]: foo(<TAB>
'COPYING.txt'        'dist/'              'setupext/'
'IPython/'           'docs/'              'tools/'
'__pycache__/'       'ipython.egg-info/'
'build/'             'scripts/'

In[6]: foo('COPYING.txt', <TAB>
'r', 'w'
```

---

The default type of tab completion is based on `isinstance` matching. You could also be explicit about it:

```
In [7]: @tab_complete
   ...: def bar(x : str, x : instance_of(str)):
   ...:     pass
   ...:

In [8]: string1 = string2 = 'some string'

In [9]: bar(<TAB>
string1  string2

In [9]: bar('a', <TAB>
string1  string2
```

All of this functionality is possible in python2 syntax (without [PEP3107](http://www.python.org/dev/peps/pep-3107/) annotations) by calling the `@tab_complete` decorator with keyword arguments.

The design here was influenced by Nick Coghlan's [emails](http://mail.python.org/pipermail/python-ideas/2012-December/018092.html) on python-ideas, and an annotation-based [typechecking library](http://code.activestate.com/recipes/572161-method-signature-type-checking-decorator-for-pytho/) on activestate.
