### PR TITLE
Make rmagic display call compatible with updated API

### DIFF
--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -665,7 +665,7 @@ class RMagics(Magics):
                 self.shell.push({output:self.Rconverter(self.r(output), dataframe=True)})
 
         for tag, disp_d in display_data:
-            publish_display_data(tag, disp_d)
+            publish_display_data(data=disp_d, source=tag)
 
         # this will keep a reference to the display_data
         # which might be useful to other objects who happen to use


### PR DESCRIPTION
Passing all arguments as keywords will work with the previous API as well.

CC @davclark - You'll want to copy this change across to rpy2, because without it, rmagic is broken with IPython master.
