### PR TITLE
Return value directly from the try block and avoid a variable

### DIFF
--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -328,10 +328,9 @@ def reload(module, exclude=['sys', 'os.path', '__builtin__', '__main__']):
         found_now[i] = 1
     try:
         with replace_import_hook(deep_import_hook):
-            ret = deep_reload_hook(module)
+            return deep_reload_hook(module)
     finally:
         found_now = {}
-    return ret
 
 # Uncomment the following to automatically activate deep reloading whenever
 # this module is imported

--- a/IPython/lib/latextools.py
+++ b/IPython/lib/latextools.py
@@ -143,10 +143,9 @@ def latex_to_png_dvipng(s, wrap):
                 stdout=devnull, stderr=devnull)
 
         with open(outfile, "rb") as f:
-            bin_data = f.read()
+            return f.read()
     finally:
         shutil.rmtree(workdir)
-    return bin_data
 
 
 def kpsewhich(filename):


### PR DESCRIPTION
Avoid another temporary variable assignment by directly returning the value from the try block. The finally block will be executed nevertheless.
