### PR TITLE
fix ipython usage text

### DIFF
--- a/IPython/core/usage.py
+++ b/IPython/core/usage.py
@@ -27,12 +27,15 @@ Tools for Interactive Computing in Python
 
 Usage
 
-    ipython [subcommand] [options] [files]
+    ipython [subcommand] [options] [-c cmd | -m mod | file] [arg] ...
 
-    If invoked with no options, it executes all the files listed in sequence
-    and exits, use -i to enter interactive mode after running the files.  Files
-    ending in .py will be treated as normal Python, but files ending in .ipy
-    can contain special IPython syntax (magic commands, shell expansions, etc.)
+    If invoked with no options, it executes the file and exits, passing the
+    remaining arguments to the script, just as if you had specified the same
+    command with python. If you specify the option `-i` before the filename, it
+    will enter an interactive IPython session after running the script, rather
+    than exiting. Files ending in .py will be treated as normal Python, but
+    files ending in .ipy can contain special IPython syntax (magic commands,
+    shell expansions, etc.)
 
     Almost all configuration in IPython is available via the command-line. Do
     `ipython --help-all` to see all available options.  For persistent

--- a/IPython/core/usage.py
+++ b/IPython/core/usage.py
@@ -27,15 +27,16 @@ Tools for Interactive Computing in Python
 
 Usage
 
-    ipython [subcommand] [options] [-c cmd | -m mod | file] [arg] ...
+    ipython [subcommand] [options] [-c cmd | -m mod | file] [--] [arg] ...
 
     If invoked with no options, it executes the file and exits, passing the
     remaining arguments to the script, just as if you had specified the same
-    command with python. If you specify the option `-i` before the filename, it
-    will enter an interactive IPython session after running the script, rather
-    than exiting. Files ending in .py will be treated as normal Python, but
-    files ending in .ipy can contain special IPython syntax (magic commands,
-    shell expansions, etc.)
+    command with python. You may need to specify `--` before args to be passed
+    to the script, to prevent IPython from attempting to parse them. If you
+    specify the option `-i` before the filename, it will enter an interactive
+    IPython session after running the script, rather than exiting. Files ending
+    in .py will be treated as normal Python, but files ending in .ipy can
+    contain special IPython syntax (magic commands, shell expansions, etc.).
 
     Almost all configuration in IPython is available via the command-line. Do
     `ipython --help-all` to see all available options.  For persistent


### PR DESCRIPTION
It does not describe current behavior, which is now like regular python.

The `[-c cmd | -m mod | file]` is taken directly from Python's own help output.

Prompted by [this question](http://stackoverflow.com/questions/15577189) on SO.
