### PR TITLE
Mixed gfm/latex parsing in codemirror

### DIFF
--- a/IPython/html/static/notebook/js/codemirror-ipythongfm.js
+++ b/IPython/html/static/notebook/js/codemirror-ipythongfm.js
@@ -1,0 +1,45 @@
+// IPython GFM (GitHub Flavored Markdown) mode is just a slightly altered GFM 
+// Mode with support for latex. 
+//
+// Latex support was supported by Codemirror GFM as of 
+//   https://github.com/marijnh/CodeMirror/pull/567
+// But was later removed in
+//   https://github.com/marijnh/CodeMirror/commit/d9c9f1b1ffe984aee41307f3e927f80d1f23590c
+
+CodeMirror.requireMode('gfm', function(){ 
+    CodeMirror.requireMode('stex', function(){ 
+        console.log('defining custom mode...');
+        CodeMirror.defineMode("ipythongfm", function(config, parserConfig) {
+            
+            var gfm_mode = CodeMirror.getMode(config, "gfm");
+            var tex_mode = CodeMirror.getMode(config, "stex");
+            
+            return CodeMirror.multiplexingMode(
+                gfm_mode,
+                {
+                    open: "$", close: "$",
+                    mode: tex_mode,
+                    delimStyle: "delimit"
+                },
+                {
+                    open: "$$", close: "$$",
+                    mode: tex_mode,
+                    delimStyle: "delimit"
+                },
+                {
+                    open: "\\(", close: "\\)",
+                    mode: tex_mode,
+                    delimStyle: "delimit"
+                },
+                {
+                    open: "\\[", close: "\\]",
+                    mode: tex_mode,
+                    delimStyle: "delimit"
+                }
+                // .. more multiplexed styles can follow here
+            );
+        }, 'gfm');
+        
+        CodeMirror.defineMIME("text/x-ipythongfm", "ipythongfm");
+    });
+});

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -234,7 +234,7 @@ var IPython = (function (IPython) {
 
     MarkdownCell.options_default = {
         cm_config: {
-            mode: 'gfm'
+            mode: 'ipythongfm'
         },
         placeholder: "Type *Markdown* and LaTeX: $\\alpha^2$"
     };

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -313,7 +313,6 @@ class="notebook_app"
 <script src="{{ static_url("components/codemirror/mode/css/css.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("components/codemirror/mode/rst/rst.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("components/codemirror/mode/markdown/markdown.js") }}" charset="utf-8"></script>
-<script src="{{ static_url("components/codemirror/mode/gfm/gfm.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("components/codemirror/mode/python/python.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("notebook/js/codemirror-ipython.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("notebook/js/codemirror-ipythongfm.js") }}" charset="utf-8"></script>

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -316,6 +316,7 @@ class="notebook_app"
 <script src="{{ static_url("components/codemirror/mode/gfm/gfm.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("components/codemirror/mode/python/python.js") }}" charset="utf-8"></script>
 <script src="{{ static_url("notebook/js/codemirror-ipython.js") }}" charset="utf-8"></script>
+<script src="{{ static_url("notebook/js/codemirror-ipythongfm.js") }}" charset="utf-8"></script>
 
 <script src="{{ static_url("components/highlight.js/build/highlight.pack.js") }}" charset="utf-8"></script>
 


### PR DESCRIPTION
Adds support for latex syntax highlighting within markdown cells.

Closes #5135
Closes #2798
