### PR TITLE
Fix bug in determination of public ips.

### DIFF
--- a/IPython/utils/localinterfaces.py
+++ b/IPython/utils/localinterfaces.py
@@ -101,7 +101,10 @@ def _load_ips_ifconfig():
     for line in lines:
         blocks = line.lower().split()
         if (len(blocks) >= 2) and (blocks[0] == 'inet'):
-            addrs.append(blocks[1])
+            if "addr:" in blocks[1]:
+                addrs.append(blocks[1].split(":")[1])
+            else:
+                addrs.append(blocks[1])
     _populate_from_list(addrs)
 
 

--- a/IPython/utils/localinterfaces.py
+++ b/IPython/utils/localinterfaces.py
@@ -101,7 +101,7 @@ def _load_ips_ifconfig():
     for line in lines:
         blocks = line.lower().split()
         if (len(blocks) >= 2) and (blocks[0] == 'inet'):
-            if "addr:" in blocks[1]:
+            if  blocks[1].startswith("addr:"):
                 addrs.append(blocks[1].split(":")[1])
             else:
                 addrs.append(blocks[1])


### PR DESCRIPTION
On some systems, the output of ifconfig contains:

```
addr:127.0.0.1
```

rather than simply `127.0.0.1`. This patch detects when this is the case
and corrects for it if necessary.
