### PR TITLE
You all know that it's uppercase I

### DIFF
--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -327,9 +327,24 @@ var IPython = (function (IPython) {
         TextCell.apply(this, [options]);
     };
 
+    
+    CodeMirror.defineMode("gfm-ipython", function(config, parserConfig) {
+      var overlay = {
+        token: function(stream, state) {
+          var ch;
+          if (stream.match("iPython")) {
+            return "itsuppercasei";
+          }
+          while (stream.next() != null && !stream.match("iPython", false)) {}
+          return null;
+        }
+      };
+      return CodeMirror.overlayMode(CodeMirror.getMode(config, parserConfig.backdrop || "gfm"), overlay);
+    });
+    
     MarkdownCell.options_default = {
         cm_config: {
-            mode: 'gfm'
+            mode: 'gfm-ipython'
         },
         placeholder: "Type *Markdown* and LaTeX: $\\alpha^2$"
     }

--- a/IPython/html/static/notebook/less/notebook.less
+++ b/IPython/html/static/notebook/less/notebook.less
@@ -65,3 +65,26 @@ p {
 .end_space {
     height: 200px;
 }
+
+// IPython, it's Uppercase I with the right Codemirror overlay !
+.cm-itsuppercasei{
+    color:darkred;
+    background-color: hsl(0, 100%, 90%);
+}
+
+.cm-itsuppercasei:after
+{
+    position: absolute;
+    content: "It's uppercase I: IPython";
+    color: #FFF;
+    font-weight:bold;
+    left: 0px;
+    background: darkred;
+    padding: 3px 10px;
+    white-space: nowrap;
+    visibility: hidden;
+}
+
+.cm-itsuppercasei:hover:after{
+    visibility: visible;
+}

--- a/IPython/html/static/notebook/less/notebook.less
+++ b/IPython/html/static/notebook/less/notebook.less
@@ -68,21 +68,7 @@ p {
 
 // IPython, it's Uppercase I with the right Codemirror overlay !
 .cm-itsuppercasei{
-    color:darkred;
-    background-color: hsl(0, 100%, 90%);
-}
-
-.cm-itsuppercasei:after
-{
-    position: absolute;
-    content: "It's uppercase I: IPython";
-    color: #FFF;
-    font-weight:bold;
-    left: 0px;
-    background: darkred;
-    padding: 3px 10px;
-    white-space: nowrap;
-    visibility: hidden;
+    border-bottom:thin dashed red;
 }
 
 .cm-itsuppercasei:hover:after{

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1,7 +1,3 @@
-.clearfix{*zoom:1}.clearfix:before,.clearfix:after{display:table;content:"";line-height:0}
-.clearfix:after{clear:both}
-.hide-text{font:0/0 a;color:transparent;text-shadow:none;background-color:transparent;border:0}
-.input-block-level{display:block;width:100%;min-height:30px;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
 article,aside,details,figcaption,figure,footer,header,hgroup,nav,section{display:block}
 audio,canvas,video{display:inline-block;*display:inline;*zoom:1}
 audio:not([controls]){display:none}
@@ -856,6 +852,10 @@ a.label:hover,a.label:focus,a.badge:hover,a.badge:focus{color:#fff;text-decorati
 .show{display:block}
 .invisible{visibility:hidden}
 .affix{position:fixed}
+.clearfix{*zoom:1}.clearfix:before,.clearfix:after{display:table;content:"";line-height:0}
+.clearfix:after{clear:both}
+.hide-text{font:0/0 a;color:transparent;text-shadow:none;background-color:transparent;border:0}
+.input-block-level{display:block;width:100%;min-height:30px;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
 @-ms-viewport{width:device-width}.hidden{display:none;visibility:hidden}
 .visible-phone{display:none !important}
 .visible-tablet{display:none !important}
@@ -1482,6 +1482,9 @@ pre,code,kbd,samp{white-space:pre-wrap}
 #fonttest{font-family:monospace}
 p{margin-bottom:0}
 .end_space{height:200px}
+.cm-itsuppercasei{color:#8b0000;background-color:#fcc}
+.cm-itsuppercasei:after{position:absolute;content:"It's uppercase I: IPython";color:#fff;font-weight:bold;left:0;background:#8b0000;padding:3px 10px;white-space:nowrap;visibility:hidden}
+.cm-itsuppercasei:hover:after{visibility:visible}
 .celltoolbar{border:thin solid #cfcfcf;border-bottom:none;background:#eee;border-radius:3px 3px 0 0;width:100%;-webkit-box-pack:end;height:22px;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch;-webkit-box-direction:reverse;-moz-box-direction:reverse;box-direction:reverse;flex-direction:row-reverse}
 .ctb_hideshow{display:none;vertical-align:bottom;padding-right:2px}
 .celltoolbar>div{padding-top:0}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1,3 +1,7 @@
+.clearfix{*zoom:1}.clearfix:before,.clearfix:after{display:table;content:"";line-height:0}
+.clearfix:after{clear:both}
+.hide-text{font:0/0 a;color:transparent;text-shadow:none;background-color:transparent;border:0}
+.input-block-level{display:block;width:100%;min-height:30px;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
 article,aside,details,figcaption,figure,footer,header,hgroup,nav,section{display:block}
 audio,canvas,video{display:inline-block;*display:inline;*zoom:1}
 audio:not([controls]){display:none}
@@ -852,10 +856,6 @@ a.label:hover,a.label:focus,a.badge:hover,a.badge:focus{color:#fff;text-decorati
 .show{display:block}
 .invisible{visibility:hidden}
 .affix{position:fixed}
-.clearfix{*zoom:1}.clearfix:before,.clearfix:after{display:table;content:"";line-height:0}
-.clearfix:after{clear:both}
-.hide-text{font:0/0 a;color:transparent;text-shadow:none;background-color:transparent;border:0}
-.input-block-level{display:block;width:100%;min-height:30px;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
 @-ms-viewport{width:device-width}.hidden{display:none;visibility:hidden}
 .visible-phone{display:none !important}
 .visible-tablet{display:none !important}
@@ -1482,8 +1482,7 @@ pre,code,kbd,samp{white-space:pre-wrap}
 #fonttest{font-family:monospace}
 p{margin-bottom:0}
 .end_space{height:200px}
-.cm-itsuppercasei{color:#8b0000;background-color:#fcc}
-.cm-itsuppercasei:after{position:absolute;content:"It's uppercase I: IPython";color:#fff;font-weight:bold;left:0;background:#8b0000;padding:3px 10px;white-space:nowrap;visibility:hidden}
+.cm-itsuppercasei{border-bottom:thin dashed #f00}
 .cm-itsuppercasei:hover:after{visibility:visible}
 .celltoolbar{border:thin solid #cfcfcf;border-bottom:none;background:#eee;border-radius:3px 3px 0 0;width:100%;-webkit-box-pack:end;height:22px;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch;-webkit-box-direction:reverse;-moz-box-direction:reverse;box-direction:reverse;flex-direction:row-reverse}
 .ctb_hideshow{display:none;vertical-align:bottom;padding-right:2px}


### PR DESCRIPTION
Define a small overlay on top of gfm that highlight `iPython` in red.

On **hover** with pure css, those red `iPython` will show : "I'ts uppercase I, IPython."
Shown only on markdown **Edit** of course. Zero influence on nbviewer or other export. 
No interference with the parsing of markdown as it is a markdown **overlay**.

![capture decran 2014-02-23 a 23 59 31](https://f.cloud.github.com/assets/335567/2241703/6054f6e4-9cde-11e3-87b8-422804bfbc20.png)
