### PR TITLE
allow classic prompts without a space

### DIFF
--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -567,7 +567,7 @@ def transform_assign_magic(line):
     return line
 
 
-_classic_prompt_re = re.compile(r'^([ \t]*>>> |^[ \t]*\.\.\. )')
+_classic_prompt_re = re.compile(r'^([ \t]*>>> ?|^[ \t]*\.\.\. ?)')
 
 def transform_classic_prompt(line):
     """Handle inputs that start with '>>> ' syntax."""

--- a/IPython/core/tests/test_inputsplitter.py
+++ b/IPython/core/tests/test_inputsplitter.py
@@ -456,10 +456,12 @@ syntax = \
         ]],
 
        classic_prompt =
-       [('>>> x=1', 'x=1'),
+       [('>>> x=1', 'x=1'), # classic prompt
+        ('>>>x=1', 'x=1'), # classic prompt, no space
         ('x=1', 'x=1'), # normal input is unmodified
         ('    ', '    '),  # blank lines are kept intact
         ('... ', ''), # continuation prompts
+        ('...x=1', 'x=1'), # continuation prompts, no space
         ],
 
        ipy_prompt =


### PR DESCRIPTION
```
>>>a=5
...b=10
```

etc.

closes #2790
