### PR TITLE
Add basic logging to nbconvert

### DIFF
--- a/IPython/nbconvert/exporters/export.py
+++ b/IPython/nbconvert/exporters/export.py
@@ -85,6 +85,7 @@ __all__ = [
 class ExporterNameError(NameError):
     pass
 
+_exporters = {}
 
 @DocDecorator
 def export(exporter, nb, **kw):
@@ -111,7 +112,9 @@ def export(exporter, nb, **kw):
     if isinstance(exporter, Exporter):
         exporter_instance = exporter
     else:
-        exporter_instance = exporter(**kw)
+        if exporter not in _exporters:
+            _exporters[exporter] = exporter(**kw)
+        exporter_instance = _exporters[exporter]
 
     #Try to convert the notebook using the appropriate conversion function.
     if isinstance(nb, NotebookNode):

--- a/IPython/nbconvert/exporters/export.py
+++ b/IPython/nbconvert/exporters/export.py
@@ -85,8 +85,6 @@ __all__ = [
 class ExporterNameError(NameError):
     pass
 
-_exporters = {}
-
 @DocDecorator
 def export(exporter, nb, **kw):
     """
@@ -112,13 +110,8 @@ def export(exporter, nb, **kw):
     if isinstance(exporter, Exporter):
         exporter_instance = exporter
     else:
-        if exporter not in _exporters:
-            exporter_instance = _exporters[exporter] = exporter(**kw)
-        else:
-            exporter_instance = _exporters[exporter]
-            for attr, value in kw.items():
-                setattr(exporter_instance, attr, value)
-
+        exporter_instance = exporter(**kw)
+    
     #Try to convert the notebook using the appropriate conversion function.
     if isinstance(nb, NotebookNode):
         output, resources = exporter_instance.from_notebook_node(nb, resources)

--- a/IPython/nbconvert/exporters/export.py
+++ b/IPython/nbconvert/exporters/export.py
@@ -113,8 +113,11 @@ def export(exporter, nb, **kw):
         exporter_instance = exporter
     else:
         if exporter not in _exporters:
-            _exporters[exporter] = exporter(**kw)
-        exporter_instance = _exporters[exporter]
+            exporter_instance = _exporters[exporter] = exporter(**kw)
+        else:
+            exporter_instance = _exporters[exporter]
+            for attr, value in kw.items():
+                setattr(exporter_instance, attr, value)
 
     #Try to convert the notebook using the appropriate conversion function.
     if isinstance(nb, NotebookNode):

--- a/IPython/nbconvert/exporters/export.py
+++ b/IPython/nbconvert/exporters/export.py
@@ -128,62 +128,27 @@ def export(exporter, nb, **kw):
         output, resources = exporter_instance.from_file(nb, resources)
     return output, resources
 
+exporter_map = dict(
+    custom=Exporter,
+    html=HTMLExporter,
+    slides=SlidesExporter,
+    latex=LatexExporter,
+    markdown=MarkdownExporter,
+    python=PythonExporter,
+    rst=RSTExporter,
+)
 
-@DocDecorator
-def export_custom(nb, **kw):
-    """
-    Export a notebook object to a custom format
-    """
-    return export(Exporter, nb, **kw)
+def _make_exporter(name, E):
+    """make an export_foo function from a short key and Exporter class E"""
+    def _export(nb, **kw):
+        return export(E, nb, **kw)
+    _export.__doc__ = """Export a notebook object to {0} format""".format(name)
+    return _export
+    
+g = globals()
 
-
-@DocDecorator
-def export_html(nb, **kw):
-    """
-    Export a notebook object to HTML
-    """
-    return export(HTMLExporter, nb, **kw)
-
-
-@DocDecorator
-def export_slides(nb, **kw):
-    """
-    Export a notebook object to Slides
-    """
-    return export(SlidesExporter, nb, **kw)
-
-
-@DocDecorator
-def export_latex(nb, **kw):
-    """
-    Export a notebook object to LaTeX
-    """
-    return export(LatexExporter, nb, **kw)
-
-
-@DocDecorator
-def export_markdown(nb, **kw):
-    """
-    Export a notebook object to Markdown
-    """
-    return export(MarkdownExporter, nb, **kw)
-
-
-@DocDecorator
-def export_python(nb, **kw):
-    """
-    Export a notebook object to Python
-    """
-    return export(PythonExporter, nb, **kw)
-
-
-@DocDecorator
-def export_rst(nb, **kw):
-    """
-    Export a notebook object to reStructuredText
-    """
-    return export(RSTExporter, nb, **kw)
-
+for name, E in exporter_map.items():
+    g['export_%s' % name] = DocDecorator(_make_exporter(name, E))
 
 @DocDecorator
 def export_by_name(format_name, nb, **kw):
@@ -208,10 +173,4 @@ def get_export_names():
     """Return a list of the currently supported export targets
 
     WARNING: API WILL CHANGE IN FUTURE RELEASES OF NBCONVERT"""
-    
-    # grab everything after 'export_'
-    l = [x[len('export_'):] for x in __all__ if x.startswith('export_')]
-    
-    # filter out the one method that is not a template
-    l = [x for x in l if 'by_name' not in x]
-    return sorted(l)
+    return sorted(exporter_map.keys())

--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -165,18 +165,13 @@ class Exporter(LoggingConfigurable):
         config : config
             User configuration instance.
         extra_loaders : list[of Jinja Loaders]
-            ordered list of Jinja loder to find templates. Will be tried in order
-            before the default FileSysteme ones.
+            ordered list of Jinja loader to find templates. Will be tried in order
+            before the default FileSystem ones.
         template : str (optional, kw arg)
             Template to use when exporting.
         """
         
-        #Call the base class constructor
-        c = self.default_config
-        if config:
-            c.merge(config)
-
-        super(Exporter, self).__init__(config=c, **kw)
+        super(Exporter, self).__init__(config=config, **kw)
 
         #Init
         self._init_template(**kw)
@@ -188,6 +183,14 @@ class Exporter(LoggingConfigurable):
     @property
     def default_config(self):
         return Config()
+    
+    def _config_changed(self, name, old, new):
+        c = self.default_config
+        if new:
+            c.merge(new)
+        if c != new:
+            self.config = c
+        
 
     def _load_template(self):
         if self.template is not None:

--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -185,6 +185,7 @@ class Exporter(LoggingConfigurable):
         return Config()
     
     def _config_changed(self, name, old, new):
+        """When setting config, make sure to start with our default_config"""
         c = self.default_config
         if new:
             c.merge(new)
@@ -193,6 +194,13 @@ class Exporter(LoggingConfigurable):
         
 
     def _load_template(self):
+        """Load the Jinja template object from the template file
+        
+        This is a no-op if the template attribute is already defined,
+        or the Jinja environment is not setup yet.
+        
+        This is triggered by various trait changes that would change the template.
+        """
         if self.template is not None:
             return
         # called too early, do nothing

--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -170,11 +170,13 @@ class Exporter(LoggingConfigurable):
         template : str (optional, kw arg)
             Template to use when exporting.
         """
+        if not config:
+            config = self.default_config
         
         super(Exporter, self).__init__(config=config, **kw)
 
         #Init
-        self._init_template(**kw)
+        self._init_template()
         self._init_environment(extra_loaders=extra_loaders)
         self._init_transformers()
         self._init_filters()
@@ -189,8 +191,9 @@ class Exporter(LoggingConfigurable):
         c = self.default_config
         if new:
             c.merge(new)
-        if c != new:
+        if c != old:
             self.config = c
+        super(Exporter, self)._config_changed(name, old, c)
         
 
     def _load_template(self):
@@ -382,14 +385,12 @@ class Exporter(LoggingConfigurable):
             raise TypeError('filter')
 
         
-    def _init_template(self, **kw):
+    def _init_template(self):
         """
         Make sure a template name is specified.  If one isn't specified, try to
         build one from the information we know.
         """
         self._template_file_changed('template_file', self.template_file, self.template_file)
-        if 'template' in kw:
-            self.template_file = kw['template']
         
 
     def _init_environment(self, extra_loaders=None):

--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -102,6 +102,7 @@ class Exporter(LoggingConfigurable):
             self.template_file = self.default_template
         else:
             self.template_file = new
+        self.template = None
         self._load_template()
     
     default_template = Unicode(u'')

--- a/IPython/nbconvert/exporters/tests/test_exporter.py
+++ b/IPython/nbconvert/exporters/tests/test_exporter.py
@@ -95,7 +95,7 @@ class TestExporter(ExportersTestsBase):
 
     def test_transformer_via_method(self):
         """
-        Can a transformer be added via the Exporter convinience method?
+        Can a transformer be added via the Exporter convenience method?
         """
         exporter = self._make_exporter()
         exporter.register_transformer(CheeseTransformer, enabled=True)
@@ -108,6 +108,5 @@ class TestExporter(ExportersTestsBase):
     def _make_exporter(self, config=None):
         #Create the exporter instance, make sure to set a template name since
         #the base Exporter doesn't have a template associated with it.
-        exporter = Exporter(config=config)
-        exporter.template_file = 'python'
+        exporter = Exporter(config=config, template_file='python')
         return exporter        

--- a/IPython/nbconvert/exporters/tests/test_html.py
+++ b/IPython/nbconvert/exporters/tests/test_html.py
@@ -46,7 +46,7 @@ class TestHTMLExporter(ExportersTestsBase):
         """
         Can a HTMLExporter export using the 'basic' template?
         """
-        (output, resources) = HTMLExporter(template='basic').from_filename(self._get_notebook())
+        (output, resources) = HTMLExporter(template_file='basic').from_filename(self._get_notebook())
         assert len(output) > 0
 
 
@@ -55,5 +55,5 @@ class TestHTMLExporter(ExportersTestsBase):
         """
         Can a HTMLExporter export using the 'full' template?
         """
-        (output, resources) = HTMLExporter(template='full').from_filename(self._get_notebook())
+        (output, resources) = HTMLExporter(template_file='full').from_filename(self._get_notebook())
         assert len(output) > 0

--- a/IPython/nbconvert/exporters/tests/test_latex.py
+++ b/IPython/nbconvert/exporters/tests/test_latex.py
@@ -46,7 +46,7 @@ class TestLatexExporter(ExportersTestsBase):
         """
         Can a LatexExporter export using 'book' template?
         """
-        (output, resources) = LatexExporter(template='book').from_filename(self._get_notebook())
+        (output, resources) = LatexExporter(template_file='book').from_filename(self._get_notebook())
         assert len(output) > 0
 
 
@@ -55,7 +55,7 @@ class TestLatexExporter(ExportersTestsBase):
         """
         Can a LatexExporter export using 'basic' template?
         """
-        (output, resources) = LatexExporter(template='basic').from_filename(self._get_notebook())
+        (output, resources) = LatexExporter(template_file='basic').from_filename(self._get_notebook())
         assert len(output) > 0
 
 
@@ -64,5 +64,5 @@ class TestLatexExporter(ExportersTestsBase):
         """
         Can a LatexExporter export using 'article' template?
         """
-        (output, resources) = LatexExporter(template='article').from_filename(self._get_notebook())
+        (output, resources) = LatexExporter(template_file='article').from_filename(self._get_notebook())
         assert len(output) > 0

--- a/IPython/nbconvert/exporters/tests/test_slides.py
+++ b/IPython/nbconvert/exporters/tests/test_slides.py
@@ -46,5 +46,5 @@ class TestSlidesExporter(ExportersTestsBase):
         """
         Can a SlidesExporter export using the 'reveal' template?
         """
-        (output, resources) = SlidesExporter(template='reveal').from_filename(self._get_notebook())
+        (output, resources) = SlidesExporter(template_file='reveal').from_filename(self._get_notebook())
         assert len(output) > 0

--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -32,7 +32,7 @@ from IPython.utils.traitlets import (
 from IPython.utils.importstring import import_item
 from IPython.utils.text import dedent
 
-from .exporters.export import export_by_name, get_export_names, ExporterNameError
+from .exporters.export import get_export_names, exporter_map
 from IPython.nbconvert import exporters, transformers, writers, post_processors
 from .utils.base import NbConvertBase
 from .utils.exceptions import ConversionException
@@ -273,11 +273,13 @@ class NbConvertApp(BaseIPythonApplication):
         conversion_success = 0
 
         if self.output_base != '' and len(self.notebooks) > 1:
-            print(dedent(
+            self.log.error(
             """UsageError: --output flag or `NbConvertApp.output_base` config option
             cannot be used when converting multiple notebooks.
-            """))
+            """)
             self.exit(1)
+        
+        exporter = exporter_map[self.export_format](config=self.config)
 
         for notebook_filename in self.notebooks:
             self.log.info("Converting notebook %s to %s", notebook_filename, self.export_format)
@@ -294,21 +296,10 @@ class NbConvertApp(BaseIPythonApplication):
 
             # Try to export
             try:
-                output, resources = export_by_name(self.export_format,
-                                              notebook_filename, 
-                                              resources=resources,
-                                              config=self.config)
-            except ExporterNameError as e:
-                print("Error while converting '%s': '%s' exporter not found."
-                      %(notebook_filename, self.export_format),
-                      file=sys.stderr)
-                print("Known exporters are:",
-                      "\n\t" + "\n\t".join(get_export_names()),
-                      file=sys.stderr)
-                self.exit(1)
+                output, resources = exporter.from_filename(notebook_filename, resources=resources)
             except ConversionException as e:
-                print("Error while converting '%s': %s" %(notebook_filename, e),
-                      file=sys.stderr)
+                self.log.error("Error while converting '%s'", notebook_filename,
+                      exc_info=True)
                 self.exit(1)
             else:
                 write_resultes = self.writer.write(output, resources, notebook_name=notebook_name)

--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -234,6 +234,8 @@ class NbConvertApp(BaseIPythonApplication):
             # notebooks without having to type the extension.
             globbed_files = glob.glob(pattern)
             globbed_files.extend(glob.glob(pattern + '.ipynb'))
+            if not globbed_files:
+                self.log.warn("pattern %r matched no files", pattern)
 
             for filename in globbed_files:
                 if not filename in filenames:

--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -17,6 +17,8 @@ Command-line interface for the NbConvert conversion utility.
 
 # Stdlib imports
 from __future__ import print_function
+
+import logging
 import sys
 import os
 import glob
@@ -79,6 +81,9 @@ class NbConvertApp(BaseIPythonApplication):
     name = 'ipython-nbconvert'
     aliases = nbconvert_aliases
     flags = nbconvert_flags
+    
+    def _log_level_default(self):
+        return logging.INFO
     
     def _classes_default(self):
         classes = [NbConvertBase]
@@ -273,6 +278,7 @@ class NbConvertApp(BaseIPythonApplication):
             self.exit(1)
 
         for notebook_filename in self.notebooks:
+            self.log.info("Converting notebook %s to %s", notebook_filename, self.export_format)
 
             # Get a unique key for the notebook and set it in the resources object.
             basename = os.path.basename(notebook_filename)
@@ -282,6 +288,7 @@ class NbConvertApp(BaseIPythonApplication):
             resources = {}
             resources['unique_key'] = notebook_name
             resources['output_files_dir'] = '%s_files' % notebook_name
+            self.log.debug("Writing extra files to %s", resources['output_files_dir'])
 
             # Try to export
             try:

--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -288,7 +288,7 @@ class NbConvertApp(BaseIPythonApplication):
             resources = {}
             resources['unique_key'] = notebook_name
             resources['output_files_dir'] = '%s_files' % notebook_name
-            self.log.debug("Writing extra files to %s", resources['output_files_dir'])
+            self.log.info("Support files will be in %s", os.path.join(resources['output_files_dir'], ''))
 
             # Try to export
             try:

--- a/IPython/nbconvert/post_processors/pdf.py
+++ b/IPython/nbconvert/post_processors/pdf.py
@@ -43,6 +43,7 @@ class PDFPostProcessor(PostProcessorBase):
             See files.py for more...
             """        
             command = self.compiler.format(input)
+            self.log.info("Building PDF: `%s`", command)
             for index in range(self.iteration_count):
                 if self.verbose:
                     subprocess.Popen(command, shell=True)

--- a/IPython/nbconvert/transformers/base.py
+++ b/IPython/nbconvert/transformers/base.py
@@ -79,8 +79,9 @@ class Transformer(NbConvertBase):
             Additional resources used in the conversion process.  Allows
             transformers to pass variables into the Jinja engine.
         """
+        self.log.debug("Applying transform: %s", self.__class__.__name__)
         try :
-            for worksheet in nb.worksheets :
+            for worksheet in nb.worksheets:
                 for index, cell in enumerate(worksheet.cells):
                     worksheet.cells[index], resources = self.transform_cell(cell, resources, index)
             return nb, resources

--- a/IPython/nbconvert/utils/base.py
+++ b/IPython/nbconvert/utils/base.py
@@ -12,13 +12,13 @@
 #-----------------------------------------------------------------------------
 
 from IPython.utils.traitlets import List
-from IPython.config.configurable import Configurable
+from IPython.config.configurable import LoggingConfigurable
 
 #-----------------------------------------------------------------------------
 # Classes and functions
 #-----------------------------------------------------------------------------
            
-class NbConvertBase(Configurable):
+class NbConvertBase(LoggingConfigurable):
     """Global configurable class for shared config
 
     Usefull for display data priority that might be use by many trasnformers

--- a/IPython/nbconvert/writers/files.py
+++ b/IPython/nbconvert/writers/files.py
@@ -45,7 +45,12 @@ class FilesWriter(WriterBase):
         super(FilesWriter, self).__init__(**kw)
         self._build_directory_changed('build_directory', self.build_directory, 
                                       self.build_directory)
-
+    
+    def _makedir(self, path):
+        """Make a directory if it doesn't already exist"""
+        if not os.path.isdir(path):
+            self.log.info("Making directory %s", path)
+            os.makedirs(path)
 
     def write(self, output, resources, notebook_name=None, **kw):
             """
@@ -67,10 +72,10 @@ class FilesWriter(WriterBase):
                 # Determine where to write the file to
                 dest = os.path.join(self.build_directory, filename)
                 path = os.path.dirname(dest)
-                if not os.path.isdir(path):
-                    os.makedirs(path)
+                self._makedir(path)
 
                 # Write file
+                self.log.info("Writing support file %s", dest)
                 with io.open(dest, 'wb') as f:
                     f.write(data)
 
@@ -84,11 +89,11 @@ class FilesWriter(WriterBase):
                         # Make sure folder exists.
                         dest = os.path.join(self.build_directory, filename)
                         path = os.path.dirname(dest)
-                        if not os.path.isdir(path):
-                            os.makedirs(path)
+                        self._makedir(path)
 
                         # Copy if destination is different.
                         if not os.path.normpath(dest) == os.path.normpath(matching_filename):
+                            self.log.info("Linking %s -> %s", matching_filename, dest)
                             link_or_copy(matching_filename, dest)
 
             # Determine where to write conversion results.
@@ -97,6 +102,7 @@ class FilesWriter(WriterBase):
                 dest = os.path.join(self.build_directory, dest)
 
             # Write conversion results.
+            self.log.info("Writing %s", dest)
             with io.open(dest, 'w') as f:
                 f.write(output)
             return dest

--- a/IPython/nbconvert/writers/files.py
+++ b/IPython/nbconvert/writers/files.py
@@ -75,7 +75,7 @@ class FilesWriter(WriterBase):
                 self._makedir(path)
 
                 # Write file
-                self.log.info("Writing support file %s", dest)
+                self.log.debug("Writing %i bytes to support file %s", len(data), dest)
                 with io.open(dest, 'wb') as f:
                     f.write(data)
 
@@ -102,7 +102,7 @@ class FilesWriter(WriterBase):
                 dest = os.path.join(self.build_directory, dest)
 
             # Write conversion results.
-            self.log.info("Writing %s", dest)
+            self.log.info("Writing %i bytes to support file %s", len(output), dest)
             with io.open(dest, 'w') as f:
                 f.write(output)
             return dest

--- a/IPython/nbconvert/writers/files.py
+++ b/IPython/nbconvert/writers/files.py
@@ -102,7 +102,7 @@ class FilesWriter(WriterBase):
                 dest = os.path.join(self.build_directory, dest)
 
             # Write conversion results.
-            self.log.info("Writing %i bytes to support file %s", len(output), dest)
+            self.log.info("Writing %i bytes to %s", len(output), dest)
             with io.open(dest, 'w') as f:
                 f.write(output)
             return dest


### PR DESCRIPTION
Basic log statements for written files, transformers, template loading, etc.

Also reuses Exporter instance if multiple notebooks are passed to NbConvertApp, to avoid repetitive re-initialization.

closes #3731
