### PR TITLE
Handle notebook hotkeys only in ipython-main-app

### DIFF
--- a/IPython/html/static/notebook/js/keyboardmanager.js
+++ b/IPython/html/static/notebook/js/keyboardmanager.js
@@ -484,6 +484,10 @@ var IPython = (function (IPython) {
             // websocket connection with firefox
             event.preventDefault();
         }
+
+        if ($(event.target).closest('#ipython-main-app').attr("id") == undefined ) {
+            return true;
+        }
         
         if (!this.enabled) {
             if (event.which === keycodes.esc) {


### PR DESCRIPTION
Hotkeys should only be handled in notebook cells, not in the menu or the toolbar.

My use case: I want to add a text input field in the toolbar. It is impossible to type in anything there, due to the keys being interpreted as hotekeys.
