### PR TITLE
Tell Travis CI to test on Python 3.3 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
     - 2.6
     - 2.7
     - 3.2
+    - 3.3
 before_install:
     - easy_install -q pyzmq
 install:


### PR DESCRIPTION
Travis now supports Python 3.3. This commit should enable that for test runs.
