### PR TITLE
Font awesome for IPython slides

### DIFF
--- a/IPython/nbconvert/templates/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/slides_reveal.tpl
@@ -30,6 +30,9 @@ document.write( '<link rel="stylesheet" href="{{resources.reveal.url_prefix}}/cs
 <script src="{{resources.reveal.url_prefix}}/lib/js/html5shiv.js"></script>
 <![endif]-->
 
+<!-- Get Font-awesome from cdn -->
+<link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css">
+
 {% for css in resources.inlining.css -%}
     <style type="text/css">
     {{ css }}
@@ -55,6 +58,11 @@ html {
 .reveal section img {
   border: 0px solid black;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0);
+}
+reveal i {
+  font-style: normal;
+  font-family: FontAwesome;
+  font-size: 2em;
 }
 .reveal .slides {
   text-align: left;

--- a/IPython/nbconvert/templates/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/slides_reveal.tpl
@@ -59,7 +59,7 @@ html {
   border: 0px solid black;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0);
 }
-reveal i {
+.reveal i {
   font-style: normal;
   font-family: FontAwesome;
   font-size: 2em;


### PR DESCRIPTION
As requested by @Carreau #4081, I have added font awesomwe support to the IPython slides.
The implementation point to a CDN to load the fontawesome css and style the `reveal i` class properly.
