### PR TITLE
Allow InputTransformers to raise SyntaxErrors

### DIFF
--- a/IPython/core/inputtransformer.py
+++ b/IPython/core/inputtransformer.py
@@ -43,6 +43,9 @@ class InputTransformer(object):
         input or None if the transformer is waiting for more input.
         
         Must be overridden by subclasses.
+
+        Implementations may raise ``SyntaxError`` if the input is invalid. No
+        other exceptions may be raised.
         """
         pass
     

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2605,7 +2605,12 @@ class InteractiveShell(SingletonConfigurable):
         if silent:
             store_history = False
 
-        self.input_transformer_manager.push(raw_cell)
+        prefilter_failed = False
+        try:
+            self.input_transformer_manager.push(raw_cell)
+        except SyntaxError:
+            self.showtraceback()
+            prefilter_failed = True
         cell = self.input_transformer_manager.source_reset()
 
         # Our own compiler remembers the __future__ environment. If we want to
@@ -2614,8 +2619,7 @@ class InteractiveShell(SingletonConfigurable):
         compiler = self.compile if shell_futures else CachingCompiler()
 
         with self.builtin_trap:
-            prefilter_failed = False
-            if len(cell.splitlines()) == 1:
+            if not prefilter_failed and len(cell.splitlines()) == 1:
                 try:
                     # use prefilter_lines to handle trailing newlines
                     # restore trailing newline for ast.parse

--- a/IPython/core/tests/test_application.py
+++ b/IPython/core/tests/test_application.py
@@ -3,9 +3,13 @@
 
 import os
 import tempfile
+import shutil
+
+import nose.tools as nt
 
 from IPython.core.application import BaseIPythonApplication
 from IPython.testing import decorators as dec
+from IPython.testing.tools import make_tempfile, ipexec
 from IPython.utils import py3compat
 
 @dec.onlyif_unicode_paths
@@ -48,3 +52,46 @@ def test_unicode_ipdir():
             os.environ["IPYTHONDIR"] = old_ipdir1
         if old_ipdir2:
             os.environ["IPYTHONDIR"] = old_ipdir2
+
+
+
+TEST_SYNTAX_ERROR_CMDS = """
+from IPython.core.inputtransformer import InputTransformer
+
+%cpaste
+class SyntaxErrorTransformer(InputTransformer):
+
+    def push(self, line):
+        if 'syntaxerror' in line:
+            raise SyntaxError('in input '+line)
+        return line
+
+    def reset(self):
+        pass
+--
+
+ip = get_ipython()
+transformer = SyntaxErrorTransformer()
+ip.input_splitter.python_line_transforms.append(transformer)
+ip.input_transformer_manager.python_line_transforms.append(transformer)
+
+# now the actual commands
+1234
+2345  # syntaxerror <- triggered here
+3456
+"""
+
+def test_syntax_error():
+    """Check that IPython does not abort if a SyntaxError is raised in an InputTransformer"""
+    try:
+        tmp = tempfile.mkdtemp()
+        filename = os.path.join(tmp, 'test_syntax_error.py')
+        with open(filename, 'w') as f:
+            f.write(TEST_SYNTAX_ERROR_CMDS)
+        out, err = ipexec(filename, pipe=True)
+        nt.assert_equal(err, '')
+        nt.assert_in('1234', out)
+        nt.assert_in('SyntaxError: in input 2345  # syntaxerror <- triggered here', out)
+        nt.assert_in('3456', out)
+    finally:
+        shutil.rmtree(tmp)

--- a/IPython/core/tests/test_application.py
+++ b/IPython/core/tests/test_application.py
@@ -3,13 +3,9 @@
 
 import os
 import tempfile
-import shutil
-
-import nose.tools as nt
 
 from IPython.core.application import BaseIPythonApplication
 from IPython.testing import decorators as dec
-from IPython.testing.tools import make_tempfile, ipexec
 from IPython.utils import py3compat
 
 @dec.onlyif_unicode_paths
@@ -52,46 +48,3 @@ def test_unicode_ipdir():
             os.environ["IPYTHONDIR"] = old_ipdir1
         if old_ipdir2:
             os.environ["IPYTHONDIR"] = old_ipdir2
-
-
-
-TEST_SYNTAX_ERROR_CMDS = """
-from IPython.core.inputtransformer import InputTransformer
-
-%cpaste
-class SyntaxErrorTransformer(InputTransformer):
-
-    def push(self, line):
-        if 'syntaxerror' in line:
-            raise SyntaxError('in input '+line)
-        return line
-
-    def reset(self):
-        pass
---
-
-ip = get_ipython()
-transformer = SyntaxErrorTransformer()
-ip.input_splitter.python_line_transforms.append(transformer)
-ip.input_transformer_manager.python_line_transforms.append(transformer)
-
-# now the actual commands
-1234
-2345  # syntaxerror <- triggered here
-3456
-"""
-
-def test_syntax_error():
-    """Check that IPython does not abort if a SyntaxError is raised in an InputTransformer"""
-    try:
-        tmp = tempfile.mkdtemp()
-        filename = os.path.join(tmp, 'test_syntax_error.py')
-        with open(filename, 'w') as f:
-            f.write(TEST_SYNTAX_ERROR_CMDS)
-        out, err = ipexec(filename, pipe=True)
-        nt.assert_equal(err, '')
-        nt.assert_in('1234', out)
-        nt.assert_in('SyntaxError: in input 2345  # syntaxerror <- triggered here', out)
-        nt.assert_in('3456', out)
-    finally:
-        shutil.rmtree(tmp)

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -36,6 +36,7 @@ import nose.tools as nt
 from IPython.testing.decorators import skipif, onlyif_unicode_paths
 from IPython.testing import tools as tt
 from IPython.utils import io
+from IPython.core.inputtransformer import InputTransformer
 
 #-----------------------------------------------------------------------------
 # Globals
@@ -647,6 +648,43 @@ def test_user_expression():
     
 
 
+
+
+class TestSyntaxErrorTransformer(unittest.TestCase):
+    """Check that SyntaxError raised by an input transformer is handled by run_cell()"""
+
+    class SyntaxErrorTransformer(InputTransformer):
+
+        def push(self, line):
+            pos = line.find('syntaxerror')
+            if pos >= 0:
+                e = SyntaxError('input contains "syntaxerror"')
+                e.text = line
+                e.offset = pos + 1
+                raise e
+            return line
+
+        def reset(self):
+            pass
+
+    def setUp(self):
+        self.transformer = TestSyntaxErrorTransformer.SyntaxErrorTransformer()
+        ip.input_splitter.python_line_transforms.append(self.transformer)
+        ip.input_transformer_manager.python_line_transforms.append(self.transformer)
+
+    def tearDown(self):
+        ip.input_splitter.python_line_transforms.remove(self.transformer)
+        ip.input_transformer_manager.python_line_transforms.remove(self.transformer)
+
+    def test_syntaxerror_input_transformer(self):
+        with tt.AssertPrints('1234'):
+            ip.run_cell('1234')
+        with tt.AssertPrints('SyntaxError: invalid syntax'):
+            ip.run_cell('1 2 3')   # plain python syntax error
+        with tt.AssertPrints('SyntaxError: input contains "syntaxerror"'):
+            ip.run_cell('2345  # syntaxerror')  # input transformer syntax error
+        with tt.AssertPrints('3456'):
+            ip.run_cell('3456')
 
 
 

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -538,8 +538,13 @@ class TerminalInteractiveShell(InteractiveShell):
                 # asynchronously by signal handlers, for example.
                 self.showtraceback()
             else:
-                self.input_splitter.push(line)
-                more = self.input_splitter.push_accepts_more()
+                try:
+                    self.input_splitter.push(line)
+                    more = self.input_splitter.push_accepts_more()
+                except SyntaxError:
+                    self.showsyntaxerror()
+                    self.input_splitter.reset()
+                    more = False
                 if (self.SyntaxTB.last_syntax_error and
                     self.autoedit_syntax):
                     self.edit_syntax_error()

--- a/IPython/terminal/tests/test_terminal.py
+++ b/IPython/terminal/tests/test_terminal.py
@@ -1,0 +1,58 @@
+# coding: utf-8
+"""Tests for the IPython terminal"""
+
+import os
+import tempfile
+import shutil
+
+import nose.tools as nt
+
+from IPython.testing.tools import make_tempfile, ipexec
+
+
+TEST_SYNTAX_ERROR_CMDS = """
+from IPython.core.inputtransformer import InputTransformer
+
+%cpaste
+class SyntaxErrorTransformer(InputTransformer):
+
+    def push(self, line):
+        pos = line.find('syntaxerror')
+        if pos >= 0:
+            e = SyntaxError('input contains "syntaxerror"')
+            e.text = line
+            e.offset = pos + 1
+            raise e
+        return line
+
+    def reset(self):
+        pass
+--
+
+ip = get_ipython()
+transformer = SyntaxErrorTransformer()
+ip.input_splitter.python_line_transforms.append(transformer)
+ip.input_transformer_manager.python_line_transforms.append(transformer)
+
+# now the actual commands
+1234
+2345  # syntaxerror <- triggered here
+3456
+"""
+
+def test_syntax_error():
+    """Check that the IPython terminal does not abort if a SyntaxError is raised in an InputTransformer"""
+    try:
+        tmp = tempfile.mkdtemp()
+        filename = os.path.join(tmp, 'test_syntax_error.py')
+        with open(filename, 'w') as f:
+            f.write(TEST_SYNTAX_ERROR_CMDS)
+        out, err = ipexec(filename, pipe=True)
+        nt.assert_equal(err, '')
+        nt.assert_in('1234', out)
+        nt.assert_in('    2345  # syntaxerror <- triggered here', out)
+        nt.assert_in('            ^', out)
+        nt.assert_in('SyntaxError: input contains "syntaxerror"', out)
+        nt.assert_in('3456', out)
+    finally:
+        shutil.rmtree(tmp)

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -172,7 +172,7 @@ def get_ipython_cmd(as_string=False):
 
     return ipython_cmd
 
-def ipexec(fname, options=None):
+def ipexec(fname, options=None, pipe=False):
     """Utility to call 'ipython filename'.
 
     Starts IPython with a minimal and safe configuration to make startup as fast
@@ -187,6 +187,9 @@ def ipexec(fname, options=None):
 
     options : optional, list
       Extra command-line flags to be passed to IPython.
+
+    pipe : optional, boolean
+      Pipe fname into IPython as stdin instead of calling it as external file
 
     Returns
     -------
@@ -207,8 +210,12 @@ def ipexec(fname, options=None):
     ipython_cmd = get_ipython_cmd()
     # Absolute path for filename
     full_fname = os.path.join(test_dir, fname)
-    full_cmd = ipython_cmd + cmdargs + [full_fname]
-    p = Popen(full_cmd, stdout=PIPE, stderr=PIPE)
+    if pipe:
+        full_cmd = ipython_cmd + cmdargs
+        p = Popen(full_cmd, stdin=open(full_fname), stdout=PIPE, stderr=PIPE)
+    else:
+        full_cmd = ipython_cmd + cmdargs + [full_fname]
+        p = Popen(full_cmd, stdout=PIPE, stderr=PIPE)
     out, err = p.communicate()
     out, err = py3compat.bytes_to_str(out), py3compat.bytes_to_str(err)
     # `import readline` causes 'ESC[?1034h' to be output sometimes,


### PR DESCRIPTION
This is a relatively trivial modification of the IPython main loop to
catch a possible SyntaxError and print it instead of
quitting. Doctesting this change is somewhat tricky since we actually
need to run the main TerminalInteractiveShell.interact() loop, and is
done through a subprocess and piping in a testcase.

As discussed recently on http://python.6.x6.nabble.com/Raising-a-SyntaxError-in-InputTransformer-td5027773.html
