### PR TITLE
Remove DefineShortVerb... line from latex base template

### DIFF
--- a/IPython/nbconvert/templates/latex/base.tplx
+++ b/IPython/nbconvert/templates/latex/base.tplx
@@ -62,8 +62,6 @@ This template does not define a docclass, the inheriting class must define this.
     
     % commands and environments needed by pandoc snippets
     % extracted from the output of `pandoc -s`
-    
-    \DefineShortVerb[commandchars=\\\{\}]{\|}
     \DefineVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\{\}}
     % Add ',fontsize=\small' for more characters per line
     \newenvironment{Shaded}{}{}


### PR DESCRIPTION
Related to Pandoc kate syntax highlighting.  Removing it doesn't seem to cause any problems with Pandoc triple backtick markdown formatted code cell blocks i.e. `'''python` (I apostrophes in that quote so they would render on GH).  It also doesn't cause any problems with pygments.  I'm pretty sure it doesn't cause any problems to remove it, but pinging @minrk just in case, since it was part of a bigger block that he added.

Removing it fixes latex errors that occur in some math strings (I think math stings with pipes in particular).  For example, this doesn't work in master when converted to latex PDF even though it should: 

``` latex
$$
|f(x)| \le M|g(x)| \; \forall x>x_{0}
$$
```

See #4946 for more info.
Pandoc 1.12.3.3 & IPython master

closes #4946
