### PR TITLE
don't use `shell=True` in PDF export

### DIFF
--- a/IPython/nbconvert/post_processors/pdf.py
+++ b/IPython/nbconvert/post_processors/pdf.py
@@ -44,9 +44,8 @@ class PDFPostProcessor(PostProcessorBase):
             """        
             command = [c.format(filename=input) for c in self.command]
             self.log.info("Building PDF: `%s`", ' '.join(command))
-            for index in range(self.iteration_count):
-                if self.verbose:
-                    subprocess.Popen(command)
-                else:
-                    with open(os.devnull, 'wb') as null:
-                        subprocess.Popen(command, stdout=null)
+            with open(os.devnull, 'wb') as null:
+                stdout = null if self.verbose else None
+                for index in range(self.iteration_count):
+                    p = subprocess.Popen(command, stdout=stdout)
+                    p.wait()

--- a/IPython/nbconvert/post_processors/pdf.py
+++ b/IPython/nbconvert/post_processors/pdf.py
@@ -46,7 +46,7 @@ class PDFPostProcessor(PostProcessorBase):
             self.log.info("Building PDF: `%s`", ' '.join(command))
             for index in range(self.iteration_count):
                 if self.verbose:
-                    subprocess.Popen(command, shell=True)
+                    subprocess.Popen(command)
                 else:
                     with open(os.devnull, 'wb') as null:
-                        subprocess.Popen(command, shell=True, stdout=null)
+                        subprocess.Popen(command, stdout=null)


### PR DESCRIPTION
causes weird `End of file on the terminal... why?` messages.
