### PR TITLE
Add way to install MathJax to a particular profile

### DIFF
--- a/IPython/external/mathjax.py
+++ b/IPython/external/mathjax.py
@@ -19,6 +19,10 @@ From the command line:
 
     $ python -m IPython.external.mathjax
 
+To a specific profile:
+
+    $ python -m IPython.external.mathjax --profile=research
+
 To install MathJax from a file you have already downloaded:
 
     $ python -m IPython.external.mathjax mathjax-xxx.tar.gz
@@ -202,13 +206,13 @@ def main() :
     parser.add_argument(
             '-p',
             '--profile',
-            help='profile to install MathJax to. Takes precedence over install-dir option')
+            default='default',
+            help='profile to install MathJax to (default is default)')
 
     parser.add_argument(
             '-i',
             '--install-dir',
-            default=default_dest,
-            help='installation directory (by default : %s)' % (default_dest))
+            help='custom installation directory')
 
     parser.add_argument(
             '-d',
@@ -231,13 +235,13 @@ def main() :
 
     pargs = parser.parse_args()
 
-    if(pargs.profile):
+    if pargs.install_dir:
+        # Explicit install_dir overrides profile
+        dest = pargs.install_dir
+    else:
         profile = pargs.profile
         static = os.path.join(locate_profile(profile), 'static')
         dest = os.path.join(static, 'mathjax')
-    else:
-        dest = pargs.install_dir
-
 
     if pargs.dest :
         print dest

--- a/IPython/external/mathjax.py
+++ b/IPython/external/mathjax.py
@@ -240,8 +240,7 @@ def main() :
         dest = pargs.install_dir
     else:
         profile = pargs.profile
-        static = os.path.join(locate_profile(profile), 'static')
-        dest = os.path.join(static, 'mathjax')
+        dest = os.path.join(locate_profile(profile), 'static', 'mathjax')
 
     if pargs.dest :
         print dest

--- a/IPython/external/mathjax.py
+++ b/IPython/external/mathjax.py
@@ -200,6 +200,12 @@ def main() :
             )
 
     parser.add_argument(
+            '-p',
+            '--profile',
+            default='default',
+            help='profile to install MathJax to. Takes precedence over install-dir option')
+
+    parser.add_argument(
             '-i',
             '--install-dir',
             default=default_dest,
@@ -208,12 +214,12 @@ def main() :
             '-d',
             '--dest',
             action='store_true',
-            help='print where is current mathjax would be installed and exit')
+            help='print where current mathjax would be installed and exit')
     parser.add_argument(
             '-r',
             '--replace',
             action='store_true',
-            help='Wether to replace current mathjax if already exist')
+            help='Whether to replace current mathjax if it already exists')
     parser.add_argument(
             '-t',
             '--test',
@@ -225,7 +231,14 @@ def main() :
 
     pargs = parser.parse_args()
 
-    dest = pargs.install_dir
+    if(pargs.profile):
+        profile = pargs.profile
+        static = os.path.join(locate_profile(profile), 'static')
+        dest = os.path.join(static, 'mathjax')
+    else:
+        dest = pargs.install_dir
+
+
     if pargs.dest :
         print dest
         return

--- a/IPython/external/mathjax.py
+++ b/IPython/external/mathjax.py
@@ -202,7 +202,6 @@ def main() :
     parser.add_argument(
             '-p',
             '--profile',
-            default='default',
             help='profile to install MathJax to. Takes precedence over install-dir option')
 
     parser.add_argument(
@@ -210,6 +209,7 @@ def main() :
             '--install-dir',
             default=default_dest,
             help='installation directory (by default : %s)' % (default_dest))
+
     parser.add_argument(
             '-d',
             '--dest',


### PR DESCRIPTION
Made a quick handler to install MathJax to a specified profile (rather than either only accepting default or requiring knowledge of a full path).

Also cleaned up some grammar.
