### PR TITLE
DOC: fix links to matplotlib, notebook docs

### DIFF
--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -156,14 +156,15 @@ class="notebook_app"
         <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Help</a>
             <ul class="dropdown-menu">
                 <li><a href="http://ipython.org/documentation.html" target="_blank">IPython Help</a></li>
-                <li><a href="http://ipython.org/ipython-doc/stable/interactive/htmlnotebook.html" target="_blank">Notebook Help</a></li>
+                <li><a href="http://ipython.org/ipython-doc/stable/interactive/notebook.html" target="_blank">Notebook Help</a></li>
                 <li id="keyboard_shortcuts"><a href="#">Keyboard Shortcuts</a></li>
                 <li class="divider"></li>
                 <li><a href="http://docs.python.org" target="_blank">Python</a></li>
                 <li><a href="http://docs.scipy.org/doc/numpy/reference/" target="_blank">NumPy</a></li>
                 <li><a href="http://docs.scipy.org/doc/scipy/reference/" target="_blank">SciPy</a></li>
+                <li><a href="http://matplotlib.org/" target="_blank">Matplotlib</a></li>
                 <li><a href="http://docs.sympy.org/dev/index.html" target="_blank">SymPy</a></li>
-                <li><a href="http://matplotlib.sourceforge.net/" target="_blank">Matplotlib</a></li>
+                <li><a href="http://pandas.pydata.org/pandas-docs/stable/" target="_blank">pandas</a></li>
             </ul>
         </li>
     </ul>

--- a/docs/source/interactive/qtconsole.rst
+++ b/docs/source/interactive/qtconsole.rst
@@ -44,7 +44,7 @@ for playing with examples from documentation, such as matplotlib.
 
 .. sourcecode:: ipython
 
-    In [6]: %load http://matplotlib.sourceforge.net/plot_directive/mpl_examples/mplot3d/contour3d_demo.py
+    In [6]: %load http://matplotlib.org/plot_directive/mpl_examples/mplot3d/contour3d_demo.py
 
     In [7]: from mpl_toolkits.mplot3d import axes3d
        ...: import matplotlib.pyplot as plt

--- a/docs/source/interactive/reference.rst
+++ b/docs/source/interactive/reference.rst
@@ -1013,7 +1013,7 @@ object, do::
 
     %gui wx
 
-For information on IPython's Matplotlib integration (and the ``matplotlib``
+For information on IPython's matplotlib_ integration (and the ``matplotlib``
 mode) see :ref:`this section <matplotlib_support>`.
 
 For developers that want to use IPython's GUI event loop integration in the
@@ -1088,7 +1088,7 @@ neither v2 PyQt nor PySide work.
 Plotting with matplotlib
 ========================
 
-`Matplotlib`_ provides high quality 2D and 3D plotting for Python. Matplotlib
+matplotlib_ provides high quality 2D and 3D plotting for Python. matplotlib_
 can produce plots on screen using a variety of GUI toolkits, including Tk,
 PyGTK, PyQt4 and wxPython. It also provides a number of commands useful for
 scientific computing, all with a syntax compatible with that of the popular
@@ -1103,8 +1103,6 @@ matplotlib backend.  You can also request a specific backend with
 backend value, which produces static figures inlined inside the application
 window instead of matplotlib's interactive figures that live in separate
 windows.
-
-.. _Matplotlib: http://matplotlib.sourceforge.net
 
 .. _interactive_demos:
 
@@ -1163,3 +1161,4 @@ divisions are allowed. If you want to be able to open an IPython
 instance at an arbitrary point in a program, you can use IPython's
 embedding facilities, see :func:`IPython.embed` for details.
 
+.. include:: ../links.txt

--- a/docs/source/links.txt
+++ b/docs/source/links.txt
@@ -31,7 +31,7 @@
 .. _graphviz: http://www.graphviz.org
 .. _Sphinx: http://sphinx.pocoo.org
 .. _`Sphinx reST`: http://sphinx.pocoo.org/rest.html
-.. _sampledoc: http://matplotlib.sourceforge.net/sampledoc
+.. _sampledoc: http://matplotlib.org/sampledoc
 .. _reST: http://docutils.sourceforge.net/rst.html
 .. _docutils: http://docutils.sourceforge.net
 .. _lyx: http://www.lyx.org

--- a/docs/source/parallel/parallel_winhpc.rst
+++ b/docs/source/parallel/parallel_winhpc.rst
@@ -12,7 +12,7 @@ interactive numerical work. Second, it is easy (often times trivial) to
 integrate legacy C/C++/Fortran code into Python. Third, a large number of
 high-quality open source projects provide all the needed building blocks for
 numerical computing: numerical arrays (NumPy), algorithms (SciPy), 2D/3D
-Visualization (Matplotlib, Mayavi, Chaco), Symbolic Mathematics (Sage, Sympy)
+Visualization (matplotlib_, Mayavi, Chaco), Symbolic Mathematics (Sage, Sympy)
 and others.
 
 The IPython project is a core part of this open-source toolchain and is
@@ -86,7 +86,7 @@ In addition, the following dependencies are needed to run the demos described
 in this document.
 
 * NumPy and SciPy (http://www.scipy.org)
-* Matplotlib (http://matplotlib.sourceforge.net/)
+* matplotlib_ (http://matplotlib.org)
 
 The easiest way of obtaining these dependencies is through the Enthought
 Python Distribution (EPD) (http://www.enthought.com/products/epd.php). EPD is
@@ -358,3 +358,4 @@ The :meth:`map` method has the same signature as Python's builtin :func:`map`
 function, but runs the calculation in parallel. More involved examples of using
 :class:`DirectView` are provided in the examples that follow.
 
+.. include:: ../links.txt


### PR DESCRIPTION
I've added a link to pandas, made all matplotlib links point to 
matplotlib.org, and fixed a link in the notebook help menu to point to our new
notebook.html, now that htmlnotebook.html is a redirect.

Whoever ends up merging this PR should backport it to 1.x.
