### PR TITLE
make paste focus the pasted cell

### DIFF
--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1040,6 +1040,7 @@ var IPython = (function (IPython) {
             var cell_data = this.clipboard;
             var new_cell = this.insert_cell_above(cell_data.cell_type);
             new_cell.fromJSON(cell_data);
+            new_cell.focus_cell();
         };
     };
 
@@ -1053,6 +1054,7 @@ var IPython = (function (IPython) {
             var cell_data = this.clipboard;
             var new_cell = this.insert_cell_below(cell_data.cell_type);
             new_cell.fromJSON(cell_data);
+            new_cell.focus_cell();
         };
     };
 


### PR DESCRIPTION
This is to make paste behave in the same manner that insert cell above and
below currently work (inserting a new item causes that item to receive focus).

This solves a problem where, if a user pastes below a cell whose bottom edge
is below the current viewing area, they have no indication that any action has
occurred. The same applies for paste above a cell whose top edge is occluded.
