### PR TITLE
yet another JS race condition fix

### DIFF
--- a/IPython/html/tests/casperjs/test_cases/check_interrupt.js
+++ b/IPython/html/tests/casperjs/test_cases/check_interrupt.js
@@ -4,8 +4,18 @@
 casper.notebook_test(function () {
     this.evaluate(function () {
         var cell = IPython.notebook.get_cell(0);
-        cell.set_text('import time\nfor x in range(3):\n    time.sleep(1)');
+        cell.set_text(
+            'import time'+
+            '\nfor x in range(3):'+
+            '\n    time.sleep(1)'
+            );
         cell.execute();
+    });
+
+    this.waitFor(function(){
+        return this.evaluate(function() {
+            return $("#notification_kernel")[0].textContent.indexOf('busy') !== -1;
+        });
     });
 
 

--- a/IPython/html/tests/casperjs/util.js
+++ b/IPython/html/tests/casperjs/util.js
@@ -67,6 +67,10 @@ casper.wait_for_output = function (cell_num) {
             },
             // pass parameter from the test suite js to the browser code js
             {c : cell_num});
+        },
+        function then() { },
+        function timeout() {
+            this.echo("wait_for_output timedout!");
         });
     });
 };


### PR DESCRIPTION
this should greatly reduce the number of timeouts seen in the JS tests

I've been beating my head against this most of this week, the culprit seems to
have been the fact that Casper can end up "clicking" the interrupt kernel menu
item _before_ the execution even starts. Extra credit to @takluyver who put up
with many expletives I shouted out while trying to get to the bottom of this.
