### PR TITLE
informative error when trying to load directories

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3015,6 +3015,8 @@ class InteractiveShell(SingletonConfigurable):
                         with io_open(tgt,'r', encoding='latin1') as f :
                             return f.read()
                     raise ValueError(("'%s' seem to be unreadable.") % target)
+            elif os.path.isdir(os.path.expanduser(tgt)):
+                raise ValueError("'%s' is a directory, not a regular file." % target)
 
         try:                                              # User namespace
             codeobj = eval(target, self.user_ns)


### PR DESCRIPTION
prior to this commit, the error message for trying to load a directory
looked like this:

```
ValueError: '~' was not found in history, as a file, url, nor in the
user namespace.
```

now, the error displayed is as follows:

```
ValueError: '~' is a directory, not a regular file.
```
