### PR TITLE
specify encoding in msgpack.unpackb

### DIFF
--- a/IPython/kernel/zmq/tests/test_session.py
+++ b/IPython/kernel/zmq/tests/test_session.py
@@ -284,7 +284,12 @@ class TestSession(SessionTestCase):
     
     @skipif(module_not_available('msgpack'))
     def test_datetimes_msgpack(self):
-        session = ss.Session(packer='msgpack.packb', unpacker='msgpack.unpackb')
+        import msgpack
+        
+        session = ss.Session(
+            pack=msgpack.packb,
+            unpack=lambda buf: msgpack.unpackb(buf, encoding='utf8'),
+        )
         self._datetime_test(session)
     
     def test_send_raw(self):


### PR DESCRIPTION
otherwise, it will leave strings as utf8 bytes, causing test failures on Python 3.
