### PR TITLE
Use forward slashes in the path to the Sphinx dependencies

### DIFF
--- a/IPython/nbconvert/transformers/extractoutput.py
+++ b/IPython/nbconvert/transformers/extractoutput.py
@@ -91,7 +91,7 @@ class ExtractOutputTransformer(Transformer):
                     # Where
                     #   cell.outputs[i].svg  contains the data
                     if output_files_dir is not None:
-                        filename = os.path.join(output_files_dir, filename)
+                        filename = os.path.join(output_files_dir, filename).replace('\\', '/')
                     out[out_type + '_filename'] = filename
 
                     #In the resources, make the figure available via

--- a/IPython/nbconvert/transformers/sphinx.py
+++ b/IPython/nbconvert/transformers/sphinx.py
@@ -168,7 +168,7 @@ class SphinxTransformer(Transformer):
             resources["sphinx"]["header"] = self.use_headers
             
         # Find and pass in the path to the Sphinx dependencies.
-        resources["sphinx"]["texinputs"] = os.path.realpath(os.path.join(sphinx.__file__, "..", "texinputs"))
+        resources["sphinx"]["texinputs"] = os.path.realpath(os.path.join(sphinx.__file__, "..", "texinputs")).replace('\\', '/')
         
         # Generate Pygments definitions for Latex 
         resources["sphinx"]["pygment_definitions"] = self._generate_pygments_latex_def()


### PR DESCRIPTION
Fix TeX `Error: Undefined control sequence` on Windows
