### PR TITLE
Modify CM margin (to rever later)

### DIFF
--- a/IPython/frontend/html/notebook/static/notebook/less/codemirror.less
+++ b/IPython/frontend/html/notebook/static/notebook/less/codemirror.less
@@ -22,7 +22,7 @@
     /*  but at the expense of extra gutter at the bottom. To compensate, we shrink the margin */
     /*  between the last line and the scrollbar when it's drawn. */
     overflow: scroll;
-    margin-bottom: -38px; /* default margin is -30px */
+    margin-bottom: -28px; /* default margin is -30px */
 }
 
 /* this one is needed for Text Cells to match code cells for some reason */

--- a/IPython/frontend/html/notebook/static/style/style.min.css
+++ b/IPython/frontend/html/notebook/static/style/style.min.css
@@ -940,7 +940,7 @@ div.out_prompt_overlay{height:100%;padding:0px;position:absolute;border-radius:4
 div.out_prompt_overlay:hover{-webkit-box-shadow:inset 0 0 1px #000000;-moz-box-shadow:inset 0 0 1px #000000;box-shadow:inset 0 0 1px #000000;background:rgba(240, 240, 240, 0.5);}
 div.output_prompt{color:darkred;margin:0 5px 0 -5px;}
 .CodeMirror{line-height:1.231;height:auto;background:none;}
-.CodeMirror-scroll{overflow:scroll;margin-bottom:-38px;}
+.CodeMirror-scroll{overflow:scroll;margin-bottom:-28px;}
 .CodeMirror-wrap .CodeMirror-scroll{overflow:scroll;}
 .CodeMirror-vscrollbar,.CodeMirror-scrollbar-filler{visibility:hidden;}
 .CodeMirror-lines{padding:0.4em;}


### PR DESCRIPTION
Fixes #3397, should also be reverted when closed by #3391
Cf #3358 also.

I can't test if this prevent the scrollbar from appearing, as I've never had the issue.

But for what I have seen, this have the Codemirror cell to always have a blank line at the end on FF, and the correct size on Chrome.
