### PR TITLE
Add `HasTraits.on_change` as a simplified API for handler registration

### DIFF
--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -414,7 +414,7 @@ class TestHasTraitsNotify(TestCase):
         class A(HasTraits):
             a = Int
         a = A()
-        self.assertRaises(TraitError, a.on_change, 'a', 10)
+        self.assertRaises(TraitError, a.on_change, 10, 'a')
         self.assertRaises(TraitError, a.on_trait_change, 10, 'a')
         self.assertRaises(TraitError, a.on_trait_change, 10, 'a', remove=True)
 
@@ -422,13 +422,13 @@ class TestHasTraitsNotify(TestCase):
         class A(HasTraits):
             a = Int
         a = A()
-        a.on_change('a', self.notify3)
+        a.on_change(self.notify3, 'a')
         a.a = 10
         self.assertTrue(10 in self._notify3)
-        a.on_change('a', self.notify4)
+        a.on_change(self.notify4, 'a')
         a.a = 20
         self.assertTrue(40 in self._notify4)
-        a.on_change('a')
+        a.on_change(None, 'a')
         self._notify3 = []
         self._notify4 = []
         a.a = 10

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -227,11 +227,11 @@ class TestHasTraitsNotify(TestCase):
     def notify2(self, name, old, new):
         self._notify2.append((name, old, new))
 
-    def notify3(self, new):
-        self._notify3.append(new)
+    def notify3(self, name, old, new):
+        self._notify3.append((name, old, new))
 
-    def notify4(self, new):
-        self._notify4.append(2*new)
+    def notify4(self, name, old, new):
+        self._notify4.append((name, old, 2*new))
 
 
     def test_notify_all(self):
@@ -418,22 +418,32 @@ class TestHasTraitsNotify(TestCase):
         self.assertRaises(TraitError, a.on_trait_change, 10, 'a')
         self.assertRaises(TraitError, a.on_trait_change, 10, 'a', remove=True)
 
+    def test_wrong_signature(self):
+        class A(HasTraits):
+            a = Int
+        a = A()
+        def bad_handler(a, b, c, d, e, f):
+            pass
+        self.assertRaises(TraitError, a.on_trait_change, bad_handler, 'a')
+        self.assertRaises(TraitError, a.on_change, bad_handler, 'a')
+        
+
     def test_notify_on_change(self):
         class A(HasTraits):
             a = Int
         a = A()
         a.on_change(self.notify3, 'a')
         a.a = 10
-        self.assertTrue(10 in self._notify3)
+        self.assertTrue(('a',0,10) in self._notify3)
         a.on_change(self.notify4, 'a')
         a.a = 20
-        self.assertTrue(40 in self._notify4)
+        self.assertTrue(('a',10,40) in self._notify4)
         a.on_change(None, 'a')
         self._notify3 = []
         self._notify4 = []
         a.a = 10
-        self.assertTrue(10 not in self._notify3)
-        self.assertTrue(20 not in self._notify4)
+        self.assertTrue(('a',20,10) not in self._notify3)
+        self.assertTrue(('a',20,10) not in self._notify4)
 
 
 class TestHasTraits(TestCase):

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -218,12 +218,21 @@ class TestHasTraitsNotify(TestCase):
     def setUp(self):
         self._notify1 = []
         self._notify2 = []
+        self._notify3 = []
+        self._notify4 = []
 
     def notify1(self, name, old, new):
         self._notify1.append((name, old, new))
 
     def notify2(self, name, old, new):
         self._notify2.append((name, old, new))
+
+    def notify3(self, new):
+        self._notify3.append(new)
+
+    def notify4(self, new):
+        self._notify4.append(2*new)
+
 
     def test_notify_all(self):
 
@@ -400,6 +409,31 @@ class TestHasTraitsNotify(TestCase):
         b.a += 1
         self.assertEqual(b.b, b.c)
         self.assertEqual(b.b, b.d)
+
+    def test_not_callable(self):
+        class A(HasTraits):
+            a = Int
+        a = A()
+        self.assertRaises(TraitError, a.on_change, 'a', 10)
+        self.assertRaises(TraitError, a.on_trait_change, 10, 'a')
+        self.assertRaises(TraitError, a.on_trait_change, 10, 'a', remove=True)
+
+    def test_notify_on_change(self):
+        class A(HasTraits):
+            a = Int
+        a = A()
+        a.on_change('a', self.notify3)
+        a.a = 10
+        self.assertTrue(10 in self._notify3)
+        a.on_change('a', self.notify4)
+        a.a = 20
+        self.assertTrue(40 in self._notify4)
+        a.on_change('a')
+        self._notify3 = []
+        self._notify4 = []
+        a.a = 10
+        self.assertTrue(10 not in self._notify3)
+        self.assertTrue(20 not in self._notify4)
 
 
 class TestHasTraits(TestCase):

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -426,7 +426,6 @@ class TestHasTraitsNotify(TestCase):
             pass
         self.assertRaises(TraitError, a.on_trait_change, bad_handler, 'a')
         self.assertRaises(TraitError, a.on_change, bad_handler, 'a')
-        
 
     def test_notify_on_change(self):
         class A(HasTraits):

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -589,7 +589,7 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
             for n in names:
                 self._add_notifiers(handler, n)
 
-    def on_change(self, name, handler=None):
+    def on_change(self, handler, name):
         """A simplified API for registering an on change handler.
         
         This method presents a simplified API for registering a handler


### PR DESCRIPTION
This closes #5030

There are two things that this does:
- Adds `HasTraits.on_change(name, handler(value))`.
- Adds checks to make sure dynamic handlers are callable, when they are registered, rather than called.
