### PR TITLE
Fix, config_file_name was ignored

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -87,7 +87,7 @@ class BaseIPythonApplication(Application):
     # because some logic happens only if we aren't using the default.
     config_file_specified = Set()
 
-    config_file_name = Unicode(u'ipython_config.py')
+    config_file_name = Unicode()
     def _config_file_name_default(self):
         return self.name.replace('-','_') + u'_config.py'
     def _config_file_name_changed(self, name, old, new):
@@ -141,7 +141,7 @@ class BaseIPythonApplication(Application):
 
     config_files = List(Unicode)
     def _config_files_default(self):
-        return [u'ipython_config.py']
+        return [self.config_file_name]
 
     copy_config_files = Bool(False, config=True,
         help="""Whether to install the default config files into the profile dir.


### PR DESCRIPTION
There are two small fixes in this PR.
1. The default hard coded value was removed from _config_file_name_ since that prevented __config_file_name_default_ from ever being called (which makes it pointless).  Also the __config_file_name_default_ method pro grammatically generated the same value.
2. The hard coded value for __config_files_default_ was replaced with a reference to _config_file_name_.  If this isn't done, _config_file_name_ never gets referenced and is thus useless.

I was forced to deal with this when I found _self.config_file_name = Unicode(u'something.py')_ was no longer working for classes inheriting from _BaseIPythonApplication_
