### PR TITLE
Adjust tab completion widget if too close to bottom of page.

### DIFF
--- a/IPython/html/static/notebook/js/completer.js
+++ b/IPython/html/static/notebook/js/completer.js
@@ -202,9 +202,8 @@ var IPython = (function (IPython) {
         this.complete.append(this.sel);
         $('body').append(this.complete);
 
-        // After everything is on the page compute the postion.
-        // We invert the completion list and put it above the code if it is too
-        // close to the bottom of the page.
+        // After everything is on the page, compute the postion.
+        // We put it above the code if it is too close to the bottom of the page.
         var cur = this.editor.getCursor();
         cur.ch = cur.ch-matched_text.length;
         var pos = this.editor.cursorCoords(cur);

--- a/IPython/html/static/notebook/js/completer.js
+++ b/IPython/html/static/notebook/js/completer.js
@@ -208,17 +208,13 @@ var IPython = (function (IPython) {
         var cur = this.editor.getCursor();
         cur.ch = cur.ch-matched_text.length;
         var pos = this.editor.cursorCoords(cur);
-        var invert = false;
         var left = pos.left-3;
         var top;
         var cheight = this.complete.height();
         var wheight = $(window).height();
-        console.log(pos.bottom, cheight, wheight)
         if (pos.bottom+cheight+5 > wheight) {
-            invert = true;
             top = pos.top-cheight-4;
         } else {
-            invert = false;
             top = pos.bottom+1;
         }
         this.complete.css('left', left + 'px');
@@ -235,7 +231,7 @@ var IPython = (function (IPython) {
             that.keydown(event);
         });
 
-        this.build_gui_list(this.raw_result, invert);
+        this.build_gui_list(this.raw_result);
 
         this.sel.focus();
         // Opera sometimes ignores focusing a freshly created node
@@ -249,23 +245,13 @@ var IPython = (function (IPython) {
         this.editor.replaceRange(completion.str, completion.from, completion.to);
     }
 
-    Completer.prototype.build_gui_list = function (completions, invert) {
-        invert = invert || false;
-        if (!invert) {
-            for (var i = 0; i < completions.length; ++i) {
-                var opt = $('<option/>').text(completions[i].str).addClass(completions[i].type);
-                this.sel.append(opt);
-            }
-            this.sel.children().first().attr('selected', 'true');
-            this.sel.scrollTop(0);
-        } else {
-            for (var i = (completions.length-1); i > -1; --i) {
-                var opt = $('<option/>').text(completions[i].str).addClass(completions[i].type);
-                this.sel.append(opt);
-            }
-            this.sel.children().last().attr('selected', 'true');
-            this.sel.scrollTop(this.sel[0].scrollHeight);
+    Completer.prototype.build_gui_list = function (completions) {
+        for (var i = 0; i < completions.length; ++i) {
+            var opt = $('<option/>').text(completions[i].str).addClass(completions[i].type);
+            this.sel.append(opt);
         }
+        this.sel.children().first().attr('selected', 'true');
+        this.sel.scrollTop(0);
     }
 
     Completer.prototype.close = function () {


### PR DESCRIPTION
In master the tab completely widget completely fails if the code is too low on the page and the widget won't fit.

This PR looks to see if the completely widget will fit below the code and if not does the following:
- Inverts the list
- Scrolls to the bottom
- Puts the widget above the code

Here is a screenshot:

![screen shot 2013-09-25 at 7 20 46 pm](https://f.cloud.github.com/assets/27600/1215009/b151824a-2652-11e3-83ea-1b40920b902c.png)
