### PR TITLE
update -dev docs to reflect latest stable version

### DIFF
--- a/IPython/core/release.py
+++ b/IPython/core/release.py
@@ -26,7 +26,7 @@ _version_extra = 'dev'
 # _version_extra = 'rc1'
 # _version_extra = ''  # Uncomment this for full releases
 
-codename = 'An Afternoon Hack'
+codename = 'Work in Progress'
 
 # Construct full version string from these.
 _ver = [_version_major, _version_minor, _version_patch]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,7 +71,7 @@ if iprelease['_version_extra']:
     .. note::
 
         This documentation is for a development version of IPython. There may be
-        significant differences from the latest stable release (0.13.2).
+        significant differences from the latest stable release (1.1.0).
 
     """
 


### PR DESCRIPTION
also updated the release codename, so it doesn't stay with the old "An 
Afternoon Hack" one.

After this is merged, it'd be good to build the docs and push them to 
http://ipython.org/ipython-doc/dev/ - and I don't believe I have the 
permission to do that, but @minrk and @takluyver probably do.
