### PR TITLE
Notebook support for a reverse proxy which handles SSL

### DIFF
--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -456,6 +456,11 @@ class NotebookApp(BaseIPythonApplication):
         config=True,
         help='The notebook manager class to use.')
 
+    trust_xheaders = Bool(False, config=True,
+        help=("Whether to trust or not X-Scheme/X-Forwarded-Proto and X-Real-Ip/X-Forwarded-For headers"
+              "sent by the upstream reverse proxy. Neccesary if the proxy handles SSL")
+    )
+
     def parse_command_line(self, argv=None):
         super(NotebookApp, self).parse_command_line(argv)
         if argv is None:
@@ -508,7 +513,8 @@ class NotebookApp(BaseIPythonApplication):
         else:
             ssl_options = None
         self.web_app.password = self.password
-        self.http_server = httpserver.HTTPServer(self.web_app, ssl_options=ssl_options)
+        self.http_server = httpserver.HTTPServer(self.web_app, ssl_options=ssl_options,
+                                                 xheaders=self.trust_xheaders)
         if not self.ip:
             warning = "WARNING: The notebook server is listening on all IP addresses"
             if ssl_options is None:


### PR DESCRIPTION
Added a "trust_xheaders" config option to NotebookApp to enable the passing of the xheaders flag to tornado.HTTPServer. This is necessary so tornado can generate the correct wss:// scheme
