### PR TITLE
Two cell toolbar fixes.

### DIFF
--- a/IPython/html/static/notebook/js/celltoolbar.js
+++ b/IPython/html/static/notebook/js/celltoolbar.js
@@ -184,6 +184,10 @@ var IPython = (function (IPython) {
     CellToolbar.register_preset = function(name, preset_list) {
         CellToolbar._presets[name] = preset_list;
         $([IPython.events]).trigger('preset_added.CellToolbar', {name: name});
+        // When "register_callback" is called by a custom extension, it may be executed after notebook is loaded.
+        // In that case, activate the preset if needed.
+        if (IPython.notebook && IPython.notebook.metadata && IPython.notebook.metadata.celltoolbar === name)
+            this.activate_preset(name);
     };
 
 
@@ -223,6 +227,8 @@ var IPython = (function (IPython) {
             CellToolbar._ui_controls_list = preset;
             CellToolbar.rebuild_all();
         }
+
+        $([IPython.events]).trigger('preset_activated.CellToolbar', {name: preset_name});
     };
 
 

--- a/IPython/html/static/notebook/js/maintoolbar.js
+++ b/IPython/html/static/notebook/js/maintoolbar.js
@@ -20,7 +20,7 @@ var IPython = (function (IPython) {
         this.bind_events();
     };
 
-    MainToolBar.prototype = new IPython.ToolBar(); 
+    MainToolBar.prototype = new IPython.ToolBar();
 
     MainToolBar.prototype.construct = function () {
         this.add_buttons_group([
@@ -92,7 +92,7 @@ var IPython = (function (IPython) {
                         }
                 }
             ],'move_up_down');
-        
+
 
         this.add_buttons_group([
                 {
@@ -170,12 +170,17 @@ var IPython = (function (IPython) {
             var name = data.name;
             select.append($('<option/>').attr('value', name).text(name));
         });
+        // Update select value when a preset is activated.
+        $([IPython.events]).on('preset_activated.CellToolbar', function (event, data) {
+            if (select.val() !== data.name)
+                select.val(data.name);
+        });
     };
 
 
     MainToolBar.prototype.bind_events = function () {
         var that = this;
-        
+
         this.element.find('#cell_type').change(function () {
             var cell_type = $(this).val();
             if (cell_type === 'code') {

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -2103,6 +2103,8 @@ var IPython = (function (IPython) {
         if (this.metadata.celltoolbar) {
             IPython.CellToolbar.global_show();
             IPython.CellToolbar.activate_preset(this.metadata.celltoolbar);
+        } else {
+            IPython.CellToolbar.global_hide();
         }
 
         // now that we're fully loaded, it is safe to restore save functionality


### PR DESCRIPTION
1. When a new notebook is loaded we should update the state of the `select` element listing the cell tollbar presets in the main toolbar, so that its value reflects the `celltollbar` metadata entry of the notebook.
2. When a new notebook without `celltoolbar` metadata entry is loaded we should make sure that the cell tollbars are hidden. In particular, that is needed when you are working to a notebook with a certain cell toolbar preset and then you revert the notebook to a state with no cell toolbars. 
