### PR TITLE
Consolidate host IP detection in utils.localinterfaces

### DIFF
--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -70,6 +70,7 @@ from IPython.zmq.ipkernel import (
     IPKernelApp
 )
 from IPython.utils.importstring import import_item
+from IPython.utils.localinterfaces import LOCALHOST
 from IPython.utils.traitlets import (
     Dict, Unicode, Integer, List, Enum, Bool,
     DottedObjectName
@@ -86,9 +87,6 @@ _kernel_action_regex = r"(?P<action>restart|interrupt)"
 _notebook_id_regex = r"(?P<notebook_id>\w+-\w+-\w+-\w+-\w+)"
 _profile_regex = r"(?P<profile>[^\/]+)" # there is almost no text that is invalid
 _cluster_action_regex = r"(?P<action>start|stop)"
-
-
-LOCALHOST = '127.0.0.1'
 
 _examples = """
 ipython notebook                       # start the notebook
@@ -610,7 +608,7 @@ class NotebookApp(BaseIPythonApplication):
         info("Use Control-C to stop this server and shut down all kernels.")
 
         if self.open_browser or self.file_to_run:
-            ip = self.ip or '127.0.0.1'
+            ip = self.ip or LOCALHOST
             try:
                 browser = webbrowser.get(self.browser or None)
             except webbrowser.Error as e:

--- a/IPython/frontend/html/notebook/tests/test_kernelmanager.py
+++ b/IPython/frontend/html/notebook/tests/test_kernelmanager.py
@@ -8,6 +8,7 @@ from IPython.testing import decorators as dec
 
 from IPython.config.loader import Config
 from IPython.frontend.html.notebook.kernelmanager import MultiKernelManager
+from IPython.utils.localinterfaces import LOCALHOST
 from IPython.zmq.kernelmanager import KernelManager
 
 class TestKernelManager(TestCase):
@@ -67,7 +68,7 @@ class TestKernelManager(TestCase):
     @dec.skip_win32
     def test_tcp_cinfo(self):
         km = self._get_tcp_km()
-        self._run_cinfo(km, 'tcp', '127.0.0.1')
+        self._run_cinfo(km, 'tcp', LOCALHOST)
 
     def test_ipc_lifecycle(self):
         km = self._get_ipc_km()

--- a/IPython/parallel/apps/ipcontrollerapp.py
+++ b/IPython/parallel/apps/ipcontrollerapp.py
@@ -25,7 +25,6 @@ from __future__ import with_statement
 
 import json
 import os
-import socket
 import stat
 import sys
 
@@ -45,6 +44,7 @@ from IPython.parallel.apps.baseapp import (
     catch_config_error,
 )
 from IPython.utils.importstring import import_item
+from IPython.utils.localinterfaces import LOCALHOST, PUBLIC_IPS
 from IPython.utils.traitlets import Instance, Unicode, Bool, List, Dict, TraitError
 
 from IPython.zmq.session import (
@@ -220,13 +220,13 @@ class IPControllerApp(BaseParallelApplication):
         location = cdict['location']
         
         if not location:
-            try:
-                location = socket.gethostbyname_ex(socket.gethostname())[2][-1]
-            except (socket.gaierror, IndexError):
-                self.log.warn("Could not identify this machine's IP, assuming 127.0.0.1."
+            if PUBLIC_IPS:
+                location = PUBLIC_IPS[-1]
+            else:
+                self.log.warn("Could not identify this machine's IP, assuming %s."
                 " You may need to specify '--location=<external_ip_address>' to help"
-                " IPython decide when to connect via loopback.")
-                location = '127.0.0.1'
+                " IPython decide when to connect via loopback." % LOCALHOST)
+                location = LOCALHOST
             cdict['location'] = location
         fname = os.path.join(self.profile_dir.security_dir, fname)
         self.log.info("writing connection info to %s", fname)

--- a/IPython/parallel/apps/logwatcher.py
+++ b/IPython/parallel/apps/logwatcher.py
@@ -26,6 +26,7 @@ import zmq
 from zmq.eventloop import ioloop, zmqstream
 
 from IPython.config.configurable import LoggingConfigurable
+from IPython.utils.localinterfaces import LOCALHOST
 from IPython.utils.traitlets import Int, Unicode, Instance, List
 
 #-----------------------------------------------------------------------------
@@ -43,7 +44,7 @@ class LogWatcher(LoggingConfigurable):
     # configurables
     topics = List([''], config=True,
         help="The ZMQ topics to subscribe to. Default is to subscribe to all messages")
-    url = Unicode('tcp://127.0.0.1:20202', config=True,
+    url = Unicode('tcp://%s:20202' % LOCALHOST, config=True,
         help="ZMQ url on which to listen for log messages")
     
     # internals

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -36,7 +36,7 @@ from IPython.core.profiledir import ProfileDir, ProfileDirError
 
 from IPython.utils.coloransi import TermColors
 from IPython.utils.jsonutil import rekey
-from IPython.utils.localinterfaces import LOCAL_IPS
+from IPython.utils.localinterfaces import LOCALHOST, LOCAL_IPS
 from IPython.utils.path import get_ipython_dir
 from IPython.utils.py3compat import cast_bytes
 from IPython.utils.traitlets import (HasTraits, Integer, Instance, Unicode,
@@ -427,7 +427,7 @@ class Client(HasTraits):
         
         url = cfg['registration']
         
-        if location is not None and addr == '127.0.0.1':
+        if location is not None and addr == LOCALHOST:
             # location specified, and connection is expected to be local
             if location not in LOCAL_IPS and not sshserver:
                 # load ssh from JSON *only* if the controller is not on

--- a/IPython/parallel/controller/hub.py
+++ b/IPython/parallel/controller/hub.py
@@ -30,6 +30,7 @@ from zmq.eventloop.zmqstream import ZMQStream
 
 # internal:
 from IPython.utils.importstring import import_item
+from IPython.utils.localinterfaces import LOCALHOST
 from IPython.utils.py3compat import cast_bytes
 from IPython.utils.traitlets import (
         HasTraits, Instance, Integer, Unicode, Dict, Set, Tuple, CBytes, DottedObjectName
@@ -176,17 +177,17 @@ class HubFactory(RegistrationFactory):
     def _notifier_port_default(self):
         return util.select_random_ports(1)[0]
 
-    engine_ip = Unicode('127.0.0.1', config=True,
+    engine_ip = Unicode(LOCALHOST, config=True,
         help="IP on which to listen for engine connections. [default: loopback]")
     engine_transport = Unicode('tcp', config=True,
         help="0MQ transport for engine connections. [default: tcp]")
 
-    client_ip = Unicode('127.0.0.1', config=True,
+    client_ip = Unicode(LOCALHOST, config=True,
         help="IP on which to listen for client connections. [default: loopback]")
     client_transport = Unicode('tcp', config=True,
         help="0MQ transport for client connections. [default : tcp]")
 
-    monitor_ip = Unicode('127.0.0.1', config=True,
+    monitor_ip = Unicode(LOCALHOST, config=True,
         help="IP on which to listen for monitor messages. [default: loopback]")
     monitor_transport = Unicode('tcp', config=True,
         help="0MQ transport for monitor messages. [default : tcp]")

--- a/IPython/parallel/engine/engine.py
+++ b/IPython/parallel/engine/engine.py
@@ -24,6 +24,7 @@ from zmq.eventloop import ioloop, zmqstream
 
 from IPython.external.ssh import tunnel
 # internal
+from IPython.utils.localinterfaces import LOCALHOST
 from IPython.utils.traitlets import (
     Instance, Dict, Integer, Type, Float, Integer, Unicode, CBytes, Bool
 )
@@ -182,13 +183,13 @@ class EngineFactory(RegistrationFactory):
             if self.max_heartbeat_misses > 0:
                 # Add a monitor socket which will record the last time a ping was seen
                 mon = self.context.socket(zmq.SUB)
-                mport = mon.bind_to_random_port('tcp://127.0.0.1')
+                mport = mon.bind_to_random_port('tcp://%s' % LOCALHOST)
                 mon.setsockopt(zmq.SUBSCRIBE, b"")
                 self._hb_listener = zmqstream.ZMQStream(mon, self.loop)
                 self._hb_listener.on_recv(self._report_ping)
             
             
-                hb_monitor = "tcp://127.0.0.1:%i"%mport
+                hb_monitor = "tcp://%s:%i" % (LOCALHOST, mport)
 
             heart = Heart(hb_ping, hb_pong, hb_monitor , heart_id=identity)
             heart.start()

--- a/IPython/parallel/factory.py
+++ b/IPython/parallel/factory.py
@@ -24,6 +24,7 @@ import zmq
 from zmq.eventloop.ioloop import IOLoop
 
 from IPython.config.configurable import Configurable
+from IPython.utils.localinterfaces import LOCALHOST
 from IPython.utils.traitlets import Integer, Instance, Unicode
 
 from IPython.parallel.util import select_random_ports
@@ -39,15 +40,16 @@ class RegistrationFactory(SessionFactory):
     
     url = Unicode('', config=True,
         help="""The 0MQ url used for registration. This sets transport, ip, and port
-        in one variable. For example: url='tcp://127.0.0.1:12345' or
-        url='epgm://*:90210'""") # url takes precedence over ip,regport,transport
+        in one variable. For example: url='tcp://%s:12345' or
+        url='epgm://*:90210'"""
+                  % LOCALHOST) # url takes precedence over ip,regport,transport
     transport = Unicode('tcp', config=True,
         help="""The 0MQ transport for communications.  This will likely be
         the default of 'tcp', but other values include 'ipc', 'epgm', 'inproc'.""")
-    ip = Unicode('127.0.0.1', config=True,
+    ip = Unicode(LOCALHOST, config=True,
         help="""The IP address for registration.  This is generally either
         '127.0.0.1' for loopback only or '*' for all interfaces.
-        [default: '127.0.0.1']""")
+        [default: '%s']""" % LOCALHOST)
     regport = Integer(config=True,
         help="""The port on which the Hub listens for registration.""")
     def _regport_default(self):

--- a/IPython/parallel/util.py
+++ b/IPython/parallel/util.py
@@ -43,6 +43,7 @@ from IPython.external.decorator import decorator
 
 # IPython imports
 from IPython.config.application import Application
+from IPython.utils.localinterfaces import LOCALHOST, PUBLIC_IPS
 from IPython.zmq.log import EnginePUBHandler
 from IPython.zmq.serialize import (
     unserialize_object, serialize_object, pack_apply_message, unpack_apply_message
@@ -186,14 +187,9 @@ def disambiguate_ip_address(ip, location=None):
     """turn multi-ip interfaces '0.0.0.0' and '*' into connectable
     ones, based on the location (default interpretation of location is localhost)."""
     if ip in ('0.0.0.0', '*'):
-        try:
-            external_ips = socket.gethostbyname_ex(socket.gethostname())[2]
-        except (socket.gaierror, IndexError):
-            # couldn't identify this machine, assume localhost
-            external_ips = []
-        if location is None or location in external_ips or not external_ips:
+        if location is None or location in PUBLIC_IPS or not PUBLIC_IPS:
             # If location is unspecified or cannot be determined, assume local
-            ip='127.0.0.1'
+            ip = LOCALHOST
         elif location:
             return location
     return ip

--- a/IPython/utils/localinterfaces.py
+++ b/IPython/utils/localinterfaces.py
@@ -19,6 +19,8 @@ LOCAL_IPS : A list of IP addresses, loopback first, that point to this machine.
 
 import socket
 
+from .data import uniq_stable
+
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
@@ -36,5 +38,7 @@ except socket.gaierror:
 
 # include all-interface aliases: 0.0.0.0 and ''
 LOCAL_IPS.extend(['0.0.0.0', ''])
+
+LOCAL_IPS = uniq_stable(LOCAL_IPS)
 
 LOCALHOST = LOCAL_IPS[0]

--- a/IPython/utils/localinterfaces.py
+++ b/IPython/utils/localinterfaces.py
@@ -5,6 +5,9 @@ LOCALHOST : The loopback interface, or the first interface that points to this
             machine.  It will *almost* always be '127.0.0.1'
 
 LOCAL_IPS : A list of IP addresses, loopback first, that point to this machine.
+
+PUBLIC_IPS : A list of public IP addresses that point to this machine.
+             Use these to tell remote clients where to find you.
 """
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2010-2011  The IPython Development Team
@@ -31,10 +34,14 @@ try:
 except socket.gaierror:
     pass
 
+PUBLIC_IPS = []
 try:
-    LOCAL_IPS.extend(socket.gethostbyname_ex(socket.gethostname())[2])
+    PUBLIC_IPS = socket.gethostbyname_ex(socket.gethostname())[2]
 except socket.gaierror:
     pass
+else:
+    PUBLIC_IPS = uniq_stable(PUBLIC_IPS)
+    LOCAL_IPS.extend(PUBLIC_IPS)
 
 # include all-interface aliases: 0.0.0.0 and ''
 LOCAL_IPS.extend(['0.0.0.0', ''])


### PR DESCRIPTION
This PR replaces a number of hard-coded 127.0.0.1 references with
LOCALHOST, and consolidates the computation of LOCALHOST,
LOCAL_IPS, and a new PUBLIC_IPS in the localinterfaces module.

It's unclear to me when LOCALHOST would not be 127.0.0.1.  I suppose
you could have another IP in the 127.0.0.0/8 block, or a IPv6 address.
It may also be possible to not have a loopback interface at all.  In
that case it's possible that we need a LOOPBACK variable in
utils.localinterfaces which is a valid loopback interface or None, so
that consumers can differentiate between generic IPs pointing back to
the local host and the loopback interface.
