### PR TITLE
respect image size metadata in qtconsole

### DIFF
--- a/IPython/qt/console/console_widget.py
+++ b/IPython/qt/console/console_widget.py
@@ -868,7 +868,7 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
     # 'ConsoleWidget' protected interface
     #--------------------------------------------------------------------------
 
-    def _append_custom(self, insert, input, before_prompt=False):
+    def _append_custom(self, insert, input, before_prompt=False, *args, **kwargs):
         """ A low-level method for appending content to the end of the buffer.
 
         If 'before_prompt' is enabled, the content will be inserted before the
@@ -883,7 +883,7 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
         start_pos = cursor.position()
 
         # Perform the insertion.
-        result = insert(cursor, input)
+        result = insert(cursor, input, *args, **kwargs)
 
         # Adjust the prompt position if we have inserted before it. This is safe
         # because buffer truncation is disabled when not executing.

--- a/IPython/qt/console/rich_ipython_widget.py
+++ b/IPython/qt/console/rich_ipython_widget.py
@@ -299,11 +299,11 @@ class RichIPythonWidget(IPythonWidget):
             image = QtGui.QImage()
             image.loadFromData(img, fmt.upper())
             if width and height:
-                image = image.scaled(width, height)
+                image = image.scaled(width, height, transformMode=QtCore.Qt.SmoothTransformation)
             elif width and not height:
-                image = image.scaledToWidth(width)
+                image = image.scaledToWidth(width, transformMode=QtCore.Qt.SmoothTransformation)
             elif height and not width:
-                image = image.scaledToHeight(height)
+                image = image.scaledToHeight(height, transformMode=QtCore.Qt.SmoothTransformation)
         except ValueError:
             self._insert_plain_text(cursor, 'Received invalid %s data.'%fmt)
         else:


### PR DESCRIPTION
This doesn't mean retina support, as image data is actually resampled, unlike
in a browser.
