### PR TITLE
Don't run PYTHONSTARTUP file if a file or code is passed

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -358,7 +358,7 @@ class InteractiveShellApp(Configurable):
         """Run files from profile startup directory"""
         startup_dir = self.profile_dir.startup_dir
         startup_files = []
-        if self.exec_PYTHONSTARTUP:
+        if self.exec_PYTHONSTARTUP and not self.file_to_run and not self.code_to_run and not self.module_to_run:
             if os.environ.get('PYTHONSTARTUP', False):
                 startup_files.append(os.environ['PYTHONSTARTUP'])
         startup_files += glob.glob(os.path.join(startup_dir, '*.py'))

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -358,7 +358,7 @@ class InteractiveShellApp(Configurable):
         """Run files from profile startup directory"""
         startup_dir = self.profile_dir.startup_dir
         startup_files = []
-        if self.exec_PYTHONSTARTUP and not self.file_to_run and not self.code_to_run and not self.module_to_run:
+        if self.exec_PYTHONSTARTUP and not (self.file_to_run or self.code_to_run or self.module_to_run):
             if os.environ.get('PYTHONSTARTUP', False):
                 startup_files.append(os.environ['PYTHONSTARTUP'])
         startup_files += glob.glob(os.path.join(startup_dir, '*.py'))


### PR DESCRIPTION
This modifies Python so the behavior is how Python behaves, this is the current situation:

![](http://monosnap.com/image/PUfzRh2mFpjrQA59aMYs27aBh30Wc3.png)

The same happens when you pass code to the Python binary vs. the IPython binary.
