### PR TITLE
WIP: Manual rebase of @dlsun's tabs implementation

### DIFF
--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -216,12 +216,12 @@ var IPython = (function (IPython) {
     CodeCell.prototype._handle_execute_reply = function (content) {
         this.set_input_prompt(content.execution_count);
         this.element.removeClass("running");
-        $([IPython.events]).trigger('set_dirty.Notebook', {'value': true});
+        $([IPython.events]).trigger('set_dirty.Worksheet', {'value': true});
     }
 
     CodeCell.prototype._handle_set_next_input = function (text) {
         var data = {'cell': this, 'text': text}
-        $([IPython.events]).trigger('set_next_input.Notebook', data);
+        $([IPython.events]).trigger('set_next_input.Worksheet', data);
     }
 
     // Basic cell manipulation.

--- a/IPython/frontend/html/notebook/static/js/layoutmanager.js
+++ b/IPython/frontend/html/notebook/static/js/layoutmanager.js
@@ -50,8 +50,10 @@ var IPython = (function (IPython) {
         $('div#pager').height(pager_height);
         if (IPython.pager.expanded) {
             $('div#notebook').height(app_height-pager_height-pager_splitter_height);
+            $('div.panel').height(app_height-pager_height-pager_splitter_height);
         } else {
             $('div#notebook').height(app_height-pager_splitter_height);
+            $('div.panel').height(app_height-pager_splitter_height);
         }
     };
 

--- a/IPython/frontend/html/notebook/static/js/menubar.js
+++ b/IPython/frontend/html/notebook/static/js/menubar.js
@@ -27,8 +27,9 @@ var IPython = (function (IPython) {
             select : function (event, ui) {
                 // The selected cell loses focus when the menu is entered, so we
                 // re-select it upon selection.
-                var i = IPython.notebook.get_selected_index();
-                IPython.notebook.select(i);
+                var ws = IPython.notebook.get_selected_worksheet();
+                var i = ws.get_selected_index();
+                ws.select(i);
             }
         });
     };
@@ -75,34 +76,37 @@ var IPython = (function (IPython) {
         });
         // Edit
         this.element.find('#cut_cell').click(function () {
-            IPython.notebook.cut_cell();
+            IPython.notebook.get_selected_worksheet().cut_cell();
         });
         this.element.find('#copy_cell').click(function () {
-            IPython.notebook.copy_cell();
+            IPython.notebook.get_selected_worksheet().copy_cell();
         });
         this.element.find('#delete_cell').click(function () {
-            IPython.notebook.delete_cell();
+            IPython.notebook.get_selected_worksheet().delete_cell();
         });
         this.element.find('#split_cell').click(function () {
-            IPython.notebook.split_cell();
+            IPython.notebook.get_selected_worksheet().split_cell();
         });
         this.element.find('#merge_cell_above').click(function () {
-            IPython.notebook.merge_cell_above();
+            IPython.notebook.get_selected_worksheet().merge_cell_above();
         });
         this.element.find('#merge_cell_below').click(function () {
-            IPython.notebook.merge_cell_below();
+            IPython.notebook.get_selected_worksheet().merge_cell_below();
         });
         this.element.find('#move_cell_up').click(function () {
-            IPython.notebook.move_cell_up();
+            IPython.notebook.get_selected_worksheet().move_cell_up();
         });
         this.element.find('#move_cell_down').click(function () {
-            IPython.notebook.move_cell_down();
+            IPython.notebook.get_selected_worksheet().move_cell_down();
         });
         this.element.find('#select_previous').click(function () {
-            IPython.notebook.select_prev();
+            IPython.notebook.get_selected_worksheet().select_prev();
         });
         this.element.find('#select_next').click(function () {
-            IPython.notebook.select_next();
+            IPython.notebook.get_selected_worksheet().select_next();
+        });
+        this.element.find('#delete_worksheet').click(function () {
+            IPython.notebook.delete_worksheet();
         });
         // View
         this.element.find('#toggle_header').click(function () {
@@ -113,69 +117,75 @@ var IPython = (function (IPython) {
             IPython.toolbar.toggle();
         });
         // Insert
+        this.element.find('#insert_worksheet_above').click(function() {
+            IPython.notebook.insert_worksheet_above('New Sheet');
+        });
+        this.element.find('#insert_worksheet_below').click(function() {
+            IPython.notebook.insert_worksheet_below('New Sheet');
+        });
         this.element.find('#insert_cell_above').click(function () {
-            IPython.notebook.insert_cell_above('code');
+            IPython.notebook.get_selected_worksheet().insert_cell_above('code');
         });
         this.element.find('#insert_cell_below').click(function () {
-            IPython.notebook.insert_cell_below('code');
+            IPython.notebook.get_selected_worksheet().insert_cell_below('code');
         });
         // Cell
         this.element.find('#run_cell').click(function () {
-            IPython.notebook.execute_selected_cell();
+            IPython.notebook.get_selected_worksheet().execute_selected_cell();
         });
         this.element.find('#run_cell_in_place').click(function () {
-            IPython.notebook.execute_selected_cell({terminal:true});
+            IPython.notebook.get_selected_worksheet().execute_selected_cell({terminal:true});
         });
         this.element.find('#run_all_cells').click(function () {
-            IPython.notebook.execute_all_cells();
-        }).attr('title', 'Run all cells in the notebook');
+            IPython.notebook.get_selected_worksheet().execute_all_cells();
+        }).attr('title', 'Run all cells in the worksheet');
         this.element.find('#run_all_cells_above').click(function () {
-            IPython.notebook.execute_cells_above();
+            IPython.notebook.get_selected_worksheet().execute_cells_above();
         }).attr('title', 'Run all cells above (but not including) this cell');
         this.element.find('#run_all_cells_below').click(function () {
-            IPython.notebook.execute_cells_below();
+            IPython.notebook.get_selected_worksheet().execute_cells_below();
         }).attr('title', 'Run this cell and all cells below it');
         this.element.find('#to_code').click(function () {
-            IPython.notebook.to_code();
+            IPython.notebook.get_selected_worksheet().to_code();
         });
         this.element.find('#to_markdown').click(function () {
-            IPython.notebook.to_markdown();
+            IPython.notebook.get_selected_worksheet().to_markdown();
         });
         this.element.find('#to_raw').click(function () {
-            IPython.notebook.to_raw();
+            IPython.notebook.get_selected_worksheet().to_raw();
         });
         this.element.find('#to_heading1').click(function () {
-            IPython.notebook.to_heading(undefined, 1);
+            IPython.notebook.get_selected_worksheet().to_heading(undefined, 1);
         });
         this.element.find('#to_heading2').click(function () {
-            IPython.notebook.to_heading(undefined, 2);
+            IPython.notebook.get_selected_worksheet().to_heading(undefined, 2);
         });
         this.element.find('#to_heading3').click(function () {
-            IPython.notebook.to_heading(undefined, 3);
+            IPython.notebook.get_selected_worksheet().to_heading(undefined, 3);
         });
         this.element.find('#to_heading4').click(function () {
-            IPython.notebook.to_heading(undefined, 4);
+            IPython.notebook.get_selected_worksheet().to_heading(undefined, 4);
         });
         this.element.find('#to_heading5').click(function () {
-            IPython.notebook.to_heading(undefined, 5);
+            IPython.notebook.get_selected_worksheet().to_heading(undefined, 5);
         });
         this.element.find('#to_heading6').click(function () {
-            IPython.notebook.to_heading(undefined, 6);
+            IPython.notebook.get_selected_worksheet().to_heading(undefined, 6);
         });
         this.element.find('#toggle_output').click(function () {
-            IPython.notebook.toggle_output();
+            IPython.notebook.get_selected_worksheet().toggle_output();
         });
         this.element.find('#collapse_all_output').click(function () {
-            IPython.notebook.collapse_all_output();
+            IPython.notebook.get_selected_worksheet().collapse_all_output();
         });
         this.element.find('#scroll_all_output').click(function () {
-            IPython.notebook.scroll_all_output();
+            IPython.notebook.get_selected_worksheet().scroll_all_output();
         });
         this.element.find('#expand_all_output').click(function () {
-            IPython.notebook.expand_all_output();
+            IPython.notebook.get_selected_worksheet().expand_all_output();
         });
         this.element.find('#clear_all_output').click(function () {
-            IPython.notebook.clear_all_output();
+            IPython.notebook.get_selected_worksheet().clear_all_output();
         });
         // Kernel
         this.element.find('#int_kernel').click(function () {

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -28,8 +28,6 @@ var IPython = (function (IPython) {
         this.paste_enabled = false;
         this.dirty = false;
         this.metadata = {};
-        // single worksheet for now
-        this.worksheet_metadata = {};
         this.control_key_active = false;
         this.notebook_id = null;
         this.notebook_name = null;
@@ -39,6 +37,7 @@ var IPython = (function (IPython) {
         this.style();
         this.create_elements();
         this.bind_events();
+        this.tabs = IPython.tab_manager.tabs;
     };
 
 
@@ -48,18 +47,6 @@ var IPython = (function (IPython) {
 
 
     Notebook.prototype.create_elements = function () {
-        // We add this end_space div to the end of the notebook div to:
-        // i) provide a margin between the last cell and the end of the notebook
-        // ii) to prevent the div from scrolling up when the last cell is being
-        // edited, but is too low on the page, which browsers will do automatically.
-        var that = this;
-        var end_space = $('<div/>').addClass('end_space').height("30%");
-        end_space.dblclick(function (e) {
-            if (that.read_only) return;
-            var ncells = that.ncells();
-            that.insert_cell_below('code',ncells-1);
-        });
-        this.element.append(end_space);
         $('div#notebook').addClass('border-box-sizing');
     };
 
@@ -67,24 +54,9 @@ var IPython = (function (IPython) {
     Notebook.prototype.bind_events = function () {
         var that = this;
 
-        $([IPython.events]).on('set_next_input.Notebook', function (event, data) {
-            var index = that.find_cell_index(data.cell);
-            var new_cell = that.insert_cell_below('code',index);
-            new_cell.set_text(data.text);
-            that.dirty = true;
-        });
-
-        $([IPython.events]).on('set_dirty.Notebook', function (event, data) {
-            that.dirty = data.value;
-        });
-
-        $([IPython.events]).on('select.Cell', function (event, data) {
-            var index = that.find_cell_index(data.cell);
-            that.select(index);
-        });
-
-
         $(document).keydown(function (event) {
+            var current_sheet = that.get_selected_worksheet();
+
             // console.log(event);
             if (that.read_only) return true;
 
@@ -103,115 +75,115 @@ var IPython = (function (IPython) {
                 return true;
             }
             if (event.which === key.UPARROW && !event.shiftKey) {
-                var cell = that.get_selected_cell();
+                var cell = current_sheet.get_selected_cell();
                 if (cell.at_top()) {
                     event.preventDefault();
-                    that.select_prev();
+                    current_sheet.select_prev();
                 };
             } else if (event.which === key.DOWNARROW && !event.shiftKey) {
-                var cell = that.get_selected_cell();
+                var cell = current_sheet.get_selected_cell();
                 if (cell.at_bottom()) {
                     event.preventDefault();
-                    that.select_next();
+                    current_sheet.select_next();
                 };
             } else if (event.which === key.ENTER && event.shiftKey) {
-                that.execute_selected_cell();
+                current_sheet.execute_selected_cell();
                 return false;
             } else if (event.which === key.ENTER && event.altKey) {
                 // Execute code cell, and insert new in place
-                that.execute_selected_cell();
+                current_sheet.execute_selected_cell();
                  // Only insert a new cell, if we ended up in an already populated cell
-                if (/\S/.test(that.get_selected_cell().get_text()) == true) {
-                    that.insert_cell_above('code');
+                if (/\S/.test(current_sheet.get_selected_cell().get_text()) == true) {
+                    current_sheet.insert_cell_above('code');
                 }
                 return false;
             } else if (event.which === key.ENTER && event.ctrlKey) {
-                that.execute_selected_cell({terminal:true});
+                current_sheet.execute_selected_cell({terminal:true});
                 return false;
             } else if (event.which === 77 && event.ctrlKey && that.control_key_active == false) {
                 that.control_key_active = true;
                 return false;
             } else if (event.which === 88 && that.control_key_active) {
                 // Cut selected cell = x
-                that.cut_cell();
+                current_sheet.cut_cell();
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 67 && that.control_key_active) {
                 // Copy selected cell = c
-                that.copy_cell();
+                current_sheet.copy_cell();
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 86 && that.control_key_active) {
                 // Paste below selected cell = v
-                that.paste_cell_below();
+                current_sheet.paste_cell_below();
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 68 && that.control_key_active) {
                 // Delete selected cell = d
-                that.delete_cell();
+                current_sheet.delete_cell();
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 65 && that.control_key_active) {
                 // Insert code cell above selected = a
-                that.insert_cell_above('code');
+                current_sheet.insert_cell_above('code');
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 66 && that.control_key_active) {
                 // Insert code cell below selected = b
-                that.insert_cell_below('code');
+                current_sheet.insert_cell_below('code');
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 89 && that.control_key_active) {
                 // To code = y
-                that.to_code();
+                current_sheet.to_code();
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 77 && that.control_key_active) {
                 // To markdown = m
-                that.to_markdown();
+                current_sheet.to_markdown();
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 84 && that.control_key_active) {
                 // To Raw = t
-                that.to_raw();
+                current_sheet.to_raw();
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 49 && that.control_key_active) {
                 // To Heading 1 = 1
-                that.to_heading(undefined, 1);
+                current_sheet.to_heading(undefined, 1);
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 50 && that.control_key_active) {
                 // To Heading 2 = 2
-                that.to_heading(undefined, 2);
+                current_sheet.to_heading(undefined, 2);
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 51 && that.control_key_active) {
                 // To Heading 3 = 3
-                that.to_heading(undefined, 3);
+                current_sheet.to_heading(undefined, 3);
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 52 && that.control_key_active) {
                 // To Heading 4 = 4
-                that.to_heading(undefined, 4);
+                current_sheet.to_heading(undefined, 4);
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 53 && that.control_key_active) {
                 // To Heading 5 = 5
-                that.to_heading(undefined, 5);
+                current_sheet.to_heading(undefined, 5);
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 54 && that.control_key_active) {
                 // To Heading 6 = 6
-                that.to_heading(undefined, 6);
+                current_sheet.to_heading(undefined, 6);
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 79 && that.control_key_active) {
                 // Toggle output = o
                 if (event.shiftKey){
-                    that.toggle_output_scroll();
+                    current_sheet.toggle_output_scroll();
                 } else {
-                    that.toggle_output();
+                    current_sheet.toggle_output();
                 }
                 that.control_key_active = false;
                 return false;
@@ -222,27 +194,27 @@ var IPython = (function (IPython) {
                 return false;
             } else if (event.which === 74 && that.control_key_active) {
                 // Move cell down = j
-                that.move_cell_down();
+                current_sheet.move_cell_down();
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 75 && that.control_key_active) {
                 // Move cell up = k
-                that.move_cell_up();
+                current_sheet.move_cell_up();
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 80 && that.control_key_active) {
                 // Select previous = p
-                that.select_prev();
+                current_sheet.select_prev();
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 78 && that.control_key_active) {
                 // Select next = n
-                that.select_next();
+                current_sheet.select_next();
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 76 && that.control_key_active) {
                 // Toggle line numbers = l
-                that.cell_toggle_line_numbers();
+                current_sheet.cell_toggle_line_numbers();
                 that.control_key_active = false;
                 return false;
             } else if (event.which === 73 && that.control_key_active) {
@@ -262,7 +234,8 @@ var IPython = (function (IPython) {
                 return false;
             } else if (event.which === 90 && that.control_key_active) {
                 // Undo last cell delete = z
-                that.undelete();
+                // XXX TODO add sheet-specific undelete behavior
+                current_sheet.undelete();
                 that.control_key_active = false;
                 return false;
             } else if (that.control_key_active) {
@@ -303,6 +276,12 @@ var IPython = (function (IPython) {
             if (kill_kernel) {
                 that.kernel.kill();
             }
+            // determine whether there have been any unsaved changes
+            for (var i=0; i<that.nsheets(); i++) {
+                if(that.get_worksheet(i).dirty) {
+                    that.dirty = true;
+                }
+            }
             if (that.dirty && ! that.read_only) {
                 return "You have unsaved changes that will be lost if you leave this page.";
             };
@@ -312,8 +291,10 @@ var IPython = (function (IPython) {
         });
     };
 
+
     Notebook.prototype.scroll_to_cell = function (cell_number, time) {
-        var cells = this.get_cells();
+        var current_sheet = this.get_selected_worksheet();
+        var cells = current_sheet.get_cells();
         var time = time || 0;
         cell_number = Math.min(cells.length-1,cell_number);
         cell_number = Math.max(0             ,cell_number);
@@ -332,82 +313,96 @@ var IPython = (function (IPython) {
         this.element.animate({scrollTop:0}, 0);
     };
 
+    
+    // Worksheet indexing, retrieval, etc.
 
-    // Cell indexing, retrieval, etc.
-
-    Notebook.prototype.get_cell_elements = function () {
-        return this.element.children("div.cell");
+    Notebook.prototype.get_worksheet_elements = function () {
+        return this.tabs.children('div.ui-tabs-panel').not('#tab-add');
     };
 
 
-    Notebook.prototype.get_cell_element = function (index) {
+    Notebook.prototype.get_worksheet_element = function (index) {
         var result = null;
-        var e = this.get_cell_elements().eq(index);
+        var e = this.get_worksheet_elements().eq(index);
         if (e.length !== 0) {
             result = e;
         }
         return result;
     };
 
-
-    Notebook.prototype.ncells = function (cell) {
-        return this.get_cell_elements().length;
+    Notebook.prototype.nsheets = function () {
+        return this.get_worksheet_elements().length;
     };
 
+// XXX TODO XXX delete cell semantics have changed slightly
+//-    Notebook.prototype.delete_cell = function (index) {
+//-        var i = this.index_or_selected(index);
+//-        if (this.is_valid_cell_index(i)) {
+//-            var ce = this.get_cell_element(i);
+//-            ce.remove();
+//-            if (i === (this.ncells())) {
+//-                this.select(i-1);
+//-            } else {
+//-                this.select(i);
+//-            };
+//-            this.dirty = true;
+//-        };
+//-        return this;
 
-    // TODO: we are often calling cells as cells()[i], which we should optimize
-    // to cells(i) or a new method.
-    Notebook.prototype.get_cells = function () {
-        return this.get_cell_elements().toArray().map(function (e) {
-            return $(e).data("cell");
+//    Notebook.prototype.delete_cell = function (index) {
+//        var i = this.index_or_selected(index);
+//        var cell = this.get_selected_cell();
+//        this.undelete_backup = cell.toJSON();
+//        if (this.is_valid_cell_index(i)) {
+//            var ce = this.get_cell_element(i);
+//            ce.remove();
+//            if (i === (this.ncells())) {
+//                this.select(i-1);
+//                this.undelete_index = i - 1;
+//                this.undelete_below = true;
+//            } else {
+//                this.select(i);
+//                this.undelete_index = i;
+//                this.undelete_below = false;
+//            };
+//            this.dirty = true;
+//        };
+//        return this;
+//    };
+
+
+    Notebook.prototype.get_worksheets = function () {
+        return this.get_worksheet_elements().toArray().map(function (e) {
+            return $(e).data('worksheet');
         });
     };
 
-
-    Notebook.prototype.get_cell = function (index) {
+    
+    Notebook.prototype.get_worksheet = function (index) {
         var result = null;
-        var ce = this.get_cell_element(index);
-        if (ce !== null) {
-            result = ce.data('cell');
+        var ws = this.get_worksheet_element(index);
+        if (ws !== null) {
+            result = ws.data('worksheet');
         }
         return result;
-    }
+    };
 
-
-    Notebook.prototype.get_next_cell = function (cell) {
+    
+    Notebook.prototype.find_worksheet_index = function (sheet) {
         var result = null;
-        var index = this.find_cell_index(cell);
-        if (index !== null && index < this.ncells()) {
-            result = this.get_cell(index+1);
-        }
-        return result;
-    }
-
-
-    Notebook.prototype.get_prev_cell = function (cell) {
-        var result = null;
-        var index = this.find_cell_index(cell);
-        if (index !== null && index > 1) {
-            result = this.get_cell(index-1);
-        }
-        return result;
-    }
-
-    Notebook.prototype.find_cell_index = function (cell) {
-        var result = null;
-        this.get_cell_elements().filter(function (index) {
-            if ($(this).data("cell") === cell) {
+        this.get_worksheet_elements().filter(function (index) {
+            if ($(this).data('worksheet') == worksheet) {
                 result = index;
             };
         });
         return result;
     };
 
-
-    Notebook.prototype.index_or_selected = function (index) {
+    
+    Notebook.prototype.index_or_selected_worksheet = function(index) {
         var i;
         if (index === undefined || index === null) {
-            i = this.get_selected_index();
+            i = this.get_selected_worksheet_index();
             if (i === null) {
                 i = 0;
             }
@@ -416,432 +411,174 @@ var IPython = (function (IPython) {
         }
         return i;
     };
-
-
-    Notebook.prototype.get_selected_cell = function () {
-        var index = this.get_selected_index();
-        return this.get_cell(index);
+    
+    
+    Notebook.prototype.get_selected_worksheet = function () {
+        var index = this.get_selected_worksheet_index();
+        return this.get_worksheet(index);
     };
-
-
-    Notebook.prototype.is_valid_cell_index = function (index) {
-        if (index !== null && index >= 0 && index < this.ncells()) {
-            return true;
-        } else {
-            return false;
-        };
-    }
-
-    Notebook.prototype.get_selected_index = function () {
-        var result = null;
-        this.get_cell_elements().filter(function (index) {
-            if ($(this).data("cell").selected === true) {
-                result = index;
-            };
-        });
-        return result;
+    
+    
+    Notebook.prototype.is_valid_worksheet_index = function (index) {
+       if (index !== null && index >= 0 && index < this.nsheets()) {
+           return true;
+       } else {
+           return false;
+       }
     };
-
-
-    // Cell selection.
-
+    
+    
+    Notebook.prototype.get_selected_worksheet_index = function () {
+        return this.tabs.tabs('option','selected');
+    };
+    
+    
+    // XXX TODO should this function do more?
+    Notebook.prototype.rename_worksheet = function (name) {
+    };
+    
+    
+    
+    // Worksheet selection.
+    
     Notebook.prototype.select = function (index) {
-        if (index !== undefined && index >= 0 && index < this.ncells()) {
-            var sindex = this.get_selected_index()
-            if (sindex !== null && index !== sindex) {
-                this.get_cell(sindex).unselect();
-            };
-            var cell = this.get_cell(index);
-            cell.select();
-            if (cell.cell_type === 'heading') {
-                $([IPython.events]).trigger('selected_cell_type_changed.Notebook',
-                    {'cell_type':cell.cell_type,level:cell.level}
-                );
+       this.tabs.tabs('select',index);
+       return this;
+    };
+
+
+    // Worksheet insertion, deletion.
+
+    Notebook.prototype.delete_worksheet = function (index) {
+        index = this.index_or_selected_worksheet(index);
+        if (this.is_valid_worksheet_index(index)) {
+            this.tabs.tabs('remove',index);
+            if (index === (this.nsheets())) {
+                this.select(index-1);
             } else {
-                $([IPython.events]).trigger('selected_cell_type_changed.Notebook',
-                    {'cell_type':cell.cell_type}
-                );
-            };
-        };
-        return this;
-    };
-
-
-    Notebook.prototype.select_next = function () {
-        var index = this.get_selected_index();
-        if (index !== null && index >= 0 && (index+1) < this.ncells()) {
-            this.select(index+1);
-        };
-        return this;
-    };
-
-
-    Notebook.prototype.select_prev = function () {
-        var index = this.get_selected_index();
-        if (index !== null && index >= 0 && (index-1) < this.ncells()) {
-            this.select(index-1);
-        };
-        return this;
-    };
-
-
-    // Cell movement
-
-    Notebook.prototype.move_cell_up = function (index) {
-        var i = this.index_or_selected();
-        if (i !== null && i < this.ncells() && i > 0) {
-            var pivot = this.get_cell_element(i-1);
-            var tomove = this.get_cell_element(i);
-            if (pivot !== null && tomove !== null) {
-                tomove.detach();
-                pivot.before(tomove);
-                this.select(i-1);
-            };
-        };
-        this.dirty = true;
-        return this;
-    };
-
-
-    Notebook.prototype.move_cell_down = function (index) {
-        var i = this.index_or_selected();
-        if (i !== null && i < (this.ncells()-1) && i >= 0) {
-            var pivot = this.get_cell_element(i+1);
-            var tomove = this.get_cell_element(i);
-            if (pivot !== null && tomove !== null) {
-                tomove.detach();
-                pivot.after(tomove);
-                this.select(i+1);
-            };
-        };
-        this.dirty = true;
-        return this;
-    };
-
-
-    Notebook.prototype.sort_cells = function () {
-        // This is not working right now. Calling this will actually crash
-        // the browser. I think there is an infinite loop in here...
-        var ncells = this.ncells();
-        var sindex = this.get_selected_index();
-        var swapped;
-        do {
-            swapped = false;
-            for (var i=1; i<ncells; i++) {
-                current = this.get_cell(i);
-                previous = this.get_cell(i-1);
-                if (previous.input_prompt_number > current.input_prompt_number) {
-                    this.move_cell_up(i);
-                    swapped = true;
-                };
-            };
-        } while (swapped);
-        this.select(sindex);
-        return this;
-    };
-
-    // Insertion, deletion.
-
-    Notebook.prototype.delete_cell = function (index) {
-        var i = this.index_or_selected(index);
-        var cell = this.get_selected_cell();
-        this.undelete_backup = cell.toJSON();
-        if (this.is_valid_cell_index(i)) {
-            var ce = this.get_cell_element(i);
-            ce.remove();
-            if (i === (this.ncells())) {
-                this.select(i-1);
-                this.undelete_index = i - 1;
-                this.undelete_below = true;
-            } else {
-                this.select(i);
-                this.undelete_index = i;
-                this.undelete_below = false;
-            };
+                this.select(index);
+            }
             this.dirty = true;
-        };
+        }
         return this;
     };
 
-
-    Notebook.prototype.insert_cell_at_bottom = function (type){
-        var len = this.ncells();
-        return this.insert_cell_below(type,len-1);
-    }
-
-    Notebook.prototype.insert_cell_below = function (type, index) {
-        // type = ('code','html','markdown')
-        // index = cell index or undefined to insert below selected
-        index = this.index_or_selected(index);
-        var cell = null;
-        // This is intentionally < rather than <= for the sake of more
-        // sensible behavior in some cases.
-        if (this.undelete_index !== null && index < this.undelete_index) {
-            this.undelete_index = this.undelete_index + 1;
+    Notebook.prototype.insert_worksheet_below = function (name, index) {
+        index = this.index_or_selected_worksheet(index);
+        id = 'tab-' + utils.uuid(); // generate random id
+        if (this.nsheets() === 0) {
+            index = 0;
+        } else {
+            index = index+1;
         }
-        if (this.ncells() === 0 || this.is_valid_cell_index(index)) {
-            if (type === 'code') {
-                cell = new IPython.CodeCell(this.kernel);
-                cell.set_input_prompt();
-            } else if (type === 'markdown') {
-                cell = new IPython.MarkdownCell();
-            } else if (type === 'html') {
-                cell = new IPython.HTMLCell();
-            } else if (type === 'raw') {
-                cell = new IPython.RawCell();
-            } else if (type === 'heading') {
-                cell = new IPython.HeadingCell();
-            };
-            if (cell !== null) {
-                if (this.ncells() === 0) {
-                    this.element.find('div.end_space').before(cell.element);
-                } else if (this.is_valid_cell_index(index)) {
-                    this.get_cell_element(index).after(cell.element);
-                };
-                cell.render();
-                this.select(this.find_cell_index(cell));
-                this.dirty = true;
-                return cell;
-            };
-        };
-        return cell;
+        this.tabs.tabs('add', '#'+id, name, index); // create tab with specified id, name, and position
+        var sheet = new IPython.Worksheet(this.tabs.children('#'+id), name, this.kernel);
+        this.select(index);
+        this.dirty = true;
+        return sheet;
     };
 
-
-    Notebook.prototype.insert_cell_above = function (type, index) {
-        // type = ('code','html','markdown')
-        // index = cell index or undefined to insert above selected
-        index = this.index_or_selected(index);
-        var cell = null;
-        if (this.undelete_index !== null && index <= this.undelete_index) {
-            this.undelete_index = this.undelete_index + 1;
+    Notebook.prototype.insert_worksheet_above = function (name, index) {
+        index = this.index_or_selected_worksheet(index);
+        id = 'tab-' + utils.uuid(); // generate random id
+        if (this.nsheets() === 0) {
+            index = 0;
         }
-        if (this.ncells() === 0 || this.is_valid_cell_index(index)) {
-            if (type === 'code') {
-                cell = new IPython.CodeCell(this.kernel);
-                cell.set_input_prompt();
-            } else if (type === 'markdown') {
-                cell = new IPython.MarkdownCell();
-            } else if (type === 'html') {
-                cell = new IPython.HTMLCell();
-            } else if (type === 'raw') {
-                cell = new IPython.RawCell();
-            } else if (type === 'heading') {
-                cell = new IPython.HeadingCell();
-            };
-            if (cell !== null) {
-                if (this.ncells() === 0) {
-                    this.element.find('div.end_space').before(cell.element);
-                } else if (this.is_valid_cell_index(index)) {
-                    this.get_cell_element(index).before(cell.element);
-                };
-                cell.render();
-                this.select(this.find_cell_index(cell));
-                this.dirty = true;
-                return cell;
-            };
-        };
-        return cell;
+        this.tabs.tabs('add', '#'+id, name, index); // create tab with specified id, name, and position
+        var sheet = new IPython.Worksheet(this.tabs.children('#'+id), name, this.kernel);
+        this.select(index);
+        this.dirty = true;
+        return sheet;
     };
 
+    
+    
+    
+    
+    //XXX TODO new function here
+    //Notebook.prototype.insert_cell_at_bottom = function (type){
+    //    var len = this.ncells();
+    //    return this.insert_cell_below(type,len-1);
+    //}
 
-    Notebook.prototype.to_code = function (index) {
-        var i = this.index_or_selected(index);
-        if (this.is_valid_cell_index(i)) {
-            var source_element = this.get_cell_element(i);
-            var source_cell = source_element.data("cell");
-            if (!(source_cell instanceof IPython.CodeCell)) {
-                var target_cell = this.insert_cell_below('code',i);
-                var text = source_cell.get_text();
-                if (text === source_cell.placeholder) {
-                    text = '';
-                }
-                target_cell.set_text(text);
-                // make this value the starting point, so that we can only undo
-                // to this state, instead of a blank cell
-                target_cell.code_mirror.clearHistory();
-                source_element.remove();
-                this.dirty = true;
-            };
-        };
-    };
+    // XXX TODO function body changed
+    //Notebook.prototype.insert_cell_below = function (type, index) {
+    //    // type = ('code','html','markdown')
+    //    // index = cell index or undefined to insert below selected
+    //    index = this.index_or_selected(index);
+    //    var cell = null;
+    //    // This is intentionally < rather than <= for the sake of more
+    //    // sensible behavior in some cases.
+    //    if (this.undelete_index !== null && index < this.undelete_index) {
+    //        this.undelete_index = this.undelete_index + 1;
+    //    }
+    //    if (this.ncells() === 0 || this.is_valid_cell_index(index)) {
+    //        if (type === 'code') {
+    //            cell = new IPython.CodeCell(this.kernel);
+    //            cell.set_input_prompt();
+    //        } else if (type === 'markdown') {
+    //            cell = new IPython.MarkdownCell();
+    //        } else if (type === 'html') {
+    //            cell = new IPython.HTMLCell();
+    //        } else if (type === 'raw') {
+    //            cell = new IPython.RawCell();
+    //        } else if (type === 'heading') {
+    //            cell = new IPython.HeadingCell();
+    //        };
+    //        if (cell !== null) {
+    //            if (this.ncells() === 0) {
+    //                this.element.find('div.end_space').before(cell.element);
+    //            } else if (this.is_valid_cell_index(index)) {
+    //                this.get_cell_element(index).after(cell.element);
+    //            };
+    //            cell.render();
+    //            this.select(this.find_cell_index(cell));
+    //            this.dirty = true;
+    //            return cell;
+    //        };
+    //    };
+    //    return cell;
+    //};
 
-
-    Notebook.prototype.to_markdown = function (index) {
-        var i = this.index_or_selected(index);
-        if (this.is_valid_cell_index(i)) {
-            var source_element = this.get_cell_element(i);
-            var source_cell = source_element.data("cell");
-            if (!(source_cell instanceof IPython.MarkdownCell)) {
-                var target_cell = this.insert_cell_below('markdown',i);
-                var text = source_cell.get_text();
-                if (text === source_cell.placeholder) {
-                    text = '';
-                };
-                // The edit must come before the set_text.
-                target_cell.edit();
-                target_cell.set_text(text);
-                // make this value the starting point, so that we can only undo
-                // to this state, instead of a blank cell
-                target_cell.code_mirror.clearHistory();
-                source_element.remove();
-                this.dirty = true;
-            };
-        };
-    };
-
-
-    Notebook.prototype.to_html = function (index) {
-        var i = this.index_or_selected(index);
-        if (this.is_valid_cell_index(i)) {
-            var source_element = this.get_cell_element(i);
-            var source_cell = source_element.data("cell");
-            var target_cell = null;
-            if (!(source_cell instanceof IPython.HTMLCell)) {
-                target_cell = this.insert_cell_below('html',i);
-                var text = source_cell.get_text();
-                if (text === source_cell.placeholder) {
-                    text = '';
-                };
-                // The edit must come before the set_text.
-                target_cell.edit();
-                target_cell.set_text(text);
-                // make this value the starting point, so that we can only undo
-                // to this state, instead of a blank cell
-                target_cell.code_mirror.clearHistory();
-                source_element.remove();
-                this.dirty = true;
-            };
-        };
-    };
-
-
-    Notebook.prototype.to_raw = function (index) {
-        var i = this.index_or_selected(index);
-        if (this.is_valid_cell_index(i)) {
-            var source_element = this.get_cell_element(i);
-            var source_cell = source_element.data("cell");
-            var target_cell = null;
-            if (!(source_cell instanceof IPython.RawCell)) {
-                target_cell = this.insert_cell_below('raw',i);
-                var text = source_cell.get_text();
-                if (text === source_cell.placeholder) {
-                    text = '';
-                };
-                // The edit must come before the set_text.
-                target_cell.edit();
-                target_cell.set_text(text);
-                // make this value the starting point, so that we can only undo
-                // to this state, instead of a blank cell
-                target_cell.code_mirror.clearHistory();
-                source_element.remove();
-                this.dirty = true;
-            };
-        };
-    };
-
-
-    Notebook.prototype.to_heading = function (index, level) {
-        level = level || 1;
-        var i = this.index_or_selected(index);
-        if (this.is_valid_cell_index(i)) {
-            var source_element = this.get_cell_element(i);
-            var source_cell = source_element.data("cell");
-            var target_cell = null;
-            if (source_cell instanceof IPython.HeadingCell) {
-                source_cell.set_level(level);
-            } else {
-                target_cell = this.insert_cell_below('heading',i);
-                var text = source_cell.get_text();
-                if (text === source_cell.placeholder) {
-                    text = '';
-                };
-                // The edit must come before the set_text.
-                target_cell.set_level(level);
-                target_cell.edit();
-                target_cell.set_text(text);
-                // make this value the starting point, so that we can only undo
-                // to this state, instead of a blank cell
-                target_cell.code_mirror.clearHistory();
-                source_element.remove();
-                this.dirty = true;
-            };
-            $([IPython.events]).trigger('selected_cell_type_changed.Notebook',
-                {'cell_type':'heading',level:level}
-            );
-        };
-    };
-
-
-    // Cut/Copy/Paste
-
-    Notebook.prototype.enable_paste = function () {
-        var that = this;
-        if (!this.paste_enabled) {
-            $('#paste_cell_replace').removeClass('ui-state-disabled')
-                .on('click', function () {that.paste_cell_replace();});
-            $('#paste_cell_above').removeClass('ui-state-disabled')
-                .on('click', function () {that.paste_cell_above();});
-            $('#paste_cell_below').removeClass('ui-state-disabled')
-                .on('click', function () {that.paste_cell_below();});
-            this.paste_enabled = true;
-        };
-    };
-
-
-    Notebook.prototype.disable_paste = function () {
-        if (this.paste_enabled) {
-            $('#paste_cell_replace').addClass('ui-state-disabled').off('click');
-            $('#paste_cell_above').addClass('ui-state-disabled').off('click');
-            $('#paste_cell_below').addClass('ui-state-disabled').off('click');
-            this.paste_enabled = false;
-        };
-    };
-
-
-    Notebook.prototype.cut_cell = function () {
-        this.copy_cell();
-        this.delete_cell();
-    }
-
-    Notebook.prototype.copy_cell = function () {
-        var cell = this.get_selected_cell();
-        this.clipboard = cell.toJSON();
-        this.enable_paste();
-    };
-
-
-    Notebook.prototype.paste_cell_replace = function () {
-        if (this.clipboard !== null && this.paste_enabled) {
-            var cell_data = this.clipboard;
-            var new_cell = this.insert_cell_above(cell_data.cell_type);
-            new_cell.fromJSON(cell_data);
-            var old_cell = this.get_next_cell(new_cell);
-            this.delete_cell(this.find_cell_index(old_cell));
-            this.select(this.find_cell_index(new_cell));
-        };
-    };
-
-
-    Notebook.prototype.paste_cell_above = function () {
-        if (this.clipboard !== null && this.paste_enabled) {
-            var cell_data = this.clipboard;
-            var new_cell = this.insert_cell_above(cell_data.cell_type);
-            new_cell.fromJSON(cell_data);
-        };
-    };
-
-
-    Notebook.prototype.paste_cell_below = function () {
-        if (this.clipboard !== null && this.paste_enabled) {
-            var cell_data = this.clipboard;
-            var new_cell = this.insert_cell_below(cell_data.cell_type);
-            new_cell.fromJSON(cell_data);
-        };
-    };
+    // XXX TODO changed slightly
+    //Notebook.prototype.insert_cell_above = function (type, index) {
+    //    // type = ('code','html','markdown')
+    //    // index = cell index or undefined to insert above selected
+    //    index = this.index_or_selected(index);
+    //    var cell = null;
+    //    if (this.undelete_index !== null && index <= this.undelete_index) {
+    //        this.undelete_index = this.undelete_index + 1;
+    //    }
+    //    if (this.ncells() === 0 || this.is_valid_cell_index(index)) {
+    //        if (type === 'code') {
+    //            cell = new IPython.CodeCell(this.kernel);
+    //            cell.set_input_prompt();
+    //        } else if (type === 'markdown') {
+    //            cell = new IPython.MarkdownCell();
+    //        } else if (type === 'html') {
+    //            cell = new IPython.HTMLCell();
+    //        } else if (type === 'raw') {
+    //            cell = new IPython.RawCell();
+    //        } else if (type === 'heading') {
+    //            cell = new IPython.HeadingCell();
+    //        };
+    //        if (cell !== null) {
+    //            if (this.ncells() === 0) {
+    //                this.element.find('div.end_space').before(cell.element);
+    //            } else if (this.is_valid_cell_index(index)) {
+    //                this.get_cell_element(index).before(cell.element);
+    //            };
+    //            cell.render();
+    //            this.select(this.find_cell_index(cell));
+    //            this.dirty = true;
+    //            return cell;
+    //        };
+    //    };
+    //    return cell;
+    //};
 
     // Cell undelete
-
+    // XXX TODO implement undelete function on worksheets
     Notebook.prototype.undelete = function() {
         if (this.undelete_backup !== null && this.undelete_index !== null) {
             var current_index = this.get_selected_index();
@@ -868,182 +605,27 @@ var IPython = (function (IPython) {
         }
     }
 
-    // Split/merge
-
-    Notebook.prototype.split_cell = function () {
-        // Todo: implement spliting for other cell types.
-        var cell = this.get_selected_cell();
-        if (cell.is_splittable()) {
-            var texta = cell.get_pre_cursor();
-            var textb = cell.get_post_cursor();
-            if (cell instanceof IPython.CodeCell) {
-                cell.set_text(texta);
-                var new_cell = this.insert_cell_below('code');
-                new_cell.set_text(textb);
-            } else if (cell instanceof IPython.MarkdownCell) {
-                cell.set_text(texta);
-                cell.render();
-                var new_cell = this.insert_cell_below('markdown');
-                new_cell.edit(); // editor must be visible to call set_text
-                new_cell.set_text(textb);
-                new_cell.render();
-            } else if (cell instanceof IPython.HTMLCell) {
-                cell.set_text(texta);
-                cell.render();
-                var new_cell = this.insert_cell_below('html');
-                new_cell.edit(); // editor must be visible to call set_text
-                new_cell.set_text(textb);
-                new_cell.render();
-            };
-        };
-    };
-
-
-    Notebook.prototype.merge_cell_above = function () {
-        var index = this.get_selected_index();
-        var cell = this.get_cell(index);
-        if (index > 0) {
-            var upper_cell = this.get_cell(index-1);
-            var upper_text = upper_cell.get_text();
-            var text = cell.get_text();
-            if (cell instanceof IPython.CodeCell) {
-                cell.set_text(upper_text+'\n'+text);
-            } else if (cell instanceof IPython.MarkdownCell || cell instanceof IPython.HTMLCell) {
-                cell.edit();
-                cell.set_text(upper_text+'\n'+text);
-                cell.render();
-            };
-            this.delete_cell(index-1);
-            this.select(this.find_cell_index(cell));
-        };
-    };
-
-
-    Notebook.prototype.merge_cell_below = function () {
-        var index = this.get_selected_index();
-        var cell = this.get_cell(index);
-        if (index < this.ncells()-1) {
-            var lower_cell = this.get_cell(index+1);
-            var lower_text = lower_cell.get_text();
-            var text = cell.get_text();
-            if (cell instanceof IPython.CodeCell) {
-                cell.set_text(text+'\n'+lower_text);
-            } else if (cell instanceof IPython.MarkdownCell || cell instanceof IPython.HTMLCell) {
-                cell.edit();
-                cell.set_text(text+'\n'+lower_text);
-                cell.render();
-            };
-            this.delete_cell(index+1);
-            this.select(this.find_cell_index(cell));
-        };
-    };
-
-
-    // Cell collapsing and output clearing
-
-    Notebook.prototype.collapse = function (index) {
-        var i = this.index_or_selected(index);
-        this.get_cell(i).collapse();
-        this.dirty = true;
-    };
-
-
-    Notebook.prototype.expand = function (index) {
-        var i = this.index_or_selected(index);
-        this.get_cell(i).expand();
-        this.dirty = true;
-    };
-
-
-    Notebook.prototype.toggle_output = function (index) {
-        var i = this.index_or_selected(index);
-        this.get_cell(i).toggle_output();
-        this.dirty = true;
-    };
-
-
-    Notebook.prototype.toggle_output_scroll = function (index) {
-        var i = this.index_or_selected(index);
-        this.get_cell(i).toggle_output_scroll();
-    };
-
-
-    Notebook.prototype.collapse_all_output = function () {
-        var ncells = this.ncells();
-        var cells = this.get_cells();
-        for (var i=0; i<ncells; i++) {
-            if (cells[i] instanceof IPython.CodeCell) {
-                cells[i].output_area.collapse();
-            }
-        };
-        // this should not be set if the `collapse` key is removed from nbformat
-        this.dirty = true;
-    };
-
-
-    Notebook.prototype.scroll_all_output = function () {
-        var ncells = this.ncells();
-        var cells = this.get_cells();
-        for (var i=0; i<ncells; i++) {
-            if (cells[i] instanceof IPython.CodeCell) {
-                cells[i].output_area.expand();
-                cells[i].output_area.scroll_if_long(20);
-            }
-        };
-        // this should not be set if the `collapse` key is removed from nbformat
-        this.dirty = true;
-    };
-
-
-    Notebook.prototype.expand_all_output = function () {
-        var ncells = this.ncells();
-        var cells = this.get_cells();
-        for (var i=0; i<ncells; i++) {
-            if (cells[i] instanceof IPython.CodeCell) {
-                cells[i].output_area.expand();
-                cells[i].output_area.unscroll_area();
-            }
-        };
-        // this should not be set if the `collapse` key is removed from nbformat
-        this.dirty = true;
-    };
-
-
-    Notebook.prototype.clear_all_output = function () {
-        var ncells = this.ncells();
-        var cells = this.get_cells();
-        for (var i=0; i<ncells; i++) {
-            if (cells[i] instanceof IPython.CodeCell) {
-                cells[i].clear_output(true,true,true);
-                // Make all In[] prompts blank, as well
-                // TODO: make this configurable (via checkbox?)
-                cells[i].set_input_prompt();
-            }
-        };
-        this.dirty = true;
-    };
-
 
     // Other cell functions: line numbers, ...
 
     Notebook.prototype.cell_toggle_line_numbers = function() {
-        this.get_selected_cell().toggle_line_numbers();
+        that.get_selected_worksheet().get_selected_cell().toggle_line_numbers();
     };
 
     // Kernel related things
 
+    // need to update to set kernel for worksheet instead -DLS
+    
     Notebook.prototype.start_kernel = function () {
         var base_url = $('body').data('baseKernelUrl') + "kernels";
         this.kernel = new IPython.Kernel(base_url);
         this.kernel.start(this.notebook_id);
-        // Now that the kernel has been created, tell the CodeCells about it.
-        var ncells = this.ncells();
-        for (var i=0; i<ncells; i++) {
-            var cell = this.get_cell(i);
-            if (cell instanceof IPython.CodeCell) {
-                cell.set_kernel(this.kernel)
-            };
-        };
+        // Now that the kernel has been created, tell the CodeCells in each sheet about it.
+        var nsheets = this.nsheets();
+        for (var i=0; i<nsheets; i++) {
+            var sheet = this.get_worksheet(i);
+            sheet.set_kernel(this.kernel);
+        }
     };
 
 
@@ -1070,54 +652,27 @@ var IPython = (function (IPython) {
     };
 
 
-    Notebook.prototype.execute_selected_cell = function (options) {
-        // add_new: should a new cell be added if we are at the end of the nb
-        // terminal: execute in terminal mode, which stays in the current cell
-        var default_options = {terminal: false, add_new: true};
-        $.extend(default_options, options);
-        var that = this;
-        var cell = that.get_selected_cell();
-        var cell_index = that.find_cell_index(cell);
-        if (cell instanceof IPython.CodeCell) {
-            cell.execute();
-        } else if (cell instanceof IPython.HTMLCell) {
-            cell.render();
-        }
-        if (default_options.terminal) {
-            cell.select_all();
-        } else {
-            if ((cell_index === (that.ncells()-1)) && default_options.add_new) {
-                that.insert_cell_below('code');
-                // If we are adding a new cell at the end, scroll down to show it.
-                that.scroll_to_bottom();
-            } else {
-                that.select(cell_index+1);
-            };
-        };
-        this.dirty = true;
-    };
-
-
-    Notebook.prototype.execute_cells_below = function () {
-        this.execute_cell_range(this.get_selected_index(), this.ncells());
-        this.scroll_to_bottom();
-    };
-
-    Notebook.prototype.execute_cells_above = function () {
-        this.execute_cell_range(0, this.get_selected_index());
-    };
-
-    Notebook.prototype.execute_all_cells = function () {
-        this.execute_cell_range(0, this.ncells());
-        that.scroll_to_bottom();
-    };
-
-    Notebook.prototype.execute_cell_range = function (start, end) {
-        for (var i=start; i<end; i++) {
-            this.select(i);
-            this.execute_selected_cell({add_new:false});
-        };
-    };
+//  XXX TODO worksheet execute cells below, cells above, cell range, all_cells
+//    Notebook.prototype.execute_cells_below = function () {
+//        this.execute_cell_range(this.get_selected_index(), this.ncells());
+//        this.scroll_to_bottom();
+//    };
+//
+//    Notebook.prototype.execute_cells_above = function () {
+//        this.execute_cell_range(0, this.get_selected_index());
+//    };
+//
+//    Notebook.prototype.execute_all_cells = function () {
+//        this.execute_cell_range(0, this.ncells());
+//        that.scroll_to_bottom();
+//    };
+//
+//    Notebook.prototype.execute_cell_range = function (start, end) {
+//        for (var i=start; i<end; i++) {
+//            this.select(i);
+//            this.execute_selected_cell({add_new:false});
+//        };
+//    };
 
     // Persistance and loading
 
@@ -1147,74 +702,47 @@ var IPython = (function (IPython) {
 
 
     Notebook.prototype.fromJSON = function (data) {
-        var ncells = this.ncells();
-        var i;
-        for (i=0; i<ncells; i++) {
-            // Always delete cell 0 as they get renumbered as they are deleted.
-            this.delete_cell(0);
+        var nsheets = this.nsheets();
+        for (var i=0; i<nsheets; i++) {
+            // Always delete worksheet 0 as they get renumbered as they are deleted.
+            this.delete_worksheet(0);
         };
         // Save the metadata and name.
-        this.metadata = data.metadata;
-        this.notebook_name = data.metadata.name;
-        // Only handle 1 worksheet for now.
-        var worksheet = data.worksheets[0];
-        if (worksheet !== undefined) {
-            if (worksheet.metadata) {
-                this.worksheet_metadata = worksheet.metadata;
+        if(data.metadata !== undefined) {
+             this.metadata = data.metadata;
+             this.notebook_name = data.metadata.name;
+        }
+        nsheets = data.worksheets.length;
+        var sheet_data = null;
+        var new_sheet = null;
+        for (var i=0; i<nsheets; i++) {
+            sheet_data = data.worksheets[i];
+            // fetch the name from the metadata if it exists, otherwise use default 
+            if(sheet_data.metadata !== undefined && sheet_data.metadata.name !== undefined) {
+                name = sheet_data.metadata.name;
+            } else {
+                name = 'New Tab ' + i;
             }
-            var new_cells = worksheet.cells;
-            ncells = new_cells.length;
-            var cell_data = null;
-            var new_cell = null;
-            for (i=0; i<ncells; i++) {
-                cell_data = new_cells[i];
-                // VERSIONHACK: plaintext -> raw
-                // handle never-released plaintext name for raw cells
-                if (cell_data.cell_type === 'plaintext'){
-                    cell_data.cell_type = 'raw';
-                }
-
-                new_cell = this.insert_cell_below(cell_data.cell_type);
-                new_cell.fromJSON(cell_data);
-            };
-        };
-        if (data.worksheets.length > 1) {
-            var dialog = $('<div/>');
-            dialog.html("This notebook has " + data.worksheets.length + " worksheets, " +
-            "but this version of IPython can only handle the first.  " +
-            "If you save this notebook, worksheets after the first will be lost."
-            );
-            this.element.append(dialog);
-            dialog.dialog({
-                resizable: false,
-                modal: true,
-                title: "Multiple worksheets",
-                closeText: "",
-                close: function(event, ui) {$(this).dialog('destroy').remove();},
-                buttons : {
-                    "OK": function () {
-                        $(this).dialog('close');
-                    }
-                },
-                width: 400
-            });
+            new_sheet = this.insert_worksheet_below(name);
+            new_sheet.fromJSON(sheet_data);
         }
     };
 
 
     Notebook.prototype.toJSON = function () {
-        var cells = this.get_cells();
-        var ncells = cells.length;
-        var cell_array = new Array(ncells);
-        for (var i=0; i<ncells; i++) {
-            cell_array[i] = cells[i].toJSON();
+        var sheets = this.get_worksheets();
+        var nsheets = sheets.length;
+        var sheet_array = new Array(nsheets);
+        for (var i=0; i<nsheets; i++) {
+            // the tabs are not in order when we call get_worksheets
+            var id = sheets[i].worksheet_id;
+            // get index of worksheet among tabs
+            var j = this.element.find('.ui-tabs-nav').find("a[href!='#tab-add']").index($("a[href=#" + id + "]"));
+            // convert sheet to JSON
+            sheet_array[i] = sheets[j].toJSON();
         };
         var data = {
-            // Only handle 1 worksheet for now.
-            worksheets : [{
-                cells: cell_array,
-                metadata: this.worksheet_metadata
-            }],
+            worksheets : sheet_array,
             metadata : this.metadata
         };
         return data;
@@ -1243,7 +771,11 @@ var IPython = (function (IPython) {
 
 
     Notebook.prototype.save_notebook_success = function (data, status, xhr) {
+        // mark notebook and all worksheets as clean
         this.dirty = false;
+        for (var i=0; i<this.nsheets(); i++) {
+            this.get_worksheet(i).dirty = false;
+        }
         $([IPython.events]).trigger('notebook_saved.Notebook');
     };
 
@@ -1273,11 +805,11 @@ var IPython = (function (IPython) {
 
     Notebook.prototype.load_notebook_success = function (data, status, xhr) {
         this.fromJSON(data);
-        if (this.ncells() === 0) {
-            this.insert_cell_below('code');
+        if (this.nsheets() === 0) {
+            this.insert_worksheet_below('New Tab');
         };
-        this.dirty = false;
         this.select(0);
+        this.dirty = false;
         this.scroll_to_top();
         if (data.orig_nbformat !== undefined && data.nbformat !== data.orig_nbformat) {
             msg = "This notebook has been converted from an older " +

--- a/IPython/frontend/html/notebook/static/js/notebookmain.js
+++ b/IPython/frontend/html/notebook/static/js/notebookmain.js
@@ -42,15 +42,16 @@ $(document).ready(function () {
     IPython.page = new IPython.Page();
     IPython.markdown_converter = new Markdown.Converter();
     IPython.layout_manager = new IPython.LayoutManager();
+    IPython.tab_manager = new IPython.TabManager('div#tabs');
     IPython.pager = new IPython.Pager('div#pager', 'div#pager_splitter');
     IPython.quick_help = new IPython.QuickHelp('span#quick_help_area');
     IPython.login_widget = new IPython.LoginWidget('span#login_widget');
     IPython.notebook = new IPython.Notebook('div#notebook');
     IPython.save_widget = new IPython.SaveWidget('span#save_widget');
-    IPython.menubar = new IPython.MenuBar('#menubar')
-    IPython.toolbar = new IPython.MainToolBar('#maintoolbar')
-    IPython.tooltip = new IPython.Tooltip()
-    IPython.notification_area = new IPython.NotificationArea('#notification_area')
+    IPython.menubar = new IPython.MenuBar('#menubar');
+    IPython.toolbar = new IPython.MainToolBar('#maintoolbar');
+    IPython.tooltip = new IPython.Tooltip();
+    IPython.notification_area = new IPython.NotificationArea('#notification_area');
     IPython.notification_area.init_notification_widgets();
 
     IPython.layout_manager.do_resize();

--- a/IPython/frontend/html/notebook/static/js/tabmanager.js
+++ b/IPython/frontend/html/notebook/static/js/tabmanager.js
@@ -1,0 +1,136 @@
+//----------------------------------------------------------------------------
+//  Copyright (C) 2008-2011  The IPython Development Team
+//
+//  Distributed under the terms of the BSD License.  The full license is in
+//  the file COPYING, distributed as part of this software.
+//----------------------------------------------------------------------------
+
+//============================================================================
+// Tabs
+//============================================================================
+
+
+var IPython = (function (IPython) {
+
+    var TabManager = function (selector) {
+	this.tabs = $(selector).tabs();
+	this.tabs.find('.ui-tabs-nav').sortable({
+	    axis: "x",
+	    update: function () {
+		// refresh the code mirror for all the worksheets
+		var sheets = IPython.notebook.get_worksheets();
+		for (var i=0; i<sheets.length; i++) {
+		    sheets[i].refresh_code_mirror();
+		}
+	    }
+	});
+	this.tabs.addClass('container');
+	this.tabs.tabs('add','#tab-add','+') // create a button for adding tabs
+        this.bind_events();
+    };
+
+
+    TabManager.prototype.bind_events = function () {
+	that = this;
+	// attach click event to the 'Add Tab' button
+	$('div#tabs').find("a[href='#tab-add']").parent('li').click(function (event) {
+	    event.preventDefault();
+	    var nsheets = IPython.notebook.nsheets();
+	    IPython.notebook.insert_worksheet_above('New Tab ' + (nsheets+1), nsheets);
+	})
+	// attach event handler for when a tab is added
+	this.tabs.bind("tabsadd", function(event, ui) {
+	    // select the tab and panels
+	    var tab = $(ui.tab);
+	    // set click and hover events
+	    var e = tab.children('span');
+	    e.click(that.set_onclick);
+	    e.hover(function () {
+		if($(this).closest('li').hasClass('ui-tabs-active') && !$(this).hasClass('editing')) {
+		    $(this).addClass("ui-state-hover");
+		}
+            }, function () {
+		if($(this).closest('li').hasClass('ui-tabs-active')) {
+		    $(this).removeClass("ui-state-hover");
+		}
+            });
+	    // add a close icon to the tab
+	    tab.after('<span class="ui-icon ui-icon-close"></span>');
+	    tab.next().click(that.close_tab);
+	    // set class for tab panel
+	    $(ui.panel).addClass('panel');
+	});
+	// attach event handler for when a tab is selected
+	this.tabs.bind("tabsshow", function(event, ui) {
+	    // ignore if the "add tab" button was clicked
+	    if($(ui.panel).attr('id') !== 'tab-add') {
+		var ws = IPython.notebook.get_worksheet(ui.index);
+		if(ws !== undefined) {
+		    if(ws.ncells() === 0) {
+			ws.insert_cell_below('code');
+		    }
+		}
+		ws.refresh_code_mirror();
+		// reselect the cell, since the cell loses focus when the tab is changed
+		var i = ws.get_selected_index();
+		ws.select(i);
+	    }
+	})
+    };
+
+    TabManager.prototype.set_onclick = function () {
+	// check whether tab is active by checking whether the containing 'li' contains some active class
+	if($(this).closest('li').hasClass('ui-tabs-active')) {
+	    // create a textbox with title as current value
+	    var curr_label = $(this).text();
+	    var editableText = $('<input/>').attr('type','text').attr('size',10);
+	    editableText.val(curr_label);
+	    $(this).html(editableText);
+	    editableText.focus();
+	    // designate tab as in editing mode
+	    $(this).removeClass("ui-state-hover");
+	    $(this).addClass('editing');
+	    // event handler for when the user clicks outside the textbox (i.e., is done editing)
+	    editableText.blur( function() {
+		var new_label = null;
+		if($(this).val()) {
+		    new_label = $(this).val();
+		} else {
+		    new_label = curr_label;
+		}
+		IPython.notebook.get_selected_worksheet().set_worksheet_name(new_label);
+		$(this).parent('span').removeClass('editing');
+		$(this).replaceWith(new_label);
+	    });
+	}
+    }
+
+    TabManager.prototype.close_tab = function () {
+	var index = $(this).closest('ul.ui-tabs-nav').children().index($(this).closest('li'));
+	var dialog = $('<div/>');
+	dialog.html('Do you want to close this tab?  You will lose all work in this worksheet.');
+	dialog.dialog({
+	    resizable: false,
+	    modal: true,
+	    title: "Close Tab",
+	    closeText: "",
+	    close: function(event, ui) {$(this).dialog('destroy').remove();},
+	    buttons: {
+		"OK": function () {
+		    IPython.notebook.delete_worksheet(index);
+		    $(this).dialog('close');
+		},
+		"Cancel": function () {
+		    $(this).dialog('close');
+		}
+	    }
+	})
+    }
+
+
+    IPython.TabManager = TabManager;
+
+    return IPython;
+
+}(IPython));
+

--- a/IPython/frontend/html/notebook/static/js/worksheet.js
+++ b/IPython/frontend/html/notebook/static/js/worksheet.js
@@ -1,0 +1,860 @@
+//----------------------------------------------------------------------------
+//  Copyright (C) 2008-2011  The IPython Development Team
+//
+//  Distributed under the terms of the BSD License.  The full license is in
+//  the file COPYING, distributed as part of this software.
+//----------------------------------------------------------------------------
+
+//============================================================================
+// Worksheet
+//============================================================================
+
+var IPython = (function (IPython) {
+
+    var utils = IPython.utils;
+    var key   = IPython.utils.keycodes;
+
+    var Worksheet = function (element, name, kernel) {
+        this.read_only = IPython.read_only;
+        this.element = element;
+        this.element.data("worksheet", this);
+        this.next_prompt_number = 1;
+        this.kernel = kernel;
+        this.clipboard = null;
+        this.paste_enabled = false;
+        this.dirty = false;
+        this.metadata = {name: name};
+        this.style();
+	this.worksheet_id = this.element.attr('id');
+        this.create_elements();
+        this.bind_events();
+    };
+
+
+    Worksheet.prototype.style = function () {
+    };
+
+    Worksheet.prototype.create_elements = function () {
+        // We add this end_space div to the end of the notebook div to:
+        // i) provide a margin between the last cell and the end of the notebook
+        // ii) to prevent the div from scrolling up when the last cell is being
+        // edited, but is too low on the page, which browsers will do automatically.
+        var that = this;
+        var end_space = $('<div/>').addClass('end_space').height("30%");
+        end_space.dblclick(function (e) {
+            if (that.read_only) return;
+            var ncells = that.ncells();
+            that.insert_cell_below('code',ncells-1);
+        });
+        this.element.append(end_space);
+    };
+
+
+    Worksheet.prototype.bind_events = function () {
+	var that = this;
+
+        $([IPython.events]).on('set_next_input.Worksheet', function (event, data) {
+            var index = that.find_cell_index(data.cell);
+            var new_cell = that.insert_cell_below('code',index);
+            new_cell.set_text(data.text);
+            that.dirty = true;
+        });
+
+	$([IPython.events]).on('set_dirty.Worksheet', function (event, data) {
+            that.dirty = data.value;
+        });
+
+        $([IPython.events]).on('select.Cell', function (event, data) {
+            var index = that.find_cell_index(data.cell);
+            that.select(index);
+        });
+
+    };
+
+
+    Worksheet.prototype.scroll_to_bottom = function () {
+        this.element.animate({scrollTop:this.element.get(0).scrollHeight}, 0);
+    };
+
+
+    Worksheet.prototype.scroll_to_top = function () {
+        this.element.animate({scrollTop:0}, 0);
+    };
+
+    // Cell indexing, retrieval, etc.
+
+    Worksheet.prototype.get_cell_elements = function () {
+        return this.element.children("div.cell");
+    };
+
+
+    Worksheet.prototype.get_cell_element = function (index) {
+        var result = null;
+        var e = this.get_cell_elements().eq(index);
+        if (e.length !== 0) {
+            result = e;
+        }
+        return result;
+    };
+
+
+    Worksheet.prototype.ncells = function () {
+        return this.get_cell_elements().length;
+    };
+
+
+    // TODO: we are often calling cells as cells()[i], which we should optimize
+    // to cells(i) or a new method.
+    Worksheet.prototype.get_cells = function () {
+        return this.get_cell_elements().toArray().map(function (e) {
+            return $(e).data("cell");
+        });
+    };
+
+
+    Worksheet.prototype.get_cell = function (index) {
+        var result = null;
+        var ce = this.get_cell_element(index);
+        if (ce !== null) {
+            result = ce.data('cell');
+        }
+        return result;
+    }
+
+
+    Worksheet.prototype.get_next_cell = function (cell) {
+        var result = null;
+        var index = this.find_cell_index(cell);
+        if (index !== null && index < this.ncells()) {
+            result = this.get_cell(index+1);
+        }
+        return result;
+    }
+
+
+    Worksheet.prototype.get_prev_cell = function (cell) {
+        var result = null;
+        var index = this.find_cell_index(cell);
+        if (index !== null && index > 1) {
+            result = this.get_cell(index-1);
+        }
+        return result;
+    }
+
+    Worksheet.prototype.find_cell_index = function (cell) {
+        var result = null;
+        this.get_cell_elements().filter(function (index) {
+            if ($(this).data("cell") === cell) {
+                result = index;
+            };
+        });
+        return result;
+    };
+
+
+    Worksheet.prototype.index_or_selected = function (index) {
+        var i;
+        if (index === undefined || index === null) {
+            i = this.get_selected_index();
+            if (i === null) {
+                i = 0;
+            }
+        } else {
+            i = index;
+        }
+        return i;
+    };
+
+
+    Worksheet.prototype.get_selected_cell = function () {
+        var index = this.get_selected_index();
+        return this.get_cell(index);
+    };
+
+
+    Worksheet.prototype.is_valid_cell_index = function (index) {
+        if (index !== null && index >= 0 && index < this.ncells()) {
+            return true;
+        } else {
+            return false;
+        };
+    }
+
+    Worksheet.prototype.get_selected_index = function () {
+        var result = null;
+        this.get_cell_elements().filter(function (index) {
+            if ($(this).data("cell").selected === true) {
+                result = index;
+            };
+        });
+        return result;
+    };
+
+
+    // Cell selection.
+
+    Worksheet.prototype.select = function (index) {
+        if (index !== undefined && index >= 0 && index < this.ncells()) {
+            sindex = this.get_selected_index()
+            if (sindex !== null && index !== sindex) {
+                this.get_cell(sindex).unselect();
+            };
+            var cell = this.get_cell(index)
+            cell.select();
+            if (cell.cell_type === 'heading') {
+                $([IPython.events]).trigger('selected_cell_type_changed.Worksheet',
+                    {'cell_type':cell.cell_type,level:cell.level}
+                );
+            } else {
+                $([IPython.events]).trigger('selected_cell_type_changed.Worksheet',
+                    {'cell_type':cell.cell_type}
+                );
+            };
+        };
+        return this;
+    };
+
+
+    Worksheet.prototype.select_next = function () {
+        var index = this.get_selected_index();
+        if (index !== null && index >= 0 && (index+1) < this.ncells()) {
+            this.select(index+1);
+        };
+        return this;
+    };
+
+
+    Worksheet.prototype.select_prev = function () {
+        var index = this.get_selected_index();
+        if (index !== null && index >= 0 && (index-1) < this.ncells()) {
+            this.select(index-1);
+        };
+        return this;
+    };
+
+
+    // Cell movement
+
+    Worksheet.prototype.move_cell_up = function (index) {
+        var i = this.index_or_selected();
+        if (i !== null && i < this.ncells() && i > 0) {
+            var pivot = this.get_cell_element(i-1);
+            var tomove = this.get_cell_element(i);
+            if (pivot !== null && tomove !== null) {
+                tomove.detach();
+                pivot.before(tomove);
+                this.select(i-1);
+            };
+        };
+        this.dirty = true;
+        return this;
+    };
+
+
+    Worksheet.prototype.move_cell_down = function (index) {
+        var i = this.index_or_selected();
+        if (i !== null && i < (this.ncells()-1) && i >= 0) {
+            var pivot = this.get_cell_element(i+1);
+            var tomove = this.get_cell_element(i);
+            if (pivot !== null && tomove !== null) {
+                tomove.detach();
+                pivot.after(tomove);
+                this.select(i+1);
+            };
+        };
+        this.dirty = true;
+        return this;
+    };
+
+
+    Worksheet.prototype.sort_cells = function () {
+        // This is not working right now. Calling this will actually crash
+        // the browser. I think there is an infinite loop in here...
+        var ncells = this.ncells();
+        var sindex = this.get_selected_index();
+        var swapped;
+        do {
+            swapped = false;
+            for (var i=1; i<ncells; i++) {
+                current = this.get_cell(i);
+                previous = this.get_cell(i-1);
+                if (previous.input_prompt_number > current.input_prompt_number) {
+                    this.move_cell_up(i);
+                    swapped = true;
+                };
+            };
+        } while (swapped);
+        this.select(sindex);
+        return this;
+    };
+
+    // Insertion, deletion.
+
+    Worksheet.prototype.delete_cell = function (index) {
+        var i = this.index_or_selected(index);
+        if (this.is_valid_cell_index(i)) {
+            var ce = this.get_cell_element(i);
+            ce.remove();
+            if (i === (this.ncells())) {
+                this.select(i-1);
+            } else {
+                this.select(i);
+            };
+            this.dirty = true;
+        };
+        return this;
+    };
+
+
+    Worksheet.prototype.insert_cell_below = function (type, index) {
+        // type = ('code','html','markdown')
+        // index = cell index or undefined to insert below selected
+        index = this.index_or_selected(index);
+        var cell = null;
+        if (this.ncells() === 0 || this.is_valid_cell_index(index)) {
+            if (type === 'code') {
+                cell = new IPython.CodeCell(this.kernel);
+                cell.set_input_prompt();
+            } else if (type === 'markdown') {
+                cell = new IPython.MarkdownCell();
+            } else if (type === 'html') {
+                cell = new IPython.HTMLCell();
+            } else if (type === 'raw') {
+                cell = new IPython.RawCell();
+            } else if (type === 'heading') {
+                cell = new IPython.HeadingCell();
+            };
+            if (cell !== null) {
+                if (this.ncells() === 0) {
+                    this.element.find('div.end_space').before(cell.element);
+                } else if (this.is_valid_cell_index(index)) {
+                    this.get_cell_element(index).after(cell.element);
+                };
+                cell.render();
+                this.select(this.find_cell_index(cell));
+                this.dirty = true;
+                return cell;
+            };
+        };
+        return cell;
+    };
+
+
+    Worksheet.prototype.insert_cell_above = function (type, index) {
+        // type = ('code','html','markdown')
+        // index = cell index or undefined to insert above selected
+        index = this.index_or_selected(index);
+        var cell = null;
+        if (this.ncells() === 0 || this.is_valid_cell_index(index)) {
+            if (type === 'code') {
+                cell = new IPython.CodeCell(this.kernel);
+                cell.set_input_prompt();
+            } else if (type === 'markdown') {
+                cell = new IPython.MarkdownCell();
+            } else if (type === 'html') {
+                cell = new IPython.HTMLCell();
+            } else if (type === 'raw') {
+                cell = new IPython.RawCell();
+            } else if (type === 'heading') {
+                cell = new IPython.HeadingCell();
+            };
+            if (cell !== null) {
+                if (this.ncells() === 0) {
+                    this.element.find('div.end_space').before(cell.element);
+                } else if (this.is_valid_cell_index(index)) {
+                    this.get_cell_element(index).before(cell.element);
+                };
+                cell.render();
+                this.select(this.find_cell_index(cell));
+                this.dirty = true;
+                return cell;
+            };
+        };
+        return cell;
+    };
+
+
+    Worksheet.prototype.to_code = function (index) {
+        var i = this.index_or_selected(index);
+        if (this.is_valid_cell_index(i)) {
+            var source_element = this.get_cell_element(i);
+            var source_cell = source_element.data("cell");
+            if (!(source_cell instanceof IPython.CodeCell)) {
+                target_cell = this.insert_cell_below('code',i);
+                var text = source_cell.get_text();
+                if (text === source_cell.placeholder) {
+                    text = '';
+                }
+                target_cell.set_text(text);
+                // make this value the starting point, so that we can only undo
+                // to this state, instead of a blank cell
+                target_cell.code_mirror.clearHistory();
+                source_element.remove();
+                this.dirty = true;
+            };
+        };
+    };
+
+
+    Worksheet.prototype.to_markdown = function (index) {
+        var i = this.index_or_selected(index);
+        if (this.is_valid_cell_index(i)) {
+            var source_element = this.get_cell_element(i);
+            var source_cell = source_element.data("cell");
+            if (!(source_cell instanceof IPython.MarkdownCell)) {
+                target_cell = this.insert_cell_below('markdown',i);
+                var text = source_cell.get_text();
+                if (text === source_cell.placeholder) {
+                    text = '';
+                };
+                // The edit must come before the set_text.
+                target_cell.edit();
+                target_cell.set_text(text);
+                // make this value the starting point, so that we can only undo
+                // to this state, instead of a blank cell
+                target_cell.code_mirror.clearHistory();
+                source_element.remove();
+                this.dirty = true;
+            };
+        };
+    };
+
+
+    Worksheet.prototype.to_html = function (index) {
+        var i = this.index_or_selected(index);
+        if (this.is_valid_cell_index(i)) {
+            var source_element = this.get_cell_element(i);
+            var source_cell = source_element.data("cell");
+            var target_cell = null;
+            if (!(source_cell instanceof IPython.HTMLCell)) {
+                target_cell = this.insert_cell_below('html',i);
+                var text = source_cell.get_text();
+                if (text === source_cell.placeholder) {
+                    text = '';
+                };
+                // The edit must come before the set_text.
+                target_cell.edit();
+                target_cell.set_text(text);
+                // make this value the starting point, so that we can only undo
+                // to this state, instead of a blank cell
+                target_cell.code_mirror.clearHistory();
+                source_element.remove();
+                this.dirty = true;
+            };
+        };
+    };
+
+
+    Worksheet.prototype.to_raw = function (index) {
+        var i = this.index_or_selected(index);
+        if (this.is_valid_cell_index(i)) {
+            var source_element = this.get_cell_element(i);
+            var source_cell = source_element.data("cell");
+            var target_cell = null;
+            if (!(source_cell instanceof IPython.RawCell)) {
+                target_cell = this.insert_cell_below('raw',i);
+                var text = source_cell.get_text();
+                if (text === source_cell.placeholder) {
+                    text = '';
+                };
+                // The edit must come before the set_text.
+                target_cell.edit();
+                target_cell.set_text(text);
+                // make this value the starting point, so that we can only undo
+                // to this state, instead of a blank cell
+                target_cell.code_mirror.clearHistory();
+                source_element.remove();
+                this.dirty = true;
+            };
+        };
+    };
+
+
+    Worksheet.prototype.to_heading = function (index, level) {
+        level = level || 1;
+        var i = this.index_or_selected(index);
+        if (this.is_valid_cell_index(i)) {
+            var source_element = this.get_cell_element(i);
+            var source_cell = source_element.data("cell");
+            var target_cell = null;
+            if (source_cell instanceof IPython.HeadingCell) {
+                source_cell.set_level(level);
+            } else {
+                target_cell = this.insert_cell_below('heading',i);
+                var text = source_cell.get_text();
+                if (text === source_cell.placeholder) {
+                    text = '';
+                };
+                // The edit must come before the set_text.
+                target_cell.set_level(level);
+                target_cell.edit();
+                target_cell.set_text(text);
+                // make this value the starting point, so that we can only undo
+                // to this state, instead of a blank cell
+                target_cell.code_mirror.clearHistory();
+                source_element.remove();
+                this.dirty = true;
+            };
+            $([IPython.events]).trigger('selected_cell_type_changed.Worksheet',
+                {'cell_type':'heading',level:level}
+            );
+        };
+    };
+
+
+    // Cut/Copy/Paste
+
+    Worksheet.prototype.enable_paste = function () {
+        var that = this;
+        if (!this.paste_enabled) {
+            $('#paste_cell').removeClass('ui-state-disabled')
+                .on('click', function () {that.paste_cell();});
+            $('#paste_cell_above').removeClass('ui-state-disabled')
+                .on('click', function () {that.paste_cell_above();});
+            $('#paste_cell_below').removeClass('ui-state-disabled')
+                .on('click', function () {that.paste_cell_below();});
+            this.paste_enabled = true;
+        };
+    };
+
+
+    Worksheet.prototype.disable_paste = function () {
+        if (this.paste_enabled) {
+            $('#paste_cell').addClass('ui-state-disabled').off('click');
+            $('#paste_cell_above').addClass('ui-state-disabled').off('click');
+            $('#paste_cell_below').addClass('ui-state-disabled').off('click');
+            this.paste_enabled = false;
+        };
+    };
+
+
+    Worksheet.prototype.cut_cell = function () {
+        this.copy_cell();
+        this.delete_cell();
+    }
+
+    Worksheet.prototype.copy_cell = function () {
+        var cell = this.get_selected_cell();
+        this.clipboard = cell.toJSON();
+        this.enable_paste();
+    };
+
+
+    Worksheet.prototype.paste_cell = function () {
+        if (this.clipboard !== null && this.paste_enabled) {
+            var cell_data = this.clipboard;
+            var new_cell = this.insert_cell_above(cell_data.cell_type);
+            new_cell.fromJSON(cell_data);
+            old_cell = this.get_next_cell(new_cell);
+            this.delete_cell(this.find_cell_index(old_cell));
+            this.select(this.find_cell_index(new_cell));
+        };
+    };
+
+
+    Worksheet.prototype.paste_cell_above = function () {
+        if (this.clipboard !== null && this.paste_enabled) {
+            var cell_data = this.clipboard;
+            var new_cell = this.insert_cell_above(cell_data.cell_type);
+            new_cell.fromJSON(cell_data);
+        };
+    };
+
+
+    Worksheet.prototype.paste_cell_below = function () {
+        if (this.clipboard !== null && this.paste_enabled) {
+            var cell_data = this.clipboard;
+            var new_cell = this.insert_cell_below(cell_data.cell_type);
+            new_cell.fromJSON(cell_data);
+        };
+    };
+
+
+    // Split/merge
+
+    Worksheet.prototype.split_cell = function () {
+        // Todo: implement spliting for other cell types.
+        var cell = this.get_selected_cell();
+        if (cell.is_splittable()) {
+            texta = cell.get_pre_cursor();
+            textb = cell.get_post_cursor();
+            if (cell instanceof IPython.CodeCell) {
+                cell.set_text(texta);
+                var new_cell = this.insert_cell_below('code');
+                new_cell.set_text(textb);
+            } else if (cell instanceof IPython.MarkdownCell) {
+                cell.set_text(texta);
+                cell.render();
+                var new_cell = this.insert_cell_below('markdown');
+                new_cell.edit(); // editor must be visible to call set_text
+                new_cell.set_text(textb);
+                new_cell.render();
+            } else if (cell instanceof IPython.HTMLCell) {
+                cell.set_text(texta);
+                cell.render();
+                var new_cell = this.insert_cell_below('html');
+                new_cell.edit(); // editor must be visible to call set_text
+                new_cell.set_text(textb);
+                new_cell.render();
+            };
+        };
+    };
+
+
+    Worksheet.prototype.merge_cell_above = function () {
+        var index = this.get_selected_index();
+        var cell = this.get_cell(index);
+        if (index > 0) {
+            upper_cell = this.get_cell(index-1);
+            upper_text = upper_cell.get_text();
+            text = cell.get_text();
+            if (cell instanceof IPython.CodeCell) {
+                cell.set_text(upper_text+'\n'+text);
+            } else if (cell instanceof IPython.MarkdownCell || cell instanceof IPython.HTMLCell) {
+                cell.edit();
+                cell.set_text(upper_text+'\n'+text);
+                cell.render();
+            };
+            this.delete_cell(index-1);
+            this.select(this.find_cell_index(cell));
+        };
+    };
+
+
+    Worksheet.prototype.merge_cell_below = function () {
+        var index = this.get_selected_index();
+        var cell = this.get_cell(index);
+        if (index < this.ncells()-1) {
+            lower_cell = this.get_cell(index+1);
+            lower_text = lower_cell.get_text();
+            text = cell.get_text();
+            if (cell instanceof IPython.CodeCell) {
+                cell.set_text(text+'\n'+lower_text);
+            } else if (cell instanceof IPython.MarkdownCell || cell instanceof IPython.HTMLCell) {
+                cell.edit();
+                cell.set_text(text+'\n'+lower_text);
+                cell.render();
+            };
+            this.delete_cell(index+1);
+            this.select(this.find_cell_index(cell));
+        };
+    };
+
+
+    // Cell collapsing and output clearing
+
+    Worksheet.prototype.collapse = function (index) {
+        var i = this.index_or_selected(index);
+        this.get_cell(i).collapse();
+        this.dirty = true;
+    };
+
+
+    Worksheet.prototype.expand = function (index) {
+        var i = this.index_or_selected(index);
+        this.get_cell(i).expand();
+        this.dirty = true;
+    };
+
+
+    Worksheet.prototype.toggle_output = function (index) {
+        var i = this.index_or_selected(index);
+        this.get_cell(i).toggle_output();
+        this.dirty = true;
+    };
+
+
+    Worksheet.prototype.toggle_output_scroll = function (index) {
+        var i = this.index_or_selected(index);
+        this.get_cell(i).toggle_output_scroll();
+    };
+
+
+    Worksheet.prototype.collapse_all_output = function () {
+        var ncells = this.ncells();
+        var cells = this.get_cells();
+        for (var i=0; i<ncells; i++) {
+            if (cells[i] instanceof IPython.CodeCell) {
+                cells[i].output_area.collapse();
+            }
+        };
+        // this should not be set if the `collapse` key is removed from nbformat
+        this.dirty = true;
+    };
+
+
+    Worksheet.prototype.scroll_all_output = function () {
+        var ncells = this.ncells();
+        var cells = this.get_cells();
+        for (var i=0; i<ncells; i++) {
+            if (cells[i] instanceof IPython.CodeCell) {
+                cells[i].output_area.expand();
+                cells[i].output_area.scroll_if_long(20);
+            }
+        };
+        // this should not be set if the `collapse` key is removed from nbformat
+        this.dirty = true;
+    };
+
+
+    Worksheet.prototype.expand_all_output = function () {
+        var ncells = this.ncells();
+        var cells = this.get_cells();
+        for (var i=0; i<ncells; i++) {
+            if (cells[i] instanceof IPython.CodeCell) {
+                cells[i].output_area.expand();
+                cells[i].output_area.unscroll_area();
+            }
+        };
+        // this should not be set if the `collapse` key is removed from nbformat
+        this.dirty = true;
+    };
+
+
+    Worksheet.prototype.clear_all_output = function () {
+        var ncells = this.ncells();
+        var cells = this.get_cells();
+        for (var i=0; i<ncells; i++) {
+            if (cells[i] instanceof IPython.CodeCell) {
+                cells[i].clear_output(true,true,true);
+                // Make all In[] prompts blank, as well
+                // TODO: make this configurable (via checkbox?)
+                cells[i].set_input_prompt();
+            }
+        };
+        this.dirty = true;
+    };
+
+
+    // Other cell functions: line numbers, ...
+
+    Worksheet.prototype.cell_toggle_line_numbers = function() {
+        this.get_selected_cell().toggle_line_numbers();
+    };
+
+
+    // Refresh code mirror for all cells in worksheet
+    Worksheet.prototype.refresh_code_mirror = function() {
+	var cells = this.get_cells();
+	for (var i=0; i<cells.length; i++) {
+	    cells[i].refresh();
+	}
+    }
+
+
+    // Kernel related things
+
+    Worksheet.prototype.set_kernel = function (kernel) {
+	this.kernel = kernel;
+	// Now that the kernel has been created, tell the CodeCells about it.
+        var ncells = this.ncells();
+        for (var i=0; i<ncells; i++) {
+            var cell = this.get_cell(i);
+            if (cell instanceof IPython.CodeCell) {
+                cell.set_kernel(this.kernel)
+            };
+        };
+    }
+
+    Worksheet.prototype.execute_selected_cell = function (options) {
+        // add_new: should a new cell be added if we are at the end of the nb
+        // terminal: execute in terminal mode, which stays in the current cell
+        default_options = {terminal: false, add_new: true};
+        $.extend(default_options, options);
+        var that = this;
+        var cell = that.get_selected_cell();
+        var cell_index = that.find_cell_index(cell);
+        if (cell instanceof IPython.CodeCell) {
+            cell.execute();
+        } else if (cell instanceof IPython.HTMLCell) {
+            cell.render();
+        }
+        if (default_options.terminal) {
+            cell.select_all();
+        } else {
+            if ((cell_index === (that.ncells()-1)) && default_options.add_new) {
+                that.insert_cell_below('code');
+                // If we are adding a new cell at the end, scroll down to show it.
+                that.scroll_to_bottom();
+            } else {
+                that.select(cell_index+1);
+            };
+        };
+        this.dirty = true;
+    };
+
+
+    Worksheet.prototype.execute_all_cells = function () {
+        var ncells = this.ncells();
+        for (var i=0; i<ncells; i++) {
+            this.select(i);
+            this.execute_selected_cell({add_new:false});
+        };
+        this.scroll_to_bottom();
+    };
+
+    // Persistance and loading
+
+    Worksheet.prototype.get_worksheet_id = function () {
+	return this.worksheet_id;
+    };
+
+    Worksheet.prototype.get_worksheet_name = function () {
+	return this.metadata.name;
+    };
+
+    Worksheet.prototype.set_worksheet_name = function (name) {
+	this.metadata.name = name;
+    }
+
+
+    Worksheet.prototype.fromJSON = function (data) {
+        var ncells = this.ncells();
+        var i;
+        for (i=0; i<ncells; i++) {
+            // Always delete cell 0 as they get renumbered as they are deleted.
+            this.delete_cell(0);
+        };
+        // Save the metadata and name.
+        if(data.metadata !== undefined) {
+	    this.metadata = data.metadata;
+	}
+        var new_cells = data.cells;
+        ncells = new_cells.length;
+        var cell_data = null;
+        var new_cell = null;
+        for (i=0; i<ncells; i++) {
+            cell_data = new_cells[i];
+            // VERSIONHACK: plaintext -> raw
+            // handle never-released plaintext name for raw cells
+            if (cell_data.cell_type === 'plaintext'){
+                cell_data.cell_type = 'raw';
+            }
+            
+            new_cell = this.insert_cell_below(cell_data.cell_type);
+            new_cell.fromJSON(cell_data);
+        };
+    };
+
+
+    Worksheet.prototype.toJSON = function () {
+        var cells = this.get_cells();
+        var ncells = cells.length;
+        var cell_array = new Array(ncells);
+        for (var i=0; i<ncells; i++) {
+            cell_array[i] = cells[i].toJSON();
+        };
+        var data = {
+            cells: cell_array,
+            metadata: this.metadata
+        };
+        return data;
+    };
+    
+    IPython.Worksheet = Worksheet;
+
+
+    return IPython;
+
+}(IPython));
+

--- a/IPython/frontend/html/notebook/static/less/notebook.less
+++ b/IPython/frontend/html/notebook/static/less/notebook.less
@@ -142,13 +142,43 @@ div#notebook_panel {
 }
 
 div#notebook {
-    overflow-y: scroll;
-    overflow-x: auto;
+    margin: 0px 0px 0px 0px;
+    padding: 0px;
     width: 100%;
-    /* This spaces the cell away from the edge of the notebook area */
-    padding: 5px 5px 15px 5px;
-    margin: 0px;
 }
+
+/* Keep scrollbar inside tab panel so that tabs stay fixed as you scroll */
+.container {
+    width: 100%;
+}
+
+.panel {
+    overflow: auto;
+}
+
+.ui-icon-close {
+    cursor: pointer;
+}
+
+/* Remove header background for tabs: http://keith-wood.name/uiTabs.html */
+#tabs {
+    padding: 0px;
+    background: none;
+    border-width: 0px;
+}
+#tabs .ui-tabs-nav {
+    padding-left: 5px;
+    background: transparent;
+    border-width: 0px 0px 1px 0px;
+    -moz-border-radius: 0px;
+    -webkit-border-radius: 0px;
+    border-radius: 0px;
+}
+#tabs .ui-tabs-panel {
+    border-width: 0px 1px 1px 1px;
+}
+
+
 
 div#pager_splitter {
     height: 8px;

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -88,6 +88,8 @@ class="notebook_app"
                 <hr/>
                 <li id="select_previous"><a href="#">Select Previous Cell</a></li>
                 <li id="select_next"><a href="#">Select Next Cell</a></li>
+                <hr/>
+                <li id="delete_worksheet"><a href="#">Delete Sheet</a></li>
             </ul>
         </li>
         <li><a href="#">View</a>
@@ -98,6 +100,9 @@ class="notebook_app"
         </li>
         <li><a href="#">Insert</a>
             <ul>
+                <li id="insert_worksheet_above"><a href="#">Insert Sheet Before</a></li>
+                <li id="insert_worksheet_below"><a href="#">Insert Sheet After</a></li>
+                <hr/>
                 <li id="insert_cell_above"><a href="#">Insert Cell Above</a></li>
                 <li id="insert_cell_below"><a href="#">Insert Cell Below</a></li>
             </ul>
@@ -163,7 +168,12 @@ class="notebook_app"
 <div id="ipython-main-app">
 
     <div id="notebook_panel">
-        <div id="notebook"></div>
+        <div id="notebook">
+          <div id="tabs">
+            <ul>
+            </ul>
+          </div>
+        </div>
         <div id="pager_splitter"></div>
         <div id="pager_container">
             <div id='pager_button_area'>
@@ -219,10 +229,11 @@ class="notebook_app"
 <script src="{{ static_url("js/notebook.js") }}" type="text/javascript" charset="utf-8"></script>
 <script src="{{ static_url("js/notificationwidget.js") }}" type="text/javascript" charset="utf-8"></script>
 <script src="{{ static_url("js/notificationarea.js") }}" type="text/javascript" charset="utf-8"></script>
+<script src="{{ static_url("js/tabmanager.js") }}" type="text/javascript" charset="utf-8"></script>
 <script src="{{ static_url("js/tooltip.js") }}" type="text/javascript" charset="utf-8"></script>
 <script src="{{ static_url("js/config.js") }}" type="text/javascript" charset="utf-8"></script>
 <script src="{{ static_url("js/notebookmain.js") }}" type="text/javascript" charset="utf-8"></script>
-
+<script src="{{ static_url("js/worksheet.js") }}" type="text/javascript" charset="utf-8"></script>
 <script src="{{ static_url("js/contexthint.js") }}" charset="utf-8"></script>
 
 <script src="{{ static_url("js/celltoolbarpresets/default.js") }}" type="text/javascript" charset="utf-8"></script>


### PR DESCRIPTION
This version is a WIP. The commit is supposed to reflect @dlsun's original implementation as closely as possible and we can move on from there. I modified the author to give Dennis proper credit. I'm happy to do a bit more work on this, but I thought I'd advertise now to get feedback on the UI.

Is the right place to discuss this PR on issue #1905?  The code is pretty much unchanged from Daniel's implementation, which is PR #2206  There are some good comments on that PR, which I wish could be transferred here somehow.

Here's a mini-todo list, reflecting what still needs to be done and aggregating other's comments.
- fix regressions/finish rebase:
  - [ ] fix delete cell, insert cell at bottom, below, above, 
  - [ ] fix undelete sheet, cell
  - [ ] fix execute all cells in worksheet, execute range of cells in a worksheet
  - [ ] loaded notebooks intialize as "dirty" and ask if user is sure they want to navigate away on tab close
- suggestions from other two issues
  - [ ] I can't repro @Carreau's [issue](https://github.com/ipython/ipython/pull/2206#issuecomment-7351376), but it should be checked
  - [ ] the tabs take up a ton of space and change in size when hovered/editing. Consider different UI?
- my suggestions
  - execute all worksheets? (following ordering of the worksheets themselves)
  - integrate tabs with one of the existing toolbars (they'd have to be smaller) or switch to a dropdown for them
  - have to think about how the worksheets should integrate with the slides work that's ongoing.  If that work hadn't started yet, I would have said that there's a presentation mode where a slide <==> worksheet.  I haven't followed the slide work so I don't know how it would integrate.
