### PR TITLE
don't instantiate Application just for default logger

### DIFF
--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -26,6 +26,7 @@ from __future__ import print_function
 # Imports
 #-----------------------------------------------------------------------------
 
+import logging
 from copy import deepcopy
 
 from .loader import Config, LazyConfigValue
@@ -381,6 +382,9 @@ class LoggingConfigurable(Configurable):
     log = Instance('logging.Logger')
     def _log_default(self):
         from IPython.config.application import Application
-        return Application.instance().log
+        if Application.initialized():
+            return Application.instance().log
+        else:
+            return logging.getLogger()
 
 

--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -25,6 +25,7 @@ Authors
 
 import argparse
 import copy
+import logging
 import os
 import re
 import sys
@@ -308,7 +309,10 @@ class ConfigLoader(object):
 
     def _log_default(self):
         from IPython.config.application import Application
-        return Application.instance().log
+        if Application.initialized():
+            return Application.instance().log
+        else:
+            return logging.getLogger()
 
     def __init__(self, log=None):
         """A base class for config loaders.


### PR DESCRIPTION
It's unlikely to come up in IPython itself, but can happen if config loaders are used elsewhere.

closes #5378
