### PR TITLE
JPG compression for inline pylab

### DIFF
--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -165,7 +165,7 @@ def mpl_runner(safe_execfile):
     return mpl_execfile
 
 
-def select_figure_format(shell, fmt, quality):
+def select_figure_format(shell, fmt, quality=90):
     """Select figure format for inline backend, can be 'png', 'retina', 'jpg', or 'svg'.
 
     Using this method ensures only one figure format is active at a time.

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -95,7 +95,7 @@ def figsize(sizex, sizey):
 
 
 def print_figure(fig, fmt='png', quality=90):
-    """Convert a figure to svg, jpg (if PIL is installed) or png for inline display."""
+    """Convert a figure to svg, png or jpg for inline display."""
     from matplotlib import rcParams
     # When there's an empty figure, we shouldn't return anything, otherwise we
     # get big blank areas in the qt console.
@@ -164,7 +164,7 @@ def mpl_runner(safe_execfile):
 
 
 def select_figure_format(shell, fmt, quality):
-    """Select figure format for inline backend, can be 'png', 'retina', or 'svg'.
+    """Select figure format for inline backend, can be 'png', 'retina', 'jpg', or 'svg'.
 
     Using this method ensures only one figure format is active at a time.
     """
@@ -175,20 +175,18 @@ def select_figure_format(shell, fmt, quality):
     png_formatter = shell.display_formatter.formatters['image/png']
     jpg_formatter = shell.display_formatter.formatters['image/jpeg']
 
+    [ f.type_printers.pop(Figure, None) for f in {svg_formatter, png_formatter, jpg_formatter} ]
+
     if fmt == 'png':
-        svg_formatter.pop(Figure, None)
         png_formatter.for_type(Figure, lambda fig: print_figure(fig, 'png'))
-    elif fmt in ('jpg', 'jpeg'):
-        svg_formatter.type_printers.pop(Figure, None)
-        jpg_formatter.for_type(Figure, lambda fig: print_figure(fig, 'jpg', quality))
     elif fmt in ('png2x', 'retina'):
-        svg_formatter.pop(Figure, None)
         png_formatter.for_type(Figure, retina_figure)
+    elif fmt in ('jpg', 'jpeg'):
+        jpg_formatter.for_type(Figure, lambda fig: print_figure(fig, 'jpg', quality))
     elif fmt == 'svg':
-        png_formatter.pop(Figure, None)
         svg_formatter.for_type(Figure, lambda fig: print_figure(fig, 'svg'))
     else:
-        raise ValueError("supported formats are: 'png', 'retina', 'svg', not %r" % fmt)
+        raise ValueError("supported formats are: 'png', 'retina', 'svg', 'jpg', not %r" % fmt)
 
     # set the format to be used in the backend()
     backend_inline._figure_format = fmt

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -95,7 +95,9 @@ def figsize(sizex, sizey):
 
 
 def print_figure(fig, fmt='png', quality=90):
-    """Convert a figure to svg, png or jpg for inline display."""
+    """Convert a figure to svg, png or jpg for inline display.
+    Quality is only relevant for jpg.
+    """
     from matplotlib import rcParams
     # When there's an empty figure, we shouldn't return anything, otherwise we
     # get big blank areas in the qt console.

--- a/IPython/core/tests/test_pylabtools.py
+++ b/IPython/core/tests/test_pylabtools.py
@@ -53,6 +53,19 @@ def test_figure_to_svg():
     svg = pt.print_figure(fig, 'svg')[:100].lower()
     nt.assert_in(b'doctype svg', svg)
 
+try:
+    from PIL import Image
+    def test_figure_to_jpg():
+        # simple check for at least svg-looking output
+        fig = plt.figure()
+        ax = fig.add_subplot(1,1,1)
+        ax.plot([1,2,3])
+        plt.draw()
+        jpg = pt.print_figure(fig, 'jpg')[:100].lower()
+        assert jpg.startswith(b'\xff\xd8')
+except ImportError:
+    pass
+
 
 def test_import_pylab():
     ip = get_ipython()

--- a/IPython/core/tests/test_pylabtools.py
+++ b/IPython/core/tests/test_pylabtools.py
@@ -56,7 +56,7 @@ def test_figure_to_svg():
 try:
     from PIL import Image
     def test_figure_to_jpg():
-        # simple check for at least svg-looking output
+        # simple check for at least jpg-looking output
         fig = plt.figure()
         ax = fig.add_subplot(1,1,1)
         ax.plot([1,2,3])

--- a/IPython/core/tests/test_pylabtools.py
+++ b/IPython/core/tests/test_pylabtools.py
@@ -26,6 +26,8 @@ import numpy as np
 from IPython.core.interactiveshell import InteractiveShell
 from .. import pylabtools as pt
 
+from IPython.testing import decorators as dec
+
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
@@ -53,18 +55,15 @@ def test_figure_to_svg():
     svg = pt.print_figure(fig, 'svg')[:100].lower()
     nt.assert_in(b'doctype svg', svg)
 
-try:
-    from PIL import Image
-    def test_figure_to_jpg():
-        # simple check for at least jpg-looking output
-        fig = plt.figure()
-        ax = fig.add_subplot(1,1,1)
-        ax.plot([1,2,3])
-        plt.draw()
-        jpg = pt.print_figure(fig, 'jpg')[:100].lower()
-        assert jpg.startswith(b'\xff\xd8')
-except ImportError:
-    pass
+@dec.skip_without("PIL.Image")
+def test_figure_to_jpg():
+    # simple check for at least jpg-looking output
+    fig = plt.figure()
+    ax = fig.add_subplot(1,1,1)
+    ax.plot([1,2,3])
+    plt.draw()
+    jpg = pt.print_figure(fig, 'jpg')[:100].lower()
+    assert jpg.startswith(b'\xff\xd8')
 
 
 def test_import_pylab():

--- a/IPython/kernel/zmq/pylab/config.py
+++ b/IPython/kernel/zmq/pylab/config.py
@@ -14,7 +14,7 @@ This module does not import anything from matplotlib.
 #-----------------------------------------------------------------------------
 
 from IPython.config.configurable import SingletonConfigurable
-from IPython.utils.traitlets import Dict, Instance, CaselessStrEnum, Bool, Int
+from IPython.utils.traitlets import Dict, Instance, CaselessStrEnum, Bool, Int, TraitError
 from IPython.utils.warn import warn
 
 #-----------------------------------------------------------------------------
@@ -66,8 +66,8 @@ class InlineBackend(InlineBackendConfig):
 
     figure_format = CaselessStrEnum(['svg', 'png', 'retina', 'jpg'],
                                     default_value='png', config=True,
-                                    help="""The image format for figures with the inline backend.
-                                    JPEG requires the PIL/Pillow library.""")
+                                    help="""The image format for figures with the inline
+                                    backend. JPEG requires the PIL/Pillow library.""")
 
     def _figure_format_changed(self, name, old, new):
         from IPython.core.pylabtools import select_figure_format
@@ -80,11 +80,11 @@ class InlineBackend(InlineBackendConfig):
             select_figure_format(self.shell, new)
 
     quality = Int(default_value=90, config=True,
-                  help="Quality of compression [0-100], currently for lossy JPEG only.")
+                  help="Quality of compression [10-100], currently for lossy JPEG only.")
 
     def _quality_changed(self, name, old, new):
-        if new < 0 or new > 100:
-            raise TraitError("figure quality must be in [0-100] range.")
+        if new < 10 or new > 100:
+            raise TraitError("figure JPEG quality must be in [10-100] range.")
     
     close_figures = Bool(True, config=True,
         help="""Close all figures at the end of each cell.

--- a/IPython/kernel/zmq/pylab/config.py
+++ b/IPython/kernel/zmq/pylab/config.py
@@ -21,11 +21,15 @@ from IPython.utils.warn import warn
 # Configurable for inline backend options
 #-----------------------------------------------------------------------------
 
-try:
-    from PIL import Image
-    has_pil = True
-except:
-    has_pil = False
+def pil_available():
+    """Test if PIL/Pillow is available"""
+    out = False
+    try:
+        from PIL import Image
+        out = True
+    except:
+        pass
+    return out
 
 # inherit from InlineBackendConfig for deprecation purposes
 class InlineBackendConfig(SingletonConfigurable):
@@ -59,28 +63,28 @@ class InlineBackend(InlineBackendConfig):
         inline backend."""
     )
 
-    fmts = ['svg', 'png', 'retina']
 
-    if has_pil:
-        # If we have PIL using jpeg as inline image format can save some bytes.
-        fmts.append('jpg')
-
-    # Matplotlib's JPEG printer supports a quality option that can be tweaked.
-    # We expose it only if PIL is available so the user isn't confused. But it
-    # isn't guarded by "has_pil" test because core/pylabtools.py expects this
-    # field OR we need to propagate the has_pil test to that module too.
-    quality = Int(default_value=90, config=has_pil,
-                  help="Quality of compression [0-100], currently for lossy JPEG only.")
-
-    figure_format = CaselessStrEnum(fmts, default_value='png', config=True,
-        help="The image format for figures with the inline backend.")
+    figure_format = CaselessStrEnum(['svg', 'png', 'retina', 'jpg'],
+                                    default_value='png', config=True,
+                                    help="""The image format for figures with the inline backend.
+                                    JPEG requires the PIL/Pillow library.""")
 
     def _figure_format_changed(self, name, old, new):
         from IPython.core.pylabtools import select_figure_format
+        if new in {"jpg", "jpeg"}:
+            if not pil_available():
+                raise TraitError("Requires PIL/Pillow for JPG figures")
         if self.shell is None:
             return
         else:
             select_figure_format(self.shell, new)
+
+    quality = Int(default_value=90, config=True,
+                  help="Quality of compression [0-100], currently for lossy JPEG only.")
+
+    def _quality_changed(self, name, old, new):
+        if new < 0 or new > 100:
+            raise TraitError("figure quality must be in [0-100] range.")
     
     close_figures = Bool(True, config=True,
         help="""Close all figures at the end of each cell.

--- a/docs/source/whatsnew/pr/inline-jpg.rst
+++ b/docs/source/whatsnew/pr/inline-jpg.rst
@@ -1,0 +1,2 @@
+* The InlineBackend.figure_format flag now supports JPEG output if PIL is available.
+* The new InlineBackend.quality flag controls the amount of compression (currently JPEG only)

--- a/docs/source/whatsnew/pr/inline-jpg.rst
+++ b/docs/source/whatsnew/pr/inline-jpg.rst
@@ -1,2 +1,3 @@
-* The InlineBackend.figure_format flag now supports JPEG output if PIL is available.
-* The new InlineBackend.quality flag controls the amount of compression (currently JPEG only)
+* The InlineBackend.figure_format flag now supports JPEG output if PIL/Pillow is available.
+* The new ``InlineBackend.quality`` flag is a Integer in the range [10, 100] which controls 
+  the quality of figures where higher values give nicer images (currently JPEG only).


### PR DESCRIPTION
This is a follow up to #4448

It adds JPG compression and quality options to render inline figures. This is useful for blogs where PNG isn't compact enough and SVG overly-verbose.
