### PR TITLE
test that rename fails with 409 if it would clobber

### DIFF
--- a/IPython/html/services/notebooks/tests/test_notebooks_api.py
+++ b/IPython/html/services/notebooks/tests/test_notebooks_api.py
@@ -245,6 +245,10 @@ class APITest(NotebookTestBase):
         self.assertIn('z.ipynb', nbnames)
         self.assertNotIn('a.ipynb', nbnames)
 
+    def test_rename_existing(self):
+        with assert_http_error(409):
+            self.nb_api.rename('a.ipynb', 'foo', 'b.ipynb')
+
     def test_save(self):
         resp = self.nb_api.read('a.ipynb', 'foo')
         nbcontent = json.loads(resp.text)['content']


### PR DESCRIPTION
(test already passes, but it should still be tested)

closes #4600
