### PR TITLE
semi-persistent notebook IDs

### DIFF
--- a/IPython/frontend/html/notebook/filenbmanager.py
+++ b/IPython/frontend/html/notebook/filenbmanager.py
@@ -176,20 +176,18 @@ class FileNotebookManager(NotebookManager):
         self.delete_notebook_id(notebook_id)
 
     def increment_filename(self, basename):
-        """Return a non-used filename of the form basename<int>.
+        """Return a non-used filename of the form basename[int].
         
-        This searches through the filenames (basename0, basename1, ...)
+        This searches through the filenames (basename, basename0, basename1, ...)
         until is find one that is not already being used. It is used to
         create Untitled and Copy names that are unique.
         """
+        name = basename
+        path = self.get_path_by_name(name)
         i = 0
-        while True:
-            name = u'%s%i' % (basename,i)
-            path = self.get_path_by_name(name)
-            if not os.path.isfile(path):
-                break
-            else:
-                i = i+1
+        while os.path.exists(self.get_path_by_name(name)):
+            name = u'%s%i' % (basename, i)
+            i += 1
         return name
         
     def info_string(self):

--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -284,7 +284,8 @@ class NewHandler(AuthenticatedHandler):
     def get(self):
         nbm = self.application.notebook_manager
         project = nbm.notebook_dir
-        notebook_id = nbm.new_notebook()
+        name = self.get_argument('name', None)
+        notebook_id = nbm.new_notebook(name)
         self.redirect('/'+urljoin(self.application.ipython_app.base_project_url, notebook_id))
 
 class NamedNotebookHandler(AuthenticatedHandler):
@@ -676,7 +677,8 @@ class NotebookCopyHandler(AuthenticatedHandler):
     def get(self, notebook_id):
         nbm = self.application.notebook_manager
         project = nbm.notebook_dir
-        notebook_id = nbm.copy_notebook(notebook_id)
+        name = self.get_argument('name', None)
+        notebook_id = nbm.copy_notebook(notebook_id, name)
         self.redirect('/'+urljoin(self.application.ipython_app.base_project_url, notebook_id))
 
 

--- a/IPython/frontend/html/notebook/nbmanager.py
+++ b/IPython/frontend/html/notebook/nbmanager.py
@@ -197,18 +197,21 @@ class NotebookManager(LoggingConfigurable):
         """
         return name
 
-    def new_notebook(self):
+    def new_notebook(self, name=None):
         """Create a new notebook and return its notebook_id."""
-        name = self.increment_filename('Untitled')
+        if name is None:
+            name = 'Untitled'
+        name = self.increment_filename(name)
         metadata = current.new_metadata(name=name)
         nb = current.new_notebook(metadata=metadata)
         notebook_id = self.write_notebook_object(nb)
         return notebook_id
 
-    def copy_notebook(self, notebook_id):
+    def copy_notebook(self, notebook_id, name=None):
         """Copy an existing notebook and return its notebook_id."""
         last_mod, nb = self.read_notebook_object(notebook_id)
-        name = nb.metadata.name + '-Copy'
+        if name is None:
+            name = nb.metadata.name + '-Copy'
         name = self.increment_filename(name)
         nb.metadata.name = name
         notebook_id = self.write_notebook_object(nb)

--- a/IPython/frontend/html/notebook/nbmanager.py
+++ b/IPython/frontend/html/notebook/nbmanager.py
@@ -23,6 +23,7 @@ from tornado import web
 
 from IPython.config.configurable import LoggingConfigurable
 from IPython.nbformat import current
+from IPython.utils import py3compat
 from IPython.utils.traitlets import List, Dict, Unicode, TraitError
 
 #-----------------------------------------------------------------------------
@@ -86,16 +87,23 @@ class NotebookManager(LoggingConfigurable):
 
     def new_notebook_id(self, name):
         """Generate a new notebook_id for a name and store its mapping."""
-        # TODO: the following will give stable urls for notebooks, but unless
-        # the notebooks are immediately redirected to their new urls when their
-        # filemname changes, nasty inconsistencies result.  So for now it's
-        # disabled and instead we use a random uuid4() call.  But we leave the
-        # logic here so that we can later reactivate it, whhen the necessary
-        # url redirection code is written.
-        #notebook_id = unicode(uuid.uuid5(uuid.NAMESPACE_URL,
-        #                 'file://'+self.get_path_by_name(name).encode('utf-8')))
-        
-        notebook_id = unicode(uuid.uuid4())
+        # Notebook IDs are persistent for a given notebook for the lifetime
+        # of the notebook server. They are based on the initial name of the notebook,
+        # so UUID urls are only persistent across server sessions
+        # for notebooks that have not been renamed.
+        # Since it's possible for multiple notebooks to have the same initial name,
+        # from which their UUID is derived, collisions are prevented
+        # by forcing a random UUID in that case.
+        url = u'file://%s:%s' % (self.notebook_dir, name)
+        notebook_id = unicode(uuid.uuid5(
+                        uuid.NAMESPACE_URL,
+                        py3compat.unicode_to_str(url)
+        ))
+        # avoid collisions, which can occur if multiple notebooks start with
+        # the same name
+        while notebook_id in self.mapping:
+            self.log.info("Notebook id collision: %s (%s)", notebook_id, name)
+            notebook_id = unicode(uuid.uuid4())
         self.mapping[notebook_id] = name
         return notebook_id
 

--- a/IPython/frontend/html/notebook/static/js/menubar.js
+++ b/IPython/frontend/html/notebook/static/js/menubar.js
@@ -67,7 +67,14 @@ var IPython = (function (IPython) {
         //  File
         var that = this;
         this.element.find('#new_notebook').click(function () {
-            window.open(that.baseProjectUrl()+'new');
+            IPython.utils.notebook_name_dialog(
+                "New Notebook",
+                "Enter new notebook name:",
+                "Untitled",
+                function(new_name) {
+                    window.open(that.baseProjectUrl()+'new?name=' + new_name);
+                }
+            );
         });
         this.element.find('#open_notebook').click(function () {
             window.open(that.baseProjectUrl());
@@ -76,9 +83,16 @@ var IPython = (function (IPython) {
             IPython.save_widget.rename_notebook();
         });
         this.element.find('#copy_notebook').click(function () {
-            var notebook_id = IPython.notebook.get_notebook_id();
-            var url = that.baseProjectUrl() + notebook_id + '/copy';
-            window.open(url,'_blank');
+            IPython.utils.notebook_name_dialog(
+                "Copy Notebook",
+                "Enter new notebook name:",
+                IPython.notebook.notebook_name + '-Copy',
+                function(new_name) {
+                    var notebook_id = IPython.notebook.get_notebook_id();
+                    var url = that.baseProjectUrl()+ notebook_id + '/copy?name=' + new_name;
+                    window.open(url, '_blank');
+                }
+            );
             return false;
         });
         this.element.find('#save_notebook').click(function () {

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -44,7 +44,6 @@ var IPython = (function (IPython) {
         this.control_key_active = false;
         this.notebook_id = null;
         this.notebook_name = null;
-        this.notebook_name_blacklist_re = /[\/\\:]/;
         this.nbformat = 3 // Increment this when changing the nbformat
         this.nbformat_minor = 0 // Increment this when changing the nbformat
         this.style();
@@ -1486,22 +1485,6 @@ var IPython = (function (IPython) {
      */
     Notebook.prototype.set_notebook_name = function (name) {
         this.notebook_name = name;
-    };
-
-    /**
-     * Check that a notebook's name is valid.
-     * 
-     * @method test_notebook_name
-     * @param {String} nbname A name for this notebook
-     * @return {Boolean} True if the name is valid, false if invalid
-     */
-    Notebook.prototype.test_notebook_name = function (nbname) {
-        nbname = nbname || '';
-        if (this.notebook_name_blacklist_re.test(nbname) == false && nbname.length>0) {
-            return true;
-        } else {
-            return false;
-        };
     };
 
     /**

--- a/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
+++ b/IPython/frontend/html/notebook/static/js/projectdashboardmain.js
@@ -22,7 +22,14 @@ $(document).ready(function () {
     $('#ipython-main-app').addClass('border-box-sizing ui-widget');
     $('div#notebooks_toolbar').addClass('ui-widget ui-helper-clearfix');    
     $('#new_notebook').button().click(function (e) {
-        window.open($('body').data('baseProjectUrl')+'new');
+        IPython.utils.notebook_name_dialog(
+            "New Notebook",
+            "Enter new notebook name:",
+            "Untitled",
+            function(new_name) {
+                window.open($('body').data('baseProjectUrl')+'new?name=' + new_name);
+            }
+        );
     });
 
     IPython.read_only = $('body').data('readOnly') === 'True';

--- a/IPython/frontend/html/notebook/static/js/savewidget.js
+++ b/IPython/frontend/html/notebook/static/js/savewidget.js
@@ -59,52 +59,14 @@ var IPython = (function (IPython) {
 
     SaveWidget.prototype.rename_notebook = function () {
         var that = this;
-        var dialog = $('<div/>');
-        dialog.append(
-            $('<h3/>').html('Enter a new notebook name:')
-            .css({'margin-bottom': '10px'})
-        );
-        dialog.append(
-            $('<input/>').attr('type','text').attr('size','25')
-            .addClass('ui-widget ui-widget-content')
-            .attr('value',IPython.notebook.get_notebook_name())
-        );
-        // $(document).append(dialog);
-        dialog.dialog({
-            resizable: false,
-            modal: true,
-            title: "Rename Notebook",
-            closeText: "",
-            close: function(event, ui) {$(this).dialog('destroy').remove();},
-            buttons : {
-                "OK": function () {
-                    var new_name = $(this).find('input').attr('value');
-                    if (!IPython.notebook.test_notebook_name(new_name)) {
-                        $(this).find('h3').html(
-                            "Invalid notebook name. Notebook names must "+
-                            "have 1 or more characters and can contain any characters " +
-                            "except :/\\. Please enter a new notebook name:"
-                        );
-                    } else {
-                        IPython.notebook.set_notebook_name(new_name);
-                        IPython.notebook.save_notebook();
-                        $(this).dialog('close');
-                    }
-                },
-                "Cancel": function () {
-                    $(this).dialog('close');
-                }
-            },
-            open : function (event, ui) {
-                var that = $(this);
-                // Upon ENTER, click the OK button.
-                that.find('input[type="text"]').keydown(function (event, ui) {
-                    if (event.which === utils.keycodes.ENTER) {
-                        that.parent().find('button').first().click();
-                    }
-                });
+        IPython.utils.notebook_name_dialog(
+            "Rename Notebook",
+            "Enter a new notebook name:",
+            function (new_name) {
+                IPython.notebook.set_notebook_name(new_name);
+                IPython.notebook.save_notebook();
             }
-        });
+        );
     }
 
 

--- a/IPython/frontend/html/notebook/static/js/utils.js
+++ b/IPython/frontend/html/notebook/static/js/utils.js
@@ -269,6 +269,75 @@ IPython.utils = (function (IPython) {
         return M;
     })();
 
+    var notebook_name_blacklist_re= /[\/\\:]/;
+
+    /**
+     * Check that a notebook's name is valid.
+     * 
+     * @function test_notebook_name
+     * @param {String} nbname A name for a notebook
+     * @return {Boolean} True if the name is valid, false if invalid
+     */
+    var test_notebook_name = function (nbname) {
+        nbname = nbname || '';
+        if (notebook_name_blacklist_re.test(nbname) == false && nbname.length>0) {
+            return true;
+        } else {
+            return false;
+        };
+    };
+
+    
+    var notebook_name_dialog = function(title, prompt, initial_value, action) {
+        // a dialog for entering a notebook name
+        // used in rename, new notebook, duplicate
+        var dialog = $('<div/>');
+        dialog.append(
+            $('<h3/>').html(prompt)
+            .css({'margin-bottom': '10px'})
+        );
+        dialog.append(
+            $('<input/>').attr('type','text').attr('size','25')
+            .addClass('ui-widget ui-widget-content')
+            .attr('value', initial_value)
+        );
+        dialog.dialog({
+            resizable: false,
+            modal: true,
+            title: title,
+            closeText: "",
+            close: function(event, ui) {$(this).dialog('destroy').remove();},
+            buttons : {
+                "OK": function () {
+                    var new_name = $(this).find('input').attr('value');
+                    if (!test_notebook_name(new_name)) {
+                        $(this).find('h3').html(
+                            "Invalid notebook name. Notebook names must "+
+                            "have 1 or more characters and can contain any characters " +
+                            "except :/\\. Please enter a new notebook name:"
+                        );
+                    } else {
+                        action(new_name);
+                        $(this).dialog('close');
+                    }
+                },
+                "Cancel": function () {
+                    $(this).dialog('close');
+                }
+            },
+            open : function (event, ui) {
+                var that = $(this);
+                // Upon ENTER, click the OK button.
+                that.find('input[type="text"]').keydown(function (event, ui) {
+                    if (event.which === keycodes.ENTER) {
+                        that.parent().find('button').first().click();
+                    }
+                });
+            }
+        });
+        
+    }
+
 
     return {
         regex_split : regex_split,
@@ -279,7 +348,9 @@ IPython.utils = (function (IPython) {
         fixCarriageReturn : fixCarriageReturn,
         autoLinkUrls : autoLinkUrls,
         points_to_pixels : points_to_pixels,
-        browser : browser    
+        browser : browser,
+        test_notebook_name : test_notebook_name,
+        notebook_name_dialog : notebook_name_dialog
     };
 
 }(IPython));

--- a/IPython/frontend/html/notebook/templates/projectdashboard.html
+++ b/IPython/frontend/html/notebook/templates/projectdashboard.html
@@ -87,4 +87,5 @@ data-read-only={{read_only}}
     <script src="{{static_url("js/notebooklist.js") }}" type="text/javascript" charset="utf-8"></script>
     <script src="{{static_url("js/clusterlist.js") }}" type="text/javascript" charset="utf-8"></script>
     <script src="{{static_url("js/projectdashboardmain.js") }}" type="text/javascript" charset="utf-8"></script>
+    <script src="{{ static_url("js/utils.js") }}" type="text/javascript" charset="utf-8"></script>
 {% endblock %}


### PR DESCRIPTION
notebook id is invariant for the lifetime of the notebook server exactly as before, and is based on the _initial_ name of the notebook.
- If the notebook is renamed, its UUID will not change
  during this session, but it will have a new UUID in the next session.
- If a notebook has the same initial name as another previously seen,
  it will get a random ID, avoiding any collisions.

Currently, the user has no control over the initial names of notebooks, which means that even with this scheme, UUIDs are almost guaranteed to change from the session in which a notebook is created and the next.  To address this, a 'name' argument is added to both the 'new notebook' and 'copy notebook' methods, and these actions now prompt for the name of the new notebook before creating them.

Be _extremely_ careful testing this PR - the reason we haven't done persistent UUIDs before is our first attempt resulted in data loss, so we must be careful and rigorous here.
