### PR TITLE
don't use lazily-evaluated rc.ids in wait_for_idle

### DIFF
--- a/IPython/parallel/tests/test_client.py
+++ b/IPython/parallel/tests/test_client.py
@@ -333,7 +333,7 @@ class TestClient(ClusterTestCase):
         
         # ensure Hub up to date:
         self.assertEqual(qs['unassigned'], 0)
-        for eid in rc.ids:
+        for eid in qs if eid != 'unassigned':
             self.assertEqual(qs[eid]['tasks'], 0)
             self.assertEqual(qs[eid]['queue'], 0)
     


### PR DESCRIPTION
can cause KeyError in parallel tests

finish up fix started in 69b0a18833750cab91ddc82fe1ddde9eab617285

Should address some intermittent failures seen by Shining Panda
