### PR TITLE
fix HTML capitalization in Highlight2HTML

### DIFF
--- a/IPython/nbconvert/exporters/templateexporter.py
+++ b/IPython/nbconvert/exporters/templateexporter.py
@@ -44,7 +44,7 @@ default_filters = {
         'ansi2html': filters.ansi2html,
         'filter_data_type': filters.DataTypeFilter,
         'get_lines': filters.get_lines,
-        'highlight2html': filters.Highlight2Html,
+        'highlight2html': filters.Highlight2HTML,
         'highlight2latex': filters.Highlight2Latex,
         'ipython2python': filters.ipython2python,
         'posix_path': filters.posix_path,

--- a/IPython/nbconvert/filters/highlight.py
+++ b/IPython/nbconvert/filters/highlight.py
@@ -32,12 +32,12 @@ MULTILINE_OUTPUTS = ['text', 'html', 'svg', 'latex', 'javascript', 'json']
 #-----------------------------------------------------------------------------
 
 __all__ = [
-    'Highlight2Html',
+    'Highlight2HTML',
     'Highlight2Latex'
 ]
 
 
-class Highlight2Html(NbConvertBase):
+class Highlight2HTML(NbConvertBase):
 
     def __call__(self, source, language=None, metadata=None):
         """

--- a/IPython/nbconvert/filters/tests/test_highlight.py
+++ b/IPython/nbconvert/filters/tests/test_highlight.py
@@ -15,7 +15,7 @@ Module with tests for Highlight
 #-----------------------------------------------------------------------------
 
 from ...tests.base import TestsBase
-from ..highlight import Highlight2Html, Highlight2Latex
+from ..highlight import Highlight2HTML, Highlight2Latex
 from IPython.config import Config
 import xml
 
@@ -23,11 +23,11 @@ import xml
 # Class
 #-----------------------------------------------------------------------------
 
-highlight2html = Highlight2Html()
+highlight2html = Highlight2HTML()
 highlight2latex = Highlight2Latex()
 c = Config()
-c.Highlight2Html.default_language='ruby'
-highlight2html_ruby = Highlight2Html(config=c)
+c.Highlight2HTML.default_language='ruby'
+highlight2html_ruby = Highlight2HTML(config=c)
 
 class TestHighlight(TestsBase):
     """Contains test functions for highlight.py"""


### PR DESCRIPTION
To be consistent with surrounding code, where we always capitalize acronyms that appear in class names.
