### PR TITLE
update payload source

### DIFF
--- a/IPython/core/payloadpage.py
+++ b/IPython/core/payloadpage.py
@@ -82,7 +82,7 @@ def page(strng, start=0, screen_lines=0, pager_cmd=None,
             pass
         
     payload = dict(
-        source='IPython.kernel.zmq.page.page',
+        source='page',
         text=strng,
         html=html,
         start_line_number=start

--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -419,10 +419,10 @@ var IPython = (function (IPython) {
         // Payloads are handled by triggering events because we don't want the Kernel
         // to depend on the Notebook or Pager classes.
         for (var i=0; i<l; i++) {
-            if (payload[i].source === 'IPython.kernel.zmq.page.page') {
+            if (payload[i].source === 'page') {
                 var data = {'text':payload[i].text}
                 $([IPython.events]).trigger('open_with_text.Pager', data);
-            } else if (payload[i].source === 'IPython.kernel.zmq.zmqshell.ZMQInteractiveShell.set_next_input') {
+            } else if (payload[i].source === 'set_next_input') {
                 if (callbacks.set_next_input !== undefined) {
                     callbacks.set_next_input(payload[i].text)
                 }

--- a/IPython/kernel/zmq/zmqshell.py
+++ b/IPython/kernel/zmq/zmqshell.py
@@ -172,7 +172,7 @@ class KernelMagics(Magics):
 
         # Send the payload back so that clients can modify their prompt display
         payload = dict(
-            source='IPython.kernel.zmq.zmqshell.ZMQInteractiveShell.doctest_mode',
+            source='doctest_mode',
             mode=dstore.mode)
         shell.payload_manager.write_payload(payload)
         
@@ -324,7 +324,7 @@ class KernelMagics(Magics):
         filename = os.path.abspath(filename)
 
         payload = {
-            'source' : 'IPython.kernel.zmq.zmqshell.ZMQInteractiveShell.edit_magic',
+            'source' : 'edit_magic',
             'filename' : filename,
             'line_number' : lineno
         }
@@ -536,7 +536,7 @@ class ZMQInteractiveShell(InteractiveShell):
         """
         new = self.prompt_manager.render('rewrite') + cmd
         payload = dict(
-            source='IPython.kernel.zmq.zmqshell.ZMQInteractiveShell.auto_rewrite_input',
+            source='auto_rewrite_input',
             transformed_input=new,
             )
         self.payload_manager.write_payload(payload)
@@ -545,7 +545,7 @@ class ZMQInteractiveShell(InteractiveShell):
         """Engage the exit actions."""
         self.exit_now = True
         payload = dict(
-            source='IPython.kernel.zmq.zmqshell.ZMQInteractiveShell.ask_exit',
+            source='ask_exit',
             exit=True,
             keepkernel=self.keepkernel_on_exit,
             )
@@ -583,7 +583,7 @@ class ZMQInteractiveShell(InteractiveShell):
         """Send the specified text to the frontend to be presented at the next
         input cell."""
         payload = dict(
-            source='IPython.kernel.zmq.zmqshell.ZMQInteractiveShell.set_next_input',
+            source='set_next_input',
             text=text
         )
         self.payload_manager.write_payload(payload)

--- a/IPython/qt/console/ipython_widget.py
+++ b/IPython/qt/console/ipython_widget.py
@@ -105,10 +105,10 @@ class IPythonWidget(FrontendWidget):
 
     # IPythonWidget protected class variables.
     _PromptBlock = namedtuple('_PromptBlock', ['block', 'length', 'number'])
-    _payload_source_edit = zmq_shell_source + '.edit_magic'
-    _payload_source_exit = zmq_shell_source + '.ask_exit'
-    _payload_source_next_input = zmq_shell_source + '.set_next_input'
-    _payload_source_page = 'IPython.kernel.zmq.page.page'
+    _payload_source_edit = 'edit_magic'
+    _payload_source_exit = 'ask_exit'
+    _payload_source_next_input = 'set_next_input'
+    _payload_source_page = 'page'
     _retrying_history_request = False
 
     #---------------------------------------------------------------------------

--- a/docs/source/development/messaging.rst
+++ b/docs/source/development/messaging.rst
@@ -450,6 +450,10 @@ When status is 'ok', the following extra fields are present::
        ip.payload_manager.write_payload(payload_dict)
 
    which appends a dictionary to the list of payloads.
+   
+   The payload API is not yet stabilized,
+   and should probably not be supported by non-Python kernels at this time.
+   In such cases, the payload list should always be empty.
 
    
 When status is 'error', the following extra fields are present::


### PR DESCRIPTION
should be simple key, not Python- (or worse, IPython-) specific long key.

I could have sworn I did this long ago, but apparently the source key was only updated in display_data, not execute_reply.

Since the current state is internally inconsistent, marking for 1.0.
