### PR TITLE
Added alingment property to slideshow preset from CellToolBar.

### DIFF
--- a/IPython/frontend/html/notebook/static/notebook/js/celltoolbarpresets/slideshow.js
+++ b/IPython/frontend/html/notebook/static/notebook/js/celltoolbarpresets/slideshow.js
@@ -51,6 +51,13 @@
     CellToolbar.register_callback('slideshow.select',select_type);
 
     slideshow_preset.push('slideshow.select');
+    
+    CellToolbar.register_preset('Slideshow',slideshow_preset);
+    console.log('Slideshow extension for metadata editing loaded.');
+
+ // New reveal_preset enhancing the slideshow_preset with an alignment function
+
+    var reveal_preset = slideshow_preset.slice();
 
     var select_align = CellToolbar.utils.select_ui_generator([
             ["Left"         ,undefined      ],
@@ -74,10 +81,10 @@
             "Alignment");
 
     CellToolbar.register_callback('slideshow.select_align',select_align);
-
-    slideshow_preset.push('slideshow.select_align');
-
-    CellToolbar.register_preset('Slideshow',slideshow_preset);
-    console.log('Slideshow extension for metadata editing loaded.');
+ 
+    reveal_preset.push('slideshow.select_align');
+ 
+    CellToolbar.register_preset('Reveal',reveal_preset);
+    console.log('Reveal extension for metadata editing loaded.');
 
 }(IPython));

--- a/IPython/frontend/html/notebook/static/notebook/js/celltoolbarpresets/slideshow.js
+++ b/IPython/frontend/html/notebook/static/notebook/js/celltoolbarpresets/slideshow.js
@@ -52,6 +52,31 @@
 
     slideshow_preset.push('slideshow.select');
 
+    var select_align = CellToolbar.utils.select_ui_generator([
+            ["Left"         ,undefined      ],
+            ["Center"       ,"center"       ],
+            ["Right"        ,"right"        ],
+            ],
+            // setter
+            function(cell, value){
+                // we check that the slideshow namespace exist and create it if needed
+                if (cell.metadata.slideshow == undefined){cell.metadata.slideshow = {}}
+                // set the value
+                cell.metadata.slideshow.align_type = value
+                },
+            //geter
+            function(cell){ var ns = cell.metadata.slideshow;
+                // if the slideshow namespace does not exist return `undefined`
+                // (will be interpreted as `false` by checkbox) otherwise
+                // return the value
+                return (ns == undefined)? undefined: ns.align_type
+                },
+            "Alignment");
+
+    CellToolbar.register_callback('slideshow.select_align',select_align);
+
+    slideshow_preset.push('slideshow.select_align');
+
     CellToolbar.register_preset('Slideshow',slideshow_preset);
     console.log('Slideshow extension for metadata editing loaded.');
 


### PR DESCRIPTION
I have added an "Alignment" property to the slideshow preset from CellToolBar.
This feature is an enhancement proposed from several reveal (nbconvert) users.

With a simple design, similar to Slide Type property (I mean, the generation of specific slideshow metadata inside the notebook to keep data about the type of the different slideshow elements) a drop down menu, left to Slide Type, and called "Alignment", show us just three possible alignment of the elements inside a cell (Left, Center, RIght). Note that the "Alignment" property is applied at the whole cell.

You can see an image below showing the new "Alignment" dropdown menu:
![aling](https://f.cloud.github.com/assets/1640669/657648/b0ebd8ac-d56a-11e2-9f51-75950895706f.png)

I have also modified nbconvert reveal-related templates and RevealHelpTransformer to get this new available alignment metadata and generate the slideshow according to the alignment proposed by the user for each cell.

Finally, with this simple modification, you gain a lot of versatility in the organization of different element inside your slides, making the framework more powerful when you want to get nice slideshows.

Cheers.
Damián.

pinging @Carreau who developed this preset ;-)
