### PR TITLE
Fix kernel restart in case connection file is deleted.

### DIFF
--- a/IPython/kernel/connect.py
+++ b/IPython/kernel/connect.py
@@ -473,7 +473,7 @@ class ConnectionFileMixin(Configurable):
 
     def write_connection_file(self):
         """Write connection info to JSON dict in self.connection_file."""
-        if self._connection_file_written:
+        if self._connection_file_written and os.path.exists(self.connection_file):
             return
 
         self.connection_file, cfg = write_connection_file(self.connection_file,


### PR DESCRIPTION
On Mac, the /tmp files are deleted after 3 days of inactivity,
causing qtconsole kernel restart to fail subsequently.
This commit adds check to ensure that connection_file is
written if it does not exist.
