### PR TITLE
Prefilter shouldn't touch execution_count

### DIFF
--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -323,9 +323,6 @@ class PrefilterManager(Configurable):
 
         normal_handler = self.get_handler_by_name('normal')
         if not stripped:
-            if not continue_prompt:
-                self.shell.displayhook.prompt_count -= 1
-
             return normal_handler.handle(line_info)
 
         # special handlers are only allowed for single line statements


### PR DESCRIPTION
Having gone through the various things that can call it, I'm pretty sure that there's no need for prefilter to be modifying the execution/prompt counter. And in testing, I can't construct an example that hits this bit of code.

If we agree on this, it supersedes #2623.
