### PR TITLE
Updated docstring for core.display.Image

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -508,9 +508,9 @@ class Image(DisplayObject):
     _ACCEPTABLE_EMBEDDINGS = [_FMT_JPEG, _FMT_PNG]
 
     def __init__(self, data=None, url=None, filename=None, format=u'png', embed=None, width=None, height=None, retina=False):
-        """Create a display an PNG/JPEG image given raw data.
+        """Create a PNG/JPEG image object given raw data.
 
-        When this object is returned by an expression or passed to the
+        When this object is returned by an input cell or passed to the
         display function, it will result in the image being displayed
         in the frontend.
 


### PR DESCRIPTION
Fixed docstring for Image that lead to misunderstanding in Issue #4222.

I also changed the wording `returned by an expression` to `returned by an input cell`. If this is deemed better it can also be applied to the classes JavaScript and DisplayObject which use identical language.
