### PR TITLE
add ipython[terminal] dependency group

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -285,9 +285,7 @@ install_requires = []
 if sys.platform == 'darwin':
     if any(arg.startswith('bdist') for arg in sys.argv) or not setupext.check_for_readline():
         install_requires.append('gnureadline')
-elif sys.platform.startswith('win'):
-    # Pyreadline has unicode and Python 3 fixes in 2.0
-    install_requires.append('pyreadline>=2.0')
+
 
 if 'setuptools' in sys.modules:
     # setup.py develop should check for submodules

--- a/setup.py
+++ b/setup.py
@@ -270,6 +270,7 @@ extras_require = dict(
     zmq = ['pyzmq>=2.1.11'],
     doc = ['Sphinx>=1.1', 'numpydoc'],
     test = ['nose>=0.10.1'],
+    terminal = [],
     notebook = ['tornado>=3.1', 'pyzmq>=2.1.11', 'jinja2'],
     nbconvert = ['pygments', 'jinja2', 'Sphinx>=0.3']
 )
@@ -282,9 +283,13 @@ for deps in extras_require.values():
 extras_require['all'] = everything
 
 install_requires = []
+
+# add readline
 if sys.platform == 'darwin':
     if any(arg.startswith('bdist') for arg in sys.argv) or not setupext.check_for_readline():
         install_requires.append('gnureadline')
+elif sys.platform.startswith('win'):
+    extras_require['terminal'].append('pyreadline>=2.0')
 
 
 if 'setuptools' in sys.modules:

--- a/setupbase.py
+++ b/setupbase.py
@@ -8,18 +8,12 @@ This includes:
     * Functions for finding things like packages, package data, etc.
     * A function for checking dependencies.
 """
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 from __future__ import print_function
 
-#-------------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-------------------------------------------------------------------------------
-
-#-------------------------------------------------------------------------------
-# Imports
-#-------------------------------------------------------------------------------
 import errno
 import os
 import sys
@@ -647,7 +641,8 @@ def get_bdist_wheel():
                 for pkg in ("gnureadline", "pyreadline", "mock"):
                     _remove_startswith(requires, pkg)
                 requires.append("gnureadline; sys.platform == 'darwin' and platform.python_implementation == 'CPython'")
-                requires.append("pyreadline (>=2.0); sys.platform == 'win32' and platform.python_implementation == 'CPython'")
+                requires.append("pyreadline (>=2.0); extra == 'terminal' and sys.platform == 'win32' and platform.python_implementation == 'CPython'")
+                requires.append("pyreadline (>=2.0); extra == 'all' and sys.platform == 'win32' and platform.python_implementation == 'CPython'")
                 requires.append("mock; extra == 'test' and python_version < '3.3'")
                 for r in requires:
                     pkg_info['Requires-Dist'] = r


### PR DESCRIPTION
for gnureadline on OS X and pyreadline on Windows.

These will _not_ be installed by default anymore. There will no longer be any checks for dependencies in entry points.

This is a proposal for discussion.

Reasons not to do it, or at least partially:
- many more OS X users actually use the terminal, which is essentially unusable with libedit (Python.org or System Python)
- most people don't understand optional dependency groups in setuptools

supersedes #5440
