### PR TITLE
run cells with `silent=True` in `%run nb.ipynb`

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2600,7 +2600,7 @@ class InteractiveShell(SingletonConfigurable):
                     # raised in user code.  It would be nice if there were
                     # versions of run_cell that did raise, so
                     # we could catch the errors.
-                    self.run_cell(cell, store_history=False, shell_futures=False)
+                    self.run_cell(cell, silent=True, shell_futures=False)
             except:
                 self.showtraceback()
                 warn('Unknown failure executing file: <%s>' % fname)


### PR DESCRIPTION
- more consistent with running scripts
- avoids a bunch of uncapturable `Out[n]:` outputs when running a notebook.

closes #5685
