### PR TITLE
Fix inputhook_wx on osx

### DIFF
--- a/IPython/lib/inputhookwx.py
+++ b/IPython/lib/inputhookwx.py
@@ -17,6 +17,7 @@ Authors:  Robin Dunn, Brian Granger, Ondrej Certik
 # Imports
 #-----------------------------------------------------------------------------
 
+import sys
 import signal
 import time
 from timeit import default_timer as clock
@@ -159,5 +160,11 @@ def inputhook_wx3():
         pass
     return 0
 
-# This is our default implementation
-inputhook_wx = inputhook_wx3
+if sys.platform == 'darwin':
+    # On OSX, evtloop.Pending() always returns True, regardless of there being
+    # any events pending. As such we can't use implementations 1 or 3 of the
+    # inputhook as those depend on a pending/dispatch loop.
+    inputhook_wx = inputhook_wx2
+else:
+    # This is our default implementation
+    inputhook_wx = inputhook_wx3


### PR DESCRIPTION
Use the inputhook_wx2 implementation on osx, fixing #2762.

Please review. Perhaps it would be better to test with `'cocoa' in wx.version()`, write a new implementation without the Pending/Dispatch loop, or just use inputhook_wx2 on all platforms.
