### PR TITLE
apply json_clean to comm_msg content

### DIFF
--- a/IPython/kernel/comm/comm.py
+++ b/IPython/kernel/comm/comm.py
@@ -1,26 +1,16 @@
 """Base class for a Comm"""
 
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2013  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 import uuid
 
 from IPython.config import LoggingConfigurable
 from IPython.core.getipython import get_ipython
 
+from IPython.utils.jsonutil import json_clean
 from IPython.utils.traitlets import Instance, Unicode, Bytes, Bool, Dict, Any
 
-#-----------------------------------------------------------------------------
-# Code
-#-----------------------------------------------------------------------------
 
 class Comm(LoggingConfigurable):
     
@@ -69,9 +59,10 @@ class Comm(LoggingConfigurable):
         """Helper for sending a comm message on IOPub"""
         data = {} if data is None else data
         metadata = {} if metadata is None else metadata
+        content = json_clean(dict(data=data, comm_id=self.comm_id, **keys))
         self.session.send(self.iopub_socket, msg_type,
-            dict(data=data, comm_id=self.comm_id, **keys),
-            metadata=metadata,
+            content,
+            metadata=json_clean(metadata),
             parent=self.shell.get_parent(),
             ident=self.topic,
         )

--- a/IPython/kernel/zmq/session.py
+++ b/IPython/kernel/zmq/session.py
@@ -67,7 +67,11 @@ def squash_unicode(obj):
 #-----------------------------------------------------------------------------
 
 # ISO8601-ify datetime objects
-json_packer = lambda obj: jsonapi.dumps(obj, default=date_default, ensure_ascii=False)
+# allow unicode
+# disallow nan, because it's not actually valid JSON
+json_packer = lambda obj: jsonapi.dumps(obj, default=date_default,
+    ensure_ascii=False, allow_nan=False,
+)
 json_unpacker = lambda s: jsonapi.loads(s)
 
 pickle_packer = lambda o: pickle.dumps(squash_dates(o),-1)


### PR DESCRIPTION
avoids errors in json encoding.

The same code that is applied to other user-generated json content.

closes #5809
