### PR TITLE
Fix typos in Cython example

### DIFF
--- a/examples/Builtin Extensions/Cython Magics.ipynb
+++ b/examples/Builtin Extensions/Cython Magics.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
-  "name": "Cython Magics",
-  "signature": "sha256:c357b93e9480d6347c6677862bf43750745cef4b30129c5bc53cb879a19d4074"
+  "name": "",
+  "signature": "sha256:91a890584d01fd61b1b252f257244d3facd2c1cc9d021d83dc894b97d9a0c47d"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -102,7 +102,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "The `%%cython_pyximport` magic allows you to enter arbitrary Cython code into a cell. That Cython code is written as a `.pyx` file in the current working directory and then imported using `pyximport`.  You have the specify the name of the module that the Code will appear in. All symbols from the module are imported automatically by the magic function."
+      "The `%%cython_pyximport` magic allows you to enter arbitrary Cython code into a cell. That Cython code is written as a `.pyx` file in the current working directory and then imported using `pyximport`.  You have to specify the name of the module that the Code will appear in. All symbols from the module are imported automatically by the magic function."
      ]
     },
     {
@@ -150,7 +150,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Probably the most important magic is the `%cython` magic.  This is similar to the `%%cython_pyximport` magic, but doesn't require you to specify a module name. Instead, the `%%cython` magic uses manages everything using temporary files in the `~/.cython/magic` directory.  All of the symbols in the Cython module are imported automatically by the magic.\n",
+      "Probably the most important magic is the `%cython` magic.  This is similar to the `%%cython_pyximport` magic, but doesn't require you to specify a module name. Instead, the `%%cython` magic manages everything using temporary files in the `~/.cython/magic` directory.  All of the symbols in the Cython module are imported automatically by the magic.\n",
       "\n",
       "Here is a simple example of a Black-Scholes options pricing algorithm written in Cython. Please note that this example might not compile on non-POSIX systems (e.g., Windows) because of a missing `erf` symbol."
      ]

--- a/examples/Builtin Extensions/Cython Magics.ipynb
+++ b/examples/Builtin Extensions/Cython Magics.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
-  "name": "",
-  "signature": "sha256:91a890584d01fd61b1b252f257244d3facd2c1cc9d021d83dc894b97d9a0c47d"
+  "name": "Cython Magics",
+  "signature": "sha256:c357b93e9480d6347c6677862bf43750745cef4b30129c5bc53cb879a19d4074"
  },
  "nbformat": 3,
  "nbformat_minor": 0,


### PR DESCRIPTION
Just couple of small things.
