### PR TITLE
Fix display of SyntaxError when .py file is modified

### DIFF
--- a/IPython/core/tests/test_ultratb.py
+++ b/IPython/core/tests/test_ultratb.py
@@ -108,8 +108,33 @@ class IndentationErrorTest(unittest.TestCase):
                 with tt.AssertPrints("zoon()", suppress=False):
                     ip.magic('run %s' % fname)
 
+se_file_1 = """1
+2
+7/
+"""
+
+se_file_2 = """7/
+"""
+
 class SyntaxErrorTest(unittest.TestCase):
     def test_syntaxerror_without_lineno(self):
         with tt.AssertNotPrints("TypeError"):
             with tt.AssertPrints("line unknown"):
                 ip.run_cell("raise SyntaxError()")
+
+    def test_changing_py_file(self):
+        with TemporaryDirectory() as td:
+            fname = os.path.join(td, "foo.py")
+            with open(fname, 'w') as f:
+                f.write(se_file_1)
+
+            with tt.AssertPrints(["7/", "SyntaxError"]):
+                ip.magic("run " + fname)
+
+            # Modify the file
+            with open(fname, 'w') as f:
+                f.write(se_file_2)
+
+            # The SyntaxError should point to the correct line
+            with tt.AssertPrints(["7/", "SyntaxError"]):
+                ip.magic("run " + fname)

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -1198,7 +1198,8 @@ class SyntaxTB(ListTB):
         # If the source file has been edited, the line in the syntax error can
         # be wrong (retrieved from an outdated cache). This replaces it with
         # the current value.
-        if isinstance(value.filename, str) and isinstance(value.lineno, int):
+        if isinstance(value.filename, py3compat.string_types) \
+                and isinstance(value.lineno, int):
             linecache.checkcache(value.filename)
             newtext = ulinecache.getline(value.filename, value.lineno)
             if newtext:

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -1193,6 +1193,19 @@ class SyntaxTB(ListTB):
         self.last_syntax_error = value
         ListTB.__call__(self,etype,value,elist)
 
+    def structured_traceback(self, etype, value, elist, tb_offset=None,
+                             context=5):
+        # If the source file has been edited, the line in the syntax error can
+        # be wrong (retrieved from an outdated cache). This replaces it with
+        # the current value.
+        if isinstance(value.filename, str) and isinstance(value.lineno, int):
+            linecache.checkcache(value.filename)
+            newtext = ulinecache.getline(value.filename, value.lineno)
+            if newtext:
+                value.text = newtext
+        return super(SyntaxTB, self).structured_traceback(etype, value, elist,
+                             tb_offset=tb_offset, context=context)
+
     def clear_err_state(self):
         """Return the current error state and clear it"""
         e = self.last_syntax_error

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -346,6 +346,8 @@ class AssertPrints(object):
     """
     def __init__(self, s, channel='stdout', suppress=True):
         self.s = s
+        if isinstance(self.s, str):
+            self.s = [self.s]
         self.channel = channel
         self.suppress = suppress
     
@@ -359,7 +361,8 @@ class AssertPrints(object):
         self.tee.flush()
         setattr(sys, self.channel, self.orig_stream)
         printed = self.buffer.getvalue()
-        assert self.s in printed, notprinted_msg.format(self.s, self.channel, printed)
+        for s in self.s:
+            assert s in printed, notprinted_msg.format(s, self.channel, printed)
         return False
 
 printed_msg = """Found {0!r} in printed output (on {1}):
@@ -376,7 +379,8 @@ class AssertNotPrints(AssertPrints):
         self.tee.flush()
         setattr(sys, self.channel, self.orig_stream)
         printed = self.buffer.getvalue()
-        assert self.s not in printed, printed_msg.format(self.s, self.channel, printed)
+        for s in self.s:
+            assert s not in printed, printed_msg.format(s, self.channel, printed)
         return False
 
 @contextmanager

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 # Imports
 #-----------------------------------------------------------------------------
 
-import inspect
 import os
 import re
 import sys
@@ -346,7 +345,7 @@ class AssertPrints(object):
     """
     def __init__(self, s, channel='stdout', suppress=True):
         self.s = s
-        if isinstance(self.s, str):
+        if isinstance(self.s, py3compat.string_types):
             self.s = [self.s]
         self.channel = channel
         self.suppress = suppress


### PR DESCRIPTION
As described on the mailing list, the line displayed with a SyntaxError can be incorrect, when editing and rerunning a file, due to stale caching. The line appears to be retrieved from the cache when the SyntaxError is created, which we can't influence, but we can replace it before we display the error, which is what this does.
