### PR TITLE
on resume, print server info again

### DIFF
--- a/IPython/frontend/html/notebook/azurenbmanager.py
+++ b/IPython/frontend/html/notebook/azurenbmanager.py
@@ -139,5 +139,5 @@ class AzureNotebookManager(NotebookManager):
         else:
             self.delete_notebook_id(notebook_id)
 
-    def log_info(self):
-        self.log.info("Serving notebooks from Azure storage: %s, %s", self.account_name, self.container)
+    def info_string(self):
+        return "Serving notebooks from Azure storage: %s, %s" % (self.account_name, self.container)

--- a/IPython/frontend/html/notebook/filenbmanager.py
+++ b/IPython/frontend/html/notebook/filenbmanager.py
@@ -191,6 +191,6 @@ class FileNotebookManager(NotebookManager):
             else:
                 i = i+1
         return name
-
-    def log_info(self):
-        self.log.info("Serving notebooks from local directory: %s", self.notebook_dir)
+        
+    def info_string(self):
+        return "Serving notebooks from local directory: %s" % self.notebook_dir

--- a/IPython/frontend/html/notebook/nbmanager.py
+++ b/IPython/frontend/html/notebook/nbmanager.py
@@ -207,4 +207,8 @@ class NotebookManager(LoggingConfigurable):
         return notebook_id
 
     def log_info(self):
-        self.log.info("Serving notebooks")
+        self.log.info(self.info_string())
+    
+    def info_string(self):
+        return "Serving notebooks"
+

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -581,8 +581,8 @@ class NotebookApp(BaseIPythonApplication):
         time.sleep(0.1)
         info = self.log.info
         info('interrupted')
-        self.print_notebook_info()
-        info("Shutdown this notebook server (y/[n])? ")
+        print self.notebook_info()
+        sys.stdout.write("Shutdown this notebook server (y/[n])? ")
         sys.stdout.flush()
         r,w,x = select.select([sys.stdin], [], [], 5)
         if r:
@@ -605,7 +605,7 @@ class NotebookApp(BaseIPythonApplication):
         ioloop.IOLoop.instance().stop()
 
     def _signal_info(self, sig, frame):
-        self.print_notebook_info()
+        print self.notebook_info()
     
     @catch_config_error
     def initialize(self, argv=None):
@@ -624,10 +624,10 @@ class NotebookApp(BaseIPythonApplication):
         self.log.info('Shutting down kernels')
         self.kernel_manager.shutdown_all()
 
-    def print_notebook_info(self):
-        "Print the current working directory and the server url information"
-        self.notebook_manager.log_info()
-        self.log.info("The IPython Notebook is running at: %s" % self._url)
+    def notebook_info(self):
+        "Return the current working directory and the server url information"
+        mgr_info = self.notebook_manager.info_string() + "\n"
+        return mgr_info +"The IPython Notebook is running at: %s" % self._url
 
     def start(self):
         """ Start the IPython Notebok server app, after initialization
@@ -639,7 +639,8 @@ class NotebookApp(BaseIPythonApplication):
         info = self.log.info
         self._url = "%s://%s:%i%s" % (proto, ip, self.port,
                                       self.base_project_url)
-        self.print_notebook_info()
+        for line in self.notebook_info().split("\n"):
+            info(line)
         info("Use Control-C to stop this server and shut down all kernels.")
 
         if self.open_browser or self.file_to_run:

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -576,7 +576,7 @@ class NotebookApp(BaseIPythonApplication):
         """
         # FIXME: remove this delay when pyzmq dependency is >= 2.1.11
         time.sleep(0.1)
-        sys.stdout.write("Shutdown Notebook Server (y/[n])? ")
+        sys.stdout.write("Shutdown Notebook Server at %s (y/[n])? " % self._url)
         sys.stdout.flush()
         r,w,x = select.select([sys.stdin], [], [], 5)
         if r:
@@ -616,11 +616,16 @@ class NotebookApp(BaseIPythonApplication):
         self.kernel_manager.shutdown_all()
 
     def start(self):
+        """ Start the IPython Notebok server app, after initialization
+        
+        This method takes no arguments so all configuration and initialization
+        must be done prior to calling this method."""
         ip = self.ip if self.ip else '[all ip addresses on your system]'
         proto = 'https' if self.certfile else 'http'
         info = self.log.info
-        info("The IPython Notebook is running at: %s://%s:%i%s" %
-             (proto, ip, self.port,self.base_project_url) )
+        self._url = "%s://%s:%i%s" % (proto, ip, self.port,
+                                      self.base_project_url)
+        info("The IPython Notebook is running at: %s" % self._url)
         info("Use Control-C to stop this server and shut down all kernels.")
 
         if self.open_browser or self.file_to_run:

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -484,7 +484,6 @@ class NotebookApp(BaseIPythonApplication):
         )
         kls = import_item(self.notebook_manager_class)
         self.notebook_manager = kls(config=self.config, log=self.log)
-        self.notebook_manager.log_info()
         self.notebook_manager.load_notebook_names()
         self.cluster_manager = ClusterManager(config=self.config, log=self.log)
         self.cluster_manager.update_profiles()
@@ -576,7 +575,10 @@ class NotebookApp(BaseIPythonApplication):
         """
         # FIXME: remove this delay when pyzmq dependency is >= 2.1.11
         time.sleep(0.1)
-        sys.stdout.write("Shutdown Notebook Server at %s (y/[n])? " % self._url)
+        info = self.log.info
+        info('interrupted')
+        self.print_notebook_info()
+        info("Shutdown this notebook server (y/[n])? ")
         sys.stdout.flush()
         r,w,x = select.select([sys.stdin], [], [], 5)
         if r:
@@ -615,6 +617,11 @@ class NotebookApp(BaseIPythonApplication):
         self.log.info('Shutting down kernels')
         self.kernel_manager.shutdown_all()
 
+    def print_notebook_info(self):
+        "Print the current working directory and the server url information"
+        self.notebook_manager.log_info()
+        self.log.info("The IPython Notebook is running at: %s" % self._url)
+
     def start(self):
         """ Start the IPython Notebok server app, after initialization
         
@@ -625,7 +632,7 @@ class NotebookApp(BaseIPythonApplication):
         info = self.log.info
         self._url = "%s://%s:%i%s" % (proto, ip, self.port,
                                       self.base_project_url)
-        info("The IPython Notebook is running at: %s" % self._url)
+        self.print_notebook_info()
         info("Use Control-C to stop this server and shut down all kernels.")
 
         if self.open_browser or self.file_to_run:

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -550,6 +550,10 @@ class NotebookApp(BaseIPythonApplication):
             # but it will work
             signal.signal(signal.SIGINT, self._handle_sigint)
         signal.signal(signal.SIGTERM, self._signal_stop)
+        signal.signal(signal.SIGUSR1, self._signal_info)
+        if hasattr(signal, 'SIGINFO'):
+            # only on BSD-based systems
+            signal.signal(signal.SIGINFO, self._signal_info)
     
     def _handle_sigint(self, sig, frame):
         """SIGINT handler spawns confirmation dialog"""
@@ -599,6 +603,9 @@ class NotebookApp(BaseIPythonApplication):
     def _signal_stop(self, sig, frame):
         self.log.critical("received signal %s, stopping", sig)
         ioloop.IOLoop.instance().stop()
+
+    def _signal_info(self, sig, frame):
+        self.print_notebook_info()
     
     @catch_config_error
     def initialize(self, argv=None):


### PR DESCRIPTION
This commit makes it possible to differentiate between many different
long-running notebook servers, where the original ip address and port
information printed at the beginning has scrolled out of the screen.

We save the server location string that gets printed on startup, and
re-print it when the user attempts to interrupt the server with Ctrl-C

Thanks to @minrk for discussion on how this should work.

Also added a docstring to the start() method
