### PR TITLE
don't set target on internal markdown links

### DIFF
--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -321,7 +321,7 @@ var IPython = (function (IPython) {
             var html = marked.parser(marked.lexer(text));
             html = $(IPython.mathjaxutils.replace_math(html, math));
             // links in markdown cells should open in new tabs
-            html.find("a[href]").attr("target", "_blank");
+            html.find("a[href]").not('[href^="#"]').attr("target", "_blank");
             try {
                 this.set_rendered(html);
             } catch (e) {


### PR DESCRIPTION
simple in-page anchor-nav shouldn't open a new tab.
