### PR TITLE
pylab import adjustments

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2865,9 +2865,17 @@ class InteractiveShell(SingletonConfigurable):
                   % (gui, " ".join(sorted(backends.keys()))))
             return
         except ImportError:
-            error("pylab mode doesn't work as matplotlib could not be found." + \
+            error("pylab mode doesn't work as matplotlib or its backend could not be imported." + \
                   "\nIs it installed on the system?")
             return
+        # warn about clobbered names
+        ignored = set(["__builtins__"])
+        both = set(ns).intersection(self.user_ns).difference(ignored)
+        clobbered = [ name for name in both if self.user_ns[name] is not ns[name] ]
+        if clobbered:
+            warn("pylab import has clobbered these variables: %s"
+            "\n`%%pylab --no-import` prevents imports from pylab, numpy, etc."  % clobbered
+            )
         self.user_ns.update(ns)
         self.user_ns_hidden.update(ns)
         # Now we must activate the gui pylab wants to use, and fix %run to take

--- a/IPython/core/magics/pylab.py
+++ b/IPython/core/magics/pylab.py
@@ -18,6 +18,7 @@ from IPython.core import magic_arguments
 from IPython.core.magic import Magics, magics_class, line_magic
 from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.warn import warn
+from IPython.core.pylabtools import backends
 
 #-----------------------------------------------------------------------------
 # Magic implementation classes
@@ -25,12 +26,11 @@ from IPython.utils.warn import warn
 
 magic_gui_arg = magic_arguments.argument(
         'gui', nargs='?',
-        help="""Name of the matplotlib backend to use
-        ('qt', 'wx', 'gtk', 'osx', 'tk', 'inline', 'auto').
+        help="""Name of the matplotlib backend to use %s.
         If given, the corresponding matplotlib backend is used,
         otherwise it will be matplotlib's default
         (which you can set in your matplotlib config file).
-        """
+        """ % str(tuple(sorted(backends.keys())))
 )
 
 

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -201,7 +201,9 @@ class InteractiveShellApp(Configurable):
                     gui, backend = pylabtools.find_gui_and_backend(self.pylab)
                     self.log.info("Enabling GUI event loop integration, "
                               "toolkit=%s, pylab=%s" % (gui, self.pylab))
-                    shell.enable_pylab(gui, import_all=self.pylab_import_all, welcome_message=True)
+                    if self.pylab == "auto":
+                        print ("using matplotlib backend: %s" % backend)
+                    shell.enable_pylab(self.pylab, import_all=self.pylab_import_all)
                 else:
                     self.log.info("Enabling GUI event loop integration, "
                                   "toolkit=%s" % self.gui)

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -176,8 +176,11 @@ class InteractiveShellApp(Configurable):
         """
     )
     pylab_import_all = Bool(True, config=True,
-        help="""If true, an 'import *' is done from numpy and pylab,
-        when using pylab"""
+        help="""If true, IPython will populate the user namespace with numpy, pylab, etc.
+        and an 'import *' is done from numpy and pylab, when using pylab mode.
+        
+        When False, pylab mode should not import any names into the user namespace.
+        """
     )
     shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
 

--- a/IPython/core/tests/test_pylabtools.py
+++ b/IPython/core/tests/test_pylabtools.py
@@ -23,6 +23,7 @@ from matplotlib import pyplot as plt
 import numpy as np
 
 # Our own imports
+from IPython.core.interactiveshell import InteractiveShell
 from IPython.testing import decorators as dec
 from .. import pylabtools as pt
 
@@ -62,11 +63,11 @@ def test_import_pylab():
     nt.assert_true('plt' in ns)
     nt.assert_equal(ns['np'], np)
 
-
 class TestPylabSwitch(object):
-    class Shell(object):
-        pylab_gui_select = None
-
+    class Shell(InteractiveShell):
+        def enable_gui(self, gui):
+            pass
+    
     def setup(self):
         import matplotlib
         def act_mpl(backend):
@@ -93,47 +94,47 @@ class TestPylabSwitch(object):
 
     def test_qt(self):
         s = self.Shell()
-        gui = pt.pylab_activate(dict(), None, False, s)
+        gui, backend = s.enable_matplotlib(None)
         nt.assert_equal(gui, 'qt')
         nt.assert_equal(s.pylab_gui_select, 'qt')
 
-        gui = pt.pylab_activate(dict(), 'inline', False, s)
+        gui, backend = s.enable_matplotlib('inline')
         nt.assert_equal(gui, 'inline')
         nt.assert_equal(s.pylab_gui_select, 'qt')
 
-        gui = pt.pylab_activate(dict(), 'qt', False, s)
+        gui, backend = s.enable_matplotlib('qt')
         nt.assert_equal(gui, 'qt')
         nt.assert_equal(s.pylab_gui_select, 'qt')
 
-        gui = pt.pylab_activate(dict(), 'inline', False, s)
+        gui, backend = s.enable_matplotlib('inline')
         nt.assert_equal(gui, 'inline')
         nt.assert_equal(s.pylab_gui_select, 'qt')
 
-        gui = pt.pylab_activate(dict(), None, False, s)
+        gui, backend = s.enable_matplotlib()
         nt.assert_equal(gui, 'qt')
         nt.assert_equal(s.pylab_gui_select, 'qt')
 
     def test_inline(self):
         s = self.Shell()
-        gui = pt.pylab_activate(dict(), 'inline', False, s)
+        gui, backend = s.enable_matplotlib('inline')
         nt.assert_equal(gui, 'inline')
         nt.assert_equal(s.pylab_gui_select, None)
 
-        gui = pt.pylab_activate(dict(), 'inline', False, s)
+        gui, backend = s.enable_matplotlib('inline')
         nt.assert_equal(gui, 'inline')
         nt.assert_equal(s.pylab_gui_select, None)
 
-        gui = pt.pylab_activate(dict(), 'qt', False, s)
+        gui, backend = s.enable_matplotlib('qt')
         nt.assert_equal(gui, 'qt')
         nt.assert_equal(s.pylab_gui_select, 'qt')
 
     def test_qt_gtk(self):
         s = self.Shell()
-        gui = pt.pylab_activate(dict(), 'qt', False, s)
+        gui, backend = s.enable_matplotlib('qt')
         nt.assert_equal(gui, 'qt')
         nt.assert_equal(s.pylab_gui_select, 'qt')
 
-        gui = pt.pylab_activate(dict(), 'gtk', False, s)
+        gui, backend = s.enable_matplotlib('gtk')
         nt.assert_equal(gui, 'qt')
         nt.assert_equal(s.pylab_gui_select, 'qt')
 

--- a/IPython/kernel/inprocess/ipkernel.py
+++ b/IPython/kernel/inprocess/ipkernel.py
@@ -170,7 +170,7 @@ class InProcessInteractiveShell(ZMQInteractiveShell):
         """Enable matplotlib integration for the kernel."""
         if not gui:
             gui = self.kernel.gui
-        return super(InProcessInteractiveShell, self).enable_matplotlib(self, gui)
+        return super(InProcessInteractiveShell, self).enable_matplotlib(gui)
 
     def enable_pylab(self, gui=None, import_all=True, welcome_message=False):
         """Activate pylab support at runtime."""

--- a/IPython/kernel/inprocess/ipkernel.py
+++ b/IPython/kernel/inprocess/ipkernel.py
@@ -160,19 +160,23 @@ class InProcessInteractiveShell(ZMQInteractiveShell):
     #-------------------------------------------------------------------------
 
     def enable_gui(self, gui=None):
-        """ Enable GUI integration for the kernel.
-        """
+        """Enable GUI integration for the kernel."""
         from IPython.kernel.zmq.eventloops import enable_gui
         if not gui:
             gui = self.kernel.gui
-        enable_gui(gui, kernel=self.kernel)
+        return enable_gui(gui, kernel=self.kernel)
 
-    def enable_pylab(self, gui=None, import_all=True, welcome_message=False):
-        """ Activate pylab support at runtime.
-        """
+    def enable_matplotlib(self, gui=None):
+        """Enable matplotlib integration for the kernel."""
         if not gui:
             gui = self.kernel.gui
-        super(InProcessInteractiveShell, self).enable_pylab(gui, import_all,
+        return super(InProcessInteractiveShell, self).enable_matplotlib(self, gui)
+
+    def enable_pylab(self, gui=None, import_all=True, welcome_message=False):
+        """Activate pylab support at runtime."""
+        if not gui:
+            gui = self.kernel.gui
+        return super(InProcessInteractiveShell, self).enable_pylab(gui, import_all,
                                                             welcome_message)
 
 InteractiveShellABC.register(InProcessInteractiveShell)

--- a/IPython/kernel/inprocess/tests/test_kernel.py
+++ b/IPython/kernel/inprocess/tests/test_kernel.py
@@ -42,7 +42,7 @@ class InProcessKernelTestCase(unittest.TestCase):
         kc = self.kc
         kc.execute('%pylab')
         msg = get_stream_message(kc)
-        self.assert_('Welcome to pylab' in msg['content']['data'])
+        self.assert_('matplotlib' in msg['content']['data'])
 
     def test_raw_input(self):
         """ Does the in-process kernel handle raw_input correctly?

--- a/IPython/lib/tests/test_irunner_pylab_magic.py
+++ b/IPython/lib/tests/test_irunner_pylab_magic.py
@@ -83,8 +83,7 @@ In \[1\]: from IPython\.config\.application import Application
 In \[2\]: app = Application\.instance\(\)
 In \[3\]: app\.pylab_import_all = True
 In \[4\]: pylab
-^Welcome to pylab, a matplotlib-based Python environment
-For more information, type 'help\(pylab\)'\.
+^using matplotlib backend:
 In \[5\]: ip=get_ipython\(\)
 In \[6\]: \'plot\' in ip\.user_ns
 Out\[6\]: True
@@ -109,8 +108,7 @@ In \[1\]: from IPython\.config\.application import Application
 In \[2\]: app = Application\.instance\(\)
 In \[3\]: app\.pylab_import_all = False
 In \[4\]: pylab
-^Welcome to pylab, a matplotlib-based Python environment
-For more information, type 'help\(pylab\)'\.
+^using matplotlib backend:
 In \[5\]: ip=get_ipython\(\)
 In \[6\]: \'plot\' in ip\.user_ns
 Out\[6\]: False

--- a/IPython/utils/decorators.py
+++ b/IPython/utils/decorators.py
@@ -33,6 +33,10 @@ def flag_calls(func):
 
     Testing for truth in wrapper.called allows you to determine if a call to
     func() was attempted and succeeded."""
+    
+    # don't wrap twice
+    if hasattr(func, 'called'):
+        return func
 
     def wrapper(*args,**kw):
         wrapper.called = False


### PR DESCRIPTION
- add `%pylab --no-import`
  - allows override of the import_all option when the magic is called
- adjust `import_pylab` to import nothing when import_all is False

it's all or nothing now, not all or some. Now `pylab_import_all=False` should mean that _no_ symbols are added to the user namespace.

This also removes `figsize` from the pyplot namespace, which was weird and confusing.

closes #2630
closes #2664
closes #3436
