### PR TITLE
Fix crash when $EDITOR is non-ASCII

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -41,13 +41,19 @@ from IPython.utils.traitlets import Integer, CBool, Unicode
 def get_default_editor():
     try:
         ed = os.environ['EDITOR']
+        if not py3compat.PY3:
+            ed = ed.decode()
+        return ed
     except KeyError:
-        if os.name == 'posix':
-            ed = 'vi'  # the only one guaranteed to be there!
-        else:
-            ed = 'notepad' # same in Windows!
-    return ed
+        pass
+    except UnicodeError:
+        warn("$EDITOR environment variable is not pure ASCII. Using platform "
+             "default editor.")
 
+    if os.name == 'posix':
+        return 'vi'  # the only one guaranteed to be there!
+    else:
+        return 'notepad' # same in Windows!
 
 def get_pasted_lines(sentinel, l_input=py3compat.input):
     """ Yield pasted lines until the user enters the given sentinel value.

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -1024,7 +1024,11 @@ class Unicode(TraitType):
         if isinstance(value, py3compat.unicode_type):
             return value
         if isinstance(value, bytes):
-            return py3compat.unicode_type(value)
+            try:
+                return value.decode('ascii', 'strict')
+            except UnicodeDecodeError:
+                msg = "Could not decode {!r} for unicode trait '{}' of {} instance."
+                raise TraitError(msg.format(value, self.name, class_of(obj)))
         self.error(obj, value)
 
 


### PR DESCRIPTION
Catch $EDITOR being non-ASCII on Python 2 and fall back to the defaults, rather than crashing.

Also, setting unicode traits from invalid bytes now produces a useful error message, rather than a crash with a complex traceback.

Fixes #4615.
