### PR TITLE
fix unicode argv parsing

### DIFF
--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -144,7 +144,7 @@ class Application(SingletonConfigurable):
     version = Unicode(u'0.0')
     
     # the argv used to initialize the application
-    argv = List(Unicode)
+    argv = List()
 
     # The log level for the application
     log_level = Enum((0,10,20,30,40,50,'DEBUG','INFO','WARN','ERROR','CRITICAL'),

--- a/IPython/config/tests/test_application.py
+++ b/IPython/config/tests/test_application.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 """
 Tests for IPython.config.application.Application
 
@@ -185,4 +186,8 @@ class TestApplication(TestCase):
         self.assertEqual(app.bar.b, 5)
         self.assertEqual(app.extra_args, ['extra', '--disable', 'args'])
     
+    def test_unicode_argv(self):
+        app = MyApp()
+        app.parse_command_line(['ünîcødé'])
+        
 


### PR DESCRIPTION
There was a bad traitlet validation introduced in 1.1

closes #4256
