### PR TITLE
nbconvert: Serve from original build directory

### DIFF
--- a/IPython/nbconvert/post_processors/serve.py
+++ b/IPython/nbconvert/post_processors/serve.py
@@ -19,7 +19,7 @@ import webbrowser
 from BaseHTTPServer import HTTPServer
 from SimpleHTTPServer import SimpleHTTPRequestHandler
 
-from IPython.utils.traitlets import Unicode, Bool
+from IPython.utils.traitlets import Bool
 
 from .base import PostProcessorBase
 
@@ -30,28 +30,24 @@ class ServePostProcessor(PostProcessorBase):
     """Post processor designed to serve files"""
 
 
-    build_directory = Unicode(".", config=True, 
-                              help="""Directory to write output to.  Leave blank
-                              to output to the current directory""")
-                              
     open_in_browser = Bool(True, config=True,
-                           help="""Set to False to deactivate 
+                           help="""Set to False to deactivate
                            the opening of the browser""")
 
     def call(self, input):
         """
         Simple implementation to serve the build directory.
         """
-        
+
         try:
-            os.chdir(self.build_directory)
+            dirname, filename = os.path.split(input)
+            os.chdir(dirname)
             httpd = HTTPServer(('127.0.0.1', 8000), SimpleHTTPRequestHandler)
             sa = httpd.socket.getsockname()
-            name = input[2:]
-            url = "http://" + sa[0] + ":" + str(sa[1]) + "/" + name
+            url = "http://" + sa[0] + ":" + str(sa[1]) + "/" + filename
             if self.open_in_browser:
                 webbrowser.open(url, new=2)
-            print("Serving " + name + " on " + url)
+            print("Serving your slides on " + url)
             print("Use Control-C to stop this server.")
             httpd.serve_forever()
         except KeyboardInterrupt:


### PR DESCRIPTION
The new `serve` post processor for nbconvert has a `build_directory` argument which I think is not really useful. I cannot really think of a situation where you want it to be different than the build directory of the original converter.

This change loses the `build_directory` argument and uses the path of the input file.

However, I'm not sure this plays well with notebooks in subdirectories. It certainly doesn't work well with external files referenced by relative paths, but I also don't think the original approach did. So it might need some more thinking.
