### PR TITLE
add `setup.py jsversion`

### DIFF
--- a/IPython/html/static/base/js/namespace.js
+++ b/IPython/html/static/base/js/namespace.js
@@ -1,11 +1,13 @@
 //----------------------------------------------------------------------------
-//  Copyright (C) 2008-2011  The IPython Development Team
+//  Copyright (C) 2011  The IPython Development Team
 //
 //  Distributed under the terms of the BSD License.  The full license is in
 //  the file COPYING, distributed as part of this software.
 //----------------------------------------------------------------------------
 
 var IPython = IPython || {};
+
+IPython.version = "2.0.0-dev";
 
 IPython.namespace = function (ns_string) {
     "use strict";

--- a/IPython/html/tests/casperjs/test_cases/misc_tests.js
+++ b/IPython/html/tests/casperjs/test_cases/misc_tests.js
@@ -1,0 +1,21 @@
+
+//
+// Miscellaneous javascript tests
+//
+casper.notebook_test(function () {
+    var jsver = this.evaluate(function () {
+        var cell = IPython.notebook.get_cell(0);
+        cell.set_text('import IPython; print IPython.__version__');
+        cell.execute();
+        return IPython.version
+    });
+
+    this.wait_for_output(0);
+
+    // refactor this into  just a get_output(0)
+    this.then(function () {
+        var result = this.get_output_cell(0);
+        this.test.assertEquals(result.text.trim(), jsver, 'IPython.version in JS matches IPython.');
+    });
+
+});

--- a/IPython/html/tests/casperjs/test_cases/misc_tests.js
+++ b/IPython/html/tests/casperjs/test_cases/misc_tests.js
@@ -5,9 +5,9 @@
 casper.notebook_test(function () {
     var jsver = this.evaluate(function () {
         var cell = IPython.notebook.get_cell(0);
-        cell.set_text('import IPython; print IPython.__version__');
+        cell.set_text('import IPython; print(IPython.__version__)');
         cell.execute();
-        return IPython.version
+        return IPython.version;
     });
 
     this.wait_for_output(0);

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ from setupbase import (
     require_submodules,
     UpdateSubmodules,
     CompileCSS,
+    JavascriptVersion,
     install_symlinked,
     install_lib_symlink,
     install_scripts_for_symlink,
@@ -236,6 +237,7 @@ setup_args['cmdclass'] = {
     'symlink': install_symlinked,
     'install_lib_symlink': install_lib_symlink,
     'install_scripts_sym': install_scripts_for_symlink,
+    'jsversion' : JavascriptVersion,
 }
 
 #---------------------------------------------------------------------------

--- a/setupbase.py
+++ b/setupbase.py
@@ -564,3 +564,25 @@ class CompileCSS(Command):
     
     def run(self):
         call("fab css", shell=True, cwd=pjoin(repo_root, "IPython", "html"))
+
+class JavascriptVersion(Command):
+    """write the javascript version to notebook javascript"""
+    description = "Write IPython version to javascript"
+    user_options = []
+    
+    def initialize_options(self):
+        pass
+    
+    def finalize_options(self):
+        pass
+    
+    def run(self):
+        nsfile = pjoin(repo_root, "IPython", "html", "static", "base", "js", "namespace.js")
+        with open(nsfile) as f:
+            lines = f.readlines()
+        with open(nsfile, 'w') as f:
+            for line in lines:
+                if line.startswith("IPython.version"):
+                    line = 'IPython.version = "{0}";\n'.format(version)
+                f.write(line)
+            


### PR DESCRIPTION
for writing the IPython version to `IPython.version` in javascript.

supersedes #4357
