### PR TITLE
[notebook] Use export hints if a .py is automatically saved

### DIFF
--- a/IPython/frontend/html/notebook/filenbmanager.py
+++ b/IPython/frontend/html/notebook/filenbmanager.py
@@ -44,6 +44,18 @@ class FileNotebookManager(NotebookManager):
         """
     )
     
+    use_export_hints = Bool(False, config=True,
+        help="""Use metadata to specify which *code* cells should be exported automatically.
+        
+        The metadata for each cell can be one of: 
+        * '"auto_export": "omit"' -> do not export this cell
+        * '"auto_export": "as_is"' -> export as is (default)
+        * '"auto_export": "commented"' -> export commented out
+        
+        if a cell has no auto_export metadata, it will be exported as_is
+        """
+    )
+    
     checkpoint_dir = Unicode(config=True,
         help="""The location in which to keep notebook checkpoints
         
@@ -188,7 +200,7 @@ class FileNotebookManager(NotebookManager):
             self.log.debug("Writing script %s", pypath)
             try:
                 with io.open(pypath,'w', encoding='utf-8') as f:
-                    current.write(nb, f, u'py')
+                    current.write(nb, f, u'py', use_export_hints=self.use_export_hints)
             except Exception as e:
                 raise web.HTTPError(400, u'Unexpected error while saving notebook as script: %s' % e)
         

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -264,10 +264,14 @@ flags.update(boolean_flag('script', 'FileNotebookManager.save_script',
                'Auto-save a .py script everytime the .ipynb notebook is saved',
                'Do not auto-save .py scripts for every notebook'))
 
+flags.update(boolean_flag('use-export-hints', 'FileNotebookManager.use_export_hints',
+               'On Auto-save a .py, use export hints for each code cell',
+               'On Auto-save a .py, save every each code cell as is'))
+
 # the flags that are specific to the frontend
 # these must be scrubbed before being passed to the kernel,
 # or it will raise an error on unrecognized flags
-notebook_flags = ['no-browser', 'no-mathjax', 'read-only', 'script', 'no-script']
+notebook_flags = ['no-browser', 'no-mathjax', 'read-only', 'script', 'no-script', 'use-export-hints']
 
 aliases = dict(kernel_aliases)
 

--- a/IPython/frontend/html/notebook/static/js/celltoolbarpresets/autoexporthint.js
+++ b/IPython/frontend/html/notebook/static/js/celltoolbarpresets/autoexporthint.js
@@ -1,0 +1,56 @@
+//----------------------------------------------------------------------------
+//  Copyright (C) 2012  The IPython Development Team
+//
+//  Distributed under the terms of the BSD License.  The full license is in
+//  the file COPYING, distributed as part of this software.
+//----------------------------------------------------------------------------
+
+//============================================================================
+//CellToolbar Example
+//============================================================================
+
+/**
+ * $.getScript('/static/js/celltoolbarpresets/exportcontrol.js');
+ * ```
+ * or more generally  
+ * ```
+ * $.getScript('url to this file');
+ * ```
+ */
+ // IIFE without asignement, we don't modifiy the IPython namespace
+(function (IPython) {
+    "use strict";
+
+    var CellToolbar = IPython.CellToolbar;
+    var autoexporthint_preset = [];
+
+    var select_type = CellToolbar.utils.select_ui_generator([
+            ["-"            ,undefined      ],
+            ["As-is (default)"        ,"as_is"        ],
+            ["Commented"    ,"commented"     ],
+            ["Omit"     ,"omit"     ],
+            ],
+            // setter
+            function(cell, value){
+                // we check that the auto_export_hint namespace exist and create it if needed
+                if (cell.metadata.auto_export_hint == undefined){cell.metadata.auto_export_hint = {}}
+                // set the value
+                cell.metadata.auto_export_hint.export_type = value
+                },
+            //geter
+            function(cell){ var ns = cell.metadata.auto_export_hint;
+                // if the auto_export_hint namespace does not exist return `undefined`
+                // (will be interpreted as `false` by checkbox) otherwise
+                // return the value
+                return (ns == undefined)? undefined: ns.export_type
+                },
+            "Auto Export Hint");
+
+    CellToolbar.register_callback('auto_export_hint.select',select_type);
+
+    autoexporthint_preset.push('auto_export_hint.select');
+
+    CellToolbar.register_preset('Auto Export Hint',autoexporthint_preset);
+    console.log('Auto Export Hint extension for metadata editing loaded.');
+
+}(IPython));

--- a/IPython/frontend/html/notebook/templates/notebook.html
+++ b/IPython/frontend/html/notebook/templates/notebook.html
@@ -238,5 +238,6 @@ class="notebook_app"
 
 <script src="{{ static_url("js/celltoolbarpresets/default.js") }}" type="text/javascript" charset="utf-8"></script>
 <script src="{{ static_url("js/celltoolbarpresets/slideshow.js") }}" type="text/javascript" charset="utf-8"></script>
+<script src="{{ static_url("js/celltoolbarpresets/autoexporthint.js") }}" type="text/javascript" charset="utf-8"></script>
 
 {% endblock %}

--- a/IPython/nbformat/v3/nbpy.py
+++ b/IPython/nbformat/v3/nbpy.py
@@ -156,14 +156,30 @@ class PyWriter(NotebookWriter):
             u'# <nbformat>%i.%i</nbformat>' % (nbformat, nbformat_minor),
             u'',
         ])
+        use_hints = kwargs.pop('use_export_hints', False)
         for ws in nb.worksheets:
             for cell in ws.cells:
                 if cell.cell_type == u'code':
+                    if use_hints:
+                        _export = cell.get(u'metadata').get(u'auto_export_hint',{}).get(u'export_type', u'as_is')
+                        if not _export in [u'as_is', u'omit', u'commented']:
+                            _export = u'as_is'
+                    else:
+                        _export = u'as_is'
                     input = cell.get(u'input')
                     if input is not None:
-                        lines.extend([u'# <codecell>',u''])
-                        lines.extend(input.splitlines())
-                        lines.append(u'')
+                        if _export == u'as_is':
+                            lines.extend([u'# <codecell>',u''])
+                            lines.extend(input.splitlines())
+                            lines.append(u'')
+                        elif _export == u'commented':
+                            lines.extend([u'# <codecell>',u''])
+                            lines.extend([u'# automatically commented',u''])
+                            lines.extend([u'# ' + line for line in input.splitlines()])
+                            lines.append(u'')
+                        else:
+                            lines.extend([u'# <codecell>',u''])
+                            lines.extend([u'# automatically omited',u''])
                 elif cell.cell_type == u'html':
                     input = cell.get(u'source')
                     if input is not None:


### PR DESCRIPTION
Use metadata of a code cell to determine if this cell should be
automatically saved into a .py file.

This is helpful if you want to import functions/classes defined in
this notebook, but the notebook contains magics or running code without
a guard.

Three states can be used: "commented", "omit", and "as_is" (default).

This must be enabled by passing "--use-export-hints" to the notebook
command in addition to "--script".

Closes #3295
