### PR TITLE
Longpath test fix

### DIFF
--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -412,11 +412,15 @@ def test_get_ipython_module_path():
 @dec.skip_if_not_win32
 def test_get_long_path_name_win32():
     with TemporaryDirectory() as tmpdir:
-        long_path = os.path.join(tmpdir, u'this is my long path name')
-        short_path = os.path.join(tmpdir, u'THISIS~1')
 
-        path = path.get_long_path_name(short_path)
-        nt.assert_equal(path, long_path)
+        # Make a long path.
+        long_path = os.path.join(tmpdir, u'this is my long path name')
+        os.makedirs(long_path)
+
+        # Test to see if the short path evaluates correctly.
+        short_path = os.path.join(tmpdir, u'THISIS~1')
+        evaluated_path = path.get_long_path_name(short_path)
+        nt.assert_equal(evaluated_path.lower(), long_path.lower())
 
 
 @dec.skip_win32

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -411,8 +411,12 @@ def test_get_ipython_module_path():
 
 @dec.skip_if_not_win32
 def test_get_long_path_name_win32():
-    p = path.get_long_path_name('c:\\docume~1')
-    nt.assert_equal(p,u'c:\\Documents and Settings')
+    with TemporaryDirectory() as tmpdir:
+        long_path = os.path.join(tmpdir, u'this is my long path name')
+        short_path = os.path.join(tmpdir, u'THISIS~1')
+
+        path = path.get_long_path_name(short_path)
+        nt.assert_equal(path, long_path)
 
 
 @dec.skip_win32


### PR DESCRIPTION
Fixes `IPython.utils.tests.test_get_long_path_name_win32` for the following cases
- User install windows to a drive other than `C:`
- User renames `Documents and Setttings` folder
- Windows 7+

closes https://github.com/ipython/ipython/issues/3944
