### PR TITLE
add page-up and page-down functionality to the autocomplete dropdown

### DIFF
--- a/IPython/html/static/notebook/js/completer.js
+++ b/IPython/html/static/notebook/js/completer.js
@@ -351,6 +351,18 @@ var IPython = (function (IPython) {
             }
             index = Math.min(Math.max(index, 0), options.length-1);
             this.sel[0].selectedIndex = index;
+        } else if (code == keycodes.pageup || code == keycodes.pagedown) {
+            CodeMirror.e_stop(event);
+
+            var options = this.sel.find('option');
+            var index = this.sel[0].selectedIndex;
+            if (code == keycodes.pageup) {
+                index -= 10; // As 10 is the hard coded size of the drop down menu
+            } else {
+                index += 10;
+            }
+            index = Math.min(Math.max(index, 0), options.length-1);
+            this.sel[0].selectedIndex = index;
         } else if (code == keycodes.left || code == keycodes.right) {
             this.close();
         }


### PR DESCRIPTION
The drop down list of the auto complete currently only accepts up and down arrow keys for browsing the possible selections. This PR adds the ability to scroll through the available options using page up/page down.

Slightly off topic: I have just been comparing the different behaviours of auto complete drop down menus in different editors, and they are all (slightly) different - what is the behaviour that we want to copy?
