### PR TITLE
make css highlight style configurable

### DIFF
--- a/IPython/nbconvert/transformers/csshtmlheader.py
+++ b/IPython/nbconvert/transformers/csshtmlheader.py
@@ -97,7 +97,8 @@ class CSSHtmlHeaderTransformer(ActivatableTransformer):
             pass
 
         #Add pygments CSS
-        pygments_css = HtmlFormatter().get_style_defs('.highlight')
+        highlight_class = '.' + self.config.get('highlight_class', 'highlight')
+        pygments_css = HtmlFormatter().get_style_defs(highlight_class)
         header.append(pygments_css)
 
         #Set header        

--- a/IPython/nbconvert/transformers/csshtmlheader.py
+++ b/IPython/nbconvert/transformers/csshtmlheader.py
@@ -20,6 +20,8 @@ from pygments.formatters import HtmlFormatter
 from IPython.utils import path
 
 from .activatable import ActivatableTransformer
+
+from IPython.utils.traitlets import Unicode
         
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -32,6 +34,9 @@ class CSSHtmlHeaderTransformer(ActivatableTransformer):
     """
 
     header = []
+
+    highlight_class = Unicode('highlight', config=True,
+                              help="CSS highlight class identifier")
 
     def __init__(self, config=None, **kw):
         """
@@ -97,8 +102,8 @@ class CSSHtmlHeaderTransformer(ActivatableTransformer):
             pass
 
         #Add pygments CSS
-        highlight_class = '.' + self.config.get('highlight_class', 'highlight')
-        pygments_css = HtmlFormatter().get_style_defs(highlight_class)
+        formatter = HtmlFormatter()
+        pygments_css = formatter.get_style_defs('.' + self.highlight_class)
         header.append(pygments_css)
 
         #Set header        

--- a/IPython/nbconvert/transformers/csshtmlheader.py
+++ b/IPython/nbconvert/transformers/csshtmlheader.py
@@ -35,7 +35,7 @@ class CSSHtmlHeaderTransformer(ActivatableTransformer):
 
     header = []
 
-    highlight_class = Unicode('highlight', config=True,
+    highlight_class = Unicode('.highlight', config=True,
                               help="CSS highlight class identifier")
 
     def __init__(self, config=None, **kw):
@@ -103,7 +103,7 @@ class CSSHtmlHeaderTransformer(ActivatableTransformer):
 
         #Add pygments CSS
         formatter = HtmlFormatter()
-        pygments_css = formatter.get_style_defs('.' + self.highlight_class)
+        pygments_css = formatter.get_style_defs(self.highlight_class)
         header.append(pygments_css)
 
         #Set header        


### PR DESCRIPTION
For blogging with ipython notebook, it's important to be able to control the CSS tag used for pygments highlighting (the style name `"highlight"` can conflict with the default settings on some blogging platforms).  Currently this is configurable for the cell rendering using a custom filter, but for the css the value hard-coded in `CSSHtmlHeaderTransformer`.  This PR makes the value configurable there as well.

This may not be the best way to go about this, but here's an example script for how the highlight tag can be configured using the changes in this PR.  Note this also needs #3512 in order to properly register the custom filter.

There may well be a better way to accomplish this using the `config` object, or perhaps even adding a configurable value to the `HtmlExporter` class.  I'm not entirely familiar with the IPython configurables & traitlet system, and would appreciate some feedback.

``` python
from IPython.nbconvert.filters.highlight import _pygment_highlight
from pygments.formatters import HtmlFormatter

from IPython.nbconvert.exporters import FullHtmlExporter
from IPython.config import Config

from IPython.nbformat import current as nbformat


def my_highlight(source, language='ipython'):
    formatter = HtmlFormatter(cssclass='highlight-ipynb')
    return _pygment_highlight(source, formatter, language)


class MyHtmlExporter(FullHtmlExporter):
    def __init__(self, *args, **kwargs):
        super(MyHtmlExporter, self).__init__(*args, **kwargs)
        self.register_filter('highlight', my_highlight)

    @property
    def default_config(self):
        c = Config({'CSSHtmlHeaderTransformer':
                    {'enabled':True, 'highlight_class':'highlight-ipynb'}})
        c.merge(super(MyHtmlExporter,self).default_config)
        return c


if __name__ == '__main__':
    infile = 'test_notebook.ipynb'
    outfile = 'test_notebook.html'

    print "converting {0} to {1}".format(infile, outfile)
    notebook = open(infile).read()
    notebook_json = nbformat.reads_json(notebook)

    exportHtml = MyHtmlExporter()
    (body,resources) = exportHtml.from_notebook_node(notebook_json)

    open(outfile, 'w').write(body)
```
