### PR TITLE
raise 404 on not found static file

### DIFF
--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -321,8 +321,8 @@ class FileFindHandler(web.StaticFileHandler):
             try:
                 abspath = os.path.abspath(filefind(path, roots))
             except IOError:
-                # empty string should always give exists=False
-                return ''
+                # IOError means not found
+                raise web.HTTPError(404)
             
             cls._static_paths[path] = abspath
             return abspath


### PR DESCRIPTION
master gives 403 due to empty string being outside of root
