### PR TITLE
use 'combine' option to ucs package

### DIFF
--- a/IPython/nbconvert/templates/latex/base.tplx
+++ b/IPython/nbconvert/templates/latex/base.tplx
@@ -20,7 +20,7 @@ This template does not define a docclass, the inheriting class must define this.
     \usepackage{geometry} % Used to adjust the document margins
     \usepackage{amsmath} % Equations
     \usepackage{amssymb} % Equations
-    \usepackage[mathletters]{ucs} % Extended unicode (utf-8) support
+    \usepackage[mathletters,combine]{ucs} % Extended unicode (utf-8) support
     \usepackage[utf8x]{inputenc} % Allow utf-8 characters in the tex document
     \usepackage{fancyvrb} % verbatim replacement that allows latex
     \usepackage{grffile} % extends the file name processing of package graphics 

--- a/IPython/nbconvert/tests/test_nbconvertapp.py
+++ b/IPython/nbconvert/tests/test_nbconvertapp.py
@@ -195,7 +195,7 @@ class TestNbConvertApp(TestsBase):
     
     @dec.onlyif_cmds_exist('pdflatex')
     @dec.onlyif_cmds_exist('pandoc')
-    def test_filename_spaces(self):
+    def test_filename_accent(self):
         """
         Generate PDFs if notebooks have an accent in their name?
         """


### PR DESCRIPTION
in latex export.

As requested by pdflatex error output in test_filename_accent.

I don't actually know what this does, but it fixes failing tests.
