### PR TITLE
Add notebook examples link to help menu.

### DIFF
--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -222,6 +222,7 @@ class="notebook_app"
                     sections = (
                         (
                             ("http://ipython.org/documentation.html","IPython Help",True),
+                            ("http://nbviewer.ipython.org/github/ipython/ipython/tree/master/examples/notebooks/", "Notebook Examples", True),
                             ("http://ipython.org/ipython-doc/stable/interactive/notebook.html","Notebook Help",True),
                             ("http://ipython.org/ipython-doc/dev/interactive/cm_keyboard.html","Editor Shortcuts",True),
                         ),(


### PR DESCRIPTION
Continuing #4617 - reapplied to master, and changed link to point to master for now - we should point it at a branch at release time.
