### PR TITLE
Fix clashes between debugger tests and coverage.py

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -35,6 +35,7 @@ from IPython import get_ipython
 from IPython.utils import PyColorize, ulinecache
 from IPython.utils import coloransi, io, py3compat
 from IPython.core.excolors import exception_colors
+from IPython.testing.skipdoctest import skip_doctest
 
 # See if we can use pydb.
 has_pydb = False
@@ -91,6 +92,7 @@ class Tracer(object):
     while functioning acceptably (though with limitations) if outside of it.
     """
 
+    @skip_doctest
     def __init__(self,colors=None):
         """Create a local debugger instance.
 

--- a/IPython/core/tests/test_debugger.py
+++ b/IPython/core/tests/test_debugger.py
@@ -85,6 +85,8 @@ def test_ipdb_magics():
     ...     """Docstring for example_function."""
     ...     pass
 
+    >>> old_trace = sys.gettrace()
+
     Create a function which triggers ipdb.
 
     >>> def trigger_ipdb():
@@ -120,10 +122,16 @@ def test_ipdb_magics():
     Docstring:  Docstring for ExampleClass.
     Constructor Docstring:Docstring for ExampleClass.__init__
     ipdb> continue
+    
+    Restore previous trace function, e.g. for coverage.py    
+    
+    >>> sys.settrace(old_trace)
     '''
 
 def test_ipdb_magics2():
     '''Test ipdb with a very short function.
+    
+    >>> old_trace = sys.gettrace()
 
     >>> def bar():
     ...     pass
@@ -139,4 +147,8 @@ def test_ipdb_magics2():
     ----> 2    pass
     <BLANKLINE>
     ipdb> continue
+    
+    Restore previous trace function, e.g. for coverage.py    
+    
+    >>> sys.settrace(old_trace)
     '''


### PR DESCRIPTION
coverage.py works by setting the trace function. But so does the debugger, so we need to re-set it after testing the debugger to get accurate coverage results.

I noticed a disparity between the coverage numbers for Python 2 and 3, which seems to be down to the order in which tests are executed. Hopefully this will fix it.
