### PR TITLE
Remove input_prefilter hook

### DIFF
--- a/IPython/core/hooks.py
+++ b/IPython/core/hooks.py
@@ -45,7 +45,7 @@ from IPython.core.error import TryNext
 # but over time we'll move here all the public API for user-accessible things.
 
 __all__ = ['editor', 'fix_error_editor', 'synchronize_with_editor',
-           'input_prefilter', 'shutdown_hook', 'late_startup_hook',
+           'shutdown_hook', 'late_startup_hook',
            'show_in_pager','pre_prompt_hook',
            'pre_run_code_hook', 'clipboard_get']
 
@@ -149,21 +149,6 @@ class CommandChainDispatcher:
         Handy if the objects are not callable.
         """
         return iter(self.chain)
-
-
-def input_prefilter(self,line):
-    """ Default input prefilter
-
-    This returns the line as unchanged, so that the interpreter
-    knows that nothing was done and proceeds with "classic" prefiltering
-    (%magics, !shell commands etc.).
-
-    Note that leading whitespace is not passed to this hook. Prefilter
-    can't alter indentation.
-
-    """
-    #print "attempt to rewrite",line #dbg
-    return line
 
 
 def shutdown_hook(self):

--- a/docs/source/whatsnew/pr/incompat-input-prefilter-hook.rst
+++ b/docs/source/whatsnew/pr/incompat-input-prefilter-hook.rst
@@ -1,0 +1,4 @@
+* The ``input_prefilter`` hook has been removed, as it was never
+  actually used by the code. The input transformer system offers much
+  more powerful APIs to work with input code. See
+  :doc:`/config/inputtransforms` for details.


### PR DESCRIPTION
Our code already doesn't call this hook (as pointed out in gh-4709), and probably hasn't for some time, so it seems ~no-one is relying on it. We have much more powerful APIs to do the same thing.
