### PR TITLE
Javascript hightlighting for NBConvert html output

### DIFF
--- a/IPython/nbconvert/filters/highlight.py
+++ b/IPython/nbconvert/filters/highlight.py
@@ -3,7 +3,7 @@ Module containing filter functions that allow code to be highlighted
 from within Jinja templates.
 """
 #-----------------------------------------------------------------------------
-# Copyright (c) 2013, the IPython Development Team.
+# Copyright (c) the IPython Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -56,7 +56,10 @@ class Highlight2HTML(NbConvertBase):
         if not language:
             language=self.default_language
 
-        return _pygments_highlight(source if len(source) > 0 else ' ', HtmlFormatter(), language, metadata)
+        return _pygments_highlight(source if len(source) > 0 else ' ',
+                                   # needed to help post processors:
+                                   HtmlFormatter(cssclass="hl-"+language), 
+                                   language, metadata)
 
 
 class Highlight2Latex(NbConvertBase):


### PR DESCRIPTION
Follow-up of #4448

Add a HTMLExporter.javascript_highlight CLI Bool to decide wether we use inbrowser highlighting or prehighlighted html.

Add a switch to nbconvert's markdown2html filter that will make pandoc output fenced code blocks as html <pre> blocks (no highlight) and rewrite the css code-classes so that google prettyprinter can pick them up and do the highlighting in the browser.

Add a html_escape filter. It is useful in templates that output raw code in <pre> tags. The code needs to be properly html-escaped because for example >= and <= will cause html parsing errors.

Update html_*.tpl templates accordingly to enable javascript highlighting.

The filters could not be part of another PR because they are necessary side-products of the feature being added.
