### PR TITLE
Keywords should shadow magic functions

### DIFF
--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -24,6 +24,7 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
+from keyword import iskeyword
 import re
 
 from IPython.core.autocall import IPyAutocall
@@ -80,7 +81,8 @@ def is_shadowed(identifier, ip):
     # This is much safer than calling ofind, which can change state
     return (identifier in ip.user_ns \
             or identifier in ip.user_global_ns \
-            or identifier in ip.ns_table['builtin'])
+            or identifier in ip.ns_table['builtin']\
+            or iskeyword(identifier))
 
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/tests/test_prefilter.py
+++ b/IPython/core/tests/test_prefilter.py
@@ -28,6 +28,7 @@ def test_prefilter_shadowed():
 
     prev_automagic_state = ip.automagic
     ip.automagic = True
+    ip.autocall = 0
 
     try:
         # These should not be transformed - they are shadowed by other names

--- a/IPython/core/tests/test_prefilter.py
+++ b/IPython/core/tests/test_prefilter.py
@@ -23,6 +23,29 @@ def test_prefilter():
     for raw, correct in pairs:
         nt.assert_equal(ip.prefilter(raw), correct)
 
+def test_prefilter_shadowed():
+    def dummy_magic(line): pass
+
+    prev_automagic_state = ip.automagic
+    ip.automagic = True
+
+    try:
+        # These should not be transformed - they are shadowed by other names
+        for name in ['if', 'zip', 'get_ipython']: # keyword, builtin, global
+            ip.register_magic_function(dummy_magic, magic_name=name)
+            res = ip.prefilter(name+' foo')
+            nt.assert_equal(res, name+' foo')
+            del ip.magics_manager.magics['line'][name]
+
+        # These should be transformed
+        for name in ['fi', 'piz', 'nohtypi_teg']:
+            ip.register_magic_function(dummy_magic, magic_name=name)
+            res = ip.prefilter(name+' foo')
+            nt.assert_not_equal(res, name+' foo')
+            del ip.magics_manager.magics['line'][name]
+
+    finally:
+        ip.automagic = prev_automagic_state
 
 def test_autocall_binops():
     """See https://github.com/ipython/ipython/issues/81"""


### PR DESCRIPTION
This is a problem I discovered while working on #4151 with @fperez.

Before:

```
In [1]: def myif(line):
   ...:     print 'boo'
   ...:     

In [2]: ip = get_ipython()

In [3]: ip.register_magic_function(myif, magic_name='if')

In [4]: if foo
boo
```

After:

```
In [1]: def myif(line):
    print 'boo'
   ...:     

In [2]: ip = get_ipython()

In [3]: ip.register_magic_function(myif, magic_name='if')

In [4]: if foo
  File "<ipython-input-4-4533b1cb7f6e>", line 1
    if foo
          ^
SyntaxError: invalid syntax
```
