### PR TITLE
Fixes to support parametric tests

### DIFF
--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -37,6 +37,10 @@ import tempfile
 import time
 import warnings
 
+# Monkeypatch for nose, see nose issue 728:
+# https://github.com/nose-devs/nose/issues/728
+from . import nosepatch2  # analysis:ignore (activated by import)
+
 # Now, proceed to import nose itself
 import nose.plugins.builtin
 from nose.plugins.xunit import Xunit

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -39,7 +39,7 @@ import warnings
 
 # Monkeypatch for nose, see nose issue 728:
 # https://github.com/nose-devs/nose/issues/728
-from . import nosepatch2  # analysis:ignore (activated by import)
+from IPython.testing import nosepatch2  # analysis:ignore (activated by import)
 
 # Now, proceed to import nose itself
 import nose.plugins.builtin

--- a/IPython/testing/nosepatch2.py
+++ b/IPython/testing/nosepatch2.py
@@ -1,0 +1,23 @@
+from nose.plugins.attrib import AttributeSelector
+
+# Workaround for nose issue #728, to allow our parametric tests to run
+# in Python 2.
+# https://github.com/nose-devs/nose/issues/728
+# This is required with nose 1.3.0, the current version at the time of
+# writing.
+
+# This patch precludes setting nose attributes on a @staticmethod test. We
+# don't currently use nose attributes, but a more sophisticated solution
+# can be devised if we decide to.
+
+def wantMethod(self, method):
+    """Accept the method if its attributes match.
+    """
+    try:
+        cls = method.im_class
+    except AttributeError:
+        # Monkeypatch: return None instead of False
+        return None
+    return self.validateAttrib(method, cls)
+
+AttributeSelector.wantMethod = wantMethod


### PR DESCRIPTION
Our parametric tests weren't running on either Python 2 or 3, for different reasons. This fixes both issues, so some test failures may appear as we exercise code that hasn't been tested recently.

For Python 2, this works around nose-devs/nose#728, which I just filed. On Python 3, I think the parametric testing machinery has always been broken. The fix is horrendously ugly, but seems to do the trick.

I am about to propose getting rid of our parametric test system, as it has failed too often and too quietly.
