### PR TITLE
Tutorial doc should link to user config intro

### DIFF
--- a/docs/source/interactive/tutorial.rst
+++ b/docs/source/interactive/tutorial.rst
@@ -178,7 +178,7 @@ visited directories and allows you to go to any previously visited one.
 Configuration
 =============
 
-Much of IPython can be tweaked through :ref:`configuration <config_overview>`.
+Much of IPython can be tweaked through :doc:`configuration </config/intro>`.
 To get started, use the command ``ipython profile create`` to produce the
 default config files. These will be placed in
 :file:`~/.ipython/profile_default`, and contain comments explaining


### PR DESCRIPTION
Not to the config development details.
