### PR TITLE
bug fix in IPython/parallel/client/remotefunction.py

### DIFF
--- a/IPython/parallel/client/remotefunction.py
+++ b/IPython/parallel/client/remotefunction.py
@@ -232,7 +232,7 @@ class ParallelFunction(RemoteFunction):
             for seq in sequences:
                 part = self.mapObject.getPartition(seq, index, nparts, maxlen)
                 args.append(part)
-            if not any(args):
+            if not len(args):
                 continue
 
             if self._mapping:


### PR DESCRIPTION
change any(args) to len(args) because any(args) fails when args is a list with numpy.array type elements.

This small change fixes the problem reported in 

http://nbviewer.ipython.org/6207703
