### PR TITLE
Empty cell warnings

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2125,7 +2125,7 @@ class InteractiveShell(SingletonConfigurable):
                                     'did you mean that instead?)' % magic_name )
             error(etpl % (magic_name, extra))
         elif cell == '':
-            warn('%%%%%s line but no cell' % magic_name)
+            raise UsageError('%%%%%s has line but no cell' % magic_name)
         else:
             # Note: this is the distance in the stack to the user's frame.
             # This will need to be updated if the internal calling logic gets

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2124,6 +2124,8 @@ class InteractiveShell(SingletonConfigurable):
             extra = '' if lm is None else (' (But line magic `%%%s` exists, '
                                     'did you mean that instead?)' % magic_name )
             error(etpl % (magic_name, extra))
+        elif cell == '':
+            warn('%%%%%s line but no cell' % magic_name)
         else:
             # Note: this is the distance in the stack to the user's frame.
             # This will need to be updated if the internal calling logic gets

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2120,13 +2120,13 @@ class InteractiveShell(SingletonConfigurable):
         fn = self.find_cell_magic(magic_name)
         if fn is None:
             lm = self.find_line_magic(magic_name)
-            etpl = "Cell magic function `%%%%%s` not found%s."
-            extra = '' if lm is None else (' (But line magic `%%%s` exists, '
-                                    'did you mean that instead?)' % magic_name )
-            error(etpl % (magic_name, extra))
+            etpl = "Cell magic function `%%{0}` not found{1}."
+            extra = '' if lm is None else (' (But line magic `%{0}` exists, '
+                            'did you mean that instead?)'.format(magic_name))
+            error(etpl.format(magic_name, extra))
         elif cell == '':
             raise UsageError('%%{0} (with double %) expects code beneath it. '
-                        'Did you mean %{0} (single %)?'.format(magic_name))
+                            'Did you mean %{0} (single %)?'.format(magic_name))
         else:
             # Note: this is the distance in the stack to the user's frame.
             # This will need to be updated if the internal calling logic gets

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2125,7 +2125,8 @@ class InteractiveShell(SingletonConfigurable):
                                     'did you mean that instead?)' % magic_name )
             error(etpl % (magic_name, extra))
         elif cell == '':
-            raise UsageError('%%%%%s has line but no cell' % magic_name)
+            raise UsageError('%%{0} (with double %) expects code beneath it. '
+                        'Did you mean %{0} (single %)?'.format(magic_name))
         else:
             # Note: this is the distance in the stack to the user's frame.
             # This will need to be updated if the internal calling logic gets

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -776,6 +776,10 @@ python-profiler package from non-free.""")
                                         posix=False, strict=False)
         if stmt == "" and cell is None:
             return
+        elif cell == '':
+            warn("Empty cell. Did you mean to use %timeit?")
+            return
+        
         timefunc = timeit.default_timer
         number = int(getattr(opts, "n", 0))
         repeat = int(getattr(opts, "r", timeit.default_repeat))

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -776,9 +776,6 @@ python-profiler package from non-free.""")
                                         posix=False, strict=False)
         if stmt == "" and cell is None:
             return
-        elif cell == '':
-            warn("Empty cell. Did you mean to use %timeit?")
-            return
         
         timefunc = timeit.default_timer
         number = int(getattr(opts, "n", 0))

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -36,6 +36,7 @@ from IPython.utils.openpy import source_to_unicode
 from IPython.utils.path import get_py_filename, unquote_filename
 from IPython.utils.process import abbrev_cwd
 from IPython.utils.terminal import set_term_title
+from IPython.utils.warn import warn
 #-----------------------------------------------------------------------------
 # Magic implementation classes
 #-----------------------------------------------------------------------------
@@ -594,6 +595,9 @@ class OSMagics(Magics):
         if cell is None:
             # line magic
             return self.shell.getoutput(line)
+        elif cell == '':
+            warn("Empty cell. Did you mean to use %!, %sx, or %system?")
+            return
         else:
             opts,args = self.parse_options(line, '', 'out=')
             output = self.shell.getoutput(cell)

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -36,7 +36,7 @@ from IPython.utils.openpy import source_to_unicode
 from IPython.utils.path import get_py_filename, unquote_filename
 from IPython.utils.process import abbrev_cwd
 from IPython.utils.terminal import set_term_title
-from IPython.utils.warn import warn
+
 #-----------------------------------------------------------------------------
 # Magic implementation classes
 #-----------------------------------------------------------------------------
@@ -595,9 +595,6 @@ class OSMagics(Magics):
         if cell is None:
             # line magic
             return self.shell.getoutput(line)
-        elif cell == '':
-            warn("Empty cell. Did you mean to use %!, %sx, or %system?")
-            return
         else:
             opts,args = self.parse_options(line, '', 'out=')
             output = self.shell.getoutput(cell)


### PR DESCRIPTION
Warns user when %%timeit and %%sx/%%system/%%! are run without cell arguments.

Should close issue #2862.
