### PR TITLE
Allow to pass option to jinja env

### DIFF
--- a/IPython/html/templates/page.html
+++ b/IPython/html/templates/page.html
@@ -1,5 +1,3 @@
-
-
 <!DOCTYPE HTML>
 <html>
 


### PR DESCRIPTION
Mainly to pass cache_size=-1 while developing not to cache templates.

`--NotebookApp.webapp_settings="{'jinja_env_opts':{'cache_size':-1}}"`
