### PR TITLE
adjust Scheduler timeout logic

### DIFF
--- a/IPython/parallel/tests/test_lbview.py
+++ b/IPython/parallel/tests/test_lbview.py
@@ -156,15 +156,23 @@ class TestLoadBalancedView(ClusterTestCase):
 
     def test_retries(self):
         view = self.view
-        view.timeout = 1 # prevent hang if this doesn't behave
         def fail():
             assert False
         for r in range(len(self.client)-1):
             with view.temp_flags(retries=r):
                 self.assertRaisesRemote(AssertionError, view.apply_sync, fail)
 
-        with view.temp_flags(retries=len(self.client), timeout=0.25):
+        with view.temp_flags(retries=len(self.client), timeout=0.1):
             self.assertRaisesRemote(error.TaskTimeout, view.apply_sync, fail)
+
+    def test_short_timeout(self):
+        view = self.view
+        def fail():
+            import time
+            time.sleep(0.25)
+            assert False
+        with view.temp_flags(retries=1, timeout=0.01):
+            self.assertRaisesRemote(AssertionError, view.apply_sync, fail)
 
     def test_invalid_dependency(self):
         view = self.view

--- a/IPython/parallel/tests/test_lbview.py
+++ b/IPython/parallel/tests/test_lbview.py
@@ -155,6 +155,7 @@ class TestLoadBalancedView(ClusterTestCase):
         self.assertRaises(error.TaskAborted, ar3.get)
 
     def test_retries(self):
+        self.minimum_engines(3)
         view = self.view
         def fail():
             assert False
@@ -166,6 +167,7 @@ class TestLoadBalancedView(ClusterTestCase):
             self.assertRaisesRemote(error.TaskTimeout, view.apply_sync, fail)
 
     def test_short_timeout(self):
+        self.minimum_engines(2)
         view = self.view
         def fail():
             import time


### PR DESCRIPTION
Timeout starts when task submission is attempted. That is, it starts _each time_ in resubmit / retry cases.

Avoids issues of timeout firing only once while a task is pending, when it might come back and be retried after the timeout has fired.

Also adds a ten second timeout for `sync` calls in the tests, which should hopefully avoid hangs when things are misbehaving.

closes #3210
