### PR TITLE
add IPython.start_ipython

### DIFF
--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -65,7 +65,6 @@ def embed_kernel(module=None, local_ns=None, **kwargs):
     from the scope of the surrounding function,
     and/or you want to load full IPython configuration,
     you probably want `IPython.start_kernel()` instead.
-
     
     Parameters
     ----------
@@ -78,7 +77,6 @@ def embed_kernel(module=None, local_ns=None, **kwargs):
         Further keyword args are relayed to the IPKernelApp constructor,
         allowing configuration of the Kernel.  Will only have an effect
         on the first embed_kernel call for a given process.
-    
     """
     
     (caller_module, caller_locals) = extract_module_locals(1)

--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -61,6 +61,12 @@ version_info = release.version_info
 def embed_kernel(module=None, local_ns=None, **kwargs):
     """Embed and start an IPython kernel in a given scope.
     
+    If you don't want the kernel to initialize the namespace
+    from the scope of the surrounding function,
+    and/or you want to load full IPython configuration,
+    you probably want `IPython.start_kernel()` instead.
+
+    
     Parameters
     ----------
     module : ModuleType, optional
@@ -112,3 +118,30 @@ def start_ipython(argv=None, **kwargs):
     """
     from IPython.terminal.ipapp import launch_new_instance
     return launch_new_instance(argv=argv, **kwargs)
+
+def start_kernel(argv=None, **kwargs):
+    """Launch a normal IPython kernel instance (as opposed to embedded)
+    
+    `IPython.embed_kernel()` puts a shell in a particular calling scope,
+    such as a function or method for debugging purposes,
+    which is often not desirable.
+    
+    `start_kernel()` does full, regular IPython initialization,
+    including loading startup files, configuration, etc.
+    much of which is skipped by `embed()`.
+    
+    Parameters
+    ----------
+    
+    argv : list or None, optional
+        If unspecified or None, IPython will parse command-line options from sys.argv.
+        To prevent any command-line parsing, pass an empty list: `argv=[]`.
+    user_ns : dict, optional
+        specify this dictionary to initialize the IPython user namespace with particular values.
+    kwargs : various, optional
+        Any other kwargs will be passed to the Application constructor,
+        such as `config`.
+    """
+    from IPython.kernel.zmq.kernelapp import launch_new_instance
+    return launch_new_instance(argv=argv, **kwargs)
+    

--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -84,3 +84,23 @@ def embed_kernel(module=None, local_ns=None, **kwargs):
     # Only import .zmq when we really need it
     from IPython.kernel.zmq.embed import embed_kernel as real_embed_kernel
     real_embed_kernel(module=module, local_ns=local_ns, **kwargs)
+
+def start_ipython(argv=None, **kwargs):
+    """launch a normal IPython instance (as opposed to embedded)
+    
+    This is a public API method, and will survive implementation changes.
+    
+    
+    Parameters
+    ----------
+    
+    argv : list or None, optional
+        If unspecified or None, IPython will parse command-line options from sys.argv.
+        To prevent any command-line parsing, pass an empty list: `argv=[]`.
+    
+    kwargs : various, optional
+        Any other kwargs will be passed to the Application constructor,
+        such as `config`.
+    """
+    from IPython.terminal.ipapp import launch_new_instance
+    return launch_new_instance(argv=argv, **kwargs)

--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -86,10 +86,17 @@ def embed_kernel(module=None, local_ns=None, **kwargs):
     real_embed_kernel(module=module, local_ns=local_ns, **kwargs)
 
 def start_ipython(argv=None, **kwargs):
-    """launch a normal IPython instance (as opposed to embedded)
+    """Launch a normal IPython instance (as opposed to embedded)
+    
+    `IPython.embed()` puts a shell in a particular calling scope,
+    such as a function or method for debugging purposes,
+    which is often not desirable.
+    
+    `start_ipython()` does full, regular IPython initialization,
+    including loading startup files, configuration, etc.
+    much of which is skipped by `embed()`.
     
     This is a public API method, and will survive implementation changes.
-    
     
     Parameters
     ----------
@@ -97,7 +104,8 @@ def start_ipython(argv=None, **kwargs):
     argv : list or None, optional
         If unspecified or None, IPython will parse command-line options from sys.argv.
         To prevent any command-line parsing, pass an empty list: `argv=[]`.
-    
+    user_ns : dict, optional
+        specify this dictionary to initialize the IPython user namespace with particular values.
     kwargs : various, optional
         Any other kwargs will be passed to the Application constructor,
         such as `config`.

--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -523,6 +523,13 @@ class Application(SingletonConfigurable):
         self.log.debug("Exiting application: %s" % self.name)
         sys.exit(exit_status)
 
+    @classmethod
+    def launch_new_instance(cls, argv=None, **kwargs):
+        """Launch a global instance of this Application"""
+        app = cls.instance(**kwargs)
+        app.initialize(argv)
+        app.start()
+
 #-----------------------------------------------------------------------------
 # utility functions, for convenience
 #-----------------------------------------------------------------------------

--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -524,8 +524,11 @@ class Application(SingletonConfigurable):
         sys.exit(exit_status)
 
     @classmethod
-    def launch_new_instance(cls, argv=None, **kwargs):
-        """Launch a global instance of this Application"""
+    def launch_instance(cls, argv=None, **kwargs):
+        """Launch a global instance of this Application
+        
+        If a global instance already exists, this reinitializes and starts it
+        """
         app = cls.instance(**kwargs)
         app.initialize(argv)
         app.start()

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -745,5 +745,5 @@ class NotebookApp(BaseIPythonApplication):
 # Main entry point
 #-----------------------------------------------------------------------------
 
-launch_new_instance = NotebookApp.launch_new_instance
+launch_new_instance = NotebookApp.launch_instance
 

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -745,8 +745,5 @@ class NotebookApp(BaseIPythonApplication):
 # Main entry point
 #-----------------------------------------------------------------------------
 
-def launch_new_instance():
-    app = NotebookApp.instance()
-    app.initialize()
-    app.start()
+launch_new_instance = NotebookApp.launch_new_instance
 

--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -203,10 +203,5 @@ class NbConvertApp(Application):
 # Main entry point
 #-----------------------------------------------------------------------------
 
-def launch_new_instance():
-    """Application entry point"""
-
-    app = NbConvertApp.instance()
-    app.description = __doc__
-    app.start(argv=sys.argv)
+launch_new_instance = NbConvertApp.launch_new_instance
 

--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -203,5 +203,5 @@ class NbConvertApp(Application):
 # Main entry point
 #-----------------------------------------------------------------------------
 
-launch_new_instance = NbConvertApp.launch_new_instance
+launch_new_instance = NbConvertApp.launch_instance
 

--- a/IPython/parallel/apps/ipclusterapp.py
+++ b/IPython/parallel/apps/ipclusterapp.py
@@ -608,12 +608,7 @@ class IPClusterApp(BaseIPythonApplication):
         else:
             return self.subapp.start()
 
-def launch_new_instance():
-    """Create and run the IPython cluster."""
-    app = IPClusterApp.instance()
-    app.initialize()
-    app.start()
-
+launch_new_instance = IPClusterApp.launch_new_instance
 
 if __name__ == '__main__':
     launch_new_instance()

--- a/IPython/parallel/apps/ipclusterapp.py
+++ b/IPython/parallel/apps/ipclusterapp.py
@@ -608,7 +608,7 @@ class IPClusterApp(BaseIPythonApplication):
         else:
             return self.subapp.start()
 
-launch_new_instance = IPClusterApp.launch_new_instance
+launch_new_instance = IPClusterApp.launch_instance
 
 if __name__ == '__main__':
     launch_new_instance()

--- a/IPython/parallel/apps/ipcontrollerapp.py
+++ b/IPython/parallel/apps/ipcontrollerapp.py
@@ -528,8 +528,7 @@ class IPControllerApp(BaseParallelApplication):
             self.cleanup_connection_files()
             
 
-
-def launch_new_instance():
+def launch_new_instance(*args, **kwargs):
     """Create and run the IPython controller"""
     if sys.platform == 'win32':
         # make sure we don't get called from a multiprocessing subprocess
@@ -545,9 +544,7 @@ def launch_new_instance():
         if p.name != 'MainProcess':
             # we are a subprocess, don't start another Controller!
             return
-    app = IPControllerApp.instance()
-    app.initialize()
-    app.start()
+    return IPControllerApp.launch_new_instance(*args, **kwargs)
 
 
 if __name__ == '__main__':

--- a/IPython/parallel/apps/ipcontrollerapp.py
+++ b/IPython/parallel/apps/ipcontrollerapp.py
@@ -544,7 +544,7 @@ def launch_new_instance(*args, **kwargs):
         if p.name != 'MainProcess':
             # we are a subprocess, don't start another Controller!
             return
-    return IPControllerApp.launch_new_instance(*args, **kwargs)
+    return IPControllerApp.launch_instance(*args, **kwargs)
 
 
 if __name__ == '__main__':

--- a/IPython/parallel/apps/ipengineapp.py
+++ b/IPython/parallel/apps/ipengineapp.py
@@ -388,11 +388,7 @@ class IPEngineApp(BaseParallelApplication):
             self.log.critical("Engine Interrupted, shutting down...\n")
 
 
-def launch_new_instance():
-    """Create and run the IPython engine"""
-    app = IPEngineApp.instance()
-    app.initialize()
-    app.start()
+launch_new_instance = IPEngineApp.launch_new_instance
 
 
 if __name__ == '__main__':

--- a/IPython/parallel/apps/ipengineapp.py
+++ b/IPython/parallel/apps/ipengineapp.py
@@ -388,7 +388,7 @@ class IPEngineApp(BaseParallelApplication):
             self.log.critical("Engine Interrupted, shutting down...\n")
 
 
-launch_new_instance = IPEngineApp.launch_new_instance
+launch_new_instance = IPEngineApp.launch_instance
 
 
 if __name__ == '__main__':

--- a/IPython/parallel/apps/iploggerapp.py
+++ b/IPython/parallel/apps/iploggerapp.py
@@ -91,7 +91,7 @@ class IPLoggerApp(BaseParallelApplication):
             self.log.critical("Logging Interrupted, shutting down...\n")
 
 
-launch_new_instance = IPLoggerApp.launch_new_instance
+launch_new_instance = IPLoggerApp.launch_instance
 
 
 if __name__ == '__main__':

--- a/IPython/parallel/apps/iploggerapp.py
+++ b/IPython/parallel/apps/iploggerapp.py
@@ -91,11 +91,7 @@ class IPLoggerApp(BaseParallelApplication):
             self.log.critical("Logging Interrupted, shutting down...\n")
 
 
-def launch_new_instance():
-    """Create and run the IPython LogWatcher"""
-    app = IPLoggerApp.instance()
-    app.initialize()
-    app.start()
+launch_new_instance = IPLoggerApp.launch_new_instance
 
 
 if __name__ == '__main__':

--- a/IPython/scripts/ipython
+++ b/IPython/scripts/ipython
@@ -2,6 +2,5 @@
 """Terminal-based IPython entry point.
 """
 
-from IPython.terminal.ipapp import launch_new_instance
-
-launch_new_instance()
+from IPython import start_ipython
+start_ipython()

--- a/IPython/terminal/console/app.py
+++ b/IPython/terminal/console/app.py
@@ -141,7 +141,7 @@ class ZMQTerminalIPythonApp(TerminalIPythonApp, IPythonConsoleApp):
         pass
 
 
-launch_new_instance = ZMQTerminalIPythonApp.launch_new_instance
+launch_new_instance = ZMQTerminalIPythonApp.launch_instance
 
 
 if __name__ == '__main__':

--- a/IPython/terminal/console/app.py
+++ b/IPython/terminal/console/app.py
@@ -140,11 +140,8 @@ class ZMQTerminalIPythonApp(TerminalIPythonApp, IPythonConsoleApp):
         # no-op in the frontend, code gets run in the backend
         pass
 
-def launch_new_instance():
-    """Create and run a full blown IPython instance"""
-    app = ZMQTerminalIPythonApp.instance()
-    app.initialize()
-    app.start()
+
+launch_new_instance = ZMQTerminalIPythonApp.launch_new_instance
 
 
 if __name__ == '__main__':

--- a/IPython/terminal/embed.py
+++ b/IPython/terminal/embed.py
@@ -272,6 +272,11 @@ def embed(**kwargs):
     instance and then call it.  Consecutive calls just call the already
     created instance.
 
+    If you don't want the kernel to initialize the namespace
+    from the scope of the surrounding function,
+    and/or you want to load full IPython configuration,
+    you probably want `IPython.start_ipython()` instead.
+
     Here is a simple example::
 
         from IPython import embed

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -389,7 +389,7 @@ def load_default_config(ipython_dir=None):
     return config
 
 
-launch_new_instance = TerminalIPythonApp.launch_new_instance
+launch_new_instance = TerminalIPythonApp.launch_instance
 
 
 if __name__ == '__main__':

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -389,11 +389,7 @@ def load_default_config(ipython_dir=None):
     return config
 
 
-def launch_new_instance():
-    """Create and run a full blown IPython instance"""
-    app = TerminalIPythonApp.instance()
-    app.initialize()
-    app.start()
+launch_new_instance = TerminalIPythonApp.launch_new_instance
 
 
 if __name__ == '__main__':

--- a/setupbase.py
+++ b/setupbase.py
@@ -315,7 +315,7 @@ def find_scripts(entry_points=False, suffix=''):
     """
     if entry_points:
         console_scripts = [s % suffix for s in [
-            'ipython%s = IPython.terminal.ipapp:launch_new_instance',
+            'ipython%s = IPython:start_ipython',
             'pycolor%s = IPython.utils.PyColorize:main',
             'ipcontroller%s = IPython.parallel.apps.ipcontrollerapp:launch_new_instance',
             'ipengine%s = IPython.parallel.apps.ipengineapp:launch_new_instance',


### PR DESCRIPTION
A public API for starting a real (non-embedded) IPython instance.

should avoid API breakage in the future due to simple module renames, as has just happened with the removal of frontend.

For implementation purposes, I have added `launch_new_instance` as a classmethod on Application.  I did this, because I wanted to add the ability to pass arguments to the instance, and didn't want to manually update every duplicate `launch_new_instance`.

closes #1537
