### PR TITLE
prefer pyrepl to readline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
     - 3.3
 before_install:
     - easy_install -q pyzmq
+    - pip install pyrepl
 install:
     - python setup.py install -q 
 script:

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -28,6 +28,7 @@ import runpy
 import sys
 import tempfile
 import types
+import warnings
 from io import open as io_open
 
 from IPython.config.configurable import SingletonConfigurable
@@ -1843,7 +1844,8 @@ class InteractiveShell(SingletonConfigurable):
                 inputrc_name = os.path.join(self.home_dir, inputrc_name)
             if os.path.isfile(inputrc_name):
                 try:
-                    readline.read_init_file(inputrc_name)
+                    with warnings.catch_warnings('ignore'):
+                        readline.read_init_file(inputrc_name)
                 except:
                     warn('Problems reading readline initialization file <%s>'
                          % inputrc_name)

--- a/IPython/utils/rlineimpl.py
+++ b/IPython/utils/rlineimpl.py
@@ -76,7 +76,7 @@ if uses_libedit and sys.platform == 'darwin':
         "     pip install pyrepl",
         "*"*78]),
         RuntimeWarning)
-elif have_readline and not sys.platform in ('win32', 'cli'):
+elif have_readline and not have_pyrepl and not sys.platform in ('win32', 'cli'):
     warnings.warn('\n'.join(["",
         "Python readline has a bug, where C-c to interrupt C-r reverse-i search",
         "can leave hidden input. Make sure you use C-g to end C-r search, and not C-c.",

--- a/IPython/utils/rlineimpl.py
+++ b/IPython/utils/rlineimpl.py
@@ -12,49 +12,25 @@ boolean and _outputfile variable used in IPython.utils.
 import sys
 import warnings
 
-if sys.platform == 'darwin':
-    # dirty trick, to skip the system readline, because pip-installed readline
-    # will never be found on OSX, since lib-dynload always comes ahead of site-packages
-    from distutils import sysconfig
-    lib_dynload = sysconfig.get_config_var('DESTSHARED')
-    del sysconfig
-    try:
-        dynload_idx = sys.path.index(lib_dynload)
-    except ValueError:
-        dynload_idx = None
-    else:
-        sys.path.pop(dynload_idx)
+# priority: pyrepl > readline > pyreadline
+have_pyrepl = False
 try:
-    from readline import *
-    import readline as _rl
+    from pyrepl.readline import *
+    import pyrepl.readline as _rl
     have_readline = True
+    have_pyrepl = True
 except ImportError:
     try:
-        from pyreadline import *
-        import pyreadline as _rl
+        from readline import *
+        import readline as _rl
         have_readline = True
     except ImportError:
-        have_readline = False
-
-if sys.platform == 'darwin':
-    # dirty trick, part II:
-    if dynload_idx is not None:
-        # restore path
-        sys.path.insert(dynload_idx, lib_dynload)
-        if not have_readline:
-            # *only* have system readline, try import again
-            try:
-                from readline import *
-                import readline as _rl
-                have_readline = True
-            except ImportError:
-                have_readline = False
-            else:
-                # if we want to warn about EPD / Fink having bad readline
-                # we would do it here
-                pass
-    # cleanup dirty trick vars
-    del dynload_idx, lib_dynload
+        try:
+            from pyreadline import *
+            import pyreadline as _rl
+            have_readline = True
+        except ImportError:
+            have_readline = False
 
 if have_readline and hasattr(_rl, 'rlmain'):
     # patch add_history to allow for strings in pyreadline <= 1.5:
@@ -96,14 +72,18 @@ if uses_libedit and sys.platform == 'darwin':
         "   * incorrect history navigation",
         "   * corrupting long-lines",
         "   * failure to wrap or indent lines properly",
-        "It is highly recommended that you install readline, which is easy_installable:",
-        "     easy_install readline",
-        "Note that `pip install readline` generally DOES NOT WORK, because",
-        "it installs to site-packages, which come *after* lib-dynload in sys.path,",
-        "where readline is located.  It must be `easy_install readline`, or to a custom",
-        "location on your PYTHONPATH (even --user comes after lib-dyload).",
+        "It is highly recommended that you install pyrepl, which is pip installable:",
+        "     pip install pyrepl",
         "*"*78]),
         RuntimeWarning)
+elif have_readline and not sys.platform in ('win32', 'cli'):
+    warnings.warn('\n'.join(["",
+        "Python readline has a bug, where C-c to interrupt C-r reverse-i search",
+        "can leave hidden input. Make sure you use C-g to end C-r search, and not C-c.",
+        "It is highly recommended that you install pyrepl, which is pip installable:",
+        "     pip install pyrepl",
+        ]),
+    RuntimeWarning)
 
 # the clear_history() function was only introduced in Python 2.4 and is
 # actually optional in the readline API, so we must explicitly check for its

--- a/setup.py
+++ b/setup.py
@@ -239,16 +239,13 @@ if 'setuptools' in sys.modules:
     requires = setup_args.setdefault('install_requires', [])
     setupext.display_status = False
     if not setupext.check_for_readline():
-        if sys.platform == 'darwin':
-            requires.append('readline')
-        elif sys.platform.startswith('win'):
+        if sys.platform.startswith('win'):
             # Pyreadline 64 bit windows issue solved in versions >=1.7.1
             # Also solves issues with some older versions of pyreadline that
             # satisfy the unconstrained depdendency.
             requires.append('pyreadline>=1.7.1')
         else:
-            pass
-            # do we want to install readline here?
+            requires.append('pyrepl>=0.8.4')
 
     # Script to be run by the windows binary installer after the default setup
     # routine, to add shortcuts and similar windows-only things.  Windows

--- a/setupext/setupext.py
+++ b/setupext/setupext.py
@@ -153,20 +153,20 @@ def check_for_pyzmq():
 def check_for_readline():
     from distutils.version import LooseVersion
     try:
-        import readline
+        import pyrepl
     except ImportError:
         try:
             import pyreadline
             vs = pyreadline.release.version
         except (ImportError, AttributeError):
-            print_status('readline', "no (required for good interactive behavior)")
+            print_status('pyrepl', "no (required for good interactive behavior)")
             return False
         if LooseVersion(vs).version >= [1,7,1]:
-            print_status('readline', "yes pyreadline-" + vs)
+            print_status('pyrepl', "yes pyreadline-" + vs)
             return True
         else:
-            print_status('readline', "no pyreadline-%s < 1.7.1" % vs)
+            print_status('pyrepl', "no pyreadline-%s < 1.7.1" % vs)
             return False
     else:
-        print_status('readline', "yes")
+        print_status('pyrepl', "yes")
         return True


### PR DESCRIPTION
This is mainly to start a discussion, not necessarily a proposal to merge as-is.

avoids various readline-related issues, such as #1286.

By preferring pyrepl to readline, we can remove the gross sys.path hack to get around System libedit readline on OS X.

I don't yet know the full limitations of pyrepl (I imagine it doesn't work on Windows), but I do know it at least doesn't yet support `readline.read_init_file`.
