### PR TITLE
Use default OS shell to run system commands

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -28,6 +28,7 @@ import runpy
 import sys
 import tempfile
 import types
+import subprocess
 from io import open as io_open
 
 from IPython.config.configurable import SingletonConfigurable
@@ -2235,7 +2236,7 @@ class InteractiveShell(SingletonConfigurable):
                 ec = os.system(cmd)
         else:
             cmd = py3compat.unicode_to_str(cmd)
-            ec = os.system(cmd)
+            ec = subprocess.call(cmd, shell=True, executable=os.environ.get('SHELL'))
             # The high byte is the exit code, the low byte is a signal number
             # that we discard for now. See the docs for os.wait()
             if ec > 255:

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2218,7 +2218,8 @@ class InteractiveShell(SingletonConfigurable):
         self.user_ns['_exit_code'] = system(self.var_expand(cmd, depth=1))
 
     def system_raw(self, cmd):
-        """Call the given cmd in a subprocess using os.system
+        """Call the given cmd in a subprocess using os.system on Windows or
+        subprocess.call using the system shell on other platforms.
 
         Parameters
         ----------
@@ -2236,11 +2237,12 @@ class InteractiveShell(SingletonConfigurable):
                 ec = os.system(cmd)
         else:
             cmd = py3compat.unicode_to_str(cmd)
-            ec = subprocess.call(cmd, shell=True, executable=os.environ.get('SHELL'))
-            # The high byte is the exit code, the low byte is a signal number
-            # that we discard for now. See the docs for os.wait()
-            if ec > 255:
-                ec >>= 8
+            # Call the cmd using the OS shell, instead of the default /bin/sh, if set.
+            ec = subprocess.call(cmd, shell=True, executable=os.environ.get('SHELL', None))
+            # Returns either the exit code or minus the value of the signal number.
+            # See the docs for subprocess.Popen.returncode .
+            if ec < 0:
+                ec = -ec
         
         # We explicitly do NOT return the subprocess status code, because
         # a non-None value would trigger :func:`sys.displayhook` calls.


### PR DESCRIPTION
Instead of using os.system which uses /bin/sh, this uses subprocess.call (the replacement of os.system) to run the command using the default shell of the OS. With this, one can use more advanced commands for bash, zsh, ksh, ...

I do not have a win32 system to test this modification, so maybe line 2236 can also be changed like 2239.
