### PR TITLE
keep .highlight css class

### DIFF
--- a/IPython/nbconvert/filters/highlight.py
+++ b/IPython/nbconvert/filters/highlight.py
@@ -2,40 +2,22 @@
 Module containing filter functions that allow code to be highlighted
 from within Jinja templates.
 """
-#-----------------------------------------------------------------------------
-# Copyright (c) the IPython Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 # pygments must not be imported at the module level
 # because errors should be raised at runtime if it's actually needed,
 # not import time, when it may not be needed.
 
-# Our own imports
 from IPython.nbconvert.utils.base import NbConvertBase
 
-#-----------------------------------------------------------------------------
-# Globals and constants
-#-----------------------------------------------------------------------------
-
 MULTILINE_OUTPUTS = ['text', 'html', 'svg', 'latex', 'javascript', 'json']
-
-#-----------------------------------------------------------------------------
-# Utility functions
-#-----------------------------------------------------------------------------
 
 __all__ = [
     'Highlight2HTML',
     'Highlight2Latex'
 ]
-
 
 class Highlight2HTML(NbConvertBase):
 
@@ -58,7 +40,7 @@ class Highlight2HTML(NbConvertBase):
 
         return _pygments_highlight(source if len(source) > 0 else ' ',
                                    # needed to help post processors:
-                                   HtmlFormatter(cssclass="hl-"+language), 
+                                   HtmlFormatter(cssclass=" highlight hl-"+language),
                                    language, metadata)
 
 


### PR DESCRIPTION
highlight area now gets two classes: `div.highlight.hl-language`

CSS header is generated for class `.highlight`, but highlighted divs were only given class `.hl-language`, so the CSS wasn't applying.

This alters the effect of PR #4682 from _changing_ the highlight class to _adding_ a highlight class.

Before:

![screen shot 2014-04-29 at 16 17 04](https://cloud.githubusercontent.com/assets/151929/2836067/fdfa1462-cff4-11e3-9e29-9aec4122fd6f.PNG)

After:

![screen shot 2014-04-29 at 16 16 26](https://cloud.githubusercontent.com/assets/151929/2836069/03b3a44a-cff5-11e3-97f9-b7b2380f1d47.PNG)
