### PR TITLE
Prevent page breaks when printing notebooks via print-view.

### DIFF
--- a/IPython/nbconvert/templates/html/full.tpl
+++ b/IPython/nbconvert/templates/html/full.tpl
@@ -32,6 +32,21 @@ pre {
   margin: 0px;
   font-size: 13px;
 }
+
+@media print {
+  div.cell {
+    display: block;
+    page-break-inside: avoid;
+  } 
+  div.output_wrapper { 
+    display: block;
+    page-break-inside: avoid; 
+  }
+  div.output { 
+    display: block;
+    page-break-inside: avoid; 
+  }
+}
 </style>
 
 <!-- Custom stylesheet, it must be in the same directory as the html file -->


### PR DESCRIPTION
Adds `page-break-inside: avoid;` to the nbconvert html full template.

closes #5115
closes #5024 
