### PR TITLE
Simplified, flexbox-less cell display.

### DIFF
--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -126,7 +126,7 @@ var IPython = (function (IPython) {
         cell.attr('tabindex','2');
 
         var input = $('<div></div>').addClass('input');
-        var prompt = $('<div/>').addClass('prompt input_prompt');
+        var prompt = $('<div/>').addClass('prompt input_prompt').append($('<div />').addClass('prompt-text'));
         var inner_cell = $('<div/>').addClass('inner_cell');
         this.celltoolbar = new IPython.CellToolbar(this);
         inner_cell.append(this.celltoolbar.element);
@@ -423,7 +423,7 @@ var IPython = (function (IPython) {
         this.input_prompt_number = number;
         var prompt_html = CodeCell.input_prompt_function(this.input_prompt_number, nline);
         // This HTML call is okay because the user contents are escaped.
-        this.element.find('div.input_prompt').html(prompt_html);
+        this.element.find('div.input_prompt div.prompt-text').html(prompt_html);
     };
 
 

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -76,8 +76,8 @@ var IPython = (function (IPython) {
         var cell = $("<div>").addClass('cell text_cell border-box-sizing');
         cell.attr('tabindex','2');
 
-        var prompt = $('<div/>').addClass('prompt input_prompt');
-        cell.append(prompt);
+        var prompt = $('<div/>').addClass('prompt-text');
+        cell.append($('<div/>').addClass('prompt input_prompt').append(prompt));
         var inner_cell = $('<div/>').addClass('inner_cell');
         this.celltoolbar = new IPython.CellToolbar(this);
         inner_cell.append(this.celltoolbar.element);

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -74,10 +74,11 @@ var IPython = (function (IPython) {
         IPython.Cell.prototype.create_element.apply(this, arguments);
 
         var cell = $("<div>").addClass('cell text_cell border-box-sizing');
+        var padded_cell = $("<div>").addClass('cell-padded').appendTo(cell);
         cell.attr('tabindex','2');
 
         var prompt = $('<div/>').addClass('prompt-text');
-        cell.append($('<div/>').addClass('prompt input_prompt').append(prompt));
+        padded_cell.append($('<div/>').addClass('prompt input_prompt').append(prompt));
         var inner_cell = $('<div/>').addClass('inner_cell');
         this.celltoolbar = new IPython.CellToolbar(this);
         inner_cell.append(this.celltoolbar.element);
@@ -87,7 +88,7 @@ var IPython = (function (IPython) {
         var render_area = $('<div/>').addClass('text_cell_render border-box-sizing').
             addClass('rendered_html').attr('tabindex','-1');
         inner_cell.append(input_area).append(render_area);
-        cell.append(inner_cell);
+        padded_cell.append(inner_cell);
         this.element = cell;
     };
 

--- a/IPython/html/static/notebook/less/cell.less
+++ b/IPython/html/static/notebook/less/cell.less
@@ -34,7 +34,7 @@ div.prompt {
 }
 
 div.inner_cell {
-    margin-left: 11ex;
+    margin-left: 12ex;
     margin-right: auto;
 }
 

--- a/IPython/html/static/notebook/less/cell.less
+++ b/IPython/html/static/notebook/less/cell.less
@@ -22,10 +22,10 @@ div.cell {
 
 div.prompt {
     /* This needs to be wide enough for 3 digit prompt numbers: In[100]: */
-    min-width: 11ex;
+    min-width: 80px;
     float: left;
     /* This padding is tuned to match the padding on the CodeMirror editor. */
-    padding: @code_padding;
+    padding-top: @code_padding;
     margin: 0px;
     font-family: @monoFontFamily;
     text-align: right;
@@ -34,7 +34,7 @@ div.prompt {
 }
 
 div.inner_cell {
-    margin-left: 12ex;
+    margin-left: 83px;
     margin-right: auto;
 }
 

--- a/IPython/html/static/notebook/less/cell.less
+++ b/IPython/html/static/notebook/less/cell.less
@@ -1,6 +1,5 @@
 div.cell {
     border: 1px solid transparent;
-    .vbox();
 
     &.selected {
         .corner-all;
@@ -24,6 +23,7 @@ div.cell {
 div.prompt {
     /* This needs to be wide enough for 3 digit prompt numbers: In[100]: */
     min-width: 11ex;
+    float: left;
     /* This padding is tuned to match the padding on the CodeMirror editor. */
     padding: @code_padding;
     margin: 0px;
@@ -33,17 +33,25 @@ div.prompt {
     line-height: @code_line_height;
 }
 
+div.inner_cell {
+    margin-left: 11ex;
+    margin-right: auto;
+}
+
 @media (max-width: 480px) {
+    // move prompts above code on small screens
+    div.prompt {
+        float: none;
+    }
+    div.inner_cell {
+        margin-left: 0px;
+        margin-right: 0px;
+    }
     // prompts are in the main column on small screens,
     // so text should be left-aligned
     div.prompt {
         text-align: left;
     }
-}
-
-div.inner_cell {
-    .vbox();
-    .box-flex1();
 }
 
 /* input_area and input_prompt must match in top border and margin for alignment */

--- a/IPython/html/static/notebook/less/cell.less
+++ b/IPython/html/static/notebook/less/cell.less
@@ -46,7 +46,7 @@ div.inner_cell {
 @media (max-width: 480px) {
     // move prompts above code on small screens
     div.prompt {
-        float: none;
+        position: relative;
     }
     div.inner_cell {
         margin-left: 0px;

--- a/IPython/html/static/notebook/less/cell.less
+++ b/IPython/html/static/notebook/less/cell.less
@@ -10,27 +10,32 @@ div.cell {
         .corner-all;
         border : thin green solid;
     }
-}
 
-div.cell {
     width: 100%;
     padding: 5px 5px 5px 0px;
     /* This acts as a spacer between cells, that is outside the border */
     margin: 0px;
     outline: none;
+
+    div.input {
+        position: relative;
+    }
 }
 
 div.prompt {
     /* This needs to be wide enough for 3 digit prompt numbers: In[100]: */
     min-width: 80px;
-    float: left;
-    /* This padding is tuned to match the padding on the CodeMirror editor. */
-    padding-top: @code_padding;
+    position: absolute;
+    height: 100%;
     margin: 0px;
     font-family: @monoFontFamily;
     text-align: right;
     /* This has to match that of the the CodeMirror class line-height below */	
     line-height: @code_line_height;
+
+    div.prompt-text {
+        padding-top: @code_padding;
+    }
 }
 
 div.inner_cell {

--- a/IPython/html/static/notebook/less/cell.less
+++ b/IPython/html/static/notebook/less/cell.less
@@ -16,6 +16,7 @@ div.cell {
     /* This acts as a spacer between cells, that is outside the border */
     margin: 0px;
     outline: none;
+    position: relative;
 
     div.input {
         position: relative;

--- a/IPython/html/static/notebook/less/codecell.less
+++ b/IPython/html/static/notebook/less/codecell.less
@@ -7,14 +7,6 @@ div.code_cell.running {
 
 div.input {
     page-break-inside: avoid;
-    .hbox();
-}
-
-@media (max-width: 480px) {
-    // move prompts above code on small screens
-    div.input {
-        .vbox();
-    }
 }
 
 /* input_area and input_prompt must match in top border and margin for alignment */

--- a/IPython/html/static/notebook/less/codecell.less
+++ b/IPython/html/static/notebook/less/codecell.less
@@ -12,7 +12,10 @@ div.input {
 /* input_area and input_prompt must match in top border and margin for alignment */
 div.input_prompt {
     color: navy;
-    border-top: 1px solid transparent;
+
+    div.prompt-text {
+        border-top: 1px solid transparent;
+    }
 }
 
 // The styles related to div.highlight are for nbconvert HTML output only. This works

--- a/IPython/html/static/notebook/less/codemirror.less
+++ b/IPython/html/static/notebook/less/codemirror.less
@@ -22,14 +22,6 @@
     overflow-x: auto;
 }
 
-@-moz-document url-prefix() {
-  /* Firefox does weird and terrible things (#3549) when overflow-x is auto */
-  /* It doesn't respect the overflow setting anyway, so we can workaround it with this */
-  .CodeMirror-scroll {
-    overflow-x: hidden;
-  }
-}
-
 .CodeMirror-lines {
     /* In CM2, this used to be 0.4em, but in CM3 it went to 4px. We need the em value because */
     /* we have set a different line-height and want this to scale with that. */

--- a/IPython/html/static/notebook/less/outputarea.less
+++ b/IPython/html/static/notebook/less/outputarea.less
@@ -26,7 +26,7 @@ div.output_collapsed {
 
 div.out_prompt_overlay {
     height: 100%;
-    padding: 0px @code_padding;
+    padding: 0px 0px;
     position: absolute;
     .corner-all;
 }
@@ -45,7 +45,7 @@ div.output_prompt {
 div.output_area {
     padding: 0px;
     page-break-inside: avoid;
-    .hbox();
+    position: relative;
 
     .MathJax_Display {
         // Inside a CodeCell, elements are left justified
@@ -73,9 +73,10 @@ div.output_area {
 }
 
 @media (max-width: 480px) {
-    // move prompts above output on small screens
-    div.output_area {
-        .vbox();
+    // move prompts above code on small screens
+    div.output_subarea {
+        margin-left: 0px;
+        margin-right: 0px;
     }
 }
 
@@ -93,7 +94,8 @@ div.output_area pre {
    the prompt div. */
 div.output_subarea {
     padding: @code_padding @code_padding 0.0em @code_padding;
-    .box-flex1();
+    margin-left: 83px;
+    margin-right: auto;
 }
 
 /* The rest of the output_* classes are for special styling of the different

--- a/IPython/html/static/notebook/less/textcell.less
+++ b/IPython/html/static/notebook/less/textcell.less
@@ -1,6 +1,5 @@
 div.text_cell {
     padding: 5px 5px 5px 0px;
-    .hbox();
 }
 @media (max-width: 480px) {
     // remove prompt indentation on small screens

--- a/IPython/html/static/notebook/less/textcell.less
+++ b/IPython/html/static/notebook/less/textcell.less
@@ -33,3 +33,7 @@ h1,h2,h3,h4,h5,h6 {
 div.cell.text_cell.rendered {
     padding: 0px;
 }
+
+div.cell-padded {
+    position: relative;
+}

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -44,20 +44,20 @@ div.traceback-wrapper{text-align:left;max-width:800px;margin:auto}
 .ansibgpurple{background-color:#f0f}
 .ansibgcyan{background-color:#0ff}
 .ansibggray{background-color:#808080}
-div.cell{border:1px solid transparent;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}div.cell.selected{border-radius:4px;border:thin #ababab solid}
+div.cell{border:1px solid transparent}div.cell.selected{border-radius:4px;border:thin #ababab solid}
 div.cell.edit_mode{border-radius:4px;border:thin #008000 solid}
 div.cell{width:100%;padding:5px 5px 5px 0;margin:0;outline:none}
-div.prompt{min-width:11ex;padding:.4em;margin:0;font-family:monospace;text-align:right;line-height:1.21429em}
-@media (max-width:480px){div.prompt{text-align:left}}div.inner_cell{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}
-div.input_area{border:1px solid #cfcfcf;border-radius:4px;background:#f7f7f7;line-height:1.21429em}
+div.prompt{min-width:80px;float:left;padding-top:.4em;margin:0;font-family:monospace;text-align:right;line-height:1.21429em}
+div.inner_cell{margin-left:83px;margin-right:auto}
+@media (max-width:480px){div.prompt{float:none} div.inner_cell{margin-left:0;margin-right:0} div.prompt{text-align:left}}div.input_area{border:1px solid #cfcfcf;border-radius:4px;background:#f7f7f7;line-height:1.21429em}
 div.prompt:empty{padding-top:0;padding-bottom:0}
-div.input{page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}
-@media (max-width:480px){div.input{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}}div.input_prompt{color:#000080;border-top:1px solid transparent}
+div.input{page-break-inside:avoid}
+div.input_prompt{color:#000080;border-top:1px solid transparent}
 div.input_area>div.highlight{margin:.4em;border:none;padding:0;background-color:transparent}
 div.input_area>div.highlight>pre{margin:0;border:none;padding:0;background-color:transparent}
 .CodeMirror{line-height:1.21429em;height:auto;background:none;}
 .CodeMirror-scroll{overflow-y:hidden;overflow-x:auto}
-@-moz-document url-prefix(){.CodeMirror-scroll{overflow-x:hidden}}.CodeMirror-lines{padding:.4em}
+.CodeMirror-lines{padding:.4em}
 .CodeMirror-linenumber{padding:0 8px 0 4px}
 .CodeMirror-gutters{border-bottom-left-radius:4px;border-top-left-radius:4px}
 .CodeMirror pre{padding:0;border:0;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
@@ -144,7 +144,7 @@ p.p-space{margin-bottom:10px}
 .rendered_html *+p{margin-top:1em}
 .rendered_html img{display:block;margin-left:auto;margin-right:auto}
 .rendered_html *+img{margin-top:1em}
-div.text_cell{padding:5px 5px 5px 0;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}
+div.text_cell{padding:5px 5px 5px 0}
 @media (max-width:480px){div.text_cell>div.prompt{display:none}}div.text_cell_render{outline:none;resize:none;width:inherit;border-style:none;padding:.5em .5em .5em .4em;color:#000}
 a.anchor-link:link{text-decoration:none;padding:0 20px;visibility:hidden}
 h1:hover .anchor-link,h2:hover .anchor-link,h3:hover .anchor-link,h4:hover .anchor-link,h5:hover .anchor-link,h6:hover .anchor-link{visibility:visible}

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -44,10 +44,10 @@ div.traceback-wrapper{text-align:left;max-width:800px;margin:auto}
 .ansibgpurple{background-color:#f0f}
 .ansibgcyan{background-color:#0ff}
 .ansibggray{background-color:#808080}
-div.cell{border:1px solid transparent}div.cell.selected{border-radius:4px;border:thin #ababab solid}
+div.cell{border:1px solid transparent;width:100%;padding:5px 5px 5px 0;margin:0;outline:none}div.cell.selected{border-radius:4px;border:thin #ababab solid}
 div.cell.edit_mode{border-radius:4px;border:thin #008000 solid}
-div.cell{width:100%;padding:5px 5px 5px 0;margin:0;outline:none}
-div.prompt{min-width:80px;float:left;padding-top:.4em;margin:0;font-family:monospace;text-align:right;line-height:1.21429em}
+div.cell div.input{position:relative}
+div.prompt{min-width:80px;position:absolute;height:100%;margin:0;font-family:monospace;text-align:right;line-height:1.21429em}div.prompt div.prompt-text{padding-top:.4em}
 div.inner_cell{margin-left:83px;margin-right:auto}
 @media (max-width:480px){div.prompt{float:none} div.inner_cell{margin-left:0;margin-right:0} div.prompt{text-align:left}}div.input_area{border:1px solid #cfcfcf;border-radius:4px;background:#f7f7f7;line-height:1.21429em}
 div.prompt:empty{padding-top:0;padding-bottom:0}

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -44,7 +44,7 @@ div.traceback-wrapper{text-align:left;max-width:800px;margin:auto}
 .ansibgpurple{background-color:#f0f}
 .ansibgcyan{background-color:#0ff}
 .ansibggray{background-color:#808080}
-div.cell{border:1px solid transparent;width:100%;padding:5px 5px 5px 0;margin:0;outline:none}div.cell.selected{border-radius:4px;border:thin #ababab solid}
+div.cell{border:1px solid transparent;width:100%;padding:5px 5px 5px 0;margin:0;outline:none;position:relative}div.cell.selected{border-radius:4px;border:thin #ababab solid}
 div.cell.edit_mode{border-radius:4px;border:thin #008000 solid}
 div.cell div.input{position:relative}
 div.prompt{min-width:80px;position:absolute;height:100%;margin:0;font-family:monospace;text-align:right;line-height:1.21429em}div.prompt div.prompt-text{padding-top:.4em}

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -149,6 +149,7 @@ div.text_cell{padding:5px 5px 5px 0}
 a.anchor-link:link{text-decoration:none;padding:0 20px;visibility:hidden}
 h1:hover .anchor-link,h2:hover .anchor-link,h3:hover .anchor-link,h4:hover .anchor-link,h5:hover .anchor-link,h6:hover .anchor-link{visibility:visible}
 div.cell.text_cell.rendered{padding:0}
+div.cell-padded{position:relative}
 .widget-area{page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}.widget-area .widget-subarea{padding:.44em .4em .4em 1px;margin-left:6px;box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch;-webkit-box-flex:2;-moz-box-flex:2;box-flex:2;flex:2;-webkit-box-align:start;-moz-box-align:start;box-align:start;align-items:flex-start}
 .widget-hlabel{min-width:10ex;padding-right:8px;padding-top:3px;text-align:right;vertical-align:text-top}
 .widget-vlabel{padding-bottom:5px;text-align:center;vertical-align:text-bottom}

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -49,7 +49,7 @@ div.cell.edit_mode{border-radius:4px;border:thin #008000 solid}
 div.cell div.input{position:relative}
 div.prompt{min-width:80px;position:absolute;height:100%;margin:0;font-family:monospace;text-align:right;line-height:1.21429em}div.prompt div.prompt-text{padding-top:.4em}
 div.inner_cell{margin-left:83px;margin-right:auto}
-@media (max-width:480px){div.prompt{float:none} div.inner_cell{margin-left:0;margin-right:0} div.prompt{text-align:left}}div.input_area{border:1px solid #cfcfcf;border-radius:4px;background:#f7f7f7;line-height:1.21429em}
+@media (max-width:480px){div.prompt{position:relative} div.inner_cell{margin-left:0;margin-right:0} div.prompt{text-align:left}}div.input_area{border:1px solid #cfcfcf;border-radius:4px;background:#f7f7f7;line-height:1.21429em}
 div.prompt:empty{padding-top:0;padding-bottom:0}
 div.input{page-break-inside:avoid}
 div.input_prompt{color:#000080}div.input_prompt div.prompt-text{border-top:1px solid transparent}
@@ -85,15 +85,15 @@ pre .coffeescript .javascript,pre .javascript .xml,pre .tex .formula,pre .xml .j
 div.output_wrapper{position:relative;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}
 div.output_scroll{height:24em;width:100%;overflow:auto;border-radius:4px;-webkit-box-shadow:inset 0 2px 8px rgba(0,0,0,0.8);-moz-box-shadow:inset 0 2px 8px rgba(0,0,0,0.8);box-shadow:inset 0 2px 8px rgba(0,0,0,0.8);display:block}
 div.output_collapsed{margin:0;padding:0;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}
-div.out_prompt_overlay{height:100%;padding:0 .4em;position:absolute;border-radius:4px}
+div.out_prompt_overlay{height:100%;padding:0 0;position:absolute;border-radius:4px}
 div.out_prompt_overlay:hover{-webkit-box-shadow:inset 0 0 1px #000;-moz-box-shadow:inset 0 0 1px #000;box-shadow:inset 0 0 1px #000;background:rgba(240,240,240,0.5)}
 div.output_prompt{color:#8b0000}
-div.output_area{padding:0;page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}div.output_area .MathJax_Display{text-align:left !important}
+div.output_area{padding:0;page-break-inside:avoid;position:relative}div.output_area .MathJax_Display{text-align:left !important}
 div.output_area .rendered_html table{margin-left:0;margin-right:0}
 div.output_area .rendered_html img{margin-left:0;margin-right:0}
 .output{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}
-@media (max-width:480px){div.output_area{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}}div.output_area pre{margin:0;padding:0;border:0;vertical-align:baseline;color:#000;background-color:transparent;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
-div.output_subarea{padding:.4em .4em 0 .4em;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}
+@media (max-width:480px){div.output_subarea{margin-left:0;margin-right:0}}div.output_area pre{margin:0;padding:0;border:0;vertical-align:baseline;color:#000;background-color:transparent;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
+div.output_subarea{padding:.4em .4em 0 .4em;margin-left:83px;margin-right:auto}
 div.output_text{text-align:left;color:#000;line-height:1.21429em}
 div.output_stderr{background:#fdd;}
 div.output_latex{text-align:left}

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -52,7 +52,7 @@ div.inner_cell{margin-left:83px;margin-right:auto}
 @media (max-width:480px){div.prompt{float:none} div.inner_cell{margin-left:0;margin-right:0} div.prompt{text-align:left}}div.input_area{border:1px solid #cfcfcf;border-radius:4px;background:#f7f7f7;line-height:1.21429em}
 div.prompt:empty{padding-top:0;padding-bottom:0}
 div.input{page-break-inside:avoid}
-div.input_prompt{color:#000080;border-top:1px solid transparent}
+div.input_prompt{color:#000080}div.input_prompt div.prompt-text{border-top:1px solid transparent}
 div.input_area>div.highlight{margin:.4em;border:none;padding:0;background-color:transparent}
 div.input_area>div.highlight>pre{margin:0;border:none;padding:0;background-color:transparent}
 .CodeMirror{line-height:1.21429em;height:auto;background:none;}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1,7 +1,3 @@
-.clearfix{*zoom:1}.clearfix:before,.clearfix:after{display:table;content:"";line-height:0}
-.clearfix:after{clear:both}
-.hide-text{font:0/0 a;color:transparent;text-shadow:none;background-color:transparent;border:0}
-.input-block-level{display:block;width:100%;min-height:30px;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
 article,aside,details,figcaption,figure,footer,header,hgroup,nav,section{display:block}
 audio,canvas,video{display:inline-block;*display:inline;*zoom:1}
 audio:not([controls]){display:none}
@@ -856,6 +852,10 @@ a.label:hover,a.label:focus,a.badge:hover,a.badge:focus{color:#fff;text-decorati
 .show{display:block}
 .invisible{visibility:hidden}
 .affix{position:fixed}
+.clearfix{*zoom:1}.clearfix:before,.clearfix:after{display:table;content:"";line-height:0}
+.clearfix:after{clear:both}
+.hide-text{font:0/0 a;color:transparent;text-shadow:none;background-color:transparent;border:0}
+.input-block-level{display:block;width:100%;min-height:30px;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
 @-ms-viewport{width:device-width}.hidden{display:none;visibility:hidden}
 .visible-phone{display:none !important}
 .visible-tablet{display:none !important}
@@ -1349,20 +1349,20 @@ input.engine_num_input{width:60px}
 .ansibgpurple{background-color:#f0f}
 .ansibgcyan{background-color:#0ff}
 .ansibggray{background-color:#808080}
-div.cell{border:1px solid transparent;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}div.cell.selected{border-radius:4px;border:thin #ababab solid}
+div.cell{border:1px solid transparent}div.cell.selected{border-radius:4px;border:thin #ababab solid}
 div.cell.edit_mode{border-radius:4px;border:thin #008000 solid}
 div.cell{width:100%;padding:5px 5px 5px 0;margin:0;outline:none}
-div.prompt{min-width:11ex;padding:.4em;margin:0;font-family:monospace;text-align:right;line-height:1.21429em}
-@media (max-width:480px){div.prompt{text-align:left}}div.inner_cell{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}
-div.input_area{border:1px solid #cfcfcf;border-radius:4px;background:#f7f7f7;line-height:1.21429em}
+div.prompt{min-width:80px;float:left;padding-top:.4em;margin:0;font-family:monospace;text-align:right;line-height:1.21429em}
+div.inner_cell{margin-left:83px;margin-right:auto}
+@media (max-width:480px){div.prompt{float:none} div.inner_cell{margin-left:0;margin-right:0} div.prompt{text-align:left}}div.input_area{border:1px solid #cfcfcf;border-radius:4px;background:#f7f7f7;line-height:1.21429em}
 div.prompt:empty{padding-top:0;padding-bottom:0}
-div.input{page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}
-@media (max-width:480px){div.input{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}}div.input_prompt{color:#000080;border-top:1px solid transparent}
+div.input{page-break-inside:avoid}
+div.input_prompt{color:#000080;border-top:1px solid transparent}
 div.input_area>div.highlight{margin:.4em;border:none;padding:0;background-color:transparent}
 div.input_area>div.highlight>pre{margin:0;border:none;padding:0;background-color:transparent}
 .CodeMirror{line-height:1.21429em;height:auto;background:none;}
 .CodeMirror-scroll{overflow-y:hidden;overflow-x:auto}
-@-moz-document url-prefix(){.CodeMirror-scroll{overflow-x:hidden}}.CodeMirror-lines{padding:.4em}
+.CodeMirror-lines{padding:.4em}
 .CodeMirror-linenumber{padding:0 8px 0 4px}
 .CodeMirror-gutters{border-bottom-left-radius:4px;border-top-left-radius:4px}
 .CodeMirror pre{padding:0;border:0;border-radius:0;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
@@ -1449,7 +1449,7 @@ p.p-space{margin-bottom:10px}
 .rendered_html *+p{margin-top:1em}
 .rendered_html img{display:block;margin-left:auto;margin-right:auto}
 .rendered_html *+img{margin-top:1em}
-div.text_cell{padding:5px 5px 5px 0;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}
+div.text_cell{padding:5px 5px 5px 0}
 @media (max-width:480px){div.text_cell>div.prompt{display:none}}div.text_cell_render{outline:none;resize:none;width:inherit;border-style:none;padding:.5em .5em .5em .4em;color:#000}
 a.anchor-link:link{text-decoration:none;padding:0 20px;visibility:hidden}
 h1:hover .anchor-link,h2:hover .anchor-link,h3:hover .anchor-link,h4:hover .anchor-link,h5:hover .anchor-link,h6:hover .anchor-link{visibility:visible}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1,3 +1,7 @@
+.clearfix{*zoom:1}.clearfix:before,.clearfix:after{display:table;content:"";line-height:0}
+.clearfix:after{clear:both}
+.hide-text{font:0/0 a;color:transparent;text-shadow:none;background-color:transparent;border:0}
+.input-block-level{display:block;width:100%;min-height:30px;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
 article,aside,details,figcaption,figure,footer,header,hgroup,nav,section{display:block}
 audio,canvas,video{display:inline-block;*display:inline;*zoom:1}
 audio:not([controls]){display:none}
@@ -852,10 +856,6 @@ a.label:hover,a.label:focus,a.badge:hover,a.badge:focus{color:#fff;text-decorati
 .show{display:block}
 .invisible{visibility:hidden}
 .affix{position:fixed}
-.clearfix{*zoom:1}.clearfix:before,.clearfix:after{display:table;content:"";line-height:0}
-.clearfix:after{clear:both}
-.hide-text{font:0/0 a;color:transparent;text-shadow:none;background-color:transparent;border:0}
-.input-block-level{display:block;width:100%;min-height:30px;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
 @-ms-viewport{width:device-width}.hidden{display:none;visibility:hidden}
 .visible-phone{display:none !important}
 .visible-tablet{display:none !important}
@@ -1349,10 +1349,10 @@ input.engine_num_input{width:60px}
 .ansibgpurple{background-color:#f0f}
 .ansibgcyan{background-color:#0ff}
 .ansibggray{background-color:#808080}
-div.cell{border:1px solid transparent}div.cell.selected{border-radius:4px;border:thin #ababab solid}
+div.cell{border:1px solid transparent;width:100%;padding:5px 5px 5px 0;margin:0;outline:none}div.cell.selected{border-radius:4px;border:thin #ababab solid}
 div.cell.edit_mode{border-radius:4px;border:thin #008000 solid}
-div.cell{width:100%;padding:5px 5px 5px 0;margin:0;outline:none}
-div.prompt{min-width:80px;float:left;padding-top:.4em;margin:0;font-family:monospace;text-align:right;line-height:1.21429em}
+div.cell div.input{position:relative}
+div.prompt{min-width:80px;position:absolute;height:100%;margin:0;font-family:monospace;text-align:right;line-height:1.21429em}div.prompt div.prompt-text{padding-top:.4em}
 div.inner_cell{margin-left:83px;margin-right:auto}
 @media (max-width:480px){div.prompt{float:none} div.inner_cell{margin-left:0;margin-right:0} div.prompt{text-align:left}}div.input_area{border:1px solid #cfcfcf;border-radius:4px;background:#f7f7f7;line-height:1.21429em}
 div.prompt:empty{padding-top:0;padding-bottom:0}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1349,7 +1349,7 @@ input.engine_num_input{width:60px}
 .ansibgpurple{background-color:#f0f}
 .ansibgcyan{background-color:#0ff}
 .ansibggray{background-color:#808080}
-div.cell{border:1px solid transparent;width:100%;padding:5px 5px 5px 0;margin:0;outline:none}div.cell.selected{border-radius:4px;border:thin #ababab solid}
+div.cell{border:1px solid transparent;width:100%;padding:5px 5px 5px 0;margin:0;outline:none;position:relative}div.cell.selected{border-radius:4px;border:thin #ababab solid}
 div.cell.edit_mode{border-radius:4px;border:thin #008000 solid}
 div.cell div.input{position:relative}
 div.prompt{min-width:80px;position:absolute;height:100%;margin:0;font-family:monospace;text-align:right;line-height:1.21429em}div.prompt div.prompt-text{padding-top:.4em}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1357,7 +1357,7 @@ div.inner_cell{margin-left:83px;margin-right:auto}
 @media (max-width:480px){div.prompt{float:none} div.inner_cell{margin-left:0;margin-right:0} div.prompt{text-align:left}}div.input_area{border:1px solid #cfcfcf;border-radius:4px;background:#f7f7f7;line-height:1.21429em}
 div.prompt:empty{padding-top:0;padding-bottom:0}
 div.input{page-break-inside:avoid}
-div.input_prompt{color:#000080;border-top:1px solid transparent}
+div.input_prompt{color:#000080}div.input_prompt div.prompt-text{border-top:1px solid transparent}
 div.input_area>div.highlight{margin:.4em;border:none;padding:0;background-color:transparent}
 div.input_area>div.highlight>pre{margin:0;border:none;padding:0;background-color:transparent}
 .CodeMirror{line-height:1.21429em;height:auto;background:none;}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1354,7 +1354,7 @@ div.cell.edit_mode{border-radius:4px;border:thin #008000 solid}
 div.cell div.input{position:relative}
 div.prompt{min-width:80px;position:absolute;height:100%;margin:0;font-family:monospace;text-align:right;line-height:1.21429em}div.prompt div.prompt-text{padding-top:.4em}
 div.inner_cell{margin-left:83px;margin-right:auto}
-@media (max-width:480px){div.prompt{float:none} div.inner_cell{margin-left:0;margin-right:0} div.prompt{text-align:left}}div.input_area{border:1px solid #cfcfcf;border-radius:4px;background:#f7f7f7;line-height:1.21429em}
+@media (max-width:480px){div.prompt{position:relative} div.inner_cell{margin-left:0;margin-right:0} div.prompt{text-align:left}}div.input_area{border:1px solid #cfcfcf;border-radius:4px;background:#f7f7f7;line-height:1.21429em}
 div.prompt:empty{padding-top:0;padding-bottom:0}
 div.input{page-break-inside:avoid}
 div.input_prompt{color:#000080}div.input_prompt div.prompt-text{border-top:1px solid transparent}
@@ -1390,15 +1390,15 @@ pre .coffeescript .javascript,pre .javascript .xml,pre .tex .formula,pre .xml .j
 div.output_wrapper{position:relative;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}
 div.output_scroll{height:24em;width:100%;overflow:auto;border-radius:4px;-webkit-box-shadow:inset 0 2px 8px rgba(0,0,0,0.8);-moz-box-shadow:inset 0 2px 8px rgba(0,0,0,0.8);box-shadow:inset 0 2px 8px rgba(0,0,0,0.8);display:block}
 div.output_collapsed{margin:0;padding:0;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}
-div.out_prompt_overlay{height:100%;padding:0 .4em;position:absolute;border-radius:4px}
+div.out_prompt_overlay{height:100%;padding:0 0;position:absolute;border-radius:4px}
 div.out_prompt_overlay:hover{-webkit-box-shadow:inset 0 0 1px #000;-moz-box-shadow:inset 0 0 1px #000;box-shadow:inset 0 0 1px #000;background:rgba(240,240,240,0.5)}
 div.output_prompt{color:#8b0000}
-div.output_area{padding:0;page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}div.output_area .MathJax_Display{text-align:left !important}
+div.output_area{padding:0;page-break-inside:avoid;position:relative}div.output_area .MathJax_Display{text-align:left !important}
 div.output_area .rendered_html table{margin-left:0;margin-right:0}
 div.output_area .rendered_html img{margin-left:0;margin-right:0}
 .output{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}
-@media (max-width:480px){div.output_area{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}}div.output_area pre{margin:0;padding:0;border:0;vertical-align:baseline;color:#000;background-color:transparent;border-radius:0;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
-div.output_subarea{padding:.4em .4em 0 .4em;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}
+@media (max-width:480px){div.output_subarea{margin-left:0;margin-right:0}}div.output_area pre{margin:0;padding:0;border:0;vertical-align:baseline;color:#000;background-color:transparent;border-radius:0;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
+div.output_subarea{padding:.4em .4em 0 .4em;margin-left:83px;margin-right:auto}
 div.output_text{text-align:left;color:#000;line-height:1.21429em}
 div.output_stderr{background:#fdd;}
 div.output_latex{text-align:left}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1454,6 +1454,7 @@ div.text_cell{padding:5px 5px 5px 0}
 a.anchor-link:link{text-decoration:none;padding:0 20px;visibility:hidden}
 h1:hover .anchor-link,h2:hover .anchor-link,h3:hover .anchor-link,h4:hover .anchor-link,h5:hover .anchor-link,h6:hover .anchor-link{visibility:visible}
 div.cell.text_cell.rendered{padding:0}
+div.cell-padded{position:relative}
 .widget-area{page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}.widget-area .widget-subarea{padding:.44em .4em .4em 1px;margin-left:6px;box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch;-webkit-box-flex:2;-moz-box-flex:2;box-flex:2;flex:2;-webkit-box-align:start;-moz-box-align:start;box-align:start;align-items:flex-start}
 .widget-hlabel{min-width:10ex;padding-right:8px;padding-top:3px;text-align:right;vertical-align:text-top}
 .widget-vlabel{padding-bottom:5px;text-align:center;vertical-align:text-bottom}


### PR DESCRIPTION
closes #5364 
closes #5192
closes #5185
closes #5612
closes #5675
also doesn't re-introduce #3549

If accepted, this probably should be back-ported to the first 2.x patch.
