### PR TITLE
Use SVG plots in OctaveMagic by default due to lack of Ghostscript on Windows Octave

### DIFF
--- a/IPython/extensions/octavemagic.py
+++ b/IPython/extensions/octavemagic.py
@@ -38,6 +38,7 @@ Usage
 import tempfile
 from glob import glob
 from shutil import rmtree
+import sys
 
 import numpy as np
 import oct2py
@@ -73,7 +74,11 @@ class OctaveMagics(Magics):
         """
         super(OctaveMagics, self).__init__(shell)
         self._oct = oct2py.Oct2Py()
-        self._plot_format = 'svg'
+        if sys.platform == 'win32':
+            # Use svg by default due to lack of Ghostscript on Windows Octave
+            self._plot_format = 'svg'
+        else:
+            self._plot_format = 'png'
 
         # Allow publish_display_data to be overridden for
         # testing purposes.
@@ -266,6 +271,9 @@ class OctaveMagics(Magics):
 
         if args.format is not None:
             plot_format = args.format
+        elif sys.platform == 'win32':
+            # Use svg by default due to lack of Ghostscript on Windows Octave
+            plot_format = 'svg'
         else:
             plot_format = 'png'
 

--- a/IPython/extensions/octavemagic.py
+++ b/IPython/extensions/octavemagic.py
@@ -73,7 +73,7 @@ class OctaveMagics(Magics):
         """
         super(OctaveMagics, self).__init__(shell)
         self._oct = oct2py.Oct2Py()
-        self._plot_format = 'png'
+        self._plot_format = 'svg'
 
         # Allow publish_display_data to be overridden for
         # testing purposes.


### PR DESCRIPTION
Newer builds of Octave on Windows do not include Ghostscript, and do not support printing PNG files out of the box.  I suggest making the default SVG files, which is supported.

As of now, a user would have to follow the instructions here to enable support for PNGs:

http://wiki.octave.org/Octave_for_Windows#Printing_.28installing_Ghostscript.29.
