### PR TITLE
Minor corrections of git-hooks setup instructions

### DIFF
--- a/git-hooks/README.md
+++ b/git-hooks/README.md
@@ -7,7 +7,8 @@ both of which just update submodules,
 so make sure that you have a fully synced repo whenever you checkout or pull.
 
 To use these hooks, you can symlink or copy them to your `.git/hooks` directory.
+In `.git/hooks`, do:
 
-    ln -s ../../git-hooks/post-checkout .git/hooks/post-checkout
-    ln -s ../../git-hooks/post-merge .git/hooks/post-merge
+    ln -s ../../git-hooks/post-checkout post-checkout
+    ln -s ../../git-hooks/post-merge post-merge
 


### PR DESCRIPTION
Previously the arguments to the `ln` commands are contradicting, no matter in which directory the commands are executed. This minor fix assumes they are to be executed in `.git/hooks` and clarifies that.
