### PR TITLE
Correct order of packages for unicode in nbconvert to LaTeX

### DIFF
--- a/IPython/nbconvert/templates/latex/base.tplx
+++ b/IPython/nbconvert/templates/latex/base.tplx
@@ -20,8 +20,8 @@ This template does not define a docclass, the inheriting class must define this.
     \usepackage{geometry} % Used to adjust the document margins
     \usepackage{amsmath} % Equations
     \usepackage{amssymb} % Equations
-    \usepackage[utf8]{inputenc} % Allow utf-8 characters in the tex document
     \usepackage[mathletters]{ucs} % Extended unicode (utf-8) support
+    \usepackage[utf8x]{inputenc} % Allow utf-8 characters in the tex document
     \usepackage{fancyvrb} % verbatim replacement that allows latex
     \usepackage{grffile} % extends the file name processing of package graphics 
                          % to support a larger range 


### PR DESCRIPTION
The ucs and inputenc latex packages set the converted notebook up for unicode support.  However, the wrong option (utf8, should be utf8x) is given to the inputenc package and the ucs package should be loaded before  inputenc.   The relevant part of the pdflatex log from "ipython nbconvert --to latex notebook.ipynb; pdflatex notebook.ipynb" is:

(/usr/local/texlive/2013/texmf-dist/tex/latex/ucs/ucsencs.def)

Package ucs Warning: ***************************
(ucs)                You seem to have loaded inputencoding utf8
(ucs)                (LaTeX kernel UTF-8) instead of utf8x (ucs.sty UTF-8).
(ucs)                Probably you are compiling a document written for a
(ucs)                pre-august-2004 ucs.sty.
(ucs)                ***************************
(ucs)                Please use \usepackage[utf8x]{inputenc} instead of
(ucs)                \usepackage[utf8]{inputenc}.
(ucs)                ***************************
(ucs)                If you should really want to use ucs.sty and kernel's
(ucs)                utf8.def together, use \usepackage[utf8x,utf8]{inputenc}
(ucs)                to disable compatibility mode
(ucs)                ***************************
(ucs)                Activating compatibility mode.
(ucs)                ***************************
(ucs)                 on input line 213.

(/usr/local/texlive/2013/texmf-dist/tex/latex/ucs/utf8x.def)

This tiny patch uses the utf8x option and gets the package order right.  More information about ucs from "texdoc ucs".
