### PR TITLE
Use istype() when checking if canned object is a dict

### DIFF
--- a/IPython/kernel/zmq/serialize.py
+++ b/IPython/kernel/zmq/serialize.py
@@ -127,7 +127,7 @@ def unserialize_object(buffers, g=None):
         for c in canned:
             _restore_buffers(c, bufs)
         newobj = uncan_sequence(canned, g)
-    elif isinstance(canned, dict) and len(canned) < MAX_ITEMS:
+    elif istype(canned, dict) and len(canned) < MAX_ITEMS:
         newobj = {}
         for k in sorted(canned.iterkeys()):
             c = canned[k]


### PR DESCRIPTION
Using istype(canned, dict) instead of isinstance(canned, dict) ensures that dict subclasses retain their type during unserialization. This also agrees with the implementation of serialize_object().
