### PR TITLE
base default cookie name on request host+port

### DIFF
--- a/IPython/frontend/html/notebook/base/handlers.py
+++ b/IPython/frontend/html/notebook/base/handlers.py
@@ -147,7 +147,10 @@ class AuthenticatedHandler(RequestHandler):
 
     @property
     def cookie_name(self):
-        return self.settings.get('cookie_name', '')
+        default_cookie_name = 'username-{host}'.format(
+            host=self.request.host,
+        ).replace(':', '-')
+        return self.settings.get('cookie_name', default_cookie_name)
     
     @property
     def password(self):

--- a/IPython/frontend/html/notebook/notebookapp.py
+++ b/IPython/frontend/html/notebook/notebookapp.py
@@ -166,7 +166,6 @@ class NotebookWebApplication(web.Application):
             # authentication
             cookie_secret=os.urandom(1024),
             login_url=url_path_join(base_project_url,'/login'),
-            cookie_name='username-%s' % uuid.uuid4(),
             read_only=ipython_app.read_only,
             password=ipython_app.password,
             


### PR DESCRIPTION
instead of random.

The random cookie name meant that every time you restarted the notebook it would get a new key in the cookie for the same host, resulting in an ever-growing cookie full of obsolete data.
