### PR TITLE
[Notebook] Deactivate tooltip on tab by default.

### DIFF
--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -209,12 +209,6 @@ var IPython = (function (IPython) {
                 // Don't autocomplete if the part of the line before the cursor
                 // is empty.  In this case, let CodeMirror handle indentation.
                 return false;
-            } else if ((pre_cursor.substr(-1) === "("|| pre_cursor.substr(-1) === " ") && IPython.config.tooltip_on_tab ) {
-                IPython.tooltip.request(that);
-                // Prevent the event from bubbling up.
-                event.stop();
-                // Prevent CodeMirror from handling the tab.
-                return true;
             } else {
                 event.stop();
                 this.completer.startCompletion();

--- a/IPython/html/static/notebook/js/config.js
+++ b/IPython/html/static/notebook/js/config.js
@@ -67,7 +67,6 @@ var IPython = (function (IPython) {
              'diff'         :{'reg':[/^diff/]}
             },
 
-        tooltip_on_tab : true,
         };
 
     // use the same method to merge user configuration

--- a/docs/source/whatsnew/pr/tooltip-on-tab.rst
+++ b/docs/source/whatsnew/pr/tooltip-on-tab.rst
@@ -1,4 +1,3 @@
- * In notebook, Showing tooltip on tab has been deactivated by default to avoid
-   conflict with completion, and will be completly removed in future version.
-   Shift-Tab could still be used to invoke tooltip when inside function
-   signature and/or on selection.
+ * In notebook, Showing tooltip on tab has been disables to avoid conflict with
+   completion, Shift-Tab could still be used to invoke tooltip when inside
+   function signature and/or on selection.

--- a/docs/source/whatsnew/pr/tooltip-on-tab.rst
+++ b/docs/source/whatsnew/pr/tooltip-on-tab.rst
@@ -1,0 +1,4 @@
+ * In notebook, Showing tooltip on tab has been deactivated by default to avoid
+   conflict with completion, and will be completly removed in future version.
+   Shift-Tab could still be used to invoke tooltip when inside function
+   signature and/or on selection.

--- a/examples/notebooks/Part 1 - Running Code.ipynb
+++ b/examples/notebooks/Part 1 - Running Code.ipynb
@@ -234,7 +234,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Tab completion after `(` brings up a tooltip with the docstring:"
+      "Shift-Tab on selection, or after `(` brings up a tooltip with the docstring:"
      ]
     },
     {


### PR DESCRIPTION
Codepath is **not** removed by this.

Should I cleanup the codepath also ?

Still need to search in documentation if/where we say that tooltip is triggered by tab.

(also people will hate us for some time)
