### PR TITLE
fix IPython.embed

### DIFF
--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -521,10 +521,12 @@ class Application(SingletonConfigurable):
                 # unlikely event that the error raised before filefind finished
                 filename = loader.full_filename or filename
                 # problem while running the file
-                log.error("Exception while loading config file %s",
-                                filename, exc_info=True)
+                if log:
+                    log.error("Exception while loading config file %s",
+                            filename, exc_info=True)
             else:
-                log.debug("Loaded config file: %s", loader.full_filename)
+                if log:
+                    log.debug("Loaded config file: %s", loader.full_filename)
             if config:
                  yield config
 

--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -507,12 +507,10 @@ class Application(SingletonConfigurable):
         """
         pyloader = PyFileConfigLoader(basefilename+'.py', path=path, log=log)
         jsonloader = JSONFileConfigLoader(basefilename+'.json', path=path, log=log)
-        config_found = False
         config = None
         for loader in [pyloader, jsonloader]:
             try:
                 config = loader.load_config()
-                config_found = True
             except ConfigFileNotFound:
                 pass
             except Exception:
@@ -529,8 +527,6 @@ class Application(SingletonConfigurable):
             if config:
                  yield config
 
-        if not config_found:
-            raise ConfigFileNotFound('Neither .json, nor .py config file found.')
         raise StopIteration
 
 

--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -505,7 +505,6 @@ class Application(SingletonConfigurable):
 
         yield each config object in turn.
         """
-
         pyloader = PyFileConfigLoader(basefilename+'.py', path=path, log=log)
         jsonloader = JSONFileConfigLoader(basefilename+'.json', path=path, log=log)
         config_found = False
@@ -519,7 +518,7 @@ class Application(SingletonConfigurable):
             except Exception:
                 # try to get the full filename, but it will be empty in the
                 # unlikely event that the error raised before filefind finished
-                filename = loader.full_filename or filename
+                filename = loader.full_filename or basefilename
                 # problem while running the file
                 if log:
                     log.error("Exception while loading config file %s",

--- a/IPython/terminal/tests/test_embed.py
+++ b/IPython/terminal/tests/test_embed.py
@@ -20,7 +20,7 @@ from IPython.utils.tempdir import NamedFileInTemporaryDirectory
 # Tests
 #-----------------------------------------------------------------------------
 
-_sample_embed = """
+_sample_embed = b"""
 from __future__ import print_function
 import IPython
 
@@ -33,12 +33,12 @@ IPython.embed()
 print('bye!')
 """
 
-_exit = "exit\r".encode('UTF-8')
+_exit = b"exit\r"
 
 def test_ipython_embed():
     """test that `IPython.embed()` works"""
     with NamedFileInTemporaryDirectory('file_with_embed.py') as f:
-        f.write(_sample_embed.encode('UTF-8'))
+        f.write(_sample_embed)
         f.flush()
 
         # run `python file_with_embed.py`

--- a/IPython/terminal/tests/test_embed.py
+++ b/IPython/terminal/tests/test_embed.py
@@ -33,19 +33,22 @@ IPython.embed()
 print('bye!')
 """
 
+_exit = "exit\r".encode('UTF-8')
+
 def test_ipython_embed():
     """test that `IPython.embed()` works"""
     with NamedFileInTemporaryDirectory('file_with_embed.py') as f:
-        f.write(_sample_embed)
+        f.write(_sample_embed.encode('UTF-8'))
         f.flush()
 
         # run `python file_with_embed.py`
         cmd = [sys.executable, f.name]
 
         _, out, p = process_handler(cmd,
-                lambda p: (p.stdin.write("exit\r"), p.communicate()[:], p))
+                lambda p: (p.stdin.write(_exit), p.communicate()[:], p))
+        std = out[0].decode('UTF-8')
         nt.assert_equal(p.returncode, 0)
-        nt.assert_in('3 . 14', out[0])
-        nt.assert_in('IPython', out[0])
-        nt.assert_in('bye!', out[0])
+        nt.assert_in('3 . 14', std)
+        nt.assert_in('IPython', std)
+        nt.assert_in('bye!', std)
 

--- a/IPython/terminal/tests/test_embed.py
+++ b/IPython/terminal/tests/test_embed.py
@@ -1,0 +1,52 @@
+"""Test embedding of IPython"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2013 The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+import sys
+import nose.tools as nt
+from IPython.utils.process import process_handler
+
+#-----------------------------------------------------------------------------
+# Tests
+#-----------------------------------------------------------------------------
+
+_sample_embed = """
+from __future__ import print_function
+import IPython
+
+a = 3
+b = 14
+print(a, '.', b)
+
+IPython.embed()
+
+print 'bye!'
+"""
+
+def test_ipython_embed():
+    """test that `ipython [subcommand] --help-all` works"""
+    #with TempFile as f:
+    #    f.write("some embed case goes here")
+
+    # run `python file_with_embed.py`
+    fname = '/home/pi/code/workspace/rambles/test_embed.py'
+    cmd = [sys.executable, fname]
+
+    #p = Popen(cmd, stdout=PIPE, stderr=PIPE, stdin=PIPE)
+    print "\nhere's the command:", cmd
+    _, out, p = process_handler(cmd,
+            lambda p: (p.stdin.write("exit\r"), p.communicate()[:], p))
+    print out[1]
+    nt.assert_equal(p.returncode, 0)
+    nt.assert_equal(p.returncode, 0)
+#out, err, rc = tt.get_output_error_code(cmd)
+

--- a/IPython/terminal/tests/test_embed.py
+++ b/IPython/terminal/tests/test_embed.py
@@ -14,6 +14,7 @@
 import sys
 import nose.tools as nt
 from IPython.utils.process import process_handler
+from IPython.utils.tempdir import NamedFileInTemporaryDirectory
 
 #-----------------------------------------------------------------------------
 # Tests
@@ -29,24 +30,22 @@ print(a, '.', b)
 
 IPython.embed()
 
-print 'bye!'
+print('bye!')
 """
 
 def test_ipython_embed():
-    """test that `ipython [subcommand] --help-all` works"""
-    #with TempFile as f:
-    #    f.write("some embed case goes here")
+    """test that `IPython.embed()` works"""
+    with NamedFileInTemporaryDirectory('file_with_embed.py') as f:
+        f.write(_sample_embed)
+        f.flush()
 
-    # run `python file_with_embed.py`
-    fname = '/home/pi/code/workspace/rambles/test_embed.py'
-    cmd = [sys.executable, fname]
+        # run `python file_with_embed.py`
+        cmd = [sys.executable, f.name]
 
-    #p = Popen(cmd, stdout=PIPE, stderr=PIPE, stdin=PIPE)
-    print "\nhere's the command:", cmd
-    _, out, p = process_handler(cmd,
-            lambda p: (p.stdin.write("exit\r"), p.communicate()[:], p))
-    print out[1]
-    nt.assert_equal(p.returncode, 0)
-    nt.assert_equal(p.returncode, 0)
-#out, err, rc = tt.get_output_error_code(cmd)
+        _, out, p = process_handler(cmd,
+                lambda p: (p.stdin.write("exit\r"), p.communicate()[:], p))
+        nt.assert_equal(p.returncode, 0)
+        nt.assert_in('3 . 14', out[0])
+        nt.assert_in('IPython', out[0])
+        nt.assert_in('bye!', out[0])
 

--- a/IPython/terminal/tests/test_embed.py
+++ b/IPython/terminal/tests/test_embed.py
@@ -44,8 +44,7 @@ def test_ipython_embed():
         # run `python file_with_embed.py`
         cmd = [sys.executable, f.name]
 
-        _, out, p = process_handler(cmd,
-                lambda p: (p.stdin.write(_exit), p.communicate()[:], p))
+        out, p = process_handler(cmd, lambda p: (p.communicate(_exit), p))
         std = out[0].decode('UTF-8')
         nt.assert_equal(p.returncode, 0)
         nt.assert_in('3 . 14', std)

--- a/IPython/terminal/tests/test_embed.py
+++ b/IPython/terminal/tests/test_embed.py
@@ -40,6 +40,7 @@ def test_ipython_embed():
     with NamedFileInTemporaryDirectory('file_with_embed.py') as f:
         f.write(_sample_embed)
         f.flush()
+        f.close() # otherwise msft won't be able to read the file
 
         # run `python file_with_embed.py`
         cmd = [sys.executable, f.name]

--- a/IPython/utils/process.py
+++ b/IPython/utils/process.py
@@ -27,7 +27,7 @@ else:
     from ._process_posix import _find_cmd, system, getoutput, arg_split
 
 
-from ._process_common import getoutputerror, get_output_error_code
+from ._process_common import getoutputerror, get_output_error_code, process_handler
 from . import py3compat
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
without this change, IPython.embed throws the following traceback:

```
  File "explete.py", line 9, in dump_inputs
   IPython.embed()
 File "/home/pi/code/ipython/IPython/terminal/embed.py", line 287, in embed
   config = load_default_config()
 File "/home/pi/code/ipython/IPython/terminal/ipapp.py", line 379, in
load_default_config
   for cf in Application._load_config_files("ipython_config",
path=profile_dir):
 File "/home/pi/code/ipython/IPython/config/application.py", line 527, in
_load_config_files
   log.debug("Loaded config file: %s", loader.full_filename) AttributeError:
'NoneType' object has no attribute 'debug'
```

@Carreau was the last to poke around in this part of the code, so pinging him,
just in case
