### PR TITLE
catch socket.error in utils.localinterfaces

### DIFF
--- a/IPython/utils/localinterfaces.py
+++ b/IPython/utils/localinterfaces.py
@@ -31,7 +31,7 @@ from .data import uniq_stable
 LOCAL_IPS = []
 try:
     LOCAL_IPS = socket.gethostbyname_ex('localhost')[2]
-except socket.gaierror:
+except socket.error:
     pass
 
 PUBLIC_IPS = []
@@ -41,7 +41,7 @@ try:
     # try hostname.local, in case hostname has been short-circuited to loopback
     if not hostname.endswith('.local') and all(ip.startswith('127') for ip in PUBLIC_IPS):
         PUBLIC_IPS = socket.gethostbyname_ex(socket.gethostname() + '.local')[2]
-except socket.gaierror:
+except socket.error:
     pass
 else:
     PUBLIC_IPS = uniq_stable(PUBLIC_IPS)


### PR DESCRIPTION
instead of socket.gaierror, which is a more specific subclass. Some failures
(e.g. connection timeouts) are not gaierrors.

Alternately, we might want to just catch any Exception.
