### PR TITLE
Added a lightweight "htmlcore" Makefile entry

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -52,9 +52,9 @@ dist: html
 	cp -al build/html .
 	@echo "Build finished.  Final docs are in html/"
 
-html: core api
+html: api htmlcore
 
-core:
+htmlcore:
 	mkdir -p build/html build/doctrees
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) build/html
 	@echo

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -52,7 +52,9 @@ dist: html
 	cp -al build/html .
 	@echo "Build finished.  Final docs are in html/"
 
-html: api
+html: core api
+
+core:
 	mkdir -p build/html build/doctrees
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) build/html
 	@echo

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -52,9 +52,10 @@ dist: html
 	cp -al build/html .
 	@echo "Build finished.  Final docs are in html/"
 
-html: api htmlcore
+html: api 
+html_noapi: clean
 
-htmlcore:
+html html_noapi:
 	mkdir -p build/html build/doctrees
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) build/html
 	@echo


### PR DESCRIPTION
`make htmlcore` now runs a lightweight doc build process that doesn't include the
"api" target. The "html" target now just references "api" and "htmlcore".

This patch is a candidate for backporting to 1.x.
