### PR TITLE
various unicode / url fixes

### DIFF
--- a/IPython/html/auth/login.py
+++ b/IPython/html/auth/login.py
@@ -32,13 +32,13 @@ class LoginHandler(IPythonHandler):
 
     def _render(self, message=None):
         self.write(self.render_template('login.html',
-                next=url_escape(self.get_argument('next', default=self.base_project_url)),
+                next=url_escape(self.get_argument('next', default=self.base_url)),
                 message=message,
         ))
 
     def get(self):
         if self.current_user:
-            self.redirect(self.get_argument('next', default=self.base_project_url))
+            self.redirect(self.get_argument('next', default=self.base_url))
         else:
             self._render()
 
@@ -51,7 +51,7 @@ class LoginHandler(IPythonHandler):
                 self._render(message={'error': 'Invalid password'})
                 return
 
-        self.redirect(self.get_argument('next', default=self.base_project_url))
+        self.redirect(self.get_argument('next', default=self.base_url))
 
 
 #-----------------------------------------------------------------------------

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -133,8 +133,8 @@ class IPythonHandler(AuthenticatedHandler):
         return self.settings.get('mathjax_url', '')
     
     @property
-    def base_project_url(self):
-        return self.settings.get('base_project_url', '/')
+    def base_url(self):
+        return self.settings.get('base_url', '/')
     
     @property
     def base_kernel_url(self):
@@ -180,7 +180,7 @@ class IPythonHandler(AuthenticatedHandler):
     @property
     def template_namespace(self):
         return dict(
-            base_project_url=self.base_project_url,
+            base_url=self.base_url,
             base_kernel_url=self.base_kernel_url,
             logged_in=self.logged_in,
             login_available=self.login_available,

--- a/IPython/html/notebook/handlers.py
+++ b/IPython/html/notebook/handlers.py
@@ -58,7 +58,7 @@ class NotebookRedirectHandler(IPythonHandler):
         nbm = self.notebook_manager
         if nbm.path_exists(path):
             # it's a *directory*, redirect to /tree
-            url = url_path_join(self.base_project_url, 'tree', path)
+            url = url_path_join(self.base_url, 'tree', path)
         else:
             # otherwise, redirect to /files
             if '/files/' in path:
@@ -73,7 +73,7 @@ class NotebookRedirectHandler(IPythonHandler):
                 if not os.path.exists(files_path):
                     path = path.replace('/files/', '/', 1)
             
-            url = url_path_join(self.base_project_url, 'files', path)
+            url = url_path_join(self.base_url, 'files', path)
         url = url_escape(url)
         self.log.debug("Redirecting %s to %s", self.request.path, url)
         self.redirect(url)

--- a/IPython/html/services/notebooks/handlers.py
+++ b/IPython/html/services/notebooks/handlers.py
@@ -47,7 +47,7 @@ class NotebookHandler(IPythonHandler):
             The URL path of the notebook.
         """
         return url_escape(url_path_join(
-            self.base_project_url, 'api', 'notebooks', path, name
+            self.base_url, 'api', 'notebooks', path, name
         ))
 
     def _finish_model(self, model, location=True):
@@ -242,7 +242,7 @@ class NotebookCheckpointsHandler(IPythonHandler):
         nbm = self.notebook_manager
         checkpoint = nbm.create_checkpoint(name, path)
         data = json.dumps(checkpoint, default=date_default)
-        location = url_path_join(self.base_project_url, 'api/notebooks',
+        location = url_path_join(self.base_url, 'api/notebooks',
             path, name, 'checkpoints', checkpoint['id'])
         self.set_header('Location', url_escape(location))
         self.set_status(201)

--- a/IPython/html/static/auth/js/loginwidget.js
+++ b/IPython/html/static/auth/js/loginwidget.js
@@ -10,10 +10,11 @@
 //============================================================================
 
 var IPython = (function (IPython) {
+    "use strict";
 
     var LoginWidget = function (selector, options) {
-        var options = options || {};
-        this.base_url = options.baseProjectUrl || $('body').data('baseProjectUrl') ;
+        options = options || {};
+        this.base_project_url = options.base_project_url || IPython.utils.get_data("baseProjectUrl");
         this.selector = selector;
         if (this.selector !== undefined) {
             this.element = $(selector);
@@ -30,10 +31,16 @@ var IPython = (function (IPython) {
     LoginWidget.prototype.bind_events = function () {
         var that = this;
         this.element.find("button#logout").click(function () {
-            window.location = that.base_url+"logout";
+            window.location = IPythin.utils.url_join_encode(
+                that.base_project_url,
+                "logout"
+            );
         });
         this.element.find("button#login").click(function () {
-            window.location = that.base_url+"login";
+            window.location = IPythin.utils.url_join_encode(
+                that.base_project_url,
+                "login"
+            );
         });
     };
 

--- a/IPython/html/static/auth/js/loginwidget.js
+++ b/IPython/html/static/auth/js/loginwidget.js
@@ -14,7 +14,7 @@ var IPython = (function (IPython) {
 
     var LoginWidget = function (selector, options) {
         options = options || {};
-        this.base_project_url = options.base_project_url || IPython.utils.get_data("baseProjectUrl");
+        this.base_url = options.base_url || IPython.utils.get_data("baseUrl");
         this.selector = selector;
         if (this.selector !== undefined) {
             this.element = $(selector);
@@ -32,13 +32,13 @@ var IPython = (function (IPython) {
         var that = this;
         this.element.find("button#logout").click(function () {
             window.location = IPythin.utils.url_join_encode(
-                that.base_project_url,
+                that.base_url,
                 "logout"
             );
         });
         this.element.find("button#login").click(function () {
             window.location = IPythin.utils.url_join_encode(
-                that.base_project_url,
+                that.base_url,
                 "login"
             );
         });

--- a/IPython/html/static/auth/js/loginwidget.js
+++ b/IPython/html/static/auth/js/loginwidget.js
@@ -14,7 +14,7 @@ var IPython = (function (IPython) {
 
     var LoginWidget = function (selector, options) {
         options = options || {};
-        this.base_url = options.base_url || IPython.utils.get_data("baseUrl");
+        this.base_url = options.base_url || IPython.utils.get_body_data("baseUrl");
         this.selector = selector;
         if (this.selector !== undefined) {
             this.element = $(selector);

--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -417,15 +417,21 @@ IPython.utils = (function (IPython) {
                 url = url + arguments[i];
             }
         }
+        url = url.replace(/\/\/+/, '/');
         return url;
     };
     
+    var parse_url = function (url) {
+        var a = document.createElement("a");
+        a.href = url;
+        return a;
+    };
     
     var encode_uri_components = function (uri) {
         // encode just the components of a multi-segment uri,
         // leaving '/' separators
         return uri.split('/').map(encodeURIComponent).join('/');
-    }
+    };
     
     var url_join_encode = function () {
         // join a sequence of url components with '/',
@@ -517,6 +523,7 @@ IPython.utils = (function (IPython) {
         autoLinkUrls : autoLinkUrls,
         points_to_pixels : points_to_pixels,
         get_body_data : get_body_data,
+        parse_url : parse_url,
         url_path_join : url_path_join,
         url_join_encode : url_join_encode,
         encode_uri_components : encode_uri_components,

--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -422,6 +422,14 @@ IPython.utils = (function (IPython) {
     };
     
     var parse_url = function (url) {
+        // an `a` element with an href allows attr-access to the parsed segments of a URL
+        // a = parse_url("http://localhost:8888/path/name#hash")
+        // a.protocol = "http:"
+        // a.host     = "localhost:8888"
+        // a.hostname = "localhost"
+        // a.port     = 8888
+        // a.pathname = "/path/name"
+        // a.hash     = "#hash"
         var a = document.createElement("a");
         a.href = url;
         return a;

--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -443,7 +443,15 @@ IPython.utils = (function (IPython) {
         } else {
             return [filename, ''];
         }
-    }
+    };
+
+
+    var get_data = function(key) {
+        // get a url-encoded item from body.data and decode it
+        // we should never have any encoded URLs anywhere else in code
+        // until we are building an actual request
+        return decodeURIComponent($('body').data(key));
+    };
 
 
     // http://stackoverflow.com/questions/2400935/browser-detection-in-javascript
@@ -508,6 +516,7 @@ IPython.utils = (function (IPython) {
         fixCarriageReturn : fixCarriageReturn,
         autoLinkUrls : autoLinkUrls,
         points_to_pixels : points_to_pixels,
+        get_data : get_data,
         url_path_join : url_path_join,
         url_join_encode : url_join_encode,
         encode_uri_components : encode_uri_components,

--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -446,7 +446,7 @@ IPython.utils = (function (IPython) {
     };
 
 
-    var get_data = function(key) {
+    var get_body_data = function(key) {
         // get a url-encoded item from body.data and decode it
         // we should never have any encoded URLs anywhere else in code
         // until we are building an actual request
@@ -516,7 +516,7 @@ IPython.utils = (function (IPython) {
         fixCarriageReturn : fixCarriageReturn,
         autoLinkUrls : autoLinkUrls,
         points_to_pixels : points_to_pixels,
-        get_data : get_data,
+        get_body_data : get_body_data,
         url_path_join : url_path_join,
         url_join_encode : url_join_encode,
         encode_uri_components : encode_uri_components,

--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -47,7 +47,7 @@ function (marked) {
     $('div#notebook_panel').addClass('border-box-sizing');
 
     var opts = {
-        base_project_url : IPython.utils.get_data("baseProjectUrl"),
+        base_url : IPython.utils.get_data("baseUrl"),
         base_kernel_url : IPython.utils.get_data("baseKernelUrl"),
         notebook_path : IPython.utils.get_data("notebookPath"),
         notebook_name : IPython.utils.get_data('notebookName')

--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -8,7 +8,6 @@
 //============================================================================
 // On document ready
 //============================================================================
-"use strict";
 
 // for the time beeing, we have to pass marked as a parameter here,
 // as injecting require.js make marked not to put itself in the globals,
@@ -18,28 +17,28 @@ require(['components/marked/lib/marked',
          'notebook/js/widgets/init'],
 
 function (marked) {
+    "use strict";
 
-    window.marked = marked
+    window.marked = marked;
 
     // monkey patch CM to be able to syntax highlight cell magics
     // bug reported upstream,
     // see https://github.com/marijnh/CodeMirror2/issues/670
-    if(CodeMirror.getMode(1,'text/plain').indent == undefined ){
+    if(CodeMirror.getMode(1,'text/plain').indent === undefined ){
         console.log('patching CM for undefined indent');
         CodeMirror.modes.null = function() {
-            return {token: function(stream) {stream.skipToEnd();},indent : function(){return 0}}
-        }
+            return {token: function(stream) {stream.skipToEnd();},indent : function(){return 0;}};
+        };
     }
 
     CodeMirror.patchedGetMode = function(config, mode){
             var cmmode = CodeMirror.getMode(config, mode);
-            if(cmmode.indent == null)
-            {
+            if(cmmode.indent === null) {
                 console.log('patch mode "' , mode, '" on the fly');
-                cmmode.indent = function(){return 0};
+                cmmode.indent = function(){return 0;};
             }
             return cmmode;
-        }
+        };
     // end monkey patching CodeMirror
 
     IPython.mathjaxutils.init();
@@ -47,35 +46,32 @@ function (marked) {
     $('#ipython-main-app').addClass('border-box-sizing');
     $('div#notebook_panel').addClass('border-box-sizing');
 
-    var baseProjectUrl = $('body').data('baseProjectUrl');
-    var notebookPath = $('body').data('notebookPath');
-    var notebookName = $('body').data('notebookName');
-    notebookName = decodeURIComponent(notebookName);
-    notebookPath = decodeURIComponent(notebookPath);
-    console.log(notebookName);
-    if (notebookPath == 'None'){
-        notebookPath = "";
-    }
+    var opts = {
+        base_project_url : IPython.utils.get_data("baseProjectUrl"),
+        base_kernel_url : IPython.utils.get_data("baseKernelUrl"),
+        notebook_path : IPython.utils.get_data("notebookPath"),
+        notebook_name : IPython.utils.get_data('notebookName')
+    };
 
     IPython.page = new IPython.Page();
     IPython.layout_manager = new IPython.LayoutManager();
     IPython.pager = new IPython.Pager('div#pager', 'div#pager_splitter');
     IPython.quick_help = new IPython.QuickHelp();
-    IPython.login_widget = new IPython.LoginWidget('span#login_widget',{baseProjectUrl:baseProjectUrl});
-    IPython.notebook = new IPython.Notebook('div#notebook',{baseProjectUrl:baseProjectUrl, notebookPath:notebookPath, notebookName:notebookName});
+    IPython.login_widget = new IPython.LoginWidget('span#login_widget', opts);
+    IPython.notebook = new IPython.Notebook('div#notebook', opts);
     IPython.keyboard_manager = new IPython.KeyboardManager();
     IPython.save_widget = new IPython.SaveWidget('span#save_widget');
-    IPython.menubar = new IPython.MenuBar('#menubar',{baseProjectUrl:baseProjectUrl, notebookPath: notebookPath})
-    IPython.toolbar = new IPython.MainToolBar('#maintoolbar-container')
-    IPython.tooltip = new IPython.Tooltip()
-    IPython.notification_area = new IPython.NotificationArea('#notification_area')
+    IPython.menubar = new IPython.MenuBar('#menubar', opts);
+    IPython.toolbar = new IPython.MainToolBar('#maintoolbar-container');
+    IPython.tooltip = new IPython.Tooltip();
+    IPython.notification_area = new IPython.NotificationArea('#notification_area');
     IPython.notification_area.init_notification_widgets();
 
     IPython.layout_manager.do_resize();
 
     $('body').append('<div id="fonttest"><pre><span id="test1">x</span>'+
                      '<span id="test2" style="font-weight: bold;">x</span>'+
-                     '<span id="test3" style="font-style: italic;">x</span></pre></div>')
+                     '<span id="test3" style="font-style: italic;">x</span></pre></div>');
     var nh = $('#test1').innerHeight();
     var bh = $('#test2').innerHeight();
     var ih = $('#test3').innerHeight();
@@ -101,7 +97,7 @@ function (marked) {
     
     $([IPython.events]).on('notebook_loaded.Notebook', first_load);
     $([IPython.events]).trigger('app_initialized.NotebookApp');
-    IPython.notebook.load_notebook(notebookName, notebookPath);
+    IPython.notebook.load_notebook(opts.notebook_name, opts.notebook_path);
 
     if (marked) {
         marked.setOptions({
@@ -121,8 +117,6 @@ function (marked) {
                 }
                 return highlighted.value;
             }
-        })
+        });
     }
-}
-
-);
+});

--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -47,10 +47,10 @@ function (marked) {
     $('div#notebook_panel').addClass('border-box-sizing');
 
     var opts = {
-        base_url : IPython.utils.get_data("baseUrl"),
-        base_kernel_url : IPython.utils.get_data("baseKernelUrl"),
-        notebook_path : IPython.utils.get_data("notebookPath"),
-        notebook_name : IPython.utils.get_data('notebookName')
+        base_url : IPython.utils.get_body_data("baseUrl"),
+        base_kernel_url : IPython.utils.get_body_data("baseKernelUrl"),
+        notebook_path : IPython.utils.get_body_data("notebookPath"),
+        notebook_name : IPython.utils.get_body_data('notebookName')
     };
 
     IPython.page = new IPython.Page();

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -30,16 +30,14 @@ var IPython = (function (IPython) {
      *
      * @param selector {string} selector for the menubar element in DOM
      * @param {object} [options]
-     *      @param [options.baseProjectUrl] {String} String to use for the
-     *      Base Project url, default would be to inspect
+     *      @param [options.base_project_url] {String} String to use for the
+     *      base project url. Default is to inspect
      *      $('body').data('baseProjectUrl');
      *      does not support change for now is set through this option
      */
     var MenuBar = function (selector, options) {
         options = options || {};
-        if (options.baseProjectUrl !== undefined) {
-            this._baseProjectUrl = options.baseProjectUrl;
-        }
+        this.base_project_url = options.base_project_url || IPython.utils.get_data("baseProjectUrl");
         this.selector = selector;
         if (this.selector !== undefined) {
             this.element = $(selector);
@@ -48,16 +46,6 @@ var IPython = (function (IPython) {
         }
     };
 
-    MenuBar.prototype.baseProjectUrl = function(){
-        return this._baseProjectUrl || $('body').data('baseProjectUrl');
-    };
-
-    MenuBar.prototype.notebookPath = function() {
-        var path = $('body').data('notebookPath');
-        path = decodeURIComponent(path);
-        return path;
-    };
-    
     MenuBar.prototype.style = function () {
         this.element.addClass('border-box-sizing');
         this.element.find("li").click(function (event, ui) {
@@ -75,16 +63,16 @@ var IPython = (function (IPython) {
         if (IPython.notebook.dirty) {
             IPython.notebook.save_notebook({async : false});
         }
-        var url = utils.url_path_join(
-            this.baseProjectUrl(),
+        var url = utils.url_join_encode(
+            this.base_project_url,
             'nbconvert',
             format,
-            this.notebookPath(),
+            this.notebook_path,
             notebook_name + '.ipynb'
         ) + "?download=" + download.toString();
 
         window.open(url);
-    }
+    };
 
     MenuBar.prototype.bind_events = function () {
         //  File
@@ -94,9 +82,9 @@ var IPython = (function (IPython) {
         });
         this.element.find('#open_notebook').click(function () {
             window.open(utils.url_join_encode(
-                that.baseProjectUrl(),
+                IPython.notebook.base_url,
                 'tree',
-                that.notebookPath()
+                IPython.notebook.notebook_path
             ));
         });
         this.element.find('#copy_notebook').click(function () {
@@ -104,15 +92,17 @@ var IPython = (function (IPython) {
             return false;
         });
         this.element.find('#download_ipynb').click(function () {
-            var notebook_name = IPython.notebook.get_notebook_name();
+            var base_url = IPython.notebook.base_url;
+            var notebook_path = IPython.notebook.notebook_path;
+            var notebook_name = IPython.notebook.notebook_name;
             if (IPython.notebook.dirty) {
                 IPython.notebook.save_notebook({async : false});
             }
             
             var url = utils.url_join_encode(
-                that.baseProjectUrl(),
+                base_url,
                 'files',
-                that.notebookPath(),
+                notebook_path,
                 notebook_name + '.ipynb'
             );
             window.location.assign(url);

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -37,7 +37,7 @@ var IPython = (function (IPython) {
      */
     var MenuBar = function (selector, options) {
         options = options || {};
-        this.base_url = options.base_url || IPython.utils.get_data("baseUrl");
+        this.base_url = options.base_url || IPython.utils.get_body_data("baseUrl");
         this.selector = selector;
         if (this.selector !== undefined) {
             this.element = $(selector);

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -30,14 +30,14 @@ var IPython = (function (IPython) {
      *
      * @param selector {string} selector for the menubar element in DOM
      * @param {object} [options]
-     *      @param [options.base_project_url] {String} String to use for the
+     *      @param [options.base_url] {String} String to use for the
      *      base project url. Default is to inspect
-     *      $('body').data('baseProjectUrl');
+     *      $('body').data('baseUrl');
      *      does not support change for now is set through this option
      */
     var MenuBar = function (selector, options) {
         options = options || {};
-        this.base_project_url = options.base_project_url || IPython.utils.get_data("baseProjectUrl");
+        this.base_url = options.base_url || IPython.utils.get_data("baseUrl");
         this.selector = selector;
         if (this.selector !== undefined) {
             this.element = $(selector);
@@ -64,7 +64,7 @@ var IPython = (function (IPython) {
             IPython.notebook.save_notebook({async : false});
         }
         var url = utils.url_join_encode(
-            this.base_project_url,
+            this.base_url,
             'nbconvert',
             format,
             this.notebook_path,

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -59,7 +59,8 @@ var IPython = (function (IPython) {
 
     MenuBar.prototype._nbconvert = function (format, download) {
         download = download || false;
-        var notebook_name = IPython.notebook.get_notebook_name();
+        var notebook_path = IPython.notebook.notebook_path;
+        var notebook_name = IPython.notebook.notebook_name;
         if (IPython.notebook.dirty) {
             IPython.notebook.save_notebook({async : false});
         }
@@ -67,8 +68,8 @@ var IPython = (function (IPython) {
             this.base_url,
             'nbconvert',
             format,
-            this.notebook_path,
-            notebook_name + '.ipynb'
+            notebook_path,
+            notebook_name
         ) + "?download=" + download.toString();
 
         window.open(url);
@@ -103,7 +104,7 @@ var IPython = (function (IPython) {
                 base_url,
                 'files',
                 notebook_path,
-                notebook_name + '.ipynb'
+                notebook_name
             );
             window.location.assign(url);
         });

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -24,7 +24,7 @@ var IPython = (function (IPython) {
      */
     var Notebook = function (selector, options) {
         this.options = options = options || {};
-        this.base_project_url = options.base_project_url;
+        this.base_url = options.base_url;
         this.notebook_path = options.notebook_path;
         this.notebook_name = options.notebook_name;
         this.element = $(selector);
@@ -1683,7 +1683,7 @@ var IPython = (function (IPython) {
         }
         $([IPython.events]).trigger('notebook_saving.Notebook');
         var url = utils.url_join_encode(
-            this.base_project_url,
+            this.base_url,
             'api/notebooks',
             this.notebook_path,
             this.notebook_name
@@ -1744,7 +1744,7 @@ var IPython = (function (IPython) {
 
     Notebook.prototype.new_notebook = function(){
         var path = this.notebook_path;
-        var base_project_url = this.base_project_url;
+        var base_url = this.base_url;
         var settings = {
             processData : false,
             cache : false,
@@ -1755,7 +1755,7 @@ var IPython = (function (IPython) {
                 var notebook_name = data.name;
                 window.open(
                     utils.url_join_encode(
-                        base_project_url,
+                        base_url,
                         'notebooks',
                         path,
                         notebook_name
@@ -1765,7 +1765,7 @@ var IPython = (function (IPython) {
             }
         };
         var url = utils.url_join_encode(
-            base_project_url,
+            base_url,
             'api/notebooks',
             path
         );
@@ -1775,7 +1775,7 @@ var IPython = (function (IPython) {
 
     Notebook.prototype.copy_notebook = function(){
         var path = this.notebook_path;
-        var base_project_url = this.base_project_url;
+        var base_url = this.base_url;
         var settings = {
             processData : false,
             cache : false,
@@ -1785,7 +1785,7 @@ var IPython = (function (IPython) {
             async : false,
             success : function (data, status, xhr) {
                 window.open(utils.url_join_encode(
-                    base_project_url,
+                    base_url,
                     'notebooks',
                     data.path,
                     data.name
@@ -1793,7 +1793,7 @@ var IPython = (function (IPython) {
             }
         };
         var url = utils.url_join_encode(
-            base_project_url,
+            base_url,
             'api/notebooks',
             path
         );
@@ -1818,7 +1818,7 @@ var IPython = (function (IPython) {
         };
         $([IPython.events]).trigger('rename_notebook.Notebook', data);
         var url = utils.url_join_encode(
-            this.base_project_url,
+            this.base_url,
             'api/notebooks',
             this.notebook_path,
             this.notebook_name
@@ -1835,7 +1835,7 @@ var IPython = (function (IPython) {
             dataType: "json",
         };
         var url = utils.url_join_encode(
-            this.base_project_url,
+            this.base_url,
             'api/notebooks',
             this.notebook_path,
             this.notebook_name
@@ -1903,7 +1903,7 @@ var IPython = (function (IPython) {
         };
         $([IPython.events]).trigger('notebook_loading.Notebook');
         var url = utils.url_join_encode(
-            this.base_project_url,
+            this.base_url,
             'api/notebooks',
             this.notebook_path,
             this.notebook_name
@@ -2054,7 +2054,7 @@ var IPython = (function (IPython) {
      */
     Notebook.prototype.list_checkpoints = function () {
         var url = utils.url_join_encode(
-            this.base_project_url,
+            this.base_url,
             'api/notebooks',
             this.notebook_path,
             this.notebook_name,
@@ -2105,7 +2105,7 @@ var IPython = (function (IPython) {
      */
     Notebook.prototype.create_checkpoint = function () {
         var url = utils.url_join_encode(
-            this.base_project_url,
+            this.base_url,
             'api/notebooks',
             this.notebook_path,
             this.notebook_name,
@@ -2192,7 +2192,7 @@ var IPython = (function (IPython) {
     Notebook.prototype.restore_checkpoint = function (checkpoint) {
         $([IPython.events]).trigger('notebook_restoring.Notebook', checkpoint);
         var url = utils.url_join_encode(
-            this.base_project_url,
+            this.base_url,
             'api/notebooks',
             this.notebook_path,
             this.notebook_name,
@@ -2240,7 +2240,7 @@ var IPython = (function (IPython) {
     Notebook.prototype.delete_checkpoint = function (checkpoint) {
         $([IPython.events]).trigger('notebook_restoring.Notebook', checkpoint);
         var url = utils.url_join_encode(
-            this.base_project_url,
+            this.base_url,
             'api/notebooks',
             this.notebook_path,
             this.notebook_name,

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -145,7 +145,7 @@ var IPython = (function (IPython) {
         };
 
         this.element.bind('collapse_pager', function (event, extrap) {
-            var time = (extrap != undefined) ? ((extrap.duration != undefined ) ? extrap.duration : 'fast') : 'fast';
+            var time = (extrap !== undefined) ? ((extrap.duration !== undefined ) ? extrap.duration : 'fast') : 'fast';
             collapse_time(time);
         });
 
@@ -158,7 +158,7 @@ var IPython = (function (IPython) {
         };
 
         this.element.bind('expand_pager', function (event, extrap) {
-            var time = (extrap != undefined) ? ((extrap.duration != undefined ) ? extrap.duration : 'fast') : 'fast';
+            var time = (extrap !== undefined) ? ((extrap.duration !== undefined ) ? extrap.duration : 'fast') : 'fast';
             expand_time(time);
         });
         
@@ -187,7 +187,7 @@ var IPython = (function (IPython) {
                 } else {
                     return "Unsaved changes will be lost.";
                 }
-            };
+            }
             // Null is the *only* return value that will make the browser not
             // pop up the "don't leave" dialog.
             return null;
@@ -219,7 +219,7 @@ var IPython = (function (IPython) {
      */
     Notebook.prototype.scroll_to_cell = function (cell_number, time) {
         var cells = this.get_cells();
-        var time = time || 0;
+        time = time || 0;
         cell_number = Math.min(cells.length-1,cell_number);
         cell_number = Math.max(0             ,cell_number);
         var scroll_value = cells[cell_number].element.position().top-cells[0].element.position().top ;
@@ -331,7 +331,7 @@ var IPython = (function (IPython) {
             result = ce.data('cell');
         }
         return result;
-    }
+    };
 
     /**
      * Get the cell below a given cell.
@@ -347,7 +347,7 @@ var IPython = (function (IPython) {
             result = this.get_cell(index+1);
         }
         return result;
-    }
+    };
 
     /**
      * Get the cell above a given cell.
@@ -365,7 +365,7 @@ var IPython = (function (IPython) {
             result = this.get_cell(index-1);
         }
         return result;
-    }
+    };
     
     /**
      * Get the numeric index of a given cell.
@@ -379,7 +379,7 @@ var IPython = (function (IPython) {
         this.get_cell_elements().filter(function (index) {
             if ($(this).data("cell") === cell) {
                 result = index;
-            };
+            }
         });
         return result;
     };
@@ -426,8 +426,8 @@ var IPython = (function (IPython) {
             return true;
         } else {
             return false;
-        };
-    }
+        }
+    };
 
     /**
      * Get the index of the currently selected cell.
@@ -440,7 +440,7 @@ var IPython = (function (IPython) {
         this.get_cell_elements().filter(function (index) {
             if ($(this).data("cell").selected === true) {
                 result = index;
-            };
+            }
         });
         return result;
     };
@@ -457,11 +457,11 @@ var IPython = (function (IPython) {
      */
     Notebook.prototype.select = function (index) {
         if (this.is_valid_cell_index(index)) {
-            var sindex = this.get_selected_index()
+            var sindex = this.get_selected_index();
             if (sindex !== null && index !== sindex) {
                 this.command_mode();
                 this.get_cell(sindex).unselect();
-            };
+            }
             var cell = this.get_cell(index);
             cell.select();
             if (cell.cell_type === 'heading') {
@@ -472,8 +472,8 @@ var IPython = (function (IPython) {
                 $([IPython.events]).trigger('selected_cell_type_changed.Notebook',
                     {'cell_type':cell.cell_type}
                 );
-            };
-        };
+            }
+        }
         return this;
     };
 
@@ -509,7 +509,7 @@ var IPython = (function (IPython) {
         this.get_cell_elements().filter(function (index) {
             if ($(this).data("cell").mode === 'edit') {
                 result = index;
-            };
+            }
         });
         return result;
     };
@@ -521,10 +521,10 @@ var IPython = (function (IPython) {
             var cell = this.get_cell(index);
             if (cell) {
                 cell.command_mode();
-            };
+            }
             this.mode = 'command';
             IPython.keyboard_manager.command_mode();
-        };
+        }
     };
 
     Notebook.prototype.edit_mode = function () {
@@ -537,7 +537,7 @@ var IPython = (function (IPython) {
             this.mode = 'edit';
             IPython.keyboard_manager.edit_mode();
             cell.edit_mode();
-        };
+        }
     };
 
     Notebook.prototype.focus_cell = function () {
@@ -566,9 +566,9 @@ var IPython = (function (IPython) {
                 this.select(i-1);
                 var cell = this.get_selected_cell();
                 cell.focus_cell();
-            };
+            }
             this.set_dirty(true);
-        };
+        }
         return this;
     };
 
@@ -591,8 +591,8 @@ var IPython = (function (IPython) {
                 this.select(i+1);
                 var cell = this.get_selected_cell();
                 cell.focus_cell();
-            };
-        };
+            }
+        }
         this.set_dirty();
         return this;
     };
@@ -632,10 +632,10 @@ var IPython = (function (IPython) {
                 this.select(i);
                 this.undelete_index = i;
                 this.undelete_below = false;
-            };
+            }
             $([IPython.events]).trigger('delete.Cell', {'cell': cell, 'index': i});
             this.set_dirty(true);
-        };
+        }
         return this;
     };
 
@@ -673,7 +673,7 @@ var IPython = (function (IPython) {
             this.undelete_index = null;
         }
         $('#undelete_cell').addClass('disabled');
-    }
+    };
 
     /**
      * Insert a cell so that after insertion the cell is at given index.
@@ -691,8 +691,8 @@ var IPython = (function (IPython) {
     Notebook.prototype.insert_cell_at_index = function(type, index){
 
         var ncells = this.ncells();
-        var index = Math.min(index,ncells);
-            index = Math.max(index,0);
+        index = Math.min(index,ncells);
+        index = Math.max(index,0);
         var cell = null;
 
         if (ncells === 0 || this.is_valid_cell_index(index) || index === ncells) {
@@ -832,8 +832,8 @@ var IPython = (function (IPython) {
                 source_element.remove();
                 this.select(i);
                 this.set_dirty(true);
-            };
-        };
+            }
+        }
     };
 
     /**
@@ -852,7 +852,7 @@ var IPython = (function (IPython) {
                 var text = source_cell.get_text();
                 if (text === source_cell.placeholder) {
                     text = '';
-                };
+                }
                 // We must show the editor before setting its contents
                 target_cell.unrender();
                 target_cell.set_text(text);
@@ -865,8 +865,8 @@ var IPython = (function (IPython) {
                     target_cell.render();
                 }
                 this.set_dirty(true);
-            };
-        };
+            }
+        }
     };
 
     /**
@@ -886,7 +886,7 @@ var IPython = (function (IPython) {
                 var text = source_cell.get_text();
                 if (text === source_cell.placeholder) {
                     text = '';
-                };
+                }
                 // We must show the editor before setting its contents
                 target_cell.unrender();
                 target_cell.set_text(text);
@@ -896,8 +896,8 @@ var IPython = (function (IPython) {
                 source_element.remove();
                 this.select(i);
                 this.set_dirty(true);
-            };
-        };
+            }
+        }
     };
 
     /**
@@ -921,7 +921,7 @@ var IPython = (function (IPython) {
                 var text = source_cell.get_text();
                 if (text === source_cell.placeholder) {
                     text = '';
-                };
+                }
                 // We must show the editor before setting its contents
                 target_cell.set_level(level);
                 target_cell.unrender();
@@ -934,12 +934,12 @@ var IPython = (function (IPython) {
                 if ((source_cell instanceof IPython.TextCell) && source_cell.rendered) {
                     target_cell.render();
                 }
-            };
+            }
             this.set_dirty(true);
             $([IPython.events]).trigger('selected_cell_type_changed.Notebook',
                 {'cell_type':'heading',level:level}
             );
-        };
+        }
     };
 
 
@@ -960,7 +960,7 @@ var IPython = (function (IPython) {
             $('#paste_cell_below').removeClass('disabled')
                 .on('click', function () {that.paste_cell_below();});
             this.paste_enabled = true;
-        };
+        }
     };
 
     /**
@@ -974,7 +974,7 @@ var IPython = (function (IPython) {
             $('#paste_cell_above').addClass('disabled').off('click');
             $('#paste_cell_below').addClass('disabled').off('click');
             this.paste_enabled = false;
-        };
+        }
     };
 
     /**
@@ -985,7 +985,7 @@ var IPython = (function (IPython) {
     Notebook.prototype.cut_cell = function () {
         this.copy_cell();
         this.delete_cell();
-    }
+    };
 
     /**
      * Copy a cell.
@@ -1011,7 +1011,7 @@ var IPython = (function (IPython) {
             var old_cell = this.get_next_cell(new_cell);
             this.delete_cell(this.find_cell_index(old_cell));
             this.select(this.find_cell_index(new_cell));
-        };
+        }
     };
 
     /**
@@ -1025,7 +1025,7 @@ var IPython = (function (IPython) {
             var new_cell = this.insert_cell_above(cell_data.cell_type);
             new_cell.fromJSON(cell_data);
             new_cell.focus_cell();
-        };
+        }
     };
 
     /**
@@ -1039,7 +1039,7 @@ var IPython = (function (IPython) {
             var new_cell = this.insert_cell_below(cell_data.cell_type);
             new_cell.fromJSON(cell_data);
             new_cell.focus_cell();
-        };
+        }
     };
 
     // Split/merge
@@ -1070,7 +1070,7 @@ var IPython = (function (IPython) {
                 new_cell.unrender();
                 new_cell.set_text(texta);
             }
-        };
+        }
     };
 
     /**
@@ -1104,10 +1104,10 @@ var IPython = (function (IPython) {
                     // that of the original selected cell;
                     cell.render();
                 }
-            };
+            }
             this.delete_cell(index-1);
             this.select(this.find_cell_index(cell));
-        };
+        }
     };
 
     /**
@@ -1141,10 +1141,10 @@ var IPython = (function (IPython) {
                     // that of the original selected cell;
                     cell.render();
                 }
-            };
+            }
             this.delete_cell(index+1);
             this.select(this.find_cell_index(cell));
-        };
+        }
     };
 
 
@@ -1364,8 +1364,8 @@ var IPython = (function (IPython) {
             var cell = this.get_cell(i);
             if (cell instanceof IPython.CodeCell) {
                 cell.set_kernel(this.session.kernel);
-            };
-        };  
+            }
+        }
     };
     
     /**
@@ -1406,7 +1406,7 @@ var IPython = (function (IPython) {
         this.command_mode();
         cell.focus_cell();
         this.set_dirty(true);
-    }
+    };
 
     /**
      * Execute or render cell outputs and insert a new cell below.
@@ -1502,7 +1502,7 @@ var IPython = (function (IPython) {
         for (var i=start; i<end; i++) {
             this.select(i);
             this.execute_cell();
-        };
+        }
     };
 
     // Persistance and loading
@@ -1537,11 +1537,11 @@ var IPython = (function (IPython) {
      */
     Notebook.prototype.test_notebook_name = function (nbname) {
         nbname = nbname || '';
-        if (this.notebook_name_blacklist_re.test(nbname) == false && nbname.length>0) {
+        if (nbname.length>0 && !this.notebook_name_blacklist_re.test(nbname)) {
             return true;
         } else {
             return false;
-        };
+        }
     };
 
     /**
@@ -1559,7 +1559,7 @@ var IPython = (function (IPython) {
         for (i=0; i<ncells; i++) {
             // Always delete cell 0 as they get renumbered as they are deleted.
             this.delete_cell(0);
-        };
+        }
         // Save the metadata and name.
         this.metadata = content.metadata;
         this.notebook_name = data.name;
@@ -1583,8 +1583,8 @@ var IPython = (function (IPython) {
 
                 new_cell = this.insert_cell_at_index(cell_data.cell_type, i);
                 new_cell.fromJSON(cell_data);
-            };
-        };
+            }
+        }
         if (content.worksheets.length > 1) {
             IPython.dialog.modal({
                 title : "Multiple worksheets",
@@ -1612,7 +1612,7 @@ var IPython = (function (IPython) {
         var cell_array = new Array(ncells);
         for (var i=0; i<ncells; i++) {
             cell_array[i] = cells[i].toJSON();
-        };
+        }
         var data = {
             // Only handle 1 worksheet for now.
             worksheets : [{
@@ -1648,7 +1648,7 @@ var IPython = (function (IPython) {
         } else {
             this.autosave_timer = null;
             $([IPython.events]).trigger("autosave_disabled.Notebook");
-        };
+        }
     };
     
     /**
@@ -1707,7 +1707,7 @@ var IPython = (function (IPython) {
         if (this._checkpoint_after_save) {
             this.create_checkpoint();
             this._checkpoint_after_save = false;
-        };
+        }
     };
     
     /**
@@ -1842,19 +1842,18 @@ var IPython = (function (IPython) {
 
     
     Notebook.prototype.rename_success = function (json, status, xhr) {
-        this.notebook_name = json.name;
-        var name = this.notebook_name;
+        var name = this.notebook_name = json.name;
         var path = json.path;
         this.session.rename_notebook(name, path);
         $([IPython.events]).trigger('notebook_renamed.Notebook', json);
-    }
+    };
 
     Notebook.prototype.rename_error = function (xhr, status, error) {
         var that = this;
         var dialog = $('<div/>').append(
             $("<p/>").addClass("rename-message")
             .text('This notebook name already exists.')
-        )
+        );
         $([IPython.events]).trigger('notebook_rename_failed.Notebook', [xhr, status, error]);
         IPython.dialog.modal({
             title: "Notebook Rename Error!",
@@ -1878,7 +1877,7 @@ var IPython = (function (IPython) {
                 that.find('input[type="text"]').focus();
             }
         });
-    }
+    };
 
     /**
      * Request a notebook's data from the server.
@@ -1928,7 +1927,7 @@ var IPython = (function (IPython) {
         } else {
             this.select(0);
             this.command_mode();
-        };
+        }
         this.set_dirty(false);
         this.scroll_to_top();
         if (data.orig_nbformat !== undefined && data.nbformat !== data.orig_nbformat) {
@@ -1953,7 +1952,7 @@ var IPython = (function (IPython) {
             var this_vs = 'v' + data.nbformat + '.' + this.nbformat_minor;
             var msg = "This notebook is version " + orig_vs + ", but we only fully support up to " +
             this_vs + ".  You can still work with this notebook, but some features " +
-            "introduced in later notebook versions may not be available."
+            "introduced in later notebook versions may not be available.";
 
             IPython.dialog.modal({
                 title : "Newer Notebook",
@@ -1969,7 +1968,7 @@ var IPython = (function (IPython) {
         
         // Create the session after the notebook is completely loaded to prevent
         // code execution upon loading, which is a security risk.
-        if (this.session == null) {
+        if (this.session === null) {
             this.start_session();
         }
         // load our checkpoint list
@@ -1994,10 +1993,11 @@ var IPython = (function (IPython) {
      */
     Notebook.prototype.load_notebook_error = function (xhr, status, error) {
         $([IPython.events]).trigger('notebook_load_failed.Notebook', [xhr, status, error]);
+        var msg;
         if (xhr.status === 400) {
-            var msg = error;
+            msg = error;
         } else if (xhr.status === 500) {
-            var msg = "An unknown error occurred while loading this notebook. " +
+            msg = "An unknown error occurred while loading this notebook. " +
             "This version can load notebook formats " +
             "v" + this.nbformat + " or earlier.";
         }
@@ -2008,7 +2008,7 @@ var IPython = (function (IPython) {
                 "OK": {}
             }
         });
-    }
+    };
 
     /*********************  checkpoint-related  *********************/
     
@@ -2073,7 +2073,7 @@ var IPython = (function (IPython) {
      * @param {jqXHR} xhr jQuery Ajax object
      */
     Notebook.prototype.list_checkpoints_success = function (data, status, xhr) {
-        var data = $.parseJSON(data);
+        data = $.parseJSON(data);
         this.checkpoints = data;
         if (data.length) {
             this.last_checkpoint = data[data.length - 1];
@@ -2124,7 +2124,7 @@ var IPython = (function (IPython) {
      * @param {jqXHR} xhr jQuery Ajax object
      */
     Notebook.prototype.create_checkpoint_success = function (data, status, xhr) {
-        var data = $.parseJSON(data);
+        data = $.parseJSON(data);
         this.add_checkpoint(data);
         $([IPython.events]).trigger('checkpoint_created.Notebook', data);
     };
@@ -2143,7 +2143,7 @@ var IPython = (function (IPython) {
     
     Notebook.prototype.restore_checkpoint_dialog = function (checkpoint) {
         var that = this;
-        var checkpoint = checkpoint || this.last_checkpoint;
+        checkpoint = checkpoint || this.last_checkpoint;
         if ( ! checkpoint ) {
             console.log("restore dialog, but no checkpoint to restore to!");
             return;
@@ -2178,7 +2178,7 @@ var IPython = (function (IPython) {
                 Cancel : {}
                 }
         });
-    }
+    };
     
     /**
      * Restore the notebook to a checkpoint state.

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1802,7 +1802,10 @@ var IPython = (function (IPython) {
 
     Notebook.prototype.rename = function (nbname) {
         var that = this;
-        var data = {name: nbname + '.ipynb'};
+        if (!nbname.match(/\.ipynb$/)) {
+            nbname = nbname + ".ipynb";
+        }
+        var data = {name: nbname};
         var settings = {
             processData : false,
             cache : false,

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -23,10 +23,10 @@ var IPython = (function (IPython) {
      * @param {Object} [options] A config object
      */
     var Notebook = function (selector, options) {
-        var options = options || {};
-        this._baseProjectUrl = options.baseProjectUrl;
-        this.notebook_path = options.notebookPath;
-        this.notebook_name = options.notebookName;
+        this.options = options = options || {};
+        this.base_project_url = options.base_project_url;
+        this.notebook_path = options.notebook_path;
+        this.notebook_name = options.notebook_name;
         this.element = $(selector);
         this.element.scroll();
         this.element.data("notebook", this);
@@ -53,8 +53,8 @@ var IPython = (function (IPython) {
         // single worksheet for now
         this.worksheet_metadata = {};
         this.notebook_name_blacklist_re = /[\/\\:]/;
-        this.nbformat = 3 // Increment this when changing the nbformat
-        this.nbformat_minor = 0 // Increment this when changing the nbformat
+        this.nbformat = 3; // Increment this when changing the nbformat
+        this.nbformat_minor = 0; // Increment this when changing the nbformat
         this.style();
         this.create_elements();
         this.bind_events();
@@ -69,24 +69,6 @@ var IPython = (function (IPython) {
         $('div#notebook').addClass('border-box-sizing');
     };
 
-    /**
-     * Get the root URL of the notebook server.
-     * 
-     * @method baseProjectUrl
-     * @return {String} The base project URL
-     */
-    Notebook.prototype.baseProjectUrl = function() {
-        return this._baseProjectUrl || $('body').data('baseProjectUrl');
-    };
-
-    Notebook.prototype.notebookName = function() {
-        return $('body').data('notebookName');
-    };
-    
-    Notebook.prototype.notebookPath = function() {
-        return $('body').data('notebookPath');
-    };
-    
     /**
      * Create an HTML and CSS representation of the notebook.
      * 
@@ -1365,7 +1347,7 @@ var IPython = (function (IPython) {
      * @method start_session
      */
     Notebook.prototype.start_session = function () {
-        this.session = new IPython.Session(this.notebook_name, this.notebook_path, this);
+        this.session = new IPython.Session(this, this.options);
         this.session.start($.proxy(this._session_started, this));
     };
 
@@ -1529,7 +1511,7 @@ var IPython = (function (IPython) {
      * Getter method for this notebook's name.
      * 
      * @method get_notebook_name
-     * @return {String} This notebook's name
+     * @return {String} This notebook's name (excluding file extension)
      */
     Notebook.prototype.get_notebook_name = function () {
         var nbname = this.notebook_name.substring(0,this.notebook_name.length-6);
@@ -1701,7 +1683,7 @@ var IPython = (function (IPython) {
         }
         $([IPython.events]).trigger('notebook_saving.Notebook');
         var url = utils.url_join_encode(
-            this._baseProjectUrl,
+            this.base_project_url,
             'api/notebooks',
             this.notebook_path,
             this.notebook_name
@@ -1762,7 +1744,7 @@ var IPython = (function (IPython) {
 
     Notebook.prototype.new_notebook = function(){
         var path = this.notebook_path;
-        var base_project_url = this._baseProjectUrl;
+        var base_project_url = this.base_project_url;
         var settings = {
             processData : false,
             cache : false,
@@ -1793,7 +1775,7 @@ var IPython = (function (IPython) {
 
     Notebook.prototype.copy_notebook = function(){
         var path = this.notebook_path;
-        var base_project_url = this._baseProjectUrl;
+        var base_project_url = this.base_project_url;
         var settings = {
             processData : false,
             cache : false,
@@ -1833,7 +1815,7 @@ var IPython = (function (IPython) {
         };
         $([IPython.events]).trigger('rename_notebook.Notebook', data);
         var url = utils.url_join_encode(
-            this._baseProjectUrl,
+            this.base_project_url,
             'api/notebooks',
             this.notebook_path,
             this.notebook_name
@@ -1850,7 +1832,7 @@ var IPython = (function (IPython) {
             dataType: "json",
         };
         var url = utils.url_join_encode(
-            this._baseProjectUrl,
+            this.base_project_url,
             'api/notebooks',
             this.notebook_path,
             this.notebook_name
@@ -1919,7 +1901,7 @@ var IPython = (function (IPython) {
         };
         $([IPython.events]).trigger('notebook_loading.Notebook');
         var url = utils.url_join_encode(
-            this._baseProjectUrl,
+            this.base_project_url,
             'api/notebooks',
             this.notebook_path,
             this.notebook_name
@@ -2069,7 +2051,7 @@ var IPython = (function (IPython) {
      */
     Notebook.prototype.list_checkpoints = function () {
         var url = utils.url_join_encode(
-            this._baseProjectUrl,
+            this.base_project_url,
             'api/notebooks',
             this.notebook_path,
             this.notebook_name,
@@ -2120,9 +2102,9 @@ var IPython = (function (IPython) {
      */
     Notebook.prototype.create_checkpoint = function () {
         var url = utils.url_join_encode(
-            this._baseProjectUrl,
+            this.base_project_url,
             'api/notebooks',
-            this.notebookPath(),
+            this.notebook_path,
             this.notebook_name,
             'checkpoints'
         );
@@ -2207,9 +2189,9 @@ var IPython = (function (IPython) {
     Notebook.prototype.restore_checkpoint = function (checkpoint) {
         $([IPython.events]).trigger('notebook_restoring.Notebook', checkpoint);
         var url = utils.url_join_encode(
-            this._baseProjectUrl,
+            this.base_project_url,
             'api/notebooks',
-            this.notebookPath(),
+            this.notebook_path,
             this.notebook_name,
             'checkpoints',
             checkpoint
@@ -2255,9 +2237,9 @@ var IPython = (function (IPython) {
     Notebook.prototype.delete_checkpoint = function (checkpoint) {
         $([IPython.events]).trigger('notebook_restoring.Notebook', checkpoint);
         var url = utils.url_join_encode(
-            this._baseProjectUrl,
+            this.base_project_url,
             'api/notebooks',
-            this.notebookPath(),
+            this.notebook_path,
             this.notebook_name,
             'checkpoints',
             checkpoint

--- a/IPython/html/static/notebook/js/savewidget.js
+++ b/IPython/html/static/notebook/js/savewidget.js
@@ -127,7 +127,7 @@ var IPython = (function (IPython) {
     
     SaveWidget.prototype.update_address_bar = function(){
         var nbname = IPython.notebook.notebook_name;
-        var path = IPython.notebook.notebookPath();
+        var path = IPython.notebook.notebook_path;
         var state = {path : utils.url_join_encode(path, nbname)};
         window.history.replaceState(state, "", utils.url_join_encode(
             "/notebooks",

--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -25,12 +25,12 @@ var IPython = (function (IPython) {
      * A Kernel Class to communicate with the Python kernel
      * @Class Kernel
      */
-    var Kernel = function (base_url) {
+    var Kernel = function (kernel_service_url) {
         this.kernel_id = null;
         this.shell_channel = null;
         this.iopub_channel = null;
         this.stdin_channel = null;
-        this.base_url = base_url;
+        this.kernel_service_url = kernel_service_url;
         this.running = false;
         this.username = "username";
         this.session_id = utils.uuid();
@@ -94,8 +94,7 @@ var IPython = (function (IPython) {
         params = params || {};
         if (!this.running) {
             var qs = $.param(params);
-            var url = this.base_url + '?' + qs;
-            $.post(url,
+            $.post(utils.url_join_encode(this.kernel_service_url) + '?' + qs,
                 $.proxy(this._kernel_started, this),
                 'json'
             );
@@ -114,8 +113,7 @@ var IPython = (function (IPython) {
         $([IPython.events]).trigger('status_restarting.Kernel', {kernel: this});
         if (this.running) {
             this.stop_channels();
-            var url = utils.url_join_encode(this.kernel_url, "restart");
-            $.post(url,
+            $.post(utils.url_join_encode(this.kernel_url, "restart"),
                 $.proxy(this._kernel_started, this),
                 'json'
             );
@@ -133,8 +131,10 @@ var IPython = (function (IPython) {
             var prot = location.protocol.replace('http', 'ws') + "//";
             ws_url = prot + location.host + ws_url;
         }
-        this.ws_url = ws_url;
-        this.kernel_url = utils.url_join_encode(this.base_url, this.kernel_id);
+        var parsed = utils.parse_url(ws_url);
+        this.ws_host = parsed.protocol + "//" + parsed.host;
+        this.kernel_url = utils.url_path_join(this.kernel_service_url, this.kernel_id);
+        this.ws_url = utils.url_path_join(parsed.pathname, this.kernel_url);
         this.start_channels();
     };
 
@@ -155,12 +155,18 @@ var IPython = (function (IPython) {
     Kernel.prototype.start_channels = function () {
         var that = this;
         this.stop_channels();
-        var ws_url = this.ws_url + this.kernel_url;
-        console.log("Starting WebSockets:", ws_url);
-        this.shell_channel = new this.WebSocket(ws_url + "/shell");
-        this.stdin_channel = new this.WebSocket(ws_url + "/stdin");
-        this.iopub_channel = new this.WebSocket(ws_url + "/iopub");
+        console.log("Starting WebSockets:", this.ws_host + this.ws_url);
+        this.shell_channel = new this.WebSocket(
+            this.ws_host + utils.url_join_encode(this.ws_url, "shell")
+        );
+        this.stdin_channel = new this.WebSocket(
+            this.ws_host + utils.url_join_encode(this.ws_url, "stdin")
+        );
+        this.iopub_channel = new this.WebSocket(
+            this.ws_host + utils.url_join_encode(this.ws_url, "iopub")
+        );
         
+        var ws_host_url = this.ws_host + this.ws_url;
         var already_called_onclose = false; // only alert once
         var ws_closed_early = function(evt){
             if (already_called_onclose){
@@ -168,7 +174,7 @@ var IPython = (function (IPython) {
             }
             already_called_onclose = true;
             if ( ! evt.wasClean ){
-                that._websocket_closed(ws_url, true);
+                that._websocket_closed(ws_host_url, true);
             }
         };
         var ws_closed_late = function(evt){
@@ -177,7 +183,7 @@ var IPython = (function (IPython) {
             }
             already_called_onclose = true;
             if ( ! evt.wasClean ){
-                that._websocket_closed(ws_url, false);
+                that._websocket_closed(ws_host_url, false);
             }
         };
         var channels = [this.shell_channel, this.iopub_channel, this.stdin_channel];
@@ -387,7 +393,7 @@ var IPython = (function (IPython) {
     Kernel.prototype.interrupt = function () {
         if (this.running) {
             $([IPython.events]).trigger('status_interrupting.Kernel', {kernel: this});
-            $.post(this.kernel_url + "/interrupt");
+            $.post(utils.url_join_encode(this.kernel_url, "interrupt"));
         }
     };
 
@@ -399,7 +405,7 @@ var IPython = (function (IPython) {
                 cache : false,
                 type : "DELETE"
             };
-            $.ajax(this.kernel_url, settings);
+            $.ajax(utils.url_join_encode(this.kernel_url), settings);
         }
     };
 

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -21,7 +21,7 @@ var IPython = (function (IPython) {
         this.name = notebook.notebook_name;
         this.path = notebook.notebook_path;
         this.base_url = notebook.base_url;
-        this.base_kernel_url = options.base_kernel_url || utils.get_data("baseKernelUrl");
+        this.base_kernel_url = options.base_kernel_url || utils.get_body_data("baseKernelUrl");
     };
     
     Session.prototype.start = function(callback) {

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -20,7 +20,7 @@ var IPython = (function (IPython) {
         this.notebook = notebook;
         this.name = notebook.notebook_name;
         this.path = notebook.notebook_path;
-        this.base_project_url = notebook.base_project_url;
+        this.base_url = notebook.base_url;
         this.base_kernel_url = options.base_kernel_url || utils.get_data("baseKernelUrl");
     };
     
@@ -45,7 +45,7 @@ var IPython = (function (IPython) {
                 }
             },
         };
-        var url = utils.url_join_encode(this.base_project_url, 'api/sessions');
+        var url = utils.url_join_encode(this.base_url, 'api/sessions');
         $.ajax(url, settings);
     };
     
@@ -65,7 +65,7 @@ var IPython = (function (IPython) {
             data: JSON.stringify(model),
             dataType : "json",
         };
-        var url = utils.url_join_encode(this.base_project_url, 'api/sessions', this.id);
+        var url = utils.url_join_encode(this.base_url, 'api/sessions', this.id);
         $.ajax(url, settings);
     };
     
@@ -77,7 +77,7 @@ var IPython = (function (IPython) {
             dataType : "json",
         };
         this.kernel.running = false;
-        var url = utils.url_join_encode(this.base_project_url, 'api/sessions', this.id);
+        var url = utils.url_join_encode(this.base_url, 'api/sessions', this.id);
         $.ajax(url, settings);
     };
     

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -89,8 +89,8 @@ var IPython = (function (IPython) {
      */
     Session.prototype._handle_start_success = function (data, status, xhr) {
         this.id = data.id;
-        var base_url = utils.url_join_encode(this.base_kernel_url, "api/kernels");
-        this.kernel = new IPython.Kernel(base_url);
+        var kernel_service_url = utils.url_path_join(this.base_kernel_url, "api/kernels");
+        this.kernel = new IPython.Kernel(kernel_service_url);
         this.kernel._kernel_started(data.kernel);
     };
     

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -14,13 +14,14 @@ var IPython = (function (IPython) {
     
     var utils = IPython.utils;
     
-    var Session = function(notebook_name, notebook_path, notebook){
+    var Session = function(notebook, options){
         this.kernel = null;
         this.id = null;
-        this.name = notebook_name;
-        this.path = notebook_path;
         this.notebook = notebook;
-        this._baseProjectUrl = notebook.baseProjectUrl();
+        this.name = notebook.notebook_name;
+        this.path = notebook.notebook_path;
+        this.base_project_url = notebook.base_project_url;
+        this.base_kernel_url = options.base_kernel_url || utils.get_data("baseKernelUrl");
     };
     
     Session.prototype.start = function(callback) {
@@ -44,7 +45,7 @@ var IPython = (function (IPython) {
                 }
             },
         };
-        var url = utils.url_join_encode(this._baseProjectUrl, 'api/sessions');
+        var url = utils.url_join_encode(this.base_project_url, 'api/sessions');
         $.ajax(url, settings);
     };
     
@@ -64,7 +65,7 @@ var IPython = (function (IPython) {
             data: JSON.stringify(model),
             dataType : "json",
         };
-        var url = utils.url_join_encode(this._baseProjectUrl, 'api/sessions', this.id);
+        var url = utils.url_join_encode(this.base_project_url, 'api/sessions', this.id);
         $.ajax(url, settings);
     };
     
@@ -76,7 +77,7 @@ var IPython = (function (IPython) {
             dataType : "json",
         };
         this.kernel.running = false;
-        var url = utils.url_join_encode(this._baseProjectUrl, 'api/sessions', this.id);
+        var url = utils.url_join_encode(this.base_project_url, 'api/sessions', this.id);
         $.ajax(url, settings);
     };
     
@@ -88,7 +89,7 @@ var IPython = (function (IPython) {
      */
     Session.prototype._handle_start_success = function (data, status, xhr) {
         this.id = data.id;
-        var base_url = utils.url_path_join($('body').data('baseKernelUrl'), "api/kernels");
+        var base_url = utils.url_join_encode(this.base_kernel_url, "api/kernels");
         this.kernel = new IPython.Kernel(base_url);
         this.kernel._kernel_started(data.kernel);
     };

--- a/IPython/html/static/tree/js/clusterlist.js
+++ b/IPython/html/static/tree/js/clusterlist.js
@@ -14,17 +14,17 @@ var IPython = (function (IPython) {
     
     var utils = IPython.utils;
 
-    var ClusterList = function (selector) {
+    var ClusterList = function (selector, options) {
         this.selector = selector;
         if (this.selector !== undefined) {
             this.element = $(selector);
             this.style();
             this.bind_events();
         }
-    };
-
-    ClusterList.prototype.baseProjectUrl = function(){
-        return this._baseProjectUrl || $('body').data('baseProjectUrl');
+        options = options || {};
+        this.options = options;
+        this.base_project_url = options.base_project_url || utils.get_data("baseProjectUrl");
+        this.notebook_path = options.notebook_path || utils.get_data("notebookPath");
     };
 
     ClusterList.prototype.style = function () {
@@ -51,7 +51,7 @@ var IPython = (function (IPython) {
             dataType : "json",
             success : $.proxy(this.load_list_success, this)
         };
-        var url = utils.url_join_encode(this.baseProjectUrl(), 'clusters');
+        var url = utils.url_join_encode(this.base_project_url, 'clusters');
         $.ajax(url, settings);
     };
 
@@ -65,7 +65,7 @@ var IPython = (function (IPython) {
         var len = data.length;
         for (var i=0; i<len; i++) {
             var element = $('<div/>');
-            var item = new ClusterItem(element);
+            var item = new ClusterItem(element, this.options);
             item.update_state(data[i]);
             element.data('item', item);
             this.element.append(element);
@@ -73,16 +73,13 @@ var IPython = (function (IPython) {
     };
 
 
-    var ClusterItem = function (element) {
+    var ClusterItem = function (element, options) {
         this.element = $(element);
+        this.base_project_url = options.base_project_url || utils.get_data("baseProjectUrl");
+        this.notebook_path = options.notebook_path || utils.get_data("notebookPath");
         this.data = null;
         this.style();
     };
-
-    ClusterItem.prototype.baseProjectUrl = function(){
-        return this._baseProjectUrl || $('body').data('baseProjectUrl');
-    };
-
 
     ClusterItem.prototype.style = function () {
         this.element.addClass('list_item').addClass("row-fluid");
@@ -138,7 +135,7 @@ var IPython = (function (IPython) {
                 };
                 status_col.text('starting');
                 var url = utils.url_join_encode(
-                    that.baseProjectUrl(),
+                    that.base_project_url,
                     'clusters',
                     that.data.profile,
                     'start'
@@ -180,7 +177,7 @@ var IPython = (function (IPython) {
             };
             status_col.text('stopping');
             var url = utils.url_join_encode(
-                that.baseProjectUrl(),
+                that.base_project_url,
                 'clusters',
                 that.data.profile,
                 'stop'

--- a/IPython/html/static/tree/js/clusterlist.js
+++ b/IPython/html/static/tree/js/clusterlist.js
@@ -23,7 +23,7 @@ var IPython = (function (IPython) {
         }
         options = options || {};
         this.options = options;
-        this.base_project_url = options.base_project_url || utils.get_data("baseProjectUrl");
+        this.base_url = options.base_url || utils.get_data("baseUrl");
         this.notebook_path = options.notebook_path || utils.get_data("notebookPath");
     };
 
@@ -51,7 +51,7 @@ var IPython = (function (IPython) {
             dataType : "json",
             success : $.proxy(this.load_list_success, this)
         };
-        var url = utils.url_join_encode(this.base_project_url, 'clusters');
+        var url = utils.url_join_encode(this.base_url, 'clusters');
         $.ajax(url, settings);
     };
 
@@ -75,7 +75,7 @@ var IPython = (function (IPython) {
 
     var ClusterItem = function (element, options) {
         this.element = $(element);
-        this.base_project_url = options.base_project_url || utils.get_data("baseProjectUrl");
+        this.base_url = options.base_url || utils.get_data("baseUrl");
         this.notebook_path = options.notebook_path || utils.get_data("notebookPath");
         this.data = null;
         this.style();
@@ -135,7 +135,7 @@ var IPython = (function (IPython) {
                 };
                 status_col.text('starting');
                 var url = utils.url_join_encode(
-                    that.base_project_url,
+                    that.base_url,
                     'clusters',
                     that.data.profile,
                     'start'
@@ -177,7 +177,7 @@ var IPython = (function (IPython) {
             };
             status_col.text('stopping');
             var url = utils.url_join_encode(
-                that.base_project_url,
+                that.base_url,
                 'clusters',
                 that.data.profile,
                 'stop'

--- a/IPython/html/static/tree/js/clusterlist.js
+++ b/IPython/html/static/tree/js/clusterlist.js
@@ -23,8 +23,8 @@ var IPython = (function (IPython) {
         }
         options = options || {};
         this.options = options;
-        this.base_url = options.base_url || utils.get_data("baseUrl");
-        this.notebook_path = options.notebook_path || utils.get_data("notebookPath");
+        this.base_url = options.base_url || utils.get_body_data("baseUrl");
+        this.notebook_path = options.notebook_path || utils.get_body_data("notebookPath");
     };
 
     ClusterList.prototype.style = function () {
@@ -75,8 +75,8 @@ var IPython = (function (IPython) {
 
     var ClusterItem = function (element, options) {
         this.element = $(element);
-        this.base_url = options.base_url || utils.get_data("baseUrl");
-        this.notebook_path = options.notebook_path || utils.get_data("notebookPath");
+        this.base_url = options.base_url || utils.get_body_data("baseUrl");
+        this.notebook_path = options.notebook_path || utils.get_body_data("notebookPath");
         this.data = null;
         this.style();
     };

--- a/IPython/html/static/tree/js/main.js
+++ b/IPython/html/static/tree/js/main.js
@@ -19,7 +19,7 @@ $(document).ready(function () {
     });
     
     var opts = {
-        base_project_url : IPython.utils.get_data("baseProjectUrl"),
+        base_url : IPython.utils.get_data("baseUrl"),
         notebook_path : IPython.utils.get_data("notebookPath"),
     };
     IPython.notebook_list = new IPython.NotebookList('#notebook_list', opts);

--- a/IPython/html/static/tree/js/main.js
+++ b/IPython/html/static/tree/js/main.js
@@ -19,8 +19,8 @@ $(document).ready(function () {
     });
     
     var opts = {
-        base_url : IPython.utils.get_data("baseUrl"),
-        notebook_path : IPython.utils.get_data("notebookPath"),
+        base_url : IPython.utils.get_body_data("baseUrl"),
+        notebook_path : IPython.utils.get_body_data("notebookPath"),
     };
     IPython.notebook_list = new IPython.NotebookList('#notebook_list', opts);
     IPython.cluster_list = new IPython.ClusterList('#cluster_list', opts);

--- a/IPython/html/static/tree/js/main.js
+++ b/IPython/html/static/tree/js/main.js
@@ -15,12 +15,16 @@ $(document).ready(function () {
     IPython.page = new IPython.Page();
 
     $('#new_notebook').button().click(function (e) {
-        IPython.notebook_list.new_notebook($('body').data('baseProjectUrl'))
+        IPython.notebook_list.new_notebook()
     });
-
-    IPython.notebook_list = new IPython.NotebookList('#notebook_list');
-    IPython.cluster_list = new IPython.ClusterList('#cluster_list');
-    IPython.login_widget = new IPython.LoginWidget('#login_widget');
+    
+    var opts = {
+        base_project_url : IPython.utils.get_data("baseProjectUrl"),
+        notebook_path : IPython.utils.get_data("notebookPath"),
+    };
+    IPython.notebook_list = new IPython.NotebookList('#notebook_list', opts);
+    IPython.cluster_list = new IPython.ClusterList('#cluster_list', opts);
+    IPython.login_widget = new IPython.LoginWidget('#login_widget', opts);
 
     var interval_id=0;
     // auto refresh every xx secondes, no need to be fast,

--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -14,7 +14,7 @@ var IPython = (function (IPython) {
     
     var utils = IPython.utils;
 
-    var NotebookList = function (selector) {
+    var NotebookList = function (selector, options) {
         this.selector = selector;
         if (this.selector !== undefined) {
             this.element = $(selector);
@@ -23,16 +23,10 @@ var IPython = (function (IPython) {
         }
         this.notebooks_list = [];
         this.sessions = {};
+        this.base_project_url = options.base_project_url || utils.get_data("baseProjectUrl");
+        this.notebook_path = options.notebook_path || utils.get_data("notebookPath");
     };
 
-    NotebookList.prototype.baseProjectUrl = function () {
-        return $('body').data('baseProjectUrl');
-    };
-
-    NotebookList.prototype.notebookPath = function() {
-        return $('body').data('notebookPath');
-    };
-    
     NotebookList.prototype.style = function () {
         $('#notebook_toolbar').addClass('list_toolbar');
         $('#drag_info').addClass('toolbar_info');
@@ -112,7 +106,7 @@ var IPython = (function (IPython) {
             dataType : "json",
             success : $.proxy(that.sessions_loaded, this)
         };
-        var url = this.baseProjectUrl() + 'api/sessions';
+        var url = utils.url_join_encode(this.base_project_url, 'api/sessions');
         $.ajax(url,settings);
     };
 
@@ -152,10 +146,10 @@ var IPython = (function (IPython) {
         };
 
         var url = utils.url_join_encode(
-                this.baseProjectUrl(),
+                this.base_project_url,
                 'api',
                 'notebooks',
-                this.notebookPath()
+                this.notebook_path
         );
         $.ajax(url, settings);
     };
@@ -175,7 +169,7 @@ var IPython = (function (IPython) {
             span12.empty();
             span12.append($('<div style="margin:auto;text-align:center;color:grey"/>').text(message));
         }
-        var path = this.notebookPath();
+        var path = this.notebook_path;
         var offset = 0;
         if (path !== '') {
             item = this.new_notebook_item(0);
@@ -233,7 +227,7 @@ var IPython = (function (IPython) {
         item.find("a.item_link")
             .attr('href',
                 utils.url_join_encode(
-                    this.baseProjectUrl(),
+                    this.base_project_url,
                     "tree",
                     path,
                     name
@@ -250,7 +244,7 @@ var IPython = (function (IPython) {
         item.find("a.item_link")
             .attr('href',
                 utils.url_join_encode(
-                    this.baseProjectUrl(),
+                    this.base_project_url,
                     "notebooks",
                     path,
                     nbname
@@ -291,7 +285,7 @@ var IPython = (function (IPython) {
                     }
                 };
                 var url = utils.url_join_encode(
-                    that.baseProjectUrl(),
+                    that.base_project_url,
                     'api/sessions',
                     session
                 );
@@ -331,9 +325,9 @@ var IPython = (function (IPython) {
                                     }
                                 };
                                 var url = utils.url_join_encode(
-                                    notebooklist.baseProjectUrl(),
+                                    notebooklist.base_project_url,
                                     'api/notebooks',
-                                    notebooklist.notebookPath(),
+                                    notebooklist.notebook_path,
                                     nbname
                                 );
                                 $.ajax(url, settings);
@@ -357,7 +351,7 @@ var IPython = (function (IPython) {
                 if (nbname.slice(nbname.length-6, nbname.length) != ".ipynb") {
                     nbname = nbname + ".ipynb";
                 }
-                var path = that.notebookPath();
+                var path = that.notebook_path;
                 var nbdata = item.data('nbdata');
                 var content_type = 'application/json';
                 var model = {
@@ -380,9 +374,9 @@ var IPython = (function (IPython) {
                 };
 
                 var url = utils.url_join_encode(
-                    that.baseProjectUrl(),
+                    that.base_project_url,
                     'api/notebooks',
-                    that.notebookPath(),
+                    that.notebook_path,
                     nbname
                 );
                 $.ajax(url, settings);
@@ -402,8 +396,8 @@ var IPython = (function (IPython) {
 
 
     NotebookList.prototype.new_notebook = function(){
-        var path = this.notebookPath();
-        var base_project_url = this.baseProjectUrl();
+        var path = this.notebook_path;
+        var base_project_url = this.base_project_url;
         var settings = {
             processData : false,
             cache : false,

--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -23,8 +23,8 @@ var IPython = (function (IPython) {
         }
         this.notebooks_list = [];
         this.sessions = {};
-        this.base_url = options.base_url || utils.get_data("baseUrl");
-        this.notebook_path = options.notebook_path || utils.get_data("notebookPath");
+        this.base_url = options.base_url || utils.get_body_data("baseUrl");
+        this.notebook_path = options.notebook_path || utils.get_body_data("notebookPath");
     };
 
     NotebookList.prototype.style = function () {

--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -23,7 +23,7 @@ var IPython = (function (IPython) {
         }
         this.notebooks_list = [];
         this.sessions = {};
-        this.base_project_url = options.base_project_url || utils.get_data("baseProjectUrl");
+        this.base_url = options.base_url || utils.get_data("baseUrl");
         this.notebook_path = options.notebook_path || utils.get_data("notebookPath");
     };
 
@@ -106,7 +106,7 @@ var IPython = (function (IPython) {
             dataType : "json",
             success : $.proxy(that.sessions_loaded, this)
         };
-        var url = utils.url_join_encode(this.base_project_url, 'api/sessions');
+        var url = utils.url_join_encode(this.base_url, 'api/sessions');
         $.ajax(url,settings);
     };
 
@@ -146,7 +146,7 @@ var IPython = (function (IPython) {
         };
 
         var url = utils.url_join_encode(
-                this.base_project_url,
+                this.base_url,
                 'api',
                 'notebooks',
                 this.notebook_path
@@ -227,7 +227,7 @@ var IPython = (function (IPython) {
         item.find("a.item_link")
             .attr('href',
                 utils.url_join_encode(
-                    this.base_project_url,
+                    this.base_url,
                     "tree",
                     path,
                     name
@@ -244,7 +244,7 @@ var IPython = (function (IPython) {
         item.find("a.item_link")
             .attr('href',
                 utils.url_join_encode(
-                    this.base_project_url,
+                    this.base_url,
                     "notebooks",
                     path,
                     nbname
@@ -285,7 +285,7 @@ var IPython = (function (IPython) {
                     }
                 };
                 var url = utils.url_join_encode(
-                    that.base_project_url,
+                    that.base_url,
                     'api/sessions',
                     session
                 );
@@ -325,7 +325,7 @@ var IPython = (function (IPython) {
                                     }
                                 };
                                 var url = utils.url_join_encode(
-                                    notebooklist.base_project_url,
+                                    notebooklist.base_url,
                                     'api/notebooks',
                                     notebooklist.notebook_path,
                                     nbname
@@ -374,7 +374,7 @@ var IPython = (function (IPython) {
                 };
 
                 var url = utils.url_join_encode(
-                    that.base_project_url,
+                    that.base_url,
                     'api/notebooks',
                     that.notebook_path,
                     nbname
@@ -397,7 +397,7 @@ var IPython = (function (IPython) {
 
     NotebookList.prototype.new_notebook = function(){
         var path = this.notebook_path;
-        var base_project_url = this.base_project_url;
+        var base_url = this.base_url;
         var settings = {
             processData : false,
             cache : false,
@@ -408,7 +408,7 @@ var IPython = (function (IPython) {
                 var notebook_name = data.name;
                 window.open(
                     utils.url_join_encode(
-                        base_project_url,
+                        base_url,
                         'notebooks',
                         path,
                         notebook_name),
@@ -417,7 +417,7 @@ var IPython = (function (IPython) {
             }
         };
         var url = utils.url_join_encode(
-            base_project_url,
+            base_url,
             'api/notebooks',
             path
         );

--- a/IPython/html/templates/login.html
+++ b/IPython/html/templates/login.html
@@ -20,7 +20,7 @@
         <div class="container">
           <div class="center-nav">
             <p class="navbar-text nav">Password:</p>
-            <form action="{{base_project_url}}login?next={{next}}" method="post" class="navbar-form pull-left">
+            <form action="{{base_url}}login?next={{next}}" method="post" class="navbar-form pull-left">
               <input type="password" name="password" id="password_input">
               <button type="submit" id="login_submit">Log in</button>
             </form>

--- a/IPython/html/templates/logout.html
+++ b/IPython/html/templates/logout.html
@@ -21,9 +21,9 @@
     {% endif %}
 
     {% if not login_available %}
-    Proceed to the <a href="{{base_project_url}}">dashboard</a>.
+    Proceed to the <a href="{{base_url}}">dashboard</a>.
     {% else %}
-    Proceed to the <a href="{{base_project_url}}login">login page</a>.
+    Proceed to the <a href="{{base_url}}login">login page</a>.
     {% endif %}
 
 

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -22,7 +22,7 @@ window.mathjax_url = "{{mathjax_url}}";
 {% block params %}
 
 data-project="{{project}}"
-data-base-project-url="{{base_project_url}}"
+data-base-url="{{base_url}}"
 data-base-kernel-url="{{base_kernel_url}}"
 data-notebook-name="{{notebook_name}}"
 data-notebook-path="{{notebook_path}}"

--- a/IPython/html/templates/page.html
+++ b/IPython/html/templates/page.html
@@ -21,7 +21,7 @@
       require.config({
           baseUrl: '{{static_url("")}}',
           paths: {
-            nbextensions : '{{ base_project_url }}nbextensions',
+            nbextensions : '{{ base_url }}nbextensions',
             underscore : '{{static_url("components/underscore/underscore-min")}}',
             backbone : '{{static_url("components/backbone/backbone-min")}}', 
           },
@@ -54,7 +54,7 @@
 <div id="header" class="navbar navbar-static-top">
   <div class="navbar-inner navbar-nobg">
     <div class="container">
-    <div id="ipython_notebook" class="nav brand pull-left"><a href="{{base_project_url}}tree/{{notebook_path}}" alt='dashboard'><img src='{{static_url("base/images/ipynblogo.png") }}' alt='IPython Notebook'/></a></div>
+    <div id="ipython_notebook" class="nav brand pull-left"><a href="{{base_url}}tree/{{notebook_path}}" alt='dashboard'><img src='{{static_url("base/images/ipynblogo.png") }}' alt='IPython Notebook'/></a></div>
 
     {% block login_widget %}
 

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -11,7 +11,7 @@
 {% block params %}
 
 data-project="{{project}}"
-data-base-project-url="{{base_project_url}}"
+data-base-url="{{base_url}}"
 data-notebook-path="{{notebook_path}}"
 data-base-kernel-url="{{base_kernel_url}}"
 

--- a/IPython/html/tests/tree/dashboard_nav.js
+++ b/IPython/html/tests/tree/dashboard_nav.js
@@ -18,9 +18,12 @@ casper.test_items = function (baseUrl) {
             if (!item.label.match('.ipynb$')) {
                 var followed_url = baseUrl+item.link;
                 if (!followed_url.match('/\.\.$')) {
-                    casper.thenOpen(baseUrl+item.link, function () {
+                    casper.thenOpen(followed_url, function () {
                         casper.wait_for_dashboard();
-                        this.test.assertEquals(this.getCurrentUrl(), followed_url, 'Testing dashboard link: '+followed_url);
+                        // getCurrentUrl is with host, and url-decoded,
+                        // but item.link is without host, and url-encoded
+                        var expected = baseUrl + decodeURIComponent(item.link);
+                        this.test.assertEquals(this.getCurrentUrl(), expected, 'Testing dashboard link: ' + expected);
                         casper.test_items(baseUrl);
                         this.back();
                     });
@@ -31,7 +34,7 @@ casper.test_items = function (baseUrl) {
 }
 
 casper.dashboard_test(function () {
-    baseUrl = this.get_notebook_server()
+    baseUrl = this.get_notebook_server();
     casper.test_items(baseUrl);
 })
 

--- a/IPython/html/tree/handlers.py
+++ b/IPython/html/tree/handlers.py
@@ -30,12 +30,12 @@ class TreeHandler(IPythonHandler):
     """Render the tree view, listing notebooks, clusters, etc."""
 
     def generate_breadcrumbs(self, path):
-        breadcrumbs = [(url_escape(url_path_join(self.base_project_url, 'tree')), '')]
+        breadcrumbs = [(url_escape(url_path_join(self.base_url, 'tree')), '')]
         comps = path.split('/')
         ncomps = len(comps)
         for i in range(ncomps):
             if comps[i]:
-                link = url_escape(url_path_join(self.base_project_url, 'tree', *comps[0:i+1]))
+                link = url_escape(url_path_join(self.base_url, 'tree', *comps[0:i+1]))
                 breadcrumbs.append((link, comps[i]))
         return breadcrumbs
 
@@ -57,7 +57,7 @@ class TreeHandler(IPythonHandler):
         if name is not None:
             # is a notebook, redirect to notebook handler
             url = url_escape(url_path_join(
-                self.base_project_url, 'notebooks', path, name
+                self.base_url, 'notebooks', path, name
             ))
             self.log.debug("Redirecting %s to %s", self.request.path, url)
             self.redirect(url)
@@ -81,7 +81,7 @@ class TreeRedirectHandler(IPythonHandler):
     @web.authenticated
     def get(self, path=''):
         url = url_escape(url_path_join(
-            self.base_project_url, 'tree', path.strip('/')
+            self.base_url, 'tree', path.strip('/')
         ))
         self.log.debug("Redirecting %s to %s", self.request.path, url)
         self.redirect(url)

--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -181,8 +181,8 @@ class JSController(TestController):
         self.ipydir = TemporaryDirectory()
         self.nbdir = TemporaryDirectory()
         print("Running notebook tests in directory: %r" % self.nbdir.name)
-        os.makedirs(os.path.join(self.nbdir.name, os.path.join('subdir1', 'subdir1a')))
-        os.makedirs(os.path.join(self.nbdir.name, os.path.join('subdir2', 'subdir2a')))
+        os.makedirs(os.path.join(self.nbdir.name, os.path.join(u'sub ∂ir1', u'sub ∂ir 1a')))
+        os.makedirs(os.path.join(self.nbdir.name, os.path.join(u'sub ∂ir2', u'sub ∂ir 1b')))
         self.dirs.append(self.ipydir)
         self.dirs.append(self.nbdir)
 


### PR DESCRIPTION
The problem:

we had a variety of ways to get the notebook name, path, and base url:
- `$('body').data("notebookPath")`
- `various_objects.notebookPath()`
- `IPython.notebook.notebook_path`

and there was a mixture of encoded and decoded URLs, causing incorrect URL errors with spaces or unicode filenames.

This should hopefully clean up how we work with URLs by eliminating some of the inconsistency:
- remove notebookPath, notebookName, and baseProjectUrl methods everywhere
- use notebook_path _attributes_ instead
- we should never store encoded URLs, only store decoded text
- perform encoding only when making an actual request
- base_project_url is changed to base_url
