### PR TITLE
Store timestamps for modules to autoreload

### DIFF
--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -533,4 +533,4 @@ def load_ipython_extension(ip):
     auto_reload = AutoreloadMagics(ip)
     ip.register_magics(auto_reload)
     ip.events.register('pre_run_cell', auto_reload.pre_run_cell)
-    ip.register_post_execute(auto_reload.post_execute_hook)
+    ip.events.register('post_execute', auto_reload.post_execute_hook)


### PR DESCRIPTION
Closes gh-4127

At present, autoreload compares the timestamps on .py and .pyc files. However, this can fail in a couple of ways (see gh-4127). With this change, it caches the mtime of the .py file when we loaded it.

Some extra complexity is needed to store the mtime as soon as possible - we scan sys.modules when autoreload is loaded, and register a post_execute hook to check for newly imported modules after each cell.
