### PR TITLE
Center LaTeX and figures in markdown

### DIFF
--- a/IPython/html/static/auth/less/style.less
+++ b/IPython/html/static/auth/less/style.less
@@ -1,2 +1,2 @@
-@import "../auth/less/login.less";
-@import "../auth/less/logout.less";
+@import "login.less";
+@import "logout.less";

--- a/IPython/html/static/base/less/style.less
+++ b/IPython/html/static/base/less/style.less
@@ -1,5 +1,4 @@
 @import "variables.less";
 @import "mixins.less";
 @import "flexbox.less";
-@import "page.less";
 

--- a/IPython/html/static/base/less/style.less
+++ b/IPython/html/static/base/less/style.less
@@ -1,4 +1,5 @@
-@import "../base/less/variables.less";
-@import "../base/less/mixins.less";
-@import "../base/less/flexbox.less";
+@import "variables.less";
+@import "mixins.less";
+@import "flexbox.less";
+@import "page.less";
 

--- a/IPython/html/static/notebook/js/mathjaxutils.js
+++ b/IPython/html/static/notebook/js/mathjaxutils.js
@@ -25,7 +25,7 @@ IPython.mathjaxutils = (function (IPython) {
                     processEscapes: true,
                     processEnvironments: true
                 },
-                displayAlign: 'left', // Change this to 'center' to center equations.
+                displayAlign: 'center', // Change this to 'center' to center equations.
                 "HTML-CSS": {
                     styles: {'.MathJax_Display': {"margin": 0}}
                 }

--- a/IPython/html/static/notebook/js/mathjaxutils.js
+++ b/IPython/html/static/notebook/js/mathjaxutils.js
@@ -25,7 +25,9 @@ IPython.mathjaxutils = (function (IPython) {
                     processEscapes: true,
                     processEnvironments: true
                 },
-                displayAlign: 'center', // Change this to 'center' to center equations.
+                // Center justify equations in code and markdown cells. Elsewhere
+                // we use CSS to left justify single line equations in code cells.
+                displayAlign: 'center',
                 "HTML-CSS": {
                     styles: {'.MathJax_Display': {"margin": 0}}
                 }

--- a/IPython/html/static/notebook/less/outputarea.less
+++ b/IPython/html/static/notebook/less/outputarea.less
@@ -3,6 +3,25 @@ div.output_area {
     padding: 0px;
     page-break-inside: avoid;
     .hbox();
+
+    .MathJax_Display {
+        // Inside a CodeCell, elements are left justified
+        text-align: left !important;
+    }
+
+    .rendered_html {
+        // Inside a CodeCell, elements are left justified
+        table {
+            // Center tables horizontally
+            margin-left: 0;
+            margin-right: 0;
+        }
+    
+        img {
+            margin-left: 0;
+            margin-right: 0;
+        }
+    }
 }
 
 

--- a/IPython/html/static/notebook/less/outputarea.less
+++ b/IPython/html/static/notebook/less/outputarea.less
@@ -12,7 +12,6 @@ div.output_area {
     .rendered_html {
         // Inside a CodeCell, elements are left justified
         table {
-            // Center tables horizontally
             margin-left: 0;
             margin-right: 0;
         }

--- a/IPython/html/static/notebook/less/renderedhtml.less
+++ b/IPython/html/static/notebook/less/renderedhtml.less
@@ -1,4 +1,4 @@
-.rendered_html{
+.rendered_html {
 
     color: black;
     em {font-style: italic;}
@@ -71,26 +71,22 @@
         text-align: justify;
     }
 
-    p + p {
-        margin-top: 1em;
-    }
-
-    p + table {
-        margin-top: 1em;
-    }
-
-    table + p {
-        margin-top: 1em;
-    }
-
     img {
         display: block;
         margin-left: auto;
         margin-right: auto;
     }
 
-    .MathJax_Display {
-        text-align: center !important;
+    * + p {
+        margin-top: 1em;
+    }
+
+    * + table {
+        margin-top: 1em;
+    }
+    
+    * + img {
+        margin-top: 1em;
     }
 
 }

--- a/IPython/html/static/notebook/less/renderedhtml.less
+++ b/IPython/html/static/notebook/less/renderedhtml.less
@@ -43,7 +43,15 @@
         margin: 1em 2em;
     }
 
-    table, tr, th, td {
+    table {
+        // Center tables horizontally
+        margin-left: auto;
+        margin-right: auto;
+        border: 1px solid black;
+        border-collapse: collapse;
+    }
+
+    tr, th, td {
         border: 1px solid black;
         border-collapse: collapse;
         margin: 1em 2em;
@@ -66,9 +74,16 @@
     p + p {
         margin-top: 1em;
     }
-    
+
+    img {
+        display: block;
+        margin-left: auto;
+        margin-right: auto;
+    }
+
     .MathJax_Display {
-        margin-left: 12ex;
+        text-align: center !important;
+        // margin-left: 12ex;
     }
 
 }

--- a/IPython/html/static/notebook/less/renderedhtml.less
+++ b/IPython/html/static/notebook/less/renderedhtml.less
@@ -91,7 +91,6 @@
 
     .MathJax_Display {
         text-align: center !important;
-        // margin-left: 12ex;
     }
 
 }

--- a/IPython/html/static/notebook/less/renderedhtml.less
+++ b/IPython/html/static/notebook/less/renderedhtml.less
@@ -75,6 +75,14 @@
         margin-top: 1em;
     }
 
+    p + table {
+        margin-top: 1em;
+    }
+
+    table + p {
+        margin-top: 1em;
+    }
+
     img {
         display: block;
         margin-left: auto;

--- a/IPython/html/static/notebook/less/renderedhtml.less
+++ b/IPython/html/static/notebook/less/renderedhtml.less
@@ -66,4 +66,9 @@
     p + p {
         margin-top: 1em;
     }
+    
+    .MathJax_Display {
+        margin-left: 12ex;
+    }
+
 }

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -176,6 +176,8 @@ div.quickhelp{float:left;width:50%;}
 .rendered_html th{font-weight:bold;}
 .rendered_html p{text-align:justify;}
 .rendered_html p+p{margin-top:1em;}
+.rendered_html p+table{margin-top:1em;}
+.rendered_html table+p{margin-top:1em;}
 .rendered_html img{display:block;margin-left:auto;margin-right:auto;}
 .rendered_html .MathJax_Display{text-align:center !important;}
 span#save_widget{padding:0px 5px;margin-top:12px;}

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -129,7 +129,9 @@ p{margin-bottom:0;}
 .end_space{height:200px;}
 #notification_area{z-index:10;}
 .notification_widget{color:#777777;padding:1px 12px;margin:2px 4px;z-index:10;border:1px solid #ccc;border-radius:4px;background:rgba(240, 240, 240, 0.5);}
-div.output_area{padding:0px;page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;}
+div.output_area{padding:0px;page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;}div.output_area .MathJax_Display{text-align:left !important;}
+div.output_area .rendered_html table{margin-left:0;margin-right:0;}
+div.output_area .rendered_html img{margin-left:0;margin-right:0;}
 div.output_area pre{font-family:monospace;margin:0;padding:0;border:0;font-size:100%;vertical-align:baseline;color:black;background-color:transparent;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0;line-height:inherit;}
 div.output_subarea{padding:0.44em 0.4em 0.4em 1px;margin-left:6px;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;}
 div.output_text{text-align:left;color:#000000;font-family:monospace;line-height:1.231em;}
@@ -175,11 +177,10 @@ div.quickhelp{float:left;width:50%;}
 .rendered_html td,.rendered_html th{text-align:left;vertical-align:middle;padding:4px;}
 .rendered_html th{font-weight:bold;}
 .rendered_html p{text-align:justify;}
-.rendered_html p+p{margin-top:1em;}
-.rendered_html p+table{margin-top:1em;}
-.rendered_html table+p{margin-top:1em;}
 .rendered_html img{display:block;margin-left:auto;margin-right:auto;}
-.rendered_html .MathJax_Display{text-align:center !important;}
+.rendered_html *+p{margin-top:1em;}
+.rendered_html *+table{margin-top:1em;}
+.rendered_html *+img{margin-top:1em;}
 span#save_widget{padding:0px 5px;margin-top:12px;}
 span#checkpoint_status,span#autosave_status{font-size:small;}
 @media (max-width:767px){span#save_widget{font-size:small;} span#checkpoint_status,span#autosave_status{font-size:x-small;}}@media (max-width:767px){span#checkpoint_status,span#autosave_status{display:none;}}@media (min-width:768px) and (max-width:979px){span#checkpoint_status{display:none;} span#autosave_status{font-size:x-small;}}div.text_cell{padding:5px 5px 5px 5px;}

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -175,6 +175,7 @@ div.quickhelp{float:left;width:50%;}
 .rendered_html th{font-weight:bold;}
 .rendered_html p{text-align:justify;}
 .rendered_html p+p{margin-top:1em;}
+.rendered_html .MathJax_Display{margin-left:12ex;}
 span#save_widget{padding:0px 5px;margin-top:12px;}
 span#checkpoint_status,span#autosave_status{font-size:small;}
 @media (max-width:767px){span#save_widget{font-size:small;} span#checkpoint_status,span#autosave_status{font-size:x-small;}}@media (max-width:767px){span#checkpoint_status,span#autosave_status{display:none;}}@media (min-width:768px) and (max-width:979px){span#checkpoint_status{display:none;} span#autosave_status{font-size:x-small;}}div.text_cell{padding:5px 5px 5px 5px;}

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -170,12 +170,14 @@ div.quickhelp{float:left;width:50%;}
 .rendered_html pre{margin:1em 2em;}
 .rendered_html pre,.rendered_html code{border:0;background-color:#ffffff;color:#000000;font-size:100%;padding:0px;}
 .rendered_html blockquote{margin:1em 2em;}
-.rendered_html table,.rendered_html tr,.rendered_html th,.rendered_html td{border:1px solid black;border-collapse:collapse;margin:1em 2em;}
+.rendered_html table{margin-left:auto;margin-right:auto;border:1px solid black;border-collapse:collapse;}
+.rendered_html tr,.rendered_html th,.rendered_html td{border:1px solid black;border-collapse:collapse;margin:1em 2em;}
 .rendered_html td,.rendered_html th{text-align:left;vertical-align:middle;padding:4px;}
 .rendered_html th{font-weight:bold;}
 .rendered_html p{text-align:justify;}
 .rendered_html p+p{margin-top:1em;}
-.rendered_html .MathJax_Display{margin-left:12ex;}
+.rendered_html img{display:block;margin-left:auto;margin-right:auto;}
+.rendered_html .MathJax_Display{text-align:center !important;}
 span#save_widget{padding:0px 5px;margin-top:12px;}
 span#checkpoint_status,span#autosave_status{font-size:small;}
 @media (max-width:767px){span#save_widget{font-size:small;} span#checkpoint_status,span#autosave_status{font-size:x-small;}}@media (max-width:767px){span#checkpoint_status,span#autosave_status{display:none;}}@media (min-width:768px) and (max-width:979px){span#checkpoint_status{display:none;} span#autosave_status{font-size:x-small;}}div.text_cell{padding:5px 5px 5px 5px;}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1510,7 +1510,9 @@ p{margin-bottom:0;}
 .end_space{height:200px;}
 #notification_area{z-index:10;}
 .notification_widget{color:#777777;padding:1px 12px;margin:2px 4px;z-index:10;border:1px solid #ccc;border-radius:4px;background:rgba(240, 240, 240, 0.5);}
-div.output_area{padding:0px;page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;}
+div.output_area{padding:0px;page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;}div.output_area .MathJax_Display{text-align:left !important;}
+div.output_area .rendered_html table{margin-left:0;margin-right:0;}
+div.output_area .rendered_html img{margin-left:0;margin-right:0;}
 div.output_area pre{font-family:monospace;margin:0;padding:0;border:0;font-size:100%;vertical-align:baseline;color:black;background-color:transparent;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0;line-height:inherit;}
 div.output_subarea{padding:0.44em 0.4em 0.4em 1px;margin-left:6px;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;}
 div.output_text{text-align:left;color:#000000;font-family:monospace;line-height:1.231em;}
@@ -1556,11 +1558,10 @@ div.quickhelp{float:left;width:50%;}
 .rendered_html td,.rendered_html th{text-align:left;vertical-align:middle;padding:4px;}
 .rendered_html th{font-weight:bold;}
 .rendered_html p{text-align:justify;}
-.rendered_html p+p{margin-top:1em;}
-.rendered_html p+table{margin-top:1em;}
-.rendered_html table+p{margin-top:1em;}
 .rendered_html img{display:block;margin-left:auto;margin-right:auto;}
-.rendered_html .MathJax_Display{text-align:center !important;}
+.rendered_html *+p{margin-top:1em;}
+.rendered_html *+table{margin-top:1em;}
+.rendered_html *+img{margin-top:1em;}
 span#save_widget{padding:0px 5px;margin-top:12px;}
 span#checkpoint_status,span#autosave_status{font-size:small;}
 @media (max-width:767px){span#save_widget{font-size:small;} span#checkpoint_status,span#autosave_status{font-size:x-small;}}@media (max-width:767px){span#checkpoint_status,span#autosave_status{display:none;}}@media (min-width:768px) and (max-width:979px){span#checkpoint_status{display:none;} span#autosave_status{font-size:x-small;}}div.text_cell{padding:5px 5px 5px 5px;}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1556,6 +1556,7 @@ div.quickhelp{float:left;width:50%;}
 .rendered_html th{font-weight:bold;}
 .rendered_html p{text-align:justify;}
 .rendered_html p+p{margin-top:1em;}
+.rendered_html .MathJax_Display{margin-left:12ex;}
 span#save_widget{padding:0px 5px;margin-top:12px;}
 span#checkpoint_status,span#autosave_status{font-size:small;}
 @media (max-width:767px){span#save_widget{font-size:small;} span#checkpoint_status,span#autosave_status{font-size:x-small;}}@media (max-width:767px){span#checkpoint_status,span#autosave_status{display:none;}}@media (min-width:768px) and (max-width:979px){span#checkpoint_status{display:none;} span#autosave_status{font-size:x-small;}}div.text_cell{padding:5px 5px 5px 5px;}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1557,6 +1557,8 @@ div.quickhelp{float:left;width:50%;}
 .rendered_html th{font-weight:bold;}
 .rendered_html p{text-align:justify;}
 .rendered_html p+p{margin-top:1em;}
+.rendered_html p+table{margin-top:1em;}
+.rendered_html table+p{margin-top:1em;}
 .rendered_html img{display:block;margin-left:auto;margin-right:auto;}
 .rendered_html .MathJax_Display{text-align:center !important;}
 span#save_widget{padding:0px 5px;margin-top:12px;}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1551,12 +1551,14 @@ div.quickhelp{float:left;width:50%;}
 .rendered_html pre{margin:1em 2em;}
 .rendered_html pre,.rendered_html code{border:0;background-color:#ffffff;color:#000000;font-size:100%;padding:0px;}
 .rendered_html blockquote{margin:1em 2em;}
-.rendered_html table,.rendered_html tr,.rendered_html th,.rendered_html td{border:1px solid black;border-collapse:collapse;margin:1em 2em;}
+.rendered_html table{margin-left:auto;margin-right:auto;border:1px solid black;border-collapse:collapse;}
+.rendered_html tr,.rendered_html th,.rendered_html td{border:1px solid black;border-collapse:collapse;margin:1em 2em;}
 .rendered_html td,.rendered_html th{text-align:left;vertical-align:middle;padding:4px;}
 .rendered_html th{font-weight:bold;}
 .rendered_html p{text-align:justify;}
 .rendered_html p+p{margin-top:1em;}
-.rendered_html .MathJax_Display{margin-left:12ex;}
+.rendered_html img{display:block;margin-left:auto;margin-right:auto;}
+.rendered_html .MathJax_Display{text-align:center !important;}
 span#save_widget{padding:0px 5px;margin-top:12px;}
 span#checkpoint_status,span#autosave_status{font-size:small;}
 @media (max-width:767px){span#save_widget{font-size:small;} span#checkpoint_status,span#autosave_status{font-size:x-small;}}@media (max-width:767px){span#checkpoint_status,span#autosave_status{display:none;}}@media (min-width:768px) and (max-width:979px){span#checkpoint_status{display:none;} span#autosave_status{font-size:x-small;}}div.text_cell{padding:5px 5px 5px 5px;}

--- a/IPython/html/static/tree/less/style.less
+++ b/IPython/html/static/tree/less/style.less
@@ -1,2 +1,2 @@
-@import "../tree/less/altuploadform.less";
-@import "../tree/less/tree.less";
+@import "altuploadform.less";
+@import "tree.less";

--- a/docs/source/whatsnew/pr/centered-math.rst
+++ b/docs/source/whatsnew/pr/centered-math.rst
@@ -1,0 +1,3 @@
+* Equations, images and tables are now centered in Markdown cells.
+* Multiline equations are now centered in output areas; single line equations
+  remain left justified.


### PR DESCRIPTION
This is to address #3224.  I have designed this so that the equations in Markdown cells match the indentation level of those in output.  This creates the desired left margin in a consistent way.  Here is what it looks like:

![screen shot 2013-08-31 at 5 40 19 pm](https://f.cloud.github.com/assets/27600/1063283/cff317fc-129f-11e3-9bb2-40cf5832ac5c.png)
