### PR TITLE
restore websocket_url configurable

### DIFF
--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -127,6 +127,10 @@ class IPythonHandler(AuthenticatedHandler):
     @property
     def base_url(self):
         return self.settings.get('base_url', '/')
+
+    @property
+    def ws_url(self):
+        return self.settings.get('websocket_url', '')
     
     #---------------------------------------------------------------
     # Manager objects
@@ -215,6 +219,7 @@ class IPythonHandler(AuthenticatedHandler):
     def template_namespace(self):
         return dict(
             base_url=self.base_url,
+            ws_url=self.ws_url,
             logged_in=self.logged_in,
             login_available=self.login_available,
             static_url=self.static_url,

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -172,6 +172,7 @@ class NotebookWebApplication(web.Application):
 
             # IPython stuff
             nbextensions_path = ipython_app.nbextensions_path,
+            websocket_url=ipython_app.websocket_url,
             mathjax_url=ipython_app.mathjax_url,
             config=ipython_app.config,
             jinja2_env=env,
@@ -512,6 +513,13 @@ class NotebookApp(BaseIPythonApplication):
     def _nbextensions_path_default(self):
         return [os.path.join(get_ipython_dir(), 'nbextensions')]
 
+    websocket_url = Unicode("", config=True,
+        help="""The base URL for websockets,
+        if it differs from the HTTP server (hint: it almost certainly doesn't).
+        
+        Should be in the form of an HTTP origin: ws[s]://hostname[:port]
+        """
+    )
     mathjax_url = Unicode("", config=True,
         help="""The url for MathJax.js."""
     )

--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -43,6 +43,7 @@ require([
 
     var common_options = {
         base_url : utils.get_body_data("baseUrl"),
+        ws_url : IPython.utils.get_body_data("wsUrl"),
         notebook_path : utils.get_body_data("notebookPath"),
         notebook_name : utils.get_body_data('notebookName')
     };

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -59,6 +59,7 @@ define([
         this.keyboard_manager = options.keyboard_manager;
         this.save_widget = options.save_widget;
         this.tooltip = new tooltip.Tooltip(this.events);
+        this.ws_url = options.ws_url;
         // default_kernel_name is a temporary measure while we implement proper
         // kernel selection and delayed start. Do not rely on it.
         this.default_kernel_name = 'python';
@@ -1496,6 +1497,7 @@ define([
     Notebook.prototype.start_session = function () {
         this.session = new session.Session({
             base_url: this.base_url,
+            ws_url: this.ws_url,
             notebook_path: this.notebook_path,
             notebook_name: this.notebook_name,
             // For now, create all sessions with the 'python' kernel, which is the

--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -23,6 +23,11 @@ define([
         this.stdin_channel = null;
         this.kernel_service_url = kernel_service_url;
         this.name = name;
+        this.ws_url = IPython.utils.get_body_data("wsUrl");
+        if (!this.ws_url) {
+            // trailing 's' in https will become wss for secure web sockets
+            this.ws_url = location.protocol.replace('http', 'ws') + "//" + location.host;
+        }
         this.running = false;
         this.username = "username";
         this.session_id = utils.uuid();
@@ -122,8 +127,6 @@ define([
         console.log("Kernel started: ", json.id);
         this.running = true;
         this.kernel_id = json.id;
-        // trailing 's' in https will become wss for secure web sockets
-        this.ws_host = location.protocol.replace('http', 'ws') + "//" + location.host;
         this.kernel_url = utils.url_path_join(this.kernel_service_url, this.kernel_id);
         this.start_channels();
     };
@@ -145,16 +148,16 @@ define([
     Kernel.prototype.start_channels = function () {
         var that = this;
         this.stop_channels();
-        var ws_host_url = this.ws_host + this.kernel_url;
+        var ws_host_url = this.ws_url + this.kernel_url;
         console.log("Starting WebSockets:", ws_host_url);
         this.shell_channel = new this.WebSocket(
-            this.ws_host + utils.url_join_encode(this.kernel_url, "shell")
+            this.ws_url + utils.url_join_encode(this.kernel_url, "shell")
         );
         this.stdin_channel = new this.WebSocket(
-            this.ws_host + utils.url_join_encode(this.kernel_url, "stdin")
+            this.ws_url + utils.url_join_encode(this.kernel_url, "stdin")
         );
         this.iopub_channel = new this.WebSocket(
-            this.ws_host + utils.url_join_encode(this.kernel_url, "iopub")
+            this.ws_url + utils.url_join_encode(this.kernel_url, "iopub")
         );
         
         var already_called_onclose = false; // only alert once

--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -15,7 +15,7 @@ define([
      * A Kernel Class to communicate with the Python kernel
      * @Class Kernel
      */
-    var Kernel = function (kernel_service_url, notebook, name) {
+    var Kernel = function (kernel_service_url, ws_url, notebook, name) {
         this.events = notebook.events;
         this.kernel_id = null;
         this.shell_channel = null;
@@ -23,7 +23,7 @@ define([
         this.stdin_channel = null;
         this.kernel_service_url = kernel_service_url;
         this.name = name;
-        this.ws_url = IPython.utils.get_body_data("wsUrl");
+        this.ws_url = ws_url || IPython.utils.get_body_data("wsUrl");
         if (!this.ws_url) {
             // trailing 's' in https will become wss for secure web sockets
             this.ws_url = location.protocol.replace('http', 'ws') + "//" + location.host;

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -17,6 +17,7 @@ define([
         this.path = options.notebook_path;
         this.kernel_name = options.kernel_name;
         this.base_url = options.base_url;
+        this.ws_url = options.ws_url;
     };
     
     Session.prototype.start = function(callback) {
@@ -91,7 +92,7 @@ define([
     Session.prototype._handle_start_success = function (data, status, xhr) {
         this.id = data.id;
         var kernel_service_url = utils.url_path_join(this.base_url, "api/kernels");
-        this.kernel = new kernel.Kernel(kernel_service_url, this.notebook, this.kernel_name);
+        this.kernel = new kernel.Kernel(kernel_service_url, this.ws_url, this.notebook, this.kernel_name);
         this.kernel._kernel_started(data.kernel);
     };
     

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -24,6 +24,7 @@ window.mathjax_url = "{{mathjax_url}}";
 
 data-project="{{project}}"
 data-base-url="{{base_url}}"
+data-ws-url="{{ws_url}}"
 data-notebook-name="{{notebook_name}}"
 data-notebook-path="{{notebook_path}}"
 class="notebook_app"


### PR DESCRIPTION
allows ws to be handled via separate proxies, as appears to be the case on OpenShift and some other hosting services.

closes #6001
