### PR TITLE
get monospace pager back

### DIFF
--- a/IPython/frontend/html/notebook/static/js/pager.js
+++ b/IPython/frontend/html/notebook/static/js/pager.js
@@ -152,9 +152,7 @@ var IPython = (function (IPython) {
     }
 
     Pager.prototype.append_text = function (text) {
-        var toinsert = $("<div/>").addClass("output_area output_stream");
-        toinsert.append($('<pre/>').html(utils.fixCarriageReturn(utils.fixConsole(text))));
-        this.pager_element.append(toinsert);
+        this.pager_element.append($('<pre/>').html(utils.fixCarriageReturn(utils.fixConsole(text))));
     };
 
 


### PR DESCRIPTION
For whatever reason, pager is not monospaced anymore. 
removing those class seem to fix it. 

Do anybody have any idea why they where here in the first place ? 

Except docstring and `%pycat`, I dont see what could use output_area and output stream in the pager.
