### PR TITLE
Test and fixes for localinterfaces

### DIFF
--- a/IPython/utils/localinterfaces.py
+++ b/IPython/utils/localinterfaces.py
@@ -27,7 +27,6 @@ import socket
 
 from .data import uniq_stable
 from .process import get_output_error_code
-from .py3compat import bytes_to_str
 from .warn import warn
 
 #-----------------------------------------------------------------------------
@@ -96,11 +95,11 @@ def _load_ips_ifconfig():
     if rc:
         raise IOError("no ifconfig: %s" % err)
     
-    lines = bytes_to_str(out).splitlines()
+    lines = out.splitlines()
     addrs = []
     for line in lines:
         blocks = line.lower().split()
-        if blocks[0] == 'inet':
+        if (len(blocks) >= 2) and (blocks[0] == 'inet'):
             addrs.append(blocks[1])
     _populate_from_list(addrs)
 
@@ -111,11 +110,11 @@ def _load_ips_ip():
     if rc:
         raise IOError("no ip: %s" % err)
     
-    lines = bytes_to_str(out).splitlines()
+    lines = out.splitlines()
     addrs = []
     for line in lines:
         blocks = line.lower().split()
-        if blocks[0] == 'inet':
+        if (len(blocks) >= 2) and (blocks[0] == 'inet'):
             addrs.append(blocks[1].split('/')[0])
     _populate_from_list(addrs)
 
@@ -126,7 +125,7 @@ def _load_ips_ipconfig():
     if rc:
         raise IOError("no ipconfig: %s" % err)
     
-    lines = bytes_to_str(out).splitlines()
+    lines = out.splitlines()
     addrs = ['127.0.0.1']
     for line in lines:
         line = line.lower().split()

--- a/IPython/utils/localinterfaces.py
+++ b/IPython/utils/localinterfaces.py
@@ -42,10 +42,10 @@ LOCALHOST = ''
 def _only_once(f):
     """decorator to only run a function once"""
     f.called = False
-    def wrapped():
+    def wrapped(**kwargs):
         if f.called:
             return
-        ret = f()
+        ret = f(**kwargs)
         f.called = True
         return ret
     return wrapped
@@ -203,7 +203,7 @@ def _load_ips_dumb():
     PUBLIC_IPS[:] = []
 
 @_only_once
-def _load_ips():
+def _load_ips(suppress_exceptions=True):
     """load the IPs that point to this machine
     
     This function will only ever be called once.
@@ -241,6 +241,8 @@ def _load_ips():
         
         return _load_ips_gethostbyname()
     except Exception as e:
+        if not suppress_exceptions:
+            raise
         # unexpected error shouldn't crash, load dumb default values instead.
         warn("Unexpected error discovering local network interfaces: %s" % e)
     _load_ips_dumb()

--- a/IPython/utils/tests/test_localinterfaces.py
+++ b/IPython/utils/tests/test_localinterfaces.py
@@ -1,0 +1,15 @@
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2013  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+from .. import localinterfaces
+
+def test_load_ips():
+    # Override the machinery that skips it if it was called before
+    localinterfaces._load_ips.called = False
+
+    # Just check this doesn't error
+    localinterfaces._load_ips(suppress_exceptions=False)


### PR DESCRIPTION
I noticed a warning from attempting to load IP addresses on Python 3. This adds a test and fixes the issue.
