### PR TITLE
Update supported Python versions in tools/test_pr

### DIFF
--- a/tools/test_pr.py
+++ b/tools/test_pr.py
@@ -29,7 +29,7 @@ ipy_repository = 'git://github.com/ipython/ipython.git'
 ipy_http_repository = 'http://github.com/ipython/ipython.git'
 gh_project="ipython/ipython"
 
-supported_pythons = ['python2.6', 'python2.7', 'python3.2']
+supported_pythons = ['python2.7', 'python3.3']
             
 missing_libs_re = re.compile(r"Tools and libraries NOT available at test time:\n"
                              r"\s*(.*?)\n")


### PR DESCRIPTION
I forgot this because we mostly use Travis now, but there are still times when Travis fails, and we also don't get it to run the IPython.parallel tests.
