### PR TITLE
Replace --pylab flag with --matplotlib in usage

### DIFF
--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -59,8 +59,9 @@ from IPython.utils.traitlets import (
 #-----------------------------------------------------------------------------
 
 _examples = """
-ipython --pylab            # start in pylab mode
-ipython --pylab=qt         # start in pylab mode with the qt4 backend
+ipython --matplotlib       # enable matplotlib integration
+ipython --matploltib=qt    # enable matplotlib integration with qt4 backend
+
 ipython --log-level=DEBUG  # set logging to DEBUG
 ipython --profile=foo      # start with profile foo
 

--- a/docs/source/whatsnew/version1.0.rst
+++ b/docs/source/whatsnew/version1.0.rst
@@ -109,9 +109,14 @@ Core
 - editor hooks have been restored from quarantine, enabling TextMate as editor,
   etc.
 - The env variable PYTHONSTARTUP is respected by IPython.
-- A ``%matplotlib`` magic is added, which is like the old ``%pylab`` magic,
+- The ``%matplotlib`` magic was added, which is like the old ``%pylab`` magic,
   but it does not import anything to the interactive namespace.
   It is recommended that users switch to ``%matplotlib`` and explicit imports.
+- The ``--matplotlib`` command line flag was also added. It invokes the new
+  ``%matplotlib`` magic and can be used in the same way as the old ``--pylab``
+  flag. You can either use it by itself as a flag (``--matplotlib``), or you
+  can also pass a backend explicitly (``--matplotlib qt`` or
+  ``--matplotlib=wx``, etc).
 
 
 Backwards incompatible changes

--- a/docs/source/whatsnew/version1.0.rst
+++ b/docs/source/whatsnew/version1.0.rst
@@ -231,7 +231,7 @@ The javascript components used in the notebook have been updated significantly.
 Some relevant changes that are results of this:
 
 - Markdown cells now support GitHub-flavored Markdown (GFM),
-  which includes ``\`\`\`python`` code blocks and tables.
+  which includes `````python`` code blocks and tables.
 - Notebook UI behaves better on more screen sizes.
 - Various code cell input issues have been fixed.
 


### PR DESCRIPTION
Since we want to encourage users to start switching to this mode of
working, we might as well advertise it (and _not_ advertise the old
namespace polluting --pylab)

@minrk, hope you don't mind, I also included a minor backticks fix in the
what's new document (I was seeing the backslashes that you had escaped). If
your version of sphinx needs it, though, and the generated documents are fine
with the extra backslashes and don't work without them, I can remove that last
commit.
