### PR TITLE
Add booktabs package to latex base.tplx

### DIFF
--- a/IPython/nbconvert/templates/latex/base.tplx
+++ b/IPython/nbconvert/templates/latex/base.tplx
@@ -30,6 +30,7 @@ This template does not define a docclass, the inheriting class must define this.
     % internal cross-reference links, web links for URLs, etc.)
     \usepackage{hyperref}
     \usepackage{longtable} % longtable support required by pandoc >1.10
+    \usepackage{booktabs}  % table support for pandoc > 1.12.2
     ((* endblock packages *))
 
     ((* block definitions *))


### PR DESCRIPTION
Trivial fix to include the booktabs package in the base.tplx which is required for tables created with pandoc > 1.12.2 (see [releases](http://johnmacfarlane.net/pandoc/releases.html#pandoc-1.12.2-2013-12-07)) - fixes #5690
