### PR TITLE
Following #2737 this error is now a name error

### DIFF
--- a/IPython/extensions/tests/test_rmagic.py
+++ b/IPython/extensions/tests/test_rmagic.py
@@ -90,7 +90,7 @@ def test_rmagic_localscope():
     nt.assert_equal(result, 2)
 
     nt.assert_raises(
-        KeyError,
+        NameError,
         ip.run_line_magic,
         "R",
         "-i var_not_defined 1+1")


### PR DESCRIPTION
Tiny fix to an error I'm seeing in the R test suite following the merge of #2737. This makes perfect sense
since the point of that pull request was to change this to a NameError. 
