### PR TITLE
Fix selection widget construction with default values and labels.

### DIFF
--- a/IPython/html/tests/casperjs/test_cases/widgets_selection.js
+++ b/IPython/html/tests/casperjs/test_cases/widgets_selection.js
@@ -1,16 +1,27 @@
 // Test selection class
 casper.notebook_test(function () {
-    index = this.append_cell(
+    var index = this.append_cell(
         'from IPython.html import widgets\n' + 
         'from IPython.display import display, clear_output\n' +
         'print("Success")');
     this.execute_cell_then(index);
 
+    var list_selector = '.widget-area .widget-subarea .widget-hbox .widget-listbox';
+    index = this.append_cell(
+        's = widgets.SelectWidget(labels=["A", "B"], values=["a", "b"])\n' +
+        'display(s)\n' +
+        'print("Success")');
+    this.execute_cell_then(index, function(index){
+        this.test.assertEquals(this.get_output_cell(index).text, 'Success\n', 
+            'Create select with default labels and values executed with correct output.');
+
+        this.test.assert(this.cell_element_exists(index, list_selector),
+            'Widget list exists.');
+    });
+
     var combo_selector = '.widget-area .widget-subarea .widget-hbox-single .btn-group .widget-combo-btn';
     var multibtn_selector = '.widget-area .widget-subarea .widget-hbox-single .btn-group[data-toggle="buttons-radio"]';
     var radio_selector = '.widget-area .widget-subarea .widget-hbox .vbox';
-    var list_selector = '.widget-area .widget-subarea .widget-hbox .widget-listbox';
-
     var selection_index;
     var selection_values = 'abcd';
     var check_state = function(context, index, state){

--- a/IPython/html/widgets/widget_selection.py
+++ b/IPython/html/widgets/widget_selection.py
@@ -34,16 +34,20 @@ class _SelectionWidget(DOMWidget):
 
     def __init__(self, *pargs, **kwargs):
         """Constructor"""
-        self.value_lock = Lock()
-        self.on_trait_change(self._string_value_set, ['_value'])
-        DOMWidget.__init__(self, *pargs, **kwargs)
+        self._ignore_validation = True
+        try:
+            self.value_lock = Lock()
+            self.on_trait_change(self._string_value_set, ['_value'])
+            DOMWidget.__init__(self, *pargs, **kwargs)
+        finally:
+            self._ignore_validation = True
 
     def _labels_changed(self, name=None, old=None, new=None):
         """Handles when the value_names Dict has been changed.
 
         This method sets the _reverse_value_names Dict to the inverse of the new
         value for the value_names Dict."""
-        if len(new) != len(self.values):
+        if not self._ignore_validation and len(new) != len(self.values):
             raise TypeError('Labels list must be the same size as the values list.')
 
     def _values_changed(self, name=None, old=None, new=None):

--- a/IPython/html/widgets/widget_selection.py
+++ b/IPython/html/widgets/widget_selection.py
@@ -34,27 +34,33 @@ class _SelectionWidget(DOMWidget):
 
     def __init__(self, *pargs, **kwargs):
         """Constructor"""
-        self._ignore_validation = True
-        try:
+        self._labels_lock = Lock()
+        with self._labels_lock:
             self.value_lock = Lock()
             self.on_trait_change(self._string_value_set, ['_value'])
             DOMWidget.__init__(self, *pargs, **kwargs)
-        finally:
-            self._ignore_validation = True
+        self._validate_labels()
 
     def _labels_changed(self, name=None, old=None, new=None):
         """Handles when the value_names Dict has been changed.
 
         This method sets the _reverse_value_names Dict to the inverse of the new
         value for the value_names Dict."""
-        if not self._ignore_validation and len(new) != len(self.values):
-            raise TypeError('Labels list must be the same size as the values list.')
+        if self._labels_lock.acquire(False):
+            try:
+                if len(new) != len(self.values):
+                    raise TypeError('Labels list must be the same size as the values list.')
+            finally:
+                self._labels_lock.release()
 
     def _values_changed(self, name=None, old=None, new=None):
         """Handles when the value_names Dict has been changed.
 
         This method sets the _reverse_value_names Dict to the inverse of the new
         value for the value_names Dict."""
+        self._validate_labels()
+
+    def _validate_labels(self):
         if len(new) != len(self.labels):
             self.labels = [(self.labels[i] if i < len(self.labels) else str(v)) for i, v in enumerate(new)]
 


### PR DESCRIPTION
Fixes #4961
- Don't validate labels and values until end of construction.
- Added test to make sure a selection widget can be created with a default values and labels.
