### PR TITLE
Fix Read the doc build, Again

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,6 +59,8 @@ extensions = [
 if ON_RTD:
     # Remove extensions not currently supported on RTD
     extensions.remove('matplotlib.sphinxext.only_directives')
+    extensions.remove('matplotlib.sphinxext.mathmpl')
+    extensions.remove('matplotlib.sphinxext.plot_directive')
     extensions.remove('ipython_directive')
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Nothing fancy, only touch Read The Doc auto build. 

Just for the principle I'll let that open a few hours before merging.
and just for the sake of you not opening your browser to see the diff : 

``` diff
 if ON_RTD:
     # Remove extensions not currently supported on RTD
     extensions.remove('matplotlib.sphinxext.only_directives')
+    extensions.remove('matplotlib.sphinxext.mathmpl')
+    extensions.remove('matplotlib.sphinxext.plot_directive')
     extensions.remove('ipython_directive')
```
