### PR TITLE
require print_method to be a bound method

### DIFF
--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -246,11 +246,13 @@ class Config(dict):
                 c = Config()
                 dict.__setitem__(self, key, c)
                 return c
-            else:
+            elif not key.startswith('_'):
                 # undefined, create lazy value, used for container methods
                 v = LazyConfigValue()
                 dict.__setitem__(self, key, v)
                 return v
+            else:
+                raise KeyError
 
     def __setitem__(self, key, value):
         if _is_section_key(key):

--- a/IPython/config/tests/test_loader.py
+++ b/IPython/config/tests/test_loader.py
@@ -369,6 +369,14 @@ class TestConfig(TestCase):
         assert isinstance(foo, LazyConfigValue)
         self.assertIn('foo', cfg)
 
+    def test_getattr_private_missing(self):
+        cfg = Config()
+        self.assertNotIn('_repr_html_', cfg)
+        with self.assertRaises(AttributeError):
+            _ = cfg._repr_html_
+        self.assertNotIn('_repr_html_', cfg)
+        self.assertEqual(len(cfg), 0)
+
     def test_getitem_not_section(self):
         cfg = Config()
         self.assertNotIn('foo', cfg)

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -26,6 +26,7 @@ Authors:
 # Stdlib imports
 import abc
 import sys
+import types
 import warnings
 
 from IPython.external.decorator import decorator
@@ -312,7 +313,8 @@ class BaseFormatter(Configurable):
                 return printer(obj)
             # Finally look for special method names
             method = pretty._safe_getattr(obj, self.print_method, None)
-            if method is not None:
+            # print_method must be a bound method:
+            if isinstance(method, types.MethodType) and method.__self__ is not None:
                 return method()
             return None
         else:

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -25,6 +25,7 @@ Authors:
 
 # Stdlib imports
 import abc
+import inspect
 import sys
 import types
 import warnings
@@ -59,18 +60,24 @@ def _valid_formatter(f):
     
     Cases checked:
     
-    - bound methods         OK
-    - unbound methods       NO
-    - any other callable    OK
+    - bound methods             OK
+    - unbound methods           NO
+    - callable with zero args   OK
     """
-    if isinstance(f, types.MethodType):
-        # bound methods are okay, unbound are not
-        return f.__self__ is not None
-    elif isinstance(f, type(str.find)):
+    if isinstance(f, type(str.find)):
         # unbound methods on compiled classes have type method_descriptor
         return False
-    elif callable(f):
+    elif isinstance(f, types.BuiltinFunctionType):
+        # bound methods on compiled classes have type builtin_function
         return True
+    elif callable(f):
+        # anything that works with zero args should be okay
+        try:
+            inspect.getcallargs(f)
+        except TypeError:
+            return False
+        else:
+            return True
     return False
 
 class DisplayFormatter(Configurable):

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -53,6 +53,26 @@ else:
 # The main DisplayFormatter class
 #-----------------------------------------------------------------------------
 
+
+def _valid_formatter(f):
+    """Return whether an object is a valid formatter
+    
+    Cases checked:
+    
+    - bound methods         OK
+    - unbound methods       NO
+    - any other callable    OK
+    """
+    if isinstance(f, types.MethodType):
+        # bound methods are okay, unbound are not
+        return f.__self__ is not None
+    elif isinstance(f, type(str.find)):
+        # unbound methods on compiled classes have type method_descriptor
+        return False
+    elif callable(f):
+        return True
+    return False
+
 class DisplayFormatter(Configurable):
 
     # When set to true only the default plain text formatter will be used.
@@ -314,7 +334,7 @@ class BaseFormatter(Configurable):
             # Finally look for special method names
             method = pretty._safe_getattr(obj, self.print_method, None)
             # print_method must be a bound method:
-            if isinstance(method, types.MethodType) and method.__self__ is not None:
+            if _valid_formatter(method):
                 return method()
             return None
         else:

--- a/IPython/core/tests/test_formatters.py
+++ b/IPython/core/tests/test_formatters.py
@@ -8,6 +8,7 @@ except:
     numpy = None
 import nose.tools as nt
 
+from IPython.config import Config
 from IPython.core.formatters import (
     PlainTextFormatter, HTMLFormatter, PDFFormatter, _mod_name_key
 )
@@ -289,3 +290,33 @@ def test_pdf_formatter():
     pdf = MakePDF()
     f = PDFFormatter()
     nt.assert_equal(f(pdf), 'PDF')
+
+def test_print_method_bound():
+    f = HTMLFormatter()
+    class MyHTML(object):
+        def _repr_html_(self):
+            return "hello"
+
+    with capture_output() as captured:
+        result = f(MyHTML)
+    nt.assert_is(result, None)
+    nt.assert_not_in("FormatterWarning", captured.stderr)
+
+    with capture_output() as captured:
+        result = f(MyHTML())
+    nt.assert_equal(result, "hello")
+    nt.assert_equal(captured.stderr, "")
+
+def test_format_config():
+    """config objects don't pretend to support fancy reprs with lazy attrs"""
+    f = HTMLFormatter()
+    cfg = Config()
+    with capture_output() as captured:
+        result = f(cfg)
+    nt.assert_is(result, None)
+    nt.assert_equal(captured.stderr, "")
+
+    with capture_output() as captured:
+        result = f(Config)
+    nt.assert_is(result, None)
+    nt.assert_equal(captured.stderr, "")


### PR DESCRIPTION
closes #4990

This may not be the exact right fix, because some weird cases might have functions, staticmethods, or other such things.  Is there a better thing to check?
