### PR TITLE
remove base_kernel_url

### DIFF
--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -136,10 +136,6 @@ class IPythonHandler(AuthenticatedHandler):
     def base_url(self):
         return self.settings.get('base_url', '/')
     
-    @property
-    def base_kernel_url(self):
-        return self.settings.get('base_kernel_url', '/')
-    
     #---------------------------------------------------------------
     # Manager objects
     #---------------------------------------------------------------
@@ -181,7 +177,6 @@ class IPythonHandler(AuthenticatedHandler):
     def template_namespace(self):
         return dict(
             base_url=self.base_url,
-            base_kernel_url=self.base_kernel_url,
             logged_in=self.logged_in,
             login_available=self.login_available,
             static_url=self.static_url,

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -160,7 +160,6 @@ class NotebookWebApplication(web.Application):
             # basics
             log_function=log_request,
             base_url=base_url,
-            base_kernel_url=ipython_app.base_kernel_url,
             template_path=template_path,
             static_path=ipython_app.static_file_path,
             static_handler_class = FileFindHandler,
@@ -430,18 +429,6 @@ class NotebookApp(BaseIPythonApplication):
     def _base_project_url_changed(self, name, old, new):
         self.log.warn("base_project_url is deprecated, use base_url")
         self.base_url = new
-
-    base_kernel_url = Unicode('/', config=True,
-                               help='''The base URL for the kernel server
-
-                               Leading and trailing slashes can be omitted,
-                               and will automatically be added.
-                               ''')
-    def _base_kernel_url_changed(self, name, old, new):
-        if not new.startswith('/'):
-            self.base_kernel_url = '/'+new
-        elif not new.endswith('/'):
-            self.base_kernel_url = new+'/'
 
     websocket_url = Unicode("", config=True,
         help="""The base URL for the websocket server,

--- a/IPython/html/services/kernels/handlers.py
+++ b/IPython/html/services/kernels/handlers.py
@@ -46,7 +46,7 @@ class MainKernelHandler(IPythonHandler):
         km = self.kernel_manager
         kernel_id = km.start_kernel()
         model = km.kernel_model(kernel_id, self.ws_url)
-        location = url_path_join(self.base_kernel_url, 'api', 'kernels', kernel_id)
+        location = url_path_join(self.base_url, 'api', 'kernels', kernel_id)
         self.set_header('Location', url_escape(location))
         self.set_status(201)
         self.finish(jsonapi.dumps(model))
@@ -85,7 +85,7 @@ class KernelActionHandler(IPythonHandler):
         if action == 'restart':
             km.restart_kernel(kernel_id)
             model = km.kernel_model(kernel_id, self.ws_url)
-            self.set_header('Location', '{0}api/kernels/{1}'.format(self.base_kernel_url, kernel_id))
+            self.set_header('Location', '{0}api/kernels/{1}'.format(self.base_url, kernel_id))
             self.write(jsonapi.dumps(model))
         self.finish()
 

--- a/IPython/html/services/sessions/handlers.py
+++ b/IPython/html/services/sessions/handlers.py
@@ -64,7 +64,7 @@ class SessionRootHandler(IPythonHandler):
         else:
             kernel_id = km.start_kernel(cwd=nbm.get_os_path(path))
             model = sm.create_session(name=name, path=path, kernel_id=kernel_id, ws_url=self.ws_url)
-        location = url_path_join(self.base_kernel_url, 'api', 'sessions', model['id'])
+        location = url_path_join(self.base_url, 'api', 'sessions', model['id'])
         self.set_header('Location', url_escape(location))
         self.set_status(201)
         self.finish(json.dumps(model, default=date_default))

--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -48,7 +48,6 @@ function (marked) {
 
     var opts = {
         base_url : IPython.utils.get_body_data("baseUrl"),
-        base_kernel_url : IPython.utils.get_body_data("baseKernelUrl"),
         notebook_path : IPython.utils.get_body_data("notebookPath"),
         notebook_name : IPython.utils.get_body_data('notebookName')
     };

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -21,7 +21,6 @@ var IPython = (function (IPython) {
         this.name = notebook.notebook_name;
         this.path = notebook.notebook_path;
         this.base_url = notebook.base_url;
-        this.base_kernel_url = options.base_kernel_url || utils.get_body_data("baseKernelUrl");
     };
     
     Session.prototype.start = function(callback) {
@@ -89,7 +88,7 @@ var IPython = (function (IPython) {
      */
     Session.prototype._handle_start_success = function (data, status, xhr) {
         this.id = data.id;
-        var kernel_service_url = utils.url_path_join(this.base_kernel_url, "api/kernels");
+        var kernel_service_url = utils.url_path_join(this.base_url, "api/kernels");
         this.kernel = new IPython.Kernel(kernel_service_url);
         this.kernel._kernel_started(data.kernel);
     };

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -23,7 +23,6 @@ window.mathjax_url = "{{mathjax_url}}";
 
 data-project="{{project}}"
 data-base-url="{{base_url}}"
-data-base-kernel-url="{{base_kernel_url}}"
 data-notebook-name="{{notebook_name}}"
 data-notebook-path="{{notebook_path}}"
 class="notebook_app"

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -13,7 +13,6 @@
 data-project="{{project}}"
 data-base-url="{{base_url}}"
 data-notebook-path="{{notebook_path}}"
-data-base-kernel-url="{{base_kernel_url}}"
 
 {% endblock %}
 

--- a/docs/source/interactive/public_server.rst
+++ b/docs/source/interactive/public_server.rst
@@ -121,8 +121,7 @@ e.g. ``http://localhost:8888/ipython/``, you can do so with
 configuration options like the following (see above for instructions about
 modifying ``ipython_notebook_config.py``)::
 
-    c.NotebookApp.base_project_url = '/ipython/'
-    c.NotebookApp.base_kernel_url = '/ipython/'
+    c.NotebookApp.base_url = '/ipython/'
     c.NotebookApp.webapp_settings = {'static_url_prefix':'/ipython/static/'}
 
 Using a different notebook store


### PR DESCRIPTION
While we are simplifying base_project_url to base_url, base_kernel_url has never been documented, and has only ever been confusing. In every case I have seen, base_kernel_url should be identical to base_url, so this just removes the separate configuration value.

I would also like to consider getting rid of ws_url, unless someone can make a case for why it should be kept.

closes #5099
