### PR TITLE
MATLAB-like drawnow().

### DIFF
--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -382,6 +382,8 @@ def configure_inline_support(shell, backend):
 def drawnow(draw_fig, show_once=False, *argv, **kwargs):
     """A function to refresh the current figure.
 
+    Depends on matplotlib's interactive mode.
+
     Parameters
     ----------
     draw_fig : callable

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -379,3 +379,50 @@ def configure_inline_support(shell, backend):
     # Setup the default figure format
     select_figure_formats(shell, cfg.figure_formats, **cfg.print_figure_kwargs)
 
+def drawnow(draw_fig, show_once=False, *argv, **kwargs):
+    """A function to refresh the current figure.
+
+    Parameters
+    ----------
+    draw_fig : callable
+               the function that draws the figure you want to update
+    *argv    : any
+               the list of parameters to pass ``draw_fig()``
+    **kwargs : any
+               the keywords to pass to ``draw_fig()``
+    show_once, optional : bool, default: False. 
+               If True, will call show() instead of draw(). 
+
+    Limitations
+    -----------
+    - If two figures open and focus moved between figures, then other figure
+      gets cleared.
+    - Occaisonally ignores Ctrl-C.
+
+    Usage Example
+    -------------
+      >>> def draw_fig_real():
+      >>>     imshow(z, interpolation='nearest')
+      >>>     colorbar()
+      >>> N = 16
+      >>> z = zeros((N,N))
+
+      >>> ion()
+      >>> for i in arange(N*N):
+      >>>     z.flat[i] = 0
+      >>>     drawnow(draw_fig_real)
+    """
+    from matplotlib.pyplot import clf, show, draw
+    # get the kwargs
+    kw = dict()
+    kw.update(kwargs)
+
+    # draw current figure
+    clf()
+    draw_fig(*argv, **kw)
+
+    # should we show once? show() causes many windows to open, draw() doesn't
+    if show_once:
+        show()
+    else:
+        draw()

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -379,7 +379,7 @@ def configure_inline_support(shell, backend):
     # Setup the default figure format
     select_figure_formats(shell, cfg.figure_formats, **cfg.print_figure_kwargs)
 
-def drawnow(draw_fig, show_once=False, *argv, **kwargs):
+def drawnow(draw_fig, show_once=False, confirm=False, *argv, **kwargs):
     """A function to refresh the current figure.
 
     Depends on matplotlib's interactive mode.
@@ -392,7 +392,7 @@ def drawnow(draw_fig, show_once=False, *argv, **kwargs):
                the list of parameters to pass ``draw_fig()``
     **kwargs : any
                the keywords to pass to ``draw_fig()``
-    show_once, optional : bool, default: False. 
+    show_once, optional : bool, default == False. 
                If True, will call show() instead of draw(). 
 
     Limitations
@@ -415,6 +415,7 @@ def drawnow(draw_fig, show_once=False, *argv, **kwargs):
       >>>     drawnow(draw_fig_real)
     """
     from matplotlib.pyplot import clf, show, draw
+
     # get the kwargs
     kw = dict()
     kw.update(kwargs)
@@ -423,8 +424,7 @@ def drawnow(draw_fig, show_once=False, *argv, **kwargs):
     clf()
     draw_fig(*argv, **kw)
 
-    # should we show once? show() causes many windows to open, draw() doesn't
-    if show_once:
-        show()
-    else:
-        draw()
+    if show_once: show()
+    else: draw()
+    if confirm: raw_input('Hit <Enter> to continue\n')
+


### PR DESCRIPTION
About a week or two ago, I was looking for an easy way to update the figure during a long time-intensive iterative process. The first results I found were matplotlib's animation framework and that being way to complex, I instead tried looking for a way use a MATLAB-like drawnow. I couldn't find one, so I wrote one myself.

I tried merging this into matplotlib, but it wasn't mpl kosher. This seems to be the correct place to contribute this function. If not, let me know the correct place (if there is one).

A typical use case:

``` python
N = 16
z = zeros((N,N))

ion()
for i in arange(1*N):
    z.flat[i] = 1
    drawnow(draw_fig_real, show_once=False)
```

Known limitations, parameters and a usage case are all covered in the docstring.
