### PR TITLE
fix some O(N) and O(N^2) operations in parallel.map

### DIFF
--- a/IPython/parallel/client/map.py
+++ b/IPython/parallel/client/map.py
@@ -56,9 +56,9 @@ else:
     arrayModules.append({'module':numarray,
         'type':numarray.numarraycore.NumArray})
 
-class Map:
+class Map(object):
     """A class for partitioning a sequence using a map."""
-            
+    
     def getPartition(self, seq, p, q):
         """Returns the pth partition of q partitions of seq."""
         
@@ -66,25 +66,24 @@ class Map:
         if p<0 or p>=q:
           print "No partition exists."
           return
-          
-        remainder = len(seq)%q
-        basesize = len(seq)//q
-        hi = []
-        lo = []
-        for n in range(q):
-            if n < remainder:
-                lo.append(n * (basesize + 1))
-                hi.append(lo[-1] + basesize + 1)
-            else:
-                lo.append(n*basesize + remainder)
-                hi.append(lo[-1] + basesize)
+        
+        N = len(seq)
+        remainder = N % q
+        basesize = N // q
+        
+        if p < remainder:
+            low = p * (basesize + 1)
+            high = low + basesize + 1
+        else:
+            low = p * basesize + remainder
+            high = low + basesize
         
         try:
-            result = seq[lo[p]:hi[p]]
+            result = seq[low:high]
         except TypeError:
             # some objects (iterators) can't be sliced,
             # use islice:
-            result = list(islice(seq, lo[p], hi[p]))
+            result = list(islice(seq, low, high))
             
         return result
            

--- a/IPython/parallel/controller/scheduler.py
+++ b/IPython/parallel/controller/scheduler.py
@@ -577,6 +577,7 @@ class TaskScheduler(SessionFactory):
     def save_unmet(self, job):
         """Save a message for later submission when its dependencies are met."""
         msg_id = job.msg_id
+        self.log.debug("Adding task %s to the queue", msg_id)
         self.queue_map[msg_id] = job
         heapq.heappush(self.queue, job)
         # track the ids in follow or after, but not those already finished

--- a/IPython/parallel/controller/scheduler.py
+++ b/IPython/parallel/controller/scheduler.py
@@ -796,7 +796,7 @@ def launch_scheduler(in_addr, out_addr, mon_addr, not_addr, reg_addr, config=Non
                         identity=b'task', in_thread=False):
 
     ZMQStream = zmqstream.ZMQStream
-    loglevel = logging.DEBUG
+
     if config:
         # unwrap dict back into Config
         config = Config(config)


### PR DESCRIPTION
some left over code from (presumably) when the map partitioning objects
were stateful made the current implemenation O(N^2),
thus crazy slow for much more than a thousand tasks.

A decorator has also been fixed to avoid calling itself more than once in a given context.

An O(N) operation when `TaskScheduler.hwm != 0` has also been fixed.

Illustration of performance differences:

http://nbviewer.ipython.org/5267262

closes #3106
