### PR TITLE
Fix: Rpush magic doesn't support comma separated lists of variables

### DIFF
--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -203,8 +203,7 @@ class RMagics(Magics):
         if local_ns is None:
             local_ns = {}
 
-        inputs = line.split(' ')
-        for input in inputs:
+        for input in line.replace(',', ' ').split():
             try:
                 val = local_ns[input]
             except KeyError:
@@ -259,7 +258,7 @@ class RMagics(Magics):
 
         '''
         args = parse_argstring(self.Rpull, line)
-        outputs = args.outputs
+        outputs = ','.join(args.outputs).split(',')
         for output in outputs:
             self.shell.push({output:self.Rconverter(self.r(output),dataframe=args.as_dataframe)})
 

--- a/IPython/extensions/tests/test_rmagic.py
+++ b/IPython/extensions/tests/test_rmagic.py
@@ -9,10 +9,13 @@ ip.magic('load_ext rmagic')
 
 def test_push():
     rm = rmagic.RMagics(ip)
-    ip.push({'X':np.arange(5), 'Y':np.array([3,5,4,6,7])})
-    ip.run_line_magic('Rpush', 'X Y')
+    ip.push({'X':np.arange(5), 'Y':np.array([3,5,4,6,7]),
+             'Z':np.arange(2), 'W':np.array([10.5, 3.0])})
+    ip.run_line_magic('Rpush', 'X, Y  Z , W')
     np.testing.assert_almost_equal(np.asarray(rm.r('X')), ip.user_ns['X'])
     np.testing.assert_almost_equal(np.asarray(rm.r('Y')), ip.user_ns['Y'])
+    np.testing.assert_almost_equal(np.asarray(rm.r('Z')), ip.user_ns['Z'])
+    np.testing.assert_almost_equal(np.asarray(rm.r('W')), ip.user_ns['W'])
 
 def test_push_localscope():
     """Test that Rpush looks for variables in the local scope first."""
@@ -30,10 +33,12 @@ result = rmagic_addone(12344)
 
 def test_pull():
     rm = rmagic.RMagics(ip)
-    rm.r('Z=c(11:20)')
-    ip.run_line_magic('Rpull', 'Z')
+    rm.r('Z=c(11:20); W=10')
+    ip.run_line_magic('Rpull', 'Z , W')
     np.testing.assert_almost_equal(np.asarray(rm.r('Z')), ip.user_ns['Z'])
     np.testing.assert_almost_equal(ip.user_ns['Z'], np.arange(11,21))
+    np.testing.assert_almost_equal(ip.user_ns['W'], np.array([10]))
+
 
 def test_Rconverter():
     datapy= np.array([(1, 2.9, 'a'), (2, 3.5, 'b'), (3, 2.1, 'c')], 


### PR DESCRIPTION
Implement @bfroehle's plan in #2733, using the `split()` implementation (no need to import separate `re` module)
