### PR TITLE
nbconvert: Provide a more useful error for invalid use case.

### DIFF
--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -88,9 +88,7 @@ def catch_config_error(method, app, *args, **kwargs):
     try:
         return method(app, *args, **kwargs)
     except (TraitError, ArgumentError) as e:
-        app.print_description()
         app.print_help()
-        app.print_examples()
         app.log.fatal("Bad config encountered during initialization:")
         app.log.fatal(str(e))
         app.log.debug("Config at the time: %s", app.config)
@@ -337,6 +335,7 @@ class Application(SingletonConfigurable):
 
         If classes=False (the default), only flags and aliases are printed.
         """
+        self.print_description()
         self.print_subcommands()
         self.print_options()
 
@@ -355,6 +354,9 @@ class Application(SingletonConfigurable):
         else:
             print "To see all available configurables, use `--help-all`"
             print
+
+        self.print_examples()
+
 
     def print_description(self):
         """Print the application description."""
@@ -475,9 +477,7 @@ class Application(SingletonConfigurable):
             interpreted_argv = argv
 
         if any(x in interpreted_argv for x in ('-h', '--help-all', '--help')):
-            self.print_description()
             self.print_help('--help-all' in interpreted_argv)
-            self.print_examples()
             self.exit(0)
 
         if '--version' in interpreted_argv or '-V' in interpreted_argv:

--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -212,13 +212,7 @@ class NbConvertApp(BaseIPythonApplication):
 
         # If nothing was converted successfully, help the user.
         if conversion_success == 0:
-
-            # No notebooks were specified, show help.
-            if len(self.notebooks) == 0:
-                self.print_help()
-
-            # Show how to access help.
-            print('For help, use "ipython nbconvert --help"')
+            self.print_help()
 
 
 #-----------------------------------------------------------------------------

--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -203,9 +203,6 @@ class NbConvertApp(BaseIPythonApplication):
                       "\n\t" + "\n\t".join(get_export_names()),
                       file=sys.stderr)
                 sys.exit(-1)
-            # except Exception as e:
-                # print("Error: could not export '%s'" % notebook_filename, file=sys.stderr)
-                # print(e, file=sys.stderr)
             else:
                 self.writer.write(output, resources, notebook_name=notebook_name)
                 conversion_success += 1
@@ -213,6 +210,7 @@ class NbConvertApp(BaseIPythonApplication):
         # If nothing was converted successfully, help the user.
         if conversion_success == 0:
             self.print_help()
+            sys.exit(-1)
 
 
 #-----------------------------------------------------------------------------

--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -215,12 +215,10 @@ class NbConvertApp(BaseIPythonApplication):
 
             # No notebooks were specified, show help.
             if len(self.notebooks) == 0:
-                self.print_help()
+                self.print_examples()
 
-            # Notebooks were specified, but not converted successfully.  Show how
-            # to access help.
-            else:
-                print('For help, use "ipython nbconvert --help"')
+            # Show how to access help.
+            print('For help, use "ipython nbconvert --help"')
 
 
 #-----------------------------------------------------------------------------

--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -215,7 +215,7 @@ class NbConvertApp(BaseIPythonApplication):
 
             # No notebooks were specified, show help.
             if len(self.notebooks) == 0:
-                self.print_examples()
+                self.print_help()
 
             # Show how to access help.
             print('For help, use "ipython nbconvert --help"')


### PR DESCRIPTION
The previous help statement was not very usefull for users who
don't know how to use nbconvert (ironically, the exact set of
users who would encounter the error).

Output for `ipython nbconvert` failure now reads:

```
This application is used to convert notebook files (*.ipynb) to various other
formats.

Options
-------

Arguments that take values are actually convenience aliases to full
Configurables, whose aliases are listed on the help line. For more information
on full configurables, see '--help-all'.

--debug
    set log level to logging.DEBUG (maximize logging output)
--init
    Initialize profile with default config files.  This is equivalent
    to running `ipython profile create <profile>` prior to startup.
--quiet
    set log level to logging.CRITICAL (minimize logging output)
--stdout
    Write notebook output to stdout instead of files.
--profile=<Unicode> (BaseIPythonApplication.profile)
    Default: u'default'
    The IPython profile to use.
--notebooks=<List> (NbConvertApp.notebooks)
    Default: []
    List of notebooks to convert. Wildcards are supported. Filenames passed
    positionally will be added to the list.
--ipython-dir=<Unicode> (BaseIPythonApplication.ipython_dir)
    Default: u'/home/jonathan/.config/ipython'
    The name of the IPython directory. This directory is used for logging
    configuration (through profiles), history storage, etc. The default is
    usually $HOME/.ipython. This options can also be specified through the
    environment variable IPYTHONDIR.
--format=<CaselessStrEnum> (NbConvertApp.export_format)
    Default: 'full_html'
    Choices: ['basic_html', 'full_html', 'latex', 'markdown', 'python', 'reveal', 'rst', 'sphinx_howto', 'sphinx_manual']
    The export format to be used.
--writer=<DottedObjectName> (NbConvertApp.writer_class)
    Default: 'FilesWriter'
    Writer class used to write the  results of the conversion
--config=<Unicode> (BaseIPythonApplication.extra_config_file)
    Default: u''
    Path to an extra config file to load.
    If specified, load this config file in addition to any other IPython config.
--log-level=<Enum> (Application.log_level)
    Default: 30
    Choices: (0, 10, 20, 30, 40, 50, 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL')
    Set the log level by value or name.

To see all available configurables, use `--help-all`

Examples
--------

    The simplest way to use nbconvert is

    > ipython nbconvert mynotebook.ipynb

    which will convert mynotebook.ipynb to the default format (probably HTML).

    You can specify the export format with `--format`.
    Options include ['basic_html', 'full_html', 'latex', 'markdown', 'python', 'reveal', 'rst', 'sphinx_howto', 'sphinx_manual']

    > ipython nbconvert --format latex mynotebook.ipnynb

    You can also pipe the output to stdout, rather than a file

    > ipython nbconvert mynotebook.ipynb --stdout

    Multiple notebooks can be given at the command line in a couple of 
    different ways:

    > ipython nbconvert notebook*.ipynb
    > ipython nbconvert notebook1.ipynb notebook2.ipynb

    or you can specify the notebooks list in a config file, containing::

        c.NbConvertApp.notebooks = ["my_notebook.ipynb"]

    > ipython nbconvert --config mycfg.py
```
