### PR TITLE
Deleted additional highlightning from reveal, closes #5819 and #5907.

### DIFF
--- a/IPython/nbconvert/templates/html/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/html/slides_reveal.tpl
@@ -174,7 +174,6 @@ transition: Reveal.getQueryHash().transition || 'linear', // default/cube/page/c
 // Optional libraries used to extend on reveal.js
 dependencies: [
 { src: "{{resources.reveal.url_prefix}}/lib/js/classList.js", condition: function() { return !document.body.classList; } },
-{ src: "{{resources.reveal.url_prefix}}/plugin/highlight/highlight.js", async: true, callback: function() { hljs.initHighlightingOnLoad(); } },
 { src: "{{resources.reveal.url_prefix}}/plugin/notes/notes.js", async: true, condition: function() { return !!document.body.classList; } }
 ]
 });


### PR DESCRIPTION
The problem is well explained in #5819.
This simple fix the issue avoiding the additional highlighting from reveal.js itself. 
