### PR TITLE
Support wheel package (and upload it to PyPi)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ def require_clean_submodules():
     this is not a distutils command.
     """
     # PACKAGERS: Add a return here to skip checks for git submodules
-    
+
     # don't do anything if nothing is actually supposed to happen
     for do_nothing in ('-h', '--help', '--help-commands', 'clean', 'submodule'):
         if do_nothing in sys.argv:
@@ -248,7 +248,7 @@ setup_args['cmdclass'] = {
 # If you want a setuptools-enhanced install, just run 'setupegg.py install'
 needs_setuptools = set(('develop', 'release', 'bdist_egg', 'bdist_rpm',
            'bdist', 'bdist_dumb', 'bdist_wininst', 'install_egg_info',
-           'egg_info', 'easy_install', 'upload',
+           'egg_info', 'easy_install', 'upload', 'bdist_wheel',
             ))
 if sys.platform == 'win32':
     # Depend on setuptools for install on *Windows only*
@@ -268,7 +268,7 @@ if 'setuptools' in sys.modules:
     # setup.py develop should check for submodules
     from setuptools.command.develop import develop
     setup_args['cmdclass']['develop'] = require_submodules(develop)
-    
+
     setuptools_extra_args['zip_safe'] = False
     setuptools_extra_args['entry_points'] = {'console_scripts':find_entry_points()}
     setup_args['extras_require'] = dict(
@@ -287,7 +287,7 @@ if 'setuptools' in sys.modules:
         for dep in deps:
             everything.add(dep)
     setup_args['extras_require']['all'] = everything
-    
+
     requires = setup_args.setdefault('install_requires', [])
     setupext.display_status = False
     if not setupext.check_for_readline():


### PR DESCRIPTION
[Wheels](https://pypi.python.org/pypi/wheel) are the [new standard](http://www.python.org/dev/peps/pep-0427) of python distribution and are intended to replace eggs. Among other advantages, they offer faster installation and allow secure digital signing. 

As IPython is a pure-python [1] package compatible with Python 2 and 3,  it can be declared as a "wheel universal", in order to build a `.whl` package valid for any platform/python version. 
To build the package (It requires `setuptools > 0.8` and `wheel`. )

```
$ python setup.py bdist_wheel
```

or (to build and upload to pypi):

```
$ python setup.py bdist_wheel upload
```

In order to compare the results, the `.whl` is 64% lighter than the standard `tar.gz` generated through `sdist`:

```
(ipython)mgaitan@traful:~/lab/ipython$ ls -hl dist/
-rw-rw-r-- 1 mgaitan mgaitan 3,1M nov 15 18:08 ipython-2.0.0_dev-py2.py3-none-any.whl
-rw-rw-r-- 1 mgaitan mgaitan 8,5M nov 15 17:44 ipython-2.0.0-dev.tar.gz
```

And it's also much faster to install

```
(ipython)mgaitan@traful:~/lab/ipython$ time pip install dist/ipython-2.0.0-dev.tar.gz 
Unpacking ./dist/ipython-2.0.0-dev.tar.gz
  Running setup.py egg_info for package from file:///home/mgaitan/lab/ipython/dist/ipython-2.0.0-dev.tar.gz
    [...] // clipped
Successfully installed ipython
Cleaning up...

real    0m2.091s
user    0m1.840s
sys 0m0.396s

(ipython)mgaitan@traful:~/lab/ipython$ time pip install dist/ipython-2.0.0_dev-py2.py3-none-any.whl 
Unpacking ./dist/ipython-2.0.0_dev-py2.py3-none-any.whl
Cleaning up...

real    0m0.328s
user    0m0.256s
sys 0m0.068s
```

Moreover, `pip >= 1.4` supports wheels. (with `--use-wheel` flag). 

This will means terabytes of bandwith and energy saved :). 

[1]: although it contains data file as statics for the notebook
