### PR TITLE
First draft of new heading spacing/font size.

### DIFF
--- a/IPython/html/static/notebook/css/override.css
+++ b/IPython/html/static/notebook/css/override.css
@@ -4,5 +4,4 @@ a hack to deal with our current css styles and no new styling should be added in
 
 #ipython-main-app {
     position: relative;
-    font-size: 110%;
 }

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -115,18 +115,19 @@ var IPython = (function (IPython) {
         var cell =  $('<div></div>').addClass('cell border-box-sizing code_cell');
         cell.attr('tabindex','2');
 
-        this.celltoolbar = new IPython.CellToolbar(this);
-
         var input = $('<div></div>').addClass('input');
-        var vbox = $('<div/>').addClass('vbox box-flex1')
-        input.append($('<div/>').addClass('prompt input_prompt'));
-        vbox.append(this.celltoolbar.element);
+        var prompt = $('<div/>').addClass('prompt input_prompt');
+        var inner_cell = $('<div/>').addClass('inner_cell');
+        this.celltoolbar = new IPython.CellToolbar(this);
+        inner_cell.append(this.celltoolbar.element);
         var input_area = $('<div/>').addClass('input_area');
         this.code_mirror = CodeMirror(input_area.get(0), this.cm_config);
         $(this.code_mirror.getInputField()).attr("spellcheck", "false");
-        vbox.append(input_area);
-        input.append(vbox);
+        inner_cell.append(input_area);
+        input.append(prompt).append(inner_cell);
+        
         var output = $('<div></div>');
+        
         cell.append(input).append(output);
         this.element = cell;
         this.output_area = new IPython.OutputArea(output, true);

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -74,17 +74,19 @@ var IPython = (function (IPython) {
         IPython.Cell.prototype.create_element.apply(this, arguments);
         var cell = $("<div>").addClass('cell text_cell border-box-sizing');
         cell.attr('tabindex','2');
+        cell.append($('<div/>').addClass('prompt input_prompt'));
 
+        var inner_cell = $('<div/>').addClass('inner_cell');
         this.celltoolbar = new IPython.CellToolbar(this);
-        cell.append(this.celltoolbar.element);
-
+        inner_cell.append(this.celltoolbar.element);
         var input_area = $('<div/>').addClass('text_cell_input border-box-sizing');
         this.code_mirror = CodeMirror(input_area.get(0), this.cm_config);
-
         // The tabindex=-1 makes this div focusable.
         var render_area = $('<div/>').addClass('text_cell_render border-box-sizing').
             addClass('rendered_html').attr('tabindex','-1');
-        cell.append(input_area).append(render_area);
+        inner_cell.append(input_area).append(render_area);
+
+        cell.append(inner_cell);
         this.element = cell;
     };
 

--- a/IPython/html/static/notebook/less/cell.less
+++ b/IPython/html/static/notebook/less/cell.less
@@ -9,7 +9,8 @@ div.cell {
     width: 100%;
     padding: 5px 5px 5px 0px;
     /* This acts as a spacer between cells, that is outside the border */
-    margin: 2px 0px 2px 7px;
+    margin: 0px;
+    // margin: 2px 0px 2px 7px;
     outline: none;
 }
 
@@ -23,4 +24,9 @@ div.prompt {
     text-align: right;
     /* This has to match that of the the CodeMirror class line-height below */	
     line-height: @code_line_height;
+}
+
+div.inner_cell {
+    .vbox();
+    .box-flex1();
 }

--- a/IPython/html/static/notebook/less/notebook.less
+++ b/IPython/html/static/notebook/less/notebook.less
@@ -25,7 +25,7 @@ div#notebook {
     overflow-x: auto;
     width: 100%;
     /* This spaces the cell away from the edge of the notebook area */
-    padding: 5px 5px 15px 5px;
+    padding: 15px 5px 15px 5px;
     margin: 0px;
     border-top: 1px solid @border_color;
 }

--- a/IPython/html/static/notebook/less/notebook.less
+++ b/IPython/html/static/notebook/less/notebook.less
@@ -16,10 +16,16 @@ span#notebook_name {
 }
 
 div#notebook_panel {
+    // We set the font properties here so the #notebook div can inherit
+    // these properties from its parent, which is important when it is
+    // embedded in other contexts.
+    font-size: @notebook_font_size;
+    line-height: @notebook_line_height;
     margin: 0px 0px 0px 0px;
     padding: 0px;
     .box-shadow(0 -1px 10px rgba(0,0,0,.1));
 }
+
 div#notebook {
     overflow-y: scroll;
     overflow-x: auto;

--- a/IPython/html/static/notebook/less/renderedhtml.less
+++ b/IPython/html/static/notebook/less/renderedhtml.less
@@ -6,16 +6,59 @@
     u {text-decoration: underline;}
     :link { text-decoration: underline }
     :visited { text-decoration: underline }
-    h1 {font-size: 225%; margin: 0; font-weight: bold;}
-    h2 {font-size: 180%; margin: 0; font-weight: bold;}
-    h3 {font-size: 142.5%; margin: 0; font-weight: bold;}
-    h4 {font-size: 100%; margin: 0; font-weight: bold;}
-    h5 {font-size: 85%; margin: 0; font-weight: bold;}
-    h6 {font-size: 85%; margin: 0; font-weight: bold; text-decoration:underline}
-    ul {list-style:disc; margin: 1em 2em;}
+    h1 {
+        font-size: 32px;
+        line-height: 40px;
+        margin-bottom: 15px;
+        padding-top: 5px;
+        margin-top: 0px;
+        font-weight: bold;
+    }
+    h2 {
+        font-size: 26px;
+        line-height: 40px;
+        margin-bottom: 13px;
+        padding-top: 7px;
+        margin-top: 0px;
+        font-weight: bold;
+    }
+    h3 {
+        font-size: 20px;
+        line-height: 40px;
+        margin-bottom: 12px;
+        padding-top: 8px;
+        margin-top: 0px;
+        font-weight: bold;
+    }
+    h4 {
+        font-size: 14px;
+        line-height: 20px;
+        margin-bottom: 0px;
+        margin-top: 0px;
+        font-weight: bold;
+    }
+    h5 {
+        font-size: 10px;
+        line-height: 20px;
+        margin-bottom: 0px;
+        margin-top: 0px;
+        font-weight: bold;
+    }
+    h6 {
+        font-size: 10px;
+        line-height: 20px;
+        margin-bottom: 0px;
+        margin-top: 0px;
+        font-weight: bold;
+    }
+    // h3 {font-size: 142.5%; margin: 0; font-weight: bold;}
+    // h4 {font-size: 100%; margin: 0; font-weight: bold;}
+    // h5 {font-size: 85%; margin: 0; font-weight: bold;}
+    // h6 {font-size: 85%; margin: 0; font-weight: bold; text-decoration:underline}
+    ul {list-style:disc; margin: 0 2em 20px 2em;}
     ul ul {list-style:square; margin: 0em 2em;}
     ul ul ul {list-style:circle; margin: 0em 2em;}
-    ol {list-style:decimal; margin: 1em 2em;}
+    ol {list-style:decimal; margin: 0 2em 20px 2em;}
     ol ol {list-style:upper-alpha; margin: 0em 2em;}
     ol ol ol {list-style:lower-alpha; margin: 0em 2em;}
     ol ol ol ol {list-style:lower-roman; margin: 0em 2em;}
@@ -28,7 +71,7 @@
     }
 
     pre {
-        margin: 1em 2em;
+        margin: 0 2em 20px 2em;
     }
 
 	pre, code {
@@ -46,7 +89,7 @@
     table, tr, th, td {
         border: 1px solid black;
         border-collapse: collapse;
-        margin: 1em 2em;
+        margin: 20px 2em;
     }
 
     td,th {
@@ -61,9 +104,12 @@
 
     p {
         text-align: justify;
+        margin-bottom: 20px;
     }
 
-    p + p {
-        margin-top: 1em;
-    }
+
+
+    // p + p {
+    //     margin-top: unit(@notebook_line_height, em);
+    // }
 }

--- a/IPython/html/static/notebook/less/renderedhtml.less
+++ b/IPython/html/static/notebook/less/renderedhtml.less
@@ -1,4 +1,4 @@
-.rendered_html{
+.rendered_html {
 
     color: black;
     em {font-style: italic;}
@@ -6,12 +6,12 @@
     u {text-decoration: underline;}
     :link { text-decoration: underline }
     :visited { text-decoration: underline }
-    h1 {font-size: 197%; margin: .65em 0; font-weight: bold;}
-    h2 {font-size: 153.9%; margin: .75em 0; font-weight: bold;}
-    h3 {font-size: 123.1%; margin: .85em 0; font-weight: bold;}
-    h4 {font-size: 100%; margin: 0.95em 0; font-weight: bold;}
-    h5 {font-size: 85%; margin: 1.5em 0; font-weight: bold;}
-    h6 {font-size: 77%; margin: 1.65em 0; font-weight: bold;}
+    h1 {font-size: 225%; margin: 0; font-weight: bold;}
+    h2 {font-size: 180%; margin: 0; font-weight: bold;}
+    h3 {font-size: 142.5%; margin: 0; font-weight: bold;}
+    h4 {font-size: 100%; margin: 0; font-weight: bold;}
+    h5 {font-size: 85%; margin: 0; font-weight: bold;}
+    h6 {font-size: 85%; margin: 0; font-weight: bold; text-decoration:underline}
     ul {list-style:disc; margin: 1em 2em;}
     ul ul {list-style:square; margin: 0em 2em;}
     ul ul ul {list-style:circle; margin: 0em 2em;}

--- a/IPython/html/static/notebook/less/textcell.less
+++ b/IPython/html/static/notebook/less/textcell.less
@@ -1,5 +1,6 @@
 div.text_cell {
     padding: 5px 5px 5px 5px;
+    .hbox();
 }
 
 div.text_cell_input {
@@ -29,4 +30,8 @@ h1,h2,h3,h4,h5,h6 {
     &:hover .anchor-link {
         visibility: visible;
     }
+}
+
+.code_cell + .text_cell .inner_cell {
+    border-top: 1px solid @border_color;
 }

--- a/IPython/html/static/notebook/less/variables.less
+++ b/IPython/html/static/notebook/less/variables.less
@@ -7,3 +7,9 @@
 @light_border_color:			darken(@cell_selected_background, 17%);
 @border_width:					1px;
 
+@notebook_font_size:            14px;
+@notebook_line_height:          1.4298;  // 20px
+@baseline_size:                 @notebook_font_size*@notebook_line_height;
+
+
+

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -119,7 +119,7 @@ body{background-color:#ffffff;}
 body.notebook_app{overflow:hidden;}
 span#notebook_name{height:1em;line-height:1em;padding:3px;border:none;font-size:146.5%;}
 div#notebook_panel{margin:0px 0px 0px 0px;padding:0px;-webkit-box-shadow:0 -1px 10px rgba(0, 0, 0, 0.1);-moz-box-shadow:0 -1px 10px rgba(0, 0, 0, 0.1);box-shadow:0 -1px 10px rgba(0, 0, 0, 0.1);}
-div#notebook{overflow-y:scroll;overflow-x:auto;width:100%;padding:5px 5px 15px 5px;margin:0px;border-top:1px solid #ababab;}
+div#notebook{overflow-y:scroll;overflow-x:auto;width:100%;padding:15px 5px 15px 5px;margin:0px;border-top:1px solid #ababab;}
 div.ui-widget-content{border:1px solid #ababab;outline:none;}
 pre.dialog{background-color:#f7f7f7;border:1px solid #ddd;border-radius:4px;padding:0.4em;padding-left:2em;}
 p.dialog{padding:0.2em;}
@@ -152,12 +152,12 @@ div.quickhelp{float:left;width:50%;}
 .rendered_html u{text-decoration:underline;}
 .rendered_html :link{text-decoration:underline;}
 .rendered_html :visited{text-decoration:underline;}
-.rendered_html h1{font-size:197%;margin:.65em 0;font-weight:bold;}
-.rendered_html h2{font-size:153.9%;margin:.75em 0;font-weight:bold;}
-.rendered_html h3{font-size:123.1%;margin:.85em 0;font-weight:bold;}
-.rendered_html h4{font-size:100%;margin:0.95em 0;font-weight:bold;}
-.rendered_html h5{font-size:85%;margin:1.5em 0;font-weight:bold;}
-.rendered_html h6{font-size:77%;margin:1.65em 0;font-weight:bold;}
+.rendered_html h1{font-size:225%;margin:0;font-weight:bold;}
+.rendered_html h2{font-size:180%;margin:0;font-weight:bold;}
+.rendered_html h3{font-size:142.5%;margin:0;font-weight:bold;}
+.rendered_html h4{font-size:100%;margin:0;font-weight:bold;}
+.rendered_html h5{font-size:85%;margin:0;font-weight:bold;}
+.rendered_html h6{font-size:85%;margin:0;font-weight:bold;text-decoration:underline;}
 .rendered_html ul{list-style:disc;margin:1em 2em;}
 .rendered_html ul ul{list-style:square;margin:0em 2em;}
 .rendered_html ul ul ul{list-style:circle;margin:0em 2em;}

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -53,8 +53,9 @@ input.engine_num_input{height:20px;margin-bottom:2px;padding-top:0;padding-botto
 .ansibgpurple{background-color:magenta;}
 .ansibgcyan{background-color:cyan;}
 .ansibggray{background-color:gray;}
-div.cell{border:1px solid transparent;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;width:100%;padding:5px 5px 5px 0px;margin:2px 0px 2px 7px;outline:none;}div.cell.selected{border-radius:4px;border:thin #ababab solid;}
+div.cell{border:1px solid transparent;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;width:100%;padding:5px 5px 5px 0px;margin:0px;outline:none;}div.cell.selected{border-radius:4px;border:thin #ababab solid;}
 div.prompt{width:11ex;padding:0.4em;margin:0px;font-family:monospace;text-align:right;line-height:1.231em;}
+div.inner_cell{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;width:100%;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;}
 .celltoolbar{border:thin solid #CFCFCF;border-bottom:none;background:#EEE;border-top-right-radius:3px;border-top-left-radius:3px;width:100%;-webkit-box-pack:end;height:22px;}
 .no_input_radius{border-top-right-radius:0px;border-top-left-radius:0px;}
 .text_cell .ctb_prompt{display:none;}
@@ -177,11 +178,12 @@ div.quickhelp{float:left;width:50%;}
 .rendered_html p+p{margin-top:1em;}
 span#save_widget{padding:0px 5px;margin-top:12px;}
 span#checkpoint_status,span#autosave_status{font-size:small;}
-@media (max-width:767px){span#save_widget{font-size:small;} span#checkpoint_status,span#autosave_status{font-size:x-small;}}@media (max-width:767px){span#checkpoint_status,span#autosave_status{display:none;}}@media (min-width:768px) and (max-width:979px){span#checkpoint_status{display:none;} span#autosave_status{font-size:x-small;}}div.text_cell{padding:5px 5px 5px 5px;}
+@media (max-width:767px){span#save_widget{font-size:small;} span#checkpoint_status,span#autosave_status{font-size:x-small;}}@media (max-width:767px){span#checkpoint_status,span#autosave_status{display:none;}}@media (min-width:768px) and (max-width:979px){span#checkpoint_status{display:none;} span#autosave_status{font-size:x-small;}}div.text_cell{padding:5px 5px 5px 5px;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;}
 div.text_cell_input{color:#000000;border:1px solid #cfcfcf;border-radius:4px;background:#f7f7f7;}
 div.text_cell_render{outline:none;resize:none;width:inherit;border-style:none;padding:5px;color:#000000;}
 a.anchor-link:link{text-decoration:none;padding:0px 20px;visibility:hidden;}
 h1:hover .anchor-link,h2:hover .anchor-link,h3:hover .anchor-link,h4:hover .anchor-link,h5:hover .anchor-link,h6:hover .anchor-link{visibility:visible;}
+.code_cell+.text_cell .inner_cell{border-top:1px solid #ababab;}
 .toolbar{padding:0px 10px;margin-top:-5px;}.toolbar select,.toolbar label{width:auto;height:26px;vertical-align:middle;margin-right:2px;margin-bottom:0px;display:inline;font-size:92%;margin-left:0.3em;margin-right:0.3em;padding:0px;padding-top:3px;}
 .toolbar .btn{padding:2px 8px;}
 .toolbar .btn-group{margin-top:0px;}

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -119,7 +119,7 @@ pre .coffeescript .javascript,pre .javascript .xml,pre .tex .formula,pre .xml .j
 body{background-color:#ffffff;}
 body.notebook_app{overflow:hidden;}
 span#notebook_name{height:1em;line-height:1em;padding:3px;border:none;font-size:146.5%;}
-div#notebook_panel{margin:0px 0px 0px 0px;padding:0px;-webkit-box-shadow:0 -1px 10px rgba(0, 0, 0, 0.1);-moz-box-shadow:0 -1px 10px rgba(0, 0, 0, 0.1);box-shadow:0 -1px 10px rgba(0, 0, 0, 0.1);}
+div#notebook_panel{font-size:14px;line-height:1.4298;margin:0px 0px 0px 0px;padding:0px;-webkit-box-shadow:0 -1px 10px rgba(0, 0, 0, 0.1);-moz-box-shadow:0 -1px 10px rgba(0, 0, 0, 0.1);box-shadow:0 -1px 10px rgba(0, 0, 0, 0.1);}
 div#notebook{overflow-y:scroll;overflow-x:auto;width:100%;padding:15px 5px 15px 5px;margin:0px;border-top:1px solid #ababab;}
 div.ui-widget-content{border:1px solid #ababab;outline:none;}
 pre.dialog{background-color:#f7f7f7;border:1px solid #ddd;border-radius:4px;padding:0.4em;padding-left:2em;}
@@ -153,29 +153,28 @@ div.quickhelp{float:left;width:50%;}
 .rendered_html u{text-decoration:underline;}
 .rendered_html :link{text-decoration:underline;}
 .rendered_html :visited{text-decoration:underline;}
-.rendered_html h1{font-size:225%;margin:0;font-weight:bold;}
-.rendered_html h2{font-size:180%;margin:0;font-weight:bold;}
-.rendered_html h3{font-size:142.5%;margin:0;font-weight:bold;}
-.rendered_html h4{font-size:100%;margin:0;font-weight:bold;}
-.rendered_html h5{font-size:85%;margin:0;font-weight:bold;}
-.rendered_html h6{font-size:85%;margin:0;font-weight:bold;text-decoration:underline;}
-.rendered_html ul{list-style:disc;margin:1em 2em;}
+.rendered_html h1{font-size:32px;line-height:40px;margin-bottom:15px;padding-top:5px;margin-top:0px;font-weight:bold;}
+.rendered_html h2{font-size:26px;line-height:40px;margin-bottom:13px;padding-top:7px;margin-top:0px;font-weight:bold;}
+.rendered_html h3{font-size:20px;line-height:40px;margin-bottom:12px;padding-top:8px;margin-top:0px;font-weight:bold;}
+.rendered_html h4{font-size:14px;line-height:20px;margin-bottom:0px;margin-top:0px;font-weight:bold;}
+.rendered_html h5{font-size:8px;line-height:20px;margin-bottom:0px;margin-top:0px;font-weight:bold;}
+.rendered_html h6{font-size:8px;line-height:20px;margin-bottom:0px;margin-top:0px;font-weight:bold;}
+.rendered_html ul{list-style:disc;margin:0 2em 20px 2em;}
 .rendered_html ul ul{list-style:square;margin:0em 2em;}
 .rendered_html ul ul ul{list-style:circle;margin:0em 2em;}
-.rendered_html ol{list-style:decimal;margin:1em 2em;}
+.rendered_html ol{list-style:decimal;margin:0 2em 20px 2em;}
 .rendered_html ol ol{list-style:upper-alpha;margin:0em 2em;}
 .rendered_html ol ol ol{list-style:lower-alpha;margin:0em 2em;}
 .rendered_html ol ol ol ol{list-style:lower-roman;margin:0em 2em;}
 .rendered_html ol ol ol ol ol{list-style:decimal;margin:0em 2em;}
 .rendered_html hr{color:black;background-color:black;}
-.rendered_html pre{margin:1em 2em;}
+.rendered_html pre{margin:0 2em 20px 2em;}
 .rendered_html pre,.rendered_html code{border:0;background-color:#ffffff;color:#000000;font-size:100%;padding:0px;}
 .rendered_html blockquote{margin:1em 2em;}
-.rendered_html table,.rendered_html tr,.rendered_html th,.rendered_html td{border:1px solid black;border-collapse:collapse;margin:1em 2em;}
+.rendered_html table,.rendered_html tr,.rendered_html th,.rendered_html td{border:1px solid black;border-collapse:collapse;margin:20px 2em;}
 .rendered_html td,.rendered_html th{text-align:left;vertical-align:middle;padding:4px;}
 .rendered_html th{font-weight:bold;}
-.rendered_html p{text-align:justify;}
-.rendered_html p+p{margin-top:1em;}
+.rendered_html p{text-align:justify;margin-bottom:20px;}
 span#save_widget{padding:0px 5px;margin-top:12px;}
 span#checkpoint_status,span#autosave_status{font-size:small;}
 @media (max-width:767px){span#save_widget{font-size:small;} span#checkpoint_status,span#autosave_status{font-size:x-small;}}@media (max-width:767px){span#checkpoint_status,span#autosave_status{display:none;}}@media (min-width:768px) and (max-width:979px){span#checkpoint_status{display:none;} span#autosave_status{font-size:x-small;}}div.text_cell{padding:5px 5px 5px 5px;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1500,7 +1500,7 @@ pre .coffeescript .javascript,pre .javascript .xml,pre .tex .formula,pre .xml .j
 body{background-color:#ffffff;}
 body.notebook_app{overflow:hidden;}
 span#notebook_name{height:1em;line-height:1em;padding:3px;border:none;font-size:146.5%;}
-div#notebook_panel{margin:0px 0px 0px 0px;padding:0px;-webkit-box-shadow:0 -1px 10px rgba(0, 0, 0, 0.1);-moz-box-shadow:0 -1px 10px rgba(0, 0, 0, 0.1);box-shadow:0 -1px 10px rgba(0, 0, 0, 0.1);}
+div#notebook_panel{font-size:14px;line-height:1.4298;margin:0px 0px 0px 0px;padding:0px;-webkit-box-shadow:0 -1px 10px rgba(0, 0, 0, 0.1);-moz-box-shadow:0 -1px 10px rgba(0, 0, 0, 0.1);box-shadow:0 -1px 10px rgba(0, 0, 0, 0.1);}
 div#notebook{overflow-y:scroll;overflow-x:auto;width:100%;padding:15px 5px 15px 5px;margin:0px;border-top:1px solid #ababab;}
 div.ui-widget-content{border:1px solid #ababab;outline:none;}
 pre.dialog{background-color:#f7f7f7;border:1px solid #ddd;border-radius:4px;padding:0.4em;padding-left:2em;}
@@ -1534,29 +1534,28 @@ div.quickhelp{float:left;width:50%;}
 .rendered_html u{text-decoration:underline;}
 .rendered_html :link{text-decoration:underline;}
 .rendered_html :visited{text-decoration:underline;}
-.rendered_html h1{font-size:225%;margin:0;font-weight:bold;}
-.rendered_html h2{font-size:180%;margin:0;font-weight:bold;}
-.rendered_html h3{font-size:142.5%;margin:0;font-weight:bold;}
-.rendered_html h4{font-size:100%;margin:0;font-weight:bold;}
-.rendered_html h5{font-size:85%;margin:0;font-weight:bold;}
-.rendered_html h6{font-size:85%;margin:0;font-weight:bold;text-decoration:underline;}
-.rendered_html ul{list-style:disc;margin:1em 2em;}
+.rendered_html h1{font-size:32px;line-height:40px;margin-bottom:15px;padding-top:5px;margin-top:0px;font-weight:bold;}
+.rendered_html h2{font-size:26px;line-height:40px;margin-bottom:13px;padding-top:7px;margin-top:0px;font-weight:bold;}
+.rendered_html h3{font-size:20px;line-height:40px;margin-bottom:12px;padding-top:8px;margin-top:0px;font-weight:bold;}
+.rendered_html h4{font-size:14px;line-height:20px;margin-bottom:0px;margin-top:0px;font-weight:bold;}
+.rendered_html h5{font-size:8px;line-height:20px;margin-bottom:0px;margin-top:0px;font-weight:bold;}
+.rendered_html h6{font-size:8px;line-height:20px;margin-bottom:0px;margin-top:0px;font-weight:bold;}
+.rendered_html ul{list-style:disc;margin:0 2em 20px 2em;}
 .rendered_html ul ul{list-style:square;margin:0em 2em;}
 .rendered_html ul ul ul{list-style:circle;margin:0em 2em;}
-.rendered_html ol{list-style:decimal;margin:1em 2em;}
+.rendered_html ol{list-style:decimal;margin:0 2em 20px 2em;}
 .rendered_html ol ol{list-style:upper-alpha;margin:0em 2em;}
 .rendered_html ol ol ol{list-style:lower-alpha;margin:0em 2em;}
 .rendered_html ol ol ol ol{list-style:lower-roman;margin:0em 2em;}
 .rendered_html ol ol ol ol ol{list-style:decimal;margin:0em 2em;}
 .rendered_html hr{color:black;background-color:black;}
-.rendered_html pre{margin:1em 2em;}
+.rendered_html pre{margin:0 2em 20px 2em;}
 .rendered_html pre,.rendered_html code{border:0;background-color:#ffffff;color:#000000;font-size:100%;padding:0px;}
 .rendered_html blockquote{margin:1em 2em;}
-.rendered_html table,.rendered_html tr,.rendered_html th,.rendered_html td{border:1px solid black;border-collapse:collapse;margin:1em 2em;}
+.rendered_html table,.rendered_html tr,.rendered_html th,.rendered_html td{border:1px solid black;border-collapse:collapse;margin:20px 2em;}
 .rendered_html td,.rendered_html th{text-align:left;vertical-align:middle;padding:4px;}
 .rendered_html th{font-weight:bold;}
-.rendered_html p{text-align:justify;}
-.rendered_html p+p{margin-top:1em;}
+.rendered_html p{text-align:justify;margin-bottom:20px;}
 span#save_widget{padding:0px 5px;margin-top:12px;}
 span#checkpoint_status,span#autosave_status{font-size:small;}
 @media (max-width:767px){span#save_widget{font-size:small;} span#checkpoint_status,span#autosave_status{font-size:x-small;}}@media (max-width:767px){span#checkpoint_status,span#autosave_status{display:none;}}@media (min-width:768px) and (max-width:979px){span#checkpoint_status{display:none;} span#autosave_status{font-size:x-small;}}div.text_cell{padding:5px 5px 5px 5px;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1500,7 +1500,7 @@ body{background-color:#ffffff;}
 body.notebook_app{overflow:hidden;}
 span#notebook_name{height:1em;line-height:1em;padding:3px;border:none;font-size:146.5%;}
 div#notebook_panel{margin:0px 0px 0px 0px;padding:0px;-webkit-box-shadow:0 -1px 10px rgba(0, 0, 0, 0.1);-moz-box-shadow:0 -1px 10px rgba(0, 0, 0, 0.1);box-shadow:0 -1px 10px rgba(0, 0, 0, 0.1);}
-div#notebook{overflow-y:scroll;overflow-x:auto;width:100%;padding:5px 5px 15px 5px;margin:0px;border-top:1px solid #ababab;}
+div#notebook{overflow-y:scroll;overflow-x:auto;width:100%;padding:15px 5px 15px 5px;margin:0px;border-top:1px solid #ababab;}
 div.ui-widget-content{border:1px solid #ababab;outline:none;}
 pre.dialog{background-color:#f7f7f7;border:1px solid #ddd;border-radius:4px;padding:0.4em;padding-left:2em;}
 p.dialog{padding:0.2em;}
@@ -1533,12 +1533,12 @@ div.quickhelp{float:left;width:50%;}
 .rendered_html u{text-decoration:underline;}
 .rendered_html :link{text-decoration:underline;}
 .rendered_html :visited{text-decoration:underline;}
-.rendered_html h1{font-size:197%;margin:.65em 0;font-weight:bold;}
-.rendered_html h2{font-size:153.9%;margin:.75em 0;font-weight:bold;}
-.rendered_html h3{font-size:123.1%;margin:.85em 0;font-weight:bold;}
-.rendered_html h4{font-size:100%;margin:0.95em 0;font-weight:bold;}
-.rendered_html h5{font-size:85%;margin:1.5em 0;font-weight:bold;}
-.rendered_html h6{font-size:77%;margin:1.65em 0;font-weight:bold;}
+.rendered_html h1{font-size:225%;margin:0;font-weight:bold;}
+.rendered_html h2{font-size:180%;margin:0;font-weight:bold;}
+.rendered_html h3{font-size:142.5%;margin:0;font-weight:bold;}
+.rendered_html h4{font-size:100%;margin:0;font-weight:bold;}
+.rendered_html h5{font-size:85%;margin:0;font-weight:bold;}
+.rendered_html h6{font-size:85%;margin:0;font-weight:bold;text-decoration:underline;}
 .rendered_html ul{list-style:disc;margin:1em 2em;}
 .rendered_html ul ul{list-style:square;margin:0em 2em;}
 .rendered_html ul ul ul{list-style:circle;margin:0em 2em;}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1434,8 +1434,9 @@ input.engine_num_input{height:20px;margin-bottom:2px;padding-top:0;padding-botto
 .ansibgpurple{background-color:magenta;}
 .ansibgcyan{background-color:cyan;}
 .ansibggray{background-color:gray;}
-div.cell{border:1px solid transparent;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;width:100%;padding:5px 5px 5px 0px;margin:2px 0px 2px 7px;outline:none;}div.cell.selected{border-radius:4px;border:thin #ababab solid;}
+div.cell{border:1px solid transparent;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;width:100%;padding:5px 5px 5px 0px;margin:0px;outline:none;}div.cell.selected{border-radius:4px;border:thin #ababab solid;}
 div.prompt{width:11ex;padding:0.4em;margin:0px;font-family:monospace;text-align:right;line-height:1.231em;}
+div.inner_cell{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;width:100%;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;}
 .celltoolbar{border:thin solid #CFCFCF;border-bottom:none;background:#EEE;border-top-right-radius:3px;border-top-left-radius:3px;width:100%;-webkit-box-pack:end;height:22px;}
 .no_input_radius{border-top-right-radius:0px;border-top-left-radius:0px;}
 .text_cell .ctb_prompt{display:none;}
@@ -1558,11 +1559,12 @@ div.quickhelp{float:left;width:50%;}
 .rendered_html p+p{margin-top:1em;}
 span#save_widget{padding:0px 5px;margin-top:12px;}
 span#checkpoint_status,span#autosave_status{font-size:small;}
-@media (max-width:767px){span#save_widget{font-size:small;} span#checkpoint_status,span#autosave_status{font-size:x-small;}}@media (max-width:767px){span#checkpoint_status,span#autosave_status{display:none;}}@media (min-width:768px) and (max-width:979px){span#checkpoint_status{display:none;} span#autosave_status{font-size:x-small;}}div.text_cell{padding:5px 5px 5px 5px;}
+@media (max-width:767px){span#save_widget{font-size:small;} span#checkpoint_status,span#autosave_status{font-size:x-small;}}@media (max-width:767px){span#checkpoint_status,span#autosave_status{display:none;}}@media (min-width:768px) and (max-width:979px){span#checkpoint_status{display:none;} span#autosave_status{font-size:x-small;}}div.text_cell{padding:5px 5px 5px 5px;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;}
 div.text_cell_input{color:#000000;border:1px solid #cfcfcf;border-radius:4px;background:#f7f7f7;}
 div.text_cell_render{outline:none;resize:none;width:inherit;border-style:none;padding:5px;color:#000000;}
 a.anchor-link:link{text-decoration:none;padding:0px 20px;visibility:hidden;}
 h1:hover .anchor-link,h2:hover .anchor-link,h3:hover .anchor-link,h4:hover .anchor-link,h5:hover .anchor-link,h6:hover .anchor-link{visibility:visible;}
+.code_cell+.text_cell .inner_cell{border-top:1px solid #ababab;}
 .toolbar{padding:0px 10px;margin-top:-5px;}.toolbar select,.toolbar label{width:auto;height:26px;vertical-align:middle;margin-right:2px;margin-bottom:0px;display:inline;font-size:92%;margin-left:0.3em;margin-right:0.3em;padding:0px;padding-top:3px;}
 .toolbar .btn{padding:2px 8px;}
 .toolbar .btn-group{margin-top:0px;}


### PR DESCRIPTION
This is to address #3224.  In master, heading cells have too much top and bottom margin so notebooks take up too much vertical space.  I have made the following changes to fix that:
- Adjusted the font sizes to be 32px, 26px, 20px, 14px, 12px and 12px with underline.
- Removed the top/bottom margins.

Here is the new look:

![screen shot 2013-08-31 at 8 37 53 pm](https://f.cloud.github.com/assets/27600/1063420/7057b94c-12b8-11e3-887b-ed47378ed3ea.png)

And the old:

![screen shot 2013-08-31 at 8 42 41 pm](https://f.cloud.github.com/assets/27600/1063423/9e4b9012-12b8-11e3-8cb2-a4bb0abc1e67.png)

This needs more work:
- [ ] We currently set the main font size to 13px, but override that up to %110 to get 14px. This means that in nbconvert produced output, the font size will always inherit the outer container.  I think we should probably start to work in pixel font sizes inside the notebook div.
- [ ] If you put Markdown headings inside Markdown cells, the top/bottom margins are too small.  With our current css classes on cells, we don't distinguish between Markdown and heading cells, so I I am not how we want to fix this.
