### PR TITLE
Fix application name when printing subcommand help.

### DIFF
--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -326,7 +326,7 @@ class Application(SingletonConfigurable):
         lines.append('-'*len(lines[0]))
         lines.append('')
         for p in wrap_paragraphs(self.subcommand_description.format(
-                    app=os.path.basename(self.argv[0]))):
+                    app=self.name)):
             lines.append(p)
             lines.append('')
         for subc, (cls, help) in iteritems(self.subcommands):


### PR DESCRIPTION
I introduced this bug in PR #5754. It's fixed against master in #5796, but that won't be backported to 2.x.
