### PR TITLE
Correct handling of ansi colour codes when nbconverting to latex

### DIFF
--- a/IPython/nbconvert/filters/ansi.py
+++ b/IPython/nbconvert/filters/ansi.py
@@ -121,28 +121,30 @@ def single_ansi2latex(code):
     """
     components = code.split(';')
     if len(components) > 1:
-        style = components[0][-1]
+        # Style is digits after '['
+        style = int(components[0].split('[')[-1])
         color = components[1][:-1]
     else:
-        style = '0'
+        style = 0
         color = components[0][-3:-1]
         
     # If the style is not normal (0), bold (1) or blinking (5) then treat it as normal
-    if style not in '015':
-        style = '0'
+    if style not in [0, 1, 5]:
+        style = 0
 
     for name, tcode in coloransi.color_templates:
         tstyle, tcolor = tcode.split(';')
+        tstyle = int(tstyle)
         if tstyle == style and tcolor == color:
             break
     else:
         return '', 0
 
-    if style == '5':
+    if style == 5:
         name = name[5:]                             # BlinkRed -> Red, etc
     name = name.lower()
 
-    if style in '15':
+    if style in [1, 5]:
         return r'\textbf{\color{'+name+'}', 1
     else:
         return r'{\color{'+name+'}', 1
@@ -173,5 +175,3 @@ def ansi2latex(text):
     if openbrack: 
         outstring += '}'*openbrack
     return outstring.strip()
-
-

--- a/IPython/nbconvert/filters/ansi.py
+++ b/IPython/nbconvert/filters/ansi.py
@@ -106,37 +106,53 @@ def ansi2html(text):
 
 
 def single_ansi2latex(code):
-    """Converts single ansi markup to latex format
+    """Converts single ansi markup to latex format.
 
     Return latex code and number of open brackets.
+
+    Accepts codes like '\x1b[1;32m' (bold, red) and the short form '\x1b[32m' (red)
+
+    Colors are matched to those defined in coloransi, which defines colors
+    using the 0, 1 (bold) and 5 (blinking) styles. Styles 1 and 5 are
+    interpreted as bold. All other styles are mapped to 0. Note that in
+    coloransi, a style of 1 does not just mean bold; for example, Brown is
+    "0;33", but Yellow is "1;33". An empty string is returned for unrecognised
+    codes and the "reset" code '\x1b[m'.
     """
-    for color in coloransi.color_templates:
+    components = code.split(';')
+    if len(components) > 1:
+        style = components[0][-1]
+        color = components[1][:-1]
+    else:
+        style = '0'
+        color = components[0][-3:-1]
+        
+    # If the style is not normal (0), bold (1) or blinking (5) then treat it as normal
+    if style not in '015':
+        style = '0'
 
-        #Make sure to get the color code (which is a part of the overall style)
-        # i.e.  0;31 is valid
-        #       31 is also valid, and means the same thing
-        #coloransi.color_templates stores the longer of the two formats %d;%d
-        #Get the short format so we can parse that too.  Short format only exist
-        #if no other formating is applied (the other number must be a 0)!
-        style_code = getattr(coloransi.TermColors, color[0])
-        color_code = style_code.split(';')[1]
-        is_normal = style_code.split(';')[0] == '0'
+    for name, tcode in coloransi.color_templates:
+        tstyle, tcolor = tcode.split(';')
+        if tstyle == style and tcolor == color:
+            break
+    else:
+        return '', 0
 
-        # regular weight
-        if (code == style_code) or (is_normal and code == color_code):
-            
-            return r'{\color{'+color[0].lower()+'}', 1
-        # bold
-        if code == style_code[:3]+str(1)+style_code[3:]:
-            return r'\textbf{\color{'+color[0].lower()+'}', 1
-    return '', 0
+    if style == '5':
+        name = name[5:]                             # BlinkRed -> Red, etc
+    name = name.lower()
+
+    if style in '15':
+        return r'\textbf{\color{'+name+'}', 1
+    else:
+        return r'{\color{'+name+'}', 1
 
 def ansi2latex(text):
     """Converts ansi formated text to latex version
 
     based on https://bitbucket.org/birkenfeld/sphinx-contrib/ansi.py
     """
-    color_pattern = re.compile('\x1b\\[([^m]+)m')
+    color_pattern = re.compile('\x1b\\[([^m]*)m')
     last_end = 0
     openbrack = 0
     outstring = ''
@@ -146,8 +162,9 @@ def ansi2latex(text):
         if openbrack:
             outstring += '}'*openbrack
             openbrack = 0
-        if not (match.group() == coloransi.TermColors.Normal or openbrack):
-            texform, openbrack = single_ansi2latex(match.group())
+        code = match.group()
+        if not (code == coloransi.TermColors.Normal or openbrack):
+            texform, openbrack = single_ansi2latex(code)
             outstring += texform
         last_end = match.end()
     
@@ -156,3 +173,5 @@ def ansi2latex(text):
     if openbrack: 
         outstring += '}'*openbrack
     return outstring.strip()
+
+

--- a/IPython/nbconvert/filters/tests/test_ansi.py
+++ b/IPython/nbconvert/filters/tests/test_ansi.py
@@ -76,7 +76,9 @@ class TestAnsi(TestsBase):
             'hel%slo' % TermColors.Green : r'hel{\color{green}lo}',
             'hello' : 'hello',
             u'hello\x1b[34mthere\x1b[mworld' : u'hello{\\color{blue}there}world',
-            u'hello\x1b[mthere': u'hellothere'
+            u'hello\x1b[mthere': u'hellothere',
+            u'hello\x1b[01;34mthere' : u"hello\\textbf{\\color{lightblue}there}",
+            u'hello\x1b[001;34mthere' : u"hello\\textbf{\\color{lightblue}there}"
             }
 
         for inval, outval in correct_outputs.items():

--- a/IPython/nbconvert/filters/tests/test_ansi.py
+++ b/IPython/nbconvert/filters/tests/test_ansi.py
@@ -71,10 +71,13 @@ class TestAnsi(TestsBase):
             '%s' % (TermColors.Red)  : r'{\color{red}}',
             'hello%s' % TermColors.Blue: r'hello{\color{blue}}',
             'he%s%sllo' % (TermColors.Green, TermColors.Cyan) : r'he{\color{green}}{\color{cyan}llo}',
-            '%shello' % TermColors.Yellow : r'{\color{yellow}hello}',
-            '{0}h{0}e{0}l{0}l{0}o{0}'.format(TermColors.White) : r'{\color{white}h}{\color{white}e}{\color{white}l}{\color{white}l}{\color{white}o}{\color{white}}',
+            '%shello' % TermColors.Yellow : r'\textbf{\color{yellow}hello}',
+            '{0}h{0}e{0}l{0}l{0}o{0}'.format(TermColors.White) : r'\textbf{\color{white}h}\textbf{\color{white}e}\textbf{\color{white}l}\textbf{\color{white}l}\textbf{\color{white}o}\textbf{\color{white}}',
             'hel%slo' % TermColors.Green : r'hel{\color{green}lo}',
-            'hello' : 'hello'}
+            'hello' : 'hello',
+            u'hello\x1b[34mthere\x1b[mworld' : u'hello{\\color{blue}there}world',
+            u'hello\x1b[mthere': u'hellothere'
+            }
 
         for inval, outval in correct_outputs.items():
             self._try_ansi2latex(inval, outval)

--- a/IPython/nbconvert/templates/latex/base.tplx
+++ b/IPython/nbconvert/templates/latex/base.tplx
@@ -20,8 +20,8 @@ This template does not define a docclass, the inheriting class must define this.
     \usepackage{geometry} % Used to adjust the document margins
     \usepackage{amsmath} % Equations
     \usepackage{amssymb} % Equations
-    \usepackage[utf8]{inputenc} % Allow utf-8 characters in the tex document
     \usepackage[mathletters]{ucs} % Extended unicode (utf-8) support
+    \usepackage[utf8x]{inputenc} % Allow utf-8 characters in the tex document
     \usepackage{fancyvrb} % verbatim replacement that allows latex
     \usepackage{grffile} % extends the file name processing of package graphics 
                          % to support a larger range 


### PR DESCRIPTION
nbconvert leaves non-printing characters such as ^[[m in latex after nbconversion of notebooks with ansi colour codes (e.g., from ls).  Latex can't cope with these even with unicode packages correctly installed, see PR 4806.  This PR corrects this and interprets blinking ansi codes as bold.  It adds tests for the ansi reset code "\x1b[m" and bold characters to the unit tests.
