### PR TITLE
DOC: %profile docstring should reference %prun

### DIFF
--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -305,7 +305,13 @@ Currently the magic system has the following functions:""",
 
     @line_magic
     def profile(self, parameter_s=''):
-        """Print your currently active IPython profile."""
+        """Print your currently active IPython profile.
+       
+        See Also
+        --------
+        prun : run code using the Python profiler
+               (:class:`~IPython.core.magics.execution.ExecutionMagics.prun`)
+        """
         from IPython.core.application import BaseIPythonApplication
         if BaseIPythonApplication.initialized():
             print(BaseIPythonApplication.instance().profile)

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -310,7 +310,7 @@ Currently the magic system has the following functions:""",
         See Also
         --------
         prun : run code using the Python profiler
-               (:class:`~IPython.core.magics.execution.ExecutionMagics.prun`)
+               (:meth:`~IPython.core.magics.execution.ExecutionMagics.prun`)
         """
         from IPython.core.application import BaseIPythonApplication
         if BaseIPythonApplication.initialized():

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -497,7 +497,7 @@ class NamespaceMagics(Magics):
 
         See Also
         --------
-        magic_reset_selective : invoked as ``%reset_selective``
+        reset_selective : invoked as ``%reset_selective``
 
         Examples
         --------
@@ -612,7 +612,7 @@ class NamespaceMagics(Magics):
 
         See Also
         --------
-        magic_reset : invoked as ``%reset``
+        reset : invoked as ``%reset``
 
         Examples
         --------


### PR DESCRIPTION
I'm teaching code profiling tomorrow, and given the name collision with our
configuration system, I think it's useful to reference %prun in the docstring for the %profile magic
