### PR TITLE
log refusal to serve hidden directories

### DIFF
--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -263,6 +263,7 @@ class AuthenticatedFileHandler(IPythonHandler, web.StaticFileHandler):
         abs_path = super(AuthenticatedFileHandler, self).validate_absolute_path(root, absolute_path)
         abs_root = os.path.abspath(root)
         if is_hidden(abs_path, abs_root):
+            self.log.info("Refusing to serve hidden file, via 404 Error")
             raise web.HTTPError(404)
         return abs_path
 

--- a/IPython/html/services/notebooks/filenbmanager.py
+++ b/IPython/html/services/notebooks/filenbmanager.py
@@ -180,6 +180,8 @@ class FileNotebookManager(NotebookManager):
         """List the directories for a given API style path."""
         path = path.strip('/')
         os_path = self._get_os_path('', path)
+        if is_hidden(os_path, self.notebook_dir):
+            self.log.info("Refusing to serve hidden directory, via 404 Error")
         if not os.path.isdir(os_path) or is_hidden(os_path, self.notebook_dir):
             raise web.HTTPError(404, u'directory does not exist: %r' % os_path)
         dir_names = os.listdir(os_path)

--- a/IPython/html/services/notebooks/filenbmanager.py
+++ b/IPython/html/services/notebooks/filenbmanager.py
@@ -180,9 +180,10 @@ class FileNotebookManager(NotebookManager):
         """List the directories for a given API style path."""
         path = path.strip('/')
         os_path = self._get_os_path('', path)
-        if is_hidden(os_path, self.notebook_dir):
+        if not os.path.isdir(os_path):
+            raise web.HTTPError(404, u'directory does not exist: %r' % os_path)
+        elif is_hidden(os_path, self.notebook_dir):
             self.log.info("Refusing to serve hidden directory, via 404 Error")
-        if not os.path.isdir(os_path) or is_hidden(os_path, self.notebook_dir):
             raise web.HTTPError(404, u'directory does not exist: %r' % os_path)
         dir_names = os.listdir(os_path)
         dirs = []

--- a/IPython/html/tree/handlers.py
+++ b/IPython/html/tree/handlers.py
@@ -62,10 +62,11 @@ class TreeHandler(IPythonHandler):
             self.log.debug("Redirecting %s to %s", self.request.path, url)
             self.redirect(url)
         else:
-            if nbm.is_hidden(path):
-                self.log.info("Refusing to serve hidden directory, via 404 Error")
-            if not nbm.path_exists(path=path) or nbm.is_hidden(path):
+            if not nbm.path_exists(path=path):
                 # Directory is hidden or does not exist.
+                raise web.HTTPError(404)
+            elif nbm.is_hidden(path):
+                self.log.info("Refusing to serve hidden directory, via 404 Error")
                 raise web.HTTPError(404)
             breadcrumbs = self.generate_breadcrumbs(path)
             page_title = self.generate_page_title(path)

--- a/IPython/html/tree/handlers.py
+++ b/IPython/html/tree/handlers.py
@@ -62,6 +62,8 @@ class TreeHandler(IPythonHandler):
             self.log.debug("Redirecting %s to %s", self.request.path, url)
             self.redirect(url)
         else:
+            if nbm.is_hidden(path):
+                self.log.info("Refusing to serve hidden directory, via 404 Error")
             if not nbm.path_exists(path=path) or nbm.is_hidden(path):
                 # Directory is hidden or does not exist.
                 raise web.HTTPError(404)


### PR DESCRIPTION
This PR  originally addressed #5157, and was titled "serve hidden directories when explicitly requested". 

Now it simply logs the refusal to serve hidden directories, but continues to serve 404 to the user as before.
