### PR TITLE
update links in notebook help menu

### DIFF
--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -227,8 +227,8 @@ class="notebook_app"
                         (
                             ("http://ipython.org/documentation.html","IPython Help",True),
                             ("http://nbviewer.ipython.org/github/ipython/ipython/tree/master/examples/notebooks/", "Notebook Examples", True),
-                            ("http://ipython.org/ipython-doc/stable/interactive/notebook.html","Notebook Help",True),
-                            ("http://ipython.org/ipython-doc/dev/interactive/cm_keyboard.html","Editor Shortcuts",True),
+                            ("http://ipython.org/ipython-doc/2/notebook/notebook.html","Notebook Help",True),
+                            ("http://ipython.org/ipython-doc/2/notebook/cm_keyboard.html","Editor Shortcuts",True),
                         ),(
                             ("http://docs.python.org","Python",True),
                             ("http://docs.scipy.org/doc/numpy/reference/","NumPy",True),


### PR DESCRIPTION
These links won't work until the next build of the docs,
but they are correct.

closes #4605
