### PR TITLE
Expose IPython version in javascript.

### DIFF
--- a/IPython/html/notebook/handlers.py
+++ b/IPython/html/notebook/handlers.py
@@ -17,11 +17,13 @@ Authors:
 #-----------------------------------------------------------------------------
 
 import os
+import json
 from tornado import web
 HTTPError = web.HTTPError
 
 from ..base.handlers import IPythonHandler
 from ..utils import url_path_join
+from ... import version_info
 
 #-----------------------------------------------------------------------------
 # Handlers
@@ -48,6 +50,7 @@ class NamedNotebookHandler(IPythonHandler):
             notebook_id=notebook_id,
             kill_kernel=False,
             mathjax_url=self.mathjax_url,
+            ipython_version="'{json}'".format(json=json.dumps(version_info))
             )
         )
 

--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -46,8 +46,9 @@ function (marked) {
     $('#ipython-main-app').addClass('border-box-sizing');
     $('div#notebook_panel').addClass('border-box-sizing');
 
-    var baseProjectUrl = $('body').data('baseProjectUrl')
+    var baseProjectUrl = $('body').data('baseProjectUrl');
 
+    IPython.version = $('body').data('ipython-version');
     IPython.page = new IPython.Page();
     IPython.layout_manager = new IPython.LayoutManager();
     IPython.pager = new IPython.Pager('div#pager', 'div#pager_splitter');

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -25,6 +25,7 @@ data-project={{project}}
 data-base-project-url={{base_project_url}}
 data-base-kernel-url={{base_kernel_url}}
 data-notebook-id={{notebook_id}}
+data-ipython-version={{ipython_version}}
 class="notebook_app"
 
 {% endblock %}


### PR DESCRIPTION
(done from github web, so there are some commit that I'll remove later, and rebase)

Expose IPython version in javascript.

Alternative is to do it in jinja template to alway be sure to have it in sync with the server version, 
and so that we cannot forget to update it. 

We should also probably expose a method that is able to reliably compare versions array,
and or look for a semver js-lib.

Prompt by the discussion on JuliaLang/IJulia.jl#84 before I forget.
