### PR TITLE
Make Qt console banner configurable

### DIFF
--- a/IPython/qt/console/frontend_widget.py
+++ b/IPython/qt/console/frontend_widget.py
@@ -78,7 +78,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
     """
 
     # The text to show when the kernel is (re)started.
-    banner = Unicode()
+    banner = Unicode(config=True)
 
     # An option and corresponding signal for overriding the default kernel
     # interrupt behavior.


### PR DESCRIPTION
The banner is configurable in the terminal, so I assume it's just an oversight that it's not configurable in the Qt console.

From [this StackOverflow question](http://stackoverflow.com/questions/18363050/modify-banner-of-qt-console-of-ipython).
