### PR TITLE
Trigger a single event on js app initilized

### DIFF
--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -100,6 +100,7 @@ function (marked) {
     };
 
     $([IPython.events]).on('notebook_loaded.Notebook', first_load);
+    $([IPython.events]).trigger('app_initialized.NotebookApp');
     IPython.notebook.load_notebook($('body').data('notebookId'));
 
     if (marked) {


### PR DESCRIPTION
Usefull to bind to extension loading, to load only once

Otherwise we advise to bind to `notebook_loaded` which is re-triggerd on checkpoint restoring.
