### PR TITLE
Fix small inconsistency in nbconvert: etype -> ename

### DIFF
--- a/IPython/nbformat/v3/nbbase.py
+++ b/IPython/nbformat/v3/nbbase.py
@@ -53,7 +53,7 @@ def from_dict(d):
 def new_output(output_type=None, output_text=None, output_png=None,
     output_html=None, output_svg=None, output_latex=None, output_json=None,
     output_javascript=None, output_jpeg=None, prompt_number=None,
-    etype=None, evalue=None, traceback=None, stream=None):
+    ename=None, evalue=None, traceback=None, stream=None):
     """Create a new code cell with input and output"""
     output = NotebookNode()
     if output_type is not None:
@@ -82,8 +82,8 @@ def new_output(output_type=None, output_text=None, output_png=None,
             output.prompt_number = int(prompt_number)
 
     if output_type == u'pyerr':
-        if etype is not None:
-            output.etype = unicode(etype)
+        if ename is not None:
+            output.ename = unicode(ename)
         if evalue is not None:
             output.evalue = unicode(evalue)
         if traceback is not None:

--- a/IPython/nbformat/v3/tests/nbexamples.py
+++ b/IPython/nbformat/v3/tests/nbexamples.py
@@ -85,7 +85,7 @@ ws.cells.append(new_code_cell(
         output_javascript=u'var i=0;'
     ),new_output(
         output_type=u'pyerr',
-        etype=u'NameError',
+        ename=u'NameError',
         evalue=u'NameError was here',
         traceback=[u'frame 0', u'frame 1', u'frame 2']
     ),new_output(

--- a/IPython/nbformat/v3/tests/test_nbbase.py
+++ b/IPython/nbformat/v3/tests/test_nbbase.py
@@ -29,11 +29,11 @@ class TestCell(TestCase):
         self.assertEqual(cc.collapsed, True)
 
     def test_pyerr(self):
-        o = new_output(output_type=u'pyerr', etype=u'NameError',
+        o = new_output(output_type=u'pyerr', ename=u'NameError',
             evalue=u'Name not found', traceback=[u'frame 0', u'frame 1', u'frame 2']
         )
         self.assertEqual(o.output_type, u'pyerr')
-        self.assertEqual(o.etype, u'NameError')
+        self.assertEqual(o.ename, u'NameError')
         self.assertEqual(o.evalue, u'Name not found')
         self.assertEqual(o.traceback, [u'frame 0', u'frame 1', u'frame 2'])
 

--- a/docs/source/development/messaging.txt
+++ b/docs/source/development/messaging.txt
@@ -949,7 +949,7 @@ Message type: ``crash``::
 
     content = {
        # Similarly to the 'error' case for execute_reply messages, this will
-       # contain ename, etype and traceback fields.
+       # contain ename, evalue and traceback fields.
 
        # An additional field with supplementary information such as where to
        # send the crash message


### PR DESCRIPTION
All .ipynb files I've looked at have "ename" field, not "etype". That's also what is being sent from the kernel to the notebook.
