### PR TITLE
Correct import for kernelmanager on Windows

### DIFF
--- a/IPython/kernel/kernelmanager.py
+++ b/IPython/kernel/kernelmanager.py
@@ -1082,7 +1082,7 @@ class KernelManager(Configurable):
         """
         if self.has_kernel:
             if sys.platform == 'win32':
-                from parentpoller import ParentPollerWindows as Poller
+                from .zmq.parentpoller import ParentPollerWindows as Poller
                 Poller.send_interrupt(self.kernel.win32_interrupt_event)
             else:
                 self.kernel.send_signal(signal.SIGINT)


### PR DESCRIPTION
This was causing test failures on Windows, e.g. [this run](https://jenkins.shiningpanda-ci.com/ipython/job/ipython-win-py27/38/console).

If it's easy for someone to test on Windows, go ahead. Otherwise I'll merge in a day or so and let ShiningPanda test it.
