### PR TITLE
Clean up notebook Javascript

### DIFF
--- a/IPython/frontend/html/notebook/static/css/notebook.css
+++ b/IPython/frontend/html/notebook/static/css/notebook.css
@@ -156,6 +156,7 @@ div.cell {
     padding: 5px 5px 5px 0px;
     /* This acts as a spacer between cells, that is outside the border */
     margin: 2px 0px 2px 0px;
+    outline: none;
 }
 
 div.code_cell {
@@ -173,7 +174,9 @@ div.prompt {
     padding: 0.4em;
     margin: 0px;
     font-family: monospace;
-    text-align:right;
+    text-align: right;
+    /* This has to match that of the the CodeMirror class line-height below */	
+    line-height: 1.231;
 }
 
 div.input {
@@ -245,6 +248,21 @@ div.output_area {
     page-break-inside: avoid;
 }
 
+	
+/* This is needed to protect the pre formating from global settings such
+   as that of bootstrap */
+div.output_area pre {	
+    font-family: monospace;	
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+    color: black;
+    background-color: white;
+}
+
 /* This class is for the output subarea inside the output_area and after
    the prompt div. */
 div.output_subarea {
@@ -259,6 +277,8 @@ div.output_text {
     text-align: left;
     color: black;
     font-family: monospace;
+    /* This has to match that of the the CodeMirror class line-height below */	
+    line-height: 1.231;
 }
 
 /* stdout/stderr are 'text' as well as 'stream', but pyout/pyerr are *not* streams */

--- a/IPython/frontend/html/notebook/static/js/celltoolbar.js
+++ b/IPython/frontend/html/notebook/static/js/celltoolbar.js
@@ -202,7 +202,6 @@ var IPython = (function (IPython) {
         for (var k in CellToolbar._presets) {
             keys.push(k);
         }
-        console.log(keys);
         return keys;
     };
 

--- a/IPython/frontend/html/notebook/static/js/celltoolbarpresets/example.js
+++ b/IPython/frontend/html/notebook/static/js/celltoolbarpresets/example.js
@@ -149,6 +149,6 @@
     example_preset.push('example.help')
 
     CellToolbar.register_preset('Example',example_preset);
-    console.log('Example extension for metadata editting loaded.');
+    console.log('Example extension for metadata editing loaded.');
 
 }(IPython));

--- a/IPython/frontend/html/notebook/static/js/completer.js
+++ b/IPython/frontend/html/notebook/static/js/completer.js
@@ -67,18 +67,16 @@ var IPython = (function (IPython) {
 
 
     var Completer = function (cell) {
-            this.editor = cell.code_mirror;
-            var that = this;
-            $([IPython.events]).on('status_busy.Kernel', function () {
-                that.skip_kernel_completion = true;
-            });
-            $([IPython.events]).on('status_idle.Kernel', function () {
-                that.skip_kernel_completion = false;
-            });
-
-
-        };
-
+        this.cell = cell;
+        this.editor = cell.code_mirror;
+        var that = this;
+        $([IPython.events]).on('status_busy.Kernel', function () {
+            that.skip_kernel_completion = true;
+        });
+        $([IPython.events]).on('status_idle.Kernel', function () {
+            that.skip_kernel_completion = false;
+        });
+    };
 
 
     Completer.prototype.startCompletion = function () {
@@ -128,7 +126,7 @@ var IPython = (function (IPython) {
             var callbacks = {
                 'complete_reply': $.proxy(this.finish_completing, this)
             };
-            IPython.notebook.kernel.complete(line, cur.ch, callbacks);
+            this.cell.kernel.complete(line, cur.ch, callbacks);
         }
     };
 

--- a/IPython/frontend/html/notebook/static/js/notificationarea.js
+++ b/IPython/frontend/html/notebook/static/js/notificationarea.js
@@ -93,24 +93,71 @@ var IPython = (function (IPython) {
 
         $([IPython.events]).on('status_dead.Kernel',function () {
             var dialog = $('<div/>');
-            dialog.html('The kernel has died, would you like to restart it? If you do not restart the kernel, you will be able to save the notebook, but running code will not work until the notebook is reopened.');
+            dialog.html('The kernel has died, would you like to restart it?' +
+                ' If you do not restart the kernel, you will be able to save' +
+                ' the notebook, but running code will not work until the notebook' +
+                ' is reopened.'
+            );
             $(document).append(dialog);
             dialog.dialog({
                 resizable: false,
                 modal: true,
                 title: "Dead kernel",
+                close: function(event, ui) {$(this).dialog('destroy').remove();},
                 buttons : {
                     "Restart": function () {
                         $([IPython.events]).trigger('status_restarting.Kernel');
                         IPython.notebook.start_kernel();
                         $(this).dialog('close');
                     },
-                    "Continue running": function () {
+                    "Don't restart": function () {
                         $(this).dialog('close');
                     }
                 }
             });
         });
+
+        $([IPython.events]).on('websocket_closed.Kernel', function (event, data) {
+            var kernel = data.kernel;
+            var ws_url = data.ws_url;
+            var early = data.early;
+            var msg;
+            console.log(early);
+            if (!early) {
+                    knw.set_message('Reconnecting WebSockets', 1000);
+                    setTimeout(function () {
+                        kernel.start_channels();
+                    }, 5000);
+                return;
+            }
+            console.log('WebSocket connection failed: ', ws_url)
+            msg = "A WebSocket connection to could not be established." +
+                " You will NOT be able to run code. Check your" +
+                " network connection or notebook server configuration.";
+            var dialog = $('<div/>');
+            dialog.html(msg);
+            $(document).append(dialog);
+            dialog.dialog({
+                resizable: false,
+                modal: true,
+                title: "WebSocket connection failed",
+                closeText: "",
+                close: function(event, ui) {$(this).dialog('destroy').remove();},
+                buttons : {
+                    "OK": function () {
+                        $(this).dialog('close');
+                    },
+                    "Reconnect": function () {
+                        knw.set_message('Reconnecting WebSockets', 1000);
+                        setTimeout(function () {
+                            kernel.start_channels();
+                        }, 5000);
+                        $(this).dialog('close');
+                    }
+                }
+            });
+        });
+
 
         var nnw = this.new_notification_widget('notebook');
 

--- a/IPython/frontend/html/notebook/static/js/notificationarea.js
+++ b/IPython/frontend/html/notebook/static/js/notificationarea.js
@@ -122,7 +122,6 @@ var IPython = (function (IPython) {
             var ws_url = data.ws_url;
             var early = data.early;
             var msg;
-            console.log(early);
             if (!early) {
                     knw.set_message('Reconnecting WebSockets', 1000);
                     setTimeout(function () {

--- a/IPython/frontend/html/notebook/static/js/outputarea.js
+++ b/IPython/frontend/html/notebook/static/js/outputarea.js
@@ -79,7 +79,7 @@ var IPython = (function (IPython) {
 
         this.element.resize(function () {
             // FIXME: Firefox on Linux misbehaves, so automatic scrolling is disabled
-            if ( $.browser.mozilla ) {
+            if ( IPython.utils.browser[0] === "Firefox" ) {
                 return;
             }
             // maybe scroll output,

--- a/IPython/frontend/html/notebook/static/js/tooltip.js
+++ b/IPython/frontend/html/notebook/static/js/tooltip.js
@@ -126,7 +126,7 @@ var IPython = (function (IPython) {
         // reexecute last call in pager by appending ? to show back in pager
         var that = this;
         var empty = function () {};
-        IPython.notebook.kernel.execute(
+        cell.kernel.execute(
         that.name + '?', {
             'execute_reply': empty,
             'output': empty,
@@ -212,7 +212,7 @@ var IPython = (function (IPython) {
         var callbacks = {
             'object_info_reply': $.proxy(this._show, this)
         }
-        var msg_id = IPython.notebook.kernel.object_info_request(re.exec(func), callbacks);
+        var msg_id = cell.kernel.object_info_request(re.exec(func), callbacks);
     }
 
     // make an imediate completion request
@@ -360,11 +360,12 @@ var IPython = (function (IPython) {
     // convenient funciton to have the correct code_mirror back into focus
     Tooltip.prototype._cmfocus = function () {
         var cm = this.code_mirror;
-        if (cm == IPython.notebook.get_selected_cell())
-        {
-            setTimeout(function () {
-                cm.focus();
-            }, 50);
+        if (IPython.notebook !== undefined) {
+            if (cm == IPython.notebook.get_selected_cell()) {
+                setTimeout(function () {
+                    cm.focus();
+                }, 50);
+            }
         }
     }
 

--- a/IPython/frontend/html/notebook/static/js/tooltip.js
+++ b/IPython/frontend/html/notebook/static/js/tooltip.js
@@ -111,7 +111,6 @@ var IPython = (function (IPython) {
             }, function (cell) {
                 that.cancel_stick();
                 that.showInPager(cell);
-                that._cmfocus();
             }];
             // call after all the tabs function above have bee call to clean their effects
             // if necessary
@@ -136,7 +135,6 @@ var IPython = (function (IPython) {
             'silent': false
         });
         this.remove_and_cancel_tooltip();
-        this._cmfocus();
     }
 
     // grow the tooltip verticaly
@@ -144,7 +142,6 @@ var IPython = (function (IPython) {
         this.text.removeClass('smalltooltip');
         this.text.addClass('bigtooltip');
         $('#expanbutton').hide('slow');
-        this._cmfocus();
     }
 
     // deal with all the logic of hiding the tooltip
@@ -170,7 +167,6 @@ var IPython = (function (IPython) {
         }
         this.cancel_pending();
         this.reset_tabs_function();
-        this._cmfocus();
     }
 
     // cancel autocall done after '(' for example.
@@ -357,17 +353,6 @@ var IPython = (function (IPython) {
         this.text.scrollTop(0);
     }
 
-    // convenient funciton to have the correct code_mirror back into focus
-    Tooltip.prototype._cmfocus = function () {
-        var cm = this.code_mirror;
-        if (IPython.notebook !== undefined) {
-            if (cm == IPython.notebook.get_selected_cell()) {
-                setTimeout(function () {
-                    cm.focus();
-                }, 50);
-            }
-        }
-    }
 
     IPython.Tooltip = Tooltip;
 

--- a/IPython/frontend/html/notebook/static/js/utils.js
+++ b/IPython/frontend/html/notebook/static/js/utils.js
@@ -272,6 +272,15 @@ IPython.utils = (function (IPython) {
         return Math.floor(points*pixel_per_point);
     };
 
+    // http://stackoverflow.com/questions/2400935/browser-detection-in-javascript
+    browser = (function() {
+        var N= navigator.appName, ua= navigator.userAgent, tem;
+        var M= ua.match(/(opera|chrome|safari|firefox|msie)\/?\s*(\.?\d+(\.\d+)*)/i);
+        if (M && (tem= ua.match(/version\/([\.\d]+)/i))!= null) M[2]= tem[1];
+        M= M? [M[1], M[2]]: [N, navigator.appVersion,'-?'];
+        return M;
+    })();
+
 
     return {
         regex_split : regex_split,
@@ -282,7 +291,9 @@ IPython.utils = (function (IPython) {
         fixCarriageReturn : fixCarriageReturn,
         wrapUrls : wrapUrls,
         autoLinkUrls : autoLinkUrls,
-        points_to_pixels : points_to_pixels
+        points_to_pixels : points_to_pixels,
+        browser : browser    
     };
 
 }(IPython));
+


### PR DESCRIPTION
There were a number of spots where the CodeCell logic depended on the IPython.notebook object.  These have been removed.  I have also cleaned up some of the css that was having problems when CodeCells are embedded onto bootstrap containing pages.  This will help us as we refactor the notebook to use bootstrap.  Finally I have further decoupled the Kernel object from everything else and improved its reconnection logic.
