### PR TITLE
Document various QtConsole embedding approaches.

### DIFF
--- a/docs/source/interactive/qtconsole.rst
+++ b/docs/source/interactive/qtconsole.rst
@@ -594,6 +594,29 @@ garbage collected until the application itself is destroyed.
 
 .. _Gotchas: http://www.riverbankcomputing.co.uk/static/Docs/PyQt4/html/gotchas.html#garbage-collection
 
+Embedding the QtConsole in a Qt application
+*******************************************
+
+In order to make the QtConsole available to an external Qt application (just as
+:func:`IPython.embed` enables one to embed a terminal session of IPython in a
+command-line application), there are a few options:
+
+* First start IPython, and then start the external Qt application from IPython,
+  as described above.
+
+* From the external Qt application, start an IPython kernel in a new process,
+  and connect to it.  See :file:`examples/lib/ipkernel_qtapp.py` for an
+  example.  In that case, objects are not shared between the Qt application and
+  the kernel.
+
+* From the Qt application, start an IPython kernel in the *same* process, and
+  connect to it.  See :file:`examples/inprocess/embedded_qtconsole.py` for an
+  example.  In that case, the objects available in the QtConsole are the
+  actual objects that live in the Qt application.  However, long-running
+  calculations in the QtConsole will block the GUI.  Moreover, the default
+  configuration will not be loaded automatically, but you can do it manually,
+  as demonstrated in the example.
+
 Regressions
 ===========
 

--- a/docs/source/interactive/qtconsole.rst
+++ b/docs/source/interactive/qtconsole.rst
@@ -597,25 +597,26 @@ garbage collected until the application itself is destroyed.
 Embedding the QtConsole in a Qt application
 *******************************************
 
-In order to make the QtConsole available to an external Qt application (just as
+In order to make the QtConsole available to an external Qt GUI application (just as
 :func:`IPython.embed` enables one to embed a terminal session of IPython in a
 command-line application), there are a few options:
 
 * First start IPython, and then start the external Qt application from IPython,
   as described above.
 
-* From the external Qt application, start an IPython kernel in a new process,
-  and connect to it.  See :file:`examples/lib/ipkernel_qtapp.py` for an
-  example.  In that case, objects are not shared between the Qt application and
-  the kernel.
+* Start a standard IPython kernel in the process of the external Qt
+  application.  See :file:`examples/lib/ipkernel_qtapp.py` for an example.  Due
+  to IPython's two-process model, the QtConsole itself will live in another
+  process with its own QApplication, and thus cannot be embedded in the main
+  GUI.
 
-* From the Qt application, start an IPython kernel in the *same* process, and
-  connect to it.  See :file:`examples/inprocess/embedded_qtconsole.py` for an
-  example.  In that case, the objects available in the QtConsole are the
-  actual objects that live in the Qt application.  However, long-running
-  calculations in the QtConsole will block the GUI.  Moreover, the default
-  configuration will not be loaded automatically, but you can do it manually,
-  as demonstrated in the example.
+* Start a special IPython kernel, the :class:`InProcessKernel`,
+  that allows a QtConsole in the same process.  See
+  :file:`examples/inprocess/embedded_qtconsole.py` for an example.  While
+  the QtConsole can now be embedded in the main GUI, one cannot connect to
+  the kernel from other consoles as there are no real ZMQ sockets anymore.
+  Moreover, the default, system-wide configuration will not be loaded and
+  applied.
 
 Regressions
 ===========

--- a/docs/source/interactive/qtconsole.rst
+++ b/docs/source/interactive/qtconsole.rst
@@ -602,7 +602,8 @@ In order to make the QtConsole available to an external Qt GUI application (just
 command-line application), there are a few options:
 
 * First start IPython, and then start the external Qt application from IPython,
-  as described above.
+  as described above.  Effectively, this embeds your application in IPython
+  rather than the other way round.
 
 * Start a standard IPython kernel in the process of the external Qt
   application.  See :file:`examples/lib/ipkernel_qtapp.py` for an example.  Due
@@ -617,6 +618,9 @@ command-line application), there are a few options:
   the kernel from other consoles as there are no real ZMQ sockets anymore.
   Moreover, the default, system-wide configuration will not be loaded and
   applied.
+
+* Start an IPython kernel in a separate subprocess and communicate with it via
+  the ZMQ sockets.
 
 Regressions
 ===========

--- a/examples/inprocess/embedded_qtconsole.py
+++ b/examples/inprocess/embedded_qtconsole.py
@@ -1,10 +1,8 @@
 import os
 
-from IPython.qt.console.qtconsoleapp import IPythonQtConsoleApp
 from IPython.qt.console.rich_ipython_widget import RichIPythonWidget
 from IPython.qt.inprocess import QtInProcessKernelManager
 from IPython.lib import guisupport
-from IPython.utils import path
 
 
 def print_process_id():
@@ -38,17 +36,8 @@ def main():
     control.kernel_manager = kernel_manager
     control.kernel_client = kernel_client
     control.exit_requested.connect(stop)
-
-    iapp = IPythonQtConsoleApp.instance()
-    iapp.config_file_paths = [path.locate_profile("default")]
-    iapp.config_files = ["ipython_qtconsole_config.py"]
-    iapp.load_config_file()
-    for cls_name, d in iapp.config.items():
-        for k, v in d.items():
-            setattr(control, k, v)
-    iapp.init_colors(control)
-
     control.show()
+
     guisupport.start_event_loop_qt4(app)
 
 

--- a/examples/inprocess/embedded_qtconsole.py
+++ b/examples/inprocess/embedded_qtconsole.py
@@ -1,8 +1,10 @@
 import os
 
+from IPython.qt.console.qtconsoleapp import IPythonQtConsoleApp
 from IPython.qt.console.rich_ipython_widget import RichIPythonWidget
 from IPython.qt.inprocess import QtInProcessKernelManager
 from IPython.lib import guisupport
+from IPython.utils import path
 
 
 def print_process_id():
@@ -36,8 +38,17 @@ def main():
     control.kernel_manager = kernel_manager
     control.kernel_client = kernel_client
     control.exit_requested.connect(stop)
-    control.show()
 
+    iapp = IPythonQtConsoleApp.instance()
+    iapp.config_file_paths = [path.locate_profile("default")]
+    iapp.config_files = ["ipython_qtconsole_config.py"]
+    iapp.load_config_file()
+    for cls_name, d in iapp.config.items():
+        for k, v in d.items():
+            setattr(control, k, v)
+    iapp.init_colors(control)
+
+    control.show()
     guisupport.start_event_loop_qt4(app)
 
 


### PR DESCRIPTION
Also added loading of default config to the in-process embedding example.
- This is really just my personal understanding of the various embedding techniques, I have personally only used the 3rd approach (in-process embedding) after fighting a little bit with the 2nd one (separate processes).
- For some reason, sphinx won't build the docs for me (even without this patch) so I haven't checked if the docs "look fine" with the patch.
