### PR TITLE
Fix missing import os in latex exporter.

### DIFF
--- a/IPython/nbconvert/exporters/latex.py
+++ b/IPython/nbconvert/exporters/latex.py
@@ -16,6 +16,9 @@ tags to circumvent Jinja/Latex syntax conflicts.
 # Imports
 #-----------------------------------------------------------------------------
 
+# Stdlib imports
+import os
+
 # IPython imports
 from IPython.utils.traitlets import Unicode
 from IPython.config import Config


### PR DESCRIPTION
The title say all.

Cheers.

Damián.
