### PR TITLE
remove special-case in get_home_dir for frozen dists

### DIFF
--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -172,8 +172,7 @@ class HomeDirError(Exception):
 def get_home_dir(require_writable=False):
     """Return the 'home' directory, as a unicode string.
 
-    * First, check for frozen env in case of py2exe
-    * Otherwise, defer to os.path.expanduser('~')
+    Uses os.path.expanduser('~'), and checks for writability.
     
     See stdlib docs for how this is determined.
     $HOME is first priority on *ALL* platforms.
@@ -189,19 +188,6 @@ def get_home_dir(require_writable=False):
             The path is resolved, but it is not guaranteed to exist or be writable.
     """
 
-    # first, check py2exe distribution root directory for _ipython.
-    # This overrides all. Normally does not exist.
-
-    if hasattr(sys, "frozen"): #Is frozen by py2exe
-        if '\\library.zip\\' in IPython.__file__.lower():#libraries compressed to zip-file
-            root, rest = IPython.__file__.lower().split('library.zip')
-        else:
-            root=os.path.join(os.path.split(IPython.__file__)[0],"../../")
-        root=os.path.abspath(root).rstrip('\\')
-        if _writable_dir(os.path.join(root, '_ipython')):
-            os.environ["IPYKITROOT"] = root
-        return py3compat.cast_unicode(root, fs_encoding)
-    
     homedir = os.path.expanduser('~')
     # Next line will make things work even when /home/ is a symlink to
     # /usr/home as it is on FreeBSD, for example

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -126,13 +126,14 @@ with_environment = with_setup(setup_environment, teardown_environment)
 def test_get_home_dir_1():
     """Testcase for py2exe logic, un-compressed lib
     """
+    unfrozen = path.get_home_dir()
     sys.frozen = True
 
     #fake filename for IPython.__init__
     IPython.__file__ = abspath(join(HOME_TEST_DIR, "Lib/IPython/__init__.py"))
 
     home_dir = path.get_home_dir()
-    nt.assert_equal(home_dir, abspath(HOME_TEST_DIR))
+    nt.assert_equal(home_dir, unfrozen)
 
 
 @skip_if_not_win32
@@ -140,12 +141,13 @@ def test_get_home_dir_1():
 def test_get_home_dir_2():
     """Testcase for py2exe logic, compressed lib
     """
+    unfrozen = path.get_home_dir()
     sys.frozen = True
     #fake filename for IPython.__init__
     IPython.__file__ = abspath(join(HOME_TEST_DIR, "Library.zip/IPython/__init__.py")).lower()
 
     home_dir = path.get_home_dir(True)
-    nt.assert_equal(home_dir, abspath(HOME_TEST_DIR).lower())
+    nt.assert_equal(home_dir, unfrozen)
 
 
 @with_environment

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -103,7 +103,7 @@ def setup_environment():
 
 
 def teardown_environment():
-    """Restore things that were remebered by the setup_environment function
+    """Restore things that were remembered by the setup_environment function
     """
     (oldenv, os.name, sys.platform, path.get_home_dir, IPython.__file__, old_wd) = oldstuff
     os.chdir(old_wd)


### PR DESCRIPTION
This doesn't seem to be the right logic anymore.

closes #2702
