### PR TITLE
require specifying the version for gh-pages

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -133,7 +133,10 @@ nightly: dist
 	rsync -avH --delete dist/ ipython:www/doc/nightly
 
 gh-pages: clean html
-	python gh-pages.py
+	# if VERSION is unspecified, it will be dev
+	# For releases, VERSION should be just the major version,
+	# e.g. VERSION=2 make gh-pages
+	python gh-pages.py $(VERSION)
 
 texinfo:
 	mkdir -p $(BUILDDIR)/texinfo

--- a/docs/gh-pages.py
+++ b/docs/gh-pages.py
@@ -82,10 +82,7 @@ if __name__ == '__main__':
     try:
         tag = sys.argv[1]
     except IndexError:
-        try:
-            tag = sh2('git describe --exact-match')
-        except CalledProcessError:
-            tag = "dev"   # Fallback
+        tag = "dev"
     
     startdir = os.getcwdu()
     if not os.path.exists(pages_dir):
@@ -117,8 +114,7 @@ if __name__ == '__main__':
 
     try:
         cd(pages_dir)
-        status = sh2('git status | head -1')
-        branch = re.match('\# On branch (.*)$', status).group(1)
+        branch = sh2('git rev-parse --abbrev-ref HEAD').strip()
         if branch != 'gh-pages':
             e = 'On %r, git branch is %r, MUST be "gh-pages"' % (pages_dir,
                                                                  branch)


### PR DESCRIPTION
From now on, we are only maintaining one build of the IPython docs per major
release, e.g. latest 1.x docs served at ipython-doc/1/. This makes gh-pages no
longer guess based on git tag. To build the 1.x docs:

```
VERSION=1 make gh-pages
```
