### PR TITLE
Use a CDN to get reveal.js library.

### DIFF
--- a/IPython/nbconvert/exporters/reveal.py
+++ b/IPython/nbconvert/exporters/reveal.py
@@ -55,10 +55,6 @@ class RevealExporter(BasicHTMLExporter):
                 },
             'RevealHelpTransformer':{
                 'enabled':True,
-                'url_prefix':'//cdn.jsdelivr.net/reveal.js/2.4.0',
-                # If you want to use a local reveal.js library, just
-                # comment the previous line and uncomment the next one.
-                #'url_prefix':'reveal.js',
                 },                
             })
         c.merge(super(RevealExporter,self).default_config)

--- a/IPython/nbconvert/exporters/reveal.py
+++ b/IPython/nbconvert/exporters/reveal.py
@@ -49,6 +49,17 @@ class RevealExporter(BasicHTMLExporter):
 
     @property
     def default_config(self):
-        c = Config({'CSSHTMLHeaderTransformer':{'enabled':True}})
+        c = Config({
+            'CSSHTMLHeaderTransformer':{
+                'enabled':True
+                },
+            'RevealHelpTransformer':{
+                'enabled':True,
+                'url_prefix':'//cdn.jsdelivr.net/reveal.js/2.4.0',
+                # If you want to use a local reveal.js library, just
+                # comment the previous line and uncomment the next one.
+                #'url_prefix':'reveal.js',
+                },                
+            })
         c.merge(super(RevealExporter,self).default_config)
         return c

--- a/IPython/nbconvert/templates/reveal.tpl
+++ b/IPython/nbconvert/templates/reveal.tpl
@@ -12,19 +12,18 @@
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 
-<link rel="stylesheet" href="//cdn.jsdelivr.net/reveal.js/2.4.0/css/reveal.css">
-<link rel="stylesheet" href="//cdn.jsdelivr.net/reveal.js/2.4.0/css/theme/simple.css" id="theme">
+<!-- General and theme style sheets -->
+<link rel="stylesheet" href="{{resources.reveal.url_prefix}}/css/reveal.css">
+<link rel="stylesheet" href="{{resources.reveal.url_prefix}}/css/theme/simple.css" id="theme">
 
 <!-- For syntax highlighting -->
-<link rel="stylesheet" href="//cdn.jsdelivr.net/reveal.js/2.4.0/lib/css/zenburn.css">
+<link rel="stylesheet" href="{{resources.reveal.url_prefix}}/lib/css/zenburn.css">
 
 <!-- If the query includes 'print-pdf', use the PDF print sheet -->
-<script>
-document.write( '<link rel="stylesheet" href="//cdn.jsdelivr.net/reveal.js/2.4.0/css/print' + ( window.location.search.match( /print-pdf/gi ) ? 'pdf' : 'paper' ) + '.css" type="text/css" media="print">' );
-</script>
+<link rel="stylesheet" href="{{resources.reveal.url_prefix}}/css/print' + ( window.location.search.match( /print-pdf/gi ) ? 'pdf' : 'paper' ) + '.css" type="text/css" media="print">
 
 <!--[if lt IE 9]>
-<script src="//cdn.jsdelivr.net/reveal.js/2.4.0/lib/js/html5shiv.js"></script>
+<script src="{{resources.reveal.url_prefix}}/lib/js/html5shiv.js"></script>
 <![endif]-->
 
 {% for css in resources.inlining.css -%}
@@ -96,7 +95,7 @@ text-align: inherit;
 
 </div></div>
 
-<!-- 
+<!--
 Uncomment the following block and the addthis_widget.js (see below inside dependencies)
 to get enable social buttons.
 -->
@@ -111,9 +110,9 @@ to get enable social buttons.
 </div>
 -->
 
-<script src="//cdn.jsdelivr.net/reveal.js/2.4.0/lib/js/head.min.js"></script>
+<script src="{{resources.reveal.url_prefix}}/lib/js/head.min.js"></script>
 
-<script src="//cdn.jsdelivr.net/reveal.js/2.4.0/js/reveal.js"></script>
+<script src="{{resources.reveal.url_prefix}}/js/reveal.js"></script>' );
 
 <script>
 
@@ -128,9 +127,9 @@ transition: Reveal.getQueryHash().transition || 'linear', // default/cube/page/c
 
 // Optional libraries used to extend on reveal.js
 dependencies: [
-{ src: '//cdn.jsdelivr.net/reveal.js/2.4.0/lib/js/classList.js', condition: function() { return !document.body.classList; } },
-{ src: '//cdn.jsdelivr.net/reveal.js/2.4.0/plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } },
-{ src: 'reveal.js/plugin/notes/notes.js', async: true, condition: function() { return !!document.body.classList; } }
+{ src: "{{resources.reveal.url_prefix}}/lib/js/classList.js", condition: function() { return !document.body.classList; } },
+{ src: "{{resources.reveal.url_prefix}}/plugin/highlight/highlight.js", async: true, callback: function() { hljs.initHighlightingOnLoad(); } },
+{ src: "{{resources.reveal.url_prefix}}/plugin/notes/notes.js", async: true, condition: function() { return !!document.body.classList; } }
 // { src: 'http://s7.addthis.com/js/300/addthis_widget.js', async: true},
 ]
 });
@@ -152,7 +151,7 @@ MathJax.Hub.Config({
 <!-- End of mathjax configuration -->
 
 <script>
-//  We wait for the onload function to load MathJax after the page is completely loaded.  
+//  We wait for the onload function to load MathJax after the page is completely loaded.
 //  MathJax is loaded 1 unit of time after the page is ready.
 //  This hack prevent problems when you load multiple js files (i.e. social button from addthis).
 //

--- a/IPython/nbconvert/templates/reveal.tpl
+++ b/IPython/nbconvert/templates/reveal.tpl
@@ -20,7 +20,9 @@
 <link rel="stylesheet" href="{{resources.reveal.url_prefix}}/lib/css/zenburn.css">
 
 <!-- If the query includes 'print-pdf', use the PDF print sheet -->
-<link rel="stylesheet" href="{{resources.reveal.url_prefix}}/css/print' + ( window.location.search.match( /print-pdf/gi ) ? 'pdf' : 'paper' ) + '.css" type="text/css" media="print">
+<script>
+document.write( '<link rel="stylesheet" href="{{resources.reveal.url_prefix}}/css/print' + ( window.location.search.match( /print-pdf/gi ) ? 'pdf' : 'paper' ) + '.css" type="text/css" media="print">' );
+</script>
 
 <!--[if lt IE 9]>
 <script src="{{resources.reveal.url_prefix}}/lib/js/html5shiv.js"></script>
@@ -112,7 +114,7 @@ to get enable social buttons.
 
 <script src="{{resources.reveal.url_prefix}}/lib/js/head.min.js"></script>
 
-<script src="{{resources.reveal.url_prefix}}/js/reveal.js"></script>' );
+<script src="{{resources.reveal.url_prefix}}/js/reveal.js"></script>
 
 <script>
 

--- a/IPython/nbconvert/templates/reveal.tpl
+++ b/IPython/nbconvert/templates/reveal.tpl
@@ -12,19 +12,19 @@
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 
-<link rel="stylesheet" href="reveal.js/css/reveal.css">
-<link rel="stylesheet" href="reveal.js/css/theme/simple.css" id="theme">
+<link rel="stylesheet" href="//cdn.jsdelivr.net/reveal.js/2.4.0/css/reveal.css">
+<link rel="stylesheet" href="//cdn.jsdelivr.net/reveal.js/2.4.0/css/theme/simple.css" id="theme">
 
 <!-- For syntax highlighting -->
-<link rel="stylesheet" href="reveal.js/lib/css/zenburn.css">
+<link rel="stylesheet" href="//cdn.jsdelivr.net/reveal.js/2.4.0/lib/css/zenburn.css">
 
 <!-- If the query includes 'print-pdf', use the PDF print sheet -->
 <script>
-document.write( '<link rel="stylesheet" href="reveal.js/css/print/' + ( window.location.search.match( /print-pdf/gi ) ? 'pdf' : 'paper' ) + '.css" type="text/css" media="print">' );
+document.write( '<link rel="stylesheet" href="//cdn.jsdelivr.net/reveal.js/2.4.0/css/print' + ( window.location.search.match( /print-pdf/gi ) ? 'pdf' : 'paper' ) + '.css" type="text/css" media="print">' );
 </script>
 
 <!--[if lt IE 9]>
-<script src="reveal.js/lib/js/html5shiv.js"></script>
+<script src="//cdn.jsdelivr.net/reveal.js/2.4.0/lib/js/html5shiv.js"></script>
 <![endif]-->
 
 {% for css in resources.inlining.css -%}
@@ -111,9 +111,9 @@ to get enable social buttons.
 </div>
 -->
 
-<script src="reveal.js/lib/js/head.min.js"></script>
+<script src="//cdn.jsdelivr.net/reveal.js/2.4.0/lib/js/head.min.js"></script>
 
-<script src="reveal.js/js/reveal.min.js"></script>
+<script src="//cdn.jsdelivr.net/reveal.js/2.4.0/js/reveal.js"></script>
 
 <script>
 
@@ -128,8 +128,8 @@ transition: Reveal.getQueryHash().transition || 'linear', // default/cube/page/c
 
 // Optional libraries used to extend on reveal.js
 dependencies: [
-{ src: 'reveal.js/lib/js/classList.js', condition: function() { return !document.body.classList; } },
-{ src: 'reveal.js/plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } },
+{ src: '//cdn.jsdelivr.net/reveal.js/2.4.0/lib/js/classList.js', condition: function() { return !document.body.classList; } },
+{ src: '//cdn.jsdelivr.net/reveal.js/2.4.0/plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } },
 { src: 'reveal.js/plugin/notes/notes.js', async: true, condition: function() { return !!document.body.classList; } }
 // { src: 'http://s7.addthis.com/js/300/addthis_widget.js', async: true},
 ]

--- a/IPython/nbconvert/transformers/revealhelp.py
+++ b/IPython/nbconvert/transformers/revealhelp.py
@@ -13,7 +13,7 @@
 #-----------------------------------------------------------------------------
 
 from .base import ConfigurableTransformer
-from IPython.utils.traitlets import Bytes
+from IPython.utils.traitlets import Unicode
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -21,12 +21,15 @@ from IPython.utils.traitlets import Bytes
 
 class RevealHelpTransformer(ConfigurableTransformer):
 
-    url_prefix = Bytes("", config=True, help="url prefix to get reveal.js files")
+    url_prefix = Unicode('//cdn.jsdelivr.net/reveal.js/2.4.0',
+                         config=True,
+                         help="""If you want to use a local reveal.js library,
+                         use 'url_prefix':'reveal.js' in your config object.""")
 
     def call(self, nb, resources):
         """
         Called once to 'transform' contents of the notebook.
-        
+
         Parameters
         ----------
         nb : NotebookNode
@@ -35,8 +38,8 @@ class RevealHelpTransformer(ConfigurableTransformer):
             Additional resources used in the conversion process.  Allows
             transformers to pass variables into the Jinja engine.
         """
-        
-        
+
+
         for worksheet in nb.worksheets :
             for i, cell in enumerate(worksheet.cells):
 
@@ -51,9 +54,8 @@ class RevealHelpTransformer(ConfigurableTransformer):
                 if cell.metadata.slide_type in ['subslide']:
                     worksheet.cells[i - 1].metadata.slide_helper = 'subslide_end'
 
-                    
+
         resources['reveal'] = {}
-        resources['reveal']['url_prefix'] = self.url_prefix            
-                    
+        resources['reveal']['url_prefix'] = self.url_prefix
+
         return nb, resources
-    

--- a/IPython/nbconvert/transformers/revealhelp.py
+++ b/IPython/nbconvert/transformers/revealhelp.py
@@ -55,7 +55,8 @@ class RevealHelpTransformer(ConfigurableTransformer):
                     worksheet.cells[i - 1].metadata.slide_helper = 'subslide_end'
 
 
-        resources['reveal'] = {}
+        if 'reveal' not in resources:
+            resources['reveal'] = {}
         resources['reveal']['url_prefix'] = self.url_prefix
 
         return nb, resources

--- a/IPython/nbconvert/transformers/revealhelp.py
+++ b/IPython/nbconvert/transformers/revealhelp.py
@@ -13,12 +13,14 @@
 #-----------------------------------------------------------------------------
 
 from .base import ConfigurableTransformer
-
+from IPython.utils.traitlets import Bytes
 #-----------------------------------------------------------------------------
 # Classes and functions
 #-----------------------------------------------------------------------------
 
 class RevealHelpTransformer(ConfigurableTransformer):
+
+    url_prefix = Bytes("", config=True, help="url prefix to get reveal.js files")
 
     def call(self, nb, resources):
         """
@@ -47,6 +49,10 @@ class RevealHelpTransformer(ConfigurableTransformer):
                     worksheet.cells[i - 1].metadata.slide_helper = 'slide_end'
                 if cell.metadata.slide_type in ['subslide']:
                     worksheet.cells[i - 1].metadata.slide_helper = 'subslide_end'
+
+                    
+        resources['reveal'] = {}
+        resources['reveal']['url_prefix'] = self.url_prefix            
                     
         return nb, resources
     

--- a/IPython/nbconvert/transformers/revealhelp.py
+++ b/IPython/nbconvert/transformers/revealhelp.py
@@ -14,6 +14,7 @@
 
 from .base import ConfigurableTransformer
 from IPython.utils.traitlets import Bytes
+
 #-----------------------------------------------------------------------------
 # Classes and functions
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
To get some background about the discussion see: https://github.com/ipython/ipython/issues/3499

This PR makes reveal.js load from a CDN kindly provided by jsdelivr (I submitted a PR there to incorporate all the reveal.js necessary files and they merge it today).

So, now the reveal converter it fully functional in his basic implementation (NOTE, I am laying to you because the speaker notes are not working until I get the new Writer API that @jdfreder is adding to IPython.nbconvert, but ALL the other features are covered and working!).

I think this PR resolve the discussion we had previously and provides to the users with a static slideshow capability directly from the notebook with only two step:

`ipython nbconvert reveal your_slideshow.ipynb`

`python -m SimpleHTTPServer 8000`

We can even simplify this with a command like `--serve` to automate the second step...
- Addendum: I make the prefix of the url to get reveal configurable, so, by default it will use the CDN from jsdelivr, but if the user want to use a local copy of reveal, s/he only has to change the url_prefix in the configurable object.

Cheers.

Damián.
