### PR TITLE
Resolve VIRTUAL_ENV if it is a symlink

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -734,7 +734,11 @@ class InteractiveShell(SingletonConfigurable):
         while os.path.islink(p):
             p = os.path.join(os.path.dirname(p), os.readlink(p))
             paths.append(p)
-        if any(p.startswith(os.environ['VIRTUAL_ENV']) for p in paths):
+        # Resolve VIRTUAL_ENV.
+        virtualenv = os.environ['VIRTUAL_ENV']
+        if os.path.islink(virtualenv):
+            virtualenv = os.readlink(virtualenv)
+        if any(p.startswith(virtualenv) for p in paths):
             # Running properly in the virtualenv, don't need to do anything
             return
         


### PR DESCRIPTION
All paths checked against VIRTUAL_ENV are being resolved, therefore
VIRTUAL_ENV should be resolved, too.

It does not solve my initial problem, where I had two symlinks though:
~/.virtualenvs/project => /srv/project/virtualenv
and /srv/project => /home/www-data/project

The real virtualenv is /home/www-data/project/virtualenv, but os.path.readlink only resolves the first level.
