### PR TITLE
Changed right arrow key movement function to mirror left arrow key

### DIFF
--- a/IPython/qt/console/console_widget.py
+++ b/IPython/qt/console/console_widget.py
@@ -1364,13 +1364,12 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, QtGui.
 
             elif key == QtCore.Qt.Key_Right:
                 original_block_number = cursor.blockNumber()
-                cursor.movePosition(QtGui.QTextCursor.Right,
+                self._control.moveCursor(QtGui.QTextCursor.Right,
                                 mode=anchormode)
                 if cursor.blockNumber() != original_block_number:
-                    cursor.movePosition(QtGui.QTextCursor.Right,
+                    self._control.moveCursor(QtGui.QTextCursor.Right,
                                         n=len(self._continuation_prompt),
                                         mode=anchormode)
-                self._set_cursor(cursor)
                 intercepted = True
 
             elif key == QtCore.Qt.Key_Home:


### PR DESCRIPTION
Seems to solve Issue #5926 on this machine, and passing the test file locally.  Changed from `cursor.movePosition` to `self._control.moveCursor`, the latter is what the left-arrow key uses.  Also removed line 1373 which seems unnecessary and which prevents the cursor from moving at all.

I'm not certain how to further test this to make sure nothing was broken.
