### PR TITLE
Switch correctly to the user's default matplotlib backend after inline.

### DIFF
--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -214,7 +214,10 @@ def find_gui_and_backend(gui=None, gui_select=None):
         # select backend based on requested gui
         backend = backends[gui]
     else:
-        backend = matplotlib.rcParams['backend']
+        # We need to read the backend from the original data structure, *not*
+        # from mpl.rcParams, since a prior invocation of %matplotlib may have
+        # overwritten that.
+        backend = matplotlib.rcParamsOrig['backend']
         # In this case, we need to find what the appropriate gui selection call
         # should be for IPython, so we can activate inputhook accordingly
         gui = backend2gui.get(backend, None)

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -217,6 +217,7 @@ def find_gui_and_backend(gui=None, gui_select=None):
         # We need to read the backend from the original data structure, *not*
         # from mpl.rcParams, since a prior invocation of %matplotlib may have
         # overwritten that.
+        # WARNING: this assumes matplotlib 1.1 or newer!!
         backend = matplotlib.rcParamsOrig['backend']
         # In this case, we need to find what the appropriate gui selection call
         # should be for IPython, so we can activate inputhook accordingly

--- a/docs/source/whatsnew/pr/incompat-mpl-backend.rst
+++ b/docs/source/whatsnew/pr/incompat-mpl-backend.rst
@@ -1,0 +1,4 @@
+We fixed an issue with switching between matplotlib inline and GUI backends,
+but the fix requires matplotlib 1.1 or newer.  So from now on, we consider
+matplotlib 1.1 to be the minimally supported version for IPython. Older
+versions for the most part will work, but we make no guarantees about it.


### PR DESCRIPTION
If '%matplotlib inline' was called first, we'd incorrectly revert to
inline when plain '%matplotlib' was called, instead of loading the
user's default GUI.  If the user called '%matplotlib' first (without
'inline') it worked correctly, but not in the other order.

The fix is to read the backend from the original defaults, not from
the runtime data structure.
