### PR TITLE
Update connect.py

### DIFF
--- a/IPython/kernel/connect.py
+++ b/IPython/kernel/connect.py
@@ -360,7 +360,7 @@ def tunnel_to_kernel(connection_info, sshserver, sshkey=None):
     if tunnel.try_passwordless_ssh(sshserver, sshkey):
         password=False
     else:
-        password = getpass("SSH Password for %s: "%sshserver)
+        password = getpass("SSH Password for %s: "%str(sshserver))
     
     for lp,rp in zip(lports, rports):
         tunnel.ssh_tunnel(lp, rp, sshserver, remote_ip, sshkey, password)


### PR DESCRIPTION
Fixing a bug on windows 7 32 bit : 

[IPythonQtConsoleApp] ERROR | Could not setup tunnels
Traceback (most recent call last):
  File "C:\Anaconda\lib\site-packages\IPython\consoleapp.py", line 304, in init_
ssh
    newports = tunnel_to_kernel(info, self.sshserver, self.sshkey)
  File "C:\Anaconda\lib\site-packages\IPython\kernel\connect.py", line 364, in t
unnel_to_kernel
    password = getpass("SSH Password for %s: "%sshserver)
  File "C:\Anaconda\lib\getpass.py", line 95, in win_getpass
    msvcrt.putch(c)
TypeError: must be char, not unicode
[IPythonQtConsoleApp] Exiting application: ipython-qtconsole
When calling getpass,
TypeError: must be char, not unicode
