### PR TITLE
set `spellcheck=false` in CodeCell inputarea

### DIFF
--- a/IPython/frontend/html/notebook/static/js/codecell.js
+++ b/IPython/frontend/html/notebook/static/js/codecell.js
@@ -120,6 +120,7 @@ var IPython = (function (IPython) {
         vbox.append(this.celltoolbar.element);
         var input_area = $('<div/>').addClass('input_area');
         this.code_mirror = CodeMirror(input_area.get(0), this.cm_config);
+        $(this.code_mirror.getInputField()).attr("spellcheck", "false");
         vbox.append(input_area);
         input.append(vbox);
         var output = $('<div></div>');


### PR DESCRIPTION
prevents autocorrect from firing in Safari (weirdly, autocorrect does not have
this effect).

Note: must be `false`, not `off`

closes #3087
