### PR TITLE
refocus active cell on dialog close

### DIFF
--- a/IPython/html/static/base/js/dialog.js
+++ b/IPython/html/static/base/js/dialog.js
@@ -64,6 +64,14 @@ IPython.dialog = (function (IPython) {
                 dialog.remove();
             });
         }
+        if (options.reselect_cell !== false) {
+            dialog.on("hidden", function () {
+                if (IPython.notebook) {
+                    cell = IPython.notebook.get_selected_cell();
+                    if (cell) cell.select();
+                }
+            });
+        }
         
         return dialog.modal(options);
     }


### PR DESCRIPTION
if there is one.

Otherwise, the cursor is lost on kernel restart, etc.
