### PR TITLE
make close-and-halt work on new tabs in Chrome

### DIFF
--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -131,7 +131,11 @@ var IPython = (function (IPython) {
         });
         this.element.find('#kill_and_exit').click(function () {
             IPython.notebook.session.delete();
-            setTimeout(function(){window.close();}, 500);
+            setTimeout(function(){
+                // allow closing of new tabs in Chromium, impossible in FF
+                window.open('', '_self', '');
+                window.close();
+            }, 500);
         });
         // Edit
         this.element.find('#cut_cell').click(function () {


### PR DESCRIPTION
If you open a notebook via right-click open-in-new-tab, the close-and-halt menu
item will not work. This commit fixes the issue for Chromium and IE. It is not
possible in Firefox, as new tabs/windows which were _not_ opened via a script (
window.open call ) are not allowed to be closed via window.close and will yield
a message like:

```
[11:50:59.691] Scripts may not close windows that were not opened by script. @
http://localhost:8888/static/notebook/js/menubar.js:105
```
