### PR TITLE
Various Config object cleanups

### DIFF
--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -32,7 +32,7 @@ import sys
 from IPython.utils.path import filefind, get_ipython_dir
 from IPython.utils import py3compat, warn
 from IPython.utils.encoding import DEFAULT_ENCODING
-from IPython.utils.py3compat import builtin_mod, unicode_type, iteritems
+from IPython.utils.py3compat import unicode_type, iteritems
 from IPython.utils.traitlets import HasTraits, List, Any, TraitError
 
 #-----------------------------------------------------------------------------

--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -244,17 +244,14 @@ class Config(dict):
         return type(self)(copy.deepcopy(list(self.items())))
     
     def __getitem__(self, key):
-        if _is_section_key(key):
-            try:
-                return dict.__getitem__(self, key)
-            except KeyError:
+        try:
+            return dict.__getitem__(self, key)
+        except KeyError:
+            if _is_section_key(key):
                 c = Config()
                 dict.__setitem__(self, key, c)
                 return c
-        else:
-            try:
-                return dict.__getitem__(self, key)
-            except KeyError:
+            else:
                 # undefined, create lazy value, used for container methods
                 v = LazyConfigValue()
                 dict.__setitem__(self, key, v)

--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -200,14 +200,14 @@ class Config(dict):
         to_update = {}
         for k, v in iteritems(other):
             if k not in self:
-                to_update[k] = v
+                to_update[k] = copy.deepcopy(v)
             else: # I have this key
                 if isinstance(v, Config) and isinstance(self[k], Config):
                     # Recursively merge common sub Configs
                     self[k].merge(v)
                 else:
                     # Plain updates for non-Configs
-                    to_update[k] = v
+                    to_update[k] = copy.deepcopy(v)
 
         self.update(to_update)
 

--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -269,7 +269,10 @@ class Config(dict):
             try:
                 return dict.__getitem__(self, key)
             except KeyError:
-                # undefined
+                if key.startswith('__'):
+                    # don't create LazyConfig on special method requests
+                    raise
+                # undefined, create lazy value, used for container methods
                 v = LazyConfigValue()
                 dict.__setitem__(self, key, v)
                 return v

--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -219,19 +219,13 @@ class Config(dict):
                 return False
             return remainder in self[first]
         
-        # we always have Sections
-        if _is_section_key(key):
-            return True
-        else:
-            return super(Config, self).__contains__(key)
+        return super(Config, self).__contains__(key)
+    
     # .has_key is deprecated for dictionaries.
     has_key = __contains__
-
+    
     def _has_section(self, key):
-        if _is_section_key(key):
-            if super(Config, self).__contains__(key):
-                return True
-        return False
+        return _is_section_key(key) and key in self
     
     def copy(self):
         return type(self)(dict.copy(self))

--- a/IPython/config/tests/test_configurable.py
+++ b/IPython/config/tests/test_configurable.py
@@ -357,4 +357,19 @@ class TestConfigContainers(TestCase):
         obj = Containers(config=c)
         self.assertEqual(obj.d, {'a':'b', 'c':'d', 'e':'f'})
     
+    def test_update_twice(self):
+        c = Config()
+        c.MyConfigurable.a = 5
+        m = MyConfigurable(config=c)
+        self.assertEqual(m.a, 5)
+        
+        c2 = Config()
+        c2.MyConfigurable.a = 10
+        m.update_config(c2)
+        self.assertEqual(m.a, 10)
+        
+        c2.MyConfigurable.a = 15
+        m.update_config(c2)
+        self.assertEqual(m.a, 15)
+    
 

--- a/IPython/config/tests/test_loader.py
+++ b/IPython/config/tests/test_loader.py
@@ -257,8 +257,6 @@ class TestConfig(TestCase):
 
     def test_builtin(self):
         c1 = Config()
-        exec('foo = True', c1)
-        self.assertEqual(c1.foo, True)
         c1.format = "json"
     
     def test_fromdict(self):

--- a/IPython/config/tests/test_loader.py
+++ b/IPython/config/tests/test_loader.py
@@ -20,6 +20,7 @@ Authors:
 #-----------------------------------------------------------------------------
 
 import os
+import pickle
 import sys
 from tempfile import mkstemp
 from unittest import TestCase
@@ -289,4 +290,10 @@ class TestConfig(TestCase):
         self.assertIn('Foo.bar', c2)
         self.assertNotIn('Foo.bar', c1)
     
+    def test_pickle_config(self):
+        cfg = Config()
+        cfg.Foo.bar = 1
+        pcfg = pickle.dumps(cfg)
+        cfg2 = pickle.loads(pcfg)
+        self.assertEqual(cfg2, cfg)
 

--- a/IPython/config/tests/test_loader.py
+++ b/IPython/config/tests/test_loader.py
@@ -324,4 +324,14 @@ class TestConfig(TestCase):
         foo = cfg['foo']
         assert isinstance(foo, LazyConfigValue)
         self.assertIn('foo', cfg)
+    
+    def test_merge_copies(self):
+        c = Config()
+        c2 = Config()
+        c2.Foo.trait = []
+        c.merge(c2)
+        c2.Foo.trait.append(1)
+        self.assertIsNot(c.Foo, c2.Foo)
+        self.assertEqual(c.Foo.trait, [])
+        self.assertEqual(c2.Foo.trait, [1])
 

--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -83,27 +83,18 @@ class Exporter(LoggingConfigurable):
         config : config
             User configuration instance.
         """
-        if not config:
-            config = self.default_config
+        with_default_config = self.default_config
+        if config:
+            with_default_config.merge(config)
+        
+        super(Exporter, self).__init__(config=with_default_config, **kw)
 
-        super(Exporter, self).__init__(config=config, **kw)
-
-        #Init
         self._init_preprocessors()
 
 
     @property
     def default_config(self):
         return Config()
-
-    def _config_changed(self, name, old, new):
-        """When setting config, make sure to start with our default_config"""
-        c = self.default_config
-        if new:
-            c.merge(new)
-        if c != old:
-            self.config = c
-        super(Exporter, self)._config_changed(name, old, c)
 
 
     def from_notebook_node(self, nb, resources=None, **kw):

--- a/IPython/nbconvert/exporters/templateexporter.py
+++ b/IPython/nbconvert/exporters/templateexporter.py
@@ -140,10 +140,7 @@ class TemplateExporter(Exporter):
         template : str (optional, kw arg)
             Template to use when exporting.
         """
-        if not config:
-            config = self.default_config
-        
-        super(Exporter, self).__init__(config=config, **kw)
+        super(TemplateExporter, self).__init__(config=config, **kw)
 
         #Init
         self._init_template()


### PR DESCRIPTION
This has expanded a bit, as bugs have been found and fixed:
- don't create LazyConfigValue on `__` names (closes #4447)
- `'Section' in cfg` shouldn't return True
- fix bad branch logic causing failures on Python 3
- cleanup workarounds for PyPy
- add some missing copy calls that could break repeated merges
- remove some artifacts of the initial Config design that we never implemented (e.g. builtins for use as `exec` namespace).
