### PR TITLE
Minor fixes for typos/inconsistencies in parallel docs

### DIFF
--- a/docs/source/parallel/parallel_multiengine.rst
+++ b/docs/source/parallel/parallel_multiengine.rst
@@ -377,7 +377,7 @@ The following examples demonstrate how to use the instance attributes:
     In [19]: ar.get()
     Out[19]: [10, 10]
 
-    In [20]: dview.targets = v.client.ids # all engines (4)
+    In [20]: dview.targets = rc.ids # all engines (4)
     
     In [21]: dview.block = True
 
@@ -588,9 +588,11 @@ If you want, you can even raise one of these original exceptions:
 
 .. sourcecode:: ipython
 
+    In [79]: from IPython.parallel import CompositeError
+
     In [80]: try:
        ....:     dview.execute('1/0', block=True)
-       ....: except parallel.error.CompositeError, e:
+       ....: except CompositeError, e:
        ....:     e.raise_exception()
        ....: 
        ....: 
@@ -669,12 +671,12 @@ You can change this limit to suit your needs with:
 
     In [20]: from IPython.parallel import CompositeError
     In [21]: CompositeError.tb_limit = 1
-    In [22]: %px a=b
+    In [22]: %px x=z
     [0:execute]: 
     ---------------------------------------------------------------------------
     NameError                                 Traceback (most recent call last)
-    ----> 1 a=b
-    NameError: name 'b' is not defined
+    ----> 1 x=z
+    NameError: name 'z' is not defined
 
     ... 3 more exceptions ...
 

--- a/docs/source/parallel/parallel_multiengine.rst
+++ b/docs/source/parallel/parallel_multiengine.rst
@@ -522,13 +522,13 @@ be collected and raise a CompositeError, as demonstrated in the next section.
 
     In [69]: from IPython.parallel import require
 
-    In [70]: @require('re'):
+    In [70]: @require('re')
        ....: def findall(pat, x):
        ....:     # re is guaranteed to be available
        ....:     return re.findall(pat, x)
           
     # you can also pass modules themselves, that you already have locally:
-    In [71]: @require(time):
+    In [71]: @require(time)
        ....: def wait(t):
        ....:     time.sleep(t)
        ....:     return t

--- a/docs/source/parallel/parallel_task.rst
+++ b/docs/source/parallel/parallel_task.rst
@@ -186,7 +186,7 @@ will be assigned to another engine. If the dependency returns *anything other th
        ....: def wintask():
        ....:    do_windows_stuff()
     
-In this case, any time you apply ``mytask``, it will only run on an OSX machine.
+In this case, any time you apply ``mactask``, it will only run on an OSX machine.
 ``@depend`` is just like ``apply``, in that it has a ``@depend(f,*args,**kwargs)``
 signature.
 


### PR DESCRIPTION
Running through the entire Direct interface page within a single session would produce errors/unexpected behavior due to inconsistencies in the naming of variables. In particular, a & b are defined earlier, so they don't throw a NameError as expected in the example.
