### PR TITLE
Add mathletters option and longtable package to latex_base.tplx

### DIFF
--- a/IPython/nbconvert/templates/latex/latex_base.tplx
+++ b/IPython/nbconvert/templates/latex/latex_base.tplx
@@ -21,7 +21,7 @@ This template does not define a docclass, the inheriting class must define this.
     \usepackage{amsmath} % Equations
     \usepackage{amssymb} % Equations
     \usepackage[utf8]{inputenc} % Allow utf-8 characters in the tex document
-    \usepackage{ucs} % Extended unicode (utf-8) support
+    \usepackage[mathletters]{ucs} % Extended unicode (utf-8) support
     \usepackage{fancyvrb} % verbatim replacement that allows latex
     \usepackage{grffile} % extends the file name processing of package graphics 
                          % to support a larger range 
@@ -29,6 +29,7 @@ This template does not define a docclass, the inheriting class must define this.
     % internal navigation ('pdf bookmarks' for the table of contents,
     % internal cross-reference links, web links for URLs, etc.)
     \usepackage{hyperref}
+    \usepackage{longtable} % longtable support required by pandoc >1.10
     ((* endblock packages *))
 
     ((* block definitions *))


### PR DESCRIPTION
The mathletters option of the ucs packages allows to use unicode greek letters -> fixes #4247
The longtable package is required as pandoc converts piped tables to longtable environments. 
