### PR TITLE
Implement a better check for hidden values for %who etc.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -969,7 +969,7 @@ class InteractiveShell(SingletonConfigurable):
 
         # A record of hidden variables we have added to the user namespace, so
         # we can list later only variables defined in actual interactive use.
-        self.user_ns_hidden = set()
+        self.user_ns_hidden = {}
 
         # Now that FakeModule produces a real module, we've run into a nasty
         # problem: after script execution (via %run), the module where the user
@@ -1300,7 +1300,8 @@ class InteractiveShell(SingletonConfigurable):
         # And configure interactive visibility
         user_ns_hidden = self.user_ns_hidden
         if interactive:
-            user_ns_hidden.difference_update(vdict)
+            for name in vdict:
+                user_ns_hidden.pop(name, None)
         else:
             user_ns_hidden.update(vdict)
     

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1149,7 +1149,7 @@ class InteractiveShell(SingletonConfigurable):
         
         Note that this does not include the displayhook, which also caches
         objects from the output."""
-        return [self.user_ns, self.user_global_ns] + \
+        return [self.user_ns, self.user_global_ns, self.user_ns_hidden] + \
                [m.__dict__ for m in self._main_mod_cache.values()]
 
     def reset(self, new_session=True):
@@ -1321,7 +1321,7 @@ class InteractiveShell(SingletonConfigurable):
         for name, obj in variables.iteritems():
             if name in self.user_ns and self.user_ns[name] is obj:
                 del self.user_ns[name]
-                self.user_ns_hidden.discard(name)
+                self.user_ns_hidden.pop(name, None)
 
     #-------------------------------------------------------------------------
     # Things related to object introspection

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -265,9 +265,10 @@ class NamespaceMagics(Magics):
 
         user_ns = self.shell.user_ns
         user_ns_hidden = self.shell.user_ns_hidden
+        nonmatching = object()  # This can never be in user_ns
         out = [ i for i in user_ns
                 if not i.startswith('_') \
-                and not i in user_ns_hidden ]
+                and (user_ns[i] is not user_ns_hidden.get(i, nonmatching)) ]
 
         typelist = parameter_s.split()
         if typelist:


### PR DESCRIPTION
From discussion in #4076, this uses a dictionary for hidden values instead of a set, and checks identity as well as name.

```
In [3]: e = 5

In [4]: f = 6

In [5]: %who
e    f   

In [6]: %whos
Variable   Type    Data/Info
----------------------------
e          int     5
f          int     6
```
