### PR TITLE
"use strict" in most (if not all) our javascript

### DIFF
--- a/IPython/html/static/base/js/dialog.js
+++ b/IPython/html/static/base/js/dialog.js
@@ -12,6 +12,7 @@
 IPython.namespace('IPython.dialog');
 
 IPython.dialog = (function (IPython) {
+    "use strict";
     
     var modal = function (options) {
         var dialog = $("<div/>").addClass("modal").attr("role", "dialog");

--- a/IPython/html/static/base/js/events.js
+++ b/IPython/html/static/base/js/events.js
@@ -17,6 +17,7 @@
 // $([IPython.events]).on('event.Namespace',function () {});
 
 var IPython = (function (IPython) {
+    "use strict";
 
     var utils = IPython.utils;
 

--- a/IPython/html/static/base/js/namespace.js
+++ b/IPython/html/static/base/js/namespace.js
@@ -8,6 +8,8 @@
 var IPython = IPython || {};
 
 IPython.namespace = function (ns_string) {
+    "use strict";
+
     var parts = ns_string.split('.'),
         parent = IPython,
         i;

--- a/IPython/html/static/base/js/page.js
+++ b/IPython/html/static/base/js/page.js
@@ -10,6 +10,7 @@
 //============================================================================
 
 var IPython = (function (IPython) {
+    "use strict";
 
     var Page = function () {
         this.style();

--- a/IPython/html/static/base/js/pagemain.js
+++ b/IPython/html/static/base/js/pagemain.js
@@ -11,6 +11,7 @@
 
 
 $(document).ready(function () {
+    "use strict";
 
     IPython.page = new IPython.Page();
     IPython.page.show();

--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -11,6 +11,7 @@
 IPython.namespace('IPython.utils');
 
 IPython.utils = (function (IPython) {
+    "use strict";
 
     //============================================================================
     // Cross-browser RegEx Split
@@ -366,7 +367,7 @@ IPython.utils = (function (IPython) {
     };
 
     // http://stackoverflow.com/questions/2400935/browser-detection-in-javascript
-    browser = (function() {
+    var browser = (function() {
         var N= navigator.appName, ua= navigator.userAgent, tem;
         var M= ua.match(/(opera|chrome|safari|firefox|msie)\/?\s*(\.?\d+(\.\d+)*)/i);
         if (M && (tem= ua.match(/version\/([\.\d]+)/i))!= null) M[2]= tem[1];

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -16,6 +16,7 @@
  */
 
 var IPython = (function (IPython) {
+    "use strict";
 
     var utils = IPython.utils;
 

--- a/IPython/html/static/notebook/js/codemirror-ipython.js
+++ b/IPython/html/static/notebook/js/codemirror-ipython.js
@@ -4,6 +4,7 @@
 // to do, but at least the simple one for now.
 
 CodeMirror.requireMode('python',function(){
+    "use strict";
 
     CodeMirror.defineMode("ipython", function(conf, parserConf) {
 

--- a/IPython/html/static/notebook/js/config.js
+++ b/IPython/html/static/notebook/js/config.js
@@ -15,6 +15,7 @@
  **/
 
 var IPython = (function (IPython) {
+    "use strict";
         /**
          * A place where some stuff can be confugured.
          *

--- a/IPython/html/static/notebook/js/layoutmanager.js
+++ b/IPython/html/static/notebook/js/layoutmanager.js
@@ -10,6 +10,7 @@
 //============================================================================
 
 var IPython = (function (IPython) {
+    "use strict";
 
     var LayoutManager = function () {
         this.bind_events();

--- a/IPython/html/static/notebook/js/maintoolbar.js
+++ b/IPython/html/static/notebook/js/maintoolbar.js
@@ -10,6 +10,7 @@
 //============================================================================
 
 var IPython = (function (IPython) {
+    "use strict";
 
     var MainToolBar = function (selector) {
         IPython.ToolBar.apply(this, arguments);

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -17,6 +17,7 @@
 
 
 var IPython = (function (IPython) {
+    "use strict";
 
     /**
      * A MenuBar Class to generate the menubar of IPython noteboko

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -10,6 +10,7 @@
 //============================================================================
 
 var IPython = (function (IPython) {
+    "use strict";
 
     var utils = IPython.utils;
     var key   = IPython.utils.keycodes;

--- a/IPython/html/static/notebook/js/pager.js
+++ b/IPython/html/static/notebook/js/pager.js
@@ -10,6 +10,7 @@
 //============================================================================
 
 var IPython = (function (IPython) {
+    "use strict";
 
     var utils = IPython.utils;
 

--- a/IPython/html/static/notebook/js/quickhelp.js
+++ b/IPython/html/static/notebook/js/quickhelp.js
@@ -10,6 +10,7 @@
 //============================================================================
 
 var IPython = (function (IPython) {
+    "use strict";
 
     var QuickHelp = function (selector) {
     };

--- a/IPython/html/static/notebook/js/savewidget.js
+++ b/IPython/html/static/notebook/js/savewidget.js
@@ -10,6 +10,7 @@
 //============================================================================
 
 var IPython = (function (IPython) {
+    "use strict";
 
     var utils = IPython.utils;
 

--- a/IPython/html/static/notebook/js/toolbar.js
+++ b/IPython/html/static/notebook/js/toolbar.js
@@ -15,6 +15,7 @@
  */
 
 var IPython = (function (IPython) {
+    "use strict";
 
     /**
      * A generic toolbar on which one can add button


### PR DESCRIPTION
- fix one variable leaking in global nameespace

For more about "strict mode" read [this](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions_and_function_scope/Strict_mode). 

TL DR, It's faster, less error prone and more secure.

I made it at "function level" instead of "script level" to allow concatenation with unstrict script.
But I wouldn't mind having it at script level.
