### PR TITLE
Do not create checkpoint_dir relative to current dir

### DIFF
--- a/IPython/html/services/notebooks/filenbmanager.py
+++ b/IPython/html/services/notebooks/filenbmanager.py
@@ -429,8 +429,6 @@ class FileNotebookManager(NotebookManager):
         checkpoint_id = u"checkpoint"
         cp_path = self.get_checkpoint_path(checkpoint_id, name, path)
         self.log.debug("creating checkpoint for notebook %s", name)
-        if not os.path.exists(self.checkpoint_dir):
-            os.mkdir(self.checkpoint_dir)
         self._copy(nb_path, cp_path)
         
         # return the checkpoint info


### PR DESCRIPTION
Please backport 19651d2 or remove two unneeded lines from FileNotebookManager.create_checkpoint, which attempt to create checkpoint_dir relative to the current working directory, not the notebooks directory set in NotebookManager.notebook_dir.

For example, if `ipython notebook` is run from `/`, it would attempt to create the directory `/.ipynb_checkpoints` and raise an exception.
