### PR TITLE
Use username and password for MongoDB on ShiningPanda

### DIFF
--- a/IPython/parallel/tests/test_mongodb.py
+++ b/IPython/parallel/tests/test_mongodb.py
@@ -30,6 +30,10 @@ from . import test_db
 conn_kwargs = {}
 if 'DB_IP' in os.environ:
     conn_kwargs['host'] = os.environ['DB_IP']
+if 'DBA_MONGODB_ADMIN_URI' in os.environ:
+    # On ShiningPanda, we need a username and password to connect. They are
+    # passed in a mongodb:// URI.
+    conn_kwargs['host'] = os.environ['DBA_MONGODB_ADMIN_URI']
 if 'DB_PORT' in os.environ:
     conn_kwargs['port'] = int(os.environ['DB_PORT'])
 


### PR DESCRIPTION
The Mongo instance started by ShiningPanda appears to need a username and password to create databases. These are supplied in a mongodb URI, as per [the docs](http://api.mongodb.org/python/current/api/pymongo/connection.html).
