### PR TITLE
nbconvert: Pandoc nowrap

### DIFF
--- a/IPython/nbconvert/filters/markdown.py
+++ b/IPython/nbconvert/filters/markdown.py
@@ -52,7 +52,7 @@ def markdown2latex(source):
 
 def markdown2html(source):
     """Convert a markdown string to HTML via pandoc"""
-    return pandoc(source, 'markdown', 'html', extra_args=['--mathjax --no-wrap'])
+    return pandoc(source, 'markdown', 'html', extra_args=['--mathjax', '--no-wrap'])
 
 def markdown2rst(source):
     """Convert a markdown string to LaTeX via pandoc.

--- a/IPython/nbconvert/filters/markdown.py
+++ b/IPython/nbconvert/filters/markdown.py
@@ -47,12 +47,12 @@ def markdown2latex(source):
     out : string
       Output as returned by pandoc.
     """
-    return pandoc(source, 'markdown', 'latex')
+    return pandoc(source, 'markdown', 'latex', extra_args=['--no-wrap'])
 
 
 def markdown2html(source):
     """Convert a markdown string to HTML via pandoc"""
-    return pandoc(source, 'markdown', 'html', extra_args=['--mathjax'])
+    return pandoc(source, 'markdown', 'html', extra_args=['--mathjax --no-wrap'])
 
 def markdown2rst(source):
     """Convert a markdown string to LaTeX via pandoc.
@@ -70,5 +70,5 @@ def markdown2rst(source):
     out : string
       Output as returned by pandoc.
     """
-    return pandoc(source, 'markdown', 'rst')
+    return pandoc(source, 'markdown', 'rst', extra_args=['--no-wrap'])
 


### PR DESCRIPTION
fixes #4122

If there is going to be a 1.2 release, this should probably be back-ported.

Line wrapping should be handled by templates / nbconvert if needed.  Pandoc line wrapping was causing pdflatex to crash because it was adding line breaks to long headers (Pandoc bug?).
