### PR TITLE
remove Firefox-specific CSS workaround

### DIFF
--- a/IPython/html/static/notebook/less/codemirror.less
+++ b/IPython/html/static/notebook/less/codemirror.less
@@ -22,14 +22,6 @@
     overflow-x: auto;
 }
 
-@-moz-document url-prefix() {
-  /* Firefox does weird and terrible things (#3549) when overflow-x is auto */
-  /* It doesn't respect the overflow setting anyway, so we can workaround it with this */
-  .CodeMirror-scroll {
-    overflow-x: hidden;
-  }
-}
-
 .CodeMirror-lines {
     /* In CM2, this used to be 0.4em, but in CM3 it went to 4px. We need the em value because */
     /* we have set a different line-height and want this to scale with that. */

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -57,7 +57,7 @@ div.input_area>div.highlight{margin:.4em;border:none;padding:0;background-color:
 div.input_area>div.highlight>pre{margin:0;border:none;padding:0;background-color:transparent}
 .CodeMirror{line-height:1.21429em;height:auto;background:none;}
 .CodeMirror-scroll{overflow-y:hidden;overflow-x:auto}
-@-moz-document url-prefix(){.CodeMirror-scroll{overflow-x:hidden}}.CodeMirror-lines{padding:.4em}
+.CodeMirror-lines{padding:.4em}
 .CodeMirror-linenumber{padding:0 8px 0 4px}
 .CodeMirror-gutters{border-bottom-left-radius:4px;border-top-left-radius:4px}
 .CodeMirror pre{padding:0;border:0;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1362,7 +1362,7 @@ div.input_area>div.highlight{margin:.4em;border:none;padding:0;background-color:
 div.input_area>div.highlight>pre{margin:0;border:none;padding:0;background-color:transparent}
 .CodeMirror{line-height:1.21429em;height:auto;background:none;}
 .CodeMirror-scroll{overflow-y:hidden;overflow-x:auto}
-@-moz-document url-prefix(){.CodeMirror-scroll{overflow-x:hidden}}.CodeMirror-lines{padding:.4em}
+.CodeMirror-lines{padding:.4em}
 .CodeMirror-linenumber{padding:0 8px 0 4px}
 .CodeMirror-gutters{border-bottom-left-radius:4px;border-top-left-radius:4px}
 .CodeMirror pre{padding:0;border:0;border-radius:0;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}


### PR DESCRIPTION
The bug being worked around appears to be fixed either in CodeMirror or Firefox (tested with FF 29).

Importantly, the workaround appears to _introduce_ incorrect behavior

closes #5192
closes #5364
