### PR TITLE
Markdown rendering bug fix.

### DIFF
--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -256,7 +256,7 @@ var IPython = (function (IPython) {
             var html = marked.parser(marked.lexer(text));
             html = IPython.mathjaxutils.replace_math(html, math);
             html = security.sanitize_html(html);
-            html = $(html);
+            html = $($.parseHTML(html));
             // links in markdown cells should open in new tabs
             html.find("a[href]").not('[href^="#"]').attr("target", "_blank");
             this.set_rendered(html);
@@ -428,7 +428,7 @@ var IPython = (function (IPython) {
             var html = marked.parser(marked.lexer(text));
             html = IPython.mathjaxutils.replace_math(html, math);
             html = security.sanitize_html(html);
-            var h = $(html);
+            var h = $($.parseHTML(html));
             // add id and linkback anchor
             var hash = h.text().replace(/ /g, '-');
             h.attr('id', hash);

--- a/IPython/html/tests/notebook/markdown.js
+++ b/IPython/html/tests/notebook/markdown.js
@@ -10,7 +10,7 @@ casper.notebook_test(function () {
         cell.render();
         return cell.get_rendered();
     });
-    this.test.assertEquals(output, '<h1 id=\"foo\">Foo</h1>', 'Markdown JS API works.');
+    this.test.assertEquals(output.trim(), '<h1 id=\"foo\">Foo</h1>', 'Markdown JS API works.');
     
     // Test menubar entries.
     output = this.evaluate(function () {
@@ -21,7 +21,7 @@ casper.notebook_test(function () {
         $('#run_cell').mouseenter().click();
         return cell.get_rendered();
     });
-    this.test.assertEquals(output, '<h1 id=\"foo\">Foo</h1>', 'Markdown menubar items work.');
+    this.test.assertEquals(output.trim(), '<h1 id=\"foo\">Foo</h1>', 'Markdown menubar items work.');
     
     // Test toolbar buttons.
     output = this.evaluate(function () {
@@ -32,5 +32,5 @@ casper.notebook_test(function () {
         $('#run_b').click();
         return cell.get_rendered();
     });
-    this.test.assertEquals(output, '<h1 id=\"foo\">Foo</h1>', 'Markdown toolbar items work.');
+    this.test.assertEquals(output.trim(), '<h1 id=\"foo\">Foo</h1>', 'Markdown toolbar items work.');
 });


### PR DESCRIPTION
The wrong signature of `$()` was being used
wrong: http://api.jquery.com/jQuery/#jQuery1
right: http://api.jquery.com/jQuery/#jQuery2

Instead of implictly calling parseHTML, call it explicitly.
closes #5943
