### PR TITLE
fix dot syntax error in inheritance diagram

### DIFF
--- a/docs/sphinxext/inheritance_diagram.py
+++ b/docs/sphinxext/inheritance_diagram.py
@@ -183,7 +183,7 @@ class InheritanceGraph(object):
         "shape": "box",
         "fontsize": 10,
         "height": 0.25,
-        "fontname": "Vera Sans, DejaVu Sans, Liberation Sans, Arial, Helvetica, sans",
+        "fontname": '"Vera Sans, DejaVu Sans, Liberation Sans, Arial, Helvetica, sans"',
         "style": '"setlinewidth(0.5)"'
         }
     default_edge_options = {


### PR DESCRIPTION
came up building the 0.13.2 docs.
