### PR TITLE
Fix filenbmanager.list_dirs fails for Windows user profile directory

### DIFF
--- a/IPython/html/utils.py
+++ b/IPython/html/utils.py
@@ -101,11 +101,21 @@ def is_hidden(abs_path, abs_root=''):
     inside_root = abs_path[len(abs_root):]
     if any(part.startswith('.') for part in inside_root.split(os.sep)):
         return True
+
+    # check that path can be listed
+    try:
+        os.listdir(abs_path)
+    except Exception:
+        return True
     
     # check UF_HIDDEN on any location up to root
     path = abs_path
     while path and path.startswith(abs_root) and path != abs_root:
-        st = os.stat(path)
+        try:
+            # may fail on Windows junctions
+            st = os.stat(path)
+        except Exception:
+            return True
         if getattr(st, 'st_flags', 0) & UF_HIDDEN:
             return True
         path = os.path.dirname(path)


### PR DESCRIPTION
Using ipython‑2.0.0‑b1, pyzmq-14.1.0, and tornado‑3.2 on win‑amd64‑py3.4rc3, Windows 8.1, I get `FileNotFoundError` and `PermissionError` (below) when starting ipython notebook from within the user profile directory.

On Windows >XP, the users profile directories contain hidden junctions such as `NetHood` or `My Documents` for backwards compatibility. Calling `os.stat` and `os.listdir` on these junctions may fail with various Exceptions.

The patch fixes these exceptions for me on win‑amd64‑py3.4 (not tested on other platforms).

```
2014-03-11 22:54:58.751 [NotebookApp] Using existing profile dir: 'C:\\Users\\gohlke\\.ipython\\profile_default'
2014-03-11 22:54:58.751 [NotebookApp] Using MathJax from CDN: http://cdn.mathjax.org/mathjax/latest/MathJax.js
2014-03-11 22:54:58.782 [NotebookApp] Serving notebooks from local directory: C:\Users\gohlke
2014-03-11 22:54:58.782 [NotebookApp] 0 active kernels
2014-03-11 22:54:58.782 [NotebookApp] The IPython Notebook is running at: http://127.0.0.1:8888/
2014-03-11 22:54:58.798 [NotebookApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
2014-03-11 22:54:59.085 [NotebookApp] ERROR | Unhandled error in API request
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\IPython\html\base\handlers.py", line 286, in wrapper
    result = method(self, *args, **kwargs)
  File "X:\Python34\lib\site-packages\IPython\html\services\notebooks\handlers.py", line 75, in get
    dirs = nbm.list_dirs(path)
  File "X:\Python34\lib\site-packages\IPython\html\services\notebooks\filenbmanager.py", line 192, in list_dirs
    if os.path.isdir(os_path) and not is_hidden(os_path, self.notebook_dir)\
  File "X:\Python34\lib\site-packages\IPython\html\utils.py", line 108, in is_hidden
    st = os.stat(path)
FileNotFoundError: [WinError 2] The system cannot find the file specified: 'C:\\Users\\gohlke\\NetHood'
ERROR:tornado.access:{
  "Connection": "Keep-Alive",
  "Accept-Language": "en-US",
  "X-Requested-With": "XMLHttpRequest",
  "User-Agent": "Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko",
  "Accept": "application/json, text/javascript, */*; q=0.01",
  "Dnt": "1",
  "Referer": "http://127.0.0.1:8888/tree",
  "Host": "127.0.0.1:8888",
  "Accept-Encoding": "gzip, deflate"
}
ERROR:tornado.access:500 GET /api/notebooks?_=1394603699023 (127.0.0.1) 11.80ms referer=http://127.0.0.1:8888/tree
2014-03-11 22:54:59.093 [NotebookApp] ERROR | Unhandled error in API request
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\IPython\html\base\handlers.py", line 286, in wrapper
    result = method(self, *args, **kwargs)
  File "X:\Python34\lib\site-packages\IPython\html\services\notebooks\handlers.py", line 75, in get
    dirs = nbm.list_dirs(path)
  File "X:\Python34\lib\site-packages\IPython\html\services\notebooks\filenbmanager.py", line 192, in list_dirs
    if os.path.isdir(os_path) and not is_hidden(os_path, self.notebook_dir)\
  File "X:\Python34\lib\site-packages\IPython\html\utils.py", line 108, in is_hidden
    st = os.stat(path)
FileNotFoundError: [WinError 2] The system cannot find the file specified: 'C:\\Users\\gohlke\\NetHood'
ERROR:tornado.access:{
  "Connection": "Keep-Alive",
  "Accept-Language": "en-US",
  "X-Requested-With": "XMLHttpRequest",
  "User-Agent": "Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko",
  "Accept": "application/json, text/javascript, */*; q=0.01",
  "Dnt": "1",
  "Referer": "http://127.0.0.1:8888/tree",
  "Host": "127.0.0.1:8888",
  "Accept-Encoding": "gzip, deflate"
}
ERROR:tornado.access:500 GET /api/notebooks?_=1394603699024 (127.0.0.1) 0.00ms referer=http://127.0.0.1:8888/tree
```

```
2014-03-11 23:46:18.002 [NotebookApp] ERROR | Unhandled error in API request
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\IPython\html\base\handlers.py", line 286, in wrapper
    result = method(self, *args, **kwargs)
  File "X:\Python34\lib\site-packages\IPython\html\services\notebooks\handlers.py", line 75, in get
    dirs = nbm.list_dirs(path)
  File "X:\Python34\lib\site-packages\IPython\html\services\notebooks\filenbmanager.py", line 188, in list_dirs
    dir_names = os.listdir(os_path)
PermissionError: [WinError 5] Access is denied: 'C:\\Users\\gohlke\\My Documents'
ERROR:tornado.access:{
  "Connection": "Keep-Alive",
  "X-Requested-With": "XMLHttpRequest",
  "Referer": "http://127.0.0.1:8889/tree/My%20Documents",
  "Accept-Language": "en-US",
  "Dnt": "1",
  "User-Agent": "Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko",
  "Accept-Encoding": "gzip, deflate",
  "Host": "127.0.0.1:8889",
  "Accept": "application/json, text/javascript, */*; q=0.01"
}
ERROR:tornado.access:500 GET /api/notebooks/My%20Documents?_=1394606777923 (127.0.0.1) 4.00ms referer=http://127.0.0.1:8
889/tree/My%20Documents
2014-03-11 23:46:18.037 [NotebookApp] ERROR | Unhandled error in API request
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\IPython\html\base\handlers.py", line 286, in wrapper
    result = method(self, *args, **kwargs)
  File "X:\Python34\lib\site-packages\IPython\html\services\notebooks\handlers.py", line 75, in get
    dirs = nbm.list_dirs(path)
  File "X:\Python34\lib\site-packages\IPython\html\services\notebooks\filenbmanager.py", line 188, in list_dirs
    dir_names = os.listdir(os_path)
PermissionError: [WinError 5] Access is denied: 'C:\\Users\\gohlke\\My Documents'
ERROR:tornado.access:{
  "Connection": "Keep-Alive",
  "X-Requested-With": "XMLHttpRequest",
  "Referer": "http://127.0.0.1:8889/tree/My%20Documents",
  "Accept-Language": "en-US",
  "Dnt": "1",
  "User-Agent": "Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko",
  "Accept-Encoding": "gzip, deflate",
  "Host": "127.0.0.1:8889",
  "Accept": "application/json, text/javascript, */*; q=0.01"
}
ERROR:tornado.access:500 GET /api/notebooks/My%20Documents?_=1394606777926 (127.0.0.1) 0.00ms referer=http://127.0.0.1:8
889/tree/My%20Documents
```
