### PR TITLE
Allow unicode arguments to passwd_check on Python 2

### DIFF
--- a/IPython/lib/security.py
+++ b/IPython/lib/security.py
@@ -113,6 +113,6 @@ def passwd_check(hashed_passphrase, passphrase):
     if len(pw_digest) == 0:
         return False
 
-    h.update(cast_bytes(passphrase, 'utf-8') + str_to_bytes(salt, 'ascii'))
+    h.update(cast_bytes(passphrase, 'utf-8') + cast_bytes(salt, 'ascii'))
 
     return h.hexdigest() == pw_digest

--- a/IPython/lib/tests/test_security.py
+++ b/IPython/lib/tests/test_security.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from IPython.lib import passwd
 from IPython.lib.security import passwd_check, salt_len
 import nose.tools as nt
@@ -19,3 +20,7 @@ def test_bad():
     nt.assert_equal(passwd_check(p, 'a:b:c:d'), False)
     nt.assert_equal(passwd_check(p, 'a:b'), False)
 
+def test_passwd_check_unicode():
+    # GH issue #4524
+    phash = u'sha1:9dc18846ca26:6bb62badc41fde529c258a8a7fbe259a91313df8'
+    assert passwd_check(phash, u'mypassword³')

--- a/IPython/lib/tests/test_security.py
+++ b/IPython/lib/tests/test_security.py
@@ -22,5 +22,5 @@ def test_bad():
 
 def test_passwd_check_unicode():
     # GH issue #4524
-    phash = u'sha1:9dc18846ca26:6bb62badc41fde529c258a8a7fbe259a91313df8'
-    assert passwd_check(phash, u'mypassword³')
+    phash = u'sha1:23862bc21dd3:7a415a95ae4580582e314072143d9c382c491e4f'
+    assert passwd_check(phash, u"łe¶ŧ←↓→")


### PR DESCRIPTION
Closes #4524
