### PR TITLE
Add a convenience class to sync traitlet attributes

### DIFF
--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -32,7 +32,7 @@ from IPython.utils.traitlets import (
     HasTraits, MetaHasTraits, TraitType, Any, CBytes, Dict,
     Int, Long, Integer, Float, Complex, Bytes, Unicode, TraitError,
     Undefined, Type, This, Instance, TCPAddress, List, Tuple,
-    ObjectName, DottedObjectName, CRegExp, Connect
+    ObjectName, DottedObjectName, CRegExp, bind
 )
 from IPython.utils import py3compat
 from IPython.testing.decorators import skipif
@@ -974,9 +974,9 @@ def test_dict_assignment():
     nt.assert_equal(d, c.value)
     nt.assert_true(c.value is d)
 
-class TestConnect(TestCase):
+class TestBind(TestCase):
     def test_connect_same(self):
-        """Verify two traitlets of the same type can be bound together using Connect"""
+        """Verify two traitlets of the same type can be bound together using bind."""
 
         # Create two simple classes with Int traitlets.
         class A(HasTraits):
@@ -985,17 +985,17 @@ class TestConnect(TestCase):
         b = A(value=8)
 
         # Conenct the two classes.
-        c = Connect((a, 'value'), (b, 'value'))
+        c = bind((a, 'value'), (b, 'value'))
 
-        # Make sure the values are the same at the point of connection.
+        # Make sure the values are the same at the point of binding.
         self.assertEqual(a.value, b.value)
 
         # Change one of the values to make sure they stay in sync.
         a.value = 5
         self.assertEqual(a.value, b.value)
 
-    def test_connect_different(self):
-        """Verify two traitlets of different types can be bound together using Connect"""
+    def test_bind_different(self):
+        """Verify two traitlets of different types can be bound together using bind."""
 
         # Create two simple classes with Int traitlets.
         class A(HasTraits):
@@ -1006,17 +1006,17 @@ class TestConnect(TestCase):
         b = B(count=8)
 
         # Conenct the two classes.
-        c = Connect((a, 'value'), (b, 'count'))
+        c = bind((a, 'value'), (b, 'count'))
 
-        # Make sure the values are the same at the point of connection.
+        # Make sure the values are the same at the point of binding.
         self.assertEqual(a.value, b.count)
 
         # Change one of the values to make sure they stay in sync.
         a.value = 5
         self.assertEqual(a.value, b.count)
 
-    def test_disconnect(self):
-        """Verify two connected traitlets can be disconnected"""
+    def test_unbind(self):
+        """Verify two binded traitlets can be unbinded."""
 
         # Create two simple classes with Int traitlets.
         class A(HasTraits):
@@ -1025,9 +1025,9 @@ class TestConnect(TestCase):
         b = A(value=8)
 
         # Conenct the two classes.
-        c = Connect((a, 'value'), (b, 'value'))
+        c = bind((a, 'value'), (b, 'value'))
         a.value = 4
-        c.disconnect()
+        c.unbind()
 
         # Change one of the values to make sure they stay in sync.
         a.value = 5

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -973,3 +973,61 @@ def test_dict_assignment():
     d['a'] = 5
     nt.assert_equal(d, c.value)
     nt.assert_true(c.value is d)
+
+def test_connect_same:
+    """Verify two traitlets of the same type can be bound together using Connect"""
+
+    # Create two simple classes with Int traitlets.
+    class A():
+        value = Int()
+    a = A(value=9)
+    b = A(value=8)
+
+    # Conenct the two classes.
+    c = Connect((a, 'value'), (b, 'value'))
+
+    # Make sure the values are the same at the point of connection.
+    assertEqual(a.value, b.value)
+
+    # Change one of the values to make sure they stay in sync.
+    a.value = 5
+    assertEqual(a.value, b.value)
+
+def test_connect_different:
+    """Verify two traitlets of different types can be bound together using Connect"""
+
+    # Create two simple classes with Int traitlets.
+    class A():
+        value = Int()
+    class B():
+        count = Int()
+    a = A(value=9)
+    b = B(count=8)
+
+    # Conenct the two classes.
+    c = Connect((a, 'value'), (b, 'count'))
+
+    # Make sure the values are the same at the point of connection.
+    assertEqual(a.value, b.count)
+
+    # Change one of the values to make sure they stay in sync.
+    a.value = 5
+    assertEqual(a.value, b.count)
+
+def test_disconnect:
+    """Verify two connected traitlets can be disconnected"""
+
+    # Create two simple classes with Int traitlets.
+    class A():
+        value = Int()
+    a = A(value=9)
+    b = A(value=8)
+
+    # Conenct the two classes.
+    c = Connect((a, 'value'), (b, 'value'))
+    a.value = 4
+    c.disconnect()
+
+    # Change one of the values to make sure they stay in sync.
+    a.value = 5
+    assertNotEqual(a.value, b.value)

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -32,7 +32,7 @@ from IPython.utils.traitlets import (
     HasTraits, MetaHasTraits, TraitType, Any, CBytes, Dict,
     Int, Long, Integer, Float, Complex, Bytes, Unicode, TraitError,
     Undefined, Type, This, Instance, TCPAddress, List, Tuple,
-    ObjectName, DottedObjectName, CRegExp
+    ObjectName, DottedObjectName, CRegExp, Connect
 )
 from IPython.utils import py3compat
 from IPython.testing.decorators import skipif
@@ -974,60 +974,61 @@ def test_dict_assignment():
     nt.assert_equal(d, c.value)
     nt.assert_true(c.value is d)
 
-def test_connect_same:
-    """Verify two traitlets of the same type can be bound together using Connect"""
+class TestConnect(TestCase):
+    def test_connect_same(self):
+        """Verify two traitlets of the same type can be bound together using Connect"""
 
-    # Create two simple classes with Int traitlets.
-    class A():
-        value = Int()
-    a = A(value=9)
-    b = A(value=8)
+        # Create two simple classes with Int traitlets.
+        class A(HasTraits):
+            value = Int()
+        a = A(value=9)
+        b = A(value=8)
 
-    # Conenct the two classes.
-    c = Connect((a, 'value'), (b, 'value'))
+        # Conenct the two classes.
+        c = Connect((a, 'value'), (b, 'value'))
 
-    # Make sure the values are the same at the point of connection.
-    assertEqual(a.value, b.value)
+        # Make sure the values are the same at the point of connection.
+        self.assertEqual(a.value, b.value)
 
-    # Change one of the values to make sure they stay in sync.
-    a.value = 5
-    assertEqual(a.value, b.value)
+        # Change one of the values to make sure they stay in sync.
+        a.value = 5
+        self.assertEqual(a.value, b.value)
 
-def test_connect_different:
-    """Verify two traitlets of different types can be bound together using Connect"""
+    def test_connect_different(self):
+        """Verify two traitlets of different types can be bound together using Connect"""
 
-    # Create two simple classes with Int traitlets.
-    class A():
-        value = Int()
-    class B():
-        count = Int()
-    a = A(value=9)
-    b = B(count=8)
+        # Create two simple classes with Int traitlets.
+        class A(HasTraits):
+            value = Int()
+        class B(HasTraits):
+            count = Int()
+        a = A(value=9)
+        b = B(count=8)
 
-    # Conenct the two classes.
-    c = Connect((a, 'value'), (b, 'count'))
+        # Conenct the two classes.
+        c = Connect((a, 'value'), (b, 'count'))
 
-    # Make sure the values are the same at the point of connection.
-    assertEqual(a.value, b.count)
+        # Make sure the values are the same at the point of connection.
+        self.assertEqual(a.value, b.count)
 
-    # Change one of the values to make sure they stay in sync.
-    a.value = 5
-    assertEqual(a.value, b.count)
+        # Change one of the values to make sure they stay in sync.
+        a.value = 5
+        self.assertEqual(a.value, b.count)
 
-def test_disconnect:
-    """Verify two connected traitlets can be disconnected"""
+    def test_disconnect(self):
+        """Verify two connected traitlets can be disconnected"""
 
-    # Create two simple classes with Int traitlets.
-    class A():
-        value = Int()
-    a = A(value=9)
-    b = A(value=8)
+        # Create two simple classes with Int traitlets.
+        class A(HasTraits):
+            value = Int()
+        a = A(value=9)
+        b = A(value=8)
 
-    # Conenct the two classes.
-    c = Connect((a, 'value'), (b, 'value'))
-    a.value = 4
-    c.disconnect()
+        # Conenct the two classes.
+        c = Connect((a, 'value'), (b, 'value'))
+        a.value = 4
+        c.disconnect()
 
-    # Change one of the values to make sure they stay in sync.
-    a.value = 5
-    assertNotEqual(a.value, b.value)
+        # Change one of the values to make sure they stay in sync.
+        a.value = 5
+        self.assertNotEqual(a.value, b.value)

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -197,7 +197,6 @@ class Connect(object):
     """
     updating = False
     def __init__(self, *args):
-        
         self.objects = args
         for obj,attr in args:
             obj.on_trait_change(self._update, attr)

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -184,8 +184,8 @@ def getmembers(object, predicate=None):
     return results
 
 @skip_doctest
-class Connect(object):
-    """Connect traits from different objects together so they remain in sync.
+class bind(object):
+    """Bind traits from different objects together so they remain in sync.
 
     Parameters
     ----------
@@ -194,7 +194,7 @@ class Connect(object):
     Examples
     --------
 
-    >>> c = Connect((obj1, 'value'), (obj2, 'value'), (obj3, 'value'))
+    >>> c = bind((obj1, 'value'), (obj2, 'value'), (obj3, 'value'))
     >>> obj1.value = 5 # updates other objects as well
     """
     updating = False
@@ -225,7 +225,7 @@ class Connect(object):
             for obj,attr in self.objects:
                 setattr(obj, attr, new)
     
-    def disconnect(self):
+    def unbind(self):
         for obj,attr in self.objects:
             obj.on_trait_change(self._update, attr, remove=True)
 

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -67,6 +67,7 @@ except:
 from .importstring import import_item
 from IPython.utils import py3compat
 from IPython.utils.py3compat import iteritems
+from IPython.testing.skipdoctest import skip_doctest
 
 SequenceTypes = (list, tuple, set, frozenset)
 
@@ -182,6 +183,7 @@ def getmembers(object, predicate=None):
     results.sort()
     return results
 
+@skip_doctest
 class Connect(object):
     """Connect traits from different objects together so they remain in sync.
 

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -205,8 +205,10 @@ class Connect(object):
     @contextlib.contextmanager
     def _busy_updating(self):
         self.updating = True
-        yield
-        self.updating = False
+        try:
+            yield
+        finally:
+            self.updating = False
 
     def _update(self, name, old, new):
         if self.updating:

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -199,9 +199,16 @@ class Connect(object):
     """
     updating = False
     def __init__(self, *args):
+        if len(args) < 2:
+            raise TypeError('At least two traitlets must be provided.')
+
         self.objects = args
         for obj,attr in args:
             obj.on_trait_change(self._update, attr)
+
+        # Syncronize the traitlets initially.
+        initial = getattr(args[0][0], args[0][1])
+        self._update(args[0][1], initial, initial)
 
     @contextlib.contextmanager
     def _busy_updating(self):


### PR DESCRIPTION
I'm opening this PR for @jasongrout

Basically this adds an easy way to synchronize two traitlets.
