### PR TITLE
Removed the dysfunctional "-i" options from the rm,cp and mv aliases

### DIFF
--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -51,7 +51,7 @@ def default_aliases():
 
     if os.name == 'posix':
         default_aliases = [('mkdir', 'mkdir'), ('rmdir', 'rmdir'),
-                           ('mv', 'mv -i'), ('rm', 'rm -i'), ('cp', 'cp -i'),
+                           ('mv', 'mv'), ('rm', 'rm'), ('cp', 'cp'),
                            ('cat', 'cat'),
                            ]
         # Useful set of ls aliases.  The GNU and BSD options are a little


### PR DESCRIPTION
Quick fix for issue #514 where the shell aliases for cp,rm,mv hang if used from the notebook due to the -i option being set.
