### PR TITLE
push cell magic to the head of the transformer line

### DIFF
--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -487,11 +487,11 @@ class IPythonInputSplitter(InputSplitter):
             self.physical_line_transforms = physical_line_transforms
         else:
             self.physical_line_transforms = [
-                                             cellmagic(end_on_blank_line=line_input_checker),
                                              leading_indent(),
                                              classic_prompt(),
                                              ipy_prompt(),
                                              strip_encoding_cookie(),
+                                             cellmagic(end_on_blank_line=line_input_checker),
                                             ]
         
         self.assemble_logical_lines = assemble_logical_lines()

--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -486,7 +486,9 @@ class IPythonInputSplitter(InputSplitter):
         if physical_line_transforms is not None:
             self.physical_line_transforms = physical_line_transforms
         else:
-            self.physical_line_transforms = [leading_indent(),
+            self.physical_line_transforms = [
+                                             cellmagic(end_on_blank_line=line_input_checker),
+                                             leading_indent(),
                                              classic_prompt(),
                                              ipy_prompt(),
                                              strip_encoding_cookie(),
@@ -496,7 +498,7 @@ class IPythonInputSplitter(InputSplitter):
         if logical_line_transforms is not None:
             self.logical_line_transforms = logical_line_transforms
         else:
-            self.logical_line_transforms = [cellmagic(end_on_blank_line=line_input_checker),
+            self.logical_line_transforms = [
                                             help_end(),
                                             escaped_commands(),
                                             assign_from_magic(),

--- a/IPython/core/inputtransformer.py
+++ b/IPython/core/inputtransformer.py
@@ -329,7 +329,14 @@ def cellmagic(end_on_blank_line=False):
     line = ''
     while True:
         line = (yield line)
-        if (not line) or (not line.startswith(ESC_MAGIC2)):
+        # consume leading empty lines
+        while not line:
+            line = (yield line)
+        
+        if not line.startswith(ESC_MAGIC2):
+            # This isn't a cell magic, idle waiting for reset then start over
+            while line is not None:
+                line = (yield line)
             continue
         
         if cellmagic_help_re.match(line):

--- a/IPython/core/inputtransformer.py
+++ b/IPython/core/inputtransformer.py
@@ -272,7 +272,8 @@ _help_end_re = re.compile(r"""(%{0,2}
                               [a-zA-Z_*][\w*]*        # Variable name
                               (\.[a-zA-Z_*][\w*]*)*   # .etc.etc
                               )
-                              (\?\??)$                # ? or ??""",
+                              (\?\??)$                # ? or ??
+                              """,
                               re.VERBOSE)
 
 def has_comment(src):

--- a/IPython/core/inputtransformer.py
+++ b/IPython/core/inputtransformer.py
@@ -3,7 +3,6 @@ import functools
 import re
 from StringIO import StringIO
 
-from IPython.core.error import UsageError
 from IPython.core.splitinput import LineInfo
 from IPython.utils import tokenize2
 from IPython.utils.openpy import cookie_comment_re
@@ -233,15 +232,6 @@ def _tr_magic(line_info):
     cmd = ' '.join([line_info.ifun, line_info.the_rest]).strip()
     return tpl % (line_info.pre, cmd)
 
-def _tr_cellmagic(line_info):
-    """Translate lines escaped with %%
-    
-    Only happens when cell magics are mid-cell, which is an error.
-    """
-    raise UsageError("Cannot call cell magics (%s%s) mid-cell" % 
-        (ESC_MAGIC2, line_info.ifun)
-    )
-
 def _tr_quote(line_info):
     "Translate lines escaped with: ,"
     return '%s%s("%s")' % (line_info.pre, line_info.ifun,
@@ -262,7 +252,6 @@ tr = { ESC_SHELL  : _tr_system,
        ESC_HELP   : _tr_help,
        ESC_HELP2  : _tr_help,
        ESC_MAGIC  : _tr_magic,
-       ESC_MAGIC2  : _tr_cellmagic,
        ESC_QUOTE  : _tr_quote,
        ESC_QUOTE2 : _tr_quote2,
        ESC_PAREN  : _tr_paren }

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1672,7 +1672,13 @@ class InteractiveShell(SingletonConfigurable):
         
         return etype, value, tb
     
-
+    def show_usage_error(self, exc):
+        """Show a short message for UsageErrors
+        
+        These are special exceptions that shouldn't show a traceback.
+        """
+        self.write_err("UsageError: %s" % exc)
+    
     def showtraceback(self,exc_tuple = None,filename=None,tb_offset=None,
                       exception_only=False):
         """Display the exception that just occurred.
@@ -1698,7 +1704,7 @@ class InteractiveShell(SingletonConfigurable):
                 # line, there may be SyntaxError cases with imported code.
                 self.showsyntaxerror(filename)
             elif etype is UsageError:
-                self.write_err("UsageError: %s" % value)
+                self.show_usage_error(value)
             else:
                 if exception_only:
                     stb = ['An exception has occurred, use %tb to see '
@@ -2597,8 +2603,8 @@ class InteractiveShell(SingletonConfigurable):
         try:
             self.input_transformer_manager.push(raw_cell)
             cell = self.input_transformer_manager.source_reset()
-        except UsageError:
-            self.showtraceback()
+        except UsageError as e:
+            self.show_usage_error(e)
             return
         
         # Our own compiler remembers the __future__ environment. If we want to

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2599,14 +2599,10 @@ class InteractiveShell(SingletonConfigurable):
         
         if silent:
             store_history = False
-        
-        try:
-            self.input_transformer_manager.push(raw_cell)
-            cell = self.input_transformer_manager.source_reset()
-        except UsageError as e:
-            self.show_usage_error(e)
-            return
-        
+
+        self.input_transformer_manager.push(raw_cell)
+        cell = self.input_transformer_manager.source_reset()
+
         # Our own compiler remembers the __future__ environment. If we want to
         # run code with a separate __future__ environment, use the default
         # compiler

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2593,10 +2593,14 @@ class InteractiveShell(SingletonConfigurable):
         
         if silent:
             store_history = False
-
-        self.input_transformer_manager.push(raw_cell)
-        cell = self.input_transformer_manager.source_reset()
-
+        
+        try:
+            self.input_transformer_manager.push(raw_cell)
+            cell = self.input_transformer_manager.source_reset()
+        except UsageError:
+            self.showtraceback()
+            return
+        
         # Our own compiler remembers the __future__ environment. If we want to
         # run code with a separate __future__ environment, use the default
         # compiler

--- a/IPython/core/splitinput.py
+++ b/IPython/core/splitinput.py
@@ -43,7 +43,7 @@ from IPython.utils.encoding import get_stream_enc
 
 line_split = re.compile("""
              ^(\s*)               # any leading space
-             ([,;/]|%%?|!!?|\?\??)?  # escape character or characters
+             ([,;/%]|!!?|\?\??)?  # escape character or characters
              \s*(%{0,2}[\w\.\*]*)     # function/method, possibly with leading %
                                   # to correctly treat things like '?%magic'
              (.*?$|$)             # rest of line

--- a/IPython/core/splitinput.py
+++ b/IPython/core/splitinput.py
@@ -43,7 +43,7 @@ from IPython.utils.encoding import get_stream_enc
 
 line_split = re.compile("""
              ^(\s*)               # any leading space
-             ([,;/%]|!!?|\?\??)?  # escape character or characters
+             ([,;/]|%%?|!!?|\?\??)?  # escape character or characters
              \s*(%{0,2}[\w\.\*]*)     # function/method, possibly with leading %
                                   # to correctly treat things like '?%magic'
              (.*?$|$)             # rest of line

--- a/IPython/core/tests/test_inputsplitter.py
+++ b/IPython/core/tests/test_inputsplitter.py
@@ -451,7 +451,9 @@ class IPythonInputTestCase(InputSplitterTestCase):
         isp = self.isp
         for raw, name, line, cell in [
             ("%%cellm a\nIn[1]:", u'cellm', u'a', u'In[1]:'),
-            ("%%cellm \n...:", u'cellm', u'', u'...:'),
+            ("%%cellm \nline\n>>>hi", u'cellm', u'', u'line\n>>>hi'),
+            (">>>%%cellm \nline\n>>>hi", u'cellm', u'', u'line\nhi'),
+            ("%%cellm \n>>>hi", u'cellm', u'', u'hi'),
             ("%%cellm \nline1\nline2", u'cellm', u'', u'line1\nline2'),
             ("%%cellm \nline1\\\\\nline2", u'cellm', u'', u'line1\\\\\nline2'),
         ]:

--- a/IPython/core/tests/test_inputsplitter.py
+++ b/IPython/core/tests/test_inputsplitter.py
@@ -446,6 +446,22 @@ class IPythonInputTestCase(InputSplitterTestCase):
                 out = isp.transform_cell(raw)
                 # Match ignoring trailing whitespace
                 self.assertEqual(out.rstrip(), out_t.rstrip())
+    
+    def test_cellmagic_preempt(self):
+        isp = self.isp
+        for raw, name, line, cell in [
+            ("%%cellm a\nIn[1]:", u'cellm', u'a', u'In[1]:'),
+            ("%%cellm \n...:", u'cellm', u'', u'...:'),
+            ("%%cellm \nline1\nline2", u'cellm', u'', u'line1\nline2'),
+            ("%%cellm \nline1\\\\\nline2", u'cellm', u'', u'line1\\\\\nline2'),
+        ]:
+            expected = "get_ipython().run_cell_magic(%r, %r, %r)" % (
+                name, line, cell
+            )
+            out = isp.transform_cell(raw)
+            self.assertEqual(out.rstrip(), expected.rstrip())
+        
+        
 
 #-----------------------------------------------------------------------------
 # Main - use as a script, mostly for developer experiments

--- a/IPython/core/tests/test_inputtransformer.py
+++ b/IPython/core/tests/test_inputtransformer.py
@@ -259,6 +259,9 @@ syntax_ml = \
           (u'hello', None),
           (None , u_fmt("get_ipython().run_cell_magic({u}'bar', {u}'123', {u}'hello')")),
           ],
+         [(u'a=5', 'a=5'),
+          (u'%%cellmagic', '%%cellmagic'),
+          ],
        ],
        
        escaped =


### PR DESCRIPTION
I'm not 100% sure this is the right fix (ping @takluyver for review), since it is unclear to me what the physical/logical distinction is.

but this does allow the cell magic transform to preempt all other transforms.

Possible alternative: put cell magic at the end of the physical line, which would enable a single use case: copy/paste of cell magic to the terminal with prompts.

closes #3604
