### PR TITLE
fix iteration over Client

### DIFF
--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -921,7 +921,16 @@ class Client(HasTraits):
             raise TypeError("key by int/slice/iterable of ints only, not %s"%(type(key)))
         else:
             return self.direct_view(key)
-
+    
+    def __iter__(self):
+        """Since we define getitem, Client is iterable
+        
+        but unless we also define __iter__, it won't work correctly unless engine IDs
+        start at zero and are continuous.
+        """
+        for eid in self.ids:
+            yield self.direct_view(eid)
+    
     #--------------------------------------------------------------------------
     # Begin public methods
     #--------------------------------------------------------------------------

--- a/IPython/parallel/tests/test_client.py
+++ b/IPython/parallel/tests/test_client.py
@@ -41,6 +41,11 @@ class TestClient(ClusterTestCase):
         self.add_engines(2)
         self.assertEqual(len(self.client.ids), n+2)
     
+    def test_iter(self):
+        self.minimum_engines(4)
+        engine_ids = [ view.targets for view in self.client ]
+        self.assertEqual(engine_ids, self.client.ids)
+    
     def test_view_indexing(self):
         """test index access for views"""
         self.minimum_engines(4)


### PR DESCRIPTION
I didn't intend for Client to be iterable, but defining `__getitem__` makes it iterable as long as engine IDs are continuous (not always the case).

This explicitly defines `__iter__` so it behaves consistently.

closes #5519
