### PR TITLE
added small config section to notebook docs page

### DIFF
--- a/docs/source/interactive/htmlnotebook.txt
+++ b/docs/source/interactive/htmlnotebook.txt
@@ -252,9 +252,14 @@ To see a list of available options ehter:
   $ ipython help notebook
 
 Defaults for these options can also be set by creating a file named 
-ipython_notebook_config.py in you IPython profile folder. The profile folder is
+ipython_notebook_config.py in your IPython profile folder. The profile folder is
 a subfolder of your IPython directory (`ipython locate` will show you where that
 is). 
+
+.. seealso:
+
+    :ref:`config_overview`, in particular :ref:`Profiles`.
+
 
 Keyboard use
 ------------

--- a/docs/source/interactive/htmlnotebook.txt
+++ b/docs/source/interactive/htmlnotebook.txt
@@ -247,14 +247,17 @@ Configuration
 -------------
 
 The IPython notebook server can be run with a variety of command line arguments. 
-To see a list of available options ehter:
+To see a list of available options enter:
 
-  $ ipython help notebook
+  $ ipython notebook --help 
 
 Defaults for these options can also be set by creating a file named 
 ipython_notebook_config.py in your IPython profile folder. The profile folder is
 a subfolder of your IPython directory (`ipython locate` will show you where that
-is). 
+is). To create default configuration files (with lots of info on available 
+options) use:
+
+  $ ipython profile create
 
 .. seealso:
 

--- a/docs/source/interactive/htmlnotebook.txt
+++ b/docs/source/interactive/htmlnotebook.txt
@@ -243,6 +243,19 @@ and then on any cell that you need to protect, use::
   if script:
     # rest of the cell...
 
+Configuration
+-------------
+
+The IPython notebook server can be run with a variety of command line arguments. 
+To see a list of available options ehter:
+
+  $ ipython help notebook
+
+Defaults for these options can also be set by creating a file named 
+ipython_notebook_config.py in you IPython profile folder. The profile folder is
+a subfolder of your IPython directory (`ipython locate` will show you where that
+is). 
+
 Keyboard use
 ------------
 


### PR DESCRIPTION
I had trouble finding out how to configure notebook (I hadn't used IPython before), so I added a small section to the notebook docs page with a brief description of what/how to configure, and links to the overall IPython configuration page.

There should probably be mention of configuring notebook in the 'configuration overview' page... 
