### PR TITLE
Dashboard sorting

### DIFF
--- a/IPython/html/services/notebooks/filenbmanager.py
+++ b/IPython/html/services/notebooks/filenbmanager.py
@@ -18,6 +18,7 @@ Authors:
 #-----------------------------------------------------------------------------
 
 import io
+import locale
 import os
 import glob
 import shutil
@@ -30,6 +31,10 @@ from IPython.utils.traitlets import Unicode, Dict, Bool, TraitError
 from IPython.utils.py3compat import getcwd
 from IPython.utils import tz
 from IPython.html.utils import is_hidden, to_os_path
+
+def sort_key(item):
+    """Case-insensitive, locale aware sorting."""
+    return locale.strxfrm(item['name'].lower())
 
 #-----------------------------------------------------------------------------
 # Classes
@@ -189,7 +194,7 @@ class FileNotebookManager(NotebookManager):
                 except IOError:
                     pass
                 dirs.append(model)
-        dirs = sorted(dirs, key=lambda item: item['name'])
+        dirs = sorted(dirs, key=sort_key)
         return dirs
 
     # TODO: Remove this after we create the contents web service and directories are
@@ -230,7 +235,7 @@ class FileNotebookManager(NotebookManager):
         path = path.strip('/')
         notebook_names = self.get_notebook_names(path)
         notebooks = [self.get_notebook(name, path, content=False) for name in notebook_names]
-        notebooks = sorted(notebooks, key=lambda item: item['name'])
+        notebooks = sorted(notebooks, key=sort_key)
         return notebooks
 
     def get_notebook(self, name, path='', content=True):

--- a/IPython/html/services/notebooks/filenbmanager.py
+++ b/IPython/html/services/notebooks/filenbmanager.py
@@ -18,7 +18,6 @@ Authors:
 #-----------------------------------------------------------------------------
 
 import io
-import locale
 import os
 import glob
 import shutil
@@ -33,8 +32,8 @@ from IPython.utils import tz
 from IPython.html.utils import is_hidden, to_os_path
 
 def sort_key(item):
-    """Case-insensitive, locale aware sorting."""
-    return locale.strxfrm(item['name'].lower())
+    """Case-insensitive sorting."""
+    return item['name'].lower()
 
 #-----------------------------------------------------------------------------
 # Classes

--- a/IPython/html/services/notebooks/filenbmanager.py
+++ b/IPython/html/services/notebooks/filenbmanager.py
@@ -182,7 +182,8 @@ class FileNotebookManager(NotebookManager):
         dirs = []
         for name in dir_names:
             os_path = self._get_os_path(name, path)
-            if os.path.isdir(os_path) and not is_hidden(os_path, self.notebook_dir):
+            if os.path.isdir(os_path) and not is_hidden(os_path, self.notebook_dir)\
+                    and not name.startswith('_'):
                 try:
                     model = self.get_dir_model(name, path)
                 except IOError:

--- a/IPython/html/services/notebooks/filenbmanager.py
+++ b/IPython/html/services/notebooks/filenbmanager.py
@@ -26,7 +26,7 @@ from tornado import web
 
 from .nbmanager import NotebookManager
 from IPython.nbformat import current
-from IPython.utils.traitlets import Unicode, Dict, Bool, TraitError
+from IPython.utils.traitlets import Unicode, Bool, TraitError
 from IPython.utils.py3compat import getcwd
 from IPython.utils import tz
 from IPython.html.utils import is_hidden, to_os_path
@@ -461,7 +461,7 @@ class FileNotebookManager(NotebookManager):
             )
         # ensure notebook is readable (never restore from an unreadable notebook)
         with io.open(cp_path, 'r', encoding='utf-8') as f:
-            nb = current.read(f, u'json')
+            current.read(f, u'json')
         shutil.copy2(cp_path, nb_path)
         self.log.debug("copying %s -> %s", cp_path, nb_path)
     

--- a/IPython/html/services/notebooks/filenbmanager.py
+++ b/IPython/html/services/notebooks/filenbmanager.py
@@ -187,7 +187,7 @@ class FileNotebookManager(NotebookManager):
         for name in dir_names:
             os_path = self._get_os_path(name, path)
             if os.path.isdir(os_path) and not is_hidden(os_path, self.notebook_dir)\
-                    and not name.startswith('_'):
+                    and self.should_list(name):
                 try:
                     model = self.get_dir_model(name, path)
                 except IOError:
@@ -233,7 +233,8 @@ class FileNotebookManager(NotebookManager):
         """
         path = path.strip('/')
         notebook_names = self.get_notebook_names(path)
-        notebooks = [self.get_notebook(name, path, content=False) for name in notebook_names]
+        notebooks = [self.get_notebook(name, path, content=False)
+                        for name in notebook_names if self.should_list(name)]
         notebooks = sorted(notebooks, key=sort_key)
         return notebooks
 

--- a/IPython/html/services/notebooks/nbmanager.py
+++ b/IPython/html/services/notebooks/nbmanager.py
@@ -17,12 +17,13 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
+from fnmatch import fnmatch
 import itertools
 import os
 
 from IPython.config.configurable import LoggingConfigurable
 from IPython.nbformat import current, sign
-from IPython.utils.traitlets import Instance, Unicode
+from IPython.utils.traitlets import Instance, Unicode, List
 
 #-----------------------------------------------------------------------------
 # Classes
@@ -36,6 +37,10 @@ class NotebookManager(LoggingConfigurable):
     def _notary_default(self):
         return sign.NotebookNotary(parent=self)
     
+    hide_globs = List(Unicode, [u'__pycache__'], config=True, help="""
+        Glob patterns to hide in file and directory listings.
+    """)
+
     # NotebookManager API part 1: methods that must be
     # implemented in subclasses.
 
@@ -241,3 +246,6 @@ class NotebookManager(LoggingConfigurable):
             self.log.warn("Notebook %s/%s is not trusted", path, name)
         self.notary.mark_cells(nb, trusted)
 
+    def should_list(self, name):
+        """Should this file/directory name be displayed in a listing?"""
+        return not any(fnmatch(name, glob) for glob in self.hide_globs)

--- a/IPython/html/services/notebooks/tests/test_notebooks_api.py
+++ b/IPython/html/services/notebooks/tests/test_notebooks_api.py
@@ -101,7 +101,10 @@ class APITest(NotebookTestBase):
                 ('foo', 'name with spaces'),
                 ('foo', u'unicodé'),
                 ('foo/bar', 'baz'),
-                (u'å b', u'ç d')
+                ('ordering', 'A'),
+                ('ordering', 'b'),
+                ('ordering', 'C'),
+                (u'å b', u'ç d'),
                ]
     hidden_dirs = ['.hidden', '__pycache__']
 
@@ -159,6 +162,11 @@ class APITest(NotebookTestBase):
         nbnames = { normalize('NFC', n['name']) for n in nbs }
         expected = [ u'a.ipynb', u'b.ipynb', u'name with spaces.ipynb', u'unicodé.ipynb']
         expected = { normalize('NFC', name) for name in expected }
+        self.assertEqual(nbnames, expected)
+        
+        nbs = notebooks_only(self.nb_api.list('ordering').json())
+        nbnames = [n['name'] for n in nbs]
+        expected = ['A.ipynb', 'b.ipynb', 'C.ipynb']
         self.assertEqual(nbnames, expected)
 
     def test_list_dirs(self):


### PR DESCRIPTION
- Hide directories beginning with `_` (#5152)
- Case-insensitive sorting (#5151), including an attempt at locale-aware sorting, although this doesn't pick up obvious characters like é on my machine.

Possibly ordering should be done by the frontend, but we're already relying on the order from the API to get index.ipynb and directory names before other things.
