### PR TITLE
switch default ws_url logic to js side

### DIFF
--- a/IPython/frontend/html/notebook/base/handlers.py
+++ b/IPython/frontend/html/notebook/base/handlers.py
@@ -211,15 +211,10 @@ class IPythonHandler(AuthenticatedHandler):
     def ws_url(self):
         """websocket url matching the current request
 
-        turns http[s]://host[:port] into
-                ws[s]://host[:port]
+        By default, this is just `''`, indicating that it should match
+        the same host, protocol, port, etc.
         """
-        proto = self.request.protocol.replace('http', 'ws')
-        host = self.settings.get('websocket_host', '')
-        # default to config value
-        if host == '':
-            host = self.request.host # get from request
-        return "%s://%s" % (proto, host)
+        return self.settings.get('websocket_url', '')
     
     @property
     def mathjax_url(self):

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -426,8 +426,12 @@ class NotebookApp(BaseIPythonApplication):
         elif not new.endswith('/'):
             self.base_kernel_url = new+'/'
 
-    websocket_host = Unicode("", config=True,
-        help="""The hostname for the websocket server."""
+    websocket_url = Unicode("", config=True,
+        help="""The base URL for the websocket server,
+        if it differs from the HTTP server (hint: it almost certainly doesn't).
+        
+        Should be in the form of an HTTP origin: ws[s]://hostname[:port]
+        """
     )
 
     extra_static_paths = List(Unicode, config=True,

--- a/IPython/frontend/html/notebook/static/services/kernels/js/kernel.js
+++ b/IPython/frontend/html/notebook/static/services/kernels/js/kernel.js
@@ -102,7 +102,11 @@ var IPython = (function (IPython) {
         console.log("Kernel started: ", json.kernel_id);
         this.running = true;
         this.kernel_id = json.kernel_id;
-        this.ws_url = json.ws_url;
+        var ws_url = json.ws_url;
+        if (ws_url.match(/wss?:\/\//) == null) {
+            ws_url = "ws" + location.origin.substr(4) + ws_url;
+        };
+        this.ws_url = ws_url;
         this.kernel_url = this.base_url + "/" + this.kernel_id;
         this.start_channels();
         $([IPython.events]).trigger('status_started.Kernel', {kernel: this});


### PR DESCRIPTION
In some cases (proxies, #3305), the request object doesn't have the right information about the originating information.  This changes the default behavior, so that `ws_url` is generally empty by default, which the javascript takes to mean 'the same as http'.  This is simpler and should be more resilient than trying a guess on server-side.

also replaces unused `websocket_host` with `websocket_url`

Rather than specifying only the hostname, it makes much more sense to specify the whole protocol,host,port in a single go.
