### PR TITLE
always fire LOCAL_IPS.extend(PUBLIC_IPS)

### DIFF
--- a/IPython/utils/localinterfaces.py
+++ b/IPython/utils/localinterfaces.py
@@ -43,7 +43,7 @@ try:
         PUBLIC_IPS = socket.gethostbyname_ex(socket.gethostname() + '.local')[2]
 except socket.error:
     pass
-else:
+finally:
     PUBLIC_IPS = uniq_stable(PUBLIC_IPS)
     LOCAL_IPS.extend(PUBLIC_IPS)
 


### PR DESCRIPTION
was in `else`, but should have been `finally` so it aways runs.

Symptom was warnings in parallel.client about `127.0.1.1` not being this machine.

backport to 1.1
