### PR TITLE
semantic-versionify version number for non-releases

### DIFF
--- a/IPython/core/release.py
+++ b/IPython/core/release.py
@@ -21,20 +21,20 @@ name = 'ipython'
 # version
 _version_major = 1
 _version_minor = 0
-_version_micro = 0  # use 0 for first of series, number for 1 and above
+_version_patch = 0
 _version_extra = 'dev'
 #_version_extra = 'rc1'
 # _version_extra = ''  # Uncomment this for full releases
 
 # Construct full version string from these.
-_ver = [_version_major, _version_minor]
-if _version_extra != 'dev':
-    _ver.append(_version_micro)
+_ver = [_version_major, _version_minor, _version_patch]
 
-__version__ = '.'.join(map(str, _ver)) + _version_extra
+__version__ = '.'.join(map(str, _ver))
+if _version_extra:
+    __version__ = __version__ + '-' + _version_extra
 
 version = __version__  # backwards compatibility name
-version_info = (_version_major, _version_minor, _version_micro, _version_extra)
+version_info = (_version_major, _version_minor, _version_patch, _version_extra)
 
 # Change this when incrementing the kernel protocol version
 kernel_protocol_version_info = (4, 0)


### PR DESCRIPTION
`1.0.0-dev` means development version leading up to 1.0.0.
