### PR TITLE
Bug fix for #4643: Regex object needs to be reset between calls in toolt...

### DIFF
--- a/IPython/html/static/notebook/js/tooltip.js
+++ b/IPython/html/static/notebook/js/tooltip.js
@@ -217,6 +217,8 @@ var IPython = (function (IPython) {
         }
         // remove everything after last open bracket
         line = line.replace(endBracket, "");
+	// reset the regex object
+	Tooltip.last_token_re.lastIndex = 0;
         return Tooltip.last_token_re.exec(line)
     };
 
@@ -266,7 +268,9 @@ var IPython = (function (IPython) {
         this.tabs_functions[this._consecutive_counter](cell, text);
 
         // then if we are at the end of list function, reset
-        if (this._consecutive_counter == this.tabs_functions.length) this.reset_tabs_function (cell, text);
+        if (this._consecutive_counter == this.tabs_functions.length) {
+	    this.reset_tabs_function (cell, text);
+	}
 
         return;
     }

--- a/IPython/html/static/notebook/js/tooltip.js
+++ b/IPython/html/static/notebook/js/tooltip.js
@@ -217,8 +217,8 @@ var IPython = (function (IPython) {
         }
         // remove everything after last open bracket
         line = line.replace(endBracket, "");
-	// reset the regex object
-	Tooltip.last_token_re.lastIndex = 0;
+        // reset the regex object
+        Tooltip.last_token_re.lastIndex = 0;
         return Tooltip.last_token_re.exec(line)
     };
 
@@ -269,7 +269,7 @@ var IPython = (function (IPython) {
 
         // then if we are at the end of list function, reset
         if (this._consecutive_counter == this.tabs_functions.length) {
-	    this.reset_tabs_function (cell, text);
+            this.reset_tabs_function (cell, text);
 	}
 
         return;


### PR DESCRIPTION
Tooltip.last_token_re is a js regex object that stores its results internally after an exec (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec). When it was starting at the result's lastIndex, it returned null (every other call) before resetting itself. This fixes the bug in #4643 
