### PR TITLE
remove hardcoded box-orient

### DIFF
--- a/IPython/nbconvert/templates/html_basic.tpl
+++ b/IPython/nbconvert/templates/html_basic.tpl
@@ -8,13 +8,13 @@
 {%- endblock codecell %}
 
 {% block input_group -%}
-<div class="input hbox">
+<div class="input">
 {{ super() }}
 </div>
 {% endblock input_group %}
 
 {% block output_group %}
-<div class="vbox output_wrapper">
+<div class="output_wrapper">
 <div class="output vbox">
 {{ super() }}
 </div>
@@ -41,7 +41,7 @@ In&nbsp;[{{ cell.prompt_number }}]:
 {%- endblock input %}
 
 {% block output %}
-<div class="hbox output_area">
+<div class="output_area">
 {%- if output.output_type == 'pyout' -%}
     <div class="prompt output_prompt">
     Out[{{ cell.prompt_number }}]:


### PR DESCRIPTION
remove some hardcoded `vbox` and `hbox` in html templates, those are not anymore in the notebook-app DOM, in favor oh having the `less` class inheriting from the corresponding mixin.

This should allow easier pure-css customization.
