### PR TITLE
notebook keyboard shortcut Ctrl-m r for 'run all cells'

### DIFF
--- a/IPython/frontend/html/notebook/static/notebook/js/notebook.js
+++ b/IPython/frontend/html/notebook/static/notebook/js/notebook.js
@@ -211,6 +211,11 @@ var IPython = (function (IPython) {
                 that.to_markdown();
                 that.control_key_active = false;
                 return false;
+            } else if (event.which === 82 && that.control_key_active) {
+                // Run all cells = r
+                that.execute_all_cells();
+                that.control_key_active = false;
+                return false;
             } else if (event.which === 84 && that.control_key_active) {
                 // To Raw = t
                 that.to_raw();

--- a/IPython/frontend/html/notebook/static/notebook/js/quickhelp.js
+++ b/IPython/frontend/html/notebook/static/notebook/js/quickhelp.js
@@ -29,6 +29,7 @@ var IPython = (function (IPython) {
             {key: 'Shift-Enter', help: 'run cell'},
             {key: 'Ctrl-Enter', help: 'run cell in-place'},
             {key: 'Alt-Enter', help: 'run cell, insert below'},
+            {key: 'Ctrl-m r', help: 'run all cells'},
             {key: 'Ctrl-m x', help: 'cut cell'},
             {key: 'Ctrl-m c', help: 'copy cell'},
             {key: 'Ctrl-m v', help: 'paste cell'},


### PR DESCRIPTION
Hi

What do you think about mapping the notebook keyboard shortcut Ctrl-m r to "run all cells" as implemented in this PR? It's a very small change and I think it would be very convenient not to have to use mouse and the menu each time one want to run all cells in a notebook (which at least I do all the time).
