### PR TITLE
fix: allow JS test to run after shutdown test

### DIFF
--- a/IPython/html/tests/casperjs/test_cases/shutdown_notebook.js
+++ b/IPython/html/tests/casperjs/test_cases/shutdown_notebook.js
@@ -26,6 +26,8 @@ casper.notebook_test(function () {
             'after shutdown: IPython.notebook.kernel.running is false ');
     });
 
+    this.thenOpen(this.get_notebook_server());
+
 //}); // end of test.begin
 });
 


### PR DESCRIPTION
shutdown notebook test closes casper browser, here we re-instatiate it after
the test

@jdfreder will need this
