### PR TITLE
propagate display metadata to all mimetypes

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -118,6 +118,12 @@ def display(*objs, **kwargs):
         for obj in objs:
             format_dict, md_dict = format(obj, include=include, exclude=exclude)
             if metadata:
+                # publish_display_data exepects metadata dict that is keyed by
+                # mimetype, so this ensures we recreate such a dict for it, if
+                # one is not already passed to us
+                if set(metadata.keys()) != set(format_dict.keys()):
+                    _md = metadata.copy()
+                    metadata = {mt: _md for mt in format_dict}
                 # kwarg-specified metadata gets precedence
                 _merge(md_dict, metadata)
             publish_display_data('display', format_dict, md_dict)

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -118,12 +118,6 @@ def display(*objs, **kwargs):
         for obj in objs:
             format_dict, md_dict = format(obj, include=include, exclude=exclude)
             if metadata:
-                # publish_display_data exepects metadata dict that is keyed by
-                # mimetype, so this ensures we recreate such a dict for it, if
-                # one is not already passed to us
-                if set(metadata.keys()) != set(format_dict.keys()):
-                    _md = metadata.copy()
-                    metadata = {mt: _md for mt in format_dict}
                 # kwarg-specified metadata gets precedence
                 _merge(md_dict, metadata)
             publish_display_data('display', format_dict, md_dict)

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -254,44 +254,26 @@ var IPython = (function (IPython) {
         this.append_output(json, true);
     };
 
-    var mime_types = ['application/javascript', 'application/json',
-               'image/jpeg', 'image/png', 'image/svg+xml', 'text/html',
-               'text/latex', 'text/plain'];
+    OutputArea.mime_map = {
+        "text/plain" : "text",
+        "text/html" : "html",
+        "image/svg+xml" : "svg",
+        "image/png" : "png",
+        "image/jpeg" : "jpeg",
+        "text/latex" : "latex",
+        "application/json" : "json",
+        "application/javascript" : "javascript",
+    };
 
     OutputArea.prototype.convert_mime_types = function (json, data) {
-        if (data === undefined) {
+        if (!data) {
             return json;
-        }
-        if (data['text/plain'] !== undefined) {
-            json.text = data['text/plain'];
-        }
-        if (data['text/html'] !== undefined) {
-            json.html = data['text/html'];
-        }
-        if (data['image/svg+xml'] !== undefined) {
-            json.svg = data['image/svg+xml'];
-        }
-        if (data['image/png'] !== undefined) {
-            json.png = data['image/png'];
-        }
-        if (data['image/jpeg'] !== undefined) {
-            json.jpeg = data['image/jpeg'];
-        }
-        if (data['text/latex'] !== undefined) {
-            json.latex = data['text/latex'];
-        }
-        if (data['application/json'] !== undefined) {
-            json.json = data['application/json'];
-        }
-        if (data['application/javascript'] !== undefined) {
-            json.javascript = data['application/javascript'];
         }
         // non-mimetype-keyed metadata used to get dropped here, this code
         // re-injects it into the json.
-        for (x in data){
-            if( !(x in mime_types) ) {
-                json[x] = data[x];
-            }
+        for (var key in data) {
+            var json_key = OutputArea.mime_map[key] || key;
+            json[json_key] = data[key];
         }
         return json;
     };

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -421,7 +421,7 @@ var IPython = (function (IPython) {
         this.append_mime_type(json, toinsert);
         this._safe_append(toinsert);
         // If we just output latex, typeset it.
-        if ((json.latex !== undefined) || (json.html !== undefined)) {
+        if ((json['text/latex'] !== undefined) || (json['text/html'] !== undefined)) {
             this.typeset();
         }
     };
@@ -484,7 +484,7 @@ var IPython = (function (IPython) {
         if (this.append_mime_type(json, toinsert)) {
             this._safe_append(toinsert);
             // If we just output latex, typeset it.
-            if ( (json.latex !== undefined) || (json.html !== undefined) ) {
+            if ((json['text/latex'] !== undefined) || (json['text/html'] !== undefined)) {
                 this.typeset();
             }
         }

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -506,7 +506,7 @@ var IPython = (function (IPython) {
             var type = OutputArea.display_order[type_i];
             var append = OutputArea.append_map[type];
             if ((json[type] !== undefined) && append) {
-                md = json.metadata || {};
+                var md = json.metadata || {};
                 append.apply(this, [json[type], md, element]);
                 return true;
             }
@@ -516,7 +516,7 @@ var IPython = (function (IPython) {
 
 
     OutputArea.prototype.append_html = function (html, md, element) {
-        type = 'text/html';
+        var type = 'text/html';
         var toinsert = this.create_output_subarea(md, "output_html rendered_html", type);
         IPython.keyboard_manager.register_events(toinsert);
         toinsert.append(html);
@@ -526,7 +526,7 @@ var IPython = (function (IPython) {
 
     OutputArea.prototype.append_javascript = function (js, md, container) {
         // We just eval the JS code, element appears in the local scope.
-        type = 'application/javascript';
+        var type = 'application/javascript';
         var element = this.create_output_subarea(md, "output_javascript", type);
         IPython.keyboard_manager.register_events(element);
         container.append(element);
@@ -540,7 +540,7 @@ var IPython = (function (IPython) {
 
 
     OutputArea.prototype.append_text = function (data, md, element, extra_class) {
-        type = 'text/plain';
+        var type = 'text/plain';
         var toinsert = this.create_output_subarea(md, "output_text", type);
         // escape ANSI & HTML specials in plaintext:
         data = utils.fixConsole(data);
@@ -555,7 +555,7 @@ var IPython = (function (IPython) {
 
 
     OutputArea.prototype.append_svg = function (svg, md, element) {
-        type = 'image/svg+xml';
+        var type = 'image/svg+xml';
         var toinsert = this.create_output_subarea(md, "output_svg", type);
         toinsert.append(svg);
         element.append(toinsert);
@@ -590,7 +590,7 @@ var IPython = (function (IPython) {
 
 
     OutputArea.prototype.append_png = function (png, md, element) {
-        type = 'image/png';
+        var type = 'image/png';
         var toinsert = this.create_output_subarea(md, "output_png", type);
         var img = $("<img/>");
         img[0].setAttribute('src','data:image/png;base64,'+png);
@@ -607,7 +607,7 @@ var IPython = (function (IPython) {
 
 
     OutputArea.prototype.append_jpeg = function (jpeg, md, element) {
-        type = 'image/jpeg';
+        var type = 'image/jpeg';
         var toinsert = this.create_output_subarea(md, "output_jpeg", type);
         var img = $("<img/>").attr('src','data:image/jpeg;base64,'+jpeg);
         if (md['height']) {
@@ -625,7 +625,7 @@ var IPython = (function (IPython) {
     OutputArea.prototype.append_latex = function (latex, md, element) {
         // This method cannot do the typesetting because the latex first has to
         // be on the page.
-        type = 'text/latex';
+        var type = 'text/latex';
         var toinsert = this.create_output_subarea(md, "output_latex", type);
         toinsert.append(latex);
         element.append(toinsert);

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -740,8 +740,6 @@ var IPython = (function (IPython) {
     // JSON serialization
 
     OutputArea.prototype.fromJSON = function (outputs) {
-        // add here the mapping of short key to mime type
-        // TODO: remove this when we update to nbformat 4
         var len = outputs.length;
         var data;
 
@@ -757,6 +755,7 @@ var IPython = (function (IPython) {
             var msg_type = data.output_type;
             if (msg_type === "display_data" || msg_type === "pyout") {
                 // convert short keys to mime keys
+                // TODO: remove mapping of short keys when we update to nbformat 4
                  data = this.rename_keys(data, OutputArea.mime_map_r);
                  data.metadata = this.rename_keys(data.metadata, OutputArea.mime_map_r);
             }
@@ -779,7 +778,7 @@ var IPython = (function (IPython) {
             if (msg_type === "display_data" || msg_type === "pyout") {
                   // convert mime keys to short keys
                  data = this.rename_keys(data, OutputArea.mime_map);
-                 data.metadata = this.rename_keys(data, OutputArea.mime_map);
+                 data.metadata = this.rename_keys(data.metadata, OutputArea.mime_map);
             }
             outputs[i] = data;
         }

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -514,11 +514,12 @@ var IPython = (function (IPython) {
                         return true;
                     }
                 } else {
-                    var old_name = OutputArea.mime_map[type]
-                    this['append_'+old_name](json[type], md, element, type);
-                    return true;
+                    var append = OutputArea.append_map[type];
+                    if (append !== undefined) {
+                        append.apply(this, [json[type], md, element, type]);
+                        return true;
+                    }
                 }
-                return false;
             }
         }
         return false;
@@ -632,6 +633,17 @@ var IPython = (function (IPython) {
         var toinsert = this.create_output_subarea(md, "output_latex", type);
         toinsert.append(latex);
         element.append(toinsert);
+    };
+
+    OutputArea.append_map = {
+        "text/plain" : OutputArea.prototype.append_text,
+        "text/html" : OutputArea.prototype.append_html,
+        "image/svg+xml" : OutputArea.prototype.append_svg,
+        "image/png" : OutputArea.prototype.append_png,
+        "image/jpeg" : OutputArea.prototype.append_jpeg,
+        "text/latex" : OutputArea.prototype.append_latex,
+        "application/json" : OutputArea.prototype.append_json,
+        "application/javascript" : OutputArea.prototype.append_javascript,
     };
 
     OutputArea.prototype.append_raw_input = function (msg) {

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -502,15 +502,13 @@ var IPython = (function (IPython) {
 
     OutputArea.prototype.append_mime_type = function (json, element) {
 
-        for(var type_i in OutputArea.display_order){
+        for (var type_i in OutputArea.display_order) {
             var type = OutputArea.display_order[type_i];
-            if(json[type] !== undefined ){
-                var append = OutputArea.append_map[type];
-                if (append !== undefined) {
-                    md = json.metadata || {};
-                    append.apply(this, [json[type], md, element]);
-                    return true;
-                }
+            var append = OutputArea.append_map[type];
+            if ((json[type] !== undefined) && append) {
+                md = json.metadata || {};
+                append.apply(this, [json[type], md, element]);
+                return true;
             }
         }
         return false;

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -516,7 +516,7 @@ var IPython = (function (IPython) {
                 } else {
                     var append = OutputArea.append_map[type];
                     if (append !== undefined) {
-                        append.apply(this, [json[type], md, element, type]);
+                        append.apply(this, [json[type], md, element]);
                         return true;
                     }
                 }
@@ -526,7 +526,8 @@ var IPython = (function (IPython) {
     };
 
 
-    OutputArea.prototype.append_html = function (html, md, element, type) {
+    OutputArea.prototype.append_html = function (html, md, element) {
+        type = 'text/html';
         var toinsert = this.create_output_subarea(md, "output_html rendered_html", type);
         IPython.keyboard_manager.register_events(toinsert);
         toinsert.append(html);
@@ -534,8 +535,9 @@ var IPython = (function (IPython) {
     };
 
 
-    OutputArea.prototype.append_javascript = function (js, md, container, type) {
+    OutputArea.prototype.append_javascript = function (js, md, container) {
         // We just eval the JS code, element appears in the local scope.
+        type = 'application/javascript';
         var element = this.create_output_subarea(md, "output_javascript", type);
         IPython.keyboard_manager.register_events(element);
         container.append(element);
@@ -548,7 +550,8 @@ var IPython = (function (IPython) {
     };
 
 
-    OutputArea.prototype.append_text = function (data, md, element, extra_class, type) {
+    OutputArea.prototype.append_text = function (data, md, element, extra_class) {
+        type = 'text/plain';
         var toinsert = this.create_output_subarea(md, "output_text", type);
         // escape ANSI & HTML specials in plaintext:
         data = utils.fixConsole(data);
@@ -562,7 +565,8 @@ var IPython = (function (IPython) {
     };
 
 
-    OutputArea.prototype.append_svg = function (svg, md, element, type) {
+    OutputArea.prototype.append_svg = function (svg, md, element) {
+        type = 'image/svg+xml';
         var toinsert = this.create_output_subarea(md, "output_svg", type);
         toinsert.append(svg);
         element.append(toinsert);
@@ -596,7 +600,8 @@ var IPython = (function (IPython) {
     };
 
 
-    OutputArea.prototype.append_png = function (png, md, element, type) {
+    OutputArea.prototype.append_png = function (png, md, element) {
+        type = 'image/png';
         var toinsert = this.create_output_subarea(md, "output_png", type);
         var img = $("<img/>");
         img[0].setAttribute('src','data:image/png;base64,'+png);
@@ -612,7 +617,8 @@ var IPython = (function (IPython) {
     };
 
 
-    OutputArea.prototype.append_jpeg = function (jpeg, md, element, type) {
+    OutputArea.prototype.append_jpeg = function (jpeg, md, element) {
+        type = 'image/jpeg';
         var toinsert = this.create_output_subarea(md, "output_jpeg", type);
         var img = $("<img/>").attr('src','data:image/jpeg;base64,'+jpeg);
         if (md['height']) {
@@ -627,9 +633,10 @@ var IPython = (function (IPython) {
     };
 
 
-    OutputArea.prototype.append_latex = function (latex, md, element, type) {
+    OutputArea.prototype.append_latex = function (latex, md, element) {
         // This method cannot do the typesetting because the latex first has to
         // be on the page.
+        type = 'text/latex';
         var toinsert = this.create_output_subarea(md, "output_latex", type);
         toinsert.append(latex);
         element.append(toinsert);

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -603,7 +603,8 @@ var IPython = (function (IPython) {
 
     OutputArea.prototype.append_png = function (png, md, element, type) {
         var toinsert = this.create_output_subarea(md, "output_png", type);
-        var img = $("<img/>").attr('src','data:image/png;base64,'+png);
+        var img = $("<img/>");
+        img[0].attr('src','data:image/png;base64,'+png);
         if (md['height']) {
             img[0].setAttribute('height', md['height']);
         }

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -333,7 +333,6 @@ var IPython = (function (IPython) {
         var mime_md = metadata[mime];
         // mime-specific higher priority
         if (mime_md && mime_md[key] !== undefined) {
-            console.log("got" + key + "   "+ mime_md[key]);
             return mime_md[key];
         }
         // fallback on global
@@ -741,11 +740,12 @@ var IPython = (function (IPython) {
         var len = outputs.length;
         var data;
         for (var i=0; i<len; i++) {
-            var msg_type = outputs[i].output_type;
+            data = outputs[i];
+            var msg_type = data.output_type;
             if (msg_type === "display_data" || msg_type === "pyout") {
                 // convert short keys to mime keys
-                 data = this.rename_keys(outputs[i], OutputArea.mime_map_r);
-                 data.metadata = this.rename_keys(outputs[i].metadata, OutputArea.mime_map_r);
+                 data = this.rename_keys(data, OutputArea.mime_map_r);
+                 data.metadata = this.rename_keys(data.metadata, OutputArea.mime_map_r);
             }
             
             // append with dynamic=false.
@@ -759,12 +759,12 @@ var IPython = (function (IPython) {
         var len = this.outputs.length;
         var data;
         for (var i=0; i<len; i++) {
-            var msg_type = this.outputs[i].output_type;
-            console.log("msg type is  ", msg_type)
+            data = this.outputs[i];
+            var msg_type = data.output_type;
             if (msg_type === "display_data" || msg_type === "pyout") {
                   // convert mime keys to short keys
-                 data = this.rename_keys(this.outputs[i], OutputArea.mime_map);
-                 data.metadata = this.rename_keys(this.outputs[i], OutputArea.mime_map);
+                 data = this.rename_keys(data, OutputArea.mime_map);
+                 data.metadata = this.rename_keys(data, OutputArea.mime_map);
             }
             outputs[i] = data;
         }

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -278,32 +278,18 @@ var IPython = (function (IPython) {
         "javascript" : "application/javascript",
     };
 
-    OutputArea.prototype.convert_mime_types = function (data) {
+    OutputArea.prototype.rename_keys = function (data, key_map) {
         for (var key in data) {
-            var json_key = OutputArea.mime_map[key] || key;
-            console.log("converting ", key, "to", json_key)
-            if (json_key !== key) {
+            var new_key = key_map[key] || key;
+            if (new_key !== key) {
                 // move mime-type keys to short name
-                console.log("converting ", key, "to", json_key)
-                data[json_key] = data[key];
+                data[new_key] = data[key];
                 delete data[key];
             }
         }
         return data;
     };
     
-    OutputArea.prototype.convert_mime_types_r = function (data) {
-        for (var key in data) {
-            var mkey = OutputArea.mime_map_r[key] || key;
-            if (mkey !== key) {
-                // move short keys to mime-type keys
-                data[mkey] = data[key];
-                delete data[key];
-            }
-        }
-        return data;
-    };
-
 
     OutputArea.prototype.append_output = function (json, dynamic) {
         // If dynamic is true, javascript output will be eval'd.
@@ -761,8 +747,8 @@ var IPython = (function (IPython) {
             var msg_type = data.output_type;
             if (msg_type === "display_data" || msg_type === "pyout") {
                 // convert short keys to mime keys
-                 this.convert_mime_types_r(data);
-                 this.convert_mime_types_r(data.metadata);
+                 this.rename_keys(data, OutputArea.mime_map_r);
+                 this.rename_keys(data.metadata, OutputArea.mime_map_r);
             }
             
             // append with dynamic=false.
@@ -780,8 +766,8 @@ var IPython = (function (IPython) {
             console.log("msg type is  ", msg_type)
             if (msg_type === "display_data" || msg_type === "pyout") {
                   // convert mime keys to short keys
-                 this.convert_mime_types(data);
-                 //this.convert_mime_types(data.metadata);
+                 this.rename_keys(data, OutputArea.mime_map);
+                 this.rename_keys(data.metadata, OutputArea.mime_map);
             }
             outputs[i] = data;
         }

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -288,6 +288,18 @@ var IPython = (function (IPython) {
         }
         return json;
     };
+    
+    OutputArea.prototype.convert_mime_types_r = function (data) {
+        for (var key in data) {
+            var mkey = OutputArea.mime_map_r[key] || key;
+            if (mkey !== key) {
+                // move short keys to mime-type keys
+                data[mkey] = data[key];
+                delete data[key];
+            }
+        }
+        return data;
+    };
 
 
     OutputArea.prototype.append_output = function (json, dynamic) {
@@ -738,10 +750,20 @@ var IPython = (function (IPython) {
     // JSON serialization
 
     OutputArea.prototype.fromJSON = function (outputs) {
+        // add here the mapping of short key to mime type
+        // TODO: remove this when we update to nbformat 4
         var len = outputs.length;
         for (var i=0; i<len; i++) {
+            // convert mime keys 
+            var data = outputs[i];
+            var msg_type = data.output_type;
+            if (msg_type === "display_data" || msg_type === "pyout") {
+                 this.convert_mime_types_r(data);
+                 this.convert_mime_types_r(data.metadata);
+            }
+            
             // append with dynamic=false.
-            this.append_output(outputs[i], false);
+            this.append_output(data, false);
         }
     };
 

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -498,9 +498,19 @@ var IPython = (function (IPython) {
             var type = OutputArea.display_order[type_i];
             if(json[type] != undefined ){
                 var md = {};
-                if (json.metadata && json.metadata[type]) {
-                    md = json.metadata[type];
-                };
+                if (json.metadata) {
+                    md = json.metadata;
+                    if (json.metadata[type]) {
+                        // XXX: need some sort of dict.update, style here if
+                        // we want to support the merging of the overall
+                        // metadata with the mimetype specific metadata.  For
+                        // now, they are mutually exclusive - if the
+                        // mimetype-keyed metadata exists, *it* is used,
+                        // otherwise, only the message-wide metadata is
+                        // available.
+                        md = json.metadata[type];
+                    }
+                }
                 if(type == 'javascript'){
                     if (dynamic) {
                         this.append_javascript(json.javascript, md, element, dynamic);

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -616,7 +616,7 @@ var IPython = (function (IPython) {
     OutputArea.prototype.append_png = function (png, md, element, type) {
         var toinsert = this.create_output_subarea(md, "output_png", type);
         var img = $("<img/>");
-        img[0].attr('src','data:image/png;base64,'+png);
+        img[0].setAttribute('src','data:image/png;base64,'+png);
         if (md['height']) {
             img[0].setAttribute('height', md['height']);
         }

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -278,17 +278,18 @@ var IPython = (function (IPython) {
         "javascript" : "application/javascript",
     };
 
-    OutputArea.prototype.convert_mime_types = function (json, data) {
-        if (!data) {
-            return json;
-        }
-        // non-mimetype-keyed metadata used to get dropped here, this code
-        // re-injects it into the json.
+    OutputArea.prototype.convert_mime_types = function (data) {
         for (var key in data) {
-            var rkey = OutputArea.mime_map_r[key] || key;
-            json[rkey] = data[key];
+            var json_key = OutputArea.mime_map[key] || key;
+            console.log("converting ", key, "to", json_key)
+            if (json_key !== key) {
+                // move mime-type keys to short name
+                console.log("converting ", key, "to", json_key)
+                data[json_key] = data[key];
+                delete data[key];
+            }
         }
-        return json;
+        return data;
     };
     
     OutputArea.prototype.convert_mime_types_r = function (data) {
@@ -756,10 +757,10 @@ var IPython = (function (IPython) {
         // TODO: remove this when we update to nbformat 4
         var len = outputs.length;
         for (var i=0; i<len; i++) {
-            // convert mime keys 
             var data = outputs[i];
             var msg_type = data.output_type;
             if (msg_type === "display_data" || msg_type === "pyout") {
+                // convert short keys to mime keys
                  this.convert_mime_types_r(data);
                  this.convert_mime_types_r(data.metadata);
             }
@@ -774,7 +775,15 @@ var IPython = (function (IPython) {
         var outputs = [];
         var len = this.outputs.length;
         for (var i=0; i<len; i++) {
-            outputs[i] = this.outputs[i];
+            var data = this.outputs[i];
+            var msg_type = data.output_type;
+            console.log("msg type is  ", msg_type)
+            if (msg_type === "display_data" || msg_type === "pyout") {
+                  // convert mime keys to short keys
+                 this.convert_mime_types(data);
+                 //this.convert_mime_types(data.metadata);
+            }
+            outputs[i] = data;
         }
         return outputs;
     };

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -239,12 +239,14 @@ var IPython = (function (IPython) {
             json.text = content.data;
             json.stream = content.name;
         } else if (msg_type === "display_data") {
-            json = this.convert_mime_types(json, content.data);
-            json.metadata = this.convert_mime_types({}, content.metadata);
+            json = content.data
+            json.output_type = msg_type
+            json.metadata = content.metadata
         } else if (msg_type === "pyout") {
+            json = content.data
+            json.output_type = msg_type
+            json.metadata = content.metadata
             json.prompt_number = content.execution_count;
-            json = this.convert_mime_types(json, content.data);
-            json.metadata = this.convert_mime_types({}, content.metadata);
         } else if (msg_type === "pyerr") {
             json.ename = content.ename;
             json.evalue = content.evalue;

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -279,15 +279,12 @@ var IPython = (function (IPython) {
     };
 
     OutputArea.prototype.rename_keys = function (data, key_map) {
+        var remapped = {};
         for (var key in data) {
             var new_key = key_map[key] || key;
-            if (new_key !== key) {
-                // move mime-type keys to short name
-                data[new_key] = data[key];
-                delete data[key];
-            }
+            remapped[new_key] = data[key];
         }
-        return data;
+        return remapped;
     };
     
 
@@ -742,13 +739,13 @@ var IPython = (function (IPython) {
         // add here the mapping of short key to mime type
         // TODO: remove this when we update to nbformat 4
         var len = outputs.length;
+        var data;
         for (var i=0; i<len; i++) {
-            var data = outputs[i];
-            var msg_type = data.output_type;
+            var msg_type = outputs[i].output_type;
             if (msg_type === "display_data" || msg_type === "pyout") {
                 // convert short keys to mime keys
-                 this.rename_keys(data, OutputArea.mime_map_r);
-                 this.rename_keys(data.metadata, OutputArea.mime_map_r);
+                 data = this.rename_keys(outputs[i], OutputArea.mime_map_r);
+                 data.metadata = this.rename_keys(outputs[i].metadata, OutputArea.mime_map_r);
             }
             
             // append with dynamic=false.
@@ -760,14 +757,14 @@ var IPython = (function (IPython) {
     OutputArea.prototype.toJSON = function () {
         var outputs = [];
         var len = this.outputs.length;
+        var data;
         for (var i=0; i<len; i++) {
-            var data = this.outputs[i];
-            var msg_type = data.output_type;
+            var msg_type = this.outputs[i].output_type;
             console.log("msg type is  ", msg_type)
             if (msg_type === "display_data" || msg_type === "pyout") {
                   // convert mime keys to short keys
-                 this.rename_keys(data, OutputArea.mime_map);
-                 this.rename_keys(data.metadata, OutputArea.mime_map);
+                 data = this.rename_keys(this.outputs[i], OutputArea.mime_map);
+                 data.metadata = this.rename_keys(this.outputs[i], OutputArea.mime_map);
             }
             outputs[i] = data;
         }

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -239,13 +239,13 @@ var IPython = (function (IPython) {
             json.text = content.data;
             json.stream = content.name;
         } else if (msg_type === "display_data") {
-            json = content.data
-            json.output_type = msg_type
-            json.metadata = content.metadata
+            json = content.data;
+            json.output_type = msg_type;
+            json.metadata = content.metadata;
         } else if (msg_type === "pyout") {
-            json = content.data
-            json.output_type = msg_type
-            json.metadata = content.metadata
+            json = content.data;
+            json.output_type = msg_type;
+            json.metadata = content.metadata;
             json.prompt_number = content.execution_count;
         } else if (msg_type === "pyerr") {
             json.ename = content.ename;
@@ -506,11 +506,8 @@ var IPython = (function (IPython) {
 
         for(var type_i in OutputArea.display_order){
             var type = OutputArea.display_order[type_i];
-            if(json[type] != undefined ){
-                var md = {};
-                if (json.metadata) {
-                    md = json.metadata;
-                }
+            if(json[type] !== undefined ){
+                md = json.metadata || {};
                 if(type == 'javascript'){
                     if (dynamic) {
                         this.append_javascript(json.javascript, md, element, dynamic);

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -254,6 +254,9 @@ var IPython = (function (IPython) {
         this.append_output(json, true);
     };
 
+    var mime_types = ['application/javascript', 'application/json',
+               'image/jpeg', 'image/png', 'image/svg+xml', 'text/html',
+               'text/latex', 'text/plain'];
 
     OutputArea.prototype.convert_mime_types = function (json, data) {
         if (data === undefined) {
@@ -282,6 +285,13 @@ var IPython = (function (IPython) {
         }
         if (data['application/javascript'] !== undefined) {
             json.javascript = data['application/javascript'];
+        }
+        // non-mimetype-keyed metadata used to get dropped here, this code
+        // re-injects it into the json.
+        for (x in data){
+            if( !(x in mime_types) ) {
+                json[x] = data[x];
+            }
         }
         return json;
     };

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -264,6 +264,17 @@ var IPython = (function (IPython) {
         "application/json" : "json",
         "application/javascript" : "javascript",
     };
+    
+    OutputArea.mime_map_r = {
+        "text" : "text/plain",
+        "html" : "text/html",
+        "svg" : "image/svg+xml",
+        "png" : "image/png",
+        "jpeg" : "image/jpeg",
+        "latex" : "text/latex",
+        "json" : "application/json",
+        "javascript" : "application/javascript",
+    };
 
     OutputArea.prototype.convert_mime_types = function (json, data) {
         if (!data) {
@@ -272,8 +283,8 @@ var IPython = (function (IPython) {
         // non-mimetype-keyed metadata used to get dropped here, this code
         // re-injects it into the json.
         for (var key in data) {
-            var json_key = OutputArea.mime_map[key] || key;
-            json[json_key] = data[key];
+            var rkey = OutputArea.mime_map_r[key] || key;
+            json[rkey] = data[key];
         }
         return json;
     };
@@ -328,7 +339,6 @@ var IPython = (function (IPython) {
             return mime_md[key];
         }
         // fallback on global
-        console.log("fallback" + key + "   "+ metadata[key]);
         return metadata[key];
     }
 
@@ -485,7 +495,15 @@ var IPython = (function (IPython) {
         }
     };
 
-    OutputArea.display_order = ['javascript','html','latex','svg','png','jpeg','text'];
+    OutputArea.display_order = [
+        'application/javascript',
+        'text/html',
+        'text/latex',
+        'image/svg+xml',
+        'image/png',
+        'image/jpeg',
+        'text/plain'
+    ];
 
     OutputArea.prototype.append_mime_type = function (json, element, dynamic) {
 
@@ -502,7 +520,8 @@ var IPython = (function (IPython) {
                         return true;
                     }
                 } else {
-                    this['append_'+type](json[type], md, element);
+                    var old_name = OutputArea.mime_map[type]
+                    this['append_'+old_name](json[type], md, element, type);
                     return true;
                 }
                 return false;

--- a/IPython/html/tests/casperjs/test_cases/isolated_svg.js
+++ b/IPython/html/tests/casperjs/test_cases/isolated_svg.js
@@ -69,13 +69,16 @@ casper.notebook_test(function () {
     // now ensure that we can pass the same metadata dict to plain old display()
     this.thenEvaluate(function () {
         var cell = IPython.notebook.get_cell(0);
+        cell.clear_output();
         cell.set_text( "from IPython.display import display\n"
                      + "display(SVG(s1), metadata=dict(isolated=True))\n"
                      + "display(SVG(s2), metadata=dict(isolated=True))\n"
             );
         cell.execute();
     });
-   
+
+    this.wait_for_output(0);
+
     // same test as original
     this.then(function () {
         var colors = this.evaluate(function () {

--- a/IPython/html/tests/casperjs/test_cases/isolated_svg.js
+++ b/IPython/html/tests/casperjs/test_cases/isolated_svg.js
@@ -62,8 +62,8 @@ casper.notebook_test(function () {
             return colors;
         });
 
-        this.test.assertEquals(colors[0], '#ff0000', 'First svg should be red');
-        this.test.assertEquals(colors[1], '#000000', 'Second svg should be black');
+        this.test.assertEquals(colors && colors[0], '#ff0000', 'display_svg() First svg should be red');
+        this.test.assertEquals(colors && colors[1], '#000000', 'display_svg() Second svg should be black');
     });
 
     // now ensure that we can pass the same metadata dict to plain old display()
@@ -91,7 +91,7 @@ casper.notebook_test(function () {
             return colors;
         });
 
-        this.test.assertEquals(colors[0], '#ff0000', 'First svg should be red');
-        this.test.assertEquals(colors[1], '#000000', 'Second svg should be black');
+        this.test.assertEquals(colors && colors[0], '#ff0000', 'display() First svg should be red');
+        this.test.assertEquals(colors && colors[1], '#000000', 'display() Second svg should be black');
     });
 });

--- a/IPython/html/tests/casperjs/test_cases/isolated_svg.js
+++ b/IPython/html/tests/casperjs/test_cases/isolated_svg.js
@@ -21,6 +21,32 @@ casper.notebook_test(function () {
                      + "display_svg(SVG(s2), metadata=dict(isolated=True))\n"
             );
         cell.execute();
+        console.log("hello" );
+    });
+
+    this.then(function() {
+        var fname=this.test.currentTestFile.split('/').pop().toLowerCase();
+        this.echo(fname)
+        this.echo(this.currentUrl)
+        this.evaluate(function (n) {
+            IPython.notebook.rename(n);
+            console.write("hello" + n);
+            IPython.notebook.save_notebook();
+        }, {n : fname});
+        this.echo(this.currentUrl)
+    });
+
+    this.then(function() {
+    
+        url = this.evaluate(function() {
+            IPython.notebook.rename("foo");
+            //$("span#notebook_name")[0].click();
+            //$("input")[0].value = "please-work";
+            //$(".btn-primary")[0].click();
+            return document.location.href;
+        })
+        this.echo("renamed" + url);
+        this.echo(this.currentUrl);
     });
 
     this.wait_for_output(0);

--- a/IPython/html/tests/casperjs/test_cases/isolated_svg.js
+++ b/IPython/html/tests/casperjs/test_cases/isolated_svg.js
@@ -1,5 +1,5 @@
 //
-// Test svg isolation
+// Test display isolation
 // An object whose metadata contains an "isolated" tag must be isolated
 // from the rest of the document. In the case of inline SVGs, this means
 // that multiple SVGs have different scopes. This test checks that there
@@ -25,6 +25,32 @@ casper.notebook_test(function () {
 
     this.wait_for_output(0);
 
+    this.then(function () {
+        var colors = this.evaluate(function () {
+            var colors = [];
+            var ifr = __utils__.findAll("iframe");
+            var svg1 = ifr[0].contentWindow.document.getElementById('r1');
+            colors[0] = window.getComputedStyle(svg1)["fill"];
+            var svg2 = ifr[1].contentWindow.document.getElementById('r2');
+            colors[1] = window.getComputedStyle(svg2)["fill"];
+            return colors;
+        });
+
+        this.test.assertEquals(colors[0], '#ff0000', 'First svg should be red');
+        this.test.assertEquals(colors[1], '#000000', 'Second svg should be black');
+    });
+
+    // now ensure that we can pass the same metadata dict to plain old display()
+    this.thenEvaluate(function () {
+        var cell = IPython.notebook.get_cell(0);
+        cell.set_text( "from IPython.display import display\n"
+                     + "display(SVG(s1), metadata=dict(isolated=True))\n"
+                     + "display(SVG(s2), metadata=dict(isolated=True))\n"
+            );
+        cell.execute();
+    });
+   
+    // same test as original
     this.then(function () {
         var colors = this.evaluate(function () {
             var colors = [];

--- a/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
+++ b/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
@@ -7,7 +7,7 @@ casper.notebook_test(function () {
         // "we have to make messes to find out who we are"
         cell.set_text([
             "%%javascript",
-            "IPython.notebook.insert_cell_above('code')"
+            "IPython.notebook.insert_cell_below('code')"
             ].join('\n')
             );
 
@@ -17,14 +17,36 @@ casper.notebook_test(function () {
     this.wait_for_output(0);
 
     this.then(function ( ) {
-        var result = this.get_output_cell(1);
+        var result = this.get_output_cell(0);
         var num_cells = this.get_cells_length();
         this.test.assertEquals(num_cells, 2, '%%javascript magic works');
-        this.test.assertTrue(result.hasOwnProperty('application/javascript'), 'JS embeded with mime key');
+        this.test.assertTrue(result.hasOwnProperty('application/javascript'),
+            'JS embeded with mime key');
+    });
+
+    //this.thenEvaluate(function() { IPython.notebook.save_notebook(); });
+
+    this.then(function ( ) {
+        json = this.evaluate(function() {
+            // the appended cell will initiall be empty
+            var json = IPython.notebook.get_cell(0).output_area.toJSON();
+            var cell = IPython.notebook.get_cell(1).output_area.fromJSON(json);
+            return json;
+        });
+        var result = this.get_output_cell(0);
+        var result2 = this.get_output_cell(1);
+        this.test.assertTrue(result.hasOwnProperty('application/javascript'),
+            'embeded JS keeps mime key after save');
+        this.test.assertTrue(json[0].hasOwnProperty('javascript'),
+            'JSON representation uses short keys');
+        this.test.assertTrue(result2.hasOwnProperty('application/javascript'),
+            'embeded JS keeps mime key on fromJSON');
+
     });
 
 
-    //this.thenEvaluate(function () { var cell = IPython.notebook.get_cell(0);
+    //this.thenEvaluate(function () { 
+    //var cell = IPython.notebook.get_cell(0);
 
     //    // we have to make messes to find out who we are
     //    cell.set_text([
@@ -37,12 +59,5 @@ casper.notebook_test(function () {
     //});
     //
     //this.wait_for_output(0);
-
-    //this.then(function ( ) {
-    //    var result = this.get_output_cell(0);
-    //    var num_cells = this.get_cells_length();
-    //    this.test.assertEquals(result.text, '10\n', 'opening notebook JSON');
-    //    this.test.assertEquals(num_cells, 2, '              %%javascript magic works')
-    //});
 
 });

--- a/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
+++ b/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
@@ -17,7 +17,7 @@ mime =  {
     
 var black_dot_jpeg="\"\"\"/9j/4AAQSkZJRgABAQEASABIAAD/2wBDACodICUgGiolIiUvLSoyP2lEPzo6P4FcYUxpmYagnpaG\nk5GovfLNqLPltZGT0v/V5fr/////o8v///////L/////2wBDAS0vLz83P3xERHz/rpOu////////\n////////////////////////////////////////////////////////////wgARCAABAAEDAREA\nAhEBAxEB/8QAFAABAAAAAAAAAAAAAAAAAAAABP/EABQBAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEA\nAhADEAAAARn/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAEFAn//xAAUEQEAAAAAAAAAAAAA\nAAAAAAAA/9oACAEDAQE/AX//xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/AX//xAAUEAEA\nAAAAAAAAAAAAAAAAAAAA/9oACAEBAAY/An//xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/\nIX//2gAMAwEAAgADAAAAEB//xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAEDAQE/EH//xAAUEQEA\nAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/EH//xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/\nEH//2Q==\"\"\"";
 var black_dot_png = '\"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAWJLR0QA\\niAUdSAAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB94BCRQnOqNu0b4AAAAKSURBVAjXY2AA\\nAAACAAHiIbwzAAAAAElFTkSuQmCC\"';
-var svg = "\"<svg width='1cm' height='1cm' viewBox='0 0 1000 500'><defs><style>rect {fill:red;}; </style></defs><rect id='r1' x='200' y='100' width='600' height='300' /></svg>\""
+var svg = "\"<svg width='1cm' height='1cm' viewBox='0 0 1000 500'><defs><style>rect {fill:red;}; </style></defs><rect id='r1' x='200' y='100' width='600' height='300' /></svg>\"";
 
 // helper function to ensure that the short_name is found in the toJSON
 // represetnation, while the original in-memory cell retains its long mimetype
@@ -207,5 +207,29 @@ casper.notebook_test(function () {
     });
     
     this.thenEvaluate(function() { IPython.notebook.save_notebook(); });
- 
+
+    this.then(function() {
+        clear_and_execute(this, [
+            "from IPython.core.formatters import HTMLFormatter",
+            "x = HTMLFormatter()",
+            "x.format_type = 'text/superfancymimetype'",
+            "get_ipython().display_formatter.formatters['text/superfancymimetype'] = x",
+            "from IPython.display import HTML, display",
+            'display(HTML("yo"))',
+            "HTML('hello')"].join('\n')
+            );
+             
+    });
+    
+    this.then(function ( ) {
+        var long_name = 'text/superfancymimetype';
+        var result = this.get_output_cell(0);
+        this.test.assertTrue(result.hasOwnProperty(long_name),
+            'display_data custom mimetype ' + long_name);
+        var result = this.get_output_cell(0, 1);
+        this.test.assertTrue(result.hasOwnProperty(long_name),
+            'pyout custom mimetype ' + long_name);
+    
+    });
+    
 });

--- a/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
+++ b/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
@@ -1,0 +1,48 @@
+// Test opening a rich notebook, saving it, and reopening it again.
+//
+//toJSON fromJSON toJSON and do a string comparison
+casper.notebook_test(function () {
+    this.evaluate(function () {
+        var cell = IPython.notebook.get_cell(0);
+        // "we have to make messes to find out who we are"
+        cell.set_text([
+            "%%javascript",
+            "IPython.notebook.insert_cell_above('code')"
+            ].join('\n')
+            );
+
+        cell.execute();
+    });
+    
+    this.wait_for_output(0);
+
+    this.then(function ( ) {
+        var result = this.get_output_cell(1);
+        var num_cells = this.get_cells_length();
+        this.test.assertEquals(num_cells, 2, '%%javascript magic works');
+        this.test.assertTrue(result.hasOwnProperty('application/javascript'), 'JS embeded with mime key');
+    });
+
+
+    //this.thenEvaluate(function () { var cell = IPython.notebook.get_cell(0);
+
+    //    // we have to make messes to find out who we are
+    //    cell.set_text([
+    //        "import IPython.html.tests as t",
+    //        "t.write_test_notebook('rich_output.ipynb')"
+    //        ].join('\n')
+    //        );
+
+    //    cell.execute();
+    //});
+    //
+    //this.wait_for_output(0);
+
+    //this.then(function ( ) {
+    //    var result = this.get_output_cell(0);
+    //    var num_cells = this.get_cells_length();
+    //    this.test.assertEquals(result.text, '10\n', 'opening notebook JSON');
+    //    this.test.assertEquals(num_cells, 2, '              %%javascript magic works')
+    //});
+
+});

--- a/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
+++ b/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
@@ -17,6 +17,7 @@ mime =  {
     
 var black_dot_jpeg="\"\"\"/9j/4AAQSkZJRgABAQEASABIAAD/2wBDACodICUgGiolIiUvLSoyP2lEPzo6P4FcYUxpmYagnpaG\nk5GovfLNqLPltZGT0v/V5fr/////o8v///////L/////2wBDAS0vLz83P3xERHz/rpOu////////\n////////////////////////////////////////////////////////////wgARCAABAAEDAREA\nAhEBAxEB/8QAFAABAAAAAAAAAAAAAAAAAAAABP/EABQBAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEA\nAhADEAAAARn/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAEFAn//xAAUEQEAAAAAAAAAAAAA\nAAAAAAAA/9oACAEDAQE/AX//xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/AX//xAAUEAEA\nAAAAAAAAAAAAAAAAAAAA/9oACAEBAAY/An//xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/\nIX//2gAMAwEAAgADAAAAEB//xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAEDAQE/EH//xAAUEQEA\nAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/EH//xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/\nEH//2Q==\"\"\"";
 var black_dot_png = '\"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAWJLR0QA\\niAUdSAAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB94BCRQnOqNu0b4AAAAKSURBVAjXY2AA\\nAAACAAHiIbwzAAAAAElFTkSuQmCC\"';
+var svg = "\"<svg width='1cm' height='1cm' viewBox='0 0 1000 500'><defs><style>rect {fill:red;}; </style></defs><rect id='r1' x='200' y='100' width='600' height='300' /></svg>\""
 
 // helper function to ensure that the short_name is found in the toJSON
 // represetnation, while the original in-memory cell retains its long mimetype
@@ -186,4 +187,25 @@ casper.notebook_test(function () {
     this.then(function ( ) {
         check_output_area.apply(this, ['display_data', ['text', 'jpeg']]);
     });
+    
+    this.then(function() {
+        clear_and_execute(this,
+            "from IPython.core.display import SVG; SVG(" + svg + ")");
+    });
+    
+    this.then(function ( ) {
+        check_output_area.apply(this, ['pyout', ['text', 'svg']]);
+    });
+
+    this.then(function() {
+        clear_and_execute(this,
+            "from IPython.core.display import SVG, display; display(SVG(" + svg + "))");
+    });
+    
+    this.then(function ( ) {
+        check_output_area.apply(this, ['display_data', ['text', 'svg']]);
+    });
+    
+    this.thenEvaluate(function() { IPython.notebook.save_notebook(); });
+ 
 });

--- a/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
+++ b/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
@@ -108,5 +108,23 @@ casper.notebook_test(function () {
     this.then(function ( ) {
         check_output_area.apply(this, ['display_data', ['text', 'json']]);
     });
+    
+    this.then(function() {
+        clear_and_execute(this,
+            "from IPython.display import Latex; Latex('$X^2$')");
+    });
+    
+    this.then(function ( ) {
+        check_output_area.apply(this, ['pyout', ['text', 'latex']]);
+    });
+
+    this.then(function() {
+        clear_and_execute(this,
+            "from IPython.display import Latex, display; display(Latex('$X^2$'))");
+    });
+    
+    this.then(function ( ) {
+        check_output_area.apply(this, ['display_data', ['text', 'latex']]);
+    });
 
 });

--- a/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
+++ b/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
@@ -13,7 +13,7 @@ casper.notebook_test(function () {
 
         cell.execute();
     });
-    
+
     this.wait_for_output(0);
 
     this.then(function ( ) {
@@ -44,8 +44,68 @@ casper.notebook_test(function () {
 
     });
 
+    this.then(function() {
+        // test output of text/plain and application/json keys
+        this.evaluate(function() {
+            IPython.notebook.get_cell(0).clear_output();
+            IPython.notebook.get_cell(1).clear_output();
+        });
+        this.set_cell_text(0, "%lsmagic");
+        this.execute_cell(0);
+    });
 
-    //this.thenEvaluate(function () { 
+    this.then(function ( ) {
+        json = this.evaluate(function() {
+            var json = IPython.notebook.get_cell(0).output_area.toJSON();
+            // appended cell will initially be empty, lets add it some output
+            var cell = IPython.notebook.get_cell(1).output_area.fromJSON(json);
+            return json;
+        });
+        var result = this.get_output_cell(0);
+        var result2 = this.get_output_cell(1);
+        this.test.assertEquals(result.output_type, 'pyout',
+            'testing pyout application/json and text/plain');
+        this.test.assertTrue(result.hasOwnProperty('application/json'),
+            'toJSON() original embeded JSON keeps mime key');
+        this.test.assertTrue(json[0].hasOwnProperty('json'),
+            'toJSON() representation uses short key');
+        this.test.assertTrue(result2.hasOwnProperty('application/json'),
+            'fromJSON() embeded JS gets mime key');
+
+    });
+    this.then(function() {
+        // test display of text/plain and application/json keys
+        this.evaluate(function() {
+            IPython.notebook.get_cell(0).clear_output();
+            IPython.notebook.get_cell(1).clear_output();
+        });
+        this.set_cell_text(0,
+            "x = %lsmagic\nfrom IPython.display import display; display(x)");
+        this.execute_cell(0);
+    });
+
+    this.then(function ( ) {
+        json = this.evaluate(function() {
+            var json = IPython.notebook.get_cell(0).output_area.toJSON();
+            // appended cell will initially be empty, lets add it some output
+            var cell = IPython.notebook.get_cell(1).output_area.fromJSON(json);
+            return json;
+        });
+        var result = this.get_output_cell(0);
+        var result2 = this.get_output_cell(1);
+        this.test.assertEquals(result.output_type, 'display_data',
+            'testing display_data application/json and text/plain');
+        this.test.assertTrue(result.hasOwnProperty('text/plain'),
+            'toJSON()\t original embeded text keeps mime key');
+        this.test.assertTrue(json[0].hasOwnProperty('text'),
+            'toJSON()\t representation uses short key');
+        this.test.assertTrue(result2.hasOwnProperty('text/plain'),
+            'fromJSON()\t embeded text gets mime key');
+
+    });
+
+
+    //this.thenEvaluate(function () {
     //var cell = IPython.notebook.get_cell(0);
 
     //    // we have to make messes to find out who we are

--- a/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
+++ b/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
@@ -17,10 +17,10 @@ mime =  {
     
 function assert_has(short_name, json, result, result2) {
     long_name = mime[short_name];
-    this.test.assertTrue(result.hasOwnProperty(long_name),
-            'toJSON()   original embeded JSON keeps ' + long_name);
     this.test.assertTrue(json[0].hasOwnProperty(short_name),
             'toJSON()   representation uses ' + short_name);
+    this.test.assertTrue(result.hasOwnProperty(long_name),
+            'toJSON()   original embeded JSON keeps ' + long_name);
     this.test.assertTrue(result2.hasOwnProperty(long_name),
             'fromJSON() embeded ' + short_name + ' gets mime key ' + long_name);
 }
@@ -45,7 +45,7 @@ casper.notebook_test(function () {
         var num_cells = this.get_cells_length();
         this.test.assertEquals(num_cells, 2, '%%javascript magic works');
         this.test.assertTrue(result.hasOwnProperty('application/javascript'),
-            'JS embeded with mime key');
+            'testing JS embeded with mime key');
     });
 
     //this.thenEvaluate(function() { IPython.notebook.save_notebook(); });

--- a/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
+++ b/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
@@ -33,6 +33,7 @@ function assert_has(short_name, json, result, result2) {
 // for a set of mimetype keys, using their short names ('javascript', 'text',
 // 'png', etc).
 function check_output_area(output_type, keys) {
+    this.wait_for_output(0);
     json = this.evaluate(function() {
         var json = IPython.notebook.get_cell(0).output_area.toJSON();
         // appended cell will initially be empty, lets add it some output
@@ -102,7 +103,6 @@ casper.notebook_test(function () {
     this.then(function() {
         clear_and_execute(this,
             "x = %lsmagic\nfrom IPython.display import display; display(x)");
-        this.execute_cell(0);
     });
 
     this.then(function ( ) {
@@ -145,4 +145,22 @@ casper.notebook_test(function () {
         check_output_area.apply(this, ['display_data', ['text', 'html']]);
     });
 
+
+    this.then(function() {
+        clear_and_execute(this,
+            "from IPython.display import Image; Image('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAWJLR0QA\\niAUdSAAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB94BCRQnOqNu0b4AAAAKSURBVAjXY2AA\\nAAACAAHiIbwzAAAAAElFTkSuQmCC')");
+    });
+    
+    this.then(function ( ) {
+        check_output_area.apply(this, ['pyout', ['text', 'png']]);
+    });
+    
+    this.then(function() {
+        clear_and_execute(this,
+            "from IPython.display import Image, display; display(Image('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAWJLR0QA\\niAUdSAAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB94BCRQnOqNu0b4AAAAKSURBVAjXY2AA\\nAAACAAHiIbwzAAAAAElFTkSuQmCC'))");
+    });
+    
+    this.then(function ( ) {
+        check_output_area.apply(this, ['display_data', ['text', 'png']]);
+    });
 });

--- a/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
+++ b/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
@@ -49,6 +49,18 @@ function check_output_area(output_type, keys) {
     }
 }
 
+
+// helper function to clear the first two cells, set the text of and execute
+// the first one
+function clear_and_execute(that, code) {
+    that.evaluate(function() {
+        IPython.notebook.get_cell(0).clear_output();
+        IPython.notebook.get_cell(1).clear_output();
+    });
+    that.set_cell_text(0, code);
+    that.execute_cell(0);
+}
+
 casper.notebook_test(function () {
     this.evaluate(function () {
         var cell = IPython.notebook.get_cell(0);
@@ -80,13 +92,7 @@ casper.notebook_test(function () {
     });
 
     this.then(function() {
-        // test output of text/plain and application/json keys
-        this.evaluate(function() {
-            IPython.notebook.get_cell(0).clear_output();
-            IPython.notebook.get_cell(1).clear_output();
-        });
-        this.set_cell_text(0, "%lsmagic");
-        this.execute_cell(0);
+        clear_and_execute(this, '%lsmagic');
     });
    
     this.then(function () {
@@ -94,12 +100,7 @@ casper.notebook_test(function () {
     });
 
     this.then(function() {
-        // test display of text/plain and application/json keys
-        this.evaluate(function() {
-            IPython.notebook.get_cell(0).clear_output();
-            IPython.notebook.get_cell(1).clear_output();
-        });
-        this.set_cell_text(0,
+        clear_and_execute(this,
             "x = %lsmagic\nfrom IPython.display import display; display(x)");
         this.execute_cell(0);
     });

--- a/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
+++ b/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
@@ -126,5 +126,23 @@ casper.notebook_test(function () {
     this.then(function ( ) {
         check_output_area.apply(this, ['display_data', ['text', 'latex']]);
     });
+    
+    this.then(function() {
+        clear_and_execute(this,
+            "from IPython.display import HTML; HTML('<b>it works!</b>')");
+    });
+    
+    this.then(function ( ) {
+        check_output_area.apply(this, ['pyout', ['text', 'html']]);
+    });
+
+    this.then(function() {
+        clear_and_execute(this,
+            "from IPython.display import HTML, display; display(HTML('<b>it works!</b>'))");
+    });
+    
+    this.then(function ( ) {
+        check_output_area.apply(this, ['display_data', ['text', 'html']]);
+    });
 
 });

--- a/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
+++ b/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
@@ -28,19 +28,19 @@ casper.notebook_test(function () {
 
     this.then(function ( ) {
         json = this.evaluate(function() {
-            // the appended cell will initiall be empty
             var json = IPython.notebook.get_cell(0).output_area.toJSON();
+            // appended cell will initially be empty, lets add it some output
             var cell = IPython.notebook.get_cell(1).output_area.fromJSON(json);
             return json;
         });
         var result = this.get_output_cell(0);
         var result2 = this.get_output_cell(1);
         this.test.assertTrue(result.hasOwnProperty('application/javascript'),
-            'embeded JS keeps mime key after save');
+            'toJSON() original embeded JS keeps mime key');
         this.test.assertTrue(json[0].hasOwnProperty('javascript'),
-            'JSON representation uses short keys');
+            'toJSON() representation uses short key');
         this.test.assertTrue(result2.hasOwnProperty('application/javascript'),
-            'embeded JS keeps mime key on fromJSON');
+            'fromJSON() embeded JS gets mime key');
 
     });
 

--- a/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
+++ b/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
@@ -15,6 +15,9 @@ mime =  {
         "javascript" : "application/javascript",
     };
     
+var black_dot_jpeg="\"\"\"/9j/4AAQSkZJRgABAQEASABIAAD/2wBDACodICUgGiolIiUvLSoyP2lEPzo6P4FcYUxpmYagnpaG\nk5GovfLNqLPltZGT0v/V5fr/////o8v///////L/////2wBDAS0vLz83P3xERHz/rpOu////////\n////////////////////////////////////////////////////////////wgARCAABAAEDAREA\nAhEBAxEB/8QAFAABAAAAAAAAAAAAAAAAAAAABP/EABQBAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEA\nAhADEAAAARn/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAEFAn//xAAUEQEAAAAAAAAAAAAA\nAAAAAAAA/9oACAEDAQE/AX//xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/AX//xAAUEAEA\nAAAAAAAAAAAAAAAAAAAA/9oACAEBAAY/An//xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/\nIX//2gAMAwEAAgADAAAAEB//xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAEDAQE/EH//xAAUEQEA\nAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/EH//xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/\nEH//2Q==\"\"\"";
+var black_dot_png = '\"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAWJLR0QA\\niAUdSAAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB94BCRQnOqNu0b4AAAAKSURBVAjXY2AA\\nAAACAAHiIbwzAAAAAElFTkSuQmCC\"';
+
 // helper function to ensure that the short_name is found in the toJSON
 // represetnation, while the original in-memory cell retains its long mimetype
 // name, and that fromJSON also gets its long mimetype name
@@ -148,8 +151,9 @@ casper.notebook_test(function () {
 
     this.then(function() {
         clear_and_execute(this,
-            "from IPython.display import Image; Image('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAWJLR0QA\\niAUdSAAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB94BCRQnOqNu0b4AAAAKSURBVAjXY2AA\\nAAACAAHiIbwzAAAAAElFTkSuQmCC')");
+            "from IPython.display import Image; Image(" + black_dot_png + ")");
     });
+    this.thenEvaluate(function() { IPython.notebook.save_notebook(); });
     
     this.then(function ( ) {
         check_output_area.apply(this, ['pyout', ['text', 'png']]);
@@ -157,10 +161,29 @@ casper.notebook_test(function () {
     
     this.then(function() {
         clear_and_execute(this,
-            "from IPython.display import Image, display; display(Image('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAWJLR0QA\\niAUdSAAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB94BCRQnOqNu0b4AAAAKSURBVAjXY2AA\\nAAACAAHiIbwzAAAAAElFTkSuQmCC'))");
+            "from IPython.display import Image, display; display(Image(" + black_dot_png + "))");
     });
     
     this.then(function ( ) {
         check_output_area.apply(this, ['display_data', ['text', 'png']]);
+    });
+
+
+    this.then(function() {
+        clear_and_execute(this,
+            "from IPython.display import Image; Image(" + black_dot_jpeg + ", format='jpeg')");
+    });
+    
+    this.then(function ( ) {
+        check_output_area.apply(this, ['pyout', ['text', 'jpeg']]);
+    });
+    
+    this.then(function() {
+        clear_and_execute(this,
+            "from IPython.display import Image, display; display(Image(" + black_dot_jpeg + ", format='jpeg'))");
+    });
+    
+    this.then(function ( ) {
+        check_output_area.apply(this, ['display_data', ['text', 'jpeg']]);
     });
 });

--- a/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
+++ b/IPython/html/tests/casperjs/test_cases/nb_roundtrip.js
@@ -1,6 +1,30 @@
 // Test opening a rich notebook, saving it, and reopening it again.
 //
 //toJSON fromJSON toJSON and do a string comparison
+
+
+// this is just a copy of OutputArea.mime_mape_r in IPython/html/static/notebook/js/outputarea.js
+mime =  {
+        "text" : "text/plain",
+        "html" : "text/html",
+        "svg" : "image/svg+xml",
+        "png" : "image/png",
+        "jpeg" : "image/jpeg",
+        "latex" : "text/latex",
+        "json" : "application/json",
+        "javascript" : "application/javascript",
+    };
+    
+function assert_has(short_name, json, result, result2) {
+    long_name = mime[short_name];
+    this.test.assertTrue(result.hasOwnProperty(long_name),
+            'toJSON()   original embeded JSON keeps ' + long_name);
+    this.test.assertTrue(json[0].hasOwnProperty(short_name),
+            'toJSON()   representation uses ' + short_name);
+    this.test.assertTrue(result2.hasOwnProperty(long_name),
+            'fromJSON() embeded ' + short_name + ' gets mime key ' + long_name);
+}
+
 casper.notebook_test(function () {
     this.evaluate(function () {
         var cell = IPython.notebook.get_cell(0);
@@ -35,12 +59,8 @@ casper.notebook_test(function () {
         });
         var result = this.get_output_cell(0);
         var result2 = this.get_output_cell(1);
-        this.test.assertTrue(result.hasOwnProperty('application/javascript'),
-            'toJSON() original embeded JS keeps mime key');
-        this.test.assertTrue(json[0].hasOwnProperty('javascript'),
-            'toJSON() representation uses short key');
-        this.test.assertTrue(result2.hasOwnProperty('application/javascript'),
-            'fromJSON() embeded JS gets mime key');
+
+        assert_has.apply(this, ['javascript', json, result, result2]);
 
     });
 
@@ -53,7 +73,7 @@ casper.notebook_test(function () {
         this.set_cell_text(0, "%lsmagic");
         this.execute_cell(0);
     });
-
+   
     this.then(function ( ) {
         json = this.evaluate(function() {
             var json = IPython.notebook.get_cell(0).output_area.toJSON();
@@ -65,12 +85,9 @@ casper.notebook_test(function () {
         var result2 = this.get_output_cell(1);
         this.test.assertEquals(result.output_type, 'pyout',
             'testing pyout application/json and text/plain');
-        this.test.assertTrue(result.hasOwnProperty('application/json'),
-            'toJSON() original embeded JSON keeps mime key');
-        this.test.assertTrue(json[0].hasOwnProperty('json'),
-            'toJSON() representation uses short key');
-        this.test.assertTrue(result2.hasOwnProperty('application/json'),
-            'fromJSON() embeded JS gets mime key');
+
+        assert_has.apply(this, ['json', json, result, result2]);
+        assert_has.apply(this, ['text', json, result, result2]);
 
     });
     this.then(function() {
@@ -95,29 +112,10 @@ casper.notebook_test(function () {
         var result2 = this.get_output_cell(1);
         this.test.assertEquals(result.output_type, 'display_data',
             'testing display_data application/json and text/plain');
-        this.test.assertTrue(result.hasOwnProperty('text/plain'),
-            'toJSON()\t original embeded text keeps mime key');
-        this.test.assertTrue(json[0].hasOwnProperty('text'),
-            'toJSON()\t representation uses short key');
-        this.test.assertTrue(result2.hasOwnProperty('text/plain'),
-            'fromJSON()\t embeded text gets mime key');
+        
+        assert_has.apply(this, ['json', json, result, result2]);
+        assert_has.apply(this, ['text', json, result, result2]);
 
     });
-
-
-    //this.thenEvaluate(function () {
-    //var cell = IPython.notebook.get_cell(0);
-
-    //    // we have to make messes to find out who we are
-    //    cell.set_text([
-    //        "import IPython.html.tests as t",
-    //        "t.write_test_notebook('rich_output.ipynb')"
-    //        ].join('\n')
-    //        );
-
-    //    cell.execute();
-    //});
-    //
-    //this.wait_for_output(0);
 
 });

--- a/IPython/html/tests/casperjs/util.js
+++ b/IPython/html/tests/casperjs/util.js
@@ -76,12 +76,13 @@ casper.wait_for_output = function (cell_num) {
 };
 
 // return the output of a given cell
-casper.get_output_cell = function (cell_num) {
-    var result = casper.evaluate(function (c) {
+casper.get_output_cell = function (cell_num, out_num) {
+    out_num = out_num || 0;
+    var result = casper.evaluate(function (c, o) {
         var cell = IPython.notebook.get_cell(c);
-        return cell.output_area.outputs[0];
+        return cell.output_area.outputs[o];
     },
-    {c : cell_num});
+    {c : cell_num, o : out_num});
     return result;
 };
 


### PR DESCRIPTION
Additionally, this PR removes in-memory short keys in favor of using mimetype keys within the notebook javascript code, and tests toJSON/fromJSON codepaths for all of the supported mimetypes.
- [x] text/plain
- [x] text/html
- [x] image/svg+xml
- [x] image/png
- [x] image/jpeg
- [x] text/latex
- [x] application/json
- [x] application/javascript
- [x] some garbage mimetype
