### PR TITLE
re-raise KeyboardInterrupt in raw_input

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -263,7 +263,13 @@ class Pdb(OldPdb):
 
     def interaction(self, frame, traceback):
         self.shell.set_completer_frame(frame)
-        OldPdb.interaction(self, frame, traceback)
+        while True:
+            try:
+                OldPdb.interaction(self, frame, traceback)
+            except KeyboardInterrupt:
+                self.shell.write("\nKeyboardInterrupt\n")
+            else:
+                break
 
     def new_do_up(self, arg):
         OldPdb.do_up(self, arg)

--- a/IPython/kernel/zmq/ipkernel.py
+++ b/IPython/kernel/zmq/ipkernel.py
@@ -766,6 +766,9 @@ class Kernel(Configurable):
                 ident, reply = self.session.recv(self.stdin_socket, 0)
             except Exception:
                 self.log.warn("Invalid Message:", exc_info=True)
+            except KeyboardInterrupt:
+                # re-raise KeyboardInterrupt, to truncate traceback
+                raise KeyboardInterrupt
             else:
                 break
         try:


### PR DESCRIPTION
shortens traceback when KeyboardInterrupt is caught deep within zmq.

closes #3786
