### PR TITLE
generate choices for `--gui` configurable from real mapping

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -36,10 +36,13 @@ from IPython.utils.path import filefind
 from IPython.utils.traitlets import (
     Unicode, Instance, List, Bool, CaselessStrEnum, Dict
 )
+from IPython.lib.inputhook import guis
 
 #-----------------------------------------------------------------------------
 # Aliases and Flags
 #-----------------------------------------------------------------------------
+
+gui_keys = tuple(sorted([ key for key in guis if key is not None ]))
 
 backend_keys = sorted(pylabtools.backends.keys())
 backend_keys.insert(0, 'auto')
@@ -175,8 +178,8 @@ class InteractiveShellApp(Configurable):
     module_to_run = Unicode('', config=True,
         help="Run the module as a script."
     )
-    gui = CaselessStrEnum(('qt', 'wx', 'gtk', 'glut', 'pyglet', 'osx'), config=True,
-        help="Enable GUI event loop integration ('qt', 'wx', 'gtk', 'glut', 'pyglet', 'osx')."
+    gui = CaselessStrEnum(gui_keys, config=True,
+        help="Enable GUI event loop integration with any of {0}.".format(gui_keys)
     )
     matplotlib = CaselessStrEnum(backend_keys,
         config=True,

--- a/IPython/lib/inputhook.py
+++ b/IPython/lib/inputhook.py
@@ -481,6 +481,19 @@ set_inputhook = inputhook_manager.set_inputhook
 current_gui = inputhook_manager.current_gui
 clear_app_refs = inputhook_manager.clear_app_refs
 
+guis = {None: clear_inputhook,
+        GUI_NONE: clear_inputhook,
+        GUI_OSX: lambda app=False: None,
+        GUI_TK: enable_tk,
+        GUI_GTK: enable_gtk,
+        GUI_WX: enable_wx,
+        GUI_QT: enable_qt4, # qt3 not supported
+        GUI_QT4: enable_qt4,
+        GUI_GLUT: enable_glut,
+        GUI_PYGLET: enable_pyglet,
+        GUI_GTK3: enable_gtk3,
+}
+
 
 # Convenience function to switch amongst them
 def enable_gui(gui=None, app=None):
@@ -507,18 +520,6 @@ def enable_gui(gui=None, app=None):
     PyOS_InputHook wrapper object or the GUI toolkit app created, if there was
     one.
     """
-    guis = {None: clear_inputhook,
-            GUI_NONE: clear_inputhook,
-            GUI_OSX: lambda app=False: None,
-            GUI_TK: enable_tk,
-            GUI_GTK: enable_gtk,
-            GUI_WX: enable_wx,
-            GUI_QT: enable_qt4, # qt3 not supported
-            GUI_QT4: enable_qt4,
-            GUI_GLUT: enable_glut,
-            GUI_PYGLET: enable_pyglet,
-            GUI_GTK3: enable_gtk3,
-            }
     try:
         gui_hook = guis[gui]
     except KeyError:


### PR DESCRIPTION
typo prevented `--gui tk` from working, even though it is supported. Should
prevent similar bugs in the future.

closes #4156

should be backported to 1.1
