### PR TITLE
Allow "x" icon and esc key to close pager in notebook

### DIFF
--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -130,6 +130,7 @@ var IPython = (function (IPython) {
             } else if (event.which === key.ESC) {
                 // Intercept escape at highest level to avoid closing
                 // websocket connection with firefox
+                that.element.trigger('collapse_pager');
                 event.preventDefault();
             } else if (event.which === key.SHIFT) {
                 // ignore shift keydown

--- a/IPython/frontend/html/notebook/static/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/js/notebook.js
@@ -130,7 +130,7 @@ var IPython = (function (IPython) {
             } else if (event.which === key.ESC) {
                 // Intercept escape at highest level to avoid closing
                 // websocket connection with firefox
-                that.element.trigger('collapse_pager');
+                IPython.pager.collapse();
                 event.preventDefault();
             } else if (event.which === key.SHIFT) {
                 // ignore shift keydown

--- a/IPython/frontend/html/notebook/static/js/pager.js
+++ b/IPython/frontend/html/notebook/static/js/pager.js
@@ -58,7 +58,7 @@ var IPython = (function (IPython) {
         )
         this.pager_button_area.append(
             $('<a>').attr('role', "button")
-                    .attr('title',"Collapse the pager")
+                    .attr('title',"Close the pager")
                     .addClass('ui-button')
                     .click(function(){that.collapse()})
                     .attr('style','position: absolute; right: 5px;')

--- a/IPython/frontend/html/notebook/static/js/pager.js
+++ b/IPython/frontend/html/notebook/static/js/pager.js
@@ -48,12 +48,22 @@ var IPython = (function (IPython) {
         var that = this;
         this.pager_button_area.append(
             $('<a>').attr('role', "button")
-                    .attr('title',"open the pager in an external window")
+                    .attr('title',"Open the pager in an external window")
                     .addClass('ui-button')
                     .click(function(){that.detach()})
-                    .attr('style','position: absolute; right: 10px;')
+                    .attr('style','position: absolute; right: 20px;')
                     .append(
                         $('<span>').addClass("ui-icon ui-icon-extlink")
+                    )
+        )
+        this.pager_button_area.append(
+            $('<a>').attr('role', "button")
+                    .attr('title',"Collapse the pager")
+                    .addClass('ui-button')
+                    .click(function(){that.collapse()})
+                    .attr('style','position: absolute; right: 5px;')
+                    .append(
+                        $('<span>').addClass("ui-icon ui-icon-close")
                     )
         )
     };


### PR DESCRIPTION
As discussed in #3196, this adds two new ways to collapse/close the pager in the htmlnotebook.  It adds a close "x" icon that upon clicking will hide the pager, and it makes it so that the ESC key immediately closes the pager.

Note that my javascript-fu is not so strong, so I'm not sure this is the best way to deal with keyboard interactions.  It seems to work fine though.

I'm also including an image below of what the new icon layout looks like:
![pagerclose](https://f.cloud.github.com/assets/346587/441707/271ed77a-b123-11e2-8b31-9b170886550c.png)

I can easily change the icon to something like a down arrow or similar, if the close x seems too "hostile" (given that it can always be re-expanded).
