### PR TITLE
Text in rename dialog was way too big - making it <p>.

### DIFF
--- a/IPython/frontend/html/notebook/static/js/savewidget.js
+++ b/IPython/frontend/html/notebook/static/js/savewidget.js
@@ -61,7 +61,7 @@ var IPython = (function (IPython) {
         var that = this;
         var dialog = $('<div/>');
         dialog.append(
-            $('<h3/>').html('Enter a new notebook name:')
+            $('<p/>').html('Enter a new notebook name:')
             .css({'margin-bottom': '10px'})
         );
         dialog.append(


### PR DESCRIPTION
This style error crept in with the transition to less and wasn't fixed.
