### PR TITLE
improve discovery of public IPs

### DIFF
--- a/IPython/utils/localinterfaces.py
+++ b/IPython/utils/localinterfaces.py
@@ -36,7 +36,11 @@ except socket.gaierror:
 
 PUBLIC_IPS = []
 try:
-    PUBLIC_IPS = socket.gethostbyname_ex(socket.gethostname())[2]
+    hostname = socket.gethostname()
+    PUBLIC_IPS = socket.gethostbyname_ex(hostname)[2]
+    # try hostname.local, in case hostname has been short-circuited to loopback
+    if not hostname.endswith('.local') and all(ip.startswith('127') for ip in PUBLIC_IPS):
+        PUBLIC_IPS = socket.gethostbyname_ex(socket.gethostname() + '.local')[2]
 except socket.gaierror:
     pass
 else:

--- a/docs/source/parallel/parallel_intro.txt
+++ b/docs/source/parallel/parallel_intro.txt
@@ -213,7 +213,7 @@ need to use ssh tunnels to connect clients from your laptop to it.  You will als
 probably need to instruct the controller to listen for engines coming from other work nodes
 on the cluster.  An example of ipcontroller-client.json, as created by::
 
-    $> ipcontroller --ip=0.0.0.0 --ssh=login.mycluster.com
+    $> ipcontroller --ip=* --ssh=login.mycluster.com
 
 
 .. sourcecode:: python

--- a/docs/source/parallel/parallel_process.txt
+++ b/docs/source/parallel/parallel_process.txt
@@ -33,15 +33,28 @@ the ``ip`` argument on the command-line, or the ``HubFactory.ip`` configurable i
 :file:`ipcontroller_config.py`.
 
 If your machines are on a trusted network, you can safely instruct the controller to listen
-on all public interfaces with::
+on all interfaces with::
 
     $> ipcontroller --ip=*
+
 
 Or you can set the same behavior as the default by adding the following line to your :file:`ipcontroller_config.py`:
 
 .. sourcecode:: python
 
     c.HubFactory.ip = '*'
+    # c.HubFactory.location = '10.0.1.1'
+
+
+.. note::
+
+    ``--ip=*`` instructs ZeroMQ to listen on all interfaces,
+    but it does not contain the IP needed for engines / clients
+    to know where the controller actually is.
+    This can be specified with ``--location=10.0.0.1``,
+    the specific IP address of the controller, as seen from engines and/or clients.
+    IPython tries to guess this value by default, but it will not always guess correctly.
+    Check the ``location`` field in your connection files if you are having connection trouble.
 
 .. note::
 
@@ -718,7 +731,11 @@ through the login node, an example :file:`ipcontroller_config.py` might contain:
     c.HubFactory.location = '10.0.1.5'
     # or to get an automatic value, try this:
     import socket
-    ex_ip = socket.gethostbyname_ex(socket.gethostname())[-1][0]
+    hostname = socket.gethostname()
+    # alternate choices for hostname include `socket.getfqdn()`
+    # or `socket.gethostname() + '.local'`
+    
+    ex_ip = socket.gethostbyname_ex(hostname)[-1][-1]
     c.HubFactory.location = ex_ip
     
     # now instruct clients to use the login node for SSH tunnels:


### PR DESCRIPTION
Checks `hostname.local` if `hostname` only points to loopback.

Also add some notes to the docs about the `--location` flag.

closes #3227
