### PR TITLE
Added missing require and jquery from cdn.

### DIFF
--- a/IPython/nbconvert/templates/html/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/html/slides_reveal.tpl
@@ -110,9 +110,6 @@ html {
 div.input_area {
   padding: 0.06em;
 }
-div.input_area>div.highlight>pre {
-  font-size: 80%;
-}
 div.code_cell {
   background-color: transparent;
 }

--- a/IPython/nbconvert/templates/html/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/html/slides_reveal.tpl
@@ -45,6 +45,9 @@
 
 <title>{{resources['metadata']['name']}} slides</title>
 
+<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+
 <!-- General and theme style sheets -->
 <link rel="stylesheet" href="{{resources.reveal.url_prefix}}/css/reveal.css">
 <link rel="stylesheet" href="{{resources.reveal.url_prefix}}/css/theme/simple.css" id="theme">
@@ -106,6 +109,9 @@ html {
 }
 div.input_area {
   padding: 0.06em;
+}
+div.input_area>div.highlight>pre {
+  font-size: 80%;
 }
 div.code_cell {
   background-color: transparent;


### PR DESCRIPTION
For some reason (I suppose some changes at the css level) the font size inside the input cells was fixed at 14 px... making the fonts really small in the reveal slideshows. This is really annoying... 
As a plus, I have also added the missing calls for require and jquery (as the full html template does).
I think these fixes belong to 2.0, but I also know we are on the edge... so I hope to get it inside :wink: 

Cheers.
