### PR TITLE
Add configurability to  tabcompletion timeout

### DIFF
--- a/IPython/terminal/console/interactiveshell.py
+++ b/IPython/terminal/console/interactiveshell.py
@@ -118,7 +118,7 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
         from IPython.core.completerlib import (module_completer,
                                                magic_run_completer, cd_completer)
         
-        self.Completer = ZMQCompleter(self, self.client)
+        self.Completer = ZMQCompleter(self, self.client, config=self.config)
         
 
         self.set_hook('complete_command', module_completer, str_key = 'import')


### PR DESCRIPTION
In zmqconsole, change default from 0.5 to 5 sec.

fixes 3768
