### PR TITLE
Trying something out: don't create new tabs

### DIFF
--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -230,7 +230,7 @@ var IPython = (function (IPython) {
                     path,
                     nbname
                 )
-            ).attr('target','_blank');
+            );
     };
 
 
@@ -387,14 +387,12 @@ var IPython = (function (IPython) {
             async : false,
             success : function (data, status, xhr) {
                 var notebook_name = data.name;
-                window.open(
+                window.location.href =
                     utils.url_join_encode(
                         base_url,
                         'notebooks',
                         path,
-                        notebook_name),
-                    '_blank'
-                );
+                        notebook_name);
             }
         };
         var url = utils.url_join_encode(


### PR DESCRIPTION
Currently, when opening an existing notebook or creating a new one from the dashboard, we always open new tabs. The notebook has always worked this way, but it isn't something we have put much thought into. Very few web site work this way (Google Docs is the main one that does). I am not at all convinced this is better, only that it is worth thinking about.
