### PR TITLE
Add HTCondor bindings to IPython.parallel

### DIFF
--- a/IPython/parallel/apps/ipclusterapp.py
+++ b/IPython/parallel/apps/ipclusterapp.py
@@ -488,6 +488,7 @@ class IPClusterStart(IPClusterEngines):
             PBS : use PBS (qsub) to submit the controller to a batch queue
             SGE : use SGE (qsub) to submit the controller to a batch queue
             LSF : use LSF (bsub) to submit the controller to a batch queue
+            Condor: use HTCondor to submit the controller to a batch queue
             SSH : use SSH to start the controller
             WindowsHPC : use Windows HPC
 

--- a/IPython/parallel/apps/ipclusterapp.py
+++ b/IPython/parallel/apps/ipclusterapp.py
@@ -60,7 +60,7 @@ _description = """Start an IPython cluster for parallel computing.
 
 An IPython cluster consists of 1 controller and 1 or more engines.
 This command automates the startup of these processes using a wide range of
-startup methods (SSH, local processes, PBS, mpiexec, SGE, LSF, Condor,
+startup methods (SSH, local processes, PBS, mpiexec, SGE, LSF, HTCondor,
 Windows HPC Server 2008). To start a cluster with 4 engines on your
 local host simply do 'ipcluster start --n=4'. For more complex usage
 you will typically do 'ipython profile create mycluster --parallel', then edit
@@ -116,7 +116,7 @@ def find_launcher_class(clsname, kind):
     ==========
     clsname : str
         The full name of the launcher class, either with or without the
-        module path, or an abbreviation (MPI, SSH, SGE, PBS, LSF, Condor
+        module path, or an abbreviation (MPI, SSH, SGE, PBS, LSF, HTCondor
         WindowsHPC).
     kind : str
         Either 'EngineSet' or 'Controller'.
@@ -287,7 +287,7 @@ class IPClusterEngines(BaseParallelApplication):
                         Note that SSH does *not* move the connection files
                         around, so you will likely have to do this manually
                         unless the machines are on a shared file system.
-            Condor : use HTCondor to submit engines to a batch queue
+            HTCondor : use HTCondor to submit engines to a batch queue
             WindowsHPC : use Windows HPC
 
         If you are using one of IPython's builtin launchers, you can specify just the
@@ -489,7 +489,7 @@ class IPClusterStart(IPClusterEngines):
             PBS : use PBS (qsub) to submit the controller to a batch queue
             SGE : use SGE (qsub) to submit the controller to a batch queue
             LSF : use LSF (bsub) to submit the controller to a batch queue
-            Condor: use HTCondor to submit the controller to a batch queue
+            HTCondor : use HTCondor to submit the controller to a batch queue
             SSH : use SSH to start the controller
             WindowsHPC : use Windows HPC
 

--- a/IPython/parallel/apps/ipclusterapp.py
+++ b/IPython/parallel/apps/ipclusterapp.py
@@ -59,8 +59,8 @@ default_config_file_name = u'ipcluster_config.py'
 _description = """Start an IPython cluster for parallel computing.
 
 An IPython cluster consists of 1 controller and 1 or more engines.
-This command automates the startup of these processes using a wide
-range of startup methods (SSH, local processes, PBS, mpiexec,
+This command automates the startup of these processes using a wide range of
+startup methods (SSH, local processes, PBS, mpiexec, SGE, LSF, Condor,
 Windows HPC Server 2008). To start a cluster with 4 engines on your
 local host simply do 'ipcluster start --n=4'. For more complex usage
 you will typically do 'ipython profile create mycluster --parallel', then edit
@@ -116,7 +116,7 @@ def find_launcher_class(clsname, kind):
     ==========
     clsname : str
         The full name of the launcher class, either with or without the
-        module path, or an abbreviation (MPI, SSH, SGE, PBS, LSF,
+        module path, or an abbreviation (MPI, SSH, SGE, PBS, LSF, Condor
         WindowsHPC).
     kind : str
         Either 'EngineSet' or 'Controller'.
@@ -125,7 +125,7 @@ def find_launcher_class(clsname, kind):
         # not a module, presume it's the raw name in apps.launcher
         if kind and kind not in clsname:
             # doesn't match necessary full class name, assume it's
-            # just 'PBS' or 'MPI' prefix:
+            # just 'PBS' or 'MPI' etc prefix:
             clsname = clsname + kind + 'Launcher'
         clsname = 'IPython.parallel.apps.launcher.'+clsname
     klass = import_item(clsname)
@@ -287,6 +287,7 @@ class IPClusterEngines(BaseParallelApplication):
                         Note that SSH does *not* move the connection files
                         around, so you will likely have to do this manually
                         unless the machines are on a shared file system.
+            Condor : use HTCondor to submit engines to a batch queue
             WindowsHPC : use Windows HPC
 
         If you are using one of IPython's builtin launchers, you can specify just the

--- a/IPython/parallel/apps/launcher.py
+++ b/IPython/parallel/apps/launcher.py
@@ -1123,7 +1123,6 @@ class BatchSystemLauncher(BaseLauncher):
     def _insert_queue_in_script(self):
         """Inserts a queue if required into the batch script.
         """
-        print self.queue_regexp.search(self.batch_template)
         if self.queue and not self.queue_regexp.search(self.batch_template):
             self.log.debug("adding PBS queue settings to batch script")
             firstline, rest = self.batch_template.split('\n',1)
@@ -1132,7 +1131,6 @@ class BatchSystemLauncher(BaseLauncher):
     def _insert_job_array_in_script(self):
         """Inserts a job array if required into the batch script.
         """
-        print self.job_array_regexp.search(self.batch_template)
         if not self.job_array_regexp.search(self.batch_template):
             self.log.debug("adding job array settings to batch script")
             firstline, rest = self.batch_template.split('\n',1)

--- a/IPython/parallel/apps/launcher.py
+++ b/IPython/parallel/apps/launcher.py
@@ -1334,23 +1334,22 @@ class CondorLauncher(BatchSystemLauncher):
 
     job_array_regexp = CRegExp('queue\W+\$')
     job_array_template = Unicode('queue {n}')
-    # template for the submission of multiple jobs
-    queue_regexp = CRegExp('#PBS\W+-q\W+\$?\w+')
-    # regex to find a queue if the user has specified a template
-    queue_template = Unicode('#PBS -q {queue}')
-    # the queue we wish to submit to. Need to know the Condor eqiv (eg ibug cluster
-    # or general?)
+
 
     def _insert_job_array_in_script(self):
         """Inserts a job array if required into the batch script.
         """
-        print self.job_array_regexp.search(self.batch_template)
-        #Condor requires that the job array goes at the bottom of the
-        #script
         if not self.job_array_regexp.search(self.batch_template):
             self.log.debug("adding job array settings to batch script")
+            #Condor requires that the job array goes at the bottom of the script
             self.batch_template = '\n'.join([self.batch_template,
                 self.job_array_template])
+
+    def _insert_queue_in_script(self):
+        """AFAIK, Condor doesn't have a concept of multiple queues that can be
+        specified in the script..
+        """
+        pass
 
 
 class CondorControllerLauncher(CondorLauncher, BatchClusterAppMixin):

--- a/IPython/parallel/apps/launcher.py
+++ b/IPython/parallel/apps/launcher.py
@@ -1330,7 +1330,7 @@ class CondorLauncher(BatchSystemLauncher):
 
     def _insert_queue_in_script(self):
         """AFAIK, Condor doesn't have a concept of multiple queues that can be
-        specified in the script..
+        specified in the script.
         """
         pass
 

--- a/IPython/parallel/apps/launcher.py
+++ b/IPython/parallel/apps/launcher.py
@@ -1285,10 +1285,10 @@ class LSFEngineSetLauncher(LSFLauncher, BatchClusterAppMixin):
 
 
 
-class CondorLauncher(BatchSystemLauncher):
-    """A BatchSystemLauncher subclass for Condor.
+class HTCondorLauncher(BatchSystemLauncher):
+    """A BatchSystemLauncher subclass for HTCondor.
 
-    Condor requires that we launch the ipengine/ipcontroller scripts rather
+    HTCondor requires that we launch the ipengine/ipcontroller scripts rather
     that the python instance but otherwise is very similar to PBS.  This is because 
     HTCondor destroys sys.executable when launching remote processes - a launched 
     python process depends on sys.executable to effectively evaluate its
@@ -1307,9 +1307,9 @@ class CondorLauncher(BatchSystemLauncher):
     """
 
     submit_command = List(['condor_submit'], config=True,
-        help="The Condor submit command ['condor_submit']")
+        help="The HTCondor submit command ['condor_submit']")
     delete_command = List(['condor_rm'], config=True,
-        help="The Condor delete command ['condor_rm']")
+        help="The HTCondor delete command ['condor_rm']")
     job_id_regexp = CRegExp(r'(\d+)\.$', config=True,
         help="Regular expression for identifying the job ID [r'(\d+)\.$']")
     job_id_regexp_group = Integer(1, config=True,
@@ -1324,21 +1324,21 @@ class CondorLauncher(BatchSystemLauncher):
         """
         if not self.job_array_regexp.search(self.batch_template):
             self.log.debug("adding job array settings to batch script")
-            #Condor requires that the job array goes at the bottom of the script
+            #HTCondor requires that the job array goes at the bottom of the script
             self.batch_template = '\n'.join([self.batch_template,
                 self.job_array_template])
 
     def _insert_queue_in_script(self):
-        """AFAIK, Condor doesn't have a concept of multiple queues that can be
+        """AFAIK, HTCondor doesn't have a concept of multiple queues that can be
         specified in the script.
         """
         pass
 
 
-class CondorControllerLauncher(CondorLauncher, BatchClusterAppMixin):
-    """Launch a controller using Condor."""
+class HTCondorControllerLauncher(HTCondorLauncher, BatchClusterAppMixin):
+    """Launch a controller using HTCondor."""
 
-    batch_file_name = Unicode(u'condor_controller', config=True,
+    batch_file_name = Unicode(u'htcondor_controller', config=True,
                               help="batch file name for the controller job.")
     default_template = Unicode(r"""
 universe        = vanilla
@@ -1350,12 +1350,12 @@ arguments       = --log-to-file '--profile-dir={profile_dir}' --cluster-id='{clu
 
     def start(self):
         """Start the controller by profile or profile_dir."""
-        return super(CondorControllerLauncher, self).start(1)
+        return super(HTCondorControllerLauncher, self).start(1)
 
 
-class CondorEngineSetLauncher(CondorLauncher, BatchClusterAppMixin):
-    """Launch Engines using Condor"""
-    batch_file_name = Unicode(u'condor_engines', config=True,
+class HTCondorEngineSetLauncher(HTCondorLauncher, BatchClusterAppMixin):
+    """Launch Engines using HTCondor"""
+    batch_file_name = Unicode(u'htcondor_engines', config=True,
                               help="batch file name for the engine(s) job.")
     default_template = Unicode("""
 universe        = vanilla
@@ -1432,10 +1432,10 @@ lsf_launchers = [
     LSFControllerLauncher,
     LSFEngineSetLauncher,
 ]
-condor_launchers = [
-    CondorLauncher,
-    CondorControllerLauncher,
-    CondorEngineSetLauncher,
+htcondor_launchers = [
+    HTCondorLauncher,
+    HTCondorControllerLauncher,
+    HTCondorEngineSetLauncher,
 ]
 all_launchers = local_launchers + mpi_launchers + ssh_launchers + winhpc_launchers\
-                + pbs_launchers + sge_launchers + lsf_launchers + condor_launchers
+                + pbs_launchers + sge_launchers + lsf_launchers + htcondor_launchers

--- a/IPython/parallel/apps/launcher.py
+++ b/IPython/parallel/apps/launcher.py
@@ -1298,9 +1298,9 @@ class CondorLauncher(BatchSystemLauncher):
     We use the ip{cluster, engine, controller} scripts as our executable to circumvent 
     this - the mechanism of shebanged scripts means that the python binary will be 
     launched with argv[0] set to the *location of the ip{cluster, engine, controller} 
-    scripts on the remote node*. This means that:
-      a. The default path to ipengine etc scripts on your remote node needs to be
-         in the same directory as the python executable you wish to run
+    scripts on the remote node*. This means you need to take care that:
+      a. Your remote nodes have their paths configured correctly, with the ipengine and ipcontroller
+         of the python environment you wish to execute code in having top precedence.
       b. This functionality is untested on Windows.
 
     If you need different behavior, consider making you own template.

--- a/IPython/parallel/apps/launcher.py
+++ b/IPython/parallel/apps/launcher.py
@@ -1184,7 +1184,6 @@ class PBSControllerLauncher(PBSLauncher, BatchClusterAppMixin):
 %s --log-to-file --profile-dir="{profile_dir}" --cluster-id="{cluster_id}"
 """%(' '.join(map(pipes.quote, ipcontroller_cmd_argv))))
 
-
     def start(self):
         """Start the controller by profile or profile_dir."""
         return super(PBSControllerLauncher, self).start(1)
@@ -1199,10 +1198,6 @@ class PBSEngineSetLauncher(PBSLauncher, BatchClusterAppMixin):
 #PBS -N ipengine
 %s --profile-dir="{profile_dir}" --cluster-id="{cluster_id}"
 """%(' '.join(map(pipes.quote,ipengine_cmd_argv))))
-
-    def start(self, n):
-        """Start n engines by profile or profile_dir."""
-        return super(PBSEngineSetLauncher, self).start(n)
 
 
 #SGE is very similar to PBS
@@ -1240,10 +1235,6 @@ class SGEEngineSetLauncher(SGELauncher, BatchClusterAppMixin):
 #$ -N ipengine
 %s --profile-dir="{profile_dir}" --cluster-id="{cluster_id}"
 """%(' '.join(map(pipes.quote, ipengine_cmd_argv))))
-
-    def start(self, n):
-        """Start n engines by profile or profile_dir."""
-        return super(SGEEngineSetLauncher, self).start(n)
 
 
 # LSF launchers
@@ -1310,10 +1301,6 @@ class LSFEngineSetLauncher(LSFLauncher, BatchClusterAppMixin):
     %s --profile-dir="{profile_dir}" --cluster-id="{cluster_id}"
     """%(' '.join(map(pipes.quote, ipengine_cmd_argv))))
 
-    def start(self, n):
-        """Start n engines by profile or profile_dir."""
-        return super(LSFEngineSetLauncher, self).start(n)
-
 
 # Condor Requires that we launch the ipengine/ipcontroller scripts rather
 # that the python instance but otherwise is very similar to PBS
@@ -1379,10 +1366,6 @@ executable      = %s
 transfer_executable = False
 arguments       = "--log-to-file '--profile-dir={profile_dir}' '--cluster-id={cluster_id}'"
 """ % condor_ipengine_cmd_argv)
-
-    def start(self, n):
-        """Start n engines by profile or profile_dir."""
-        return super(CondorEngineSetLauncher, self).start(n)
 
 
 #-----------------------------------------------------------------------------

--- a/IPython/parallel/tests/test_launcher.py
+++ b/IPython/parallel/tests/test_launcher.py
@@ -129,8 +129,8 @@ class TestSGEControllerLauncher(BatchTest, ControllerLauncherTest, TestCase):
 class TestLSFControllerLauncher(BatchTest, ControllerLauncherTest, TestCase):
     launcher_class = launcher.LSFControllerLauncher
 
-class TestCondorControllerLauncher(BatchTest, ControllerLauncherTest, TestCase):
-    launcher_class = launcher.CondorControllerLauncher
+class TestHTCondorControllerLauncher(BatchTest, ControllerLauncherTest, TestCase):
+    launcher_class = launcher.HTCondorControllerLauncher
 
 class TestSSHControllerLauncher(SSHTest, ControllerLauncherTest, TestCase):
     launcher_class = launcher.SSHControllerLauncher
@@ -158,8 +158,8 @@ class TestSGEEngineSetLauncher(BatchTest, EngineSetLauncherTest, TestCase):
 class TestLSFEngineSetLauncher(BatchTest, EngineSetLauncherTest, TestCase):
     launcher_class = launcher.LSFEngineSetLauncher
 
-class TestCondorEngineSetLauncher(BatchTest, EngineSetLauncherTest, TestCase):
-    launcher_class = launcher.CondorEngineSetLauncher
+class TestHTCondorEngineSetLauncher(BatchTest, EngineSetLauncherTest, TestCase):
+    launcher_class = launcher.HTCondorEngineSetLauncher
 
 class TestSSHEngineSetLauncher(EngineSetLauncherTest, TestCase):
     launcher_class = launcher.SSHEngineSetLauncher

--- a/IPython/parallel/tests/test_launcher.py
+++ b/IPython/parallel/tests/test_launcher.py
@@ -129,6 +129,9 @@ class TestSGEControllerLauncher(BatchTest, ControllerLauncherTest, TestCase):
 class TestLSFControllerLauncher(BatchTest, ControllerLauncherTest, TestCase):
     launcher_class = launcher.LSFControllerLauncher
 
+class TestCondorControllerLauncher(BatchTest, ControllerLauncherTest, TestCase):
+    launcher_class = launcher.CondorControllerLauncher
+
 class TestSSHControllerLauncher(SSHTest, ControllerLauncherTest, TestCase):
     launcher_class = launcher.SSHControllerLauncher
 
@@ -154,6 +157,9 @@ class TestSGEEngineSetLauncher(BatchTest, EngineSetLauncherTest, TestCase):
 
 class TestLSFEngineSetLauncher(BatchTest, EngineSetLauncherTest, TestCase):
     launcher_class = launcher.LSFEngineSetLauncher
+
+class TestCondorEngineSetLauncher(BatchTest, EngineSetLauncherTest, TestCase):
+    launcher_class = launcher.CondorEngineSetLauncher
 
 class TestSSHEngineSetLauncher(EngineSetLauncherTest, TestCase):
     launcher_class = launcher.SSHEngineSetLauncher


### PR DESCRIPTION
This PR adds a new set of subclasses in `IPython/parallel/apps/launcher.py` to add support for the HTCondor batch management system.

I've tried to make a template that has sensible defaults that should work out of the box for most users.

**Help config setup**
I think I have added config/help support where required but I am still getting my head around the config/traitlets setup in IPython. Does everything look ok?

**BatchLauncher changes**
1. Adding job and queue templates to the job are now overridable methods (Condor has to place it's `job_array` at the end)
2. Added `job_id_regexp_group` to allow for subclasses to specify what group of the `job_id_regexp` needs to be matched. By default this is 0, which means all current implementations remain unchanged, whilst allowing for Condor to have a simple regexp setup. I'm not the worlds foremost regexp expert so there might be a way around this without introducing groups..

**Batch launch commands changes**
Condor destroys sys.executable for the jobs it farms out, ruining Python's module path checking. This is pretty problematic for the current batch setup, which calls something like 
`/local/python/path/bin/python -c 'commands required to start the engine or controller' --profile-dir=...`
on the remote. 

However, by instead calling
`/local/python/path/bin/ipengine --profile-dir=...`  and 
`/local/python/path/bin/ipcontroller --profile-dir=...`
we can skirt around the issue as on entry to these scripts the shebang causes `/local/python/path/bin/python` to be called, with the sys.executable path set correctly.

I can't think of any downside to this approach, other than you now demand that python is running from a folder containing `ipengine` and `ipcontroller`, which is of course the setup everyone has from install. My only concern is that I have no idea how these scripts (and Condor in general for that matter) behave in the Windows world.

**Documentation changes**
Finally, once accepted the docs probably want to be upgraded to mention the support. Is that something I should do in this PR?
