### PR TITLE
never use ssh multiplexer in tunnels

### DIFF
--- a/IPython/external/ssh/tunnel.py
+++ b/IPython/external/ssh/tunnel.py
@@ -214,7 +214,7 @@ def openssh_tunnel(lport, rport, server, remoteip='127.0.0.1', keyfile=None, pas
         server, port = server.split(':')
         ssh += " -p %s" % port
         
-    cmd = "%s -f -L 127.0.0.1:%i:%s:%i %s sleep %i" % (
+    cmd = "%s -f -S none -L 127.0.0.1:%i:%s:%i %s sleep %i" % (
         ssh, lport, remoteip, rport, server, timeout)
     tunnel = pexpect.spawn(cmd)
     failed = False


### PR DESCRIPTION
`ssh -f` is [broken in OpenSSH](https://bugzilla.mindrot.org/show_bug.cgi?id=1948) when a ControlMaster multiplexed connection is used.

`-S none` disables the multiplexed connection.

closes #4717
