### PR TITLE
ensure raw_input returns str in zmq shell

### DIFF
--- a/IPython/kernel/zmq/ipkernel.py
+++ b/IPython/kernel/zmq/ipkernel.py
@@ -770,7 +770,7 @@ class Kernel(Configurable):
             else:
                 break
         try:
-            value = reply['content']['value']
+            value = py3compat.unicode_to_str(reply['content']['value'])
         except:
             self.log.error("Got bad raw_input reply: ")
             self.log.error("%s", parent)


### PR DESCRIPTION
matches raw_input.  Some things can't handle unicode objects (e.g. `help()`).

closes #1145
