### PR TITLE
Fix NameError: name '_rl' is not defined

### DIFF
--- a/IPython/utils/rlineimpl.py
+++ b/IPython/utils/rlineimpl.py
@@ -27,7 +27,7 @@ for _rlmod_name in _rlmod_names:
         have_readline = True
         break
 
-if sys.platform == 'win32' or sys.platform == 'cli':
+if have_readline and (sys.platform == 'win32' or sys.platform == 'cli'):
     try:
         _outputfile=_rl.GetOutputFile()
     except AttributeError:


### PR DESCRIPTION
Ipython-2.0.0-b1 notebook on Windows without the pyreadline package fails with:

```
X:\Python34\lib\site-packages\IPython\utils\rlineimpl.py in <module>()
     30 if sys.platform == 'win32' or sys.platform == 'cli':
     31     try:
---> 32         _outputfile=_rl.GetOutputFile()
        global _outputfile = undefined
        global _rl.GetOutputFile = undefined
     33     except AttributeError:
     34         warnings.warn("Failed GetOutputFile")

NameError: name '_rl' is not defined
```
