### PR TITLE
set_next_input: keep only last input when repeatedly called in a single cell

### DIFF
--- a/IPython/core/payload.py
+++ b/IPython/core/payload.py
@@ -29,9 +29,17 @@ class PayloadManager(Configurable):
 
     _payload = List([])
 
-    def write_payload(self, data):
+    def write_payload(self, data, update=False):
         if not isinstance(data, dict):
             raise TypeError('Each payload write must be a dict, got: %r' % data)
+
+        if update and 'source' in data:
+            source = data['source']
+            for i,pl in enumerate(self._payload):
+                if 'source' in pl and pl['source'] == source:
+                    self._payload[i] = data
+                    return
+
         self._payload.append(data)
 
     def read_payload(self):

--- a/IPython/core/payload.py
+++ b/IPython/core/payload.py
@@ -32,8 +32,8 @@ class PayloadManager(Configurable):
     def write_payload(self, data, single=True):
         """Include or update the specified `data` payload in the PayloadManager.
 
-        If a previous payload with the same source than `data` exists
-        and `single` is True, it will be overwritten with the new one.
+        If a previous payload with the same source exists and `single` is True,
+        it will be overwritten with the new one.
         """
 
         if not isinstance(data, dict):

--- a/IPython/core/payload.py
+++ b/IPython/core/payload.py
@@ -29,11 +29,17 @@ class PayloadManager(Configurable):
 
     _payload = List([])
 
-    def write_payload(self, data, update=False):
+    def write_payload(self, data, single=True):
+        """Include or update the specified `data` payload in the PayloadManager.
+
+        If a previous payload with the same source than `data` exists
+        and `single` is True, it will be overwritten with the new one.
+        """
+
         if not isinstance(data, dict):
             raise TypeError('Each payload write must be a dict, got: %r' % data)
 
-        if update and 'source' in data:
+        if single and 'source' in data:
             source = data['source']
             for i, pl in enumerate(self._payload):
                 if 'source' in pl and pl['source'] == source:

--- a/IPython/core/payload.py
+++ b/IPython/core/payload.py
@@ -35,7 +35,7 @@ class PayloadManager(Configurable):
 
         if update and 'source' in data:
             source = data['source']
-            for i,pl in enumerate(self._payload):
+            for i, pl in enumerate(self._payload):
                 if 'source' in pl and pl['source'] == source:
                     self._payload[i] = data
                     return

--- a/IPython/kernel/tests/test_message_spec.py
+++ b/IPython/kernel/tests/test_message_spec.py
@@ -406,6 +406,15 @@ def test_kernel_info_request():
     validate_message(reply, 'kernel_info_reply', msg_id)
 
 
+def test_single_payload():
+    flush_channels()
+    msg_id, reply = execute(code="for i in range(3):\n"+
+                                 "   x=range?\n")
+    payload = reply['payload']
+    next_input_pls = [pl for pl in payload if pl["source"] == "set_next_input"]
+    nt.assert_equal(len(next_input_pls), 1)
+
+
 # IOPub channel
 
 

--- a/IPython/kernel/zmq/zmqshell.py
+++ b/IPython/kernel/zmq/zmqshell.py
@@ -583,7 +583,7 @@ class ZMQInteractiveShell(InteractiveShell):
             source='set_next_input',
             text=text
         )
-        self.payload_manager.write_payload(payload, update=True)
+        self.payload_manager.write_payload(payload)
     
     #-------------------------------------------------------------------------
     # Things related to magics

--- a/IPython/kernel/zmq/zmqshell.py
+++ b/IPython/kernel/zmq/zmqshell.py
@@ -583,7 +583,7 @@ class ZMQInteractiveShell(InteractiveShell):
             source='set_next_input',
             text=text
         )
-        self.payload_manager.write_payload(payload)
+        self.payload_manager.write_payload(payload, update=True)
     
     #-------------------------------------------------------------------------
     # Things related to magics


### PR DESCRIPTION
When calling multiple times set_next_input in a single cell execution,
we should only keep the last input.

Closes #1349
