### PR TITLE
fix local files examples in markdown

### DIFF
--- a/examples/notebooks/Part 4 - Markdown Cells.ipynb
+++ b/examples/notebooks/Part 4 - Markdown Cells.ipynb
@@ -231,13 +231,13 @@
       "\n",
       "    <img src=\"files/python-logo.svg\" />\n",
       "\n",
-      "<img src=\"/files/python-logo.svg\" />\n",
+      "<img src=\"files/python-logo.svg\" />\n",
       "\n",
       "and a video with the HTML5 video tag:\n",
       "\n",
       "    <video controls src=\"files/animation.m4v\" />\n",
       "\n",
-      "<video controls src=\"/files/animation.m4v\" />\n",
+      "<video controls src=\"files/animation.m4v\" />\n",
       "\n",
       "These do not embed the data into the notebook file, and require that the files exist when you are viewing the notebook."
      ]


### PR DESCRIPTION
absolute `/files` prefix was used, which is wrong and not portable.
Even the example code directly above it uses the correct relative `files/` prefix.
