### PR TITLE
Added rm_math_space to markdown cells in the basichtml.tpl to be rendered ok by mathjax after the nbconvertion.

### DIFF
--- a/IPython/nbconvert/templates/basichtml.tpl
+++ b/IPython/nbconvert/templates/basichtml.tpl
@@ -53,13 +53,13 @@ Out[{{cell.prompt_number}}]:
 
 {% block markdowncell scoped %}
 <div class="text_cell_render border-box-sizing rendered_html">
-{{ cell.source | markdown| rm_fake}}
+{{ cell.source | rm_math_space | markdown | rm_fake}}
 </div>
 {%- endblock markdowncell %}
 
 {% block headingcell scoped %}
 <div class="text_cell_render border-box-sizing rendered_html">
-  {{("#" * cell.level + cell.source) | replace('\n', ' ') | markdown | rm_fake | add_anchor }}
+  {{("#" * cell.level + cell.source) | replace('\n', ' ') | rm_math_space | markdown | rm_fake | add_anchor }}
 </div>
 {% endblock headingcell %}
 


### PR DESCRIPTION
This solves the issue https://github.com/ipython/ipython/issues/3739

Cheers.

Damián

PS: pinging @jdfreder who is renaming this function in other PR ;-)
