### PR TITLE
test_pylabtools also needs to modify matplotlib.rcParamsOrig

### DIFF
--- a/IPython/core/tests/test_pylabtools.py
+++ b/IPython/core/tests/test_pylabtools.py
@@ -73,7 +73,9 @@ class TestPylabSwitch(object):
 
         # Save rcParams since they get modified
         self._saved_rcParams = matplotlib.rcParams
+        self._saved_rcParamsOrig = matplotlib.rcParamsOrig
         matplotlib.rcParams = dict(backend='Qt4Agg')
+        matplotlib.rcParamsOrig = dict(backend='Qt4Agg')
 
         # Mock out functions
         self._save_am = pt.activate_matplotlib
@@ -89,6 +91,7 @@ class TestPylabSwitch(object):
         pt.configure_inline_support = self._save_cis
         import matplotlib
         matplotlib.rcParams = self._saved_rcParams
+        matplotlib.rcParamsOrig = self._saved_rcParamsOrig
 
     def test_qt(self):
         s = self.Shell()


### PR DESCRIPTION
From bbb4baa8ff1010, the code to find a matplotlib backend checks rcParamsOrig instead of rcParams. The tests for pylabtools configure rcParams to control which backend is selected by default, so they need updating to also set rcParamsOrig.

closes gh-4335
