### PR TITLE
fix possible race condition in test_await_data

### DIFF
--- a/IPython/parallel/tests/test_asyncresult.py
+++ b/IPython/parallel/tests/test_asyncresult.py
@@ -301,8 +301,9 @@ class AsyncResultTest(ClusterTestCase):
         # timeout after 10s
         while time.time() <= tic + 10:
             if ar.data:
-                found.add(ar.data['i'])
-                if ar.data['i'] == 4:
+                i = ar.data['i']
+                found.add(i)
+                if i == 4:
                     break
             time.sleep(0.05)
         


### PR DESCRIPTION
ar.data checks the latest value, and was checked twice assuming no change. This could cause `4` to stop the iteration but be absent from `found`, causing test failure.
