### PR TITLE
Fixed custom jinja2 templates being ignored when setting template_path

### DIFF
--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -173,7 +173,7 @@ class NotebookWebApplication(web.Application):
             mathjax_url=ipython_app.mathjax_url,
             config=ipython_app.config,
             use_less=ipython_app.use_less,
-            jinja2_env=Environment(loader=FileSystemLoader(template_path))
+            jinja2_env=Environment(loader=FileSystemLoader(template_path)),
         )
 
         # allow custom overrides for the tornado web app.

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -172,12 +172,15 @@ class NotebookWebApplication(web.Application):
             # IPython stuff
             mathjax_url=ipython_app.mathjax_url,
             config=ipython_app.config,
-            use_less=ipython_app.use_less,
-            jinja2_env=Environment(loader=FileSystemLoader(template_path)),
+            use_less=ipython_app.use_less
         )
 
         # allow custom overrides for the tornado web app.
         settings.update(settings_overrides)
+
+        # create a jinja2 environment using the template path and store it in settings
+        settings.jinja2_env=Environment(loader=FileSystemLoader(settings.template_path))
+
         return settings
 
     def init_handlers(self, settings):

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -179,7 +179,7 @@ class NotebookWebApplication(web.Application):
         settings.update(settings_overrides)
 
         # create a jinja2 environment using the template path and store it in settings
-        settings.jinja2_env=Environment(loader=FileSystemLoader(settings.template_path))
+        settings["jinja2_env"]=Environment(loader=FileSystemLoader(settings["template_path"]))
 
         return settings
 

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -149,7 +149,7 @@ class NotebookWebApplication(web.Application):
         # Note that the URLs these patterns check against are escaped,
         # and thus guaranteed to be ASCII: 'héllo' is really 'h%C3%A9llo'.
         base_project_url = py3compat.unicode_to_str(base_project_url, 'ascii')
-        template_path = os.path.join(os.path.dirname(__file__), "templates")
+        template_path = settings_overrides.get("template_path", os.path.join(os.path.dirname(__file__), "templates"))
         settings = dict(
             # basics
             base_project_url=base_project_url,
@@ -172,15 +172,12 @@ class NotebookWebApplication(web.Application):
             # IPython stuff
             mathjax_url=ipython_app.mathjax_url,
             config=ipython_app.config,
-            use_less=ipython_app.use_less
+            use_less=ipython_app.use_less,
+            jinja2_env=Environment(loader=FileSystemLoader(template_path))
         )
 
         # allow custom overrides for the tornado web app.
         settings.update(settings_overrides)
-
-        # create a jinja2 environment using the template path and store it in settings
-        settings["jinja2_env"]=Environment(loader=FileSystemLoader(settings["template_path"]))
-
         return settings
 
     def init_handlers(self, settings):


### PR DESCRIPTION
IPython/html/notebookapp.py was ignoring user specified templates by setting the jinja2 environment to the default template directory before updating template_path.  This fix allows a user defined template_path to propagate to the jinja2 environment.
