### PR TITLE
notebooks should always have one checkpoint

### DIFF
--- a/IPython/html/services/notebooks/filenbmanager.py
+++ b/IPython/html/services/notebooks/filenbmanager.py
@@ -222,6 +222,10 @@ class FileNotebookManager(NotebookManager):
 
         if 'content' not in model:
             raise web.HTTPError(400, u'No notebook JSON data provided')
+        
+        # One checkpoint should always exist
+        if self.notebook_exists(name, path) and not self.list_checkpoints(name, path):
+            self.create_checkpoint(name, path)
 
         new_path = model.get('path', path).strip('/')
         new_name = model.get('name', name)

--- a/IPython/html/services/notebooks/filenbmanager.py
+++ b/IPython/html/services/notebooks/filenbmanager.py
@@ -326,8 +326,9 @@ class FileNotebookManager(NotebookManager):
     def get_checkpoint_path(self, checkpoint_id, name, path=''):
         """find the path to a checkpoint"""
         path = path.strip('/')
+        basename, _ = os.path.splitext(name)
         filename = u"{name}-{checkpoint_id}{ext}".format(
-            name=name,
+            name=basename,
             checkpoint_id=checkpoint_id,
             ext=self.filename_ext,
         )

--- a/IPython/html/services/notebooks/nbmanager.py
+++ b/IPython/html/services/notebooks/nbmanager.py
@@ -117,7 +117,7 @@ class NotebookManager(LoggingConfigurable):
         raise NotImplementedError('must be implemented in a subclass')
 
     def create_notebook_model(self, model=None, path=''):
-        """Create a new untitled notebook and return its model with no content."""
+        """Create a new notebook and return its model with no content."""
         path = path.strip('/')
         if model is None:
             model = {}


### PR DESCRIPTION
closes #4396

also fix checkpoint filename, which had double '.ipynb'
