### PR TITLE
Coffeescript notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ __pycache__
 *.bak
 .ipynb_checkpoints
 .tox
+.idea

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "components"]
 	path = IPython/html/static/components
 	url = https://github.com/ipython/ipython-components.git
+    ignore = dirty

--- a/CoffeeScriptMagic.ipynb
+++ b/CoffeeScriptMagic.ipynb
@@ -1,0 +1,429 @@
+{
+ "metadata": {
+  "name": "",
+  "signature": "sha256:74515832bc8c846fba8ff83b0fe273610d23915f2e0f2c05205290d0e590a130"
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "heading",
+     "level": 1,
+     "metadata": {},
+     "source": [
+      "Executing CoffeeScript in IPython Notebook"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Here is a little extension that adds a `%%coffee` cell magic."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%reload_ext coffee_script_magic"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 13
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Demo"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Maybe you know already that the builtin `%%javascript` cell magic lets you execute javascript, like so:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%%javascript\n",
+      "console.log(\"Hello from javascript\");"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "javascript": [
+        "console.log(\"Hello from javascript\");"
+       ],
+       "metadata": {},
+       "output_type": "display_data",
+       "text": [
+        "<IPython.core.display.Javascript at 0x10bc85650>"
+       ]
+      }
+     ],
+     "prompt_number": 15
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Now you can also execute CoffeeScript:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%%coffee\n",
+      "console.log \"Hello from CoffeeScript\""
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "application/coffeescript": "console.log \"Hello from CoffeeScript\"",
+       "metadata": {},
+       "output_type": "display_data"
+      }
+     ],
+     "prompt_number": 18
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "In contrast to the JavaScript magic, results are shown just like python output:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "2 + 2"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "metadata": {},
+       "output_type": "pyout",
+       "prompt_number": 19,
+       "text": [
+        "4"
+       ]
+      }
+     ],
+     "prompt_number": 19
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "You can even define variables and reuse them across cells:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%%coffee\n",
+      "a = 64"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "application/coffeescript": "a = 64",
+       "metadata": {},
+       "output_type": "display_data"
+      }
+     ],
+     "prompt_number": 25
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%%coffee\n",
+      "Math.sqrt a * 100"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "application/coffeescript": "Math.sqrt a * 100",
+       "metadata": {},
+       "output_type": "display_data"
+      }
+     ],
+     "prompt_number": 26
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Errors are displayed in the notebook."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%%coffee\n",
+      "a.some_undefined_function()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "application/coffeescript": "a.some_undefined_function()",
+       "metadata": {},
+       "output_type": "display_data"
+      }
+     ],
+     "prompt_number": 30
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Making CoffeeScript the Default"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "When you want to use a lot of CoffeeScript in a notebook, it can be quite annoying to have to type `%%coffee` again and again. Fortunately you can use the default_cell_magic extension:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%reload_ext default_cell_magic"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 31
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%default_cell_magic coffee"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 32
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "From now on, almost everything will be interpreted as CoffeeScript:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": true,
+     "input": [
+      "console.log \"Hello again from CoffeeScript\""
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "application/coffeescript": "console.log \"Hello again from CoffeeScript\"",
+       "metadata": {},
+       "output_type": "display_data"
+      }
+     ],
+     "prompt_number": 33
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Of course you can switch back to Python etc., see the help of %default_cell_magic."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%default_cell_magic?"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 34
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Fun in the browser"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "banner = $('<div class=\"output_subarea\">CoffeeScript</div>')\n",
+      "banner.css border: \"4px solid green\"\n",
+      "context.output_subarea.append banner\n",
+      "banner.animate fontSize: \"2em\", padding: 20, \"color\": \"green\""
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "application/coffeescript": "banner = $('<div class=\"output_subarea\">CoffeeScript</div>')\nbanner.css border: \"4px solid green\"\ncontext.output_subarea.append banner\nbanner.animate fontSize: \"2em\", padding: 20, \"color\": \"green\"",
+       "metadata": {},
+       "output_type": "display_data"
+      }
+     ],
+     "prompt_number": 94
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "This example uses jQuery to append an element to `context.output_subarea` which is set to the current output cell."
+     ]
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "PaperJS - not working"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "As an example, let's do some graphics in the browser."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Inject [paper.js](http://www.paperjs.org) into the page."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "s = document.createElement(\"script\")\n",
+      "s.type = \"text/javascript\"\n",
+      "s.src = \"http://paperjs.org/assets/js/paper.js\"\n",
+      "$(\"head\").append(s)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "application/coffeescript": "s = document.createElement(\"script\")\ns.type = \"text/javascript\"\ns.src = \"http://paperjs.org/assets/js/paper.js\"\n$(\"head\").append(s)",
+       "metadata": {},
+       "output_type": "display_data"
+      }
+     ],
+     "prompt_number": 62
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Create a canvas element."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "sheet = $('<canvas id=\"thecanvas\" width=\"600\" height=\"300\" style=\"background:gray;\"/>')\n",
+      "context.element.append sheet\n",
+      "paper.setup document.getElementById(\"thecanvas\")"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "application/coffeescript": "sheet = $('<canvas id=\"thecanvas\" width=\"600\" height=\"300\" style=\"background:gray;\"/>')\ncontext.element.append sheet\npaper.setup document.getElementById(\"thecanvas\")",
+       "metadata": {},
+       "output_type": "display_data"
+      }
+     ],
+     "prompt_number": 65
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Now we can draw something on the canvas:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "new paper.Path.Circle center: [50, 50], radius: 20, fillColor: \"red\"\n",
+      "# paper.view.show()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "application/coffeescript": "new paper.Path.Circle center: [50, 50], radius: 20, fillColor: \"red\"\n# paper.view.show()",
+       "metadata": {},
+       "output_type": "display_data"
+      }
+     ],
+     "prompt_number": 66
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "How it works"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "The input cell is sent to the IPython kernel. When the kernel sees the `%%coffee` cell magic, it takes the rest of the cell and sends it back to the client with a MIME type of `application/coffeescript`. The IPython notebook interprets that MIME type, just like it does with python output or images that come from the kernel. For `application/coffeescript`, it compiles the source code from JavaScript to CoffeeScript, executes it, and appends the result to the output area. Accessing variables across cells is possible because the CoffeeScript code is executed in the context of the browser's global `window` object. This is a big difference from executing python code: **CoffeeScript code is executed in the browser**."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}

--- a/CoffeeScriptMagic.ipynb
+++ b/CoffeeScriptMagic.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:74515832bc8c846fba8ff83b0fe273610d23915f2e0f2c05205290d0e590a130"
+  "signature": "sha256:126ba0274216f624c84d29becfc515e09ebbeee19b2cd9cb277c51249682e70b"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -311,93 +311,15 @@
      "level": 2,
      "metadata": {},
      "source": [
-      "PaperJS - not working"
+      "PaperJS"
      ]
     },
     {
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "As an example, let's do some graphics in the browser."
+      "See the separate notebook PaperJS.ipynb for some fun with graphics in the browser."
      ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Inject [paper.js](http://www.paperjs.org) into the page."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "s = document.createElement(\"script\")\n",
-      "s.type = \"text/javascript\"\n",
-      "s.src = \"http://paperjs.org/assets/js/paper.js\"\n",
-      "$(\"head\").append(s)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "application/coffeescript": "s = document.createElement(\"script\")\ns.type = \"text/javascript\"\ns.src = \"http://paperjs.org/assets/js/paper.js\"\n$(\"head\").append(s)",
-       "metadata": {},
-       "output_type": "display_data"
-      }
-     ],
-     "prompt_number": 62
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Create a canvas element."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "sheet = $('<canvas id=\"thecanvas\" width=\"600\" height=\"300\" style=\"background:gray;\"/>')\n",
-      "context.element.append sheet\n",
-      "paper.setup document.getElementById(\"thecanvas\")"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "application/coffeescript": "sheet = $('<canvas id=\"thecanvas\" width=\"600\" height=\"300\" style=\"background:gray;\"/>')\ncontext.element.append sheet\npaper.setup document.getElementById(\"thecanvas\")",
-       "metadata": {},
-       "output_type": "display_data"
-      }
-     ],
-     "prompt_number": 65
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Now we can draw something on the canvas:"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "new paper.Path.Circle center: [50, 50], radius: 20, fillColor: \"red\"\n",
-      "# paper.view.show()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "application/coffeescript": "new paper.Path.Circle center: [50, 50], radius: 20, fillColor: \"red\"\n# paper.view.show()",
-       "metadata": {},
-       "output_type": "display_data"
-      }
-     ],
-     "prompt_number": 66
     },
     {
      "cell_type": "heading",
@@ -413,14 +335,6 @@
      "source": [
       "The input cell is sent to the IPython kernel. When the kernel sees the `%%coffee` cell magic, it takes the rest of the cell and sends it back to the client with a MIME type of `application/coffeescript`. The IPython notebook interprets that MIME type, just like it does with python output or images that come from the kernel. For `application/coffeescript`, it compiles the source code from JavaScript to CoffeeScript, executes it, and appends the result to the output area. Accessing variables across cells is possible because the CoffeeScript code is executed in the context of the browser's global `window` object. This is a big difference from executing python code: **CoffeeScript code is executed in the browser**."
      ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
     }
    ],
    "metadata": {}

--- a/DefaultCellMagic.ipynb
+++ b/DefaultCellMagic.ipynb
@@ -1,0 +1,200 @@
+{
+ "metadata": {
+  "name": "",
+  "signature": "sha256:a74541876fcd6af3b1df3858e4624b991fa31a1856e48bc3dc5d10e37914e433"
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "heading",
+     "level": 1,
+     "metadata": {},
+     "source": [
+      "Default Cell Magic Extension"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Prepend cells with a default cell magic so you don't have to type it again and again."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%load_ext default_cell_magic"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 1
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "IPython notebook lets you execute code in other interpreters via cell magics. For example, here is the `%%bash` cell magic. "
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%%bash\n",
+      "# The whole cell is sent to bash to execute\n",
+      "ls | sort -r | head"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "tox.ini\n",
+        "tools\n",
+        "setupext\n",
+        "setupegg.py\n",
+        "setupbase.py\n",
+        "setup.py\n",
+        "scripts\n",
+        "mist.patch\n",
+        "git-hooks\n",
+        "examples\n"
+       ]
+      }
+     ],
+     "prompt_number": 2
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "With the default_cell_magic extension you can use a cell magic without having to write it again and again."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%default_cell_magic bash"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 3
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "From now on, every code cell will be prepended with `%%bash` automatically. "
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "apropos python\n",
+      "date"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "ipcluster(1)             - start a cluster for IPython parallel computing\n",
+        "ipcontroller(1)          - start a controller for IPython parallel computing\n",
+        "ipengine(1)              - IPython parallel computing engine\n",
+        "iplogger(1)              - IPython logging utility for parallel computing\n",
+        "ipython(1)               - Tools for Interactive Computing in Python\n",
+        "pycolor(1)               - Colorize a python file or stdin using ANSI and print to stdout\n",
+        "python(1)                - an interpreted, interactive, object-oriented programming language\n",
+        "Inline::Python(3pm)      - Write Perl subs and classes in Python\n",
+        "pydoc(1)                 - the Python documentation tool\n",
+        "python(1)                - an interpreted, interactive, object-oriented programming language\n",
+        "python(1), pythonw(1)    - an interpreted, interactive, object-oriented programming language\n",
+        "pythonw(1)               - run python script allowing GUI\n",
+        "pythonw(1)               - run python script with GUI\n",
+        "Fr 14 Feb 2014 19:27:30 CET\n"
+       ]
+      }
+     ],
+     "prompt_number": 4
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "You can invite python back for just one cell:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%%python\n",
+      "print \"Hello from %s!\" % 'python'.capitalize()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "Hello from Python!\n"
+       ]
+      }
+     ],
+     "prompt_number": 13
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Or revert everything to the normal behavior:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%default_cell_magic"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 14
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "print \"Now this is a real %s notebook again!\" % 'python'.upper()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "Now this is a real PYTHON notebook again!\n"
+       ]
+      }
+     ],
+     "prompt_number": 15
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}

--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -14,11 +14,12 @@
 // which make both this file fail at setting marked configuration, and textcell.js
 // which search marked into global.
 require(['components/marked/lib/marked',
+         'components/coffee-script/extras/coffee-script',
          'notebook/js/widgets/init'],
 
-function (marked) {
+function (marked, CoffeeScript) {
     "use strict";
-
+    window.CoffeeScript = CoffeeScript;
     window.marked = marked;
 
     // monkey patch CM to be able to syntax highlight cell magics

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -543,6 +543,8 @@ var IPython = (function (IPython) {
             return 'null';
         } else if (obj === undefined) {
             return 'undefined'
+        } else if (_.isFunction(obj)) {
+            return "";
         } else {
             return obj.toString();
         }

--- a/PaperJS.ipynb
+++ b/PaperJS.ipynb
@@ -1,0 +1,271 @@
+{
+ "metadata": {
+  "name": "",
+  "signature": "sha256:88564cd7a35d135f4ad16fe161d92ceba7d5f0c927fe88d129ee56fa047facb2"
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "heading",
+     "level": 1,
+     "metadata": {},
+     "source": [
+      "PaperJS + CoffeeScript in an Interactive Notebook"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "[PaperJS](http://www.paperjs.org) is a JavaScript library for vector graphics. With the CoffeeScript extension for the [IPython notebook](http://ipython.org/notebook.html) you can mix explanations, [CoffeeScript](http://coffeescript.org/) code and results in a single interactive document. Thanks to IPython, the notebook document can be saved and converted to other formats like static HTML. Currently you need to use the IPython fork at https://github.com/mberth/ipython/tree/coffeescript_notebook for this."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Load the [IPython notebook](http://ipython.org/notebook.html) extension and use `%default_cell_magic` to have input interpreted as CoffeeScript by default."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%reload_ext coffee_script_magic\n",
+      "%reload_ext default_cell_magic\n",
+      "%default_cell_magic coffee"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 1
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "A small example to show that we are actually executing CoffeeScript in the browser."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "a = 10\n",
+      "Math.sqrt a * 100"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "application/coffeescript": "a = 10\nMath.sqrt a * 100",
+       "metadata": {},
+       "output_type": "display_data"
+      }
+     ],
+     "prompt_number": 247
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Inject paper.js into the page."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Manipulate the notebook HTML to insert the PaperJS script tag."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "s = document.createElement(\"script\")\n",
+      "s.type = \"text/javascript\"\n",
+      "s.src = \"http://paperjs.org/assets/js/paper.js\"\n",
+      "$(\"head\").append(s)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "application/coffeescript": "s = document.createElement(\"script\")\ns.type = \"text/javascript\"\ns.src = \"http://paperjs.org/assets/js/paper.js\"\n$(\"head\").append(s)",
+       "metadata": {},
+       "output_type": "display_data"
+      }
+     ],
+     "prompt_number": 129
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Make a canvas"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Make a new canvas element, initialize PaperJS to draw on it."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "makeCanvas = (canvasId=\"thecanvas\", width=600, height=300) ->\n",
+      "    sheet = $(\"<canvas id='#{canvasId}' width='#{width}' height='#{height}' style='background:gray;'/>\")\n",
+      "    $(context.element).find(\".output_subarea\").replaceWith(sheet)\n",
+      "    setTimeout -> paper.setup document.getElementById(canvasId), 50"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "application/coffeescript": "makeCanvas = (canvasId=\"thecanvas\", width=600, height=300) ->\n    sheet = $(\"<canvas id='#{canvasId}' width='#{width}' height='#{height}' style='background:gray;'/>\")\n    $(context.element).find(\".output_subarea\").replaceWith(sheet)\n    setTimeout -> paper.setup document.getElementById(canvasId), 50",
+       "metadata": {},
+       "output_type": "display_data"
+      }
+     ],
+     "prompt_number": 242
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Examples"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Let's draw something... Start by creating a new canvas."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "makeCanvas()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "application/coffeescript": "makeCanvas()",
+       "metadata": {},
+       "output_type": "display_data"
+      }
+     ],
+     "prompt_number": 265
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Create a bunch of colored circles."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "circles = []\n",
+      "for i in [360..0] by -1\n",
+      "    color = new paper.Color hue: i, saturation: 1, brightness: 0.9\n",
+      "    circles.push new paper.Path.Circle center: [300,150], radius: i, fillColor: color\n",
+      "# Force PaperJS to redraw, this is necessary when you use it directly from JavaScript\n",
+      "paper.view.draw()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "application/coffeescript": "circles = []\nfor i in [360..0] by -1\n    color = new paper.Color hue: i, saturation: 1, brightness: 0.9\n    circles.push new paper.Path.Circle center: [300,150], radius: i, fillColor: color\n# Force PaperJS to redraw, this is necessary when you use it directly from JavaScript\npaper.view.draw()",
+       "metadata": {},
+       "output_type": "display_data"
+      }
+     ],
+     "prompt_number": 266
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Add a square to the picture."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "width = 200\n",
+      "square = new paper.Path.Rectangle [100,100], [width, width]\n",
+      "square.set strokeColor: \"indigo\", strokeWidth: 10\n",
+      "square.position = paper.view.center\n",
+      "paper.view.draw()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "application/coffeescript": "width = 200\nsquare = new paper.Path.Rectangle [100,100], [width, width]\nsquare.set strokeColor: \"indigo\", strokeWidth: 10\nsquare.position = paper.view.center\npaper.view.draw()",
+       "metadata": {},
+       "output_type": "display_data"
+      }
+     ],
+     "prompt_number": 267
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Use the [onFrame()](http://paperjs.org/reference/path/#onframe) method \n",
+      "to do some [animation](http://paperjs.org/tutorials/animation/creating-animations/). \n",
+      "On every frame, turn the square by 1 degree and \n",
+      "change the colors of the circles a little. "
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "square.onFrame = (event) ->\n",
+      "    @rotate 1\n",
+      "    for c in circles\n",
+      "        c.fillColor.hue += 0.5"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "application/coffeescript": "square.onFrame = (event) ->\n    @rotate 1\n    for c in circles\n        c.fillColor.hue += 0.5",
+       "metadata": {},
+       "output_type": "display_data"
+      }
+     ],
+     "prompt_number": 270
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Now you can experiment with the example, just change the source and press Shift-Enter to execute it."
+     ]
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}

--- a/coffee_script_magic.py
+++ b/coffee_script_magic.py
@@ -1,0 +1,37 @@
+# Use CoffeeScript in IPython notebook. CoffeeScript is executed in
+# the global (window) context to make variables accessible across
+# cells.
+#
+# Example:
+#
+# > %%coffee
+# > console.log "Hello from CoffeeScript!"
+#
+# Note: this needs various patches to IPython, for example in
+# IPython/html/static/notebook/js/outputarea.js and the CoffeeScript
+# compiler in IPython/html/static/coffee-script.js.
+#
+# CoffeeScript execution works similarly to the built-in javascript
+# cell magic.  The cell contents is sent back from the kernel for
+# display with a MIME type of 'application/coffeescript'. The MIME
+# type is recognized and executed on the notebook client in
+# IPython.OutputArea.append_mime_type.
+
+from IPython.core.magic import Magics, magics_class,  cell_magic
+from IPython.core.displaypub import publish_display_data
+
+@magics_class
+class CoffeeScript(Magics):
+
+    @cell_magic
+    def coffee(self, line, cell):
+        """Send the cell contents back to the client with MIME type application/coffeescript.
+        """
+        publish_display_data('CoffeeScriptMagic',
+            {
+                'application/coffeescript': cell
+            })
+
+def load_ipython_extension(ip):
+    cs = CoffeeScript(ip)
+    ip.register_magics(cs)

--- a/default_cell_magic.py
+++ b/default_cell_magic.py
@@ -1,0 +1,83 @@
+"""Set a default cell magic for all subsequent inputs in IPython notebook.
+
+See docs for %default_cell_magic for details.
+"""
+#-----------------------------------------------------------------------------
+# Copyright (c) 2014, the IPython Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from IPython.core.magic import Magics, magics_class,  line_magic
+from IPython.core.inputsplitter import IPythonInputSplitter
+
+class OverrideSplitter(IPythonInputSplitter):
+    """Wrapper for the original IPythonInputSplitter that changes
+    cell input by prepending a default magic or removing %%python
+    as needed.
+    """
+    def __init__(self, splitter, magic=""):
+        self.splitter = splitter
+        self.magic = "%%" + magic
+
+    def patch_magic(self, text):
+        """Patch cell text with magic, unless it already has a magic,
+        or it starts with %%python.
+        """
+        python_magic = "%%python"
+        if text.startswith(python_magic):
+            return text[len(python_magic):]
+        if text.startswith("%"):
+            return text
+        return ("%s\n" % self.magic) + text
+
+    def transform_cell(self, cell):
+        """Patch the cell contents, then delegate to original
+        IPythonInputSplitter.
+        """
+        patched = self.patch_magic(cell)
+        return self.splitter.transform_cell(patched)
+
+@magics_class
+class DefaultCellMagic(Magics):
+
+    @line_magic
+    def default_cell_magic(self, parameters):
+        """Set a default cell magic in IPython notebook.
+
+        Example:
+
+        > %load_ext default_cell_magic
+        > %default_cell_magic bash
+
+        From now on all cells will be interpreted as bash commands by
+        prepending them with `%%bash` before they are executed. You can
+        switch back to python by using the %%python cell magic:
+
+        > %%python
+        > print "Hello from %s" % python.capitalize()
+
+        Cells that already start with a cell magic (or a line magic) are left unchanged.
+
+        You can switch back to IPython's normal behavior by using
+        %default_cell_magic with no argument:
+
+        > %default_cell_magic
+        """
+        itm_old = self.shell.input_transformer_manager
+        if isinstance(itm_old, OverrideSplitter):
+            itm_old = itm_old.splitter
+        args = parameters.split()
+        if args == []:
+            self.shell.input_transformer_manager = itm_old
+        else:
+            self.shell.input_transformer_manager = OverrideSplitter(itm_old, args[0])
+
+
+def load_ipython_extension(ip):
+    dcm = DefaultCellMagic(ip)
+    ip.register_magics(dcm)
+
+# TODO: implement unload, reload_extension has problems ATM.

--- a/docs/source/whatsnew/pr/coffeescript_notebook.rst
+++ b/docs/source/whatsnew/pr/coffeescript_notebook.rst
@@ -1,0 +1,31 @@
+Default Cell Magic
+------------------
+
+Use
+
+    %default_cell_magic xyz
+
+to have the `%%xyz` cell magic prepended automatically to all subsequent input cells. See
+
+    %default_cell_magic?
+
+for details.
+
+
+CoffeeScript Cell Magic
+-----------------------
+
+Execute CoffeeScript in the browser. Experience is similar to running python in teh notebook:
+results are shown in the notebook, variables can be accessed across cells etc.
+
+Example:
+
+    %%coffee
+    console.log "Hello from CoffeeScript!"
+
+
+Together with
+
+    %default_cell_magic coffee
+
+this can be used to write CoffeeScript notebooks with code being executed in the context of the browser.


### PR DESCRIPTION
I want to use CoffeeScript in place of Python inside an IPython notebook, so I can work in the interactive and explorative way that I like so much about IPython. Please give me feedback on the changes / extensions below. I'm new to IPython development, perhaps there are better ways to package this. Furthermore there is no testing at the moment. Any comments and criticisms are very much welcome. -- Matthias
## CoffeeScript Cell Magic

Execute CoffeeScript in the browser. Experience is similar to running python in the notebook:
results are shown in the notebook, variables can be accessed across cells etc.

Example:

```
%%coffee
console.log "Hello from CoffeeScript!"
```

Together with

```
%default_cell_magic coffee
```

(see below) this can be used to write CoffeeScript notebooks with code being executed in the context of the browser.
## Screenshots

![coffeescript_notebook](https://f.cloud.github.com/assets/77945/2178024/4c49d968-9652-11e3-89a5-17b1a27dcc0b.png)

![coffeescript_notebook_2](https://f.cloud.github.com/assets/77945/2178029/bff0c78c-9652-11e3-8a23-6e1b4fb09746.png)
## Default Cell Magic

Use

```
%default_cell_magic xyz
```

to have the `%%xyz` cell magic prepended automatically to all subsequent input cells. See

```
%default_cell_magic?
```

for details.
