### PR TITLE
Fixing some css minors in full_html and reveal.

### DIFF
--- a/IPython/nbconvert/templates/fullhtml.tpl
+++ b/IPython/nbconvert/templates/fullhtml.tpl
@@ -22,6 +22,7 @@ body {
 }
 
 pre {
+    padding: 0.2em;
     border: none;
     margin: 0px;
     font-size: 13px;

--- a/IPython/nbconvert/templates/reveal.tpl
+++ b/IPython/nbconvert/templates/reveal.tpl
@@ -79,7 +79,7 @@ font-size: 80%;
 }
 div.output_prompt {
     /* 5px right shift to account for margin in parent container */
-    margin: 5px 5px 0 -5px;
+    margin: 5px 5px 0 0;
 }
 .rendered_html p {
 text-align: inherit;


### PR DESCRIPTION
There are some issues in the padding of pre tag making the cell bigger and with lot of space around the text in the full_html template, so I put a reasonable padding to fit the cell in a proper way...
And I have also aligned the output prompt with the imput prompt in the reveal template.

Damián.
