### PR TITLE
shift tab for tooltip

### DIFF
--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -37,7 +37,6 @@ var IPython = (function (IPython) {
         this.kernel = kernel || null;
         this.code_mirror = null;
         this.input_prompt_number = null;
-        this.tooltip_on_tab = true;
         this.collapsed = false;
         this.default_mode = 'python';
         IPython.Cell.apply(this, arguments);
@@ -47,7 +46,6 @@ var IPython = (function (IPython) {
             function() { that.auto_highlight(); }
         );
     };
-
 
     CodeCell.prototype = new IPython.Cell();
 
@@ -142,6 +140,17 @@ var IPython = (function (IPython) {
             } else {
                 return true;
             };
+        } else if (event.keyCode === key.TAB && event.type == 'keydown' && event.shiftKey) {
+                if (editor.somethingSelected()){
+                    var anchor = editor.getCursor("anchor");
+                    var head = editor.getCursor("head");
+                    if( anchor.line != head.line){
+                        return false;
+                    }
+                }
+                IPython.tooltip.request(that);
+                event.stop();
+                return true;
         } else if (event.keyCode === key.TAB && event.type == 'keydown') {
             // Tab completion.
             //Do not trim here because of tooltip
@@ -151,7 +160,7 @@ var IPython = (function (IPython) {
                 // Don't autocomplete if the part of the line before the cursor
                 // is empty.  In this case, let CodeMirror handle indentation.
                 return false;
-            } else if ((pre_cursor.substr(-1) === "("|| pre_cursor.substr(-1) === " ") && that.tooltip_on_tab ) {
+            } else if ((pre_cursor.substr(-1) === "("|| pre_cursor.substr(-1) === " ") && IPython.config.tooltip_on_tab ) {
                 IPython.tooltip.request(that);
                 // Prevent the event from bubbling up.
                 event.stop();

--- a/IPython/frontend/html/notebook/static/js/config.js
+++ b/IPython/frontend/html/notebook/static/js/config.js
@@ -22,7 +22,7 @@ var IPython = (function (IPython) {
          * @static
          *
          **/
-    var config = {
+    var default_config = {
         /**
          * Dictionary of object to autodetect highlight mode for code cell.
          * Item of the dictionnary should take the form :
@@ -63,10 +63,14 @@ var IPython = (function (IPython) {
          */
         raw_cell_highlight : {
              'diff'         :{'reg':[/^diff/]}
-            }
+            },
+
+        tooltip_on_tab : true,
         };
 
-    IPython.config = config;
+    // use the same method to merge user configuration
+    IPython.config = {};
+    $.extend(IPython.config, default_config);
 
     return IPython;
 

--- a/IPython/frontend/html/notebook/static/js/tooltip.js
+++ b/IPython/frontend/html/notebook/static/js/tooltip.js
@@ -228,6 +228,10 @@ var IPython = (function (IPython) {
             ch: 0
         }, cursor).trim();
 
+        if(editor.somethingSelected()){
+            text = editor.getSelection();
+        }
+
         // need a permanent handel to code_mirror for future auto recall
         this.code_mirror = editor;
 
@@ -288,7 +292,15 @@ var IPython = (function (IPython) {
         var w = $(this.code_mirror.getScrollerElement()).width();
         // ofset of the editor
         var o = $(this.code_mirror.getScrollerElement()).offset();
-        var pos = this.code_mirror.cursorCoords();
+
+        // whatever anchor/head order but arrow at mid x selection
+        var anchor = this.code_mirror.cursorCoords(false);
+        var head  = this.code_mirror.cursorCoords(true);
+        var pos = {};
+        pos.y = head.y
+        pos.yBot = head.yBot
+        pos.x = (head.x+anchor.x)/2;
+
         var xinit = pos.x;
         var xinter = o.left + (xinit - o.left) / w * (w - 450);
         var posarrowleft = xinit - xinter;


### PR DESCRIPTION
As discussed on list,  use shift tab to trigger tooltip

This does _not_ change the curent behavior, only add the shift+tab shortcut. 

Note that the shift tab shortcut has a slightly different behavior.  You can **select  part of a line** and pressing shift-tab will show you the **tooltip only for the selection**.

This is disabled for multiline selection to still allow to unindent block of code, Keep in mind that the real real shortcut for indent unindent is Ctrl+] or [ . Select/tab is not really supported by codemirror.

Finally the "tooltip_on_tab" behavior is globally configurable via IPython.config so that it could be easily switched to false. 

I can be overridden via js console for test purpose.

```
IPython.config.tooltip_on_tab = true | false
```

Take effect immediately, only on current notebook.

or via custom.js

```
var user_conf = {tooltip_on_tab:false | true};
$.extend(IPython.config, user_conf)
```
