### PR TITLE
FF Fix: ext link icon same line as link text in help menu

### DIFF
--- a/IPython/html/static/notebook/less/menubar.less
+++ b/IPython/html/static/notebook/less/menubar.less
@@ -23,3 +23,11 @@ i.menu-icon {
   // add padding to account for float-right
   padding-top: 4px;
 }
+
+ul#help_menu li a{
+    overflow: hidden;
+    padding-right: 2.2em;
+    i {
+        margin-right: -1.2em;
+    }
+}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1493,6 +1493,7 @@ p{margin-bottom:0}
 .nav-wrapper{border-bottom:1px solid #d4d4d4}
 #menubar li.dropdown{line-height:12px}
 i.menu-icon{padding-top:4px}
+ul#help_menu li a{overflow:hidden;padding-right:2.2em}ul#help_menu li a i{margin-right:-1.2em}
 #notification_area{z-index:10}
 .notification_widget{color:#777;padding:1px 12px;margin:2px 4px;z-index:10;border:1px solid #ccc;border-radius:4px;background:rgba(240,240,240,0.5)}.notification_widget.span{padding-right:2px}
 #indicator_area{color:#777;padding:2px 2px;margin:2px -9px 2px 4px;z-index:10}

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -238,7 +238,10 @@ class="notebook_app"
 
                 {% for helplinks in sections %}
                     {% for link in helplinks %}
-                        <li><a href="{{link[0]}}" {{'target="_blank" title="Opens in a new window"' if link[2]}}>{{link[1]}}{{'<i class="icon-external-link menu-icon pull-right"></i>' if link[2]}}</a></li>
+                        <li><a href="{{link[0]}}" {{'target="_blank" title="Opens in a new window"' if link[2]}}>
+                        {{'<i class="icon-external-link menu-icon pull-right"></i>' if link[2]}}
+                        {{link[1]}}
+                        </a></li>
                     {% endfor %}
                     {% if not loop.last %}
                         <li class="divider"></li>


### PR DESCRIPTION
It turns out this is a known FF bug- https://bugzilla.mozilla.org/show_bug.cgi?id=50630

Fixes #5016
