### PR TITLE
Don't require HistoryManager to have a shell

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -634,8 +634,9 @@ class HistoryManager(HistoryAccessor):
                    '_ii': self._ii,
                    '_iii': self._iii,
                    new_i : self._i00 }
-
-        self.shell.push(to_main, interactive=False)
+        
+        if self.shell is not None:
+            self.shell.push(to_main, interactive=False)
 
     def store_output(self, line_num):
         """If database output logging is enabled, this saves all the


### PR DESCRIPTION
Allows use of HistoryManager to work with history database without a shell instance present.
