### PR TITLE
disable specifying kernel args on the notebook command-line

### DIFF
--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -1,23 +1,10 @@
 # coding: utf-8
-"""A tornado based IPython notebook server.
+"""A tornado based IPython notebook server."""
 
-Authors:
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
-* Brian Granger
-"""
 from __future__ import print_function
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2013  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
-
-# stdlib
 import errno
 import io
 import json
@@ -33,7 +20,6 @@ import time
 import webbrowser
 
 
-# Third party
 # check for pyzmq 2.1.11
 from IPython.utils.zmqrelated import check_for_zmq
 check_for_zmq('2.1.11', 'IPython.html')
@@ -61,7 +47,6 @@ if version_info < (3,1,0):
 from tornado import httpserver
 from tornado import web
 
-# Our own libraries
 from IPython.html import DEFAULT_STATIC_FILES_PATH
 from .base.handlers import Template404
 from .log import log_request
@@ -78,7 +63,6 @@ from IPython.config.application import catch_config_error, boolean_flag
 from IPython.core.application import BaseIPythonApplication
 from IPython.core.profiledir import ProfileDir
 from IPython.consoleapp import IPythonConsoleApp
-from IPython.kernel import swallow_argv
 from IPython.kernel.zmq.session import default_secure
 from IPython.kernel.zmq.kernelapp import (
     kernel_flags,
@@ -561,16 +545,7 @@ class NotebookApp(BaseIPythonApplication):
 
     def init_kernel_argv(self):
         """construct the kernel arguments"""
-        # Scrub frontend-specific flags
-        self.kernel_argv = swallow_argv(self.argv, notebook_aliases, notebook_flags)
-        if any(arg.startswith(u'--pylab') for arg in self.kernel_argv):
-            self.log.warn('\n    '.join([
-                "Starting all kernels in pylab mode is not recommended,",
-                "and will be disabled in a future release.",
-                "Please use the %matplotlib magic to enable matplotlib instead.",
-                "pylab implies many imports, which can have confusing side effects",
-                "and harm the reproducibility of your notebooks.",
-            ]))
+        self.kernel_argv = []
         # Kernel should inherit default config file from frontend
         self.kernel_argv.append("--IPKernelApp.parent_appname='%s'" % self.name)
         # Kernel should get *absolute* path to profile directory

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -511,15 +511,16 @@ class NotebookApp(BaseIPythonApplication):
         """
     )
     def _pylab_changed(self, name, old, new):
-        """when --pylab is specified, display a warning and ignore the value"""
+        """when --pylab is specified, display a warning and exit"""
         if new != 'warn':
             backend = ' %s' % new
         else:
             backend = ''
-        self.log.warn("Support for specifying --pylab on the command line has been removed.")
-        self.log.warn(
+        self.log.error("Support for specifying --pylab on the command line has been removed.")
+        self.log.error(
             "Please use `%pylab{0}` or `%matplotlib{0}` in the notebook itself.".format(backend)
         )
+        self.exit(1)
 
     def _notebook_dir_changed(self, name, old, new):
         """Do a bit of validation of the notebook dir."""


### PR DESCRIPTION
this is deprecated in 2.0, and will be removed in 3.0

`ipython notebook --pylab=inline` will never work again!
