### PR TITLE
Inherit the width of pre code inside the input code cells.

### DIFF
--- a/IPython/nbconvert/templates/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/slides_reveal.tpl
@@ -45,7 +45,7 @@ html {
   font-size: 20px;
 }
 .reveal pre {
-  width: 95%;
+  width: inherit;
   padding: 0.4em;
   margin: 0px;
   font-family: monospace, sans-serif;


### PR DESCRIPTION
This fix a ugly bug because of different widths between pre code inside de cells and the cell itself.
Pics attached... see the right border of the cell... 
**Before the fix:**

![fix_pre_1](https://f.cloud.github.com/assets/1640669/1608718/95f9fe12-5511-11e3-8cbd-563e45f64ea8.png)

**And after the fix:**

![fix_pre_2](https://f.cloud.github.com/assets/1640669/1608719/a116e1e8-5511-11e3-997c-2120613fafef.png)
