### PR TITLE
Add the option to skip output cells when saving.

### DIFF
--- a/IPython/frontend/html/notebook/filenbmanager.py
+++ b/IPython/frontend/html/notebook/filenbmanager.py
@@ -43,6 +43,14 @@ class FileNotebookManager(NotebookManager):
         short `--script` flag.
         """
     )
+
+    skip_outputs = Bool(False, config=True,
+        help="""Don't save output cells and prompt numbers.
+        
+        This is useful when the notebook files are to be put under version
+        control and may also make them significantly smaller, with the obvious
+        drawback that all output needs to be regenerated at runtime."""
+    )
     
     checkpoint_dir = Unicode(config=True,
         help="""The location in which to keep notebook checkpoints
@@ -178,7 +186,7 @@ class FileNotebookManager(NotebookManager):
         try:
             self.log.debug("Autosaving notebook %s", path)
             with open(path,'w') as f:
-                current.write(nb, f, u'json')
+                current.write(nb, f, u'json', skip_outputs=self.skip_outputs)
         except Exception as e:
             raise web.HTTPError(400, u'Unexpected error while autosaving notebook: %s' % e)
 

--- a/IPython/nbformat/v3/nbjson.py
+++ b/IPython/nbformat/v3/nbjson.py
@@ -49,6 +49,28 @@ class JSONReader(NotebookReader):
         return restore_bytes(rejoin_lines(from_dict(d)))
 
 
+def _remove_outputs(d):
+    if isinstance(d, dict):
+        print("dict")
+        res = {}
+        for key, value in d.items():
+            print(key)
+            print(key == "outputs")
+            print(key == u"outputs")
+            if key == u"outputs":
+                res["outputs"] = []
+            elif key == u"prompt_number":
+                pass
+            else:
+                res[key] = _remove_outputs(value)
+        return res
+    elif isinstance(d, list):
+        print("list")
+        return [_remove_outputs(i) for i in d]
+    else:
+        return d
+
+
 class JSONWriter(NotebookWriter):
 
     def writes(self, nb, **kwargs):
@@ -58,6 +80,9 @@ class JSONWriter(NotebookWriter):
         kwargs['separators'] = (',',': ')
         if kwargs.pop('split_lines', True):
             nb = split_lines(copy.deepcopy(nb))
+        if kwargs.pop('skip_outputs', False):
+            nb = _remove_outputs(nb)
+
         return py3compat.str_to_unicode(json.dumps(nb, **kwargs), 'utf-8')
     
 

--- a/IPython/nbformat/v3/nbjson.py
+++ b/IPython/nbformat/v3/nbjson.py
@@ -51,12 +51,8 @@ class JSONReader(NotebookReader):
 
 def _remove_outputs(d):
     if isinstance(d, dict):
-        print("dict")
         res = {}
         for key, value in d.items():
-            print(key)
-            print(key == "outputs")
-            print(key == u"outputs")
             if key == u"outputs":
                 res["outputs"] = []
             elif key == u"prompt_number":
@@ -65,7 +61,6 @@ def _remove_outputs(d):
                 res[key] = _remove_outputs(value)
         return res
     elif isinstance(d, list):
-        print("list")
         return [_remove_outputs(i) for i in d]
     else:
         return d


### PR DESCRIPTION
To allow notebooks to be put under proper version control it is very sensible to remove the variable but “non-source” parts, the output cells (i.e. massive base64-encoded pngs) and prompt numbers.
