### PR TITLE
forcefully hide CodeMirror scrollbars

### DIFF
--- a/IPython/html/static/notebook/less/codemirror.less
+++ b/IPython/html/static/notebook/less/codemirror.less
@@ -48,3 +48,10 @@
     border: 0;
     .border-radius(0)
 }
+
+// FIXME: This is a horrible workaround for CodeMirror bug #2562.
+// Let's try not to release 3.0 with this.
+
+.CodeMirror-vscrollbar, .CodeMirror-hscrollbar {
+    display: none !important;
+}

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -61,6 +61,7 @@ div.input_area>div.highlight>pre{margin:0;border:none;padding:0;background-color
 .CodeMirror-linenumber{padding:0 8px 0 4px}
 .CodeMirror-gutters{border-bottom-left-radius:4px;border-top-left-radius:4px}
 .CodeMirror pre{padding:0;border:0;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
+.CodeMirror-vscrollbar,.CodeMirror-hscrollbar{display:none !important}
 pre code{display:block;padding:.5em}
 .highlight-base,pre code,pre .subst,pre .tag .title,pre .lisp .title,pre .clojure .built_in,pre .nginx .title{color:#000}
 .highlight-string,pre .string,pre .constant,pre .parent,pre .tag .value,pre .rules .value,pre .rules .value .number,pre .preprocessor,pre .ruby .symbol,pre .ruby .symbol .string,pre .aggregate,pre .template_tag,pre .django .variable,pre .smalltalk .class,pre .addition,pre .flow,pre .stream,pre .bash .variable,pre .apache .tag,pre .apache .cbracket,pre .tex .command,pre .tex .special,pre .erlang_repl .function_or_atom,pre .markdown .header{color:#ba2121}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -1366,6 +1366,7 @@ div.input_area>div.highlight>pre{margin:0;border:none;padding:0;background-color
 .CodeMirror-linenumber{padding:0 8px 0 4px}
 .CodeMirror-gutters{border-bottom-left-radius:4px;border-top-left-radius:4px}
 .CodeMirror pre{padding:0;border:0;border-radius:0;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
+.CodeMirror-vscrollbar,.CodeMirror-hscrollbar{display:none !important}
 pre code{display:block;padding:.5em}
 .highlight-base,pre code,pre .subst,pre .tag .title,pre .lisp .title,pre .clojure .built_in,pre .nginx .title{color:#000}
 .highlight-string,pre .string,pre .constant,pre .parent,pre .tag .value,pre .rules .value,pre .rules .value .number,pre .preprocessor,pre .ruby .symbol,pre .ruby .symbol .string,pre .aggregate,pre .template_tag,pre .django .variable,pre .smalltalk .class,pre .addition,pre .flow,pre .stream,pre .bash .variable,pre .apache .tag,pre .apache .cbracket,pre .tex .command,pre .tex .special,pre .erlang_repl .function_or_atom,pre .markdown .header{color:#ba2121}


### PR DESCRIPTION
workaround for CodeMirror issue 2562

less drastic but more gross alternative to #5889

closes #5885
