### PR TITLE
Fix duplicate completion in notebook

### DIFF
--- a/IPython/html/static/notebook/js/completer.js
+++ b/IPython/html/static/notebook/js/completer.js
@@ -15,10 +15,10 @@ var IPython = (function (IPython) {
     }
 
     function _existing_completion(item, completion_array){
-       for( var c in completion_array ) {
-           if(completion_array[c].substr(-item.length) == item)
-           { return true; }
-       }
+        for( var c in completion_array ) {
+            if(completion_array[c].trim().substr(-item.length) == item)
+            { return true; }
+        }
        return false;
     }
 


### PR DESCRIPTION
comparaison between kernel completion and context-completin were
returning duplicate entry in some cases, due to trailing space.
sripping trailing space in comparaison prevent this.

fixes #3563

example

```
import bar
from foo im<tab>
```

used to propose `import` twice (actually `import` and `import[space]` as
`import` was a token on the first line) now just complete directly to
`import[space]`.
