### PR TITLE
fix tooltip token regex for single-character names

### DIFF
--- a/IPython/html/static/notebook/js/tooltip.js
+++ b/IPython/html/static/notebook/js/tooltip.js
@@ -197,7 +197,7 @@ var IPython = (function (IPython) {
     }
 
     // easy access for julia monkey patching.
-    Tooltip.last_token_re = /[a-z_][0-9a-z._]+$/gi;
+    Tooltip.last_token_re = /[a-z_][0-9a-z._]*$/gi;
 
     Tooltip.prototype.extract_oir_token = function(line){
         // use internally just to make the request to the kernel

--- a/IPython/html/tests/casperjs/test_cases/tooltip.js
+++ b/IPython/html/tests/casperjs/test_cases/tooltip.js
@@ -1,0 +1,19 @@
+//
+// Test the tooltip
+//
+casper.notebook_test(function () {
+    var token = this.evaluate(function() {
+        return IPython.tooltip.extract_oir_token("C(");
+    });
+    this.test.assertEquals(token, ["C"], "tooltip token: C");
+
+    token = this.evaluate(function() {
+        return IPython.tooltip.extract_oir_token("MyClass(");
+    });
+    this.test.assertEquals(token, ["MyClass"], "tooltip token: MyClass");
+
+    token = this.evaluate(function() {
+        return IPython.tooltip.extract_oir_token("foo123(");
+    });
+    this.test.assertEquals(token, ["foo123"], "tooltip token: foo123");
+});


### PR DESCRIPTION
closes #4808
