### PR TITLE
Fix %paste with blank lines

### DIFF
--- a/IPython/core/tests/test_magic_terminal.py
+++ b/IPython/core/tests/test_magic_terminal.py
@@ -48,7 +48,7 @@ def check_cpaste(code, should_fail=False):
                 ip.magic('cpaste')
 
         if not should_fail:
-            assert ip.user_ns['code_ran']
+            assert ip.user_ns['code_ran'], "%r failed" % code
     finally:
         sys.stdin = stdin_save
 
@@ -130,6 +130,7 @@ class PasteTestCase(TestCase):
 
     def test_paste_py_multi_r(self):
         "Now, test that self.paste -r works"
+        self.test_paste_py_multi()
         nt.assert_equal(ip.user_ns.pop('x'), [1,2,3])
         nt.assert_equal(ip.user_ns.pop('y'), [1,4,9])
         nt.assert_false('x' in ip.user_ns)

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -150,14 +150,13 @@ class TerminalMagics(Magics):
     def store_or_execute(self, block, name):
         """ Execute a block, or store it in a variable, per the user's request.
         """
-
-        b = self.cleanup_input(block)
         if name:
             # If storing it for further editing
-            self.shell.user_ns[name] = SList(b.splitlines())
+            self.shell.user_ns[name] = SList(block.splitlines())
             print("Block assigned to '%s'" % name)
         else:
-            self.shell.user_ns['pasted_block'] = b
+            self.shell.user_ns['pasted_block'] = block
+            b = self.shell.input_transformer_manager.transform_cell(block)
             self.shell.using_paste_magics = True
             try:
                 self.shell.run_cell(b)

--- a/IPython/frontend/terminal/interactiveshell.py
+++ b/IPython/frontend/terminal/interactiveshell.py
@@ -83,69 +83,6 @@ class TerminalMagics(Magics):
     def __init__(self, shell):
         super(TerminalMagics, self).__init__(shell)
         self.input_splitter = IPythonInputSplitter()
-
-    def cleanup_input(self, block):
-        """Apply all possible IPython cleanups to an input block.
-
-        This means:
-
-        - remove any global leading whitespace (dedent)
-        - remove any email quotes ('>') if they are present in *all* lines
-        - apply all static inputsplitter transforms and break into sub-blocks
-        - apply prefilter() to each sub-block that is a single line.
-
-        Parameters
-        ----------
-        block : str
-          A possibly multiline input string of code.
-
-        Returns
-        -------
-        transformed block : str
-          The input, with all transformations above applied.
-        """
-        # We have to effectively implement client-side the loop that is done by
-        # the terminal frontend, and furthermore do it on a block that can
-        # possibly contain multiple statments pasted in one go.
-
-        # First, run the input through the block splitting code.  We should
-        # eventually make this a self-contained method in the inputsplitter.
-        isp = self.input_splitter
-        isp.reset()
-        b = textwrap.dedent(block)
-
-        # Remove email quotes first.  These must be consistently applied to
-        # *all* lines to be removed
-        b = strip_email_quotes(b)
-
-        # Split the input into independent sub-blocks so we can later do
-        # prefiltering (which must be done *only* to single-line inputs)
-        blocks = []
-        last_block = []
-        for line in b.splitlines():
-            isp.push(line)
-            last_block.append(line)
-            if not isp.push_accepts_more():
-                blocks.append(isp.source_reset())
-                last_block = []
-        if last_block:
-            blocks.append('\n'.join(last_block))
-
-        # Now, apply prefiltering to any one-line block to match the behavior
-        # of the interactive terminal
-        final_blocks = []
-        for block in blocks:
-            lines = block.splitlines()
-            if len(lines) == 1:
-                final_blocks.append(self.shell.prefilter(lines[0]))
-            else:
-                final_blocks.append(block)
-
-        # We now have the final version of the input code as a list of blocks,
-        # with all inputsplitter transformations applied and single-line blocks
-        # run through prefilter.  For further processing, turn into a single
-        # string as the rest of our apis use string inputs.
-        return '\n'.join(final_blocks)
         
     def store_or_execute(self, block, name):
         """ Execute a block, or store it in a variable, per the user's request.
@@ -155,13 +92,19 @@ class TerminalMagics(Magics):
             self.shell.user_ns[name] = SList(block.splitlines())
             print("Block assigned to '%s'" % name)
         else:
-            self.shell.user_ns['pasted_block'] = block
-            b = self.shell.input_transformer_manager.transform_cell(block)
+            b = self.preclean_input(block)
+            self.shell.user_ns['pasted_block'] = b
             self.shell.using_paste_magics = True
             try:
                 self.shell.run_cell(b)
             finally:
                 self.shell.using_paste_magics = False
+    
+    def preclean_input(self, block):
+        lines = block.splitlines()
+        while lines and not lines[0].strip():
+            lines = lines[1:]
+        return strip_email_quotes('\n'.join(lines))
 
     def rerun_pasted(self, name='pasted_block'):
         """ Rerun a previously pasted command.

--- a/IPython/frontend/terminal/tests/test_interactivshell.py
+++ b/IPython/frontend/terminal/tests/test_interactivshell.py
@@ -171,6 +171,7 @@ class InteractiveShellTestCase(unittest.TestCase):
         expected = [ py3compat.unicode_to_str(e, enc) for e in expected ]
         self.assertEqual(hist, expected)
     
+class TerminalMagicsTestCase(unittest.TestCase):
     def test_paste_magics_message(self):
         """Test that an IndentationError while using paste magics doesn't
         trigger a message about paste magics and also the opposite."""
@@ -187,3 +188,16 @@ class InteractiveShellTestCase(unittest.TestCase):
         with tt.AssertNotPrints("If you want to paste code into IPython, try the "
                 "%paste and %cpaste magic functions."):
             tm.store_or_execute(s, name=None)
+
+    def test_paste_magics_blankline(self):
+        """Test that code with a blank line doesn't get split (gh-3246)."""
+        ip = get_ipython()
+        s = ('def pasted_func(a):\n'
+             '    b = a+1\n'
+             '\n'
+             '    return b')
+        
+        tm = ip.magics_manager.registry['TerminalMagics']
+        tm.store_or_execute(s, name=None)
+        
+        self.assertEqual(ip.user_ns['pasted_func'](54), 55)

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -49,10 +49,6 @@ from nose.util import anyp, getpackage, test_address, resolve_name, tolist
 
 # Our own imports
 
-# We're temporarily using TerminalMagics.cleanup_input() until the functionality
-# is moved into core.
-from IPython.frontend.terminal.interactiveshell import TerminalMagics
-
 #-----------------------------------------------------------------------------
 # Module globals and other constants
 #-----------------------------------------------------------------------------
@@ -386,7 +382,11 @@ class IPDocTestParser(doctest.DocTestParser):
 
     def ip2py(self,source):
         """Convert input IPython source into valid Python."""
-        return TerminalMagics(_ip).cleanup_input(source)
+        block = _ip.input_transformer_manager.transform_cell(source)
+        if len(block.splitlines()) == 1:
+            return _ip.prefilter(block)
+        else:
+            return block
 
     def parse(self, string, name='<string>'):
         """


### PR DESCRIPTION
Closes gh-3246

This gets things working again. I'm still having a think about whether the remaining API details (stripping email quotes) can be moved into the core input transformers, but this fixes the problem.

This means that automagics won't work in pasted code. I think that's a good idea, because trying to apply automagics widely leads to bizarre and confusing bugs like #3334. Most code that people run using %paste is probably pure-Python code anyway.

Also, if you use `%paste foo` to transfer the clipboard contents to a variable, there's no obvious reason to expect that the content is Python code, so it now stores the raw string instead of trying to clean it up as code.
