### PR TITLE
closes #3045, #3123 for tornado < version 3.0

### DIFF
--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -522,6 +522,30 @@ class NotebookApp(BaseIPythonApplication):
             try:
                 self.http_server.listen(port, self.ip)
             except socket.error as e:
+                # XXX: remove the e.errno == -9 block when we require
+                # tornado >= 3.0
+                if e.errno == -9:
+                    # The flags passed to socket.getaddrinfo from
+                    # tornado.netutils.bind_sockets can cause "gaierror:
+                    # [Errno -9] Address family for hostname not supported"
+                    # when the interface is not associated, for example.
+                    # Changing the flags to exclude socket.AI_ADDRCONFIG does
+                    # not cause this error, but the only way to do this is to
+                    # monkeypatch socket to remove the AI_ADDRCONFIG attribute
+                    saved_AI_ADDRCONFIG = socket.AI_ADDRCONFIG
+                    self.log.info('Monkeypatching socket to fix tornado bug')
+                    del(socket.AI_ADDRCONFIG)
+                    try:
+                        # retry the tornado call without AI_ADDRCONFIG flags
+                        self.http_server.listen(port, self.ip)
+                    except socket.error as e2:
+                        e = e2
+                    else:
+                        self.port = port
+                        success = True
+                        break
+                    # restore the monekypatch
+                    socket.AI_ADDRCONFIG = saved_AI_ADDRCONFIG
                 if e.errno != errno.EADDRINUSE:
                     raise
                 self.log.info('The port %i is already in use, trying another random port.' % port)

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -40,6 +40,7 @@ from jinja2 import Environment, FileSystemLoader
 from zmq.eventloop import ioloop
 ioloop.install()
 
+import tornado
 from tornado import httpserver
 from tornado import web
 
@@ -524,7 +525,7 @@ class NotebookApp(BaseIPythonApplication):
             except socket.error as e:
                 # XXX: remove the e.errno == -9 block when we require
                 # tornado >= 3.0
-                if e.errno == -9:
+                if e.errno == -9 and tornado.version_info[0] < 3:
                     # The flags passed to socket.getaddrinfo from
                     # tornado.netutils.bind_sockets can cause "gaierror:
                     # [Errno -9] Address family for hostname not supported"
@@ -533,7 +534,7 @@ class NotebookApp(BaseIPythonApplication):
                     # not cause this error, but the only way to do this is to
                     # monkeypatch socket to remove the AI_ADDRCONFIG attribute
                     saved_AI_ADDRCONFIG = socket.AI_ADDRCONFIG
-                    self.log.info('Monkeypatching socket to fix tornado bug')
+                    self.log.warn('Monkeypatching socket to fix tornado bug')
                     del(socket.AI_ADDRCONFIG)
                     try:
                         # retry the tornado call without AI_ADDRCONFIG flags


### PR DESCRIPTION
This fixes the `gaierror: [Errno -9] Address family for hostname not supported` error from  unassociated interfaces.

related to facebook/tornado#593 - but the fix was only applied to 3.0

I've verified that this fix works for tornado 2.1, 2.4, 2.4.1, and the behavior it fixes does not trigger on tornado 3.0

This was really annoying when I happend to get lose a wireless signal, or unplug from the network, and since it is only fixed in a version of Tornado that was release less than 2 weeks ago, I'd prefer it if we had a workaround in our code (though I understand that opinions may differ).
