### PR TITLE
Fix %history -f for two-process clients on python2

### DIFF
--- a/IPython/core/magics/history.py
+++ b/IPython/core/magics/history.py
@@ -24,6 +24,7 @@ from IPython.core.magic_arguments import (argument, magic_arguments,
                                           parse_argstring)
 from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils import io
+from IPython.utils.py3compat import str_to_unicode
 
 #-----------------------------------------------------------------------------
 # Magics class implementation
@@ -211,7 +212,7 @@ class HistoryMagics(Magics):
                 print(u">>> ", end=u"", file=outfile)
                 if multiline:
                     inline = "\n... ".join(inline.splitlines()) + "\n..."
-            print(inline, file=outfile)
+            print(str_to_unicode(inline), file=outfile)
             if get_output and output:
                 print(output, file=outfile)
 


### PR DESCRIPTION
Saving history has been broken for a while on python2 for the two process
terminals.

This fixes `history -f myhistfile` which used to cause a traceback complaining
about unicode that looked something like this:

```
/home/pi/code/ipython/IPython/core/magics/history.pyc in history(self, parameter_s)
       212                 if multiline:
       213                     inline = "\n...  ".join(inline.splitlines()) + "\n..."
   --> 214             print(inline, file=outfile)
       215             if get_output and output:
       216                 print(output, file=outfile)

TypeError: must be unicode, not str
```

@takluyver should direct me if I should have used a different approach here.
Part of the reason I used str_to_unicode is because then this patch can be
easily backported to 1.x, though I don't know if we'll be having another one of those releases
