### PR TITLE
support extracted output in HTML template

### DIFF
--- a/IPython/nbconvert/preprocessors/extractoutput.py
+++ b/IPython/nbconvert/preprocessors/extractoutput.py
@@ -35,7 +35,7 @@ class ExtractOutputPreprocessor(Preprocessor):
     output_filename_template = Unicode(
         "{unique_key}_{cell_index}_{index}{extension}", config=True)
 
-    extract_output_types = Set({'png', 'jpg', 'svg', 'application/pdf'}, config=True)
+    extract_output_types = Set({'png', 'jpeg', 'svg', 'application/pdf'}, config=True)
 
     def preprocess_cell(self, cell, resources, cell_index):
         """
@@ -71,7 +71,7 @@ class ExtractOutputPreprocessor(Preprocessor):
                     data = out[out_type]
 
                     #Binary files are base64-encoded, SVG is already XML
-                    if out_type in {'png', 'jpg', 'application/pdf'}:
+                    if out_type in {'png', 'jpeg', 'application/pdf'}:
 
                         # data is b64-encoded as text (str, unicode)
                         # decodestring only accepts bytes

--- a/IPython/nbconvert/templates/html/basic.tpl
+++ b/IPython/nbconvert/templates/html/basic.tpl
@@ -113,7 +113,11 @@ unknown type  {{ cell.type }}
 {%- endblock stream_stderr %}
 
 {% block data_svg -%}
+{%- if output.svg_filename %}
+<img src="{{output.svg_filename | posix_path}}"
+{%- else %}
 {{ output.svg }}
+{%- endif %}
 {%- endblock data_svg %}
 
 {% block data_html -%}
@@ -123,7 +127,11 @@ unknown type  {{ cell.type }}
 {%- endblock data_html %}
 
 {% block data_png %}
+{%- if output.png_filename %}
+<img src="{{output.png_filename | posix_path}}"
+{%- else %}
 <img src="data:image/png;base64,{{ output.png }}"
+{%- endif %}
 {%- if 'metadata' in output and 'width' in output.metadata.get('png', {}) %}
 width={{output.metadata['png']['width']}}
 {%- endif %}
@@ -134,7 +142,11 @@ height={{output.metadata['png']['height']}}
 {%- endblock data_png %}
 
 {% block data_jpg %}
+{%- if output.jpeg_filename %}
+<img src="{{output.jpeg_filename | posix_path}}"
+{%- else %}
 <img src="data:image/jpeg;base64,{{ output.jpeg }}"
+{%- endif %}
 {%- if 'metadata' in output and 'width' in output.metadata.get('jpeg', {}) %}
 width={{output.metadata['jpeg']['width']}}
 {%- endif %}


### PR DESCRIPTION
allows

```
ipython nbconvert --to html --ExtractOutput.enabled=True
```

to work properly without any b64-encoded data.
