### PR TITLE
Allow the %run magic with '-b' to specify a file.

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -582,7 +582,7 @@ python-profiler package from non-free.""")
                         ns = {'execfile': py3compat.execfile, 'prog_ns': prog_ns}
                         try:
                             #save filename so it can be used by methods on the deb object
-                            deb._exec_filename = bp_file
+                            deb._exec_filename = filename
                             deb.run('execfile("%s", prog_ns)' % filename, ns)
 
                         except:


### PR DESCRIPTION
Hello,

Here is a minor tweak to the %run command that some users might find helpful:

The syntax would be:

```
%run -d -b file2.py:30 file1.py
```

to break at line 30 of file2.py when running file1.py.

The old syntax

```
%run -d -b 20 file1.py
```

still works the way it used to.

Suggested by user gozzilli on StackOverflow
(http://stackoverflow.com/questions/14305203/ipython-set-a-breakpoint-in-imported-file/).
