### PR TITLE
safe_run_module: Silence SystemExit codes 0 and None.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2483,7 +2483,7 @@ class InteractiveShell(SingletonConfigurable):
                 # explicitly silenced, but only in short form.
                 if kw['raise_exceptions']:
                     raise
-                if status.code not in (0, None) and not kw['exit_ignore']:
+                if status.code and not kw['exit_ignore']:
                     self.showtraceback(exception_only=True)
             except:
                 if kw['raise_exceptions']:
@@ -2532,6 +2532,8 @@ class InteractiveShell(SingletonConfigurable):
         This version will never throw an exception, but instead print
         helpful error messages to the screen.
 
+        `SystemExit` exceptions with status code 0 or None are ignored.
+
         Parameters
         ----------
         mod_name : string
@@ -2540,10 +2542,14 @@ class InteractiveShell(SingletonConfigurable):
             The globals namespace.
         """
         try:
-            where.update(
-                runpy.run_module(str(mod_name), run_name="__main__",
-                                 alter_sys=True)
-                )
+            try:
+                where.update(
+                    runpy.run_module(str(mod_name), run_name="__main__",
+                                     alter_sys=True)
+                    )
+            except SystemExit as status:
+                if status.code:
+                    raise
         except:
             self.showtraceback()
             warn('Unknown failure executing module: <%s>' % mod_name)


### PR DESCRIPTION
In `safe_execfile` we ignore SystemExit exceptions with codes 0 and 1.  We don't do this for `safe_run_module` which leads to the following mismatch of tracebacks between Python and IPython:

```
$ cat > exit0.py
import sys
sys.exit(0)

$ python -m exit0

$ ipython -m exit0
---------------------------------------------------------------------------
SystemExit                                Traceback (most recent call last)
/usr/lib/python2.7/runpy.pyc in run_module(mod_name, init_globals, run_name, alter_sys)
    174     if alter_sys:
    175         return _run_module_code(code, init_globals, run_name,
--> 176                                 fname, loader, pkg_name)
    177     else:
    178         # Leave the sys module alone

/usr/lib/python2.7/runpy.pyc in _run_module_code(code, init_globals, mod_name, mod_fname, mod_loader, pkg_name)
     80         mod_globals = temp_module.module.__dict__
     81         _run_code(code, mod_globals, init_globals,
---> 82                   mod_name, mod_fname, mod_loader, pkg_name)
     83     # Copy the globals of the temporary module, as they
     84     # may be cleared when the temporary module goes away

/usr/lib/python2.7/runpy.pyc in _run_code(code, run_globals, init_globals, mod_name, mod_fname, mod_loader, pkg_name)
     70                        __loader__ = mod_loader,
     71                        __package__ = pkg_name)
---> 72     exec code in run_globals
     73     return run_globals
     74 

/tmp/exit0.py in <module>()
      1 import sys
----> 2 sys.exit(0)

SystemExit: 0
WARNING: Unknown failure executing module: <exit0>
```

The attached pull request silences SystemExit exceptions with codes 0 and None. 
