### PR TITLE
use signalstatus if exit status is undefined

### DIFF
--- a/IPython/utils/_process_posix.py
+++ b/IPython/utils/_process_posix.py
@@ -188,6 +188,13 @@ class ProcessHandler(object):
         # We follow the subprocess pattern, returning either the exit status
         # as a positive number, or the terminating signal as a negative
         # number. sh returns 128+n for signals
+        if child.exitstatus is None:
+            # on WIFSIGNALED, pexpect sets signalstatus, leaving exitstatus=None
+            if child.signalstatus is None:
+                # this condition may never occur,
+                # but let's be certain we always return an integer.
+                return 0
+            return -child.signalstatus
         if child.exitstatus > 128:
             return -(child.exitstatus - 128)
         return child.exitstatus

--- a/IPython/utils/_process_posix.py
+++ b/IPython/utils/_process_posix.py
@@ -187,7 +187,9 @@ class ProcessHandler(object):
 
         # We follow the subprocess pattern, returning either the exit status
         # as a positive number, or the terminating signal as a negative
-        # number. sh returns 128+n for signals
+        # number.
+        # on Linux, sh returns 128+n for signals terminating child processes on Linux
+        # on BSD (OS X), the signal code is set instead
         if child.exitstatus is None:
             # on WIFSIGNALED, pexpect sets signalstatus, leaving exitstatus=None
             if child.signalstatus is None:


### PR DESCRIPTION
fixes failing test_exit_code_signal on OS X
