### PR TITLE
Prevent errors when pressing arrow keys in an empty notebook

### DIFF
--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -1381,7 +1381,7 @@ var IPython = (function (IPython) {
     /**
      * Run the selected cell.
      * 
-     * This executes code cells, and skips all others.
+     * Execute or render cell outputs.
      * 
      * @method execute_selected_cell
      * @param {Object} options Customize post-execution behavior

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -137,13 +137,13 @@ var IPython = (function (IPython) {
             }
             if (event.which === key.UPARROW && !event.shiftKey) {
                 var cell = that.get_selected_cell();
-                if (cell.at_top()) {
+                if (cell && cell.at_top()) {
                     event.preventDefault();
                     that.select_prev();
                 };
             } else if (event.which === key.DOWNARROW && !event.shiftKey) {
                 var cell = that.get_selected_cell();
-                if (cell.at_bottom()) {
+                if (cell && cell.at_bottom()) {
                     event.preventDefault();
                     that.select_next();
                 };


### PR DESCRIPTION
`Notebook.get_selected_cell()` returns `null` in an empty notebook.

As a bonus, there's a CasperJS test in https://github.com/ipython/ipython/pull/3125.
