### PR TITLE
add versioning notes to small message spec changes

### DIFF
--- a/IPython/core/release.py
+++ b/IPython/core/release.py
@@ -39,7 +39,7 @@ version = __version__  # backwards compatibility name
 version_info = (_version_major, _version_minor, _version_patch, _version_extra)
 
 # Change this when incrementing the kernel protocol version
-kernel_protocol_version_info = (4, 0)
+kernel_protocol_version_info = (4, 1)
 
 description = "IPython: Productive Interactive Computing"
 

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -743,7 +743,12 @@ var IPython = (function (IPython) {
 
 
     OutputArea.prototype.handle_clear_output = function (msg) {
-        this.clear_output(msg.content.wait);
+        // msg spec v4 had stdout, stderr, display keys
+        // v4.1 replaced these with just wait
+        // The default behavior is the same (stdout=stderr=display=True, wait=False),
+        // so v4 messages will still be properly handled,
+        // except for the rarely used clearing less than all output.
+        this.clear_output(msg.content.wait || false);
     };
 
 

--- a/docs/source/development/messaging.rst
+++ b/docs/source/development/messaging.rst
@@ -5,6 +5,13 @@
 ======================
 
 
+Versioning
+==========
+
+The IPython message specification is versioned independently of IPython.
+The current version of the specification is 4.1.
+
+
 Introduction
 ============
 
@@ -1001,6 +1008,14 @@ Message type: ``clear_output``::
         'wait' : bool,
     }
 
+.. versionchanged:: 4.1
+
+    'stdout', 'stderr', and 'display' boolean keys for selective clearing are removed,
+    and 'wait' is added.
+    The selective clearing keys are ignored in v4 and the default behavior remains the same,
+    so v4 clear_output messages will be safely handled by a v4.1 frontend.
+
+
 Messages on the stdin ROUTER/DEALER sockets
 ===========================================
 
@@ -1071,7 +1086,9 @@ access to the message between the monitor's send, and the monitor's recv.
 Custom Messages
 ===============
 
-IPython 2.0 adds a messaging system for developers to add their own objects with Frontend
+.. versionadded:: 4.1
+
+IPython 2.0 (msgspec v4.1) adds a messaging system for developers to add their own objects with Frontend
 and Kernel-side components, and allow them to communicate with each other.
 To do this, IPython adds a notion of a ``Comm``, which exists on both sides,
 and can communicate in either direction.
@@ -1080,8 +1097,6 @@ These messages are fully symmetrical - both the Kernel and the Frontend can send
 and no messages expect a reply.
 The Kernel listens for these messages on the Shell channel,
 and the Frontend listens for them on the IOPub channel.
-
-.. versionadded:: 2.0
 
 Opening a Comm
 --------------


### PR DESCRIPTION
spec version is 4.1

Verified that 4.0-style clear_output messages are properly handled in the notebook.

closes #4793
