### PR TITLE
Install jquery-ui images

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -161,6 +161,7 @@ def find_package_data():
         pjoin(components, "jquery", "jquery.min.js"),
         pjoin(components, "jquery-ui", "ui", "minified", "jquery-ui.min.js"),
         pjoin(components, "jquery-ui", "themes", "smoothness", "jquery-ui.min.css"),
+        pjoin(components, "jquery-ui", "themes", "smoothness", "images", "ui-bg_glass_75_e6e6e6_1x400.png"),
         pjoin(components, "marked", "lib", "marked.js"),
         pjoin(components, "requirejs", "require.js"),
         pjoin(components, "underscore", "underscore-min.js"),

--- a/setupbase.py
+++ b/setupbase.py
@@ -161,7 +161,7 @@ def find_package_data():
         pjoin(components, "jquery", "jquery.min.js"),
         pjoin(components, "jquery-ui", "ui", "minified", "jquery-ui.min.js"),
         pjoin(components, "jquery-ui", "themes", "smoothness", "jquery-ui.min.css"),
-        pjoin(components, "jquery-ui", "themes", "smoothness", "images", "ui-bg_glass_75_e6e6e6_1x400.png"),
+        pjoin(components, "jquery-ui", "themes", "smoothness", "images", "*"),
         pjoin(components, "marked", "lib", "marked.js"),
         pjoin(components, "requirejs", "require.js"),
         pjoin(components, "underscore", "underscore-min.js"),


### PR DESCRIPTION
Using ipython-2.0.0-rc1.win-amd64-py3.4 with IE11 get the following warning:

```
WARNING:tornado.access:404 GET /static/components/jquery-ui/themes/smoothness/images/ui-bg_glass_75_e6e6e6_1x400.png (127.0.0.1) 0.00ms referer=http://127.0.0.1:8888/notebooks/Rmagick.ipynb
```
