### PR TITLE
Notice for users who disable javascript

### DIFF
--- a/IPython/frontend/html/notebook/static/base/less/page.less
+++ b/IPython/frontend/html/notebook/static/base/less/page.less
@@ -26,6 +26,16 @@ div#header {
     padding-left: 16px;
 }
 
+#noscript {
+     width: auto;
+     padding-top: 16px;
+     padding-bottom: 16px;
+     text-align: center;
+     font-size: 22px;
+     color: red;
+     font-weight: bold;
+}
+
 #ipython_notebook img {
     font-family: Verdana, "Helvetica Neue", Arial, Helvetica, Geneva, sans-serif;
     height: 24px;

--- a/IPython/frontend/html/notebook/static/style/style.min.css
+++ b/IPython/frontend/html/notebook/static/style/style.min.css
@@ -1048,6 +1048,7 @@ a.label:hover,a.label:focus,a.badge:hover,a.badge:focus{color:#ffffff;text-decor
 body{background-color:white;position:absolute;left:0px;right:0px;top:0px;bottom:0px;overflow:visible;}
 div#header{display:none;}
 #ipython_notebook{padding-left:16px;}
+#noscript{width:auto;padding-top:16px;padding-bottom:16px;text-align:center;font-size:22px;color:red;font-weight:bold;}
 #ipython_notebook img{font-family:Verdana,"Helvetica Neue",Arial,Helvetica,Geneva,sans-serif;height:24px;text-decoration:none;color:black;}
 #site{width:100%;display:none;}
 .ui-button .ui-button-text{padding:0.2em 0.8em;font-size:77%;}

--- a/IPython/frontend/html/notebook/templates/page.html
+++ b/IPython/frontend/html/notebook/templates/page.html
@@ -41,7 +41,7 @@
 <body {% block params %}{% endblock %}>
 
 <noscript>
-  <div id='noscript' style='width: auto; padding-top: 5px, padding-bottom: 5px; text-align: center; font-size: 22px; color: red; font-weight: bold;'>
+    <div id='noscript'>
       IPython Notebook requires JavaScript.<br>
       Please enable it to proceed.
   </div>

--- a/IPython/frontend/html/notebook/templates/page.html
+++ b/IPython/frontend/html/notebook/templates/page.html
@@ -40,6 +40,13 @@
 
 <body {% block params %}{% endblock %}>
 
+<noscript>
+  <div id='noscript' style='width: auto; padding-top: 5px, padding-bottom: 5px; text-align: center; font-size: 22px; color: red; font-weight: bold;'>
+      IPython Notebook requires JavaScript.<br>
+      Please enable it to proceed.
+  </div>
+</noscript>
+
 <div id="header" class="navbar navbar-static-top">
   <div class="navbar-inner navbar-nobg">
     <div class="container">


### PR DESCRIPTION
I run into this from time to time, because I forget that I have NoScript running, or have disabled javascript for some reason.

This also helps to communicate interoperability for the case when the `webbrowser` python standard library module find `lynx` or `w3m` as the only browser (on headless servers without X11, for example).
