### PR TITLE
Allow None for most traits

### DIFF
--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -898,6 +898,25 @@ class TestList(TraitTestBase):
             value = list(value)
         return value
 
+class Foo(object):
+    pass
+
+class InstanceListTrait(HasTraits):
+
+    value = List(Instance(__name__+'.Foo'))
+
+class TestInstanceList(TraitTestBase):
+
+    obj = InstanceListTrait()
+
+    def test_klass(self):
+        """Test that the instance klass is properly assigned."""
+        self.assertIs(self.obj.traits()['value']._trait.klass, Foo)
+
+    _default_value = []
+    _good_values = [[Foo(), Foo(), None], None]
+    _bad_values = [['1', 2,], '1', [Foo]]
+
 class LenListTrait(HasTraits):
 
     value = List(Int, [0], minlen=1, maxlen=2)

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -16,7 +16,7 @@ import nose.tools as nt
 from nose import SkipTest
 
 from IPython.utils.traitlets import (
-    HasTraits, MetaHasTraits, TraitType, AllowNone, Any, CBytes, Dict,
+    HasTraits, MetaHasTraits, TraitType, Any, CBytes, Dict,
     Int, Long, Integer, Float, Complex, Bytes, Unicode, TraitError,
     Undefined, Type, This, Instance, TCPAddress, List, Tuple,
     ObjectName, DottedObjectName, CRegExp, link
@@ -73,7 +73,7 @@ class TestTraitType(TestCase):
         self.assertEqual(a.tt, -1)
 
     def test_default_validate(self):
-        class MyIntTT(AllowNone):
+        class MyIntTT(TraitType):
             def validate(self, obj, value):
                 if isinstance(value, int):
                     return value
@@ -354,29 +354,29 @@ class TestHasTraitsNotify(TestCase):
 
         class A(HasTraits):
             listen_to = ['a']
-
+            
             a = Int(0)
             b = 0
-
+            
             def __init__(self, **kwargs):
                 super(A, self).__init__(**kwargs)
                 self.on_trait_change(self.listener1, ['a'])
-
+            
             def listener1(self, name, old, new):
                 self.b += 1
 
         class B(A):
-
+                    
             c = 0
             d = 0
-
+            
             def __init__(self, **kwargs):
                 super(B, self).__init__(**kwargs)
                 self.on_trait_change(self.listener2)
-
+            
             def listener2(self, name, old, new):
                 self.c += 1
-
+            
             def _a_changed(self, name, old, new):
                 self.d += 1
 
@@ -442,7 +442,7 @@ class TestHasTraits(TestCase):
             def __init__(self, i):
                 super(A, self).__init__()
                 self.i = i
-
+        
         a = A(5)
         self.assertEqual(a.i, 5)
         # should raise TypeError if no positional arg given
@@ -677,19 +677,19 @@ class TraitTestBase(TestCase):
         if (hasattr(self, '_bad_values') and hasattr(self, '_good_values') and
         None in self._bad_values):
             trait=self.obj.traits()['value']
-            if isinstance(trait, AllowNone) and not trait._allow_none:
-                try:
-                    trait._allow_none = True
-                    self._bad_values.remove(None)
-                    #skip coerce. Allow None casts None to None.
-                    self.assign(None)
-                    self.assertEqual(self.obj.value,None)
-                    self.test_good_values()
-                    self.test_bad_values()
-                finally:
-                    #tear down
-                    trait._allow_none = False
-                    self._bad_values.append(None)
+            try:
+                trait.allow_none = True
+                self._bad_values.remove(None)
+                #skip coerce. Allow None casts None to None.
+                self.assign(None)
+                self.assertEqual(self.obj.value,None)
+                self.test_good_values()
+                self.test_bad_values()
+            finally:
+                #tear down
+                trait.allow_none = False
+                self._bad_values.append(None)
+                print "bad values %s" % self
 
 
     def tearDown(self):
@@ -894,7 +894,7 @@ class TestList(TraitTestBase):
     _default_value = []
     _good_values = [[], [1], list(range(10)), (1,2)]
     _bad_values = [10, [1,'a'], 'a']
-
+    
     def coerce(self, value):
         if value is not None:
             value = list(value)
@@ -1073,7 +1073,7 @@ class TestLink(TestCase):
             count = Int()
         a = A(value=9)
         b = B(count=8)
-
+        
         # Register callbacks that count.
         callback_count = []
         def a_callback(name, old, new):

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -689,8 +689,6 @@ class TraitTestBase(TestCase):
                 #tear down
                 trait.allow_none = False
                 self._bad_values.append(None)
-                print "bad values %s" % self
-
 
     def tearDown(self):
         # restore default value after tests, if set

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -16,7 +16,7 @@ import nose.tools as nt
 from nose import SkipTest
 
 from IPython.utils.traitlets import (
-    HasTraits, MetaHasTraits, TraitType, Any, CBytes, Dict,
+    HasTraits, MetaHasTraits, TraitType, AllowNone, Any, CBytes, Dict,
     Int, Long, Integer, Float, Complex, Bytes, Unicode, TraitError,
     Undefined, Type, This, Instance, TCPAddress, List, Tuple,
     ObjectName, DottedObjectName, CRegExp, link
@@ -73,7 +73,7 @@ class TestTraitType(TestCase):
         self.assertEqual(a.tt, -1)
 
     def test_default_validate(self):
-        class MyIntTT(TraitType):
+        class MyIntTT(AllowNone):
             def validate(self, obj, value):
                 if isinstance(value, int):
                     return value
@@ -354,29 +354,29 @@ class TestHasTraitsNotify(TestCase):
 
         class A(HasTraits):
             listen_to = ['a']
-            
+
             a = Int(0)
             b = 0
-            
+
             def __init__(self, **kwargs):
                 super(A, self).__init__(**kwargs)
                 self.on_trait_change(self.listener1, ['a'])
-            
+
             def listener1(self, name, old, new):
                 self.b += 1
 
         class B(A):
-                    
+
             c = 0
             d = 0
-            
+
             def __init__(self, **kwargs):
                 super(B, self).__init__(**kwargs)
                 self.on_trait_change(self.listener2)
-            
+
             def listener2(self, name, old, new):
                 self.c += 1
-            
+
             def _a_changed(self, name, old, new):
                 self.d += 1
 
@@ -442,7 +442,7 @@ class TestHasTraits(TestCase):
             def __init__(self, i):
                 super(A, self).__init__()
                 self.i = i
-        
+
         a = A(5)
         self.assertEqual(a.i, 5)
         # should raise TypeError if no positional arg given
@@ -673,6 +673,23 @@ class TraitTestBase(TestCase):
         if hasattr(self, '_default_value'):
             self.assertEqual(self._default_value, self.obj.value)
 
+    def test_allow_none(self):
+        if (hasattr(self, '_bad_values') and hasattr(self, '_good_values') and
+        None in self._bad_values):
+            trait=self.obj.traits()['value']
+            if isinstance(trait, AllowNone) and not trait._allow_none:
+                trait._allow_none = True
+                self._bad_values.remove(None)
+                #skip coerce. Allow None casts None to None.
+                self.assign(None)
+                self.assertEqual(self.obj.value,None)
+                self.test_good_values()
+                self.test_bad_values()
+                #tear down
+                trait._allow_none = False
+                self._bad_values.append(None)
+
+
     def tearDown(self):
         # restore default value after tests, if set
         if hasattr(self, '_default_value'):
@@ -830,7 +847,7 @@ class TestObjectName(TraitTestBase):
     _default_value = "abc"
     _good_values = ["a", "gh", "g9", "g_", "_G", u"a345_"]
     _bad_values = [1, "", u"€", "9g", "!", "#abc", "aj@", "a.b", "a()", "a[0]",
-                                                            object(), object]
+                                                        None, object(), object]
     if sys.version_info[0] < 3:
         _bad_values.append(u"þ")
     else:
@@ -845,7 +862,7 @@ class TestDottedObjectName(TraitTestBase):
 
     _default_value = "a.b"
     _good_values = ["A", "y.t", "y765.__repr__", "os.path.join", u"os.path.join"]
-    _bad_values = [1, u"abc.€", "_.@", ".", ".abc", "abc.", ".abc."]
+    _bad_values = [1, u"abc.€", "_.@", ".", ".abc", "abc.", ".abc.", None]
     if sys.version_info[0] < 3:
         _bad_values.append(u"t.þ")
     else:
@@ -862,7 +879,7 @@ class TestTCPAddress(TraitTestBase):
 
     _default_value = ('127.0.0.1',0)
     _good_values = [('localhost',0),('192.168.0.1',1000),('www.google.com',80)]
-    _bad_values = [(0,0),('localhost',10.0),('localhost',-1)]
+    _bad_values = [(0,0),('localhost',10.0),('localhost',-1), None]
 
 class ListTrait(HasTraits):
 
@@ -875,7 +892,7 @@ class TestList(TraitTestBase):
     _default_value = []
     _good_values = [[], [1], list(range(10)), (1,2)]
     _bad_values = [10, [1,'a'], 'a']
-    
+
     def coerce(self, value):
         if value is not None:
             value = list(value)
@@ -1054,7 +1071,7 @@ class TestLink(TestCase):
             count = Int()
         a = A(value=9)
         b = B(count=8)
-        
+
         # Register callbacks that count.
         callback_count = []
         def a_callback(name, old, new):

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -936,14 +936,14 @@ class TestLenList(TraitTestBase):
 
 class TupleTrait(HasTraits):
 
-    value = Tuple(Int)
+    value = Tuple(Int(allow_none=True))
 
 class TestTupleTrait(TraitTestBase):
 
     obj = TupleTrait()
 
     _default_value = None
-    _good_values = [(1,), None, (0,), [1]]
+    _good_values = [(1,), None, (0,), [1], (None,)]
     _bad_values = [10, (1,2), ('a'), ()]
 
     def coerce(self, value):

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -678,16 +678,18 @@ class TraitTestBase(TestCase):
         None in self._bad_values):
             trait=self.obj.traits()['value']
             if isinstance(trait, AllowNone) and not trait._allow_none:
-                trait._allow_none = True
-                self._bad_values.remove(None)
-                #skip coerce. Allow None casts None to None.
-                self.assign(None)
-                self.assertEqual(self.obj.value,None)
-                self.test_good_values()
-                self.test_bad_values()
-                #tear down
-                trait._allow_none = False
-                self._bad_values.append(None)
+                try:
+                    trait._allow_none = True
+                    self._bad_values.remove(None)
+                    #skip coerce. Allow None casts None to None.
+                    self.assign(None)
+                    self.assertEqual(self.obj.value,None)
+                    self.test_good_values()
+                    self.test_bad_values()
+                finally:
+                    #tear down
+                    trait._allow_none = False
+                    self._bad_values.append(None)
 
 
     def tearDown(self):

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -1448,7 +1448,7 @@ class Tuple(Container):
         validated = []
         for t,v in zip(self._traits, value):
             try:
-                v = t.validate(obj, v)
+                v = t._validate(obj, v)
             except TraitError:
                 self.element_error(obj, v, t)
             else:

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -1284,6 +1284,11 @@ class Container(Instance):
                 validated.append(v)
         return self.klass(validated)
 
+    def instance_init(self, obj):
+        if isinstance(self._trait, Instance):
+            self._trait._resolve_classes()
+        super(Container, self).instance_init(obj)
+
 
 class List(Container):
     """An instance of a Python list."""

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -751,7 +751,7 @@ class Type(ClassBasedTraitType):
 
         self.klass       = klass
 
-        super(Type, self).__init__(default_value, allow_none, **metadata)
+        super(Type, self).__init__(default_value, allow_none=allow_none, **metadata)
 
     def validate(self, obj, value):
         """Validates that the value is a valid object instance."""
@@ -857,7 +857,7 @@ class Instance(ClassBasedTraitType):
 
             default_value = DefaultValueGenerator(*args, **kw)
 
-        super(Instance, self).__init__(default_value, allow_none, **metadata)
+        super(Instance, self).__init__(default_value, allow_none=allow_none, **metadata)
 
     def validate(self, obj, value):
         if isinstance(value, self.klass):
@@ -1165,7 +1165,7 @@ class Enum(TraitType):
 
     def __init__(self, values, default_value=None, allow_none=True, **metadata):
         self.values = values
-        super(Enum, self).__init__(default_value, allow_none, **metadata)
+        super(Enum, self).__init__(default_value, allow_none=allow_none, **metadata)
 
     def validate(self, obj, value):
         if value in self.values:

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -1277,7 +1277,7 @@ class Container(Instance):
             return value
         for v in value:
             try:
-                v = self._trait.validate(obj, v)
+                v = self._trait._validate(obj, v)
             except TraitError:
                 self.element_error(obj, v, self._trait)
             else:
@@ -1353,8 +1353,6 @@ class List(Container):
     
     def validate(self, obj, value):
         value = super(List, self).validate(obj, value)
-        if value is None:
-            return value
 
         value = self.validate_elements(obj, value)
 


### PR DESCRIPTION
With this patch most of the traits have an `_allow_none` property that works in the same way as the one for the instance. 
It is often useful that traits have no implicit default value (like zero for number types) and that there is a way to represent "No value defined by the user".
By default everything should work exactly as before.
The validation has to take allow_none into account in every trait implementation.
Casting traits cast None to None when `_allow_none` is set. 
Tests included.
