### PR TITLE
Fix interact animation page jump FF

### DIFF
--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -293,14 +293,18 @@ var IPython = (function (IPython) {
         
         this.outputs.push(json);
         
-        // Only reset the height to automatic if the height is currently
-        // fixed (done by wait=True flag on clear_output).
-        if (needs_height_reset) {
-            this.element.height('');    
-        }
-
+        // We must release the animation fixed height in a timeout since Gecko
+        // (FireFox) doesn't render the image immediately as the data is 
+        // available.
         var that = this;
-        setTimeout(function(){that.element.trigger('resize');}, 100);
+        setTimeout(function(){
+            // Only reset the height to automatic if the height is currently
+            // fixed (done by wait=True flag on clear_output).
+            if (needs_height_reset) {
+                that.element.height('');    
+            }
+            that.element.trigger('resize');
+        }, 250);
     };
 
 

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -632,8 +632,8 @@ var IPython = (function (IPython) {
         var type = 'image/png';
         var toinsert = this.create_output_subarea(md, "output_png", type);
         var img = $("<img/>").attr('src','data:image/png;base64,'+png);
-        if (handle_inserted !== undefined) {           
-            img.load(handle_inserted);
+        if (handle_inserted !== undefined) {      
+            img.on('load', handle_inserted);
         }
         set_width_height(img, md, 'image/png');
         this._dblclick_to_reset_size(img);
@@ -648,7 +648,7 @@ var IPython = (function (IPython) {
         var toinsert = this.create_output_subarea(md, "output_jpeg", type);
         var img = $("<img/>").attr('src','data:image/jpeg;base64,'+jpeg);
         if (handle_inserted !== undefined) {           
-            img.load(handle_inserted);
+            img.on('load', handle_inserted);
         }
         set_width_height(img, md, 'image/jpeg');
         this._dblclick_to_reset_size(img);
@@ -771,7 +771,9 @@ var IPython = (function (IPython) {
                 this.clear_queued = false;
             }
             
-            // clear all, no need for logic
+            // clear all
+            // Remove onload event listeners on child img elements.
+            this.element.find('img').off('load');
             this.element.html("");
             this.outputs = [];
             this.trusted = true;

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -274,9 +274,6 @@ var IPython = (function (IPython) {
         
         // validate output data types
         json = this.validate_output(json);
-        // TODO: Why are we recieving these new line characters for no 
-        // reason?  They ruin everything.
-        if (json.output_type === 'stream' && !json.text.trim()) return;
 
         // Clear the output if clear is queued.
         var needs_height_reset = false;

--- a/IPython/kernel/zmq/zmqshell.py
+++ b/IPython/kernel/zmq/zmqshell.py
@@ -90,11 +90,7 @@ class ZMQDisplayPublisher(DisplayPublisher):
 
     def clear_output(self, wait=False):
         content = dict(wait=wait)
-
-        print('\r', file=sys.stdout, end='')
-        print('\r', file=sys.stderr, end='')
         self._flush_streams()
-        
         self.session.send(
             self.pub_socket, u'clear_output', content,
             parent=self.parent_header, ident=self.topic,

--- a/IPython/qt/console/frontend_widget.py
+++ b/IPython/qt/console/frontend_widget.py
@@ -197,6 +197,9 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         self._local_kernel = kw.get('local_kernel',
                                     FrontendWidget._local_kernel)
 
+        # Whether or not a clear_output call is pending new output.
+        self._pending_clearoutput = False
+
     #---------------------------------------------------------------------------
     # 'ConsoleWidget' public interface
     #---------------------------------------------------------------------------
@@ -339,6 +342,14 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
     #---------------------------------------------------------------------------
     # 'BaseFrontendMixin' abstract interface
     #---------------------------------------------------------------------------
+    def _handle_clear_output(self, msg):
+        """Handle clear output messages."""
+        if not self._hidden and self._is_from_this_session(msg):
+            wait = msg['content'].get('wait', True)
+            if wait:
+                self._pending_clearoutput = True
+            else:
+                self.clear_output()
 
     def _handle_complete_reply(self, rep):
         """ Handle replies for tab completion.
@@ -520,6 +531,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         """
         self.log.debug("pyout: %s", msg.get('content', ''))
         if not self._hidden and self._is_from_this_session(msg):
+            self.flush_clearoutput()
             text = msg['content']['data']
             self._append_plain_text(text + '\n', before_prompt=True)
 
@@ -528,13 +540,8 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         """
         self.log.debug("stream: %s", msg.get('content', ''))
         if not self._hidden and self._is_from_this_session(msg):
-            # Most consoles treat tabs as being 8 space characters. Convert tabs
-            # to spaces so that output looks as expected regardless of this
-            # widget's tab width.
-            text = msg['content']['data'].expandtabs(8)
-
-            self._append_plain_text(text, before_prompt=True)
-            self._control.moveCursor(QtGui.QTextCursor.End)
+            self.flush_clearoutput()
+            self.append_stream(msg['content']['data'])
 
     def _handle_shutdown_reply(self, msg):
         """ Handle shutdown signal, only if from other console.
@@ -684,6 +691,31 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
                 'Cannot restart a Kernel I did not start\n',
                 before_prompt=True
             )
+
+    def append_stream(self, text):
+        """Appends text to the output stream."""
+        # Most consoles treat tabs as being 8 space characters. Convert tabs
+        # to spaces so that output looks as expected regardless of this
+        # widget's tab width.
+        text = text.expandtabs(8)
+
+        print([ord(c) for c in text])
+        self._append_plain_text(text, before_prompt=True)
+        self._control.moveCursor(QtGui.QTextCursor.End)
+
+    def flush_clearoutput(self):
+        """If a clearoutput is pending, execute it."""
+        if self._pending_clearoutput:
+            self._pending_clearoutput = False
+            self.clear_output()
+
+    def clear_output(self):
+        """Clear the output area."""
+        cursor = self._control.textCursor()
+        cursor.beginEditBlock()
+        cursor.movePosition(cursor.StartOfLine, cursor.KeepAnchor)
+        cursor.insertText('')
+        cursor.endEditBlock()
 
     #---------------------------------------------------------------------------
     # 'FrontendWidget' protected interface

--- a/IPython/qt/console/frontend_widget.py
+++ b/IPython/qt/console/frontend_widget.py
@@ -698,8 +698,6 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         # to spaces so that output looks as expected regardless of this
         # widget's tab width.
         text = text.expandtabs(8)
-
-        print([ord(c) for c in text])
         self._append_plain_text(text, before_prompt=True)
         self._control.moveCursor(QtGui.QTextCursor.End)
 
@@ -710,7 +708,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
             self.clear_output()
 
     def clear_output(self):
-        """Clear the output area."""
+        """Clears the current line of output."""
         cursor = self._control.textCursor()
         cursor.beginEditBlock()
         cursor.movePosition(cursor.StartOfLine, cursor.KeepAnchor)

--- a/IPython/qt/console/ipython_widget.py
+++ b/IPython/qt/console/ipython_widget.py
@@ -140,7 +140,6 @@ class IPythonWidget(FrontendWidget):
     #---------------------------------------------------------------------------
     # 'BaseFrontendMixin' abstract interface
     #---------------------------------------------------------------------------
-
     def _handle_complete_reply(self, rep):
         """ Reimplemented to support IPython's improved completion machinery.
         """
@@ -223,6 +222,7 @@ class IPythonWidget(FrontendWidget):
         """
         self.log.debug("pyout: %s", msg.get('content', ''))
         if not self._hidden and self._is_from_this_session(msg):
+            self.flush_clearoutput()
             content = msg['content']
             prompt_number = content.get('execution_count', 0)
             data = content['data']
@@ -250,6 +250,7 @@ class IPythonWidget(FrontendWidget):
         # eventually will as this allows all frontends to monitor the display
         # data. But we need to figure out how to handle this in the GUI.
         if not self._hidden and self._is_from_this_session(msg):
+            self.flush_clearoutput()
             source = msg['content']['source']
             data = msg['content']['data']
             metadata = msg['content']['metadata']

--- a/IPython/qt/console/rich_ipython_widget.py
+++ b/IPython/qt/console/rich_ipython_widget.py
@@ -114,6 +114,7 @@ class RichIPythonWidget(IPythonWidget):
         """ Overridden to handle rich data types, like SVG.
         """
         if not self._hidden and self._is_from_this_session(msg):
+            self.flush_clearoutput()
             content = msg['content']
             prompt_number = content.get('execution_count', 0)
             data = content['data']
@@ -140,6 +141,7 @@ class RichIPythonWidget(IPythonWidget):
         """ Overridden to handle rich data types, like SVG.
         """
         if not self._hidden and self._is_from_this_session(msg):
+            self.flush_clearoutput()
             source = msg['content']['source']
             data = msg['content']['data']
             metadata = msg['content']['metadata']


### PR DESCRIPTION
Firefox doesn't render images immediately as the data is available.  When animating the way that we animate, this causes the output area to collapse quickly before returning to its original size.  When the output area collapses, FireFox scrolls upwards in attempt to compensate for the lost vertical content (so it looks like you are on the same spot in the page, with respect to the contents below the image's prior location).  The solution is to resize the image output after the `img onload` event has fired.

This PR:
- Releases the `clear_output` height lock after the image has been loaded (instead of immediately or using a timeout).
- Removes a `setTimeout` call in the `append_output` method.
- `clear_output` in zmqshell no longer sends `\r` to the stream outputs.

closes #5128
