### PR TITLE
minor template loading cleanup

### DIFF
--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -223,8 +223,10 @@ class Exporter(LoggingConfigurable):
             self.log.debug("Attempting to load template %s", try_name)
             try:
                 self.template = self.environment.get_template(try_name)
-            except TemplateNotFound:
+            except (TemplateNotFound, IOError):
                 pass
+            except Exception as e:
+                self.log.warn("Unexpected exception loading template: %s", try_name, exc_info=True)
             else:
                 self.log.info("Loaded template %s", try_name)
                 break

--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -215,10 +215,14 @@ class Exporter(LoggingConfigurable):
         # as if the name is explicitly specified, then try the name as a 
         # 'flavor', and lastly just try to load the template by module name.
         module_name = self.__module__.rsplit('.', 1)[-1]
-        try_names = [self.template_file + self.template_extension,
-                     self.template_file,
-                     module_name + '_' + self.template_file + self.template_extension,
-                     module_name + self.template_extension]
+        try_names = []
+        if self.template_file:
+            try_names.extend([
+                self.template_file + self.template_extension,
+                self.template_file,
+                module_name + '_' + self.template_file + self.template_extension,
+            ])
+        try_names.append(module_name + self.template_extension)
         for try_name in try_names:
             self.log.debug("Attempting to load template %s", try_name)
             try:


### PR DESCRIPTION
- catch more than just TemplateNotFound (IOError raised on Windows)
- don't try empty template names
