### PR TITLE
Fix store magic test 

### DIFF
--- a/IPython/extensions/tests/test_storemagic.py
+++ b/IPython/extensions/tests/test_storemagic.py
@@ -27,6 +27,6 @@ def test_store_restore():
     ip.magic('store -r')
     nt.assert_equal(ip.user_ns['foo'], 78)
     nt.assert_in('bar', ip.alias_manager.alias_table)
-    nt.assert_in(tmpd, ip.user_ns['_dh'])
+    nt.assert_in(os.path.realpath(tmpd), ip.user_ns['_dh'])
     
     os.rmdir(tmpd)


### PR DESCRIPTION
On MacOSX the temp dir in /var is symlinked into /private/var thus making this comparison fail. This pull request fixes the issue by using `os.path.realpath` to expand the tempdir into the real directory.
