### PR TITLE
Manually document py3compat module.

### DIFF
--- a/docs/autogen_api.py
+++ b/docs/autogen_api.py
@@ -31,6 +31,8 @@ if __name__ == '__main__':
                                         r'\.testing\.plugin',
                                         # This just prints a deprecation msg:
                                         r'\.frontend$',
+                                        # We document this manually.
+                                        r'\.utils\.py3compat',
                                         ]
     
     # We're rarely working on machines with the Azure SDK installed, so we


### PR DESCRIPTION
Automatic documentation doesn't work well with things that have alternative definitions inside conditional blocks, so I wrote some documentation manually.
