### PR TITLE
nbconvert: Add cwd to sys.path

### DIFF
--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -136,12 +136,12 @@ class NbConvertApp(BaseIPythonApplication):
     @catch_config_error
     def initialize(self, argv=None):
         super(NbConvertApp, self).initialize(argv)
-        self.init_path()
+        self.init_syspath()
         self.init_notebooks()
         self.init_writer()
 
 
-    def init_path(self):
+    def init_syspath(self):
         """
         Add the cwd to the sys.path ($PYTHONPATH)
         """

--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -145,7 +145,7 @@ class NbConvertApp(BaseIPythonApplication):
         """
         Add the cwd to the sys.path ($PYTHONPATH)
         """
-        sys.path.append(os.getcwd())
+        sys.path.insert(0, os.getcwd())
         
 
     def init_notebooks(self):

--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -136,8 +136,17 @@ class NbConvertApp(BaseIPythonApplication):
     @catch_config_error
     def initialize(self, argv=None):
         super(NbConvertApp, self).initialize(argv)
+        self.init_path()
         self.init_notebooks()
         self.init_writer()
+
+
+    def init_path(self):
+        """
+        Add the cwd to the sys.path ($PYTHONPATH)
+        """
+        sys.path.append(os.getcwd())
+        
 
     def init_notebooks(self):
         """Construct the list of notebooks.


### PR DESCRIPTION
This makes transformers and filters in the cwd load
from dotted object names.

_Disclaimer: The new init def is not required, I thought it looked better (so the initialize def only contains init_... functions).  If we remove it the changes are one line_
