### PR TITLE
define InlineBackend configurable in its own file

### DIFF
--- a/IPython/kernel/zmq/pylab/backend_inline.py
+++ b/IPython/kernel/zmq/pylab/backend_inline.py
@@ -13,7 +13,7 @@ from __future__ import print_function
 
 # Third-party imports
 import matplotlib
-from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.backends.backend_agg import new_figure_manager, FigureCanvasAgg # analysis: ignore
 from matplotlib._pylab_helpers import Gcf
 
 # Local imports


### PR DESCRIPTION
avoids unnecessary matplotlib imports in places such as the notebook server process
