### PR TITLE
proposal: remove codename

### DIFF
--- a/IPython/core/release.py
+++ b/IPython/core/release.py
@@ -26,7 +26,8 @@ _version_extra = 'dev'
 # _version_extra = 'rc1'
 # _version_extra = ''  # Uncomment this for full releases
 
-codename = 'Work in Progress'
+# release.codename is deprecated in 2.0, will be removed in 3.0
+codename = ''
 
 # Construct full version string from these.
 _ver = [_version_major, _version_minor, _version_patch]

--- a/IPython/utils/sysinfo.py
+++ b/IPython/utils/sysinfo.py
@@ -82,7 +82,6 @@ def pkg_info(pkg_path):
     return dict(
         ipython_version=release.version,
         ipython_path=pkg_path,
-        codename=release.codename,
         commit_source=src,
         commit_hash=hsh,
         sys_version=sys.version,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,8 +95,7 @@ numpydoc_class_members_toctree = False
 # other places throughout the built documents.
 #
 # The full version, including alpha/beta/rc tags.
-codename = iprelease['codename']
-release = "%s: %s" % (iprelease['version'], codename)
+release = "%s" % iprelease['version']
 # Just the X.Y.Z part, no '-dev'
 version = iprelease['version'].split('-', 1)[0]
 


### PR DESCRIPTION
I'm not sure figuring out a silly codename for each release is worth anyone's time.

Since the RC is out and the release imminent and there hasn't been a proposal for 2.0, I think we can just remove it.
