### PR TITLE
log error message when API requests fail

### DIFF
--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -287,6 +287,7 @@ def json_errors(method):
         except web.HTTPError as e:
             status = e.status_code
             message = e.log_message
+            self.log.warn(message)
             self.set_status(e.status_code)
             self.finish(json.dumps(dict(message=message)))
         except Exception:


### PR DESCRIPTION
we have been silencing our helpful log messages when they are on JSON API requests
