### PR TITLE
Fix IPython.start_* functions

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -34,7 +34,7 @@ from IPython.utils import py3compat
 from IPython.utils.contexts import preserve_keys
 from IPython.utils.path import filefind
 from IPython.utils.traitlets import (
-    Unicode, Instance, List, Bool, CaselessStrEnum
+    Unicode, Instance, List, Bool, CaselessStrEnum, Dict
 )
 
 #-----------------------------------------------------------------------------
@@ -198,9 +198,11 @@ class InteractiveShellApp(Configurable):
     )
     shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
     
-    def __init__(self, user_ns=None, **kwargs):
-        self.user_ns = user_ns
-        super(InteractiveShellApp, self).__init__(**kwargs)
+    user_ns = Dict(default_value=None)
+    def _user_ns_changed(self, name, old, new):
+        if self.shell is not None:
+            self.shell.user_ns = new
+            self.shell.init_user_ns()
 
     def init_path(self):
         """Add current working directory, '', to sys.path"""

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -197,6 +197,10 @@ class InteractiveShellApp(Configurable):
         """
     )
     shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
+    
+    def __init__(self, user_ns=None, **kwargs):
+        self.user_ns = user_ns
+        super(InteractiveShellApp, self).__init__(**kwargs)
 
     def init_path(self):
         """Add current working directory, '', to sys.path"""

--- a/IPython/kernel/zmq/kernelapp.py
+++ b/IPython/kernel/zmq/kernelapp.py
@@ -458,6 +458,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp):
         except KeyboardInterrupt:
             pass
 
+launch_new_instance = IPKernelApp.launch_instance
 
 def main():
     """Run an IPKernel as an application"""

--- a/IPython/kernel/zmq/kernelapp.py
+++ b/IPython/kernel/zmq/kernelapp.py
@@ -393,6 +393,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp):
                                 stdin_socket=self.stdin_socket,
                                 log=self.log,
                                 profile_dir=self.profile_dir,
+                                user_ns=self.user_ns,
         )
         kernel.record_ports(self.ports)
         self.kernel = kernel

--- a/IPython/kernel/zmq/tests/test_start_kernel.py
+++ b/IPython/kernel/zmq/tests/test_start_kernel.py
@@ -1,0 +1,17 @@
+import nose.tools as nt
+
+from .test_embed_kernel import setup, teardown, setup_kernel
+
+TIMEOUT = 15
+
+def test_ipython_start_kernel_userns():
+    cmd = ('from IPython import start_kernel\n'
+           'ns = {"tre": 123}\n'
+           'start_kernel(user_ns=ns)')
+    
+    with setup_kernel(cmd) as client:
+        msg_id = client.object_info('tre')
+        msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
+        content = msg['content']
+        assert content['found']
+        nt.assert_equal(content['string_form'], u'123')

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -334,7 +334,7 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
         # so the banner shows *before* all extension loading stuff.
         self.shell = TerminalInteractiveShell.instance(parent=self,
                         display_banner=False, profile_dir=self.profile_dir,
-                        ipython_dir=self.ipython_dir)
+                        ipython_dir=self.ipython_dir, user_ns=self.user_ns)
         self.shell.configurables.append(self)
 
     def init_banner(self):


### PR DESCRIPTION
`start_kernel()` didn't work at all (#4005), and I found while investigating that passing `user_ns` to either `start_ipython()` or `start_kernel()` had no effect, because the Application wasn't passing it on to the Shell.

This is a simple fix for the most pressing issues. We should think about any other parameters that we want to be passed through from our top level API, e.g. possibly `user_module`.

Definitely a candidate for backporting to 1.x
