### PR TITLE
nbconvert: Make sure node is atleast version 0.9.12

### DIFF
--- a/IPython/nbconvert/filters/markdown.py
+++ b/IPython/nbconvert/filters/markdown.py
@@ -111,9 +111,12 @@ def _verify_node(cmd):
     try:
         out, err, return_code = get_output_error_code([cmd, '--version'])
     except OSError:
-         # Command not found
+        # Command not found
         return False
-    return return_code == 0 and check_version(out.lstrip('v'), '0.9.12')
+    if return_code:
+        # Command error
+        return False
+    return check_version(out.lstrip('v'), '0.9.12')
 
 # prefer md2html via marked if node.js >= 0.9.12 is available
 # node is called nodejs on debian, so try that first

--- a/IPython/nbconvert/filters/markdown.py
+++ b/IPython/nbconvert/filters/markdown.py
@@ -77,10 +77,10 @@ def markdown2html(source):
                 warnings.warn(  "Node.js 0.9.12 or later wasn't found.\n" +
                                 "Nbconvert will try to use Pandoc instead.")
                 _node = False
-    if not _node:
-        return markdown2html_pandoc(source)
-    else:
+    if _node:
         return markdown2html_marked(source)
+    else:
+        return markdown2html_pandoc(source)
 
 def markdown2html_pandoc(source):
     """Convert a markdown string to HTML via pandoc"""


### PR DESCRIPTION
Trying to export html using nbconvert and an older version of node fails silently.  All of the markdown gets stripped from the document.  I used `nvm` to install and test `node.js` with our `marked.js` for node versions 0.6+.  I discovered only node versions 0.9.12 and up produce any output. 0.8 and earlier produce no output and 0.9.11 and earlier hang.

This PR adds a test that makes sure that node is the right version before deciding to use it, otherwise pandoc is used.
#5263
