### PR TITLE
reduce a few implicit imports

### DIFF
--- a/IPython/html/services/clusters/clustermanager.py
+++ b/IPython/html/services/clusters/clustermanager.py
@@ -21,7 +21,6 @@ from zmq.eventloop import ioloop
 
 from IPython.config.configurable import LoggingConfigurable
 from IPython.utils.traitlets import Dict, Instance, CFloat
-from IPython.parallel.apps.ipclusterapp import IPClusterStart
 from IPython.core.profileapp import list_profiles_in
 from IPython.core.profiledir import ProfileDir
 from IPython.utils import py3compat
@@ -33,17 +32,6 @@ from IPython.utils.path import get_ipython_dir
 #-----------------------------------------------------------------------------
 
 
-class DummyIPClusterStart(IPClusterStart):
-    """Dummy subclass to skip init steps that conflict with global app.
-    
-    Instantiating and initializing this class should result in fully configured
-    launchers, but no other side effects or state.
-    """
-
-    def init_signal(self):
-        pass
-    def reinit_logging(self):
-        pass
 
 
 class ClusterManager(LoggingConfigurable):
@@ -59,6 +47,20 @@ class ClusterManager(LoggingConfigurable):
         return IOLoop.instance()
 
     def build_launchers(self, profile_dir):
+        from IPython.parallel.apps.ipclusterapp import IPClusterStart
+        
+        class DummyIPClusterStart(IPClusterStart):
+            """Dummy subclass to skip init steps that conflict with global app.
+    
+            Instantiating and initializing this class should result in fully configured
+            launchers, but no other side effects or state.
+            """
+
+            def init_signal(self):
+                pass
+            def reinit_logging(self):
+                pass
+        
         starter = DummyIPClusterStart(log=self.log)
         starter.initialize(['--profile-dir', profile_dir])
         cl = starter.controller_launcher

--- a/IPython/kernel/connect.py
+++ b/IPython/kernel/connect.py
@@ -22,7 +22,6 @@ from subprocess import Popen, PIPE
 import tempfile
 
 import zmq
-from zmq.ssh import tunnel
 
 # IPython imports
 from IPython.config import LoggingConfigurable
@@ -342,6 +341,7 @@ def tunnel_to_kernel(connection_info, sshserver, sshkey=None):
     (shell, iopub, stdin, hb) : ints
         The four ports on localhost that have been forwarded to the kernel.
     """
+    from zmq.ssh import tunnel
     if isinstance(connection_info, string_types):
         # it's a path, unpack it
         with open(connection_info) as f:

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -18,7 +18,6 @@ from pprint import pprint
 pjoin = os.path.join
 
 import zmq
-from zmq.ssh import tunnel
 
 from IPython.config.configurable import MultipleInstanceError
 from IPython.core.application import BaseIPythonApplication
@@ -443,6 +442,7 @@ class Client(HasTraits):
             # default to ssh via localhost
             sshserver = addr
         if self._ssh and password is None:
+            from zmq.ssh import tunnel
             if tunnel.try_passwordless_ssh(sshserver, sshkey, paramiko):
                 password=False
             else:
@@ -467,6 +467,7 @@ class Client(HasTraits):
         self._query_socket = self._context.socket(zmq.DEALER)
 
         if self._ssh:
+            from zmq.ssh import tunnel
             tunnel.tunnel_connection(self._query_socket, cfg['registration'], sshserver, **ssh_kwargs)
         else:
             self._query_socket.connect(cfg['registration'])
@@ -589,6 +590,7 @@ class Client(HasTraits):
 
         def connect_socket(s, url):
             if self._ssh:
+                from zmq.ssh import tunnel
                 return tunnel.tunnel_connection(s, url, sshserver, **ssh_kwargs)
             else:
                 return s.connect(url)


### PR DESCRIPTION
- starting the notebook no longer implies IPython.parallel until clusters are started
- IPython.parallel no longer implies numpy (or numeric or numarray)
- move zmq.ssh, which implies paramiko, into local imports when it's actually used
