### PR TITLE
process escapes in mathjax

### DIFF
--- a/IPython/frontend/html/notebook/static/notebook/js/mathjaxutils.js
+++ b/IPython/frontend/html/notebook/static/notebook/js/mathjaxutils.js
@@ -20,6 +20,7 @@ IPython.mathjaxutils = (function (IPython) {
                 tex2jax: {
                     inlineMath: [ ['$','$'], ["\\(","\\)"] ],
                     displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+                    processEscapes: true,
                     processEnvironments: true
                 },
                 displayAlign: 'left', // Change this to 'center' to center equations.


### PR DESCRIPTION
allows `\$` to enter dollar signs in markdown.
