### PR TITLE
relax ipconfig matching on Windows

### DIFF
--- a/IPython/utils/localinterfaces.py
+++ b/IPython/utils/localinterfaces.py
@@ -23,6 +23,7 @@ PUBLIC_IPS : A list of public IP addresses that point to this machine.
 #-----------------------------------------------------------------------------
 
 import os
+import re
 import socket
 
 from .data import uniq_stable
@@ -118,6 +119,7 @@ def _load_ips_ip():
             addrs.append(blocks[1].split('/')[0])
     _populate_from_list(addrs)
 
+_ipconfig_ipv4_pat = re.compile(r'ipv4.*(\d+\.\d+\.\d+\.\d+)$', re.IGNORECASE)
 
 def _load_ips_ipconfig():
     """load ip addresses from `ipconfig` output (Windows)"""
@@ -128,9 +130,9 @@ def _load_ips_ipconfig():
     lines = out.splitlines()
     addrs = ['127.0.0.1']
     for line in lines:
-        line = line.lower().split()
-        if line[:2] == ['ipv4', 'address']:
-            addrs.append(line.split()[-1])
+        m = _ipconfig_ipv4_pat.match(line.strip())
+        if m:
+            addrs.append(m.group(1))
     _populate_from_list(addrs)
 
 

--- a/IPython/utils/localinterfaces.py
+++ b/IPython/utils/localinterfaces.py
@@ -128,7 +128,7 @@ def _load_ips_ipconfig():
         raise IOError("no ipconfig: %s" % err)
     
     lines = out.splitlines()
-    addrs = ['127.0.0.1']
+    addrs = []
     for line in lines:
         m = _ipconfig_ipv4_pat.match(line.strip())
         if m:


### PR DESCRIPTION
looser match via regular expression, doesn't make English assumptions.

I don't know if Asian Windows has characters other than 'ipv4', but I would
doubt it.

closes #4538
