### PR TITLE
Unset PYTHONWARNINGS envvar before running subprocess tests.

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -120,8 +120,8 @@ def get_encoding(obj):
         # Print only text files, not extension binaries.  Note that
         # getsourcelines returns lineno with 1-offset and page() uses
         # 0-offset, so we must adjust.
-        buffer = stdlib_io.open(ofile, 'rb')   # Tweaked to use io.open for Python 2
-        encoding, lines = openpy.detect_encoding(buffer.readline)
+        with stdlib_io.open(ofile, 'rb') as buffer:   # Tweaked to use io.open for Python 2
+            encoding, lines = openpy.detect_encoding(buffer.readline)
         return encoding
 
 def getdoc(obj):

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -213,7 +213,9 @@ def ipexec(fname, options=None):
     # Absolute path for filename
     full_fname = os.path.join(test_dir, fname)
     full_cmd = ipython_cmd + cmdargs + [full_fname]
-    p = Popen(full_cmd, stdout=PIPE, stderr=PIPE)
+    env = os.environ.copy()
+    env.pop('PYTHONWARNINGS')  # Avoid extraneous warnings appearing on stderr
+    p = Popen(full_cmd, stdout=PIPE, stderr=PIPE, env=env)
     out, err = p.communicate()
     out, err = py3compat.bytes_to_str(out), py3compat.bytes_to_str(err)
     # `import readline` causes 'ESC[?1034h' to be output sometimes,

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -214,7 +214,7 @@ def ipexec(fname, options=None):
     full_fname = os.path.join(test_dir, fname)
     full_cmd = ipython_cmd + cmdargs + [full_fname]
     env = os.environ.copy()
-    env.pop('PYTHONWARNINGS')  # Avoid extraneous warnings appearing on stderr
+    env.pop('PYTHONWARNINGS', None)  # Avoid extraneous warnings appearing on stderr
     p = Popen(full_cmd, stdout=PIPE, stderr=PIPE, env=env)
     out, err = p.communicate()
     out, err = py3compat.bytes_to_str(out), py3compat.bytes_to_str(err)


### PR DESCRIPTION
The extra warnings in the subprocesses were causing test failures.

Closes gh-5218

Also, explicitly close a file, to squash some warnings seen while running the tests.
