### PR TITLE
Shut down kernels in parallel

### DIFF
--- a/IPython/kernel/manager.py
+++ b/IPython/kernel/manager.py
@@ -252,9 +252,6 @@ class KernelManager(LoggingConfigurable, ConnectionFileMixin):
         On Windows, this just kills kernels instead, because the shutdown
         messages don't work.
         """
-        # FIXME: Shutdown does not work on Windows due to ZMQ errors!
-        if sys.platform == 'win32' and self.has_kernel:
-            return self._kill_kernel()
         content = dict(restart=restart)
         msg = self.session.msg("shutdown_request", content=content)
         self.session.send(self._control_socket, msg)
@@ -345,11 +342,6 @@ class KernelManager(LoggingConfigurable, ConnectionFileMixin):
             # Start new kernel.
             self._launch_args.update(kw)
             self.start_kernel(**self._launch_args)
-
-            # FIXME: Messages get dropped in Windows due to probable ZMQ bug
-            # unless there is some delay here.
-            if sys.platform == 'win32':
-                time.sleep(0.2)
 
     @property
     def has_kernel(self):

--- a/IPython/kernel/manager.py
+++ b/IPython/kernel/manager.py
@@ -259,15 +259,15 @@ class KernelManager(LoggingConfigurable, ConnectionFileMixin):
         msg = self.session.msg("shutdown_request", content=content)
         self.session.send(self._control_socket, msg)
 
-    def wait_shutdown(self, totaltime=1, interval=0.1):
+    def finish_shutdown(self, waittime=1, pollinterval=0.1):
         """Wait for kernel shutdown, then kill process if it doesn't shutdown.
         
         This does not send shutdown requests - use :meth:`request_shutdown`
         first.
         """
-        for i in range(int(totaltime/interval)):
+        for i in range(int(waittime/pollinterval)):
             if self.is_alive():
-                time.sleep(interval)
+                time.sleep(pollinterval)
             else:
                 break
         else:
@@ -311,7 +311,7 @@ class KernelManager(LoggingConfigurable, ConnectionFileMixin):
             # Don't send any additional kernel kill messages immediately, to give
             # the kernel a chance to properly execute shutdown actions. Wait for at
             # most 1s, checking every 0.1s.
-            self.wait_shutdown()
+            self.finish_shutdown()
 
         self.cleanup(connection_file=not restart)
 

--- a/IPython/kernel/manager.py
+++ b/IPython/kernel/manager.py
@@ -275,14 +275,12 @@ class KernelManager(LoggingConfigurable, ConnectionFileMixin):
             if self.has_kernel:
                 self._kill_kernel()
 
-    def cleanup(self, restart=False):
+    def cleanup(self, connection_file=True):
         """Clean up resources when the kernel is shut down"""
-        if not restart:
+        if connection_file:
             self.cleanup_connection_file()
-            self.cleanup_ipc_files()
-        else:
-            self.cleanup_ipc_files()
 
+        self.cleanup_ipc_files()
         self._close_control_socket()
 
     def shutdown_kernel(self, now=False, restart=False):
@@ -315,7 +313,7 @@ class KernelManager(LoggingConfigurable, ConnectionFileMixin):
             # most 1s, checking every 0.1s.
             self.wait_shutdown()
 
-        self.cleanup(restart=restart)
+        self.cleanup(connection_file=not restart)
 
     def restart_kernel(self, now=False, **kw):
         """Restarts a kernel with the arguments that were used to launch it.

--- a/IPython/kernel/multikernelmanager.py
+++ b/IPython/kernel/multikernelmanager.py
@@ -131,6 +131,20 @@ class MultiKernelManager(LoggingConfigurable):
         self.log.info("Kernel shutdown: %s" % kernel_id)
         self.remove_kernel(kernel_id)
 
+    @kernel_method
+    def request_shutdown(self, kernel_id):
+        """Ask a kernel to shut down by its kernel uuid"""
+
+    @kernel_method
+    def wait_shutdown(self, kernel_id):
+        """Wait for a kernel to finish shutting down, and kill it if it doesn't
+        """
+        self.log.info("Kernel shutdown: %s" % kernel_id)
+
+    @kernel_method
+    def cleanup(self, kernel_id):
+        """Clean up a kernel's resources"""
+
     def remove_kernel(self, kernel_id):
         """remove a kernel from our mapping.
 
@@ -143,8 +157,12 @@ class MultiKernelManager(LoggingConfigurable):
 
     def shutdown_all(self, now=False):
         """Shutdown all kernels."""
-        for kid in self.list_kernel_ids():
-            self.shutdown_kernel(kid, now=now)
+        kids = self.list_kernel_ids()
+        for kid in kids:
+            self.request_shutdown(kid)
+        for kid in kids:
+            self.wait_shutdown(kid)
+            self.cleanup(kid)
 
     @kernel_method
     def interrupt_kernel(self, kernel_id):

--- a/IPython/kernel/multikernelmanager.py
+++ b/IPython/kernel/multikernelmanager.py
@@ -138,7 +138,7 @@ class MultiKernelManager(LoggingConfigurable):
         """Ask a kernel to shut down by its kernel uuid"""
 
     @kernel_method
-    def wait_shutdown(self, kernel_id, totaltime=1, interval=0.1):
+    def finish_shutdown(self, kernel_id, waittime=1, pollinterval=0.1):
         """Wait for a kernel to finish shutting down, and kill it if it doesn't
         """
         self.log.info("Kernel shutdown: %s" % kernel_id)
@@ -163,7 +163,7 @@ class MultiKernelManager(LoggingConfigurable):
         for kid in kids:
             self.request_shutdown(kid)
         for kid in kids:
-            self.wait_shutdown(kid)
+            self.finish_shutdown(kid)
             self.cleanup(kid)
 
     @kernel_method

--- a/IPython/kernel/multikernelmanager.py
+++ b/IPython/kernel/multikernelmanager.py
@@ -118,7 +118,7 @@ class MultiKernelManager(LoggingConfigurable):
         return kernel_id
 
     @kernel_method
-    def shutdown_kernel(self, kernel_id, now=False):
+    def shutdown_kernel(self, kernel_id, now=False, restart=False):
         """Shutdown a kernel by its kernel uuid.
 
         Parameters
@@ -127,22 +127,24 @@ class MultiKernelManager(LoggingConfigurable):
             The id of the kernel to shutdown.
         now : bool
             Should the kernel be shutdown forcibly using a signal.
+        restart : bool
+            Will the kernel be restarted?
         """
         self.log.info("Kernel shutdown: %s" % kernel_id)
         self.remove_kernel(kernel_id)
 
     @kernel_method
-    def request_shutdown(self, kernel_id):
+    def request_shutdown(self, kernel_id, restart=False):
         """Ask a kernel to shut down by its kernel uuid"""
 
     @kernel_method
-    def wait_shutdown(self, kernel_id):
+    def wait_shutdown(self, kernel_id, totaltime=1, interval=0.1):
         """Wait for a kernel to finish shutting down, and kill it if it doesn't
         """
         self.log.info("Kernel shutdown: %s" % kernel_id)
 
     @kernel_method
-    def cleanup(self, kernel_id):
+    def cleanup(self, kernel_id, connection_file=True):
         """Clean up a kernel's resources"""
 
     def remove_kernel(self, kernel_id):


### PR DESCRIPTION
When stopping the notebook server, it currently sends a shutdown request to each kernel and then waits for the process to finish. This can be slow if you have several kernels running. This makes it issue all the shutdown requests before waiting on the processes, so shutdown happens in parallel.

KernelManager (and MultiKernelManager) gain three new public API methods to allow this:
- `request_shutdown` (promoted from a private method)
- `wait_shutdown` (refactored out of shutdown_kernel)
- `cleanup` (refactored out of shutdown_kernel)
