### PR TITLE
swallow enter event in rename dialog

### DIFF
--- a/IPython/html/static/notebook/js/savewidget.js
+++ b/IPython/html/static/notebook/js/savewidget.js
@@ -100,6 +100,7 @@ var IPython = (function (IPython) {
                 that.find('input[type="text"]').keydown(function (event, ui) {
                     if (event.which === utils.keycodes.ENTER) {
                         that.find('.btn-primary').first().click();
+                        return false;
                     }
                 });
                 that.find('input[type="text"]').focus();


### PR DESCRIPTION
avoids adding newline in cell after dialog is closed.

closes #3926
