### PR TITLE
basic timezone info

### DIFF
--- a/IPython/html/services/notebooks/azurenbmanager.py
+++ b/IPython/html/services/notebooks/azurenbmanager.py
@@ -26,7 +26,7 @@ from tornado import web
 from .nbmanager import NotebookManager
 from IPython.nbformat import current
 from IPython.utils.traitlets import Unicode, Instance
-
+from IPython.utils import tz
 
 #-----------------------------------------------------------------------------
 # Classes
@@ -98,7 +98,7 @@ class AzureNotebookManager(NotebookManager):
             raise web.HTTPError(500, u'Unreadable JSON notebook.')
         # Todo: The last modified should actually be saved in the notebook document.
         # We are just using the current datetime until that is implemented.
-        last_modified = datetime.datetime.utcnow()
+        last_modified = tz.utcnow()
         return last_modified, nb
 
     def write_notebook_object(self, nb, notebook_id=None):

--- a/IPython/html/services/notebooks/filenbmanager.py
+++ b/IPython/html/services/notebooks/filenbmanager.py
@@ -28,6 +28,7 @@ from tornado import web
 from .nbmanager import NotebookManager
 from IPython.nbformat import current
 from IPython.utils.traitlets import Unicode, Dict, Bool, TraitError
+from IPython.utils import tz
 
 #-----------------------------------------------------------------------------
 # Classes
@@ -139,7 +140,7 @@ class FileNotebookManager(NotebookManager):
     def read_notebook_object_from_path(self, path):
         """read a notebook object from a path"""
         info = os.stat(path)
-        last_modified = datetime.datetime.utcfromtimestamp(info.st_mtime)
+        last_modified = tz.utcfromtimestamp(info.st_mtime)
         with open(path,'r') as f:
             s = f.read()
             try:
@@ -281,7 +282,7 @@ class FileNotebookManager(NotebookManager):
         """construct the info dict for a given checkpoint"""
         path = self.get_checkpoint_path(notebook_id, checkpoint_id)
         stats = os.stat(path)
-        last_modified = datetime.datetime.utcfromtimestamp(stats.st_mtime)
+        last_modified = tz.utcfromtimestamp(stats.st_mtime)
         info = dict(
             checkpoint_id = checkpoint_id,
             last_modified = last_modified,

--- a/IPython/utils/jsonutil.py
+++ b/IPython/utils/jsonutil.py
@@ -33,7 +33,7 @@ next_attr_name = '__next__' if py3compat.PY3 else 'next'
 
 # timestamp formats
 ISO8601="%Y-%m-%dT%H:%M:%S.%f"
-ISO8601_PAT=re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z?([\+\-]\d{2}:?\d{2})?$")
+ISO8601_PAT=re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+)Z?([\+\-]\d{2}:?\d{2})?$")
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -71,9 +71,11 @@ def extract_dates(obj):
     elif isinstance(obj, (list, tuple)):
         obj = [ extract_dates(o) for o in obj ]
     elif isinstance(obj, basestring):
-        if ISO8601_PAT.match(obj):
+        m = ISO8601_PAT.match(obj)
+        if m:
             # FIXME: add actual timezone support
-            notz = obj.split('Z',1)[0]
+            # this just drops the timezone info
+            notz = m.groups()[0]
             obj = datetime.strptime(notz, ISO8601)
     return obj
 

--- a/IPython/utils/jsonutil.py
+++ b/IPython/utils/jsonutil.py
@@ -33,7 +33,7 @@ next_attr_name = '__next__' if py3compat.PY3 else 'next'
 
 # timestamp formats
 ISO8601="%Y-%m-%dT%H:%M:%S.%f"
-ISO8601_PAT=re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+$")
+ISO8601_PAT=re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+(Z?[\+\-]\d{2}:?\d{2})?$")
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -72,7 +72,9 @@ def extract_dates(obj):
         obj = [ extract_dates(o) for o in obj ]
     elif isinstance(obj, basestring):
         if ISO8601_PAT.match(obj):
-            obj = datetime.strptime(obj, ISO8601)
+            # FIXME: add actual timezone support
+            notz = obj.split('Z',1)[0]
+            obj = datetime.strptime(notz, ISO8601)
     return obj
 
 def squash_dates(obj):
@@ -84,13 +86,13 @@ def squash_dates(obj):
     elif isinstance(obj, (list, tuple)):
         obj = [ squash_dates(o) for o in obj ]
     elif isinstance(obj, datetime):
-        obj = obj.strftime(ISO8601)
+        obj = obj.isoformat()
     return obj
 
 def date_default(obj):
     """default function for packing datetime objects in JSON."""
     if isinstance(obj, datetime):
-        return obj.strftime(ISO8601)
+        return obj.isoformat()
     else:
         raise TypeError("%r is not JSON serializable"%obj)
 

--- a/IPython/utils/jsonutil.py
+++ b/IPython/utils/jsonutil.py
@@ -33,7 +33,7 @@ next_attr_name = '__next__' if py3compat.PY3 else 'next'
 
 # timestamp formats
 ISO8601="%Y-%m-%dT%H:%M:%S.%f"
-ISO8601_PAT=re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+(Z?[\+\-]\d{2}:?\d{2})?$")
+ISO8601_PAT=re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z?([\+\-]\d{2}:?\d{2})?$")
 
 #-----------------------------------------------------------------------------
 # Classes and functions

--- a/IPython/utils/tz.py
+++ b/IPython/utils/tz.py
@@ -1,0 +1,46 @@
+# encoding: utf-8
+"""
+Timezone utilities
+
+Just UTC-awareness right now
+"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2013 The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+from datetime import tzinfo, timedelta, datetime
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------
+# constant for zero offset
+ZERO = timedelta(0)
+
+class tzUTC(tzinfo):
+    """tzinfo object for UTC (zero offset)"""
+
+    def utcoffset(self, d):
+        return ZERO
+
+    def dst(self, d):
+        return ZERO
+
+UTC = tzUTC()
+
+def utc_aware(unaware):
+    """decorator for adding UTC tzinfo to datetime's utcfoo methods"""
+    def utc_method(*args, **kwargs):
+        dt = unaware(*args, **kwargs)
+        return dt.replace(tzinfo=UTC)
+    return utc_method
+
+utcfromtimestamp = utc_aware(datetime.utcfromtimestamp)
+utcnow = utc_aware(datetime.utcnow)


### PR DESCRIPTION
- minor tweaks to jsonutil, to include timezone info if available
- add `IPython.utils.tz`, which just has basic info for making `utcnow()`, etc. include tzinfo in the datetime object
- use this tzinfo in the `last_modified` keys in notebook managers, which fixes Firefox's timezone offset for checkpoints

closes #3396
