### PR TITLE
nbconvert: Fix CWD imports

### DIFF
--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -199,8 +199,8 @@ class NbConvertApp(BaseIPythonApplication):
 
     @catch_config_error
     def initialize(self, argv=None):
-        super(NbConvertApp, self).initialize(argv)
         self.init_syspath()
+        super(NbConvertApp, self).initialize(argv)
         self.init_notebooks()
         self.init_writer()
         self.init_postprocessor()

--- a/IPython/nbconvert/tests/files/hello.py
+++ b/IPython/nbconvert/tests/files/hello.py
@@ -1,0 +1,7 @@
+from IPython.nbconvert.writers.base import WriterBase
+
+class HelloWriter(WriterBase):
+
+    def write(self, output, resources, notebook_name=None, **kw):
+        with open('hello.txt', 'w') as outfile:
+            outfile.write('hello world')

--- a/IPython/nbconvert/tests/test_nbconvertapp.py
+++ b/IPython/nbconvert/tests/test_nbconvertapp.py
@@ -200,3 +200,12 @@ class TestNbConvertApp(TestsBase):
                             '--PDFPostProcessor.verbose=True')
             assert os.path.isfile(u'nb1_análisis.tex')
             assert os.path.isfile(u'nb1_análisis.pdf')
+
+    def test_cwd_plugin(self):
+        """
+        Verify that an extension in the cwd can be imported.
+        """
+        with self.create_temp_cwd(['hello.py']):
+            self.create_empty_notebook(u'empty.ipynb')
+            self.call('nbconvert empty --to html --NbConvertApp.writer_class=\'hello.HelloWriter\'')
+            assert os.path.isfile(u'hello.txt')


### PR DESCRIPTION
In master, setting an nbconvert class name to one that's located in the CWD doesn't work (i.e. `c.NbConvertApp.writer_class = 'notebook_copy_writer.NotebookCopyWriter'` ).

The CWD needs to be appended to the Python path before the traitlets are initialized.  This PR also includes a test.
