### PR TITLE
coalesce stream output in the notebook

### DIFF
--- a/IPython/html/tests/notebook/output.js
+++ b/IPython/html/tests/notebook/output.js
@@ -1,0 +1,98 @@
+//
+// Various output tests
+//
+
+casper.notebook_test(function () {
+    
+    this.test_coalesced_output = function (msg, code, expected) {
+        this.then(function () {
+            this.echo("Test coalesced output: " + msg);
+        });
+        
+        this.thenEvaluate(function (code) {
+            IPython.notebook.insert_cell_at_index(0, "code");
+            var cell = IPython.notebook.get_cell(0);
+            cell.set_text(code);
+            cell.execute();
+        }, {code: code});
+        
+        this.wait_for_output(0);
+        
+        this.then(function () {
+            var results = this.evaluate(function () {
+                var cell = IPython.notebook.get_cell(0);
+                return cell.output_area.outputs;
+            });
+            this.test.assertEquals(results.length, expected.length, "correct number of outputs");
+            for (var i = 0; i < results.length; i++) {
+                var r = results[i];
+                var ex = expected[i];
+                this.test.assertEquals(r.output_type, ex.output_type, "output  " + i);
+                if (r.output_type === 'stream') {
+                    this.test.assertEquals(r.stream, ex.stream, "stream  " + i);
+                    this.test.assertEquals(r.text, ex.text, "content " + i);
+                }
+            }
+        });
+        
+    };
+    
+    this.thenEvaluate(function () {
+        IPython.notebook.insert_cell_at_index(0, "code");
+        var cell = IPython.notebook.get_cell(0);
+        cell.set_text([
+            "from __future__ import print_function",
+            "import sys",
+            "from IPython.display import display"
+            ].join("\n")
+        );
+        cell.execute();
+    });
+    
+    this.test_coalesced_output("stdout", [
+        "print(1)",
+        "sys.stdout.flush()",
+        "print(2)",
+        "sys.stdout.flush()",
+        "print(3)"
+        ].join("\n"), [{
+            output_type: "stream",
+            stream: "stdout",
+            text: "1\n2\n3\n"
+        }]
+    );
+    
+    this.test_coalesced_output("stdout+sdterr", [
+        "print(1)",
+        "sys.stdout.flush()",
+        "print(2)",
+        "print(3, file=sys.stderr)"
+        ].join("\n"), [{
+            output_type: "stream",
+            stream: "stdout",
+            text: "1\n2\n"
+        },{
+            output_type: "stream",
+            stream: "stderr",
+            text: "3\n"
+        }]
+    );
+
+    this.test_coalesced_output("display splits streams", [
+        "print(1)",
+        "sys.stdout.flush()",
+        "display(2)",
+        "print(3)"
+        ].join("\n"), [{
+            output_type: "stream",
+            stream: "stdout",
+            text: "1\n"
+        },{
+            output_type: "display_data",
+        },{
+            output_type: "stream",
+            stream: "stdout",
+            text: "3\n"
+        }]
+    );
+});

--- a/IPython/html/tests/widgets/widget.js
+++ b/IPython/html/tests/widgets/widget.js
@@ -151,7 +151,7 @@ casper.notebook_test(function () {
         'display(textbox)\n' +
         'textbox.add_class("my-throttle-textbox")\n' +
         'def handle_change(name, old, new):\n' +
-        '    print(len(new))\n' +
+        '    display(len(new))\n' +
         '    time.sleep(0.5)\n' +
         'textbox.on_trait_change(handle_change, "value")\n' +
         'print(textbox.model_id)');
@@ -182,7 +182,7 @@ casper.notebook_test(function () {
         this.test.assert(outputs.length <= 5, 'Messages throttled.');
 
         // We also need to verify that the last state sent was correct.
-        var last_state = outputs[outputs.length-1].text;
-        this.test.assertEquals(last_state, "20\n", "Last state sent when throttling.");
+        var last_state = outputs[outputs.length-1]['text/plain'];
+        this.test.assertEquals(last_state, "20", "Last state sent when throttling.");
     });
 });

--- a/IPython/html/tests/widgets/widget_button.js
+++ b/IPython/html/tests/widgets/widget_button.js
@@ -8,14 +8,14 @@ casper.notebook_test(function () {
 
     var button_index = this.append_cell(
         'button = widgets.ButtonWidget(description="Title")\n' +
-        'display(button)\n'+
+        'display(button)\n' +
         'print("Success")\n' +
         'def handle_click(sender):\n' +
-        '    print("Clicked")\n' +
+        '    display("Clicked")\n' +
         'button.on_click(handle_click)');
     this.execute_cell_then(button_index, function(index){
 
-        this.test.assertEquals(this.get_output_cell(index).text, 'Success\n', 
+        this.test.assertEquals(this.get_output_cell(index).text, 'Success\n',
             'Create button cell executed with correct output.');
 
         this.test.assert(this.cell_element_exists(index, 
@@ -37,7 +37,7 @@ casper.notebook_test(function () {
     this.wait_for_output(button_index, 1);
 
     this.then(function () {
-        this.test.assertEquals(this.get_output_cell(button_index, 1).text, 'Clicked\n', 
+        this.test.assertEquals(this.get_output_cell(button_index, 1)['text/plain'], "'Clicked'",
             'Button click event fires.');
     });
 });

--- a/docs/source/whatsnew/pr/coalesce-streams.rst
+++ b/docs/source/whatsnew/pr/coalesce-streams.rst
@@ -1,0 +1,5 @@
+- Consecutive stream (stdout/stderr) output is merged into a single output
+  in the notebook document.
+  Previously, all output messages were preserved as separate output fields in the JSON.
+  Now, the same merge is applied to the stored output as the displayed output,
+  improving document load time for notebooks with many small outputs.


### PR DESCRIPTION
This merges consecutive outputs on one stream into a single output.

Essentially, it applies the same merging that we do visually to the content stored in the notebook document.

The result is a large performance improvement in load-time and file size for notebooks that have many calls to `sys.stdout.flush()`.
