### PR TITLE
Print sources for fget/fset/fdel property methods

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1443,10 +1443,16 @@ class InteractiveShell(SingletonConfigurable):
                 continue
             else:
                 #print 'oname_rest:', oname_rest  # dbg
-                for part in oname_rest:
+                for idx, part in enumerate(oname_rest):
                     try:
                         parent = obj
-                        obj = getattr(obj,part)
+                        # The last part is looked up in a special way to avoid
+                        # descriptor invocation as it may raise or have side
+                        # effects.
+                        if idx == len(oname_rest) - 1:
+                            obj = self._getattr_property(obj, part)
+                        else:
+                            obj = getattr(obj, part)
                     except:
                         # Blanket except b/c some badly implemented objects
                         # allow __getattr__ to raise exceptions other than
@@ -1486,33 +1492,48 @@ class InteractiveShell(SingletonConfigurable):
         return {'found':found, 'obj':obj, 'namespace':ospace,
                 'ismagic':ismagic, 'isalias':isalias, 'parent':parent}
 
-    def _ofind_property(self, oname, info):
-        """Second part of object finding, to look for property details."""
-        if info.found:
-            # Get the docstring of the class property if it exists.
-            path = oname.split('.')
-            root = '.'.join(path[:-1])
-            if info.parent is not None:
-                try:
-                    target = getattr(info.parent, '__class__')
-                    # The object belongs to a class instance.
-                    try:
-                        target = getattr(target, path[-1])
-                        # The class defines the object.
-                        if isinstance(target, property):
-                            oname = root + '.__class__.' + path[-1]
-                            info = Struct(self._ofind(oname))
-                    except AttributeError: pass
-                except AttributeError: pass
+    @staticmethod
+    def _getattr_property(obj, attrname):
+        """Property-aware getattr to use in object finding.
 
-        # We return either the new info or the unmodified input if the object
-        # hadn't been found
-        return info
+        If attrname represents a property, return it unevaluated (in case it has
+        side effects or raises an error.
+
+        """
+        if not isinstance(obj, type):
+            try:
+                # `getattr(type(obj), attrname)` is not guaranteed to return
+                # `obj`, but does so for property:
+                #
+                # property.__get__(self, None, cls) -> self
+                #
+                # The universal alternative is to traverse the mro manually
+                # searching for attrname in class dicts.
+                attr = getattr(type(obj), attrname)
+            except AttributeError:
+                pass
+            else:
+                # This relies on the fact that data descriptors (with both
+                # __get__ & __set__ magic methods) take precedence over
+                # instance-level attributes:
+                #
+                #    class A(object):
+                #        @property
+                #        def foobar(self): return 123
+                #    a = A()
+                #    a.__dict__['foobar'] = 345
+                #    a.foobar  # == 123
+                #
+                # So, a property may be returned right away.
+                if isinstance(attr, property):
+                    return attr
+
+        # Nothing helped, fall back.
+        return getattr(obj, attrname)
 
     def _object_find(self, oname, namespaces=None):
         """Find an object and return a struct with info about it."""
-        inf = Struct(self._ofind(oname, namespaces))
-        return Struct(self._ofind_property(oname, inf))
+        return Struct(self._ofind(oname, namespaces))
 
     def _inspect(self, meth, oname, namespaces=None, **kw):
         """Generic interface to the inspector system.

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -45,8 +45,8 @@ from IPython.utils.py3compat import cast_unicode, string_types, PY3
 _func_call_docstring = types.FunctionType.__call__.__doc__
 _object_init_docstring = object.__init__.__doc__
 _builtin_type_docstrings = {
-    t.__doc__ for t in (types.ModuleType, types.MethodType, types.FunctionType,
-                        property)
+    inspect.getdoc(t) for t in (types.ModuleType, types.MethodType,
+                                types.FunctionType, property)
 }
 
 _builtin_func_type = type(all)

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -18,6 +18,7 @@ __all__ = ['Inspector','InspectColors']
 import inspect
 import linecache
 import os
+from textwrap import dedent
 import types
 import io as stdlib_io
 
@@ -28,6 +29,7 @@ except ImportError:
 
 # IPython's own
 from IPython.core import page
+from IPython.lib.pretty import pretty
 from IPython.testing.skipdoctest import skip_doctest_py3
 from IPython.utils import PyColorize
 from IPython.utils import io
@@ -43,7 +45,8 @@ from IPython.utils.py3compat import cast_unicode, string_types, PY3
 _func_call_docstring = types.FunctionType.__call__.__doc__
 _object_init_docstring = object.__init__.__doc__
 _builtin_type_docstrings = {
-    t.__doc__ for t in (types.ModuleType, types.MethodType, types.FunctionType)
+    t.__doc__ for t in (types.ModuleType, types.MethodType, types.FunctionType,
+                        property)
 }
 
 _builtin_func_type = type(all)
@@ -150,33 +153,68 @@ def getdoc(obj):
         return None
 
 
-def getsource(obj,is_binary=False):
+def getsource(obj, oname=''):
     """Wrapper around inspect.getsource.
 
     This can be modified by other projects to provide customized source
     extraction.
 
-    Inputs:
+    Parameters
+    ----------
+    obj : object
+        an object whose source code we will attempt to extract
+    oname : str
+        (optional) a name under which the object is known
 
-    - obj: an object whose source code we will attempt to extract.
+    Returns
+    -------
+    src : unicode or None
 
-    Optional inputs:
+    """
 
-    - is_binary: whether the object is known to come from a binary source.
-      This implementation will skip returning any output for binary objects, but
-      custom extractors may know how to meaningfully process them."""
+    if isinstance(obj, property):
+        sources = []
+        for attrname in ['fget', 'fset', 'fdel']:
+            fn = getattr(obj, attrname)
+            if fn is not None:
+                encoding = get_encoding(fn)
+                oname_prefix = ('%s.' % oname) if oname else ''
+                sources.append(cast_unicode(
+                    ''.join(('# ', oname_prefix, attrname)),
+                    encoding=encoding))
+                if inspect.isfunction(fn):
+                    sources.append(dedent(getsource(fn)))
+                else:
+                    # Default str/repr only prints function name,
+                    # pretty.pretty prints module name too.
+                    sources.append(cast_unicode(
+                        '%s%s = %s\n' % (
+                            oname_prefix, attrname, pretty(fn)),
+                        encoding=encoding))
+        if sources:
+            return '\n'.join(sources)
+        else:
+            return None
 
-    if is_binary:
-        return None
     else:
-        # get source if obj was decorated with @decorator
-        if hasattr(obj,"__wrapped__"):
+        # Get source for non-property objects.
+
+        # '__wrapped__' attribute is used by some decorators (e.g. ones defined
+        # functools) to provide access to the decorated function.
+        if hasattr(obj, "__wrapped__"):
             obj = obj.__wrapped__
+
         try:
             src = inspect.getsource(obj)
         except TypeError:
-            if hasattr(obj,'__class__'):
-                src = inspect.getsource(obj.__class__)
+            # The object itself provided no meaningful source, try looking for
+            # its class definition instead.
+            if hasattr(obj, '__class__'):
+                try:
+                    src = inspect.getsource(obj.__class__)
+                except TypeError:
+                    return None
+
         encoding = get_encoding(obj)
         return cast_unicode(src, encoding=encoding)
 
@@ -457,15 +495,18 @@ class Inspector:
         else:
             page.page('\n'.join(lines))
 
-    def psource(self,obj,oname=''):
+    def psource(self, obj, oname=''):
         """Print the source code for an object."""
 
         # Flush the source cache because inspect can return out-of-date source
         linecache.checkcache()
         try:
-            src = getsource(obj)
-        except:
-            self.noinfo('source',oname)
+            src = getsource(obj, oname=oname)
+        except Exception:
+            src = None
+
+        if src is None:
+            self.noinfo('source', oname)
         else:
             page.page(self.format(src))
 
@@ -696,32 +737,25 @@ class Inspector:
             elif fname.endswith('<string>'):
                 fname = 'Dynamically generated function. No source code available.'
             out['file'] = fname
-        
-        # Docstrings only in detail 0 mode, since source contains them (we
-        # avoid repetitions).  If source fails, we add them back, see below.
-        if ds and detail_level == 0:
-                out['docstring'] = ds
 
-        # Original source code for any callable
+        # Original source code for a callable, class or property.
         if detail_level:
             # Flush the source cache because inspect can return out-of-date
             # source
             linecache.checkcache()
-            source = None
             try:
-                try:
-                    source = getsource(obj, binary_file)
-                except TypeError:
-                    if hasattr(obj, '__class__'):
-                        source = getsource(obj.__class__, binary_file)
-                if source is not None:
-                    out['source'] = source.rstrip()
+                if isinstance(obj, property) or not binary_file:
+                    src = getsource(obj, oname)
+                    if src is not None:
+                        src = src.rstrip()
+                    out['source'] = src
+
             except Exception:
                 pass
 
-            if ds and source is None:
-                out['docstring'] = ds
-
+        # Add docstring only if no source is to be shown (avoid repetitions).
+        if ds and out.get('source', None) is None:
+            out['docstring'] = ds
 
         # Constructor docstring for classes
         if inspect.isclass(obj):
@@ -823,7 +857,6 @@ class Inspector:
                     argspec_dict['varkw'] = argspec_dict.pop('keywords')
 
         return object_info(**out)
-
 
     def psearch(self,pattern,ns_table,ns_search=[],
                 ignore_case=False,show_all=False):

--- a/docs/source/whatsnew/pr/incompat-oinspect-getsource.rst
+++ b/docs/source/whatsnew/pr/incompat-oinspect-getsource.rst
@@ -1,0 +1,5 @@
+* :func:`IPython.core.oinspect.getsource` call specification has changed:
+
+  * `oname` keyword argument has been added for property source formatting
+  * `is_binary` keyword argument has been dropped, passing ``True`` had
+    previously short-circuited the function to return ``None`` unconditionally


### PR DESCRIPTION
This is a work-in-progress fixing issue #1555 which has been bugging me for quite a while. Here's what it is capable of now:

``` python

In [1]: def foo(x): return id(x)

In [2]: p = property(foo, lambda x,val: None, id)

In [3]: p?
Type:       property
String Form:<property object at 0x2c52c00>
File:       /home/immerrr/sources/<ipython-input-1-8d2e34e1a2b1>
Docstring:  <no docstring>

In [4]: p??
Type:       property
String Form:<property object at 0x2c52c00>
File:       /home/immerrr/sources/<ipython-input-1-8d2e34e1a2b1>
Getter:     def foo(x): return id(x)

Setter:     p = property(foo, lambda x,val: None, id)

Deleter:    <function id>

In [5]: class Foo(object):
   ...:     @property
   ...:     def bar(self):
   ...:         return None
   ...:     

In [6]: f = Foo()

In [7]: f.bar?
Type:       property
String Form:<property object at 0x2f84aa0>
File:       /home/immerrr/sources/<ipython-input-5-64d3245b5460>
Docstring:  <no docstring>

In [8]: f.bar??
Type:       property
String Form:<property object at 0x2f84aa0>
File:       /home/immerrr/sources/<ipython-input-5-64d3245b5460>
Getter:
    @property
    def bar(self):
        return None

```

Admittedly, this is not perfect, so ideas about what's missing are welcome. What I think is missing:
- [x] tests (didn't look how testing is done in IPython, nor do I have an idea how to test this properly)
- [x] get rid of newlines that still appear after one-liner source snippets
- [x] stop invoking property getter when querying as it may cause unintended side-effects and/or raise an error rendering the property inaccessible 
