### PR TITLE
One liner to fix debugger printing stack traces when lines of context are larger than source.

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -352,8 +352,8 @@ class Pdb(OldPdb):
 
         start = lineno - 1 - context//2
         lines = ulinecache.getlines(filename)
-        start = max(start, 0)
         start = min(start, len(lines) - context)
+        start = max(start, 0)
         lines = lines[start : start + context]
 
         for i,line in enumerate(lines):

--- a/IPython/core/tests/test_debugger.py
+++ b/IPython/core/tests/test_debugger.py
@@ -121,3 +121,22 @@ def test_ipdb_magics():
     Constructor Docstring:Docstring for ExampleClass.__init__
     ipdb> continue
     '''
+
+def test_ipdb_magics():
+    '''Test ipdb with a very short function.
+
+    >>> def bar():
+    ...     pass
+
+    Run ipdb.
+
+    >>> with PdbTestInput([
+    ...    'continue',
+    ... ]):
+    ...     debugger.Pdb().runcall(bar)
+    > <doctest ...>(2)bar()
+          1 def bar():
+    ----> 2    pass
+    <BLANKLINE>
+    ipdb> continue
+    '''


### PR DESCRIPTION
Correctly print stack traces when context is larger than lines of source.

To test:

```
In [6]: def bar():
   ...:     return 20
   ...:
```

Before:

```
In [7]: ipdb.runcall(bar)
 <ipython-input-6-d0ed3bd5e16c>(2)bar()
          0     return 20
```

And here's after:

```
In [6]: ipdb.runcall(bar)
 <ipython-input-5-d0ed3bd5e16c>(2)bar()
          1 def bar():
    ----> 2     return 20
```

Replaces gh-2697.  (Adds a test.)
