### PR TITLE
Enable automatic line breaks in MathJax.

### DIFF
--- a/IPython/html/static/notebook/js/mathjaxutils.js
+++ b/IPython/html/static/notebook/js/mathjaxutils.js
@@ -27,7 +27,8 @@ IPython.mathjaxutils = (function (IPython) {
                 },
                 displayAlign: 'left', // Change this to 'center' to center equations.
                 "HTML-CSS": {
-                    styles: {'.MathJax_Display': {"margin": 0}}
+                    styles: {'.MathJax_Display': {"margin": 0}},
+                    linebreaks: { automatic: true }
                 }
             });
             MathJax.Hub.Configured();


### PR DESCRIPTION
Closes #4280

This enables automatics linebreaks in MathJax:

![screen shot 2013-09-25 at 7 29 06 pm](https://f.cloud.github.com/assets/27600/1215038/ae749f34-2653-11e3-9cca-18ee7f393d90.png)
