### PR TITLE
change ol format order

### DIFF
--- a/IPython/frontend/html/notebook/static/css/renderedhtml.css
+++ b/IPython/frontend/html/notebook/static/css/renderedhtml.css
@@ -13,11 +13,12 @@
 .rendered_html ul {list-style:disc; margin: 1em 2em;}
 .rendered_html ul ul {list-style:square; margin: 0em 2em;}
 .rendered_html ul ul ul {list-style:circle; margin-left: 0em 2em;}
-.rendered_html ol {list-style:upper-roman; margin: 1em 2em;}
+.rendered_html ol {list-style:decimal; margin: 1em 2em;}
 .rendered_html ol ol {list-style:upper-alpha; margin: 0em 2em;}
-.rendered_html ol ol ol {list-style:decimal; margin: 0em 2em;}
-.rendered_html ol ol ol ol {list-style:lower-alpha; margin: 0em 2em;}
-.rendered_html ol ol ol ol ol {list-style:lower-roman; margin: 0em 2em;}
+.rendered_html ol ol ol {list-style:lower-alpha; margin: 0em 2em;}
+.rendered_html ol ol ol ol {list-style:lower-roman; margin: 0em 2em;}
+/* any extras will just be numbers: */
+.rendered_html ol ol ol ol ol {list-style:decimal; margin: 0em 2em;}
 
 .rendered_html hr {
     color: black;


### PR DESCRIPTION
from: I.A.1.a.i

to: 1.A.a.i

It is debateable whether this is actually preferable, but I certainly prefer it, and the current behavior has even been reported as a bug.

closes #2634
