### PR TITLE
Default color output for ls on OSX

### DIFF
--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -72,17 +72,17 @@ def default_aliases():
                           ]
         else:
             # BSD, OSX, etc.
-            ls_aliases = [('ls', 'ls -F'),
+            ls_aliases = [('ls', 'ls -F -G'),
                           # long ls
-                          ('ll', 'ls -F -l'),
+                          ('ll', 'ls -F -l -G'),
                           # ls normal files only
-                          ('lf', 'ls -F -l %l | grep ^-'),
+                          ('lf', 'ls -F -l -G %l | grep ^-'),
                           # ls symbolic links
-                          ('lk', 'ls -F -l %l | grep ^l'),
+                          ('lk', 'ls -F -l -G %l | grep ^l'),
                           # directories or links to directories,
-                          ('ldir', 'ls -F -l %l | grep /$'),
+                          ('ldir', 'ls -F -G -l %l | grep /$'),
                           # things which are executable
-                          ('lx', 'ls -F -l %l | grep ^-..x'),
+                          ('lx', 'ls -F -l -G %l | grep ^-..x'),
                           ]
         default_aliases = default_aliases + ls_aliases
     elif os.name in ['nt', 'dos']:
@@ -255,7 +255,7 @@ class AliasManager(Configurable):
                 if l2.split(None,1)[0] == line.split(None,1)[0]:
                     line = l2
                     break
-                line=l2
+                line = l2
             else:
                 break
 

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -182,8 +182,9 @@ class OSMagics(Magics):
                             try:
                                 # Removes dots from the name since ipython
                                 # will assume names with dots to be python.
-                                self.shell.alias_manager.define_alias(
-                                    ff.replace('.',''), ff)
+                                if ff not in self.shell.alias_manager:
+                                    self.shell.alias_manager.define_alias(
+                                        ff.replace('.',''), ff)
                             except InvalidAliasError:
                                 pass
                             else:


### PR DESCRIPTION
Also fixed incorrect overriding of ls alias on OSX which prevented producing color output.
