### PR TITLE
Display R errors without Python traceback

### DIFF
--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -578,16 +578,24 @@ class RMagics(Magics):
         self.r('png("%s/Rplots%%03d.png",%s)' % (tmpd.replace('\\', '/'), png_args))
 
         text_output = ''
-        if line_mode:
-            for line in code.split(';'):
-                text_result, result = self.eval(line)
+        try:
+            if line_mode:
+                for line in code.split(';'):
+                    text_result, result = self.eval(line)
+                    text_output += text_result
+                if text_result:
+                    # the last line printed something to the console so we won't return it
+                    return_output = False
+            else:
+                text_result, result = self.eval(code)
                 text_output += text_result
-            if text_result:
-                # the last line printed something to the console so we won't return it
-                return_output = False
-        else:
-            text_result, result = self.eval(code)
-            text_output += text_result
+        
+        except RInterpreterError as e:
+            print(e.stdout)
+            if not e.stdout.endswith(e.err):
+                print(e.err)
+            rmtree(tmpd)
+            return
 
         self.r('dev.off()')
 


### PR DESCRIPTION
Errors from R magic cells currently produce a big Python traceback that's irrelevant to the user:

![rmagic_err_before](https://f.cloud.github.com/assets/327925/726055/af6239c2-e0c8-11e2-9227-708a29d4912d.png)

With these changes, the user only sees the R error, without our traceback:

![rmagic_err_after](https://f.cloud.github.com/assets/327925/726056/c3ef54e2-e0c8-11e2-9ece-7e1689df5230.png)
