### PR TITLE
DRY out load_connection_file implementations

### DIFF
--- a/IPython/consoleapp.py
+++ b/IPython/consoleapp.py
@@ -28,7 +28,7 @@ from IPython.kernel import tunnel_to_kernel, find_connection_file, swallow_argv
 from IPython.kernel.kernelspec import NoSuchKernel
 from IPython.utils.path import filefind
 from IPython.utils.traitlets import (
-    Dict, List, Unicode, CUnicode, Int, CBool, Any
+    Dict, List, Unicode, CUnicode, CBool, Any
 )
 from IPython.kernel.zmq.kernelapp import (
     kernel_flags,
@@ -144,21 +144,6 @@ class IPythonConsoleApp(ConnectionFileMixin):
     sshkey = Unicode('', config=True,
         help="""Path to the ssh key to use for logging in to the ssh server.""")
     
-    hb_port = Int(0, config=True,
-        help="set the heartbeat port [default: random]")
-    shell_port = Int(0, config=True,
-        help="set the shell (ROUTER) port [default: random]")
-    iopub_port = Int(0, config=True,
-        help="set the iopub (PUB) port [default: random]")
-    stdin_port = Int(0, config=True,
-        help="set the stdin (DEALER) port [default: random]")
-    connection_file = Unicode('', config=True,
-        help="""JSON file in which to store connection info [default: kernel-<pid>.json]
-
-        This file will contain the IP, ports, and authentication key needed to connect
-        clients to this kernel. By default, this file will be created in the security-dir
-        of the current profile, but can be specified by absolute path.
-        """)
     def _connection_file_default(self):
         return 'kernel-%i.json' % os.getpid()
 

--- a/IPython/kernel/connect.py
+++ b/IPython/kernel/connect.py
@@ -419,11 +419,16 @@ class ConnectionFileMixin(Configurable):
 
     # protected traits
 
-    hb_port = Integer(0, config=True, help="set the heartbeat port [default: random]")
-    shell_port = Integer(0, config=True, help="set the shell (ROUTER) port [default: random]")
-    iopub_port = Integer(0, config=True, help="set the iopub (PUB) port [default: random]")
-    stdin_port = Integer(0, config=True, help="set the stdin (ROUTER) port [default: random]")
-    control_port = Integer(0, config=True, help="set the control (ROUTER) port [default: random]")
+    hb_port = Integer(0, config=True,
+            help="set the heartbeat port [default: random]")
+    shell_port = Integer(0, config=True,
+            help="set the shell (ROUTER) port [default: random]")
+    iopub_port = Integer(0, config=True,
+            help="set the iopub (PUB) port [default: random]")
+    stdin_port = Integer(0, config=True,
+            help="set the stdin (ROUTER) port [default: random]")
+    control_port = Integer(0, config=True,
+            help="set the control (ROUTER) port [default: random]")
 
     @property
     def ports(self):

--- a/IPython/kernel/connect.py
+++ b/IPython/kernel/connect.py
@@ -386,7 +386,13 @@ class ConnectionFileMixin(Configurable):
     """Mixin for configurable classes that work with connection files"""
 
     # The addresses for the communication channels
-    connection_file = Unicode('')
+    connection_file = Unicode('', config=True, 
+    help="""JSON file in which to store connection info [default: kernel-<pid>.json]
+    
+    This file will contain the IP, ports, and authentication key needed to connect
+    clients to this kernel. By default, this file will be created in the security dir
+    of the current profile, but can be specified by absolute path.
+    """)
     _connection_file_written = Bool(False)
 
     transport = CaselessStrEnum(['tcp', 'ipc'], default_value='tcp', config=True)
@@ -413,11 +419,11 @@ class ConnectionFileMixin(Configurable):
 
     # protected traits
 
-    shell_port = Integer(0)
-    iopub_port = Integer(0)
-    stdin_port = Integer(0)
-    control_port = Integer(0)
-    hb_port = Integer(0)
+    hb_port = Integer(0, config=True, help="set the heartbeat port [default: random]")
+    shell_port = Integer(0, config=True, help="set the shell (ROUTER) port [default: random]")
+    iopub_port = Integer(0, config=True, help="set the iopub (PUB) port [default: random]")
+    stdin_port = Integer(0, config=True, help="set the stdin (ROUTER) port [default: random]")
+    control_port = Integer(0, config=True, help="set the control (ROUTER) port [default: random]")
 
     @property
     def ports(self):

--- a/IPython/kernel/connect.py
+++ b/IPython/kernel/connect.py
@@ -1,8 +1,8 @@
 """Utilities for connecting to kernels
 
-There is a ConnectionFileMixin class which encapsulates the logic related to
-writing and reading connections files
-
+Notable contents: 
+- ConnectionFileMixin class
+    encapsulates the logic related to writing and reading connections files.
 """
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
@@ -488,8 +488,8 @@ class ConnectionFileMixin(Configurable):
         self.log.debug(u"Loading connection file %s", self.connection_file)
         with open(self.connection_file) as f:
             cfg = json.load(f)
-        self.transport = cfg.get('transport', 'tcp')
-        self.ip = cfg.get('ip', localhost())
+        self.transport = cfg.get('transport', self.transport)
+        self.ip = cfg.get('ip', self._ip_default())
         
         for name in port_names:
             if getattr(self, name) == 0 and name in cfg:

--- a/IPython/kernel/zmq/kernelapp.py
+++ b/IPython/kernel/zmq/kernelapp.py
@@ -30,11 +30,9 @@ from IPython.core.shellapp import (
     InteractiveShellApp, shell_flags, shell_aliases
 )
 from IPython.utils import io
-from IPython.utils.localinterfaces import localhost
 from IPython.utils.path import filefind
 from IPython.utils.traitlets import (
-    Any, Instance, Dict, Unicode, Integer, Bool, CaselessStrEnum,
-    DottedObjectName,
+    Any, Instance, Dict, Unicode, Integer, Bool, DottedObjectName,
 )
 from IPython.utils.importstring import import_item
 from IPython.kernel import write_connection_file
@@ -138,30 +136,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         self.config_file_specified.remove(self.config_file_name)
         
     # connection info:
-    transport = CaselessStrEnum(['tcp', 'ipc'], default_value='tcp', config=True)
-    ip = Unicode(config=True,
-        help="Set the IP or interface on which the kernel will listen.")
-    def _ip_default(self):
-        if self.transport == 'ipc':
-            if self.connection_file:
-                return os.path.splitext(self.abs_connection_file)[0] + '-ipc'
-            else:
-                return 'kernel-ipc'
-        else:
-            return localhost()
     
-    hb_port = Integer(0, config=True, help="set the heartbeat port [default: random]")
-    shell_port = Integer(0, config=True, help="set the shell (ROUTER) port [default: random]")
-    iopub_port = Integer(0, config=True, help="set the iopub (PUB) port [default: random]")
-    stdin_port = Integer(0, config=True, help="set the stdin (ROUTER) port [default: random]")
-    control_port = Integer(0, config=True, help="set the control (ROUTER) port [default: random]")
-    connection_file = Unicode('', config=True, 
-    help="""JSON file in which to store connection info [default: kernel-<pid>.json]
-    
-    This file will contain the IP, ports, and authentication key needed to connect
-    clients to this kernel. By default, this file will be created in the security dir
-    of the current profile, but can be specified by absolute path.
-    """)
     @property
     def abs_connection_file(self):
         if os.path.basename(self.connection_file) == self.connection_file:
@@ -236,17 +211,6 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
             pass
         
         self.cleanup_ipc_files()
-    
-    def cleanup_ipc_files(self):
-        """cleanup ipc files if we wrote them"""
-        if self.transport != 'ipc':
-            return
-        for port in (self.shell_port, self.iopub_port, self.stdin_port, self.hb_port, self.control_port):
-            ipcfile = "%s-%i" % (self.ip, port)
-            try:
-                os.remove(ipcfile)
-            except (IOError, OSError):
-                pass
     
     def init_connection_file(self):
         if not self.connection_file:


### PR DESCRIPTION
We currently have three (slightly) different implementations of
load_connection_file. This PR unifies them to one.
