### PR TITLE
log user tracebacks in the kernel (INFO-level)

### DIFF
--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -396,6 +396,10 @@ class Kernel(Configurable):
             reply_content['engine_info'] = e_info
             # reset after use
             shell._reply_content = None
+        
+        if 'traceback' in reply_content:
+            self.log.info("Exception in execute request:\n%s", '\n'.join(reply_content['traceback']))
+        
 
         # At this point, we can tell whether the main code execution succeeded
         # or not.  If it did, we proceed to evaluate user_variables/expressions
@@ -596,6 +600,7 @@ class Kernel(Configurable):
             
             self.session.send(self.iopub_socket, u'pyerr', reply_content, parent=parent,
                                 ident=self._topic('pyerr'))
+            self.log.info("Exception in apply request:\n%s", '\n'.join(reply_content['traceback']))
             result_buf = []
 
             if reply_content['ename'] == 'UnmetDependency':


### PR DESCRIPTION
Should make debugging errors a little less painful

should close #2473

I don't know why I didn't issue this PR earlier, this fix is from months ago.
