### PR TITLE
Fix Gecko (Netscape) keyboard handling

### DIFF
--- a/IPython/html/static/base/js/keyboard.js
+++ b/IPython/html/static/base/js/keyboard.js
@@ -54,7 +54,7 @@ IPython.keyboard = (function (IPython) {
     var browser = IPython.utils.browser[0];
     var platform = IPython.utils.platform;
     
-    if (browser === 'Firefox' || browser === 'Opera') {
+    if (browser === 'Firefox' || browser === 'Opera' || browser === 'Netscape') {
         $.extend(_keycodes, _mozilla_keycodes);
     } else if (browser === 'Safari' || browser === 'Chrome' || browser === 'MSIE') {
         $.extend(_keycodes, _ie_keycodes);


### PR DESCRIPTION
It took a while for me to track down this bug which was uncovered by the SlimerJS tests. :grinning: 

Our browser detection appropriately sees SlimerJS as Netscape, which is the [original source of the Gecko rendering engine](http://en.wikipedia.org/wiki/Gecko_%28layout_engine%29).
