### PR TITLE
Fix iopubwatcher.py example script.

### DIFF
--- a/examples/parallel/iopubwatcher.py
+++ b/examples/parallel/iopubwatcher.py
@@ -14,35 +14,29 @@ Authors
 * MinRK
 """
 
-import os
 import sys
 import json
 import zmq
 
 from IPython.kernel.zmq.session import Session
-from IPython.parallel.util import disambiguate_url
 from IPython.utils.py3compat import str_to_bytes
 from IPython.utils.path import get_security_file
 
 def main(connection_file):
     """watch iopub channel, and print messages"""
-    
+
     ctx = zmq.Context.instance()
-    
+
     with open(connection_file) as f:
         cfg = json.loads(f.read())
-    
-    location = cfg['location']
-    reg_url = cfg['url']
-    session = Session(key=str_to_bytes(cfg['exec_key']))
-    
-    query = ctx.socket(zmq.DEALER)
-    query.connect(disambiguate_url(cfg['url'], location))
-    session.send(query, "connection_request")
-    idents,msg = session.recv(query, mode=0)
-    c = msg['content']
-    iopub_url = disambiguate_url(c['iopub'], location)
+
+    reg_url = cfg['interface']
+    iopub_port = cfg['iopub']
+    iopub_url = "%s:%s"%(reg_url, iopub_port)
+
+    session = Session(key=str_to_bytes(cfg['key']))
     sub = ctx.socket(zmq.SUB)
+
     # This will subscribe to all messages:
     sub.setsockopt(zmq.SUBSCRIBE, b'')
     # replace with b'' with b'engine.1.stdout' to subscribe only to engine 1's stdout


### PR DESCRIPTION
Should I PEP8 this?

```
examples/parallel/iopubwatcher.py:1:80: E501 line too long (91 > 79 characters)
examples/parallel/iopubwatcher.py:3:80: E501 line too long (95 > 79 characters)
examples/parallel/iopubwatcher.py:5:80: E501 line too long (92 > 79 characters)
examples/parallel/iopubwatcher.py:6:80: E501 line too long (89 > 79 characters)
examples/parallel/iopubwatcher.py:9:80: E501 line too long (93 > 79 characters)
examples/parallel/iopubwatcher.py:25:1: E302 expected 2 blank lines, found 1
examples/parallel/iopubwatcher.py:35:24: E228 missing whitespace around modulo operator
examples/parallel/iopubwatcher.py:42:80: E501 line too long (85 > 79 characters)
examples/parallel/iopubwatcher.py:53:19: E231 missing whitespace after ','
```

Did I make this script less general by removing the `disambiguate_url` stuff? I'm not sure. 

This fixes [issue #5057](https://github.com/ipython/ipython/issues/5057).
