### PR TITLE
Specify unicode type properly in rmagic

### DIFF
--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -72,7 +72,8 @@ from IPython.core.magic_arguments import (
     argument, magic_arguments, parse_argstring
 )
 from IPython.external.simplegeneric import generic
-from IPython.utils.py3compat import str_to_unicode, unicode_to_str, PY3
+from IPython.utils.py3compat import (str_to_unicode, unicode_to_str, PY3,
+                                     unicode_type)
 
 class RInterpreterError(ri.RRuntimeError):
     """An error when running R code in a %%R magic cell."""
@@ -390,7 +391,7 @@ class RMagics(Magics):
         help='Convert these objects to data.frames and return as structured arrays.'
         )
     @argument(
-        '-u', '--units', type=unicode, choices=["px", "in", "cm", "mm"],
+        '-u', '--units', type=unicode_type, choices=["px", "in", "cm", "mm"],
         help='Units of png plotting device sent as an argument to *png* in R. One of ["px", "in", "cm", "mm"].'
         )
     @argument(

--- a/IPython/utils/py3compat.py
+++ b/IPython/utils/py3compat.py
@@ -84,6 +84,7 @@ if sys.version_info[0] >= 3:
     cast_bytes_py2 = no_code
     
     string_types = (str,)
+    unicode_type = str
     
     def isidentifier(s, dotted=False):
         if dotted:
@@ -134,6 +135,7 @@ else:
     cast_bytes_py2 = cast_bytes
     
     string_types = (str, unicode)
+    unicode_type = unicode
     
     import re
     _name_re = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*$")


### PR DESCRIPTION
2to3 wasn't converting this instance of `unicode`, so it failed under Python 3.

I'll soon be making a similar change on a larger scale as we abandon 2to3.
