### PR TITLE
don't use lazily-evaluated rc.ids in wait_for_idle

### DIFF
--- a/IPython/parallel/tests/test_client.py
+++ b/IPython/parallel/tests/test_client.py
@@ -325,7 +325,7 @@ class TestClient(ClusterTestCase):
         # timeout 5s, polling every 100ms
         qs = rc.queue_status()
         for i in range(50):
-            if qs['unassigned'] or any(qs[eid]['tasks'] + qs[eid]['queue'] for eid in rc.ids):
+            if qs['unassigned'] or any(qs[eid]['tasks'] + qs[eid]['queue'] for eid in qs if eid != 'unassigned'):
                 time.sleep(0.1)
                 qs = rc.queue_status()
             else:


### PR DESCRIPTION
iterate through the keys directly, which should avoid possible KeyError when engine state changes.

should fix occasionally failing tests on Shining Panda
