### PR TITLE
unify visual line handling

### DIFF
--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -70,7 +70,12 @@ var IPython = (function (IPython) {
         cm_config : {
             indentUnit : 4,
             readOnly: false,
-            theme: "default"
+            theme: "default",
+            extraKeys: {
+                "Cmd-Right":"goLineRight",
+                "End":"goLineRight",
+                "Cmd-Left":"goLineLeft"
+            }
         }
     };
     


### PR DESCRIPTION
Extra change on top of @ivanov pr #5768 to have more consistent handling of visual lines.

In a  long wrapped line End/Cmd-Right will go to the end of the visual line which seem more logical.
Cmd-Left beginning of line. I did note rebind Ctrl-Left because there is already custom logic in code mirror for "smart" beginning of line.
