### PR TITLE
don't use parent=self in handlers

### DIFF
--- a/IPython/html/base/zmqhandlers.py
+++ b/IPython/html/base/zmqhandlers.py
@@ -84,7 +84,7 @@ class AuthenticatedZMQStreamHandler(ZMQStreamHandler, IPythonHandler):
 
     def open(self, kernel_id):
         self.kernel_id = kernel_id.decode('ascii')
-        self.session = Session(parent=self)
+        self.session = Session(config=self.config)
         self.save_on_message = self.on_message
         self.on_message = self.on_first_message
 


### PR DESCRIPTION
handlers aren't configurable, so shouldn't be passed as parent.

closes #3502
