### PR TITLE
add missing `%%html` magic

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2062,6 +2062,8 @@ class InteractiveShell(SingletonConfigurable):
         mman.register_alias('ed', 'edit')
         mman.register_alias('hist', 'history')
         mman.register_alias('rep', 'recall')
+        mman.register_alias('SVG', 'svg', 'cell')
+        mman.register_alias('HTML', 'html', 'cell')
 
         # FIXME: Move the color initialization to the DisplayHook, which
         # should be split into a prompt manager and displayhook. We probably

--- a/IPython/core/magics/display.py
+++ b/IPython/core/magics/display.py
@@ -12,7 +12,7 @@
 #-----------------------------------------------------------------------------
 
 # Our own packages
-from IPython.core.display import display, Javascript, Latex, SVG
+from IPython.core.display import display, Javascript, Latex, SVG, HTML
 from IPython.core.magic import  (
     Magics, magics_class, cell_magic
 )
@@ -45,3 +45,8 @@ class DisplayMagics(Magics):
     def svg(self, line, cell):
         """Render the cell as an SVG literal"""
         display(SVG(cell))
+
+    @cell_magic
+    def html(self, line, cell):
+        """Render the cell as an SVG literal"""
+        display(HTML(cell))


### PR DESCRIPTION
and uppercase aliases `%%SVG` and `%%HTML`.

Is there a better place for magic aliases to be defined?
inside InteractiveShell.init_magics doesn't seem right to me.
