### PR TITLE
Drop 2to3, common codebase for Python 2 and 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
     - sudo apt-get install pandoc
     - pip install pygments
     - pip install sphinx
+    - pip install six
 install:
     - python setup.py install -q 
 script:

--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -39,6 +39,7 @@ from IPython.utils.traitlets import (
 )
 from IPython.utils.importstring import import_item
 from IPython.utils.text import indent, wrap_paragraphs, dedent
+from IPython.utils.py3compat import string_types
 import six
 
 #-----------------------------------------------------------------------------
@@ -152,7 +153,7 @@ class Application(SingletonConfigurable):
                     help="Set the log level by value or name.")
     def _log_level_changed(self, name, old, new):
         """Adjust the log level when log_level is set."""
-        if isinstance(new, basestring):
+        if isinstance(new, string_types):
             new = getattr(logging, new)
             self.log_level = new
         self.log.setLevel(new)
@@ -215,7 +216,7 @@ class Application(SingletonConfigurable):
         for key,value in six.iteritems(new):
             assert len(value) == 2, "Bad flag: %r:%s"%(key,value)
             assert isinstance(value[0], (dict, Config)), "Bad flag: %r:%s"%(key,value)
-            assert isinstance(value[1], basestring), "Bad flag: %r:%s"%(key,value)
+            assert isinstance(value[1], string_types), "Bad flag: %r:%s"%(key,value)
 
 
     # subcommands for launching other applications
@@ -397,7 +398,7 @@ class Application(SingletonConfigurable):
         """Initialize a subcommand with argv."""
         subapp,help = self.subcommands.get(subc)
 
-        if isinstance(subapp, basestring):
+        if isinstance(subapp, string_types):
             subapp = import_item(subapp)
 
         # clear existing instances

--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -7,6 +7,7 @@ Authors:
 * Brian Granger
 * Min RK
 """
+from __future__ import print_function
 
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2008-2011  The IPython Development Team
@@ -38,6 +39,7 @@ from IPython.utils.traitlets import (
 )
 from IPython.utils.importstring import import_item
 from IPython.utils.text import indent, wrap_paragraphs, dedent
+import six
 
 #-----------------------------------------------------------------------------
 # function for re-wrapping a helpstring
@@ -210,7 +212,7 @@ class Application(SingletonConfigurable):
     flags = Dict()
     def _flags_changed(self, name, old, new):
         """ensure flags dict is valid"""
-        for key,value in new.iteritems():
+        for key,value in six.iteritems(new):
             assert len(value) == 2, "Bad flag: %r:%s"%(key,value)
             assert isinstance(value[0], (dict, Config)), "Bad flag: %r:%s"%(key,value)
             assert isinstance(value[1], basestring), "Bad flag: %r:%s"%(key,value)
@@ -270,7 +272,7 @@ class Application(SingletonConfigurable):
             for c in cls.mro()[:-3]:
                 classdict[c.__name__] = c
 
-        for alias, longname in self.aliases.iteritems():
+        for alias, longname in six.iteritems(self.aliases):
             classname, traitname = longname.split('.',1)
             cls = classdict[classname]
 
@@ -282,7 +284,7 @@ class Application(SingletonConfigurable):
                 help[0] = help[0].replace('--%s='%alias, '-%s '%alias)
             lines.extend(help)
         # lines.append('')
-        print os.linesep.join(lines)
+        print(os.linesep.join(lines))
 
     def print_flag_help(self):
         """Print the flag part of the help."""
@@ -290,12 +292,12 @@ class Application(SingletonConfigurable):
             return
 
         lines = []
-        for m, (cfg,help) in self.flags.iteritems():
+        for m, (cfg,help) in six.iteritems(self.flags):
             prefix = '--' if len(m) > 1 else '-'
             lines.append(prefix+m)
             lines.append(indent(dedent(help.strip())))
         # lines.append('')
-        print os.linesep.join(lines)
+        print(os.linesep.join(lines))
 
     def print_options(self):
         if not self.flags and not self.aliases:
@@ -306,10 +308,10 @@ class Application(SingletonConfigurable):
         for p in wrap_paragraphs(self.option_description):
             lines.append(p)
             lines.append('')
-        print os.linesep.join(lines)
+        print(os.linesep.join(lines))
         self.print_flag_help()
         self.print_alias_help()
-        print
+        print()
 
     def print_subcommands(self):
         """Print the subcommand part of the help."""
@@ -322,12 +324,12 @@ class Application(SingletonConfigurable):
         for p in wrap_paragraphs(self.subcommand_description):
             lines.append(p)
             lines.append('')
-        for subc, (cls, help) in self.subcommands.iteritems():
+        for subc, (cls, help) in six.iteritems(self.subcommands):
             lines.append(subc)
             if help:
                 lines.append(indent(dedent(help.strip())))
         lines.append('')
-        print os.linesep.join(lines)
+        print(os.linesep.join(lines))
 
     def print_help(self, classes=False):
         """Print the help for each Configurable class in self.classes.
@@ -340,19 +342,19 @@ class Application(SingletonConfigurable):
 
         if classes:
             if self.classes:
-                print "Class parameters"
-                print "----------------"
-                print
+                print("Class parameters")
+                print("----------------")
+                print()
                 for p in wrap_paragraphs(self.keyvalue_description):
-                    print p
-                    print
+                    print(p)
+                    print()
 
             for cls in self.classes:
                 cls.class_print_help()
-                print
+                print()
         else:
-            print "To see all available configurables, use `--help-all`"
-            print
+            print("To see all available configurables, use `--help-all`")
+            print()
 
         self.print_examples()
 
@@ -360,8 +362,8 @@ class Application(SingletonConfigurable):
     def print_description(self):
         """Print the application description."""
         for p in wrap_paragraphs(self.description):
-            print p
-            print
+            print(p)
+            print()
 
     def print_examples(self):
         """Print usage and examples.
@@ -370,15 +372,15 @@ class Application(SingletonConfigurable):
         and should contain examples of the application's usage.
         """
         if self.examples:
-            print "Examples"
-            print "--------"
-            print
-            print indent(dedent(self.examples.strip()))
-            print
+            print("Examples")
+            print("--------")
+            print()
+            print(indent(dedent(self.examples.strip())))
+            print()
 
     def print_version(self):
         """Print the version string."""
-        print self.version
+        print(self.version)
 
     def update_config(self, config):
         """Fire the traits events when the config is updated."""
@@ -428,7 +430,7 @@ class Application(SingletonConfigurable):
         # flatten aliases, which have the form:
         # { 'alias' : 'Class.trait' }
         aliases = {}
-        for alias, cls_trait in self.aliases.iteritems():
+        for alias, cls_trait in six.iteritems(self.aliases):
             cls,trait = cls_trait.split('.',1)
             children = mro_tree[cls]
             if len(children) == 1:
@@ -439,9 +441,9 @@ class Application(SingletonConfigurable):
         # flatten flags, which are of the form:
         # { 'key' : ({'Cls' : {'trait' : value}}, 'help')}
         flags = {}
-        for key, (flagdict, help) in self.flags.iteritems():
+        for key, (flagdict, help) in six.iteritems(self.flags):
             newflag = {}
-            for cls, subdict in flagdict.iteritems():
+            for cls, subdict in six.iteritems(flagdict):
                 children = mro_tree[cls]
                 # exactly one descendent, promote flag section
                 if len(children) == 1:

--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -13,6 +13,7 @@ Authors:
 * Fernando Perez
 * Min RK
 """
+from __future__ import print_function
 
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2008-2011  The IPython Development Team
@@ -28,9 +29,10 @@ Authors:
 import datetime
 from copy import deepcopy
 
-from loader import Config
+from .loader import Config
 from IPython.utils.traitlets import HasTraits, Instance
 from IPython.utils.text import indent, wrap_paragraphs
+import six
 
 
 #-----------------------------------------------------------------------------
@@ -147,7 +149,7 @@ class Configurable(HasTraits):
             section_names = self.section_names()
         
         my_config = self._find_my_config(cfg)
-        for name, config_value in my_config.iteritems():
+        for name, config_value in six.iteritems(my_config):
             if name in traits:
                 # We have to do a deepcopy here if we don't deepcopy the entire
                 # config object. If we don't, a mutable config_value will be
@@ -191,7 +193,7 @@ class Configurable(HasTraits):
         final_help = []
         final_help.append(u'%s options' % cls.__name__)
         final_help.append(len(final_help[0])*u'-')
-        for k, v in sorted(cls.class_traits(config=True).iteritems()):
+        for k, v in sorted(six.iteritems(cls.class_traits(config=True))):
             help = cls.class_get_trait_help(v, inst)
             final_help.append(help)
         return '\n'.join(final_help)
@@ -231,7 +233,7 @@ class Configurable(HasTraits):
     @classmethod
     def class_print_help(cls, inst=None):
         """Get the help string for a single trait and print it."""
-        print cls.class_get_help(inst)
+        print(cls.class_get_help(inst))
 
     @classmethod
     def class_config_section(cls):
@@ -271,7 +273,7 @@ class Configurable(HasTraits):
             lines.append(c('%s will inherit config from: %s'%(cls.__name__, pstr)))
             lines.append('')
 
-        for name, trait in cls.class_traits(config=True).iteritems():
+        for name, trait in six.iteritems(cls.class_traits(config=True)):
             help = trait.get_metadata('help') or ''
             lines.append(c(help))
             lines.append('# c.%s.%s = %r'%(cls.__name__, name, trait.get_default_value()))

--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -23,7 +23,11 @@ Authors
 # Imports
 #-----------------------------------------------------------------------------
 
-import __builtin__ as builtin_mod
+try:
+    import builtins
+except ImportError:  
+    # Python 2
+    import __builtin__ as builtins
 import os
 import re
 import sys
@@ -156,11 +160,11 @@ class Config(dict):
         is_section_key = self.__class__._is_section_key.__get__(self)
 
         # Because we use this for an exec namespace, we need to delegate
-        # the lookup of names in __builtin__ to itself.  This means
+        # the lookup of names in builtins to itself.  This means
         # that you can't have section or attribute names that are
         # builtins.
         try:
-            return getattr(builtin_mod, key)
+            return getattr(builtins, key)
         except AttributeError:
             pass
         if is_section_key(key):

--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -32,6 +32,7 @@ from IPython.external import argparse
 from IPython.utils.path import filefind, get_ipython_dir
 from IPython.utils import py3compat, warn
 from IPython.utils.encoding import DEFAULT_ENCODING
+import six
 
 #-----------------------------------------------------------------------------
 # Exceptions
@@ -105,7 +106,7 @@ class Config(dict):
     def merge(self, other):
         """merge another config object into this one"""
         to_update = {}
-        for k, v in other.iteritems():
+        for k, v in six.iteritems(other):
             if k not in self:
                 to_update[k] = v
             else: # I have this key
@@ -375,14 +376,14 @@ class CommandLineConfigLoader(ConfigLoader):
             # This case happens if the rhs is a string.
             value = rhs
 
-        exec u'self.config.%s = value' % lhs
+        exec(u'self.config.%s = value' % lhs)
 
     def _load_flag(self, cfg):
         """update self.config from a flag, which can be a dict or Config"""
         if isinstance(cfg, (dict, Config)):
             # don't clobber whole config sections, update
             # each section from config:
-            for sec,c in cfg.iteritems():
+            for sec,c in six.iteritems(cfg):
                 self.config[sec].update(c)
         else:
             raise TypeError("Invalid flag: %r" % cfg)
@@ -630,8 +631,8 @@ class ArgParseConfigLoader(CommandLineConfigLoader):
 
     def _convert_to_config(self):
         """self.parsed_data->self.config"""
-        for k, v in vars(self.parsed_data).iteritems():
-            exec "self.config.%s = v"%k in locals(), globals()
+        for k, v in six.iteritems(vars(self.parsed_data)):
+            exec("self.config.%s = v"%k, locals(), globals())
 
 class KVArgParseConfigLoader(ArgParseConfigLoader):
     """A config loader that loads aliases and flags with argparse,
@@ -647,7 +648,7 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
         if flags is None:
             flags = self.flags
         paa = self.parser.add_argument
-        for key,value in aliases.iteritems():
+        for key,value in six.iteritems(aliases):
             if key in flags:
                 # flags
                 nargs = '?'
@@ -657,7 +658,7 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
                 paa('-'+key, '--'+key, type=unicode, dest=value, nargs=nargs)
             else:
                 paa('--'+key, type=unicode, dest=value, nargs=nargs)
-        for key, (value, help) in flags.iteritems():
+        for key, (value, help) in six.iteritems(flags):
             if key in self.aliases:
                 #
                 self.alias_flags[self.aliases[key]] = value
@@ -676,7 +677,7 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
         else:
             subcs = []
 
-        for k, v in vars(self.parsed_data).iteritems():
+        for k, v in six.iteritems(vars(self.parsed_data)):
             if v is None:
                 # it was a flag that shares the name of an alias
                 subcs.append(self.alias_flags[k])

--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -151,7 +151,7 @@ class Config(dict):
 
     def __deepcopy__(self, memo):
         import copy
-        return type(self)(copy.deepcopy(self.items()))
+        return type(self)(copy.deepcopy(list(self.items())))
 
     def __getitem__(self, key):
         # We cannot use directly self._is_section_key, because it triggers
@@ -469,7 +469,7 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
         if enc is None:
             enc = DEFAULT_ENCODING
         for arg in argv:
-            if not isinstance(arg, unicode):
+            if not isinstance(arg, py3compat.unicode_type):
                 # only decode if not already decoded
                 arg = arg.decode(enc)
             uargv.append(arg)
@@ -659,9 +659,9 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
             else:
                 nargs = None
             if len(key) is 1:
-                paa('-'+key, '--'+key, type=unicode, dest=value, nargs=nargs)
+                paa('-'+key, '--'+key, type=py3compat.unicode_type, dest=value, nargs=nargs)
             else:
-                paa('--'+key, type=unicode, dest=value, nargs=nargs)
+                paa('--'+key, type=py3compat.unicode_type, dest=value, nargs=nargs)
         for key, (value, help) in six.iteritems(flags):
             if key in self.aliases:
                 #

--- a/IPython/config/tests/test_loader.py
+++ b/IPython/config/tests/test_loader.py
@@ -64,7 +64,7 @@ class TestPyFileCL(TestCase):
         self.assertEqual(config.a, 10)
         self.assertEqual(config.b, 20)
         self.assertEqual(config.Foo.Bar.value, 10)
-        self.assertEqual(config.Foo.Bam.value, range(10))
+        self.assertEqual(config.Foo.Bam.value, list(range(10)))
         self.assertEqual(config.D.C.value, 'hi there')
 
 class MyLoader1(ArgParseConfigLoader):
@@ -126,7 +126,7 @@ class TestKeyValueCL(TestCase):
         self.assertEqual(config.a, 10)
         self.assertEqual(config.b, 20)
         self.assertEqual(config.Foo.Bar.value, 10)
-        self.assertEqual(config.Foo.Bam.value, range(10))
+        self.assertEqual(config.Foo.Bam.value, list(range(10)))
         self.assertEqual(config.D.C.value, 'hi there')
     
     def test_expanduser(self):
@@ -247,7 +247,7 @@ class TestConfig(TestCase):
         c1.Foo.bar = 10
         c1.Foo.bam = 30
         c1.a = 'asdf'
-        c1.b = range(10)
+        c1.b = list(range(10))
         import copy
         c2 = copy.deepcopy(c1)
         self.assertEqual(c1, c2)
@@ -256,7 +256,7 @@ class TestConfig(TestCase):
 
     def test_builtin(self):
         c1 = Config()
-        exec 'foo = True' in c1
+        exec('foo = True', c1)
         self.assertEqual(c1.foo, True)
         c1.format = "json"
     

--- a/IPython/config/tests/test_loader.py
+++ b/IPython/config/tests/test_loader.py
@@ -93,8 +93,8 @@ class TestArgParseCL(TestCase):
         self.assertEqual(config.n, True)
         self.assertEqual(config.Global.bam, 'wow')
         config = cl.load_config(['wow'])
-        self.assertEqual(config.keys(), ['Global'])
-        self.assertEqual(config.Global.keys(), ['bam'])
+        self.assertEqual(list(config.keys()), ['Global'])
+        self.assertEqual(list(config.Global.keys()), ['bam'])
         self.assertEqual(config.Global.bam, 'wow')
 
     def test_add_arguments(self):

--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -20,7 +20,11 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
-import __builtin__
+try:
+    import builtins
+except ImportError:  
+    # Python 2
+    import __builtin__ as builtins
 import keyword
 import os
 import re
@@ -132,7 +136,7 @@ class AliasManager(Configurable):
         # set of things NOT to alias (keywords, builtins and some magics)
         no_alias = set(['cd','popd','pushd','dhist','alias','unalias'])
         no_alias.update(set(keyword.kwlist))
-        no_alias.update(set(__builtin__.__dict__.keys()))
+        no_alias.update(set(builtins.__dict__.keys()))
         self.no_alias = no_alias
 
     def init_aliases(self):

--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -32,7 +32,7 @@ import sys
 
 from IPython.config.configurable import Configurable
 from IPython.core.splitinput import split_user_input
-
+from IPython.utils.py3compat import string_types
 from IPython.utils.traitlets import List, Instance
 from IPython.utils.warn import warn, error
 import six
@@ -176,7 +176,7 @@ class AliasManager(Configurable):
         if name in self.no_alias:
             raise InvalidAliasError("The name %s can't be aliased "
                                     "because it is a keyword or builtin." % name)
-        if not (isinstance(cmd, basestring)):
+        if not (isinstance(cmd, string_types)):
             raise InvalidAliasError("An alias command must be a string, "
                                     "got: %r" % cmd)
         nargs = cmd.count('%s')

--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -31,6 +31,7 @@ from IPython.core.splitinput import split_user_input
 
 from IPython.utils.traitlets import List, Instance
 from IPython.utils.warn import warn, error
+import six
 
 #-----------------------------------------------------------------------------
 # Utilities
@@ -125,7 +126,7 @@ class AliasManager(Configurable):
 
     @property
     def aliases(self):
-        return [(item[0], item[1][1]) for item in self.alias_table.iteritems()]
+        return [(item[0], item[1][1]) for item in six.iteritems(self.alias_table)]
 
     def exclude_aliases(self):
         # set of things NOT to alias (keywords, builtins and some magics)

--- a/IPython/core/builtin_trap.py
+++ b/IPython/core/builtin_trap.py
@@ -23,6 +23,7 @@ import __builtin__
 from IPython.config.configurable import Configurable
 
 from IPython.utils.traitlets import Instance
+import six
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -99,14 +100,14 @@ class BuiltinTrap(Configurable):
         """Store ipython references in the __builtin__ namespace."""
 
         add_builtin = self.add_builtin
-        for name, func in self.auto_builtins.iteritems():
+        for name, func in six.iteritems(self.auto_builtins):
             add_builtin(name, func)
 
     def deactivate(self):
         """Remove any builtins which might have been added by add_builtins, or
         restore overwritten ones to their previous values."""
         remove_builtin = self.remove_builtin
-        for key, val in self._orig_builtins.iteritems():
+        for key, val in six.iteritems(self._orig_builtins):
             remove_builtin(key, val)
         self._orig_builtins.clear()
         self._builtins_added = False

--- a/IPython/core/builtin_trap.py
+++ b/IPython/core/builtin_trap.py
@@ -1,5 +1,5 @@
 """
-A context manager for managing things injected into :mod:`__builtin__`.
+A context manager for managing things injected into :mod:`builtins`.
 
 Authors:
 
@@ -18,7 +18,11 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
-import __builtin__
+try:
+    import builtins
+except ImportError:  
+    # Python 2
+    import __builtin__ as builtins
 
 from IPython.config.configurable import Configurable
 
@@ -79,7 +83,7 @@ class BuiltinTrap(Configurable):
 
     def add_builtin(self, key, value):
         """Add a builtin and save the original."""
-        bdict = __builtin__.__dict__
+        bdict = builtins.__dict__
         orig = bdict.get(key, BuiltinUndefined)
         if value is HideBuiltin:
             if orig is not BuiltinUndefined: #same as 'key in bdict'
@@ -92,12 +96,12 @@ class BuiltinTrap(Configurable):
     def remove_builtin(self, key, orig):
         """Remove an added builtin and re-set the original."""
         if orig is BuiltinUndefined:
-            del __builtin__.__dict__[key]
+            del builtins.__dict__[key]
         else:
-            __builtin__.__dict__[key] = orig
+            builtins.__dict__[key] = orig
 
     def activate(self):
-        """Store ipython references in the __builtin__ namespace."""
+        """Store ipython references in the builtins namespace."""
 
         add_builtin = self.add_builtin
         for name, func in six.iteritems(self.auto_builtins):

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -84,6 +84,7 @@ from IPython.utils import io
 from IPython.utils.dir2 import dir2
 from IPython.utils.process import arg_split
 from IPython.utils.traitlets import CBool, Enum
+from six.moves import filter
 
 #-----------------------------------------------------------------------------
 # Globals

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -666,7 +666,7 @@ class IPCompleter(Completer):
                         # true if txt is _not_ a _ name, false otherwise:
                         no__name = (lambda txt:
                                     re.match(r'.*\._.*?',txt) is None)
-                    matches = filter(no__name, matches)
+                    matches = list(filter(no__name, matches))
             except NameError:
                 # catches <undefined attributes>.<tab>
                 matches = []

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -87,6 +87,7 @@ from IPython.utils import generics
 from IPython.utils import io
 from IPython.utils.dir2 import dir2
 from IPython.utils.process import arg_split
+from IPython.utils.py3compat import string_types
 from IPython.utils.traitlets import CBool, Enum
 from six.moves import filter
 
@@ -389,7 +390,7 @@ def get__all__entries(obj):
     except:
         return []
     
-    return [w for w in words if isinstance(w, basestring)]
+    return [w for w in words if isinstance(w, string_types)]
 
 
 class IPCompleter(Completer):

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -66,7 +66,11 @@ used, and this module (and the readline module) are silently inactive.
 # Imports
 #-----------------------------------------------------------------------------
 
-import __builtin__
+try:
+    import builtins
+except ImportError:  
+    # Python 2
+    import __builtin__ as builtins
 import __main__
 import glob
 import inspect
@@ -315,7 +319,7 @@ class Completer(Configurable):
         match_append = matches.append
         n = len(text)
         for lst in [keyword.kwlist,
-                    __builtin__.__dict__.keys(),
+                    builtins.__dict__.keys(),
                     self.namespace.keys(),
                     self.global_namespace.keys()]:
             for word in lst:

--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -34,6 +34,8 @@ from IPython.utils._process_common import arg_split
 
 # FIXME: this should be pulled in with the right call via the component system
 from IPython import get_ipython
+import six
+from six.moves import filter
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -323,7 +325,7 @@ def cd_completer(self, event):
             return [compress_user(relpath, tilde_expand, tilde_val)]
 
         # if no completions so far, try bookmarks
-        bks = self.db.get('bookmarks',{}).iterkeys()
+        bks = six.iterkeys(self.db.get('bookmarks',{}))
         bkmatches = [s for s in bks if s.startswith(event.symbol)]
         if bkmatches:
             return bkmatches

--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -270,7 +270,7 @@ def magic_run_completer(self, event):
     # should complete on all files, since after the first one other files may
     # be arguments to the input script.
 
-    if filter(magic_run_re.match, comps):
+    if any(magic_run_re.match(c) for c in comps):
         pys =  [f.replace('\\','/') for f in lglob('*')]
     else:
         pys =  [f.replace('\\','/')

--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -34,8 +34,6 @@ from IPython.utils._process_common import arg_split
 
 # FIXME: this should be pulled in with the right call via the component system
 from IPython import get_ipython
-import six
-from six.moves import filter
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -325,7 +323,7 @@ def cd_completer(self, event):
             return [compress_user(relpath, tilde_expand, tilde_val)]
 
         # if no completions so far, try bookmarks
-        bks = six.iterkeys(self.db.get('bookmarks',{}))
+        bks = self.db.get('bookmarks',{}).keys()
         bkmatches = [s for s in bks if s.startswith(event.symbol)]
         if bkmatches:
             return bkmatches

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -139,7 +139,10 @@ class Tracer(object):
         # at least raise that limit to 80 chars, which should be enough for
         # most interactive uses.
         try:
-            from repr import aRepr
+            try:
+                from reprlib import aRepr
+            except ImportError:
+                from repr import aRepr
             aRepr.maxstring = 80
         except:
             # This is only a user-facing convenience, so any error we encounter
@@ -324,7 +327,10 @@ class Pdb(OldPdb):
         # vds: <<
 
     def format_stack_entry(self, frame_lineno, lprefix=': ', context = 3):
-        import repr
+        try:
+            import reprlib
+        except ImportError:
+            import repr as reprlib
 
         ret = []
 
@@ -342,7 +348,7 @@ class Pdb(OldPdb):
         if '__return__' in frame.f_locals:
             rv = frame.f_locals['__return__']
             #return_value += '->'
-            return_value += repr.repr(rv) + '\n'
+            return_value += reprlib.repr(rv) + '\n'
         ret.append(return_value)
 
         #s = filename + '(' + `lineno` + ')'
@@ -357,7 +363,7 @@ class Pdb(OldPdb):
         call = ''
         if func != '?':
             if '__args__' in frame.f_locals:
-                args = repr.repr(frame.f_locals['__args__'])
+                args = reprlib.repr(frame.f_locals['__args__'])
             else:
                 args = '()'
             call = tpl_call % (func, args)

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -22,7 +22,8 @@ from __future__ import print_function
 import os
 import struct
 
-from IPython.utils.py3compat import string_types, cast_bytes_py2, cast_unicode
+from IPython.utils.py3compat import (string_types, cast_bytes_py2, cast_unicode,
+                                    unicode_type)
 
 from .displaypub import publish_display_data
 
@@ -300,7 +301,7 @@ class DisplayObject(object):
 
         self.data = data
         self.url = url
-        self.filename = None if filename is None else unicode(filename)
+        self.filename = None if filename is None else unicode_type(filename)
 
         self.reload()
 
@@ -444,11 +445,11 @@ class Javascript(DisplayObject):
             The full URLs of the css files should be given. A single css URL
             can also be given as a string.
         """
-        if isinstance(lib, basestring):
+        if isinstance(lib, string_types):
             lib = [lib]
         elif lib is None:
             lib = []
-        if isinstance(css, basestring):
+        if isinstance(css, string_types):
             css = [css]
         elif css is None:
             css = []
@@ -590,7 +591,7 @@ class Image(DisplayObject):
             if data[:2] == _JPEG:
                 format = 'jpeg'
 
-        self.format = unicode(format).lower()
+        self.format = unicode_type(format).lower()
         self.embed = embed if embed is not None else (url is None)
 
         if self.embed and self.format not in self._ACCEPTABLE_EMBEDDINGS:
@@ -654,7 +655,7 @@ class Image(DisplayObject):
             return self._data_and_metadata()
 
     def _find_ext(self, s):
-        return unicode(s.split('.')[-1].lower())
+        return unicode_type(s.split('.')[-1].lower())
 
 
 def clear_output(stdout=True, stderr=True, other=True):

--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -23,7 +23,11 @@ Authors:
 #-----------------------------------------------------------------------------
 from __future__ import print_function
 
-import __builtin__
+try:
+    import builtins
+except ImportError:  
+    # Python 2
+    import __builtin__ as builtins
 
 import sys
 
@@ -87,10 +91,10 @@ class DisplayHook(Configurable):
 
     def check_for_underscore(self):
         """Check if the user has set the '_' variable by hand."""
-        # If something injected a '_' variable in __builtin__, delete
+        # If something injected a '_' variable in builtins, delete
         # ipython's automatic one so we don't clobber that.  gettext() in
         # particular uses _, so we need to stay away from it.
-        if '_' in __builtin__.__dict__:
+        if '_' in builtins.__dict__:
             try:
                 del self.shell.user_ns['_']
             except KeyError:
@@ -203,10 +207,10 @@ class DisplayHook(Configurable):
                      'with the current result.')
 
                 self.flush()
-            # Don't overwrite '_' and friends if '_' is in __builtin__ (otherwise
+            # Don't overwrite '_' and friends if '_' is in builtins (otherwise
             # we cause buggy behavior for things like gettext).
 
-            if '_' not in __builtin__.__dict__:
+            if '_' not in builtins.__dict__:
                 self.___ = self.__
                 self.__ = self._
                 self._ = result
@@ -270,7 +274,7 @@ class DisplayHook(Configurable):
         # Release our own references to objects:
         self._, self.__, self.___ = '', '', ''
 
-        if '_' not in __builtin__.__dict__:
+        if '_' not in builtins.__dict__:
             self.shell.user_ns.update({'_':None,'__':None, '___':None})
         import gc
         # TODO: Is this really needed?

--- a/IPython/core/displaypub.py
+++ b/IPython/core/displaypub.py
@@ -30,8 +30,7 @@ Authors:
 from __future__ import print_function
 
 from IPython.config.configurable import Configurable
-from IPython.utils import io
-from IPython.utils.traitlets import List
+from IPython.utils import io, py3compat
 
 #-----------------------------------------------------------------------------
 # Main payload class
@@ -58,7 +57,7 @@ class DisplayPublisher(Configurable):
             Any metadata for the data.
         """
 
-        if not isinstance(source, basestring):
+        if not isinstance(source, py3compat.string_types):
             raise TypeError('source must be a str, got: %r' % source)
         if not isinstance(data, dict):
             raise TypeError('data must be a dict, got: %r' % data)

--- a/IPython/core/displaypub.py
+++ b/IPython/core/displaypub.py
@@ -31,6 +31,7 @@ from __future__ import print_function
 
 from IPython.config.configurable import Configurable
 from IPython.utils import io, py3compat
+from IPython.utils.traitlets import List
 
 #-----------------------------------------------------------------------------
 # Main payload class

--- a/IPython/core/excolors.py
+++ b/IPython/core/excolors.py
@@ -24,7 +24,7 @@ def exception_colors():
     >>> ec = exception_colors()
     >>> ec.active_scheme_name
     ''
-    >>> print ec.active_colors
+    >>> print(ec.active_colors)
     None
 
     Now we activate a color scheme:

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -27,8 +27,6 @@ Authors:
 import abc
 import sys
 import warnings
-# We must use StringIO, as cStringIO doesn't handle unicode properly.
-from StringIO import StringIO
 
 # Our own imports
 from IPython.config.configurable import Configurable
@@ -36,7 +34,11 @@ from IPython.lib import pretty
 from IPython.utils.traitlets import (
     Bool, Dict, Integer, Unicode, CUnicode, ObjectName, List,
 )
-from IPython.utils.py3compat import unicode_to_str
+from IPython.utils.py3compat import unicode_to_str, PY3
+if PY3:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 import six
 
 
@@ -169,7 +171,7 @@ class DisplayFormatter(Configurable):
     @property
     def format_types(self):
         """Return the format types (MIME types) of the active formatters."""
-        return self.formatters.keys()
+        return list(self.formatters.keys())
 
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -34,11 +34,7 @@ from IPython.lib import pretty
 from IPython.utils.traitlets import (
     Bool, Dict, Integer, Unicode, CUnicode, ObjectName, List,
 )
-from IPython.utils.py3compat import unicode_to_str, PY3
-if PY3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from IPython.utils.py3compat import unicode_to_str, StringIO
 import six
 
 

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -37,6 +37,7 @@ from IPython.utils.traitlets import (
     Bool, Dict, Integer, Unicode, CUnicode, ObjectName, List,
 )
 from IPython.utils.py3compat import unicode_to_str
+import six
 
 
 #-----------------------------------------------------------------------------
@@ -176,7 +177,7 @@ class DisplayFormatter(Configurable):
 #-----------------------------------------------------------------------------
 
 
-class FormatterABC(object):
+class FormatterABC(six.with_metaclass(abc.ABCMeta, object)):
     """ Abstract base class for Formatters.
 
     A formatter is a callable class that is responsible for computing the
@@ -184,7 +185,6 @@ class FormatterABC(object):
     an HTML formatter would have a format type of `text/html` and would return
     the HTML representation of the object when called.
     """
-    __metaclass__ = abc.ABCMeta
 
     # The format type of the data returned, usually a MIME type.
     format_type = 'text/plain'

--- a/IPython/core/inputtransformer.py
+++ b/IPython/core/inputtransformer.py
@@ -6,11 +6,7 @@ from IPython.core.splitinput import LineInfo
 from IPython.utils import tokenize2
 from IPython.utils.openpy import cookie_comment_re
 from IPython.utils.tokenize2 import generate_tokens, untokenize, TokenError
-from IPython.utils.py3compat import PY3
-if PY3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from IPython.utils.py3compat import StringIO
 import six
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/inputtransformer.py
+++ b/IPython/core/inputtransformer.py
@@ -7,6 +7,7 @@ from IPython.core.splitinput import LineInfo
 from IPython.utils import tokenize2
 from IPython.utils.openpy import cookie_comment_re
 from IPython.utils.tokenize2 import generate_tokens, untokenize, TokenError
+import six
 
 #-----------------------------------------------------------------------------
 # Globals
@@ -33,9 +34,8 @@ ESC_SEQUENCES = [ESC_SHELL, ESC_SH_CAP, ESC_HELP ,\
                  ESC_QUOTE, ESC_QUOTE2, ESC_PAREN ]
 
 
-class InputTransformer(object):
+class InputTransformer(six.with_metaclass(abc.ABCMeta, object)):
     """Abstract base class for line-based input transformers."""
-    __metaclass__ = abc.ABCMeta
     
     @abc.abstractmethod
     def push(self, line):

--- a/IPython/core/inputtransformer.py
+++ b/IPython/core/inputtransformer.py
@@ -1,12 +1,16 @@
 import abc
 import functools
 import re
-from StringIO import StringIO
 
 from IPython.core.splitinput import LineInfo
 from IPython.utils import tokenize2
 from IPython.utils.openpy import cookie_comment_re
 from IPython.utils.tokenize2 import generate_tokens, untokenize, TokenError
+from IPython.utils.py3compat import PY3
+if PY3:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 import six
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -17,7 +17,11 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import __builtin__ as builtin_mod
+try:
+    import builtins
+except ImportError:  
+    # Python 2
+    import __builtin__ as builtins
 import __future__
 import abc
 import ast
@@ -620,14 +624,14 @@ class InteractiveShell(SingletonConfigurable):
         # that an IPython shell has been created, and we make no attempts at
         # removing on exit or representing the existence of more than one
         # IPython at a time.
-        builtin_mod.__dict__['__IPYTHON__'] = True
+        builtins.__dict__['__IPYTHON__'] = True
 
         # In 0.11 we introduced '__IPYTHON__active' as an integer we'd try to
         # manage on enter/exit, but with all our shells it's virtually
         # impossible to get all the cases right.  We're leaving the name in for
         # those who adapted their codes to check for this flag, but will
         # eventually remove it after a few more releases.
-        builtin_mod.__dict__['__IPYTHON__active'] = \
+        builtins.__dict__['__IPYTHON__active'] = \
                                           'Deprecated, check for __IPYTHON__'
 
         self.builtin_trap = BuiltinTrap(shell=self)
@@ -1002,7 +1006,7 @@ class InteractiveShell(SingletonConfigurable):
         # introspection facilities can search easily.
         self.ns_table = {'user_global':self.user_module.__dict__,
                          'user_local':self.user_ns,
-                         'builtin':builtin_mod.__dict__
+                         'builtin':builtins.__dict__
                          }
     
     @property
@@ -1048,8 +1052,8 @@ class InteractiveShell(SingletonConfigurable):
         # We must ensure that __builtin__ (without the final 's') is always
         # available and pointing to the __builtin__ *module*.  For more details:
         # http://mail.python.org/pipermail/python-dev/2001-April/014068.html
-        user_module.__dict__.setdefault('__builtin__', builtin_mod)
-        user_module.__dict__.setdefault('__builtins__', builtin_mod)
+        user_module.__dict__.setdefault('__builtin__', builtins)
+        user_module.__dict__.setdefault('__builtins__', builtins)
         
         if user_ns is None:
             user_ns = user_module.__dict__
@@ -1348,7 +1352,7 @@ class InteractiveShell(SingletonConfigurable):
             # find things in the same order that Python finds them.
             namespaces = [ ('Interactive', self.user_ns),
                            ('Interactive (global)', self.user_global_ns),
-                           ('Python builtin', builtin_mod.__dict__),
+                           ('Python builtin', builtins.__dict__),
                            ('Alias', self.alias_manager.alias_table),
                            ]
             alias_ns = self.alias_manager.alias_table

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -76,6 +76,7 @@ from IPython.utils.traitlets import (Integer, CBool, CaselessStrEnum, Enum,
                                      List, Unicode, Instance, Type)
 from IPython.utils.warn import warn, error
 import IPython.core.hooks
+import six
 
 #-----------------------------------------------------------------------------
 # Globals
@@ -742,7 +743,7 @@ class InteractiveShell(SingletonConfigurable):
     def restore_sys_module_state(self):
         """Restore the state of the sys module."""
         try:
-            for k, v in self._orig_sys_module_state.iteritems():
+            for k, v in six.iteritems(self._orig_sys_module_state):
                 setattr(sys, k, v)
         except AttributeError:
             pass
@@ -1226,7 +1227,7 @@ class InteractiveShell(SingletonConfigurable):
             # Also check in output history
             ns_refs.append(self.history_manager.output_hist)
             for ns in ns_refs:
-                to_delete = [n for n, o in ns.iteritems() if o is obj]
+                to_delete = [n for n, o in six.iteritems(ns) if o is obj]
                 for name in to_delete:
                     del ns[name]
 
@@ -1317,7 +1318,7 @@ class InteractiveShell(SingletonConfigurable):
         variables : dict
           A dictionary mapping object names (as strings) to the objects.
         """
-        for name, obj in variables.iteritems():
+        for name, obj in six.iteritems(variables):
             if name in self.user_ns and self.user_ns[name] is obj:
                 del self.user_ns[name]
                 self.user_ns_hidden.discard(name)
@@ -2422,7 +2423,7 @@ class InteractiveShell(SingletonConfigurable):
         user_ns = self.user_ns
         global_ns = self.user_global_ns
         
-        for key, expr in expressions.iteritems():
+        for key, expr in six.iteritems(expressions):
             try:
                 value = self._format_user_obj(eval(expr, global_ns, user_ns))
             except:
@@ -2437,7 +2438,7 @@ class InteractiveShell(SingletonConfigurable):
     def ex(self, cmd):
         """Execute a normal python statement in user namespace."""
         with self.builtin_trap:
-            exec cmd in self.user_global_ns, self.user_ns
+            exec(cmd, self.user_global_ns, self.user_ns)
 
     def ev(self, expr):
         """Evaluate python expression expr in user namespace.
@@ -2662,7 +2663,7 @@ class InteractiveShell(SingletonConfigurable):
                     
                     # Execute any registered post-execution functions.
                     # unless we are silent
-                    post_exec = [] if silent else self._post_execute.iteritems()
+                    post_exec = [] if silent else six.iteritems(self._post_execute)
                     
                     for func, status in post_exec:
                         if self.disable_failing_post_execute and not status:
@@ -2818,7 +2819,7 @@ class InteractiveShell(SingletonConfigurable):
             try:
                 self.hooks.pre_run_code_hook()
                 #rprint('Running code', repr(code_obj)) # dbg
-                exec code_obj in self.user_global_ns, self.user_ns
+                exec(code_obj, self.user_global_ns, self.user_ns)
             finally:
                 # Reset our crash handler in place
                 sys.excepthook = old_excepthook
@@ -3132,8 +3133,7 @@ class InteractiveShell(SingletonConfigurable):
         self.restore_sys_module_state()
 
 
-class InteractiveShellABC(object):
+class InteractiveShellABC(six.with_metaclass(abc.ABCMeta, object)):
     """An abstract base class for InteractiveShell."""
-    __metaclass__ = abc.ABCMeta
 
 InteractiveShellABC.register(InteractiveShell)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1283,8 +1283,8 @@ class InteractiveShell(SingletonConfigurable):
         # We need a dict of name/value pairs to do namespace updates.
         if isinstance(variables, dict):
             vdict = variables
-        elif isinstance(variables, (basestring, list, tuple)):
-            if isinstance(variables, basestring):
+        elif isinstance(variables, py3compat.string_types + (list, tuple)):
+            if isinstance(variables, py3compat.string_types):
                 vlist = variables.split()
             else:
                 vlist = variables
@@ -1581,14 +1581,14 @@ class InteractiveShell(SingletonConfigurable):
             msg = "CustomTB must return list of strings, not %r" % stb
             if stb is None:
                 return []
-            elif isinstance(stb, basestring):
+            elif isinstance(stb, py3compat.string_types):
                 return [stb]
             elif not isinstance(stb, list):
                 raise TypeError(msg)
             # it's a list
             for line in stb:
                 # check every element
-                if not isinstance(line, basestring):
+                if not isinstance(line, py3compat.string_types):
                     raise TypeError(msg)
             return stb
 
@@ -2188,7 +2188,7 @@ class InteractiveShell(SingletonConfigurable):
 
         from IPython.core import macro
 
-        if isinstance(themacro, basestring):
+        if isinstance(themacro, py3compat.string_types):
             themacro = macro.Macro(themacro)
         if not isinstance(themacro, macro.Macro):
             raise ValueError('A macro must be a string or a Macro instance.')
@@ -2364,7 +2364,7 @@ class InteractiveShell(SingletonConfigurable):
         exc_info = {
             u'status' : 'error',
             u'traceback' : stb,
-            u'ename' : unicode(etype.__name__),
+            u'ename' : py3compat.unicode_type(etype.__name__),
             u'evalue' : py3compat.safe_unicode(evalue),
         }
 
@@ -3093,7 +3093,7 @@ class InteractiveShell(SingletonConfigurable):
         except Exception:
             raise ValueError(("'%s' was not found in history, as a file, url, "
                                 "nor in the user namespace.") % target)
-        if isinstance(codeobj, basestring):
+        if isinstance(codeobj, py3compat.string_types):
             return codeobj
         elif isinstance(codeobj, Macro):
             return codeobj.value

--- a/IPython/core/logger.py
+++ b/IPython/core/logger.py
@@ -1,5 +1,6 @@
 """Logger class for IPython's logging facilities.
 """
+from __future__ import print_function
 
 #*****************************************************************************
 #       Copyright (C) 2001 Janko Hauser <jhauser@zscout.de> and
@@ -137,33 +138,33 @@ class Logger(object):
         label = {0:'OFF',1:'ON',False:'OFF',True:'ON'}
 
         if self.logfile is None:
-            print """
+            print("""
 Logging hasn't been started yet (use logstart for that).
 
 %logon/%logoff are for temporarily starting and stopping logging for a logfile
 which already exists. But you must first start the logging process with
-%logstart (optionally giving a logfile name)."""
+%logstart (optionally giving a logfile name).""")
 
         else:
             if self.log_active == val:
-                print 'Logging is already',label[val]
+                print('Logging is already',label[val])
             else:
-                print 'Switching logging',label[val]
+                print('Switching logging',label[val])
                 self.log_active = not self.log_active
                 self.log_active_out = self.log_active
 
     def logstate(self):
         """Print a status message about the logger."""
         if self.logfile is None:
-            print 'Logging has not been activated.'
+            print('Logging has not been activated.')
         else:
             state = self.log_active and 'active' or 'temporarily suspended'
-            print 'Filename       :',self.logfname
-            print 'Mode           :',self.logmode
-            print 'Output logging :',self.log_output
-            print 'Raw input log  :',self.log_raw_input
-            print 'Timestamping   :',self.timestamp
-            print 'State          :',state
+            print('Filename       :',self.logfname)
+            print('Mode           :',self.logmode)
+            print('Output logging :',self.log_output)
+            print('Raw input log  :',self.log_raw_input)
+            print('Timestamping   :',self.timestamp)
+            print('State          :',state)
 
     def log(self, line_mod, line_ori):
         """Write the sources to a log.
@@ -213,7 +214,7 @@ which already exists. But you must first start the logging process with
             self.logfile.close()
             self.logfile = None
         else:
-            print "Logging hadn't been started."
+            print("Logging hadn't been started.")
         self.log_active = False
 
     # For backwards compatibility, in case anyone was using this.

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 """Magic functions for InteractiveShell.
 """
+from __future__ import print_function
 
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2001 Janko Hauser <jhauser@zscout.de> and
@@ -32,6 +33,7 @@ from IPython.utils.process import arg_split
 from IPython.utils.text import dedent
 from IPython.utils.traitlets import Bool, Dict, Instance, MetaHasTraits
 from IPython.utils.warn import error
+import six
 
 #-----------------------------------------------------------------------------
 # Globals
@@ -193,14 +195,14 @@ def _method_magic_marker(magic_kind):
         if callable(arg):
             # "Naked" decorator call (just @foo, no args)
             func = arg
-            name = func.func_name
+            name = func.__name__
             retval = decorator(call, func)
             record_magic(magics, magic_kind, name, name)
         elif isinstance(arg, basestring):
             # Decorator called with arguments (@foo('bar'))
             name = arg
             def mark(func, *a, **kw):
-                record_magic(magics, magic_kind, name, func.func_name)
+                record_magic(magics, magic_kind, name, func.__name__)
                 return decorator(call, func)
             retval = mark
         else:
@@ -238,7 +240,7 @@ def _function_magic_marker(magic_kind):
         if callable(arg):
             # "Naked" decorator call (just @foo, no args)
             func = arg
-            name = func.func_name
+            name = func.__name__
             ip.register_magic_function(func, magic_kind, name)
             retval = decorator(call, func)
         elif isinstance(arg, basestring):
@@ -347,7 +349,7 @@ class MagicsManager(Configurable):
         docs = {}
         for m_type in self.magics:
             m_docs = {}
-            for m_name, m_func in self.magics[m_type].iteritems():
+            for m_name, m_func in six.iteritems(self.magics[m_type]):
                 if m_func.__doc__:
                     if brief:
                         m_docs[m_name] = m_func.__doc__.split('\n', 1)[0]
@@ -424,7 +426,7 @@ class MagicsManager(Configurable):
         # Create the new method in the user_magics and register it in the
         # global table
         validate_type(magic_kind)
-        magic_name = func.func_name if magic_name is None else magic_name
+        magic_name = func.__name__ if magic_name is None else magic_name
         setattr(self.user_magics, magic_name, func)
         record_magic(self.magics, magic_kind, magic_name, func)
 
@@ -523,7 +525,7 @@ class Magics(object):
         for mtype in magic_kinds:
             tab = self.magics[mtype] = {}
             cls_tab = class_magics[mtype]
-            for magic_name, meth_name in cls_tab.iteritems():
+            for magic_name, meth_name in six.iteritems(cls_tab):
                 if isinstance(meth_name, basestring):
                     # it's a method name, grab it
                     tab[magic_name] = getattr(self, meth_name)
@@ -533,8 +535,8 @@ class Magics(object):
 
     def arg_err(self,func):
         """Print docstring if incorrect arguments were passed"""
-        print 'Error in arguments:'
-        print oinspect.getdoc(func)
+        print('Error in arguments:')
+        print(oinspect.getdoc(func))
 
     def format_latex(self, strng):
         """Format a string for latex inclusion."""

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -30,6 +30,7 @@ from IPython.core.inputsplitter import ESC_MAGIC, ESC_MAGIC2
 from IPython.external.decorator import decorator
 from IPython.utils.ipstruct import Struct
 from IPython.utils.process import arg_split
+from IPython.utils.py3compat import string_types
 from IPython.utils.text import dedent
 from IPython.utils.traitlets import Bool, Dict, Instance, MetaHasTraits
 from IPython.utils.warn import error
@@ -198,7 +199,7 @@ def _method_magic_marker(magic_kind):
             name = func.__name__
             retval = decorator(call, func)
             record_magic(magics, magic_kind, name, name)
-        elif isinstance(arg, basestring):
+        elif isinstance(arg, string_types):
             # Decorator called with arguments (@foo('bar'))
             name = arg
             def mark(func, *a, **kw):
@@ -243,7 +244,7 @@ def _function_magic_marker(magic_kind):
             name = func.__name__
             ip.register_magic_function(func, magic_kind, name)
             retval = decorator(call, func)
-        elif isinstance(arg, basestring):
+        elif isinstance(arg, string_types):
             # Decorator called with arguments (@foo('bar'))
             name = arg
             def mark(func, *a, **kw):
@@ -526,7 +527,7 @@ class Magics(object):
             tab = self.magics[mtype] = {}
             cls_tab = class_magics[mtype]
             for magic_name, meth_name in six.iteritems(cls_tab):
-                if isinstance(meth_name, basestring):
+                if isinstance(meth_name, string_types):
                     # it's a method name, grab it
                     tab[magic_name] = getattr(self, meth_name)
                 else:

--- a/IPython/core/magics/auto.py
+++ b/IPython/core/magics/auto.py
@@ -1,5 +1,6 @@
 """Implementation of magic functions that control various automatic behaviors.
 """
+from __future__ import print_function
 #-----------------------------------------------------------------------------
 #  Copyright (c) 2012 The IPython Development Team.
 #
@@ -57,7 +58,7 @@ class AutoMagics(Magics):
         else:
             val = not mman.auto_magic
         mman.auto_magic = val
-        print '\n' + self.shell.magics_manager.auto_status()
+        print('\n' + self.shell.magics_manager.auto_status())
 
     @skip_doctest
     @line_magic
@@ -125,4 +126,4 @@ class AutoMagics(Magics):
                 except AttributeError:
                     self.shell.autocall = self._magic_state.autocall_save = 1
 
-        print "Automatic calling is:",['OFF','Smart','Full'][self.shell.autocall]
+        print("Automatic calling is:",['OFF','Smart','Full'][self.shell.autocall])

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -28,6 +28,7 @@ from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.ipstruct import Struct
 from IPython.utils.path import unquote_filename
 from IPython.utils.warn import warn, error
+from IPython.utils.py3compat import unicode_type
 
 #-----------------------------------------------------------------------------
 # Magics class implementation
@@ -600,7 +601,7 @@ Defaulting color scheme to 'NoColor'"""
              'format. The filename argument gives the name of the source file.'
     )
     @magic_arguments.argument(
-        'filename', type=unicode,
+        'filename', type=unicode_type,
         help='Notebook name or filename'
     )
     @line_magic

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -71,7 +71,7 @@ class MagicsDisplay(object):
             magic_dict[key] = d
             for name, obj in subdict.items():
                 try:
-                    classname = obj.im_class.__name__
+                    classname = obj.__self__.__class__.__name__
                 except AttributeError:
                     classname = 'Other'
                 

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -1,5 +1,6 @@
 """Implementation of code management magic functions.
 """
+from __future__ import print_function
 #-----------------------------------------------------------------------------
 #  Copyright (c) 2012 The IPython Development Team.
 #
@@ -93,15 +94,15 @@ class CodeMagics(Magics):
             try:
                 overwrite = self.shell.ask_yes_no('File `%s` exists. Overwrite (y/[N])? ' % fname, default='n')
             except StdinNotImplementedError:
-                print "File `%s` exists. Use `%%save -f %s` to force overwrite" % (fname, parameter_s)
+                print("File `%s` exists. Use `%%save -f %s` to force overwrite" % (fname, parameter_s))
                 return
             if not overwrite :
-                print 'Operation cancelled.'
+                print('Operation cancelled.')
                 return
         try:
             cmds = self.shell.find_user_code(codefrom,raw)
         except (TypeError, ValueError) as e:
-            print e.args[0]
+            print(e.args[0])
             return
         out = py3compat.cast_unicode(cmds)
         with io.open(fname, mode, encoding="utf-8") as f:
@@ -111,8 +112,8 @@ class CodeMagics(Magics):
             # make sure we end on a newline
             if not out.endswith(u'\n'):
                 f.write(u'\n')
-        print 'The following commands were written to file `%s`:' % fname
-        print cmds
+        print('The following commands were written to file `%s`:' % fname)
+        print(cmds)
 
     @line_magic
     def pastebin(self, parameter_s=''):
@@ -134,7 +135,7 @@ class CodeMagics(Magics):
         try:
             code = self.shell.find_user_code(args)
         except (ValueError, TypeError) as e:
-            print e.args[0]
+            print(e.args[0])
             return
 
         from urllib2 import urlopen  # Deferred import
@@ -205,7 +206,7 @@ class CodeMagics(Magics):
                 ans = True
 
             if ans is False :
-                print 'Operation cancelled.'
+                print('Operation cancelled.')
                 return
 
         self.shell.set_next_input(contents)
@@ -327,7 +328,7 @@ class CodeMagics(Magics):
 
         if use_temp:
             filename = shell.mktempfile(data)
-            print 'IPython will make a temporary file named:',filename
+            print('IPython will make a temporary file named:',filename)
 
         # use last_call to remember the state of the previous call, but don't
         # let it be clobbered by successive '-p' calls.
@@ -506,7 +507,7 @@ class CodeMagics(Magics):
             self._edit_macro(args, e.args[0])
             return
         except InteractivelyDefined as e:
-            print "Editing In[%i]" % e.index
+            print("Editing In[%i]" % e.index)
             args = str(e.index)
             filename, lineno, is_temp = self._find_edit_target(self.shell, 
                                                        args, opts, last_call)
@@ -516,7 +517,7 @@ class CodeMagics(Magics):
             return
 
         # do actual editing here
-        print 'Editing...',
+        print('Editing...', end=' ')
         sys.stdout.flush()
         try:
             # Quote filenames that may have spaces in them
@@ -534,9 +535,9 @@ class CodeMagics(Magics):
                 self.shell.user_ns['pasted_block'] = f.read()
 
         if 'x' in opts:  # -x prevents actual execution
-            print
+            print()
         else:
-            print 'done. Executing edited code...'
+            print('done. Executing edited code...')
             with preserve_keys(self.shell.user_ns, '__file__'):
                 if not is_temp:
                     self.shell.user_ns['__file__'] = filename

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -264,7 +264,7 @@ class CodeMagics(Magics):
 
                     #print '*** args',args,'type',type(args)  # dbg
                     data = eval(args, shell.user_ns)
-                    if not isinstance(data, basestring):
+                    if not isinstance(data, py3compat.string_types):
                         raise DataIsObject
 
                 except (NameError,SyntaxError):

--- a/IPython/core/magics/config.py
+++ b/IPython/core/magics/config.py
@@ -1,5 +1,6 @@
 """Implementation of configuration-related magic functions.
 """
+from __future__ import print_function
 #-----------------------------------------------------------------------------
 #  Copyright (c) 2012 The IPython Development Team.
 #
@@ -116,9 +117,9 @@ class ConfigMagics(Magics):
         line = s.strip()
         if not line:
             # print available configurable names
-            print "Available objects for config:"
+            print("Available objects for config:")
             for name in classnames:
-                print "    ", name
+                print("    ", name)
             return
         elif line in classnames:
             # `%config TerminalInteractiveShell` will print trait info for
@@ -128,7 +129,7 @@ class ConfigMagics(Magics):
             help = cls.class_get_help(c)
             # strip leading '--' from cl-args:
             help = re.sub(re.compile(r'^--', re.MULTILINE), '', help)
-            print help
+            print(help)
             return
         elif reg.match(line):
             cls, attr = line.split('.')
@@ -149,7 +150,7 @@ class ConfigMagics(Magics):
         # leave quotes on args when splitting, because we want
         # unquoted args to eval in user_ns
         cfg = Config()
-        exec "cfg."+line in locals(), self.shell.user_ns
+        exec("cfg."+line, locals(), self.shell.user_ns)
 
         for configurable in configurables:
             try:

--- a/IPython/core/magics/deprecated.py
+++ b/IPython/core/magics/deprecated.py
@@ -1,5 +1,6 @@
 """Deprecated Magic functions.
 """
+from __future__ import print_function
 #-----------------------------------------------------------------------------
 #  Copyright (c) 2012 The IPython Development Team.
 #
@@ -26,20 +27,20 @@ class DeprecatedMagics(Magics):
     @line_magic
     def install_profiles(self, parameter_s=''):
         """%install_profiles has been deprecated."""
-        print '\n'.join([
+        print('\n'.join([
             "%install_profiles has been deprecated.",
             "Use `ipython profile list` to view available profiles.",
             "Requesting a profile with `ipython profile create <name>`",
             "or `ipython --profile=<name>` will start with the bundled",
             "profile of that name if it exists."
-        ])
+        ]))
 
     @line_magic
     def install_default_config(self, parameter_s=''):
         """%install_default_config has been deprecated."""
-        print '\n'.join([
+        print('\n'.join([
             "%install_default_config has been deprecated.",
             "Use `ipython profile create <name>` to initialize a profile",
             "with the default config files.",
             "Add `--reset` to overwrite already existing config files with defaults."
-        ])
+        ]))

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -25,7 +25,6 @@ import bdb
 import os
 import sys
 import time
-from StringIO import StringIO
 import six
 from six.moves import map
 from six.moves import zip
@@ -58,6 +57,11 @@ from IPython.utils.module_paths import find_mod
 from IPython.utils.path import get_py_filename, unquote_filename, shellglob
 from IPython.utils.timing import clock, clock2
 from IPython.utils.warn import warn, error
+from IPython.utils.py3compat import PY3
+if PY3:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -27,7 +27,6 @@ import sys
 import time
 import six
 from six.moves import map
-from six.moves import zip
 
 # cProfile was added in Python2.5
 try:
@@ -933,7 +932,7 @@ python-profiler package from non-free.""")
         tc = clock()-t0
 
         ns = {}
-        exec(code, self.shell.user_ns, ns)
+        six.exec_(code, self.shell.user_ns, ns)
         timer.inner = ns["inner"]
 
         if number == 0:

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -56,11 +56,7 @@ from IPython.utils.module_paths import find_mod
 from IPython.utils.path import get_py_filename, unquote_filename, shellglob
 from IPython.utils.timing import clock, clock2
 from IPython.utils.warn import warn, error
-from IPython.utils.py3compat import PY3
-if PY3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from IPython.utils.py3compat import StringIO
 
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Implementation of execution-related magic functions.
 """
+from __future__ import print_function
 #-----------------------------------------------------------------------------
 #  Copyright (c) 2012 The IPython Development Team.
 #
@@ -21,6 +22,9 @@ import os
 import sys
 import time
 from StringIO import StringIO
+import six
+from six.moves import map
+from six.moves import zip
 
 # cProfile was added in Python2.5
 try:
@@ -237,22 +241,22 @@ python-profiler package from non-free.""")
 
         if 'q' not in opts:
             page.page(output)
-        print sys_exit,
+        print(sys_exit, end=' ')
 
         dump_file = opts.D[0]
         text_file = opts.T[0]
         if dump_file:
             dump_file = unquote_filename(dump_file)
             prof.dump_stats(dump_file)
-            print '\n*** Profile stats marshalled to file',\
-                  repr(dump_file)+'.',sys_exit
+            print('\n*** Profile stats marshalled to file',\
+                  repr(dump_file)+'.',sys_exit)
         if text_file:
             text_file = unquote_filename(text_file)
             pfile = open(text_file,'w')
             pfile.write(output)
             pfile.close()
-            print '\n*** Profile printout saved to text file',\
-                  repr(text_file)+'.',sys_exit
+            print('\n*** Profile printout saved to text file',\
+                  repr(text_file)+'.',sys_exit)
 
         if 'r' in opts:
             return stats
@@ -292,7 +296,7 @@ python-profiler package from non-free.""")
 
         # set on the shell
         self.shell.call_pdb = new_pdb
-        print 'Automatic pdb calling has been turned',on_off(new_pdb)
+        print('Automatic pdb calling has been turned',on_off(new_pdb))
 
     @skip_doctest
     @magic_arguments.magic_arguments()
@@ -510,7 +514,7 @@ python-profiler package from non-free.""")
             filename = file_finder(arg_lst[0])
         except IndexError:
             warn('you must provide at least a filename.')
-            print '\n%run:\n', oinspect.getdoc(self.run)
+            print('\n%run:\n', oinspect.getdoc(self.run))
             return
         except IOError as e:
             try:
@@ -727,7 +731,7 @@ python-profiler package from non-free.""")
             deb.mainpyfile = deb.canonic(filename)
 
         # Start file run
-        print "NOTE: Enter 'c' at the %s prompt to continue execution." % deb.prompt
+        print("NOTE: Enter 'c' at the %s prompt to continue execution." % deb.prompt)
         try:
             if filename:
                 # save filename so it can be used by methods on the deb object
@@ -761,24 +765,24 @@ python-profiler package from non-free.""")
             t1 = clock2()
             t_usr = t1[0] - t0[0]
             t_sys = t1[1] - t0[1]
-            print "\nIPython CPU timings (estimated):"
-            print "  User   : %10.2f s." % t_usr
-            print "  System : %10.2f s." % t_sys
+            print("\nIPython CPU timings (estimated):")
+            print("  User   : %10.2f s." % t_usr)
+            print("  System : %10.2f s." % t_sys)
         else:
-            runs = range(nruns)
+            runs = list(range(nruns))
             t0 = clock2()
             for nr in runs:
                 run()
             t1 = clock2()
             t_usr = t1[0] - t0[0]
             t_sys = t1[1] - t0[1]
-            print "\nIPython CPU timings (estimated):"
-            print "Total runs performed:", nruns
-            print "  Times  : %10s   %10s" % ('Total', 'Per run')
-            print "  User   : %10.2f s, %10.2f s." % (t_usr, t_usr / nruns)
-            print "  System : %10.2f s, %10.2f s." % (t_sys, t_sys / nruns)
+            print("\nIPython CPU timings (estimated):")
+            print("Total runs performed:", nruns)
+            print("  Times  : %10s   %10s" % ('Total', 'Per run'))
+            print("  User   : %10.2f s, %10.2f s." % (t_usr, t_usr / nruns))
+            print("  System : %10.2f s, %10.2f s." % (t_sys, t_sys / nruns))
         twall1 = time.time()
-        print "Wall time: %10.2f s." % (twall1 - twall0)
+        print("Wall time: %10.2f s." % (twall1 - twall0))
 
     @skip_doctest
     @line_cell_magic
@@ -921,7 +925,7 @@ python-profiler package from non-free.""")
         tc = clock()-t0
 
         ns = {}
-        exec code in self.shell.user_ns, ns
+        exec(code, self.shell.user_ns, ns)
         timer.inner = ns["inner"]
 
         if number == 0:
@@ -934,10 +938,10 @@ python-profiler package from non-free.""")
 
         best = min(timer.repeat(repeat, number)) / number
 
-        print u"%d loops, best of %d: %s per loop" % (number, repeat,
-                                                          _format_time(best, precision))
+        print(u"%d loops, best of %d: %s per loop" % (number, repeat,
+                                                          _format_time(best, precision)))
         if tc > tc_min:
-            print "Compiler time: %.2f s" % tc
+            print("Compiler time: %.2f s" % tc)
 
     @skip_doctest
     @needs_local_scope
@@ -1042,7 +1046,7 @@ python-profiler package from non-free.""")
             end = clock2()
         else:
             st = clock2()
-            exec code in glob, local_ns
+            exec(code, glob, local_ns)
             end = clock2()
             out = None
         wall_end = wtime()
@@ -1053,13 +1057,13 @@ python-profiler package from non-free.""")
         cpu_tot = cpu_user+cpu_sys
         # On windows cpu_sys is always zero, so no new information to the next print 
         if sys.platform != 'win32':
-            print "CPU times: user %s, sys: %s, total: %s" % \
-                (_format_time(cpu_user),_format_time(cpu_sys),_format_time(cpu_tot))
-        print "Wall time: %s" % _format_time(wall_time)
+            print("CPU times: user %s, sys: %s, total: %s" % \
+                (_format_time(cpu_user),_format_time(cpu_sys),_format_time(cpu_tot)))
+        print("Wall time: %s" % _format_time(wall_time))
         if tc > tc_min:
-            print "Compiler : %s" % _format_time(tc)
+            print("Compiler : %s" % _format_time(tc))
         if tp > tp_min:
-            print "Parser   : %s" % _format_time(tp)
+            print("Parser   : %s" % _format_time(tp))
         return out
 
     @skip_doctest
@@ -1127,7 +1131,7 @@ python-profiler package from non-free.""")
         """
         opts,args = self.parse_options(parameter_s,'rq',mode='list')
         if not args:   # List existing macros
-            return sorted(k for k,v in self.shell.user_ns.iteritems() if\
+            return sorted(k for k,v in six.iteritems(self.shell.user_ns) if\
                                                         isinstance(v, Macro))
         if len(args) == 1:
             raise UsageError(
@@ -1138,14 +1142,14 @@ python-profiler package from non-free.""")
         try:
             lines = self.shell.find_user_code(codefrom, 'r' in opts)
         except (ValueError, TypeError) as e:
-            print e.args[0]
+            print(e.args[0])
             return
         macro = Macro(lines)
         self.shell.define_macro(name, macro)
         if not ( 'q' in opts) : 
-            print 'Macro `%s` created. To execute, type its name (without quotes).' % name
-            print '=== Macro contents: ==='
-            print macro,
+            print('Macro `%s` created. To execute, type its name (without quotes).' % name)
+            print('=== Macro contents: ===')
+            print(macro, end=' ')
 
     @magic_arguments.magic_arguments()
     @magic_arguments.argument('output', type=str, default='', nargs='?',

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -15,7 +15,11 @@ from __future__ import print_function
 #-----------------------------------------------------------------------------
 
 # Stdlib
-import __builtin__ as builtin_mod
+try:
+    import builtins
+except ImportError:  
+    # Python 2
+    import __builtin__ as builtins
 import ast
 import bdb
 import os
@@ -661,7 +665,7 @@ python-profiler package from non-free.""")
             # Since this seems to be done by the interpreter itself, the best
             # we can do is to at least restore __builtins__ for the user on
             # exit.
-            self.shell.user_ns['__builtins__'] = builtin_mod
+            self.shell.user_ns['__builtins__'] = builtins
 
             # Ensure key global structures are restored
             sys.argv = save_argv

--- a/IPython/core/magics/extension.py
+++ b/IPython/core/magics/extension.py
@@ -1,5 +1,6 @@
 """Implementation of magic functions for the extension machinery.
 """
+from __future__ import print_function
 #-----------------------------------------------------------------------------
 #  Copyright (c) 2012 The IPython Development Team.
 #
@@ -46,12 +47,12 @@ class ExtensionMagics(Magics):
             filename = self.shell.extension_manager.install_extension(args,
                                                                  opts.get('n'))
         except ValueError as e:
-            print e
+            print(e)
             return
 
         filename = os.path.basename(filename)
-        print "Installed %s. To use it, type:" % filename
-        print "  %%load_ext %s" % os.path.splitext(filename)[0]
+        print("Installed %s. To use it, type:" % filename)
+        print("  %%load_ext %s" % os.path.splitext(filename)[0])
 
 
     @line_magic
@@ -62,10 +63,10 @@ class ExtensionMagics(Magics):
         res = self.shell.extension_manager.load_extension(module_str)
         
         if res == 'already loaded':
-            print "The %s extension is already loaded. To reload it, use:" % module_str
-            print "  %reload_ext", module_str
+            print("The %s extension is already loaded. To reload it, use:" % module_str)
+            print("  %reload_ext", module_str)
         elif res == 'no load function':
-            print "The %s module is not an IPython extension." % module_str
+            print("The %s module is not an IPython extension." % module_str)
 
     @line_magic
     def unload_ext(self, module_str):
@@ -80,9 +81,9 @@ class ExtensionMagics(Magics):
         res = self.shell.extension_manager.unload_extension(module_str)
         
         if res == 'no unload function':
-            print "The %s extension doesn't define how to unload it." % module_str
+            print("The %s extension doesn't define how to unload it." % module_str)
         elif res == "not loaded":
-            print "The %s extension is not loaded." % module_str
+            print("The %s extension is not loaded." % module_str)
 
     @line_magic
     def reload_ext(self, module_str):

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -401,8 +401,6 @@ class NamespaceMagics(Magics):
                 ndarray_type = ndarray.__name__
 
         # Find all variable names and types so we can figure out column sizes
-        def get_vars(i):
-            return self.shell.user_ns[i]
 
         # some types are well known and can be shorter
         abbrevs = {'IPython.core.macro.Macro' : 'Macro'}
@@ -410,7 +408,7 @@ class NamespaceMagics(Magics):
             tn = type(v).__name__
             return abbrevs.get(tn,tn)
 
-        varlist = map(get_vars,varnames)
+        varlist = [self.shell.user_ns[n] for n in varnames]
 
         typelist = []
         for vv in varlist:
@@ -583,7 +581,7 @@ class NamespaceMagics(Magics):
                     from numpy import ndarray
                     # This must be done with items and not iteritems because
                     # we're going to modify the dict in-place.
-                    for x,val in user_ns.items():
+                    for x,val in list(user_ns.items()):
                         if isinstance(val,ndarray):
                             del user_ns[x]
                 except ImportError:

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -26,8 +26,6 @@ from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.encoding import DEFAULT_ENCODING
 from IPython.utils.openpy import read_py_file
 from IPython.utils.path import get_py_filename
-from six.moves import map
-from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Magic implementation classes

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -1,5 +1,6 @@
 """Implementation of namespace-related magic functions.
 """
+from __future__ import print_function
 #-----------------------------------------------------------------------------
 #  Copyright (c) 2012 The IPython Development Team.
 #
@@ -25,6 +26,8 @@ from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.encoding import DEFAULT_ENCODING
 from IPython.utils.openpy import read_py_file
 from IPython.utils.path import get_py_filename
+from six.moves import map
+from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Magic implementation classes
@@ -117,7 +120,7 @@ class NamespaceMagics(Magics):
             try:
                 filename = get_py_filename(parameter_s)
             except IOError as msg:
-                print msg
+                print(msg)
                 return
             page.page(self.shell.pycolorize(read_py_file(filename, skip_encoding_cookie=False)))
 
@@ -204,7 +207,7 @@ class NamespaceMagics(Magics):
         try:
             parameter_s.encode('ascii')
         except UnicodeEncodeError:
-            print 'Python identifiers can only contain ascii characters.'
+            print('Python identifiers can only contain ascii characters.')
             return
 
         # default namespaces to be searched
@@ -326,20 +329,20 @@ class NamespaceMagics(Magics):
         varlist = self.who_ls(parameter_s)
         if not varlist:
             if parameter_s:
-                print 'No variables match your requested type.'
+                print('No variables match your requested type.')
             else:
-                print 'Interactive namespace is empty.'
+                print('Interactive namespace is empty.')
             return
 
         # if we have variables, move on...
         count = 0
         for i in varlist:
-            print i+'\t',
+            print(i+'\t', end=' ')
             count += 1
             if count > 8:
                 count = 0
-                print
-        print
+                print()
+        print()
 
     @skip_doctest
     @line_magic
@@ -377,9 +380,9 @@ class NamespaceMagics(Magics):
         varnames = self.who_ls(parameter_s)
         if not varnames:
             if parameter_s:
-                print 'No variables match your requested type.'
+                print('No variables match your requested type.')
             else:
-                print 'Interactive namespace is empty.'
+                print('Interactive namespace is empty.')
             return
 
         # if we have variables, move on...
@@ -431,15 +434,15 @@ class NamespaceMagics(Magics):
         varwidth = max(max(map(len,varnames)), len(varlabel)) + colsep
         typewidth = max(max(map(len,typelist)), len(typelabel)) + colsep
         # table header
-        print varlabel.ljust(varwidth) + typelabel.ljust(typewidth) + \
-              ' '+datalabel+'\n' + '-'*(varwidth+typewidth+len(datalabel)+1)
+        print(varlabel.ljust(varwidth) + typelabel.ljust(typewidth) + \
+              ' '+datalabel+'\n' + '-'*(varwidth+typewidth+len(datalabel)+1))
         # and the table itself
         kb = 1024
         Mb = 1048576  # kb**2
         for vname,var,vtype in zip(varnames,varlist,typelist):
-            print vformat.format(vname, vtype, varwidth=varwidth, typewidth=typewidth),
+            print(vformat.format(vname, vtype, varwidth=varwidth, typewidth=typewidth), end=' ')
             if vtype in seq_types:
-                print "n="+str(len(var))
+                print("n="+str(len(var)))
             elif vtype == ndarray_type:
                 vshape = str(var.shape).replace(',','').replace(' ','x')[1:-1]
                 if vtype==ndarray_type:
@@ -449,13 +452,13 @@ class NamespaceMagics(Magics):
                     vdtype = var.dtype
 
                 if vbytes < 100000:
-                    print aformat % (vshape, vsize, vdtype, vbytes)
+                    print(aformat % (vshape, vsize, vdtype, vbytes))
                 else:
-                    print aformat % (vshape, vsize, vdtype, vbytes),
+                    print(aformat % (vshape, vsize, vdtype, vbytes), end=' ')
                     if vbytes < Mb:
-                        print '(%s kb)' % (vbytes/kb,)
+                        print('(%s kb)' % (vbytes/kb,))
                     else:
-                        print '(%s Mb)' % (vbytes/Mb,)
+                        print('(%s Mb)' % (vbytes/Mb,))
             else:
                 try:
                     vstr = str(var)
@@ -466,9 +469,9 @@ class NamespaceMagics(Magics):
                     vstr = "<object with id %d (str() failed)>" % id(var)
                 vstr = vstr.replace('\n', '\\n')
                 if len(vstr) < 50:
-                    print vstr
+                    print(vstr)
                 else:
-                    print vstr[:25] + "<...>" + vstr[-25:]
+                    print(vstr[:25] + "<...>" + vstr[-25:])
 
     @line_magic
     def reset(self, parameter_s=''):
@@ -539,7 +542,7 @@ class NamespaceMagics(Magics):
             except StdinNotImplementedError:
                 ans = True
         if not ans:
-            print 'Nothing done.'
+            print('Nothing done.')
             return
 
         if 's' in opts:                     # Soft reset
@@ -556,11 +559,11 @@ class NamespaceMagics(Magics):
         for target in args:
             target = target.lower() # make matches case insensitive
             if target == 'out':
-                print "Flushing output cache (%d entries)" % len(user_ns['_oh'])
+                print("Flushing output cache (%d entries)" % len(user_ns['_oh']))
                 self.shell.displayhook.flush()
 
             elif target == 'in':
-                print "Flushing input history"
+                print("Flushing input history")
                 pc = self.shell.displayhook.prompt_count + 1
                 for n in range(1, pc):
                     key = '_i'+repr(n)
@@ -584,15 +587,15 @@ class NamespaceMagics(Magics):
                         if isinstance(val,ndarray):
                             del user_ns[x]
                 except ImportError:
-                    print "reset array only works if Numpy is available."
+                    print("reset array only works if Numpy is available.")
 
             elif target == 'dhist':
-                print "Flushing directory history"
+                print("Flushing directory history")
                 del user_ns['_dh'][:]
 
             else:
-                print "Don't know how to reset ",
-                print target + ", please run `%reset?` for details"
+                print("Don't know how to reset ", end=' ')
+                print(target + ", please run `%reset?` for details")
 
         gc.collect()
 
@@ -669,11 +672,11 @@ class NamespaceMagics(Magics):
             except StdinNotImplementedError:
                 ans = True
         if not ans:
-            print 'Nothing done.'
+            print('Nothing done.')
             return
         user_ns = self.shell.user_ns
         if not regex:
-            print 'No regex pattern specified. Nothing done.'
+            print('No regex pattern specified. Nothing done.')
             return
         else:
             try:
@@ -700,4 +703,4 @@ class NamespaceMagics(Magics):
         try:
             self.shell.del_var(varname, ('n' in opts))
         except (NameError, ValueError) as e:
-            print type(e).__name__ +": "+ str(e)
+            print(type(e).__name__ +": "+ str(e))

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -35,6 +35,7 @@ from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.openpy import source_to_unicode
 from IPython.utils.path import unquote_filename
 from IPython.utils.process import abbrev_cwd
+from IPython.utils.py3compat import unicode_type
 from IPython.utils.terminal import set_term_title
 from six.moves import filter
 from six.moves import map
@@ -707,7 +708,7 @@ class OSMagics(Magics):
              'The file will be created if it does not exist.'
     )
     @magic_arguments.argument(
-        'filename', type=unicode,
+        'filename', type=unicode_type,
         help='file to write'
     )
     @cell_magic

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -3,6 +3,7 @@
 Note: this module is named 'osm' instead of 'os' to avoid a collision with the
 builtin.
 """
+from __future__ import print_function
 #-----------------------------------------------------------------------------
 #  Copyright (c) 2012 The IPython Development Team.
 #
@@ -35,6 +36,9 @@ from IPython.utils.openpy import source_to_unicode
 from IPython.utils.path import unquote_filename
 from IPython.utils.process import abbrev_cwd
 from IPython.utils.terminal import set_term_title
+from six.moves import filter
+from six.moves import map
+from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Magic implementation classes
@@ -106,7 +110,7 @@ class OSMagics(Magics):
             # for k, v in stored:
             #     atab.append(k, v[0])
 
-            print "Total number of aliases:", len(aliases)
+            print("Total number of aliases:", len(aliases))
             sys.stdout.flush()
             return aliases
 
@@ -114,7 +118,7 @@ class OSMagics(Magics):
         try:
             alias,cmd = par.split(None, 1)
         except:
-            print oinspect.getdoc(self.alias)
+            print(oinspect.getdoc(self.alias))
         else:
             self.shell.alias_manager.soft_define_alias(alias, cmd)
     # end magic_alias
@@ -127,7 +131,7 @@ class OSMagics(Magics):
         self.shell.alias_manager.undefine_alias(aname)
         stored = self.shell.db.get('stored_aliases', {} )
         if aname in stored:
-            print "Removing %stored alias",aname
+            print("Removing %stored alias",aname)
             del stored[aname]
             self.shell.db['stored_aliases'] = stored
 
@@ -274,7 +278,7 @@ class OSMagics(Magics):
             try:
                 ps = self.shell.user_ns['_dh'][nn]
             except IndexError:
-                print 'The requested directory does not exist in history.'
+                print('The requested directory does not exist in history.')
                 return
             else:
                 opts = {}
@@ -297,7 +301,7 @@ class OSMagics(Magics):
                 ps = fallback
 
             if ps is None:
-                print "No matching entry in directory history"
+                print("No matching entry in directory history")
                 return
             else:
                 opts = {}
@@ -321,7 +325,7 @@ class OSMagics(Magics):
 
                 if ps in bkms:
                     target = bkms[ps]
-                    print '(bookmark:%s) -> %s' % (ps, target)
+                    print('(bookmark:%s) -> %s' % (ps, target))
                     ps = target
                 else:
                     if 'b' in opts:
@@ -337,7 +341,7 @@ class OSMagics(Magics):
                 if hasattr(self.shell, 'term_title') and self.shell.term_title:
                     set_term_title('IPython: ' + abbrev_cwd())
             except OSError:
-                print sys.exc_info()[1]
+                print(sys.exc_info()[1])
             else:
                 cwd = os.getcwdu()
                 dhist = self.shell.user_ns['_dh']
@@ -356,7 +360,7 @@ class OSMagics(Magics):
                 dhist.append(cwd)
                 self.shell.db['dhist'] = compress_dhist(dhist)[-100:]
         if not 'q' in opts and self.shell.user_ns['_dh']:
-            print self.shell.user_ns['_dh'][-1]
+            print(self.shell.user_ns['_dh'][-1])
 
 
     @line_magic
@@ -389,7 +393,7 @@ class OSMagics(Magics):
             raise UsageError("%popd on empty stack")
         top = self.shell.dir_stack.pop(0)
         self.cd(top)
-        print "popd ->",top
+        print("popd ->",top)
 
     @line_magic
     def dirs(self, parameter_s=''):
@@ -431,9 +435,9 @@ class OSMagics(Magics):
                 return
         else:
             ini,fin = 0,len(dh)
-        print 'Directory history (kept in _dh)'
+        print('Directory history (kept in _dh)')
         for i in range(ini, fin):
-            print "%d: %s" % (i, dh[i])
+            print("%d: %s" % (i, dh[i]))
 
     @skip_doctest
     @line_magic
@@ -545,7 +549,7 @@ class OSMagics(Magics):
         split = 'l' in opts
         out = self.shell.getoutput(cmd, split=split)
         if 'v' in opts:
-            print '%s ==\n%s' % (var, pformat(out))
+            print('%s ==\n%s' % (var, pformat(out)))
         if var:
             self.shell.user_ns.update({var:out})
         else:
@@ -657,9 +661,9 @@ class OSMagics(Magics):
             else:
                 size = 0
             fmt = '%-'+str(size)+'s -> %s'
-            print 'Current bookmarks:'
+            print('Current bookmarks:')
             for bk in bks:
-                print fmt % (bk, bkms[bk])
+                print(fmt % (bk, bkms[bk]))
         else:
             if not args:
                 raise UsageError("%bookmark: You must specify the bookmark name")
@@ -691,7 +695,7 @@ class OSMagics(Magics):
         try :
             cont = self.shell.find_user_code(parameter_s, skip_encoding_cookie=False)
         except (ValueError, IOError):
-            print "Error: no such file, variable, URL, history range or macro"
+            print("Error: no such file, variable, URL, history range or macro")
             return
 
         page.page(self.shell.pycolorize(source_to_unicode(cont)))
@@ -717,11 +721,11 @@ class OSMagics(Magics):
         
         if os.path.exists(filename):
             if args.append:
-                print "Appending to %s" % filename
+                print("Appending to %s" % filename)
             else:
-                print "Overwriting %s" % filename
+                print("Overwriting %s" % filename)
         else:
-            print "Writing %s" % filename
+            print("Writing %s" % filename)
         
         mode = 'a' if args.append else 'w'
         with io.open(filename, mode, encoding='utf-8') as f:

--- a/IPython/core/magics/pylab.py
+++ b/IPython/core/magics/pylab.py
@@ -1,5 +1,6 @@
 """Implementation of magic functions for matplotlib/pylab support.
 """
+from __future__ import print_function
 #-----------------------------------------------------------------------------
 #  Copyright (c) 2012 The IPython Development Team.
 #
@@ -139,5 +140,5 @@ class PylabMagics(Magics):
     def _show_matplotlib_backend(self, gui, backend):
         """show matplotlib message backend message"""
         if not gui or gui == 'auto':
-            print ("Using matplotlib backend: %s" % backend)
+            print(("Using matplotlib backend: %s" % backend))
     

--- a/IPython/core/magics/pylab.py
+++ b/IPython/core/magics/pylab.py
@@ -140,5 +140,5 @@ class PylabMagics(Magics):
     def _show_matplotlib_backend(self, gui, backend):
         """show matplotlib message backend message"""
         if not gui or gui == 'auto':
-            print(("Using matplotlib backend: %s" % backend))
+            print("Using matplotlib backend: %s" % backend)
     

--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -1,4 +1,5 @@
 """Magic functions for running cells in various scripts."""
+from __future__ import print_function
 #-----------------------------------------------------------------------------
 #  Copyright (c) 2012 The IPython Development Team.
 #
@@ -187,7 +188,7 @@ class ScriptMagics(Magics, Configurable):
             p = Popen(cmd, stdout=PIPE, stderr=PIPE, stdin=PIPE)
         except OSError as e:
             if e.errno == errno.ENOENT:
-                print "Couldn't find program: %r" % cmd[0]
+                print("Couldn't find program: %r" % cmd[0])
                 return
             else:
                 raise
@@ -212,20 +213,20 @@ class ScriptMagics(Magics, Configurable):
                 p.send_signal(signal.SIGINT)
                 time.sleep(0.1)
                 if p.poll() is not None:
-                    print "Process is interrupted."
+                    print("Process is interrupted.")
                     return
                 p.terminate()
                 time.sleep(0.1)
                 if p.poll() is not None:
-                    print "Process is terminated."
+                    print("Process is terminated.")
                     return
                 p.kill()
-                print "Process is killed."
+                print("Process is killed.")
             except OSError:
                 pass
             except Exception as e:
-                print "Error while terminating subprocess (pid=%i): %s" \
-                    % (p.pid, e)
+                print("Error while terminating subprocess (pid=%i): %s" \
+                    % (p.pid, e))
             return
         out = py3compat.bytes_to_str(out)
         err = py3compat.bytes_to_str(err)
@@ -250,7 +251,7 @@ class ScriptMagics(Magics, Configurable):
     def killbgscripts(self, _nouse_=''):
         """Kill all BG processes started by %%script and its family."""
         self.kill_bg_processes()
-        print "All background processes were killed."
+        print("All background processes were killed.")
 
     def kill_bg_processes(self):
         """Kill all BG processes which are still running."""

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -187,13 +187,13 @@ def getargspec(obj):
     if inspect.isfunction(obj):
         func_obj = obj
     elif inspect.ismethod(obj):
-        func_obj = obj.im_func
+        func_obj = obj.__func__
     elif hasattr(obj, '__call__'):
         func_obj = obj.__call__
     else:
         raise TypeError('arg is not a Python function')
-    args, varargs, varkw = inspect.getargs(func_obj.func_code)
-    return args, varargs, varkw, func_obj.func_defaults
+    args, varargs, varkw = inspect.getargs(func_obj.__code__)
+    return args, varargs, varkw, func_obj.__defaults__
 
 
 def format_argspec(argspec):

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -39,7 +39,7 @@ from IPython.utils import py3compat
 from IPython.utils.text import indent
 from IPython.utils.wildcard import list_namespace
 from IPython.utils.coloransi import *
-from IPython.utils.py3compat import cast_unicode
+from IPython.utils.py3compat import cast_unicode, string_types
 
 #****************************************************************************
 # Builtin color schemes
@@ -129,7 +129,7 @@ def getdoc(obj):
         pass
     else:
         # if we get extra info, we add it to the normal docstring.
-        if isinstance(ds, basestring):
+        if isinstance(ds, string_types):
             return inspect.cleandoc(ds)
     
     try:

--- a/IPython/core/profileapp.py
+++ b/IPython/core/profileapp.py
@@ -9,6 +9,7 @@ Authors:
 * Min RK
 
 """
+from __future__ import print_function
 
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2008-2011  The IPython Development Team
@@ -125,7 +126,7 @@ class ProfileLocate(BaseIPythonApplication):
             self.profile = self.extra_args[0]
     
     def start(self):
-        print self.profile_dir.location
+        print(self.profile_dir.location)
 
 
 class ProfileList(Application):
@@ -156,35 +157,35 @@ class ProfileList(Application):
     def _print_profiles(self, profiles):
         """print list of profiles, indented."""
         for profile in profiles:
-            print '    %s' % profile
+            print('    %s' % profile)
 
     def list_profile_dirs(self):
         profiles = list_bundled_profiles()
         if profiles:
-            print
-            print "Available profiles in IPython:"
+            print()
+            print("Available profiles in IPython:")
             self._print_profiles(profiles)
-            print
-            print "    The first request for a bundled profile will copy it"
-            print "    into your IPython directory (%s)," % self.ipython_dir
-            print "    where you can customize it."
+            print()
+            print("    The first request for a bundled profile will copy it")
+            print("    into your IPython directory (%s)," % self.ipython_dir)
+            print("    where you can customize it.")
         
         profiles = list_profiles_in(self.ipython_dir)
         if profiles:
-            print
-            print "Available profiles in %s:" % self.ipython_dir
+            print()
+            print("Available profiles in %s:" % self.ipython_dir)
             self._print_profiles(profiles)
         
         profiles = list_profiles_in(os.getcwdu())
         if profiles:
-            print
-            print "Available profiles in current directory (%s):" % os.getcwdu()
+            print()
+            print("Available profiles in current directory (%s):" % os.getcwdu())
             self._print_profiles(profiles)
         
-        print
-        print "To use any of the above profiles, start IPython with:"
-        print "    ipython --profile=<name>"
-        print
+        print()
+        print("To use any of the above profiles, start IPython with:")
+        print("    ipython --profile=<name>")
+        print()
 
     def start(self):
         self.list_profile_dirs()
@@ -296,8 +297,8 @@ class ProfileApp(Application):
 
     def start(self):
         if self.subapp is None:
-            print "No subcommand specified. Must specify one of: %s"%(self.subcommands.keys())
-            print
+            print("No subcommand specified. Must specify one of: %s"%(self.subcommands.keys()))
+            print()
             self.print_description()
             self.print_subcommands()
             self.exit(1)

--- a/IPython/core/prompts.py
+++ b/IPython/core/prompts.py
@@ -32,8 +32,6 @@ from IPython.config.configurable import Configurable
 from IPython.core import release
 from IPython.utils import coloransi, py3compat
 from IPython.utils.traitlets import (Unicode, Instance, Dict, Bool, Int)
-from six.moves import map
-from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Color schemes for prompts

--- a/IPython/core/prompts.py
+++ b/IPython/core/prompts.py
@@ -32,6 +32,8 @@ from IPython.config.configurable import Configurable
 from IPython.core import release
 from IPython.utils import coloransi, py3compat
 from IPython.utils.traitlets import (Unicode, Instance, Dict, Bool, Int)
+from six.moves import map
+from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Color schemes for prompts

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -7,6 +7,7 @@ Authors
 * Fernando Perez.
 * Brian Granger
 """
+from __future__ import print_function
 
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2009  The IPython Development Team
@@ -74,7 +75,7 @@ def getfigs(*fig_nums):
         for num in fig_nums:
             f = Gcf.figs.get(num)
             if f is None:
-                print('Warning: figure %s not available.' % num)
+                print(('Warning: figure %s not available.' % num))
             else:
                 figs.append(f.canvas.figure)
         return figs
@@ -270,12 +271,12 @@ def import_pylab(user_ns, import_all=True):
           "np = numpy\n"
           "plt = pyplot\n"
           )
-    exec s in user_ns
+    exec(s, user_ns)
     
     if import_all:
         s = ("from matplotlib.pylab import *\n"
              "from numpy import *\n")
-        exec s in user_ns
+        exec(s, user_ns)
     
     # IPython symbols to add
     user_ns['figsize'] = figsize

--- a/IPython/core/release.py
+++ b/IPython/core/release.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """Release data for the IPython project."""
+from six.moves import map
+from six.moves import zip
 
 #-----------------------------------------------------------------------------
 #  Copyright (c) 2008, IPython Development Team.

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -21,6 +21,7 @@ Authors
 #-----------------------------------------------------------------------------
 
 from __future__ import absolute_import
+from __future__ import print_function
 
 import glob
 import os
@@ -245,7 +246,7 @@ class InteractiveShellApp(Configurable):
             self.log.info("Enabling GUI event loop integration, "
                       "eventloop=%s, matplotlib=%s", gui, backend)
             if key == "auto":
-                print ("Using matplotlib backend: %s" % backend)
+                print(("Using matplotlib backend: %s" % backend))
         else:
             gui = r
             self.log.info("Enabling GUI event loop integration, "

--- a/IPython/core/tests/print_argv.py
+++ b/IPython/core/tests/print_argv.py
@@ -1,2 +1,3 @@
+from __future__ import print_function
 import sys
-print sys.argv[1:]
+print(sys.argv[1:])

--- a/IPython/core/tests/refbug.py
+++ b/IPython/core/tests/refbug.py
@@ -12,6 +12,7 @@ This script is meant to be called by other parts of the test suite that call it
 via %run as if it were executed interactively by the user. As of 2011-05-29,
 test_run.py calls it.
 """
+from __future__ import print_function
 
 #-----------------------------------------------------------------------------
 # Module imports
@@ -44,4 +45,4 @@ if __name__ == '__main__':
 
     def call_f():
         for func in cache:
-            print 'lowercased:',func().lower()
+            print('lowercased:',func().lower())

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -18,8 +18,8 @@ from IPython.core import completer
 from IPython.external.decorators import knownfailureif
 from IPython.utils.tempdir import TemporaryDirectory
 from IPython.utils.generics import complete_object
+from IPython.utils.py3compat import unicode_type, string_types
 from six.moves import map
-from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Test functions
@@ -66,7 +66,7 @@ def check_line_split(splitter, test_specs):
 
 
 def test_line_split():
-    """Basice line splitter test with default specs."""
+    """Basic line splitter test with default specs."""
     sp = completer.CompletionSplitter()
     # The format of the test specs is: part1, part2, expected answer.  Parts 1
     # and 2 are joined into the 'line' sent to the splitter, as if the cursor
@@ -85,7 +85,7 @@ def test_line_split():
     check_line_split(sp, t)
     # Ensure splitting works OK with unicode by re-running the tests with
     # all inputs turned into unicode
-    check_line_split(sp, [ map(unicode, p) for p in t] )
+    check_line_split(sp, [ map(unicode_type, p) for p in t] )
 
 
 def test_custom_completion_error():
@@ -106,13 +106,13 @@ def test_unicode_completions():
     # Some strings that trigger different types of completion.  Check them both
     # in str and unicode forms
     s = ['ru', '%ru', 'cd /', 'floa', 'float(x)/']
-    for t in s + map(unicode, s):
+    for t in s + list(map(unicode_type, s)):
         # We don't need to check exact completion values (they may change
         # depending on the state of the namespace, but at least no exceptions
         # should be thrown and the return value should be a pair of text, list
         # values.
         text, matches = ip.complete(t)
-        nt.assert_true(isinstance(text, basestring))
+        nt.assert_true(isinstance(text, string_types))
         nt.assert_true(isinstance(matches, list))
 
 
@@ -160,7 +160,7 @@ def test_abspath_file_completions():
     ip = get_ipython()
     with TemporaryDirectory() as tmpdir:
         prefix = os.path.join(tmpdir, 'foo')
-        suffixes = map(str, [1,2])
+        suffixes = ('1', '2')
         names = [prefix+s for s in suffixes]
         for n in names:
             open(n, 'w').close()
@@ -183,10 +183,12 @@ def test_local_file_completions():
         with TemporaryDirectory() as tmpdir:
             os.chdir(tmpdir)
             prefix = './foo'
-            suffixes = map(str, [1,2])
+            suffixes = ('1', '2')
             names = [prefix+s for s in suffixes]
             for n in names:
                 open(n, 'w').close()
+            
+            print(os.listdir('.'))
 
             # Check simple completion
             c = ip.complete(prefix)[1]
@@ -265,8 +267,8 @@ def test_limit_to__all__True_ok():
     cfg.IPCompleter.limit_to__all__ = True
     c.update_config(cfg)
     s, matches = c.complete('d.')
-    nt.assert_true('d.z' in matches) 
-    nt.assert_false('d.x' in matches)
+    nt.assert_in('d.z', matches) 
+    nt.assert_not_in('d.x', matches)
 
 
 def test_get__all__entries_ok():

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -228,8 +228,8 @@ def test_omit__names():
     cfg.IPCompleter.omit__names = 0
     c.update_config(cfg)
     s,matches = c.complete('ip.')
-    nt.assert_true('ip.__str__' in matches)
-    nt.assert_true('ip._hidden_attr' in matches)
+    nt.assert_in('ip.__str__', matches)
+    nt.assert_in('ip._hidden_attr', matches)
     cfg.IPCompleter.omit__names = 1
     c.update_config(cfg)
     s,matches = c.complete('ip.')
@@ -238,8 +238,8 @@ def test_omit__names():
     cfg.IPCompleter.omit__names = 2
     c.update_config(cfg)
     s,matches = c.complete('ip.')
-    nt.assert_false('ip.__str__' in matches)
-    nt.assert_false('ip._hidden_attr' in matches)
+    nt.assert_not_in('ip.__str__', matches)
+    nt.assert_not_in('ip._hidden_attr', matches)
     del ip._hidden_attr
 
 
@@ -252,7 +252,7 @@ def test_limit_to__all__False_ok():
     cfg.IPCompleter.limit_to__all__ = False
     c.update_config(cfg)
     s, matches = c.complete('d.')
-    nt.assert_true('d.x' in matches) 
+    nt.assert_in('d.x', matches) 
 
 
 def test_limit_to__all__True_ok():

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -18,6 +18,8 @@ from IPython.core import completer
 from IPython.external.decorators import knownfailureif
 from IPython.utils.tempdir import TemporaryDirectory
 from IPython.utils.generics import complete_object
+from six.moves import map
+from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Test functions

--- a/IPython/core/tests/test_debugger.py
+++ b/IPython/core/tests/test_debugger.py
@@ -1,5 +1,6 @@
 """Tests for debugging machinery.
 """
+from __future__ import print_function
 #-----------------------------------------------------------------------------
 #  Copyright (c) 2012, The IPython Development Team.
 #
@@ -36,7 +37,7 @@ class _FakeInput(object):
 
     def readline(self):
         line = next(self.lines)
-        print line
+        print(line)
         return line+'\n'
 
 class PdbTestInput(object):

--- a/IPython/core/tests/test_debugger.py
+++ b/IPython/core/tests/test_debugger.py
@@ -58,7 +58,10 @@ class PdbTestInput(object):
 #-----------------------------------------------------------------------------
 
 def test_longer_repr():
-    from repr import repr as trepr
+    try:
+        from reprlib import repr as trepr
+    except ImportError:
+        from repr import repr as trepr
     
     a = '1234567890'* 7
     ar = "'1234567890123456789012345678901234567890123456789012345678901234567890'"

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -43,9 +43,12 @@ def test_history():
             
             # Detailed tests for _get_range_session
             grs = ip.history_manager._get_range_session
-            nt.assert_equal(list(grs(start=2,stop=-1)), zip([0], [2], hist[1:-1]))
-            nt.assert_equal(list(grs(start=-2)), zip([0,0], [2,3], hist[-2:]))
-            nt.assert_equal(list(grs(output=True)), zip([0,0,0], [1,2,3], zip(hist, [None,None,'spam'])))
+            nt.assert_equal(list(grs(start=2,stop=-1)), \
+                                               list(zip([0], [2], hist[1:-1])))
+            nt.assert_equal(list(grs(start=-2)), \
+                                            list(zip([0,0], [2,3], hist[-2:])))
+            nt.assert_equal(list(grs(output=True)), \
+                    list(zip([0,0,0], [1,2,3], zip(hist, [None,None,'spam']))))
 
             # Check whether specifying a range beyond the end of the current
             # session results in an error (gh-804)
@@ -66,10 +69,10 @@ def test_history():
             for i, cmd in enumerate(newcmds, start=1):
                 ip.history_manager.store_inputs(i, cmd)
             gothist = ip.history_manager.get_range(start=1, stop=4)
-            nt.assert_equal(list(gothist), zip([0,0,0],[1,2,3], newcmds))
+            nt.assert_equal(list(gothist), list(zip([0,0,0],[1,2,3], newcmds)))
             # Previous session:
             gothist = ip.history_manager.get_range(-1, 1, 4)
-            nt.assert_equal(list(gothist), zip([1,1,1],[1,2,3], hist))
+            nt.assert_equal(list(gothist), list(zip([1,1,1],[1,2,3], hist)))
 
             newhist = [(2, i, c) for (i, c) in enumerate(newcmds, 1)]
 

--- a/IPython/core/tests/test_inputsplitter.py
+++ b/IPython/core/tests/test_inputsplitter.py
@@ -114,7 +114,7 @@ def test_remove_comments():
 
 def test_get_input_encoding():
     encoding = isp.get_input_encoding()
-    nt.assert_true(isinstance(encoding, basestring))
+    nt.assert_true(isinstance(encoding, py3compat.string_types))
     # simple-minded check that at least encoding a simple string works with the
     # encoding we got.
     nt.assert_equal(u'test'.encode(encoding), b'test')

--- a/IPython/core/tests/test_inputsplitter.py
+++ b/IPython/core/tests/test_inputsplitter.py
@@ -6,6 +6,7 @@ Authors
 * Fernando Perez
 * Robert Kern
 """
+from __future__ import print_function
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2010-2011  The IPython Development Team
 #
@@ -28,6 +29,7 @@ from IPython.core import inputsplitter as isp
 from IPython.core.tests.test_inputtransformer import syntax, syntax_ml
 from IPython.testing import tools as tt
 from IPython.utils import py3compat
+import six
 
 #-----------------------------------------------------------------------------
 # Semi-complete examples (also used as tests)
@@ -365,11 +367,11 @@ class InteractiveLoopTestCase(unittest.TestCase):
         """
         src = mini_interactive_loop(pseudo_input(lines))
         test_ns = {}
-        exec src in test_ns
+        exec(src, test_ns)
         # We can't check that the provided ns is identical to the test_ns,
         # because Python fills test_ns with extra keys (copyright, etc).  But
         # we can check that the given dict is *contained* in test_ns
-        for k,v in ns.iteritems():
+        for k,v in six.iteritems(ns):
             self.assertEqual(test_ns[k], v)
 
     def test_simple(self):
@@ -404,7 +406,7 @@ class IPythonInputTestCase(InputSplitterTestCase):
     def test_syntax(self):
         """Call all single-line syntax tests from the main object"""
         isp = self.isp
-        for example in syntax.itervalues():
+        for example in six.itervalues(syntax):
             for raw, out_t in example:
                 if raw.startswith(' '):
                     continue
@@ -417,7 +419,7 @@ class IPythonInputTestCase(InputSplitterTestCase):
 
     def test_syntax_multiline(self):
         isp = self.isp
-        for example in syntax_ml.itervalues():
+        for example in six.itervalues(syntax_ml):
             for line_pairs in example:
                 out_t_parts = []
                 raw_parts = []
@@ -437,7 +439,7 @@ class IPythonInputTestCase(InputSplitterTestCase):
 
     def test_syntax_multiline_cell(self):
         isp = self.isp
-        for example in syntax_ml.itervalues():
+        for example in six.itervalues(syntax_ml):
 
             out_t_parts = []
             for line_pairs in example:
@@ -497,10 +499,10 @@ if __name__ == '__main__':
             # real interpreter would instead send it for execution somewhere.
             #src = isp.source; raise EOFError # dbg
             src, raw = isp.source_raw_reset()
-            print 'Input source was:\n', src
-            print 'Raw source was:\n', raw
+            print('Input source was:\n', src)
+            print('Raw source was:\n', raw)
     except EOFError:
-        print 'Bye'
+        print('Bye')
 
 # Tests for cell magics support
 

--- a/IPython/core/tests/test_inputsplitter.py
+++ b/IPython/core/tests/test_inputsplitter.py
@@ -29,7 +29,6 @@ from IPython.core import inputsplitter as isp
 from IPython.core.tests.test_inputtransformer import syntax, syntax_ml
 from IPython.testing import tools as tt
 from IPython.utils import py3compat
-import six
 
 #-----------------------------------------------------------------------------
 # Semi-complete examples (also used as tests)
@@ -371,7 +370,7 @@ class InteractiveLoopTestCase(unittest.TestCase):
         # We can't check that the provided ns is identical to the test_ns,
         # because Python fills test_ns with extra keys (copyright, etc).  But
         # we can check that the given dict is *contained* in test_ns
-        for k,v in six.iteritems(ns):
+        for k,v in ns.items():
             self.assertEqual(test_ns[k], v)
 
     def test_simple(self):
@@ -406,7 +405,7 @@ class IPythonInputTestCase(InputSplitterTestCase):
     def test_syntax(self):
         """Call all single-line syntax tests from the main object"""
         isp = self.isp
-        for example in six.itervalues(syntax):
+        for example in syntax.values():
             for raw, out_t in example:
                 if raw.startswith(' '):
                     continue
@@ -419,7 +418,7 @@ class IPythonInputTestCase(InputSplitterTestCase):
 
     def test_syntax_multiline(self):
         isp = self.isp
-        for example in six.itervalues(syntax_ml):
+        for example in syntax_ml.values():
             for line_pairs in example:
                 out_t_parts = []
                 raw_parts = []
@@ -439,7 +438,7 @@ class IPythonInputTestCase(InputSplitterTestCase):
 
     def test_syntax_multiline_cell(self):
         isp = self.isp
-        for example in six.itervalues(syntax_ml):
+        for example in syntax_ml.values():
 
             out_t_parts = []
             for line_pairs in example:

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -35,10 +35,7 @@ import nose.tools as nt
 from IPython.testing.decorators import skipif, onlyif_unicode_paths
 from IPython.testing import tools as tt
 from IPython.utils import io, py3compat
-if py3compat.PY3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from IPython.utils.py3compat import StringIO
 
 #-----------------------------------------------------------------------------
 # Globals

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -27,7 +27,6 @@ import sys
 import tempfile
 import unittest
 from os.path import join
-from StringIO import StringIO
 
 # third-party
 import nose.tools as nt
@@ -35,7 +34,11 @@ import nose.tools as nt
 # Our own
 from IPython.testing.decorators import skipif, onlyif_unicode_paths
 from IPython.testing import tools as tt
-from IPython.utils import io
+from IPython.utils import io, py3compat
+if py3compat.PY3:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 #-----------------------------------------------------------------------------
 # Globals
@@ -150,7 +153,7 @@ class InteractiveShellTestCase(unittest.TestCase):
             assert isinstance(ip.user_ns['byte_str'], str) # string literals are byte strings by default
             ip.run_cell('from __future__ import unicode_literals')
             ip.run_cell(u'unicode_str = "a"')
-            assert isinstance(ip.user_ns['unicode_str'], unicode) # strings literals are now unicode
+            assert isinstance(ip.user_ns['unicode_str'], py3compat.unicode_type) # strings literals are now unicode
         finally:
             # Reset compiler flags so we don't mess up other tests.
             ip.compile.reset_compiler_flags()
@@ -164,7 +167,10 @@ class InteractiveShellTestCase(unittest.TestCase):
                      "        list.__init__(self,x)"))
         ip.run_cell("w=Mylist([1,2,3])")
         
-        from cPickle import dumps
+        try:
+            from cPickle import dumps
+        except ImportError:
+            from pickle import dumps
         
         # We need to swap in our main module - this is only necessary
         # inside the test framework, because IPython puts the interactive module
@@ -431,7 +437,7 @@ class TestSystemRaw(unittest.TestCase):
     def test_1(self):
         """Test system_raw with non-ascii cmd
         """
-        cmd = ur'''python -c "'åäö'"   '''
+        cmd = u'''python -c "'åäö'"   '''
         ip.system_raw(cmd)
     
     def test_exit_code(self):

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -14,6 +14,7 @@ import os
 import sys
 from StringIO import StringIO
 from unittest import TestCase
+import six
 
 try:
     from importlib import invalidate_caches   # Required from Python 3.3
@@ -55,7 +56,7 @@ def test_rehashx():
     # Practically ALL ipython development systems will have more than 10 aliases
 
     nt.assert_true(len(_ip.alias_manager.alias_table) > 10)
-    for key, val in _ip.alias_manager.alias_table.iteritems():
+    for key, val in six.iteritems(_ip.alias_manager.alias_table):
         # we must strip dots from alias names
         nt.assert_not_in('.', key)
 
@@ -245,18 +246,18 @@ def test_reset_out():
     _ip.run_cell("parrot = 'dead'", store_history=True)
     # test '%reset -f out', make an Out prompt
     _ip.run_cell("parrot", store_history=True)
-    nt.assert_true('dead' in [_ip.user_ns[x] for x in '_','__','___'])
+    nt.assert_true('dead' in [_ip.user_ns[x] for x in ('_','__','___')])
     _ip.magic('reset -f out')
-    nt.assert_false('dead' in [_ip.user_ns[x] for x in '_','__','___'])
+    nt.assert_false('dead' in [_ip.user_ns[x] for x in ('_','__','___')])
     nt.assert_equal(len(_ip.user_ns['Out']), 0)
 
 def test_reset_in():
     "Test '%reset in' magic"
     # test '%reset -f in'
     _ip.run_cell("parrot", store_history=True)
-    nt.assert_true('parrot' in [_ip.user_ns[x] for x in '_i','_ii','_iii'])
+    nt.assert_true('parrot' in [_ip.user_ns[x] for x in ('_i','_ii','_iii')])
     _ip.magic('%reset -f in')
-    nt.assert_false('parrot' in [_ip.user_ns[x] for x in '_i','_ii','_iii'])
+    nt.assert_false('parrot' in [_ip.user_ns[x] for x in ('_i','_ii','_iii')])
     nt.assert_equal(len(set(_ip.user_ns['In'])), 1)
 
 def test_reset_dhist():
@@ -771,9 +772,9 @@ def test_multiple_magics():
     foo2 = FooFoo(ip)
     mm = ip.magics_manager
     mm.register(foo1)
-    nt.assert_true(mm.magics['line']['foo'].im_self is foo1)
+    nt.assert_true(mm.magics['line']['foo'].__self__ is foo1)
     mm.register(foo2)
-    nt.assert_true(mm.magics['line']['foo'].im_self is foo2)
+    nt.assert_true(mm.magics['line']['foo'].__self__ is foo2)
 
 def test_alias_magic():
     """Test %alias_magic."""

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -34,13 +34,10 @@ from IPython.nbformat import current
 from IPython.testing import decorators as dec
 from IPython.testing import tools as tt
 from IPython.utils import py3compat
+from IPython.utils.py3compat import StringIO
 from IPython.utils.io import capture_output
 from IPython.utils.tempdir import TemporaryDirectory
 from IPython.utils.process import find_cmd
-if py3compat.PY3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
 
 #-----------------------------------------------------------------------------
 # Test functions begin

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -12,7 +12,6 @@ from __future__ import absolute_import
 import io
 import os
 import sys
-from StringIO import StringIO
 from unittest import TestCase
 import six
 
@@ -38,6 +37,10 @@ from IPython.utils import py3compat
 from IPython.utils.io import capture_output
 from IPython.utils.tempdir import TemporaryDirectory
 from IPython.utils.process import find_cmd
+if py3compat.PY3:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 #-----------------------------------------------------------------------------
 # Test functions begin

--- a/IPython/core/tests/test_magic_terminal.py
+++ b/IPython/core/tests/test_magic_terminal.py
@@ -14,11 +14,7 @@ from unittest import TestCase
 import nose.tools as nt
 
 from IPython.testing import tools as tt
-from IPython.utils import py3compat
-if py3compat.PY3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from IPython.utils.py3compat import StringIO
 
 #-----------------------------------------------------------------------------
 # Globals

--- a/IPython/core/tests/test_magic_terminal.py
+++ b/IPython/core/tests/test_magic_terminal.py
@@ -9,12 +9,16 @@ from __future__ import absolute_import
 #-----------------------------------------------------------------------------
 
 import sys
-from StringIO import StringIO
 from unittest import TestCase
 
 import nose.tools as nt
 
 from IPython.testing import tools as tt
+from IPython.utils import py3compat
+if py3compat.PY3:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 #-----------------------------------------------------------------------------
 # Globals

--- a/IPython/core/tests/test_prompts.py
+++ b/IPython/core/tests/test_prompts.py
@@ -9,6 +9,7 @@ from IPython.testing import tools as tt, decorators as dec
 from IPython.core.prompts import PromptManager, LazyEvaluate
 from IPython.testing.globalipapp import get_ipython
 from IPython.utils.tempdir import TemporaryDirectory
+from IPython.utils.py3compat import unicode_type
 
 ip = get_ipython()
 
@@ -77,7 +78,7 @@ class PromptTests(unittest.TestCase):
         u = u'ünicødé'
         lz = LazyEvaluate(lambda : u)
         # str(lz) would fail
-        self.assertEqual(unicode(lz), u)
+        self.assertEqual(unicode_type(lz), u)
         self.assertEqual(format(lz), u)
     
     def test_lazy_eval_nonascii_bytes(self):
@@ -93,7 +94,7 @@ class PromptTests(unittest.TestCase):
         lz = LazyEvaluate(lambda : f)
         
         self.assertEqual(str(lz), str(f))
-        self.assertEqual(unicode(lz), unicode(f))
+        self.assertEqual(unicode_type(lz), unicode_type(f))
         self.assertEqual(format(lz), str(f))
         self.assertEqual(format(lz, '.1'), '0.5')
     

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -75,6 +75,7 @@ Inheritance diagram:
 #*****************************************************************************
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 import inspect
 import keyword
@@ -87,6 +88,8 @@ import time
 import tokenize
 import traceback
 import types
+from six.moves import map
+from six.moves import zip
 
 try:                           # Python 2
     generate_tokens = tokenize.generate_tokens
@@ -191,9 +194,9 @@ def findsource(object):
             raise IOError('could not find class definition')
 
     if ismethod(object):
-        object = object.im_func
+        object = object.__func__
     if isfunction(object):
-        object = object.func_code
+        object = object.__code__
     if istraceback(object):
         object = object.tb_frame
     if isframe(object):
@@ -254,7 +257,7 @@ def _fixed_getinnerframes(etb, context=1,tb_offset=0):
 
     aux = traceback.extract_tb(etb)
     assert len(records) == len(aux)
-    for i, (file, lnum, _, _) in zip(range(len(records)), aux):
+    for i, (file, lnum, _, _) in zip(list(range(len(records))), aux):
         maybeStart = lnum-1 - context//2
         start =  max(maybeStart, 0)
         end   = start + context
@@ -1031,7 +1034,7 @@ class VerboseTB(TBTools):
         try:
             self.debugger()
         except KeyboardInterrupt:
-            print "\nKeyboardInterrupt"
+            print("\nKeyboardInterrupt")
 
 #----------------------------------------------------------------------------
 class FormattedTB(VerboseTB, ListTB):
@@ -1162,7 +1165,7 @@ class AutoFormattedTB(FormattedTB):
         try:
             self.debugger()
         except KeyboardInterrupt:
-            print "\nKeyboardInterrupt"
+            print("\nKeyboardInterrupt")
 
     def structured_traceback(self, etype=None, value=None, tb=None,
                              tb_offset=None, context=5):
@@ -1221,27 +1224,27 @@ if __name__ == "__main__":
         i = f - g
         return h / i
 
-    print ''
-    print '*** Before ***'
+    print('')
+    print('*** Before ***')
     try:
-        print spam(1, (2, 3))
+        print(spam(1, (2, 3)))
     except:
         traceback.print_exc()
-    print ''
+    print('')
 
     handler = ColorTB()
-    print '*** ColorTB ***'
+    print('*** ColorTB ***')
     try:
-        print spam(1, (2, 3))
+        print(spam(1, (2, 3)))
     except:
         handler(*sys.exc_info())
-    print ''
+    print('')
 
     handler = VerboseTB()
-    print '*** VerboseTB ***'
+    print('*** VerboseTB ***')
     try:
-        print spam(1, (2, 3))
+        print(spam(1, (2, 3)))
     except:
         handler(*sys.exc_info())
-    print ''
+    print('')
 

--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -305,10 +305,10 @@ if PY3:
                           lambda a, b: update_function(a.__func__, b.__func__)),
                         ])
 else:
-    UPDATE_RULES.extend([(lambda a, b: isinstance2(a, b, type),
+    UPDATE_RULES.extend([(lambda a, b: isinstance2(a, b, types.ClassType),
                           update_class),
                          (lambda a, b: isinstance2(a, b, types.MethodType),
-                          lambda a, b: update_function(a.__func__, b.__func__)),
+                          lambda a, b: update_function(a.im_func, b.im_func)),
                         ])
 
 

--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -186,9 +186,9 @@ class ModuleReloader(object):
             return
 
         if check_all or self.check_all:
-            modules = sys.modules.keys()
+            modules = list(sys.modules.keys())
         else:
-            modules = self.modules.keys()
+            modules = list(self.modules.keys())
 
         for modname in modules:
             m = sys.modules.get(modname, None)
@@ -258,7 +258,7 @@ def update_function(old, new):
 def update_class(old, new):
     """Replace stuff in the __dict__ of a class, and upgrade
     method code objects"""
-    for key in old.__dict__.keys():
+    for key in list(old.__dict__.keys()):
         old_obj = getattr(old, key)
 
         try:
@@ -339,7 +339,7 @@ def superreload(module, reload=reload, old_objects={}):
     """
 
     # collect old objects in the module
-    for name, obj in module.__dict__.items():
+    for name, obj in list(module.__dict__.items()):
         if not hasattr(obj, '__module__') or obj.__module__ != module.__name__:
             continue
         key = (module.__name__, name)
@@ -370,7 +370,7 @@ def superreload(module, reload=reload, old_objects={}):
         raise
 
     # iterate over all objects and update functions & classes
-    for name, new_obj in module.__dict__.items():
+    for name, new_obj in list(module.__dict__.items()):
         key = (module.__name__, name)
         if key not in old_objects: continue
 
@@ -473,10 +473,8 @@ class AutoreloadMagics(Magics):
         """
         modname = parameter_s
         if not modname:
-            to_reload = self._reloader.modules.keys()
-            to_reload.sort()
-            to_skip = self._reloader.skip_modules.keys()
-            to_skip.sort()
+            to_reload = sorted(self._reloader.modules.keys())
+            to_skip = sorted(self._reloader.skip_modules.keys())
             if stream is None:
                 stream = sys.stdout
             if self._reloader.check_all:

--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -305,10 +305,10 @@ if PY3:
                           lambda a, b: update_function(a.__func__, b.__func__)),
                         ])
 else:
-    UPDATE_RULES.extend([(lambda a, b: isinstance2(a, b, types.ClassType),
+    UPDATE_RULES.extend([(lambda a, b: isinstance2(a, b, type),
                           update_class),
                          (lambda a, b: isinstance2(a, b, types.MethodType),
-                          lambda a, b: update_function(a.im_func, b.im_func)),
+                          lambda a, b: update_function(a.__func__, b.__func__)),
                         ])
 
 
@@ -348,7 +348,7 @@ def superreload(module, reload=reload, old_objects={}):
         except TypeError:
             # weakref doesn't work for all types;
             # create strong references for 'important' cases
-            if not PY3 and isinstance(obj, types.ClassType):
+            if not PY3 and isinstance(obj, type):
                 old_objects.setdefault(key, []).append(StrongRef(obj))
 
     # reload module

--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -64,7 +64,8 @@ from IPython.core.magic_arguments import (
     argument, magic_arguments, parse_argstring
 )
 from IPython.external.simplegeneric import generic
-from IPython.utils.py3compat import str_to_unicode, unicode_to_str, PY3
+from IPython.utils.py3compat import (str_to_unicode, unicode_to_str, PY3,
+                                     unicode_type)
 
 class RInterpreterError(ri.RRuntimeError):
     """An error when running R code in a %%R magic cell."""
@@ -382,7 +383,7 @@ class RMagics(Magics):
         help='Convert these objects to data.frames and return as structured arrays.'
         )
     @argument(
-        '-u', '--units', type=unicode, choices=["px", "in", "cm", "mm"],
+        '-u', '--units', type=unicode_type, choices=["px", "in", "cm", "mm"],
         help='Units of png plotting device sent as an argument to *png* in R. One of ["px", "in", "cm", "mm"].'
         )
     @argument(

--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -26,6 +26,7 @@ Usage
 {RGET_DOC}
 
 """
+from __future__ import print_function
 
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2012 The IPython Development Team
@@ -607,9 +608,9 @@ class RMagics(Magics):
                     ri.set_writeconsole(old_writeconsole)
         
         except RInterpreterError as e:
-            print(e.stdout)
+            print((e.stdout))
             if not e.stdout.endswith(e.err):
-                print(e.err)
+                print((e.err))
             rmtree(tmpd)
             return
 

--- a/IPython/extensions/storemagic.py
+++ b/IPython/extensions/storemagic.py
@@ -9,6 +9,7 @@ To automatically restore stored variables at startup, add this to your
 
   c.StoreMagic.autorestore = True
 """
+from __future__ import print_function
 #-----------------------------------------------------------------------------
 #  Copyright (c) 2012, The IPython Development Team.
 #
@@ -29,6 +30,8 @@ from IPython.core.error import UsageError
 from IPython.core.fakemodule import FakeModule
 from IPython.core.magic import Magics, magics_class, line_magic
 from IPython.testing.skipdoctest import skip_doctest
+from six.moves import map
+from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Functions and classes
@@ -50,8 +53,8 @@ def refresh_variables(ip):
         try:
             obj = db[key]
         except KeyError:
-            print "Unable to restore variable '%s', ignoring (use %%store -d to forget!)" % justkey
-            print "The error was:", sys.exc_info()[0]
+            print("Unable to restore variable '%s', ignoring (use %%store -d to forget!)" % justkey)
+            print("The error was:", sys.exc_info()[0])
         else:
             #print "restored",justkey,"=",obj #dbg
             ip.user_ns[justkey] = obj
@@ -143,7 +146,7 @@ class StoreMagics(Magics):
                     try:
                         obj = db['autorestore/' + arg]
                     except KeyError:
-                        print "no stored variable %s" % arg
+                        print("no stored variable %s" % arg)
                     else:
                         ip.user_ns[arg] = obj
             else:
@@ -158,13 +161,13 @@ class StoreMagics(Magics):
             else:
                 size = 0
 
-            print 'Stored variables and their in-db values:'
+            print('Stored variables and their in-db values:')
             fmt = '%-'+str(size)+'s -> %s'
             get = db.get
             for var in vars:
                 justkey = os.path.basename(var)
                 # print 30 first characters from every var
-                print fmt % (justkey, repr(get(var, '<unavailable>'))[:50])
+                print(fmt % (justkey, repr(get(var, '<unavailable>'))[:50]))
 
         # default action - store the variable
         else:
@@ -176,8 +179,8 @@ class StoreMagics(Magics):
                 else:
                     fil = open(fnam, 'w')
                 obj = ip.ev(args[0])
-                print "Writing '%s' (%s) to file '%s'." % (args[0],
-                  obj.__class__.__name__, fnam)
+                print("Writing '%s' (%s) to file '%s'." % (args[0],
+                  obj.__class__.__name__, fnam))
 
 
                 if not isinstance (obj, basestring):
@@ -203,23 +206,23 @@ class StoreMagics(Magics):
                     staliases = db.get('stored_aliases',{})
                     staliases[ name ] = cmd
                     db['stored_aliases'] = staliases
-                    print "Alias stored: %s (%s)" % (name, cmd)
+                    print("Alias stored: %s (%s)" % (name, cmd))
                     return
                 else:
                     raise UsageError("Unknown variable '%s'" % args[0])
 
             else:
                 if isinstance(inspect.getmodule(obj), FakeModule):
-                    print textwrap.dedent("""\
+                    print(textwrap.dedent("""\
                     Warning:%s is %s
                     Proper storage of interactively declared classes (or instances
                     of those classes) is not possible! Only instances
                     of classes in real modules on file system can be %%store'd.
-                    """ % (args[0], obj) )
+                    """ % (args[0], obj) ))
                     return
                 #pickled = pickle.dumps(obj)
                 db[ 'autorestore/' + args[0] ] = obj
-                print "Stored '%s' (%s)" % (args[0], obj.__class__.__name__)
+                print("Stored '%s' (%s)" % (args[0], obj.__class__.__name__))
 
 
 def load_ipython_extension(ip):

--- a/IPython/extensions/tests/test_autoreload.py
+++ b/IPython/extensions/tests/test_autoreload.py
@@ -18,13 +18,17 @@ import tempfile
 import shutil
 import random
 import time
-from StringIO import StringIO
 
 import nose.tools as nt
 import IPython.testing.tools as tt
 
 from IPython.extensions.autoreload import AutoreloadMagics
 from IPython.core.hooks import TryNext
+from IPython.utils.py3compat import PY3
+if PY3:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 #-----------------------------------------------------------------------------
 # Test fixture

--- a/IPython/extensions/tests/test_autoreload.py
+++ b/IPython/extensions/tests/test_autoreload.py
@@ -44,7 +44,7 @@ class FakeShell(object):
             self.auto_magics.pre_run_code_hook(self)
         except TryNext:
             pass
-        exec code in self.ns
+        exec(code, self.ns)
 
     def push(self, items):
         self.ns.update(items)

--- a/IPython/extensions/tests/test_rmagic.py
+++ b/IPython/extensions/tests/test_rmagic.py
@@ -1,8 +1,13 @@
-from StringIO import StringIO
-
 import numpy as np
+
 from IPython.testing.decorators import skip_without
 from IPython.extensions import rmagic
+from IPython.utils.py3compat import PY3
+if PY3:
+    from io import StringIO
+else:
+    from StringIO import StringIO
+
 from rpy2 import rinterface
 import nose.tools as nt
 

--- a/IPython/external/argparse/__init__.py
+++ b/IPython/external/argparse/__init__.py
@@ -8,5 +8,5 @@ try:
         from argparse import *
         from argparse import SUPPRESS
 except (ImportError, AttributeError):
-    from _argparse import *
-    from _argparse import SUPPRESS
+    from ._argparse import *
+    from ._argparse import SUPPRESS

--- a/IPython/external/decorator/__init__.py
+++ b/IPython/external/decorator/__init__.py
@@ -1,4 +1,4 @@
 try:
     from decorator import *
 except ImportError:
-    from _decorator import *
+    from ._decorator import *

--- a/IPython/external/decorator/_decorator.py
+++ b/IPython/external/decorator/_decorator.py
@@ -35,8 +35,6 @@ Patched in IPython to work in Python 3 without 2to3 conversion.
 """
 from __future__ import print_function
 
-import six
-
 __version__ = '3.4.0'
 
 __all__ = ["decorator", "FunctionMaker", "contextmanager"]
@@ -158,7 +156,7 @@ class FunctionMaker(object):
         try:
             code = compile(src, '<string>', 'single')
             # print >> sys.stderr, 'Compiling %s' % src
-            six.exec_(code, evaldict)
+            exec(code, evaldict)
         except:
             print('Error in generated code:', file=sys.stderr)
             print(src, file=sys.stderr)

--- a/IPython/external/decorators/__init__.py
+++ b/IPython/external/decorators/__init__.py
@@ -2,8 +2,8 @@ try:
     from numpy.testing.decorators import *
     from numpy.testing.noseclasses import KnownFailure
 except ImportError:
-    from _decorators import *
+    from ._decorators import *
     try:
-        from _numpy_testing_noseclasses import KnownFailure
+        from ._numpy_testing_noseclasses import KnownFailure
     except ImportError:
         pass

--- a/IPython/external/decorators/_decorators.py
+++ b/IPython/external/decorators/_decorators.py
@@ -20,9 +20,9 @@ import warnings
 #from numpy.testing.utils import \
 #        WarningManager, WarningMessage
 # Our version:
-from _numpy_testing_utils import WarningManager
+from ._numpy_testing_utils import WarningManager
 try:
-    from _numpy_testing_noseclasses import KnownFailureTest
+    from ._numpy_testing_noseclasses import KnownFailureTest
 except:
     pass
 

--- a/IPython/external/jsonpointer/__init__.py
+++ b/IPython/external/jsonpointer/__init__.py
@@ -1,4 +1,4 @@
 try:
     from jsonpointer import *
 except ImportError :
-    from _jsonpointer import *
+    from ._jsonpointer import *

--- a/IPython/external/jsonschema/__init__.py
+++ b/IPython/external/jsonschema/__init__.py
@@ -1,4 +1,4 @@
 try:
     from jsonschema import *
 except ImportError :
-    from _jsonschema import *
+    from ._jsonschema import *

--- a/IPython/external/mathjax.py
+++ b/IPython/external/mathjax.py
@@ -32,6 +32,7 @@ To find the directory where IPython would like MathJax installed:
     $ python -m IPython.external.mathjax -d
 
 """
+from __future__ import print_function
 
 
 #-----------------------------------------------------------------------------
@@ -74,7 +75,7 @@ def check_perms(dest, replace=False):
     components = dest.split(os.path.sep)
     subpaths = [ os.path.sep+os.path.sep.join(components[1:i]) for i in range(1,len(components))]
 
-    existing_path = filter(os.path.exists, subpaths)
+    existing_path = [p for p in subpaths if os.path.exists(p)]
     last_writable = existing_path[-1]
     if not os.access(last_writable, os.W_OK):
         raise IOError("Need have write access to %s" % parent)
@@ -89,11 +90,11 @@ def check_perms(dest, replace=False):
         if replace:
             if not os.access(dest, os.W_OK):
                 raise IOError("Need have write access to %s" % dest)
-            print "removing previous MathJax install"
+            print("removing previous MathJax install")
             shutil.rmtree(dest)
             return True
         else:
-            print "offline MathJax apparently already installed"
+            print("offline MathJax apparently already installed")
             return False
     else :
         return True
@@ -130,7 +131,7 @@ def extract_zip( fd, dest ) :
 
     # it will be mathjax-MathJax-<sha>, rename to just mathjax
     d = os.path.join(parent, topdir)
-    print d
+    print(d)
     os.rename(os.path.join(parent, topdir), dest)
 
 ##
@@ -165,11 +166,11 @@ def install_mathjax(tag='v2.0', dest=default_dest, replace=False, file=None, ext
     if file is None :
         # download mathjax
         mathjax_url = "https://github.com/mathjax/MathJax/tarball/%s" % tag
-        print "Downloading mathjax source from %s" % mathjax_url
+        print("Downloading mathjax source from %s" % mathjax_url)
         response = urllib2.urlopen(mathjax_url)
         file = response.fp
 
-    print "Extracting to %s" % dest
+    print("Extracting to %s" % dest)
     extractor( file, dest )
 
 ##
@@ -178,12 +179,12 @@ def test_func( remove, dest) :
     """See if mathjax appears to be installed correctly"""
     status = 0
     if not os.path.isdir( dest ) :
-        print "%s directory not found" % dest
+        print("%s directory not found" % dest)
         status = 1
     if not os.path.exists( dest + "/MathJax.js" ) :
-        print "MathJax.js not present in %s" % dest
+        print("MathJax.js not present in %s" % dest)
         status = 1
-    print "ok"
+    print("ok")
     if remove and os.path.exists(dest):
         shutil.rmtree( dest )
     return status
@@ -227,7 +228,7 @@ def main() :
 
     dest = pargs.install_dir
     if pargs.dest :
-        print dest
+        print(dest)
         return
 
     # remove/replace existing mathjax?

--- a/IPython/external/path/_path.py
+++ b/IPython/external/path/_path.py
@@ -1,55 +1,148 @@
+#
+# Copyright (c) 2010 Mikhail Gusarov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 """ path.py - An object representing a path to a file or directory.
 
-Example:
+Original author:
+ Jason Orendorff <jason.orendorff\x40gmail\x2ecom>
 
-from IPython.external.path import path
-d = path('/home/guido/bin')
-for f in d.files('*.py'):
-    f.chmod(0755)
+Current maintainer:
+ Jason R. Coombs <jaraco@jaraco.com>
 
-This module requires Python 2.5 or later.
+Contributors:
+ Mikhail Gusarov <dottedmag@dottedmag.net>
+ Marc Abramowitz <marc@marc-abramowitz.com>
+ Jason R. Coombs <jaraco@jaraco.com>
+ Jason Chu <jchu@xentac.net>
+ Vojislav Stojkovic <vstojkovic@syntertainment.com>
 
+Example::
 
-URL:     http://pypi.python.org/pypi/path.py
-Author:  Jason Orendorff <jason.orendorff\x40gmail\x2ecom> (and others - see the url!)
-Date:    9 Mar 2007
+    from path import path
+    d = path('/home/guido/bin')
+    for f in d.files('*.py'):
+        f.chmod(0755)
+
+path.py requires Python 2.5 or later.
 """
 
+from __future__ import with_statement
 
-# TODO
-#   - Tree-walking functions don't avoid symlink loops.  Matt Harrison
-#     sent me a patch for this.
-#   - Bug in write_text().  It doesn't support Universal newline mode.
-#   - Better error message in listdir() when self isn't a
-#     directory. (On Windows, the error message really sucks.)
-#   - Make sure everything has a good docstring.
-#   - Add methods for regex find and replace.
-#   - guess_content_type() method?
-#   - Perhaps support arguments to touch().
+import sys
+import warnings
+import os
+import fnmatch
+import glob
+import shutil
+import codecs
+import hashlib
+import errno
+import tempfile
+import functools
+import operator
+import re
 
-from __future__ import generators
+try:
+    import win32security
+except ImportError:
+    pass
 
-import sys, warnings, os, fnmatch, glob, shutil, codecs
-from hashlib import md5
+try:
+    import pwd
+except ImportError:
+    pass
 
-__version__ = '2.2'
-__all__ = ['path']
+################################
+# Monkey patchy python 3 support
+try:
+    basestring
+except NameError:
+    basestring = str
 
-# Platform-specific support for path.owner
-if os.name == 'nt':
-    try:
-        import win32security
-    except ImportError:
-        win32security = None
+try:
+    unicode
+except NameError:
+    unicode = str
+
+try:
+    os.getcwdu
+except AttributeError:
+    os.getcwdu = os.getcwd
+
+if sys.version < '3':
+    def u(x):
+        return codecs.unicode_escape_decode(x)[0]
 else:
-    try:
-        import pwd
-    except ImportError:
-        pwd = None
+    def u(x):
+        return x
+
+o777 = 511
+o766 = 502
+o666 = 438
+o554 = 364
+################################
+
+__version__ = '4.3'
+__all__ = ['path']
 
 
 class TreeWalkWarning(Warning):
     pass
+
+
+def simple_cache(func):
+    """
+    Save results for the 'using_module' classmethod.
+    When Python 3.2 is available, use functools.lru_cache instead.
+    """
+    saved_results = {}
+
+    def wrapper(cls, module):
+        if module in saved_results:
+            return saved_results[module]
+        saved_results[module] = func(cls, module)
+        return saved_results[module]
+    return wrapper
+
+
+class ClassProperty(property):
+    def __get__(self, cls, owner):
+        return self.fget.__get__(None, owner)()
+
+
+class multimethod(object):
+    """
+    Acts like a classmethod when invoked from the class and like an
+    instancemethod when invoked from the instance.
+    """
+    def __init__(self, func):
+        self.func = func
+
+    def __get__(self, instance, owner):
+        return (
+            functools.partial(self.func, owner) if instance is None
+            else functools.partial(self.func, owner, instance)
+        )
+
 
 class path(unicode):
     """ Represents a filesystem path.
@@ -58,26 +151,45 @@ class path(unicode):
     counterparts in os.path.
     """
 
+    module = os.path
+    "The path module to use for path operations."
+
+    def __init__(self, other=''):
+        if other is None:
+            raise TypeError("Invalid initial value for path: None")
+
+    @classmethod
+    @simple_cache
+    def using_module(cls, module):
+        subclass_name = cls.__name__ + '_' + module.__name__
+        bases = (cls,)
+        ns = {'module': module}
+        return type(subclass_name, bases, ns)
+
+    @ClassProperty
+    @classmethod
+    def _next_class(cls):
+        """
+        What class should be used to construct new instances from this class
+        """
+        return cls
+
     # --- Special Python methods.
 
     def __repr__(self):
-        return 'path(%s)' % unicode.__repr__(self)
+        return '%s(%s)' % (type(self).__name__, super(path, self).__repr__())
 
     # Adding a path and a string yields a path.
     def __add__(self, more):
         try:
-            resultStr = unicode.__add__(self, more)
-        except TypeError:  #Python bug
-            resultStr = NotImplemented
-        if resultStr is NotImplemented:
-            return resultStr
-        return self.__class__(resultStr)
+            return self._next_class(super(path, self).__add__(more))
+        except TypeError:  # Python bug
+            return NotImplemented
 
     def __radd__(self, other):
-        if isinstance(other, basestring):
-            return self.__class__(other.__add__(self))
-        else:
+        if not isinstance(other, basestring):
             return NotImplemented
+        return self._next_class(other.__add__(self))
 
     # The / operator joins paths.
     def __div__(self, rel):
@@ -86,28 +198,50 @@ class path(unicode):
         Join two path components, adding a separator character if
         needed.
         """
-        return self.__class__(os.path.join(self, rel))
+        return self._next_class(self.module.join(self, rel))
 
     # Make the / operator work even when true division is enabled.
     __truediv__ = __div__
 
+    def __enter__(self):
+        self._old_dir = self.getcwd()
+        os.chdir(self)
+        return self
+
+    def __exit__(self, *_):
+        os.chdir(self._old_dir)
+
+    @classmethod
     def getcwd(cls):
         """ Return the current working directory as a path object. """
         return cls(os.getcwdu())
-    getcwd = classmethod(getcwd)
 
-
+    #
     # --- Operations on path strings.
 
-    def isabs(s): return os.path.isabs(s)
-    def abspath(self):       return self.__class__(os.path.abspath(self))
-    def normcase(self):      return self.__class__(os.path.normcase(self))
-    def normpath(self):      return self.__class__(os.path.normpath(self))
-    def realpath(self):      return self.__class__(os.path.realpath(self))
-    def expanduser(self):    return self.__class__(os.path.expanduser(self))
-    def expandvars(self):    return self.__class__(os.path.expandvars(self))
-    def dirname(self):       return self.__class__(os.path.dirname(self))
-    def basename(s): return os.path.basename(s)
+    def abspath(self):
+        return self._next_class(self.module.abspath(self))
+
+    def normcase(self):
+        return self._next_class(self.module.normcase(self))
+
+    def normpath(self):
+        return self._next_class(self.module.normpath(self))
+
+    def realpath(self):
+        return self._next_class(self.module.realpath(self))
+
+    def expanduser(self):
+        return self._next_class(self.module.expanduser(self))
+
+    def expandvars(self):
+        return self._next_class(self.module.expandvars(self))
+
+    def dirname(self):
+        return self._next_class(self.module.dirname(self))
+
+    def basename(self):
+        return self._next_class(self.module.basename(self))
 
     def expand(self):
         """ Clean up a filename by calling expandvars(),
@@ -118,23 +252,36 @@ class path(unicode):
         """
         return self.expandvars().expanduser().normpath()
 
-    def _get_namebase(self):
-        base, ext = os.path.splitext(self.name)
+    @property
+    def namebase(self):
+        """ The same as path.name, but with one file extension stripped off.
+
+        For example, path('/home/guido/python.tar.gz').name == 'python.tar.gz',
+        but          path('/home/guido/python.tar.gz').namebase == 'python.tar'
+        """
+        base, ext = self.module.splitext(self.name)
         return base
 
-    def _get_ext(self):
-        f, ext = os.path.splitext(unicode(self))
+    @property
+    def ext(self):
+        """ The file extension, for example '.py'. """
+        f, ext = self.module.splitext(self)
         return ext
 
-    def _get_drive(self):
-        drive, r = os.path.splitdrive(self)
-        return self.__class__(drive)
+    @property
+    def drive(self):
+        """ The drive specifier, for example 'C:'.
+        This is always empty on systems that don't use drive specifiers.
+        """
+        drive, r = self.module.splitdrive(self)
+        return self._next_class(drive)
 
     parent = property(
         dirname, None, None,
         """ This path's parent directory, as a new path object.
 
-        For example, path('/usr/local/lib/libpython.so').parent == path('/usr/local/lib')
+        For example,
+        path('/usr/local/lib/libpython.so').parent == path('/usr/local/lib')
         """)
 
     name = property(
@@ -144,28 +291,10 @@ class path(unicode):
         For example, path('/usr/local/lib/libpython.so').name == 'libpython.so'
         """)
 
-    namebase = property(
-        _get_namebase, None, None,
-        """ The same as path.name, but with one file extension stripped off.
-
-        For example, path('/home/guido/python.tar.gz').name     == 'python.tar.gz',
-        but          path('/home/guido/python.tar.gz').namebase == 'python.tar'
-        """)
-
-    ext = property(
-        _get_ext, None, None,
-        """ The file extension, for example '.py'. """)
-
-    drive = property(
-        _get_drive, None, None,
-        """ The drive specifier, for example 'C:'.
-        This is always empty on systems that don't use drive specifiers.
-        """)
-
     def splitpath(self):
         """ p.splitpath() -> Return (p.parent, p.name). """
-        parent, child = os.path.split(self)
-        return self.__class__(parent), child
+        parent, child = self.module.split(self)
+        return self._next_class(parent), child
 
     def splitdrive(self):
         """ p.splitdrive() -> Return (p.drive, <the rest of p>).
@@ -174,8 +303,8 @@ class path(unicode):
         no drive specifier, p.drive is empty, so the return value
         is simply (path(''), p).  This is always the case on Unix.
         """
-        drive, rel = os.path.splitdrive(self)
-        return self.__class__(drive), rel
+        drive, rel = self.module.splitdrive(self)
+        return self._next_class(drive), rel
 
     def splitext(self):
         """ p.splitext() -> Return (p.stripext(), p.ext).
@@ -187,8 +316,8 @@ class path(unicode):
         last path segment.  This has the property that if
         (a, b) == p.splitext(), then a + b == p.
         """
-        filename, ext = os.path.splitext(self)
-        return self.__class__(filename), ext
+        filename, ext = self.module.splitext(self)
+        return self._next_class(filename), ext
 
     def stripext(self):
         """ p.stripext() -> Remove one file extension from the path.
@@ -198,36 +327,39 @@ class path(unicode):
         """
         return self.splitext()[0]
 
-    if hasattr(os.path, 'splitunc'):
-        def splitunc(self):
-            unc, rest = os.path.splitunc(self)
-            return self.__class__(unc), rest
+    def splitunc(self):
+        unc, rest = self.module.splitunc(self)
+        return self._next_class(unc), rest
 
-        def _get_uncshare(self):
-            unc, r = os.path.splitunc(self)
-            return self.__class__(unc)
-
-        uncshare = property(
-            _get_uncshare, None, None,
-            """ The UNC mount point for this path.
-            This is empty for paths on local drives. """)
-
-    def joinpath(self, *args):
-        """ Join two or more path components, adding a separator
-        character (os.sep) if needed.  Returns a new path
-        object.
+    @property
+    def uncshare(self):
         """
-        return self.__class__(os.path.join(self, *args))
+        The UNC mount point for this path.
+        This is empty for paths on local drives.
+        """
+        unc, r = self.module.splitunc(self)
+        return self._next_class(unc)
+
+    @multimethod
+    def joinpath(cls, first, *others):
+        """
+        Join first to zero or more path components, adding a separator
+        character (first.module.sep) if needed.  Returns a new instance of
+        first._next_class.
+        """
+        if not isinstance(first, cls):
+            first = cls(first)
+        return first._next_class(first.module.join(first, *others))
 
     def splitall(self):
         r""" Return a list of the path components in this path.
 
         The first item in the list will be a path.  Its value will be
         either os.curdir, os.pardir, empty, or the root directory of
-        this path (for example, '/' or 'C:\\').  The other items in
+        this path (for example, ``'/'`` or ``'C:\\'``).  The other items in
         the list will be strings.
 
-        path.path.joinpath(*result) will yield the original path.
+        ``path.path.joinpath(*result)`` will yield the original path.
         """
         parts = []
         loc = self
@@ -241,11 +373,11 @@ class path(unicode):
         parts.reverse()
         return parts
 
-    def relpath(self):
+    def relpath(self, start='.'):
         """ Return this path as a relative path,
-        based from the current working directory.
+        based from start, which defaults to the current working directory.
         """
-        cwd = self.__class__(os.getcwdu())
+        cwd = self._next_class(start)
         return cwd.relpathto(self)
 
     def relpathto(self, dest):
@@ -256,20 +388,20 @@ class path(unicode):
         dest.abspath().
         """
         origin = self.abspath()
-        dest = self.__class__(dest).abspath()
+        dest = self._next_class(dest).abspath()
 
         orig_list = origin.normcase().splitall()
         # Don't normcase dest!  We want to preserve the case.
         dest_list = dest.splitall()
 
-        if orig_list[0] != os.path.normcase(dest_list[0]):
+        if orig_list[0] != self.module.normcase(dest_list[0]):
             # Can't get here from there.
             return dest
 
         # Find the location where the two paths start to differ.
         i = 0
         for start_seg, dest_seg in zip(orig_list, dest_list):
-            if start_seg != os.path.normcase(dest_seg):
+            if start_seg != self.module.normcase(dest_seg):
                 break
             i += 1
 
@@ -283,8 +415,8 @@ class path(unicode):
             # If they happen to be identical, use os.curdir.
             relpath = os.curdir
         else:
-            relpath = os.path.join(*segments)
-        return self.__class__(relpath)
+            relpath = self.module.join(*segments)
+        return self._next_class(relpath)
 
     # --- Listing, searching, walking, and matching
 
@@ -313,7 +445,7 @@ class path(unicode):
 
         With the optional 'pattern' argument, this only lists
         directories whose names match the given pattern.  For
-        example, d.dirs('build-*').
+        example, ``d.dirs('build-*')``.
         """
         return [p for p in self.listdir(pattern) if p.isdir()]
 
@@ -325,9 +457,9 @@ class path(unicode):
 
         With the optional 'pattern' argument, this only lists files
         whose names match the given pattern.  For example,
-        d.files('*.pyc').
+        ``d.files('*.pyc')``.
         """
-        
+
         return [p for p in self.listdir(pattern) if p.isfile()]
 
     def walk(self, pattern=None, errors='strict'):
@@ -388,7 +520,7 @@ class path(unicode):
 
         With the optional 'pattern' argument, this yields only
         directories whose names match the given pattern.  For
-        example, mydir.walkdirs('*test') yields only directories
+        example, ``mydir.walkdirs('*test')`` yields only directories
         with names ending in 'test'.
 
         The errors= keyword argument controls behavior when an
@@ -424,7 +556,7 @@ class path(unicode):
 
         The optional argument, pattern, limits the results to files
         with names that match the pattern.  For example,
-        mydir.walkfiles('*.tmp') yields only files with the .tmp
+        ``mydir.walkfiles('*.tmp')`` yields only files with the .tmp
         extension.
         """
         if errors not in ('strict', 'warn', 'ignore'):
@@ -471,7 +603,7 @@ class path(unicode):
         """ Return True if self.name matches the given pattern.
 
         pattern - A filename pattern with wildcards,
-            for example '*.py'.
+            for example ``'*.py'``.
         """
         return fnmatch.fnmatch(self.name, pattern)
 
@@ -483,23 +615,40 @@ class path(unicode):
         For example, path('/users').glob('*/bin/*') returns a list
         of all the files users have in their bin directories.
         """
-        cls = self.__class__
-        return [cls(s) for s in glob.glob(unicode(self / pattern))]
+        cls = self._next_class
+        return [cls(s) for s in glob.glob(self / pattern)]
 
-
+    #
     # --- Reading or writing an entire file at once.
 
-    def open(self, mode='r'):
+    def open(self, *args, **kwargs):
         """ Open this file.  Return a file object. """
-        return open(self, mode)
+        return open(self, *args, **kwargs)
 
     def bytes(self):
         """ Open this file, read all bytes, return them as a string. """
-        f = self.open('rb')
-        try:
+        with self.open('rb') as f:
             return f.read()
-        finally:
-            f.close()
+
+    def chunks(self, size, *args, **kwargs):
+        """ Returns a generator yielding chunks of the file, so it can
+            be read piece by piece with a simple for loop.
+
+           Any argument you pass after `size` will be passed to `open()`.
+
+           :example:
+
+               >>> for chunk in path("file.txt").chunk(8192):
+               ...    print(chunk)
+
+            This will read the file by chunks of 8192 bytes.
+        """
+        with open(self, *args, **kwargs) as f:
+            while True:
+                d = f.read(size)
+                if not d:
+                    break
+                yield d
 
     def write_bytes(self, bytes, append=False):
         """ Open this file and write the given bytes to it.
@@ -511,17 +660,14 @@ class path(unicode):
             mode = 'ab'
         else:
             mode = 'wb'
-        f = self.open(mode)
-        try:
+        with self.open(mode) as f:
             f.write(bytes)
-        finally:
-            f.close()
 
     def text(self, encoding=None, errors='strict'):
         r""" Open this file, read it in, return the content as a string.
 
-        This uses 'U' mode in Python 2.3 and later, so '\r\n' and '\r'
-        are automatically translated to '\n'.
+        This method uses 'U' mode, so '\r\n' and '\r' are automatically
+        translated to '\n'.
 
         Optional arguments:
 
@@ -534,27 +680,22 @@ class path(unicode):
         """
         if encoding is None:
             # 8-bit
-            f = self.open('U')
-            try:
+            with self.open('U') as f:
                 return f.read()
-            finally:
-                f.close()
         else:
             # Unicode
-            f = codecs.open(self, 'r', encoding, errors)
-            # (Note - Can't use 'U' mode here, since codecs.open
-            # doesn't support 'U' mode, even in Python 2.3.)
-            try:
+            with codecs.open(self, 'r', encoding, errors) as f:
+                # (Note - Can't use 'U' mode here, since codecs.open
+                # doesn't support 'U' mode.)
                 t = f.read()
-            finally:
-                f.close()
-            return (t.replace(u'\r\n', u'\n')
-                     .replace(u'\r\x85', u'\n')
-                     .replace(u'\r', u'\n')
-                     .replace(u'\x85', u'\n')
-                     .replace(u'\u2028', u'\n'))
+            return (t.replace(u('\r\n'), u('\n'))
+                     .replace(u('\r\x85'), u('\n'))
+                     .replace(u('\r'), u('\n'))
+                     .replace(u('\x85'), u('\n'))
+                     .replace(u('\u2028'), u('\n')))
 
-    def write_text(self, text, encoding=None, errors='strict', linesep=os.linesep, append=False):
+    def write_text(self, text, encoding=None, errors='strict',
+                   linesep=os.linesep, append=False):
         r""" Write the given text to this file.
 
         The default behavior is to overwrite any existing file;
@@ -622,12 +763,12 @@ class path(unicode):
             if linesep is not None:
                 # Convert all standard end-of-line sequences to
                 # ordinary newline characters.
-                text = (text.replace(u'\r\n', u'\n')
-                            .replace(u'\r\x85', u'\n')
-                            .replace(u'\r', u'\n')
-                            .replace(u'\x85', u'\n')
-                            .replace(u'\u2028', u'\n'))
-                text = text.replace(u'\n', linesep)
+                text = (text.replace(u('\r\n'), u('\n'))
+                            .replace(u('\r\x85'), u('\n'))
+                            .replace(u('\r'), u('\n'))
+                            .replace(u('\x85'), u('\n'))
+                            .replace(u('\u2028'), u('\n')))
+                text = text.replace(u('\n'), linesep)
             if encoding is None:
                 encoding = sys.getdefaultencoding()
             bytes = text.encode(encoding, errors)
@@ -658,14 +799,11 @@ class path(unicode):
                 translated to '\n'.  If false, newline characters are
                 stripped off.  Default is True.
 
-        This uses 'U' mode in Python 2.3 and later.
+        This uses 'U' mode.
         """
         if encoding is None and retain:
-            f = self.open('U')
-            try:
+            with self.open('U') as f:
                 return f.readlines()
-            finally:
-                f.close()
         else:
             return self.text(encoding, errors).splitlines(retain)
 
@@ -707,18 +845,17 @@ class path(unicode):
             mode = 'ab'
         else:
             mode = 'wb'
-        f = self.open(mode)
-        try:
+        with self.open(mode) as f:
             for line in lines:
                 isUnicode = isinstance(line, unicode)
                 if linesep is not None:
                     # Strip off any existing line-end and add the
                     # specified linesep string.
                     if isUnicode:
-                        if line[-2:] in (u'\r\n', u'\x0d\x85'):
+                        if line[-2:] in (u('\r\n'), u('\x0d\x85')):
                             line = line[:-2]
-                        elif line[-1:] in (u'\r', u'\n',
-                                           u'\x85', u'\u2028'):
+                        elif line[-1:] in (u('\r'), u('\n'),
+                                           u('\x85'), u('\u2028')):
                             line = line[:-1]
                     else:
                         if line[-2:] == '\r\n':
@@ -731,57 +868,91 @@ class path(unicode):
                         encoding = sys.getdefaultencoding()
                     line = line.encode(encoding, errors)
                 f.write(line)
-        finally:
-            f.close()
 
     def read_md5(self):
         """ Calculate the md5 hash for this file.
 
         This reads through the entire file.
         """
-        f = self.open('rb')
-        try:
-            m = md5()
-            while True:
-                d = f.read(8192)
-                if not d:
-                    break
-                m.update(d)
-        finally:
-            f.close()
-        return m.digest()
+        return self.read_hash('md5')
+
+    def _hash(self, hash_name):
+        """ Returns a hash object for the file at the current path.
+
+            `hash_name` should be a hash algo name such as 'md5' or 'sha1'
+            that's available in the `hashlib` module.
+        """
+        m = hashlib.new(hash_name)
+        for chunk in self.chunks(8192):
+            m.update(chunk)
+        return m
+
+    def read_hash(self, hash_name):
+        """ Calculate given hash for this file.
+
+        List of supported hashes can be obtained from hashlib package. This
+        reads the entire file.
+        """
+        return self._hash(hash_name).digest()
+
+    def read_hexhash(self, hash_name):
+        """ Calculate given hash for this file, returning hexdigest.
+
+        List of supported hashes can be obtained from hashlib package. This
+        reads the entire file.
+        """
+        return self._hash(hash_name).hexdigest()
 
     # --- Methods for querying the filesystem.
-    # N.B. We can't assign the functions directly, because they may on some
-    # platforms be implemented in C, and compiled functions don't get bound.
-    # See gh-737 for discussion of this.
+    # N.B. On some platforms, the os.path functions may be implemented in C
+    # (e.g. isdir on Windows, Python 3.2.2), and compiled functions don't get
+    # bound. Playing it safe and wrapping them all in method calls.
 
-    def exists(s): return os.path.exists(s)
-    def isdir(s): return os.path.isdir(s)
-    def isfile(s): return os.path.isfile(s)
-    def islink(s): return os.path.islink(s)
-    def ismount(s): return os.path.ismount(s)
+    def isabs(self):
+        return self.module.isabs(self)
 
-    if hasattr(os.path, 'samefile'):
-        def samefile(s, o): return os.path.samefile(s, o)
+    def exists(self):
+        return self.module.exists(self)
 
-    def getatime(s): return os.path.getatime(s)
+    def isdir(self):
+        return self.module.isdir(self)
+
+    def isfile(self):
+        return self.module.isfile(self)
+
+    def islink(self):
+        return self.module.islink(self)
+
+    def ismount(self):
+        return self.module.ismount(self)
+
+    def samefile(self, other):
+        return self.module.samefile(self, other)
+
+    def getatime(self):
+        return self.module.getatime(self)
+
     atime = property(
         getatime, None, None,
         """ Last access time of the file. """)
 
-    def getmtime(s): return os.path.getmtime(s)
+    def getmtime(self):
+        return self.module.getmtime(self)
+
     mtime = property(
         getmtime, None, None,
         """ Last-modified time of the file. """)
 
-    if hasattr(os.path, 'getctime'):
-        def getctime(s): return os.path.getctime(s)
-        ctime = property(
-            getctime, None, None,
-            """ Creation time of the file. """)
+    def getctime(self):
+        return self.module.getctime(self)
 
-    def getsize(s): return os.path.getsize(s)
+    ctime = property(
+        getctime, None, None,
+        """ Creation time of the file. """)
+
+    def getsize(self):
+        return self.module.getsize(self)
+
     size = property(
         getsize, None, None,
         """ Size of the file, in bytes. """)
@@ -802,27 +973,36 @@ class path(unicode):
         """ Like path.stat(), but do not follow symbolic links. """
         return os.lstat(self)
 
-    def get_owner(self):
-        r""" Return the name of the owner of this file or directory.
+    def __get_owner_windows(self):
+        r"""
+        Return the name of the owner of this file or directory. Follow
+        symbolic links.
 
-        This follows symbolic links.
-
-        On Windows, this returns a name of the form ur'DOMAIN\User Name'.
-        On Windows, a group can own a file or directory.
+        Return a name of the form ur'DOMAIN\User Name'; may be a group.
         """
-        if os.name == 'nt':
-            if win32security is None:
-                raise Exception("path.owner requires win32all to be installed")
-            desc = win32security.GetFileSecurity(
-                self, win32security.OWNER_SECURITY_INFORMATION)
-            sid = desc.GetSecurityDescriptorOwner()
-            account, domain, typecode = win32security.LookupAccountSid(None, sid)
-            return domain + u'\\' + account
-        else:
-            if pwd is None:
-                raise NotImplementedError("path.owner is not implemented on this platform.")
-            st = self.stat()
-            return pwd.getpwuid(st.st_uid).pw_name
+        desc = win32security.GetFileSecurity(
+            self, win32security.OWNER_SECURITY_INFORMATION)
+        sid = desc.GetSecurityDescriptorOwner()
+        account, domain, typecode = win32security.LookupAccountSid(None, sid)
+        return domain + u('\\') + account
+
+    def __get_owner_unix(self):
+        """
+        Return the name of the owner of this file or directory. Follow
+        symbolic links.
+        """
+        st = self.stat()
+        return pwd.getpwuid(st.st_uid).pw_name
+
+    def __get_owner_not_implemented(self):
+        raise NotImplementedError("Ownership not available on this platform.")
+
+    if 'win32security' in globals():
+        get_owner = __get_owner_windows
+    elif 'pwd' in globals():
+        get_owner = __get_owner_unix
+    else:
+        get_owner = __get_owner_not_implemented
 
     owner = property(
         get_owner, None, None,
@@ -837,41 +1017,85 @@ class path(unicode):
         def pathconf(self, name):
             return os.pathconf(self, name)
 
-
+    #
     # --- Modifying operations on files and directories
 
     def utime(self, times):
         """ Set the access and modified times of this file. """
         os.utime(self, times)
+        return self
 
     def chmod(self, mode):
         os.chmod(self, mode)
+        return self
 
     if hasattr(os, 'chown'):
-        def chown(self, uid, gid):
+        def chown(self, uid=-1, gid=-1):
             os.chown(self, uid, gid)
+            return self
 
     def rename(self, new):
         os.rename(self, new)
+        return self._next_class(new)
 
     def renames(self, new):
         os.renames(self, new)
+        return self._next_class(new)
 
-
+    #
     # --- Create/delete operations on directories
 
-    def mkdir(self, mode=0o777):
+    def mkdir(self, mode=o777):
         os.mkdir(self, mode)
+        return self
 
-    def makedirs(self, mode=0o777):
+    def mkdir_p(self, mode=o777):
+        try:
+            self.mkdir(mode)
+        except OSError:
+            _, e, _ = sys.exc_info()
+            if e.errno != errno.EEXIST:
+                raise
+        return self
+
+    def makedirs(self, mode=o777):
         os.makedirs(self, mode)
+        return self
+
+    def makedirs_p(self, mode=o777):
+        try:
+            self.makedirs(mode)
+        except OSError:
+            _, e, _ = sys.exc_info()
+            if e.errno != errno.EEXIST:
+                raise
+        return self
 
     def rmdir(self):
         os.rmdir(self)
+        return self
+
+    def rmdir_p(self):
+        try:
+            self.rmdir()
+        except OSError:
+            _, e, _ = sys.exc_info()
+            if e.errno != errno.ENOTEMPTY and e.errno != errno.EEXIST:
+                raise
+        return self
 
     def removedirs(self):
         os.removedirs(self)
+        return self
 
+    def removedirs_p(self):
+        try:
+            self.removedirs()
+        except OSError:
+            _, e, _ = sys.exc_info()
+            if e.errno != errno.ENOTEMPTY and e.errno != errno.EEXIST:
+                raise
+        return self
 
     # --- Modifying operations on files
 
@@ -879,16 +1103,31 @@ class path(unicode):
         """ Set the access/modified times of this file to the current time.
         Create the file if it does not exist.
         """
-        fd = os.open(self, os.O_WRONLY | os.O_CREAT, 0o666)
+        fd = os.open(self, os.O_WRONLY | os.O_CREAT, o666)
         os.close(fd)
         os.utime(self, None)
+        return self
 
     def remove(self):
         os.remove(self)
+        return self
+
+    def remove_p(self):
+        try:
+            self.unlink()
+        except OSError:
+            _, e, _ = sys.exc_info()
+            if e.errno != errno.ENOENT:
+                raise
+        return self
 
     def unlink(self):
         os.unlink(self)
+        return self
 
+    def unlink_p(self):
+        self.remove_p()
+        return self
 
     # --- Links
 
@@ -896,11 +1135,13 @@ class path(unicode):
         def link(self, newpath):
             """ Create a hard link at 'newpath', pointing to this file. """
             os.link(self, newpath)
+            return self._next_class(newpath)
 
     if hasattr(os, 'symlink'):
         def symlink(self, newlink):
             """ Create a symbolic link at 'newlink', pointing here. """
             os.symlink(self, newlink)
+            return self._next_class(newlink)
 
     if hasattr(os, 'readlink'):
         def readlink(self):
@@ -908,7 +1149,7 @@ class path(unicode):
 
             The result may be an absolute or a relative path.
             """
-            return self.__class__(os.readlink(self))
+            return self._next_class(os.readlink(self))
 
         def readlinkabs(self):
             """ Return the path to which this symbolic link points.
@@ -921,7 +1162,7 @@ class path(unicode):
             else:
                 return (self.parent / p).abspath()
 
-
+    #
     # --- High-level functions from shutil
 
     copyfile = shutil.copyfile
@@ -934,7 +1175,21 @@ class path(unicode):
         move = shutil.move
     rmtree = shutil.rmtree
 
+    def rmtree_p(self):
+        try:
+            self.rmtree()
+        except OSError:
+            _, e, _ = sys.exc_info()
+            if e.errno != errno.ENOENT:
+                raise
+        return self
 
+    def chdir(self):
+        os.chdir(self)
+
+    cd = chdir
+
+    #
     # --- Special stuff from os
 
     if hasattr(os, 'chroot'):
@@ -944,4 +1199,69 @@ class path(unicode):
     if hasattr(os, 'startfile'):
         def startfile(self):
             os.startfile(self)
+            return self
 
+
+class tempdir(path):
+    """
+    A temporary directory via tempfile.mkdtemp, and constructed with the
+    same parameters that you can use as a context manager.
+
+    Example:
+
+        with tempdir() as d:
+            # do stuff with the path object "d"
+
+        # here the directory is deleted automatically
+    """
+
+    @ClassProperty
+    @classmethod
+    def _next_class(cls):
+        return path
+
+    def __new__(cls, *args, **kwargs):
+        dirname = tempfile.mkdtemp(*args, **kwargs)
+        return super(tempdir, cls).__new__(cls, dirname)
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if not exc_value:
+            self.rmtree()
+
+
+def _permission_mask(mode):
+    """
+    Convert a Unix chmod symbolic mode like 'ugo+rwx' to a function
+    suitable for applying to a mask to affect that change.
+
+    >>> mask = _permission_mask('ugo+rwx')
+    >>> oct(mask(o554))
+    'o777'
+
+    >>> oct(_permission_mask('gw-x')(o777))
+    'o766'
+    """
+    parsed = re.match('(?P<who>[ugo]+)(?P<op>[-+])(?P<what>[rwx]+)$', mode)
+    if not parsed:
+        raise ValueError("Unrecognized symbolic mode", mode)
+    spec_map = dict(r=4, w=2, x=1)
+    spec = reduce(operator.or_, [spec_map[perm]
+                  for perm in parsed.group('what')])
+    # now apply spec to each in who
+    shift_map = dict(u=6, g=3, o=0)
+    mask = reduce(operator.or_, [spec << shift_map[subj]
+                  for subj in parsed.group('who')])
+
+    op = parsed.group('op')
+    # if op is -, invert the mask
+    if op == '-':
+        mask ^= o777
+
+    op_map = {'+': operator.or_, '-': operator.and_}
+    return functools.partial(op_map[op], mask)

--- a/IPython/external/pexpect/__init__.py
+++ b/IPython/external/pexpect/__init__.py
@@ -2,4 +2,4 @@ try:
     import pexpect
     from pexpect import *
 except ImportError:
-    from _pexpect import *
+    from ._pexpect import *

--- a/IPython/external/pexpect/_pexpect.py
+++ b/IPython/external/pexpect/_pexpect.py
@@ -144,6 +144,8 @@ class TIMEOUT(ExceptionPexpect):
 ##    """Raised when a scan buffer fills before matching an expected pattern."""
 
 PY3 = (sys.version_info[0] >= 3)
+if PY3:
+    unicode = str
 
 def _cast_bytes(s, enc):
     if isinstance(s, unicode):

--- a/IPython/external/pexpect/_pexpect.py
+++ b/IPython/external/pexpect/_pexpect.py
@@ -1465,7 +1465,7 @@ class spawnb(object):
         """This returns the terminal window size of the child tty. The return
         value is a tuple of (rows, cols). """
 
-        TIOCGWINSZ = getattr(termios, 'TIOCGWINSZ', 1074295912L)
+        TIOCGWINSZ = getattr(termios, 'TIOCGWINSZ', 1074295912)
         s = struct.pack('HHHH', 0, 0, 0, 0)
         x = fcntl.ioctl(self.fileno(), TIOCGWINSZ, s)
         return struct.unpack('HHHH', x)[0:2]
@@ -1487,7 +1487,7 @@ class spawnb(object):
         # Newer versions of Linux have totally different values for TIOCSWINSZ.
         # Note that this fix is a hack.
         TIOCSWINSZ = getattr(termios, 'TIOCSWINSZ', -2146929561)
-        if TIOCSWINSZ == 2148037735L: # L is not required in Python >= 2.2.
+        if TIOCSWINSZ == 2148037735: # L is not required in Python >= 2.2.
             TIOCSWINSZ = -2146929561 # Same bits, but with sign.
         # Note, assume ws_xpixel and ws_ypixel are zero.
         s = struct.pack('HHHH', r, c, 0, 0)

--- a/IPython/external/simplegeneric/__init__.py
+++ b/IPython/external/simplegeneric/__init__.py
@@ -1,4 +1,4 @@
 try:
     from simplegeneric import *
 except ImportError:
-    from _simplegeneric import *
+    from ._simplegeneric import *

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -37,6 +37,7 @@ except ImportError:
 from IPython.config import Application
 from IPython.external.decorator import decorator
 from IPython.utils.path import filefind
+from IPython.utils.py3compat import string_types
 
 #-----------------------------------------------------------------------------
 # Monkeypatch for Tornado <= 2.1.1 - Remove when no longer necessary!
@@ -263,7 +264,7 @@ class FileFindHandler(web.StaticFileHandler):
     _lock = threading.Lock()  # protects _static_hashes
     
     def initialize(self, path, default_filename=None):
-        if isinstance(path, basestring):
+        if isinstance(path, string_types):
             path = [path]
         self.roots = tuple(
             os.path.abspath(os.path.expanduser(p)) + os.path.sep for p in path
@@ -366,7 +367,7 @@ class FileFindHandler(web.StaticFileHandler):
         """
         # begin subclass override:
         static_paths = settings['static_path']
-        if isinstance(static_paths, basestring):
+        if isinstance(static_paths, string_types):
             static_paths = [static_paths]
         roots = tuple(
             os.path.abspath(os.path.expanduser(p)) + os.path.sep for p in static_paths

--- a/IPython/html/base/zmqhandlers.py
+++ b/IPython/html/base/zmqhandlers.py
@@ -16,7 +16,10 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
-import Cookie
+try:
+    from http import cookies  # Python 3
+except ImportError:
+    import Cookie as cookies  # Python 2
 import logging
 from tornado import web
 from tornado import websocket
@@ -102,7 +105,7 @@ class AuthenticatedZMQStreamHandler(ZMQStreamHandler, IPythonHandler):
             logging.error("First ws message didn't have the form 'identity:[cookie]' - %r", msg)
         
         try:
-            self.request._cookies = Cookie.SimpleCookie(msg)
+            self.request._cookies = cookies.SimpleCookie(msg)
         except:
             self.log.warn("couldn't parse cookie string: %s",msg, exc_info=True)
 

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -5,6 +5,7 @@ Authors:
 
 * Brian Granger
 """
+from __future__ import print_function
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2013  The IPython Development Team
 #
@@ -616,7 +617,7 @@ class NotebookApp(BaseIPythonApplication):
         time.sleep(0.1)
         info = self.log.info
         info('interrupted')
-        print self.notebook_info()
+        print(self.notebook_info())
         sys.stdout.write("Shutdown this notebook server (y/[n])? ")
         sys.stdout.flush()
         r,w,x = select.select([sys.stdin], [], [], 5)
@@ -627,8 +628,8 @@ class NotebookApp(BaseIPythonApplication):
                 ioloop.IOLoop.instance().stop()
                 return
         else:
-            print "No answer for 5s:",
-        print "resuming operation..."
+            print("No answer for 5s:", end=' ')
+        print("resuming operation...")
         # no answer, or answer is no:
         # set it back to original SIGINT handler
         # use IOLoop.add_callback because signal.signal must be called
@@ -640,7 +641,7 @@ class NotebookApp(BaseIPythonApplication):
         ioloop.IOLoop.instance().stop()
 
     def _signal_info(self, sig, frame):
-        print self.notebook_info()
+        print(self.notebook_info())
     
     def init_components(self):
         """Check the components submodule, and warn if it's unclean"""

--- a/IPython/html/services/kernels/kernelmanager.py
+++ b/IPython/html/services/kernels/kernelmanager.py
@@ -22,6 +22,7 @@ from IPython.kernel.multikernelmanager import MultiKernelManager
 from IPython.utils.traitlets import (
     Dict, List, Unicode,
 )
+import six
 
 #-----------------------------------------------------------------------------
 # Classes
@@ -53,7 +54,7 @@ class MappingKernelManager(MultiKernelManager):
 
     def notebook_for_kernel(self, kernel_id):
         """Return the notebook_id for a kernel_id or None."""
-        for notebook_id, kid in self._notebook_mapping.iteritems():
+        for notebook_id, kid in six.iteritems(self._notebook_mapping):
             if kernel_id == kid:
                 return notebook_id
         return None

--- a/IPython/html/services/notebooks/nbmanager.py
+++ b/IPython/html/services/notebooks/nbmanager.py
@@ -24,6 +24,7 @@ from tornado import web
 from IPython.config.configurable import LoggingConfigurable
 from IPython.nbformat import current
 from IPython.utils.traitlets import List, Dict, Unicode, TraitError
+from IPython.utils.py3compat import unicode_type
 
 #-----------------------------------------------------------------------------
 # Classes
@@ -92,10 +93,10 @@ class NotebookManager(LoggingConfigurable):
         # disabled and instead we use a random uuid4() call.  But we leave the
         # logic here so that we can later reactivate it, whhen the necessary
         # url redirection code is written.
-        #notebook_id = unicode(uuid.uuid5(uuid.NAMESPACE_URL,
+        #notebook_id = unicode_type(uuid.uuid5(uuid.NAMESPACE_URL,
         #                 'file://'+self.get_path_by_name(name).encode('utf-8')))
         
-        notebook_id = unicode(uuid.uuid4())
+        notebook_id = unicode_type(uuid.uuid4())
         self.mapping[notebook_id] = name
         return notebook_id
 
@@ -112,7 +113,7 @@ class NotebookManager(LoggingConfigurable):
 
     def get_notebook(self, notebook_id, format=u'json'):
         """Get the representation of a notebook in format by notebook_id."""
-        format = unicode(format)
+        format = unicode_type(format)
         if format not in self.allowed_formats:
             raise web.HTTPError(415, u'Invalid notebook format: %s' % format)
         last_modified, nb = self.read_notebook_object(notebook_id)

--- a/IPython/kernel/blocking/channels.py
+++ b/IPython/kernel/blocking/channels.py
@@ -13,7 +13,10 @@ Useful for test suites and blocking terminal interfaces.
 # Imports
 #-----------------------------------------------------------------------------
 
-import Queue
+try:
+    import queue  # Python 3
+except ImportError:
+    import Queue as queue  # Python 2
 
 from IPython.kernel.channels import IOPubChannel, HBChannel, \
     ShellChannel, StdInChannel
@@ -27,7 +30,7 @@ class BlockingChannelMixin(object):
 
     def __init__(self, *args, **kwds):
         super(BlockingChannelMixin, self).__init__(*args, **kwds)
-        self._in_queue = Queue.Queue()
+        self._in_queue = queue.Queue()
 
     def call_handlers(self, msg):
         self._in_queue.put(msg)
@@ -46,7 +49,7 @@ class BlockingChannelMixin(object):
         while True:
             try:
                 msgs.append(self.get_msg(block=False))
-            except Queue.Empty:
+            except queue.Empty:
                 break
         return msgs
 

--- a/IPython/kernel/channels.py
+++ b/IPython/kernel/channels.py
@@ -31,6 +31,7 @@ from .channelsabc import (
     ShellChannelABC, IOPubChannelABC,
     HBChannelABC, StdInChannelABC,
 )
+import six
 
 #-----------------------------------------------------------------------------
 # Constants and exceptions
@@ -61,7 +62,7 @@ def validate_string_dict(dct):
     """Validate that the input is a dict with string keys and values.
 
     Raises ValueError if not."""
-    for k,v in dct.iteritems():
+    for k,v in six.iteritems(dct):
         if not isinstance(k, basestring):
             raise ValueError('key %r in dict must be a string' % k)
         if not isinstance(v, basestring):
@@ -444,7 +445,7 @@ class IOPubChannel(ZMQSocketChannel):
         # We do the IOLoop callback process twice to ensure that the IOLoop
         # gets to perform at least one full poll.
         stop_time = time.time() + timeout
-        for i in xrange(2):
+        for i in range(2):
             self._flushed = False
             self.ioloop.add_callback(self._flush)
             while not self._flushed and time.time() < stop_time:

--- a/IPython/kernel/channels.py
+++ b/IPython/kernel/channels.py
@@ -31,6 +31,7 @@ from .channelsabc import (
     ShellChannelABC, IOPubChannelABC,
     HBChannelABC, StdInChannelABC,
 )
+from IPython.utils.py3compat import string_types
 import six
 
 #-----------------------------------------------------------------------------
@@ -54,7 +55,7 @@ def validate_string_list(lst):
     if not isinstance(lst, list):
         raise ValueError('input %r must be a list' % lst)
     for x in lst:
-        if not isinstance(x, basestring):
+        if not isinstance(x, string_types):
             raise ValueError('element %r in list must be a string' % x)
 
 
@@ -63,9 +64,9 @@ def validate_string_dict(dct):
 
     Raises ValueError if not."""
     for k,v in six.iteritems(dct):
-        if not isinstance(k, basestring):
+        if not isinstance(k, string_types):
             raise ValueError('key %r in dict must be a string' % k)
-        if not isinstance(v, basestring):
+        if not isinstance(v, string_types):
             raise ValueError('value %r in dict must be a string' % v)
 
 
@@ -265,7 +266,7 @@ class ShellChannel(ZMQSocketChannel):
 
 
         # Don't waste network traffic if inputs are invalid
-        if not isinstance(code, basestring):
+        if not isinstance(code, string_types):
             raise ValueError('code %r must be a string' % code)
         validate_string_list(user_variables)
         validate_string_dict(user_expressions)

--- a/IPython/kernel/channelsabc.py
+++ b/IPython/kernel/channelsabc.py
@@ -13,16 +13,15 @@
 
 # Standard library imports
 import abc
+import six
 
 #-----------------------------------------------------------------------------
 # Channels
 #-----------------------------------------------------------------------------
 
 
-class ChannelABC(object):
+class ChannelABC(six.with_metaclass(abc.ABCMeta, object)):
     """A base class for all channel ABCs."""
-
-    __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
     def start(self):

--- a/IPython/kernel/clientabc.py
+++ b/IPython/kernel/clientabc.py
@@ -13,20 +13,19 @@
 
 # Standard library imports
 import abc
+import six
 
 #-----------------------------------------------------------------------------
 # Main kernel client class
 #-----------------------------------------------------------------------------
 
-class KernelClientABC(object):
+class KernelClientABC(six.with_metaclass(abc.ABCMeta, object)):
     """KernelManager ABC.
 
     The docstrings for this class can be found in the base implementation:
 
     `IPython.kernel.client.KernelClient`
     """
-
-    __metaclass__ = abc.ABCMeta
 
     @abc.abstractproperty
     def kernel(self):

--- a/IPython/kernel/inprocess/socket.py
+++ b/IPython/kernel/inprocess/socket.py
@@ -13,7 +13,10 @@
 
 # Standard library imports.
 import abc
-import Queue
+try:
+    import queue  # Python 3
+except:
+    import Queue as queue  # Python 2
 
 # System library imports.
 import zmq
@@ -22,7 +25,6 @@ import zmq
 from IPython.utils.traitlets import HasTraits, Instance, Int
 import six
 from six.moves import map
-from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Generic socket interface
@@ -46,7 +48,7 @@ SocketABC.register(zmq.Socket)
 class DummySocket(HasTraits):
     """ A dummy socket implementing (part of) the zmq.Socket interface. """
     
-    queue = Instance(Queue.Queue, ())
+    queue = Instance(queue.Queue, ())
     message_sent = Int(0) # Should be an Event
 
     #-------------------------------------------------------------------------

--- a/IPython/kernel/inprocess/socket.py
+++ b/IPython/kernel/inprocess/socket.py
@@ -59,7 +59,7 @@ class DummySocket(HasTraits):
         return self.queue.get_nowait()
 
     def send_multipart(self, msg_parts, flags=0, copy=True, track=False):
-        msg_parts = map(zmq.Message, msg_parts)
+        msg_parts = list(map(zmq.Message, msg_parts))
         self.queue.put_nowait(msg_parts)
         self.message_sent += 1
 

--- a/IPython/kernel/inprocess/socket.py
+++ b/IPython/kernel/inprocess/socket.py
@@ -20,14 +20,15 @@ import zmq
 
 # Local imports.
 from IPython.utils.traitlets import HasTraits, Instance, Int
+import six
+from six.moves import map
+from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Generic socket interface
 #-----------------------------------------------------------------------------
 
-class SocketABC(object):
-    __metaclass__ = abc.ABCMeta
-
+class SocketABC(six.with_metaclass(abc.ABCMeta, object)):
     @abc.abstractmethod
     def recv_multipart(self, flags=0, copy=True, track=False):
         raise NotImplementedError

--- a/IPython/kernel/inprocess/tests/test_kernel.py
+++ b/IPython/kernel/inprocess/tests/test_kernel.py
@@ -11,7 +11,6 @@
 from __future__ import print_function
 
 # Standard library imports
-from StringIO import StringIO
 import sys
 import unittest
 
@@ -22,6 +21,10 @@ from IPython.kernel.inprocess.ipkernel import InProcessKernel
 from IPython.testing.decorators import skipif_not_matplotlib
 from IPython.utils.io import capture_output
 from IPython.utils import py3compat
+if py3compat.PY3:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 #-----------------------------------------------------------------------------
 # Test case

--- a/IPython/kernel/managerabc.py
+++ b/IPython/kernel/managerabc.py
@@ -13,16 +13,15 @@
 
 # Standard library imports.
 import abc
+import six
 
 #-----------------------------------------------------------------------------
 # Channels
 #-----------------------------------------------------------------------------
 
 
-class ChannelABC(object):
+class ChannelABC(six.with_metaclass(abc.ABCMeta, object)):
     """A base class for all channel ABCs."""
-
-    __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
     def start(self):
@@ -130,15 +129,13 @@ class HBChannelABC(ChannelABC):
 # Main kernel manager class
 #-----------------------------------------------------------------------------
 
-class KernelManagerABC(object):
+class KernelManagerABC(six.with_metaclass(abc.ABCMeta, object)):
     """KernelManager ABC.
 
     The docstrings for this class can be found in the base implementation:
 
     `IPython.kernel.kernelmanager.KernelManager`
     """
-
-    __metaclass__ = abc.ABCMeta
 
     @abc.abstractproperty
     def kernel(self):

--- a/IPython/kernel/multikernelmanager.py
+++ b/IPython/kernel/multikernelmanager.py
@@ -25,6 +25,7 @@ import zmq
 
 from IPython.config.configurable import LoggingConfigurable
 from IPython.utils.importstring import import_item
+from IPython.utils.py3compat import unicode_type
 from IPython.utils.traitlets import (
     Instance, Dict, Unicode, Any, DottedObjectName
 )
@@ -102,7 +103,7 @@ class MultiKernelManager(LoggingConfigurable):
             km.start_kernel(stdout=PIPE, stderr=PIPE)
 
         """
-        kernel_id = kwargs.pop('kernel_id', unicode(uuid.uuid4()))
+        kernel_id = kwargs.pop('kernel_id', unicode_type(uuid.uuid4()))
         if kernel_id in self:
             raise DuplicateKernelError('Kernel already exists: %s' % kernel_id)
         # kernel_manager_factory is the constructor for the KernelManager

--- a/IPython/kernel/tests/test_message_spec.py
+++ b/IPython/kernel/tests/test_message_spec.py
@@ -9,7 +9,10 @@
 
 import re
 from subprocess import PIPE
-from Queue import Empty
+try:
+    from queue import Empty  # Python 3
+except:
+    from Queue import Empty  # Python 2
 
 import nose.tools as nt
 

--- a/IPython/kernel/tests/test_message_spec.py
+++ b/IPython/kernel/tests/test_message_spec.py
@@ -19,6 +19,7 @@ from IPython.testing import decorators as dec
 from IPython.utils.traitlets import (
     HasTraits, TraitError, Bool, Unicode, Dict, Integer, List, Enum, Any,
 )
+import six
 
 #-----------------------------------------------------------------------------
 # Global setup and utilities
@@ -238,7 +239,7 @@ class DisplayData(Reference):
     metadata = Dict()
     data = Dict()
     def _data_changed(self, name, old, new):
-        for k,v in new.iteritems():
+        for k,v in six.iteritems(new):
             nt.assert_true(mime_pat.match(k))
             nt.assert_true(isinstance(v, basestring), "expected string data, got %r" % v)
 
@@ -247,7 +248,7 @@ class PyOut(Reference):
     execution_count = Integer()
     data = Dict()
     def _data_changed(self, name, old, new):
-        for k,v in new.iteritems():
+        for k,v in six.iteritems(new):
             nt.assert_true(mime_pat.match(k))
             nt.assert_true(isinstance(v, basestring), "expected string data, got %r" % v)
 

--- a/IPython/kernel/zmq/displayhook.py
+++ b/IPython/kernel/zmq/displayhook.py
@@ -5,7 +5,7 @@ from IPython.core.displayhook import DisplayHook
 from IPython.kernel.inprocess.socket import SocketABC
 from IPython.utils.jsonutil import encode_images
 from IPython.utils.traitlets import Instance, Dict
-from session import extract_header, Session
+from .session import extract_header, Session
 
 class ZMQDisplayHook(object):
     """A simple displayhook that publishes the object's repr over a ZeroMQ

--- a/IPython/kernel/zmq/displayhook.py
+++ b/IPython/kernel/zmq/displayhook.py
@@ -1,4 +1,8 @@
-import __builtin__
+try:
+    import builtins
+except ImportError:  
+    # Python 2
+    import __builtin__ as builtins
 import sys
 
 from IPython.core.displayhook import DisplayHook
@@ -21,7 +25,7 @@ class ZMQDisplayHook(object):
         if obj is None:
             return
 
-        __builtin__._ = obj
+        builtins._ = obj
         sys.stdout.flush()
         sys.stderr.flush()
         msg = self.session.send(self.pub_socket, u'pyout', {u'data':repr(obj)},

--- a/IPython/kernel/zmq/embed.py
+++ b/IPython/kernel/zmq/embed.py
@@ -8,7 +8,7 @@ import sys
 
 from IPython.utils.frame import extract_module_locals
 
-from kernelapp import IPKernelApp
+from .kernelapp import IPKernelApp
 
 #-----------------------------------------------------------------------------
 # Code

--- a/IPython/kernel/zmq/iostream.py
+++ b/IPython/kernel/zmq/iostream.py
@@ -16,7 +16,7 @@ from io import StringIO, UnsupportedOperation
 
 import zmq
 
-from session import extract_header
+from .session import extract_header
 
 from IPython.utils import py3compat
 

--- a/IPython/kernel/zmq/iostream.py
+++ b/IPython/kernel/zmq/iostream.py
@@ -180,7 +180,7 @@ class OutStream(object):
             raise ValueError('I/O operation on closed file')
         else:
             # Make sure that we're handling unicode
-            if not isinstance(string, unicode):
+            if not isinstance(string, py3compat.unicode_type):
                 string = string.decode(self.encoding, 'replace')
             
             is_child = (self._check_mp_mode() == CHILD)

--- a/IPython/kernel/zmq/ipkernel.py
+++ b/IPython/kernel/zmq/ipkernel.py
@@ -103,7 +103,7 @@ class Kernel(Configurable):
     ident = Unicode()
 
     def _ident_default(self):
-        return unicode(uuid.uuid4())
+        return py3compat.unicode_type(uuid.uuid4())
 
 
     # Private interface
@@ -671,7 +671,7 @@ class Kernel(Configurable):
     def abort_request(self, stream, ident, parent):
         """abort a specifig msg by id"""
         msg_ids = parent['content'].get('msg_ids', None)
-        if isinstance(msg_ids, basestring):
+        if isinstance(msg_ids, py3compat.string_types):
             msg_ids = [msg_ids]
         if not msg_ids:
             self.abort_queues()

--- a/IPython/kernel/zmq/ipkernel.py
+++ b/IPython/kernel/zmq/ipkernel.py
@@ -51,7 +51,6 @@ from IPython.utils.traitlets import (
 from .serialize import serialize_object, unpack_apply_message
 from .session import Session
 from .zmqshell import ZMQInteractiveShell
-import six
 
 
 #-----------------------------------------------------------------------------
@@ -621,7 +620,7 @@ class Kernel(Configurable):
                 exec(code, shell.user_global_ns, shell.user_ns)
                 result = working.get(resultname)
             finally:
-                for key in six.iterkeys(ns):
+                for key in ns:
                     working.pop(key)
 
             result_buf = serialize_object(result,

--- a/IPython/kernel/zmq/ipkernel.py
+++ b/IPython/kernel/zmq/ipkernel.py
@@ -16,7 +16,11 @@ Things to do:
 from __future__ import print_function
 
 # Standard library imports
-import __builtin__
+try:
+    import builtins
+except ImportError:  
+    # Python 2
+    import __builtin__ as builtins
 import sys
 import time
 import traceback
@@ -357,11 +361,11 @@ class Kernel(Configurable):
             raw_input = lambda prompt='' : self._no_raw_input()
 
         if py3compat.PY3:
-            self._sys_raw_input = __builtin__.input
-            __builtin__.input = raw_input
+            self._sys_raw_input = builtins.input
+            builtins.input = raw_input
         else:
-            self._sys_raw_input = __builtin__.raw_input
-            __builtin__.raw_input = raw_input
+            self._sys_raw_input = builtins.raw_input
+            builtins.raw_input = raw_input
 
         # Set the parent message of the display hook and out streams.
         shell.displayhook.set_parent(parent)
@@ -401,9 +405,9 @@ class Kernel(Configurable):
         finally:
             # Restore raw_input.
              if py3compat.PY3:
-                 __builtin__.input = self._sys_raw_input
+                 builtins.input = self._sys_raw_input
              else:
-                 __builtin__.raw_input = self._sys_raw_input
+                 builtins.raw_input = self._sys_raw_input
 
         reply_content[u'status'] = status
 

--- a/IPython/kernel/zmq/ipkernel.py
+++ b/IPython/kernel/zmq/ipkernel.py
@@ -44,9 +44,10 @@ from IPython.utils.traitlets import (
     Type
 )
 
-from serialize import serialize_object, unpack_apply_message
-from session import Session
-from zmqshell import ZMQInteractiveShell
+from .serialize import serialize_object, unpack_apply_message
+from .session import Session
+from .zmqshell import ZMQInteractiveShell
+import six
 
 
 #-----------------------------------------------------------------------------
@@ -613,10 +614,10 @@ class Kernel(Configurable):
             working.update(ns)
             code = "%s = %s(*%s,**%s)" % (resultname, fname, argname, kwargname)
             try:
-                exec code in shell.user_global_ns, shell.user_ns
+                exec(code, shell.user_global_ns, shell.user_ns)
                 result = working.get(resultname)
             finally:
-                for key in ns.iterkeys():
+                for key in six.iterkeys(ns):
                     working.pop(key)
 
             result_buf = serialize_object(result,

--- a/IPython/kernel/zmq/kernelapp.py
+++ b/IPython/kernel/zmq/kernelapp.py
@@ -50,13 +50,13 @@ from IPython.utils.importstring import import_item
 from IPython.kernel import write_connection_file
 
 # local imports
-from heartbeat import Heartbeat
-from ipkernel import Kernel
-from parentpoller import ParentPollerUnix, ParentPollerWindows
-from session import (
+from .heartbeat import Heartbeat
+from .ipkernel import Kernel
+from .parentpoller import ParentPollerUnix, ParentPollerWindows
+from .session import (
     Session, session_flags, session_aliases, default_secure,
 )
-from zmqshell import ZMQInteractiveShell
+from .zmqshell import ZMQInteractiveShell
 
 #-----------------------------------------------------------------------------
 # Flags and Aliases

--- a/IPython/kernel/zmq/parentpoller.py
+++ b/IPython/kernel/zmq/parentpoller.py
@@ -6,7 +6,10 @@ except:
 import os
 import platform
 import time
-from thread import interrupt_main
+try:
+    from _thread import interrupt_main  # Python 3
+except ImportError:
+    from thread import interrupt_main   # Python 2
 from threading import Thread
 
 from IPython.utils.warn import warn

--- a/IPython/kernel/zmq/serialize.py
+++ b/IPython/kernel/zmq/serialize.py
@@ -30,7 +30,6 @@ from IPython.utils.pickleutil import (
     can, uncan, can_sequence, uncan_sequence, CannedObject,
     istype, sequence_types,
 )
-import six
 
 if py3compat.PY3:
     buffer = memoryview
@@ -92,7 +91,7 @@ def serialize_object(obj, buffer_threshold=MAX_BYTES, item_threshold=MAX_ITEMS):
             buffers.extend(_extract_buffers(c, buffer_threshold))
     elif istype(obj, dict) and len(obj) < item_threshold:
         cobj = {}
-        for k in sorted(six.iterkeys(obj)):
+        for k in sorted(obj.keys()):
             c = can(obj[k])
             buffers.extend(_extract_buffers(c, buffer_threshold))
             cobj[k] = c
@@ -130,7 +129,7 @@ def unserialize_object(buffers, g=None):
         newobj = uncan_sequence(canned, g)
     elif istype(canned, dict) and len(canned) < MAX_ITEMS:
         newobj = {}
-        for k in sorted(six.iterkeys(canned)):
+        for k in sorted(canned.keys()):
             c = canned[k]
             _restore_buffers(c, bufs)
             newobj[k] = uncan(c, g)

--- a/IPython/kernel/zmq/serialize.py
+++ b/IPython/kernel/zmq/serialize.py
@@ -30,6 +30,7 @@ from IPython.utils.pickleutil import (
     can, uncan, can_sequence, uncan_sequence, CannedObject,
     istype, sequence_types,
 )
+import six
 
 if py3compat.PY3:
     buffer = memoryview
@@ -91,7 +92,7 @@ def serialize_object(obj, buffer_threshold=MAX_BYTES, item_threshold=MAX_ITEMS):
             buffers.extend(_extract_buffers(c, buffer_threshold))
     elif istype(obj, dict) and len(obj) < item_threshold:
         cobj = {}
-        for k in sorted(obj.iterkeys()):
+        for k in sorted(six.iterkeys(obj)):
             c = can(obj[k])
             buffers.extend(_extract_buffers(c, buffer_threshold))
             cobj[k] = c
@@ -129,7 +130,7 @@ def unserialize_object(buffers, g=None):
         newobj = uncan_sequence(canned, g)
     elif istype(canned, dict) and len(canned) < MAX_ITEMS:
         newobj = {}
-        for k in sorted(canned.iterkeys()):
+        for k in sorted(six.iterkeys(canned)):
             c = canned[k]
             _restore_buffers(c, bufs)
             newobj[k] = uncan(c, g)

--- a/IPython/kernel/zmq/session.py
+++ b/IPython/kernel/zmq/session.py
@@ -50,7 +50,7 @@ from IPython.config.configurable import Configurable, LoggingConfigurable
 from IPython.utils import io
 from IPython.utils.importstring import import_item
 from IPython.utils.jsonutil import extract_dates, squash_dates, date_default
-from IPython.utils.py3compat import str_to_bytes, str_to_unicode
+from IPython.utils.py3compat import str_to_bytes, str_to_unicode, unicode_type
 from IPython.utils.traitlets import (CBytes, Unicode, Bool, Any, Instance, Set,
                                         DottedObjectName, CUnicode, Dict, Integer,
                                         TraitError,
@@ -289,7 +289,7 @@ class Session(Configurable):
     session = CUnicode(u'', config=True,
         help="""The UUID identifying this session.""")
     def _session_default(self):
-        u = unicode(uuid.uuid4())
+        u = unicode_type(uuid.uuid4())
         self.bsession = u.encode('ascii')
         return u
 
@@ -524,7 +524,7 @@ class Session(Configurable):
         elif isinstance(content, bytes):
             # content is already packed, as in a relayed message
             pass
-        elif isinstance(content, unicode):
+        elif isinstance(content, unicode_type):
             # should be bytes, but JSON often spits out unicode
             content = content.encode('utf8')
         else:

--- a/IPython/kernel/zmq/session.py
+++ b/IPython/kernel/zmq/session.py
@@ -32,6 +32,7 @@ import pprint
 import random
 import uuid
 from datetime import datetime
+import six
 
 try:
     import cPickle
@@ -166,14 +167,14 @@ class Message(object):
 
     def __init__(self, msg_dict):
         dct = self.__dict__
-        for k, v in dict(msg_dict).iteritems():
+        for k, v in six.iteritems(dict(msg_dict)):
             if isinstance(v, dict):
                 v = Message(v)
             dct[k] = v
 
     # Having this iterator lets dict(msg_obj) work out of the box.
     def __iter__(self):
-        return iter(self.__dict__.iteritems())
+        return iter(six.iteritems(self.__dict__))
 
     def __repr__(self):
         return repr(self.__dict__)

--- a/IPython/kernel/zmq/tests/test_embed_kernel.py
+++ b/IPython/kernel/zmq/tests/test_embed_kernel.py
@@ -179,11 +179,12 @@ def test_embed_kernel_reentrant():
     
     with setup_kernel(cmd) as client:
         for i in range(5):
+            print(i)
             msg_id = client.object_info('count')
             msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
             content = msg['content']
             nt.assert_true(content['found'])
-            nt.assert_equal(content['string_form'], unicode(i))
+            nt.assert_equal(content['string_form'], py3compat.unicode_type(i))
             
             # exit from embed_kernel
             client.execute("get_ipython().exit_now = True")

--- a/IPython/kernel/zmq/tests/test_serialize.py
+++ b/IPython/kernel/zmq/tests/test_serialize.py
@@ -21,6 +21,7 @@ from IPython.kernel.zmq.serialize import serialize_object, unserialize_object
 from IPython.testing import decorators as dec
 from IPython.utils.pickleutil import CannedArray, CannedClass
 from IPython.parallel import interactive
+import six
 
 #-------------------------------------------------------------------------------
 # Globals and Utilities
@@ -37,7 +38,7 @@ class C(object):
     """dummy class for """
     
     def __init__(self, **kwargs):
-        for key,value in kwargs.iteritems():
+        for key,value in six.iteritems(kwargs):
             setattr(self, key, value)
 
 SHAPES = ((100,), (1024,10), (10,8,6,5), (), (0,))
@@ -60,8 +61,8 @@ def test_roundtrip_simple():
 @dec.parametric
 def test_roundtrip_nested():
     for obj in [
-        dict(a=range(5), b={1:b'hello'}),
-        [range(5),[range(3),(1,[b'whoda'])]],
+        dict(a=list(range(5)), b={1:b'hello'}),
+        [list(range(5)),[list(range(3)),(1,[b'whoda'])]],
     ]:
         obj2 = roundtrip(obj)
         yield nt.assert_equals(obj, obj2)
@@ -157,7 +158,7 @@ def test_numpy_in_dict():
         for dtype in DTYPES:
             A = numpy.empty(shape, dtype=dtype)
             _scrub_nan(A)
-            bufs = serialize_object(dict(a=A,b=1,c=range(20)))
+            bufs = serialize_object(dict(a=A,b=1,c=list(range(20))))
             canned = pickle.loads(bufs[0])
             yield nt.assert_true(canned['a'], CannedArray)
             d, r = unserialize_object(bufs)

--- a/IPython/kernel/zmq/zmqshell.py
+++ b/IPython/kernel/zmq/zmqshell.py
@@ -49,7 +49,7 @@ from IPython.utils.warn import error
 from IPython.kernel.zmq.displayhook import ZMQShellDisplayHook
 from IPython.kernel.zmq.datapub import ZMQDataPublisher
 from IPython.kernel.zmq.session import extract_header
-from session import Session
+from .session import Session
 
 #-----------------------------------------------------------------------------
 # Functions and classes

--- a/IPython/kernel/zmq/zmqshell.py
+++ b/IPython/kernel/zmq/zmqshell.py
@@ -555,7 +555,7 @@ class ZMQInteractiveShell(InteractiveShell):
 
         exc_content = {
             u'traceback' : stb,
-            u'ename' : unicode(etype.__name__),
+            u'ename' : py3compat.unicode_type(etype.__name__),
             u'evalue' : py3compat.safe_unicode(evalue),
         }
 

--- a/IPython/lib/backgroundjobs.py
+++ b/IPython/lib/backgroundjobs.py
@@ -21,6 +21,7 @@ separate implementation).
 An example notebook is provided in our documentation illustrating interactive
 use of the system.
 """
+from __future__ import print_function
 
 #*****************************************************************************
 #       Copyright (C) 2005-2006 Fernando Perez <fperez@colorado.edu>
@@ -36,6 +37,7 @@ import threading
 from IPython import get_ipython
 from IPython.core.ultratb import AutoFormattedTB
 from IPython.utils.warn import error
+from six.moves import filter
 
 
 class BackgroundJobManager(object):
@@ -190,7 +192,7 @@ class BackgroundJobManager(object):
         job.num = len(self.all)+1 if self.all else 0
         self.running.append(job)
         self.all[job.num] = job
-        print 'Starting job # %s in a separate thread.' % job.num
+        print('Starting job # %s in a separate thread.' % job.num)
         job.start()
         return job
 
@@ -245,10 +247,10 @@ class BackgroundJobManager(object):
         Return True if the group had any elements."""
 
         if group:
-            print '%s jobs:' % name
+            print('%s jobs:' % name)
             for job in group:
-                print '%s : %s' % (job.num,job)
-            print
+                print('%s : %s' % (job.num,job))
+            print()
             return True
 
     def _group_flush(self,group,name):
@@ -259,7 +261,7 @@ class BackgroundJobManager(object):
         njobs = len(group)
         if njobs:
             plural = {1:''}.setdefault(njobs,'s')
-            print 'Flushing %s %s job%s.' % (njobs,name,plural)
+            print('Flushing %s %s job%s.' % (njobs,name,plural))
             group[:] = []
             return True
         
@@ -325,7 +327,7 @@ class BackgroundJobManager(object):
         fl_comp = self._group_flush(self.completed, 'Completed')
         fl_dead = self._group_flush(self.dead, 'Dead')
         if not (fl_comp or fl_dead):
-            print 'No jobs to flush.'
+            print('No jobs to flush.')
 
     def result(self,num):
         """result(N) -> return the result of job N."""
@@ -345,9 +347,9 @@ class BackgroundJobManager(object):
         if job is None:
             self._update_status()
             for deadjob in self.dead:
-                print "Traceback for: %r" % deadjob
+                print("Traceback for: %r" % deadjob)
                 self._traceback(deadjob)
-                print
+                print()
         else:
             self._traceback(job)
 
@@ -416,7 +418,7 @@ class BackgroundJobBase(threading.Thread):
         return '<BackgroundJob #%d: %s>' % (self.num, self.strform)
 
     def traceback(self):
-        print self._tb
+        print(self._tb)
         
     def run(self):
         try:

--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -6,6 +6,8 @@ To enable it type::
     import __builtin__, deepreload
     __builtin__.reload = deepreload.reload
 
+For Python 3, replace '__builtin__' with 'builtins'.
+
 You can then disable it with::
 
     __builtin__.reload = deepreload.original_reload
@@ -25,7 +27,11 @@ from __future__ import print_function
 #  the file COPYING, distributed as part of this software.
 #*****************************************************************************
 
-import __builtin__
+try:
+    import builtins
+except ImportError:  
+    # Python 2
+    import __builtin__ as builtins
 from contextlib import contextmanager
 import imp
 import sys
@@ -33,16 +39,18 @@ import sys
 from types import ModuleType
 from warnings import warn
 
-original_import = __builtin__.__import__
+from IPython.utils.py3compat import builtin_mod_name
+
+original_import = builtins.__import__
 
 @contextmanager
 def replace_import_hook(new_import):
-    saved_import = __builtin__.__import__
-    __builtin__.__import__ = new_import
+    saved_import = builtins.__import__
+    builtins.__import__ = new_import
     try:
         yield
     finally:
-        __builtin__.__import__ = saved_import
+        builtins.__import__ = saved_import
 
 def get_parent(globals, level):
     """
@@ -313,12 +321,12 @@ def deep_reload_hook(m):
 
 # Save the original hooks
 try:
-    original_reload = __builtin__.reload
+    original_reload = builtins.reload
 except AttributeError:
     original_reload = imp.reload    # Python 3
 
 # Replacement for reload()
-def reload(module, exclude=['sys', 'os.path', '__builtin__', '__main__']):
+def reload(module, exclude=['sys', 'os.path', builtin_mod_name, '__main__']):
     """Recursively reload all modules used in the given module.  Optionally
     takes a list of modules to exclude from reloading.  The default exclude
     list contains sys, __main__, and __builtin__, to prevent, e.g., resetting
@@ -336,4 +344,4 @@ def reload(module, exclude=['sys', 'os.path', '__builtin__', '__main__']):
 
 # Uncomment the following to automatically activate deep reloading whenever
 # this module is imported
-#__builtin__.reload = reload
+#builtins.reload = reload

--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -17,6 +17,7 @@ Alternatively, you can add a dreload builtin alongside normal reload with::
 This code is almost entirely based on knee.py, which is a Python
 re-implementation of hierarchical module import.
 """
+from __future__ import print_function
 #*****************************************************************************
 #       Copyright (C) 2001 Nathaniel Gray <n8gray@caltech.edu>
 #
@@ -91,7 +92,7 @@ def get_parent(globals, level):
             globals['__package__'] = name = modname[:lastdot]
 
     dot = len(name)
-    for x in xrange(level, 1, -1):
+    for x in range(level, 1, -1):
         try:
             dot = name.rindex('.', 0, dot)
         except ValueError:
@@ -167,7 +168,7 @@ def import_submodule(mod, subname, fullname):
     if fullname in found_now and fullname in sys.modules:
         m = sys.modules[fullname]
     else:
-        print 'Reloading', fullname
+        print('Reloading', fullname)
         found_now[fullname] = 1
         oldm = sys.modules.get(fullname, None)
 

--- a/IPython/lib/demo.py
+++ b/IPython/lib/demo.py
@@ -186,6 +186,8 @@ import sys
 from IPython.utils import io
 from IPython.utils.text import marquee
 from IPython.utils import openpy
+from six.moves import map
+from six.moves import zip
 __all__ = ['Demo','IPythonDemo','LineDemo','IPythonLineDemo','DemoError']
 
 class DemoError(Exception): pass
@@ -421,7 +423,7 @@ class Demo(object):
     def run_cell(self,source):
         """Execute a string with one or more lines of code"""
 
-        exec source in self.user_ns
+        exec(source, self.user_ns)
 
     def __call__(self,index=None):
         """run a block of the demo.

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -128,8 +128,7 @@ class FileLink(object):
             text to append at the end of link [default: '<br>']
         """
         if isdir(path):
-            raise ValueError,\
-             ("Cannot display a directory using FileLink. "
+            raise ValueError("Cannot display a directory using FileLink. "
               "Use FileLinks to display '%s'." % path)
         self.path = path
         self.url_prefix = url_prefix
@@ -214,8 +213,7 @@ class FileLinks(FileLink):
 
         """
         if isfile(path):
-            raise ValueError,\
-             ("Cannot display a file using FileLinks. "
+            raise ValueError("Cannot display a file using FileLinks. "
               "Use FileLink to display '%s'." % path)
         self.included_suffixes = included_suffixes
         # remove trailing slashs for more consistent output formatting

--- a/IPython/lib/editorhooks.py
+++ b/IPython/lib/editorhooks.py
@@ -4,6 +4,7 @@ They should honor the line number argument, at least.
 
 Contributions are *very* welcome.
 """
+from __future__ import print_function
 
 import os
 import pipes
@@ -45,7 +46,7 @@ def install_editor(template, wait=False):
         if line is None:
             line = 0
         cmd = template.format(filename=pipes.quote(filename), line=line)
-        print ">", cmd
+        print(">", cmd)
         proc = subprocess.Popen(cmd, shell=True)
         if wait and proc.wait() != 0:
             raise TryNext()

--- a/IPython/lib/inputhookglut.py
+++ b/IPython/lib/inputhookglut.py
@@ -2,6 +2,7 @@
 """
 GLUT Inputhook support functions
 """
+from __future__ import print_function
 
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2008-2011  The IPython Development Team
@@ -114,7 +115,7 @@ def glut_close():
 def glut_int_handler(signum, frame):
     # Catch sigint and print the defautl message
     signal.signal(signal.SIGINT, signal.default_int_handler)
-    print '\nKeyboardInterrupt'
+    print('\nKeyboardInterrupt')
     # Need to reprint the prompt at this stage
 
 

--- a/IPython/lib/irunner.py
+++ b/IPython/lib/irunner.py
@@ -189,7 +189,7 @@ class InteractiveRunner(object):
 
         # if the source is a string, chop it up in lines so we can iterate
         # over it just as if it were an open file.
-        if isinstance(source, basestring):
+        if isinstance(source, py3compat.string_types):
             source = source.splitlines(True)
 
         if self.echo:

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -104,6 +104,7 @@ Inheritance diagram:
 :license: BSD License.
 """
 from __future__ import with_statement
+from __future__ import print_function
 from contextlib import contextmanager
 import sys
 import types
@@ -111,6 +112,8 @@ import re
 import datetime
 from StringIO import StringIO
 from collections import deque
+from six.moves import map
+from six.moves import zip
 
 
 __all__ = ['pretty', 'pprint', 'PrettyPrinter', 'RepresentationPrinter',
@@ -709,7 +712,7 @@ _type_pprinters = {
     type:                       _type_pprint,
     types.FunctionType:         _function_pprint,
     types.BuiltinFunctionType:  _function_pprint,
-    types.SliceType:            _repr_pprint,
+    slice:            _repr_pprint,
     types.MethodType:           _repr_pprint,
     
     datetime.datetime:          _repr_pprint,
@@ -719,7 +722,7 @@ _type_pprinters = {
 
 try:
     _type_pprinters[types.DictProxyType] = _dict_pprinter_factory('<dictproxy {', '}>')
-    _type_pprinters[types.ClassType] = _type_pprint
+    _type_pprinters[type] = _type_pprint
 except AttributeError: # Python 3
     pass
     
@@ -766,11 +769,11 @@ if __name__ == '__main__':
         def __init__(self):
             self.foo = 1
             self.bar = re.compile(r'\s+')
-            self.blub = dict.fromkeys(range(30), randrange(1, 40))
+            self.blub = dict.fromkeys(list(range(30)), randrange(1, 40))
             self.hehe = 23424.234234
             self.list = ["blub", "blah", self]
 
         def get_foo(self):
-            print "foo"
+            print("foo")
 
     pprint(Foo(), verbose=True)

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -110,12 +110,15 @@ import sys
 import types
 import re
 import datetime
-from StringIO import StringIO
 from collections import deque
 from six.moves import map
 from six.moves import zip
 
-from IPython.utils.py3compat import builtin_mod_name
+from IPython.utils.py3compat import builtin_mod_name, PY3
+if PY3:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 
 __all__ = ['pretty', 'pprint', 'PrettyPrinter', 'RepresentationPrinter',
@@ -699,10 +702,8 @@ except NameError:
 #: printers for builtin types
 _type_pprinters = {
     int:                        _repr_pprint,
-    long:                       _repr_pprint,
     float:                      _repr_pprint,
     str:                        _repr_pprint,
-    unicode:                    _repr_pprint,
     tuple:                      _seq_pprinter_factory('(', ')', tuple),
     list:                       _seq_pprinter_factory('[', ']', list),
     dict:                       _dict_pprinter_factory('{', '}', dict),
@@ -730,7 +731,9 @@ except AttributeError: # Python 3
     
 try:
     _type_pprinters[xrange] = _repr_pprint
-except NameError:
+    _type_pprinters[long] = _repr_pprint
+    _type_pprinters[unicode] = _repr_pprint
+except NameError:  # Python 3
     _type_pprinters[range] = _repr_pprint
 
 #: printers for types specified by name

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -115,6 +115,8 @@ from collections import deque
 from six.moves import map
 from six.moves import zip
 
+from IPython.utils.py3compat import builtin_mod_name
+
 
 __all__ = ['pretty', 'pprint', 'PrettyPrinter', 'RepresentationPrinter',
     'for_type', 'for_type_by_name']
@@ -647,7 +649,7 @@ def _type_pprint(obj, p, cycle):
         # and others may set it to None.
         return p.text(obj.__name__)
 
-    if mod in ('__builtin__', 'exceptions'):
+    if mod in (builtin_mod_name, 'exceptions'):
         name = obj.__name__
     else:
         name = mod + '.' + obj.__name__
@@ -661,7 +663,7 @@ def _repr_pprint(obj, p, cycle):
 
 def _function_pprint(obj, p, cycle):
     """Base pprint for all functions and builtin functions."""
-    if obj.__module__ in ('__builtin__', 'exceptions') or not obj.__module__:
+    if obj.__module__ in (builtin_mod_name, 'exceptions') or not obj.__module__:
         name = obj.__name__
     else:
         name = obj.__module__ + '.' + obj.__name__

--- a/IPython/lib/tests/test_deepreload.py
+++ b/IPython/lib/tests/test_deepreload.py
@@ -12,6 +12,7 @@ import nose.tools as nt
 from IPython.testing import decorators as dec
 from IPython.utils.syspathcontext import prepended_to_syspath
 from IPython.utils.tempdir import TemporaryDirectory
+from IPython.utils.py3compat import builtin_mod_name
 from IPython.lib.deepreload import reload as dreload
 
 #-----------------------------------------------------------------------------
@@ -24,7 +25,7 @@ def test_deepreload_numpy():
     import numpy
     exclude = [
         # Standard exclusions:
-        'sys', 'os.path', '__builtin__', '__main__',
+        'sys', 'os.path', builtin_mod_name, '__main__',
         # Test-related exclusions:
         'unittest', 'UserDict',
         ]

--- a/IPython/lib/tests/test_irunner.py
+++ b/IPython/lib/tests/test_irunner.py
@@ -8,19 +8,22 @@ from __future__ import print_function
 VERBOSE = True
 
 # stdlib imports
-import StringIO
 import sys
 import unittest
 
 # IPython imports
 from IPython.lib import irunner
-from IPython.utils.py3compat import doctest_refactor_print
+from IPython.utils.py3compat import doctest_refactor_print, PY3
+if PY3:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 # Testing code begins
 class RunnerTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.out = StringIO.StringIO()
+        self.out = StringIO()
         #self.out = sys.stdout
 
     def _test_runner(self,runner,source,output):

--- a/IPython/lib/tests/test_irunner_pylab_magic.py
+++ b/IPython/lib/tests/test_irunner_pylab_magic.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 VERBOSE = True
 
 # stdlib imports
-import StringIO
 import sys
 import unittest
 import re
@@ -15,6 +14,11 @@ import re
 # IPython imports
 from IPython.lib import irunner
 from IPython.testing import decorators
+from IPython.utils.py3compat import PY3
+if PY3:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 def pylab_not_importable():
     """Test if importing pylab fails. (For example, when having no display)"""
@@ -28,7 +32,7 @@ def pylab_not_importable():
 class RunnerTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.out = StringIO.StringIO()
+        self.out = StringIO()
         #self.out = sys.stdout
 
     def _test_runner(self,runner,source,output):

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -62,7 +62,7 @@ NoModule.__module__ = None
 def test_indentation():
     """Test correct indentation in groups"""
     count = 40
-    gotoutput = pretty.pretty(MyList(range(count)))
+    gotoutput = pretty.pretty(MyList(list(range(count))))
     expectedoutput = "MyList(\n" + ",\n".join("   %d" % i for i in range(count)) + ")"
 
     nt.assert_equal(gotoutput, expectedoutput)

--- a/IPython/nbconvert/__init__.py
+++ b/IPython/nbconvert/__init__.py
@@ -1,7 +1,7 @@
 """Utilities for converting notebooks to and from different formats."""
 
 from .exporters import *
-import filters
-import preprocessors
-import postprocessors
-import writers
+from . import filters
+from . import preprocessors
+from . import postprocessors
+from . import writers

--- a/IPython/nbconvert/exporters/export.py
+++ b/IPython/nbconvert/exporters/export.py
@@ -17,6 +17,7 @@ from functools import wraps
 
 from IPython.nbformat.v3.nbbase import NotebookNode
 from IPython.config import Config
+from IPython.utils.py3compat import string_types
 
 from .exporter import Exporter
 from .html import HTMLExporter
@@ -115,7 +116,7 @@ def export(exporter, nb, **kw):
     #Try to convert the notebook using the appropriate conversion function.
     if isinstance(nb, NotebookNode):
         output, resources = exporter_instance.from_notebook_node(nb, resources)
-    elif isinstance(nb, basestring):
+    elif isinstance(nb, string_types):
         output, resources = exporter_instance.from_filename(nb, resources)
     else:
         output, resources = exporter_instance.from_file(nb, resources)

--- a/IPython/nbconvert/filters/ansi.py
+++ b/IPython/nbconvert/filters/ansi.py
@@ -14,6 +14,7 @@
 
 import re
 from IPython.utils import coloransi
+import six
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -71,7 +72,7 @@ def ansi2html(text):
         '`': '&#96;',
     }
     
-    for c, escape in html_escapes.iteritems():
+    for c, escape in six.iteritems(html_escapes):
         text = text.replace(c, escape)
 
     ansi_re = re.compile('\x1b' + r'\[([\dA-Fa-f;]*?)m')

--- a/IPython/nbconvert/filters/strings.py
+++ b/IPython/nbconvert/filters/strings.py
@@ -23,6 +23,8 @@ from xml.etree import ElementTree
 
 from IPython.core.interactiveshell import InteractiveShell
 from IPython.utils import py3compat
+from six.moves import map
+from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Functions

--- a/IPython/nbconvert/postprocessors/serve.py
+++ b/IPython/nbconvert/postprocessors/serve.py
@@ -17,8 +17,14 @@ from __future__ import print_function
 import os
 import webbrowser
 
-from BaseHTTPServer import HTTPServer
-from SimpleHTTPServer import SimpleHTTPRequestHandler
+try:
+    # Python 3
+    from http.server import HTTPServer
+    from http.server import SimpleHTTPRequestHandler
+except ImportError:
+    # Python 2
+    from BaseHTTPServer import HTTPServer
+    from SimpleHTTPServer import SimpleHTTPRequestHandler
 
 from IPython.utils.traitlets import Bool
 

--- a/IPython/nbconvert/postprocessors/serve.py
+++ b/IPython/nbconvert/postprocessors/serve.py
@@ -1,6 +1,7 @@
 """
 Contains postprocessor for serving nbconvert output.
 """
+from __future__ import print_function
 #-----------------------------------------------------------------------------
 #Copyright (c) 2013, the IPython Development Team.
 #
@@ -48,7 +49,7 @@ class ServePostProcessor(PostProcessorBase):
             url = "http://" + sa[0] + ":" + str(sa[1]) + "/" + filename
             if self.open_in_browser:
                 webbrowser.open(url, new=2)
-            print("Serving your slides on " + url)
+            print(("Serving your slides on " + url))
             print("Use Control-C to stop this server.")
             httpd.serve_forever()
         except KeyboardInterrupt:

--- a/IPython/nbconvert/preprocessors/convertfigures.py
+++ b/IPython/nbconvert/preprocessors/convertfigures.py
@@ -48,7 +48,7 @@ class ConvertFiguresPreprocessor(Preprocessor):
 
         # Loop through all of the datatypes of the outputs in the cell.
         for index, cell_out in enumerate(cell.get('outputs', [])):
-            for data_type, data in cell_out.items():
+            for data_type, data in list(cell_out.items()):
                 # this must run *before* extract outputs,
                 # so figure_name and filename do not exist
                 self._convert_figure(cell_out, resources, data_type, data)

--- a/IPython/nbconvert/preprocessors/revealhelp.py
+++ b/IPython/nbconvert/preprocessors/revealhelp.py
@@ -13,7 +13,10 @@
 #-----------------------------------------------------------------------------
 
 import os
-import urllib2
+try:
+    from urllib.request import urlopen  # Python 3
+except ImportError:
+    from urllib2 import urlopen  # Python 2
 
 from .base import Preprocessor
 from IPython.utils.traitlets import Unicode, Bool
@@ -89,6 +92,6 @@ class RevealHelpPreprocessor(Preprocessor):
     def notes_helper(self, infile):
         """Helper function to get the content from an url."""
 
-        content = urllib2.urlopen(infile).read()
+        content = urlopen(infile).read()
 
         return content

--- a/IPython/nbconvert/utils/console.py
+++ b/IPython/nbconvert/utils/console.py
@@ -13,6 +13,7 @@
 
 # Used to determine python version
 import sys
+import six
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -97,7 +98,7 @@ def prompt_dictionary(choices, default_style=1, menu_comments={}):
     # Build the menu that will be displayed to the user with
     # all of the options available. 
     prompt = ""
-    for key, value in choices.iteritems():
+    for key, value in six.iteritems(choices):
         prompt += "%d %s " % (key, value)
         if key in menu_comments:
             prompt += menu_comments[key]

--- a/IPython/nbconvert/writers/debug.py
+++ b/IPython/nbconvert/writers/debug.py
@@ -1,6 +1,7 @@
 """
 Contains debug writer.
 """
+from __future__ import print_function
 #-----------------------------------------------------------------------------
 #Copyright (c) 2013, the IPython Development Team.
 #
@@ -34,9 +35,9 @@ class DebugWriter(WriterBase):
         """
 
         if isinstance(resources['outputs'], dict):
-            print("outputs extracted from %s" % notebook_name)
-            print('-' * 80)
+            print(("outputs extracted from %s" % notebook_name))
+            print(('-' * 80))
             pprint(resources['outputs'], indent=2, width=70)
         else:
-            print("no outputs extracted from %s" % notebook_name)
-        print('=' * 80)
+            print(("no outputs extracted from %s" % notebook_name))
+        print(('=' * 80))

--- a/IPython/nbconvert/writers/tests/test_debug.py
+++ b/IPython/nbconvert/writers/tests/test_debug.py
@@ -15,7 +15,7 @@ Module with tests for debug
 #-----------------------------------------------------------------------------
 
 import sys
-from StringIO import StringIO
+from IPython.utils.py3compat import StringIO
 
 from ...tests.base import TestsBase
 from ..debug import DebugWriter

--- a/IPython/nbconvert/writers/tests/test_files.py
+++ b/IPython/nbconvert/writers/tests/test_files.py
@@ -16,7 +16,7 @@ Module with tests for files
 
 import sys
 import os
-from StringIO import StringIO
+from IPython.utils.py3compat import StringIO
 
 from ...tests.base import TestsBase
 from ..files import FilesWriter

--- a/IPython/nbconvert/writers/tests/test_stdout.py
+++ b/IPython/nbconvert/writers/tests/test_stdout.py
@@ -15,7 +15,7 @@ Module with tests for stdout
 #-----------------------------------------------------------------------------
 
 import sys
-from StringIO import StringIO
+from IPython.utils.py3compat import StringIO
 
 from ...tests.base import TestsBase
 from ..stdout import StdoutWriter

--- a/IPython/nbformat/current.py
+++ b/IPython/nbformat/current.py
@@ -32,6 +32,8 @@ from IPython.nbformat.v3 import (
     nbformat_minor,
 )
 
+from IPython.utils.py3compat import unicode_type
+
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
@@ -132,7 +134,7 @@ def reads(s, format, **kwargs):
     nb : NotebookNode
         The notebook that was read.
     """
-    format = unicode(format)
+    format = unicode_type(format)
     if format == u'json' or format == u'ipynb':
         return reads_json(s, **kwargs)
     elif format == u'py':
@@ -158,7 +160,7 @@ def writes(nb, format, **kwargs):
     s : unicode
         The notebook string.
     """
-    format = unicode(format)
+    format = unicode_type(format)
     if format == u'json' or format == u'ipynb':
         return writes_json(nb, **kwargs)
     elif format == u'py':

--- a/IPython/nbformat/v1/nbbase.py
+++ b/IPython/nbformat/v1/nbbase.py
@@ -20,6 +20,7 @@ import pprint
 import uuid
 
 from IPython.utils.ipstruct import Struct
+from IPython.utils.py3compat import unicode_type
 
 #-----------------------------------------------------------------------------
 # Code
@@ -46,7 +47,7 @@ def new_code_cell(code=None, prompt_number=None):
     cell = NotebookNode()
     cell.cell_type = u'code'
     if code is not None:
-        cell.code = unicode(code)
+        cell.code = unicode_type(code)
     if prompt_number is not None:
         cell.prompt_number = int(prompt_number)
     return cell
@@ -56,7 +57,7 @@ def new_text_cell(text=None):
     """Create a new text cell."""
     cell = NotebookNode()
     if text is not None:
-        cell.text = unicode(text)
+        cell.text = unicode_type(text)
     cell.cell_type = u'text'
     return cell
 

--- a/IPython/nbformat/v2/nbbase.py
+++ b/IPython/nbformat/v2/nbbase.py
@@ -25,6 +25,7 @@ import pprint
 import uuid
 
 from IPython.utils.ipstruct import Struct
+from IPython.utils.py3compat import string_types, unicode_type
 
 #-----------------------------------------------------------------------------
 # Code
@@ -53,25 +54,25 @@ def new_output(output_type=None, output_text=None, output_png=None,
     """Create a new code cell with input and output"""
     output = NotebookNode()
     if output_type is not None:
-        output.output_type = unicode(output_type)
+        output.output_type = unicode_type(output_type)
 
     if output_type != 'pyerr':
         if output_text is not None:
-            output.text = unicode(output_text)
+            output.text = unicode_type(output_text)
         if output_png is not None:
             output.png = bytes(output_png)
         if output_jpeg is not None:
             output.jpeg = bytes(output_jpeg)
         if output_html is not None:
-            output.html = unicode(output_html)
+            output.html = unicode_type(output_html)
         if output_svg is not None:
-            output.svg = unicode(output_svg)
+            output.svg = unicode_type(output_svg)
         if output_latex is not None:
-            output.latex = unicode(output_latex)
+            output.latex = unicode_type(output_latex)
         if output_json is not None:
-            output.json = unicode(output_json)
+            output.json = unicode_type(output_json)
         if output_javascript is not None:
-            output.javascript = unicode(output_javascript)
+            output.javascript = unicode_type(output_javascript)
 
     if output_type == u'pyout':
         if prompt_number is not None:
@@ -79,11 +80,11 @@ def new_output(output_type=None, output_text=None, output_png=None,
 
     if output_type == u'pyerr':
         if etype is not None:
-            output.etype = unicode(etype)
+            output.etype = unicode_type(etype)
         if evalue is not None:
-            output.evalue = unicode(evalue)
+            output.evalue = unicode_type(evalue)
         if traceback is not None:
-            output.traceback = [unicode(frame) for frame in list(traceback)]
+            output.traceback = [unicode_type(frame) for frame in list(traceback)]
 
     return output
 
@@ -94,9 +95,9 @@ def new_code_cell(input=None, prompt_number=None, outputs=None,
     cell = NotebookNode()
     cell.cell_type = u'code'
     if language is not None:
-        cell.language = unicode(language)
+        cell.language = unicode_type(language)
     if input is not None:
-        cell.input = unicode(input)
+        cell.input = unicode_type(input)
     if prompt_number is not None:
         cell.prompt_number = int(prompt_number)
     if outputs is None:
@@ -112,9 +113,9 @@ def new_text_cell(cell_type, source=None, rendered=None):
     """Create a new text cell."""
     cell = NotebookNode()
     if source is not None:
-        cell.source = unicode(source)
+        cell.source = unicode_type(source)
     if rendered is not None:
-        cell.rendered = unicode(rendered)
+        cell.rendered = unicode_type(rendered)
     cell.cell_type = cell_type
     return cell
 
@@ -123,7 +124,7 @@ def new_worksheet(name=None, cells=None):
     """Create a worksheet by name with with a list of cells."""
     ws = NotebookNode()
     if name is not None:
-        ws.name = unicode(name)
+        ws.name = unicode_type(name)
     if cells is None:
         ws.cells = []
     else:
@@ -151,29 +152,29 @@ def new_metadata(name=None, authors=None, license=None, created=None,
     """Create a new metadata node."""
     metadata = NotebookNode()
     if name is not None:
-        metadata.name = unicode(name)
+        metadata.name = unicode_type(name)
     if authors is not None:
         metadata.authors = list(authors)
     if created is not None:
-        metadata.created = unicode(created)
+        metadata.created = unicode_type(created)
     if modified is not None:
-        metadata.modified = unicode(modified)
+        metadata.modified = unicode_type(modified)
     if license is not None:
-        metadata.license = unicode(license)
+        metadata.license = unicode_type(license)
     if gistid is not None:
-        metadata.gistid = unicode(gistid)
+        metadata.gistid = unicode_type(gistid)
     return metadata
 
 def new_author(name=None, email=None, affiliation=None, url=None):
     """Create a new author."""
     author = NotebookNode()
     if name is not None:
-        author.name = unicode(name)
+        author.name = unicode_type(name)
     if email is not None:
-        author.email = unicode(email)
+        author.email = unicode_type(email)
     if affiliation is not None:
-        author.affiliation = unicode(affiliation)
+        author.affiliation = unicode_type(affiliation)
     if url is not None:
-        author.url = unicode(url)
+        author.url = unicode_type(url)
     return author
 

--- a/IPython/nbformat/v2/nbpy.py
+++ b/IPython/nbformat/v2/nbpy.py
@@ -20,6 +20,8 @@ import re
 from .rwbase import NotebookReader, NotebookWriter
 from .nbbase import new_code_cell, new_text_cell, new_worksheet, new_notebook
 
+from IPython.utils.py3compat import unicode_type
+
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
@@ -136,7 +138,7 @@ class PyWriter(NotebookWriter):
                         lines.extend([u'# ' + line for line in input.splitlines()])
                         lines.append(u'')
         lines.append('')
-        return unicode('\n'.join(lines))
+        return unicode_type('\n'.join(lines))
 
 
 _reader = PyReader()

--- a/IPython/nbformat/v2/rwbase.py
+++ b/IPython/nbformat/v2/rwbase.py
@@ -19,7 +19,7 @@ Authors:
 from base64 import encodestring, decodestring
 import pprint
 
-from IPython.utils.py3compat import str_to_bytes
+from IPython.utils.py3compat import str_to_bytes, string_types, unicode_type
 
 #-----------------------------------------------------------------------------
 # Code
@@ -83,17 +83,17 @@ def split_lines(nb):
     for ws in nb.worksheets:
         for cell in ws.cells:
             if cell.cell_type == 'code':
-                if 'input' in cell and isinstance(cell.input, basestring):
+                if 'input' in cell and isinstance(cell.input, string_types):
                     cell.input = cell.input.splitlines()
                 for output in cell.outputs:
                     for key in _multiline_outputs:
                         item = output.get(key, None)
-                        if isinstance(item, basestring):
+                        if isinstance(item, string_types):
                             output[key] = item.splitlines()
             else: # text cell
                 for key in ['source', 'rendered']:
                     item = cell.get(key, None)
-                    if isinstance(item, basestring):
+                    if isinstance(item, string_types):
                         cell[key] = item.splitlines()
     return nb
 
@@ -110,11 +110,11 @@ def base64_decode(nb):
             if cell.cell_type == 'code':
                 for output in cell.outputs:
                     if 'png' in output:
-                        if isinstance(output.png, unicode):
+                        if isinstance(output.png, unicode_type):
                             output.png = output.png.encode('ascii')
                         output.png = decodestring(output.png)
                     if 'jpeg' in output:
-                        if isinstance(output.jpeg, unicode):
+                        if isinstance(output.jpeg, unicode_type):
                             output.jpeg = output.jpeg.encode('ascii')
                         output.jpeg = decodestring(output.jpeg)
     return nb

--- a/IPython/nbformat/v3/nbbase.py
+++ b/IPython/nbformat/v3/nbbase.py
@@ -25,6 +25,7 @@ import pprint
 import uuid
 
 from IPython.utils.ipstruct import Struct
+from IPython.utils.py3compat import unicode_type
 
 #-----------------------------------------------------------------------------
 # Code
@@ -57,7 +58,7 @@ def new_output(output_type=None, output_text=None, output_png=None,
     """Create a new code cell with input and output"""
     output = NotebookNode()
     if output_type is not None:
-        output.output_type = unicode(output_type)
+        output.output_type = unicode_type(output_type)
 
     if metadata is None:
         metadata = {}
@@ -67,21 +68,21 @@ def new_output(output_type=None, output_text=None, output_png=None,
 
     if output_type != 'pyerr':
         if output_text is not None:
-            output.text = unicode(output_text)
+            output.text = unicode_type(output_text)
         if output_png is not None:
             output.png = bytes(output_png)
         if output_jpeg is not None:
             output.jpeg = bytes(output_jpeg)
         if output_html is not None:
-            output.html = unicode(output_html)
+            output.html = unicode_type(output_html)
         if output_svg is not None:
-            output.svg = unicode(output_svg)
+            output.svg = unicode_type(output_svg)
         if output_latex is not None:
-            output.latex = unicode(output_latex)
+            output.latex = unicode_type(output_latex)
         if output_json is not None:
-            output.json = unicode(output_json)
+            output.json = unicode_type(output_json)
         if output_javascript is not None:
-            output.javascript = unicode(output_javascript)
+            output.javascript = unicode_type(output_javascript)
 
     if output_type == u'pyout':
         if prompt_number is not None:
@@ -89,14 +90,14 @@ def new_output(output_type=None, output_text=None, output_png=None,
 
     if output_type == u'pyerr':
         if ename is not None:
-            output.ename = unicode(ename)
+            output.ename = unicode_type(ename)
         if evalue is not None:
-            output.evalue = unicode(evalue)
+            output.evalue = unicode_type(evalue)
         if traceback is not None:
-            output.traceback = [unicode(frame) for frame in list(traceback)]
+            output.traceback = [unicode_type(frame) for frame in list(traceback)]
 
     if output_type == u'stream':
-        output.stream = 'stdout' if stream is None else unicode(stream)
+        output.stream = 'stdout' if stream is None else unicode_type(stream)
     
     return output
 
@@ -107,9 +108,9 @@ def new_code_cell(input=None, prompt_number=None, outputs=None,
     cell = NotebookNode()
     cell.cell_type = u'code'
     if language is not None:
-        cell.language = unicode(language)
+        cell.language = unicode_type(language)
     if input is not None:
-        cell.input = unicode(input)
+        cell.input = unicode_type(input)
     if prompt_number is not None:
         cell.prompt_number = int(prompt_number)
     if outputs is None:
@@ -130,9 +131,9 @@ def new_text_cell(cell_type, source=None, rendered=None, metadata=None):
     if cell_type == 'plaintext':
         cell_type = 'raw'
     if source is not None:
-        cell.source = unicode(source)
+        cell.source = unicode_type(source)
     if rendered is not None:
-        cell.rendered = unicode(rendered)
+        cell.rendered = unicode_type(rendered)
     cell.metadata = NotebookNode(metadata or {})
     cell.cell_type = cell_type
     return cell
@@ -143,9 +144,9 @@ def new_heading_cell(source=None, rendered=None, level=1, metadata=None):
     cell = NotebookNode()
     cell.cell_type = u'heading'
     if source is not None:
-        cell.source = unicode(source)
+        cell.source = unicode_type(source)
     if rendered is not None:
-        cell.rendered = unicode(rendered)
+        cell.rendered = unicode_type(rendered)
     cell.level = int(level)
     cell.metadata = NotebookNode(metadata or {})
     return cell
@@ -155,7 +156,7 @@ def new_worksheet(name=None, cells=None, metadata=None):
     """Create a worksheet by name with with a list of cells."""
     ws = NotebookNode()
     if name is not None:
-        ws.name = unicode(name)
+        ws.name = unicode_type(name)
     if cells is None:
         ws.cells = []
     else:
@@ -178,7 +179,7 @@ def new_notebook(name=None, metadata=None, worksheets=None):
     else:
         nb.metadata = NotebookNode(metadata)
     if name is not None:
-        nb.metadata.name = unicode(name)
+        nb.metadata.name = unicode_type(name)
     return nb
 
 
@@ -187,29 +188,29 @@ def new_metadata(name=None, authors=None, license=None, created=None,
     """Create a new metadata node."""
     metadata = NotebookNode()
     if name is not None:
-        metadata.name = unicode(name)
+        metadata.name = unicode_type(name)
     if authors is not None:
         metadata.authors = list(authors)
     if created is not None:
-        metadata.created = unicode(created)
+        metadata.created = unicode_type(created)
     if modified is not None:
-        metadata.modified = unicode(modified)
+        metadata.modified = unicode_type(modified)
     if license is not None:
-        metadata.license = unicode(license)
+        metadata.license = unicode_type(license)
     if gistid is not None:
-        metadata.gistid = unicode(gistid)
+        metadata.gistid = unicode_type(gistid)
     return metadata
 
 def new_author(name=None, email=None, affiliation=None, url=None):
     """Create a new author."""
     author = NotebookNode()
     if name is not None:
-        author.name = unicode(name)
+        author.name = unicode_type(name)
     if email is not None:
-        author.email = unicode(email)
+        author.email = unicode_type(email)
     if affiliation is not None:
-        author.affiliation = unicode(affiliation)
+        author.affiliation = unicode_type(affiliation)
     if url is not None:
-        author.url = unicode(url)
+        author.url = unicode_type(url)
     return author
 

--- a/IPython/nbformat/v3/nbpy.py
+++ b/IPython/nbformat/v3/nbpy.py
@@ -23,6 +23,8 @@ from .nbbase import (
     new_notebook, new_heading_cell, nbformat, nbformat_minor,
 )
 
+from IPython.utils.py3compat import unicode_type
+
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
@@ -190,7 +192,7 @@ class PyWriter(NotebookWriter):
                         lines.extend([u'# ' + line for line in input.splitlines()])
                         lines.append(u'')
         lines.append('')
-        return unicode('\n'.join(lines))
+        return unicode_type('\n'.join(lines))
 
 
 _reader = PyReader()

--- a/IPython/nbformat/v3/rwbase.py
+++ b/IPython/nbformat/v3/rwbase.py
@@ -20,8 +20,7 @@ from base64 import encodestring, decodestring
 import pprint
 
 from IPython.utils import py3compat
-
-str_to_bytes = py3compat.str_to_bytes
+from IPython.utils.py3compat import string_types, unicode_type, str_to_bytes
 
 #-----------------------------------------------------------------------------
 # Code
@@ -101,17 +100,17 @@ def split_lines(nb):
     for ws in nb.worksheets:
         for cell in ws.cells:
             if cell.cell_type == 'code':
-                if 'input' in cell and isinstance(cell.input, basestring):
+                if 'input' in cell and isinstance(cell.input, string_types):
                     cell.input = cell.input.splitlines(True)
                 for output in cell.outputs:
                     for key in _multiline_outputs:
                         item = output.get(key, None)
-                        if isinstance(item, basestring):
+                        if isinstance(item, string_types):
                             output[key] = item.splitlines(True)
             else: # text, heading cell
                 for key in ['source', 'rendered']:
                     item = cell.get(key, None)
-                    if isinstance(item, basestring):
+                    if isinstance(item, string_types):
                         cell[key] = item.splitlines(True)
     return nb
 
@@ -128,11 +127,11 @@ def base64_decode(nb):
             if cell.cell_type == 'code':
                 for output in cell.outputs:
                     if 'png' in output:
-                        if isinstance(output.png, unicode):
+                        if isinstance(output.png, unicode_type):
                             output.png = output.png.encode('ascii')
                         output.png = decodestring(output.png)
                     if 'jpeg' in output:
-                        if isinstance(output.jpeg, unicode):
+                        if isinstance(output.jpeg, unicode_type):
                             output.jpeg = output.jpeg.encode('ascii')
                         output.jpeg = decodestring(output.jpeg)
     return nb

--- a/IPython/nbformat/v3/tests/test_nbpy.py
+++ b/IPython/nbformat/v3/tests/test_nbpy.py
@@ -8,6 +8,8 @@ from .. import nbpy
 from .nbexamples import nb0, nb0_py
 import six
 
+from IPython.utils.py3compat import string_types
+
 
 class TestPy(formattest.NBFormatTest, TestCase):
 
@@ -32,7 +34,7 @@ class TestPy(formattest.NBFormatTest, TestCase):
             for a,b in zip(da, db):
                 self.assertSubset(a,b)
         else:
-            if isinstance(da, basestring) and isinstance(db, basestring):
+            if isinstance(da, string_types) and isinstance(db, string_types):
                 # pyfile is not sensitive to preserving leading/trailing
                 # newlines in blocks through roundtrip
                 da = da.strip('\n')

--- a/IPython/nbformat/v3/tests/test_nbpy.py
+++ b/IPython/nbformat/v3/tests/test_nbpy.py
@@ -6,6 +6,7 @@ from . import formattest
 
 from .. import nbpy
 from .nbexamples import nb0, nb0_py
+import six
 
 
 class TestPy(formattest.NBFormatTest, TestCase):
@@ -22,7 +23,7 @@ class TestPy(formattest.NBFormatTest, TestCase):
         elements.
         """
         if isinstance(da, dict):
-            for k,v in da.iteritems():
+            for k,v in six.iteritems(da):
                 if k in self.ignored_keys:
                     continue
                 self.assertTrue(k in db)

--- a/IPython/nbformat/v3/validator.py
+++ b/IPython/nbformat/v3/validator.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #!/usr/bin/env python
 # -*- coding: utf8 -*-
 
@@ -6,6 +7,7 @@ import IPython.external.jsonpointer as jsonpointer
 from IPython.external import argparse
 import traceback
 import json
+import six
 
 def nbvalidate(nbjson, schema='v3.withref.json', key=None,verbose=True):
     v3schema = resolve_ref(json.load(open(schema,'r')))
@@ -34,7 +36,7 @@ def resolve_ref(json, base=None):
             temp.append(resolve_ref(item, base=base))
     elif type(json) is dict:
         temp = {};
-        for key,value in json.iteritems():
+        for key,value in six.iteritems(json):
             if key == '$ref':
                 return resolve_ref(jsonpointer.resolve_pointer(base,value), base=base)
             else :
@@ -79,10 +81,10 @@ if __name__ == '__main__':
                             key=args.key,
                             verbose=args.verbose)
         if nerror is 0:
-            print u"[Pass]",name
+            print(u"[Pass]",name)
         else :
-            print u"[    ]",name,'(%d)'%(nerror)
+            print(u"[    ]",name,'(%d)'%(nerror))
         if args.verbose :
-            print '=================================================='
+            print('==================================================')
 
 

--- a/IPython/parallel/apps/baseapp.py
+++ b/IPython/parallel/apps/baseapp.py
@@ -38,10 +38,10 @@ from IPython.core.application import (
     base_flags as base_ip_flags
 )
 from IPython.utils.path import expand_path
+from IPython.utils.py3compat import unicode_type
 
 from IPython.utils.traitlets import Unicode, Bool, Instance, Dict, List
 from six.moves import map
-from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Module errors
@@ -113,7 +113,7 @@ class BaseParallelApplication(BaseIPythonApplication):
         help='Set the working dir for the process.'
     )
     def _work_dir_changed(self, name, old, new):
-        self.work_dir = unicode(expand_path(new))
+        self.work_dir = unicode_type(expand_path(new))
 
     log_to_file = Bool(config=True,
         help="whether to log to a file")
@@ -160,7 +160,7 @@ class BaseParallelApplication(BaseIPythonApplication):
         
     def to_work_dir(self):
         wd = self.work_dir
-        if unicode(wd) != os.getcwdu():
+        if unicode_type(wd) != os.getcwdu():
             os.chdir(wd)
             self.log.info("Changing to working dir: %s" % wd)
         # This is the working dir by now.

--- a/IPython/parallel/apps/baseapp.py
+++ b/IPython/parallel/apps/baseapp.py
@@ -40,6 +40,8 @@ from IPython.core.application import (
 from IPython.utils.path import expand_path
 
 from IPython.utils.traitlets import Unicode, Bool, Instance, Dict, List
+from six.moves import map
+from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Module errors

--- a/IPython/parallel/apps/ipclusterapp.py
+++ b/IPython/parallel/apps/ipclusterapp.py
@@ -9,6 +9,7 @@ Authors:
 * MinRK
 
 """
+from __future__ import print_function
 
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2008-2011  The IPython Development Team
@@ -595,8 +596,8 @@ class IPClusterApp(BaseIPythonApplication):
 
     def start(self):
         if self.subapp is None:
-            print "No subcommand specified. Must specify one of: %s"%(self.subcommands.keys())
-            print
+            print("No subcommand specified. Must specify one of: %s"%(self.subcommands.keys()))
+            print()
             self.print_description()
             self.print_subcommands()
             self.exit(1)

--- a/IPython/parallel/apps/ipclusterapp.py
+++ b/IPython/parallel/apps/ipclusterapp.py
@@ -38,6 +38,7 @@ from IPython.core.application import BaseIPythonApplication
 from IPython.core.profiledir import ProfileDir
 from IPython.utils.daemonize import daemonize
 from IPython.utils.importstring import import_item
+from IPython.utils.py3compat import string_types
 from IPython.utils.sysinfo import num_cpus
 from IPython.utils.traitlets import (Integer, Unicode, Bool, CFloat, Dict, List, Any,
                                         DottedObjectName)
@@ -258,7 +259,7 @@ class IPClusterEngines(BaseParallelApplication):
 
     engine_launcher = Any(config=True, help="Deprecated, use engine_launcher_class")
     def _engine_launcher_changed(self, name, old, new):
-        if isinstance(new, basestring):
+        if isinstance(new, string_types):
             self.log.warn("WARNING: %s.engine_launcher is deprecated as of 0.12,"
                     " use engine_launcher_class" % self.__class__.__name__)
             self.engine_launcher_class = new
@@ -462,7 +463,7 @@ class IPClusterStart(IPClusterEngines):
 
     controller_launcher = Any(config=True, help="Deprecated, use controller_launcher_class")
     def _controller_launcher_changed(self, name, old, new):
-        if isinstance(new, basestring):
+        if isinstance(new, string_types):
             # old 0.11-style config
             self.log.warn("WARNING: %s.controller_launcher is deprecated as of 0.12,"
                     " use controller_launcher_class" % self.__class__.__name__)

--- a/IPython/parallel/apps/ipcontrollerapp.py
+++ b/IPython/parallel/apps/ipcontrollerapp.py
@@ -482,7 +482,7 @@ class IPControllerApp(BaseParallelApplication):
         for s in statements:
             try:
                 self.log.msg("Executing statement: '%s'" % s)
-                exec s in globals(), locals()
+                exec(s, globals(), locals())
             except:
                 self.log.msg("Error running statement: %s" % s)
 

--- a/IPython/parallel/apps/ipengineapp.py
+++ b/IPython/parallel/apps/ipengineapp.py
@@ -364,7 +364,7 @@ class IPEngineApp(BaseParallelApplication):
             try:
                 self.log.info("Initializing MPI:")
                 self.log.info(mpi_import_statement)
-                exec mpi_import_statement in globals()
+                exec(mpi_import_statement, globals())
             except:
                 mpi = None
         else:

--- a/IPython/parallel/apps/launcher.py
+++ b/IPython/parallel/apps/launcher.py
@@ -30,6 +30,9 @@ import time
 # signal imports, handling various platforms, versions
 
 from signal import SIGINT, SIGTERM
+import six
+from six.moves import map
+from six.moves import zip
 try:
     from signal import SIGKILL
 except ImportError:
@@ -404,14 +407,14 @@ class LocalEngineSetLauncher(LocalEngineLauncher):
 
     def signal(self, sig):
         dlist = []
-        for el in self.launchers.itervalues():
+        for el in six.itervalues(self.launchers):
             d = el.signal(sig)
             dlist.append(d)
         return dlist
 
     def interrupt_then_kill(self, delay=1.0):
         dlist = []
-        for el in self.launchers.itervalues():
+        for el in six.itervalues(self.launchers):
             d = el.interrupt_then_kill(delay)
             dlist.append(d)
         return dlist
@@ -421,7 +424,7 @@ class LocalEngineSetLauncher(LocalEngineLauncher):
 
     def _notice_engine_stopped(self, data):
         pid = data['pid']
-        for idx,el in self.launchers.iteritems():
+        for idx,el in six.iteritems(self.launchers):
             if el.process.pid == pid:
                 break
         self.launchers.pop(idx)
@@ -742,7 +745,7 @@ class SSHEngineSetLauncher(LocalEngineSetLauncher):
     def engine_count(self):
         """determine engine count from `engines` dict"""
         count = 0
-        for n in self.engines.itervalues():
+        for n in six.itervalues(self.engines):
             if isinstance(n, (tuple,list)):
                 n,args = n
             count += n
@@ -754,7 +757,7 @@ class SSHEngineSetLauncher(LocalEngineSetLauncher):
         """
 
         dlist = []
-        for host, n in self.engines.iteritems():
+        for host, n in six.iteritems(self.engines):
             if isinstance(n, (tuple, list)):
                 n, args = n
             else:

--- a/IPython/parallel/apps/launcher.py
+++ b/IPython/parallel/apps/launcher.py
@@ -32,7 +32,6 @@ import time
 from signal import SIGINT, SIGTERM
 import six
 from six.moves import map
-from six.moves import zip
 try:
     from signal import SIGKILL
 except ImportError:

--- a/IPython/parallel/apps/win32support.py
+++ b/IPython/parallel/apps/win32support.py
@@ -39,10 +39,10 @@ class ForwarderThread(Thread):
         """Loop through lines in self.fd, and send them over self.sock."""
         line = self.fd.readline()
         # allow for files opened in unicode mode
-        if isinstance(line, unicode):
-            send = self.sock.send_unicode
-        else:
+        if isinstance(line, bytes):
             send = self.sock.send
+        else:
+            send = self.sock.send_unicode
         while line:
             send(line)
             line = self.fd.readline()

--- a/IPython/parallel/apps/winhpcjob.py
+++ b/IPython/parallel/apps/winhpcjob.py
@@ -32,6 +32,7 @@ from IPython.utils.traitlets import (
     Unicode, Integer, List, Instance,
     Enum, Bool
 )
+import six
 
 #-----------------------------------------------------------------------------
 # Job and Task classes
@@ -215,7 +216,7 @@ class WinHPCTask(Configurable):
 
     def get_env_vars(self):
         env_vars = ET.Element('EnvironmentVariables')
-        for k, v in self.environment_variables.iteritems():
+        for k, v in six.iteritems(self.environment_variables):
             variable = ET.SubElement(env_vars, "Variable")
             name = ET.SubElement(variable, "Name")
             name.text = k

--- a/IPython/parallel/client/asyncresult.py
+++ b/IPython/parallel/client/asyncresult.py
@@ -705,6 +705,6 @@ class AsyncHubResult(AsyncResult):
             else:
                 self._success = True
             finally:
-                self._metadata = map(self._client.metadata.get, self.msg_ids)
+                self._metadata = list(map(self._client.metadata.get, self.msg_ids))
 
 __all__ = ['AsyncResult', 'AsyncMapResult', 'AsyncHubResult']

--- a/IPython/parallel/client/asyncresult.py
+++ b/IPython/parallel/client/asyncresult.py
@@ -26,6 +26,9 @@ from zmq import MessageTracker
 from IPython.core.display import clear_output, display, display_pretty
 from IPython.external.decorator import decorator
 from IPython.parallel import error
+from six.moves import filter
+from six.moves import map
+from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Functions

--- a/IPython/parallel/client/asyncresult.py
+++ b/IPython/parallel/client/asyncresult.py
@@ -146,7 +146,7 @@ class AsyncResult(object):
         self._ready = self._client.wait(self.msg_ids, timeout)
         if self._ready:
             try:
-                results = map(self._client.results.get, self.msg_ids)
+                results = list(map(self._client.results.get, self.msg_ids))
                 self._result = results
                 if self._single_result:
                     r = results[0]
@@ -672,10 +672,10 @@ class AsyncHubResult(AsyncResult):
         start = time.time()
         if self._ready:
             return
-        local_ids = filter(lambda msg_id: msg_id in self._client.outstanding, self.msg_ids)
+        local_ids = [m for m in self.msg_ids if m in self._client.outstanding]
         local_ready = self._client.wait(local_ids, timeout)
         if local_ready:
-            remote_ids = filter(lambda msg_id: msg_id not in self._client.results, self.msg_ids)
+            remote_ids = [m for m in self.msg_ids if m not in self._client.results]
             if not remote_ids:
                 self._ready = True
             else:
@@ -690,7 +690,7 @@ class AsyncHubResult(AsyncResult):
                     self._ready = True
         if self._ready:
             try:
-                results = map(self._client.results.get, self.msg_ids)
+                results = list(map(self._client.results.get, self.msg_ids))
                 self._result = results
                 if self._single_result:
                     r = results[0]

--- a/IPython/parallel/client/asyncresult.py
+++ b/IPython/parallel/client/asyncresult.py
@@ -26,6 +26,7 @@ from zmq import MessageTracker
 from IPython.core.display import clear_output, display, display_pretty
 from IPython.external.decorator import decorator
 from IPython.parallel import error
+from IPython.utils.py3compat import string_types
 from six.moves import filter
 from six.moves import map
 from six.moves import zip
@@ -64,7 +65,7 @@ class AsyncResult(object):
     _single_result = False
 
     def __init__(self, client, msg_ids, fname='unknown', targets=None, tracker=None):
-        if isinstance(msg_ids, basestring):
+        if isinstance(msg_ids, string_types):
             # always a list
             msg_ids = [msg_ids]
             self._single_result = True
@@ -257,7 +258,7 @@ class AsyncResult(object):
         elif isinstance(key, slice):
             self._check_ready()
             return error.collect_exceptions(self._result[key], self._fname)
-        elif isinstance(key, basestring):
+        elif isinstance(key, string_types):
             # metadata proxy *does not* require that results are done
             self.wait(0)
             values = [ md[key] for md in self._metadata ]

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -4,6 +4,7 @@ Authors:
 
 * MinRK
 """
+from __future__ import print_function
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2010-2011  The IPython Development Team
 #
@@ -24,6 +25,10 @@ import warnings
 from datetime import datetime
 from getpass import getpass
 from pprint import pprint
+import six
+from six.moves import filter
+from six.moves import map
+from six.moves import zip
 
 pjoin = os.path.join
 
@@ -199,21 +204,21 @@ class Metadata(dict):
 
     def __getattr__(self, key):
         """getattr aliased to getitem"""
-        if key in self.iterkeys():
+        if key in six.iterkeys(self):
             return self[key]
         else:
             raise AttributeError(key)
 
     def __setattr__(self, key, value):
         """setattr aliased to setitem, with strict"""
-        if key in self.iterkeys():
+        if key in six.iterkeys(self):
             self[key] = value
         else:
             raise AttributeError(key)
 
     def __setitem__(self, key, value):
         """strict static key enforcement"""
-        if key in self.iterkeys():
+        if key in six.iterkeys(self):
             dict.__setitem__(self, key, value)
         else:
             raise KeyError(key)
@@ -533,13 +538,13 @@ class Client(HasTraits):
 
     def _update_engines(self, engines):
         """Update our engines dict and _ids from a dict of the form: {id:uuid}."""
-        for k,v in engines.iteritems():
+        for k,v in six.iteritems(engines):
             eid = int(k)
             if eid not in self._engines:
                 self._ids.append(eid)
             self._engines[eid] = v
         self._ids = sorted(self._ids)
-        if sorted(self._engines.keys()) != range(len(self._engines)) and \
+        if sorted(self._engines.keys()) != list(range(len(self._engines))) and \
                         self._task_scheme == 'pure' and self._task_socket:
             self._stop_scheduling_tasks()
 
@@ -580,7 +585,7 @@ class Client(HasTraits):
             targets = [targets]
 
         if isinstance(targets, slice):
-            indices = range(len(self._ids))[targets]
+            indices = list(range(len(self._ids)))[targets]
             ids = self.ids
             targets = [ ids[i] for i in indices ]
 
@@ -734,9 +739,9 @@ class Client(HasTraits):
         msg_id = parent['msg_id']
         if msg_id not in self.outstanding:
             if msg_id in self.history:
-                print ("got stale result: %s"%msg_id)
+                print(("got stale result: %s"%msg_id))
             else:
-                print ("got unknown result: %s"%msg_id)
+                print(("got unknown result: %s"%msg_id))
         else:
             self.outstanding.remove(msg_id)
 
@@ -770,11 +775,11 @@ class Client(HasTraits):
         msg_id = parent['msg_id']
         if msg_id not in self.outstanding:
             if msg_id in self.history:
-                print ("got stale result: %s"%msg_id)
-                print self.results[msg_id]
-                print msg
+                print(("got stale result: %s"%msg_id))
+                print(self.results[msg_id])
+                print(msg)
             else:
-                print ("got unknown result: %s"%msg_id)
+                print(("got unknown result: %s"%msg_id))
         else:
             self.outstanding.remove(msg_id)
         content = msg['content']

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -44,7 +44,7 @@ from IPython.utils.coloransi import TermColors
 from IPython.utils.jsonutil import rekey
 from IPython.utils.localinterfaces import LOCALHOST, LOCAL_IPS
 from IPython.utils.path import get_ipython_dir
-from IPython.utils.py3compat import cast_bytes
+from IPython.utils.py3compat import cast_bytes, string_types
 from IPython.utils.traitlets import (HasTraits, Integer, Instance, Unicode,
                                     Dict, List, Bool, Set, Any)
 from IPython.external.decorator import decorator
@@ -572,7 +572,7 @@ class Client(HasTraits):
 
         if targets is None:
             targets = self._ids
-        elif isinstance(targets, basestring):
+        elif isinstance(targets, string_types):
             if targets.lower() == 'all':
                 targets = self._ids
             else:
@@ -1058,7 +1058,7 @@ class Client(HasTraits):
         if jobs is None:
             theids = self.outstanding
         else:
-            if isinstance(jobs, (int, basestring, AsyncResult)):
+            if isinstance(jobs, string_types + (int, AsyncResult)):
                 jobs = [jobs]
             theids = set()
             for job in jobs:
@@ -1126,9 +1126,9 @@ class Client(HasTraits):
         targets = self._build_targets(targets)[0]
         
         msg_ids = []
-        if isinstance(jobs, (basestring,AsyncResult)):
+        if isinstance(jobs, string_types + (AsyncResult,)):
             jobs = [jobs]
-        bad_ids = filter(lambda obj: not isinstance(obj, (basestring, AsyncResult)), jobs)
+        bad_ids = filter(lambda obj: not isinstance(obj, string_types + (AsyncResult,)), jobs)
         if bad_ids:
             raise TypeError("Invalid msg_id type %r, expected str or AsyncResult"%bad_ids[0])
         for j in jobs:
@@ -1279,7 +1279,7 @@ class Client(HasTraits):
         metadata = metadata if metadata is not None else {}
 
         # validate arguments
-        if not isinstance(code, basestring):
+        if not isinstance(code, string_types):
             raise TypeError("code must be text, not %s" % type(code))
         if not isinstance(metadata, dict):
             raise TypeError("metadata must be dict, not %s" % type(metadata))
@@ -1407,7 +1407,7 @@ class Client(HasTraits):
         for id in indices_or_msg_ids:
             if isinstance(id, int):
                 id = self.history[id]
-            if not isinstance(id, basestring):
+            if not isinstance(id, string_types):
                 raise TypeError("indices must be str or int, not %r"%id)
             theids.append(id)
 
@@ -1462,7 +1462,7 @@ class Client(HasTraits):
         for id in indices_or_msg_ids:
             if isinstance(id, int):
                 id = self.history[id]
-            if not isinstance(id, basestring):
+            if not isinstance(id, string_types):
                 raise TypeError("indices must be str or int, not %r"%id)
             theids.append(id)
 
@@ -1519,7 +1519,7 @@ class Client(HasTraits):
         for msg_id in msg_ids:
             if isinstance(msg_id, int):
                 msg_id = self.history[msg_id]
-            if not isinstance(msg_id, basestring):
+            if not isinstance(msg_id, string_types):
                 raise TypeError("msg_ids must be str, not %r"%msg_id)
             theids.append(msg_id)
 
@@ -1644,9 +1644,9 @@ class Client(HasTraits):
         if not jobs:
             return []
         msg_ids = []
-        if isinstance(jobs, (basestring,AsyncResult)):
+        if isinstance(jobs, string_types + (AsyncResult,)):
             jobs = [jobs]
-        bad_ids = filter(lambda obj: not isinstance(obj, (basestring, AsyncResult)), jobs)
+        bad_ids = filter(lambda obj: not isinstance(obj, string_types + (AsyncResult,)), jobs)
         if bad_ids:
             raise TypeError("Invalid msg_id type %r, expected str or AsyncResult"%bad_ids[0])
         for j in jobs:
@@ -1818,7 +1818,7 @@ class Client(HasTraits):
             The subset of keys to be returned.  The default is to fetch everything but buffers.
             'msg_id' will *always* be included.
         """
-        if isinstance(keys, basestring):
+        if isinstance(keys, string_types):
             keys = [keys]
         content = dict(query=query, keys=keys)
         self.session.send(self._query_socket, "db_request", content=content)

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -1066,7 +1066,7 @@ class Client(HasTraits):
                     # index access
                     job = self.history[job]
                 elif isinstance(job, AsyncResult):
-                    map(theids.add, job.msg_ids)
+                    for id in job.msg_ids: theids.add(id)
                     continue
                 theids.add(job)
         if not theids.intersection(self.outstanding):
@@ -1697,8 +1697,9 @@ class Client(HasTraits):
             msg_ids = []
             msg_ids.extend(self._build_msgids_from_target(targets))
             msg_ids.extend(self._build_msgids_from_jobs(jobs))
-            map(self.results.pop, msg_ids)
-            map(self.metadata.pop, msg_ids)
+            for id in msg_ids:
+                self.results.pop(id)
+                self.metadata.pop(id)
 
 
     @spin_first

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -28,7 +28,6 @@ from pprint import pprint
 import six
 from six.moves import filter
 from six.moves import map
-from six.moves import zip
 
 pjoin = os.path.join
 
@@ -204,21 +203,21 @@ class Metadata(dict):
 
     def __getattr__(self, key):
         """getattr aliased to getitem"""
-        if key in six.iterkeys(self):
+        if key in self:
             return self[key]
         else:
             raise AttributeError(key)
 
     def __setattr__(self, key, value):
         """setattr aliased to setitem, with strict"""
-        if key in six.iterkeys(self):
+        if key in self:
             self[key] = value
         else:
             raise AttributeError(key)
 
     def __setitem__(self, key, value):
         """strict static key enforcement"""
-        if key in six.iterkeys(self):
+        if key in self:
             dict.__setitem__(self, key, value)
         else:
             raise KeyError(key)

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -1128,7 +1128,7 @@ class Client(HasTraits):
         msg_ids = []
         if isinstance(jobs, string_types + (AsyncResult,)):
             jobs = [jobs]
-        bad_ids = filter(lambda obj: not isinstance(obj, string_types + (AsyncResult,)), jobs)
+        bad_ids = [obj for obj in jobs if not isinstance(obj, string_types + (AsyncResult,))]
         if bad_ids:
             raise TypeError("Invalid msg_id type %r, expected str or AsyncResult"%bad_ids[0])
         for j in jobs:
@@ -1411,8 +1411,8 @@ class Client(HasTraits):
                 raise TypeError("indices must be str or int, not %r"%id)
             theids.append(id)
 
-        local_ids = filter(lambda msg_id: msg_id in self.outstanding or msg_id in self.results, theids)
-        remote_ids = filter(lambda msg_id: msg_id not in local_ids, theids)
+        local_ids = [msg_id for msg_id in theids if (msg_id in self.outstanding or msg_id in self.results)]
+        remote_ids = [msg_id for msg_id in theids if msg_id not in local_ids]
         
         # given single msg_id initially, get_result shot get the result itself,
         # not a length-one list
@@ -1637,7 +1637,7 @@ class Client(HasTraits):
         if not targets: # needed as _build_targets otherwise uses all engines
             return []
         target_ids = self._build_targets(targets)[0] 
-        return filter(lambda md_id: self.metadata[md_id]["engine_uuid"] in target_ids, self.metadata)
+        return [md_id for md_id in self.metadata if self.metadata[md_id]["engine_uuid"] in target_ids]
     
     def _build_msgids_from_jobs(self, jobs=None):
         """Build a list of msg_ids from "jobs" """
@@ -1646,7 +1646,7 @@ class Client(HasTraits):
         msg_ids = []
         if isinstance(jobs, string_types + (AsyncResult,)):
             jobs = [jobs]
-        bad_ids = filter(lambda obj: not isinstance(obj, string_types + (AsyncResult,)), jobs)
+        bad_ids = [obj for obj in jobs if not isinstance(obj, string_types + (AsyncResult,))]
         if bad_ids:
             raise TypeError("Invalid msg_id type %r, expected str or AsyncResult"%bad_ids[0])
         for j in jobs:

--- a/IPython/parallel/client/magics.py
+++ b/IPython/parallel/client/magics.py
@@ -26,6 +26,7 @@ Usage
 {CONFIG_DOC}
 
 """
+from __future__ import print_function
 
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2008 The IPython Development Team
@@ -251,7 +252,7 @@ class ParallelMagics(Magics):
         else:
             str_targets = str(targets)
         if self.verbose:
-            print base + " execution on engine(s): %s" % str_targets
+            print(base + " execution on engine(s): %s" % str_targets)
         
         result = self.view.execute(cell, silent=False, block=False)
         self.last_result = result
@@ -358,7 +359,7 @@ class ParallelMagics(Magics):
         self.shell.run_cell = self.pxrun_cell
 
         self._autopx = True
-        print "%autopx enabled"
+        print("%autopx enabled")
 
     def _disable_autopx(self):
         """Disable %autopx by restoring the original InteractiveShell.run_cell.
@@ -366,7 +367,7 @@ class ParallelMagics(Magics):
         if self._autopx:
             self.shell.run_cell = self._original_run_cell
             self._autopx = False
-            print "%autopx disabled"
+            print("%autopx disabled")
 
     def pxrun_cell(self, raw_cell, store_history=False, silent=False):
         """drop-in replacement for InteractiveShell.run_cell.

--- a/IPython/parallel/client/map.py
+++ b/IPython/parallel/client/map.py
@@ -100,7 +100,7 @@ class Map(object):
             if isinstance(testObject, m['type']):
                 return m['module'].concatenate(listOfPartitions)
         # Next try for Python sequence types
-        if isinstance(testObject, (types.ListType, types.TupleType)):
+        if isinstance(testObject, (list, tuple)):
             return utils_flatten(listOfPartitions)
         # If we have scalars, just return listOfPartitions
         return listOfPartitions
@@ -122,7 +122,7 @@ class RoundRobinMap(Map):
             #print m
             if isinstance(testObject, m['type']):
                 return self.flatten_array(m['type'], listOfPartitions)
-        if isinstance(testObject, (types.ListType, types.TupleType)):
+        if isinstance(testObject, (list, tuple)):
             return self.flatten_list(listOfPartitions)
         return listOfPartitions
     

--- a/IPython/parallel/client/remotefunction.py
+++ b/IPython/parallel/client/remotefunction.py
@@ -17,6 +17,7 @@ Authors:
 #-----------------------------------------------------------------------------
 
 from __future__ import division
+from __future__ import print_function
 
 import sys
 import warnings
@@ -26,6 +27,7 @@ from IPython.testing.skipdoctest import skip_doctest
 
 from . import map as Map
 from .asyncresult import AsyncMapResult
+from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Functions and Decorators
@@ -89,7 +91,7 @@ def sync_view_results(f, self, *args, **kwargs):
     view = self.view
     if view._in_sync_results:
         return f(self, *args, **kwargs)
-    print 'in sync results', f
+    print('in sync results', f)
     view._in_sync_results = True
     try:
         ret = f(self, *args, **kwargs)

--- a/IPython/parallel/client/view.py
+++ b/IPython/parallel/client/view.py
@@ -53,7 +53,7 @@ def save_ids(f, self, *args, **kwargs):
         nmsgs = len(self.client.history) - n_previous
         msg_ids = self.client.history[-nmsgs:]
         self.history.extend(msg_ids)
-        map(self.outstanding.add, msg_ids)
+        self.outstanding.update(msg_ids)
     return ret
 
 @decorator

--- a/IPython/parallel/client/view.py
+++ b/IPython/parallel/client/view.py
@@ -4,6 +4,7 @@ Authors:
 
 * Min RK
 """
+from __future__ import print_function
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2010-2011  The IPython Development Team
 #
@@ -35,6 +36,9 @@ from IPython.parallel.controller.dependency import Dependency, dependent
 from . import map as Map
 from .asyncresult import AsyncResult, AsyncMapResult
 from .remotefunction import ParallelFunction, parallel, remote, getname
+import six
+from six.moves import map
+from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Decorators
@@ -162,7 +166,7 @@ class View(HasTraits):
             safely edit after arrays and buffers during non-copying
             sends.
         """
-        for name, value in kwargs.iteritems():
+        for name, value in six.iteritems(kwargs):
             if name not in self._flag_names:
                 raise KeyError("Invalid name: %r"%name)
             else:
@@ -482,9 +486,9 @@ class DirectView(View):
                 modules.add(key)
                 if not quiet:
                     if fromlist:
-                        print "importing %s from %s on engine(s)"%(','.join(fromlist), name)
+                        print("importing %s from %s on engine(s)"%(','.join(fromlist), name))
                     else:
-                        print "importing %s on engine(s)"%name
+                        print("importing %s on engine(s)"%name)
                 results.append(self.apply_async(remote_import, name, fromlist, level))
             # restore override
             __builtin__.__import__ = save_import
@@ -830,7 +834,7 @@ class DirectView(View):
             # This is injected into __builtins__.
             ip = get_ipython()
         except NameError:
-            print "The IPython parallel magics (%px, etc.) only work within IPython."
+            print("The IPython parallel magics (%px, etc.) only work within IPython.")
             return
         
         M = ParallelMagics(ip, self, suffix)

--- a/IPython/parallel/controller/dependency.py
+++ b/IPython/parallel/controller/dependency.py
@@ -55,7 +55,11 @@ class dependent(object):
 
     def __init__(self, f, df, *dargs, **dkwargs):
         self.f = f
-        self.__name__ = getattr(f, '__name__', 'f')
+        name = getattr(f, '__name__', 'f')
+        if py3compat.PY3:
+            self.__name__ = name
+        else:
+            self.func_name = name
         self.df = df
         self.dargs = dargs
         self.dkwargs = dkwargs
@@ -70,7 +74,7 @@ class dependent(object):
     if not py3compat.PY3:
         @property
         def __name__(self):
-            return self.__name__
+            return self.func_name
 
 @interactive
 def _require(*modules, **mapping):

--- a/IPython/parallel/controller/dependency.py
+++ b/IPython/parallel/controller/dependency.py
@@ -55,7 +55,7 @@ class dependent(object):
 
     def __init__(self, f, df, *dargs, **dkwargs):
         self.f = f
-        self.func_name = getattr(f, '__name__', 'f')
+        self.__name__ = getattr(f, '__name__', 'f')
         self.df = df
         self.dargs = dargs
         self.dkwargs = dkwargs
@@ -70,7 +70,7 @@ class dependent(object):
     if not py3compat.PY3:
         @property
         def __name__(self):
-            return self.func_name
+            return self.__name__
 
 @interactive
 def _require(*modules, **mapping):
@@ -80,7 +80,7 @@ def _require(*modules, **mapping):
     user_ns = globals()
     for name in modules:
         try:
-            exec 'import %s' % name in user_ns
+            exec('import %s' % name, user_ns)
         except ImportError:
             raise UnmetDependency(name)
             

--- a/IPython/parallel/controller/dependency.py
+++ b/IPython/parallel/controller/dependency.py
@@ -117,7 +117,7 @@ def require(*objects, **mapping):
         if isinstance(obj, ModuleType):
             obj = obj.__name__
         
-        if isinstance(obj, basestring):
+        if isinstance(obj, py3compat.string_types):
             names.append(obj)
         elif hasattr(obj, '__name__'):
             mapping[obj.__name__] = obj
@@ -165,10 +165,10 @@ class Dependency(set):
         ids = []
         
         # extract ids from various sources:
-        if isinstance(dependencies, (basestring, AsyncResult)):
+        if isinstance(dependencies, py3compat.string_types + (AsyncResult,)):
             dependencies = [dependencies]
         for d in dependencies:
-            if isinstance(d, basestring):
+            if isinstance(d, py3compat.string_types):
                 ids.append(d)
             elif isinstance(d, AsyncResult):
                 ids.extend(d.msg_ids)

--- a/IPython/parallel/controller/dictdb.py
+++ b/IPython/parallel/controller/dictdb.py
@@ -52,6 +52,7 @@ from datetime import datetime
 from IPython.config.configurable import LoggingConfigurable
 
 from IPython.utils.traitlets import Dict, Unicode, Integer, Float
+import six
 
 filters = {
  '$lt' : lambda a,b: a < b,
@@ -74,7 +75,7 @@ class CompositeFilter(object):
     def __init__(self, dikt):
         self.tests = []
         self.values = []
-        for key, value in dikt.iteritems():
+        for key, value in six.iteritems(dikt):
             self.tests.append(filters[key])
             self.values.append(value)
 
@@ -131,7 +132,7 @@ class DictDB(BaseDB):
 
     def _match_one(self, rec, tests):
         """Check if a specific record matches tests."""
-        for key,test in tests.iteritems():
+        for key,test in six.iteritems(tests):
             if not test(rec.get(key, None)):
                 return False
         return True
@@ -140,13 +141,13 @@ class DictDB(BaseDB):
         """Find all the matches for a check dict."""
         matches = []
         tests = {}
-        for k,v in check.iteritems():
+        for k,v in six.iteritems(check):
             if isinstance(v, dict):
                 tests[k] = CompositeFilter(v)
             else:
                 tests[k] = lambda o: o==v
 
-        for rec in self._records.itervalues():
+        for rec in six.itervalues(self._records):
             if self._match_one(rec, tests):
                 matches.append(copy(rec))
         return matches

--- a/IPython/parallel/controller/heartmonitor.py
+++ b/IPython/parallel/controller/heartmonitor.py
@@ -28,7 +28,6 @@ from IPython.utils.traitlets import Set, Instance, CFloat, Integer, Dict
 
 from IPython.parallel.util import log_errors
 from six.moves import map
-from six.moves import zip
 
 class Heart(object):
     """A basic heart object for responding to a HeartMonitor.
@@ -127,10 +126,10 @@ class HeartMonitor(LoggingConfigurable):
         goodhearts = self.hearts.intersection(self.responses)
         missed_beats = self.hearts.difference(goodhearts)
         newhearts = self.responses.difference(goodhearts)
-        map(self.handle_new_heart, newhearts)
+        list(map(self.handle_new_heart, newhearts))
         heartfailures, on_probation = self._check_missed(missed_beats, self.on_probation,
                                                          self.hearts)
-        map(self.handle_heart_failure, heartfailures)
+        list(map(self.handle_heart_failure, heartfailures))
         self.on_probation = on_probation
         self.responses = set()
         #print self.on_probation, self.hearts

--- a/IPython/parallel/controller/heartmonitor.py
+++ b/IPython/parallel/controller/heartmonitor.py
@@ -27,6 +27,8 @@ from IPython.utils.py3compat import str_to_bytes
 from IPython.utils.traitlets import Set, Instance, CFloat, Integer, Dict
 
 from IPython.parallel.util import log_errors
+from six.moves import map
+from six.moves import zip
 
 class Heart(object):
     """A basic heart object for responding to a HeartMonitor.

--- a/IPython/parallel/controller/hub.py
+++ b/IPython/parallel/controller/hub.py
@@ -1189,7 +1189,7 @@ class Hub(SessionFactory):
             except Exception:
                 reply = error.wrap_exception()
         else:
-            pending = filter(lambda m: m in self.pending, msg_ids)
+            pending = [m for m in msg_ids if m in self.pending]
             if pending:
                 try:
                     raise IndexError("msg pending: %r" % pending[0])

--- a/IPython/parallel/controller/hub.py
+++ b/IPython/parallel/controller/hub.py
@@ -31,7 +31,7 @@ from zmq.eventloop.zmqstream import ZMQStream
 # internal:
 from IPython.utils.importstring import import_item
 from IPython.utils.localinterfaces import LOCALHOST
-from IPython.utils.py3compat import cast_bytes
+from IPython.utils.py3compat import cast_bytes, unicode_type
 from IPython.utils.traitlets import (
         HasTraits, Instance, Integer, Unicode, Dict, Set, Tuple, CBytes, DottedObjectName
         )
@@ -45,7 +45,6 @@ from .heartmonitor import HeartMonitor
 import six
 from six.moves import filter
 from six.moves import map
-from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Code
@@ -471,13 +470,13 @@ class Hub(SessionFactory):
             # default to all
             return self.ids
 
-        if isinstance(targets, (int,str,unicode)):
+        if isinstance(targets, (int,str,unicode_type)):
             # only one target specified
             targets = [targets]
         _targets = []
         for t in targets:
             # map raw identities to ids
-            if isinstance(t, (str,unicode)):
+            if isinstance(t, (str,unicode_type)):
                 t = self.by_ident.get(cast_bytes(t), t)
             _targets.append(t)
         targets = _targets

--- a/IPython/parallel/controller/hub.py
+++ b/IPython/parallel/controller/hub.py
@@ -42,6 +42,10 @@ from IPython.parallel.factory import RegistrationFactory
 from IPython.kernel.zmq.session import SessionFactory
 
 from .heartmonitor import HeartMonitor
+import six
+from six.moves import filter
+from six.moves import map
+from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Code
@@ -607,7 +611,7 @@ class Hub(SessionFactory):
         try:
             # it's posible iopub arrived first:
             existing = self.db.get_record(msg_id)
-            for key,evalue in existing.iteritems():
+            for key,evalue in six.iteritems(existing):
                 rvalue = record.get(key, None)
                 if evalue and rvalue and evalue != rvalue:
                     self.log.warn("conflicting initial state for record: %r:%r <%r> %r", msg_id, rvalue, key, evalue)
@@ -713,7 +717,7 @@ class Hub(SessionFactory):
                     # still check content,header which should not change
                     # but are not expensive to compare as buffers
 
-            for key,evalue in existing.iteritems():
+            for key,evalue in six.iteritems(existing):
                 if key.endswith('buffers'):
                     # don't compare buffers
                     continue
@@ -888,7 +892,7 @@ class Hub(SessionFactory):
         self.log.info("client::client %r connected", client_id)
         content = dict(status='ok')
         jsonable = {}
-        for k,v in self.keytable.iteritems():
+        for k,v in six.iteritems(self.keytable):
             if v not in self.dead_engines:
                 jsonable[str(k)] = v
         content['engines'] = jsonable
@@ -916,7 +920,7 @@ class Hub(SessionFactory):
                 content = error.wrap_exception()
                 self.log.error("uuid %r in use", uuid, exc_info=True)
         else:
-            for h, ec in self.incoming_registrations.iteritems():
+            for h, ec in six.iteritems(self.incoming_registrations):
                 if uuid == h:
                     try:
                         raise KeyError("heart_id %r in use" % uuid)
@@ -1069,7 +1073,7 @@ class Hub(SessionFactory):
         self.log.debug("save engine state to %s" % self.engine_state_file)
         state = {}
         engines = {}
-        for eid, ec in self.engines.iteritems():
+        for eid, ec in six.iteritems(self.engines):
             if ec.uuid not in self.dead_engines:
                 engines[eid] = ec.uuid
         
@@ -1093,7 +1097,7 @@ class Hub(SessionFactory):
         
         save_notifier = self.notifier
         self.notifier = None
-        for eid, uuid in state['engines'].iteritems():
+        for eid, uuid in six.iteritems(state['engines']):
             heart = uuid.encode('ascii')
             # start with this heart as current and beating:
             self.heartmonitor.responses.add(heart)
@@ -1286,7 +1290,7 @@ class Hub(SessionFactory):
         finish(dict(status='ok', resubmitted=resubmitted))
         
         # store the new IDs in the Task DB
-        for msg_id, resubmit_id in resubmitted.iteritems():
+        for msg_id, resubmit_id in six.iteritems(resubmitted):
             try:
                 self.db.update_record(msg_id, {'resubmitted' : resubmit_id})
             except Exception:

--- a/IPython/parallel/controller/mongodb.py
+++ b/IPython/parallel/controller/mongodb.py
@@ -64,7 +64,7 @@ class MongoDB(BaseDB):
     def _binary_buffers(self, rec):
         for key in ('buffers', 'result_buffers'):
             if rec.get(key, None):
-                rec[key] = map(Binary, rec[key])
+                rec[key] = list(map(Binary, rec[key]))
         return rec
     
     def add_record(self, msg_id, rec):

--- a/IPython/parallel/controller/mongodb.py
+++ b/IPython/parallel/controller/mongodb.py
@@ -22,6 +22,8 @@ except ImportError:
 from IPython.utils.traitlets import Dict, List, Unicode, Instance
 
 from .dictdb import BaseDB
+from six.moves import map
+from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # MongoDB class

--- a/IPython/parallel/controller/scheduler.py
+++ b/IPython/parallel/controller/scheduler.py
@@ -27,6 +27,9 @@ from collections import deque
 from datetime import datetime
 from random import randint, random
 from types import FunctionType
+from six.moves import filter
+from six.moves import map
+from six.moves import zip
 
 try:
     import numpy
@@ -52,7 +55,7 @@ from .dependency import Dependency
 @decorator
 def logged(f,self,*args,**kwargs):
     # print ("#--------------------")
-    self.log.debug("scheduler::%s(*%s,**%s)", f.func_name, args, kwargs)
+    self.log.debug("scheduler::%s(*%s,**%s)", f.__name__, args, kwargs)
     # print ("#--")
     return f(self,*args, **kwargs)
 
@@ -515,7 +518,7 @@ class TaskScheduler(SessionFactory):
     def available_engines(self):
         """return a list of available engine indices based on HWM"""
         if not self.hwm:
-            return range(len(self.targets))
+            return list(range(len(self.targets)))
         available = []
         for idx in range(len(self.targets)):
             if self.loads[idx] < self.hwm:

--- a/IPython/parallel/controller/scheduler.py
+++ b/IPython/parallel/controller/scheduler.py
@@ -550,7 +550,7 @@ class TaskScheduler(SessionFactory):
                 # check follow
                 return job.follow.check(self.completed[target], self.failed[target])
 
-            indices = filter(can_run, available)
+            indices = list(filter(can_run, available))
 
             if not indices:
                 # couldn't run

--- a/IPython/parallel/controller/sqlitedb.py
+++ b/IPython/parallel/controller/sqlitedb.py
@@ -15,6 +15,9 @@ import json
 import os
 import cPickle as pickle
 from datetime import datetime
+import six
+from six.moves import map
+from six.moves import zip
 
 try:
     import sqlite3
@@ -292,9 +295,9 @@ class SQLiteDB(BaseDB):
         if skeys:
             raise KeyError("Illegal testing key(s): %s"%skeys)
 
-        for name,sub_check in check.iteritems():
+        for name,sub_check in six.iteritems(check):
             if isinstance(sub_check, dict):
-                for test,value in sub_check.iteritems():
+                for test,value in six.iteritems(sub_check):
                     try:
                         op = operators[test]
                     except KeyError:

--- a/IPython/parallel/controller/sqlitedb.py
+++ b/IPython/parallel/controller/sqlitedb.py
@@ -13,7 +13,10 @@ Authors:
 
 import json
 import os
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 from datetime import datetime
 import six
 from six.moves import map

--- a/IPython/parallel/controller/sqlitedb.py
+++ b/IPython/parallel/controller/sqlitedb.py
@@ -78,7 +78,7 @@ def _adapt_bufs(bufs):
     # this is *horrible*
     # copy buffers into single list and pickle it:
     if bufs and isinstance(bufs[0], (bytes, buffer)):
-        return sqlite3.Binary(pickle.dumps(map(bytes, bufs),-1))
+        return sqlite3.Binary(pickle.dumps(list(map(bytes, bufs)),-1))
     elif bufs:
         return bufs
     else:

--- a/IPython/parallel/error.py
+++ b/IPython/parallel/error.py
@@ -17,6 +17,8 @@ from __future__ import print_function
 import sys
 import traceback
 
+from IPython.utils.py3compat import unicode_type
+
 __docformat__ = "restructuredtext en"
 
 # Tell nose to skip this module
@@ -233,8 +235,8 @@ def wrap_exception(engine_info={}):
     exc_content = {
         'status' : 'error',
         'traceback' : stb,
-        'ename' : unicode(etype.__name__),
-        'evalue' : unicode(evalue),
+        'ename' : unicode_type(etype.__name__),
+        'evalue' : unicode_type(evalue),
         'engine_info' : engine_info
     }
     return exc_content

--- a/IPython/parallel/tests/__init__.py
+++ b/IPython/parallel/tests/__init__.py
@@ -1,4 +1,5 @@
 """toplevel setup/teardown for parallel tests."""
+from __future__ import print_function
 
 #-------------------------------------------------------------------------------
 #  Copyright (C) 2011  The IPython Development Team
@@ -63,7 +64,7 @@ def setup():
     tic = time.time()
     while not os.path.exists(engine_json) or not os.path.exists(client_json):
         if cp.poll() is not None:
-            print cp.poll()
+            print(cp.poll())
             raise RuntimeError("The test controller failed to start.")
         elif time.time()-tic > 15:
             raise RuntimeError("Timeout waiting for the test controller to start.")
@@ -112,15 +113,15 @@ def teardown():
             try:
                 p.stop()
             except Exception as e:
-                print e
+                print(e)
                 pass
         if p.poll() is None:
             time.sleep(.25)
         if p.poll() is None:
             try:
-                print 'cleaning up test process...'
+                print('cleaning up test process...')
                 p.signal(SIGKILL)
             except:
-                print "couldn't shutdown process: ", p
+                print("couldn't shutdown process: ", p)
     blackhole.close()
     

--- a/IPython/parallel/tests/clienttest.py
+++ b/IPython/parallel/tests/clienttest.py
@@ -16,7 +16,6 @@ from __future__ import print_function
 import sys
 import tempfile
 import time
-from StringIO import StringIO
 
 from nose import SkipTest
 

--- a/IPython/parallel/tests/clienttest.py
+++ b/IPython/parallel/tests/clienttest.py
@@ -29,6 +29,7 @@ from IPython.parallel import error
 from IPython.parallel import Client
 
 from IPython.parallel.tests import launchers, add_engines
+from six.moves import filter
 
 # simple tasks for use in apply tests
 

--- a/IPython/parallel/tests/test_asyncresult.py
+++ b/IPython/parallel/tests/test_asyncresult.py
@@ -26,6 +26,7 @@ from IPython.parallel.error import TimeoutError
 from IPython.parallel import error, Client
 from IPython.parallel.tests import add_engines
 from .clienttest import ClusterTestCase
+import six
 
 def setup():
     add_engines(2, total=True)
@@ -77,12 +78,12 @@ class AsyncResultTest(ClusterTestCase):
         self.assertEqual(ar.get(), [5]*n)
         d = ar.get_dict()
         self.assertEqual(sorted(d.keys()), sorted(self.client.ids))
-        for eid,r in d.iteritems():
+        for eid,r in six.iteritems(d):
             self.assertEqual(r, 5)
     
     def test_get_dict_single(self):
         view = self.client[-1]
-        for v in (range(5), 5, ('abc', 'def'), 'string'):
+        for v in (list(range(5)), 5, ('abc', 'def'), 'string'):
             ar = view.apply_async(echo, v)
             self.assertEqual(ar.get(), v)
             d = ar.get_dict()
@@ -145,11 +146,11 @@ class AsyncResultTest(ClusterTestCase):
     
     def test_len(self):
         v = self.client.load_balanced_view()
-        ar = v.map_async(lambda x: x, range(10))
+        ar = v.map_async(lambda x: x, list(range(10)))
         self.assertEqual(len(ar), 10)
-        ar = v.apply_async(lambda x: x, range(10))
+        ar = v.apply_async(lambda x: x, list(range(10)))
         self.assertEqual(len(ar), 1)
-        ar = self.client[:].apply_async(lambda x: x, range(10))
+        ar = self.client[:].apply_async(lambda x: x, list(range(10)))
         self.assertEqual(len(ar), len(self.client.ids))
     
     def test_wall_time_single(self):

--- a/IPython/parallel/tests/test_client.py
+++ b/IPython/parallel/tests/test_client.py
@@ -17,6 +17,7 @@ Authors:
 #-------------------------------------------------------------------------------
 
 from __future__ import division
+from __future__ import print_function
 
 import time
 from datetime import datetime
@@ -30,7 +31,7 @@ from IPython.parallel import error
 from IPython.parallel import AsyncResult, AsyncHubResult
 from IPython.parallel import LoadBalancedView, DirectView
 
-from clienttest import ClusterTestCase, segfault, wait, add_engines
+from .clienttest import ClusterTestCase, segfault, wait, add_engines
 
 def setup():
     add_engines(4, total=True)
@@ -95,7 +96,7 @@ class TestClient(ClusterTestCase):
         
         def double(x):
             return x*2
-        seq = range(100)
+        seq = list(range(100))
         ref = [ double(x) for x in seq ]
         
         # add some engines, which should be used
@@ -172,7 +173,7 @@ class TestClient(ClusterTestCase):
         # give the monitor time to notice the message
         time.sleep(.25)
         ahr = self.client.get_result(ar.msg_ids[0])
-        print ar.get(), ahr.get(), ar._single_result, ahr._single_result
+        print(ar.get(), ahr.get(), ar._single_result, ahr._single_result)
         self.assertTrue(isinstance(ahr, AsyncHubResult))
         self.assertEqual(ahr.get().pyout, ar.get().pyout)
         ar2 = self.client.get_result(ar.msg_ids[0])

--- a/IPython/parallel/tests/test_dependency.py
+++ b/IPython/parallel/tests/test_dependency.py
@@ -29,7 +29,6 @@ from IPython.parallel.util import interactive
 from IPython.parallel.tests import add_engines
 from .clienttest import ClusterTestCase
 from six.moves import map
-from six.moves import zip
 
 def setup():
     add_engines(1, total=True)
@@ -43,9 +42,9 @@ def wait(n):
 def func(x):
     return x*x
 
-mixed = map(str, list(range(10)))
-completed = map(str, list(range(0,10,2)))
-failed = map(str, list(range(1,10,2)))
+mixed = list(map(str, list(range(10))))
+completed = list(map(str, list(range(0,10,2))))
+failed = list(map(str, list(range(1,10,2))))
 
 class DependencyTest(ClusterTestCase):
     

--- a/IPython/parallel/tests/test_dependency.py
+++ b/IPython/parallel/tests/test_dependency.py
@@ -28,6 +28,8 @@ from IPython.parallel.util import interactive
 
 from IPython.parallel.tests import add_engines
 from .clienttest import ClusterTestCase
+from six.moves import map
+from six.moves import zip
 
 def setup():
     add_engines(1, total=True)
@@ -41,9 +43,9 @@ def wait(n):
 def func(x):
     return x*x
 
-mixed = map(str, range(10))
-completed = map(str, range(0,10,2))
-failed = map(str, range(1,10,2))
+mixed = map(str, list(range(10)))
+completed = map(str, list(range(0,10,2)))
+failed = map(str, list(range(1,10,2)))
 
 class DependencyTest(ClusterTestCase):
     
@@ -52,8 +54,8 @@ class DependencyTest(ClusterTestCase):
         self.user_ns = {'__builtins__' : __builtins__}
         self.view = self.client.load_balanced_view()
         self.dview = self.client[-1]
-        self.succeeded = set(map(str, range(0,25,2)))
-        self.failed = set(map(str, range(1,25,2)))
+        self.succeeded = set(map(str, list(range(0,25,2))))
+        self.failed = set(map(str, list(range(1,25,2))))
     
     def assertMet(self, dep):
         self.assertTrue(dep.check(self.succeeded, self.failed), "Dependency should be met")

--- a/IPython/parallel/tests/test_dependency.py
+++ b/IPython/parallel/tests/test_dependency.py
@@ -75,12 +75,12 @@ class DependencyTest(ClusterTestCase):
     def test_require_imports(self):
         """test that @require imports names"""
         @self.cancan
-        @pmod.require('urllib')
+        @pmod.require('base64')
         @interactive
-        def encode(dikt):
-            return urllib.urlencode(dikt)
+        def encode(arg):
+            return base64.b64encode(arg)
         # must pass through canning to properly connect namespaces
-        self.assertEqual(encode(dict(a=5)), 'a=5')
+        self.assertEqual(encode(b'foo'), b'Zm9v')
     
     def test_success_only(self):
         dep = pmod.Dependency(mixed, success=True, failure=False)

--- a/IPython/parallel/tests/test_launcher.py
+++ b/IPython/parallel/tests/test_launcher.py
@@ -33,7 +33,7 @@ from IPython.config import Config
 
 from IPython.parallel.apps import launcher
 
-from IPython.testing import decorators as dec
+from IPython.utils.py3compat import string_types
 
 
 #-------------------------------------------------------------------------------
@@ -79,7 +79,7 @@ class LauncherTest:
     def test_args(self):
         launcher = self.build_launcher()
         for arg in launcher.args:
-            self.assertTrue(isinstance(arg, basestring), str(arg))
+            self.assertTrue(isinstance(arg, string_types), str(arg))
 
 class BatchTest:
     """Tests for batch-system launchers (LSF, SGE, PBS)"""

--- a/IPython/parallel/tests/test_lbview.py
+++ b/IPython/parallel/tests/test_lbview.py
@@ -29,6 +29,8 @@ from IPython.parallel import error
 from IPython.parallel.tests import add_engines
 
 from .clienttest import ClusterTestCase, crash, wait, skip_without
+from six.moves import map
+from six.moves import zip
 
 def setup():
     add_engines(3, total=True)
@@ -55,7 +57,7 @@ class TestLoadBalancedView(ClusterTestCase):
     def test_map(self):
         def f(x):
             return x**2
-        data = range(16)
+        data = list(range(16))
         r = self.view.map_sync(f, data)
         self.assertEqual(r, map(f, data))
     
@@ -63,7 +65,7 @@ class TestLoadBalancedView(ClusterTestCase):
         def f(x):
             return x**2
         
-        data = range(16)
+        data = list(range(16))
         r = self.view.map_sync(f, iter(data))
         self.assertEqual(r, map(f, iter(data)))
     
@@ -74,8 +76,8 @@ class TestLoadBalancedView(ClusterTestCase):
             if x is None:
                 return x
             return x*y
-        data = range(10)
-        data2 = range(4)
+        data = list(range(10))
+        data2 = list(range(4))
         
         r = self.view.map_sync(f, data, data2)
         self.assertEqual(r, map(f, data, data2))
@@ -87,8 +89,8 @@ class TestLoadBalancedView(ClusterTestCase):
             if x is None:
                 return x
             return x*y
-        data = range(4)
-        data2 = range(10)
+        data = list(range(4))
+        data2 = list(range(10))
         
         r = self.view.map_sync(f, data, data2)
         self.assertEqual(r, map(f, data, data2))
@@ -100,7 +102,7 @@ class TestLoadBalancedView(ClusterTestCase):
             import time
             time.sleep(0.05*x)
             return x**2
-        data = range(16,0,-1)
+        data = list(range(16,0,-1))
         reference = map(f, data)
         
         amr = self.view.map_async(slow_f, data, ordered=False)
@@ -119,7 +121,7 @@ class TestLoadBalancedView(ClusterTestCase):
             import time
             time.sleep(0.05*x)
             return x**2
-        data = range(16,0,-1)
+        data = list(range(16,0,-1))
         reference = map(f, data)
         
         amr = self.view.map_async(slow_f, data)
@@ -135,7 +137,7 @@ class TestLoadBalancedView(ClusterTestCase):
         """test map on iterables (balanced)"""
         view = self.view
         # 101 is prime, so it won't be evenly distributed
-        arr = range(101)
+        arr = list(range(101))
         # so that it will be an iterator, even in Python 3
         it = iter(arr)
         r = view.map_sync(lambda x:x, arr)

--- a/IPython/parallel/tests/test_lbview.py
+++ b/IPython/parallel/tests/test_lbview.py
@@ -29,8 +29,6 @@ from IPython.parallel import error
 from IPython.parallel.tests import add_engines
 
 from .clienttest import ClusterTestCase, crash, wait, skip_without
-from six.moves import map
-from six.moves import zip
 
 def setup():
     add_engines(3, total=True)

--- a/IPython/parallel/tests/test_lbview.py
+++ b/IPython/parallel/tests/test_lbview.py
@@ -59,7 +59,7 @@ class TestLoadBalancedView(ClusterTestCase):
             return x**2
         data = list(range(16))
         r = self.view.map_sync(f, data)
-        self.assertEqual(r, map(f, data))
+        self.assertEqual(r, list(map(f, data)))
     
     def test_map_generator(self):
         def f(x):
@@ -67,7 +67,7 @@ class TestLoadBalancedView(ClusterTestCase):
         
         data = list(range(16))
         r = self.view.map_sync(f, iter(data))
-        self.assertEqual(r, map(f, iter(data)))
+        self.assertEqual(r, list(map(f, iter(data))))
     
     def test_map_short_first(self):
         def f(x,y):
@@ -80,7 +80,7 @@ class TestLoadBalancedView(ClusterTestCase):
         data2 = list(range(4))
         
         r = self.view.map_sync(f, data, data2)
-        self.assertEqual(r, map(f, data, data2))
+        self.assertEqual(r, list(map(f, data, data2)))
 
     def test_map_short_last(self):
         def f(x,y):
@@ -93,7 +93,7 @@ class TestLoadBalancedView(ClusterTestCase):
         data2 = list(range(10))
         
         r = self.view.map_sync(f, data, data2)
-        self.assertEqual(r, map(f, data, data2))
+        self.assertEqual(r, list(map(f, data, data2)))
 
     def test_map_unordered(self):
         def f(x):
@@ -103,7 +103,7 @@ class TestLoadBalancedView(ClusterTestCase):
             time.sleep(0.05*x)
             return x**2
         data = list(range(16,0,-1))
-        reference = map(f, data)
+        reference = list(map(f, data))
         
         amr = self.view.map_async(slow_f, data, ordered=False)
         self.assertTrue(isinstance(amr, pmod.AsyncMapResult))
@@ -122,7 +122,7 @@ class TestLoadBalancedView(ClusterTestCase):
             time.sleep(0.05*x)
             return x**2
         data = list(range(16,0,-1))
-        reference = map(f, data)
+        reference = list(map(f, data))
         
         amr = self.view.map_async(slow_f, data)
         self.assertTrue(isinstance(amr, pmod.AsyncMapResult))

--- a/IPython/parallel/tests/test_magics.py
+++ b/IPython/parallel/tests/test_magics.py
@@ -113,7 +113,7 @@ class TestParallelMagics(ClusterTestCase, ParametricTestCase):
         
         v['generate_output'] = generate_output
         
-        with capture_output() as io:
+        with capture_output(display=False) as io:
             ip.run_cell_magic('px', '--group-outputs=engine', 'generate_output()')
         
         self.assertFalse('\n\n' in io.stdout)
@@ -147,7 +147,7 @@ class TestParallelMagics(ClusterTestCase, ParametricTestCase):
         
         v['generate_output'] = generate_output
         
-        with capture_output() as io:
+        with capture_output(display=False) as io:
             ip.run_cell_magic('px', '--group-outputs=order', 'generate_output()')
         
         self.assertFalse('\n\n' in io.stdout)
@@ -188,7 +188,7 @@ class TestParallelMagics(ClusterTestCase, ParametricTestCase):
         
         v['generate_output'] = generate_output
         
-        with capture_output() as io:
+        with capture_output(display=False) as io:
             ip.run_cell_magic('px', '--group-outputs=type', 'generate_output()')
         
         self.assertFalse('\n\n' in io.stdout)
@@ -246,7 +246,7 @@ class TestParallelMagics(ClusterTestCase, ParametricTestCase):
         v.activate()
         v.block=True
 
-        with capture_output() as io:
+        with capture_output(display=False) as io:
             ip.magic('autopx')
             ip.run_cell('\n'.join(('a=5','b=12345','c=0')))
             ip.run_cell('b*=2')
@@ -304,7 +304,7 @@ class TestParallelMagics(ClusterTestCase, ParametricTestCase):
 
         for name in ('a', 'b'):
             ip.magic('px ' + name)
-            with capture_output() as io:
+            with capture_output(display=False) as io:
                 ip.magic('pxresult')
             output = io.stdout
             msg = "expected %s output to include %s, but got: %s" % \
@@ -324,7 +324,7 @@ class TestParallelMagics(ClusterTestCase, ParametricTestCase):
         
         self.assertTrue("Populating the interactive namespace from numpy and matplotlib" in io.stdout, io.stdout)
         
-        with capture_output() as io:
+        with capture_output(display=False) as io:
             ip.magic("px plot(rand(100))")
         
         self.assertTrue('Out[' in io.stdout, io.stdout)

--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -456,10 +456,7 @@ class TestView(ClusterTestCase, ParametricTestCase):
         
         @interactive
         def check_unicode(a, check):
-            try: unicode
-            except NameError:
-                unicode = str  # Python 3
-            assert isinstance(a, unicode), "%r is not unicode"%a
+            assert not isinstance(a, bytes), "%r is bytes, not unicode"%a
             assert isinstance(check, bytes), "%r is not bytes"%check
             assert a.encode('utf8') == check, "%s != %s"%(a,check)
         

--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -41,6 +41,8 @@ from IPython.parallel.util import interactive
 from IPython.parallel.tests import add_engines
 
 from .clienttest import ClusterTestCase, crash, wait, skip_without
+from six.moves import map
+from six.moves import zip
 
 def setup():
     add_engines(3, total=True)
@@ -72,7 +74,7 @@ class TestView(ClusterTestCase, ParametricTestCase):
     
     def test_push_pull(self):
         """test pushing and pulling"""
-        data = dict(a=10, b=1.05, c=range(10), d={'e':(1,2),'f':'hi'})
+        data = dict(a=10, b=1.05, c=list(range(10)), d={'e':(1,2),'f':'hi'})
         t = self.client.ids[-1]
         v = self.client[t]
         push = v.push
@@ -233,7 +235,7 @@ class TestView(ClusterTestCase, ParametricTestCase):
 
     def test_scatter_gather(self):
         view = self.client[:]
-        seq1 = range(16)
+        seq1 = list(range(16))
         view.scatter('a', seq1)
         seq2 = view.gather('a', block=True)
         self.assertEqual(seq2, seq1)
@@ -252,7 +254,7 @@ class TestView(ClusterTestCase, ParametricTestCase):
     def test_scatter_gather_lazy(self):
         """scatter/gather with targets='all'"""
         view = self.client.direct_view(targets='all')
-        x = range(64)
+        x = list(range(64))
         view.scatter('x', x)
         gathered = view.gather('x', block=True)
         self.assertEqual(gathered, x)
@@ -318,7 +320,7 @@ class TestView(ClusterTestCase, ParametricTestCase):
         """push/pull pandas.TimeSeries"""
         import pandas
         
-        ts = pandas.TimeSeries(range(10))
+        ts = pandas.TimeSeries(list(range(10)))
         
         view = self.client[-1]
         
@@ -332,7 +334,7 @@ class TestView(ClusterTestCase, ParametricTestCase):
         view = self.client[:]
         def f(x):
             return x**2
-        data = range(16)
+        data = list(range(16))
         r = view.map_sync(f, data)
         self.assertEqual(r, map(f, data))
     
@@ -340,7 +342,7 @@ class TestView(ClusterTestCase, ParametricTestCase):
         """test map on iterables (direct)"""
         view = self.client[:]
         # 101 is prime, so it won't be evenly distributed
-        arr = range(101)
+        arr = list(range(101))
         # ensure it will be an iterator, even in Python 3
         it = iter(arr)
         r = view.map_sync(lambda x: x, it)
@@ -359,7 +361,7 @@ class TestView(ClusterTestCase, ParametricTestCase):
         assert_array_equal(r, arr)
     
     def test_scatter_gather_nonblocking(self):
-        data = range(16)
+        data = list(range(16))
         view = self.client[:]
         view.scatter('a', data, block=False)
         ar = view.gather('a', block=False)
@@ -491,7 +493,7 @@ class TestView(ClusterTestCase, ParametricTestCase):
     
     def test_eval_reference(self):
         v = self.client[self.client.ids[0]]
-        v['g'] = range(5)
+        v['g'] = list(range(5))
         rg = pmod.Reference('g[0]')
         echo = lambda x:x
         self.assertEqual(v.apply_sync(echo, rg), 0)
@@ -504,7 +506,7 @@ class TestView(ClusterTestCase, ParametricTestCase):
 
     def test_single_engine_map(self):
         e0 = self.client[self.client.ids[0]]
-        r = range(5)
+        r = list(range(5))
         check = [ -1*i for i in r ]
         result = e0.map_sync(lambda x: -1*x, r)
         self.assertEqual(result, check)

--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -336,7 +336,7 @@ class TestView(ClusterTestCase, ParametricTestCase):
             return x**2
         data = list(range(16))
         r = view.map_sync(f, data)
-        self.assertEqual(r, map(f, data))
+        self.assertEqual(r, list(map(f, data)))
     
     def test_map_iterable(self):
         """test map on iterables (direct)"""

--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -22,7 +22,6 @@ import platform
 import time
 from collections import namedtuple
 from tempfile import mktemp
-from StringIO import StringIO
 
 import zmq
 from nose import SkipTest
@@ -31,6 +30,7 @@ from nose.plugins.attrib import attr
 from IPython.testing import decorators as dec
 from IPython.testing.ipunittest import ParametricTestCase
 from IPython.utils.io import capture_output
+from IPython.utils.py3compat import unicode_type
 
 from IPython import parallel  as pmod
 from IPython.parallel import error
@@ -456,7 +456,7 @@ class TestView(ClusterTestCase, ParametricTestCase):
         
         @interactive
         def check_unicode(a, check):
-            assert isinstance(a, unicode), "%r is not unicode"%a
+            assert isinstance(a, unicode_type), "%r is not unicode"%a
             assert isinstance(check, bytes), "%r is not bytes"%check
             assert a.encode('utf8') == check, "%s != %s"%(a,check)
         
@@ -598,7 +598,7 @@ class TestView(ClusterTestCase, ParametricTestCase):
         view.execute("from IPython.core.display import *")
         ar = view.execute("[ display(i) for i in range(5) ]", block=True)
         
-        expected = [ {u'text/plain' : unicode(j)} for j in range(5) ]
+        expected = [ {u'text/plain' : unicode_type(j)} for j in range(5) ]
         for outputs in ar.outputs:
             mimes = [ out['data'] for out in outputs ]
             self.assertEqual(mimes, expected)
@@ -614,7 +614,7 @@ class TestView(ClusterTestCase, ParametricTestCase):
         
         ar = view.apply_async(publish)
         ar.get(5)
-        expected = [ {u'text/plain' : unicode(j)} for j in range(5) ]
+        expected = [ {u'text/plain' : unicode_type(j)} for j in range(5) ]
         for outputs in ar.outputs:
             mimes = [ out['data'] for out in outputs ]
             self.assertEqual(mimes, expected)

--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -456,7 +456,10 @@ class TestView(ClusterTestCase, ParametricTestCase):
         
         @interactive
         def check_unicode(a, check):
-            assert isinstance(a, unicode_type), "%r is not unicode"%a
+            try: unicode
+            except NameError:
+                unicode = str  # Python 3
+            assert isinstance(a, unicode), "%r is not unicode"%a
             assert isinstance(check, bytes), "%r is not bytes"%check
             assert a.encode('utf8') == check, "%s != %s"%(a,check)
         

--- a/IPython/parallel/util.py
+++ b/IPython/parallel/util.py
@@ -169,7 +169,7 @@ def validate_url_container(container):
         url = container
         return validate_url(url)
     elif isinstance(container, dict):
-        container = six.itervalues(container)
+        container = container.values()
     
     for element in container:
         validate_url_container(element)

--- a/IPython/parallel/util.py
+++ b/IPython/parallel/util.py
@@ -23,6 +23,9 @@ import stat
 import socket
 import sys
 from signal import signal, SIGINT, SIGABRT, SIGTERM
+import six
+from six.moves import map
+from six.moves import zip
 try:
     from signal import SIGKILL
 except ImportError:
@@ -58,7 +61,7 @@ class Namespace(dict):
     
     def __getattr__(self, key):
         """getattr aliased to getitem"""
-        if key in self.iterkeys():
+        if key in six.iterkeys(self):
             return self[key]
         else:
             raise NameError(key)
@@ -76,7 +79,7 @@ class ReverseDict(dict):
     def __init__(self, *args, **kwargs):
         dict.__init__(self, *args, **kwargs)
         self._reverse = dict()
-        for key, value in self.iteritems():
+        for key, value in six.iteritems(self):
             self._reverse[value] = key
     
     def __getitem__(self, key):
@@ -167,7 +170,7 @@ def validate_url_container(container):
         url = container
         return validate_url(url)
     elif isinstance(container, dict):
-        container = container.itervalues()
+        container = six.itervalues(container)
     
     for element in container:
         validate_url_container(element)
@@ -230,9 +233,9 @@ def _push(**ns):
     while tmp in user_ns:
         tmp = tmp + '_'
     try:
-        for name, value in ns.iteritems():
+        for name, value in six.iteritems(ns):
             user_ns[tmp] = value
-            exec "%s = %s" % (name, tmp) in user_ns
+            exec("%s = %s" % (name, tmp), user_ns)
     finally:
         user_ns.pop(tmp, None)
 
@@ -247,7 +250,7 @@ def _pull(keys):
 @interactive
 def _execute(code):
     """helper method for implementing `client.execute` via `client.apply`"""
-    exec code in globals()
+    exec(code, globals())
 
 #--------------------------------------------------------------------------
 # extra process management utilities
@@ -258,7 +261,7 @@ _random_ports = set()
 def select_random_ports(n):
     """Selects and return n random ports that are available."""
     ports = []
-    for i in xrange(n):
+    for i in range(n):
         sock = socket.socket()
         sock.bind(('', 0))
         while sock.getsockname()[1] in _random_ports:

--- a/IPython/parallel/util.py
+++ b/IPython/parallel/util.py
@@ -24,7 +24,6 @@ import socket
 import sys
 from signal import signal, SIGINT, SIGABRT, SIGTERM
 import six
-from six.moves import map
 try:
     from signal import SIGKILL
 except ImportError:
@@ -61,7 +60,7 @@ class Namespace(dict):
     
     def __getattr__(self, key):
         """getattr aliased to getitem"""
-        if key in six.iterkeys(self):
+        if key in self:
             return self[key]
         else:
             raise NameError(key)

--- a/IPython/parallel/util.py
+++ b/IPython/parallel/util.py
@@ -25,7 +25,6 @@ import sys
 from signal import signal, SIGINT, SIGABRT, SIGTERM
 import six
 from six.moves import map
-from six.moves import zip
 try:
     from signal import SIGKILL
 except ImportError:
@@ -47,6 +46,7 @@ from IPython.external.decorator import decorator
 # IPython imports
 from IPython.config.application import Application
 from IPython.utils.localinterfaces import LOCALHOST, PUBLIC_IPS
+from IPython.utils.py3compat import string_types
 from IPython.kernel.zmq.log import EnginePUBHandler
 from IPython.kernel.zmq.serialize import (
     unserialize_object, serialize_object, pack_apply_message, unpack_apply_message
@@ -133,7 +133,7 @@ def is_url(url):
 
 def validate_url(url):
     """validate a url for zeromq"""
-    if not isinstance(url, basestring):
+    if not isinstance(url, string_types):
         raise TypeError("url must be a string, not %r"%type(url))
     url = url.lower()
     
@@ -166,7 +166,7 @@ def validate_url(url):
 
 def validate_url_container(container):
     """validate a potentially nested collection of urls."""
-    if isinstance(container, basestring):
+    if isinstance(container, string_types):
         url = container
         return validate_url(url)
     elif isinstance(container, dict):

--- a/IPython/parallel/util.py
+++ b/IPython/parallel/util.py
@@ -233,7 +233,7 @@ def _push(**ns):
     while tmp in user_ns:
         tmp = tmp + '_'
     try:
-        for name, value in six.iteritems(ns):
+        for name, value in ns.items():
             user_ns[tmp] = value
             exec("%s = %s" % (name, tmp), user_ns)
     finally:
@@ -243,7 +243,7 @@ def _push(**ns):
 def _pull(keys):
     """helper method for implementing `client.pull` via `client.apply`"""
     if isinstance(keys, (list,tuple, set)):
-        return map(lambda key: eval(key, globals()), keys)
+        return [eval(key, globals()) for key in keys]
     else:
         return eval(keys, globals())
 

--- a/IPython/qt/console/ansi_code_processor.py
+++ b/IPython/qt/console/ansi_code_processor.py
@@ -10,9 +10,6 @@ import re
 
 # System library imports
 from IPython.external.qt import QtGui
-from six.moves import filter
-from six.moves import map
-from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Constants and datatypes
@@ -106,7 +103,7 @@ class AnsiCodeProcessor(object):
                 self.actions = []
             start = match.end()
 
-            groups = filter(lambda x: x is not None, match.groups())
+            groups = [x for x in match.groups() if x is not None]
             g0 = groups[0]
             if g0 == '\a':
                 self.actions.append(BeepAction('beep'))
@@ -129,7 +126,7 @@ class AnsiCodeProcessor(object):
                 if g0.startswith('['):
                     # Case 1: CSI code.
                     try:
-                        params = map(int, params)
+                        params = list(map(int, params))
                     except ValueError:
                         # Silently discard badly formed codes.
                         pass

--- a/IPython/qt/console/ansi_code_processor.py
+++ b/IPython/qt/console/ansi_code_processor.py
@@ -10,6 +10,7 @@ import re
 
 # System library imports
 from IPython.external.qt import QtGui
+from IPython.utils.py3compat import string_types
 
 #-----------------------------------------------------------------------------
 # Constants and datatypes
@@ -318,7 +319,7 @@ class QtAnsiCodeProcessor(AnsiCodeProcessor):
             color += 8
 
         constructor = self.color_map.get(color, None)
-        if isinstance(constructor, basestring):
+        if isinstance(constructor, string_types):
             # If this is an X11 color name, we just hope there is a close SVG
             # color name. We could use QColor's static method
             # 'setAllowX11ColorNames()', but this is global and only available

--- a/IPython/qt/console/ansi_code_processor.py
+++ b/IPython/qt/console/ansi_code_processor.py
@@ -10,6 +10,9 @@ import re
 
 # System library imports
 from IPython.external.qt import QtGui
+from six.moves import filter
+from six.moves import map
+from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Constants and datatypes
@@ -365,7 +368,7 @@ class QtAnsiCodeProcessor(AnsiCodeProcessor):
         if color.value() >= 127:
             # Colors appropriate for a terminal with a light background. For
             # now, only use non-bright colors...
-            for i in xrange(8):
+            for i in range(8):
                 self.default_color_map[i + 8] = self.default_color_map[i]
 
             # ...and replace white with black.

--- a/IPython/qt/console/completion_html.py
+++ b/IPython/qt/console/completion_html.py
@@ -317,7 +317,7 @@ class CompletionHtml(QtGui.QWidget):
         self._old_cursor = cursor
         self._index = (0, 0)
         sjoin = lambda x : [ y.ljust(w, ' ') for y, w in zip(x, ci['columns_width'])]
-        self._justified_items = map(sjoin, items_m)
+        self._justified_items = list(map(sjoin, items_m))
         self._update_list(hilight=False)
 
 

--- a/IPython/qt/console/completion_html.py
+++ b/IPython/qt/console/completion_html.py
@@ -12,6 +12,8 @@
 import IPython.utils.text as text
 
 from IPython.external.qt import QtCore, QtGui
+from six.moves import map
+from six.moves import zip
 
 #--------------------------------------------------------------------------
 # Return an HTML table with selected item in a special class

--- a/IPython/qt/console/console_widget.py
+++ b/IPython/qt/console/console_widget.py
@@ -28,7 +28,6 @@ from .completion_widget import CompletionWidget
 from .completion_html import CompletionHtml
 from .completion_plain import CompletionPlain
 from .kill_ring import QtKillRing
-import six
 
 
 #-----------------------------------------------------------------------------
@@ -70,7 +69,7 @@ def is_letter_or_number(char):
 # Classes
 #-----------------------------------------------------------------------------
 
-class ConsoleWidget(six.with_metaclass(MetaQObjectHasTraits, type('NewBase', (LoggingConfigurable, QtGui.QWidget), {}))):
+class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, QtGui.QWidget), {})):
     """ An abstract base class for console-type widgets. This class has
         functionality for:
 
@@ -221,7 +220,7 @@ class ConsoleWidget(six.with_metaclass(MetaQObjectHasTraits, type('NewBase', (Lo
 
     # The shortcuts defined by this widget. We need to keep track of these to
     # support 'override_shortcuts' above.
-    _shortcuts = set(_ctrl_down_remap.keys() +
+    _shortcuts = set(list(_ctrl_down_remap.keys()) +
                      [ QtCore.Qt.Key_C, QtCore.Qt.Key_G, QtCore.Qt.Key_O,
                        QtCore.Qt.Key_V ])
 

--- a/IPython/qt/console/console_widget.py
+++ b/IPython/qt/console/console_widget.py
@@ -23,11 +23,12 @@ from IPython.qt.rich_text import HtmlExporter
 from IPython.qt.util import MetaQObjectHasTraits, get_font
 from IPython.utils.text import columnize
 from IPython.utils.traitlets import Bool, Enum, Integer, Unicode
-from ansi_code_processor import QtAnsiCodeProcessor
-from completion_widget import CompletionWidget
-from completion_html import CompletionHtml
-from completion_plain import CompletionPlain
-from kill_ring import QtKillRing
+from .ansi_code_processor import QtAnsiCodeProcessor
+from .completion_widget import CompletionWidget
+from .completion_html import CompletionHtml
+from .completion_plain import CompletionPlain
+from .kill_ring import QtKillRing
+import six
 
 
 #-----------------------------------------------------------------------------
@@ -69,7 +70,7 @@ def is_letter_or_number(char):
 # Classes
 #-----------------------------------------------------------------------------
 
-class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
+class ConsoleWidget(six.with_metaclass(MetaQObjectHasTraits, type('NewBase', (LoggingConfigurable, QtGui.QWidget), {}))):
     """ An abstract base class for console-type widgets. This class has
         functionality for:
 
@@ -82,7 +83,6 @@ class ConsoleWidget(LoggingConfigurable, QtGui.QWidget):
         ConsoleWidget also provides a number of utility methods that will be
         convenient to implementors of a console-style widget.
     """
-    __metaclass__ = MetaQObjectHasTraits
 
     #------ Configuration ------------------------------------------------------
 

--- a/IPython/qt/console/frontend_widget.py
+++ b/IPython/qt/console/frontend_widget.py
@@ -16,11 +16,11 @@ from IPython.core.inputtransformer import classic_prompt
 from IPython.core.oinspect import call_tip
 from IPython.qt.base_frontend_mixin import BaseFrontendMixin
 from IPython.utils.traitlets import Bool, Instance, Unicode
-from bracket_matcher import BracketMatcher
-from call_tip_widget import CallTipWidget
-from completion_lexer import CompletionLexer
-from history_console_widget import HistoryConsoleWidget
-from pygments_highlighter import PygmentsHighlighter
+from .bracket_matcher import BracketMatcher
+from .call_tip_widget import CallTipWidget
+from .completion_lexer import CompletionLexer
+from .history_console_widget import HistoryConsoleWidget
+from .pygments_highlighter import PygmentsHighlighter
 
 
 class FrontendHighlighter(PygmentsHighlighter):

--- a/IPython/qt/console/history_console_widget.py
+++ b/IPython/qt/console/history_console_widget.py
@@ -3,7 +3,7 @@ from IPython.external.qt import QtGui
 
 # Local imports
 from IPython.utils.traitlets import Bool
-from console_widget import ConsoleWidget
+from .console_widget import ConsoleWidget
 
 
 class HistoryConsoleWidget(ConsoleWidget):

--- a/IPython/qt/console/ipython_widget.py
+++ b/IPython/qt/console/ipython_widget.py
@@ -22,8 +22,10 @@ from IPython.external.qt import QtCore, QtGui
 from IPython.core.inputsplitter import IPythonInputSplitter
 from IPython.core.inputtransformer import ipy_prompt
 from IPython.utils.traitlets import Bool, Unicode
-from frontend_widget import FrontendWidget
-import styles
+from .frontend_widget import FrontendWidget
+from . import styles
+from six.moves import map
+from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Constants

--- a/IPython/qt/console/pygments_highlighter.py
+++ b/IPython/qt/console/pygments_highlighter.py
@@ -1,5 +1,6 @@
 # System library imports.
 from IPython.external.qt import QtGui
+from IPython.utils.py3compat import string_types
 from pygments.formatters.html import HtmlFormatter
 from pygments.lexer import RegexLexer, _TokenType, Text, Error
 from pygments.lexers import PythonLexer
@@ -130,7 +131,7 @@ class PygmentsHighlighter(QtGui.QSyntaxHighlighter):
     def set_style(self, style):
         """ Sets the style to the specified Pygments style.
         """
-        if isinstance(style, basestring):
+        if isinstance(style, string_types):
             style = get_style_by_name(style)
         self._style = style
         self._clear_caches()

--- a/IPython/qt/console/pygments_highlighter.py
+++ b/IPython/qt/console/pygments_highlighter.py
@@ -4,6 +4,7 @@ from pygments.formatters.html import HtmlFormatter
 from pygments.lexer import RegexLexer, _TokenType, Text, Error
 from pygments.lexers import PythonLexer
 from pygments.styles import get_style_by_name
+import six
 
 
 def get_tokens_unprocessed(self, text, stack=('root',)):
@@ -73,7 +74,7 @@ class PygmentsBlockUserData(QtGui.QTextBlockUserData):
     syntax_stack = ('root',)
 
     def __init__(self, **kwds):
-        for key, value in kwds.iteritems():
+        for key, value in six.iteritems(kwds):
             setattr(self, key, value)
         QtGui.QTextBlockUserData.__init__(self)
 

--- a/IPython/qt/console/qtconsoleapp.py
+++ b/IPython/qt/console/qtconsoleapp.py
@@ -39,7 +39,7 @@ if os.name == 'nt':
     def gui_excepthook(exctype, value, tb):
         try:
             import ctypes, traceback
-            MB_ICONERROR = 0x00000010L
+            MB_ICONERROR = 0x00000010
             title = u'Error starting IPython QtConsole'
             msg = u''.join(traceback.format_exception(exctype, value, tb))
             ctypes.windll.user32.MessageBoxW(0, msg, title, MB_ICONERROR)

--- a/IPython/qt/console/rich_ipython_widget.py
+++ b/IPython/qt/console/rich_ipython_widget.py
@@ -17,7 +17,9 @@ from IPython.external.qt import QtCore, QtGui
 # Local imports
 from IPython.utils.traitlets import Bool
 from IPython.qt.svg import save_svg, svg_to_clipboard, svg_to_image
-from ipython_widget import IPythonWidget
+from .ipython_widget import IPythonWidget
+from six.moves import map
+from six.moves import zip
 
 
 class RichIPythonWidget(IPythonWidget):

--- a/IPython/qt/kernel_mixins.py
+++ b/IPython/qt/kernel_mixins.py
@@ -6,7 +6,8 @@ from IPython.external.qt import QtCore
 
 # IPython imports.
 from IPython.utils.traitlets import HasTraits, Type
-from util import MetaQObjectHasTraits, SuperQObject
+from .util import MetaQObjectHasTraits, SuperQObject
+import six
 
 
 class ChannelQObject(SuperQObject):
@@ -168,26 +169,21 @@ class QtHBChannelMixin(ChannelQObject):
         self.kernel_died.emit(since_last_heartbeat)
 
 
-class QtKernelRestarterMixin(HasTraits, SuperQObject):
+class QtKernelRestarterMixin(six.with_metaclass(MetaQObjectHasTraits, type('NewBase', (HasTraits, SuperQObject), {}))):
 
-    __metaclass__ = MetaQObjectHasTraits
     _timer = None
 
 
-class QtKernelManagerMixin(HasTraits, SuperQObject):
+class QtKernelManagerMixin(six.with_metaclass(MetaQObjectHasTraits, type('NewBase', (HasTraits, SuperQObject), {}))):
     """ A KernelClient that provides signals and slots.
     """
-
-    __metaclass__ = MetaQObjectHasTraits
 
     kernel_restarted = QtCore.Signal()
 
 
-class QtKernelClientMixin(HasTraits, SuperQObject):
+class QtKernelClientMixin(six.with_metaclass(MetaQObjectHasTraits, type('NewBase', (HasTraits, SuperQObject), {}))):
     """ A KernelClient that provides signals and slots.
     """
-
-    __metaclass__ = MetaQObjectHasTraits
 
     # Emitted when the kernel client has started listening.
     started_channels = QtCore.Signal()

--- a/IPython/qt/kernel_mixins.py
+++ b/IPython/qt/kernel_mixins.py
@@ -169,19 +169,19 @@ class QtHBChannelMixin(ChannelQObject):
         self.kernel_died.emit(since_last_heartbeat)
 
 
-class QtKernelRestarterMixin(six.with_metaclass(MetaQObjectHasTraits, type('NewBase', (HasTraits, SuperQObject), {}))):
+class QtKernelRestarterMixin(MetaQObjectHasTraits('NewBase', (HasTraits, SuperQObject), {})):
 
     _timer = None
 
 
-class QtKernelManagerMixin(six.with_metaclass(MetaQObjectHasTraits, type('NewBase', (HasTraits, SuperQObject), {}))):
+class QtKernelManagerMixin(MetaQObjectHasTraits('NewBase', (HasTraits, SuperQObject), {})):
     """ A KernelClient that provides signals and slots.
     """
 
     kernel_restarted = QtCore.Signal()
 
 
-class QtKernelClientMixin(six.with_metaclass(MetaQObjectHasTraits, type('NewBase', (HasTraits, SuperQObject), {}))):
+class QtKernelClientMixin(MetaQObjectHasTraits('NewBase', (HasTraits, SuperQObject), {})):
     """ A KernelClient that provides signals and slots.
     """
 

--- a/IPython/qt/util.py
+++ b/IPython/qt/util.py
@@ -9,6 +9,7 @@ from IPython.external.qt import QtCore, QtGui
 
 # IPython imports.
 from IPython.utils.traitlets import HasTraits, TraitType
+import six
 
 #-----------------------------------------------------------------------------
 # Metaclasses
@@ -27,7 +28,7 @@ class MetaQObjectHasTraits(MetaQObject, MetaHasTraits):
     def __new__(mcls, name, bases, classdict):
         # FIXME: this duplicates the code from MetaHasTraits.
         # I don't think a super() call will help me here.
-        for k,v in classdict.iteritems():
+        for k,v in six.iteritems(classdict):
             if isinstance(v, TraitType):
                 v.name = k
             elif inspect.isclass(v):

--- a/IPython/scripts/iptest
+++ b/IPython/scripts/iptest
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """IPython Test Suite Runner.
 """
+from __future__ import print_function
 
 # The tests can't even run if nose isn't available, so might as well  give the
 # user a civilized error message in that case.
@@ -18,7 +19,7 @@ http://somethingaboutorange.com/mrl/projects/nose
 
 Exiting."""
     import sys
-    print >> sys.stderr, error
+    print(error, file=sys.stderr)
 else:
     from IPython.testing import iptest
     iptest.main()

--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -51,6 +51,7 @@ Authors
 - VáclavŠmilauer <eudoxos-AT-arcig.cz>: Prompt generalizations.
 - Skipper Seabold, refactoring, cleanups, pure python addition
 """
+from __future__ import print_function
 
 #-----------------------------------------------------------------------------
 # Imports
@@ -88,7 +89,7 @@ from IPython.utils import io
 # Globals
 #-----------------------------------------------------------------------------
 # for tokenizing blocks
-COMMENT, INPUT, OUTPUT =  range(3)
+COMMENT, INPUT, OUTPUT =  list(range(3))
 
 #-----------------------------------------------------------------------------
 # Functions and class declarations
@@ -648,7 +649,7 @@ class IpythonDirective(Directive):
         #print lines
         if len(lines)>2:
             if debug:
-                print '\n'.join(lines)
+                print('\n'.join(lines))
             else: #NOTE: this raises some errors, what's it for?
                 #print 'INSERTING %d lines'%len(lines)
                 self.state_machine.insert_input(
@@ -825,4 +826,4 @@ if __name__=='__main__':
     if not os.path.isdir('_static'):
         os.mkdir('_static')
     test()
-    print 'All OK? Check figures in _static/'
+    print('All OK? Check figures in _static/')

--- a/IPython/terminal/console/completer.py
+++ b/IPython/terminal/console/completer.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 import readline
-from Queue import Empty
+
+try:
+    from queue import Empty  # Python 3
+except ImportError:
+    from Queue import Empty  # Python 2
 
 from IPython.config import Configurable
 from IPython.utils.traitlets import Float

--- a/IPython/terminal/console/interactiveshell.py
+++ b/IPython/terminal/console/interactiveshell.py
@@ -23,11 +23,14 @@ import subprocess
 from io import BytesIO
 import base64
 
-from Queue import Empty
+try:
+    from queue import Empty  # Python 3
+except ImportError:
+    from Queue import Empty  # Python 2
 
 from IPython.core import page
 from IPython.utils.warn import warn, error
-from IPython.utils import io
+from IPython.utils import io, py3compat
 from IPython.utils.traitlets import List, Enum, Any, Instance, Unicode, Float
 from IPython.utils.tempdir import NamedFileInTemporaryDirectory
 
@@ -326,7 +329,7 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
             signal.signal(signal.SIGINT, double_int)
             
             try:
-                raw_data = raw_input(msg_rep["content"]["prompt"])
+                raw_data = py3compat.input(msg_rep["content"]["prompt"])
             except EOFError:
                 # turn EOFError into EOF character
                 raw_data = '\x04'
@@ -387,7 +390,7 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
         if display_banner is None:
             display_banner = self.display_banner
         
-        if isinstance(display_banner, basestring):
+        if isinstance(display_banner, py3compat.string_types):
             self.show_banner(display_banner)
         elif display_banner:
             self.show_banner()

--- a/IPython/terminal/embed.py
+++ b/IPython/terminal/embed.py
@@ -23,6 +23,7 @@ Notes
 #-----------------------------------------------------------------------------
 
 from __future__ import with_statement
+from __future__ import print_function
 
 import sys
 import warnings
@@ -153,7 +154,7 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
         self.banner2 = self.old_banner2
 
         if self.exit_msg is not None:
-            print self.exit_msg
+            print(self.exit_msg)
 
     def mainloop(self, local_ns=None, module=None, stack_depth=0,
                  display_banner=None, global_ns=None, compile_flags=None):

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -105,7 +105,7 @@ class TerminalMagics(Magics):
         # Sanity checks
         if b is None:
             raise UsageError('No previous pasted block available')
-        if not isinstance(b, basestring):
+        if not isinstance(b, py3compat.string_types):
             raise UsageError(
                 "Variable 'pasted_block' is not a string, can't execute")
 
@@ -473,7 +473,7 @@ class TerminalInteractiveShell(InteractiveShell):
         if display_banner is None:
             display_banner = self.display_banner
 
-        if isinstance(display_banner, basestring):
+        if isinstance(display_banner, py3compat.string_types):
             self.show_banner(display_banner)
         elif display_banner:
             self.show_banner()

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -24,6 +24,7 @@ Authors
 #-----------------------------------------------------------------------------
 
 from __future__ import absolute_import
+from __future__ import print_function
 
 import logging
 import os
@@ -195,7 +196,7 @@ class LocateIPythonApp(BaseIPythonApplication):
         if self.subapp is not None:
             return self.subapp.start()
         else:
-            print self.ipython_dir
+            print(self.ipython_dir)
 
 
 class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
@@ -342,7 +343,7 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
         if self.display_banner and self.interact:
             self.shell.show_banner()
         # Make sure there is a space below the banner.
-        if self.log_level <= logging.INFO: print
+        if self.log_level <= logging.INFO: print()
 
     def _pylab_changed(self, name, old, new):
         """Replace --pylab='inline' with --pylab='auto'"""

--- a/IPython/testing/__init__.py
+++ b/IPython/testing/__init__.py
@@ -21,7 +21,7 @@ def test(all=False):
 
     # Do the import internally, so that this function doesn't increase total
     # import time
-    from iptest import run_iptestall
+    from .iptest import run_iptestall
     run_iptestall(inc_slow=all)
 
 # So nose doesn't try to run this as a test itself and we end up with an

--- a/IPython/testing/_paramtestpy2.py
+++ b/IPython/testing/_paramtestpy2.py
@@ -22,7 +22,7 @@ from compiler.consts import CO_GENERATOR
 
 def isgenerator(func):
     try:
-        return func.func_code.co_flags & CO_GENERATOR != 0
+        return func.__code__.co_flags & CO_GENERATOR != 0
     except AttributeError:
         return False
 

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -74,6 +74,7 @@ from IPython.external.decorators import *
 
 # For onlyif_cmd_exists decorator
 from IPython.utils.process import is_cmd_found
+from IPython.utils.py3compat import string_types
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -151,7 +152,7 @@ def make_label_dec(label,ds=None):
     True
     """
 
-    if isinstance(label,basestring):
+    if isinstance(label, string_types):
         labels = [label]
     else:
         labels = label
@@ -160,12 +161,12 @@ def make_label_dec(label,ds=None):
     # dry run on a dummy function.
     tmp = lambda : None
     for label in labels:
-        setattr(tmp,label,True)
+        setattr(tmp, label, True)
 
     # This is the actual decorator we'll return
     def decor(f):
         for label in labels:
-            setattr(f,label,True)
+            setattr(f, label, True)
         return f
 
     # Apply the user's docstring, or autogenerate a basic one

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -60,12 +60,12 @@ from IPython.external.decorator import decorator
 
 # We already have python3-compliant code for parametric tests
 if sys.version[0]=='2':
-    from _paramtestpy2 import parametric
+    from ._paramtestpy2 import parametric
 else:
-    from _paramtestpy3 import parametric
+    from ._paramtestpy3 import parametric
 
 # Expose the unittest-driven decorators
-from ipunittest import ipdoctest, ipdocstring
+from .ipunittest import ipdoctest, ipdocstring
 
 # Grab the numpy-specific decorators which we keep in a file that we
 # occasionally update from upstream: decorators.py is a copy of

--- a/IPython/testing/globalipapp.py
+++ b/IPython/testing/globalipapp.py
@@ -20,7 +20,11 @@ from __future__ import print_function
 #-----------------------------------------------------------------------------
 
 # stdlib
-import __builtin__ as builtin_mod
+try:
+    import builtins
+except ImportError:  
+    # Python 2
+    import __builtin__ as builtins
 import os
 import sys
 
@@ -159,8 +163,8 @@ def start_ipython():
     # now return this without recursively calling here again.
     _ip = shell
     get_ipython = _ip.get_ipython
-    builtin_mod._ip = _ip
-    builtin_mod.get_ipython = get_ipython
+    builtins._ip = _ip
+    builtins.get_ipython = get_ipython
 
     # To avoid extra IPython messages during testing, suppress io.stdout/stderr
     io.stdout = StreamProxy('stdout')

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -345,7 +345,6 @@ class IPTester(object):
 
     def __init__(self, runner='iptest', params=None):
         """Create new test runner."""
-        p = os.path
         if runner == 'iptest':
             iptest_app = os.path.abspath(get_ipython_module_path('IPython.testing.iptest'))
             self.runner = pycmd2argv(iptest_app) + sys.argv[1:]

--- a/IPython/testing/ipunittest.py
+++ b/IPython/testing/ipunittest.py
@@ -40,6 +40,8 @@ import re
 import sys
 import unittest
 from doctest import DocTestFinder, DocTestRunner, TestResults
+from six.moves import map
+from six.moves import zip
 
 # We already have python3-compliant code for parametric tests
 if sys.version[0]=='2':

--- a/IPython/testing/nosepatch.py
+++ b/IPython/testing/nosepatch.py
@@ -56,7 +56,7 @@ def getTestCaseNames(self, testCaseClass):
         return False
         # END MONKEYPATCH
     
-    cases = filter(wanted, dir(testCaseClass))
+    cases = list(filter(wanted, dir(testCaseClass)))
     for base in testCaseClass.__bases__:
         for case in self.getTestCaseNames(base):
             if case not in cases:

--- a/IPython/testing/nosepatch.py
+++ b/IPython/testing/nosepatch.py
@@ -25,6 +25,7 @@ import unittest
 import sys
 import nose.loader
 from inspect import ismethod, isfunction
+from six.moves import filter
 
 #-----------------------------------------------------------------------------
 # Classes and functions

--- a/IPython/testing/plugin/dtexample.py
+++ b/IPython/testing/plugin/dtexample.py
@@ -3,7 +3,7 @@
 This file just contains doctests both using plain python and IPython prompts.
 All tests should be loaded by nose.
 """
-from IPython.utils.py3compat import doctest_refactor_print
+from __future__ import print_function
 
 def pyfunc():
     """Some pure python tests...
@@ -24,7 +24,7 @@ def pyfunc():
     """
     return 'pyfunc'
 
-@doctest_refactor_print
+
 def ipfunc():
     """Some ipython tests...
 
@@ -34,8 +34,8 @@ def ipfunc():
     Out[3]: 5
 
     In [26]: for i in range(3):
-       ....:     print i,
-       ....:     print i+1,
+       ....:     print(i, end=' ')
+       ....:     print(i+1, end=' ')
        ....:
     0 1 1 2 2 3
 
@@ -59,7 +59,7 @@ def ipfunc():
     In [7]: 'hi'
     Out[7]: 'hi'
 
-    In [8]: print repr(_)
+    In [8]: print(repr(_))
     'hi'
     
     In [7]: 3+4
@@ -128,14 +128,13 @@ def random_all():
     """
     pass
 
-@doctest_refactor_print
 def iprand():
     """Some ipython tests with random output.
 
     In [7]: 3+4
     Out[7]: 7
 
-    In [8]: print 'hello'
+    In [8]: print('hello')
     world  # random
 
     In [9]: iprand()
@@ -143,7 +142,6 @@ def iprand():
     """
     return 'iprand'
 
-@doctest_refactor_print
 def iprand_all():
     """Some ipython tests with fully random output.
 
@@ -152,7 +150,7 @@ def iprand_all():
     In [7]: 1
     Out[7]: 99
 
-    In [8]: print 'hello'
+    In [8]: print('hello')
     world
 
     In [9]: iprand_all()

--- a/IPython/testing/plugin/dtexample.py
+++ b/IPython/testing/plugin/dtexample.py
@@ -17,10 +17,10 @@ def pyfunc():
     5
 
     >>> for i in range(3):
-    ...     print i,
-    ...     print i+1,
+    ...     print(i, end=' ')
+    ...     print(i+1, end=' ')
     ...
-    0 1 1 2 2 3
+    0 1 1 2 2 3 
     """
     return 'pyfunc'
 

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -617,7 +617,7 @@ class ExtensionDoctest(doctests.Doctest):
 
         if exclude_patterns is None:
             exclude_patterns = []
-        self.exclude_patterns = map(re.compile,exclude_patterns)
+        self.exclude_patterns = list(map(re.compile,exclude_patterns))
         doctests.Doctest.__init__(self)
 
     def options(self, parser, env=os.environ):

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -19,7 +19,11 @@ Limitations:
 # Module imports
 
 # From the standard library
-import __builtin__ as builtin_mod
+try:
+    import builtins
+except ImportError:  
+    # Python 2
+    import __builtin__ as builtins
 import commands
 import doctest
 import inspect
@@ -281,7 +285,7 @@ class DocTestCase(doctests.DocTestCase):
             # We must remove the _ key in the namespace, so that Python's
             # doctest code sets it naturally
             _ip.user_ns.pop('_', None)
-            _ip.user_ns['__builtins__'] = builtin_mod
+            _ip.user_ns['__builtins__'] = builtins
             self._dt_test.globs = _ip.user_ns
 
         super(DocTestCase, self).setUp()

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -46,6 +46,8 @@ import nose.core
 
 from nose.plugins import doctests, Plugin
 from nose.util import anyp, getpackage, test_address, resolve_name, tolist
+from six.moves import map
+from six.moves import zip
 
 # Our own imports
 
@@ -96,7 +98,7 @@ class DocTestFinder(doctest.DocTestFinder):
         if module is None:
             return True
         elif inspect.isfunction(object):
-            return module.__dict__ is object.func_globals
+            return module.__dict__ is object.__globals__
         elif inspect.isbuiltin(object):
             return module.__name__ == object.__module__
         elif inspect.isclass(object):
@@ -106,7 +108,7 @@ class DocTestFinder(doctest.DocTestFinder):
             # __module__ attribute of methods, but since the same error is easy
             # to make by extension code writers, having this safety in place
             # isn't such a bad idea
-            return module.__name__ == object.im_class.__module__
+            return module.__name__ == object.__self__.__class__.__module__
         elif inspect.getmodule(object) is not None:
             return module is inspect.getmodule(object)
         elif hasattr(object, '__module__'):
@@ -154,7 +156,7 @@ class DocTestFinder(doctest.DocTestFinder):
                 if isinstance(val, staticmethod):
                     val = getattr(obj, valname)
                 if isinstance(val, classmethod):
-                    val = getattr(obj, valname).im_func
+                    val = getattr(obj, valname).__func__
 
                 # Recurse to methods, properties, and nested classes.
                 if ((inspect.isfunction(val) or inspect.isclass(val) or

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -24,18 +24,19 @@ try:
 except ImportError:  
     # Python 2
     import __builtin__ as builtins
-import commands
 import doctest
 import inspect
 import logging
 import os
 import re
 import sys
-import traceback
-import unittest
 
 from inspect import getmodule
-from StringIO import StringIO
+from IPython.utils import py3compat
+if py3compat.PY3:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 # We are overriding the default doctest runner, so we need to import a few
 # things from doctest directly
@@ -51,7 +52,6 @@ import nose.core
 from nose.plugins import doctests, Plugin
 from nose.util import anyp, getpackage, test_address, resolve_name, tolist
 from six.moves import map
-from six.moves import zip
 
 # Our own imports
 

--- a/IPython/testing/plugin/iptest.py
+++ b/IPython/testing/plugin/iptest.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python
 """Nose-based test runner.
 """
+from __future__ import print_function
 
 from nose.core import main
 from nose.plugins.builtin import plugins
 from nose.plugins.doctests import Doctest
 
-import ipdoctest
-from ipdoctest import IPDocTestRunner
+from . import ipdoctest
+from .ipdoctest import IPDocTestRunner
 
 if __name__ == '__main__':
-    print 'WARNING: this code is incomplete!'
-    print
+    print('WARNING: this code is incomplete!')
+    print()
 
     pp = [x() for x in plugins]  # activate all builtin plugins first
     main(testRunner=IPDocTestRunner(),

--- a/IPython/testing/plugin/show_refs.py
+++ b/IPython/testing/plugin/show_refs.py
@@ -5,8 +5,6 @@ This is used by a companion test case.
 from __future__ import print_function
 
 import gc
-from six.moves import map
-from six.moves import zip
 
 class C(object):
    def __del__(self):
@@ -17,6 +15,6 @@ if __name__ == '__main__':
    c = C()
 
    c_refs = gc.get_referrers(c)
-   ref_ids = map(id,c_refs)
+   ref_ids = list(map(id, c_refs))
 
-   print('c referrers:',map(type,c_refs))
+   print('c referrers:', list(map(type, c_refs)))

--- a/IPython/testing/plugin/show_refs.py
+++ b/IPython/testing/plugin/show_refs.py
@@ -2,8 +2,11 @@
 
 This is used by a companion test case.
 """
+from __future__ import print_function
 
 import gc
+from six.moves import map
+from six.moves import zip
 
 class C(object):
    def __del__(self):
@@ -16,4 +19,4 @@ if __name__ == '__main__':
    c_refs = gc.get_referrers(c)
    ref_ids = map(id,c_refs)
 
-   print 'c referrers:',map(type,c_refs)
+   print('c referrers:',map(type,c_refs))

--- a/IPython/testing/plugin/simple.py
+++ b/IPython/testing/plugin/simple.py
@@ -3,6 +3,7 @@
 This file just contains doctests both using plain python and IPython prompts.
 All tests should be loaded by nose.
 """
+from __future__ import print_function
 
 def pyfunc():
     """Some pure python tests...

--- a/IPython/testing/plugin/simple.py
+++ b/IPython/testing/plugin/simple.py
@@ -16,10 +16,10 @@ def pyfunc():
     5
 
     >>> for i in range(3):
-    ...     print i,
-    ...     print i+1,
+    ...     print(i, end=' ')
+    ...     print(i+1, end=' ')
     ...
-    0 1 1 2 2 3
+    0 1 1 2 2 3 
     """
     return 'pyfunc'
 

--- a/IPython/testing/plugin/simplevars.py
+++ b/IPython/testing/plugin/simplevars.py
@@ -1,2 +1,3 @@
+from __future__ import print_function
 x = 1
-print 'x is:',x
+print('x is:',x)

--- a/IPython/testing/tests/test_decorators.py
+++ b/IPython/testing/tests/test_decorators.py
@@ -1,5 +1,6 @@
 """Tests for the decorators we've created for IPython.
 """
+from __future__ import print_function
 
 # Module imports
 # Std lib
@@ -33,11 +34,11 @@ def getargspec(obj):
     if inspect.isfunction(obj):
         func_obj = obj
     elif inspect.ismethod(obj):
-        func_obj = obj.im_func
+        func_obj = obj.__func__
     else:
         raise TypeError('arg is not a Python function')
-    args, varargs, varkw = inspect.getargs(func_obj.func_code)
-    return args, varargs, varkw, func_obj.func_defaults
+    args, varargs, varkw = inspect.getargs(func_obj.__code__)
+    return args, varargs, varkw, func_obj.__defaults__
 
 #-----------------------------------------------------------------------------
 # Testing functions
@@ -86,9 +87,9 @@ def doctest_bad(x,y=1,**k):
     >>> 1+1
     3
     """
-    print 'x:',x
-    print 'y:',y
-    print 'k:',k
+    print('x:',x)
+    print('y:',y)
+    print('k:',k)
 
 
 def call_doctest_bad():
@@ -136,7 +137,7 @@ class FooClass(object):
         >>> f = FooClass(3)
         junk
         """
-        print 'Making a FooClass.'
+        print('Making a FooClass.')
         self.x = x
         
     @skip_doctest

--- a/IPython/testing/tests/test_tools.py
+++ b/IPython/testing/tests/test_tools.py
@@ -14,6 +14,7 @@ Tests for testing.tools
 # Imports
 #-----------------------------------------------------------------------------
 from __future__ import with_statement
+from __future__ import print_function
 
 import os
 import unittest
@@ -75,16 +76,16 @@ def test_temp_pyfile():
 class TestAssertPrints(unittest.TestCase):
     def test_passing(self):
         with tt.AssertPrints("abc"):
-            print "abcd"
-            print "def"
-            print b"ghi"
+            print("abcd")
+            print("def")
+            print(b"ghi")
     
     def test_failing(self):
         def func():
             with tt.AssertPrints("abc"):
-                print "acd"
-                print "def"
-                print b"ghi"
+                print("acd")
+                print("def")
+                print(b"ghi")
         
         self.assertRaises(AssertionError, func)
 

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -336,8 +336,8 @@ class AssertPrints(object):
     Examples
     --------
     >>> with AssertPrints("abc", suppress=False):
-    ...     print "abcd"
-    ...     print "def"
+    ...     print("abcd")
+    ...     print("def")
     ... 
     abcd
     def

--- a/IPython/utils/PyColorize.py
+++ b/IPython/utils/PyColorize.py
@@ -52,11 +52,7 @@ except AttributeError:
     generate_tokens = tokenize._tokenize
 
 from IPython.utils.coloransi import *
-from .py3compat import PY3
-if PY3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from .py3compat import StringIO
 
 #############################################################################
 ### Python Source Parser (does Hilighting)

--- a/IPython/utils/PyColorize.py
+++ b/IPython/utils/PyColorize.py
@@ -38,7 +38,6 @@ _scheme_default = 'Linux'
 
 
 # Imports
-import StringIO
 import keyword
 import os
 import sys
@@ -53,6 +52,11 @@ except AttributeError:
     generate_tokens = tokenize._tokenize
 
 from IPython.utils.coloransi import *
+from .py3compat import PY3
+if PY3:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 #############################################################################
 ### Python Source Parser (does Hilighting)
@@ -143,13 +147,13 @@ class Parser:
 
         string_output = 0
         if out == 'str' or self.out == 'str' or \
-           isinstance(self.out,StringIO.StringIO):
+           isinstance(self.out, StringIO):
             # XXX - I don't really like this state handling logic, but at this
             # point I don't want to make major changes, so adding the
             # isinstance() check is the simplest I can do to ensure correct
             # behavior.
             out_old = self.out
-            self.out = StringIO.StringIO()
+            self.out = StringIO()
             string_output = 1
         elif out is not None:
             self.out = out
@@ -183,7 +187,7 @@ class Parser:
 
         # parse the source and write it
         self.pos = 0
-        text = StringIO.StringIO(self.raw)
+        text = StringIO(self.raw)
 
         error = False
         try:

--- a/IPython/utils/_tokenize_py2.py
+++ b/IPython/utils/_tokenize_py2.py
@@ -31,6 +31,9 @@ Older entry points
 are the same, except instead of generating tokens, tokeneater is a callback
 function to which the 5 fields described above are passed as 5 arguments,
 each time a new token is found."""
+from __future__ import print_function
+from six.moves import map
+from six.moves import zip
 
 __author__ = 'Ka-Ping Yee <ping@lfw.org>'
 __credits__ = ('GvR, ESR, Tim Peters, Thomas Wouters, Fred Drake, '
@@ -161,8 +164,8 @@ class StopTokenizing(Exception): pass
 def printtoken(type, token, srow_scol, erow_ecol, line): # for testing
     srow, scol = srow_scol
     erow, ecol = erow_ecol
-    print "%d,%d-%d,%d:\t%s\t%s" % \
-        (srow, scol, erow, ecol, tok_name[type], repr(token))
+    print("%d,%d-%d,%d:\t%s\t%s" % \
+        (srow, scol, erow, ecol, tok_name[type], repr(token)))
 
 def tokenize(readline, tokeneater=printtoken):
     """
@@ -307,7 +310,7 @@ def generate_tokens(readline):
 
         if contstr:                            # continued string
             if not line:
-                raise TokenError, ("EOF in multi-line string", strstart)
+                raise TokenError("EOF in multi-line string", strstart)
             endmatch = endprog.match(line)
             if endmatch:
                 pos = end = endmatch.end(0)
@@ -368,7 +371,7 @@ def generate_tokens(readline):
 
         else:                                  # continued statement
             if not line:
-                raise TokenError, ("EOF in multi-line statement", (lnum, 0))
+                raise TokenError("EOF in multi-line statement", (lnum, 0))
             continued = 0
 
         while pos < max:

--- a/IPython/utils/_tokenize_py3.py
+++ b/IPython/utils/_tokenize_py3.py
@@ -35,6 +35,8 @@ operators.  Additionally, all token lists start with an ENCODING token
 which tells you which encoding was used to decode the bytes stream.
 """
 from __future__ import absolute_import
+from six.moves import map
+from six.moves import zip
 
 __author__ = 'Ka-Ping Yee <ping@lfw.org>'
 __credits__ = ('GvR, ESR, Tim Peters, Thomas Wouters, Fred Drake, '

--- a/IPython/utils/attic.py
+++ b/IPython/utils/attic.py
@@ -21,6 +21,8 @@ import sys
 import warnings
 
 from IPython.utils.warn import warn
+from six.moves import map
+from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Code

--- a/IPython/utils/attic.py
+++ b/IPython/utils/attic.py
@@ -22,7 +22,6 @@ import warnings
 
 from IPython.utils.warn import warn
 from six.moves import map
-from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Code
@@ -48,7 +47,7 @@ class EvalDict:
 
     >>> text = "python"
 
-    >>> print "%(text.capitalize())s %(number/9.0).1f rules!" % EvalDict()
+    >>> print("%(text.capitalize())s %(number/9.0).1f rules!" % EvalDict())
     Python 2.1 rules!
     """
 

--- a/IPython/utils/capture.py
+++ b/IPython/utils/capture.py
@@ -16,11 +16,7 @@ from __future__ import print_function
 #-----------------------------------------------------------------------------
 
 import sys
-from .py3compat import PY3
-if PY3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from .py3compat import StringIO
 
 #-----------------------------------------------------------------------------
 # Classes and functions

--- a/IPython/utils/capture.py
+++ b/IPython/utils/capture.py
@@ -16,7 +16,11 @@ from __future__ import print_function
 #-----------------------------------------------------------------------------
 
 import sys
-from StringIO import StringIO
+from .py3compat import PY3
+if PY3:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 #-----------------------------------------------------------------------------
 # Classes and functions

--- a/IPython/utils/codeutil.py
+++ b/IPython/utils/codeutil.py
@@ -24,7 +24,12 @@ __docformat__ = "restructuredtext en"
 #-------------------------------------------------------------------------------
 
 import sys
-import types, copy_reg
+import types
+try:
+    import copyreg
+except ImportError:
+    # Python 2
+    import copy_reg as copyreg
 
 def code_ctor(*args):
     return types.CodeType(*args)
@@ -40,4 +45,4 @@ def reduce_code(co):
         args.insert(1, co.co_kwonlyargcount)
     return code_ctor, tuple(args)
 
-copy_reg.pickle(types.CodeType, reduce_code)
+copyreg.pickle(types.CodeType, reduce_code)

--- a/IPython/utils/coloransi.py
+++ b/IPython/utils/coloransi.py
@@ -166,7 +166,7 @@ class ColorSchemeTable(dict):
         Names are by default compared in a case-insensitive way, but this can
         be changed by setting the parameter case_sensitive to true."""
 
-        scheme_names = self.keys()
+        scheme_names = list(self.keys())
         if case_sensitive:
             valid_schemes = scheme_names
             scheme_test = scheme

--- a/IPython/utils/data.py
+++ b/IPython/utils/data.py
@@ -30,6 +30,6 @@ def flatten(seq):
 
 def chop(seq, size):
     """Chop a sequence into chunks of the given size."""
-    return [seq[i:i+size] for i in xrange(0,len(seq),size)]
+    return [seq[i:i+size] for i in range(0,len(seq),size)]
 
 

--- a/IPython/utils/dir2.py
+++ b/IPython/utils/dir2.py
@@ -17,6 +17,8 @@
 # Code
 #-----------------------------------------------------------------------------
 
+from .py3compat import string_types
+
 def get_class_members(cls):
     ret = dir(cls)
     if hasattr(cls, '__bases__'):
@@ -69,5 +71,5 @@ def dir2(obj):
     # filter out non-string attributes which may be stuffed by dir() calls
     # and poor coding in third-party modules
 
-    words = [w for w in words if isinstance(w, basestring)]
+    words = [w for w in words if isinstance(w, string_types)]
     return sorted(words)

--- a/IPython/utils/frame.py
+++ b/IPython/utils/frame.py
@@ -16,13 +16,11 @@ from __future__ import print_function
 #-----------------------------------------------------------------------------
 
 import sys
-from IPython.utils import py3compat
 
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
 
-@py3compat.doctest_refactor_print
 def extract_vars(*names,**kw):
     """Extract a set of variables by name from another frame.
 
@@ -40,7 +38,7 @@ def extract_vars(*names,**kw):
 
         In [2]: def func(x):
            ...:     y = 1
-           ...:     print sorted(extract_vars('x','y').items())
+           ...:     print(sorted(extract_vars('x','y').items()))
            ...:
 
         In [3]: func('hello')

--- a/IPython/utils/frame.py
+++ b/IPython/utils/frame.py
@@ -2,6 +2,7 @@
 """
 Utilities for working with stack frames.
 """
+from __future__ import print_function
 
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2008-2011  The IPython Development Team
@@ -78,8 +79,8 @@ def debugx(expr,pre_msg=''):
     expr->value pair."""
 
     cf = sys._getframe(1)
-    print '[DBG:%s] %s%s -> %r' % (cf.f_code.co_name,pre_msg,expr,
-                                   eval(expr,cf.f_globals,cf.f_locals))
+    print('[DBG:%s] %s%s -> %r' % (cf.f_code.co_name,pre_msg,expr,
+                                   eval(expr,cf.f_globals,cf.f_locals)))
 
 
 # deactivate it by uncommenting the following line, which makes it a no-op

--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -17,9 +17,15 @@ from __future__ import print_function
 import os
 import sys
 import tempfile
-from StringIO import StringIO
 from .capture import CapturedIO, capture_output
+
 from six.moves import filter
+
+from . import py3compat
+if py3compat.PY3:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 #-----------------------------------------------------------------------------
 # Code
@@ -58,7 +64,7 @@ class IOStream:
                       file=sys.stderr)
 
     def writelines(self, lines):
-        if isinstance(lines, basestring):
+        if isinstance(lines, py3compat.string_types):
             lines = [lines]
         for line in lines:
             self.write(line)
@@ -171,7 +177,7 @@ def ask_yes_no(prompt,default=None):
     ans = None
     while ans not in answers.keys():
         try:
-            ans = raw_input(prompt+' ').lower()
+            ans = py3compat.input(prompt+' ').lower()
             if not ans:  # response was an empty string
                 ans = default
         except KeyboardInterrupt:

--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -19,6 +19,7 @@ import sys
 import tempfile
 from StringIO import StringIO
 from .capture import CapturedIO, capture_output
+from six.moves import filter
 
 #-----------------------------------------------------------------------------
 # Code

--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -21,11 +21,7 @@ from .capture import CapturedIO, capture_output
 
 from six.moves import filter
 
-from . import py3compat
-if py3compat.PY3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from .py3compat import StringIO, string_types
 
 #-----------------------------------------------------------------------------
 # Code
@@ -64,7 +60,7 @@ class IOStream:
                       file=sys.stderr)
 
     def writelines(self, lines):
-        if isinstance(lines, py3compat.string_types):
+        if isinstance(lines, string_types):
             lines = [lines]
         for line in lines:
             self.write(line)

--- a/IPython/utils/ipstruct.py
+++ b/IPython/utils/ipstruct.py
@@ -78,7 +78,7 @@ class Struct(dict):
         >>> try:
         ...     s['b'] = 20
         ... except KeyError:
-        ...     print 'this is not allowed'
+        ...     print('this is not allowed')
         ...
         this is not allowed
         """
@@ -103,7 +103,7 @@ class Struct(dict):
         >>> try:
         ...     s.get = 10
         ... except AttributeError:
-        ...     print "you can't set a class member"
+        ...     print("you can't set a class member")
         ...
         you can't set a class member
         """
@@ -139,7 +139,7 @@ class Struct(dict):
         >>> try:
         ...     s.b
         ... except AttributeError:
-        ...     print "I don't have that key"
+        ...     print("I don't have that key")
         ...
         I don't have that key
         """

--- a/IPython/utils/jsonutil.py
+++ b/IPython/utils/jsonutil.py
@@ -15,6 +15,9 @@ import math
 import re
 import types
 from datetime import datetime
+import six
+from six.moves import map
+from six.moves import zip
 
 try:
     # base64.encodestring is deprecated in Python 3.x
@@ -42,7 +45,7 @@ ISO8601_PAT=re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+)Z?([\+\-]\d{
 def rekey(dikt):
     """Rekey a dict that has been forced to use str keys where there should be
     ints by json."""
-    for k in dikt.iterkeys():
+    for k in six.iterkeys(dikt):
         if isinstance(k, basestring):
             ik=fk=None
             try:
@@ -66,7 +69,7 @@ def extract_dates(obj):
     """extract ISO8601 dates from unpacked JSON"""
     if isinstance(obj, dict):
         obj = dict(obj) # don't clobber
-        for k,v in obj.iteritems():
+        for k,v in six.iteritems(obj):
             obj[k] = extract_dates(v)
     elif isinstance(obj, (list, tuple)):
         obj = [ extract_dates(o) for o in obj ]
@@ -83,7 +86,7 @@ def squash_dates(obj):
     """squash datetime objects into ISO8601 strings"""
     if isinstance(obj, dict):
         obj = dict(obj) # don't clobber
-        for k,v in obj.iteritems():
+        for k,v in six.iteritems(obj):
             obj[k] = squash_dates(v)
     elif isinstance(obj, (list, tuple)):
         obj = [ squash_dates(o) for o in obj ]
@@ -183,7 +186,7 @@ def json_clean(obj):
     """
     # types that are 'atomic' and ok in json as-is.  bool doesn't need to be
     # listed explicitly because bools pass as int instances
-    atomic_ok = (unicode, int, types.NoneType)
+    atomic_ok = (unicode, int, type(None))
 
     # containers that we need to convert into lists
     container_to_list = (tuple, set, types.GeneratorType)
@@ -218,7 +221,7 @@ def json_clean(obj):
                              'key collision would lead to dropped values')
         # If all OK, proceed by making the new dict that will be json-safe
         out = {}
-        for k,v in obj.iteritems():
+        for k,v in six.iteritems(obj):
             out[str(k)] = json_clean(v)
         return out
 

--- a/IPython/utils/jsonutil.py
+++ b/IPython/utils/jsonutil.py
@@ -17,7 +17,6 @@ import types
 from datetime import datetime
 import six
 from six.moves import map
-from six.moves import zip
 
 try:
     # base64.encodestring is deprecated in Python 3.x
@@ -46,7 +45,7 @@ def rekey(dikt):
     """Rekey a dict that has been forced to use str keys where there should be
     ints by json."""
     for k in six.iterkeys(dikt):
-        if isinstance(k, basestring):
+        if isinstance(k, py3compat.string_types):
             ik=fk=None
             try:
                 ik = int(k)
@@ -73,7 +72,7 @@ def extract_dates(obj):
             obj[k] = extract_dates(v)
     elif isinstance(obj, (list, tuple)):
         obj = [ extract_dates(o) for o in obj ]
-    elif isinstance(obj, basestring):
+    elif isinstance(obj, py3compat.string_types):
         m = ISO8601_PAT.match(obj)
         if m:
             # FIXME: add actual timezone support
@@ -175,7 +174,7 @@ def json_clean(obj):
     --------
     >>> json_clean(4)
     4
-    >>> json_clean(range(10))
+    >>> json_clean(list(range(10)))
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     >>> sorted(json_clean(dict(x=1, y=2)).items())
     [('x', 1), ('y', 2)]
@@ -186,7 +185,7 @@ def json_clean(obj):
     """
     # types that are 'atomic' and ok in json as-is.  bool doesn't need to be
     # listed explicitly because bools pass as int instances
-    atomic_ok = (unicode, int, type(None))
+    atomic_ok = (py3compat.unicode_type, int, type(None))
 
     # containers that we need to convert into lists
     container_to_list = (tuple, set, types.GeneratorType)

--- a/IPython/utils/jsonutil.py
+++ b/IPython/utils/jsonutil.py
@@ -15,7 +15,7 @@ import math
 import re
 import types
 from datetime import datetime
-import six
+import s
 from six.moves import map
 
 try:
@@ -44,7 +44,7 @@ ISO8601_PAT=re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+)Z?([\+\-]\d{
 def rekey(dikt):
     """Rekey a dict that has been forced to use str keys where there should be
     ints by json."""
-    for k in six.iterkeys(dikt):
+    for k in dikt:
         if isinstance(k, py3compat.string_types):
             ik=fk=None
             try:

--- a/IPython/utils/jsonutil.py
+++ b/IPython/utils/jsonutil.py
@@ -15,7 +15,7 @@ import math
 import re
 import types
 from datetime import datetime
-import s
+import six
 from six.moves import map
 
 try:

--- a/IPython/utils/openpy.py
+++ b/IPython/utils/openpy.py
@@ -11,8 +11,8 @@ from io import TextIOWrapper, BytesIO
 import os.path
 import re
 
-cookie_re = re.compile(ur"coding[:=]\s*([-\w.]+)", re.UNICODE)
-cookie_comment_re = re.compile(ur"^\s*#.*coding[:=]\s*([-\w.]+)", re.UNICODE)
+cookie_re = re.compile(u"coding[:=]\\s*([-\\w.]+)", re.UNICODE)
+cookie_comment_re = re.compile(u"^\\s*#.*coding[:=]\\s*([-\\w.]+)", re.UNICODE)
 
 try:
     # Available in Python 3

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -29,6 +29,8 @@ from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.process import system
 from IPython.utils.importstring import import_item
 from IPython.utils import py3compat
+from six.moves import map
+from six.moves import zip
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -30,7 +30,6 @@ from IPython.utils.process import system
 from IPython.utils.importstring import import_item
 from IPython.utils import py3compat
 from six.moves import map
-from six.moves import zip
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
@@ -157,7 +156,7 @@ def filefind(filename, path_dirs=None):
 
     if path_dirs is None:
         path_dirs = ("",)
-    elif isinstance(path_dirs, basestring):
+    elif isinstance(path_dirs, py3compat.string_types):
         path_dirs = (path_dirs,)
 
     for path in path_dirs:

--- a/IPython/utils/pickleshare.py
+++ b/IPython/utils/pickleshare.py
@@ -32,6 +32,7 @@ Author: Ville Vainio <vivainio@gmail.com>
 License: MIT open source license.
 
 """
+from __future__ import print_function
 
 from IPython.external.path import path as Path
 import os,stat,time
@@ -138,7 +139,7 @@ class PickleShareDB(collections.MutableMapping):
             try:
                 all.update(self[f])
             except KeyError:
-                print "Corrupt",f,"deleted - hset is not threadsafe!"
+                print("Corrupt",f,"deleted - hset is not threadsafe!")
                 del self[f]
 
             self.uncache(f)
@@ -280,25 +281,25 @@ class PickleShareLink:
 def test():
     db = PickleShareDB('~/testpickleshare')
     db.clear()
-    print "Should be empty:",db.items()
+    print("Should be empty:",db.items())
     db['hello'] = 15
     db['aku ankka'] = [1,2,313]
     db['paths/nest/ok/keyname'] = [1,(5,46)]
     db.hset('hash', 'aku', 12)
     db.hset('hash', 'ankka', 313)
-    print "12 =",db.hget('hash','aku')
-    print "313 =",db.hget('hash','ankka')
-    print "all hashed",db.hdict('hash')
-    print db.keys()
-    print db.keys('paths/nest/ok/k*')
-    print dict(db) # snapsot of whole db
+    print("12 =",db.hget('hash','aku'))
+    print("313 =",db.hget('hash','ankka'))
+    print("all hashed",db.hdict('hash'))
+    print(db.keys())
+    print(db.keys('paths/nest/ok/k*'))
+    print(dict(db)) # snapsot of whole db
     db.uncache() # frees memory, causes re-reads later
 
     # shorthand for accessing deeply nested files
     lnk = db.getlink('myobjects/test')
     lnk.foo = 2
     lnk.bar = lnk.foo + 5
-    print lnk.bar # 7
+    print(lnk.bar) # 7
 
 def stress():
     db = PickleShareDB('~/fsdbtest')
@@ -316,7 +317,7 @@ def stress():
             db[str(j)] = db.get(str(j), []) + [(i,j,"proc %d" % os.getpid())]
             db.hset('hash',j, db.hget('hash',j,15) + 1 )
 
-        print i,
+        print(i, end=' ')
         sys.stdout.flush()
         if i % 10 == 0:
             db.uncache()
@@ -335,7 +336,7 @@ def main():
     DB = PickleShareDB
     import sys
     if len(sys.argv) < 2:
-        print usage
+        print(usage)
         return
 
     cmd = sys.argv[1]
@@ -355,7 +356,7 @@ def main():
     elif cmd == 'testwait':
         db = DB(args[0])
         db.clear()
-        print db.waitget('250')
+        print(db.waitget('250'))
     elif cmd == 'test':
         test()
         stress()

--- a/IPython/utils/pickleshare.py
+++ b/IPython/utils/pickleshare.py
@@ -37,7 +37,10 @@ from __future__ import print_function
 from IPython.external.path import path as Path
 import os,stat,time
 import collections
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 import glob
 
 def gethashfile(key):

--- a/IPython/utils/pickleutil.py
+++ b/IPython/utils/pickleutil.py
@@ -19,6 +19,7 @@ import copy
 import logging
 import sys
 from types import FunctionType
+import six
 
 try:
     import cPickle as pickle
@@ -30,9 +31,9 @@ try:
 except:
     numpy = None
 
-import codeutil  # This registers a hook when it's imported
-import py3compat
-from importstring import import_item
+from . import codeutil  # This registers a hook when it's imported
+from . import py3compat
+from .importstring import import_item
 
 from IPython.config import Application
 
@@ -109,9 +110,9 @@ class CannedFunction(CannedObject):
 
     def __init__(self, f):
         self._check_type(f)
-        self.code = f.func_code
-        if f.func_defaults:
-            self.defaults = [ can(fd) for fd in f.func_defaults ]
+        self.code = f.__code__
+        if f.__defaults__:
+            self.defaults = [ can(fd) for fd in f.__defaults__ ]
         else:
             self.defaults = None
         self.module = f.__module__ or '__main__'
@@ -248,7 +249,7 @@ def can(obj):
     
     import_needed = False
     
-    for cls,canner in can_map.iteritems():
+    for cls,canner in six.iteritems(can_map):
         if isinstance(cls, basestring):
             import_needed = True
             break
@@ -273,7 +274,7 @@ def can_dict(obj):
     """can the *values* of a dict"""
     if istype(obj, dict):
         newobj = {}
-        for k, v in obj.iteritems():
+        for k, v in six.iteritems(obj):
             newobj[k] = can(v)
         return newobj
     else:
@@ -293,7 +294,7 @@ def uncan(obj, g=None):
     """invert canning"""
     
     import_needed = False
-    for cls,uncanner in uncan_map.iteritems():
+    for cls,uncanner in six.iteritems(uncan_map):
         if isinstance(cls, basestring):
             import_needed = True
             break
@@ -311,7 +312,7 @@ def uncan(obj, g=None):
 def uncan_dict(obj, g=None):
     if istype(obj, dict):
         newobj = {}
-        for k, v in obj.iteritems():
+        for k, v in six.iteritems(obj):
             newobj[k] = uncan(v,g)
         return newobj
     else:

--- a/IPython/utils/pickleutil.py
+++ b/IPython/utils/pickleutil.py
@@ -91,7 +91,7 @@ class CannedObject(object):
 class Reference(CannedObject):
     """object for wrapping a remote reference by name."""
     def __init__(self, name):
-        if not isinstance(name, basestring):
+        if not isinstance(name, py3compat.string_types):
             raise TypeError("illegal name: %r"%name)
         self.name = name
         self.buffers = []
@@ -220,7 +220,7 @@ def _import_mapping(mapping, original=None):
     log = _logger()
     log.debug("Importing canning map")
     for key,value in mapping.items():
-        if isinstance(key, basestring):
+        if isinstance(key, py3compat.string_types):
             try:
                 cls = import_item(key)
             except Exception:
@@ -250,7 +250,7 @@ def can(obj):
     import_needed = False
     
     for cls,canner in six.iteritems(can_map):
-        if isinstance(cls, basestring):
+        if isinstance(cls, py3compat.string_types):
             import_needed = True
             break
         elif istype(obj, cls):
@@ -295,7 +295,7 @@ def uncan(obj, g=None):
     
     import_needed = False
     for cls,uncanner in six.iteritems(uncan_map):
-        if isinstance(cls, basestring):
+        if isinstance(cls, py3compat.string_types):
             import_needed = True
             break
         elif isinstance(obj, cls):

--- a/IPython/utils/pickleutil.py
+++ b/IPython/utils/pickleutil.py
@@ -219,7 +219,7 @@ def _import_mapping(mapping, original=None):
     """
     log = _logger()
     log.debug("Importing canning map")
-    for key,value in mapping.items():
+    for key in list(mapping):
         if isinstance(key, py3compat.string_types):
             try:
                 cls = import_item(key)

--- a/IPython/utils/py3compat.py
+++ b/IPython/utils/py3compat.py
@@ -36,10 +36,19 @@ def cast_bytes(s, encoding=None):
         return encode(s, encoding)
     return s
 
+if sys.version_info[0] >= 3:
+    PY3 = True
+    string_types = (str,)
+    unicode_type = str
+else:
+    PY3 = False
+    string_types = (str, unicode)
+    unicode_type = unicode
+
 def _modify_str_or_docstring(str_change_func):
     @functools.wraps(str_change_func)
     def wrapper(func_or_str):
-        if isinstance(func_or_str, basestring):
+        if isinstance(func_or_str, string_types):
             func = None
             doc = func_or_str
         else:
@@ -54,30 +63,10 @@ def _modify_str_or_docstring(str_change_func):
         return doc
     return wrapper
 
-def safe_unicode(e):
-    """unicode(e) with various fallbacks. Used for exceptions, which may not be
-    safe to call unicode() on.
-    """
-    try:
-        return unicode(e)
-    except UnicodeError:
-        pass
 
-    try:
-        return py3compat.str_to_unicode(str(e))
-    except UnicodeError:
-        pass
 
-    try:
-        return py3compat.str_to_unicode(repr(e))
-    except UnicodeError:
-        pass
 
-    return u'Unrecoverably corrupt evalue'
-
-if sys.version_info[0] >= 3:
-    PY3 = True
-    
+if PY3:
     input = input
     builtin_mod_name = "builtins"
     
@@ -86,8 +75,6 @@ if sys.version_info[0] >= 3:
     str_to_bytes = encode
     bytes_to_str = decode
     cast_bytes_py2 = no_code
-    
-    string_types = (str,)
     
     def isidentifier(s, dotted=False):
         if dotted:
@@ -124,10 +111,11 @@ if sys.version_info[0] >= 3:
         
         Accepts a string or a function, so it can be used as a decorator."""
         return s.format(u='')
+    
+    # Safe way to get a unicode extension, needed on Python 2
+    safe_unicode = str
 
 else:
-    PY3 = False
-    
     input = raw_input
     builtin_mod_name = "__builtin__"
     
@@ -136,8 +124,6 @@ else:
     str_to_bytes = no_code
     bytes_to_str = no_code
     cast_bytes_py2 = cast_bytes
-    
-    string_types = (str, unicode)
     
     import re
     _name_re = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*$")
@@ -206,3 +192,24 @@ else:
             else:
                 filename = fname
             builtins.execfile(filename, *where)
+    
+    def safe_unicode(e):
+        """unicode(e) with various fallbacks. Used for exceptions, which may not be
+        safe to call unicode() on.
+        """
+        try:
+            return unicode(e)
+        except UnicodeError:
+            pass
+    
+        try:
+            return decode(str(e))
+        except UnicodeError:
+            pass
+    
+        try:
+            return decode(repr(e))
+        except UnicodeError:
+            pass
+    
+        return u'Unrecoverably corrupt evalue'

--- a/IPython/utils/py3compat.py
+++ b/IPython/utils/py3compat.py
@@ -97,7 +97,7 @@ if sys.version_info[0] >= 3:
     def execfile(fname, glob, loc=None):
         loc = loc if (loc is not None) else glob
         with open(fname, 'rb') as f:
-            exec compile(f.read(), fname, 'exec') in glob, loc
+            exec(compile(f.read(), fname, 'exec'), glob, loc)
     
     # Refactor print statements in doctests.
     _print_statement_re = re.compile(r"\bprint (?P<expr>.*)$", re.MULTILINE)
@@ -194,7 +194,7 @@ else:
                 filename = unicode_to_str(fname)
             else:
                 filename = fname
-            exec compile(scripttext, filename, 'exec') in glob, loc
+            exec(compile(scripttext, filename, 'exec'), glob, loc)
     else:
         def execfile(fname, *where):
             if isinstance(fname, unicode):

--- a/IPython/utils/py3compat.py
+++ b/IPython/utils/py3compat.py
@@ -114,6 +114,8 @@ if PY3:
     
     # Safe way to get a unicode extension, needed on Python 2
     safe_unicode = str
+    
+    from io import StringIO
 
 else:
     input = raw_input
@@ -213,3 +215,5 @@ else:
             pass
     
         return u'Unrecoverably corrupt evalue'
+    
+    from StringIO import StringIO

--- a/IPython/utils/py3compat.py
+++ b/IPython/utils/py3compat.py
@@ -1,6 +1,10 @@
 # coding: utf-8
 """Compatibility tricks for Python 3. Mainly to do with unicode."""
-import __builtin__
+try:
+    import builtins
+except ImportError:  
+    # Python 2
+    import __builtin__ as builtins
 import functools
 import sys
 import re
@@ -187,7 +191,7 @@ else:
             # The rstrip() is necessary b/c trailing whitespace in files will
             # cause an IndentationError in Python 2.6 (this was fixed in 2.7,
             # but we still support 2.6).  See issue 1027.
-            scripttext = __builtin__.open(fname).read().rstrip() + '\n'
+            scripttext = builtins.open(fname).read().rstrip() + '\n'
             # compile converts unicode filename to str assuming
             # ascii. Let's do the conversion before calling compile
             if isinstance(fname, unicode):
@@ -201,4 +205,4 @@ else:
                 filename = fname.encode(sys.getfilesystemencoding())
             else:
                 filename = fname
-            __builtin__.execfile(filename, *where)
+            builtins.execfile(filename, *where)

--- a/IPython/utils/strdispatch.py
+++ b/IPython/utils/strdispatch.py
@@ -17,7 +17,7 @@ class StrDispatch(object):
     >>> dis.add_s('hei',34, priority = 4)
     >>> dis.add_s('hei',123, priority = 2)
     >>> dis.add_re('h.i', 686)
-    >>> print list(dis.flat_matches('hei'))
+    >>> print(list(dis.flat_matches('hei')))
     [123, 34, 686]
     """
 

--- a/IPython/utils/tests/test_io.py
+++ b/IPython/utils/tests/test_io.py
@@ -21,11 +21,7 @@ import nose.tools as nt
 
 from IPython.testing.ipunittest import ParametricTestCase
 from IPython.utils.io import Tee, capture_output
-from IPython.utils.py3compat import doctest_refactor_print, PY3
-if PY3:
-    from io import StringIO
-else:
-    from StringIO import StringIO    
+from IPython.utils.py3compat import doctest_refactor_print, StringIO
 
 #-----------------------------------------------------------------------------
 # Tests

--- a/IPython/utils/tests/test_io.py
+++ b/IPython/utils/tests/test_io.py
@@ -15,14 +15,17 @@ from __future__ import print_function
 
 import sys
 
-from StringIO import StringIO
 from subprocess import Popen, PIPE
 
 import nose.tools as nt
 
 from IPython.testing.ipunittest import ParametricTestCase
 from IPython.utils.io import Tee, capture_output
-from IPython.utils.py3compat import doctest_refactor_print
+from IPython.utils.py3compat import doctest_refactor_print, PY3
+if PY3:
+    from io import StringIO
+else:
+    from StringIO import StringIO    
 
 #-----------------------------------------------------------------------------
 # Tests
@@ -34,7 +37,7 @@ def test_tee_simple():
     chan = StringIO()
     text = 'Hello'
     tee = Tee(chan, channel='stdout')
-    print(text, file=chan)
+    print(text, file=tee)
     nt.assert_equal(chan.getvalue(), text+"\n")
 
 

--- a/IPython/utils/tests/test_jsonutil.py
+++ b/IPython/utils/tests/test_jsonutil.py
@@ -23,6 +23,7 @@ from IPython.testing import decorators as dec
 from IPython.utils import jsonutil, tz
 from ..jsonutil import json_clean, encode_images
 from ..py3compat import unicode_to_str, str_to_bytes
+import six
 
 #-----------------------------------------------------------------------------
 # Test functions
@@ -73,7 +74,7 @@ def test_encode_images():
         'image/jpeg' : jpegdata,
     }
     encoded = encode_images(fmt)
-    for key, value in fmt.iteritems():
+    for key, value in six.iteritems(fmt):
         # encoded has unicode, want bytes
         decoded = decodestring(encoded[key].encode('ascii'))
         yield nt.assert_equal(decoded, value)
@@ -81,11 +82,11 @@ def test_encode_images():
     yield nt.assert_equal(encoded, encoded2)
     
     b64_str = {}
-    for key, encoded in encoded.iteritems():
+    for key, encoded in six.iteritems(encoded):
         b64_str[key] = unicode_to_str(encoded)
     encoded3 = encode_images(b64_str)
     yield nt.assert_equal(encoded3, b64_str)
-    for key, value in fmt.iteritems():
+    for key, value in six.iteritems(fmt):
         # encoded3 has str, want bytes
         decoded = decodestring(str_to_bytes(encoded3[key]))
         yield nt.assert_equal(decoded, value)

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -35,19 +35,20 @@ from IPython.utils import path
 from IPython.utils import py3compat
 from IPython.utils.tempdir import TemporaryDirectory
 from six.moves import map
-from six.moves import zip
 
 # Platform-dependent imports
 try:
-    import _winreg as wreg
+    import winreg as wreg  # Python 3
 except ImportError:
-    #Fake _winreg module on none windows platforms
-    import types
-    wr_name = "winreg" if py3compat.PY3 else "_winreg"
-    sys.modules[wr_name] = types.ModuleType(wr_name)
-    import _winreg as wreg
-    #Add entries that needs to be stubbed by the testing code
-    (wreg.OpenKey, wreg.QueryValueEx,) = (None, None)
+    try:
+        import _winreg as wreg  # Python 2
+    except ImportError:
+        # Fake _winreg module on non-Windows platforms
+        import types
+        wr_name = "winreg" if py3compat.PY3 else "_winreg"
+        wreg = sys.modules[wr_name] = types.ModuleType(wr_name)
+        # Add entries that needs to be stubbed by the testing code
+        (wreg.OpenKey, wreg.QueryValueEx,) = (None, None)
 
 try:
     reload
@@ -112,7 +113,7 @@ def teardown_environment():
     os.chdir(old_wd)
     reload(path)
 
-    for key in env.keys():
+    for key in list(env.keys()):
         if key not in oldenv:
             del env[key]
     env.update(oldenv)
@@ -501,8 +502,8 @@ class TestShellGlob(object):
 
     @classmethod
     def setUpClass(cls):
-        cls.filenames_start_with_a = map('a{0}'.format, list(range(3)))
-        cls.filenames_end_with_b = map('{0}b'.format, list(range(3)))
+        cls.filenames_start_with_a = ['a0', 'a1', 'a2']
+        cls.filenames_end_with_b = ['0b', '1b', '2b']
         cls.filenames = cls.filenames_start_with_a + cls.filenames_end_with_b
         cls.tempdir = TemporaryDirectory()
         td = cls.tempdir.name

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -34,6 +34,8 @@ from IPython.testing.tools import make_tempfile, AssertPrints
 from IPython.utils import path
 from IPython.utils import py3compat
 from IPython.utils.tempdir import TemporaryDirectory
+from six.moves import map
+from six.moves import zip
 
 # Platform-dependent imports
 try:
@@ -499,8 +501,8 @@ class TestShellGlob(object):
 
     @classmethod
     def setUpClass(cls):
-        cls.filenames_start_with_a = map('a{0}'.format, range(3))
-        cls.filenames_end_with_b = map('{0}b'.format, range(3))
+        cls.filenames_start_with_a = map('a{0}'.format, list(range(3)))
+        cls.filenames_end_with_b = map('{0}b'.format, list(range(3)))
         cls.filenames = cls.filenames_start_with_a + cls.filenames_end_with_b
         cls.tempdir = TemporaryDirectory()
         td = cls.tempdir.name

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 """Tests for IPython.utils.text"""
+from __future__ import print_function
 
 #-----------------------------------------------------------------------------
 #  Copyright (C) 2011  The IPython Development Team
@@ -45,11 +46,11 @@ def test_columnize_random():
         longer_line = max([len(x) for x in out.split('\n')])
         longer_element = max(rand_len)
         if longer_line > displaywidth:
-            print "Columnize displayed something lager than displaywidth : %s " % longer_line
-            print "longer element : %s " % longer_element
-            print "displaywidth : %s " % displaywidth
-            print "number of element : %s " % nitems
-            print "size of each element :\n %s" % rand_len
+            print("Columnize displayed something lager than displaywidth : %s " % longer_line)
+            print("longer element : %s " % longer_element)
+            print("displaywidth : %s " % displaywidth)
+            print("number of element : %s " % nitems)
+            print("size of each element :\n %s" % rand_len)
             assert False
 
 def test_columnize_medium():

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -148,16 +148,16 @@ class TestTraitType(TestCase):
 
         a = A()
         self.assertEqual(a._trait_values, {})
-        self.assertEqual(a._trait_dyn_inits.keys(), ['x'])
+        self.assertEqual(list(a._trait_dyn_inits.keys()), ['x'])
         self.assertEqual(a.x, 11)
         self.assertEqual(a._trait_values, {'x': 11})
         b = B()
         self.assertEqual(b._trait_values, {'x': 20})
-        self.assertEqual(a._trait_dyn_inits.keys(), ['x'])
+        self.assertEqual(list(a._trait_dyn_inits.keys()), ['x'])
         self.assertEqual(b.x, 20)
         c = C()
         self.assertEqual(c._trait_values, {})
-        self.assertEqual(a._trait_dyn_inits.keys(), ['x'])
+        self.assertEqual(list(a._trait_dyn_inits.keys()), ['x'])
         self.assertEqual(c.x, 21)
         self.assertEqual(c._trait_values, {'x': 21})
         # Ensure that the base class remains unmolested when the _default
@@ -165,7 +165,7 @@ class TestTraitType(TestCase):
         a = A()
         c = C()
         self.assertEqual(a._trait_values, {})
-        self.assertEqual(a._trait_dyn_inits.keys(), ['x'])
+        self.assertEqual(list(a._trait_dyn_inits.keys()), ['x'])
         self.assertEqual(a.x, 11)
         self.assertEqual(a._trait_values, {'x': 11})
 

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -639,6 +639,7 @@ class TraitTestBase(TestCase):
     def test_bad_values(self):
         if hasattr(self, '_bad_values'):
             for value in self._bad_values:
+                print(value)
                 try:
                     self.assertRaises(TraitError, self.assign, value)
                 except AssertionError:
@@ -680,7 +681,7 @@ class TestInt(TraitTestBase):
                       10.1, -10.1, '10L', '-10L', '10.1', '-10.1', u'10L',
                       u'-10L', u'10.1', u'-10.1',  '10', '-10', u'10', u'-10']
     if not py3compat.PY3:
-        _bad_values.extend([10, -10, 10*sys.maxint, -10*sys.maxint])
+        _bad_values.extend([long(10), long(-10), 10*sys.maxint, -10*sys.maxint])
 
 
 class LongTrait(HasTraits):
@@ -742,7 +743,7 @@ class TestFloat(TraitTestBase):
                       1j, '10', '-10', '10L', '-10L', '10.1', '-10.1', u'10',
                       u'-10', u'10L', u'-10L', u'10.1', u'-10.1']
     if not py3compat.PY3:
-        _bad_values.extend([10, -10])
+        _bad_values.extend([long(10), long(-10)])
 
 
 class ComplexTrait(HasTraits):
@@ -758,7 +759,7 @@ class TestComplex(TraitTestBase):
                       10.1j, 10.1+10.1j, 10.1-10.1j]
     _bad_values    = [u'10L', u'-10L', 'ten', [10], {'ten': 10},(10,), None]
     if not py3compat.PY3:
-        _bad_values.extend([10, -10])
+        _bad_values.extend([long(10), long(-10)])
 
 
 class BytesTrait(HasTraits):

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -680,20 +680,20 @@ class TestInt(TraitTestBase):
                       10.1, -10.1, '10L', '-10L', '10.1', '-10.1', u'10L',
                       u'-10L', u'10.1', u'-10.1',  '10', '-10', u'10', u'-10']
     if not py3compat.PY3:
-        _bad_values.extend([10L, -10L, 10*sys.maxint, -10*sys.maxint])
+        _bad_values.extend([10, -10, 10*sys.maxint, -10*sys.maxint])
 
 
 class LongTrait(HasTraits):
 
-    value = Long(99L)
+    value = Long(99)
 
 class TestLong(TraitTestBase):
 
     obj = LongTrait()
 
-    _default_value = 99L
-    _good_values   = [10, -10, 10L, -10L]
-    _bad_values    = ['ten', u'ten', [10], [10l], {'ten': 10},(10,),(10L,),
+    _default_value = 99
+    _good_values   = [10, -10, 10, -10]
+    _bad_values    = ['ten', u'ten', [10], [10], {'ten': 10},(10,),(10,),
                       None, 1j, 10.1, -10.1, '10', '-10', '10L', '-10L', '10.1',
                       '-10.1', u'10', u'-10', u'10L', u'-10L', u'10.1',
                       u'-10.1']
@@ -724,7 +724,7 @@ class TestInteger(TestLong):
         if py3compat.PY3:
             raise SkipTest("not relevant on py3")
 
-        self.obj.value = 100L
+        self.obj.value = 100
         self.assertEqual(type(self.obj.value), int)
 
 
@@ -742,7 +742,7 @@ class TestFloat(TraitTestBase):
                       1j, '10', '-10', '10L', '-10L', '10.1', '-10.1', u'10',
                       u'-10', u'10L', u'-10L', u'10.1', u'-10.1']
     if not py3compat.PY3:
-        _bad_values.extend([10L, -10L])
+        _bad_values.extend([10, -10])
 
 
 class ComplexTrait(HasTraits):
@@ -758,7 +758,7 @@ class TestComplex(TraitTestBase):
                       10.1j, 10.1+10.1j, 10.1-10.1j]
     _bad_values    = [u'10L', u'-10L', 'ten', [10], {'ten': 10},(10,), None]
     if not py3compat.PY3:
-        _bad_values.extend([10L, -10L])
+        _bad_values.extend([10, -10])
 
 
 class BytesTrait(HasTraits):
@@ -772,7 +772,7 @@ class TestBytes(TraitTestBase):
     _default_value = b'string'
     _good_values   = [b'10', b'-10', b'10L',
                       b'-10L', b'10.1', b'-10.1', b'string']
-    _bad_values    = [10, -10, 10L, -10L, 10.1, -10.1, 1j, [10],
+    _bad_values    = [10, -10, 10, -10, 10.1, -10.1, 1j, [10],
                       ['ten'],{'ten': 10},(10,), None,  u'string']
 
 
@@ -787,7 +787,7 @@ class TestUnicode(TraitTestBase):
     _default_value = u'unicode'
     _good_values   = ['10', '-10', '10L', '-10L', '10.1',
                       '-10.1', '', u'', 'string', u'string', u"€"]
-    _bad_values    = [10, -10, 10L, -10L, 10.1, -10.1, 1j,
+    _bad_values    = [10, -10, 10, -10, 10.1, -10.1, 1j,
                       [10], ['ten'], [u'ten'], {'ten': 10},(10,), None]
 
 
@@ -843,7 +843,7 @@ class TestList(TraitTestBase):
     obj = ListTrait()
 
     _default_value = []
-    _good_values = [[], [1], range(10)]
+    _good_values = [[], [1], list(range(10))]
     _bad_values = [10, [1,'a'], 'a', (1,2)]
 
 class LenListTrait(HasTraits):
@@ -855,8 +855,8 @@ class TestLenList(TraitTestBase):
     obj = LenListTrait()
 
     _default_value = [0]
-    _good_values = [[1], range(2)]
-    _bad_values = [10, [1,'a'], 'a', (1,2), [], range(3)]
+    _good_values = [[1], list(range(2))]
+    _bad_values = [10, [1,'a'], 'a', (1,2), [], list(range(3))]
 
 class TupleTrait(HasTraits):
 

--- a/IPython/utils/tests/test_wildcard.py
+++ b/IPython/utils/tests/test_wildcard.py
@@ -51,85 +51,75 @@ class Tests (unittest.TestCase):
     def test_case(self):
         ns=root.__dict__
         tests=[
-         ("a*",     ["abbot","abel","active","arna",]),
-         ("?b*.?o*",["abbot.koppel","abbot.loop","abel.koppel","abel.loop",]),
-         ("_a*",    []),
-         ("_*anka", ["__anka",]),
-         ("_*a*",   ["__anka",]),
+         ("a*",     {"abbot","abel","active","arna",}),
+         ("?b*.?o*",{"abbot.koppel","abbot.loop","abel.koppel","abel.loop",}),
+         ("_a*",    set()),
+         ("_*anka", {"__anka",}),
+         ("_*a*",   {"__anka",}),
         ]
         for pat,res in tests:
-            res.sort()
             a=wildcard.list_namespace(ns,"all",pat,ignore_case=False,
                                       show_all=False).keys()
-            a.sort()
-            self.assertEqual(a,res)
+            self.assertEqual(set(a),res)
 
     def test_case_showall(self):
         ns=root.__dict__
         tests=[
-         ("a*",     ["abbot","abel","active","arna",]),
-         ("?b*.?o*",["abbot.koppel","abbot.loop","abel.koppel","abel.loop",]),
-         ("_a*",    ["_apan"]),
-         ("_*anka", ["__anka",]),
-         ("_*a*",   ["__anka","_apan",]),
+         ("a*",     {"abbot","abel","active","arna",}),
+         ("?b*.?o*",{"abbot.koppel","abbot.loop","abel.koppel","abel.loop",}),
+         ("_a*",    {"_apan"}),
+         ("_*anka", {"__anka",}),
+         ("_*a*",   {"__anka","_apan",}),
         ]
         for pat,res in tests:
-            res.sort()
             a=wildcard.list_namespace(ns,"all",pat,ignore_case=False,
                                       show_all=True).keys()
-            a.sort()
-            self.assertEqual(a,res)
+            self.assertEqual(set(a),res)
 
 
     def test_nocase(self):
         ns=root.__dict__
         tests=[
-         ("a*",     ["abbot","abel","ABEL","active","arna",]),
-         ("?b*.?o*",["abbot.koppel","abbot.loop","abel.koppel","abel.loop",
-                     "ABEL.koppel","ABEL.loop",]),
-         ("_a*",    []),
-         ("_*anka", ["__anka","__ANKA",]),
-         ("_*a*",   ["__anka","__ANKA",]),
+         ("a*",     {"abbot","abel","ABEL","active","arna",}),
+         ("?b*.?o*",{"abbot.koppel","abbot.loop","abel.koppel","abel.loop",
+                     "ABEL.koppel","ABEL.loop",}),
+         ("_a*",    set()),
+         ("_*anka", {"__anka","__ANKA",}),
+         ("_*a*",   {"__anka","__ANKA",}),
         ]
         for pat,res in tests:
-            res.sort()
             a=wildcard.list_namespace(ns,"all",pat,ignore_case=True,
                                       show_all=False).keys()
-            a.sort()
-            self.assertEqual(a,res)
+            self.assertEqual(set(a),res)
 
     def test_nocase_showall(self):
         ns=root.__dict__
         tests=[
-         ("a*",     ["abbot","abel","ABEL","active","arna",]),
-         ("?b*.?o*",["abbot.koppel","abbot.loop","abel.koppel","abel.loop",
-                     "ABEL.koppel","ABEL.loop",]),
-         ("_a*",    ["_apan","_APAN"]),
-         ("_*anka", ["__anka","__ANKA",]),
-         ("_*a*",   ["__anka","__ANKA","_apan","_APAN"]),
+         ("a*",     {"abbot","abel","ABEL","active","arna",}),
+         ("?b*.?o*",{"abbot.koppel","abbot.loop","abel.koppel","abel.loop",
+                     "ABEL.koppel","ABEL.loop",}),
+         ("_a*",    {"_apan","_APAN"}),
+         ("_*anka", {"__anka","__ANKA",}),
+         ("_*a*",   {"__anka","__ANKA","_apan","_APAN"}),
         ]
         for pat,res in tests:
-            res.sort()
             a=wildcard.list_namespace(ns,"all",pat,ignore_case=True,
                                       show_all=True).keys()
-            a.sort()
-            self.assertEqual(a,res)
+            self.assertEqual(set(a),res)
             
     def test_dict_attributes(self):
         """Dictionaries should be indexed by attributes, not by keys. This was
         causing Github issue 129."""
         ns = {"az":{"king":55}, "pq":{1:0}}
         tests = [
-          ("a*", ["az"]),
-          ("az.k*", ["az.keys"]),
-          ("pq.k*", ["pq.keys"])
+          ("a*", {"az"}),
+          ("az.k*", {"az.keys"}),
+          ("pq.k*", {"pq.keys"})
         ]
         for pat, res in tests:
-            res.sort()
             a = wildcard.list_namespace(ns, "all", pat, ignore_case=False,
                                         show_all=True).keys()
-            a.sort()
-            self.assertEqual(a, res)
+            self.assertEqual(set(a), res)
     
     def test_dict_dir(self):
         class A(object):

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -27,6 +27,9 @@ from string import Formatter
 from IPython.external.path import path
 from IPython.testing.skipdoctest import skip_doctest_py3, skip_doctest
 from IPython.utils import py3compat
+from six.moves import filter
+from six.moves import map
+from six.moves import zip
 
 #-----------------------------------------------------------------------------
 # Code
@@ -602,7 +605,7 @@ class DollarFormatter(FullEvalFormatter):
 
 def _chunks(l, n):
     """Yield successive n-sized chunks from l."""
-    for i in xrange(0, len(l), n):
+    for i in range(0, len(l), n):
         yield l[i:i+n]
 
 

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -311,7 +311,7 @@ def list_strings(arg):
         Out[9]: ['A', 'list', 'of', 'strings']
     """
 
-    if isinstance(arg,basestring): return [arg]
+    if isinstance(arg, py3compat.string_types): return [arg]
     else: return arg
 
 
@@ -612,7 +612,7 @@ def _chunks(l, n):
 def _find_optimal(rlist , separator_size=2 , displaywidth=80):
     """Calculate optimal info to columnize a list of string"""
     for nrow in range(1, len(rlist)+1) :
-        chk = map(max,_chunks(rlist, nrow))
+        chk = list(map(max,_chunks(rlist, nrow)))
         sumlength = sum(chk)
         ncols = len(chk)
         if sumlength+separator_size*(ncols-1) <= displaywidth :
@@ -685,7 +685,7 @@ def compute_item_matrix(items, empty=None, *args, **kwargs) :
         'rows_numbers': 5})
 
     """
-    info = _find_optimal(map(len, items), *args, **kwargs)
+    info = _find_optimal(list(map(len, items)), *args, **kwargs)
     nrow, ncol = info['rows_numbers'], info['columns_numbers']
     return ([[ _get_or_default(items, c*nrow+i, default=empty) for c in range(ncol) ] for i in range(nrow) ], info)
 

--- a/IPython/utils/timing.py
+++ b/IPython/utils/timing.py
@@ -87,7 +87,7 @@ def timings_out(reps,func,*args,**kw):
         out = func(*args,**kw)
         tot_time = clock()-start
     else:
-        rng = xrange(reps-1) # the last time is executed separately to store output
+        rng = range(reps-1) # the last time is executed separately to store output
         start = clock()
         for dummy in rng: func(*args,**kw)
         out = func(*args,**kw)  # one last time

--- a/IPython/utils/tokenize2.py
+++ b/IPython/utils/tokenize2.py
@@ -4,6 +4,6 @@
 import sys
 
 if sys.version_info[0] >= 3:
-    from _tokenize_py3 import *
+    from ._tokenize_py3 import *
 else:
-    from _tokenize_py2 import *
+    from ._tokenize_py2 import *

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -95,7 +95,7 @@ def class_of ( object ):
     correct indefinite article ('a' or 'an') preceding it (e.g., 'an Image',
     'a PlotValue').
     """
-    if isinstance( object, basestring ):
+    if isinstance( object, py3compat.string_types ):
         return add_article( object )
 
     return add_article( object.__class__.__name__ )
@@ -679,7 +679,7 @@ class Type(ClassBasedTraitType):
         elif klass is None:
             klass = default_value
 
-        if not (inspect.isclass(klass) or isinstance(klass, basestring)):
+        if not (inspect.isclass(klass) or isinstance(klass, py3compat.string_types)):
             raise TraitError("A Type trait must specify a class.")
 
         self.klass       = klass
@@ -700,7 +700,7 @@ class Type(ClassBasedTraitType):
 
     def info(self):
         """ Returns a description of the trait."""
-        if isinstance(self.klass, basestring):
+        if isinstance(self.klass, py3compat.string_types):
             klass = self.klass
         else:
             klass = self.klass.__name__
@@ -714,9 +714,9 @@ class Type(ClassBasedTraitType):
         super(Type, self).instance_init(obj)
 
     def _resolve_classes(self):
-        if isinstance(self.klass, basestring):
+        if isinstance(self.klass, py3compat.string_types):
             self.klass = import_item(self.klass)
-        if isinstance(self.default_value, basestring):
+        if isinstance(self.default_value, py3compat.string_types):
             self.default_value = import_item(self.default_value)
 
     def get_default_value(self):
@@ -771,7 +771,8 @@ class Instance(ClassBasedTraitType):
 
         self._allow_none = allow_none
 
-        if (klass is None) or (not (inspect.isclass(klass) or isinstance(klass, basestring))):
+        if (klass is None) or (not (inspect.isclass(klass) or \
+                                    isinstance(klass, py3compat.string_types))):
             raise TraitError('The klass argument must be a class'
                                 ' you gave: %r' % klass)
         self.klass = klass
@@ -808,7 +809,7 @@ class Instance(ClassBasedTraitType):
             self.error(obj, value)
 
     def info(self):
-        if isinstance(self.klass, basestring):
+        if isinstance(self.klass, py3compat.string_types):
             klass = self.klass
         else:
             klass = self.klass.__name__
@@ -823,7 +824,7 @@ class Instance(ClassBasedTraitType):
         super(Instance, self).instance_init(obj)
 
     def _resolve_classes(self):
-        if isinstance(self.klass, basestring):
+        if isinstance(self.klass, py3compat.string_types):
             self.klass = import_item(self.klass)
 
     def get_default_value(self):
@@ -1021,10 +1022,10 @@ class Unicode(TraitType):
     info_text = 'a unicode string'
 
     def validate(self, obj, value):
-        if isinstance(value, unicode):
+        if isinstance(value, py3compat.unicode_type):
             return value
         if isinstance(value, bytes):
-            return unicode(value)
+            return value.decode()
         self.error(obj, value)
 
 
@@ -1033,7 +1034,7 @@ class CUnicode(Unicode):
 
     def validate(self, obj, value):
         try:
-            return unicode(value)
+            return py3compat.unicode_type(value)
         except:
             self.error(obj, value)
 
@@ -1052,7 +1053,7 @@ class ObjectName(TraitType):
         # Python 2:
         def coerce_str(self, obj, value):
             "In Python 2, coerce ascii-only unicode to str"
-            if isinstance(value, unicode):
+            if isinstance(value, py3compat.unicode_type):
                 try:
                     return str(value)
                 except UnicodeEncodeError:
@@ -1130,7 +1131,7 @@ class CaselessStrEnum(Enum):
             if self._allow_none:
                 return value
 
-        if not isinstance(value, basestring):
+        if not isinstance(value, py3compat.string_types):
             self.error(obj, value)
 
         for v in self.values:
@@ -1417,7 +1418,7 @@ class TCPAddress(TraitType):
     def validate(self, obj, value):
         if isinstance(value, tuple):
             if len(value) == 2:
-                if isinstance(value[0], basestring) and isinstance(value[1], int):
+                if isinstance(value[0], py3compat.string_types) and isinstance(value[1], int):
                     port = value[1]
                     if port >= 0 and port <= 65535:
                         return value

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -58,6 +58,7 @@ import re
 import sys
 import types
 from types import FunctionType
+import six
 try:
     from types import ClassType, InstanceType
     ClassTypes = (ClassType, type)
@@ -373,7 +374,7 @@ class MetaHasTraits(type):
         # print "MetaHasTraitlets (mcls, name): ", mcls, name
         # print "MetaHasTraitlets (bases): ", bases
         # print "MetaHasTraitlets (classdict): ", classdict
-        for k,v in classdict.iteritems():
+        for k,v in six.iteritems(classdict):
             if isinstance(v, TraitType):
                 v.name = k
             elif inspect.isclass(v):
@@ -389,14 +390,12 @@ class MetaHasTraits(type):
         This sets the :attr:`this_class` attribute of each TraitType in the
         class dict to the newly created class ``cls``.
         """
-        for k, v in classdict.iteritems():
+        for k, v in six.iteritems(classdict):
             if isinstance(v, TraitType):
                 v.this_class = cls
         super(MetaHasTraits, cls).__init__(name, bases, classdict)
 
-class HasTraits(object):
-
-    __metaclass__ = MetaHasTraits
+class HasTraits(six.with_metaclass(MetaHasTraits, object)):
 
     def __new__(cls, *args, **kw):
         # This is needed because in Python 2.6 object.__new__ only accepts
@@ -429,7 +428,7 @@ class HasTraits(object):
         # Allow trait values to be set using keyword arguments.
         # We need to use setattr for this to trigger validation and
         # notifications.
-        for key, value in kw.iteritems():
+        for key, value in six.iteritems(kw):
             setattr(self, key, value)
 
     def _notify_trait(self, name, old_value, new_value):
@@ -901,7 +900,7 @@ else:
     class Long(TraitType):
         """A long integer trait."""
 
-        default_value = 0L
+        default_value = 0
         info_text = 'a long'
 
         def validate(self, obj, value):

--- a/IPython/utils/wildcard.py
+++ b/IPython/utils/wildcard.py
@@ -18,6 +18,7 @@ import re
 import types
 
 from IPython.utils.dir2 import dir2
+import six
 
 def create_typestr2type_dicts(dont_include_in_type2typestr=["lambda"]):
     """Return dictionaries mapping lower case typename (e.g. 'tuple') to type
@@ -43,7 +44,7 @@ def is_type(obj, typestr_or_type):
     TODO: Should be extended for choosing more than one type."""
     if typestr_or_type == "all":
         return True
-    if type(typestr_or_type) == types.TypeType:
+    if type(typestr_or_type) == type:
         test_type = typestr_or_type
     else:
         test_type = typestr2type.get(typestr_or_type, False)
@@ -82,7 +83,7 @@ def filter_ns(ns, name_pattern="*", type_pattern="all", ignore_case=True,
         reg = re.compile(pattern+"$")
 
     # Check each one matches regex; shouldn't be hidden; of correct type.
-    return dict((key,obj) for key, obj in ns.iteritems() if reg.match(key) \
+    return dict((key,obj) for key, obj in six.iteritems(ns) if reg.match(key) \
                                             and show_hidden(key, show_all) \
                                             and is_type(obj, type_pattern) )
 
@@ -102,10 +103,10 @@ def list_namespace(namespace, type_pattern, filter, ignore_case=False, show_all=
                             type_pattern="all",
                             ignore_case=ignore_case, show_all=show_all)
         results = {}
-        for name, obj in filtered.iteritems():
+        for name, obj in six.iteritems(filtered):
             ns = list_namespace(dict_dir(obj), type_pattern,
                                 ".".join(pattern_list[1:]),
                                 ignore_case=ignore_case, show_all=show_all)
-            for inner_name, inner_obj in ns.iteritems():
+            for inner_name, inner_obj in six.iteritems(ns):
                 results["%s.%s"%(name,inner_name)] = inner_obj
         return results

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ from setupbase import (
     find_packages,
     find_package_data,
     find_scripts,
+    build_scripts_rename,
     find_data_files,
     check_for_dependencies,
     git_prebuild,
@@ -319,7 +320,10 @@ else:
     # check for dependencies an inform the user what is needed.  This is
     # just to make life easy for users.
     check_for_dependencies()
-    setup_args['scripts'] = find_scripts(False, suffix = '3' if PY3 else '')
+    setup_args['scripts'] = find_scripts(False)
+    if PY3:
+        # Rename scripts with '3' suffix
+        setup_args['cmdclass']['build_scripts'] = build_scripts_rename
 
 #---------------------------------------------------------------------------
 # Do the actual setup now

--- a/setup.py
+++ b/setup.py
@@ -53,10 +53,6 @@ if os.path.exists('MANIFEST'): os.remove('MANIFEST')
 
 from distutils.core import setup
 
-# On Python 3, we need distribute (new setuptools) to do the 2to3 conversion
-if PY3:
-    import setuptools
-
 # Our own imports
 from setupbase import target_update
 
@@ -270,7 +266,7 @@ if 'setuptools' in sys.modules:
     setup_args['cmdclass']['develop'] = require_submodules(develop)
     
     setuptools_extra_args['zip_safe'] = False
-    setuptools_extra_args['entry_points'] = find_scripts(True)
+    setuptools_extra_args['entry_points'] = find_scripts(True, suffix = '3' if PY3 else '')
     setup_args['extras_require'] = dict(
         parallel = 'pyzmq>=2.1.11',
         qtconsole = ['pyzmq>=2.1.11', 'pygments'],
@@ -318,29 +314,12 @@ if 'setuptools' in sys.modules:
                                  {"install_script":
                                   "ipython_win_post_install.py"}}
 
-    if PY3:
-        setuptools_extra_args['use_2to3'] = True
-        # we try to make a 2.6, 2.7, and 3.1 to 3.3 python compatible code
-        # so we explicitly disable some 2to3 fixes to be sure we aren't forgetting
-        # anything.
-        setuptools_extra_args['use_2to3_exclude_fixers'] = [
-                'lib2to3.fixes.fix_apply',
-                'lib2to3.fixes.fix_except',
-                'lib2to3.fixes.fix_has_key',
-                'lib2to3.fixes.fix_next',
-                'lib2to3.fixes.fix_repr',
-                'lib2to3.fixes.fix_tuple_params',
-                ]
-        from setuptools.command.build_py import build_py
-        setup_args['cmdclass'] = {'build_py': git_prebuild('IPython', build_cmd=build_py)}
-        setuptools_extra_args['entry_points'] = find_scripts(True, suffix='3')
-        setuptools._dont_write_bytecode = True
 else:
     # If we are running without setuptools, call this function which will
     # check for dependencies an inform the user what is needed.  This is
     # just to make life easy for users.
     check_for_dependencies()
-    setup_args['scripts'] = find_scripts(False)
+    setup_args['scripts'] = find_scripts(False, suffix = '3' if PY3 else '')
 
 #---------------------------------------------------------------------------
 # Do the actual setup now

--- a/setupbase.py
+++ b/setupbase.py
@@ -353,6 +353,8 @@ class build_scripts_rename(build_scripts):
         new_outfiles = [p + self._suffix for p in outfiles]
         updated_files = [p + self._suffix for p in updated_files]
         for old, new in zip(outfiles, new_outfiles):
+            if os.path.exists(new):
+                os.unlink(new)
             self.move_file(old, new)
         return new_outfiles, updated_files
             

--- a/setupbase.py
+++ b/setupbase.py
@@ -28,6 +28,7 @@ try:
 except:
     from ConfigParser import ConfigParser
 from distutils.command.build_py import build_py
+from distutils.command.build_scripts import build_scripts
 from distutils.cmd import Command
 from glob import glob
 
@@ -342,6 +343,19 @@ def find_scripts(entry_points=False, suffix=''):
                    pjoin(main_scripts, 'iptest')
         ]
     return scripts
+
+class build_scripts_rename(build_scripts):
+    """Use this on Python 3 to rename scripts to ipython3 etc."""
+    _suffix = '3'
+    
+    def copy_scripts(self):
+        outfiles, updated_files = super(build_scripts_rename, self).copy_scripts()
+        new_outfiles = [p + self._suffix for p in outfiles]
+        updated_files = [p + self._suffix for p in updated_files]
+        for old, new in zip(outfiles, new_outfiles):
+            self.move_file(old, new)
+        return new_outfiles, updated_files
+            
 
 #---------------------------------------------------------------------------
 # Verify all dependencies


### PR DESCRIPTION
This moves IPython to a common codebase supporting Python 2.7 and Python 3.3+. The test suite, including IPython.parallel, is passing on both versions, and I've briefly tested running the terminal interface, terminal zmq console, Qt console and notebook. It will be important to merge this soon so that people using master have as much time as possible to find corner cases.

We still need to work out what we're doing about `six`. It's currently imported as an external module. It would be a fairly natural candidate for bundling into `IPython.externals`, or we could copy relevant functionality to `py3compat`, where we probably already duplicate some things.
