### PR TITLE
%Rpush: Look for variables in the local scope first.

### DIFF
--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -178,8 +178,9 @@ class RMagics(Magics):
         return value
 
     @skip_doctest
+    @needs_local_scope
     @line_magic
-    def Rpush(self, line):
+    def Rpush(self, line, local_ns=None):
         '''
         A line-level magic for R that pushes
         variables from python to rpy2. The line should be made up
@@ -199,10 +200,16 @@ class RMagics(Magics):
             Out[11]: array([ 6.23333333])
 
         '''
+        if local_ns is None:
+            local_ns = {}
 
         inputs = line.split(' ')
         for input in inputs:
-            self.r.assign(input, self.pyconverter(self.shell.user_ns[input]))
+            try:
+                val = local_ns[input]
+            except KeyError:
+                val = self.shell.user_ns[input]
+            self.r.assign(input, self.pyconverter(val))
 
     @skip_doctest
     @magic_arguments()

--- a/IPython/extensions/tests/test_rmagic.py
+++ b/IPython/extensions/tests/test_rmagic.py
@@ -14,6 +14,20 @@ def test_push():
     np.testing.assert_almost_equal(np.asarray(rm.r('X')), ip.user_ns['X'])
     np.testing.assert_almost_equal(np.asarray(rm.r('Y')), ip.user_ns['Y'])
 
+def test_push_localscope():
+    """Test that Rpush looks for variables in the local scope first."""
+    ip.run_cell('''
+def rmagic_addone(u):
+    %Rpush u
+    %R result = u+1
+    %Rpull result
+    return result[0]
+u = 0
+result = rmagic_addone(12344)
+    ''')
+    result = ip.user_ns['result']
+    np.testing.assert_equal(result, 12345)
+
 def test_pull():
     rm = rmagic.RMagics(ip)
     rm.r('Z=c(11:20)')


### PR DESCRIPTION
This is intended as a cleaned up version of #2698 & #2552, which partially addresses the issue in #2550.

The issue had two components:
1. The `%Rpush` line magic did not look for variables in the local scope.
2. The `%Rpush` line magic expected variable names to be separated with spaces.

This pull request addresses only the first of these two issues.  I feel that the issues are sufficiently different to deserve separate consideration (and separate pull requests).  In particular, `%Rpull` currently requires variable names to be separated by spaces as well and I think we should ensure that the semantics for `%Rpush` and `%Rpull` remain identical.

I'm going to close #2698 and link to this issue.
