### PR TITLE
Fix blank slides issue in Reveal slideshow pdf export

### DIFF
--- a/IPython/nbconvert/templates/html/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/html/slides_reveal.tpl
@@ -55,9 +55,16 @@
 <!-- For syntax highlighting -->
 <link rel="stylesheet" href="{{resources.reveal.url_prefix}}/lib/css/zenburn.css">
 
-<!-- If the query includes 'print-pdf', use the PDF print sheet -->
+<!-- If the query includes 'print-pdf', include the PDF print sheet -->
 <script>
-document.write( '<link rel="stylesheet" href="{{resources.reveal.url_prefix}}/css/print/' + ( window.location.search.match( /print-pdf/gi ) ? 'pdf' : 'paper' ) + '.css" type="text/css" media="print">' );
+if( window.location.search.match( /print-pdf/gi ) ) {
+        var link = document.createElement( 'link' );
+        link.rel = 'stylesheet';
+        link.type = 'text/css';
+        link.href = '{{resources.reveal.url_prefix}}/css/print/pdf.css';
+        document.getElementsByTagName( 'head' )[0].appendChild( link );
+}
+
 </script>
 
 <!--[if lt IE 9]>


### PR DESCRIPTION
Applied the bugfix made on the original index.html from
reveal.js project into the template :
- https://github.com/hakimel/reveal.js/commit/08fb6cb2f96a6d97aaa21c35a925ebb59b0b0070
