### PR TITLE
Added authentication configuration for the notebook app.

### DIFF
--- a/IPython/html/auth/login.py
+++ b/IPython/html/auth/login.py
@@ -3,10 +3,11 @@
 Authors:
 
 * Brian Granger
+* Phil Elson
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2011  The IPython Development Team
+#  Copyright (C) 2014  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.
@@ -19,7 +20,9 @@ Authors:
 import uuid
 
 from tornado.escape import url_escape
+from tornado import web
 
+from IPython.config.configurable import Configurable
 from IPython.lib.security import passwd_check
 
 from ..base.handlers import IPythonHandler
@@ -29,7 +32,10 @@ from ..base.handlers import IPythonHandler
 #-----------------------------------------------------------------------------
 
 class LoginHandler(IPythonHandler):
-
+    """ The basic IPythonWebApplication login handler which authenticates with a
+    hashed password from the configuration.
+    
+    """
     def _render(self, message=None):
         self.write(self.render_template('login.html',
                 next=url_escape(self.get_argument('next', default=self.base_url)),
@@ -43,20 +49,38 @@ class LoginHandler(IPythonHandler):
             self._render()
 
     def post(self):
-        pwd = self.get_argument('password', default=u'')
-        if self.login_available:
-            if passwd_check(self.password, pwd):
+        hashed_password = self.password_from_configuration(self.application)
+        typed_password = self.get_argument('password', default=u'')
+        if self.login_available(self.application):
+            if passwd_check(hashed_password, typed_password):
                 self.set_secure_cookie(self.cookie_name, str(uuid.uuid4()))
             else:
                 self._render(message={'error': 'Invalid password'})
                 return
 
         self.redirect(self.get_argument('next', default=self.base_url))
+    
+    @classmethod
+    def validate_notebook_app_security(cls, notebook_app, ssl_options=None):
+        if not notebook_app.ip:
+            warning = "WARNING: The notebook server is listening on all IP addresses"
+            if ssl_options is None:
+                notebook_app.log.critical(warning + " and not using encryption. This "
+                    "is not recommended.")
+            if not self.password_from_configuration(notebook_app):
+                notebook_app.log.critical(warning + " and not using authentication. "
+                    "This is highly insecure and not recommended.")
 
+    @staticmethod
+    def password_from_configuration(webapp):
+        """ Return the hashed password from the given NotebookWebApplication's configuration.
+        
+        If there is no configured password, None will be returned.
+        
+        """
+        return webapp.settings['config']['NotebookApp'].get('password', None)
 
-#-----------------------------------------------------------------------------
-# URL to handler mappings
-#-----------------------------------------------------------------------------
-
-
-default_handlers = [(r"/login", LoginHandler)]
+    @classmethod
+    def login_available(cls, webapp):
+        """Whether this LoginHandler is needed - and therefore whether the login page should be displayed."""
+        return bool(cls.password_from_configuration(webapp))

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -6,7 +6,7 @@ Authors:
 """
 
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2011  The IPython Development Team
+#  Copyright (C) 2014  The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.
@@ -85,17 +85,17 @@ class AuthenticatedHandler(web.RequestHandler):
         return self.settings.get('cookie_name', default_cookie_name)
     
     @property
-    def password(self):
-        """our password"""
-        return self.settings.get('password', '')
-    
-    @property
     def logged_in(self):
         """Is a user currently logged in?
 
         """
         user = self.get_current_user()
         return (user and not user == 'anonymous')
+
+    @property
+    def _login_handler(self):
+        """Return the login handler for this application."""
+        return self.settings['login_handler_class']
 
     @property
     def login_available(self):
@@ -105,7 +105,7 @@ class AuthenticatedHandler(web.RequestHandler):
         whether the user is already logged in or not.
 
         """
-        return bool(self.settings.get('password', ''))
+        return bool(self._login_handler.login_available(self.application))
 
 
 class IPythonHandler(AuthenticatedHandler):

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -91,7 +91,7 @@ class TraitError(Exception):
 #-----------------------------------------------------------------------------
 
 
-def class_of ( object ):
+def class_of( object ):
     """ Returns a string containing the class name of an object with the
     correct indefinite article ('a' or 'an') preceding it (e.g., 'an Image',
     'a PlotValue').


### PR DESCRIPTION
In this PR I've refactored the authentication code for the NotebookApp. The LoginHandler is now responsible for all things authentication related - including validation/warnings, and determination of whether a login screen should be displayed. I've also exposed a configuration on the application which allows control of which LoginHandler to use.

My motivation for this is to implement alternative authentication schemes - my present data point is to implement a KerberosLoginHandler which makes use of an internal Active Directory password store (via kerberos). With the changes in this PR all that is needed is a simple LoginHandler subclass, and the configuration set along the lines of:

`c.NotebookApp.login_handler = 'my_module.KerberosLoginHandler'`

Because I want to sure this up a little more, my own subclass restricts the protocol to https only, and does not need a password defined in the configuration.

If there are any contentious issues here, I'd be happy to join you for a dev hangout in the near future.
