### PR TITLE
Fix incorrect `Patch` logic in widget code

### DIFF
--- a/IPython/html/static/notebook/js/widgets/widget.js
+++ b/IPython/html/static/notebook/js/widgets/widget.js
@@ -203,7 +203,7 @@ function(WidgetManager, _, Backbone){
             // Push this model's state to the back-end
             //
             // This invokes a Backbone.Sync.
-            this.save(this.changedAttributes(), {patch: true, callbacks: callbacks});
+            this.save({patch: true, callbacks: callbacks});
         },
 
         _pack_models: function(value) {

--- a/IPython/html/static/notebook/js/widgets/widget.js
+++ b/IPython/html/static/notebook/js/widgets/widget.js
@@ -148,7 +148,7 @@ function(WidgetManager, _, Backbone){
             }
 
             // Delete any key value pairs that the back-end already knows about.
-            var attrs = (method === 'patch') ? model.changed : model.toJSON(options);
+            var attrs = (method === 'patch') ? options.attrs : model.toJSON(options);
             if (this.key_value_lock !== null) {
                 var key = this.key_value_lock[0];
                 var value = this.key_value_lock[1];

--- a/IPython/html/static/notebook/js/widgets/widget.js
+++ b/IPython/html/static/notebook/js/widgets/widget.js
@@ -148,7 +148,7 @@ function(WidgetManager, _, Backbone){
             }
 
             // Delete any key value pairs that the back-end already knows about.
-            var attrs = (method === 'patch') ? options.attrs : model.toJSON(options);
+            var attrs = (method === 'patch') ? model.changed : model.toJSON(options);
             if (this.key_value_lock !== null) {
                 var key = this.key_value_lock[0];
                 var value = this.key_value_lock[1];

--- a/IPython/html/static/notebook/js/widgets/widget.js
+++ b/IPython/html/static/notebook/js/widgets/widget.js
@@ -141,7 +141,7 @@ function(WidgetManager, _, Backbone){
             var return_value = WidgetModel.__super__.set.apply(this, arguments);
 
             // Backbone only remembers the diff of the most recent set()
-            // opertation.  Calling set multiple times in a row results in a 
+            // operation.  Calling set multiple times in a row results in a 
             // loss of diff information.  Here we keep our own running diff.
             this._buffered_state_diff = $.extend(this._buffered_state_diff, this.changedAttributes() || {});
             return return_value;

--- a/IPython/html/static/notebook/js/widgets/widget.js
+++ b/IPython/html/static/notebook/js/widgets/widget.js
@@ -94,7 +94,7 @@ function(WidgetManager, _, Backbone){
             _.each(state, function(value, key) {
                 that.key_value_lock = [key, value];
                 try {
-                    that.set(key, that._unpack_models(value));
+                    WidgetModel.__super__.set.apply(that, [key, that._unpack_models(value)]);
                 } finally {
                     that.key_value_lock = null;
                 }

--- a/IPython/html/static/notebook/js/widgets/widget.js
+++ b/IPython/html/static/notebook/js/widgets/widget.js
@@ -203,7 +203,7 @@ function(WidgetManager, _, Backbone){
             // Push this model's state to the back-end
             //
             // This invokes a Backbone.Sync.
-            this.save({patch: true, callbacks: callbacks});
+            this.save(this.changedAttributes(), {patch: true, callbacks: callbacks});
         },
 
         _pack_models: function(value) {

--- a/IPython/html/tests/widgets/widget.js
+++ b/IPython/html/tests/widgets/widget.js
@@ -98,7 +98,7 @@ casper.notebook_test(function () {
                     this.touch();
                 },
             });
-            WidgetManager.register_widget_view('MultiSetView', MultiSetView);
+            IPython.WidgetManager.register_widget_view('MultiSetView', MultiSetView);
         }, {});
     });
 

--- a/IPython/html/tests/widgets/widget.js
+++ b/IPython/html/tests/widgets/widget.js
@@ -111,6 +111,10 @@ casper.notebook_test(function () {
         '    a = CInt(0, sync=True)\n' +
         '    b = CInt(0, sync=True)\n' +
         '    c = CInt(0, sync=True)\n' +
+        '    d = CInt(-1, sync=True)\n' + // See if it sends a full state.
+        '    def _handle_receive_state(self, sync_data):\n' +
+        '        widgets.Widget._handle_receive_state(self, sync_data)\n'+
+        '        self.d = len(sync_data)\n' +
         'multiset = MultiSetWidget()\n' +
         'display(multiset)\n' +
         'print(multiset.model_id)');
@@ -125,6 +129,13 @@ casper.notebook_test(function () {
     this.execute_cell_then(index, function(index) {
         this.test.assertEquals(this.get_output_cell(index).text.trim(), '123',
             'Multiple model.set calls and one view.touch update state in back-end.');
+    });
+
+    index = this.append_cell(
+        'print("%d" % (multiset.d))');
+    this.execute_cell_then(index, function(index) {
+        this.test.assertEquals(this.get_output_cell(index).text.trim(), '3',
+            'Multiple model.set calls sent a partial state.');
     });
 
     var textbox = {};

--- a/IPython/html/tests/widgets/widget.js
+++ b/IPython/html/tests/widgets/widget.js
@@ -8,13 +8,14 @@ var recursive_compare = function(a, b) {
 
     if (same) {
         if (a instanceof Object) {
-            for (var key in a) {
+            var key;
+            for (key in a) {
                 if (a.hasOwnProperty(key) && !recursive_compare(a[key], b[key])) {
                     same = false;
                     break;
                 }
             }
-            for (var key in b) {
+            for (key in b) {
                 if (b.hasOwnProperty(key) && !recursive_compare(a[key], b[key])) {
                     same = false;
                     break;
@@ -26,7 +27,7 @@ var recursive_compare = function(a, b) {
     }
     
     return same;
-}
+};
 
 // Test the widget framework.
 casper.notebook_test(function () {
@@ -58,7 +59,6 @@ casper.notebook_test(function () {
             var output = that.evaluate(function(input) {
                 var model = new IPython.WidgetModel(IPython.notebook.kernel.widget_manager, undefined);
                 var results = model._pack_models(input);
-                delete model;
                 return results;
             }, {input: input});
             that.test.assert(recursive_compare(input, output), 
@@ -68,7 +68,6 @@ casper.notebook_test(function () {
             var output = that.evaluate(function(input) {
                 var model = new IPython.WidgetModel(IPython.notebook.kernel.widget_manager, undefined);
                 var results = model._unpack_models(input);
-                delete model;
                 return results;
             }, {input: input});
             that.test.assert(recursive_compare(input, output), 
@@ -79,15 +78,53 @@ casper.notebook_test(function () {
             test_unpack(input);
         };
         
-        test_packing({0: 'hi', 1: 'bye'})
-        test_packing(['hi', 'bye'])
-        test_packing(['hi', 5])
-        test_packing(['hi', '5'])
-        test_packing([1.0, 0])
-        test_packing([1.0, false])
-        test_packing([1, false])
-        test_packing([1, false, {a: 'hi'}])
-        test_packing([1, false, ['hi']])
+        test_packing({0: 'hi', 1: 'bye'});
+        test_packing(['hi', 'bye']);
+        test_packing(['hi', 5]);
+        test_packing(['hi', '5']);
+        test_packing([1.0, 0]);
+        test_packing([1.0, false]);
+        test_packing([1, false]);
+        test_packing([1, false, {a: 'hi'}]);
+        test_packing([1, false, ['hi']]);
+
+        // Test multi-set, single touch code.  First create a custom widget.
+        this.evaluate(function() {
+            var MultiSetView = IPython.DOMWidgetView.extend({
+                render: function(){
+                    this.model.set('a', 1);
+                    this.model.set('b', 2);
+                    this.model.set('c', 3);
+                    this.touch();
+                },
+            });
+            WidgetManager.register_widget_view('MultiSetView', MultiSetView);
+        }, {});
+    });
+
+    // Try creating the multiset widget, verify that sets the values correctly.
+    var multiset = {};
+    multiset.index = this.append_cell(
+        'from IPython.utils.traitlets import Unicode, CInt\n' +
+        'class MultiSetWidget(widgets.Widget):\n' +
+        '    _view_name = Unicode("MultiSetView", sync=True)\n' +
+        '    a = CInt(0, sync=True)\n' +
+        '    b = CInt(0, sync=True)\n' +
+        '    c = CInt(0, sync=True)\n' +
+        'multiset = MultiSetWidget()\n' +
+        'display(multiset)\n' +
+        'print(multiset.model_id)');
+    this.execute_cell_then(multiset.index, function(index) {
+        multiset.model_id = this.get_output_cell(index).text.trim();
+    });
+
+    this.wait_for_widget(multiset);
+
+    index = this.append_cell(
+        'print("%d%d%d" % (multiset.a, multiset.b, multiset.c))');
+    this.execute_cell_then(index, function(index) {
+        this.test.assertEquals(this.get_output_cell(index).text.trim(), '123',
+            'Multiple model.set calls and one view.touch update state in back-end.');
     });
 
     var textbox = {};


### PR DESCRIPTION
This does not work in master

``` javascript
this.model.set('x', x);
this.model.set('y', y);
this.model.set('z', z);
this.touch();
```

instead one has to write 

``` javascript
this.model.set('x', x);
this.touch();
this.model.set('y', y);
this.touch();
this.model.set('z', z);
this.touch();
```

or

``` javascript
this.model.set({'x': x, 'y': y, 'z': z});
this.touch();
```

because the attr diff is only maintained for the last set operation.  This patch fixes this so the first method can be used.
