### PR TITLE
don't assume tested ipython is on the PATH

### DIFF
--- a/IPython/terminal/console/tests/test_console.py
+++ b/IPython/terminal/console/tests/test_console.py
@@ -20,7 +20,6 @@ from nose import SkipTest
 
 from IPython.testing import decorators as dec
 from IPython.utils import py3compat
-from IPython.utils.process import find_cmd
 
 #-----------------------------------------------------------------------------
 # Test functions begin
@@ -31,7 +30,19 @@ def test_console_starts():
     """test that `ipython console` starts a terminal"""
     from IPython.external import pexpect
     
-    p = pexpect.spawn(sys.executable, args=['-m', 'IPython', 'console', '--colors=NoColor'])
+    args = ['console', '--colors=NoColor']
+    # FIXME: remove workaround for 2.6 support
+    if sys.version_info[:2] > (2,6):
+        args = ['-m', 'IPython'] + args
+        cmd = sys.executable
+    else:
+        cmd = 'ipython'
+    
+    try:
+        p = pexpect.spawn(cmd, args=args)
+    except IOError:
+        raise SkipTest("Couldn't find command %s" % cmd)
+    
     idx = p.expect([r'In \[\d+\]', pexpect.EOF], timeout=15)
     nt.assert_equal(idx, 0, "expected in prompt")
     p.sendline('5')

--- a/IPython/terminal/console/tests/test_console.py
+++ b/IPython/terminal/console/tests/test_console.py
@@ -1,6 +1,6 @@
 """Tests for two-process terminal frontend
 
-Currenlty only has the most simple test possible, starting a console and running
+Currently only has the most simple test possible, starting a console and running
 a single command.
 
 Authors:
@@ -12,6 +12,7 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
+import sys
 import time
 
 import nose.tools as nt
@@ -30,19 +31,7 @@ def test_console_starts():
     """test that `ipython console` starts a terminal"""
     from IPython.external import pexpect
     
-    # weird IOErrors prevent this from firing sometimes:
-    ipython_cmd = None
-    for i in range(5):
-        try:
-            ipython_cmd = find_cmd('ipython3' if py3compat.PY3 else 'ipython')
-        except IOError:
-            time.sleep(0.1)
-        else:
-            break
-    if ipython_cmd is None:
-        raise SkipTest("Could not determine ipython command")
-    
-    p = pexpect.spawn(ipython_cmd, args=['console', '--colors=NoColor'])
+    p = pexpect.spawn(sys.executable, args=['-m', 'IPython', 'console', '--colors=NoColor'])
     idx = p.expect([r'In \[\d+\]', pexpect.EOF], timeout=15)
     nt.assert_equal(idx, 0, "expected in prompt")
     p.sendline('5')

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -188,7 +188,11 @@ def ipexec(fname, options=None):
     _ip = get_ipython()
     test_dir = os.path.dirname(__file__)
     
-    ipython_cmd = pipes.quote(sys.executable) + " -m IPython"
+    # FIXME: remove workaround for 2.6 support
+    if sys.version_info[:2] > (2,6):
+        ipython_cmd = pipes.quote(sys.executable) + " -m IPython"
+    else:
+        ipython_cmd = "ipython"
     # Absolute path for filename
     full_fname = os.path.join(test_dir, fname)
     full_cmd = '%s %s %s' % (ipython_cmd, cmdargs, full_fname)

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -187,7 +187,7 @@ def ipexec(fname, options=None):
     _ip = get_ipython()
     test_dir = os.path.dirname(__file__)
 
-    ipython_cmd = find_cmd('ipython3' if py3compat.PY3 else 'ipython')
+    ipython_cmd = [sys.executable, '-m', 'IPython']
     # Absolute path for filename
     full_fname = os.path.join(test_dir, fname)
     full_cmd = '%s %s %s' % (ipython_cmd, cmdargs, full_fname)

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -37,7 +37,7 @@ except ImportError:
     has_nose = False
 
 from IPython.config.loader import Config
-from IPython.utils.process import find_cmd, getoutputerror
+from IPython.utils.process import getoutputerror
 from IPython.utils.text import list_strings
 from IPython.utils.io import temp_pyfile, Tee
 from IPython.utils import py3compat

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 #-----------------------------------------------------------------------------
 
 import os
+import pipes
 import re
 import sys
 import tempfile
@@ -157,7 +158,7 @@ def default_config():
 def ipexec(fname, options=None):
     """Utility to call 'ipython filename'.
 
-    Starts IPython witha minimal and safe configuration to make startup as fast
+    Starts IPython with a minimal and safe configuration to make startup as fast
     as possible.
 
     Note that this starts IPython in a subprocess!
@@ -186,8 +187,8 @@ def ipexec(fname, options=None):
 
     _ip = get_ipython()
     test_dir = os.path.dirname(__file__)
-
-    ipython_cmd = [sys.executable, '-m', 'IPython']
+    
+    ipython_cmd = pipes.quote(sys.executable) + " -m IPython"
     # Absolute path for filename
     full_fname = os.path.join(test_dir, fname)
     full_cmd = '%s %s %s' % (ipython_cmd, cmdargs, full_fname)


### PR DESCRIPTION
Use more portable / reliable `python -m IPython`

especially helpful when there are many Pythons, or PATH is not reliable (Windows).
