### PR TITLE
interpret any exception in getcallargs as not callable

### DIFF
--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -74,7 +74,7 @@ def _valid_formatter(f):
         # anything that works with zero args should be okay
         try:
             inspect.getcallargs(f)
-        except TypeError:
+        except Exception:
             return False
         else:
             return True


### PR DESCRIPTION
some object (mock) lie to callable

closes #5817
