### PR TITLE
Add widget div to notebook

### DIFF
--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -126,8 +126,10 @@ var IPython = (function (IPython) {
         $(this.code_mirror.getInputField()).attr("spellcheck", "false");
         vbox.append(input_area);
         input.append(vbox);
+        var widget_area = $('<div/>').addClass('widget_area');
+        widget_area.hide();
         var output = $('<div></div>');
-        cell.append(input).append(output);
+        cell.append(input).append(widget_area).append(output);
         this.element = cell;
         this.output_area = new IPython.OutputArea(output, true);
 


### PR DESCRIPTION
Adds a widget div, hidden by default, between code cell input and output divs.  Doesn't get cleared by clear_output.
