### PR TITLE
be conservative about kernel_info implementation

### DIFF
--- a/IPython/qt/console/ipython_widget.py
+++ b/IPython/qt/console/ipython_widget.py
@@ -264,7 +264,7 @@ class IPythonWidget(FrontendWidget):
         """ Handle kernel info replies.
         """
         if not self._guiref_loaded:
-            if rep['content']['language'] == 'python':
+            if rep['content'].get('language') == 'python':
                 self._load_guiref_magic()
             self._guiref_loaded = True
 


### PR DESCRIPTION
in case kernels don't comply with the message spec by leaving out the language key.

as recommended in [this comment](https://github.com/ipython/ipython/pull/4787/files#r8846785).
