### PR TITLE
respect `pylab_import_all` when `--pylab` specified at the command-line

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -217,7 +217,7 @@ class InteractiveShellApp(Configurable):
         enable = False
         shell = self.shell
         if self.pylab:
-            enable = shell.enable_pylab
+            enable = lambda key: shell.enable_pylab(key, import_all=self.pylab_import_all)
             key = self.pylab
         elif self.matplotlib:
             enable = shell.enable_matplotlib


### PR DESCRIPTION
Earlier cleanup cleaned up a bit too much, ignoring this configurable.

should be backported to 1.x
