### PR TITLE
Remove unexpected keyword parameter to remove_kernel

### DIFF
--- a/IPython/html/services/kernels/kernelmanager.py
+++ b/IPython/html/services/kernels/kernelmanager.py
@@ -68,7 +68,7 @@ class MappingKernelManager(MultiKernelManager):
         """notice that a kernel died"""
         self.log.warn("Kernel %s died, removing from map.", kernel_id)
         self.delete_mapping_for_kernel(kernel_id)
-        self.remove_kernel(kernel_id, now=True)
+        self.remove_kernel(kernel_id)
 
     def start_kernel(self, notebook_id=None, **kwargs):
         """Start a kernel for a notebook an return its kernel_id.


### PR DESCRIPTION
Closes #3474

I can't now see how to hit this code - the ctypes deliberate crash in our example notebook doesn't hit it, but we were hitting it the other day. There's only one `remove_kernel` method defined in the codebase, and it doesn't have a `now` parameter.
