### PR TITLE
P3K: fix DeprecationWarning under Python 3.x 

### DIFF
--- a/IPython/utils/jsonutil.py
+++ b/IPython/utils/jsonutil.py
@@ -15,8 +15,14 @@ import math
 import re
 import sys
 import types
-from base64 import encodestring
 from datetime import datetime
+
+try:
+    # base64.encodestring is deprecated in Python 3.x
+    from base64 import encodebytes
+except ImportError:
+    # Python 2.x
+    from base64 import encodestring as encodebytes
 
 from IPython.utils import py3compat
 from IPython.utils.encoding import DEFAULT_ENCODING
@@ -82,7 +88,7 @@ def squash_dates(obj):
     elif isinstance(obj, datetime):
         obj = obj.strftime(ISO8601)
     return obj
-    
+
 def date_default(obj):
     """default function for packing datetime objects in JSON."""
     if isinstance(obj, datetime):
@@ -97,37 +103,37 @@ JPEG = b'\xff\xd8'
 
 def encode_images(format_dict):
     """b64-encodes images in a displaypub format dict
-    
+
     Perhaps this should be handled in json_clean itself?
-    
+
     Parameters
     ----------
-    
+
     format_dict : dict
         A dictionary of display data keyed by mime-type
-    
+
     Returns
     -------
-    
+
     format_dict : dict
         A copy of the same dictionary,
         but binary image data ('image/png' or 'image/jpeg')
         is base64-encoded.
-    
+
     """
     encoded = format_dict.copy()
     pngdata = format_dict.get('image/png')
     if isinstance(pngdata, bytes) and pngdata[:8] == PNG:
-        encoded['image/png'] = encodestring(pngdata).decode('ascii')
+        encoded['image/png'] = encodebytes(pngdata).decode('ascii')
     jpegdata = format_dict.get('image/jpeg')
     if isinstance(jpegdata, bytes) and jpegdata[:2] == JPEG:
-        encoded['image/jpeg'] = encodestring(jpegdata).decode('ascii')
+        encoded['image/jpeg'] = encodebytes(jpegdata).decode('ascii')
     return encoded
 
 
 def json_clean(obj):
     """Clean an object to ensure it's safe to encode in JSON.
-    
+
     Atomic, immutable objects are returned unmodified.  Sets and tuples are
     converted to lists, lists are copied and dicts are also copied.
 
@@ -142,7 +148,7 @@ def json_clean(obj):
     Returns
     -------
     out : object
-    
+
       A version of the input which will not cause an encoding error when
       encoded as JSON.  Note that this function does not *encode* its inputs,
       it simply sanitizes it so that there will be no encoding errors later.
@@ -163,26 +169,26 @@ def json_clean(obj):
     # types that are 'atomic' and ok in json as-is.  bool doesn't need to be
     # listed explicitly because bools pass as int instances
     atomic_ok = (unicode, int, types.NoneType)
-    
+
     # containers that we need to convert into lists
     container_to_list = (tuple, set, types.GeneratorType)
-    
+
     if isinstance(obj, float):
         # cast out-of-range floats to their reprs
         if math.isnan(obj) or math.isinf(obj):
             return repr(obj)
         return obj
-    
+
     if isinstance(obj, atomic_ok):
         return obj
-    
+
     if isinstance(obj, bytes):
         return obj.decode(DEFAULT_ENCODING, 'replace')
-    
+
     if isinstance(obj, container_to_list) or (
         hasattr(obj, '__iter__') and hasattr(obj, next_attr_name)):
         obj = list(obj)
-        
+
     if isinstance(obj, list):
         return [json_clean(x) for x in obj]
 


### PR DESCRIPTION
The warning is:

```
.../site-packages/IPython/utils/jsonutil.py:121: DeprecationWarning: encodestring() is a deprecated alias, use encodebytes()
  encoded['image/png'] = encodestring(pngdata).decode('ascii')
```
