### PR TITLE
restore "unsaved changes" warning on unload

### DIFF
--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -349,9 +349,11 @@ var IPython = (function (IPython) {
             // still warn, because if we don't the autosave may fail.
             if (that.dirty && ! that.read_only) {
                 if ( that.autosave_interval ) {
-                    setTimeout(function() { that.save_notebook(); }, 0);
+                    that.save_notebook();
+                    return "Autosave in progress, latest changes may be lost.";
+                } else {
+                    return "Unsaved changes will be lost.";
                 }
-                return "Unsaved changes will be lost.";
             };
             // Null is the *only* return value that will make the browser not
             // pop up the "don't leave" dialog.

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -345,9 +345,13 @@ var IPython = (function (IPython) {
             if (kill_kernel) {
                 that.kernel.kill();
             }
-            // if we are autosaving, trigger an autosave on nav-away
-            if (that.dirty && that.autosave_interval && ! that.read_only) {
-                that.save_notebook();
+            // if we are autosaving, trigger an autosave on nav-away.
+            // still warn, because if we don't the autosave may fail.
+            if (that.dirty && ! that.read_only) {
+                if ( that.autosave_interval ) {
+                    setTimeout(function() { that.save_notebook(); }, 0);
+                }
+                return "Unsaved changes will be lost.";
             };
             // Null is the *only* return value that will make the browser not
             // pop up the "don't leave" dialog.


### PR DESCRIPTION
Autosave is triggered at this event, but it seems to fail sometimes (perhaps when it's too slow?).

This restores the "beforeunload" warning message, informing the user that unsaved changes may be lost.
It still triggers an autosave (assuming autosave is enabled), in which case the message is "Autosave in progress".

closes #3475
