### PR TITLE
Respect DB_IP and DB_PORT in mongodb tests

### DIFF
--- a/IPython/parallel/tests/test_mongodb.py
+++ b/IPython/parallel/tests/test_mongodb.py
@@ -16,6 +16,8 @@ Authors:
 # Imports
 #-------------------------------------------------------------------------------
 
+import os
+
 from unittest import TestCase
 
 from nose import SkipTest
@@ -25,8 +27,14 @@ from IPython.parallel.controller.mongodb import MongoDB
 
 from . import test_db
 
+conn_kwargs = {}
+if 'DB_IP' in os.environ:
+    conn_kwargs['host'] = os.environ['DB_IP']
+if 'DB_PORT' in os.environ:
+    conn_kwargs['port'] = int(os.environ['DB_PORT'])
+
 try:
-    c = Connection()
+    c = Connection(**conn_kwargs)
 except Exception:
     c=None
 


### PR DESCRIPTION
It is usually preferred to run tests on a test-local database with dedicated mongod instance rather than using the system-wide database. In order to support that, an easy way of providing the proper port is handy.

For example, pymongo test suite uses `DB_IP` and `DB_PORT` environment variables to allow providing an alternate mongod instance. Using the same variable names in IPython's test suite seems like a good idea.
