### PR TITLE
minor checkpoint cleanup

### DIFF
--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -224,11 +224,11 @@ var IPython = (function (IPython) {
         this.update_restore_checkpoint(null);
         
         $([IPython.events]).on('checkpoints_listed.Notebook', function (event, data) {
-            that.update_restore_checkpoint(data);
+            that.update_restore_checkpoint(IPython.notebook.checkpoints);
         });
         
         $([IPython.events]).on('checkpoint_created.Notebook', function (event, data) {
-            that.update_restore_checkpoint([data]);
+            that.update_restore_checkpoint(IPython.notebook.checkpoints);
         });
     };
 
@@ -247,8 +247,7 @@ var IPython = (function (IPython) {
             return;
         };
         
-        for (var i = 0; i < checkpoints.length; i++) {
-            var checkpoint = checkpoints[i];
+        checkpoints.map(function (checkpoint) {
             var d = new Date(checkpoint.last_modified);
             ul.append(
                 $("<li/>").append(
@@ -260,7 +259,7 @@ var IPython = (function (IPython) {
                     })
                 )
             );
-        };
+        });
     };
 
     IPython.MenuBar = MenuBar;


### PR DESCRIPTION
- remember list of checkpoints browser-side
- don't clobber list when a new checkpoint is created
- cleanup references in MenuBar restore list.
  There was a closure issue, where multiple menu items would actually all
  restore the same checkpoint.

Issues revealed by rgbkrk/bookstore, which supports multiple checkpoints.

I'm fine if this doesn't get into 1.0, given timing.
