### PR TITLE
remove backward compat `container` in output area as planed.

### DIFF
--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -569,11 +569,6 @@ var IPython = (function (IPython) {
         var toinsert = this.create_output_subarea(md, "output_javascript", type);
         IPython.keyboard_manager.register_events(toinsert);
         element.append(toinsert);
-        // FIXME TODO : remove `container element for 3.0` 
-        //backward compat, js should be eval'ed in a context where `container` is defined.
-        var container = element;
-        container.show = function(){console.log('Warning "container.show()" is deprecated.')};
-        // end backward compat
 
         // Fix for ipython/issues/5293, make sure `element` is the area which
         // output can be inserted into at the time of JS execution.

--- a/docs/source/whatsnew/pr/incompat-remove-js-container.rst
+++ b/docs/source/whatsnew/pr/incompat-remove-js-container.rst
@@ -1,0 +1,4 @@
+Accessing the `container` DOM object when displaying javascript has been
+deprecated in IPython 2.0 in favor of accessing `element`. Starting with
+IPython 3.0 trying to access `container` will raise an error in browser
+javascript console.


### PR DESCRIPTION
TODO comment says `remove me for 3.0`

@jdfreder, it might conflict with your #5980.
