### PR TITLE
Fix comment typo in prefilter.py

### DIFF
--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -212,7 +212,7 @@ class PrefilterManager(Configurable):
             self._checkers.remove(checker)
 
     #-------------------------------------------------------------------------
-    # API for managing checkers
+    # API for managing handlers
     #-------------------------------------------------------------------------
 
     def init_handlers(self):


### PR DESCRIPTION
This section header comment is a duplicate of the one above it.  It should actually read "handlers".
