### PR TITLE
Don't overwrite widget description in interact

### DIFF
--- a/IPython/html/widgets/interaction.py
+++ b/IPython/html/widgets/interaction.py
@@ -166,7 +166,8 @@ def _widgets_from_abbreviations(seq):
     result = []
     for name, abbrev, default in seq:
         widget = _widget_from_abbrev(abbrev, default)
-        widget.description = name
+        if not widget.description:
+            widget.description = name
         result.append(widget)
     return result
 

--- a/IPython/html/widgets/tests/test_interaction.py
+++ b/IPython/html/widgets/tests/test_interaction.py
@@ -463,3 +463,20 @@ def test_fixed():
         description='b',
     )
 
+def test_default_description():
+    c = interactive(f, b='text')
+    w = c.children[0]
+    check_widget(w,
+        cls=widgets.TextWidget,
+        value='text',
+        description='b',
+    )
+
+def test_custom_description():
+    c = interactive(f, b=widgets.TextWidget(value='text', description='foo'))
+    w = c.children[0]
+    check_widget(w,
+        cls=widgets.TextWidget,
+        value='text',
+        description='foo',
+    )

--- a/examples/Interactive Widgets/Using Interact.ipynb
+++ b/examples/Interactive Widgets/Using Interact.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:d75ab1c53fa3389eeac78ecf8e89beb52871950f296aad25776699b6d6125037"
+  "signature": "sha256:3f30c6e839ac39f890da34a2af6bf50bf0d99ea32f7aadc043f3e31f619e4bc9"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -87,7 +87,7 @@
        "metadata": {},
        "output_type": "display_data",
        "text": [
-        "<IPython.core.display.HTML at 0x10efc0d50>"
+        "<IPython.core.display.HTML object>"
        ]
       }
      ],
@@ -110,7 +110,7 @@
       "         z=True,\n",
       "         Text=u'Type here!',\n",
       "         #Algorithm=['This','That','Other'],\n",
-      "         a=widgets.FloatSliderWidget(min=-10.0, max=10.0, step=0.1, value=5.0)\n",
+      "         a=widgets.FloatSliderWidget(min=-10.0, max=10.0, step=0.1, value=5.0, description=\"Float (a)\")\n",
       "         )"
      ],
      "language": "python",
@@ -122,14 +122,14 @@
         "<tr><td>Current</td><td>4.99</td></tr>\n",
         "<tr><td>Text</td><td>Type here!</td></tr>\n",
         "<tr><td>z</td><td>True</td></tr>\n",
-        "<tr><td>a</td><td>5.0</td></tr>\n",
         "<tr><td>Temp</td><td>5</td></tr>\n",
+        "<tr><td>Float (a)</td><td>5.0</td></tr>\n",
         "</table>"
        ],
        "metadata": {},
        "output_type": "display_data",
        "text": [
-        "<IPython.core.display.HTML at 0x10efcca10>"
+        "<IPython.core.display.HTML object>"
        ]
       }
      ],
@@ -150,14 +150,14 @@
         "<tr><td>Current</td><td>4.99</td></tr>\n",
         "<tr><td>Text</td><td>Type here!</td></tr>\n",
         "<tr><td>z</td><td>True</td></tr>\n",
-        "<tr><td>a</td><td>5.0</td></tr>\n",
         "<tr><td>Temp</td><td>5</td></tr>\n",
+        "<tr><td>Float (a)</td><td>5.0</td></tr>\n",
         "</table>"
        ],
        "metadata": {},
        "output_type": "display_data",
        "text": [
-        "<IPython.core.display.HTML at 0x10f027050>"
+        "<IPython.core.display.HTML object>"
        ]
       }
      ],


### PR DESCRIPTION
If an existing widget is used with `interact`, and that widget has a description, then the description should not be overwritten. If it does not have a description, then the name should be used as a default.

This is as an alternative to #5653 as discussed in the dev meeting.
