### PR TITLE
Add shortcut for "Run all cells"

### DIFF
--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -321,7 +321,12 @@ var IPython = (function (IPython) {
                 // Split cell = -
                 that.split_cell();
                 that.control_key_active = false;
-                return false;                                               
+                return false;
+            } else if (event.which === 82 && that.control_key_active) {
+                // Run all cells = r
+                that.execute_all_cells();
+                that.control_key_active = false;
+                return false;
             } else if (that.control_key_active) {
                 that.control_key_active = false;
                 return true;

--- a/IPython/html/static/notebook/js/quickhelp.js
+++ b/IPython/html/static/notebook/js/quickhelp.js
@@ -50,7 +50,7 @@ var IPython = (function (IPython) {
             {key: 'Ctrl-m n', help: 'select next'},
             {key: 'Ctrl-m i', help: 'interrupt kernel'},
             {key: 'Ctrl-m .', help: 'restart kernel'},
-            {key: 'Ctrl-m r', help: 'run all cells'}
+            {key: 'Ctrl-m r', help: 'run all cells'},
             {key: 'Ctrl-m h', help: 'show keyboard shortcuts'}
         ];
         for (var i=0; i<shortcuts.length; i++) {

--- a/IPython/html/static/notebook/js/quickhelp.js
+++ b/IPython/html/static/notebook/js/quickhelp.js
@@ -50,6 +50,7 @@ var IPython = (function (IPython) {
             {key: 'Ctrl-m n', help: 'select next'},
             {key: 'Ctrl-m i', help: 'interrupt kernel'},
             {key: 'Ctrl-m .', help: 'restart kernel'},
+            {key: 'Ctrl-m r', help: 'run all cells'}
             {key: 'Ctrl-m h', help: 'show keyboard shortcuts'}
         ];
         for (var i=0; i<shortcuts.length; i++) {


### PR DESCRIPTION
Adds the shortcut `Ctrl-m` `r` for "Run all cells".
This is often required after a kernel restart, e.g. to change `matplotlib` between inline and external window, or when returning to a notebook saved in a previous session.

This fixes issue #4040.
