### PR TITLE
minor bug fix, define 'cell' in dialog.js.

### DIFF
--- a/IPython/html/static/base/js/dialog.js
+++ b/IPython/html/static/base/js/dialog.js
@@ -68,7 +68,7 @@ IPython.dialog = (function (IPython) {
         if (options.reselect_cell !== false) {
             dialog.on("hidden", function () {
                 if (IPython.notebook) {
-                    cell = IPython.notebook.get_selected_cell();
+                    var cell = IPython.notebook.get_selected_cell();
                     if (cell) cell.select();
                 }
             });


### PR DESCRIPTION
Very minor fix...

The 'cell' variable in dialog.js isn't defined and causes an error in js console. 

I found this bug after renaming a notebook... the dialog box that pops up for a rename causes an error in my javascript console. 
