### PR TITLE
logging.Formatter is not new-style in 2.6

### DIFF
--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -115,8 +115,10 @@ class LevelFormatter(logging.Formatter):
             record.highlevel = self.highlevel_format % record.__dict__
         else:
             record.highlevel = ""
-        
-        return super(LevelFormatter, self).format(record)
+        if sys.version_info[:2] > (2,6):
+            return super(LevelFormatter, self).format(record)
+        else:
+            return logging.Formatter.format(self, record)
             
 
 class Application(SingletonConfigurable):

--- a/IPython/config/tests/test_application.py
+++ b/IPython/config/tests/test_application.py
@@ -18,7 +18,10 @@ Authors:
 #-----------------------------------------------------------------------------
 
 import logging
+from io import StringIO
 from unittest import TestCase
+
+import nose.tools as nt
 
 from IPython.config.configurable import Configurable
 from IPython.config.loader import Config
@@ -79,6 +82,16 @@ class MyApp(Application):
 
 
 class TestApplication(TestCase):
+
+    def test_log(self):
+        stream = StringIO()
+        app = MyApp(log_level=logging.INFO)
+        handler = logging.StreamHandler(stream)
+        # trigger reconstruction of the log formatter
+        app.log.handlers = [handler]
+        app.log_format = "%(message)s"
+        app.log.info("hello")
+        nt.assert_in("hello", stream.getvalue())
 
     def test_basic(self):
         app = MyApp()


### PR DESCRIPTION
so we can't use super.

closes #3968
