### PR TITLE
CM configurable Take 2

### DIFF
--- a/IPython/frontend/html/notebook/static/js/cell.js
+++ b/IPython/frontend/html/notebook/static/js/cell.js
@@ -32,29 +32,40 @@ var IPython = (function (IPython) {
      */
     var Cell = function (options) {
 
-        options = options || {};
+        options = this.mergeopt(Cell, options)
         // superclass default overwrite our default
-        this.cm_config = $.extend({},Cell.cm_default,options.cm_config);
 
-        this.placeholder = this.placeholder || '';
-        this.read_only = false;
+        this.placeholder = options.placeholder || '';
+        this.read_only = options.cm_config.readOnly;
         this.selected = false;
         this.element = null;
         this.metadata = {};
         // load this from metadata later ?
         this.user_highlight = 'auto';
+        this.cm_config = options.cm_config;
         this.create_element();
         if (this.element !== null) {
             this.element.data("cell", this);
             this.bind_events();
         }
         this.cell_id = utils.uuid();
+        this._options = options;
     };
 
-    Cell.cm_default = {
+    Cell.options_default = {
+        cm_config : {
             indentUnit : 4,
-            readOnly: this.read_only,
+            readOnly: false,
+            theme: "default"
+        }
     };
+
+    Cell.prototype.mergeopt = function(_class, options, overwrite){
+        overwrite = overwrite || {};
+        return $.extend(true, {}, _class.options_default, options, overwrite)
+
+    }
+
 
 
     /**
@@ -95,7 +106,7 @@ var IPython = (function (IPython) {
     Cell.prototype.typeset = function () {
         if (window.MathJax){
             var cell_math = this.element.get(0);
-            MathJax.Hub.Queue(["Typeset",MathJax.Hub,cell_math]);
+            MathJax.Hub.Queue(["Typeset", MathJax.Hub, cell_math]);
         }
     };
 
@@ -196,7 +207,7 @@ var IPython = (function (IPython) {
      **/
     Cell.prototype.get_pre_cursor = function () {
         var cursor = this.code_mirror.getCursor();
-        var text = this.code_mirror.getRange({line:0,ch:0}, cursor);
+        var text = this.code_mirror.getRange({line:0, ch:0}, cursor);
         text = text.replace(/^\n+/, '').replace(/\n+$/, '');
         return text;
     }
@@ -293,7 +304,7 @@ var IPython = (function (IPython) {
                 // here we handle non magic_modes
                 if(first_line.match(regs[reg]) != null) {
                     if (mode.search('magic_') != 0) {
-                        this.code_mirror.setOption('mode',mode);
+                        this.code_mirror.setOption('mode', mode);
                         CodeMirror.autoLoadMode(this.code_mirror, mode);
                         return;
                     }

--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -62,7 +62,6 @@ var IPython = (function (IPython) {
      *      @param [options.cm_config] {object} config to pass to CodeMirror
      */
     var CodeCell = function (kernel, options) {
-        var options = options || {}
         this.kernel = kernel || null;
         this.code_mirror = null;
         this.input_prompt_number = null;
@@ -71,15 +70,10 @@ var IPython = (function (IPython) {
 
 
         var cm_overwrite_options  = {
-            extraKeys: {"Tab": "indentMore","Shift-Tab" : "indentLess",'Backspace':"delSpaceToPrevTabStop"},
             onKeyEvent: $.proxy(this.handle_codemirror_keyevent,this)
         };
 
-        var arg_cm_options = options.cm_options || {};
-        var cm_config = $.extend({},CodeCell.cm_default, arg_cm_options, cm_overwrite_options);
-
-        var options = {};
-        options.cm_config = cm_config;
+        options = this.mergeopt(CodeCell, options, {cm_config:cm_overwrite_options});
 
         IPython.Cell.apply(this,[options]);
 
@@ -89,10 +83,13 @@ var IPython = (function (IPython) {
         );
     };
 
-    CodeCell.cm_default = {
+    CodeCell.options_default = {
+        cm_config : {
+            extraKeys: {"Tab": "indentMore","Shift-Tab" : "indentLess",'Backspace':"delSpaceToPrevTabStop"},
             mode: 'python',
             theme: 'ipython',
             matchBrackets: true
+        }
     };
 
 


### PR DESCRIPTION
Pinging @fperez, 
This should fix your issues with markdown cell coloration. 

It is a little more complicated than I expected if we want to avoid code duplication in a few places, so I'll work on that.
## 

Change the way configurability works.
Config dict should be passed down to the parent class where it will be
merged with the default value and propagate to this only in the base
class.

This allow to both alter the configuration on a per instance basis, or
globaly by tempering with the class instance.

This also get rid of IPython global in some cases.
## 

Still not **perfect** but I think this is the limit of my js knowledge, there is a minimal amount of code of 4 line to propagate the configuration :

```
var options = {foo:bar}; // default options can be class parameter
var overwrite_options ={boo:baz}; // came from args, or not
options = this.mergeopt(CodeCell, options, overwrite options);
IPython.Cell.apply(this,[options]);
```

I'm just not found of passing `[option]` instead of just options and the squash the options dict together in a 3 step way...
