### PR TITLE
tell mathjax to ignore 'no-mathjax' classed elements

### DIFF
--- a/IPython/html/static/notebook/js/mathjaxutils.js
+++ b/IPython/html/static/notebook/js/mathjaxutils.js
@@ -22,6 +22,7 @@ IPython.mathjaxutils = (function (IPython) {
                 tex2jax: {
                     inlineMath: [ ['$','$'], ["\\(","\\)"] ],
                     displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+                    ignoreClass: "no-mathjax",
                     processEscapes: true,
                     processEnvironments: true
                 },


### PR DESCRIPTION
makes it easier to express that mathjax should not be applied to a given block.

closes #4817
