### PR TITLE
Minor typo in docstring of IPython.parallel DirectView

### DIFF
--- a/IPython/parallel/client/view.py
+++ b/IPython/parallel/client/view.py
@@ -404,7 +404,7 @@ class DirectView(View):
     # push a=5:
     >>> dv['a'] = 5
     # pull 'foo':
-    >>> db['foo']
+    >>> dv['foo']
 
     """
 


### PR DESCRIPTION
This is the tiniest pull request ever, but this docstring typo did get me confused for a few seconds.
