### PR TITLE
restore use of tornado static_url in templates

### DIFF
--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -193,8 +193,9 @@ class IPythonHandler(AuthenticatedHandler):
             logged_in=self.logged_in,
             login_available=self.login_available,
             use_less=self.use_less,
+            static_url=self.static_url,
         )
-
+    
     def get_json_body(self):
         """Return the body of the request as JSON data."""
         if not self.request.body:

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -330,13 +330,16 @@ class FileFindHandler(web.StaticFileHandler):
                 abspath = os.path.abspath(filefind(path, roots))
             except IOError:
                 # IOError means not found
-                raise web.HTTPError(404)
+                return ''
             
             cls._static_paths[path] = abspath
             return abspath
     
     def validate_absolute_path(self, root, absolute_path):
         """check if the file should be served (raises 404, 403, etc.)"""
+        if absolute_path == '':
+            raise web.HTTPError(404)
+        
         for root in self.root:
             if (absolute_path + os.sep).startswith(root):
                 break

--- a/IPython/html/templates/page.html
+++ b/IPython/html/templates/page.html
@@ -1,9 +1,6 @@
 
 
 <!DOCTYPE HTML>
-{% macro static_url(name) -%}
-   {{ base_project_url }}static/{{ name }}
-{%- endmacro %}
 <html>
 
 <head>
@@ -28,7 +25,7 @@
     <script src="{{static_url("components/requirejs/require.js") }}" type="text/javascript" charset="utf-8"></script>
     <script>
       require.config({
-          baseUrl: '{{static_url()}}',
+          baseUrl: '{{static_url("")}}',
           paths: {
             nbextensions : '{{ base_project_url }}nbextensions'
           }


### PR DESCRIPTION
instead of jinja macro that doesn't write hashes

closes #4714
