### PR TITLE
A few small patches to image handling

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -420,6 +420,9 @@ class Javascript(DisplayObject):
         r += lib_t2*len(self.lib)
         return r
 
+# constants for identifying png/jpeg data
+_PNG = b'\x89PNG\r\n\x1a\n'
+_JPEG = b'\xff\xd8'
 
 class Image(DisplayObject):
 
@@ -487,6 +490,11 @@ class Image(DisplayObject):
                 format = self._FMT_JPEG
             if ext == u'png':
                 format = self._FMT_PNG
+        elif isinstance(data, bytes) and format == 'png':
+            # infer image type from image data header,
+            # only if format might not have been specified.
+            if data[:2] == _JPEG:
+                format = 'jpeg'
 
         self.format = unicode(format).lower()
         self.embed = embed if embed is not None else (url is None)

--- a/IPython/utils/jsonutil.py
+++ b/IPython/utils/jsonutil.py
@@ -97,9 +97,11 @@ def date_default(obj):
 
 # constants for identifying png/jpeg data
 PNG = b'\x89PNG\r\n\x1a\n'
-PNG64 = encodebytes(PNG)
+# front of PNG base64-encoded
+PNG64 = b'iVBORw0KG'
 JPEG = b'\xff\xd8'
-JPEG64 = encodebytes(JPEG)
+# front of JPEG base64-encoded
+JPEG64 = b'/9'
 
 def encode_images(format_dict):
     """b64-encodes images in a displaypub format dict
@@ -126,14 +128,14 @@ def encode_images(format_dict):
     pngdata = format_dict.get('image/png')
     if isinstance(pngdata, bytes):
         # make sure we don't double-encode
-        if pngdata[:13] != PNG64:
+        if not pngdata.startswith(PNG64):
             pngdata = encodebytes(pngdata)
         encoded['image/png'] = pngdata.decode('ascii')
 
     jpegdata = format_dict.get('image/jpeg')
     if isinstance(jpegdata, bytes):
         # make sure we don't double-encode
-        if jpegdata[:5] != JPEG64:
+        if not jpegdata.startswith(JPEG64):
             jpegdata = encodebytes(jpegdata)
         encoded['image/jpeg'] = jpegdata.decode('ascii')
 

--- a/IPython/utils/jsonutil.py
+++ b/IPython/utils/jsonutil.py
@@ -97,7 +97,9 @@ def date_default(obj):
 
 # constants for identifying png/jpeg data
 PNG = b'\x89PNG\r\n\x1a\n'
+PNG64 = encodebytes(PNG)
 JPEG = b'\xff\xd8'
+JPEG64 = encodebytes(JPEG)
 
 def encode_images(format_dict):
     """b64-encodes images in a displaypub format dict
@@ -120,12 +122,21 @@ def encode_images(format_dict):
 
     """
     encoded = format_dict.copy()
+
     pngdata = format_dict.get('image/png')
-    if isinstance(pngdata, bytes) and pngdata[:8] == PNG:
-        encoded['image/png'] = encodebytes(pngdata).decode('ascii')
+    if isinstance(pngdata, bytes):
+        # make sure we don't double-encode
+        if pngdata[:13] != PNG64:
+            pngdata = encodebytes(pngdata)
+        encoded['image/png'] = pngdata.decode('ascii')
+
     jpegdata = format_dict.get('image/jpeg')
-    if isinstance(jpegdata, bytes) and jpegdata[:2] == JPEG:
-        encoded['image/jpeg'] = encodebytes(jpegdata).decode('ascii')
+    if isinstance(jpegdata, bytes):
+        # make sure we don't double-encode
+        if jpegdata[:5] != JPEG64:
+            jpegdata = encodebytes(jpegdata)
+        encoded['image/jpeg'] = jpegdata.decode('ascii')
+
     return encoded
 
 


### PR DESCRIPTION
1. tweak double-encode logic for image data
   
   Instead of only b64-encoding for valid image data, b64-encode unless it is specifically detected as b64-encoded valid image data. This prevents garbage data from skipping the b64 step, and causing unicode errors.
2. check image header to identify image type
3. allow Image("filename")
   
   We already support passing a URL this way, it's silly to not support passing a filename, as user reports have shown many times.

Closes #3081
