### PR TITLE
handle empty metadata in pyout messages more gracefully.

### DIFF
--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -255,6 +255,9 @@ var IPython = (function (IPython) {
 
 
     OutputArea.prototype.convert_mime_types = function (json, data) {
+        if (data === undefined) {
+            return json;
+        }
         if (data['text/plain'] !== undefined) {
             json.text = data['text/plain'];
         }


### PR DESCRIPTION
This was causing our fledgling pure Julia IPython kernel to fail to display data in the notebook since we don't populate the metadata hash and the notebook assumes that it will be populated in a way that mirrors the content.
