### PR TITLE
Simplify caching of modules with %run

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -819,20 +819,22 @@ class InteractiveShell(SingletonConfigurable):
     # Things related to the "main" module
     #-------------------------------------------------------------------------
 
-    def new_main_mod(self,filename):
+    def new_main_mod(self, filename):
         """Return a new 'main' module object for user code execution.
         
-        When scripts are executed via %run, we must keep a reference to the
-        namespace of their __main__ module (a FakeModule instance) around so
-        that Python doesn't clear it, rendering objects defined therein
-        useless.
+        ``filename`` should be the path of the script which will be run in the
+        module. Requests with the same filename will get the same module, with
+        its namespace cleared.
+        
+        When scripts are executed via %run, we must keep a reference to their
+        __main__ module (a FakeModule instance) around so that Python doesn't
+        clear it, rendering references to module globals useless.
 
         This method keeps said reference in a private dict, keyed by the
-        absolute path of the module object (which corresponds to the script
-        path).  This way, for multiple executions of the same script we only
-        keep one copy of the namespace (the last one), thus preventing memory
-        leaks from old references while allowing the objects from the last
-        execution to be accessible.
+        absolute path of the script. This way, for multiple executions of the
+        same script we only keep one copy of the namespace (the last one),
+        thus preventing memory leaks from old references while allowing the
+        objects from the last execution to be accessible.
         """
         filename = os.path.abspath(filename)
         try:

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -508,7 +508,7 @@ python-profiler package from non-free.""")
             prog_ns = self.shell.user_ns
             __name__save = self.shell.user_ns['__name__']
             prog_ns['__name__'] = '__main__'
-            main_mod = self.shell.new_main_mod(prog_ns)
+            main_mod = self.shell.user_module
         else:
             # Run in a fresh, empty namespace
             if 'n' in opts:
@@ -516,7 +516,10 @@ python-profiler package from non-free.""")
             else:
                 name = '__main__'
 
-            main_mod = self.shell.new_main_mod()
+            # The shell MUST hold a reference to prog_ns so after %run
+            # exits, the python deletion mechanism doesn't zero it out
+            # (leaving dangling references). See interactiveshell for details
+            main_mod = self.shell.new_main_mod(filename)
             prog_ns = main_mod.__dict__
             prog_ns['__name__'] = name
 
@@ -593,10 +596,6 @@ python-profiler package from non-free.""")
                 if 'i' in opts:
                     self.shell.user_ns['__name__'] = __name__save
                 else:
-                    # The shell MUST hold a reference to prog_ns so after %run
-                    # exits, the python deletion mechanism doesn't zero it out
-                    # (leaving dangling references).
-                    self.shell.cache_main_mod(prog_ns, filename)
                     # update IPython interactive namespace
 
                     # Some forms of read errors on the file may mean the

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -244,7 +244,6 @@ class TestMagicRunSimple(tt.TempFileMixin):
             err = None
         tt.ipexec_validate(self.fname, 'object A deleted', err)
     
-    @dec.skip_known_failure 
     def test_aggressive_namespace_cleanup(self):
         """Test that namespace cleanup is not too aggressive GH-238
 
@@ -262,7 +261,7 @@ class TestMagicRunSimple(tt.TempFileMixin):
         self.mktmp(py3compat.doctest_refactor_print(src))
         _ip.magic('run %s' % self.fname)
         _ip.run_cell('ip == get_ipython()')
-        nt.assert_equal(_ip.user_ns['i'], 5)
+        nt.assert_equal(_ip.user_ns['i'], 4)
     
     def test_run_second(self):
         """Test that running a second file doesn't clobber the first, gh-3547

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -263,6 +263,20 @@ class TestMagicRunSimple(tt.TempFileMixin):
         _ip.magic('run %s' % self.fname)
         _ip.run_cell('ip == get_ipython()')
         nt.assert_equal(_ip.user_ns['i'], 5)
+    
+    def test_run_second(self):
+        """Test that running a second file doesn't clobber the first, gh-3547
+        """
+        self.mktmp("avar = 1\n"
+                   "def afunc():\n"
+                   "  return avar\n")
+
+        empty = tt.TempFileMixin()
+        empty.mktmp("")
+        
+        _ip.magic('run %s' % self.fname)
+        _ip.magic('run %s' % empty.fname)
+        nt.assert_equal(_ip.user_ns['afunc'](), 1)
 
     @dec.skip_win32
     def test_tclass(self):

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -257,8 +257,9 @@ class TestMagicRunSimple(tt.TempFileMixin):
                "   try:\n"
                "       ip.magic('run %s')\n"
                "   except NameError as e:\n"
-               "       print i;break\n" % empty.fname)
-        self.mktmp(py3compat.doctest_refactor_print(src))
+               "       print(i)\n"
+               "       break\n" % empty.fname)
+        self.mktmp(src)
         _ip.magic('run %s' % self.fname)
         _ip.run_cell('ip == get_ipython()')
         nt.assert_equal(_ip.user_ns['i'], 4)

--- a/docs/source/whatsnew/development.txt
+++ b/docs/source/whatsnew/development.txt
@@ -48,3 +48,7 @@ Backwards incompatible changes
   :func:`IPython.utils.doctestreload.doctest_reload` to make doctests run 
   correctly inside IPython. Python releases since those versions are unaffected.
   For details, see :ghpull:`3068` and `Python issue 8048 <http://bugs.python.org/issue8048>`_.
+* The ``InteractiveShell.cache_main_mod()`` method has been removed, and
+  :meth:`~IPython.core.interactiveshell.InteractiveShell.new_main_mod` has a
+  different signature, expecting a filename where earlier versions expected
+  a namespace. See :ghpull:`3555` for details.


### PR DESCRIPTION
Previously, we cleared and re-used a single FakeModule instance in which to run scripts, and cached copies of the modules' namespaces to prevent them from being cleared. Now, we cache one FakeModule instance per script file, clearing it and re-using it if the same script is re-run.

I've assumed that `new_main_mod` and `cache_main_mod` don't count as public APIs; they're certainly bizarre corners that I hope no-one else has needed to use directly. Fixing this would be much harder if we have to preserve their signatures.

This closes #3547, and also fixes another test that was marked as a known failure. (Entirely clean test run on IPython.core!)

Pinging @fperez, as I think you're the most familiar with this code.
