### PR TITLE
don't use combine option on ucs package

### DIFF
--- a/IPython/nbconvert/templates/latex/base.tplx
+++ b/IPython/nbconvert/templates/latex/base.tplx
@@ -20,7 +20,7 @@ This template does not define a docclass, the inheriting class must define this.
     \usepackage{geometry} % Used to adjust the document margins
     \usepackage{amsmath} % Equations
     \usepackage{amssymb} % Equations
-    \usepackage[mathletters,combine]{ucs} % Extended unicode (utf-8) support
+    \usepackage[mathletters]{ucs} % Extended unicode (utf-8) support
     \usepackage[utf8x]{inputenc} % Allow utf-8 characters in the tex document
     \usepackage{fancyvrb} % verbatim replacement that allows latex
     \usepackage{grffile} % extends the file name processing of package graphics 


### PR DESCRIPTION
Caused problems with unicode.

It seems f9c32fcee337b6560ec31e25fba04cae6021b74a was actually the right fix for the original error, not faf51b858a8c5757944822ee1d75c11367e994f.

closes #5129
