### PR TITLE
Fix required Python versions

### DIFF
--- a/docs/source/whatsnew/version2.0.rst
+++ b/docs/source/whatsnew/version2.0.rst
@@ -7,8 +7,8 @@ Release 2.0.0
 
 April, 2014
 
-IPython 2.0 requires Python ≥ 2.7.2 or ≥ 3.2.1.
-It does not support Python 3.0, 3.1, 2.5, or 2.6.
+IPython 2.0 requires Python ≥ 2.7.2 or ≥ 3.3.0.
+It does not support Python 3.0, 3.1, 3.2, 2.5, or 2.6.
 
 The principal milestones of 2.0 are:
 


### PR DESCRIPTION
It seems there's been a small inconsistency in documentation, which mentions Python 3.2.1 as minimum requirement for IPython 2.0. I've changed it to 3.3.0 - I don't know if there's 0 for minor version is sufficient, feel free to adjust it.
