### PR TITLE
fix cursor keys in long lines wrapped in markdown

### DIFF
--- a/IPython/html/static/notebook/js/keyboardmanager.js
+++ b/IPython/html/static/notebook/js/keyboardmanager.js
@@ -111,9 +111,7 @@ var IPython = (function (IPython) {
                     return false;
                 } else if (cell) {
                     var cm = cell.code_mirror;
-                    var cursor = cm.getCursor();
-                    cursor.line -= 1;
-                    cm.setCursor(cursor);
+                    cm.execCommand('goLineUp');
                     return false;
                 }
             }
@@ -134,9 +132,7 @@ var IPython = (function (IPython) {
                     return false;
                 } else {
                     var cm = cell.code_mirror;
-                    var cursor = cm.getCursor();
-                    cursor.line += 1;
-                    cm.setCursor(cursor);
+                    cm.execCommand('goLineDown');
                     return false;
                 }
             }


### PR DESCRIPTION
closes #5467 

pinging @ellisonbg and @jdfreder who reported the bug
