### PR TITLE
WinHPC launcher fixes

### DIFF
--- a/IPython/parallel/apps/winhpcjob.py
+++ b/IPython/parallel/apps/winhpcjob.py
@@ -145,7 +145,7 @@ class WinHPCJob(Configurable):
         """Return the string representation of the job description XML."""
         root = self.as_element()
         indent(root)
-        txt = ET.tostring(root, encoding="utf-8")
+        txt = ET.tostring(root, encoding="utf-8").decode('utf-8')
         # Now remove the tokens used to order the attributes.
         txt = re.sub(r'_[A-Z]_','',txt)
         txt = '<?xml version="1.0" encoding="utf-8"?>\n' + txt

--- a/IPython/parallel/apps/winhpcjob.py
+++ b/IPython/parallel/apps/winhpcjob.py
@@ -264,8 +264,8 @@ class IPControllerTask(WinHPCTask):
     unit_type = Unicode("Core", config=False)
     work_directory = Unicode('', config=False)
 
-    def __init__(self, config=None):
-        super(IPControllerTask, self).__init__(config=config)
+    def __init__(self, **kwargs):
+        super(IPControllerTask, self).__init__(**kwargs)
         the_uuid = uuid.uuid1()
         self.std_out_file_path = os.path.join('log','ipcontroller-%s.out' % the_uuid)
         self.std_err_file_path = os.path.join('log','ipcontroller-%s.err' % the_uuid)
@@ -292,8 +292,8 @@ class IPEngineTask(WinHPCTask):
     unit_type = Unicode("Core", config=False)
     work_directory = Unicode('', config=False)
 
-    def __init__(self, config=None):
-        super(IPEngineTask,self).__init__(config=config)
+    def __init__(self, **kwargs):
+        super(IPEngineTask,self).__init__(**kwargs)
         the_uuid = uuid.uuid1()
         self.std_out_file_path = os.path.join('log','ipengine-%s.out' % the_uuid)
         self.std_err_file_path = os.path.join('log','ipengine-%s.err' % the_uuid)

--- a/IPython/parallel/tests/test_launcher.py
+++ b/IPython/parallel/tests/test_launcher.py
@@ -177,9 +177,17 @@ class TestSSHEngineLauncher(SSHTest, LauncherTest, TestCase):
 # Windows Launcher Tests
 #-------------------------------------------------------------------------------
 
-if sys.platform.startswith("win"):
-    class TestWinHPCControllerLauncher(ControllerLauncherTest, TestCase):
-        launcher_class = launcher.WindowsHPCControllerLauncher
+class WinHPCTest:
+    """Tests for WinHPC Launchers"""
+    def test_batch_template(self):
+        launcher = self.build_launcher()
+        job_file = os.path.join(self.profile_dir, launcher.job_file_name)
+        self.assertEqual(launcher.job_file, job_file)
+        launcher.write_job_file(1)
+        self.assertTrue(os.path.isfile(job_file))
 
-    class TestWinHPCEngineSetLauncher(EngineSetLauncherTest, TestCase):
-        launcher_class = launcher.WindowsHPCEngineSetLauncher
+class TestWinHPCControllerLauncher(WinHPCTest, ControllerLauncherTest, TestCase):
+    launcher_class = launcher.WindowsHPCControllerLauncher
+
+class TestWinHPCEngineSetLauncher(WinHPCTest, EngineSetLauncherTest, TestCase):
+    launcher_class = launcher.WindowsHPCEngineSetLauncher


### PR DESCRIPTION
fixes unicode and TypeError issues with the WinHPC launchers

also enables tests that should run on any platform,
since they don't actually require Windows.

closes #4351
