### PR TITLE
Fix rmagic for cells ending in comment.

### DIFF
--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -209,7 +209,7 @@ class RMagics(Magics):
         old_writeconsole = ri.get_writeconsole()
         ri.set_writeconsole(self.write_console)
         try:
-            res = ro.r("withVisible({%s})" % line)
+            res = ro.r("withVisible({%s\n})" % line)
             value = res[0] #value (R object)
             visible = ro.conversion.ri2py(res[1])[0] #visible (boolean)
         except (ri.RRuntimeError, ValueError) as exception:


### PR DESCRIPTION
Closes gh-5579

Simplest possible fix, because rmagic is being moved out to rpy2. But it's not released there yet, so it's still worth us fixing this.
