### PR TITLE
try to fallback to pysqlite2.dbapi2 as sqlite3 in core.history

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -20,7 +20,10 @@ import re
 try:
     import sqlite3
 except ImportError:
-    sqlite3 = None
+    try:
+        from pysqlite2 import dbapi2 as sqlite3
+    except ImportError:
+        sqlite3 = None
 import threading
 
 # Our own packages


### PR DESCRIPTION
for situations where Python is built without sqlite3 and
can not easily be changed, it would be nice to still be
able to get history with pysqlite2.
