### PR TITLE
fix windows error

### DIFF
--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -190,7 +190,7 @@ def ipexec(fname, options=None):
     
     # FIXME: remove workaround for 2.6 support
     if sys.version_info[:2] > (2,6):
-        ipython_cmd = pipes.quote(sys.executable) + " -m IPython"
+        ipython_cmd = sys.executable + " -m IPython"
     else:
         ipython_cmd = "ipython"
     # Absolute path for filename


### PR DESCRIPTION
excessive quoting of the excutable was producing errors like this:

"The filename, directory name, or volume label syntax is incorrect."

without this patch, the quickest way to get a failing test is via `iptest IPython.testing`
