### PR TITLE
Exclude frontend shim from docs build

### DIFF
--- a/docs/autogen_api.py
+++ b/docs/autogen_api.py
@@ -45,6 +45,7 @@ if __name__ == '__main__':
                                         r'\.ipdoctest',
                                         r'\.Gnuplot',
                                         r'\.frontend\.process\.winprocess',
+                                        r'\.frontend',
                                         r'\.Shell',
                                         ]
     


### PR DESCRIPTION
Closes #3517

The API doc writer has separate exclude patterns for modules and packages, so frontend needed to be listed in the modules exclusions.
