### PR TITLE
fixes #4039.

### DIFF
--- a/IPython/html/static/notebook/js/celltoolbar.js
+++ b/IPython/html/static/notebook/js/celltoolbar.js
@@ -329,7 +329,8 @@ var IPython = (function (IPython) {
      *
      * @param list_list {list of sublist} List of sublist of metadata value and name in the dropdown list.
      *        subslit shoud contain 2 element each, first a string that woul be displayed in the dropdown list,
-     *        and second the corresponding value to  be passed to setter/return by getter.
+     *        and second the corresponding value to  be passed to setter/return by getter. the corresponding value 
+     *        should not be "undefined" or behavior can be unexpected.
      * @param setter {function( cell, newValue )}
      *        A setter method to set the newValue
      * @param getter {function( cell )}
@@ -341,7 +342,7 @@ var IPython = (function (IPython) {
      * @example
      *
      *      var select_type = CellToolbar.utils.select_ui_generator([
-     *              ["<None>"            , undefined      ],
+     *              ["<None>"       , "None"      ],
      *              ["Header Slide" , "header_slide" ],
      *              ["Slide"        , "slide"        ],
      *              ["Fragment"     , "fragment"     ],

--- a/IPython/html/static/notebook/js/celltoolbarpresets/slideshow.js
+++ b/IPython/html/static/notebook/js/celltoolbarpresets/slideshow.js
@@ -9,14 +9,6 @@
 //CellToolbar Example
 //============================================================================
 
-/**
- * $.getScript('/static/js/celltoolbarpresets/slideshow.js');
- * ```
- * or more generally  
- * ```
- * $.getScript('url to this file');
- * ```
- */
  // IIFE without asignement, we don't modifiy the IPython namespace
 (function (IPython) {
     "use strict";
@@ -25,7 +17,7 @@
     var slideshow_preset = [];
 
     var select_type = CellToolbar.utils.select_ui_generator([
-            ["-"            ,undefined      ],
+            ["-"            ,"-"            ],
             ["Slide"        ,"slide"        ],
             ["Sub-Slide"    ,"subslide"     ],
             ["Fragment"     ,"fragment"     ],


### PR DESCRIPTION
Issues is that $(selector).val() return the associated text if no data
is present (hence one cannot associate explicitely an option to
"undefined")

fix in doc and example.

Ping @damianavila that might be affected by this slight change, but shouldn't has we were obviously already storing '-' in metadata.
