### PR TITLE
Correct initial state of kernel status indicator

### DIFF
--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -102,6 +102,16 @@ var IPython = (function (IPython) {
         $([IPython.events]).on('status_interrupting.Kernel',function () {
             knw.set_message("Interrupting kernel", 2000);
         });
+        
+        // Start the kernel indicator in the busy state, and send a kernel_info request.
+        // When the kernel_info reply arrives, the kernel is idle.
+        $kernel_ind_icon.attr('class','icon-circle').attr('title','Kernel Busy');
+
+        $([IPython.events]).on('status_started.Kernel', function (evt, data) {
+            data.kernel.kernel_info(function () {
+                $([IPython.events]).trigger('status_idle.Kernel');
+            });
+        });
 
         $([IPython.events]).on('status_dead.Kernel',function () {
             var msg = 'The kernel has died, and the automatic restart has failed.' +


### PR DESCRIPTION
- start as busy, since we don't know
- send a kernel_info request once connections are established
- set idle on reply to the to the kernel_info request

Two cases:
1. Kernel is busy when the notebook opens, and it will be correctly indicated as such.
2. Kernel is idle when the notebook opens. It will briefly indicate as busy,
   then indicate idle as soon as the kernel is responsive.

There may actually be a bonus effect in cases where kernels are slow to start, since they will take some time to respond to the info request. In this case, the busy indicator will actually communicate how long it takes for the kernel to become responsive.
