### PR TITLE
Fix for cell magics in Qt console

### DIFF
--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -477,7 +477,7 @@ class IPythonInputSplitter(InputSplitter):
     # List with lines of raw input accumulated so far.
     _buffer_raw = None
 
-    def __init__(self, line_input_checker=False, physical_line_transforms=None,
+    def __init__(self, line_input_checker=True, physical_line_transforms=None,
                     logical_line_transforms=None, python_line_transforms=None):
         super(IPythonInputSplitter, self).__init__()
         self._buffer_raw = []


### PR DESCRIPTION
Make `line_input_checker=True` the default for InputSplitter.

The Qt console needs to use it in line_input_checker mode, but can't specify arguments in case because it could be instantiating the InputSplitter base class.

This is something of a temporary fix, because I hope soon to add an 'is it done' message type so it's judged in the kernel. But we want cell magics to be usable in the Qt console in the meantime.

Closes gh-3248
