### PR TITLE
#5603: Provide online documentation for Python's keywords and operators

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1447,6 +1447,12 @@ class InteractiveShell(SingletonConfigurable):
                 ospace = 'IPython internal'
                 ismagic = True
 
+        if not found:
+            obj = self.find_keyword(oname)
+            if obj is not None:
+                found = True
+                ospace = 'Python keyword'
+
         # Last try: special-case some literals like '', [], {}, etc:
         if not found and oname_head in ["''",'""','[]','{}','()']:
             obj = eval(oname_head)
@@ -1511,6 +1517,10 @@ class InteractiveShell(SingletonConfigurable):
                 )
             else:
                 return oinspect.object_info(name=oname, found=False)
+
+    def find_keyword(self, keyword):
+        from IPython.core.keywords_documentation import keywords_documentation
+        return keywords_documentation.get(keyword, None)
 
     #-------------------------------------------------------------------------
     # Things related to history management

--- a/IPython/core/keywords_documentation.py
+++ b/IPython/core/keywords_documentation.py
@@ -1,0 +1,92 @@
+import operator
+
+class DocObject:
+    def __init__(self, doc):
+        self.__doc__ = doc
+
+keywords_documentation = {
+    "for": DocObject("""
+    The ``for`` statement (for loops)
+
+    The for statement is used to iterate over the elements of a
+    sequence (such as a string, tuple or list) or other iterable
+    object.
+
+    Syntax:
+
+        for variable in container:
+            <code>
+
+        for variable in container:
+            <code>
+        else:
+            <code>
+
+    Semantic:
+
+        For each value in the container, assign that value to
+        ``variable`` and execute <code>.
+
+        A ``break`` statement executed in the code terminates the loop
+        without executing the ``else`` clause's code. A ``continue``
+        statement executed in the code skips the rest of the code and
+        continues with the next item, or with the ``else`` clause if
+        there was no next item.
+
+    Seealso:
+
+        - https://docs.python.org/3/tutorial/controlflow.html#for-statements
+        - https://docs.python.org/3/reference/compound_stmts.html#the-for-statement
+
+    Examples::
+
+        for letter in ["a", "b", "c"]:
+            print letter
+        a
+        b
+        c
+
+        for i in range(5):
+            print i
+        0
+        1
+        2
+        3
+        4
+    """),
+
+    "if": DocObject("""
+    Conditionals
+
+    Syntax:
+
+        if condition:
+            <code1>
+
+        if condition:
+            <code1>
+        elif condition:
+            <code2>
+        else:
+            <code3>
+
+    Semantic:
+
+    EXAMPLES::
+
+        if x < 0:
+            print "x is negative"
+        elif x > 0:
+            print "x is positive"
+        else:
+            print "x is null"
+    """),
+
+    "+": operator.add,
+}
+
+keywords_documentation["elif"] = keywords_documentation["if"]
+keywords_documentation["else"] = keywords_documentation["if"]
+
+keywords_documentation["break"] = keywords_documentation["for"]
+keywords_documentation["continue"] = keywords_documentation["for"]


### PR DESCRIPTION
This is a proof of concept implementation for issue #5603. It implements keyword lookup in pdoc and provides draft of documentation for::

```
    >>>> for?
    >>>> if?
```

as well as `continue`, `break`, `elif`, `else`.

What remains to be done:
1. Finalize the documentation for `for` and `if` (in particular: markup for examples, style, ...) as a template for the other keywords.
2. Write the documentation for all the Python keywords.
3. Maybe improve the rendering of documentation for Python keywords (e.g. we don't really care about the lines `Type`, `BaseClass`, `String from`).
4. Implement online documentation for operators::

```
 >>>> +?
```

  It sounds like this would require to touch a bit the parser, which is beyond my current knowledge of the IPython infrastructure
5. I believe `+?` should yield the documentation of `operator.add`, and similarly for the other operators. Those docstrings deserve to be improved: at least mentioning the link with the corresponding **xxxx** methods and linking to the Special methods section on docs.python.org (which might differ a bit for Python 2 or 3). I guess improving those docstrings needs to be done upstream in Python.

I alas won't have time to devote to this. I can probably find a volunteer among my fellow teachers for 2.
