### PR TITLE
fix n^2 performance issue in coalesce_streams preprocessor

### DIFF
--- a/IPython/html/nbconvert/tests/test_nbconvert_handlers.py
+++ b/IPython/html/nbconvert/tests/test_nbconvert_handlers.py
@@ -58,7 +58,7 @@ class APITest(NotebookTestBase):
         nb.worksheets = [ws]
         ws.cells.append(new_heading_cell(u'Created by test ³'))
         cc1 = new_code_cell(input=u'print(2*6)')
-        cc1.outputs.append(new_output(output_text=u'12'))
+        cc1.outputs.append(new_output(output_text=u'12', output_type='stream'))
         cc1.outputs.append(new_output(output_png=png_green_pixel, output_type='pyout'))
         ws.cells.append(cc1)
         

--- a/IPython/nbconvert/preprocessors/coalescestreams.py
+++ b/IPython/nbconvert/preprocessors/coalescestreams.py
@@ -1,23 +1,10 @@
-"""Module that allows latex output notebooks to be conditioned before
-they are converted.  Exposes a decorator (@cell_preprocessor) in
-addition to the coalesce_streams pre-proccessor.
-"""
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, the IPython Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
+"""Preprocessor for merging consecutive stream outputs for easier handling."""
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 import re
 
-#-----------------------------------------------------------------------------
-# Functions
-#-----------------------------------------------------------------------------
 def cell_preprocessor(function):
     """
     Wrap a function to be executed on all cells of a notebook
@@ -34,7 +21,12 @@ def cell_preprocessor(function):
     """
     
     def wrappedfunc(nb, resources):
-        for worksheet in nb.worksheets :
+        from IPython.config import Application
+        if Application.initialized():
+            Application.instance().log.debug(
+                "Applying preprocessor: %s", function.__name__
+            )
+        for worksheet in nb.worksheets:
             for index, cell in enumerate(worksheet.cells):
                 worksheet.cells[index], resources = function(cell, resources, index)
         return nb, resources

--- a/IPython/nbformat/v3/nbbase.py
+++ b/IPython/nbformat/v3/nbbase.py
@@ -4,22 +4,10 @@ The Python representation of a notebook is a nested structure of
 dictionary subclasses that support attribute access
 (IPython.utils.ipstruct.Struct). The functions in this module are merely
 helpers to build the structs in the right form.
-
-Authors:
-
-* Brian Granger
 """
 
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2011  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 import pprint
 import uuid
@@ -51,15 +39,14 @@ def from_dict(d):
         return d
 
 
-def new_output(output_type=None, output_text=None, output_png=None,
+def new_output(output_type, output_text=None, output_png=None,
     output_html=None, output_svg=None, output_latex=None, output_json=None,
     output_javascript=None, output_jpeg=None, prompt_number=None,
     ename=None, evalue=None, traceback=None, stream=None, metadata=None):
     """Create a new output, to go in the ``cell.outputs`` list of a code cell.
     """
     output = NotebookNode()
-    if output_type is not None:
-        output.output_type = unicode_type(output_type)
+    output.output_type = unicode_type(output_type)
 
     if metadata is None:
         metadata = {}

--- a/IPython/nbformat/v3/tests/test_nbbase.py
+++ b/IPython/nbformat/v3/tests/test_nbbase.py
@@ -143,15 +143,15 @@ class TestMetadata(TestCase):
 
 class TestOutputs(TestCase):
     def test_binary_png(self):
-        out = new_output(output_png=b'\x89PNG\r\n\x1a\n')
+        out = new_output(output_png=b'\x89PNG\r\n\x1a\n', output_type='display_data')
 
     def test_b64b6tes_png(self):
-        out = new_output(output_png=b'iVBORw0KG')
+        out = new_output(output_png=b'iVBORw0KG', output_type='display_data')
     
     def test_binary_jpeg(self):
-        out = new_output(output_jpeg=b'\xff\xd8')
+        out = new_output(output_jpeg=b'\xff\xd8', output_type='display_data')
 
     def test_b64b6tes_jpeg(self):
-        out = new_output(output_jpeg=b'/9')
+        out = new_output(output_jpeg=b'/9', output_type='display_data')
         
 


### PR DESCRIPTION
for n consecutive stream outputs, `\r` fix would be compiled n times, and applied to each ith output (n-i) times.
- move pattern to module level
- apply replacement after coalescing outputs

An example notebook from nbviewer with ~1k outputs that was taking 90 seconds to render now takes 3 seconds.
