### PR TITLE
Wrap nbconvert Markdown/Heading cells in live divs

### DIFF
--- a/IPython/nbconvert/templates/html/basic.tpl
+++ b/IPython/nbconvert/templates/html/basic.tpl
@@ -59,6 +59,7 @@ In&nbsp;[{{ cell.prompt_number }}]:
 {% endblock output %}
 
 {% block markdowncell scoped %}
+<div class="cell border-box-sizing text_cell">
 <div class="input">
 {{ self.empty_in_prompt() }}
 <div class="inner_cell">
@@ -67,14 +68,17 @@ In&nbsp;[{{ cell.prompt_number }}]:
 </div>
 </div>
 </div>
+</div>
 {%- endblock markdowncell %}
 
 {% block headingcell scoped %}
+<div class="cell border-box-sizing text_cell">
 <div class="input">
 {{ self.empty_in_prompt() }}
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 {{ ("#" * cell.level + cell.source) | replace('\n', ' ')  | markdown2html | strip_files_prefix | add_anchor }}
+</div>
 </div>
 </div>
 </div>


### PR DESCRIPTION
Addresses https://github.com/ipython/ipython/issues/5206

This partially mimics the live IPython notebook layout, but is not a
complete solution.
