### PR TITLE
fix warning condition on notebook startup

### DIFF
--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -715,14 +715,15 @@ class NotebookApp(BaseIPythonApplication):
             
             nbdir = os.path.abspath(self.notebook_manager.notebook_dir)
             f = self.file_to_run
-            if f and f.startswith(nbdir):
-                f = f[len(nbdir):]
-            else:
-                self.log.warn(
-                    "Probably won't be able to open notebook %s "
-                    "because it is not in notebook_dir %s",
-                    f, nbdir,
-                )
+            if f:
+                if f.startswith(nbdir):
+                    f = f[len(nbdir):]
+                else:
+                    self.log.warn(
+                        "Probably won't be able to open notebook %s "
+                        "because it is not in notebook_dir %s",
+                        f, nbdir,
+                    )
 
             if os.path.isfile(self.file_to_run):
                 url = url_path_join('notebooks', f)


### PR DESCRIPTION
should have only warned if file_to_run is defined _and_ it's outside the notebook_dir, but warning was shown even if it was not specified.
