### PR TITLE
require latex titles to be ascii

### DIFF
--- a/IPython/nbconvert/exporters/templateexporter.py
+++ b/IPython/nbconvert/exporters/templateexporter.py
@@ -62,6 +62,7 @@ default_filters = {
         'citation2latex': filters.citation2latex,
         'path2url': filters.path2url,
         'add_prompts': filters.add_prompts,
+        'ascii_only': filters.ascii_only,
 }
 
 #-----------------------------------------------------------------------------

--- a/IPython/nbconvert/filters/strings.py
+++ b/IPython/nbconvert/filters/strings.py
@@ -43,7 +43,8 @@ __all__ = [
     'ipython2python',
     'posix_path',
     'path2url',
-    'add_prompts'
+    'add_prompts',
+    'ascii_only',
 ]
 
 
@@ -213,3 +214,8 @@ def path2url(path):
     """Turn a file path into a URL"""
     parts = path.split(os.path.sep)
     return '/'.join(quote(part) for part in parts)
+
+def ascii_only(s):
+    """ensure a string is ascii"""
+    s = py3compat.cast_unicode(s)
+    return s.encode('ascii', 'replace').decode('ascii')

--- a/IPython/nbconvert/templates/latex/base.tplx
+++ b/IPython/nbconvert/templates/latex/base.tplx
@@ -89,7 +89,7 @@ This template does not define a docclass, the inheriting class must define this.
     \def\gt{>}
     \def\lt{<}
     % Document parameters
-    ((* block title *))\title{((( resources.metadata.name | escape_latex )))}((* endblock title *))
+    ((* block title *))\title{((( resources.metadata.name | ascii_only | escape_latex )))}((* endblock title *))
     ((* block date *))((* endblock date *))
     ((* block author *))((* endblock author *))
     ((* endblock definitions *))


### PR DESCRIPTION
otherwise the ucs package dies, telling you to enable a 'combine' option, whose only effect seems to be to remove all unicode characters.

see #5133
