### PR TITLE
Fix for color ls output on OSX, implicit cd support, case insensitive tab completion

### DIFF
--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -70,8 +70,22 @@ def default_aliases():
                           # things which are executable
                           ('lx', 'ls -F -o --color %l | grep ^-..x'),
                           ]
+        elif sys.platform.startswith('darwin'):
+            # OSX
+            ls_aliases = [('ls', 'ls -FG'),
+                          # long ls
+                          ('ll', 'ls -FG -l'),
+                          # ls normal files only
+                          ('lf', 'ls -FG -l %l | grep ^-'),
+                          # ls symbolic links
+                          ('lk', 'ls -FG -l %l | grep ^l'),
+                          # directories or links to directories,
+                          ('ldir', 'ls -FG -l %l | grep /$'),
+                          # things which are executable
+                          ('lx', 'ls -FG -l %l | grep ^-..x'),
+                          ]
         else:
-            # BSD, OSX, etc.
+            # BSD, etc.
             ls_aliases = [('ls', 'ls -F'),
                           # long ls
                           ('ll', 'ls -F -l'),
@@ -255,7 +269,7 @@ class AliasManager(Configurable):
                 if l2.split(None,1)[0] == line.split(None,1)[0]:
                     line = l2
                     break
-                line=l2
+                line = l2
             else:
                 break
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2645,6 +2645,8 @@ class InteractiveShell(SingletonConfigurable):
                             MemoryError):
                         if self.implicit_cd:
                             if os.path.isdir(cell.strip()): # implicit cd
+                                if store_history:
+                                    self.execution_count += 1
                                 os.chdir(cell.strip())
                                 return None
                         self.showsyntaxerror()

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2644,10 +2644,11 @@ class InteractiveShell(SingletonConfigurable):
                     except (OverflowError, SyntaxError, ValueError, TypeError,
                             MemoryError):
                         if self.implicit_cd:
-                            if os.path.isdir(cell.strip()): # implicit cd
+                            command = cell.strip()
+                            if os.path.isdir(command): # implicit cd
                                 if store_history:
                                     self.execution_count += 1
-                                os.chdir(cell.strip())
+                                self.run_line_magic('cd', command)
                                 return None
                         self.showsyntaxerror()
                         if store_history:
@@ -2830,9 +2831,9 @@ class InteractiveShell(SingletonConfigurable):
             self.CustomTB(etype,value,tb)
         except NameError:
             if self.implicit_cd:
-                command = code_obj.co_names[0]
-                if os.path.isdir(command.strip()): # implicit cd
-                    os.chdir(command.strip())
+                command = code_obj.co_names[0].strip()
+                if os.path.isdir(command): # implicit cd
+                    self.run_line_magic('cd', command)
             else:
                 raise
         except:

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -182,8 +182,9 @@ class OSMagics(Magics):
                             try:
                                 # Removes dots from the name since ipython
                                 # will assume names with dots to be python.
-                                self.shell.alias_manager.define_alias(
-                                    ff.replace('.',''), ff)
+                                if ff not in self.shell.alias_manager:
+                                    self.shell.alias_manager.define_alias(
+                                        ff.replace('.',''), ff)
                             except InvalidAliasError:
                                 pass
                             else:


### PR DESCRIPTION
I've been looking into replacing my current favorite shell (Oh My Zsh) with IPython, these fixes go a long way towards making that a reality.

Implicit cd and case insensitive tab are of course a user preference, so I have made them configurable and kept the default behavior. To enable use this in your config:

c.InteractiveShell.implicit_cd = True
c.Completer.case_insensitive = True
