### PR TITLE
Fixing line-height of list items in tree view.

### DIFF
--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -30,6 +30,7 @@
 .list_container>div{border-bottom:1px solid #ababab;}.list_container>div:hover .list-item{background-color:red;}
 .list_container>div:last-child{border:none;}
 .list_item:hover .list_item{background-color:#ddd;}
+.item_name{line-height:24px;}
 .list_container>div>span,.list_container>div>div{padding:8px;}
 .list_item a{text-decoration:none;}
 input.nbname_input{height:15px;}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1411,6 +1411,7 @@ span#login_widget{float:right;}
 .list_container>div{border-bottom:1px solid #ababab;}.list_container>div:hover .list-item{background-color:red;}
 .list_container>div:last-child{border:none;}
 .list_item:hover .list_item{background-color:#ddd;}
+.item_name{line-height:24px;}
 .list_container>div>span,.list_container>div>div{padding:8px;}
 .list_item a{text-decoration:none;}
 input.nbname_input{height:15px;}

--- a/IPython/html/static/tree/less/tree.less
+++ b/IPython/html/static/tree/less/tree.less
@@ -50,6 +50,10 @@
   };
 }
 
+.item_name {
+    line-height: 24px;
+}
+
 .list_container > div > span, .list_container > div > div {
   padding: 8px;
 }


### PR DESCRIPTION
The notebook dashboard has a list of notebooks.  In master, the notebook names have too much space below and not enough above.  This PR sets the `line-height` to center the notebook names vertically in the box.

Before:

![screen shot 2013-09-25 at 6 16 42 pm](https://f.cloud.github.com/assets/27600/1214773/7ac2132e-2649-11e3-8d6f-9614d4590089.png)

After:

![screen shot 2013-09-25 at 6 15 42 pm](https://f.cloud.github.com/assets/27600/1214774/7e5aa42e-2649-11e3-86b5-c9edd200c0fd.png)
