### PR TITLE
Use new input transformation API in %time magic

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -959,9 +959,9 @@ python-profiler package from non-free.""")
             raise UsageError("Can't use statement directly after '%%time'!")
         
         if cell:
-            expr = self.shell.prefilter(cell,False)
+            expr = self.shell.input_transformer_manager.transform_cell(cell)
         else:
-            expr = self.shell.prefilter(line,False)
+            expr = self.shell.input_transformer_manager.transform_cell(line)
 
         # Minimum time above which parse time will be reported
         tp_min = 0.1

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -301,6 +301,16 @@ def test_time2():
     with tt.AssertPrints("CPU times: user "):
         ip.run_cell("%time None")
 
+def test_time3():
+    """Erroneous magic function calls, issue gh-3334"""
+    ip = get_ipython()
+    ip.user_ns.pop('run', None)
+    
+    with tt.AssertNotPrints("not found", channel='stderr'):
+        ip.run_cell("%%time\n"
+                    "run = 0\n"
+                    "run += 1")
+
 def test_doctest_mode():
     "Toggle doctest_mode twice, it should be a no-op and run without error"
     _ip.magic('doctest_mode')


### PR DESCRIPTION
This avoids the perils of 'multiline specials', where valid Python code unexpectedly gets turned into IPython magic commands.

Closes gh-3334
