### PR TITLE
Add adapter for msg spec versions

### DIFF
--- a/IPython/html/base/zmqhandlers.py
+++ b/IPython/html/base/zmqhandlers.py
@@ -1,20 +1,7 @@
-"""Tornado handlers for WebSocket <-> ZMQ sockets.
+"""Tornado handlers for WebSocket <-> ZMQ sockets."""
 
-Authors:
-
-* Brian Granger
-"""
-
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2011  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 try:
     from urllib.parse import urlparse # Py 3
@@ -37,9 +24,6 @@ from IPython.utils.py3compat import PY3, cast_unicode
 
 from .handlers import IPythonHandler
 
-#-----------------------------------------------------------------------------
-# ZMQ handlers
-#-----------------------------------------------------------------------------
 
 class ZMQStreamHandler(websocket.WebSocketHandler):
 

--- a/IPython/html/services/kernels/handlers.py
+++ b/IPython/html/services/kernels/handlers.py
@@ -1,20 +1,7 @@
-"""Tornado handlers for the notebook.
+"""Tornado handlers for kernels."""
 
-Authors:
-
-* Brian Granger
-"""
-
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2011  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 import logging
 from tornado import web
@@ -22,15 +9,13 @@ from tornado import web
 from zmq.utils import jsonapi
 
 from IPython.utils.jsonutil import date_default
+from IPython.utils.py3compat import string_types
 from IPython.html.utils import url_path_join, url_escape
 
 from ...base.handlers import IPythonHandler, json_errors
 from ...base.zmqhandlers import AuthenticatedZMQStreamHandler
 
-#-----------------------------------------------------------------------------
-# Kernel handlers
-#-----------------------------------------------------------------------------
-
+from IPython.core.release import kernel_protocol_version
 
 class MainKernelHandler(IPythonHandler):
 
@@ -96,6 +81,34 @@ class ZMQChannelHandler(AuthenticatedZMQStreamHandler):
         km = self.kernel_manager
         meth = getattr(km, 'connect_%s' % self.channel)
         self.zmq_stream = meth(self.kernel_id, identity=self.session.bsession)
+        self.kernel_info_channel = None
+        self.kernel_info_channel = km.connect_shell(self.kernel_id)
+        self.kernel_info_channel.on_recv(self._handle_kernel_info)
+        self._request_kernel_info()
+    
+    def _request_kernel_info(self):
+        self.log.debug("requesting kernel info")
+        self.session.send(self.kernel_info_channel, "kernel_info_request")
+    
+    def _handle_kernel_info(self, msg):
+        idents,msg = self.session.feed_identities(msg)
+        try:
+            msg = self.session.unserialize(msg)
+        except:
+            self.log.error("Bad kernel_info reply", exc_info=True)
+            self._request_kernel_info()
+            return
+        else:
+            if msg['msg_type'] != 'kernel_info_reply' or 'protocol_version' not in msg['content']:
+                self.log.error("Kernel info request failed, assuming current %s", msg['content'])
+            else:
+                protocol_version = msg['content']['protocol_version']
+                if protocol_version != kernel_protocol_version:
+                    self.session.adapt_version = int(protocol_version.split('.')[0])
+                    self.log.info("adapting kernel to %s" % protocol_version)
+        self.kernel_info_channel.close()
+        self.kernel_info_channel = None
+    
     
     def initialize(self, *args, **kwargs):
         self.zmq_stream = None

--- a/IPython/html/static/notebook/js/completer.js
+++ b/IPython/html/static/notebook/js/completer.js
@@ -171,6 +171,15 @@ var IPython = (function (IPython) {
         var matches = content.matches;
 
         var cur = this.editor.getCursor();
+        if (end === null) {
+            // adapted message spec replies don't have cursor position info,
+            // interpret end=null as current position,
+            // and negative start relative to that
+            end = utils.to_absolute_cursor_pos(this.editor, cur);
+            if (start < 0) {
+                start = end + start;
+            }
+        }
         var results = CodeMirror.contextHint(this.editor);
         var filtered_results = [];
         //remove results from context completion

--- a/IPython/kernel/adapter.py
+++ b/IPython/kernel/adapter.py
@@ -1,0 +1,295 @@
+"""Adapters for IPython msg spec versions."""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import json
+
+from IPython.core.release import kernel_protocol_version, kernel_protocol_version_info
+from IPython.utils.tokenutil import token_at_cursor
+
+
+def code_to_line(code, cursor_pos):
+    """Turn a multiline code block and cursor position into a single line
+    and new cursor position.
+    
+    For adapting complete_ and object_info_requests.
+    """
+    for line in code.splitlines(True):
+        n = len(line)
+        if cursor_pos > n:
+            cursor_pos -= n
+        else:
+            break
+    return line, cursor_pos
+
+
+class Adapter(object):
+    """Base class for adapting messages
+    
+    Override message_type(msg) methods to create adapters.
+    """
+    
+    msg_type_map = {}
+    
+    def update_header(self, msg):
+        return msg
+    
+    def update_metadata(self, msg):
+        return msg
+    
+    def update_msg_type(self, msg):
+        header = msg['header']
+        msg_type = header['msg_type']
+        if msg_type in self.msg_type_map:
+            msg['msg_type'] = header['msg_type'] = self.msg_type_map[msg_type]
+        return msg
+    
+    def __call__(self, msg):
+        msg = self.update_header(msg)
+        msg = self.update_metadata(msg)
+        msg = self.update_msg_type(msg)
+        header = msg['header']
+        
+        handler = getattr(self, header['msg_type'], None)
+        if handler is None:
+            return msg
+        return handler(msg)
+
+def _version_str_to_list(version):
+    """convert a version string to a list of ints
+    
+    non-int segments are excluded
+    """
+    v = []
+    for part in content[key].split('.'):
+        try:
+            v.append(int(part))
+        except ValueError:
+            pass
+    return v
+
+class V5toV4(Adapter):
+    """Adapt msg protocol v5 to v4"""
+    
+    version = '4.1'
+    
+    msg_type_map = {
+        'execute_result' : 'pyout',
+        'execute_input' : 'pyin',
+        'error' : 'pyerr',
+        'inspect_request' : 'object_info_request',
+        'inspect_reply' : 'object_info_reply',
+    }
+    
+    def update_header(self, msg):
+        msg['header'].pop('version', None)
+        return msg
+    
+    # shell channel
+    
+    def kernel_info_reply(self, msg):
+        content = msg['content']
+        content.pop('banner', None)
+        for key in ('language_version', 'protocol_version'):
+            if key in content:
+                content[key] = _version_str_to_list(content[key])
+        if content.pop('implementation', '') == 'ipython' \
+            and 'implementation_version' in content:
+            content['ipython_version'] = content.pop('implmentation_version')
+        content.pop('implementation_version', None)
+        content.setdefault("implmentation", content['language'])
+        return msg
+    
+    def execute_request(self, msg):
+        content = msg['content']
+        content.setdefault('user_variables', [])
+        return msg
+    
+    def execute_reply(self, msg):
+        content = msg['content']
+        content.setdefault('user_variables', {})
+        # TODO: handle payloads
+        return msg
+    
+    def complete_request(self, msg):
+        content = msg['content']
+        code = content['code']
+        cursor_pos = content['cursor_pos']
+        line, cursor_pos = code_to_line(code, cursor_pos)
+        
+        new_content = msg['content'] = {}
+        new_content['text'] = ''
+        new_content['line'] = line
+        new_content['blob'] = None
+        new_content['cursor_pos'] = cursor_pos
+        return msg
+    
+    def complete_reply(self, msg):
+        content = msg['content']
+        cursor_start = content.pop('cursor_start')
+        cursor_end = content.pop('cursor_end')
+        match_len = cursor_end - cursor_start
+        content['matched_text'] = content['matches'][0][:match_len]
+        content.pop('metadata', None)
+        return msg
+    
+    def object_info_request(self, msg):
+        content = msg['content']
+        code = content['code']
+        cursor_pos = content['cursor_pos']
+        line, cursor_pos = code_to_line(code, cursor_pos)
+        
+        new_content = msg['content'] = {}
+        new_content['name'] = token_at_cursor(code, cursor_pos)
+        new_content['detail_level'] = content['detail_level']
+        return msg
+    
+    def object_info_reply(self, msg):
+        """inspect_reply can't be easily backward compatible"""
+        msg['content'] = {'found' : False, 'name' : 'unknown'}
+        return msg
+    
+    # iopub channel
+    
+    def display_data(self, msg):
+        content = msg['content']
+        content.setdefault("source", "display")
+        return msg
+    
+    # stdin channel
+    
+    def input_request(self, msg):
+        msg['content'].pop('password', None)
+        return msg
+
+def _tuple_to_str(version):
+    return ".".join(map(str, version))
+
+class V4toV5(Adapter):
+    """Convert msg spec V4 to V5"""
+    version = kernel_protocol_version
+    
+    # invert message renames above
+    msg_type_map = {v:k for k,v in V5toV4.msg_type_map.items()}
+    
+    def update_header(self, msg):
+        msg['header']['version'] = self.version
+        return msg
+    
+    # shell channel
+    
+    def kernel_info_reply(self, msg):
+        content = msg['content']
+        for key in ('language_version', 'protocol_version', 'ipython_version'):
+            if key in content:
+                content[key] = ".".join(map(str, content[key]))
+        
+        if content['language'].startswith('python') and 'ipython_version' in content:
+            content['implementation'] = 'ipython'
+            content['implementation_version'] = content.pop('ipython_version')
+        
+        content['banner'] = ''
+        return msg
+    
+    def execute_request(self, msg):
+        content = msg['content']
+        user_variables = content.pop('user_variables', [])
+        user_expressions = content.setdefault('user_expressions', {})
+        for v in user_variables:
+            user_expressions[v] = v
+        return msg
+    
+    def execute_reply(self, msg):
+        content = msg['content']
+        user_expressions = content.setdefault('user_expressions', {})
+        user_variables = content.pop('user_variables', {})
+        if user_variables:
+            user_expressions.update(user_variables)
+        return msg
+    
+    def complete_request(self, msg):
+        old_content = msg['content']
+        
+        new_content = msg['content'] = {}
+        new_content['code'] = old_content['line']
+        new_content['cursor_pos'] = old_content['cursor_pos']
+        return msg
+    
+    def complete_reply(self, msg):
+        # TODO: complete_reply needs more context than we have
+        # Maybe strip common prefix and give magic cursor_start = cursor_end = 0?
+        content = msg['content'] = {}
+        content['matches'] = []
+        content['cursor_start'] = content['cursor_end'] = 0
+        content['metadata'] = {}
+        return msg
+    
+    def inspect_request(self, msg):
+        content = msg['content']
+        name = content['name']
+        
+        new_content = msg['content'] = {}
+        new_content['code'] = name
+        new_content['cursor_pos'] = len(name) - 1
+        new_content['detail_level'] = content['detail_level']
+        return msg
+    
+    def inspect_reply(self, msg):
+        """inspect_reply can't be easily backward compatible"""
+        msg['content'] = {'found' : False, 'name' : 'unknown'}
+        return msg
+    
+    # iopub channel
+    
+    def display_data(self, msg):
+        content = msg['content']
+        content.pop("source", None)
+        data = content['data']
+        if 'application/json' in data:
+            data['application/json'] = json.dumps(data['application/json'])
+        return msg
+    
+    # stdin channel
+    
+    def input_request(self, msg):
+        msg['content'].setdefault('password', False)
+        return msg
+    
+
+
+def adapt(msg, to_version=kernel_protocol_version_info[0]):
+    """Adapt a single message to a target version
+    
+    Parameters
+    ----------
+    
+    msg : dict
+        An IPython message.
+    to_version : int, optional
+        The target major version.
+        If unspecified, adapt to the current version for IPython.
+    
+    Returns
+    -------
+    
+    msg : dict
+        An IPython message appropriate in the new version.
+    """
+    header = msg['header']
+    if 'version' in header:
+        from_version = int(header['version'].split('.')[0])
+    else:
+        # assume last version before adding the key to the header
+        from_version = 4
+    adapter = adapters.get((from_version, to_version), None)
+    if adapter is None:
+        return msg
+    return adapter(msg)
+
+
+# one adapter per major version from,to
+adapters = {
+    (5,4) : V5toV4(),
+    (4,5) : V4toV5(),
+}

--- a/IPython/kernel/blocking/channels.py
+++ b/IPython/kernel/blocking/channels.py
@@ -63,7 +63,10 @@ class BlockingIOPubChannel(BlockingChannelMixin, IOPubChannel):
 
 
 class BlockingShellChannel(BlockingChannelMixin, ShellChannel):
-    pass
+    def call_handlers(self, msg):
+        if msg['msg_type'] == 'kernel_info_reply':
+            self._handle_kernel_info_reply(msg)
+        return super(BlockingShellChannel, self).call_handlers(msg)
 
 
 class BlockingStdInChannel(BlockingChannelMixin, StdInChannel):

--- a/IPython/kernel/tests/test_adapter.py
+++ b/IPython/kernel/tests/test_adapter.py
@@ -114,13 +114,11 @@ class V4toV5TestCase(AdapterTest):
         v4, v5 = self.adapt(msg)
         v4c = v4['content']
         v5c = v5['content']
-        n = len(v4c['matched_text'])
-        expected_matches = [ m[n:] for m in v4c['matches'] ]
         
-        self.assertEqual(v5c['matches'], expected_matches)
+        self.assertEqual(v5c['matches'], v4c['matches'])
         self.assertEqual(v5c['metadata'], {})
-        self.assertEqual(v5c['cursor_start'], 0)
-        self.assertEqual(v5c['cursor_end'], 0)
+        self.assertEqual(v5c['cursor_start'], -4)
+        self.assertEqual(v5c['cursor_end'], None)
     
     def test_object_info_request(self):
         msg = self.msg("object_info_request", {

--- a/IPython/kernel/tests/test_adapter.py
+++ b/IPython/kernel/tests/test_adapter.py
@@ -1,0 +1,189 @@
+"""Tests for adapting IPython msg spec versions"""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import copy
+
+from unittest import TestCase
+import nose.tools as nt
+
+from IPython.kernel.adapter import adapt, V4toV5, V5toV4
+from IPython.kernel.zmq.session import Session
+
+
+def test_default_version():
+    s = Session()
+    msg = s.msg("msg_type")
+    msg['header'].pop('version')
+    original = copy.deepcopy(msg)
+    adapted = adapt(original)
+    nt.assert_equal(adapted['header'].version, V4toV5.version)
+
+
+class AdapterTest(TestCase):
+    
+    def setUp(self):
+        print("hi")
+        self.session = Session()
+    
+    def adapt(self, msg, version=None):
+        original = copy.deepcopy(msg)
+        adapted = adapt(msg, version or self.to_version)
+        return original, adapted
+    
+    def check_header(self, msg):
+        pass
+
+
+class V4toV5TestCase(AdapterTest):
+    from_version = 4
+    to_version = 5
+    
+    def msg(self, msg_type, content):
+        """Create a v4 msg (same as v5, minus version header)"""
+        msg = self.session.msg(msg_type, content)
+        msg['header'].pop('version')
+        return msg
+    
+    def test_same_version(self):
+        msg = self.msg("execute_result",
+            content={'status' : 'ok'}
+        )
+        original, adapted = self.adapt(msg, self.from_version)
+    
+        self.assertEqual(original, adapted)
+    
+    def test_no_adapt(self):
+        msg = self.msg("input_reply", {'value' : 'some text'})
+        v4, v5 = self.adapt(msg)
+        self.assertEqual(v5['header']['version'], V4toV5.version)
+        v5['header'].pop('version')
+        self.assertEqual(v4, v5)
+    
+    def test_rename_type(self):
+        for v5_type, v4_type in [
+                ('execute_result', 'pyout'),
+                ('execute_input', 'pyin'),
+                ('error', 'pyerr'),
+            ]:
+            msg = self.msg(v4_type, {'key' : 'value'})
+            v4, v5 = self.adapt(msg)
+            self.assertEqual(v5['header']['version'], V4toV5.version)
+            self.assertEqual(v5['header']['msg_type'], v5_type)
+            self.assertEqual(v4['content'], v5['content'])
+    
+    def test_execute_request(self):
+        msg = self.msg("execute_request", {
+            'code' : 'a=5',
+            'silent' : False,
+            'user_expressions' : {'a' : 'apple'},
+            'user_variables' : ['b'],
+        })
+        v4, v5 = self.adapt(msg)
+        self.assertEqual(v4['header']['msg_type'], v5['header']['msg_type'])
+        v4c = v4['content']
+        v5c = v5['content']
+        self.assertEqual(v5c['user_expressions'], {'a' : 'apple', 'b': 'b'})
+        nt.assert_not_in('user_variables', v5c)
+        self.assertEqual(v5c['code'], v4c['code'])
+    
+    def test_complete_request(self):
+        pass
+    
+    def test_complete_reply(self):
+        pass
+    
+    def test_object_info_request(self):
+        pass
+    
+    def test_object_info_reply(self):
+        pass
+    
+    # iopub channel
+    
+    def test_display_data(self):
+        pass
+    
+    # stdin channel
+    
+    def test_input_request(self):
+        msg = self.msg('input_request', {'prompt': "$>"})
+        v4, v5 = self.adapt(msg)
+        self.assertEqual(v5['content']['prompt'], v4['content']['prompt'])
+        self.assertFalse(v5['content']['password'])
+
+
+class V5toV4TestCase(AdapterTest):
+    from_version = 5
+    to_version = 4
+    
+    def msg(self, msg_type, content):
+        return self.session.msg(msg_type, content)
+    
+    def test_same_version(self):
+        msg = self.msg("execute_result",
+            content={'status' : 'ok'}
+        )
+        original, adapted = self.adapt(msg, self.from_version)
+    
+        self.assertEqual(original, adapted)
+    
+    def test_no_adapt(self):
+        msg = self.msg("input_reply", {'value' : 'some text'})
+        v5, v4 = self.adapt(msg)
+        self.assertNotIn('version', v4['header'])
+        v5['header'].pop('version')
+        self.assertEqual(v4, v5)
+    
+    def test_rename_type(self):
+        for v5_type, v4_type in [
+                ('execute_result', 'pyout'),
+                ('execute_input', 'pyin'),
+                ('error', 'pyerr'),
+            ]:
+            msg = self.msg(v5_type, {'key' : 'value'})
+            v5, v4 = self.adapt(msg)
+            self.assertEqual(v4['header']['msg_type'], v4_type)
+            nt.assert_not_in('version', v4['header'])
+            self.assertEqual(v4['content'], v5['content'])
+    
+    def test_execute_request(self):
+        msg = self.msg("execute_request", {
+            'code' : 'a=5',
+            'silent' : False,
+            'user_expressions' : {'a' : 'apple'},
+        })
+        v5, v4 = self.adapt(msg)
+        self.assertEqual(v4['header']['msg_type'], v5['header']['msg_type'])
+        v4c = v4['content']
+        v5c = v5['content']
+        self.assertEqual(v4c['user_variables'], [])
+        self.assertEqual(v5c['code'], v4c['code'])
+    
+    def test_complete_request(self):
+        pass
+    
+    def test_complete_reply(self):
+        pass
+    
+    def test_inspect_request(self):
+        pass
+    
+    def test_inspect_reply(self):
+        pass
+    
+    # iopub channel
+    
+    def test_display_data(self):
+        pass
+    
+    # stdin channel
+    
+    def test_input_request(self):
+        msg = self.msg('input_request', {'prompt': "$>", 'password' : True})
+        v5, v4 = self.adapt(msg)
+        self.assertEqual(v5['content']['prompt'], v4['content']['prompt'])
+        self.assertNotIn('password', v4['content'])
+    
+

--- a/IPython/qt/kernel_mixins.py
+++ b/IPython/qt/kernel_mixins.py
@@ -59,6 +59,7 @@ class QtShellChannelMixin(ChannelQObject):
     complete_reply = QtCore.Signal(object)
     inspect_reply = QtCore.Signal(object)
     history_reply = QtCore.Signal(object)
+    kernel_info_reply = QtCore.Signal(object)
 
     #---------------------------------------------------------------------------
     # 'ShellChannel' interface
@@ -72,6 +73,9 @@ class QtShellChannelMixin(ChannelQObject):
 
         # Emit signals for specialized message types.
         msg_type = msg['header']['msg_type']
+        if msg_type == 'kernel_info_reply':
+            self._handle_kernel_info_reply(msg)
+        
         signal = getattr(self, msg_type, None)
         if signal:
             signal.emit(msg)


### PR DESCRIPTION
in IPython.kernel.adapter

Based on PR #4536

Basic changes:
- Add IPython.kernel.adapter with translation code. Mainly an `adapt(msg)` function.
- Adapt messages to/from the current version in the Session object.
- Frontends request kernel_info for the protocol version, which selects the version to adapt to, if any.

With this PR, at least the Julia and R kernels work in all three zmq-based frontends, without updating to the v5 msg spec.
