### PR TITLE
For 2.0: Fix links in Notebook Help Menu

### DIFF
--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -227,7 +227,6 @@ class="notebook_app"
                         (
                             ("http://ipython.org/documentation.html","IPython Help",True),
                             ("http://nbviewer.ipython.org/github/ipython/ipython/tree/master/examples/Index.ipynb", "Notebook Help", True),
-                            ("http://ipython.org/ipython-doc/2/notebook/cm_keyboard.html","Editor Shortcuts",True),
                         ),(
                             ("http://docs.python.org","Python",True),
                             ("http://docs.scipy.org/doc/numpy/reference/","NumPy",True),

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -226,8 +226,7 @@ class="notebook_app"
                     sections = (
                         (
                             ("http://ipython.org/documentation.html","IPython Help",True),
-                            ("http://nbviewer.ipython.org/github/ipython/ipython/tree/master/examples/notebooks/", "Notebook Examples", True),
-                            ("http://ipython.org/ipython-doc/2/notebook/notebook.html","Notebook Help",True),
+                            ("http://nbviewer.ipython.org/github/ipython/ipython/tree/master/examples/Index.ipynb", "Notebook Help", True),
                             ("http://ipython.org/ipython-doc/2/notebook/cm_keyboard.html","Editor Shortcuts",True),
                         ),(
                             ("http://docs.python.org","Python",True),

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -226,7 +226,7 @@ class="notebook_app"
                     sections = (
                         (
                             ("http://ipython.org/documentation.html","IPython Help",True),
-                            ("http://nbviewer.ipython.org/github/ipython/ipython/tree/master/examples/Index.ipynb", "Notebook Help", True),
+                            ("http://nbviewer.ipython.org/github/ipython/ipython/tree/2.x/examples/Index.ipynb", "Notebook Help", True),
                         ),(
                             ("http://docs.python.org","Python",True),
                             ("http://docs.scipy.org/doc/numpy/reference/","NumPy",True),


### PR DESCRIPTION
We need to update some of the links in the Help Menu before 2.0. This does that, but the links won't work until after #5337 is merged.
