### PR TITLE
Fix documentation of Kernel.stop_channels

### DIFF
--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -187,7 +187,7 @@ var IPython = (function (IPython) {
     };
 
     /**
-     * Start the `shell`and `iopub` channels.
+     * Stop the `shell`and `iopub` channels.
      * @method stop_channels
      */
     Kernel.prototype.stop_channels = function () {


### PR DESCRIPTION
Just a minor fix to the documentation.
