### PR TITLE
Fixed minor typo causing AttributeError to be thrown.

### DIFF
--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -797,7 +797,7 @@ class Client(HasTraits):
             msg_type = msg['header']['msg_type']
             handler = self._notification_handlers.get(msg_type, None)
             if handler is None:
-                raise Exception("Unhandled message type: %s"%msg.msg_type)
+                raise Exception("Unhandled message type: %s" % msg_type)
             else:
                 handler(msg)
             idents,msg = self.session.recv(self._notification_socket, mode=zmq.NOBLOCK)
@@ -811,7 +811,7 @@ class Client(HasTraits):
             msg_type = msg['header']['msg_type']
             handler = self._queue_handlers.get(msg_type, None)
             if handler is None:
-                raise Exception("Unhandled message type: %s"%msg.msg_type)
+                raise Exception("Unhandled message type: %s" % msg_type)
             else:
                 handler(msg)
             idents,msg = self.session.recv(sock, mode=zmq.NOBLOCK)


### PR DESCRIPTION
I'm not sure how I caused the error to be thrown and couldn't reproduce it with the same call again, nevertheless I think the fix is correct.

``` python
In [21]: rc.shutdown(hub=True)
Traceback (most recent call last):

  File "<ipython-input-21-977a05a15f31>", line 1, in <module>
    rc.shutdown(hub=True)

  File "<string>", line 2, in shutdown

  File "c:\dev\code\ipython\IPython\parallel\client\client.py", line 69, in spin_first
    self.spin()

  File "c:\dev\code\ipython\IPython\parallel\client\client.py", line 1005, in spin
    self._flush_notifications()

  File "c:\dev\code\ipython\IPython\parallel\client\client.py", line 800, in _flush_notifications
    raise Exception("Unhandled message type: %s"%msg.msg_type)

AttributeError: 'dict' object has no attribute 'msg_type'
```
