### PR TITLE
fix regular expression for detecting links in stdout

### DIFF
--- a/IPython/frontend/html/notebook/static/js/outputarea.js
+++ b/IPython/frontend/html/notebook/static/js/outputarea.js
@@ -378,7 +378,6 @@ var IPython = (function (IPython) {
     OutputArea.prototype.append_text = function (data, element, extra_class) {
         var toinsert = $("<div/>").addClass("box-flex1 output_subarea output_text");
         // escape ANSI & HTML specials in plaintext:
-        data = utils.wrapUrls(data);
         data = utils.fixConsole(data);
         data = utils.fixCarriageReturn(data);
         data = utils.autoLinkUrls(data);

--- a/IPython/frontend/html/notebook/static/js/utils.js
+++ b/IPython/frontend/html/notebook/static/js/utils.js
@@ -201,22 +201,10 @@ IPython.utils = (function (IPython) {
         return txt;
     }
 
-    // Locate URLs in plain text and wrap them in spaces so that they can be
-    // better picked out by autoLinkUrls even after the text has been
-    // converted to HTML
-    function wrapUrls(txt) {
-        // Note this regexp is a modified version of one from
-        // Markdown.Converter For now it only supports http(s) and ftp URLs,
-        // but could easily support others (though file:// should maybe be
-        // avoided)
-        var url_re = /(^|\W)(https?|ftp)(:\/\/[-A-Z0-9+&@#\/%?=~_|\[\]\(\)!:,\.;]*[-A-Z0-9+&@#\/%=~_|\[\]])($|\W)/gi;
-        return txt.replace(url_re, "$1 $2$3 $4");
-    }
-
-    // Locate a URL with spaces around it and convert that to a anchor tag
+    // Locate any URLs and convert them to a anchor tag
     function autoLinkUrls(txt) {
-        return txt.replace(/ ((https?|ftp):[^'">\s]+) /gi,
-            "<a target=\"_blank\" href=\"$1\">$1</a>");
+        return txt.replace(/(^|\s)(https?|ftp)(:[^'">\s]+)/gi,
+            "$1<a target=\"_blank\" href=\"$2$3\">$2$3</a>");
     }
 
     grow = function(element) {
@@ -289,7 +277,6 @@ IPython.utils = (function (IPython) {
         keycodes : keycodes,
         grow : grow,
         fixCarriageReturn : fixCarriageReturn,
-        wrapUrls : wrapUrls,
         autoLinkUrls : autoLinkUrls,
         points_to_pixels : points_to_pixels,
         browser : browser    


### PR DESCRIPTION
The previous expression was matching both the beginning and the end of the line, which would end up swallowing the next match, ultimately matching every other URL in the string.

This removes the end-of-line check, so it will match every URL.

The wrapURLs function to make URLs easier to identify does not seem to have been necessary, and has thus been removed.

closes #2834
