### PR TITLE
Fix auto_rewrite_input event for the Notebook app

### DIFF
--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -293,6 +293,7 @@ var IPython = (function (IPython) {
                 reply : $.proxy(this._handle_execute_reply, this),
                 payload : {
                     set_next_input : $.proxy(this._handle_set_next_input, this),
+                    auto_rewrite_input : $.proxy(this._handle_auto_rewrite_input, this),
                     page : $.proxy(this._open_with_pager, this)
                 }
             },
@@ -325,6 +326,19 @@ var IPython = (function (IPython) {
     CodeCell.prototype._handle_set_next_input = function (payload) {
         var data = {'cell': this, 'text': payload.text};
         $([IPython.events]).trigger('set_next_input.Notebook', data);
+    };
+
+    /**
+     * @method _handle_auto_rewrite_input
+     * @private
+     */
+    CodeCell.prototype._handle_auto_rewrite_input = function (payload) {
+        var data = {
+            'cell': this, 
+            'transformed_input': payload.transformed_input,
+            'raw_input': payload.raw_input
+        };
+        $([IPython.events]).trigger('auto_rewrite_input.Notebook', data);
     };
 
     /**

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -109,6 +109,11 @@ var IPython = (function (IPython) {
             that.dirty = true;
         });
 
+        $([IPython.events]).on('auto_rewrite_input.Notebook', function (event, data) {
+            data.cell.set_text(data.raw_input);
+            that.dirty = true;
+        });
+
         $([IPython.events]).on('set_dirty.Notebook', function (event, data) {
             that.dirty = data.value;
         });

--- a/IPython/kernel/zmq/zmqshell.py
+++ b/IPython/kernel/zmq/zmqshell.py
@@ -475,14 +475,11 @@ class ZMQInteractiveShell(InteractiveShell):
         install_payload_page()
 
     def auto_rewrite_input(self, cmd):
-        """Called to show the auto-rewritten input for autocall and friends.
-
-        FIXME: this payload is currently not correctly processed by the
-        frontend.
-        """
+        """Called to show the auto-rewritten input for autocall and friends.""" 
         new = self.prompt_manager.render('rewrite') + cmd
         payload = dict(
             source='auto_rewrite_input',
+            raw_input=cmd,
             transformed_input=new,
             )
         self.payload_manager.write_payload(payload)


### PR DESCRIPTION
Currently auto_rewrite_input payloads are ignored by the notebook frontend. This PR adds the missing functionality.
