### PR TITLE
HeadingCells cannot be split or merged

### DIFF
--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -207,10 +207,19 @@ var IPython = (function (IPython) {
 
 
     /**
-     * can the cell be splitted in 2 cells.
+     * can the cell be split into two cells
      * @method is_splittable
      **/
     Cell.prototype.is_splittable = function () {
+        return true;
+    };
+
+
+    /**
+     * can the cell be merged with other cells
+     * @method is_mergeable
+     **/
+    Cell.prototype.is_mergeable = function () {
         return true;
     };
 

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1175,8 +1175,14 @@ var IPython = (function (IPython) {
     Notebook.prototype.merge_cell_above = function () {
         var index = this.get_selected_index();
         var cell = this.get_cell(index);
+        if (!cell.is_mergeable()) {
+            return;
+        }
         if (index > 0) {
             var upper_cell = this.get_cell(index-1);
+            if (!upper_cell.is_mergeable()) {
+                return;
+            }
             var upper_text = upper_cell.get_text();
             var text = cell.get_text();
             if (cell instanceof IPython.CodeCell) {
@@ -1199,8 +1205,14 @@ var IPython = (function (IPython) {
     Notebook.prototype.merge_cell_below = function () {
         var index = this.get_selected_index();
         var cell = this.get_cell(index);
+        if (!cell.is_mergeable()) {
+            return;
+        }
         if (index < this.ncells()-1) {
             var lower_cell = this.get_cell(index+1);
+            if (!lower_cell.is_mergeable()) {
+                return;
+            }
             var lower_text = lower_cell.get_text();
             var text = cell.get_text();
             if (cell instanceof IPython.CodeCell) {

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -482,6 +482,22 @@ var IPython = (function (IPython) {
         return data;
     };
 
+    /**
+     * can the cell be split into two cells
+     * @method is_splittable
+     **/
+    HeadingCell.prototype.is_splittable = function () {
+        return false;
+    };
+
+
+    /**
+     * can the cell be merged with other cells
+     * @method is_mergeable
+     **/
+    HeadingCell.prototype.is_mergeable = function () {
+        return false;
+    };
 
     /**
      * Change heading level of cell, and re-render


### PR DESCRIPTION
Merging with heading cells can lose data, and never makes sense.

Closes #4200.
