### PR TITLE
Improved heartbeat controller to engine monitoring for long running tasks

### DIFF
--- a/IPython/parallel/controller/heartmonitor.py
+++ b/IPython/parallel/controller/heartmonitor.py
@@ -74,7 +74,7 @@ class HeartMonitor(LoggingConfigurable):
         help='The frequency at which the Hub pings the engines for heartbeats '
         '(in ms)',
     )
-    max_heartmonitor_misses = Integer(2, config=True,
+    max_heartmonitor_misses = Integer(20, config=True,
         help='Allow misses from engine to controller heart monitor before shutting down.',
     )
 

--- a/IPython/parallel/controller/heartmonitor.py
+++ b/IPython/parallel/controller/heartmonitor.py
@@ -74,8 +74,8 @@ class HeartMonitor(LoggingConfigurable):
         help='The frequency at which the Hub pings the engines for heartbeats '
         '(in ms)',
     )
-    max_heartmonitor_misses = Integer(20, config=True,
-        help='Allow consecutive misses from engine to controller heart monitor before shutting down.',
+    max_heartmonitor_misses = Integer(10, config=True,
+        help='Allowed consecutive missed pings from controller Hub to engine before unregistering.',
     )
 
     pingstream=Instance('zmq.eventloop.zmqstream.ZMQStream')

--- a/IPython/parallel/controller/heartmonitor.py
+++ b/IPython/parallel/controller/heartmonitor.py
@@ -75,7 +75,7 @@ class HeartMonitor(LoggingConfigurable):
         '(in ms)',
     )
     max_heartmonitor_misses = Integer(20, config=True,
-        help='Allow misses from engine to controller heart monitor before shutting down.',
+        help='Allow consecutive misses from engine to controller heart monitor before shutting down.',
     )
 
     pingstream=Instance('zmq.eventloop.zmqstream.ZMQStream')
@@ -144,6 +144,7 @@ class HeartMonitor(LoggingConfigurable):
         new_probation = {}
         for cur_heart in (b for b in missed_beats if b in hearts):
             miss_count = on_probation.get(cur_heart, 0) + 1
+            self.log.info("heartbeat::missed %s : %s" % (cur_heart, miss_count))
             if miss_count > self.max_heartmonitor_misses:
                 failures.append(cur_heart)
             else:

--- a/IPython/parallel/controller/heartmonitor.py
+++ b/IPython/parallel/controller/heartmonitor.py
@@ -24,7 +24,7 @@ from zmq.eventloop import ioloop, zmqstream
 
 from IPython.config.configurable import LoggingConfigurable
 from IPython.utils.py3compat import str_to_bytes
-from IPython.utils.traitlets import Set, Instance, CFloat, Integer
+from IPython.utils.traitlets import Set, Instance, CFloat, Integer, Dict
 
 from IPython.parallel.util import log_errors
 
@@ -74,6 +74,9 @@ class HeartMonitor(LoggingConfigurable):
         help='The frequency at which the Hub pings the engines for heartbeats '
         '(in ms)',
     )
+    max_heartmonitor_misses = Integer(2, config=True,
+        help='Allow misses from engine to controller heart monitor before shutting down.',
+    )
 
     pingstream=Instance('zmq.eventloop.zmqstream.ZMQStream')
     pongstream=Instance('zmq.eventloop.zmqstream.ZMQStream')
@@ -84,7 +87,7 @@ class HeartMonitor(LoggingConfigurable):
     # not settable:
     hearts=Set()
     responses=Set()
-    on_probation=Set()
+    on_probation=Dict()
     last_ping=CFloat(0)
     _new_handlers = Set()
     _failure_handlers = Set()
@@ -121,17 +124,31 @@ class HeartMonitor(LoggingConfigurable):
         self.log.debug("heartbeat::sending %s", self.lifetime)
         goodhearts = self.hearts.intersection(self.responses)
         missed_beats = self.hearts.difference(goodhearts)
-        heartfailures = self.on_probation.intersection(missed_beats)
         newhearts = self.responses.difference(goodhearts)
         map(self.handle_new_heart, newhearts)
+        heartfailures, on_probation = self._check_missed(missed_beats, self.on_probation,
+                                                         self.hearts)
         map(self.handle_heart_failure, heartfailures)
-        self.on_probation = missed_beats.intersection(self.hearts)
+        self.on_probation = on_probation
         self.responses = set()
         #print self.on_probation, self.hearts
         # self.log.debug("heartbeat::beat %.3f, %i beating hearts", self.lifetime, len(self.hearts))
         self.pingstream.send(str_to_bytes(str(self.lifetime)))
         # flush stream to force immediate socket send
         self.pingstream.flush()
+
+    def _check_missed(self, missed_beats, on_probation, hearts):
+        """Update heartbeats on probation, identifying any that have too many misses.
+        """
+        failures = []
+        new_probation = {}
+        for cur_heart in (b for b in missed_beats if b in hearts):
+            miss_count = on_probation.get(cur_heart, 0) + 1
+            if miss_count > self.max_heartmonitor_misses:
+                failures.append(cur_heart)
+            else:
+                new_probation[cur_heart] = miss_count
+        return failures, new_probation
 
     def handle_new_heart(self, heart):
         if self._new_handlers:


### PR DESCRIPTION
I'm using Ipython parallel for long running tasks (hours to days) on larger clusters (100+ engines) and have been having trouble losing connectivity with engines. The ipcontroller log would intermittently report a block of 5 to 10 `registration::unregister_engine` messages and remove those engines.

In digging into the problem, it appears as if the current behavior is to ping engines every 3 seconds and kill an engine if it fails to respond to pings twice. The first failed ping results in an engine being put `on_probation` and the second triggers unregistration.

For longer running engines this is too restrictive, and is at odds with the new `EngineFactory.max_heartbeat_misses` which defaults to 50 misses.

This pull request provides a configuration variable `HeartMonitor.max_heartmonitor_misses`, which allows ipcontrollers to specify how many consecutive misses to allow before unregistering an engine. It defaults to failing to contact an engine for 1 minute.

I'm happy to adjust or include different defaults if desired. Thanks much for all your work on IPython.
Brad
