### PR TITLE
Children fire event

### DIFF
--- a/IPython/html/widgets/widget_container.py
+++ b/IPython/html/widgets/widget_container.py
@@ -27,6 +27,15 @@ class ContainerWidget(DOMWidget):
     children = List(Instance(DOMWidget))
     _children = List(Instance(DOMWidget), sync=True)
 
+
+    def __init__(self, **kwargs):
+        super(ContainerWidget, self).__init__(**kwargs)
+        self.on_displayed(ContainerWidget._fire_children_displayed)
+
+    def _fire_children_displayed(self):
+        for child in self._children:
+            child._handle_displayed()
+
     def _children_changed(self, name, old, new):
         """Validate children list.
 


### PR DESCRIPTION
Now when a container widget is displayed, the _handle_displayed method
of each of its children is fired.
