### PR TITLE
add utils.wait_for_idle in js tests

### DIFF
--- a/IPython/html/tests/casperjs/util.js
+++ b/IPython/html/tests/casperjs/util.js
@@ -67,11 +67,9 @@ casper.delete_current_notebook = function () {
 };
 
 casper.wait_for_idle = function () {
-    this.then(function () {
-        this.waitFor(function () {
-            return this.evaluate(function () {
-                return IPython._status == 'idle';
-            });
+    this.waitFor(function () {
+        return this.evaluate(function () {
+            return IPython._status == 'idle';
         });
     });
 };


### PR DESCRIPTION
and use it in execute_cell_then, since there is not always output.

Should fix some failing js tests

_fingers crossed for Travis_

Ping @jdfreder, since I asked him to look into some of the intermittent js failures, and this might be a starting point.
