### PR TITLE
check for complete pyside presence before trying to import

### DIFF
--- a/IPython/external/qt.py
+++ b/IPython/external/qt.py
@@ -23,11 +23,20 @@ def prepare_pyqt4():
 # Select Qt binding, using the QT_API environment variable if available.
 QT_API = os.environ.get('QT_API')
 if QT_API is None:
+    pyside_found = False
     try:
         import PySide
         if PySide.__version__ < '1.0.3':
             # old PySide, fallback on PyQt
             raise ImportError
+        # we can't import an incomplete pyside and pyqt4
+        # this will cause a crash in sip (#1431)
+        # check for complete presence before importing
+        import imp
+        imp.find_module("QtCore", PySide.__path__)
+        imp.find_module("QtGui", PySide.__path__)
+        imp.find_module("QtSvg", PySide.__path__)
+        pyside_found = True
         from PySide import QtCore, QtGui, QtSvg
         QT_API = QT_API_PYSIDE
     except ImportError:
@@ -35,6 +44,11 @@ if QT_API is None:
             prepare_pyqt4()
             import PyQt4
             from PyQt4 import QtCore, QtGui, QtSvg
+            if pyside_found:
+                print "WARNING: PySide installation incomplete and PyQt4 " \
+                      "present.\nThis will likely crash, please install " \
+                      "PySide completely, remove PySide or PyQt4 or set " \
+                      "the QT_API environment variable to pyqt or pyside"
             if QtCore.PYQT_VERSION_STR < '4.7':
                 # PyQt 4.6 has issues with null strings returning as None
                 raise ImportError


### PR DESCRIPTION
importing pyside partially and then falling back to pyqt causes a crash
in sip (see gh-1431)
To avoid it try to locate all modules before the import and should that
fail print a warning.

debian splits pyside into many small packages so sometimes people end up with incomplete pyside installations.
