### PR TITLE
check that a handler is actually registered in ShortcutManager.handles

### DIFF
--- a/IPython/html/static/base/js/keyboard.js
+++ b/IPython/html/static/base/js/keyboard.js
@@ -252,7 +252,7 @@ IPython.keyboard = (function (IPython) {
     ShortcutManager.prototype.handles = function (event) {
         var shortcut = event_to_shortcut(event);
         var data = this._shortcuts[shortcut];
-        return !( data === undefined )
+        return !( data === undefined || data.handler === undefined )
     }
 
     return {


### PR DESCRIPTION
there are a few shortcuts that do not specify handlers (just for quick help contents), and this was preventing the actual events from ever firing.

closes #5448
