### PR TITLE
fix initial sys.path

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -137,7 +137,7 @@ class BaseIPythonApplication(Application):
     )
     def _ipython_dir_default(self):
         d = get_ipython_dir()
-        self._ipython_dir_changed('ipython_dir', '', d)
+        self._ipython_dir_changed('ipython_dir', d, d)
         return d
     
     _in_init_profile_dir = False

--- a/IPython/kernel/tests/test_kernel.py
+++ b/IPython/kernel/tests/test_kernel.py
@@ -17,6 +17,7 @@ import nose.tools as nt
 
 from IPython.testing import decorators as dec, tools as tt
 from IPython.utils import py3compat
+from IPython.utils.path import locate_profile
 
 from .utils import new_kernel, kernel, TIMEOUT, assemble_output, execute, flush_channels
 
@@ -45,6 +46,21 @@ def test_simple_print():
         nt.assert_equal(stderr, '')
         _check_mp_mode(kc, expected=False)
 
+
+def test_sys_path():
+    """test that sys.path doesn't get messed up by default"""
+    with kernel() as kc:
+        msg_id, content = execute(kc=kc, code="import sys; print (repr(sys.path[0]))")
+        stdout, stderr = assemble_output(kc.iopub_channel)
+        nt.assert_equal(stdout, "''\n")
+
+def test_sys_path_profile_dir():
+    """test that sys.path doesn't get messed up when `--profile-dir` is specified"""
+    
+    with new_kernel(['--profile-dir', locate_profile('default')]) as kc:
+        msg_id, content = execute(kc=kc, code="import sys; print (repr(sys.path[0]))")
+        stdout, stderr = assemble_output(kc.iopub_channel)
+        nt.assert_equal(stdout, "''\n")
 
 @dec.knownfailureif(sys.platform == 'win32', "subprocess prints fail on Windows")
 def test_subprocess_print():

--- a/IPython/kernel/tests/utils.py
+++ b/IPython/kernel/tests/utils.py
@@ -36,10 +36,13 @@ KC = None
 #-------------------------------------------------------------------------------
 
 
-def start_new_kernel():
+def start_new_kernel(argv=None):
     """start a new kernel, and return its Manager and Client"""
     km = KernelManager()
-    km.start_kernel(stdout=PIPE, stderr=PIPE)
+    kwargs = dict(stdout=PIPE, stderr=PIPE)
+    if argv:
+        kwargs['extra_arguments'] = argv
+    km.start_kernel(**kwargs)
     kc = km.client()
     kc.start_channels()
     
@@ -123,7 +126,7 @@ def stop_global_kernel():
     KM = None
 
 @contextmanager
-def new_kernel():
+def new_kernel(argv=None):
     """Context manager for a new kernel in a subprocess
     
     Should only be used for tests where the kernel must not be re-used.
@@ -132,7 +135,7 @@ def new_kernel():
     -------
     kernel_client: connected KernelClient instance
     """
-    km, kc = start_new_kernel()
+    km, kc = start_new_kernel(argv)
     try:
         yield kc
     finally:


### PR DESCRIPTION
recent change caused initial sys.path to lose '' as the first element in the
notebook.

closes #4317
