### PR TITLE
404 on attempt to list notebooks in nonexistant directory

### DIFF
--- a/IPython/html/services/notebooks/filenbmanager.py
+++ b/IPython/html/services/notebooks/filenbmanager.py
@@ -76,6 +76,8 @@ class FileNotebookManager(NotebookManager):
     def get_notebook_names(self, path=''):
         """List all notebook names in the notebook dir and path."""
         path = path.strip('/')
+        if not os.path.isdir(self.get_os_path(path=path)):
+            raise web.HTTPError(404, 'Directory not found: ' + path)
         names = glob.glob(self.get_os_path('*'+self.filename_ext, path))
         names = [os.path.basename(name)
                  for name in names]

--- a/IPython/html/services/sessions/tests/test_sessions_api.py
+++ b/IPython/html/services/sessions/tests/test_sessions_api.py
@@ -9,7 +9,7 @@ import shutil
 pjoin = os.path.join
 
 from IPython.html.utils import url_path_join
-from IPython.html.tests.launchnotebook import NotebookTestBase
+from IPython.html.tests.launchnotebook import NotebookTestBase, assert_http_error
 from IPython.nbformat.current import new_notebook, write
 
 class SessionAPI(object):
@@ -64,14 +64,6 @@ class SessionAPITest(NotebookTestBase):
             self.sess_api.delete(session['id'])
         shutil.rmtree(pjoin(self.notebook_dir.name, 'foo'))
 
-    def assert_404(self, id):
-        try:
-            self.sess_api.get(id)
-        except requests.HTTPError as e:
-            self.assertEqual(e.response.status_code, 404)
-        else:
-            assert False, "Getting nonexistent session didn't give HTTP error"
-
     def test_create(self):
         sessions = self.sess_api.list().json()
         self.assertEqual(len(sessions), 0)
@@ -101,7 +93,8 @@ class SessionAPITest(NotebookTestBase):
         sessions = self.sess_api.list().json()
         self.assertEqual(sessions, [])
 
-        self.assert_404(sid)
+        with assert_http_error(404):
+            self.sess_api.get(sid)
 
     def test_modify(self):
         newsession = self.sess_api.create('nb1.ipynb', 'foo').json()

--- a/IPython/html/tests/launchnotebook.py
+++ b/IPython/html/tests/launchnotebook.py
@@ -3,11 +3,11 @@
 import sys
 import time
 import requests
+from contextlib import contextmanager
 from subprocess import Popen, PIPE
 from unittest import TestCase
 
 from IPython.utils.tempdir import TemporaryDirectory
-
 
 class NotebookTestBase(TestCase):
     """A base class for tests that need a running notebook.
@@ -67,3 +67,15 @@ class NotebookTestBase(TestCase):
     @classmethod
     def base_url(cls):
         return 'http://localhost:%i/' % cls.port
+
+
+@contextmanager
+def assert_http_error(status):
+    try:
+        yield
+    except requests.HTTPError as e:
+        real_status = e.response.status_code
+        assert real_status == status, \
+                    "Expected status %d, got %d" % (real_status, status)
+    else:
+        assert False, "Expected HTTP error status"


### PR DESCRIPTION
[This is against multidir]

Also some test simplification - a unified `assert_http_error` context manager.
