### PR TITLE
support notebooks in %run

### DIFF
--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -54,7 +54,7 @@ import_re = re.compile(r'(?P<name>[a-zA-Z_][a-zA-Z0-9_]*?)'
                        r'|'.join(re.escape(s[0]) for s in imp.get_suffixes()))
 
 # RE for the ipython %run command (python + ipython scripts)
-magic_run_re = re.compile(r'.*(\.ipy|\.py[w]?)$')
+magic_run_re = re.compile(r'.*(\.ipy|\.ipynb|\.py[w]?)$')
 
 #-----------------------------------------------------------------------------
 # Local utilities
@@ -250,7 +250,7 @@ def module_completer(self,event):
 # completers, that is currently reimplemented in each.
 
 def magic_run_completer(self, event):
-    """Complete files that end in .py or .ipy for the %run command.
+    """Complete files that end in .py or .ipy or .ipynb for the %run command.
     """
     comps = arg_split(event.line, strict=False)
     relpath = (len(comps) > 1 and comps[-1] or '').strip("'\"")
@@ -274,7 +274,7 @@ def magic_run_completer(self, event):
     else:
         pys =  [f.replace('\\','/')
                 for f in lglob(relpath+'*.py') + lglob(relpath+'*.ipy') +
-                lglob(relpath + '*.pyw')]
+                lglob(relpath+'*.ipynb') + lglob(relpath + '*.pyw')]
     #print('run comp:', dirs+pys) # dbg
     return [compress_user(p, tilde_expand, tilde_val) for p in dirs+pys]
 

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -552,7 +552,7 @@ python-profiler package from non-free.""")
           details on the options available specifically for profiling.
 
         There is one special usage for which the text above doesn't apply:
-        if the filename ends with .ipy, the file is run as ipython script,
+        if the filename ends with .ipy[nb], the file is run as ipython script,
         just as if the commands were written on IPython prompt.
 
         -m
@@ -596,7 +596,7 @@ python-profiler package from non-free.""")
             error(msg)
             return
 
-        if filename.lower().endswith('.ipy'):
+        if filename.lower().endswith(('.ipy', '.ipynb')):
             with preserve_keys(self.shell.user_ns, '__file__'):
                 self.shell.user_ns['__file__'] = filename
                 self.shell.safe_execfile_ipy(filename)

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -370,6 +370,23 @@ tclass.py: deleting object: C-third
         
         with tt.AssertNotPrints('SystemExit'):
             _ip.magic('run -e %s' % self.fname)
+    
+    def test_run_nb(self):
+        """Test %run notebook.ipynb"""
+        from IPython.nbformat import current
+        nb = current.new_notebook(
+            worksheets=[
+                current.new_worksheet(cells=[
+                    current.new_code_cell("answer=42")
+                ])
+            ]
+        )
+        src = current.writes(nb, 'json')
+        self.mktmp(src, ext='.ipynb')
+        
+        _ip.magic("run %s" % self.fname)
+        
+        nt.assert_equal(_ip.user_ns['answer'], 42)
         
 
 

--- a/docs/source/whatsnew/pr/nbrun.rst
+++ b/docs/source/whatsnew/pr/nbrun.rst
@@ -1,0 +1,1 @@
+* You can now run notebooks in an interactive session via ``%run notebook.ipynb``.


### PR DESCRIPTION
Simple enough - just generalized safe_exec_ipy a bit to support a sequence of cells rather than just one cell (the .ipy behavior).

I think we have an issue open for this, but I can't seem to find it. (closes #1675 -pi)
