### PR TITLE
use https for all embeds

### DIFF
--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -199,7 +199,7 @@ class IFrame(object):
 class YouTubeVideo(IFrame):
     """Class for embedding a YouTube Video in an IPython session, based on its video id.
 
-    e.g. to embed the video from http://www.youtube.com/watch?v=foo , you would
+    e.g. to embed the video from https://www.youtube.com/watch?v=foo , you would
     do::
 
         vid = YouTubeVideo("foo")
@@ -220,7 +220,7 @@ class YouTubeVideo(IFrame):
     """
 
     def __init__(self, id, width=400, height=300, **kwargs):
-        src = "http://www.youtube.com/embed/{0}".format(id)
+        src = "https://www.youtube.com/embed/{0}".format(id)
         super(YouTubeVideo, self).__init__(src, width, height, **kwargs)
 
 class VimeoVideo(IFrame):
@@ -229,7 +229,7 @@ class VimeoVideo(IFrame):
     """
 
     def __init__(self, id, width=400, height=300, **kwargs):
-        src="http://player.vimeo.com/video/{0}".format(id)
+        src="https://player.vimeo.com/video/{0}".format(id)
         super(VimeoVideo, self).__init__(src, width, height, **kwargs)
 
 class ScribdDocument(IFrame):
@@ -245,7 +245,7 @@ class ScribdDocument(IFrame):
     """
 
     def __init__(self, id, width=400, height=300, **kwargs):
-        src="http://www.scribd.com/embeds/{0}/content".format(id)
+        src="https://www.scribd.com/embeds/{0}/content".format(id)
         super(ScribdDocument, self).__init__(src, width, height, **kwargs)
 
 class FileLink(object):


### PR DESCRIPTION
YouTube, Vimeo, Scribd

I can't think of a reason not to, and http embeds won't work on https pages.
