### PR TITLE
Trivial hacks to get ipython 0.10.2 to install on jython 2.5.4rc1 and 2....

### DIFF
--- a/IPython/ColorANSI.py
+++ b/IPython/ColorANSI.py
@@ -87,7 +87,7 @@ class InputTermColors:
     
     NoColor = ''  # for color schemes in color-less terminals.
 
-    if os.name == 'nt' and os.environ.get('TERM','dumb') == 'emacs':
+    if os.name == 'java' or os.name == 'nt' and os.environ.get('TERM','dumb') == 'emacs':
         # (X)emacs on W32 gets confused with \001 and \002 so we remove them
         Normal = '\033[0m'   # Reset normal coloring
         _base  = '\033[%sm'  # Template for all other colors

--- a/IPython/Prompts.py
+++ b/IPython/Prompts.py
@@ -117,7 +117,7 @@ HOME = os.environ.get("HOME","//////:::::ZZZZZ,,,~~~")
 USER           = os.environ.get("USER")
 HOSTNAME       = socket.gethostname()
 HOSTNAME_SHORT = HOSTNAME.split(".")[0]
-ROOT_SYMBOL    = "$#"[os.name=='nt' or os.getuid()==0]
+ROOT_SYMBOL    = "$#"[os.name!='posix']
 
 prompt_specials_color = {
     # Prompt/history count

--- a/IPython/genutils.py
+++ b/IPython/genutils.py
@@ -918,6 +918,11 @@ def get_home_dir():
     isdir = os.path.isdir
     env = os.environ
 
+    host_os = 'posix';
+    if (os.name == 'java'):
+        from java.lang import System as System
+        if 'Windows' in System.getProperty('os.name'):
+            host_os = 'nt'
     # first, check py2exe distribution root directory for _ipython.
     # This overrides all. Normally does not exist.
 
@@ -938,7 +943,7 @@ def get_home_dir():
             raise KeyError
         return homedir.decode(sys.getfilesystemencoding())
     except KeyError:
-        if os.name == 'posix':
+        if os.name == 'posix' or host_os == 'posix':
             # Last-ditch attempt at finding a suitable $HOME, on systems where
             # it may not be defined in the environment but the system shell
             # still knows it - reported once as:
@@ -950,7 +955,7 @@ def get_home_dir():
                 return homedir.decode(sys.getfilesystemencoding())
             else:
                 raise HomeDirError('Undefined $HOME, IPython cannot proceed.')
-        elif os.name == 'nt':
+        elif os.name == 'nt' or host_os == 'nt':
             # For some strange reason, win9x returns 'nt' for os.name.
             try:
                 homedir = os.path.join(env['HOMEDRIVE'],env['HOMEPATH'])
@@ -1529,11 +1534,19 @@ def get_pager_cmd(pager_cmd = None):
 
     Makes some attempts at finding an OS-correct one."""
 
+    default_pager_cmd = None
     if os.name == 'posix':
         default_pager_cmd = 'less -r'  # -r for color control sequences
     elif os.name in ['nt','dos']:
         default_pager_cmd = 'type'
+    elif os.name == 'java':
+        from java.lang import System as System
+        if ('Windows' in System.getProperty('os.name')):
+            default_pager_cmd = 'type'
+        else:
+            default_pager_cmd = 'less -r'
 
+    
     if pager_cmd is None:
         try:
             pager_cmd = os.environ['PAGER']

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,8 @@ if os.name == 'posix':
     os_name = 'posix'
 elif os.name in ['nt','dos']:
     os_name = 'windows'
+elif os.name == 'java':
+    os_name = 'posix'
 else:
     print 'Unsupported operating system:',os.name
     sys.exit(1)


### PR DESCRIPTION
...7beta1

Notes:
-Running on 2.7beta 1 requires a custom compile of jython using an older version of JLine
-Windows doesn't really work
