### PR TITLE
restore accidentally removed EngineError

### DIFF
--- a/IPython/parallel/error.py
+++ b/IPython/parallel/error.py
@@ -43,6 +43,9 @@ class IPythonError(Exception):
 class KernelError(IPythonError):
     pass
 
+class EngineError(KernelError):
+    pass
+
 class NoEnginesRegistered(KernelError):
     pass
 


### PR DESCRIPTION
in cleanup PR #3527, I removed one too many exception classes.

I acked IPython to check that I didn't miss any more.

closes #4100

should be backported to 1.1.
