### PR TITLE
Add automatic Closebrackets function to Codemirror.

### DIFF
--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -101,7 +101,8 @@ var IPython = (function (IPython) {
             },
             mode: 'ipython',
             theme: 'ipython',
-            matchBrackets: true
+            matchBrackets: true,
+            autoCloseBrackets: true
         }
     };
 

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -273,6 +273,7 @@ class="notebook_app"
 <script src="{{ static_url("components/codemirror/addon/mode/multiplex.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("components/codemirror/addon/mode/overlay.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("components/codemirror/addon/edit/matchbrackets.js") }}" charset="utf-8"></script>
+<script src="{{ static_url("components/codemirror/addon/edit/closebrackets.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("components/codemirror/addon/comment/comment.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("components/codemirror/mode/htmlmixed/htmlmixed.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("components/codemirror/mode/xml/xml.js") }}" charset="utf-8"></script>


### PR DESCRIPTION
This is a trivial change to add automatic close of brackets `{`, `[` and `(` to code cells...
This behaviour is extensively spread across multiple IDE and code editors, and I think it worth to make it a default option.
I tested in live and I really like the millisecond I do not spent looking for the closing bracket :wink: 

Thoughts?
