### PR TITLE
Fix Python 3 handling of urllib

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -312,8 +312,11 @@ class DisplayObject(object):
                 self.data = f.read()
         elif self.url is not None:
             try:
-                import urllib2
-                response = urllib2.urlopen(self.url)
+                try:
+                    from urllib.request import urlopen  # Py3
+                except ImportError:
+                    from urllib2 import urlopen
+                response = urlopen(self.url)
                 self.data = response.read()
                 # extract encoding from header, if there is one:
                 encoding = None

--- a/IPython/core/extensions.py
+++ b/IPython/core/extensions.py
@@ -151,37 +151,39 @@ class ExtensionManager(Configurable):
         if hasattr(mod, 'unload_ipython_extension'):
             mod.unload_ipython_extension(self.shell)
             return True
-    
+
     def install_extension(self, url, filename=None):
         """Download and install an IPython extension. 
-        
+
         If filename is given, the file will be so named (inside the extension
         directory). Otherwise, the name from the URL will be used. The file must
         have a .py or .zip extension; otherwise, a ValueError will be raised.
-        
+
         Returns the full path to the installed file.
         """
         # Ensure the extension directory exists
         if not os.path.isdir(self.ipython_extension_dir):
             os.makedirs(self.ipython_extension_dir, mode = 0o777)
-        
+
         if os.path.isfile(url):
             src_filename = os.path.basename(url)
             copy = copyfile
         else:
-            from urllib import urlretrieve  # Deferred imports
+            # Deferred imports
             try:
                 from urllib.parse import urlparse  # Py3
+                from urllib.request import urlretrieve
             except ImportError:
                 from urlparse import urlparse
+                from urllib import urlretrieve
             src_filename = urlparse(url).path.split('/')[-1]
             copy = urlretrieve
-            
+
         if filename is None:
             filename = src_filename
         if os.path.splitext(filename)[1] not in ('.py', '.zip'):
             raise ValueError("The file must have a .py or .zip extension", filename)
-        
+
         filename = os.path.join(self.ipython_extension_dir, filename)
         copy(url, filename)
         return filename

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3088,7 +3088,11 @@ class InteractiveShell(SingletonConfigurable):
                 return openpy.read_py_url(utarget, skip_encoding_cookie=skip_encoding_cookie)
         except UnicodeDecodeError:
             if not py_only :
-                from urllib import urlopen  # Deferred import
+                # Deferred import
+                try:
+                    from urllib.request import urlopen  # Py3
+                except ImportError:
+                    from urllib import urlopen
                 response = urlopen(target)
                 return response.read().decode('latin1')
             raise ValueError(("'%s' seem to be unreadable.") % utarget)

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -235,7 +235,11 @@ class CodeMagics(Magics):
             print(e.args[0])
             return
 
-        from urllib2 import urlopen  # Deferred import
+        # Deferred import
+        try:
+            from urllib.request import urlopen # Py 3
+        except ImportError:
+            from urllib2 import urlopen
         import json
         post_data = json.dumps({
           "description": opts.get('d', "Pasted from IPython"),

--- a/IPython/external/mathjax.py
+++ b/IPython/external/mathjax.py
@@ -58,10 +58,14 @@ import os
 import shutil
 import sys
 import tarfile
-import urllib2
 import zipfile
 
 from IPython.utils.path import get_ipython_dir
+
+try:
+    from urllib.request import urlopen # Py 3
+except ImportError:
+    from urllib2 import urlopen
 
 #-----------------------------------------------------------------------------
 #
@@ -167,7 +171,7 @@ def install_mathjax(tag='v2.2', dest=default_dest, replace=False, file=None, ext
         # download mathjax
         mathjax_url = "https://github.com/mathjax/MathJax/archive/%s.tar.gz" %tag
         print("Downloading mathjax source from %s" % mathjax_url)
-        response = urllib2.urlopen(mathjax_url)
+        response = urlopen(mathjax_url)
         file = response.fp
 
     print("Extracting to %s" % dest)

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -183,7 +183,10 @@ class IFrame(object):
     def _repr_html_(self):
         """return the embed iframe"""
         if self.params:
-            from urllib import urlencode
+            try:
+                from urllib.parse import urlencode # Py 3
+            except ImportError:
+                from urllib import urlencode
             params = "?" + urlencode(self.params)
         else:
             params = ""

--- a/IPython/utils/openpy.py
+++ b/IPython/utils/openpy.py
@@ -207,7 +207,11 @@ def read_py_url(url, errors='replace', skip_encoding_cookie=True):
     -------
     A unicode string containing the contents of the file.
     """
-    from urllib import urlopen  # Deferred import for faster start
+    # Deferred import for faster start
+    try:
+        from urllib.request import urlopen # Py 3
+    except ImportError:
+        from urllib import urlopen
     response = urlopen(url)
     buffer = io.BytesIO(response.read())
     return source_to_unicode(buffer, errors, skip_encoding_cookie)


### PR DESCRIPTION
Added try/except blocks to properly import moved methods in the urllib and urllib2 modules. This would break things including `%load`ing scripts by url and installing a local copy of MathJax.
