### PR TITLE
don’t modify dict keys while iterating through them

### DIFF
--- a/IPython/utils/jsonutil.py
+++ b/IPython/utils/jsonutil.py
@@ -47,22 +47,18 @@ datetime.strptime("1", "%d")
 def rekey(dikt):
     """Rekey a dict that has been forced to use str keys where there should be
     ints by json."""
-    for k in dikt:
+    for k in list(dikt):
         if isinstance(k, string_types):
-            ik=fk=None
+            nk = None
             try:
-                ik = int(k)
+                nk = int(k)
             except ValueError:
                 try:
-                    fk = float(k)
+                    nk = float(k)
                 except ValueError:
                     continue
-            if ik is not None:
-                nk = ik
-            else:
-                nk = fk
             if nk in dikt:
-                raise KeyError("already have key %r"%nk)
+                raise KeyError("already have key %r" % nk)
             dikt[nk] = dikt.pop(k)
     return dikt
 

--- a/IPython/utils/tests/test_jsonutil.py
+++ b/IPython/utils/tests/test_jsonutil.py
@@ -64,6 +64,13 @@ def test():
         json.loads(json.dumps(out))
 
 
+def test_rekey():
+    # This could fail due to modifying the dict keys in-place on Python 3
+    d = { i:i for i in map(str, range(128)) }
+    d = jsonutil.rekey(d)
+    for key in d:
+        nt.assert_is_instance(key, int)
+
 
 def test_encode_images():
     # invalid data, but the header and footer are from real files


### PR DESCRIPTION
in `jsonutil.rekey`, which could prevent some keys from being modified during the iteration.

closes #5901

Fixes 'unorderable types' failure on Python 3 in test_client:

```
File "/usr/lib/python3.4/unittest/case.py", line 57, in testPartExecutor
    yield
File "/usr/lib/python3.4/unittest/case.py", line 574, in run
    testMethod()
File "/usr/local/lib/python3.4/site-packages/IPython/parallel/tests/test_client.py", line 193, in test_queue_status
    intkeys = sorted(intkeys)
unorderable types: int() < str()
```

ping @takluyver
