### PR TITLE
Do not validate keyword arguments set to None (Traits)

### DIFF
--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -232,7 +232,7 @@ class link(object):
             for obj,attr in self.objects.keys():
                 if obj is not sending_obj or attr != sending_attr:
                     setattr(obj, attr, new)
-    
+
     def unlink(self):
         for key, callback in self.objects.items():
             (obj,attr) = key
@@ -484,7 +484,7 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
         # We need to use setattr for this to trigger validation and
         # notifications.
         for key, value in iteritems(kw):
-	    if value is not None:
+            if value is not None:
                 setattr(self, key, value)
 
     def _notify_trait(self, name, old_value, new_value):

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -484,7 +484,8 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
         # We need to use setattr for this to trigger validation and
         # notifications.
         for key, value in iteritems(kw):
-            setattr(self, key, value)
+	    if value is not None:
+                setattr(self, key, value)
 
     def _notify_trait(self, name, old_value, new_value):
 


### PR DESCRIPTION
Default Python behavior should be that None is equivalent to not
set.
