### PR TITLE
shows entire session history when only startsess is given

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -748,7 +748,7 @@ class HistorySavingThread(threading.Thread):
 # To match, e.g. ~5/8-~2/3
 range_re = re.compile(r"""
 ((?P<startsess>~?\d+)/)?
-(?P<start>\d+)                    # Only the start line num is compulsory
+(?P<start>\d+)?
 ((?P<sep>[\-:])
  ((?P<endsess>~?\d+)/)?
  (?P<end>\d+))?
@@ -767,9 +767,18 @@ def extract_hist_ranges(ranges_str):
         rmatch = range_re.match(range_str)
         if not rmatch:
             continue
-        start = int(rmatch.group("start"))
-        end = rmatch.group("end")
-        end = int(end) if end else start+1   # If no end specified, get (a, a+1)
+        start = rmatch.group("start")
+        if start:
+            start = int(start)
+            end = rmatch.group("end")
+            # If no end specified, get (a, a + 1)
+            end = int(end) if end else start + 1
+        else:  # start not specified
+            if not rmatch.group('startsess'):  # no startsess
+                continue
+            start = 1
+            end = None  # provide the entire session hist
+
         if rmatch.group("sep") == "-":       # 1-3 == 1:4 --> [1, 2, 3]
             end += 1
         startsess = rmatch.group("startsess") or "0"

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -148,7 +148,7 @@ def test_extract_hist_ranges():
                 (-4, 7, 10),
                 (-9, 2, None),  # None == to end
                 (-8, 1, None),
-                (-7, 1, 6)
+                (-7, 1, 6),
                 (-10, 1, None)]
     actual = list(extract_hist_ranges(instr))
     nt.assert_equal(actual, expected)

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -141,14 +141,15 @@ def test_history():
 
 
 def test_extract_hist_ranges():
-    instr = "1 2/3 ~4/5-6 ~4/7-~4/9 ~9/2-~7/5"
+    instr = "1 2/3 ~4/5-6 ~4/7-~4/9 ~9/2-~7/5 ~10/"
     expected = [(0, 1, 2),  # 0 == current session
                 (2, 3, 4),
                 (-4, 5, 7),
                 (-4, 7, 10),
                 (-9, 2, None),  # None == to end
                 (-8, 1, None),
-                (-7, 1, 6)]
+                (-7, 1, 6)
+                (-10, 1, None)]
     actual = list(extract_hist_ranges(instr))
     nt.assert_equal(actual, expected)
 


### PR DESCRIPTION
If a user only provide session number (ex: `~1/`) to `%history` magic, it will show entire history of that session. #2963
