### PR TITLE
Disable virtualenv warning in bash on Windows

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -732,6 +732,16 @@ class InteractiveShell(SingletonConfigurable):
             # Not in a virtualenv
             return
         
+        # Handle no symbolic link case first.
+        if not os.path.islink(sys.executable):
+            # Adapted from pip.locations.running_under_virtualenv
+            if hasattr(sys, 'real_prefix'):
+                # Running properly in a virtualenv
+                return
+            elif sys.prefix != getattr(sys, "base_prefix", sys.prefix):
+                # Running properly in a venv
+                return
+
         # venv detection:
         # stdlib venv may symlink sys.executable, so we can't use realpath.
         # but others can symlink *to* the venv Python, so we can't just use sys.executable.

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -732,26 +732,16 @@ class InteractiveShell(SingletonConfigurable):
             # Not in a virtualenv
             return
         
-        # Handle no symbolic link case first.
-        if not os.path.islink(sys.executable):
-            # Adapted from pip.locations.running_under_virtualenv
-            if hasattr(sys, 'real_prefix'):
-                # Running properly in a virtualenv
-                return
-            elif sys.prefix != getattr(sys, "base_prefix", sys.prefix):
-                # Running properly in a venv
-                return
-
         # venv detection:
         # stdlib venv may symlink sys.executable, so we can't use realpath.
         # but others can symlink *to* the venv Python, so we can't just use sys.executable.
         # So we just check every item in the symlink tree (generally <= 3)
-        p = sys.executable
+        p = os.path.normcase(sys.executable)
         paths = [p]
         while os.path.islink(p):
-            p = os.path.join(os.path.dirname(p), os.readlink(p))
+            p = os.path.normcase(os.path.join(os.path.dirname(p), os.readlink(p)))
             paths.append(p)
-        if any(p.startswith(os.environ['VIRTUAL_ENV']) for p in paths):
+        if any(p.startswith(os.path.normcase(os.environ['VIRTUAL_ENV'])) for p in paths):
             # Running properly in the virtualenv, don't need to do anything
             return
         

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -741,7 +741,8 @@ class InteractiveShell(SingletonConfigurable):
         while os.path.islink(p):
             p = os.path.normcase(os.path.join(os.path.dirname(p), os.readlink(p)))
             paths.append(p)
-        if any(p.startswith(os.path.normcase(os.environ['VIRTUAL_ENV'])) for p in paths):
+        p_venv = os.path.normcase(os.environ['VIRTUAL_ENV'])
+        if any(p.startswith(p_venv) for p in paths):
             # Running properly in the virtualenv, don't need to do anything
             return
         


### PR DESCRIPTION
This is for IPython installed in a virtual environment on Windows. When I run IPython in bash I get the warning:

```
WARNING: Attempting to work in a virtualenv. If you encounter problems, please install IPython inside the virtualenv.
```

Four tests fail in bash:

```
Test we're not loading modules on startup that we shouldn't. ... ERROR
IPython.core.tests.test_run.TestMagicRunSimple.test_obj_del ... ERROR
Test that `__file__` is set when running `ipython file.ipy` ... ERROR
Test that `__file__` is set when running `ipython file.py` ... ERROR
```
