### PR TITLE
Added working speaker notes for slides.

### DIFF
--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -63,8 +63,8 @@ nbconvert_aliases.update({
     'writer' : 'NbConvertApp.writer_class',
     'post': 'NbConvertApp.post_processor_class',
     'output': 'NbConvertApp.output_base',
-    'local': 'RevealHelpTransformer.url_prefix',
-    'notes': 'RevealHelpTransformer.speaker_notes'
+    'offline-slides': 'RevealHelpTransformer.url_prefix',
+    'slide-notes': 'RevealHelpTransformer.speaker_notes'
 })
 
 nbconvert_flags = {}

--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -62,7 +62,9 @@ nbconvert_aliases.update({
     'notebooks' : 'NbConvertApp.notebooks',
     'writer' : 'NbConvertApp.writer_class',
     'post': 'NbConvertApp.post_processor_class',
-    'output': 'NbConvertApp.output_base'
+    'output': 'NbConvertApp.output_base',
+    'local': 'RevealHelpTransformer.url_prefix',
+    'notes': 'RevealHelpTransformer.speaker_notes'
 })
 
 nbconvert_flags = {}

--- a/IPython/nbconvert/templates/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/slides_reveal.tpl
@@ -135,7 +135,7 @@ transition: Reveal.getQueryHash().transition || 'linear', // default/cube/page/c
 dependencies: [
 { src: "{{resources.reveal.url_prefix}}/lib/js/classList.js", condition: function() { return !document.body.classList; } },
 { src: "{{resources.reveal.url_prefix}}/plugin/highlight/highlight.js", async: true, callback: function() { hljs.initHighlightingOnLoad(); } },
-{ src: "{{resources.reveal.url_prefix}}/plugin/notes/notes.js", async: true, condition: function() { return !!document.body.classList; } }
+{ src: "{{resources.reveal.notes_prefix}}/plugin/notes/notes.js", async: true, condition: function() { return !!document.body.classList; } }
 // { src: 'http://s7.addthis.com/js/300/addthis_widget.js', async: true},
 ]
 });

--- a/IPython/nbconvert/transformers/revealhelp.py
+++ b/IPython/nbconvert/transformers/revealhelp.py
@@ -29,9 +29,10 @@ class RevealHelpTransformer(Transformer):
                          help="""If you want to use a local reveal.js library,
                          use 'url_prefix':'reveal.js' in your config object.""")
 
-    speaker_notes = Bool(False, config=True, help="""
-                         If you want to use the speaker notes set 
-                         'speaker_notes':'True' in your config object.""")
+    speaker_notes = Bool(False, 
+                         config=True, 
+                         help="""If you want to use the speaker notes 
+                         set this to True.""")
 
     def call(self, nb, resources):
         """

--- a/IPython/nbconvert/transformers/revealhelp.py
+++ b/IPython/nbconvert/transformers/revealhelp.py
@@ -27,12 +27,11 @@ class RevealHelpTransformer(Transformer):
     url_prefix = Unicode('//cdn.jsdelivr.net/reveal.js/2.4.0',
                          config=True,
                          help="""If you want to use a local reveal.js library,
-                         use 'url_prefix':'reveal.js' in your config object or
-                         --local reveal.js in command line.""")
+                         use 'url_prefix':'reveal.js' in your config object.""")
 
     speaker_notes = Bool(False, config=True, help="""
-                     If you want to use the speaker notes set speaker_notes:True
-                     in your config object or --notes True in command line.""")
+                         If you want to use the speaker notes set 
+                         'speaker_notes':'True' in your config object.""")
 
     def call(self, nb, resources):
         """

--- a/docs/source/interactive/nbconvert.rst
+++ b/docs/source/interactive/nbconvert.rst
@@ -63,7 +63,11 @@ The currently supported export formats are:
   This generates a Reveal.js HTML slideshow.
   It must be served by an HTTP server.  The easiest way to get this is to add
   ``--post serve`` on the command-line.
-
+  If you want to use the speaker notes plugin, just add
+  ``--notes True`` on the command-line.
+  For low connectivity environments, you can use a local copy of the reveal.js library, just add
+  ``--local reveal.js`` on the command-line, and do not forget to move your downloaded ``reveal.js`` library to the same folder where your slides are located.
+  
 * ``--to markdown``
 
   Simple markdown output.  Markdown cells are unaffected,

--- a/docs/source/interactive/nbconvert.rst
+++ b/docs/source/interactive/nbconvert.rst
@@ -65,8 +65,9 @@ The currently supported export formats are:
   ``--post serve`` on the command-line.
   If you want to use the speaker notes plugin, just add
   ``--notes True`` on the command-line.
-  For low connectivity environments, you can use a local copy of the reveal.js library, just add
-  ``--local reveal.js`` on the command-line, and do not forget to move your downloaded ``reveal.js`` library to the same folder where your slides are located.
+  For low connectivity environments, you can use a local copy of the reveal.js library, 
+  just add ``--local reveal.js`` on the command-line, and do not forget to move your 
+  downloaded ``reveal.js`` library to the same folder where your slides are located.
   
 * ``--to markdown``
 

--- a/docs/source/interactive/nbconvert.rst
+++ b/docs/source/interactive/nbconvert.rst
@@ -64,9 +64,9 @@ The currently supported export formats are:
   It must be served by an HTTP server.  The easiest way to get this is to add
   ``--post serve`` on the command-line.
   If you want to use the speaker notes plugin, just add
-  ``--slide-notes True`` on the command-line.
+  ``--slide-notes=True`` on the command-line.
   For low connectivity environments, you can use a local copy of the reveal.js library, 
-  just add ``--offline-slides reveal.js`` on the command-line, and do not forget to move
+  just add ``--offline-slides=reveal.js`` on the command-line, and do not forget to move
   your downloaded ``reveal.js`` library to the same folder where your slides are located.
   
 * ``--to markdown``

--- a/docs/source/interactive/nbconvert.rst
+++ b/docs/source/interactive/nbconvert.rst
@@ -64,10 +64,10 @@ The currently supported export formats are:
   It must be served by an HTTP server.  The easiest way to get this is to add
   ``--post serve`` on the command-line.
   If you want to use the speaker notes plugin, just add
-  ``--notes True`` on the command-line.
+  ``--slide-notes True`` on the command-line.
   For low connectivity environments, you can use a local copy of the reveal.js library, 
-  just add ``--local reveal.js`` on the command-line, and do not forget to move your 
-  downloaded ``reveal.js`` library to the same folder where your slides are located.
+  just add ``--offline-slides reveal.js`` on the command-line, and do not forget to move
+  your downloaded ``reveal.js`` library to the same folder where your slides are located.
   
 * ``--to markdown``
 


### PR DESCRIPTION
[ not for 1.0 ] 

Tomorrow morning I had a discussion with @jdfreder from a previous PR #3852. His comments were high valuable, so I closed this PR in favor of this one with, I think, a better implementation.
To resume, I fetch the cdn containing the files we need to make speaker notes works. Then I pass this info using the resources dict to the write which output the files in the correct path...
I make some other additions to make this feature an option from the command line, ie:
- if you want a simple slideshow:

`ipython nbconvert your_slides.ipynb --to slides`
- if you want a simple **served** slideshow:

`ipython nbconvert your_slides.ipynb --to slides --post serve`
- if you want to use a local copy of the `reveal.js` library:

`ipython nbconvert your_slides.ipynb --to slides --post serve --local reveal.js`
- and if you want to use speaker notes:

`ipython nbconvert your_slides.ipynb --to slides --post serve --notes True`
or
`ipython nbconvert your_slides.ipynb --to slides --post serve --notes True --local reveal.js` 
but this last one is redundant because if you are using a local reveal.js library the speaker notes are functional by default.

OK, that's all.

Damián.
