### PR TITLE
don't force . relative path, fix #3897

### DIFF
--- a/IPython/nbconvert/writers/files.py
+++ b/IPython/nbconvert/writers/files.py
@@ -30,7 +30,7 @@ class FilesWriter(WriterBase):
     """Consumes nbconvert output and produces files."""
 
 
-    build_directory = Unicode(".", config=True, 
+    build_directory = Unicode("", config=True,
                               help="""Directory to write output to.  Leave blank
                               to output to the current directory""")
 


### PR DESCRIPTION
As per #3897, .\filename is not recognized by pdflatex.
