### PR TITLE
Updates storemagic extension to allow for specifying variable name to load

### DIFF
--- a/IPython/extensions/storemagic.py
+++ b/IPython/extensions/storemagic.py
@@ -33,7 +33,7 @@ from IPython.testing.skipdoctest import skip_doctest
 #-----------------------------------------------------------------------------
 # Functions and classes
 #-----------------------------------------------------------------------------
-    
+
 def restore_aliases(ip):
     staliases = ip.db.get('stored_aliases', {})
     for k,v in staliases.items():
@@ -100,6 +100,8 @@ class StoreMagics(Magics):
         * ``%store -z``       - Remove all variables from storage
         * ``%store -r``       - Refresh all variables from store (delete
                                 current vals)
+        * ``%store -r spam``  - Refresh specified variable from store (delete
+                                current val)
         * ``%store foo >a.txt``  - Store value of foo to new file a.txt
         * ``%store foo >>a.txt`` - Append value of foo to file a.txt
 
@@ -133,8 +135,16 @@ class StoreMagics(Magics):
                 del db[k]
 
         elif 'r' in opts:
-            refresh_variables(ip)
-
+            if args:
+                try:
+                    obj = db['autorestore/' + args[0]]
+                except KeyError:
+                    print "Unable to restore variable '%s', (use %%store -d to forget!)" % args[0]
+                    print "The error was:", sys.exc_info()[0]
+                else:
+                    ip.user_ns[args[0]] = obj
+            else:
+                refresh_variables(ip)
 
         # run without arguments -> list variables & values
         elif not args:

--- a/IPython/extensions/storemagic.py
+++ b/IPython/extensions/storemagic.py
@@ -100,8 +100,8 @@ class StoreMagics(Magics):
         * ``%store -z``       - Remove all variables from storage
         * ``%store -r``       - Refresh all variables from store (delete
                                 current vals)
-        * ``%store -r spam``  - Refresh specified variable from store (delete
-                                current val)
+        * ``%store -r spam bar`` - Refresh specified variables from store
+                                   (delete current val)
         * ``%store foo >a.txt``  - Store value of foo to new file a.txt
         * ``%store foo >>a.txt`` - Append value of foo to file a.txt
 
@@ -136,13 +136,13 @@ class StoreMagics(Magics):
 
         elif 'r' in opts:
             if args:
-                try:
-                    obj = db['autorestore/' + args[0]]
-                except KeyError:
-                    print "Unable to restore variable '%s', (use %%store -d to forget!)" % args[0]
-                    print "The error was:", sys.exc_info()[0]
-                else:
-                    ip.user_ns[args[0]] = obj
+                for arg in args:
+                    try:
+                        obj = db['autorestore/' + arg]
+                    except KeyError:
+                        print "no stored variable %s" % arg
+                    else:
+                        ip.user_ns[arg] = obj
             else:
                 refresh_variables(ip)
 


### PR DESCRIPTION
Previously `store -r` loaded all previously saved variables.
This pull adds the ability to specify a name with `store -r foo` to load just foo.

Contributes to update of storemagic mentioned in gh-3167
