### PR TITLE
fix regex for cleaning old logs with ipcluster

### DIFF
--- a/IPython/parallel/apps/ipclusterapp.py
+++ b/IPython/parallel/apps/ipclusterapp.py
@@ -401,10 +401,8 @@ class IPClusterEngines(BaseParallelApplication):
         if self.clean_logs:
             log_dir = self.profile_dir.log_dir
             for f in os.listdir(log_dir):
-                if re.match(r'ip(engine|controller)z-\d+\.(log|err|out)',f):
+                if re.match(r'ip(engine|controller)-.+\.(log|err|out)',f):
                     os.remove(os.path.join(log_dir, f))
-        # This will remove old log files for ipcluster itself
-        # super(IPBaseParallelApplication, self).start_logging()
 
     def start(self):
         """Start the app for the engines subcommand."""


### PR DESCRIPTION
It still had the 'z' suffix from ages and ages ago, so no files would ever match.

closes #4810
