### PR TITLE
IPython slides: fragments are now in a linear flow and include next "-" cells.

### DIFF
--- a/IPython/nbconvert/postprocessors/serve.py
+++ b/IPython/nbconvert/postprocessors/serve.py
@@ -53,7 +53,7 @@ class ServePostProcessor(PostProcessorBase):
     open_in_browser = Bool(True, config=True,
         help="""Should the browser be opened automatically?"""
     )
-    reveal_cdn = Unicode("https://cdn.jsdelivr.net/reveal.js/2.5.0", config=True,
+    reveal_cdn = Unicode("https://cdn.jsdelivr.net/reveal.js/2.6.2", config=True,
         help="""URL for reveal.js CDN."""
     )
     reveal_prefix = Unicode("reveal.js", config=True, help="URL prefix for reveal.js")

--- a/IPython/nbconvert/preprocessors/revealhelp.py
+++ b/IPython/nbconvert/preprocessors/revealhelp.py
@@ -65,8 +65,8 @@ class RevealHelpPreprocessor(Preprocessor):
                         worksheet.cells[index + i].metadata.frag_number = index
                         i += 1
                 #Restart the slide_helper when the cell status is changed
-                #to "do nothing".
-                if cell.metadata.slide_type in ['-']:
+                #to other types.
+                if cell.metadata.slide_type in ['-', 'skip', 'notes', 'fragment']:
                     worksheet.cells[index - 1].metadata.slide_helper = '-'
 
         if not isinstance(resources['reveal'], dict):

--- a/IPython/nbconvert/preprocessors/revealhelp.py
+++ b/IPython/nbconvert/preprocessors/revealhelp.py
@@ -55,7 +55,14 @@ class RevealHelpPreprocessor(Preprocessor):
                     worksheet.cells[index - 1].metadata.slide_helper = 'slide_end'
                 if cell.metadata.slide_type in ['subslide']:
                     worksheet.cells[index - 1].metadata.slide_helper = 'subslide_end'
-
+                if cell.metadata.slide_type in ['fragment']:
+                    try:
+                        i = 1
+                        while 1:
+                            worksheet.cells[index + i].metadata.frag_helper = 'fragment_end'
+                            i += 1
+                    except IndexError as e:
+                        pass #Last cell doesn't have a next one
 
         if not isinstance(resources['reveal'], dict):
             resources['reveal'] = {}

--- a/IPython/nbconvert/preprocessors/revealhelp.py
+++ b/IPython/nbconvert/preprocessors/revealhelp.py
@@ -49,20 +49,22 @@ class RevealHelpPreprocessor(Preprocessor):
                 #Make sure the cell has slideshow metadata.
                 cell.metadata.slide_type = cell.get('metadata', {}).get('slideshow', {}).get('slide_type', '-')
 
-                #Get the slide type.  If type is start of subslide or slide,
+                #Get the slide type. If type is start of subslide or slide,
                 #end the last subslide/slide.
                 if cell.metadata.slide_type in ['slide']:
                     worksheet.cells[index - 1].metadata.slide_helper = 'slide_end'
                 if cell.metadata.slide_type in ['subslide']:
                     worksheet.cells[index - 1].metadata.slide_helper = 'subslide_end'
+                #Prevent the rendering of "do nothing" cells before fragments
                 if cell.metadata.slide_type in ['fragment']:
-                    try:
-                        i = 1
-                        while 1:
-                            worksheet.cells[index + i].metadata.frag_helper = 'fragment_end'
-                            i += 1
-                    except IndexError as e:
-                        pass #Last cell doesn't have a next one
+                    i = 1
+                    while i < len(worksheet.cells) - index:
+                        worksheet.cells[index + i].metadata.frag_helper = 'fragment_end'
+                        i += 1
+                #Restart the slide_helper when the cell status is changed
+                #to "do nothing".
+                if cell.metadata.slide_type in ['-']:
+                    worksheet.cells[index - 1].metadata.slide_helper = '-'
 
         if not isinstance(resources['reveal'], dict):
             resources['reveal'] = {}

--- a/IPython/nbconvert/preprocessors/revealhelp.py
+++ b/IPython/nbconvert/preprocessors/revealhelp.py
@@ -56,10 +56,13 @@ class RevealHelpPreprocessor(Preprocessor):
                 if cell.metadata.slide_type in ['subslide']:
                     worksheet.cells[index - 1].metadata.slide_helper = 'subslide_end'
                 #Prevent the rendering of "do nothing" cells before fragments
+                #Group fragments passing frag_number to the data-fragment-index
                 if cell.metadata.slide_type in ['fragment']:
+                    worksheet.cells[index].metadata.frag_number = index
                     i = 1
                     while i < len(worksheet.cells) - index:
                         worksheet.cells[index + i].metadata.frag_helper = 'fragment_end'
+                        worksheet.cells[index + i].metadata.frag_number = index
                         i += 1
                 #Restart the slide_helper when the cell status is changed
                 #to "do nothing".

--- a/IPython/nbconvert/preprocessors/tests/test_revealhelp.py
+++ b/IPython/nbconvert/preprocessors/tests/test_revealhelp.py
@@ -28,11 +28,11 @@ class Testrevealhelp(PreprocessorTestsBase):
     """Contains test functions for revealhelp.py"""
 
     def build_notebook(self):
-        """Build a reveal slides notebook in memory for use with tests.  
+        """Build a reveal slides notebook in memory for use with tests.
         Overrides base in PreprocessorTestsBase"""
 
         outputs = [nbformat.new_output(output_type="stream", stream="stdout", output_text="a")]
-        
+
         slide_metadata = {'slideshow' : {'slide_type': 'slide'}}
         subslide_metadata = {'slideshow' : {'slide_type': 'subslide'}}
 
@@ -56,7 +56,7 @@ class Testrevealhelp(PreprocessorTestsBase):
     def test_constructor(self):
         """Can a RevealHelpPreprocessor be constructed?"""
         self.build_preprocessor()
-    
+
 
     def test_reveal_attribute(self):
         """Make sure the reveal url_prefix resources is set"""
@@ -82,7 +82,8 @@ class Testrevealhelp(PreprocessorTestsBase):
 
         # Make sure slide end is only applied to the cells preceeding slide 
         # cells.
-        assert 'slide_helper' not in cells[1].metadata
+        assert 'slide_helper' in cells[1].metadata
+        self.assertEqual(cells[1].metadata['slide_helper'], '-')
 
         # Verify 'slide-end'
         assert 'slide_helper' in cells[0].metadata

--- a/IPython/nbconvert/templates/html/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/html/slides_reveal.tpl
@@ -10,7 +10,13 @@
     <section>
     {{ super() }}
 {%- elif cell.metadata.slide_type in ['-'] -%}
-    {{ super() }}
+    {%- if cell.metadata.frag_helper in ['fragment_end'] -%}
+        <div class="fragment">
+        {{ super() }}
+        </div>
+    {%- else -%}
+        {{ super() }}
+    {%- endif -%}
 {%- elif cell.metadata.slide_type in ['skip'] -%}
     <div style=display:none>
     {{ super() }}

--- a/IPython/nbconvert/templates/html/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/html/slides_reveal.tpl
@@ -11,7 +11,7 @@
     {{ super() }}
 {%- elif cell.metadata.slide_type in ['-'] -%}
     {%- if cell.metadata.frag_helper in ['fragment_end'] -%}
-        <div class="fragment">
+        <div class="fragment" data-fragment-index="{{ cell.metadata.frag_number }}">
         {{ super() }}
         </div>
     {%- else -%}
@@ -26,7 +26,7 @@
     {{ super() }}
     </aside>
 {%- elif cell.metadata.slide_type in ['fragment'] -%}
-    <div class="fragment">
+    <div class="fragment" data-fragment-index="{{ cell.metadata.frag_number }}">
     {{ super() }}
     </div>
 {%- endif -%}


### PR DESCRIPTION
This PR solves, in general, the issue raise in #4356, but in a more simple way... using the new data-fragment-index attribute from Reveal and some little logic to mark the next cells as fragments continuations.
In particular, this PR address:
- update reveal.js CDN
- fragments are now more than a cell-level property, because now you can include more than one cell in a fragment.
- "-" (do nothing) cells are now included with the previous fragment (in the case there is one).

This is what I pretend to do when I discussed this issue with @pelson (but data-fragment-index attribute was buggy at that time). He had/has valid points in the discussion, and... I still think the previous design was not a bug, instead a choice, but I also recognize what the majority of the people is asking for, so here you have it :wink: but in a more compatible way with the current code design/structure :stuck_out_tongue_winking_eye: 

Pinging @Carreau, @dhirschfeld and @astrofrog, because they were pinged in the last discussion and probably they are interested...

OK, that's all for now... cheers.
