### PR TITLE
WIP: %kernels magic

### DIFF
--- a/IPython/html/kernels_magic.py
+++ b/IPython/html/kernels_magic.py
@@ -30,6 +30,7 @@ nb = """<div class="list_item row-fluid">
 js = """
 var nb = '<div class="list_item row-fluid"> <div class="span12"> <i class="item_icon icon-book"></i> <a class="item_link" href="/notebooks/NAME" target="_blank"> <span class="item_name">NAME</span></a> <div class="item_buttons btn-group pull-right"> <button class="btn btn-mini btn-danger">Shutdown</button> </div> </div> </div>'
 
+var this_path = IPython.notebook.notebook_path + "/" + IPython.notebook.notebook_name;
 var load_sessions = function () {
     var settings = {
         processData : false,
@@ -40,7 +41,8 @@ var load_sessions = function () {
             // clear out the previous list
             $('#kernels_list').replaceWith("<div id='kernels_list'></div>")
             for (var i = d.length-1; i >= 0; i--) {
-                var x = $('#kernels_list ul').append(nb.replace(/NAME/g, d[i].notebook.name));
+                var path = d[i].notebook.path + '/' + d[i].notebook.name;
+                var x = $('#kernels_list').append(nb.replace(/NAME/g, path));
                 add_shutdown_button(x, d[i].id);
             }
         }, this)

--- a/IPython/html/kernels_magic.py
+++ b/IPython/html/kernels_magic.py
@@ -1,0 +1,94 @@
+"""
+Kernel's magic work in progress
+"""
+import os
+from IPython.display import display, Javascript, HTML
+
+list = """<div id='kernels_list'>
+     List of Active Kernels:
+    <ul>
+    
+    </ul>
+</div>
+"""
+
+nb = """<div class="list_item row-fluid">
+    <div class="span12">
+        <i class="item_icon icon-book"></i>
+        <a class="item_link" href="/notebooks/" target="_blank">
+        <span class="item_name">kernels magic.ipynb</span></a>
+        <div class="item_buttons btn-group pull-right">
+            <button class="btn btn-mini btn-danger">Shutdown</button>
+        </div>
+    </div>
+</div>"""
+
+# TODO: refactor notebooklist.js so the relevant portion we've ripped out here
+# can be used from a util function.
+js = """
+var nb = '<div class="list_item row-fluid"> <div class="span12"> <i class="item_icon icon-book"></i> <a class="item_link" href="/notebooks/NAME" target="_blank"> <span class="item_name">NAME</span></a> <div class="item_buttons btn-group pull-right"> <button class="btn btn-mini btn-danger">Shutdown</button> </div> </div> </div>'
+
+var load_sessions = function () {
+    var settings = {
+        processData : false,
+        cache : false,
+        type : "GET",
+        dataType : "json",
+        success : $.proxy(function(d) { 
+            console.log(d);
+            for (var i = d.length-1; i >= 0; i--) {
+                var c = d[i];
+                console.log(c.id);
+                // 
+                var x = $('#kernels_list ul').append(nb.replace(/NAME/g, c.notebook.name));
+                add_shutdown_button(x, c.id);
+                //$('#kernels_list ul').append("<li>" + c.notebook.name + "</li>")
+                //$('#kernels_list ul').append("<button class='btn btn-mini btn-danger'>Shutdown</button>")
+            }
+        }, this)
+    };
+    var url = utils.url_join_encode('/api/sessions');
+    var aj= $.ajax(url,settings);
+};
+
+load_sessions();
+
+// TODO: this was ripped out of notebooklist.js, refactor to use it
+var add_shutdown_button = function (item, session) {
+        var that = this;
+        console.log('adding ', item, session);
+        var shutdown_button = $("<button/>").text("Shutdown").addClass("btn btn-mini btn-danger").
+            click(function (e) {
+                var settings = {
+                    processData : false,
+                    cache : false,
+                    type : "DELETE",
+                    dataType : "json",
+                    success : function () {
+                        that.load_sessions();
+                    }
+                };
+                var url = utils.url_join_encode(
+                    '/',
+                    'api/sessions',
+                    session
+                );
+                $.ajax(url, settings);
+                return false;
+            });
+        // var new_buttons = item.find('a'); // shutdown_button;
+        item.find(".input_button").text("").append(shutdown_button);
+    
+    
+        console.log(shutdown_button);
+        item.find('.item_buttons').text("").append(shutdown_button);
+    
+    };
+"""
+def list_kernels(line=''):
+    display(HTML(list))
+    display(Javascript(js))
+
+def load_ipython_extension(ip):
+    ip.magics_manager.register_function(list_kernels, magic_name='kernels')
+    list_kernels()

--- a/IPython/html/kernels_magic.py
+++ b/IPython/html/kernels_magic.py
@@ -3,14 +3,15 @@ Kernel's magic work in progress
 """
 from IPython.display import display, Javascript, HTML
 
-list = """<div id='kernels_list'>
+list = """
         <div class="item_buttons btn-group">
             <button id="refresh_kernels" class="btn btn-mini">Active Kernels (click to update)</button>
         </div>
-    <ul>
-    
-    </ul>
-</div>
+        <div class="alert" style="margin: 10px">
+        Warning: Opening a notebook from here that is still open in another
+        browser window may cause unpredictable state.
+        </div>
+<div id='kernels_list'></div>
 """
 
 nb = """<div class="list_item row-fluid">
@@ -37,7 +38,7 @@ var load_sessions = function () {
         dataType : "json",
         success : $.proxy(function(d) { 
             // clear out the previous list
-            $('#kernels_list ul').replaceWith("<ul></ul>")
+            $('#kernels_list').replaceWith("<div id='kernels_list'></div>")
             for (var i = d.length-1; i >= 0; i--) {
                 var x = $('#kernels_list ul').append(nb.replace(/NAME/g, d[i].notebook.name));
                 add_shutdown_button(x, d[i].id);

--- a/IPython/html/kernels_magic.py
+++ b/IPython/html/kernels_magic.py
@@ -1,7 +1,6 @@
 """
 Kernel's magic work in progress
 """
-import os
 from IPython.display import display, Javascript, HTML
 
 list = """<div id='kernels_list'>
@@ -35,10 +34,10 @@ var load_sessions = function () {
         type : "GET",
         dataType : "json",
         success : $.proxy(function(d) { 
-            console.log(d);
+            // clear out the preious list
+            $('#kernels_list ul').replaceWith("<ul></ul>")
             for (var i = d.length-1; i >= 0; i--) {
                 var c = d[i];
-                console.log(c.id);
                 // 
                 var x = $('#kernels_list ul').append(nb.replace(/NAME/g, c.notebook.name));
                 add_shutdown_button(x, c.id);
@@ -55,8 +54,6 @@ load_sessions();
 
 // TODO: this was ripped out of notebooklist.js, refactor to use it
 var add_shutdown_button = function (item, session) {
-        var that = this;
-        console.log('adding ', item, session);
         var shutdown_button = $("<button/>").text("Shutdown").addClass("btn btn-mini btn-danger").
             click(function (e) {
                 var settings = {
@@ -65,7 +62,7 @@ var add_shutdown_button = function (item, session) {
                     type : "DELETE",
                     dataType : "json",
                     success : function () {
-                        that.load_sessions();
+                        load_sessions();
                     }
                 };
                 var url = utils.url_join_encode(
@@ -80,15 +77,19 @@ var add_shutdown_button = function (item, session) {
         item.find(".input_button").text("").append(shutdown_button);
     
     
-        console.log(shutdown_button);
         item.find('.item_buttons').text("").append(shutdown_button);
     
     };
 """
 def list_kernels(line=''):
+    """
+    List the notebooks with the currently active kernels. You can shutdown
+    these kernels by clicking the red "Shutdown" button.
+
+    TODO: add `%kernels kill kernel_id` option
+    """
     display(HTML(list))
     display(Javascript(js))
 
 def load_ipython_extension(ip):
     ip.magics_manager.register_function(list_kernels, magic_name='kernels')
-    list_kernels()

--- a/IPython/html/kernels_magic.py
+++ b/IPython/html/kernels_magic.py
@@ -4,14 +4,15 @@ Kernel's magic work in progress
 from IPython.display import display, Javascript, HTML
 
 list = """
+        <div class="alert" style="margin-left: 8px">
+        <b>Warning:</b> Opening the same notebook using more than one browser
+        window may cause you unpredictable behaviour
+        </div>
         <div class="item_buttons btn-group">
             <button id="refresh_kernels" class="btn btn-mini">Active Kernels (click to update)</button>
         </div>
-        <div class="alert" style="margin: 10px">
-        Warning: Opening a notebook from here that is still open in another
-        browser window may cause unpredictable state.
-        </div>
-<div id='kernels_list'></div>
+<div class='kernels_list'>
+</div>
 """
 
 nb = """<div class="list_item row-fluid">

--- a/IPython/html/kernels_magic.py
+++ b/IPython/html/kernels_magic.py
@@ -40,16 +40,16 @@ var load_sessions = function () {
         dataType : "json",
         success : $.proxy(function(d) { 
             // clear out the previous list
-            $('#kernels_list').replaceWith("<div id='kernels_list'></div>")
+            $('.kernels_list .list_item').remove();
             for (var i = d.length-1; i >= 0; i--) {
                 var path = d[i].notebook.path + '/' + d[i].notebook.name;
-                var x = $('#kernels_list').append(nb.replace(/NAME/g, path));
-                if (path == this_path) {
-                    x.find('.list_item').slice(-1).find('a')
-                        .removeAttr('href').attr('title', 'this notebook');
-                }
+                var x = $('.kernels_list').append(nb.replace(/NAME/g, path));
                 add_shutdown_button(x, d[i].id);
             }
+            // Now let's remove the active link that points to *this* notebook
+            $("span.item_name").filter(function() {
+                    return $(this).html() === this_path;
+                }).parent().removeAttr('href').attr('title', 'this notebook');
         }, this)
     };
     var url = utils.url_join_encode('/api/sessions');

--- a/IPython/html/kernels_magic.py
+++ b/IPython/html/kernels_magic.py
@@ -4,7 +4,9 @@ Kernel's magic work in progress
 from IPython.display import display, Javascript, HTML
 
 list = """<div id='kernels_list'>
-     List of Active Kernels:
+        <div class="item_buttons btn-group">
+            <button id="refresh_kernels" class="btn btn-mini">Active Kernels (click to update)</button>
+        </div>
     <ul>
     
     </ul>
@@ -34,15 +36,11 @@ var load_sessions = function () {
         type : "GET",
         dataType : "json",
         success : $.proxy(function(d) { 
-            // clear out the preious list
+            // clear out the previous list
             $('#kernels_list ul').replaceWith("<ul></ul>")
             for (var i = d.length-1; i >= 0; i--) {
-                var c = d[i];
-                // 
-                var x = $('#kernels_list ul').append(nb.replace(/NAME/g, c.notebook.name));
-                add_shutdown_button(x, c.id);
-                //$('#kernels_list ul').append("<li>" + c.notebook.name + "</li>")
-                //$('#kernels_list ul').append("<button class='btn btn-mini btn-danger'>Shutdown</button>")
+                var x = $('#kernels_list ul').append(nb.replace(/NAME/g, d[i].notebook.name));
+                add_shutdown_button(x, d[i].id);
             }
         }, this)
     };
@@ -51,6 +49,8 @@ var load_sessions = function () {
 };
 
 load_sessions();
+
+$('#refresh_kernels').click(load_sessions);
 
 // TODO: this was ripped out of notebooklist.js, refactor to use it
 var add_shutdown_button = function (item, session) {
@@ -66,17 +66,13 @@ var add_shutdown_button = function (item, session) {
                     }
                 };
                 var url = utils.url_join_encode(
-                    '/',
+                    IPython.notebook.base_url,
                     'api/sessions',
                     session
                 );
                 $.ajax(url, settings);
                 return false;
             });
-        // var new_buttons = item.find('a'); // shutdown_button;
-        item.find(".input_button").text("").append(shutdown_button);
-    
-    
         item.find('.item_buttons').text("").append(shutdown_button);
     
     };

--- a/IPython/html/kernels_magic.py
+++ b/IPython/html/kernels_magic.py
@@ -43,6 +43,10 @@ var load_sessions = function () {
             for (var i = d.length-1; i >= 0; i--) {
                 var path = d[i].notebook.path + '/' + d[i].notebook.name;
                 var x = $('#kernels_list').append(nb.replace(/NAME/g, path));
+                if (path == this_path) {
+                    x.find('.list_item').slice(-1).find('a')
+                        .removeAttr('href').attr('title', 'this notebook');
+                }
                 add_shutdown_button(x, d[i].id);
             }
         }, this)

--- a/IPython/html/kernels_magic.py
+++ b/IPython/html/kernels_magic.py
@@ -86,9 +86,7 @@ var add_shutdown_button = function (item, session) {
     };
 """
 def list_kernels(line=''):
-    """
-    List the notebooks with the currently active kernels. You can shutdown
-    these kernels by clicking the red "Shutdown" button.
+    """List notebooks with currently active kernels which can be shutdown.
 
     TODO: add `%kernels kill kernel_id` option
     """

--- a/IPython/html/kernels_magic.py
+++ b/IPython/html/kernels_magic.py
@@ -47,9 +47,10 @@ var load_sessions = function () {
                 add_shutdown_button(x, d[i].id);
             }
             // Now let's remove the active link that points to *this* notebook
-            $("span.item_name").filter(function() {
+            var p = $("span.item_name").filter(function() {
                     return $(this).html() === this_path;
                 }).parent().removeAttr('href').attr('title', 'this notebook');
+            p.parent().find('button').remove();
         }, this)
     };
     var url = utils.url_join_encode('/api/sessions');

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -560,6 +560,7 @@ class NotebookApp(BaseIPythonApplication):
         self.kernel_argv.append("--IPKernelApp.parent_appname='%s'" % self.name)
         # Kernel should get *absolute* path to profile directory
         self.kernel_argv.extend(["--profile-dir", self.profile_dir.location])
+        self.kernel_argv.append("-c='%load_ext IPython.html.kernels_magic'")
 
     def init_configurables(self):
         # force Session default to be secure


### PR DESCRIPTION
@fperez requested this, and here's a functional version of it. 

This PR adds a `%kernels` magic, which returns a list of notebooks which have an active kernel, and adds a shutdown button for it, just like on the dashboard's Notebooks tab. The difference is that this will show _all_ notebooks with an active kernel, not just the ones in the current subdirectory, and it will list the entire (served) path for the notebook.

Features:
- [x] list of active notebooks updated when shutting down a kernel.
- [x] above actually updates all results of %kernels magic for this notebook
- [x] link to the current notebook is inactive
- [x] allow manual update (in case kernels were started or shutdown since the magic was originally run)

TODO:
- [ ] sane representation in console
- [ ] `%kernels kill <id>` (not yet implemented)
  - this is actually quite difficult, since kernels do not know that they are running in from a notebook server

optional:
- [ ] refactor NotebookList so we can add an Active Kernels dashboard tab (depending on feedback)
  - on the table for [this week's lab meeting](https://hackpad.com/2014-IPython-Weekly-Development-Meetings-v8bNV6EmqVd#:h=February-20,-2014)
- [ ] window blur and focus autorefresh (like the dashboard view)
- [ ] switch to the recycling symbol for refreshing ? 

(see screenshot below)
