### PR TITLE
don't blacklist builtin names

### DIFF
--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -173,10 +173,6 @@ class Config(dict):
             return dict.__getitem__(self, key)
 
     def __setitem__(self, key, value):
-        # Don't allow names in __builtin__ to be modified.
-        if hasattr(builtin_mod, key):
-            raise ConfigError('Config variable names cannot have the same name '
-                              'as a Python builtin: %s' % key)
         if self._is_section_key(key):
             if not isinstance(value, Config):
                 raise ValueError('values whose keys begin with an uppercase '

--- a/IPython/config/tests/test_loader.py
+++ b/IPython/config/tests/test_loader.py
@@ -258,7 +258,7 @@ class TestConfig(TestCase):
         c1 = Config()
         exec 'foo = True' in c1
         self.assertEqual(c1.foo, True)
-        self.assertRaises(ConfigError, setattr, c1, 'ValueError', 10)
+        c1.format = "json"
     
     def test_fromdict(self):
         c1 = Config({'Foo' : {'bar' : 1}})


### PR DESCRIPTION
It is wholly appropriate for a class to have a `format` trait, or similar, but Config prohibits trait names that are in builtins.

This prohibition is simply removed.
