### PR TITLE
don't inject help into user_ns

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1125,13 +1125,6 @@ class InteractiveShell(SingletonConfigurable):
         # http://mail.python.org/pipermail/python-dev/2001-April/014068.html
         ns = dict()
         
-        # Put 'help' in the user namespace
-        try:
-            from site import _Helper
-            ns['help'] = _Helper()
-        except ImportError:
-            warn('help() not available - check site.py')
-
         # make global variables for user access to the histories
         ns['_ih'] = self.history_manager.input_hist_parsed
         ns['_oh'] = self.history_manager.output_hist


### PR DESCRIPTION
because it's in builtins. I presume this was for old Pythons, but it doesn't seem necessary for ≥ 2.7.

Prompted because the injection fails on 3.4, causing the warning:

```
WARNING: help() not available - check site.py
```

but help actually works just fine.
