### PR TITLE
Only create one view per model, and cache that view.

### DIFF
--- a/IPython/html/static/notebook/js/widgetmanager.js
+++ b/IPython/html/static/notebook/js/widgetmanager.js
@@ -104,6 +104,10 @@
         };
 
         WidgetManager.prototype.create_view = function(model, options, view) {
+            if (model.view !== undefined) {
+                return model.view;
+            }
+
             // Creates a view for a particular model.
             var view_name = model.get('_view_name');
             var ViewType = WidgetManager._view_types[view_name];
@@ -120,7 +124,7 @@
                 var parameters = {model: model, options: options};
                 view = new ViewType(parameters);
                 view.render();
-                model.views.push(view);
+                model.view = view;
                 model.on('destroy', view.remove, view);
                 return view;
             }

--- a/IPython/html/static/notebook/js/widgets/widget.js
+++ b/IPython/html/static/notebook/js/widgets/widget.js
@@ -37,7 +37,6 @@ function(WidgetManager, _, Backbone){
             this.msg_buffer = null;
             this.key_value_lock = null;
             this.id = model_id;
-            this.views = [];
 
             if (comm !== undefined) {
                 // Remember comm associated with the model.
@@ -66,9 +65,6 @@ function(WidgetManager, _, Backbone){
             delete this.comm.model; // Delete ref so GC will collect widget model.
             delete this.comm;
             delete this.model_id; // Delete id from model so widget manager cleans up.
-            _.each(this.views, function(view, i) {
-                view.remove();
-            });
         },
 
         _handle_comm_msg: function (msg) {
@@ -283,7 +279,6 @@ function(WidgetManager, _, Backbone){
             this.model.on('change',this.update,this);
             this.options = parameters.options;
             this.child_views = [];
-            this.model.views.push(this);
         },
 
         update: function(){


### PR DESCRIPTION
When the original view code was written, we allowed multiple views per model.  Since that time, we've settled more on the concept of one view per model.  This change 'enforces' this constraint, and caches that view with the model so that it's easy to retrieve it.

I also deleted some code that removed the view, since it seemed redundant with the event handler set up in the widgetmanager.
