### PR TITLE
 Issue 2565, take two: provide docking widget that allows to search, paste and run magic commands

### DIFF
--- a/IPython/qt/console/magic_helper.py
+++ b/IPython/qt/console/magic_helper.py
@@ -1,0 +1,179 @@
+"""Magic Helper - dockable widget showing magic commands for the MainWindow
+
+
+Authors:
+
+* Dimitry Kloper
+
+"""
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# stdlib imports
+import json
+import re
+import sys
+
+# System library imports
+from IPython.external.qt import QtGui,QtCore
+
+from IPython.core.magic import magic_escapes
+
+class MagicHelper(QtGui.QDockWidget):
+
+    pasteRequested = QtCore.pyqtSignal(str, name = 'pasteRequested')
+    runRequested = QtCore.pyqtSignal(str, name = 'runRequested')
+
+    #---------------------------------------------------------------------------
+    # 'object' interface
+    #---------------------------------------------------------------------------
+
+    def __init__(self, name, parent):
+
+        super(MagicHelper, self).__init__(name, parent)
+
+        # this is a hack. The main_window reference will be used for 
+        # explicit interface to kernel that must be hidden by signal/slot 
+        # mechanism in the future
+        self.main_window = parent
+
+        self.data = None
+
+        class MinListWidget(QtGui.QListWidget):
+            def sizeHint(self):
+                s = QtCore.QSize()
+                s.setHeight(super(MinListWidget,self).sizeHint().height())
+                s.setWidth(self.sizeHintForColumn(0))
+                return s
+
+        self.frame = QtGui.QFrame()
+        self.search_label = QtGui.QLabel("Search:")
+        self.search_line = QtGui.QLineEdit()
+        self.search_class = QtGui.QComboBox()
+        self.search_list = MinListWidget()
+        self.paste_button = QtGui.QPushButton("Paste")
+        self.run_button = QtGui.QPushButton("Run")
+        
+        main_layout = QtGui.QVBoxLayout()
+        search_layout = QtGui.QHBoxLayout()
+        search_layout.addWidget(self.search_label)
+        search_layout.addWidget(self.search_line, 10)
+        main_layout.addLayout(search_layout)
+        main_layout.addWidget(self.search_class)
+        main_layout.addWidget(self.search_list, 10)
+        action_layout = QtGui.QHBoxLayout()
+        action_layout.addWidget(self.paste_button)
+        action_layout.addWidget(self.run_button)
+        main_layout.addLayout(action_layout)
+
+        self.frame.setLayout(main_layout)
+        self.setWidget(self.frame)
+
+        self.visibilityChanged[bool].connect( self.update_magic_helper )
+        self.search_class.activated[int].connect( 
+            self.class_selected
+        )
+        self.search_line.textChanged[str].connect(
+            self.search_changed
+        )
+        self.search_list.itemDoubleClicked[QtGui.QListWidgetItem].connect(
+            self.paste_requested
+        )
+        self.paste_button.clicked[bool].connect(
+            self.paste_requested
+        )
+        self.run_button.clicked[bool].connect(
+            self.run_requested
+        )
+
+    def update_magic_helper(self, visible):
+        if not visible or self.data != None:
+            return
+        self.data = {}
+        self.search_class.clear()
+        self.search_class.addItem("Populating...")
+        self.main_window.active_frontend._silent_exec_callback(
+            'get_ipython().magic("lsmagic")',
+            self.populate_magic_helper
+        )
+
+    def populate_magic_helper(self, data):
+        if not data:
+            return
+
+        if data['status'] != 'ok':
+            self.main_window.log.warn(
+                "%%lsmagic user-expression failed: {}".format(data)
+            )
+            return
+
+        self.search_class.clear()
+        self.search_list.clear()
+                
+        self.data = json.loads(
+            data['data'].get('application/json', {})
+        )
+        
+        self.search_class.addItem('All Magics', 'any')
+        classes = set()
+
+        for mtype in sorted(self.data):
+            subdict = self.data[mtype]
+            for name in sorted(subdict):
+                classes.add(subdict[name])
+
+        for cls in sorted(classes):
+            label = re.sub("([a-zA-Z]+)([A-Z][a-z])","\g<1> \g<2>", cls)
+            self.search_class.addItem(label, cls)
+
+        self.filter_magic_helper('.', 'any')
+
+    def class_selected(self, index):
+        item = self.search_class.itemData(index)
+        regex = self.search_line.text()
+        self.filter_magic_helper(regex = regex, cls = item)
+
+    def search_changed(self, search_string):
+        item = self.search_class.itemData(
+            self.search_class.currentIndex()
+        )
+        self.filter_magic_helper(regex = search_string, cls = item)
+
+    def _get_current_search_item(self, item = None):
+        text = None
+        if not isinstance(item, QtGui.QListWidgetItem):
+            item = self.search_list.currentItem()        
+        text = item.text()
+        return text
+
+    def paste_requested(self, item = None):
+        text = self._get_current_search_item(item)
+        if text != None:
+            self.pasteRequested.emit(text)
+
+    def run_requested(self, item = None):
+        text = self._get_current_search_item(item)
+        if text != None:            
+            self.runRequested.emit(text)
+
+    def filter_magic_helper(self, regex, cls):
+        if regex == "" or regex == None:
+            regex = '.'
+        if cls == None:
+            cls = 'any'
+
+        self.search_list.clear()
+        for mtype in sorted(self.data):
+            subdict = self.data[mtype]
+            prefix = magic_escapes[mtype]
+
+            for name in sorted(subdict):
+                mclass = subdict[name]
+                pmagic = prefix + name
+
+                if (re.match(regex, name) or re.match(regex, pmagic)) and \
+                   (cls == 'any' or cls == mclass): 
+                    self.search_list.addItem(pmagic)
+

--- a/IPython/qt/console/magic_helper.py
+++ b/IPython/qt/console/magic_helper.py
@@ -1,9 +1,4 @@
 """MagicHelper - dockable widget showing magic commands for the MainWindow
-
-
-Authors:
-
-* Dimitry Kloper
 """
 
 # Copyright (c) IPython Development Team.

--- a/IPython/qt/console/magic_helper.py
+++ b/IPython/qt/console/magic_helper.py
@@ -4,8 +4,10 @@
 Authors:
 
 * Dimitry Kloper
-
 """
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License. 
 
 #-----------------------------------------------------------------------------
 # Imports

--- a/IPython/qt/console/magic_helper.py
+++ b/IPython/qt/console/magic_helper.py
@@ -27,16 +27,16 @@ class MagicHelper(QtGui.QDockWidget):
     # signals
     #---------------------------------------------------------------------------
 
-    pasteRequested = QtCore.pyqtSignal(str, name = 'pasteRequested')
+    pasteRequested = QtCore.Signal(str, name = 'pasteRequested')
     """This signal is emitted when user wants to paste selected magic 
        command into the command line.
     """
 
-    runRequested = QtCore.pyqtSignal(str, name = 'runRequested')
+    runRequested = QtCore.Signal(str, name = 'runRequested')
     """This signal is emitted when user wants to execute selected magic command
     """
 
-    readyForUpdate = QtCore.pyqtSignal(name = 'readyForUpdate')
+    readyForUpdate = QtCore.Signal(name = 'readyForUpdate')
     """This signal is emitted when MagicHelper is ready to be populated.
        Since kernel querying mechanisms are out of scope of this class,
        it expects its owner to invoke MagicHelper.populate_magic_helper()

--- a/IPython/qt/console/magic_helper.py
+++ b/IPython/qt/console/magic_helper.py
@@ -25,6 +25,7 @@ class MagicHelper(QtGui.QDockWidget):
 
     pasteRequested = QtCore.pyqtSignal(str, name = 'pasteRequested')
     runRequested = QtCore.pyqtSignal(str, name = 'runRequested')
+    readyForUpdate = QtCore.pyqtSignal(name = 'readyForUpdate')
 
     #---------------------------------------------------------------------------
     # 'object' interface
@@ -33,11 +34,6 @@ class MagicHelper(QtGui.QDockWidget):
     def __init__(self, name, parent):
 
         super(MagicHelper, self).__init__(name, parent)
-
-        # this is a hack. The main_window reference will be used for 
-        # explicit interface to kernel that must be hidden by signal/slot 
-        # mechanism in the future
-        self.main_window = parent
 
         self.data = None
 
@@ -94,21 +90,9 @@ class MagicHelper(QtGui.QDockWidget):
         self.data = {}
         self.search_class.clear()
         self.search_class.addItem("Populating...")
-        self.main_window.active_frontend._silent_exec_callback(
-            'get_ipython().magic("lsmagic")',
-            self.populate_magic_helper
-        )
+        self.readyForUpdate.emit()
 
     def populate_magic_helper(self, data):
-        if not data:
-            return
-
-        if data['status'] != 'ok':
-            self.main_window.log.warn(
-                "%%lsmagic user-expression failed: {}".format(data)
-            )
-            return
-
         self.search_class.clear()
         self.search_list.clear()
                 

--- a/IPython/qt/console/magic_helper.py
+++ b/IPython/qt/console/magic_helper.py
@@ -1,4 +1,4 @@
-"""Magic Helper - dockable widget showing magic commands for the MainWindow
+"""MagicHelper - dockable widget showing magic commands for the MainWindow
 
 
 Authors:
@@ -22,28 +22,50 @@ from IPython.external.qt import QtGui,QtCore
 from IPython.core.magic import magic_escapes
 
 class MagicHelper(QtGui.QDockWidget):
-
-    pasteRequested = QtCore.pyqtSignal(str, name = 'pasteRequested')
-    runRequested = QtCore.pyqtSignal(str, name = 'runRequested')
-    readyForUpdate = QtCore.pyqtSignal(name = 'readyForUpdate')
+    """MagicHelper - dockable widget for convenient search and running of
+                     magic command for IPython QtConsole.
+    """
 
     #---------------------------------------------------------------------------
-    # 'object' interface
+    # signals
+    #---------------------------------------------------------------------------
+
+    pasteRequested = QtCore.pyqtSignal(str, name = 'pasteRequested')
+    """This signal is emitted when user wants to paste selected magic 
+       command into the command line.
+    """
+
+    runRequested = QtCore.pyqtSignal(str, name = 'runRequested')
+    """This signal is emitted when user wants to execute selected magic command
+    """
+
+    readyForUpdate = QtCore.pyqtSignal(name = 'readyForUpdate')
+    """This signal is emitted when MagicHelper is ready to be populated.
+       Since kernel querying mechanisms are out of scope of this class,
+       it expects its owner to invoke MagicHelper.populate_magic_helper()
+       as a reaction on this event.
+    """
+
+    #---------------------------------------------------------------------------
+    # constructor
     #---------------------------------------------------------------------------
 
     def __init__(self, name, parent):
-
         super(MagicHelper, self).__init__(name, parent)
 
         self.data = None
 
         class MinListWidget(QtGui.QListWidget):
+            """Temp class to overide the default QListWidget size hint
+               in order to make MagicHelper narrow
+            """
             def sizeHint(self):
                 s = QtCore.QSize()
                 s.setHeight(super(MinListWidget,self).sizeHint().height())
                 s.setWidth(self.sizeHintForColumn(0))
                 return s
 
+        # construct content
         self.frame = QtGui.QFrame()
         self.search_label = QtGui.QLabel("Search:")
         self.search_line = QtGui.QLineEdit()
@@ -52,6 +74,7 @@ class MagicHelper(QtGui.QDockWidget):
         self.paste_button = QtGui.QPushButton("Paste")
         self.run_button = QtGui.QPushButton("Run")
         
+        # layout all the widgets
         main_layout = QtGui.QVBoxLayout()
         search_layout = QtGui.QHBoxLayout()
         search_layout.addWidget(self.search_label)
@@ -67,7 +90,8 @@ class MagicHelper(QtGui.QDockWidget):
         self.frame.setLayout(main_layout)
         self.setWidget(self.frame)
 
-        self.visibilityChanged[bool].connect( self.update_magic_helper )
+        # connect all the relevant signals to handlers
+        self.visibilityChanged[bool].connect( self._update_magic_helper )
         self.search_class.activated[int].connect( 
             self.class_selected
         )
@@ -84,15 +108,29 @@ class MagicHelper(QtGui.QDockWidget):
             self.run_requested
         )
 
-    def update_magic_helper(self, visible):
+    #---------------------------------------------------------------------------
+    # implementation
+    #---------------------------------------------------------------------------
+
+    def _update_magic_helper(self, visible):
+        """Start update sequence. 
+           This method is called when MagicHelper becomes visible. It clears
+           the content and emits readyForUpdate signal. The owner of the 
+           instance is expected to invoke populate_magic_helper() when magic
+           info is available.
+        """
         if not visible or self.data != None:
             return
         self.data = {}
         self.search_class.clear()
         self.search_class.addItem("Populating...")
+        self.search_list.clear()
         self.readyForUpdate.emit()
 
     def populate_magic_helper(self, data):
+        """Expects data returned by lsmagics query from kernel.
+           Populates the search_class and search_list with relevant items.
+        """
         self.search_class.clear()
         self.search_list.clear()
                 
@@ -115,17 +153,24 @@ class MagicHelper(QtGui.QDockWidget):
         self.filter_magic_helper('.', 'any')
 
     def class_selected(self, index):
+        """Handle search_class selection changes
+        """
         item = self.search_class.itemData(index)
         regex = self.search_line.text()
         self.filter_magic_helper(regex = regex, cls = item)
 
     def search_changed(self, search_string):
+        """Handle search_line text changes.
+           The text is interpreted as a regular expression
+        """
         item = self.search_class.itemData(
             self.search_class.currentIndex()
         )
         self.filter_magic_helper(regex = search_string, cls = item)
 
     def _get_current_search_item(self, item = None):
+        """Retrieve magic command currently selected in the search_list
+        """
         text = None
         if not isinstance(item, QtGui.QListWidgetItem):
             item = self.search_list.currentItem()        
@@ -133,16 +178,24 @@ class MagicHelper(QtGui.QDockWidget):
         return text
 
     def paste_requested(self, item = None):
+        """Emit pasteRequested signal with currently selected item text
+        """
         text = self._get_current_search_item(item)
         if text != None:
             self.pasteRequested.emit(text)
 
     def run_requested(self, item = None):
+        """Emit runRequested signal with currently selected item text
+        """
         text = self._get_current_search_item(item)
         if text != None:            
             self.runRequested.emit(text)
 
     def filter_magic_helper(self, regex, cls):
+        """Update search_list with magic commands whose text match
+           regex and class match cls.
+           If cls equals 'any' - any class matches.
+        """
         if regex == "" or regex == None:
             regex = '.'
         if cls == None:

--- a/IPython/qt/console/mainwindow.py
+++ b/IPython/qt/console/mainwindow.py
@@ -653,12 +653,8 @@ class MainWindow(QtGui.QMainWindow):
                     self,
                     triggered=self._make_dynamic_magic(pmagic)
                     )
-                xaction_all = QtGui.QAction(pmagic,
-                    self,
-                    triggered=self._make_dynamic_magic(pmagic)
-                    )
                 magic_menu.addAction(xaction)
-                self.all_magic_menu.addAction(xaction_all)
+                self.all_magic_menu.addAction(xaction)
 
     def update_all_magic_menu(self):
         """ Update the list of magics in the "All Magics..." Menu

--- a/IPython/qt/console/mainwindow.py
+++ b/IPython/qt/console/mainwindow.py
@@ -2,17 +2,6 @@
 
 This is a tabbed pseudo-terminal of IPython sessions, with a menu bar for
 common actions.
-
-Authors:
-
-* Evan Patterson
-* Min RK
-* Erik Tollerud
-* Fernando Perez
-* Bussonnier Matthias
-* Thomas Kluyver
-* Paul Ivanov
-
 """
 
 # Copyright (c) IPython Development Team.

--- a/IPython/qt/console/mainwindow.py
+++ b/IPython/qt/console/mainwindow.py
@@ -813,6 +813,162 @@ class MainWindow(QtGui.QMainWindow):
             triggered=self._open_online_help)
         self.add_menu_action(self.help_menu, self.onlineHelpAct)
 
+    def init_magic_helper(self):
+        self.magic_helper_data = None
+        self.magic_helper = QtGui.QDockWidget("Magics", self)
+        self.magic_helper.setAllowedAreas(QtCore.Qt.LeftDockWidgetArea | 
+                                          QtCore.Qt.RightDockWidgetArea)        
+        self.magic_helper.setVisible(False)
+
+        class MinListWidget(QtGui.QListWidget):
+            def sizeHint(self):
+                s = QtCore.QSize()
+                s.setHeight(super(MinListWidget,self).sizeHint().height())
+                s.setWidth(self.sizeHintForColumn(0))
+                return s
+
+        self.magic_helper_frame = QtGui.QFrame()
+        self.magic_helper_searchl = QtGui.QLabel("Search:")
+        self.magic_helper_search = QtGui.QLineEdit()
+        self.magic_helper_class = QtGui.QComboBox()
+        self.magic_helper_list = MinListWidget()
+        self.magic_helper_paste = QtGui.QPushButton("Paste")
+        self.magic_helper_run = QtGui.QPushButton("Run")
+        
+        main_layout = QtGui.QVBoxLayout()
+        search_layout = QtGui.QHBoxLayout()
+        search_layout.addWidget(self.magic_helper_searchl)
+        search_layout.addWidget(self.magic_helper_search, 10)
+        main_layout.addLayout(search_layout)
+        main_layout.addWidget(self.magic_helper_class)
+        main_layout.addWidget(self.magic_helper_list, 10)
+        action_layout = QtGui.QHBoxLayout()
+        action_layout.addWidget(self.magic_helper_paste)
+        action_layout.addWidget(self.magic_helper_run)
+        main_layout.addLayout(action_layout)
+
+        self.magic_helper_frame.setLayout(main_layout)
+        self.magic_helper.setWidget(self.magic_helper_frame)
+
+        self.magic_helper.visibilityChanged[bool].connect(
+            self.update_magic_helper
+        )
+        self.magic_helper_class.activated[int].connect(
+            self.magic_helper_class_selected
+        )
+        self.magic_helper_search.textChanged[str].connect(
+            self.magic_helper_search_changed
+        )
+        self.magic_helper_list.itemDoubleClicked[QtGui.QListWidgetItem].connect(
+            self.magic_helper_paste_requested
+        )
+        self.magic_helper_paste.clicked[bool].connect(
+            self.magic_helper_paste_requested
+        )
+        self.magic_helper_run.clicked[bool].connect(
+            self.magic_helper_run_requested
+        )
+
+        self.addDockWidget(QtCore.Qt.RightDockWidgetArea, self.magic_helper)
+        self.add_menu_action(self.magic_menu, 
+                             self.magic_helper.toggleViewAction())
+
+    def update_magic_helper(self, visible):
+        if not visible or self.magic_helper_data != None:
+            return
+        self.magic_helper_data = {}
+        self.magic_helper_class.clear()
+        self.magic_helper_class.addItem("Populating...")
+        self.active_frontend._silent_exec_callback(
+            'get_ipython().magic("lsmagic")',
+            self.populate_magic_helper
+        )
+
+    def populate_magic_helper(self, data):
+        if not data:
+            return
+
+        if data['status'] != 'ok':
+            self.log.warn("%%lsmagic user-expression failed: {}".format(data))
+            return
+
+        self.magic_helper_class.clear()
+        self.magic_helper_list.clear()
+                
+        self.magic_helper_data = json.loads(
+            data['data'].get('application/json', {})
+        )
+        
+        self.magic_helper_class.addItem('All Magics', 'any')
+        classes = set()
+
+        for mtype in sorted(self.magic_helper_data):
+            subdict = self.magic_helper_data[mtype]
+            for name in sorted(subdict):
+                classes.add(subdict[name])
+
+        for cls in sorted(classes):
+            label = re.sub("([a-zA-Z]+)([A-Z][a-z])","\g<1> \g<2>", cls)
+            self.magic_helper_class.addItem(label, cls)
+
+        self.filter_magic_helper('.', 'any')
+
+    def magic_helper_class_selected(self, index):
+        item = self.magic_helper_class.itemData(index)
+        regex = self.magic_helper_search.text()
+        self.filter_magic_helper(regex = regex, cls = item)
+
+    def magic_helper_search_changed(self, search_string):
+        item = self.magic_helper_class.itemData(
+            self.magic_helper_class.currentIndex()
+        )
+        self.filter_magic_helper(regex = search_string, cls = item)
+
+    def _magic_helper_get_current(self, item = None):
+        text = None
+        if not isinstance(item, QtGui.QListWidgetItem):
+            item = self.magic_helper_list.currentItem()        
+        text = item.text()
+        return text
+
+    def _set_active_frontend_focus(self):
+        # this is a hack, self.active_frontend._control seems to be 
+        # a private member. Unfortunately this is the only method 
+        # to set focus reliably
+        QtCore.QTimer.singleShot(200, self.active_frontend._control.setFocus)
+
+    def magic_helper_paste_requested(self, item = None):
+        text = self._magic_helper_get_current(item)
+        if text != None:
+            self.active_frontend.input_buffer = text            
+            self._set_active_frontend_focus()
+
+    def magic_helper_run_requested(self, item = None):
+        text = self._magic_helper_get_current(item)
+        if text != None:            
+            self.active_frontend.execute(text)  
+            self._set_active_frontend_focus()
+
+    def filter_magic_helper(self, regex, cls):
+        if regex == "" or regex == None:
+            regex = '.'
+        if cls == None:
+            cls = 'any'
+
+        self.magic_helper_list.clear()
+        for mtype in sorted(self.magic_helper_data):
+            subdict = self.magic_helper_data[mtype]
+            prefix = magic_escapes[mtype]
+
+            for name in sorted(subdict):
+                mclass = subdict[name]
+                pmagic = prefix + name
+
+                if (re.match(regex, name) or re.match(regex, pmagic)) and \
+                   (cls == 'any' or cls == mclass): 
+                    self.magic_helper_list.addItem(pmagic)
+
+        
     # minimize/maximize/fullscreen actions:
 
     def toggle_menu_bar(self):

--- a/IPython/qt/console/mainwindow.py
+++ b/IPython/qt/console/mainwindow.py
@@ -15,6 +15,10 @@ Authors:
 
 """
 
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License. 
+
+
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------

--- a/IPython/qt/console/mainwindow.py
+++ b/IPython/qt/console/mainwindow.py
@@ -713,6 +713,9 @@ class MainWindow(QtGui.QMainWindow):
         self.magic_helper.runRequested[str].connect(
             self.magic_helper_run_requested
         )
+        self.magic_helper.readyForUpdate.connect(
+            self.magic_helper_update_requested
+        )
 
         self.addDockWidget(QtCore.Qt.RightDockWidgetArea, self.magic_helper)
 
@@ -732,8 +735,23 @@ class MainWindow(QtGui.QMainWindow):
             self.active_frontend.execute(text)  
             self._set_active_frontend_focus()
 
+    def magic_helper_update_requested(self):
+        def _handle_data(data):
+            if not data:
+                return
 
-        
+            if data['status'] != 'ok':
+                self.log.warn( 
+                    "%%lsmagic user-expression failed: {}".format(data)
+                )
+                return
+            self.magic_helper.populate_magic_helper(data)
+
+        self.active_frontend._silent_exec_callback(
+            'get_ipython().magic("lsmagic")',
+            _handle_data
+        )
+
     # minimize/maximize/fullscreen actions:
 
     def toggle_menu_bar(self):

--- a/IPython/qt/console/qtconsoleapp.py
+++ b/IPython/qt/console/qtconsoleapp.py
@@ -15,6 +15,9 @@ Authors:
 
 """
 
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License. 
+
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------

--- a/IPython/qt/console/qtconsoleapp.py
+++ b/IPython/qt/console/qtconsoleapp.py
@@ -271,8 +271,8 @@ class IPythonQtConsoleApp(BaseIPythonApplication, IPythonConsoleApp):
                                 )
         self.window.log = self.log
         self.window.add_tab_with_frontend(self.widget)
-        self.window.init_menu_bar()
         self.window.init_magic_helper()
+        self.window.init_menu_bar()
 
         # Ignore on OSX, where there is always a menu bar
         if sys.platform != 'darwin' and self.hide_menubar:

--- a/IPython/qt/console/qtconsoleapp.py
+++ b/IPython/qt/console/qtconsoleapp.py
@@ -2,17 +2,6 @@
 
 This is not a complete console app, as subprocess will not be able to receive
 input, there is no real readline support, among other limitations.
-
-Authors:
-
-* Evan Patterson
-* Min RK
-* Erik Tollerud
-* Fernando Perez
-* Bussonnier Matthias
-* Thomas Kluyver
-* Paul Ivanov
-
 """
 
 # Copyright (c) IPython Development Team.

--- a/IPython/qt/console/qtconsoleapp.py
+++ b/IPython/qt/console/qtconsoleapp.py
@@ -272,6 +272,7 @@ class IPythonQtConsoleApp(BaseIPythonApplication, IPythonConsoleApp):
         self.window.log = self.log
         self.window.add_tab_with_frontend(self.widget)
         self.window.init_menu_bar()
+        self.window.init_magic_helper()
 
         # Ignore on OSX, where there is always a menu bar
         if sys.platform != 'darwin' and self.hide_menubar:


### PR DESCRIPTION
This is continuation of PR #5649.
a. I have re-implemented the whole "all magics" menu to be a simple docking widget that allows search, paste and run magic commands.
b. Search text works as regular expression. It is applied only on magics of class selected by the combo.
c. Double clicking pastes the magic command into the command line. 

![1](https://cloud.githubusercontent.com/assets/2404104/2833893/9825fee4-cfd6-11e3-8d14-2c2c0c5c090c.gif)
