### PR TITLE
Skip qtconsole help test if no X11

### DIFF
--- a/IPython/qt/console/tests/test_app.py
+++ b/IPython/qt/console/tests/test_app.py
@@ -14,11 +14,13 @@
 import nose.tools as nt
 
 import IPython.testing.tools as tt
+from IPython.testing.decorators import skip_if_no_x11
 
 #-----------------------------------------------------------------------------
 # Test functions
 #-----------------------------------------------------------------------------
 
+@skip_if_no_x11
 def test_help_output():
     """ipython qtconsole --help-all works"""
     tt.help_all_output_test('qtconsole')


### PR DESCRIPTION
It may be possible to make the help output work without X11, but it's not high priority, and we don't use the Qt console enough to know if we break some corner case. This will let the relevant test pass.
