### PR TITLE
make execute button in menu bar match shift-enter

### DIFF
--- a/IPython/html/static/notebook/js/maintoolbar.js
+++ b/IPython/html/static/notebook/js/maintoolbar.js
@@ -100,8 +100,9 @@ var IPython = (function (IPython) {
                     label : 'Run Cell',
                     icon : 'icon-play',
                     callback : function () {
-                    IPython.notebook.execute_cell();
-                        }
+                        // emulate default shift-enter behavior
+                        IPython.notebook.execute_cell_and_select_below();
+                    }
                 },
                 {
                     id : 'interrupt_b',


### PR DESCRIPTION
I noticed this when testing the UI on my iPad. I expected the button to perform the default execute behavior, but it doesn't.
