### PR TITLE
add ignored *args to HasTraits constructor

### DIFF
--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -411,6 +411,18 @@ class TestHasTraits(TestCase):
         self.assertEqual(a.i, 1)
         self.assertEqual(a.x, 10.0)
 
+    def test_positional_args(self):
+        class A(HasTraits):
+            i = Int(0)
+            def __init__(self, i):
+                super(A, self).__init__()
+                self.i = i
+        
+        a = A(5)
+        self.assertEqual(a.i, 5)
+        # should raise TypeError if no positional arg given
+        self.assertRaises(TypeError, A)
+
 #-----------------------------------------------------------------------------
 # Tests for specific trait types
 #-----------------------------------------------------------------------------

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -398,7 +398,7 @@ class HasTraits(object):
 
     __metaclass__ = MetaHasTraits
 
-    def __new__(cls, **kw):
+    def __new__(cls, *args, **kw):
         # This is needed because in Python 2.6 object.__new__ only accepts
         # the cls argument.
         new_meth = super(HasTraits, cls).__new__
@@ -425,7 +425,7 @@ class HasTraits(object):
 
         return inst
 
-    def __init__(self, **kw):
+    def __init__(self, *args, **kw):
         # Allow trait values to be set using keyword arguments.
         # We need to use setattr for this to trigger validation and
         # notifications.


### PR DESCRIPTION
makes subclassing nicer / easier, avoiding unclear

```
TypeError: __new__() takes exactly 1 argument (2 given)
```

discussed [on the list](http://mail.scipy.org/pipermail/ipython-dev/2013-April/011409.html).
