### PR TITLE
remove an inappropriate `!`

### DIFF
--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -456,7 +456,7 @@ var IPython = (function (IPython) {
         var callbacks = this._msg_callbacks[msg_id];
         if (callbacks !== undefined) {
             callbacks.iopub_done = true;
-            if (!callbacks.shell_done) {
+            if (callbacks.shell_done) {
                 this.clear_callbacks_for_msg(msg_id);
             }
         }


### PR DESCRIPTION
The logic was backward, causing input prompt not to be set when many executions were submitted simultaneously.

closes #5800
