### PR TITLE
forward stdout from forked processes

### DIFF
--- a/IPython/kernel/inprocess/ipkernel.py
+++ b/IPython/kernel/inprocess/ipkernel.py
@@ -140,11 +140,11 @@ class InProcessKernel(Kernel):
 
     def _stdout_default(self):
         from IPython.kernel.zmq.iostream import OutStream
-        return OutStream(self.session, self.iopub_socket, u'stdout')
+        return OutStream(self.session, self.iopub_socket, u'stdout', pipe=False)
 
     def _stderr_default(self):
         from IPython.kernel.zmq.iostream import OutStream
-        return OutStream(self.session, self.iopub_socket, u'stderr')
+        return OutStream(self.session, self.iopub_socket, u'stderr', pipe=False)
 
 #-----------------------------------------------------------------------------
 # Interactive shell subclass

--- a/IPython/kernel/tests/test_message_spec.py
+++ b/IPython/kernel/tests/test_message_spec.py
@@ -50,7 +50,7 @@ def flush_channels(km=None):
     if km is None:
         km = KM
     """flush any messages waiting on the queue"""
-    for channel in (KM.shell_channel, KM.iopub_channel):
+    for channel in (km.shell_channel, km.iopub_channel):
         while True:
             try:
                 msg = channel.get_msg(block=True, timeout=0.1)

--- a/IPython/kernel/tests/test_message_spec.py
+++ b/IPython/kernel/tests/test_message_spec.py
@@ -46,7 +46,9 @@ def teardown():
     KM.shutdown_kernel()
 
 
-def flush_channels():
+def flush_channels(km=None):
+    if km is None:
+        km = KM
     """flush any messages waiting on the queue"""
     for channel in (KM.shell_channel, KM.iopub_channel):
         while True:
@@ -58,10 +60,12 @@ def flush_channels():
                 list(validate_message(msg))
 
 
-def execute(code='', **kwargs):
+def execute(code='', km=None, **kwargs):
     """wrapper for doing common steps for validating an execution request"""
-    shell = KM.shell_channel
-    sub = KM.iopub_channel
+    if km is None:
+        km = KM
+    shell = km.shell_channel
+    sub = km.iopub_channel
     
     msg_id = shell.execute(code=code, **kwargs)
     reply = shell.get_msg(timeout=2)

--- a/IPython/kernel/zmq/iostream.py
+++ b/IPython/kernel/zmq/iostream.py
@@ -152,7 +152,10 @@ class OutStream(object):
                     self._pipe_uuid,
                     string.encode(self.encoding, 'replace'),
                 ], copy=False, track=True)
-                tracker.wait(1)
+                try:
+                    tracker.wait(1)
+                except:
+                    pass
 
     def isatty(self):
         return False

--- a/IPython/kernel/zmq/iostream.py
+++ b/IPython/kernel/zmq/iostream.py
@@ -36,6 +36,7 @@ class OutStream(object):
     """A file like object that publishes the stream to a 0MQ PUB socket."""
 
     # The time interval between automatic flushes, in seconds.
+    _subprocess_flush_limit = 256
     flush_interval = 0.05
     topic=None
 
@@ -105,7 +106,7 @@ class OutStream(object):
         """flush possible pub data from subprocesses into my buffer"""
         if not self._pipe_flag or not self._is_master_process():
             return
-        for i in range(100):
+        for i in range(self._subprocess_flush_limit):
             if self._pipe_poller.poll(0):
                 msg = self._pipe_in.recv_multipart()
                 if msg[0] != self._pipe_uuid:

--- a/IPython/kernel/zmq/iostream.py
+++ b/IPython/kernel/zmq/iostream.py
@@ -1,5 +1,6 @@
 import sys
 import time
+import os
 from io import StringIO
 
 from session import extract_header, Message
@@ -7,6 +8,9 @@ from session import extract_header, Message
 from IPython.utils import io, text
 from IPython.utils import py3compat
 
+import multiprocessing as mp
+import multiprocessing.sharedctypes as mpshc
+from ctypes import c_bool
 #-----------------------------------------------------------------------------
 # Globals
 #-----------------------------------------------------------------------------
@@ -29,6 +33,46 @@ class OutStream(object):
         self.name = name
         self.parent_header = {}
         self._new_buffer()
+        self._manager = mp.Manager()
+        #use sharectype here so it don't have to hit the manager
+        #no synchronize needed either(right?). Just a flag telling the master
+        #to switch the buffer to que
+        self._found_newprocess = mpshc.RawValue(c_bool, False)
+        self._que_buffer = self._manager.Queue()
+        self._que_lock = self._manager.Lock()
+        self._masterpid = os.getpid()
+        self._master_has_switched = False
+
+    def _switch_to_que(self):
+        #should only be called on master process
+        #don't clear the que before putting data in since
+        #child process might have put something in the que before the
+        #master know it.
+        self._que_buffer.put(self._buffer.getvalue())
+        self._new_buffer()
+        self._start = -1
+
+    def _is_master_process(self):
+        return os.getpid()==self._masterpid
+
+    def _debug_print(self,s):
+        sys.__stdout__.write(s+'\n')
+        sys.__stdout__.flush()
+
+    def _check_mp_mode(self):
+        """check multiprocess and switch to que if necessary"""
+        if not self._found_newprocess.value:
+            if not self._is_master_process():
+                self._found_newprocess.value = True
+        elif self._found_newprocess.value and not self._master_has_switched:
+
+            #switch to que if it has not been switch
+            if self._is_master_process():
+                self._switch_to_que()
+                self._master_has_switched = True
+
+        return self._found_newprocess.value
+
 
     def set_parent(self, parent):
         self.parent_header = extract_header(parent)
@@ -38,20 +82,33 @@ class OutStream(object):
 
     def flush(self):
         #io.rprint('>>>flushing output buffer: %s<<<' % self.name)  # dbg
+
         if self.pub_socket is None:
             raise ValueError(u'I/O operation on closed file')
         else:
-            data = self._buffer.getvalue()
-            if data:
-                content = {u'name':self.name, u'data':data}
-                msg = self.session.send(self.pub_socket, u'stream', content=content,
-                                       parent=self.parent_header, ident=self.topic)
+            if self._is_master_process():
+                data = u''
+                #obtain data
+                if self._check_mp_mode():#multiprocess
+                    with self._que_lock:
+                        while not self._que_buffer.empty():
+                            data += self._que_buffer.get()
+                else:#single process mode
+                    data = self._buffer.getvalue()
 
-                if hasattr(self.pub_socket, 'flush'):
-                    # socket itself has flush (presumably ZMQStream)
-                    self.pub_socket.flush()
-                self._buffer.close()
-                self._new_buffer()
+                if data:
+                    content = {u'name':self.name, u'data':data}
+                    msg = self.session.send(self.pub_socket, u'stream', content=content,
+                                           parent=self.parent_header, ident=self.topic)
+
+                    if hasattr(self.pub_socket, 'flush'):
+                        # socket itself has flush (presumably ZMQStream)
+                        self.pub_socket.flush()
+                    self._buffer.close()
+                    self._new_buffer()
+            else:
+                pass
+
 
     def isatty(self):
         return False
@@ -76,7 +133,12 @@ class OutStream(object):
             if not isinstance(string, unicode):
                 string = string.decode(self.encoding, 'replace')
 
-            self._buffer.write(string)
+            if self._check_mp_mode(): #multi process mode
+                with self._que_lock:
+                    self._que_buffer.put(string)
+            else: #sigle process mode
+                self._buffer.write(string)
+
             current_time = time.time()
             if self._start <= 0:
                 self._start = current_time

--- a/IPython/kernel/zmq/iostream.py
+++ b/IPython/kernel/zmq/iostream.py
@@ -1,7 +1,11 @@
 import sys
 import time
 import os
+import threading
+import uuid
 from io import StringIO
+
+import zmq
 
 from session import extract_header, Message
 
@@ -9,11 +13,15 @@ from IPython.utils import io, text
 from IPython.utils import py3compat
 
 import multiprocessing as mp
-import multiprocessing.sharedctypes as mpshc
+# import multiprocessing.sharedctypes as mpshc
 from ctypes import c_bool
 #-----------------------------------------------------------------------------
 # Globals
 #-----------------------------------------------------------------------------
+
+MASTER_NO_CHILDREN = 0
+MASTER_WITH_CHILDREN = 1
+CHILD = 2
 
 #-----------------------------------------------------------------------------
 # Stream classes
@@ -33,46 +41,105 @@ class OutStream(object):
         self.name = name
         self.parent_header = {}
         self._new_buffer()
-        self._manager = mp.Manager()
-        #use sharectype here so it don't have to hit the manager
-        #no synchronize needed either(right?). Just a flag telling the master
-        #to switch the buffer to que
-        self._found_newprocess = mpshc.RawValue(c_bool, False)
-        self._que_buffer = self._manager.Queue()
-        self._que_lock = self._manager.Lock()
-        self._masterpid = os.getpid()
-        self._master_has_switched = False
-
-    def _switch_to_que(self):
-        #should only be called on master process
-        #don't clear the que before putting data in since
-        #child process might have put something in the que before the
-        #master know it.
-        self._que_buffer.put(self._buffer.getvalue())
-        self._new_buffer()
-        self._start = -1
-
+        self._found_newprocess = threading.Event()
+        self._buffer_lock = threading.Lock()
+        self._master_pid = os.getpid()
+        self._master_thread = threading.current_thread().ident
+        self._pipe_pid = os.getpid()
+        self._setup_pipe_in()
+    
+    def _setup_pipe_in(self):
+        """setup listening pipe for subprocesses"""
+        ctx = self._pipe_ctx = zmq.Context()
+        
+        # signal pair for terminating background thread
+        self._pipe_signaler = ctx.socket(zmq.PAIR)
+        self._pipe_signalee = ctx.socket(zmq.PAIR)
+        self._pipe_signaler.bind("inproc://ostream_pipe")
+        self._pipe_signalee.connect("inproc://ostream_pipe")
+        # thread event to signal cleanup is done
+        self._pipe_done = threading.Event() 
+        
+        # use UUID to authenticate pipe messages
+        self._pipe_uuid = uuid.uuid4().bytes
+        
+        self._pipe_thread = threading.Thread(target=self._pipe_main)
+        self._pipe_thread.start()
+    
+    def _setup_pipe_out(self):
+        # must be new context after fork
+        ctx = zmq.Context()
+        self._pipe_pid = os.getpid()
+        self._pipe_out = ctx.socket(zmq.PUSH)
+        self._pipe_out_lock = threading.Lock()
+        self._pipe_out.connect("tcp://127.0.0.1:%i" % self._pipe_port)
+    
+    def _pipe_main(self):
+        """eventloop for receiving"""
+        ctx = self._pipe_ctx
+        self._pipe_in = ctx.socket(zmq.PULL)
+        self._pipe_port = self._pipe_in.bind_to_random_port("tcp://127.0.0.1")
+        poller = zmq.Poller()
+        poller.register(self._pipe_signalee, zmq.POLLIN)
+        poller.register(self._pipe_in, zmq.POLLIN)
+        while True:
+            if not self._is_master_process():
+                return
+            try:
+                events = dict(poller.poll(1000))
+            except zmq.ZMQError:
+                # should only be triggered by process-ending cleanup
+                return
+            
+            if self._pipe_signalee in events:
+                break
+            if self._pipe_in in events:
+                msg = self._pipe_in.recv_multipart()
+                if msg[0] != self._pipe_uuid:
+                    # message not authenticated
+                    continue
+                self._found_newprocess.set()
+                text = msg[1].decode(self.encoding, 'replace')
+                with self._buffer_lock:
+                    self._buffer.write(text)
+                    if self._start < 0:
+                        self._start = time.time()
+        
+        # wrap it up
+        self._pipe_signaler.close()
+        self._pipe_signalee.close()
+        self._pipe_in.close()
+        self._pipe_ctx.term()
+        self._pipe_done.set()
+    
+    
+    def __del__(self):
+        if not self._is_master_process():
+            return
+        self._pipe_signaler.send(b'die')
+        self._pipe_done.wait(10)
+    
     def _is_master_process(self):
-        return os.getpid()==self._masterpid
-
-    def _debug_print(self,s):
-        sys.__stdout__.write(s+'\n')
-        sys.__stdout__.flush()
+        return os.getpid() == self._master_pid
+    
+    def _is_master_thread(self):
+        return threading.current_thread().ident == self._master_thread
+    
+    def _have_pipe_out(self):
+        return os.getpid() == self._pipe_pid
 
     def _check_mp_mode(self):
-        """check multiprocess and switch to que if necessary"""
-        if not self._found_newprocess.value:
-            if not self._is_master_process():
-                self._found_newprocess.value = True
-        elif self._found_newprocess.value and not self._master_has_switched:
-
-            #switch to que if it has not been switch
-            if self._is_master_process():
-                self._switch_to_que()
-                self._master_has_switched = True
-
-        return self._found_newprocess.value
-
+        """check for forks, and switch to zmq pipeline if necessary"""
+        if self._is_master_process():
+            if self._found_newprocess.is_set():
+                return MASTER_WITH_CHILDREN
+            else:
+                return MASTER_NO_CHILDREN
+        else:
+            if not self._have_pipe_out():
+                # setup a new out pipe
+                self._setup_pipe_out()
+            return CHILD
 
     def set_parent(self, parent):
         self.parent_header = extract_header(parent)
@@ -81,20 +148,26 @@ class OutStream(object):
         self.pub_socket = None
 
     def flush(self):
-        #io.rprint('>>>flushing output buffer: %s<<<' % self.name)  # dbg
-
+        """trigger actual zmq send"""
         if self.pub_socket is None:
             raise ValueError(u'I/O operation on closed file')
         else:
             if self._is_master_process():
+                if not self._is_master_thread():
+                    # sub-threads mustn't trigger flush,
+                    # but at least they can force the timer.
+                    self._start = 0
                 data = u''
-                #obtain data
-                if self._check_mp_mode():#multiprocess
-                    with self._que_lock:
-                        while not self._que_buffer.empty():
-                            data += self._que_buffer.get()
-                else:#single process mode
+                # obtain data
+                if self._check_mp_mode(): # multiprocess, needs a lock
+                    with self._buffer_lock:
+                        data = self._buffer.getvalue()
+                        self._buffer.close()
+                        self._new_buffer()
+                else: # single process mode
                     data = self._buffer.getvalue()
+                    self._buffer.close()
+                    self._new_buffer()
 
                 if data:
                     content = {u'name':self.name, u'data':data}
@@ -104,10 +177,11 @@ class OutStream(object):
                     if hasattr(self.pub_socket, 'flush'):
                         # socket itself has flush (presumably ZMQStream)
                         self.pub_socket.flush()
-                    self._buffer.close()
-                    self._new_buffer()
             else:
-                pass
+                self._check_mp_mode()
+                with self._pipe_out_lock:
+                    tracker = self._pipe_out.send(b'', copy=False, track=True)
+                    tracker.wait(1)
 
 
     def isatty(self):
@@ -132,15 +206,23 @@ class OutStream(object):
             # Make sure that we're handling unicode
             if not isinstance(string, unicode):
                 string = string.decode(self.encoding, 'replace')
-
-            if self._check_mp_mode(): #multi process mode
-                with self._que_lock:
-                    self._que_buffer.put(string)
-            else: #sigle process mode
+            
+            mp_mode = self._check_mp_mode()
+            if mp_mode == CHILD:
+                with self._pipe_out_lock:
+                    self._pipe_out.send_multipart([
+                        self._pipe_uuid,
+                        string.encode(self.encoding, 'replace'),
+                    ])
+                return
+            elif mp_mode == MASTER_NO_CHILDREN:
                 self._buffer.write(string)
+            elif mp_mode == MASTER_WITH_CHILDREN:
+                with self._buffer_lock:
+                    self._buffer.write(string)
 
             current_time = time.time()
-            if self._start <= 0:
+            if self._start < 0:
                 self._start = current_time
             elif current_time - self._start > self.flush_interval:
                 self.flush()

--- a/IPython/kernel/zmq/session.py
+++ b/IPython/kernel/zmq/session.py
@@ -45,6 +45,7 @@ from zmq.eventloop.zmqstream import ZMQStream
 
 from IPython.config.application import Application, boolean_flag
 from IPython.config.configurable import Configurable, LoggingConfigurable
+from IPython.utils import io
 from IPython.utils.importstring import import_item
 from IPython.utils.jsonutil import extract_dates, squash_dates, date_default
 from IPython.utils.py3compat import str_to_bytes

--- a/IPython/zmq/tests/test_kernel.py
+++ b/IPython/zmq/tests/test_kernel.py
@@ -13,6 +13,7 @@
 
 import os
 import shutil
+import sys
 import tempfile
 
 from Queue import Empty
@@ -124,6 +125,7 @@ def test_simple_print():
     print ('hello')
 
 
+@dec.knownfailureif(sys.platform == 'win32', "subprocess prints fail on Windows")
 def test_subprocess_print():
     """printing from forked mp.Process"""
     with new_kernel() as km:
@@ -162,7 +164,7 @@ def test_subprocess_noprint():
         np = 5
         code = '\n'.join([
             "import multiprocessing as mp",
-            "pool = [mp.Process(target=range,args=(i,)) for i in range(%i)]" % np,
+            "pool = [mp.Process(target=range, args=(i,)) for i in range(%i)]" % np,
             "for p in pool: p.start()",
             "for p in pool: p.join()"
         ])
@@ -176,6 +178,7 @@ def test_subprocess_noprint():
         _check_mp_mode(km, expected=False, stream="stderr")
 
 
+@dec.knownfailureif(sys.platform == 'win32', "subprocess prints fail on Windows")
 def test_subprocess_error():
     """error in mp.Process doesn't crash"""
     with new_kernel() as km:

--- a/IPython/zmq/tests/test_kernel.py
+++ b/IPython/zmq/tests/test_kernel.py
@@ -133,10 +133,9 @@ def test_subprocess_print():
         flush_channels(km)
         np = 5
         code = '\n'.join([
+            "from __future__ import print_function",
             "import multiprocessing as mp",
-            "def f(x):",
-            "    print('hello',x)",
-            "pool = [mp.Process(target=f,args=(i,)) for i in range(%i)]" % np,
+            "pool = [mp.Process(target=print, args=('hello', i,)) for i in range(%i)]" % np,
             "for p in pool: p.start()",
             "for p in pool: p.join()"
         ])
@@ -163,9 +162,7 @@ def test_subprocess_noprint():
         np = 5
         code = '\n'.join([
             "import multiprocessing as mp",
-            "def f(x):",
-            "    return x",
-            "pool = [mp.Process(target=f,args=(i,)) for i in range(%i)]" % np,
+            "pool = [mp.Process(target=range,args=(i,)) for i in range(%i)]" % np,
             "for p in pool: p.start()",
             "for p in pool: p.join()"
         ])
@@ -186,9 +183,7 @@ def test_subprocess_error():
         
         code = '\n'.join([
             "import multiprocessing as mp",
-            "def f():",
-            "    return 1/0",
-            "p = mp.Process(target=f)",
+            "p = mp.Process(target=int, args=('hi',))",
             "p.start()",
             "p.join()",
         ])
@@ -196,7 +191,7 @@ def test_subprocess_error():
         msg_id, content = execute(km=km, code=code)
         stdout, stderr = assemble_output(iopub)
         nt.assert_equal(stdout, '')
-        nt.assert_true("ZeroDivisionError" in stderr, stderr)
+        nt.assert_true("ValueError" in stderr, stderr)
 
         _check_mp_mode(km, expected=False)
         _check_mp_mode(km, expected=False, stream="stderr")

--- a/IPython/zmq/tests/test_kernel.py
+++ b/IPython/zmq/tests/test_kernel.py
@@ -108,14 +108,14 @@ def _check_mp_mode(km, expected=False, stream="stdout"):
     execute(km=km, code="import sys")
     flush_channels(km)
     msg_id, content = execute(km=km, code="print (sys.%s._check_mp_mode())" % stream)
-    stdout, stderr = assemble_output(km.sub_channel)
+    stdout, stderr = assemble_output(km.iopub_channel)
     nt.assert_equal(eval(stdout.strip()), expected)
 
 
 def test_simple_print():
     """simple print statement in kernel"""
     with new_kernel() as km:
-        iopub = km.sub_channel
+        iopub = km.iopub_channel
         msg_id, content = execute(km=km, code="print ('hi')")
         stdout, stderr = assemble_output(iopub)
         nt.assert_equal(stdout, 'hi\n')
@@ -127,7 +127,7 @@ def test_simple_print():
 def test_subprocess_print():
     """printing from forked mp.Process"""
     with new_kernel() as km:
-        iopub = km.sub_channel
+        iopub = km.iopub_channel
         
         _check_mp_mode(km, expected=False)
         flush_channels(km)
@@ -158,7 +158,7 @@ def test_subprocess_print():
 def test_subprocess_noprint():
     """mp.Process without print doesn't trigger iostream mp_mode"""
     with new_kernel() as km:
-        iopub = km.sub_channel
+        iopub = km.iopub_channel
         
         np = 5
         code = '\n'.join([
@@ -182,7 +182,7 @@ def test_subprocess_noprint():
 def test_subprocess_error():
     """error in mp.Process doesn't crash"""
     with new_kernel() as km:
-        iopub = km.sub_channel
+        iopub = km.iopub_channel
         
         code = '\n'.join([
             "import multiprocessing as mp",

--- a/IPython/zmq/tests/test_kernel.py
+++ b/IPython/zmq/tests/test_kernel.py
@@ -151,7 +151,7 @@ def test_subprocess_print():
         for n in range(np):
             nt.assert_equal(stdout.count(str(n)), 1, stdout)
         nt.assert_equal(stderr, '')
-        _check_mp_mode(km, expected=True)
+        _check_mp_mode(km, expected=False)
         _check_mp_mode(km, expected=False, stream="stderr")
 
 
@@ -199,5 +199,5 @@ def test_subprocess_error():
         nt.assert_true("ZeroDivisionError" in stderr, stderr)
 
         _check_mp_mode(km, expected=False)
-        _check_mp_mode(km, expected=True, stream="stderr")
+        _check_mp_mode(km, expected=False, stream="stderr")
 

--- a/IPython/zmq/tests/test_kernel.py
+++ b/IPython/zmq/tests/test_kernel.py
@@ -1,0 +1,183 @@
+"""test the IPython Kernel"""
+
+#-------------------------------------------------------------------------------
+#  Copyright (C) 2013  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-------------------------------------------------------------------------------
+
+#-------------------------------------------------------------------------------
+# Imports
+#-------------------------------------------------------------------------------
+
+import os
+import shutil
+import tempfile
+
+from Queue import Empty
+from contextlib import contextmanager
+from subprocess import PIPE
+
+import nose.tools as nt
+
+from IPython.zmq.blockingkernelmanager import BlockingKernelManager
+from IPython.zmq.tests.test_message_spec import execute, flush_channels
+from IPython.testing import decorators as dec
+from IPython.utils import path, py3compat
+
+#-------------------------------------------------------------------------------
+# Tests
+#-------------------------------------------------------------------------------
+
+def setup():
+    """setup temporary IPYTHONDIR for tests"""
+    global IPYTHONDIR
+    global save_env
+    global save_get_ipython_dir
+    
+    IPYTHONDIR = tempfile.mkdtemp()
+
+    save_env = os.environ.copy()
+    os.environ["IPYTHONDIR"] = IPYTHONDIR
+
+    save_get_ipython_dir = path.get_ipython_dir
+    path.get_ipython_dir = lambda : IPYTHONDIR
+
+
+def teardown():
+    path.get_ipython_dir = save_get_ipython_dir
+    os.environ = save_env
+    
+    try:
+        shutil.rmtree(IPYTHONDIR)
+    except (OSError, IOError):
+        # no such file
+        pass
+
+
+@contextmanager
+def new_kernel():
+    """start a kernel in a subprocess, and wait for it to be ready
+    
+    Returns
+    -------
+    kernel_manager: connected KernelManager instance
+    """
+    KM = BlockingKernelManager()
+
+    KM.start_kernel(stdout=PIPE, stderr=PIPE)
+    KM.start_channels()
+    
+    # wait for kernel to be ready
+    KM.shell_channel.execute("import sys")
+    KM.shell_channel.get_msg(block=True, timeout=5)
+    flush_channels(KM)
+    try:
+        yield KM
+    finally:
+        KM.stop_channels()
+        KM.shutdown_kernel()
+
+
+def assemble_output(iopub):
+    """assemble stdout/err from an execution"""
+    stdout = ''
+    stderr = ''
+    while True:
+        msg = iopub.get_msg(block=True, timeout=1)
+        msg_type = msg['msg_type']
+        content = msg['content']
+        if msg_type == 'status' and content['execution_state'] == 'idle':
+            # idle message signals end of output
+            break
+        elif msg['msg_type'] == 'stream':
+            if content['name'] == 'stdout':
+                stdout = stdout + content['data']
+            elif content['name'] == 'stderr':
+                stderr = stderr + content['data']
+            else:
+                raise KeyError("bad stream: %r" % content['name'])
+        else:
+            # other output, ignored
+            pass
+    return stdout, stderr
+
+
+def _check_mp_mode(km, expected=False, stream="stdout"):
+    execute(km=km, code="import sys")
+    flush_channels(km)
+    msg_id, content = execute(km=km, code="print (sys.stdout._check_mp_mode())")
+    stdout, stderr = assemble_output(km.sub_channel)
+    nt.assert_equal(eval(stdout.strip()), expected)
+
+
+@dec.parametric
+def test_simple_print():
+    """simple print statement in kernel"""
+    with new_kernel() as km:
+        iopub = km.sub_channel
+        
+        msg_id, content = execute(km=km, code="print ('hi')")
+        stdout, stderr = assemble_output(iopub)
+        yield nt.assert_equal(stdout, 'hi\n')
+        yield nt.assert_equal(stderr, '')
+        yield _check_mp_mode(km, expected=False)
+
+
+@dec.parametric
+def test_subprocess_print():
+    """printing from forked mp.Process"""
+    with new_kernel() as km:
+        iopub = km.sub_channel
+        
+        yield _check_mp_mode(km, expected=False)
+        flush_channels(km)
+        np = 5
+        code = '\n'.join([
+            "import multiprocessing as mp",
+            "def f(x):",
+            "    print 'hello',x",
+            "pool = [mp.Process(target=f,args=(i,)) for i in range(%i)]" % np,
+            "for p in pool: p.start()",
+            "for p in pool: p.join()"
+        ])
+        
+        expected = '\n'.join([
+            "hello %s" % i for i in range(np)
+        ]) + '\n'
+        
+        msg_id, content = execute(km=km, code=code)
+        stdout, stderr = assemble_output(iopub)
+        yield nt.assert_equal(stdout.count("hello"), np, stdout)
+        for n in range(np):
+            yield nt.assert_equal(stdout.count(str(n)), 1, stdout)
+        yield nt.assert_equal(stderr, '')
+        yield _check_mp_mode(km, expected=True)
+        yield _check_mp_mode(km, expected=True, stream="stderr")
+
+
+@dec.parametric
+def test_subprocess_noprint():
+    """mp.Process without print doesn't trigger iostream mp_mode"""
+    with new_kernel() as km:
+        iopub = km.sub_channel
+        
+        np = 5
+        code = '\n'.join([
+            "import multiprocessing as mp",
+            "def f(x):",
+            "    return x",
+            "pool = [mp.Process(target=f,args=(i,)) for i in range(%i)]" % np,
+            "for p in pool: p.start()",
+            "for p in pool: p.join()"
+        ])
+        
+        msg_id, content = execute(km=km, code=code)
+        stdout, stderr = assemble_output(iopub)
+        yield nt.assert_equal(stdout, '')
+        yield nt.assert_equal(stderr, '')
+
+        yield _check_mp_mode(km, expected=False)
+        yield _check_mp_mode(km, expected=False, stream="stderr")
+

--- a/IPython/zmq/tests/test_kernel.py
+++ b/IPython/zmq/tests/test_kernel.py
@@ -112,31 +112,30 @@ def _check_mp_mode(km, expected=False, stream="stdout"):
     nt.assert_equal(eval(stdout.strip()), expected)
 
 
-@dec.parametric
 def test_simple_print():
     """simple print statement in kernel"""
     with new_kernel() as km:
         iopub = km.sub_channel
         msg_id, content = execute(km=km, code="print ('hi')")
         stdout, stderr = assemble_output(iopub)
-        yield nt.assert_equal(stdout, 'hi\n')
-        yield nt.assert_equal(stderr, '')
-        yield _check_mp_mode(km, expected=False)
+        nt.assert_equal(stdout, 'hi\n')
+        nt.assert_equal(stderr, '')
+        _check_mp_mode(km, expected=False)
+    print ('hello')
 
 
-@dec.parametric
 def test_subprocess_print():
     """printing from forked mp.Process"""
     with new_kernel() as km:
         iopub = km.sub_channel
         
-        yield _check_mp_mode(km, expected=False)
+        _check_mp_mode(km, expected=False)
         flush_channels(km)
         np = 5
         code = '\n'.join([
             "import multiprocessing as mp",
             "def f(x):",
-            "    print 'hello',x",
+            "    print('hello',x)",
             "pool = [mp.Process(target=f,args=(i,)) for i in range(%i)]" % np,
             "for p in pool: p.start()",
             "for p in pool: p.join()"
@@ -148,15 +147,14 @@ def test_subprocess_print():
         
         msg_id, content = execute(km=km, code=code)
         stdout, stderr = assemble_output(iopub)
-        yield nt.assert_equal(stdout.count("hello"), np, stdout)
+        nt.assert_equal(stdout.count("hello"), np, stdout)
         for n in range(np):
-            yield nt.assert_equal(stdout.count(str(n)), 1, stdout)
-        yield nt.assert_equal(stderr, '')
-        yield _check_mp_mode(km, expected=True)
-        yield _check_mp_mode(km, expected=False, stream="stderr")
+            nt.assert_equal(stdout.count(str(n)), 1, stdout)
+        nt.assert_equal(stderr, '')
+        _check_mp_mode(km, expected=True)
+        _check_mp_mode(km, expected=False, stream="stderr")
 
 
-@dec.parametric
 def test_subprocess_noprint():
     """mp.Process without print doesn't trigger iostream mp_mode"""
     with new_kernel() as km:
@@ -174,13 +172,13 @@ def test_subprocess_noprint():
         
         msg_id, content = execute(km=km, code=code)
         stdout, stderr = assemble_output(iopub)
-        yield nt.assert_equal(stdout, '')
-        yield nt.assert_equal(stderr, '')
+        nt.assert_equal(stdout, '')
+        nt.assert_equal(stderr, '')
 
-        yield _check_mp_mode(km, expected=False)
-        yield _check_mp_mode(km, expected=False, stream="stderr")
+        _check_mp_mode(km, expected=False)
+        _check_mp_mode(km, expected=False, stream="stderr")
 
-@dec.parametric
+
 def test_subprocess_error():
     """error in mp.Process doesn't crash"""
     with new_kernel() as km:
@@ -197,9 +195,9 @@ def test_subprocess_error():
         
         msg_id, content = execute(km=km, code=code)
         stdout, stderr = assemble_output(iopub)
-        yield nt.assert_equal(stdout, '')
+        nt.assert_equal(stdout, '')
         nt.assert_true("ZeroDivisionError" in stderr, stderr)
 
-        yield _check_mp_mode(km, expected=False)
-        yield _check_mp_mode(km, expected=True, stream="stderr")
+        _check_mp_mode(km, expected=False)
+        _check_mp_mode(km, expected=True, stream="stderr")
 


### PR DESCRIPTION
third attempt, in collaboration with @piti118

uses zmq instead of multiprocessing, because mp has too many issues.
- messages are sent via PUSH/PULL from subprocesses
- messages are sent at flush time, not at write time
- subprocess messages
- no threads, no sync events, etc.

some basic tests are included

todo:
- [x] test on Windows
- [x] resolve issues with inprocess kernels
