### PR TITLE
elide long containers in pretty

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -122,6 +122,7 @@ else:
 __all__ = ['pretty', 'pprint', 'PrettyPrinter', 'RepresentationPrinter',
     'for_type', 'for_type_by_name']
 
+SEQ_LENGTH_LIMIT = 1000
 
 _re_pattern_type = type(re.compile(''))
 
@@ -599,6 +600,12 @@ def _seq_pprinter_factory(start, end, basetype):
         step = len(start)
         p.begin_group(step, start)
         for idx, x in enumerate(obj):
+            if idx >= SEQ_LENGTH_LIMIT:
+                p.text(',')
+                p.breakable()
+                p.text('...')
+                p.end_group(step, end)
+                return
             if idx:
                 p.text(',')
                 p.breakable()
@@ -636,6 +643,12 @@ def _set_pprinter_factory(start, end, basetype):
                 # Sometimes the items don't sort.
                 pass
             for idx, x in enumerate(items):
+                if idx >= SEQ_LENGTH_LIMIT:
+                    p.text(',')
+                    p.breakable()
+                    p.text('...')
+                    p.end_group(step, end)
+                    return
                 if idx:
                     p.text(',')
                     p.breakable()
@@ -665,6 +678,12 @@ def _dict_pprinter_factory(start, end, basetype=None):
             # Sometimes the keys don't sort.
             pass
         for idx, key in enumerate(keys):
+            if idx >= SEQ_LENGTH_LIMIT:
+                p.text(',')
+                p.breakable()
+                p.text('...')
+                p.end_group(1, end)
+                return
             if idx:
                 p.text(',')
                 p.breakable()

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -330,7 +330,7 @@ class PrettyPrinter(_PrettyPrinterBase):
     def _enumerate(self, seq):
         """like enumerate, but with an upper limit on the number of items"""
         for idx, x in enumerate(seq):
-            if idx >= self.max_seq_length:
+            if self.max_seq_length and idx >= self.max_seq_length:
                 self.text(',')
                 self.breakable()
                 self.text('...')

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -122,8 +122,6 @@ else:
 __all__ = ['pretty', 'pprint', 'PrettyPrinter', 'RepresentationPrinter',
     'for_type', 'for_type_by_name']
 
-SEQ_LENGTH_LIMIT = 1000
-
 _re_pattern_type = type(re.compile(''))
 
 def _failed_repr(obj, e):
@@ -230,10 +228,11 @@ class PrettyPrinter(_PrettyPrinterBase):
     callback method.
     """
 
-    def __init__(self, output, max_width=79, newline='\n'):
+    def __init__(self, output, max_width=79, newline='\n', max_seq_length=1000):
         self.output = output
         self.max_width = max_width
         self.newline = newline
+        self.max_seq_length = max_seq_length
         self.output_width = 0
         self.buffer_width = 0
         self.buffer = deque()
@@ -606,13 +605,13 @@ def _seq_pprinter_factory(start, end, basetype):
             return p.text(start + '...' + end)
         step = len(start)
         p.begin_group(step, start)
-        for idx, x in _enumerate(obj, SEQ_LENGTH_LIMIT):
+        for idx, x in _enumerate(obj, p.max_seq_length):
             if idx:
                 p.text(',')
                 p.breakable()
             p.pretty(x)
         
-        if len(obj) >= SEQ_LENGTH_LIMIT:
+        if len(obj) >= p.max_seq_length:
             p.text(',')
             p.breakable()
             p.text('...')
@@ -648,13 +647,13 @@ def _set_pprinter_factory(start, end, basetype):
             except Exception:
                 # Sometimes the items don't sort.
                 pass
-            for idx, x in _enumerate(items, SEQ_LENGTH_LIMIT):
+            for idx, x in _enumerate(items, p.max_seq_length):
                 if idx:
                     p.text(',')
                     p.breakable()
                 p.pretty(x)
             
-            if len(obj) >= SEQ_LENGTH_LIMIT:
+            if len(obj) >= p.max_seq_length:
                 p.text(',')
                 p.breakable()
                 p.text('...')
@@ -682,7 +681,7 @@ def _dict_pprinter_factory(start, end, basetype=None):
         except Exception as e:
             # Sometimes the keys don't sort.
             pass
-        for idx, key in _enumerate(keys, SEQ_LENGTH_LIMIT):
+        for idx, key in _enumerate(keys, p.max_seq_length):
             if idx:
                 p.text(',')
                 p.breakable()
@@ -690,7 +689,7 @@ def _dict_pprinter_factory(start, end, basetype=None):
             p.text(': ')
             p.pretty(obj[key])
         
-        if len(obj) >= SEQ_LENGTH_LIMIT:
+        if len(obj) >= p.max_seq_length:
             p.text(',')
             p.breakable()
             p.text('...')

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -196,4 +196,29 @@ def test_super_repr():
     sb = SB()
     output = pretty.pretty(super(SA, sb))
     nt.assert_in("SA", output)
-    
+
+
+def test_long_list():
+    lis = list(range(10000))
+    p = pretty.pretty(lis)
+    last2 = p.rsplit('\n', 2)[-2:]
+    nt.assert_equal(last2, [' 999,', ' ...]'])
+
+def test_long_set():
+    s = set(range(10000))
+    p = pretty.pretty(s)
+    last2 = p.rsplit('\n', 2)[-2:]
+    nt.assert_equal(last2, [' 999,', ' ...}'])
+
+def test_long_tuple():
+    tup = tuple(range(10000))
+    p = pretty.pretty(tup)
+    last2 = p.rsplit('\n', 2)[-2:]
+    nt.assert_equal(last2, [' 999,', ' ...)'])
+
+def test_long_dict():
+    d = { n:n for n in range(10000) }
+    p = pretty.pretty(d)
+    last2 = p.rsplit('\n', 2)[-2:]
+    nt.assert_equal(last2, [' 999: 999,', ' ...}'])
+


### PR DESCRIPTION
limits sequence length to 1k items

avoids performance issues with pretty-printing large containers

closes #5347
