### PR TITLE
avoid import of nearby temporary with %edit

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -572,6 +572,7 @@ class InteractiveShell(SingletonConfigurable):
 
         # Temporary files used for various purposes.  Deleted at exit.
         self.tempfiles = []
+        self.tempdirs = []
 
         # Keep track of readline usage (later set by init_readline)
         self.has_readline = False
@@ -3003,15 +3004,19 @@ class InteractiveShell(SingletonConfigurable):
     def mktempfile(self, data=None, prefix='ipython_edit_'):
         """Make a new tempfile and return its filename.
 
-        This makes a call to tempfile.mktemp, but it registers the created
-        filename internally so ipython cleans it up at exit time.
+        This makes a call to tempfile.mkstemp (created in a tempfile.mkdtemp),
+        but it registers the created filename internally so ipython cleans it up
+        at exit time.
 
         Optional inputs:
 
           - data(None): if data is given, it gets written out to the temp file
             immediately, and the file is closed again."""
 
-        filename = tempfile.mktemp('.py', prefix)
+        dirname = tempfile.mkdtemp(prefix=prefix)
+        self.tempdirs.append(dirname)
+
+        handle, filename = tempfile.mkstemp('.py', prefix, dir=dirname)
         self.tempfiles.append(filename)
 
         if data:
@@ -3164,10 +3169,16 @@ class InteractiveShell(SingletonConfigurable):
         # history db
         self.history_manager.end_session()
 
-        # Cleanup all tempfiles left around
+        # Cleanup all tempfiles and folders left around
         for tfile in self.tempfiles:
             try:
                 os.unlink(tfile)
+            except OSError:
+                pass
+
+        for tdir in self.tempdirs:
+            try:
+                os.rmdir(tdir)
             except OSError:
                 pass
 


### PR DESCRIPTION
use mk**s**temp now,
and create files in subfolders.

should close gh-4731

Note that some part of the logic could now use
http://docs.python.org/2/library/tempfile.html#tempfile.NamedTemporaryFile
That will be deleted on close and avoid IPython to track it.
