### PR TITLE
Fix for converting notebooks that contain unicode characters.

### DIFF
--- a/IPython/nbconvert/writers/files.py
+++ b/IPython/nbconvert/writers/files.py
@@ -103,6 +103,6 @@ class FilesWriter(WriterBase):
 
             # Write conversion results.
             self.log.info("Writing %i bytes to %s", len(output), dest)
-            with io.open(dest, 'w') as f:
-                f.write(output)
+            with io.open(dest, 'wb') as f:
+                f.write(output.encode('utf-8'))
             return dest


### PR DESCRIPTION
I tried converting a notebook that had a ü in it using nbconvert, and get:

```
$ ipython3 nbconvert *.ipynb --to latex --post PDF
[NbConvertApp] Using existing profile dir: '/Users/tom/.ipython/profile_default'
[NbConvertApp] Converting notebook 00. About the course.ipynb to latex
[NbConvertApp] Support files will be in 00. About the course_files/
[NbConvertApp] Loaded template latex_article.tplx
[NbConvertApp] Writing 17249 bytes to ./00. About the course.tex
b'stitut f\xc3\xbcr\nAstronomi'
Traceback (most recent call last):
  File "/Users/tom/Library/Python/3.3/bin/ipython3", line 9, in <module>
    load_entry_point('ipython==1.0.0-dev', 'console_scripts', 'ipython3')()
  File "/Users/tom/Library/Python/3.3/lib/python/site-packages/ipython-1.0.0_dev-py3.3.egg/IPython/__init__.py", line 118, in start_ipython
    return launch_new_instance(argv=argv, **kwargs)
  File "/Users/tom/Library/Python/3.3/lib/python/site-packages/ipython-1.0.0_dev-py3.3.egg/IPython/config/application.py", line 539, in launch_instance
    app.start()
  File "/Users/tom/Library/Python/3.3/lib/python/site-packages/ipython-1.0.0_dev-py3.3.egg/IPython/terminal/ipapp.py", line 355, in start
    return self.subapp.start()
  File "/Users/tom/Library/Python/3.3/lib/python/site-packages/ipython-1.0.0_dev-py3.3.egg/IPython/nbconvert/nbconvertapp.py", line 266, in start
    self.convert_notebooks()
  File "/Users/tom/Library/Python/3.3/lib/python/site-packages/ipython-1.0.0_dev-py3.3.egg/IPython/nbconvert/nbconvertapp.py", line 305, in convert_notebooks
    write_resultes = self.writer.write(output, resources, notebook_name=notebook_name)
  File "/Users/tom/Library/Python/3.3/lib/python/site-packages/ipython-1.0.0_dev-py3.3.egg/IPython/nbconvert/writers/files.py", line 109, in write
    f.write(output)
UnicodeEncodeError: 'ascii' codec can't encode character '\xfc' in position 11338: ordinal not in range(128)
```

The attached code seems to fix this, but understanding the intricacies of unicode isn't my strongest point, so let me know if it's the completely wrong approach :)
