### PR TITLE
Fix scrolling output (not working post clear_output changes)

### DIFF
--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -311,7 +311,7 @@ var IPython = (function (IPython) {
         // Only reset the height to automatic if the height is currently
         // fixed (done by wait=True flag on clear_output).
         if (needs_height_reset) {
-            this.element.height('auto');    
+            this.element.height('');    
         }
 
         var that = this;

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -291,8 +291,10 @@ var IPython = (function (IPython) {
         this.expand();
 
         // Clear the output if clear is queued.
+        var needs_height_reset = false;
         if (this.clear_queued) {
             this.clear_output(false);
+            needs_height_reset = true;
         }
 
         if (json.output_type === 'pyout') {
@@ -305,7 +307,13 @@ var IPython = (function (IPython) {
             this.append_stream(json);
         }
         this.outputs.push(json);
-        this.element.height('auto');
+        
+        // Only reset the height to automatic if the height is currently
+        // fixed (done by wait=True flag on clear_output).
+        if (needs_height_reset) {
+            this.element.height('auto');    
+        }
+
         var that = this;
         setTimeout(function(){that.element.trigger('resize');}, 100);
     };


### PR DESCRIPTION
Added a conditional for the append output height reset.
- My question is, do we still even need to fix the height?  
  - Will the supported browsers ever redraw while Javascript is being parsed?

Regression introduced in #4229
