### PR TITLE
Get Tracer working after ipapi.get replaced with get_ipython

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -206,6 +206,12 @@ class Pdb(OldPdb):
 
         self.shell = get_ipython()
 
+        if self.shell is None:
+            # No IPython instance running, we must create one
+            from IPython.terminal.interactiveshell import \
+                TerminalInteractiveShell
+            self.shell = TerminalInteractiveShell.instance()
+
         if self.is_pydb:
 
             # interactiveshell.py's ipalias seems to want pdb's checkline


### PR DESCRIPTION
Commit 790f731 replaced `ipapi.get` with a `get_ipython` function,
that changed the API slightly, returning None when no InteractiveShell
instance has been registered.
