### PR TITLE
pass profile-dir instead of profile name to Kernel

### DIFF
--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -142,6 +142,9 @@ class Application(SingletonConfigurable):
 
     # The version string of this application.
     version = Unicode(u'0.0')
+    
+    # the argv used to initialize the application
+    argv = List(Unicode)
 
     # The log level for the application
     log_level = Enum((0,10,20,30,40,50,'DEBUG','INFO','WARN','ERROR','CRITICAL'),
@@ -454,6 +457,7 @@ class Application(SingletonConfigurable):
     def parse_command_line(self, argv=None):
         """Parse the command line arguments."""
         argv = sys.argv[1:] if argv is None else argv
+        self.argv = list(argv)
         
         if argv and argv[0] == 'help':
             # turn `ipython help notebook` into `ipython notebook -h`

--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -53,6 +53,7 @@ from IPython.utils.traitlets import List, Unicode, Type, Bool, Dict, Set, Instan
 # aliases and flags
 
 base_aliases = {
+    'profile-dir' : 'ProfileDir.location',
     'profile' : 'BaseIPythonApplication.profile',
     'ipython-dir' : 'BaseIPythonApplication.ipython_dir',
     'log-level' : 'Application.log_level',

--- a/IPython/parallel/apps/baseapp.py
+++ b/IPython/parallel/apps/baseapp.py
@@ -71,7 +71,6 @@ class ParallelCrashHandler(CrashHandler):
 base_aliases = {}
 base_aliases.update(base_ip_aliases)
 base_aliases.update({
-    'profile-dir' : 'ProfileDir.location',
     'work-dir' : 'BaseParallelApplication.work_dir',
     'log-to-file' : 'BaseParallelApplication.log_to_file',
     'clean-logs' : 'BaseParallelApplication.clean_logs',


### PR DESCRIPTION
avoids relative path issues for local profiles when the notebook server starts in a different directory from the kernels.

moves the `profile-dir` alias from the parallel apps up to the base IPython app

Candidate for backport to 1.1
