### PR TITLE
skip submodule check in package managers

### DIFF
--- a/IPython/utils/submodule.py
+++ b/IPython/utils/submodule.py
@@ -32,8 +32,9 @@ def ipython_parent():
 
 def ipython_submodules(root):
     """return IPython submodules relative to root"""
+    from IPython.frontend.html.notebook import DEFAULT_STATIC_FILES_PATH
     return [
-        pjoin(root, 'IPython', 'frontend', 'html', 'notebook', 'static', 'components'),
+        pjoin(DEFAULT_STATIC_FILES_PATH, 'components')
     ]
 
 def is_repo(d):

--- a/IPython/utils/submodule.py
+++ b/IPython/utils/submodule.py
@@ -40,6 +40,12 @@ def is_repo(d):
     """is d a git repo?"""
     return os.path.exists(pjoin(d, '.git'))
 
+def is_package():
+    """Is a package manager responsible for the static files path?"""
+    from IPython.utils.path import get_ipython_package_dir
+    from IPython.frontend.html.notebook import DEFAULT_STATIC_FILES_PATH
+    return not DEFAULT_STATIC_FILES_PATH.startswith(get_ipython_package_dir())
+
 def check_submodule_status(root=None):
     """check submodule status
 
@@ -51,8 +57,12 @@ def check_submodule_status(root=None):
     """
 
     if hasattr(sys, "frozen"):
-      # frozen via py2exe or similar, don't bother
-      return 'clean'
+        # frozen via py2exe or similar, don't bother
+        return 'clean'
+    
+    if is_package():
+        # package manager is responsible for static files, don't bother
+        return 'clean'
 
     if not root:
         root = ipython_parent()


### PR DESCRIPTION
custom DEFAULT_STATIC_FILES_PATH means a package is responsible, and everything should be assumed to be fine.
