### PR TITLE
fix raw_input in qtconsole

### DIFF
--- a/IPython/qt/console/console_widget.py
+++ b/IPython/qt/console/console_widget.py
@@ -2060,6 +2060,7 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
                 self._prompt = prompt
                 self._prompt_html = None
 
+        self._flush_pending_stream()
         self._prompt_pos = self._get_end_cursor().position()
         self._prompt_started()
 


### PR DESCRIPTION
adds a flush, whose absence produced mis-measured prompts, including the prompt in the raw_input reply.

closes #3785
