### PR TITLE
Kernel registry (IPEP 25)

### DIFF
--- a/IPython/consoleapp.py
+++ b/IPython/consoleapp.py
@@ -341,6 +341,7 @@ class IPythonConsoleApp(ConnectionFileMixin):
                                 connection_file=self.connection_file,
                                 kernel_name=self.kernel_name,
                                 parent=self,
+                                ipython_dir=self.ipython_dir,
         )
         self.kernel_manager.client_factory = self.kernel_client_class
         self.kernel_manager.start_kernel(extra_arguments=self.kernel_argv)

--- a/IPython/consoleapp.py
+++ b/IPython/consoleapp.py
@@ -175,7 +175,7 @@ class IPythonConsoleApp(ConnectionFileMixin):
     existing = CUnicode('', config=True,
         help="""Connect to an already running kernel""")
 
-    kernel_name = Unicode('native', config=True,
+    kernel_name = Unicode('python', config=True,
         help="""The name of the default kernel to start.""")
 
     confirm_exit = CBool(True, config=True,

--- a/IPython/consoleapp.py
+++ b/IPython/consoleapp.py
@@ -98,6 +98,7 @@ app_aliases = dict(
     existing = 'IPythonConsoleApp.existing',
     f = 'IPythonConsoleApp.connection_file',
 
+    kernel = 'IPythonConsoleApp.kernel_name',
 
     ssh = 'IPythonConsoleApp.sshserver',
 )
@@ -173,6 +174,9 @@ class IPythonConsoleApp(ConnectionFileMixin):
 
     existing = CUnicode('', config=True,
         help="""Connect to an already running kernel""")
+
+    kernel_name = Unicode('native', config=True,
+        help="""The name of the default kernel to start.""")
 
     confirm_exit = CBool(True, config=True,
         help="""
@@ -335,6 +339,7 @@ class IPythonConsoleApp(ConnectionFileMixin):
                                 stdin_port=self.stdin_port,
                                 hb_port=self.hb_port,
                                 connection_file=self.connection_file,
+                                kernel_name=self.kernel_name,
                                 parent=self,
         )
         self.kernel_manager.client_factory = self.kernel_client_class

--- a/IPython/kernel/kernelspec.py
+++ b/IPython/kernel/kernelspec.py
@@ -62,6 +62,10 @@ def _list_kernels_in(dir):
     return {f.lower(): pjoin(dir, f) for f in os.listdir(dir)
                         if _is_kernel_dir(pjoin(dir, f))}
 
+class NoSuchKernel(KeyError):
+    def __init__(self, name):
+        self.name = name
+
 class KernelSpecManager(HasTraits):
     ipython_dir = Unicode()
     def _ipython_dir_default(self):
@@ -115,12 +119,15 @@ class KernelSpecManager(HasTraits):
     def get_kernel_spec(self, kernel_name):
         """Returns a :class:`KernelSpec` instance for the given kernel_name.
         
-        Raises KeyError if the given kernel name is not found.
+        Raises :exc:`NoSuchKernel` if the given kernel name is not found.
         """
         if kernel_name == 'python':
             kernel_name = NATIVE_KERNEL_NAME
         d = self.find_kernel_specs()
-        resource_dir = d[kernel_name.lower()]
+        try:
+            resource_dir = d[kernel_name.lower()]
+        except KeyError:
+            raise NoSuchKernel(kernel_name)
         return KernelSpec.from_resource_dir(resource_dir)
 
 def find_kernel_specs():

--- a/IPython/kernel/kernelspec.py
+++ b/IPython/kernel/kernelspec.py
@@ -105,7 +105,7 @@ def get_kernel_spec(kernel_name):
     
     Raises KeyError if the given kernel name is not found.
     """
-    if kernel_name == 'native':
+    if kernel_name == 'python':
         kernel_name = NATIVE_KERNEL_NAME
     d = find_kernel_specs()
     resource_dir = d[kernel_name.lower()]

--- a/IPython/kernel/kernelspec.py
+++ b/IPython/kernel/kernelspec.py
@@ -7,7 +7,7 @@ pjoin = os.path.join
 
 from IPython.utils.path import get_ipython_dir
 from IPython.utils.py3compat import PY3
-from IPython.utils.traitlets import HasTraits, List, Unicode
+from IPython.utils.traitlets import HasTraits, List, Unicode, Dict
 
 USER_KERNEL_DIR = pjoin(get_ipython_dir(), 'kernels')
 
@@ -33,6 +33,7 @@ class KernelSpec(HasTraits):
     display_name = Unicode()
     language = Unicode()
     codemirror_mode = None
+    env = Dict()
     
     resource_dir = Unicode()
     

--- a/IPython/kernel/kernelspec.py
+++ b/IPython/kernel/kernelspec.py
@@ -1,0 +1,72 @@
+import io
+import json
+import os
+
+pjoin = os.path.join
+
+from IPython.utils.path import get_ipython_dir
+from IPython.utils.py3compat import PY3
+from IPython.utils.traitlets import HasTraits, List, Unicode
+
+USER_KERNEL_DIR = pjoin(get_ipython_dir(), 'kernels')
+
+if os.name == 'nt':
+    programdata = os.environ.get('PROGRAMDATA', None)
+    if programdata:
+        SYSTEM_KERNEL_DIR = pjoin(programdata, 'ipython', 'kernels')
+    else:  # PROGRAMDATA is not defined by default on XP.
+        SYSTEM_KERNEL_DIR = None
+else:
+    SYSTEM_KERNEL_DIR = "/usr/share/ipython/kernels"
+    
+NATIVE_KERNEL_NAME = 'python3' if PY3 else 'python2'
+
+class KernelSpec(HasTraits):
+    argv = List()
+    display_name = Unicode()
+    language = Unicode()
+    codemirror_mode = Unicode()
+    
+    resource_dir = Unicode()
+    
+    def __init__(self, resource_dir, argv, display_name, language,
+                 codemirror_mode=None):
+        super(KernelSpec, self).__init__(resource_dir=resource_dir, argv=argv,
+                display_name=display_name, language=language,
+                codemirror_mode=codemirror_mode)
+        if not self.codemirror_mode:
+            self.codemirror_mode = self.language
+    
+    @classmethod
+    def from_resource_dir(cls, resource_dir):
+        kernel_file = os.path.join(resource_dir, 'kernel.json')
+        with io.open(kernel_file, 'r', encoding='utf-8') as f:
+            kernel_dict = json.load(f)
+        return cls(resource_dir=resource_dir, **kernel_dict)
+
+def _is_kernel_dir(path):
+    return os.path.isdir(path) and os.path.isfile(pjoin(path, 'kernel.json'))
+
+def _list_kernels_in(dir):
+    if dir is None:
+        return {}
+    return {f.lower(): pjoin(dir, f) for f in os.listdir(dir)
+                        if _is_kernel_dir(pjoin(dir, f))}
+
+def list_kernel_specs():
+    """Returns a dict mapping kernels to resource directories."""
+    d = _list_kernels_in(SYSTEM_KERNEL_DIR)
+    d.update(_list_kernels_in(USER_KERNEL_DIR))
+    
+    if NATIVE_KERNEL_NAME not in d:
+        d[NATIVE_KERNEL_NAME] = ''  # TODO: native kernel resource directory
+    return d
+
+def get_kernel_spec(kernel_name):
+    """Returns a KernelSpec instance for the given kernel_name.
+    
+    Raises KeyError if the given kernel name is not found.
+    """
+    d = list_kernel_specs()
+    resource_dir = d[kernel_name.lower()]
+    return KernelSpec.from_resource_dir(resource_dir)

--- a/IPython/kernel/kernelspec.py
+++ b/IPython/kernel/kernelspec.py
@@ -40,15 +40,23 @@ class KernelSpec(HasTraits):
     
     @classmethod
     def from_resource_dir(cls, resource_dir):
-        kernel_file = os.path.join(resource_dir, 'kernel.json')
+        """Create a KernelSpec object by reading kernel.json
+        
+        Pass the path to the *directory* containing kernel.json.
+        """
+        kernel_file = pjoin(resource_dir, 'kernel.json')
         with io.open(kernel_file, 'r', encoding='utf-8') as f:
             kernel_dict = json.load(f)
         return cls(resource_dir=resource_dir, **kernel_dict)
 
 def _is_kernel_dir(path):
+    """Is ``path`` a kernel directory?"""
     return os.path.isdir(path) and os.path.isfile(pjoin(path, 'kernel.json'))
 
 def _list_kernels_in(dir):
+    """Ensure dir exists, and return a mapping of kernel names to resource
+    directories from it.
+    """
     if dir is None:
         return {}
     if not os.path.isdir(dir):
@@ -57,6 +65,11 @@ def _list_kernels_in(dir):
                         if _is_kernel_dir(pjoin(dir, f))}
 
 def _make_native_kernel_dir():
+    """Makes a kernel directory for the native kernel.
+    
+    The native kernel is the kernel using the same Python runtime as this
+    process. This will put its informatino in the user kernels directory.
+    """
     path = pjoin(USER_KERNEL_DIR, NATIVE_KERNEL_NAME)
     os.mkdir(path)
     with io.open(pjoin(path, 'kernel.json'), 'w', encoding='utf-8') as f:
@@ -73,16 +86,17 @@ def _make_native_kernel_dir():
     return path
 
 def list_kernel_specs():
-    """Returns a dict mapping kernels to resource directories."""
+    """Returns a dict mapping kernel names to resource directories."""
     d = _list_kernels_in(SYSTEM_KERNEL_DIR)
     d.update(_list_kernels_in(USER_KERNEL_DIR))
     
     if NATIVE_KERNEL_NAME not in d:
         d[NATIVE_KERNEL_NAME] = _make_native_kernel_dir()
     return d
+    # TODO: Caching?
 
 def get_kernel_spec(kernel_name):
-    """Returns a KernelSpec instance for the given kernel_name.
+    """Returns a :class:`KernelSpec` instance for the given kernel_name.
     
     Raises KeyError if the given kernel name is not found.
     """

--- a/IPython/kernel/kernelspec.py
+++ b/IPython/kernel/kernelspec.py
@@ -76,7 +76,7 @@ def _make_native_kernel_dir():
     """
     path = pjoin(USER_KERNEL_DIR, NATIVE_KERNEL_NAME)
     os.makedirs(path, mode=0o755)
-    with io.open(pjoin(path, 'kernel.json'), 'w', encoding='utf-8') as f:
+    with open(pjoin(path, 'kernel.json'), 'w') as f:
         json.dump({'argv':[NATIVE_KERNEL_NAME, '-c',
                            'from IPython.kernel.zmq.kernelapp import main; main()',
                             '-f', '{connection_file}'],

--- a/IPython/kernel/kernelspec.py
+++ b/IPython/kernel/kernelspec.py
@@ -100,6 +100,8 @@ def get_kernel_spec(kernel_name):
     
     Raises KeyError if the given kernel name is not found.
     """
+    if kernel_name == 'native':
+        kernel_name = NATIVE_KERNEL_NAME
     d = list_kernel_specs()
     resource_dir = d[kernel_name.lower()]
     return KernelSpec.from_resource_dir(resource_dir)

--- a/IPython/kernel/kernelspec.py
+++ b/IPython/kernel/kernelspec.py
@@ -79,7 +79,7 @@ def _make_native_kernel_dir():
                    'codemirror_mode': {'name': 'python',
                                        'version': sys.version_info[0]},
                   },
-                  f)
+                  f, indent=1)
     # TODO: Copy icons into directory
     return path
 

--- a/IPython/kernel/kernelspec.py
+++ b/IPython/kernel/kernelspec.py
@@ -26,7 +26,7 @@ class KernelSpec(HasTraits):
     argv = List()
     display_name = Unicode()
     language = Unicode()
-    codemirror_mode = Unicode()
+    codemirror_mode = None
     
     resource_dir = Unicode()
     
@@ -57,10 +57,8 @@ def _list_kernels_in(dir):
     """Ensure dir exists, and return a mapping of kernel names to resource
     directories from it.
     """
-    if dir is None:
+    if dir is None or not os.path.isdir(dir):
         return {}
-    if not os.path.isdir(dir):
-        os.makedirs(dir, mode=0o644)
     return {f.lower(): pjoin(dir, f) for f in os.listdir(dir)
                         if _is_kernel_dir(pjoin(dir, f))}
 
@@ -71,7 +69,7 @@ def _make_native_kernel_dir():
     process. This will put its informatino in the user kernels directory.
     """
     path = pjoin(USER_KERNEL_DIR, NATIVE_KERNEL_NAME)
-    os.mkdir(path)
+    os.makedirs(path, mode=0o755)
     with io.open(pjoin(path, 'kernel.json'), 'w', encoding='utf-8') as f:
         json.dump({'argv':[NATIVE_KERNEL_NAME, '-c',
                            'from IPython.kernel.zmq.kernelapp import main; main()',

--- a/IPython/kernel/kernelspec.py
+++ b/IPython/kernel/kernelspec.py
@@ -89,7 +89,7 @@ def _make_native_kernel_dir():
     # TODO: Copy icons into directory
     return path
 
-def list_kernel_specs():
+def find_kernel_specs():
     """Returns a dict mapping kernel names to resource directories."""
     d = {}
     for kernel_dir in kernel_dirs:
@@ -107,6 +107,6 @@ def get_kernel_spec(kernel_name):
     """
     if kernel_name == 'native':
         kernel_name = NATIVE_KERNEL_NAME
-    d = list_kernel_specs()
+    d = find_kernel_specs()
     resource_dir = d[kernel_name.lower()]
     return KernelSpec.from_resource_dir(resource_dir)

--- a/IPython/kernel/kernelspec.py
+++ b/IPython/kernel/kernelspec.py
@@ -19,6 +19,12 @@ if os.name == 'nt':
         SYSTEM_KERNEL_DIR = None
 else:
     SYSTEM_KERNEL_DIR = "/usr/share/ipython/kernels"
+
+# List of kernel directories to search. Later ones take priority over earlier.
+kernel_dirs = [
+    SYSTEM_KERNEL_DIR,
+    USER_KERNEL_DIR,
+]
     
 NATIVE_KERNEL_NAME = 'python3' if PY3 else 'python2'
 
@@ -85,8 +91,9 @@ def _make_native_kernel_dir():
 
 def list_kernel_specs():
     """Returns a dict mapping kernel names to resource directories."""
-    d = _list_kernels_in(SYSTEM_KERNEL_DIR)
-    d.update(_list_kernels_in(USER_KERNEL_DIR))
+    d = {}
+    for kernel_dir in kernel_dirs:
+        d.update(_list_kernels_in(kernel_dir))
     
     if NATIVE_KERNEL_NAME not in d:
         d[NATIVE_KERNEL_NAME] = _make_native_kernel_dir()

--- a/IPython/kernel/launcher.py
+++ b/IPython/kernel/launcher.py
@@ -1,21 +1,8 @@
 """Utilities for launching kernels
-
-Authors:
-
-* Min Ragan-Kelley
-
 """
 
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2013  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 import os
 import sys
@@ -24,9 +11,6 @@ from subprocess import Popen, PIPE
 from IPython.utils.encoding import getdefaultencoding
 from IPython.utils.py3compat import cast_bytes_py2
 
-#-----------------------------------------------------------------------------
-# Launching Kernels
-#-----------------------------------------------------------------------------
 
 def swallow_argv(argv, aliases=None, flags=None):
     """strip frontend-specific aliases and flags from an argument list
@@ -136,7 +120,7 @@ def make_ipkernel_cmd(code, executable=None, extra_arguments=[], **kw):
     return arguments
 
 
-def launch_kernel(cmd, stdin=None, stdout=None, stderr=None,
+def launch_kernel(cmd, stdin=None, stdout=None, stderr=None, env=None,
                         independent=False,
                         cwd=None, ipython_kernel=True,
                         **kw
@@ -221,7 +205,7 @@ def launch_kernel(cmd, stdin=None, stdout=None, stderr=None,
         if independent:
             proc = Popen(cmd,
                          creationflags=512, # CREATE_NEW_PROCESS_GROUP
-                         stdin=_stdin, stdout=_stdout, stderr=_stderr, env=os.environ)
+                         stdin=_stdin, stdout=_stdout, stderr=_stderr, env=env)
         else:
             if ipython_kernel:
                 try:
@@ -238,7 +222,7 @@ def launch_kernel(cmd, stdin=None, stdout=None, stderr=None,
             
             
             proc = Popen(cmd,
-                         stdin=_stdin, stdout=_stdout, stderr=_stderr, cwd=cwd, env=os.environ)
+                         stdin=_stdin, stdout=_stdout, stderr=_stderr, cwd=cwd, env=env)
 
         # Attach the interrupt event to the Popen objet so it can be used later.
         proc.win32_interrupt_event = interrupt_event
@@ -246,12 +230,12 @@ def launch_kernel(cmd, stdin=None, stdout=None, stderr=None,
     else:
         if independent:
             proc = Popen(cmd, preexec_fn=lambda: os.setsid(),
-                         stdin=_stdin, stdout=_stdout, stderr=_stderr, cwd=cwd, env=os.environ)
+                         stdin=_stdin, stdout=_stdout, stderr=_stderr, cwd=cwd, env=env)
         else:
             if ipython_kernel:
                 cmd += ['--parent=1']
             proc = Popen(cmd,
-                         stdin=_stdin, stdout=_stdout, stderr=_stderr, cwd=cwd, env=os.environ)
+                         stdin=_stdin, stdout=_stdout, stderr=_stderr, cwd=cwd, env=env)
 
     # Clean up pipes created to work around Popen bug.
     if redirect_in:

--- a/IPython/kernel/manager.py
+++ b/IPython/kernel/manager.py
@@ -19,6 +19,7 @@ import zmq
 from IPython.config.configurable import LoggingConfigurable
 from IPython.utils.importstring import import_item
 from IPython.utils.localinterfaces import is_local_ip, local_ips
+from IPython.utils.path import get_ipython_dir
 from IPython.utils.traitlets import (
     Any, Instance, Unicode, List, Bool, Type, DottedObjectName
 )
@@ -60,15 +61,20 @@ class KernelManager(LoggingConfigurable, ConnectionFileMixin):
     # generally a Popen instance
     kernel = Any()
     
+    kernel_spec_manager = Instance(kernelspec.KernelSpecManager)
+    
+    def _kernel_spec_manager_default(self):
+        return kernelspec.KernelSpecManager(ipython_dir=self.ipython_dir)
+    
     kernel_name = Unicode('python')
     
     kernel_spec = Instance(kernelspec.KernelSpec)
     
     def _kernel_spec_default(self):
-        return kernelspec.get_kernel_spec(self.kernel_name)
+        return self.kernel_spec_manager.get_kernel_spec(self.kernel_name)
     
     def _kernel_name_changed(self, name, old, new):
-        self.kernel_spec = kernelspec.get_kernel_spec(new)
+        self.kernel_spec = self.kernel_spec_manager.get_kernel_spec(new)
         self.ipython_kernel = new in {'python', 'python2', 'python3'}
 
     kernel_cmd = List(Unicode, config=True,
@@ -91,6 +97,10 @@ class KernelManager(LoggingConfigurable, ConnectionFileMixin):
         self.ipython_kernel = False
 
     ipython_kernel = Bool(True)
+    
+    ipython_dir = Unicode()
+    def _ipython_dir_default(self):
+        return get_ipython_dir()
 
     # Protected traits
     _launch_args = Any()

--- a/IPython/kernel/manager.py
+++ b/IPython/kernel/manager.py
@@ -70,7 +70,7 @@ class KernelManager(LoggingConfigurable, ConnectionFileMixin):
     # generally a Popen instance
     kernel = Any()
     
-    kernel_name = Unicode('native')
+    kernel_name = Unicode('python')
     
     kernel_spec = Instance(kernelspec.KernelSpec)
     
@@ -79,7 +79,7 @@ class KernelManager(LoggingConfigurable, ConnectionFileMixin):
     
     def _kernel_name_changed(self, name, old, new):
         self.kernel_spec = kernelspec.get_kernel_spec(new)
-        self.ipython_kernel = new in {'native', 'python2', 'python3'}
+        self.ipython_kernel = new in {'python', 'python2', 'python3'}
 
     kernel_cmd = List(Unicode, config=True,
         help="""DEPRECATED: Use kernel_name instead.
@@ -167,7 +167,7 @@ class KernelManager(LoggingConfigurable, ConnectionFileMixin):
         """replace templated args (e.g. {connection_file})"""
         if self.kernel_cmd:
             cmd = self.kernel_cmd
-        elif self.kernel_name == 'native':
+        elif self.kernel_name == 'python':
             # The native kernel gets special handling
             cmd = make_ipkernel_cmd(
                 'from IPython.kernel.zmq.kernelapp import main; main()',

--- a/IPython/kernel/manager.py
+++ b/IPython/kernel/manager.py
@@ -1,19 +1,12 @@
 """Base class to manage a running kernel"""
 
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2013  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 from __future__ import absolute_import
 
 # Standard library imports
+import os
 import re
 import signal
 import sys
@@ -40,9 +33,6 @@ from .managerabc import (
     KernelManagerABC
 )
 
-#-----------------------------------------------------------------------------
-# Main kernel manager class
-#-----------------------------------------------------------------------------
 
 class KernelManager(LoggingConfigurable, ConnectionFileMixin):
     """Manages a single kernel in a subprocess on this host.
@@ -232,8 +222,15 @@ class KernelManager(LoggingConfigurable, ConnectionFileMixin):
         self._launch_args = kw.copy()
         # build the Popen cmd
         kernel_cmd = self.format_kernel_cmd(**kw)
+        if self.kernel_cmd:
+            # If kernel_cmd has been set manually, don't refer to a kernel spec
+            env = os.environ
+        else:
+            # Environment variables from kernel spec are added to os.environ
+            env = os.environ.copy()
+            env.update(self.kernel_spec.env or {})
         # launch the kernel subprocess
-        self.kernel = self._launch_kernel(kernel_cmd,
+        self.kernel = self._launch_kernel(kernel_cmd, env=env,
                                     ipython_kernel=self.ipython_kernel,
                                     **kw)
         self.start_restarter()
@@ -401,10 +398,6 @@ class KernelManager(LoggingConfigurable, ConnectionFileMixin):
             # we don't have a kernel
             return False
 
-
-#-----------------------------------------------------------------------------
-# ABC Registration
-#-----------------------------------------------------------------------------
 
 KernelManagerABC.register(KernelManager)
 

--- a/IPython/kernel/tests/test_kernelspec.py
+++ b/IPython/kernel/tests/test_kernelspec.py
@@ -1,0 +1,39 @@
+import json
+import os
+from os.path import join as pjoin
+import unittest
+
+from IPython.utils.tempdir import TemporaryDirectory
+from IPython.kernel import kernelspec
+
+sample_kernel_json = {'argv':['cat', '{connection_file}'],
+                      'display_name':'Test kernel',
+                      'language':'bash',
+                     }
+
+class KernelSpecTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = td = TemporaryDirectory()
+        self.sample_kernel_dir = pjoin(td.name, 'kernels', 'Sample')
+        os.makedirs(self.sample_kernel_dir)
+        json_file = pjoin(self.sample_kernel_dir, 'kernel.json')
+        with open(json_file, 'w') as f:
+            json.dump(sample_kernel_json, f)
+
+        self.ksm = kernelspec.KernelSpecManager(ipython_dir=td.name)
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def test_find_kernel_specs(self):
+        kernels = self.ksm.find_kernel_specs()
+        self.assertEqual(kernels['sample'], self.sample_kernel_dir)
+
+    def test_get_kernel_spec(self):
+        ks = self.ksm.get_kernel_spec('SAMPLE')  # Case insensitive
+        self.assertEqual(ks.resource_dir, self.sample_kernel_dir)
+        self.assertEqual(ks.argv, sample_kernel_json['argv'])
+        self.assertEqual(ks.display_name, sample_kernel_json['display_name'])
+        self.assertEqual(ks.language, sample_kernel_json['language'])
+        self.assertEqual(ks.codemirror_mode, sample_kernel_json['language'])
+        self.assertEqual(ks.env, {})


### PR DESCRIPTION
This is the first part of implementing the kernel registry and selection machinery in [IPEP 25](https://github.com/ipython/ipython/wiki/IPEP-25:-Registry-of-installed-kernels).

The `ipython console` and `ipython qtconsole` entry points gain a `--kernel foo` command line option. I've been testing with this in `~/.ipython/kernels/IR/kernel.json`:

``` json
{"argv":["R","-e","IRkernel::main('{connection_file}')"],
"display_name":"R",
"language":"R"
}
```

KernelManager.kernel_cmd is deprecated. If you set it, it generates a warning, but still overrides the kernel spec machinery.
