### PR TITLE
adjust default value of level in sync_imports

### DIFF
--- a/IPython/parallel/client/view.py
+++ b/IPython/parallel/client/view.py
@@ -457,7 +457,7 @@ class DirectView(View):
             else:
                 user_ns[name] = sys.modules[name]
 
-        def view_import(name, globals={}, locals={}, fromlist=[], level=-1):
+        def view_import(name, globals={}, locals={}, fromlist=[], level=0):
             """the drop-in replacement for __import__, that optionally imports
             locally as well.
             """
@@ -478,7 +478,7 @@ class DirectView(View):
             imp.release_lock()
 
             key = name+':'+','.join(fromlist or [])
-            if level == -1 and key not in modules:
+            if level <= 0 and key not in modules:
                 modules.add(key)
                 if not quiet:
                     if fromlist:

--- a/IPython/parallel/tests/test_view.py
+++ b/IPython/parallel/tests/test_view.py
@@ -805,4 +805,30 @@ class TestView(ClusterTestCase):
         view = self.client[-1]
         tup = view.apply_sync(echoxy, point(1, 2))
         self.assertEqual(tup, (2,1))
+    
+    def test_sync_imports(self):
+        view = self.client[-1]
+        with capture_output() as io:
+            with view.sync_imports():
+                import IPython
+        self.assertIn("IPython", io.stdout)
+        
+        @interactive
+        def find_ipython():
+            return 'IPython' in globals()
+        
+        assert view.apply_sync(find_ipython)
+
+    def test_sync_imports_quiet(self):
+        view = self.client[-1]
+        with capture_output() as io:
+            with view.sync_imports(quiet=True):
+                import IPython
+        self.assertEqual(io.stdout, '')
+        
+        @interactive
+        def find_ipython():
+            return 'IPython' in globals()
+        
+        assert view.apply_sync(find_ipython)
 


### PR DESCRIPTION
and value check for <= 0 instead of just -1.

Python 3 no longer allows negative values (relative or absolute), and we should have always allowed 0 to work anyway.

closes #4296
