### PR TITLE
flush replies when entering an eventloop

### DIFF
--- a/IPython/kernel/zmq/eventloops.py
+++ b/IPython/kernel/zmq/eventloops.py
@@ -251,5 +251,5 @@ def enable_gui(gui, kernel=None):
             )
     loop = loop_map[gui]
     if loop and kernel.eventloop is not None and kernel.eventloop is not loop:
-            raise RuntimeError("Cannot activate multiple GUI eventloops")
+        raise RuntimeError("Cannot activate multiple GUI eventloops")
     kernel.eventloop = loop


### PR DESCRIPTION
avoids possible hangs when the GUI eventloop prevents queued replies from being sent

should close #4997
