### PR TITLE
run js tests separately on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 python:
     - 2.7
     - 3.3
+env:
+    - GROUP=
+    - GROUP=js
 before_install:
     # workaround for https://github.com/travis-ci/travis-cookbooks/issues/155
     - sudo rm -rf /dev/shm && sudo ln -s /run/shm /dev/shm
@@ -14,4 +17,4 @@ before_install:
 install:
     - time python setup.py install -q 
 script:
-    - cd /tmp && iptest
+    - cd /tmp && iptest $GROUP

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,12 @@ python:
 before_install:
     # workaround for https://github.com/travis-ci/travis-cookbooks/issues/155
     - sudo rm -rf /dev/shm && sudo ln -s /run/shm /dev/shm
-    - easy_install -q pyzmq
-    - pip install jinja2 sphinx pygments tornado requests mock
     # Pierre Carrier's PPA for PhantomJS and CasperJS
-    - sudo add-apt-repository -y ppa:pcarrier/ppa
-    - sudo apt-get update
-    - sudo apt-get install pandoc casperjs nodejs
+    - time sudo add-apt-repository -y ppa:pcarrier/ppa
+    - time sudo apt-get update
+    - time sudo apt-get install pandoc casperjs nodejs libzmq3-dev
+    - time pip install jinja2 sphinx pygments tornado requests mock pyzmq
 install:
-    - python setup.py install -q 
+    - time python setup.py install -q 
 script:
     - cd /tmp && iptest

--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -306,9 +306,11 @@ def prepare_controllers(options):
             js_testgroups = [g for g in testgroups if g not in py_testgroups]
     else:
         py_testgroups = py_test_group_names
-        js_testgroups = all_js_groups()
         if not options.all:
+            js_testgroups = []
             test_sections['parallel'].enabled = False
+        else:
+            js_testgroups = all_js_groups()
 
     c_js = [JSController(name) for name in js_testgroups]
     c_py = [PyTestController(name, options) for name in py_testgroups]


### PR DESCRIPTION
Slightly reduces the impact of the extremely slow js tests by running them separately in the build grid.

Just `iptest` will no longer run the js tests (just like parallel).
