### PR TITLE
set default value from signature defaults in interact

### DIFF
--- a/IPython/html/widgets/interaction.py
+++ b/IPython/html/widgets/interaction.py
@@ -26,7 +26,7 @@ from IPython.html.widgets import (Widget, TextWidget,
     ContainerWidget, DOMWidget)
 from IPython.display import display, clear_output
 from IPython.utils.py3compat import string_types, unicode_type
-from IPython.utils.traitlets import HasTraits, TraitError, Any, Unicode
+from IPython.utils.traitlets import HasTraits, Any, Unicode
 
 empty = Parameter.empty
 
@@ -116,13 +116,13 @@ def _widget_from_abbrev(abbrev, default=empty):
         return abbrev
     
     widget = _widget_abbrev(abbrev)
-    if default is not empty and isinstance(abbrev, (list, tuple)):
+    if default is not empty and isinstance(abbrev, (list, tuple, dict)):
         # if it's not a single-value abbreviation,
         # set the initial value from the default
         try:
             widget.value = default
-        except TraitError:
-            # warn?
+        except Exception:
+            # ignore failure to set default
             pass
     if widget is None:
         raise ValueError("%r cannot be transformed to a Widget" % (abbrev,))

--- a/IPython/html/widgets/interaction.py
+++ b/IPython/html/widgets/interaction.py
@@ -188,7 +188,6 @@ def interactive(__interact_f, **kwargs):
     getcallargs(f, **{n:v for n,v,_ in new_kwargs})
     # Now build the widgets from the abbreviations.
     kwargs_widgets.extend(_widgets_from_abbreviations(new_kwargs))
-    kwargs_widgets.extend(_widgets_from_abbreviations(sorted(kwargs.items(), key = lambda x: x[0])))
 
     # This has to be done as an assignment, not using container.children.append,
     # so that traitlets notices the update. We skip any objects (such as fixed) that

--- a/IPython/html/widgets/tests/test_interaction.py
+++ b/IPython/html/widgets/tests/test_interaction.py
@@ -298,7 +298,7 @@ def test_default_values():
     )
 
 def test_default_out_of_bounds():
-    @annotate(f=(0, 10.), h={'a': 1, 'b': 2}, j=['hi', 'there'])
+    @annotate(f=(0, 10.), h={'a': 1}, j=['hi', 'there'])
     def f(f='hi', h=5, j='other'):
         pass
     
@@ -310,13 +310,13 @@ def test_default_out_of_bounds():
         ),
         h=dict(
             cls=widgets.DropdownWidget,
-            values={'a': 1, 'b': 2},
-            value=1
+            values={'a': 1},
+            value=1,
         ),
         j=dict(
             cls=widgets.DropdownWidget,
             values={'hi':'hi', 'there':'there'},
-            value='hi'
+            value='hi',
         ),
     )
 

--- a/IPython/html/widgets/tests/test_interaction.py
+++ b/IPython/html/widgets/tests/test_interaction.py
@@ -267,8 +267,8 @@ def test_defaults():
     )
 
 def test_default_values():
-    @annotate(n=10, f=(0, 10.), g=5)
-    def f(n, f=4.5, g=1):
+    @annotate(n=10, f=(0, 10.), g=5, h={'a': 1, 'b': 2}, j=['hi', 'there'])
+    def f(n, f=4.5, g=1, h=2, j='there'):
         pass
     
     c = interactive(f)
@@ -284,6 +284,39 @@ def test_default_values():
         g=dict(
             cls=widgets.IntSliderWidget,
             value=5,
+        ),
+        h=dict(
+            cls=widgets.DropdownWidget,
+            values={'a': 1, 'b': 2},
+            value=2
+        ),
+        j=dict(
+            cls=widgets.DropdownWidget,
+            values={'hi':'hi', 'there':'there'},
+            value='there'
+        ),
+    )
+
+def test_default_out_of_bounds():
+    @annotate(f=(0, 10.), h={'a': 1, 'b': 2}, j=['hi', 'there'])
+    def f(f='hi', h=5, j='other'):
+        pass
+    
+    c = interactive(f)
+    check_widgets(c,
+        f=dict(
+            cls=widgets.FloatSliderWidget,
+            value=5.,
+        ),
+        h=dict(
+            cls=widgets.DropdownWidget,
+            values={'a': 1, 'b': 2},
+            value=1
+        ),
+        j=dict(
+            cls=widgets.DropdownWidget,
+            values={'hi':'hi', 'there':'there'},
+            value='hi'
         ),
     )
 

--- a/IPython/html/widgets/tests/test_interaction.py
+++ b/IPython/html/widgets/tests/test_interaction.py
@@ -22,7 +22,6 @@ import IPython.testing.tools as tt
 from IPython.html import widgets
 from IPython.html.widgets import interact, interactive, Widget, interaction
 from IPython.utils.py3compat import annotate
-# from IPython.utils.capture import capture_output
 
 #-----------------------------------------------------------------------------
 # Utility stuff
@@ -248,7 +247,7 @@ def test_list_tuple_invalid():
 
 def test_defaults():
     @annotate(n=10)
-    def f(n, f=4.5):
+    def f(n, f=4.5, g=1):
         pass
     
     c = interactive(f)
@@ -260,6 +259,31 @@ def test_defaults():
         f=dict(
             cls=widgets.FloatSliderWidget,
             value=4.5,
+        ),
+        g=dict(
+            cls=widgets.IntSliderWidget,
+            value=1,
+        ),
+    )
+
+def test_default_values():
+    @annotate(n=10, f=(0, 10.), g=5)
+    def f(n, f=4.5, g=1):
+        pass
+    
+    c = interactive(f)
+    check_widgets(c,
+        n=dict(
+            cls=widgets.IntSliderWidget,
+            value=10,
+        ),
+        f=dict(
+            cls=widgets.FloatSliderWidget,
+            value=4.5,
+        ),
+        g=dict(
+            cls=widgets.IntSliderWidget,
+            value=5,
         ),
     )
 

--- a/IPython/html/widgets/widget_selection.py
+++ b/IPython/html/widgets/widget_selection.py
@@ -90,6 +90,8 @@ class _SelectionWidget(DOMWidget):
                         # set the selected value name
                         self.value_name = k
                         return
+                # undo the change, and raise KeyError
+                self.value = old
                 raise KeyError(new)
             finally:
                 self.value_lock.release()


### PR DESCRIPTION
If available, use the default value from the signature for the initial condition, when using range/choice abbreviations.

Not affected:
- single-value abbreviations (`@interact(a=5)` sets `a=5`)
- explicit Widgets

as proposed in #5134
