### PR TITLE
Don't monkeypatch doctest during IPython startup.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -64,7 +64,6 @@ from IPython.utils import io
 from IPython.utils import py3compat
 from IPython.utils import openpy
 from IPython.utils.decorators import undoc
-from IPython.utils.doctestreload import doctest_reload
 from IPython.utils.io import ask_yes_no
 from IPython.utils.ipstruct import Struct
 from IPython.utils.path import get_home_dir, get_ipython_dir, get_py_filename, unquote_filename
@@ -489,7 +488,6 @@ class InteractiveShell(SingletonConfigurable):
         self.init_display_pub()
         self.init_data_pub()
         self.init_displayhook()
-        self.init_reload_doctest()
         self.init_latextool()
         self.init_magics()
         self.init_logstart()
@@ -681,14 +679,6 @@ class InteractiveShell(SingletonConfigurable):
         # This is a context manager that installs/revmoes the displayhook at
         # the appropriate time.
         self.display_trap = DisplayTrap(hook=self.displayhook)
-
-    def init_reload_doctest(self):
-        # Do a proper resetting of doctest, including the necessary displayhook
-        # monkeypatching
-        try:
-            doctest_reload()
-        except ImportError:
-            warn("doctest module does not exist.")
 
     def init_latextool(self):
         """Configure LaTeXTool."""

--- a/IPython/utils/doctestreload.py
+++ b/IPython/utils/doctestreload.py
@@ -62,6 +62,11 @@ def doctest_reload():
 
     Notes
     -----
+    
+    As of Python 2.6.6, 2.7.1 and 3.2, this monkeypatching is no longer required.
+    doctest now takes care of resetting sys.displayhook itself. This function
+    remains for now in case anyone has to work with older versions, but it's
+    no longer called during IPython startup.
 
     This function *used to* reload doctest, but this has been disabled because
     reloading doctest unconditionally can cause massive breakage of other

--- a/IPython/utils/doctestreload.py
+++ b/IPython/utils/doctestreload.py
@@ -52,13 +52,13 @@ def doctest_reload():
       - imports doctest but does NOT reload it (see below).
 
       - resets its global 'master' attribute to None, so that multiple uses of
-      the module interactively don't produce cumulative reports.
+        the module interactively don't produce cumulative reports.
 
       - Monkeypatches its core test runner method to protect it from IPython's
-      modified displayhook.  Doctest expects the default displayhook behavior
-      deep down, so our modification breaks it completely.  For this reason, a
-      hard monkeypatch seems like a reasonable solution rather than asking
-      users to manually use a different doctest runner when under IPython.
+        modified displayhook.  Doctest expects the default displayhook behavior
+        deep down, so our modification breaks it completely.  For this reason, a
+        hard monkeypatch seems like a reasonable solution rather than asking
+        users to manually use a different doctest runner when under IPython.
 
     Notes
     -----

--- a/docs/source/whatsnew/development.txt
+++ b/docs/source/whatsnew/development.txt
@@ -40,3 +40,7 @@ Backwards incompatible changes
   :mod:`IPython.lib.inputhook`.
 * For all kernel managers, the ``sub_channel`` attribute has been renamed to
   ``iopub_channel``.
+* Users on Python versions before 2.6.6, 2.7.1 or 3.2 will now need to call
+  :func:`IPython.utils.doctestreload.doctest_reload` to make doctests run 
+  correctly inside IPython. Python releases since those versions are unaffected.
+  For details, see :ghpull:`3068` and `Python issue 8048 <http://bugs.python.org/issue8048>`_.


### PR DESCRIPTION
This is no longer required since Python [issue 8048](http://bugs.python.org/issue8048) was fixed in 2.6.6, 2.7.1 and 3.2.

It should buy us another small improvement in startup time, because we no longer need to load doctest on startup. That saves 29 modules on 2.7, and 8 on 3.2. Cold start time appears to drop by something like 10%, although there's quite a bit of noise in the measurements.

I've left the module `IPython.utils.doctestreload` around for now, in case anyone is working with earlier versions of Python and needs to use it.
