### PR TITLE
add a dirty class to cell when modified

### DIFF
--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -100,7 +100,7 @@ var IPython = (function (IPython) {
      * @method mark_clean
      */
     Cell.prototype.mark_clean = function(){
-        this._clean_generation = this.code_mirror.changeGeneration()
+        this._clean_generation = this.code_mirror.changeGeneration();
         this.mark_maybe_dirty();
     }
 
@@ -158,7 +158,7 @@ var IPython = (function (IPython) {
         if (this.code_mirror) {
             this.code_mirror.on("change", function(cm, change) {
                 $([IPython.events]).trigger("set_dirty.Notebook", {value: true});
-                that.mark_maybe_dirty()
+                that.mark_maybe_dirty();
             });
         }
         if (this.code_mirror) {
@@ -373,6 +373,7 @@ var IPython = (function (IPython) {
             this.metadata = data.metadata;
         }
         this.celltoolbar.rebuild();
+        this.mark_clean();
     };
 
 

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -47,6 +47,7 @@ var IPython = (function (IPython) {
         this.cm_config = options.cm_config;
         this.cell_id = utils.uuid();
         this._options = options;
+        this._clean_generation = 0;
 
         // For JS VM engines optimisation, attributes should be all set (even
         // to null) in the constructor, and if possible, if different subclass
@@ -88,8 +89,20 @@ var IPython = (function (IPython) {
         return $.extend(true, {}, _class.options_default, options, overwrite)
 
     }
-
-
+   
+    /**
+     * Mark the current cell as clean.
+     *
+     * Store the current CodeMirror edit generation and add
+     * necessary class to the dom to mark the current cell source content
+     * as in sync with it's content.
+     *
+     * @method mark_clean
+     */
+    Cell.prototype.mark_clean = function(){
+        this._clean_generation = this.code_mirror.changeGeneration()
+        this.mark_maybe_dirty();
+    }
 
     /**
      * Empty. Subclasses must implement create_element.
@@ -140,9 +153,12 @@ var IPython = (function (IPython) {
                 $([IPython.events]).trigger('select.Cell', {'cell':that});
             };
         });
+
+        var that = this;
         if (this.code_mirror) {
             this.code_mirror.on("change", function(cm, change) {
                 $([IPython.events]).trigger("set_dirty.Notebook", {value: true});
+                that.mark_maybe_dirty()
             });
         }
         if (this.code_mirror) {
@@ -167,6 +183,26 @@ var IPython = (function (IPython) {
             });
         }
     };
+
+    Cell.prototype.mark_dirty = function(){
+        this._clean_generation = -1;
+        this.mark_maybe_dirty();
+    }
+
+    /**
+     * Mark a cell as dirty if necessary
+     */
+    Cell.prototype.mark_maybe_dirty = function() {
+        var clean = this.code_mirror.isClean(this._clean_generation)
+        if (this.element !== null){
+            if(clean) {
+              this.element.removeClass('dirty');
+            } else {
+              this.element.addClass('dirty');
+            }
+        }
+        $([IPython.events]).trigger("set_dirty.Cell", {value:!clean, cell: this});
+    }
 
     /**
      * Triger typsetting of math by mathjax on current cell element

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -291,6 +291,7 @@ var IPython = (function (IPython) {
         var callbacks = this.get_callbacks();
         
         this.last_msg_id = this.kernel.execute(this.get_text(), callbacks, {silent: false, store_history: true});
+        this.mark_clean();
     };
     
     /**
@@ -471,6 +472,7 @@ var IPython = (function (IPython) {
 
 
     CodeCell.prototype.clear_output = function (wait) {
+        this.mark_dirty();
         this.output_area.clear_output(wait);
     };
 

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -503,6 +503,7 @@ var IPython = (function (IPython) {
                 }
             }
         }
+        this.mark_clean();
     };
 
 

--- a/IPython/html/static/notebook/less/notebook.less
+++ b/IPython/html/static/notebook/less/notebook.less
@@ -67,5 +67,5 @@ p {
 }
 
 .dirty .prompt{
-    color:gray
+    color:gray;
 }

--- a/IPython/html/static/notebook/less/notebook.less
+++ b/IPython/html/static/notebook/less/notebook.less
@@ -65,3 +65,7 @@ p {
 .end_space {
     height: 200px;
 }
+
+.dirty .prompt{
+    color:gray
+}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1545,7 +1545,7 @@ pre,code,kbd,samp{white-space:pre-wrap;}
 #fonttest{font-family:monospace;}
 p{margin-bottom:0;}
 .end_space{height:200px;}
-.dirty .prompt{color:#808080;}
+.dirty .prompt{color:gray;}
 .celltoolbar{border:thin solid #CFCFCF;border-bottom:none;background:#EEE;border-radius:3px 3px 0px 0px;width:100%;-webkit-box-pack:end;height:22px;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;-webkit-box-direction:reverse;-moz-box-direction:reverse;box-direction:reverse;}
 .ctb_hideshow{display:none;vertical-align:bottom;padding-right:2px;}
 .celltoolbar>div{padding-top:0px;}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1545,6 +1545,7 @@ pre,code,kbd,samp{white-space:pre-wrap;}
 #fonttest{font-family:monospace;}
 p{margin-bottom:0;}
 .end_space{height:200px;}
+.dirty .prompt{color:#808080;}
 .celltoolbar{border:thin solid #CFCFCF;border-bottom:none;background:#EEE;border-radius:3px 3px 0px 0px;width:100%;-webkit-box-pack:end;height:22px;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;-webkit-box-direction:reverse;-moz-box-direction:reverse;box-direction:reverse;}
 .ctb_hideshow{display:none;vertical-align:bottom;padding-right:2px;}
 .celltoolbar>div{padding-top:0px;}


### PR DESCRIPTION
Allow to do stuff like : 
![capture decran 2013-10-08 a 17 21 28](https://f.cloud.github.com/assets/335567/1290212/08d4331c-302d-11e3-84af-1c70ac5c5181.png)

with this css

```
<style>
.dirty div.input div.prompt{
    color:grey;
}

.dirty div.prompt{
    color:grey;
}
</style>
```

All cells that have not been executed in the current page have grey prompt, prompt get colored if you execute the cell. It revert back to grey if you ever trigger a 'dirty' on code mirror.
