### PR TITLE
Allow shutdown when no engines are registered

### DIFF
--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -1151,14 +1151,17 @@ class Client(HasTraits):
             NOT IMPLEMENTED
             whether to restart engines after shutting them down.
         """
-        
+        from IPython.parallel.error import NoEnginesRegistered
         if restart:
             raise NotImplementedError("Engine restart is not yet implemented")
         
         block = self.block if block is None else block
         if hub:
             targets = 'all'
-        targets = self._build_targets(targets)[0]
+        try:
+            targets = self._build_targets(targets)[0]
+        except NoEnginesRegistered:
+            targets = []
         for t in targets:
             self.session.send(self._control_socket, 'shutdown_request',
                         content={'restart':restart},ident=t)

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -1558,7 +1558,7 @@ class Client(HasTraits):
                     elif header['msg_type'] == 'execute_reply':
                         res = ExecuteReply(msg_id, rcontent, md)
                     else:
-                        raise KeyError("unhandled msg type: %r" % header[msg_type])
+                        raise KeyError("unhandled msg type: %r" % header['msg_type'])
                 else:
                     res = self._unwrap_exception(rcontent)
                     failures.append(res)


### PR DESCRIPTION
When no engines are registered the `Client.shutdown` method raises a `NoEnginesRegistered` exception.
This occurs before the hub shutdown thus preventing the hub from being shutdown.
