### PR TITLE
Update notebook.rst fixing broken reference to notebook examples readme

### DIFF
--- a/docs/source/notebook/notebook.rst
+++ b/docs/source/notebook/notebook.rst
@@ -204,7 +204,7 @@ toolbar (which will be "Code", initially), or via :ref:`keyboard shortcuts
 
 For more information on the different things you can do in a notebook,
 see the `collection of examples
-<https://github.com/ipython/ipython/tree/master/examples/notebooks#readme>`_.
+<http://nbviewer.ipython.org/github/ipython/ipython/blob/master/examples/Notebook/Index.ipynb>`_.
 
 Code cells
 ~~~~~~~~~~


### PR DESCRIPTION
Since the notebook directory doesn't contain a readme anymore, updating to point to the index notebook rendered via nbviewer
