### PR TITLE
remove shift-= merge keyboard shortcut

### DIFF
--- a/IPython/html/static/notebook/js/keyboardmanager.js
+++ b/IPython/html/static/notebook/js/keyboardmanager.js
@@ -524,14 +524,6 @@ var IPython = (function (IPython) {
                 return false;
             }
         },
-        'shift+=' : {
-            help    : 'merge cell below',
-            help_index : 'ek',
-            handler : function (event) {
-                IPython.notebook.merge_cell_below();
-                return false;
-            }
-        },
         'shift+m' : {
             help    : 'merge cell below',
             help_index : 'ek',


### PR DESCRIPTION
The merge below was duplicated for two keyboard shortcuts, I assume one was meant to be merge above.

I wasn't sure if the help_index needed to change as well
