### PR TITLE
fix typo in message spec doc

### DIFF
--- a/docs/source/development/messaging.rst
+++ b/docs/source/development/messaging.rst
@@ -630,7 +630,7 @@ Message type: ``complete_reply``::
     # this is typically the common prefix of the matches,
     # and the text that is already in the block that would be replaced by the full completion.
     # This would be 'a.is' in the above example.
-    'text' : str,
+    'matched_text' : str,
     
     # status should be 'ok' unless an exception was raised during the request,
     # in which case it should be 'error', along with the usual error message content


### PR DESCRIPTION
complete_reply have a `matched_text` and not a `text` field.

Fixes  #4485.

Should we backport doc fixes on 1.x ?
