### PR TITLE
check for markdown no longer needed, closes #3610

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -278,7 +278,7 @@ if 'setuptools' in sys.modules:
         doc = 'Sphinx>=0.3',
         test = 'nose>=0.10.1',
         notebook = ['tornado>=2.0', 'pyzmq>=2.1.11', 'jinja2'],
-        nbconvert = ['pygments', 'markdown', 'jinja2', 'Sphinx>=0.3']
+        nbconvert = ['pygments', 'jinja2', 'Sphinx>=0.3']
     )
     requires = setup_args.setdefault('install_requires', [])
     setupext.display_status = False

--- a/setupbase.py
+++ b/setupbase.py
@@ -355,7 +355,7 @@ def check_for_dependencies():
         check_for_sphinx, check_for_pygments,
         check_for_nose, check_for_pexpect,
         check_for_pyzmq, check_for_readline,
-        check_for_jinja2, check_for_markdown
+        check_for_jinja2
     )
     print_line()
     print_raw("BUILDING IPYTHON")
@@ -374,7 +374,6 @@ def check_for_dependencies():
     check_for_pyzmq()
     check_for_readline()
     check_for_jinja2()
-    check_for_markdown()
 
 #---------------------------------------------------------------------------
 # VCS related

--- a/setupext/setupext.py
+++ b/setupext/setupext.py
@@ -93,16 +93,6 @@ def check_for_jinja2():
         print_status('jinja2', jinja2.__version__)
         return True
 
-def check_for_markdown():
-    try:
-        import markdown
-    except ImportError:
-        print_status('pygments', "Not found (required for nbconvert)")
-        return False
-    else:
-        print_status('markdown', markdown.version)
-        return True
-
 def check_for_nose():
     try:
         import nose


### PR DESCRIPTION
After #3582 was merged, we no longer depend on a python version of
markdown.

This closes #3610
