### PR TITLE
IPEP 10: kernel side filtering of display formats

### DIFF
--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -65,7 +65,7 @@ class DisplayFormatter(Configurable):
         return self.format_types
     
     def _active_types_changed(self, name, old, new):
-        for key, formatter in self.formatters.keys():
+        for key, formatter in self.formatters.items():
             if key in new:
                 formatter.enabled = True
             else:

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -63,7 +63,14 @@ class DisplayFormatter(Configurable):
         help="""List of currently active mime-types""")
     def _active_types_default(self):
         return self.format_types
-
+    
+    def _active_types_changed(self, name, old, new):
+        for key, formatter in self.formatters.keys():
+            if key in new:
+                formatter.enabled = True
+            else:
+                formatter.enabled = False
+    
     # A dict of formatter whose keys are format types (MIME types) and whose
     # values are subclasses of BaseFormatter.
     formatters = Dict()
@@ -109,7 +116,6 @@ class DisplayFormatter(Configurable):
             A list of format type strings (MIME types) to include in the
             format data dict. If this is set *only* the format types included
             in this list will be computed.
-            If unspecified, `active_types` will be used.
         exclude : list or tuple, optional
             A list of format type string (MIME types) to exclude in the format
             data dict. If this is set all format types will be computed,
@@ -125,8 +131,6 @@ class DisplayFormatter(Configurable):
             that format.
         """
         format_dict = {}
-        if include is None:
-            include = self.active_types
 
         for format_type, formatter in self.formatters.items():
             if format_type not in include:

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -60,7 +60,11 @@ class DisplayFormatter(Configurable):
             self.active_types = self.format_types
     
     active_types = List(Unicode, config=True,
-        help="""List of currently active mime-types""")
+        help="""List of currently active mime-types to display.
+        You can use this to set a white-list for formats to display.
+        
+        Most users will not need to change this value.
+        """)
     def _active_types_default(self):
         return self.format_types
     

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -133,11 +133,10 @@ class DisplayFormatter(Configurable):
         format_dict = {}
 
         for format_type, formatter in self.formatters.items():
-            if format_type not in include:
+            if include and format_type not in include:
                 continue
-            if exclude is not None:
-                if format_type in exclude:
-                    continue
+            if exclude and format_type in exclude:
+                continue
             try:
                 data = formatter(obj)
             except:

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -26,6 +26,7 @@ Authors:
 # Stdlib imports
 import abc
 import sys
+import warnings
 # We must use StringIO, as cStringIO doesn't handle unicode properly.
 from StringIO import StringIO
 

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -427,7 +427,7 @@ Defaulting color scheme to 'NoColor'"""
         save_dstore('rc_separate_out2',shell.separate_out2)
         save_dstore('rc_prompts_pad_left',pm.justify)
         save_dstore('rc_separate_in',shell.separate_in)
-        save_dstore('rc_plain_text_only',disp_formatter.plain_text_only)
+        save_dstore('rc_active_types',disp_formatter.active_types)
         save_dstore('prompt_templates',(pm.in_template, pm.in2_template, pm.out_template))
 
         if mode == False:
@@ -444,7 +444,7 @@ Defaulting color scheme to 'NoColor'"""
             pm.justify = False
 
             ptformatter.pprint = False
-            disp_formatter.plain_text_only = True
+            disp_formatter.active_types = ['text/plain']
 
             shell.magic('xmode Plain')
         else:
@@ -459,7 +459,7 @@ Defaulting color scheme to 'NoColor'"""
             pm.justify = dstore.rc_prompts_pad_left
 
             ptformatter.pprint = dstore.rc_pprint
-            disp_formatter.plain_text_only = dstore.rc_plain_text_only
+            disp_formatter.active_types = dstore.rc_active_types
 
             shell.magic('xmode ' + dstore.xmode)
 

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -383,6 +383,15 @@ class TerminalInteractiveShell(InteractiveShell):
         self.init_banner(banner1, banner2, display_banner)
 
     #-------------------------------------------------------------------------
+    # Overrides of init stages
+    #-------------------------------------------------------------------------
+
+    def init_display_formatter(self):
+        super(TerminalInteractiveShell, self).init_display_formatter()
+        # terminal only supports plaintext
+        self.display_formatter.active_types = ['text/plain']
+
+    #-------------------------------------------------------------------------
     # Things related to the terminal
     #-------------------------------------------------------------------------
 

--- a/IPython/kernel/zmq/zmqshell.py
+++ b/IPython/kernel/zmq/zmqshell.py
@@ -150,18 +150,18 @@ class KernelMagics(Magics):
         # save a few values we'll need to recover later
         mode = save_dstore('mode', False)
         save_dstore('rc_pprint', ptformatter.pprint)
-        save_dstore('rc_plain_text_only',disp_formatter.plain_text_only)
+        save_dstore('rc_active_types',disp_formatter.active_types)
         save_dstore('xmode', shell.InteractiveTB.mode)
 
         if mode == False:
             # turn on
             ptformatter.pprint = False
-            disp_formatter.plain_text_only = True
+            disp_formatter.active_types = ['text/plain']
             shell.magic('xmode Plain')
         else:
             # turn off
             ptformatter.pprint = dstore.rc_pprint
-            disp_formatter.plain_text_only = dstore.rc_plain_text_only
+            disp_formatter.active_types = dstore.rc_active_types
             shell.magic("xmode " + dstore.xmode)
 
         # Store new mode and inform on console


### PR DESCRIPTION
Draft implementation of [IPEP 10](https://github.com/ipython/ipython/wiki/IPEP-10:-kernel-side-filtering-of-display-formats)

This adds `active_types` list to DisplayFormatter as a global default for `include`,
rather than always having default of everything.

There is no change whatsoever for the default behavior of any zmq-based IPython kernels (notebook, qtconsole, etc.).
The only actual effect under default conditions is to eliminate the cost of registering unused formatters in terminal IPython.
