### PR TITLE
Select adequate highlighter for cell magic languages

### DIFF
--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -68,7 +68,8 @@ class Exporter(LoggingConfigurable):
                                  nbpreprocessors.CSSHTMLHeaderPreprocessor,
                                  nbpreprocessors.RevealHelpPreprocessor,
                                  nbpreprocessors.LatexPreprocessor,
-                                 nbpreprocessors.SphinxPreprocessor],
+                                 nbpreprocessors.SphinxPreprocessor,
+                                 nbpreprocessors.HighlightMagicsPreprocessor],
         config=True,
         help="""List of preprocessors available by default, by name, namespace, 
         instance, or type.""")

--- a/IPython/nbconvert/exporters/html.py
+++ b/IPython/nbconvert/exporters/html.py
@@ -46,7 +46,10 @@ class HTMLExporter(TemplateExporter):
         c = Config({
             'CSSHTMLHeaderPreprocessor':{
                 'enabled':True
-                }          
+                },
+            'HighlightMagicsPreprocessor': {
+                'enabled':True
+                }
             })
         c.merge(super(HTMLExporter,self).default_config)
         return c

--- a/IPython/nbconvert/exporters/latex.py
+++ b/IPython/nbconvert/exporters/latex.py
@@ -85,6 +85,9 @@ class LatexExporter(TemplateExporter):
                  },
              'SphinxPreprocessor': {
                     'enabled':True
+                 },
+             'HighlightMagicsPreprocessor': {
+                    'enabled':True
                  }
          })
         c.merge(super(LatexExporter,self).default_config)

--- a/IPython/nbconvert/exporters/slides.py
+++ b/IPython/nbconvert/exporters/slides.py
@@ -47,6 +47,9 @@ class SlidesExporter(TemplateExporter):
             'RevealHelpPreprocessor':{
                 'enabled':True,
                 },                
+            'HighlightMagicsPreprocessor': {
+                'enabled':True
+                }
             })
         c.merge(super(SlidesExporter,self).default_config)
         return c

--- a/IPython/nbconvert/filters/highlight.py
+++ b/IPython/nbconvert/filters/highlight.py
@@ -39,45 +39,51 @@ __all__ = [
     'highlight2latex'
 ]
 
-def highlight2html(cell, language='ipython'):
+def highlight2html(source, metadata=None, language='ipython'):
     """
     Return a syntax-highlighted version of the input source as html output.
 
     Parameters
     ----------
-    cell : NotebookNode cell
-        cell to highlight
+    source : str
+        source of the cell to highlight.
+    metadata : NotebookNode cell metadata
+        metadata of the cell to highlight.
     language : str
         Language to highlight the syntax of.
     """
 
-    return _pygment_highlight(cell, HtmlFormatter(), language)
+    return _pygment_highlight(source, HtmlFormatter(), metadata, language)
 
 
-def highlight2latex(cell, language='ipython'):
+def highlight2latex(source, metadata=None, language='ipython'):
     """
     Return a syntax-highlighted version of the input source as latex output.
 
     Parameters
     ----------
-    cell : NotebookNode cell
-        cell to highlight
+    source : str
+        source of the cell to highlight.
+    metadata : NotebookNode cell metadata
+        metadata of the cell to highlight.
     language : str
         Language to highlight the syntax of.
     """
-    return _pygment_highlight(cell, LatexFormatter(), language)
+    return _pygment_highlight(source, LatexFormatter(), metadata, language)
 
 
 
-def _pygment_highlight(cell, output_formatter, language='ipython'):
+def _pygment_highlight(source, output_formatter, metadata=None, language='ipython'):
     """
     Return a syntax-highlighted version of the input source
 
     Parameters
     ----------
-    cell : NotebookNode cell
-        cell to highlight
+    source : str
+        source of the cell to highlight.
     output_formatter : Pygments formatter
+    metadata : NotebookNode cell metadata
+        metadata of the cell to highlight.
     language : str
         Language to highlight the syntax of.
     """
@@ -85,14 +91,14 @@ def _pygment_highlight(cell, output_formatter, language='ipython'):
     # If the cell uses a magic extension language,
     # use the magic language instead.
     if language == 'ipython' \
-        and 'metadata' in cell \
-        and 'magics_language' in cell['metadata']:
+        and metadata \
+        and 'magics_language' in metadata:
 
-        language = cell['metadata']['magics_language']
+        language = metadata['magics_language']
 
     if language == 'ipython':
         lexer = IPythonLexer()
     else:
         lexer = get_lexer_by_name(language, stripall=True)
 
-    return pygements_highlight(cell['input'], lexer, output_formatter)
+    return pygements_highlight(source, lexer, output_formatter)

--- a/IPython/nbconvert/filters/highlight.py
+++ b/IPython/nbconvert/filters/highlight.py
@@ -14,8 +14,6 @@ from within Jinja templates.
 # Imports
 #-----------------------------------------------------------------------------
 
-import re
-
 from pygments import highlight as pygements_highlight
 from pygments.lexers import get_lexer_by_name
 from pygments.formatters import HtmlFormatter

--- a/IPython/nbconvert/filters/highlight.py
+++ b/IPython/nbconvert/filters/highlight.py
@@ -95,4 +95,4 @@ def _pygment_highlight(cell, output_formatter, language='ipython'):
     else:
         lexer = get_lexer_by_name(language, stripall=True)
 
-    return pygements_highlight(cell, lexer, output_formatter)
+    return pygements_highlight(cell['input'], lexer, output_formatter)

--- a/IPython/nbconvert/filters/highlight.py
+++ b/IPython/nbconvert/filters/highlight.py
@@ -39,7 +39,7 @@ __all__ = [
     'highlight2latex'
 ]
 
-def highlight2html(source, metadata=None, language='ipython'):
+def highlight2html(source, language='ipython', metadata=None):
     """
     Return a syntax-highlighted version of the input source as html output.
 
@@ -47,16 +47,16 @@ def highlight2html(source, metadata=None, language='ipython'):
     ----------
     source : str
         source of the cell to highlight.
-    metadata : NotebookNode cell metadata
-        metadata of the cell to highlight.
     language : str
         Language to highlight the syntax of.
+    metadata : NotebookNode cell metadata
+        metadata of the cell to highlight.
     """
 
-    return _pygment_highlight(source, HtmlFormatter(), metadata, language)
+    return _pygment_highlight(source, HtmlFormatter(), language, metadata)
 
 
-def highlight2latex(source, metadata=None, language='ipython'):
+def highlight2latex(source, language='ipython', metadata=None):
     """
     Return a syntax-highlighted version of the input source as latex output.
 
@@ -64,16 +64,16 @@ def highlight2latex(source, metadata=None, language='ipython'):
     ----------
     source : str
         source of the cell to highlight.
-    metadata : NotebookNode cell metadata
-        metadata of the cell to highlight.
     language : str
         Language to highlight the syntax of.
+    metadata : NotebookNode cell metadata
+        metadata of the cell to highlight.
     """
-    return _pygment_highlight(source, LatexFormatter(), metadata, language)
+    return _pygment_highlight(source, LatexFormatter(), language, metadata)
 
 
 
-def _pygment_highlight(source, output_formatter, metadata=None, language='ipython'):
+def _pygment_highlight(source, output_formatter, language='ipython', metadata=None):
     """
     Return a syntax-highlighted version of the input source
 
@@ -82,10 +82,10 @@ def _pygment_highlight(source, output_formatter, metadata=None, language='ipytho
     source : str
         source of the cell to highlight.
     output_formatter : Pygments formatter
-    metadata : NotebookNode cell metadata
-        metadata of the cell to highlight.
     language : str
         Language to highlight the syntax of.
+    metadata : NotebookNode cell metadata
+        metadata of the cell to highlight.
     """
 
     # If the cell uses a magic extension language,

--- a/IPython/nbconvert/filters/tests/test_highlight.py
+++ b/IPython/nbconvert/filters/tests/test_highlight.py
@@ -60,6 +60,6 @@ class TestHighlight(TestsBase):
 
     def _try_highlight(self, method, test, tokens):
         """Try highlighting source, look for key tokens"""
-        results = method({'input': test})
+        results = method(test)
         for token in tokens:
             assert token in results

--- a/IPython/nbconvert/filters/tests/test_highlight.py
+++ b/IPython/nbconvert/filters/tests/test_highlight.py
@@ -15,7 +15,7 @@ Module with tests for Highlight
 #-----------------------------------------------------------------------------
 
 from ...tests.base import TestsBase
-from ..highlight import highlight2html, highlight2latex, which_magic_language
+from ..highlight import highlight2html, highlight2latex
 
 
 #-----------------------------------------------------------------------------
@@ -39,59 +39,27 @@ class TestHighlight(TestsBase):
         %%pylab
         plot(x,y, 'r')
         """
-        ]
+        ]   
 
     tokens = [
         ['Hello World Example', 'say', 'text', 'print', 'def'],
         ['pylab', 'plot']]
+
 
     def test_highlight2html(self):
         """highlight2html test"""
         for index, test in enumerate(self.tests):
             self._try_highlight(highlight2html, test, self.tokens[index])
 
+
     def test_highlight2latex(self):
         """highlight2latex test"""
         for index, test in enumerate(self.tests):
             self._try_highlight(highlight2latex, test, self.tokens[index])
+
 
     def _try_highlight(self, method, test, tokens):
         """Try highlighting source, look for key tokens"""
         results = method(test)
         for token in tokens:
             assert token in results
-
-    magic_tests = {
-            'r':
-                """%%R -i x,y -o XYcoef
-                lm.fit <- lm(y~x)
-                par(mfrow=c(2,2))
-                print(summary(lm.fit))
-                plot(lm.fit)
-                XYcoef <- coef(lm.fit)
-                """,
-            'bash':
-                """# the following code is in bash
-                %%bash
-                echo "test" > out
-                """,
-            'ipython':
-                """# this should not be detected
-                print("%%R")
-                """
-            }
-
-    def test_highlight_rmagic(self):
-        """Test %%R magic highlighting"""
-        language = which_magic_language(self.magic_tests['r'])
-        assert language == 'r'
-
-    def test_highlight_bashmagic(self):
-        """Test %%bash magic highlighting"""
-        language = which_magic_language(self.magic_tests['bash'])
-        assert language == 'bash'
-
-    def test_highlight_interferemagic(self):
-        """Test that magic highlighting does not interfere with ipython code"""
-        language = which_magic_language(self.magic_tests['ipython'])
-        assert language == None

--- a/IPython/nbconvert/filters/tests/test_highlight.py
+++ b/IPython/nbconvert/filters/tests/test_highlight.py
@@ -60,6 +60,6 @@ class TestHighlight(TestsBase):
 
     def _try_highlight(self, method, test, tokens):
         """Try highlighting source, look for key tokens"""
-        results = method(test)
+        results = method({'input': test})
         for token in tokens:
             assert token in results

--- a/IPython/nbconvert/filters/tests/test_highlight.py
+++ b/IPython/nbconvert/filters/tests/test_highlight.py
@@ -15,7 +15,7 @@ Module with tests for Highlight
 #-----------------------------------------------------------------------------
 
 from ...tests.base import TestsBase
-from ..highlight import highlight2html, highlight2latex
+from ..highlight import highlight2html, highlight2latex, which_magic_language
 
 
 #-----------------------------------------------------------------------------
@@ -39,27 +39,59 @@ class TestHighlight(TestsBase):
         %%pylab
         plot(x,y, 'r')
         """
-        ]   
+        ]
 
     tokens = [
         ['Hello World Example', 'say', 'text', 'print', 'def'],
         ['pylab', 'plot']]
-
 
     def test_highlight2html(self):
         """highlight2html test"""
         for index, test in enumerate(self.tests):
             self._try_highlight(highlight2html, test, self.tokens[index])
 
-
     def test_highlight2latex(self):
         """highlight2latex test"""
         for index, test in enumerate(self.tests):
             self._try_highlight(highlight2latex, test, self.tokens[index])
-
 
     def _try_highlight(self, method, test, tokens):
         """Try highlighting source, look for key tokens"""
         results = method(test)
         for token in tokens:
             assert token in results
+
+    magic_tests = {
+            'r':
+                """%%R -i x,y -o XYcoef
+                lm.fit <- lm(y~x)
+                par(mfrow=c(2,2))
+                print(summary(lm.fit))
+                plot(lm.fit)
+                XYcoef <- coef(lm.fit)
+                """,
+            'bash':
+                """# the following code is in bash
+                %%bash
+                echo "test" > out
+                """,
+            'ipython':
+                """# this should not be detected
+                print("%%R")
+                """
+            }
+
+    def test_highlight_rmagic(self):
+        """Test %%R magic highlighting"""
+        language = which_magic_language(self.magic_tests['r'])
+        assert language == 'r'
+
+    def test_highlight_bashmagic(self):
+        """Test %%bash magic highlighting"""
+        language = which_magic_language(self.magic_tests['bash'])
+        assert language == 'bash'
+
+    def test_highlight_interferemagic(self):
+        """Test that magic highlighting does not interfere with ipython code"""
+        language = which_magic_language(self.magic_tests['ipython'])
+        assert language == None

--- a/IPython/nbconvert/preprocessors/__init__.py
+++ b/IPython/nbconvert/preprocessors/__init__.py
@@ -7,6 +7,7 @@ from .revealhelp import RevealHelpPreprocessor
 from .latex import LatexPreprocessor
 from .sphinx import SphinxPreprocessor
 from .csshtmlheader import CSSHTMLHeaderPreprocessor
+from .highlightmagics import HighlightMagicsPreprocessor
 
 # decorated function Preprocessors
 from .coalescestreams import coalesce_streams

--- a/IPython/nbconvert/preprocessors/highlightmagics.py
+++ b/IPython/nbconvert/preprocessors/highlightmagics.py
@@ -36,13 +36,17 @@ class HighlightMagicsPreprocessor(Preprocessor):
     """
 
     # list of magic language extensions and their associated pygment lexers
-    languages = Dict(
+    default_languages = Dict(
         default_value={
             '%%R': 'r',
             '%%bash': 'bash',
             '%%octave': 'octave',
             '%%perl': 'perl',
             '%%ruby': 'ruby'},
+        config=False)
+
+    # user defined language extensions
+    languages = Dict(
         config=True,
         help=("Syntax highlighting for magic's extension languages. "
          "Each item associates a language magic extension such as %%R, "
@@ -53,9 +57,12 @@ class HighlightMagicsPreprocessor(Preprocessor):
 
         super(HighlightMagicsPreprocessor, self).__init__(config=config, **kw)
 
+        # Update the default languages dict with the user configured ones
+        self.default_languages.update(self.languages)
+
         # build a regular expression to catch language extensions and choose
         # an adequate pygments lexer
-        any_language = "|".join(self.languages.keys())
+        any_language = "|".join(self.default_languages.keys())
         self.re_magic_language = re.compile(
             r'^\s*({0})\s+'.format(any_language))
 
@@ -76,8 +83,8 @@ class HighlightMagicsPreprocessor(Preprocessor):
         if m:
             # By construction of the re, the matched language must be in the
             # languages dictionnary
-            assert(m.group(1) in self.languages)
-            return self.languages[m.group(1)]
+            assert(m.group(1) in self.default_languages)
+            return self.default_languages[m.group(1)]
         else:
             return None
 

--- a/IPython/nbconvert/preprocessors/highlightmagics.py
+++ b/IPython/nbconvert/preprocessors/highlightmagics.py
@@ -1,0 +1,104 @@
+"""This preprocessor detect cells using a different language through
+magic extensions such as `%%R` or `%%octave`. Cell's metadata is marked
+so that the appropriate highlighter can be used in the `highlight`
+filter.
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, the IPython Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+from __future__ import print_function, absolute_import
+
+import re
+
+# Our own imports
+# Needed to override preprocessor
+from .base import (Preprocessor)
+from IPython.utils.traitlets import Dict
+
+#-----------------------------------------------------------------------------
+# Classes
+#-----------------------------------------------------------------------------
+
+
+class HighlightMagicsPreprocessor(Preprocessor):
+    """
+    Detects and tags code cells that use a different languages than Python.
+    """
+
+    # list of magic language extensions and their associated pygment lexers
+    languages = Dict(
+        default_value={
+            '%%R': 'r',
+            '%%bash': 'bash',
+            '%%octave': 'octave',
+            '%%perl': 'perl',
+            '%%ruby': 'ruby'},
+        config=True,
+        help=("Syntax highlighting for magic's extension languages. "
+         "Each item associates a language magic extension such as %%R, "
+         "with a pygments lexer such as r."))
+
+    def __init__(self, config=None, **kw):
+        """Public constructor"""
+
+        super(HighlightMagicsPreprocessor, self).__init__(config=config, **kw)
+
+        # build a regular expression to catch language extensions and choose
+        # an adequate pygments lexer
+        any_language = "|".join(self.languages.keys())
+        self.re_magic_language = re.compile(
+            r'^\s*({0})\s+'.format(any_language))
+
+    def which_magic_language(self, source):
+        """
+        When a cell uses another language through a magic extension,
+        the other language is returned.
+        If no language magic is detected, this function returns None.
+
+        Parameters
+        ----------
+        source: str
+            Source code of the cell to highlight
+        """
+
+        m = self.re_magic_language.match(source)
+
+        if m:
+            # By construction of the re, the matched language must be in the
+            # languages dictionnary
+            assert(m.group(1) in self.languages)
+            return self.languages[m.group(1)]
+        else:
+            return None
+
+    def preprocess_cell(self, cell, resources, cell_index):
+        """
+        Tags cells using a magic extension language
+
+        Parameters
+        ----------
+        cell : NotebookNode cell
+            Notebook cell being processed
+        resources : dictionary
+            Additional resources used in the conversion process.  Allows
+            preprocessors to pass variables into the Jinja engine.
+        cell_index : int
+            Index of the cell being processed (see base.py)
+        """
+
+        # Only tag code cells
+        if hasattr(cell, "input") and cell.cell_type == "code":
+            magic_language = self.which_magic_language(cell.input)
+            if magic_language:
+                cell['metadata']['magics_language'] = magic_language
+        return cell, resources

--- a/IPython/nbconvert/preprocessors/highlightmagics.py
+++ b/IPython/nbconvert/preprocessors/highlightmagics.py
@@ -86,8 +86,7 @@ class HighlightMagicsPreprocessor(Preprocessor):
 
         if m:
             # By construction of the re, the matched language must be in the
-            # languages dictionnary
-            assert(m.group(1) in self.default_languages)
+            # languages dictionary
             return self.default_languages[m.group(1)]
         else:
             return None

--- a/IPython/nbconvert/preprocessors/highlightmagics.py
+++ b/IPython/nbconvert/preprocessors/highlightmagics.py
@@ -40,9 +40,14 @@ class HighlightMagicsPreprocessor(Preprocessor):
         default_value={
             '%%R': 'r',
             '%%bash': 'bash',
+            '%%cython': 'cython',
+            '%%javascript': 'javascript',
+            '%%julia': 'julia',
+            '%%latex': 'latex',
             '%%octave': 'octave',
             '%%perl': 'perl',
-            '%%ruby': 'ruby'},
+            '%%ruby': 'ruby',
+            '%%sh': 'sh'},
         config=False)
 
     # user defined language extensions

--- a/IPython/nbconvert/preprocessors/highlightmagics.py
+++ b/IPython/nbconvert/preprocessors/highlightmagics.py
@@ -47,8 +47,7 @@ class HighlightMagicsPreprocessor(Preprocessor):
             '%%octave': 'octave',
             '%%perl': 'perl',
             '%%ruby': 'ruby',
-            '%%sh': 'sh'},
-        config=False)
+            '%%sh': 'sh'})
 
     # user defined language extensions
     languages = Dict(

--- a/IPython/nbconvert/preprocessors/highlightmagics.py
+++ b/IPython/nbconvert/preprocessors/highlightmagics.py
@@ -21,8 +21,7 @@ from __future__ import print_function, absolute_import
 import re
 
 # Our own imports
-# Needed to override preprocessor
-from .base import (Preprocessor)
+from .base import Preprocessor
 from IPython.utils.traitlets import Dict
 
 #-----------------------------------------------------------------------------

--- a/IPython/nbconvert/preprocessors/tests/test_highlightmagics.py
+++ b/IPython/nbconvert/preprocessors/tests/test_highlightmagics.py
@@ -1,0 +1,68 @@
+"""
+Module with tests for the HighlightMagics preprocessor
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, the IPython Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+from .base import PreprocessorTestsBase
+from ..highlightmagics import HighlightMagicsPreprocessor
+
+
+#-----------------------------------------------------------------------------
+# Class
+#-----------------------------------------------------------------------------
+
+class TestHighlightMagics(PreprocessorTestsBase):
+    """Contains test functions for highlightmagics.py"""
+
+
+    def build_preprocessor(self):
+        """Make an instance of a preprocessor"""
+        preprocessor = HighlightMagicsPreprocessor()
+        preprocessor.enabled = True
+        return preprocessor
+
+    def test_constructor(self):
+        """Can a HighlightMagicsPreprocessor be constructed?"""
+        self.build_preprocessor()
+
+    def test_tagging(self):
+        """Test the HighlightMagicsPreprocessor tagging"""
+        nb = self.build_notebook()
+        res = self.build_resources()
+        preprocessor = self.build_preprocessor()
+        nb.worksheets[0].cells[0].input = """%%R -i x,y -o XYcoef
+            lm.fit <- lm(y~x)
+            par(mfrow=c(2,2))
+            print(summary(lm.fit))
+            plot(lm.fit)
+            XYcoef <- coef(lm.fit)"""
+
+        nb, res = preprocessor(nb, res)
+
+        assert('magics_language' in nb.worksheets[0].cells[0]['metadata'])
+
+        self.assertEqual(nb.worksheets[0].cells[0]['metadata']['magics_language'], 'r')
+
+    def test_no_false_positive(self):
+        """Test that HighlightMagicsPreprocessor does not tag false positives"""
+        nb = self.build_notebook()
+        res = self.build_resources()
+        preprocessor = self.build_preprocessor()
+        nb.worksheets[0].cells[0].input = """# this should not be detected
+                print(\"""
+                %%R -i x, y
+                \""")"""
+        nb, res = preprocessor(nb, res)
+
+        assert('magics_language' not in nb.worksheets[0].cells[0]['metadata'])

--- a/IPython/nbconvert/templates/html_basic.tpl
+++ b/IPython/nbconvert/templates/html_basic.tpl
@@ -36,7 +36,7 @@ In&nbsp;[{{ cell.prompt_number }}]:
 
 {% block input %}
 <div class="input_area box-flex1">
-{{ cell.input | highlight2html }}
+{{ cell | highlight2html }}
 </div>
 {%- endblock input %}
 

--- a/IPython/nbconvert/templates/html_basic.tpl
+++ b/IPython/nbconvert/templates/html_basic.tpl
@@ -36,7 +36,7 @@ In&nbsp;[{{ cell.prompt_number }}]:
 
 {% block input %}
 <div class="input_area box-flex1">
-{{ cell | highlight2html }}
+{{ cell.input | highlight2html(metadata=cell.metadata) }}
 </div>
 {%- endblock input %}
 

--- a/IPython/nbconvert/templates/latex/sphinx.tplx
+++ b/IPython/nbconvert/templates/latex/sphinx.tplx
@@ -284,7 +284,7 @@ Note: For best display, use latex syntax highlighting. =))
         \vspace{-25pt}
 
         % Add contents below.
-        ((( cell | highlight2latex )))
+        ((( cell.input | highlight2latex(metadata=cell.metadata) )))
 
     ((* elif resources.sphinx.outputstyle == 'notebook' *))
         \vspace{6pt}
@@ -292,7 +292,7 @@ Note: For best display, use latex syntax highlighting. =))
         \vspace{-2.65\baselineskip}
         \begin{ColorVerbatim}
             \vspace{-0.7\baselineskip}
-            ((( cell | highlight2latex )))
+            ((( cell.input | highlight2latex(metadata=cell.metadata) )))
             ((* if cell.input == None or cell.input == '' *))
                 \vspace{0.3\baselineskip}
             ((* else *))

--- a/IPython/nbconvert/templates/latex/sphinx.tplx
+++ b/IPython/nbconvert/templates/latex/sphinx.tplx
@@ -284,7 +284,7 @@ Note: For best display, use latex syntax highlighting. =))
         \vspace{-25pt}
 
         % Add contents below.
-        ((( cell.input | highlight2latex )))
+        ((( cell | highlight2latex )))
 
     ((* elif resources.sphinx.outputstyle == 'notebook' *))
         \vspace{6pt}
@@ -292,7 +292,7 @@ Note: For best display, use latex syntax highlighting. =))
         \vspace{-2.65\baselineskip}
         \begin{ColorVerbatim}
             \vspace{-0.7\baselineskip}
-            ((( cell.input | highlight2latex )))
+            ((( cell | highlight2latex )))
             ((* if cell.input == None or cell.input == '' *))
                 \vspace{0.3\baselineskip}
             ((* else *))


### PR DESCRIPTION
Detect cells that use language extension magics such as %%R or %%bash
and call the appropriate pygmentize lexer.

Closes #4184
## 

@Carreau

> Sure, wherever the PR come from, it will be reviewed, we don't treat regular of new user differently. Just ask if >we are not clear on how to do things, it is often hard to judge how people are used to code.
> 
> You will probably need an heuristic in nbconvert preprocessor that inspect the cell source and decide for a >highlighting scheme, stuff this in metadata along with the cell, and use those metadata to feed them to the >hightlight filter in templates.
> 
> @jdfreder should also be able to help you too.

Thanks ! I first tried to follow your proposed architecture, using a preprocessor.
Writing the preprocessor and tagging the cell metadata is feasible.

The problem comes when the highlight filter is called. Indeed the higlight filter interface
only sees the cell content,

``` python
def _pygment_highlight(source, output_formatter, language='ipython'):
```

therefore the metadata is lost at that point.

Since the preprocessor was anyways deciding the extension language based on the
cell content, I propose the following simpler (but less modular) implementation.

Thanks for your review,

Pablo
