### PR TITLE
correct static path for CM modes autoload

### DIFF
--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -46,7 +46,6 @@ var IPython = (function (IPython) {
 
     var utils = IPython.utils;
     var key   = IPython.utils.keycodes;
-    CodeMirror.modeURL = "/static/components/codemirror/mode/%N/%N.js";
 
     /**
      * A Cell conceived to write code.

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -204,6 +204,9 @@ class="notebook_app"
 {{super()}}
 
 <script src="{{ static_url("components/codemirror/lib/codemirror.js") }}" charset="utf-8"></script>
+<script type="text/javascript">
+    CodeMirror.modeURL = "{{ static_url("components/codemirror/mode/%N/%N.js") }}";
+</script>
 <script src="{{ static_url("components/codemirror/addon/mode/loadmode.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("components/codemirror/addon/mode/multiplex.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("components/codemirror/addon/mode/overlay.js") }}" charset="utf-8"></script>


### PR DESCRIPTION
This should also allow to require CM-python mode for ipython mode and
only pass a config options instead of copy-past of all file.
