### PR TITLE
Remove outdated code from extensions.autoreload

### DIFF
--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -107,7 +107,6 @@ skip_doctest = True
 # Imports
 #-----------------------------------------------------------------------------
 
-import imp
 import os
 import sys
 import traceback
@@ -126,16 +125,6 @@ from IPython.utils.py3compat import PY3
 #------------------------------------------------------------------------------
 # Autoreload functionality
 #------------------------------------------------------------------------------
-
-def _get_compiled_ext():
-    """Official way to get the extension of compiled files (.pyc or .pyo)"""
-    for ext, mode, typ in imp.get_suffixes():
-        if typ == imp.PY_COMPILED:
-            return ext
-
-
-PY_COMPILED_EXT = _get_compiled_ext()
-
 
 class ModuleReloader(object):
     enabled = False
@@ -218,7 +207,6 @@ class ModuleReloader(object):
             path, ext = os.path.splitext(filename)
 
             if ext.lower() == '.py':
-                ext = PY_COMPILED_EXT
                 pyc_filename = pyfile.cache_from_source(filename)
                 py_filename = filename
             else:
@@ -322,7 +310,7 @@ else:
                          (lambda a, b: isinstance2(a, b, types.MethodType),
                           lambda a, b: update_function(a.im_func, b.im_func)),
                         ])
-        
+
 
 def update_generic(a, b):
     for type_check, update in UPDATE_RULES:


### PR DESCRIPTION
imp.getsuffixes() raises a DeprecationWarning under Python 3.3;
in order to fix this I just removed _get_compiled_ext and
PY_COMPILED_EXT because they are no longer used
(see 8a8884b399cf3f5b761313bf0d446ba204f2c810 and 2911f3ed7db45ec2571772a9e25513559d480179).
