### PR TITLE
make hiding of initial namespace optional

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -163,6 +163,11 @@ class InteractiveShellApp(Configurable):
     
     # Extensions that are always loaded (not configurable)
     default_extensions = List(Unicode, [u'storemagic'], config=False)
+    
+    hide_initial_ns = Bool(True, config=True,
+        help="""Should variables loaded at startup (by startup files, exec_lines, etc.)
+        be hidden from tools like %who?"""
+    )
 
     exec_files = List(Unicode, config=True,
         help="""List of files to run at IPython startup."""
@@ -290,7 +295,8 @@ class InteractiveShellApp(Configurable):
         sys.stderr.flush()
         
         # Hide variables defined here from %who etc.
-        self.shell.user_ns_hidden.update(self.shell.user_ns)
+        if self.hide_initial_ns:
+            self.shell.user_ns_hidden.update(self.shell.user_ns)
 
     def _run_exec_lines(self):
         """Run lines of code in IPythonApp.exec_lines in the user's namespace."""

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -287,16 +287,19 @@ class InteractiveShellApp(Configurable):
         self._run_startup_files()
         self._run_exec_lines()
         self._run_exec_files()
+        
+        # Hide variables defined here from %who etc.
+        if self.hide_initial_ns:
+            self.shell.user_ns_hidden.update(self.shell.user_ns)
+        
+        # command-line execution (ipython -i script.py, ipython -m module)
+        # should *not* be excluded from %whos
         self._run_cmd_line_code()
         self._run_module()
         
         # flush output, so itwon't be attached to the first cell
         sys.stdout.flush()
         sys.stderr.flush()
-        
-        # Hide variables defined here from %who etc.
-        if self.hide_initial_ns:
-            self.shell.user_ns_hidden.update(self.shell.user_ns)
 
     def _run_exec_lines(self):
         """Run lines of code in IPythonApp.exec_lines in the user's namespace."""

--- a/docs/source/whatsnew/pr/hide-whos.rst
+++ b/docs/source/whatsnew/pr/hide-whos.rst
@@ -3,7 +3,7 @@ changes to hidden namespace on startup
 
 Previously, all names declared in code run at startup
 (startup files, ``ipython -i script.py``, etc.)
-were added to the hidden namespace, which hides the names from tools like ``%who``.
+were added to the hidden namespace, which hides the names from tools like ``%whos``.
 There are two changes to this behavior:
 
 1. Scripts run on the command-line ``ipython -i script.py``now behave the same as if they were

--- a/docs/source/whatsnew/pr/hide-whos.rst
+++ b/docs/source/whatsnew/pr/hide-whos.rst
@@ -1,0 +1,12 @@
+changes to hidden namespace on startup
+--------------------------------------
+
+Previously, all names declared in code run at startup
+(startup files, ``ipython -i script.py``, etc.)
+were added to the hidden namespace, which hides the names from tools like ``%who``.
+There are two changes to this behavior:
+
+1. Scripts run on the command-line ``ipython -i script.py``now behave the same as if they were
+   passed to ``%run``, so their variables are never hidden.
+2. A boolean config flag ``InteractiveShellApp.hide_initial_ns`` has been added to optionally
+   disable the hidden behavior altogether. The default behavior is unchanged.


### PR DESCRIPTION
It is by design that names loaded by startup files, etc. are hidden from things like `%who`.

But this behavior is pretty surprising, especially since

```
ipython -i script.py
```

and

```
%run -i script.py
```

have different behaviors with respect to the hidden namespace.

Since the current behavior was added at the request of @fperez, I left the default behavior unchanged, but added a flag to disable hiding initial variables.
