### PR TITLE
allow custom template paths in exporter

### DIFF
--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -98,7 +98,11 @@ class Exporter(Configurable):
 
     template_skeleton_path = Unicode(
         "/../templates/skeleton/", config=True,
-        help="Path where the template skeleton files are located.") 
+        help="Path where the template skeleton files are located.")
+
+    user_template_path = Unicode(
+        "", config=True,
+        help="Additional path for user-defined templates")
 
     #Jinja block definitions
     jinja_comment_block_start = Unicode("", config=True)
@@ -288,12 +292,16 @@ class Exporter(Configurable):
         """
         Create the Jinja templating environment.
         """
+        this_directory = os.path.dirname(os.path.realpath(__file__))
+        template_paths = [this_directory + self.template_path,
+                          this_directory + self.template_skeleton_path]
+
+        if self.user_template_path:
+            template_paths.append(self.user_template_path)
         
+
         self.environment = Environment(
-            loader=FileSystemLoader([
-                os.path.dirname(os.path.realpath(__file__)) + self.template_path,
-                os.path.dirname(os.path.realpath(__file__)) + self.template_skeleton_path,
-                ]),
+            loader=FileSystemLoader(template_paths),
             extensions=JINJA_EXTENSIONS
             )
         


### PR DESCRIPTION
This PR adds a keyword to the nbconvert `Exporter` class so that a user can define their own template that extends one of the basic templates included in the distribution.  The syntax looks like this:

``` python
exportHTML = BasicHTMLExporter(user_template_path='/abs/path/to/my/templates',
                               template_file='mytemplate.tpl')
```

Ant the user-defined template might look something like:

```
{%- extends 'basichtml.tpl' -%}

{% block body %}
<div class="ipynb">
{{ super() }}
</div>
{%- endblock body %}
```

Because the default path is not overridden with this new option, it allows the user-defined templates to extend the built-in templates using a simple "extends" block.  This would result in the same output as the `basichtml` template, but wrapped with custom div tags.
