### PR TITLE
Fix pretty reprs of super() objects

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -678,7 +678,7 @@ def _dict_pprinter_factory(start, end, basetype=None):
 def _super_pprint(obj, p, cycle):
     """The pprint for the super type."""
     p.begin_group(8, '<super: ')
-    p.pretty(obj.__self_class__)
+    p.pretty(obj.__thisclass__)
     p.text(',')
     p.breakable()
     p.pretty(obj.__self__)

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -181,4 +181,19 @@ def test_really_bad_repr():
     nt.assert_in("failed", output)
     nt.assert_in("BadException: unknown", output)
     nt.assert_in("unknown type", output)
+
+
+class SA(object):
+    pass
+
+class SB(SA):
+    pass
+
+def test_super_repr():
+    output = pretty.pretty(super(SA))
+    nt.assert_in("SA", output)
+
+    sb = SB()
+    output = pretty.pretty(super(SA, sb))
+    nt.assert_in("SA", output)
     


### PR DESCRIPTION
Prompted by [this SO question](http://stackoverflow.com/questions/21531713/why-does-ipython-display-super-objects-differently-from-the-regular-python-int).

The problem:

```
In [1]: class A(object):
    pass
   ...: 

In [2]: class B(A): pass

In [3]: class C(B): pass

In [4]: c = C()

In [5]: super(B, c)
Out[5]: <super: __main__.C, <__main__.C at 0x2a772d0>>

In [6]: repr(super(B, c))
Out[6]: "<super: <class 'B'>, <C object>>"

In [7]: super(B)
Out[7]: <super: None, None>

In [8]: repr(super(B))
Out[8]: "<super: <class 'B'>, NULL>"
```

Afterwards:

```
In [6]: super(B, c)
Out[6]: <super: __main__.B, <__main__.C at 0x1fbb6d0>>

In [7]: super(B)
Out[7]: <super: __main__.B, None>
```
