### PR TITLE
Unicode content crashes the pager (console)

### DIFF
--- a/IPython/core/page.py
+++ b/IPython/core/page.py
@@ -219,7 +219,7 @@ def page(strng, start=0, screen_lines=0, pager_cmd=None):
                 # if I use popen4, things hang. No idea why.
                 #pager,shell_out = os.popen4(pager_cmd)
                 pager = os.popen(pager_cmd,'w')
-                pager.write(strng)
+                pager.write(strng.encode(sys.stdout.encoding))
                 pager.close()
                 retval = pager.close()  # success returns None
             except IOError as msg:  # broken pipe when user quits


### PR DESCRIPTION
We've run into an interesting bug in the astropy project.  

https://github.com/astropy/astropy/issues/600

When displaying a docstring that contains Unicode and is also long enough that it gets sent to the pager it fails since the docstring can't be sent to the pager as ascii.  This crashes in the middle of sending content to the pager, so the shell ends up in an inconsistent state and stops echoing the keyboard etc.

The fix (attached) is merely to encode the content sent to the pager in the same encoding as the terminal (`sys.stdout.encoding`).  Strictly speaking, this isn't always the right thing to do, since the pager may be configured to expect a different encoding than the terminal, but that is sort of an irrational way to configure a machine... ;)  For example, `less`, in the absence of any special environment variables to tell it otherwise, uses the standard `LC*` environment variables to determine what to do, which should be the same mechanism the terminal also uses by default.

If anyone can suggest a better fix, I'm all for it.  Perhaps it should be configurable, defaulting to `sys.stdout.encoding`?
