### PR TITLE
Update px pylab test to match new output of pylab

### DIFF
--- a/IPython/parallel/tests/test_magics.py
+++ b/IPython/parallel/tests/test_magics.py
@@ -322,8 +322,7 @@ class TestParallelMagics(ClusterTestCase, ParametricTestCase):
         with capture_output() as io:
             ip.magic("px %pylab inline")
         
-        self.assertTrue("Welcome to pylab" in io.stdout, io.stdout)
-        self.assertTrue("backend_inline" in io.stdout, io.stdout)
+        self.assertTrue("Populating the interactive namespace from numpy and matplotlib" in io.stdout, io.stdout)
         
         with capture_output() as io:
             ip.magic("px plot(rand(100))")


### PR DESCRIPTION
This is similar to the fix in #3722 but only exposed when running the tests with `--all`
