### PR TITLE
emit event on appended element on dom

### DIFF
--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -533,7 +533,8 @@ var IPython = (function (IPython) {
             var append = OutputArea.append_map[type];
             if ((json[type] !== undefined) && append) {
                 var md = json.metadata || {};
-                append.apply(this, [json[type], md, element]);
+                var toinsert = append.apply(this, [json[type], md, element]);
+                $([IPython.events]).trigger('output_appended.OutputArea', [type, json[type], md, toinsert]);
                 return true;
             }
         }
@@ -547,6 +548,7 @@ var IPython = (function (IPython) {
         IPython.keyboard_manager.register_events(toinsert);
         toinsert.append(html);
         element.append(toinsert);
+        return toinsert;
     };
 
 
@@ -562,6 +564,7 @@ var IPython = (function (IPython) {
             console.log(err);
             this._append_javascript_error(err, element);
         }
+        return container;
     };
 
 
@@ -577,6 +580,7 @@ var IPython = (function (IPython) {
         }
         toinsert.append($("<pre/>").html(data));
         element.append(toinsert);
+        return toinsert;
     };
 
 
@@ -585,6 +589,7 @@ var IPython = (function (IPython) {
         var toinsert = this.create_output_subarea(md, "output_svg", type);
         toinsert.append(svg);
         element.append(toinsert);
+        return toinsert;
     };
 
 
@@ -629,6 +634,7 @@ var IPython = (function (IPython) {
         this._dblclick_to_reset_size(img);
         toinsert.append(img);
         element.append(toinsert);
+        return toinsert;
     };
 
 
@@ -645,6 +651,7 @@ var IPython = (function (IPython) {
         this._dblclick_to_reset_size(img);
         toinsert.append(img);
         element.append(toinsert);
+        return toinsert;
     };
 
 
@@ -655,6 +662,7 @@ var IPython = (function (IPython) {
         var toinsert = this.create_output_subarea(md, "output_latex", type);
         toinsert.append(latex);
         element.append(toinsert);
+        return toinsert;
     };
 
     OutputArea.append_map = {

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -558,9 +558,11 @@ var IPython = (function (IPython) {
         var toinsert = this.create_output_subarea(md, "output_javascript", type);
         IPython.keyboard_manager.register_events(toinsert);
         element.append(toinsert);
+        // FIXME TODO : remove `container element for 3.0` 
         //backward compat, js should be eval'ed in a context where `container` is defined.
         var container = element;
         container.show = function(){console.log('Warning "container.show()" is deprecated.')};
+        // end backward compat
         try {
             eval(js);
         } catch(err) {

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -41,7 +41,85 @@ var IPython = (function (IPython) {
         this.style();
         this.bind_events();
     };
-    
+
+    /**
+     * Class properties
+     **/
+
+    /**
+     * Threshold to trigger autoscroll when the OutputArea is resized,
+     * typically when new outputs are added.
+     *
+     * Behavior is undefined if autoscroll is lower than minimum_scroll_threshold,
+     * unless it is < 0, in which case autoscroll will never be triggered
+     *
+     * @property auto_scroll_threshold
+     * @type Number
+     * @default 100
+     *
+     **/
+    OutputArea.auto_scroll_threshold = 100;
+
+    /**
+     * Lower limit (in lines) for OutputArea to be made scrollable. OutputAreas
+     * shorter than this are never scrolled.
+     *
+     * @property minimum_scroll_threshold
+     * @type Number
+     * @default 20
+     *
+     **/
+    OutputArea.minimum_scroll_threshold = 20;
+
+
+
+    OutputArea.mime_map = {
+        "text/plain" : "text",
+        "text/html" : "html",
+        "image/svg+xml" : "svg",
+        "image/png" : "png",
+        "image/jpeg" : "jpeg",
+        "text/latex" : "latex",
+        "application/json" : "json",
+        "application/javascript" : "javascript",
+    };
+
+    OutputArea.mime_map_r = {
+        "text" : "text/plain",
+        "html" : "text/html",
+        "svg" : "image/svg+xml",
+        "png" : "image/png",
+        "jpeg" : "image/jpeg",
+        "latex" : "text/latex",
+        "json" : "application/json",
+        "javascript" : "application/javascript",
+    };
+
+    OutputArea.display_order = [
+        'application/javascript',
+        'text/html',
+        'text/latex',
+        'image/svg+xml',
+        'image/png',
+        'image/jpeg',
+        'text/plain'
+    ];
+
+    OutputArea.append_map = {
+        "text/plain" : OutputArea.prototype.append_text,
+        "text/html" : OutputArea.prototype.append_html,
+        "image/svg+xml" : OutputArea.prototype.append_svg,
+        "image/png" : OutputArea.prototype.append_png,
+        "image/jpeg" : OutputArea.prototype.append_jpeg,
+        "text/latex" : OutputArea.prototype.append_latex,
+        "application/json" : OutputArea.prototype.append_json,
+        "application/javascript" : OutputArea.prototype.append_javascript,
+    };
+
+    /**
+     * Class prototypes
+     **/
+
     OutputArea.prototype.create_elements = function () {
         this.element = $("<div/>");
         this.collapse_button = $("<div/>");
@@ -159,33 +237,6 @@ var IPython = (function (IPython) {
     };
 
     /**
-     * Threshold to trigger autoscroll when the OutputArea is resized,
-     * typically when new outputs are added.
-     *
-     * Behavior is undefined if autoscroll is lower than minimum_scroll_threshold,
-     * unless it is < 0, in which case autoscroll will never be triggered
-     *
-     * @property auto_scroll_threshold
-     * @type Number
-     * @default 100
-     *
-     **/
-    OutputArea.auto_scroll_threshold = 100;
-
-
-    /**
-     * Lower limit (in lines) for OutputArea to be made scrollable. OutputAreas
-     * shorter than this are never scrolled.
-     *
-     * @property minimum_scroll_threshold
-     * @type Number
-     * @default 20
-     *
-     **/
-    OutputArea.minimum_scroll_threshold = 20;
-
-
-    /**
      *
      * Scroll OutputArea if height supperior than a threshold (in lines).
      *
@@ -254,28 +305,7 @@ var IPython = (function (IPython) {
         }
         this.append_output(json);
     };
-
-    OutputArea.mime_map = {
-        "text/plain" : "text",
-        "text/html" : "html",
-        "image/svg+xml" : "svg",
-        "image/png" : "png",
-        "image/jpeg" : "jpeg",
-        "text/latex" : "latex",
-        "application/json" : "json",
-        "application/javascript" : "javascript",
-    };
     
-    OutputArea.mime_map_r = {
-        "text" : "text/plain",
-        "html" : "text/html",
-        "svg" : "image/svg+xml",
-        "png" : "image/png",
-        "jpeg" : "image/jpeg",
-        "latex" : "text/latex",
-        "json" : "application/json",
-        "javascript" : "application/javascript",
-    };
     
     OutputArea.prototype.rename_keys = function (data, key_map) {
         var remapped = {};
@@ -516,15 +546,6 @@ var IPython = (function (IPython) {
         }
     };
 
-    OutputArea.display_order = [
-        'application/javascript',
-        'text/html',
-        'text/latex',
-        'image/svg+xml',
-        'image/png',
-        'image/jpeg',
-        'text/plain'
-    ];
 
     OutputArea.prototype.append_mime_type = function (json, element) {
 
@@ -670,16 +691,6 @@ var IPython = (function (IPython) {
         return toinsert;
     };
 
-    OutputArea.append_map = {
-        "text/plain" : OutputArea.prototype.append_text,
-        "text/html" : OutputArea.prototype.append_html,
-        "image/svg+xml" : OutputArea.prototype.append_svg,
-        "image/png" : OutputArea.prototype.append_png,
-        "image/jpeg" : OutputArea.prototype.append_jpeg,
-        "text/latex" : OutputArea.prototype.append_latex,
-        "application/json" : OutputArea.prototype.append_json,
-        "application/javascript" : OutputArea.prototype.append_javascript,
-    };
 
     OutputArea.prototype.append_raw_input = function (msg) {
         var that = this;

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -42,79 +42,6 @@ var IPython = (function (IPython) {
         this.bind_events();
     };
 
-    /**
-     * Class properties
-     **/
-
-    /**
-     * Threshold to trigger autoscroll when the OutputArea is resized,
-     * typically when new outputs are added.
-     *
-     * Behavior is undefined if autoscroll is lower than minimum_scroll_threshold,
-     * unless it is < 0, in which case autoscroll will never be triggered
-     *
-     * @property auto_scroll_threshold
-     * @type Number
-     * @default 100
-     *
-     **/
-    OutputArea.auto_scroll_threshold = 100;
-
-    /**
-     * Lower limit (in lines) for OutputArea to be made scrollable. OutputAreas
-     * shorter than this are never scrolled.
-     *
-     * @property minimum_scroll_threshold
-     * @type Number
-     * @default 20
-     *
-     **/
-    OutputArea.minimum_scroll_threshold = 20;
-
-
-
-    OutputArea.mime_map = {
-        "text/plain" : "text",
-        "text/html" : "html",
-        "image/svg+xml" : "svg",
-        "image/png" : "png",
-        "image/jpeg" : "jpeg",
-        "text/latex" : "latex",
-        "application/json" : "json",
-        "application/javascript" : "javascript",
-    };
-
-    OutputArea.mime_map_r = {
-        "text" : "text/plain",
-        "html" : "text/html",
-        "svg" : "image/svg+xml",
-        "png" : "image/png",
-        "jpeg" : "image/jpeg",
-        "latex" : "text/latex",
-        "json" : "application/json",
-        "javascript" : "application/javascript",
-    };
-
-    OutputArea.display_order = [
-        'application/javascript',
-        'text/html',
-        'text/latex',
-        'image/svg+xml',
-        'image/png',
-        'image/jpeg',
-        'text/plain'
-    ];
-
-    OutputArea.append_map = {
-        "text/plain" : OutputArea.prototype.append_text,
-        "text/html" : OutputArea.prototype.append_html,
-        "image/svg+xml" : OutputArea.prototype.append_svg,
-        "image/png" : OutputArea.prototype.append_png,
-        "image/jpeg" : OutputArea.prototype.append_jpeg,
-        "text/latex" : OutputArea.prototype.append_latex,
-        "application/json" : OutputArea.prototype.append_json,
-        "application/javascript" : OutputArea.prototype.append_javascript,
-    };
 
     /**
      * Class prototypes
@@ -835,6 +762,79 @@ var IPython = (function (IPython) {
         return outputs;
     };
 
+    /**
+     * Class properties
+     **/
+
+    /**
+     * Threshold to trigger autoscroll when the OutputArea is resized,
+     * typically when new outputs are added.
+     *
+     * Behavior is undefined if autoscroll is lower than minimum_scroll_threshold,
+     * unless it is < 0, in which case autoscroll will never be triggered
+     *
+     * @property auto_scroll_threshold
+     * @type Number
+     * @default 100
+     *
+     **/
+    OutputArea.auto_scroll_threshold = 100;
+
+    /**
+     * Lower limit (in lines) for OutputArea to be made scrollable. OutputAreas
+     * shorter than this are never scrolled.
+     *
+     * @property minimum_scroll_threshold
+     * @type Number
+     * @default 20
+     *
+     **/
+    OutputArea.minimum_scroll_threshold = 20;
+
+
+
+    OutputArea.mime_map = {
+        "text/plain" : "text",
+        "text/html" : "html",
+        "image/svg+xml" : "svg",
+        "image/png" : "png",
+        "image/jpeg" : "jpeg",
+        "text/latex" : "latex",
+        "application/json" : "json",
+        "application/javascript" : "javascript",
+    };
+
+    OutputArea.mime_map_r = {
+        "text" : "text/plain",
+        "html" : "text/html",
+        "svg" : "image/svg+xml",
+        "png" : "image/png",
+        "jpeg" : "image/jpeg",
+        "latex" : "text/latex",
+        "json" : "application/json",
+        "javascript" : "application/javascript",
+    };
+
+    OutputArea.display_order = [
+        'application/javascript',
+        'text/html',
+        'text/latex',
+        'image/svg+xml',
+        'image/png',
+        'image/jpeg',
+        'text/plain'
+    ];
+
+    OutputArea.append_map = {
+        "text/plain" : OutputArea.prototype.append_text,
+        "text/html" : OutputArea.prototype.append_html,
+        "image/svg+xml" : OutputArea.prototype.append_svg,
+        "image/png" : OutputArea.prototype.append_png,
+        "image/jpeg" : OutputArea.prototype.append_jpeg,
+        "text/latex" : OutputArea.prototype.append_latex,
+        "application/json" : OutputArea.prototype.append_json,
+        "application/javascript" : OutputArea.prototype.append_javascript,
+    };
 
     IPython.OutputArea = OutputArea;
 

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -552,19 +552,22 @@ var IPython = (function (IPython) {
     };
 
 
-    OutputArea.prototype.append_javascript = function (js, md, container) {
+    OutputArea.prototype.append_javascript = function (js, md, element) {
         // We just eval the JS code, element appears in the local scope.
         var type = 'application/javascript';
-        var element = this.create_output_subarea(md, "output_javascript", type);
-        IPython.keyboard_manager.register_events(element);
-        container.append(element);
+        var toinsert = this.create_output_subarea(md, "output_javascript", type);
+        IPython.keyboard_manager.register_events(toinsert);
+        element.append(toinsert);
+        //backward compat, js should be eval'ed in a context where `container` is defined.
+        var container = element;
+        container.show = function(){console.log('Warning "container.show()" is deprecated.')};
         try {
             eval(js);
         } catch(err) {
             console.log(err);
-            this._append_javascript_error(err, element);
+            this._append_javascript_error(err, toinsert);
         }
-        return container;
+        return toinsert;
     };
 
 

--- a/docs/source/whatsnew/pr/deprecation-js-container.rst
+++ b/docs/source/whatsnew/pr/deprecation-js-container.rst
@@ -1,0 +1,3 @@
+* calling `container.show()` on javascript display is deprecated and will
+  trigger errors on future IPython notebook versions. `container` now show
+  itself as soon as non-empty


### PR DESCRIPTION
Start working on #4747,

I'm wondering if we shouldn't have the `this['append_'+type](json[type],
md, element)` return (a reference to) the inner element it happends to
pass it to the event.

I'm also wondering if I should pass the mimetype as a parameter of the
event, or dynamically create the event-name based on the mime-type.

Last possibility is that each of the `append_xxx(xxx, md, element)`
(except JS) seem to end with `element.append(toinsert)` we could hve
them return the `toinsert` and move `element.append(toinsert)` to `append
mimetype.`

Thoughts ?
