### PR TITLE
diverse fixes for project url

### DIFF
--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -874,25 +874,6 @@ class FileFindHandler(web.StaticFileHandler):
         return None
 
 
-    # make_static_url and parse_url_path totally unchanged from tornado 2.2.0
-    # but needed for tornado < 2.2.0 compat
-    @classmethod
-    def make_static_url(cls, settings, path):
-        """Constructs a versioned url for the given path.
-
-        This method may be overridden in subclasses (but note that it is
-        a class method rather than an instance method).
-
-        ``settings`` is the `Application.settings` dictionary.  ``path``
-        is the static path being requested.  The url returned should be
-        relative to the current host.
-        """
-        static_url_prefix = settings.get('static_url_prefix', '/static/')
-        version_hash = cls.get_version(settings, path)
-        if version_hash:
-            return static_url_prefix + path + "?v=" + version_hash
-        return static_url_prefix + path
-
     def parse_url_path(self, url_path):
         """Converts a static URL path into a filesystem path.
 

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -164,8 +164,9 @@ class NotebookWebApplication(web.Application):
             template_path=os.path.join(os.path.dirname(__file__), "templates"),
             static_path=ipython_app.static_file_path,
             static_handler_class = FileFindHandler,
+            static_url_prefix = url_path_join(base_project_url,'/static/'),
             cookie_secret=os.urandom(1024),
-            login_url="%s/login"%(base_project_url.rstrip('/')),
+            login_url=url_path_join(base_project_url,'/login'),
             cookie_name='username-%s' % uuid.uuid4(),
         )
 
@@ -363,13 +364,33 @@ class NotebookApp(BaseIPythonApplication):
             self.mathjax_url = u''
 
     base_project_url = Unicode('/', config=True,
-                               help='''The base URL for the notebook server''')
+                               help='''The base URL for the notebook server.
+
+                               Leading and trailing slashes can be omitted,
+                               and will automatically be added.
+                               ''')
+    def _base_project_url_changed(self, name, old, new):
+        if not new.startswith('/'):
+            self.base_project_url = '/'+new
+        elif not new.endswith('/'):
+            self.base_project_url = new+'/'
+
     base_kernel_url = Unicode('/', config=True,
-                               help='''The base URL for the kernel server''')
+                               help='''The base URL for the kernel server
+
+                               Leading and trailing slashes can be omitted,
+                               and will automatically be added.
+                               ''')
+    def _base_kernel_url_changed(self, name, old, new):
+        if not new.startswith('/'):
+            self.base_kernel_url = '/'+new
+        elif not new.endswith('/'):
+            self.base_kernel_url = new+'/'
+
     websocket_host = Unicode("", config=True,
         help="""The hostname for the websocket server."""
     )
-    
+
     extra_static_paths = List(Unicode, config=True,
         help="""Extra paths to search for serving static files.
         

--- a/IPython/frontend/html/notebook/templates/page.html
+++ b/IPython/frontend/html/notebook/templates/page.html
@@ -2,7 +2,7 @@
 
 <!DOCTYPE HTML>
 {% macro static_url(name) -%}
-    /static/{{ name }} 
+   {{ base_project_url }}static/{{ name }}
 {%- endmacro %}
 <html>
 
@@ -28,7 +28,7 @@
 <body {% block params %}{% endblock %}>
 
 <div id="header">
-    <span id="ipython_notebook"><div><a href={{base_project_url}} alt='dashboard'><img src='{{static_url("ipynblogo.png") }}' alt='IPython Notebook'/></a></div></span>
+    <span id="ipython_notebook"><div><a href="{{base_project_url}}" alt='dashboard'><img src='{{static_url("ipynblogo.png") }}' alt='IPython Notebook'/></a></div></span>
 
     {% block login_widget %}
 


### PR DESCRIPTION
- Force leading and trailing slashes in base_project/kernel_url
  - Add support for the prefix in template for static files
  - Fix some forgotten quotes
  - remove old make_static_url which is now a jinja2 macro

fixes-2720
