### PR TITLE
Make it clear that 1.0 is not released yet

### DIFF
--- a/docs/source/whatsnew/version1.0.rst
+++ b/docs/source/whatsnew/version1.0.rst
@@ -5,6 +5,10 @@
 Release 1.0
 ===========
 
+.. note::
+
+   This document describes a pre-release version of IPython.
+
 IPython 1.0 requires Python ≥ 2.6.5 or ≥ 3.2.1.
 It does not support Python 3.0, 3.1, or 2.5.
 
@@ -212,7 +216,7 @@ The javascript components used in the notebook have been updated significantly.
 Some relevant changes that are results of this:
 
 - Markdown cells now support GitHub-flavored Markdown (GFM),
-which includes ``\`\`\`python`` code blocks and tables.
+  which includes ``\`\`\`python`` code blocks and tables.
 - Notebook UI behaves better on more screen sizes.
 - Various code cell input issues have been fixed.
 


### PR DESCRIPTION
Our "What's new in 1.0" page got posted to HN, causing some confusion about our release (https://news.ycombinator.com/item?id=6116843 ). This adds a note at the top of that page that it is a pre-release version, which we should remove when we make the final release.
