### PR TITLE
Correct description for Bytes traitlet type

### DIFF
--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -996,7 +996,7 @@ class Bytes(TraitType):
     """A trait for byte strings."""
 
     default_value = b''
-    info_text = 'a string'
+    info_text = 'a bytes object'
 
     def validate(self, obj, value):
         if isinstance(value, bytes):


### PR DESCRIPTION
Closes #4463

Alternatives: 'a bytes object', 'a byte string', 'bytes'. The last reads most naturally to me, but all the others I can see are described as 'a/an thing'.
