### PR TITLE
don't interfere with set_next_input contents in qtconsole

### DIFF
--- a/IPython/qt/console/ipython_widget.py
+++ b/IPython/qt/console/ipython_widget.py
@@ -539,7 +539,7 @@ class IPythonWidget(FrontendWidget):
         self.exit_requested.emit(self)
 
     def _handle_payload_next_input(self, item):
-        self.input_buffer = dedent(item['text'].rstrip())
+        self.input_buffer = item['text']
 
     def _handle_payload_page(self, item):
         # Since the plain text widget supports only a very small subset of HTML


### PR DESCRIPTION
It was dedented and rstripped for no apparent reason, causing inconsistent behavior. No other frontend behaved this way.
