### PR TITLE
time magic: shorten unnecessary output on windows

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -948,8 +948,10 @@ python-profiler package from non-free.""")
         cpu_user = end[0]-st[0]
         cpu_sys = end[1]-st[1]
         cpu_tot = cpu_user+cpu_sys
-        print "CPU times: user %s, sys: %s, total: %s" % \
-              (_format_time(cpu_user),_format_time(cpu_sys),_format_time(cpu_tot))
+        # On windows cpu_sys is always zero, so no new information to the next print 
+        if sys.platform != 'win32':
+            print "CPU times: user %s, sys: %s, total: %s" % \
+                (_format_time(cpu_user),_format_time(cpu_sys),_format_time(cpu_tot))
         print "Wall time: %s" % _format_time(wall_time)
         if tc > tc_min:
             print "Compiler : %s" % _format_time(tc)

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -283,15 +283,23 @@ def test_tb_syntaxerror():
 def test_time():
     ip = get_ipython()
     
-    with tt.AssertPrints("CPU times: user "):
+    with tt.AssertPrints("Wall time: "):
         ip.run_cell("%time None")
     
     ip.run_cell("def f(kmjy):\n"
                 "    %time print (2*kmjy)")
     
-    with tt.AssertPrints("CPU times: user "):
+    with tt.AssertPrints("Wall time: "):
         with tt.AssertPrints("hihi", suppress=False):
             ip.run_cell("f('hi')")
+
+
+@dec.skip_win32
+def test_time2():
+    ip = get_ipython()
+    
+    with tt.AssertPrints("CPU times: user "):
+        ip.run_cell("%time None")
 
 def test_doctest_mode():
     "Toggle doctest_mode twice, it should be a no-op and run without error"


### PR DESCRIPTION
On windows the detailed info (i.e. cpu time) is not available and
always reported as zero. The rest of the information is therefore
redundant with the next print (wall time) and can be omitted.
