### PR TITLE
NBConvert stdout writer unicode fix.

### DIFF
--- a/IPython/nbconvert/writers/stdout.py
+++ b/IPython/nbconvert/writers/stdout.py
@@ -13,6 +13,7 @@ Contains Stdout writer
 # Imports
 #-----------------------------------------------------------------------------
 
+import sys
 from .base import WriterBase
 
 #-----------------------------------------------------------------------------
@@ -30,5 +31,4 @@ class StdoutWriter(WriterBase):
 
         See base for more...
         """
-
-        print(output)
+        sys.stdout.write(output)

--- a/IPython/nbconvert/writers/tests/test_stdout.py
+++ b/IPython/nbconvert/writers/tests/test_stdout.py
@@ -49,3 +49,21 @@ class TestStdout(TestsBase):
 
         # Revert stdout
         sys.stdout = stdout
+
+
+    def test_utf_output(self):
+        """Test stdout writer unicode output."""
+        
+        # Capture the stdout.  Remember original.
+        stdout = sys.stdout
+        stream = StringIO()
+        sys.stdout = stream
+
+        # Create stdout writer, test output
+        writer = StdoutWriter()
+        writer.write(u'\xC3\x97', {'b': 'c'})
+        output = stream.getvalue()
+        self.assertEqual(output, u'\xC3\x97')
+
+        # Revert stdout
+        sys.stdout = stdout


### PR DESCRIPTION
`print()` was only printing ASCII representations of the conversion results.
