### PR TITLE
future pyzmq compatibility

### DIFF
--- a/IPython/parallel/__init__.py
+++ b/IPython/parallel/__init__.py
@@ -23,10 +23,7 @@ import zmq
 from IPython.config.configurable import MultipleInstanceError
 from IPython.zmq import check_for_zmq
 
-if os.name == 'nt':
-    min_pyzmq = '2.1.7'
-else:
-    min_pyzmq = '2.1.4'
+min_pyzmq = '2.1.11'
 
 check_for_zmq(min_pyzmq, 'IPython.parallel')
 

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -167,19 +167,9 @@ have['wx'] = test_for('wx')
 have['wx.aui'] = test_for('wx.aui')
 have['azure'] = test_for('azure')
 
-if os.name == 'nt':
-    min_zmq = (2,1,7)
-else:
-    min_zmq = (2,1,4)
+min_zmq = (2,1,11)
 
-def version_tuple(mod):
-    "turn '2.1.9' into (2,1,9), and '2.1dev' into (2,1,999)"
-    # turn 'dev' into 999, because Python3 rejects str-int comparisons
-    vs = mod.__version__.replace('dev', '.999')
-    tup = tuple([int(v) for v in vs.split('.') ])
-    return tup
-
-have['zmq'] = test_for('zmq', min_zmq, version_tuple)
+have['zmq'] = test_for('zmq.pyzmq_version_info', min_zmq)
 
 #-----------------------------------------------------------------------------
 # Functions and classes

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -169,7 +169,7 @@ have['azure'] = test_for('azure')
 
 min_zmq = (2,1,11)
 
-have['zmq'] = test_for('zmq.pyzmq_version_info', min_zmq)
+have['zmq'] = test_for('zmq.pyzmq_version_info', min_zmq, callback=lambda x: x())
 
 #-----------------------------------------------------------------------------
 # Functions and classes

--- a/IPython/zmq/__init__.py
+++ b/IPython/zmq/__init__.py
@@ -6,11 +6,11 @@
 #-----------------------------------------------------------------------------
 
 #-----------------------------------------------------------------------------
-# Verify zmq version dependency >= 2.1.4
+# Verify zmq version dependency >= 2.1.11
 #-----------------------------------------------------------------------------
 
 import warnings
-from distutils.version import LooseVersion as V
+from IPython.utils.version import check_version
 
 
 def patch_pyzmq():
@@ -20,22 +20,6 @@ def patch_pyzmq():
     """
     
     import zmq
-    
-    # ioloop.install, introduced in pyzmq 2.1.7
-    from zmq.eventloop import ioloop
-    
-    def install():
-        import tornado.ioloop
-        tornado.ioloop.IOLoop = ioloop.IOLoop
-    
-    if not hasattr(ioloop, 'install'):
-        ioloop.install = install
-    
-    # fix missing DEALER/ROUTER aliases in pyzmq < 2.1.9
-    if not hasattr(zmq, 'DEALER'):
-        zmq.DEALER = zmq.XREQ
-    if not hasattr(zmq, 'ROUTER'):
-        zmq.ROUTER = zmq.XREP
     
     # fallback on stdlib json if jsonlib is selected, because jsonlib breaks things.
     # jsonlib support is removed from pyzmq >= 2.2.0
@@ -54,17 +38,11 @@ def check_for_zmq(minimum_version, module='IPython.zmq'):
 
     pyzmq_version = zmq.__version__
     
-    if 'dev' not in pyzmq_version and V(pyzmq_version) < V(minimum_version):
+    if not check_version(pyzmq_version, minimum_version):
         raise ImportError("%s requires pyzmq >= %s, but you have %s"%(
                         module, minimum_version, pyzmq_version))
 
-    if V(zmq.zmq_version()) >= V('4.0.0'):
-        warnings.warn("""libzmq 4 detected.
-        It is unlikely that IPython's zmq code will work properly.
-        Please install libzmq stable, which is 2.1.x or 2.2.x""",
-        RuntimeWarning)
-
-check_for_zmq('2.1.4')
+check_for_zmq('2.1.11')
 patch_pyzmq()
 
 from .blockingkernelmanager import BlockingKernelManager

--- a/IPython/zmq/tests/test_session.py
+++ b/IPython/zmq/tests/test_session.py
@@ -28,6 +28,7 @@ class SessionTestCase(BaseZMQTestCase):
 
 
 class MockSocket(zmq.Socket):
+    data = None
 
     def __init__(self, *args, **kwargs):
         super(MockSocket,self).__init__(*args,**kwargs)

--- a/IPython/zmq/tests/test_session.py
+++ b/IPython/zmq/tests/test_session.py
@@ -27,22 +27,6 @@ class SessionTestCase(BaseZMQTestCase):
         self.session = ss.Session()
 
 
-class MockSocket(zmq.Socket):
-    data = None
-
-    def __init__(self, *args, **kwargs):
-        super(MockSocket,self).__init__(*args,**kwargs)
-        self.data = []
-
-    def send_multipart(self, msgparts, *args, **kwargs):
-        self.data.extend(msgparts)
-
-    def send(self, part, *args, **kwargs):
-        self.data.append(part)
-
-    def recv_multipart(self, *args, **kwargs):
-        return self.data
-
 class TestSession(SessionTestCase):
 
     def test_msg(self):
@@ -76,11 +60,16 @@ class TestSession(SessionTestCase):
         self.assertEqual(type(new_msg['content']['b']),type(new_msg['content']['b']))
 
     def test_send(self):
-        socket = MockSocket(zmq.Context.instance(),zmq.PAIR)
+        ctx = zmq.Context.instance()
+        A = ctx.socket(zmq.PAIR)
+        B = ctx.socket(zmq.PAIR)
+        A.bind("inproc://test")
+        B.connect("inproc://test")
 
         msg = self.session.msg('execute', content=dict(a=10))
-        self.session.send(socket, msg, ident=b'foo', buffers=[b'bar'])
-        ident, msg_list = self.session.feed_identities(socket.data)
+        self.session.send(A, msg, ident=b'foo', buffers=[b'bar'])
+        
+        ident, msg_list = self.session.feed_identities(B.recv_multipart())
         new_msg = self.session.unserialize(msg_list)
         self.assertEqual(ident[0], b'foo')
         self.assertEqual(new_msg['msg_id'],msg['msg_id'])
@@ -90,17 +79,15 @@ class TestSession(SessionTestCase):
         self.assertEqual(new_msg['parent_header'],msg['parent_header'])
         self.assertEqual(new_msg['metadata'],msg['metadata'])
         self.assertEqual(new_msg['buffers'],[b'bar'])
-
-        socket.data = []
 
         content = msg['content']
         header = msg['header']
         parent = msg['parent_header']
         metadata = msg['metadata']
         msg_type = header['msg_type']
-        self.session.send(socket, None, content=content, parent=parent,
+        self.session.send(A, None, content=content, parent=parent,
             header=header, metadata=metadata, ident=b'foo', buffers=[b'bar'])
-        ident, msg_list = self.session.feed_identities(socket.data)
+        ident, msg_list = self.session.feed_identities(B.recv_multipart())
         new_msg = self.session.unserialize(msg_list)
         self.assertEqual(ident[0], b'foo')
         self.assertEqual(new_msg['msg_id'],msg['msg_id'])
@@ -111,10 +98,8 @@ class TestSession(SessionTestCase):
         self.assertEqual(new_msg['parent_header'],msg['parent_header'])
         self.assertEqual(new_msg['buffers'],[b'bar'])
 
-        socket.data = []
-
-        self.session.send(socket, msg, ident=b'foo', buffers=[b'bar'])
-        ident, new_msg = self.session.recv(socket)
+        self.session.send(A, msg, ident=b'foo', buffers=[b'bar'])
+        ident, new_msg = self.session.recv(B)
         self.assertEqual(ident[0], b'foo')
         self.assertEqual(new_msg['msg_id'],msg['msg_id'])
         self.assertEqual(new_msg['msg_type'],msg['msg_type'])
@@ -124,7 +109,9 @@ class TestSession(SessionTestCase):
         self.assertEqual(new_msg['parent_header'],msg['parent_header'])
         self.assertEqual(new_msg['buffers'],[b'bar'])
 
-        socket.close()
+        A.close()
+        B.close()
+        ctx.term()
 
     def test_args(self):
         """initialization arguments for Session"""

--- a/setup.py
+++ b/setup.py
@@ -229,12 +229,12 @@ if 'setuptools' in sys.modules:
     setuptools_extra_args['zip_safe'] = False
     setuptools_extra_args['entry_points'] = find_scripts(True)
     setup_args['extras_require'] = dict(
-        parallel = 'pyzmq>=2.1.4',
-        qtconsole = ['pyzmq>=2.1.4', 'pygments'],
-        zmq = 'pyzmq>=2.1.4',
+        parallel = 'pyzmq>=2.1.11',
+        qtconsole = ['pyzmq>=2.1.11', 'pygments'],
+        zmq = 'pyzmq>=2.1.11',
         doc = 'Sphinx>=0.3',
         test = 'nose>=0.10.1',
-        notebook = ['tornado>=2.0', 'pyzmq>=2.1.4', 'jinja2'],
+        notebook = ['tornado>=2.0', 'pyzmq>=2.1.11', 'jinja2'],
     )
     requires = setup_args.setdefault('install_requires', [])
     setupext.display_status = False

--- a/setupext/setupext.py
+++ b/setupext/setupext.py
@@ -142,23 +142,13 @@ def check_for_pyzmq():
     else:
         # pyzmq 2.1.10 adds pyzmq_version_info funtion for returning
         # version as a tuple
-        if hasattr(zmq, 'pyzmq_version_info'):
-            if zmq.pyzmq_version_info() >= (2,1,4):
+        if hasattr(zmq, 'pyzmq_version_info') and zmq.pyzmq_version_info() >= (2,1,11):
                 print_status("pyzmq", zmq.__version__)
                 return True
-            else:
-                # this branch can never occur, at least until we update our
-                # pyzmq dependency beyond 2.1.10
-                return False
-        # this is necessarily earlier than 2.1.10, so string comparison is
-        # okay
-        if zmq.__version__ < '2.1.4':
-            print_status('pyzmq', "no (have %s, but require >= 2.1.4 for"
-            " qtconsole and parallel computing capabilities)"%zmq.__version__)
-            return False
         else:
-            print_status("pyzmq", zmq.__version__)
-            return True
+            print_status('pyzmq', "no (have %s, but require >= 2.1.11 for"
+            " qtconsole, notebook, and parallel computing capabilities)" % zmq.__version__)
+            return False
 
 def check_for_readline():
     from distutils.version import LooseVersion


### PR DESCRIPTION
- [x] small change to allow MockSocket tests to run on pyzmq >= 3
- [x] bump base pyzmq to 2.1.11 (Dec 2011), and remove associated patches/workarounds.
