### PR TITLE
demote "iopub lacks parent" message to debug-level

### DIFF
--- a/IPython/parallel/controller/hub.py
+++ b/IPython/parallel/controller/hub.py
@@ -845,7 +845,7 @@ class Hub(SessionFactory):
 
         parent = msg['parent_header']
         if not parent:
-            self.log.warn("iopub::IOPub message lacks parent: %r", msg)
+            self.log.debug("iopub::IOPub message lacks parent: %r", msg)
             return
         msg_id = parent['msg_id']
         msg_type = msg['header']['msg_type']


### PR DESCRIPTION
these happen all the time, and aren’t worth warning about
