### PR TITLE
Add 'mistune' markdown parser as an option for markdown2html

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ before_install:
     - time sudo apt-get install pandoc casperjs nodejs libzmq3-dev
     # pin tornado < 4 for js tests while phantom is on super old webkit
     - if [[ $GROUP == 'js' ]]; then pip install 'tornado<4'; fi
-    - time pip install -f https://nipy.bic.berkeley.edu/wheelhouse/travis jinja2 sphinx pygments tornado requests mock pyzmq jsonschema jsonpointer
-    - time npm install -g requirejs jquery
+    - time pip install -f https://nipy.bic.berkeley.edu/wheelhouse/travis jinja2 sphinx pygments tornado requests mock pyzmq jsonschema jsonpointer mistune
 install:
     - time python setup.py install -q 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
     # Pierre Carrier's PPA for PhantomJS and CasperJS
     - time sudo add-apt-repository -y ppa:pcarrier/ppa
     - time sudo apt-get update
-    - time sudo apt-get install pandoc casperjs nodejs libzmq3-dev
+    - time sudo apt-get install pandoc casperjs libzmq3-dev
     # pin tornado < 4 for js tests while phantom is on super old webkit
     - if [[ $GROUP == 'js' ]]; then pip install 'tornado<4'; fi
     - time pip install -f https://nipy.bic.berkeley.edu/wheelhouse/travis jinja2 sphinx pygments tornado requests mock pyzmq jsonschema jsonpointer mistune

--- a/IPython/nbconvert/filters/markdown.py
+++ b/IPython/nbconvert/filters/markdown.py
@@ -90,8 +90,22 @@ def markdown2html(source):
     else:
         return markdown2html_pandoc(source)
 
+if mistune is not None:
+    from pygments import highlight
+    from pygments.lexers import get_lexer_by_name
+    from pygments.formatters import HtmlFormatter
+
+    class MyRenderer(mistune.Renderer):
+        def block_code(self, code, lang):
+            if not lang:
+                return '\n<pre><code>%s</code></pre>\n' % \
+                    mistune.escape(code)
+            lexer = get_lexer_by_name(lang, stripall=True)
+            formatter = HtmlFormatter()
+            return highlight(code, lexer, formatter)
+
 def markdown2html_mistune(source):
-    return mistune.markdown(source)
+    return mistune.Markdown(renderer=MyRenderer()).render(source)
 
 def markdown2html_pandoc(source):
     """Convert a markdown string to HTML via pandoc"""

--- a/IPython/nbconvert/filters/markdown.py
+++ b/IPython/nbconvert/filters/markdown.py
@@ -167,7 +167,7 @@ def markdown2html_marked(source, encoding='utf-8'):
     return out.rstrip('\n')
 
 # The mistune renderer is the default, because it's simple to depend on it
-markdown2html = markdown2html_marked
+markdown2html = markdown2html_mistune
 
 def markdown2rst(source):
     """Convert a markdown string to ReST via pandoc.

--- a/IPython/nbconvert/filters/markdown.py
+++ b/IPython/nbconvert/filters/markdown.py
@@ -116,7 +116,7 @@ class MarkdownWithMath(mistune.Markdown):
     def parse_block_math(self):
         return self.renderer.block_math(self.token['text'])
 
-class MyRenderer(mistune.Renderer):
+class IPythonRenderer(mistune.Renderer):
     def block_code(self, code, lang):
         if not lang:
             return '\n<pre><code>%s</code></pre>\n' % \
@@ -134,7 +134,7 @@ class MyRenderer(mistune.Renderer):
 
 def markdown2html_mistune(source):
     """Convert a markdown string to HTML using mistune"""
-    return MarkdownWithMath(renderer=MyRenderer()).render(source)
+    return MarkdownWithMath(renderer=IPythonRenderer()).render(source)
 
 def markdown2html_pandoc(source):
     """Convert a markdown string to HTML via pandoc"""

--- a/IPython/nbconvert/filters/markdown.py
+++ b/IPython/nbconvert/filters/markdown.py
@@ -21,6 +21,11 @@ import subprocess
 import warnings
 from io import TextIOWrapper, BytesIO
 
+try:
+    import mistune
+except ImportError:
+    mistune = None
+
 # IPython imports
 from IPython.nbconvert.utils.pandoc import pandoc
 from IPython.nbconvert.utils.exceptions import ConversionException
@@ -38,6 +43,7 @@ __all__ = [
     'markdown2html',
     'markdown2html_pandoc',
     'markdown2html_marked',
+    'markdown2html_mistune',
     'markdown2latex',
     'markdown2rst',
 ]
@@ -79,8 +85,13 @@ def markdown2html(source):
                 _node = False
     if _node:
         return markdown2html_marked(source)
+    if mistune is not None:
+        return markdown2html_mistune(source)
     else:
         return markdown2html_pandoc(source)
+
+def markdown2html_mistune(source):
+    return mistune.markdown(source)
 
 def markdown2html_pandoc(source):
     """Convert a markdown string to HTML via pandoc"""

--- a/IPython/nbconvert/filters/markdown.py
+++ b/IPython/nbconvert/filters/markdown.py
@@ -25,6 +25,7 @@ import mistune
 from pygments import highlight
 from pygments.lexers import get_lexer_by_name
 from pygments.formatters import HtmlFormatter
+from pygments.util import ClassNotFound
 
 # IPython imports
 from IPython.nbconvert.utils.pandoc import pandoc
@@ -118,10 +119,17 @@ class MarkdownWithMath(mistune.Markdown):
 
 class IPythonRenderer(mistune.Renderer):
     def block_code(self, code, lang):
+        if lang:
+            try:
+                lexer = get_lexer_by_name(lang, stripall=True)
+            except ClassNotFound:
+                code = lang + '\n' + code
+                lang = None
+
         if not lang:
             return '\n<pre><code>%s</code></pre>\n' % \
                 mistune.escape(code)
-        lexer = get_lexer_by_name(lang, stripall=True)
+
         formatter = HtmlFormatter()
         return highlight(code, lexer, formatter)
 

--- a/IPython/nbconvert/filters/markdown.py
+++ b/IPython/nbconvert/filters/markdown.py
@@ -72,9 +72,10 @@ def markdown2latex(source):
 
 class MathBlockGrammar(mistune.BlockGrammar):
     block_math = re.compile("^\$\$(.*?)\$\$")
+    block_math2 = re.compile(r"^\\begin(.*?)\\end")
 
 class MathBlockLexer(mistune.BlockLexer):
-    default_features = ['block_math'] + mistune.BlockLexer.default_features
+    default_features = ['block_math', 'block_math2'] + mistune.BlockLexer.default_features
 
     def __init__(self, rules=None, **kwargs):
         if rules is None:
@@ -87,6 +88,8 @@ class MathBlockLexer(mistune.BlockLexer):
             'type': 'block_math',
             'text': m.group(1)
         })
+
+    parse_block_math2 = parse_block_math
 
 class MathInlineGrammar(mistune.InlineGrammar):
     math = re.compile("^\$(.+?)\$")

--- a/IPython/nbconvert/filters/tests/test_markdown.py
+++ b/IPython/nbconvert/filters/tests/test_markdown.py
@@ -63,8 +63,6 @@ class TestMarkdown(TestsBase):
         for index, test in enumerate(self.tests):
             self._try_markdown(markdown2latex, test, self.tokens[index])
 
-
-    @dec.onlyif_cmds_exist('pandoc')
     def test_markdown2html(self):
         """markdown2html test"""
         for index, test in enumerate(self.tests):

--- a/IPython/nbconvert/filters/tests/test_markdown.py
+++ b/IPython/nbconvert/filters/tests/test_markdown.py
@@ -1,19 +1,7 @@
+"""Tests for conversions from markdown to other formats"""
 
-"""
-Module with tests for Markdown
-"""
-
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, the IPython Development Team.
-#
+# Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
 
 from copy import copy
 
@@ -23,10 +11,6 @@ from IPython.testing import decorators as dec
 from ...tests.base import TestsBase
 from ..markdown import markdown2latex, markdown2html, markdown2rst
 
-
-#-----------------------------------------------------------------------------
-# Class
-#-----------------------------------------------------------------------------
 
 class TestMarkdown(TestsBase):
 
@@ -67,6 +51,19 @@ class TestMarkdown(TestsBase):
         """markdown2html test"""
         for index, test in enumerate(self.tests):
             self._try_markdown(markdown2html, test, self.tokens[index])
+
+    def test_markdown2html_math(self):
+        # Mathematical expressions should be passed through unaltered
+        cases = [("\\begin{equation*}\n"
+                  "\\left( \\sum_{k=1}^n a_k b_k \\right)^2 \\leq \\left( \\sum_{k=1}^n a_k^2 \\right) \\left( \\sum_{k=1}^n b_k^2 \\right)\n"
+                  "\\end{equation*}"),
+                 ("$$\n"
+                  "a = 1 *3* 5\n"
+                  "$$"),
+                  "$ a = 1 *3* 5 $",
+                ]
+        for case in cases:
+            self.assertIn(case, markdown2html(case))
 
 
     @dec.onlyif_cmds_exist('pandoc')

--- a/setup.py
+++ b/setup.py
@@ -273,8 +273,8 @@ extras_require = dict(
     test = ['nose>=0.10.1'],
     terminal = [],
     nbformat = ['jsonschema>=2.0', 'jsonpointer>=1.3'],
-    notebook = ['tornado>=3.1', 'pyzmq>=2.1.11', 'jinja2'],
-    nbconvert = ['pygments', 'jinja2', 'Sphinx>=0.3', 'mistune']
+    notebook = ['tornado>=3.1', 'pyzmq>=2.1.11', 'jinja2', 'pygments', 'mistune'],
+    nbconvert = ['pygments', 'jinja2', 'mistune']
 )
 
 if sys.version_info < (3, 3):

--- a/setup.py
+++ b/setup.py
@@ -273,8 +273,8 @@ extras_require = dict(
     test = ['nose>=0.10.1'],
     terminal = [],
     nbformat = ['jsonschema>=2.0', 'jsonpointer>=1.3'],
-    notebook = ['tornado>=3.1', 'pyzmq>=2.1.11', 'jinja2', 'pygments', 'mistune'],
-    nbconvert = ['pygments', 'jinja2', 'mistune']
+    notebook = ['tornado>=3.1', 'pyzmq>=2.1.11', 'jinja2', 'pygments', 'mistune>=0.3'],
+    nbconvert = ['pygments', 'jinja2', 'mistune>=0.3']
 )
 
 if sys.version_info < (3, 3):

--- a/setup.py
+++ b/setup.py
@@ -274,7 +274,7 @@ extras_require = dict(
     terminal = [],
     nbformat = ['jsonschema>=2.0', 'jsonpointer>=1.3'],
     notebook = ['tornado>=3.1', 'pyzmq>=2.1.11', 'jinja2'],
-    nbconvert = ['pygments', 'jinja2', 'Sphinx>=0.3']
+    nbconvert = ['pygments', 'jinja2', 'Sphinx>=0.3', 'mistune']
 )
 
 if sys.version_info < (3, 3):


### PR DESCRIPTION
[Mistune](https://github.com/lepture/mistune) is a pure Python markdown compiler, which compiles itself using Cython if you have Cython available at install time. It describes itself as 'inspired by marked', and the author mentions in a [blog post](http://lepture.com/en/2014/markdown-parsers-in-python) that his idea was to port marked to Python, so we should be able to expect highly consistent results.

Advantages:
- Customisability: we can subclass and override methods if we need to change behaviour. The readme has [a simple example](https://github.com/lepture/mistune#renderer) of integrating with pygments for syntax highlighting.
- Installation: It's just another Python package to install - it doesn't need compilers, or another runtime.
- Performance? It's probably not the most optimised implementation, but I guess there's a considerable saving from not starting up a separate process for every markdown cell. I haven't benchmarked, though.

At present, I've put this after node+marked and before pandoc in the order of preference. The tests pass when I comment out the marked version.
