### PR TITLE
sphinx and PDF tweaks

### DIFF
--- a/IPython/nbconvert/post_processors/pdf.py
+++ b/IPython/nbconvert/post_processors/pdf.py
@@ -30,7 +30,7 @@ class PDFPostProcessor(PostProcessorBase):
         How many times pdflatex will be called.
         """)
 
-    command = List(["pdflatex", "{filename}"], config=True, help="""
+    command = List(["pdflatex", "--interaction=batchmode", "{filename}"], config=True, help="""
         Shell command used to compile PDF.""")
 
     verbose = Bool(False, config=True, help="""

--- a/IPython/nbconvert/transformers/sphinx.py
+++ b/IPython/nbconvert/transformers/sphinx.py
@@ -168,7 +168,7 @@ class SphinxTransformer(Transformer):
             resources["sphinx"]["header"] = self.use_headers
             
         # Find and pass in the path to the Sphinx dependencies.
-        resources["sphinx"]["texinputs"] = os.path.realpath(os.path.join(sphinx.__file__, "..", "texinputs"))
+        resources["sphinx"]["texinputs"] = os.path.realpath(os.path.join(sphinx.package_dir, "texinputs"))
         
         # Generate Pygments definitions for Latex 
         resources["sphinx"]["pygment_definitions"] = self._generate_pygments_latex_def()


### PR DESCRIPTION
- add `--interaction=batchmode` to pdflatex call

avoids waiting for input
- use sphinx.package_dir to find texinputs

this can vary, e.g. for debian installs it is /usr/share/sphinx

closes #3894
