### PR TITLE
Fix javascript output alignment bug

### DIFF
--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -320,7 +320,7 @@ var IPython = (function (IPython) {
 
 
     OutputArea.prototype.create_output_area = function () {
-        var oa = $("<div/>").addClass("output_area");
+        var oa = $("<div/>").addClass("output_area").addClass("hbox");
         if (this.prompt_area) {
             oa.append($('<div/>').addClass('prompt'));
         }

--- a/IPython/html/static/notebook/less/outputarea.less
+++ b/IPython/html/static/notebook/less/outputarea.less
@@ -23,11 +23,10 @@ div.output_area {
     }
 }
 
-
 /* This is needed to protect the pre formating from global settings such
    as that of bootstrap */
-div.output_area pre {	
-    font-family: @monoFontFamily;	
+div.output_area pre {
+    font-family: @monoFontFamily;
     margin: 0;
     padding: 0;
     border: 0;
@@ -75,6 +74,9 @@ div.output_latex {
 }
 
 div.output_html {
+}
+
+div.output_javascript {
 }
 
 div.output_png {


### PR DESCRIPTION
This fixed the output alignment issue in the notebook for javascript cells. 

I forced the display attribute of the output_area to always be `flex`. That way, when you call `.show()` in a javascript cell, it won't inherit the default display attribute `block`. This was causing the issue shown here:

![screen shot 2013-08-23 at 11 18 36 pm](https://f.cloud.github.com/assets/2791223/1170492/a662fe14-20de-11e3-9770-fd76f5d95ae5.png)

It should be aligned underneath the cell like this:

![screen shot 2013-08-23 at 11 14 30 pm](https://f.cloud.github.com/assets/2791223/1170499/b16a253a-20de-11e3-9ed0-9c8211116a38.png)

Also, I added a CSS class for javascript output. This isn't used to fix this issue, but we have it for all other output types, so I added it for consistency. We may use it in the future.
