### PR TITLE
Change z-index of ipython_tooltip

### DIFF
--- a/IPython/html/static/notebook/less/tooltip.less
+++ b/IPython/html/static/notebook/less/tooltip.less
@@ -117,7 +117,7 @@
     };
     position: absolute;
 
-	z-index: 2;
+	z-index: 1000;
 	
 	.tooltiptext {
 		pre {


### PR DESCRIPTION
I experienced the problem stated in #5755. Giving the ipython_tooltip class a higher z-index indeed solves the problem. I intentionally set it to a high value so it likelier remains on top when styles are changed in the future.
