### PR TITLE
explicitly load python mode before IPython mode

### DIFF
--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -211,7 +211,6 @@ class="notebook_app"
 <script src="{{ static_url("components/codemirror/addon/mode/overlay.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("components/codemirror/addon/edit/matchbrackets.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("components/codemirror/addon/comment/comment.js") }}" charset="utf-8"></script>
-<script src="{{ static_url("notebook/js/codemirror-ipython.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("components/codemirror/mode/htmlmixed/htmlmixed.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("components/codemirror/mode/xml/xml.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("components/codemirror/mode/javascript/javascript.js") }}" charset="utf-8"></script>
@@ -219,6 +218,8 @@ class="notebook_app"
 <script src="{{ static_url("components/codemirror/mode/rst/rst.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("components/codemirror/mode/markdown/markdown.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("components/codemirror/mode/gfm/gfm.js") }}" charset="utf-8"></script>
+<script src="{{ static_url("components/codemirror/mode/python/python.js") }}" charset="utf-8"></script>
+<script src="{{ static_url("notebook/js/codemirror-ipython.js") }}" charset="utf-8"></script>
 
 <script src="{{ static_url("components/highlight.js/build/highlight.pack.js") }}" charset="utf-8"></script>
 


### PR DESCRIPTION
ensures IPython mode gets defined at startup, which can sometimes fail because
the Python mode was loaded dynamically.

closes #3636
