### PR TITLE
fix regular expression for ANSI escapes

### DIFF
--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -178,11 +178,11 @@ IPython.utils = (function (IPython) {
           // `\033[Xm` == `\033[0;Xm` sets foreground color to `X`.
           //
           str = str.replace(
-              new RegExp('\033\\[([01];)?' + ansi + 'm', 'g'), span
+              new RegExp('\033\\[(0?[01];)?' + ansi + 'm', 'g'), span
           );
         });
 
-        str = str.replace(/\033\[([01]|39|22)?m/g, '</span>');
+        str = str.replace(/\033\[(0?[01]|39|22)?m/g, '</span>');
         return str;
       };
     


### PR DESCRIPTION
wouldn't catch `\x1b[01;`, only `\x1b[0;` or `\x1b[1;`.

closes #3614
