### PR TITLE
Better reverse search KeyboardInterrupt handling

### DIFF
--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -565,13 +565,26 @@ class TerminalInteractiveShell(InteractiveShell):
                     self.rl_do_indent = False
 
             except KeyboardInterrupt:
-                #double-guard against keyboardinterrupts during kbdint handling
+                # double-guard against keyboardinterrupts during kbdint handling
                 try:
-                    self.write('\nKeyboardInterrupt\n')
+                    # these keybindings vary based on ~/.inputrc for GNU
+                    # readline
+                    self.write('\nKeyboardInterrupt\nUse C-g to exit reverse '
+                               'search mode. Use C-u/C-k for line deletes.')
                     source_raw = self.input_splitter.source_raw_reset()[1]
                     hlen_b4_cell = \
                         self._replace_rlhist_multiline(source_raw, hlen_b4_cell)
                     more = False
+                    # If a user reverse searches with C-r, then readline will
+                    # keep the last line in the input buffer, even if the input
+                    # is interrupted with C-c. Instead, the user should use
+                    # C-g to exit reverse search mode. There is no good reason
+                    # for a user to raise a KeyboardInterrupt under normal
+                    # circumstances, and instead the readline keybindings (like
+                    # C-g, C-u, C-k) should be used. See issue #1286 or #2486.
+                    # Note: ommitting this fix is dangerous because a user
+                    # could otherwise cause a dangerous line to be re-executed.
+                    self.set_next_input(self.readline.get_line_buffer())
                 except KeyboardInterrupt:
                     pass
             except EOFError:


### PR DESCRIPTION
The previous KeyboardInterrupt handling is dangerous because previous
lines or commands can be mistakenly executed.

When a user interrupts a readline reverse search (C-r) with C-c, a
KeyboardInterrupt is thrown, but the readline buffer still has a line in
the buffer from the search attempt. The previous behavior of IPython was
to show a blank line instead of the current readline buffer, causing a
previous command to be executed if the user presses enter on the
seemingly blank line.

Additionally, keyboard input was not shown on the blank line because
readline was still in reverse search mode. For example, pressing C-k on
the blank line would reset readline, but most users would expect the
input buffer that IPython displays to be correct because of the
prominently displayed KeyboardInterrupt.

This modifies how a KeyboardInterrupt is handled in IPython. Under
normal circumstances in the operation of readline, a KeyboardInterrupt
should never be thrown. IPython now displays a helpful reminder to use
default readline keybindings (which might be overridden by ~/.inputrc,
but whatever), and then displays the current line buffer on the next
line.

Another possible solution would be to send C-g (abort reverse search) or
C-k to readline through raw_input somehow. However, this solution would
require checking ~/.inputrc to figure out what the current "abort
reverse search" keybinding is.

fixes #1286
fixes #2486
