### PR TITLE
Remove -i options from mv, rm and cp aliases

### DIFF
--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -50,7 +50,7 @@ def default_aliases():
 
     if os.name == 'posix':
         default_aliases = [('mkdir', 'mkdir'), ('rmdir', 'rmdir'),
-                           ('mv', 'mv -i'), ('rm', 'rm -i'), ('cp', 'cp -i'),
+                           ('mv', 'mv'), ('rm', 'rm'), ('cp', 'cp'),
                            ('cat', 'cat'),
                            ]
         # Useful set of ls aliases.  The GNU and BSD options are a little


### PR DESCRIPTION
This was arguably useful in the terminal, but it means these aliases can't be used from any of the ZMQ frontends. And users familiar with the shell shouldn't find the default (non -i) behaviour surprising.

Supersedes gh-5729, which accidentally included an unrelated change.
