### PR TITLE
sort dictionary keys before comparison, ordering is not guaranteed

### DIFF
--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -655,7 +655,7 @@ def test_user_expression():
     r = ip.user_expressions(query)
     import pprint
     pprint.pprint(r)
-    nt.assert_equal(r.keys(), query.keys())
+    nt.assert_equal(set(r.keys()), set(query.keys()))
     a = r['a']
     nt.assert_equal(set(['status', 'data', 'metadata']), set(a.keys()))
     nt.assert_equal(a['status'], 'ok')


### PR DESCRIPTION
failed for me on 1.x with

```
nose.proxy.AssertionError: AssertionError: Lists differ: ['a', 'b'] != ['b', 'a']
```

(2to3 wraps a list around it)
