### PR TITLE
be a bit more forceful when checking / updating submodules

### DIFF
--- a/ipython.py
+++ b/ipython.py
@@ -18,11 +18,9 @@ import os, sys
 this_dir = os.path.dirname(sys.argv[0])
 sys.path.insert(0, this_dir)
 
-from setupbase import check_for_submodules, update_submodules
+from setupbase import update_submodules
 
-if not check_for_submodules():
-    update_submodules()
-
+update_submodules(allow_raise=False, quiet=True)
 
 # Now proceed with execution
 execfile(os.path.join(

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ from setupbase import (
     find_data_files,
     check_for_dependencies,
     git_prebuild,
-    check_for_submodules,
     update_submodules,
     require_submodules,
     UpdateSubmodules,
@@ -113,7 +112,7 @@ if os_name == 'windows' and 'sdist' in sys.argv:
 # Make sure we aren't trying to run without submodules
 #-------------------------------------------------------------------------------
 
-def ensure_submodules_exist():
+def probably_update_submodules():
     """Check out git submodules before distutils can do anything
     
     Because distutils cannot be trusted to update the tree
@@ -123,10 +122,9 @@ def ensure_submodules_exist():
     for do_nothing in ('-h', '--help', '--help-commands', 'clean'):
         if do_nothing in sys.argv:
             return
-    if not check_for_submodules():
-        update_submodules()
+    update_submodules(allow_raise=False)
 
-ensure_submodules_exist()
+probably_update_submodules()
 
 #-------------------------------------------------------------------------------
 # Things related to the IPython documentation

--- a/setupbase.py
+++ b/setupbase.py
@@ -388,12 +388,30 @@ def check_for_submodules():
             return False
     return True
 
-def update_submodules():
+def update_submodules(allow_raise=True, quiet=False):
     """update git submodules"""
     import subprocess
-    print("updating git submodules")
-    subprocess.check_call('git submodule init'.split())
-    subprocess.check_call('git submodule update --recursive'.split())
+    here = os.path.dirname(__file__)
+    # do nothing if we are not in a git repo
+    if not os.path.exists(pjoin(here, '.git')):
+        return
+    
+    if not quiet:
+        print("updating git submodules")
+    cwd = os.getcwdu()
+    os.chdir(here)
+    try:
+        # we are in a git repo
+        subprocess.check_call('git submodule init'.split())
+        subprocess.check_call('git submodule update --recursive'.split())
+    except Exception:
+        if not quiet:
+            print("WARNING: Failed to update git submodules!")
+        if allow_raise:
+            raise
+    finally:
+        os.chdir(cwd)
+    
 
 class UpdateSubmodules(Command):
     """Update git submodules

--- a/setupbase.py
+++ b/setupbase.py
@@ -398,7 +398,7 @@ def update_submodules(allow_raise=True, quiet=False):
     
     if not quiet:
         print("updating git submodules")
-    cwd = os.getcwdu()
+    cwd = os.getcwd()
     os.chdir(here)
     try:
         # we are in a git repo


### PR DESCRIPTION
previously, submodule update would only fire if the submodule dir did not exist. Now, it will try to fire on every setup.py command (when run from a repo), and warn if it fails.

Should be a bit less likely to have 'wtf?' moments when the submodule is out of date.
