### PR TITLE
Fix import errors when running tests from the source directory

### DIFF
--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -335,12 +335,17 @@ class IPTester(object):
     processes = None
     #: str, coverage xml output file
     coverage_xml = None
+    #: string, path to the ipython directory
+    ipython_path = None
 
     def __init__(self, runner='iptest', params=None):
         """Create new test runner."""
         p = os.path
         if runner == 'iptest':
             iptest_app = os.path.abspath(get_ipython_module_path('IPython.testing.iptest'))
+            self.ipython_path = iptest_app
+            for i in range(3): # The ipython directory is 3 levels up.
+                self.ipython_path = os.path.dirname(self.ipython_path)
             self.runner = pycmd2argv(iptest_app) + sys.argv[1:]
         else:
             raise Exception('Not a valid test runner: %s' % repr(runner))
@@ -380,6 +385,12 @@ class IPTester(object):
         with TemporaryDirectory() as IPYTHONDIR:
             env = os.environ.copy()
             env['IPYTHONDIR'] = IPYTHONDIR
+            pythonpath = env.get('PYTHONPATH')
+            if pythonpath is None:
+                pythonpath = self.ipython_path
+            else:
+                pythonpath += os.pathsep + self.ipython_path
+            env['PYTHONPATH'] = pythonpath
             # print >> sys.stderr, '*** CMD:', ' '.join(self.call_args) # dbg
             subp = subprocess.Popen(self.call_args, env=env)
             self.processes.append(subp)


### PR DESCRIPTION
[ not for 1.0 ] 

The proposed PR fixes multiple module import errors when running tests from the IPython source directory using the command <code>python -c "import IPython; IPython.test()"</code> as suggested in the [documentation](http://ipython.org/ipython-doc/stable/development/testing.html#for-the-impatient-running-the-tests):

```
**********************************************************************
IPython test group: IPython.config
Traceback (most recent call last):
  File "/home/viz/workspace/ipython/IPython/testing/iptest.py", line 44, in <module>
    from IPython.testing import nosepatch
ImportError: No module named IPython.testing
**********************************************************************
IPython test group: IPython.core
Traceback (most recent call last):
  File "/home/viz/workspace/ipython/IPython/testing/iptest.py", line 44, in <module>
    from IPython.testing import nosepatch
ImportError: No module named IPython.testing
...
```

The problem is that the tests are run in a temporary directory and not in the IPython directory and IPython modules are not on the search path. This is fixed by adding the path to IPython directory to the module search path (<code>$PYTHONPATH</code>).
