### PR TITLE
If there is an error comparing traitlet values when setting a trait, default to go ahead and notify of the new value.

### DIFF
--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -371,7 +371,12 @@ class TraitType(object):
         new_value = self._validate(obj, value)
         old_value = self.__get__(obj)
         obj._trait_values[self.name] = new_value
-        if old_value != new_value:
+        try:
+            notify = (old_value != new_value)
+        except:
+            # if there is an error in comparing, default to notify
+            notify = True
+        if notify:
             obj._notify_trait(self.name, old_value, new_value)
 
     def _validate(self, obj, value):


### PR DESCRIPTION
If a trait is not comparable with the default value (like None) or with other objects of the same instance, the comparing that is done to see if we should notify of updates fails.  With this PR, if comparing the object to the old value throws an error, we go ahead and notify of the new setting.

This problem prevented having a trait that was an Instance of a pandas dataframe, for example.  These examples didn't work before, but work with this pull request

``` python
from __future__ import print_function # For py 2.7 compat

from IPython.html import widgets # Widget definitions
from IPython.utils.traitlets import Unicode, Instance # Used to declare attributes of our widget
import pandas as pd
class A(widgets.DOMWidget):
    _view_name = Unicode('PDView', sync=True)
    value = Instance(pd.DataFrame)

a=A()
a.value=pd.DataFrame([1,2,3])
print(a.value)
B=A(value=pd.DataFrame([4,2,1]))
print(B.value)
B.value=pd.DataFrame([[4,3,2],[5,4,1]])
print(B.value)
```
