### PR TITLE
moved DummyMod to proper namespace to enable dill pickling

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -187,8 +187,10 @@ class ReadlineNoRecord(object):
         return [ghi(x) for x in range(start, end)]
 
 
+@undoc
 class DummyMod(object):
-    "A dummy module used for IPython's interactive namespace."
+    """A dummy module used for IPython's interactive module when
+    a namespace must be assigned to the module's __dict__."""
     pass
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -186,6 +186,11 @@ class ReadlineNoRecord(object):
         ghi = self.shell.readline.get_history_item
         return [ghi(x) for x in range(start, end)]
 
+
+class DummyMod(object):
+    "A dummy module used for IPython's interactive namespace."
+    pass
+
 #-----------------------------------------------------------------------------
 # Main IPython class
 #-----------------------------------------------------------------------------
@@ -1035,9 +1040,6 @@ class InteractiveShell(SingletonConfigurable):
         """
         if user_module is None and user_ns is not None:
             user_ns.setdefault("__name__", "__main__")
-            class DummyMod(object):
-                "A dummy module used for IPython's interactive namespace."
-                pass
             user_module = DummyMod()
             user_module.__dict__ = user_ns
             

--- a/IPython/terminal/embed.py
+++ b/IPython/terminal/embed.py
@@ -244,8 +244,9 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
         # actually completes using the frame's locals/globals
         self.set_completer_frame()
 
-        with self.builtin_trap, self.display_trap:
-            self.interact(display_banner=display_banner)
+        with self.builtin_trap:
+            with self.display_trap:
+                self.interact(display_banner=display_banner)
         
         # now, purge out the local namespace of IPython's hidden variables.
         if local_ns is not None:

--- a/IPython/terminal/embed.py
+++ b/IPython/terminal/embed.py
@@ -29,6 +29,7 @@ import warnings
 
 from IPython.core import ultratb, compilerop
 from IPython.core.magic import Magics, magics_class, line_magic
+from IPython.core.interactiveshell import DummyMod
 from IPython.terminal.interactiveshell import TerminalInteractiveShell
 from IPython.terminal.ipapp import load_default_config
 
@@ -185,9 +186,6 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
         there is no fundamental reason why it can't work perfectly."""
         
         if (global_ns is not None) and (module is None):
-            class DummyMod(object):
-                """A dummy module object for embedded IPython."""
-                pass
             warnings.warn("global_ns is deprecated, use module instead.", DeprecationWarning)
             module = DummyMod()
             module.__dict__ = global_ns

--- a/IPython/terminal/embed.py
+++ b/IPython/terminal/embed.py
@@ -242,9 +242,8 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
         # actually completes using the frame's locals/globals
         self.set_completer_frame()
 
-        with self.builtin_trap:
-            with self.display_trap:
-                self.interact(display_banner=display_banner)
+        with self.builtin_trap, self.display_trap:
+            self.interact(display_banner=display_banner)
         
         # now, purge out the local namespace of IPython's hidden variables.
         if local_ns is not None:

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -422,19 +422,20 @@ class TerminalInteractiveShell(InteractiveShell):
         internally created default banner.
         """
 
-        with self.builtin_trap, self.display_trap:
+        with self.builtin_trap:
+            with self.display_trap:
 
-            while 1:
-                try:
-                    self.interact(display_banner=display_banner)
-                    #self.interact_with_readline()
-                    # XXX for testing of a readline-decoupled repl loop, call
-                    # interact_with_readline above
-                    break
-                except KeyboardInterrupt:
-                    # this should not be necessary, but KeyboardInterrupt
-                    # handling seems rather unpredictable...
-                    self.write("\nKeyboardInterrupt in interact()\n")
+                while 1:
+                    try:
+                        self.interact(display_banner=display_banner)
+                        #self.interact_with_readline()
+                        #XXX for testing of a readline-decoupled repl loop, call
+                        # interact_with_readline above
+                        break
+                    except KeyboardInterrupt:
+                        # this should not be necessary, but KeyboardInterrupt
+                        # handling seems rather unpredictable...
+                        self.write("\nKeyboardInterrupt in interact()\n")
 
     def _replace_rlhist_multiline(self, source_raw, hlen_before_cell):
         """Store multiple lines as a single entry in history"""

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -422,20 +422,19 @@ class TerminalInteractiveShell(InteractiveShell):
         internally created default banner.
         """
 
-        with self.builtin_trap:
-            with self.display_trap:
+        with self.builtin_trap, self.display_trap:
 
-                while 1:
-                    try:
-                        self.interact(display_banner=display_banner)
-                        #self.interact_with_readline()
-                        #XXX for testing of a readline-decoupled repl loop, call
-                        # interact_with_readline above
-                        break
-                    except KeyboardInterrupt:
-                        # this should not be necessary, but KeyboardInterrupt
-                        # handling seems rather unpredictable...
-                        self.write("\nKeyboardInterrupt in interact()\n")
+            while 1:
+                try:
+                    self.interact(display_banner=display_banner)
+                    #self.interact_with_readline()
+                    # XXX for testing of a readline-decoupled repl loop, call
+                    # interact_with_readline above
+                    break
+                except KeyboardInterrupt:
+                    # this should not be necessary, but KeyboardInterrupt
+                    # handling seems rather unpredictable...
+                    self.write("\nKeyboardInterrupt in interact()\n")
 
     def _replace_rlhist_multiline(self, source_raw, hlen_before_cell):
         """Store multiple lines as a single entry in history"""


### PR DESCRIPTION
enables pickling with dill, which worked in 0.13, but seemed to be broken in 1.0.

Issues remain, however, since dill.dump_session now saves "DummyMod" stub and not the user's interactive session. Needs more investigation into reason behind DummyMod, and if it's really a necessary evil.
