### PR TITLE
Limit latex equations to page width for nbconvert.

### DIFF
--- a/IPython/nbconvert/templates/latex/base.tplx
+++ b/IPython/nbconvert/templates/latex/base.tplx
@@ -159,7 +159,7 @@ This template does not define a docclass, the inheriting class must define this.
 ((* block data_latex -*))
     ((*- if output.latex.startswith('$'): -*))
         ((= Replace $ symbols with more explicit, equation block. =))
-        \begin{equation*}\adjustbox{max width=\textwidth}{$
+        \begin{equation*}\adjustbox{max width=\hsize}{$
         ((( output.latex | strip_dollars )))
         $}\end{equation*}
     ((*- else -*))

--- a/IPython/nbconvert/templates/latex/base.tplx
+++ b/IPython/nbconvert/templates/latex/base.tplx
@@ -157,11 +157,11 @@ This template does not define a docclass, the inheriting class must define this.
 
 % Display latex
 ((* block data_latex -*))
-    ((*- if output.latex.startswith('$'): -*)) 
+    ((*- if output.latex.startswith('$'): -*))
         ((= Replace $ symbols with more explicit, equation block. =))
-        \begin{equation*}
+        \begin{equation*}\adjustbox{max width=\textwidth}{$
         ((( output.latex | strip_dollars )))
-        \end{equation*}
+        $}\end{equation*}
     ((*- else -*))
         ((( output.latex )))
     ((*- endif *))


### PR DESCRIPTION
This prevents latex equations from going off the edge of the page. It scales them to the page width if they do and leaves them alone if they don't (using adjustbox max width).  I have tested this against several equation on a test document and have found no problems.
