### PR TITLE
Remove mention of iplogger from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -175,10 +175,6 @@ if len(sys.argv) >= 2 and sys.argv[1] in ('sdist','bdist_rpm'):
                   ['docs/man/ipengine.1'],
                   'cd docs/man && gzip -9c ipengine.1 > ipengine.1.gz'),
 
-                 ('docs/man/iplogger.1.gz',
-                  ['docs/man/iplogger.1'],
-                  'cd docs/man && gzip -9c iplogger.1 > iplogger.1.gz'),
-
                  ('docs/man/ipython.1.gz',
                   ['docs/man/ipython.1'],
                   'cd docs/man && gzip -9c ipython.1 > ipython.1.gz'),


### PR DESCRIPTION
The iplogger entry point has been removed, but this reference to it hadn't.
