### PR TITLE
Changed url link in Help dropdown menu.

### DIFF
--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -201,6 +201,7 @@ class="notebook_app"
         <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Help</a>
             <ul class="dropdown-menu" title="Opens in a new window">
                 <li><a href="http://ipython.org/documentation.html" target="_blank">IPython Help</a></li>
+                <li><a href="http://nbviewer.ipython.org/github/ipython/ipython/tree/1.x/examples/notebooks/" target="_blank">Notebook Examples</a></li>
                 <li><a href="http://ipython.org/ipython-doc/stable/interactive/notebook.html" target="_blank">Notebook Help</a></li>
                 <li id="keyboard_shortcuts" title="Opens a tooltip with all keyboard shortcuts"><a href="#">Keyboard Shortcuts</a></li>
                 <li><a href="http://ipython.org/ipython-doc/dev/interactive/cm_keyboard.html" target="_blank">Editor Shortcuts</a></li>


### PR DESCRIPTION
Trying to resolve #4057. 

I removed "iPython Help" link from the drop-down help menu and replaced it with "Notebook Examples"
that links to http://nbviewer.ipython.org/github/ipython/ipython/tree/1.x/examples/notebooks/.

Let me know if you have feedback on this new url change or if you have alternative ideas to style the help menu. 
