### PR TITLE
Restored ipython profile locate dir and fixed typo. (Fixes #3708).

### DIFF
--- a/IPython/core/profileapp.py
+++ b/IPython/core/profileapp.py
@@ -86,7 +86,7 @@ _main_examples = """
 ipython profile create -h  # show the help string for the create subcommand
 ipython profile list -h    # show the help string for the list subcommand
 
-ipython locate profile foo # print the path to the directory for profile 'foo'
+ipython profile locate foo # print the path to the directory for profile 'foo'
 """
 
 #-----------------------------------------------------------------------------
@@ -121,7 +121,7 @@ def list_bundled_profiles():
 
 
 class ProfileLocate(BaseIPythonApplication):
-    description = """print the path an IPython profile dir"""
+    description = """print the path to an IPython profile dir"""
     
     def parse_command_line(self, argv=None):
         super(ProfileLocate, self).parse_command_line(argv)
@@ -299,6 +299,7 @@ class ProfileApp(Application):
     subcommands = Dict(dict(
         create = (ProfileCreate, ProfileCreate.description.splitlines()[0]),
         list = (ProfileList, ProfileList.description.splitlines()[0]),
+        locate = (ProfileLocate, ProfileLocate.description.splitlines()[0]),
     ))
 
     def start(self):
@@ -310,4 +311,3 @@ class ProfileApp(Application):
             self.exit(1)
         else:
             return self.subapp.start()
-

--- a/IPython/core/profileapp.py
+++ b/IPython/core/profileapp.py
@@ -86,7 +86,7 @@ _main_examples = """
 ipython profile create -h  # show the help string for the create subcommand
 ipython profile list -h    # show the help string for the list subcommand
 
-ipython profile locate foo # print the path to the directory for profile 'foo'
+ipython locate profile foo # print the path to the directory for profile 'foo'
 """
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Reverts commit 1406201 from #1762.
