### PR TITLE
skip test on unix when x11 not available

### DIFF
--- a/IPython/lib/tests/test_irunner_pylab_magic.py
+++ b/IPython/lib/tests/test_irunner_pylab_magic.py
@@ -66,6 +66,7 @@ class RunnerTestCase(unittest.TestCase):
         self.assertTrue(mismatch==0,'Number of mismatched lines: %s' %
                         mismatch)
 
+    @decorators.skip_if_no_x11
     @decorators.skipif_not_matplotlib
     @decorators.skipif(pylab_not_importable, "Likely a run without X.")
     def test_pylab_import_all_enabled(self):
@@ -92,6 +93,7 @@ Out\[6\]: True
         runner = irunner.IPythonRunner(out=self.out)
         self._test_runner(runner,source,output)
 
+    @decorators.skip_if_no_x11
     @decorators.skipif_not_matplotlib
     @decorators.skipif(pylab_not_importable, "Likely a run without X.")
     def test_pylab_import_all_disabled(self):

--- a/IPython/qt/console/tests/test_console_widget.py
+++ b/IPython/qt/console/tests/test_console_widget.py
@@ -6,7 +6,9 @@ from IPython.external.qt import QtCore, QtGui
 
 # Local imports
 from IPython.qt.console.console_widget import ConsoleWidget
+import IPython.testing.decorators as dec
 
+setup = dec.skip_file_no_x11(__name__)
 
 class TestConsoleWidget(unittest.TestCase):
 

--- a/IPython/qt/console/tests/test_kill_ring.py
+++ b/IPython/qt/console/tests/test_kill_ring.py
@@ -6,7 +6,9 @@ from IPython.external.qt import QtGui
 
 # Local imports
 from IPython.qt.console.kill_ring import KillRing, QtKillRing
+import IPython.testing.decorators as dec
 
+setup = dec.skip_file_no_x11(__name__)
 
 class TestKillRing(unittest.TestCase):
 

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -330,7 +330,7 @@ skip_if_not_osx = skipif(sys.platform != 'darwin',
 
 
 _x11_skip_cond = (sys.platform not in ('darwin', 'win32') and
-                  os.environ['DISPLAY']=='')
+                  os.environ.get('DISPLAY', '') == '')
 _x11_skip_msg = "Skipped under *nix when X11/XOrg not available"
 
 skip_if_no_x11 = skipif(_x11_skip_cond, _x11_skip_msg)

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -49,6 +49,7 @@ Authors
 
 # Stdlib imports
 import sys
+import os
 import tempfile
 import unittest
 
@@ -295,6 +296,19 @@ def module_not_available(module):
 
     return mod_not_avail
 
+
+def decorated_dummy(dec, name):
+    """Return a dummy function decorated with dec, with the given name.
+    
+    Examples
+    --------
+    import IPython.testing.decorators as dec
+    setup = dec.decorated_dummy(dec.skip_if_no_x11, __name__)
+    """
+    dummy = lambda: None
+    dummy.__name__ = name
+    return dec(dummy)
+
 #-----------------------------------------------------------------------------
 # Decorators for public use
 
@@ -313,6 +327,17 @@ skip_if_not_linux = skipif(not sys.platform.startswith('linux'),
                            "This test only runs under Linux")
 skip_if_not_osx = skipif(sys.platform != 'darwin',
                          "This test only runs under OSX")
+
+
+_x11_skip_cond = (sys.platform not in ('darwin', 'win32') and
+                  os.environ['DISPLAY']=='')
+_x11_skip_msg = "Skipped under *nix when X11/XOrg not available"
+
+skip_if_no_x11 = skipif(_x11_skip_cond, _x11_skip_msg)
+
+# not a decorator itself, returns a dummy function to be used as setup
+def skip_file_no_x11(name):
+    return decorated_dummy(skip_if_no_x11, name) if _x11_skip_cond else None
 
 # Other skip decorators
 


### PR DESCRIPTION
If you just use `DISPLAY= iptest` then Qt console tests were failing with a
generic `: cannot connect to X server`
