### PR TITLE
skip a failing test on windows

### DIFF
--- a/IPython/extensions/tests/test_cythonmagic.py
+++ b/IPython/extensions/tests/test_cythonmagic.py
@@ -29,6 +29,7 @@ def test_cython_inline():
     nt.assert_equal(result, 30)
 
 
+@dec.skip_win32
 def test_cython_pyximport():
     module_name = '_test_cython_pyximport'
     ip.run_cell_magic('cython_pyximport', module_name, code)


### PR DESCRIPTION
soon, the cython magic will move into its own repo and this can be dealt
with properly, but most windows installs will not have a compiler
available out-of-the-box, so it's safer just to skip this altogether
