### PR TITLE
PDF figures as links from png or svg figures

### DIFF
--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -85,6 +85,7 @@ class DisplayFormatter(Configurable):
             HTMLFormatter,
             SVGFormatter,
             PNGFormatter,
+            PDFFormatter,
             JPEGFormatter,
             LatexFormatter,
             JSONFormatter,
@@ -109,6 +110,7 @@ class DisplayFormatter(Configurable):
         * application/json
         * application/javascript
         * image/png
+        * application/pdf
         * image/jpeg
         * image/svg+xml
 
@@ -533,6 +535,22 @@ class PNGFormatter(BaseFormatter):
     print_method = ObjectName('_repr_png_')
 
 
+class PDFFormatter(BaseFormatter):
+    """A PDF formatter.
+
+    To defined the callables that compute to PDF representation of your
+    objects, define a :meth:`_repr_pdf_` method or use the :meth:`for_type`
+    or :meth:`for_type_by_name` methods to register functions that handle
+    this.
+
+    The return value of this formatter should be raw PDF data, *not*
+    base64 encoded.
+    """
+    format_type = Unicode('application/pdf')
+
+    print_method = ObjectName('_repr_pdf_')
+
+
 class JPEGFormatter(BaseFormatter):
     """A JPEG formatter.
 
@@ -601,6 +619,7 @@ FormatterABC.register(PlainTextFormatter)
 FormatterABC.register(HTMLFormatter)
 FormatterABC.register(SVGFormatter)
 FormatterABC.register(PNGFormatter)
+FormatterABC.register(PDFFormatter)
 FormatterABC.register(JPEGFormatter)
 FormatterABC.register(LatexFormatter)
 FormatterABC.register(JSONFormatter)
@@ -620,6 +639,7 @@ def format_display_data(obj, include=None, exclude=None):
     * application/json
     * application/javascript
     * image/png
+    * application/pdf
     * image/jpeg
     * image/svg+xml
 

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -170,16 +170,20 @@ def select_figure_format(shell, fmt):
 
     svg_formatter = shell.display_formatter.formatters['image/svg+xml']
     png_formatter = shell.display_formatter.formatters['image/png']
+    pdf_formatter = shell.display_formatter.formatters['application/pdf']
 
     if fmt == 'png':
         svg_formatter.type_printers.pop(Figure, None)
         png_formatter.for_type(Figure, lambda fig: print_figure(fig, 'png'))
+        pdf_formatter.for_type(Figure, lambda fig: print_figure(fig, 'pdf'))
     elif fmt in ('png2x', 'retina'):
         svg_formatter.type_printers.pop(Figure, None)
         png_formatter.for_type(Figure, retina_figure)
+        pdf_formatter.for_type(Figure, lambda fig: print_figure(fig, 'pdf'))
     elif fmt == 'svg':
         png_formatter.type_printers.pop(Figure, None)
         svg_formatter.for_type(Figure, lambda fig: print_figure(fig, 'svg'))
+        pdf_formatter.for_type(Figure, lambda fig: print_figure(fig, 'pdf'))
     else:
         raise ValueError("supported formats are: 'png', 'retina', 'svg', not %r" % fmt)
 

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -282,6 +282,9 @@ var IPython = (function (IPython) {
         if (data['application/javascript'] !== undefined) {
             json.javascript = data['application/javascript'];
         }
+        if (data['application/pdf'] !== undefined) {
+            json.pdf = data['application/pdf'];
+        }
         return json;
     };
 
@@ -403,7 +406,7 @@ var IPython = (function (IPython) {
         }
     };
 
-    OutputArea.display_order = ['javascript','html','latex','svg','png','jpeg','text'];
+    OutputArea.display_order = ['javascript','html','latex','svg','png','jpeg','pdf','text'];
 
     OutputArea.prototype.append_mime_type = function (json, element, dynamic) {
         for(var type_i in OutputArea.display_order){
@@ -419,6 +422,10 @@ var IPython = (function (IPython) {
                     }
                 } else {
                     this['append_'+type](json[type], md, element);
+                }
+                if(((type == 'png') || (type == 'svg') || (type == 'jpeg')) &&
+                    json['pdf'] != undefined){
+                    this.append_pdf(json['pdf'], md, element, type);
                 }
                 return;
             }
@@ -532,6 +539,12 @@ var IPython = (function (IPython) {
         this._dblclick_to_reset_size(img);
         toinsert.append(img);
         element.append(toinsert);
+    };
+
+
+    OutputArea.prototype.append_pdf = function (pdf, md, element, type) {
+        var link = $("<a/>").attr('download', '').attr('href','data:application/pdf;base64,'+pdf);
+        element.find('img').wrap(link);
     };
 
 

--- a/IPython/utils/jsonutil.py
+++ b/IPython/utils/jsonutil.py
@@ -106,6 +106,8 @@ PNG64 = b'iVBORw0KG'
 JPEG = b'\xff\xd8'
 # front of JPEG base64-encoded
 JPEG64 = b'/9'
+# front of PDF base64-encoded
+PDF64 = b'JVBER'
 
 def encode_images(format_dict):
     """b64-encodes images in a displaypub format dict
@@ -142,6 +144,13 @@ def encode_images(format_dict):
         if not jpegdata.startswith(JPEG64):
             jpegdata = encodebytes(jpegdata)
         encoded['image/jpeg'] = jpegdata.decode('ascii')
+
+    pdfdata = format_dict.get('application/pdf')
+    if isinstance(pdfdata, bytes):
+        # make sure we don't double-encode
+        if not pdfdata.startswith(PDF64):
+            pdfdata = encodebytes(pdfdata)
+        encoded['application/pdf'] = pdfdata.decode('ascii')
 
     return encoded
 


### PR DESCRIPTION
I've implemented a feature that I've wanted for a while.  When a figure is displayed, the img is a link to a PDF version of the figure.  This follows the convention for webpages in my collaboration, where a figure should be displayed on the webpage as a raster, but a vector (eps or pdf) needs to be available for people to use in LaTeX.

To do this, I made four changes.  First, I added a PDFFormatter class to formatters.py, and registered it as a formatter.  Then, I changed pylabtools.py to always generate PDF output, whether `figure_format` is "png", "svg", or "retina".  I think this part still needs some work, as it is currently not configurable.  Then, I made jsonutil.py detect and encode PDF data in base64.  Finally, I added the necessary javascript to outputarea.js to wrap the anchor tag around the img tag.

I have not tested how this interacts with nbconvert, because my system does not have Haskell available.  I have to convince the sysadmins that I really need it before I can try to set up pandoc.  So I may need some assistance in that regard.

I also made these changes against the tip of the 1.x branch, rather than against the tip of master.  My apologies; I did the work before reading CONTRIBUTING.md.  I'm happy to attempt to forward-port the changes to master if need be, but I intend to continue using 1.x for the foreseeable future.

I hope that this new feature is helpful and can eventually make it into ipython.
Best regards,
Jon
