### PR TITLE
Fix ssh tunnel for Python3

### DIFF
--- a/IPython/external/ssh/tunnel.py
+++ b/IPython/external/ssh/tunnel.py
@@ -27,6 +27,7 @@ import socket
 from multiprocessing import Process
 from getpass import getpass, getuser
 import warnings
+from IPython.utils.py3compat import xrange
 
 try:
     with warnings.catch_warnings():


### PR DESCRIPTION
`xrange` was unrecognized.
