### PR TITLE
Ignore sys.argv for NotebookNotary in tests

### DIFF
--- a/IPython/nbformat/sign.py
+++ b/IPython/nbformat/sign.py
@@ -84,7 +84,7 @@ class NotebookNotary(LoggingConfigurable):
         if app is None:
             # create an app, without the global instance
             app = BaseIPythonApplication()
-            app.initialize()
+            app.initialize(argv=[])
         return app.profile_dir
     
     algorithm = Enum(algorithms, default_value='sha256', config=True,


### PR DESCRIPTION
This was causing failures on SP because BaseIPythonApplication was trying to parse nose flags like `--with-xunit`.
