### PR TITLE
default application logger shouldn't propagate

### DIFF
--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -146,6 +146,7 @@ class Application(SingletonConfigurable):
         """
         log = logging.getLogger(self.__class__.__name__)
         log.setLevel(self.log_level)
+        log.propagate = False
         _log = log # copied from Logger.hasHandlers() (new in Python 3.2)
         while _log:
             if _log.handlers:


### PR DESCRIPTION
avoids annoying duplicate messages on the root logger under some circumstances.

If apps want to hook up their own logging, they should assign the log attribute.
