### PR TITLE
open markdown links in new tabs

### DIFF
--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -317,7 +317,9 @@ var IPython = (function (IPython) {
             if (text === "") { text = this.placeholder; }
             text = IPython.mathjaxutils.remove_math(text);
             var html = marked.parser(marked.lexer(text));
-            html = IPython.mathjaxutils.replace_math(html);
+            html = $(IPython.mathjaxutils.replace_math(html));
+            // links in markdown cells should open in new tabs
+            html.find("a[href]").attr("target", "_blank");
             try {
                 this.set_rendered(html);
             } catch (e) {


### PR DESCRIPTION
restores earlier behavior lost when we switched to marked.

closes #3439
