### PR TITLE
transparent background match ... all colors

### DIFF
--- a/IPython/kernel/zmq/pylab/config.py
+++ b/IPython/kernel/zmq/pylab/config.py
@@ -39,8 +39,8 @@ class InlineBackend(InlineBackendConfig):
     # make that fit.
     rc = Dict({'figure.figsize': (6.0,4.0),
         # play nicely with white background in the Qt and notebook frontend
-        'figure.facecolor': 'white',
-        'figure.edgecolor': 'white',
+        'figure.facecolor': (1,1,1,0),
+        'figure.edgecolor': (1,1,1,0),
         # 12pt labels get cutoff on 6x4 logplots, so use 10pt.
         'font.size': 10,
         # 72 dpi matches SVG/qtconsole


### PR DESCRIPTION
I think it make sens; this is `white` with `alpha=0` so it should fail gracefully on things that don't like alpha. it's much nicer on blog post with custom themes, and not-white-but-almost backgrounds. 

It changes nothing on notebook and qtconsole with default theme.

Do anyone see any case where the figure would be on a super-dark background ?
