### PR TITLE
Fixed Issue #5531 -- Re-arranged placement of shortcut info in keyboard popup

### DIFF
--- a/IPython/html/static/notebook/js/keyboardmanager.js
+++ b/IPython/html/static/notebook/js/keyboardmanager.js
@@ -56,7 +56,7 @@ var IPython = (function (IPython) {
         default_common_shortcuts['cmd-s'] =
             {
                 help    : 'save notebook',
-                help_index : 'fb',
+                help_index : 'bi',
                 handler : function (event) {
                     IPython.notebook.save_checkpoint();
                     event.preventDefault();
@@ -67,7 +67,7 @@ var IPython = (function (IPython) {
         default_common_shortcuts['ctrl-s'] =
             {
                 help    : 'save notebook',
-                help_index : 'fb',
+                help_index : 'bi',
                 handler : function (event) {
                     IPython.notebook.save_checkpoint();
                     event.preventDefault();
@@ -236,7 +236,7 @@ var IPython = (function (IPython) {
         },
         'shift-v' : {
             help    : 'paste cell above',
-            help_index : 'eg',
+            help_index : 'bf',
             handler : function (event) {
                 IPython.notebook.paste_cell_above();
                 return false;
@@ -361,7 +361,7 @@ var IPython = (function (IPython) {
         },
         'shift-o' : {
             help    : 'toggle output scrolling',
-            help_index : 'gc',
+            help_index : 'bh',
             handler : function (event) {
                 IPython.notebook.toggle_output_scroll();
                 return false;
@@ -369,7 +369,7 @@ var IPython = (function (IPython) {
         },
         's' : {
             help    : 'save notebook',
-            help_index : 'fa',
+            help_index : 'bj',
             handler : function (event) {
                 IPython.notebook.save_checkpoint();
                 return false;
@@ -377,7 +377,7 @@ var IPython = (function (IPython) {
         },
         'ctrl-j' : {
             help    : 'move cell down',
-            help_index : 'eb',
+            help_index : 'bd',
             handler : function (event) {
                 IPython.notebook.move_cell_down();
                 return false;
@@ -385,7 +385,7 @@ var IPython = (function (IPython) {
         },
         'ctrl-k' : {
             help    : 'move cell up',
-            help_index : 'ea',
+            help_index : 'be',
             handler : function (event) {
                 IPython.notebook.move_cell_up();
                 return false;
@@ -435,7 +435,7 @@ var IPython = (function (IPython) {
         },
         'shift-m' : {
             help    : 'merge cell below',
-            help_index : 'ek',
+            help_index : 'bg',
             handler : function (event) {
                 IPython.notebook.merge_cell_below();
                 return false;


### PR DESCRIPTION
Closes #5531. This is the better version; I closed the previous PR.

Users were confused on how to use keyboard shortcuts because the pop-up
window documentation was confusing. I changed the help_indices to move the items around in the shortcut popup.

Screenshot: 
![keyboard_shortcuts_v2](https://cloud.githubusercontent.com/assets/954858/2732105/2e765024-c636-11e3-8ccb-90fc846e51f6.png)
