### PR TITLE
only process cr if it's found

### DIFF
--- a/IPython/nbconvert/preprocessors/coalescestreams.py
+++ b/IPython/nbconvert/preprocessors/coalescestreams.py
@@ -70,7 +70,7 @@ def coalesce_streams(cell, resources, index):
     
     # process \r characters
     for output in new_outputs:
-        if output.output_type == 'stream':
+        if output.output_type == 'stream' and '\r' in output.text:
             output.text = cr_pat.sub('', output.text)
 
     cell.outputs = new_outputs


### PR DESCRIPTION
because re.sub is crazy slow.

I found [a notebook](https://github.com/pysal/pPysal/blob/master/weights/two_stage.ipynb) that takes about a minute to render in master, and 2s with this PR.

I think this is why nbviewer is still having issues, so I think we should merge this ASAP.
