### PR TITLE
Daemon StreamCapturer

### DIFF
--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -359,6 +359,7 @@ class ExclusionPlugin(Plugin):
 
 
 class StreamCapturer(Thread):
+    daemon = True  # Don't hang if main thread crashes
     started = False
     def __init__(self):
         super(StreamCapturer, self).__init__()


### PR DESCRIPTION
The StreamCapturer should die if the main thread crashes. On Shiningpanda, a failure in another nose plugin has been causing the tests to hang, because the main thread exits, but the StreamCapturer thread is still alive.

Under normal conditions, the thread will still be shut down cleanly - it will only die a messy death if the main thread does.
