### PR TITLE
Magic doc fixes

### DIFF
--- a/IPython/extensions/cythonmagic.py
+++ b/IPython/extensions/cythonmagic.py
@@ -4,8 +4,17 @@
 Cython related magics
 =====================
 
+Magic command interface for interactive work with Cython
+
+.. note::
+
+  The ``Cython`` package needs to be installed separately. It
+  can be obtained using ``easy_install`` or ``pip``.
+
 Usage
 =====
+
+To enable the magics below, execute ``%load_ext cythonmagic``.
 
 ``%%cython``
 

--- a/IPython/extensions/octavemagic.py
+++ b/IPython/extensions/octavemagic.py
@@ -11,8 +11,12 @@ Magics for interacting with Octave via oct2py.
   The ``oct2py`` module needs to be installed separately and
   can be obtained using ``easy_install`` or ``pip``.
 
+  You will also need a working copy of GNU Octave.
+
 Usage
 =====
+
+To enable the magics below, execute ``%load_ext octavemagic``.
 
 ``%octave``
 

--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -6,8 +6,17 @@ Rmagic
 
 Magic command interface for interactive work with R via rpy2
 
+.. note::
+
+  The ``rpy2`` package needs to be installed separately. It
+  can be obtained using ``easy_install`` or ``pip``.
+
+  You will also need a working copy of R.
+
 Usage
 =====
+
+To enable the magics below, execute ``%load_ext rmagic``.
 
 ``%R``
 

--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -434,12 +434,12 @@ class RMagics(Magics):
         is printed if it would printed be when evaluating the same code 
         within a standard R REPL.
         
-        Nothing is returned to python by default in cell mode.
+        Nothing is returned to python by default in cell mode::
 
             In [10]: %%R
                ....: Y = c(2,4,3,9)
                ....: summary(lm(Y~X))
-       
+
             Call:
             lm(formula = Y ~ X)
 
@@ -456,9 +456,9 @@ class RMagics(Magics):
             Multiple R-squared: 0.6993,Adjusted R-squared: 0.549
             F-statistic: 4.651 on 1 and 2 DF,  p-value: 0.1638
 
-        In the notebook, plots are published as the output of the cell.
+        In the notebook, plots are published as the output of the cell::
 
-        %R plot(X, Y)
+            %R plot(X, Y)
 
         will create a scatter plot of X bs Y.
 
@@ -484,19 +484,19 @@ class RMagics(Magics):
         * If the cell is not None, the magic returns None.
 
         * If the cell evaluates as False, the resulting value is returned
-        unless the final line prints something to the console, in
-        which case None is returned.
+          unless the final line prints something to the console, in
+          which case None is returned.
 
         * If the final line results in a NULL value when evaluated
-        by rpy2, then None is returned.
+          by rpy2, then None is returned.
 
         * No attempt is made to convert the final value to a structured array.
-        Use the --dataframe flag or %Rget to push / return a structured array.
+          Use the --dataframe flag or %Rget to push / return a structured array.
 
         * If the -n flag is present, there is no return value.
 
         * A trailing ';' will also result in no return value as the last
-        value in the line is an empty string.
+          value in the line is an empty string.
 
         The --dataframe argument will attempt to return structured arrays. 
         This is useful for dataframes with


### PR DESCRIPTION
Closes #1986 (adds reference to load_ext in r, octave, and cython magics). In addition, adds installation requirements and other doc fixes for rmagic.

This is a candidate for backporting to 1.x.
