### PR TITLE
no highlight if no language specified

### DIFF
--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -99,6 +99,10 @@ function (marked) {
             tables: true,
             langPrefix: "language-",
             highlight: function(code, lang) {
+                if (!lang) {
+                    // no language, no highlight
+                    return code;
+                }
                 var highlighted;
                 try {
                     highlighted = hljs.highlight(lang, code, false);


### PR DESCRIPTION
This matches behavior of places like GitHub, where if you do not specify a language, e.g.

``````
```
no_highlighting("here")
```
``````

There is no syntax highlighting. You must do

``````
```python
def foo(a="hi"):
    return 5
```
``````

to enable highlighting in a particular language.

With configuration as it is right now in IPython, it is impossible to disable syntax highlighting in markdown blocks.
