### PR TITLE
Remove PyReadline as an install requirement on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -285,9 +285,7 @@ install_requires = []
 if sys.platform == 'darwin':
     if any(arg.startswith('bdist') for arg in sys.argv) or not setupext.check_for_readline():
         install_requires.append('gnureadline')
-elif sys.platform.startswith('win'):
-    # Pyreadline has unicode and Python 3 fixes in 2.0
-    install_requires.append('pyreadline>=2.0')
+
 
 if 'setuptools' in sys.modules:
     # setup.py develop should check for submodules


### PR DESCRIPTION
How about removing pyreadline as an install requirement on Windows for version 2.0 so IPython can be used without pyreadline? 

AFAIK the current situation is:
- IPython can be installed without pyreadline using bdist_wininst installers.
- The IPython scripts in sys.prefix\Scripts do not work if pyreadline is not installed (fixed by this PR).
- The IPython console can be used without pyreadline, in which case a warning is printed that "Proper color support under MS Windows requires the pyreadline library".
- Pyreadline is not used/required by the IPython Qt console and the notebook.
- Pyreadline 2.0 conflicts/interferes with the colorama package and pip usage: See https://github.com/pypa/pip/issues/1314 and https://github.com/pyreadline/pyreadline/issues/18
- Pyreadline changes the tab key behavior on the standard Windows console. See http://stackoverflow.com/questions/20353511/python-command-line-not-accepting-tabs
- The Pyreadline project seems abandoned (the last commit was a year ago)
