### PR TITLE
send idle/busy on all shell messages

### DIFF
--- a/IPython/kernel/comm/manager.py
+++ b/IPython/kernel/comm/manager.py
@@ -1,15 +1,7 @@
 """Base class to manage comms"""
 
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2013  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 import sys
 
@@ -23,9 +15,6 @@ from IPython.utils.traitlets import Instance, Unicode, Dict, Any
 
 from .comm import Comm
 
-#-----------------------------------------------------------------------------
-# Code
-#-----------------------------------------------------------------------------
 
 def lazy_keys(dikt):
     """Return lazy-evaluated string representation of a dictionary's keys
@@ -34,27 +23,6 @@ def lazy_keys(dikt):
     Used for debug-logging.
     """
     return LazyEvaluate(lambda d: list(d.keys()))
-
-
-def with_output(method):
-    """method decorator for ensuring output is handled properly in a message handler
-    
-    - sets parent header before entering the method
-    - publishes busy/idle
-    - flushes stdout/stderr after
-    """
-    def method_with_output(self, stream, ident, msg):
-        parent = msg['header']
-        self.shell.set_parent(parent)
-        self.shell.kernel._publish_status('busy', parent)
-        try:
-            return method(self, stream, ident, msg)
-        finally:
-            sys.stdout.flush()
-            sys.stderr.flush()
-            self.shell.kernel._publish_status('idle', parent)
-    
-    return method_with_output
 
 
 class CommManager(LoggingConfigurable):
@@ -127,7 +95,6 @@ class CommManager(LoggingConfigurable):
         return comm
     
     # Message handlers
-    @with_output
     def comm_open(self, stream, ident, msg):
         """Handler for comm_open messages"""
         content = msg['content']
@@ -151,7 +118,6 @@ class CommManager(LoggingConfigurable):
             comm.close()
             self.unregister_comm(comm_id)
     
-    @with_output
     def comm_msg(self, stream, ident, msg):
         """Handler for comm_msg messages"""
         content = msg['content']
@@ -165,7 +131,6 @@ class CommManager(LoggingConfigurable):
         except Exception:
             self.log.error("Exception in comm_msg for %s", comm_id, exc_info=True)
     
-    @with_output
     def comm_close(self, stream, ident, msg):
         """Handler for comm_close messages"""
         content = msg['content']

--- a/IPython/kernel/zmq/kernelbase.py
+++ b/IPython/kernel/zmq/kernelbase.py
@@ -136,7 +136,11 @@ class Kernel(Configurable):
             return
 
         self.log.debug("Control received: %s", msg)
-
+        
+        # Set the parent message for side effects.
+        self.set_parent(idents, msg)
+        self._publish_status(u'busy')
+        
         header = msg['header']
         msg_type = header['msg_type']
 
@@ -148,6 +152,10 @@ class Kernel(Configurable):
                 handler(self.control_stream, idents, msg)
             except Exception:
                 self.log.error("Exception in control handler:", exc_info=True)
+        
+        sys.stdout.flush()
+        sys.stderr.flush()
+        self._publish_status(u'idle')
     
     def dispatch_shell(self, stream, msg):
         """dispatch shell requests"""

--- a/docs/source/development/messaging.rst
+++ b/docs/source/development/messaging.rst
@@ -894,7 +894,7 @@ Message type: ``status``::
 
 .. versionchanged:: 5.0
 
-    Busy and idle messages should be sent before/after handling every shell message,
+    Busy and idle messages should be sent before/after handling every message,
     not just execution.
 
 Clear output

--- a/docs/source/development/messaging.rst
+++ b/docs/source/development/messaging.rst
@@ -886,11 +886,16 @@ This message type is used by frontends to monitor the status of the kernel.
 Message type: ``status``::
 
     content = {
-        # When the kernel starts to execute code, it will enter the 'busy'
+        # When the kernel starts to handle a message, it will enter the 'busy'
         # state and when it finishes, it will enter the 'idle' state.
         # The kernel will publish state 'starting' exactly once at process startup.
         execution_state : ('busy', 'idle', 'starting')
     }
+
+.. versionchanged:: 5.0
+
+    Busy and idle messages should be sent before/after handling every shell message,
+    not just execution.
 
 Clear output
 ------------


### PR DESCRIPTION
Instead of just those that execute code. This means that kernel_info_request triggers busy/idle, allowing clients to check IOPub channel status without executing code.

Pinging Kernel authors, because this is a minor message spec change:

@gibiansky, @stevengj, @dsblank
