### PR TITLE
Restore autorestore option for storemagic

### DIFF
--- a/IPython/extensions/tests/test_storemagic.py
+++ b/IPython/extensions/tests/test_storemagic.py
@@ -1,5 +1,6 @@
 import tempfile, os
 
+from IPython.config.loader import Config
 import nose.tools as nt
 
 ip = get_ipython()
@@ -30,3 +31,20 @@ def test_store_restore():
     nt.assert_in(os.path.realpath(tmpd), ip.user_ns['_dh'])
     
     os.rmdir(tmpd)
+
+def test_autorestore():
+    ip.user_ns['foo'] = 95
+    ip.magic('store foo')
+    del ip.user_ns['foo']
+    c = Config()
+    c.StoreMagics.autorestore = False
+    orig_config = ip.config
+    try:
+        ip.config = c
+        ip.extension_manager.reload_extension('storemagic')
+        nt.assert_not_in('foo', ip.user_ns)
+        c.StoreMagics.autorestore = True
+        ip.extension_manager.reload_extension('storemagic')
+        nt.assert_equal(ip.user_ns['foo'], 95)
+    finally:
+        ip.config = orig_config

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -47,6 +47,7 @@ from IPython.core.magics import ScriptMagics
 from IPython.core.shellapp import (
     InteractiveShellApp, shell_flags, shell_aliases
 )
+from IPython.extensions.storemagic import StoreMagics
 from IPython.terminal.interactiveshell import TerminalInteractiveShell
 from IPython.utils import warn
 from IPython.utils.path import get_ipython_dir, check_for_old_config
@@ -219,6 +220,7 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
             PlainTextFormatter,
             IPCompleter,
             ScriptMagics,
+            StoreMagics,
         ]
 
     subcommands = Dict(dict(


### PR DESCRIPTION
It is now StoreMagics.autorestore rather than StoreMagic.autorestore (note the extra s).

Closes #4078
