### PR TITLE
Make nbconvert html full output like notebook's html.

### DIFF
--- a/IPython/html/static/base/less/variables.less
+++ b/IPython/html/static/base/less/variables.less
@@ -7,4 +7,3 @@
 
 // Our own global variables for all pages go here
 
-@code_line_height:      1.231em;

--- a/IPython/html/static/notebook/css/override.css
+++ b/IPython/html/static/notebook/css/override.css
@@ -4,5 +4,4 @@ a hack to deal with our current css styles and no new styling should be added in
 
 #ipython-main-app {
     position: relative;
-    font-size: 110%;
 }

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -403,7 +403,7 @@ var IPython = (function (IPython) {
         if (this.prompt_area) {
             toinsert.find('div.prompt').addClass('output_prompt').text('Out[' + n + ']:');
         }
-        this.append_mime_type(json, toinsert);
+        this.append_mime_type(json, toinsert, 'output_pyout');
         this._safe_append(toinsert);
         // If we just output latex, typeset it.
         if ((json['text/latex'] !== undefined) || (json['text/html'] !== undefined)) {
@@ -498,11 +498,11 @@ var IPython = (function (IPython) {
                     } else {
                         // don't display if we don't know how to sanitize it
                         console.log("Ignoring untrusted " + type + " output.");
-                        continue;
+                    continue;
                     }
                 }
                 var md = json.metadata || {};
-                var toinsert = append.apply(this, [value, md, element]);
+                var toinsert = append.apply(this, [value, md, element, extra_class]);
                 $([IPython.events]).trigger('output_appended.OutputArea', [type, value, md, toinsert]);
                 return true;
             }
@@ -511,9 +511,12 @@ var IPython = (function (IPython) {
     };
 
 
-    OutputArea.prototype.append_html = function (html, md, element) {
+    OutputArea.prototype.append_html = function (html, md, element, extra_class) {
         var type = 'text/html';
         var toinsert = this.create_output_subarea(md, "output_html rendered_html", type);
+        if (extra_class){
+            toinsert.addClass(extra_class);
+        }
         IPython.keyboard_manager.register_events(toinsert);
         toinsert.append(html);
         element.append(toinsert);
@@ -521,10 +524,13 @@ var IPython = (function (IPython) {
     };
 
 
-    OutputArea.prototype.append_javascript = function (js, md, element) {
+    OutputArea.prototype.append_javascript = function (js, md, element, extra_class) {
         // We just eval the JS code, element appears in the local scope.
         var type = 'application/javascript';
         var toinsert = this.create_output_subarea(md, "output_javascript", type);
+        if (extra_class){
+            toinsert.addClass(extra_class);
+        }
         IPython.keyboard_manager.register_events(toinsert);
         element.append(toinsert);
         // FIXME TODO : remove `container element for 3.0` 
@@ -560,9 +566,12 @@ var IPython = (function (IPython) {
     };
 
 
-    OutputArea.prototype.append_svg = function (svg, md, element) {
+    OutputArea.prototype.append_svg = function (svg, md, element, extra_class) {
         var type = 'image/svg+xml';
         var toinsert = this.create_output_subarea(md, "output_svg", type);
+        if (extra_class){
+            toinsert.addClass(extra_class);
+        }
         toinsert.append(svg);
         element.append(toinsert);
         return toinsert;
@@ -613,9 +622,12 @@ var IPython = (function (IPython) {
     };
 
 
-    OutputArea.prototype.append_jpeg = function (jpeg, md, element) {
+    OutputArea.prototype.append_jpeg = function (jpeg, md, element, extra_class) {
         var type = 'image/jpeg';
         var toinsert = this.create_output_subarea(md, "output_jpeg", type);
+        if (extra_class){
+            toinsert.addClass(extra_class);
+        }
         var img = $("<img/>").attr('src','data:image/jpeg;base64,'+jpeg);
         set_width_height(img, md, 'image/jpeg');
         this._dblclick_to_reset_size(img);
@@ -625,9 +637,12 @@ var IPython = (function (IPython) {
     };
 
 
-    OutputArea.prototype.append_pdf = function (pdf, md, element) {
+    OutputArea.prototype.append_pdf = function (pdf, md, element, extra_class) {
         var type = 'application/pdf';
         var toinsert = this.create_output_subarea(md, "output_pdf", type);
+        if (extra_class){
+            toinsert.addClass(extra_class);
+        }
         var a = $('<a/>').attr('href', 'data:application/pdf;base64,'+pdf);
         a.attr('target', '_blank');
         a.text('View PDF')
@@ -636,11 +651,14 @@ var IPython = (function (IPython) {
         return toinsert;
      }
 
-    OutputArea.prototype.append_latex = function (latex, md, element) {
+    OutputArea.prototype.append_latex = function (latex, md, element, extra_class) {
         // This method cannot do the typesetting because the latex first has to
         // be on the page.
         var type = 'text/latex';
         var toinsert = this.create_output_subarea(md, "output_latex", type);
+        if (extra_class){
+            toinsert.addClass(extra_class);
+        }
         toinsert.append(latex);
         element.append(toinsert);
         return toinsert;

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -485,7 +485,7 @@ var IPython = (function (IPython) {
         'image/jpeg' : true
     };
     
-    OutputArea.prototype.append_mime_type = function (json, element) {
+    OutputArea.prototype.append_mime_type = function (json, element, extra_class) {
         for (var type_i in OutputArea.display_order) {
             var type = OutputArea.display_order[type_i];
             var append = OutputArea.append_map[type];
@@ -498,7 +498,7 @@ var IPython = (function (IPython) {
                     } else {
                         // don't display if we don't know how to sanitize it
                         console.log("Ignoring untrusted " + type + " output.");
-                    continue;
+                        continue;
                     }
                 }
                 var md = json.metadata || {};

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -422,7 +422,7 @@ var IPython = (function (IPython) {
             }
             s = s + '\n';
             var toinsert = this.create_output_area();
-            this.append_text(s, {}, toinsert);
+            this.append_text(s, {}, toinsert, 'output_pyerr');
             this._safe_append(toinsert);
         }
     };

--- a/IPython/html/static/notebook/less/codecell.less
+++ b/IPython/html/static/notebook/less/codecell.less
@@ -16,3 +16,25 @@ div.input_prompt {
     border-top: 1px solid transparent;
 }
 
+
+// The styles related to div.highlight are for nbconvert HTML output only. This works
+// because the .highlight div isn't present in the live notebook. We could put this into
+// nbconvert, but it easily falls out of sync, can't use our less variables and doesn't
+// help the basic template when paired with our CSS.
+
+div.input_area > div.highlight {
+    margin: @code_padding;
+    border: none;
+    padding: 0px;
+    background-color: transparent;
+}
+
+div.input_area > div.highlight > pre {
+    margin: 0px;
+    border: 0px;
+    padding: 0px;
+    background-color: transparent;
+    font-size: @notebook_font_size;
+    line-height: @code_line_height;
+}
+

--- a/IPython/html/static/notebook/less/notebook.less
+++ b/IPython/html/static/notebook/less/notebook.less
@@ -21,6 +21,8 @@ div#notebook_panel {
     .box-shadow(0 -1px 10px rgba(0,0,0,.1));
 }
 div#notebook {
+    font-size: @notebook_font_size;
+    line-height: @notebook_line_height;
     overflow-y: scroll;
     overflow-x: auto;
     width: 100%;

--- a/IPython/html/static/notebook/less/pager.less
+++ b/IPython/html/static/notebook/less/pager.less
@@ -8,6 +8,8 @@ div#pager_splitter {
 }
 
 div#pager {
+    font-size: @notebook_font_size;
+    line-height: @notebook_line_height;
     overflow: auto;
     display: none;
 

--- a/IPython/html/static/notebook/less/variables.less
+++ b/IPython/html/static/notebook/less/variables.less
@@ -6,5 +6,8 @@
 @border_color:                  darken(@cell_selected_background, 31%);
 @light_border_color:            darken(@cell_selected_background, 17%);
 @border_width:                  1px;
-@code_padding:                  0.4em;
+@notebook_font_size:            14px;
+@notebook_line_height:          20px;
+@code_line_height:              1.21429em;  // changed from 1.231 to get 17px even
+@code_padding:                  0.4em;  // 5.6 px
 

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -71,13 +71,15 @@ input.engine_num_input{width:60px}
 div.cell{border:1px solid transparent;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;width:100%;display:flex;flex-direction:column;align-items:stretch}div.cell.selected{border-radius:4px;border:thin #ababab solid}
 div.cell.edit_mode{border-radius:4px;border:thin #008000 solid}
 div.cell{width:100%;padding:5px 5px 5px 0;margin:0;outline:none}
-div.prompt{min-width:11ex;padding:.4em;margin:0;font-family:monospace;text-align:right;line-height:1.231em}
+div.prompt{min-width:11ex;padding:.4em;margin:0;font-family:monospace;text-align:right;line-height:1.21429em}
 div.inner_cell{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;width:100%;display:flex;flex-direction:column;align-items:stretch;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}
 div.input_area{border:1px solid #cfcfcf;border-radius:4px;background:#f7f7f7}
 div.prompt:empty{padding-top:0;padding-bottom:0}
 div.input{page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}
 div.input_prompt{color:#000080;border-top:1px solid transparent}
-.CodeMirror{line-height:1.231em;height:auto;background:none;}
+div.input_area>div.highlight{margin:.4em;border:none;padding:0;background-color:transparent}
+div.input_area>div.highlight>pre{margin:0;border:0;padding:0;background-color:transparent;font-size:14px;line-height:1.21429em}
+.CodeMirror{line-height:1.21429em;height:auto;background:none;}
 .CodeMirror-scroll{overflow-y:hidden;overflow-x:auto}
 @-moz-document url-prefix(){.CodeMirror-scroll{overflow-x:hidden}}.CodeMirror-lines{padding:.4em}
 .CodeMirror-linenumber{padding:0 8px 0 4px}
@@ -116,7 +118,7 @@ div.output_area .rendered_html img{margin-left:0;margin-right:0}
 .output{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;width:100%;display:flex;flex-direction:column;align-items:stretch}
 div.output_area pre{font-family:monospace;margin:0;padding:0;border:0;font-size:100%;vertical-align:baseline;color:#000;background-color:transparent;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0;line-height:inherit}
 div.output_subarea{padding:.4em .4em 0 .4em;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}
-div.output_text{text-align:left;color:#000;font-family:monospace;line-height:1.231em}
+div.output_text{text-align:left;color:#000;font-family:monospace;line-height:1.21429em}
 div.output_stderr{background:#fdd;}
 div.output_latex{text-align:left}
 div.output_javascript:empty{padding:0}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1348,13 +1348,15 @@ input.engine_num_input{width:60px}
 div.cell{border:1px solid transparent;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;width:100%;display:flex;flex-direction:column;align-items:stretch}div.cell.selected{border-radius:4px;border:thin #ababab solid}
 div.cell.edit_mode{border-radius:4px;border:thin #008000 solid}
 div.cell{width:100%;padding:5px 5px 5px 0;margin:0;outline:none}
-div.prompt{min-width:11ex;padding:.4em;margin:0;font-family:monospace;text-align:right;line-height:1.231em}
+div.prompt{min-width:11ex;padding:.4em;margin:0;font-family:monospace;text-align:right;line-height:1.21429em}
 div.inner_cell{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;width:100%;display:flex;flex-direction:column;align-items:stretch;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}
 div.input_area{border:1px solid #cfcfcf;border-radius:4px;background:#f7f7f7}
 div.prompt:empty{padding-top:0;padding-bottom:0}
 div.input{page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}
 div.input_prompt{color:#000080;border-top:1px solid transparent}
-.CodeMirror{line-height:1.231em;height:auto;background:none;}
+div.input_area>div.highlight{margin:.4em;border:none;padding:0;background-color:transparent}
+div.input_area>div.highlight>pre{margin:0;border:0;padding:0;background-color:transparent;font-size:14px;line-height:1.21429em}
+.CodeMirror{line-height:1.21429em;height:auto;background:none;}
 .CodeMirror-scroll{overflow-y:hidden;overflow-x:auto}
 @-moz-document url-prefix(){.CodeMirror-scroll{overflow-x:hidden}}.CodeMirror-lines{padding:.4em}
 .CodeMirror-linenumber{padding:0 8px 0 4px}
@@ -1393,7 +1395,7 @@ div.output_area .rendered_html img{margin-left:0;margin-right:0}
 .output{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;width:100%;display:flex;flex-direction:column;align-items:stretch}
 div.output_area pre{font-family:monospace;margin:0;padding:0;border:0;font-size:100%;vertical-align:baseline;color:#000;background-color:transparent;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0;line-height:inherit}
 div.output_subarea{padding:.4em .4em 0 .4em;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}
-div.output_text{text-align:left;color:#000;font-family:monospace;line-height:1.231em}
+div.output_text{text-align:left;color:#000;font-family:monospace;line-height:1.21429em}
 div.output_stderr{background:#fdd;}
 div.output_latex{text-align:left}
 div.output_javascript:empty{padding:0}
@@ -1474,7 +1476,7 @@ body{background-color:#fff}
 body.notebook_app{overflow:hidden}
 span#notebook_name{height:1em;line-height:1em;padding:3px;border:none;font-size:146.5%}
 div#notebook_panel{margin:0 0 0 0;padding:0;-webkit-box-shadow:0 -1px 10px rgba(0,0,0,0.1);-moz-box-shadow:0 -1px 10px rgba(0,0,0,0.1);box-shadow:0 -1px 10px rgba(0,0,0,0.1)}
-div#notebook{overflow-y:scroll;overflow-x:auto;width:100%;padding:1em 0 1em 0;margin:0;border-top:1px solid #ababab;outline:none;box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box}
+div#notebook{font-size:14px;line-height:20px;overflow-y:scroll;overflow-x:auto;width:100%;padding:1em 0 1em 0;margin:0;border-top:1px solid #ababab;outline:none;box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box}
 div.ui-widget-content{border:1px solid #ababab;outline:none}
 pre.dialog{background-color:#f7f7f7;border:1px solid #ddd;border-radius:4px;padding:.4em;padding-left:2em}
 p.dialog{padding:.2em}
@@ -1507,7 +1509,7 @@ ul#help_menu li a{overflow:hidden;padding-right:2.2em}ul#help_menu li a i{margin
 .notification_widget{color:#777;padding:1px 12px;margin:2px 4px;z-index:10;border:1px solid #ccc;border-radius:4px;background:rgba(240,240,240,0.5)}.notification_widget.span{padding-right:2px}
 div#pager_splitter{height:8px}
 #pager-container{position:relative;padding:15px 0}
-div#pager{overflow:auto;display:none}div#pager pre{font-size:13px;line-height:1.231em;color:#000;background-color:#f7f7f7;padding:.4em}
+div#pager{font-size:14px;line-height:20px;overflow:auto;display:none}div#pager pre{font-size:13px;line-height:1.21429em;color:#000;background-color:#f7f7f7;padding:.4em}
 .shortcut_key{display:inline-block;width:15ex;text-align:right;font-family:monospace}
 .shortcut_descr{display:inline-block}
 span#save_widget{padding:0 5px;margin-top:12px}

--- a/IPython/nbconvert/filters/highlight.py
+++ b/IPython/nbconvert/filters/highlight.py
@@ -56,7 +56,7 @@ class Highlight2Html(NbConvertBase):
         if not language:
             language=self.default_language
 
-        return _pygments_highlight(source, HtmlFormatter(), language, metadata)
+        return _pygments_highlight(source if len(source) > 0 else ' ', HtmlFormatter(), language, metadata)
 
 
 class Highlight2Latex(NbConvertBase):

--- a/IPython/nbconvert/templates/html/basic.tpl
+++ b/IPython/nbconvert/templates/html/basic.tpl
@@ -175,13 +175,13 @@ height={{output.metadata['jpeg']['height']}}
 {%- endblock -%}
 
 {%- block data_javascript %}
+<div class="output_subarea output_javascript">
 <script type="text/javascript">
 {{ output.javascript }}
 </script>
+</div>
 {%- endblock -%}
 
 {%- block display_data scoped -%}
-<div class="box-flex1 output_subarea output_display_data">
 {{ super() }}
-</div>
 {%- endblock display_data -%}

--- a/IPython/nbconvert/templates/html/basic.tpl
+++ b/IPython/nbconvert/templates/html/basic.tpl
@@ -87,11 +87,11 @@ unknown type  {{ cell.type }}
 {% endblock unknowncell %}
 
 {% block pyout -%}
-{%- set extra_classes=" output_pyout" -%}
+{%- set extra_class="output_pyout" -%}
 {% block data_priority scoped %}
 {{ super() }}
 {% endblock %}
-{%- set extra_classes="" -%}
+{%- set extra_class="" -%}
 {%- endblock pyout %}
 
 {% block stream_stdout -%}
@@ -111,7 +111,7 @@ unknown type  {{ cell.type }}
 {%- endblock stream_stderr %}
 
 {% block data_svg scoped -%}
-<div class="output_svg output_subarea{{extra_classes}}">
+<div class="output_svg output_subarea {{extra_class}}">
 {%- if output.svg_filename %}
 <img src="{{output.svg_filename | posix_path}}"
 {%- else %}
@@ -121,13 +121,13 @@ unknown type  {{ cell.type }}
 {%- endblock data_svg %}
 
 {% block data_html scoped -%}
-<div class="output_html rendered_html output_subarea{{extra_classes}}">
+<div class="output_html rendered_html output_subarea {{extra_class}}">
 {{ output.html }}
 </div>
 {%- endblock data_html %}
 
 {% block data_png scoped %}
-<div class="output_png output_subarea{{extra_classes}}">
+<div class="output_png output_subarea {{extra_class}}">
 {%- if output.png_filename %}
 <img src="{{output.png_filename | posix_path}}"
 {%- else %}
@@ -144,7 +144,7 @@ height={{output.metadata['png']['height']}}
 {%- endblock data_png %}
 
 {% block data_jpg scoped %}
-<div class="output_jpeg output_subarea{{extra_classes}}">
+<div class="output_jpeg output_subarea {{extra_class}}">
 {%- if output.jpeg_filename %}
 <img src="{{output.jpeg_filename | posix_path}}"
 {%- else %}
@@ -161,7 +161,7 @@ height={{output.metadata['jpeg']['height']}}
 {%- endblock data_jpg %}
 
 {% block data_latex scoped %}
-<div class="output_latex output_subarea{{extra_classes}}">
+<div class="output_latex output_subarea {{extra_class}}">
 {{ output.latex }}
 </div>
 {%- endblock data_latex %}
@@ -177,7 +177,7 @@ height={{output.metadata['jpeg']['height']}}
 {%- endblock traceback_line %}
 
 {%- block data_text scoped %}
-<div class="output_text output_subarea{{extra_classes}}">
+<div class="output_text output_subarea {{extra_class}}">
 <pre>
 {{ output.text | ansi2html }}
 </pre>
@@ -185,7 +185,7 @@ height={{output.metadata['jpeg']['height']}}
 {%- endblock -%}
 
 {%- block data_javascript scoped %}
-<div class="output_subarea output_javascript{{extra_classes}}">
+<div class="output_subarea output_javascript {{extra_class}}">
 <script type="text/javascript">
 {{ output.javascript }}
 </script>

--- a/IPython/nbconvert/templates/html/basic.tpl
+++ b/IPython/nbconvert/templates/html/basic.tpl
@@ -62,7 +62,6 @@ In&nbsp;[{{ cell.prompt_number }}]:
 
 {% block markdowncell scoped %}
 <div class="cell border-box-sizing text_cell rendered unselected">
-<div class="input">
 {{ self.empty_in_prompt() }}
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
@@ -70,17 +69,14 @@ In&nbsp;[{{ cell.prompt_number }}]:
 </div>
 </div>
 </div>
-</div>
 {%- endblock markdowncell %}
 
 {% block headingcell scoped %}
 <div class="cell border-box-sizing text_cell rendered unselected">
-<div class="input">
 {{ self.empty_in_prompt() }}
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 {{ ("#" * cell.level + cell.source) | replace('\n', ' ')  | markdown2html | strip_files_prefix | add_anchor }}
-</div>
 </div>
 </div>
 </div>

--- a/IPython/nbconvert/templates/html/basic.tpl
+++ b/IPython/nbconvert/templates/html/basic.tpl
@@ -2,7 +2,7 @@
 
 
 {% block codecell %}
-<div class="cell border-box-sizing code_cell rendered unselected">
+<div class="cell border-box-sizing code_cell rendered">
 {{ super() }}
 </div>
 {%- endblock codecell %}
@@ -61,7 +61,7 @@ In&nbsp;[{{ cell.prompt_number }}]:
 {% endblock output %}
 
 {% block markdowncell scoped %}
-<div class="cell border-box-sizing text_cell rendered unselected">
+<div class="cell border-box-sizing text_cell rendered">
 {{ self.empty_in_prompt() }}
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
@@ -72,7 +72,7 @@ In&nbsp;[{{ cell.prompt_number }}]:
 {%- endblock markdowncell %}
 
 {% block headingcell scoped %}
-<div class="cell border-box-sizing text_cell rendered unselected">
+<div class="cell border-box-sizing text_cell rendered">
 {{ self.empty_in_prompt() }}
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">

--- a/IPython/nbconvert/templates/html/basic.tpl
+++ b/IPython/nbconvert/templates/html/basic.tpl
@@ -95,7 +95,7 @@ unknown type  {{ cell.type }}
 {%- endblock pyout %}
 
 {% block stream_stdout -%}
-<div class="box-flex1 output_subarea output_stream output_stdout">
+<div class="output_subarea output_stream output_stdout output_text">
 <pre>
 {{ output.text | ansi2html }}
 </pre>
@@ -159,7 +159,7 @@ height={{output.metadata['jpeg']['height']}}
 {%- endblock data_latex %}
 
 {% block pyerr -%}
-<div class="box-flex1 output_subarea output_pyerr">
+<div class="output_subarea output_text output_pyerr">
 <pre>{{ super() }}</pre>
 </div>
 {%- endblock pyerr %}

--- a/IPython/nbconvert/templates/html/basic.tpl
+++ b/IPython/nbconvert/templates/html/basic.tpl
@@ -119,7 +119,7 @@ unknown type  {{ cell.type }}
 {%- endblock data_svg %}
 
 {% block data_html -%}
-<div class="output_html rendered_html">
+<div class="output_html rendered_html output_subarea">
 {{ output.html }}
 </div>
 {%- endblock data_html %}
@@ -181,7 +181,3 @@ height={{output.metadata['jpeg']['height']}}
 </script>
 </div>
 {%- endblock -%}
-
-{%- block display_data scoped -%}
-{{ super() }}
-{%- endblock display_data -%}

--- a/IPython/nbconvert/templates/html/basic.tpl
+++ b/IPython/nbconvert/templates/html/basic.tpl
@@ -2,7 +2,7 @@
 
 
 {% block codecell %}
-<div class="cell border-box-sizing code_cell">
+<div class="cell border-box-sizing code_cell rendered unselected">
 {{ super() }}
 </div>
 {%- endblock codecell %}
@@ -40,8 +40,10 @@ In&nbsp;[{{ cell.prompt_number }}]:
 {% endblock output_prompt %}
 
 {% block input %}
-<div class="input_area box-flex1">
+<div class="inner_cell">
+    <div class="input_area">
 {{ cell.input | highlight2html(language=resources.get('language'), metadata=cell.metadata) }}
+</div>
 </div>
 {%- endblock input %}
 
@@ -59,7 +61,7 @@ In&nbsp;[{{ cell.prompt_number }}]:
 {% endblock output %}
 
 {% block markdowncell scoped %}
-<div class="cell border-box-sizing text_cell">
+<div class="cell border-box-sizing text_cell rendered unselected">
 <div class="input">
 {{ self.empty_in_prompt() }}
 <div class="inner_cell">
@@ -72,7 +74,7 @@ In&nbsp;[{{ cell.prompt_number }}]:
 {%- endblock markdowncell %}
 
 {% block headingcell scoped %}
-<div class="cell border-box-sizing text_cell">
+<div class="cell border-box-sizing text_cell rendered unselected">
 <div class="input">
 {{ self.empty_in_prompt() }}
 <div class="inner_cell">
@@ -89,7 +91,7 @@ unknown type  {{ cell.type }}
 {% endblock unknowncell %}
 
 {% block pyout -%}
-<div class="box-flex1 output_subarea output_pyout">
+<div class="output_subarea output_text">
 {% block data_priority scoped %}
 {{ super() }}
 {% endblock %}

--- a/IPython/nbconvert/templates/html/basic.tpl
+++ b/IPython/nbconvert/templates/html/basic.tpl
@@ -87,11 +87,11 @@ unknown type  {{ cell.type }}
 {% endblock unknowncell %}
 
 {% block pyout -%}
-<div class="output_subarea output_text output_pyout">
+{%- set extra_classes=" output_pyout" -%}
 {% block data_priority scoped %}
 {{ super() }}
 {% endblock %}
-</div>
+{%- set extra_classes="" -%}
 {%- endblock pyout %}
 
 {% block stream_stdout -%}
@@ -110,8 +110,8 @@ unknown type  {{ cell.type }}
 </div>
 {%- endblock stream_stderr %}
 
-{% block data_svg -%}
-<div class="output_svg output_subarea">
+{% block data_svg scoped -%}
+<div class="output_svg output_subarea{{extra_classes}}">
 {%- if output.svg_filename %}
 <img src="{{output.svg_filename | posix_path}}"
 {%- else %}
@@ -120,14 +120,14 @@ unknown type  {{ cell.type }}
 </div>
 {%- endblock data_svg %}
 
-{% block data_html -%}
-<div class="output_html rendered_html output_subarea">
+{% block data_html scoped -%}
+<div class="output_html rendered_html output_subarea{{extra_classes}}">
 {{ output.html }}
 </div>
 {%- endblock data_html %}
 
-{% block data_png %}
-<div class="output_png output_subarea">
+{% block data_png scoped %}
+<div class="output_png output_subarea{{extra_classes}}">
 {%- if output.png_filename %}
 <img src="{{output.png_filename | posix_path}}"
 {%- else %}
@@ -143,8 +143,8 @@ height={{output.metadata['png']['height']}}
 </div>
 {%- endblock data_png %}
 
-{% block data_jpg %}
-<div class="output_jpeg output_subarea">
+{% block data_jpg scoped %}
+<div class="output_jpeg output_subarea{{extra_classes}}">
 {%- if output.jpeg_filename %}
 <img src="{{output.jpeg_filename | posix_path}}"
 {%- else %}
@@ -160,8 +160,8 @@ height={{output.metadata['jpeg']['height']}}
 </div>
 {%- endblock data_jpg %}
 
-{% block data_latex %}
-<div class="output_latex output_subarea">
+{% block data_latex scoped %}
+<div class="output_latex output_subarea{{extra_classes}}">
 {{ output.latex }}
 </div>
 {%- endblock data_latex %}
@@ -176,16 +176,16 @@ height={{output.metadata['jpeg']['height']}}
 {{ line | ansi2html }}
 {%- endblock traceback_line %}
 
-{%- block data_text %}
-<div class="output_text output_subarea">
+{%- block data_text scoped %}
+<div class="output_text output_subarea{{extra_classes}}">
 <pre>
 {{ output.text | ansi2html }}
 </pre>
 </div>
 {%- endblock -%}
 
-{%- block data_javascript %}
-<div class="output_subarea output_javascript">
+{%- block data_javascript scoped %}
+<div class="output_subarea output_javascript{{extra_classes}}">
 <script type="text/javascript">
 {{ output.javascript }}
 </script>

--- a/IPython/nbconvert/templates/html/basic.tpl
+++ b/IPython/nbconvert/templates/html/basic.tpl
@@ -87,7 +87,7 @@ unknown type  {{ cell.type }}
 {% endblock unknowncell %}
 
 {% block pyout -%}
-<div class="output_subarea output_text">
+<div class="output_subarea output_text output_pyout">
 {% block data_priority scoped %}
 {{ super() }}
 {% endblock %}
@@ -103,7 +103,7 @@ unknown type  {{ cell.type }}
 {%- endblock stream_stdout %}
 
 {% block stream_stderr -%}
-<div class="box-flex1 output_subarea output_stream output_stderr">
+<div class="output_subarea output_stream output_stderr output_text">
 <pre>
 {{ output.text | ansi2html }}
 </pre>

--- a/IPython/nbconvert/templates/html/basic.tpl
+++ b/IPython/nbconvert/templates/html/basic.tpl
@@ -161,7 +161,9 @@ height={{output.metadata['jpeg']['height']}}
 {%- endblock data_jpg %}
 
 {% block data_latex %}
+<div class="output_latex output_subarea">
 {{ output.latex }}
+</div>
 {%- endblock data_latex %}
 
 {% block pyerr -%}
@@ -175,9 +177,11 @@ height={{output.metadata['jpeg']['height']}}
 {%- endblock traceback_line %}
 
 {%- block data_text %}
+<div class="output_text output_subarea">
 <pre>
 {{ output.text | ansi2html }}
 </pre>
+</div>
 {%- endblock -%}
 
 {%- block data_javascript %}

--- a/IPython/nbconvert/templates/html/basic.tpl
+++ b/IPython/nbconvert/templates/html/basic.tpl
@@ -111,11 +111,13 @@ unknown type  {{ cell.type }}
 {%- endblock stream_stderr %}
 
 {% block data_svg -%}
+<div class="output_svg output_subarea">
 {%- if output.svg_filename %}
 <img src="{{output.svg_filename | posix_path}}"
 {%- else %}
 {{ output.svg }}
 {%- endif %}
+</div>
 {%- endblock data_svg %}
 
 {% block data_html -%}
@@ -125,6 +127,7 @@ unknown type  {{ cell.type }}
 {%- endblock data_html %}
 
 {% block data_png %}
+<div class="output_png output_subarea">
 {%- if output.png_filename %}
 <img src="{{output.png_filename | posix_path}}"
 {%- else %}
@@ -137,9 +140,11 @@ width={{output.metadata['png']['width']}}
 height={{output.metadata['png']['height']}}
 {%- endif %}
 >
+</div>
 {%- endblock data_png %}
 
 {% block data_jpg %}
+<div class="output_jpeg output_subarea">
 {%- if output.jpeg_filename %}
 <img src="{{output.jpeg_filename | posix_path}}"
 {%- else %}
@@ -152,6 +157,7 @@ width={{output.metadata['jpeg']['width']}}
 height={{output.metadata['jpeg']['height']}}
 {%- endif %}
 >
+</div>
 {%- endblock data_jpg %}
 
 {% block data_latex %}

--- a/IPython/nbconvert/templates/html/full.tpl
+++ b/IPython/nbconvert/templates/html/full.tpl
@@ -10,8 +10,8 @@
 <meta charset="utf-8" />
 <title>{{resources['metadata']['name']}}</title>
 
-<script src="//cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
 
 {% for css in resources.inlining.css -%}
     <style type="text/css">

--- a/IPython/nbconvert/templates/html/full.tpl
+++ b/IPython/nbconvert/templates/html/full.tpl
@@ -10,6 +10,9 @@
 <meta charset="utf-8" />
 <title>{{resources['metadata']['name']}}</title>
 
+<script src="//cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+
 {% for css in resources.inlining.css -%}
     <style type="text/css">
     {{ css }}

--- a/IPython/nbconvert/templates/html/full.tpl
+++ b/IPython/nbconvert/templates/html/full.tpl
@@ -60,7 +60,17 @@ pre {
 
 {% block body %}
 <body>
+<div style="display: block;" id="site" class="border-box-sizing">
+  <div id="ipython-main-app" class="border-box-sizing">
+    <div id="notebook_panel" class="border-box-sizing" style="-webkit-box-shadow: none; -moz-box-shadow: none; box-shadow: none;">
+      <div tabindex="-1" id="notebook" class="border-box-sizing" style="overflow: visible; border-top: none;">
+        <div class="container" id="notebook-container">
 {{ super() }}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 </body>
 {%- endblock body %}
 

--- a/IPython/nbconvert/templates/html/full.tpl
+++ b/IPython/nbconvert/templates/html/full.tpl
@@ -25,16 +25,6 @@ body {
   overflow: visible;
   padding: 8px;
 }
-.input_area {
-  padding: 0.2em;
-}
-
-pre {
-  padding: 0.2em;
-  border: none;
-  margin: 0px;
-  font-size: 13px;
-}
 
 div#notebook {
   overflow: visible;

--- a/IPython/nbconvert/templates/html/full.tpl
+++ b/IPython/nbconvert/templates/html/full.tpl
@@ -33,6 +33,17 @@ pre {
   font-size: 13px;
 }
 
+div#notebook_panel {
+  -webkit-box-shadow: none; 
+  -moz-box-shadow: none; 
+  box-shadow: none;
+}
+
+div#notebook {
+  overflow: visible;
+  border-top: none;
+}
+
 @media print {
   div.cell {
     display: block;
@@ -62,8 +73,8 @@ pre {
 <body>
 <div style="display: block;" id="site" class="border-box-sizing">
   <div id="ipython-main-app" class="border-box-sizing">
-    <div id="notebook_panel" class="border-box-sizing" style="-webkit-box-shadow: none; -moz-box-shadow: none; box-shadow: none;">
-      <div tabindex="-1" id="notebook" class="border-box-sizing" style="overflow: visible; border-top: none;">
+    <div id="notebook_panel" class="border-box-sizing">
+      <div tabindex="-1" id="notebook" class="border-box-sizing">
         <div class="container" id="notebook-container">
 {{ super() }}
         </div>

--- a/IPython/nbconvert/templates/html/full.tpl
+++ b/IPython/nbconvert/templates/html/full.tpl
@@ -33,12 +33,6 @@ pre {
   font-size: 13px;
 }
 
-div#notebook_panel {
-  -webkit-box-shadow: none; 
-  -moz-box-shadow: none; 
-  box-shadow: none;
-}
-
 div#notebook {
   overflow: visible;
   border-top: none;
@@ -71,17 +65,11 @@ div#notebook {
 
 {% block body %}
 <body>
-<div style="display: block;" id="site" class="border-box-sizing">
-  <div id="ipython-main-app" class="border-box-sizing">
-    <div id="notebook_panel" class="border-box-sizing">
-      <div tabindex="-1" id="notebook" class="border-box-sizing">
-        <div class="container" id="notebook-container">
+  <div tabindex="-1" id="notebook" class="border-box-sizing">
+    <div class="container" id="notebook-container">
 {{ super() }}
-        </div>
-      </div>
     </div>
   </div>
-</div>
 </body>
 {%- endblock body %}
 

--- a/IPython/nbconvert/tests/README.md
+++ b/IPython/nbconvert/tests/README.md
@@ -1,0 +1,1 @@
+To compare nbconvert html output to the notebook's native html see https://gist.github.com/9241376.git.


### PR DESCRIPTION
Basically makes the DOMs of both map one to one.  This doesn't mean string notebook html == string nbconvert output.

I used a custom in-house HTML diffing rig to diff, see here https://gist.github.com/jdfreder/9241376 (mentioned in the README.md inside nbconvert/tests).

related to #5084
closes #5224
