### PR TITLE
Applied bug fix: using fc and ec did not properly set the figure canvas ...

### DIFF
--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -118,8 +118,8 @@ def print_figure(fig, fmt='png', bbox_inches='tight', **kwargs):
     # build keyword args
     kw = dict(
         format=fmt,
-        fc=fig.get_facecolor(),
-        ec=fig.get_edgecolor(),
+        facecolor=fig.get_facecolor(),
+        edgecolor=fig.get_edgecolor(),
         dpi=dpi,
         bbox_inches=bbox_inches,
     )


### PR DESCRIPTION
...facecolor and edgecolor. This is resolves [issue #5553](https://github.com/ipython/ipython/issues/5553#issuecomment-41751751) in which rcParams['figure.facecolor'] is ignored. The same fix should be applied to master. Thanks!
