### PR TITLE
Allow user_ns trait to be None

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -201,7 +201,7 @@ class InteractiveShellApp(Configurable):
     )
     shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
     
-    user_ns = Dict(default_value=None)
+    user_ns = Instance(dict, args=None, allow_none=True)
     def _user_ns_changed(self, name, old, new):
         if self.shell is not None:
             self.shell.user_ns = new

--- a/IPython/kernel/zmq/ipkernel.py
+++ b/IPython/kernel/zmq/ipkernel.py
@@ -87,7 +87,7 @@ class Kernel(Configurable):
         if self.shell is not None:
             self.shell.user_module = new
     
-    user_ns = Dict(default_value=None)
+    user_ns = Instance(dict, args=None, allow_none=True)
     def _user_ns_changed(self, name, old, new):
         if self.shell is not None:
             self.shell.user_ns = new

--- a/IPython/kernel/zmq/tests/test_start_kernel.py
+++ b/IPython/kernel/zmq/tests/test_start_kernel.py
@@ -8,10 +8,38 @@ def test_ipython_start_kernel_userns():
     cmd = ('from IPython import start_kernel\n'
            'ns = {"tre": 123}\n'
            'start_kernel(user_ns=ns)')
-    
+
     with setup_kernel(cmd) as client:
         msg_id = client.object_info('tre')
         msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
         content = msg['content']
         assert content['found']
         nt.assert_equal(content['string_form'], u'123')
+
+        # user_module should be an instance of DummyMod
+        msg_id = client.execute("usermod = get_ipython().user_module")
+        msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
+        content = msg['content']
+        nt.assert_equal(content['status'], u'ok')
+        msg_id = client.object_info('usermod')
+        msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
+        content = msg['content']
+        assert content['found']
+        nt.assert_in('DummyMod', content['string_form'])
+
+def test_ipython_start_kernel_no_userns():
+    # Issue #4188 - user_ns should be passed to shell as None, not {}
+    cmd = ('from IPython import start_kernel\n'
+           'start_kernel()')
+
+    with setup_kernel(cmd) as client:
+        # user_module should not be an instance of DummyMod
+        msg_id = client.execute("usermod = get_ipython().user_module")
+        msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
+        content = msg['content']
+        nt.assert_equal(content['status'], u'ok')
+        msg_id = client.object_info('usermod')
+        msg = client.get_shell_msg(block=True, timeout=TIMEOUT)
+        content = msg['content']
+        assert content['found']
+        nt.assert_not_in('DummyMod', content['string_form'])


### PR DESCRIPTION
The Dict trait converts None to an empty dict, which caused the application to pass in a user_ns to the shell, which then behaves slightly differently, creating a DummyMod instance.

Ping @minrk : Is this the best way to fix this?
