### PR TITLE
Provide a name of the HistorySavingThread

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -713,7 +713,7 @@ class HistorySavingThread(threading.Thread):
     stop_now = False
     enabled = True
     def __init__(self, history_manager):
-        super(HistorySavingThread, self).__init__()
+        super(HistorySavingThread, self).__init__(name="IPythonHistorySavingThread")
         self.history_manager = history_manager
         self.enabled = history_manager.enabled
         atexit.register(self.stop)


### PR DESCRIPTION
This name appears when using PyDev to debug and is more informative
than the default "Thread-N"
