### PR TITLE
Refactor output collapse/expand/scroll

### DIFF
--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -48,20 +48,13 @@ var IPython = (function (IPython) {
         this.prompt_overlay = $("<div/>");
         this.wrapper.append(this.prompt_overlay);
         this.wrapper.append(this.element);
-        this.wrapper.append(this.collapse_button);
     };
 
 
     OutputArea.prototype.style = function () {
-        this.collapse_button.hide();
-        this.prompt_overlay.hide();
-        
+
         this.wrapper.addClass('output_wrapper');
         this.element.addClass('output');
-        
-        this.collapse_button.addClass("btn output_collapsed");
-        this.collapse_button.attr('title', 'click to expand output');
-        this.collapse_button.html('. . .');
         
         this.prompt_overlay.addClass('out_prompt_overlay prompt');
         this.prompt_overlay.attr('title', 'click to expand output; double click to hide output');
@@ -94,8 +87,13 @@ var IPython = (function (IPython) {
 
     OutputArea.prototype.bind_events = function () {
         var that = this;
-        this.prompt_overlay.dblclick(function () { that.toggle_output(); });
-        this.prompt_overlay.click(function () { that.toggle_scroll(); });
+        // this.prompt_overlay.dblclick(function () { that.toggle_output(); });
+        // this.prompt_overlay.click(function () { that.toggle_scroll(); });
+        this.prompt_overlay.click(function () {
+            console.log('hi there');
+            that.toggle_output();
+        });
+
 
         this.element.resize(function () {
             // FIXME: Firefox on Linux misbehaves, so automatic scrolling is disabled
@@ -108,19 +106,15 @@ var IPython = (function (IPython) {
                 that.scroll_area();
             }
         });
-        this.collapse_button.click(function () {
-            that.expand();
-        });
     };
 
 
     OutputArea.prototype.collapse = function () {
         if (!this.collapsed) {
-            this.element.hide();
-            this.prompt_overlay.hide();
-            if (this.element.html()){
-                this.collapse_button.show();
-            }
+            this.wrapper.css('overflow-y', 'hidden');
+            this.wrapper.css('max-height', '30px');
+            // this.element.hide();
+            // this.prompt_overlay.hide();
             this.collapsed = true;
         }
     };
@@ -128,9 +122,10 @@ var IPython = (function (IPython) {
 
     OutputArea.prototype.expand = function () {
         if (this.collapsed) {
-            this.collapse_button.hide();
-            this.element.show();
-            this.prompt_overlay.show();
+            // this.element.show();
+            // this.prompt_overlay.show();
+            this.wrapper.css('max-height', '');
+            this.wrapper.css('overflow-y', 'visible');
             this.collapsed = false;
         }
     };

--- a/IPython/html/static/notebook/less/outputarea.less
+++ b/IPython/html/static/notebook/less/outputarea.less
@@ -30,11 +30,11 @@ div.out_prompt_overlay {
     .corner-all;
 }
 
-div.out_prompt_overlay:hover {
-    /* use inner shadow to get border that is computed the same on WebKit/FF */
-    .box-shadow(inset 0 0 1px #000);
-    background: rgba(240, 240, 240, 0.5);
-}
+// div.out_prompt_overlay:hover {
+//     /* use inner shadow to get border that is computed the same on WebKit/FF */
+//     .box-shadow(inset 0 0 1px #000);
+//     background: rgba(240, 240, 240, 0.5);
+// }
 
 div.output_prompt {
     color: darkred;

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -91,7 +91,6 @@ div.output_wrapper{position:relative;display:-webkit-box;-webkit-box-orient:vert
 div.output_scroll{height:24em;width:100%;overflow:auto;border-radius:4px;-webkit-box-shadow:inset 0 2px 8px rgba(0, 0, 0, 0.8);-moz-box-shadow:inset 0 2px 8px rgba(0, 0, 0, 0.8);box-shadow:inset 0 2px 8px rgba(0, 0, 0, 0.8);}
 div.output_collapsed{margin:0px;padding:0px;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;width:100%;}
 div.out_prompt_overlay{height:100%;padding:0px 0.4em;position:absolute;border-radius:4px;}
-div.out_prompt_overlay:hover{-webkit-box-shadow:inset 0 0 1px #000000;-moz-box-shadow:inset 0 0 1px #000000;box-shadow:inset 0 0 1px #000000;background:rgba(240, 240, 240, 0.5);}
 div.output_prompt{color:darkred;}
 div.output_area{padding:0px;page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;}div.output_area .MathJax_Display{text-align:left !important;}
 div.output_area .rendered_html table{margin-left:0;margin-right:0;}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1472,7 +1472,6 @@ div.output_wrapper{position:relative;display:-webkit-box;-webkit-box-orient:vert
 div.output_scroll{height:24em;width:100%;overflow:auto;border-radius:4px;-webkit-box-shadow:inset 0 2px 8px rgba(0, 0, 0, 0.8);-moz-box-shadow:inset 0 2px 8px rgba(0, 0, 0, 0.8);box-shadow:inset 0 2px 8px rgba(0, 0, 0, 0.8);}
 div.output_collapsed{margin:0px;padding:0px;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;width:100%;}
 div.out_prompt_overlay{height:100%;padding:0px 0.4em;position:absolute;border-radius:4px;}
-div.out_prompt_overlay:hover{-webkit-box-shadow:inset 0 0 1px #000000;-moz-box-shadow:inset 0 0 1px #000000;box-shadow:inset 0 0 1px #000000;background:rgba(240, 240, 240, 0.5);}
 div.output_prompt{color:darkred;}
 div.output_area{padding:0px;page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;}div.output_area .MathJax_Display{text-align:left !important;}
 div.output_area .rendered_html table{margin-left:0;margin-right:0;}


### PR DESCRIPTION
The current UI for controlling the different modes of the output area (collapsed/scrolled) is confusing. This is a work in progress to improve that UI. The idea is to set the `max-height` when collapsed to merely reduce the size of the output area, leaving a consistent area to click on for the mode changes.
