### PR TITLE
Fix nbrun in notebooks with non-code cells.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2568,7 +2568,8 @@ class InteractiveShell(SingletonConfigurable):
                     if not nb.worksheets:
                         return
                     for cell in nb.worksheets[0].cells:
-                        yield cell.input
+                        if cell.cell_type == 'code':
+                            yield cell.input
             else:
                 with open(fname) as f:
                     yield f.read()

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -377,6 +377,7 @@ tclass.py: deleting object: C-third
         nb = current.new_notebook(
             worksheets=[
                 current.new_worksheet(cells=[
+                    current.new_text_cell("The Ultimate Question of Everything"),
                     current.new_code_cell("answer=42")
                 ])
             ]


### PR DESCRIPTION
When you try to run notebooks with the `run` magic:

`% run my_notebook.ipynb`

if the notebook contains non-code cells, it fails...
So I made a little fix to filter the code cells from the notebook passed as argument.
