### PR TITLE
allow keyboard interrupt to break out of ipdb

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -278,6 +278,7 @@ class Pdb(OldPdb):
                 OldPdb.interaction(self, frame, traceback)
             except KeyboardInterrupt:
                 self.shell.write("\nKeyboardInterrupt\n")
+                break
             else:
                 break
 


### PR DESCRIPTION
@takluyver @minrk and I discussed this issue in person.

It's currently problematic that there is no way, short of restarting a kernel,
to get out of an ipdb session if you've deleted the output of the cell in the
notebook which started it (by e.g. re-executing that cell).

This patch makes Ctrl-C behave the same as Ctrl-D inside of ipdb - it exits
the ipdb session. This also makes it possible to stop ipdb sessions from
another client.

I polled @katyhuff, @scopatz, and some other pyne/pyne hackers and they were
surprised to hear that this was not the behavior already.
