### PR TITLE
Tmpdir cleanup errors

### DIFF
--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -15,7 +15,7 @@ import nose.tools as nt
 from IPython.config.loader import Config
 from IPython.core import completer
 from IPython.external.decorators import knownfailureif
-from IPython.utils.tempdir import TemporaryDirectory
+from IPython.utils.tempdir import TemporaryDirectory, TemporaryWorkingDirectory
 from IPython.utils.generics import complete_object
 from IPython.utils import py3compat
 from IPython.utils.py3compat import string_types, unicode_type
@@ -189,28 +189,22 @@ def test_abspath_file_completions():
 
 def test_local_file_completions():
     ip = get_ipython()
-    cwd = py3compat.getcwd()
-    try:
-        with TemporaryDirectory() as tmpdir:
-            os.chdir(tmpdir)
-            prefix = './foo'
-            suffixes = ['1', '2']
-            names = [prefix+s for s in suffixes]
-            for n in names:
-                open(n, 'w').close()
+    with TemporaryWorkingDirectory():
+        prefix = './foo'
+        suffixes = ['1', '2']
+        names = [prefix+s for s in suffixes]
+        for n in names:
+            open(n, 'w').close()
 
-            # Check simple completion
-            c = ip.complete(prefix)[1]
-            nt.assert_equal(c, names)
+        # Check simple completion
+        c = ip.complete(prefix)[1]
+        nt.assert_equal(c, names)
 
-            # Now check with a function call
-            cmd = 'a = f("%s' % prefix
-            c = ip.complete(prefix, cmd)[1]
-            comp = [prefix+s for s in suffixes]
-            nt.assert_equal(c, comp)
-    finally:
-        # prevent failures from making chdir stick
-        os.chdir(cwd)
+        # Now check with a function call
+        cmd = 'a = f("%s' % prefix
+        c = ip.complete(prefix, cmd)[1]
+        comp = [prefix+s for s in suffixes]
+        nt.assert_equal(c, comp)
 
 
 def test_greedy_completions():

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -134,6 +134,8 @@ def test_history():
             ip.history_manager.writeout_cache()
             nt.assert_equal(ip.history_manager.session_number, 3)
         finally:
+            # Ensure saving thread is shut down before we try to clean up the files
+            ip.history_manager.save_thread.stop()
             # Restore history manager
             ip.history_manager = hist_manager_ori
 

--- a/IPython/core/tests/test_prompts.py
+++ b/IPython/core/tests/test_prompts.py
@@ -8,7 +8,7 @@ import os
 from IPython.testing import tools as tt, decorators as dec
 from IPython.core.prompts import PromptManager, LazyEvaluate
 from IPython.testing.globalipapp import get_ipython
-from IPython.utils.tempdir import TemporaryDirectory
+from IPython.utils.tempdir import TemporaryWorkingDirectory
 from IPython.utils import py3compat
 from IPython.utils.py3compat import unicode_type
 
@@ -67,13 +67,10 @@ class PromptTests(unittest.TestCase):
     
     @dec.onlyif_unicode_paths
     def test_render_unicode_cwd(self):
-        save = py3compat.getcwd()
-        with TemporaryDirectory(u'ünicødé') as td:
-            os.chdir(td)
+        with TemporaryWorkingDirectory(u'ünicødé'):
             self.pm.in_template = r'\w [\#]'
             p = self.pm.render('in', color=False)
             self.assertEqual(p, u"%s [%i]" % (py3compat.getcwd(), ip.execution_count))
-        os.chdir(save)
     
     def test_lazy_eval_unicode(self):
         u = u'ünicødé'


### PR DESCRIPTION
Windows tests on Python 3 are failing in these places because the `TemporaryDirectory` context manager attempts to clean up files or folders that are still in use. On Python 2 the code was just ignoring the errors.

I think these changes should resolve it. In two cases, we can use the new `TemporaryWorkingDirectory` context manager, which actually makes the code simpler.
