### PR TITLE
only validate package_data when it might be used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ from setupbase import (
     setup_args,
     find_packages,
     find_package_data,
+    check_package_data,
     find_entry_points,
     build_scripts_entrypt,
     find_data_files,
@@ -191,11 +192,21 @@ if len(sys.argv) >= 2 and sys.argv[1] in ('sdist','bdist_rpm'):
 
 packages = find_packages()
 package_data = find_package_data()
+
 data_files = find_data_files()
 
 setup_args['packages'] = packages
 setup_args['package_data'] = package_data
 setup_args['data_files'] = data_files
+
+def maybe_check_package_data():
+    for should_check in ('bdist', 'sdist', 'build', 'install'):
+        for arg in sys.argv:
+            if arg.startswith(should_check):
+                check_package_data(package_data)
+                return
+
+maybe_check_package_data()
 
 #---------------------------------------------------------------------------
 # custom distutils commands

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ from setupbase import (
     setup_args,
     find_packages,
     find_package_data,
-    check_package_data,
+    check_package_data_first,
     find_entry_points,
     build_scripts_entrypt,
     find_data_files,
@@ -199,15 +199,6 @@ setup_args['packages'] = packages
 setup_args['package_data'] = package_data
 setup_args['data_files'] = data_files
 
-def maybe_check_package_data():
-    for should_check in ('bdist', 'sdist', 'build', 'install'):
-        for arg in sys.argv:
-            if arg.startswith(should_check):
-                check_package_data(package_data)
-                return
-
-maybe_check_package_data()
-
 #---------------------------------------------------------------------------
 # custom distutils commands
 #---------------------------------------------------------------------------
@@ -235,7 +226,7 @@ class UploadWindowsInstallers(upload):
             self.upload_file('bdist_wininst', 'any', dist_file)
 
 setup_args['cmdclass'] = {
-    'build_py': git_prebuild('IPython'),
+    'build_py': check_package_data_first(git_prebuild('IPython')),
     'sdist' : git_prebuild('IPython', sdist),
     'upload_wininst' : UploadWindowsInstallers,
     'submodule' : UpdateSubmodules,

--- a/setupbase.py
+++ b/setupbase.py
@@ -190,6 +190,7 @@ def find_package_data():
     
     return package_data
 
+
 def check_package_data(package_data):
     """verify that package_data globs make sense"""
     print("checking package data")
@@ -201,6 +202,18 @@ def check_package_data(package_data):
                 assert len(glob(path)) > 0, "No files match pattern %s" % path
             else:
                 assert os.path.exists(path), "Missing package data: %s" % path
+
+
+def check_package_data_first(command):
+    """decorator for checking package_data before running a given command
+    
+    Probably only needs to wrap build_py
+    """
+    class DecoratedCommand(command):
+        def run(self):
+            check_package_data(self.package_data)
+            command.run(self)
+    return DecoratedCommand
 
 
 #---------------------------------------------------------------------------

--- a/setupbase.py
+++ b/setupbase.py
@@ -188,7 +188,11 @@ def find_package_data():
         'IPython.nbformat' : ['tests/*.ipynb']
     }
     
-    # verify that package_data makes sense
+    return package_data
+
+def check_package_data(package_data):
+    """verify that package_data globs make sense"""
+    print("checking package data")
     for pkg, data in package_data.items():
         pkg_root = pjoin(*pkg.split('.'))
         for d in data:
@@ -197,8 +201,6 @@ def find_package_data():
                 assert len(glob(path)) > 0, "No files match pattern %s" % path
             else:
                 assert os.path.exists(path), "Missing package data: %s" % path
-
-    return package_data
 
 
 #---------------------------------------------------------------------------


### PR DESCRIPTION
closes #5046

Now, we may not want these asserts at all, but given the volume of the output of setup, warnings are effectively useless.
