### PR TITLE
`build` listed twice in .gitignore. Removing one.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ docs/gh-pages
 IPython/html/notebook/static/mathjax
 *.py[co]
 __pycache__
-build
 *.egg-info
 *~
 *.bak


### PR DESCRIPTION
`build` was listed twice in `.gitignore`. Removed one instance.
