### PR TITLE
check for libedit in readline on OS X

### DIFF
--- a/setupext/setupext.py
+++ b/setupext/setupext.py
@@ -162,5 +162,8 @@ def check_for_readline():
             print_status('readline', "no pyreadline-%s < 1.7.1" % vs)
             return False
     else:
+        if sys.platform == 'darwin' and 'libedit' in readline.__doc__:
+            print_status('readline', "no (libedit detected)")
+            return False
         print_status('readline', "yes")
         return True


### PR DESCRIPTION
ensures readline is expressed as setuptools dependency on OS X if libedit is detected.
