### PR TITLE
fix tb_offset when running a file

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2533,7 +2533,8 @@ class InteractiveShell(SingletonConfigurable):
             except:
                 if kw['raise_exceptions']:
                     raise
-                self.showtraceback()
+                # tb offset is 2 because we wrap execfile
+                self.showtraceback(tb_offset=2)
 
     def safe_execfile_ipy(self, fname):
         """Like safe_execfile, but for .ipy or .ipynb files with IPython syntax.

--- a/IPython/utils/py3compat.py
+++ b/IPython/utils/py3compat.py
@@ -181,9 +181,6 @@ else:
     def MethodType(func, instance):
         return types.MethodType(func, instance, type(instance))
     
-    # don't override system execfile on 2.x:
-    execfile = execfile
-    
     def doctest_refactor_print(func_or_str):
         return func_or_str
 


### PR DESCRIPTION
either with %run or via `ipython script.py`

since we wrap execfile, the tb_offset needs to be 2 instead of the default (1).

closes #4835
