### PR TITLE
notebook: Added new short key for all-cell execution

### DIFF
--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -128,6 +128,10 @@ var IPython = (function (IPython) {
             } else if (event.which === key.ENTER && event.ctrlKey) {
                 that.execute_selected_cell({terminal:true});
                 return false;
+            } else if (event.which === key.ENTER && that.control_key_active) {
+                that.execute_cell_range(0, that.ncells());
+                that.control_key_active = false;
+                return false;
             } else if (event.which === 77 && event.ctrlKey && that.control_key_active == false) {
                 that.control_key_active = true;
                 return false;

--- a/IPython/frontend/html/notebook/static/js/quickhelp.js
+++ b/IPython/frontend/html/notebook/static/js/quickhelp.js
@@ -28,6 +28,7 @@ var IPython = (function (IPython) {
         var shortcuts = [
             {key: 'Shift-Enter', help: 'run cell'},
             {key: 'Ctrl-Enter', help: 'run cell in-place'},
+            {key: 'Ctrl-m Enter', help: 'run all cells'},
             {key: 'Alt-Enter', help: 'run cell, insert below'},
             {key: 'Ctrl-m x', help: 'cut cell'},
             {key: 'Ctrl-m c', help: 'copy cell'},


### PR DESCRIPTION
Actions exposed in the `Cell` menu should have keyboard shortcuts. Now you can
type:

  Ctrl-m . Enter Ctrl-m Enter

To restart the kernel (Ctrl-m .), accept the restart (Enter), and rerun all
the cells (Ctrl-m Enter) to straighten out your prompt numbers.
