### PR TITLE
adding stream kwarg to current.new_output

### DIFF
--- a/IPython/nbformat/v3/nbbase.py
+++ b/IPython/nbformat/v3/nbbase.py
@@ -53,7 +53,7 @@ def from_dict(d):
 def new_output(output_type=None, output_text=None, output_png=None,
     output_html=None, output_svg=None, output_latex=None, output_json=None,
     output_javascript=None, output_jpeg=None, prompt_number=None,
-    etype=None, evalue=None, traceback=None):
+    etype=None, evalue=None, traceback=None, stream=None):
     """Create a new code cell with input and output"""
     output = NotebookNode()
     if output_type is not None:
@@ -88,6 +88,9 @@ def new_output(output_type=None, output_text=None, output_png=None,
             output.evalue = unicode(evalue)
         if traceback is not None:
             output.traceback = [unicode(frame) for frame in list(traceback)]
+
+    if output_type == u'stream':
+        output.stream = 'stdout' if stream is None else unicode(stream)
 
     return output
 

--- a/IPython/nbformat/v3/tests/nbexamples.py
+++ b/IPython/nbformat/v3/tests/nbexamples.py
@@ -93,6 +93,7 @@ ws.cells.append(new_code_cell(
         output_text='foo\rbar\r\n'
     ),new_output(
         output_type=u'stream',
+        stream='stderr',
         output_text='\rfoo\rbar\n'
     )]
 ))


### PR DESCRIPTION
This was missing, and made unnecessarily clunky to create output cells
of stream type using the nbformat API.

Before this commit, you had to do something like

```
from IPython.nbformat import current as c
output = c.new_output('stream', the_text)
output['stream'] = 'stdout'
```

after this commit

```
from IPython.nbformat import current as c
output = c.new_output('stream', the_text, stream='stdout')
```

and actually, that stream= argument defaults to 'stdout' if it isn't given.

I modified a test that will break if this functionality is ever removed.
