### PR TITLE
Escape filename for pdflatex in nbconvert

### DIFF
--- a/IPython/nbconvert/post_processors/pdf.py
+++ b/IPython/nbconvert/post_processors/pdf.py
@@ -15,6 +15,7 @@ Contains writer for writing nbconvert output to PDF.
 
 import subprocess
 import os
+import shlex
 
 from IPython.utils.traitlets import Integer, Unicode, Bool
 
@@ -42,7 +43,7 @@ class PDFPostProcessor(PostProcessorBase):
             Consume and write Jinja output a PDF.  
             See files.py for more...
             """        
-            command = self.compiler.format(input)
+            command = self.compiler.format(shlex.quote(input))
             self.log.info("Building PDF: `%s`", command)
             for index in range(self.iteration_count):
                 if self.verbose:

--- a/IPython/nbconvert/post_processors/pdf.py
+++ b/IPython/nbconvert/post_processors/pdf.py
@@ -15,9 +15,8 @@ Contains writer for writing nbconvert output to PDF.
 
 import subprocess
 import os
-import shlex
 
-from IPython.utils.traitlets import Integer, Unicode, Bool
+from IPython.utils.traitlets import Integer, List, Bool
 
 from .base import PostProcessorBase
 
@@ -31,7 +30,7 @@ class PDFPostProcessor(PostProcessorBase):
         How many times pdflatex will be called.
         """)
 
-    compiler = Unicode(u'pdflatex {0}', config=True, help="""
+    compiler = List(["pdflatex", "{filename}"], config=True, help="""
         Shell command used to compile PDF.""")
 
     verbose = Bool(False, config=True, help="""
@@ -43,8 +42,8 @@ class PDFPostProcessor(PostProcessorBase):
             Consume and write Jinja output a PDF.  
             See files.py for more...
             """        
-            command = self.compiler.format(shlex.quote(input))
-            self.log.info("Building PDF: `%s`", command)
+            command = [c.format(filename=input) for c in self.compiler]
+            self.log.info("Building PDF: `%s`", ' '.join(command))
             for index in range(self.iteration_count):
                 if self.verbose:
                     subprocess.Popen(command, shell=True)

--- a/IPython/nbconvert/post_processors/pdf.py
+++ b/IPython/nbconvert/post_processors/pdf.py
@@ -30,7 +30,7 @@ class PDFPostProcessor(PostProcessorBase):
         How many times pdflatex will be called.
         """)
 
-    compiler = List(["pdflatex", "{filename}"], config=True, help="""
+    command = List(["pdflatex", "{filename}"], config=True, help="""
         Shell command used to compile PDF.""")
 
     verbose = Bool(False, config=True, help="""
@@ -42,7 +42,7 @@ class PDFPostProcessor(PostProcessorBase):
             Consume and write Jinja output a PDF.  
             See files.py for more...
             """        
-            command = [c.format(filename=input) for c in self.compiler]
+            command = [c.format(filename=input) for c in self.command]
             self.log.info("Building PDF: `%s`", ' '.join(command))
             for index in range(self.iteration_count):
                 if self.verbose:


### PR DESCRIPTION
This is a simple change, but it's needed otherwise filenames with spaces cause issues:

```
$ ipython3 nbconvert 12.\ Files\ and\ strings\ \(advanced\).ipynb --to latex --post PDF
[NbConvertApp] Using existing profile dir: '/Users/tom/.ipython/profile_default'
[NbConvertApp] Converting notebook 12. Files and strings (advanced).ipynb to latex
[NbConvertApp] Support files will be in 12. Files and strings (advanced)_files/
[NbConvertApp] Loaded template latex_article.tplx
[NbConvertApp] Writing 30139 bytes to ./12. Files and strings (advanced).tex
[NbConvertApp] Building PDF: `pdflatex ./12. Files and strings (advanced).tex`
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `pdflatex ./12. Files and strings (advanced).tex'
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `pdflatex ./12. Files and strings (advanced).tex'
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `pdflatex ./12. Files and strings (advanced).tex'
```
