### PR TITLE
add redirect handler for notebooks by name

### DIFF
--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -609,6 +609,20 @@ class ShellHandler(AuthenticatedZMQStreamHandler):
 # Notebook web service handlers
 #-----------------------------------------------------------------------------
 
+class NotebookRedirectHandler(AuthenticatedHandler):
+    
+    @authenticate_unless_readonly
+    def get(self, notebook_name):
+        app = self.application
+        if notebook_name.endswith('.ipynb'):
+            notebook_name = notebook_name[:-6]
+        notebook_id = app.notebook_manager.rev_mapping.get(notebook_name, '')
+        if notebook_id:
+            url = self.settings.get('base_project_url', '/') + notebook_id
+            return self.redirect(url)
+        else:
+            raise HTTPError(404)
+
 class NotebookRootHandler(AuthenticatedHandler):
 
     @authenticate_unless_readonly

--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -614,8 +614,8 @@ class NotebookRedirectHandler(AuthenticatedHandler):
     @authenticate_unless_readonly
     def get(self, notebook_name):
         app = self.application
-        if notebook_name.endswith('.ipynb'):
-            notebook_name = notebook_name[:-6]
+        # strip trailing .ipynb:
+        notebook_name = os.path.splitext(notebook_name)[0]
         notebook_id = app.notebook_manager.rev_mapping.get(notebook_name, '')
         if notebook_id:
             url = self.settings.get('base_project_url', '/') + notebook_id

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -51,7 +51,7 @@ from .handlers import (LoginHandler, LogoutHandler,
     ShellHandler, NotebookRootHandler, NotebookHandler, NotebookCopyHandler,
     RSTHandler, AuthenticatedFileHandler, PrintNotebookHandler,
     MainClusterHandler, ClusterProfileHandler, ClusterActionHandler,
-    FileFindHandler,
+    FileFindHandler, NotebookRedirectHandler,
 )
 from .nbmanager import NotebookManager
 from .filenbmanager import FileNotebookManager
@@ -85,6 +85,7 @@ from IPython.utils.path import filefind
 _kernel_id_regex = r"(?P<kernel_id>\w+-\w+-\w+-\w+-\w+)"
 _kernel_action_regex = r"(?P<action>restart|interrupt)"
 _notebook_id_regex = r"(?P<notebook_id>\w+-\w+-\w+-\w+-\w+)"
+_notebook_name_regex = r"(?P<notebook_name>.+\.ipynb)"
 _profile_regex = r"(?P<profile>[^\/]+)" # there is almost no text that is invalid
 _cluster_action_regex = r"(?P<action>start|stop)"
 
@@ -135,6 +136,7 @@ class NotebookWebApplication(web.Application):
             (r"/logout", LogoutHandler),
             (r"/new", NewHandler),
             (r"/%s" % _notebook_id_regex, NamedNotebookHandler),
+            (r"/%s" % _notebook_name_regex, NotebookRedirectHandler),
             (r"/%s/copy" % _notebook_id_regex, NotebookCopyHandler),
             (r"/%s/print" % _notebook_id_regex, PrintNotebookHandler),
             (r"/kernels", MainKernelHandler),
@@ -169,6 +171,7 @@ class NotebookWebApplication(web.Application):
             cookie_secret=os.urandom(1024),
             login_url=url_path_join(base_project_url,'/login'),
             cookie_name='username-%s' % uuid.uuid4(),
+            base_project_url = base_project_url,
         )
 
         # allow custom overrides for the tornado web app.


### PR DESCRIPTION
Now you can visit `localhost:8888/My Notebook.ipynb`, and it will redirect you to the UUID url. This allows cross-notebook links, etc. with `[other notebook](Notebook Name.ipynb)`.
It does not introduce any of the problems associated with 'real' persistent URLs,
since these are only written by humans, and only redirect to real URLs.
A rename breaks such a link, exactly as you would expect.

see #3056
