### PR TITLE
Reset readline delimiters after loading rmagic.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -358,6 +358,7 @@ class InteractiveShell(SingletonConfigurable):
     # but for now, we can't do that as readline is welded in everywhere.
     readline_use = CBool(True, config=True)
     readline_remove_delims = Unicode('-/~', config=True)
+    readline_delims = Unicode() # set by init_readline()
     # don't use \M- bindings by default, because they
     # conflict with 8-bit encodings. See gh-58,gh-88
     readline_parse_and_bind = List([
@@ -1866,6 +1867,9 @@ class InteractiveShell(SingletonConfigurable):
                 delims = delims.replace(d, "")
             delims = delims.replace(ESC_MAGIC, '')
             readline.set_completer_delims(delims)
+            # Store these so we can restore them if something like rpy2 modifies
+            # them.
+            self.readline_delims = delims
             # otherwise we end up with a monster history after a while:
             readline.set_history_length(self.history_length)
 

--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -617,3 +617,7 @@ __doc__ = __doc__.format(
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
     ip.register_magics(RMagics)
+    # Initialising rpy2 interferes with readline. Since, at this point, we've
+    # probably just loaded rpy2, we reset the delimiters. See issue gh-2759.
+    if ip.has_readline:
+        ip.readline.set_completer_delims(ip.readline_delims)


### PR DESCRIPTION
Closes gh-2759

This fixes the problem when using the R magics. Users using rpy2 directly are still likely to experience it. I'm not sure how we can resolve that in IPython, except by awkward special cases that look for rpy2 being initialised.
