### PR TITLE
P3K: fix cookie parsing under Python 3.x (+ duplicate import is removed)

### DIFF
--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -27,7 +27,6 @@ import stat
 import threading
 import time
 import uuid
-import os
 
 from tornado.escape import url_escape
 from tornado import web
@@ -41,6 +40,7 @@ from IPython.zmq.session import Session
 from IPython.lib.security import passwd_check
 from IPython.utils.jsonutil import date_default
 from IPython.utils.path import filefind
+from IPython.utils.py3compat import PY3
 
 try:
     from docutils.core import publish_string
@@ -434,8 +434,9 @@ class AuthenticatedZMQStreamHandler(ZMQStreamHandler):
     def _inject_cookie_message(self, msg):
         """Inject the first message, which is the document cookie,
         for authentication."""
-        if isinstance(msg, unicode):
-            # Cookie can't constructor doesn't accept unicode strings for some reason
+        if not PY3 and isinstance(msg, unicode):
+            # Cookie constructor doesn't accept unicode strings
+            # under Python 2.x for some reason
             msg = msg.encode('utf8', 'replace')
         try:
             self.request._cookies = Cookie.SimpleCookie(msg)


### PR DESCRIPTION
This fixes 

```
WARNING:root:couldn't parse cookie string: b'__utma=96992031.448119963.1345042395.1345203014.1351851470.3; __utmz=96992031.1345042395.1.1.utmcsr=(direct)|utmccn=(direct)|utmcmd=(none); sessionid=2456b59cebe2a3c7075c6d3f1d136c36; csrftoken=I9knGxQWHWXSUAeOXihXlzs0IJxbss07'
Traceback (most recent call last):
  File "/Users/kmike/envs/pymorphy-33/lib/python3.3/site-packages/ipython-0.14.dev-py3.3.egg/IPython/frontend/html/notebook/handlers.py", line 441, in _inject_cookie_message
    self.request._cookies = http.cookies.SimpleCookie(msg)
  File "/usr/local/Cellar/python3/3.3.0/Frameworks/Python.framework/Versions/3.3/lib/python3.3/http/cookies.py", line 476, in __init__
    self.load(input)
  File "/usr/local/Cellar/python3/3.3.0/Frameworks/Python.framework/Versions/3.3/lib/python3.3/http/cookies.py", line 524, in load
    for key, value in rawdata.items():
AttributeError: 'bytes' object has no attribute 'items'
```

warning under Python 3.x
