### PR TITLE
nbconvert: Fix, sphinx template not removing new lines from headers

### DIFF
--- a/IPython/nbconvert/templates/latex/sphinx.tplx
+++ b/IPython/nbconvert/templates/latex/sphinx.tplx
@@ -232,7 +232,7 @@ Note: For best display, use latex syntax highlighting. =))
     in IPYNB file titles) do not make their way into latex.  Sometimes this
     causes latex to barf. =))
     ((*- endif -*))
-    {((( cell.source | citation2latex | markdown2latex )))}
+    {((( cell.source | replace('\n', ' ') | citation2latex | markdown2latex )))}
 ((*- endblock headingcell *))
 
 %==============================================================================


### PR DESCRIPTION
If 1.1 hasn't been released yet, it would be nice to backport this.

See #4122 
