### PR TITLE
various issues in markdown and rst templates

### DIFF
--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -68,7 +68,8 @@ default_filters = {
         'strip_math_space': filters.strip_math_space,
         'wrap_text': filters.wrap_text,
         'escape_latex': filters.escape_latex,
-        'citation2latex': filters.citation2latex
+        'citation2latex': filters.citation2latex,
+        'path2url': filters.path2url,
 }
 
 #-----------------------------------------------------------------------------

--- a/IPython/nbconvert/exporters/markdown.py
+++ b/IPython/nbconvert/exporters/markdown.py
@@ -13,6 +13,7 @@ Exporter that will export your ipynb to Markdown.
 # Imports
 #-----------------------------------------------------------------------------
 
+from IPython.config import Config
 from IPython.utils.traitlets import Unicode
 
 from .exporter import Exporter
@@ -29,3 +30,9 @@ class MarkdownExporter(Exporter):
     file_extension = Unicode(
         'md', config=True, 
         help="Extension of the file that should be written to disk")
+
+    @property
+    def default_config(self):
+        c = Config({'ExtractOutputPreprocessor':{'enabled':True}})
+        c.merge(super(MarkdownExporter,self).default_config)
+        return c

--- a/IPython/nbconvert/filters/strings.py
+++ b/IPython/nbconvert/filters/strings.py
@@ -19,6 +19,7 @@ templates.
 import os
 import re
 import textwrap
+from urllib2 import quote
 from xml.etree import ElementTree
 
 from IPython.core.interactiveshell import InteractiveShell
@@ -38,6 +39,7 @@ __all__ = [
     'get_lines',
     'ipython2python',
     'posix_path',
+    'path2url',
 ]
 
 
@@ -181,3 +183,8 @@ def posix_path(path):
     if os.path.sep != '/':
         return path.replace(os.path.sep, '/')
     return path
+
+def path2url(path):
+    """Turn a file path into a URL"""
+    parts = path.split(os.path.sep)
+    return '/'.join(quote(part) for part in parts)

--- a/IPython/nbconvert/templates/latex/sphinx.tplx
+++ b/IPython/nbconvert/templates/latex/sphinx.tplx
@@ -362,7 +362,7 @@ Note: For best display, use latex syntax highlighting. =))
 ((*- endblock -*))
 
 ((*- block data_jpg -*))
-((( conditionally_center_output(insert_graphics(output.jpg_filename | posix_path)) )))
+((( conditionally_center_output(insert_graphics(output.jpeg_filename | posix_path)) )))
 ((*- endblock -*))
 
 ((*- block data_svg -*))

--- a/IPython/nbconvert/templates/markdown.tpl
+++ b/IPython/nbconvert/templates/markdown.tpl
@@ -2,19 +2,13 @@
 
 
 {% block in_prompt %}
-In[{{ cell.prompt_number if cell.prompt_number else ' ' }}]:
 {% endblock in_prompt %}
 
 {% block output_prompt %}
-{% if cell.haspyout %}
-Out[{{ cell.prompt_number }}]:
-{%- endif %}
 {%- endblock output_prompt %}
 
 {% block input %}
-```
-{{ cell.input }}
-```
+{{ cell.input | indent(4)}}
 {% endblock input %}
 
 {% block pyerr %}
@@ -26,6 +20,7 @@ Out[{{ cell.prompt_number }}]:
 {% endblock traceback_line %}
 
 {% block pyout %}
+
 {% block data_priority scoped %}
 {{ super() }}
 {% endblock %}
@@ -48,10 +43,12 @@ Out[{{ cell.prompt_number }}]:
 {% endblock data_jpg %}
 
 {% block data_latex %}
-$$
 {{ output.latex }}
-$$
 {% endblock data_latex %}
+
+{% block data_html scoped %}
+{{ output.html }}
+{% endblock data_html %}
 
 {% block data_text scoped %}
 {{ output.text | indent }}
@@ -60,6 +57,7 @@ $$
 {% block markdowncell scoped %}
 {{ cell.source | wrap_text(80) }}
 {% endblock markdowncell %}
+
 
 {% block headingcell scoped %}
 {{ '#' * cell.level }} {{ cell.source | replace('\n', ' ') }}

--- a/IPython/nbconvert/templates/markdown.tpl
+++ b/IPython/nbconvert/templates/markdown.tpl
@@ -31,15 +31,15 @@
 {% endblock stream %}
 
 {% block data_svg %}
-[!image]({{ output.svg_filename }})
+![svg]({{ output.svg_filename | path2url }})
 {% endblock data_svg %}
 
 {% block data_png %}
-[!image]({{ output.png_filename }})
+![png]({{ output.png_filename | path2url }})
 {% endblock data_png %}
 
 {% block data_jpg %}
-[!image]({{ output.jpg_filename }})
+![jpeg]({{ output.jpeg_filename | path2url }})
 {% endblock data_jpg %}
 
 {% block data_latex %}

--- a/IPython/nbconvert/templates/rst.tpl
+++ b/IPython/nbconvert/templates/rst.tpl
@@ -2,25 +2,22 @@
 
 
 {% block in_prompt %}
-
-In[{{ cell.prompt_number if cell.prompt_number else ' ' }}]:
-
-.. code:: python
-
 {% endblock in_prompt %}
 
 {% block output_prompt %}
-{% if cell.haspyout -%}
-    Out[{{ cell.prompt_number }}]:
-{% endif %}
 {% endblock output_prompt %}
 
 {% block input %}
+{%- if not cell.input.isspace() -%}
+.. code:: python
+
 {{ cell.input | indent}}
+{%- endif -%}
 {% endblock input %}
 
 {% block pyerr %}
 ::
+
 {{ super() }}
 {% endblock pyerr %}
 
@@ -49,18 +46,26 @@ In[{{ cell.prompt_number if cell.prompt_number else ' ' }}]:
 {% endblock data_png %}
 
 {% block data_jpg %}
-..jpg image:: {{ output.jpg_filename }}
+.. image:: {{ output.jpeg_filename }}
 {% endblock data_jpg %}
 
 {% block data_latex %}
 .. math::
-{{ output.latex | indent }}
+
+{{ output.latex | strip_dollars | indent }}
 {% endblock data_latex %}
 
 {% block data_text scoped %}
 .. parsed-literal::
+
 {{ output.text | indent }}
 {% endblock data_text %}
+
+{% block data_html scoped %}
+.. raw:: html
+
+{{ output.html | indent }}
+{% endblock data_html %}
 
 {% block markdowncell scoped %}
 {{ cell.source | markdown2rst }}


### PR DESCRIPTION
- remove prompts from default output
- add missing HTML block
- remove double-wrapping of latex
- use plain-markdown indentation for code blocks (could use GFM `` ` `python`)
- images didn't work in either one at all
- markdown extracts output

closes #4024

candidate for backport to 1.1
