### PR TITLE
try to avoid EADDRINUSE errors on travis

### DIFF
--- a/IPython/kernel/connect.py
+++ b/IPython/kernel/connect.py
@@ -109,6 +109,7 @@ def write_connection_file(fname=None, shell_port=0, iopub_port=0, stdin_port=0, 
     if transport == 'tcp':
         for i in range(ports_needed):
             sock = socket.socket()
+            # struct.pack('ii', (0,0)) is 8 null bytes
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, b'\0' * 8)
             sock.bind(('', 0))
             ports.append(sock)

--- a/IPython/kernel/connect.py
+++ b/IPython/kernel/connect.py
@@ -109,6 +109,7 @@ def write_connection_file(fname=None, shell_port=0, iopub_port=0, stdin_port=0, 
     if transport == 'tcp':
         for i in range(ports_needed):
             sock = socket.socket()
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, b'\0' * 8)
             sock.bind(('', 0))
             ports.append(sock)
         for i, sock in enumerate(ports):

--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -221,9 +221,14 @@ def run_webapp(q, ipydir, nbdir, loglevel=0):
     sys.stderr = open(os.devnull, 'w')
     server = nbapp.NotebookApp()
     args = ['--no-browser']
-    args.extend(['--ipython-dir', ipydir])
-    args.extend(['--notebook-dir', nbdir])
-    args.extend(['--log-level', str(loglevel)])
+    args.extend(['--ipython-dir', ipydir,
+                 '--notebook-dir', nbdir,
+                 '--log-level', str(loglevel),
+    ])
+    # ipc doesn't work on Windows, and darwin has crazy-long temp paths,
+    # which run afoul of ipc's maximum path length.
+    if sys.platform.startswith('linux'):
+        args.append('--KernelManager.transport=ipc')
     server.initialize(args)
     # communicate the port number to the parent process
     q.put(server.port)


### PR DESCRIPTION
- use ipc for notebook js tests (on linux only)
- set SO_LINGER=0 during port selection
