### PR TITLE
Transform code before %prun/%%prun runs

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -181,6 +181,7 @@ python-profiler package from non-free.""")
                                            list_all=True, posix=False)
         if cell is not None:
             arg_str += '\n' + cell
+        arg_str = self.shell.input_splitter.transform_cell(arg_str)
         return self._run_with_profiler(arg_str, opts, self.shell.user_ns)
 
     def _run_with_profiler(self, code, opts, namespace):

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -490,6 +490,21 @@ def test_timeit_special_syntax():
     
 
 @dec.skipif(execution.profile is None)
+def test_prun_special_syntax():
+    "Test %%prun with IPython special syntax"
+    @register_line_magic
+    def lmagic(line):
+        ip = get_ipython()
+        ip.user_ns['lmagic_out'] = line
+
+    # line mode test
+    _ip.run_line_magic('prun', '-q %lmagic my line')
+    nt.assert_equal(_ip.user_ns['lmagic_out'], 'my line')
+    # cell mode test
+    _ip.run_cell_magic('prun', '-q', '%lmagic my line2')
+    nt.assert_equal(_ip.user_ns['lmagic_out'], 'my line2')
+
+@dec.skipif(execution.profile is None)
 def test_prun_quotes():
     "Test that prun does not clobber string escapes (GH #1302)"
     _ip.magic(r"prun -q x = '\t'")


### PR DESCRIPTION
This makes it so that prun works with IPython-specific syntax (e.g., `%prun %logon`).  This mirrors the change @fperez made in commit 3ac024c8b39300055bd515e9d88186049a30cdbe for the timeit magic.
