### PR TITLE
remove KernelApp.parent_appname

### DIFF
--- a/IPython/consoleapp.py
+++ b/IPython/consoleapp.py
@@ -165,8 +165,6 @@ class IPythonConsoleApp(ConnectionFileMixin):
         if argv is None:
             argv = sys.argv[1:]
         self.kernel_argv = swallow_argv(argv, self.frontend_aliases, self.frontend_flags)
-        # kernel should inherit default config file from frontend
-        self.kernel_argv.append("--IPKernelApp.parent_appname='%s'" % self.name)
     
     def init_connection_file(self):
         """find the connection file, and load the info if found.

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -589,11 +589,8 @@ class NotebookApp(BaseIPythonApplication):
 
     def init_kernel_argv(self):
         """construct the kernel arguments"""
-        self.kernel_argv = []
-        # Kernel should inherit default config file from frontend
-        self.kernel_argv.append("--IPKernelApp.parent_appname='%s'" % self.name)
         # Kernel should get *absolute* path to profile directory
-        self.kernel_argv.extend(["--profile-dir", self.profile_dir.location])
+        self.kernel_argv = ["--profile-dir", self.profile_dir.location]
 
     def init_configurables(self):
         # force Session default to be secure

--- a/IPython/kernel/zmq/kernelapp.py
+++ b/IPython/kernel/zmq/kernelapp.py
@@ -118,16 +118,6 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
     def _config_file_name_default(self):
         return 'ipython_config.py'
     
-    # inherit config file name from parent:
-    parent_appname = Unicode(config=True)
-    def _parent_appname_changed(self, name, old, new):
-        if self.config_file_specified:
-            # it was manually specified, ignore
-            return
-        self.config_file_name = new.replace('-','_') + u'_config.py'
-        # don't let this count as specifying the config file
-        self.config_file_specified.remove(self.config_file_name)
-        
     # connection info:
     
     @property


### PR DESCRIPTION
This allowed the Kernel to load config from ipython_qtconsole_config.py or ipython_notebook_config.py, depending on the parent that started the kernel. This is of limited usefulness, and can add weird, unexpected side effects.

We may not actually want to remove this feature, but it's just another bit of config complexity that I think we don't need, so I thought it was worth proposing.
