### PR TITLE
Qt frontend: Handle 'aborted' prompt replies.

### DIFF
--- a/IPython/qt/console/ipython_widget.py
+++ b/IPython/qt/console/ipython_widget.py
@@ -175,11 +175,15 @@ class IPythonWidget(FrontendWidget):
         msg_id = msg['parent_header'].get('msg_id')
         info = self._request_info['execute'].get(msg_id)
         if info and info.kind == 'prompt':
-           number = msg['content']['execution_count'] + 1
-           self._show_interpreter_prompt(number)
-           self._request_info['execute'].pop(msg_id)
+            content = msg['content']
+            if content['status'] == 'aborted':
+                self._show_interpreter_prompt()
+            else:
+                number = content['execution_count'] + 1
+                self._show_interpreter_prompt(number)
+            self._request_info['execute'].pop(msg_id)
         else:
-           super(IPythonWidget, self)._handle_execute_reply(msg)
+            super(IPythonWidget, self)._handle_execute_reply(msg)
 
     def _handle_history_reply(self, msg):
         """ Implemented to handle history tail replies, which are only supported


### PR DESCRIPTION
On some rare occasions, the execution request for prompt
is aborted by the kernel (due to an error in another execution request -
https://github.com/ipython/ipython/blob/master/IPython/kernel/zmq/ipkernel.py#L469 ),
which is not handled gracefully by the ipython qt frontend widget
raising `KeyError: 'execution_count'`

```
Traceback (most recent call last):
  File "/home/pankaj/work/ipython/IPython/qt/base_frontend_mixin.py", line 138, in _dispatch
    handler(msg)
  File "/home/pankaj/work/ipython/IPython/qt/console/ipython_widget.py", line 178, in _handle_execute_reply
    number = msg['content']['execution_count'] + 1
KeyError: 'execution_count'
```

This commit simply handles 'aborted' prompt requests by retrying it.
