### PR TITLE
rename `%%file` to `%%writefile`

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2060,6 +2060,7 @@ class InteractiveShell(SingletonConfigurable):
         mman.register_alias('rep', 'recall')
         mman.register_alias('SVG', 'svg', 'cell')
         mman.register_alias('HTML', 'html', 'cell')
+        mman.register_alias('file', 'fwrite', 'cell')
 
         # FIXME: Move the color initialization to the DisplayHook, which
         # should be split into a prompt manager and displayhook. We probably

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2055,7 +2055,8 @@ class InteractiveShell(SingletonConfigurable):
 
         # Register Magic Aliases
         mman = self.magics_manager
-        # surely, this can't be were magics aliases should be defined?
+        # FIXME: magic aliases should be defined by the Magics classes
+        # or in MagicsManager, not here
         mman.register_alias('ed', 'edit')
         mman.register_alias('hist', 'history')
         mman.register_alias('rep', 'recall')

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2055,12 +2055,13 @@ class InteractiveShell(SingletonConfigurable):
 
         # Register Magic Aliases
         mman = self.magics_manager
+        # surely, this can't be were magics aliases should be defined?
         mman.register_alias('ed', 'edit')
         mman.register_alias('hist', 'history')
         mman.register_alias('rep', 'recall')
         mman.register_alias('SVG', 'svg', 'cell')
         mman.register_alias('HTML', 'html', 'cell')
-        mman.register_alias('file', 'fwrite', 'cell')
+        mman.register_alias('file', 'writefile', 'cell')
 
         # FIXME: Move the color initialization to the DisplayHook, which
         # should be split into a prompt manager and displayhook. We probably

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -707,12 +707,12 @@ class OSMagics(Magics):
         help='file to write'
     )
     @cell_magic
-    def file(self, line, cell):
+    def fwrite(self, line, cell):
         """Write the contents of the cell to a file.
         
         The file will be overwritten unless the -a (--append) flag is specified.
         """
-        args = magic_arguments.parse_argstring(self.file, line)
+        args = magic_arguments.parse_argstring(self.fwrite, line)
         filename = os.path.expanduser(unquote_filename(args.filename))
         
         if os.path.exists(filename):

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -707,12 +707,12 @@ class OSMagics(Magics):
         help='file to write'
     )
     @cell_magic
-    def fwrite(self, line, cell):
+    def writefile(self, line, cell):
         """Write the contents of the cell to a file.
         
         The file will be overwritten unless the -a (--append) flag is specified.
         """
-        args = magic_arguments.parse_argstring(self.fwrite, line)
+        args = magic_arguments.parse_argstring(self.writefile, line)
         filename = os.path.expanduser(unquote_filename(args.filename))
         
         if os.path.exists(filename):


### PR DESCRIPTION
keeps `%%file` as alias

Alternative to #3313, no behavior is changed.
