### PR TITLE
fix logic for append_javascript

### DIFF
--- a/IPython/frontend/html/notebook/static/js/outputarea.js
+++ b/IPython/frontend/html/notebook/static/js/outputarea.js
@@ -331,8 +331,10 @@ var IPython = (function (IPython) {
         for(var type_i in OutputArea.display_order){
             var type = OutputArea.display_order[type_i];
             if(json[type] != undefined ){
-                if(type == 'javascript' && dynamic){
-                    this.append_javascript(json.javascript, element, dynamic);
+                if(type == 'javascript'){
+                    if (dynamic) {
+                        this.append_javascript(json.javascript, element, dynamic);
+                    }
                 } else {
                     this['append_'+type](json[type], element);
                 }


### PR DESCRIPTION
PR #2911 results in appending javascript even if dynamic is false, so in
current master all javascript outputs are actually run at load.
