### PR TITLE
Make non-ASCII docstring unicode

### DIFF
--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -234,7 +234,7 @@ rprint = raw_print
 rprinte = raw_print_err
 
 def unicode_std_stream(stream='stdout'):
-    """Get a wrapper to write unicode to stdout/stderr as UTF-8.
+    u"""Get a wrapper to write unicode to stdout/stderr as UTF-8.
 
     This ignores environment variables and default encodings, to reliably write
     unicode to stdout or stderr.


### PR DESCRIPTION
We shouldn't have non-ascii characters in a bytes literal. This seems to be the source of problems for the docs build on ShiningPanda.

Merging straight away, just making a PR so there's a record of this.
