### PR TITLE
Suppress output even when a comment follows ;. Fixes #4525.

### DIFF
--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -26,6 +26,7 @@ from __future__ import print_function
 import sys
 
 from IPython.core.formatters import _safe_get_formatter_method
+from IPython.core import inputsplitter
 from IPython.config.configurable import Configurable
 from IPython.utils import io
 from IPython.utils.py3compat import builtin_mod
@@ -100,12 +101,10 @@ class DisplayHook(Configurable):
         # do not print output if input ends in ';'
         try:
             cell = self.shell.history_manager.input_hist_parsed[self.prompt_count]
-            if cell.rstrip().endswith(';'):
-                return True
+            return inputsplitter.remove_comments(cell).rstrip().endswith(';')
         except IndexError:
             # some uses of ipshellembed may fail here
-            pass
-        return False
+            return False
 
     def start_displayhook(self):
         """Start the displayhook, initializing resources."""

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -98,13 +98,17 @@ class InteractiveShellTestCase(unittest.TestCase):
     def test_dont_cache_with_semicolon(self):
         "Ending a line with semicolon should not cache the returned object (GH-307)"
         oldlen = len(ip.user_ns['Out'])
-        a = ip.run_cell('1;', store_history=True)
-        newlen = len(ip.user_ns['Out'])
-        self.assertEqual(oldlen, newlen)
+        for cell in ['1;', '1; #a', '1;1;']:
+            ip.run_cell(cell, store_history=True)
+            newlen = len(ip.user_ns['Out'])
+            self.assertEqual(oldlen, newlen)
+        i = 0
         #also test the default caching behavior
-        ip.run_cell('1', store_history=True)
-        newlen = len(ip.user_ns['Out'])
-        self.assertEqual(oldlen+1, newlen)
+        for cell in ['1', '1 #;', '1;1']:
+            ip.run_cell(cell, store_history=True)
+            newlen = len(ip.user_ns['Out'])
+            i += 1
+            self.assertEqual(oldlen+i, newlen)
 
     def test_In_variable(self):
         "Verify that In variable grows with user input (GH-284)"


### PR DESCRIPTION
Fixes https://github.com/ipython/ipython/issues/4525

Before:

```
In [1]: 1
Out[1]: 1

In [2]: 1;

In [3]: 1; # comment
Out[3]: 1

In [4]: 1; 2
Out[4]: 2

In [5]: 1 # comment ;
```

Now:

```
In [1]: 1
Out[1]: 1

In [2]: 1;

In [3]: 1; # comment

In [4]: 1; 2
Out[4]: 2

In [5]: 1 # comment;
Out[5]: 1
```
