### PR TITLE
Proposed solution for issue 2565: Provide magic menu checkbox for pasting magics instead of direct executing

### DIFF
--- a/IPython/qt/console/mainwindow.py
+++ b/IPython/qt/console/mainwindow.py
@@ -653,12 +653,8 @@ class MainWindow(QtGui.QMainWindow):
                     self,
                     triggered=self._make_dynamic_magic(pmagic)
                     )
-                xaction_all = QtGui.QAction(pmagic,
-                    self,
-                    triggered=self._make_dynamic_magic(pmagic)
-                    )
                 magic_menu.addAction(xaction)
-                self.all_magic_menu.addAction(xaction_all)
+                self.all_magic_menu.addAction(xaction)
 
     def update_all_magic_menu(self):
         """ Update the list of magics in the "All Magics..." Menu

--- a/IPython/qt/console/mainwindow.py
+++ b/IPython/qt/console/mainwindow.py
@@ -613,7 +613,11 @@ class MainWindow(QtGui.QMainWindow):
         # need two level nested function to be sure to pass magic
         # to active frontend **at run time**.
         def inner_dynamic_magic():
-            self.active_frontend.execute(magic)
+            if not self.run_or_paste_action.isChecked():
+                self.active_frontend.execute(magic)
+            else:
+                self.active_frontend.input_buffer = magic
+
         inner_dynamic_magic.__name__ = "dynamics_magic_s"
         return inner_dynamic_magic
 
@@ -706,6 +710,15 @@ class MainWindow(QtGui.QMainWindow):
         # least once let's do it immediately, but it's assured to works
         self.pop.trigger()
 
+        self.run_or_paste_action = QtGui.QAction(
+            "Only Paste Magics",
+            self,
+            statusTip="Check to paste magics without executing them",
+        )
+        self.run_or_paste_action.setCheckable(True)
+        self.add_menu_action(self.magic_menu, self.run_or_paste_action)
+        self.magic_menu.addSeparator()
+ 
         self.reset_action = QtGui.QAction("&Reset",
             self,
             statusTip="Clear all variables from workspace",


### PR DESCRIPTION
This is related to issue #2565 (https://github.com/ipython/ipython/issues/2565).  
There is no reasonable way to programmatically distinguish between magics with parameters  and magics that do not require params.  
Thus, I have implemented "Only Paste Magics" menu checkbox. When checked menu items will just paste magics into the input without executing them. When unchecked (default) magics are executed.
