### PR TITLE
remove unnecessary onload hack from mathjax macro

### DIFF
--- a/IPython/nbconvert/templates/html/mathjax.tpl
+++ b/IPython/nbconvert/templates/html/mathjax.tpl
@@ -1,4 +1,6 @@
 {%- macro mathjax() -%}
+    <!-- Load mathjax -->
+    <script src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
     <!-- MathJax configuration -->
     <script type="text/x-mathjax-config">
     MathJax.Hub.Config({
@@ -18,19 +20,4 @@
     });
     </script>
     <!-- End of mathjax configuration -->
-
-    <script>
-    //  We wait for the onload function to load MathJax after the page is completely loaded.
-    //  MathJax is loaded 1 unit of time after the page is ready.
-    //  This hack prevent problems when you load multiple js files.
-
-    window.onload = function () {
-      setTimeout(function () {
-        var script = document.createElement("script");
-        script.type = "text/javascript";
-        script.src  = "https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS_HTML";
-        document.getElementsByTagName("head")[0].appendChild(script);
-      },1)
-    }
-    </script>
 {%- endmacro %}


### PR DESCRIPTION
This is still up for discussion.

@damianavila can you provide an example where the hack is necessary? It seems it was added in a PR only meant to consolidate files without changing any behavior. I can find no report of the problems this claims to fix.  I very much doubt that it is the right fix for whatever problem it addresses, so I would like to try to find the right solution.
