### PR TITLE
Python 3 & getcwdu

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -40,6 +40,7 @@ from IPython.config.loader import ConfigFileNotFound
 from IPython.core import release, crashhandler
 from IPython.core.profiledir import ProfileDir, ProfileDirError
 from IPython.utils.path import get_ipython_dir, get_ipython_package_dir
+from IPython.utils import py3compat
 from IPython.utils.traitlets import List, Unicode, Type, Bool, Dict, Set, Instance
 
 #-----------------------------------------------------------------------------
@@ -103,7 +104,7 @@ class BaseIPythonApplication(Application):
 
     config_file_paths = List(Unicode)
     def _config_file_paths_default(self):
-        return [os.getcwdu()]
+        return [py3compat.getcwd()]
 
     extra_config_file = Unicode(config=True,
     help="""Path to an extra config file to load.
@@ -179,7 +180,7 @@ class BaseIPythonApplication(Application):
         super(BaseIPythonApplication, self).__init__(**kwargs)
         # ensure current working directory exists
         try:
-            directory = os.getcwdu()
+            directory = py3compat.getcwd()
         except:
             # raise exception
             self.log.error("Current working directory doesn't exist.")

--- a/IPython/core/crashhandler.py
+++ b/IPython/core/crashhandler.py
@@ -28,7 +28,7 @@ from pprint import pformat
 from IPython.core import ultratb
 from IPython.core.release import author_email
 from IPython.utils.sysinfo import sys_info
-from IPython.utils.py3compat import input
+from IPython.utils.py3compat import input, getcwd
 
 #-----------------------------------------------------------------------------
 # Code
@@ -140,9 +140,9 @@ class CrashHandler(object):
         try:
             rptdir = self.app.ipython_dir
         except:
-            rptdir = os.getcwdu()
+            rptdir = getcwd()
         if rptdir is None or not os.path.isdir(rptdir):
-            rptdir = os.getcwdu()
+            rptdir = getcwd()
         report_name = os.path.join(rptdir,self.crash_report_fname)
         # write the report filename into the instance dict so it can get
         # properly expanded out in the user message template

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -30,6 +30,7 @@ import threading
 from IPython.config.configurable import Configurable
 from IPython.external.decorator import decorator
 from IPython.utils.path import locate_profile
+from IPython.utils import py3compat
 from IPython.utils.traitlets import (
     Any, Bool, Dict, Instance, Integer, List, Unicode, TraitError,
 )
@@ -423,7 +424,7 @@ class HistoryManager(HistoryAccessor):
     dir_hist = List()
     def _dir_hist_default(self):
         try:
-            return [os.getcwdu()]
+            return [py3compat.getcwd()]
         except OSError:
             return []
 
@@ -519,7 +520,7 @@ class HistoryManager(HistoryAccessor):
         optionally open a new session."""
         self.output_hist.clear()
         # The directory history can't be completely empty
-        self.dir_hist[:] = [os.getcwdu()]
+        self.dir_hist[:] = [py3compat.getcwd()]
         
         if new_session:
             if self.session_number:

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -578,7 +578,7 @@ class InteractiveShell(SingletonConfigurable):
 
         # keep track of where we started running (mainly for crash post-mortem)
         # This is not being used anywhere currently.
-        self.starting_dir = os.getcwdu()
+        self.starting_dir = py3compat.getcwd()
 
         # Indentation management
         self.indent_current_nsp = 0

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -36,6 +36,7 @@ from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.openpy import source_to_unicode
 from IPython.utils.path import unquote_filename
 from IPython.utils.process import abbrev_cwd
+from IPython.utils import py3compat
 from IPython.utils.py3compat import unicode_type
 from IPython.utils.terminal import set_term_title
 
@@ -180,7 +181,7 @@ class OSMagics(Magics):
                 winext += '|py'
             execre = re.compile(r'(.*)\.(%s)$' % winext,re.IGNORECASE)
             isexec = lambda fname:os.path.isfile(fname) and execre.match(fname)
-        savedir = os.getcwdu()
+        savedir = py3compat.getcwd()
 
         # Now walk the paths looking for executables to alias.
         try:
@@ -234,7 +235,7 @@ class OSMagics(Magics):
           In [9]: pwd
           Out[9]: '/home/tsuser/sprint/ipython'
         """
-        return os.getcwdu()
+        return py3compat.getcwd()
 
     @skip_doctest
     @line_magic
@@ -278,7 +279,7 @@ class OSMagics(Magics):
           /home/tsuser/parent/child
         """
 
-        oldcwd = os.getcwdu()
+        oldcwd = py3compat.getcwd()
         numcd = re.match(r'(-)(\d+)$',parameter_s)
         # jump in directory history by number
         if numcd:
@@ -351,7 +352,7 @@ class OSMagics(Magics):
             except OSError:
                 print(sys.exc_info()[1])
             else:
-                cwd = os.getcwdu()
+                cwd = py3compat.getcwd()
                 dhist = self.shell.user_ns['_dh']
                 if oldcwd != cwd:
                     dhist.append(cwd)
@@ -361,7 +362,7 @@ class OSMagics(Magics):
             os.chdir(self.shell.home_dir)
             if hasattr(self.shell, 'term_title') and self.shell.term_title:
                 set_term_title('IPython: ' + '~')
-            cwd = os.getcwdu()
+            cwd = py3compat.getcwd()
             dhist = self.shell.user_ns['_dh']
 
             if oldcwd != cwd:
@@ -387,7 +388,7 @@ class OSMagics(Magics):
 
         dir_s = self.shell.dir_stack
         tgt = os.path.expanduser(unquote_filename(parameter_s))
-        cwd = os.getcwdu().replace(self.shell.home_dir,'~')
+        cwd = py3compat.getcwd().replace(self.shell.home_dir,'~')
         if tgt:
             self.cd(parameter_s)
         dir_s.insert(0,cwd)
@@ -676,7 +677,7 @@ class OSMagics(Magics):
             if not args:
                 raise UsageError("%bookmark: You must specify the bookmark name")
             elif len(args)==1:
-                bkms[args[0]] = os.getcwdu()
+                bkms[args[0]] = py3compat.getcwd()
             elif len(args)==2:
                 bkms[args[0]] = args[1]
         self.shell.db['bookmarks'] = bkms

--- a/IPython/core/profileapp.py
+++ b/IPython/core/profileapp.py
@@ -31,6 +31,7 @@ from IPython.core.application import (
 from IPython.core.profiledir import ProfileDir
 from IPython.utils.importstring import import_item
 from IPython.utils.path import get_ipython_dir, get_ipython_package_dir
+from IPython.utils import py3compat
 from IPython.utils.traitlets import Unicode, Bool, Dict
 
 #-----------------------------------------------------------------------------
@@ -180,10 +181,10 @@ class ProfileList(Application):
             print("Available profiles in %s:" % self.ipython_dir)
             self._print_profiles(profiles)
         
-        profiles = list_profiles_in(os.getcwdu())
+        profiles = list_profiles_in(py3compat.getcwd())
         if profiles:
             print()
-            print("Available profiles in current directory (%s):" % os.getcwdu())
+            print("Available profiles in current directory (%s):" % py3compat.getcwd())
             self._print_profiles(profiles)
         
         print()
@@ -248,7 +249,7 @@ class ProfileCreate(BaseIPythonApplication):
         name = app_path.rsplit('.', 1)[-1]
         try:
             app = import_item(app_path)
-        except ImportError as e:
+        except ImportError:
             self.log.info("Couldn't import %s, config file will be excluded", name)
         except Exception:
             self.log.warn('Unexpected error importing %s', name, exc_info=True)

--- a/IPython/core/profiledir.py
+++ b/IPython/core/profiledir.py
@@ -27,6 +27,7 @@ import errno
 
 from IPython.config.configurable import LoggingConfigurable
 from IPython.utils.path import get_ipython_package_dir, expand_path
+from IPython.utils import py3compat
 from IPython.utils.traitlets import Unicode, Bool
 
 #-----------------------------------------------------------------------------
@@ -233,7 +234,7 @@ class ProfileDir(LoggingConfigurable):
         is not found, a :class:`ProfileDirError` exception will be raised.
 
         The search path algorithm is:
-        1. ``os.getcwdu()``
+        1. ``py3compat.getcwd()``
         2. ``ipython_dir``
 
         Parameters
@@ -245,7 +246,7 @@ class ProfileDir(LoggingConfigurable):
             will be "profile_<profile>".
         """
         dirname = u'profile_' + name
-        paths = [os.getcwdu(), ipython_dir]
+        paths = [py3compat.getcwd(), ipython_dir]
         for p in paths:
             profile_dir = os.path.join(p, dirname)
             if os.path.isdir(profile_dir):

--- a/IPython/core/prompts.py
+++ b/IPython/core/prompts.py
@@ -212,7 +212,7 @@ def cwd_filt(depth):
     $HOME is always replaced with '~'.
     If depth==0, the full path is returned."""
 
-    cwd = os.getcwdu().replace(HOME,"~")
+    cwd = py3compat.getcwd().replace(HOME,"~")
     out = os.sep.join(cwd.split(os.sep)[-depth:])
     return out or os.sep
 
@@ -222,7 +222,7 @@ def cwd_filt2(depth):
     $HOME is always replaced with '~'.
     If depth==0, the full path is returned."""
 
-    full_cwd = os.getcwdu()
+    full_cwd = py3compat.getcwd()
     cwd = full_cwd.replace(HOME,"~").split(os.sep)
     if '~' in cwd and len(cwd) == depth+1:
         depth += 1
@@ -238,9 +238,9 @@ def cwd_filt2(depth):
 #-----------------------------------------------------------------------------
 
 lazily_evaluate = {'time': LazyEvaluate(time.strftime, "%H:%M:%S"),
-                   'cwd': LazyEvaluate(os.getcwdu),
-                   'cwd_last': LazyEvaluate(lambda: os.getcwdu().split(os.sep)[-1]),
-                   'cwd_x': [LazyEvaluate(lambda: os.getcwdu().replace(HOME,"~"))] +\
+                   'cwd': LazyEvaluate(py3compat.getcwd),
+                   'cwd_last': LazyEvaluate(lambda: py3compat.getcwd().split(os.sep)[-1]),
+                   'cwd_x': [LazyEvaluate(lambda: py3compat.getcwd().replace(HOME,"~"))] +\
                             [LazyEvaluate(cwd_filt, x) for x in range(1,6)],
                    'cwd_y': [LazyEvaluate(cwd_filt2, x) for x in range(6)]
                    }

--- a/IPython/core/tests/test_application.py
+++ b/IPython/core/tests/test_application.py
@@ -13,9 +13,9 @@ def test_unicode_cwd():
     """Check that IPython starts with non-ascii characters in the path."""
     wd = tempfile.mkdtemp(suffix=u"€")
     
-    old_wd = os.getcwdu()
+    old_wd = py3compat.getcwd()
     os.chdir(wd)
-    #raise Exception(repr(os.getcwdu()))
+    #raise Exception(repr(py3compat.getcwd()))
     try:
         app = BaseIPythonApplication()
         # The lines below are copied from Application.initialize()

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -18,6 +18,7 @@ from IPython.core import completer
 from IPython.external.decorators import knownfailureif
 from IPython.utils.tempdir import TemporaryDirectory
 from IPython.utils.generics import complete_object
+from IPython.utils import py3compat
 from IPython.utils.py3compat import string_types, unicode_type
 
 #-----------------------------------------------------------------------------
@@ -177,7 +178,7 @@ def test_abspath_file_completions():
 
 def test_local_file_completions():
     ip = get_ipython()
-    cwd = os.getcwdu()
+    cwd = py3compat.getcwd()
     try:
         with TemporaryDirectory() as tmpdir:
             os.chdir(tmpdir)

--- a/IPython/core/tests/test_completerlib.py
+++ b/IPython/core/tests/test_completerlib.py
@@ -16,6 +16,7 @@ import unittest
 from os.path import join
 
 from IPython.core.completerlib import magic_run_completer, module_completion
+from IPython.utils import py3compat
 from IPython.utils.tempdir import TemporaryDirectory
 from IPython.testing.decorators import onlyif_unicode_paths
 
@@ -33,7 +34,7 @@ class Test_magic_run_completer(unittest.TestCase):
         for fil in [u"aao.py", u"a.py", u"b.py"]:
             with open(join(self.BASETESTDIR, fil), "w") as sfile:
                 sfile.write("pass\n")
-        self.oldpath = os.getcwdu()
+        self.oldpath = py3compat.getcwd()
         os.chdir(self.BASETESTDIR)
 
     def tearDown(self):
@@ -86,7 +87,7 @@ class Test_magic_run_completer_nonascii(unittest.TestCase):
         for fil in [u"aaø.py", u"a.py", u"b.py"]:
             with open(join(self.BASETESTDIR, fil), "w") as sfile:
                 sfile.write("pass\n")
-        self.oldpath = os.getcwdu()
+        self.oldpath = py3compat.getcwd()
         os.chdir(self.BASETESTDIR)
 
     def tearDown(self):

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -36,6 +36,7 @@ import nose.tools as nt
 from IPython.testing.decorators import skipif, skip_win32, onlyif_unicode_paths
 from IPython.testing import tools as tt
 from IPython.utils import io
+from IPython.utils import py3compat
 from IPython.utils.py3compat import unicode_type, PY3
 
 if PY3:
@@ -406,7 +407,7 @@ class TestSafeExecfileNonAsciiPath(unittest.TestCase):
         os.mkdir(self.TESTDIR)
         with open(join(self.TESTDIR, u"åäötestscript.py"), "w") as sfile:
             sfile.write("pass\n")
-        self.oldpath = os.getcwdu()
+        self.oldpath = py3compat.getcwd()
         os.chdir(self.TESTDIR)
         self.fname = u"åäötestscript.py"
 

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -390,9 +390,9 @@ def test_parse_options():
     
 def test_dirops():
     """Test various directory handling operations."""
-    # curpath = lambda :os.path.splitdrive(os.getcwdu())[1].replace('\\','/')
-    curpath = os.getcwdu
-    startdir = os.getcwdu()
+    # curpath = lambda :os.path.splitdrive(py3compat.getcwd())[1].replace('\\','/')
+    curpath = py3compat.getcwd
+    startdir = py3compat.getcwd()
     ipdir = os.path.realpath(_ip.ipython_dir)
     try:
         _ip.magic('cd "%s"' % ipdir)

--- a/IPython/core/tests/test_prompts.py
+++ b/IPython/core/tests/test_prompts.py
@@ -9,6 +9,7 @@ from IPython.testing import tools as tt, decorators as dec
 from IPython.core.prompts import PromptManager, LazyEvaluate
 from IPython.testing.globalipapp import get_ipython
 from IPython.utils.tempdir import TemporaryDirectory
+from IPython.utils import py3compat
 from IPython.utils.py3compat import unicode_type
 
 ip = get_ipython()
@@ -66,12 +67,12 @@ class PromptTests(unittest.TestCase):
     
     @dec.onlyif_unicode_paths
     def test_render_unicode_cwd(self):
-        save = os.getcwdu()
+        save = py3compat.getcwd()
         with TemporaryDirectory(u'ünicødé') as td:
             os.chdir(td)
             self.pm.in_template = r'\w [\#]'
             p = self.pm.render('in', color=False)
-            self.assertEqual(p, u"%s [%i]" % (os.getcwdu(), ip.execution_count))
+            self.assertEqual(p, u"%s [%i]" % (py3compat.getcwd(), ip.execution_count))
         os.chdir(save)
     
     def test_lazy_eval_unicode(self):
@@ -101,7 +102,7 @@ class PromptTests(unittest.TestCase):
     @dec.skip_win32
     def test_cwd_x(self):
         self.pm.in_template = r"\X0"
-        save = os.getcwdu()
+        save = py3compat.getcwd()
         os.chdir(os.path.expanduser('~'))
         p = self.pm.render('in', color=False)
         try:

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -390,7 +390,7 @@ class TestMagicRunWithPackage(unittest.TestCase):
         self.value = int(random.random() * 10000)
 
         self.tempdir = TemporaryDirectory()
-        self.__orig_cwd = os.getcwdu()
+        self.__orig_cwd = py3compat.getcwd()
         sys.path.insert(0, self.tempdir.name)
 
         self.writefile(os.path.join(package, '__init__.py'), '')

--- a/IPython/external/path/_path.py
+++ b/IPython/external/path/_path.py
@@ -84,9 +84,9 @@ except NameError:
     unicode = str
 
 try:
-    os.getcwdu
+    getcwdu = os.getcwdu
 except AttributeError:
-    os.getcwdu = os.getcwd
+    getcwdu = os.getcwd
 
 if sys.version < '3':
     def u(x):
@@ -214,7 +214,7 @@ class path(unicode):
     @classmethod
     def getcwd(cls):
         """ Return the current working directory as a path object. """
-        return cls(os.getcwdu())
+        return cls(getcwdu())
 
     #
     # --- Operations on path strings.

--- a/IPython/html/services/clusters/clustermanager.py
+++ b/IPython/html/services/clusters/clustermanager.py
@@ -16,8 +16,6 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
-import os
-
 from tornado import web
 from zmq.eventloop import ioloop
 
@@ -26,6 +24,7 @@ from IPython.utils.traitlets import Dict, Instance, CFloat
 from IPython.parallel.apps.ipclusterapp import IPClusterStart
 from IPython.core.profileapp import list_profiles_in
 from IPython.core.profiledir import ProfileDir
+from IPython.utils import py3compat
 from IPython.utils.path import get_ipython_dir
 
 
@@ -74,7 +73,7 @@ class ClusterManager(LoggingConfigurable):
     def update_profiles(self):
         """List all profiles in the ipython_dir and cwd.
         """
-        for path in [get_ipython_dir(), os.getcwdu()]:
+        for path in [get_ipython_dir(), py3compat.getcwd()]:
             for profile in list_profiles_in(path):
                 pd = self.get_profile_dir(profile, path)
                 if profile not in self.profiles:

--- a/IPython/html/services/notebooks/nbmanager.py
+++ b/IPython/html/services/notebooks/nbmanager.py
@@ -21,7 +21,8 @@ import os
 
 from IPython.config.configurable import LoggingConfigurable
 from IPython.nbformat import current
-from IPython.utils.traitlets import List, Dict, Unicode, TraitError
+from IPython.utils import py3compat
+from IPython.utils.traitlets import Unicode, TraitError
 
 #-----------------------------------------------------------------------------
 # Classes
@@ -35,7 +36,7 @@ class NotebookManager(LoggingConfigurable):
     # 2. The cwd of the kernel for a project.
     # Right now we use this attribute in a number of different places and
     # we are going to have to disentangle all of this.
-    notebook_dir = Unicode(os.getcwdu(), config=True, help="""
+    notebook_dir = Unicode(py3compat.getcwd(), config=True, help="""
             The directory to use for notebooks.
             """)
 

--- a/IPython/parallel/apps/baseapp.py
+++ b/IPython/parallel/apps/baseapp.py
@@ -36,6 +36,7 @@ from IPython.core.application import (
     base_flags as base_ip_flags
 )
 from IPython.utils.path import expand_path
+from IPython.utils import py3compat
 from IPython.utils.py3compat import unicode_type
 
 from IPython.utils.traitlets import Unicode, Bool, Instance, Dict
@@ -105,7 +106,7 @@ class BaseParallelApplication(BaseIPythonApplication):
         """override default log format to include time"""
         return u"%(asctime)s.%(msecs).03d [%(name)s]%(highlevel)s %(message)s"
 
-    work_dir = Unicode(os.getcwdu(), config=True,
+    work_dir = Unicode(py3compat.getcwd(), config=True,
         help='Set the working dir for the process.'
     )
     def _work_dir_changed(self, name, old, new):
@@ -156,7 +157,7 @@ class BaseParallelApplication(BaseIPythonApplication):
         
     def to_work_dir(self):
         wd = self.work_dir
-        if unicode_type(wd) != os.getcwdu():
+        if unicode_type(wd) != py3compat.getcwd():
             os.chdir(wd)
             self.log.info("Changing to working dir: %s" % wd)
         # This is the working dir by now.

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -45,7 +45,7 @@ from nose.plugins import doctests, Plugin
 from nose.util import anyp, getpackage, test_address, resolve_name, tolist
 
 # Our own imports
-from IPython.utils.py3compat import builtin_mod, PY3
+from IPython.utils.py3compat import builtin_mod, PY3, getcwd
 
 if PY3:
     from io import StringIO
@@ -255,7 +255,7 @@ class DocTestCase(doctests.DocTestCase):
             # Save our current directory and switch out to the one where the
             # test was originally created, in case another doctest did a
             # directory change.  We'll restore this in the finally clause.
-            curdir = os.getcwdu()
+            curdir = getcwd()
             #print 'runTest in dir:', self._ori_dir  # dbg
             os.chdir(self._ori_dir)
 

--- a/IPython/utils/_process_win32.py
+++ b/IPython/utils/_process_win32.py
@@ -54,7 +54,7 @@ class AvoidUNCPath(object):
             os.system(cmd)
     """
     def __enter__(self):
-        self.path = os.getcwdu()
+        self.path = py3compat.getcwd()
         self.is_unc_path = self.path.startswith(r"\\")
         if self.is_unc_path:
             # change to c drive (as cmd.exe cannot handle UNC addresses)

--- a/IPython/utils/_process_win32_controller.py
+++ b/IPython/utils/_process_win32_controller.py
@@ -17,7 +17,7 @@ import os, sys, threading
 import ctypes, msvcrt
 
 # local imports
-from .py3compat import unicode_type
+from . import py3compat
 
 # Win32 API types needed for the API calls
 from ctypes import POINTER
@@ -174,7 +174,7 @@ class AvoidUNCPath(object):
             os.system(cmd)
     """
     def __enter__(self):
-        self.path = os.getcwdu()
+        self.path = py3compat.getcwd()
         self.is_unc_path = self.path.startswith(r"\\")
         if self.is_unc_path:
             # change to c drive (as cmd.exe cannot handle UNC addresses)

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -166,7 +166,7 @@ def filefind(filename, path_dirs=None):
         path_dirs = (path_dirs,)
 
     for path in path_dirs:
-        if path == '.': path = os.getcwdu()
+        if path == '.': path = py3compat.getcwd()
         testname = expand_path(os.path.join(path, filename))
         if os.path.isfile(testname):
             return os.path.abspath(testname)

--- a/IPython/utils/process.py
+++ b/IPython/utils/process.py
@@ -28,6 +28,7 @@ else:
 
 
 from ._process_common import getoutputerror, get_output_error_code
+from . import py3compat
 
 #-----------------------------------------------------------------------------
 # Code
@@ -105,7 +106,7 @@ def pycmd2argv(cmd):
 
 def abbrev_cwd():
     """ Return abbreviated version of cwd, e.g. d:mydir """
-    cwd = os.getcwdu().replace('\\','/')
+    cwd = py3compat.getcwd().replace('\\','/')
     drivepart = ''
     tail = cwd
     if sys.platform == 'win32':

--- a/IPython/utils/py3compat.py
+++ b/IPython/utils/py3compat.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 """Compatibility tricks for Python 3. Mainly to do with unicode."""
 import functools
+import os
 import sys
 import re
 import types
@@ -95,6 +96,7 @@ if sys.version_info[0] >= 3:
     xrange = range
     def iteritems(d): return iter(d.items())
     def itervalues(d): return iter(d.values())
+    getcwd = os.getcwd
     
     MethodType = types.MethodType
     
@@ -172,6 +174,7 @@ else:
     xrange = xrange
     def iteritems(d): return d.iteritems()
     def itervalues(d): return d.itervalues()
+    getcwd = os.getcwdu
 
     def MethodType(func, instance):
         return types.MethodType(func, instance, type(instance))

--- a/IPython/utils/terminal.py
+++ b/IPython/utils/terminal.py
@@ -25,6 +25,8 @@ import struct
 import sys
 import warnings
 
+from . import py3compat
+
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
@@ -102,7 +104,7 @@ if sys.platform == 'win32':
 
             try:
                 # Cannot be on network share when issuing system commands
-                curr = os.getcwdu()
+                curr = py3compat.getcwd()
                 os.chdir("C:")
                 ret = os.system("title " + title)
             finally:

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -523,7 +523,7 @@ class TestShellGlob(object):
     @classmethod
     @contextmanager
     def in_tempdir(cls):
-        save = os.getcwdu()
+        save = py3compat.getcwd()
         try:
             os.chdir(cls.tempdir.name)
             yield


### PR DESCRIPTION
We were using the `os.getcwdu()` function in several places. That doesn't exist on Python 3, but the path.py module was masking that by setting `os.getcwdu = os.getcwd`. As described in #4462, however, that didn't always work.

This adds a reference in `py3compat` which points to getcwd on Python 3 and getcwdu in Python 2.
