### PR TITLE
add missing mathjax_url to new settings dict

### DIFF
--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -202,6 +202,7 @@ class NotebookWebApplication(web.Application):
             cluster_manager=cluster_manager,
             
             # IPython stuff
+            mathjax_url=ipython_app.mathjax_url,
             max_msg_size=ipython_app.max_msg_size,
             config=ipython_app.config,
             use_less=ipython_app.use_less,


### PR DESCRIPTION
MathJax isn't working in master because of the omission
