### PR TITLE
clear previous callbacks on execute

### DIFF
--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -66,6 +66,7 @@ var IPython = (function (IPython) {
         this.input_prompt_number = null;
         this.collapsed = false;
         this.cell_type = "code";
+        this.last_msg_id = null;
 
 
         var cm_overwrite_options  = {
@@ -243,6 +244,9 @@ var IPython = (function (IPython) {
         this.output_area.clear_output(true, true, true);
         this.set_input_prompt('*');
         this.element.addClass("running");
+        if (this.last_msg_id) {
+            this.kernel.clear_callbacks_for_msg(this.last_msg_id);
+        }
         var callbacks = {
             'execute_reply': $.proxy(this._handle_execute_reply, this),
             'output': $.proxy(this.output_area.handle_output, this.output_area),
@@ -250,7 +254,7 @@ var IPython = (function (IPython) {
             'set_next_input': $.proxy(this._handle_set_next_input, this),
             'input_request': $.proxy(this._handle_input_request, this)
         };
-        var msg_id = this.kernel.execute(this.get_text(), callbacks, {silent: false, store_history: true});
+        this.last_msg_id = this.kernel.execute(this.get_text(), callbacks, {silent: false, store_history: true});
     };
 
     /**

--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -403,9 +403,16 @@ var IPython = (function (IPython) {
     };
 
 
+    Kernel.prototype.clear_callbacks_for_msg = function (msg_id) {
+        if (this._msg_callbacks[msg_id] !== undefined ) {
+            delete this._msg_callbacks[msg_id];
+        }
+    };
+
+
     Kernel.prototype.set_callbacks_for_msg = function (msg_id, callbacks) {
         this._msg_callbacks[msg_id] = callbacks || {};
-    }
+    };
 
 
     Kernel.prototype._handle_shell_reply = function (e) {


### PR DESCRIPTION
avoids mixed up display of multiple executions in one output area when a
cell is resubmitted.

closes #4223
