### PR TITLE
set overflow-x: hidden on Firefox only

### DIFF
--- a/IPython/html/static/notebook/less/codemirror.less
+++ b/IPython/html/static/notebook/less/codemirror.less
@@ -22,6 +22,14 @@
     overflow-x: auto;
 }
 
+@-moz-document {
+  /* Firefox does weird and terrible things (#3549) when overflow-x is auto */
+  /* It doesn't respect the overflow setting anyway, so we can workaround it with this */
+  .CodeMirror-scroll {
+    overflow-x: hidden;
+  }
+}
+
 .CodeMirror-lines {
   /* In CM2, this used to be 0.4em, but in CM3 it went to 4px. We need the em value because */
   /* we have set a different line-height and want this to scale with that. */

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1457,7 +1457,7 @@ div.out_prompt_overlay:hover{-webkit-box-shadow:inset 0 0 1px #000000;-moz-box-s
 div.output_prompt{color:darkred;}
 .CodeMirror{line-height:1.231em;height:auto;background:none;}
 .CodeMirror-scroll{overflow-y:hidden;overflow-x:auto;}
-.CodeMirror-lines{padding:0.4em;}
+@-moz-document {.CodeMirror-scroll{overflow-x:hidden;}}.CodeMirror-lines{padding:0.4em;}
 .CodeMirror-linenumber{padding:0 8px 0 4px;}
 .CodeMirror-gutters{border-bottom-left-radius:4px;border-top-left-radius:4px;}
 .CodeMirror pre{padding:0;border:0;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0;}


### PR DESCRIPTION
workaround crazy Firefox-only behavior when selecting newlines

closes #3549
