### PR TITLE
Fixing issue preventing the correct read of images by full_html and reveal exporters.

### DIFF
--- a/IPython/nbconvert/filters/strings.py
+++ b/IPython/nbconvert/filters/strings.py
@@ -15,7 +15,7 @@ templates.
 # Imports
 #-----------------------------------------------------------------------------
 
-# Our own imports
+import re
 import textwrap
 
 #-----------------------------------------------------------------------------
@@ -63,16 +63,19 @@ def strip_dollars(text):
     return text.strip('$')
 
 
+files_url_pattern = re.compile(r'(src|href)\=([\'"]?)files/')
+
 def rm_fake(text):
     """
-    Remove all occurrences of 'files/' from text
+    Fix all fake URLs that start with `files/`,
+    stripping out the `files/` prefix.
     
     Parameters
     ----------
     text : str
-        Text to remove 'files/' from
+        Text in which to replace 'src="files/real...' with 'src="real...'
     """
-    return text.replace('files/', '')
+    return files_url_pattern.sub(r"\1=\2", text)
 
 
 def python_comment(text):

--- a/IPython/nbconvert/filters/strings.py
+++ b/IPython/nbconvert/filters/strings.py
@@ -65,14 +65,14 @@ def strip_dollars(text):
 
 def rm_fake(text):
     """
-    Remove all occurrences of '/files/' from text
+    Remove all occurrences of 'files/' from text
     
     Parameters
     ----------
     text : str
-        Text to remove '/files/' from
+        Text to remove 'files/' from
     """
-    return text.replace('/files/', '')
+    return text.replace('files/', '')
 
 
 def python_comment(text):


### PR DESCRIPTION
Currently to see and images in the notebook inside a md cell you can use the prefix files/ to read the content of the directory where the ipynb lives. But, if you do a conversion using full_html or reveal exporters, the are not rendered ok because the previous version of this function erased `/files/` instead of `files/`. With this fix, the html files produced by full_html and reveal exporters can read the images in a correct way.
