### PR TITLE
Removed readline dependency for ipython.terminal.console.completer

### DIFF
--- a/IPython/terminal/console/completer.py
+++ b/IPython/terminal/console/completer.py
@@ -27,16 +27,7 @@ class ZMQCompleter(Configurable):
         import readline
         line = readline.get_line_buffer()
         cursor_pos = readline.get_endidx()
-
-        # send completion request to kernel
-        # Give the kernel up to 0.5s to respond
-        msg_id = self.client.shell_channel.complete(text=text, line=line,
-                                                        cursor_pos=cursor_pos)
-
-        msg = self.client.shell_channel.get_msg(timeout=self.timeout)
-        if msg['parent_header']['msg_id'] == msg_id:
-            return msg["content"]["matches"]
-        return []
+        return complete_request(text, line, cursor_pos)
 
     def complete_request(self, text, line, cursor_pos):
         # send completion request to kernel
@@ -63,14 +54,13 @@ class ZMQCompleter(Configurable):
             return None
 
     def complete(self, text, line, cursor_pos=None):
-        if state == 0:
-            try:
-                self.matches = self.complete_request(text, line, cursor_pos)
-            except Empty:
-                #print('WARNING: Kernel timeout on tab completion.')
-                pass
+        try:
+            self.matches = self.complete_request(text, line, cursor_pos)
+        except Empty:
+            #print('WARNING: Kernel timeout on tab completion.')
+            pass
 
         try:
-            return self.matches[state]
+            return self.matches[0]
         except IndexError:
             return None

--- a/IPython/terminal/console/completer.py
+++ b/IPython/terminal/console/completer.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import readline
 try:
     from queue import Empty  # Py 3
 except ImportError:
@@ -16,40 +15,62 @@ class ZMQCompleter(Configurable):
     and then return them for each value of state."""
 
     timeout = Float(5.0, config=True, help='timeout before completion abort')
-    
+
     def __init__(self, shell, client, config=None):
         super(ZMQCompleter,self).__init__(config=config)
 
         self.shell = shell
         self.client =  client
         self.matches = []
-        
-    def complete_request(self,text):
+
+    def rlcomplete_request(self, text):
+        import readline
         line = readline.get_line_buffer()
         cursor_pos = readline.get_endidx()
-        
+
         # send completion request to kernel
         # Give the kernel up to 0.5s to respond
         msg_id = self.client.shell_channel.complete(text=text, line=line,
                                                         cursor_pos=cursor_pos)
-        
+
         msg = self.client.shell_channel.get_msg(timeout=self.timeout)
         if msg['parent_header']['msg_id'] == msg_id:
             return msg["content"]["matches"]
         return []
-    
+
+    def complete_request(self, text, line, cursor_pos):
+        # send completion request to kernel
+        # Give the kernel up to 0.5s to respond
+        msg_id = self.client.shell_channel.complete(text=text, line=line,
+                                                        cursor_pos=cursor_pos)
+
+        msg = self.client.shell_channel.get_msg(timeout=self.timeout)
+        if msg['parent_header']['msg_id'] == msg_id:
+            return msg["content"]["matches"]
+        return []
+
     def rlcomplete(self, text, state):
         if state == 0:
             try:
-                self.matches = self.complete_request(text)
+                self.matches = self.rlcomplete_request(text)
             except Empty:
                 #print('WARNING: Kernel timeout on tab completion.')
                 pass
-        
+
         try:
             return self.matches[state]
         except IndexError:
             return None
-    
+
     def complete(self, text, line, cursor_pos=None):
-        return self.rlcomplete(text, 0)
+        if state == 0:
+            try:
+                self.matches = self.complete_request(text, line, cursor_pos)
+            except Empty:
+                #print('WARNING: Kernel timeout on tab completion.')
+                pass
+
+        try:
+            return self.matches[state]
+        except IndexError:
+            return None


### PR DESCRIPTION
I noticed this issue while using the sublime repl plugin for ipython in sublime text, which used the `ZMQTerminalIPythonApp` class, which then imported `ZMQCompleter`, but then failed to run due to the readline dependency. I don't think this is necessary on windows, so I moved the import into the `rlcomplete` functions instead, which seems to fix the sublime repl issue.

I'm not very familar with ipython code, so please review, thanks!
