### PR TITLE
changes for ironpython (notebook)

### DIFF
--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -209,11 +209,12 @@ class ScriptMagics(Magics):
             out, err = p.communicate(cell)
         except KeyboardInterrupt:
             try:
-                p.send_signal(signal.SIGINT)
-                time.sleep(0.1)
-                if p.poll() is not None:
-                    print("Process is interrupted.")
-                    return
+                if sys.platform != 'cli':
+                    p.send_signal(signal.SIGINT)
+                    time.sleep(0.1)
+                    if p.poll() is not None:
+                        print("Process is interrupted.")
+                        return
                 p.terminate()
                 time.sleep(0.1)
                 if p.poll() is not None:

--- a/IPython/core/prompts.py
+++ b/IPython/core/prompts.py
@@ -134,8 +134,10 @@ def multiple_replace(dict, text):
 
 # - I also need to split up the color schemes from the prompt specials
 # somehow.  I don't have a clean design for that quite yet.
-
-HOME = py3compat.str_to_unicode(os.environ.get("HOME","//////:::::ZZZZZ,,,~~~"))
+if sys.platform != 'cli':
+    HOME = py3compat.str_to_unicode(os.environ.get("HOME", "//////:::::ZZZZZ,,,~~~"))
+else:
+    HOME = py3compat.str_to_unicode(os.environ.get("HOME", ",://////ZZZZZ,,,~~~"))
 
 # This is needed on FreeBSD, and maybe other systems which symlink /home to
 # /usr/home, but retain the $HOME variable as pointing to /home

--- a/IPython/external/pexpect/__init__.py
+++ b/IPython/external/pexpect/__init__.py
@@ -1,5 +1,8 @@
-try:
-    import pexpect
-    from pexpect import *
-except ImportError:
-    from ._pexpect import *
+import sys
+if sys.platform != 'cli':
+    try:
+        import pexpect
+        from pexpect import *
+    except ImportError:
+        from ._pexpect import *
+del sys

--- a/IPython/external/pexpect/__init__.py
+++ b/IPython/external/pexpect/__init__.py
@@ -1,8 +1,5 @@
-import sys
-if sys.platform != 'cli':
-    try:
-        import pexpect
-        from pexpect import *
-    except ImportError:
-        from ._pexpect import *
-del sys
+try:
+    import pexpect
+    from pexpect import *
+except ImportError:
+    from ._pexpect import *

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -365,7 +365,7 @@ class NotebookApp(BaseIPythonApplication):
         """
     )
     def _cookie_secret_default(self):
-        return os.urandom(1024)
+        return py3compat.str_to_bytes(os.urandom(1024))
 
     password = Unicode(u'', config=True,
                       help="""Hashed password to use for web authentication.
@@ -680,15 +680,31 @@ class NotebookApp(BaseIPythonApplication):
         print(self.notebook_info())
         sys.stdout.write("Shutdown this notebook server (y/[n])? ")
         sys.stdout.flush()
-        r,w,x = select.select([sys.stdin], [], [], 5)
-        if r:
-            line = sys.stdin.readline()
-            if line.lower().startswith('y'):
-                self.log.critical("Shutdown confirmed")
-                ioloop.IOLoop.instance().stop()
-                return
+        if sys.platform != 'cli': # win32?
+            r,w,x = select.select([sys.stdin], [], [], 5)
+            if r:
+                line = sys.stdin.readline()
+                if line.lower().startswith('y'):
+                    self.log.critical("Shutdown confirmed")
+                    ioloop.IOLoop.instance().stop()
+                    return
+            else:
+                print("No answer for 5s:", end=' ')
         else:
-            print("No answer for 5s:", end=' ')
+            import msvcrt
+            startTime = time.time()
+            while True:
+                if msvcrt.kbhit():
+                    if msvcrt.getch().lower() == 'y':
+                        self.log.critical("Shutdown confirmed")
+                        ioloop.IOLoop.instance().stop()
+                        return
+                    break # any other key
+                elif time.time() - startTime > 5:
+                    print("No answer for 5s:", end=' ')
+                    break
+                time.sleep(0.1)
+
         print("resuming operation...")
         # no answer, or answer is no:
         # set it back to original SIGINT handler

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -365,7 +365,7 @@ class NotebookApp(BaseIPythonApplication):
         """
     )
     def _cookie_secret_default(self):
-        return py3compat.str_to_bytes(os.urandom(1024))
+        return py3compat.cast_bytes_py2(os.urandom(1024))
 
     password = Unicode(u'', config=True,
                       help="""Hashed password to use for web authentication.

--- a/IPython/kernel/launcher.py
+++ b/IPython/kernel/launcher.py
@@ -190,7 +190,7 @@ def launch_kernel(cmd, stdin=None, stdout=None, stderr=None,
         _stdout, _stderr = stdout, stderr
 
     # Spawn a kernel.
-    if sys.platform == 'win32' or sys.platform == 'cli':
+    if sys.platform == 'win32' or sys.platform == 'cli': # windows or ironpython
         
         if cwd and sys.platform == 'win32':
             # Popen on Python 2 on Windows cannot handle unicode cwd.
@@ -214,6 +214,7 @@ def launch_kernel(cmd, stdin=None, stdout=None, stderr=None,
                 if stderr is None:
                     cmd.append('--no-stderr')
 
+        # enable Ironpython support for sys._getframe
         if sys.platform == 'cli':
             cmd.insert(1, '-X:Frames')
 
@@ -241,15 +242,13 @@ def launch_kernel(cmd, stdin=None, stdout=None, stderr=None,
         # Attach the interrupt event to the Popen objet so it can be used later.
         proc.win32_interrupt_event = interrupt_event
 
-    else:
+    else: # posix
         if independent:
             proc = Popen(cmd, preexec_fn=lambda: os.setsid(),
                          stdin=_stdin, stdout=_stdout, stderr=_stderr, cwd=cwd, env=os.environ)
         else:
             if ipython_kernel:
                 cmd += ['--parent=1']
-            if sys.platform == 'cli':
-                cmd.insert(1, '-X:Frames')
             proc = Popen(cmd,
                          stdin=_stdin, stdout=_stdout, stderr=_stderr, cwd=cwd, env=os.environ)
 

--- a/IPython/kernel/launcher.py
+++ b/IPython/kernel/launcher.py
@@ -190,9 +190,9 @@ def launch_kernel(cmd, stdin=None, stdout=None, stderr=None,
         _stdout, _stderr = stdout, stderr
 
     # Spawn a kernel.
-    if sys.platform == 'win32':
+    if sys.platform == 'win32' or sys.platform == 'cli':
         
-        if cwd:
+        if cwd and sys.platform == 'win32':
             # Popen on Python 2 on Windows cannot handle unicode cwd.
             cwd = cast_bytes_py2(cwd, sys.getfilesystemencoding() or 'ascii')
         
@@ -214,6 +214,9 @@ def launch_kernel(cmd, stdin=None, stdout=None, stderr=None,
                 if stderr is None:
                     cmd.append('--no-stderr')
 
+        if sys.platform == 'cli':
+            cmd.insert(1, '-X:Frames')
+
         # Launch the kernel process.
         if independent:
             proc = Popen(cmd,
@@ -232,8 +235,6 @@ def launch_kernel(cmd, stdin=None, stdout=None, stderr=None,
                                          True, # Inheritable by new processes.
                                          DUPLICATE_SAME_ACCESS)
                 cmd +=[ '--parent=%i' % handle ]
-            
-            
             proc = Popen(cmd,
                          stdin=_stdin, stdout=_stdout, stderr=_stderr, cwd=cwd, env=os.environ)
 
@@ -247,6 +248,8 @@ def launch_kernel(cmd, stdin=None, stdout=None, stderr=None,
         else:
             if ipython_kernel:
                 cmd += ['--parent=1']
+            if sys.platform == 'cli':
+                cmd.insert(1, '-X:Frames')
             proc = Popen(cmd,
                          stdin=_stdin, stdout=_stdout, stderr=_stderr, cwd=cwd, env=os.environ)
 

--- a/IPython/kernel/manager.py
+++ b/IPython/kernel/manager.py
@@ -346,7 +346,7 @@ class KernelManager(LoggingConfigurable, ConnectionFileMixin):
         platforms.
         """
         if self.has_kernel:
-            if sys.platform == 'win32':
+            if sys.platform == 'win32' or sys.platform == 'cli':
                 from .zmq.parentpoller import ParentPollerWindows as Poller
                 Poller.send_interrupt(self.kernel.win32_interrupt_event)
             else:

--- a/IPython/kernel/zmq/iostream.py
+++ b/IPython/kernel/zmq/iostream.py
@@ -12,8 +12,13 @@ import os
 import threading
 import time
 import uuid
-from io import StringIO, UnsupportedOperation
-
+from io import UnsupportedOperation
+import sys
+if sys.platform != 'cli':
+    from io import StringIO
+else:
+    # io.StringIO is broken in ironpython
+    from StringIO import StringIO
 import zmq
 
 from .session import extract_header

--- a/IPython/kernel/zmq/iostream.py
+++ b/IPython/kernel/zmq/iostream.py
@@ -18,6 +18,7 @@ if sys.platform != 'cli':
     from io import StringIO
 else:
     # io.StringIO is broken in ironpython
+    # https://ironpython.codeplex.com/workitem/34713
     from StringIO import StringIO
 import zmq
 

--- a/IPython/kernel/zmq/kernelapp.py
+++ b/IPython/kernel/zmq/kernelapp.py
@@ -202,7 +202,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp):
                                      ostream=sys.__stdout__)
 
     def init_poller(self):
-        if sys.platform == 'win32':
+        if sys.platform == 'win32' or sys.platform == 'cli':
             if self.interrupt or self.parent_handle:
                 self.poller = ParentPollerWindows(self.interrupt, self.parent_handle)
         elif self.parent_handle:

--- a/IPython/kernel/zmq/kernelapp.py
+++ b/IPython/kernel/zmq/kernelapp.py
@@ -74,7 +74,7 @@ kernel_aliases.update({
     'parent': 'IPKernelApp.parent_handle',
     'transport': 'IPKernelApp.transport',
 })
-if sys.platform.startswith('win'):
+if sys.platform.startswith('win') or sys.platform == 'cli':
     kernel_aliases['interrupt'] = 'IPKernelApp.interrupt'
 
 kernel_flags = dict(base_flags)

--- a/IPython/kernel/zmq/parentpoller.py
+++ b/IPython/kernel/zmq/parentpoller.py
@@ -66,6 +66,11 @@ class ParentPollerWindows(Thread):
         self.interrupt_handle = interrupt_handle
         self.parent_handle = parent_handle
 
+    class SECURITY_ATTRIBUTES(ctypes.Structure):
+        _fields_ = [ ("nLength", ctypes.c_int),
+                     ("lpSecurityDescriptor", ctypes.c_void_p),
+                     ("bInheritHandle", ctypes.c_int) ]
+
     @staticmethod
     def create_interrupt_event():
         """ Create an interrupt event handle.
@@ -78,13 +83,9 @@ class ParentPollerWindows(Thread):
         # Create a security attributes struct that permits inheritance of the
         # handle by new processes.
         # FIXME: We can clean up this mess by requiring pywin32 for IPython.
-        class SECURITY_ATTRIBUTES(ctypes.Structure):
-            _fields_ = [ ("nLength", ctypes.c_int),
-                         ("lpSecurityDescriptor", ctypes.c_void_p),
-                         ("bInheritHandle", ctypes.c_int) ]
-        sa = SECURITY_ATTRIBUTES()
+        sa = ParentPollerWindows.SECURITY_ATTRIBUTES()
         sa_p = ctypes.pointer(sa)
-        sa.nLength = ctypes.sizeof(SECURITY_ATTRIBUTES)
+        sa.nLength = ctypes.sizeof(ParentPollerWindows.SECURITY_ATTRIBUTES)
         sa.lpSecurityDescriptor = 0
         sa.bInheritHandle = 1
 

--- a/IPython/kernel/zmq/parentpoller.py
+++ b/IPython/kernel/zmq/parentpoller.py
@@ -67,6 +67,8 @@ class ParentPollerWindows(Thread):
         self.parent_handle = parent_handle
 
     class SECURITY_ATTRIBUTES(ctypes.Structure):
+    # moved out of create_interrupt_event due to a bug in ironpython implementation
+    # of ctypes: https://ironpython.codeplex.com/workitem/34839
         _fields_ = [ ("nLength", ctypes.c_int),
                      ("lpSecurityDescriptor", ctypes.c_void_p),
                      ("bInheritHandle", ctypes.c_int) ]

--- a/IPython/kernel/zmq/tests/test_embed_kernel.py
+++ b/IPython/kernel/zmq/tests/test_embed_kernel.py
@@ -69,6 +69,7 @@ def setup_kernel(cmd):
     """
     args = [sys.executable, '-c', cmd]
     if sys.platform == 'cli':
+        # enable support for sys._getframe in ironpython
         args.insert(1, '-X:Frames')
     kernel = Popen(args, stdout=PIPE, stderr=PIPE, env=env)
     connection_file = os.path.join(IPYTHONDIR,

--- a/IPython/parallel/util.py
+++ b/IPython/parallel/util.py
@@ -225,6 +225,8 @@ def interactive(f):
     # build new FunctionType, so it can have the right globals
     # interactive functions never have closures, that's kind of the point
     if sys.platform != 'cli':
+        # ipython does not implement FunctionType.__new__
+        # https://ironpython.codeplex.com/workitem/34932
         if isinstance(f, FunctionType):
             mainmod = __import__('__main__')
             f = FunctionType(f.__code__, mainmod.__dict__,

--- a/IPython/parallel/util.py
+++ b/IPython/parallel/util.py
@@ -222,14 +222,14 @@ def interactive(f):
     This results in the function being linked to the user_ns as globals()
     instead of the module globals().
     """
-    
     # build new FunctionType, so it can have the right globals
     # interactive functions never have closures, that's kind of the point
-    if isinstance(f, FunctionType):
-        mainmod = __import__('__main__')
-        f = FunctionType(f.__code__, mainmod.__dict__,
-            f.__name__, f.__defaults__,
-        )
+    if sys.platform != 'cli':
+        if isinstance(f, FunctionType):
+            mainmod = __import__('__main__')
+            f = FunctionType(f.__code__, mainmod.__dict__,
+                f.__name__, f.__defaults__,
+            )
     # associate with __main__ for uncanning
     f.__module__ = '__main__'
     return f

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -27,6 +27,8 @@ from contextlib import contextmanager
 if sys.platform != 'cli':
     from io import StringIO
 else:
+    # io.StringIO is broken in ironpython
+    # https://ironpython.codeplex.com/workitem/34713
     from StringIO import StringIO
 from subprocess import Popen, PIPE
 

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -24,7 +24,10 @@ import sys
 import tempfile
 
 from contextlib import contextmanager
-from io import StringIO
+if sys.platform != 'cli':
+    from io import StringIO
+else:
+    from StringIO import StringIO
 from subprocess import Popen, PIPE
 
 try:

--- a/IPython/utils/_process_common.py
+++ b/IPython/utils/_process_common.py
@@ -68,7 +68,7 @@ def process_handler(cmd, callback, stderr=subprocess.PIPE):
     sys.stdout.flush()
     sys.stderr.flush()
     # On win32, close_fds can't be true when using pipes for stdin/out/err
-    close_fds = sys.platform != 'win32'
+    close_fds = sys.platform != 'win32' and sys.platform != 'cli'
     p = subprocess.Popen(cmd, shell=isinstance(cmd, py3compat.string_types),
                          stdin=subprocess.PIPE,
                          stdout=subprocess.PIPE,

--- a/IPython/utils/process.py
+++ b/IPython/utils/process.py
@@ -21,7 +21,7 @@ import sys
 import shlex
 
 # Our own
-if sys.platform == 'win32':
+if sys.platform == 'win32' or sys.platform == 'cli':
     from ._process_win32 import _find_cmd, system, getoutput, AvoidUNCPath, arg_split
 else:
     from ._process_posix import _find_cmd, system, getoutput, arg_split
@@ -109,7 +109,7 @@ def abbrev_cwd():
     cwd = py3compat.getcwd().replace('\\','/')
     drivepart = ''
     tail = cwd
-    if sys.platform == 'win32':
+    if sys.platform == 'win32' or sys.platform == 'cli':
         if len(cwd) < 4:
             return cwd
         drivepart,tail = os.path.splitdrive(cwd)

--- a/IPython/utils/py3compat.py
+++ b/IPython/utils/py3compat.py
@@ -29,7 +29,11 @@ def cast_unicode(s, encoding=None):
 
 def cast_bytes(s, encoding=None):
     if not isinstance(s, bytes):
-        return encode(s, encoding)
+        if sys.platform != 'cli':
+            return encode(s, encoding)
+        else:
+            # repackage into bytes
+            return bytes(encode(s, encoding), 'iso-8859-1')
     return s
 
 def _modify_str_or_docstring(str_change_func):
@@ -87,7 +91,7 @@ if sys.version_info[0] >= 3:
     
     string_types = (str,)
     unicode_type = str
-    
+
     def isidentifier(s, dotted=False):
         if dotted:
             return all(isidentifier(a) for a in s.split("."))
@@ -144,6 +148,10 @@ else:
     
     string_types = (str, unicode)
     unicode_type = unicode
+    # IronPython 2.x has str/byte/unicode like 3.x but stdlib 2.x
+    if sys.platform == 'cli':
+        bytes_to_str = decode
+        str_to_bytes = lambda s: bytes(s, "iso-8859-1") # assume it is bytes in str and not unicode
     
     import re
     _name_re = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*$")


### PR DESCRIPTION
- the undefined $HOME 'absurd' string is tolerable by os.path.abspath
- prevent from importing not supported modules - pyexpect, io
- spawning child python process includes extra parameter -X:Frames
- aligned execution path with windows cpython
- bytes_to_str, str_to_bytes and cast_bytes have ironpython specific
  version
- added windows specific version for 'confirm exit'
- stubbed out not supported FunctionType ctor

Note: In order to get ipython notepad to work under ironpython, in addition to this PR, modified versions of the following are required:
- pyzmq (alrady PR)
- tornado
- Ironpython
