### PR TITLE
increase patience for slow kernel startup in tests

### DIFF
--- a/IPython/kernel/tests/test_message_spec.py
+++ b/IPython/kernel/tests/test_message_spec.py
@@ -32,6 +32,10 @@ def setup():
     KC.start_channels()
     
     # wait for kernel to be ready
+    try:
+        msg = KC.iopub_channel.get_msg(block=True, timeout=10)
+    except Empty:
+        pass
     KC.execute("pass")
     KC.get_shell_msg(block=True, timeout=5)
     flush_channels()


### PR DESCRIPTION
should decrease the false CI test failures with `Empty` on slow testing VMs.

If _this_ PR has a false-positive failure, then I was definitely wrong.
