### PR TITLE
Updated IPython console lexers.

### DIFF
--- a/IPython/nbconvert/utils/lexers.py
+++ b/IPython/nbconvert/utils/lexers.py
@@ -38,7 +38,8 @@ from pygments.token import (
 )
 from pygments.util import get_bool_opt
 
-
+# Local
+from IPython.testing.skipdoctest import skip_doctest
 
 line_re = re.compile('.*?\n')
 
@@ -170,34 +171,36 @@ class IPythonTracebackLexer(DelegatingLexer):
         DelegatingLexer.__init__(self, IPyLexer,
                                  IPythonPartialTracebackLexer, **options)
 
-
+@skip_doctest
 class IPythonConsoleLexer(Lexer):
     """
-    An IPython console lexer for IPython code-blocks and doctests, such as:
+    An IPython console lexer for IPython code-blocks and doctests, such as::
 
-    .. sourcecode:: ipythoncon
+        .. sourcecode:: ipythoncon
 
-        In [1]: a = 'foo'
+            In [1]: a = 'foo'
 
-        In [2]: a
-        Out[2]: 'foo'
+            In [2]: a
+            Out[2]: 'foo'
 
-        In [3]: print a
-        foo
+            In [3]: print a
+            foo
 
-        In [4]: 1 / 0
+            In [4]: 1 / 0
 
-    Support is also provided for IPython exceptions.
 
-    .. code-block:: ipythoncon
 
-        In [1]: raise Exception
-        ---------------------------------------------------------------------------
-        Exception                                 Traceback (most recent call last)
-        <ipython-input-1-fca2ab0ca76b> in <module>()
-        ----> 1 raise Exception
+    Support is also provided for IPython exceptions. ::
 
-        Exception:
+        .. code-block:: ipythoncon
+
+            In [1]: raise Exception
+            ---------------------------------------------------------------------------
+            Exception                                 Traceback (most recent call last)
+            <ipython-input-1-fca2ab0ca76b> in <module>()
+            ----> 1 raise Exception
+
+            Exception:
 
     """
     name = 'IPython console session'

--- a/IPython/nbconvert/utils/lexers.py
+++ b/IPython/nbconvert/utils/lexers.py
@@ -217,10 +217,8 @@ class IPythonConsoleLexer(Lexer):
     aliases = ['ipythoncon']
     mimetypes = ['text/x-ipython-console']
 
-    # The regexps used to determine what is input and what is output. The
-    # input regex should be consistent with and also be the combination of
-    # the values of the `in_template` and `in2_templates`. For example, the
-    # defaults prompts are:
+    # The regexps used to determine what is input and what is output.
+    # The default prompts for IPython are:
     #
     #     c.PromptManager.in_template  = 'In [\#]: '
     #     c.PromptManager.in2_template = '   .\D.: '
@@ -322,11 +320,24 @@ class IPythonConsoleLexer(Lexer):
         self.buffer = u''
         self.insertions = []
 
-    def get_modecode(self, line):
+    def get_mci(self, line):
         """
-        Returns the next mode and code to be added to the next mode's buffer.
+        Parses the line and returns a 3-tuple: (mode, code, insertion).
 
-        The next mode depends on current mode and contents of line.
+        `mode` is the next mode (or state) of the lexer, and is always equal
+        to 'input', 'output', or 'tb'.
+
+        `code` is a portion of the line that should be added to the buffer
+        corresponding to the next mode and eventually lexed by another lexer.
+        For example, `code` could be Python code if `mode` were 'input'.
+
+        `insertion` is a 3-tuple (index, token, text) representing an
+        unprocessed "token" that will be inserted into the stream of tokens
+        that are created from the buffer once we change modes. This is usually
+        the input or output prompt.
+
+        In general, the next mode depends on current mode and on the contents
+        of `line`.
 
         """
         # To reduce the number of regex match checks, we have multiple
@@ -436,7 +447,7 @@ class IPythonConsoleLexer(Lexer):
         self.reset()
         for match in line_re.finditer(text):
             line = match.group()
-            mode, code, insertion = self.get_modecode(line)
+            mode, code, insertion = self.get_mci(line)
 
             if mode != self.mode:
                 # Yield buffered tokens before transitioning to new mode.

--- a/IPython/nbconvert/utils/lexers.py
+++ b/IPython/nbconvert/utils/lexers.py
@@ -1,46 +1,473 @@
-"""A custom pygments lexer for IPython code cells.
-
-Informs The pygments highlighting library of the quirks of IPython's superset
-of Python -- magic commands, !shell commands, etc.
+# -*- coding: utf-8 -*-
 """
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, the IPython Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
+Defines a variety of Pygments lexers for highlighting IPython code.
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+This includes:
 
-# Third-party imports
-from pygments.lexers import PythonLexer, BashLexer
-from pygments.lexer import bygroups, using
-from pygments.token import Keyword, Operator, Text
+    IPythonLexer
+    IPython3Lexer
+        Lexers for pure IPython (python + magic/shell commands)
 
-#-----------------------------------------------------------------------------
-# Class declarations
-#-----------------------------------------------------------------------------
+    IPythonPartialTracebackLexer
+    IPythonTracebackLexer
+        Supports 2.x and 3.x via keyword `python3`.  The partial traceback
+        lexer reads everything but the Python code appearing in a traceback.
+        The full lexer combines the partial lexer with an IPython lexer.
 
-class IPythonLexer(PythonLexer):
+    IPythonConsoleLexer
+        A lexer for IPython console sessions, with support for tracebacks.
+
+    IPyLexer
+        A friendly lexer which examines the first line of text and from it,
+        decides whether to use an IPython lexer or an IPython console lexer.
+        This is probably the only lexer that needs to be explicitly added
+        to Pygments.
+
+"""
+
+# Standard library
+import re
+
+# Third party
+from pygments.lexers import BashLexer, PythonLexer, Python3Lexer
+from pygments.lexer import (
+    Lexer, DelegatingLexer, RegexLexer, do_insertions, bygroups, using,
+)
+from pygments.token import (
+    Comment, Generic, Keyword, Literal, Name, Operator, Other, Text, Error,
+)
+from pygments.util import get_bool_opt
+
+
+
+line_re = re.compile('.*?\n')
+
+ipython_tokens = [
+  (r'(\%+)(\w+)\s+(\.*)(\n)', bygroups(Operator, Keyword,
+                                       using(BashLexer), Text)),
+  (r'(\%+)(\w+)\b', bygroups(Operator, Keyword)),
+  (r'^(!)(.+)(\n)', bygroups(Operator, using(BashLexer), Text)),
+]
+
+def build_ipy_lexer(python3):
+    """Builds IPython lexers depending on the value of `python3`.
+
+    The lexer inherits from an appropriate Python lexer and then adds
+    information about IPython specific keywords (i.e. magic commands,
+    shell commands, etc.)
+
+    Parameters
+    ----------
+    python3 : bool
+        If `True`, then build an IPython lexer from a Python 3 lexer.
+
     """
-    Pygments Lexer for use with IPython code.  Inherits from 
-    PythonLexer and adds information about IPython specific
-    keywords (i.e. magic commands, shell commands, etc.)
+    # It would be nice to have a single IPython lexer class which takes
+    # a boolean `python3`.  But since there are two Python lexer classes,
+    # we will also have two IPython lexer classes.
+    if python3:
+        PyLexer = Python3Lexer
+        clsname = 'IPython3Lexer'
+        name = 'IPython3'
+        aliases = ['ipython3']
+        doc = """IPython3 Lexer"""
+    else:
+        PyLexer = PythonLexer
+        clsname = 'IPythonLexer'
+        name = 'IPython'
+        aliases = ['ipython']
+        doc = """IPython Lexer"""
+
+    tokens = PyLexer.tokens.copy()
+    tokens['root'] = ipython_tokens + tokens['root']
+
+    attrs = {'name': name, 'aliases': aliases,
+             '__doc__': doc, 'tokens': tokens}
+
+    return type(name, (PyLexer,), attrs)
+
+
+IPython3Lexer = build_ipy_lexer(python3=True)
+IPythonLexer = build_ipy_lexer(python3=False)
+
+
+class IPythonPartialTracebackLexer(RegexLexer):
     """
-    
-    #Basic properties
-    name = 'IPython'
-    aliases = ['ip', 'ipython']
-    filenames = ['*.ipy']
-    
-    #Highlighting information
-    tokens = PythonLexer.tokens.copy()
-    tokens['root'] = [
-        (r'(\%+)(\w+)\s+(\.*)(\n)', bygroups(Operator, Keyword,
-                                             using(BashLexer), Text)),
-        (r'(\%+)(\w+)\b', bygroups(Operator, Keyword)),
-        (r'^(!)(.+)(\n)', bygroups(Operator, using(BashLexer), Text)),
-        ] + tokens['root']
+    Partial lexer for IPython tracebacks.
+
+    Handles all the non-python output. This works for both Python 2.x and 3.x.
+
+    """
+    name = 'IPython Partial Traceback'
+
+    tokens = {
+        'root': [
+            # Tracebacks for syntax errors have a different style.
+            # For both types of tracebacks, we mark the first line with
+            # Generic.Traceback.  For syntax errors, we mark the filename
+            # as we mark the filenames for non-syntax tracebacks.
+            #
+            # These two regexps define how IPythonConsoleLexer finds a
+            # traceback.
+            #
+            ## Non-syntax traceback
+            (r'^(\^C)?(-+\n)', bygroups(Error, Generic.Traceback)),
+            ## Syntax traceback
+            (r'^(  File)(.*)(, line )(\d+\n)',
+             bygroups(Generic.Traceback, Name.Namespace,
+                      Generic.Traceback, Literal.Number.Integer)),
+
+            # (Exception Identifier)(Whitespace)(Traceback Message)
+            (r'(?u)(^[^\d\W]\w*)(\s*)(Traceback.*?\n)',
+             bygroups(Name.Exception, Generic.Whitespace, Text)),
+            # (Module/Filename)(Text)(Callee)(Function Signature)
+            # Better options for callee and function signature?
+            (r'(.*)( in )(.*)(\(.*\)\n)',
+             bygroups(Name.Namespace, Text, Name.Entity, Name.Tag)),
+            # Regular line: (Whitespace)(Line Number)(Python Code)
+            (r'(\s*?)(\d+)(.*?\n)',
+             bygroups(Generic.Whitespace, Literal.Number.Integer, Other)),
+            # Emphasized line: (Arrow)(Line Number)(Python Code)
+            # Using Exception token so arrow color matches the Exception.
+            (r'(-*>?\s?)(\d+)(.*?\n)',
+             bygroups(Name.Exception, Literal.Number.Integer, Other)),
+            # (Exception Identifier)(Message)
+            (r'(?u)(^[^\d\W]\w*)(:.*?\n)',
+             bygroups(Name.Exception, Text)),
+            # Tag everything else as Other, will be handled later.
+            (r'.*\n', Other),
+        ],
+    }
+
+
+class IPythonTracebackLexer(DelegatingLexer):
+    """
+    IPython traceback lexer.
+
+    For doctests, the tracebacks can be snipped as much as desired with the
+    exception to the lines that designate a traceback. For non-syntax error
+    tracebacks, this is the line of hyphens. For syntax error tracebacks,
+    this is the line which lists the File and line number.
+
+    """
+    # The lexer inherits from DelegatingLexer.  The "root" lexer is an
+    # appropriate IPython lexer, which depends on the value of the boolean
+    # `python3`.  First, we parse with the partial IPython traceback lexer.
+    # Then, any code marked with the "Other" token is delegated to the root
+    # lexer.
+    #
+    name = 'IPython Traceback'
+    aliases = ['ipythontb']
+
+    def __init__(self, **options):
+        self.python3 = get_bool_opt(options, 'python3', False)
+
+        if self.python3:
+            IPyLexer = IPython3Lexer
+        else:
+            IPyLexer = IPythonLexer
+
+        DelegatingLexer.__init__(self, IPyLexer,
+                                 IPythonPartialTracebackLexer, **options)
+
+
+class IPythonConsoleLexer(Lexer):
+    """
+    An IPython console lexer for IPython code-blocks and doctests, such as:
+
+    .. sourcecode:: ipythoncon
+
+        In [1]: a = 'foo'
+
+        In [2]: a
+        Out[2]: 'foo'
+
+        In [3]: print a
+        foo
+
+        In [4]: 1 / 0
+
+    Support is also provided for IPython exceptions.
+
+    .. code-block:: ipythoncon
+
+        In [1]: raise Exception
+        ---------------------------------------------------------------------------
+        Exception                                 Traceback (most recent call last)
+        <ipython-input-1-fca2ab0ca76b> in <module>()
+        ----> 1 raise Exception
+
+        Exception:
+
+    """
+    name = 'IPython console session'
+    aliases = ['ipythoncon']
+    mimetypes = ['text/x-ipython-console']
+
+    # The regexps used to determine what is input and what is output. The
+    # input regex should be consistent with and also be the combination of
+    # the values of the `in_template` and `in2_templates`. For example, the
+    # defaults prompts are:
+    #
+    #     c.PromptManager.in_template  = 'In [\#]: '
+    #     c.PromptManager.in2_template = '   .\D.: '
+    #     c.PromptManager.out_template = 'Out[\#]: '
+    #
+    # Note, we do not include the trailing whitespace in the regex since
+    # we want to allow blank prompts (and editors often remove trailing
+    # whitespace).
+    #
+    in1_regex = r'In \[[0-9]+\]: '
+    in2_regex = r'   \.\.+\.: '
+    out_regex = r'Out\[[0-9]+\]: '
+
+    #: The regex to determine when a traceback starts.
+    ipytb_start = re.compile(r'^(\^C)?(-+\n)|^(  File)(.*)(, line )(\d+\n)')
+
+    def __init__(self, **options):
+        """Initialize the IPython console lexer.
+
+        Parameters
+        ----------
+        python3 : bool
+            If `True`, then the console inputs are parsed using a Python 3
+            lexer. Otherwise, they are parsed using a Python 2 lexer.
+        in1_regex : RegexObject
+            The compiled regular expression used to detect the start
+            of inputs. Although the IPython configuration setting may have a
+            trailing whitespace, do not include it in the regex. If `None`,
+            then the default input prompt is assumed.
+        in2_regex : RegexObject
+            The compiled regular expression used to detect the continuation
+            of inputs. Although the IPython configuration setting may have a
+            trailing whitespace, do not include it in the regex. If `None`,
+            then the default input prompt is assumed.
+        out_regex : RegexObject
+            The compiled regular expression used to detect outputs. If `None`,
+            then the default output prompt is assumed.
+
+        """
+        self.python3 = get_bool_opt(options, 'python3', False)
+
+        in1_regex = options.get('in1_regex', self.in1_regex)
+        in2_regex = options.get('in2_regex', self.in2_regex)
+        out_regex = options.get('out_regex', self.out_regex)
+
+        # So that we can work with input and output prompts which have been
+        # rstrip'd (possibly by editors) we also need rstrip'd variants. If
+        # we do not do this, then such prompts will be tagged as 'output'.
+        # The reason can't just use the rstrip'd variants instead is because
+        # we want any whitespace associated with the prompt to be inserted
+        # with the token. This allows formatted code to be modified so as hide
+        # the appearance of prompts.  For example, see copybutton.js.
+        in1_regex_rstrip = in1_regex.rstrip() + '\n'
+        in2_regex_rstrip = in2_regex.rstrip() + '\n'
+        out_regex_rstrip = out_regex.rstrip() + '\n'
+
+        # Compile and save them all.
+        attrs = ['in1_regex', 'in2_regex', 'out_regex',
+                 'in1_regex_rstrip', 'in2_regex_rstrip', 'out_regex_rstrip']
+        for attr in attrs:
+            self.__setattr__(attr, re.compile(locals()[attr]))
+
+        Lexer.__init__(self, **options)
+
+        if self.python3:
+            pylexer = IPython3Lexer
+            tblexer = IPythonTracebackLexer
+        else:
+            pylexer = IPythonLexer
+            tblexer = IPythonTracebackLexer
+
+        self.pylexer = pylexer(**options)
+        self.tblexer = tblexer(**options)
+
+        self.reset()
+
+    def reset(self):
+        self.mode = 'output'
+        self.index = 0
+        self.buffer = u''
+        self.insertions = []
+
+    def buffered_tokens(self):
+        """
+        Generator of unprocessed tokens after doing insertions and before
+        changing to a new state.
+
+        """
+        if self.mode == 'output':
+            tokens = [(0, Generic.Output, self.buffer)]
+        elif self.mode == 'input':
+            tokens = self.pylexer.get_tokens_unprocessed(self.buffer)
+        else: # traceback
+            tokens = self.tblexer.get_tokens_unprocessed(self.buffer)
+
+        for i, t, v in do_insertions(self.insertions, tokens):
+            # All token indexes are relative to the buffer.
+            yield self.index + i, t, v
+
+        # Clear it all
+        self.index += len(self.buffer)
+        self.buffer = u''
+        self.insertions = []
+
+    def get_modecode(self, line):
+        """
+        Returns the next mode and code to be added to the next mode's buffer.
+
+        The next mode depends on current mode and contents of line.
+
+        """
+        # To reduce the number of regex match checks, we have multiple
+        # 'if' blocks instead of 'if-elif' blocks.
+
+        ### Check for possible end of input
+        ###
+        in2_match = self.in2_regex.match(line)
+        in2_match_rstrip = self.in2_regex_rstrip.match(line)
+        if (in2_match and in2_match.group().rstrip() == line.rstrip()) or \
+           in2_match_rstrip:
+            end_input = True
+        else:
+            end_input = False
+        if end_input and self.mode != 'tb':
+            # Only look for an end of input when not in tb mode.
+            # An ellipsis could appear within the traceback.
+            mode = 'output'
+            code = u''
+            insertion = (0, Generic.Prompt, line)
+            return mode, code, insertion
+
+        ### Check for output prompt
+        ###
+        out_match = self.out_regex.match(line)
+        out_match_rstrip = self.out_regex_rstrip.match(line)
+        if out_match or out_match_rstrip:
+            mode = 'output'
+            if out_match:
+                idx = out_match.end()
+            else:
+                idx = out_match_rstrip.end()
+            code = line[idx:]
+            # Use the 'heading' token for output.  We cannot use Generic.Error
+            # since it would conflict with exceptions.
+            insertion = (0, Generic.Heading, line[:idx])
+            return mode, code, insertion
+
+
+        ### Check for input or continuation prompt (non stripped version)
+        ###
+        in1_match = self.in1_regex.match(line)
+        if in1_match or (in2_match and self.mode != 'tb'):
+            # New input or when not in tb, continued input.
+            # We do not check for continued input when in tb since it is
+            # allowable to replace a long stack with an ellipsis.
+            mode = 'input'
+            if in1_match:
+                idx = in1_match.end()
+            else: # in2_match
+                idx = in2_match.end()
+            code = line[idx:]
+            insertion = (0, Generic.Prompt, line[:idx])
+            return mode, code, insertion
+
+        ### Check for input or continuation prompt (stripped version)
+        ###
+        in1_match_rstrip = self.in1_regex_rstrip.match(line)
+        if in1_match_rstrip or (in2_match_rstrip and self.mode != 'tb'):
+            # New input or when not in tb, continued input.
+            # We do not check for continued input when in tb since it is
+            # allowable to replace a long stack with an ellipsis.
+            mode = 'input'
+            if in1_match_rstrip:
+                idx = in1_match_rstrip.end()
+            else: # in2_match
+                idx = in2_match_rstrip.end()
+            code = line[idx:]
+            insertion = (0, Generic.Prompt, line[:idx])
+            return mode, code, insertion
+
+        ### Check for traceback
+        ###
+        if self.ipytb_start.match(line):
+            mode = 'tb'
+            code = line
+            insertion = None
+            return mode, code, insertion
+
+        ### All other stuff...
+        ###
+        if self.mode in ('input', 'output'):
+            # We assume all other text is output. Multiline input that
+            # does not use the continuation marker cannot be detected.
+            # For example, the 3 in the following is clearly output:
+            #
+            #    In [1]: print 3
+            #    3
+            #
+            # But the following second line is part of the input:
+            #
+            #    In [2]: while True:
+            #        print True
+            #
+            # In both cases, the 2nd line will be 'output'.
+            #
+            mode = 'output'
+        else:
+            mode = 'tb'
+
+        code = line
+        insertion = None
+
+        return mode, code, insertion
+
+    def get_tokens_unprocessed(self, text):
+        self.reset()
+        for match in line_re.finditer(text):
+            line = match.group()
+            mode, code, insertion = self.get_modecode(line)
+
+            if mode != self.mode:
+                # Yield buffered tokens before transitioning to new mode.
+                for token in self.buffered_tokens():
+                    yield token
+                self.mode = mode
+
+            if insertion:
+                self.insertions.append((len(self.buffer), [insertion]))
+            self.buffer += code
+        else:
+            for token in self.buffered_tokens():
+                yield token
+
+class IPyLexer(Lexer):
+    """
+    Primary lexer for all IPython-like code.
+
+    This is a simple helper lexer.  If the first line of the text begins with
+    "In \[[0-9]+\]:", then the entire text is parsed with an IPython console
+    lexer. If not, then the entire text is parsed with an IPython lexer.
+
+    The goal is to reduce the number of lexers that are registered
+    with Pygments.
+
+    """
+    name = 'IPy session'
+    aliases = ['ipy']
+
+    def __init__(self, **options):
+        self.python3 = get_bool_opt(options, 'python3', False)
+        Lexer.__init__(self, **options)
+
+        self.IPythonLexer = IPythonLexer(**options)
+        self.IPythonConsoleLexer = IPythonConsoleLexer(**options)
+
+    def get_tokens_unprocessed(self, text):
+        if re.match(r'(In \[[0-9]+\]:)', text.strip()):
+            lex = self.IPythonConsoleLexer
+        else:
+            lex = self.IPythonLexer
+        for token in lex.get_tokens_unprocessed(text):
+            yield token
+

--- a/IPython/nbconvert/utils/lexers.py
+++ b/IPython/nbconvert/utils/lexers.py
@@ -226,10 +226,6 @@ class IPythonConsoleLexer(Lexer):
     #     c.PromptManager.in2_template = '   .\D.: '
     #     c.PromptManager.out_template = 'Out[\#]: '
     #
-    # Note, we do not include the trailing whitespace in the regex since
-    # we want to allow blank prompts (and editors often remove trailing
-    # whitespace).
-    #
     in1_regex = r'In \[[0-9]+\]: '
     in2_regex = r'   \.\.+\.: '
     out_regex = r'Out\[[0-9]+\]: '
@@ -272,7 +268,8 @@ class IPythonConsoleLexer(Lexer):
         # The reason can't just use the rstrip'd variants instead is because
         # we want any whitespace associated with the prompt to be inserted
         # with the token. This allows formatted code to be modified so as hide
-        # the appearance of prompts.  For example, see copybutton.js.
+        # the appearance of prompts, with the whitespace included. One example
+        # use of this is in copybutton.js from the standard lib Python docs.
         in1_regex_rstrip = in1_regex.rstrip() + '\n'
         in2_regex_rstrip = in2_regex.rstrip() + '\n'
         out_regex_rstrip = out_regex.rstrip() + '\n'

--- a/IPython/nbconvert/utils/lexers.py
+++ b/IPython/nbconvert/utils/lexers.py
@@ -24,6 +24,13 @@ This includes:
         to Pygments.
 
 """
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, the IPython Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
 
 # Standard library
 import re

--- a/IPython/nbconvert/utils/lexers.py
+++ b/IPython/nbconvert/utils/lexers.py
@@ -174,9 +174,11 @@ class IPythonTracebackLexer(DelegatingLexer):
 @skip_doctest
 class IPythonConsoleLexer(Lexer):
     """
-    An IPython console lexer for IPython code-blocks and doctests, such as::
+    An IPython console lexer for IPython code-blocks and doctests, such as:
 
-        .. sourcecode:: ipythoncon
+    .. code-block:: rst
+
+        .. code-block:: ipythoncon
 
             In [1]: a = 'foo'
 
@@ -189,8 +191,9 @@ class IPythonConsoleLexer(Lexer):
             In [4]: 1 / 0
 
 
+    Support is also provided for IPython exceptions:
 
-    Support is also provided for IPython exceptions. ::
+    .. code-block:: rst
 
         .. code-block:: ipythoncon
 

--- a/IPython/nbconvert/utils/lexers.py
+++ b/IPython/nbconvert/utils/lexers.py
@@ -170,9 +170,9 @@ class IPythonTracebackLexer(DelegatingLexer):
     def __init__(self, **options):
         self.python3 = get_bool_opt(options, 'python3', False)
         if self.python3:
-            self.aliases = ['ipythontb3']
+            self.aliases = ['ipython3tb']
         else:
-            self.aliases = ['ipythontb2', 'ipythontb']
+            self.aliases = ['ipython2tb', 'ipythontb']
 
         if self.python3:
             IPyLexer = IPython3Lexer
@@ -189,7 +189,7 @@ class IPythonConsoleLexer(Lexer):
 
     .. code-block:: rst
 
-        .. code-block:: ipythoncon
+        .. code-block:: ipythonconsole
 
             In [1]: a = 'foo'
 
@@ -206,7 +206,7 @@ class IPythonConsoleLexer(Lexer):
 
     .. code-block:: rst
 
-        .. code-block:: ipythoncon
+        .. code-block:: ipythonconsole
 
             In [1]: raise Exception
             ---------------------------------------------------------------------------
@@ -218,7 +218,7 @@ class IPythonConsoleLexer(Lexer):
 
     """
     name = 'IPython console session'
-    aliases = ['ipythoncon']
+    aliases = ['ipythonconsole']
     mimetypes = ['text/x-ipython-console']
 
     # The regexps used to determine what is input and what is output.
@@ -260,9 +260,9 @@ class IPythonConsoleLexer(Lexer):
         """
         self.python3 = get_bool_opt(options, 'python3', False)
         if self.python3:
-            self.aliases = ['ipythoncon3']
+            self.aliases = ['ipython3console']
         else:
-            self.aliases = ['ipythoncon2', 'ipythoncon']
+            self.aliases = ['ipython2console', 'ipythonconsole']
 
         in1_regex = options.get('in1_regex', self.in1_regex)
         in2_regex = options.get('in2_regex', self.in2_regex)

--- a/IPython/nbconvert/utils/lexers.py
+++ b/IPython/nbconvert/utils/lexers.py
@@ -83,7 +83,7 @@ def build_ipy_lexer(python3):
         PyLexer = PythonLexer
         clsname = 'IPythonLexer'
         name = 'IPython'
-        aliases = ['ipython']
+        aliases = ['ipython2', 'ipython']
         doc = """IPython Lexer"""
 
     tokens = PyLexer.tokens.copy()
@@ -169,6 +169,10 @@ class IPythonTracebackLexer(DelegatingLexer):
 
     def __init__(self, **options):
         self.python3 = get_bool_opt(options, 'python3', False)
+        if self.python3:
+            self.aliases = ['ipythontb3']
+        else:
+            self.aliases = ['ipythontb2', 'ipythontb']
 
         if self.python3:
             IPyLexer = IPython3Lexer
@@ -255,6 +259,10 @@ class IPythonConsoleLexer(Lexer):
 
         """
         self.python3 = get_bool_opt(options, 'python3', False)
+        if self.python3:
+            self.aliases = ['ipythoncon3']
+        else:
+            self.aliases = ['ipythoncon2', 'ipythoncon']
 
         in1_regex = options.get('in1_regex', self.in1_regex)
         in2_regex = options.get('in2_regex', self.in2_regex)
@@ -479,6 +487,11 @@ class IPyLexer(Lexer):
 
     def __init__(self, **options):
         self.python3 = get_bool_opt(options, 'python3', False)
+        if self.python3:
+            self.aliases = ['ipy3']
+        else:
+            self.aliases = ['ipy2', 'ipy']
+
         Lexer.__init__(self, **options)
 
         self.IPythonLexer = IPythonLexer(**options)

--- a/IPython/nbconvert/utils/lexers.py
+++ b/IPython/nbconvert/utils/lexers.py
@@ -351,8 +351,7 @@ class IPythonConsoleLexer(Lexer):
         # To reduce the number of regex match checks, we have multiple
         # 'if' blocks instead of 'if-elif' blocks.
 
-        ### Check for possible end of input
-        ###
+        # Check for possible end of input
         in2_match = self.in2_regex.match(line)
         in2_match_rstrip = self.in2_regex_rstrip.match(line)
         if (in2_match and in2_match.group().rstrip() == line.rstrip()) or \
@@ -368,8 +367,7 @@ class IPythonConsoleLexer(Lexer):
             insertion = (0, Generic.Prompt, line)
             return mode, code, insertion
 
-        ### Check for output prompt
-        ###
+        # Check for output prompt
         out_match = self.out_regex.match(line)
         out_match_rstrip = self.out_regex_rstrip.match(line)
         if out_match or out_match_rstrip:
@@ -385,8 +383,7 @@ class IPythonConsoleLexer(Lexer):
             return mode, code, insertion
 
 
-        ### Check for input or continuation prompt (non stripped version)
-        ###
+        # Check for input or continuation prompt (non stripped version)
         in1_match = self.in1_regex.match(line)
         if in1_match or (in2_match and self.mode != 'tb'):
             # New input or when not in tb, continued input.
@@ -401,8 +398,7 @@ class IPythonConsoleLexer(Lexer):
             insertion = (0, Generic.Prompt, line[:idx])
             return mode, code, insertion
 
-        ### Check for input or continuation prompt (stripped version)
-        ###
+        # Check for input or continuation prompt (stripped version)
         in1_match_rstrip = self.in1_regex_rstrip.match(line)
         if in1_match_rstrip or (in2_match_rstrip and self.mode != 'tb'):
             # New input or when not in tb, continued input.
@@ -417,16 +413,14 @@ class IPythonConsoleLexer(Lexer):
             insertion = (0, Generic.Prompt, line[:idx])
             return mode, code, insertion
 
-        ### Check for traceback
-        ###
+        # Check for traceback
         if self.ipytb_start.match(line):
             mode = 'tb'
             code = line
             insertion = None
             return mode, code, insertion
 
-        ### All other stuff...
-        ###
+        # All other stuff...
         if self.mode in ('input', 'output'):
             # We assume all other text is output. Multiline input that
             # does not use the continuation marker cannot be detected.

--- a/IPython/sphinxext/ipython_console_highlighting.py
+++ b/IPython/sphinxext/ipython_console_highlighting.py
@@ -23,5 +23,5 @@ ipy = IPyLexer(python3=False)
 ipy3 = IPyLexer(python3=True)
 ipy3.aliases = ['ipy3']
 
-highlighting.lexers['ipy'] = ipy
-highlighting.lexers['ipy3'] = ipy3
+highlighting.lexers['ipython'] = ipy
+highlighting.lexers['ipython3'] = ipy3

--- a/IPython/sphinxext/ipython_console_highlighting.py
+++ b/IPython/sphinxext/ipython_console_highlighting.py
@@ -19,9 +19,9 @@ def setup(app):
 # Alternatively, we could register the lexer with pygments instead. This would
 # require using setuptools entrypoints: http://pygments.org/docs/plugins
 
-ipy = IPyLexer(python3=False)
+ipy2 = IPyLexer(python3=False)
 ipy3 = IPyLexer(python3=True)
-ipy3.aliases = ['ipy3']
 
-highlighting.lexers['ipython'] = ipy
+highlighting.lexers['ipython'] = ipy2
+highlighting.lexers['ipython2'] = ipy2
 highlighting.lexers['ipython3'] = ipy3

--- a/IPython/sphinxext/ipython_console_highlighting.py
+++ b/IPython/sphinxext/ipython_console_highlighting.py
@@ -1,114 +1,27 @@
-"""reST directive for syntax-highlighting ipython interactive sessions.
+"""
+reST directive for syntax-highlighting ipython interactive sessions.
 
-XXX - See what improvements can be made based on the new (as of Sept 2009)
-'pycon' lexer for the python console.  At the very least it will give better
-highlighted tracebacks.
 """
 
-#-----------------------------------------------------------------------------
-# Needed modules
-
-# Standard library
-import re
-
-# Third party
-from pygments.lexer import Lexer, do_insertions
-from pygments.lexers.agile import (PythonConsoleLexer, PythonLexer,
-                                   PythonTracebackLexer)
-from pygments.token import Comment, Generic
-
 from sphinx import highlighting
-
-#-----------------------------------------------------------------------------
-# Global constants
-line_re = re.compile('.*?\n')
-
-#-----------------------------------------------------------------------------
-# Code begins - classes and functions
-
-class IPythonConsoleLexer(Lexer):
-    """
-    For IPython console output or doctests, such as:
-
-    .. sourcecode:: ipython
-
-      In [1]: a = 'foo'
-
-      In [2]: a
-      Out[2]: 'foo'
-
-      In [3]: print a
-      foo
-
-      In [4]: 1 / 0
-
-    Notes:
-
-      - Tracebacks are not currently supported.
-
-      - It assumes the default IPython prompts, not customized ones.
-    """
-
-    name = 'IPython console session'
-    aliases = ['ipython']
-    mimetypes = ['text/x-ipython-console']
-    input_prompt = re.compile("(In \[[0-9]+\]: )|(   \.\.\.+:)")
-    output_prompt = re.compile("(Out\[[0-9]+\]: )|(   \.\.\.+:)")
-    continue_prompt = re.compile("   \.\.\.+:")
-    tb_start = re.compile("\-+")
-
-    def get_tokens_unprocessed(self, text):
-        pylexer = PythonLexer(**self.options)
-        tblexer = PythonTracebackLexer(**self.options)
-
-        curcode = ''
-        insertions = []
-        for match in line_re.finditer(text):
-            line = match.group()
-            input_prompt = self.input_prompt.match(line)
-            continue_prompt = self.continue_prompt.match(line.rstrip())
-            output_prompt = self.output_prompt.match(line)
-            if line.startswith("#"):
-                insertions.append((len(curcode),
-                                   [(0, Comment, line)]))
-            elif input_prompt is not None:
-                insertions.append((len(curcode),
-                                   [(0, Generic.Prompt, input_prompt.group())]))
-                curcode += line[input_prompt.end():]
-            elif continue_prompt is not None:
-                insertions.append((len(curcode),
-                                   [(0, Generic.Prompt, continue_prompt.group())]))
-                curcode += line[continue_prompt.end():]
-            elif output_prompt is not None:
-                # Use the 'error' token for output.  We should probably make
-                # our own token, but error is typicaly in a bright color like
-                # red, so it works fine for our output prompts.
-                insertions.append((len(curcode),
-                                   [(0, Generic.Error, output_prompt.group())]))
-                curcode += line[output_prompt.end():]
-            else:
-                if curcode:
-                    for item in do_insertions(insertions,
-                                              pylexer.get_tokens_unprocessed(curcode)):
-                        yield item
-                        curcode = ''
-                        insertions = []
-                yield match.start(), Generic.Output, line
-        if curcode:
-            for item in do_insertions(insertions,
-                                      pylexer.get_tokens_unprocessed(curcode)):
-                yield item
-
+from ..nbconvert.utils.lexers import IPyLexer
 
 def setup(app):
     """Setup as a sphinx extension."""
 
     # This is only a lexer, so adding it below to pygments appears sufficient.
-    # But if somebody knows that the right API usage should be to do that via
+    # But if somebody knows what the right API usage should be to do that via
     # sphinx, by all means fix it here.  At least having this setup.py
     # suppresses the sphinx warning we'd get without it.
     pass
 
-#-----------------------------------------------------------------------------
-# Register the extension as a valid pygments lexer
-highlighting.lexers['ipython'] = IPythonConsoleLexer()
+# Register the extension as a valid pygments lexerself.
+# Alternatively, we could register the lexer with pygments instead. This would
+# require using setuptools entrypoints: http://pygments.org/docs/plugins
+
+ipy = IPyLexer(python3=False)
+ipy3 = IPyLexer(python3=True)
+ipy3.aliases = ['ipy3']
+
+highlighting.lexers['ipy'] = ipy
+highlighting.lexers['ipy3'] = ipy3

--- a/IPython/sphinxext/ipython_console_highlighting.py
+++ b/IPython/sphinxext/ipython_console_highlighting.py
@@ -15,7 +15,7 @@ def setup(app):
     # suppresses the sphinx warning we'd get without it.
     pass
 
-# Register the extension as a valid pygments lexerself.
+# Register the extension as a valid pygments lexer.
 # Alternatively, we could register the lexer with pygments instead. This would
 # require using setuptools entrypoints: http://pygments.org/docs/plugins
 

--- a/docs/source/whatsnew/pr/ipython-console-lexer.rst
+++ b/docs/source/whatsnew/pr/ipython-console-lexer.rst
@@ -2,7 +2,7 @@ New IPython Console Lexer
 -------------------------
 
 The IPython console lexer has been rewritten and now supports tracebacks
-and customized input/output prompts. An entire suite of lexers are now
+and customized input/output prompts. An entire suite of lexers is now
 available at :module:`IPython.nbconvert.utils.lexers`. These include:
 
     IPythonLexer

--- a/docs/source/whatsnew/pr/ipython-console-lexer.rst
+++ b/docs/source/whatsnew/pr/ipython-console-lexer.rst
@@ -1,0 +1,58 @@
+New IPython Console Lexer
+-------------------------
+
+The IPython console lexer has been rewritten and now supports tracebacks
+and customized input/output prompts. An entire suite of lexers are now
+available at :module:`IPython.nbconvert.utils.lexers`. These include:
+
+    IPythonLexer
+    IPython3Lexer
+        Lexers for pure IPython (python + magic/shell commands)
+
+    IPythonPartialTracebackLexer
+    IPythonTracebackLexer
+        Supports 2.x and 3.x via the keyword `python3`.  The partial traceback
+        lexer reads everything but the Python code appearing in a traceback.
+        The full lexer combines the partial lexer with an IPython lexer.
+
+    IPythonConsoleLexer
+        A lexer for IPython console sessions, with support for tracebacks.
+        Supports 2.x and 3.x via the keyword `python3`.
+
+    IPyLexer
+        A friendly lexer which examines the first line of text and from it,
+        decides whether to use an IPython lexer or an IPython console lexer.
+        Supports 2.x and 3.x via the keyword `python3`.
+
+Previously, the :class:`IPythonConsoleLexer` class was available at
+:module:`IPython.sphinxext.ipython_console_hightlight`.  It was inserted
+into Pygments' list of available lexers under the name `ipython`.  It should
+be mentioned that this name is inaccurate.  An IPython console session
+is not the same as IPython code (which itself is a superset of the Python
+language).
+
+Now, the Sphinx extension inserts two console lexers into Pygment's list of
+available lexers.  Both are IPyLexer instances under the names:  `ipython` and
+`ipython3`. As mentioned above, these names are misleading, but they are kept
+for backwards compatibility and typical usage.  If a project needs to make
+Pygments aware of more than just the IPyLexer class, then one should not
+make the IPyLexer class available under the name `ipython` and use `ipy` or
+some other non-conflicting value.
+
+Code blocks such as::
+
+    .. code-block:: ipython
+
+       In [1]: 2**2
+       Out[1]: 4
+
+will continue to work as before, but now, they will also properly highlight
+tracebacks.  For pure IPython code, the same lexer will work::
+
+    .. code-block:: ipython
+
+       x = ''.join(map(str, range(10)))
+       !echo $x
+
+Since the first line of the block did not begin with a standard IPython console
+prompt, the entire block is assumed to be IPython code instead.

--- a/docs/source/whatsnew/pr/ipython-console-lexer.rst
+++ b/docs/source/whatsnew/pr/ipython-console-lexer.rst
@@ -27,32 +27,36 @@ available at :module:`IPython.nbconvert.utils.lexers`. These include:
 Previously, the :class:`IPythonConsoleLexer` class was available at
 :module:`IPython.sphinxext.ipython_console_hightlight`.  It was inserted
 into Pygments' list of available lexers under the name `ipython`.  It should
-be mentioned that this name is inaccurate.  An IPython console session
+be mentioned that this name is inaccurate, since an IPython console session
 is not the same as IPython code (which itself is a superset of the Python
 language).
 
-Now, the Sphinx extension inserts two console lexers into Pygment's list of
-available lexers.  Both are IPyLexer instances under the names:  `ipython` and
-`ipython3`. As mentioned above, these names are misleading, but they are kept
-for backwards compatibility and typical usage.  If a project needs to make
-Pygments aware of more than just the IPyLexer class, then one should not
-make the IPyLexer class available under the name `ipython` and use `ipy` or
-some other non-conflicting value.
+Now, the Sphinx extension inserts two console lexers into Pygments' list of
+available lexers. Both are IPyLexer instances under the names: `ipython` and
+`ipython3`. Although the names can be confusing (as mentioned above), their
+continued use is, in part, to maintain backwards compatibility and to
+aid typical usage. If a project needs to make Pygments aware of more than just
+the IPyLexer class, then one should not make the IPyLexer class available under
+the name `ipython` and use `ipy` or some other non-conflicting value.
 
-Code blocks such as::
+Code blocks such as:
+
+.. code-block:: rst
 
     .. code-block:: ipython
 
-       In [1]: 2**2
-       Out[1]: 4
+        In [1]: 2**2
+        Out[1]: 4
 
 will continue to work as before, but now, they will also properly highlight
-tracebacks.  For pure IPython code, the same lexer will work::
+tracebacks.  For pure IPython code, the same lexer will also work:
+
+.. code-block:: rst
 
     .. code-block:: ipython
 
-       x = ''.join(map(str, range(10)))
-       !echo $x
+        x = ''.join(map(str, range(10)))
+        !echo $x
 
 Since the first line of the block did not begin with a standard IPython console
-prompt, the entire block is assumed to be IPython code instead.
+prompt, the entire block is assumed to consist of IPython code instead.


### PR DESCRIPTION
I've updated the `IPythonConsoleLexer` to support tracebacks and customized prompts.  This is done through a separate `IPythonTracebackLexer` class.  The lexer made known to Pygments is `IPyLexer` and now can handle pure IPython code as well as IPython console session code.  As for tracebacks, these can be trimmed as much as possible.  All that is required is to keep the initial line.

Down the road, I suspect this could be useful for the IPython notebooks, as it looks like tracebacks are colored with ANSI and converted appropriately.  I'm happy to dig into that on a separate pull request, but I'll need some help.

I tried my best to give decent Pygment token values to the parts of the traceback. At least now, people are free to customize the CSS to achieve whatever styling they want.  I also had to change the token given to the output prompt from `Generic.Error` to `Generic.Heading`.  I used `Generic.Error` for exceptions in tracebacks.

You can see this live here: http://docs.dit.io/en/latest/generalinfo.html#quickstart.  Down at the bottom, you can see how an exception is highlighted using the default theme on ReadTheDocs.  I can provide other examples (such as terminal output with the 'terminal256'  formatter) if necessary.

More generally, there is a question of whether these lexers should be added to Pygments or whether they should remain in IPython.  I'm leaning towards IPython, but I'm curious to hear what others think.  Pygments also supports plugins via setuptools entrypoints, but then IPython would have to depend on the ipython-lexer sphinx extension---just seems like more trouble than its worth.
