### PR TITLE
ENH: %lsext magic and entry_points for ipython_extensions, ipython_exporters

### DIFF
--- a/IPython/core/extensions.py
+++ b/IPython/core/extensions.py
@@ -213,8 +213,15 @@ class ExtensionManager(Configurable):
         return pkg_resources.iter_entry_points(group='ipython_extensions')
 
     def print_extensions(self):
-        """Print the list of IPython extensions which define
-        ``ipython_extension`` ``entry_points``, and their source locations
+        """Print a list of Loaded, Registered, and IPYTHONDIR extensions
+
+        Loaded extensions are already loaded in the IPython config.
+
+        'Registered' extensions define  ``ipython_extension`` ``entry_points``
+        in their ``setup.py`` files.
+
+        IPYTHONDIR extensions must contain a function named
+        ``load_ipython_extension``.
         """
         import pkgutil
         import glob
@@ -236,9 +243,3 @@ class ExtensionManager(Configurable):
             os.path.join(self.ipython_extension_dir, '*')):
             print(' %r' % path_)
 
-        # .. note: If the extension is not listed here, it may very well be
-        #    still %load_ext-able. Any Python module with a
-        #    load_ipython_extension function may be an IPython extension.
-        #    You might consider adding a ipython_extension entrypoint
-        #    in the extension; or searching sys.path with something like
-        #    grin --sys-path load_ipython_extension

--- a/IPython/core/extensions.py
+++ b/IPython/core/extensions.py
@@ -233,7 +233,7 @@ class ExtensionManager(Configurable):
 
         print("Available (IPYTHONDIR):")
         for path_ in glob.glob(
-            os.path.join(self.ipython_extension_dir, '*.py*')):
+            os.path.join(self.ipython_extension_dir, '*')):
             print(' %r' % path_)
 
         # .. note: If the extension is not listed here, it may very well be

--- a/IPython/core/extensions.py
+++ b/IPython/core/extensions.py
@@ -17,6 +17,7 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
+from collections import OrderedDict
 import os
 from shutil import copyfile
 import sys
@@ -45,7 +46,7 @@ class ExtensionManager(Configurable):
     the only argument.  You can do anything you want with IPython at
     that point, including defining new magic and aliases, adding new
     components, etc.
-    
+
     You can also optionally define an :func:`unload_ipython_extension(ipython)`
     function, which will be called if the user unloads or reloads the extension.
     The extension manager will only call :func:`load_ipython_extension` again
@@ -65,7 +66,7 @@ class ExtensionManager(Configurable):
         self.shell.on_trait_change(
             self._on_ipython_dir_changed, 'ipython_dir'
         )
-        self.loaded = set()
+        self.loaded = OrderedDict()
 
     def __del__(self):
         self.shell.on_trait_change(
@@ -89,16 +90,16 @@ class ExtensionManager(Configurable):
         """
         if module_str in self.loaded:
             return "already loaded"
-        
+
         from IPython.utils.syspathcontext import prepended_to_syspath
-        
+
         with self.shell.builtin_trap:
             if module_str not in sys.modules:
                 with prepended_to_syspath(self.ipython_extension_dir):
                     __import__(module_str)
             mod = sys.modules[module_str]
             if self._call_load_ipython_extension(mod):
-                self.loaded.add(module_str)
+                self.loaded[module_str] = mod
             else:
                 return "no load function"
 
@@ -107,18 +108,18 @@ class ExtensionManager(Configurable):
 
         This function looks up the extension's name in ``sys.modules`` and
         simply calls ``mod.unload_ipython_extension(self)``.
-        
+
         Returns the string "no unload function" if the extension doesn't define
         a function to unload itself, "not loaded" if the extension isn't loaded,
         otherwise None.
         """
         if module_str not in self.loaded:
             return "not loaded"
-        
+
         if module_str in sys.modules:
             mod = sys.modules[module_str]
             if self._call_unload_ipython_extension(mod):
-                self.loaded.discard(module_str)
+                self.loaded.pop(module_str)
             else:
                 return "no unload function"
 
@@ -138,7 +139,7 @@ class ExtensionManager(Configurable):
             with prepended_to_syspath(self.ipython_extension_dir):
                 reload(mod)
             if self._call_load_ipython_extension(mod):
-                self.loaded.add(module_str)
+                self.loaded[module_str] = mod
         else:
             self.load_extension(module_str)
 
@@ -153,7 +154,7 @@ class ExtensionManager(Configurable):
             return True
 
     def install_extension(self, url, filename=None):
-        """Download and install an IPython extension. 
+        """Download and install an IPython extension.
 
         If filename is given, the file will be so named (inside the extension
         directory). Otherwise, the name from the URL will be used. The file must
@@ -187,3 +188,57 @@ class ExtensionManager(Configurable):
         filename = os.path.join(self.ipython_extension_dir, filename)
         copy(url, filename)
         return filename
+
+    @staticmethod
+    def list_available_extensions():
+        """List IPython extensions which define ``ipython_extension``
+        setuptools ``entry_points``
+
+        Like so::
+
+            setup(
+                #...
+                entry_points='''
+                [ipython_extensions]
+                myextension = myextension_pkg.module
+                ''')
+
+        Or like::
+
+            entry_points['ipython_extensions'] = [
+                'myextension = myextension_pkg.module']
+
+        """
+        import pkg_resources
+        return pkg_resources.iter_entry_points(group='ipython_extensions')
+
+    def print_extensions(self):
+        """Print the list of IPython extensions which define
+        ``ipython_extension`` ``entry_points``, and their source locations
+        """
+        import pkgutil
+        import glob
+
+        print("Loaded:")
+        for modulestr, mod in self.loaded.iteritems():
+            path_ = mod.__file__
+            print(' %s -- %r' % (modulestr, mod.__file__))
+        print("")
+
+        print("Available (Registered):")
+        for ext in ExtensionManager.list_available_extensions():
+            path_ = pkgutil.find_loader(ext.module_name).filename
+            print(' %s -- %r' % (ext.name, path_))
+        print("")
+
+        print("Available (IPYTHONDIR):")
+        for path_ in glob.glob(
+            os.path.join(self.ipython_extension_dir, '*.py*')):
+            print(' %r' % path_)
+
+        # .. note: If the extension is not listed here, it may very well be
+        #    still %load_ext-able. Any Python module with a
+        #    load_ipython_extension function may be an IPython extension.
+        #    You might consider adding a ipython_extension entrypoint
+        #    in the extension; or searching sys.path with something like
+        #    grin --sys-path load_ipython_extension

--- a/IPython/core/extensions.py
+++ b/IPython/core/extensions.py
@@ -220,7 +220,7 @@ class ExtensionManager(Configurable):
         import glob
 
         print("Loaded:")
-        for modulestr, mod in self.loaded.iteritems():
+        for modulestr, mod in self.loaded.items():
             path_ = mod.__file__
             print(' %s -- %r' % (modulestr, mod.__file__))
         print("")

--- a/IPython/core/magics/extension.py
+++ b/IPython/core/magics/extension.py
@@ -57,7 +57,10 @@ class ExtensionMagics(Magics):
 
     @line_magic
     def load_ext(self, module_str):
-        """Load an IPython extension by its module name."""
+        """Load an IPython extension by its module name.
+
+        Use ``%lsext`` to list Loaded, Registered, and IPYTHONDIR extensions.
+        """
         if not module_str:
             raise UsageError('Missing module name.')
         res = self.shell.extension_manager.load_extension(module_str)
@@ -93,7 +96,7 @@ class ExtensionMagics(Magics):
         self.shell.extension_manager.reload_extension(module_str)
 
     @line_magic
-    def list_extensions(self, _):
-        """List extensions specifying ``ipython_extensions`` ``entry_points``
+    def lsext(self, _):
+        """List Loaded, Registered, and IPYTHONDIR extensions
         """
         self.shell.extension_manager.print_extensions()

--- a/IPython/core/magics/extension.py
+++ b/IPython/core/magics/extension.py
@@ -61,7 +61,7 @@ class ExtensionMagics(Magics):
         if not module_str:
             raise UsageError('Missing module name.')
         res = self.shell.extension_manager.load_extension(module_str)
-        
+
         if res == 'already loaded':
             print("The %s extension is already loaded. To reload it, use:" % module_str)
             print("  %reload_ext", module_str)
@@ -71,15 +71,15 @@ class ExtensionMagics(Magics):
     @line_magic
     def unload_ext(self, module_str):
         """Unload an IPython extension by its module name.
-        
+
         Not all extensions can be unloaded, only those which define an
         ``unload_ipython_extension`` function.
         """
         if not module_str:
             raise UsageError('Missing module name.')
-        
+
         res = self.shell.extension_manager.unload_extension(module_str)
-        
+
         if res == 'no unload function':
             print("The %s extension doesn't define how to unload it." % module_str)
         elif res == "not loaded":
@@ -91,3 +91,9 @@ class ExtensionMagics(Magics):
         if not module_str:
             raise UsageError('Missing module name.')
         self.shell.extension_manager.reload_extension(module_str)
+
+    @line_magic
+    def list_extensions(self, _):
+        """List extensions specifying ``ipython_extensions`` ``entry_points``
+        """
+        self.shell.extension_manager.print_extensions()

--- a/IPython/core/magics/extension.py
+++ b/IPython/core/magics/extension.py
@@ -113,4 +113,4 @@ class ExtensionMagics(Magics):
         ``sys.path`` + IPYTHONDIR/extensions for modules with
         ``load_ipython_extension`` functions.
         """
-        self.shell.extension_manager.print_extensions()
+        return self.shell.extension_manager.print_extensions()

--- a/IPython/core/magics/extension.py
+++ b/IPython/core/magics/extension.py
@@ -98,5 +98,19 @@ class ExtensionMagics(Magics):
     @line_magic
     def lsext(self, _):
         """List Loaded, Registered, and IPYTHONDIR extensions
+
+        * 'Loaded' extensions are already loaded in the IPython config.
+        * 'Registered' extensions define  ``ipython_extension``
+          ``entry_points`` in their ``setup.py`` files.
+        * IPYTHONDIR extensions are located in IPYTHONDIR,
+          and must contain a function named ``load_ipython_extension``.
+
+        Any Python module on ``sys.path`` with a ``load_ipython_extension``
+        function may be an IPython extension.
+
+        If the extension is not listed here, it may very well be
+        still ``%load_ext``-able. You might consider searching
+        ``sys.path`` + IPYTHONDIR/extensions for modules with
+        ``load_ipython_extension`` functions.
         """
         self.shell.extension_manager.print_extensions()

--- a/IPython/nbconvert/exporters/export.py
+++ b/IPython/nbconvert/exporters/export.py
@@ -15,18 +15,13 @@ Module containing single call export functions.
 
 from functools import wraps
 
+import pkg_resources
+
 from IPython.nbformat.v3.nbbase import NotebookNode
 from IPython.utils.decorators import undoc
 from IPython.utils.py3compat import string_types
 
 from .exporter import Exporter
-from .templateexporter import TemplateExporter
-from .html import HTMLExporter
-from .slides import SlidesExporter
-from .latex import LatexExporter
-from .markdown import MarkdownExporter
-from .python import PythonExporter
-from .rst import RSTExporter
 
 #-----------------------------------------------------------------------------
 # Classes
@@ -34,7 +29,7 @@ from .rst import RSTExporter
 
 @undoc
 def DocDecorator(f):
-    
+
     #Set docstring of function
     f.__doc__ = f.__doc__ + """
     nb : :class:`~{nbnode_mod}.NotebookNode`
@@ -43,14 +38,14 @@ def DocDecorator(f):
         User configuration instance.
     resources : dict (optional, keyword arg)
         Resources used in the conversion process.
-        
+
     Returns
     -------
     tuple- output, resources, exporter_instance
     output : str
         Jinja 2 output.  This is the resulting converted notebook.
     resources : dictionary
-        Dictionary of resources used prior to and during the conversion 
+        Dictionary of resources used prior to and during the conversion
         process.
     exporter_instance : Exporter
         Instance of the Exporter class used to export the document.  Useful
@@ -61,11 +56,11 @@ def DocDecorator(f):
     -----
     WARNING: API WILL CHANGE IN FUTURE RELEASES OF NBCONVERT
     """.format(nbnode_mod=NotebookNode.__module__)
-            
+
     @wraps(f)
     def decorator(*args, **kwargs):
         return f(*args, **kwargs)
-    
+
     return decorator
 
 
@@ -95,7 +90,7 @@ class ExporterNameError(NameError):
 def export(exporter, nb, **kw):
     """
     Export a notebook object using specific exporter class.
-    
+
     Parameters
     ----------
     exporter : class:`~IPython.nbconvert.exporters.exporter.Exporter` class or instance
@@ -104,7 +99,7 @@ def export(exporter, nb, **kw):
       the class type provided exposes a constructor (``__init__``) with the same
       signature as the base Exporter class.
     """
-    
+
     #Check arguments
     if exporter is None:
         raise TypeError("Exporter is None")
@@ -112,14 +107,14 @@ def export(exporter, nb, **kw):
         raise TypeError("exporter does not inherit from Exporter (base)")
     if nb is None:
         raise TypeError("nb is None")
-    
+
     #Create the exporter
     resources = kw.pop('resources', None)
     if isinstance(exporter, Exporter):
         exporter_instance = exporter
     else:
         exporter_instance = exporter(**kw)
-    
+
     #Try to convert the notebook using the appropriate conversion function.
     if isinstance(nb, NotebookNode):
         output, resources = exporter_instance.from_notebook_node(nb, resources)
@@ -129,15 +124,8 @@ def export(exporter, nb, **kw):
         output, resources = exporter_instance.from_file(nb, resources)
     return output, resources
 
-exporter_map = dict(
-    custom=TemplateExporter,
-    html=HTMLExporter,
-    slides=SlidesExporter,
-    latex=LatexExporter,
-    markdown=MarkdownExporter,
-    python=PythonExporter,
-    rst=RSTExporter,
-)
+exporters = list(pkg_resources.iter_entry_points(group='ipython_exporters'))
+exporter_map = { exp.name:exp.load() for exp in exporters }
 
 def _make_exporter(name, E):
     """make an export_foo function from a short key and Exporter class E"""
@@ -145,7 +133,7 @@ def _make_exporter(name, E):
         return export(E, nb, **kw)
     _export.__doc__ = """Export a notebook object to {0} format""".format(name)
     return _export
-    
+
 g = globals()
 
 for name, E in exporter_map.items():
@@ -157,15 +145,15 @@ def export_by_name(format_name, nb, **kw):
     Export a notebook object to a template type by its name.  Reflection
     (Inspect) is used to find the template's corresponding explicit export
     method defined in this module.  That method is then called directly.
-    
+
     Parameters
     ----------
     format_name : str
         Name of the template style to export to.
     """
-    
+
     function_name = "export_" + format_name.lower()
-    
+
     if function_name in globals():
         return globals()[function_name](nb, **kw)
     else:

--- a/IPython/nbconvert/exporters/export.py
+++ b/IPython/nbconvert/exporters/export.py
@@ -22,6 +22,13 @@ from IPython.utils.decorators import undoc
 from IPython.utils.py3compat import string_types
 
 from .exporter import Exporter
+from .templateexporter import TemplateExporter
+from .html import HTMLExporter
+from .slides import SlidesExporter
+from .latex import LatexExporter
+from .markdown import MarkdownExporter
+from .python import PythonExporter
+from .rst import RSTExporter
 
 #-----------------------------------------------------------------------------
 # Classes

--- a/setup.py
+++ b/setup.py
@@ -279,7 +279,16 @@ if 'setuptools' in sys.modules:
             'rmagic = IPython.extensions.rmagic [numpy, rmagic]',
             'storemagic = IPython.extensions.storemagic',
             'sympyprinting = IPython.extensions.sympyprinting [sympy]',
-        ]
+        ],
+        'ipython_exporters': [
+            'custom = IPython.nbconvert.exporters.templateexporter:TemplateExporter',
+            'html = IPython.nbconvert.exporters.html:HTMLExporter',
+            'slides = IPython.nbconvert.exporters.slides:SlidesExporter',
+            'latex = IPython.nbconvert.exporters.latex:LatexExporter',
+            'markdown = IPython.nbconvert.exporters.markdown:MarkdownExporter',
+            'python = IPython.nbconvert.exporters.python:PythonExporter',
+            'rst = IPython.nbconvert.exporters.rst:RSTExporter',
+        ],
     }
     setup_args['extras_require'] = dict(
         parallel = 'pyzmq>=2.1.11',

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ def require_clean_submodules():
     this is not a distutils command.
     """
     # PACKAGERS: Add a return here to skip checks for git submodules
-    
+
     # don't do anything if nothing is actually supposed to happen
     for do_nothing in ('-h', '--help', '--help-commands', 'clean', 'submodule'):
         if do_nothing in sys.argv:
@@ -267,9 +267,20 @@ if 'setuptools' in sys.modules:
     # setup.py develop should check for submodules
     from setuptools.command.develop import develop
     setup_args['cmdclass']['develop'] = require_submodules(develop)
-    
+
     setuptools_extra_args['zip_safe'] = False
-    setuptools_extra_args['entry_points'] = {'console_scripts':find_entry_points()}
+    setuptools_extra_args['entry_points'] = {
+        'console_scripts':find_entry_points(),
+        'ipython_extensions': [
+            'autoreload = IPython.extensions.autoreload',
+            'cythonmagic = IPython.extensions.cythonmagic [cython]',
+            'octavemagic = IPython.extensions.octavemagic [numpy, octave]',
+            'parallelmagic = IPython.extensions.parallelmagic',
+            'rmagic = IPython.extensions.rmagic [numpy, rmagic]',
+            'storemagic = IPython.extensions.storemagic',
+            'sympyprinting = IPython.extensions.sympyprinting [sympy]',
+        ]
+    }
     setup_args['extras_require'] = dict(
         parallel = 'pyzmq>=2.1.11',
         qtconsole = ['pyzmq>=2.1.11', 'pygments'],
@@ -277,7 +288,13 @@ if 'setuptools' in sys.modules:
         doc = ['Sphinx>=1.1', 'numpydoc'],
         test = 'nose>=0.10.1',
         notebook = ['tornado>=3.1', 'pyzmq>=2.1.11', 'jinja2'],
-        nbconvert = ['pygments', 'jinja2', 'Sphinx>=0.3']
+        nbconvert = ['pygments', 'jinja2', 'Sphinx>=0.3'],
+        # IPython extensions
+        cython = 'cython',
+        numpy = 'numpy',
+        octave = 'oct2py',
+        rmagic = 'rpy2',
+        sympy = 'sympy',
     )
     everything = set()
     for deps in setup_args['extras_require'].values():
@@ -286,7 +303,7 @@ if 'setuptools' in sys.modules:
         for dep in deps:
             everything.add(dep)
     setup_args['extras_require']['all'] = everything
-    
+
     requires = setup_args.setdefault('install_requires', [])
     setupext.display_status = False
     if not setupext.check_for_readline():


### PR DESCRIPTION
It would be great if it was possible for:

1.a. users to detect which extensions are [loaded, registered, in IPYTHONDIR] at runtime (`%lsext`)
1.b. developers to 'register' third-party extensions as `ipython_extensions` in their `setup.py` (`ipython_extensions`)

2.a. users to use third-party exporter 'plugins'
2.b. developers to 'register' third-party exporters as `ipython_exporters` in their `setup.py` (`ipython_exporters`)
