### PR TITLE
check realpath of env in init_virtualenv

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -716,7 +716,9 @@ class InteractiveShell(SingletonConfigurable):
             # Not in a virtualenv
             return
         
-        if sys.executable.startswith(os.environ['VIRTUAL_ENV']):
+        if os.path.realpath(sys.executable).startswith(
+            os.path.realpath(os.environ['VIRTUAL_ENV'])
+        ):
             # Running properly in the virtualenv, don't need to do anything
             return
         


### PR DESCRIPTION
should help with symlinked envs

I'm not certain this is the right thing to do,
as it may do weird things for environments with symlinked homes, etc.

@ivanov, I think you have seen issues with that before, can you test?

closes #4486
