### PR TITLE
noted sub_channel being renamed to iopub_channel

### DIFF
--- a/docs/source/whatsnew/development.txt
+++ b/docs/source/whatsnew/development.txt
@@ -38,3 +38,5 @@ Backwards incompatible changes
   event loops are no longer exposed in the top level of :mod:`IPython.lib`.
   Code calling these should make sure to import them from
   :mod:`IPython.lib.inputhook`.
+* For all kernel managers, the ``sub_channel`` attribute has been renamed to
+  ``iopub_channel``.


### PR DESCRIPTION
Ran into this while trying to use some vim-ipython code.
