### PR TITLE
added check_for_tornado, closes #3916

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -357,7 +357,7 @@ def check_for_dependencies():
         check_for_sphinx, check_for_pygments,
         check_for_nose, check_for_pexpect,
         check_for_pyzmq, check_for_readline,
-        check_for_jinja2
+        check_for_jinja2, check_for_tornado
     )
     print_line()
     print_raw("BUILDING IPYTHON")
@@ -374,6 +374,7 @@ def check_for_dependencies():
     check_for_nose()
     check_for_pexpect()
     check_for_pyzmq()
+    check_for_tornado()
     check_for_readline()
     check_for_jinja2()
 

--- a/setupext/setupext.py
+++ b/setupext/setupext.py
@@ -130,6 +130,16 @@ def check_for_pyzmq():
             " qtconsole, notebook, and parallel computing capabilities)" % zmq.__version__)
             return False
 
+def check_for_tornado():
+    try:
+        import tornado
+    except ImportError:
+        print_status('tornado', "no (required for notebook)")
+        return False
+    else:
+        print_status('tornado', tornado.version)
+        return True
+
 def check_for_readline():
     from distutils.version import LooseVersion
     try:


### PR DESCRIPTION
This way, those relying on the output of `python setup.py install` get clued
in about the fact that it is required for the notebook
