### PR TITLE
Allow tests to run without jsonschema

### DIFF
--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -371,7 +371,8 @@ tclass.py: deleting object: C-third
         
         with tt.AssertNotPrints('SystemExit'):
             _ip.magic('run -e %s' % self.fname)
-    
+
+    @dec.skip_without('IPython.nbformat.current')  # Requires jsonschema
     def test_run_nb(self):
         """Test %run notebook.ipynb"""
         from IPython.nbformat import current

--- a/IPython/nbconvert/filters/ansi.py
+++ b/IPython/nbconvert/filters/ansi.py
@@ -14,6 +14,7 @@
 
 import re
 from IPython.utils import coloransi
+from IPython.utils.text import strip_ansi
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -25,19 +26,6 @@ __all__ = [
     'single_ansi2latex',
     'ansi2latex'
 ]
-
-def strip_ansi(source):
-    """
-    Remove ansi from text
-    
-    Parameters
-    ----------
-    source : str
-        Source to remove the ansi from
-    """
-    
-    return re.sub(r'\033\[(\d|;)+?m', '', source)
-
 
 ansi_colormap = {
     '30': 'ansiblack',

--- a/IPython/terminal/tests/test_help.py
+++ b/IPython/terminal/tests/test_help.py
@@ -12,6 +12,7 @@
 #-----------------------------------------------------------------------------
 
 import IPython.testing.tools as tt
+from IPython.testing.decorators import skip_without
 
 #-----------------------------------------------------------------------------
 # Tests
@@ -36,5 +37,6 @@ def test_locate_help():
 def test_locate_profile_help():
     tt.help_all_output_test("locate profile")
 
+@skip_without('IPython.nbformat.current')  # Requires jsonschema to be installed
 def test_trust_help():
     tt.help_all_output_test("trust")

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -147,6 +147,7 @@ have['tornado'] = test_for('tornado.version_info', (3,1,0), callback=None)
 have['jinja2'] = test_for('jinja2')
 have['requests'] = test_for('requests')
 have['sphinx'] = test_for('sphinx')
+have['jsonschema'] = test_for('jsonschema')
 have['casperjs'] = is_cmd_found('casperjs')
 have['phantomjs'] = is_cmd_found('phantomjs')
 have['slimerjs'] = is_cmd_found('slimerjs')
@@ -266,7 +267,7 @@ test_sections['qt'].requires('zmq', 'qt', 'pygments')
 
 # html:
 sec = test_sections['html']
-sec.requires('zmq', 'tornado', 'requests', 'sqlite3')
+sec.requires('zmq', 'tornado', 'requests', 'sqlite3', 'jsonschema')
 # The notebook 'static' directory contains JS, css and other
 # files for web serving.  Occasionally projects may put a .py
 # file in there (MathJax ships a conf.py), so we might as
@@ -284,7 +285,7 @@ test_sections['config'].exclude('profile')
 
 # nbconvert:
 sec = test_sections['nbconvert']
-sec.requires('pygments', 'jinja2')
+sec.requires('pygments', 'jinja2', 'jsonschema')
 # Exclude nbconvert directories containing config files used to test.
 # Executing the config files with iptest would cause an exception.
 sec.exclude('tests.files')
@@ -292,6 +293,9 @@ sec.exclude('exporters.tests.files')
 if not have['tornado']:
     sec.exclude('nbconvert.post_processors.serve')
     sec.exclude('nbconvert.post_processors.tests.test_serve')
+
+# nbformat:
+test_sections['nbformat'].requires('jsonschema')
 
 #-----------------------------------------------------------------------------
 # Functions and classes

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -148,6 +148,7 @@ have['jinja2'] = test_for('jinja2')
 have['requests'] = test_for('requests')
 have['sphinx'] = test_for('sphinx')
 have['jsonschema'] = test_for('jsonschema')
+have['jsonpointer'] = test_for('jsonpointer')
 have['casperjs'] = is_cmd_found('casperjs')
 have['phantomjs'] = is_cmd_found('phantomjs')
 have['slimerjs'] = is_cmd_found('slimerjs')
@@ -267,7 +268,7 @@ test_sections['qt'].requires('zmq', 'qt', 'pygments')
 
 # html:
 sec = test_sections['html']
-sec.requires('zmq', 'tornado', 'requests', 'sqlite3', 'jsonschema')
+sec.requires('zmq', 'tornado', 'requests', 'sqlite3', 'jsonschema', 'jsonpointer')
 # The notebook 'static' directory contains JS, css and other
 # files for web serving.  Occasionally projects may put a .py
 # file in there (MathJax ships a conf.py), so we might as
@@ -285,7 +286,7 @@ test_sections['config'].exclude('profile')
 
 # nbconvert:
 sec = test_sections['nbconvert']
-sec.requires('pygments', 'jinja2', 'jsonschema')
+sec.requires('pygments', 'jinja2', 'jsonschema', 'jsonpointer')
 # Exclude nbconvert directories containing config files used to test.
 # Executing the config files with iptest would cause an exception.
 sec.exclude('tests.files')
@@ -295,7 +296,7 @@ if not have['tornado']:
     sec.exclude('nbconvert.post_processors.tests.test_serve')
 
 # nbformat:
-test_sections['nbformat'].requires('jsonschema')
+test_sections['nbformat'].requires('jsonschema', 'jsonpointer')
 
 #-----------------------------------------------------------------------------
 # Functions and classes

--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -27,7 +27,7 @@ from IPython.utils.path import compress_user
 from IPython.utils.py3compat import bytes_to_str
 from IPython.utils.sysinfo import get_sys_info
 from IPython.utils.tempdir import TemporaryDirectory
-from IPython.nbconvert.filters.ansi import strip_ansi
+from IPython.utils.text import strip_ansi
 
 try:
     # Python >= 3.3

--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -217,7 +217,8 @@ def all_js_groups():
 
 class JSController(TestController):
     """Run CasperJS tests """
-    requirements =  ['zmq', 'tornado', 'jinja2', 'casperjs', 'sqlite3']
+    requirements =  ['zmq', 'tornado', 'jinja2', 'casperjs', 'sqlite3',
+                     'jsonschema', 'jsonpointer']
     display_slimer_output = False
 
     def __init__(self, section, enabled=True, engine='phantomjs'):

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -491,6 +491,17 @@ def strip_email_quotes(text):
             text = '\n'.join([ ln[strip:] for ln in lines])
     return text
 
+def strip_ansi(source):
+    """
+    Remove ansi escape codes from text.
+    
+    Parameters
+    ----------
+    source : str
+        Source to remove the ansi from
+    """
+    return re.sub(r'\033\[(\d|;)+?m', '', source)
+
 
 class EvalFormatter(Formatter):
     """A String Formatter that allows evaluation of simple expressions.

--- a/setupbase.py
+++ b/setupbase.py
@@ -146,7 +146,7 @@ def find_package_data():
     # (there are lots of resources we bundle for sdist-reasons that we don't actually use)
     static_data.extend([
         pjoin(components, "backbone", "backbone-min.js"),
-        pjoin(components, "bootstrap", "bootstrap", "js", "bootstrap.min.js"),
+        pjoin(components, "bootstrap", "js", "bootstrap.min.js"),
         pjoin(components, "bootstrap-tour", "build", "css", "bootstrap-tour.min.css"),
         pjoin(components, "bootstrap-tour", "build", "js", "bootstrap-tour.min.js"),
         pjoin(components, "font-awesome", "font", "*.*"),


### PR DESCRIPTION
- Moved strip_ansi to utils.text, so that the test machinery can load it without loading nbformat
- Added jsonschema as a requirement for the nbformat, nbconvert and html tests
- Skipped some other tests that handle notebooks if nbformat is not importable.

See #5970.
