### PR TITLE
Don't autoclose strings

### DIFF
--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -102,7 +102,8 @@ var IPython = (function (IPython) {
             mode: 'ipython',
             theme: 'ipython',
             matchBrackets: true,
-            autoCloseBrackets: true
+             // don't auto-close strings because of CodeMirror #2385
+            autoCloseBrackets: "()[]{}"
         }
     };
 


### PR DESCRIPTION
CodeMirror doesn't do the right thing with triple-quoted strings, so don't let it try.

ping @fperez
