### PR TITLE
use Python 3-style for pretty-printed sets

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -668,7 +668,7 @@ _type_pprinters = {
     list:                       _seq_pprinter_factory('[', ']', list),
     dict:                       _dict_pprinter_factory('{', '}', dict),
     
-    set:                        _seq_pprinter_factory('set([', '])', set),
+    set:                        _seq_pprinter_factory('{', '}', set),
     frozenset:                  _seq_pprinter_factory('frozenset([', '])', frozenset),
     super:                      _super_pprint,
     _re_pattern_type:           _re_pattern_pprint,


### PR DESCRIPTION
Sets are now `{1,2,3}` instead of `set([1,2,3])`, matching repr(set) on Python 3.

This change applies Python 3-style to all Python versions.

closes #3156
