### PR TITLE
Fix installing mathjax from downloaded file via command line

### DIFF
--- a/IPython/external/mathjax.py
+++ b/IPython/external/mathjax.py
@@ -219,7 +219,6 @@ def main() :
             '--test',
             action='store_true')
     parser.add_argument('tarball',
-            type=int,
             help="the local tar/zip-ball containing mathjax",
             nargs='?',
             metavar='tarball')


### PR DESCRIPTION
Fix `mathjax.py: error: argument tarball: invalid int value: 'mathjax-xxx.zip'` when running `python -m IPython.external.mathjax mathjax-xxx.zip`.
