### PR TITLE
remove websocket url

### DIFF
--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -120,15 +120,6 @@ class IPythonHandler(AuthenticatedHandler):
     #---------------------------------------------------------------
     
     @property
-    def ws_url(self):
-        """websocket url matching the current request
-
-        By default, this is just `''`, indicating that it should match
-        the same host, protocol, port, etc.
-        """
-        return self.settings.get('websocket_url', '')
-    
-    @property
     def mathjax_url(self):
         return self.settings.get('mathjax_url', '')
     

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -430,14 +430,6 @@ class NotebookApp(BaseIPythonApplication):
         self.log.warn("base_project_url is deprecated, use base_url")
         self.base_url = new
 
-    websocket_url = Unicode("", config=True,
-        help="""The base URL for the websocket server,
-        if it differs from the HTTP server (hint: it almost certainly doesn't).
-        
-        Should be in the form of an HTTP origin: ws[s]://hostname[:port]
-        """
-    )
-
     extra_static_paths = List(Unicode, config=True,
         help="""Extra paths to search for serving static files.
         

--- a/IPython/html/services/kernels/handlers.py
+++ b/IPython/html/services/kernels/handlers.py
@@ -38,14 +38,14 @@ class MainKernelHandler(IPythonHandler):
     @json_errors
     def get(self):
         km = self.kernel_manager
-        self.finish(jsonapi.dumps(km.list_kernels(self.ws_url)))
+        self.finish(jsonapi.dumps(km.list_kernels()))
 
     @web.authenticated
     @json_errors
     def post(self):
         km = self.kernel_manager
         kernel_id = km.start_kernel()
-        model = km.kernel_model(kernel_id, self.ws_url)
+        model = km.kernel_model(kernel_id)
         location = url_path_join(self.base_url, 'api', 'kernels', kernel_id)
         self.set_header('Location', url_escape(location))
         self.set_status(201)
@@ -61,7 +61,7 @@ class KernelHandler(IPythonHandler):
     def get(self, kernel_id):
         km = self.kernel_manager
         km._check_kernel_id(kernel_id)
-        model = km.kernel_model(kernel_id, self.ws_url)
+        model = km.kernel_model(kernel_id)
         self.finish(jsonapi.dumps(model))
 
     @web.authenticated
@@ -84,7 +84,7 @@ class KernelActionHandler(IPythonHandler):
             self.set_status(204)
         if action == 'restart':
             km.restart_kernel(kernel_id)
-            model = km.kernel_model(kernel_id, self.ws_url)
+            model = km.kernel_model(kernel_id)
             self.set_header('Location', '{0}api/kernels/{1}'.format(self.base_url, kernel_id))
             self.write(jsonapi.dumps(model))
         self.finish()

--- a/IPython/html/services/kernels/kernelmanager.py
+++ b/IPython/html/services/kernels/kernelmanager.py
@@ -75,19 +75,19 @@ class MappingKernelManager(MultiKernelManager):
         self._check_kernel_id(kernel_id)
         super(MappingKernelManager, self).shutdown_kernel(kernel_id, now=now)
 
-    def kernel_model(self, kernel_id, ws_url):
+    def kernel_model(self, kernel_id):
         """Return a dictionary of kernel information described in the
         JSON standard model."""
         self._check_kernel_id(kernel_id)
-        model = {"id":kernel_id, "ws_url": ws_url}
+        model = {"id":kernel_id}
         return model
 
-    def list_kernels(self, ws_url):
+    def list_kernels(self):
         """Returns a list of kernel_id's of kernels running."""
         kernels = []
         kernel_ids = super(MappingKernelManager, self).list_kernel_ids()
         for kernel_id in kernel_ids:
-            model = self.kernel_model(kernel_id, ws_url)
+            model = self.kernel_model(kernel_id)
             kernels.append(model)
         return kernels
 

--- a/IPython/html/services/kernels/tests/test_kernels_api.py
+++ b/IPython/html/services/kernels/tests/test_kernels_api.py
@@ -93,7 +93,6 @@ class KernelAPITest(NotebookTestBase):
         self.assertEqual(r.headers['Location'], '/api/kernels/'+kern2['id'])
         rekern = r.json()
         self.assertEqual(rekern['id'], kern2['id'])
-        self.assertIn('ws_url', rekern)
 
     def test_kernel_handler(self):
         # GET kernel with given id
@@ -103,7 +102,6 @@ class KernelAPITest(NotebookTestBase):
         self.assertEqual(r.status_code, 200)
         assert isinstance(kern1, dict)
         self.assertIn('id', kern1)
-        self.assertIn('ws_url', kern1)
         self.assertEqual(kern1['id'], kid)
 
         # Request a bad kernel id and check that a JSON

--- a/IPython/html/services/sessions/handlers.py
+++ b/IPython/html/services/sessions/handlers.py
@@ -63,7 +63,7 @@ class SessionRootHandler(IPythonHandler):
             model = sm.get_session(name=name, path=path)
         else:
             kernel_id = km.start_kernel(cwd=nbm.get_os_path(path))
-            model = sm.create_session(name=name, path=path, kernel_id=kernel_id, ws_url=self.ws_url)
+            model = sm.create_session(name=name, path=path, kernel_id=kernel_id)
         location = url_path_join(self.base_url, 'api', 'sessions', model['id'])
         self.set_header('Location', url_escape(location))
         self.set_status(201)

--- a/IPython/html/services/sessions/sessionmanager.py
+++ b/IPython/html/services/sessions/sessionmanager.py
@@ -33,7 +33,7 @@ class SessionManager(LoggingConfigurable):
     # Session database initialized below
     _cursor = None
     _connection = None
-    _columns = {'session_id', 'name', 'path', 'kernel_id', 'ws_url'}
+    _columns = {'session_id', 'name', 'path', 'kernel_id'}
     
     @property
     def cursor(self):
@@ -41,7 +41,7 @@ class SessionManager(LoggingConfigurable):
         if self._cursor is None:
             self._cursor = self.connection.cursor()
             self._cursor.execute("""CREATE TABLE session 
-                (session_id, name, path, kernel_id, ws_url)""")
+                (session_id, name, path, kernel_id)""")
         return self._cursor
 
     @property
@@ -69,12 +69,12 @@ class SessionManager(LoggingConfigurable):
         "Create a uuid for a new session"
         return unicode_type(uuid.uuid4())
 
-    def create_session(self, name=None, path=None, kernel_id=None, ws_url=None):
+    def create_session(self, name=None, path=None, kernel_id=None):
         """Creates a session and returns its model"""
         session_id = self.new_session_id()
-        return self.save_session(session_id, name=name, path=path, kernel_id=kernel_id, ws_url=ws_url)
+        return self.save_session(session_id, name=name, path=path, kernel_id=kernel_id)
 
-    def save_session(self, session_id, name=None, path=None, kernel_id=None, ws_url=None):
+    def save_session(self, session_id, name=None, path=None, kernel_id=None):
         """Saves the items for the session with the given session_id
         
         Given a session_id (and any other of the arguments), this method
@@ -91,16 +91,14 @@ class SessionManager(LoggingConfigurable):
             the path to the named notebook
         kernel_id : str
             a uuid for the kernel associated with this session
-        ws_url : str
-            the websocket url
-            
+        
         Returns
         -------
         model : dict
             a dictionary of the session model
         """
-        self.cursor.execute("INSERT INTO session VALUES (?,?,?,?,?)",
-            (session_id, name, path, kernel_id, ws_url)
+        self.cursor.execute("INSERT INTO session VALUES (?,?,?,?)",
+            (session_id, name, path, kernel_id)
         )
         return self.get_session(session_id=session_id)
 
@@ -114,7 +112,7 @@ class SessionManager(LoggingConfigurable):
         ----------
         **kwargs : keyword argument
             must be given one of the keywords and values from the session database
-            (i.e. session_id, name, path, kernel_id, ws_url)
+            (i.e. session_id, name, path, kernel_id)
 
         Returns
         -------
@@ -184,7 +182,6 @@ class SessionManager(LoggingConfigurable):
             },
             'kernel': {
                 'id': row['kernel_id'],
-                'ws_url': row['ws_url']
             }
         }
         return model

--- a/IPython/html/services/sessions/tests/test_sessionmanager.py
+++ b/IPython/html/services/sessions/tests/test_sessionmanager.py
@@ -11,16 +11,16 @@ class TestSessionManager(TestCase):
     def test_get_session(self):
         sm = SessionManager()
         session_id = sm.new_session_id()
-        sm.save_session(session_id=session_id, name='test.ipynb', path='/path/to/', kernel_id='5678', ws_url='ws_url')
+        sm.save_session(session_id=session_id, name='test.ipynb', path='/path/to/', kernel_id='5678')
         model = sm.get_session(session_id=session_id)
-        expected = {'id':session_id, 'notebook':{'name':u'test.ipynb', 'path': u'/path/to/'}, 'kernel':{'id':u'5678', 'ws_url':u'ws_url'}}
+        expected = {'id':session_id, 'notebook':{'name':u'test.ipynb', 'path': u'/path/to/'}, 'kernel':{'id':u'5678'}}
         self.assertEqual(model, expected)
 
     def test_bad_get_session(self):
         # Should raise error if a bad key is passed to the database.
         sm = SessionManager()
         session_id = sm.new_session_id()
-        sm.save_session(session_id=session_id, name='test.ipynb', path='/path/to/', kernel_id='5678', ws_url='ws_url')
+        sm.save_session(session_id=session_id, name='test.ipynb', path='/path/to/', kernel_id='5678')
         self.assertRaises(TypeError, sm.get_session, bad_id=session_id) # Bad keyword
 
     def test_list_sessions(self):
@@ -28,33 +28,33 @@ class TestSessionManager(TestCase):
         session_id1 = sm.new_session_id()
         session_id2 = sm.new_session_id()
         session_id3 = sm.new_session_id()
-        sm.save_session(session_id=session_id1, name='test1.ipynb', path='/path/to/1/', kernel_id='5678', ws_url='ws_url')
-        sm.save_session(session_id=session_id2, name='test2.ipynb', path='/path/to/2/', kernel_id='5678', ws_url='ws_url')
-        sm.save_session(session_id=session_id3, name='test3.ipynb', path='/path/to/3/', kernel_id='5678', ws_url='ws_url')
+        sm.save_session(session_id=session_id1, name='test1.ipynb', path='/path/to/1/', kernel_id='5678')
+        sm.save_session(session_id=session_id2, name='test2.ipynb', path='/path/to/2/', kernel_id='5678')
+        sm.save_session(session_id=session_id3, name='test3.ipynb', path='/path/to/3/', kernel_id='5678')
         sessions = sm.list_sessions()
         expected = [{'id':session_id1, 'notebook':{'name':u'test1.ipynb', 
-                    'path': u'/path/to/1/'}, 'kernel':{'id':u'5678', 'ws_url': 'ws_url'}},
+                    'path': u'/path/to/1/'}, 'kernel':{'id':u'5678'}},
                     {'id':session_id2, 'notebook': {'name':u'test2.ipynb', 
-                    'path': u'/path/to/2/'}, 'kernel':{'id':u'5678', 'ws_url': 'ws_url'}},
+                    'path': u'/path/to/2/'}, 'kernel':{'id':u'5678'}},
                     {'id':session_id3, 'notebook':{'name':u'test3.ipynb', 
-                    'path': u'/path/to/3/'}, 'kernel':{'id':u'5678', 'ws_url': 'ws_url'}}]
+                    'path': u'/path/to/3/'}, 'kernel':{'id':u'5678'}}]
         self.assertEqual(sessions, expected)
 
     def test_update_session(self):
         sm = SessionManager()
         session_id = sm.new_session_id()
-        sm.save_session(session_id=session_id, name='test.ipynb', path='/path/to/', kernel_id=None, ws_url='ws_url')
+        sm.save_session(session_id=session_id, name='test.ipynb', path='/path/to/', kernel_id=None)
         sm.update_session(session_id, kernel_id='5678')
         sm.update_session(session_id, name='new_name.ipynb')
         model = sm.get_session(session_id=session_id)
-        expected = {'id':session_id, 'notebook':{'name':u'new_name.ipynb', 'path': u'/path/to/'}, 'kernel':{'id':u'5678', 'ws_url': 'ws_url'}}
+        expected = {'id':session_id, 'notebook':{'name':u'new_name.ipynb', 'path': u'/path/to/'}, 'kernel':{'id':u'5678'}}
         self.assertEqual(model, expected)
     
     def test_bad_update_session(self):
         # try to update a session with a bad keyword ~ raise error
         sm = SessionManager()
         session_id = sm.new_session_id()
-        sm.save_session(session_id=session_id, name='test.ipynb', path='/path/to/', kernel_id='5678', ws_url='ws_url')
+        sm.save_session(session_id=session_id, name='test.ipynb', path='/path/to/', kernel_id='5678')
         self.assertRaises(TypeError, sm.update_session, session_id=session_id, bad_kw='test.ipynb') # Bad keyword
 
     def test_delete_session(self):
@@ -62,22 +62,22 @@ class TestSessionManager(TestCase):
         session_id1 = sm.new_session_id()
         session_id2 = sm.new_session_id()
         session_id3 = sm.new_session_id()
-        sm.save_session(session_id=session_id1, name='test1.ipynb', path='/path/to/1/', kernel_id='5678', ws_url='ws_url')
-        sm.save_session(session_id=session_id2, name='test2.ipynb', path='/path/to/2/', kernel_id='5678', ws_url='ws_url')
-        sm.save_session(session_id=session_id3, name='test3.ipynb', path='/path/to/3/', kernel_id='5678', ws_url='ws_url')
+        sm.save_session(session_id=session_id1, name='test1.ipynb', path='/path/to/1/', kernel_id='5678')
+        sm.save_session(session_id=session_id2, name='test2.ipynb', path='/path/to/2/', kernel_id='5678')
+        sm.save_session(session_id=session_id3, name='test3.ipynb', path='/path/to/3/', kernel_id='5678')
         sm.delete_session(session_id2)
         sessions = sm.list_sessions()
         expected = [{'id':session_id1, 'notebook':{'name':u'test1.ipynb', 
-                    'path': u'/path/to/1/'}, 'kernel':{'id':u'5678', 'ws_url': 'ws_url'}},
+                    'path': u'/path/to/1/'}, 'kernel':{'id':u'5678'}},
                     {'id':session_id3, 'notebook':{'name':u'test3.ipynb', 
-                    'path': u'/path/to/3/'}, 'kernel':{'id':u'5678', 'ws_url': 'ws_url'}}]
+                    'path': u'/path/to/3/'}, 'kernel':{'id':u'5678'}}]
         self.assertEqual(sessions, expected)
 
     def test_bad_delete_session(self):
         # try to delete a session that doesn't exist ~ raise error
         sm = SessionManager()
         session_id = sm.new_session_id()
-        sm.save_session(session_id=session_id, name='test.ipynb', path='/path/to/', kernel_id='5678', ws_url='ws_url')
+        sm.save_session(session_id=session_id, name='test.ipynb', path='/path/to/', kernel_id='5678')
         self.assertRaises(TypeError, sm.delete_session, bad_kwarg='23424') # Bad keyword
         self.assertRaises(web.HTTPError, sm.delete_session, session_id='23424') # nonexistant
 

--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -125,16 +125,9 @@ var IPython = (function (IPython) {
         console.log("Kernel started: ", json.id);
         this.running = true;
         this.kernel_id = json.id;
-        var ws_url = json.ws_url;
-        if (ws_url.match(/wss?:\/\//) === null) {
-            // trailing 's' in https will become wss for secure web sockets
-            var prot = location.protocol.replace('http', 'ws') + "//";
-            ws_url = prot + location.host + ws_url;
-        }
-        var parsed = utils.parse_url(ws_url);
-        this.ws_host = parsed.protocol + "//" + parsed.host;
+        // trailing 's' in https will become wss for secure web sockets
+        this.ws_host = location.protocol.replace('http', 'ws') + "//" + location.host;
         this.kernel_url = utils.url_path_join(this.kernel_service_url, this.kernel_id);
-        this.ws_url = utils.url_path_join(parsed.pathname, this.kernel_url);
         this.start_channels();
     };
 
@@ -155,18 +148,18 @@ var IPython = (function (IPython) {
     Kernel.prototype.start_channels = function () {
         var that = this;
         this.stop_channels();
-        console.log("Starting WebSockets:", this.ws_host + this.ws_url);
+        var ws_host_url = this.ws_host + this.kernel_url;
+        console.log("Starting WebSockets:", ws_host_url);
         this.shell_channel = new this.WebSocket(
-            this.ws_host + utils.url_join_encode(this.ws_url, "shell")
+            this.ws_host + utils.url_join_encode(this.kernel_url, "shell")
         );
         this.stdin_channel = new this.WebSocket(
-            this.ws_host + utils.url_join_encode(this.ws_url, "stdin")
+            this.ws_host + utils.url_join_encode(this.kernel_url, "stdin")
         );
         this.iopub_channel = new this.WebSocket(
-            this.ws_host + utils.url_join_encode(this.ws_url, "iopub")
+            this.ws_host + utils.url_join_encode(this.kernel_url, "iopub")
         );
         
-        var ws_host_url = this.ws_host + this.ws_url;
         var already_called_onclose = false; // only alert once
         var ws_closed_early = function(evt){
             if (already_called_onclose){

--- a/docs/source/whatsnew/pr/incompat-base-url.rst
+++ b/docs/source/whatsnew/pr/incompat-base-url.rst
@@ -1,0 +1,6 @@
+Simplifying configurable URLs
+-----------------------------
+
+- base_kernel_url configurable is removed
+- websocket_url configurable is removed
+- base_project_url is renamed to base_url (base_project_url is kept as a deprecates alias, for now)


### PR DESCRIPTION
websockets just use the kernel URL

(normal behavior is unchanged, only unused configurability is removed)
