### PR TITLE
Workaround so only one CTRL-C is required for a new prompt in --gui=qt

### DIFF
--- a/IPython/lib/inputhookqt4.py
+++ b/IPython/lib/inputhookqt4.py
@@ -116,8 +116,22 @@ def create_inputhook_qt4(mgr, app=None):
         except KeyboardInterrupt:
             ignore_CTRL_C()
             got_kbdint[0] = True
-            print("\nKeyboardInterrupt - Ctrl-C again for new prompt")
             mgr.clear_inputhook()
+            import os, signal, time, threading
+            if(os.name == 'posix'):
+                pid = os.getpid()
+                print("^C")
+                thread = threading.Thread(
+                            target = lambda:
+                                ( time.sleep(.1),
+                                  os.kill(pid, signal.SIGINT) )
+                        )
+
+                thread.start()
+            else:
+                print("\nKeyboardInterrupt - Ctrl-C again for new prompt")
+
+
         except: # NO exceptions are allowed to escape from a ctypes callback
             ignore_CTRL_C()
             from traceback import print_exc

--- a/IPython/lib/inputhookqt4.py
+++ b/IPython/lib/inputhookqt4.py
@@ -125,13 +125,13 @@ def create_inputhook_qt4(mgr, app=None):
             if(os.name == 'posix'):
                 pid = os.getpid()
                 print("^C")
-                thread = threading.Thread(
-                            target = lambda:
-                                ( time.sleep(.01),
-                                  os.kill(pid, signal.SIGINT) )
-                        )
 
-                thread.start()
+                timer = threading.Timer( .01,
+                                         os.kill,
+                                         args=[pid, signal.SIGINT] 
+                                       )
+
+                timer.start()
             else:
                 print("\nKeyboardInterrupt - Ctrl-C again for new prompt")
 

--- a/IPython/lib/inputhookqt4.py
+++ b/IPython/lib/inputhookqt4.py
@@ -16,6 +16,11 @@ Author: Christian Boos
 # Imports
 #-----------------------------------------------------------------------------
 
+import os
+import signal
+import time
+import threading
+
 from IPython.core.interactiveshell import InteractiveShell
 from IPython.external.qt_for_kernel import QtCore, QtGui
 from IPython.lib.inputhook import allow_CTRL_C, ignore_CTRL_C, stdin_ready
@@ -117,13 +122,12 @@ def create_inputhook_qt4(mgr, app=None):
             ignore_CTRL_C()
             got_kbdint[0] = True
             mgr.clear_inputhook()
-            import os, signal, time, threading
             if(os.name == 'posix'):
                 pid = os.getpid()
                 print("^C")
                 thread = threading.Thread(
                             target = lambda:
-                                ( time.sleep(.1),
+                                ( time.sleep(.01),
                                   os.kill(pid, signal.SIGINT) )
                         )
 

--- a/IPython/lib/inputhookqt4.py
+++ b/IPython/lib/inputhookqt4.py
@@ -71,6 +71,8 @@ def create_inputhook_qt4(mgr, app=None):
 
     got_kbdint = [False]
 
+    sigint_timer = [None]
+
     def inputhook_qt4():
         """PyOS_InputHook python hook for Qt4.
 
@@ -126,12 +128,13 @@ def create_inputhook_qt4(mgr, app=None):
                 pid = os.getpid()
                 print("^C")
 
-                timer = threading.Timer( .01,
-                                         os.kill,
-                                         args=[pid, signal.SIGINT] 
-                                       )
+                if(not sigint_timer[0]):
+                    sigint_timer[0] = threading.Timer(.01,
+                                             os.kill,
+                                             args=[pid, signal.SIGINT] 
+                                           )
 
-                timer.start()
+                    sigint_timer[0].start()
             else:
                 print("\nKeyboardInterrupt - Ctrl-C again for new prompt")
 
@@ -152,6 +155,10 @@ def create_inputhook_qt4(mgr, app=None):
         (in case the latter was temporarily deactivated after a
         CTRL+C)
         """
+        if(sigint_timer[0]):
+            sigint_timer[0].cancel()
+            sigint_timer[0] = None
+
         if got_kbdint[0]:
             mgr.set_inputhook(inputhook_qt4)
         got_kbdint[0] = False

--- a/IPython/lib/inputhookqt4.py
+++ b/IPython/lib/inputhookqt4.py
@@ -124,16 +124,21 @@ def create_inputhook_qt4(mgr, app=None):
             ignore_CTRL_C()
             got_kbdint[0] = True
             mgr.clear_inputhook()
+
+            # This generates a second SIGINT so the user doesn't have to
+            # press CTRL+C twice to get a clean prompt.
+            #
+            # Since we can't catch the resulting KeyboardInterrupt here
+            # (because this is a ctypes callback), we use a timer to
+            # generate the SIGINT after we leave this callback.
+            #
+            # Unfortunately this doesn't work on Windows (SIGINT kills
+            # Python and CTRL_C_EVENT doesn't work).
             if(os.name == 'posix'):
                 pid = os.getpid()
-                print("^C")
-
                 if(not sigint_timer[0]):
-                    sigint_timer[0] = threading.Timer(.01,
-                                             os.kill,
-                                             args=[pid, signal.SIGINT] 
-                                           )
-
+                    sigint_timer[0] = threading.Timer(.01, os.kill,
+                                         args=[pid, signal.SIGINT] )
                     sigint_timer[0].start()
             else:
                 print("\nKeyboardInterrupt - Ctrl-C again for new prompt")


### PR DESCRIPTION
I have a habit of using CTRL-C to clear lines in a terminal (and MATLAB), so it is really annoying to have to press it twice in ipython.

This is a kludgy, posix only workaround, and I only tested it for Python 2.7 on Linux and Windows.
