### PR TITLE
Added new setting to support notebook server over HTTPS via a reverse proxy, also some apparent bug fixes for notebook configuration.

### DIFF
--- a/IPython/frontend/html/notebook/handlers.py
+++ b/IPython/frontend/html/notebook/handlers.py
@@ -237,8 +237,11 @@ class IPythonHandler(AuthenticatedHandler):
         turns http[s]://host[:port] into
                 ws[s]://host[:port]
         """
-        proto = self.request.protocol.replace('http', 'ws')
-        host = self.settings.get('websocket_host', '')
+        # default to config value
+        proto = self.config.get('NotebookApp', {}).get('websocket_proto', '')
+        if proto == '':
+            proto = self.request.protocol.replace('http', 'ws')
+        host = self.config.get('NotebookApp', {}).get('websocket_host', '')
         # default to config value
         if host == '':
             host = self.request.host # get from request
@@ -246,15 +249,15 @@ class IPythonHandler(AuthenticatedHandler):
     
     @property
     def mathjax_url(self):
-        return self.settings.get('mathjax_url', '')
+        return self.config.get('NotebookApp', {}).get('mathjax_url', '')
     
     @property
     def base_project_url(self):
-        return self.settings.get('base_project_url', '/')
+        return self.config.get('NotebookApp', {}).get('base_project_url', '/')
     
     @property
     def base_kernel_url(self):
-        return self.settings.get('base_kernel_url', '/')
+        return self.config.get('NotebookApp', {}).get('base_kernel_url', '/')
     
     #---------------------------------------------------------------
     # Manager objects

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -442,6 +442,10 @@ class NotebookApp(BaseIPythonApplication):
         elif not new.endswith('/'):
             self.base_kernel_url = new+'/'
 
+    websocket_proto = Enum(("ws", "wss"), config=True,
+        help="""The scheme for the websocket server."""
+    )
+
     websocket_host = Unicode("", config=True,
         help="""The hostname for the websocket server."""
     )


### PR DESCRIPTION
Currently the protocol scheme used for the websockets is chosen based on
the protocol being served - `ws` for `http` and `wss` for `https`.
Typically this works fine, but it fails when the ipython notebook server
is running behind a reverse proxy such as nginx where the front-end
interface is HTTPS but the notebook server is running over HTTP (which
isn't too insecure as long as they share a host).

This commit adds a new setting `websocket_proto` which can be set to
either `ws` or `wss` to force the websocket scheme to one or other
regardless of the scheme used for standard HTTP requests. If omitted
the previous behaviour is used.

This commit also includes some fixes for apparent references to apparent
bugs in accessing the settings for the notebook.
