### PR TITLE
Widget API fix: Front-end update invoked updates.

### DIFF
--- a/IPython/html/static/notebook/js/widgets/widget.js
+++ b/IPython/html/static/notebook/js/widgets/widget.js
@@ -37,6 +37,8 @@ function(WidgetManager, _, Backbone){
             this.msg_throttle = 3;
             this.msg_buffer = null;
             this.key_value_lock = null;
+            this.setting_lock = 0;
+            this.save_called = null;
             this.id = model_id;
             this.views = [];
 
@@ -137,14 +139,24 @@ function(WidgetManager, _, Backbone){
         },
 
         set: function(key, val, options) {
-            // Set a value.
-            var return_value = WidgetModel.__super__.set.apply(this, arguments);
+            this.setting_lock++;
+            try {
+                // Set a value.
+                var return_value = WidgetModel.__super__.set.apply(this, arguments);
 
-            // Backbone only remembers the diff of the most recent set()
-            // operation.  Calling set multiple times in a row results in a 
-            // loss of diff information.  Here we keep our own running diff.
-            this._buffered_state_diff = $.extend(this._buffered_state_diff, this.changedAttributes() || {});
-            return return_value;
+                // Backbone only remembers the diff of the most recent set()
+                // operation.  Calling set multiple times in a row results in a 
+                // loss of diff information.  Here we keep our own running diff.
+                this._buffered_state_diff = $.extend(this._buffered_state_diff, this.changedAttributes() || {});
+                return return_value;
+            } finally {
+                this.setting_lock--;
+
+                if (this.setting_lock === 0 && this.save_called) {
+                    this.save_changes(this.save_called);
+                    this.save_called = null;
+                }
+            }
         },
 
         sync: function (method, model, options) {
@@ -217,7 +229,11 @@ function(WidgetManager, _, Backbone){
             // Push this model's state to the back-end
             //
             // This invokes a Backbone.Sync.
-            this.save(this._buffered_state_diff, {patch: true, callbacks: callbacks});
+            if (this.setting_lock > 0) {
+                this.save_called = {patch: true, callbacks: callbacks};
+            } else if (! _.isEmpty(this._buffered_state_diff)) {
+                this.save(this._buffered_state_diff, {patch: true, callbacks: callbacks});    
+            }
         },
 
         _pack_models: function(value) {

--- a/IPython/html/tests/widgets/widget.js
+++ b/IPython/html/tests/widgets/widget.js
@@ -144,9 +144,11 @@ casper.notebook_test(function () {
                     this.model.on('change', this.model_changed, this);
                 },
                 model_changed: function() {
-                    this.model.set('a', 2);
-                    this.model.set('b', 3);
-                    this.touch();
+                    if (this.model.get('a') !== 2) {
+                        this.model.set('a', 2);
+                        this.model.set('b', 3);
+                        this.touch();    
+                    }
                 },
             });
             IPython.WidgetManager.register_widget_view('UpdateUpdate', UpdateUpdate);

--- a/IPython/html/tests/widgets/widget.js
+++ b/IPython/html/tests/widgets/widget.js
@@ -137,7 +137,7 @@ casper.notebook_test(function () {
         this.test.assertEquals(this.get_output_cell(index).text.trim(), '3',
             'Multiple model.set calls sent a partial state.');
 
-        // Test multi-set, single touch code.  First create a custom widget.
+        // Test update invoked update (front-end).
         this.evaluate(function() {
             var UpdateUpdate = IPython.DOMWidgetView.extend({
                 render: function(){

--- a/IPython/html/tests/widgets/widget.js
+++ b/IPython/html/tests/widgets/widget.js
@@ -141,7 +141,7 @@ casper.notebook_test(function () {
         this.evaluate(function() {
             var UpdateUpdate = IPython.DOMWidgetView.extend({
                 render: function(){
-                    this.model.on('change:a', this.model_changed, this);
+                    this.model.on('change', this.model_changed, this);
                 },
                 model_changed: function() {
                     this.model.set('a', 2);

--- a/IPython/html/tests/widgets/widget.js
+++ b/IPython/html/tests/widgets/widget.js
@@ -141,11 +141,12 @@ casper.notebook_test(function () {
         this.evaluate(function() {
             var UpdateUpdate = IPython.DOMWidgetView.extend({
                 render: function(){
-                    this.model.on('change', this.model_changed, this);
+                    this.model.on('change:a', this.model_changed, this);
                 },
                 model_changed: function() {
                     this.model.set('a', 2);
                     this.model.set('b', 3);
+                    this.touch();
                 },
             });
             IPython.WidgetManager.register_widget_view('UpdateUpdate', UpdateUpdate);

--- a/IPython/html/tests/widgets/widget.js
+++ b/IPython/html/tests/widgets/widget.js
@@ -77,7 +77,7 @@ casper.notebook_test(function () {
             test_pack(input);
             test_unpack(input);
         };
-        
+
         test_packing({0: 'hi', 1: 'bye'});
         test_packing(['hi', 'bye']);
         test_packing(['hi', 5]);
@@ -136,6 +136,44 @@ casper.notebook_test(function () {
     this.execute_cell_then(index, function(index) {
         this.test.assertEquals(this.get_output_cell(index).text.trim(), '3',
             'Multiple model.set calls sent a partial state.');
+
+        // Test multi-set, single touch code.  First create a custom widget.
+        this.evaluate(function() {
+            var UpdateUpdate = IPython.DOMWidgetView.extend({
+                render: function(){
+                    this.model.on('change', this.model_changed, this);
+                },
+                model_changed: function() {
+                    this.model.set('a', 2);
+                    this.model.set('b', 3);
+                },
+            });
+            IPython.WidgetManager.register_widget_view('UpdateUpdate', UpdateUpdate);
+        }, {});
+    });
+
+    // Try creating the updateupdate widget, verify that sets the values correctly.
+    var updateupdate = {};
+    updateupdate.index = this.append_cell(
+        'class UpdateUpdateWidget(widgets.Widget):\n' +
+        '    _view_name = Unicode("UpdateUpdate", sync=True)\n' +
+        '    a = CInt(0, sync=True)\n' +
+        '    b = CInt(0, sync=True)\n' +
+        'updateupdate = UpdateUpdateWidget()\n' +
+        'display(updateupdate)\n' +
+        'updateupdate.a = 1\n' +
+        'print(updateupdate.model_id)');
+    this.execute_cell_then(updateupdate.index, function(index) {
+        updateupdate.model_id = this.get_output_cell(index).text.trim();
+    });
+
+    this.wait_for_widget(updateupdate);
+
+    index = this.append_cell(
+        'print("%d%d" % (updateupdate.a, updateupdate.b))');
+    this.execute_cell_then(index, function(index) {
+        this.test.assertEquals(this.get_output_cell(index).text.trim(), '23',
+            'Update invoked update in the front-end synced to the back-end.');
     });
 
     var textbox = {};


### PR DESCRIPTION
Fixes a problem with cummulative multi-set diff logic as pointed out by @jasongrout

> This seems to be a likely scenario:
> - A function triggered on the model change invokes `model.save_changes` to sync
> - The buffered diff wouldn't be updated, so the model would get confused about what to sync
