### PR TITLE
Silence exception thrown by completer when dir() does not return a list

### DIFF
--- a/IPython/utils/dir2.py
+++ b/IPython/utils/dir2.py
@@ -62,7 +62,7 @@ def dir2(obj):
 
     try:
         words = set(dir(obj))
-    except:
+    except Exception:
         # TypeError: dir(obj) does not return a list
         words = set()
 

--- a/IPython/utils/dir2.py
+++ b/IPython/utils/dir2.py
@@ -60,7 +60,11 @@ def dir2(obj):
     # Start building the attribute list via dir(), and then complete it
     # with a few extra special-purpose calls.
 
-    words = set(dir(obj))
+    try:
+        words = set(dir(obj))
+    except:
+        # TypeError: dir(obj) does not return a list
+        words = set()
 
     if safe_hasattr(obj, '__class__'):
         #words.add('__class__')


### PR DESCRIPTION
``` python
In [1]: import SOAPpy

In [2]: s = SOAPpy.SOAPProxy('http://abc.com', namespace='xyz')

In [3]: s.Traceback (most recent call last):
  File "IPython/core/completer.py", line 1043, in complete
    self.matches.extend(matcher(text))
  File "IPython/core/completer.py", line 725, in python_matches
    matches = self.attr_matches(text)
  File "IPython/core/completer.py", line 403, in attr_matches
    words = dir2(obj)
  File "IPython/utils/dir2.py", line 63, in dir2
    words = set(dir(obj))
TypeError: __dir__() must return a list, not instance

If you suspect this is an IPython bug, please report it at:
    https://github.com/ipython/ipython/issues
or send an email to the mailing list at ipython-dev@scipy.org

You can print a more detailed traceback right now with "%tb", or use "%debug"
to interactively debug it.

Extra-detailed tracebacks for bug-reporting purposes can be enabled via:
    %config Application.verbose_crash=True


  File "<ipython-input-3-fbb1f01da851>", line 1
    s.
      ^
SyntaxError: invalid syntax


In [4]: dir(s)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-9d6ad02bd404> in <module>()
----> 1 dir(s)

TypeError: __dir__() must return a list, not instance

In [5]: s.__dir__()
Out[5]: <SOAPpy.Client.__Method at 150204780>

In [6]: 
```
