### PR TITLE
Use different treshold for (auto)scroll in output

### DIFF
--- a/IPython/frontend/html/notebook/static/notebook/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/notebook/js/notebook.js
@@ -1242,7 +1242,7 @@ var IPython = (function (IPython) {
         for (var i=0; i<ncells; i++) {
             if (cells[i] instanceof IPython.CodeCell) {
                 cells[i].output_area.expand();
-                cells[i].output_area.scroll_if_long(20);
+                cells[i].output_area.scroll_if_long();
             }
         };
         // this should not be set if the `collapse` key is removed from nbformat

--- a/IPython/frontend/html/notebook/static/notebook/js/outputarea.js
+++ b/IPython/frontend/html/notebook/static/notebook/js/outputarea.js
@@ -168,7 +168,7 @@ var IPython = (function (IPython) {
      * Threshold to trigger autoscroll when the OutputArea is resized,
      * typically when new outputs are added.
      *
-     * Behavior is undefined if autoscroll is lower than scroll_threshold,
+     * Behavior is undefined if autoscroll is lower than minimum_scroll_threshold,
      * unless it is < 0, in which case autoscroll will never be triggered
      *
      * @property auto_scroll_threshold
@@ -183,12 +183,12 @@ var IPython = (function (IPython) {
      * Lower limit (in lines) for OutputArea to be made scrollable. OutputAreas
      * shorter than this are never scrolled.
      *
-     * @property scroll_threshold
+     * @property minimum_scroll_threshold
      * @type Number
      * @default 20
      *
      **/
-    OutputArea.scroll_threshold = 20;
+    OutputArea.minimum_scroll_threshold = 20;
 
 
     /**
@@ -196,17 +196,17 @@ var IPython = (function (IPython) {
      * Scroll OutputArea if height supperior than a threshold (in lines).
      *
      * Threshold is a maximum number of lines. If unspecified, defaults to
-     * OutputArea.scroll_threshold.
+     * OutputArea.minimum_scroll_threshold.
      *
      * Negative or null (0) threshold will prevent the OutputArea from ever
      * scrolling
      *
      * @method scroll_if_long
-     * @param [lines=OutputArea.scroll_threshold]{Number} Default to `OutputArea.scroll_threshold`
+     * @param [lines=OutputArea.minimum_scroll_threshold]{Number} Default to `OutputArea.minimum_scroll_threshold`
      *
      **/
     OutputArea.prototype.scroll_if_long = function (lines) {
-        var n = lines | OutputArea.scroll_threshold;
+        var n = lines | OutputArea.minimum_scroll_threshold;
         if(n <= 0){
             return
         }

--- a/IPython/frontend/html/notebook/static/notebook/js/outputarea.js
+++ b/IPython/frontend/html/notebook/static/notebook/js/outputarea.js
@@ -169,7 +169,7 @@ var IPython = (function (IPython) {
      * typically when new outputs are added.
      *
      * Behavior is undefined if autoscroll is lower than scroll_threshold,
-     * unless it is < 0 then autoscroll will never be triggerd
+     * unless it is < 0, in which case autoscroll will never be triggered
      *
      * @property auto_scroll_threshold
      * @type Number
@@ -180,8 +180,8 @@ var IPython = (function (IPython) {
 
 
     /**
-     * Defautl value for minimal length for output are to be able to switch to
-     * scroll mode
+     * Lower limit (in lines) for OutputArea to be made scrollable. OutputAreas
+     * shorter than this are never scrolled.
      *
      * @property scroll_threshold
      * @type Number
@@ -192,14 +192,17 @@ var IPython = (function (IPython) {
 
 
     /**
-     * Scroll OutputArea if height supperior than a threshold.
      *
-     * Treshold is exprimed as a number of lines, fallback to a (configurable) default.
+     * Scroll OutputArea if height supperior than a threshold (in lines).
      *
-     * Negative or null (0) threshold will prevent the OutputArea ever to scroll.
+     * Threshold is a maximum number of lines. If unspecified, defaults to
+     * OutputArea.scroll_threshold.
+     *
+     * Negative or null (0) threshold will prevent the OutputArea from ever
+     * scrolling
      *
      * @method scroll_if_long
-     * @param [lines=20,configurable]{Number}
+     * @param [lines=OutputArea.scroll_threshold]{Number} Default to `OutputArea.scroll_threshold`
      *
      **/
     OutputArea.prototype.scroll_if_long = function (lines) {

--- a/IPython/frontend/html/notebook/static/notebook/js/outputarea.js
+++ b/IPython/frontend/html/notebook/static/notebook/js/outputarea.js
@@ -1,5 +1,5 @@
 //----------------------------------------------------------------------------
-//  Copyright (C) 2008-2011  The IPython Development Team
+//  Copyright (C) 2008 The IPython Development Team
 //
 //  Distributed under the terms of the BSD License.  The full license is in
 //  the file COPYING, distributed as part of this software.
@@ -9,10 +9,21 @@
 // OutputArea
 //============================================================================
 
+/**
+ * @module IPython
+ * @namespace IPython
+ * @submodule OutputArea
+ */
 var IPython = (function (IPython) {
     "use strict";
 
     var utils = IPython.utils;
+
+    /**
+     * @class OutputArea
+     *
+     * @constructor
+     */
 
     var OutputArea = function (selector, prompt_area) {
         this.selector = selector;
@@ -59,8 +70,18 @@ var IPython = (function (IPython) {
         this.collapse();
     };
 
-
+    /**
+     * Should the OutputArea scroll?
+     * Returns whether the height (in lines) exceeds a threshold.
+     *
+     * @private
+     * @method _should_scroll
+     * @param [lines=100]{Integer}
+     * @return {Bool}
+     *
+     */
     OutputArea.prototype._should_scroll = function (lines) {
+        if (lines <=0 ){ return }
         if (!lines) {
             lines = 100;
         }
@@ -84,7 +105,7 @@ var IPython = (function (IPython) {
             }
             // maybe scroll output,
             // if it's grown large enough and hasn't already been scrolled.
-            if ( !that.scrolled && that._should_scroll()) {
+            if ( !that.scrolled && that._should_scroll(OutputArea.auto_scroll_threshold)) {
                 that.scroll_area();
             }
         });
@@ -143,9 +164,51 @@ var IPython = (function (IPython) {
         this.scrolled = false;
     };
 
+    /**
+     * Threshold to trigger autoscroll when the OutputArea is resized,
+     * typically when new outputs are added.
+     *
+     * Behavior is undefined if autoscroll is lower than scroll_threshold,
+     * unless it is < 0 then autoscroll will never be triggerd
+     *
+     * @property auto_scroll_threshold
+     * @type Number
+     * @default 20
+     *
+     **/
+    OutputArea.auto_scroll_threshold = 20;
 
+
+    /**
+     * Defautl value for minimal length for output are to be able to switch to
+     * scroll mode
+     *
+     * @property scroll_threshold
+     * @type Number
+     * @default 20
+     *
+     **/
+    OutputArea.scroll_threshold = 20;
+
+
+    /**
+     * Scroll OutputArea if height supperior than a threshold.
+     *
+     * Treshold is exprimed as a number of lines, fallback to a (configurable) default.
+     *
+     * Negative or null (0) threshold will prevent the OutputArea ever to scroll.
+     *
+     * @method scroll_if_long
+     * @param [lines=20,configurable]{Number}
+     *
+     **/
     OutputArea.prototype.scroll_if_long = function (lines) {
-        if (this._should_scroll(lines)) {
+        var n = lines | OutputArea.scroll_threshold;
+        if(n <= 0){
+            return
+        }
+
+        if (this._should_scroll(n)) {
             // only allow scrolling long-enough output
             this.scroll_area();
         }
@@ -157,7 +220,7 @@ var IPython = (function (IPython) {
             this.unscroll_area();
         } else {
             // only allow scrolling long-enough output
-            this.scroll_if_long(20);
+            this.scroll_if_long();
         }
     };
 
@@ -466,7 +529,7 @@ var IPython = (function (IPython) {
         toinsert.append(latex);
         element.append(toinsert);
     };
-    
+
     OutputArea.prototype.append_raw_input = function (content) {
         var that = this;
         this.expand();

--- a/IPython/frontend/html/notebook/static/notebook/js/outputarea.js
+++ b/IPython/frontend/html/notebook/static/notebook/js/outputarea.js
@@ -173,10 +173,10 @@ var IPython = (function (IPython) {
      *
      * @property auto_scroll_threshold
      * @type Number
-     * @default 20
+     * @default 100
      *
      **/
-    OutputArea.auto_scroll_threshold = 20;
+    OutputArea.auto_scroll_threshold = 100;
 
 
     /**

--- a/IPython/frontend/html/notebook/static/notebook/js/outputarea.js
+++ b/IPython/frontend/html/notebook/static/notebook/js/outputarea.js
@@ -198,11 +198,12 @@ var IPython = (function (IPython) {
      * Threshold is a maximum number of lines. If unspecified, defaults to
      * OutputArea.minimum_scroll_threshold.
      *
-     * Negative or null (0) threshold will prevent the OutputArea from ever
-     * scrolling
+     * Negative threshold will prevent the OutputArea from ever scrolling.
      *
      * @method scroll_if_long
-     * @param [lines=OutputArea.minimum_scroll_threshold]{Number} Default to `OutputArea.minimum_scroll_threshold`
+     *
+     * @param [lines=20]{Number} Default to 20 if not set,
+     * behavior undefined for value of `0`.
      *
      **/
     OutputArea.prototype.scroll_if_long = function (lines) {


### PR DESCRIPTION
Allow, in particular to switch to scolling for longer input (or disable
it) by still keeping the possibility to manually toggle the output to
scroll.
## 

I ended up doing that because it is **really** annoying to want to see long result coming through and have the output area constantly collapsing, but I still want to be able to collapse if I want to.

With this I can just issue a `IPyton.OutputArea.auto_scroll_treshold = -1` in js console and I'm good to go !
