### PR TITLE
nbconvert doc update

### DIFF
--- a/docs/source/interactive/nbconvert.rst
+++ b/docs/source/interactive/nbconvert.rst
@@ -71,7 +71,7 @@ The currently supported export formats are:
 * ``--to markdown``
 
   Simple markdown output.  Markdown cells are unaffected,
-  and code cells are placed in triple-backtick (```````) blocks.
+  and code cells indented 4 spaces.
 
 * ``--to rst``
 


### PR DESCRIPTION
fix docs, closes #5345

(we were referring to tripple backticks, but now we actually indent)
