### PR TITLE
Make test robust against differences in line endings

### DIFF
--- a/IPython/utils/tests/test_openpy.py
+++ b/IPython/utils/tests/test_openpy.py
@@ -24,8 +24,8 @@ def test_read_file():
 def test_source_to_unicode():
     with io.open(nonascii_path, 'rb') as f:
         source_bytes = f.read()
-    nt.assert_equal(openpy.source_to_unicode(source_bytes, skip_encoding_cookie=False),
-                    source_bytes.decode('iso-8859-5'))
+    nt.assert_equal(openpy.source_to_unicode(source_bytes, skip_encoding_cookie=False).splitlines(),
+                    source_bytes.decode('iso-8859-5').splitlines())
 
     source_no_cookie = openpy.source_to_unicode(source_bytes, skip_encoding_cookie=True)
     nt.assert_not_in(u'coding: iso-8859-5', source_no_cookie)


### PR DESCRIPTION
git on Windows can change line endings on checkout, which was leading to a test failure.
