### PR TITLE
Missing class def for TimeoutError

### DIFF
--- a/IPython/html/tests/launchnotebook.py
+++ b/IPython/html/tests/launchnotebook.py
@@ -16,6 +16,9 @@ from IPython.utils.tempdir import TemporaryDirectory
 MAX_WAITTIME = 30   # seconds to wait for notebook server to start
 POLL_INTERVAL = 0.1 # time between attempts
 
+class TimeoutError(Exception):
+    pass
+
 class NotebookTestBase(TestCase):
     """A base class for tests that need a running notebook.
     

--- a/IPython/html/tests/launchnotebook.py
+++ b/IPython/html/tests/launchnotebook.py
@@ -16,6 +16,8 @@ from IPython.utils.tempdir import TemporaryDirectory
 MAX_WAITTIME = 30   # seconds to wait for notebook server to start
 POLL_INTERVAL = 0.1 # time between attempts
 
+# TimeoutError is a builtin on Python 3. This can be removed when we stop
+# supporting Python 2.
 class TimeoutError(Exception):
     pass
 


### PR DESCRIPTION
In launchnotebook.py we were missing a definition of TimeoutError. This was causing weird effects when some tests fail.
