### PR TITLE
Remove 5s wait on inactivity on GUI inputhook loops

### DIFF
--- a/IPython/lib/inputhookglut.py
+++ b/IPython/lib/inputhookglut.py
@@ -157,10 +157,7 @@ def inputhook_glut():
             # 0.01    1.5%
             # 0.05    0.5%
             used_time = clock() - t
-            if used_time > 5*60.0:
-                # print 'Sleep for 5 s'  # dbg
-                time.sleep(5.0)
-            elif used_time > 10.0:
+            if used_time > 10.0:
                 # print 'Sleep for 1 s'  # dbg
                 time.sleep(1.0)
             elif used_time > 0.1:

--- a/IPython/lib/inputhookpyglet.py
+++ b/IPython/lib/inputhookpyglet.py
@@ -96,10 +96,7 @@ def inputhook_pyglet():
             # 0.01    1.5%
             # 0.05    0.5%
             used_time = clock() - t
-            if used_time > 5*60.0:
-                # print 'Sleep for 5 s'  # dbg
-                time.sleep(5.0)
-            elif used_time > 10.0:
+            if used_time > 10.0:
                 # print 'Sleep for 1 s'  # dbg
                 time.sleep(1.0)
             elif used_time > 0.1:

--- a/IPython/lib/inputhookwx.py
+++ b/IPython/lib/inputhookwx.py
@@ -142,10 +142,7 @@ def inputhook_wx3():
                 # 0.01    1.5%
                 # 0.05    0.5%
                 used_time = clock() - t
-                if used_time > 5*60.0:
-                    # print 'Sleep for 5 s'  # dbg
-                    time.sleep(5.0)
-                elif used_time > 10.0:
+                if used_time > 10.0:
                     # print 'Sleep for 1 s'  # dbg
                     time.sleep(1.0)
                 elif used_time > 0.1:


### PR DESCRIPTION
The 5s (and 1s) waits were originally added in commit 5074878, but the 5 second wait meant if you left the console for 5+ minutes idle, it would
take up to 5 seconds for a response to a keypress. This tradeoff of CPU
cycles for battery life seems too far.

Note that commit 5074878 was originally for wx, glut and pyglet are based
on the wx version and came into existence after commit 5074878.
