### PR TITLE
Skip remaining IPC test on Windows

### DIFF
--- a/IPython/kernel/kernelmanager.py
+++ b/IPython/kernel/kernelmanager.py
@@ -849,7 +849,7 @@ class KernelManager(Configurable):
             self._connection_file_written = False
             try:
                 os.remove(self.connection_file)
-            except (IOError, OSError):
+            except (IOError, OSError, AttributeError):
                 pass
     
     def cleanup_ipc_files(self):

--- a/IPython/kernel/tests/test_multikernelmanager.py
+++ b/IPython/kernel/tests/test_multikernelmanager.py
@@ -65,15 +65,16 @@ class TestKernelManager(TestCase):
         km = self._get_tcp_km()
         self._run_lifecycle(km)
     
-    @dec.skip_win32
     def test_tcp_cinfo(self):
         km = self._get_tcp_km()
         self._run_cinfo(km, 'tcp', LOCALHOST)
 
+    @dec.skip_win32
     def test_ipc_lifecycle(self):
         km = self._get_ipc_km()
         self._run_lifecycle(km)
     
+    @dec.skip_win32
     def test_ipc_cinfo(self):
         km = self._get_ipc_km()
         self._run_cinfo(km, 'ipc', 'test')


### PR DESCRIPTION
also fix an issue that could appear as an AttributeError when `KM.__del__` is called during gc on process exit.

closes #2898
