### PR TITLE
reST cell type (render in server-side as a whole document) 

### DIFF
--- a/IPython/html/services/notebooks/handlers.py
+++ b/IPython/html/services/notebooks/handlers.py
@@ -144,7 +144,9 @@ class NotebookRstHandler(IPythonHandler):
     def post(self):
         """post creates a """
         source = self.get_argument('source')
-        self.finish(rst2html(source))
+        html = rst2html(source).split("<!-- split //-->\n")[:-1]
+        self.set_header('Content-Type', 'application/json')
+        self.finish(jsonapi.dumps(html))
 
 
 #-----------------------------------------------------------------------------

--- a/IPython/html/static/notebook/js/maintoolbar.js
+++ b/IPython/html/static/notebook/js/maintoolbar.js
@@ -20,7 +20,7 @@ var IPython = (function (IPython) {
         this.bind_events();
     };
 
-    MainToolBar.prototype = new IPython.ToolBar(); 
+    MainToolBar.prototype = new IPython.ToolBar();
 
     MainToolBar.prototype.construct = function () {
         this.add_buttons_group([
@@ -78,7 +78,7 @@ var IPython = (function (IPython) {
                         }
                 }
             ],'move_up_down');
-        
+
         this.add_buttons_group([
                 {
                     id : 'insert_above_b',
@@ -125,6 +125,7 @@ var IPython = (function (IPython) {
                 // .addClass('ui-widget-content')
                 .append($('<option/>').attr('value','code').text('Code'))
                 .append($('<option/>').attr('value','markdown').text('Markdown'))
+                .append($('<option/>').attr('value','restructuredtext').text('reStructuredText'))
                 .append($('<option/>').attr('value','raw').text('Raw Text'))
                 .append($('<option/>').attr('value','heading1').text('Heading 1'))
                 .append($('<option/>').attr('value','heading2').text('Heading 2'))
@@ -168,13 +169,15 @@ var IPython = (function (IPython) {
 
     MainToolBar.prototype.bind_events = function () {
         var that = this;
-        
+
         this.element.find('#cell_type').change(function () {
             var cell_type = $(this).val();
             if (cell_type === 'code') {
                 IPython.notebook.to_code();
             } else if (cell_type === 'markdown')  {
                 IPython.notebook.to_markdown();
+            } else if (cell_type === 'restructuredtext')  {
+                IPython.notebook.to_restructuredtext();
             } else if (cell_type === 'raw')  {
                 IPython.notebook.to_raw();
             } else if (cell_type === 'heading1')  {

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -17,7 +17,7 @@ var IPython = (function (IPython) {
 
     /**
      * A notebook contains and manages cells.
-     * 
+     *
      * @class Notebook
      * @constructor
      * @param {String} selector A jQuery selector for the notebook's DOM element
@@ -61,7 +61,7 @@ var IPython = (function (IPython) {
 
     /**
      * Tweak the notebook's CSS style.
-     * 
+     *
      * @method style
      */
     Notebook.prototype.style = function () {
@@ -70,7 +70,7 @@ var IPython = (function (IPython) {
 
     /**
      * Get the root URL of the notebook server.
-     * 
+     *
      * @method baseProjectUrl
      * @return {String} The base project URL
      */
@@ -80,7 +80,7 @@ var IPython = (function (IPython) {
 
     /**
      * Create an HTML and CSS representation of the notebook.
-     * 
+     *
      * @method create_elements
      */
     Notebook.prototype.create_elements = function () {
@@ -102,7 +102,7 @@ var IPython = (function (IPython) {
 
     /**
      * Bind JavaScript events: key presses and custom IPython events.
-     * 
+     *
      * @method bind_events
      */
     Notebook.prototype.bind_events = function () {
@@ -123,7 +123,7 @@ var IPython = (function (IPython) {
             var index = that.find_cell_index(data.cell);
             that.select(index);
         });
-        
+
         $([IPython.events]).on('status_autorestarting.Kernel', function () {
             IPython.dialog.modal({
                 title: "Kernel Restarting",
@@ -321,14 +321,14 @@ var IPython = (function (IPython) {
                 // Split cell = -
                 that.split_cell();
                 that.control_key_active = false;
-                return false;                                               
+                return false;
             } else if (that.control_key_active) {
                 that.control_key_active = false;
                 return true;
             }
             return true;
         });
-        
+
         var collapse_time = function(time){
             var app_height = $('#ipython-main-app').height(); // content height
             var splitter_height = $('div#pager_splitter').outerHeight(true);
@@ -353,7 +353,7 @@ var IPython = (function (IPython) {
             var time = (extrap != undefined) ? ((extrap.duration != undefined ) ? extrap.duration : 'fast') : 'fast';
             expand_time(time);
         });
-        
+
         // Firefox 22 broke $(window).on("beforeunload")
         // I'm not sure why or how.
         window.onbeforeunload = function (e) {
@@ -388,7 +388,7 @@ var IPython = (function (IPython) {
 
     /**
      * Set the dirty flag, and trigger the set_dirty.Notebook event
-     * 
+     *
      * @method set_dirty
      */
     Notebook.prototype.set_dirty = function (value) {
@@ -403,7 +403,7 @@ var IPython = (function (IPython) {
 
     /**
      * Scroll the top of the page to a given cell.
-     * 
+     *
      * @method scroll_to_cell
      * @param {Number} cell_number An index of the cell to view
      * @param {Number} time Animation time in milliseconds
@@ -421,7 +421,7 @@ var IPython = (function (IPython) {
 
     /**
      * Scroll to the bottom of the page.
-     * 
+     *
      * @method scroll_to_bottom
      */
     Notebook.prototype.scroll_to_bottom = function () {
@@ -430,7 +430,7 @@ var IPython = (function (IPython) {
 
     /**
      * Scroll to the top of the page.
-     * 
+     *
      * @method scroll_to_top
      */
     Notebook.prototype.scroll_to_top = function () {
@@ -442,7 +442,7 @@ var IPython = (function (IPython) {
 
     /**
      * Get all cell elements in the notebook.
-     * 
+     *
      * @method get_cell_elements
      * @return {jQuery} A selector of all cell elements
      */
@@ -452,7 +452,7 @@ var IPython = (function (IPython) {
 
     /**
      * Get a particular cell element.
-     * 
+     *
      * @method get_cell_element
      * @param {Number} index An index of a cell to select
      * @return {jQuery} A selector of the given cell.
@@ -468,7 +468,7 @@ var IPython = (function (IPython) {
 
     /**
      * Count the cells in this notebook.
-     * 
+     *
      * @method ncells
      * @return {Number} The number of cells in this notebook
      */
@@ -478,7 +478,7 @@ var IPython = (function (IPython) {
 
     /**
      * Get all Cell objects in this notebook.
-     * 
+     *
      * @method get_cells
      * @return {Array} This notebook's Cell objects
      */
@@ -492,7 +492,7 @@ var IPython = (function (IPython) {
 
     /**
      * Get a Cell object from this notebook.
-     * 
+     *
      * @method get_cell
      * @param {Number} index An index of a cell to retrieve
      * @return {Cell} A particular cell
@@ -508,7 +508,7 @@ var IPython = (function (IPython) {
 
     /**
      * Get the cell below a given cell.
-     * 
+     *
      * @method get_next_cell
      * @param {Cell} cell The provided cell
      * @return {Cell} The next cell
@@ -524,7 +524,7 @@ var IPython = (function (IPython) {
 
     /**
      * Get the cell above a given cell.
-     * 
+     *
      * @method get_prev_cell
      * @param {Cell} cell The provided cell
      * @return {Cell} The previous cell
@@ -539,10 +539,10 @@ var IPython = (function (IPython) {
         }
         return result;
     }
-    
+
     /**
      * Get the numeric index of a given cell.
-     * 
+     *
      * @method find_cell_index
      * @param {Cell} cell The provided cell
      * @return {Number} The cell's numeric index
@@ -559,7 +559,7 @@ var IPython = (function (IPython) {
 
     /**
      * Get a given index , or the selected index if none is provided.
-     * 
+     *
      * @method index_or_selected
      * @param {Number} index A cell's index
      * @return {Number} The given index, or selected index if none is provided.
@@ -589,7 +589,7 @@ var IPython = (function (IPython) {
 
     /**
      * Check whether a cell index is valid.
-     * 
+     *
      * @method is_valid_cell_index
      * @param {Number} index A cell index
      * @return True if the index is valid, false otherwise
@@ -604,7 +604,7 @@ var IPython = (function (IPython) {
 
     /**
      * Get the index of the currently selected cell.
-     
+
      * @method get_selected_index
      * @return {Number} The selected cell's numeric index
      */
@@ -623,7 +623,7 @@ var IPython = (function (IPython) {
 
     /**
      * Programmatically select a cell.
-     * 
+     *
      * @method select
      * @param {Number} index A cell's index
      * @return {Notebook} This notebook
@@ -678,7 +678,7 @@ var IPython = (function (IPython) {
 
     /**
      * Move given (or selected) cell up and select it.
-     * 
+     *
      * @method move_cell_up
      * @param [index] {integer} cell index
      * @return {Notebook} This notebook
@@ -701,7 +701,7 @@ var IPython = (function (IPython) {
 
     /**
      * Move given (or selected) cell down and select it
-     * 
+     *
      * @method move_cell_down
      * @param [index] {integer} cell index
      * @return {Notebook} This notebook
@@ -726,7 +726,7 @@ var IPython = (function (IPython) {
 
     /**
      * Delete a cell from the notebook.
-     * 
+     *
      * @method delete_cell
      * @param [index] A cell's numeric index
      * @return {Notebook} This notebook
@@ -780,6 +780,8 @@ var IPython = (function (IPython) {
                 cell.set_input_prompt();
             } else if (type === 'markdown') {
                 cell = new IPython.MarkdownCell();
+            } else if (type === 'restructuredtext') {
+                cell = new IPython.RestructuredtextCell();
             } else if (type === 'raw') {
                 cell = new IPython.RawCell();
             } else if (type === 'heading') {
@@ -885,7 +887,7 @@ var IPython = (function (IPython) {
 
     /**
      * Turn a cell into a code cell.
-     * 
+     *
      * @method to_code
      * @param {Number} [index] A cell's index
      */
@@ -912,7 +914,7 @@ var IPython = (function (IPython) {
 
     /**
      * Turn a cell into a Markdown cell.
-     * 
+     *
      * @method to_markdown
      * @param {Number} [index] A cell's index
      */
@@ -939,9 +941,42 @@ var IPython = (function (IPython) {
         };
     };
 
-    /**
+
+     /**
+     * Turn render all restructuredtext cells
+     *
+     * @method to_restructuredtext
+     * @param {Number} [index] A cell's index
+     */
+     Notebook.prototype.to_restructuredtext = function (index) {
+         var i = this.index_or_selected(index);
+         if (this.is_valid_cell_index(i)) {
+
+             var source_element = this.get_cell_element(i);
+             var source_cell = source_element.data("cell");
+             if (!(source_cell instanceof IPython.RestructuredtextCell)) {
+                 var target_cell = this.insert_cell_below('restructuredtext',i);
+                 var text = source_cell.get_text();
+                 if (text === source_cell.placeholder) {
+                     text = '';
+                 };
+                 // The edit must come before the set_text.
+                 target_cell.edit();
+                 target_cell.set_text(text);
+                 // make this value the starting point, so that we can only undo
+                 // to this state, instead of a blank cell
+                 target_cell.code_mirror.clearHistory();
+                 source_element.remove();
+                 this.set_dirty(true);
+             };
+         };
+     };
+
+
+
+     /**
      * Turn a cell into a raw text cell.
-     * 
+     *
      * @method to_raw
      * @param {Number} [index] A cell's index
      */
@@ -971,7 +1006,7 @@ var IPython = (function (IPython) {
 
     /**
      * Turn a cell into a heading cell.
-     * 
+     *
      * @method to_heading
      * @param {Number} [index] A cell's index
      * @param {Number} [level] A heading level (e.g., 1 becomes &lt;h1&gt;)
@@ -1012,7 +1047,7 @@ var IPython = (function (IPython) {
 
     /**
      * Enable UI elements for pasting cells.
-     * 
+     *
      * @method enable_paste
      */
     Notebook.prototype.enable_paste = function () {
@@ -1030,7 +1065,7 @@ var IPython = (function (IPython) {
 
     /**
      * Disable UI elements for pasting cells.
-     * 
+     *
      * @method disable_paste
      */
     Notebook.prototype.disable_paste = function () {
@@ -1044,7 +1079,7 @@ var IPython = (function (IPython) {
 
     /**
      * Cut a cell.
-     * 
+     *
      * @method cut_cell
      */
     Notebook.prototype.cut_cell = function () {
@@ -1054,7 +1089,7 @@ var IPython = (function (IPython) {
 
     /**
      * Copy a cell.
-     * 
+     *
      * @method copy_cell
      */
     Notebook.prototype.copy_cell = function () {
@@ -1065,7 +1100,7 @@ var IPython = (function (IPython) {
 
     /**
      * Replace the selected cell with a cell in the clipboard.
-     * 
+     *
      * @method paste_cell_replace
      */
     Notebook.prototype.paste_cell_replace = function () {
@@ -1081,7 +1116,7 @@ var IPython = (function (IPython) {
 
     /**
      * Paste a cell from the clipboard above the selected cell.
-     * 
+     *
      * @method paste_cell_above
      */
     Notebook.prototype.paste_cell_above = function () {
@@ -1094,7 +1129,7 @@ var IPython = (function (IPython) {
 
     /**
      * Paste a cell from the clipboard below the selected cell.
-     * 
+     *
      * @method paste_cell_below
      */
     Notebook.prototype.paste_cell_below = function () {
@@ -1109,7 +1144,7 @@ var IPython = (function (IPython) {
 
     /**
      * Restore the most recently deleted cell.
-     * 
+     *
      * @method undelete
      */
     Notebook.prototype.undelete = function() {
@@ -1143,7 +1178,7 @@ var IPython = (function (IPython) {
 
     /**
      * Split the selected cell into two, at the cursor.
-     * 
+     *
      * @method split_cell
      */
     Notebook.prototype.split_cell = function () {
@@ -1169,7 +1204,7 @@ var IPython = (function (IPython) {
 
     /**
      * Combine the selected cell into the cell above it.
-     * 
+     *
      * @method merge_cell_above
      */
     Notebook.prototype.merge_cell_above = function () {
@@ -1199,7 +1234,7 @@ var IPython = (function (IPython) {
 
     /**
      * Combine the selected cell into the cell below it.
-     * 
+     *
      * @method merge_cell_below
      */
     Notebook.prototype.merge_cell_below = function () {
@@ -1232,7 +1267,7 @@ var IPython = (function (IPython) {
 
     /**
      * Hide a cell's output.
-     * 
+     *
      * @method collapse
      * @param {Number} index A cell's numeric index
      */
@@ -1244,7 +1279,7 @@ var IPython = (function (IPython) {
 
     /**
      * Show a cell's output.
-     * 
+     *
      * @method expand
      * @param {Number} index A cell's numeric index
      */
@@ -1255,7 +1290,7 @@ var IPython = (function (IPython) {
     };
 
     /** Toggle whether a cell's output is collapsed or expanded.
-     * 
+     *
      * @method toggle_output
      * @param {Number} index A cell's numeric index
      */
@@ -1267,7 +1302,7 @@ var IPython = (function (IPython) {
 
     /**
      * Toggle a scrollbar for long cell outputs.
-     * 
+     *
      * @method toggle_output_scroll
      * @param {Number} index A cell's numeric index
      */
@@ -1278,7 +1313,7 @@ var IPython = (function (IPython) {
 
     /**
      * Hide each code cell's output area.
-     * 
+     *
      * @method collapse_all_output
      */
     Notebook.prototype.collapse_all_output = function () {
@@ -1295,7 +1330,7 @@ var IPython = (function (IPython) {
 
     /**
      * Expand each code cell's output area, and add a scrollbar for long output.
-     * 
+     *
      * @method scroll_all_output
      */
     Notebook.prototype.scroll_all_output = function () {
@@ -1313,7 +1348,7 @@ var IPython = (function (IPython) {
 
     /**
      * Expand each code cell's output area, and remove scrollbars.
-     * 
+     *
      * @method expand_all_output
      */
     Notebook.prototype.expand_all_output = function () {
@@ -1331,7 +1366,7 @@ var IPython = (function (IPython) {
 
     /**
      * Clear each code cell's output area.
-     * 
+     *
      * @method clear_all_output
      */
     Notebook.prototype.clear_all_output = function () {
@@ -1353,7 +1388,7 @@ var IPython = (function (IPython) {
 
     /**
      * Toggle line numbers in the selected cell's input area.
-     * 
+     *
      * @method cell_toggle_line_numbers
      */
     Notebook.prototype.cell_toggle_line_numbers = function() {
@@ -1364,7 +1399,7 @@ var IPython = (function (IPython) {
 
     /**
      * Start a new kernel and set it on each code cell.
-     * 
+     *
      * @method start_kernel
      */
     Notebook.prototype.start_kernel = function () {
@@ -1383,7 +1418,7 @@ var IPython = (function (IPython) {
 
     /**
      * Prompt the user to restart the IPython kernel.
-     * 
+     *
      * @method restart_kernel
      */
     Notebook.prototype.restart_kernel = function () {
@@ -1407,9 +1442,9 @@ var IPython = (function (IPython) {
 
     /**
      * Run the selected cell.
-     * 
+     *
      * Execute or render cell outputs.
-     * 
+     *
      * @method execute_selected_cell
      * @param {Object} options Customize post-execution behavior
      */
@@ -1440,7 +1475,7 @@ var IPython = (function (IPython) {
 
     /**
      * Execute all cells below the selected cell.
-     * 
+     *
      * @method execute_cells_below
      */
     Notebook.prototype.execute_cells_below = function () {
@@ -1450,7 +1485,7 @@ var IPython = (function (IPython) {
 
     /**
      * Execute all cells above the selected cell.
-     * 
+     *
      * @method execute_cells_above
      */
     Notebook.prototype.execute_cells_above = function () {
@@ -1459,7 +1494,7 @@ var IPython = (function (IPython) {
 
     /**
      * Execute all cells.
-     * 
+     *
      * @method execute_all_cells
      */
     Notebook.prototype.execute_all_cells = function () {
@@ -1469,7 +1504,7 @@ var IPython = (function (IPython) {
 
     /**
      * Execute a contiguous range of cells.
-     * 
+     *
      * @method execute_cell_range
      * @param {Number} start Index of the first cell to execute (inclusive)
      * @param {Number} end Index of the last cell to execute (exclusive)
@@ -1485,7 +1520,7 @@ var IPython = (function (IPython) {
 
     /**
      * Getter method for this notebook's ID.
-     * 
+     *
      * @method get_notebook_id
      * @return {String} This notebook's ID
      */
@@ -1495,7 +1530,7 @@ var IPython = (function (IPython) {
 
     /**
      * Getter method for this notebook's name.
-     * 
+     *
      * @method get_notebook_name
      * @return {String} This notebook's name
      */
@@ -1515,7 +1550,7 @@ var IPython = (function (IPython) {
 
     /**
      * Check that a notebook's name is valid.
-     * 
+     *
      * @method test_notebook_name
      * @param {String} nbname A name for this notebook
      * @return {Boolean} True if the name is valid, false if invalid
@@ -1531,9 +1566,9 @@ var IPython = (function (IPython) {
 
     /**
      * Load a notebook from JSON (.ipynb).
-     * 
+     *
      * This currently handles one worksheet: others are deleted.
-     * 
+     *
      * @method fromJSON
      * @param {Object} data JSON representation of a notebook
      */
@@ -1586,7 +1621,7 @@ var IPython = (function (IPython) {
 
     /**
      * Dump this notebook into a JSON-friendly object.
-     * 
+     *
      * @method toJSON
      * @return {Object} A JSON-friendly representation of this notebook.
      */
@@ -1610,7 +1645,7 @@ var IPython = (function (IPython) {
 
     /**
      * Start an autosave timer, for periodically saving the notebook.
-     * 
+     *
      * @method set_autosave_interval
      * @param {Integer} interval the autosave interval in milliseconds
      */
@@ -1620,7 +1655,7 @@ var IPython = (function (IPython) {
         if (this.autosave_timer) {
             clearInterval(this.autosave_timer);
         }
-        
+
         this.autosave_interval = this.minimum_autosave_interval = interval;
         if (interval) {
             this.autosave_timer = setInterval(function() {
@@ -1634,10 +1669,10 @@ var IPython = (function (IPython) {
             $([IPython.events]).trigger("autosave_disabled.Notebook");
         };
     };
-    
+
     /**
      * Save this notebook on the server.
-     * 
+     *
      * @method save_notebook
      */
     Notebook.prototype.save_notebook = function () {
@@ -1646,7 +1681,7 @@ var IPython = (function (IPython) {
         data.metadata.name = this.notebook_name;
         data.nbformat = this.nbformat;
         data.nbformat_minor = this.nbformat_minor;
-        
+
         // time the ajax call for autosave tuning purposes.
         var start =  new Date().getTime();
 
@@ -1664,10 +1699,10 @@ var IPython = (function (IPython) {
         var url = this.baseProjectUrl() + 'notebooks/' + this.notebook_id;
         $.ajax(url, settings);
     };
-    
+
     /**
      * Success callback for saving a notebook.
-     * 
+     *
      * @method save_notebook_success
      * @param {Integer} start the time when the save request started
      * @param {Object} data JSON representation of a notebook
@@ -1683,10 +1718,10 @@ var IPython = (function (IPython) {
             this._checkpoint_after_save = false;
         };
     };
-    
+
     /**
      * update the autosave interval based on how long the last save took
-     * 
+     *
      * @method _update_autosave_interval
      * @param {Integer} timestamp when the save request started
      */
@@ -1703,10 +1738,10 @@ var IPython = (function (IPython) {
             }
         }
     };
-    
+
     /**
      * Failure callback for saving a notebook.
-     * 
+     *
      * @method save_notebook_error
      * @param {jqXHR} xhr jQuery Ajax object
      * @param {String} status Description of response status
@@ -1715,10 +1750,10 @@ var IPython = (function (IPython) {
     Notebook.prototype.save_notebook_error = function (xhr, status, error_msg) {
         $([IPython.events]).trigger('notebook_save_failed.Notebook');
     };
-    
+
     /**
      * Request a notebook's data from the server.
-     * 
+     *
      * @method load_notebook
      * @param {String} notebook_id A notebook to load
      */
@@ -1741,9 +1776,9 @@ var IPython = (function (IPython) {
 
     /**
      * Success callback for loading a notebook from the server.
-     * 
+     *
      * Load notebook data from the JSON response.
-     * 
+     *
      * @method load_notebook_success
      * @param {Object} data JSON representation of a notebook
      * @param {String} status Description of response status
@@ -1792,7 +1827,7 @@ var IPython = (function (IPython) {
             });
 
         }
-        
+
         // Create the kernel after the notebook is completely loaded to prevent
         // code execution upon loading, which is a security risk.
         this.start_kernel();
@@ -1804,7 +1839,7 @@ var IPython = (function (IPython) {
 
     /**
      * Failure callback for loading a notebook from the server.
-     * 
+     *
      * @method load_notebook_error
      * @param {jqXHR} xhr jQuery Ajax object
      * @param {String} textStatus Description of response status
@@ -1828,21 +1863,21 @@ var IPython = (function (IPython) {
     }
 
     /*********************  checkpoint-related  *********************/
-    
+
     /**
      * Save the notebook then immediately create a checkpoint.
-     * 
+     *
      * @method save_checkpoint
      */
     Notebook.prototype.save_checkpoint = function () {
         this._checkpoint_after_save = true;
         this.save_notebook();
     };
-    
+
     /**
      * Add a checkpoint for this notebook.
      * for use as a callback from checkpoint creation.
-     * 
+     *
      * @method add_checkpoint
      */
     Notebook.prototype.add_checkpoint = function (checkpoint) {
@@ -1860,10 +1895,10 @@ var IPython = (function (IPython) {
         }
         this.last_checkpoint = this.checkpoints[this.checkpoints.length - 1];
     };
-    
+
     /**
      * List checkpoints for this notebook.
-     * 
+     *
      * @method list_checkpoints
      */
     Notebook.prototype.list_checkpoints = function () {
@@ -1877,7 +1912,7 @@ var IPython = (function (IPython) {
 
     /**
      * Success callback for listing checkpoints.
-     * 
+     *
      * @method list_checkpoint_success
      * @param {Object} data JSON representation of a checkpoint
      * @param {String} status Description of response status
@@ -1896,7 +1931,7 @@ var IPython = (function (IPython) {
 
     /**
      * Failure callback for listing a checkpoint.
-     * 
+     *
      * @method list_checkpoint_error
      * @param {jqXHR} xhr jQuery Ajax object
      * @param {String} status Description of response status
@@ -1905,10 +1940,10 @@ var IPython = (function (IPython) {
     Notebook.prototype.list_checkpoints_error = function (xhr, status, error_msg) {
         $([IPython.events]).trigger('list_checkpoints_failed.Notebook');
     };
-    
+
     /**
      * Create a checkpoint of this notebook on the server from the most recent save.
-     * 
+     *
      * @method create_checkpoint
      */
     Notebook.prototype.create_checkpoint = function () {
@@ -1922,7 +1957,7 @@ var IPython = (function (IPython) {
 
     /**
      * Success callback for creating a checkpoint.
-     * 
+     *
      * @method create_checkpoint_success
      * @param {Object} data JSON representation of a checkpoint
      * @param {String} status Description of response status
@@ -1936,7 +1971,7 @@ var IPython = (function (IPython) {
 
     /**
      * Failure callback for creating a checkpoint.
-     * 
+     *
      * @method create_checkpoint_error
      * @param {jqXHR} xhr jQuery Ajax object
      * @param {String} status Description of response status
@@ -1945,7 +1980,7 @@ var IPython = (function (IPython) {
     Notebook.prototype.create_checkpoint_error = function (xhr, status, error_msg) {
         $([IPython.events]).trigger('checkpoint_failed.Notebook');
     };
-    
+
     Notebook.prototype.restore_checkpoint_dialog = function (checkpoint) {
         var that = this;
         var checkpoint = checkpoint || this.last_checkpoint;
@@ -1969,7 +2004,7 @@ var IPython = (function (IPython) {
                 Date(checkpoint.last_modified)
             ).css("text-align", "center")
         );
-        
+
         IPython.dialog.modal({
             title : "Revert notebook to checkpoint",
             body : body,
@@ -1984,10 +2019,10 @@ var IPython = (function (IPython) {
                 }
         });
     }
-    
+
     /**
      * Restore the notebook to a checkpoint state.
-     * 
+     *
      * @method restore_checkpoint
      * @param {String} checkpoint ID
      */
@@ -2000,10 +2035,10 @@ var IPython = (function (IPython) {
             $.proxy(this.restore_checkpoint_error, this)
         );
     };
-    
+
     /**
      * Success callback for restoring a notebook to a checkpoint.
-     * 
+     *
      * @method restore_checkpoint_success
      * @param {Object} data (ignored, should be empty)
      * @param {String} status Description of response status
@@ -2016,7 +2051,7 @@ var IPython = (function (IPython) {
 
     /**
      * Failure callback for restoring a notebook to a checkpoint.
-     * 
+     *
      * @method restore_checkpoint_error
      * @param {jqXHR} xhr jQuery Ajax object
      * @param {String} status Description of response status
@@ -2025,10 +2060,10 @@ var IPython = (function (IPython) {
     Notebook.prototype.restore_checkpoint_error = function (xhr, status, error_msg) {
         $([IPython.events]).trigger('checkpoint_restore_failed.Notebook');
     };
-    
+
     /**
      * Delete a notebook checkpoint.
-     * 
+     *
      * @method delete_checkpoint
      * @param {String} checkpoint ID
      */
@@ -2041,10 +2076,10 @@ var IPython = (function (IPython) {
             error: $.proxy(this.delete_notebook_error,this)
         });
     };
-    
+
     /**
      * Success callback for deleting a notebook checkpoint
-     * 
+     *
      * @method delete_checkpoint_success
      * @param {Object} data (ignored, should be empty)
      * @param {String} status Description of response status
@@ -2057,7 +2092,7 @@ var IPython = (function (IPython) {
 
     /**
      * Failure callback for deleting a notebook checkpoint.
-     * 
+     *
      * @method delete_checkpoint_error
      * @param {jqXHR} xhr jQuery Ajax object
      * @param {String} status Description of response status

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -283,6 +283,67 @@ var IPython = (function (IPython) {
 
 
     /**
+     * @class RestructuredtextCell
+     * @constructor RestructuredtextCell
+     * @extends IPython.HTMLCell
+     */
+    var RestructuredtextCell = function (options) {
+        var options = options || {};
+
+        options = this.mergeopt(RestructuredtextCell,options);
+        TextCell.apply(this, [options]);
+
+        this.cell_type = 'restructuredtext';
+    };
+
+    RestructuredtextCell.options_default = {
+        cm_config: {
+            mode: 'rst'
+        },
+        placeholder: "Type *reStructuredText* and LaTeX: $\\alpha^2$"
+    }
+
+
+    RestructuredtextCell.prototype = new TextCell();
+
+
+    /**
+     * @method render
+     */
+    RestructuredtextCell.prototype.render = function () {
+        if (this.rendered === false) {
+            var text = this.get_text();
+            if (text === "") { text = this.placeholder; }
+
+            var whole_rst_source = "";
+
+            $.each(IPython.notebook.get_cells(), function(i, cell){
+                if (cell.cell_type === "restructuredtext"){
+                    whole_rst_source += "\n.. rst-cell-" + i.toString() + "\n\n" + cell.get_text();
+                }
+            });
+
+            var html = "<pre>" + whole_rst_source + "</pre>";
+            try {
+                this.set_rendered(html);
+            } catch (e) {
+                console.log("Error running Javascript in reStructuredText:");
+                console.log(e);
+                this.set_rendered($("<div/>").addClass("js-error").html(
+                    "Error rendering reStructuredText!<br/>" + e.toString())
+                );
+            }
+            this.element.find('div.text_cell_input').hide();
+            this.element.find("div.text_cell_render").show();
+            this.typeset()
+            this.rendered = true;
+        }
+    };
+
+
+
+
+    /**
      * @class MarkdownCell
      * @constructor MarkdownCell
      * @extends IPython.HTMLCell
@@ -553,7 +614,7 @@ var IPython = (function (IPython) {
                     .attr('href', '#' + hash)
                     .text('¶')
             );
-            
+
             this.set_rendered(h);
             this.typeset();
             this.element.find('div.text_cell_input').hide();
@@ -564,6 +625,7 @@ var IPython = (function (IPython) {
 
     IPython.TextCell = TextCell;
     IPython.MarkdownCell = MarkdownCell;
+    IPython.RestructuredtextCell = RestructuredtextCell;
     IPython.RawCell = RawCell;
     IPython.HeadingCell = HeadingCell;
 

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -316,10 +316,12 @@ var IPython = (function (IPython) {
             if (text === "") { text = this.placeholder; }
 
             var whole_rst_source = "";
-
+            var split_mark = "\n\n.. raw:: html\n\n   <!-- split //-->\n\n";
+            var rst_cells = [];
             $.each(IPython.notebook.get_cells(), function(i, cell){
                 if (cell.cell_type === "restructuredtext"){
-                    whole_rst_source += "\n.. rst-cell\n\n" + cell.get_text();
+                    rst_cells.push(i);
+                    whole_rst_source += cell.get_text() + split_mark;
                 }
             });
 
@@ -327,17 +329,17 @@ var IPython = (function (IPython) {
             $.post(url,
                 {'source': whole_rst_source},
                 function( data ){
-                    $.each(IPython.notebook.get_cells(), function(i, cell){
-                        if (cell.cell_type === "restructuredtext"){
-                            try {
-                                cell.set_rendered(data);
-                            } catch (e) {
-                                console.log("Error running Javascript in reStructuredText:");
-                                console.log(e);
-                                cell.set_rendered($("<div/>").addClass("js-error").html(
-                                    "Error rendering reStructuredText!<br/>" + e.toString())
-                                );
-                            }
+
+                    $.each(data, function(i, cell_html){
+                        var cell = IPython.notebook.get_cell(rst_cells[i])
+                        try {
+                            cell.set_rendered(cell_html);
+                        } catch (e) {
+                            console.log("Error running Javascript in reStructuredText:");
+                            console.log(e);
+                            cell.set_rendered($("<div/>").addClass("js-error").html(
+                                "Error rendering reStructuredText!<br/>" + e.toString())
+                            );
                         }
                     });
             });

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -319,20 +319,28 @@ var IPython = (function (IPython) {
 
             $.each(IPython.notebook.get_cells(), function(i, cell){
                 if (cell.cell_type === "restructuredtext"){
-                    whole_rst_source += "\n.. rst-cell-" + i.toString() + "\n\n" + cell.get_text();
+                    whole_rst_source += "\n.. rst-cell\n\n" + cell.get_text();
                 }
             });
 
-            var html = "<pre>" + whole_rst_source + "</pre>";
-            try {
-                this.set_rendered(html);
-            } catch (e) {
-                console.log("Error running Javascript in reStructuredText:");
-                console.log(e);
-                this.set_rendered($("<div/>").addClass("js-error").html(
-                    "Error rendering reStructuredText!<br/>" + e.toString())
-                );
-            }
+            var url = $('body').data('baseProjectUrl') + 'notebooks/rst';
+            $.post(url,
+                {'source': whole_rst_source},
+                function( data ){
+                    $.each(IPython.notebook.get_cells(), function(i, cell){
+                        if (cell.cell_type === "restructuredtext"){
+                            try {
+                                cell.set_rendered(data);
+                            } catch (e) {
+                                console.log("Error running Javascript in reStructuredText:");
+                                console.log(e);
+                                cell.set_rendered($("<div/>").addClass("js-error").html(
+                                    "Error rendering reStructuredText!<br/>" + e.toString())
+                                );
+                            }
+                        }
+                    });
+            });
             this.element.find('div.text_cell_input').hide();
             this.element.find("div.text_cell_render").show();
             this.typeset()

--- a/IPython/html/utils.py
+++ b/IPython/html/utils.py
@@ -1,8 +1,10 @@
+# -*- coding: utf-8 -*-
 """Notebook related utilities
 
 Authors:
 
 * Brian Granger
+* Martín Gaitán
 """
 
 #-----------------------------------------------------------------------------
@@ -15,6 +17,31 @@ Authors:
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+import docutils.core
+import docutils.io
+try:
+    from rst2html5 import HTML5Writer
+except ImportError:
+    HTML5Writer = None
+
+
+def rst2html(source):
+    writer = HTML5Writer() if HTML5Writer else None
+    output, pub = docutils.core.publish_programmatically(
+        source=source, source_path=None,
+        source_class=docutils.io.StringInput,
+        destination_class=docutils.io.StringOutput,
+        destination=None,
+        destination_path=None,
+        reader=None, reader_name='standalone',
+        parser=None, parser_name='restructuredtext',
+        writer=writer, writer_name='html',
+        settings=None, settings_spec=None,
+        settings_overrides=None,
+        config_section=None,
+        enable_exit_status=None)
+    return pub.writer.parts['body']
+
 
 def url_path_join(*pieces):
     """Join components of url into a relative url


### PR DESCRIPTION
This is my first attempt to implement #3714 , and although it seems to be working well, take it as a proof of concept to get early feedback. 

I know this is recurrent and controversial feature (#888, #1331 and may be more) but paraphasing somebody in an issue comment (I've read it yesterday but can't find the source now) who said: _"In IPython we code what we need"_ . Of course, I (and hopefully more people) need it :)

I've could also argue that reStructuredText is the "de facto" markup to write "documents" in a "pythonic way" being a markup so much powerful than markdown. Having support in the notebook would mean a kind of powerful front-end editor for tools like Sphinx, Nikola, etc. 
## The approach

The idea is very simple: join all rst cells as a whole document adding a separation mark, render via docutils (in server side), split the html into cell "chunks"  (using those marks), and inject each chunk in the correspondent cell. 

This simple idea solves the problem [described by @minrk](https://github.com/ipython/ipython/issues/3714#issuecomment-21313844) about rendering rST one cell at a time . 

I would like to read your opinions

PS: sorry if my english isn't so clear. 
