### PR TITLE
Test skipping without unicode paths

### DIFF
--- a/IPython/core/tests/test_completerlib.py
+++ b/IPython/core/tests/test_completerlib.py
@@ -17,6 +17,7 @@ from os.path import join
 
 from IPython.core.completerlib import magic_run_completer, module_completion
 from IPython.utils.tempdir import TemporaryDirectory
+from IPython.testing.decorators import onlyif_unicode_paths
 
 
 class MockEvent(object):
@@ -29,7 +30,7 @@ class MockEvent(object):
 class Test_magic_run_completer(unittest.TestCase):
     def setUp(self):
         self.BASETESTDIR = tempfile.mkdtemp()
-        for fil in [u"aaø.py", u"a.py", u"b.py"]:
+        for fil in [u"aao.py", u"a.py", u"b.py"]:
             with open(join(self.BASETESTDIR, fil), "w") as sfile:
                 sfile.write("pass\n")
         self.oldpath = os.getcwdu()
@@ -45,7 +46,7 @@ class Test_magic_run_completer(unittest.TestCase):
         event = MockEvent(u"%run a")
         mockself = None
         match = set(magic_run_completer(mockself, event))
-        self.assertEqual(match, set([u"a.py", u"aaø.py"]))
+        self.assertEqual(match, set([u"a.py", u"aao.py"]))
 
     def test_2(self):
         """Test magic_run_completer, should match one alterntive
@@ -53,14 +54,14 @@ class Test_magic_run_completer(unittest.TestCase):
         event = MockEvent(u"%run aa")
         mockself = None
         match = set(magic_run_completer(mockself, event))
-        self.assertEqual(match, set([u"aaø.py"]))
+        self.assertEqual(match, set([u"aao.py"]))
 
     def test_3(self):
         """Test magic_run_completer with unterminated " """
         event = MockEvent(u'%run "a')
         mockself = None
         match = set(magic_run_completer(mockself, event))
-        self.assertEqual(match, set([u"a.py", u"aaø.py"]))
+        self.assertEqual(match, set([u"a.py", u"aao.py"]))
 
     def test_import_invalid_module(self):
         """Testing of issue https://github.com/ipython/ipython/issues/1107"""
@@ -77,3 +78,43 @@ class Test_magic_run_completer(unittest.TestCase):
             self.assertFalse(intersection, intersection)
             
             assert valid_module_names.issubset(s), valid_module_names.intersection(s)
+
+class Test_magic_run_completer_nonascii(unittest.TestCase):
+    @onlyif_unicode_paths
+    def setUp(self):
+        self.BASETESTDIR = tempfile.mkdtemp()
+        for fil in [u"aaø.py", u"a.py", u"b.py"]:
+            with open(join(self.BASETESTDIR, fil), "w") as sfile:
+                sfile.write("pass\n")
+        self.oldpath = os.getcwdu()
+        os.chdir(self.BASETESTDIR)
+
+    def tearDown(self):
+        os.chdir(self.oldpath)
+        shutil.rmtree(self.BASETESTDIR)
+
+    @onlyif_unicode_paths
+    def test_1(self):
+        """Test magic_run_completer, should match two alterntives
+        """
+        event = MockEvent(u"%run a")
+        mockself = None
+        match = set(magic_run_completer(mockself, event))
+        self.assertEqual(match, set([u"a.py", u"aaø.py"]))
+
+    @onlyif_unicode_paths
+    def test_2(self):
+        """Test magic_run_completer, should match one alterntive
+        """
+        event = MockEvent(u"%run aa")
+        mockself = None
+        match = set(magic_run_completer(mockself, event))
+        self.assertEqual(match, set([u"aaø.py"]))
+
+    @onlyif_unicode_paths
+    def test_3(self):
+        """Test magic_run_completer with unterminated " """
+        event = MockEvent(u'%run "a')
+        mockself = None
+        match = set(magic_run_completer(mockself, event))
+        self.assertEqual(match, set([u"a.py", u"aaø.py"]))

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -33,7 +33,7 @@ from StringIO import StringIO
 import nose.tools as nt
 
 # Our own
-from IPython.testing.decorators import skipif
+from IPython.testing.decorators import skipif, onlyif_unicode_paths
 from IPython.testing import tools as tt
 from IPython.utils import io
 
@@ -404,6 +404,7 @@ class InteractiveShellTestCase(unittest.TestCase):
 
 class TestSafeExecfileNonAsciiPath(unittest.TestCase):
 
+    @onlyif_unicode_paths
     def setUp(self):
         self.BASETESTDIR = tempfile.mkdtemp()
         self.TESTDIR = join(self.BASETESTDIR, u"åäö")
@@ -418,6 +419,7 @@ class TestSafeExecfileNonAsciiPath(unittest.TestCase):
         os.chdir(self.oldpath)
         shutil.rmtree(self.BASETESTDIR)
 
+    @onlyif_unicode_paths
     def test_1(self):
         """Test safe_execfile with non-ascii path
         """
@@ -425,6 +427,7 @@ class TestSafeExecfileNonAsciiPath(unittest.TestCase):
 
 
 class TestSystemRaw(unittest.TestCase):
+    @onlyif_unicode_paths
     def test_1(self):
         """Test system_raw with non-ascii cmd
         """

--- a/IPython/core/tests/test_profile.py
+++ b/IPython/core/tests/test_profile.py
@@ -122,9 +122,11 @@ def test_list_profiles_in():
     # the module-level teardown.
     td = tempfile.mkdtemp(dir=TMP_TEST_DIR)
     td = py3compat.str_to_unicode(td)
-    for name in ('profile_foo', u'profile_ünicode', 'profile_hello', 
-                 'not_a_profile'):
+    for name in ('profile_foo', 'profile_hello', 'not_a_profile'):
         os.mkdir(os.path.join(td, name))
+    if dec.unicode_paths:
+        os.mkdir(os.path.join(td, u'profile_ünicode'))
+    
     with open(os.path.join(td, 'profile_file'), 'w') as f:
         f.write("I am not a profile directory")
     profiles = list_profiles_in(td)
@@ -139,7 +141,8 @@ def test_list_profiles_in():
             profiles.remove(p)
             found_unicode = True
             break
-    nt.assert_true(found_unicode)
+    if dec.unicode_paths:
+        nt.assert_true(found_unicode)
     nt.assert_equal(set(profiles), set(['foo', 'hello']))
 
 

--- a/IPython/core/tests/test_prompts.py
+++ b/IPython/core/tests/test_prompts.py
@@ -63,6 +63,7 @@ class PromptTests(unittest.TestCase):
         self.pm.in_template = r'\#>'
         self.assertEqual(self.pm.render('in',color=False), '%d>' % ip.execution_count)
     
+    @dec.onlyif_unicode_paths
     def test_render_unicode_cwd(self):
         save = os.getcwdu()
         with TemporaryDirectory(u'ünicødé') as td:

--- a/IPython/core/tests/test_ultratb.py
+++ b/IPython/core/tests/test_ultratb.py
@@ -6,6 +6,7 @@ import os.path
 import unittest
 
 from IPython.testing import tools as tt
+from IPython.testing.decorators import onlyif_unicode_paths
 from IPython.utils.syspathcontext import prepended_to_syspath
 from IPython.utils.tempdir import TemporaryDirectory
 
@@ -59,9 +60,22 @@ def fail():
 '''
 
 class NonAsciiTest(unittest.TestCase):
-    def test_iso8859_5(self):
+    @onlyif_unicode_paths
+    def test_nonascii_path(self):
         # Non-ascii directory name as well.
         with TemporaryDirectory(suffix=u'é') as td:
+            fname = os.path.join(td, u"fooé.py")
+            with open(fname, "w") as f:
+                f.write(file_1)
+            
+            with prepended_to_syspath(td):
+                ip.run_cell("import foo")
+            
+            with tt.AssertPrints("ZeroDivisionError"):
+                ip.run_cell("foo.f()")
+    
+    def test_iso8859_5(self):
+        with TemporaryDirectory() as td:
             fname = os.path.join(td, 'dfghjkl.py')
 
             with io.open(fname, 'w', encoding='iso-8859-5') as f:

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -28,7 +28,8 @@ from nose import with_setup
 
 import IPython
 from IPython.testing import decorators as dec
-from IPython.testing.decorators import skip_if_not_win32, skip_win32
+from IPython.testing.decorators import (skip_if_not_win32, skip_win32,
+                                        onlyif_unicode_paths,)
 from IPython.testing.tools import make_tempfile, AssertPrints
 from IPython.utils import path
 from IPython.utils import py3compat
@@ -479,7 +480,8 @@ def test_get_py_filename():
             else:
                 nt.assert_raises(IOError, path.get_py_filename, '"foo with spaces.py"', force_win32=False)
                 nt.assert_raises(IOError, path.get_py_filename, "'foo with spaces.py'", force_win32=False)
-                
+
+@onlyif_unicode_paths
 def test_unicode_in_filename():
     """When a file doesn't exist, the exception raised should be safe to call
     str() on - i.e. in Python 2 it must only have ASCII characters.


### PR DESCRIPTION
I somehow broke unicode in the terminal on this Debian box, and it revealed a load of tests that errored because they were trying to use non-ascii paths and commands. We already have a decorator for this, so I've scattered it around, and broken up a couple of tests into smaller chunks.
