### PR TITLE
engine ID metadata should be unicode, not bytes

### DIFF
--- a/IPython/parallel/controller/scheduler.py
+++ b/IPython/parallel/controller/scheduler.py
@@ -358,7 +358,7 @@ class TaskScheduler(SessionFactory):
             # build fake metadata
             md = dict(
                 status=u'error',
-                engine=engine,
+                engine=engine.decode('ascii'),
                 date=datetime.now(),
             )
             msg = self.session.msg('apply_reply', content, parent=parent, metadata=md)


### PR DESCRIPTION
fixes `TypeError: b'f5b984b0-fd8c-4873-a23e-658425c1e28a' is not JSON serializable` when an engine dies while working on a task in Python 3.

candidate for backport to 1.2
