### PR TITLE
avoid string version comparisons in external.qt

### DIFF
--- a/IPython/external/qt.py
+++ b/IPython/external/qt.py
@@ -7,7 +7,7 @@ Do not use this if you need PyQt with the old QString/QVariant API.
 """
 
 import os
-from IPython.utils.version import NumericalVersion as V
+from IPython.utils.version import check_version
 # Available APIs.
 QT_API_PYQT = 'pyqt'
 QT_API_PYSIDE = 'pyside'
@@ -26,7 +26,7 @@ if QT_API is None:
     pyside_found = False
     try:
         import PySide
-        if V(PySide.__version__) < V('1.0.3'):
+        if not check_version(PySide.__version__, '1.0.3'):
             # old PySide, fallback on PyQt
             raise ImportError
         # we can't import an incomplete pyside and pyqt4
@@ -49,7 +49,7 @@ if QT_API is None:
                       "present.\nThis will likely crash, please install " \
                       "PySide completely, remove PySide or PyQt4 or set " \
                       "the QT_API environment variable to pyqt or pyside"
-            if V(QtCore.PYQT_VERSION_STR) < V('4.7'):
+            if not check_version(QtCore.PYQT_VERSION_STR, '4.7'):
                 # PyQt 4.6 has issues with null strings returning as None
                 raise ImportError
             QT_API = QT_API_PYQT
@@ -63,7 +63,7 @@ elif QT_API == QT_API_PYQT:
 # Now peform the imports.
 if QT_API == QT_API_PYQT:
     from PyQt4 import QtCore, QtGui, QtSvg
-    if V(QtCore.PYQT_VERSION_STR) < V('4.7'):
+    if not check_version(QtCore.PYQT_VERSION_STR, '4.7'):
         raise ImportError("IPython requires PyQt4 >= 4.7, found %s"%QtCore.PYQT_VERSION_STR)
 
     # Alias PyQt-specific functions for PySide compatibility.
@@ -72,7 +72,7 @@ if QT_API == QT_API_PYQT:
 
 elif QT_API == QT_API_PYSIDE:
     import PySide
-    if V(PySide.__version__) < V('1.0.3'):
+    if not check_version(PySide.__version__, '1.0.3'):
         raise ImportError("IPython requires PySide >= 1.0.3, found %s"%PySide.__version__)
     from PySide import QtCore, QtGui, QtSvg
 

--- a/IPython/external/qt.py
+++ b/IPython/external/qt.py
@@ -7,7 +7,7 @@ Do not use this if you need PyQt with the old QString/QVariant API.
 """
 
 import os
-
+from distutils.version import LooseVersion as V
 # Available APIs.
 QT_API_PYQT = 'pyqt'
 QT_API_PYSIDE = 'pyside'
@@ -26,7 +26,7 @@ if QT_API is None:
     pyside_found = False
     try:
         import PySide
-        if PySide.__version__ < '1.0.3':
+        if V(PySide.__version__) < V('1.0.3'):
             # old PySide, fallback on PyQt
             raise ImportError
         # we can't import an incomplete pyside and pyqt4
@@ -49,7 +49,7 @@ if QT_API is None:
                       "present.\nThis will likely crash, please install " \
                       "PySide completely, remove PySide or PyQt4 or set " \
                       "the QT_API environment variable to pyqt or pyside"
-            if QtCore.PYQT_VERSION_STR < '4.7':
+            if V(QtCore.PYQT_VERSION_STR) < V('4.7'):
                 # PyQt 4.6 has issues with null strings returning as None
                 raise ImportError
             QT_API = QT_API_PYQT
@@ -63,7 +63,7 @@ elif QT_API == QT_API_PYQT:
 # Now peform the imports.
 if QT_API == QT_API_PYQT:
     from PyQt4 import QtCore, QtGui, QtSvg
-    if QtCore.PYQT_VERSION_STR < '4.7':
+    if V(QtCore.PYQT_VERSION_STR) < V('4.7'):
         raise ImportError("IPython requires PyQt4 >= 4.7, found %s"%QtCore.PYQT_VERSION_STR)
 
     # Alias PyQt-specific functions for PySide compatibility.
@@ -72,7 +72,7 @@ if QT_API == QT_API_PYQT:
 
 elif QT_API == QT_API_PYSIDE:
     import PySide
-    if PySide.__version__ < '1.0.3':
+    if V(PySide.__version__) < V('1.0.3'):
         raise ImportError("IPython requires PySide >= 1.0.3, found %s"%PySide.__version__)
     from PySide import QtCore, QtGui, QtSvg
 

--- a/IPython/external/qt.py
+++ b/IPython/external/qt.py
@@ -7,7 +7,7 @@ Do not use this if you need PyQt with the old QString/QVariant API.
 """
 
 import os
-from distutils.version import LooseVersion as V
+from IPython.utils.version import NumericalVersion as V
 # Available APIs.
 QT_API_PYQT = 'pyqt'
 QT_API_PYSIDE = 'pyside'

--- a/IPython/external/qt_for_kernel.py
+++ b/IPython/external/qt_for_kernel.py
@@ -32,9 +32,10 @@ import os
 import sys
 
 from IPython.utils.warn import warn
+from IPython.utils.version import NumericalVersion as V
 
 matplotlib = sys.modules.get('matplotlib')
-if matplotlib and matplotlib.__version__ <= '1.0.1':
+if matplotlib and V(matplotlib.__version__) <= V('1.0.1'):
     # 1.0.1 doesn't support pyside or v2, so stick with PyQt @v1,
     # and ignore everything else
     from PyQt4 import QtCore, QtGui

--- a/IPython/external/qt_for_kernel.py
+++ b/IPython/external/qt_for_kernel.py
@@ -32,10 +32,10 @@ import os
 import sys
 
 from IPython.utils.warn import warn
-from IPython.utils.version import NumericalVersion as V
+from IPython.utils.version import check_version
 
 matplotlib = sys.modules.get('matplotlib')
-if matplotlib and V(matplotlib.__version__) <= V('1.0.1'):
+if matplotlib and not check_version(matplotlib.__version__, '1.0.2'):
     # 1.0.1 doesn't support pyside or v2, so stick with PyQt @v1,
     # and ignore everything else
     from PyQt4 import QtCore, QtGui

--- a/IPython/utils/version.py
+++ b/IPython/utils/version.py
@@ -53,4 +53,17 @@ def version_tuple(vs):
     regular integer element.
     """
     return tuple(NumericalVersion(vs).version)
+
+#
+def check_version(v, check):
+    """check version string v >= check
+
+    If dev/prerelease tags result in TypeError for string-number comparison,
+    it is assumed that the dependency is satisfied.
+    Users on dev branches are responsible for keeping their own packages up to date.
+    """
+    try:
+        return LooseVersion(v) >= LooseVersion(check)
+    except TypeError:
+        return True
     

--- a/IPython/utils/version.py
+++ b/IPython/utils/version.py
@@ -1,0 +1,56 @@
+# encoding: utf-8
+"""
+Utilities for version comparison
+
+It is a bit ridiculous that we need these.
+"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2013  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+from distutils.version import LooseVersion
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------
+
+class NumericalVersion(LooseVersion):
+    """A version of LooseVersion that is *always* comparable
+    
+    String elements (of any kind!) are interpreted as infinite.
+    Since these are generally only on development branches,
+    that is fairly safe, even though technically 1.0a1 should be less than 1.0.
+    """
+    def parse (self, vstring):
+        # I've given up on thinking I can reconstruct the version string
+        # from the parsed tuple -- so I just store the string here for
+        # use by __str__
+        self.vstring = vstring
+        components = filter(lambda x: x and x != '.',
+                            self.component_re.split(vstring))
+        for i in range(len(components)):
+            try:
+                components[i] = int(components[i])
+            except ValueError:
+                # this is the only change
+                components[i] = float('inf')
+
+        self.version = components
+
+def version_tuple(vs):
+    """Return a tuple of numbers from a version string.
+    
+    'dev' 'a', 'etc' are transformed to float('inf'),
+    so they will always compare positively to any
+    regular integer element.
+    """
+    return tuple(NumericalVersion(vs).version)
+    

--- a/IPython/utils/version.py
+++ b/IPython/utils/version.py
@@ -22,39 +22,6 @@ from distutils.version import LooseVersion
 # Code
 #-----------------------------------------------------------------------------
 
-class NumericalVersion(LooseVersion):
-    """A version of LooseVersion that is *always* comparable
-    
-    String elements (of any kind!) are interpreted as infinite.
-    Since these are generally only on development branches,
-    that is fairly safe, even though technically 1.0a1 should be less than 1.0.
-    """
-    def parse (self, vstring):
-        # I've given up on thinking I can reconstruct the version string
-        # from the parsed tuple -- so I just store the string here for
-        # use by __str__
-        self.vstring = vstring
-        components = filter(lambda x: x and x != '.',
-                            self.component_re.split(vstring))
-        for i in range(len(components)):
-            try:
-                components[i] = int(components[i])
-            except ValueError:
-                # this is the only change
-                components[i] = float('inf')
-
-        self.version = components
-
-def version_tuple(vs):
-    """Return a tuple of numbers from a version string.
-    
-    'dev' 'a', 'etc' are transformed to float('inf'),
-    so they will always compare positively to any
-    regular integer element.
-    """
-    return tuple(NumericalVersion(vs).version)
-
-#
 def check_version(v, check):
     """check version string v >= check
 
@@ -66,4 +33,4 @@ def check_version(v, check):
         return LooseVersion(v) >= LooseVersion(check)
     except TypeError:
         return True
-    
+


### PR DESCRIPTION
We have learned from pyzmq that one should _always_ parse version strings
before comparing them.
