### PR TITLE
remove raw cell placeholder on focus, closes #5238

### DIFF
--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -389,6 +389,7 @@ var IPython = (function (IPython) {
         var that = this;
         this.element.focusout(function() {
             that.auto_highlight();
+            that.render();
         });
 
         this.code_mirror.on('focus', function() { that.unrender(); });
@@ -409,6 +410,7 @@ var IPython = (function (IPython) {
             var text = this.get_text();
             if (text === "") { text = this.placeholder; }
             this.set_text(text);
+            this.element.removeClass('rendered');
         }
         return cont;
     };

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -390,6 +390,8 @@ var IPython = (function (IPython) {
         this.element.focusout(function() {
             that.auto_highlight();
         });
+
+        this.code_mirror.on('focus', function() { that.unrender(); });
     };
 
     /**
@@ -402,13 +404,13 @@ var IPython = (function (IPython) {
 
     /** @method render **/
     RawCell.prototype.render = function () {
-        // Make sure that this cell type can never be rendered
-        if (this.rendered) {
-            this.unrender();
+        var cont = IPython.TextCell.prototype.render.apply(this);
+        if (cont){
+            var text = this.get_text();
+            if (text === "") { text = this.placeholder; }
+            this.set_text(text);
         }
-        var text = this.get_text();
-        if (text === "") { text = this.placeholder; }
-        this.set_text(text);
+        return cont;
     };
 
 

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -376,8 +376,8 @@ var IPython = (function (IPython) {
     };
 
     RawCell.options_default = {
-        placeholder : "Write raw LaTeX or other formats here, for use with nbconvert.\n" +
-            "It will not be rendered in the notebook.\n" + 
+        placeholder : "Write raw LaTeX or other formats here, for use with nbconvert. " +
+            "It will not be rendered in the notebook. " + 
             "When passing through nbconvert, a Raw Cell's content is added to the output unmodified."
     };
 


### PR DESCRIPTION
Unlike markdown cells, when Raw text cells are "rendered", the codemirror instance is still visible. This PR makes it so that when the CodeMirror instance is focused (which you can do with a click selection), that will trigger an unrender event.
