### PR TITLE
Menu cleanup

### DIFF
--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -418,26 +418,30 @@ var IPython = (function (IPython) {
     };
 
 
-    CodeCell.prototype.collapse = function () {
+    CodeCell.prototype.collapse_output = function () {
         this.collapsed = true;
         this.output_area.collapse();
     };
 
 
-    CodeCell.prototype.expand = function () {
+    CodeCell.prototype.expand_output = function () {
         this.collapsed = false;
         this.output_area.expand();
+        this.output_area.unscroll_area();
     };
 
+    CodeCell.prototype.scroll_output = function () {
+        this.output_area.expand();
+        this.output_area.scroll_if_long();
+    };
 
     CodeCell.prototype.toggle_output = function () {
         this.collapsed = Boolean(1 - this.collapsed);
         this.output_area.toggle_output();
     };
 
-
     CodeCell.prototype.toggle_output_scroll = function () {
-    this.output_area.toggle_scroll();
+        this.output_area.toggle_scroll();
     };
 
 
@@ -510,6 +514,7 @@ var IPython = (function (IPython) {
 
     CodeCell.prototype.clear_output = function (wait) {
         this.output_area.clear_output(wait);
+        this.set_input_prompt();
     };
 
 
@@ -533,9 +538,9 @@ var IPython = (function (IPython) {
             this.output_area.fromJSON(data.outputs);
             if (data.collapsed !== undefined) {
                 if (data.collapsed) {
-                    this.collapse();
+                    this.collapse_output();
                 } else {
-                    this.expand();
+                    this.expand_output();
                 }
             }
         }

--- a/IPython/html/static/notebook/js/keyboardmanager.js
+++ b/IPython/html/static/notebook/js/keyboardmanager.js
@@ -451,7 +451,7 @@ var IPython = (function (IPython) {
             }
         },
         'shift+o' : {
-            help    : 'toggle output scroll',
+            help    : 'toggle output scrolling',
             help_index : 'gc',
             handler : function (event) {
                 IPython.notebook.toggle_output_scroll();

--- a/IPython/html/static/notebook/js/maintoolbar.js
+++ b/IPython/html/static/notebook/js/maintoolbar.js
@@ -110,6 +110,14 @@ var IPython = (function (IPython) {
                     callback : function () {
                         IPython.notebook.session.interrupt_kernel();
                         }
+                },
+                {
+                    id : 'repeat_b',
+                    label : 'Restart Kernel',
+                    icon : 'icon-repeat',
+                    callback : function () {
+                        IPython.notebook.restart_kernel();
+                        }
                 }
             ],'run_int');
     };

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -219,6 +219,33 @@ var IPython = (function (IPython) {
         this.element.find('#run_all_cells_below').click(function () {
             IPython.notebook.execute_cells_below();
         });
+        this.element.find('#to_code').click(function () {
+            IPython.notebook.to_code();
+        });
+        this.element.find('#to_markdown').click(function () {
+            IPython.notebook.to_markdown();
+        });
+        this.element.find('#to_raw').click(function () {
+            IPython.notebook.to_raw();
+        });
+        this.element.find('#to_heading1').click(function () {
+            IPython.notebook.to_heading(undefined, 1);
+        });
+        this.element.find('#to_heading2').click(function () {
+            IPython.notebook.to_heading(undefined, 2);
+        });
+        this.element.find('#to_heading3').click(function () {
+            IPython.notebook.to_heading(undefined, 3);
+        });
+        this.element.find('#to_heading4').click(function () {
+            IPython.notebook.to_heading(undefined, 4);
+        });
+        this.element.find('#to_heading5').click(function () {
+            IPython.notebook.to_heading(undefined, 5);
+        });
+        this.element.find('#to_heading6').click(function () {
+            IPython.notebook.to_heading(undefined, 6);
+        });
         this.element.find('#collapse_current_output').click(function () {
             IPython.notebook.collapse_output();
         });
@@ -242,6 +269,13 @@ var IPython = (function (IPython) {
         });
         this.element.find('#clear_all_output').click(function () {
             IPython.notebook.clear_all_output();
+        });
+        // Kernel
+        this.element.find('#int_kernel').click(function () {
+            IPython.notebook.session.interrupt_kernel();
+        });
+        this.element.find('#restart_kernel').click(function () {
+            IPython.notebook.restart_kernel();
         });
         // Help
         this.element.find('#keyboard_shortcuts').click(function () {

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -225,35 +225,17 @@ var IPython = (function (IPython) {
         this.element.find('#run_all_cells_below').click(function () {
             IPython.notebook.execute_cells_below();
         });
-        this.element.find('#to_code').click(function () {
-            IPython.notebook.to_code();
+        this.element.find('#collapse_current_output').click(function () {
+            IPython.notebook.collapse_output();
         });
-        this.element.find('#to_markdown').click(function () {
-            IPython.notebook.to_markdown();
+        this.element.find('#scroll_current_output').click(function () {
+            IPython.notebook.scroll_output();
         });
-        this.element.find('#to_raw').click(function () {
-            IPython.notebook.to_raw();
+        this.element.find('#expand_current_output').click(function () {
+            IPython.notebook.expand_output();
         });
-        this.element.find('#to_heading1').click(function () {
-            IPython.notebook.to_heading(undefined, 1);
-        });
-        this.element.find('#to_heading2').click(function () {
-            IPython.notebook.to_heading(undefined, 2);
-        });
-        this.element.find('#to_heading3').click(function () {
-            IPython.notebook.to_heading(undefined, 3);
-        });
-        this.element.find('#to_heading4').click(function () {
-            IPython.notebook.to_heading(undefined, 4);
-        });
-        this.element.find('#to_heading5').click(function () {
-            IPython.notebook.to_heading(undefined, 5);
-        });
-        this.element.find('#to_heading6').click(function () {
-            IPython.notebook.to_heading(undefined, 6);
-        });
-        this.element.find('#toggle_output').click(function () {
-            IPython.notebook.toggle_output();
+        this.element.find('#clear_current_output').click(function () {
+            IPython.notebook.clear_output();
         });
         this.element.find('#collapse_all_output').click(function () {
             IPython.notebook.collapse_all_output();

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -178,12 +178,6 @@ var IPython = (function (IPython) {
         this.element.find('#move_cell_down').click(function () {
             IPython.notebook.move_cell_down();
         });
-        this.element.find('#select_previous').click(function () {
-            IPython.notebook.select_prev();
-        });
-        this.element.find('#select_next').click(function () {
-            IPython.notebook.select_next();
-        });
         this.element.find('#edit_nb_metadata').click(function () {
             IPython.notebook.edit_metadata();
         });

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -267,13 +267,6 @@ var IPython = (function (IPython) {
         this.element.find('#clear_all_output').click(function () {
             IPython.notebook.clear_all_output();
         });
-        // Kernel
-        this.element.find('#int_kernel').click(function () {
-            IPython.notebook.session.interrupt_kernel();
-        });
-        this.element.find('#restart_kernel').click(function () {
-            IPython.notebook.restart_kernel();
-        });
         // Help
         this.element.find('#keyboard_shortcuts').click(function () {
             IPython.quick_help.show_keyboard_shortcuts();

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -246,30 +246,27 @@ var IPython = (function (IPython) {
         this.element.find('#to_heading6').click(function () {
             IPython.notebook.to_heading(undefined, 6);
         });
-        this.element.find('#collapse_current_output').click(function () {
-            IPython.notebook.collapse_output();
+        
+        this.element.find('#toggle_current_output').click(function () {
+            IPython.notebook.toggle_output();
         });
-        this.element.find('#scroll_current_output').click(function () {
-            IPython.notebook.scroll_output();
-        });
-        this.element.find('#expand_current_output').click(function () {
-            IPython.notebook.expand_output();
+        this.element.find('#toggle_current_output_scroll').click(function () {
+            IPython.notebook.toggle_output_scroll();
         });
         this.element.find('#clear_current_output').click(function () {
             IPython.notebook.clear_output();
         });
-        this.element.find('#collapse_all_output').click(function () {
-            IPython.notebook.collapse_all_output();
+        
+        this.element.find('#toggle_all_output').click(function () {
+            IPython.notebook.toggle_all_output();
         });
-        this.element.find('#scroll_all_output').click(function () {
-            IPython.notebook.scroll_all_output();
-        });
-        this.element.find('#expand_all_output').click(function () {
-            IPython.notebook.expand_all_output();
+        this.element.find('#toggle_all_output_scroll').click(function () {
+            IPython.notebook.toggle_all_output_scroll();
         });
         this.element.find('#clear_all_output').click(function () {
             IPython.notebook.clear_all_output();
         });
+        
         // Kernel
         this.element.find('#int_kernel').click(function () {
             IPython.notebook.session.interrupt_kernel();

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1296,6 +1296,21 @@ var IPython = (function (IPython) {
     };
 
     /**
+     * Hide/show the output of all cells.
+     * 
+     * @method toggle_all_output
+     */
+    Notebook.prototype.toggle_all_output = function () {
+        $.map(this.get_cells(), function (cell, i) {
+            if (cell instanceof IPython.CodeCell) {
+                cell.toggle_output();
+            }
+        });
+        // this should not be set if the `collapse` key is removed from nbformat
+        this.set_dirty(true);
+    };
+
+    /**
      * Toggle a scrollbar for long cell outputs.
      * 
      * @method toggle_output_scroll
@@ -1310,6 +1325,20 @@ var IPython = (function (IPython) {
         }
     };
 
+    /**
+     * Toggle the scrolling of long output on all cells.
+     * 
+     * @method toggle_all_output_scrolling
+     */
+    Notebook.prototype.toggle_all_output_scroll = function () {
+        $.map(this.get_cells(), function (cell, i) {
+            if (cell instanceof IPython.CodeCell) {
+                cell.toggle_output_scroll();
+            }
+        });
+        // this should not be set if the `collapse` key is removed from nbformat
+        this.set_dirty(true);
+    };
 
     // Other cell functions: line numbers, ...
 

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1165,47 +1165,16 @@ var IPython = (function (IPython) {
     /**
      * Hide a cell's output.
      * 
-     * @method collapse
+     * @method collapse_output
      * @param {Number} index A cell's numeric index
      */
-    Notebook.prototype.collapse = function (index) {
+    Notebook.prototype.collapse_output = function (index) {
         var i = this.index_or_selected(index);
-        this.get_cell(i).collapse();
-        this.set_dirty(true);
-    };
-
-    /**
-     * Show a cell's output.
-     * 
-     * @method expand
-     * @param {Number} index A cell's numeric index
-     */
-    Notebook.prototype.expand = function (index) {
-        var i = this.index_or_selected(index);
-        this.get_cell(i).expand();
-        this.set_dirty(true);
-    };
-
-    /** Toggle whether a cell's output is collapsed or expanded.
-     * 
-     * @method toggle_output
-     * @param {Number} index A cell's numeric index
-     */
-    Notebook.prototype.toggle_output = function (index) {
-        var i = this.index_or_selected(index);
-        this.get_cell(i).toggle_output();
-        this.set_dirty(true);
-    };
-
-    /**
-     * Toggle a scrollbar for long cell outputs.
-     * 
-     * @method toggle_output_scroll
-     * @param {Number} index A cell's numeric index
-     */
-    Notebook.prototype.toggle_output_scroll = function (index) {
-        var i = this.index_or_selected(index);
-        this.get_cell(i).toggle_output_scroll();
+        var cell = this.get_cell(i);
+        if (cell !== null && (cell instanceof IPython.CodeCell)) {
+            cell.collapse_output();
+            this.set_dirty(true);
+        }
     };
 
     /**
@@ -1218,7 +1187,7 @@ var IPython = (function (IPython) {
         var cells = this.get_cells();
         for (var i=0; i<ncells; i++) {
             if (cells[i] instanceof IPython.CodeCell) {
-                cells[i].output_area.collapse();
+                cells[i].collapse_output();
             }
         };
         // this should not be set if the `collapse` key is removed from nbformat
@@ -1226,21 +1195,18 @@ var IPython = (function (IPython) {
     };
 
     /**
-     * Expand each code cell's output area, and add a scrollbar for long output.
+     * Show a cell's output.
      * 
-     * @method scroll_all_output
+     * @method expand_output
+     * @param {Number} index A cell's numeric index
      */
-    Notebook.prototype.scroll_all_output = function () {
-        var ncells = this.ncells();
-        var cells = this.get_cells();
-        for (var i=0; i<ncells; i++) {
-            if (cells[i] instanceof IPython.CodeCell) {
-                cells[i].output_area.expand();
-                cells[i].output_area.scroll_if_long();
-            }
-        };
-        // this should not be set if the `collapse` key is removed from nbformat
-        this.set_dirty(true);
+    Notebook.prototype.expand_output = function (index) {
+        var i = this.index_or_selected(index);
+        var cell = this.get_cell(i);
+        if (cell !== null && (cell instanceof IPython.CodeCell)) {
+            cell.expand_output();
+            this.set_dirty(true);
+        }
     };
 
     /**
@@ -1253,12 +1219,26 @@ var IPython = (function (IPython) {
         var cells = this.get_cells();
         for (var i=0; i<ncells; i++) {
             if (cells[i] instanceof IPython.CodeCell) {
-                cells[i].output_area.expand();
-                cells[i].output_area.unscroll_area();
+                cells[i].expand_output();
             }
         };
         // this should not be set if the `collapse` key is removed from nbformat
         this.set_dirty(true);
+    };
+
+    /**
+     * Clear the selected CodeCell's output area.
+     * 
+     * @method clear_output
+     * @param {Number} index A cell's numeric index
+     */
+    Notebook.prototype.clear_output = function (index) {
+        var i = this.index_or_selected(index);
+        var cell = this.get_cell(i);
+        if (cell !== null && (cell instanceof IPython.CodeCell)) {
+            cell.clear_output();
+            this.set_dirty(true);
+        }
     };
 
     /**
@@ -1272,12 +1252,70 @@ var IPython = (function (IPython) {
         for (var i=0; i<ncells; i++) {
             if (cells[i] instanceof IPython.CodeCell) {
                 cells[i].clear_output();
-                // Make all In[] prompts blank, as well
-                // TODO: make this configurable (via checkbox?)
-                cells[i].set_input_prompt();
             }
         };
         this.set_dirty(true);
+    };
+
+    /**
+     * Scroll the selected CodeCell's output area.
+     * 
+     * @method scroll_output
+     * @param {Number} index A cell's numeric index
+     */
+    Notebook.prototype.scroll_output = function (index) {
+        var i = this.index_or_selected(index);
+        var cell = this.get_cell(i);
+        if (cell !== null && (cell instanceof IPython.CodeCell)) {
+            cell.scroll_output();
+            this.set_dirty(true);
+        }
+    };
+
+    /**
+     * Expand each code cell's output area, and add a scrollbar for long output.
+     * 
+     * @method scroll_all_output
+     */
+    Notebook.prototype.scroll_all_output = function () {
+        var ncells = this.ncells();
+        var cells = this.get_cells();
+        for (var i=0; i<ncells; i++) {
+            if (cells[i] instanceof IPython.CodeCell) {
+                cells[i].scroll_output();
+            }
+        };
+        // this should not be set if the `collapse` key is removed from nbformat
+        this.set_dirty(true);
+    };
+
+    /** Toggle whether a cell's output is collapsed or expanded.
+     * 
+     * @method toggle_output
+     * @param {Number} index A cell's numeric index
+     */
+    Notebook.prototype.toggle_output = function (index) {
+        var i = this.index_or_selected(index);
+        var cell = this.get_cell(i);
+        if (cell !== null && (cell instanceof IPython.CodeCell)) {
+            cell.toggle_output();
+            this.set_dirty(true);
+        }
+    };
+
+    /**
+     * Toggle a scrollbar for long cell outputs.
+     * 
+     * @method toggle_output_scroll
+     * @param {Number} index A cell's numeric index
+     */
+    Notebook.prototype.toggle_output_scroll = function (index) {
+        var i = this.index_or_selected(index);
+        var cell = this.get_cell(i);
+        if (cell !== null && (cell instanceof IPython.CodeCell)) {
+            cell.toggle_output_scroll();
+            this.set_dirty(true);
+        }
     };
 
 

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1183,13 +1183,11 @@ var IPython = (function (IPython) {
      * @method collapse_all_output
      */
     Notebook.prototype.collapse_all_output = function () {
-        var ncells = this.ncells();
-        var cells = this.get_cells();
-        for (var i=0; i<ncells; i++) {
-            if (cells[i] instanceof IPython.CodeCell) {
-                cells[i].collapse_output();
+        $.map(this.get_cells(), function (cell, i) {
+            if (cell instanceof IPython.CodeCell) {
+                cell.collapse_output();
             }
-        };
+        });
         // this should not be set if the `collapse` key is removed from nbformat
         this.set_dirty(true);
     };
@@ -1215,13 +1213,11 @@ var IPython = (function (IPython) {
      * @method expand_all_output
      */
     Notebook.prototype.expand_all_output = function () {
-        var ncells = this.ncells();
-        var cells = this.get_cells();
-        for (var i=0; i<ncells; i++) {
-            if (cells[i] instanceof IPython.CodeCell) {
-                cells[i].expand_output();
+        $.map(this.get_cells(), function (cell, i) {
+            if (cell instanceof IPython.CodeCell) {
+                cell.expand_output();
             }
-        };
+        });
         // this should not be set if the `collapse` key is removed from nbformat
         this.set_dirty(true);
     };
@@ -1247,13 +1243,11 @@ var IPython = (function (IPython) {
      * @method clear_all_output
      */
     Notebook.prototype.clear_all_output = function () {
-        var ncells = this.ncells();
-        var cells = this.get_cells();
-        for (var i=0; i<ncells; i++) {
-            if (cells[i] instanceof IPython.CodeCell) {
-                cells[i].clear_output();
+        $.map(this.get_cells(), function (cell, i) {
+            if (cell instanceof IPython.CodeCell) {
+                cell.clear_output();
             }
-        };
+        });
         this.set_dirty(true);
     };
 
@@ -1278,13 +1272,11 @@ var IPython = (function (IPython) {
      * @method scroll_all_output
      */
     Notebook.prototype.scroll_all_output = function () {
-        var ncells = this.ncells();
-        var cells = this.get_cells();
-        for (var i=0; i<ncells; i++) {
-            if (cells[i] instanceof IPython.CodeCell) {
-                cells[i].scroll_output();
+        $.map(this.get_cells(), function (cell, i) {
+            if (cell instanceof IPython.CodeCell) {
+                cell.scroll_output();
             }
-        };
+        });
         // this should not be set if the `collapse` key is removed from nbformat
         this.set_dirty(true);
     };

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -110,9 +110,6 @@ class="notebook_app"
                 <li id="move_cell_up"><a href="#">Move Cell Up</a></li>
                 <li id="move_cell_down"><a href="#">Move Cell Down</a></li>
                 <li class="divider"></li>
-                <li id="select_previous"><a href="#">Select Previous Cell</a></li>
-                <li id="select_next"><a href="#">Select Next Cell</a></li>
-                <li class="divider"></li>
                 <li id="edit_nb_metadata"><a href="#">Edit Notebook Metadata</a></li>
             </ul>
         </li>

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -51,7 +51,7 @@ class="notebook_app"
     <div class="container">
     <ul id="menus" class="nav">
         <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">File</a>
-            <ul class="dropdown-menu">
+            <ul id="file_menu" class="dropdown-menu">
                 <li id="new_notebook"
                     title="Make a new notebook (Opens a new window)">
                     <a href="#">New</a></li>
@@ -94,7 +94,7 @@ class="notebook_app"
             </ul>
         </li>
         <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Edit</a>
-            <ul class="dropdown-menu">
+            <ul id="edit_menu" class="dropdown-menu">
                 <li id="cut_cell"><a href="#">Cut Cell</a></li>
                 <li id="copy_cell"><a href="#">Copy Cell</a></li>
                 <li id="paste_cell_above" class="disabled"><a href="#">Paste Cell Above</a></li>
@@ -114,7 +114,7 @@ class="notebook_app"
             </ul>
         </li>
         <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">View</a>
-            <ul class="dropdown-menu">
+            <ul id="view_menu" class="dropdown-menu">
                 <li id="toggle_header"
                     title="Show/Hide the IPython Notebook logo and notebook title (above menu bar)">
                     <a href="#">Toggle Header</a></li>
@@ -124,7 +124,7 @@ class="notebook_app"
             </ul>
         </li>
         <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Insert</a>
-            <ul class="dropdown-menu">
+            <ul id="insert_menu" class="dropdown-menu">
                 <li id="insert_cell_above"
                     title="Insert an empty Code cell above the currently active cell">
                     <a href="#">Insert Cell Above</a></li>
@@ -134,7 +134,7 @@ class="notebook_app"
             </ul>
         </li>
         <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Cell</a>
-            <ul class="dropdown-menu">
+            <ul id="cell_menu" class="dropdown-menu">
                 <li id="run_cell" title="Run this cell, and move cursor to the next one">
                     <a href="#">Run</a></li>
                 <li id="run_cell_select_below" title="Run this cell, select below">
@@ -205,7 +205,7 @@ class="notebook_app"
             </ul>
         </li>
         <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Kernel</a>
-            <ul class="dropdown-menu">
+            <ul id="kernel_menu" class="dropdown-menu">
                 <li id="int_kernel"
                     title="Send KeyboardInterrupt (CTRL-C) to the Kernel">
                     <a href="#">Interrupt</a></li>
@@ -215,7 +215,7 @@ class="notebook_app"
             </ul>
         </li>
         <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Help</a>
-            <ul class="dropdown-menu" title="Opens in a new window">
+            <ul id="help_menu" class="dropdown-menu">
                 <li><a href="http://ipython.org/documentation.html" target="_blank">IPython Help</a></li>
                 <li><a href="http://ipython.org/ipython-doc/stable/interactive/notebook.html" target="_blank">Notebook Help</a></li>
                 <li id="keyboard_shortcuts" title="Opens a tooltip with all keyboard shortcuts"><a href="#">Keyboard Shortcuts</a></li>

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -151,39 +151,26 @@ class="notebook_app"
                 <li id="run_all_cells_below" title="Run this cell and all cells below it">
                     <a href="#">Run All Below</a></li>
                 <li class="divider"></li>
-                <li id="change_cell_type" class="dropdown-submenu"
-                    title="All cells in the notebook have a cell type. By default, new cells are created as 'Code' cells">
-                    <a href="#">Cell Type</a>
+                <li id="current_outputs" class="dropdown-submenu"><a href="#">Current Output</a>
                     <ul class="dropdown-menu">
-                      <li id="to_code"
-                          title="Contents will be sent to the kernel for execution, and output will display in the footer of cell">
-                          <a href="#">Code</a></li>
-                      <li id="to_markdown"
-                          title="Contents will be rendered as HTML and serve as explanatory text">
-                          <a href="#">Markdown</a></li>
-                      <li id="to_raw"
-                          title="Contents will pass through nbconvert unmodified">
-                          <a href="#">Raw NBConvert</a></li>
-                      <li id="to_heading1"><a href="#">Heading 1</a></li>
-                      <li id="to_heading2"><a href="#">Heading 2</a></li>
-                      <li id="to_heading3"><a href="#">Heading 3</a></li>
-                      <li id="to_heading4"><a href="#">Heading 4</a></li>
-                      <li id="to_heading5"><a href="#">Heading 5</a></li>
-                      <li id="to_heading6"><a href="#">Heading 6</a></li>
+                        <li id="collapse_current_output"><a href="#">Collapse</a></li>
+                        <li id="expand_current_output"><a href="#">Expand</a></li>
+                        <li id="clear_current_output"
+                            title="Clear the output portion of the current cell">
+                            <a href="#">Clear</a>
+                        </li>
+                        <li id="scroll_current_output"><a href="#">Scroll Long</a></li>
                     </ul>
                 </li>
-                <li class="divider"></li>
-                <li id="toggle_output"
-                    title="Show/Hide the output portion of a Code cell">
-                    <a href="#">Toggle Current Output</a></li>
                 <li id="all_outputs" class="dropdown-submenu"><a href="#">All Output</a>
                     <ul class="dropdown-menu">
-                        <li id="expand_all_output"><a href="#">Expand</a></li>
-                        <li id="scroll_all_output"><a href="#">Scroll Long</a></li>
                         <li id="collapse_all_output"><a href="#">Collapse</a></li>
+                        <li id="expand_all_output"><a href="#">Expand</a></li>
                         <li id="clear_all_output"
-                            title="Remove the output portion of all Code cells">
-                            <a href="#">Clear</a></li>
+                            title="Clear the output portion of all Code cells">
+                            <a href="#">Clear</a>
+                        </li>
+                        <li id="scroll_all_output"><a href="#">Scroll Long</a></li>
                     </ul>
                 </li>
             </ul>

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -172,24 +172,34 @@ class="notebook_app"
                 <li class="divider"></li>
                 <li id="current_outputs" class="dropdown-submenu"><a href="#">Current Output</a>
                     <ul class="dropdown-menu">
-                        <li id="collapse_current_output"><a href="#">Collapse</a></li>
-                        <li id="expand_current_output"><a href="#">Expand</a></li>
+                        <li id="toggle_current_output"
+                            title="Hide/Show the output of the current cell">
+                            <a href="#">Toggle</a>
+                        </li>
+                        <li id="toggle_current_output_scroll"
+                            title="Scroll the output of the current cell">
+                            <a href="#">Toggle Scrolling</a>
+                        </li>
                         <li id="clear_current_output"
-                            title="Clear the output portion of the current cell">
+                            title="Clear the output of the current cell">
                             <a href="#">Clear</a>
                         </li>
-                        <li id="scroll_current_output"><a href="#">Scroll Long</a></li>
                     </ul>
                 </li>
                 <li id="all_outputs" class="dropdown-submenu"><a href="#">All Output</a>
                     <ul class="dropdown-menu">
-                        <li id="collapse_all_output"><a href="#">Collapse</a></li>
-                        <li id="expand_all_output"><a href="#">Expand</a></li>
+                        <li id="toggle_all_output"
+                            title="Hide/Show the output of all cells">
+                            <a href="#">Toggle</a>
+                        </li>
+                        <li id="toggle_all_output_scroll"
+                            title="Scroll the output of all cells">
+                            <a href="#">Toggle Scrolling</a>
+                        </li>
                         <li id="clear_all_output"
-                            title="Clear the output portion of all Code cells">
+                            title="Clear the output of all cells">
                             <a href="#">Clear</a>
                         </li>
-                        <li id="scroll_all_output"><a href="#">Scroll Long</a></li>
                     </ul>
                 </li>
             </ul>

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -148,6 +148,28 @@ class="notebook_app"
                 <li id="run_all_cells_below" title="Run this cell and all cells below it">
                     <a href="#">Run All Below</a></li>
                 <li class="divider"></li>
+                <li id="change_cell_type" class="dropdown-submenu"
+                    title="All cells in the notebook have a cell type. By default, new cells are created as 'Code' cells">
+                    <a href="#">Cell Type</a>
+                    <ul class="dropdown-menu">
+                      <li id="to_code"
+                          title="Contents will be sent to the kernel for execution, and output will display in the footer of cell">
+                          <a href="#">Code</a></li>
+                      <li id="to_markdown"
+                          title="Contents will be rendered as HTML and serve as explanatory text">
+                          <a href="#">Markdown</a></li>
+                      <li id="to_raw"
+                          title="Contents will pass through nbconvert unmodified">
+                          <a href="#">Raw NBConvert</a></li>
+                      <li id="to_heading1"><a href="#">Heading 1</a></li>
+                      <li id="to_heading2"><a href="#">Heading 2</a></li>
+                      <li id="to_heading3"><a href="#">Heading 3</a></li>
+                      <li id="to_heading4"><a href="#">Heading 4</a></li>
+                      <li id="to_heading5"><a href="#">Heading 5</a></li>
+                      <li id="to_heading6"><a href="#">Heading 6</a></li>
+                    </ul>
+                </li>
+                <li class="divider"></li>
                 <li id="current_outputs" class="dropdown-submenu"><a href="#">Current Output</a>
                     <ul class="dropdown-menu">
                         <li id="collapse_current_output"><a href="#">Collapse</a></li>
@@ -170,6 +192,16 @@ class="notebook_app"
                         <li id="scroll_all_output"><a href="#">Scroll Long</a></li>
                     </ul>
                 </li>
+            </ul>
+        </li>
+        <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Kernel</a>
+            <ul class="dropdown-menu">
+                <li id="int_kernel"
+                    title="Send KeyboardInterrupt (CTRL-C) to the Kernel">
+                    <a href="#">Interrupt</a></li>
+                <li id="restart_kernel"
+                    title="Restart the Kernel">
+                    <a href="#">Restart</a></li>
             </ul>
         </li>
         <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Help</a>

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -188,16 +188,6 @@ class="notebook_app"
                 </li>
             </ul>
         </li>
-        <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Kernel</a>
-            <ul class="dropdown-menu">
-                <li id="int_kernel"
-                    title="Send KeyboardInterrupt (CTRL-C) to the Kernel">
-                    <a href="#">Interrupt</a></li>
-                <li id="restart_kernel"
-                    title="Restart the Kernel">
-                    <a href="#">Restart</a></li>
-            </ul>
-        </li>
         <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Help</a>
             <ul class="dropdown-menu" title="Opens in a new window">
                 <li><a href="http://ipython.org/documentation.html" target="_blank">IPython Help</a></li>


### PR DESCRIPTION
We had a lot of stuff in the menus that was not really needed and some other stuff that was poorly organized. Here is a summary:
- Removed the Kernel menu entirely. All kernel actions are in the toolbar.
- Added a "Restart Kernel" button to the toolbar.
- Removed the cell selection menu items from the "Cell" menu. The are again the toolbar.
- Cleaned up the output management menu items in the "Cell" menu.
- Removed the unneeded "Select Prev|Next" from the "Edit" menu.

Yeah simplification!
