### PR TITLE
Add support for PyQt5.

### DIFF
--- a/IPython/external/qt.py
+++ b/IPython/external/qt.py
@@ -1,22 +1,22 @@
-""" A Qt API selector that can be used to switch between PyQt and PySide.
+""" A Qt API selector that can be used to switch between PyQt4/5 and PySide.
 
 This uses the ETS 4.0 selection pattern of:
-PySide first, PyQt with API v2. second.
+PySide first, PyQt4 (API v2.) second, then PyQt5.
 
-Do not use this if you need PyQt with the old QString/QVariant API.
+Do not use this if you need PyQt4 with the old QString/QVariant API.
 """
 
 import os
 
 from IPython.external.qt_loaders import (load_qt, QT_API_PYSIDE,
-                                         QT_API_PYQT)
+                                         QT_API_PYQT, QT_API_PYQT5)
 
 QT_API = os.environ.get('QT_API', None)
-if QT_API not in [QT_API_PYSIDE, QT_API_PYQT, None]:
-    raise RuntimeError("Invalid Qt API %r, valid values are: %r, %r" %
-                       (QT_API, QT_API_PYSIDE, QT_API_PYQT))
+if QT_API not in [QT_API_PYSIDE, QT_API_PYQT, QT_API_PYQT5, None]:
+    raise RuntimeError("Invalid Qt API %r, valid values are: %r, %r, %r" %
+                       (QT_API, QT_API_PYSIDE, QT_API_PYQT, QT_API_PYQT5))
 if QT_API is None:
-    api_opts = [QT_API_PYSIDE, QT_API_PYQT]
+    api_opts = [QT_API_PYSIDE, QT_API_PYQT, QT_API_PYQT5]
 else:
     api_opts = [QT_API]
 

--- a/IPython/kernel/inprocess/channels.py
+++ b/IPython/kernel/inprocess/channels.py
@@ -28,7 +28,7 @@ class InProcessChannel(object):
     """Base class for in-process channels."""
     proxy_methods = []
 
-    def __init__(self, client):
+    def __init__(self, client=None):
         super(InProcessChannel, self).__init__()
         self.client = client
         self._is_alive = False


### PR DESCRIPTION
This PR adds the new `QT_API_PYQT5` to `IPython/external/qt_loaders.py` and allows to embed the IPython console in Qt5 Applications. In case of PyQt5, the loader returns a union of `PyQt5.QtGui` and `PyQt5.QtWidgets` acting as a Qt4-QtGui compatibility module.

One small fix to `InProcessChannel.__init__` was necessary though. For some reason, when constructing `QtInProcessShellChannel`, the `QtCore.QObject.__init__` initializer from `SuperQObject` indirectly calls the `InProcessChannel.__init__` function, which doesn't have a default constructor and thus fails. I assume this has something to do with the metaclass/multiple inheritance approach IPython uses on QObject. Adding a default value for `client` in `InProcessChannel.__init__` solved the problem for me.
