### PR TITLE
Rmagic: error message when moving an non-existant variable from python to R

### DIFF
--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -208,7 +208,14 @@ class RMagics(Magics):
             try:
                 val = local_ns[input]
             except KeyError:
-                val = self.shell.user_ns[input]
+                try:
+                    val = self.shell.user_ns[input]
+                except KeyError:
+                    # reraise the KeyError as a NameError so that it looks like
+                    # the standard python behavior when you use an unnamed
+                    # variable
+                    raise NameError("name '%s' is not defined" % input)
+
             self.r.assign(input, self.pyconverter(val))
 
     @skip_doctest
@@ -511,7 +518,10 @@ class RMagics(Magics):
                 try:
                     val = local_ns[input]
                 except KeyError:
-                    val = self.shell.user_ns[input]
+                    try:
+                        val = self.shell.user_ns[input]
+                    except KeyError:
+                        raise NameError("name '%s' is not defined" % input)
                 self.r.assign(input, self.pyconverter(val))
 
         png_argdict = dict([(n, getattr(args, n)) for n in ['units', 'height', 'width', 'bg', 'pointsize']])


### PR DESCRIPTION
Currently, when you try to push a non-existant python variable to R, you get a `KeyError`

```
In [1]: %load_ext rmagic
In [2]: %Rpush sdf

[... traceback ...]

KeyError: u'sdf'
```

Maybe the error message could be more intuitive? The fact that local variables are stored in a dict (thus generating a `KeyError`) is kind-of an implementation detail.

In regular python, using an undefined variable name generates a `NameError` -- perhaps that would also be the appropriate error to raise in this case?

This PR changes the error to:

```
In [1]: %load_ext rmagic
In [2]: %Rpush sdf

[... traceback ...]

NameError: name 'sdf' is not defined
```
