### PR TITLE
Store default codemirror mode in only 1 place

### DIFF
--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -322,8 +322,8 @@ var IPython = (function (IPython) {
                 }
             }
         }
-        // fallback on default (python)
-        var default_mode = this.default_mode || 'text/plain';
+        // fallback on default
+        var default_mode = this._options.cm_config.mode || 'text/plain';
         this.code_mirror.setOption('mode', default_mode);
     };
 

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -323,7 +323,12 @@ var IPython = (function (IPython) {
             }
         }
         // fallback on default
-        var default_mode = this._options.cm_config.mode || 'text/plain';
+        var default_mode
+        try {
+            default_mode = this._options.cm_config.mode;
+        } catch(e) {
+            default_mode = 'text/plain';
+        }
         this.code_mirror.setOption('mode', default_mode);
     };
 

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -65,7 +65,6 @@ var IPython = (function (IPython) {
         this.code_mirror = null;
         this.input_prompt_number = null;
         this.collapsed = false;
-        this.default_mode = 'ipython';
         this.cell_type = "code";
 
 


### PR DESCRIPTION
All is in title.
The default_mode value was not used in any other places.
