### PR TITLE
Hide dynamically defined metaclass base from Sphinx.

### DIFF
--- a/IPython/utils/py3compat.py
+++ b/IPython/utils/py3compat.py
@@ -239,4 +239,4 @@ else:
 
 def with_metaclass(meta, *bases):
     """Create a base class with a metaclass."""
-    return meta("NewBase", bases, {})
+    return meta("_NewBase", bases, {})


### PR DESCRIPTION
The inheritance diagram extension in Sphinx 1.2 stores class references, which Sphinx then tries to pickle. This chokes on our dynamically defined base classes from the `with_metaclass` function. Starting the name with an underscore makes Sphinx ignore the class.

(Bug obscurity/fix simplicity) ratio is high.
