### PR TITLE
move DEFAULT_STATIC_FILES_PATH to IPython.html

### DIFF
--- a/IPython/frontend/html/notebook/__init__.py
+++ b/IPython/frontend/html/notebook/__init__.py
@@ -1,20 +1,7 @@
 """The IPython HTML Notebook"""
 
-# check for tornado 2.1.0
-msg = "The IPython Notebook requires tornado >= 2.1.0"
-try:
-    import tornado
-except ImportError:
-    raise ImportError(msg)
-try:
-    version_info = tornado.version_info
-except AttributeError:
-    raise ImportError(msg + ", but you have < 1.1.0")
-if version_info < (2,1,0):
-    raise ImportError(msg + ", but you have %s" % tornado.version)
-del msg
+import os
+# Packagers: modify this line if you store the notebook static files elsewhere
+DEFAULT_STATIC_FILES_PATH = os.path.join(os.path.dirname(__file__), "static")
 
-# check for pyzmq 2.1.4
-from IPython.kernel.zmq import check_for_zmq
-check_for_zmq('2.1.4', 'IPython.frontend.html.notebook')
-del check_for_zmq
+del os

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -33,8 +33,8 @@ import webbrowser
 
 
 # Third party
-# check for pyzmq 2.1.11 (this is actually redundant)
-from IPython.kernel.zmq import check_for_zmq
+# check for pyzmq 2.1.11
+from IPython.utils.zmqrelated import check_for_zmq
 check_for_zmq('2.1.11', 'IPython.frontend.html.notebook')
 
 import zmq

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -31,7 +31,12 @@ import time
 import uuid
 import webbrowser
 
+
 # Third party
+# check for pyzmq 2.1.11 (this is actually redundant)
+from IPython.kernel.zmq import check_for_zmq
+check_for_zmq('2.1.11', 'IPython.frontend.html.notebook')
+
 import zmq
 from jinja2 import Environment, FileSystemLoader
 
@@ -40,11 +45,24 @@ from jinja2 import Environment, FileSystemLoader
 from zmq.eventloop import ioloop
 ioloop.install()
 
-import tornado
+# check for tornado 2.1.0
+msg = "The IPython Notebook requires tornado >= 2.1.0"
+try:
+    import tornado
+except ImportError:
+    raise ImportError(msg)
+try:
+    version_info = tornado.version_info
+except AttributeError:
+    raise ImportError(msg + ", but you have < 1.1.0")
+if version_info < (2,1,0):
+    raise ImportError(msg + ", but you have %s" % tornado.version)
+
 from tornado import httpserver
 from tornado import web
 
 # Our own libraries
+from IPython.frontend.html.notebook import DEFAULT_STATIC_FILES_PATH
 from .kernelmanager import MappingKernelManager
 from .handlers import (LoginHandler, LogoutHandler,
     ProjectDashboardHandler, NewHandler, NamedNotebookHandler,
@@ -97,9 +115,6 @@ ipython notebook --pylab=inline        # pylab in inline plotting mode
 ipython notebook --certfile=mycert.pem # use SSL/TLS certificate
 ipython notebook --port=5555 --ip=*    # Listen on port 5555, all interfaces
 """
-
-# Packagers: modify this line if you store the notebook static files elsewhere
-DEFAULT_STATIC_FILES_PATH = os.path.join(os.path.dirname(__file__), "static")
 
 #-----------------------------------------------------------------------------
 # Helper functions

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -584,19 +584,7 @@ class NotebookApp(BaseIPythonApplication):
             self.exit(1)
     
     def init_signal(self):
-        # FIXME: remove this check when pyzmq dependency is >= 2.1.11
-        # safely extract zmq version info:
-        try:
-            zmq_v = zmq.pyzmq_version_info()
-        except AttributeError:
-            zmq_v = [ int(n) for n in re.findall(r'\d+', zmq.__version__) ]
-            if 'dev' in zmq.__version__:
-                zmq_v.append(999)
-            zmq_v = tuple(zmq_v)
-        if zmq_v >= (2,1,9) and not sys.platform.startswith('win'):
-            # This won't work with 2.1.7 and
-            # 2.1.9-10 will log ugly 'Interrupted system call' messages,
-            # but it will work
+        if not sys.platform.startswith('win'):
             signal.signal(signal.SIGINT, self._handle_sigint)
         signal.signal(signal.SIGTERM, self._signal_stop)
         if hasattr(signal, 'SIGUSR1'):

--- a/IPython/kernel/__init__.py
+++ b/IPython/kernel/__init__.py
@@ -1,5 +1,8 @@
 """IPython kernels and associated utilities"""
 
+# just for friendlier zmq version check
+from . import zmq
+
 from .connect import *
 from .launcher import *
 from .kernelmanager import KernelManager

--- a/IPython/kernel/zmq/__init__.py
+++ b/IPython/kernel/zmq/__init__.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2010  The IPython Development Team
+#  Copyright (C) 2013  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING.txt, distributed as part of this software.
@@ -9,41 +9,9 @@
 # Verify zmq version dependency >= 2.1.11
 #-----------------------------------------------------------------------------
 
-import warnings
-from IPython.utils.version import check_version
+from IPython.utils.zmqrelated import check_for_zmq
 
-
-def patch_pyzmq():
-    """backport a few patches from newer pyzmq
-    
-    These can be removed as we bump our minimum pyzmq version
-    """
-    
-    import zmq
-    
-    # fallback on stdlib json if jsonlib is selected, because jsonlib breaks things.
-    # jsonlib support is removed from pyzmq >= 2.2.0
-
-    from zmq.utils import jsonapi
-    if jsonapi.jsonmod.__name__ == 'jsonlib':
-        import json
-        jsonapi.jsonmod = json
-
-
-def check_for_zmq(minimum_version, module='IPython.kernel.zmq'):
-    try:
-        import zmq
-    except ImportError:
-        raise ImportError("%s requires pyzmq >= %s"%(module, minimum_version))
-
-    pyzmq_version = zmq.__version__
-    
-    if not check_version(pyzmq_version, minimum_version):
-        raise ImportError("%s requires pyzmq >= %s, but you have %s"%(
-                        module, minimum_version, pyzmq_version))
-
-check_for_zmq('2.1.11')
-patch_pyzmq()
+check_for_zmq('2.1.11', 'IPython.kernel.zmq')
 
 from .session import Session
 

--- a/IPython/parallel/__init__.py
+++ b/IPython/parallel/__init__.py
@@ -21,7 +21,7 @@ import warnings
 import zmq
 
 from IPython.config.configurable import MultipleInstanceError
-from IPython.kernel.zmq import check_for_zmq
+from IPython.utils.zmqrelated import check_for_zmq
 
 min_pyzmq = '2.1.11'
 

--- a/IPython/utils/zmqrelated.py
+++ b/IPython/utils/zmqrelated.py
@@ -1,0 +1,47 @@
+"""utilities for checking zmq versions"""
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2013  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING.txt, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Verify zmq version dependency >= 2.1.11
+#-----------------------------------------------------------------------------
+
+import warnings
+from IPython.utils.version import check_version
+
+
+def patch_pyzmq():
+    """backport a few patches from newer pyzmq
+    
+    These can be removed as we bump our minimum pyzmq version
+    """
+    
+    import zmq
+    
+    # fallback on stdlib json if jsonlib is selected, because jsonlib breaks things.
+    # jsonlib support is removed from pyzmq >= 2.2.0
+
+    from zmq.utils import jsonapi
+    if jsonapi.jsonmod.__name__ == 'jsonlib':
+        import json
+        jsonapi.jsonmod = json
+
+
+def check_for_zmq(minimum_version, required_by='Someone'):
+    try:
+        import zmq
+    except ImportError:
+        raise ImportError("%s requires pyzmq >= %s"%(required_by, minimum_version))
+    
+    patch_pyzmq()
+    
+    pyzmq_version = zmq.__version__
+    
+    if not check_version(pyzmq_version, minimum_version):
+        raise ImportError("%s requires pyzmq >= %s, but you have %s"%(
+                        required_by, minimum_version, pyzmq_version))
+


### PR DESCRIPTION
and move the friendly version checks to notebookapp.py

DEFAULT_STATIC_FILES_PATH is now accessible without pyzmq/tornado/jinja being importable. If someone tries to use old pyzmq or tornado directly with handlers, the version check won't happen, but that's probably the right thing to do anyway.

I also cleaned up a few workarounds for old pyzmq that we no longer support.

Question: should we move `check_for_zmq` to somewhere generic, like `utils.version`?
