### PR TITLE
rmagic extension: saving ggplot graphs (2 line fix)

### DIFF
--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -528,6 +528,13 @@ class RMagics(Magics):
 
         self.r('dev.off()')
 
+        # try saving any ggplots, but run the ggsave command inside of a try
+        # catch block that passes on any exceptions, this keeping ggplot
+        # purely optional
+        ggplot_save_cmd = 'tryCatch({ggsave("%s/Rplots_gg%%03d.png", %s)}, error=function(e) {})'\
+            % (tmpd.replace('\\', '/'), png_args)
+        self.r(ggplot_save_cmd)
+
         # read out all the saved .png files
 
         images = [open(imgfile, 'rb').read() for imgfile in glob("%s/Rplots*png" % tmpd)]


### PR DESCRIPTION
This is a response to [an email](http://comments.gmane.org/gmane.comp.python.ipython.devel/9765) on IPython-dev, which mentioned that its hard to get plots generated by ggplot in R using the rmagic extension to render in the notebook.

The reason for the issue is that, using the standard R graphics, the rmagic extension manually saves the graph in a tempdir with a special file name and then loads them up to send to the display publisher. Since it doesn't cd into that directory, there's no way to just save your ggplot graph in the right spot.

While ggplot is an R extension, it is very widely used. Wikipedia calls it one of the more popular R packages. https://en.wikipedia.org/wiki/Ggplot2

This PR runs its code in a little R try/catch block, so if you don't have ggplot loaded up (or installed), it's no problem.

demo: http://nbviewer.ipython.org/4349612/
