### PR TITLE
display: scope SVG's style elements so they do not leak

### DIFF
--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -302,6 +302,8 @@ var IPython = (function (IPython) {
         this.outputs.push(json);
         var that = this;
         setTimeout(function(){that.element.trigger('resize');}, 100);
+        // Call jquery.scoped plugin to scope svg's style
+        $.scoped();
     };
 
 

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -223,6 +223,7 @@ class="notebook_app"
 <script src="{{ static_url("notebook/js/codemirror-ipython.js") }}" charset="utf-8"></script>
 
 <script src="{{ static_url("components/highlight.js/build/highlight.pack.js") }}" charset="utf-8"></script>
+<script src="{{ static_url("components/jquery.scoped.js/jquery.scoped.js") }}" charset="utf-8"></script>
 
 <script src="{{ static_url("dateformat/date.format.js") }}" charset="utf-8"></script>
 


### PR DESCRIPTION
When multiple SVG figures are inlined in the same DOM, they
share the same css namespace. This patch, scopes each SVG's style
block so it does not leak into other figures.

Should help fixing #1866

---

Please see #1866 for the discussion.
(This pull request needs an accompanying patch on ipython-components: https://github.com/ipython/ipython-components/pull/8)
