### PR TITLE
protect against broken repr in lib.pretty

### DIFF
--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -202,7 +202,7 @@ class FormatterABC(with_metaclass(abc.ABCMeta, object)):
         """
         try:
             return repr(obj)
-        except TypeError:
+        except Exception:
             return None
 
 
@@ -465,10 +465,7 @@ class PlainTextFormatter(BaseFormatter):
     def __call__(self, obj):
         """Compute the pretty representation of the object."""
         if not self.pprint:
-            try:
-                return repr(obj)
-            except TypeError:
-                return ''
+            return pretty._safe_repr(obj)
         else:
             # This uses use StringIO, as cStringIO doesn't handle unicode.
             stream = StringIO()

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -170,13 +170,13 @@ def _safe_repr(obj):
         return _failed_repr(obj, e)
 
 def _safe_getattr(obj, attr, default=None):
-    """never-raise version of getattr
+    """Safe version of getattr.
     
-    catches errors other than AttributeError,
-    unlike vanilla getattr
+    Same as getattr, but will return ``default`` on any Exception,
+    rather than raising.
     """
     try:
-        return getattr(obj, attr)
+        return getattr(obj, attr, default)
     except Exception:
         return default
 

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -125,6 +125,13 @@ __all__ = ['pretty', 'pprint', 'PrettyPrinter', 'RepresentationPrinter',
 
 _re_pattern_type = type(re.compile(''))
 
+def _safe_repr(obj):
+    """Don't trust repr to not be broken."""
+    try:
+        return repr(obj)
+    except Exception as e:
+        return "<repr(obj) failed: %s>" % e
+
 
 def pretty(obj, verbose=False, max_width=79, newline='\n'):
     """
@@ -495,7 +502,7 @@ def _default_pprint(obj, p, cycle):
     klass = getattr(obj, '__class__', None) or type(obj)
     if getattr(klass, '__repr__', None) not in _baseclass_reprs:
         # A user-provided repr. Find newlines and replace them with p.break_()
-        output = repr(obj)
+        output = _safe_repr(obj)
         for idx,output_line in enumerate(output.splitlines()):
             if idx:
                 p.break_()
@@ -673,7 +680,7 @@ def _type_pprint(obj, p, cycle):
 
 def _repr_pprint(obj, p, cycle):
     """A pprint that just redirects to the normal repr function."""
-    p.text(repr(obj))
+    p.text(_safe_repr(obj))
 
 
 def _function_pprint(obj, p, cycle):

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -160,3 +160,25 @@ def test_bad_repr():
     """Don't raise, even when repr fails"""
     output = pretty.pretty(BadRepr())
     nt.assert_in("failed", output)
+    nt.assert_in("at 0x", output)
+    nt.assert_in("test_pretty", output)
+
+class BadException(Exception):
+    def __str__(self):
+        return -1
+
+class ReallyBadRepr(object):
+    __module__ = 1
+    @property
+    def __class__(self):
+        raise ValueError("I am horrible")
+    
+    def __repr__(self):
+        raise BadException()
+
+def test_really_bad_repr():
+    output = pretty.pretty(ReallyBadRepr())
+    nt.assert_in("failed", output)
+    nt.assert_in("BadException: unknown", output)
+    nt.assert_in("unknown type", output)
+    

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -74,6 +74,10 @@ class BreakingReprParent(object):
         with p.group(4,"TG: ",":"):
             p.pretty(BreakingRepr())
 
+class BadRepr(object):
+    
+    def __repr__(self):
+        return 1/0
 
 
 def test_indentation():
@@ -151,3 +155,8 @@ def test_pprint_break_repr():
     output = pretty.pretty(BreakingReprParent())
     expected = "TG: Breaking(\n    ):"
     nt.assert_equal(output, expected)
+
+def test_bad_repr():
+    """Don't raise, even when repr fails"""
+    output = pretty.pretty(BadRepr())
+    nt.assert_in("failed", output)


### PR DESCRIPTION
for example:

``` python
from lxml import html
import urllib2
from IPython.display import display

term = 'cat'
data = html.parse("""http://en.wiktionary.org/w/index.php?title=%s&printable=yes""" % urllib2.quote(term.encode('utf-8')), parser=html.HTMLParser(encoding="utf-8"))
d = data.xpath(".//div[@id='mw-content-text']")[0]
display(d.getchildren())
```
