### PR TITLE
Don't hardcode **latex** posix paths in nbconvert

### DIFF
--- a/IPython/nbconvert/exporters/latex.py
+++ b/IPython/nbconvert/exporters/latex.py
@@ -47,11 +47,11 @@ class LatexExporter(Exporter):
 
     #Latex constants
     template_path = Unicode(
-        "/../templates/latex/", config=True,
+        os.path.join("..", "templates", "latex"), config=True,
         help="Path where the template files are located.")
 
     template_skeleton_path = Unicode(
-        "/../templates/latex/skeleton/", config=True,
+        os.path.join("..", "templates", "latex", "skeleton"), config=True,
         help="Path where the template skeleton files are located.") 
 
     #Special Jinja2 syntax that will not conflict when exporting latex.

--- a/IPython/nbconvert/transformers/sphinx.py
+++ b/IPython/nbconvert/transformers/sphinx.py
@@ -169,7 +169,7 @@ class SphinxTransformer(ActivatableTransformer):
             resources["sphinx"]["header"] = self.use_headers
             
         # Find and pass in the path to the Sphinx dependencies.
-        resources["sphinx"]["texinputs"] = os.path.abspath(sphinx.__file__ + "/../texinputs")
+        resources["sphinx"]["texinputs"] = os.path.realpath(os.path.join(sphinx.__file__, "..", "texinputs"))
         
         # Generate Pygments definitions for Latex 
         resources["sphinx"]["pygment_definitions"] = self._generate_pygments_latex_def()


### PR DESCRIPTION
@minrk just noticed after merging #3539 that it didn't include the fix for the latex paths too.
