### PR TITLE
ensure load_connection_file works after self.session is created

### DIFF
--- a/IPython/kernel/client.py
+++ b/IPython/kernel/client.py
@@ -56,11 +56,6 @@ class KernelClient(LoggingConfigurable, ConnectionFileMixin):
     def _context_default(self):
         return zmq.Context.instance()
 
-    # The Session to use for communication with the kernel.
-    session = Instance(Session)
-    def _session_default(self):
-        return Session(parent=self)
-
     # The classes to use for the various channels
     shell_channel_class = Type(ShellChannel)
     iopub_channel_class = Type(IOPubChannel)

--- a/IPython/kernel/client.py
+++ b/IPython/kernel/client.py
@@ -1,23 +1,12 @@
-"""Base class to manage the interaction with a running kernel
-"""
+"""Base class to manage the interaction with a running kernel"""
 
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2013  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 from __future__ import absolute_import
 
 import zmq
 
-# Local imports
-from IPython.config.configurable import LoggingConfigurable
 from IPython.utils.traitlets import (
     Any, Instance, Type,
 )
@@ -31,11 +20,7 @@ from .clientabc import KernelClientABC
 from .connect import ConnectionFileMixin
 
 
-#-----------------------------------------------------------------------------
-# Main kernel client class
-#-----------------------------------------------------------------------------
-
-class KernelClient(LoggingConfigurable, ConnectionFileMixin):
+class KernelClient(ConnectionFileMixin):
     """Communicates with a single kernel on any host via zmq channels.
 
     There are four channels associated with each kernel:

--- a/IPython/kernel/connect.py
+++ b/IPython/kernel/connect.py
@@ -34,7 +34,7 @@ from IPython.utils.path import filefind, get_ipython_dir
 from IPython.utils.py3compat import (str_to_bytes, bytes_to_str, cast_bytes_py2,
                                      string_types)
 from IPython.utils.traitlets import (
-    Bool, Integer, Unicode, CaselessStrEnum,
+    Bool, Integer, Unicode, CaselessStrEnum, Instance,
 )
 
 
@@ -433,6 +433,12 @@ class ConnectionFileMixin(Configurable):
     def ports(self):
         return [ getattr(self, name) for name in port_names ]
 
+    # The Session to use for communication with the kernel.
+    session = Instance('IPython.kernel.zmq.session.Session')
+    def _session_default(self):
+        from IPython.kernel.zmq.session import Session
+        return Session(parent=self)
+
     #--------------------------------------------------------------------------
     # Connection and ipc file management
     #--------------------------------------------------------------------------
@@ -506,15 +512,10 @@ class ConnectionFileMixin(Configurable):
                 # not overridden by config or cl_args
                 setattr(self, name, cfg[name])
         
-        if self.session:
-            session = self.session
-        else:
-            session = self.config.Session
-        
         if 'key' in cfg:
-            session.key = str_to_bytes(cfg['key'])
+            self.session.key = str_to_bytes(cfg['key'])
         if 'signature_scheme' in cfg:
-            session.signature_scheme = cfg['signature_scheme']
+            self.session.signature_scheme = cfg['signature_scheme']
 
     #--------------------------------------------------------------------------
     # Creating connected sockets

--- a/IPython/kernel/connect.py
+++ b/IPython/kernel/connect.py
@@ -27,7 +27,7 @@ import zmq
 from IPython.external.ssh import tunnel
 
 # IPython imports
-from IPython.config import Configurable
+from IPython.config import LoggingConfigurable
 from IPython.core.profiledir import ProfileDir
 from IPython.utils.localinterfaces import localhost
 from IPython.utils.path import filefind, get_ipython_dir
@@ -381,7 +381,7 @@ channel_socket_types = {
 
 port_names = [ "%s_port" % channel for channel in ('shell', 'stdin', 'iopub', 'hb', 'control')]
 
-class ConnectionFileMixin(Configurable):
+class ConnectionFileMixin(LoggingConfigurable):
     """Mixin for configurable classes that work with connection files"""
 
     # The addresses for the communication channels

--- a/IPython/kernel/connect.py
+++ b/IPython/kernel/connect.py
@@ -505,10 +505,17 @@ class ConnectionFileMixin(Configurable):
             if getattr(self, name) == 0 and name in cfg:
                 # not overridden by config or cl_args
                 setattr(self, name, cfg[name])
+        
+        if self.session:
+            session = self.session
+        else:
+            session = self.config.Session
+        
         if 'key' in cfg:
-            self.config.Session.key = str_to_bytes(cfg['key'])
+            session.key = str_to_bytes(cfg['key'])
         if 'signature_scheme' in cfg:
-            self.config.Session.signature_scheme = cfg['signature_scheme']
+            session.signature_scheme = cfg['signature_scheme']
+
     #--------------------------------------------------------------------------
     # Creating connected sockets
     #--------------------------------------------------------------------------

--- a/IPython/kernel/manager.py
+++ b/IPython/kernel/manager.py
@@ -46,11 +46,6 @@ class KernelManager(LoggingConfigurable, ConnectionFileMixin):
     def _context_default(self):
         return zmq.Context.instance()
 
-    # The Session to use for communication with the kernel.
-    session = Instance(Session)
-    def _session_default(self):
-        return Session(parent=self)
-
     # the class to create with our `client` method
     client_class = DottedObjectName('IPython.kernel.blocking.BlockingKernelClient')
     client_factory = Type()

--- a/IPython/kernel/manager.py
+++ b/IPython/kernel/manager.py
@@ -5,7 +5,6 @@
 
 from __future__ import absolute_import
 
-# Standard library imports
 import os
 import re
 import signal
@@ -15,8 +14,6 @@ import warnings
 
 import zmq
 
-# Local imports
-from IPython.config.configurable import LoggingConfigurable
 from IPython.utils.importstring import import_item
 from IPython.utils.localinterfaces import is_local_ip, local_ips
 from IPython.utils.path import get_ipython_dir
@@ -35,7 +32,7 @@ from .managerabc import (
 )
 
 
-class KernelManager(LoggingConfigurable, ConnectionFileMixin):
+class KernelManager(ConnectionFileMixin):
     """Manages a single kernel in a subprocess on this host.
 
     This version starts kernels with Popen.

--- a/IPython/kernel/tests/test_connect.py
+++ b/IPython/kernel/tests/test_connect.py
@@ -27,6 +27,7 @@ from IPython.core.application import BaseIPythonApplication
 from IPython.utils.tempdir import TemporaryDirectory, TemporaryWorkingDirectory
 from IPython.utils.py3compat import str_to_bytes
 from IPython.kernel import connect
+from IPython.kernel.zmq.session import Session
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -51,6 +52,24 @@ def test_write_connection_file():
             info = json.load(f)
     info['key'] = str_to_bytes(info['key'])
     nt.assert_equal(info, sample_info)
+
+
+def test_load_connection_file_session():
+    """test load_connection_file() after """
+    session = Session()
+    app = DummyConsoleApp(session=Session())
+    app.initialize(argv=[])
+    session = app.session
+    
+    with TemporaryDirectory() as d:
+        cf = os.path.join(d, 'kernel.json')
+        connect.write_connection_file(cf, **sample_info)
+        app.connection_file = cf
+        app.load_connection_file()
+    
+    nt.assert_equal(session.key, sample_info['key'])
+    nt.assert_equal(session.signature_scheme, sample_info['signature_scheme'])
+
 
 def test_app_load_connection_file():
     """test `ipython console --existing` loads a connection file"""

--- a/IPython/kernel/zmq/kernelapp.py
+++ b/IPython/kernel/zmq/kernelapp.py
@@ -111,7 +111,6 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
     kernel = Any()
     poller = Any() # don't restrict this even though current pollers are all Threads
     heartbeat = Instance(Heartbeat)
-    session = Instance('IPython.kernel.zmq.session.Session')
     ports = Dict()
     
     # ipkernel doesn't get its own config file
@@ -289,11 +288,6 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
                                 stdin=self.stdin_port, hb=self.hb_port,
                                 control=self.control_port)
 
-    def init_session(self):
-        """create our session object"""
-        default_secure(self.config)
-        self.session = Session(parent=self, username=u'kernel')
-
     def init_blackhole(self):
         """redirects stdout/stderr to devnull if necessary"""
         if self.no_stdout or self.no_stderr:
@@ -363,9 +357,9 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
     @catch_config_error
     def initialize(self, argv=None):
         super(IPKernelApp, self).initialize(argv)
+        default_secure(self.config)
         self.init_blackhole()
         self.init_connection_file()
-        self.init_session()
         self.init_poller()
         self.init_sockets()
         self.init_heartbeat()


### PR DESCRIPTION
Adds session and log traitlets to ConnectionFileMixin, because it relies on both.

closes #5853
