### PR TITLE
ESC should be handled by CM if tooltip is not on

### DIFF
--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -166,7 +166,7 @@ var IPython = (function (IPython) {
             // triger on keypress (!) otherwise inconsistent event.which depending on plateform
             // browser and keyboard layout !
             // Pressing '(' , request tooltip, don't forget to reappend it
-            // The second argument says to hide the tooltip if the docstring 
+            // The second argument says to hide the tooltip if the docstring
             // is actually empty
             IPython.tooltip.pending(that, true);
         } else if (event.which === key.UPARROW && event.type === 'keydown') {
@@ -179,8 +179,12 @@ var IPython = (function (IPython) {
                 return true;
             };
         } else if (event.which === key.ESC) {
-            IPython.tooltip.remove_and_cancel_tooltip(true);
-            return true;
+            if (!IPython.tooltip._hidden) {
+              IPython.tooltip.remove_and_cancel_tooltip(true);
+              return true;
+            } else {
+              return false;
+            }
         } else if (event.which === key.DOWNARROW && event.type === 'keydown') {
             // If we are not at the bottom, let CM handle the down arrow and
             // prevent the global keydown handler from handling it.
@@ -272,7 +276,7 @@ var IPython = (function (IPython) {
         var data = {'cell': this, 'text': text}
         $([IPython.events]).trigger('set_next_input.Notebook', data);
     }
-    
+
     /**
      * @method _handle_input_request
      * @private

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -179,12 +179,7 @@ var IPython = (function (IPython) {
                 return true;
             };
         } else if (event.which === key.ESC) {
-            if (!IPython.tooltip._hidden) {
-              IPython.tooltip.remove_and_cancel_tooltip(true);
-              return true;
-            } else {
-              return false;
-            }
+            return IPython.tooltip.remove_and_cancel_tooltip(true);
         } else if (event.which === key.DOWNARROW && event.type === 'keydown') {
             // If we are not at the bottom, let CM handle the down arrow and
             // prevent the global keydown handler from handling it.

--- a/IPython/html/static/notebook/js/tooltip.js
+++ b/IPython/html/static/notebook/js/tooltip.js
@@ -167,8 +167,8 @@ var IPython = (function (IPython) {
         // note that we don't handle closing directly inside the calltip
         // as in the completer, because it is not focusable, so won't
         // get the event.
-        if (this._hidden === false) {
-          if (this._sticky == false || force == true) {
+        if (!this._hidden) {
+          if (force || !this._sticky) {
               this.cancel_stick();
               this._hide();
           }

--- a/IPython/html/static/notebook/js/tooltip.js
+++ b/IPython/html/static/notebook/js/tooltip.js
@@ -161,16 +161,23 @@ var IPython = (function (IPython) {
         this.code_mirror = null;
     }
 
+    // return true on successfully removing a visible tooltip; otherwise return
+    // false.
     Tooltip.prototype.remove_and_cancel_tooltip = function (force) {
         // note that we don't handle closing directly inside the calltip
         // as in the completer, because it is not focusable, so won't
         // get the event.
-        if (this._sticky == false || force == true) {
-            this.cancel_stick();
-            this._hide();
+        if (this._hidden === false) {
+          if (this._sticky == false || force == true) {
+              this.cancel_stick();
+              this._hide();
+          }
+          this.cancel_pending();
+          this.reset_tabs_function();
+          return true;
+        } else {
+          return false;
         }
-        this.cancel_pending();
-        this.reset_tabs_function();
     }
 
     // cancel autocall done after '(' for example.
@@ -335,7 +342,7 @@ var IPython = (function (IPython) {
         if (docstring == null) {
             docstring = reply.docstring;
         }
-        
+
         if (docstring == null) {
             // For reals this time, no docstring
             if (this._hide_if_no_docstring) {


### PR DESCRIPTION
This PR fixes an issue on a key-press event with ESC  in code cells, allowing the event to propagate to CM if tooltip is not on.

Currently, key-pressing ESC in a code cell simply removes tooltip, and the event is ignored by CM.   I can not get out of insert mode when I am using Vim key binding.
