### PR TITLE
rollback #3358

### DIFF
--- a/IPython/frontend/html/notebook/static/notebook/less/codemirror.less
+++ b/IPython/frontend/html/notebook/static/notebook/less/codemirror.less
@@ -18,22 +18,8 @@
 .CodeMirror-scroll {
     /*  The CodeMirror docs are a bit fuzzy on if overflow-y should be hidden or visible.*/
     /*  We have found that if it is visible, vertical scrollbars appear with font size changes.*/
-    /*  overflow: scroll prevents scrollbars being drawn on top of the last line of the cell, */
-    /*  but at the expense of extra gutter at the bottom. To compensate, we shrink the margin */
-    /*  between the last line and the scrollbar when it's drawn. */
-    overflow: scroll;
-    margin-bottom: -38px; /* default margin is -30px */
-}
-
-/* this one is needed for Text Cells to match code cells for some reason */
-.CodeMirror-wrap .CodeMirror-scroll {
-  overflow: scroll;
-}
-
-/* CM sometimes draws a vertical scrollbar under zoom, but it never should in the Notebook. */
-/* this hides them - display: none would be preferable, but it gets clobbered by CodeMirror */
-.CodeMirror-vscrollbar, .CodeMirror-scrollbar-filler {
-    visibility: hidden;
+    overflow-y: hidden;
+    overflow-x: auto;
 }
 
 .CodeMirror-lines {

--- a/IPython/frontend/html/notebook/static/style/style.min.css
+++ b/IPython/frontend/html/notebook/static/style/style.min.css
@@ -940,9 +940,7 @@ div.out_prompt_overlay{height:100%;padding:0px;position:absolute;border-radius:4
 div.out_prompt_overlay:hover{-webkit-box-shadow:inset 0 0 1px #000000;-moz-box-shadow:inset 0 0 1px #000000;box-shadow:inset 0 0 1px #000000;background:rgba(240, 240, 240, 0.5);}
 div.output_prompt{color:darkred;margin:0 5px 0 -5px;}
 .CodeMirror{line-height:1.231;height:auto;background:none;}
-.CodeMirror-scroll{overflow:scroll;margin-bottom:-38px;}
-.CodeMirror-wrap .CodeMirror-scroll{overflow:scroll;}
-.CodeMirror-vscrollbar,.CodeMirror-scrollbar-filler{visibility:hidden;}
+.CodeMirror-scroll{overflow-y:hidden;overflow-x:auto;}
 .CodeMirror-lines{padding:0.4em;}
 .CodeMirror-linenumber{padding:0 8px 0 4px;}
 .CodeMirror-gutters{border-bottom-left-radius:4px;border-top-left-radius:4px;}


### PR DESCRIPTION
#3358 was a workaround for a CodeMirror (actually Chrome seems to be the one at fault) bug drawing scrollbars over text, when there isn't anything to scroll. The workaround was a compromise, always drawing the space for the scrollbars to prevent the overlay, but reducing the margin so it isn't quite so annoying in the ~99% of the time that there are no scrollbars.  It turns out (#3397, #3399) that the margins are not reliable, so the margin adjustment could cause the very same problem.

closes #3391, #3397, #3399

For users who need to hide the scrollbars while zooming text while we wait for a CodeMirror release, you can add the following to your custom.css:

``` css
.CodeMirror-scroll, .CodeMirror-wrap .CodeMirror-scroll {
 overflow: scroll;
}

.CodeMirror-vscrollbar, .CodeMirror-scrollbar-filler, .CodeMirror-hscrollbar {
   visibility: hidden;
}
```

or just put CodeMirror master in your profile's static/components directory.
