### PR TITLE
Explicitly state what version of Pandoc is supported in docs/install

### DIFF
--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -426,7 +426,7 @@ Dependencies for nbconvert (converting notebooks to various formats)
 pandoc
 ------
 
-The most important dependency of nbconvert is Pandoc_, a document format translation program.
+The most important dependency of nbconvert is Pandoc_ 1.10 or later, a document format translation program.
 This is not a Python package, so it cannot be expressed as a regular IPython dependency with setuptools.
 
 To install pandoc on Linux, you can generally use your package manager::


### PR DESCRIPTION
There may be a better place to put this, but I wasn't able to find where.  Pandoc < 1.10 isn't supported, and parses $$ (and possibly other things) differently.  #4313 made me aware that <= 1.9 is no longer supported (or never was?).
