### PR TITLE
Notebook server info files

### DIFF
--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -727,8 +727,8 @@ class NotebookApp(BaseIPythonApplication):
 
     def write_server_info_file(self):
         """Write the result of server_info() to the JSON file info_file."""
-        with io.open(self.info_file, 'w', encoding='utf-8') as f:
-            json.dump(self.server_info(), f)
+        with open(self.info_file, 'w') as f:
+            json.dump(self.server_info(), f, indent=2)
 
     def remove_server_info_file(self):
         """Remove the nbserver-<pid>.json file created for this server.

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -230,11 +230,11 @@ class NbserverListApp(BaseIPythonApplication):
     def start(self):
         if not self.json:
             print("Currently running servers:")
-        for serverinfo in discover_running_servers(self.profile):
+        for serverinfo in list_running_servers(self.profile):
             if self.json:
                 print(json.dumps(serverinfo))
             else:
-                print(serverinfo['url'], "::", serverinfo['notebookdir'])
+                print(serverinfo['url'], "::", serverinfo['notebook_dir'])
 
 #-----------------------------------------------------------------------------
 # Aliases and Flags
@@ -746,8 +746,8 @@ class NotebookApp(BaseIPythonApplication):
                 'hostname': self.ip if self.ip else 'localhost',
                 'port': self.port,
                 'secure': bool(self.certfile),
-                'baseurlpath': self.base_project_url,
-                'notebookdir': os.path.abspath(self.notebook_manager.notebook_dir),
+                'base_project_url': self.base_project_url,
+                'notebook_dir': os.path.abspath(self.notebook_manager.notebook_dir),
                }
 
     def write_server_info_file(self):

--- a/IPython/html/tests/test_notebookapp.py
+++ b/IPython/html/tests/test_notebookapp.py
@@ -27,7 +27,7 @@ def test_help_output():
 def test_server_info_file():
     nbapp = notebookapp.NotebookApp(profile='nbserver_file_test')
     def get_servers():
-        return list(notebookapp.discover_running_servers(profile='nbserver_file_test'))
+        return list(notebookapp.list_running_servers(profile='nbserver_file_test'))
     nbapp.initialize(argv=[])
     nbapp.write_server_info_file()
     servers = get_servers()

--- a/IPython/html/tests/test_notebookapp.py
+++ b/IPython/html/tests/test_notebookapp.py
@@ -14,6 +14,7 @@
 import nose.tools as nt
 
 import IPython.testing.tools as tt
+from IPython.html import notebookapp
 
 #-----------------------------------------------------------------------------
 # Test functions
@@ -23,3 +24,18 @@ def test_help_output():
     """ipython notebook --help-all works"""
     tt.help_all_output_test('notebook')
 
+def test_server_info_file():
+    nbapp = notebookapp.NotebookApp(profile='nbserver_file_test')
+    def get_servers():
+        return list(notebookapp.discover_running_servers(profile='nbserver_file_test'))
+    nbapp.initialize(argv=[])
+    nbapp.write_server_info_file()
+    servers = get_servers()
+    nt.assert_equal(len(servers), 1)
+    nt.assert_equal(servers[0]['port'], nbapp.port)
+    nt.assert_equal(servers[0]['url'], nbapp.connection_url)
+    nbapp.remove_server_info_file()
+    nt.assert_equal(get_servers(), [])
+
+    # The ENOENT error should be silenced.
+    nbapp.remove_server_info_file()


### PR DESCRIPTION
This adds info files for running notebook servers, akin to the connection files we already write for kernels, along with a function to discover them. This should facilitate making tools that can open notebooks without starting a new server for each one.

What values are serialised and what names they're given are up for discussion. I've currently put in the URL and its component parts and the root directory where the server is running.
