### PR TITLE
add contents webservice

### DIFF
--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -1,4 +1,4 @@
-"""Base Tornado handlers for the notebook."""
+"""Base Tornado handlers for the notebook server."""
 
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
@@ -141,8 +141,8 @@ class IPythonHandler(AuthenticatedHandler):
         return self.settings['kernel_manager']
 
     @property
-    def notebook_manager(self):
-        return self.settings['notebook_manager']
+    def contents_manager(self):
+        return self.settings['contents_manager']
     
     @property
     def cluster_manager(self):
@@ -158,7 +158,7 @@ class IPythonHandler(AuthenticatedHandler):
 
     @property
     def project_dir(self):
-        return self.notebook_manager.notebook_dir
+        return getattr(self.contents_manager, 'root_dir', '/')
     
     #---------------------------------------------------------------
     # CORS

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -156,10 +156,6 @@ class IPythonHandler(AuthenticatedHandler):
     def kernel_spec_manager(self):
         return self.settings['kernel_spec_manager']
 
-    @property
-    def project_dir(self):
-        return getattr(self.contents_manager, 'root_dir', '/')
-    
     #---------------------------------------------------------------
     # CORS
     #---------------------------------------------------------------

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -416,6 +416,8 @@ class TrailingSlashHandler(web.RequestHandler):
 path_regex = r"(?P<path>(?:/.*)*)"
 notebook_name_regex = r"(?P<name>[^/]+\.ipynb)"
 notebook_path_regex = "%s/%s" % (path_regex, notebook_name_regex)
+file_name_regex = r"(?P<name>[^/]+)"
+file_path_regex = "%s/%s" % (path_regex, file_name_regex)
 
 #-----------------------------------------------------------------------------
 # URL to handler mappings

--- a/IPython/html/nbconvert/handlers.py
+++ b/IPython/html/nbconvert/handlers.py
@@ -9,7 +9,10 @@ import zipfile
 
 from tornado import web
 
-from ..base.handlers import IPythonHandler, notebook_path_regex
+from ..base.handlers import (
+    IPythonHandler, FilesRedirectHandler,
+    notebook_path_regex, path_regex,
+)
 from IPython.nbformat.current import to_notebook_json
 
 from IPython.utils.py3compat import cast_bytes
@@ -128,6 +131,7 @@ class NbconvertPostHandler(IPythonHandler):
 
         self.finish(output)
 
+
 #-----------------------------------------------------------------------------
 # URL to handler mappings
 #-----------------------------------------------------------------------------
@@ -139,4 +143,5 @@ default_handlers = [
     (r"/nbconvert/%s%s" % (_format_regex, notebook_path_regex),
          NbconvertFileHandler),
     (r"/nbconvert/%s" % _format_regex, NbconvertPostHandler),
+    (r"/nbconvert/html%s" % path_regex, FilesRedirectHandler),
 ]

--- a/IPython/html/nbconvert/handlers.py
+++ b/IPython/html/nbconvert/handlers.py
@@ -73,7 +73,7 @@ class NbconvertFileHandler(IPythonHandler):
         exporter = get_exporter(format, config=self.config, log=self.log)
         
         path = path.strip('/')
-        model = self.notebook_manager.get_notebook(name=name, path=path)
+        model = self.contents_manager.get(name=name, path=path)
 
         self.set_header('Last-Modified', model['last_modified'])
         

--- a/IPython/html/nbconvert/handlers.py
+++ b/IPython/html/nbconvert/handlers.py
@@ -1,3 +1,8 @@
+"""Tornado handlers for nbconvert."""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 import io
 import os
 import zipfile
@@ -73,7 +78,7 @@ class NbconvertFileHandler(IPythonHandler):
         exporter = get_exporter(format, config=self.config, log=self.log)
         
         path = path.strip('/')
-        model = self.contents_manager.get(name=name, path=path)
+        model = self.contents_manager.get_model(name=name, path=path)
 
         self.set_header('Last-Modified', model['last_modified'])
         

--- a/IPython/html/nbconvert/tests/test_nbconvert_handlers.py
+++ b/IPython/html/nbconvert/tests/test_nbconvert_handlers.py
@@ -106,7 +106,7 @@ class APITest(NotebookTestBase):
 
     @onlyif_cmds_exist('pandoc')
     def test_from_post(self):
-        nbmodel_url = url_path_join(self.base_url(), 'api/notebooks/foo/testnb.ipynb')
+        nbmodel_url = url_path_join(self.base_url(), 'api/contents/foo/testnb.ipynb')
         nbmodel = requests.get(nbmodel_url).json()
         
         r = self.nbconvert_api.from_post(format='html', nbmodel=nbmodel)
@@ -121,7 +121,7 @@ class APITest(NotebookTestBase):
 
     @onlyif_cmds_exist('pandoc')
     def test_from_post_zip(self):
-        nbmodel_url = url_path_join(self.base_url(), 'api/notebooks/foo/testnb.ipynb')
+        nbmodel_url = url_path_join(self.base_url(), 'api/contents/foo/testnb.ipynb')
         nbmodel = requests.get(nbmodel_url).json()
 
         r = self.nbconvert_api.from_post(format='latex', nbmodel=nbmodel)

--- a/IPython/html/notebook/handlers.py
+++ b/IPython/html/notebook/handlers.py
@@ -35,12 +35,12 @@ class NotebookHandler(IPythonHandler):
         """get renders the notebook template if a name is given, or 
         redirects to the '/files/' handler if the name is not given."""
         path = path.strip('/')
-        nbm = self.notebook_manager
+        cm = self.contents_manager
         if name is None:
             raise web.HTTPError(500, "This shouldn't be accessible: %s" % self.request.uri)
         
         # a .ipynb filename was given
-        if not nbm.notebook_exists(name, path):
+        if not cm.file_exists(name, path):
             raise web.HTTPError(404, u'Notebook does not exist: %s/%s' % (path, name))
         name = url_escape(name)
         path = url_escape(path)
@@ -55,8 +55,8 @@ class NotebookHandler(IPythonHandler):
 
 class NotebookRedirectHandler(IPythonHandler):
     def get(self, path=''):
-        nbm = self.notebook_manager
-        if nbm.path_exists(path):
+        cm = self.contents_manager
+        if cm.path_exists(path):
             # it's a *directory*, redirect to /tree
             url = url_path_join(self.base_url, 'tree', path)
         else:
@@ -68,7 +68,7 @@ class NotebookRedirectHandler(IPythonHandler):
                 # but so is the files handler itself,
                 # so it should work until both are cleaned up.
                 parts = path.split('/')
-                files_path = os.path.join(nbm.notebook_dir, *parts)
+                files_path = os.path.join(cm.root_dir, *parts)
                 if not os.path.exists(files_path):
                     self.log.warn("Deprecated files/ URL: %s", path)
                     path = path.replace('/files/', '/', 1)

--- a/IPython/html/notebook/handlers.py
+++ b/IPython/html/notebook/handlers.py
@@ -1,31 +1,17 @@
-"""Tornado handlers for the live notebook view.
+"""Tornado handlers for the live notebook view."""
 
-Authors:
-
-* Brian Granger
-"""
-
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2011  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 import os
 from tornado import web
 HTTPError = web.HTTPError
 
-from ..base.handlers import IPythonHandler, notebook_path_regex, path_regex
-from ..utils import url_path_join, url_escape
-
-#-----------------------------------------------------------------------------
-# Handlers
-#-----------------------------------------------------------------------------
+from ..base.handlers import (
+    IPythonHandler, FilesRedirectHandler,
+    notebook_path_regex, path_regex,
+)
+from ..utils import url_escape
 
 
 class NotebookHandler(IPythonHandler):
@@ -53,33 +39,6 @@ class NotebookHandler(IPythonHandler):
             )
         )
 
-class NotebookRedirectHandler(IPythonHandler):
-    def get(self, path=''):
-        cm = self.contents_manager
-        if cm.path_exists(path):
-            # it's a *directory*, redirect to /tree
-            url = url_path_join(self.base_url, 'tree', path)
-        else:
-            orig_path = path
-            # otherwise, redirect to /files
-            parts = path.split('/')
-            path = '/'.join(parts[:-1])
-            name = parts[-1]
-
-            if not cm.file_exists(name=name, path=path) and 'files' in parts:
-                # redirect without files/ iff it would 404
-                # this preserves pre-2.0-style 'files/' links
-                self.log.warn("Deprecated files/ URL: %s", orig_path)
-                parts.remove('files')
-                path = '/'.join(parts[:-1])
-
-            if not cm.file_exists(name=name, path=path):
-                raise web.HTTPError(404)
-            
-            url = url_path_join(self.base_url, 'files', path, name)
-        url = url_escape(url)
-        self.log.debug("Redirecting %s to %s", self.request.path, url)
-        self.redirect(url)
 
 #-----------------------------------------------------------------------------
 # URL to handler mappings
@@ -88,6 +47,6 @@ class NotebookRedirectHandler(IPythonHandler):
 
 default_handlers = [
     (r"/notebooks%s" % notebook_path_regex, NotebookHandler),
-    (r"/notebooks%s" % path_regex, NotebookRedirectHandler),
+    (r"/notebooks%s" % path_regex, FilesRedirectHandler),
 ]
 

--- a/IPython/html/notebook/handlers.py
+++ b/IPython/html/notebook/handlers.py
@@ -31,7 +31,6 @@ class NotebookHandler(IPythonHandler):
         name = url_escape(name)
         path = url_escape(path)
         self.write(self.render_template('notebook.html',
-            project=self.project_dir,
             notebook_path=path,
             notebook_name=name,
             kill_kernel=False,

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -265,6 +265,11 @@ flags['no-mathjax']=(
     """
 )
 
+# Add notebook manager flags
+flags.update(boolean_flag('script', 'FileContentsManager.save_script',
+               'DEPRECATED, IGNORED',
+               'DEPRECATED, IGNORED'))
+
 aliases = dict(base_aliases)
 
 aliases.update({

--- a/IPython/html/services/contents/filemanager.py
+++ b/IPython/html/services/contents/filemanager.py
@@ -54,7 +54,7 @@ class FileContentsManager(ContentsManager):
             self.log.debug("copystat on %s failed", dest, exc_info=True)
 
     def _get_os_path(self, name=None, path=''):
-        """Given a filename and a URL path, return its file system
+        """Given a filename and API path, return its file system
         path.
 
         Parameters
@@ -62,8 +62,7 @@ class FileContentsManager(ContentsManager):
         name : string
             A filename
         path : string
-            The relative URL path (with '/' as separator) to the named
-            file.
+            The relative API path to the named file.
 
         Returns
         -------
@@ -76,6 +75,8 @@ class FileContentsManager(ContentsManager):
 
     def path_exists(self, path):
         """Does the API-style path refer to an extant directory?
+
+        API-style wrapper for os.path.isdir
 
         Parameters
         ----------
@@ -114,6 +115,8 @@ class FileContentsManager(ContentsManager):
     def file_exists(self, name, path=''):
         """Returns True if the file exists, else returns False.
 
+        API-style wrapper for os.path.isfile
+
         Parameters
         ----------
         name : string
@@ -123,7 +126,8 @@ class FileContentsManager(ContentsManager):
 
         Returns
         -------
-        bool
+        exists : bool
+            Whether the file exists.
         """
         path = path.strip('/')
         nbpath = self._get_os_path(name, path=path)
@@ -132,6 +136,8 @@ class FileContentsManager(ContentsManager):
     def exists(self, name=None, path=''):
         """Returns True if the path [and name] exists, else returns False.
 
+        API-style wrapper for os.path.exists
+
         Parameters
         ----------
         name : string
@@ -141,7 +147,8 @@ class FileContentsManager(ContentsManager):
 
         Returns
         -------
-        bool
+        exists : bool
+            Whether the target exists.
         """
         path = path.strip('/')
         os_path = self._get_os_path(name, path=path)
@@ -246,7 +253,7 @@ class FileContentsManager(ContentsManager):
         name : str
             the name of the target
         path : str
-            the URL path that describes the relative path for the target
+            the API path that describes the relative path for the target
 
         Returns
         -------
@@ -344,7 +351,11 @@ class FileContentsManager(ContentsManager):
         return model
 
     def update(self, model, name, path=''):
-        """Update the file's path and/or name"""
+        """Update the file's path and/or name
+
+        For use in PATCH requests, to enable renaming a file without
+        re-uploading its contents. Only used for renaming at the moment.
+        """
         path = path.strip('/')
         new_name = model.get('name', name)
         new_path = model.get('path', path).strip('/')
@@ -393,7 +404,7 @@ class FileContentsManager(ContentsManager):
 
         # Should we proceed with the move?
         if os.path.isfile(new_os_path):
-            raise web.HTTPError(409, u'Notebook with name already exists: %s' % new_os_path)
+            raise web.HTTPError(409, u'File with name already exists: %s' % new_os_path)
 
         # Move the file
         try:

--- a/IPython/html/services/contents/filemanager.py
+++ b/IPython/html/services/contents/filemanager.py
@@ -309,10 +309,10 @@ class FileContentsManager(ContentsManager):
         """Save the file model and return the model with no content."""
         path = path.strip('/')
 
-        if 'content' not in model:
-            raise web.HTTPError(400, u'No file content provided')
         if 'type' not in model:
             raise web.HTTPError(400, u'No file type provided')
+        if 'content' not in model and model['type'] != 'directory':
+            raise web.HTTPError(400, u'No file content provided')
 
         # One checkpoint should always exist
         if self.file_exists(name, path) and not self.list_checkpoints(name, path):

--- a/IPython/html/services/contents/filenbmanager.py
+++ b/IPython/html/services/contents/filenbmanager.py
@@ -27,10 +27,10 @@ def sort_key(item):
 #-----------------------------------------------------------------------------
 
 class FileNotebookManager(NotebookManager):
-    
+
     save_script = Bool(False, config=True,
         help="""Automatically create a Python script when saving the notebook.
-        
+
         For easier use of import, %run and %load across notebooks, a
         <notebook-name>.py script will be created next to any
         <notebook-name>.ipynb on each save.  This can also be set with the
@@ -38,7 +38,7 @@ class FileNotebookManager(NotebookManager):
         """
     )
     notebook_dir = Unicode(getcwd(), config=True)
-    
+
     def _notebook_dir_changed(self, name, old, new):
         """Do a bit of validation of the notebook dir."""
         if not os.path.isabs(new):
@@ -47,19 +47,19 @@ class FileNotebookManager(NotebookManager):
             return
         if not os.path.exists(new) or not os.path.isdir(new):
             raise TraitError("notebook dir %r is not a directory" % new)
-    
+
     checkpoint_dir = Unicode('.ipynb_checkpoints', config=True,
         help="""The directory name in which to keep notebook checkpoints
-        
+
         This is a path relative to the notebook's own directory.
-        
+
         By default, it is .ipynb_checkpoints
         """
     )
-    
+
     def _copy(self, src, dest):
         """copy src to dest
-        
+
         like shutil.copy2, but log errors in copystat
         """
         shutil.copyfile(src, dest)
@@ -67,7 +67,7 @@ class FileNotebookManager(NotebookManager):
             shutil.copystat(src, dest)
         except OSError as e:
             self.log.debug("copystat on %s failed", dest, exc_info=True)
-    
+
     def get_notebook_names(self, path=''):
         """List all notebook names in the notebook dir and path."""
         path = path.strip('/')
@@ -80,13 +80,13 @@ class FileNotebookManager(NotebookManager):
 
     def path_exists(self, path):
         """Does the API-style path (directory) actually exist?
-        
+
         Parameters
         ----------
         path : string
             The path to check. This is an API path (`/` separated,
             relative to base notebook-dir).
-        
+
         Returns
         -------
         exists : bool
@@ -98,18 +98,18 @@ class FileNotebookManager(NotebookManager):
 
     def is_hidden(self, path):
         """Does the API style path correspond to a hidden directory or file?
-        
+
         Parameters
         ----------
         path : string
             The path to check. This is an API path (`/` separated,
             relative to base notebook-dir).
-        
+
         Returns
         -------
         exists : bool
             Whether the path is hidden.
-        
+
         """
         path = path.strip('/')
         os_path = self._get_os_path(path=path)
@@ -204,13 +204,13 @@ class FileNotebookManager(NotebookManager):
     def list_notebooks(self, path):
         """Returns a list of dictionaries that are the standard model
         for all notebooks in the relative 'path'.
-        
+
         Parameters
         ----------
         path : str
             the URL path that describes the relative path for the
             listed notebooks
-        
+
         Returns
         -------
         notebooks : list of dicts
@@ -225,7 +225,7 @@ class FileNotebookManager(NotebookManager):
 
     def get_notebook(self, name, path='', content=True):
         """ Takes a path and name for a notebook and returns its model
-        
+
         Parameters
         ----------
         name : str
@@ -233,11 +233,11 @@ class FileNotebookManager(NotebookManager):
         path : str
             the URL path that describes the relative path for
             the notebook
-            
+
         Returns
         -------
         model : dict
-            the notebook model. If contents=True, returns the 'contents' 
+            the notebook model. If contents=True, returns the 'contents'
             dict in the model as well.
         """
         path = path.strip('/')
@@ -284,9 +284,9 @@ class FileNotebookManager(NotebookManager):
         # Save the notebook file
         os_path = self._get_os_path(new_name, new_path)
         nb = current.to_notebook_json(model['content'])
-        
+
         self.check_and_sign(nb, new_name, new_path)
-        
+
         if 'name' in nb['metadata']:
             nb['metadata']['name'] = u''
         try:
@@ -325,7 +325,7 @@ class FileNotebookManager(NotebookManager):
         os_path = self._get_os_path(name, path)
         if not os.path.isfile(os_path):
             raise web.HTTPError(404, u'Notebook does not exist: %s' % os_path)
-        
+
         # clear checkpoints
         for checkpoint in self.list_checkpoints(name, path):
             checkpoint_id = checkpoint['id']
@@ -333,7 +333,7 @@ class FileNotebookManager(NotebookManager):
             if os.path.isfile(cp_path):
                 self.log.debug("Unlinking checkpoint %s", cp_path)
                 os.unlink(cp_path)
-        
+
         self.log.debug("Unlinking notebook %s", os_path)
         os.unlink(os_path)
 
@@ -343,7 +343,7 @@ class FileNotebookManager(NotebookManager):
         new_path = new_path.strip('/')
         if new_name == old_name and new_path == old_path:
             return
-        
+
         new_os_path = self._get_os_path(new_name, new_path)
         old_os_path = self._get_os_path(old_name, old_path)
 
@@ -375,9 +375,9 @@ class FileNotebookManager(NotebookManager):
         # Move the .py script
         if self.save_script:
             shutil.move(old_py_path, new_py_path)
-  
+
     # Checkpoint-related utilities
-    
+
     def get_checkpoint_path(self, checkpoint_id, name, path=''):
         """find the path to a checkpoint"""
         path = path.strip('/')
@@ -404,9 +404,9 @@ class FileNotebookManager(NotebookManager):
             last_modified = last_modified,
         )
         return info
-        
+
     # public checkpoint API
-    
+
     def create_checkpoint(self, name, path=''):
         """Create a checkpoint from the current state of a notebook"""
         path = path.strip('/')
@@ -416,13 +416,13 @@ class FileNotebookManager(NotebookManager):
         cp_path = self.get_checkpoint_path(checkpoint_id, name, path)
         self.log.debug("creating checkpoint for notebook %s", name)
         self._copy(nb_path, cp_path)
-        
+
         # return the checkpoint info
         return self.get_checkpoint_model(checkpoint_id, name, path)
-    
+
     def list_checkpoints(self, name, path=''):
         """list the checkpoints for a given notebook
-        
+
         This notebook manager currently only supports one checkpoint per notebook.
         """
         path = path.strip('/')
@@ -432,8 +432,8 @@ class FileNotebookManager(NotebookManager):
             return []
         else:
             return [self.get_checkpoint_model(checkpoint_id, name, path)]
-        
-    
+
+
     def restore_checkpoint(self, checkpoint_id, name, path=''):
         """restore a notebook to a checkpointed state"""
         path = path.strip('/')
@@ -450,7 +450,7 @@ class FileNotebookManager(NotebookManager):
             current.read(f, u'json')
         self._copy(cp_path, nb_path)
         self.log.debug("copying %s -> %s", cp_path, nb_path)
-    
+
     def delete_checkpoint(self, checkpoint_id, name, path=''):
         """delete a notebook's checkpoint"""
         path = path.strip('/')
@@ -461,7 +461,7 @@ class FileNotebookManager(NotebookManager):
             )
         self.log.debug("unlinking %s", cp_path)
         os.unlink(cp_path)
-    
+
     def info_string(self):
         return "Serving notebooks from local directory: %s" % self.notebook_dir
 

--- a/IPython/html/services/contents/handlers.py
+++ b/IPython/html/services/contents/handlers.py
@@ -38,7 +38,7 @@ class NotebookHandler(IPythonHandler):
 
     def notebook_location(self, name, path=''):
         """Return the full URL location of a notebook based.
-        
+
         Parameters
         ----------
         name : unicode
@@ -57,7 +57,7 @@ class NotebookHandler(IPythonHandler):
             self.set_header('Location', location)
         self.set_header('Last-Modified', model['last_modified'])
         self.finish(json.dumps(model, default=date_default))
-    
+
     @web.authenticated
     @json_errors
     def get(self, path='', name=None):
@@ -99,10 +99,10 @@ class NotebookHandler(IPythonHandler):
             raise web.HTTPError(400, u'JSON body missing')
         model = nbm.update_notebook(model, name, path)
         self._finish_model(model)
-    
+
     def _copy_notebook(self, copy_from, path, copy_to=None):
         """Copy a notebook in path, optionally specifying the new name.
-        
+
         Only support copying within the same directory.
         """
         self.log.info(u"Copying notebook from %s/%s to %s/%s",
@@ -112,23 +112,23 @@ class NotebookHandler(IPythonHandler):
         model = self.notebook_manager.copy_notebook(copy_from, copy_to, path)
         self.set_status(201)
         self._finish_model(model)
-    
+
     def _upload_notebook(self, model, path, name=None):
         """Upload a notebook
-        
+
         If name specified, create it in path/name.
         """
         self.log.info(u"Uploading notebook to %s/%s", path, name or '')
         if name:
             model['name'] = name
-        
+
         model = self.notebook_manager.create_notebook(model, path)
         self.set_status(201)
         self._finish_model(model)
-    
+
     def _create_empty_notebook(self, path, name=None):
         """Create an empty notebook in path
-        
+
         If name specified, create it in path/name.
         """
         self.log.info(u"Creating new notebook in %s/%s", path, name or '')
@@ -138,7 +138,7 @@ class NotebookHandler(IPythonHandler):
         model = self.notebook_manager.create_notebook(model, path=path)
         self.set_status(201)
         self._finish_model(model)
-    
+
     def _save_notebook(self, model, path, name):
         """Save an existing notebook."""
         self.log.info(u"Saving notebook at %s/%s", path, name)
@@ -149,26 +149,26 @@ class NotebookHandler(IPythonHandler):
         else:
             location = False
         self._finish_model(model, location)
-    
+
     @web.authenticated
     @json_errors
     def post(self, path='', name=None):
         """Create a new notebook in the specified path.
-        
+
         POST creates new notebooks. The server always decides on the notebook name.
-        
+
         POST /api/notebooks/path
           New untitled notebook in path. If content specified, upload a
           notebook, otherwise start empty.
         POST /api/notebooks/path?copy=OtherNotebook.ipynb
           New copy of OtherNotebook in path
         """
-        
+
         if name is not None:
             raise web.HTTPError(400, "Only POST to directories. Use PUT for full names.")
-        
+
         model = self.get_json_body()
-        
+
         if model is not None:
             copy_from = model.get('copy_from')
             if copy_from:
@@ -184,10 +184,10 @@ class NotebookHandler(IPythonHandler):
     @json_errors
     def put(self, path='', name=None):
         """Saves the notebook in the location specified by name and path.
-        
+
         PUT is very similar to POST, but the requester specifies the name,
         whereas with POST, the server picks the name.
-        
+
         PUT /api/notebooks/path/Name.ipynb
           Save notebook at ``path/Name.ipynb``. Notebook structure is specified
           in `content` key of JSON request body. If content is not specified,
@@ -197,7 +197,7 @@ class NotebookHandler(IPythonHandler):
         """
         if name is None:
             raise web.HTTPError(400, "Only PUT to full names. Use POST for directories.")
-        
+
         model = self.get_json_body()
         if model:
             copy_from = model.get('copy_from')
@@ -223,9 +223,9 @@ class NotebookHandler(IPythonHandler):
 
 
 class NotebookCheckpointsHandler(IPythonHandler):
-    
+
     SUPPORTED_METHODS = ('GET', 'POST')
-    
+
     @web.authenticated
     @json_errors
     def get(self, path='', name=None):
@@ -234,7 +234,7 @@ class NotebookCheckpointsHandler(IPythonHandler):
         checkpoints = nbm.list_checkpoints(name, path)
         data = json.dumps(checkpoints, default=date_default)
         self.finish(data)
-    
+
     @web.authenticated
     @json_errors
     def post(self, path='', name=None):
@@ -250,9 +250,9 @@ class NotebookCheckpointsHandler(IPythonHandler):
 
 
 class ModifyNotebookCheckpointsHandler(IPythonHandler):
-    
+
     SUPPORTED_METHODS = ('POST', 'DELETE')
-    
+
     @web.authenticated
     @json_errors
     def post(self, path, name, checkpoint_id):
@@ -261,7 +261,7 @@ class ModifyNotebookCheckpointsHandler(IPythonHandler):
         nbm.restore_checkpoint(checkpoint_id, name, path)
         self.set_status(204)
         self.finish()
-    
+
     @web.authenticated
     @json_errors
     def delete(self, path, name, checkpoint_id):
@@ -270,7 +270,7 @@ class ModifyNotebookCheckpointsHandler(IPythonHandler):
         nbm.delete_checkpoint(checkpoint_id, name, path)
         self.set_status(204)
         self.finish()
-        
+
 #-----------------------------------------------------------------------------
 # URL to handler mappings
 #-----------------------------------------------------------------------------
@@ -285,4 +285,3 @@ default_handlers = [
     (r"/api/notebooks%s" % notebook_path_regex, NotebookHandler),
     (r"/api/notebooks%s" % path_regex, NotebookHandler),
 ]
-

--- a/IPython/html/services/contents/manager.py
+++ b/IPython/html/services/contents/manager.py
@@ -155,16 +155,23 @@ class ContentsManager(LoggingConfigurable):
                 break
         return name
 
-    def create_notebook(self, model=None, path=''):
+    def create_file(self, model=None, path='', ext='.ipynb'):
         """Create a new notebook and return its model with no content."""
         path = path.strip('/')
         if model is None:
             model = {}
         if 'content' not in model:
-            metadata = current.new_metadata(name=u'')
-            model['content'] = current.new_notebook(metadata=metadata)
+            if ext == '.ipynb':
+                metadata = current.new_metadata(name=u'')
+                model['content'] = current.new_notebook(metadata=metadata)
+                model.setdefault('type', 'notebook')
+                model.setdefault('format', 'json')
+            else:
+                model['content'] = ''
+                model.setdefault('type', 'file')
+                model.setdefault('format', 'text')
         if 'name' not in model:
-            model['name'] = self.increment_filename('Untitled.ipynb', path)
+            model['name'] = self.increment_filename('Untitled' + ext, path)
 
         model['path'] = path
         model = self.save(model, model['name'], model['path'])

--- a/IPython/html/services/contents/manager.py
+++ b/IPython/html/services/contents/manager.py
@@ -165,16 +165,16 @@ class ContentsManager(LoggingConfigurable):
         path = path.strip('/')
         if model is None:
             model = {}
-        if 'content' not in model:
+        if 'content' not in model and model.get('type', None) != 'directory':
             if ext == '.ipynb':
                 metadata = current.new_metadata(name=u'')
                 model['content'] = current.new_notebook(metadata=metadata)
-                model.setdefault('type', 'notebook')
-                model.setdefault('format', 'json')
+                model['type'] = 'notebook'
+                model['format'] = 'json'
             else:
                 model['content'] = ''
-                model.setdefault('type', 'file')
-                model.setdefault('format', 'text')
+                model['type'] = 'file'
+                model['format'] = 'text'
         if 'name' not in model:
             model['name'] = self.increment_filename('Untitled' + ext, path)
 
@@ -185,7 +185,7 @@ class ContentsManager(LoggingConfigurable):
     def copy(self, from_name, to_name=None, path=''):
         """Copy an existing file and return its new model.
 
-        If to_name not specified, increment `from_name-Copy#.ipynb`.
+        If to_name not specified, increment `from_name-Copy#.ext`.
         """
         path = path.strip('/')
         model = self.get_model(from_name, path)

--- a/IPython/html/services/contents/manager.py
+++ b/IPython/html/services/contents/manager.py
@@ -75,27 +75,7 @@ class ContentsManager(LoggingConfigurable):
         """
         raise NotImplementedError('must be implemented in a subclass')
 
-    # TODO: Remove this after we create the contents web service and directories are
-    # no longer listed by the notebook web service.
-    def list_dirs(self, path):
-        """List the directory models for a given API style path."""
-        raise NotImplementedError('must be implemented in a subclass')
-
-    # TODO: Remove this after we create the contents web service and directories are
-    # no longer listed by the notebook web service.
-    def get_dir_model(self, name, path=''):
-        """Get the directory model given a directory name and its API style path.
-
-        The keys in the model should be:
-        * name
-        * path
-        * last_modified
-        * created
-        * type='directory'
-        """
-        raise NotImplementedError('must be implemented in a subclass')
-
-    def list_files(self, path=''):
+    def list(self, path=''):
         """Return a list of contents dicts without content.
 
         This returns a list of dicts
@@ -196,7 +176,7 @@ class ContentsManager(LoggingConfigurable):
         If to_name not specified, increment `from_name-Copy#.ipynb`.
         """
         path = path.strip('/')
-        model = self.get(from_name, path)
+        model = self.get_model(from_name, path)
         if not to_name:
             base, ext = os.path.splitext(from_name)
             copy_name = u'{0}-Copy{1}'.format(base, ext)
@@ -218,7 +198,7 @@ class ContentsManager(LoggingConfigurable):
         path : string
             The notebook's directory
         """
-        model = self.get(name, path)
+        model = self.get_model(name, path)
         nb = model['content']
         self.log.warn("Trusting notebook %s/%s", path, name)
         self.notary.mark_cells(nb, True)

--- a/IPython/html/services/contents/manager.py
+++ b/IPython/html/services/contents/manager.py
@@ -7,6 +7,8 @@ from fnmatch import fnmatch
 import itertools
 import os
 
+from tornado.web import HTTPError
+
 from IPython.config.configurable import LoggingConfigurable
 from IPython.nbformat import current, sign
 from IPython.utils.traitlets import Instance, Unicode, List
@@ -187,6 +189,8 @@ class ContentsManager(LoggingConfigurable):
         """
         path = path.strip('/')
         model = self.get_model(from_name, path)
+        if model['type'] == 'directory':
+            raise HTTPError(400, "Can't copy directories")
         if not to_name:
             base, ext = os.path.splitext(from_name)
             copy_name = u'{0}-Copy{1}'.format(base, ext)

--- a/IPython/html/services/contents/manager.py
+++ b/IPython/html/services/contents/manager.py
@@ -18,7 +18,10 @@ class ContentsManager(LoggingConfigurable):
     def _notary_default(self):
         return sign.NotebookNotary(parent=self)
 
-    hide_globs = List(Unicode, [u'__pycache__'], config=True, help="""
+    hide_globs = List(Unicode, [
+            u'__pycache__', '*.pyc', '*.pyo',
+            '.DS_Store', '*.so', '*.dylib', '*~',
+        ], config=True, help="""
         Glob patterns to hide in file and directory listings.
     """)
 
@@ -60,14 +63,14 @@ class ContentsManager(LoggingConfigurable):
         raise NotImplementedError
 
     def file_exists(self, name, path=''):
-        """Returns a True if the notebook exists. Else, returns False.
+        """Returns a True if the file exists. Else, returns False.
 
         Parameters
         ----------
         name : string
-            The name of the notebook you are checking.
+            The name of the file you are checking.
         path : string
-            The relative path to the notebook (with '/' as separator)
+            The relative path to the file's directory (with '/' as separator)
 
         Returns
         -------
@@ -87,38 +90,38 @@ class ContentsManager(LoggingConfigurable):
         raise NotImplementedError('must be implemented in a subclass')
 
     def get_model(self, name, path='', content=True):
-        """Get the notebook model with or without content."""
+        """Get the model of a file or directory with or without content."""
         raise NotImplementedError('must be implemented in a subclass')
 
     def save(self, model, name, path=''):
-        """Save the notebook and return the model with no content."""
+        """Save the file or directory and return the model with no content."""
         raise NotImplementedError('must be implemented in a subclass')
 
     def update(self, model, name, path=''):
-        """Update the notebook and return the model with no content."""
+        """Update the file or directory and return the model with no content."""
         raise NotImplementedError('must be implemented in a subclass')
 
     def delete(self, name, path=''):
-        """Delete notebook by name and path."""
+        """Delete file or directory by name and path."""
         raise NotImplementedError('must be implemented in a subclass')
 
     def create_checkpoint(self, name, path=''):
-        """Create a checkpoint of the current state of a notebook
+        """Create a checkpoint of the current state of a file
 
         Returns a checkpoint_id for the new checkpoint.
         """
         raise NotImplementedError("must be implemented in a subclass")
 
     def list_checkpoints(self, name, path=''):
-        """Return a list of checkpoints for a given notebook"""
+        """Return a list of checkpoints for a given file"""
         return []
 
     def restore_checkpoint(self, checkpoint_id, name, path=''):
-        """Restore a notebook from one of its checkpoints"""
+        """Restore a file from one of its checkpoints"""
         raise NotImplementedError("must be implemented in a subclass")
 
     def delete_checkpoint(self, checkpoint_id, name, path=''):
-        """delete a checkpoint for a notebook"""
+        """delete a checkpoint for a file"""
         raise NotImplementedError("must be implemented in a subclass")
 
     def info_string(self):
@@ -139,7 +142,7 @@ class ContentsManager(LoggingConfigurable):
         filename : unicode
             The name of a file, including extension
         path : unicode
-            The URL path of the notebooks directory
+            The URL path of the target's directory
 
         Returns
         -------
@@ -156,7 +159,7 @@ class ContentsManager(LoggingConfigurable):
         return name
 
     def create_file(self, model=None, path='', ext='.ipynb'):
-        """Create a new notebook and return its model with no content."""
+        """Create a new file or directory and return its model with no content."""
         path = path.strip('/')
         if model is None:
             model = {}

--- a/IPython/html/services/contents/nbmanager.py
+++ b/IPython/html/services/contents/nbmanager.py
@@ -32,11 +32,11 @@ from IPython.utils.traitlets import Instance, Unicode, List
 class NotebookManager(LoggingConfigurable):
 
     filename_ext = Unicode(u'.ipynb')
-    
+
     notary = Instance(sign.NotebookNotary)
     def _notary_default(self):
         return sign.NotebookNotary(parent=self)
-    
+
     hide_globs = List(Unicode, [u'__pycache__'], config=True, help="""
         Glob patterns to hide in file and directory listings.
     """)
@@ -46,14 +46,14 @@ class NotebookManager(LoggingConfigurable):
 
     def path_exists(self, path):
         """Does the API-style path (directory) actually exist?
-        
+
         Override this method in subclasses.
-        
+
         Parameters
         ----------
         path : string
             The path to check
-        
+
         Returns
         -------
         exists : bool
@@ -63,18 +63,18 @@ class NotebookManager(LoggingConfigurable):
 
     def is_hidden(self, path):
         """Does the API style path correspond to a hidden directory or file?
-        
+
         Parameters
         ----------
         path : string
             The path to check. This is an API path (`/` separated,
             relative to base notebook-dir).
-        
+
         Returns
         -------
         exists : bool
             Whether the path is hidden.
-        
+
         """
         raise NotImplementedError
 
@@ -104,7 +104,7 @@ class NotebookManager(LoggingConfigurable):
     # no longer listed by the notebook web service.
     def get_dir_model(self, name, path=''):
         """Get the directory model given a directory name and its API style path.
-        
+
         The keys in the model should be:
         * name
         * path
@@ -145,15 +145,15 @@ class NotebookManager(LoggingConfigurable):
 
     def create_checkpoint(self, name, path=''):
         """Create a checkpoint of the current state of a notebook
-        
+
         Returns a checkpoint_id for the new checkpoint.
         """
         raise NotImplementedError("must be implemented in a subclass")
-    
+
     def list_checkpoints(self, name, path=''):
         """Return a list of checkpoints for a given notebook"""
         return []
-    
+
     def restore_checkpoint(self, checkpoint_id, name, path=''):
         """Restore a notebook from one of its checkpoints"""
         raise NotImplementedError("must be implemented in a subclass")
@@ -161,7 +161,7 @@ class NotebookManager(LoggingConfigurable):
     def delete_checkpoint(self, checkpoint_id, name, path=''):
         """delete a checkpoint for a notebook"""
         raise NotImplementedError("must be implemented in a subclass")
-    
+
     def info_string(self):
         return "Serving notebooks"
 
@@ -174,7 +174,7 @@ class NotebookManager(LoggingConfigurable):
 
     def increment_filename(self, basename, path=''):
         """Increment a notebook filename without the .ipynb to make it unique.
-        
+
         Parameters
         ----------
         basename : unicode
@@ -206,14 +206,14 @@ class NotebookManager(LoggingConfigurable):
             model['content'] = current.new_notebook(metadata=metadata)
         if 'name' not in model:
             model['name'] = self.increment_filename('Untitled', path)
-            
+
         model['path'] = path
         model = self.save_notebook(model, model['name'], model['path'])
         return model
 
     def copy_notebook(self, from_name, to_name=None, path=''):
         """Copy an existing notebook and return its new model.
-        
+
         If to_name not specified, increment `from_name-Copy#.ipynb`.
         """
         path = path.strip('/')
@@ -224,13 +224,13 @@ class NotebookManager(LoggingConfigurable):
         model['name'] = to_name
         model = self.save_notebook(model, to_name, path)
         return model
-    
+
     def log_info(self):
         self.log.info(self.info_string())
 
     def trust_notebook(self, name, path=''):
         """Explicitly trust a notebook
-        
+
         Parameters
         ----------
         name : string
@@ -243,12 +243,12 @@ class NotebookManager(LoggingConfigurable):
         self.log.warn("Trusting notebook %s/%s", path, name)
         self.notary.mark_cells(nb, True)
         self.save_notebook(model, name, path)
-    
+
     def check_and_sign(self, nb, name, path=''):
         """Check for trusted cells, and sign the notebook.
-        
+
         Called as a part of saving notebooks.
-        
+
         Parameters
         ----------
         nb : dict
@@ -262,12 +262,12 @@ class NotebookManager(LoggingConfigurable):
             self.notary.sign(nb)
         else:
             self.log.warn("Saving untrusted notebook %s/%s", path, name)
-    
+
     def mark_trusted_cells(self, nb, name, path=''):
         """Mark cells as trusted if the notebook signature matches.
-        
+
         Called as a part of loading notebooks.
-        
+
         Parameters
         ----------
         nb : dict

--- a/IPython/html/services/contents/tests/test_contents_api.py
+++ b/IPython/html/services/contents/tests/test_contents_api.py
@@ -303,6 +303,10 @@ class APITest(NotebookTestBase):
         resp = self.api.mkdir(u'New ∂ir', path=u'å b')
         self._check_created(resp, u'New ∂ir', u'å b', type='directory')
 
+    def test_mkdir_hidden_400(self):
+        with assert_http_error(400):
+            resp = self.api.mkdir(u'.hidden', path=u'å b')
+
     def test_upload_txt(self):
         body = u'ünicode téxt'
         model = {

--- a/IPython/html/services/contents/tests/test_contents_api.py
+++ b/IPython/html/services/contents/tests/test_contents_api.py
@@ -22,8 +22,6 @@ from IPython.utils import py3compat
 from IPython.utils.data import uniq_stable
 
 
-# TODO: Remove this after we create the contents web service and directories are
-# no longer listed by the notebook web service.
 def notebooks_only(dir_model):
     return [nb for nb in dir_model['content'] if nb['type']=='notebook']
 
@@ -279,9 +277,9 @@ class APITest(NotebookTestBase):
 
     def test_create_untitled_txt(self):
         resp = self.api.create_untitled(path='foo/bar', ext='.txt')
-        self._check_created(resp, 'Untitled0.txt', 'foo/bar', type='file')
+        self._check_created(resp, 'untitled0.txt', 'foo/bar', type='file')
 
-        resp = self.api.read(path='foo/bar', name='Untitled0.txt')
+        resp = self.api.read(path='foo/bar', name='untitled0.txt')
         model = resp.json()
         self.assertEqual(model['type'], 'file')
         self.assertEqual(model['format'], 'text')
@@ -362,6 +360,10 @@ class APITest(NotebookTestBase):
     def test_copy(self):
         resp = self.api.copy(u'ç d.ipynb', u'cøpy.ipynb', path=u'å b')
         self._check_created(resp, u'cøpy.ipynb', u'å b')
+
+    def test_copy_path(self):
+        resp = self.api.copy(u'foo/a.ipynb', u'cøpyfoo.ipynb', path=u'å b')
+        self._check_created(resp, u'cøpyfoo.ipynb', u'å b')
 
     def test_copy_dir_400(self):
         # can't copy directories

--- a/IPython/html/services/contents/tests/test_manager.py
+++ b/IPython/html/services/contents/tests/test_manager.py
@@ -101,7 +101,7 @@ class TestContentsManager(TestCase):
 
     def new_notebook(self):
         cm = self.contents_manager
-        model = cm.create_notebook()
+        model = cm.create_file()
         name = model['name']
         path = model['path']
 
@@ -112,10 +112,10 @@ class TestContentsManager(TestCase):
         cm.save(full_model, name, path)
         return nb, name, path
 
-    def test_create_notebook(self):
+    def test_create_file(self):
         cm = self.contents_manager
         # Test in root directory
-        model = cm.create_notebook()
+        model = cm.create_file()
         assert isinstance(model, dict)
         self.assertIn('name', model)
         self.assertIn('path', model)
@@ -125,7 +125,7 @@ class TestContentsManager(TestCase):
         # Test in sub-directory
         sub_dir = '/foo/'
         self.make_dir(cm.root_dir, 'foo')
-        model = cm.create_notebook(None, sub_dir)
+        model = cm.create_file(None, sub_dir)
         assert isinstance(model, dict)
         self.assertIn('name', model)
         self.assertIn('path', model)
@@ -135,7 +135,7 @@ class TestContentsManager(TestCase):
     def test_get(self):
         cm = self.contents_manager
         # Create a notebook
-        model = cm.create_notebook()
+        model = cm.create_file()
         name = model['name']
         path = model['path']
 
@@ -150,7 +150,7 @@ class TestContentsManager(TestCase):
         # Test in sub-directory
         sub_dir = '/foo/'
         self.make_dir(cm.root_dir, 'foo')
-        model = cm.create_notebook(None, sub_dir)
+        model = cm.create_file(None, sub_dir)
         model2 = cm.get_model(name, sub_dir)
         assert isinstance(model2, dict)
         self.assertIn('name', model2)
@@ -162,7 +162,7 @@ class TestContentsManager(TestCase):
     def test_update(self):
         cm = self.contents_manager
         # Create a notebook
-        model = cm.create_notebook()
+        model = cm.create_file()
         name = model['name']
         path = model['path']
 
@@ -181,7 +181,7 @@ class TestContentsManager(TestCase):
         # Create a directory and notebook in that directory
         sub_dir = '/foo/'
         self.make_dir(cm.root_dir, 'foo')
-        model = cm.create_notebook(None, sub_dir)
+        model = cm.create_file(None, sub_dir)
         name = model['name']
         path = model['path']
 
@@ -200,7 +200,7 @@ class TestContentsManager(TestCase):
     def test_save(self):
         cm = self.contents_manager
         # Create a notebook
-        model = cm.create_notebook()
+        model = cm.create_file()
         name = model['name']
         path = model['path']
 
@@ -219,7 +219,7 @@ class TestContentsManager(TestCase):
         # Create a directory and notebook in that directory
         sub_dir = '/foo/'
         self.make_dir(cm.root_dir, 'foo')
-        model = cm.create_notebook(None, sub_dir)
+        model = cm.create_file(None, sub_dir)
         name = model['name']
         path = model['path']
         model = cm.get_model(name, path)
@@ -248,7 +248,7 @@ class TestContentsManager(TestCase):
         path = u'å b'
         name = u'nb √.ipynb'
         os.mkdir(os.path.join(cm.root_dir, path))
-        orig = cm.create_notebook({'name' : name}, path=path)
+        orig = cm.create_file({'name' : name}, path=path)
 
         # copy with unspecified name
         copy = cm.copy(name, path=path)

--- a/IPython/html/services/contents/tests/test_nbmanager.py
+++ b/IPython/html/services/contents/tests/test_nbmanager.py
@@ -55,7 +55,7 @@ class TestFileNotebookManager(TestCase):
             path = fm._get_os_path('test.ipynb', '////')
             fs_path = os.path.join(fm.notebook_dir, 'test.ipynb')
             self.assertEqual(path, fs_path)
-    
+
     def test_checkpoint_subdir(self):
         subd = u'sub ∂ir'
         cp_name = 'test-cp.ipynb'
@@ -68,10 +68,10 @@ class TestFileNotebookManager(TestCase):
         self.assertNotEqual(cp_dir, cp_subdir)
         self.assertEqual(cp_dir, os.path.join(nbdir, fm.checkpoint_dir, cp_name))
         self.assertEqual(cp_subdir, os.path.join(nbdir, subd, fm.checkpoint_dir, cp_name))
-    
+
 
 class TestNotebookManager(TestCase):
-    
+
     def setUp(self):
         self._temp_dir = TemporaryDirectory()
         self.td = self._temp_dir.name
@@ -79,10 +79,10 @@ class TestNotebookManager(TestCase):
             notebook_dir=self.td,
             log=logging.getLogger()
         )
-    
+
     def tearDown(self):
         self._temp_dir.cleanup()
-    
+
     def make_dir(self, abs_path, rel_path):
         """make subdirectory, rel_path is the relative path
         to that directory from the location where the server started"""
@@ -91,27 +91,27 @@ class TestNotebookManager(TestCase):
             os.makedirs(os_path)
         except OSError:
             print("Directory already exists: %r" % os_path)
-    
+
     def add_code_cell(self, nb):
         output = current.new_output("display_data", output_javascript="alert('hi');")
         cell = current.new_code_cell("print('hi')", outputs=[output])
         if not nb.worksheets:
             nb.worksheets.append(current.new_worksheet())
         nb.worksheets[0].cells.append(cell)
-    
+
     def new_notebook(self):
         nbm = self.notebook_manager
         model = nbm.create_notebook()
         name = model['name']
         path = model['path']
-        
+
         full_model = nbm.get_notebook(name, path)
         nb = full_model['content']
         self.add_code_cell(nb)
-        
+
         nbm.save_notebook(full_model, name, path)
         return nb, name, path
-    
+
     def test_create_notebook(self):
         nm = self.notebook_manager
         # Test in root directory
@@ -158,7 +158,7 @@ class TestNotebookManager(TestCase):
         self.assertIn('content', model2)
         self.assertEqual(model2['name'], 'Untitled0.ipynb')
         self.assertEqual(model2['path'], sub_dir.strip('/'))
-            
+
     def test_update_notebook(self):
         nm = self.notebook_manager
         # Create a notebook
@@ -184,7 +184,7 @@ class TestNotebookManager(TestCase):
         model = nm.create_notebook(None, sub_dir)
         name = model['name']
         path = model['path']
-        
+
         # Change the name in the model for rename
         model['name'] = 'test_in_sub.ipynb'
         model = nm.update_notebook(model, name, path)
@@ -193,7 +193,7 @@ class TestNotebookManager(TestCase):
         self.assertIn('path', model)
         self.assertEqual(model['name'], 'test_in_sub.ipynb')
         self.assertEqual(model['path'], sub_dir.strip('/'))
-        
+
         # Make sure the old name is gone
         self.assertRaises(HTTPError, nm.get_notebook, name, path)
 
@@ -255,50 +255,50 @@ class TestNotebookManager(TestCase):
         nm = self.notebook_manager
         # Create a notebook
         nb, name, path = self.new_notebook()
-        
+
         # Delete the notebook
         nm.delete_notebook(name, path)
-        
+
         # Check that a 'get' on the deleted notebook raises and error
         self.assertRaises(HTTPError, nm.get_notebook, name, path)
-    
+
     def test_copy_notebook(self):
         nm = self.notebook_manager
         path = u'å b'
         name = u'nb √.ipynb'
         os.mkdir(os.path.join(nm.notebook_dir, path))
         orig = nm.create_notebook({'name' : name}, path=path)
-        
+
         # copy with unspecified name
         copy = nm.copy_notebook(name, path=path)
         self.assertEqual(copy['name'], orig['name'].replace('.ipynb', '-Copy0.ipynb'))
-        
+
         # copy with specified name
         copy2 = nm.copy_notebook(name, u'copy 2.ipynb', path=path)
         self.assertEqual(copy2['name'], u'copy 2.ipynb')
-    
+
     def test_trust_notebook(self):
         nbm = self.notebook_manager
         nb, name, path = self.new_notebook()
-        
+
         untrusted = nbm.get_notebook(name, path)['content']
         assert not nbm.notary.check_cells(untrusted)
-        
+
         # print(untrusted)
         nbm.trust_notebook(name, path)
         trusted = nbm.get_notebook(name, path)['content']
         # print(trusted)
         assert nbm.notary.check_cells(trusted)
-    
+
     def test_mark_trusted_cells(self):
         nbm = self.notebook_manager
         nb, name, path = self.new_notebook()
-        
+
         nbm.mark_trusted_cells(nb, name, path)
         for cell in nb.worksheets[0].cells:
             if cell.cell_type == 'code':
                 assert not cell.trusted
-        
+
         nbm.trust_notebook(name, path)
         nb = nbm.get_notebook(name, path)['content']
         for cell in nb.worksheets[0].cells:
@@ -308,11 +308,11 @@ class TestNotebookManager(TestCase):
     def test_check_and_sign(self):
         nbm = self.notebook_manager
         nb, name, path = self.new_notebook()
-        
+
         nbm.mark_trusted_cells(nb, name, path)
         nbm.check_and_sign(nb, name, path)
         assert not nbm.notary.check_signature(nb)
-        
+
         nbm.trust_notebook(name, path)
         nb = nbm.get_notebook(name, path)['content']
         nbm.mark_trusted_cells(nb, name, path)

--- a/IPython/html/services/contents/tests/test_notebooks_api.py
+++ b/IPython/html/services/contents/tests/test_notebooks_api.py
@@ -163,7 +163,7 @@ class APITest(NotebookTestBase):
         expected = [ u'a.ipynb', u'b.ipynb', u'name with spaces.ipynb', u'unicodé.ipynb']
         expected = { normalize('NFC', name) for name in expected }
         self.assertEqual(nbnames, expected)
-        
+
         nbs = notebooks_only(self.nb_api.list('ordering').json())
         nbnames = [n['name'] for n in nbs]
         expected = ['A.ipynb', 'b.ipynb', 'C.ipynb']
@@ -344,4 +344,3 @@ class APITest(NotebookTestBase):
         self.assertEqual(r.status_code, 204)
         cps = self.nb_api.get_checkpoints('a.ipynb', 'foo').json()
         self.assertEqual(cps, [])
-

--- a/IPython/html/services/sessions/handlers.py
+++ b/IPython/html/services/sessions/handlers.py
@@ -1,20 +1,7 @@
-"""Tornado handlers for the sessions web service.
+"""Tornado handlers for the sessions web service."""
 
-Authors:
-
-* Zach Sailer
-"""
-
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2013  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 import json
 
@@ -23,10 +10,6 @@ from tornado import web
 from ...base.handlers import IPythonHandler, json_errors
 from IPython.utils.jsonutil import date_default
 from IPython.html.utils import url_path_join, url_escape
-
-#-----------------------------------------------------------------------------
-# Session web service handlers
-#-----------------------------------------------------------------------------
 
 
 class SessionRootHandler(IPythonHandler):
@@ -45,6 +28,8 @@ class SessionRootHandler(IPythonHandler):
         # Creates a new session
         #(unless a session already exists for the named nb)
         sm = self.session_manager
+        cm = self.contents_manager
+        km = self.kernel_manager
 
         model = self.get_json_body()
         if model is None:

--- a/IPython/html/services/sessions/sessionmanager.py
+++ b/IPython/html/services/sessions/sessionmanager.py
@@ -32,7 +32,7 @@ from IPython.utils.traitlets import Instance
 class SessionManager(LoggingConfigurable):
 
     kernel_manager = Instance('IPython.html.services.kernels.kernelmanager.MappingKernelManager')
-    notebook_manager = Instance('IPython.html.services.notebooks.nbmanager.NotebookManager', args=())
+    contents_manager = Instance('IPython.html.services.contents.manager.ContentsManager', args=())
     
     # Session database initialized below
     _cursor = None
@@ -77,7 +77,7 @@ class SessionManager(LoggingConfigurable):
         """Creates a session and returns its model"""
         session_id = self.new_session_id()
         # allow nbm to specify kernels cwd
-        kernel_path = self.notebook_manager.get_kernel_path(name=name, path=path)
+        kernel_path = self.contents_manager.get_kernel_path(name=name, path=path)
         kernel_id = self.kernel_manager.start_kernel(path=kernel_path,
                                                      kernel_name=kernel_name)
         return self.save_session(session_id, name=name, path=path,

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1908,7 +1908,7 @@ define([
         this.events.trigger('notebook_saving.Notebook');
         var url = utils.url_join_encode(
             this.base_url,
-            'api/notebooks',
+            'api/contents',
             this.notebook_path,
             this.notebook_name
         );
@@ -2041,7 +2041,7 @@ define([
         };
         var url = utils.url_join_encode(
             base_url,
-            'api/notebooks',
+            'api/contents',
             path
         );
         $.ajax(url,settings);
@@ -2070,7 +2070,7 @@ define([
         };
         var url = utils.url_join_encode(
             base_url,
-            'api/notebooks',
+            'api/contents',
             path
         );
         $.ajax(url,settings);
@@ -2095,7 +2095,7 @@ define([
         this.events.trigger('rename_notebook.Notebook', data);
         var url = utils.url_join_encode(
             this.base_url,
-            'api/notebooks',
+            'api/contents',
             this.notebook_path,
             this.notebook_name
         );
@@ -2113,7 +2113,7 @@ define([
         };
         var url = utils.url_join_encode(
             this.base_url,
-            'api/notebooks',
+            'api/contents',
             this.notebook_path,
             this.notebook_name
         );
@@ -2182,7 +2182,7 @@ define([
         this.events.trigger('notebook_loading.Notebook');
         var url = utils.url_join_encode(
             this.base_url,
-            'api/notebooks',
+            'api/contents',
             this.notebook_path,
             this.notebook_name
         );
@@ -2345,7 +2345,7 @@ define([
     Notebook.prototype.list_checkpoints = function () {
         var url = utils.url_join_encode(
             this.base_url,
-            'api/notebooks',
+            'api/contents',
             this.notebook_path,
             this.notebook_name,
             'checkpoints'
@@ -2396,7 +2396,7 @@ define([
     Notebook.prototype.create_checkpoint = function () {
         var url = utils.url_join_encode(
             this.base_url,
-            'api/notebooks',
+            'api/contents',
             this.notebook_path,
             this.notebook_name,
             'checkpoints'
@@ -2485,7 +2485,7 @@ define([
         this.events.trigger('notebook_restoring.Notebook', checkpoint);
         var url = utils.url_join_encode(
             this.base_url,
-            'api/notebooks',
+            'api/contents',
             this.notebook_path,
             this.notebook_name,
             'checkpoints',
@@ -2533,7 +2533,7 @@ define([
         this.events.trigger('notebook_restoring.Notebook', checkpoint);
         var url = utils.url_join_encode(
             this.base_url,
-            'api/notebooks',
+            'api/contents',
             this.notebook_path,
             this.notebook_name,
             'checkpoints',

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1885,6 +1885,8 @@ define([
         var model = {};
         model.name = this.notebook_name;
         model.path = this.notebook_path;
+        model.type = 'notebook';
+        model.format = 'json';
         model.content = this.toJSON();
         model.content.nbformat = this.nbformat;
         model.content.nbformat_minor = this.nbformat_minor;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -7955,6 +7955,22 @@ input.engine_num_input {
 .notebook_icon:before.pull-right {
   margin-left: .3em;
 }
+.file_icon:before {
+  display: inline-block;
+  font-family: FontAwesome;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  content: "\f016";
+}
+.file_icon:before.pull-left {
+  margin-right: .3em;
+}
+.file_icon:before.pull-right {
+  margin-left: .3em;
+}
 /*!
 *
 * IPython notebook

--- a/IPython/html/static/tree/js/kernellist.js
+++ b/IPython/html/static/tree/js/kernellist.js
@@ -19,7 +19,7 @@ define([
         //          base_url: string
         //          notebook_path: string
         notebooklist.NotebookList.call(this, selector, $.extend({
-            element_name: 'running'}, 
+            element_name: 'running'},
             options));
     };
 
@@ -28,13 +28,20 @@ define([
     KernelList.prototype.sessions_loaded = function (d) {
         this.sessions = d;
         this.clear_list();
-        var item;
-        for (var path in d) {
-            item = this.new_notebook_item(-1);
-            this.add_link('', path, item);
-            this.add_shutdown_button(item, this.sessions[path]);
+        var item, path_name;
+        for (path_name in d) {
+            if (!d.hasOwnProperty(path_name)) {
+                // nothing is safe in javascript
+                continue;
+            }
+            item = this.new_item(-1);
+            this.add_link({
+                name: path_name,
+                path: '',
+                type: 'notebook',
+            }, item);
+            this.add_shutdown_button(item, this.sessions[path_name]);
         }
-       
         $('#running_list_header').toggle($.isEmptyObject(d));
     };
     

--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -148,7 +148,7 @@ define([
         var url = utils.url_join_encode(
                 this.base_url,
                 'api',
-                'notebooks',
+                'contents',
                 this.notebook_path
         );
         $.ajax(url, settings);
@@ -328,7 +328,7 @@ define([
                                 };
                                 var url = utils.url_join_encode(
                                     notebooklist.base_url,
-                                    'api/notebooks',
+                                    'api/contents',
                                     notebooklist.notebook_path,
                                     nbname
                                 );
@@ -375,7 +375,7 @@ define([
 
                 var url = utils.url_join_encode(
                     that.base_url,
-                    'api/notebooks',
+                    'api/contents',
                     that.notebook_path,
                     nbname
                 );
@@ -419,7 +419,7 @@ define([
         };
         var url = utils.url_join_encode(
             base_url,
-            'api/notebooks',
+            'api/contents',
             path
         );
         $.ajax(url, settings);

--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -80,7 +80,7 @@ define([
             var name_and_ext = utils.splitext(f.name);
             var file_ext = name_and_ext[1];
             if (file_ext === '.ipynb') {
-                var item = that.new_notebook_item(0);
+                var item = that.new_item(0);
                 item.addClass('new-file');
                 that.add_name_input(f.name, item);
                 // Store the notebook item in the reader so we can use it later
@@ -236,7 +236,7 @@ define([
         var icon = NotebookList.icons[model.type];
         var uri_prefix = NotebookList.uri_prefixes[model.type];
         item.find(".item_icon").addClass(icon).addClass('icon-fixed-width');
-        item.find("a.item_link")
+        var link = item.find("a.item_link")
             .attr('href',
                 utils.url_join_encode(
                     this.base_url,
@@ -245,6 +245,11 @@ define([
                     name
                 )
             );
+        // directory nav doesn't open new tabs
+        // files, notebooks do
+        if (model.type !== "directory") {
+            link.attr('target','_blank');
+        }
         var path_name = utils.url_path_join(path, name);
         if (model.type == 'file') {
             this.add_delete_button(item);
@@ -362,7 +367,10 @@ define([
                 var nbdata = item.data('nbdata');
                 var content_type = 'application/json';
                 var model = {
+                    path: path,
+                    name: nbname,
                     content : JSON.parse(nbdata),
+                    type : 'notebook'
                 };
                 var settings = {
                     processData : false,
@@ -372,7 +380,7 @@ define([
                     data : JSON.stringify(model),
                     headers : {'Content-Type': content_type},
                     success : function (data, status, xhr) {
-                        that.add_link(path, nbname, item);
+                        that.add_link(model, item);
                         that.add_delete_button(item);
                     },
                     error : utils.log_ajax_error,

--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -161,7 +161,8 @@ define([
             message = param.msg;
         }
         var item = null;
-        var len = data.length;
+        var content = data.content;
+        var len = content.length;
         this.clear_list();
         if (len === 0) {
             item = this.new_notebook_item(0);
@@ -177,12 +178,12 @@ define([
             offset = 1;
         }
         for (var i=0; i<len; i++) {
-            if (data[i].type === 'directory') {
-                var name = data[i].name;
+            if (content[i].type === 'directory') {
+                var name = content[i].name;
                 item = this.new_notebook_item(i+offset);
                 this.add_dir(path, name, item);
             } else {
-                var name = data[i].name;
+                var name = content[i].name;
                 item = this.new_notebook_item(i+offset);
                 this.add_link(path, name, item);
                 name = utils.url_path_join(path, name);

--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -382,7 +382,20 @@ define([
                 if (file_ext === '.ipynb') {
                     model.type = 'notebook';
                     model.format = 'json';
-                    model.content = JSON.parse(filedata);
+                    try {
+                        model.content = JSON.parse(filedata);
+                    } catch (e) {
+                        dialog.modal({
+                            title : 'Cannot upload invalid Notebook',
+                            body : "The error was: " + e,
+                            buttons : {'OK' : {
+                                'class' : 'btn-primary',
+                                click: function () {
+                                    item.remove();
+                                }
+                            }}
+                        });
+                    }
                     content_type = 'application/json';
                 } else {
                     model.type = 'file';

--- a/IPython/html/static/tree/less/tree.less
+++ b/IPython/html/static/tree/less/tree.less
@@ -147,3 +147,7 @@ input.engine_num_input {
 .notebook_icon:before {
     .icon(@fa-var-book)
 }
+
+.file_icon:before {
+    .icon(@fa-var-file-o)
+}

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -10,7 +10,6 @@
 
 {% block params %}
 
-data-project="{{project}}"
 data-base-url="{{base_url}}"
 data-notebook-path="{{notebook_path}}"
 

--- a/IPython/html/tests/launchnotebook.py
+++ b/IPython/html/tests/launchnotebook.py
@@ -33,7 +33,7 @@ class NotebookTestBase(TestCase):
     @classmethod
     def wait_until_alive(cls):
         """Wait for the server to be alive"""
-        url = 'http://localhost:%i/api/notebooks' % cls.port
+        url = 'http://localhost:%i/api/contents' % cls.port
         for _ in range(int(MAX_WAITTIME/POLL_INTERVAL)):
             try:
                 requests.get(url)

--- a/IPython/html/tree/handlers.py
+++ b/IPython/html/tree/handlers.py
@@ -1,27 +1,11 @@
-"""Tornado handlers for the tree view.
+"""Tornado handlers for the tree view."""
 
-Authors:
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
-* Brian Granger
-"""
-
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2011  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
 from tornado import web
 from ..base.handlers import IPythonHandler, notebook_path_regex, path_regex
 from ..utils import url_path_join, url_escape
-
-#-----------------------------------------------------------------------------
-# Handlers
-#-----------------------------------------------------------------------------
 
 
 class TreeHandler(IPythonHandler):

--- a/IPython/html/tree/handlers.py
+++ b/IPython/html/tree/handlers.py
@@ -53,7 +53,6 @@ class TreeHandler(IPythonHandler):
             breadcrumbs = self.generate_breadcrumbs(path)
             page_title = self.generate_page_title(path)
             self.write(self.render_template('tree.html',
-                project=self.project_dir,
                 page_title=page_title,
                 notebook_path=path,
                 breadcrumbs=breadcrumbs

--- a/IPython/html/tree/handlers.py
+++ b/IPython/html/tree/handlers.py
@@ -51,7 +51,7 @@ class TreeHandler(IPythonHandler):
     @web.authenticated
     def get(self, path='', name=None):
         path = path.strip('/')
-        nbm = self.notebook_manager
+        cm = self.contents_manager
         if name is not None:
             # is a notebook, redirect to notebook handler
             url = url_escape(url_path_join(
@@ -60,10 +60,10 @@ class TreeHandler(IPythonHandler):
             self.log.debug("Redirecting %s to %s", self.request.path, url)
             self.redirect(url)
         else:
-            if not nbm.path_exists(path=path):
+            if not cm.path_exists(path=path):
                 # Directory is hidden or does not exist.
                 raise web.HTTPError(404)
-            elif nbm.is_hidden(path):
+            elif cm.is_hidden(path):
                 self.log.info("Refusing to serve hidden directory, via 404 Error")
                 raise web.HTTPError(404)
             breadcrumbs = self.generate_breadcrumbs(path)

--- a/IPython/html/utils.py
+++ b/IPython/html/utils.py
@@ -113,6 +113,9 @@ def is_hidden(abs_path, abs_root=''):
     # check UF_HIDDEN on any location up to root
     path = abs_path
     while path and path.startswith(abs_root) and path != abs_root:
+        if not os.path.exists(path):
+            path = os.path.dirname(path)
+            continue
         try:
             # may fail on Windows junctions
             st = os.stat(path)

--- a/docs/source/whatsnew/pr/incompat-contents-service.rst
+++ b/docs/source/whatsnew/pr/incompat-contents-service.rst
@@ -3,4 +3,4 @@
   which supports all kinds of files.
 - The Dashboard now lists all files, not just notebooks and directories.
 - The ``--script`` hook for saving notebooks to Python scripts is removed,
-  use ``ipython nbconvert --to python [notebook]`` instead.
+  use :samp:`ipython nbconvert --to python {notebook}` instead.

--- a/docs/source/whatsnew/pr/incompat-contents-service.rst
+++ b/docs/source/whatsnew/pr/incompat-contents-service.rst
@@ -1,0 +1,6 @@
+- The NotebookManager and ``/api/notebooks`` service has been replaced by
+  a more generic ContentsManager and ``/api/contents`` service,
+  which supports all kinds of files.
+- The Dashboard now lists all files, not just notebooks and directories.
+- The ``--script`` hook for saving notebooks to Python scripts is removed,
+  use ``ipython nbconvert --to python [notebook]`` instead.


### PR DESCRIPTION
This mainly renames the 'notebooks' service to 'contents' and teaches it about regular files. There is no longer special treatment of directories, just different forms for `content`. Tree view now shows all files.

As usual, modeled on GitHub [contents API](https://developer.github.com/v3/repos/contents/).

I will enumerate the changes to the models and API, but the gist:
- all contents models have name, path, dates, type
- type is one of: directory, file, notebook
- if content is requested:
  - additional `format` key will be `json`, `text`, or `base64`, describing `content`
  - `content` will be
    - list of JSON models for directory contents
    - notebook JSON for notebooks (format=json)
    - file text for text files (format=text)
    - b64-encoded data for binary files (format=base64)
