### PR TITLE
fix stream output created by raw_input

### DIFF
--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -794,7 +794,7 @@ var IPython = (function (IPython) {
         }
         var content = {
             output_type : 'stream',
-            name : 'stdout',
+            stream : 'stdout',
             text : theprompt.text() + echo + '\n'
         }
         // remove form container


### PR DESCRIPTION
was using incorrect 'name', when it should have been 'stream', creating invalid content in notebook documents.

Found via testing validation in #6045
