### PR TITLE
Fix rename notebook - show error with invalid name

### DIFF
--- a/IPython/html/static/notebook/js/savewidget.js
+++ b/IPython/html/static/notebook/js/savewidget.js
@@ -87,6 +87,7 @@ var IPython = (function (IPython) {
                             "have 1 or more characters and can contain any characters " +
                             "except :/\\. Please enter a new notebook name:"
                         );
+                        return false;
                     } else {
                         IPython.notebook.set_notebook_name(new_name);
                         IPython.notebook.save_notebook();


### PR DESCRIPTION
Before the dialog was closing anyway so you couldn't see the error message.
