### PR TITLE
BUG: Opening parenthesis after non-callable raises ValueError

### DIFF
--- a/IPython/frontend/qt/console/call_tip_widget.py
+++ b/IPython/frontend/qt/console/call_tip_widget.py
@@ -1,6 +1,5 @@
 # Standard library imports
 import re
-from textwrap import dedent
 from unicodedata import category
 
 # System library imports
@@ -254,6 +253,9 @@ class CallTipWidget(QtGui.QLabel):
         # make sure a long argument list does not make
         # the first row overflow the width of the actual tip body
         rows = doc.split("\n")
+        # An object which is not a callable has '<no docstring>' as doc
+        if len(rows) == 1:
+            return doc
         max_text_width = max(80, max([len(x) for x in rows[1:]]))
         rows= textwrap.wrap(rows[0],max_text_width) + rows[1:]
         doc = "\n".join(rows)


### PR DESCRIPTION
Typing something like `None(` raises a value error.
