### PR TITLE
Chrome frame awareness

### DIFF
--- a/IPython/frontend/html/notebook/templates/page.html
+++ b/IPython/frontend/html/notebook/templates/page.html
@@ -10,7 +10,7 @@
     <meta charset="utf-8">
 
     <title>{% block title %}IPython Notebook{% endblock %}</title>
-
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <link rel="stylesheet" href="{{static_url("jquery/css/themes/base/jquery-ui.min.css") }}" type="text/css" />
     <link rel="stylesheet" href="{{static_url("css/boilerplate.css") }}" type="text/css" />
     <link rel="stylesheet" href="{{static_url("css/fbm.css") }}" type="text/css" />


### PR DESCRIPTION
This change allows running IPython Notebook on unsupported IE browser, if user has installed Chrome Frame. This header has no effect in other environments. More info: [FAQ](http://www.chromium.org/developers/how-tos/chrome-frame-getting-started/chrome-frame-faq#TOC-For-Developers)

<a href="http://i.imgur.com/tSQYB.png">![img1](http://i.imgur.com/tSQYBs.png)</a>

It's possible for user to create custom and lighter IE COM object, and render IPython Notebook inside:

<a href="http://i.imgur.com/78eCe.png">![img2](http://i.imgur.com/78eCes.png)</a>
