### PR TITLE
Replace underscores in variable names when using interact

### DIFF
--- a/IPython/html/widgets/interaction.py
+++ b/IPython/html/widgets/interaction.py
@@ -166,7 +166,10 @@ def _widgets_from_abbreviations(seq):
     result = []
     for name, abbrev, default in seq:
         widget = _widget_from_abbrev(abbrev, default)
-        widget.description = name
+        desc = name.replace("_", " ")
+        if not any([s.isupper() for s in desc]):
+            desc = desc.capitalize()
+        widget.description = desc
         result.append(widget)
     return result
 

--- a/examples/Interactive Widgets/Using Interact.ipynb
+++ b/examples/Interactive Widgets/Using Interact.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:d75ab1c53fa3389eeac78ecf8e89beb52871950f296aad25776699b6d6125037"
+  "signature": "sha256:f9c886d2430e61ef7eae7902c2125468d942b31a06da7a5b0ec4cdfc805d858a"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -87,7 +87,7 @@
        "metadata": {},
        "output_type": "display_data",
        "text": [
-        "<IPython.core.display.HTML at 0x10efc0d50>"
+        "<IPython.core.display.HTML at 0x10444a810>"
        ]
       }
      ],
@@ -121,15 +121,15 @@
         "<h3>Arguments:</h3><table>\n",
         "<tr><td>Current</td><td>4.99</td></tr>\n",
         "<tr><td>Text</td><td>Type here!</td></tr>\n",
-        "<tr><td>z</td><td>True</td></tr>\n",
-        "<tr><td>a</td><td>5.0</td></tr>\n",
+        "<tr><td>Z</td><td>True</td></tr>\n",
+        "<tr><td>A</td><td>5.0</td></tr>\n",
         "<tr><td>Temp</td><td>5</td></tr>\n",
         "</table>"
        ],
        "metadata": {},
        "output_type": "display_data",
        "text": [
-        "<IPython.core.display.HTML at 0x10efcca10>"
+        "<IPython.core.display.HTML at 0x104451ad0>"
        ]
       }
      ],
@@ -149,19 +149,56 @@
         "<h3>Arguments:</h3><table>\n",
         "<tr><td>Current</td><td>4.99</td></tr>\n",
         "<tr><td>Text</td><td>Type here!</td></tr>\n",
-        "<tr><td>z</td><td>True</td></tr>\n",
-        "<tr><td>a</td><td>5.0</td></tr>\n",
+        "<tr><td>Z</td><td>True</td></tr>\n",
+        "<tr><td>A</td><td>5.0</td></tr>\n",
         "<tr><td>Temp</td><td>5</td></tr>\n",
         "</table>"
        ],
        "metadata": {},
        "output_type": "display_data",
        "text": [
-        "<IPython.core.display.HTML at 0x10f027050>"
+        "<IPython.core.display.HTML at 0x1020a7dd0>"
        ]
       }
      ],
      "prompt_number": 5
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "If you use variable names with underscores, `interact` will replace the underscores with spaces when displaying the widget. Additionally, it will capitalize the first letter of the variable (but only if there are no other capital letters -- it assumes that if you are using capitals in your variable names, then you are using them for a reason, and so will not touch them)."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "i = interact(show_args,\n",
+      "         my_cool_variable=(0,10),\n",
+      "         My_Cool_Variable=(0.,10.,0.01),\n",
+      "         MCV=\"Hello\"\n",
+      "         )"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "html": [
+        "<h3>Arguments:</h3><table>\n",
+        "<tr><td>MCV</td><td>Hello</td></tr>\n",
+        "<tr><td>My cool variable</td><td>5</td></tr>\n",
+        "<tr><td>My Cool Variable</td><td>4.99</td></tr>\n",
+        "</table>"
+       ],
+       "metadata": {},
+       "output_type": "display_data",
+       "text": [
+        "<IPython.core.display.HTML at 0x104451d90>"
+       ]
+      }
+     ],
+     "prompt_number": 6
     }
    ],
    "metadata": {}


### PR DESCRIPTION
If your variable names in interact have underscores in them, then the widgets will be displayed with labels like "my_variable:", which is less desirable than "My variable:" or even "my variable:"

This pull request replaces underscores with spaces, and also capitalizes the first letter, but only if there are no other capitals. This is because people usually code using lower-case variable names, so the idea is that if there is already a capital letter, it is probably there for a reason.
