### PR TITLE
Test no incorrect 'data:image/png;base64,b' in html files.

### DIFF
--- a/IPython/nbconvert/tests/test_nbconvertapp.py
+++ b/IPython/nbconvert/tests/test_nbconvertapp.py
@@ -15,10 +15,12 @@ Contains tests for the nbconvertapp
 
 import os
 import glob
+import sys
 
 from .base import TestsBase
 
 from IPython.testing import decorators as dec
+from IPython.external.decorators import knownfailureif
 
     
 #-----------------------------------------------------------------------------
@@ -101,6 +103,20 @@ class TestNbConvertApp(TestsBase):
                       '--post PDF --PDFPostProcessor.verbose=True')
             assert os.path.isfile('notebook1.tex')
             assert os.path.isfile('notebook1.pdf')
+
+
+    @dec.onlyif_cmds_exist('pandoc')
+    @knownfailureif(sys.version_info[0] >= 3, "nbconvert html conversion fails for .png images on Python3 ")
+    def test_png_base64_html_ok(self):
+        """
+        is png base64 well formed in HTML ?
+        """
+        with self.create_temp_cwd(['notebook2.ipynb']):
+            self.call('nbconvert --log-level 0 --to HTML '
+                      'notebook2.ipynb --template full ')
+            assert os.path.isfile('notebook2.html')
+            with open('notebook2.html') as f:
+                assert "data:image/png;base64,b'" not in f.read()
 
 
     @dec.onlyif_cmds_exist('pandoc')


### PR DESCRIPTION
Check  that HTML conversion of a notebook with images by "nbconvert --to html" is ok.

It currently fails under python3 (detected in issue #3903 )

bad transformation =
 img src="data:image/png;base64,b'iVBOR....

good transformation = 
img src="data:image/png;base64,iVBOR....
