### PR TITLE
Spring Cleaning, and  Load speedup

### DIFF
--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -295,6 +295,7 @@ var IPython = (function (IPython) {
             this.code_mirror.setOption('mode', mode);
             return;
         }
+        var current_mode = this.code_mirror.getOption('mode', mode);
         var first_line = this.code_mirror.getLine(0);
         // loop on every pairs
         for( var mode in modes) {
@@ -303,8 +304,12 @@ var IPython = (function (IPython) {
             for(var reg in regs ) {
                 // here we handle non magic_modes
                 if(first_line.match(regs[reg]) != null) {
+                    if(current_mode == mode){
+                        return;
+                    }
                     if (mode.search('magic_') != 0) {
                         this.code_mirror.setOption('mode', mode);
+                        console.log('from',current_mode,'to',mode)
                         CodeMirror.autoLoadMode(this.code_mirror, mode);
                         return;
                     }
@@ -312,6 +317,9 @@ var IPython = (function (IPython) {
                     var close = modes[mode]['close']|| "%%end";
                     var mmode = mode;
                     mode = mmode.substr(6);
+                    if(current_mode == mode){
+                        return;
+                    }
                     CodeMirror.autoLoadMode(this.code_mirror, mode);
                     // create on the fly a mode that swhitch between
                     // plain/text and smth else otherwise `%%` is
@@ -328,6 +336,7 @@ var IPython = (function (IPython) {
                         );
                     });
                     this.code_mirror.setOption('mode', mmode);
+                    console.log('from',current_mode,'to', mmode)
                     return;
                 }
             }
@@ -339,7 +348,11 @@ var IPython = (function (IPython) {
         } catch(e) {
             default_mode = 'text/plain';
         }
+        if( current_mode === default_mode){
+            return
+        }
         this.code_mirror.setOption('mode', default_mode);
+        console.log('from',current_mode,'to', default_mode)
     };
 
     IPython.Cell = Cell;

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -39,18 +39,28 @@ var IPython = (function (IPython) {
         this.placeholder = options.placeholder || '';
         this.read_only = options.cm_config.readOnly;
         this.selected = false;
-        this.element = null;
         this.metadata = {};
         // load this from metadata later ?
         this.user_highlight = 'auto';
         this.cm_config = options.cm_config;
+        this.cell_id = utils.uuid();
+        this._options = options;
+
+        // For JS VM engines optimisation, attributes should be all set (even
+        // to null) in the constructor, and if possible, if different subclass
+        // have new attributes with same name, they should be created in the
+        // same order. Easiest is to create and set to null in parent class.
+
+        this.element = null;
+        this.cell_type = null;
+        this.code_mirror = null;
+
+
         this.create_element();
         if (this.element !== null) {
             this.element.data("cell", this);
             this.bind_events();
         }
-        this.cell_id = utils.uuid();
-        this._options = options;
     };
 
     Cell.options_default = {
@@ -309,7 +319,6 @@ var IPython = (function (IPython) {
                     }
                     if (mode.search('magic_') != 0) {
                         this.code_mirror.setOption('mode', mode);
-                        console.log('from',current_mode,'to',mode)
                         CodeMirror.autoLoadMode(this.code_mirror, mode);
                         return;
                     }
@@ -336,7 +345,6 @@ var IPython = (function (IPython) {
                         );
                     });
                     this.code_mirror.setOption('mode', mmode);
-                    console.log('from',current_mode,'to', mmode)
                     return;
                 }
             }
@@ -352,7 +360,6 @@ var IPython = (function (IPython) {
             return
         }
         this.code_mirror.setOption('mode', default_mode);
-        console.log('from',current_mode,'to', default_mode)
     };
 
     IPython.Cell = Cell;

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -202,8 +202,10 @@ var IPython = (function (IPython) {
                 return true;
         } else if (event.keyCode === key.TAB && event.type == 'keydown') {
             // Tab completion.
-            //Do not trim here because of tooltip
-            if (editor.somethingSelected()) { return false; }
+            IPython.tooltip.remove_and_cancel_tooltip();
+            if (editor.somethingSelected()) {
+                return false;
+            }
             var pre_cursor = editor.getRange({line:cur.line,ch:0},cur);
             if (pre_cursor.trim() === "") {
                 // Don't autocomplete if the part of the line before the cursor
@@ -443,7 +445,8 @@ var IPython = (function (IPython) {
         var data = IPython.Cell.prototype.toJSON.apply(this);
         data.input = this.get_text();
         data.cell_type = 'code';
-        if (this.input_prompt_number) {
+        // is finite protect against undefined and '*' value
+        if (isFinite(this.input_prompt_number)) {
             data.prompt_number = this.input_prompt_number;
         }
         var outputs = this.output_area.toJSON();

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -62,10 +62,16 @@ var IPython = (function (IPython) {
      */
     var CodeCell = function (kernel, options) {
         this.kernel = kernel || null;
-        this.code_mirror = null;
-        this.input_prompt_number = null;
         this.collapsed = false;
         this.cell_type = "code";
+
+        // create all attributed in constructor function
+        // even if null for V8 VM optimisation
+        this.input_prompt_number = null;
+        this.celltoolbar = null;
+        this.output_area = null;
+        this.last_msg_id = null;
+        this.completer = null;
 
 
         var cm_overwrite_options  = {
@@ -129,13 +135,7 @@ var IPython = (function (IPython) {
         cell.append(input).append(output);
         this.element = cell;
         this.output_area = new IPython.OutputArea(output, true);
-
-        // construct a completer only if class exist
-        // otherwise no print view
-        if (IPython.Completer !== undefined)
-        {
-            this.completer = new IPython.Completer(this);
-        }
+        this.completer = new IPython.Completer(this);
     };
 
     /**

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -789,8 +789,8 @@ var IPython = (function (IPython) {
      *
      * @return cell {cell|null} created cell or null
      **/
-    Notebook.prototype.insert_cell_at_index = function(type, index, opts){
-        var opts = opts || {select:true};
+    Notebook.prototype.insert_cell_at_index = function(type, index){
+
         var ncells = this.ncells();
         var index = Math.min(index,ncells);
             index = Math.max(index,0);
@@ -810,9 +810,7 @@ var IPython = (function (IPython) {
 
             if(this._insert_element_at_index(cell.element,index)){
                 cell.render();
-                if(opts.select){
-                    this.select(this.find_cell_index(cell));
-                }
+                this.select(this.find_cell_index(cell));
                 $([IPython.events]).trigger('create.Cell', {'cell': cell, 'index': index});
                 this.set_dirty(true);
             }
@@ -888,9 +886,9 @@ var IPython = (function (IPython) {
      * @return handle to created cell or null
      *
      **/
-    Notebook.prototype.insert_cell_below = function (type, index, opts) {
+    Notebook.prototype.insert_cell_below = function (type, index) {
         index = this.index_or_selected(index);
-        return this.insert_cell_at_index(type, index+1, opts);
+        return this.insert_cell_at_index(type, index+1);
     };
 
 
@@ -902,9 +900,9 @@ var IPython = (function (IPython) {
      *
      * @return the added cell; or null
      **/
-    Notebook.prototype.insert_cell_at_bottom = function (type, opts){
+    Notebook.prototype.insert_cell_at_bottom = function (type){
         var len = this.ncells();
-        return this.insert_cell_below(type,len-1, opts);
+        return this.insert_cell_below(type,len-1);
     };
 
     /**
@@ -1590,7 +1588,7 @@ var IPython = (function (IPython) {
                     cell_data.cell_type = 'raw';
                 }
 
-                new_cell = this.insert_cell_at_bottom(cell_data.cell_type,{select:false});
+                new_cell = this.insert_cell_at_bottom(cell_data.cell_type);
                 new_cell.fromJSON(cell_data);
             };
         };

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -789,8 +789,8 @@ var IPython = (function (IPython) {
      *
      * @return cell {cell|null} created cell or null
      **/
-    Notebook.prototype.insert_cell_at_index = function(type, index){
-
+    Notebook.prototype.insert_cell_at_index = function(type, index, opts){
+        var opts = opts || {select:false};
         var ncells = this.ncells();
         var index = Math.min(index,ncells);
             index = Math.max(index,0);
@@ -810,7 +810,9 @@ var IPython = (function (IPython) {
 
             if(this._insert_element_at_index(cell.element,index)){
                 cell.render();
-                this.select(this.find_cell_index(cell));
+                if(opts.select){
+                    this.select(this.find_cell_index(cell));
+                }
                 $([IPython.events]).trigger('create.Cell', {'cell': cell, 'index': index});
                 this.set_dirty(true);
             }
@@ -886,9 +888,9 @@ var IPython = (function (IPython) {
      * @return handle to created cell or null
      *
      **/
-    Notebook.prototype.insert_cell_below = function (type, index) {
+    Notebook.prototype.insert_cell_below = function (type, index, opts) {
         index = this.index_or_selected(index);
-        return this.insert_cell_at_index(type, index+1);
+        return this.insert_cell_at_index(type, index+1, opts);
     };
 
 
@@ -900,9 +902,9 @@ var IPython = (function (IPython) {
      *
      * @return the added cell; or null
      **/
-    Notebook.prototype.insert_cell_at_bottom = function (type){
+    Notebook.prototype.insert_cell_at_bottom = function (type, opts){
         var len = this.ncells();
-        return this.insert_cell_below(type,len-1);
+        return this.insert_cell_below(type,len-1, opts);
     };
 
     /**
@@ -1588,7 +1590,7 @@ var IPython = (function (IPython) {
                     cell_data.cell_type = 'raw';
                 }
 
-                new_cell = this.insert_cell_below(cell_data.cell_type);
+                new_cell = this.insert_cell_at_bottom(cell_data.cell_type,{select:false});
                 new_cell.fromJSON(cell_data);
             };
         };

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -790,7 +790,7 @@ var IPython = (function (IPython) {
      * @return cell {cell|null} created cell or null
      **/
     Notebook.prototype.insert_cell_at_index = function(type, index, opts){
-        var opts = opts || {select:false};
+        var opts = opts || {select:true};
         var ncells = this.ncells();
         var index = Math.min(index,ncells);
             index = Math.max(index,0);

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -576,12 +576,13 @@ var IPython = (function (IPython) {
 
     OutputArea.prototype.append_png = function (png, md, element) {
         var toinsert = this.create_output_subarea(md, "output_png");
-        var img = $("<img/>").attr('src','data:image/png;base64,'+png);
+        var img = $("<img/>")
+        img[0].setAttribute('src','data:image/png;base64,'+png);
         if (md['height']) {
-            img.attr('height', md['height']);
+            img[0].setAttribute('height', md['height']);
         }
         if (md['width']) {
-            img.attr('width', md['width']);
+            img[0].setAttribute('width', md['width']);
         }
         this._dblclick_to_reset_size(img);
         toinsert.append(img);

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -576,7 +576,7 @@ var IPython = (function (IPython) {
 
     OutputArea.prototype.append_png = function (png, md, element) {
         var toinsert = this.create_output_subarea(md, "output_png");
-        var img = $("<img/>")
+        var img = $("<img/>");
         img[0].setAttribute('src','data:image/png;base64,'+png);
         if (md['height']) {
             img[0].setAttribute('height', md['height']);


### PR DESCRIPTION
0) prompt '*' strore fix + tab remove tooltip
tab was not cancelling tooltip bringing to cases where you could have
tooltip andcompleter open.

Do not store '*' when serializing cells.

get rid of most slowdown at notebook loading.
1) Do not setOption('mode',new_mode) on CM if new and old mode are the
   same. It triggert **a lot** of calculation of bounding box in the
   end.

2) Do **not** select cell when loading the notebook it triggers
   **a lot** of CM even that check visible things and so on and so
   forth. So add a option to add_cell_at_index not to select it

3) jQuery $.attr has some magics, but has a slight overhead on
   real native ELEM.setAttribute DOM method. Seem slight improvement
   when loads of PNGs on one page
