### PR TITLE
Use the get method to access values in a dict.

### DIFF
--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -280,9 +280,8 @@ def deep_reload_hook(m):
         subname = name
         path = None
     else:
-        try:
-            parent = sys.modules[name[:dot]]
-        except KeyError:
+        parent = sys.modules.get(name[:dot])
+        if parent is None:
             modules_reloading.clear()
             raise ImportError("reload(): parent %.200s not in sys.modules" % name[:dot])
         subname = name[dot+1:]


### PR DESCRIPTION
While I understand that probably this is also a controversial PR, in my favor I would like to say that the change reduces an unnecessary level of nesting and avoids a superfluous `try/except` block. Also, I feel that the `get` method is a more pythonic way to access dictionary elements. :)
