### PR TITLE
Fix traitlet _notify_trait by-ref issue

### DIFF
--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -363,6 +363,44 @@ class TestHasTraitsNotify(TestCase):
 
         self.assertEqual(len(a._trait_notifiers['a']),0)
 
+    def test_notify_only_once(self):
+
+        class A(HasTraits):
+            listen_to = ['a']
+            
+            a = Int(0)
+            b = 0
+            
+            def __init__(self, **kwargs):
+                super(A, self).__init__(**kwargs)
+                self.on_trait_change(self.listener1, ['a'])
+            
+            def listener1(self, name, old, new):
+                self.b += 1
+
+        class B(A):
+                    
+            c = 0
+            d = 0
+            
+            def __init__(self, **kwargs):
+                super(B, self).__init__(**kwargs)
+                self.on_trait_change(self.listener2)
+            
+            def listener2(self, name, old, new):
+                self.c += 1
+            
+            def _a_changed(self, name, old, new):
+                self.d += 1
+
+        b = B()
+        b.a += 1
+        self.assertEqual(b.b, b.c)
+        self.assertEqual(b.b, b.d)
+        b.a += 1
+        self.assertEqual(b.b, b.c)
+        self.assertEqual(b.b, b.d)
+
 
 class TestHasTraits(TestCase):
 

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -435,9 +435,9 @@ class HasTraits(object):
     def _notify_trait(self, name, old_value, new_value):
 
         # First dynamic ones
-        callables = self._trait_notifiers.get(name,[])
-        more_callables = self._trait_notifiers.get('anytrait',[])
-        callables.extend(more_callables)
+        callables = []
+        callables.extend(self._trait_notifiers.get(name,[]))
+        callables.extend(self._trait_notifiers.get('anytrait',[]))
 
         # Now static ones
         try:


### PR DESCRIPTION
This fixes a problem with the existing traitlet machinery, where `anytrait` values get added to the notifiers list every time the `_notify_trait` function is called.

The bug is that each time the traitlet changes, the `anytrait` callbacks will each be called N times, where N is the number of times the traitlet has been changed (in the current application instance).
