### PR TITLE
Add note to `%cython` Black-Scholes example warning of missing erf.

### DIFF
--- a/docs/examples/notebooks/cython_extension.ipynb
+++ b/docs/examples/notebooks/cython_extension.ipynb
@@ -149,7 +149,7 @@
      "source": [
       "Probably the most important magic is the `%cython` magic.  This is similar to the `%%cython_pyximport` magic, but doesn't require you to specify a module name. Instead, the `%%cython` magic uses manages everything using temporary files in the `~/.cython/magic` directory.  All of the symbols in the Cython module are imported automatically by the magic.\n",
       "\n",
-      "Here is a simple example of a Black-Scholes options pricing algorithm written in Cython:"
+      "Here is a simple example of a Black-Scholes options pricing algorithm written in Cython. Please note that this example might not compile on non-POSIX systems (e.g., Windows) because of a missing `erf` symbol."
      ]
     },
     {


### PR DESCRIPTION
As @kluono pointed out in #2588, the example might not compile on Windows
due to a missing `erf` symbol. Since I do not have a Windows box to test any
potential fixes, the best I can do is include a note warning the user that
the example might not compile.
