### PR TITLE
Fix issue #2563, "core.profiledir.check_startup_dir() doesn't work inside py2exe'd installation"

### DIFF
--- a/IPython/core/profiledir.py
+++ b/IPython/core/profiledir.py
@@ -102,7 +102,11 @@ class ProfileDir(LoggingConfigurable):
             os.mkdir(self.startup_dir)
         readme = os.path.join(self.startup_dir, 'README')
         src = os.path.join(get_ipython_package_dir(), u'config', u'profile', u'README_STARTUP')
-        if not os.path.exists(readme):
+
+        if not os.path.exists(src):
+            self.log.warn("Could not copy README_STARTUP to startup dir. Source file %s does not exist." % src)
+
+        if os.path.exists(src) and not os.path.exists(readme):
             shutil.copy(src, readme)
 
     def _security_dir_changed(self, name, old, new):


### PR DESCRIPTION
On Windows inside a py2exe'd environment, README_STARTUP does not
get copied into library.zip. Added a warning and a skip if
the file IPython/config/profile/README_STARTUP is missing.
