### PR TITLE
fix qtconsole history logic for end-of-line

### DIFF
--- a/IPython/frontend/qt/console/history_console_widget.py
+++ b/IPython/frontend/qt/console/history_console_widget.py
@@ -90,7 +90,7 @@ class HistoryConsoleWidget(ConsoleWidget):
             # and the cursor is at the end of the first line
             
             # check if we are at the end of the first line
-            c = self._get_prompt_cursor()
+            c = self._get_cursor()
             current_pos = c.position()
             c.movePosition(QtGui.QTextCursor.EndOfLine)
             at_eol = (c.position() == current_pos)

--- a/IPython/frontend/qt/console/history_console_widget.py
+++ b/IPython/frontend/qt/console/history_console_widget.py
@@ -88,9 +88,15 @@ class HistoryConsoleWidget(ConsoleWidget):
             # to the line up to the cursor is if we are already
             # in a simple scroll (no prefix),
             # and the cursor is at the end of the first line
-            first_line = input_buffer.split('\n', 1)[0]
+            
+            # check if we are at the end of the first line
+            c = self._get_prompt_cursor()
+            current_pos = c.position()
+            c.movePosition(QtGui.QTextCursor.EndOfLine)
+            at_eol = (c.position() == current_pos)
+            
             if self._history_index == len(self._history) or \
-                not (self._history_prefix == '' and col == len(first_line)) or \
+                not (self._history_prefix == '' and at_eol) or \
                 not (self._get_edited_history(self._history_index)[:col] == input_buffer[:col]):
                 self._history_prefix = input_buffer[:col]
 


### PR DESCRIPTION
EndOfLine may or may not mean the end of a full line when the line is longer
than the window. This commit uses the same logic to check as the actual move,
so it should be consistent.

closes #2943
