### PR TITLE
Don't auto-move .config/ipython if symbolic link

### DIFF
--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -287,6 +287,9 @@ def get_ipython_dir():
                 if os.path.exists(ipdir):
                     warnings.warn(('Ignoring {0} in favour of {1}. Remove {0} '
                     'to get rid of this message').format(cu(xdg_ipdir), cu(ipdir)))
+                elif os.path.islink(xdg_ipdir):
+                    warnings.warn(('{0} is deprecated. Move link to {1} '
+                    'to get rid of this message').format(cu(xdg_ipdir), cu(ipdir)))
                 else:
                     warnings.warn('Moving {0} to {1}'.format(cu(xdg_ipdir), cu(ipdir)))
                     os.rename(xdg_ipdir, ipdir)


### PR DESCRIPTION
After upgrading Ipython to latest package on arch linux, it refused to start with this error message: 

```
Traceback (most recent call last):
  File "/usr/lib/python3.4/site-packages/IPython/utils/traitlets.py", line 349, in __get__
    value = obj._trait_values[self.name]
KeyError: 'ipython_dir'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/ipython", line 5, in <module>
    start_ipython()
  File "/usr/lib/python3.4/site-packages/IPython/__init__.py", line 118, in start_ipython
    return launch_new_instance(argv=argv, **kwargs)
  File "/usr/lib/python3.4/site-packages/IPython/config/application.py", line 562, in launch_instance
    app.initialize(argv)
  File "<string>", line 2, in initialize
  File "/usr/lib/python3.4/site-packages/IPython/config/application.py", line 92, in catch_config_error
    return method(app, *args, **kwargs)
  File "/usr/lib/python3.4/site-packages/IPython/terminal/ipapp.py", line 321, in initialize
    super(TerminalIPythonApp, self).initialize(argv)
  File "<string>", line 2, in initialize
  File "/usr/lib/python3.4/site-packages/IPython/config/application.py", line 92, in catch_config_error
    return method(app, *args, **kwargs)
  File "/usr/lib/python3.4/site-packages/IPython/core/application.py", line 387, in initialize
    self.init_profile_dir()
  File "/usr/lib/python3.4/site-packages/IPython/core/application.py", line 295, in init_profile_dir
    p = ProfileDir.find_profile_dir_by_name(self.ipython_dir, self.profile, self.config)
  File "/usr/lib/python3.4/site-packages/IPython/utils/traitlets.py", line 353, in __get__
    value = obj._trait_dyn_inits[self.name](obj)
  File "/usr/lib/python3.4/site-packages/IPython/core/application.py", line 141, in _ipython_dir_default
    self._ipython_dir_changed('ipython_dir', d, d)
  File "/usr/lib/python3.4/site-packages/IPython/core/application.py", line 224, in _ipython_dir_changed
    os.makedirs(new, mode=0o777)
  File "/usr/lib/python3.4/os.py", line 244, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/home/bfred/.ipython'
```

Same problem on master. It turns out it automatically moved .config/ipython to .ipython , this fails on systems where this is a relative symbolic link (i e to a dotfiles repo, '../dotfiles/ipython' in my case), which gets broken in the new location.

  In general one doesn't know why the user have a symbolic link, to the simplest would be warn the user to move/fix the link themselves, I think. 
