### PR TITLE
Push pandas dataframes to R magic

### DIFF
--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -114,19 +114,34 @@ def Rconverter(Robj, dataframe=False):
         Robj = np.rec.fromarrays(Robj, names = names)
     return np.asarray(Robj)
 
+def pyconverter(pyobj):
+    """Convert Python objects to R objects."""
+    if 'pandas' in sys.modules:
+        # We only do this if pandas is already loaded
+        from pandas import DataFrame
+        if isinstance(pyobj, DataFrame):
+            from pandas.rpy.common import convert_to_r_dataframe
+            return convert_to_r_dataframe(pyobj)
+    
+    return np.asarray(pyobj)
+
 @magics_class
 class RMagics(Magics):
     """A set of magics useful for interactive work with R via rpy2.
     """
 
     def __init__(self, shell, Rconverter=Rconverter,
-                 pyconverter=np.asarray,
+                 pyconverter=pyconverter,
                  cache_display_data=False):
         """
         Parameters
         ----------
 
         shell : IPython shell
+        
+        Rconverter : callable
+            To be called on values taken from R before putting them in the
+            IPython namespace.
 
         pyconverter : callable
             To be called on values in ipython namespace before 

--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -121,7 +121,7 @@ def pyconverter(pyobj):
         from pandas import DataFrame
         if isinstance(pyobj, DataFrame):
             from pandas.rpy.common import convert_to_r_dataframe
-            return convert_to_r_dataframe(pyobj)
+            return convert_to_r_dataframe(pyobj, strings_as_factors=True)
     
     return np.asarray(pyobj)
 

--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -46,8 +46,13 @@ import numpy as np
 
 import rpy2.rinterface as ri
 import rpy2.robjects as ro
-from rpy2.robjects.numpy2ri import numpy2ri
-ro.conversion.py2ri = numpy2ri
+try:
+    from rpy2.robjects import pandas2ri
+    pandas2ri.activate()
+except ImportError:
+    pandas2ri = None
+    from rpy2.robjects import numpy2ri
+    numpy2ri.activate()
 
 # IPython imports
 
@@ -58,6 +63,7 @@ from IPython.testing.skipdoctest import skip_doctest
 from IPython.core.magic_arguments import (
     argument, magic_arguments, parse_argstring
 )
+from IPython.external.simplegeneric import generic
 from IPython.utils.py3compat import str_to_unicode, unicode_to_str, PY3
 
 class RInterpreterError(ri.RRuntimeError):
@@ -114,16 +120,32 @@ def Rconverter(Robj, dataframe=False):
         Robj = np.rec.fromarrays(Robj, names = names)
     return np.asarray(Robj)
 
+@generic
 def pyconverter(pyobj):
-    """Convert Python objects to R objects."""
-    if 'pandas' in sys.modules:
-        # We only do this if pandas is already loaded
-        from pandas import DataFrame
-        if isinstance(pyobj, DataFrame):
-            from pandas.rpy.common import convert_to_r_dataframe
-            return convert_to_r_dataframe(pyobj, strings_as_factors=True)
+    """Convert Python objects to R objects. Add types using the decorator:
     
+    @pyconverter.when_type
+    """
+    return pyobj
+
+# The default conversion for lists seems to make them a nested list. That has
+# some advantages, but is rarely convenient, so for interactive use, we convert
+# lists to a numpy array, which becomes an R vector.
+@pyconverter.when_type(list)
+def pyconverter_list(pyobj):
     return np.asarray(pyobj)
+
+if pandas2ri is None:
+    # pandas2ri was new in rpy2 2.3.3, so for now we'll fallback to pandas'
+    # conversion function.
+    try:
+        from pandas import DataFrame
+        from pandas.rpy.common import convert_to_r_dataframe
+        @pyconverter.when_type(DataFrame)
+        def pyconverter_dataframe(pyobj):
+            return convert_to_r_dataframe(pyobj, strings_as_factors=True)
+    except ImportError:
+        pass
 
 @magics_class
 class RMagics(Magics):

--- a/IPython/extensions/tests/test_rmagic.py
+++ b/IPython/extensions/tests/test_rmagic.py
@@ -65,7 +65,7 @@ def test_Rconverter():
     np.testing.assert_equal(id(w.data), id(v.data))
     nt.assert_equal(w.dtype, v.dtype)
 
-    ip.run_cell_magic('R', ' -d datar  datar=datapy', '')
+    ip.run_cell_magic('R', ' -d datar', 'datar=datapy')
 
     u = ip.run_line_magic('Rget', ' -d datar')
     np.testing.assert_almost_equal(u['x'], v['x'])

--- a/IPython/extensions/tests/test_rmagic.py
+++ b/IPython/extensions/tests/test_rmagic.py
@@ -1,5 +1,6 @@
 import numpy as np
 from IPython.core.interactiveshell import InteractiveShell
+from IPython.testing.decorators import skip_without
 from IPython.extensions import rmagic
 import nose.tools as nt
 
@@ -27,6 +28,20 @@ result = rmagic_addone(12344)
     ''')
     result = ip.user_ns['result']
     np.testing.assert_equal(result, 12345)
+
+@skip_without('pandas')
+def test_push_dataframe():
+    from pandas import DataFrame
+    rm = rmagic.RMagics(ip)
+    df = DataFrame([{'a': 1, 'b': 'bar'}, {'a': 5, 'b': 'foo', 'c': 20}])
+    ip.push({'df':df})
+    ip.run_line_magic('Rpush', 'df')
+    # Values come packaged in arrays, so we unbox them to test.
+    nt.assert_equal(rm.r('df$b[1]')[0], 'bar')
+    nt.assert_equal(rm.r('df$a[2]')[0], 5)
+    
+    missing = rm.r('df$c[1]')[0]
+    assert np.isnan(missing), missing
 
 def test_pull():
     rm = rmagic.RMagics(ip)


### PR DESCRIPTION
At present, if you make a pandas DataFrame and try to use it with rmagic, the converter spits out some ugly nested lists without column names. The obvious expectation is that it will produce an R data.frame, which the design of DataFrame was based on.

The only concern with this is that the [pandas docs](http://pandas.pydata.org/pandas-docs/stable/r_interface.html#converting-dataframes-into-r-objects) describe the conversion as 'experimental', and from a comment in the source, it won't handle multi-level indices. We could catch errors and fall back to the current behaviour, but the result seems fairly useless, and I think it's more confusing to silently change behaviour when there's a problem.
