### PR TITLE
clear _reply_content cache before using it

### DIFF
--- a/IPython/kernel/zmq/ipkernel.py
+++ b/IPython/kernel/zmq/ipkernel.py
@@ -383,8 +383,9 @@ class Kernel(Configurable):
             self._publish_pyin(code, parent, shell.execution_count)
 
         reply_content = {}
+        # FIXME: the shell calls the exception handler itself.
+        shell._reply_content = None
         try:
-            # FIXME: the shell calls the exception handler itself.
             shell.run_cell(code, store_history=store_history, silent=silent)
         except:
             status = u'error'


### PR DESCRIPTION
Any exceptions raised in startup code could be interpreted as the first actual execution failing.

/cc @fperez
