### PR TITLE
Added support for markdown in heading cells when they are nbconverted.

### DIFF
--- a/IPython/nbconvert/templates/basichtml.tpl
+++ b/IPython/nbconvert/templates/basichtml.tpl
@@ -62,7 +62,7 @@ Out[{{cell.prompt_number}}]:
 <h{{cell.level}}>
 {% set source = cell.source | replace(' ','_') %}
 <a class="heading-anchor" id="{{source}}" href="#{{source}}">
-  {{cell.source}}
+  {{cell.source | markdown| rm_fake}}
 </a>
 </h{{cell.level}}>
 </div>

--- a/IPython/nbconvert/templates/markdown.tpl
+++ b/IPython/nbconvert/templates/markdown.tpl
@@ -61,7 +61,7 @@ $$
 
 {% block headingcell scoped %}
 
-{{ '#' * cell.level }} {{ cell.source}}
+{{ '#' * cell.level }} {{ cell.source | wrap(80)}}
 
 {% endblock headingcell %}
 

--- a/IPython/nbconvert/templates/markdown.tpl
+++ b/IPython/nbconvert/templates/markdown.tpl
@@ -61,7 +61,7 @@ $$
 
 {% block headingcell scoped %}
 
-{{ '#' * cell.level }} {{ cell.source }}
+{{ '#' * cell.level }} {{ cell.source | wordwrap(80, False, '\n'+'#' * cell.level+' ')}}
 
 {% endblock headingcell %}
 

--- a/IPython/nbconvert/templates/markdown.tpl
+++ b/IPython/nbconvert/templates/markdown.tpl
@@ -61,7 +61,7 @@ $$
 
 {% block headingcell scoped %}
 
-{{ '#' * cell.level }} {{ cell.source | wrap(80)}}
+{{ '#' * cell.level }} {{ cell.source }}
 
 {% endblock headingcell %}
 

--- a/IPython/nbconvert/templates/markdown.tpl
+++ b/IPython/nbconvert/templates/markdown.tpl
@@ -61,7 +61,7 @@ $$
 
 {% block headingcell scoped %}
 
-{{ '#' * cell.level }} {{ cell.source | wordwrap(80, False, '\n'+'#' * cell.level+' ')}}
+{{ '#' * cell.level }} {{ cell.source }}
 
 {% endblock headingcell %}
 

--- a/IPython/nbconvert/templates/rst.tpl
+++ b/IPython/nbconvert/templates/rst.tpl
@@ -64,7 +64,7 @@ Out[{{cell.prompt_number}}]:{% endif %}{% endblock output_prompt %}
 
 {% block headingcell scoped %}
 {%- set len = cell.source|length -%}
-{{ cell.source}}
+{{ cell.source | markdown2rst}}
 {% if cell.level == 1 %}
 {{- '=' * len }}
 {%- elif cell.level == 2 %}

--- a/IPython/nbconvert/templates/rst.tpl
+++ b/IPython/nbconvert/templates/rst.tpl
@@ -64,7 +64,7 @@ Out[{{cell.prompt_number}}]:{% endif %}{% endblock output_prompt %}
 
 {% block headingcell scoped %}
 {%- set len = cell.source|length -%}
-{{ cell.source | markdown2rst}}
+{{ cell.source | markdown2rst }}
 {% if cell.level == 1 %}
 {{- '=' * len }}
 {%- elif cell.level == 2 %}


### PR DESCRIPTION
@minrk as posted a PR where provides the possibility to write markdown in heading cells: https://github.com/ipython/ipython/pull/3531

@Carreau has pointed out the need of a counterpart in the nbconvert machinery.

@jakobgager and @jdfreder have pointed out that the latex exporter already supported markdown in heading.

So, I have made some little changes for the remaining basic templates: basichtml, rst, markdown (python tpl don't need changes) to cover this issue from the nbconvert machinery point of view.

Damián. 
