### PR TITLE
remove redundant cls alias on Windows

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -379,9 +379,6 @@ class TerminalInteractiveShell(InteractiveShell):
         if os.name == 'posix':
             aliases = [('clear', 'clear'), ('more', 'more'), ('less', 'less'),
                        ('man', 'man')]
-        elif os.name == 'nt':
-            aliases = [('cls', 'cls')]
-
 
         for name, cmd in aliases:
             self.alias_manager.soft_define_alias(name, cmd)


### PR DESCRIPTION
It's already a magic, and the duplicate alias was failing with Invalid alias.

The conditions for the alias and magic differ, which is definitely wrong:
- `sys.platform == 'win32'` for the magic
- `os.name == 'nt'` for the alias

but I have no idea which one is preferable.

We could also invert this patch, so only the alias is defined and not the magic, but obviously we shouldn't have both.
