### PR TITLE
add a dialog when the kernel is auto-restarted

### DIFF
--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -123,6 +123,18 @@ var IPython = (function (IPython) {
             var index = that.find_cell_index(data.cell);
             that.select(index);
         });
+        
+        $([IPython.events]).on('status_autorestarting.Kernel', function () {
+            IPython.dialog.modal({
+                title: "Kernel Restarting",
+                body: "The kernel appears to have died. It will restart automatically.",
+                buttons: {
+                    OK : {
+                        class : "btn-primary"
+                    }
+                }
+            });
+        });
 
 
         $(document).keydown(function (event) {

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -86,6 +86,18 @@ var IPython = (function (IPython) {
             IPython.save_widget.update_document_title();
             knw.set_message("Restarting kernel", 2000);
         });
+        
+        $([IPython.events]).on('status_autorestarting.Kernel',function () {
+            IPython.dialog.modal({
+                title: "Kernel Restarting",
+                body: "The kernel appears to have died. It is being restarted.",
+                buttons: {
+                    OK : {
+                        class : "btn-primary"
+                    }
+                }
+            });
+        });
 
         $([IPython.events]).on('status_interrupting.Kernel',function () {
             knw.set_message("Interrupting kernel");

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -86,18 +86,6 @@ var IPython = (function (IPython) {
             IPython.save_widget.update_document_title();
             knw.set_message("Restarting kernel", 2000);
         });
-        
-        $([IPython.events]).on('status_autorestarting.Kernel',function () {
-            IPython.dialog.modal({
-                title: "Kernel Restarting",
-                body: "The kernel appears to have died. It is being restarted.",
-                buttons: {
-                    OK : {
-                        class : "btn-primary"
-                    }
-                }
-            });
-        });
 
         $([IPython.events]).on('status_interrupting.Kernel',function () {
             knw.set_message("Interrupting kernel");

--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -448,6 +448,11 @@ var IPython = (function (IPython) {
             } else if (content.execution_state === 'idle') {
                 $([IPython.events]).trigger('status_idle.Kernel', {kernel: this});
             } else if (content.execution_state === 'restarting') {
+                // autorestarting is distinct from restarting,
+                // in that it means the kernel died and the server is restarting it.
+                // status_restarting sets the notification widget,
+                // autorestart shows the more prominent dialog.
+                $([IPython.events]).trigger('status_autorestarting.Kernel', {kernel: this});
                 $([IPython.events]).trigger('status_restarting.Kernel', {kernel: this});
             } else if (content.execution_state === 'dead') {
                 this.stop_channels();


### PR DESCRIPTION
adds the autorestart status event for the dialog

so that user-restart is distinct from server-side auto restart.

closes #3490
