### PR TITLE
Define __file__ when we %edit a real file.

### DIFF
--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -28,6 +28,7 @@ from IPython.core.oinspect import find_file, find_source_lines
 from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils import openpy
 from IPython.utils import py3compat
+from IPython.utils.contexts import preserve_keys
 from IPython.utils.io import file_read
 from IPython.utils.path import get_py_filename, unquote_filename
 from IPython.utils.warn import warn
@@ -513,12 +514,15 @@ class CodeMagics(Magics):
             print
         else:
             print 'done. Executing edited code...'
-            if 'r' in opts:    # Untranslated IPython code
-                self.shell.run_cell(file_read(filename),
-                                                    store_history=False)
-            else:
-                self.shell.safe_execfile(filename, self.shell.user_ns,
-                                         self.shell.user_ns)
+            with preserve_keys(self.shell.user_ns, '__file__'):
+                if not is_temp:
+                    self.shell.user_ns['__file__'] = filename
+                if 'r' in opts:    # Untranslated IPython code
+                    self.shell.run_cell(file_read(filename),
+                                        store_history=False)
+                else:
+                    self.shell.safe_execfile(filename, self.shell.user_ns,
+                                             self.shell.user_ns)
 
         if is_temp:
             try:


### PR DESCRIPTION
Old behavior:

```
In [1]: %pycat test_script.py
print(__file__)

In [2]: %edit test_script.py
 done. Executing edited code...
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
/usr/lib/python2.7/dist-packages/IPython/utils/py3compat.pyc in execfile(fname, *where)
    176             else:
    177                 filename = fname
--> 178             __builtin__.execfile(filename, *where)

/home/bfroehle/src/ipython/test_script.py in <module>()
----> 1 print(__file__)

NameError: name '__file__' is not defined
```

New behavior:

```
In [1]: %pycat test_script.py
print(__file__)

In [2]: %edit test_script.py
 done. Executing edited code...
test_script.py
```

Closes gh-2765.
