### PR TITLE
common IPython prefix for ModIndex

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -232,6 +232,8 @@ texinfo_documents = [
    1),
 ]
 
+modindex_common_prefix = ['IPython.']
+
 
 # Cleanup
 # -------


### PR DESCRIPTION
So that not all is not classified under `I`

Cf http://ipython.org/ipython-doc/dev/py-modindex.html vs 
![capture decran 2013-12-11 a 16 37 08](https://f.cloud.github.com/assets/335567/1725009/a0186df0-6279-11e3-9a65-26a404579724.png) 
