### PR TITLE
Iptest refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ before_install:
 install:
     - python setup.py install -q 
 script:
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.'* ]]; then iptest -w /tmp; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.'* ]]; then iptest3 -w /tmp; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.'* ]]; then iptest; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.'* ]]; then iptest3; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ before_install:
 install:
     - python setup.py install -q 
 script:
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.'* ]]; then iptest; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.'* ]]; then iptest3; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.'* ]]; then cd /tmp; iptest; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.'* ]]; then cd /tmp; iptest3; fi

--- a/IPython/core/tests/test_debugger.py
+++ b/IPython/core/tests/test_debugger.py
@@ -118,7 +118,6 @@ def test_ipdb_magics():
     Type:       ExampleClass
     String Form:ExampleClass()
     Namespace:  Locals
-    File:       ...
     Docstring:  Docstring for ExampleClass.
     Constructor Docstring:Docstring for ExampleClass.__init__
     ipdb> continue

--- a/IPython/core/tests/test_debugger.py
+++ b/IPython/core/tests/test_debugger.py
@@ -117,7 +117,7 @@ def test_ipdb_magics():
     ipdb> pinfo a
     Type:       ExampleClass
     String Form:ExampleClass()
-    Namespace:  Locals
+    Namespace:  Local...
     Docstring:  Docstring for ExampleClass.
     Constructor Docstring:Docstring for ExampleClass.__init__
     ipdb> continue

--- a/IPython/scripts/iptest
+++ b/IPython/scripts/iptest
@@ -20,5 +20,5 @@ Exiting."""
     import sys
     print >> sys.stderr, error
 else:
-    from IPython.testing import iptest
-    iptest.main()
+    from IPython.testing import iptestcontroller
+    iptestcontroller.main()

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -43,10 +43,6 @@ from nose.plugins import Plugin
 
 # Our own imports
 from IPython.utils.importstring import import_item
-from IPython.utils.path import get_ipython_package_dir
-from IPython.utils.warn import warn
-
-from IPython.testing import globalipapp
 from IPython.testing.plugin.ipdoctest import IPythonDoctest
 from IPython.external.decorators import KnownFailure, knownfailureif
 
@@ -303,6 +299,8 @@ sec.exclude('exporters.tests.files')
 #-----------------------------------------------------------------------------
 
 def check_exclusions_exist():
+    from IPython.utils.path import get_ipython_package_dir
+    from IPython.utils.warn import warn
     parent = os.path.dirname(get_ipython_package_dir())
     for sec in test_sections:
         for pattern in sec.exclusions:
@@ -416,11 +414,12 @@ def run_iptest():
     # objects should, individual shells shouldn't).  But for now, this
     # workaround allows the test suite for the inprocess module to complete.
     if section.name != 'kernel.inprocess':
+        from IPython.testing import globalipapp
         globalipapp.start_ipython()
 
     # Now nose can run
     TestProgram(argv=argv, addplugins=plugins)
 
-
 if __name__ == '__main__':
     run_iptest()
+

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -293,6 +293,9 @@ sec.requires('pygments', 'jinja2', 'sphinx')
 # Executing the config files with iptest would cause an exception.
 sec.exclude('tests.files')
 sec.exclude('exporters.tests.files')
+if not have['tornado']:
+    sec.exclude('nbconvert.post_processors.serve')
+    sec.exclude('nbconvert.post_processors.tests.test_serve')
 
 #-----------------------------------------------------------------------------
 # Functions and classes

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -30,13 +30,8 @@ from __future__ import print_function
 import glob
 import os
 import os.path as path
-import signal
 import sys
-import subprocess
-import tempfile
-import time
 import warnings
-import multiprocessing.pool
 
 # Now, proceed to import nose itself
 import nose.plugins.builtin
@@ -45,12 +40,8 @@ from nose import SkipTest
 from nose.core import TestProgram
 
 # Our own imports
-from IPython.utils import py3compat
 from IPython.utils.importstring import import_item
-from IPython.utils.path import get_ipython_module_path, get_ipython_package_dir
-from IPython.utils.process import pycmd2argv
-from IPython.utils.sysinfo import sys_info
-from IPython.utils.tempdir import TemporaryDirectory
+from IPython.utils.path import get_ipython_package_dir
 from IPython.utils.warn import warn
 
 from IPython.testing import globalipapp
@@ -166,32 +157,6 @@ have['zmq'] = test_for('zmq.pyzmq_version_info', min_zmq, callback=lambda x: x()
 #-----------------------------------------------------------------------------
 # Functions and classes
 #-----------------------------------------------------------------------------
-
-def report():
-    """Return a string with a summary report of test-related variables."""
-
-    out = [ sys_info(), '\n']
-
-    avail = []
-    not_avail = []
-
-    for k, is_avail in have.items():
-        if is_avail:
-            avail.append(k)
-        else:
-            not_avail.append(k)
-
-    if avail:
-        out.append('\nTools and libraries available at test time:\n')
-        avail.sort()
-        out.append('   ' + ' '.join(avail)+'\n')
-
-    if not_avail:
-        out.append('\nTools and libraries NOT available at test time:\n')
-        not_avail.sort()
-        out.append('   ' + ' '.join(not_avail)+'\n')
-
-    return ''.join(out)
 
 
 def make_exclude():
@@ -325,160 +290,9 @@ def make_exclude():
 
     return exclusions
 
-
-class IPTester(object):
-    """Call that calls iptest or trial in a subprocess.
-    """
-    #: string, name of test runner that will be called
-    runner = None
-    #: list, parameters for test runner
-    params = None
-    #: list, arguments of system call to be made to call test runner
-    call_args = None
-    #: list, subprocesses we start (for cleanup)
-    processes = None
-    #: str, coverage xml output file
-    coverage_xml = None
-    buffer_output = False
-
-    def __init__(self, runner='iptest', params=None):
-        """Create new test runner."""
-        p = os.path
-        if runner == 'iptest':
-            iptest_app = os.path.abspath(get_ipython_module_path('IPython.testing.iptest'))
-            self.runner = pycmd2argv(iptest_app) + sys.argv[1:]
-        else:
-            raise Exception('Not a valid test runner: %s' % repr(runner))
-        if params is None:
-            params = []
-        if isinstance(params, str):
-            params = [params]
-        self.params = params
-
-        # Assemble call
-        self.call_args = self.runner+self.params
-        
-        # Find the section we're testing (IPython.foo)
-        for sect in self.params:
-            if sect.startswith('IPython') or sect in special_test_suites: break
-        else:
-            raise ValueError("Section not found", self.params)
-        
-        if '--with-xunit' in self.call_args:
-            
-            self.call_args.append('--xunit-file')
-            # FIXME: when Windows uses subprocess.call, these extra quotes are unnecessary:
-            xunit_file = path.abspath(sect+'.xunit.xml')
-            if sys.platform == 'win32':
-                xunit_file = '"%s"' % xunit_file
-            self.call_args.append(xunit_file)
-        
-        if '--with-xml-coverage' in self.call_args:
-            self.coverage_xml = path.abspath(sect+".coverage.xml")
-            self.call_args.remove('--with-xml-coverage')
-            self.call_args = ["coverage", "run", "--source="+sect] + self.call_args[1:]
-
-        # Store anything we start to clean up on deletion
-        self.processes = []
-
-    def _run_cmd(self):
-        with TemporaryDirectory() as IPYTHONDIR:
-            env = os.environ.copy()
-            env['IPYTHONDIR'] = IPYTHONDIR
-            # print >> sys.stderr, '*** CMD:', ' '.join(self.call_args) # dbg
-            output = subprocess.PIPE if self.buffer_output else None
-            subp = subprocess.Popen(self.call_args, stdout=output,
-                    stderr=output, env=env)
-            self.processes.append(subp)
-            # If this fails, the process will be left in self.processes and
-            # cleaned up later, but if the wait call succeeds, then we can
-            # clear the stored process.
-            retcode = subp.wait()
-            self.processes.pop()
-            self.stdout = subp.stdout
-            self.stderr = subp.stderr
-            return retcode
-
-    def run(self):
-        """Run the stored commands"""
-        try:
-            retcode = self._run_cmd()
-        except KeyboardInterrupt:
-            return -signal.SIGINT
-        except:
-            import traceback
-            traceback.print_exc()
-            return 1  # signal failure
-        
-        if self.coverage_xml:
-            subprocess.call(["coverage", "xml", "-o", self.coverage_xml])
-        return retcode
-
-    def __del__(self):
-        """Cleanup on exit by killing any leftover processes."""
-        for subp in self.processes:
-            if subp.poll() is not None:
-                continue # process is already dead
-
-            try:
-                print('Cleaning up stale PID: %d' % subp.pid)
-                subp.kill()
-            except: # (OSError, WindowsError) ?
-                # This is just a best effort, if we fail or the process was
-                # really gone, ignore it.
-                pass
-            else:
-                for i in range(10):
-                    if subp.poll() is None:
-                        time.sleep(0.1)
-                    else:
-                        break
-
-            if subp.poll() is None:
-                # The process did not die...
-                print('... failed. Manual cleanup may be required.')
-
-
 special_test_suites = {
     'autoreload': ['IPython.extensions.autoreload', 'IPython.extensions.tests.test_autoreload'],
 }
-                
-def make_runners(inc_slow=False):
-    """Define the top-level packages that need to be tested.
-    """
-
-    # Packages to be tested via nose, that only depend on the stdlib
-    nose_pkg_names = ['config', 'core', 'extensions', 'lib', 'terminal',
-                      'testing', 'utils', 'nbformat']
-
-    if have['qt']:
-        nose_pkg_names.append('qt')
-
-    if have['tornado']:
-        nose_pkg_names.append('html')
-        
-    if have['zmq']:
-        nose_pkg_names.insert(0, 'kernel')
-        nose_pkg_names.insert(1, 'kernel.inprocess')
-        if inc_slow:
-            nose_pkg_names.insert(0, 'parallel')
-
-    if all((have['pygments'], have['jinja2'], have['sphinx'])):
-        nose_pkg_names.append('nbconvert')
-
-    # For debugging this code, only load quick stuff
-    #nose_pkg_names = ['core', 'extensions']  # dbg
-
-    # Make fully qualified package names prepending 'IPython.' to our name lists
-    nose_packages = ['IPython.%s' % m for m in nose_pkg_names ]
-
-    # Make runners
-    runners = [ (v, IPTester('iptest', params=v)) for v in nose_packages ]
-    
-    for name in special_test_suites:
-        runners.append((name, IPTester('iptest', params=name)))
-
-    return runners
 
 
 def run_iptest():
@@ -546,111 +360,6 @@ def run_iptest():
     # Now nose can run
     TestProgram(argv=argv, addplugins=plugins)
 
-def do_run(x):
-    print('IPython test group:',x[0])
-    ret = x[1].run()
-    return ret
-
-def run_iptestall(inc_slow=False, fast=False):
-    """Run the entire IPython test suite by calling nose and trial.
-
-    This function constructs :class:`IPTester` instances for all IPython
-    modules and package and then runs each of them.  This causes the modules
-    and packages of IPython to be tested each in their own subprocess using
-    nose.
-    
-    Parameters
-    ----------
-    
-    inc_slow : bool, optional
-      Include slow tests, like IPython.parallel. By default, these tests aren't
-      run.
-
-    fast : bool, option
-      Run the test suite in parallel, if True, using as many threads as there
-      are processors
-    """
-    if fast:
-        p = multiprocessing.pool.ThreadPool()
-    else:
-        p = multiprocessing.pool.ThreadPool(1)
-
-    runners = make_runners(inc_slow=inc_slow)
-
-    # Run the test runners in a temporary dir so we can nuke it when finished
-    # to clean up any junk files left over by accident.  This also makes it
-    # robust against being run in non-writeable directories by mistake, as the
-    # temp dir will always be user-writeable.
-    curdir = os.getcwdu()
-    testdir = tempfile.gettempdir()
-    os.chdir(testdir)
-
-    # Run all test runners, tracking execution time
-    failed = []
-    t_start = time.time()
-
-    try:
-        all_res = p.map(do_run, runners)
-        print('*'*70)
-        for ((name, runner), res) in zip(runners, all_res):
-            tgroup = 'IPython test group: ' + name
-            res_string = 'OK' if res == 0 else 'FAILED'
-            res_string = res_string.rjust(70 - len(tgroup), '.')
-            print(tgroup + res_string)
-            if res:
-                failed.append( (name, runner) )
-                if res == -signal.SIGINT:
-                    print("Interrupted")
-                    break
-    finally:
-        os.chdir(curdir)
-    t_end = time.time()
-    t_tests = t_end - t_start
-    nrunners = len(runners)
-    nfail = len(failed)
-    # summarize results
-    print()
-    print('*'*70)
-    print('Test suite completed for system with the following information:')
-    print(report())
-    print('Ran %s test groups in %.3fs' % (nrunners, t_tests))
-    print()
-    print('Status:')
-    if not failed:
-        print('OK')
-    else:
-        # If anything went wrong, point out what command to rerun manually to
-        # see the actual errors and individual summary
-        print('ERROR - %s out of %s test groups failed.' % (nfail, nrunners))
-        for name, failed_runner in failed:
-            print('-'*40)
-            print('Runner failed:',name)
-            print('You may wish to rerun this one individually, with:')
-            failed_call_args = [py3compat.cast_unicode(x) for x in failed_runner.call_args]
-            print(u' '.join(failed_call_args))
-            print()
-        # Ensure that our exit code indicates failure
-        sys.exit(1)
-
-
-def main():
-    for arg in sys.argv[1:]:
-        if arg.startswith('IPython') or arg in special_test_suites:
-            # This is in-process
-            run_iptest()
-    else:
-        inc_slow =  "--all" in sys.argv
-        if inc_slow:
-            sys.argv.remove("--all")
-
-        fast =  "--fast" in sys.argv
-        if fast:
-            sys.argv.remove("--fast")
-            IPTester.buffer_output = True
-
-        # This starts subprocesses
-        run_iptestall(inc_slow=inc_slow, fast=fast)
-
 
 if __name__ == '__main__':
-    main()
+    run_iptest()

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -368,8 +368,13 @@ def run_iptest():
     warnings.filterwarnings('ignore',
         'This will be removed soon.  Use IPython.testing.util instead')
     
-    section = test_sections[sys.argv[1]]
-    sys.argv[1:2] = section.includes
+    if sys.argv[1] in test_sections:
+        section = test_sections[sys.argv[1]]
+        sys.argv[1:2] = section.includes
+    else:
+        arg1 = sys.argv[1]
+        section = TestSection(arg1, includes=[arg1])
+        
 
     argv = sys.argv + [ '--detailed-errors',  # extra info in tracebacks
 
@@ -413,7 +418,7 @@ def run_iptest():
     # assumptions about what needs to be a singleton and what doesn't (app
     # objects should, individual shells shouldn't).  But for now, this
     # workaround allows the test suite for the inprocess module to complete.
-    if section.name != 'kernel.inprocess':
+    if 'kernel.inprocess' not in section.name:
         from IPython.testing import globalipapp
         globalipapp.start_ipython()
 

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -368,11 +368,14 @@ def run_iptest():
     warnings.filterwarnings('ignore',
         'This will be removed soon.  Use IPython.testing.util instead')
     
-    if sys.argv[1] in test_sections:
-        section = test_sections[sys.argv[1]]
+    arg1 = sys.argv[1]
+    if arg1 in test_sections:
+        section = test_sections[arg1]
+        sys.argv[1:2] = section.includes
+    elif arg1.startswith('IPython.') and arg1[8:] in test_sections:
+        section = test_sections[arg1[8:]]
         sys.argv[1:2] = section.includes
     else:
-        arg1 = sys.argv[1]
         section = TestSection(arg1, includes=[arg1])
         
 

--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -18,93 +18,67 @@ test suite.
 #-----------------------------------------------------------------------------
 from __future__ import print_function
 
+import argparse
 import multiprocessing.pool
 import os
 import signal
 import sys
 import subprocess
-import tempfile
 import time
 
-from .iptest import have, special_test_suites
+from .iptest import have, test_group_names, test_sections
 from IPython.utils import py3compat
-from IPython.utils.path import get_ipython_module_path
-from IPython.utils.process import pycmd2argv
 from IPython.utils.sysinfo import sys_info
 from IPython.utils.tempdir import TemporaryDirectory
 
 
-class IPTester(object):
-    """Call that calls iptest or trial in a subprocess.
+class IPTestController(object):
+    """Run iptest in a subprocess
     """
-    #: string, name of test runner that will be called
-    runner = None
-    #: list, parameters for test runner
-    params = None
-    #: list, arguments of system call to be made to call test runner
-    call_args = None
-    #: list, subprocesses we start (for cleanup)
-    processes = None
-    #: str, coverage xml output file
-    coverage_xml = None
+    #: str, IPython test suite to be executed.
+    section = None
+    #: list, command line arguments to be executed
+    cmd = None
+    #: dict, extra environment variables to set for the subprocess
+    env = None
+    #: list, TemporaryDirectory instances to clear up when the process finishes
+    dirs = None
+    #: subprocess.Popen instance
+    process = None
     buffer_output = False
 
-    def __init__(self, runner='iptest', params=None):
+    def __init__(self, section):
         """Create new test runner."""
-        if runner == 'iptest':
-            iptest_app = os.path.abspath(get_ipython_module_path('IPython.testing.iptest'))
-            self.runner = pycmd2argv(iptest_app) + sys.argv[1:]
-        else:
-            raise Exception('Not a valid test runner: %s' % repr(runner))
-        if params is None:
-            params = []
-        if isinstance(params, str):
-            params = [params]
-        self.params = params
-
-        # Assemble call
-        self.call_args = self.runner+self.params
+        self.section = section
+        self.cmd = [sys.executable, '-m', 'IPython.testing.iptest', section]
+        self.env = {}
+        self.dirs = []
+        ipydir = TemporaryDirectory()
+        self.dirs.append(ipydir)
+        self.env['IPYTHONDIR'] = ipydir.name
+        workingdir = TemporaryDirectory()
+        self.dirs.append(workingdir)
+        self.env['IPTEST_WORKING_DIR'] = workingdir.name
+    
+    def add_xunit(self):
+        xunit_file = os.path.abspath(self.section + '.xunit.xml')
+        self.cmd.extend(['--with-xunit', '--xunit-file', xunit_file])
+    
+    def add_coverage(self, xml=True):
+        self.cmd.extend(['--with-coverage', '--cover-package', self.section])
+        if xml:
+            coverage_xml = os.path.abspath(self.section + ".coverage.xml")
+            self.cmd.extend(['--cover-xml', '--cover-xml-file', coverage_xml])
         
-        # Find the section we're testing (IPython.foo)
-        for sect in self.params:
-            if sect.startswith('IPython') or sect in special_test_suites: break
-        else:
-            raise ValueError("Section not found", self.params)
-        
-        if '--with-xunit' in self.call_args:
-            
-            self.call_args.append('--xunit-file')
-            # FIXME: when Windows uses subprocess.call, these extra quotes are unnecessary:
-            xunit_file = os.path.abspath(sect+'.xunit.xml')
-            if sys.platform == 'win32':
-                xunit_file = '"%s"' % xunit_file
-            self.call_args.append(xunit_file)
-        
-        if '--with-xml-coverage' in self.call_args:
-            self.coverage_xml = os.path.abspath(sect+".coverage.xml")
-            self.call_args.remove('--with-xml-coverage')
-            self.call_args = ["coverage", "run", "--source="+sect] + self.call_args[1:]
 
-        # Store anything we start to clean up on deletion
-        self.processes = []
-
-    def _run_cmd(self):
-        with TemporaryDirectory() as IPYTHONDIR:
-            env = os.environ.copy()
-            env['IPYTHONDIR'] = IPYTHONDIR
-            # print >> sys.stderr, '*** CMD:', ' '.join(self.call_args) # dbg
-            output = subprocess.PIPE if self.buffer_output else None
-            subp = subprocess.Popen(self.call_args, stdout=output,
-                    stderr=output, env=env)
-            self.processes.append(subp)
-            # If this fails, the process will be left in self.processes and
-            # cleaned up later, but if the wait call succeeds, then we can
-            # clear the stored process.
-            retcode = subp.wait()
-            self.processes.pop()
-            self.stdout = subp.stdout
-            self.stderr = subp.stderr
-            return retcode
+    def launch(self):
+        # print('*** ENV:', self.env)  # dbg
+        # print('*** CMD:', self.cmd)  # dbg
+        env = os.environ.copy()
+        env.update(self.env)
+        output = subprocess.PIPE if self.buffer_output else None
+        self.process = subprocess.Popen(self.cmd, stdout=output,
+                stderr=output, env=env)
 
     def run(self):
         """Run the stored commands"""
@@ -121,71 +95,61 @@ class IPTester(object):
             subprocess.call(["coverage", "xml", "-o", self.coverage_xml])
         return retcode
 
-    def __del__(self):
+    def cleanup(self):
         """Cleanup on exit by killing any leftover processes."""
-        for subp in self.processes:
-            if subp.poll() is not None:
-                continue # process is already dead
+        subp = self.process
+        if subp is None or (subp.poll() is not None):
+            return  # Process doesn't exist, or is already dead.
 
-            try:
-                print('Cleaning up stale PID: %d' % subp.pid)
-                subp.kill()
-            except: # (OSError, WindowsError) ?
-                # This is just a best effort, if we fail or the process was
-                # really gone, ignore it.
-                pass
-            else:
-                for i in range(10):
-                    if subp.poll() is None:
-                        time.sleep(0.1)
-                    else:
-                        break
+        try:
+            print('Cleaning up stale PID: %d' % subp.pid)
+            subp.kill()
+        except: # (OSError, WindowsError) ?
+            # This is just a best effort, if we fail or the process was
+            # really gone, ignore it.
+            pass
+        else:
+            for i in range(10):
+                if subp.poll() is None:
+                    time.sleep(0.1)
+                else:
+                    break
 
-            if subp.poll() is None:
-                # The process did not die...
-                print('... failed. Manual cleanup may be required.')
-
-def make_runners(inc_slow=False):
-    """Define the top-level packages that need to be tested.
-    """
-
-    # Packages to be tested via nose, that only depend on the stdlib
-    nose_pkg_names = ['config', 'core', 'extensions', 'lib', 'terminal',
-                      'testing', 'utils', 'nbformat']
-
-    if have['qt']:
-        nose_pkg_names.append('qt')
-
-    if have['tornado']:
-        nose_pkg_names.append('html')
+        if subp.poll() is None:
+            # The process did not die...
+            print('... failed. Manual cleanup may be required.')
         
-    if have['zmq']:
-        nose_pkg_names.insert(0, 'kernel')
-        nose_pkg_names.insert(1, 'kernel.inprocess')
-        if inc_slow:
-            nose_pkg_names.insert(0, 'parallel')
-
-    if all((have['pygments'], have['jinja2'], have['sphinx'])):
-        nose_pkg_names.append('nbconvert')
-
-    # For debugging this code, only load quick stuff
-    #nose_pkg_names = ['core', 'extensions']  # dbg
-
-    # Make fully qualified package names prepending 'IPython.' to our name lists
-    nose_packages = ['IPython.%s' % m for m in nose_pkg_names ]
-
-    # Make runners
-    runners = [ (v, IPTester('iptest', params=v)) for v in nose_packages ]
+        for td in self.dirs:
+            td.cleanup()
     
-    for name in special_test_suites:
-        runners.append((name, IPTester('iptest', params=name)))
+    __del__ = cleanup
 
-    return runners
+def test_controllers_to_run(inc_slow=False):
+    """Returns an ordered list of IPTestController instances to be run."""
+    res = []
+    if not inc_slow:
+        test_sections['parallel'].enabled = False
+    for name in test_group_names:
+        if test_sections[name].will_run:
+            res.append(IPTestController(name))
+    return res
 
-def do_run(x):
-    print('IPython test group:',x[0])
-    ret = x[1].run()
-    return ret
+def do_run(controller):
+    try:
+        try:
+            controller.launch()
+        except Exception:
+            import traceback
+            traceback.print_exc()
+            return controller, 1  # signal failure
+    
+        exitcode = controller.process.wait()
+        controller.cleanup()
+        return controller, exitcode
+    
+    except KeyboardInterrupt:
+        controller.cleanup()
+        return controller, -signal.SIGINT
 
 def report():
     """Return a string with a summary report of test-related variables."""
@@ -213,7 +177,7 @@ def report():
 
     return ''.join(out)
 
-def run_iptestall(inc_slow=False, fast=False):
+def run_iptestall(inc_slow=False, jobs=1, xunit=False, coverage=False):
     """Run the entire IPython test suite by calling nose and trial.
 
     This function constructs :class:`IPTester` instances for all IPython
@@ -232,43 +196,31 @@ def run_iptestall(inc_slow=False, fast=False):
       Run the test suite in parallel, if True, using as many threads as there
       are processors
     """
-    if fast:
-        p = multiprocessing.pool.ThreadPool()
-    else:
-        p = multiprocessing.pool.ThreadPool(1)
+    pool = multiprocessing.pool.ThreadPool(jobs)
+    if jobs != 1:
+        IPTestController.buffer_output = True
 
-    runners = make_runners(inc_slow=inc_slow)
-
-    # Run the test runners in a temporary dir so we can nuke it when finished
-    # to clean up any junk files left over by accident.  This also makes it
-    # robust against being run in non-writeable directories by mistake, as the
-    # temp dir will always be user-writeable.
-    curdir = os.getcwdu()
-    testdir = tempfile.gettempdir()
-    os.chdir(testdir)
+    controllers = test_controllers_to_run(inc_slow=inc_slow)
 
     # Run all test runners, tracking execution time
     failed = []
     t_start = time.time()
 
-    try:
-        all_res = p.map(do_run, runners)
-        print('*'*70)
-        for ((name, runner), res) in zip(runners, all_res):
-            tgroup = 'IPython test group: ' + name
-            res_string = 'OK' if res == 0 else 'FAILED'
-            res_string = res_string.rjust(70 - len(tgroup), '.')
-            print(tgroup + res_string)
-            if res:
-                failed.append( (name, runner) )
-                if res == -signal.SIGINT:
-                    print("Interrupted")
-                    break
-    finally:
-        os.chdir(curdir)
+    print('*'*70)
+    for (controller, res) in pool.imap_unordered(do_run, controllers):
+        tgroup = 'IPython test group: ' + controller.section
+        res_string = 'OK' if res == 0 else 'FAILED'
+        res_string = res_string.rjust(70 - len(tgroup), '.')
+        print(tgroup + res_string)
+        if res:
+            failed.append(controller)
+            if res == -signal.SIGINT:
+                print("Interrupted")
+                break
+    
     t_end = time.time()
     t_tests = t_end - t_start
-    nrunners = len(runners)
+    nrunners = len(controllers)
     nfail = len(failed)
     # summarize results
     print()
@@ -284,11 +236,11 @@ def run_iptestall(inc_slow=False, fast=False):
         # If anything went wrong, point out what command to rerun manually to
         # see the actual errors and individual summary
         print('ERROR - %s out of %s test groups failed.' % (nfail, nrunners))
-        for name, failed_runner in failed:
+        for controller in failed:
             print('-'*40)
-            print('Runner failed:',name)
+            print('Runner failed:', controller.section)
             print('You may wish to rerun this one individually, with:')
-            failed_call_args = [py3compat.cast_unicode(x) for x in failed_runner.call_args]
+            failed_call_args = [py3compat.cast_unicode(x) for x in controller.cmd]
             print(u' '.join(failed_call_args))
             print()
         # Ensure that our exit code indicates failure
@@ -296,23 +248,27 @@ def run_iptestall(inc_slow=False, fast=False):
 
 
 def main():
-    for arg in sys.argv[1:]:
-        if arg.startswith('IPython') or arg in special_test_suites:
-            from .iptest import run_iptest
-            # This is in-process
-            run_iptest()
-    else:
-        inc_slow =  "--all" in sys.argv
-        if inc_slow:
-            sys.argv.remove("--all")
+    if len(sys.argv) > 1 and (sys.argv[1] in test_sections):
+        from .iptest import run_iptest
+        # This is in-process
+        run_iptest()
+        return
+            
+    parser = argparse.ArgumentParser(description='Run IPython test suite')
+    parser.add_argument('--all', action='store_true',
+                        help='Include slow tests not run by default.')
+    parser.add_argument('-j', '--fast', nargs='?', const=None, default=1,
+                        help='Run test sections in parallel.')
+    parser.add_argument('--xunit', action='store_true',
+                        help='Produce Xunit XML results')
+    parser.add_argument('--coverage', action='store_true',
+                        help='Measure test coverage.')
 
-        fast =  "--fast" in sys.argv
-        if fast:
-            sys.argv.remove("--fast")
-            IPTester.buffer_output = True
+    options = parser.parse_args()
 
-        # This starts subprocesses
-        run_iptestall(inc_slow=inc_slow, fast=fast)
+    # This starts subprocesses
+    run_iptestall(inc_slow=options.all, jobs=options.fast,
+                  xunit=options.xunit, coverage=options.coverage)
 
 
 if __name__ == '__main__':

--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -28,6 +28,7 @@ import subprocess
 import time
 
 from .iptest import have, test_group_names, test_sections
+from IPython.utils.py3compat import bytes_to_str
 from IPython.utils.sysinfo import sys_info
 from IPython.utils.tempdir import TemporaryDirectory
 
@@ -269,7 +270,7 @@ def run_iptestall(inc_slow=False, jobs=1, xunit_out=False, coverage_out=False):
                 res_string = 'OK' if res == 0 else 'FAILED'
                 print(justify('IPython test group: ' + controller.section, res_string))
                 if res:
-                    print(controller.stdout)
+                    print(bytes_to_str(controller.stdout))
                     failed.append(controller)
                     if res == -signal.SIGINT:
                         print("Interrupted")

--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -1,0 +1,319 @@
+# -*- coding: utf-8 -*-
+"""IPython Test Process Controller
+
+This module runs one or more subprocesses which will actually run the IPython
+test suite.
+
+"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2009-2011  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+from __future__ import print_function
+
+import multiprocessing.pool
+import os
+import signal
+import sys
+import subprocess
+import tempfile
+import time
+
+from .iptest import have, special_test_suites
+from IPython.utils import py3compat
+from IPython.utils.path import get_ipython_module_path
+from IPython.utils.process import pycmd2argv
+from IPython.utils.sysinfo import sys_info
+from IPython.utils.tempdir import TemporaryDirectory
+
+
+class IPTester(object):
+    """Call that calls iptest or trial in a subprocess.
+    """
+    #: string, name of test runner that will be called
+    runner = None
+    #: list, parameters for test runner
+    params = None
+    #: list, arguments of system call to be made to call test runner
+    call_args = None
+    #: list, subprocesses we start (for cleanup)
+    processes = None
+    #: str, coverage xml output file
+    coverage_xml = None
+    buffer_output = False
+
+    def __init__(self, runner='iptest', params=None):
+        """Create new test runner."""
+        if runner == 'iptest':
+            iptest_app = os.path.abspath(get_ipython_module_path('IPython.testing.iptest'))
+            self.runner = pycmd2argv(iptest_app) + sys.argv[1:]
+        else:
+            raise Exception('Not a valid test runner: %s' % repr(runner))
+        if params is None:
+            params = []
+        if isinstance(params, str):
+            params = [params]
+        self.params = params
+
+        # Assemble call
+        self.call_args = self.runner+self.params
+        
+        # Find the section we're testing (IPython.foo)
+        for sect in self.params:
+            if sect.startswith('IPython') or sect in special_test_suites: break
+        else:
+            raise ValueError("Section not found", self.params)
+        
+        if '--with-xunit' in self.call_args:
+            
+            self.call_args.append('--xunit-file')
+            # FIXME: when Windows uses subprocess.call, these extra quotes are unnecessary:
+            xunit_file = os.path.abspath(sect+'.xunit.xml')
+            if sys.platform == 'win32':
+                xunit_file = '"%s"' % xunit_file
+            self.call_args.append(xunit_file)
+        
+        if '--with-xml-coverage' in self.call_args:
+            self.coverage_xml = os.path.abspath(sect+".coverage.xml")
+            self.call_args.remove('--with-xml-coverage')
+            self.call_args = ["coverage", "run", "--source="+sect] + self.call_args[1:]
+
+        # Store anything we start to clean up on deletion
+        self.processes = []
+
+    def _run_cmd(self):
+        with TemporaryDirectory() as IPYTHONDIR:
+            env = os.environ.copy()
+            env['IPYTHONDIR'] = IPYTHONDIR
+            # print >> sys.stderr, '*** CMD:', ' '.join(self.call_args) # dbg
+            output = subprocess.PIPE if self.buffer_output else None
+            subp = subprocess.Popen(self.call_args, stdout=output,
+                    stderr=output, env=env)
+            self.processes.append(subp)
+            # If this fails, the process will be left in self.processes and
+            # cleaned up later, but if the wait call succeeds, then we can
+            # clear the stored process.
+            retcode = subp.wait()
+            self.processes.pop()
+            self.stdout = subp.stdout
+            self.stderr = subp.stderr
+            return retcode
+
+    def run(self):
+        """Run the stored commands"""
+        try:
+            retcode = self._run_cmd()
+        except KeyboardInterrupt:
+            return -signal.SIGINT
+        except:
+            import traceback
+            traceback.print_exc()
+            return 1  # signal failure
+        
+        if self.coverage_xml:
+            subprocess.call(["coverage", "xml", "-o", self.coverage_xml])
+        return retcode
+
+    def __del__(self):
+        """Cleanup on exit by killing any leftover processes."""
+        for subp in self.processes:
+            if subp.poll() is not None:
+                continue # process is already dead
+
+            try:
+                print('Cleaning up stale PID: %d' % subp.pid)
+                subp.kill()
+            except: # (OSError, WindowsError) ?
+                # This is just a best effort, if we fail or the process was
+                # really gone, ignore it.
+                pass
+            else:
+                for i in range(10):
+                    if subp.poll() is None:
+                        time.sleep(0.1)
+                    else:
+                        break
+
+            if subp.poll() is None:
+                # The process did not die...
+                print('... failed. Manual cleanup may be required.')
+
+def make_runners(inc_slow=False):
+    """Define the top-level packages that need to be tested.
+    """
+
+    # Packages to be tested via nose, that only depend on the stdlib
+    nose_pkg_names = ['config', 'core', 'extensions', 'lib', 'terminal',
+                      'testing', 'utils', 'nbformat']
+
+    if have['qt']:
+        nose_pkg_names.append('qt')
+
+    if have['tornado']:
+        nose_pkg_names.append('html')
+        
+    if have['zmq']:
+        nose_pkg_names.insert(0, 'kernel')
+        nose_pkg_names.insert(1, 'kernel.inprocess')
+        if inc_slow:
+            nose_pkg_names.insert(0, 'parallel')
+
+    if all((have['pygments'], have['jinja2'], have['sphinx'])):
+        nose_pkg_names.append('nbconvert')
+
+    # For debugging this code, only load quick stuff
+    #nose_pkg_names = ['core', 'extensions']  # dbg
+
+    # Make fully qualified package names prepending 'IPython.' to our name lists
+    nose_packages = ['IPython.%s' % m for m in nose_pkg_names ]
+
+    # Make runners
+    runners = [ (v, IPTester('iptest', params=v)) for v in nose_packages ]
+    
+    for name in special_test_suites:
+        runners.append((name, IPTester('iptest', params=name)))
+
+    return runners
+
+def do_run(x):
+    print('IPython test group:',x[0])
+    ret = x[1].run()
+    return ret
+
+def report():
+    """Return a string with a summary report of test-related variables."""
+
+    out = [ sys_info(), '\n']
+
+    avail = []
+    not_avail = []
+
+    for k, is_avail in have.items():
+        if is_avail:
+            avail.append(k)
+        else:
+            not_avail.append(k)
+
+    if avail:
+        out.append('\nTools and libraries available at test time:\n')
+        avail.sort()
+        out.append('   ' + ' '.join(avail)+'\n')
+
+    if not_avail:
+        out.append('\nTools and libraries NOT available at test time:\n')
+        not_avail.sort()
+        out.append('   ' + ' '.join(not_avail)+'\n')
+
+    return ''.join(out)
+
+def run_iptestall(inc_slow=False, fast=False):
+    """Run the entire IPython test suite by calling nose and trial.
+
+    This function constructs :class:`IPTester` instances for all IPython
+    modules and package and then runs each of them.  This causes the modules
+    and packages of IPython to be tested each in their own subprocess using
+    nose.
+    
+    Parameters
+    ----------
+    
+    inc_slow : bool, optional
+      Include slow tests, like IPython.parallel. By default, these tests aren't
+      run.
+
+    fast : bool, option
+      Run the test suite in parallel, if True, using as many threads as there
+      are processors
+    """
+    if fast:
+        p = multiprocessing.pool.ThreadPool()
+    else:
+        p = multiprocessing.pool.ThreadPool(1)
+
+    runners = make_runners(inc_slow=inc_slow)
+
+    # Run the test runners in a temporary dir so we can nuke it when finished
+    # to clean up any junk files left over by accident.  This also makes it
+    # robust against being run in non-writeable directories by mistake, as the
+    # temp dir will always be user-writeable.
+    curdir = os.getcwdu()
+    testdir = tempfile.gettempdir()
+    os.chdir(testdir)
+
+    # Run all test runners, tracking execution time
+    failed = []
+    t_start = time.time()
+
+    try:
+        all_res = p.map(do_run, runners)
+        print('*'*70)
+        for ((name, runner), res) in zip(runners, all_res):
+            tgroup = 'IPython test group: ' + name
+            res_string = 'OK' if res == 0 else 'FAILED'
+            res_string = res_string.rjust(70 - len(tgroup), '.')
+            print(tgroup + res_string)
+            if res:
+                failed.append( (name, runner) )
+                if res == -signal.SIGINT:
+                    print("Interrupted")
+                    break
+    finally:
+        os.chdir(curdir)
+    t_end = time.time()
+    t_tests = t_end - t_start
+    nrunners = len(runners)
+    nfail = len(failed)
+    # summarize results
+    print()
+    print('*'*70)
+    print('Test suite completed for system with the following information:')
+    print(report())
+    print('Ran %s test groups in %.3fs' % (nrunners, t_tests))
+    print()
+    print('Status:')
+    if not failed:
+        print('OK')
+    else:
+        # If anything went wrong, point out what command to rerun manually to
+        # see the actual errors and individual summary
+        print('ERROR - %s out of %s test groups failed.' % (nfail, nrunners))
+        for name, failed_runner in failed:
+            print('-'*40)
+            print('Runner failed:',name)
+            print('You may wish to rerun this one individually, with:')
+            failed_call_args = [py3compat.cast_unicode(x) for x in failed_runner.call_args]
+            print(u' '.join(failed_call_args))
+            print()
+        # Ensure that our exit code indicates failure
+        sys.exit(1)
+
+
+def main():
+    for arg in sys.argv[1:]:
+        if arg.startswith('IPython') or arg in special_test_suites:
+            from .iptest import run_iptest
+            # This is in-process
+            run_iptest()
+    else:
+        inc_slow =  "--all" in sys.argv
+        if inc_slow:
+            sys.argv.remove("--all")
+
+        fast =  "--fast" in sys.argv
+        if fast:
+            sys.argv.remove("--fast")
+            IPTester.buffer_output = True
+
+        # This starts subprocesses
+        run_iptestall(inc_slow=inc_slow, fast=fast)
+
+
+if __name__ == '__main__':
+    main()

--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -349,7 +349,8 @@ def run_iptestall(inc_slow=False, jobs=1, xunit_out=False, coverage_out=False):
 
 
 def main():
-    if len(sys.argv) > 1 and (sys.argv[1] in test_sections):
+    if len(sys.argv) > 1 and \
+            ((sys.argv[1] in test_sections) or sys.argv[1].startswith('IPython')):
         from .iptest import run_iptest
         # This is in-process
         run_iptest()

--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -387,7 +387,7 @@ def main():
                         'all tests.')
     parser.add_argument('--all', action='store_true',
                         help='Include slow tests not run by default.')
-    parser.add_argument('-j', '--fast', nargs='?', const=None, default=1,
+    parser.add_argument('-j', '--fast', nargs='?', const=None, default=1, type=int,
                         help='Run test sections in parallel.')
     parser.add_argument('--xunit', action='store_true',
                         help='Produce Xunit XML results')
@@ -397,12 +397,6 @@ def main():
 
     options = parser.parse_args()
 
-    try:
-        options.fast = int(options.fast)
-    except TypeError:
-        pass
-
-    # This starts subprocesses
     run_iptestall(options)
 
 

--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -95,7 +95,7 @@ class IPTestController(object):
             subprocess.call(["coverage", "xml", "-o", self.coverage_xml])
         return retcode
 
-    def cleanup(self):
+    def cleanup_process(self):
         """Cleanup on exit by killing any leftover processes."""
         subp = self.process
         if subp is None or (subp.poll() is not None):
@@ -118,7 +118,10 @@ class IPTestController(object):
         if subp.poll() is None:
             # The process did not die...
             print('... failed. Manual cleanup may be required.')
-        
+    
+    def cleanup(self):
+        "Kill process if it's still alive, and clean up temporary directories"
+        self.cleanup_process()
         for td in self.dirs:
             td.cleanup()
     

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -597,23 +597,6 @@ class ExtensionDoctest(doctests.Doctest):
     name = 'extdoctest'   # call nosetests with --with-extdoctest
     enabled = True
 
-    def __init__(self,exclude_patterns=None):
-        """Create a new ExtensionDoctest plugin.
-
-        Parameters
-        ----------
-
-        exclude_patterns : sequence of strings, optional
-          These patterns are compiled as regular expressions, subsequently used
-          to exclude any filename which matches them from inclusion in the test
-          suite (using pattern.search(), NOT pattern.match() ).
-        """
-
-        if exclude_patterns is None:
-            exclude_patterns = []
-        self.exclude_patterns = map(re.compile,exclude_patterns)
-        doctests.Doctest.__init__(self)
-
     def options(self, parser, env=os.environ):
         Plugin.options(self, parser, env)
         parser.add_option('--doctest-tests', action='store_true',
@@ -715,35 +698,6 @@ class ExtensionDoctest(doctests.Doctest):
                     yield DocFileCase(test)
                 else:
                     yield False # no tests to load
-
-    def wantFile(self,filename):
-        """Return whether the given filename should be scanned for tests.
-
-        Modified version that accepts extension modules as valid containers for
-        doctests.
-        """
-        #print '*** ipdoctest- wantFile:',filename  # dbg
-
-        for pat in self.exclude_patterns:
-            if pat.search(filename):
-                # print '###>>> SKIP:',filename  # dbg
-                return False
-
-        if is_extension_module(filename):
-            return True
-        else:
-            return doctests.Doctest.wantFile(self,filename)
-
-    def wantDirectory(self, directory):
-        """Return whether the given directory should be scanned for tests.
-
-        Modified version that supports exclusions.
-        """
-
-        for pat in self.exclude_patterns:
-            if pat.search(directory):
-                return False
-        return True
 
 
 class IPythonDoctest(ExtensionDoctest):

--- a/IPython/utils/tempdir.py
+++ b/IPython/utils/tempdir.py
@@ -5,6 +5,8 @@ This is copied from the stdlib and will be standard in Python 3.2 and onwards.
 from __future__ import print_function
 
 import os as _os
+import warnings as _warnings
+import sys as _sys
 
 # This code should only be used in Python versions < 3.2, since after that we
 # can rely on the stdlib itself.
@@ -49,7 +51,7 @@ except ImportError:
                 self._closed = True
                 if _warn:
                     self._warn("Implicitly cleaning up {!r}".format(self),
-                               ResourceWarning)
+                               Warning)
 
         def __exit__(self, exc, value, tb):
             self.cleanup()
@@ -69,6 +71,7 @@ except ImportError:
         _remove = staticmethod(_os.remove)
         _rmdir = staticmethod(_os.rmdir)
         _os_error = _os.error
+        _warn = _warnings.warn
 
         def _rmtree(self, path):
             # Essentially a stripped down version of shutil.rmtree.  We can't

--- a/setupbase.py
+++ b/setupbase.py
@@ -323,7 +323,7 @@ def find_scripts(entry_points=False, suffix=''):
             'ipengine%s = IPython.parallel.apps.ipengineapp:launch_new_instance',
             'iplogger%s = IPython.parallel.apps.iploggerapp:launch_new_instance',
             'ipcluster%s = IPython.parallel.apps.ipclusterapp:launch_new_instance',
-            'iptest%s = IPython.testing.iptest:main',
+            'iptest%s = IPython.testing.iptestcontroller:main',
             'irunner%s = IPython.lib.irunner:main',
         ]]
         gui_scripts = []


### PR DESCRIPTION
This refactors iptest to bring it a bit more up to date. There's probably more work that can be done, but I think this is a good point to do a first PR on it.

The main changes:
- The machinery to run a testing subprocess has been split out into iptestcontroller and rationalised. Now you create an IPTestController instance, set up its command line arguments, Python code and environment variables, and then launch it.
- Command line parsing is now done by argparse, rather than lots of `if '--with-xunit' in argv:`. This makes it easier to add more options later, and also gives us simple ways to get combined coverage reports (and we should later be able to get coverage from subprocesses, but that's a question for another PR).
- Instead of a list of test groups and a list of exclusions, we now have a list of TestSection instances, each of which has inclusions and exclusions, as well as a list of requirements. This allows us to exclude tests from one section but include them in another (e.g. autoreload, kernel.inprocess) in a clean way. I've rearranged the specification of dependencies and exclusions to group them by section.
- Exclusions are now handled by a separate nose plugin (`ExclusionsPlugin`) rather than being an exciting side-effect of our ipdoctest plugin.
