### PR TITLE
Add preprocessor that clears cell outputs

### DIFF
--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -70,6 +70,7 @@ class Exporter(LoggingConfigurable):
                                   'IPython.nbconvert.preprocessors.CSSHTMLHeaderPreprocessor',
                                   'IPython.nbconvert.preprocessors.RevealHelpPreprocessor',
                                   'IPython.nbconvert.preprocessors.LatexPreprocessor',
+                                  'IPython.nbconvert.preprocessors.ClearOutputPreprocessor',
                                   'IPython.nbconvert.preprocessors.HighlightMagicsPreprocessor'],
         config=True,
         help="""List of preprocessors available by default, by name, namespace, 

--- a/IPython/nbconvert/preprocessors/__init__.py
+++ b/IPython/nbconvert/preprocessors/__init__.py
@@ -7,6 +7,7 @@ from .revealhelp import RevealHelpPreprocessor
 from .latex import LatexPreprocessor
 from .csshtmlheader import CSSHTMLHeaderPreprocessor
 from .highlightmagics import HighlightMagicsPreprocessor
+from .clearoutput import ClearOutputPreprocessor
 
 # decorated function Preprocessors
 from .coalescestreams import coalesce_streams

--- a/IPython/nbconvert/preprocessors/clearoutput.py
+++ b/IPython/nbconvert/preprocessors/clearoutput.py
@@ -1,12 +1,7 @@
 """Module containing a preprocessor that removes the outputs from code cells"""
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, the IPython Development Team.
-#
+# Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 #-----------------------------------------------------------------------------
 # Imports

--- a/IPython/nbconvert/preprocessors/clearoutput.py
+++ b/IPython/nbconvert/preprocessors/clearoutput.py
@@ -1,0 +1,32 @@
+"""Module containing a preprocessor that removes the outputs from code cells"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, the IPython Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+from .base import Preprocessor
+
+
+#-----------------------------------------------------------------------------
+# Classes
+#-----------------------------------------------------------------------------
+class ClearOutputPreprocessor(Preprocessor):
+    """
+    Removes the output from all code cells in a notebook.
+    """
+
+    def preprocess_cell(self, cell, resources, cell_index):
+        """
+        Apply a transformation on each cell. See base.py for details.
+        """
+        if cell.cell_type == 'code':
+            cell.outputs = []
+        return cell, resources

--- a/IPython/nbconvert/preprocessors/tests/test_clearoutput.py
+++ b/IPython/nbconvert/preprocessors/tests/test_clearoutput.py
@@ -1,0 +1,46 @@
+"""
+Module with tests for the clearoutput preprocessor.
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, the IPython Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+from IPython.nbformat import current as nbformat
+
+from .base import PreprocessorTestsBase
+from ..clearoutput import ClearOutputPreprocessor
+
+
+#-----------------------------------------------------------------------------
+# Class
+#-----------------------------------------------------------------------------
+
+class TestClearOutput(PreprocessorTestsBase):
+    """Contains test functions for clearoutput.py"""
+
+
+    def build_preprocessor(self):
+        """Make an instance of a preprocessor"""
+        preprocessor = ClearOutputPreprocessor()
+        preprocessor.enabled = True
+        return preprocessor
+
+    def test_constructor(self):
+        """Can a ClearOutputPreprocessor be constructed?"""
+        self.build_preprocessor()
+
+    def test_output(self):
+        """Test the output of the ClearOutputPreprocessor"""
+        nb = self.build_notebook()
+        res = self.build_resources()
+        preprocessor = self.build_preprocessor()
+        nb, res = preprocessor(nb, res)
+        assert nb.worksheets[0].cells[0].outputs == []

--- a/IPython/nbconvert/preprocessors/tests/test_clearoutput.py
+++ b/IPython/nbconvert/preprocessors/tests/test_clearoutput.py
@@ -2,13 +2,8 @@
 Module with tests for the clearoutput preprocessor.
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, the IPython Development Team.
-#
+# Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 #-----------------------------------------------------------------------------
 # Imports

--- a/docs/source/whatsnew/pr/clear-output-preprocessor
+++ b/docs/source/whatsnew/pr/clear-output-preprocessor
@@ -1,0 +1,1 @@
+Adds an optional preprocessor step to `nbconvert` called `ClearOutputPreprocessor`. This clears the output from IPython notebooks.


### PR DESCRIPTION
Added a preprocessor that clears all cell outputs. I added it to `preprocessors/__init__.py` and `exporters/exporter.py` -- does it need to be added anywhere else, or documented somewhere?
