### PR TITLE
More concise test summary info

### DIFF
--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -199,6 +199,13 @@ class LocateIPythonApp(BaseIPythonApplication):
             print self.ipython_dir
 
 
+class SysinfoApp(BaseIPythonApplication):
+    description = """print information about IPython and the platform."""
+    def start(self):
+        from IPython import sys_info
+        print(sys_info())
+
+
 class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
     name = u'ipython'
     description = usage.cl_usage
@@ -247,6 +254,9 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
         ),
         nbconvert=('IPython.nbconvert.nbconvertapp.NbConvertApp',
             "Convert notebooks to/from other formats."
+        ),
+        sysinfo=('IPython.terminal.ipapp.SysinfoApp',
+            SysinfoApp.description
         ),
     ))
 

--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -330,7 +330,7 @@ def run_iptestall(options):
     took = "Took %.3fs." % t_tests
     print('Status: ', end='')
     if not failed:
-        print('OK.', took)
+        print('OK (%d test groups).' % nrunners, took)
     else:
         # If anything went wrong, point out what command to rerun manually to
         # see the actual errors and individual summary

--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -28,8 +28,9 @@ import subprocess
 import time
 
 from .iptest import have, test_group_names, test_sections
+from IPython.utils.path import compress_user
 from IPython.utils.py3compat import bytes_to_str
-from IPython.utils.sysinfo import brief_sys_info
+from IPython.utils.sysinfo import get_sys_info
 from IPython.utils.tempdir import TemporaryDirectory
 
 
@@ -205,8 +206,20 @@ def do_run(controller):
 
 def report():
     """Return a string with a summary report of test-related variables."""
+    inf = get_sys_info()
+    out = []
+    def _add(name, value):
+        out.append((name, value))
 
-    out = [ brief_sys_info(), '\n']
+    _add('IPython version', inf['ipython_version'])
+    _add('IPython commit', "{} ({})".format(inf['commit_hash'], inf['commit_source']))
+    _add('IPython package', compress_user(inf['ipython_path']))
+    _add('Python version', inf['sys_version'].replace('\n',''))
+    _add('sys.executable', compress_user(inf['sys_executable']))
+    _add('Platform', inf['platform'])
+
+    width = max(len(n) for (n,v) in out)
+    out = ["{:<{width}}: {}\n".format(n, v, width=width) for (n,v) in out]
 
     avail = []
     not_avail = []

--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -29,7 +29,7 @@ import time
 
 from .iptest import have, test_group_names, test_sections
 from IPython.utils.py3compat import bytes_to_str
-from IPython.utils.sysinfo import sys_info
+from IPython.utils.sysinfo import brief_sys_info
 from IPython.utils.tempdir import TemporaryDirectory
 
 
@@ -206,7 +206,7 @@ def do_run(controller):
 def report():
     """Return a string with a summary report of test-related variables."""
 
-    out = [ sys_info(), '\n']
+    out = [ brief_sys_info(), '\n']
 
     avail = []
     not_avail = []
@@ -327,17 +327,16 @@ def run_iptestall(options):
     print('_'*70)
     print('Test suite completed for system with the following information:')
     print(report())
-    print('Ran %s test groups in %.3fs' % (nrunners, t_tests))
-    print()
+    took = "Took %.3fs." % t_tests
     print('Status: ', end='')
     if not failed:
-        print('OK')
+        print('OK.', took)
     else:
         # If anything went wrong, point out what command to rerun manually to
         # see the actual errors and individual summary
         failed_sections = [c.section for c in failed]
         print('ERROR - {} out of {} test groups failed ({}).'.format(nfail,
-                                  nrunners, ', '.join(failed_sections)))
+                                  nrunners, ', '.join(failed_sections)), took)
         print()
         print('You may wish to rerun these, with:')
         print('  iptest', *failed_sections)

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -88,6 +88,13 @@ def unquote_filename(name, win32=(sys.platform=='win32')):
             name = name[1:-1]
     return name
 
+def compress_user(path):
+    """Reverse of :func:`os.path.expanduser`
+    """
+    home = os.path.expanduser('~')
+    if path.startswith(home):
+        path =  "~" + path[len(home):]
+    return path
 
 def get_py_filename(name, force_win32=None):
     """Return a valid python filename in the current directory.

--- a/IPython/utils/sysinfo.py
+++ b/IPython/utils/sysinfo.py
@@ -117,6 +117,34 @@ def sys_info():
     path = p.dirname(p.abspath(p.join(__file__, '..')))
     return pprint.pformat(pkg_info(path))
 
+def _compress_user(path):
+    """Reverse of :func:`os.path.expanduser`
+    """
+    home = os.path.expanduser('~')
+    if path.startswith(home):
+        path =  "~" + path[len(home):]
+    return path
+
+def brief_sys_info():
+    """Return summary information about IPython and the system, as a string.
+    """
+    p = os.path
+    path = p.dirname(p.abspath(p.join(__file__, '..')))
+    inf = pkg_info(path)
+    out = []
+    def _add(name, value):
+        out.append((name, value))
+
+    _add('IPython version', inf['ipython_version'])
+    _add('IPython commit', "{} ({})".format(inf['commit_hash'], inf['commit_source']))
+    _add('IPython package', _compress_user(inf['ipython_path']))
+    _add('Python version', inf['sys_version'].replace('\n',''))
+    _add('sys.executable', _compress_user(inf['sys_executable']))
+    _add('Platform', inf['platform'])
+
+    width = max(len(n) for (n,v) in out)
+    return '\n'.join("{:<{width}}: {}".format(n, v, width=width) for (n,v) in out)
+
 
 def _num_cpus_unix():
     """Return the number of active CPUs on a Unix system."""

--- a/IPython/utils/sysinfo.py
+++ b/IPython/utils/sysinfo.py
@@ -93,6 +93,11 @@ def pkg_info(pkg_path):
         default_encoding=encoding.DEFAULT_ENCODING,
         )
 
+def get_sys_info():
+    """Return useful information about IPython and the system, as a dict."""
+    p = os.path
+    path = p.dirname(p.abspath(p.join(__file__, '..')))
+    return pkg_info(path)
 
 @py3compat.doctest_refactor_print
 def sys_info():
@@ -112,39 +117,8 @@ def sys_info():
          'sys_executable': '/usr/bin/python',
          'sys_platform': 'linux2',
          'sys_version': '2.6.6 (r266:84292, Sep 15 2010, 15:52:39) \\n[GCC 4.4.5]'}
-   """
-    p = os.path
-    path = p.dirname(p.abspath(p.join(__file__, '..')))
-    return pprint.pformat(pkg_info(path))
-
-def _compress_user(path):
-    """Reverse of :func:`os.path.expanduser`
     """
-    home = os.path.expanduser('~')
-    if path.startswith(home):
-        path =  "~" + path[len(home):]
-    return path
-
-def brief_sys_info():
-    """Return summary information about IPython and the system, as a string.
-    """
-    p = os.path
-    path = p.dirname(p.abspath(p.join(__file__, '..')))
-    inf = pkg_info(path)
-    out = []
-    def _add(name, value):
-        out.append((name, value))
-
-    _add('IPython version', inf['ipython_version'])
-    _add('IPython commit', "{} ({})".format(inf['commit_hash'], inf['commit_source']))
-    _add('IPython package', _compress_user(inf['ipython_path']))
-    _add('Python version', inf['sys_version'].replace('\n',''))
-    _add('sys.executable', _compress_user(inf['sys_executable']))
-    _add('Platform', inf['platform'])
-
-    width = max(len(n) for (n,v) in out)
-    return '\n'.join("{:<{width}}: {}".format(n, v, width=width) for (n,v) in out)
-
+    return pprint.pformat(get_sys_info())
 
 def _num_cpus_unix():
     """Return the number of active CPUs on a Unix system."""


### PR DESCRIPTION
The summary info printed after a test run has got quite long, which means more scrolling back to see actual test failure details. This pares it down a bit.

Before:

```
Test suite completed for system with the following information:
{'codename': 'Work in Progress',
 'commit_hash': '2cdbe39',
 'commit_source': 'installation',
 'default_encoding': 'UTF-8',
 'ipython_path': '/home/takluyver/.virtualenvs/ipy-3/lib/python3.3/site-packages/ipython-2.0.0_dev-py3.3.egg/IPython',
 'ipython_version': '2.0.0-dev',
 'os_name': 'posix',
 'platform': 'Linux-3.10-3-amd64-x86_64-with-debian-jessie-sid',
 'sys_executable': '/home/takluyver/.virtualenvs/ipy-3/bin/python',
 'sys_platform': 'linux',
 'sys_version': '3.3.2+ (default, Jun 13 2013, 11:56:31) \n[GCC 4.8.1]'}

Tools and libraries available at test time:
   curses cython jinja2 matplotlib numpy pexpect pygments pymongo qt rpy2 sphinx sqlite3 tornado zmq

Tools and libraries NOT available at test time:
   azure oct2py wx wx.aui

Ran 1 test groups in 3.569s

Status: OK
```

After:

```
Test suite completed for system with the following information:
IPython version: 2.0.0-dev
IPython commit : 97d2b83 (installation)
IPython package: ~/.virtualenvs/ipy-3/lib/python3.3/site-packages/ipython-2.0.0_dev-py3.3.egg/IPython
Python version : 3.3.2+ (default, Jun 13 2013, 11:56:31) [GCC 4.8.1]
sys.executable : ~/.virtualenvs/ipy-3/bin/python
Platform       : Linux-3.10-3-amd64-x86_64-with-debian-jessie-sid

Tools and libraries available at test time:
   curses cython jinja2 matplotlib numpy pexpect pygments pymongo qt rpy2 sphinx sqlite3 tornado zmq

Tools and libraries NOT available at test time:
   azure oct2py wx wx.aui

Status: OK (1 test groups). Took 3.476s.
```
