### PR TITLE
support non-modules in @require

### DIFF
--- a/IPython/parallel/controller/dependency.py
+++ b/IPython/parallel/controller/dependency.py
@@ -59,10 +59,12 @@ class dependent(object):
         self.df = df
         self.dargs = dargs
         self.dkwargs = dkwargs
-
-    def __call__(self, *args, **kwargs):
+    
+    def check_dependency(self):
         if self.df(*self.dargs, **self.dkwargs) is False:
             raise UnmetDependency()
+    
+    def __call__(self, *args, **kwargs):
         return self.f(*args, **kwargs)
     
     if not py3compat.PY3:

--- a/IPython/parallel/controller/dependency.py
+++ b/IPython/parallel/controller/dependency.py
@@ -11,8 +11,6 @@ Authors:
 #  the file COPYING, distributed as part of this software.
 #-----------------------------------------------------------------------------
 
-import sys
-
 from types import ModuleType
 
 from IPython.parallel.client.asyncresult import AsyncResult
@@ -63,9 +61,6 @@ class dependent(object):
         self.dkwargs = dkwargs
 
     def __call__(self, *args, **kwargs):
-        user_ns = sys.modules['__main__'].__dict__
-        for key, value in self.dkwargs.items():
-            self.dkwargs[key] = uncan(value, user_ns)
         if self.df(*self.dargs, **self.dkwargs) is False:
             raise UnmetDependency()
         return self.f(*args, **kwargs)

--- a/IPython/utils/pickleutil.py
+++ b/IPython/utils/pickleutil.py
@@ -64,7 +64,7 @@ class CannedObject(object):
         obj = self.obj
         for key in self.keys:
             setattr(obj, key, uncan(getattr(obj, key), g))
-
+        
         if self.hook:
             self.hook = uncan(self.hook, g)
             self.hook(obj, g)
@@ -308,6 +308,11 @@ def uncan_sequence(obj, g=None):
     else:
         return obj
 
+def _uncan_dependent_hook(dep, g=None):
+    dep.check_dependency()
+    
+def can_dependent(obj):
+    return CannedObject(obj, keys=('f', 'df'), hook=_uncan_dependent_hook)
 
 #-------------------------------------------------------------------------------
 # API dictionaries
@@ -316,7 +321,7 @@ def uncan_sequence(obj, g=None):
 # These dicts can be extended for custom serialization of new objects
 
 can_map = {
-    'IPython.parallel.dependent' : lambda obj: CannedObject(obj, keys=('f','df')),
+    'IPython.parallel.dependent' : can_dependent,
     'numpy.ndarray' : CannedArray,
     FunctionType : CannedFunction,
     bytes : CannedBytes,

--- a/IPython/utils/pickleutil.py
+++ b/IPython/utils/pickleutil.py
@@ -49,9 +49,10 @@ else:
 
 
 class CannedObject(object):
-    def __init__(self, obj, keys=[]):
+    def __init__(self, obj, keys=[], hook=None):
         self.keys = keys
         self.obj = copy.copy(obj)
+        self.hook = can(hook)
         for key in keys:
             setattr(self.obj, key, can(getattr(obj, key)))
         
@@ -60,8 +61,13 @@ class CannedObject(object):
     def get_object(self, g=None):
         if g is None:
             g = {}
+        obj = self.obj
         for key in self.keys:
-            setattr(self.obj, key, uncan(getattr(self.obj, key), g))
+            setattr(obj, key, uncan(getattr(obj, key), g))
+
+        if self.hook:
+            self.hook = uncan(self.hook, g)
+            self.hook(obj, g)
         return self.obj
     
 

--- a/IPython/utils/pickleutil.py
+++ b/IPython/utils/pickleutil.py
@@ -50,6 +50,22 @@ else:
 
 class CannedObject(object):
     def __init__(self, obj, keys=[], hook=None):
+        """can an object for safe pickling
+        
+        Parameters
+        ==========
+        
+        obj:
+            The object to be canned
+        keys: list (optional)
+            list of attribute names that will be explicitly canned / uncanned
+        hook: callable (optional)
+            An optional extra callable,
+            which can do additional processing of the uncanned object.
+        
+        large data may be offloaded into the buffers list,
+        used for zero-copy transfers.
+        """
         self.keys = keys
         self.obj = copy.copy(obj)
         self.hook = can(hook)


### PR DESCRIPTION
Functions and other objects can be passed, which implies a push when the function is passed to apply.

This relieves one of the most common complaints in IPython.parallel - allowing multi-function tasks without a `push` call for the intermediate functions.

``` python
def foo(a):
    return a*a

@parallel.require(foo)
def bar(b):
    return foo(b)

@parallel.require(bar)
def baz(c, d):
    return bar(c) - bar(d)

view.apply_sync(baz, 4, 5)
```

Pinging @ogrisel as the source of the idea at PyData.
