### PR TITLE
change default behavior of database task storage

### DIFF
--- a/IPython/parallel/controller/mongodb.py
+++ b/IPython/parallel/controller/mongodb.py
@@ -39,7 +39,7 @@ class MongoDB(BaseDB):
         necessary if the default mongodb configuration does not point to your
         mongod instance."""
     )
-    database = Unicode(config=True,
+    database = Unicode("ipython-tasks", config=True,
         help="""The MongoDB database name to use for storing tasks for this session. If unspecified,
         a new database will be created with the Hub's IDENT.  Specifying the database will result
         in tasks from previous sessions being available via Clients' db_query and

--- a/IPython/parallel/controller/sqlitedb.py
+++ b/IPython/parallel/controller/sqlitedb.py
@@ -195,7 +195,7 @@ class SQLiteDB(BaseDB):
 
         If a bad (old) table does exist, return False
         """
-        cursor = self._db.execute("PRAGMA table_info(%s)"%self.table)
+        cursor = self._db.execute("PRAGMA table_info('%s')"%self.table)
         lines = cursor.fetchall()
         if not lines:
             # table does not exist
@@ -241,7 +241,7 @@ class SQLiteDB(BaseDB):
             )
             previous_table = self.table
 
-        self._db.execute("""CREATE TABLE IF NOT EXISTS %s
+        self._db.execute("""CREATE TABLE IF NOT EXISTS '%s'
                 (msg_id text PRIMARY KEY,
                 header dict text,
                 metadata dict text,
@@ -333,12 +333,12 @@ class SQLiteDB(BaseDB):
         d['msg_id'] = msg_id
         line = self._dict_to_list(d)
         tups = '(%s)'%(','.join(['?']*len(line)))
-        self._db.execute("INSERT INTO %s VALUES %s"%(self.table, tups), line)
+        self._db.execute("INSERT INTO '%s' VALUES %s"%(self.table, tups), line)
         # self._db.commit()
 
     def get_record(self, msg_id):
         """Get a specific Task Record, by msg_id."""
-        cursor = self._db.execute("""SELECT * FROM %s WHERE msg_id==?"""%self.table, (msg_id,))
+        cursor = self._db.execute("""SELECT * FROM '%s' WHERE msg_id==?"""%self.table, (msg_id,))
         line = cursor.fetchone()
         if line is None:
             raise KeyError("No such msg: %r"%msg_id)
@@ -346,7 +346,7 @@ class SQLiteDB(BaseDB):
 
     def update_record(self, msg_id, rec):
         """Update the data in an existing record."""
-        query = "UPDATE %s SET "%self.table
+        query = "UPDATE '%s' SET "%self.table
         sets = []
         keys = sorted(rec.keys())
         values = []
@@ -361,13 +361,13 @@ class SQLiteDB(BaseDB):
 
     def drop_record(self, msg_id):
         """Remove a record from the DB."""
-        self._db.execute("""DELETE FROM %s WHERE msg_id==?"""%self.table, (msg_id,))
+        self._db.execute("""DELETE FROM '%s' WHERE msg_id==?"""%self.table, (msg_id,))
         # self._db.commit()
 
     def drop_matching_records(self, check):
         """Remove a record from the DB."""
         expr,args = self._render_expression(check)
-        query = "DELETE FROM %s WHERE %s"%(self.table, expr)
+        query = "DELETE FROM '%s' WHERE %s"%(self.table, expr)
         self._db.execute(query,args)
         # self._db.commit()
 
@@ -399,7 +399,7 @@ class SQLiteDB(BaseDB):
         else:
             req = '*'
         expr,args = self._render_expression(check)
-        query = """SELECT %s FROM %s WHERE %s"""%(req, self.table, expr)
+        query = """SELECT %s FROM '%s' WHERE %s"""%(req, self.table, expr)
         cursor = self._db.execute(query, args)
         matches = cursor.fetchall()
         records = []
@@ -410,7 +410,7 @@ class SQLiteDB(BaseDB):
 
     def get_history(self):
         """get all msg_ids, ordered by time submitted."""
-        query = """SELECT msg_id FROM %s ORDER by submitted ASC"""%self.table
+        query = """SELECT msg_id FROM '%s' ORDER by submitted ASC"""%self.table
         cursor = self._db.execute(query)
         # will be a list of length 1 tuples
         return [ tup[0] for tup in cursor.fetchall()]

--- a/IPython/parallel/controller/sqlitedb.py
+++ b/IPython/parallel/controller/sqlitedb.py
@@ -96,7 +96,7 @@ class SQLiteDB(BaseDB):
     location = Unicode('', config=True,
         help="""The directory containing the sqlite task database.  The default
         is to use the cluster_dir location.""")
-    table = Unicode("", config=True,
+    table = Unicode("ipython-tasks", config=True,
         help="""The SQLite Table to use for storing tasks for this session. If unspecified,
         a new table will be created with the Hub's IDENT.  Specifying the table will result
         in tasks from previous sessions being available via Clients' db_query and


### PR DESCRIPTION
The previous default behavior was to create a new table (sqlite) / database (mongodb) for each Hub instance, so that task history would not be shared by subsequent IPython sessions.

I don't think this was the right choice, so this PR switches the default behavior to use the table / database `ipython-tasks`. The result is that all Hub sessions in a given profile will share history by default, which makes the benefit of the db backends clearer.

Configurable behavior remains the same, only the default is changed.
