### PR TITLE
check every link when detecting virutalenv

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -716,9 +716,16 @@ class InteractiveShell(SingletonConfigurable):
             # Not in a virtualenv
             return
         
-        if os.path.realpath(sys.executable).startswith(
-            os.path.realpath(os.environ['VIRTUAL_ENV'])
-        ):
+        # venv detection:
+        # stdlib venv may symlink sys.executable, so we can't use realpath.
+        # but others can symlink *to* the venv Python, so we can't just use sys.executable.
+        # So we just check every item in the symlink tree (generally <= 3)
+        p = sys.executable
+        paths = [p]
+        while os.path.islink(p):
+            p = os.path.join(os.path.dirname(p), os.readlink(p))
+            paths.append(p)
+        if any(p.startswith(os.environ['VIRTUAL_ENV']) for p in paths):
             # Running properly in the virtualenv, don't need to do anything
             return
         


### PR DESCRIPTION
- can't use just sys.executable, because the env python can be a link target
- can't use realpath, because the env python can be a link to outside the env
