### PR TITLE
inserting new cells preserves cell type

### DIFF
--- a/IPython/html/static/notebook/js/keyboardmanager.js
+++ b/IPython/html/static/notebook/js/keyboardmanager.js
@@ -259,7 +259,7 @@ var IPython = (function (IPython) {
             help    : 'insert cell above',
             help_index : 'ec',
             handler : function (event) {
-                IPython.notebook.insert_cell_above('code');
+                IPython.notebook.insert_cell_above();
                 IPython.notebook.select_prev();
                 IPython.notebook.focus_cell();
                 return false;
@@ -269,7 +269,7 @@ var IPython = (function (IPython) {
             help    : 'insert cell below',
             help_index : 'ed',
             handler : function (event) {
-                IPython.notebook.insert_cell_below('code');
+                IPython.notebook.insert_cell_below();
                 IPython.notebook.select_next();
                 IPython.notebook.focus_cell();
                 return false;

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1478,7 +1478,7 @@ var IPython = (function (IPython) {
         // If we are at the end always insert a new cell and return
         if (cell_index === (this.ncells()-1)) {
             this.command_mode();
-            this.insert_cell_below('code');
+            this.insert_cell_below();
             this.select(cell_index+1);
             this.edit_mode();
             this.scroll_to_bottom();
@@ -1487,7 +1487,7 @@ var IPython = (function (IPython) {
         }
 
         this.command_mode();
-        this.insert_cell_below('code');
+        this.insert_cell_below();
         this.select(cell_index+1);
         this.edit_mode();
         this.set_dirty(true);
@@ -1508,7 +1508,7 @@ var IPython = (function (IPython) {
         // If we are at the end always insert a new cell and return
         if (cell_index === (this.ncells()-1)) {
             this.command_mode();
-            this.insert_cell_below('code');
+            this.insert_cell_below();
             this.select(cell_index+1);
             this.edit_mode();
             this.scroll_to_bottom();

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -731,13 +731,16 @@ var IPython = (function (IPython) {
     /**
      * Insert a cell so that after insertion the cell is at given index.
      *
+     * If cell type is not provided, it will default to the type of the
+     * currently active cell.
+     *
      * Similar to insert_above, but index parameter is mandatory
      *
-     * Index will be brought back into the accissible range [0,n]
+     * Index will be brought back into the accessible range [0,n]
      *
      * @method insert_cell_at_index
-     * @param type {string} in ['code','markdown','heading']
-     * @param [index] {int} a valid index where to inser cell
+     * @param [type] {string} in ['code','markdown','heading'], defaults to 'code'
+     * @param [index] {int} a valid index where to insert cell
      *
      * @return cell {cell|null} created cell or null
      **/
@@ -747,6 +750,7 @@ var IPython = (function (IPython) {
         index = Math.min(index,ncells);
         index = Math.max(index,0);
         var cell = null;
+        type = type || this.get_selected_cell().cell_type;
 
         if (ncells === 0 || this.is_valid_cell_index(index) || index === ncells) {
             if (type === 'code') {
@@ -819,7 +823,7 @@ var IPython = (function (IPython) {
      * default index value is the one of currently selected cell
      *
      * @method insert_cell_above
-     * @param type {string} cell type
+     * @param [type] {string} cell type
      * @param [index] {integer}
      *
      * @return handle to created cell or null
@@ -831,12 +835,12 @@ var IPython = (function (IPython) {
 
     /**
      * Insert a cell of given type below given index, or at bottom
-     * of notebook if index greater thatn number of cell
+     * of notebook if index greater than number of cells
      *
      * default index value is the one of currently selected cell
      *
      * @method insert_cell_below
-     * @param type {string} cell type
+     * @param [type] {string} cell type
      * @param [index] {integer}
      *
      * @return handle to created cell or null

--- a/IPython/html/tests/notebook/dualmode_cellinsert.js
+++ b/IPython/html/tests/notebook/dualmode_cellinsert.js
@@ -18,10 +18,25 @@ casper.notebook_test(function () {
         this.select_cell(2);
         this.trigger_keydown('a'); // Creates one cell
         this.test.assertEquals(this.get_cell_text(2), '', 'a; New cell 2 text is empty');
+        this.test.assertEquals(this.get_cell(2).cell_type, 'code', 'a; inserts a code cell when on code cell');
         this.validate_notebook_state('a', 'command', 2);
         this.trigger_keydown('b'); // Creates one cell
         this.test.assertEquals(this.get_cell_text(2), '', 'b; Cell 2 text is still empty');
         this.test.assertEquals(this.get_cell_text(3), '', 'b; New cell 3 text is empty');
+        this.test.assertEquals(this.get_cell(3).cell_type, 'code', 'b; inserts a code cell when on code cell');
+        this.validate_notebook_state('b', 'command', 3);
+    });
+    this.then(function () {
+        // Cell insertion
+        this.select_cell(2);
+        this.trigger_keydown('m'); // switch it to markdown for the next test
+        this.trigger_keydown('a'); // Creates one cell
+        this.test.assertEquals(this.get_cell_text(2), '', 'a; New cell 2 text is empty');
+        this.test.assertEquals(this.get_cell(2).cell_type, 'markdown', 'a; inserts a markdown cell when on markdown cell');
+        this.validate_notebook_state('a', 'command', 2);
+        this.trigger_keydown('b'); // Creates one cell
+        this.test.assertEquals(this.get_cell_text(2), '', 'b; Cell 2 text is still empty');
+        this.test.assertEquals(this.get_cell(3).cell_type, 'markdown', 'b; inserts a markdown cell when on markdown cell');
         this.validate_notebook_state('b', 'command', 3);
     });
 });

--- a/IPython/html/tests/util.js
+++ b/IPython/html/tests/util.js
@@ -167,8 +167,6 @@ casper.get_cell_text = function(index){
 casper.insert_cell_at_bottom = function(cell_type){
     // Inserts a cell at the bottom of the notebook
     // Returns the new cell's index.
-    cell_type = cell_type || 'code';
-
     return this.evaluate(function (cell_type) {
         var cell = IPython.notebook.insert_cell_at_bottom(cell_type);
         return IPython.notebook.find_cell_index(cell);


### PR DESCRIPTION
This PR closes #4917

use current cell's type when inserting new cells above/below

This PR retains all previous behavior when cell type is explicitly provided,
but simply adds the ability to insert cells without specifying a cell type, in
which case the cell type is inferred from the currently selected cell.
