### PR TITLE
protect highlight.js against unknown languages

### DIFF
--- a/IPython/frontend/html/notebook/static/js/notebookmain.js
+++ b/IPython/frontend/html/notebook/static/js/notebookmain.js
@@ -101,9 +101,9 @@ $(document).ready(function () {
             langPrefix: "language-",
             highlight: function(code, lang) {
                 var highlighted;
-                if (lang) {
+                try {
                     highlighted = hljs.highlight(lang, code, false);
-                } else {
+                } catch(err) {
                     highlighted = hljs.highlightAuto(code);
                 }
                 return highlighted.value;


### PR DESCRIPTION
falls back on autodetect if specified language fails (e.g. unrecognized language).

closes #3268
