### PR TITLE
Ignore .DS_Store files (OSX)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ __pycache__
 *.bak
 .ipynb_checkpoints
 .tox
+.DS_Store


### PR DESCRIPTION
My Mac seems to create these boogers everywhere.  My guess is they are icon cache files- no reason for these to make their way into IPython.
