### PR TITLE
handle simple closures in pickleutil

### DIFF
--- a/IPython/utils/codeutil.py
+++ b/IPython/utils/codeutil.py
@@ -10,18 +10,8 @@ we need to automate all of this so that functions themselves can be pickled.
 Reference: A. Tremols, P Cogolo, "Python Cookbook," p 302-305
 """
 
-__docformat__ = "restructuredtext en"
-
-#-------------------------------------------------------------------------------
-#  Copyright (C) 2008-2011  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-------------------------------------------------------------------------------
-
-#-------------------------------------------------------------------------------
-# Imports
-#-------------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 import sys
 import types
@@ -34,12 +24,10 @@ def code_ctor(*args):
     return types.CodeType(*args)
 
 def reduce_code(co):
-    if co.co_freevars or co.co_cellvars:
-        raise ValueError("Sorry, cannot pickle code objects with closures")
     args =  [co.co_argcount, co.co_nlocals, co.co_stacksize,
             co.co_flags, co.co_code, co.co_consts, co.co_names,
             co.co_varnames, co.co_filename, co.co_name, co.co_firstlineno,
-            co.co_lnotab]
+            co.co_lnotab, co.co_freevars, co.co_cellvars]
     if sys.version_info[0] >= 3:
         args.insert(1, co.co_kwonlyargcount)
     return code_ctor, tuple(args)

--- a/IPython/utils/py3compat.py
+++ b/IPython/utils/py3compat.py
@@ -131,6 +131,10 @@ if sys.version_info[0] >= 3:
         
         Accepts a string or a function, so it can be used as a decorator."""
         return s.format(u='')
+    
+    def get_closure(f):
+        """Get a function's closure attribute"""
+        return f.__closure__
 
 else:
     PY3 = False
@@ -192,6 +196,9 @@ else:
     def doctest_refactor_print(func_or_str):
         return func_or_str
 
+    def get_closure(f):
+        """Get a function's closure attribute"""
+        return f.func_closure
 
     # Abstract u'abc' syntax:
     @_modify_str_or_docstring

--- a/IPython/utils/tests/test_pickleutil.py
+++ b/IPython/utils/tests/test_pickleutil.py
@@ -1,0 +1,62 @@
+
+import pickle
+
+import nose.tools as nt
+from IPython.utils import codeutil
+from IPython.utils.pickleutil import can, uncan
+
+def interactive(f):
+    f.__module__ = '__main__'
+    return f
+
+def dumps(obj):
+    return pickle.dumps(can(obj))
+
+def loads(obj):
+    return uncan(pickle.loads(obj))
+
+def test_no_closure():
+    @interactive
+    def foo():
+        a = 5
+        return a
+    
+    pfoo = dumps(foo)
+    bar = loads(pfoo)
+    nt.assert_equal(foo(), bar())
+
+def test_generator_closure():
+    # this only creates a closure on Python 3
+    @interactive
+    def foo():
+        i = 'i'
+        r = [ i for j in (1,2) ]
+        return r
+    
+    pfoo = dumps(foo)
+    bar = loads(pfoo)
+    nt.assert_equal(foo(), bar())
+
+def test_nested_closure():
+    @interactive
+    def foo():
+        i = 'i'
+        def g():
+            return i
+        return g()
+    
+    pfoo = dumps(foo)
+    bar = loads(pfoo)
+    nt.assert_equal(foo(), bar())
+
+def test_closure():
+    i = 'i'
+    @interactive
+    def foo():
+        return i
+    
+    pfoo = dumps(foo)
+    bar = loads(pfoo)
+    nt.assert_equal(foo(), bar())
+
+    


### PR DESCRIPTION
It turns out this is pretty straightforward. I'm sure there are plenty of cases where dill / cloud pickle are going to be desirable, but Python 3 makes trivial closures a lot more likely, and this handles those cases easily enough.
