### PR TITLE
add parent to Configurable

### DIFF
--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -64,8 +64,8 @@ class Configurable(HasTraits):
             If this is empty, default values are used. If config is a
             :class:`Config` instance, it will be used to configure the
             instance.
-        parent : Configurable instance
-            The parent
+        parent : Configurable instance, optional
+            The parent Configurable instance of this object.
 
         Notes
         -----
@@ -112,6 +112,31 @@ class Configurable(HasTraits):
         return  [c.__name__ for c in reversed(cls.__mro__) if
             issubclass(c, Configurable) and issubclass(cls, c)
         ]
+    
+    def _find_my_config(self, cfg):
+        """extract my config from a global Config object
+        
+        will construct a Config object of only the config values that apply to me
+        based on my mro(), as well as those of my parent(s) if they exist.
+        
+        If I am Bar and my parent is Foo, and their parent is Tim,
+        this will return merge following config sections, in this order::
+        
+            [Bar, Foo.bar, Tim.Foo.Bar]
+        
+        With the last item being the highest priority.
+        """
+        cfgs = [cfg]
+        if self.parent:
+            cfgs.append(self.parent._find_my_config(cfg))
+        my_config = Config()
+        for c in cfgs:
+            for sname in self.section_names():
+                # Don't do a blind getattr as that would cause the config to
+                # dynamically create the section with name Class.__name__.
+                if c._has_section(sname):
+                    my_config.merge(c[sname])
+        return my_config
 
     def _load_config(self, cfg, section_names=None, traits=None):
         """load traits from a Config object"""
@@ -121,24 +146,13 @@ class Configurable(HasTraits):
         if section_names is None:
             section_names = self.section_names()
         
-        for sname in section_names:
-            # Don't do a blind getattr as that would cause the config to
-            # dynamically create the section with name self.__class__.__name__.
-            if cfg._has_section(sname):
-                my_config = cfg[sname]
-                for k, v in traits.iteritems():
-                    try:
-                        # Here we grab the value from the config
-                        # If k has the naming convention of a config
-                        # section, it will be auto created.
-                        config_value = my_config[k]
-                    except KeyError:
-                        pass
-                    else:
-                        # We have to do a deepcopy here if we don't deepcopy the entire
-                        # config object. If we don't, a mutable config_value will be
-                        # shared by all instances, effectively making it a class attribute.
-                        setattr(self, k, deepcopy(config_value))
+        my_config = self._find_my_config(cfg)
+        for name, config_value in my_config.iteritems():
+            if name in traits:
+                # We have to do a deepcopy here if we don't deepcopy the entire
+                # config object. If we don't, a mutable config_value will be
+                # shared by all instances, effectively making it a class attribute.
+                setattr(self, name, deepcopy(config_value))
 
     def _config_changed(self, name, old, new):
         """Update all the class traits having ``config=True`` as metadata.
@@ -155,13 +169,6 @@ class Configurable(HasTraits):
         # and works down the mro loading the config for each section.
         section_names = self.section_names()
         self._load_config(new, traits=traits, section_names=section_names)
-        
-        # load parent config as well, if we have one
-        parent_section_names = [] if self.parent is None else self.parent.section_names()
-        for parent in parent_section_names:
-            if not new._has_section(parent):
-                continue
-            self._load_config(new[parent], traits=traits, section_names=section_names)
 
     def update_config(self, config):
         """Fire the traits events when the config is updated."""

--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -81,7 +81,7 @@ class Configurable(HasTraits):
         This ensures that instances will be configured properly.
         """
         parent = kwargs.pop('parent', None)
-        if parent:
+        if parent is not None:
             # config is implied from parent
             if kwargs.get('config', None) is None:
                 kwargs['config'] = parent.config

--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -52,6 +52,7 @@ class MultipleInstanceError(ConfigurableError):
 class Configurable(HasTraits):
 
     config = Instance(Config, (), {})
+    parent = Instance('IPython.config.configurable.Configurable')
     created = None
 
     def __init__(self, **kwargs):
@@ -63,6 +64,8 @@ class Configurable(HasTraits):
             If this is empty, default values are used. If config is a
             :class:`Config` instance, it will be used to configure the
             instance.
+        parent : Configurable instance
+            The parent
 
         Notes
         -----
@@ -77,6 +80,13 @@ class Configurable(HasTraits):
 
         This ensures that instances will be configured properly.
         """
+        parent = kwargs.pop('parent', None)
+        if parent:
+            # config is implied from parent
+            if 'config' not in kwargs:
+                kwargs['config'] = parent.config
+            self.parent = parent
+        
         config = kwargs.pop('config', None)
         if config is not None:
             # We used to deepcopy, but for now we are trying to just save
@@ -95,6 +105,40 @@ class Configurable(HasTraits):
     #-------------------------------------------------------------------------
     # Static trait notifiations
     #-------------------------------------------------------------------------
+    
+    @classmethod
+    def section_names(cls):
+        """return section names as a list"""
+        return  [c.__name__ for c in reversed(cls.__mro__) if
+            issubclass(c, Configurable) and issubclass(cls, c)
+        ]
+
+    def _load_config(self, cfg, section_names=None, traits=None):
+        """load traits from a Config object"""
+        
+        if traits is None:
+            traits = self.traits(config=True)
+        if section_names is None:
+            section_names = self.section_names()
+        
+        for sname in section_names:
+            # Don't do a blind getattr as that would cause the config to
+            # dynamically create the section with name self.__class__.__name__.
+            if cfg._has_section(sname):
+                my_config = cfg[sname]
+                for k, v in traits.iteritems():
+                    try:
+                        # Here we grab the value from the config
+                        # If k has the naming convention of a config
+                        # section, it will be auto created.
+                        config_value = my_config[k]
+                    except KeyError:
+                        pass
+                    else:
+                        # We have to do a deepcopy here if we don't deepcopy the entire
+                        # config object. If we don't, a mutable config_value will be
+                        # shared by all instances, effectively making it a class attribute.
+                        setattr(self, k, deepcopy(config_value))
 
     def _config_changed(self, name, old, new):
         """Update all the class traits having ``config=True`` as metadata.
@@ -109,39 +153,16 @@ class Configurable(HasTraits):
         # We auto-load config section for this class as well as any parent
         # classes that are Configurable subclasses.  This starts with Configurable
         # and works down the mro loading the config for each section.
-        section_names = [cls.__name__ for cls in \
-            reversed(self.__class__.__mro__) if
-            issubclass(cls, Configurable) and issubclass(self.__class__, cls)]
-
-        for sname in section_names:
-            # Don't do a blind getattr as that would cause the config to
-            # dynamically create the section with name self.__class__.__name__.
-            if new._has_section(sname):
-                my_config = new[sname]
-                for k, v in traits.iteritems():
-                    # Don't allow traitlets with config=True to start with
-                    # uppercase.  Otherwise, they are confused with Config
-                    # subsections.  But, developers shouldn't have uppercase
-                    # attributes anyways! (PEP 6)
-                    if k[0].upper()==k[0] and not k.startswith('_'):
-                        raise ConfigurableError('Configurable traitlets with '
-                        'config=True must start with a lowercase so they are '
-                        'not confused with Config subsections: %s.%s' % \
-                        (self.__class__.__name__, k))
-                    try:
-                        # Here we grab the value from the config
-                        # If k has the naming convention of a config
-                        # section, it will be auto created.
-                        config_value = my_config[k]
-                    except KeyError:
-                        pass
-                    else:
-                        # print "Setting %s.%s from %s.%s=%r" % \
-                        #     (self.__class__.__name__,k,sname,k,config_value)
-                        # We have to do a deepcopy here if we don't deepcopy the entire
-                        # config object. If we don't, a mutable config_value will be
-                        # shared by all instances, effectively making it a class attribute.
-                        setattr(self, k, deepcopy(config_value))
+        section_names = self.section_names()
+        self._load_config(new, traits=traits, section_names=section_names)
+        
+        # load parent config as well, if we have one
+        parent_section_names = [] if self.parent is None else self.parent.section_names()
+        for parent in parent_section_names:
+            print parent, new._has_section(parent), new[parent]
+            if not new._has_section(parent):
+                continue
+            self._load_config(new[parent], traits=traits, section_names=section_names)
 
     def update_config(self, config):
         """Fire the traits events when the config is updated."""
@@ -161,7 +182,6 @@ class Configurable(HasTraits):
         class defaults.
         """
         assert inst is None or isinstance(inst, cls)
-        cls_traits = cls.class_traits(config=True)
         final_help = []
         final_help.append(u'%s options' % cls.__name__)
         final_help.append(len(final_help[0])*u'-')

--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -83,7 +83,7 @@ class Configurable(HasTraits):
         parent = kwargs.pop('parent', None)
         if parent:
             # config is implied from parent
-            if 'config' not in kwargs:
+            if kwargs.get('config', None) is None:
                 kwargs['config'] = parent.config
             self.parent = parent
         
@@ -159,7 +159,6 @@ class Configurable(HasTraits):
         # load parent config as well, if we have one
         parent_section_names = [] if self.parent is None else self.parent.section_names()
         for parent in parent_section_names:
-            print parent, new._has_section(parent), new[parent]
             if not new._has_section(parent):
                 continue
             self._load_config(new[parent], traits=traits, section_names=section_names)

--- a/IPython/config/tests/test_application.py
+++ b/IPython/config/tests/test_application.py
@@ -72,10 +72,10 @@ class MyApp(Application):
             ))
     
     def init_foo(self):
-        self.foo = Foo(config=self.config)
+        self.foo = Foo(parent=self)
 
     def init_bar(self):
-        self.bar = Bar(config=self.config)
+        self.bar = Bar(parent=self)
 
 
 class TestApplication(TestCase):

--- a/IPython/config/tests/test_configurable.py
+++ b/IPython/config/tests/test_configurable.py
@@ -192,7 +192,6 @@ class MyParent2(MyParent):
 class TestParentConfigurable(TestCase):
     
     def test_parent_config(self):
-        
         cfg = Config({
             'MyParent' : {
                 'MyConfigurable' : {
@@ -205,7 +204,6 @@ class TestParentConfigurable(TestCase):
         self.assertEqual(myc.b, parent.config.MyParent.MyConfigurable.b)
 
     def test_parent_inheritance(self):
-        
         cfg = Config({
             'MyParent' : {
                 'MyConfigurable' : {
@@ -217,8 +215,26 @@ class TestParentConfigurable(TestCase):
         myc = MyConfigurable(parent=parent)
         self.assertEqual(myc.b, parent.config.MyParent.MyConfigurable.b)
 
+    def test_multi_parent(self):
+        cfg = Config({
+            'MyParent2' : {
+                'MyParent' : {
+                    'MyConfigurable' : {
+                        'b' : 2.0,
+                    }
+                },
+                # this one shouldn't count
+                'MyConfigurable' : {
+                    'b' : 3.0,
+                },
+            }
+        })
+        parent2 = MyParent2(config=cfg)
+        parent = MyParent(parent=parent2)
+        myc = MyConfigurable(parent=parent)
+        self.assertEqual(myc.b, parent.config.MyParent2.MyParent.MyConfigurable.b)
+
     def test_parent_priority(self):
-        
         cfg = Config({
             'MyConfigurable' : {
                 'b' : 2.0,
@@ -237,3 +253,32 @@ class TestParentConfigurable(TestCase):
         parent = MyParent2(config=cfg)
         myc = MyConfigurable(parent=parent)
         self.assertEqual(myc.b, parent.config.MyParent2.MyConfigurable.b)
+
+    def test_multi_parent_priority(self):
+        cfg = Config({
+            'MyConfigurable' : {
+                'b' : 2.0,
+            },
+            'MyParent' : {
+                'MyConfigurable' : {
+                    'b' : 3.0,
+                }
+            },
+            'MyParent2' : {
+                'MyConfigurable' : {
+                    'b' : 4.0,
+                }
+            },
+            'MyParent2' : {
+                'MyParent' : {
+                    'MyConfigurable' : {
+                        'b' : 5.0,
+                    }
+                }
+            }
+        })
+        parent2 = MyParent2(config=cfg)
+        parent = MyParent2(parent=parent2)
+        myc = MyConfigurable(parent=parent)
+        self.assertEqual(myc.b, parent.config.MyParent2.MyParent.MyConfigurable.b)
+

--- a/IPython/config/tests/test_configurable.py
+++ b/IPython/config/tests/test_configurable.py
@@ -181,3 +181,59 @@ class TestSingletonConfigurable(TestCase):
         self.assertEqual(bam, Bam._instance)
         self.assertEqual(bam, Bar._instance)
         self.assertEqual(SingletonConfigurable._instance, None)
+
+
+class MyParent(Configurable):
+    pass
+
+class MyParent2(MyParent):
+    pass
+
+class TestParentConfigurable(TestCase):
+    
+    def test_parent_config(self):
+        
+        cfg = Config({
+            'MyParent' : {
+                'MyConfigurable' : {
+                    'b' : 2.0,
+                }
+            }
+        })
+        parent = MyParent(config=cfg)
+        myc = MyConfigurable(parent=parent)
+        self.assertEqual(myc.b, parent.config.MyParent.MyConfigurable.b)
+
+    def test_parent_inheritance(self):
+        
+        cfg = Config({
+            'MyParent' : {
+                'MyConfigurable' : {
+                    'b' : 2.0,
+                }
+            }
+        })
+        parent = MyParent2(config=cfg)
+        myc = MyConfigurable(parent=parent)
+        self.assertEqual(myc.b, parent.config.MyParent.MyConfigurable.b)
+
+    def test_parent_priority(self):
+        
+        cfg = Config({
+            'MyConfigurable' : {
+                'b' : 2.0,
+            },
+            'MyParent' : {
+                'MyConfigurable' : {
+                    'b' : 3.0,
+                }
+            },
+            'MyParent2' : {
+                'MyConfigurable' : {
+                    'b' : 4.0,
+                }
+            }
+        })
+        parent = MyParent2(config=cfg)
+        myc = MyConfigurable(parent=parent)
+        self.assertEqual(myc.b, parent.config.MyParent2.MyConfigurable.b)

--- a/IPython/consoleapp.py
+++ b/IPython/consoleapp.py
@@ -341,7 +341,7 @@ class IPythonConsoleApp(Configurable):
                                 stdin_port=self.stdin_port,
                                 hb_port=self.hb_port,
                                 connection_file=self.connection_file,
-                                config=self.config,
+                                parent=self,
         )
         self.kernel_manager.client_factory = self.kernel_client_class
         self.kernel_manager.start_kernel(extra_arguments=self.kernel_argv)
@@ -371,7 +371,7 @@ class IPythonConsoleApp(Configurable):
                                 stdin_port=self.stdin_port,
                                 hb_port=self.hb_port,
                                 connection_file=self.connection_file,
-                                config=self.config,
+                                parent=self,
             )
 
         self.kernel_client.start_channels()

--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -114,8 +114,8 @@ class AliasManager(Configurable):
     user_aliases = List(default_value=[], config=True)
     shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
 
-    def __init__(self, shell=None, config=None):
-        super(AliasManager, self).__init__(shell=shell, config=config)
+    def __init__(self, shell=None, **kwargs):
+        super(AliasManager, self).__init__(shell=shell, **kwargs)
         self.alias_table = {}
         self.exclude_aliases()
         self.init_aliases()

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -246,7 +246,7 @@ class Completer(Configurable):
     )
     
 
-    def __init__(self, namespace=None, global_namespace=None, config=None, **kwargs):
+    def __init__(self, namespace=None, global_namespace=None, **kwargs):
         """Create a new completer for the command line.
 
         Completer(namespace=ns,global_namespace=ns2) -> completer instance.
@@ -280,7 +280,7 @@ class Completer(Configurable):
         else:
             self.global_namespace = global_namespace
 
-        super(Completer, self).__init__(config=config, **kwargs)
+        super(Completer, self).__init__(**kwargs)
 
     def complete(self, text, state):
         """Return the next possible completion for 'text'.

--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -50,8 +50,8 @@ class DisplayHook(Configurable):
 
     shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
 
-    def __init__(self, shell=None, cache_size=1000, config=None):
-        super(DisplayHook, self).__init__(shell=shell, config=config)
+    def __init__(self, shell=None, cache_size=1000, **kwargs):
+        super(DisplayHook, self).__init__(shell=shell, **kwargs)
 
         cache_size_min = 3
         if cache_size <= 0:

--- a/IPython/core/extensions.py
+++ b/IPython/core/extensions.py
@@ -47,7 +47,7 @@ class ExtensionManager(Configurable):
     that point, including defining new magic and aliases, adding new
     components, etc.
     
-    You can also optionaly define an :func:`unload_ipython_extension(ipython)`
+    You can also optionally define an :func:`unload_ipython_extension(ipython)`
     function, which will be called if the user unloads or reloads the extension.
     The extension manager will only call :func:`load_ipython_extension` again
     if the extension is reloaded.
@@ -61,8 +61,8 @@ class ExtensionManager(Configurable):
 
     shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
 
-    def __init__(self, shell=None, config=None):
-        super(ExtensionManager, self).__init__(shell=shell, config=config)
+    def __init__(self, shell=None, **kwargs):
+        super(ExtensionManager, self).__init__(shell=shell, **kwargs)
         self.shell.on_trait_change(
             self._on_ipython_dir_changed, 'ipython_dir'
         )

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -92,7 +92,7 @@ class DisplayFormatter(Configurable):
         ]
         d = {}
         for cls in formatter_classes:
-            f = cls(config=self.config)
+            f = cls(parent=self)
             d[f.format_type] = f
         return d
 

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -148,7 +148,7 @@ class HistoryAccessor(Configurable):
                     (self.__class__.__name__, new)
             raise TraitError(msg)
     
-    def __init__(self, profile='default', hist_file=u'', config=None, **traits):
+    def __init__(self, profile='default', hist_file=u'', **traits):
         """Create a new history accessor.
         
         Parameters
@@ -162,7 +162,7 @@ class HistoryAccessor(Configurable):
           Config object. hist_file can also be set through this.
         """
         # We need a pointer back to the shell for various tasks.
-        super(HistoryAccessor, self).__init__(config=config, **traits)
+        super(HistoryAccessor, self).__init__(**traits)
         # defer setting hist_file from kwarg until after init,
         # otherwise the default kwarg value would clobber any value
         # set by config

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -419,13 +419,13 @@ class InteractiveShell(SingletonConfigurable):
     # Tracks any GUI loop loaded for pylab
     pylab_gui_select = None
 
-    def __init__(self, config=None, ipython_dir=None, profile_dir=None,
+    def __init__(self, ipython_dir=None, profile_dir=None,
                  user_module=None, user_ns=None,
                  custom_exceptions=((), None), **kwargs):
 
         # This is where traits with a config_key argument are updated
         # from the values on config.
-        super(InteractiveShell, self).__init__(config=config, **kwargs)
+        super(InteractiveShell, self).__init__(**kwargs)
         self.configurables = [self]
 
         # These are relatively independent and stateless
@@ -651,7 +651,7 @@ class InteractiveShell(SingletonConfigurable):
             io.stderr = io.IOStream(sys.stderr)
 
     def init_prompts(self):
-        self.prompt_manager = PromptManager(shell=self, config=self.config)
+        self.prompt_manager = PromptManager(shell=self, parent=self)
         self.configurables.append(self.prompt_manager)
         # Set system prompts, so that scripts can decide if they are running
         # interactively.
@@ -660,24 +660,24 @@ class InteractiveShell(SingletonConfigurable):
         sys.ps3 = 'Out: '
 
     def init_display_formatter(self):
-        self.display_formatter = DisplayFormatter(config=self.config)
+        self.display_formatter = DisplayFormatter(parent=self)
         self.configurables.append(self.display_formatter)
 
     def init_display_pub(self):
-        self.display_pub = self.display_pub_class(config=self.config)
+        self.display_pub = self.display_pub_class(parent=self)
         self.configurables.append(self.display_pub)
 
     def init_data_pub(self):
         if not self.data_pub_class:
             self.data_pub = None
             return
-        self.data_pub = self.data_pub_class(config=self.config)
+        self.data_pub = self.data_pub_class(parent=self)
         self.configurables.append(self.data_pub)
 
     def init_displayhook(self):
         # Initialize displayhook, set in/out prompts and printing system
         self.displayhook = self.displayhook_class(
-            config=self.config,
+            parent=self,
             shell=self,
             cache_size=self.cache_size,
         )
@@ -688,7 +688,7 @@ class InteractiveShell(SingletonConfigurable):
 
     def init_latextool(self):
         """Configure LaTeXTool."""
-        cfg = LaTeXTool.instance(config=self.config)
+        cfg = LaTeXTool.instance(parent=self)
         if cfg not in self.configurables:
             self.configurables.append(cfg)
 
@@ -1511,7 +1511,7 @@ class InteractiveShell(SingletonConfigurable):
 
     def init_history(self):
         """Sets up the command history, and starts regular autosaves."""
-        self.history_manager = HistoryManager(shell=self, config=self.config)
+        self.history_manager = HistoryManager(shell=self, parent=self)
         self.configurables.append(self.history_manager)
 
     #-------------------------------------------------------------------------
@@ -1943,7 +1943,7 @@ class InteractiveShell(SingletonConfigurable):
                                      global_namespace=self.user_global_ns,
                                      alias_table=self.alias_manager.alias_table,
                                      use_readline=self.has_readline,
-                                     config=self.config,
+                                     parent=self,
                                      )
         self.configurables.append(self.Completer)
 
@@ -2038,7 +2038,7 @@ class InteractiveShell(SingletonConfigurable):
     def init_magics(self):
         from IPython.core import magics as m
         self.magics_manager = magic.MagicsManager(shell=self,
-                                   config=self.config,
+                                   parent=self,
                                    user_magics=m.UserMagics(self))
         self.configurables.append(self.magics_manager)
 
@@ -2299,7 +2299,7 @@ class InteractiveShell(SingletonConfigurable):
     #-------------------------------------------------------------------------
 
     def init_alias(self):
-        self.alias_manager = AliasManager(shell=self, config=self.config)
+        self.alias_manager = AliasManager(shell=self, parent=self)
         self.configurables.append(self.alias_manager)
         self.ns_table['alias'] = self.alias_manager.alias_table,
 
@@ -2308,7 +2308,7 @@ class InteractiveShell(SingletonConfigurable):
     #-------------------------------------------------------------------------
 
     def init_extension_manager(self):
-        self.extension_manager = ExtensionManager(shell=self, config=self.config)
+        self.extension_manager = ExtensionManager(shell=self, parent=self)
         self.configurables.append(self.extension_manager)
 
     #-------------------------------------------------------------------------
@@ -2316,7 +2316,7 @@ class InteractiveShell(SingletonConfigurable):
     #-------------------------------------------------------------------------
 
     def init_payload(self):
-        self.payload_manager = PayloadManager(config=self.config)
+        self.payload_manager = PayloadManager(parent=self)
         self.configurables.append(self.payload_manager)
 
     #-------------------------------------------------------------------------
@@ -2324,7 +2324,7 @@ class InteractiveShell(SingletonConfigurable):
     #-------------------------------------------------------------------------
 
     def init_prefilter(self):
-        self.prefilter_manager = PrefilterManager(shell=self, config=self.config)
+        self.prefilter_manager = PrefilterManager(shell=self, parent=self)
         self.configurables.append(self.prefilter_manager)
         # Ultimately this will be refactored in the new interpreter code, but
         # for now, we should expose the main prefilter method (there's legacy

--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -134,8 +134,8 @@ class PrefilterManager(Configurable):
     multi_line_specials = CBool(True, config=True)
     shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
 
-    def __init__(self, shell=None, config=None):
-        super(PrefilterManager, self).__init__(shell=shell, config=config)
+    def __init__(self, shell=None, **kwargs):
+        super(PrefilterManager, self).__init__(shell=shell, **kwargs)
         self.shell = shell
         self.init_transformers()
         self.init_handlers()
@@ -150,7 +150,7 @@ class PrefilterManager(Configurable):
         self._transformers = []
         for transformer_cls in _default_transformers:
             transformer_cls(
-                shell=self.shell, prefilter_manager=self, config=self.config
+                shell=self.shell, prefilter_manager=self, parent=self
             )
 
     def sort_transformers(self):
@@ -186,7 +186,7 @@ class PrefilterManager(Configurable):
         self._checkers = []
         for checker in _default_checkers:
             checker(
-                shell=self.shell, prefilter_manager=self, config=self.config
+                shell=self.shell, prefilter_manager=self, parent=self
             )
 
     def sort_checkers(self):
@@ -223,7 +223,7 @@ class PrefilterManager(Configurable):
         self._esc_handlers = {}
         for handler in _default_handlers:
             handler(
-                shell=self.shell, prefilter_manager=self, config=self.config
+                shell=self.shell, prefilter_manager=self, parent=self
             )
 
     @property
@@ -368,9 +368,9 @@ class PrefilterTransformer(Configurable):
     prefilter_manager = Instance('IPython.core.prefilter.PrefilterManager')
     enabled = Bool(True, config=True)
 
-    def __init__(self, shell=None, prefilter_manager=None, config=None):
+    def __init__(self, shell=None, prefilter_manager=None, **kwargs):
         super(PrefilterTransformer, self).__init__(
-            shell=shell, prefilter_manager=prefilter_manager, config=config
+            shell=shell, prefilter_manager=prefilter_manager, **kwargs
         )
         self.prefilter_manager.register_transformer(self)
 
@@ -396,9 +396,9 @@ class PrefilterChecker(Configurable):
     prefilter_manager = Instance('IPython.core.prefilter.PrefilterManager')
     enabled = Bool(True, config=True)
 
-    def __init__(self, shell=None, prefilter_manager=None, config=None):
+    def __init__(self, shell=None, prefilter_manager=None, **kwargs):
         super(PrefilterChecker, self).__init__(
-            shell=shell, prefilter_manager=prefilter_manager, config=config
+            shell=shell, prefilter_manager=prefilter_manager, **kwargs
         )
         self.prefilter_manager.register_checker(self)
 
@@ -561,9 +561,9 @@ class PrefilterHandler(Configurable):
     shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
     prefilter_manager = Instance('IPython.core.prefilter.PrefilterManager')
 
-    def __init__(self, shell=None, prefilter_manager=None, config=None):
+    def __init__(self, shell=None, prefilter_manager=None, **kwargs):
         super(PrefilterHandler, self).__init__(
-            shell=shell, prefilter_manager=prefilter_manager, config=config
+            shell=shell, prefilter_manager=prefilter_manager, **kwargs
         )
         self.prefilter_manager.register_handler(
             self.handler_name,

--- a/IPython/core/prompts.py
+++ b/IPython/core/prompts.py
@@ -318,8 +318,8 @@ class PromptManager(Configurable):
     def _invisible_chars_default(self):
         return {'in': 0, 'in2': 0, 'out': 0, 'rewrite':0}
     
-    def __init__(self, shell, config=None):
-        super(PromptManager, self).__init__(shell=shell, config=config)
+    def __init__(self, shell, **kwargs):
+        super(PromptManager, self).__init__(shell=shell, **kwargs)
         
         # Prepare colour scheme table
         self.color_scheme_table = coloransi.ColorSchemeTable([PColNoColors,

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -283,7 +283,7 @@ def configure_inline_support(shell, backend, user_ns=None):
 
     user_ns = shell.user_ns if user_ns is None else user_ns
     
-    cfg = InlineBackend.instance(config=shell.config)
+    cfg = InlineBackend.instance(parent=shell)
     cfg.shell = shell
     if cfg not in shell.configurables:
         shell.configurables.append(cfg)

--- a/IPython/html/base/zmqhandlers.py
+++ b/IPython/html/base/zmqhandlers.py
@@ -84,7 +84,7 @@ class AuthenticatedZMQStreamHandler(ZMQStreamHandler, IPythonHandler):
 
     def open(self, kernel_id):
         self.kernel_id = kernel_id.decode('ascii')
-        self.session = Session(config=self.config)
+        self.session = Session(parent=self)
         self.save_on_message = self.on_message
         self.on_message = self.on_first_message
 

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -522,13 +522,13 @@ class NotebookApp(BaseIPythonApplication):
         # force Session default to be secure
         default_secure(self.config)
         self.kernel_manager = MappingKernelManager(
-            config=self.config, log=self.log, kernel_argv=self.kernel_argv,
+            parent=self, log=self.log, kernel_argv=self.kernel_argv,
             connection_dir = self.profile_dir.security_dir,
         )
         kls = import_item(self.notebook_manager_class)
-        self.notebook_manager = kls(config=self.config, log=self.log)
+        self.notebook_manager = kls(parent=self, log=self.log)
         self.notebook_manager.load_notebook_names()
-        self.cluster_manager = ClusterManager(config=self.config, log=self.log)
+        self.cluster_manager = ClusterManager(parent=self, log=self.log)
         self.cluster_manager.update_profiles()
 
     def init_logging(self):

--- a/IPython/kernel/client.py
+++ b/IPython/kernel/client.py
@@ -59,7 +59,7 @@ class KernelClient(LoggingConfigurable, ConnectionFileMixin):
     # The Session to use for communication with the kernel.
     session = Instance(Session)
     def _session_default(self):
-        return Session(config=self.config)
+        return Session(parent=self)
 
     # The classes to use for the various channels
     shell_channel_class = Type(ShellChannel)

--- a/IPython/kernel/inprocess/ipkernel.py
+++ b/IPython/kernel/inprocess/ipkernel.py
@@ -134,7 +134,7 @@ class InProcessKernel(Kernel):
 
     def _session_default(self):
         from IPython.kernel.zmq.session import Session
-        return Session(config=self.config)
+        return Session(parent=self)
 
     def _shell_class_default(self):
         return InProcessInteractiveShell

--- a/IPython/kernel/ioloop/manager.py
+++ b/IPython/kernel/ioloop/manager.py
@@ -48,7 +48,7 @@ class IOLoopKernelManager(KernelManager):
             if self._restarter is None:
                 self._restarter = IOLoopKernelRestarter(
                     kernel_manager=self, loop=self.loop,
-                    config=self.config, log=self.log
+                    parent=self, log=self.log
                 )
             self._restarter.start()
 

--- a/IPython/kernel/manager.py
+++ b/IPython/kernel/manager.py
@@ -56,7 +56,7 @@ class KernelManager(LoggingConfigurable, ConnectionFileMixin):
     # The Session to use for communication with the kernel.
     session = Instance(Session)
     def _session_default(self):
-        return Session(config=self.config)
+        return Session(parent=self)
 
     # the class to create with our `client` method
     client_class = DottedObjectName('IPython.kernel.blocking.BlockingKernelClient')
@@ -129,7 +129,7 @@ class KernelManager(LoggingConfigurable, ConnectionFileMixin):
         kw.update(dict(
             connection_file=self.connection_file,
             session=self.session,
-            config=self.config,
+            parent=self,
         ))
 
         # add kwargs last, for manual overrides

--- a/IPython/kernel/multikernelmanager.py
+++ b/IPython/kernel/multikernelmanager.py
@@ -110,7 +110,7 @@ class MultiKernelManager(LoggingConfigurable):
         # including things like its transport and ip.
         km = self.kernel_manager_factory(connection_file=os.path.join(
                     self.connection_dir, "kernel-%s.json" % kernel_id),
-                    config=self.config, autorestart=True, log=self.log
+                    parent=self, autorestart=True, log=self.log
         )
         km.start_kernel(**kwargs)
         self._kernels[kernel_id] = km

--- a/IPython/kernel/zmq/ipkernel.py
+++ b/IPython/kernel/zmq/ipkernel.py
@@ -141,7 +141,7 @@ class Kernel(Configurable):
         super(Kernel, self).__init__(**kwargs)
 
         # Initialize the InteractiveShell subclass
-        self.shell = self.shell_class.instance(config=self.config,
+        self.shell = self.shell_class.instance(parent=self,
             profile_dir = self.profile_dir,
             user_module = self.user_module,
             user_ns     = self.user_ns,

--- a/IPython/parallel/apps/ipclusterapp.py
+++ b/IPython/parallel/apps/ipclusterapp.py
@@ -338,7 +338,7 @@ class IPClusterEngines(BaseParallelApplication):
             self.exit(1)
 
         launcher = klass(
-            work_dir=u'.', config=self.config, log=self.log,
+            work_dir=u'.', parent=self, log=self.log,
             profile_dir=self.profile_dir.location, cluster_id=self.cluster_id,
         )
         return launcher

--- a/IPython/parallel/apps/ipengineapp.py
+++ b/IPython/parallel/apps/ipengineapp.py
@@ -360,7 +360,7 @@ class IPEngineApp(BaseParallelApplication):
     
     def init_mpi(self):
         global mpi
-        self.mpi = MPI(config=self.config)
+        self.mpi = MPI(parent=self)
 
         mpi_import_statement = self.mpi.init_script
         if mpi_import_statement:

--- a/IPython/parallel/apps/iploggerapp.py
+++ b/IPython/parallel/apps/iploggerapp.py
@@ -76,7 +76,7 @@ class IPLoggerApp(BaseParallelApplication):
     
     def init_watcher(self):
         try:
-            self.watcher = LogWatcher(config=self.config, log=self.log)
+            self.watcher = LogWatcher(parent=self, log=self.log)
         except:
             self.log.error("Couldn't start the LogWatcher", exc_info=True)
             self.exit(1)

--- a/IPython/parallel/apps/launcher.py
+++ b/IPython/parallel/apps/launcher.py
@@ -385,7 +385,7 @@ class LocalEngineSetLauncher(LocalEngineLauncher):
         for i in range(n):
             if i > 0:
                 time.sleep(self.delay)
-            el = self.launcher_class(work_dir=self.work_dir, config=self.config, log=self.log,
+            el = self.launcher_class(work_dir=self.work_dir, parent=self, log=self.log,
                                     profile_dir=self.profile_dir, cluster_id=self.cluster_id,
             )
 
@@ -767,7 +767,7 @@ class SSHEngineSetLauncher(LocalEngineSetLauncher):
             for i in range(n):
                 if i > 0:
                     time.sleep(self.delay)
-                el = self.launcher_class(work_dir=self.work_dir, config=self.config, log=self.log,
+                el = self.launcher_class(work_dir=self.work_dir, parent=self, log=self.log,
                                         profile_dir=self.profile_dir, cluster_id=self.cluster_id,
                 )
                 if i > 0:
@@ -922,9 +922,9 @@ class WindowsHPCControllerLauncher(WindowsHPCLauncher, ClusterAppMixin):
         help="extra args to pass to ipcontroller")
 
     def write_job_file(self, n):
-        job = IPControllerJob(config=self.config)
+        job = IPControllerJob(parent=self)
 
-        t = IPControllerTask(config=self.config)
+        t = IPControllerTask(parent=self)
         # The tasks work directory is *not* the actual work directory of
         # the controller. It is used as the base path for the stdout/stderr
         # files that the scheduler redirects to.
@@ -954,10 +954,10 @@ class WindowsHPCEngineSetLauncher(WindowsHPCLauncher, ClusterAppMixin):
         help="extra args to pas to ipengine")
 
     def write_job_file(self, n):
-        job = IPEngineSetJob(config=self.config)
+        job = IPEngineSetJob(parent=self)
 
         for i in range(n):
-            t = IPEngineTask(config=self.config)
+            t = IPEngineTask(parent=self)
             # The tasks work directory is *not* the actual work directory of
             # the engine. It is used as the base path for the stdout/stderr
             # files that the scheduler redirects to.

--- a/IPython/parallel/controller/hub.py
+++ b/IPython/parallel/controller/hub.py
@@ -300,7 +300,7 @@ class HubFactory(RegistrationFactory):
         hrep = ctx.socket(zmq.ROUTER)
         util.set_hwm(hrep, 0)
         hrep.bind(self.engine_url('hb_pong'))
-        self.heartmonitor = HeartMonitor(loop=loop, config=self.config, log=self.log,
+        self.heartmonitor = HeartMonitor(loop=loop, parent=self, log=self.log,
                                 pingstream=ZMQStream(hpub,loop),
                                 pongstream=ZMQStream(hrep,loop)
                             )
@@ -324,7 +324,7 @@ class HubFactory(RegistrationFactory):
         db_class = _db_shortcuts.get(self.db_class.lower(), self.db_class)
         self.log.info('Hub using DB backend: %r', (db_class.split('.')[-1]))
         self.db = import_item(str(db_class))(session=self.session.session,
-                                            config=self.config, log=self.log)
+                                            parent=self, log=self.log)
         time.sleep(.25)
 
         # resubmit stream

--- a/IPython/parallel/engine/engine.py
+++ b/IPython/parallel/engine/engine.py
@@ -230,7 +230,7 @@ class EngineFactory(RegistrationFactory):
                 sys.displayhook = self.display_hook_factory(self.session, iopub_socket)
                 sys.displayhook.topic = cast_bytes('engine.%i.pyout' % self.id)
 
-            self.kernel = Kernel(config=self.config, int_id=self.id, ident=self.ident, session=self.session,
+            self.kernel = Kernel(parent=self, int_id=self.id, ident=self.ident, session=self.session,
                     control_stream=control_stream, shell_streams=shell_streams, iopub_socket=iopub_socket,
                     loop=loop, user_ns=self.user_ns, log=self.log)
             
@@ -251,7 +251,7 @@ class EngineFactory(RegistrationFactory):
 
             
             # FIXME: This is a hack until IPKernelApp and IPEngineApp can be fully merged
-            app = IPKernelApp(config=self.config, shell=self.kernel.shell, kernel=self.kernel, log=self.log)
+            app = IPKernelApp(parent=self, shell=self.kernel.shell, kernel=self.kernel, log=self.log)
             app.init_profile_dir()
             app.init_code()
             

--- a/IPython/parallel/tests/test_launcher.py
+++ b/IPython/parallel/tests/test_launcher.py
@@ -56,7 +56,7 @@ class LauncherTest:
         kw = dict(
             work_dir=self.profile_dir,
             profile_dir=self.profile_dir,
-            config=self.config,
+            parent=self,
             cluster_id='',
             log=logging.getLogger(),
         )

--- a/IPython/parallel/tests/test_launcher.py
+++ b/IPython/parallel/tests/test_launcher.py
@@ -56,7 +56,7 @@ class LauncherTest:
         kw = dict(
             work_dir=self.profile_dir,
             profile_dir=self.profile_dir,
-            parent=self,
+            config=self.config,
             cluster_id='',
             log=logging.getLogger(),
         )

--- a/IPython/qt/console/qtconsoleapp.py
+++ b/IPython/qt/console/qtconsoleapp.py
@@ -196,7 +196,7 @@ class IPythonQtConsoleApp(BaseIPythonApplication, IPythonConsoleApp):
         """
         kernel_manager = self.kernel_manager_class(
                                 connection_file=self._new_connection_file(),
-                                config=self.config,
+                                parent=self,
                                 autorestart=True,
         )
         # start the kernel

--- a/IPython/qt/manager.py
+++ b/IPython/qt/manager.py
@@ -37,7 +37,7 @@ class QtKernelManager(KernelManager, QtKernelManagerMixin):
             if self._restarter is None:
                 self._restarter = QtKernelRestarter(
                     kernel_manager=self,
-                    config=self.config,
+                    parent=self,
                     log=self.log,
                 )
                 self._restarter.add_callback(self._handle_kernel_restarted)

--- a/IPython/terminal/console/app.py
+++ b/IPython/terminal/console/app.py
@@ -112,7 +112,7 @@ class ZMQTerminalIPythonApp(TerminalIPythonApp, IPythonConsoleApp):
         IPythonConsoleApp.initialize(self)
         # relay sigint to kernel
         signal.signal(signal.SIGINT, self.handle_sigint)
-        self.shell = ZMQTerminalInteractiveShell.instance(config=self.config,
+        self.shell = ZMQTerminalInteractiveShell.instance(parent=self,
                         display_banner=False, profile_dir=self.profile_dir,
                         ipython_dir=self.ipython_dir,
                         manager=self.kernel_manager,

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -337,7 +337,7 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
         # shell.display_banner should always be False for the terminal
         # based app, because we call shell.show_banner() by hand below
         # so the banner shows *before* all extension loading stuff.
-        self.shell = TerminalInteractiveShell.instance(config=self.config,
+        self.shell = TerminalInteractiveShell.instance(parent=self,
                         display_banner=False, profile_dir=self.profile_dir,
                         ipython_dir=self.ipython_dir)
         self.shell.configurables.append(self)


### PR DESCRIPTION
this adds the notion of a parent and member config, so the config:

   c.Foo.Bar.attr = value

will only set `Bar.attr = value` for `Bar` instances which are members of `Foo` instances. The mechanism for doing this is

``` python
f = Foo(config=cfg) f.b = Bar(parent=f)
```

This Instance config has higher priority than plain class config for Bar, but still lower priority than direct keyword arg trait assignment.

The main implication this has is to change the standard creation of descendants:

``` python
self.bar = Bar(config=self.config)
```

into a direct parent expression

``` python
self.bar = Bar(parent=self)
```

This also means that most Configurables will actually have a handle on their parent object.

It also means that most IPython configurables have a handle on their parent object.
If this is undesirable, we can construct the name list at init, without holding onto the key.
