### PR TITLE
fix a typo introduced by a rebased PR

### DIFF
--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -531,7 +531,7 @@ var IPython = (function (IPython) {
                     .text('¶')
             );
             this.set_rendered(h);
-            this.element.find('div.text_cell_input').hide();
+            this.element.find('div.input_area').hide();
             this.element.find("div.text_cell_render").show();
             this.typeset();
         }


### PR DESCRIPTION
caused heading cells to appear in both rendered and unrendered state
