### PR TITLE
Use subprocess for system_raw

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2239,10 +2239,8 @@ class InteractiveShell(SingletonConfigurable):
             cmd = py3compat.unicode_to_str(cmd)
             # Call the cmd using the OS shell, instead of the default /bin/sh, if set.
             ec = subprocess.call(cmd, shell=True, executable=os.environ.get('SHELL', None))
-            # Returns either the exit code or minus the value of the signal number.
-            # See the docs for subprocess.Popen.returncode .
-            if ec < 0:
-                ec = -ec
+            # exit code is positive for program failure, or negative for
+            # terminating signal number.
         
         # We explicitly do NOT return the subprocess status code, because
         # a non-None value would trigger :func:`sys.displayhook` calls.

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -28,6 +28,7 @@ import runpy
 import sys
 import tempfile
 import types
+import subprocess
 from io import open as io_open
 
 from IPython.config.configurable import SingletonConfigurable
@@ -2235,7 +2236,7 @@ class InteractiveShell(SingletonConfigurable):
                 ec = os.system(cmd)
         else:
             cmd = py3compat.unicode_to_str(cmd)
-            ec = os.system(cmd)
+            ec = subprocess.call(cmd, shell=True, executable=os.environ.get('SHELL'))
             # The high byte is the exit code, the low byte is a signal number
             # that we discard for now. See the docs for os.wait()
             if ec > 255:

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2218,7 +2218,8 @@ class InteractiveShell(SingletonConfigurable):
         self.user_ns['_exit_code'] = system(self.var_expand(cmd, depth=1))
 
     def system_raw(self, cmd):
-        """Call the given cmd in a subprocess using os.system
+        """Call the given cmd in a subprocess using os.system on Windows or
+        subprocess.call using the system shell on other platforms.
 
         Parameters
         ----------
@@ -2236,11 +2237,12 @@ class InteractiveShell(SingletonConfigurable):
                 ec = os.system(cmd)
         else:
             cmd = py3compat.unicode_to_str(cmd)
-            ec = subprocess.call(cmd, shell=True, executable=os.environ.get('SHELL'))
-            # The high byte is the exit code, the low byte is a signal number
-            # that we discard for now. See the docs for os.wait()
-            if ec > 255:
-                ec >>= 8
+            # Call the cmd using the OS shell, instead of the default /bin/sh, if set.
+            ec = subprocess.call(cmd, shell=True, executable=os.environ.get('SHELL', None))
+            # Returns either the exit code or minus the value of the signal number.
+            # See the docs for subprocess.Popen.returncode .
+            if ec < 0:
+                ec = -ec
         
         # We explicitly do NOT return the subprocess status code, because
         # a non-None value would trigger :func:`sys.displayhook` calls.

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -33,7 +33,7 @@ from StringIO import StringIO
 import nose.tools as nt
 
 # Our own
-from IPython.testing.decorators import skipif, onlyif_unicode_paths
+from IPython.testing.decorators import skipif, skip_win32, onlyif_unicode_paths
 from IPython.testing import tools as tt
 from IPython.utils import io
 
@@ -437,6 +437,13 @@ class TestSystemRaw(unittest.TestCase):
     def test_exit_code(self):
         """Test that the exit code is parsed correctly."""
         ip.system_raw('exit 1')
+        self.assertEqual(ip.user_ns['_exit_code'], 1)
+
+class TestSystemPiped(unittest.TestCase):
+    # TODO: Exit codes are currently ignored on Windows.
+    @skip_win32
+    def test_exit_code(self):
+        ip.system_piped('exit 1')
         self.assertEqual(ip.user_ns['_exit_code'], 1)
 
 class TestModules(unittest.TestCase, tt.TempFileMixin):

--- a/IPython/utils/_process_posix.py
+++ b/IPython/utils/_process_posix.py
@@ -187,9 +187,9 @@ class ProcessHandler(object):
 
         # We follow the subprocess pattern, returning either the exit status
         # as a positive number, or the terminating signal as a negative
-        # number
-        if child.signalstatus is not None:
-            return -child.signalstatus
+        # number. sh returns 128+n for signals
+        if child.exitstatus > 128:
+            return -(child.exitstatus - 128)
         return child.exitstatus
 
 

--- a/IPython/utils/_process_posix.py
+++ b/IPython/utils/_process_posix.py
@@ -184,6 +184,12 @@ class ProcessHandler(object):
                 child.terminate(force=True)
         # add isalive check, to ensure exitstatus is set:
         child.isalive()
+
+        # We follow the subprocess pattern, returning either the exit status
+        # as a positive number, or the terminating signal as a negative
+        # number
+        if child.signalstatus is not None:
+            return -child.signalstatus
         return child.exitstatus
 
 


### PR DESCRIPTION
Supersedes #4049

This unifies the exit codes from `system_raw` and `system_piped` to use the subprocess model on Unix - positive numbers for exit status, negative for terminating signal.

This doesn't change the situation on Windows. `system_raw` will give the raw exit code (Windows exit statuses don't appear to include the terminating signal), and `system_piped` will give nothing - our process_win32 machinery never gets the exit code, and I don't want to go messing around with that.

I've not figured out a good way to test the terminating signal exit codes, as our main process APIs are blocking. It may require threads...
