### PR TITLE
Notebook storage to an OpenStack Swift cluster

### DIFF
--- a/IPython/html/services/notebooks/openstacknbmanager.py
+++ b/IPython/html/services/notebooks/openstacknbmanager.py
@@ -23,7 +23,7 @@ Authors:
 import datetime
 
 import pyrax
-from pyrax import pyrax.exceptions.NoSuchContainer as NoSuchContainer
+from pyrax import exceptions.NoSuchContainer as NoSuchContainer
 
 from tornado import web
 

--- a/IPython/html/services/notebooks/openstacknbmanager.py
+++ b/IPython/html/services/notebooks/openstacknbmanager.py
@@ -75,14 +75,14 @@ class OpenStackNotebookManager(NotebookManager):
             metadata = obj.get_metadata()
 
             name = metadata['x-object-meta-nbname']
-            self.mapping[id] = name
+            self.mapping[nb_id] = name
 
     def list_notebooks(self):
         """List all notebooks in the container.
 
         This version uses `self.mapping` as the authoritative notebook list.
         """
-        data = [dict(notebook_id=id,name=name) for id, name in self.mapping.items()]
+        data = [dict(notebook_id=nb_id,name=name) for nb_id, name in self.mapping.items()]
         data = sorted(data, key=lambda item: item['name'])
         return data
 

--- a/IPython/html/services/notebooks/openstacknbmanager.py
+++ b/IPython/html/services/notebooks/openstacknbmanager.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+# -*- coding: utf-8 -*-
+
+"""A notebook manager that uses OpenStack Swift object storage.
+
+Authors:
+
+* Kyle Kelley
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (C) 2013 The IPython Development Team
+#
+# Distributed under the terms of the BSD License. The full license is in
+# the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+import datetime
+
+from swiftclient import client
+
+from tornado import web
+
+from .nbmanager import NotebookManager
+from IPython.nbformat import current
+from IPython.utils.traitlets import Unicode, Instance
+from IPython.utils import tz
+
+#-----------------------------------------------------------------------------
+# Classes
+#-----------------------------------------------------------------------------
+
+class OpenStackNotebookManager(NotebookManager):
+
+    account_name = Unicode('', config=True, help='OpenStack account name.')
+    account_key = Unicode('', config=True, help='OpenStack account key.')
+    container = Unicode('', config=True, help='Container name for notebooks.')
+
+    def __init__(self, **kwargs):
+        super(OpenStackNotebookManager, self).__init__(**kwargs)
+        pass
+
+    def load_notebook_names(self):
+        """On startup load the notebook ids and names from OpenStack Swift.
+
+        The object names are the notebook ids and the notebook names are stored
+        as object metadata.
+        """
+        pass
+
+    def list_notebooks(self):
+        """List all notebooks in the container.
+
+        This version uses `self.mapping` as the authoritative notebook list.
+        """
+        pass
+
+    def read_notebook_object(self, notebook_id):
+        """Get the object representation of a notebook by notebook_id."""
+        pass
+
+    def write_notebook_object(self, nb, notebook_id=None):
+        """Save an existing notebook object by notebook_id."""
+        pass
+
+    def delete_notebook(self, notebook_id):
+        """Delete notebook by notebook_id."""
+        pass
+
+    def info_string(self):
+        pass

--- a/IPython/html/services/notebooks/openstacknbmanager.py
+++ b/IPython/html/services/notebooks/openstacknbmanager.py
@@ -23,6 +23,7 @@ Authors:
 import datetime
 
 import pyrax
+from pyrax import pyrax.exceptions.NoSuchContainer as NoSuchContainer
 
 from tornado import web
 
@@ -40,7 +41,7 @@ class OpenStackNotebookManager(NotebookManager):
     account_name = Unicode('', config=True, help='OpenStack account name.')
     account_key = Unicode('', config=True, help='OpenStack account key.')
     identity_type = Unicode('', config=True, help='OpenStack Identity type (e.g. rackspace)')
-    container = Unicode('', config=True, help='Container name for notebooks.')
+    container_name = Unicode('', config=True, help='Container name for notebooks.')
 
     def __init__(self, **kwargs):
         super(OpenStackNotebookManager, self).__init__(**kwargs)
@@ -48,7 +49,8 @@ class OpenStackNotebookManager(NotebookManager):
         pyrax.set_credentials(username=account_name, api_key=account_key)
         # Set the region, optionally
         # pyrax.set_setting("region", region) # e.g. "LON"
-        pass
+
+        self.cf = pyrax.cloudfiles
 
     def load_notebook_names(self):
         """On startup load the notebook ids and names from OpenStack Swift.
@@ -56,6 +58,15 @@ class OpenStackNotebookManager(NotebookManager):
         The object names are the notebook ids and the notebook names are stored
         as object metadata.
         """
+        # Cached version of the mapping of notebook IDs to notebook names
+        self.mapping = {}
+
+        try:
+            container = self.cf.get_container(self.container_name)
+        except NoSuchContainer:
+            container = self.cf.create_container(self.container_name)
+        objects = container.get_objects()
+
         pass
 
     def list_notebooks(self):
@@ -67,11 +78,50 @@ class OpenStackNotebookManager(NotebookManager):
 
     def read_notebook_object(self, notebook_id):
         """Get the object representation of a notebook by notebook_id."""
-        pass
+        if not self.notebook_exists(notebook_id):
+            raise web.HTTPError(404, u'Notebook does not exist: %s' % notebook_id)
+        try:
+            obj = self.container.get_object(notebook_id)
+            s = obj.get() # Read the file into s
+        except:
+            raise web.HTTPError(500, u'Notebook cannot be read.')
+        try:
+            nb = current.reads(s, u'json')
+        except:
+            raise web.HTTPError(500, u'Unreadable JSON notebook.')
+        # Todo: The last modified should actually be saved in the notebook document.
+        # We are just using the current datetime until that is implemented.
+        last_modified = tz.utcnow()
+        return last_modified, nb
 
     def write_notebook_object(self, nb, notebook_id=None):
         """Save an existing notebook object by notebook_id."""
-        pass
+
+        try:
+            new_name = nb.metadata.name
+        except AttributeError:
+            raise web.HTTPError(400, u'Missing notebook name')
+
+        if notebook_id is None:
+            notebook_id = self.new_notebook_id(new_name)
+
+        if notebook_id not in self.mapping:
+            raise web.HTTPError(404, u'Notebook does not exist: %s' % notebook_id)
+
+        try:
+            data = current.writes(nb, u'json')
+        except Exception as e:
+            raise web.HTTPError(400, u'Unexpected error while saving notebook: %s' % e)
+
+        metadata = {'nbname': new_name}
+        try:
+            obj = self.container.store_object(notebook_id, data)
+            obj.set_metadata(metadata)
+        except Exception as e:
+            raise web.HTTPError(400, u'Unexpected error while saving notebook: %s' % e)
+
+        self.mapping[notebook_id] = new_name
+        return notebook_id
 
     def delete_notebook(self, notebook_id):
         """Delete notebook by notebook_id."""

--- a/IPython/html/services/notebooks/openstacknbmanager.py
+++ b/IPython/html/services/notebooks/openstacknbmanager.py
@@ -144,6 +144,29 @@ class OpenStackNotebookManager(NotebookManager):
         else:
             self.delete_notebook_id(notebook_id)
 
+
+    # Checkpoint-related
+
+    def create_checkpoint(self, notebook_id):
+        """Create a checkpoint of the current state of a notebook
+
+        Returns a checkpoint_id for the new checkpoint.
+        """
+        raise web.HTTPError(405, "Checkpoints not implemented")
+
+    def list_checkpoints(self, notebook_id):
+        """Return a list of checkpoints for a given notebook"""
+        raise web.HTTPError(405, "Checkpoints not implemented")
+
+    def restore_checkpoint(self, notebook_id, checkpoint_id):
+        """Restore a notebook from one of its checkpoints"""
+        raise web.HTTPError(405, "Checkpoints not implemented")
+
+    def delete_checkpoint(self, notebook_id, checkpoint_id):
+        """delete a checkpoint for a notebook"""
+        raise web.HTTPError(405, "Checkpoints not implemented")
+
     def info_string(self):
         info = "Serving notebooks from OpenStack Swift storage: {},{}"
         return info.format(self.account_name, self.container_name)
+

--- a/IPython/html/services/notebooks/openstacknbmanager.py
+++ b/IPython/html/services/notebooks/openstacknbmanager.py
@@ -22,7 +22,7 @@ Authors:
 
 import datetime
 
-from swiftclient import client
+import pyrax
 
 from tornado import web
 
@@ -39,10 +39,15 @@ class OpenStackNotebookManager(NotebookManager):
 
     account_name = Unicode('', config=True, help='OpenStack account name.')
     account_key = Unicode('', config=True, help='OpenStack account key.')
+    identity_type = Unicode('', config=True, help='OpenStack Identity type (e.g. rackspace)')
     container = Unicode('', config=True, help='Container name for notebooks.')
 
     def __init__(self, **kwargs):
         super(OpenStackNotebookManager, self).__init__(**kwargs)
+        pyrax.set_setting("identity_type", identity_type)
+        pyrax.set_credentials(username=account_name, api_key=account_key)
+        # Set the region, optionally
+        # pyrax.set_setting("region", region) # e.g. "LON"
         pass
 
     def load_notebook_names(self):

--- a/IPython/html/services/notebooks/openstacknbmanager.py
+++ b/IPython/html/services/notebooks/openstacknbmanager.py
@@ -23,7 +23,7 @@ Authors:
 import datetime
 
 import pyrax
-from pyrax import exceptions.NoSuchContainer as NoSuchContainer
+from pyrax.exceptions import NoSuchContainer as NoSuchContainer
 
 from tornado import web
 

--- a/IPython/html/services/notebooks/openstacknbmanager.py
+++ b/IPython/html/services/notebooks/openstacknbmanager.py
@@ -71,7 +71,6 @@ class OpenStackNotebookManager(NotebookManager):
             nb_id = obj.name
             metadata = obj.get_metadata()
 
-            # OpenStack Swift prepends "x-object-meta-" to the metadata name
             name = metadata['x-object-meta-nbname']
             self.mapping[id] = name
 
@@ -121,7 +120,7 @@ class OpenStackNotebookManager(NotebookManager):
         except Exception as e:
             raise web.HTTPError(400, u'Unexpected error while saving notebook: %s' % e)
 
-        metadata = {'nbname': new_name}
+        metadata = {'x-object-meta-nbname': new_name}
         try:
             obj = self.container.store_object(notebook_id, data)
             obj.set_metadata(metadata)


### PR DESCRIPTION
This is just a shell so you can see what I'm up to. My goal is to make this work on anyone's deployment of OpenStack Swift ([CERN has a swift cluster, for example](http://www.theregister.co.uk/2013/07/01/rackspace_cern_openstack_partnership/)) as well as Rackspace's CloudFiles (which is OpenStack Swift underneath).  I'm largely following the model of the Azure notebook manager and the guidance in the superclass, `NotebookManager`.

Let me know what you think. I probably don't need to say this, but don't merge it yet!
