### PR TITLE
Add autorestart logic to the kernel managers

### DIFF
--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -407,6 +407,9 @@ class ZMQStreamHandler(websocket.WebSocketHandler):
         return jsonapi.dumps(msg, default=date_default)
 
     def _on_zmq_reply(self, msg_list):
+        # Sometimes this gets triggered when the on_close method is scheduled in the 
+        # eventloop but hasn't been called.
+        if self.stream.closed(): return
         try:
             msg = self._reserialize_reply(msg_list)
         except Exception:

--- a/IPython/frontend/html/notebook/heartbeat.py
+++ b/IPython/frontend/html/notebook/heartbeat.py
@@ -1,5 +1,7 @@
 """A ZMQStream based heartbeat.
 
+This code is currently not used.
+
 Authors:
 
 * Brian Granger

--- a/IPython/frontend/html/notebook/heartbeat.py
+++ b/IPython/frontend/html/notebook/heartbeat.py
@@ -1,0 +1,105 @@
+"""A ZMQStream based heartbeat.
+
+Authors:
+
+* Brian Granger
+"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2008-2011  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+import time
+
+import zmq
+from zmq.eventloop import ioloop
+
+
+from IPython.config.configurable import LoggingConfigurable
+from IPython.utils.traitlets import (
+    Instance, Float, Bool
+)
+
+#-----------------------------------------------------------------------------
+# Classes
+#-----------------------------------------------------------------------------
+
+class Heartbeat(LoggingConfigurable):
+
+    context = Instance('zmq.Context')
+    def _context_default(self):
+        return zmq.Context.instance()
+
+    loop = Instance('zmq.eventloop.ioloop.IOLoop', allow_none=False)
+    def _loop_default(self):
+        return ioloop.IOLoop.instance()
+
+    stream = Instance('zmq.eventloop.zmqstream.ZMQStream')
+
+    _beating = Bool(False)
+    _kernel_alive = Bool(True)
+
+    time_to_dead = Float(3.0, config=True, help="""Kernel heartbeat interval in seconds.""")
+    first_beat = Float(5.0, config=True, help="Delay (in seconds) before sending first heartbeat.")
+
+    def start(self, callback):
+        """Start the heartbeating and call the callback if the kernel dies."""
+        if not self._beating:
+            self._kernel_alive = True
+
+            def ping_or_dead():
+                self.stream.flush()
+                if self._kernel_alive:
+                    self._kernel_alive = False
+                    self.stream.send(b'ping')
+                    # flush stream to force immediate socket send
+                    self.stream.flush()
+                else:
+                    try:
+                        callback()
+                    except:
+                        pass
+                    finally:
+                        self.stop()
+
+            def beat_received(msg):
+                self._kernel_alive = True
+
+            self.stream.on_recv(beat_received)
+            self._hb_periodic_callback = ioloop.PeriodicCallback(
+                ping_or_dead, self.time_to_dead*1000, self.loop
+            )
+            self.loop.add_timeout(time.time()+self.first_beat, self._really_start_hb)
+            self._beating= True
+    
+    def _really_start_hb(self):
+        """callback for delayed heartbeat start
+        
+        Only start the hb loop if we haven't been closed during the wait.
+        """
+        if self._beating and not self.stream.closed():
+            self._hb_periodic_callback.start()
+
+    def stop(self):
+        """Stop the heartbeating and cancel all related callbacks."""
+        if self._beating:
+            self._beating = False
+            self._hb_periodic_callback.stop()
+            if not self.stream.closed():
+                self.stream.on_recv(None)
+
+    def pause(self):
+        """Pause the heartbeat."""
+        pass
+
+    def unpause(self):
+        """Unpase the heartbeat."""
+        pass
+

--- a/IPython/frontend/html/notebook/kernelmanager.py
+++ b/IPython/frontend/html/notebook/kernelmanager.py
@@ -22,6 +22,7 @@ from IPython.kernel.multikernelmanager import MultiKernelManager
 from IPython.utils.traitlets import (
     Dict, List, Unicode, Float, Integer,
 )
+
 #-----------------------------------------------------------------------------
 # Classes
 #-----------------------------------------------------------------------------

--- a/IPython/frontend/html/notebook/kernelmanager.py
+++ b/IPython/frontend/html/notebook/kernelmanager.py
@@ -20,7 +20,7 @@ from tornado import web
 
 from IPython.kernel.multikernelmanager import MultiKernelManager
 from IPython.utils.traitlets import (
-    Dict, List, Unicode, Float, Integer,
+    Dict, List, Unicode, Integer,
 )
 
 #-----------------------------------------------------------------------------
@@ -32,9 +32,6 @@ class MappingKernelManager(MultiKernelManager):
     """A KernelManager that handles notebok mapping and HTTP error handling"""
 
     kernel_argv = List(Unicode)
-    
-    time_to_dead = Float(3.0, config=True, help="""Kernel heartbeat interval in seconds.""")
-    first_beat = Float(5.0, config=True, help="Delay (in seconds) before sending first heartbeat.")
     
     max_msg_size = Integer(65536, config=True, help="""
         The max raw message size accepted from the browser

--- a/IPython/frontend/terminal/console/interactiveshell.py
+++ b/IPython/frontend/terminal/console/interactiveshell.py
@@ -160,7 +160,7 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
             self.km.shell_channel.get_msg()
         # shell_channel.execute takes 'hidden', which is the inverse of store_hist
         msg_id = self.km.shell_channel.execute(cell, not store_history)
-        while not self.km.shell_channel.msg_ready() and self.km.is_alive:
+        while not self.km.shell_channel.msg_ready() and self.km.is_alive():
             try:
                 self.handle_stdin_request(timeout=0.05)
             except Empty:
@@ -389,7 +389,7 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
         # ask_exit callback.
 
         while not self.exit_now:
-            if not self.km.is_alive:
+            if not self.km.is_alive():
                 # kernel died, prompt for action or exit
                 action = "restart" if self.km.has_kernel else "wait for restart"
                 ans = self.ask_yes_no("kernel died, %s ([y]/n)?" % action, default='y')

--- a/IPython/kernel/blockingkernelmanager.py
+++ b/IPython/kernel/blockingkernelmanager.py
@@ -81,7 +81,7 @@ class BlockingHBChannel(HBChannel):
 
 
 class BlockingKernelManager(KernelManager):
-    
+
     # The classes to use for the various channels.
     shell_channel_class = Type(BlockingShellChannel)
     iopub_channel_class = Type(BlockingIOPubChannel)

--- a/IPython/kernel/inprocess/kernelmanager.py
+++ b/IPython/kernel/inprocess/kernelmanager.py
@@ -298,7 +298,6 @@ class InProcessKernelManager(Configurable):
     def signal_kernel(self, signum):
         raise NotImplementedError("Cannot signal in-process kernel.")
 
-    @property
     def is_alive(self):
         return True
 

--- a/IPython/kernel/ioloopkernelmanager.py
+++ b/IPython/kernel/ioloopkernelmanager.py
@@ -1,0 +1,50 @@
+"""A kernel manager with ioloop based logic."""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2013  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+from __future__ import absolute_import
+
+import zmq
+from zmq.eventloop import ioloop
+
+from IPython.utils.traitlets import (
+    Instance
+)
+
+from .blockingkernelmanager import BlockingKernelManager
+from .ioloopkernelrestarter import IOLoopKernelRestarter
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------
+
+class IOLoopKernelManager(BlockingKernelManager):
+
+    loop = Instance('zmq.eventloop.ioloop.IOLoop', allow_none=False)
+    def _loop_default(self):
+        return ioloop.IOLoop.instance()
+
+    _restarter = Instance('IPython.kernel.ioloopkernelrestarter.IOLoopKernelRestarter')
+
+    def start_restarter(self):
+        if self.autorestart and self.has_kernel:
+            if self._restarter is None:
+                self._restarter = IOLoopKernelRestarter(
+                    kernel_manager=self, loop=self.loop,
+                    config=self.config, log=self.log
+                )
+            self._restarter.start()
+
+    def stop_restarter(self):
+        if self.autorestart:
+            if self._restarter is not None:
+                self._restarter.stop()

--- a/IPython/kernel/kernelmanager.py
+++ b/IPython/kernel/kernelmanager.py
@@ -985,7 +985,7 @@ class KernelManager(Configurable):
             # most 1s, checking every 0.1s.
             self.shell_channel.shutdown(restart=restart)
             for i in range(10):
-                if self.is_alive:
+                if self.is_alive():
                     time.sleep(0.1)
                 else:
                     break
@@ -1100,7 +1100,6 @@ class KernelManager(Configurable):
         else:
             raise RuntimeError("Cannot signal kernel. No kernel is running!")
 
-    @property
     def is_alive(self):
         """Is the kernel process still running?"""
         if self.has_kernel:

--- a/IPython/kernel/kernelmanagerabc.py
+++ b/IPython/kernel/kernelmanagerabc.py
@@ -220,7 +220,7 @@ class KernelManagerABC(object):
     def signal_kernel(self, signum):
         pass
 
-    @abc.abstractproperty
+    @abc.abstractmethod
     def is_alive(self):
         pass
 

--- a/IPython/kernel/kernelrestarter.py
+++ b/IPython/kernel/kernelrestarter.py
@@ -15,6 +15,8 @@ restarts the kernel if it dies.
 # Imports
 #-----------------------------------------------------------------------------
 
+from __future__ import absolute_import
+
 import zmq
 from zmq.eventloop import ioloop
 

--- a/IPython/kernel/kernelrestarter.py
+++ b/IPython/kernel/kernelrestarter.py
@@ -1,0 +1,65 @@
+"""A basic in process kernel monitor with autorestarting.
+
+This watches a kernel's state using KernelManager.is_alive and auto
+restarts the kernel if it dies.
+"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2013  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+import zmq
+from zmq.eventloop import ioloop
+
+
+from IPython.config.configurable import LoggingConfigurable
+from IPython.utils.traitlets import (
+    Instance, Float
+)
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------
+
+class KernelRestarter(LoggingConfigurable):
+    """Monitor and autorestart a kernel."""
+
+    loop = Instance('zmq.eventloop.ioloop.IOLoop', allow_none=False)
+    def _loop_default(self):
+        return ioloop.IOLoop.instance()
+
+    kernel_manager = Instance('IPython.kernel.kernelmanager.KernelManager')
+
+    time_to_dead = Float(3.0, config=True,
+        help="""Kernel heartbeat interval in seconds."""
+    )
+
+    def __init__(self, **kwargs):
+        super(KernelRestarter, self).__init__(**kwargs)
+
+    def start(self):
+        self.pc = ioloop.PeriodicCallback(self.poll, self.time_to_dead, self.ioloop)
+        self.pc.start()
+
+    def poll(self):
+        if not self.kernel_manager.is_alive():
+            self.stop()
+            # This restart event should leave the connection file in place so
+            # the ports are the same. Because this takes place below the
+            # MappingKernelManager, the kernel_id will also remain the same.
+            self.kernel_manager.restart_kernel(now=True);
+            self.start()
+
+    def stop(self):
+        self.pc.stop()
+        self.pc = None
+
+
+

--- a/IPython/kernel/kernelrestarter.py
+++ b/IPython/kernel/kernelrestarter.py
@@ -41,25 +41,37 @@ class KernelRestarter(LoggingConfigurable):
         help="""Kernel heartbeat interval in seconds."""
     )
 
+    _pcallback = None
+
     def __init__(self, **kwargs):
         super(KernelRestarter, self).__init__(**kwargs)
 
     def start(self):
-        self.pc = ioloop.PeriodicCallback(self.poll, self.time_to_dead, self.ioloop)
-        self.pc.start()
+        """Start the polling of the kernel."""
+        if self._pcallback is None:
+            self._pcallback = ioloop.PeriodicCallback(
+                self._poll, 1000*self.time_to_dead, self.ioloop
+            )
+        self._pcallback.start()
 
-    def poll(self):
+    def stop(self):
+        """Stop the kernel polling."""
+        if self._pcallback is not None:
+            self._pcallback.stop()
+
+    def clear(self):
+        """Clear the underlying PeriodicCallback."""
+        self.stop()
+        if self._pcallback is not None:
+            self._pcallback = None
+
+    def _poll(self):
         if not self.kernel_manager.is_alive():
             self.stop()
             # This restart event should leave the connection file in place so
             # the ports are the same. Because this takes place below the
             # MappingKernelManager, the kernel_id will also remain the same.
+            self.log('KernelRestarter: restarting kernel')
             self.kernel_manager.restart_kernel(now=True);
             self.start()
-
-    def stop(self):
-        self.pc.stop()
-        self.pc = None
-
-
 

--- a/IPython/kernel/multikernelmanager.py
+++ b/IPython/kernel/multikernelmanager.py
@@ -154,6 +154,19 @@ class MultiKernelManager(LoggingConfigurable):
         """
         return self.get_kernel(kernel_id).restart_kernel()
 
+    def is_alive(self, kernel_id):
+        """Is the kernel alive.
+
+        This calls KernelManager.is_alive() which calls Popen.poll on the
+        actual kernel subprocess.
+
+        Parameters
+        ==========
+        kernel_id : uuid
+            The id of the kernel.
+        """
+        return self.get_kernel(kernel_id).is_alive()
+
     def get_kernel(self, kernel_id):
         """Get the single KernelManager object for a kernel by its uuid.
 

--- a/IPython/kernel/multikernelmanager.py
+++ b/IPython/kernel/multikernelmanager.py
@@ -23,12 +23,15 @@ import uuid
 
 import zmq
 from zmq.eventloop.zmqstream import ZMQStream
+from zmq.eventloop import ioloop
 
 from IPython.config.configurable import LoggingConfigurable
 from IPython.utils.importstring import import_item
 from IPython.utils.traitlets import (
-    Instance, Dict, Unicode, Any, DottedObjectName,
+    Instance, Dict, Unicode, Any, DottedObjectName, Bool
 )
+# from IPython.kernel.kernelrestarter import KernelRestarter
+
 #-----------------------------------------------------------------------------
 # Classes
 #-----------------------------------------------------------------------------
@@ -61,7 +64,7 @@ class MultiKernelManager(LoggingConfigurable):
     def _loop_default(self):
         return ioloop.IOLoop.instance()
 
-    autorestart = Bool(True, config=True,
+    autorestart = Bool(False, config=True,
         help="""Should we autorestart kernels that die."""
     )
 
@@ -83,18 +86,29 @@ class MultiKernelManager(LoggingConfigurable):
     def __contains__(self, kernel_id):
         return kernel_id in self._kernels
 
-    def start_watching(self, kernel_id):
-        km = self.get_kernel(kernel_id):
+    def start_restarter(self, kernel_id):
+        km = self.get_kernel(kernel_id)
         if self.autorestart:
-            kr = KernelRestarter(
-                kernel_manager=km, loop=self.loop,
-                config=self.config, log=self.log
-            )
+            kr = self._restarters.get(kernel_id, None)
+            if kr is None:
+                kr = KernelRestarter(
+                    kernel_manager=km, loop=self.loop,
+                    config=self.config, log=self.log
+                )
+                self._restarters[kernel_id] = kr
             kr.start()
-            self._restarters[kernel_id] = kr
 
-    def stop_watching(self, kernel_id):
-        
+    def stop_restarter(self, kernel_id):
+        if self.autorestart:
+            kr = self._restarters.get(kernel_id, None)
+            if kr is not None:
+                kr.stop()
+
+    def clear_restarter(self, kernel_id):
+        if self.autorestart:
+            kr = self._restarters.pop(kernel_id, None)
+            if kr is not None:
+                kr.stop()
 
     def start_kernel(self, **kwargs):
         """Start a new kernel.
@@ -121,7 +135,7 @@ class MultiKernelManager(LoggingConfigurable):
         # start just the shell channel, needed for graceful restart
         km.start_channels(shell=True, iopub=False, stdin=False, hb=False)
         self._kernels[kernel_id] = km
-        self.start_watching(kernel_id)
+        self.start_restarter(kernel_id)
         return kernel_id
 
     def shutdown_kernel(self, kernel_id, now=False):
@@ -135,11 +149,11 @@ class MultiKernelManager(LoggingConfigurable):
             Should the kernel be shutdown forcibly using a signal.
         """
         k = self.get_kernel(kernel_id)
-        self.stop_watching(kernel_id)
+        self.stop_restarter(kernel_id)
         k.shutdown_kernel(now=now)
         k.shell_channel.stop()
         del self._kernels[kernel_id]
-        self.remove_watching(kernel_id)
+        self.clear_restarter(kernel_id)
 
     def shutdown_all(self, now=False):
         """Shutdown all kernels."""
@@ -178,9 +192,9 @@ class MultiKernelManager(LoggingConfigurable):
             The id of the kernel to interrupt.
         """
         km = self.get_kernel(kernel_id)
-        self.stop_watching()
+        self.stop_restarter(kernel_id)
         km.restart_kernel()
-        self.start_watching()
+        self.start_restarter(kernel_id)
 
     def is_alive(self, kernel_id):
         """Is the kernel alive.

--- a/IPython/kernel/multikernelmanager.py
+++ b/IPython/kernel/multikernelmanager.py
@@ -56,10 +56,19 @@ class MultiKernelManager(LoggingConfigurable):
     context = Instance('zmq.Context')
     def _context_default(self):
         return zmq.Context.instance()
-    
+
+    loop = Instance('zmq.eventloop.ioloop.IOLoop', allow_none=False)
+    def _loop_default(self):
+        return ioloop.IOLoop.instance()
+
+    autorestart = Bool(True, config=True,
+        help="""Should we autorestart kernels that die."""
+    )
+
     connection_dir = Unicode('')
 
     _kernels = Dict()
+    _restarters = Dict()
 
     def list_kernel_ids(self):
         """Return a list of the kernel ids of the active kernels."""
@@ -73,6 +82,19 @@ class MultiKernelManager(LoggingConfigurable):
 
     def __contains__(self, kernel_id):
         return kernel_id in self._kernels
+
+    def start_watching(self, kernel_id):
+        km = self.get_kernel(kernel_id):
+        if self.autorestart:
+            kr = KernelRestarter(
+                kernel_manager=km, loop=self.loop,
+                config=self.config, log=self.log
+            )
+            kr.start()
+            self._restarters[kernel_id] = kr
+
+    def stop_watching(self, kernel_id):
+        
 
     def start_kernel(self, **kwargs):
         """Start a new kernel.
@@ -99,6 +121,7 @@ class MultiKernelManager(LoggingConfigurable):
         # start just the shell channel, needed for graceful restart
         km.start_channels(shell=True, iopub=False, stdin=False, hb=False)
         self._kernels[kernel_id] = km
+        self.start_watching(kernel_id)
         return kernel_id
 
     def shutdown_kernel(self, kernel_id, now=False):
@@ -112,9 +135,11 @@ class MultiKernelManager(LoggingConfigurable):
             Should the kernel be shutdown forcibly using a signal.
         """
         k = self.get_kernel(kernel_id)
+        self.stop_watching(kernel_id)
         k.shutdown_kernel(now=now)
         k.shell_channel.stop()
         del self._kernels[kernel_id]
+        self.remove_watching(kernel_id)
 
     def shutdown_all(self, now=False):
         """Shutdown all kernels."""
@@ -152,7 +177,10 @@ class MultiKernelManager(LoggingConfigurable):
         kernel_id : uuid
             The id of the kernel to interrupt.
         """
-        return self.get_kernel(kernel_id).restart_kernel()
+        km = self.get_kernel(kernel_id)
+        self.stop_watching()
+        km.restart_kernel()
+        self.start_watching()
 
     def is_alive(self, kernel_id):
         """Is the kernel alive.

--- a/IPython/kernel/tests/test_kernelmanager.py
+++ b/IPython/kernel/tests/test_kernelmanager.py
@@ -12,12 +12,16 @@ from IPython.kernel.kernelmanager import KernelManager
 class TestKernelManager(TestCase):
 
     def _get_tcp_km(self):
-        return KernelManager()
+        c = Config()
+        # c.KernelManager.autorestart=False
+        km = KernelManager(config=c)
+        return km
 
     def _get_ipc_km(self):
         c = Config()
         c.KernelManager.transport = 'ipc'
         c.KernelManager.ip = 'test'
+        # c.KernelManager.autorestart=False
         km = KernelManager(config=c)
         return km
 

--- a/IPython/kernel/tests/test_kernelmanager.py
+++ b/IPython/kernel/tests/test_kernelmanager.py
@@ -23,8 +23,10 @@ class TestKernelManager(TestCase):
 
     def _run_lifecycle(self, km):
         km.start_kernel(stdout=PIPE, stderr=PIPE)
+        self.assertTrue(km.is_alive())
         km.start_channels(shell=True, iopub=False, stdin=False, hb=False)
         km.restart_kernel()
+        self.assertTrue(km.is_alive())
         # We need a delay here to give the restarting kernel a chance to
         # restart. Otherwise, the interrupt will kill it, causing the test
         # suite to hang. The reason it *hangs* is that the shutdown

--- a/IPython/kernel/tests/test_multikernelmanager.py
+++ b/IPython/kernel/tests/test_multikernelmanager.py
@@ -25,10 +25,12 @@ class TestKernelManager(TestCase):
 
     def _run_lifecycle(self, km):
         kid = km.start_kernel(stdout=PIPE, stderr=PIPE)
+        self.assertTrue(km.is_alive(kid))
         self.assertTrue(kid in km)
         self.assertTrue(kid in km.list_kernel_ids())
         self.assertEqual(len(km),1)
         km.restart_kernel(kid)
+        self.assertTrue(km.is_alive(kid))
         self.assertTrue(kid in km.list_kernel_ids())
         # We need a delay here to give the restarting kernel a chance to
         # restart. Otherwise, the interrupt will kill it, causing the test

--- a/IPython/kernel/tests/test_multikernelmanager.py
+++ b/IPython/kernel/tests/test_multikernelmanager.py
@@ -14,12 +14,16 @@ from IPython.kernel.multikernelmanager import MultiKernelManager
 class TestKernelManager(TestCase):
 
     def _get_tcp_km(self):
-        return MultiKernelManager()
+        c = Config()
+        # c.KernelManager.autorestart=False
+        km = MultiKernelManager(config=c)
+        return km
 
     def _get_ipc_km(self):
         c = Config()
         c.KernelManager.transport = 'ipc'
         c.KernelManager.ip = 'test'
+        # c.KernelManager.autorestart=False
         km = MultiKernelManager(config=c)
         return km
 


### PR DESCRIPTION
Currently, when kernels die in the notebook, the user is prompted and asked if they want to restart the kernel.  This is problematic from a number of standpoints:
- If there is client, the kernel/notebook mapping gets messed up.
- A dead kernel should always be restarted.

In this PR, I have added a new KernelRestarter object that works alongside a KernelManager object to poll the kernel's subprocess and call KernelManager.restart_kernel if it dies.  I am also changing how the user is notified of this event.

Remaining:
- [ ] Finish logic in MultiKernelManager.
- [ ] Update MultiKernelManager tests.
- [ ] Add new kernel message when the kernel starts/restarts.
- [ ] Add new kernel death logic to the notebook UI.
- [ ] Test different combinations of frontends.
- [ ] Decide what to do about old heartbeat code.
