### PR TITLE
Fix progress bar and scrolling bug.

### DIFF
--- a/IPython/nbconvert/templates/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/slides_reveal.tpl
@@ -63,7 +63,7 @@ html {
   opacity: 1;
 }
 .reveal .progress {
-  top: 0;
+  position: static;
 }
 div.input_area {
   padding: 0.06em;

--- a/IPython/nbconvert/templates/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/slides_reveal.tpl
@@ -62,6 +62,9 @@ html {
 .reveal.fade {
   opacity: 1;
 }
+.reveal .progress {
+  top: 0;
+}
 div.input_area {
   padding: 0.06em;
 }


### PR DESCRIPTION
Scrolling on the html tag raised a new bug involving the progress bar.
You can see an example image below:

![prog_bar_bug](https://f.cloud.github.com/assets/1640669/1385367/805ba81c-3b5d-11e3-8c62-6532b3f2e4de.png)

The more robust solution I found was (it was no so simple because reveal is not prepared for scrolling slides, so I tried several things) change the `position` property to `static`. 

Now, the progress bar is on the top of the slide (which is nice, I think) and supports better the scrolling of the slides.

![prog_bar_fixed](https://f.cloud.github.com/assets/1640669/1385513/f9bc9048-3b5f-11e3-9bca-37a29954a430.png)

Damian
