### PR TITLE
Make submodule checks work under Python 3.

### DIFF
--- a/IPython/utils/submodule.py
+++ b/IPython/utils/submodule.py
@@ -32,20 +32,13 @@ def ipython_parent():
 
 def ipython_submodules(root):
     """return IPython submodules relative to root"""
-    from IPython.frontend.html.notebook import DEFAULT_STATIC_FILES_PATH
     return [
-        pjoin(DEFAULT_STATIC_FILES_PATH, 'components')
+        pjoin(root, 'IPython', 'frontend', 'html', 'notebook', 'static', 'components'),
     ]
 
 def is_repo(d):
     """is d a git repo?"""
     return os.path.exists(pjoin(d, '.git'))
-
-def is_package():
-    """Is a package manager responsible for the static files path?"""
-    from IPython.utils.path import get_ipython_package_dir
-    from IPython.frontend.html.notebook import DEFAULT_STATIC_FILES_PATH
-    return not DEFAULT_STATIC_FILES_PATH.startswith(get_ipython_package_dir())
 
 def check_submodule_status(root=None):
     """check submodule status
@@ -60,23 +53,19 @@ def check_submodule_status(root=None):
     if hasattr(sys, "frozen"):
         # frozen via py2exe or similar, don't bother
         return 'clean'
-    
-    if is_package():
-        # package manager is responsible for static files, don't bother
-        return 'clean'
 
     if not root:
         root = ipython_parent()
+    
+    if not is_repo(root):
+        # not in git, assume clean
+        return 'clean'
 
     submodules = ipython_submodules(root)
 
     for submodule in submodules:
         if not os.path.exists(submodule):
             return 'missing'
-
-    if not is_repo(root):
-        # not in git, assume clean
-        return 'clean'
 
     # check with git submodule status
     proc = subprocess.Popen('git submodule status',

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,8 @@ def require_clean_submodules():
     after everything has been set in motion,
     this is not a distutils command.
     """
+    # PACKAGERS: Add a return here to skip checks for git submodules
+    
     # don't do anything if nothing is actually supposed to happen
     for do_nothing in ('-h', '--help', '--help-commands', 'clean', 'submodule'):
         if do_nothing in sys.argv:


### PR DESCRIPTION
My shot at fixing gh-3385.
- Ditch the imports from utils.submodule
- Move the `is_repo` check up: distro packaging will often not be running from a git repository, in which case packagers won't need to do anything. If we're not in a git repository, there's nothing sensible we can do about submodules anyway.
- Clearly label where packagers can patch to disable the submodule tests completely.
