### PR TITLE
semantic names for indicator icons

### DIFF
--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -2048,6 +2048,7 @@ var IPython = (function (IPython) {
         } else {
             this.select(0);
             this.handle_command_mode(this.get_cell(0));
+            $([IPython.events]).trigger('command_mode.Notebook');
         }
         this.set_dirty(false);
         this.scroll_to_top();

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -2048,7 +2048,6 @@ var IPython = (function (IPython) {
         } else {
             this.select(0);
             this.handle_command_mode(this.get_cell(0));
-            $([IPython.events]).trigger('command_mode.Notebook');
         }
         this.set_dirty(false);
         this.scroll_to_top();

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -75,12 +75,12 @@ var IPython = (function (IPython) {
         // Command/Edit mode
         $([IPython.events]).on('edit_mode.Notebook',function () {
             IPython.save_widget.update_document_title();
-            $modal_ind_icon.attr('class','icon-pencil').attr('title','Edit Mode');
+            $modal_ind_icon.attr('class','ipython-edit-mode').attr('title','Edit Mode');
         });
 
         $([IPython.events]).on('command_mode.Notebook',function () {
             IPython.save_widget.update_document_title();
-            $modal_ind_icon.attr('class','').attr('title','Command Mode');
+            $modal_ind_icon.attr('class','ipython-command-mode').attr('title','Command Mode');
         });
 
         // Kernel events

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -44,21 +44,21 @@ var IPython = (function (IPython) {
     };
 
     NotificationArea.prototype.widget = function(name) {
-        if(this.widget_dict[name] == undefined) {
+        if(this.widget_dict[name] === undefined) {
             return this.new_notification_widget(name);
         }
         return this.get_widget(name);
     };
 
     NotificationArea.prototype.get_widget = function(name) {
-        if(this.widget_dict[name] == undefined) {
+        if(this.widget_dict[name] === undefined) {
             throw('no widgets with this name');
         }
         return this.widget_dict[name];
     };
 
     NotificationArea.prototype.new_notification_widget = function(name) {
-        if(this.widget_dict[name] != undefined) {
+        if(this.widget_dict[name] !== undefined) {
             throw('widget with that name already exists ! ');
         }
         var div = $('<div/>').attr('id','notification_'+name);
@@ -75,26 +75,26 @@ var IPython = (function (IPython) {
         // Command/Edit mode
         $([IPython.events]).on('edit_mode.Notebook',function () {
             IPython.save_widget.update_document_title();
-            $modal_ind_icon.attr('class','ipython-edit-mode').attr('title','Edit Mode');
+            $modal_ind_icon.attr('class','edit_mode_icon').attr('title','Edit Mode');
         });
 
         $([IPython.events]).on('command_mode.Notebook',function () {
             IPython.save_widget.update_document_title();
-            $modal_ind_icon.attr('class','ipython-command-mode').attr('title','Command Mode');
+            $modal_ind_icon.attr('class','command_mode_icon').attr('title','Command Mode');
         });
 
         // Implicitly start off in Command mode, switching to Edit mode will trigger event
-        $modal_ind_icon.attr('class','ipython-command-mode').attr('title','Command Mode');
+        $modal_ind_icon.attr('class','command-mode_icon').attr('title','Command Mode');
 
         // Kernel events
         $([IPython.events]).on('status_idle.Kernel',function () {
             IPython.save_widget.update_document_title();
-            $kernel_ind_icon.attr('class','ipython-kernel-idle').attr('title','Kernel Idle');
+            $kernel_ind_icon.attr('class','kernel_idle_icon').attr('title','Kernel Idle');
         });
 
         $([IPython.events]).on('status_busy.Kernel',function () {
             window.document.title='(Busy) '+window.document.title;
-            $kernel_ind_icon.attr('class','ipython-kernel-busy').attr('title','Kernel Busy');
+            $kernel_ind_icon.attr('class','kernel_busy_icon').attr('title','Kernel Busy');
         });
 
         $([IPython.events]).on('status_restarting.Kernel',function () {
@@ -108,7 +108,7 @@ var IPython = (function (IPython) {
         
         // Start the kernel indicator in the busy state, and send a kernel_info request.
         // When the kernel_info reply arrives, the kernel is idle.
-        $kernel_ind_icon.attr('class','ipython-kernel-busy').attr('title','Kernel Busy');
+        $kernel_ind_icon.attr('class','kernel_busy_icon').attr('title','Kernel Busy');
 
         $([IPython.events]).on('status_started.Kernel', function (evt, data) {
             data.kernel.kernel_info(function () {
@@ -151,7 +151,7 @@ var IPython = (function (IPython) {
                     }, 5000);
                 return;
             }
-            console.log('WebSocket connection failed: ', ws_url)
+            console.log('WebSocket connection failed: ', ws_url);
             msg = "A WebSocket connection could not be established." +
                 " You will NOT be able to run code. Check your" +
                 " network connection or notebook server configuration.";

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -86,12 +86,12 @@ var IPython = (function (IPython) {
         // Kernel events
         $([IPython.events]).on('status_idle.Kernel',function () {
             IPython.save_widget.update_document_title();
-            $kernel_ind_icon.attr('class','icon-circle-blank').attr('title','Kernel Idle');
+            $kernel_ind_icon.attr('class','ipython-kernel-idle').attr('title','Kernel Idle');
         });
 
         $([IPython.events]).on('status_busy.Kernel',function () {
             window.document.title='(Busy) '+window.document.title;
-            $kernel_ind_icon.attr('class','icon-circle').attr('title','Kernel Busy');
+            $kernel_ind_icon.attr('class','ipython-kernel-busy').attr('title','Kernel Busy');
         });
 
         $([IPython.events]).on('status_restarting.Kernel',function () {

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -83,6 +83,9 @@ var IPython = (function (IPython) {
             $modal_ind_icon.attr('class','ipython-command-mode').attr('title','Command Mode');
         });
 
+        // Implicitly start off in Command mode, switching to Edit mode will trigger event
+        $modal_ind_icon.attr('class','ipython-command-mode').attr('title','Command Mode');
+
         // Kernel events
         $([IPython.events]).on('status_idle.Kernel',function () {
             IPython.save_widget.update_document_title();
@@ -105,7 +108,7 @@ var IPython = (function (IPython) {
         
         // Start the kernel indicator in the busy state, and send a kernel_info request.
         // When the kernel_info reply arrives, the kernel is idle.
-        $kernel_ind_icon.attr('class','icon-circle').attr('title','Kernel Busy');
+        $kernel_ind_icon.attr('class','ipython-kernel-busy').attr('title','Kernel Busy');
 
         $([IPython.events]).on('status_started.Kernel', function (evt, data) {
             data.kernel.kernel_info(function () {

--- a/IPython/html/static/notebook/less/notificationarea.less
+++ b/IPython/html/static/notebook/less/notificationarea.less
@@ -16,3 +16,11 @@
     margin-right: -16px;
 }
 
+.ipython-edit-mode:before {
+     .icon(@pencil);
+}
+
+.ipython-command-mode:before {
+     .icon(' ');
+}
+

--- a/IPython/html/static/notebook/less/notificationarea.less
+++ b/IPython/html/static/notebook/less/notificationarea.less
@@ -16,19 +16,19 @@
     margin-right: -16px;
 }
 
-.ipython-edit-mode:before {
+.edit_mode_icon:before {
      .icon(@pencil);
 }
 
-.ipython-command-mode:before {
+.command_mode_icon:before {
      .icon(' ');
 }
 
-.ipython-kernel-idle:before {
+.kernel_idle_icon:before {
      .icon(@circle-blank);
 }
 
-.ipython-kernel-busy:before {
+.kernel_busy_icon:before {
      .icon(@circle);
 }
 

--- a/IPython/html/static/notebook/less/notificationarea.less
+++ b/IPython/html/static/notebook/less/notificationarea.less
@@ -24,3 +24,12 @@
      .icon(' ');
 }
 
+.ipython-kernel-idle:before {
+     .icon(@circle-blank);
+}
+
+.ipython-kernel-busy:before {
+     .icon(@circle);
+}
+
+

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1506,6 +1506,8 @@ ul#help_menu li a{overflow:hidden;padding-right:2.2em}ul#help_menu li a i{margin
 #notification_area{z-index:10}
 .indicator_area{color:#777;padding:4px 3px;margin:0;width:11px;z-index:10;text-align:center}
 #kernel_indicator{margin-right:-16px}
+.ipython-edit-mode:before{font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;*margin-right:.3em;content:"\f040"}
+.ipython-command-mode:before{font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;*margin-right:.3em;content:' '}
 .notification_widget{color:#777;padding:1px 12px;margin:2px 4px;z-index:10;border:1px solid #ccc;border-radius:4px;background:rgba(240,240,240,0.5)}.notification_widget.span{padding-right:2px}
 div#pager_splitter{height:8px}
 #pager-container{position:relative;padding:15px 0}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1506,10 +1506,10 @@ ul#help_menu li a{overflow:hidden;padding-right:2.2em}ul#help_menu li a i{margin
 #notification_area{z-index:10}
 .indicator_area{color:#777;padding:4px 3px;margin:0;width:11px;z-index:10;text-align:center}
 #kernel_indicator{margin-right:-16px}
-.ipython-edit-mode:before{font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;*margin-right:.3em;content:"\f040"}
-.ipython-command-mode:before{font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;*margin-right:.3em;content:' '}
-.ipython-kernel-idle:before{font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;*margin-right:.3em;content:"\f10c"}
-.ipython-kernel-busy:before{font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;*margin-right:.3em;content:"\f111"}
+.edit_mode_icon:before{font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;*margin-right:.3em;content:"\f040"}
+.command_mode_icon:before{font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;*margin-right:.3em;content:' '}
+.kernel_idle_icon:before{font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;*margin-right:.3em;content:"\f10c"}
+.kernel_busy_icon:before{font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;*margin-right:.3em;content:"\f111"}
 .notification_widget{color:#777;padding:1px 12px;margin:2px 4px;z-index:10;border:1px solid #ccc;border-radius:4px;background:rgba(240,240,240,0.5)}.notification_widget.span{padding-right:2px}
 div#pager_splitter{height:8px}
 #pager-container{position:relative;padding:15px 0}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1508,6 +1508,8 @@ ul#help_menu li a{overflow:hidden;padding-right:2.2em}ul#help_menu li a i{margin
 #kernel_indicator{margin-right:-16px}
 .ipython-edit-mode:before{font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;*margin-right:.3em;content:"\f040"}
 .ipython-command-mode:before{font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;*margin-right:.3em;content:' '}
+.ipython-kernel-idle:before{font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;*margin-right:.3em;content:"\f10c"}
+.ipython-kernel-busy:before{font-family:FontAwesome;font-weight:normal;font-style:normal;text-decoration:inherit;-webkit-font-smoothing:antialiased;*margin-right:.3em;content:"\f111"}
 .notification_widget{color:#777;padding:1px 12px;margin:2px 4px;z-index:10;border:1px solid #ccc;border-radius:4px;background:rgba(240,240,240,0.5)}.notification_widget.span{padding-right:2px}
 div#pager_splitter{height:8px}
 #pager-container{position:relative;padding:15px 0}


### PR DESCRIPTION
For all of the discussion that we had about what kind of icons should and
should not be used to indicate what mode the notebook is in, we never went
through to make it possible to override it.

With this change, it is now possible to override what icons are displayed for
Command and Edit Modes.

For example, @minrk liked the fighter-jet icon for Command Mode, so he can put
this in his custom.css

``` css
.command_mode_icon:before {
    content: "\f0fb";
}
```

You can find other icons here: http://fortawesome.github.io/Font-Awesome/3.2.1/icons/ - just click through to an icon and use its unicode representation with a leading slash. For example, in the example above, I've made the [fighter jet icon](http://fortawesome.github.io/Font-Awesome/3.2.1/icon/fighter-jet/) - find the F0FB text on that page to see where to find the unicode representation for other icons.
