### PR TITLE
Add dict key completion in IPCompleter

### DIFF
--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -584,21 +584,6 @@ def test_dict_key_completion_unicode_py3():
     nt.assert_in(unicode_type(b"a\xd7\x90']", 'utf8'), matches)
 
 
-def test_dict_like_key_completion():
-    """Test dict key completion applies where __getitem__ and keys exist"""
-    class D(object):
-        def __getitem__(self):
-            pass
-        def keys(self):
-            return iter(['hello', 'world'])
-    ip = get_ipython()
-    complete = ip.Completer.complete
-    ip.user_ns['d'] = D()
-    _, matches = complete(line_buffer="d['")
-    nt.assert_in("hello']", matches)
-    nt.assert_in("world']", matches)
-
-
 @dec.skip_without('numpy')
 def test_struct_array_key_completion():
     """Test dict key completion applies to numpy struct arrays"""

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -539,7 +539,7 @@ def test_dict_key_completion_unicode_py2():
     ip = get_ipython()
     complete = ip.Completer.complete
 
-    ip.user_ns['d'] = {unicode_type('abc'): None,
+    ip.user_ns['d'] = {u'abc': None,
                        unicode_type('a\xd7\x90', 'utf8'): None}
 
     _, matches = complete(line_buffer="d[")

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -20,6 +20,7 @@ from IPython.utils.tempdir import TemporaryDirectory
 from IPython.utils.generics import complete_object
 from IPython.utils import py3compat
 from IPython.utils.py3compat import string_types, unicode_type
+from IPython.testing import decorators as dec
 
 #-----------------------------------------------------------------------------
 # Test functions
@@ -392,3 +393,206 @@ def test_magic_completion_order():
     text, matches = c.complete('timeit')
     nt.assert_equal(matches, ["timeit", "%timeit","%%timeit"])
 
+
+
+def test_dict_key_completion_string():
+    """Test dictionary key completion for string keys"""
+    ip = get_ipython()
+    complete = ip.Completer.complete
+
+    ip.user_ns['d'] = {'abc': None}
+
+    # check completion at different stages
+    _, matches = complete(line_buffer="d[")
+    nt.assert_in("'abc']", matches)
+
+    _, matches = complete(line_buffer="d['")
+    nt.assert_in("abc']", matches)
+
+    _, matches = complete(line_buffer="d['a")
+    nt.assert_in("abc']", matches)
+
+    # check use of different quoting
+    _, matches = complete(line_buffer="d[\"")
+    nt.assert_in("abc\"]", matches)
+
+    _, matches = complete(line_buffer="d[\"a")
+    nt.assert_in("abc\"]", matches)
+
+    # check sensitivity to following context
+    _, matches = complete(line_buffer="d[]", cursor_pos=2)
+    nt.assert_in("'abc'", matches)
+
+    _, matches = complete(line_buffer="d['']", cursor_pos=3)
+    nt.assert_in("abc", matches)
+
+    # check multiple solutions are correctly returned and that noise is not
+    ip.user_ns['d'] = {'abc': None, 'abd': None, 'bad': None, object(): None,
+                       5: None}
+
+    _, matches = complete(line_buffer="d['a")
+    nt.assert_in("abc']", matches)
+    nt.assert_in("abd']", matches)
+    nt.assert_not_in("bad']", matches)
+
+    # check escaping and whitespace
+    ip.user_ns['d'] = {'a\nb': None, 'a\'b': None, 'a"b': None, 'a word': None}
+    _, matches = complete(line_buffer="d['a")
+    nt.assert_in("a\\nb']", matches)
+    nt.assert_in("a\\'b']", matches)
+    nt.assert_in("a\"b']", matches)
+    nt.assert_in("a word']", matches)
+
+    # - can complete on non-initial word of the string
+    _, matches = complete(line_buffer="d['a w")
+    nt.assert_in("word']", matches)
+
+    # - understands quote escaping
+    _, matches = complete(line_buffer="d['a\\'")
+    nt.assert_in("b']", matches)
+
+    # - default quoting should work like repr
+    _, matches = complete(line_buffer="d[")
+    nt.assert_in("\"a'b\"]", matches)
+
+    # - when opening quote with ", possible to match with unescaped apostrophe
+    _, matches = complete(line_buffer="d[\"a'")
+    nt.assert_in("b\"]", matches)
+
+
+def test_dict_key_completion_contexts():
+    """Test expression contexts in which dict key completion occurs"""
+    ip = get_ipython()
+    complete = ip.Completer.complete
+    d = {'abc': None}
+    ip.user_ns['d'] = d
+
+    class C:
+        data = d
+    ip.user_ns['C'] = C
+    ip.user_ns['get'] = lambda: d
+
+    def assert_no_completion(**kwargs):
+        _, matches = complete(**kwargs)
+        nt.assert_not_in('abc', matches)
+        nt.assert_not_in('abc\'', matches)
+        nt.assert_not_in('abc\']', matches)
+        nt.assert_not_in('\'abc\'', matches)
+        nt.assert_not_in('\'abc\']', matches)
+
+    def assert_completion(**kwargs):
+        _, matches = complete(**kwargs)
+        nt.assert_in("'abc']", matches)
+
+    # no completion after string closed, even if reopened
+    ip.Completer.greedy = False
+    assert_no_completion(line_buffer="d['a'")
+    assert_no_completion(line_buffer="d[\"a\"")
+    assert_no_completion(line_buffer="d['a' + ")
+    assert_no_completion(line_buffer="d['a' + '")
+
+    # completion in non-trivial expressions
+    assert_completion(line_buffer="+ d[")
+    assert_completion(line_buffer="(d[")
+    assert_completion(line_buffer="C.data[")
+
+    # greedy flag
+    assert_no_completion(line_buffer="get()[")
+    ip.Completer.greedy = True
+    assert_completion(line_buffer="get()[")
+
+
+
+@dec.onlyif(sys.version_info[0] >= 3, 'This test only applies in Py>=3')
+def test_dict_key_completion_bytes():
+    """Test handling of bytes in dict key completion"""
+    ip = get_ipython()
+    complete = ip.Completer.complete
+
+    ip.user_ns['d'] = {'abc': None, b'abd': None}
+
+    _, matches = complete(line_buffer="d[")
+    nt.assert_in("'abc']", matches)
+    nt.assert_in("b'abd']", matches)
+
+    if False:  # not currently implemented
+        _, matches = complete(line_buffer="d[b")
+        nt.assert_in("b'abd']", matches)
+        nt.assert_not_in("b'abc']", matches)
+
+        _, matches = complete(line_buffer="d[b'")
+        nt.assert_in("abd']", matches)
+        nt.assert_not_in("abc']", matches)
+
+        _, matches = complete(line_buffer="d[B'")
+        nt.assert_in("abd']", matches)
+        nt.assert_not_in("abc']", matches)
+
+        _, matches = complete(line_buffer="d['")
+        nt.assert_in("abc']", matches)
+        nt.assert_not_in("abd']", matches)
+
+
+@dec.onlyif(sys.version_info[0] < 3, 'This test only applies in Py<3')
+def test_dict_key_completion_unicode():
+    """Test handling of unicode in dict key completion"""
+    ip = get_ipython()
+    complete = ip.Completer.complete
+
+    ip.user_ns['d'] = {unicode_type('abc'): None,
+                       unicode_type('a\xd7\x90', 'utf8'): None}
+
+    _, matches = complete(line_buffer="d[")
+    nt.assert_in("u'abc']", matches)
+    nt.assert_in("u'a\\u05d0']", matches)
+
+    _, matches = complete(line_buffer="d['a")
+    nt.assert_in("abc']", matches)
+    nt.assert_not_in("a\\u05d0']", matches)
+
+    _, matches = complete(line_buffer="d[u'a")
+    nt.assert_in("abc']", matches)
+    nt.assert_in("a\\u05d0']", matches)
+
+    _, matches = complete(line_buffer="d[U'a")
+    nt.assert_in("abc']", matches)
+    nt.assert_in("a\\u05d0']", matches)
+
+
+def test_dict_like_key_completion():
+    """Test dict key completion applies where __getitem__ and keys exist"""
+    class D(object):
+        def __getitem__(self):
+            pass
+        def keys(self):
+            return iter(['hello', 'world'])
+    ip = get_ipython()
+    complete = ip.Completer.complete
+    ip.user_ns['d'] = D()
+    _, matches = complete(line_buffer="d['")
+    nt.assert_in("hello']", matches)
+    nt.assert_in("world']", matches)
+
+
+@dec.skip_without('numpy')
+def test_struct_array_key_completion():
+    """Test dict key completion applies to numpy struct arrays"""
+    import numpy
+    ip = get_ipython()
+    complete = ip.Completer.complete
+    ip.user_ns['d'] = numpy.array([], dtype=[('hello', 'f'), ('world', 'f')])
+    _, matches = complete(line_buffer="d['")
+    nt.assert_in("hello']", matches)
+    nt.assert_in("world']", matches)
+
+
+@dec.skip_without('pandas')
+def test_dataframe_key_completion():
+    """Test dict key completion applies to pandas DataFrames"""
+    import pandas
+    ip = get_ipython()
+    complete = ip.Completer.complete
+    ip.user_ns['d'] = pandas.DataFrame({'hello': [1], 'world': [2]})
+    _, matches = complete(line_buffer="d['")
+    nt.assert_in("hello']", matches)
+    nt.assert_in("world']", matches)


### PR DESCRIPTION
As requested at #1533 and later.

This patch should complete string/unicode keys and their quotation in dicts, numpy struct arrays, pandas DataFrames, Tokyo Cabinets, etc.
