### PR TITLE
try wheels for faster dependency installation on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
     - time sudo add-apt-repository -y ppa:pcarrier/ppa
     - time sudo apt-get update
     - time sudo apt-get install pandoc casperjs nodejs libzmq3-dev
-    - time pip install jinja2 sphinx pygments tornado requests mock pyzmq
+    - time pip install -f https://nipy.bic.berkeley.edu/wheelhouse/travis jinja2 sphinx pygments tornado requests mock pyzmq
 install:
     - time python setup.py install -q 
 script:


### PR DESCRIPTION
Wheels built by me, and hosted here at Berkeley.

2to3 on pygments and docutils was adding 2 minutes to install time on Python 3.

I did not upload wheels for pyzmq because they did not import properly on the VM on the first try. But compilation does not take nearly as long as 2to3 (~15s).

Compare [before](https://travis-ci.org/ipython/ipython/builds/23957994) and [after](https://travis-ci.org/minrk/ipython/builds/23956791).
