### PR TITLE
remove strip_math_space

### DIFF
--- a/IPython/nbconvert/exporters/templateexporter.py
+++ b/IPython/nbconvert/exporters/templateexporter.py
@@ -56,7 +56,6 @@ default_filters = {
         'html2text' : filters.html2text,
         'add_anchor': filters.add_anchor,
         'ansi2latex': filters.ansi2latex,
-        'strip_math_space': filters.strip_math_space,
         'wrap_text': filters.wrap_text,
         'escape_latex': filters.escape_latex,
         'citation2latex': filters.citation2latex,

--- a/IPython/nbconvert/filters/latex.py
+++ b/IPython/nbconvert/filters/latex.py
@@ -44,8 +44,7 @@ LATEX_SUBS = {
 # Functions
 #-----------------------------------------------------------------------------
 
-__all__ = ['escape_latex',
-           'strip_math_space']
+__all__ = ['escape_latex']
 
 def escape_latex(text):
     """
@@ -61,63 +60,4 @@ def escape_latex(text):
         text = pattern.sub(replacement, text)
 
     return text
-    
-    
-def strip_math_space(text):
-    """
-    Remove the space between latex math commands and enclosing $ symbols.
-    This filter is important because latex isn't as flexible as the notebook
-    front end when it comes to flagging math using ampersand symbols.
-    
-    Parameters
-    ----------
-    text : str
-        Text to filter.
-    """
 
-    # First, scan through the markdown looking for $.  If
-    # a $ symbol is found, without a preceding \, assume
-    # it is the start of a math block.  UNLESS that $ is
-    # not followed by another within two math_lines.
-    math_regions = []
-    math_lines = 0
-    within_math = False
-    math_start_index = 0
-    ptext = ''
-    last_character = ""
-    skip = False
-    for index, char in enumerate(text):
-
-        #Make sure the character isn't preceeded by a backslash
-        if (char == "$" and last_character != "\\"):
-
-            # Close the math region if this is an ending $
-            if within_math:
-                within_math = False
-                skip = True
-                ptext = ptext+'$'+text[math_start_index+1:index].strip()+'$'
-                math_regions.append([math_start_index, index+1])
-            else:
-
-                # Start a new math region
-                within_math = True
-                math_start_index = index
-                math_lines = 0
-
-        # If we are in a math region, count the number of lines parsed.
-        # Cancel the math region if we find two line breaks!
-        elif char == "\n":
-            if within_math:
-                math_lines += 1
-                if math_lines > 1:
-                    within_math = False
-                    ptext = ptext+text[math_start_index:index]
-
-        # Remember the last character so we can easily watch
-        # for backslashes
-        last_character = char
-        if not within_math and not skip:
-            ptext = ptext+char
-        if skip:
-            skip = False
-    return ptext

--- a/IPython/nbconvert/filters/tests/test_latex.py
+++ b/IPython/nbconvert/filters/tests/test_latex.py
@@ -15,7 +15,7 @@ Module with tests for Latex
 #-----------------------------------------------------------------------------
 
 from ...tests.base import TestsBase
-from ..latex import escape_latex, strip_math_space
+from ..latex import escape_latex
 
 
 #-----------------------------------------------------------------------------
@@ -43,24 +43,3 @@ class TestLatex(TestsBase):
         self.assertEqual(escape_latex(test), result)
 
 
-    def test_strip_math_space(self):
-        """strip_math_space test"""
-        tests = [
-            ('$e$','$e$'),
-            ('$ e $','$e$'),
-            ('xxx$e^i$yyy','xxx$e^i$yyy'),
-            ('xxx$ e^i $yyy','xxx$e^i$yyy'),
-            ('xxx$e^i $yyy','xxx$e^i$yyy'),
-            ('xxx$ e^i$yyy','xxx$e^i$yyy'),
-            ('\$ e $ e $','\$ e $e$'),
-            ('','')]
-
-        for test in tests:
-            self._try_strip_math_space(test[0], test[1])
-
-
-    def _try_strip_math_space(self, test, result):
-        """
-        Try to remove spaces between dollar symbols and contents correctly
-        """
-        self.assertEqual(strip_math_space(test), result)

--- a/IPython/nbconvert/preprocessors/latex.py
+++ b/IPython/nbconvert/preprocessors/latex.py
@@ -14,27 +14,22 @@ they are converted.
 #-----------------------------------------------------------------------------
 
 from __future__ import print_function, absolute_import
-import os
 
-# Third-party import, needed for Pygments latex definitions.
-from pygments.formatters import LatexFormatter
-
-# ipy imports
-from .base import (Preprocessor)
-from IPython.nbconvert import filters
+from .base import Preprocessor
 
 #-----------------------------------------------------------------------------
 # Classes
 #-----------------------------------------------------------------------------
 
 class LatexPreprocessor(Preprocessor):
-    """
-    Converter for latex destined documents.
+    """Preprocessor for latex destined documents.
+    
+    Mainly populates the `latex` key in the resources dict,
+    adding definitions for pygments highlight styles.
     """
 
     def preprocess(self, nb, resources):
-        """
-        Preprocessing to apply on each notebook.
+        """Preprocessing to apply on each notebook.
         
         Parameters
         ----------
@@ -44,31 +39,9 @@ class LatexPreprocessor(Preprocessor):
             Additional resources used in the conversion process.  Allows
             preprocessors to pass variables into the Jinja engine.
         """
-        # Generate Pygments definitions for Latex 
-        resources["latex"] = {}
-        resources["latex"]["pygments_definitions"] = LatexFormatter().get_style_defs()
-        return super(LatexPreprocessor, self).preprocess(nb, resources)
-
-
-    def preprocess_cell(self, cell, resources, index):
-        """
-        Apply a transformation on each cell,
+        # Generate Pygments definitions for Latex
+        from pygments.formatters import LatexFormatter
         
-        Parameters
-        ----------
-        cell : NotebookNode cell
-            Notebook cell being processed
-        resources : dictionary
-            Additional resources used in the conversion process.  Allows
-            preprocessors to pass variables into the Jinja engine.
-        index : int
-            Modified index of the cell being processed (see base.py)
-        """
-        
-        #If the cell is a markdown cell, preprocess the ampersands used to
-        #remove the space between them and their contents.  Latex will complain
-        #if spaces exist between the ampersands and the math content.  
-        #See filters.latex.rm_math_space for more information.
-        if hasattr(cell, "source") and cell.cell_type == "markdown":
-            cell.source = filters.strip_math_space(cell.source)
-        return cell, resources
+        resources.setdefault("latex", {})
+        resources["latex"].setdefault("pygments_definitions", LatexFormatter().get_style_defs())
+        return nb, resources

--- a/IPython/nbconvert/preprocessors/tests/test_latex.py
+++ b/IPython/nbconvert/preprocessors/tests/test_latex.py
@@ -47,5 +47,5 @@ class TestLatex(PreprocessorTestsBase):
         # Make sure the code cell wasn't modified.
         self.assertEqual(nb.worksheets[0].cells[0].input, '$ e $')
 
-        # Verify that the markdown cell was processed.
-        self.assertEqual(nb.worksheets[0].cells[1].source, '$e$')
+        # Verify that the markdown cell wasn't processed.
+        self.assertEqual(nb.worksheets[0].cells[1].source, '$ e $')

--- a/IPython/nbconvert/templates/html_basic.tpl
+++ b/IPython/nbconvert/templates/html_basic.tpl
@@ -55,13 +55,13 @@ In&nbsp;[{{ cell.prompt_number }}]:
 
 {% block markdowncell scoped %}
 <div class="text_cell_render border-box-sizing rendered_html">
-{{ cell.source | strip_math_space | markdown2html | strip_files_prefix }}
+{{ cell.source  | markdown2html | strip_files_prefix }}
 </div>
 {%- endblock markdowncell %}
 
 {% block headingcell scoped %}
 <div class="text_cell_render border-box-sizing rendered_html">
-{{ ("#" * cell.level + cell.source) | replace('\n', ' ') | strip_math_space | markdown2html | strip_files_prefix | add_anchor }}
+{{ ("#" * cell.level + cell.source) | replace('\n', ' ')  | markdown2html | strip_files_prefix | add_anchor }}
 </div>
 {% endblock headingcell %}
 


### PR DESCRIPTION
I don't think it solves any problems with supported pandoc versions, and it does introduce new ones.

Unless someone can come up with a case where it actually solves a problem, it should be removed.

closes #4309
supersedes #4310
