### PR TITLE
Do not record memory addresses of display objects

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -299,6 +299,7 @@ class DisplayObject(object):
     """An object that wraps data to be displayed."""
 
     _read_flags = 'r'
+    _show_mem_addr = False
 
     def __init__(self, data=None, url=None, filename=None):
         """Create a display object given raw data.
@@ -335,7 +336,15 @@ class DisplayObject(object):
 
         self.reload()
         self._check_data()
-    
+
+    def __repr__(self):
+        if not self._show_mem_addr:
+            cls = self.__class__
+            r = "<%s.%s object>" % (cls.__module__, cls.__name__)
+        else:
+            r = super(DisplayObject, self).__repr__()
+        return r
+
     def _check_data(self):
         """Override in subclasses if there's something to check."""
         pass

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -116,3 +116,19 @@ def test_set_matplotlib_formats_kwargs():
     expected.update(cfg.print_figure_kwargs)
     nt.assert_equal(cell, expected)
 
+def test_displayobject_repr():
+    h = display.HTML('<br />')
+    nt.assert_equal(repr(h), '<IPython.core.display.HTML object>')
+    h._show_mem_addr = True
+    nt.assert_equal(
+        repr(h), '<IPython.core.display.HTML object at %s>' % hex(id(h)))
+    h._show_mem_addr = False
+    nt.assert_equal(repr(h), '<IPython.core.display.HTML object>')
+
+    j = display.Javascript('')
+    nt.assert_equal(repr(j), '<IPython.core.display.Javascript object>')
+    j._show_mem_addr = True
+    nt.assert_equal(
+        repr(j), '<IPython.core.display.Javascript object at %s>' % hex(id(j)))
+    j._show_mem_addr = False
+    nt.assert_equal(repr(j), '<IPython.core.display.Javascript object>')

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -120,15 +120,13 @@ def test_displayobject_repr():
     h = display.HTML('<br />')
     nt.assert_equal(repr(h), '<IPython.core.display.HTML object>')
     h._show_mem_addr = True
-    nt.assert_equal(
-        repr(h), '<IPython.core.display.HTML object at %s>' % hex(id(h)))
+    nt.assert_equal(repr(h), object.__repr__(h))
     h._show_mem_addr = False
     nt.assert_equal(repr(h), '<IPython.core.display.HTML object>')
 
     j = display.Javascript('')
     nt.assert_equal(repr(j), '<IPython.core.display.Javascript object>')
     j._show_mem_addr = True
-    nt.assert_equal(
-        repr(j), '<IPython.core.display.Javascript object at %s>' % hex(id(j)))
+    nt.assert_equal(repr(j), object.__repr__(j))
     j._show_mem_addr = False
     nt.assert_equal(repr(j), '<IPython.core.display.Javascript object>')


### PR DESCRIPTION
The `repr` of the `DisplayObject` class always shows the memory address, which is annoying, because if you rerun an entire notebook and have a bunch of displayed objects, then these are all changed in the notebook diff, because the memory address changes between runs (even if the what is displayed visually does not).

This pull request overrides the `__repr__` method of `DisplayObject` to suppress memory addresses, and adds a class variable called `_show_mem_addr` which defaults to `False`, but can be set to `True`, which will cause the behavior of `__repr__` to go back to what it was originally.
