### PR TITLE
fix missing errno import

### DIFF
--- a/IPython/core/profiledir.py
+++ b/IPython/core/profiledir.py
@@ -23,6 +23,7 @@ Authors:
 
 import os
 import shutil
+import errno
 
 from IPython.config.configurable import LoggingConfigurable
 from IPython.utils.path import get_ipython_package_dir, expand_path


### PR DESCRIPTION
trivial fix, this import was missing, but it's only triggered when there's a
race condition, which is why this hasn't come up.
