### PR TITLE
add pickleutil.PICKLE_PROTOCOL

### DIFF
--- a/IPython/kernel/zmq/serialize.py
+++ b/IPython/kernel/zmq/serialize.py
@@ -1,19 +1,7 @@
-"""serialization utilities for apply messages
+"""serialization utilities for apply messages"""
 
-Authors:
-
-* Min RK
-"""
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2010-2011  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 try:
     import cPickle
@@ -22,13 +10,12 @@ except:
     cPickle = None
     import pickle
 
-
 # IPython imports
 from IPython.utils import py3compat
 from IPython.utils.data import flatten
 from IPython.utils.pickleutil import (
     can, uncan, can_sequence, uncan_sequence, CannedObject,
-    istype, sequence_types,
+    istype, sequence_types, PICKLE_PROTOCOL,
 )
 
 if py3compat.PY3:
@@ -99,7 +86,7 @@ def serialize_object(obj, buffer_threshold=MAX_BYTES, item_threshold=MAX_ITEMS):
         cobj = can(obj)
         buffers.extend(_extract_buffers(cobj, buffer_threshold))
 
-    buffers.insert(0, pickle.dumps(cobj,-1))
+    buffers.insert(0, pickle.dumps(cobj, PICKLE_PROTOCOL))
     return buffers
 
 def unserialize_object(buffers, g=None):
@@ -162,8 +149,8 @@ def pack_apply_message(f, args, kwargs, buffer_threshold=MAX_BYTES, item_thresho
     
     info = dict(nargs=len(args), narg_bufs=len(arg_bufs), kw_keys=kw_keys)
     
-    msg = [pickle.dumps(can(f),-1)]
-    msg.append(pickle.dumps(info, -1))
+    msg = [pickle.dumps(can(f), PICKLE_PROTOCOL)]
+    msg.append(pickle.dumps(info, PICKLE_PROTOCOL))
     msg.extend(arg_bufs)
     msg.extend(kwarg_bufs)
     

--- a/IPython/kernel/zmq/session.py
+++ b/IPython/kernel/zmq/session.py
@@ -43,6 +43,7 @@ from IPython.utils.traitlets import (CBytes, Unicode, Bool, Any, Instance, Set,
                                         DottedObjectName, CUnicode, Dict, Integer,
                                         TraitError,
 )
+from IPython.utils.pickleutil import PICKLE_PROTOCOL
 from IPython.kernel.adapter import adapt
 from IPython.kernel.zmq.serialize import MAX_ITEMS, MAX_BYTES
 
@@ -76,7 +77,7 @@ json_packer = lambda obj: jsonapi.dumps(obj, default=date_default,
 )
 json_unpacker = lambda s: jsonapi.loads(s)
 
-pickle_packer = lambda o: pickle.dumps(squash_dates(o),-1)
+pickle_packer = lambda o: pickle.dumps(squash_dates(o), PICKLE_PROTOCOL)
 pickle_unpacker = pickle.loads
 
 default_packer = json_packer

--- a/IPython/utils/pickleutil.py
+++ b/IPython/utils/pickleutil.py
@@ -28,6 +28,11 @@ else:
     from types import ClassType
     class_type = (type, ClassType)
 
+try:
+    PICKLE_PROTOCOL = pickle.DEFAULT_PROTOCOL
+except AttributeError:
+    PICKLE_PROTOCOL = pickle.HIGHEST_PROTOCOL
+
 def _get_cell_type(a=None):
     """the type of a closure cell doesn't seem to be importable,
     so just create one
@@ -244,7 +249,7 @@ class CannedArray(CannedObject):
             self.pickled = True
         if self.pickled:
             # just pickle it
-            self.buffers = [pickle.dumps(obj, -1)]
+            self.buffers = [pickle.dumps(obj, PICKLE_PROTOCOL)]
         else:
             # ensure contiguous
             obj = ascontiguousarray(obj, dtype=None)


### PR DESCRIPTION
instead of hardcoding `-1`.

default to DEFAULT_PROTOCOL if defined (Python 3.4), and HIGHEST_PROTOCOL
otherwise.

Matches dill behavior

closes #5998
