### PR TITLE
use `type(obj) is cls` as switch when canning

### DIFF
--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -308,6 +308,21 @@ class TestView(ClusterTestCase, ParametricTestCase):
         self.assertEqual(R2.dtype, R.dtype)
         self.assertEqual(R2.shape, R.shape)
         assert_array_equal(R2, R)
+
+    @skip_without('pandas')
+    def test_push_pull_timeseries(self):
+        """push/pull pandas.TimeSeries"""
+        import pandas
+        
+        ts = pandas.TimeSeries(range(10))
+        
+        view = self.client[-1]
+        
+        view.push(dict(ts=ts), block=True)
+        rts = view['ts']
+        
+        self.assertEqual(type(rts), type(ts))
+        self.assertTrue((ts == rts).all())
     
     def test_map(self):
         view = self.client[:]

--- a/IPython/utils/pickleutil.py
+++ b/IPython/utils/pickleutil.py
@@ -217,7 +217,7 @@ def can(obj):
         if isinstance(cls, basestring):
             import_needed = True
             break
-        elif isinstance(obj, cls):
+        elif type(obj) is cls:
             return canner(obj)
     
     if import_needed:

--- a/IPython/utils/pickleutil.py
+++ b/IPython/utils/pickleutil.py
@@ -208,6 +208,19 @@ def _import_mapping(mapping, original=None):
             else:
                 mapping[cls] = mapping.pop(key)
 
+def istype(obj, check):
+    """like isinstance(obj, check), but strict
+    
+    This won't catch subclasses.
+    """
+    if isinstance(check, tuple):
+        for cls in check:
+            if type(obj) is cls:
+                return True
+        return False
+    else:
+        return type(obj) is check
+
 def can(obj):
     """prepare an object for pickling"""
     
@@ -217,7 +230,7 @@ def can(obj):
         if isinstance(cls, basestring):
             import_needed = True
             break
-        elif type(obj) is cls:
+        elif istype(obj, cls):
             return canner(obj)
     
     if import_needed:


### PR DESCRIPTION
`isinstance(obj, cos)` would trigger the canning shortcuts for subclasses,
which can be inappropriate (e.g. pandas.TimeSeries).

closes #2793
