### PR TITLE
Fix parallel.client.View map() on numpy arrays

### DIFF
--- a/IPython/parallel/client/remotefunction.py
+++ b/IPython/parallel/client/remotefunction.py
@@ -232,7 +232,8 @@ class ParallelFunction(RemoteFunction):
             for seq in sequences:
                 part = self.mapObject.getPartition(seq, index, nparts, maxlen)
                 args.append(part)
-            if not any(args):
+
+            if sum([len(arg) for arg in args]) == 0:
                 continue
 
             if self._mapping:

--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -343,7 +343,7 @@ class TestView(ClusterTestCase, ParametricTestCase):
         # ensure it will be an iterator, even in Python 3
         it = iter(arr)
         r = view.map_sync(lambda x: x, it)
-        self.assertEqual(r, list(it))
+        self.assertEqual(r, list(arr))
 
     @skip_without('numpy')
     def test_map_numpy(self):

--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -344,6 +344,18 @@ class TestView(ClusterTestCase, ParametricTestCase):
         it = iter(arr)
         r = view.map_sync(lambda x:x, arr)
         self.assertEqual(r, list(arr))
+
+    @skip_without('numpy')
+    def test_map_numpy(self):
+        """test map on numpy arrays (direct)"""
+        import numpy
+        from numpy.testing.utils import assert_array_equal
+
+        view = self.client[:]
+        # 101 is prime, so it won't be evenly distributed
+        arr = numpy.arange(101)
+        r = view.map_sync(lambda x: x, arr)
+        assert_array_equal(r, arr)
     
     def test_scatter_gather_nonblocking(self):
         data = range(16)

--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -342,8 +342,8 @@ class TestView(ClusterTestCase, ParametricTestCase):
         arr = range(101)
         # ensure it will be an iterator, even in Python 3
         it = iter(arr)
-        r = view.map_sync(lambda x:x, arr)
-        self.assertEqual(r, list(arr))
+        r = view.map_sync(lambda x: x, it)
+        self.assertEqual(r, list(it))
 
     @skip_without('numpy')
     def test_map_numpy(self):


### PR DESCRIPTION
Resolves https://github.com/ipython/ipython/issues/4020.
