### PR TITLE
use gnureadline on OS X

### DIFF
--- a/IPython/terminal/console/completer.py
+++ b/IPython/terminal/console/completer.py
@@ -1,7 +1,6 @@
 """Adapt readline completer interface to make ZMQ request.
 """
 # -*- coding: utf-8 -*-
-import readline
 try:
     from queue import Empty  # Py 3
 except ImportError:
@@ -10,6 +9,7 @@ except ImportError:
 from IPython.config import Configurable
 from IPython.core.completer import IPCompleter
 from IPython.utils.traitlets import Float
+import IPython.utils.rlineimpl as readline
 
 class ZMQCompleter(IPCompleter):
     """Client-side completion machinery.

--- a/setup.py
+++ b/setup.py
@@ -279,7 +279,7 @@ for deps in extras_require.values():
 extras_require['all'] = everything
 install_requires = []
 if sys.platform == 'darwin':
-    install_requires.append('readline')
+    install_requires.append('gnureadline')
 elif sys.platform.startswith('win'):
     # Pyreadline has unicode and Python 3 fixes in 2.0
     install_requires.append('pyreadline>=2.0')

--- a/setup.py
+++ b/setup.py
@@ -279,7 +279,8 @@ for deps in extras_require.values():
 extras_require['all'] = everything
 install_requires = []
 if sys.platform == 'darwin':
-    install_requires.append('gnureadline')
+    if any(arg.startswith('bdist') for arg in sys.argv) or not setupext.check_for_readline():
+        install_requires.append('gnureadline')
 elif sys.platform.startswith('win'):
     # Pyreadline has unicode and Python 3 fixes in 2.0
     install_requires.append('pyreadline>=2.0')

--- a/setupbase.py
+++ b/setupbase.py
@@ -641,8 +641,8 @@ def get_bdist_wheel():
                 
                 for pkg in ("gnureadline", "pyreadline"):
                     _remove_startswith(requires, pkg)
-                requires.append("gnureadline; sys.platform == 'darwin'")
-                requires.append("pyreadline (>=2.0); sys.platform == 'win32'")
+                requires.append("gnureadline; sys.platform == 'darwin' and platform.python_implementation == 'CPython'")
+                requires.append("pyreadline (>=2.0); sys.platform == 'win32' and platform.python_implementation == 'CPython'")
                 for r in requires:
                     pkg_info['Requires-Dist'] = r
                 write_pkg_info(metadata_path, pkg_info)

--- a/setupbase.py
+++ b/setupbase.py
@@ -639,9 +639,9 @@ def get_bdist_wheel():
                     if found:
                         lis.pop(idx)
                 
-                for pkg in ("readline", "pyreadline"):
+                for pkg in ("gnureadline", "pyreadline"):
                     _remove_startswith(requires, pkg)
-                requires.append("readline; sys.platform == 'darwin'")
+                requires.append("gnureadline; sys.platform == 'darwin'")
                 requires.append("pyreadline (>=2.0); sys.platform == 'win32'")
                 for r in requires:
                     pkg_info['Requires-Dist'] = r

--- a/setupext/setupext.py
+++ b/setupext/setupext.py
@@ -146,9 +146,17 @@ def check_for_tornado():
 
 def check_for_readline():
     from distutils.version import LooseVersion
+    readline = None
     try:
-        import readline
+        import gnureadline as readline
     except ImportError:
+        pass
+    if readline is None:
+        try:
+            import readline
+        except ImportError:
+            pass
+    if readline is None:
         try:
             import pyreadline
             vs = pyreadline.release.version


### PR DESCRIPTION
the readline Python package has been renamed to gnureadline to avoid namespace conflicts with the stdlib. Because of this, we no longer need to do any shenanigans with sys.path, or recommend easy_install over pip with lengthy disclaimers. Just import it and be done.

(yay!)
