### PR TITLE
Doc bugfix: user_ns is not an attribute of Magic objects.

### DIFF
--- a/docs/source/interactive/reference.txt
+++ b/docs/source/interactive/reference.txt
@@ -227,7 +227,7 @@ IPython object:
         def lmagic(self, line):
             "my line magic"
             print "Full access to the main IPython object:", self.shell
-            print "Variables in the user namespace:", self.user_ns.keys()
+            print "Variables in the user namespace:", self.shell.user_ns.keys()
             return line
 
         @cell_magic


### PR DESCRIPTION
The interactive reference document has a minor bug where the user_ns is not accessed correctly.  This fixes that issue, getting the namespace via the shell's user_ns attribute.
