### PR TITLE
Strip useless ANSI escape codes in notebook

### DIFF
--- a/IPython/frontend/html/notebook/static/js/utils.js
+++ b/IPython/frontend/html/notebook/static/js/utils.js
@@ -174,6 +174,12 @@ IPython.utils = (function (IPython) {
         var cmds = [];
         var opener = "";
         var closer = "";
+
+        // Strip all ANSI codes that are not color related.  Matches
+        // all ANSI codes that do not end with "m".
+        var ignored_re = /(?=(\033\[[\d;=]*[a-ln-zA-Z]{1}))\1(?!m)/g;
+        txt = txt.replace(ignored_re, "");
+
         while (re.test(txt)) {
             var cmds = txt.match(re)[1].split(";");
             closer = opened?"</span>":"";


### PR DESCRIPTION
This fixes issue #2385.

ANSI color escape codes get handled specially by the notebook, but other kinds of codes just get printed out.  Strip these codes out of the notebook output.
