### PR TITLE
Calculate real path for symlinked IPython package in sysinfo

### DIFF
--- a/IPython/utils/sysinfo.py
+++ b/IPython/utils/sysinfo.py
@@ -95,7 +95,7 @@ def pkg_info(pkg_path):
 def get_sys_info():
     """Return useful information about IPython and the system, as a dict."""
     p = os.path
-    path = p.dirname(p.abspath(p.join(__file__, '..')))
+    path = p.realpath(p.dirname(p.abspath(p.join(__file__, '..'))))
     return pkg_info(path)
 
 @py3compat.doctest_refactor_print


### PR DESCRIPTION
If you've done `python setup.py symlink`, it's probably more useful for test output to show the real location that the IPython code is coming from, not the location of the symlink.

See discussion on #5725
