### PR TITLE
exclude `.git` in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -37,3 +37,4 @@ global-exclude *.flc
 global-exclude *.pyc
 global-exclude *.pyo
 global-exclude .dircopy.log
+global-exclude .git


### PR DESCRIPTION
so it won't be included in submodules in sdists.
