### PR TITLE
add output flag to nbconvert

### DIFF
--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -23,7 +23,6 @@ import glob
 
 # From IPython
 from IPython.core.application import BaseIPythonApplication, base_aliases, base_flags
-from IPython.core.error import UsageError
 from IPython.config import catch_config_error, Configurable
 from IPython.utils.traitlets import (
     Unicode, List, Instance, DottedObjectName, Type, CaselessStrEnum,


### PR DESCRIPTION
fixes #3799

Cannot do it only in Writer as the basename can be used in templates as it is used for resources `to map to <basename>_files`. Here is my try on it.

Also we could be good practice to catch UsageError at high level and sys.exit only in one place.

ping @jdfreder.
