### PR TITLE
Creating an entry point for notebook manager extensions

### DIFF
--- a/IPython/html/static/custom/custom.js
+++ b/IPython/html/static/custom/custom.js
@@ -12,7 +12,7 @@
  *
  * Same thing with `profile/static/custom/custom.css` to inject custom css into the notebook.
  *
- * Example :
+ * __Example 1:__
  *
  * Create a custom button in toolbar that execute `%qtconsole` in kernel
  * and hence open a qtconsole attached to the same kernel as the current notebook
@@ -30,7 +30,16 @@
  *            ]);
  *    });
  *
- * Example :
+ * __Example 2:__
+ *
+ * At the completion of the dashboard loading, load an unofficial javascript extension
+ * that is installed in profile/static/custom/ 
+ *
+ *    $([IPython.events]).on('app_initialized.DashboardApp', function(){
+ *        require(['custom/unofficial_extension.js'])
+ *    });
+ *
+ * __Example 3:__
  *
  *  Use `jQuery.getScript(url [, success(script, textStatus, jqXHR)] );`
  *  to load custom script into the notebook.

--- a/IPython/html/static/tree/js/main.js
+++ b/IPython/html/static/tree/js/main.js
@@ -70,7 +70,8 @@ $(document).ready(function () {
     enable_autorefresh();
 
     IPython.page.show();
-    
+    $([IPython.events]).trigger('app_initialized.DashboardApp');
+
     // bound the upload method to the on change of the file select list
     $("#alternate_upload").change(function (event){
         IPython.notebook_list.handleFilesUpload(event,'form');


### PR DESCRIPTION
Following the comments about  #5989, I'm turning my multicolumn notebook manager hack into an extension. I have the feeling that the only way to load extensions as early as the notebook manager is to create a new entry point by:
- Firing app_initialized.DashboardApp event when loaded the notebook manager (in tree/js/main.js)
- Updating tree.html template to load nbextensions through custom.js and this newly created event.

Is this change necessary and acceptable to you?
