### PR TITLE
remove inappropriate wheel tag override

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -626,9 +626,6 @@ def get_bdist_wheel():
         
         class bdist_wheel_tag(bdist_wheel):
 
-            def get_tag(self):
-                return ('py%i' % sys.version_info[0], 'none', 'any')
-
             def add_requirements(self, metadata_path):
                 """transform platform-dependent requirements"""
                 pkg_info = read_pkg_info(metadata_path)


### PR DESCRIPTION
I misunderstood how these tags are interpreted. We do not want `py2` and `py3`, we want `py27` and `py33`, which indicate >= matching in the minor version.

This means we should build wheels with the minimum supported Python.
