### PR TITLE
Some improvements to cell toolbars

### DIFF
--- a/IPython/html/static/notebook/js/celltoolbar.js
+++ b/IPython/html/static/notebook/js/celltoolbar.js
@@ -389,7 +389,7 @@ var IPython = (function (IPython) {
      *      CellToolbar.register_callback('slideshow.select', select_type);
      *
      */
-    CellToolbar.utils.select_ui_generator = function(list_list, setter, getter, label, cell_types){
+    CellToolbar.utils.select_ui_generator = function(list_list, setter, getter, label) {
         label = label || "";
         return function(div, cell, celltoolbar) {
             var button_container = $(div);
@@ -406,12 +406,6 @@ var IPython = (function (IPython) {
                         setter(cell, select.val());
                     });
             button_container.append($('<div/>').append(lbl).append(select));
-            if (cell_types && cell_types.indexOf(cell.cell_type) == -1) {
-                celltoolbar.hide();
-            } else {
-                celltoolbar.show();
-            }
-
         };
     };
 

--- a/IPython/html/static/notebook/js/celltoolbar.js
+++ b/IPython/html/static/notebook/js/celltoolbar.js
@@ -37,7 +37,6 @@ var IPython = (function (IPython) {
         this.inner_element = $('<div/>').addClass('celltoolbar')
         this.element = $('<div/>').addClass('ctb_hideshow')
             .append(this.inner_element);
-        this.show();
     };
 
 
@@ -250,6 +249,7 @@ var IPython = (function (IPython) {
         // which is probably inner_element
         // or this.element.
         this.inner_element.empty();
+        this.ui_controls_list = [];
 
         var callbacks = CellToolbar._callback_dict;
         var preset = CellToolbar._ui_controls_list;
@@ -267,12 +267,20 @@ var IPython = (function (IPython) {
             var local_div = $('<div/>').addClass('button_container');
             try {
                 callback(local_div, this.cell, this);
+                this.ui_controls_list.push(key);
             } catch (e) {
                 console.log("Error in cell toolbar callback " + key, e);
                 continue;
             }
             // only append if callback succeeded.
             this.inner_element.append(local_div);
+        }
+
+        // If there are no controls hide the toolbar.
+        if (this.ui_controls_list.length) {
+            this.show();
+        } else {
+            this.hide();
         }
     };
 

--- a/IPython/html/static/notebook/js/celltoolbar.js
+++ b/IPython/html/static/notebook/js/celltoolbar.js
@@ -276,11 +276,11 @@ var IPython = (function (IPython) {
             this.inner_element.append(local_div);
         }
 
-        // If there are no controls hide the toolbar.
-        if (this.ui_controls_list.length) {
-            this.show();
-        } else {
+        // If there are no controls or the cell is a rendered TextCell hide the toolbar.
+        if (!this.ui_controls_list.length || (this.cell instanceof IPython.TextCell && this.cell.rendered)) {
             this.hide();
+        } else {
+            this.show();
         }
     };
 

--- a/IPython/html/static/notebook/js/celltoolbar.js
+++ b/IPython/html/static/notebook/js/celltoolbar.js
@@ -118,7 +118,9 @@ var IPython = (function (IPython) {
      * @method register_callback
      * @param name {String} name to use to refer to the callback. It is advised to use a prefix with the name
      * for easier sorting and avoid collision
-     * @param  callback {function(div, cell)} callback that will be called to generate the ui element
+     * @param callback {function(div, cell)} callback that will be called to generate the ui element
+     * @param [cell_types] {List of String|undefined} optional list of cell types. If present the UI element
+     * will be added only to cells of types in the list.
      *
      *
      * The callback will receive the following element :
@@ -154,9 +156,9 @@ var IPython = (function (IPython) {
      *      // user the ability to use it later
      *      CellToolbar.register_callback('foo', toggle);
      */
-    CellToolbar.register_callback = function(name, callback){
+    CellToolbar.register_callback = function(name, callback, cell_types) {
         // Overwrite if it already exists.
-        CellToolbar._callback_dict[name] = callback;
+        CellToolbar._callback_dict[name] = cell_types ? {callback: callback, cell_types: cell_types} : callback;
     };
 
 
@@ -256,6 +258,11 @@ var IPython = (function (IPython) {
             var key = preset[i];
             var callback = callbacks[key];
             if (!callback) continue;
+
+            if (typeof callback === 'object') {
+                if (callback.cell_types.indexOf(this.cell.cell_type) === -1) continue;
+                callback = callback.callback;
+            }
             
             var local_div = $('<div/>').addClass('button_container');
             try {

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -407,11 +407,6 @@ var IPython = (function (IPython) {
     };
 
 
-    HeadingCell.prototype.set_rendered = function (html) {
-        this.element.find("div.text_cell_render").html(html);
-    };
-
-
     HeadingCell.prototype.get_rendered = function () {
         var r = this.element.find("div.text_cell_render");
         return r.children().first().html();

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -138,6 +138,9 @@ var IPython = (function (IPython) {
             }
             this.refresh();
         }
+        if (this.celltoolbar.ui_controls_list.length) {
+            this.celltoolbar.show();
+        }
         return cont;
     };
 
@@ -178,6 +181,7 @@ var IPython = (function (IPython) {
      */
     TextCell.prototype.set_rendered = function(text) {
         this.element.find('div.text_cell_render').html(text);
+        this.celltoolbar.hide();
     };
 
 


### PR DESCRIPTION
1. Added an optional parameter to `CellToolbar.register_callback`.
   If defined, the UI element will be inserted only in cells of the types listed in that parameter.
2. Hide a cell toolbar if it does not contain UI controls.
3. Hide the toolbar of rendered text cells.

As side-effect, I noted that in `HeadingCell`, `set_rendered` was overridden by a method that was exactly the same of the base class one. So I removed it.
