### PR TITLE
Working speaker notes for slides

### DIFF
--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -66,6 +66,10 @@ nbconvert_aliases.update({
 nbconvert_flags = {}
 nbconvert_flags.update(base_flags)
 nbconvert_flags.update({
+    'notes' : (
+        {'NbConvertApp' : {'writer_class' : "NotesWriter"}},
+        ""
+        ),
     'stdout' : (
         {'NbConvertApp' : {'writer_class' : "StdoutWriter"}},
         "Write notebook output to stdout instead of files."
@@ -150,6 +154,7 @@ class NbConvertApp(BaseIPythonApplication):
                                     help="""Writer class used to write the 
                                     results of the conversion""")
     writer_aliases = {'FilesWriter': 'IPython.nbconvert.writers.files.FilesWriter',
+                      'NotesWriter': 'IPython.nbconvert.writers.notes.NotesWriter',
                       'DebugWriter': 'IPython.nbconvert.writers.debug.DebugWriter',
                       'StdoutWriter': 'IPython.nbconvert.writers.stdout.StdoutWriter'}
     writer_factory = Type()
@@ -303,6 +308,7 @@ class NbConvertApp(BaseIPythonApplication):
                 self.exit(1)
             else:
                 write_resultes = self.writer.write(output, resources, notebook_name=notebook_name)
+                write_notes = self.writer.write_notes()
 
                 #Post-process if post processor has been defined.
                 if hasattr(self, 'post_processor') and self.post_processor:

--- a/IPython/nbconvert/templates/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/slides_reveal.tpl
@@ -135,7 +135,7 @@ transition: Reveal.getQueryHash().transition || 'linear', // default/cube/page/c
 dependencies: [
 { src: "{{resources.reveal.url_prefix}}/lib/js/classList.js", condition: function() { return !document.body.classList; } },
 { src: "{{resources.reveal.url_prefix}}/plugin/highlight/highlight.js", async: true, callback: function() { hljs.initHighlightingOnLoad(); } },
-{ src: "{{resources.reveal.url_prefix}}/plugin/notes/notes.js", async: true, condition: function() { return !!document.body.classList; } }
+{ src: "reveal.js/plugin/notes/notes.js", async: true, condition: function() { return !!document.body.classList; } }
 // { src: 'http://s7.addthis.com/js/300/addthis_widget.js', async: true},
 ]
 });

--- a/IPython/nbconvert/writers/__init__.py
+++ b/IPython/nbconvert/writers/__init__.py
@@ -1,3 +1,4 @@
 from .files import FilesWriter
+from .notes import NotesWriter
 from .stdout import StdoutWriter
 from .base import WriterBase

--- a/IPython/nbconvert/writers/files.py
+++ b/IPython/nbconvert/writers/files.py
@@ -100,3 +100,7 @@ class FilesWriter(WriterBase):
             with io.open(dest, 'w') as f:
                 f.write(output)
             return dest
+
+
+    def write_notes(self):
+            pass

--- a/IPython/nbconvert/writers/notes.py
+++ b/IPython/nbconvert/writers/notes.py
@@ -1,0 +1,61 @@
+"""
+Contains writer for writing nbconvert output to filesystem.
+"""
+#-----------------------------------------------------------------------------
+#Copyright (c) 2013, the IPython Development Team.
+#
+#Distributed under the terms of the Modified BSD License.
+#
+#The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+import io
+import os
+import glob
+import urllib2
+import codecs
+
+from IPython.utils.traitlets import Unicode
+from IPython.utils.path import link_or_copy
+
+from .base import WriterBase
+from .files import FilesWriter
+
+#-----------------------------------------------------------------------------
+# Classes
+#-----------------------------------------------------------------------------
+
+class NotesWriter(FilesWriter):
+    """Consumes nbconvert output and produces files."""
+
+
+    def write_notes(self):
+            """
+            """
+
+            html_infile = 'http://cdn.jsdelivr.net/reveal.js/2.4.0/plugin/notes/notes.html'
+            html_outfile = "notes.html"    
+            self.write_helper(html_infile, html_outfile)
+            
+            js_infile = 'http://cdn.jsdelivr.net/reveal.js/2.4.0/plugin/notes/notes.js'
+            js_outfile = "notes.js"
+            self.write_helper(js_infile, js_outfile) 
+            
+
+    def write_helper(self, infile, outfile):
+            """
+            """
+                      
+            notes_path = "reveal.js/plugin/notes"
+            dir_dest = os.path.join(self.build_directory, notes_path)
+            if not os.path.isdir(dir_dest):
+                os.makedirs(dir_dest)
+            
+            file_dest = os.path.join(dir_dest, outfile)
+
+            with codecs.open(file_dest, 'w', 'utf-8') as f:
+                f.write(urllib2.urlopen(infile).read())

--- a/IPython/nbconvert/writers/notes.py
+++ b/IPython/nbconvert/writers/notes.py
@@ -1,5 +1,5 @@
 """
-Contains writer for writing nbconvert output to filesystem.
+Contains writer for writing speaker notes plugin for reveal slides.
 """
 #-----------------------------------------------------------------------------
 #Copyright (c) 2013, the IPython Development Team.
@@ -13,16 +13,10 @@ Contains writer for writing nbconvert output to filesystem.
 # Imports
 #-----------------------------------------------------------------------------
 
-import io
 import os
-import glob
 import urllib2
 import codecs
 
-from IPython.utils.traitlets import Unicode
-from IPython.utils.path import link_or_copy
-
-from .base import WriterBase
 from .files import FilesWriter
 
 #-----------------------------------------------------------------------------
@@ -30,12 +24,12 @@ from .files import FilesWriter
 #-----------------------------------------------------------------------------
 
 class NotesWriter(FilesWriter):
-    """Consumes nbconvert output and produces files."""
+    """Build the reveal speaker notes plugin infrastructure 
+       to support the speaker notes functionality."""
 
 
     def write_notes(self):
-            """
-            """
+            """Writes the necessary html and js files."""
 
             html_infile = 'http://cdn.jsdelivr.net/reveal.js/2.4.0/plugin/notes/notes.html'
             html_outfile = "notes.html"    
@@ -43,19 +37,18 @@ class NotesWriter(FilesWriter):
             
             js_infile = 'http://cdn.jsdelivr.net/reveal.js/2.4.0/plugin/notes/notes.js'
             js_outfile = "notes.js"
-            self.write_helper(js_infile, js_outfile) 
+            self.write_helper(js_infile, js_outfile)
             
 
     def write_helper(self, infile, outfile):
-            """
-            """
-                      
+            """Helper function to write the content of a url to a file."""
+            
             notes_path = "reveal.js/plugin/notes"
             dir_dest = os.path.join(self.build_directory, notes_path)
             if not os.path.isdir(dir_dest):
                 os.makedirs(dir_dest)
             
             file_dest = os.path.join(dir_dest, outfile)
-
+            
             with codecs.open(file_dest, 'w', 'utf-8') as f:
                 f.write(urllib2.urlopen(infile).read())


### PR DESCRIPTION
I have implemented a `writer` inherited from `FileWriter` which provides the feature of speaker notes in the slideshows loaded by the CDN (it is also functional with the slides using a local copy of reveal.js).
The writer fetch the CDN content of two needed files, and write them to the slideshow directory, to be properly served and then functional. 

To use it, the user has to add the `--notes` flag in the command line, ie:

`ipython nbconvert your_slides.ipynb --to slides --notes --post serve` if the user want to add the possibility to use speaker notes... 

Cheers.

Damián.
