### PR TITLE
exclude IPython.lib.kernel in iptest

### DIFF
--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -272,6 +272,7 @@ def make_exclude():
                            ])
 
     if not have['zmq']:
+        exclusions.append(ipjoin('lib', 'kernel'))
         exclusions.append(ipjoin('kernel'))
         exclusions.append(ipjoin('qt'))
         exclusions.append(ipjoin('html'))


### PR DESCRIPTION
when pyzmq is unavailable
