### PR TITLE
Make parameters for kernel start method more general

### DIFF
--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1370,7 +1370,7 @@ var IPython = (function (IPython) {
     Notebook.prototype.start_kernel = function () {
         var base_url = $('body').data('baseKernelUrl') + "kernels";
         this.kernel = new IPython.Kernel(base_url);
-        this.kernel.start(this.notebook_id);
+        this.kernel.start({notebook: this.notebook_id});
         // Now that the kernel has been created, tell the CodeCells about it.
         var ncells = this.ncells();
         for (var i=0; i<ncells; i++) {

--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -72,10 +72,10 @@ var IPython = (function (IPython) {
      * Start the Python kernel
      * @method start
      */
-    Kernel.prototype.start = function (notebook_id) {
+    Kernel.prototype.start = function (params) {
         var that = this;
         if (!this.running) {
-            var qs = $.param({notebook:notebook_id});
+            var qs = $.param(params);
             var url = this.base_url + '?' + qs;
             $.post(url,
                 $.proxy(that._kernel_started,that),


### PR DESCRIPTION
In the Sage cell, we'd like to pass more parameters to a starting kernel (like a default timeout, etc.).  This is easy to do if we make the start method just a bit more general.  In fact, our kernel backend doesn't care about the notebook id, and this also makes it easy for us to ignore it.
