### PR TITLE
Fix stripping continuation prompts when copying from Qt console

### DIFF
--- a/IPython/core/inputtransformer.py
+++ b/IPython/core/inputtransformer.py
@@ -453,8 +453,7 @@ def classic_prompt():
 def ipy_prompt():
     """Strip IPython's In [1]:/...: prompts."""
     # FIXME: non-capturing version (?:...) usable?
-    # FIXME: r'^(In \[\d+\]: | {3}\.{3,}: )' clearer?
-    prompt_re = re.compile(r'^(In \[\d+\]: |\ \ \ \.\.\.+: )')
+    prompt_re = re.compile(r'^(In \[\d+\]: |\ {3,}\.{3,}: )')
     return _strip_prompts(prompt_re)
 
 

--- a/IPython/core/tests/test_inputtransformer.py
+++ b/IPython/core/tests/test_inputtransformer.py
@@ -206,6 +206,11 @@ syntax_ml = \
           ('   ....:     print i','    print i'),
           ('   ....: ', ''),
           ],
+         [('In [24]: for i in range(10):','for i in range(10):'),
+          # Qt console prompts expand with spaces, not dots
+          ('    ...:     print i','    print i'),
+          ('    ...: ', ''),
+          ],
          [('In [2]: a="""','a="""'),
           ('   ...: 123"""','123"""'),
           ],


### PR DESCRIPTION
Closes issue #4728.

Thanks to @y-p for tracking down an obscure problem.
