### PR TITLE
ZMQCompleter inherits from IPCompleter

### DIFF
--- a/IPython/terminal/console/completer.py
+++ b/IPython/terminal/console/completer.py
@@ -8,9 +8,10 @@ except ImportError:
     from Queue import Empty  # Py 2
 
 from IPython.config import Configurable
+from IPython.core.completer import IPCompleter
 from IPython.utils.traitlets import Float
 
-class ZMQCompleter(Configurable):
+class ZMQCompleter(IPCompleter):
     """Client-side completion machinery.
 
     How it works: self.complete will be called multiple times, with


### PR DESCRIPTION
ensures the readline completion delimiter change implied by greedy completion is inherited by the frontend.

closes #1181
