### PR TITLE
make BlockingKernelClient the default Client

### DIFF
--- a/IPython/kernel/manager.py
+++ b/IPython/kernel/manager.py
@@ -59,7 +59,7 @@ class KernelManager(LoggingConfigurable, ConnectionFileMixin):
         return Session(config=self.config)
 
     # the class to create with our `client` method
-    client_class = DottedObjectName('IPython.kernel.client.KernelClient')
+    client_class = DottedObjectName('IPython.kernel.blocking.BlockingKernelClient')
     client_factory = Type()
     def _client_class_changed(self, name, old, new):
         self.client_factory = import_item(str(new))

--- a/IPython/kernel/tests/test_message_spec.py
+++ b/IPython/kernel/tests/test_message_spec.py
@@ -15,7 +15,7 @@ from Queue import Empty
 
 import nose.tools as nt
 
-from IPython.kernel import KernelManager, BlockingKernelClient
+from IPython.kernel import KernelManager
 
 
 from IPython.testing import decorators as dec
@@ -31,7 +31,6 @@ from IPython.utils.traitlets import (
 def setup():
     global KM, KC
     KM = KernelManager()
-    KM.client_factory = BlockingKernelClient
     KM.start_kernel(stdout=PIPE, stderr=PIPE)
     KC = KM.client()
     KC.start_channels()


### PR DESCRIPTION
The default Client class returned by `KernelManager.client()` should be BlockingKernelClient, because the base KernelClient is incomplete.

Ultimately, the base KernelClient will probably become a blocking client, and the Blocking subclass will go away.
