### PR TITLE
outputarea.js: Wrap inline SVGs inside an iframe

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -363,30 +363,6 @@ class Latex(DisplayObject):
 
 class SVG(DisplayObject):
 
-    def __init__(self, data=None, url=None, filename=None, scoped=False):
-        """Create a SVG display object given raw data.
-
-        When this object is returned by an expression or passed to the
-        display function, it will result in the data being displayed
-        in the frontend. If the data is a URL, the data will first be
-        downloaded and then displayed.
-
-        Parameters
-        ----------
-        data : unicode, str or bytes
-            The Javascript source code or a URL to download it from.
-        url : unicode
-            A URL to download the data from.
-        filename : unicode
-            Path to a local file to load the data from.
-        scoped : bool
-            Should the SVG declarations be scoped.
-        """
-        if not isinstance(scoped, (bool)):
-            raise TypeError('expected bool, got: %r' % scoped)
-        self.scoped = scoped
-        super(SVG, self).__init__(data=data, url=url, filename=filename)
-
     # wrap data in a property, which extracts the <svg> tag, discarding
     # document headers
     _data = None
@@ -416,11 +392,7 @@ class SVG(DisplayObject):
         self._data = svg
 
     def _repr_svg_(self):
-        if self.scoped:
-            metadata = dict(scoped=True)
-            return self.data, metadata
-        else:
-            return self.data
+        return self.data
 
 
 class JSON(DisplayObject):

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -409,7 +409,7 @@ class SVG(DisplayObject):
         # get svg tag (should be 1)
         found_svg = x.getElementsByTagName('svg')
         if found_svg:
-            # If the user request scoping, tag the svg with the
+            # If the user requests scoping, tag the svg with the
             # ipython-scoped class
             if self.scoped:
                 classes = (found_svg[0].getAttribute('class') +

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -395,8 +395,6 @@ class SVG(DisplayObject):
     def data(self):
         return self._data
 
-    _scoped_class = "ipython-scoped"
-
     @data.setter
     def data(self, svg):
         if svg is None:
@@ -409,12 +407,6 @@ class SVG(DisplayObject):
         # get svg tag (should be 1)
         found_svg = x.getElementsByTagName('svg')
         if found_svg:
-            # If the user requests scoping, tag the svg with the
-            # ipython-scoped class
-            if self.scoped:
-                classes = (found_svg[0].getAttribute('class') +
-                           " " + self._scoped_class)
-                found_svg[0].setAttribute('class', classes)
             svg = found_svg[0].toxml()
         else:
             # fallback on the input, trust the user
@@ -424,7 +416,11 @@ class SVG(DisplayObject):
         self._data = svg
 
     def _repr_svg_(self):
-        return self.data
+        if self.scoped:
+            metadata = dict(scoped=True)
+            return self.data, metadata
+        else:
+            return self.data
 
 
 class JSON(DisplayObject):

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -363,6 +363,30 @@ class Latex(DisplayObject):
 
 class SVG(DisplayObject):
 
+    def __init__(self, data=None, url=None, filename=None, scoped=False):
+        """Create a SVG display object given raw data.
+
+        When this object is returned by an expression or passed to the
+        display function, it will result in the data being displayed
+        in the frontend. If the data is a URL, the data will first be
+        downloaded and then displayed.
+
+        Parameters
+        ----------
+        data : unicode, str or bytes
+            The Javascript source code or a URL to download it from.
+        url : unicode
+            A URL to download the data from.
+        filename : unicode
+            Path to a local file to load the data from.
+        scoped : bool
+            Should the SVG declarations be scoped.
+        """
+        if not isinstance(scoped, (bool)):
+            raise TypeError('expected bool, got: %r' % scoped)
+        self.scoped = scoped
+        super(SVG, self).__init__(data=data, url=url, filename=filename)
+
     # wrap data in a property, which extracts the <svg> tag, discarding
     # document headers
     _data = None
@@ -370,6 +394,8 @@ class SVG(DisplayObject):
     @property
     def data(self):
         return self._data
+
+    _scoped_class = "ipython-scoped"
 
     @data.setter
     def data(self, svg):
@@ -383,6 +409,12 @@ class SVG(DisplayObject):
         # get svg tag (should be 1)
         found_svg = x.getElementsByTagName('svg')
         if found_svg:
+            # If the user request scoping, tag the svg with the
+            # ipython-scoped class
+            if self.scoped:
+                classes = (found_svg[0].getAttribute('class') +
+                           " " + self._scoped_class)
+                found_svg[0].setAttribute('class', classes)
             svg = found_svg[0].toxml()
         else:
             # fallback on the input, trust the user

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -335,6 +335,7 @@ var IPython = (function (IPython) {
             // Create an iframe to isolate the subarea from the rest of the
             // document
             var iframe = $('<iframe/>');
+            iframe.attr('height', 1);
             iframe.attr('frameborder', 0);
             iframe.attr('scrolling', 'auto');
 

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -494,9 +494,36 @@ var IPython = (function (IPython) {
 
 
     OutputArea.prototype.append_svg = function (svg, md, element) {
-        var toinsert = $("<div/>").addClass("output_subarea output_svg");
-        toinsert.append(svg);
-        element.append(toinsert);
+        // To avoid style or use collisions between multiple svg figures,
+        // svg figures are wrapped inside an iframe.
+
+        var iframe = $('<iframe/>')
+        iframe.attr('frameborder', 0);
+        iframe.attr('scrolling', 'no');
+
+        var wrapper = $("<div/>").addClass("output_subarea output_svg");
+        wrapper.append(svg);
+
+        // Once the iframe is loaded, the svg is dynamically inserted
+        iframe.on('load', function() {
+            // Set the iframe height and width to fit the svg
+            // (the +10 pixel offset handles the default body margins
+            // in Chrome)
+            var svg = wrapper.children()[0];
+            iframe.width(svg.width.baseVal.value + 10);
+            iframe.height(svg.height.baseVal.value + 10);
+
+            // Workaround needed by Firefox, to properly render svg inside iframes,
+            // see http://stackoverflow.com/questions/10177190/svg-dynamically-added-to-iframe-does-not-render-correctly
+            iframe.contents()[0].open();
+            iframe.contents()[0].close();
+
+            // Insert the svg inside the iframe
+            var body = iframe.contents().find('body');
+            body.html(wrapper.html());
+        });
+
+        element.append(iframe);
     };
 
 

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -502,7 +502,7 @@ var IPython = (function (IPython) {
             // To avoid style or use collisions between multiple svg figures,
             // svg figures are wrapped inside an iframe.
             var iframe = $('<iframe/>')
-                iframe.attr('frameborder', 0);
+            iframe.attr('frameborder', 0);
             iframe.attr('scrolling', 'no');
 
             // Once the iframe is loaded, the svg is dynamically inserted

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -334,8 +334,9 @@ var IPython = (function (IPython) {
         if (md['isolated']) {
             // Create an iframe to isolate the subarea from the rest of the
             // document
-            var iframe = $('<iframe/>');
+            var iframe = $('<iframe/>').addClass('box-flex1');
             iframe.attr('height', 1);
+            iframe.css({'width':'100%', 'display':'block'});
             iframe.attr('frameborder', 0);
             iframe.attr('scrolling', 'auto');
 
@@ -355,8 +356,7 @@ var IPython = (function (IPython) {
                 this.contentDocument.close();
 
                 var body = this.contentDocument.body;
-                // Adjust the iframe width and height
-                iframe.width(body.scrollWidth + 'px');
+                // Adjust the iframe height automatically
                 iframe.height(body.scrollHeight + 'px');
             });
 

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -494,36 +494,40 @@ var IPython = (function (IPython) {
 
 
     OutputArea.prototype.append_svg = function (svg, md, element) {
-        // To avoid style or use collisions between multiple svg figures,
-        // svg figures are wrapped inside an iframe.
-
-        var iframe = $('<iframe/>')
-        iframe.attr('frameborder', 0);
-        iframe.attr('scrolling', 'no');
-
-        var wrapper = $("<div/>").addClass("output_subarea output_svg");
+        var wrapper = $('<div/>').addClass('output_subarea output_svg');
         wrapper.append(svg);
+        var svg_element = wrapper.children()[0];
 
-        // Once the iframe is loaded, the svg is dynamically inserted
-        iframe.on('load', function() {
-            // Set the iframe height and width to fit the svg
-            // (the +10 pixel offset handles the default body margins
-            // in Chrome)
-            var svg = wrapper.children()[0];
-            iframe.width(svg.width.baseVal.value + 10);
-            iframe.height(svg.height.baseVal.value + 10);
+        if (svg_element.classList.contains('ipython-scoped')) {
+            // To avoid style or use collisions between multiple svg figures,
+            // svg figures are wrapped inside an iframe.
+            var iframe = $('<iframe/>')
+                iframe.attr('frameborder', 0);
+            iframe.attr('scrolling', 'no');
 
-            // Workaround needed by Firefox, to properly render svg inside iframes,
-            // see http://stackoverflow.com/questions/10177190/svg-dynamically-added-to-iframe-does-not-render-correctly
-            iframe.contents()[0].open();
-            iframe.contents()[0].close();
+            // Once the iframe is loaded, the svg is dynamically inserted
+            iframe.on('load', function() {
+                // Set the iframe height and width to fit the svg
+                // (the +10 pixel offset handles the default body margins
+                // in Chrome)
+                iframe.width(svg_element.width.baseVal.value + 10);
+                iframe.height(svg_element.height.baseVal.value + 10);
 
-            // Insert the svg inside the iframe
-            var body = iframe.contents().find('body');
-            body.html(wrapper.html());
-        });
+                // Workaround needed by Firefox, to properly render svg inside
+                // iframes, see http://stackoverflow.com/questions/10177190/
+                // svg-dynamically-added-to-iframe-does-not-render-correctly
+                iframe.contents()[0].open();
+                iframe.contents()[0].close();
 
-        element.append(iframe);
+                // Insert the svg inside the iframe
+                var body = iframe.contents().find('body');
+                body.html(wrapper.html());
+            });
+
+            element.append(iframe);
+        } else {
+            element.append(wrapper);
+        }
     };
 
 

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -498,7 +498,7 @@ var IPython = (function (IPython) {
         wrapper.append(svg);
         var svg_element = wrapper.children()[0];
 
-        if (svg_element.classList.contains('ipython-scoped')) {
+        if (md['scoped']) {
             // To avoid style or use collisions between multiple svg figures,
             // svg figures are wrapped inside an iframe.
             var iframe = $('<iframe/>')

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -335,8 +335,7 @@ var IPython = (function (IPython) {
             // Create an iframe to isolate the subarea from the rest of the
             // document
             var iframe = $('<iframe/>').addClass('box-flex1');
-            iframe.attr('height', 1);
-            iframe.css({'width':'100%', 'display':'block'});
+            iframe.css({'height':1, 'width':'100%', 'display':'block'});
             iframe.attr('frameborder', 0);
             iframe.attr('scrolling', 'auto');
 

--- a/IPython/html/tests/casperjs/test_cases/isolated_svg.js
+++ b/IPython/html/tests/casperjs/test_cases/isolated_svg.js
@@ -1,6 +1,6 @@
 //
 // Test svg isolation
-// An object whoose metadata contains an "isolated" tag must be isolated
+// An object whose metadata contains an "isolated" tag must be isolated
 // from the rest of the document. In the case of inline SVGs, this means
 // that multiple SVGs have different scopes. This test checks that there
 // are no CSS leaks between two isolated SVGs.

--- a/IPython/html/tests/casperjs/test_cases/isolated_svg.js
+++ b/IPython/html/tests/casperjs/test_cases/isolated_svg.js
@@ -1,0 +1,42 @@
+//
+// Test svg isolation
+// An object whoose metadata contains an "isolated" tag must be isolated
+// from the rest of the document. In the case of inline SVGs, this means
+// that multiple SVGs have different scopes. This test checks that there
+// are no CSS leaks between two isolated SVGs.
+//
+
+casper.notebook_test(function () {
+    this.evaluate(function () {
+        var cell = IPython.notebook.get_cell(0);
+        cell.set_text( "from IPython.core.display import SVG, display_svg\n"
+                     + "s1 = '''<svg width='1cm' height='1cm' viewBox='0 0 1000 500'>"
+                     + "<defs><style>rect {fill:red;}; </style></defs>"
+                     + "<rect id='r1' x='200' y='100' width='600' height='300' /></svg>"
+                     + "'''\n"
+                     + "s2 = '''<svg width='1cm' height='1cm' viewBox='0 0 1000 500'>"
+                     + "<rect id='r2' x='200' y='100' width='600' height='300' /></svg>"
+                     + "'''\n"
+                     + "display_svg(SVG(s1), metadata=dict(isolated=True))\n"
+                     + "display_svg(SVG(s2), metadata=dict(isolated=True))\n"
+            );
+        cell.execute();
+    });
+
+    this.wait_for_output(0);
+
+    this.then(function () {
+        var colors = this.evaluate(function () {
+            var colors = [];
+            var ifr = __utils__.findAll("iframe");
+            var svg1 = ifr[0].contentWindow.document.getElementById('r1');
+            colors[0] = window.getComputedStyle(svg1)["fill"];
+            var svg2 = ifr[1].contentWindow.document.getElementById('r2');
+            colors[1] = window.getComputedStyle(svg2)["fill"];
+            return colors;
+        });
+
+        this.test.assertEquals(colors[0], '#ff0000', 'First svg should be red');
+        this.test.assertEquals(colors[1], '#000000', 'Second svg should be black');
+    });
+});


### PR DESCRIPTION
When multiple inline SVGs are included in a single document,
they share the same parse tree. Therefore, style collisions and
use id collisions can occur and upset the rendering.

This patch wraps each SVG inside an individual iframe, ensuring
that SVG's declarations do not collide.

(The SVG representation is kept as XML and not converted to a binary
format, so I do not think this approach precludes the use of d3.js)

Tested on:
- Chrome Version 29.0.1547.57 Debian 7.1 (217859)
- Mozilla/5.0 (X11; Linux x86_64; rv:17.0) Gecko/20130806 Firefox/17.0 Iceweasel/17.0.8

Closes #1866
## 

This PR wraps SVG figures inside an iframe (originally suggested by @Carreau in #1866).
