### PR TITLE
make help menu a template

### DIFF
--- a/IPython/html/static/notebook/less/menubar.less
+++ b/IPython/html/static/notebook/less/menubar.less
@@ -18,3 +18,8 @@
 #menubar li.dropdown {
   line-height: 12px;
 }
+
+i.menu-icon {
+  // add padding to account for float-right
+  padding-top: 4px;
+}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1,7 +1,3 @@
-.clearfix{*zoom:1}.clearfix:before,.clearfix:after{display:table;content:"";line-height:0}
-.clearfix:after{clear:both}
-.hide-text{font:0/0 a;color:transparent;text-shadow:none;background-color:transparent;border:0}
-.input-block-level{display:block;width:100%;min-height:30px;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
 article,aside,details,figcaption,figure,footer,header,hgroup,nav,section{display:block}
 audio,canvas,video{display:inline-block;*display:inline;*zoom:1}
 audio:not([controls]){display:none}
@@ -856,6 +852,10 @@ a.label:hover,a.label:focus,a.badge:hover,a.badge:focus{color:#fff;text-decorati
 .show{display:block}
 .invisible{visibility:hidden}
 .affix{position:fixed}
+.clearfix{*zoom:1}.clearfix:before,.clearfix:after{display:table;content:"";line-height:0}
+.clearfix:after{clear:both}
+.hide-text{font:0/0 a;color:transparent;text-shadow:none;background-color:transparent;border:0}
+.input-block-level{display:block;width:100%;min-height:30px;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
 @-ms-viewport{width:device-width}.hidden{display:none;visibility:hidden}
 .visible-phone{display:none !important}
 .visible-tablet{display:none !important}
@@ -1426,6 +1426,7 @@ p{margin-bottom:0}
 #menubar .navbar{margin-bottom:8px}
 .nav-wrapper{border-bottom:1px solid #d4d4d4}
 #menubar li.dropdown{line-height:12px}
+i.menu-icon{padding-top:4px}
 #notification_area{z-index:10}
 .notification_widget{color:#777;padding:1px 12px;margin:2px 4px;z-index:10;border:1px solid #ccc;border-radius:4px;background:rgba(240,240,240,0.5)}
 div#pager_splitter{height:8px}

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -228,7 +228,7 @@ class="notebook_app"
                             ("http://docs.python.org","Python",True),
                             ("http://docs.scipy.org/doc/numpy/reference/","NumPy",True),
                             ("http://docs.scipy.org/doc/scipy/reference/","SciPy",True),
-                            ("http://matplotlib.org/","Matplotlib",True),
+                            ("http://matplotlib.org/contents.html","Matplotlib",True),
                             ("http://docs.sympy.org/dev/index.html","SymPy",True),
                             ("http://pandas.pydata.org/pandas-docs/stable/","pandas", True)
                         )

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -215,18 +215,35 @@ class="notebook_app"
             </ul>
         </li>
         <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Help</a>
-            <ul id="help_menu" class="dropdown-menu">
-                <li><a href="http://ipython.org/documentation.html" target="_blank">IPython Help</a></li>
-                <li><a href="http://ipython.org/ipython-doc/stable/interactive/notebook.html" target="_blank">Notebook Help</a></li>
+            <ul  id="help_menu" class="dropdown-menu">
                 <li id="keyboard_shortcuts" title="Opens a tooltip with all keyboard shortcuts"><a href="#">Keyboard Shortcuts</a></li>
-                <li><a href="http://ipython.org/ipython-doc/dev/interactive/cm_keyboard.html" target="_blank">Editor Shortcuts</a></li>
                 <li class="divider"></li>
-                <li><a href="http://docs.python.org" target="_blank">Python</a></li>
-                <li><a href="http://docs.scipy.org/doc/numpy/reference/" target="_blank">NumPy</a></li>
-                <li><a href="http://docs.scipy.org/doc/scipy/reference/" target="_blank">SciPy</a></li>
-                <li><a href="http://matplotlib.org/" target="_blank">Matplotlib</a></li>
-                <li><a href="http://docs.sympy.org/dev/index.html" target="_blank">SymPy</a></li>
-                <li><a href="http://pandas.pydata.org/pandas-docs/stable/" target="_blank">pandas</a></li>
+                {% set
+                    sections = (
+                        (
+                            ("http://ipython.org/documentation.html","IPython Help",True),
+                            ("http://ipython.org/ipython-doc/stable/interactive/notebook.html","Notebook Help",True),
+                            ("http://ipython.org/ipython-doc/dev/interactive/cm_keyboard.html","Editor Shortcuts",True),
+                        ),(
+                            ("http://docs.python.org","Python",True),
+                            ("http://docs.scipy.org/doc/numpy/reference/","NumPy",True),
+                            ("http://docs.scipy.org/doc/scipy/reference/","SciPy",True),
+                            ("http://matplotlib.org/","Matplotlib",True),
+                            ("http://docs.sympy.org/dev/index.html","SymPy",True),
+                            ("http://pandas.pydata.org/pandas-docs/stable/","pandas", True)
+                        )
+                    )
+                %}
+
+                {% for helplinks in sections %}
+                    {% for link in helplinks %}
+                        <li><a href="{{link[0]}}" {{'target="_blank" title="Opens in a new window"' if link[2]}}>{{link[1]}}{{'<i class="icon-external-link menu-icon pull-right"></i>' if link[2]}}</a></li>
+                    {% endfor %}
+                    {% if not loop.last %}
+                        <li class="divider"></li>
+                    {% endif %}
+                {% endfor %}
+                </li>
             </ul>
         </li>
     </ul>


### PR DESCRIPTION
Move Help shortcut to the top, "external" Icon, and make it templated. 

![capture decran 2014-01-16 a 12 02 53](https://f.cloud.github.com/assets/335567/1934359/4fcd3c90-7ee9-11e3-89c2-88778d7669c7.png).

Not yet "configurable", cause we should decide on where/how to do that on a per kernel basis.
