### PR TITLE
fix raw_input CSS

### DIFF
--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -660,14 +660,14 @@ var IPython = (function (IPython) {
         var area = this.create_output_area();
         
         // disable any other raw_inputs, if they are left around
-        $("div.output_subarea.raw_input").remove();
+        $("div.output_subarea.raw_input_container").remove();
         
         area.append(
             $("<div/>")
-            .addClass("box-flex1 output_subarea raw_input")
+            .addClass("box-flex1 output_subarea raw_input_container")
             .append(
                 $("<span/>")
-                .addClass("input_prompt")
+                .addClass("raw_input_prompt")
                 .text(content.prompt)
             )
             .append(
@@ -698,8 +698,8 @@ var IPython = (function (IPython) {
     }
 
     OutputArea.prototype._submit_raw_input = function (evt) {
-        var container = this.element.find("div.raw_input");
-        var theprompt = container.find("span.input_prompt");
+        var container = this.element.find("div.raw_input_container");
+        var theprompt = container.find("span.raw_input_prompt");
         var theinput = container.find("input.raw_input");
         var value = theinput.val();
         var content = {

--- a/IPython/html/static/notebook/less/outputarea.less
+++ b/IPython/html/static/notebook/less/outputarea.less
@@ -139,16 +139,15 @@ div.output_javascript:empty {
 
 /* raw_input styles */
 
-div.raw_input {
-    line-height: 1em;
+div.raw_input_container {
     font-family: @monoFontFamily;
     // for some reason, em padding doesn't compute the same for raw_input
     // that is not the first input, but px does
     padding-top: 5px;
 }
 
-span.input_prompt {
-    font-family: inherit;
+span.raw_input_prompt {
+    /* nothing needed here */
 }
 
 input.raw_input {
@@ -156,10 +155,11 @@ input.raw_input {
     font-size: inherit;
     color: inherit;
     width: auto;
-    margin: 0px 0px 0px 1px;
-    padding-left: 1px;
-    padding-top: 0px;
-    height: 1em;
+    /* make sure input baseline aligns with prompt */
+    vertical-align: baseline;
+    /* padding + margin = 0.5em between prompt and cursor */
+    padding: 0em 0.25em;
+    margin: 0em 0.25em;
 }
 
 input.raw_input:focus {

--- a/IPython/html/static/notebook/less/outputarea.less
+++ b/IPython/html/static/notebook/less/outputarea.less
@@ -140,11 +140,11 @@ div.output_javascript:empty {
 /* raw_input styles */
 
 div.raw_input {
-    padding-top: 0px;
-    padding-bottom: 0px;
-    height: 1em;
     line-height: 1em;
     font-family: @monoFontFamily;
+    // for some reason, em padding doesn't compute the same for raw_input
+    // that is not the first input, but px does
+    padding-top: 5px;
 }
 
 span.input_prompt {
@@ -156,10 +156,14 @@ input.raw_input {
     font-size: inherit;
     color: inherit;
     width: auto;
-    margin: -2px 0px 0px 1px;
+    margin: 0px 0px 0px 1px;
     padding-left: 1px;
-    padding-top: 2px;
+    padding-top: 0px;
     height: 1em;
+}
+
+input.raw_input:focus {
+    box-shadow: none;
 }
 
 p.p-space {

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -123,9 +123,9 @@ div.output_stderr{background:#fdd;}
 div.output_latex{text-align:left}
 div.output_javascript:empty{padding:0}
 .js-error{color:#8b0000}
-div.raw_input{line-height:1em;font-family:monospace;padding-top:5px}
-span.input_prompt{font-family:inherit}
-input.raw_input{font-family:inherit;font-size:inherit;color:inherit;width:auto;margin:0 0 0 1px;padding-left:1px;padding-top:0;height:1em}
+div.raw_input_container{font-family:monospace;padding-top:5px}
+span.raw_input_prompt{}
+input.raw_input{font-family:inherit;font-size:inherit;color:inherit;width:auto;vertical-align:baseline;padding:0 .25em;margin:0 .25em}
 input.raw_input:focus{box-shadow:none}
 p.p-space{margin-bottom:10px}
 .rendered_html{color:#000;}.rendered_html em{font-style:italic}

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -123,9 +123,10 @@ div.output_stderr{background:#fdd;}
 div.output_latex{text-align:left}
 div.output_javascript:empty{padding:0}
 .js-error{color:#8b0000}
-div.raw_input{padding-top:0;padding-bottom:0;height:1em;line-height:1em;font-family:monospace}
+div.raw_input{line-height:1em;font-family:monospace;padding-top:5px}
 span.input_prompt{font-family:inherit}
-input.raw_input{font-family:inherit;font-size:inherit;color:inherit;width:auto;margin:-2px 0 0 1px;padding-left:1px;padding-top:2px;height:1em}
+input.raw_input{font-family:inherit;font-size:inherit;color:inherit;width:auto;margin:0 0 0 1px;padding-left:1px;padding-top:0;height:1em}
+input.raw_input:focus{box-shadow:none}
 p.p-space{margin-bottom:10px}
 .rendered_html{color:#000;}.rendered_html em{font-style:italic}
 .rendered_html strong{font-weight:bold}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1400,9 +1400,10 @@ div.output_stderr{background:#fdd;}
 div.output_latex{text-align:left}
 div.output_javascript:empty{padding:0}
 .js-error{color:#8b0000}
-div.raw_input{padding-top:0;padding-bottom:0;height:1em;line-height:1em;font-family:monospace}
+div.raw_input{line-height:1em;font-family:monospace;padding-top:5px}
 span.input_prompt{font-family:inherit}
-input.raw_input{font-family:inherit;font-size:inherit;color:inherit;width:auto;margin:-2px 0 0 1px;padding-left:1px;padding-top:2px;height:1em}
+input.raw_input{font-family:inherit;font-size:inherit;color:inherit;width:auto;margin:0 0 0 1px;padding-left:1px;padding-top:0;height:1em}
+input.raw_input:focus{box-shadow:none}
 p.p-space{margin-bottom:10px}
 .rendered_html{color:#000;}.rendered_html em{font-style:italic}
 .rendered_html strong{font-weight:bold}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1400,9 +1400,9 @@ div.output_stderr{background:#fdd;}
 div.output_latex{text-align:left}
 div.output_javascript:empty{padding:0}
 .js-error{color:#8b0000}
-div.raw_input{line-height:1em;font-family:monospace;padding-top:5px}
-span.input_prompt{font-family:inherit}
-input.raw_input{font-family:inherit;font-size:inherit;color:inherit;width:auto;margin:0 0 0 1px;padding-left:1px;padding-top:0;height:1em}
+div.raw_input_container{font-family:monospace;padding-top:5px}
+span.raw_input_prompt{}
+input.raw_input{font-family:inherit;font-size:inherit;color:inherit;width:auto;vertical-align:baseline;padding:0 .25em;margin:0 .25em}
 input.raw_input:focus{box-shadow:none}
 p.p-space{margin-bottom:10px}
 .rendered_html{color:#000;}.rendered_html em{font-style:italic}


### PR DESCRIPTION
I had to express padding in px, not em for consistent appearance. I'm not sure why.

closes #5324
before:
![screen shot 2014-03-10 at 3 16 05 pm](https://f.cloud.github.com/assets/27600/2379924/ab94f1f8-a8a1-11e3-8e79-cff91832fb61.png)

after:
![screen shot 2014-03-11 at 16 08 31](https://f.cloud.github.com/assets/151929/2392050/1e00318c-a972-11e3-8e3c-9f67954f258a.PNG)
