### PR TITLE
Fix get_ipython_dir when $HOME is /

### DIFF
--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -308,7 +308,7 @@ def get_ipython_dir():
                         " using a temp directory."%ipdir)
         ipdir = tempfile.mkdtemp()
     elif not os.path.exists(ipdir):
-        parent = ipdir.rsplit(os.path.sep, 1)[0]
+        parent, _ = os.path.split(ipdir)
         if not _writable_dir(parent):
             # ipdir does not exist and parent isn't writable
             warnings.warn("IPython parent '%s' is not a writable location,"

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -308,7 +308,7 @@ def get_ipython_dir():
                         " using a temp directory."%ipdir)
         ipdir = tempfile.mkdtemp()
     elif not os.path.exists(ipdir):
-        parent, _ = os.path.split(ipdir)
+        parent = os.path.dirname(ipdir)
         if not _writable_dir(parent):
             # ipdir does not exist and parent isn't writable
             warnings.warn("IPython parent '%s' is not a writable location,"

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -295,6 +295,17 @@ def test_get_ipython_dir_7():
     ipdir = path.get_ipython_dir()
     nt.assert_equal(ipdir, os.path.join(home_dir, 'somewhere'))
 
+@with_environment
+def test_get_ipython_dir_8():
+    """test_get_ipython_dir_8, test / home directory"""
+    old = path._writable_dir, path.get_xdg_dir
+    try:
+        path._writable_dir = lambda path: bool(path)
+        path.get_xdg_dir = lambda: None
+        env['HOME'] = '/'
+        nt.assert_equal(path.get_ipython_dir(), '/.ipython')
+    finally:
+        path._writable_dir, path.get_xdg_dir = old
 
 @with_environment
 def test_get_xdg_dir_0():

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -302,6 +302,8 @@ def test_get_ipython_dir_8():
     try:
         path._writable_dir = lambda path: bool(path)
         path.get_xdg_dir = lambda: None
+        env.pop('IPYTHON_DIR', None)
+        env.pop('IPYTHONDIR', None)
         env['HOME'] = '/'
         nt.assert_equal(path.get_ipython_dir(), '/.ipython')
     finally:


### PR DESCRIPTION
Pretty self-explanatory. Many Unix flavors set $HOME to / for root.
