### PR TITLE
remove weird unicode space in the new copyright header

### DIFF
--- a/COPYING.rst
+++ b/COPYING.rst
@@ -70,5 +70,5 @@ to indicate the copyright and license terms:
 
 ::
 
-    # Copyright (c) IPython Development Team.
-    # Distributed under the terms of the Modified BSD License.
+    # Copyright (c) IPython Development Team.
+    # Distributed under the terms of the Modified BSD License.

--- a/IPython/html/static/notebook/js/quickhelp.js
+++ b/IPython/html/static/notebook/js/quickhelp.js
@@ -1,5 +1,5 @@
-// Copyright (c) IPython Development Team.
-// Distributed under the terms of the Modified BSD License.
+// Copyright (c) IPython Development Team.
+// Distributed under the terms of the Modified BSD License.
 
 //============================================================================
 // QuickHelp button


### PR DESCRIPTION
The bytes were actually:

```
#\xe2\x80\x82Copyright...
```
