### PR TITLE
Use new entry point for python -m IPython

### DIFF
--- a/IPython/__main__.py
+++ b/IPython/__main__.py
@@ -9,6 +9,6 @@
 #  The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from IPython.terminal.ipapp import launch_new_instance
+from IPython import start_ipython
 
-launch_new_instance()
+start_ipython()


### PR DESCRIPTION
`python -m IPython` also works. This just makes the official `start_ipython` entry point more obvious.
