### PR TITLE
Hopefully fix ordering of output on ShiningPanda

### DIFF
--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -291,6 +291,7 @@ def run_iptestall(options):
         # This actually means sequential, i.e. with 1 job
         for controller in to_run:
             print('IPython test group:', controller.section)
+            sys.stdout.flush()  # Show in correct order when output is piped
             controller, res = do_run(controller)
             if res:
                 failed.append(controller)


### PR DESCRIPTION
Test output on ShiningPanda gets out of order - all the dots appear before any of the 'IPython test group' headings. See for instance [this log](https://jenkins.shiningpanda-ci.com/ipython/job/ipython-win-py27/106/console).

The dots are being printed to stderr, while our own messages are printed to stdout, and must be getting buffered. I think this should fix it.
