### PR TITLE
Allow filename with extension in find_cmd in Windows.

### DIFF
--- a/IPython/utils/_process_win32.py
+++ b/IPython/utils/_process_win32.py
@@ -83,7 +83,7 @@ def _find_cmd(cmd):
         path = None
         for ext in extensions:
             try:
-                path = SearchPath(PATH, cmd + ext)[0]
+                path = SearchPath(PATH, cmd, ext)[0]
             except:
                 pass
         if path is None:


### PR DESCRIPTION
closes #3316

According to [documentation here](http://docs.activestate.com/activepython/2.4/pywin32/win32api__SearchPath_meth.html), SearchPath takes an optional third parameter for the extension, which is only added if the filename doesn't have an extension.

Should be tested by someone on Windows.
