### PR TITLE
Drop log level to info for Qt console shutdown

### DIFF
--- a/IPython/qt/console/frontend_widget.py
+++ b/IPython/qt/console/frontend_widget.py
@@ -546,7 +546,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
     def _handle_shutdown_reply(self, msg):
         """ Handle shutdown signal, only if from other console.
         """
-        self.log.warn("shutdown: %s", msg.get('content', ''))
+        self.log.info("shutdown: %s", msg.get('content', ''))
         restart = msg.get('content', {}).get('restart', False)
         if not self._hidden and not self._is_from_this_session(msg):
             # got shutdown reply, request came from session other than ours


### PR DESCRIPTION
At present, shutting down the Qt console displays this message in the terminal:

```
[IPythonQtConsoleApp] WARNING | shutdown: {'status': 'ok', 'restart': False}
```

I don't think this needs to be a warning - it's responding correctly to a user action. Info messages are not shown by default, so this change silences the message in the default case.
