### PR TITLE
Always use XDG config directory on Linux

### DIFF
--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -277,15 +277,20 @@ def get_ipython_dir():
         # not set explicitly, use XDG_CONFIG_HOME or HOME
         home_ipdir = pjoin(home_dir, ipdir_def)
         if xdg_dir:
-            # use XDG, as long as the user isn't already
-            # using $HOME/.ipython and *not* XDG/ipython
+            # On Linux & similar systems, use the XDG dir
+            # (~/.config/ipython by default)
+            ipdir = pjoin(xdg_dir, xdg_def)
 
-            xdg_ipdir = pjoin(xdg_dir, xdg_def)
+            # Warn if we detect the old .ipython directory
+            if _writable_dir(home_ipdir):
+                if os.path.exists(ipdir):
+                    warnings.warn(('Ignoring ~/.ipython in favour of %s. '
+                    'Remove ~/.ipython to get rid of this message.') % ipdir)
+                else:
+                    warnings.warn('Moving ~/.ipython to %s.' % ipdir)
+                    os.rename(home_ipdir, ipdir)
 
-            if _writable_dir(xdg_ipdir) or not _writable_dir(home_ipdir):
-                ipdir = xdg_ipdir
-
-        if ipdir is None:
+        else:
             # not using XDG
             ipdir = home_ipdir
 


### PR DESCRIPTION
We've put config files in `.config/ipython` on Linux by default for a few releases, and I think it's time to force the change. This simplifies what we have to tell people about where their config files are.

Before:
- On Windows or Mac, it's in `.ipython`
- On Linux, it's in:
  - `.config/ipython` if `.ipython` doesn't exist
  - `.ipython` if that exists and `.config/ipython` doesn't
  - `.config/ipython` if that and `.ipython` both exist

After:
- On Windows or Mac, it's in `.ipython`
- On Linux, it's in `.config/ipython`
