### PR TITLE
Make running PYTHONSTARTUP optional

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -172,6 +172,10 @@ class InteractiveShellApp(Configurable):
     exec_files = List(Unicode, config=True,
         help="""List of files to run at IPython startup."""
     )
+    exec_PYTHONSTARTUP = Bool(True, config=True,
+        help="""Run the file referenced by the PYTHONSTARTUP environment
+        variable at IPython startup."""
+    )
     file_to_run = Unicode('', config=True,
         help="""A file to be run""")
 
@@ -354,8 +358,9 @@ class InteractiveShellApp(Configurable):
         """Run files from profile startup directory"""
         startup_dir = self.profile_dir.startup_dir
         startup_files = []
-        if os.environ.get('PYTHONSTARTUP', False):
-            startup_files.append(os.environ['PYTHONSTARTUP'])
+        if self.exec_PYTHONSTARTUP:
+            if os.environ.get('PYTHONSTARTUP', False):
+                startup_files.append(os.environ['PYTHONSTARTUP'])
         startup_files += glob.glob(os.path.join(startup_dir, '*.py'))
         startup_files += glob.glob(os.path.join(startup_dir, '*.ipy'))
         if not startup_files:

--- a/docs/source/interactive/reference.rst
+++ b/docs/source/interactive/reference.rst
@@ -761,10 +761,10 @@ won't work::
 IPython as your default Python environment
 ==========================================
 
-Python honors the environment variable PYTHONSTARTUP and will execute at
-startup the file referenced by this variable. If you put the following code at
-the end of that file, then IPython will be your working environment anytime you
-start Python::
+Python honors the environment variable :envvar:`PYTHONSTARTUP` and will
+execute at startup the file referenced by this variable. If you put the
+following code at the end of that file, then IPython will be your working
+environment anytime you start Python::
 
     from IPython.frontend.terminal.ipapp import launch_new_instance
     launch_new_instance()
@@ -773,6 +773,11 @@ start Python::
 The ``raise SystemExit`` is needed to exit Python when
 it finishes, otherwise you'll be back at the normal Python '>>>'
 prompt.
+
+You'll also need to set the config option
+``InteractiveShellApp.exec_PYTHONSTARTUP = False``, otherwise IPython
+will try to run :envvar:`PYTHONSTARTUP` again, sending it into an
+infinite loop.
 
 This is probably useful to developers who manage multiple Python
 versions and don't want to have correspondingly multiple IPython

--- a/docs/source/interactive/reference.rst
+++ b/docs/source/interactive/reference.rst
@@ -766,18 +766,14 @@ execute at startup the file referenced by this variable. If you put the
 following code at the end of that file, then IPython will be your working
 environment anytime you start Python::
 
-    from IPython.frontend.terminal.ipapp import launch_new_instance
-    launch_new_instance()
+    import os, IPython
+    os.environ['PYTHONSTARTUP'] = ''  # Prevent running this again
+    IPython.start_ipython()
     raise SystemExit
 
 The ``raise SystemExit`` is needed to exit Python when
 it finishes, otherwise you'll be back at the normal Python '>>>'
 prompt.
-
-You'll also need to set the config option
-``InteractiveShellApp.exec_PYTHONSTARTUP = False``, otherwise IPython
-will try to run :envvar:`PYTHONSTARTUP` again, sending it into an
-infinite loop.
 
 This is probably useful to developers who manage multiple Python
 versions and don't want to have correspondingly multiple IPython


### PR DESCRIPTION
It makes sense either to have PYTHONSTARTUP set up things for all interactive Python sessions, or to bring some convenience features to the default Python shell. We used to ignore it, but IPython 1.x executes
the PYTHONSTARTUP file. In conversation with @minrk, we felt there should be a config option not to run it, but running it should remain the default.

This was prompted by someone following instructions in the docs to use PYTHONSTARTUP to start IPython, which resulted in infinite recursion as it ran PYTHONSTARTUP and tried to start itself again.
