### PR TITLE
Use an absolute path to iptest, because the tests are not always run from $IPYTHONDIR.

### DIFF
--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -340,7 +340,7 @@ class IPTester(object):
         """Create new test runner."""
         p = os.path
         if runner == 'iptest':
-            iptest_app = get_ipython_module_path('IPython.testing.iptest')
+            iptest_app = os.path.abspath(get_ipython_module_path('IPython.testing.iptest'))
             self.runner = pycmd2argv(iptest_app) + sys.argv[1:]
         else:
             raise Exception('Not a valid test runner: %s' % repr(runner))


### PR DESCRIPTION
This change fixes [Issue 3480](https://github.com/ipython/ipython/issues/3480) by using an absolute path to <code>iptest</code>.
