### PR TITLE
Emergency JS tests fix

### DIFF
--- a/IPython/html/tests/notebook/dualmode.js
+++ b/IPython/html/tests/notebook/dualmode.js
@@ -47,14 +47,22 @@ casper.notebook_test(function () {
         this.evaluate(function(){
             $('#keyboard_shortcuts a').click();
         }, {});
+    });
+    // Wait for the dialog to fade in completely.
+    this.wait(1000);
+    this.then(function () {
 
         this.trigger_keydown('k');
         this.validate_notebook_state('k in command mode while keyboard help is up', 'command', 3);
 
         // Close keyboard help
         this.evaluate(function(){
-            $('div.modal button.close').click();
+            $('div.modal-footer button.btn-default').click();
         }, {});
+    });
+    // Wait for the dialog to fade out completely.
+    this.wait(1000);
+    this.then(function () {
 
         this.trigger_keydown('k');
         this.validate_notebook_state('k in command mode', 'command', 2);

--- a/IPython/html/tests/notebook/dualmode.js
+++ b/IPython/html/tests/notebook/dualmode.js
@@ -48,10 +48,27 @@ casper.notebook_test(function () {
             $('#keyboard_shortcuts a').click();
         }, {});
     });
-    // Wait for the dialog to fade in completely.
-    this.wait(1000);
-    this.then(function () {
 
+    // Wait for the dialog to fade in completely.
+    this.waitForSelector('div.modal', function() {
+        this.evaluate(function(){
+            IPython.modal_shown = false;
+            $('div.modal').on('shown.bs.modal', function (){
+                IPython.modal_shown = true;
+            });
+            $('div.modal').on('hidden.bs.modal', function (){
+                IPython.modal_shown = false;
+            });
+        });
+        
+    });
+
+    this.waitFor(function () {
+        return this.evaluate(function(){
+            return IPython.modal_shown;
+        });
+    },
+    function() {
         this.trigger_keydown('k');
         this.validate_notebook_state('k in command mode while keyboard help is up', 'command', 3);
 
@@ -60,9 +77,14 @@ casper.notebook_test(function () {
             $('div.modal-footer button.btn-default').click();
         }, {});
     });
+
     // Wait for the dialog to fade out completely.
-    this.wait(1000);
-    this.then(function () {
+    this.waitFor(function () {
+        return this.evaluate(function(){
+            return !IPython.modal_shown;
+        });
+    },
+    function() {
 
         this.trigger_keydown('k');
         this.validate_notebook_state('k in command mode', 'command', 2);

--- a/IPython/html/tests/widgets/widget_selection.js
+++ b/IPython/html/tests/widgets/widget_selection.js
@@ -105,6 +105,9 @@ casper.notebook_test(function () {
         this.test.assert(verify_selection(this, 2), 'List selection updated view states correctly.');
 
         // Verify that selecting a multibutton option updates all of the others.
+        // Bootstrap3 has changed the toggle button group behavior.  Two clicks
+        // are required to actually select an item.
+        this.cell_element_function(selection_index, multibtn_selector + ' .btn:nth-child(4)', 'click');
         this.cell_element_function(selection_index, multibtn_selector + ' .btn:nth-child(4)', 'click');
     });
     this.wait_for_idle();


### PR DESCRIPTION
Whoops, broken by the Bootstrap3 migration PR #5617
- Wait for keyboard help dialog fadein and fadeout (introduced in Bootstrap3).

In the future, we probably want to figure out how to do this without timeouts, using the Bootstrap `bs.model.shown` event (or something similar).
