### PR TITLE
unify keyboard shortcut and codemirror interaction

### DIFF
--- a/IPython/html/static/base/js/keyboard.js
+++ b/IPython/html/static/base/js/keyboard.js
@@ -237,6 +237,12 @@ IPython.keyboard = (function (IPython) {
         return true;
     }
 
+    ShortcutManager.prototype.use_shortcut = function (event) {
+        var shortcut = event_to_shortcut(event);
+        var data = this._shortcuts[shortcut];
+        return !( data === undefined )
+    }
+
     return {
         keycodes : keycodes,
         inv_keycodes : inv_keycodes,

--- a/IPython/html/static/base/js/keyboard.js
+++ b/IPython/html/static/base/js/keyboard.js
@@ -237,7 +237,7 @@ IPython.keyboard = (function (IPython) {
         return true;
     }
 
-    ShortcutManager.prototype.use_shortcut = function (event) {
+    ShortcutManager.prototype.handles = function (event) {
         var shortcut = event_to_shortcut(event);
         var data = this._shortcuts[shortcut];
         return !( data === undefined )

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -164,7 +164,7 @@ var IPython = (function (IPython) {
      *
      * @method handle_codemirror_keyevent
      * @param {CodeMirror} editor - The codemirror instance bound to the cell
-     * @param {event} event -
+     * @param {event} event - key press event which either should or should not be handled by CodeMirror
      * @return {Boolean} `true` if CodeMirror should ignore the event, `false` Otherwise
      */
     Cell.prototype.handle_codemirror_keyevent = function (editor, event) {

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -238,7 +238,7 @@ var IPython = (function (IPython) {
      * @param {event} event -
      * @return {Boolean} `true` if CodeMirror should ignore the event, `false` Otherwise
      */
-    CodeCell.prototype.handle_keyevent = function (editor, event) {
+    Cell.prototype.handle_keyevent = function (editor, event) {
 
         // console.log('CM', this.mode, event.which, event.type)
 

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -281,7 +281,7 @@ var IPython = (function (IPython) {
     Cell.prototype.at_top = function () {
         var cm = this.code_mirror;
         var cursor = cm.getCursor();
-        if (cursor.line === 0 && cm.findPosV(cursor, -1, 'line').hitSide) {
+        if (cursor.line === 0 && cursor.ch === 0) {
             return true;
         } else {
             return false;
@@ -295,7 +295,7 @@ var IPython = (function (IPython) {
     Cell.prototype.at_bottom = function () {
         var cm = this.code_mirror;
         var cursor = cm.getCursor();
-        if (cursor.line === (cm.lineCount()-1) && cm.findPosV(cursor, 1, 'line').hitSide) {
+        if (cursor.line === (cm.lineCount()-1) && cursor.ch === cm.getLine(cursor.line).length) {
             return true;
         } else {
             return false;

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -173,7 +173,7 @@ var IPython = (function (IPython) {
 
         // if this is an edit_shortcuts shortcut, the global keyboard/shortcut
         // manager will handle it
-        if (shortcuts.use_shortcut(event)) { return true; }
+        if (shortcuts.handles(event)) { return true; }
         
         return false;
     };

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -278,7 +278,7 @@ var IPython = (function (IPython) {
      * @return {Boolean}
      */
     Cell.prototype.at_top = function () {
-        var cm = this.code_mirror
+        var cm = this.code_mirror;
         var cursor = cm.getCursor();
         if (cursor.line === 0 && cm.findPosV(cursor, -1, 'line').hitSide) {
             return true;
@@ -292,7 +292,7 @@ var IPython = (function (IPython) {
      * @return {Boolean}
      * */
     Cell.prototype.at_bottom = function () {
-        var cm = this.code_mirror
+        var cm = this.code_mirror;
         var cursor = cm.getCursor();
         if (cursor.line === (cm.lineCount()-1) && cm.findPosV(cursor, 1, 'line').hitSide) {
             return true;

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -171,7 +171,8 @@ var IPython = (function (IPython) {
         var that = this;
         var shortcuts = IPython.keyboard_manager.edit_shortcuts;
 
-        // if this is an edit_shortcuts shortcut, we've already handled it.
+        // if this is an edit_shortcuts shortcut, the global keyboard/shortcut
+        // manager will handle it
         if (shortcuts.use_shortcut(event)) { return true; }
         
         return false;
@@ -254,7 +255,7 @@ var IPython = (function (IPython) {
     };
 
     /**
-     * Either delegates keyboard shortcut handling to either IPython keyboard
+     * Delegates keyboard shortcut handling to either IPython keyboard
      * manager when in command mode, or CodeMirror when in edit mode
      *
      * @method handle_keyevent

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -230,6 +230,26 @@ var IPython = (function (IPython) {
     };
 
     /**
+     * Either delegates keyboard shortcut handling to either IPython keyboard
+     * manager when in command mode, or CodeMirror when in edit mode
+     *
+     * @method handle_keyevent
+     * @param {CodeMirror} editor - The codemirror instance bound to the cell
+     * @param {event} event -
+     * @return {Boolean} `true` if CodeMirror should ignore the event, `false` Otherwise
+     */
+    CodeCell.prototype.handle_keyevent = function (editor, event) {
+
+        // console.log('CM', this.mode, event.which, event.type)
+
+        if (this.mode === 'command') {
+            return true;
+        } else if (this.mode === 'edit') {
+            return this.handle_codemirror_keyevent(editor, event);
+        }
+    };
+
+    /**
      * @method at_top
      * @return {Boolean}
      */

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -260,7 +260,7 @@ var IPython = (function (IPython) {
      *
      * @method handle_keyevent
      * @param {CodeMirror} editor - The codemirror instance bound to the cell
-     * @param {event} event -
+     * @param {event} - key event to be handled
      * @return {Boolean} `true` if CodeMirror should ignore the event, `false` Otherwise
      */
     Cell.prototype.handle_keyevent = function (editor, event) {

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -283,9 +283,8 @@ var IPython = (function (IPython) {
         var cursor = cm.getCursor();
         if (cursor.line === 0 && cursor.ch === 0) {
             return true;
-        } else {
-            return false;
         }
+        return false;
     };
 
     /**
@@ -297,10 +296,10 @@ var IPython = (function (IPython) {
         var cursor = cm.getCursor();
         if (cursor.line === (cm.lineCount()-1) && cursor.ch === cm.getLine(cursor.line).length) {
             return true;
-        } else {
-            return false;
         }
+        return false;
     };
+
     /**
      * enter the command mode for the cell
      * @method command_mode

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -230,6 +230,34 @@ var IPython = (function (IPython) {
     };
 
     /**
+     * @method at_top
+     * @return {Boolean}
+     */
+    Cell.prototype.at_top = function () {
+        var cm = this.code_mirror
+        var cursor = cm.getCursor();
+        if (cursor.line === 0 && cm.findPosV(cursor, -1, 'line').hitSide) {
+            console.log('at top');
+            return true;
+        } else {
+            return false;
+        }
+    };
+
+    /**
+     * @method at_bottom
+     * @return {Boolean}
+     * */
+    Cell.prototype.at_bottom = function () {
+        var cm = this.code_mirror
+        var cursor = cm.getCursor();
+        if (cursor.line === (cm.lineCount()-1) && cm.findPosV(cursor, 1, 'line').hitSide) {
+            return true;
+        } else {
+            return false;
+        }
+    };
+    /**
      * enter the command mode for the cell
      * @method command_mode
      * @return is the action being taken

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -174,28 +174,7 @@ var IPython = (function (IPython) {
         // if this is an edit_shortcuts shortcut, we've already handled it.
         if (shortcuts.use_shortcut(event)) { return true; }
         
-        if (event.keyCode === keycodes.enter && (event.shiftKey || event.ctrlKey || event.altKey)) {
-            // Always ignore shift-enter in CodeMirror as we handle it.
-            return true;
-        } else if (event.which === keycodes.up && event.type === 'keydown') {
-            // If we are not at the top, let CM handle the up arrow and
-            // prevent the global keydown handler from handling it.
-            if (!that.at_top()) {
-                event.stop();
-                return false;
-            } else {
-                return true;
-            };
-        } else if (event.which === keycodes.down && event.type === 'keydown') {
-            // If we are not at the bottom, let CM handle the down arrow and
-            // prevent the global keydown handler from handling it.
-            if (!that.at_bottom()) {
-                event.stop();
-                return false;
-            } else {
-                return true;
-            };
-        } else if (event.which === keycodes.esc && event.type === 'keydown') {
+        if (event.which === keycodes.esc && event.type === 'keydown') {
             if (that.code_mirror.options.keyMap === "vim-insert") {
                 // vim keyMap is active and in insert mode. In this case we leave vim
                 // insert mode, but remain in notebook edit mode.

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -169,7 +169,11 @@ var IPython = (function (IPython) {
      */
     Cell.prototype.handle_codemirror_keyevent = function (editor, event) {
         var that = this;
+        var shortcuts = IPython.keyboard_manager.edit_shortcuts;
 
+        // if this is an edit_shortcuts shortcut, we've already handled it.
+        if (shortcuts.use_shortcut(event)) { return true; }
+        
         if (event.keyCode === keycodes.enter && (event.shiftKey || event.ctrlKey || event.altKey)) {
             // Always ignore shift-enter in CodeMirror as we handle it.
             return true;

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -174,19 +174,6 @@ var IPython = (function (IPython) {
         // if this is an edit_shortcuts shortcut, we've already handled it.
         if (shortcuts.use_shortcut(event)) { return true; }
         
-        if (event.which === keycodes.esc && event.type === 'keydown') {
-            if (that.code_mirror.options.keyMap === "vim-insert") {
-                // vim keyMap is active and in insert mode. In this case we leave vim
-                // insert mode, but remain in notebook edit mode.
-                // Let' CM handle this event and prevent global handling.
-                event.stop();
-                return false;
-            } else {
-                // vim keyMap is not active. Leave notebook edit mode.
-                // Don't let CM handle the event, defer to global handling.
-                return true;
-            }
-        }
         return false;
     };
 

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -245,7 +245,7 @@ var IPython = (function (IPython) {
         
         // keyboard event wasn't one of those unique to code cells, let's see
         // if it's one of the generic ones (i.e. check edit mode shortcuts)
-        return IPython.Cell.prototype.handle_codemirror_keyevent.apply(this, [editor, event])
+        return IPython.Cell.prototype.handle_codemirror_keyevent.apply(this, [editor, event]);
     };
 
     // Kernel related calls.

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -501,26 +501,6 @@ var IPython = (function (IPython) {
     };
 
 
-    CodeCell.prototype.at_top = function () {
-        var cursor = this.code_mirror.getCursor();
-        if (cursor.line === 0 && cursor.ch === 0) {
-            return true;
-        } else {
-            return false;
-        }
-    };
-
-
-    CodeCell.prototype.at_bottom = function () {
-        var cursor = this.code_mirror.getCursor();
-        if (cursor.line === (this.code_mirror.lineCount()-1) && cursor.ch === this.code_mirror.getLine(cursor.line).length) {
-            return true;
-        } else {
-            return false;
-        }
-    };
-
-
     CodeCell.prototype.clear_output = function (wait) {
         this.output_area.clear_output(wait);
         this.set_input_prompt();

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -197,7 +197,7 @@ var IPython = (function (IPython) {
         if (event.keyCode === keycodes.enter && (event.shiftKey || event.ctrlKey || event.altKey)) {
             // Always ignore shift-enter in CodeMirror as we handle it.
             return true;
-        } else if (event.which === 40 && event.type === 'keypress' && IPython.tooltip.time_before_tooltip >= 0) {
+        } else if (event.which === keycodes.down && event.type === 'keypress' && IPython.tooltip.time_before_tooltip >= 0) {
             // triger on keypress (!) otherwise inconsistent event.which depending on plateform
             // browser and keyboard layout !
             // Pressing '(' , request tooltip, don't forget to reappend it

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -194,60 +194,26 @@ var IPython = (function (IPython) {
             this.auto_highlight();
         }
 
-        if (event.keyCode === keycodes.enter && (event.shiftKey || event.ctrlKey || event.altKey)) {
-            // Always ignore shift-enter in CodeMirror as we handle it.
-            return true;
-        } else if (event.which === keycodes.down && event.type === 'keypress' && IPython.tooltip.time_before_tooltip >= 0) {
+        if (event.which === keycodes.down && event.type === 'keypress' && IPython.tooltip.time_before_tooltip >= 0) {
             // triger on keypress (!) otherwise inconsistent event.which depending on plateform
             // browser and keyboard layout !
             // Pressing '(' , request tooltip, don't forget to reappend it
             // The second argument says to hide the tooltip if the docstring
             // is actually empty
             IPython.tooltip.pending(that, true);
-        } else if (event.which === keycodes.up && event.type === 'keydown') {
-            // If we are not at the top, let CM handle the up arrow and
-            // prevent the global keydown handler from handling it.
-            if (!that.at_top()) {
-                event.stop();
-                return false;
-            } else {
-                return true;
+        } else if ( tooltip_closed && event.which === keycodes.esc && event.type === 'keydown') {
+            // If tooltip is active, cancel it.
+            // The call to remove_and_cancel_tooltip above in L177 doesn't pass
+            // force=true. Because of this it won't actually close the tooltip
+            // if it is in sticky mode. Thus, we have to check again if it is open
+            // and close it with force=true.
+            if (!IPython.tooltip._hidden) {
+                IPython.tooltip.remove_and_cancel_tooltip(true);
             }
-        } else if (event.which === keycodes.esc && event.type === 'keydown') {
-            // First see if the tooltip is active and if so cancel it.
-            if (tooltip_closed) {
-                // The call to remove_and_cancel_tooltip above in L177 doesn't pass
-                // force=true. Because of this it won't actually close the tooltip
-                // if it is in sticky mode. Thus, we have to check again if it is open
-                // and close it with force=true.
-                if (!IPython.tooltip._hidden) {
-                    IPython.tooltip.remove_and_cancel_tooltip(true);
-                }
-                // If we closed the tooltip, don't let CM or the global handlers
-                // handle this event.
-                event.stop();
-                return true;
-            }
-            if (that.code_mirror.options.keyMap === "vim-insert") {
-                // vim keyMap is active and in insert mode. In this case we leave vim
-                // insert mode, but remain in notebook edit mode.
-                // Let' CM handle this event and prevent global handling.
-                event.stop();
-                return false;
-            } else {
-                // vim keyMap is not active. Leave notebook edit mode.
-                // Don't let CM handle the event, defer to global handling.
-                return true;
-            }
-        } else if (event.which === keycodes.down && event.type === 'keydown') {
-            // If we are not at the bottom, let CM handle the down arrow and
-            // prevent the global keydown handler from handling it.
-            if (!that.at_bottom()) {
-                event.stop();
-                return false;
-            } else {
-                return true;
-            }
+            // If we closed the tooltip, don't let CM or the global handlers
+            // handle this event.
+            event.stop();
+            return true;
         } else if (event.keyCode === keycodes.tab && event.type === 'keydown' && event.shiftKey) {
                 if (editor.somethingSelected()){
                     var anchor = editor.getCursor("anchor");
@@ -275,12 +241,11 @@ var IPython = (function (IPython) {
                 this.completer.startCompletion();
                 return true;
             }
-        } else {
-            // keypress/keyup also trigger on TAB press, and we don't want to
-            // use those to disable tab completion.
-            return false;
-        }
-        return false;
+        } 
+        
+        // keyboard event wasn't one of those unique to code cells, let's see
+        // if it's one of the generic ones (i.e. check edit mode shortcuts)
+        return IPython.Cell.prototype.handle_codemirror_keyevent.apply(this, [editor, event])
     };
 
     // Kernel related calls.

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -171,16 +171,6 @@ var IPython = (function (IPython) {
         );
     };
 
-    CodeCell.prototype.handle_keyevent = function (editor, event) {
-
-        // console.log('CM', this.mode, event.which, event.type)
-
-        if (this.mode === 'command') {
-            return true;
-        } else if (this.mode === 'edit') {
-            return this.handle_codemirror_keyevent(editor, event);
-        }
-    };
 
     /**
      *  This method gets called in CodeMirror's onKeyDown/onKeyPress

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -202,9 +202,9 @@ var IPython = (function (IPython) {
             // is actually empty
             IPython.tooltip.pending(that, true);
         } else if ( tooltip_closed && event.which === keycodes.esc && event.type === 'keydown') {
-            // If tooltip is active, cancel it.
-            // The call to remove_and_cancel_tooltip above in L177 doesn't pass
-            // force=true. Because of this it won't actually close the tooltip
+            // If tooltip is active, cancel it.  The call to
+            // remove_and_cancel_tooltip above doesn't pass, force=true.
+            // Because of this it won't actually close the tooltip
             // if it is in sticky mode. Thus, we have to check again if it is open
             // and close it with force=true.
             if (!IPython.tooltip._hidden) {
@@ -410,7 +410,7 @@ var IPython = (function (IPython) {
 
     CodeCell.input_prompt_classical = function (prompt_value, lines_number) {
         var ns;
-        if (prompt_value == undefined) {
+        if (prompt_value === undefined) {
             ns = "&nbsp;";
         } else {
             ns = encodeURIComponent(prompt_value);

--- a/IPython/html/static/notebook/js/keyboardmanager.js
+++ b/IPython/html/static/notebook/js/keyboardmanager.js
@@ -100,23 +100,21 @@ var IPython = (function (IPython) {
             help_index : '',
             handler : function (event) {
                 var index = IPython.notebook.get_selected_index();
-                if (index !== null && index !== 0) {
-                    var cell = IPython.notebook.get_cell(index);
-                    if (cell && cell.at_top()) {
-                        event.preventDefault();
-                        IPython.notebook.command_mode();
-                        IPython.notebook.select_prev();
-                        IPython.notebook.edit_mode();
-                        var cm = IPython.notebook.get_selected_cell().code_mirror;
-                        cm.setCursor(cm.lastLine(), 0);
-                        return false;
-                    } else if (cell) {
-                        var cm = cell.code_mirror;
-                        var cursor = cm.getCursor();
-                        cursor.line -= 1;
-                        cm.setCursor(cursor);
-                        return false;
-                    }
+                var cell = IPython.notebook.get_cell(index);
+                if (cell && cell.at_top() && index !== 0) {
+                    event.preventDefault();
+                    IPython.notebook.command_mode();
+                    IPython.notebook.select_prev();
+                    IPython.notebook.edit_mode();
+                    var cm = IPython.notebook.get_selected_cell().code_mirror;
+                    cm.setCursor(cm.lastLine(), 0);
+                    return false;
+                } else if (cell) {
+                    var cm = cell.code_mirror;
+                    var cursor = cm.getCursor();
+                    cursor.line -= 1;
+                    cm.setCursor(cursor);
+                    return false;
                 }
             }
         },
@@ -125,23 +123,21 @@ var IPython = (function (IPython) {
             help_index : '',
             handler : function (event) {
                 var index = IPython.notebook.get_selected_index();
-                if (index !== null && index !== (IPython.notebook.ncells()-1)) {
-                    var cell = IPython.notebook.get_cell(index);
-                    if (cell && cell.at_bottom()) {
-                        event.preventDefault();
-                        IPython.notebook.command_mode();
-                        IPython.notebook.select_next();
-                        IPython.notebook.edit_mode();
-                        var cm = IPython.notebook.get_selected_cell().code_mirror;
-                        cm.setCursor(0, 0);
-                        return false;
-                    } else if (cell) {
-                        var cm = cell.code_mirror;
-                        var cursor = cm.getCursor();
-                        cursor.line += 1;
-                        cm.setCursor(cursor);
-                        return false;
-                    }
+                var cell = IPython.notebook.get_cell(index);
+                if (cell.at_bottom() && index !== (IPython.notebook.ncells()-1)) {
+                    event.preventDefault();
+                    IPython.notebook.command_mode();
+                    IPython.notebook.select_next();
+                    IPython.notebook.edit_mode();
+                    var cm = IPython.notebook.get_selected_cell().code_mirror;
+                    cm.setCursor(0, 0);
+                    return false;
+                } else {
+                    var cm = cell.code_mirror;
+                    var cursor = cm.getCursor();
+                    cursor.line += 1;
+                    cm.setCursor(cursor);
+                    return false;
                 }
             }
         },

--- a/IPython/html/static/notebook/js/keyboardmanager.js
+++ b/IPython/html/static/notebook/js/keyboardmanager.js
@@ -109,9 +109,9 @@ var IPython = (function (IPython) {
                         IPython.notebook.edit_mode();
                         return false;
                     } else if (cell) {
-                        var cm = cell.code_mirror
-                        var cursor = cm.getCursor()
-                        cursor.line -= 1
+                        var cm = cell.code_mirror;
+                        var cursor = cm.getCursor();
+                        cursor.line -= 1;
                         cm.setCursor(cursor);
                     }
                 }
@@ -131,9 +131,9 @@ var IPython = (function (IPython) {
                         IPython.notebook.edit_mode();
                         return false;
                     } else if (cell) {
-                        var cm = cell.code_mirror
-                        var cursor = cm.getCursor()
-                        cursor.line += 1
+                        var cm = cell.code_mirror;
+                        var cursor = cm.getCursor();
+                        cursor.line += 1;
                         cm.setCursor(cursor);
                     }
                 }

--- a/IPython/html/static/notebook/js/keyboardmanager.js
+++ b/IPython/html/static/notebook/js/keyboardmanager.js
@@ -107,12 +107,16 @@ var IPython = (function (IPython) {
                         IPython.notebook.command_mode();
                         IPython.notebook.select_prev();
                         IPython.notebook.edit_mode();
+                        var cm = IPython.notebook.get_selected_cell().code_mirror;
+                        var prev_cursor = cell.code_mirror.getCursor();
+                        cm.setCursor(cm.lastLine(), prev_cursor.ch)
                         return false;
                     } else if (cell) {
                         var cm = cell.code_mirror;
                         var cursor = cm.getCursor();
                         cursor.line -= 1;
                         cm.setCursor(cursor);
+                        return false;
                     }
                 }
             }
@@ -129,12 +133,16 @@ var IPython = (function (IPython) {
                         IPython.notebook.command_mode();
                         IPython.notebook.select_next();
                         IPython.notebook.edit_mode();
+                        var cm = IPython.notebook.get_selected_cell().code_mirror;
+                        var prev_cursor = cell.code_mirror.getCursor();
+                        cm.setCursor(0, prev_cursor.ch);
                         return false;
                     } else if (cell) {
                         var cm = cell.code_mirror;
                         var cursor = cm.getCursor();
                         cursor.line += 1;
                         cm.setCursor(cursor);
+                        return false;
                     }
                 }
             }

--- a/IPython/html/static/notebook/js/keyboardmanager.js
+++ b/IPython/html/static/notebook/js/keyboardmanager.js
@@ -108,6 +108,11 @@ var IPython = (function (IPython) {
                         IPython.notebook.select_prev();
                         IPython.notebook.edit_mode();
                         return false;
+                    } else if (cell) {
+                        var cm = cell.code_mirror
+                        var cursor = cm.getCursor()
+                        cursor.line -= 1
+                        cm.setCursor(cursor);
                     }
                 }
             }
@@ -125,6 +130,11 @@ var IPython = (function (IPython) {
                         IPython.notebook.select_next();
                         IPython.notebook.edit_mode();
                         return false;
+                    } else if (cell) {
+                        var cm = cell.code_mirror
+                        var cursor = cm.getCursor()
+                        cursor.line += 1
+                        cm.setCursor(cursor);
                     }
                 }
             }

--- a/IPython/html/static/notebook/js/keyboardmanager.js
+++ b/IPython/html/static/notebook/js/keyboardmanager.js
@@ -108,8 +108,7 @@ var IPython = (function (IPython) {
                         IPython.notebook.select_prev();
                         IPython.notebook.edit_mode();
                         var cm = IPython.notebook.get_selected_cell().code_mirror;
-                        var prev_cursor = cell.code_mirror.getCursor();
-                        cm.setCursor(cm.lastLine(), prev_cursor.ch)
+                        cm.setCursor(cm.lastLine(), 0);
                         return false;
                     } else if (cell) {
                         var cm = cell.code_mirror;
@@ -134,8 +133,7 @@ var IPython = (function (IPython) {
                         IPython.notebook.select_next();
                         IPython.notebook.edit_mode();
                         var cm = IPython.notebook.get_selected_cell().code_mirror;
-                        var prev_cursor = cell.code_mirror.getCursor();
-                        cm.setCursor(0, prev_cursor.ch);
+                        cm.setCursor(0, 0);
                         return false;
                     } else if (cell) {
                         var cm = cell.code_mirror;

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -113,57 +113,6 @@ var IPython = (function (IPython) {
         });
     };
 
-    /**
-     * This method gets called in CodeMirror's onKeyDown/onKeyPress
-     * handlers and is used to provide custom key handling.
-     *
-     * Subclass should override this method to have custom handling
-     *
-     * @method handle_codemirror_keyevent
-     * @param {CodeMirror} editor - The codemirror instance bound to the cell
-     * @param {event} event -
-     * @return {Boolean} `true` if CodeMirror should ignore the event, `false` Otherwise
-     */
-    TextCell.prototype.handle_codemirror_keyevent = function (editor, event) {
-        var that = this;
-
-        if (event.keyCode === 13 && (event.shiftKey || event.ctrlKey || event.altKey)) {
-            // Always ignore shift-enter in CodeMirror as we handle it.
-            return true;
-        } else if (event.which === keycodes.up && event.type === 'keydown') {
-            // If we are not at the top, let CM handle the up arrow and
-            // prevent the global keydown handler from handling it.
-            if (!that.at_top()) {
-                event.stop();
-                return false;
-            } else {
-                return true;
-            };
-        } else if (event.which === keycodes.down && event.type === 'keydown') {
-            // If we are not at the bottom, let CM handle the down arrow and
-            // prevent the global keydown handler from handling it.
-            if (!that.at_bottom()) {
-                event.stop();
-                return false;
-            } else {
-                return true;
-            };
-        } else if (event.which === keycodes.esc && event.type === 'keydown') {
-            if (that.code_mirror.options.keyMap === "vim-insert") {
-                // vim keyMap is active and in insert mode. In this case we leave vim
-                // insert mode, but remain in notebook edit mode.
-                // Let' CM handle this event and prevent global handling.
-                event.stop();
-                return false;
-            } else {
-                // vim keyMap is not active. Leave notebook edit mode.
-                // Don't let CM handle the event, defer to global handling.
-                return true;
-            }
-        }
-        return false;
-    };
-
     // Cell level actions
     
     TextCell.prototype.select = function () {

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -242,40 +242,6 @@ var IPython = (function (IPython) {
         this.element.find('div.text_cell_render').html(text);
     };
 
-    /**
-     * @method at_top
-     * @return {Boolean}
-     */
-    TextCell.prototype.at_top = function () {
-        if (this.rendered) {
-            return true;
-        } else {
-            var cursor = this.code_mirror.getCursor();
-            if (cursor.line === 0 && cm.findPosV(cm.getCursor(), -1, 'line',  cm.charCoords(cm.getCursor(),'div').left).hitSide) {
-                console.log('at top');
-                return true;
-            } else {
-                return false;
-            }
-        }
-    };
-
-    /**
-     * @method at_bottom
-     * @return {Boolean}
-     * */
-    TextCell.prototype.at_bottom = function () {
-        if (this.rendered) {
-            return true;
-        } else {
-            var cursor = this.code_mirror.getCursor();
-            if (cursor.line === (this.code_mirror.lineCount()-1) && cursor.ch === this.code_mirror.getLine(cursor.line).length) {
-                return true;
-            } else {
-                return false;
-            }
-        }
-    };
 
     /**
      * Create Text cell from JSON

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -251,7 +251,8 @@ var IPython = (function (IPython) {
             return true;
         } else {
             var cursor = this.code_mirror.getCursor();
-            if (cursor.line === 0 && cursor.ch === 0) {
+            if (cursor.line === 0 && cm.findPosV(cm.getCursor(), -1, 'line',  cm.charCoords(cm.getCursor(),'div').left).hitSide) {
+                console.log('at top');
                 return true;
             } else {
                 return false;

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -113,22 +113,11 @@ var IPython = (function (IPython) {
         });
     };
 
-    TextCell.prototype.handle_keyevent = function (editor, event) {
-
-        // console.log('CM', this.mode, event.which, event.type)
-
-        if (this.mode === 'command') {
-            return true;
-        } else if (this.mode === 'edit') {
-            return this.handle_codemirror_keyevent(editor, event);
-        }
-    };
-
     /**
      * This method gets called in CodeMirror's onKeyDown/onKeyPress
      * handlers and is used to provide custom key handling.
      *
-     * Subclass should override this method to have custom handeling
+     * Subclass should override this method to have custom handling
      *
      * @method handle_codemirror_keyevent
      * @param {CodeMirror} editor - The codemirror instance bound to the cell


### PR DESCRIPTION
Ok, this is in a state where it can use some review. I haven't yet verified that this provides everything one needs to integrate with CodeMirror's vim mode, but this makes the situation a lot better.

So to start with, the relevant code was repeated in both CodeCell and TextCell, both of which are extensions of Cell, so this just unifies the logic in Cell.

TextCell had logic here to check if the cell was rendered or not, but I don't believe it is possible to end up triggering such a code path.  (Should that be required, I can always just add back these methods to TextCell, performing the .rendered==True check, and calling the Cell)

Prior to this PR, code mirror at_top would only return true on if the cursor was at the first character of the top line. Now, pressing up arrow on any character on the top line will take you to the cell above.

The same applies for the bottom line. Pressing down arrow would only go to the next cell if the cursor was at a location _after_ the last character (something that is only possible to achieve in vim mode if the last line is empty, for example). Now, down arrow on any character of the last line will go to the next cell.

I've also added a use_shortcut method to ShortcutManager, which allows us to a remove a bunch of special-casing of key events like up and down arrow, escape, shift/ctrl/alt-enter. 

For example, this PR makes it possible to remove our special-casing of up arrow at the top of the cell, preventing it from going to the cell above. This can be done via this javascript:

```
IPython.keyboard_manager.edit_shortcuts.remove_shortcut('up')
```

Previously, the up arrow functionality at the top of a cell was welded into the code base as an if statement.
