### PR TITLE
changed instances of 'outout' to 'output' in alt texts

### DIFF
--- a/IPython/frontend/html/notebook/static/js/outputarea.js
+++ b/IPython/frontend/html/notebook/static/js/outputarea.js
@@ -50,11 +50,11 @@ var IPython = (function (IPython) {
         
         this.collapse_button.button();
         this.collapse_button.addClass('output_collapsed vbox');
-        this.collapse_button.attr('title', 'click to expand outout');
+        this.collapse_button.attr('title', 'click to expand output');
         this.collapse_button.html('. . .');
         
         this.prompt_overlay.addClass('out_prompt_overlay prompt');
-        this.prompt_overlay.attr('title', 'click to expand outout; double click to hide output');
+        this.prompt_overlay.attr('title', 'click to expand output; double click to hide output');
         
         this.collapse();
     };


### PR DESCRIPTION
is it supposed to be 'outout' it looked like a typo to me so here's a change
