### PR TITLE
Drop patch for compatibility with pyreadline 1.5

### DIFF
--- a/IPython/utils/rlineimpl.py
+++ b/IPython/utils/rlineimpl.py
@@ -56,18 +56,6 @@ if sys.platform == 'darwin':
     # cleanup dirty trick vars
     del dynload_idx, lib_dynload
 
-if have_readline and hasattr(_rl, 'rlmain'):
-    # patch add_history to allow for strings in pyreadline <= 1.5:
-    # fix copied from pyreadline 1.6
-    import pyreadline
-    if pyreadline.release.version <= '1.5':
-        def add_history(line):
-            """add a line to the history buffer."""
-            from pyreadline import lineobj
-            if not isinstance(line, lineobj.TextLine):
-                line = lineobj.TextLine(line)
-            return _rl.add_history(line)
-
 if (sys.platform == 'win32' or sys.platform == 'cli') and have_readline:
     try:
         _outputfile=_rl.GetOutputFile()


### PR DESCRIPTION
Closes #1307

Needs testing on Windows.
#1307 implies that we have other compatibility things, but it's not clear what they are. There's [this check](https://github.com/ipython/ipython/blob/master/IPython/core/interactiveshell.py#L1824) in init_readline(), and pyreadline does now have [set_startup_hook](https://github.com/pyreadline/pyreadline/blob/master/pyreadline/rlmain.py#L211), but it does something different from `set_pre_input_hook`, and I don't know when it was added.
