### PR TITLE
PyQt 4.10: use self._document = self.document()

### DIFF
--- a/IPython/frontend/qt/console/pygments_highlighter.py
+++ b/IPython/frontend/qt/console/pygments_highlighter.py
@@ -94,7 +94,7 @@ class PygmentsHighlighter(QtGui.QSyntaxHighlighter):
     def __init__(self, parent, lexer=None):
         super(PygmentsHighlighter, self).__init__(parent)
 
-        self._document = QtGui.QTextDocument()
+        self._document = self.document()
         self._formatter = HtmlFormatter(nowrap=True)
         self._lexer = lexer if lexer else PythonLexer()
         self.set_style('default')


### PR DESCRIPTION
in PygmentsHighlighter, required for PyQt 4.10 compatibility.

closes #3084

I have tested this on all my machines with earlier PyQt and PySide, and it doesn't break anything.  I don't have any truly old versions of PyQt, though.

see [PyQt list](http://www.riverbankcomputing.com/pipermail/pyqt/2013-March/032512.html) for details.
