### PR TITLE
Refactor inputhook to allow easy extension

### DIFF
--- a/IPython/kernel/zmq/eventloops.py
+++ b/IPython/kernel/zmq/eventloops.py
@@ -51,6 +51,34 @@ def _notify_stream_qt(kernel, stream):
     notifier = QtCore.QSocketNotifier(fd, QtCore.QSocketNotifier.Read, kernel.app)
     notifier.activated.connect(process_stream_events)
 
+# mapping of keys to loop functions
+loop_map = {
+    'inline': None,
+    None : None,
+}
+
+def register_integration(*toolkitnames):
+    """Decorator to register an event loop to integrate with the IPython kernel
+    
+    The decorator takes names to register the event loop as for the %gui magic.
+    You can provide alternative names for the same toolkit.
+    
+    The decorated function should take a single argument, the IPython kernel
+    instance, arrange for the event loop to call ``kernel.do_one_iteration()``
+    at least every ``kernel._poll_interval`` seconds, and start the event loop.
+    
+    :mod:`IPython.kernel.zmq.eventloops` provides and registers such functions
+    for a few common event loops.
+    """
+    def decorator(func):
+        for name in toolkitnames:
+            loop_map[name] = func
+        return func
+    
+    return decorator
+
+
+@register_integration('qt', 'qt4')
 def loop_qt4(kernel):
     """Start a kernel with PyQt4 event loop integration."""
 
@@ -65,6 +93,7 @@ def loop_qt4(kernel):
     start_event_loop_qt4(kernel.app)
 
 
+@register_integration('wx')
 def loop_wx(kernel):
     """Start a kernel with wx event loop support."""
 
@@ -117,6 +146,7 @@ def loop_wx(kernel):
     start_event_loop_wx(kernel.app)
 
 
+@register_integration('tk')
 def loop_tk(kernel):
     """Start a kernel with the Tk event loop."""
 
@@ -146,6 +176,7 @@ def loop_tk(kernel):
     kernel.timer.start()
 
 
+@register_integration('gtk')
 def loop_gtk(kernel):
     """Start the kernel, coordinating with the GTK event loop"""
     from .gui.gtkembed import GTKEmbed
@@ -154,6 +185,7 @@ def loop_gtk(kernel):
     gtk_kernel.start()
 
 
+@register_integration('gtk3')
 def loop_gtk3(kernel):
     """Start the kernel, coordinating with the GTK event loop"""
     from .gui.gtk3embed import GTKEmbed
@@ -162,6 +194,7 @@ def loop_gtk3(kernel):
     gtk_kernel.start()
 
 
+@register_integration('osx')
 def loop_cocoa(kernel):
     """Start the kernel, coordinating with the Cocoa CFRunLoop event loop
     via the matplotlib MacOSX backend.
@@ -232,18 +265,6 @@ def loop_cocoa(kernel):
             # ensure excepthook is restored
             sys.excepthook = real_excepthook
 
-# mapping of keys to loop functions
-loop_map = {
-    'qt' : loop_qt4,
-    'qt4': loop_qt4,
-    'inline': None,
-    'osx': loop_cocoa,
-    'wx' : loop_wx,
-    'tk' : loop_tk,
-    'gtk': loop_gtk,
-    'gtk3': loop_gtk3,
-    None : None,
-}
 
 
 def enable_gui(gui, kernel=None):

--- a/IPython/lib/inputhook.py
+++ b/IPython/lib/inputhook.py
@@ -546,6 +546,7 @@ current_gui = inputhook_manager.current_gui
 clear_app_refs = inputhook_manager.clear_app_refs
 enable_gui = inputhook_manager.enable_gui
 disable_gui = inputhook_manager.disable_gui
+register = inputhook_manager.register
 guis = inputhook_manager.guihooks
 
 # Deprecated methods: kept for backwards compatibility, do not use in new code

--- a/IPython/lib/inputhook.py
+++ b/IPython/lib/inputhook.py
@@ -549,12 +549,21 @@ register = inputhook_manager.register
 guis = inputhook_manager.guihooks
 
 # Deprecated methods: kept for backwards compatibility, do not use in new code
-enable_wx = lambda app=None: inputhook_manager.enable_gui('wx', app)
-enable_qt4 = lambda app=None: inputhook_manager.enable_gui('qt4', app)
-enable_gtk = lambda app=None: inputhook_manager.enable_gui('gtk', app)
-enable_tk = lambda app=None: inputhook_manager.enable_gui('tk', app)
-enable_glut = lambda app=None: inputhook_manager.enable_gui('glut', app)
-enable_pyglet = lambda app=None: inputhook_manager.enable_gui('pyglet', app)
-enable_gtk3 = lambda app=None: inputhook_manager.enable_gui('gtk3', app)
+def _make_deprecated_enable(name):
+    def enable_toolkit(app=None):
+        warn("This function is deprecated - use enable_gui(%r) instead" % name)
+        inputhook_manager.enable_gui(name, app)
+    
+enable_wx = _make_deprecated_enable('wx')
+enable_qt4 = _make_deprecated_enable('qt4')
+enable_gtk = _make_deprecated_enable('gtk')
+enable_tk = _make_deprecated_enable('tk')
+enable_glut = _make_deprecated_enable('glut')
+enable_pyglet = _make_deprecated_enable('pyglet')
+enable_gtk3 = _make_deprecated_enable('gtk3')
+
+def _deprecated_disable():
+    warn("This function is deprecated: use disable_gui() instead")
+    inputhook_manager.disable_gui()
 disable_wx = disable_qt4 = disable_gtk = disable_gtk3 = disable_glut = \
-        disable_pyglet = inputhook_manager.disable_gui
+        disable_pyglet = _deprecated_disable

--- a/IPython/lib/inputhook.py
+++ b/IPython/lib/inputhook.py
@@ -190,13 +190,12 @@ class InputHookManager(object):
         the names with which to register this GUI integration. The classes
         themselves should subclass :class:`InputHookBase`.
         
-        Examples
-        --------
+        ::
         
-        @inputhook_manager.register('qt')
-        class QtInputHook(InputHookBase):
-            def enable(self, app=None):
-                ...
+            @inputhook_manager.register('qt')
+            class QtInputHook(InputHookBase):
+                def enable(self, app=None):
+                    ...
         """
         def decorator(cls):
             inst = cls(self)

--- a/docs/source/config/eventloops.rst
+++ b/docs/source/config/eventloops.rst
@@ -1,0 +1,103 @@
+================================
+Integrating with GUI event loops
+================================
+
+When the user types ``%gui qt``, IPython integrates itself with the Qt event
+loop, so you can use both a GUI and an interactive prompt together. IPython
+supports a number of common GUI toolkits, but from IPython 3.0, it is possible
+to integrate other event loops without modifying IPython itself.
+
+Terminal IPython handles event loops very differently from the IPython kernel,
+so different steps are needed to integrate with each.
+
+Event loops in the terminal
+---------------------------
+
+In the terminal, IPython uses a blocking Python function to wait for user input.
+However, the Python C API provides a hook, :c:func:`PyOS_InputHook`, which is
+called frequently while waiting for input. This can be set to a function which
+briefly runs the event loop and then returns.
+
+IPython provides Python level wrappers for setting and resetting this hook. To
+use them, subclass :class:`IPython.lib.inputhook.InputHookBase`, and define
+an ``enable(app=None)`` method, which initialises the event loop and calls
+``self.manager.set_inputhook(f)`` with a function which will briefly run the
+event loop before exiting. Decorate the class with a call to
+:func:`IPython.lib.inputhook.register`::
+
+    from IPython.lib.inputhook import register, InputHookBase
+
+    @register('clutter')
+    class ClutterInputHook(InputHookBase):
+        def enable(self, app=None):
+            self.manager.set_inputhook(inputhook_clutter)
+
+You can also optionally define a ``disable()`` method, taking no arguments, if
+there are extra steps needed to clean up. IPython will take care of resetting
+the hook, whether or not you provide a disable method.
+
+The simplest way to define the hook function is just to run one iteration of the
+event loop, or to run until no events are pending. Most event loops provide some
+mechanism to do one of these things. However, the GUI may lag slightly,
+because the hook is only called every 0.1 seconds. Alternatively, the hook can
+keep running the event loop until there is input ready on stdin. IPython
+provides a function to facilitate this:
+
+.. currentmodule:: IPython.lib.inputhook
+
+.. function:: stdin_ready()
+
+   Returns True if there is something ready to read on stdin.
+   
+   If this is the case, the hook function should return immediately.
+   
+   This is implemented for Windows and POSIX systems - on other platforms, it
+   always returns True, so that the hook always gives Python a chance to check
+   for input.
+
+
+Event loops in the kernel
+-------------------------
+
+The kernel runs its own event loop, so it's simpler to integrate with others.
+IPython allows the other event loop to take control, but it must call
+:meth:`IPython.kernel.zmq.kernelbase.Kernel.do_one_iteration` periodically.
+
+To integrate with this, write a function that takes a single argument,
+the IPython kernel instance, arranges for your event loop to call
+``kernel.do_one_iteration()`` at least every ``kernel._poll_interval`` seconds,
+and starts the event loop.
+
+Decorate this function with :func:`IPython.kernel.zmq.eventloops.register_integration`,
+passing in the names you wish to register it for. Here is a slightly simplified
+version of the Tkinter integration already included in IPython::
+
+    @register_integration('tk')
+    def loop_tk(kernel):
+        """Start a kernel with the Tk event loop."""
+        from tkinter import Tk
+
+        # Tk uses milliseconds
+        poll_interval = int(1000*kernel._poll_interval)
+        # For Tkinter, we create a Tk object and call its withdraw method.
+        class Timer(object):
+            def __init__(self, func):
+                self.app = Tk()
+                self.app.withdraw()
+                self.func = func
+
+            def on_timer(self):
+                self.func()
+                self.app.after(poll_interval, self.on_timer)
+
+            def start(self):
+                self.on_timer()  # Call it once to get things going.
+                self.app.mainloop()
+
+        kernel.timer = Timer(kernel.do_one_iteration)
+        kernel.timer.start()
+
+Some event loops can go one better, and integrate checking for messages on the
+kernel's ZMQ sockets, making the kernel more responsive than plain polling. How
+to do this is outside the scope of this document; if you are interested, look at
+the integration with Qt in :mod:`IPython.kernel.zmq.eventloops`.

--- a/docs/source/config/index.rst
+++ b/docs/source/config/index.rst
@@ -30,3 +30,4 @@ Extending and integrating with IPython
    custommagics
    inputtransforms
    callbacks
+   eventloops

--- a/docs/source/whatsnew/pr/inputhook_extensible.rst
+++ b/docs/source/whatsnew/pr/inputhook_extensible.rst
@@ -1,0 +1,4 @@
+* It's now possible to provide mechanisms to integrate IPython with other event
+  loops, in addition to the ones we already support. This lets you run GUI code
+  in IPython with an interactive prompt, and to embed the IPython
+  kernel in GUI applications. See :doc:`/config/eventloops` for details.

--- a/docs/source/whatsnew/pr/inputhook_extensible.rst
+++ b/docs/source/whatsnew/pr/inputhook_extensible.rst
@@ -1,4 +1,7 @@
 * It's now possible to provide mechanisms to integrate IPython with other event
   loops, in addition to the ones we already support. This lets you run GUI code
   in IPython with an interactive prompt, and to embed the IPython
-  kernel in GUI applications. See :doc:`/config/eventloops` for details.
+  kernel in GUI applications. See :doc:`/config/eventloops` for details. As part
+  of this, the direct ``enable_*`` and ``disable_*`` functions for various GUIs
+  in :mod:`IPython.lib.inputhook` have been deprecated in favour of
+  :meth:`~.InputHookManager.enable_gui` and :meth:`~.InputHookManager.disable_gui`.

--- a/examples/IPython Kernel/gui/gui-gtk.py
+++ b/examples/IPython Kernel/gui/gui-gtk.py
@@ -33,7 +33,7 @@ button.show()
 window.show()
 
 try:
-    from IPython.lib.inputhook import enable_gtk
-    enable_gtk()
+    from IPython.lib.inputhook import enable_gui
+    enable_gui('gtk')
 except ImportError:
     gtk.main()

--- a/examples/IPython Kernel/gui/gui-gtk3.py
+++ b/examples/IPython Kernel/gui/gui-gtk3.py
@@ -31,7 +31,7 @@ button.show()
 window.show()
 
 try:
-    from IPython.lib.inputhook import enable_gtk3
-    enable_gtk3()
+    from IPython.lib.inputhook import enable_gui
+    enable_gui('gtk3')
 except ImportError:
     Gtk.main()

--- a/examples/IPython Kernel/gui/gui-pyglet.py
+++ b/examples/IPython Kernel/gui/gui-pyglet.py
@@ -27,7 +27,7 @@ def on_draw():
     label.draw()
 
 try:
-    from IPython.lib.inputhook import enable_pyglet
-    enable_pyglet()
+    from IPython.lib.inputhook import enable_gui
+    enable_gui('pyglet')
 except ImportError:
     pyglet.app.run()

--- a/examples/IPython Kernel/gui/gui-tk.py
+++ b/examples/IPython Kernel/gui/gui-tk.py
@@ -30,6 +30,7 @@ root = Tk()
 app = MyApp(root)
 
 try:
-    from IPython.lib.inputhook import enable_tk; enable_tk(root)
+    from IPython.lib.inputhook import enable_gui
+    enable_gui('tk', root)
 except ImportError:
     root.mainloop()

--- a/examples/IPython Kernel/gui/gui-wx.py
+++ b/examples/IPython Kernel/gui/gui-wx.py
@@ -100,7 +100,7 @@ if __name__ == '__main__':
         frame.Show(True)
 
     try:
-        from IPython.lib.inputhook import enable_wx
-        enable_wx(app)
+        from IPython.lib.inputhook import enable_gui
+        enable_gui('wx', app)
     except ImportError:
         app.MainLoop()


### PR DESCRIPTION
Not ready for merge

Prompted by #5645, @minrk suggested that we should provide an extension mechanism for input hooks, so that that code (which we don't use, test or maintain very much) can be maintained outside IPython. This is a prototype of that.

To define a new GUI integration, you register a class like this:

``` python
from IPython.lib.inputhook import register, InputHookBase

@register('clutter')
class ClutterInputHook(InputHookBase):
    def enable(self, app=None):
        self.manager.set_inputhook(inputhook_clutter)
```

It can also define a `disable()` method, but only one of the 7 we include needs that. Once this code has run (e.g. by importing a module or using `%load_ext`), the user should be able to do `%gui clutter`.

To do:
- [x] Similar mechanisms for the kernel event loop
- [x] Docs
