### PR TITLE
Fix inheritance_diagram Sphinx extension for Sphinx 1.2

### DIFF
--- a/docs/sphinxext/inheritance_diagram.py
+++ b/docs/sphinxext/inheritance_diagram.py
@@ -40,7 +40,9 @@ except ImportError:
 
 from docutils.nodes import Body, Element
 from docutils.parsers.rst import directives
-from sphinx.roles import xfileref_role
+from sphinx.roles import XRefRole
+
+xfileref_role = XRefRole()
 
 def my_import(name):
     """Module importer - taken from the python documentation.


### PR DESCRIPTION
Our [Shiningpanda docs job](https://jenkins.shiningpanda-ci.com/ipython/job/ipython-docs/47/console) got a beta version of Sphinx 1.2, and the inheritance_diagram extension couldn't load.

This change is equivalent to what Sphinx already did with the deprecated `xfileref_role` function ([diff in Sphinx](https://bitbucket.org/birkenfeld/sphinx/commits/56266122d558664d64934b8266e2c9b5851c6896#Lsphinx/roles.pyF321))
