### PR TITLE
new `ipython history clear` subcommand

### DIFF
--- a/IPython/core/historyapp.py
+++ b/IPython/core/historyapp.py
@@ -16,7 +16,8 @@ from IPython.utils.traitlets import Bool, Int, Dict
 trim_hist_help = """Trim the IPython history database to the last 1000 entries.
 
 This actually copies the last 1000 entries to a new database, and then replaces
-the old file with the new.
+the old file with the new. Use the `--keep=` argument to specify a number
+other than 1000.
 """
 
 class HistoryTrim(BaseIPythonApplication):

--- a/IPython/core/historyapp.py
+++ b/IPython/core/historyapp.py
@@ -30,7 +30,7 @@ class HistoryTrim(BaseIPythonApplication):
     
     flags = Dict(dict(
         backup = ({'HistoryTrim' : {'backup' : True}},
-            "Set Application.log_level to 0, maximizing log output."
+            "Keep the old history file as history.sqlite.<N>"
         )
     ))
     

--- a/IPython/core/historyapp.py
+++ b/IPython/core/historyapp.py
@@ -56,11 +56,12 @@ class HistoryTrim(BaseIPythonApplication):
         
         inputs.pop() # Remove the extra element we got to check the length.
         inputs.reverse()
-        first_session = inputs[0][0]
-        outputs = list(con.execute('SELECT session, line, output FROM '
-                                   'output_history WHERE session >= ?', (first_session,)))
-        sessions = list(con.execute('SELECT session, start, end, num_cmds, remark FROM '
-                                    'sessions WHERE session >= ?', (first_session,)))
+        if inputs:
+            first_session = inputs[0][0]
+            outputs = list(con.execute('SELECT session, line, output FROM '
+                                       'output_history WHERE session >= ?', (first_session,)))
+            sessions = list(con.execute('SELECT session, start, end, num_cmds, remark FROM '
+                                        'sessions WHERE session >= ?', (first_session,)))
         con.close()
         
         # Create the new history database.
@@ -83,11 +84,12 @@ class HistoryTrim(BaseIPythonApplication):
         new_db.commit()
 
 
-        with new_db:
-            # Add the recent history into the new database.
-            new_db.executemany('insert into sessions values (?,?,?,?,?)', sessions)
-            new_db.executemany('insert into history values (?,?,?,?)', inputs)
-            new_db.executemany('insert into output_history values (?,?,?)', outputs)
+        if inputs:
+            with new_db:
+                # Add the recent history into the new database.
+                new_db.executemany('insert into sessions values (?,?,?,?,?)', sessions)
+                new_db.executemany('insert into history values (?,?,?,?)', inputs)
+                new_db.executemany('insert into output_history values (?,?,?)', outputs)
         new_db.close()
 
         if self.backup:

--- a/IPython/core/historyapp.py
+++ b/IPython/core/historyapp.py
@@ -30,8 +30,12 @@ class HistoryTrim(BaseIPythonApplication):
     
     flags = Dict(dict(
         backup = ({'HistoryTrim' : {'backup' : True}},
-            "Keep the old history file as history.sqlite.<N>"
+            backup.get_metadata('help')
         )
+    ))
+
+    aliases=Dict(dict(
+        keep = 'HistoryTrim.keep'
     ))
     
     def start(self):
@@ -44,7 +48,7 @@ class HistoryTrim(BaseIPythonApplication):
                                 'history ORDER BY session DESC, line DESC LIMIT ?', (self.keep+1,)))
         if len(inputs) <= self.keep:
             print("There are already at most %d entries in the history database." % self.keep)
-            print("Not doing anything.")
+            print("Not doing anything. Use --keep= argument to keep fewer entries")
             return
         
         print("Trimming history to the most recent %d entries." % self.keep)

--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -155,11 +155,13 @@ class Tee(object):
             self.close()
 
 
-def ask_yes_no(prompt,default=None):
+def ask_yes_no(prompt, default=None, interrupt=None):
     """Asks a question and returns a boolean (y/n) answer.
 
     If default is given (one of 'y','n'), it is used if the user input is
-    empty. Otherwise the question is repeated until an answer is given.
+    empty. If interrupt is given (one of 'y','n'), it is used if the user
+    presses Ctrl-C. Otherwise the question is repeated until an answer is
+    given.
 
     An EOF is treated as the default answer.  If there is no default, an
     exception is raised to prevent infinite loops.
@@ -174,7 +176,8 @@ def ask_yes_no(prompt,default=None):
             if not ans:  # response was an empty string
                 ans = default
         except KeyboardInterrupt:
-            pass
+            if interrupt:
+                ans = interrupt
         except EOFError:
             if default in answers.keys():
                 ans = default

--- a/docs/source/whatsnew/pr/bash-completion.rst
+++ b/docs/source/whatsnew/pr/bash-completion.rst
@@ -1,0 +1,1 @@
+* bash completion updated with support for all ipython subcommands and flags, including nbconvert

--- a/docs/source/whatsnew/pr/history-clear.rst
+++ b/docs/source/whatsnew/pr/history-clear.rst
@@ -1,0 +1,4 @@
+* `ipython history trim`: added `--keep=<N>` as an alias for the more verbose
+  `--HistoryTrim.keep=<N>`
+* new `ipython history clear` subcommand, which is the same as the newly supported
+  `ipython history trim --keep=0`

--- a/docs/source/whatsnew/pr/history-clear.rst
+++ b/docs/source/whatsnew/pr/history-clear.rst
@@ -1,4 +1,4 @@
-* `ipython history trim`: added `--keep=<N>` as an alias for the more verbose
-  `--HistoryTrim.keep=<N>`
-* new `ipython history clear` subcommand, which is the same as the newly supported
-  `ipython history trim --keep=0`
+* ``ipython history trim``: added ``--keep=<N>`` as an alias for the more verbose
+  ``--HistoryTrim.keep=<N>``
+* new ``ipython history clear`` subcommand, which is the same as the newly supported
+  ``ipython history trim --keep=0``

--- a/examples/core/ipython-completion.bash
+++ b/examples/core/ipython-completion.bash
@@ -24,7 +24,7 @@ _ipython()
 {
     local cur=${COMP_WORDS[COMP_CWORD]}
     local prev=${COMP_WORDS[COMP_CWORD - 1]}
-    local subcommands="notebook qtconsole console kernel profile locate history nbconvert"
+    local subcommands="notebook qtconsole console kernel profile locate history nbconvert "
     local opts=""
     if [ -z "$__ipython_complete_baseopts" ]; then
         _ipython_get_flags baseopts
@@ -46,7 +46,7 @@ _ipython()
 
     if [[ ${cur} == -* ]]; then
         case $mode in
-            "notebook" | "qtconsole" | "console" | "kernel")
+            "notebook" | "qtconsole" | "console" | "kernel" | "nbconvert")
                 _ipython_get_flags $mode
                 opts=$"${opts} ${baseopts}"
                 ;;

--- a/examples/core/ipython-completion.bash
+++ b/examples/core/ipython-completion.bash
@@ -54,7 +54,7 @@ _ipython()
                 _ipython_get_flags $mode
                 ;;
             "history")
-                if [[ $COMP_CWORD -ge 2 ]]; then
+                if [[ $COMP_CWORD -ge 3 ]]; then
                     # 'history trim' and 'history clear' covered by next line
                     _ipython_get_flags history\ "${COMP_WORDS[2]}"
                 else

--- a/examples/core/ipython-completion.bash
+++ b/examples/core/ipython-completion.bash
@@ -54,8 +54,9 @@ _ipython()
                 _ipython_get_flags $mode
                 ;;
             "history")
-                if [[ "${COMP_WORDS[2]}" == "trim" ]]; then
-                    _ipython_get_flags "history trim"
+                if [[ $COMP_CWORD -ge 2 ]]; then
+                    # 'history trim' and 'history clear' covered by next line
+                    _ipython_get_flags history\ "${COMP_WORDS[2]}"
                 else
                     _ipython_get_flags $mode
 
@@ -70,14 +71,18 @@ _ipython()
         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
         return 0
     elif [[ $mode == "profile" ]]; then
-        opts="list create locate"
+        opts="list 	create 	locate "
+        local IFS=$'\t\n'
         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
     elif [[ $mode == "history" ]]; then
-        if [[ "${COMP_WORDS[2]}" == "trim" ]]; then
-            COMPREPLY="--"
+        if [[ $COMP_CWORD -ge 3 ]]; then
+            # drop into flags
+            opts="--"
         else
-            COMPREPLY="trim "
+            opts="trim 	clear "
         fi
+        local IFS=$'\t\n'
+        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
     elif [[ $mode == "locate" ]]; then
         opts="profile"
         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )

--- a/examples/core/ipython-completion.bash
+++ b/examples/core/ipython-completion.bash
@@ -50,8 +50,16 @@ _ipython()
                 _ipython_get_flags $mode
                 opts=$"${opts} ${baseopts}"
                 ;;
-            "locate" | "history" | "profile")
+            "locate" | "profile")
                 _ipython_get_flags $mode
+                ;;
+            "history")
+                if [[ "${COMP_WORDS[2]}" == "trim" ]]; then
+                    _ipython_get_flags "history trim"
+                else
+                    _ipython_get_flags $mode
+
+                fi
                 opts=$"${opts}"
                 ;;
             *)
@@ -65,8 +73,11 @@ _ipython()
         opts="list create locate"
         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
     elif [[ $mode == "history" ]]; then
-        opts="trim"
-        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        if [[ "${COMP_WORDS[2]}" == "trim" ]]; then
+            COMPREPLY="--"
+        else
+            COMPREPLY="trim "
+        fi
     elif [[ $mode == "locate" ]]; then
         opts="profile"
         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )


### PR DESCRIPTION
This new subcommand is equivalent to `ipython history trim --HistoryTrim.keep=0`, which is now supported (and also has a more convenient `--keep` alias)

This command comes with a fix to bash completion of flags for `ipython history subcmd`

also included is a tiny fix for nbconvert completion that was pointed out by @jakobgager in #4528

also included is a change to our utils.io.ask_yes_no function that allows for specifying the behavior of a KeyboardInterrupt.
