### PR TITLE
remove pdf from display data_priority

### DIFF
--- a/IPython/nbconvert/templates/latex/base.tplx
+++ b/IPython/nbconvert/templates/latex/base.tplx
@@ -60,13 +60,6 @@ it introduces a new line
 \end{center}
 ((*- endblock -*))
 
-((*- block data_pdf -*))
-\begin{center}
-\includegraphics[width=0.7\textwidth]{(((output.pdf_filename[:-4])))}
-\par
-\end{center}
-((*- endblock -*))
-
 ((* block pyout *))
 ((* block data_priority scoped *))((( super() )))((* endblock *))
 ((* endblock pyout *))

--- a/IPython/nbconvert/templates/latex/skeleton/display_priority.tplx
+++ b/IPython/nbconvert/templates/latex/skeleton/display_priority.tplx
@@ -6,10 +6,6 @@
 
 ((*- block data_priority scoped -*))
     ((*- for type in output | filter_data_type -*))
-        ((*- if type in ['pdf']*))
-            ((*- block data_pdf -*))
-            ((*- endblock -*))
-        ((*- endif -*))
         ((*- if type in ['svg']*))
             ((*- block data_svg -*))
             ((*- endblock -*))

--- a/IPython/nbconvert/templates/latex/sphinx_base.tplx
+++ b/IPython/nbconvert/templates/latex/sphinx_base.tplx
@@ -358,10 +358,6 @@ Note: For best display, use latex syntax highlighting. =))
     ((( conditionally_center_output(insert_graphics(output.svg_filename)) )))
 ((*- endblock -*))
 
-((*- block data_pdf -*))
-    ((( conditionally_center_output(insert_graphics(output.pdf_filename[:-4])) )))
-((*- endblock -*))
-
 ((*- block data_latex *))
     ((* if resources.sphinx.centeroutput *))\begin{center}((* endif -*))((( output.latex | rm_math_space )))((*- if resources.sphinx.centeroutput *))\end{center} ((* endif -*))
 ((*- endblock -*))

--- a/IPython/nbconvert/templates/skeleton/display_priority.tpl
+++ b/IPython/nbconvert/templates/skeleton/display_priority.tpl
@@ -5,10 +5,6 @@
 
 {%- block data_priority scoped -%}
     {%- for type in output | filter_data_type -%}
-        {%- if type in ['pdf']%}
-            {%- block data_pdf -%}
-            {%- endblock -%}
-        {%- endif -%}
         {%- if type in ['svg']%}
             {%- block data_svg -%}
             {%- endblock -%}


### PR DESCRIPTION
rational is to have 1 to 1 mapping between stored data in notebook
and branches in templates.

If the fie need to be converted in another format then the
configurability of templates for filename in the notebook should allow
to do it.

basically if I have a foo.svg figure I want to include in the notebook,
the {{ svg block }} shoudl be able to include a name that is

foo.svg, or foo.png or foo.tiff or foo.gif

---

PR opened mainly for discussion.

I admit that I was the one who introduced the `pdf` block in display data priority, and forgot to remove it. 
hence the incomprehension.

I'll probably not be able to respond for quite some time as I'm traveling for the full day tomorrow.
