### PR TITLE
setup.py symlink improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ from setupbase import (
     install_symlinked,
     install_lib_symlink,
     install_scripts_for_symlink,
+    unsymlink,
 )
 from setupext import setupext
 
@@ -237,6 +238,7 @@ setup_args['cmdclass'] = {
     'symlink': install_symlinked,
     'install_lib_symlink': install_lib_symlink,
     'install_scripts_sym': install_scripts_for_symlink,
+    'unsymlink': unsymlink,
     'jsversion' : JavascriptVersion,
 }
 

--- a/setupbase.py
+++ b/setupbase.py
@@ -381,7 +381,8 @@ class install_lib_symlink(Command):
         try:
             os.symlink(pkg, dest)
         except OSError as e:
-            if e.errno == errno.EEXIST and os.path.islink(dest):
+            if e.errno == errno.EEXIST and os.path.islink(dest) \
+                    and os.path.realpath(dest) == pkg:
                 print('Symlink already exists')
             else:
                 raise

--- a/setupbase.py
+++ b/setupbase.py
@@ -383,6 +383,15 @@ class install_lib_symlink(Command):
         print('symlinking %s -> %s' % (pkg, dest))
         os.symlink(pkg, dest)
 
+class unsymlink(install):
+    def run(self):
+        dest = os.path.join(self.install_lib, 'IPython')
+        if os.path.islink(dest):
+            print('removing symlink at %s' % dest)
+            os.unlink(dest)
+        else:
+            print('No symlink exists at %s' % dest)
+
 class install_symlinked(install):
     def run(self):
         if sys.platform == 'win32':

--- a/setupbase.py
+++ b/setupbase.py
@@ -390,7 +390,10 @@ class install_symlinked(install):
     def run(self):
         if sys.platform == 'win32':
             raise Exception("This doesn't work on Windows.")
-        install.run(self)
+
+        # Run all sub-commands (at least those that need to be run)
+        for cmd_name in self.get_sub_commands():
+            self.run_command(cmd_name)
     
     # 'sub_commands': a list of commands this command might have to run to
     # get its work done.  See cmd.py for more info.

--- a/setupbase.py
+++ b/setupbase.py
@@ -377,15 +377,11 @@ class install_lib_symlink(Command):
             raise Exception("This doesn't work on Windows.")
         pkg = os.path.join(os.getcwd(), 'IPython')
         dest = os.path.join(self.install_dir, 'IPython')
+        if os.path.islink(dest):
+            print('removing existing symlink at %s' % dest)
+            os.unlink(dest)
         print('symlinking %s -> %s' % (pkg, dest))
-        try:
-            os.symlink(pkg, dest)
-        except OSError as e:
-            if e.errno == errno.EEXIST and os.path.islink(dest) \
-                    and os.path.realpath(dest) == pkg:
-                print('Symlink already exists')
-            else:
-                raise
+        os.symlink(pkg, dest)
 
 class install_symlinked(install):
     def run(self):

--- a/setupbase.py
+++ b/setupbase.py
@@ -381,8 +381,8 @@ class install_lib_symlink(Command):
         try:
             os.symlink(pkg, dest)
         except OSError as e:
-            if e.errno == errno.EEXIST:
-                print('ALREADY EXISTS')
+            if e.errno == errno.EEXIST and os.path.islink(dest):
+                print('Symlink already exists')
             else:
                 raise
 


### PR DESCRIPTION
A couple of improvements to the `setup.py symlink` command:
- It doesn't needlessly copy the library files into the build directory and byte-compile them before symlinking. This should be a helpful speed up on slow platforms such as the raspberry pi.
- Previously, if the target in site-packages which was to be symlinked already existed, it was ignored, which would lead to silent failure if you tried to symlink over a conventionally installed version. Now it checks that the destination is a symlink, so you'll get an error if it's a regular directory, but running `setup.py symlink` again (e.g. if scripts change) will work.
