### PR TITLE
Discretion in quote-closing a completed dict key

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1981,7 +1981,7 @@ class InteractiveShell(SingletonConfigurable):
         if self.has_readline:
             self.set_readline_completer()
 
-    def complete(self, text, line=None, cursor_pos=None):
+    def complete(self, text, line=None, cursor_pos=None, from_readline=False):
         """Return the completed text and a list of completions.
 
         Parameters
@@ -1997,6 +1997,9 @@ class InteractiveShell(SingletonConfigurable):
 
            cursor_pos : int, optional
              The position of the cursor on the input line.
+
+           from_readline : bool, option
+             True if this completion was requested from a Readline instance.
 
         Returns
         -------
@@ -2024,7 +2027,8 @@ class InteractiveShell(SingletonConfigurable):
 
         # Inject names into __builtin__ so we can complete on the added names.
         with self.builtin_trap:
-            return self.Completer.complete(text, line, cursor_pos)
+            return self.Completer.complete(text, line, cursor_pos,
+                                           from_readline=from_readline)
 
     def set_custom_completer(self, completer, pos=0):
         """Adds a new custom completer function.

--- a/IPython/kernel/channels.py
+++ b/IPython/kernel/channels.py
@@ -288,7 +288,7 @@ class ShellChannel(ZMQSocketChannel):
         self._queue_send(msg)
         return msg['header']['msg_id']
 
-    def complete(self, text, line, cursor_pos, block=None):
+    def complete(self, text, line, cursor_pos, block=None, from_readline=False):
         """Tab complete text in the kernel's namespace.
 
         Parameters
@@ -303,12 +303,16 @@ class ShellChannel(ZMQSocketChannel):
             requested.
         block : str, optional
             The full block of code in which the completion is being requested.
+        from_readline : bool, option
+            True if this completion was requested from a Readline instance.
+
 
         Returns
         -------
         The msg_id of the message sent.
         """
-        content = dict(text=text, line=line, block=block, cursor_pos=cursor_pos)
+        content = dict(text=text, line=line, block=block,
+                       cursor_pos=cursor_pos, from_readline=from_readline)
         msg = self.session.msg('complete_request', content)
         self._queue_send(msg)
         return msg['header']['msg_id']

--- a/IPython/kernel/zmq/ipkernel.py
+++ b/IPython/kernel/zmq/ipkernel.py
@@ -787,7 +787,8 @@ class Kernel(Configurable):
             cpos = len(c['text'])
             if cpos==0:
                 cpos = len(c['line'])
-        return self.shell.complete(c['text'], c['line'], cpos)
+        return self.shell.complete(c['text'], c['line'], cpos,
+                                   from_readline=c.get('from_readline', False))
 
     def _at_shutdown(self):
         """Actions taken at shutdown by the kernel, called by python's atexit.

--- a/IPython/terminal/console/completer.py
+++ b/IPython/terminal/console/completer.py
@@ -34,7 +34,8 @@ class ZMQCompleter(IPCompleter):
         # send completion request to kernel
         # Give the kernel up to 0.5s to respond
         msg_id = self.client.shell_channel.complete(text=text, line=line,
-                                                        cursor_pos=cursor_pos)
+                                                    cursor_pos=cursor_pos,
+                                                    from_readline=True)
         
         msg = self.client.shell_channel.get_msg(timeout=self.timeout)
         if msg['parent_header']['msg_id'] == msg_id:


### PR DESCRIPTION
This pertains to #5304 and the issue [noted there](https://github.com/ipython/ipython/pull/5304#issuecomment-42062566) by @takluyver. It takes a fairly maximal approach to solving it, while Thomas suggested something minimal.

This PR distinguishes a completion request from a readline frontend to those triggered otherwise. It avoids an explicit endquote in the readline case.

I have managed to test it with:
- local console with readline
- `--existing` console with readline
- notebook

I do not have qt set up to test there.

@takluyver, WDYT?

(I am yet to add a unit test with `from_readline=True`.)
