### PR TITLE
Autocompletion for zsh

### DIFF
--- a/examples/core/ipython-completion.bash
+++ b/examples/core/ipython-completion.bash
@@ -1,5 +1,9 @@
 # load with: . ipython-completion.bash
 
+if [[ -n ${ZSH_VERSION-} ]]; then
+    autoload -Uz bashcompinit && bashcompinit
+fi
+
 _ipython_get_flags()
 {
     local url=$1


### PR DESCRIPTION
This turns on bash compatibility mode for zsh's autocompletion, allowing zsh users to use the bash completion script included with ipython.
