### PR TITLE
Add LaTeX citation handling to nbconvert

### DIFF
--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -68,6 +68,7 @@ default_filters = {
         'strip_math_space': filters.strip_math_space,
         'wrap_text': filters.wrap_text,
         'escape_latex': filters.escape_latex,
+        'parse_citation': filters.parse_citation
 }
 
 #-----------------------------------------------------------------------------

--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -68,7 +68,7 @@ default_filters = {
         'strip_math_space': filters.strip_math_space,
         'wrap_text': filters.wrap_text,
         'escape_latex': filters.escape_latex,
-        'parse_citation': filters.parse_citation
+        'citation2latex': filters.citation2latex
 }
 
 #-----------------------------------------------------------------------------

--- a/IPython/nbconvert/filters/__init__.py
+++ b/IPython/nbconvert/filters/__init__.py
@@ -4,3 +4,4 @@ from .highlight import *
 from .latex import *
 from .markdown import *
 from .strings import *
+from .citation import *

--- a/IPython/nbconvert/filters/citation.py
+++ b/IPython/nbconvert/filters/citation.py
@@ -1,0 +1,70 @@
+"""Citation handling for LaTeX output."""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, the IPython Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------
+
+
+__all__ = ['parse_citation']
+
+
+def parse_citation(s):
+    """Parse citations in Markdown cells.
+    
+    This looks for HTML tags having a data attribute names `data-cite`
+    and replaces it by the call to LaTeX cite command. The tranformation
+    looks like this:
+    
+    `<cite data-cite="granger">(Granger, 2013)</cite>`
+    
+    Becomes
+    
+    `\\cite{granger}`
+    
+    Any HTML tag can be used, which allows the citations to be formatted
+    in HTML in any manner.
+    """
+    try:
+        from lxml import html
+    except ImportError:
+        return s
+
+    tree = html.fragment_fromstring(s, create_parent='div')
+    _process_node_cite(tree)
+    s = html.tostring(tree)
+    s = s.lstrip('<div>')
+    s = s.rstrip('</div>')
+    return s
+
+
+def _process_node_cite(node):
+    """Do the citation replacement as we walk the lxml tree."""
+    
+    def _get(o, name):
+        value = getattr(o, name)
+        return '' if value is None else value
+    
+    if 'data-cite' in node.attrib:
+        cite = '\cite{%(ref)s}' % {'ref': node.attrib['data-cite']}
+        prev = node.getprevious()
+        if prev is not None:
+            prev.tail = _get(prev, 'tail') + cite + _get(node, 'tail')
+        else:
+            parent = node.getparent()
+            if parent is not None:
+                parent.text = _get(parent, 'text') + cite + _get(node, 'tail')
+        try:
+            node.getparent().remove(node)
+        except AttributeError:
+            pass
+    else:
+        for child in node:
+            _process_node_cite(child)

--- a/IPython/nbconvert/filters/citation.py
+++ b/IPython/nbconvert/filters/citation.py
@@ -13,10 +13,10 @@
 #-----------------------------------------------------------------------------
 
 
-__all__ = ['parse_citation']
+__all__ = ['citation2latex']
 
 
-def parse_citation(s):
+def citation2latex(s):
     """Parse citations in Markdown cells.
     
     This looks for HTML tags having a data attribute names `data-cite`

--- a/IPython/nbconvert/filters/citation.py
+++ b/IPython/nbconvert/filters/citation.py
@@ -40,8 +40,10 @@ def parse_citation(s):
     tree = html.fragment_fromstring(s, create_parent='div')
     _process_node_cite(tree)
     s = html.tostring(tree)
-    s = s.lstrip('<div>')
-    s = s.rstrip('</div>')
+    if s.endswith('</div>'):
+        s = s[:-6]
+    if s.startswith('<div>'):
+        s = s[5:]
     return s
 
 

--- a/IPython/nbconvert/filters/citation.py
+++ b/IPython/nbconvert/filters/citation.py
@@ -51,7 +51,7 @@ def _process_node_cite(node):
     """Do the citation replacement as we walk the lxml tree."""
     
     def _get(o, name):
-        value = getattr(o, name)
+        value = getattr(o, name, None)
         return '' if value is None else value
     
     if 'data-cite' in node.attrib:

--- a/IPython/nbconvert/filters/tests/test_citation.py
+++ b/IPython/nbconvert/filters/tests/test_citation.py
@@ -10,7 +10,7 @@
 # Imports
 #-----------------------------------------------------------------------------
 
-from ..citation import parse_citation
+from ..citation import citation2latex
 
 #-----------------------------------------------------------------------------
 # Tests
@@ -24,6 +24,8 @@ porttitor scelerisque ac id diam <cite data-cite="granger">Granger</cite>. Mauri
 velit, lobortis sed interdum at, vestibulum vitae libero <strong data-cite="fperez">Perez</strong>.
 Lorem ipsum dolor sit amet, consectetur adipiscing elit
 <em data-cite="takluyver">Thomas</em>. Quisque iaculis ligula ut ipsum mattis viverra.
+
+<p>Here is a plain paragraph that should be unaffected.</p>
 
 * One <cite data-cite="jdfreder">Jonathan</cite>.
 * Two <cite data-cite="carreau">Matthias</cite>.
@@ -39,16 +41,18 @@ velit, lobortis sed interdum at, vestibulum vitae libero \cite{fperez}.
 Lorem ipsum dolor sit amet, consectetur adipiscing elit
 \cite{takluyver}. Quisque iaculis ligula ut ipsum mattis viverra.
 
+<p>Here is a plain paragraph that should be unaffected.</p>
+
 * One \cite{jdfreder}.
 * Two \cite{carreau}.
 * Three \cite{ivanov}.
 """
 
-def test_parse_citation():
+def test_citation2latex():
     """Are citations parsed properly?"""
     try:
         import lxml
     except ImportError:
-        assert test_md == parse_citation(test_md) 
+        assert test_md == citation2latex(test_md) 
     else:
-        assert test_md_parsed == parse_citation(test_md)
+        assert test_md_parsed == citation2latex(test_md)

--- a/IPython/nbconvert/filters/tests/test_citation.py
+++ b/IPython/nbconvert/filters/tests/test_citation.py
@@ -1,0 +1,54 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, the IPython Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+from ..citation import parse_citation
+
+#-----------------------------------------------------------------------------
+# Tests
+#-----------------------------------------------------------------------------
+
+test_md = """
+# My Heading
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus ac magna non augue
+porttitor scelerisque ac id diam <cite data-cite="granger">Granger</cite>. Mauris elit
+velit, lobortis sed interdum at, vestibulum vitae libero <strong data-cite="fperez">Perez</strong>.
+Lorem ipsum dolor sit amet, consectetur adipiscing elit
+<em data-cite="takluyver">Thomas</em>. Quisque iaculis ligula ut ipsum mattis viverra.
+
+* One <cite data-cite="jdfreder">Jonathan</cite>.
+* Two <cite data-cite="carreau">Matthias</cite>.
+* Three <cite data-cite="ivanov">Paul</cite>.
+"""
+
+test_md_parsed = """
+# My Heading
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus ac magna non augue
+porttitor scelerisque ac id diam \cite{granger}. Mauris elit
+velit, lobortis sed interdum at, vestibulum vitae libero \cite{fperez}.
+Lorem ipsum dolor sit amet, consectetur adipiscing elit
+\cite{takluyver}. Quisque iaculis ligula ut ipsum mattis viverra.
+
+* One \cite{jdfreder}.
+* Two \cite{carreau}.
+* Three \cite{ivanov}.
+"""
+
+def test_parse_citation():
+    """Are citations parsed properly?"""
+    try:
+        import lxml
+    except ImportError:
+        assert test_md == parse_citation(test_md) 
+    else:
+        assert test_md_parsed == parse_citation(test_md)

--- a/IPython/nbconvert/postprocessors/pdf.py
+++ b/IPython/nbconvert/postprocessors/pdf.py
@@ -46,7 +46,7 @@ class PDFPostProcessor(PostProcessorBase):
         """)
 
     def run_command(self, command_list, filename, count, log_function):
-        """Run pdflatex or bibtext count times.
+        """Run command_list count times.
         
         Parameters
         ----------

--- a/IPython/nbconvert/postprocessors/tests/test_pdf.py
+++ b/IPython/nbconvert/postprocessors/tests/test_pdf.py
@@ -62,3 +62,7 @@ class TestPDF(TestsBase):
 
             # Check that the PDF was created.
             assert os.path.isfile('a.pdf')
+            
+            # Make sure that temp files are cleaned up
+            for ext in processor.temp_file_exts:
+                assert not os.path.isfile('a'+ext)

--- a/IPython/nbconvert/templates/latex/latex_basic.tplx
+++ b/IPython/nbconvert/templates/latex/latex_basic.tplx
@@ -103,11 +103,11 @@ it introduces a new line
 ((* endblock stream *))
 
 ((* block markdowncell scoped *))
-((( cell.source | markdown2latex )))
+((( cell.source | parse_citation | markdown2latex )))
 ((* endblock markdowncell *))
 
 ((* block headingcell scoped -*))
-((( ('#' * cell.level + cell.source) | replace('\n', ' ') | markdown2latex )))
+((( ('#' * cell.level + cell.source) | replace('\n', ' ') | parse_citation | markdown2latex )))
 ((* endblock headingcell *))
 
 ((* block rawcell scoped *))
@@ -127,6 +127,10 @@ unknown type  ((( cell.type )))
 ((( super() )))
 
 ((* block bodyEnd *))
+
+((* block bibliography *))
+((* endblock bibliography *))
+
 \end{document}
 ((* endblock bodyEnd *))
 ((* endblock body *))

--- a/IPython/nbconvert/templates/latex/latex_basic.tplx
+++ b/IPython/nbconvert/templates/latex/latex_basic.tplx
@@ -103,11 +103,11 @@ it introduces a new line
 ((* endblock stream *))
 
 ((* block markdowncell scoped *))
-((( cell.source | parse_citation | markdown2latex )))
+((( cell.source | citation2latex | markdown2latex )))
 ((* endblock markdowncell *))
 
 ((* block headingcell scoped -*))
-((( ('#' * cell.level + cell.source) | replace('\n', ' ') | parse_citation | markdown2latex )))
+((( ('#' * cell.level + cell.source) | replace('\n', ' ') | citation2latex | markdown2latex )))
 ((* endblock headingcell *))
 
 ((* block rawcell scoped *))

--- a/IPython/nbconvert/templates/latex/sphinx.tplx
+++ b/IPython/nbconvert/templates/latex/sphinx.tplx
@@ -192,6 +192,9 @@ Note: For best display, use latex syntax highlighting. =))
         \renewcommand{\indexname}{Index}
         \printindex
 
+        ((* block bibliography *))
+        ((* endblock bibliography *))
+
     % End of document
     \end{document}
 ((* endblock bodyEnd *))
@@ -229,7 +232,7 @@ Note: For best display, use latex syntax highlighting. =))
     in IPYNB file titles) do not make their way into latex.  Sometimes this
     causes latex to barf. =))
     ((*- endif -*))
-    {((( cell.source | markdown2latex )))}
+    {((( cell.source | parse_citation | markdown2latex )))}
 ((*- endblock headingcell *))
 
 %==============================================================================
@@ -239,7 +242,7 @@ Note: For best display, use latex syntax highlighting. =))
 %          called since we know we want latex output.
 %==============================================================================
 ((*- block markdowncell scoped-*))
-((( cell.source | markdown2latex )))
+((( cell.source | parse_citation | markdown2latex )))
 ((*- endblock markdowncell -*))
 
 %==============================================================================

--- a/IPython/nbconvert/templates/latex/sphinx.tplx
+++ b/IPython/nbconvert/templates/latex/sphinx.tplx
@@ -232,7 +232,7 @@ Note: For best display, use latex syntax highlighting. =))
     in IPYNB file titles) do not make their way into latex.  Sometimes this
     causes latex to barf. =))
     ((*- endif -*))
-    {((( cell.source | parse_citation | markdown2latex )))}
+    {((( cell.source | citation2latex | markdown2latex )))}
 ((*- endblock headingcell *))
 
 %==============================================================================
@@ -242,7 +242,7 @@ Note: For best display, use latex syntax highlighting. =))
 %          called since we know we want latex output.
 %==============================================================================
 ((*- block markdowncell scoped-*))
-((( cell.source | parse_citation | markdown2latex )))
+((( cell.source | citation2latex | markdown2latex )))
 ((*- endblock markdowncell -*))
 
 %==============================================================================

--- a/docs/source/interactive/nbconvert.rst
+++ b/docs/source/interactive/nbconvert.rst
@@ -125,6 +125,21 @@ and using the command::
 
 .. _notebook_format:
 
+LaTeX citations
+---------------
+
+``nbconvert`` now has support for LaTeX citations. With this capability you
+can:
+
+* Manage citations using BibTeX.
+* Cite those citations in Markdown cells using HTML data attributes.
+* Have ``nbconvert`` generate proper LaTeX citations and run BibTeX.
+
+For an example of how this works, please see the citations example in
+the nbconvert-examples_ repository.
+
+.. _nbconvert-examples: https://github.com/ipython/nbconvert-examples
+
 Notebook JSON file format
 -------------------------
 


### PR DESCRIPTION
This PR adds the ability for nbconvert to manage LaTeX citations.  These are entered into the markdown cells using data attributes:

``` html
<strong data-cite="granger">(Granger, 2013)</strong>
```

Which gets converted to the following in the LaTeX document: `\cite{granger}`

We then run BibTeX.  The user also has to override the bibliography block of the nbconvert template. See:

https://github.com/ipython/nbconvert-examples

For a full example.
