### PR TITLE
use istype on lists/tuples

### DIFF
--- a/IPython/kernel/zmq/serialize.py
+++ b/IPython/kernel/zmq/serialize.py
@@ -34,7 +34,8 @@ except:
 from IPython.utils import py3compat
 from IPython.utils.data import flatten
 from IPython.utils.pickleutil import (
-    can, uncan, can_sequence, uncan_sequence, CannedObject
+    can, uncan, can_sequence, uncan_sequence, CannedObject,
+    istype, sequence_types,
 )
 
 if py3compat.PY3:
@@ -91,11 +92,11 @@ def serialize_object(obj, buffer_threshold=MAX_BYTES, item_threshold=MAX_ITEMS):
     [bufs] : list of buffers representing the serialized object.
     """
     buffers = []
-    if isinstance(obj, (list, tuple)) and len(obj) < item_threshold:
+    if istype(obj, sequence_types) and len(obj) < item_threshold:
         cobj = can_sequence(obj)
         for c in cobj:
             buffers.extend(_extract_buffers(c, buffer_threshold))
-    elif isinstance(obj, dict) and len(obj) < item_threshold:
+    elif istype(obj, dict) and len(obj) < item_threshold:
         cobj = {}
         for k in sorted(obj.iterkeys()):
             c = can(obj[k])
@@ -129,7 +130,7 @@ def unserialize_object(buffers, g=None):
         # a zmq message
         pobj = bytes(pobj)
     canned = pickle.loads(pobj)
-    if isinstance(canned, (list, tuple)) and len(canned) < MAX_ITEMS:
+    if istype(canned, sequence_types) and len(canned) < MAX_ITEMS:
         for c in canned:
             _restore_buffers(c, bufs)
         newobj = uncan_sequence(canned, g)

--- a/IPython/kernel/zmq/tests/test_serialize.py
+++ b/IPython/kernel/zmq/tests/test_serialize.py
@@ -12,6 +12,7 @@
 #-------------------------------------------------------------------------------
 
 import pickle
+from collections import namedtuple
 
 import nose.tools as nt
 
@@ -186,10 +187,40 @@ def test_class_oldstyle():
     
     bufs = serialize_object(dict(C=C))
     canned = pickle.loads(bufs[0])
-    yield nt.assert_true(canned['C'], CannedClass)
+    yield nt.assert_true(isinstance(canned['C'], CannedClass))
     d, r = unserialize_object(bufs)
     C2 = d['C']
     yield nt.assert_equal(C2.a, C.a)
+
+@dec.parametric
+def test_tuple():
+    tup = (lambda x:x, 1)
+    bufs = serialize_object(tup)
+    canned = pickle.loads(bufs[0])
+    yield nt.assert_true(isinstance(canned, tuple))
+    t2, r = unserialize_object(bufs)
+    yield nt.assert_equal(t2[0](t2[1]), tup[0](tup[1]))
+
+point = namedtuple('point', 'x y')
+
+@dec.parametric
+def test_namedtuple():
+    p = point(1,2)
+    bufs = serialize_object(p)
+    canned = pickle.loads(bufs[0])
+    yield nt.assert_true(isinstance(canned, point))
+    p2, r = unserialize_object(bufs, globals())
+    yield nt.assert_equal(p2.x, p.x)
+    yield nt.assert_equal(p2.y, p.y)
+
+@dec.parametric
+def test_list():
+    lis = [lambda x:x, 1]
+    bufs = serialize_object(lis)
+    canned = pickle.loads(bufs[0])
+    yield nt.assert_true(isinstance(canned, list))
+    l2, r = unserialize_object(bufs)
+    yield nt.assert_equal(l2[0](l2[1]), lis[0](lis[1]))
 
 @dec.parametric
 def test_class_inheritance():

--- a/IPython/utils/pickleutil.py
+++ b/IPython/utils/pickleutil.py
@@ -18,7 +18,6 @@ __docformat__ = "restructuredtext en"
 import copy
 import logging
 import sys
-from collections import namedtuple
 from types import FunctionType
 
 try:

--- a/IPython/utils/pickleutil.py
+++ b/IPython/utils/pickleutil.py
@@ -18,6 +18,7 @@ __docformat__ = "restructuredtext en"
 import copy
 import logging
 import sys
+from collections import namedtuple
 from types import FunctionType
 
 try:
@@ -249,7 +250,7 @@ def can_class(obj):
 
 def can_dict(obj):
     """can the *values* of a dict"""
-    if isinstance(obj, dict):
+    if istype(obj, dict):
         newobj = {}
         for k, v in obj.iteritems():
             newobj[k] = can(v)
@@ -257,9 +258,11 @@ def can_dict(obj):
     else:
         return obj
 
+sequence_types = (list, tuple, set)
+
 def can_sequence(obj):
     """can the elements of a sequence"""
-    if isinstance(obj, (list, tuple)):
+    if istype(obj, sequence_types):
         t = type(obj)
         return t([can(i) for i in obj])
     else:
@@ -285,7 +288,7 @@ def uncan(obj, g=None):
     return obj
 
 def uncan_dict(obj, g=None):
-    if isinstance(obj, dict):
+    if istype(obj, dict):
         newobj = {}
         for k, v in obj.iteritems():
             newobj[k] = uncan(v,g)
@@ -294,7 +297,7 @@ def uncan_dict(obj, g=None):
         return obj
 
 def uncan_sequence(obj, g=None):
-    if isinstance(obj, (list, tuple)):
+    if istype(obj, sequence_types):
         t = type(obj)
         return t([uncan(i,g) for i in obj])
     else:


### PR DESCRIPTION
avoids catching and mistreating subclasses, such as namedtuples.
