### PR TITLE
non-python kernels run python code with qtconsole

### DIFF
--- a/IPython/qt/console/ipython_widget.py
+++ b/IPython/qt/console/ipython_widget.py
@@ -135,6 +135,8 @@ class IPythonWidget(FrontendWidget):
         else:
             self.set_default_style()
 
+        self._guiref_loaded = False
+
     #---------------------------------------------------------------------------
     # 'BaseFrontendMixin' abstract interface
     #---------------------------------------------------------------------------
@@ -258,10 +260,21 @@ class IPythonWidget(FrontendWidget):
             # This newline seems to be needed for text and html output.
             self._append_plain_text(u'\n', True)
 
+    def _handle_kernel_info_reply(self, rep):
+        """ Handle kernel info replies.
+        """
+        if not self._guiref_loaded:
+            if rep['content']['language'] == 'python':
+                self._load_guiref_magic()
+            self._guiref_loaded = True
+
     def _started_channels(self):
         """Reimplemented to make a history request and load %guiref."""
         super(IPythonWidget, self)._started_channels()
-        self._load_guiref_magic()
+
+        # The reply will trigger %guiref load provided language=='python'
+        self.kernel_client.kernel_info()
+
         self.kernel_client.shell_channel.history(hist_access_type='tail',
                                                   n=1000)
     


### PR DESCRIPTION
When launching the qtconsole with a non-python kernel it crashes immediately since the frontend [requests that the following code is run by the kernel](https://github.com/ipython/ipython/blob/master/IPython/qt/console/ipython_widget.py#L276):

```
try:
    _usage
except:
    from IPython.core import usage as _usage
    get_ipython().register_magic_function(_usage.page_guiref, 'line', 'guiref')
    del _usage
```

obviously only python kernels understand and can execute this.

Either we
- check the language of the kernel first (with a `kernel_info_request` message).
- find another way to register the magic functions for python kernels.
