### PR TITLE
[DRAFT/DEMO] lxml free citation2latex

### DIFF
--- a/IPython/nbconvert/filters/citation.py
+++ b/IPython/nbconvert/filters/citation.py
@@ -34,4 +34,4 @@ def citation2latex(s):
     """
     import re
     return re.sub("<(?P<tag>[a-z]+) .*?data-cite=['\"]{0,1}(?P<label>[^['\" >]*).*?/(?P=tag)>",
-                  '\\cite{\g<label>}',s)
+                  '\\cite{\g<label>}',s, flags=re.S|re.I)

--- a/IPython/nbconvert/filters/citation.py
+++ b/IPython/nbconvert/filters/citation.py
@@ -32,41 +32,6 @@ def citation2latex(s):
     Any HTML tag can be used, which allows the citations to be formatted
     in HTML in any manner.
     """
-    try:
-        from lxml import html
-    except ImportError:
-        return s
-
-    tree = html.fragment_fromstring(s, create_parent='div')
-    _process_node_cite(tree)
-    s = html.tostring(tree, encoding='unicode')
-    if s.endswith('</div>'):
-        s = s[:-6]
-    if s.startswith('<div>'):
-        s = s[5:]
-    return s
-
-
-def _process_node_cite(node):
-    """Do the citation replacement as we walk the lxml tree."""
-    
-    def _get(o, name):
-        value = getattr(o, name, None)
-        return '' if value is None else value
-    
-    if 'data-cite' in node.attrib:
-        cite = '\cite{%(ref)s}' % {'ref': node.attrib['data-cite']}
-        prev = node.getprevious()
-        if prev is not None:
-            prev.tail = _get(prev, 'tail') + cite + _get(node, 'tail')
-        else:
-            parent = node.getparent()
-            if parent is not None:
-                parent.text = _get(parent, 'text') + cite + _get(node, 'tail')
-        try:
-            node.getparent().remove(node)
-        except AttributeError:
-            pass
-    else:
-        for child in node:
-            _process_node_cite(child)
+    import re
+    return re.sub("<(?P<tag>[a-z]+) .*?data-cite=['\"]{0,1}(?P<label>[^['\" >]*).*?/(?P=tag)>",
+                  '\\cite{\g<label>}',s)

--- a/IPython/nbconvert/filters/citation.py
+++ b/IPython/nbconvert/filters/citation.py
@@ -33,5 +33,5 @@ def citation2latex(s):
     in HTML in any manner.
     """
     import re
-    return re.sub("<(?P<tag>[a-z]+) .*?data-cite=['\"]{0,1}(?P<label>[^['\" >]*).*?/(?P=tag)>",
+    return re.sub("<(?P<tag>[a-z]+) [^>]*?data-cite=['\"]{0,1}(?P<label>[^['\" >]*).*?/(?P=tag)>",
                   '\\cite{\g<label>}',s, flags=re.S|re.I)

--- a/IPython/nbconvert/filters/tests/test_citation.py
+++ b/IPython/nbconvert/filters/tests/test_citation.py
@@ -50,9 +50,4 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit
 
 def test_citation2latex():
     """Are citations parsed properly?"""
-    try:
-        import lxml
-    except ImportError:
-        assert test_md == citation2latex(test_md) 
-    else:
-        assert test_md_parsed == citation2latex(test_md)
+    assert test_md_parsed == citation2latex(test_md)


### PR DESCRIPTION
Despite the fact that parsing an html structure using regex is a bad practice, here the lxml approach (#4090) is replaced with a regex. The main idea is, that there is actually no real html structure to parse but rather some html tags with a data-cite attribute.

I'm still not convinced that lxml is necessary. The lxml approach requires the lxml package, is much slower and introduces some bugs which are difficult to cope with.

This fixes #4251 and #4283
