### PR TITLE
Remove more .html(...) calls.

### DIFF
--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -147,7 +147,7 @@ var IPython = (function (IPython) {
         this.widget_subarea = widget_subarea;
         var widget_clear_buton = $('<button />')
             .addClass('close')
-            .text('\u00D7')
+            .html('&times;')  // Literal = safe
             .click(function() {
                 widget_area.slideUp('', function(){ widget_subarea.text(''); });
                 })

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -466,8 +466,7 @@ var IPython = (function (IPython) {
         var prompt_text = CodeCell.input_prompt_function(this.input_prompt_number, nline);
         var prompt = this.element.find('div.input_prompt');
         prompt.text(prompt_text);
-        prompt.html(prompt.html().replace(/\n/g,'<br/>')); /* CAUTION! .html(...)
-         CALL IS REQUIRED HERE TO CONVERT NEW LINES TO BR ELEMENTS */
+        prompt.html(prompt.html().replace(/\n/g,'<br/>')); // CAUTION! .html(...) CALL IS REQUIRED HERE TO CONVERT NEW LINES TO BR ELEMENTS
     };
 
     CodeCell.prototype.clear_input = function () {

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -147,9 +147,9 @@ var IPython = (function (IPython) {
         this.widget_subarea = widget_subarea;
         var widget_clear_buton = $('<button />')
             .addClass('close')
-            .html('&times;')
+            .text('\u00D7')
             .click(function() {
-                widget_area.slideUp('', function(){ widget_subarea.html(''); });
+                widget_area.slideUp('', function(){ widget_subarea.text(''); });
                 })
             .appendTo(widget_prompt);
 
@@ -306,7 +306,7 @@ var IPython = (function (IPython) {
         this.output_area.clear_output();
         
         // Clear widget area
-        this.widget_subarea.html('');
+        this.widget_subarea.text('');
         this.widget_subarea.height('');
         this.widget_area.height('');
         this.widget_area.hide();
@@ -417,12 +417,10 @@ var IPython = (function (IPython) {
         this.code_mirror.setSelection(start, end);
     };
 
-
     CodeCell.prototype.collapse_output = function () {
         this.collapsed = true;
         this.output_area.collapse();
     };
-
 
     CodeCell.prototype.expand_output = function () {
         this.collapsed = false;
@@ -444,27 +442,20 @@ var IPython = (function (IPython) {
         this.output_area.toggle_scroll();
     };
 
-
     CodeCell.input_prompt_classical = function (prompt_value, lines_number) {
-        var ns;
-        if (prompt_value == undefined) {
-            ns = "&nbsp;";
-        } else {
-            ns = encodeURIComponent(prompt_value);
-        }
-        return 'In&nbsp;[' + ns + ']:';
+        var ns = prompt_value || ' ';
+        return 'In [' + ns + ']:';
     };
 
     CodeCell.input_prompt_continuation = function (prompt_value, lines_number) {
-        var html = [CodeCell.input_prompt_classical(prompt_value, lines_number)];
+        var text = [CodeCell.input_prompt_classical(prompt_value, lines_number)];
         for(var i=1; i < lines_number; i++) {
-            html.push(['...:']);
+            text.push(['...:']);
         }
-        return html.join('<br/>');
+        return text.join('\n');
     };
 
     CodeCell.input_prompt_function = CodeCell.input_prompt_classical;
-
 
     CodeCell.prototype.set_input_prompt = function (number) {
         var nline = 1;
@@ -472,25 +463,24 @@ var IPython = (function (IPython) {
            nline = this.code_mirror.lineCount();
         }
         this.input_prompt_number = number;
-        var prompt_html = CodeCell.input_prompt_function(this.input_prompt_number, nline);
-        this.element.find('div.input_prompt').html(prompt_html);
+        var prompt_text = CodeCell.input_prompt_function(this.input_prompt_number, nline);
+        var prompt = this.element.find('div.input_prompt');
+        prompt.text(prompt_text);
+        prompt.html(prompt.html().replace(/\n/g,'<br/>')); /* CAUTION! .html(...)
+         CALL IS REQUIRED HERE TO CONVERT NEW LINES TO BR ELEMENTS */
     };
-
 
     CodeCell.prototype.clear_input = function () {
         this.code_mirror.setValue('');
     };
 
-
     CodeCell.prototype.get_text = function () {
         return this.code_mirror.getValue();
     };
 
-
     CodeCell.prototype.set_text = function (code) {
         return this.code_mirror.setValue(code);
     };
-
 
     CodeCell.prototype.at_top = function () {
         var cursor = this.code_mirror.getCursor();
@@ -501,7 +491,6 @@ var IPython = (function (IPython) {
         }
     };
 
-
     CodeCell.prototype.at_bottom = function () {
         var cursor = this.code_mirror.getCursor();
         if (cursor.line === (this.code_mirror.lineCount()-1) && cursor.ch === this.code_mirror.getLine(cursor.line).length) {
@@ -510,7 +499,6 @@ var IPython = (function (IPython) {
             return false;
         }
     };
-
 
     CodeCell.prototype.clear_output = function (wait) {
         this.output_area.clear_output(wait);
@@ -546,7 +534,6 @@ var IPython = (function (IPython) {
             }
         }
     };
-
 
     CodeCell.prototype.toJSON = function () {
         var data = IPython.Cell.prototype.toJSON.apply(this);

--- a/IPython/html/static/notebook/js/notificationwidget.js
+++ b/IPython/html/static/notebook/js/notificationwidget.js
@@ -76,7 +76,7 @@ var IPython = (function (IPython) {
 
 
     NotificationWidget.prototype.get_message = function () {
-        return this.inner.html();
+        return this.inner.text();
     };
 
 

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -546,6 +546,8 @@ var IPython = (function (IPython) {
         if (extra_class){
             toinsert.addClass(extra_class);
         }
+
+        // TODO: SCRUB
         toinsert.append($("<pre/>").html(data)); // CAUTION! html(...) CALL MANDITORY BECAUSE OF fixConsole(...) CALL
         element.append(toinsert);
         return toinsert;

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -124,7 +124,7 @@ var IPython = (function (IPython) {
         if (!this.collapsed) {
             this.element.hide();
             this.prompt_overlay.hide();
-            if (this.element.html()){
+            if (this.element.text()){
                 this.collapse_button.show();
             }
             this.collapsed = true;
@@ -344,7 +344,7 @@ var IPython = (function (IPython) {
                 // We must directly write the html. When using Jquery's append
                 // method, javascript is evaluated in the parent document and
                 // not in the iframe document.
-                this.contentDocument.write(subarea.html());
+                this.contentDocument.write(subarea.html()); // CAUTION! .html(...) CALL MANDITORY!!!
 
                 this.contentDocument.close();
 
@@ -370,12 +370,10 @@ var IPython = (function (IPython) {
         // display a message when a javascript error occurs in display output
         var msg = "Javascript error adding output!"
         if ( element === undefined ) return;
-        element.append(
-            $('<div/>').html(msg + "<br/>" +
-                err.toString() +
-                '<br/>See your browser Javascript console for more details.'
-            ).addClass('js-error')
-        );
+        element
+            .append($('<div/>').text(msg).addClass('js-error'))
+            .append($('<div/>').text(err.toString()).addClass('js-error'))
+            .append($('<div/>').text('See your browser Javascript console for more details.').addClass('js-error'));
     };
     
     OutputArea.prototype._safe_append = function (toinsert) {
@@ -446,8 +444,8 @@ var IPython = (function (IPython) {
                 // escape ANSI & HTML specials:
                 var pre = this.element.find('div.'+subclass).last().find('pre');
                 var html = utils.fixCarriageReturn(
-                    pre.html() + utils.fixConsole(text));
-                pre.html(html);
+                    pre.html() + utils.fixConsole(text)); // CAUTION! html(...) CALL MANDITORY BECAUSE OF fixConsole(...)
+                pre.html(html); // CAUTION! html(...) CALL MANDITORY!!!
                 return;
             }
         }
@@ -548,7 +546,7 @@ var IPython = (function (IPython) {
         if (extra_class){
             toinsert.addClass(extra_class);
         }
-        toinsert.append($("<pre/>").html(data));
+        toinsert.append($("<pre/>").html(data)); // CAUTION! html(...) CALL MANDITORY BECAUSE OF fixConsole(...) CALL
         element.append(toinsert);
         return toinsert;
     };
@@ -735,7 +733,7 @@ var IPython = (function (IPython) {
             }
             
             // clear all, no need for logic
-            this.element.html("");
+            this.element.text("");
             this.outputs = [];
             this.trusted = true;
             this.unscroll_area();

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -443,6 +443,8 @@ var IPython = (function (IPython) {
                 // so append directly into its pre tag
                 // escape ANSI & HTML specials:
                 var pre = this.element.find('div.'+subclass).last().find('pre');
+                
+                // TODO: SCRUB
                 var html = utils.fixCarriageReturn(
                     pre.html() + utils.fixConsole(text)); // CAUTION! html(...) CALL MANDITORY BECAUSE OF fixConsole(...)
                 pre.html(html); // CAUTION! html(...) CALL MANDITORY!!!

--- a/IPython/html/static/notebook/js/pager.js
+++ b/IPython/html/static/notebook/js/pager.js
@@ -164,7 +164,9 @@ var IPython = (function (IPython) {
     }
 
     Pager.prototype.append_text = function (text) {
-        this.pager_element.find(".container").append($('<pre/>').html(utils.fixCarriageReturn(utils.fixConsole(text))));
+        this.pager_element.find(".container").append($('<pre/>').html( // CAUTION! html(...) CALL MANDITORY BECAUSE OF fixConsole(...) CALL
+            utils.fixCarriageReturn(utils.fixConsole(text)))
+        );
     };
 
 

--- a/IPython/html/static/notebook/js/pager.js
+++ b/IPython/html/static/notebook/js/pager.js
@@ -164,6 +164,7 @@ var IPython = (function (IPython) {
     }
 
     Pager.prototype.append_text = function (text) {
+        // TODO: SCRUB
         this.pager_element.find(".container").append($('<pre/>').html( // CAUTION! html(...) CALL MANDITORY BECAUSE OF fixConsole(...) CALL
             utils.fixCarriageReturn(utils.fixConsole(text)))
         );

--- a/IPython/html/static/notebook/js/quickhelp.js
+++ b/IPython/html/static/notebook/js/quickhelp.js
@@ -32,7 +32,7 @@ var IPython = (function (IPython) {
         // The documentation
         var doc = $('<div/>').addClass('alert');
         doc.append(
-            $('<button/>').addClass('close').attr('data-dismiss','alert').text('\u00D7')
+            $('<button/>').addClass('close').attr('data-dismiss','alert').html('&times;') // Literal = safe
         ).append(
             'The IPython Notebook has two different keyboard input modes. <b>Edit mode</b> '+
             'allows you to type code/text into a cell and is indicated by a green cell '+

--- a/IPython/html/static/notebook/js/quickhelp.js
+++ b/IPython/html/static/notebook/js/quickhelp.js
@@ -32,7 +32,7 @@ var IPython = (function (IPython) {
         // The documentation
         var doc = $('<div/>').addClass('alert');
         doc.append(
-            $('<button/>').addClass('close').attr('data-dismiss','alert').html('&times;')
+            $('<button/>').addClass('close').attr('data-dismiss','alert').text('\u00D7')
         ).append(
             'The IPython Notebook has two different keyboard input modes. <b>Edit mode</b> '+
             'allows you to type code/text into a cell and is indicated by a green cell '+

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -235,10 +235,10 @@ var IPython = (function (IPython) {
     /**
      * setter :{{#crossLink "TextCell/set_rendered"}}{{/crossLink}}
      * @method get_rendered
-     * @return {text} text of rendered element
+     * @return {html} html of rendered element
      * */
     TextCell.prototype.get_rendered = function() {
-        return this.element.find('div.text_cell_render').text(); 
+        return this.element.find('div.text_cell_render').html(); // HTML return- safe
     };
 
     /**
@@ -514,7 +514,7 @@ var IPython = (function (IPython) {
 
     HeadingCell.prototype.get_rendered = function () {
         var r = this.element.find("div.text_cell_render");
-        return r.children().first().text(); 
+        return r.children().first().html(); // HTML return- safe.
     };
 
     HeadingCell.prototype.render = function () {

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -349,7 +349,7 @@ var IPython = (function (IPython) {
             text = text_and_math[0];
             math = text_and_math[1];
 
-            // TODO: The following code takes user input and creates HTML.  This
+            // The following code takes user input and creates HTML.  This
             // operation has the potential to produce unsafe HTML and should
             // be scrubbed...
             var html = marked.parser(marked.lexer(text));
@@ -358,6 +358,7 @@ var IPython = (function (IPython) {
             html.find("a[href]").not('[href^="#"]').attr("target", "_blank");
             var rendered = this.element.find('div.text_cell_render');
             try {
+                // TODO: SCRUB
                 rendered.html(html); // CAUTION! html(...) CALL MANDITORY!!!
             } catch (e) {
                 console.log("Error running Javascript in Markdown:");
@@ -530,7 +531,7 @@ var IPython = (function (IPython) {
             math = text_and_math[1];
 
 
-            // TODO: The following code takes user input and creates HTML.  This
+            // The following code takes user input and creates HTML.  This
             // operation has the potential to produce unsafe HTML and should
             // be scrubbed...
             var html = marked.parser(marked.lexer(text));
@@ -546,6 +547,7 @@ var IPython = (function (IPython) {
             );
             
             var rendered = this.element.find("div.text_cell_render");
+            // TODO: SCRUB
             rendered.html(h); // CAUTION! .html(...) CALL MANDITORY!!!
             this.typeset();
 

--- a/IPython/html/static/notebook/js/tooltip.js
+++ b/IPython/html/static/notebook/js/tooltip.js
@@ -369,9 +369,9 @@ var IPython = (function (IPython) {
         this._hidden = false;
         this.text.children().remove();
 
-        var pre = $('<pre/>').html(utils.fixConsole(docstring));
+        var pre = $('<pre/>').html(utils.fixConsole(docstring)); // CAUTION! html(...) CALL MANDITORY BECAUSE OF fixConsole(...) CALL!
         if (defstring) {
-            var defstring_html = $('<pre/>').html(utils.fixConsole(defstring));
+            var defstring_html = $('<pre/>').html(utils.fixConsole(defstring)); // CAUTION! html(...) CALL MANDITORY BECAUSE OF fixConsole(...) CALL!
             this.text.append(defstring_html);
         }
         this.text.append(pre);

--- a/IPython/html/static/notebook/js/tooltip.js
+++ b/IPython/html/static/notebook/js/tooltip.js
@@ -369,8 +369,10 @@ var IPython = (function (IPython) {
         this._hidden = false;
         this.text.children().remove();
 
+        // TODO: SCRUB
         var pre = $('<pre/>').html(utils.fixConsole(docstring)); // CAUTION! html(...) CALL MANDITORY BECAUSE OF fixConsole(...) CALL!
         if (defstring) {
+            // TODO: SCRUB
             var defstring_html = $('<pre/>').html(utils.fixConsole(defstring)); // CAUTION! html(...) CALL MANDITORY BECAUSE OF fixConsole(...) CALL!
             this.text.append(defstring_html);
         }


### PR DESCRIPTION
- Removed the `.html(...)` calls that could be removed without rewriting lots of notebook code.
- Added comment to each remaining call to `.html(...)`
- Added `TODO: SCRUB` comments before every `.html(...)` call that needs to be scrubbed.

Closes #5034
