### PR TITLE
Making reveal font-size a relative unit.

### DIFF
--- a/IPython/nbconvert/templates/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/slides_reveal.tpl
@@ -45,7 +45,7 @@ html {
   overflow-y: auto;
 }
 .reveal {
-  font-size: 20px;
+  font-size: 160%;
 }
 .reveal pre {
   width: inherit;


### PR DESCRIPTION
Simple change to make it the font size property more friendly to the user and compatible with the live reveal extension.
