### PR TITLE
minor notebook logging changes

### DIFF
--- a/IPython/html/log.py
+++ b/IPython/html/log.py
@@ -37,14 +37,10 @@ def log_request(handler):
         request_time=request_time,
     )
     msg = "{status} {method} {uri} ({ip}) {request_time:.2f}ms"
-    if status >= 300:
-        # log referers on redirects
+    if status >= 400:
+        # log bad referers
         ns['referer'] = request.headers.get('Referer', 'None')
         msg = msg + ' referer={referer}'
-    if status >= 400:
-        # log user agent for failed requests
-        ns['agent'] = request.headers.get('User-Agent', 'Unknown')
-        msg = msg + ' user-agent={agent}'
     if status >= 500 and status != 502:
         # log all headers if it caused an error
         log_method(json.dumps(request.headers, indent=2))


### PR DESCRIPTION
log refer only on 4XX, and never log user agent

This function was ported from nbviewer, and some of the choices were not quite right for the notebook server.
