### PR TITLE
Don't reset the readline completer after each prompt

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -565,12 +565,6 @@ class TerminalInteractiveShell(InteractiveShell):
           - continue_prompt(False): whether this line is the first one or a
           continuation in a sequence of inputs.
         """
-        # Code run by the user may have modified the readline completer state.
-        # We must ensure that our completer is back in place.
-
-        if self.has_readline:
-            self.set_readline_completer()
-        
         # raw_input expects str, but we pass it unicode sometimes
         prompt = py3compat.cast_bytes_py2(prompt)
 


### PR DESCRIPTION
This makes it impossible to setup a custom completer. The comment says that
"we must ensure that our completer is back in place," but I don't see why. All 
that does it make it impossible to use a different completer. One can trick 
IPython into not doing this by monkeypatching ip.has_readline to False, but 
then certain features like multiline editing are no longer enabled.

See https://github.com/davidhalter/jedi/pull/321.
