### PR TITLE
logging.Formatter is not new-style in 2.6

### DIFF
--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -115,8 +115,10 @@ class LevelFormatter(logging.Formatter):
             record.highlevel = self.highlevel_format % record.__dict__
         else:
             record.highlevel = ""
-        
-        return super(LevelFormatter, self).format(record)
+        if sys.version_info[:2] > (2,6):
+            return super(LevelFormatter, self).format(record)
+        else:
+            return logging.Formatter.format(self, record)
             
 
 class Application(SingletonConfigurable):


### PR DESCRIPTION
so we can't use super.

closes #3968

PR #3973 re-issued against 1.x
