### PR TITLE
Select name when renaming a notebook

### DIFF
--- a/IPython/html/static/notebook/js/savewidget.js
+++ b/IPython/html/static/notebook/js/savewidget.js
@@ -52,7 +52,7 @@ var IPython = (function (IPython) {
         $([IPython.events]).on('checkpoints_listed.Notebook', function (event, data) {
             that.set_last_checkpoint(data[0]);
         });
-        
+
         $([IPython.events]).on('checkpoint_created.Notebook', function (event, data) {
             that.set_last_checkpoint(data);
         });
@@ -104,7 +104,7 @@ var IPython = (function (IPython) {
                         return false;
                     }
                 });
-                that.find('input[type="text"]').focus();
+                that.find('input[type="text"]').focus().select();
             }
         });
     }

--- a/docs/source/whatsnew/pr/select-notebook-rename.rst
+++ b/docs/source/whatsnew/pr/select-notebook-rename.rst
@@ -1,0 +1,6 @@
+Select Notebook Name When Renaming a Notebook
+---------------------------------------------
+
+The default notebook name is Untitled. It's unlikely you want to keep this name
+or part of it when naming your notebook. Instead, IPython will select the text
+in the input field so the user can easily type over the name and change it.


### PR DESCRIPTION
The default notebook name is `Untitled<x>`. It is unlikely the user will want to
keep this name or part of it. Instead, select the text in the input field when renaming, so the
user can easily type over the name and change it.

To test this change, create a new notebook, then click on the title "Untitled0" or similar to rename it. Instead of the cursor waiting at the end of the line, the text field should be selected, for easier changing.
