### PR TITLE
some $.html( -> $.text(

### DIFF
--- a/IPython/html/static/notebook/js/celltoolbarpresets/rawcell.js
+++ b/IPython/html/static/notebook/js/celltoolbarpresets/rawcell.js
@@ -33,7 +33,7 @@
         } else if (value === 'dialog'){
             var dialog = $('<div/>').append(
                 $("<p/>")
-                    .html("Set the MIME type of the raw cell:")
+                    .text("Set the MIME type of the raw cell:")
             ).append(
                 $("<br/>")
             ).append(

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -409,7 +409,12 @@ var IPython = (function (IPython) {
 
 
     CodeCell.input_prompt_classical = function (prompt_value, lines_number) {
-        var ns = prompt_value || "&nbsp;";
+        var ns;
+        if (prompt_value == undefined) {
+            ns = "&nbsp;";
+        } else {
+            ns = encodeURIComponent(prompt_value);
+        }
         return 'In&nbsp;[' + ns + ']:';
     };
 

--- a/IPython/html/static/notebook/js/mathjaxutils.js
+++ b/IPython/html/static/notebook/js/mathjaxutils.js
@@ -38,40 +38,40 @@ IPython.mathjaxutils = (function (IPython) {
             // Don't have MathJax, but should. Show dialog.
             var message = $('<div/>')
                 .append(
-                    $("<p/></p>").addClass('dialog').html(
+                    $("<p/></p>").addClass('dialog').text(
                         "Math/LaTeX rendering will be disabled."
                     )
                 ).append(
-                    $("<p></p>").addClass('dialog').html(
+                    $("<p></p>").addClass('dialog').text(
                         "If you have administrative access to the notebook server and" +
                         " a working internet connection, you can install a local copy" +
                         " of MathJax for offline use with the following command on the server" +
                         " at a Python or IPython prompt:"
                     )
                 ).append(
-                    $("<pre></pre>").addClass('dialog').html(
+                    $("<pre></pre>").addClass('dialog').text(
                         ">>> from IPython.external import mathjax; mathjax.install_mathjax()"
                     )
                 ).append(
-                    $("<p></p>").addClass('dialog').html(
+                    $("<p></p>").addClass('dialog').text(
                         "This will try to install MathJax into the IPython source directory."
                     )
                 ).append(
-                    $("<p></p>").addClass('dialog').html(
+                    $("<p></p>").addClass('dialog').text(
                         "If IPython is installed to a location that requires" +
                         " administrative privileges to write, you will need to make this call as" +
                         " an administrator, via 'sudo'."
                     )
                 ).append(
-                    $("<p></p>").addClass('dialog').html(
+                    $("<p></p>").addClass('dialog').text(
                         "When you start the notebook server, you can instruct it to disable MathJax support altogether:"
                     )
                 ).append(
-                    $("<pre></pre>").addClass('dialog').html(
+                    $("<pre></pre>").addClass('dialog').text(
                         "$ ipython notebook --no-mathjax"
                     )
                 ).append(
-                    $("<p></p>").addClass('dialog').html(
+                    $("<p></p>").addClass('dialog').text(
                         "which will prevent this dialog from appearing."
                     )
                 );

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1318,7 +1318,7 @@ var IPython = (function (IPython) {
         var that = this;
         IPython.dialog.modal({
             title : "Restart kernel or continue running?",
-            body : $("<p/>").html(
+            body : $("<p/>").text(
                 'Do you want to restart the current kernel?  You will lose all variables defined in it.'
             ),
             buttons : {
@@ -1781,7 +1781,7 @@ var IPython = (function (IPython) {
         var that = this;
         var dialog = $('<div/>').append(
             $("<p/>").addClass("rename-message")
-            .html('This notebook name already exists.')
+            .text('This notebook name already exists.')
         )
         $([IPython.events]).trigger('notebook_rename_failed.Notebook', [xhr, status, error]);
         IPython.dialog.modal({

--- a/IPython/html/static/notebook/js/notificationwidget.js
+++ b/IPython/html/static/notebook/js/notificationwidget.js
@@ -43,7 +43,7 @@ var IPython = (function (IPython) {
     NotificationWidget.prototype.set_message = function (msg, timeout, click_callback) {
         var callback = click_callback || function() {return false;};
         var that = this;
-        this.element.html(msg);
+        this.element.text(msg);
         this.element.fadeIn(100);
         if (this.timeout !== null) {
             clearTimeout(this.timeout);
@@ -51,13 +51,13 @@ var IPython = (function (IPython) {
         }
         if (timeout !== undefined && timeout >=0) {
             this.timeout = setTimeout(function () {
-                that.element.fadeOut(100, function () {that.element.html('');});
+                that.element.fadeOut(100, function () {that.element.text('');});
                 that.timeout = null;
             }, timeout);
         } else {
             this.element.click(function() {
                 if( callback() != false ) {
-                    that.element.fadeOut(100, function () {that.element.html('');});
+                    that.element.fadeOut(100, function () {that.element.text('');});
                     that.element.unbind('click');
                 }
                 if (that.timeout !== undefined) {

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -61,7 +61,7 @@ var IPython = (function (IPython) {
         
         this.collapse_button.addClass("btn output_collapsed");
         this.collapse_button.attr('title', 'click to expand output');
-        this.collapse_button.html('. . .');
+        this.collapse_button.text('. . .');
         
         this.prompt_overlay.addClass('out_prompt_overlay prompt');
         this.prompt_overlay.attr('title', 'click to expand output; double click to hide output');
@@ -442,7 +442,7 @@ var IPython = (function (IPython) {
         var n = json.prompt_number || ' ';
         var toinsert = this.create_output_area();
         if (this.prompt_area) {
-            toinsert.find('div.prompt').addClass('output_prompt').html('Out[' + n + ']:');
+            toinsert.find('div.prompt').addClass('output_prompt').text('Out[' + n + ']:');
         }
         this.append_mime_type(json, toinsert);
         this._safe_append(toinsert);

--- a/IPython/html/static/notebook/js/quickhelp.js
+++ b/IPython/html/static/notebook/js/quickhelp.js
@@ -32,7 +32,7 @@ var IPython = (function (IPython) {
         // The documentation
         var doc = $('<div/>').addClass('alert');
         doc.append(
-            $('<button/>').addClass('close').attr('data-dismiss','alert').html('&times')
+            $('<button/>').addClass('close').attr('data-dismiss','alert').html('&times;')
         ).append(
             'The IPython Notebook has two different keyboard input modes. <b>Edit mode</b> '+
             'allow you the type code/text into a cell and is indicated by a green cell '+
@@ -75,16 +75,16 @@ var IPython = (function (IPython) {
             help = command_shortcuts[i]['help'];
             shortcut = command_shortcuts[i]['shortcut'];
             cmd_col1.append($('<div>').addClass('quickhelp').
-                append($('<span/>').addClass('shortcut_key').html(shortcut)).
-                append($('<span/>').addClass('shortcut_descr').html(' : ' + help))
+                append($('<span/>').addClass('shortcut_key').text(shortcut)).
+                append($('<span/>').addClass('shortcut_descr').text(' : ' + help))
             );
         };
         for (i=half; i<n; i++) {
             help = command_shortcuts[i]['help'];
             shortcut = command_shortcuts[i]['shortcut'];
             cmd_col2.append($('<div>').addClass('quickhelp').
-                append($('<span/>').addClass('shortcut_key').html(shortcut)).
-                append($('<span/>').addClass('shortcut_descr').html(' : ' + help))
+                append($('<span/>').addClass('shortcut_key').text(shortcut)).
+                append($('<span/>').addClass('shortcut_descr').text(' : ' + help))
             );
         };
         cmd_sub_div.append(cmd_col1).append(cmd_col2);
@@ -108,16 +108,16 @@ var IPython = (function (IPython) {
             help = edit_shortcuts[i]['help'];
             shortcut = edit_shortcuts[i]['shortcut'];
             edit_col1.append($('<div>').addClass('quickhelp').
-                append($('<span/>').addClass('shortcut_key').html(shortcut)).
-                append($('<span/>').addClass('shortcut_descr').html(' : ' + help))
+                append($('<span/>').addClass('shortcut_key').text(shortcut)).
+                append($('<span/>').addClass('shortcut_descr').text(' : ' + help))
             );
         };
         for (i=half; i<n; i++) {
             help = edit_shortcuts[i]['help'];
             shortcut = edit_shortcuts[i]['shortcut'];
             edit_col2.append($('<div>').addClass('quickhelp').
-                append($('<span/>').addClass('shortcut_key').html(shortcut)).
-                append($('<span/>').addClass('shortcut_descr').html(' : ' + help))
+                append($('<span/>').addClass('shortcut_key').text(shortcut)).
+                append($('<span/>').addClass('shortcut_descr').text(' : ' + help))
             );
         };
         edit_sub_div.append(edit_col1).append(edit_col2);

--- a/IPython/html/static/notebook/js/savewidget.js
+++ b/IPython/html/static/notebook/js/savewidget.js
@@ -71,7 +71,7 @@ var IPython = (function (IPython) {
         var that = this;
         var dialog = $('<div/>').append(
             $("<p/>").addClass("rename-message")
-                .html('Enter a new notebook name:')
+                .text('Enter a new notebook name:')
         ).append(
             $("<br/>")
         ).append(
@@ -88,7 +88,7 @@ var IPython = (function (IPython) {
                     click: function () {
                     var new_name = $(this).find('input').val();
                     if (!IPython.notebook.test_notebook_name(new_name)) {
-                        $(this).find('.rename-message').html(
+                        $(this).find('.rename-message').text(
                             "Invalid notebook name. Notebook names must "+
                             "have 1 or more characters and can contain any characters " +
                             "except :/\\. Please enter a new notebook name:"
@@ -116,7 +116,7 @@ var IPython = (function (IPython) {
 
     SaveWidget.prototype.update_notebook_name = function () {
         var nbname = IPython.notebook.get_notebook_name();
-        this.element.find('span#notebook_name').html(nbname);
+        this.element.find('span#notebook_name').text(nbname);
     };
 
 
@@ -138,11 +138,11 @@ var IPython = (function (IPython) {
 
 
     SaveWidget.prototype.set_save_status = function (msg) {
-        this.element.find('span#autosave_status').html(msg);
+        this.element.find('span#autosave_status').text(msg);
     }
 
     SaveWidget.prototype.set_checkpoint_status = function (msg) {
-        this.element.find('span#checkpoint_status').html(msg);
+        this.element.find('span#checkpoint_status').text(msg);
     }
 
     SaveWidget.prototype.set_last_checkpoint = function (checkpoint) {

--- a/IPython/html/static/tree/js/clusterlist.js
+++ b/IPython/html/static/tree/js/clusterlist.js
@@ -101,7 +101,7 @@ var IPython = (function (IPython) {
     ClusterItem.prototype.state_stopped = function () {
         var that = this;
         var profile_col = $('<span/>').addClass('profile_col span4').text(this.data.profile);
-        var status_col = $('<span/>').addClass('status_col span3').html('stopped');
+        var status_col = $('<span/>').addClass('status_col span3').text('stopped');
         var engines_col = $('<span/>').addClass('engine_col span3');
         var input = $('<input/>').attr('type','number')
                 .attr('min',1)
@@ -122,7 +122,7 @@ var IPython = (function (IPython) {
         start_button.click(function (e) {
             var n = that.element.find('.engine_num_input').val();
             if (!/^\d+$/.test(n) && n.length>0) {
-                status_col.html('invalid engine #');
+                status_col.text('invalid engine #');
             } else {
                 var settings = {
                     cache : false,
@@ -133,10 +133,10 @@ var IPython = (function (IPython) {
                         that.update_state(data);
                     },
                     error : function (data, status, xhr) {
-                        status_col.html("error starting cluster");
+                        status_col.text("error starting cluster");
                     }
                 };
-                status_col.html('starting');
+                status_col.text('starting');
                 var url = utils.url_join_encode(
                     that.baseProjectUrl(),
                     'clusters',
@@ -152,8 +152,8 @@ var IPython = (function (IPython) {
     ClusterItem.prototype.state_running = function () {
         var that = this;
         var profile_col = $('<span/>').addClass('profile_col span4').text(this.data.profile);
-        var status_col = $('<span/>').addClass('status_col span3').html('running');
-        var engines_col = $('<span/>').addClass('engines_col span3').html(this.data.n);
+        var status_col = $('<span/>').addClass('status_col span3').text('running');
+        var engines_col = $('<span/>').addClass('engines_col span3').text(this.data.n);
         var stop_button = $('<button/>').addClass("btn btn-mini").text("Stop");
         var action_col = $('<span/>').addClass('action_col span2').append(
             $("<span/>").addClass("item_buttons btn-group").append(
@@ -175,10 +175,10 @@ var IPython = (function (IPython) {
                 },
                 error : function (data, status, xhr) {
                     console.log('error',data);
-                    status_col.html("error stopping cluster");
+                    status_col.text("error stopping cluster");
                 }
             };
-            status_col.html('stopping');
+            status_col.text('stopping');
             var url = utils.url_join_encode(
                 that.baseProjectUrl(),
                 'clusters',

--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -263,7 +263,7 @@ var IPython = (function (IPython) {
                 return false;
             });
         // var new_buttons = item.find('a'); // shutdown_button;
-        item.find(".item_buttons").html("").append(shutdown_button);
+        item.find(".item_buttons").text("").append(shutdown_button);
     };
 
     NotebookList.prototype.add_delete_button = function (item) {
@@ -308,7 +308,7 @@ var IPython = (function (IPython) {
                 });
                 return false;
             });
-        item.find(".item_buttons").html("").append(delete_button);
+        item.find(".item_buttons").text("").append(delete_button);
     };
 
 

--- a/IPython/html/tests/casperjs/test_cases/inject_js.js
+++ b/IPython/html/tests/casperjs/test_cases/inject_js.js
@@ -1,0 +1,23 @@
+//
+// Test robustness about JS injection in different place
+//
+// This assume malicious document arrive to the frontend.
+//
+
+casper.notebook_test(function () {
+    var messages = [];
+    this.on('remote.alert', function (msg) {
+        messages.push(msg);
+    });
+    
+    this.evaluate(function () {
+        var cell = IPython.notebook.get_cell(0);
+        var json = cell.toJSON()
+        json.prompt_number = "<script> alert('hello from input prompts !')</script>"
+        cell.fromJSON(j)
+    });
+
+    this.then(function () {
+        this.test.assert(messages.length == 0, "Captured log message from script tag injection !");
+    });
+});

--- a/IPython/html/tests/casperjs/test_cases/inject_js.js
+++ b/IPython/html/tests/casperjs/test_cases/inject_js.js
@@ -12,9 +12,9 @@ casper.notebook_test(function () {
     
     this.evaluate(function () {
         var cell = IPython.notebook.get_cell(0);
-        var json = cell.toJSON()
-        json.prompt_number = "<script> alert('hello from input prompts !')</script>"
-        cell.fromJSON(j)
+        var json = cell.toJSON();
+        json.prompt_number = "<script> alert('hello from input prompts !')</script>";
+        cell.fromJSON(json);
     });
 
     this.then(function () {


### PR DESCRIPTION
Thoses that are obvious and easy to fix.

we shoudl have I think a travis test that grep for .html( and return
less than 20 lines :-)

One more fix is `html('&times')` to `html('&times;')` (add semicolon).

Havent check manually each place in UI. 
