### PR TITLE
check png is base 64 in branch 1.0 (test case for issue #3903)

### DIFF
--- a/IPython/nbconvert/tests/test_nbconvertapp.py
+++ b/IPython/nbconvert/tests/test_nbconvertapp.py
@@ -112,7 +112,7 @@ class TestNbConvertApp(TestsBase):
                       'notebook2.ipynb --template full ')
             assert os.path.isfile('notebook2.html')
             with open('notebook2.html') as f:
-                assert "data:image/png;base64,i" in f.read()
+                assert "data:image/png;base64,b'" not in f.read()
 
 
 

--- a/IPython/nbconvert/tests/test_nbconvertapp.py
+++ b/IPython/nbconvert/tests/test_nbconvertapp.py
@@ -102,6 +102,19 @@ class TestNbConvertApp(TestsBase):
             assert os.path.isfile('notebook1.tex')
             assert os.path.isfile('notebook1.pdf')
 
+    @dec.onlyif_cmds_exist('pandoc')
+    def test_png_base64_html_ok(self):
+        """
+        is png base64 well formed in HTML ?
+        """
+        with self.create_temp_cwd(['notebook2.ipynb']):
+            self.call('nbconvert --log-level 0 --to HTML '
+                      'notebook2.ipynb --template full ')
+            assert os.path.isfile('notebook2.html')
+            with open('notebook2.html') as f:
+                assert "data:image/png;base64,i" in f.read()
+
+
 
     @dec.onlyif_cmds_exist('pandoc')
     def test_template(self):


### PR DESCRIPTION
This check that the Base64 png image in the "--to html" converted notebook is correctly generated.
(Test fails on 1.0.0 for python3.\* , and ipython 2.0 dev too)
