### PR TITLE
Basic exercise of `ipython [subcommand] -h` and help-all

### DIFF
--- a/IPython/html/tests/test_notebookapp.py
+++ b/IPython/html/tests/test_notebookapp.py
@@ -20,10 +20,6 @@ import IPython.testing.tools as tt
 #-----------------------------------------------------------------------------
 
 def test_help_output():
-    """ipython notebook -h works"""
-    tt.help_output_test('notebook')
-
-def test_help_all_output():
     """ipython notebook --help-all works"""
     tt.help_all_output_test('notebook')
 

--- a/IPython/html/tests/test_notebookapp.py
+++ b/IPython/html/tests/test_notebookapp.py
@@ -1,0 +1,29 @@
+"""Test NotebookApp"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2013 The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+import nose.tools as nt
+
+import IPython.testing.tools as tt
+
+#-----------------------------------------------------------------------------
+# Test functions
+#-----------------------------------------------------------------------------
+
+def test_help_output():
+    """ipython notebook -h works"""
+    tt.help_output_test('notebook')
+
+def test_help_all_output():
+    """ipython notebook --help-all works"""
+    tt.help_all_output_test('notebook')
+

--- a/IPython/kernel/connect.py
+++ b/IPython/kernel/connect.py
@@ -34,14 +34,13 @@ import zmq
 from IPython.external.ssh import tunnel
 
 # IPython imports
-# from IPython.config import Configurable
+from IPython.config import Configurable
 from IPython.core.profiledir import ProfileDir
 from IPython.utils.localinterfaces import LOCALHOST
 from IPython.utils.path import filefind, get_ipython_dir
 from IPython.utils.py3compat import str_to_bytes, bytes_to_str
 from IPython.utils.traitlets import (
     Bool, Integer, Unicode, CaselessStrEnum,
-    HasTraits,
 )
 
 
@@ -383,7 +382,7 @@ channel_socket_types = {
 
 port_names = [ "%s_port" % channel for channel in ('shell', 'stdin', 'iopub', 'hb', 'control')]
 
-class ConnectionFileMixin(HasTraits):
+class ConnectionFileMixin(Configurable):
     """Mixin for configurable classes that work with connection files"""
 
     # The addresses for the communication channels

--- a/IPython/kernel/tests/test_kernel.py
+++ b/IPython/kernel/tests/test_kernel.py
@@ -23,7 +23,7 @@ import nose.tools as nt
 
 from IPython.kernel import KernelManager
 from IPython.kernel.tests.test_message_spec import execute, flush_channels
-from IPython.testing import decorators as dec
+from IPython.testing import decorators as dec, tools as tt
 from IPython.utils import path, py3compat
 
 #-------------------------------------------------------------------------------
@@ -206,7 +206,6 @@ def test_subprocess_error():
         _check_mp_mode(kc, expected=False)
         _check_mp_mode(kc, expected=False, stream="stderr")
 
-
 # raw_input tests
 
 def test_raw_input():
@@ -249,4 +248,9 @@ def test_eval_input():
         nt.assert_equal(reply['content']['status'], 'ok')
         stdout, stderr = assemble_output(iopub)
         nt.assert_equal(stdout, "2\n")
+
+
+def test_help_output():
+    """ipython kernel --help-all works"""
+    tt.help_all_output_test('kernel')
 

--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -25,6 +25,7 @@ import glob
 
 # From IPython
 from IPython.core.application import BaseIPythonApplication, base_aliases, base_flags
+from IPython.core.profiledir import ProfileDir
 from IPython.config import catch_config_error, Configurable
 from IPython.utils.traitlets import (
     Unicode, List, Instance, DottedObjectName, Type, CaselessStrEnum,
@@ -87,12 +88,13 @@ class NbConvertApp(BaseIPythonApplication):
         return logging.INFO
     
     def _classes_default(self):
-        classes = [NbConvertBase]
+        classes = [NbConvertBase, ProfileDir]
         for pkg in (exporters, preprocessors, writers):
             for name in dir(pkg):
                 cls = getattr(pkg, name)
                 if isinstance(cls, type) and issubclass(cls, Configurable):
                     classes.append(cls)
+        
         return classes
 
     description = Unicode(

--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -62,8 +62,8 @@ nbconvert_aliases.update({
     'writer' : 'NbConvertApp.writer_class',
     'post': 'NbConvertApp.postprocessor_class',
     'output': 'NbConvertApp.output_base',
-    'offline-slides': 'RevealHelpTransformer.url_prefix',
-    'slide-notes': 'RevealHelpTransformer.speaker_notes'
+    'offline-slides': 'RevealHelpPreprocessor.url_prefix',
+    'slide-notes': 'RevealHelpPreprocessor.speaker_notes'
 })
 
 nbconvert_flags = {}

--- a/IPython/nbconvert/tests/test_nbconvertapp.py
+++ b/IPython/nbconvert/tests/test_nbconvertapp.py
@@ -40,10 +40,6 @@ class TestNbConvertApp(TestsBase):
             self.assertIn("see '--help-all'", out)
     
     def test_help_output(self):
-        """ipython nbconvert -h works"""
-        tt.help_output_test('nbconvert')
-
-    def test_help_all_output(self):
         """ipython nbconvert --help-all works"""
         tt.help_all_output_test('nbconvert')
 

--- a/IPython/nbconvert/tests/test_nbconvertapp.py
+++ b/IPython/nbconvert/tests/test_nbconvertapp.py
@@ -1,12 +1,10 @@
-"""
-Contains tests for the nbconvertapp
-"""
+"""Test NbConvertApp"""
+
 #-----------------------------------------------------------------------------
-#Copyright (c) 2013, the IPython Development Team.
+#  Copyright (C) 2013 The IPython Development Team
 #
-#Distributed under the terms of the Modified BSD License.
-#
-#The full license is in the file COPYING.txt, distributed with this software.
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
 #-----------------------------------------------------------------------------
 
 #-----------------------------------------------------------------------------
@@ -18,9 +16,10 @@ import glob
 
 from .base import TestsBase
 
+import IPython.testing.tools as tt
 from IPython.testing import decorators as dec
 
-    
+
 #-----------------------------------------------------------------------------
 # Constants
 #-----------------------------------------------------------------------------
@@ -35,13 +34,18 @@ class TestNbConvertApp(TestsBase):
 
 
     def test_notebook_help(self):
-        """
-        Will help show if no notebooks are specified?
-        """
+        """Will help show if no notebooks are specified?"""
         with self.create_temp_cwd():
             out, err = self.call('nbconvert --log-level 0', ignore_return_code=True)
-            assert "see '--help-all'" in out
+            self.assertIn("see '--help-all'", out)
+    
+    def test_help_output(self):
+        """ipython nbconvert -h works"""
+        tt.help_output_test('nbconvert')
 
+    def test_help_all_output(self):
+        """ipython nbconvert --help-all works"""
+        tt.help_all_output_test('nbconvert')
 
     def test_glob(self):
         """

--- a/IPython/qt/console/tests/test_app.py
+++ b/IPython/qt/console/tests/test_app.py
@@ -20,10 +20,6 @@ import IPython.testing.tools as tt
 #-----------------------------------------------------------------------------
 
 def test_help_output():
-    """ipython qtconsole -h works"""
-    tt.help_output_test('qtconsole')
-
-def test_help_all_output():
     """ipython qtconsole --help-all works"""
     tt.help_all_output_test('qtconsole')
 

--- a/IPython/qt/console/tests/test_app.py
+++ b/IPython/qt/console/tests/test_app.py
@@ -1,0 +1,29 @@
+"""Test QtConsoleApp"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2013 The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+import nose.tools as nt
+
+import IPython.testing.tools as tt
+
+#-----------------------------------------------------------------------------
+# Test functions
+#-----------------------------------------------------------------------------
+
+def test_help_output():
+    """ipython qtconsole -h works"""
+    tt.help_output_test('qtconsole')
+
+def test_help_all_output():
+    """ipython qtconsole --help-all works"""
+    tt.help_all_output_test('qtconsole')
+

--- a/IPython/terminal/console/tests/test_console.py
+++ b/IPython/terminal/console/tests/test_console.py
@@ -58,10 +58,6 @@ def test_console_starts():
         p.terminate()
 
 def test_help_output():
-    """ipython console -h works"""
-    tt.help_output_test('console')
-    
-def test_help_all_output():
     """ipython console --help-all works"""
     tt.help_all_output_test('console')
 

--- a/IPython/terminal/console/tests/test_console.py
+++ b/IPython/terminal/console/tests/test_console.py
@@ -18,11 +18,12 @@ import time
 import nose.tools as nt
 from nose import SkipTest
 
+import IPython.testing.tools as tt
 from IPython.testing import decorators as dec
 from IPython.utils import py3compat
 
 #-----------------------------------------------------------------------------
-# Test functions begin
+# Tests
 #-----------------------------------------------------------------------------
 
 @dec.skip_win32
@@ -55,3 +56,12 @@ def test_console_starts():
     p.expect([pexpect.EOF, pexpect.TIMEOUT], timeout=t)
     if p.isalive():
         p.terminate()
+
+def test_help_output():
+    """ipython console -h works"""
+    tt.help_output_test('console')
+    
+def test_help_all_output():
+    """ipython console --help-all works"""
+    tt.help_all_output_test('console')
+

--- a/IPython/terminal/tests/test_help.py
+++ b/IPython/terminal/tests/test_help.py
@@ -19,37 +19,19 @@ import IPython.testing.tools as tt
 
 
 def test_ipython_help():
-    tt.help_output_test()
-
-def test_ipython_help_all():
     tt.help_all_output_test()
 
 def test_profile_help():
-    tt.help_output_test("profile")
-
-def test_profile_help_all():
     tt.help_all_output_test("profile")
 
 def test_profile_list_help():
-    tt.help_output_test("profile list")
-
-def test_profile_list_help_all():
     tt.help_all_output_test("profile list")
 
 def test_profile_create_help():
-    tt.help_output_test("profile create")
-
-def test_profile_create_help_all():
     tt.help_all_output_test("profile create")
 
 def test_locate_help():
-    tt.help_output_test("locate")
-
-def test_locate_help_all():
     tt.help_all_output_test("locate")
 
 def test_locate_profile_help():
-    tt.help_output_test("locate profile")
-
-def test_locate_profile_all():
     tt.help_all_output_test("locate profile")

--- a/IPython/terminal/tests/test_help.py
+++ b/IPython/terminal/tests/test_help.py
@@ -11,57 +11,45 @@
 # Imports
 #-----------------------------------------------------------------------------
 
-from IPython.testing.tools import help, help_all
+import IPython.testing.tools as tt
 
 #-----------------------------------------------------------------------------
 # Tests
 #-----------------------------------------------------------------------------
 
 
-@help()
 def test_ipython_help():
-    pass
+    tt.help_output_test()
 
-@help_all()
 def test_ipython_help_all():
-    pass
+    tt.help_all_output_test()
 
-@help("profile")
 def test_profile_help():
-    pass
+    tt.help_output_test("profile")
 
-@help_all("profile")
 def test_profile_help_all():
-    pass
+    tt.help_all_output_test("profile")
 
-@help("profile list")
 def test_profile_list_help():
-    pass
+    tt.help_output_test("profile list")
 
-@help_all("profile list")
 def test_profile_list_help_all():
-    pass
+    tt.help_all_output_test("profile list")
 
-@help("profile create")
 def test_profile_create_help():
-    pass
+    tt.help_output_test("profile create")
 
-@help_all("profile create")
 def test_profile_create_help_all():
-    pass
+    tt.help_all_output_test("profile create")
 
-@help("locate")
 def test_locate_help():
-    pass
+    tt.help_output_test("locate")
 
-@help_all("locate")
 def test_locate_help_all():
-    pass
+    tt.help_all_output_test("locate")
 
-@help("locate profile")
 def test_locate_profile_help():
-    pass
+    tt.help_output_test("locate profile")
 
-@help_all("locate profile")
 def test_locate_profile_all():
-    pass
+    tt.help_all_output_test("locate profile")

--- a/IPython/terminal/tests/test_help.py
+++ b/IPython/terminal/tests/test_help.py
@@ -1,0 +1,67 @@
+"""Test help output of various IPython entry points"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2013 The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+from IPython.testing.tools import help, help_all
+
+#-----------------------------------------------------------------------------
+# Tests
+#-----------------------------------------------------------------------------
+
+
+@help()
+def test_ipython_help():
+    pass
+
+@help_all()
+def test_ipython_help_all():
+    pass
+
+@help("profile")
+def test_profile_help():
+    pass
+
+@help_all("profile")
+def test_profile_help_all():
+    pass
+
+@help("profile list")
+def test_profile_list_help():
+    pass
+
+@help_all("profile list")
+def test_profile_list_help_all():
+    pass
+
+@help("profile create")
+def test_profile_create_help():
+    pass
+
+@help_all("profile create")
+def test_profile_create_help_all():
+    pass
+
+@help("locate")
+def test_locate_help():
+    pass
+
+@help_all("locate")
+def test_locate_help_all():
+    pass
+
+@help("locate profile")
+def test_locate_profile_help():
+    pass
+
+@help_all("locate profile")
+def test_locate_profile_all():
+    pass

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -8,7 +8,7 @@ Authors
 from __future__ import absolute_import
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2009-2011  The IPython Development Team
+#  Copyright (C) 2009 The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 # Imports
 #-----------------------------------------------------------------------------
 
+import inspect
 import os
 import re
 import sys
@@ -37,6 +38,7 @@ except ImportError:
     has_nose = False
 
 from IPython.config.loader import Config
+from IPython.utils.process import get_output_error_code
 from IPython.utils.text import list_strings
 from IPython.utils.io import temp_pyfile, Tee
 from IPython.utils import py3compat
@@ -408,3 +410,56 @@ def monkeypatch(obj, name, attr):
     setattr(obj, name, attr)
     yield
     setattr(obj, name, orig)
+
+
+def help_output_test(subcommand=''):
+    """test that `ipython [subcommand] -h` works"""
+    cmd = ' '.join(get_ipython_cmd() + [subcommand, '-h'])
+    out, err, rc = get_output_error_code(cmd)
+    nt.assert_equal(rc, 0, err)
+    nt.assert_not_in("Traceback", err)
+    nt.assert_in("Options", out)
+    nt.assert_in("--help-all", out)
+    return out, err
+
+
+def help_all_output_test(subcommand=''):
+    """test that `ipython [subcommand] --help-all` works"""
+    cmd = ' '.join(get_ipython_cmd() + [subcommand, '--help-all'])
+    out, err, rc = get_output_error_code(cmd)
+    nt.assert_equal(rc, 0, err)
+    nt.assert_not_in("Traceback", err)
+    nt.assert_in("Options", out)
+    nt.assert_in("Class parameters", out)
+    return out, err
+
+
+def help(cmd=''):
+    """decorator for making a test for `ipython cmd -h`"""
+    def wrap_help_test(f):
+        def test_help_output():
+            out, err = help_output_test(cmd)
+            if inspect.getargspec(f).args:
+                return f(out, err)
+            else:
+                return f()
+        cmds = cmd + ' ' if cmd else ''
+        test_help_output.__doc__ = "ipython {cmds}--help-all works".format(cmds=cmds)
+
+        return test_help_output
+    return wrap_help_test
+
+
+def help_all(cmd=''):
+    """decorator for making a test for `ipython [cmd] --help-all`"""
+    def wrap_help_test(f):
+        def test_help_output():
+            out, err = help_all_output_test(cmd)
+            if inspect.getargspec(f).args:
+                return f(out, err)
+            else:
+                return f()
+        cmds = cmd + ' ' if cmd else ''
+        test_help_output.__doc__ = "ipython {cmds}--help-all works".format(cmds=cmds)
+        return test_help_output
+    return wrap_help_test

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -433,33 +433,3 @@ def help_all_output_test(subcommand=''):
     nt.assert_in("Class parameters", out)
     return out, err
 
-
-def help(cmd=''):
-    """decorator for making a test for `ipython cmd -h`"""
-    def wrap_help_test(f):
-        def test_help_output():
-            out, err = help_output_test(cmd)
-            if inspect.getargspec(f).args:
-                return f(out, err)
-            else:
-                return f()
-        cmds = cmd + ' ' if cmd else ''
-        test_help_output.__doc__ = "ipython {cmds}--help-all works".format(cmds=cmds)
-
-        return test_help_output
-    return wrap_help_test
-
-
-def help_all(cmd=''):
-    """decorator for making a test for `ipython [cmd] --help-all`"""
-    def wrap_help_test(f):
-        def test_help_output():
-            out, err = help_all_output_test(cmd)
-            if inspect.getargspec(f).args:
-                return f(out, err)
-            else:
-                return f()
-        cmds = cmd + ' ' if cmd else ''
-        test_help_output.__doc__ = "ipython {cmds}--help-all works".format(cmds=cmds)
-        return test_help_output
-    return wrap_help_test


### PR DESCRIPTION
for various subcommands.

Prompted by the fact that `ip qtconsole -h` and `ip nbconvert -h` are both broken in master.
This PR also fixes both.

Should be backported to 1.1
