### PR TITLE
fix AsyncResult.get_dict for single result

### DIFF
--- a/IPython/parallel/client/asyncresult.py
+++ b/IPython/parallel/client/asyncresult.py
@@ -195,15 +195,17 @@ class AsyncResult(object):
             results = [results]
         engine_ids = [ md['engine_id'] for md in self._metadata ]
         
-        seen = set()
-        for engine_id in engine_ids:
-            if engine_id in seen:
-                raise ValueError("Cannot build dict, %i jobs ran on engine #%i"%(
-                    engine_ids.count(engine_id), engine_id))
+        
+        rdict = {}
+        for engine_id, result in zip(engine_ids, results):
+            if engine_id in rdict:
+                raise ValueError("Cannot build dict, %i jobs ran on engine #%i" % (
+                    engine_ids.count(engine_id), engine_id)
+                )
             else:
-                seen.add(engine_id)
+                rdict[engine_id] = result
 
-        return dict(zip(engine_ids,results))
+        return rdict
 
     @property
     def result(self):

--- a/IPython/parallel/client/asyncresult.py
+++ b/IPython/parallel/client/asyncresult.py
@@ -191,12 +191,17 @@ class AsyncResult(object):
         """
 
         results = self.get(timeout)
+        if self._single_result:
+            results = [results]
         engine_ids = [ md['engine_id'] for md in self._metadata ]
-        bycount = sorted(engine_ids, key=lambda k: engine_ids.count(k))
-        maxcount = bycount.count(bycount[-1])
-        if maxcount > 1:
-            raise ValueError("Cannot build dict, %i jobs ran on engine #%i"%(
-                    maxcount, bycount[-1]))
+        
+        seen = set()
+        for engine_id in engine_ids:
+            if engine_id in seen:
+                raise ValueError("Cannot build dict, %i jobs ran on engine #%i"%(
+                    engine_ids.count(engine_id), engine_id))
+            else:
+                seen.add(engine_id)
 
         return dict(zip(engine_ids,results))
 


### PR DESCRIPTION
and add tests for single-result and invalid input (multiple results on one engine).

closes #3646
