### PR TITLE
update release/authors

### DIFF
--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -52,9 +52,7 @@ from .utils.sysinfo import sys_info
 from .utils.frame import extract_module_locals
 
 # Release data
-__author__ = ''
-for author, email in release.authors.itervalues():
-    __author__ += author + ' <' + email + '>\n'
+__author__ = '%s <%s>' % (release.author, release.author_email)
 __license__  = release.license
 __version__  = release.version
 version_info = release.version_info

--- a/IPython/core/release.py
+++ b/IPython/core/release.py
@@ -130,7 +130,7 @@ url = 'http://ipython.org'
 
 download_url = 'https://github.com/ipython/ipython/downloads'
 
-platforms = ['Linux','Mac OSX','Windows XP/2000/NT/Vista/7']
+platforms = ['Linux','Mac OSX','Windows XP/Vista/7/8']
 
 keywords = ['Interactive','Interpreter','Shell','Parallel','Distributed',
             'Web-based computing', 'Qt console', 'Embedding']
@@ -144,8 +144,8 @@ classifiers = [
     'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.1',
     'Programming Language :: Python :: 3.2',
+    'Programming Language :: Python :: 3.3',
     'Topic :: System :: Distributed Computing',
     'Topic :: System :: Shells'
     ]

--- a/IPython/frontend/terminal/ipapp.py
+++ b/IPython/frontend/terminal/ipapp.py
@@ -92,7 +92,7 @@ class IPAppCrashHandler(CrashHandler):
     """sys.excepthook for IPython itself, leaves a detailed report on disk."""
 
     def __init__(self, app):
-        contact_name = release.authors['Fernando'][0]
+        contact_name = release.author
         contact_email = release.author_email
         bug_tracker = 'https://github.com/ipython/ipython/issues'
         super(IPAppCrashHandler,self).__init__(


### PR DESCRIPTION
- don't tell people to email Fernando every time IPython crashes :)
- supported Pythons updated to remove 3.1, add 3.3.
- `IPython.__author__` is now just ipython-dev, rather than assorted individuals
- don't mention old, unsupported Windowses (I would argue that XP should be dropped as well, but I know that won't fly)
