### PR TITLE
use TextIOWrapper when communicating with pandoc subprocess

### DIFF
--- a/IPython/nbconvert/tests/files/notebook2.ipynb
+++ b/IPython/nbconvert/tests/files/notebook2.ipynb
@@ -124,6 +124,14 @@
      "prompt_number": 10
     },
     {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Here is a very long heading that pandoc will wrap and wrap and wrap and wrap and wrap and wrap and wrap and wrap and wrap and wrap and wrap and wrap"
+     ]
+    },
+    {
      "cell_type": "markdown",
      "metadata": {},
      "source": [

--- a/IPython/nbconvert/tests/test_nbconvertapp.py
+++ b/IPython/nbconvert/tests/test_nbconvertapp.py
@@ -103,6 +103,20 @@ class TestNbConvertApp(TestsBase):
             assert os.path.isfile('notebook1.tex')
             assert os.path.isfile('notebook1.pdf')
 
+    @dec.onlyif_cmds_exist('pandoc')
+    def test_spurious_cr(self):
+        """Check for extra CR characters"""
+        with self.create_temp_cwd(['notebook2.ipynb']):
+            self.call('nbconvert --log-level 0 --to latex notebook2')
+            assert os.path.isfile('notebook2.tex')
+            with open('notebook2.tex') as f:
+                tex = f.read()
+            self.call('nbconvert --log-level 0 --to html notebook2')
+            assert os.path.isfile('notebook2.html')
+            with open('notebook2.html') as f:
+                html = f.read()
+        self.assertEqual(tex.count('\r'), tex.count('\r\n'))
+        self.assertEqual(html.count('\r'), html.count('\r\n'))
 
     @dec.onlyif_cmds_exist('pandoc')
     def test_png_base64_html_ok(self):
@@ -113,7 +127,6 @@ class TestNbConvertApp(TestsBase):
             assert os.path.isfile('notebook2.html')
             with open('notebook2.html') as f:
                 assert "data:image/png;base64,b'" not in f.read()
-
 
     @dec.onlyif_cmds_exist('pandoc')
     def test_template(self):

--- a/IPython/nbconvert/utils/pandoc.py
+++ b/IPython/nbconvert/utils/pandoc.py
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # Stdlib imports
 import subprocess
+from io import TextIOWrapper, BytesIO
 
 # IPython imports
 from IPython.utils.py3compat import cast_bytes
@@ -64,6 +65,6 @@ def pandoc(source, fmt, to, extra_args=None, encoding='utf-8'):
             "http://johnmacfarlane.net/pandoc/installing.html"
         )
     out, _ = p.communicate(cast_bytes(source, encoding))
-    out = out.decode(encoding, 'replace')
-    return out[:-1]
+    out = TextIOWrapper(BytesIO(out), encoding, 'replace').read()
+    return out.rstrip('\n')
 


### PR DESCRIPTION
uses 'universal-newline' mode, to avoid any confusion with CRLF.

closes #4122 
closes #3819

alternative to #4202
