### PR TITLE
Added the possibility to read a custom.css file for tweaking the final html in full_html and reveal templates.

### DIFF
--- a/IPython/nbconvert/templates/fullhtml.tpl
+++ b/IPython/nbconvert/templates/fullhtml.tpl
@@ -28,6 +28,9 @@ pre {
 }
 </style>
 
+<!-- Custom stylesheet, it must be in the same directory as the html file -->
+<link rel="stylesheet" href="custom.css">
+
 <script src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS_HTML" type="text/javascript">
 
 </script>

--- a/IPython/nbconvert/templates/reveal.tpl
+++ b/IPython/nbconvert/templates/reveal.tpl
@@ -85,6 +85,10 @@ div.output_prompt {
 text-align: inherit;
 }
 </style>
+
+<!-- Custom stylesheet, it must be in the same directory as the html file -->
+<link rel="stylesheet" href="custom.css">
+
 </head>
 {% endblock header%}
 


### PR DESCRIPTION
The idea behind this PR is give to the advanced users the possibility to add a custom.css in the same directory where the final html (full_html or reveal) lives to easily changes some specific css.

This PR follow the same idea of live slidemode where you can define a custom.css file (now named main.css).

@fperez also suggest this kind of customization when I explain my PR about customizing things with the notebook UI (https://github.com/ipython/ipython/pull/3432), which I believe is important from the design point of view for some users, but will be released as a extension. 

For example, a use case: 
- to use the darker themes in reveal, you have to add some css modifications... and do it editing by hand the html source code is a pain...

Following the self-campaign of at least one tiny but useful (I think) PR a day... I wait for your comments ;-)

Damián.
