### PR TITLE
support use_cloudpickle in addition to use_dill

### DIFF
--- a/IPython/parallel/client/view.py
+++ b/IPython/parallel/client/view.py
@@ -519,6 +519,12 @@ class DirectView(View):
         pickleutil.use_dill()
         return self.apply(pickleutil.use_dill)
 
+    def use_cloudpickle(self):
+        """Expand serialization support with cloudpickle.
+        """
+        pickleutil.use_cloudpickle()
+        return self.apply(pickleutil.use_cloudpickle)
+
 
     @sync_results
     @save_ids

--- a/IPython/utils/pickleutil.py
+++ b/IPython/utils/pickleutil.py
@@ -68,6 +68,26 @@ def use_dill():
     # disable special function handling, let dill take care of it
     can_map.pop(FunctionType, None)
 
+def use_cloudpickle():
+    """use cloudpickle to expand serialization support
+    
+    adds support for object methods and closures to serialization.
+    """
+    from cloud.serialization import cloudpickle
+    
+    global pickle
+    pickle = cloudpickle
+
+    try:
+        from IPython.kernel.zmq import serialize
+    except ImportError:
+        pass
+    else:
+        serialize.pickle = cloudpickle
+    
+    # disable special function handling, let cloudpickle take care of it
+    can_map.pop(FunctionType, None)
+
 
 #-------------------------------------------------------------------------------
 # Classes

--- a/docs/source/whatsnew/pr/cloudpickle.rst
+++ b/docs/source/whatsnew/pr/cloudpickle.rst
@@ -1,0 +1,5 @@
+* Adds a ``use_cloudpickle`` method to ``DirectView`` objects, which works like
+  ``view.use_dill()``, but causes the ``cloudpickle`` module from PiCloud's
+  `cloud`__ library to be used rather than dill or the builtin pickle module.
+
+  __ https://pypi.python.org/pypi/cloud


### PR DESCRIPTION
In the same manner as `use_dill`, this adds support for PiCloud's `cloudpickle` from their [`cloud`](https://pypi.python.org/pypi/cloud) library. It's by far the most reliable and wtf-free way to do remote code execution in python that I've found. I'm using this hack in some of my own projects and I figured others may as well benefit.
