### PR TITLE
Nbconvert HTTP service

### DIFF
--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -355,6 +355,14 @@ class TrailingSlashHandler(web.RequestHandler):
         self.redirect(self.request.uri.rstrip('/'))
 
 #-----------------------------------------------------------------------------
+# URL pattern fragments for re-use
+#-----------------------------------------------------------------------------
+
+path_regex = r"(?P<path>(?:/.*)*)"
+notebook_name_regex = r"(?P<name>[^/]+\.ipynb)"
+notebook_path_regex = "%s/%s" % (path_regex, notebook_name_regex)
+
+#-----------------------------------------------------------------------------
 # URL to handler mappings
 #-----------------------------------------------------------------------------
 

--- a/IPython/html/nbconvert/handlers.py
+++ b/IPython/html/nbconvert/handlers.py
@@ -1,0 +1,68 @@
+import os
+
+from tornado import web
+
+from ..base.handlers import IPythonHandler
+from IPython.nbformat.current import to_notebook_json
+from IPython.nbconvert.exporters.export import exporter_map
+from IPython.utils import tz
+
+
+def has_resource_files(resources):
+    output_files_dir = resources.get('output_files_dir', "")
+    return bool(os.path.isdir(output_files_dir) and \
+                    os.listdir(output_files_dir))
+
+class NbconvertFileHandler(IPythonHandler):
+
+    SUPPORTED_METHODS = ('GET',)
+    
+    @web.authenticated
+    def get(self, format, path='', name=None):
+        exporter = exporter_map[format]()
+        
+        path = path.strip('/')
+        os_path = self.notebook_manager.get_os_path(name, path)
+        if not os.path.isfile(os_path):
+            raise web.HTTPError(404, u'Notebook does not exist: %s' % name)
+
+        info = os.stat(os_path)
+        self.set_header('Last-Modified', tz.utcfromtimestamp(info.st_mtime))
+        
+        output, resources = exporter.from_filename(os_path)
+        
+        # TODO: If there are resources, combine them into a zip file
+        assert not has_resource_files(resources)
+        
+        self.finish(output)
+
+class NbconvertPostHandler(IPythonHandler):
+    SUPPORTED_METHODS = ('POST',)
+
+    @web.authenticated 
+    def post(self, format):
+        exporter = exporter_map[format]()
+        
+        model = self.get_json_body()
+        nbnode = to_notebook_json(model['content'])
+        output, resources = exporter.from_notebook_node(nbnode)
+        
+        # TODO: If there are resources, combine them into a zip file
+        assert not has_resource_files(resources)
+        
+        self.finish(output)
+
+#-----------------------------------------------------------------------------
+# URL to handler mappings
+#-----------------------------------------------------------------------------
+
+_format_regex = r"(?P<format>\w+)"
+_path_regex = r"(?P<path>(?:/.*)*)"
+_notebook_name_regex = r"(?P<name>[^/]+\.ipynb)"
+_notebook_path_regex = "%s/%s" % (_path_regex, _notebook_name_regex)
+
+default_handlers = [
+    (r"/nbconvert/%s%s" % (_format_regex, _notebook_path_regex),
+         NbconvertFileHandler),
+    (r"/nbconvert/%s" % _format_regex, NbconvertPostHandler),
+]

--- a/IPython/html/nbconvert/handlers.py
+++ b/IPython/html/nbconvert/handlers.py
@@ -36,8 +36,9 @@ class NbconvertFileHandler(IPythonHandler):
                             'attachment; filename="%s"' % filename)
         
         # MIME type
-        if exporter.mime_type:
-            self.set_header('Content-Type', '%s; charset=utf-8' % exporter.mime_type)
+        if exporter.output_mimetype:
+            self.set_header('Content-Type',
+                            '%s; charset=utf-8' % exporter.output_mimetype)
 
         output, resources = exporter.from_filename(os_path)
         
@@ -57,8 +58,9 @@ class NbconvertPostHandler(IPythonHandler):
         nbnode = to_notebook_json(model['content'])
         
         # MIME type
-        if exporter.mime_type:
-            self.set_header('Content-Type', '%s; charset=utf-8' % exporter.mime_type)
+        if exporter.output_mimetype:
+            self.set_header('Content-Type',
+            '%s; charset=utf-8' % exporter.output_mimetype)
 
         output, resources = exporter.from_notebook_node(nbnode)
 

--- a/IPython/html/nbconvert/handlers.py
+++ b/IPython/html/nbconvert/handlers.py
@@ -28,11 +28,17 @@ class NbconvertFileHandler(IPythonHandler):
 
         info = os.stat(os_path)
         self.set_header('Last-Modified', tz.utcfromtimestamp(info.st_mtime))
+
+        # Force download if requested
         if self.get_argument('download', 'false').lower() == 'true':
             filename = os.path.splitext(name)[0] + '.' + exporter.file_extension
             self.set_header('Content-Disposition',
                             'attachment; filename="%s"' % filename)
         
+        # MIME type
+        if exporter.mime_type:
+            self.set_header('Content-Type', '%s; charset=utf-8' % exporter.mime_type)
+
         output, resources = exporter.from_filename(os_path)
         
         # TODO: If there are resources, combine them into a zip file
@@ -49,8 +55,13 @@ class NbconvertPostHandler(IPythonHandler):
         
         model = self.get_json_body()
         nbnode = to_notebook_json(model['content'])
-        output, resources = exporter.from_notebook_node(nbnode)
         
+        # MIME type
+        if exporter.mime_type:
+            self.set_header('Content-Type', '%s; charset=utf-8' % exporter.mime_type)
+
+        output, resources = exporter.from_notebook_node(nbnode)
+
         # TODO: If there are resources, combine them into a zip file
         assert not has_resource_files(resources)
         

--- a/IPython/html/nbconvert/handlers.py
+++ b/IPython/html/nbconvert/handlers.py
@@ -1,4 +1,6 @@
+import io
 import os
+import zipfile
 
 from tornado import web
 
@@ -6,12 +8,44 @@ from ..base.handlers import IPythonHandler, notebook_path_regex
 from IPython.nbformat.current import to_notebook_json
 from IPython.nbconvert.exporters.export import exporter_map
 from IPython.utils import tz
+from IPython.utils.py3compat import cast_bytes
 
+import sys
 
-def has_resource_files(resources):
-    output_files_dir = resources.get('output_files_dir', "")
-    return bool(os.path.isdir(output_files_dir) and \
-                    os.listdir(output_files_dir))
+def find_resource_files(output_files_dir):
+    files = []
+    for dirpath, dirnames, filenames in os.walk(output_files_dir):
+        files.extend([os.path.join(dirpath, f) for f in filenames])
+    return files
+
+def respond_zip(handler, name, output, resources):
+    """Zip up the output and resource files and respond with the zip file.
+
+    Returns True if it has served a zip file, False if there are no resource
+    files, in which case we serve the plain output file.
+    """
+    # Check if we have resource files we need to zip
+    output_files = resources.get('outputs', None)
+    if not output_files:
+        return False
+
+    # Headers
+    zip_filename = os.path.splitext(name)[0] + '.zip'
+    handler.set_header('Content-Disposition',
+                       'attachment; filename="%s"' % zip_filename)
+    handler.set_header('Content-Type', 'application/zip')
+
+    # Prepare the zip file
+    buffer = io.BytesIO()
+    zipf = zipfile.ZipFile(buffer, mode='w', compression=zipfile.ZIP_DEFLATED)
+    output_filename = os.path.splitext(name)[0] + '.' + resources['output_extension']
+    zipf.writestr(output_filename, cast_bytes(output, 'utf-8'))
+    for filename, data in output_files.items():
+        zipf.writestr(os.path.basename(filename), data)
+    zipf.close()
+
+    handler.finish(buffer.getvalue())
+    return True
 
 class NbconvertFileHandler(IPythonHandler):
 
@@ -29,22 +63,22 @@ class NbconvertFileHandler(IPythonHandler):
         info = os.stat(os_path)
         self.set_header('Last-Modified', tz.utcfromtimestamp(info.st_mtime))
 
+        output, resources = exporter.from_filename(os_path)
+
+        if respond_zip(self, name, output, resources):
+            return
+
         # Force download if requested
         if self.get_argument('download', 'false').lower() == 'true':
-            filename = os.path.splitext(name)[0] + '.' + exporter.file_extension
+            filename = os.path.splitext(name)[0] + '.' + resources['output_extension']
             self.set_header('Content-Disposition',
-                            'attachment; filename="%s"' % filename)
-        
+                               'attachment; filename="%s"' % filename)
+
         # MIME type
         if exporter.output_mimetype:
             self.set_header('Content-Type',
                             '%s; charset=utf-8' % exporter.output_mimetype)
 
-        output, resources = exporter.from_filename(os_path)
-        
-        # TODO: If there are resources, combine them into a zip file
-        assert not has_resource_files(resources)
-        
         self.finish(output)
 
 class NbconvertPostHandler(IPythonHandler):
@@ -56,17 +90,17 @@ class NbconvertPostHandler(IPythonHandler):
         
         model = self.get_json_body()
         nbnode = to_notebook_json(model['content'])
-        
-        # MIME type
-        if exporter.output_mimetype:
-            self.set_header('Content-Type',
-            '%s; charset=utf-8' % exporter.output_mimetype)
 
         output, resources = exporter.from_notebook_node(nbnode)
 
-        # TODO: If there are resources, combine them into a zip file
-        assert not has_resource_files(resources)
-        
+        if respond_zip(self, nbnode.metadata.name, output, resources):
+            return
+
+        # MIME type
+        if exporter.output_mimetype:
+            self.set_header('Content-Type',
+                            '%s; charset=utf-8' % exporter.output_mimetype)
+
         self.finish(output)
 
 #-----------------------------------------------------------------------------

--- a/IPython/html/nbconvert/handlers.py
+++ b/IPython/html/nbconvert/handlers.py
@@ -1,8 +1,9 @@
+import json
 import os
 
 from tornado import web
 
-from ..base.handlers import IPythonHandler
+from ..base.handlers import IPythonHandler, json_errors
 from IPython.nbformat.current import to_notebook_json
 from IPython.nbconvert.exporters.export import exporter_map
 from IPython.utils import tz
@@ -69,6 +70,19 @@ class NbconvertPostHandler(IPythonHandler):
         
         self.finish(output)
 
+class NbconvertRootHandler(IPythonHandler):
+    SUPPORTED_METHODS = ('GET',)
+
+    @web.authenticated
+    @json_errors
+    def get(self):
+        res = {}
+        for format, exporter in exporter_map.items():
+            res[format] = info = {}
+            info['output_mimetype'] = exporter.output_mimetype
+
+        self.finish(json.dumps(res))
+
 #-----------------------------------------------------------------------------
 # URL to handler mappings
 #-----------------------------------------------------------------------------
@@ -82,4 +96,5 @@ default_handlers = [
     (r"/nbconvert/%s%s" % (_format_regex, _notebook_path_regex),
          NbconvertFileHandler),
     (r"/nbconvert/%s" % _format_regex, NbconvertPostHandler),
+    (r"/nbconvert", NbconvertRootHandler),
 ]

--- a/IPython/html/nbconvert/handlers.py
+++ b/IPython/html/nbconvert/handlers.py
@@ -19,7 +19,7 @@ class NbconvertFileHandler(IPythonHandler):
     
     @web.authenticated
     def get(self, format, path='', name=None):
-        exporter = exporter_map[format]()
+        exporter = exporter_map[format](config=self.config)
         
         path = path.strip('/')
         os_path = self.notebook_manager.get_os_path(name, path)
@@ -52,7 +52,7 @@ class NbconvertPostHandler(IPythonHandler):
 
     @web.authenticated 
     def post(self, format):
-        exporter = exporter_map[format]()
+        exporter = exporter_map[format](config=self.config)
         
         model = self.get_json_body()
         nbnode = to_notebook_json(model['content'])

--- a/IPython/html/nbconvert/handlers.py
+++ b/IPython/html/nbconvert/handlers.py
@@ -2,7 +2,7 @@ import os
 
 from tornado import web
 
-from ..base.handlers import IPythonHandler
+from ..base.handlers import IPythonHandler, notebook_path_regex
 from IPython.nbformat.current import to_notebook_json
 from IPython.nbconvert.exporters.export import exporter_map
 from IPython.utils import tz
@@ -74,12 +74,10 @@ class NbconvertPostHandler(IPythonHandler):
 #-----------------------------------------------------------------------------
 
 _format_regex = r"(?P<format>\w+)"
-_path_regex = r"(?P<path>(?:/.*)*)"
-_notebook_name_regex = r"(?P<name>[^/]+\.ipynb)"
-_notebook_path_regex = "%s/%s" % (_path_regex, _notebook_name_regex)
+
 
 default_handlers = [
-    (r"/nbconvert/%s%s" % (_format_regex, _notebook_path_regex),
+    (r"/nbconvert/%s%s" % (_format_regex, notebook_path_regex),
          NbconvertFileHandler),
     (r"/nbconvert/%s" % _format_regex, NbconvertPostHandler),
 ]

--- a/IPython/html/nbconvert/handlers.py
+++ b/IPython/html/nbconvert/handlers.py
@@ -1,9 +1,8 @@
-import json
 import os
 
 from tornado import web
 
-from ..base.handlers import IPythonHandler, json_errors
+from ..base.handlers import IPythonHandler
 from IPython.nbformat.current import to_notebook_json
 from IPython.nbconvert.exporters.export import exporter_map
 from IPython.utils import tz
@@ -70,19 +69,6 @@ class NbconvertPostHandler(IPythonHandler):
         
         self.finish(output)
 
-class NbconvertRootHandler(IPythonHandler):
-    SUPPORTED_METHODS = ('GET',)
-
-    @web.authenticated
-    @json_errors
-    def get(self):
-        res = {}
-        for format, exporter in exporter_map.items():
-            res[format] = info = {}
-            info['output_mimetype'] = exporter.output_mimetype
-
-        self.finish(json.dumps(res))
-
 #-----------------------------------------------------------------------------
 # URL to handler mappings
 #-----------------------------------------------------------------------------
@@ -96,5 +82,4 @@ default_handlers = [
     (r"/nbconvert/%s%s" % (_format_regex, _notebook_path_regex),
          NbconvertFileHandler),
     (r"/nbconvert/%s" % _format_regex, NbconvertPostHandler),
-    (r"/nbconvert", NbconvertRootHandler),
 ]

--- a/IPython/html/nbconvert/handlers.py
+++ b/IPython/html/nbconvert/handlers.py
@@ -28,6 +28,10 @@ class NbconvertFileHandler(IPythonHandler):
 
         info = os.stat(os_path)
         self.set_header('Last-Modified', tz.utcfromtimestamp(info.st_mtime))
+        if self.get_argument('download', 'false').lower() == 'true':
+            filename = os.path.splitext(name)[0] + '.' + exporter.file_extension
+            self.set_header('Content-Disposition',
+                            'attachment; filename="%s"' % filename)
         
         output, resources = exporter.from_filename(os_path)
         

--- a/IPython/html/nbconvert/tests/test_nbconvert_api.py
+++ b/IPython/html/nbconvert/tests/test_nbconvert_api.py
@@ -61,10 +61,12 @@ class APITest(NotebookTestBase):
     def test_from_file(self):
         r = self.nbconvert_api.from_file('html', 'foo', 'testnb.ipynb')
         self.assertEqual(r.status_code, 200)
+        self.assertIn(u'text/html', r.headers['Content-Type'])
         self.assertIn(u'Created by test', r.text)
         self.assertIn(u'print', r.text)
-        
+
         r = self.nbconvert_api.from_file('python', 'foo', 'testnb.ipynb')
+        self.assertIn(u'text/x-python', r.headers['Content-Type'])
         self.assertIn(u'print(2*6)', r.text)
 
     def test_from_file_404(self):
@@ -74,8 +76,8 @@ class APITest(NotebookTestBase):
     def test_from_file_download(self):
         r = self.nbconvert_api.from_file('python', 'foo', 'testnb.ipynb', download=True)
         content_disposition = r.headers['Content-Disposition']
-        assert 'attachment' in content_disposition
-        assert 'testnb.py' in content_disposition
+        self.assertIn('attachment', content_disposition)
+        self.assertIn('testnb.py', content_disposition)
 
     def test_from_post(self):
         nbmodel_url = url_path_join(self.base_url(), 'api/notebooks/foo/testnb.ipynb')
@@ -83,8 +85,10 @@ class APITest(NotebookTestBase):
         
         r = self.nbconvert_api.from_post(format='html', nbmodel=nbmodel)
         self.assertEqual(r.status_code, 200)
+        self.assertIn(u'text/html', r.headers['Content-Type'])
         self.assertIn(u'Created by test', r.text)
         self.assertIn(u'print', r.text)
         
         r = self.nbconvert_api.from_post(format='python', nbmodel=nbmodel)
+        self.assertIn(u'text/x-python', r.headers['Content-Type'])
         self.assertIn(u'print(2*6)', r.text)

--- a/IPython/html/nbconvert/tests/test_nbconvert_api.py
+++ b/IPython/html/nbconvert/tests/test_nbconvert_api.py
@@ -1,0 +1,83 @@
+import io
+import json
+import os
+from os.path import join as pjoin
+import shutil
+
+import requests
+
+from IPython.html.utils import url_path_join
+from IPython.html.tests.launchnotebook import NotebookTestBase, assert_http_error
+from IPython.nbformat.current import (new_notebook, write, new_worksheet,
+                                      new_heading_cell, new_code_cell)
+
+class NbconvertAPI(object):
+    """Wrapper for nbconvert API calls."""
+    def __init__(self, base_url):
+        self.base_url = base_url
+
+    def _req(self, verb, path, body=None):
+        response = requests.request(verb,
+                url_path_join(self.base_url, 'nbconvert', path),
+                data=body,
+        )
+        response.raise_for_status()
+        return response
+
+    def from_file(self, format, path, name):
+        return self._req('GET', url_path_join(format, path, name))
+
+    def from_post(self, format, nbmodel):
+        body = json.dumps(nbmodel)
+        return self._req('POST', format, body)
+
+class APITest(NotebookTestBase):
+    def setUp(self):
+        nbdir = self.notebook_dir.name
+        
+        if not os.path.isdir(pjoin(nbdir, 'foo')):
+            os.mkdir(pjoin(nbdir, 'foo'))
+        
+        nb = new_notebook(name='testnb')
+        
+        ws = new_worksheet()
+        nb.worksheets = [ws]
+        ws.cells.append(new_heading_cell(u'Created by test ³'))
+        ws.cells.append(new_code_cell(input=u'print(2*6)'))
+        
+        with io.open(pjoin(nbdir, 'foo', 'testnb.ipynb'), 'w',
+                     encoding='utf-8') as f:
+            write(nb, f, format='ipynb')
+
+        self.nbconvert_api = NbconvertAPI(self.base_url())
+
+    def tearDown(self):
+        nbdir = self.notebook_dir.name
+
+        for dname in ['foo']:
+            shutil.rmtree(pjoin(nbdir, dname), ignore_errors=True)
+    
+    def test_from_file(self):
+        r = self.nbconvert_api.from_file('html', 'foo', 'testnb.ipynb')
+        self.assertEqual(r.status_code, 200)
+        self.assertIn(u'Created by test', r.text)
+        self.assertIn(u'print', r.text)
+        
+        r = self.nbconvert_api.from_file('python', 'foo', 'testnb.ipynb')
+        self.assertIn(u'print(2*6)', r.text)
+
+    def test_from_file_404(self):
+        with assert_http_error(404):
+            self.nbconvert_api.from_file('html', 'foo', 'thisdoesntexist.ipynb')
+
+    def test_from_post(self):
+        nbmodel_url = url_path_join(self.base_url(), 'api/notebooks/foo/testnb.ipynb')
+        nbmodel = requests.get(nbmodel_url).json()
+        
+        r = self.nbconvert_api.from_post(format='html', nbmodel=nbmodel)
+        self.assertEqual(r.status_code, 200)
+        self.assertIn(u'Created by test', r.text)
+        self.assertIn(u'print', r.text)
+        
+        r = self.nbconvert_api.from_post(format='python', nbmodel=nbmodel)
+        self.assertIn(u'print(2*6)', r.text)

--- a/IPython/html/nbconvert/tests/test_nbconvert_api.py
+++ b/IPython/html/nbconvert/tests/test_nbconvert_api.py
@@ -16,16 +16,17 @@ class NbconvertAPI(object):
     def __init__(self, base_url):
         self.base_url = base_url
 
-    def _req(self, verb, path, body=None):
+    def _req(self, verb, path, body=None, params=None):
         response = requests.request(verb,
                 url_path_join(self.base_url, 'nbconvert', path),
-                data=body,
+                data=body, params=params,
         )
         response.raise_for_status()
         return response
 
-    def from_file(self, format, path, name):
-        return self._req('GET', url_path_join(format, path, name))
+    def from_file(self, format, path, name, download=False):
+        return self._req('GET', url_path_join(format, path, name),
+                         params={'download':download})
 
     def from_post(self, format, nbmodel):
         body = json.dumps(nbmodel)
@@ -69,6 +70,12 @@ class APITest(NotebookTestBase):
     def test_from_file_404(self):
         with assert_http_error(404):
             self.nbconvert_api.from_file('html', 'foo', 'thisdoesntexist.ipynb')
+
+    def test_from_file_download(self):
+        r = self.nbconvert_api.from_file('python', 'foo', 'testnb.ipynb', download=True)
+        content_disposition = r.headers['Content-Disposition']
+        assert 'attachment' in content_disposition
+        assert 'testnb.py' in content_disposition
 
     def test_from_post(self):
         nbmodel_url = url_path_join(self.base_url(), 'api/notebooks/foo/testnb.ipynb')

--- a/IPython/html/nbconvert/tests/test_nbconvert_api.py
+++ b/IPython/html/nbconvert/tests/test_nbconvert_api.py
@@ -32,6 +32,9 @@ class NbconvertAPI(object):
         body = json.dumps(nbmodel)
         return self._req('POST', format, body)
 
+    def list_formats(self):
+        return self._req('GET', '')
+
 class APITest(NotebookTestBase):
     def setUp(self):
         nbdir = self.notebook_dir.name
@@ -92,3 +95,10 @@ class APITest(NotebookTestBase):
         r = self.nbconvert_api.from_post(format='python', nbmodel=nbmodel)
         self.assertIn(u'text/x-python', r.headers['Content-Type'])
         self.assertIn(u'print(2*6)', r.text)
+
+    def test_list_formats(self):
+        formats = self.nbconvert_api.list_formats().json()
+        self.assertIsInstance(formats, dict)
+        self.assertIn('python', formats)
+        self.assertIn('html', formats)
+        self.assertEqual(formats['python']['output_mimetype'], 'text/x-python')

--- a/IPython/html/nbconvert/tests/test_nbconvert_handlers.py
+++ b/IPython/html/nbconvert/tests/test_nbconvert_handlers.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 import io
 import json
 import os
@@ -95,10 +96,3 @@ class APITest(NotebookTestBase):
         r = self.nbconvert_api.from_post(format='python', nbmodel=nbmodel)
         self.assertIn(u'text/x-python', r.headers['Content-Type'])
         self.assertIn(u'print(2*6)', r.text)
-
-    def test_list_formats(self):
-        formats = self.nbconvert_api.list_formats().json()
-        self.assertIsInstance(formats, dict)
-        self.assertIn('python', formats)
-        self.assertIn('html', formats)
-        self.assertEqual(formats['python']['output_mimetype'], 'text/x-python')

--- a/IPython/html/nbconvert/tests/test_nbconvert_handlers.py
+++ b/IPython/html/nbconvert/tests/test_nbconvert_handlers.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import base64
 import io
 import json
 import os
@@ -37,6 +38,10 @@ class NbconvertAPI(object):
     def list_formats(self):
         return self._req('GET', '')
 
+png_green_pixel = base64.encodestring(b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00'
+b'\x00\x00\x01\x00\x00x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDAT'
+b'\x08\xd7c\x90\xfb\xcf\x00\x00\x02\\\x01\x1e.~d\x87\x00\x00\x00\x00IEND\xaeB`\x82')
+
 class APITest(NotebookTestBase):
     def setUp(self):
         nbdir = self.notebook_dir.name
@@ -51,6 +56,7 @@ class APITest(NotebookTestBase):
         ws.cells.append(new_heading_cell(u'Created by test ³'))
         cc1 = new_code_cell(input=u'print(2*6)')
         cc1.outputs.append(new_output(output_text=u'12'))
+        cc1.outputs.append(new_output(output_png=png_green_pixel, output_type='pyout'))
         ws.cells.append(cc1)
         
         with io.open(pjoin(nbdir, 'foo', 'testnb.ipynb'), 'w',

--- a/IPython/html/notebook/handlers.py
+++ b/IPython/html/notebook/handlers.py
@@ -20,8 +20,7 @@ import os
 from tornado import web
 HTTPError = web.HTTPError
 
-from ..base.handlers import IPythonHandler
-from ..services.notebooks.handlers import _notebook_path_regex, _path_regex
+from ..base.handlers import IPythonHandler, notebook_path_regex, path_regex
 from ..utils import url_path_join, url_escape
 
 #-----------------------------------------------------------------------------
@@ -85,7 +84,7 @@ class NotebookRedirectHandler(IPythonHandler):
 
 
 default_handlers = [
-    (r"/notebooks%s" % _notebook_path_regex, NotebookHandler),
-    (r"/notebooks%s" % _path_regex, NotebookRedirectHandler),
+    (r"/notebooks%s" % notebook_path_regex, NotebookHandler),
+    (r"/notebooks%s" % path_regex, NotebookRedirectHandler),
 ]
 

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -197,6 +197,7 @@ class NotebookWebApplication(web.Application):
         handlers.extend(load_handlers('services.notebooks.handlers'))
         handlers.extend(load_handlers('services.clusters.handlers'))
         handlers.extend(load_handlers('services.sessions.handlers'))
+        handlers.extend(load_handlers('services.nbconvert.handlers'))
         handlers.extend([
             (r"/files/(.*)", AuthenticatedFileHandler, {'path' : settings['notebook_manager'].notebook_dir}),
             (r"/nbextensions/(.*)", FileFindHandler, {'path' : settings['nbextensions_path']}),

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -192,6 +192,7 @@ class NotebookWebApplication(web.Application):
         handlers.extend(load_handlers('auth.login'))
         handlers.extend(load_handlers('auth.logout'))
         handlers.extend(load_handlers('notebook.handlers'))
+        handlers.extend(load_handlers('nbconvert.handlers'))
         handlers.extend(load_handlers('services.kernels.handlers'))
         handlers.extend(load_handlers('services.notebooks.handlers'))
         handlers.extend(load_handlers('services.clusters.handlers'))

--- a/IPython/html/services/nbconvert/handlers.py
+++ b/IPython/html/services/nbconvert/handlers.py
@@ -1,0 +1,23 @@
+import json
+
+from tornado import web
+
+from ...base.handlers import IPythonHandler, json_errors
+from IPython.nbconvert.exporters.export import exporter_map
+
+class NbconvertRootHandler(IPythonHandler):
+    SUPPORTED_METHODS = ('GET',)
+
+    @web.authenticated
+    @json_errors
+    def get(self):
+        res = {}
+        for format, exporter in exporter_map.items():
+            res[format] = info = {}
+            info['output_mimetype'] = exporter.output_mimetype
+
+        self.finish(json.dumps(res))
+
+default_handlers = [
+    (r"/api/nbconvert", NbconvertRootHandler),
+]

--- a/IPython/html/services/nbconvert/tests/test_nbconvert_api.py
+++ b/IPython/html/services/nbconvert/tests/test_nbconvert_api.py
@@ -1,0 +1,31 @@
+import requests
+
+from IPython.html.utils import url_path_join
+from IPython.html.tests.launchnotebook import NotebookTestBase
+
+class NbconvertAPI(object):
+    """Wrapper for nbconvert API calls."""
+    def __init__(self, base_url):
+        self.base_url = base_url
+
+    def _req(self, verb, path, body=None, params=None):
+        response = requests.request(verb,
+                url_path_join(self.base_url, 'api/nbconvert', path),
+                data=body, params=params,
+        )
+        response.raise_for_status()
+        return response
+
+    def list_formats(self):
+        return self._req('GET', '')
+
+class APITest(NotebookTestBase):
+    def setUp(self):
+        self.nbconvert_api = NbconvertAPI(self.base_url())
+
+    def test_list_formats(self):
+        formats = self.nbconvert_api.list_formats().json()
+        self.assertIsInstance(formats, dict)
+        self.assertIn('python', formats)
+        self.assertIn('html', formats)
+        self.assertEqual(formats['python']['output_mimetype'], 'text/x-python')

--- a/IPython/html/services/notebooks/filenbmanager.py
+++ b/IPython/html/services/notebooks/filenbmanager.py
@@ -178,7 +178,7 @@ class FileNotebookManager(NotebookManager):
         return notebooks
 
     def get_notebook_model(self, name, path='', content=True):
-        """ Takes a path and name for a notebook and returns it's model
+        """ Takes a path and name for a notebook and returns its model
         
         Parameters
         ----------

--- a/IPython/html/services/notebooks/handlers.py
+++ b/IPython/html/services/notebooks/handlers.py
@@ -23,7 +23,9 @@ from tornado import web
 from IPython.html.utils import url_path_join, url_escape
 from IPython.utils.jsonutil import date_default
 
-from IPython.html.base.handlers import IPythonHandler, json_errors
+from IPython.html.base.handlers import (IPythonHandler, json_errors,
+                                    notebook_path_regex, path_regex,
+                                    notebook_name_regex)
 
 #-----------------------------------------------------------------------------
 # Notebook web service handlers
@@ -264,17 +266,14 @@ class ModifyNotebookCheckpointsHandler(IPythonHandler):
 #-----------------------------------------------------------------------------
 
 
-_path_regex = r"(?P<path>(?:/.*)*)"
 _checkpoint_id_regex = r"(?P<checkpoint_id>[\w-]+)"
-_notebook_name_regex = r"(?P<name>[^/]+\.ipynb)"
-_notebook_path_regex = "%s/%s" % (_path_regex, _notebook_name_regex)
 
 default_handlers = [
-    (r"/api/notebooks%s/checkpoints" % _notebook_path_regex, NotebookCheckpointsHandler),
-    (r"/api/notebooks%s/checkpoints/%s" % (_notebook_path_regex, _checkpoint_id_regex),
+    (r"/api/notebooks%s/checkpoints" % notebook_path_regex, NotebookCheckpointsHandler),
+    (r"/api/notebooks%s/checkpoints/%s" % (notebook_path_regex, _checkpoint_id_regex),
         ModifyNotebookCheckpointsHandler),
-    (r"/api/notebooks%s" % _notebook_path_regex, NotebookHandler),
-    (r"/api/notebooks%s" % _path_regex, NotebookHandler),
+    (r"/api/notebooks%s" % notebook_path_regex, NotebookHandler),
+    (r"/api/notebooks%s" % path_regex, NotebookHandler),
 ]
 
 

--- a/IPython/html/static/notebook/js/celltoolbarpresets/rawcell.js
+++ b/IPython/html/static/notebook/js/celltoolbarpresets/rawcell.js
@@ -22,7 +22,7 @@
     ["reST", "text/restructuredtext"],
     ["HTML", "text/html"],
     ["Markdown", "text/markdown"],
-    ["Python", "application/x-python"],
+    ["Python", "text/x-python"],
     ["Custom", "dialog"],
 
     ],

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -133,7 +133,11 @@ var IPython = (function (IPython) {
         this.element.find('#download_html').click(function () {
             that._nbconvert('html', true);
         });
-        
+
+        this.element.find('#download_rst').click(function () {
+            that._nbconvert('rst', true);
+        });
+
         this.element.find('#rename_notebook').click(function () {
             IPython.save_widget.rename_notebook();
         });

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -83,11 +83,7 @@ var IPython = (function (IPython) {
             notebook_name + '.ipynb'
         ) + "?download=" + download.toString();
 
-        if (download) {
-            window.location.assign(url);
-        } else {
-            window.open(url);
-        }
+        window.open(url);
     }
 
     MenuBar.prototype.bind_events = function () {

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -69,6 +69,26 @@ var IPython = (function (IPython) {
         );
     };
 
+    MenuBar.prototype._nbconvert = function (format, download) {
+        download = download || false;
+        var notebook_name = IPython.notebook.get_notebook_name();
+        if (IPython.notebook.dirty) {
+            IPython.notebook.save_notebook({async : false});
+        }
+        var url = utils.url_path_join(
+            this.baseProjectUrl(),
+            'nbconvert',
+            format,
+            this.notebookPath(),
+            notebook_name + '.ipynb'
+        ) + "?download=" + download.toString();
+
+        if (download) {
+            window.location.assign(url);
+        } else {
+            window.open(url);
+        }
+    }
 
     MenuBar.prototype.bind_events = function () {
         //  File
@@ -102,24 +122,17 @@ var IPython = (function (IPython) {
             window.location.assign(url);
         });
         
-        /* FIXME: download-as-py doesn't work right now
-         * We will need nbconvert hooked up to get this back
-        
-        this.element.find('#download_py').click(function () {
-            var notebook_name = IPython.notebook.get_notebook_name();
-            if (IPython.notebook.dirty) {
-                IPython.notebook.save_notebook({async : false});
-            }
-            var url = utils.url_path_join(
-                that.baseProjectUrl(),
-                'api/notebooks',
-                that.notebookPath(),
-                notebook_name + '.ipynb?format=py&download=True'
-            );
-            window.location.assign(url);
+        this.element.find('#print_preview').click(function () {
+            that._nbconvert('html', false);
         });
-        
-        */
+
+        this.element.find('#download_py').click(function () {
+            that._nbconvert('python', true);
+        });
+
+        this.element.find('#download_html').click(function () {
+            that._nbconvert('html', true);
+        });
         
         this.element.find('#rename_notebook').click(function () {
             IPython.save_widget.rename_notebook();

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -83,6 +83,7 @@ class="notebook_app"
                         <li id="download_ipynb"><a href="#">IPython Notebook (.ipynb)</a></li>
                         <li id="download_py"><a href="#">Python (.py)</a></li>
                         <li id="download_html"><a href="#">HTML (.html)</a></li>
+                        <li id="download_rst"><a href="#">reST (.rst)</a></li>
                     </ul>
                 </li>
                 <li class="divider"></li>

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -77,10 +77,12 @@ class="notebook_app"
                   </ul>
                 </li>
                 <li class="divider"></li>
+                <li id="print_preview"><a href="#">Print Preview</a></li>
                 <li class="dropdown-submenu"><a href="#">Download as</a>
                     <ul class="dropdown-menu">
                         <li id="download_ipynb"><a href="#">IPython Notebook (.ipynb)</a></li>
-                        <!-- <li id="download_py"><a href="#">Python (.py)</a></li> -->
+                        <li id="download_py"><a href="#">Python (.py)</a></li>
+                        <li id="download_html"><a href="#">HTML (.html)</a></li>
                     </ul>
                 </li>
                 <li class="divider"></li>

--- a/IPython/html/tests/launchnotebook.py
+++ b/IPython/html/tests/launchnotebook.py
@@ -57,10 +57,9 @@ class NotebookTestBase(TestCase):
             '--notebook-dir=%s' % cls.notebook_dir.name,
         ]
         cls.notebook = Popen(notebook_args,
-            stdout=nose.ipy_stream_capturer.writefd,
+            stdout=nose.iptest_stdstreams_fileno(),
             stderr=STDOUT,
         )
-        nose.ipy_stream_capturer.ensure_started()
         cls.wait_until_alive()
 
     @classmethod

--- a/IPython/html/tests/launchnotebook.py
+++ b/IPython/html/tests/launchnotebook.py
@@ -1,12 +1,13 @@
 """Base class for notebook tests."""
 
-import os
 import sys
 import time
 import requests
 from contextlib import contextmanager
-from subprocess import Popen, PIPE
+from subprocess import Popen, STDOUT
 from unittest import TestCase
+
+import nose
 
 from IPython.utils.tempdir import TemporaryDirectory
 
@@ -55,11 +56,11 @@ class NotebookTestBase(TestCase):
             '--ipython-dir=%s' % cls.ipython_dir.name,
             '--notebook-dir=%s' % cls.notebook_dir.name,
         ]
-        devnull = open(os.devnull, 'w')
         cls.notebook = Popen(notebook_args,
-            stdout=devnull,
-            stderr=devnull,
+            stdout=nose.ipy_stream_capturer.writefd,
+            stderr=STDOUT,
         )
+        nose.ipy_stream_capturer.ensure_started()
         cls.wait_until_alive()
 
     @classmethod

--- a/IPython/html/tree/handlers.py
+++ b/IPython/html/tree/handlers.py
@@ -18,9 +18,8 @@ Authors:
 import os
 
 from tornado import web
-from ..base.handlers import IPythonHandler
+from ..base.handlers import IPythonHandler, notebook_path_regex, path_regex
 from ..utils import url_path_join, path2url, url2path, url_escape
-from ..services.notebooks.handlers import _notebook_path_regex, _path_regex
 
 #-----------------------------------------------------------------------------
 # Handlers
@@ -70,8 +69,8 @@ class TreeRedirectHandler(IPythonHandler):
 
 
 default_handlers = [
-    (r"/tree%s" % _notebook_path_regex, TreeHandler),
-    (r"/tree%s" % _path_regex, TreeHandler),
+    (r"/tree%s" % notebook_path_regex, TreeHandler),
+    (r"/tree%s" % path_regex, TreeHandler),
     (r"/tree", TreeHandler),
     (r"/", TreeRedirectHandler),
     ]

--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -53,6 +53,10 @@ class Exporter(LoggingConfigurable):
         help="Extension of the file that should be written to disk"
         )
 
+    mime_type = Unicode('', config=True,
+        help="MIME type of the result file, for HTTP response headers."
+        )
+
     #Configurability, allows the user to easily add filters and preprocessors.
     preprocessors = List(config=True,
         help="""List of preprocessors, by name or namespace, to enable.""")

--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -53,7 +53,7 @@ class Exporter(LoggingConfigurable):
         help="Extension of the file that should be written to disk"
         )
 
-    mime_type = Unicode('', config=True,
+    output_mimetype = Unicode('', config=True,
         help="MIME type of the result file, for HTTP response headers."
         )
 

--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -53,9 +53,10 @@ class Exporter(LoggingConfigurable):
         help="Extension of the file that should be written to disk"
         )
 
-    output_mimetype = Unicode('', config=True,
-        help="MIME type of the result file, for HTTP response headers."
-        )
+    # MIME type of the result file, for HTTP response headers.
+    # This is *not* a traitlet, because we want to be able to access it from
+    # the class, not just on instances.
+    output_mimetype = ''
 
     #Configurability, allows the user to easily add filters and preprocessors.
     preprocessors = List(config=True,

--- a/IPython/nbconvert/exporters/html.py
+++ b/IPython/nbconvert/exporters/html.py
@@ -36,6 +36,10 @@ class HTMLExporter(TemplateExporter):
         help="Extension of the file that should be written to disk"
         )
 
+    mime_type = Unicode('text/html', config=True,
+        help="MIME type of the result file, for HTTP response headers."
+        )
+
     default_template = Unicode('full', config=True, help="""Flavor of the data 
         format to use.  I.E. 'full' or 'basic'""")
     

--- a/IPython/nbconvert/exporters/html.py
+++ b/IPython/nbconvert/exporters/html.py
@@ -43,8 +43,7 @@ class HTMLExporter(TemplateExporter):
     default_template = Unicode('full', config=True, help="""Flavor of the data 
         format to use.  I.E. 'full' or 'basic'""")
     
-    def _output_mimetype_default(self):
-        return 'text/html'
+    output_mimetype = 'text/html'
     
     @property
     def default_config(self):

--- a/IPython/nbconvert/exporters/html.py
+++ b/IPython/nbconvert/exporters/html.py
@@ -43,7 +43,7 @@ class HTMLExporter(TemplateExporter):
     default_template = Unicode('full', config=True, help="""Flavor of the data 
         format to use.  I.E. 'full' or 'basic'""")
     
-    def _raw_mimetype_default(self):
+    def _output_mimetype_default(self):
         return 'text/html'
     
     @property

--- a/IPython/nbconvert/exporters/latex.py
+++ b/IPython/nbconvert/exporters/latex.py
@@ -40,10 +40,6 @@ class LatexExporter(TemplateExporter):
         'tex', config=True, 
         help="Extension of the file that should be written to disk")
 
-    mime_type = Unicode('application/x-tex', config=True,
-        help="MIME type of the result file, for HTTP response headers."
-        )
-
     default_template = Unicode('article', config=True, help="""Template of the 
         data format to use.  I.E. 'article' or 'report'""")
 
@@ -67,7 +63,7 @@ class LatexExporter(TemplateExporter):
     #Extension that the template files use.    
     template_extension = Unicode(".tplx", config=True)
 
-    def _raw_mimetype_default(self):
+    def _output_mimetype_default(self):
         return 'text/latex'
 
 

--- a/IPython/nbconvert/exporters/latex.py
+++ b/IPython/nbconvert/exporters/latex.py
@@ -40,6 +40,10 @@ class LatexExporter(TemplateExporter):
         'tex', config=True, 
         help="Extension of the file that should be written to disk")
 
+    mime_type = Unicode('application/x-tex', config=True,
+        help="MIME type of the result file, for HTTP response headers."
+        )
+
     default_template = Unicode('article', config=True, help="""Template of the 
         data format to use.  I.E. 'article' or 'report'""")
 

--- a/IPython/nbconvert/exporters/latex.py
+++ b/IPython/nbconvert/exporters/latex.py
@@ -63,8 +63,7 @@ class LatexExporter(TemplateExporter):
     #Extension that the template files use.    
     template_extension = Unicode(".tplx", config=True)
 
-    def _output_mimetype_default(self):
-        return 'text/latex'
+    output_mimetype = 'text/latex'
 
 
     @property

--- a/IPython/nbconvert/exporters/markdown.py
+++ b/IPython/nbconvert/exporters/markdown.py
@@ -30,15 +30,11 @@ class MarkdownExporter(TemplateExporter):
         'md', config=True, 
         help="Extension of the file that should be written to disk")
 
-    def _raw_mimetype_default(self):
+    def _output_mimetype_default(self):
         return 'text/markdown'
     
     def _raw_mimetypes_default(self):
-        return ['text/markdown', 'text/html']
-
-    mime_type = Unicode('text/x-markdown', config=True,
-        help="MIME type of the result file, for HTTP response headers."
-        )
+        return ['text/markdown', 'text/html', '']
 
     @property
     def default_config(self):

--- a/IPython/nbconvert/exporters/markdown.py
+++ b/IPython/nbconvert/exporters/markdown.py
@@ -30,8 +30,7 @@ class MarkdownExporter(TemplateExporter):
         'md', config=True, 
         help="Extension of the file that should be written to disk")
 
-    def _output_mimetype_default(self):
-        return 'text/markdown'
+    output_mimetype = 'text/markdown'
     
     def _raw_mimetypes_default(self):
         return ['text/markdown', 'text/html', '']

--- a/IPython/nbconvert/exporters/markdown.py
+++ b/IPython/nbconvert/exporters/markdown.py
@@ -36,6 +36,10 @@ class MarkdownExporter(TemplateExporter):
     def _raw_mimetypes_default(self):
         return ['text/markdown', 'text/html']
 
+    mime_type = Unicode('text/x-markdown', config=True,
+        help="MIME type of the result file, for HTTP response headers."
+        )
+
     @property
     def default_config(self):
         c = Config({'ExtractOutputPreprocessor':{'enabled':True}})

--- a/IPython/nbconvert/exporters/python.py
+++ b/IPython/nbconvert/exporters/python.py
@@ -29,9 +29,5 @@ class PythonExporter(TemplateExporter):
         'py', config=True, 
         help="Extension of the file that should be written to disk")
 
-    def _raw_mimetype_default(self):
-        return 'application/x-python'
-
-    mime_type = Unicode('text/x-python', config=True,
-        help="MIME type of the result file, for HTTP response headers."
-        )
+    def _output_mimetype_default(self):
+        return 'text/x-python'

--- a/IPython/nbconvert/exporters/python.py
+++ b/IPython/nbconvert/exporters/python.py
@@ -29,5 +29,4 @@ class PythonExporter(TemplateExporter):
         'py', config=True, 
         help="Extension of the file that should be written to disk")
 
-    def _output_mimetype_default(self):
-        return 'text/x-python'
+    output_mimetype = 'text/x-python'

--- a/IPython/nbconvert/exporters/python.py
+++ b/IPython/nbconvert/exporters/python.py
@@ -32,3 +32,6 @@ class PythonExporter(TemplateExporter):
     def _raw_mimetype_default(self):
         return 'application/x-python'
 
+    mime_type = Unicode('text/x-python', config=True,
+        help="MIME type of the result file, for HTTP response headers."
+        )

--- a/IPython/nbconvert/exporters/rst.py
+++ b/IPython/nbconvert/exporters/rst.py
@@ -32,7 +32,11 @@ class RSTExporter(TemplateExporter):
 
     def _raw_mimetype_default(self):
         return 'text/restructuredtext'
-    
+
+    mime_type = Unicode('text/x-rst', config=True,
+        help="MIME type of the result file, for HTTP response headers."
+        )
+
     @property
     def default_config(self):
         c = Config({'ExtractOutputPreprocessor':{'enabled':True}})

--- a/IPython/nbconvert/exporters/rst.py
+++ b/IPython/nbconvert/exporters/rst.py
@@ -30,8 +30,7 @@ class RSTExporter(TemplateExporter):
         'rst', config=True, 
         help="Extension of the file that should be written to disk")
 
-    def _output_mimetype_default(self):
-        return 'text/restructuredtext'
+    output_mimetype = 'text/restructuredtext'
 
     @property
     def default_config(self):

--- a/IPython/nbconvert/exporters/rst.py
+++ b/IPython/nbconvert/exporters/rst.py
@@ -30,12 +30,8 @@ class RSTExporter(TemplateExporter):
         'rst', config=True, 
         help="Extension of the file that should be written to disk")
 
-    def _raw_mimetype_default(self):
+    def _output_mimetype_default(self):
         return 'text/restructuredtext'
-
-    mime_type = Unicode('text/x-rst', config=True,
-        help="MIME type of the result file, for HTTP response headers."
-        )
 
     @property
     def default_config(self):

--- a/IPython/nbconvert/exporters/slides.py
+++ b/IPython/nbconvert/exporters/slides.py
@@ -31,9 +31,8 @@ class SlidesExporter(HTMLExporter):
         help="Extension of the file that should be written to disk"
         )
 
-    mime_type = Unicode('text/html', config=True,
-        help="MIME type of the result file, for HTTP response headers."
-        )
+    def _output_mimetype_default(self):
+        return 'text/html'
 
     default_template = Unicode('reveal', config=True, help="""Template of the 
         data format to use.  I.E. 'reveal'""")

--- a/IPython/nbconvert/exporters/slides.py
+++ b/IPython/nbconvert/exporters/slides.py
@@ -31,8 +31,7 @@ class SlidesExporter(HTMLExporter):
         help="Extension of the file that should be written to disk"
         )
 
-    def _output_mimetype_default(self):
-        return 'text/html'
+    output_mimetype = 'text/html'
 
     default_template = Unicode('reveal', config=True, help="""Template of the 
         data format to use.  I.E. 'reveal'""")

--- a/IPython/nbconvert/exporters/slides.py
+++ b/IPython/nbconvert/exporters/slides.py
@@ -31,6 +31,10 @@ class SlidesExporter(HTMLExporter):
         help="Extension of the file that should be written to disk"
         )
 
+    mime_type = Unicode('text/html', config=True,
+        help="MIME type of the result file, for HTTP response headers."
+        )
+
     default_template = Unicode('reveal', config=True, help="""Template of the 
         data format to use.  I.E. 'reveal'""")
 

--- a/IPython/nbconvert/exporters/templateexporter.py
+++ b/IPython/nbconvert/exporters/templateexporter.py
@@ -126,12 +126,13 @@ class TemplateExporter(Exporter):
         help="""Dictionary of filters, by name and namespace, to add to the Jinja
         environment.""")
 
-    raw_mimetype = Unicode('')
+    output_mimetype = Unicode('')
+
     raw_mimetypes = List(config=True,
         help="""formats of raw cells to be included in this Exporter's output."""
     )
     def _raw_mimetypes_default(self):
-        return [self.raw_mimetype]
+        return [self.output_mimetype, '']
 
 
     def __init__(self, config=None, extra_loaders=None, **kw):
@@ -209,7 +210,6 @@ class TemplateExporter(Exporter):
           preprocessors and filters.
         """
         nb_copy, resources = super(TemplateExporter, self).from_notebook_node(nb, resources, **kw)
-        resources.setdefault('raw_mimetype', self.raw_mimetype)
         resources.setdefault('raw_mimetypes', self.raw_mimetypes)
 
         self._load_template()

--- a/IPython/nbconvert/exporters/templateexporter.py
+++ b/IPython/nbconvert/exporters/templateexporter.py
@@ -126,8 +126,6 @@ class TemplateExporter(Exporter):
         help="""Dictionary of filters, by name and namespace, to add to the Jinja
         environment.""")
 
-    output_mimetype = Unicode('')
-
     raw_mimetypes = List(config=True,
         help="""formats of raw cells to be included in this Exporter's output."""
     )

--- a/IPython/nbconvert/exporters/tests/base.py
+++ b/IPython/nbconvert/exporters/tests/base.py
@@ -23,7 +23,7 @@ from ...tests.base import TestsBase
 #-----------------------------------------------------------------------------
 
 all_raw_mimetypes = {
-    'application/x-python',
+    'text/x-python',
     'text/markdown',
     'text/html',
     'text/restructuredtext',

--- a/IPython/nbconvert/exporters/tests/files/rawtest.ipynb
+++ b/IPython/nbconvert/exporters/tests/files/rawtest.ipynb
@@ -43,7 +43,7 @@
     {
      "cell_type": "raw",
      "metadata": {
-      "raw_mimetype": "application/x-python"
+      "raw_mimetype": "text/x-python"
      },
      "source": [
       "def bar():\n",

--- a/IPython/nbconvert/preprocessors/extractoutput.py
+++ b/IPython/nbconvert/preprocessors/extractoutput.py
@@ -17,7 +17,7 @@ import base64
 import sys
 import os
 
-from IPython.utils.traitlets import Unicode
+from IPython.utils.traitlets import Unicode, Set
 from .base import Preprocessor
 from IPython.utils import py3compat
 
@@ -34,6 +34,7 @@ class ExtractOutputPreprocessor(Preprocessor):
     output_filename_template = Unicode(
         "{unique_key}_{cell_index}_{index}.{extension}", config=True)
 
+    extract_output_types = Set({'png', 'jpg', 'svg', 'pdf'}, config=True)
 
     def preprocess_cell(self, cell, resources, cell_index):
         """
@@ -63,8 +64,8 @@ class ExtractOutputPreprocessor(Preprocessor):
         #Loop through all of the outputs in the cell
         for index, out in enumerate(cell.get('outputs', [])):
 
-            #Get the output in data formats that the template is interested in.
-            for out_type in self.display_data_priority:
+            #Get the output in data formats that the template needs extracted
+            for out_type in self.extract_output_types:
                 if out.hasattr(out_type): 
                     data = out[out_type]
 

--- a/IPython/nbconvert/preprocessors/tests/test_extractoutput.py
+++ b/IPython/nbconvert/preprocessors/tests/test_extractoutput.py
@@ -29,6 +29,7 @@ class TestExtractOutput(PreprocessorTestsBase):
     def build_preprocessor(self):
         """Make an instance of a preprocessor"""
         preprocessor = ExtractOutputPreprocessor()
+        preprocessor.extract_output_types = {'text', 'png'}
         preprocessor.enabled = True
         return preprocessor
 

--- a/IPython/nbconvert/templates/latex/skeleton/null.tplx
+++ b/IPython/nbconvert/templates/latex/skeleton/null.tplx
@@ -81,7 +81,7 @@ consider calling super even if it is a leave block, we might insert more blocks 
                 ((*- endblock headingcell -*))
             ((*- elif cell.cell_type in ['raw'] -*))
                 ((*- block rawcell scoped -*))
-                ((* if cell.metadata.get('raw_mimetype', resources.get('raw_mimetype')) == resources.get('raw_mimetype') *))
+                ((* if cell.metadata.get('raw_mimetype', '').lower() in resources.get('raw_mimetypes', ['']) *))
                 ((( cell.source )))
                 ((* endif *))
                 ((*- endblock rawcell -*))

--- a/IPython/nbconvert/templates/python.tpl
+++ b/IPython/nbconvert/templates/python.tpl
@@ -27,7 +27,7 @@ it introduces a new line
 {# .... #}
 
 {% block pyout %}
-{{ output.text | indent | comment_lines }}
+{{ output.text or '' | indent | comment_lines }}
 {% endblock pyout %}
 
 {% block stream %}

--- a/IPython/nbconvert/templates/skeleton/null.tpl
+++ b/IPython/nbconvert/templates/skeleton/null.tpl
@@ -77,7 +77,7 @@ consider calling super even if it is a leave block, we might insert more blocks 
                 {%- endblock headingcell -%}
             {%- elif cell.cell_type in ['raw'] -%}
                 {%- block rawcell scoped -%}
-                {% if cell.metadata.get('raw_mimetype', resources.get('raw_mimetype', '')).lower() in resources.get('raw_mimetypes', ['']) %}
+                {% if cell.metadata.get('raw_mimetype', '').lower() in resources.get('raw_mimetypes', ['']) %}
                 {{ cell.source }}
                 {% endif %}
                 {%- endblock rawcell -%}

--- a/IPython/nbformat/v3/nbbase.py
+++ b/IPython/nbformat/v3/nbbase.py
@@ -55,7 +55,8 @@ def new_output(output_type=None, output_text=None, output_png=None,
     output_html=None, output_svg=None, output_latex=None, output_json=None,
     output_javascript=None, output_jpeg=None, prompt_number=None,
     ename=None, evalue=None, traceback=None, stream=None, metadata=None):
-    """Create a new code cell with input and output"""
+    """Create a new output, to go in the ``cell.outputs`` list of a code cell.
+    """
     output = NotebookNode()
     if output_type is not None:
         output.output_type = unicode_type(output_type)

--- a/docs/source/whatsnew/pr/nbconvert-service.rst
+++ b/docs/source/whatsnew/pr/nbconvert-service.rst
@@ -1,0 +1,3 @@
+* Print preview is back in the notebook menus, along with options to
+  download the open notebook in various formats. This is powered by
+  nbconvert.


### PR DESCRIPTION
This brings back print preview and 'download as' (currently Python, HTML and reST are in the menu).

New URL patterns:
- `GET /nbconvert/<format>/path/to/Notebook.ipynb`
- `POST /nbconvert/<format>` with the JSON notebook model as the body data.

nbconvert exporters gain a `mime_type` traitlet, used in the HTTP response headers so the browser knows what type of file it's getting.
