### PR TITLE
Correct TypeError message in svg2pdf

### DIFF
--- a/IPython/nbconvert/preprocessors/svg2pdf.py
+++ b/IPython/nbconvert/preprocessors/svg2pdf.py
@@ -92,4 +92,4 @@ class SVG2PDFPreprocessor(ConvertFiguresPreprocessor):
                     # PDF is a nb supported binary, data type, so base64 encode.
                     return base64.encodestring(f.read())
             else:
-                raise TypeError("Inkscape svg to png conversion failed")
+                raise TypeError("Inkscape svg to pdf conversion failed")


### PR DESCRIPTION
Trivial change of error message.

Found during discussion in http://stackoverflow.com/q/19659864/2870069 
