### PR TITLE
Proposal for a hook system

### DIFF
--- a/IPython/html/static/base/js/hooks.js
+++ b/IPython/html/static/base/js/hooks.js
@@ -1,0 +1,85 @@
+//----------------------------------------------------------------------------
+//  Copyright (C) 2014  The IPython Development Team
+//
+//  Distributed under the terms of the BSD License.  The full license is in
+//  the file COPYING, distributed as part of this software.
+//----------------------------------------------------------------------------
+
+//============================================================================
+// Hook
+//============================================================================
+
+/**
+ * A Hook is a sequence of callbacks. They are called in order based on their
+ * nice values (lower nice values are executed first).
+ *
+ * @module IPython
+ * @namespace IPython
+ */
+
+var IPython = (function(IPython) {
+    "use strict";
+
+    /**
+     * @class Hook
+     * @constructor
+     */
+    var Hook = function() {
+        this.items = [];
+    };
+
+
+    /**
+     * Add a callback to the hook.
+     *
+     * @method add_callback
+     * @param {function} callback - The callback to be added to the hook.
+     * @param {number} [nice=0] - Optional number representing the callback priority.
+     *        The lower the number, the higher the priority is.
+     * @return {function} - The added callback.
+     */
+    Hook.prototype.add_callback = function(callback, nice) {
+        nice = nice == null ? 0 : nice;
+        var item = {callback: callback, nice: nice};
+        var i = this.items.length;
+        while (i > 0 && nice < this.items[i - 1].nice) i--;
+        this.items.splice(i, 0, item);
+        return callback;
+    };
+
+
+    /**
+     * Remove a callback from the hook.
+     *
+     * @method remove_callback
+     * @param {function} callback - The callback to be removed.
+     */
+    Hook.prototype.remove_callback = function(callback) {
+        var l = this.items.length;
+        for (var i = 0; i < l; i++) {
+            if (this.items[i].callback === callback) {
+                this.items.splice(i, 1);
+                return;
+            }
+        }
+    };
+
+
+     /**
+     * Execute the hook callbacks.
+     *
+     * @method execute
+     * @param {Array} args - An array of data. Its elements will be passed as arguments to the callbacks.
+     */
+    Hook.prototype.execute = function(args) {
+        var l = this.items.length;
+        for (var i = 0;  i < l; i++)
+            this.items[i].callback.apply(window, args);
+    }
+
+    IPython.Hook = Hook;
+
+    return IPython;
+
+}(IPython));
+

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -322,6 +322,7 @@ class="notebook_app"
 <script src="{{ static_url("dateformat/date.format.js") }}" charset="utf-8"></script>
 
 <script src="{{ static_url("base/js/events.js") }}" type="text/javascript" charset="utf-8"></script>
+<script src="{{ static_url("base/js/hooks.js") }}" type="text/javascript" charset="utf-8"></script>
 <script src="{{ static_url("base/js/utils.js") }}" type="text/javascript" charset="utf-8"></script>
 <script src="{{ static_url("base/js/keyboard.js") }}" type="text/javascript" charset="utf-8"></script>
 <script src="{{ static_url("base/js/security.js") }}" type="text/javascript" charset="utf-8"></script>


### PR DESCRIPTION
1. Added a new class `Hook` to the `IPython` javascript namespace.
   Hooks can be used by extensions to customize the html notebook behaviour.
   They are essentially sequences of callbacks. To each callback is associated a number, the nice value. When the hook is executed, its callbacks are called in order based on their nice values, lower values are executed first.
   
   Choosing appropriate nice values, extension authors can insert their callbacks at the planned positions in the execution queue.
   
   `Hook` object has three methods:
   -   `add_callback` is used to add a callback to the hook.
   -   `remove_callback` is used to remove a callback from the hook.
   -   `execute` is used to execute the hook callbacks. It accepts an array of data as parameter, its elements will be passed to the callbacks when called.
2. Added `preprocess` and `postprocess` hooks to markdown and heading cells.
   The former can be used to modify the text that will be passed to the markdown renderer, the ladder to customize the rendering result before it is set into the output area.
   
   Turned parts of the cell rendering logic into `preprocess` and `postprocess` callbacks.
