### PR TITLE
Better error message when CWD doesn't exist on startup

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -147,18 +147,12 @@ class BaseIPythonApplication(Application):
     def __init__(self, **kwargs):
         super(BaseIPythonApplication, self).__init__(**kwargs)
         # ensure current working directory exists
-        level_up = False
-        while True:
-            try:
-                directory = os.getcwdu()
-            except OSError:
-                # search level up until directory exists
-                os.chdir("..")
-                level_up = True
-            else:
-                if level_up:
-                    self.log.warn("Current working directory doesn't exist.\nSetting to: %s"%(directory))
-                break
+        try:
+            directory = os.getcwdu()
+        except:
+            # raise exception
+            self.log.error("Current working directory doesn't exist.")
+            raise
 
         # ensure even default IPYTHONDIR exists
         if not os.path.exists(self.ipython_dir):

--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -146,6 +146,20 @@ class BaseIPythonApplication(Application):
 
     def __init__(self, **kwargs):
         super(BaseIPythonApplication, self).__init__(**kwargs)
+        # ensure current working directory exists
+        level_up = False
+        while True:
+            try:
+                directory = os.getcwdu()
+            except OSError:
+                # search level up until directory exists
+                os.chdir("..")
+                level_up = True
+            else:
+                if level_up:
+                    self.log.warn("Current working directory doesn't exist.\nSetting to: %s"%(directory))
+                break
+
         # ensure even default IPYTHONDIR exists
         if not os.path.exists(self.ipython_dir):
             self._ipython_dir_changed('ipython_dir', self.ipython_dir, self.ipython_dir)

--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -144,6 +144,7 @@ class BaseIPythonApplication(Application):
     # The class to use as the crash handler.
     crash_handler_class = Type(crashhandler.CrashHandler)
 
+    @catch_config_error
     def __init__(self, **kwargs):
         super(BaseIPythonApplication, self).__init__(**kwargs)
         # ensure current working directory exists

--- a/IPython/parallel/scripts/ipcluster
+++ b/IPython/parallel/scripts/ipcluster
@@ -11,8 +11,15 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
-
+import sys
+import traceback
 
 from IPython.parallel.apps.ipclusterapp import launch_new_instance
 
-launch_new_instance()
+try:
+    launch_new_instance()
+except:
+    exc_type, exc_value, exc_traceback = sys.exc_info()
+    traceback.print_exception(exc_type, exc_value, exc_traceback,
+                              file=sys.stderr)
+    sys.exit(1)

--- a/IPython/parallel/scripts/ipcluster
+++ b/IPython/parallel/scripts/ipcluster
@@ -11,15 +11,6 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
-import sys
-import traceback
-
 from IPython.parallel.apps.ipclusterapp import launch_new_instance
 
-try:
-    launch_new_instance()
-except:
-    exc_type, exc_value, exc_traceback = sys.exc_info()
-    traceback.print_exception(exc_type, exc_value, exc_traceback,
-                              file=sys.stderr)
-    sys.exit(1)
+launch_new_instance()

--- a/IPython/parallel/scripts/ipcontroller
+++ b/IPython/parallel/scripts/ipcontroller
@@ -11,15 +11,6 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
-import sys
-import traceback
-
 from IPython.parallel.apps.ipcontrollerapp import launch_new_instance
 
-try:
-    launch_new_instance()
-except:
-    exc_type, exc_value, exc_traceback = sys.exc_info()
-    traceback.print_exception(exc_type, exc_value, exc_traceback,
-                              file=sys.stderr)
-    sys.exit(1)
+launch_new_instance()

--- a/IPython/parallel/scripts/ipcontroller
+++ b/IPython/parallel/scripts/ipcontroller
@@ -11,8 +11,15 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
-
+import sys
+import traceback
 
 from IPython.parallel.apps.ipcontrollerapp import launch_new_instance
 
-launch_new_instance()
+try:
+    launch_new_instance()
+except:
+    exc_type, exc_value, exc_traceback = sys.exc_info()
+    traceback.print_exception(exc_type, exc_value, exc_traceback,
+                              file=sys.stderr)
+    sys.exit(1)

--- a/IPython/parallel/scripts/ipengine
+++ b/IPython/parallel/scripts/ipengine
@@ -11,15 +11,6 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
-import sys
-import traceback
-
 from IPython.parallel.apps.ipengineapp import launch_new_instance
 
-try:
-    launch_new_instance()
-except:
-    exc_type, exc_value, exc_traceback = sys.exc_info()
-    traceback.print_exception(exc_type, exc_value, exc_traceback,
-                              file=sys.stderr)
-    sys.exit(1)
+launch_new_instance()

--- a/IPython/parallel/scripts/ipengine
+++ b/IPython/parallel/scripts/ipengine
@@ -11,10 +11,15 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
-
+import sys
+import traceback
 
 from IPython.parallel.apps.ipengineapp import launch_new_instance
 
-launch_new_instance()
-
-
+try:
+    launch_new_instance()
+except:
+    exc_type, exc_value, exc_traceback = sys.exc_info()
+    traceback.print_exception(exc_type, exc_value, exc_traceback,
+                              file=sys.stderr)
+    sys.exit(1)

--- a/IPython/parallel/scripts/iplogger
+++ b/IPython/parallel/scripts/iplogger
@@ -11,10 +11,15 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
-
+import sys
+import traceback
 
 from IPython.parallel.apps.iploggerapp import launch_new_instance
 
-launch_new_instance()
-
-
+try:
+    launch_new_instance()
+except:
+    exc_type, exc_value, exc_traceback = sys.exc_info()
+    traceback.print_exception(exc_type, exc_value, exc_traceback,
+                              file=sys.stderr)
+    sys.exit(1)

--- a/IPython/parallel/scripts/iplogger
+++ b/IPython/parallel/scripts/iplogger
@@ -11,15 +11,6 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
-import sys
-import traceback
-
 from IPython.parallel.apps.iploggerapp import launch_new_instance
 
-try:
-    launch_new_instance()
-except:
-    exc_type, exc_value, exc_traceback = sys.exc_info()
-    traceback.print_exception(exc_type, exc_value, exc_traceback,
-                              file=sys.stderr)
-    sys.exit(1)
+launch_new_instance()

--- a/IPython/scripts/ipython
+++ b/IPython/scripts/ipython
@@ -1,15 +1,7 @@
 #!/usr/bin/env python
 """Terminal-based IPython entry point.
 """
-import sys
-import traceback
 
 from IPython.frontend.terminal.ipapp import launch_new_instance
 
-try:
-    launch_new_instance()
-except:
-    exc_type, exc_value, exc_traceback = sys.exc_info()
-    traceback.print_exception(exc_type, exc_value, exc_traceback,
-                              file=sys.stderr)
-    sys.exit(1)
+launch_new_instance()

--- a/IPython/scripts/ipython
+++ b/IPython/scripts/ipython
@@ -1,7 +1,15 @@
 #!/usr/bin/env python
 """Terminal-based IPython entry point.
 """
+import sys
+import traceback
 
 from IPython.frontend.terminal.ipapp import launch_new_instance
 
-launch_new_instance()
+try:
+    launch_new_instance()
+except:
+    exc_type, exc_value, exc_traceback = sys.exc_info()
+    traceback.print_exception(exc_type, exc_value, exc_traceback,
+                              file=sys.stderr)
+    sys.exit(1)


### PR DESCRIPTION
When starting an ipython application in a directory, that doens't exist,
search for first existing directory upwards instead of crashing.

See bug:
https://bugzilla.redhat.com/show_bug.cgi?id=593115
