### PR TITLE
Scroll to the top after change of slides in the IPython slides

### DIFF
--- a/IPython/nbconvert/templates/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/slides_reveal.tpl
@@ -173,7 +173,8 @@ window.onload = function () {
 
 <script>
 Reveal.addEventListener( 'slidechanged', function( event ) {
-MathJax.Hub.Rerender(event.currentSlide);
+  window.scrollTo(0,0);
+  MathJax.Hub.Rerender(event.currentSlide);
 });
 </script>
 

--- a/IPython/nbconvert/templates/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/slides_reveal.tpl
@@ -36,10 +36,11 @@ document.write( '<link rel="stylesheet" href="{{resources.reveal.url_prefix}}/cs
 
 <style type="text/css">
 /* Overrides of notebook CSS for static HTML export */
+html {
+overflow-y: auto;
+}
 .reveal {
 font-size: 20px;
-overflow-y: auto;
-overflow-x: hidden;
 }
 .reveal pre {
 width: 95%;


### PR DESCRIPTION
Currently, when you change from one slide to another, if you scroll down the content, when you go to a new slide, the content keep scrolled... and this is painful because the content of your next slide is at the top (not a the bottom) of the slide.

This PR solves this issue making the scroll to the top automatically when the user changes from one slide to another.
As a plus, I have change the overflow-y from `.reveal` class to the html element because it is necessary to make the scroll to the top work ok, and it seems to fix the disappear of the scrolling bar when you narrow a little bit the browser window.
