### PR TITLE
Remove commented addthis toolbar

### DIFF
--- a/IPython/nbconvert/templates/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/slides_reveal.tpl
@@ -121,7 +121,6 @@ dependencies: [
 { src: "{{resources.reveal.url_prefix}}/lib/js/classList.js", condition: function() { return !document.body.classList; } },
 { src: "{{resources.reveal.url_prefix}}/plugin/highlight/highlight.js", async: true, callback: function() { hljs.initHighlightingOnLoad(); } },
 { src: "{{resources.reveal.url_prefix}}/plugin/notes/notes.js", async: true, condition: function() { return !!document.body.classList; } }
-// { src: 'http://s7.addthis.com/js/300/addthis_widget.js', async: true},
 ]
 });
 </script>
@@ -144,7 +143,7 @@ MathJax.Hub.Config({
 <script>
 //  We wait for the onload function to load MathJax after the page is completely loaded.
 //  MathJax is loaded 1 unit of time after the page is ready.
-//  This hack prevent problems when you load multiple js files (i.e. social button from addthis).
+//  This hack prevent problems when you load multiple js files.
 //
 window.onload = function () {
   setTimeout(function () {

--- a/IPython/nbconvert/templates/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/slides_reveal.tpl
@@ -101,21 +101,6 @@ text-align: inherit;
 </div>
 </div>
 
-<!--
-Uncomment the following block and the addthis_widget.js (see below inside dependencies)
-to get enable social buttons.
--->
-
-<!--
-<div class="addthis_toolbox addthis_floating_style addthis_32x32_style" style="left:20px;top:20px;">
-<a class="addthis_button_twitter"></a>
-<a class="addthis_button_google_plusone_share"></a>
-<a class="addthis_button_linkedin"></a>
-<a class="addthis_button_facebook"></a>
-<a class="addthis_button_more"></a>
-</div>
--->
-
 <script src="{{resources.reveal.url_prefix}}/lib/js/head.min.js"></script>
 
 <script src="{{resources.reveal.url_prefix}}/js/reveal.js"></script>


### PR DESCRIPTION
It makes no sense to have commented code to add a toolbar which IPython slides are not using right now (and it will not use in the future, at least not with the default settings).
