### PR TITLE
capture some logging/warning output in some tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
     # Pierre Carrier's PPA for PhantomJS and CasperJS
     - sudo add-apt-repository -y ppa:pcarrier/ppa
     - sudo apt-get update
-    - sudo apt-get install pandoc casperjs
+    - sudo apt-get install pandoc casperjs nodejs
 install:
     - python setup.py install -q 
 script:

--- a/IPython/html/tests/test_notebookapp.py
+++ b/IPython/html/tests/test_notebookapp.py
@@ -11,6 +11,7 @@
 # Imports
 #-----------------------------------------------------------------------------
 
+import logging
 import os
 from tempfile import NamedTemporaryFile
 
@@ -31,7 +32,7 @@ def test_help_output():
     tt.help_all_output_test('notebook')
 
 def test_server_info_file():
-    nbapp = NotebookApp(profile='nbserver_file_test')
+    nbapp = NotebookApp(profile='nbserver_file_test', log=logging.getLogger())
     def get_servers():
         return list(notebookapp.list_running_servers(profile='nbserver_file_test'))
     nbapp.initialize(argv=[])

--- a/IPython/nbconvert/exporters/tests/base.py
+++ b/IPython/nbconvert/exporters/tests/base.py
@@ -14,7 +14,7 @@
 
 import os
 
-from IPython.testing.decorators import onlyif_cmds_exist
+from IPython.testing.decorators import onlyif_any_cmd_exists
 
 from ...tests.base import TestsBase
 
@@ -39,7 +39,7 @@ class ExportersTestsBase(TestsBase):
     def _get_notebook(self, nb_name='notebook2.ipynb'):
         return os.path.join(self._get_files_path(), nb_name)
     
-    @onlyif_cmds_exist('pandoc')
+    @onlyif_any_cmd_exists('nodejs', 'node', 'pandoc')
     def test_raw_cell_inclusion(self):
         """test raw cell inclusion based on raw_mimetype metadata"""
         if self.should_include_raw is None:

--- a/IPython/nbconvert/exporters/tests/test_html.py
+++ b/IPython/nbconvert/exporters/tests/test_html.py
@@ -14,7 +14,7 @@
 
 from .base import ExportersTestsBase
 from ..html import HTMLExporter
-from IPython.testing.decorators import onlyif_cmds_exist
+from IPython.testing.decorators import onlyif_any_cmd_exists
 
 #-----------------------------------------------------------------------------
 # Class
@@ -33,7 +33,7 @@ class TestHTMLExporter(ExportersTestsBase):
         HTMLExporter()
 
 
-    @onlyif_cmds_exist('pandoc')
+    @onlyif_any_cmd_exists('nodejs', 'node', 'pandoc')
     def test_export(self):
         """
         Can a HTMLExporter export something?
@@ -42,7 +42,7 @@ class TestHTMLExporter(ExportersTestsBase):
         assert len(output) > 0
 
 
-    @onlyif_cmds_exist('pandoc')
+    @onlyif_any_cmd_exists('nodejs', 'node', 'pandoc')
     def test_export_basic(self):
         """
         Can a HTMLExporter export using the 'basic' template?
@@ -51,7 +51,7 @@ class TestHTMLExporter(ExportersTestsBase):
         assert len(output) > 0
 
 
-    @onlyif_cmds_exist('pandoc')
+    @onlyif_any_cmd_exists('nodejs', 'node', 'pandoc')
     def test_export_full(self):
         """
         Can a HTMLExporter export using the 'full' template?

--- a/IPython/nbconvert/exporters/tests/test_slides.py
+++ b/IPython/nbconvert/exporters/tests/test_slides.py
@@ -14,7 +14,7 @@
 
 from .base import ExportersTestsBase
 from ..slides import SlidesExporter
-from IPython.testing.decorators import onlyif_cmds_exist
+from IPython.testing.decorators import onlyif_any_cmd_exists
 
 #-----------------------------------------------------------------------------
 # Class
@@ -33,7 +33,7 @@ class TestSlidesExporter(ExportersTestsBase):
         SlidesExporter()
 
 
-    @onlyif_cmds_exist('pandoc')
+    @onlyif_any_cmd_exists('nodejs', 'node', 'pandoc')
     def test_export(self):
         """
         Can a SlidesExporter export something?
@@ -42,7 +42,7 @@ class TestSlidesExporter(ExportersTestsBase):
         assert len(output) > 0
 
 
-    @onlyif_cmds_exist('pandoc')
+    @onlyif_any_cmd_exists('nodejs', 'node', 'pandoc')
     def test_export_reveal(self):
         """
         Can a SlidesExporter export using the 'reveal' template?

--- a/IPython/nbconvert/postprocessors/tests/test_pdf.py
+++ b/IPython/nbconvert/postprocessors/tests/test_pdf.py
@@ -14,6 +14,7 @@ Module with tests for the PDF post-processor
 # Imports
 #-----------------------------------------------------------------------------
 
+import logging
 import os
 
 from IPython.testing import decorators as dec
@@ -56,7 +57,7 @@ class TestPDF(TestsBase):
                 f.write(HELLO_WORLD)
 
             # Construct post-processor
-            processor = PDFPostProcessor()
+            processor = PDFPostProcessor(log=logging.getLogger())
             processor.verbose = False
             processor('a.tex')
 

--- a/IPython/nbconvert/tests/test_nbconvertapp.py
+++ b/IPython/nbconvert/tests/test_nbconvertapp.py
@@ -21,12 +21,6 @@ from .base import TestsBase
 import IPython.testing.tools as tt
 from IPython.testing import decorators as dec
 
-
-#-----------------------------------------------------------------------------
-# Constants
-#-----------------------------------------------------------------------------
-
-
 #-----------------------------------------------------------------------------
 # Classes and functions
 #-----------------------------------------------------------------------------
@@ -85,7 +79,7 @@ class TestNbConvertApp(TestsBase):
         """
         with self.create_temp_cwd(['notebook2.ipynb']):
             os.rename('notebook2.ipynb', 'notebook with spaces.ipynb')
-            o,e = self.call('nbconvert --log-level 0 --to latex '
+            self.call('nbconvert --log-level 0 --to latex '
                             '"notebook with spaces" --post PDF '
                             '--PDFPostProcessor.verbose=True')
             assert os.path.isfile('notebook with spaces.tex')
@@ -194,15 +188,14 @@ class TestNbConvertApp(TestsBase):
             self.call('nbconvert --log-level 0 --to python nb1_*')
             assert os.path.isfile(u'nb1_análisis.py')
     
-    @dec.onlyif_cmds_exist('pdflatex')
-    @dec.onlyif_cmds_exist('pandoc')
-    def test_filename_accent(self):
+    @dec.onlyif_cmds_exist('pdflatex', 'pandoc')
+    def test_filename_accent_pdf(self):
         """
         Generate PDFs if notebooks have an accent in their name?
         """
         with self.create_temp_cwd():
             self.create_empty_notebook(u'nb1_análisis.ipynb')
-            o,e = self.call('nbconvert --log-level 0 --to latex '
+            self.call('nbconvert --log-level 0 --to latex '
                             '"nb1_*" --post PDF '
                             '--PDFPostProcessor.verbose=True')
             assert os.path.isfile(u'nb1_análisis.tex')

--- a/IPython/nbconvert/utils/tests/test_pandoc.py
+++ b/IPython/nbconvert/utils/tests/test_pandoc.py
@@ -42,7 +42,7 @@ class TestPandoc(TestsBase):
 
         # original_env["PATH"] should contain pandoc
         os.environ["PATH"] = self.original_env["PATH"]
-        with warnings.catch_warnings(True) as w:
+        with warnings.catch_warnings(record=True) as w:
             pandoc.get_pandoc_version()
             pandoc.check_pandoc_version()
             pandoc.pandoc("", "markdown", "html")
@@ -53,7 +53,7 @@ class TestPandoc(TestsBase):
         original_minversion = pandoc._minimal_version
         
         pandoc._minimal_version = "120.0"
-        with warnings.catch_warnings(True) as w:
+        with warnings.catch_warnings(record=True) as w:
             assert not pandoc.check_pandoc_version()
         self.assertEqual(len(w), 1)
 

--- a/IPython/nbconvert/utils/tests/test_pandoc.py
+++ b/IPython/nbconvert/utils/tests/test_pandoc.py
@@ -10,6 +10,7 @@
 # Imports
 #-----------------------------------------------------------------------------
 import os
+import warnings
 
 from IPython.testing import decorators as dec
 
@@ -32,22 +33,29 @@ class TestPandoc(TestsBase):
         pandoc.clean_cache()
 
         os.environ["PATH"] = ""
-        assert pandoc_function_raised_missing(pandoc.get_pandoc_version) == True
-        assert pandoc_function_raised_missing(pandoc.check_pandoc_version) == True
-        assert pandoc_function_raised_missing(pandoc.pandoc, "", "markdown", "html") == True
+        with self.assertRaises(pandoc.PandocMissing):
+            pandoc.get_pandoc_version()
+        with self.assertRaises(pandoc.PandocMissing):
+            pandoc.check_pandoc_version()
+        with self.assertRaises(pandoc.PandocMissing):
+            pandoc.pandoc("", "markdown", "html")
 
         # original_env["PATH"] should contain pandoc
         os.environ["PATH"] = self.original_env["PATH"]
-        assert pandoc_function_raised_missing(pandoc.get_pandoc_version) == False
-        assert pandoc_function_raised_missing(pandoc.check_pandoc_version) == False
-        assert pandoc_function_raised_missing(pandoc.pandoc, "", "markdown", "html") == False
+        with warnings.catch_warnings(True) as w:
+            pandoc.get_pandoc_version()
+            pandoc.check_pandoc_version()
+            pandoc.pandoc("", "markdown", "html")
+        self.assertEqual(w, [])
         
     @dec.onlyif_cmds_exist('pandoc')
     def test_minimal_version(self):
         original_minversion = pandoc._minimal_version
-
+        
         pandoc._minimal_version = "120.0"
-        assert not pandoc.check_pandoc_version()
+        with warnings.catch_warnings(True) as w:
+            assert not pandoc.check_pandoc_version()
+        self.assertEqual(len(w), 1)
 
         pandoc._minimal_version = pandoc.get_pandoc_version()
         assert pandoc.check_pandoc_version()

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -381,3 +381,20 @@ def onlyif_cmds_exist(*commands):
                             "is installed".format(cmd))
             raise e
     return null_deco
+
+def onlyif_any_cmd_exists(*commands):
+    """
+    Decorator to skip test unless at least one of `commands` is found.
+    """
+    for cmd in commands:
+        try:
+            if is_cmd_found(cmd):
+                return null_deco
+        except ImportError as e:
+            # is_cmd_found uses pywin32 on windows, which might not be available
+            if sys.platform == 'win32' and 'pywin32' in str(e):
+                return skip("This test runs only if pywin32 and command '{0}' "
+                            "is installed".format(cmd))
+            raise e
+    return skip("This test runs only if one of the commands {0} "
+                "is installed".format(commands))

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -393,8 +393,8 @@ def onlyif_any_cmd_exists(*commands):
         except ImportError as e:
             # is_cmd_found uses pywin32 on windows, which might not be available
             if sys.platform == 'win32' and 'pywin32' in str(e):
-                return skip("This test runs only if pywin32 and command '{0}' "
-                            "is installed".format(cmd))
+                return skip("This test runs only if pywin32 and commands '{0}' "
+                            "are installed".format(commands))
             raise e
     return skip("This test runs only if one of the commands {0} "
                 "is installed".format(commands))


### PR DESCRIPTION
A few tests were generating log statements or warnings in iptest output. This captures those log statements and warnings.

It also adds the `@onlyif_any_cmd_exists` decorator, which is like `@onlyif_cmds_exist`, but pass if any is available instead of all, and then uses that to allow nbconvert html tests to run with node instead of pandoc.
