### PR TITLE
Refactoring Notebook.command_mode

### DIFF
--- a/IPython/html/static/notebook/js/keyboardmanager.js
+++ b/IPython/html/static/notebook/js/keyboardmanager.js
@@ -84,7 +84,6 @@ var IPython = (function (IPython) {
             help_index : 'aa',
             handler : function (event) {
                 IPython.notebook.command_mode();
-                IPython.notebook.focus_cell();
                 return false;
             }
         },
@@ -93,7 +92,6 @@ var IPython = (function (IPython) {
             help_index : 'ab',
             handler : function (event) {
                 IPython.notebook.command_mode();
-                IPython.notebook.focus_cell();
                 return false;
             }
         },

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -525,7 +525,6 @@ var IPython = (function (IPython) {
      * @param [cell] {Cell} Cell to enter command mode on.
      **/
     Notebook.prototype.handle_command_mode = function (cell) {
-        if (cell === null) { return; } // TODO: do I really need this?
         if (this.mode !== 'command') {
             cell.command_mode(); // TODO: is this OK here?
             this.mode = 'command';
@@ -556,7 +555,6 @@ var IPython = (function (IPython) {
      * @param [cell] {Cell} Cell to enter edit mode on.
      **/
     Notebook.prototype.handle_edit_mode = function (cell) {
-        if (cell === null) { return; } // TODO: do I really need this?
         if (this.mode !== 'edit') {
             cell.edit_mode();
             this.mode = 'edit';

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -116,11 +116,11 @@ var IPython = (function (IPython) {
         });
 
         $([IPython.events]).on('edit_mode.Cell', function (event, data) {
-            that.handle_edit_mode(that.find_cell_index(data.cell));
+            that.handle_edit_mode(data.cell);
         });
 
         $([IPython.events]).on('command_mode.Cell', function (event, data) {
-            that.command_mode();
+            that.handle_command_mode(data.cell);
         });
 
         $([IPython.events]).on('status_autorestarting.Kernel', function () {
@@ -519,20 +519,15 @@ var IPython = (function (IPython) {
     };
 
     /**
-     * Make the notebook enter command mode.
+     * Handle when a a cell blurs and the notebook should enter command mode.
      *
-     * @method command_mode
+     * @method handle_command_mode
+     * @param [cell] {Cell} Cell to enter command mode on.
      **/
-    Notebook.prototype.command_mode = function () {
-        // Make sure there isn't an edit mode cell lingering around.
-        var cell = this.get_cell(this.get_edit_index());
-        if (cell) {
-            cell.command_mode();
-        }
-
-        // Notify the keyboard manager if this is a change of mode for the 
-        // notebook as a whole.
+    Notebook.prototype.handle_command_mode = function (cell) {
+        if (cell === null) { return; } // TODO: do I really need this?
         if (this.mode !== 'command') {
+            cell.command_mode(); // TODO: is this OK here?
             this.mode = 'command';
             $([IPython.events]).trigger('command_mode.Notebook');
             IPython.keyboard_manager.command_mode();
@@ -540,19 +535,28 @@ var IPython = (function (IPython) {
     };
 
     /**
+     * Make the notebook enter command mode.
+     *
+     * @method command_mode
+     **/
+    Notebook.prototype.command_mode = function () {
+        var cell = this.get_cell(this.get_edit_index());
+        if (cell && this.mode !== 'command') {
+            // We don't call cell.command_mode, but rather call cell.focus_cell()
+            // which will blur and CM editor and trigger the call to
+            // handle_command_mode.
+            cell.focus_cell();
+        }
+    };
+
+    /**
      * Handle when a cell fires it's edit_mode event.
      *
      * @method handle_edit_mode
-     * @param [index] {int} Cell index to select.  If no index is provided, 
-     *  the current selected cell is used.
+     * @param [cell] {Cell} Cell to enter edit mode on.
      **/
-    Notebook.prototype.handle_edit_mode = function (index) {
-        // Make sure the cell exists.
-        var cell = this.get_cell(index);
-        if (cell === null) { return; }
-
-        // Set the cell to edit mode and notify the keyboard manager if this
-        // is a change of mode for the notebook as a whole.
+    Notebook.prototype.handle_edit_mode = function (cell) {
+        if (cell === null) { return; } // TODO: do I really need this?
         if (this.mode !== 'edit') {
             cell.edit_mode();
             this.mode = 'edit';
@@ -1449,7 +1453,6 @@ var IPython = (function (IPython) {
         var cell_index = this.find_cell_index(cell);
         
         cell.execute();
-        cell.focus_cell();
         this.command_mode();
         this.set_dirty(true);
     };
@@ -1501,7 +1504,6 @@ var IPython = (function (IPython) {
         }
 
         this.select(cell_index+1);
-        this.get_cell(cell_index+1).focus_cell();
         this.command_mode();
         this.set_dirty(true);
     };
@@ -1972,7 +1974,7 @@ var IPython = (function (IPython) {
             this.edit_mode(0);
         } else {
             this.select(0);
-            this.command_mode();
+            this.handle_command_mode(this.get_cell(0));
         }
         this.set_dirty(false);
         this.scroll_to_top();


### PR DESCRIPTION
This splits `Notebook.command_mode` into two parts, like `edit_mode` is already. This is needed to avoid having to call `Cell.focus_cell` manually each time `Notebook.command_mode` is called.
