### PR TITLE
finish 3870

### DIFF
--- a/IPython/nbconvert/writers/files.py
+++ b/IPython/nbconvert/writers/files.py
@@ -103,6 +103,6 @@ class FilesWriter(WriterBase):
 
             # Write conversion results.
             self.log.info("Writing %i bytes to %s", len(output), dest)
-            with io.open(dest, 'wb') as f:
-                f.write(output.encode('utf-8'))
+            with io.open(dest, 'w', encoding='utf-8') as f:
+                f.write(output)
             return dest

--- a/IPython/nbconvert/writers/files.py
+++ b/IPython/nbconvert/writers/files.py
@@ -103,6 +103,6 @@ class FilesWriter(WriterBase):
 
             # Write conversion results.
             self.log.info("Writing %i bytes to %s", len(output), dest)
-            with io.open(dest, 'w') as f:
-                f.write(output)
+            with io.open(dest, 'wb') as f:
+                f.write(output.encode('utf-8'))
             return dest


### PR DESCRIPTION
specify encoding in `io.open` call (finishes #3870).
