### PR TITLE
Nbconvert fix, silent fail if template doesn't exist

### DIFF
--- a/IPython/nbconvert/exporters/export.py
+++ b/IPython/nbconvert/exporters/export.py
@@ -221,5 +221,5 @@ def export_by_name(template_name, nb, config=None, transformers=None, filters=No
     if function_name in globals():
         return globals()[function_name](nb, config, transformers, filters)
     else:
-        return None
+        raise NameError("template not found")
 


### PR DESCRIPTION
If template is not found by name, an exception is thrown.
