### PR TITLE
Remove max_msg_size

### DIFF
--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -174,7 +174,6 @@ class NotebookWebApplication(web.Application):
             
             # IPython stuff
             mathjax_url=ipython_app.mathjax_url,
-            max_msg_size=ipython_app.max_msg_size,
             config=ipython_app.config,
             use_less=ipython_app.use_less,
             jinja2_env=Environment(loader=FileSystemLoader(template_path)),
@@ -294,11 +293,6 @@ class NotebookApp(BaseIPythonApplication):
     aliases = Dict(aliases)
 
     kernel_argv = List(Unicode)
-
-    max_msg_size = Integer(2**20, config=True, help="""
-        The max raw message size (in bytes) accepted from the browser
-        over a WebSocket connection.
-    """)
 
     def _log_level_default(self):
         return logging.INFO

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -295,8 +295,8 @@ class NotebookApp(BaseIPythonApplication):
 
     kernel_argv = List(Unicode)
 
-    max_msg_size = Integer(65536, config=True, help="""
-        The max raw message size accepted from the browser
+    max_msg_size = Integer(2**20, config=True, help="""
+        The max raw message size (in bytes) accepted from the browser
         over a WebSocket connection.
     """)
 

--- a/IPython/html/services/kernels/handlers.py
+++ b/IPython/html/services/kernels/handlers.py
@@ -79,10 +79,6 @@ class KernelActionHandler(IPythonHandler):
 
 class ZMQChannelHandler(AuthenticatedZMQStreamHandler):
     
-    @property
-    def max_msg_size(self):
-        return self.settings.get('max_msg_size', 2**20)
-    
     def create_stream(self):
         km = self.kernel_manager
         meth = getattr(km, 'connect_%s' % self.channel)
@@ -109,13 +105,8 @@ class ZMQChannelHandler(AuthenticatedZMQStreamHandler):
             self.zmq_stream.on_recv(self._on_zmq_reply)
 
     def on_message(self, msg):
-        if len(msg) < self.max_msg_size:
-            msg = jsonapi.loads(msg)
-            self.session.send(self.zmq_stream, msg)
-        else:
-            self.log.warn("Dropping oversized message: %iB > %iB (NotebookApp.max_msg_size)",
-                len(msg), self.max_msg_size
-            )
+        msg = jsonapi.loads(msg)
+        self.session.send(self.zmq_stream, msg)
 
     def on_close(self):
         # This method can be called twice, once by self.kernel_died and once

--- a/IPython/html/services/kernels/handlers.py
+++ b/IPython/html/services/kernels/handlers.py
@@ -81,7 +81,7 @@ class ZMQChannelHandler(AuthenticatedZMQStreamHandler):
     
     @property
     def max_msg_size(self):
-        return self.settings.get('max_msg_size', 65535)
+        return self.settings.get('max_msg_size', 2**20)
     
     def create_stream(self):
         km = self.kernel_manager

--- a/IPython/html/services/kernels/handlers.py
+++ b/IPython/html/services/kernels/handlers.py
@@ -112,6 +112,10 @@ class ZMQChannelHandler(AuthenticatedZMQStreamHandler):
         if len(msg) < self.max_msg_size:
             msg = jsonapi.loads(msg)
             self.session.send(self.zmq_stream, msg)
+        else:
+            self.log.warn("Dropping oversized message: %iB > %iB (NotebookApp.max_msg_size)",
+                len(msg), self.max_msg_size
+            )
 
     def on_close(self):
         # This method can be called twice, once by self.kernel_died and once


### PR DESCRIPTION
The max_msg_size safety limit is just removed.

<del>to 1MB. 64k is probably too conservative (1MB may be as well, I'm not sure of the value of this configurable, really).

Also warn about the dropped messages, so that there is a hint about the cause of strange behavior.
</del>


closes #3124 
