### PR TITLE
nbconvert: fix logic of verbose flag in PDF post processor

### DIFF
--- a/IPython/nbconvert/post_processors/pdf.py
+++ b/IPython/nbconvert/post_processors/pdf.py
@@ -45,7 +45,7 @@ class PDFPostProcessor(PostProcessorBase):
             command = [c.format(filename=input) for c in self.command]
             self.log.info("Building PDF: `%s`", ' '.join(command))
             with open(os.devnull, 'wb') as null:
-                stdout = null if self.verbose else None
+                stdout = null if not self.verbose else None
                 for index in range(self.iteration_count):
                     p = subprocess.Popen(command, stdout=stdout)
                     p.wait()


### PR DESCRIPTION
Found via new tests #3933 
