### PR TITLE
close Client sockets if connection fails

### DIFF
--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -495,7 +495,12 @@ class Client(HasTraits):
                                     }
         self._queue_handlers = {'execute_reply' : self._handle_execute_reply,
                                 'apply_reply' : self._handle_apply_reply}
-        self._connect(sshserver, ssh_kwargs, timeout)
+        
+        try:
+            self._connect(sshserver, ssh_kwargs, timeout)
+        except:
+            self.close(linger=0)
+            raise
         
         # last step: setup magics, if we are in IPython:
         


### PR DESCRIPTION
avoids runaway FDs in cases of frequent client failure.

also cleanup Client.close a little bit, allowing setting `linger` on sockets at shutdown time,
which is helpful for preventing FD growth on connection failure.

Should be considered for backport to 1.1.
