### PR TITLE
Provide logging messages in ipcluster log when engine or controllers fail to start

### DIFF
--- a/IPython/parallel/apps/ipclusterapp.py
+++ b/IPython/parallel/apps/ipclusterapp.py
@@ -348,7 +348,11 @@ class IPClusterEngines(BaseParallelApplication):
         # Some EngineSetLaunchers ignore `n` and use their own engine count, such as SSH:
         n = getattr(self.engine_launcher, 'engine_count', self.n)
         self.log.info("Starting %s Engines with %s", n, self.engine_launcher_class)
-        self.engine_launcher.start(self.n)
+        try:
+            self.engine_launcher.start(self.n)
+        except:
+            self.log.exception("Engine start failed")
+            raise
         self.engine_launcher.on_stop(self.engines_stopped_early)
         if self.early_shutdown:
             ioloop.DelayedCallback(self.engines_started_ok, self.early_shutdown*1000, self.loop).start()
@@ -517,7 +521,11 @@ class IPClusterStart(IPClusterEngines):
     def start_controller(self):
         self.log.info("Starting Controller with %s", self.controller_launcher_class)
         self.controller_launcher.on_stop(self.stop_launchers)
-        self.controller_launcher.start()
+        try:
+            self.controller_launcher.start()
+        except:
+            self.log.exception("Controller start failed")
+            raise
 
     def stop_controller(self):
         # self.log.info("In stop_controller")


### PR DESCRIPTION
This is a logging/debugging improvement that writes out error tracebacks when controllers or engines fail to start from ipcluster. Previously these were silently ignored and the start process hangs without helpful messages. This is useful for debugging problems with custom controller or engine classes as well as general failures during submission.
