### PR TITLE
Fix test for Python 3 on Windows.

### DIFF
--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -252,13 +252,15 @@ class TestMagicRunSimple(tt.TempFileMixin):
         class secondtmp(tt.TempFileMixin): pass
         empty = secondtmp()
         empty.mktmp('')
+        # On Windows, the filename will have \users in it, so we need to use the
+        # repr so that the \u becomes \\u.
         src = ("ip = get_ipython()\n"
                "for i in range(5):\n"
                "   try:\n"
-               "       ip.magic('run %s')\n"
+               "       ip.magic(%r)\n"
                "   except NameError as e:\n"
                "       print(i)\n"
-               "       break\n" % empty.fname)
+               "       break\n" % ('run ' + empty.fname))
         self.mktmp(src)
         _ip.magic('run %s' % self.fname)
         _ip.run_cell('ip == get_ipython()')


### PR DESCRIPTION
IPython.core.tests.test_run.test_aggressive_namespace_cleanup was recently enabled, but the test itself had a problem under Python 3 and Windows:

https://jenkins.shiningpanda-ci.com/ipython/job/ipython-win-py33/24/console
