### PR TITLE
warn when notebook is started in pylab mode

### DIFF
--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -499,7 +499,7 @@ class NotebookApp(BaseIPythonApplication):
 
     trust_xheaders = Bool(False, config=True,
         help=("Whether to trust or not X-Scheme/X-Forwarded-Proto and X-Real-Ip/X-Forwarded-For headers"
-              "sent by the upstream reverse proxy. Neccesary if the proxy handles SSL")
+              "sent by the upstream reverse proxy. Necessary if the proxy handles SSL")
     )
     
     def parse_command_line(self, argv=None):
@@ -521,6 +521,13 @@ class NotebookApp(BaseIPythonApplication):
         """construct the kernel arguments"""
         # Scrub frontend-specific flags
         self.kernel_argv = swallow_argv(self.argv, notebook_aliases, notebook_flags)
+        if any(arg.startswith(u'--pylab') for arg in self.kernel_argv):
+            self.log.warn('\n    '.join([
+                "Starting all kernels in pylab mode is not recommended.",
+                "Please use the %matplotlib magic to enable matplotlib instead.",
+                "pylab implies many imports, which can have confusing side effects",
+                "and harm the reproducibility of your notebooks.",
+            ]))
         # Kernel should inherit default config file from frontend
         self.kernel_argv.append("--IPKernelApp.parent_appname='%s'" % self.name)
         # Kernel should get *absolute* path to profile directory

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -523,7 +523,8 @@ class NotebookApp(BaseIPythonApplication):
         self.kernel_argv = swallow_argv(self.argv, notebook_aliases, notebook_flags)
         if any(arg.startswith(u'--pylab') for arg in self.kernel_argv):
             self.log.warn('\n    '.join([
-                "Starting all kernels in pylab mode is not recommended.",
+                "Starting all kernels in pylab mode is not recommended,",
+                "and will be disabled in a future release.",
                 "Please use the %matplotlib magic to enable matplotlib instead.",
                 "pylab implies many imports, which can have confusing side effects",
                 "and harm the reproducibility of your notebooks.",


### PR DESCRIPTION
because it is always a bad idea

Hopefully we will actually deprecate specifying kernel args at notebook launch, but that won't be for a while. Warning about the most harmful and common option seems like a good compromise.
