### PR TITLE
remove mention of nonexistent `_margv` in macro

### DIFF
--- a/IPython/core/macro.py
+++ b/IPython/core/macro.py
@@ -19,8 +19,6 @@ class Macro(object):
 
     Macro is just a callable that executes a string of IPython
     input when called.
-    
-    Args to macro are available in _margv list if you need them.
     """
 
     def __init__(self,code):


### PR DESCRIPTION
closes #3476
