### PR TITLE
Minor typo fix in "Cython Magics.ipynb"

### DIFF
--- a/examples/Builtin Extensions/Cython Magics.ipynb
+++ b/examples/Builtin Extensions/Cython Magics.ipynb
@@ -27,7 +27,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "IPtyhon has a `cythonmagic` extension that contains a number of magic functions for working with Cython code. This extension can be loaded using the `%load_ext` magic as follows:"
+      "IPython has a `cythonmagic` extension that contains a number of magic functions for working with Cython code. This extension can be loaded using the `%load_ext` magic as follows:"
      ]
     },
     {


### PR DESCRIPTION
`IPtyhon` -> `IPython`
