### PR TITLE
Set kernel_id before checking websocket

### DIFF
--- a/IPython/html/base/zmqhandlers.py
+++ b/IPython/html/base/zmqhandlers.py
@@ -98,12 +98,12 @@ class ZMQStreamHandler(websocket.WebSocketHandler):
 class AuthenticatedZMQStreamHandler(ZMQStreamHandler, IPythonHandler):
 
     def open(self, kernel_id):
+        self.kernel_id = cast_unicode(kernel_id, 'ascii')
         # Check to see that origin matches host directly, including ports
         if not self.same_origin():
             self.log.warn("Cross Origin WebSocket Attempt.")
             raise web.HTTPError(404)
 
-        self.kernel_id = cast_unicode(kernel_id, 'ascii')
         self.session = Session(config=self.config)
         self.save_on_message = self.on_message
         self.on_message = self.on_first_message


### PR DESCRIPTION
If websocket attempt fails and cross origin attempt is detected, a HTTPError(404) error is raised. However, in the process of closing connections because of this 404 error, an unhandled Attribute exception (kernel_id not an attribute) is raised. Setting the kernel_id first avoids this.
