### PR TITLE
remove nonfunctional `-la` short arg in cython magic

### DIFF
--- a/IPython/extensions/cythonmagic.py
+++ b/IPython/extensions/cythonmagic.py
@@ -132,7 +132,7 @@ class CythonMagics(Magics):
              "Extension flag (can be specified  multiple times)."
     )
     @magic_arguments.argument(
-        '-la', '--link-args', action='append', default=[],
+        '--link-args', action='append', default=[],
         help="Extra flags to pass to linker via the `extra_link_args` "
              "Extension flag (can be specified  multiple times)."
     )


### PR DESCRIPTION
short flags only allow one letter, so `-la` is the same as `-l`, which is
already taken.

closes #2709
