### PR TITLE
Document objects in API location rather than where defined

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -26,13 +26,13 @@ from IPython.core.formatters import _safe_get_formatter_method
 from IPython.utils.py3compat import (string_types, cast_bytes_py2, cast_unicode,
                                      unicode_type)
 from IPython.testing.skipdoctest import skip_doctest
-from .displaypub import publish_display_data
 
 __all__ = ['display', 'display_pretty', 'display_html', 'display_markdown',
 'display_svg', 'display_png', 'display_jpeg', 'display_latex', 'display_json',
 'display_javascript', 'display_pdf', 'DisplayObject', 'TextDisplayObject',
 'Pretty', 'HTML', 'Markdown', 'Math', 'Latex', 'SVG', 'JSON', 'Javascript',
-'clear_output', 'set_matplotlib_formats', 'set_matplotlib_close']
+'clear_output', 'set_matplotlib_formats', 'set_matplotlib_close',
+'publish_display_data']
 
 #-----------------------------------------------------------------------------
 # utility functions
@@ -83,6 +83,48 @@ def _display_mimetype(mimetype, objs, raw=False, metadata=None):
 #-----------------------------------------------------------------------------
 # Main functions
 #-----------------------------------------------------------------------------
+
+def publish_display_data(data, metadata=None, source=None):
+    """Publish data and metadata to all frontends.
+
+    See the ``display_data`` message in the messaging documentation for
+    more details about this message type.
+
+    The following MIME types are currently implemented:
+
+    * text/plain
+    * text/html
+    * text/markdown
+    * text/latex
+    * application/json
+    * application/javascript
+    * image/png
+    * image/jpeg
+    * image/svg+xml
+
+    Parameters
+    ----------
+    data : dict
+        A dictionary having keys that are valid MIME types (like
+        'text/plain' or 'image/svg+xml') and values that are the data for
+        that MIME type. The data itself must be a JSON'able data
+        structure. Minimally all data should have the 'text/plain' data,
+        which can be displayed by all frontends. If more than the plain
+        text is given, it is up to the frontend to decide which
+        representation to use.
+    metadata : dict
+        A dictionary for metadata related to the data. This can contain
+        arbitrary key, value pairs that frontends can use to interpret
+        the data. mime-type keys matching those in data can be used
+        to specify metadata about particular representations.
+    source : str, deprecated
+        Unused.
+        """
+    from IPython.core.interactiveshell import InteractiveShell
+    InteractiveShell.instance().display_pub.publish(
+        data=data,
+        metadata=metadata,
+    )
 
 def display(*objs, **kwargs):
     """Display a Python object in all frontends.

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -28,6 +28,12 @@ from IPython.utils.py3compat import (string_types, cast_bytes_py2, cast_unicode,
 from IPython.testing.skipdoctest import skip_doctest
 from .displaypub import publish_display_data
 
+__all__ = ['display', 'display_pretty', 'display_html', 'display_markdown',
+'display_svg', 'display_png', 'display_jpeg', 'display_latex', 'display_json',
+'display_javascript', 'display_pdf', 'DisplayObject', 'TextDisplayObject',
+'Pretty', 'HTML', 'Markdown', 'Math', 'Latex', 'SVG', 'JSON', 'Javascript',
+'clear_output', 'set_matplotlib_formats', 'set_matplotlib_close']
+
 #-----------------------------------------------------------------------------
 # utility functions
 #-----------------------------------------------------------------------------

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -31,7 +31,7 @@ __all__ = ['display', 'display_pretty', 'display_html', 'display_markdown',
 'display_svg', 'display_png', 'display_jpeg', 'display_latex', 'display_json',
 'display_javascript', 'display_pdf', 'DisplayObject', 'TextDisplayObject',
 'Pretty', 'HTML', 'Markdown', 'Math', 'Latex', 'SVG', 'JSON', 'Javascript',
-'clear_output', 'set_matplotlib_formats', 'set_matplotlib_close',
+'Image', 'clear_output', 'set_matplotlib_formats', 'set_matplotlib_close',
 'publish_display_data']
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/displaypub.py
+++ b/IPython/core/displaypub.py
@@ -19,8 +19,10 @@ from __future__ import print_function
 
 from IPython.config.configurable import Configurable
 from IPython.utils import io
-from IPython.utils.py3compat import string_types
 from IPython.utils.traitlets import List
+
+# This used to be defined here - it is imported for backwards compatibility
+from .display import publish_display_data
 
 #-----------------------------------------------------------------------------
 # Main payload class
@@ -112,48 +114,3 @@ class CapturingDisplayPublisher(DisplayPublisher):
         
         # empty the list, *do not* reassign a new list
         del self.outputs[:]
-
-
-def publish_display_data(data, metadata=None, source=None):
-    """Publish data and metadata to all frontends.
-
-    See the ``display_data`` message in the messaging documentation for
-    more details about this message type.
-
-    The following MIME types are currently implemented:
-
-    * text/plain
-    * text/html
-    * text/markdown
-    * text/latex
-    * application/json
-    * application/javascript
-    * image/png
-    * image/jpeg
-    * image/svg+xml
-
-    Parameters
-    ----------
-    data : dict
-        A dictionary having keys that are valid MIME types (like
-        'text/plain' or 'image/svg+xml') and values that are the data for
-        that MIME type. The data itself must be a JSON'able data
-        structure. Minimally all data should have the 'text/plain' data,
-        which can be displayed by all frontends. If more than the plain
-        text is given, it is up to the frontend to decide which
-        representation to use.
-    metadata : dict
-        A dictionary for metadata related to the data. This can contain
-        arbitrary key, value pairs that frontends can use to interpret
-        the data. mime-type keys matching those in data can be used
-        to specify metadata about particular representations.
-    source : str, deprecated
-        Unused.
-        """
-    from IPython.core.interactiveshell import InteractiveShell
-    InteractiveShell.instance().display_pub.publish(
-        data=data,
-        metadata=metadata,
-    )
-
-

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -7,6 +7,9 @@ from os import walk, sep
 
 from IPython.core.display import DisplayObject
 
+__all__ = ['Audio', 'IFrame', 'YouTubeVideo', 'VimeoVideo', 'ScribdDocument',
+           'FileLink', 'FileLinks']
+
 
 class Audio(DisplayObject):
     """Create an audio object.

--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -100,14 +100,13 @@ class Exporter(LoggingConfigurable):
     def default_config(self):
         return Config()
 
-    @nbformat.docstring_nbformat_mod
     def from_notebook_node(self, nb, resources=None, **kw):
         """
         Convert a notebook from a notebook node instance.
 
         Parameters
         ----------
-        nb : :class:`~{nbformat_mod}.nbbase.NotebookNode`
+        nb : :class:`~IPython.nbformat.current.NotebookNode`
           Notebook node
         resources : dict
           Additional resources that can be accessed read/write by

--- a/IPython/nbconvert/exporters/templateexporter.py
+++ b/IPython/nbconvert/exporters/templateexporter.py
@@ -27,7 +27,6 @@ from IPython.utils.traitlets import MetaHasTraits, Unicode, List, Dict, Any
 from IPython.utils.importstring import import_item
 from IPython.utils import py3compat, text
 
-from IPython.nbformat.current import docstring_nbformat_mod
 from IPython.nbconvert import filters
 from .exporter import Exporter
 
@@ -193,14 +192,13 @@ class TemplateExporter(Exporter):
                 self.log.info("Loaded template %s", try_name)
                 break
 
-    @docstring_nbformat_mod
     def from_notebook_node(self, nb, resources=None, **kw):
         """
         Convert a notebook from a notebook node instance.
     
         Parameters
         ----------
-        nb : :class:`~{nbformat_mod}.nbbase.NotebookNode`
+        nb : :class:`~IPython.nbformat.current.NotebookNode`
           Notebook node
         resources : dict
           Additional resources that can be accessed read/write by

--- a/IPython/nbformat/current.py
+++ b/IPython/nbformat/current.py
@@ -2,7 +2,6 @@
 
 from __future__ import print_function
 
-from xml.etree import ElementTree as ET
 import re
 
 from IPython.utils.py3compat import unicode_type
@@ -32,16 +31,6 @@ __all__ = ['NotebookNode', 'new_code_cell', 'new_text_cell', 'new_notebook',
 current_nbformat = nbformat
 current_nbformat_minor = nbformat_minor
 current_nbformat_module = _v_latest.__name__
-
-
-def docstring_nbformat_mod(func):
-    """Decorator for docstrings referring to classes/functions accessed through
-    nbformat.current.
-
-    Put {nbformat_mod} in the docstring in place of 'IPython.nbformat.v3'.
-    """
-    func.__doc__ = func.__doc__.format(nbformat_mod=current_nbformat_module)
-    return func
 
 
 class NBFormatError(ValueError):

--- a/IPython/nbformat/current.py
+++ b/IPython/nbformat/current.py
@@ -22,6 +22,12 @@ from .validator import validate
 
 from IPython.utils.log import get_logger
 
+__all__ = ['NotebookNode', 'new_code_cell', 'new_text_cell', 'new_notebook',
+'new_output', 'new_worksheet', 'parse_filename', 'new_metadata', 'new_author',
+'new_heading_cell', 'nbformat', 'nbformat_minor', 'nbformat_schema',
+'to_notebook_json', 'convert', 'validate', 'NBFormatError', 'parse_py',
+'reads_json', 'writes_json', 'reads_py', 'writes_py', 'reads', 'writes', 'read',
+'write']
 
 current_nbformat = nbformat
 current_nbformat_minor = nbformat_minor

--- a/docs/autogen_api.py
+++ b/docs/autogen_api.py
@@ -38,6 +38,9 @@ if __name__ == '__main__':
                                         # These are exposed by nbformat.current
                                         r'\.nbformat\.convert',
                                         r'\.nbformat\.validator',
+                                        # These are exposed in display
+                                        r'\.core\.display',
+                                        r'\.lib\.display',
                                         ]
 
     # These modules import functions and classes from other places to expose
@@ -46,6 +49,7 @@ if __name__ == '__main__':
     # above.
     docwriter.names_from__all__.update({
         'IPython.nbformat.current',
+        'IPython.display',
     })
     
     # Now, generate the outputs

--- a/docs/autogen_api.py
+++ b/docs/autogen_api.py
@@ -21,6 +21,8 @@ if __name__ == '__main__':
                                         # Extensions are documented elsewhere.
                                         r'\.extensions',
                                         r'\.config\.profile',
+                                        # These should be accessed via nbformat.current
+                                        r'\.nbformat\.v\d+',
                                         ]
 
     # The inputhook* modules often cause problems on import, such as trying to
@@ -33,7 +35,18 @@ if __name__ == '__main__':
                                         r'\.frontend$',
                                         # We document this manually.
                                         r'\.utils\.py3compat',
+                                        # These are exposed by nbformat.current
+                                        r'\.nbformat\.convert',
+                                        r'\.nbformat\.validator',
                                         ]
+
+    # These modules import functions and classes from other places to expose
+    # them as part of the public API. They must have __all__ defined. The
+    # non-API modules they import from should be excluded by the skip patterns
+    # above.
+    docwriter.names_from__all__.update({
+        'IPython.nbformat.current',
+    })
     
     # Now, generate the outputs
     docwriter.write_api_docs(outdir)

--- a/docs/autogen_api.py
+++ b/docs/autogen_api.py
@@ -33,6 +33,8 @@ if __name__ == '__main__':
                                         r'\.testing\.plugin',
                                         # This just prints a deprecation msg:
                                         r'\.frontend$',
+                                        # Deprecated:
+                                        r'\.core\.magics\.deprecated'
                                         # We document this manually.
                                         r'\.utils\.py3compat',
                                         # These are exposed by nbformat.current


### PR DESCRIPTION
This adds a mechanism for classes and functions to be documented where they are exposed as public API, instead of where they are defined. To do this:
- Add `__all__` to the module definition so that it doesn't expose all the random stuff it imports
- Add the API module name to `names_from__all__` in `docs/autogen_api.py`.
- Add the defining modules to the exclusions in the same file, so the objects aren't documented twice.

I've done this with `nbformat.current` (exposing things from `nbformat.v3`), and `IPython.display` (exposing things from `core.display` and `lib.display`).
