### PR TITLE
Don't urlescape the text that goes into a title tag

### DIFF
--- a/IPython/html/tree/handlers.py
+++ b/IPython/html/tree/handlers.py
@@ -44,7 +44,7 @@ class TreeHandler(IPythonHandler):
         if len(comps) > 3:
             for i in range(len(comps)-2):
                 comps.pop(0)
-        page_title = url_escape(url_path_join(*comps))
+        page_title = url_path_join(*comps)
         if page_title:
             return page_title+'/'
         else:


### PR DESCRIPTION
If there are spaces in a folder name, you get funny stuff in the `<title>` tag in the tree view. For example, a folder called `/Analysis and Results` will result in the title `<title>Analysis%20and%20Results</title>`.

There's no need for URL escaping the page title.
