### PR TITLE
Refactor alias machinery

### DIFF
--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -150,7 +150,6 @@ class AliasManager(Configurable):
 
     def __init__(self, shell=None, **kwargs):
         super(AliasManager, self).__init__(shell=shell, **kwargs)
-        self.alias_table = {}
         self.init_exclusions()
         self.init_aliases()
 
@@ -211,6 +210,14 @@ class AliasManager(Configurable):
         if name in self.no_alias:
             raise InvalidAliasError("The name %s can't be aliased "
                                     "because it is a keyword or builtin." % name)
+        try:
+            caller = self.shell.magics_manager.magics['line'][name]
+        except KeyError:
+            pass
+        else:
+            if not isinstance(caller, AliasCaller):
+                raise InvalidAliasError("The name %s can't be aliased "
+                                        "because it is another magic command." % name)
         if not (isinstance(cmd, basestring)):
             raise InvalidAliasError("An alias command must be a string, "
                                     "got: %r" % cmd)
@@ -223,3 +230,8 @@ class AliasManager(Configurable):
             return caller.cmd
         else:
             raise ValueError('%s is not an alias' % name)
+    
+    def is_alias(self, name):
+        """Return whether or not a given name has been defined as an alias"""
+        caller = self.shell.magics_manager.magics['line'].get(name, None)
+        return isinstance(caller, AliasCaller)

--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -210,6 +210,14 @@ class AliasManager(Configurable):
             raise InvalidAliasError("An alias command must be a string, "
                                     "got: %r" % cmd)
         return True
+    
+    def retrieve_alias(self, name):
+        """Retrieve the command to which an alias expands."""
+        caller = self.shell.magics_manager.magics['line'].get(name, None)
+        if isinstance(caller, AliasCaller):
+            return caller.cmd
+        else:
+            raise ValueError('%s is not an alias' % name)
 
     def call_alias(self, alias, rest=''):
         """Call an alias given its name and the rest of the line."""

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -431,8 +431,7 @@ class IPCompleter(Completer):
     )
 
     def __init__(self, shell=None, namespace=None, global_namespace=None,
-                 alias_table=None, use_readline=True,
-                 config=None, **kwargs):
+                 use_readline=True, config=None, **kwargs):
         """IPCompleter() -> completer
 
         Return a completer object suitable for use by the readline library
@@ -449,9 +448,6 @@ class IPCompleter(Completer):
         - global_namespace: secondary optional dict for completions, to
           handle cases (such as IPython embedded inside functions) where
           both Python scopes are visible.
-
-        - If alias_table is supplied, it should be a dictionary of aliases
-          to complete.
 
         use_readline : bool, optional
           If true, use the readline library.  This completer can still function
@@ -476,9 +472,6 @@ class IPCompleter(Completer):
         # List where completion matches will be stored
         self.matches = []
         self.shell = shell
-        if alias_table is None:
-            alias_table = {}
-        self.alias_table = alias_table
         # Regexp to split filenames with spaces in them
         self.space_name_re = re.compile(r'([^\\] )')
         # Hold a local ref. to glob.glob for speed
@@ -505,7 +498,6 @@ class IPCompleter(Completer):
         self.matchers = [self.python_matches,
                          self.file_matches,
                          self.magic_matches,
-                         self.alias_matches,
                          self.python_func_kw_matches,
                          ]
 
@@ -627,22 +619,6 @@ class IPCompleter(Completer):
         if not text.startswith(pre2):
             comp += [ pre+m for m in line_magics if m.startswith(bare_text)]
         return comp
-
-    def alias_matches(self, text):
-        """Match internal system aliases"""
-        #print 'Completer->alias_matches:',text,'lb',self.text_until_cursor # dbg
-
-        # if we are not in the first 'item', alias matching
-        # doesn't make sense - unless we are starting with 'sudo' command.
-        main_text = self.text_until_cursor.lstrip()
-        if ' ' in main_text and not main_text.startswith('sudo'):
-            return []
-        text = os.path.expanduser(text)
-        aliases =  self.alias_table.keys()
-        if text == '':
-            return aliases
-        else:
-            return [a for a in aliases if a.startswith(text)]
 
     def python_matches(self,text):
         """Match attributes or global python names"""

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1936,7 +1936,6 @@ class InteractiveShell(SingletonConfigurable):
         self.Completer = IPCompleter(shell=self,
                                      namespace=self.user_ns,
                                      global_namespace=self.user_global_ns,
-                                     #alias_table=self.alias_manager.alias_table,
                                      use_readline=self.has_readline,
                                      parent=self,
                                      )

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1363,9 +1363,7 @@ class InteractiveShell(SingletonConfigurable):
             namespaces = [ ('Interactive', self.user_ns),
                            ('Interactive (global)', self.user_global_ns),
                            ('Python builtin', builtin_mod.__dict__),
-                           ('Alias', self.alias_manager.alias_table),
                            ]
-            alias_ns = self.alias_manager.alias_table
 
         # initialize results to 'null'
         found = False; obj = None;  ospace = None;  ds = None;
@@ -1404,8 +1402,6 @@ class InteractiveShell(SingletonConfigurable):
                     # If we finish the for loop (no break), we got all members
                     found = True
                     ospace = nsname
-                    if ns == alias_ns:
-                        isalias = True
                     break  # namespace loop
 
         # Try to see if it's magic
@@ -2305,7 +2301,6 @@ class InteractiveShell(SingletonConfigurable):
     def init_alias(self):
         self.alias_manager = AliasManager(shell=self, parent=self)
         self.configurables.append(self.alias_manager)
-        self.ns_table['alias'] = self.alias_manager.alias_table,
 
     #-------------------------------------------------------------------------
     # Things related to extensions

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -470,7 +470,6 @@ class InteractiveShell(SingletonConfigurable):
         # because it and init_io have to come after init_readline.
         self.init_user_ns()
         self.init_logger()
-        self.init_alias()
         self.init_builtins()
 
         # The following was in post_config_initialization
@@ -502,6 +501,7 @@ class InteractiveShell(SingletonConfigurable):
         self.init_displayhook()
         self.init_latextool()
         self.init_magics()
+        self.init_alias()
         self.init_logstart()
         self.init_pdb()
         self.init_extension_manager()
@@ -1940,7 +1940,7 @@ class InteractiveShell(SingletonConfigurable):
         self.Completer = IPCompleter(shell=self,
                                      namespace=self.user_ns,
                                      global_namespace=self.user_global_ns,
-                                     alias_table=self.alias_manager.alias_table,
+                                     #alias_table=self.alias_manager.alias_table,
                                      use_readline=self.has_readline,
                                      parent=self,
                                      )

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -192,7 +192,7 @@ class OSMagics(Magics):
                             try:
                                 # Removes dots from the name since ipython
                                 # will assume names with dots to be python.
-                                if ff not in self.shell.alias_manager:
+                                if not self.shell.alias_manager.is_alias(ff):
                                     self.shell.alias_manager.define_alias(
                                         ff.replace('.',''), ff)
                             except InvalidAliasError:

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -26,7 +26,7 @@ from pprint import pformat
 from IPython.core import magic_arguments
 from IPython.core import oinspect
 from IPython.core import page
-from IPython.core.alias import AliasError
+from IPython.core.alias import AliasError, Alias
 from IPython.core.error import UsageError
 from IPython.core.magic import  (
     Magics, compress_dhist, magics_class, line_magic, cell_magic, line_cell_magic
@@ -200,7 +200,7 @@ class OSMagics(Magics):
                             else:
                                 syscmdlist.append(ff)
             else:
-                no_alias = self.shell.alias_manager.no_alias
+                no_alias = Alias.blacklist
                 for pdir in path:
                     os.chdir(pdir)
                     for ff in os.listdir(pdir):

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -26,6 +26,7 @@ from pprint import pformat
 from IPython.core import magic_arguments
 from IPython.core import oinspect
 from IPython.core import page
+from IPython.core.alias import AliasError
 from IPython.core.error import UsageError
 from IPython.core.magic import  (
     Magics, compress_dhist, magics_class, line_magic, cell_magic, line_cell_magic
@@ -113,10 +114,14 @@ class OSMagics(Magics):
         # Now try to define a new one
         try:
             alias,cmd = par.split(None, 1)
-        except:
-            print oinspect.getdoc(self.alias)
-        else:
-            self.shell.alias_manager.soft_define_alias(alias, cmd)
+        except TypeError:
+            print(oinspect.getdoc(self.alias))
+            return
+        
+        try:
+            self.shell.alias_manager.define_alias(alias, cmd)
+        except AliasError as e:
+            print(e)
     # end magic_alias
 
     @line_magic
@@ -124,7 +129,12 @@ class OSMagics(Magics):
         """Remove an alias"""
 
         aname = parameter_s.strip()
-        self.shell.alias_manager.undefine_alias(aname)
+        try:
+            self.shell.alias_manager.undefine_alias(aname)
+        except ValueError as e:
+            print(e)
+            return
+        
         stored = self.shell.db.get('stored_aliases', {} )
         if aname in stored:
             print "Removing %stored alias",aname

--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -700,14 +700,12 @@ _default_checkers = [
     IPyAutocallChecker,
     AssignmentChecker,
     AutoMagicChecker,
-    AliasChecker,
     PythonOpsChecker,
     AutocallChecker
 ]
 
 _default_handlers = [
     PrefilterHandler,
-    AliasHandler,
     MacroHandler,
     MagicHandler,
     AutoHandler,

--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -488,22 +488,6 @@ class AutoMagicChecker(PrefilterChecker):
         return self.prefilter_manager.get_handler_by_name('magic')
 
 
-class AliasChecker(PrefilterChecker):
-
-    priority = Integer(800, config=True)
-
-    def check(self, line_info):
-        "Check if the initital identifier on the line is an alias."
-        # Note: aliases can not contain '.'
-        head = line_info.ifun.split('.',1)[0]
-        if line_info.ifun not in self.shell.alias_manager \
-               or head not in self.shell.alias_manager \
-               or is_shadowed(head, self.shell):
-            return None
-
-        return self.prefilter_manager.get_handler_by_name('alias')
-
-
 class PythonOpsChecker(PrefilterChecker):
 
     priority = Integer(900, config=True)
@@ -589,20 +573,6 @@ class PrefilterHandler(Configurable):
 
     def __str__(self):
         return "<%s(name=%s)>" % (self.__class__.__name__, self.handler_name)
-
-
-class AliasHandler(PrefilterHandler):
-
-    handler_name = Unicode('alias')
-
-    def handle(self, line_info):
-        """Handle alias input lines. """
-        transformed = self.shell.alias_manager.expand_aliases(line_info.ifun,line_info.the_rest)
-        # pre is needed, because it carries the leading whitespace.  Otherwise
-        # aliases won't work in indented sections.
-        line_out = '%sget_ipython().system(%r)' % (line_info.pre_whitespace, transformed)
-
-        return line_out
 
 
 class MacroHandler(PrefilterHandler):

--- a/IPython/core/tests/test_alias.py
+++ b/IPython/core/tests/test_alias.py
@@ -1,0 +1,41 @@
+from IPython.utils.capture import capture_output
+
+import nose.tools as nt
+
+def test_alias_lifecycle():
+    name = 'test_alias1'
+    cmd = 'echo "Hello"'
+    am = _ip.alias_manager
+    am.clear_aliases()
+    am.define_alias(name, cmd)
+    assert am.is_alias(name)
+    nt.assert_equal(am.retrieve_alias(name), cmd)
+    nt.assert_in((name, cmd), am.aliases)
+    
+    # Test running the alias
+    orig_system = _ip.system
+    result = []
+    _ip.system = result.append
+    try:
+        _ip.run_cell('%{}'.format(name))
+        result = [c.strip() for c in result]
+        nt.assert_equal(result, [cmd])
+    finally:
+        _ip.system = orig_system
+    
+    # Test removing the alias
+    am.undefine_alias(name)
+    assert not am.is_alias(name)
+    with nt.assert_raises(ValueError):
+        am.retrieve_alias(name)
+    nt.assert_not_in((name, cmd), am.aliases)
+    
+
+def test_alias_args_error():
+    """Error expanding with wrong number of arguments"""
+    _ip.alias_manager.define_alias('parts', 'echo first %s second %s')
+    # capture stderr:
+    with capture_output() as cap:
+        _ip.run_cell('parts 1')
+
+    nt.assert_equal(cap.stderr.split(':')[0], 'UsageError')

--- a/IPython/core/tests/test_handlers.py
+++ b/IPython/core/tests/test_handlers.py
@@ -45,28 +45,6 @@ def run(tests):
 
 
 def test_handlers():
-    # alias expansion
-
-    # We're using 'true' as our syscall of choice because it doesn't
-    # write anything to stdout.
-
-    # Turn off actual execution of aliases, because it's noisy
-    old_system_cmd = ip.system
-    ip.system = lambda cmd: None
-
-
-    ip.alias_manager.alias_table['an_alias'] = (0, 'true')
-    # These are useful for checking a particular recursive alias issue
-    ip.alias_manager.alias_table['top'] = (0, 'd:/cygwin/top')
-    ip.alias_manager.alias_table['d'] =   (0, 'true')
-    run([(i,py3compat.u_format(o)) for i,o in \
-        [("an_alias",    "get_ipython().system({u}'true ')"),     # alias
-         # Below: recursive aliases should expand whitespace-surrounded
-         # chars, *not* initial chars which happen to be aliases:
-         ("top",         "get_ipython().system({u}'d:/cygwin/top ')"),
-         ]])
-    ip.system = old_system_cmd
-
     call_idx = CallableIndexable()
     ip.user_ns['call_idx'] = call_idx
 

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -106,17 +106,6 @@ class InteractiveShellTestCase(unittest.TestCase):
         ip.run_cell('a = """\n%exit\n"""')
         self.assertEqual(ip.user_ns['a'], '\n%exit\n')
     
-    def test_alias_crash(self):
-        """Errors in prefilter can't crash IPython"""
-        ip.run_cell('%alias parts echo first %s second %s')
-        # capture stderr:
-        save_err = io.stderr
-        io.stderr = StringIO()
-        ip.run_cell('parts 1')
-        err = io.stderr.getvalue()
-        io.stderr = save_err
-        self.assertEqual(err.split(':')[0], 'ERROR')
-    
     def test_trailing_newline(self):
         """test that running !(command) does not raise a SyntaxError"""
         ip.run_cell('!(true)\n', False)

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -48,16 +48,16 @@ class DummyMagics(magic.Magics): pass
 def test_rehashx():
     # clear up everything
     _ip = get_ipython()
-    _ip.alias_manager.alias_table.clear()
+    _ip.alias_manager.clear_aliases()
     del _ip.db['syscmdlist']
     
     _ip.magic('rehashx')
     # Practically ALL ipython development systems will have more than 10 aliases
 
-    nt.assert_true(len(_ip.alias_manager.alias_table) > 10)
-    for key, val in _ip.alias_manager.alias_table.iteritems():
+    nt.assert_true(len(_ip.alias_manager.aliases) > 10)
+    for name, cmd in _ip.alias_manager.aliases:
         # we must strip dots from alias names
-        nt.assert_not_in('.', key)
+        nt.assert_not_in('.', name)
 
     # rehashx must fill up syscmdlist
     scoms = _ip.db['syscmdlist']

--- a/IPython/extensions/storemagic.py
+++ b/IPython/extensions/storemagic.py
@@ -211,16 +211,17 @@ class StoreMagics(Magics, Configurable):
             except KeyError:
                 # it might be an alias
                 # This needs to be refactored to use the new AliasManager stuff.
-                if args[0] in ip.alias_manager:
-                    name = args[0]
-                    nargs, cmd = ip.alias_manager.alias_table[ name ]
-                    staliases = db.get('stored_aliases',{})
-                    staliases[ name ] = cmd
-                    db['stored_aliases'] = staliases
-                    print "Alias stored: %s (%s)" % (name, cmd)
-                    return
-                else:
-                    raise UsageError("Unknown variable '%s'" % args[0])
+                name = args[0]
+                try:
+                    cmd = ip.alias_manager.retrieve_alias(name)
+                except ValueError:
+                    raise UsageError("Unknown variable '%s'" % name)
+                
+                staliases = db.get('stored_aliases',{})
+                staliases[name] = cmd
+                db['stored_aliases'] = staliases
+                print "Alias stored: %s (%s)" % (name, cmd)
+                return
 
             else:
                 modname = getattr(inspect.getmodule(obj), '__name__', '')

--- a/IPython/extensions/storemagic.py
+++ b/IPython/extensions/storemagic.py
@@ -210,7 +210,6 @@ class StoreMagics(Magics, Configurable):
                 obj = ip.user_ns[args[0]]
             except KeyError:
                 # it might be an alias
-                # This needs to be refactored to use the new AliasManager stuff.
                 name = args[0]
                 try:
                     cmd = ip.alias_manager.retrieve_alias(name)

--- a/IPython/extensions/tests/test_storemagic.py
+++ b/IPython/extensions/tests/test_storemagic.py
@@ -27,7 +27,7 @@ def test_store_restore():
     # Check restoring
     ip.magic('store -r')
     nt.assert_equal(ip.user_ns['foo'], 78)
-    nt.assert_in('bar', ip.alias_manager.alias_table)
+    assert ip.alias_manager.is_alias('bar')
     nt.assert_in(os.path.realpath(tmpd), ip.user_ns['_dh'])
     
     os.rmdir(tmpd)

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -369,7 +369,7 @@ class TerminalInteractiveShell(InteractiveShell):
 
 
         for name, cmd in aliases:
-            self.alias_manager.define_alias(name, cmd)
+            self.alias_manager.soft_define_alias(name, cmd)
 
     #-------------------------------------------------------------------------
     # Things related to the banner and usage

--- a/docs/source/whatsnew/pr/incompat-drop-alias.rst
+++ b/docs/source/whatsnew/pr/incompat-drop-alias.rst
@@ -1,0 +1,3 @@
+- The alias system has been reimplemented to use magic functions. There should be little
+  visible difference while automagics are enabled, as they are by default, but parts of the
+  :class:`~IPython.core.alias.AliasManager` API have been removed.


### PR DESCRIPTION
This refactors the alias machinery to use magic commands instead of a separate namespace, as per the roadmap. So long as the user has automagics enabled (which is the default), they won't see much difference: aliases will continue to work much as they did before.

One minor difference is that the old implementation supported nested aliases (i.e. one alias could point to another, which described an actual system command). I don't know if that was ever used much - none of the default aliases appear to rely on it. If we decide it's important, we could probably add it back in, but it would be a bit of extra complexity.
