### PR TITLE
Port to fontawesome4

### DIFF
--- a/IPython/html/static/base/less/page.less
+++ b/IPython/html/static/base/less/page.less
@@ -93,3 +93,8 @@ span#login_widget {
     }
 }
 
+// less mixin to be sure to add the right class to get icons with font awesome.
+.icon(@ico){
+    .fa();
+    content: @ico;
+}

--- a/IPython/html/static/notebook/js/maintoolbar.js
+++ b/IPython/html/static/notebook/js/maintoolbar.js
@@ -35,7 +35,7 @@ define([
                 {
                     id : 'save_b',
                     label : 'Save and Checkpoint',
-                    icon : 'icon-save',
+                    icon : 'fa fa-save',
                     callback : function () {
                         that.notebook.save_checkpoint();
                         }
@@ -46,7 +46,7 @@ define([
                 {
                     id : 'insert_below_b',
                     label : 'Insert Cell Below',
-                    icon : 'icon-plus-sign',
+                    icon : 'fa fa-plus',
                     callback : function () {
                         that.notebook.insert_cell_below('code');
                         that.notebook.select_next();
@@ -59,7 +59,7 @@ define([
                 {
                     id : 'cut_b',
                     label : 'Cut Cell',
-                    icon : 'icon-cut',
+                    icon : 'fa fa-cut',
                     callback : function () {
                         that.notebook.cut_cell();
                         }
@@ -67,7 +67,7 @@ define([
                 {
                     id : 'copy_b',
                     label : 'Copy Cell',
-                    icon : 'icon-copy',
+                    icon : 'fa fa-copy',
                     callback : function () {
                         that.notebook.copy_cell();
                         }
@@ -75,7 +75,7 @@ define([
                 {
                     id : 'paste_b',
                     label : 'Paste Cell Below',
-                    icon : 'icon-paste',
+                    icon : 'fa fa-paste',
                     callback : function () {
                         that.notebook.paste_cell_below();
                         }
@@ -86,7 +86,7 @@ define([
                 {
                     id : 'move_up_b',
                     label : 'Move Cell Up',
-                    icon : 'icon-arrow-up',
+                    icon : 'fa fa-arrow-up',
                     callback : function () {
                         that.notebook.move_cell_up();
                         }
@@ -94,7 +94,7 @@ define([
                 {
                     id : 'move_down_b',
                     label : 'Move Cell Down',
-                    icon : 'icon-arrow-down',
+                    icon : 'fa fa-arrow-down',
                     callback : function () {
                         that.notebook.move_cell_down();
                         }
@@ -106,7 +106,7 @@ define([
                 {
                     id : 'run_b',
                     label : 'Run Cell',
-                    icon : 'icon-play',
+                    icon : 'fa fa-play',
                     callback : function () {
                         // emulate default shift-enter behavior
                         that.notebook.execute_cell_and_select_below();
@@ -115,7 +115,7 @@ define([
                 {
                     id : 'interrupt_b',
                     label : 'Interrupt',
-                    icon : 'icon-stop',
+                    icon : 'fa fa-stop',
                     callback : function () {
                         that.notebook.session.interrupt_kernel();
                         }
@@ -123,7 +123,7 @@ define([
                 {
                     id : 'repeat_b',
                     label : 'Restart Kernel',
-                    icon : 'icon-repeat',
+                    icon : 'fa fa-repeat',
                     callback : function () {
                         that.notebook.restart_kernel();
                         }

--- a/IPython/html/static/notebook/js/maintoolbar.js
+++ b/IPython/html/static/notebook/js/maintoolbar.js
@@ -35,7 +35,7 @@ define([
                 {
                     id : 'save_b',
                     label : 'Save and Checkpoint',
-                    icon : 'fa fa-save',
+                    icon : 'fa-save',
                     callback : function () {
                         that.notebook.save_checkpoint();
                         }
@@ -46,7 +46,7 @@ define([
                 {
                     id : 'insert_below_b',
                     label : 'Insert Cell Below',
-                    icon : 'fa fa-plus',
+                    icon : 'fa-plus',
                     callback : function () {
                         that.notebook.insert_cell_below('code');
                         that.notebook.select_next();
@@ -59,7 +59,7 @@ define([
                 {
                     id : 'cut_b',
                     label : 'Cut Cell',
-                    icon : 'fa fa-cut',
+                    icon : 'fa-cut',
                     callback : function () {
                         that.notebook.cut_cell();
                         }
@@ -67,7 +67,7 @@ define([
                 {
                     id : 'copy_b',
                     label : 'Copy Cell',
-                    icon : 'fa fa-copy',
+                    icon : 'fa-copy',
                     callback : function () {
                         that.notebook.copy_cell();
                         }
@@ -75,7 +75,7 @@ define([
                 {
                     id : 'paste_b',
                     label : 'Paste Cell Below',
-                    icon : 'fa fa-paste',
+                    icon : 'fa-paste',
                     callback : function () {
                         that.notebook.paste_cell_below();
                         }
@@ -86,7 +86,7 @@ define([
                 {
                     id : 'move_up_b',
                     label : 'Move Cell Up',
-                    icon : 'fa fa-arrow-up',
+                    icon : 'fa-arrow-up',
                     callback : function () {
                         that.notebook.move_cell_up();
                         }
@@ -94,7 +94,7 @@ define([
                 {
                     id : 'move_down_b',
                     label : 'Move Cell Down',
-                    icon : 'fa fa-arrow-down',
+                    icon : 'fa-arrow-down',
                     callback : function () {
                         that.notebook.move_cell_down();
                         }
@@ -106,7 +106,7 @@ define([
                 {
                     id : 'run_b',
                     label : 'Run Cell',
-                    icon : 'fa fa-play',
+                    icon : 'fa-play',
                     callback : function () {
                         // emulate default shift-enter behavior
                         that.notebook.execute_cell_and_select_below();
@@ -115,7 +115,7 @@ define([
                 {
                     id : 'interrupt_b',
                     label : 'Interrupt',
-                    icon : 'fa fa-stop',
+                    icon : 'fa-stop',
                     callback : function () {
                         that.notebook.session.interrupt_kernel();
                         }
@@ -123,7 +123,7 @@ define([
                 {
                     id : 'repeat_b',
                     label : 'Restart Kernel',
-                    icon : 'fa fa-repeat',
+                    icon : 'fa-repeat',
                     callback : function () {
                         that.notebook.restart_kernel();
                         }

--- a/IPython/html/static/notebook/js/toolbar.js
+++ b/IPython/html/static/notebook/js/toolbar.js
@@ -66,7 +66,7 @@ define([
                 .addClass('btn btn-default')
                 .attr("title", el.label)
                 .append(
-                    $("<i/>").addClass(el.icon)
+                    $("<i/>").addClass(el.icon).addClass('fa')
                 );
             var id = el.id;
             if( id !== undefined )

--- a/IPython/html/static/notebook/less/notificationarea.less
+++ b/IPython/html/static/notebook/less/notificationarea.less
@@ -28,19 +28,19 @@
 }
 
 .edit_mode_icon:before {
-     .icon(@pencil);
+     content: @fa-var-pencil;
 }
 
 .command_mode_icon:before {
-     .icon(' ');
+     content: ' ';
 }
 
 .kernel_idle_icon:before {
-     .icon(@circle-blank);
+     content: @fa-var-circle-o;
 }
 
 .kernel_busy_icon:before {
-     .icon(@circle);
+     content: @fa-var-circle;
 }
 
 

--- a/IPython/html/static/notebook/less/notificationarea.less
+++ b/IPython/html/static/notebook/less/notificationarea.less
@@ -28,19 +28,19 @@
 }
 
 .edit_mode_icon:before {
-     content: @fa-var-pencil;
+    .icon(@fa-var-pencil)
 }
 
 .command_mode_icon:before {
-     content: ' ';
+    .icon(' ');
 }
 
 .kernel_idle_icon:before {
-     content: @fa-var-circle-o;
+    .icon(@fa-var-circle-o);
 }
 
 .kernel_busy_icon:before {
-     content: @fa-var-circle;
+    .icon(@fa-var-circle);
 }
 
 

--- a/IPython/html/static/style/style.less
+++ b/IPython/html/static/style/style.less
@@ -12,7 +12,7 @@
 *
 */
 @import "../components/font-awesome/less/font-awesome.less";
-@FontAwesomePath:    "../components/font-awesome/font";
+@FontAwesomePath:    "../components/font-awesome/fonts";
 
 // base
 @import "../base/less/style.less";

--- a/IPython/html/static/style/style.less
+++ b/IPython/html/static/style/style.less
@@ -12,7 +12,7 @@
 *
 */
 @import "../components/font-awesome/less/font-awesome.less";
-@FontAwesomePath:    "../components/font-awesome/fonts";
+@fa-font-path:    "../components/font-awesome/fonts";
 
 // base
 @import "../base/less/style.less";

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -5785,147 +5785,71 @@ button.close {
 *
 */
 /*!
- *  Font Awesome 3.2.1
- *  the iconic font designed for Bootstrap
- *  ------------------------------------------------------------------------------
- *  The full suite of pictographic icons, examples, and documentation can be
- *  found at http://fontawesome.io.  Stay up to date on Twitter at
- *  http://twitter.com/fontawesome.
- *
- *  License
- *  ------------------------------------------------------------------------------
- *  - The Font Awesome font is licensed under SIL OFL 1.1 -
- *    http://scripts.sil.org/OFL
- *  - Font Awesome CSS, LESS, and SASS files are licensed under MIT License -
- *    http://opensource.org/licenses/mit-license.html
- *  - Font Awesome documentation licensed under CC BY 3.0 -
- *    http://creativecommons.org/licenses/by/3.0/
- *  - Attribution is no longer required in Font Awesome 3.0, but much appreciated:
- *    "Font Awesome by Dave Gandy - http://fontawesome.io"
- *
- *  Author - Dave Gandy
- *  ------------------------------------------------------------------------------
- *  Email: dave@fontawesome.io
- *  Twitter: http://twitter.com/davegandy
- *  Work: Lead Product Designer @ Kyruus - http://kyruus.com
+ *  Font Awesome 4.1.0 by @davegandy - http://fontawesome.io - @fontawesome
+ *  License - http://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT License)
  */
 /* FONT PATH
  * -------------------------- */
 @font-face {
   font-family: 'FontAwesome';
-  src: url('../components/font-awesome/font/fontawesome-webfont.eot?v=3.2.1');
-  src: url('../components/font-awesome/font/fontawesome-webfont.eot?#iefix&v=3.2.1') format('embedded-opentype'), url('../components/font-awesome/font/fontawesome-webfont.woff?v=3.2.1') format('woff'), url('../components/font-awesome/font/fontawesome-webfont.ttf?v=3.2.1') format('truetype'), url('../components/font-awesome/font/fontawesome-webfont.svg#fontawesomeregular?v=3.2.1') format('svg');
+  src: url('../components/font-awesome/fonts/fontawesome-webfont.eot?v=4.1.0');
+  src: url('../components/font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=4.1.0') format('embedded-opentype'), url('../components/font-awesome/fonts/fontawesome-webfont.woff?v=4.1.0') format('woff'), url('../components/font-awesome/fonts/fontawesome-webfont.ttf?v=4.1.0') format('truetype'), url('../components/font-awesome/fonts/fontawesome-webfont.svg?v=4.1.0#fontawesomeregular') format('svg');
   font-weight: normal;
   font-style: normal;
 }
-/* FONT AWESOME CORE
- * -------------------------- */
-[class^="icon-"],
-[class*=" icon-"] {
-  font-family: FontAwesome;
-  font-weight: normal;
-  font-style: normal;
-  text-decoration: inherit;
-  -webkit-font-smoothing: antialiased;
-  *margin-right: .3em;
-}
-[class^="icon-"]:before,
-[class*=" icon-"]:before {
-  text-decoration: inherit;
+.fa {
   display: inline-block;
-  speak: none;
+  font-family: FontAwesome;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 /* makes the font 33% larger relative to the icon container */
-.icon-large:before {
-  vertical-align: -10%;
+.fa-lg {
   font-size: 1.33333333em;
+  line-height: 0.75em;
+  vertical-align: -15%;
 }
-/* makes sure icons active on rollover in links */
-a [class^="icon-"],
-a [class*=" icon-"] {
-  display: inline;
+.fa-2x {
+  font-size: 2em;
 }
-/* increased font size for icon-large */
-[class^="icon-"].icon-fixed-width,
-[class*=" icon-"].icon-fixed-width {
-  display: inline-block;
-  width: 1.14285714em;
-  text-align: right;
-  padding-right: 0.28571429em;
+.fa-3x {
+  font-size: 3em;
 }
-[class^="icon-"].icon-fixed-width.icon-large,
-[class*=" icon-"].icon-fixed-width.icon-large {
-  width: 1.42857143em;
+.fa-4x {
+  font-size: 4em;
 }
-.icons-ul {
+.fa-5x {
+  font-size: 5em;
+}
+.fa-fw {
+  width: 1.28571429em;
+  text-align: center;
+}
+.fa-ul {
+  padding-left: 0;
   margin-left: 2.14285714em;
   list-style-type: none;
 }
-.icons-ul > li {
+.fa-ul > li {
   position: relative;
 }
-.icons-ul .icon-li {
+.fa-li {
   position: absolute;
   left: -2.14285714em;
   width: 2.14285714em;
+  top: 0.14285714em;
   text-align: center;
-  line-height: inherit;
 }
-[class^="icon-"].hide,
-[class*=" icon-"].hide {
-  display: none;
+.fa-li.fa-lg {
+  left: -1.85714286em;
 }
-.icon-muted {
-  color: #eeeeee;
-}
-.icon-light {
-  color: #ffffff;
-}
-.icon-dark {
-  color: #333333;
-}
-.icon-border {
-  border: solid 1px #eeeeee;
+.fa-border {
   padding: .2em .25em .15em;
-  -webkit-border-radius: 3px;
-  -moz-border-radius: 3px;
-  border-radius: 3px;
-}
-.icon-2x {
-  font-size: 2em;
-}
-.icon-2x.icon-border {
-  border-width: 2px;
-  -webkit-border-radius: 4px;
-  -moz-border-radius: 4px;
-  border-radius: 4px;
-}
-.icon-3x {
-  font-size: 3em;
-}
-.icon-3x.icon-border {
-  border-width: 3px;
-  -webkit-border-radius: 5px;
-  -moz-border-radius: 5px;
-  border-radius: 5px;
-}
-.icon-4x {
-  font-size: 4em;
-}
-.icon-4x.icon-border {
-  border-width: 4px;
-  -webkit-border-radius: 6px;
-  -moz-border-radius: 6px;
-  border-radius: 6px;
-}
-.icon-5x {
-  font-size: 5em;
-}
-.icon-5x.icon-border {
-  border-width: 5px;
-  -webkit-border-radius: 7px;
-  -moz-border-radius: 7px;
-  border-radius: 7px;
+  border: solid 0.08em #eeeeee;
+  border-radius: .1em;
 }
 .pull-right {
   float: right;
@@ -5933,146 +5857,17 @@ a [class*=" icon-"] {
 .pull-left {
   float: left;
 }
-[class^="icon-"].pull-left,
-[class*=" icon-"].pull-left {
+.fa.pull-left {
   margin-right: .3em;
 }
-[class^="icon-"].pull-right,
-[class*=" icon-"].pull-right {
+.fa.pull-right {
   margin-left: .3em;
 }
-/* BOOTSTRAP SPECIFIC CLASSES
- * -------------------------- */
-/* Bootstrap 2.0 sprites.less reset */
-[class^="icon-"],
-[class*=" icon-"] {
-  display: inline;
-  width: auto;
-  height: auto;
-  line-height: normal;
-  vertical-align: baseline;
-  background-image: none;
-  background-position: 0% 0%;
-  background-repeat: repeat;
-  margin-top: 0;
-}
-/* more sprites.less reset */
-.icon-white,
-.nav-pills > .active > a > [class^="icon-"],
-.nav-pills > .active > a > [class*=" icon-"],
-.nav-list > .active > a > [class^="icon-"],
-.nav-list > .active > a > [class*=" icon-"],
-.navbar-inverse .nav > .active > a > [class^="icon-"],
-.navbar-inverse .nav > .active > a > [class*=" icon-"],
-.dropdown-menu > li > a:hover > [class^="icon-"],
-.dropdown-menu > li > a:hover > [class*=" icon-"],
-.dropdown-menu > .active > a > [class^="icon-"],
-.dropdown-menu > .active > a > [class*=" icon-"],
-.dropdown-submenu:hover > a > [class^="icon-"],
-.dropdown-submenu:hover > a > [class*=" icon-"] {
-  background-image: none;
-}
-/* keeps Bootstrap styles with and without icons the same */
-.btn [class^="icon-"].icon-large,
-.nav [class^="icon-"].icon-large,
-.btn [class*=" icon-"].icon-large,
-.nav [class*=" icon-"].icon-large {
-  line-height: .9em;
-}
-.btn [class^="icon-"].icon-spin,
-.nav [class^="icon-"].icon-spin,
-.btn [class*=" icon-"].icon-spin,
-.nav [class*=" icon-"].icon-spin {
-  display: inline-block;
-}
-.nav-tabs [class^="icon-"],
-.nav-pills [class^="icon-"],
-.nav-tabs [class*=" icon-"],
-.nav-pills [class*=" icon-"],
-.nav-tabs [class^="icon-"].icon-large,
-.nav-pills [class^="icon-"].icon-large,
-.nav-tabs [class*=" icon-"].icon-large,
-.nav-pills [class*=" icon-"].icon-large {
-  line-height: .9em;
-}
-.btn [class^="icon-"].pull-left.icon-2x,
-.btn [class*=" icon-"].pull-left.icon-2x,
-.btn [class^="icon-"].pull-right.icon-2x,
-.btn [class*=" icon-"].pull-right.icon-2x {
-  margin-top: .18em;
-}
-.btn [class^="icon-"].icon-spin.icon-large,
-.btn [class*=" icon-"].icon-spin.icon-large {
-  line-height: .8em;
-}
-.btn.btn-small [class^="icon-"].pull-left.icon-2x,
-.btn.btn-small [class*=" icon-"].pull-left.icon-2x,
-.btn.btn-small [class^="icon-"].pull-right.icon-2x,
-.btn.btn-small [class*=" icon-"].pull-right.icon-2x {
-  margin-top: .25em;
-}
-.btn.btn-large [class^="icon-"],
-.btn.btn-large [class*=" icon-"] {
-  margin-top: 0;
-}
-.btn.btn-large [class^="icon-"].pull-left.icon-2x,
-.btn.btn-large [class*=" icon-"].pull-left.icon-2x,
-.btn.btn-large [class^="icon-"].pull-right.icon-2x,
-.btn.btn-large [class*=" icon-"].pull-right.icon-2x {
-  margin-top: .05em;
-}
-.btn.btn-large [class^="icon-"].pull-left.icon-2x,
-.btn.btn-large [class*=" icon-"].pull-left.icon-2x {
-  margin-right: .2em;
-}
-.btn.btn-large [class^="icon-"].pull-right.icon-2x,
-.btn.btn-large [class*=" icon-"].pull-right.icon-2x {
-  margin-left: .2em;
-}
-/* Fixes alignment in nav lists */
-.nav-list [class^="icon-"],
-.nav-list [class*=" icon-"] {
-  line-height: inherit;
-}
-/* EXTRAS
- * -------------------------- */
-/* Stacked and layered icon */
-.icon-stack {
-  position: relative;
-  display: inline-block;
-  width: 2em;
-  height: 2em;
-  line-height: 2em;
-  vertical-align: -35%;
-}
-.icon-stack [class^="icon-"],
-.icon-stack [class*=" icon-"] {
-  display: block;
-  text-align: center;
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  font-size: 1em;
-  line-height: inherit;
-  *line-height: 2em;
-}
-.icon-stack .icon-stack-base {
-  font-size: 2em;
-  *line-height: 1em;
-}
-/* Animated rotating icon */
-.icon-spin {
-  display: inline-block;
+.fa-spin {
+  -webkit-animation: spin 2s infinite linear;
   -moz-animation: spin 2s infinite linear;
   -o-animation: spin 2s infinite linear;
-  -webkit-animation: spin 2s infinite linear;
   animation: spin 2s infinite linear;
-}
-/* Prevent stack and spinners from being taken inline when inside a link */
-a .icon-stack,
-a .icon-spin {
-  display: inline-block;
-  text-decoration: none;
 }
 @-moz-keyframes spin {
   0% {
@@ -6098,1170 +5893,1462 @@ a .icon-spin {
     -o-transform: rotate(359deg);
   }
 }
-@-ms-keyframes spin {
-  0% {
-    -ms-transform: rotate(0deg);
-  }
-  100% {
-    -ms-transform: rotate(359deg);
-  }
-}
 @keyframes spin {
   0% {
+    -webkit-transform: rotate(0deg);
     transform: rotate(0deg);
   }
   100% {
+    -webkit-transform: rotate(359deg);
     transform: rotate(359deg);
   }
 }
-/* Icon rotations and mirroring */
-.icon-rotate-90:before {
+.fa-rotate-90 {
+  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=1);
   -webkit-transform: rotate(90deg);
   -moz-transform: rotate(90deg);
   -ms-transform: rotate(90deg);
   -o-transform: rotate(90deg);
   transform: rotate(90deg);
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=1);
 }
-.icon-rotate-180:before {
+.fa-rotate-180 {
+  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
   -webkit-transform: rotate(180deg);
   -moz-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   -o-transform: rotate(180deg);
   transform: rotate(180deg);
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
 }
-.icon-rotate-270:before {
+.fa-rotate-270 {
+  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
   -webkit-transform: rotate(270deg);
   -moz-transform: rotate(270deg);
   -ms-transform: rotate(270deg);
   -o-transform: rotate(270deg);
   transform: rotate(270deg);
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
 }
-.icon-flip-horizontal:before {
+.fa-flip-horizontal {
+  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1);
   -webkit-transform: scale(-1, 1);
   -moz-transform: scale(-1, 1);
   -ms-transform: scale(-1, 1);
   -o-transform: scale(-1, 1);
   transform: scale(-1, 1);
 }
-.icon-flip-vertical:before {
+.fa-flip-vertical {
+  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1);
   -webkit-transform: scale(1, -1);
   -moz-transform: scale(1, -1);
   -ms-transform: scale(1, -1);
   -o-transform: scale(1, -1);
   transform: scale(1, -1);
 }
-/* ensure rotation occurs inside anchor tags */
-a .icon-rotate-90:before,
-a .icon-rotate-180:before,
-a .icon-rotate-270:before,
-a .icon-flip-horizontal:before,
-a .icon-flip-vertical:before {
+.fa-stack {
+  position: relative;
   display: inline-block;
+  width: 2em;
+  height: 2em;
+  line-height: 2em;
+  vertical-align: middle;
+}
+.fa-stack-1x,
+.fa-stack-2x {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  text-align: center;
+}
+.fa-stack-1x {
+  line-height: inherit;
+}
+.fa-stack-2x {
+  font-size: 2em;
+}
+.fa-inverse {
+  color: #ffffff;
 }
 /* Font Awesome uses the Unicode Private Use Area (PUA) to ensure screen
    readers do not read off random characters that represent icons */
-.icon-glass:before {
+.fa-glass:before {
   content: "\f000";
 }
-.icon-music:before {
+.fa-music:before {
   content: "\f001";
 }
-.icon-search:before {
+.fa-search:before {
   content: "\f002";
 }
-.icon-envelope-alt:before {
+.fa-envelope-o:before {
   content: "\f003";
 }
-.icon-heart:before {
+.fa-heart:before {
   content: "\f004";
 }
-.icon-star:before {
+.fa-star:before {
   content: "\f005";
 }
-.icon-star-empty:before {
+.fa-star-o:before {
   content: "\f006";
 }
-.icon-user:before {
+.fa-user:before {
   content: "\f007";
 }
-.icon-film:before {
+.fa-film:before {
   content: "\f008";
 }
-.icon-th-large:before {
+.fa-th-large:before {
   content: "\f009";
 }
-.icon-th:before {
+.fa-th:before {
   content: "\f00a";
 }
-.icon-th-list:before {
+.fa-th-list:before {
   content: "\f00b";
 }
-.icon-ok:before {
+.fa-check:before {
   content: "\f00c";
 }
-.icon-remove:before {
+.fa-times:before {
   content: "\f00d";
 }
-.icon-zoom-in:before {
+.fa-search-plus:before {
   content: "\f00e";
 }
-.icon-zoom-out:before {
+.fa-search-minus:before {
   content: "\f010";
 }
-.icon-power-off:before,
-.icon-off:before {
+.fa-power-off:before {
   content: "\f011";
 }
-.icon-signal:before {
+.fa-signal:before {
   content: "\f012";
 }
-.icon-gear:before,
-.icon-cog:before {
+.fa-gear:before,
+.fa-cog:before {
   content: "\f013";
 }
-.icon-trash:before {
+.fa-trash-o:before {
   content: "\f014";
 }
-.icon-home:before {
+.fa-home:before {
   content: "\f015";
 }
-.icon-file-alt:before {
+.fa-file-o:before {
   content: "\f016";
 }
-.icon-time:before {
+.fa-clock-o:before {
   content: "\f017";
 }
-.icon-road:before {
+.fa-road:before {
   content: "\f018";
 }
-.icon-download-alt:before {
+.fa-download:before {
   content: "\f019";
 }
-.icon-download:before {
+.fa-arrow-circle-o-down:before {
   content: "\f01a";
 }
-.icon-upload:before {
+.fa-arrow-circle-o-up:before {
   content: "\f01b";
 }
-.icon-inbox:before {
+.fa-inbox:before {
   content: "\f01c";
 }
-.icon-play-circle:before {
+.fa-play-circle-o:before {
   content: "\f01d";
 }
-.icon-rotate-right:before,
-.icon-repeat:before {
+.fa-rotate-right:before,
+.fa-repeat:before {
   content: "\f01e";
 }
-.icon-refresh:before {
+.fa-refresh:before {
   content: "\f021";
 }
-.icon-list-alt:before {
+.fa-list-alt:before {
   content: "\f022";
 }
-.icon-lock:before {
+.fa-lock:before {
   content: "\f023";
 }
-.icon-flag:before {
+.fa-flag:before {
   content: "\f024";
 }
-.icon-headphones:before {
+.fa-headphones:before {
   content: "\f025";
 }
-.icon-volume-off:before {
+.fa-volume-off:before {
   content: "\f026";
 }
-.icon-volume-down:before {
+.fa-volume-down:before {
   content: "\f027";
 }
-.icon-volume-up:before {
+.fa-volume-up:before {
   content: "\f028";
 }
-.icon-qrcode:before {
+.fa-qrcode:before {
   content: "\f029";
 }
-.icon-barcode:before {
+.fa-barcode:before {
   content: "\f02a";
 }
-.icon-tag:before {
+.fa-tag:before {
   content: "\f02b";
 }
-.icon-tags:before {
+.fa-tags:before {
   content: "\f02c";
 }
-.icon-book:before {
+.fa-book:before {
   content: "\f02d";
 }
-.icon-bookmark:before {
+.fa-bookmark:before {
   content: "\f02e";
 }
-.icon-print:before {
+.fa-print:before {
   content: "\f02f";
 }
-.icon-camera:before {
+.fa-camera:before {
   content: "\f030";
 }
-.icon-font:before {
+.fa-font:before {
   content: "\f031";
 }
-.icon-bold:before {
+.fa-bold:before {
   content: "\f032";
 }
-.icon-italic:before {
+.fa-italic:before {
   content: "\f033";
 }
-.icon-text-height:before {
+.fa-text-height:before {
   content: "\f034";
 }
-.icon-text-width:before {
+.fa-text-width:before {
   content: "\f035";
 }
-.icon-align-left:before {
+.fa-align-left:before {
   content: "\f036";
 }
-.icon-align-center:before {
+.fa-align-center:before {
   content: "\f037";
 }
-.icon-align-right:before {
+.fa-align-right:before {
   content: "\f038";
 }
-.icon-align-justify:before {
+.fa-align-justify:before {
   content: "\f039";
 }
-.icon-list:before {
+.fa-list:before {
   content: "\f03a";
 }
-.icon-indent-left:before {
+.fa-dedent:before,
+.fa-outdent:before {
   content: "\f03b";
 }
-.icon-indent-right:before {
+.fa-indent:before {
   content: "\f03c";
 }
-.icon-facetime-video:before {
+.fa-video-camera:before {
   content: "\f03d";
 }
-.icon-picture:before {
+.fa-photo:before,
+.fa-image:before,
+.fa-picture-o:before {
   content: "\f03e";
 }
-.icon-pencil:before {
+.fa-pencil:before {
   content: "\f040";
 }
-.icon-map-marker:before {
+.fa-map-marker:before {
   content: "\f041";
 }
-.icon-adjust:before {
+.fa-adjust:before {
   content: "\f042";
 }
-.icon-tint:before {
+.fa-tint:before {
   content: "\f043";
 }
-.icon-edit:before {
+.fa-edit:before,
+.fa-pencil-square-o:before {
   content: "\f044";
 }
-.icon-share:before {
+.fa-share-square-o:before {
   content: "\f045";
 }
-.icon-check:before {
+.fa-check-square-o:before {
   content: "\f046";
 }
-.icon-move:before {
+.fa-arrows:before {
   content: "\f047";
 }
-.icon-step-backward:before {
+.fa-step-backward:before {
   content: "\f048";
 }
-.icon-fast-backward:before {
+.fa-fast-backward:before {
   content: "\f049";
 }
-.icon-backward:before {
+.fa-backward:before {
   content: "\f04a";
 }
-.icon-play:before {
+.fa-play:before {
   content: "\f04b";
 }
-.icon-pause:before {
+.fa-pause:before {
   content: "\f04c";
 }
-.icon-stop:before {
+.fa-stop:before {
   content: "\f04d";
 }
-.icon-forward:before {
+.fa-forward:before {
   content: "\f04e";
 }
-.icon-fast-forward:before {
+.fa-fast-forward:before {
   content: "\f050";
 }
-.icon-step-forward:before {
+.fa-step-forward:before {
   content: "\f051";
 }
-.icon-eject:before {
+.fa-eject:before {
   content: "\f052";
 }
-.icon-chevron-left:before {
+.fa-chevron-left:before {
   content: "\f053";
 }
-.icon-chevron-right:before {
+.fa-chevron-right:before {
   content: "\f054";
 }
-.icon-plus-sign:before {
+.fa-plus-circle:before {
   content: "\f055";
 }
-.icon-minus-sign:before {
+.fa-minus-circle:before {
   content: "\f056";
 }
-.icon-remove-sign:before {
+.fa-times-circle:before {
   content: "\f057";
 }
-.icon-ok-sign:before {
+.fa-check-circle:before {
   content: "\f058";
 }
-.icon-question-sign:before {
+.fa-question-circle:before {
   content: "\f059";
 }
-.icon-info-sign:before {
+.fa-info-circle:before {
   content: "\f05a";
 }
-.icon-screenshot:before {
+.fa-crosshairs:before {
   content: "\f05b";
 }
-.icon-remove-circle:before {
+.fa-times-circle-o:before {
   content: "\f05c";
 }
-.icon-ok-circle:before {
+.fa-check-circle-o:before {
   content: "\f05d";
 }
-.icon-ban-circle:before {
+.fa-ban:before {
   content: "\f05e";
 }
-.icon-arrow-left:before {
+.fa-arrow-left:before {
   content: "\f060";
 }
-.icon-arrow-right:before {
+.fa-arrow-right:before {
   content: "\f061";
 }
-.icon-arrow-up:before {
+.fa-arrow-up:before {
   content: "\f062";
 }
-.icon-arrow-down:before {
+.fa-arrow-down:before {
   content: "\f063";
 }
-.icon-mail-forward:before,
-.icon-share-alt:before {
+.fa-mail-forward:before,
+.fa-share:before {
   content: "\f064";
 }
-.icon-resize-full:before {
+.fa-expand:before {
   content: "\f065";
 }
-.icon-resize-small:before {
+.fa-compress:before {
   content: "\f066";
 }
-.icon-plus:before {
+.fa-plus:before {
   content: "\f067";
 }
-.icon-minus:before {
+.fa-minus:before {
   content: "\f068";
 }
-.icon-asterisk:before {
+.fa-asterisk:before {
   content: "\f069";
 }
-.icon-exclamation-sign:before {
+.fa-exclamation-circle:before {
   content: "\f06a";
 }
-.icon-gift:before {
+.fa-gift:before {
   content: "\f06b";
 }
-.icon-leaf:before {
+.fa-leaf:before {
   content: "\f06c";
 }
-.icon-fire:before {
+.fa-fire:before {
   content: "\f06d";
 }
-.icon-eye-open:before {
+.fa-eye:before {
   content: "\f06e";
 }
-.icon-eye-close:before {
+.fa-eye-slash:before {
   content: "\f070";
 }
-.icon-warning-sign:before {
+.fa-warning:before,
+.fa-exclamation-triangle:before {
   content: "\f071";
 }
-.icon-plane:before {
+.fa-plane:before {
   content: "\f072";
 }
-.icon-calendar:before {
+.fa-calendar:before {
   content: "\f073";
 }
-.icon-random:before {
+.fa-random:before {
   content: "\f074";
 }
-.icon-comment:before {
+.fa-comment:before {
   content: "\f075";
 }
-.icon-magnet:before {
+.fa-magnet:before {
   content: "\f076";
 }
-.icon-chevron-up:before {
+.fa-chevron-up:before {
   content: "\f077";
 }
-.icon-chevron-down:before {
+.fa-chevron-down:before {
   content: "\f078";
 }
-.icon-retweet:before {
+.fa-retweet:before {
   content: "\f079";
 }
-.icon-shopping-cart:before {
+.fa-shopping-cart:before {
   content: "\f07a";
 }
-.icon-folder-close:before {
+.fa-folder:before {
   content: "\f07b";
 }
-.icon-folder-open:before {
+.fa-folder-open:before {
   content: "\f07c";
 }
-.icon-resize-vertical:before {
+.fa-arrows-v:before {
   content: "\f07d";
 }
-.icon-resize-horizontal:before {
+.fa-arrows-h:before {
   content: "\f07e";
 }
-.icon-bar-chart:before {
+.fa-bar-chart-o:before {
   content: "\f080";
 }
-.icon-twitter-sign:before {
+.fa-twitter-square:before {
   content: "\f081";
 }
-.icon-facebook-sign:before {
+.fa-facebook-square:before {
   content: "\f082";
 }
-.icon-camera-retro:before {
+.fa-camera-retro:before {
   content: "\f083";
 }
-.icon-key:before {
+.fa-key:before {
   content: "\f084";
 }
-.icon-gears:before,
-.icon-cogs:before {
+.fa-gears:before,
+.fa-cogs:before {
   content: "\f085";
 }
-.icon-comments:before {
+.fa-comments:before {
   content: "\f086";
 }
-.icon-thumbs-up-alt:before {
+.fa-thumbs-o-up:before {
   content: "\f087";
 }
-.icon-thumbs-down-alt:before {
+.fa-thumbs-o-down:before {
   content: "\f088";
 }
-.icon-star-half:before {
+.fa-star-half:before {
   content: "\f089";
 }
-.icon-heart-empty:before {
+.fa-heart-o:before {
   content: "\f08a";
 }
-.icon-signout:before {
+.fa-sign-out:before {
   content: "\f08b";
 }
-.icon-linkedin-sign:before {
+.fa-linkedin-square:before {
   content: "\f08c";
 }
-.icon-pushpin:before {
+.fa-thumb-tack:before {
   content: "\f08d";
 }
-.icon-external-link:before {
+.fa-external-link:before {
   content: "\f08e";
 }
-.icon-signin:before {
+.fa-sign-in:before {
   content: "\f090";
 }
-.icon-trophy:before {
+.fa-trophy:before {
   content: "\f091";
 }
-.icon-github-sign:before {
+.fa-github-square:before {
   content: "\f092";
 }
-.icon-upload-alt:before {
+.fa-upload:before {
   content: "\f093";
 }
-.icon-lemon:before {
+.fa-lemon-o:before {
   content: "\f094";
 }
-.icon-phone:before {
+.fa-phone:before {
   content: "\f095";
 }
-.icon-unchecked:before,
-.icon-check-empty:before {
+.fa-square-o:before {
   content: "\f096";
 }
-.icon-bookmark-empty:before {
+.fa-bookmark-o:before {
   content: "\f097";
 }
-.icon-phone-sign:before {
+.fa-phone-square:before {
   content: "\f098";
 }
-.icon-twitter:before {
+.fa-twitter:before {
   content: "\f099";
 }
-.icon-facebook:before {
+.fa-facebook:before {
   content: "\f09a";
 }
-.icon-github:before {
+.fa-github:before {
   content: "\f09b";
 }
-.icon-unlock:before {
+.fa-unlock:before {
   content: "\f09c";
 }
-.icon-credit-card:before {
+.fa-credit-card:before {
   content: "\f09d";
 }
-.icon-rss:before {
+.fa-rss:before {
   content: "\f09e";
 }
-.icon-hdd:before {
+.fa-hdd-o:before {
   content: "\f0a0";
 }
-.icon-bullhorn:before {
+.fa-bullhorn:before {
   content: "\f0a1";
 }
-.icon-bell:before {
-  content: "\f0a2";
-}
-.icon-certificate:before {
-  content: "\f0a3";
-}
-.icon-hand-right:before {
-  content: "\f0a4";
-}
-.icon-hand-left:before {
-  content: "\f0a5";
-}
-.icon-hand-up:before {
-  content: "\f0a6";
-}
-.icon-hand-down:before {
-  content: "\f0a7";
-}
-.icon-circle-arrow-left:before {
-  content: "\f0a8";
-}
-.icon-circle-arrow-right:before {
-  content: "\f0a9";
-}
-.icon-circle-arrow-up:before {
-  content: "\f0aa";
-}
-.icon-circle-arrow-down:before {
-  content: "\f0ab";
-}
-.icon-globe:before {
-  content: "\f0ac";
-}
-.icon-wrench:before {
-  content: "\f0ad";
-}
-.icon-tasks:before {
-  content: "\f0ae";
-}
-.icon-filter:before {
-  content: "\f0b0";
-}
-.icon-briefcase:before {
-  content: "\f0b1";
-}
-.icon-fullscreen:before {
-  content: "\f0b2";
-}
-.icon-group:before {
-  content: "\f0c0";
-}
-.icon-link:before {
-  content: "\f0c1";
-}
-.icon-cloud:before {
-  content: "\f0c2";
-}
-.icon-beaker:before {
-  content: "\f0c3";
-}
-.icon-cut:before {
-  content: "\f0c4";
-}
-.icon-copy:before {
-  content: "\f0c5";
-}
-.icon-paperclip:before,
-.icon-paper-clip:before {
-  content: "\f0c6";
-}
-.icon-save:before {
-  content: "\f0c7";
-}
-.icon-sign-blank:before {
-  content: "\f0c8";
-}
-.icon-reorder:before {
-  content: "\f0c9";
-}
-.icon-list-ul:before {
-  content: "\f0ca";
-}
-.icon-list-ol:before {
-  content: "\f0cb";
-}
-.icon-strikethrough:before {
-  content: "\f0cc";
-}
-.icon-underline:before {
-  content: "\f0cd";
-}
-.icon-table:before {
-  content: "\f0ce";
-}
-.icon-magic:before {
-  content: "\f0d0";
-}
-.icon-truck:before {
-  content: "\f0d1";
-}
-.icon-pinterest:before {
-  content: "\f0d2";
-}
-.icon-pinterest-sign:before {
-  content: "\f0d3";
-}
-.icon-google-plus-sign:before {
-  content: "\f0d4";
-}
-.icon-google-plus:before {
-  content: "\f0d5";
-}
-.icon-money:before {
-  content: "\f0d6";
-}
-.icon-caret-down:before {
-  content: "\f0d7";
-}
-.icon-caret-up:before {
-  content: "\f0d8";
-}
-.icon-caret-left:before {
-  content: "\f0d9";
-}
-.icon-caret-right:before {
-  content: "\f0da";
-}
-.icon-columns:before {
-  content: "\f0db";
-}
-.icon-sort:before {
-  content: "\f0dc";
-}
-.icon-sort-down:before {
-  content: "\f0dd";
-}
-.icon-sort-up:before {
-  content: "\f0de";
-}
-.icon-envelope:before {
-  content: "\f0e0";
-}
-.icon-linkedin:before {
-  content: "\f0e1";
-}
-.icon-rotate-left:before,
-.icon-undo:before {
-  content: "\f0e2";
-}
-.icon-legal:before {
-  content: "\f0e3";
-}
-.icon-dashboard:before {
-  content: "\f0e4";
-}
-.icon-comment-alt:before {
-  content: "\f0e5";
-}
-.icon-comments-alt:before {
-  content: "\f0e6";
-}
-.icon-bolt:before {
-  content: "\f0e7";
-}
-.icon-sitemap:before {
-  content: "\f0e8";
-}
-.icon-umbrella:before {
-  content: "\f0e9";
-}
-.icon-paste:before {
-  content: "\f0ea";
-}
-.icon-lightbulb:before {
-  content: "\f0eb";
-}
-.icon-exchange:before {
-  content: "\f0ec";
-}
-.icon-cloud-download:before {
-  content: "\f0ed";
-}
-.icon-cloud-upload:before {
-  content: "\f0ee";
-}
-.icon-user-md:before {
-  content: "\f0f0";
-}
-.icon-stethoscope:before {
-  content: "\f0f1";
-}
-.icon-suitcase:before {
-  content: "\f0f2";
-}
-.icon-bell-alt:before {
+.fa-bell:before {
   content: "\f0f3";
 }
-.icon-coffee:before {
+.fa-certificate:before {
+  content: "\f0a3";
+}
+.fa-hand-o-right:before {
+  content: "\f0a4";
+}
+.fa-hand-o-left:before {
+  content: "\f0a5";
+}
+.fa-hand-o-up:before {
+  content: "\f0a6";
+}
+.fa-hand-o-down:before {
+  content: "\f0a7";
+}
+.fa-arrow-circle-left:before {
+  content: "\f0a8";
+}
+.fa-arrow-circle-right:before {
+  content: "\f0a9";
+}
+.fa-arrow-circle-up:before {
+  content: "\f0aa";
+}
+.fa-arrow-circle-down:before {
+  content: "\f0ab";
+}
+.fa-globe:before {
+  content: "\f0ac";
+}
+.fa-wrench:before {
+  content: "\f0ad";
+}
+.fa-tasks:before {
+  content: "\f0ae";
+}
+.fa-filter:before {
+  content: "\f0b0";
+}
+.fa-briefcase:before {
+  content: "\f0b1";
+}
+.fa-arrows-alt:before {
+  content: "\f0b2";
+}
+.fa-group:before,
+.fa-users:before {
+  content: "\f0c0";
+}
+.fa-chain:before,
+.fa-link:before {
+  content: "\f0c1";
+}
+.fa-cloud:before {
+  content: "\f0c2";
+}
+.fa-flask:before {
+  content: "\f0c3";
+}
+.fa-cut:before,
+.fa-scissors:before {
+  content: "\f0c4";
+}
+.fa-copy:before,
+.fa-files-o:before {
+  content: "\f0c5";
+}
+.fa-paperclip:before {
+  content: "\f0c6";
+}
+.fa-save:before,
+.fa-floppy-o:before {
+  content: "\f0c7";
+}
+.fa-square:before {
+  content: "\f0c8";
+}
+.fa-navicon:before,
+.fa-reorder:before,
+.fa-bars:before {
+  content: "\f0c9";
+}
+.fa-list-ul:before {
+  content: "\f0ca";
+}
+.fa-list-ol:before {
+  content: "\f0cb";
+}
+.fa-strikethrough:before {
+  content: "\f0cc";
+}
+.fa-underline:before {
+  content: "\f0cd";
+}
+.fa-table:before {
+  content: "\f0ce";
+}
+.fa-magic:before {
+  content: "\f0d0";
+}
+.fa-truck:before {
+  content: "\f0d1";
+}
+.fa-pinterest:before {
+  content: "\f0d2";
+}
+.fa-pinterest-square:before {
+  content: "\f0d3";
+}
+.fa-google-plus-square:before {
+  content: "\f0d4";
+}
+.fa-google-plus:before {
+  content: "\f0d5";
+}
+.fa-money:before {
+  content: "\f0d6";
+}
+.fa-caret-down:before {
+  content: "\f0d7";
+}
+.fa-caret-up:before {
+  content: "\f0d8";
+}
+.fa-caret-left:before {
+  content: "\f0d9";
+}
+.fa-caret-right:before {
+  content: "\f0da";
+}
+.fa-columns:before {
+  content: "\f0db";
+}
+.fa-unsorted:before,
+.fa-sort:before {
+  content: "\f0dc";
+}
+.fa-sort-down:before,
+.fa-sort-desc:before {
+  content: "\f0dd";
+}
+.fa-sort-up:before,
+.fa-sort-asc:before {
+  content: "\f0de";
+}
+.fa-envelope:before {
+  content: "\f0e0";
+}
+.fa-linkedin:before {
+  content: "\f0e1";
+}
+.fa-rotate-left:before,
+.fa-undo:before {
+  content: "\f0e2";
+}
+.fa-legal:before,
+.fa-gavel:before {
+  content: "\f0e3";
+}
+.fa-dashboard:before,
+.fa-tachometer:before {
+  content: "\f0e4";
+}
+.fa-comment-o:before {
+  content: "\f0e5";
+}
+.fa-comments-o:before {
+  content: "\f0e6";
+}
+.fa-flash:before,
+.fa-bolt:before {
+  content: "\f0e7";
+}
+.fa-sitemap:before {
+  content: "\f0e8";
+}
+.fa-umbrella:before {
+  content: "\f0e9";
+}
+.fa-paste:before,
+.fa-clipboard:before {
+  content: "\f0ea";
+}
+.fa-lightbulb-o:before {
+  content: "\f0eb";
+}
+.fa-exchange:before {
+  content: "\f0ec";
+}
+.fa-cloud-download:before {
+  content: "\f0ed";
+}
+.fa-cloud-upload:before {
+  content: "\f0ee";
+}
+.fa-user-md:before {
+  content: "\f0f0";
+}
+.fa-stethoscope:before {
+  content: "\f0f1";
+}
+.fa-suitcase:before {
+  content: "\f0f2";
+}
+.fa-bell-o:before {
+  content: "\f0a2";
+}
+.fa-coffee:before {
   content: "\f0f4";
 }
-.icon-food:before {
+.fa-cutlery:before {
   content: "\f0f5";
 }
-.icon-file-text-alt:before {
+.fa-file-text-o:before {
   content: "\f0f6";
 }
-.icon-building:before {
+.fa-building-o:before {
   content: "\f0f7";
 }
-.icon-hospital:before {
+.fa-hospital-o:before {
   content: "\f0f8";
 }
-.icon-ambulance:before {
+.fa-ambulance:before {
   content: "\f0f9";
 }
-.icon-medkit:before {
+.fa-medkit:before {
   content: "\f0fa";
 }
-.icon-fighter-jet:before {
+.fa-fighter-jet:before {
   content: "\f0fb";
 }
-.icon-beer:before {
+.fa-beer:before {
   content: "\f0fc";
 }
-.icon-h-sign:before {
+.fa-h-square:before {
   content: "\f0fd";
 }
-.icon-plus-sign-alt:before {
+.fa-plus-square:before {
   content: "\f0fe";
 }
-.icon-double-angle-left:before {
+.fa-angle-double-left:before {
   content: "\f100";
 }
-.icon-double-angle-right:before {
+.fa-angle-double-right:before {
   content: "\f101";
 }
-.icon-double-angle-up:before {
+.fa-angle-double-up:before {
   content: "\f102";
 }
-.icon-double-angle-down:before {
+.fa-angle-double-down:before {
   content: "\f103";
 }
-.icon-angle-left:before {
+.fa-angle-left:before {
   content: "\f104";
 }
-.icon-angle-right:before {
+.fa-angle-right:before {
   content: "\f105";
 }
-.icon-angle-up:before {
+.fa-angle-up:before {
   content: "\f106";
 }
-.icon-angle-down:before {
+.fa-angle-down:before {
   content: "\f107";
 }
-.icon-desktop:before {
+.fa-desktop:before {
   content: "\f108";
 }
-.icon-laptop:before {
+.fa-laptop:before {
   content: "\f109";
 }
-.icon-tablet:before {
+.fa-tablet:before {
   content: "\f10a";
 }
-.icon-mobile-phone:before {
+.fa-mobile-phone:before,
+.fa-mobile:before {
   content: "\f10b";
 }
-.icon-circle-blank:before {
+.fa-circle-o:before {
   content: "\f10c";
 }
-.icon-quote-left:before {
+.fa-quote-left:before {
   content: "\f10d";
 }
-.icon-quote-right:before {
+.fa-quote-right:before {
   content: "\f10e";
 }
-.icon-spinner:before {
+.fa-spinner:before {
   content: "\f110";
 }
-.icon-circle:before {
+.fa-circle:before {
   content: "\f111";
 }
-.icon-mail-reply:before,
-.icon-reply:before {
+.fa-mail-reply:before,
+.fa-reply:before {
   content: "\f112";
 }
-.icon-github-alt:before {
+.fa-github-alt:before {
   content: "\f113";
 }
-.icon-folder-close-alt:before {
+.fa-folder-o:before {
   content: "\f114";
 }
-.icon-folder-open-alt:before {
+.fa-folder-open-o:before {
   content: "\f115";
 }
-.icon-expand-alt:before {
-  content: "\f116";
-}
-.icon-collapse-alt:before {
-  content: "\f117";
-}
-.icon-smile:before {
+.fa-smile-o:before {
   content: "\f118";
 }
-.icon-frown:before {
+.fa-frown-o:before {
   content: "\f119";
 }
-.icon-meh:before {
+.fa-meh-o:before {
   content: "\f11a";
 }
-.icon-gamepad:before {
+.fa-gamepad:before {
   content: "\f11b";
 }
-.icon-keyboard:before {
+.fa-keyboard-o:before {
   content: "\f11c";
 }
-.icon-flag-alt:before {
+.fa-flag-o:before {
   content: "\f11d";
 }
-.icon-flag-checkered:before {
+.fa-flag-checkered:before {
   content: "\f11e";
 }
-.icon-terminal:before {
+.fa-terminal:before {
   content: "\f120";
 }
-.icon-code:before {
+.fa-code:before {
   content: "\f121";
 }
-.icon-reply-all:before {
+.fa-mail-reply-all:before,
+.fa-reply-all:before {
   content: "\f122";
 }
-.icon-mail-reply-all:before {
-  content: "\f122";
-}
-.icon-star-half-full:before,
-.icon-star-half-empty:before {
+.fa-star-half-empty:before,
+.fa-star-half-full:before,
+.fa-star-half-o:before {
   content: "\f123";
 }
-.icon-location-arrow:before {
+.fa-location-arrow:before {
   content: "\f124";
 }
-.icon-crop:before {
+.fa-crop:before {
   content: "\f125";
 }
-.icon-code-fork:before {
+.fa-code-fork:before {
   content: "\f126";
 }
-.icon-unlink:before {
+.fa-unlink:before,
+.fa-chain-broken:before {
   content: "\f127";
 }
-.icon-question:before {
+.fa-question:before {
   content: "\f128";
 }
-.icon-info:before {
+.fa-info:before {
   content: "\f129";
 }
-.icon-exclamation:before {
+.fa-exclamation:before {
   content: "\f12a";
 }
-.icon-superscript:before {
+.fa-superscript:before {
   content: "\f12b";
 }
-.icon-subscript:before {
+.fa-subscript:before {
   content: "\f12c";
 }
-.icon-eraser:before {
+.fa-eraser:before {
   content: "\f12d";
 }
-.icon-puzzle-piece:before {
+.fa-puzzle-piece:before {
   content: "\f12e";
 }
-.icon-microphone:before {
+.fa-microphone:before {
   content: "\f130";
 }
-.icon-microphone-off:before {
+.fa-microphone-slash:before {
   content: "\f131";
 }
-.icon-shield:before {
+.fa-shield:before {
   content: "\f132";
 }
-.icon-calendar-empty:before {
+.fa-calendar-o:before {
   content: "\f133";
 }
-.icon-fire-extinguisher:before {
+.fa-fire-extinguisher:before {
   content: "\f134";
 }
-.icon-rocket:before {
+.fa-rocket:before {
   content: "\f135";
 }
-.icon-maxcdn:before {
+.fa-maxcdn:before {
   content: "\f136";
 }
-.icon-chevron-sign-left:before {
+.fa-chevron-circle-left:before {
   content: "\f137";
 }
-.icon-chevron-sign-right:before {
+.fa-chevron-circle-right:before {
   content: "\f138";
 }
-.icon-chevron-sign-up:before {
+.fa-chevron-circle-up:before {
   content: "\f139";
 }
-.icon-chevron-sign-down:before {
+.fa-chevron-circle-down:before {
   content: "\f13a";
 }
-.icon-html5:before {
+.fa-html5:before {
   content: "\f13b";
 }
-.icon-css3:before {
+.fa-css3:before {
   content: "\f13c";
 }
-.icon-anchor:before {
+.fa-anchor:before {
   content: "\f13d";
 }
-.icon-unlock-alt:before {
+.fa-unlock-alt:before {
   content: "\f13e";
 }
-.icon-bullseye:before {
+.fa-bullseye:before {
   content: "\f140";
 }
-.icon-ellipsis-horizontal:before {
+.fa-ellipsis-h:before {
   content: "\f141";
 }
-.icon-ellipsis-vertical:before {
+.fa-ellipsis-v:before {
   content: "\f142";
 }
-.icon-rss-sign:before {
+.fa-rss-square:before {
   content: "\f143";
 }
-.icon-play-sign:before {
+.fa-play-circle:before {
   content: "\f144";
 }
-.icon-ticket:before {
+.fa-ticket:before {
   content: "\f145";
 }
-.icon-minus-sign-alt:before {
+.fa-minus-square:before {
   content: "\f146";
 }
-.icon-check-minus:before {
+.fa-minus-square-o:before {
   content: "\f147";
 }
-.icon-level-up:before {
+.fa-level-up:before {
   content: "\f148";
 }
-.icon-level-down:before {
+.fa-level-down:before {
   content: "\f149";
 }
-.icon-check-sign:before {
+.fa-check-square:before {
   content: "\f14a";
 }
-.icon-edit-sign:before {
+.fa-pencil-square:before {
   content: "\f14b";
 }
-.icon-external-link-sign:before {
+.fa-external-link-square:before {
   content: "\f14c";
 }
-.icon-share-sign:before {
+.fa-share-square:before {
   content: "\f14d";
 }
-.icon-compass:before {
+.fa-compass:before {
   content: "\f14e";
 }
-.icon-collapse:before {
+.fa-toggle-down:before,
+.fa-caret-square-o-down:before {
   content: "\f150";
 }
-.icon-collapse-top:before {
+.fa-toggle-up:before,
+.fa-caret-square-o-up:before {
   content: "\f151";
 }
-.icon-expand:before {
+.fa-toggle-right:before,
+.fa-caret-square-o-right:before {
   content: "\f152";
 }
-.icon-euro:before,
-.icon-eur:before {
+.fa-euro:before,
+.fa-eur:before {
   content: "\f153";
 }
-.icon-gbp:before {
+.fa-gbp:before {
   content: "\f154";
 }
-.icon-dollar:before,
-.icon-usd:before {
+.fa-dollar:before,
+.fa-usd:before {
   content: "\f155";
 }
-.icon-rupee:before,
-.icon-inr:before {
+.fa-rupee:before,
+.fa-inr:before {
   content: "\f156";
 }
-.icon-yen:before,
-.icon-jpy:before {
+.fa-cny:before,
+.fa-rmb:before,
+.fa-yen:before,
+.fa-jpy:before {
   content: "\f157";
 }
-.icon-renminbi:before,
-.icon-cny:before {
+.fa-ruble:before,
+.fa-rouble:before,
+.fa-rub:before {
   content: "\f158";
 }
-.icon-won:before,
-.icon-krw:before {
+.fa-won:before,
+.fa-krw:before {
   content: "\f159";
 }
-.icon-bitcoin:before,
-.icon-btc:before {
+.fa-bitcoin:before,
+.fa-btc:before {
   content: "\f15a";
 }
-.icon-file:before {
+.fa-file:before {
   content: "\f15b";
 }
-.icon-file-text:before {
+.fa-file-text:before {
   content: "\f15c";
 }
-.icon-sort-by-alphabet:before {
+.fa-sort-alpha-asc:before {
   content: "\f15d";
 }
-.icon-sort-by-alphabet-alt:before {
+.fa-sort-alpha-desc:before {
   content: "\f15e";
 }
-.icon-sort-by-attributes:before {
+.fa-sort-amount-asc:before {
   content: "\f160";
 }
-.icon-sort-by-attributes-alt:before {
+.fa-sort-amount-desc:before {
   content: "\f161";
 }
-.icon-sort-by-order:before {
+.fa-sort-numeric-asc:before {
   content: "\f162";
 }
-.icon-sort-by-order-alt:before {
+.fa-sort-numeric-desc:before {
   content: "\f163";
 }
-.icon-thumbs-up:before {
+.fa-thumbs-up:before {
   content: "\f164";
 }
-.icon-thumbs-down:before {
+.fa-thumbs-down:before {
   content: "\f165";
 }
-.icon-youtube-sign:before {
+.fa-youtube-square:before {
   content: "\f166";
 }
-.icon-youtube:before {
+.fa-youtube:before {
   content: "\f167";
 }
-.icon-xing:before {
+.fa-xing:before {
   content: "\f168";
 }
-.icon-xing-sign:before {
+.fa-xing-square:before {
   content: "\f169";
 }
-.icon-youtube-play:before {
+.fa-youtube-play:before {
   content: "\f16a";
 }
-.icon-dropbox:before {
+.fa-dropbox:before {
   content: "\f16b";
 }
-.icon-stackexchange:before {
+.fa-stack-overflow:before {
   content: "\f16c";
 }
-.icon-instagram:before {
+.fa-instagram:before {
   content: "\f16d";
 }
-.icon-flickr:before {
+.fa-flickr:before {
   content: "\f16e";
 }
-.icon-adn:before {
+.fa-adn:before {
   content: "\f170";
 }
-.icon-bitbucket:before {
+.fa-bitbucket:before {
   content: "\f171";
 }
-.icon-bitbucket-sign:before {
+.fa-bitbucket-square:before {
   content: "\f172";
 }
-.icon-tumblr:before {
+.fa-tumblr:before {
   content: "\f173";
 }
-.icon-tumblr-sign:before {
+.fa-tumblr-square:before {
   content: "\f174";
 }
-.icon-long-arrow-down:before {
+.fa-long-arrow-down:before {
   content: "\f175";
 }
-.icon-long-arrow-up:before {
+.fa-long-arrow-up:before {
   content: "\f176";
 }
-.icon-long-arrow-left:before {
+.fa-long-arrow-left:before {
   content: "\f177";
 }
-.icon-long-arrow-right:before {
+.fa-long-arrow-right:before {
   content: "\f178";
 }
-.icon-apple:before {
+.fa-apple:before {
   content: "\f179";
 }
-.icon-windows:before {
+.fa-windows:before {
   content: "\f17a";
 }
-.icon-android:before {
+.fa-android:before {
   content: "\f17b";
 }
-.icon-linux:before {
+.fa-linux:before {
   content: "\f17c";
 }
-.icon-dribbble:before {
+.fa-dribbble:before {
   content: "\f17d";
 }
-.icon-skype:before {
+.fa-skype:before {
   content: "\f17e";
 }
-.icon-foursquare:before {
+.fa-foursquare:before {
   content: "\f180";
 }
-.icon-trello:before {
+.fa-trello:before {
   content: "\f181";
 }
-.icon-female:before {
+.fa-female:before {
   content: "\f182";
 }
-.icon-male:before {
+.fa-male:before {
   content: "\f183";
 }
-.icon-gittip:before {
+.fa-gittip:before {
   content: "\f184";
 }
-.icon-sun:before {
+.fa-sun-o:before {
   content: "\f185";
 }
-.icon-moon:before {
+.fa-moon-o:before {
   content: "\f186";
 }
-.icon-archive:before {
+.fa-archive:before {
   content: "\f187";
 }
-.icon-bug:before {
+.fa-bug:before {
   content: "\f188";
 }
-.icon-vk:before {
+.fa-vk:before {
   content: "\f189";
 }
-.icon-weibo:before {
+.fa-weibo:before {
   content: "\f18a";
 }
-.icon-renren:before {
+.fa-renren:before {
   content: "\f18b";
+}
+.fa-pagelines:before {
+  content: "\f18c";
+}
+.fa-stack-exchange:before {
+  content: "\f18d";
+}
+.fa-arrow-circle-o-right:before {
+  content: "\f18e";
+}
+.fa-arrow-circle-o-left:before {
+  content: "\f190";
+}
+.fa-toggle-left:before,
+.fa-caret-square-o-left:before {
+  content: "\f191";
+}
+.fa-dot-circle-o:before {
+  content: "\f192";
+}
+.fa-wheelchair:before {
+  content: "\f193";
+}
+.fa-vimeo-square:before {
+  content: "\f194";
+}
+.fa-turkish-lira:before,
+.fa-try:before {
+  content: "\f195";
+}
+.fa-plus-square-o:before {
+  content: "\f196";
+}
+.fa-space-shuttle:before {
+  content: "\f197";
+}
+.fa-slack:before {
+  content: "\f198";
+}
+.fa-envelope-square:before {
+  content: "\f199";
+}
+.fa-wordpress:before {
+  content: "\f19a";
+}
+.fa-openid:before {
+  content: "\f19b";
+}
+.fa-institution:before,
+.fa-bank:before,
+.fa-university:before {
+  content: "\f19c";
+}
+.fa-mortar-board:before,
+.fa-graduation-cap:before {
+  content: "\f19d";
+}
+.fa-yahoo:before {
+  content: "\f19e";
+}
+.fa-google:before {
+  content: "\f1a0";
+}
+.fa-reddit:before {
+  content: "\f1a1";
+}
+.fa-reddit-square:before {
+  content: "\f1a2";
+}
+.fa-stumbleupon-circle:before {
+  content: "\f1a3";
+}
+.fa-stumbleupon:before {
+  content: "\f1a4";
+}
+.fa-delicious:before {
+  content: "\f1a5";
+}
+.fa-digg:before {
+  content: "\f1a6";
+}
+.fa-pied-piper-square:before,
+.fa-pied-piper:before {
+  content: "\f1a7";
+}
+.fa-pied-piper-alt:before {
+  content: "\f1a8";
+}
+.fa-drupal:before {
+  content: "\f1a9";
+}
+.fa-joomla:before {
+  content: "\f1aa";
+}
+.fa-language:before {
+  content: "\f1ab";
+}
+.fa-fax:before {
+  content: "\f1ac";
+}
+.fa-building:before {
+  content: "\f1ad";
+}
+.fa-child:before {
+  content: "\f1ae";
+}
+.fa-paw:before {
+  content: "\f1b0";
+}
+.fa-spoon:before {
+  content: "\f1b1";
+}
+.fa-cube:before {
+  content: "\f1b2";
+}
+.fa-cubes:before {
+  content: "\f1b3";
+}
+.fa-behance:before {
+  content: "\f1b4";
+}
+.fa-behance-square:before {
+  content: "\f1b5";
+}
+.fa-steam:before {
+  content: "\f1b6";
+}
+.fa-steam-square:before {
+  content: "\f1b7";
+}
+.fa-recycle:before {
+  content: "\f1b8";
+}
+.fa-automobile:before,
+.fa-car:before {
+  content: "\f1b9";
+}
+.fa-cab:before,
+.fa-taxi:before {
+  content: "\f1ba";
+}
+.fa-tree:before {
+  content: "\f1bb";
+}
+.fa-spotify:before {
+  content: "\f1bc";
+}
+.fa-deviantart:before {
+  content: "\f1bd";
+}
+.fa-soundcloud:before {
+  content: "\f1be";
+}
+.fa-database:before {
+  content: "\f1c0";
+}
+.fa-file-pdf-o:before {
+  content: "\f1c1";
+}
+.fa-file-word-o:before {
+  content: "\f1c2";
+}
+.fa-file-excel-o:before {
+  content: "\f1c3";
+}
+.fa-file-powerpoint-o:before {
+  content: "\f1c4";
+}
+.fa-file-photo-o:before,
+.fa-file-picture-o:before,
+.fa-file-image-o:before {
+  content: "\f1c5";
+}
+.fa-file-zip-o:before,
+.fa-file-archive-o:before {
+  content: "\f1c6";
+}
+.fa-file-sound-o:before,
+.fa-file-audio-o:before {
+  content: "\f1c7";
+}
+.fa-file-movie-o:before,
+.fa-file-video-o:before {
+  content: "\f1c8";
+}
+.fa-file-code-o:before {
+  content: "\f1c9";
+}
+.fa-vine:before {
+  content: "\f1ca";
+}
+.fa-codepen:before {
+  content: "\f1cb";
+}
+.fa-jsfiddle:before {
+  content: "\f1cc";
+}
+.fa-life-bouy:before,
+.fa-life-saver:before,
+.fa-support:before,
+.fa-life-ring:before {
+  content: "\f1cd";
+}
+.fa-circle-o-notch:before {
+  content: "\f1ce";
+}
+.fa-ra:before,
+.fa-rebel:before {
+  content: "\f1d0";
+}
+.fa-ge:before,
+.fa-empire:before {
+  content: "\f1d1";
+}
+.fa-git-square:before {
+  content: "\f1d2";
+}
+.fa-git:before {
+  content: "\f1d3";
+}
+.fa-hacker-news:before {
+  content: "\f1d4";
+}
+.fa-tencent-weibo:before {
+  content: "\f1d5";
+}
+.fa-qq:before {
+  content: "\f1d6";
+}
+.fa-wechat:before,
+.fa-weixin:before {
+  content: "\f1d7";
+}
+.fa-send:before,
+.fa-paper-plane:before {
+  content: "\f1d8";
+}
+.fa-send-o:before,
+.fa-paper-plane-o:before {
+  content: "\f1d9";
+}
+.fa-history:before {
+  content: "\f1da";
+}
+.fa-circle-thin:before {
+  content: "\f1db";
+}
+.fa-header:before {
+  content: "\f1dc";
+}
+.fa-paragraph:before {
+  content: "\f1dd";
+}
+.fa-sliders:before {
+  content: "\f1de";
+}
+.fa-share-alt:before {
+  content: "\f1e0";
+}
+.fa-share-alt-square:before {
+  content: "\f1e1";
+}
+.fa-bomb:before {
+  content: "\f1e2";
 }
 /*!
 *
@@ -7302,7 +7389,6 @@ universal implementation of the flexible box model is used when available (see
 `Modern browsers` comments below).  Browsers that are known to implement this 
 new spec completely include:
 
-<<<<<<< HEAD
     Firefox 28.0+
     Chrome 29.0+
     Internet Explorer 11+ 
@@ -7741,22 +7827,36 @@ input.engine_num_input {
   margin-right: 0px;
 }
 .folder_icon:before {
+  display: inline-block;
   font-family: FontAwesome;
-  font-weight: normal;
   font-style: normal;
-  text-decoration: inherit;
+  font-weight: normal;
+  line-height: 1;
   -webkit-font-smoothing: antialiased;
-  *margin-right: .3em;
+  -moz-osx-font-smoothing: grayscale;
   content: "\f114";
 }
+.folder_icon:before.pull-left {
+  margin-right: .3em;
+}
+.folder_icon:before.pull-right {
+  margin-left: .3em;
+}
 .notebook_icon:before {
+  display: inline-block;
   font-family: FontAwesome;
-  font-weight: normal;
   font-style: normal;
-  text-decoration: inherit;
+  font-weight: normal;
+  line-height: 1;
   -webkit-font-smoothing: antialiased;
-  *margin-right: .3em;
+  -moz-osx-font-smoothing: grayscale;
   content: "\f02d";
+}
+.notebook_icon:before.pull-left {
+  margin-right: .3em;
+}
+.notebook_icon:before.pull-right {
+  margin-left: .3em;
 }
 /*!
 *
@@ -8020,8 +8120,6 @@ div.input_area > div.highlight > pre {
   /* .CodeMirror-lines */
   padding: 0;
   border: 0;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
   border-radius: 0;
 }
 .CodeMirror-vscrollbar,
@@ -8365,8 +8463,6 @@ div.output_area pre {
   vertical-align: baseline;
   color: #000000;
   background-color: transparent;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
   border-radius: 0;
 }
 /* This class is for the output subarea inside the output_area and after
@@ -9549,40 +9645,68 @@ ul#help_menu li a i {
   margin-right: 5px;
 }
 .edit_mode_icon:before {
+  display: inline-block;
   font-family: FontAwesome;
-  font-weight: normal;
   font-style: normal;
-  text-decoration: inherit;
+  font-weight: normal;
+  line-height: 1;
   -webkit-font-smoothing: antialiased;
-  *margin-right: .3em;
+  -moz-osx-font-smoothing: grayscale;
   content: "\f040";
 }
+.edit_mode_icon:before.pull-left {
+  margin-right: .3em;
+}
+.edit_mode_icon:before.pull-right {
+  margin-left: .3em;
+}
 .command_mode_icon:before {
+  display: inline-block;
   font-family: FontAwesome;
-  font-weight: normal;
   font-style: normal;
-  text-decoration: inherit;
+  font-weight: normal;
+  line-height: 1;
   -webkit-font-smoothing: antialiased;
-  *margin-right: .3em;
+  -moz-osx-font-smoothing: grayscale;
   content: ' ';
 }
+.command_mode_icon:before.pull-left {
+  margin-right: .3em;
+}
+.command_mode_icon:before.pull-right {
+  margin-left: .3em;
+}
 .kernel_idle_icon:before {
+  display: inline-block;
   font-family: FontAwesome;
-  font-weight: normal;
   font-style: normal;
-  text-decoration: inherit;
+  font-weight: normal;
+  line-height: 1;
   -webkit-font-smoothing: antialiased;
-  *margin-right: .3em;
+  -moz-osx-font-smoothing: grayscale;
   content: "\f10c";
 }
+.kernel_idle_icon:before.pull-left {
+  margin-right: .3em;
+}
+.kernel_idle_icon:before.pull-right {
+  margin-left: .3em;
+}
 .kernel_busy_icon:before {
+  display: inline-block;
   font-family: FontAwesome;
-  font-weight: normal;
   font-style: normal;
-  text-decoration: inherit;
+  font-weight: normal;
+  line-height: 1;
   -webkit-font-smoothing: antialiased;
-  *margin-right: .3em;
+  -moz-osx-font-smoothing: grayscale;
   content: "\f111";
+}
+.kernel_busy_icon:before.pull-left {
+  margin-right: .3em;
+}
+.kernel_busy_icon:before.pull-right {
+  margin-left: .3em;
 }
 .notification_widget {
   color: #777777;
@@ -9648,24 +9772,6 @@ fieldset[disabled] .notification_widget {
   filter: alpha(opacity=65);
   -webkit-box-shadow: none;
   box-shadow: none;
-}
-.notification_widget [class^="icon-"].icon-large,
-.notification_widget [class*=" icon-"].icon-large {
-  line-height: .9em;
-}
-.notification_widget [class^="icon-"].icon-spin,
-.notification_widget [class*=" icon-"].icon-spin {
-  display: inline-block;
-}
-.notification_widget [class^="icon-"].pull-left.icon-2x,
-.notification_widget [class*=" icon-"].pull-left.icon-2x,
-.notification_widget [class^="icon-"].pull-right.icon-2x,
-.notification_widget [class*=" icon-"].pull-right.icon-2x {
-  margin-top: .18em;
-}
-.notification_widget [class^="icon-"].icon-spin.icon-large,
-.notification_widget [class*=" icon-"].icon-spin.icon-large {
-  line-height: .8em;
 }
 .notification_widget:hover,
 .notification_widget:focus,
@@ -10115,8 +10221,6 @@ span#autosave_status {
 }
 .ipython_tooltip .tooltiptext pre {
   border: 0;
-  -webkit-border-radius: 0;
-  -moz-border-radius: 0;
   border-radius: 0;
   font-size: 100%;
   background-color: #f7f7f7;
@@ -10146,1591 +10250,3 @@ span#autosave_status {
   -o-transform: rotate(45deg);
 }
 /*# sourceMappingURL=../style/style.min.css.map */
-=======
-html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
-body{margin:0}
-article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
-audio,canvas,progress,video{display:inline-block;vertical-align:baseline}
-audio:not([controls]){display:none;height:0}
-[hidden],template{display:none}
-a{background:transparent}
-a:active,a:hover{outline:0}
-abbr[title]{border-bottom:1px dotted}
-b,strong{font-weight:bold}
-dfn{font-style:italic}
-h1{font-size:2em;margin:.67em 0}
-mark{background:#ff0;color:#000}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-0.5em}
-sub{bottom:-0.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:1em 40px}
-hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
-pre{overflow:auto}
-code,kbd,pre,samp{font-family:monospace,monospace;font-size:1em}
-button,input,optgroup,select,textarea{color:inherit;font:inherit;margin:0}
-button{overflow:visible}
-button,select{text-transform:none}
-button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-input{line-height:normal}
-input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
-input[type="number"]::-webkit-inner-spin-button,input[type="number"]::-webkit-outer-spin-button{height:auto}
-input[type="search"]{-webkit-appearance:textfield;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;box-sizing:content-box}
-input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}
-fieldset{border:1px solid #c0c0c0;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-textarea{overflow:auto}
-optgroup{font-weight:bold}
-table{border-collapse:collapse;border-spacing:0}
-td,th{padding:0}
-@media print{*{text-shadow:none !important;color:#000 !important;background:transparent !important;box-shadow:none !important} a,a:visited{text-decoration:underline} a[href]:after{content:" (" attr(href) ")"} abbr[title]:after{content:" (" attr(title) ")"} a[href^="javascript:"]:after,a[href^="#"]:after{content:""} pre,blockquote{border:1px solid #999;page-break-inside:avoid} thead{display:table-header-group} tr,img{page-break-inside:avoid} img{max-width:100% !important} p,h2,h3{orphans:3;widows:3} h2,h3{page-break-after:avoid} select{background:#fff !important} .navbar{display:none} .table td,.table th{background-color:#fff !important} .btn>.caret,.dropup>.btn>.caret{border-top-color:#000 !important} .label{border:1px solid #000} .table{border-collapse:collapse !important} .table-bordered th,.table-bordered td{border:1px solid #ddd !important}}*{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
-*:before,*:after{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
-html{font-size:62.5%;-webkit-tap-highlight-color:rgba(0,0,0,0)}
-body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:13px;line-height:1.428571429;color:#000;background-color:#fff}
-input,button,select,textarea{font-family:inherit;font-size:inherit;line-height:inherit}
-a{color:#428bca;text-decoration:none}a:hover,a:focus{color:#2a6496;text-decoration:underline}
-a:focus{outline:thin dotted;outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}
-figure{margin:0}
-img{vertical-align:middle}
-.img-responsive,.thumbnail>img,.thumbnail a>img,.carousel-inner>.item>img,.carousel-inner>.item>a>img{display:block;max-width:100%;height:auto}
-.img-rounded{border-radius:6px}
-.img-thumbnail{padding:4px;line-height:1.428571429;background-color:#fff;border:1px solid #ddd;border-radius:4px;-webkit-transition:all .2s ease-in-out;transition:all .2s ease-in-out;display:inline-block;max-width:100%;height:auto}
-.img-circle{border-radius:50%}
-hr{margin-top:18px;margin-bottom:18px;border:0;border-top:1px solid #eee}
-.sr-only{position:absolute;width:1px;height:1px;margin:-1px;padding:0;overflow:hidden;clip:rect(0, 0, 0, 0);border:0}
-h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6{font-family:inherit;font-weight:500;line-height:1.1;color:inherit}h1 small,h2 small,h3 small,h4 small,h5 small,h6 small,.h1 small,.h2 small,.h3 small,.h4 small,.h5 small,.h6 small,h1 .small,h2 .small,h3 .small,h4 .small,h5 .small,h6 .small,.h1 .small,.h2 .small,.h3 .small,.h4 .small,.h5 .small,.h6 .small{font-weight:normal;line-height:1;color:#999}
-h1,.h1,h2,.h2,h3,.h3{margin-top:18px;margin-bottom:9px}h1 small,.h1 small,h2 small,.h2 small,h3 small,.h3 small,h1 .small,.h1 .small,h2 .small,.h2 .small,h3 .small,.h3 .small{font-size:65%}
-h4,.h4,h5,.h5,h6,.h6{margin-top:9px;margin-bottom:9px}h4 small,.h4 small,h5 small,.h5 small,h6 small,.h6 small,h4 .small,.h4 .small,h5 .small,.h5 .small,h6 .small,.h6 .small{font-size:75%}
-h1,.h1{font-size:33px}
-h2,.h2{font-size:27px}
-h3,.h3{font-size:23px}
-h4,.h4{font-size:17px}
-h5,.h5{font-size:13px}
-h6,.h6{font-size:12px}
-p{margin:0 0 9px}
-.lead{margin-bottom:18px;font-size:14px;font-weight:200;line-height:1.4}@media (min-width:768px){.lead{font-size:19.5px}}
-small,.small{font-size:85%}
-cite{font-style:normal}
-.text-left{text-align:left}
-.text-right{text-align:right}
-.text-center{text-align:center}
-.text-justify{text-align:justify}
-.text-muted{color:#999}
-.text-primary{color:#428bca}a.text-primary:hover{color:#3071a9}
-.text-success{color:#3c763d}a.text-success:hover{color:#2b542c}
-.text-info{color:#31708f}a.text-info:hover{color:#245269}
-.text-warning{color:#8a6d3b}a.text-warning:hover{color:#66512c}
-.text-danger{color:#a94442}a.text-danger:hover{color:#843534}
-.bg-primary{color:#fff;background-color:#428bca}a.bg-primary:hover{background-color:#3071a9}
-.bg-success{background-color:#dff0d8}a.bg-success:hover{background-color:#c1e2b3}
-.bg-info{background-color:#d9edf7}a.bg-info:hover{background-color:#afd9ee}
-.bg-warning{background-color:#fcf8e3}a.bg-warning:hover{background-color:#f7ecb5}
-.bg-danger{background-color:#f2dede}a.bg-danger:hover{background-color:#e4b9b9}
-.page-header{padding-bottom:8px;margin:36px 0 18px;border-bottom:1px solid #eee}
-ul,ol{margin-top:0;margin-bottom:9px}ul ul,ol ul,ul ol,ol ol{margin-bottom:0}
-.list-unstyled{padding-left:0;list-style:none}
-.list-inline{padding-left:0;list-style:none;margin-left:-5px}.list-inline>li{display:inline-block;padding-left:5px;padding-right:5px}
-dl{margin-top:0;margin-bottom:18px}
-dt,dd{line-height:1.428571429}
-dt{font-weight:bold}
-dd{margin-left:0}
-@media (min-width:768px){.dl-horizontal dt{float:left;width:160px;clear:left;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap} .dl-horizontal dd{margin-left:180px}}abbr[title],abbr[data-original-title]{cursor:help;border-bottom:1px dotted #999}
-.initialism{font-size:90%;text-transform:uppercase}
-blockquote{padding:9px 18px;margin:0 0 18px;font-size:inherit;border-left:5px solid #eee}blockquote p:last-child,blockquote ul:last-child,blockquote ol:last-child{margin-bottom:0}
-blockquote footer,blockquote small,blockquote .small{display:block;font-size:80%;line-height:1.428571429;color:#999}blockquote footer:before,blockquote small:before,blockquote .small:before{content:'\2014 \00A0'}
-.blockquote-reverse,blockquote.pull-right{padding-right:15px;padding-left:0;border-right:5px solid #eee;border-left:0;text-align:right}.blockquote-reverse footer:before,blockquote.pull-right footer:before,.blockquote-reverse small:before,blockquote.pull-right small:before,.blockquote-reverse .small:before,blockquote.pull-right .small:before{content:''}
-.blockquote-reverse footer:after,blockquote.pull-right footer:after,.blockquote-reverse small:after,blockquote.pull-right small:after,.blockquote-reverse .small:after,blockquote.pull-right .small:after{content:'\00A0 \2014'}
-blockquote:before,blockquote:after{content:""}
-address{margin-bottom:18px;font-style:normal;line-height:1.428571429}
-code,kbd,pre,samp{font-family:monospace}
-code{padding:2px 4px;font-size:90%;color:#c7254e;background-color:#f9f2f4;white-space:nowrap;border-radius:4px}
-kbd{padding:2px 4px;font-size:90%;color:#fff;background-color:#333;border-radius:3px;box-shadow:inset 0 -1px 0 rgba(0,0,0,0.25)}
-pre{display:block;padding:8.5px;margin:0 0 9px;font-size:12px;line-height:1.428571429;word-break:break-all;word-wrap:break-word;color:#333;background-color:#f5f5f5;border:1px solid #ccc;border-radius:4px}pre code{padding:0;font-size:inherit;color:inherit;white-space:pre-wrap;background-color:transparent;border-radius:0}
-.pre-scrollable{max-height:340px;overflow-y:scroll}
-.container{margin-right:auto;margin-left:auto;padding-left:15px;padding-right:15px}@media (min-width:768px){.container{width:750px}}@media (min-width:992px){.container{width:970px}}@media (min-width:1200px){.container{width:1170px}}
-.container-fluid{margin-right:auto;margin-left:auto;padding-left:15px;padding-right:15px}
-.row{margin-left:-15px;margin-right:-15px}
-.col-xs-1, .col-sm-1, .col-md-1, .col-lg-1, .col-xs-2, .col-sm-2, .col-md-2, .col-lg-2, .col-xs-3, .col-sm-3, .col-md-3, .col-lg-3, .col-xs-4, .col-sm-4, .col-md-4, .col-lg-4, .col-xs-5, .col-sm-5, .col-md-5, .col-lg-5, .col-xs-6, .col-sm-6, .col-md-6, .col-lg-6, .col-xs-7, .col-sm-7, .col-md-7, .col-lg-7, .col-xs-8, .col-sm-8, .col-md-8, .col-lg-8, .col-xs-9, .col-sm-9, .col-md-9, .col-lg-9, .col-xs-10, .col-sm-10, .col-md-10, .col-lg-10, .col-xs-11, .col-sm-11, .col-md-11, .col-lg-11, .col-xs-12, .col-sm-12, .col-md-12, .col-lg-12{position:relative;min-height:1px;padding-left:15px;padding-right:15px}
-.col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6, .col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12{float:left}
-.col-xs-12{width:100%}
-.col-xs-11{width:91.66666666666666%}
-.col-xs-10{width:83.33333333333334%}
-.col-xs-9{width:75%}
-.col-xs-8{width:66.66666666666666%}
-.col-xs-7{width:58.333333333333336%}
-.col-xs-6{width:50%}
-.col-xs-5{width:41.66666666666667%}
-.col-xs-4{width:33.33333333333333%}
-.col-xs-3{width:25%}
-.col-xs-2{width:16.666666666666664%}
-.col-xs-1{width:8.333333333333332%}
-.col-xs-pull-12{right:100%}
-.col-xs-pull-11{right:91.66666666666666%}
-.col-xs-pull-10{right:83.33333333333334%}
-.col-xs-pull-9{right:75%}
-.col-xs-pull-8{right:66.66666666666666%}
-.col-xs-pull-7{right:58.333333333333336%}
-.col-xs-pull-6{right:50%}
-.col-xs-pull-5{right:41.66666666666667%}
-.col-xs-pull-4{right:33.33333333333333%}
-.col-xs-pull-3{right:25%}
-.col-xs-pull-2{right:16.666666666666664%}
-.col-xs-pull-1{right:8.333333333333332%}
-.col-xs-pull-0{right:0}
-.col-xs-push-12{left:100%}
-.col-xs-push-11{left:91.66666666666666%}
-.col-xs-push-10{left:83.33333333333334%}
-.col-xs-push-9{left:75%}
-.col-xs-push-8{left:66.66666666666666%}
-.col-xs-push-7{left:58.333333333333336%}
-.col-xs-push-6{left:50%}
-.col-xs-push-5{left:41.66666666666667%}
-.col-xs-push-4{left:33.33333333333333%}
-.col-xs-push-3{left:25%}
-.col-xs-push-2{left:16.666666666666664%}
-.col-xs-push-1{left:8.333333333333332%}
-.col-xs-push-0{left:0}
-.col-xs-offset-12{margin-left:100%}
-.col-xs-offset-11{margin-left:91.66666666666666%}
-.col-xs-offset-10{margin-left:83.33333333333334%}
-.col-xs-offset-9{margin-left:75%}
-.col-xs-offset-8{margin-left:66.66666666666666%}
-.col-xs-offset-7{margin-left:58.333333333333336%}
-.col-xs-offset-6{margin-left:50%}
-.col-xs-offset-5{margin-left:41.66666666666667%}
-.col-xs-offset-4{margin-left:33.33333333333333%}
-.col-xs-offset-3{margin-left:25%}
-.col-xs-offset-2{margin-left:16.666666666666664%}
-.col-xs-offset-1{margin-left:8.333333333333332%}
-.col-xs-offset-0{margin-left:0}
-@media (min-width:768px){.col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12{float:left} .col-sm-12{width:100%} .col-sm-11{width:91.66666666666666%} .col-sm-10{width:83.33333333333334%} .col-sm-9{width:75%} .col-sm-8{width:66.66666666666666%} .col-sm-7{width:58.333333333333336%} .col-sm-6{width:50%} .col-sm-5{width:41.66666666666667%} .col-sm-4{width:33.33333333333333%} .col-sm-3{width:25%} .col-sm-2{width:16.666666666666664%} .col-sm-1{width:8.333333333333332%} .col-sm-pull-12{right:100%} .col-sm-pull-11{right:91.66666666666666%} .col-sm-pull-10{right:83.33333333333334%} .col-sm-pull-9{right:75%} .col-sm-pull-8{right:66.66666666666666%} .col-sm-pull-7{right:58.333333333333336%} .col-sm-pull-6{right:50%} .col-sm-pull-5{right:41.66666666666667%} .col-sm-pull-4{right:33.33333333333333%} .col-sm-pull-3{right:25%} .col-sm-pull-2{right:16.666666666666664%} .col-sm-pull-1{right:8.333333333333332%} .col-sm-pull-0{right:0} .col-sm-push-12{left:100%} .col-sm-push-11{left:91.66666666666666%} .col-sm-push-10{left:83.33333333333334%} .col-sm-push-9{left:75%} .col-sm-push-8{left:66.66666666666666%} .col-sm-push-7{left:58.333333333333336%} .col-sm-push-6{left:50%} .col-sm-push-5{left:41.66666666666667%} .col-sm-push-4{left:33.33333333333333%} .col-sm-push-3{left:25%} .col-sm-push-2{left:16.666666666666664%} .col-sm-push-1{left:8.333333333333332%} .col-sm-push-0{left:0} .col-sm-offset-12{margin-left:100%} .col-sm-offset-11{margin-left:91.66666666666666%} .col-sm-offset-10{margin-left:83.33333333333334%} .col-sm-offset-9{margin-left:75%} .col-sm-offset-8{margin-left:66.66666666666666%} .col-sm-offset-7{margin-left:58.333333333333336%} .col-sm-offset-6{margin-left:50%} .col-sm-offset-5{margin-left:41.66666666666667%} .col-sm-offset-4{margin-left:33.33333333333333%} .col-sm-offset-3{margin-left:25%} .col-sm-offset-2{margin-left:16.666666666666664%} .col-sm-offset-1{margin-left:8.333333333333332%} .col-sm-offset-0{margin-left:0}}@media (min-width:992px){.col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12{float:left} .col-md-12{width:100%} .col-md-11{width:91.66666666666666%} .col-md-10{width:83.33333333333334%} .col-md-9{width:75%} .col-md-8{width:66.66666666666666%} .col-md-7{width:58.333333333333336%} .col-md-6{width:50%} .col-md-5{width:41.66666666666667%} .col-md-4{width:33.33333333333333%} .col-md-3{width:25%} .col-md-2{width:16.666666666666664%} .col-md-1{width:8.333333333333332%} .col-md-pull-12{right:100%} .col-md-pull-11{right:91.66666666666666%} .col-md-pull-10{right:83.33333333333334%} .col-md-pull-9{right:75%} .col-md-pull-8{right:66.66666666666666%} .col-md-pull-7{right:58.333333333333336%} .col-md-pull-6{right:50%} .col-md-pull-5{right:41.66666666666667%} .col-md-pull-4{right:33.33333333333333%} .col-md-pull-3{right:25%} .col-md-pull-2{right:16.666666666666664%} .col-md-pull-1{right:8.333333333333332%} .col-md-pull-0{right:0} .col-md-push-12{left:100%} .col-md-push-11{left:91.66666666666666%} .col-md-push-10{left:83.33333333333334%} .col-md-push-9{left:75%} .col-md-push-8{left:66.66666666666666%} .col-md-push-7{left:58.333333333333336%} .col-md-push-6{left:50%} .col-md-push-5{left:41.66666666666667%} .col-md-push-4{left:33.33333333333333%} .col-md-push-3{left:25%} .col-md-push-2{left:16.666666666666664%} .col-md-push-1{left:8.333333333333332%} .col-md-push-0{left:0} .col-md-offset-12{margin-left:100%} .col-md-offset-11{margin-left:91.66666666666666%} .col-md-offset-10{margin-left:83.33333333333334%} .col-md-offset-9{margin-left:75%} .col-md-offset-8{margin-left:66.66666666666666%} .col-md-offset-7{margin-left:58.333333333333336%} .col-md-offset-6{margin-left:50%} .col-md-offset-5{margin-left:41.66666666666667%} .col-md-offset-4{margin-left:33.33333333333333%} .col-md-offset-3{margin-left:25%} .col-md-offset-2{margin-left:16.666666666666664%} .col-md-offset-1{margin-left:8.333333333333332%} .col-md-offset-0{margin-left:0}}@media (min-width:1200px){.col-lg-1, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9, .col-lg-10, .col-lg-11, .col-lg-12{float:left} .col-lg-12{width:100%} .col-lg-11{width:91.66666666666666%} .col-lg-10{width:83.33333333333334%} .col-lg-9{width:75%} .col-lg-8{width:66.66666666666666%} .col-lg-7{width:58.333333333333336%} .col-lg-6{width:50%} .col-lg-5{width:41.66666666666667%} .col-lg-4{width:33.33333333333333%} .col-lg-3{width:25%} .col-lg-2{width:16.666666666666664%} .col-lg-1{width:8.333333333333332%} .col-lg-pull-12{right:100%} .col-lg-pull-11{right:91.66666666666666%} .col-lg-pull-10{right:83.33333333333334%} .col-lg-pull-9{right:75%} .col-lg-pull-8{right:66.66666666666666%} .col-lg-pull-7{right:58.333333333333336%} .col-lg-pull-6{right:50%} .col-lg-pull-5{right:41.66666666666667%} .col-lg-pull-4{right:33.33333333333333%} .col-lg-pull-3{right:25%} .col-lg-pull-2{right:16.666666666666664%} .col-lg-pull-1{right:8.333333333333332%} .col-lg-pull-0{right:0} .col-lg-push-12{left:100%} .col-lg-push-11{left:91.66666666666666%} .col-lg-push-10{left:83.33333333333334%} .col-lg-push-9{left:75%} .col-lg-push-8{left:66.66666666666666%} .col-lg-push-7{left:58.333333333333336%} .col-lg-push-6{left:50%} .col-lg-push-5{left:41.66666666666667%} .col-lg-push-4{left:33.33333333333333%} .col-lg-push-3{left:25%} .col-lg-push-2{left:16.666666666666664%} .col-lg-push-1{left:8.333333333333332%} .col-lg-push-0{left:0} .col-lg-offset-12{margin-left:100%} .col-lg-offset-11{margin-left:91.66666666666666%} .col-lg-offset-10{margin-left:83.33333333333334%} .col-lg-offset-9{margin-left:75%} .col-lg-offset-8{margin-left:66.66666666666666%} .col-lg-offset-7{margin-left:58.333333333333336%} .col-lg-offset-6{margin-left:50%} .col-lg-offset-5{margin-left:41.66666666666667%} .col-lg-offset-4{margin-left:33.33333333333333%} .col-lg-offset-3{margin-left:25%} .col-lg-offset-2{margin-left:16.666666666666664%} .col-lg-offset-1{margin-left:8.333333333333332%} .col-lg-offset-0{margin-left:0}}table{max-width:100%;background-color:transparent}
-th{text-align:left}
-.table{width:100%;margin-bottom:18px}.table>thead>tr>th,.table>tbody>tr>th,.table>tfoot>tr>th,.table>thead>tr>td,.table>tbody>tr>td,.table>tfoot>tr>td{padding:8px;line-height:1.428571429;vertical-align:top;border-top:1px solid #ddd}
-.table>thead>tr>th{vertical-align:bottom;border-bottom:2px solid #ddd}
-.table>caption+thead>tr:first-child>th,.table>colgroup+thead>tr:first-child>th,.table>thead:first-child>tr:first-child>th,.table>caption+thead>tr:first-child>td,.table>colgroup+thead>tr:first-child>td,.table>thead:first-child>tr:first-child>td{border-top:0}
-.table>tbody+tbody{border-top:2px solid #ddd}
-.table .table{background-color:#fff}
-.table-condensed>thead>tr>th,.table-condensed>tbody>tr>th,.table-condensed>tfoot>tr>th,.table-condensed>thead>tr>td,.table-condensed>tbody>tr>td,.table-condensed>tfoot>tr>td{padding:5px}
-.table-bordered{border:1px solid #ddd}.table-bordered>thead>tr>th,.table-bordered>tbody>tr>th,.table-bordered>tfoot>tr>th,.table-bordered>thead>tr>td,.table-bordered>tbody>tr>td,.table-bordered>tfoot>tr>td{border:1px solid #ddd}
-.table-bordered>thead>tr>th,.table-bordered>thead>tr>td{border-bottom-width:2px}
-.table-striped>tbody>tr:nth-child(odd)>td,.table-striped>tbody>tr:nth-child(odd)>th{background-color:#f9f9f9}
-.table-hover>tbody>tr:hover>td,.table-hover>tbody>tr:hover>th{background-color:#f5f5f5}
-table col[class*="col-"]{position:static;float:none;display:table-column}
-table td[class*="col-"],table th[class*="col-"]{position:static;float:none;display:table-cell}
-.table>thead>tr>td.active,.table>tbody>tr>td.active,.table>tfoot>tr>td.active,.table>thead>tr>th.active,.table>tbody>tr>th.active,.table>tfoot>tr>th.active,.table>thead>tr.active>td,.table>tbody>tr.active>td,.table>tfoot>tr.active>td,.table>thead>tr.active>th,.table>tbody>tr.active>th,.table>tfoot>tr.active>th{background-color:#f5f5f5}
-.table-hover>tbody>tr>td.active:hover,.table-hover>tbody>tr>th.active:hover,.table-hover>tbody>tr.active:hover>td,.table-hover>tbody>tr.active:hover>th{background-color:#e8e8e8}
-.table>thead>tr>td.success,.table>tbody>tr>td.success,.table>tfoot>tr>td.success,.table>thead>tr>th.success,.table>tbody>tr>th.success,.table>tfoot>tr>th.success,.table>thead>tr.success>td,.table>tbody>tr.success>td,.table>tfoot>tr.success>td,.table>thead>tr.success>th,.table>tbody>tr.success>th,.table>tfoot>tr.success>th{background-color:#dff0d8}
-.table-hover>tbody>tr>td.success:hover,.table-hover>tbody>tr>th.success:hover,.table-hover>tbody>tr.success:hover>td,.table-hover>tbody>tr.success:hover>th{background-color:#d0e9c6}
-.table>thead>tr>td.info,.table>tbody>tr>td.info,.table>tfoot>tr>td.info,.table>thead>tr>th.info,.table>tbody>tr>th.info,.table>tfoot>tr>th.info,.table>thead>tr.info>td,.table>tbody>tr.info>td,.table>tfoot>tr.info>td,.table>thead>tr.info>th,.table>tbody>tr.info>th,.table>tfoot>tr.info>th{background-color:#d9edf7}
-.table-hover>tbody>tr>td.info:hover,.table-hover>tbody>tr>th.info:hover,.table-hover>tbody>tr.info:hover>td,.table-hover>tbody>tr.info:hover>th{background-color:#c4e3f3}
-.table>thead>tr>td.warning,.table>tbody>tr>td.warning,.table>tfoot>tr>td.warning,.table>thead>tr>th.warning,.table>tbody>tr>th.warning,.table>tfoot>tr>th.warning,.table>thead>tr.warning>td,.table>tbody>tr.warning>td,.table>tfoot>tr.warning>td,.table>thead>tr.warning>th,.table>tbody>tr.warning>th,.table>tfoot>tr.warning>th{background-color:#fcf8e3}
-.table-hover>tbody>tr>td.warning:hover,.table-hover>tbody>tr>th.warning:hover,.table-hover>tbody>tr.warning:hover>td,.table-hover>tbody>tr.warning:hover>th{background-color:#faf2cc}
-.table>thead>tr>td.danger,.table>tbody>tr>td.danger,.table>tfoot>tr>td.danger,.table>thead>tr>th.danger,.table>tbody>tr>th.danger,.table>tfoot>tr>th.danger,.table>thead>tr.danger>td,.table>tbody>tr.danger>td,.table>tfoot>tr.danger>td,.table>thead>tr.danger>th,.table>tbody>tr.danger>th,.table>tfoot>tr.danger>th{background-color:#f2dede}
-.table-hover>tbody>tr>td.danger:hover,.table-hover>tbody>tr>th.danger:hover,.table-hover>tbody>tr.danger:hover>td,.table-hover>tbody>tr.danger:hover>th{background-color:#ebcccc}
-@media (max-width:767px){.table-responsive{width:100%;margin-bottom:13.5px;overflow-y:hidden;overflow-x:scroll;-ms-overflow-style:-ms-autohiding-scrollbar;border:1px solid #ddd;-webkit-overflow-scrolling:touch}.table-responsive>.table{margin-bottom:0}.table-responsive>.table>thead>tr>th,.table-responsive>.table>tbody>tr>th,.table-responsive>.table>tfoot>tr>th,.table-responsive>.table>thead>tr>td,.table-responsive>.table>tbody>tr>td,.table-responsive>.table>tfoot>tr>td{white-space:nowrap} .table-responsive>.table-bordered{border:0}.table-responsive>.table-bordered>thead>tr>th:first-child,.table-responsive>.table-bordered>tbody>tr>th:first-child,.table-responsive>.table-bordered>tfoot>tr>th:first-child,.table-responsive>.table-bordered>thead>tr>td:first-child,.table-responsive>.table-bordered>tbody>tr>td:first-child,.table-responsive>.table-bordered>tfoot>tr>td:first-child{border-left:0} .table-responsive>.table-bordered>thead>tr>th:last-child,.table-responsive>.table-bordered>tbody>tr>th:last-child,.table-responsive>.table-bordered>tfoot>tr>th:last-child,.table-responsive>.table-bordered>thead>tr>td:last-child,.table-responsive>.table-bordered>tbody>tr>td:last-child,.table-responsive>.table-bordered>tfoot>tr>td:last-child{border-right:0} .table-responsive>.table-bordered>tbody>tr:last-child>th,.table-responsive>.table-bordered>tfoot>tr:last-child>th,.table-responsive>.table-bordered>tbody>tr:last-child>td,.table-responsive>.table-bordered>tfoot>tr:last-child>td{border-bottom:0}}fieldset{padding:0;margin:0;border:0;min-width:0}
-legend{display:block;width:100%;padding:0;margin-bottom:18px;font-size:19.5px;line-height:inherit;color:#333;border:0;border-bottom:1px solid #e5e5e5}
-label{display:inline-block;margin-bottom:5px;font-weight:bold}
-input[type="search"]{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
-input[type="radio"],input[type="checkbox"]{margin:4px 0 0;margin-top:1px \9;line-height:normal}
-input[type="file"]{display:block}
-input[type="range"]{display:block;width:100%}
-select[multiple],select[size]{height:auto}
-input[type="file"]:focus,input[type="radio"]:focus,input[type="checkbox"]:focus{outline:thin dotted;outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}
-output{display:block;padding-top:7px;font-size:13px;line-height:1.428571429;color:#555}
-.form-control{display:block;width:100%;height:32px;padding:6px 12px;font-size:13px;line-height:1.428571429;color:#555;background-color:#fff;background-image:none;border:1px solid #ccc;border-radius:4px;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);-webkit-transition:border-color ease-in-out .15s, box-shadow ease-in-out .15s;transition:border-color ease-in-out .15s, box-shadow ease-in-out .15s}.form-control:focus{border-color:#66afe9;outline:0;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);box-shadow:inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6)}
-.form-control::-moz-placeholder{color:#999;opacity:1}
-.form-control:-ms-input-placeholder{color:#999}
-.form-control::-webkit-input-placeholder{color:#999}
-.form-control[disabled],.form-control[readonly],fieldset[disabled] .form-control{cursor:not-allowed;background-color:#eee;opacity:1}
-textarea.form-control{height:auto}
-input[type="search"]{-webkit-appearance:none}
-input[type="date"]{line-height:32px}
-.form-group{margin-bottom:15px}
-.radio,.checkbox{display:block;min-height:18px;margin-top:10px;margin-bottom:10px;padding-left:20px}.radio label,.checkbox label{display:inline;font-weight:normal;cursor:pointer}
-.radio input[type="radio"],.radio-inline input[type="radio"],.checkbox input[type="checkbox"],.checkbox-inline input[type="checkbox"]{float:left;margin-left:-20px}
-.radio+.radio,.checkbox+.checkbox{margin-top:-5px}
-.radio-inline,.checkbox-inline{display:inline-block;padding-left:20px;margin-bottom:0;vertical-align:middle;font-weight:normal;cursor:pointer}
-.radio-inline+.radio-inline,.checkbox-inline+.checkbox-inline{margin-top:0;margin-left:10px}
-input[type="radio"][disabled],input[type="checkbox"][disabled],.radio[disabled],.radio-inline[disabled],.checkbox[disabled],.checkbox-inline[disabled],fieldset[disabled] input[type="radio"],fieldset[disabled] input[type="checkbox"],fieldset[disabled] .radio,fieldset[disabled] .radio-inline,fieldset[disabled] .checkbox,fieldset[disabled] .checkbox-inline{cursor:not-allowed}
-.input-sm{height:30px;padding:5px 10px;font-size:12px;line-height:1.5;border-radius:3px}select.input-sm{height:30px;line-height:30px}
-textarea.input-sm,select[multiple].input-sm{height:auto}
-.input-lg{height:45px;padding:10px 16px;font-size:17px;line-height:1.33;border-radius:6px}select.input-lg{height:45px;line-height:45px}
-textarea.input-lg,select[multiple].input-lg{height:auto}
-.has-feedback{position:relative}.has-feedback .form-control{padding-right:40px}
-.has-feedback .form-control-feedback{position:absolute;top:23px;right:0;display:block;width:32px;height:32px;line-height:32px;text-align:center}
-.has-success .help-block,.has-success .control-label,.has-success .radio,.has-success .checkbox,.has-success .radio-inline,.has-success .checkbox-inline{color:#3c763d}
-.has-success .form-control{border-color:#3c763d;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075)}.has-success .form-control:focus{border-color:#2b542c;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #67b168;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #67b168}
-.has-success .input-group-addon{color:#3c763d;border-color:#3c763d;background-color:#dff0d8}
-.has-success .form-control-feedback{color:#3c763d}
-.has-warning .help-block,.has-warning .control-label,.has-warning .radio,.has-warning .checkbox,.has-warning .radio-inline,.has-warning .checkbox-inline{color:#8a6d3b}
-.has-warning .form-control{border-color:#8a6d3b;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075)}.has-warning .form-control:focus{border-color:#66512c;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #c0a16b;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #c0a16b}
-.has-warning .input-group-addon{color:#8a6d3b;border-color:#8a6d3b;background-color:#fcf8e3}
-.has-warning .form-control-feedback{color:#8a6d3b}
-.has-error .help-block,.has-error .control-label,.has-error .radio,.has-error .checkbox,.has-error .radio-inline,.has-error .checkbox-inline{color:#a94442}
-.has-error .form-control{border-color:#a94442;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075)}.has-error .form-control:focus{border-color:#843534;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #ce8483;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #ce8483}
-.has-error .input-group-addon{color:#a94442;border-color:#a94442;background-color:#f2dede}
-.has-error .form-control-feedback{color:#a94442}
-.form-control-static{margin-bottom:0}
-.help-block{display:block;margin-top:5px;margin-bottom:10px;color:#404040}
-@media (min-width:768px){.form-inline .form-group{display:inline-block;margin-bottom:0;vertical-align:middle} .form-inline .form-control{display:inline-block;width:auto;vertical-align:middle} .form-inline .input-group>.form-control{width:100%} .form-inline .control-label{margin-bottom:0;vertical-align:middle} .form-inline .radio,.form-inline .checkbox{display:inline-block;margin-top:0;margin-bottom:0;padding-left:0;vertical-align:middle} .form-inline .radio input[type="radio"],.form-inline .checkbox input[type="checkbox"]{float:none;margin-left:0} .form-inline .has-feedback .form-control-feedback{top:0}}
-.form-horizontal .control-label,.form-horizontal .radio,.form-horizontal .checkbox,.form-horizontal .radio-inline,.form-horizontal .checkbox-inline{margin-top:0;margin-bottom:0;padding-top:7px}
-.form-horizontal .radio,.form-horizontal .checkbox{min-height:25px}
-.form-horizontal .form-group{margin-left:-15px;margin-right:-15px}
-.form-horizontal .form-control-static{padding-top:7px}
-@media (min-width:768px){.form-horizontal .control-label{text-align:right}}.form-horizontal .has-feedback .form-control-feedback{top:0;right:15px}
-.btn{display:inline-block;margin-bottom:0;font-weight:normal;text-align:center;vertical-align:middle;cursor:pointer;background-image:none;border:1px solid transparent;white-space:nowrap;padding:6px 12px;font-size:13px;line-height:1.428571429;border-radius:4px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.btn:focus,.btn:active:focus,.btn.active:focus{outline:thin dotted;outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}
-.btn:hover,.btn:focus{color:#333;text-decoration:none}
-.btn:active,.btn.active{outline:0;background-image:none;-webkit-box-shadow:inset 0 3px 5px rgba(0,0,0,0.125);box-shadow:inset 0 3px 5px rgba(0,0,0,0.125)}
-.btn.disabled,.btn[disabled],fieldset[disabled] .btn{cursor:not-allowed;pointer-events:none;opacity:.65;filter:alpha(opacity=65);-webkit-box-shadow:none;box-shadow:none}
-.btn-default{color:#333;background-color:#fff;border-color:#ccc}.btn-default:hover,.btn-default:focus,.btn-default:active,.btn-default.active,.open .dropdown-toggle.btn-default{color:#333;background-color:#ebebeb;border-color:#adadad}
-.btn-default:active,.btn-default.active,.open .dropdown-toggle.btn-default{background-image:none}
-.btn-default.disabled,.btn-default[disabled],fieldset[disabled] .btn-default,.btn-default.disabled:hover,.btn-default[disabled]:hover,fieldset[disabled] .btn-default:hover,.btn-default.disabled:focus,.btn-default[disabled]:focus,fieldset[disabled] .btn-default:focus,.btn-default.disabled:active,.btn-default[disabled]:active,fieldset[disabled] .btn-default:active,.btn-default.disabled.active,.btn-default[disabled].active,fieldset[disabled] .btn-default.active{background-color:#fff;border-color:#ccc}
-.btn-default .badge{color:#fff;background-color:#333}
-.btn-primary{color:#fff;background-color:#428bca;border-color:#357ebd}.btn-primary:hover,.btn-primary:focus,.btn-primary:active,.btn-primary.active,.open .dropdown-toggle.btn-primary{color:#fff;background-color:#3276b1;border-color:#285e8e}
-.btn-primary:active,.btn-primary.active,.open .dropdown-toggle.btn-primary{background-image:none}
-.btn-primary.disabled,.btn-primary[disabled],fieldset[disabled] .btn-primary,.btn-primary.disabled:hover,.btn-primary[disabled]:hover,fieldset[disabled] .btn-primary:hover,.btn-primary.disabled:focus,.btn-primary[disabled]:focus,fieldset[disabled] .btn-primary:focus,.btn-primary.disabled:active,.btn-primary[disabled]:active,fieldset[disabled] .btn-primary:active,.btn-primary.disabled.active,.btn-primary[disabled].active,fieldset[disabled] .btn-primary.active{background-color:#428bca;border-color:#357ebd}
-.btn-primary .badge{color:#428bca;background-color:#fff}
-.btn-success{color:#fff;background-color:#5cb85c;border-color:#4cae4c}.btn-success:hover,.btn-success:focus,.btn-success:active,.btn-success.active,.open .dropdown-toggle.btn-success{color:#fff;background-color:#47a447;border-color:#398439}
-.btn-success:active,.btn-success.active,.open .dropdown-toggle.btn-success{background-image:none}
-.btn-success.disabled,.btn-success[disabled],fieldset[disabled] .btn-success,.btn-success.disabled:hover,.btn-success[disabled]:hover,fieldset[disabled] .btn-success:hover,.btn-success.disabled:focus,.btn-success[disabled]:focus,fieldset[disabled] .btn-success:focus,.btn-success.disabled:active,.btn-success[disabled]:active,fieldset[disabled] .btn-success:active,.btn-success.disabled.active,.btn-success[disabled].active,fieldset[disabled] .btn-success.active{background-color:#5cb85c;border-color:#4cae4c}
-.btn-success .badge{color:#5cb85c;background-color:#fff}
-.btn-info{color:#fff;background-color:#5bc0de;border-color:#46b8da}.btn-info:hover,.btn-info:focus,.btn-info:active,.btn-info.active,.open .dropdown-toggle.btn-info{color:#fff;background-color:#39b3d7;border-color:#269abc}
-.btn-info:active,.btn-info.active,.open .dropdown-toggle.btn-info{background-image:none}
-.btn-info.disabled,.btn-info[disabled],fieldset[disabled] .btn-info,.btn-info.disabled:hover,.btn-info[disabled]:hover,fieldset[disabled] .btn-info:hover,.btn-info.disabled:focus,.btn-info[disabled]:focus,fieldset[disabled] .btn-info:focus,.btn-info.disabled:active,.btn-info[disabled]:active,fieldset[disabled] .btn-info:active,.btn-info.disabled.active,.btn-info[disabled].active,fieldset[disabled] .btn-info.active{background-color:#5bc0de;border-color:#46b8da}
-.btn-info .badge{color:#5bc0de;background-color:#fff}
-.btn-warning{color:#fff;background-color:#f0ad4e;border-color:#eea236}.btn-warning:hover,.btn-warning:focus,.btn-warning:active,.btn-warning.active,.open .dropdown-toggle.btn-warning{color:#fff;background-color:#ed9c28;border-color:#d58512}
-.btn-warning:active,.btn-warning.active,.open .dropdown-toggle.btn-warning{background-image:none}
-.btn-warning.disabled,.btn-warning[disabled],fieldset[disabled] .btn-warning,.btn-warning.disabled:hover,.btn-warning[disabled]:hover,fieldset[disabled] .btn-warning:hover,.btn-warning.disabled:focus,.btn-warning[disabled]:focus,fieldset[disabled] .btn-warning:focus,.btn-warning.disabled:active,.btn-warning[disabled]:active,fieldset[disabled] .btn-warning:active,.btn-warning.disabled.active,.btn-warning[disabled].active,fieldset[disabled] .btn-warning.active{background-color:#f0ad4e;border-color:#eea236}
-.btn-warning .badge{color:#f0ad4e;background-color:#fff}
-.btn-danger{color:#fff;background-color:#d9534f;border-color:#d43f3a}.btn-danger:hover,.btn-danger:focus,.btn-danger:active,.btn-danger.active,.open .dropdown-toggle.btn-danger{color:#fff;background-color:#d2322d;border-color:#ac2925}
-.btn-danger:active,.btn-danger.active,.open .dropdown-toggle.btn-danger{background-image:none}
-.btn-danger.disabled,.btn-danger[disabled],fieldset[disabled] .btn-danger,.btn-danger.disabled:hover,.btn-danger[disabled]:hover,fieldset[disabled] .btn-danger:hover,.btn-danger.disabled:focus,.btn-danger[disabled]:focus,fieldset[disabled] .btn-danger:focus,.btn-danger.disabled:active,.btn-danger[disabled]:active,fieldset[disabled] .btn-danger:active,.btn-danger.disabled.active,.btn-danger[disabled].active,fieldset[disabled] .btn-danger.active{background-color:#d9534f;border-color:#d43f3a}
-.btn-danger .badge{color:#d9534f;background-color:#fff}
-.btn-link{color:#428bca;font-weight:normal;cursor:pointer;border-radius:0}.btn-link,.btn-link:active,.btn-link[disabled],fieldset[disabled] .btn-link{background-color:transparent;-webkit-box-shadow:none;box-shadow:none}
-.btn-link,.btn-link:hover,.btn-link:focus,.btn-link:active{border-color:transparent}
-.btn-link:hover,.btn-link:focus{color:#2a6496;text-decoration:underline;background-color:transparent}
-.btn-link[disabled]:hover,fieldset[disabled] .btn-link:hover,.btn-link[disabled]:focus,fieldset[disabled] .btn-link:focus{color:#999;text-decoration:none}
-.btn-lg,.btn-group-lg>.btn{padding:10px 16px;font-size:17px;line-height:1.33;border-radius:6px}
-.btn-sm,.btn-group-sm>.btn{padding:5px 10px;font-size:12px;line-height:1.5;border-radius:3px}
-.btn-xs,.btn-group-xs>.btn{padding:1px 5px;font-size:12px;line-height:1.5;border-radius:3px}
-.btn-block{display:block;width:100%;padding-left:0;padding-right:0}
-.btn-block+.btn-block{margin-top:5px}
-input[type="submit"].btn-block,input[type="reset"].btn-block,input[type="button"].btn-block{width:100%}
-.fade{opacity:0;-webkit-transition:opacity .15s linear;transition:opacity .15s linear}.fade.in{opacity:1}
-.collapse{display:none}.collapse.in{display:block}
-.collapsing{position:relative;height:0;overflow:hidden;-webkit-transition:height .35s ease;transition:height .35s ease}
-@font-face{font-family:'Glyphicons Halflings';src:url('../fonts/glyphicons-halflings-regular.eot');src:url('../fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'),url('../fonts/glyphicons-halflings-regular.woff') format('woff'),url('../fonts/glyphicons-halflings-regular.ttf') format('truetype'),url('../fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg')}.glyphicon{position:relative;top:1px;display:inline-block;font-family:'Glyphicons Halflings';font-style:normal;font-weight:normal;line-height:1;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
-.glyphicon-asterisk:before{content:"\2a"}
-.glyphicon-plus:before{content:"\2b"}
-.glyphicon-euro:before{content:"\20ac"}
-.glyphicon-minus:before{content:"\2212"}
-.glyphicon-cloud:before{content:"\2601"}
-.glyphicon-envelope:before{content:"\2709"}
-.glyphicon-pencil:before{content:"\270f"}
-.glyphicon-glass:before{content:"\e001"}
-.glyphicon-music:before{content:"\e002"}
-.glyphicon-search:before{content:"\e003"}
-.glyphicon-heart:before{content:"\e005"}
-.glyphicon-star:before{content:"\e006"}
-.glyphicon-star-empty:before{content:"\e007"}
-.glyphicon-user:before{content:"\e008"}
-.glyphicon-film:before{content:"\e009"}
-.glyphicon-th-large:before{content:"\e010"}
-.glyphicon-th:before{content:"\e011"}
-.glyphicon-th-list:before{content:"\e012"}
-.glyphicon-ok:before{content:"\e013"}
-.glyphicon-remove:before{content:"\e014"}
-.glyphicon-zoom-in:before{content:"\e015"}
-.glyphicon-zoom-out:before{content:"\e016"}
-.glyphicon-off:before{content:"\e017"}
-.glyphicon-signal:before{content:"\e018"}
-.glyphicon-cog:before{content:"\e019"}
-.glyphicon-trash:before{content:"\e020"}
-.glyphicon-home:before{content:"\e021"}
-.glyphicon-file:before{content:"\e022"}
-.glyphicon-time:before{content:"\e023"}
-.glyphicon-road:before{content:"\e024"}
-.glyphicon-download-alt:before{content:"\e025"}
-.glyphicon-download:before{content:"\e026"}
-.glyphicon-upload:before{content:"\e027"}
-.glyphicon-inbox:before{content:"\e028"}
-.glyphicon-play-circle:before{content:"\e029"}
-.glyphicon-repeat:before{content:"\e030"}
-.glyphicon-refresh:before{content:"\e031"}
-.glyphicon-list-alt:before{content:"\e032"}
-.glyphicon-lock:before{content:"\e033"}
-.glyphicon-flag:before{content:"\e034"}
-.glyphicon-headphones:before{content:"\e035"}
-.glyphicon-volume-off:before{content:"\e036"}
-.glyphicon-volume-down:before{content:"\e037"}
-.glyphicon-volume-up:before{content:"\e038"}
-.glyphicon-qrcode:before{content:"\e039"}
-.glyphicon-barcode:before{content:"\e040"}
-.glyphicon-tag:before{content:"\e041"}
-.glyphicon-tags:before{content:"\e042"}
-.glyphicon-book:before{content:"\e043"}
-.glyphicon-bookmark:before{content:"\e044"}
-.glyphicon-print:before{content:"\e045"}
-.glyphicon-camera:before{content:"\e046"}
-.glyphicon-font:before{content:"\e047"}
-.glyphicon-bold:before{content:"\e048"}
-.glyphicon-italic:before{content:"\e049"}
-.glyphicon-text-height:before{content:"\e050"}
-.glyphicon-text-width:before{content:"\e051"}
-.glyphicon-align-left:before{content:"\e052"}
-.glyphicon-align-center:before{content:"\e053"}
-.glyphicon-align-right:before{content:"\e054"}
-.glyphicon-align-justify:before{content:"\e055"}
-.glyphicon-list:before{content:"\e056"}
-.glyphicon-indent-left:before{content:"\e057"}
-.glyphicon-indent-right:before{content:"\e058"}
-.glyphicon-facetime-video:before{content:"\e059"}
-.glyphicon-picture:before{content:"\e060"}
-.glyphicon-map-marker:before{content:"\e062"}
-.glyphicon-adjust:before{content:"\e063"}
-.glyphicon-tint:before{content:"\e064"}
-.glyphicon-edit:before{content:"\e065"}
-.glyphicon-share:before{content:"\e066"}
-.glyphicon-check:before{content:"\e067"}
-.glyphicon-move:before{content:"\e068"}
-.glyphicon-step-backward:before{content:"\e069"}
-.glyphicon-fast-backward:before{content:"\e070"}
-.glyphicon-backward:before{content:"\e071"}
-.glyphicon-play:before{content:"\e072"}
-.glyphicon-pause:before{content:"\e073"}
-.glyphicon-stop:before{content:"\e074"}
-.glyphicon-forward:before{content:"\e075"}
-.glyphicon-fast-forward:before{content:"\e076"}
-.glyphicon-step-forward:before{content:"\e077"}
-.glyphicon-eject:before{content:"\e078"}
-.glyphicon-chevron-left:before{content:"\e079"}
-.glyphicon-chevron-right:before{content:"\e080"}
-.glyphicon-plus-sign:before{content:"\e081"}
-.glyphicon-minus-sign:before{content:"\e082"}
-.glyphicon-remove-sign:before{content:"\e083"}
-.glyphicon-ok-sign:before{content:"\e084"}
-.glyphicon-question-sign:before{content:"\e085"}
-.glyphicon-info-sign:before{content:"\e086"}
-.glyphicon-screenshot:before{content:"\e087"}
-.glyphicon-remove-circle:before{content:"\e088"}
-.glyphicon-ok-circle:before{content:"\e089"}
-.glyphicon-ban-circle:before{content:"\e090"}
-.glyphicon-arrow-left:before{content:"\e091"}
-.glyphicon-arrow-right:before{content:"\e092"}
-.glyphicon-arrow-up:before{content:"\e093"}
-.glyphicon-arrow-down:before{content:"\e094"}
-.glyphicon-share-alt:before{content:"\e095"}
-.glyphicon-resize-full:before{content:"\e096"}
-.glyphicon-resize-small:before{content:"\e097"}
-.glyphicon-exclamation-sign:before{content:"\e101"}
-.glyphicon-gift:before{content:"\e102"}
-.glyphicon-leaf:before{content:"\e103"}
-.glyphicon-fire:before{content:"\e104"}
-.glyphicon-eye-open:before{content:"\e105"}
-.glyphicon-eye-close:before{content:"\e106"}
-.glyphicon-warning-sign:before{content:"\e107"}
-.glyphicon-plane:before{content:"\e108"}
-.glyphicon-calendar:before{content:"\e109"}
-.glyphicon-random:before{content:"\e110"}
-.glyphicon-comment:before{content:"\e111"}
-.glyphicon-magnet:before{content:"\e112"}
-.glyphicon-chevron-up:before{content:"\e113"}
-.glyphicon-chevron-down:before{content:"\e114"}
-.glyphicon-retweet:before{content:"\e115"}
-.glyphicon-shopping-cart:before{content:"\e116"}
-.glyphicon-folder-close:before{content:"\e117"}
-.glyphicon-folder-open:before{content:"\e118"}
-.glyphicon-resize-vertical:before{content:"\e119"}
-.glyphicon-resize-horizontal:before{content:"\e120"}
-.glyphicon-hdd:before{content:"\e121"}
-.glyphicon-bullhorn:before{content:"\e122"}
-.glyphicon-bell:before{content:"\e123"}
-.glyphicon-certificate:before{content:"\e124"}
-.glyphicon-thumbs-up:before{content:"\e125"}
-.glyphicon-thumbs-down:before{content:"\e126"}
-.glyphicon-hand-right:before{content:"\e127"}
-.glyphicon-hand-left:before{content:"\e128"}
-.glyphicon-hand-up:before{content:"\e129"}
-.glyphicon-hand-down:before{content:"\e130"}
-.glyphicon-circle-arrow-right:before{content:"\e131"}
-.glyphicon-circle-arrow-left:before{content:"\e132"}
-.glyphicon-circle-arrow-up:before{content:"\e133"}
-.glyphicon-circle-arrow-down:before{content:"\e134"}
-.glyphicon-globe:before{content:"\e135"}
-.glyphicon-wrench:before{content:"\e136"}
-.glyphicon-tasks:before{content:"\e137"}
-.glyphicon-filter:before{content:"\e138"}
-.glyphicon-briefcase:before{content:"\e139"}
-.glyphicon-fullscreen:before{content:"\e140"}
-.glyphicon-dashboard:before{content:"\e141"}
-.glyphicon-paperclip:before{content:"\e142"}
-.glyphicon-heart-empty:before{content:"\e143"}
-.glyphicon-link:before{content:"\e144"}
-.glyphicon-phone:before{content:"\e145"}
-.glyphicon-pushpin:before{content:"\e146"}
-.glyphicon-usd:before{content:"\e148"}
-.glyphicon-gbp:before{content:"\e149"}
-.glyphicon-sort:before{content:"\e150"}
-.glyphicon-sort-by-alphabet:before{content:"\e151"}
-.glyphicon-sort-by-alphabet-alt:before{content:"\e152"}
-.glyphicon-sort-by-order:before{content:"\e153"}
-.glyphicon-sort-by-order-alt:before{content:"\e154"}
-.glyphicon-sort-by-attributes:before{content:"\e155"}
-.glyphicon-sort-by-attributes-alt:before{content:"\e156"}
-.glyphicon-unchecked:before{content:"\e157"}
-.glyphicon-expand:before{content:"\e158"}
-.glyphicon-collapse-down:before{content:"\e159"}
-.glyphicon-collapse-up:before{content:"\e160"}
-.glyphicon-log-in:before{content:"\e161"}
-.glyphicon-flash:before{content:"\e162"}
-.glyphicon-log-out:before{content:"\e163"}
-.glyphicon-new-window:before{content:"\e164"}
-.glyphicon-record:before{content:"\e165"}
-.glyphicon-save:before{content:"\e166"}
-.glyphicon-open:before{content:"\e167"}
-.glyphicon-saved:before{content:"\e168"}
-.glyphicon-import:before{content:"\e169"}
-.glyphicon-export:before{content:"\e170"}
-.glyphicon-send:before{content:"\e171"}
-.glyphicon-floppy-disk:before{content:"\e172"}
-.glyphicon-floppy-saved:before{content:"\e173"}
-.glyphicon-floppy-remove:before{content:"\e174"}
-.glyphicon-floppy-save:before{content:"\e175"}
-.glyphicon-floppy-open:before{content:"\e176"}
-.glyphicon-credit-card:before{content:"\e177"}
-.glyphicon-transfer:before{content:"\e178"}
-.glyphicon-cutlery:before{content:"\e179"}
-.glyphicon-header:before{content:"\e180"}
-.glyphicon-compressed:before{content:"\e181"}
-.glyphicon-earphone:before{content:"\e182"}
-.glyphicon-phone-alt:before{content:"\e183"}
-.glyphicon-tower:before{content:"\e184"}
-.glyphicon-stats:before{content:"\e185"}
-.glyphicon-sd-video:before{content:"\e186"}
-.glyphicon-hd-video:before{content:"\e187"}
-.glyphicon-subtitles:before{content:"\e188"}
-.glyphicon-sound-stereo:before{content:"\e189"}
-.glyphicon-sound-dolby:before{content:"\e190"}
-.glyphicon-sound-5-1:before{content:"\e191"}
-.glyphicon-sound-6-1:before{content:"\e192"}
-.glyphicon-sound-7-1:before{content:"\e193"}
-.glyphicon-copyright-mark:before{content:"\e194"}
-.glyphicon-registration-mark:before{content:"\e195"}
-.glyphicon-cloud-download:before{content:"\e197"}
-.glyphicon-cloud-upload:before{content:"\e198"}
-.glyphicon-tree-conifer:before{content:"\e199"}
-.glyphicon-tree-deciduous:before{content:"\e200"}
-.caret{display:inline-block;width:0;height:0;margin-left:2px;vertical-align:middle;border-top:4px solid;border-right:4px solid transparent;border-left:4px solid transparent}
-.dropdown{position:relative}
-.dropdown-toggle:focus{outline:0}
-.dropdown-menu{position:absolute;top:100%;left:0;z-index:1000;display:none;float:left;min-width:160px;padding:5px 0;margin:2px 0 0;list-style:none;font-size:13px;background-color:#fff;border:1px solid #ccc;border:1px solid rgba(0,0,0,0.15);border-radius:4px;-webkit-box-shadow:0 6px 12px rgba(0,0,0,0.175);box-shadow:0 6px 12px rgba(0,0,0,0.175);background-clip:padding-box}.dropdown-menu.pull-right{right:0;left:auto}
-.dropdown-menu .divider{height:1px;margin:8px 0;overflow:hidden;background-color:#e5e5e5}
-.dropdown-menu>li>a{display:block;padding:3px 20px;clear:both;font-weight:normal;line-height:1.428571429;color:#333;white-space:nowrap}
-.dropdown-menu>li>a:hover,.dropdown-menu>li>a:focus{text-decoration:none;color:#262626;background-color:#f5f5f5}
-.dropdown-menu>.active>a,.dropdown-menu>.active>a:hover,.dropdown-menu>.active>a:focus{color:#fff;text-decoration:none;outline:0;background-color:#428bca}
-.dropdown-menu>.disabled>a,.dropdown-menu>.disabled>a:hover,.dropdown-menu>.disabled>a:focus{color:#999}
-.dropdown-menu>.disabled>a:hover,.dropdown-menu>.disabled>a:focus{text-decoration:none;background-color:transparent;background-image:none;filter:progid:DXImageTransform.Microsoft.gradient(enabled = false);cursor:not-allowed}
-.open>.dropdown-menu{display:block}
-.open>a{outline:0}
-.dropdown-menu-right{left:auto;right:0}
-.dropdown-menu-left{left:0;right:auto}
-.dropdown-header{display:block;padding:3px 20px;font-size:12px;line-height:1.428571429;color:#999}
-.dropdown-backdrop{position:fixed;left:0;right:0;bottom:0;top:0;z-index:990}
-.pull-right>.dropdown-menu{right:0;left:auto}
-.dropup .caret,.navbar-fixed-bottom .dropdown .caret{border-top:0;border-bottom:4px solid;content:""}
-.dropup .dropdown-menu,.navbar-fixed-bottom .dropdown .dropdown-menu{top:auto;bottom:100%;margin-bottom:1px}
-@media (min-width:768px){.navbar-right .dropdown-menu{left:auto;right:0} .navbar-right .dropdown-menu-left{left:0;right:auto}}.btn-group,.btn-group-vertical{position:relative;display:inline-block;vertical-align:middle}.btn-group>.btn,.btn-group-vertical>.btn{position:relative;float:left}.btn-group>.btn:hover,.btn-group-vertical>.btn:hover,.btn-group>.btn:focus,.btn-group-vertical>.btn:focus,.btn-group>.btn:active,.btn-group-vertical>.btn:active,.btn-group>.btn.active,.btn-group-vertical>.btn.active{z-index:2}
-.btn-group>.btn:focus,.btn-group-vertical>.btn:focus{outline:none}
-.btn-group .btn+.btn,.btn-group .btn+.btn-group,.btn-group .btn-group+.btn,.btn-group .btn-group+.btn-group{margin-left:-1px}
-.btn-toolbar{margin-left:-5px}.btn-toolbar .btn-group,.btn-toolbar .input-group{float:left}
-.btn-toolbar>.btn,.btn-toolbar>.btn-group,.btn-toolbar>.input-group{margin-left:5px}
-.btn-group>.btn:not(:first-child):not(:last-child):not(.dropdown-toggle){border-radius:0}
-.btn-group>.btn:first-child{margin-left:0}.btn-group>.btn:first-child:not(:last-child):not(.dropdown-toggle){border-bottom-right-radius:0;border-top-right-radius:0}
-.btn-group>.btn:last-child:not(:first-child),.btn-group>.dropdown-toggle:not(:first-child){border-bottom-left-radius:0;border-top-left-radius:0}
-.btn-group>.btn-group{float:left}
-.btn-group>.btn-group:not(:first-child):not(:last-child)>.btn{border-radius:0}
-.btn-group>.btn-group:first-child>.btn:last-child,.btn-group>.btn-group:first-child>.dropdown-toggle{border-bottom-right-radius:0;border-top-right-radius:0}
-.btn-group>.btn-group:last-child>.btn:first-child{border-bottom-left-radius:0;border-top-left-radius:0}
-.btn-group .dropdown-toggle:active,.btn-group.open .dropdown-toggle{outline:0}
-.btn-group>.btn+.dropdown-toggle{padding-left:8px;padding-right:8px}
-.btn-group>.btn-lg+.dropdown-toggle{padding-left:12px;padding-right:12px}
-.btn-group.open .dropdown-toggle{-webkit-box-shadow:inset 0 3px 5px rgba(0,0,0,0.125);box-shadow:inset 0 3px 5px rgba(0,0,0,0.125)}.btn-group.open .dropdown-toggle.btn-link{-webkit-box-shadow:none;box-shadow:none}
-.btn .caret{margin-left:0}
-.btn-lg .caret{border-width:5px 5px 0;border-bottom-width:0}
-.dropup .btn-lg .caret{border-width:0 5px 5px}
-.btn-group-vertical>.btn,.btn-group-vertical>.btn-group,.btn-group-vertical>.btn-group>.btn{display:block;float:none;width:100%;max-width:100%}
-.btn-group-vertical>.btn-group>.btn{float:none}
-.btn-group-vertical>.btn+.btn,.btn-group-vertical>.btn+.btn-group,.btn-group-vertical>.btn-group+.btn,.btn-group-vertical>.btn-group+.btn-group{margin-top:-1px;margin-left:0}
-.btn-group-vertical>.btn:not(:first-child):not(:last-child){border-radius:0}
-.btn-group-vertical>.btn:first-child:not(:last-child){border-top-right-radius:4px;border-bottom-right-radius:0;border-bottom-left-radius:0}
-.btn-group-vertical>.btn:last-child:not(:first-child){border-bottom-left-radius:4px;border-top-right-radius:0;border-top-left-radius:0}
-.btn-group-vertical>.btn-group:not(:first-child):not(:last-child)>.btn{border-radius:0}
-.btn-group-vertical>.btn-group:first-child:not(:last-child)>.btn:last-child,.btn-group-vertical>.btn-group:first-child:not(:last-child)>.dropdown-toggle{border-bottom-right-radius:0;border-bottom-left-radius:0}
-.btn-group-vertical>.btn-group:last-child:not(:first-child)>.btn:first-child{border-top-right-radius:0;border-top-left-radius:0}
-.btn-group-justified{display:table;width:100%;table-layout:fixed;border-collapse:separate}.btn-group-justified>.btn,.btn-group-justified>.btn-group{float:none;display:table-cell;width:1%}
-.btn-group-justified>.btn-group .btn{width:100%}
-[data-toggle="buttons"]>.btn>input[type="radio"],[data-toggle="buttons"]>.btn>input[type="checkbox"]{display:none}
-.input-group{position:relative;display:table;border-collapse:separate}.input-group[class*="col-"]{float:none;padding-left:0;padding-right:0}
-.input-group .form-control{position:relative;z-index:2;float:left;width:100%;margin-bottom:0}
-.input-group-lg>.form-control,.input-group-lg>.input-group-addon,.input-group-lg>.input-group-btn>.btn{height:45px;padding:10px 16px;font-size:17px;line-height:1.33;border-radius:6px}select.input-group-lg>.form-control,select.input-group-lg>.input-group-addon,select.input-group-lg>.input-group-btn>.btn{height:45px;line-height:45px}
-textarea.input-group-lg>.form-control,textarea.input-group-lg>.input-group-addon,textarea.input-group-lg>.input-group-btn>.btn,select[multiple].input-group-lg>.form-control,select[multiple].input-group-lg>.input-group-addon,select[multiple].input-group-lg>.input-group-btn>.btn{height:auto}
-.input-group-sm>.form-control,.input-group-sm>.input-group-addon,.input-group-sm>.input-group-btn>.btn{height:30px;padding:5px 10px;font-size:12px;line-height:1.5;border-radius:3px}select.input-group-sm>.form-control,select.input-group-sm>.input-group-addon,select.input-group-sm>.input-group-btn>.btn{height:30px;line-height:30px}
-textarea.input-group-sm>.form-control,textarea.input-group-sm>.input-group-addon,textarea.input-group-sm>.input-group-btn>.btn,select[multiple].input-group-sm>.form-control,select[multiple].input-group-sm>.input-group-addon,select[multiple].input-group-sm>.input-group-btn>.btn{height:auto}
-.input-group-addon,.input-group-btn,.input-group .form-control{display:table-cell}.input-group-addon:not(:first-child):not(:last-child),.input-group-btn:not(:first-child):not(:last-child),.input-group .form-control:not(:first-child):not(:last-child){border-radius:0}
-.input-group-addon,.input-group-btn{width:1%;white-space:nowrap;vertical-align:middle}
-.input-group-addon{padding:6px 12px;font-size:13px;font-weight:normal;line-height:1;color:#555;text-align:center;background-color:#eee;border:1px solid #ccc;border-radius:4px}.input-group-addon.input-sm{padding:5px 10px;font-size:12px;border-radius:3px}
-.input-group-addon.input-lg{padding:10px 16px;font-size:17px;border-radius:6px}
-.input-group-addon input[type="radio"],.input-group-addon input[type="checkbox"]{margin-top:0}
-.input-group .form-control:first-child,.input-group-addon:first-child,.input-group-btn:first-child>.btn,.input-group-btn:first-child>.btn-group>.btn,.input-group-btn:first-child>.dropdown-toggle,.input-group-btn:last-child>.btn:not(:last-child):not(.dropdown-toggle),.input-group-btn:last-child>.btn-group:not(:last-child)>.btn{border-bottom-right-radius:0;border-top-right-radius:0}
-.input-group-addon:first-child{border-right:0}
-.input-group .form-control:last-child,.input-group-addon:last-child,.input-group-btn:last-child>.btn,.input-group-btn:last-child>.btn-group>.btn,.input-group-btn:last-child>.dropdown-toggle,.input-group-btn:first-child>.btn:not(:first-child),.input-group-btn:first-child>.btn-group:not(:first-child)>.btn{border-bottom-left-radius:0;border-top-left-radius:0}
-.input-group-addon:last-child{border-left:0}
-.input-group-btn{position:relative;font-size:0;white-space:nowrap}.input-group-btn>.btn{position:relative}.input-group-btn>.btn+.btn{margin-left:-1px}
-.input-group-btn>.btn:hover,.input-group-btn>.btn:focus,.input-group-btn>.btn:active{z-index:2}
-.input-group-btn:first-child>.btn,.input-group-btn:first-child>.btn-group{margin-right:-1px}
-.input-group-btn:last-child>.btn,.input-group-btn:last-child>.btn-group{margin-left:-1px}
-.nav{margin-bottom:0;padding-left:0;list-style:none}.nav>li{position:relative;display:block}.nav>li>a{position:relative;display:block;padding:10px 15px}.nav>li>a:hover,.nav>li>a:focus{text-decoration:none;background-color:#eee}
-.nav>li.disabled>a{color:#999}.nav>li.disabled>a:hover,.nav>li.disabled>a:focus{color:#999;text-decoration:none;background-color:transparent;cursor:not-allowed}
-.nav .open>a,.nav .open>a:hover,.nav .open>a:focus{background-color:#eee;border-color:#428bca}
-.nav .nav-divider{height:1px;margin:8px 0;overflow:hidden;background-color:#e5e5e5}
-.nav>li>a>img{max-width:none}
-.nav-tabs{border-bottom:1px solid #ddd}.nav-tabs>li{float:left;margin-bottom:-1px}.nav-tabs>li>a{margin-right:2px;line-height:1.428571429;border:1px solid transparent;border-radius:4px 4px 0 0}.nav-tabs>li>a:hover{border-color:#eee #eee #ddd}
-.nav-tabs>li.active>a,.nav-tabs>li.active>a:hover,.nav-tabs>li.active>a:focus{color:#555;background-color:#fff;border:1px solid #ddd;border-bottom-color:transparent;cursor:default}
-.nav-tabs.nav-justified{width:100%;border-bottom:0}.nav-tabs.nav-justified>li{float:none}.nav-tabs.nav-justified>li>a{text-align:center;margin-bottom:5px}
-.nav-tabs.nav-justified>.dropdown .dropdown-menu{top:auto;left:auto}
-@media (min-width:768px){.nav-tabs.nav-justified>li{display:table-cell;width:1%}.nav-tabs.nav-justified>li>a{margin-bottom:0}}.nav-tabs.nav-justified>li>a{margin-right:0;border-radius:4px}
-.nav-tabs.nav-justified>.active>a,.nav-tabs.nav-justified>.active>a:hover,.nav-tabs.nav-justified>.active>a:focus{border:1px solid #ddd}
-@media (min-width:768px){.nav-tabs.nav-justified>li>a{border-bottom:1px solid #ddd;border-radius:4px 4px 0 0} .nav-tabs.nav-justified>.active>a,.nav-tabs.nav-justified>.active>a:hover,.nav-tabs.nav-justified>.active>a:focus{border-bottom-color:#fff}}
-.nav-pills>li{float:left}.nav-pills>li>a{border-radius:4px}
-.nav-pills>li+li{margin-left:2px}
-.nav-pills>li.active>a,.nav-pills>li.active>a:hover,.nav-pills>li.active>a:focus{color:#fff;background-color:#428bca}
-.nav-stacked>li{float:none}.nav-stacked>li+li{margin-top:2px;margin-left:0}
-.nav-justified{width:100%}.nav-justified>li{float:none}.nav-justified>li>a{text-align:center;margin-bottom:5px}
-.nav-justified>.dropdown .dropdown-menu{top:auto;left:auto}
-@media (min-width:768px){.nav-justified>li{display:table-cell;width:1%}.nav-justified>li>a{margin-bottom:0}}
-.nav-tabs-justified{border-bottom:0}.nav-tabs-justified>li>a{margin-right:0;border-radius:4px}
-.nav-tabs-justified>.active>a,.nav-tabs-justified>.active>a:hover,.nav-tabs-justified>.active>a:focus{border:1px solid #ddd}
-@media (min-width:768px){.nav-tabs-justified>li>a{border-bottom:1px solid #ddd;border-radius:4px 4px 0 0} .nav-tabs-justified>.active>a,.nav-tabs-justified>.active>a:hover,.nav-tabs-justified>.active>a:focus{border-bottom-color:#fff}}
-.tab-content>.tab-pane{display:none}
-.tab-content>.active{display:block}
-.nav-tabs .dropdown-menu{margin-top:-1px;border-top-right-radius:0;border-top-left-radius:0}
-.navbar{position:relative;min-height:36px;margin-bottom:18px;border:1px solid transparent}@media (min-width:768px){.navbar{border-radius:4px}}
-@media (min-width:768px){.navbar-header{float:left}}
-.navbar-collapse{max-height:340px;overflow-x:visible;padding-right:15px;padding-left:15px;border-top:1px solid transparent;box-shadow:inset 0 1px 0 rgba(255,255,255,0.1);-webkit-overflow-scrolling:touch}.navbar-collapse.in{overflow-y:auto}
-@media (min-width:768px){.navbar-collapse{width:auto;border-top:0;box-shadow:none}.navbar-collapse.collapse{display:block !important;height:auto !important;padding-bottom:0;overflow:visible !important} .navbar-collapse.in{overflow-y:visible} .navbar-fixed-top .navbar-collapse,.navbar-static-top .navbar-collapse,.navbar-fixed-bottom .navbar-collapse{padding-left:0;padding-right:0}}
-.container>.navbar-header,.container-fluid>.navbar-header,.container>.navbar-collapse,.container-fluid>.navbar-collapse{margin-right:-15px;margin-left:-15px}@media (min-width:768px){.container>.navbar-header,.container-fluid>.navbar-header,.container>.navbar-collapse,.container-fluid>.navbar-collapse{margin-right:0;margin-left:0}}
-.navbar-static-top{z-index:1000;border-width:0 0 1px}@media (min-width:768px){.navbar-static-top{border-radius:0}}
-.navbar-fixed-top,.navbar-fixed-bottom{position:fixed;right:0;left:0;z-index:1030}@media (min-width:768px){.navbar-fixed-top,.navbar-fixed-bottom{border-radius:0}}
-.navbar-fixed-top{top:0;border-width:0 0 1px}
-.navbar-fixed-bottom{bottom:0;margin-bottom:0;border-width:1px 0 0}
-.navbar-brand{float:left;padding:9px 15px;font-size:17px;line-height:18px;height:36px}.navbar-brand:hover,.navbar-brand:focus{text-decoration:none}
-@media (min-width:768px){.navbar>.container .navbar-brand,.navbar>.container-fluid .navbar-brand{margin-left:-15px}}
-.navbar-toggle{position:relative;float:right;margin-right:15px;padding:9px 10px;margin-top:1px;margin-bottom:1px;background-color:transparent;background-image:none;border:1px solid transparent;border-radius:4px}.navbar-toggle:focus{outline:none}
-.navbar-toggle .icon-bar{display:block;width:22px;height:2px;border-radius:1px}
-.navbar-toggle .icon-bar+.icon-bar{margin-top:4px}
-@media (min-width:768px){.navbar-toggle{display:none}}
-.navbar-nav{margin:4.5px -15px}.navbar-nav>li>a{padding-top:10px;padding-bottom:10px;line-height:18px}
-@media (max-width:767px){.navbar-nav .open .dropdown-menu{position:static;float:none;width:auto;margin-top:0;background-color:transparent;border:0;box-shadow:none}.navbar-nav .open .dropdown-menu>li>a,.navbar-nav .open .dropdown-menu .dropdown-header{padding:5px 15px 5px 25px} .navbar-nav .open .dropdown-menu>li>a{line-height:18px}.navbar-nav .open .dropdown-menu>li>a:hover,.navbar-nav .open .dropdown-menu>li>a:focus{background-image:none}}@media (min-width:768px){.navbar-nav{float:left;margin:0}.navbar-nav>li{float:left}.navbar-nav>li>a{padding-top:9px;padding-bottom:9px} .navbar-nav.navbar-right:last-child{margin-right:-15px}}
-@media (min-width:768px){.navbar-left{float:left !important;float:left} .navbar-right{float:right !important;float:right}}.navbar-form{margin-left:-15px;margin-right:-15px;padding:10px 15px;border-top:1px solid transparent;border-bottom:1px solid transparent;-webkit-box-shadow:inset 0 1px 0 rgba(255,255,255,0.1),0 1px 0 rgba(255,255,255,0.1);box-shadow:inset 0 1px 0 rgba(255,255,255,0.1),0 1px 0 rgba(255,255,255,0.1);margin-top:2px;margin-bottom:2px}@media (min-width:768px){.navbar-form .form-group{display:inline-block;margin-bottom:0;vertical-align:middle} .navbar-form .form-control{display:inline-block;width:auto;vertical-align:middle} .navbar-form .input-group>.form-control{width:100%} .navbar-form .control-label{margin-bottom:0;vertical-align:middle} .navbar-form .radio,.navbar-form .checkbox{display:inline-block;margin-top:0;margin-bottom:0;padding-left:0;vertical-align:middle} .navbar-form .radio input[type="radio"],.navbar-form .checkbox input[type="checkbox"]{float:none;margin-left:0} .navbar-form .has-feedback .form-control-feedback{top:0}}@media (max-width:767px){.navbar-form .form-group{margin-bottom:5px}}
-@media (min-width:768px){.navbar-form{width:auto;border:0;margin-left:0;margin-right:0;padding-top:0;padding-bottom:0;-webkit-box-shadow:none;box-shadow:none}.navbar-form.navbar-right:last-child{margin-right:-15px}}
-.navbar-nav>li>.dropdown-menu{margin-top:0;border-top-right-radius:0;border-top-left-radius:0}
-.navbar-fixed-bottom .navbar-nav>li>.dropdown-menu{border-bottom-right-radius:0;border-bottom-left-radius:0}
-.navbar-btn{margin-top:2px;margin-bottom:2px}.navbar-btn.btn-sm{margin-top:3px;margin-bottom:3px}
-.navbar-btn.btn-xs{margin-top:7px;margin-bottom:7px}
-.navbar-text{margin-top:9px;margin-bottom:9px}@media (min-width:768px){.navbar-text{float:left;margin-left:15px;margin-right:15px}.navbar-text.navbar-right:last-child{margin-right:0}}
-.navbar-default{background-color:#f8f8f8;border-color:#e7e7e7}.navbar-default .navbar-brand{color:#777}.navbar-default .navbar-brand:hover,.navbar-default .navbar-brand:focus{color:#5e5e5e;background-color:transparent}
-.navbar-default .navbar-text{color:#777}
-.navbar-default .navbar-nav>li>a{color:#777}.navbar-default .navbar-nav>li>a:hover,.navbar-default .navbar-nav>li>a:focus{color:#333;background-color:transparent}
-.navbar-default .navbar-nav>.active>a,.navbar-default .navbar-nav>.active>a:hover,.navbar-default .navbar-nav>.active>a:focus{color:#555;background-color:#e7e7e7}
-.navbar-default .navbar-nav>.disabled>a,.navbar-default .navbar-nav>.disabled>a:hover,.navbar-default .navbar-nav>.disabled>a:focus{color:#ccc;background-color:transparent}
-.navbar-default .navbar-toggle{border-color:#ddd}.navbar-default .navbar-toggle:hover,.navbar-default .navbar-toggle:focus{background-color:#ddd}
-.navbar-default .navbar-toggle .icon-bar{background-color:#888}
-.navbar-default .navbar-collapse,.navbar-default .navbar-form{border-color:#e7e7e7}
-.navbar-default .navbar-nav>.open>a,.navbar-default .navbar-nav>.open>a:hover,.navbar-default .navbar-nav>.open>a:focus{background-color:#e7e7e7;color:#555}
-@media (max-width:767px){.navbar-default .navbar-nav .open .dropdown-menu>li>a{color:#777}.navbar-default .navbar-nav .open .dropdown-menu>li>a:hover,.navbar-default .navbar-nav .open .dropdown-menu>li>a:focus{color:#333;background-color:transparent} .navbar-default .navbar-nav .open .dropdown-menu>.active>a,.navbar-default .navbar-nav .open .dropdown-menu>.active>a:hover,.navbar-default .navbar-nav .open .dropdown-menu>.active>a:focus{color:#555;background-color:#e7e7e7} .navbar-default .navbar-nav .open .dropdown-menu>.disabled>a,.navbar-default .navbar-nav .open .dropdown-menu>.disabled>a:hover,.navbar-default .navbar-nav .open .dropdown-menu>.disabled>a:focus{color:#ccc;background-color:transparent}}
-.navbar-default .navbar-link{color:#777}.navbar-default .navbar-link:hover{color:#333}
-.navbar-inverse{background-color:#222;border-color:#080808}.navbar-inverse .navbar-brand{color:#999}.navbar-inverse .navbar-brand:hover,.navbar-inverse .navbar-brand:focus{color:#fff;background-color:transparent}
-.navbar-inverse .navbar-text{color:#999}
-.navbar-inverse .navbar-nav>li>a{color:#999}.navbar-inverse .navbar-nav>li>a:hover,.navbar-inverse .navbar-nav>li>a:focus{color:#fff;background-color:transparent}
-.navbar-inverse .navbar-nav>.active>a,.navbar-inverse .navbar-nav>.active>a:hover,.navbar-inverse .navbar-nav>.active>a:focus{color:#fff;background-color:#080808}
-.navbar-inverse .navbar-nav>.disabled>a,.navbar-inverse .navbar-nav>.disabled>a:hover,.navbar-inverse .navbar-nav>.disabled>a:focus{color:#444;background-color:transparent}
-.navbar-inverse .navbar-toggle{border-color:#333}.navbar-inverse .navbar-toggle:hover,.navbar-inverse .navbar-toggle:focus{background-color:#333}
-.navbar-inverse .navbar-toggle .icon-bar{background-color:#fff}
-.navbar-inverse .navbar-collapse,.navbar-inverse .navbar-form{border-color:#101010}
-.navbar-inverse .navbar-nav>.open>a,.navbar-inverse .navbar-nav>.open>a:hover,.navbar-inverse .navbar-nav>.open>a:focus{background-color:#080808;color:#fff}
-@media (max-width:767px){.navbar-inverse .navbar-nav .open .dropdown-menu>.dropdown-header{border-color:#080808} .navbar-inverse .navbar-nav .open .dropdown-menu .divider{background-color:#080808} .navbar-inverse .navbar-nav .open .dropdown-menu>li>a{color:#999}.navbar-inverse .navbar-nav .open .dropdown-menu>li>a:hover,.navbar-inverse .navbar-nav .open .dropdown-menu>li>a:focus{color:#fff;background-color:transparent} .navbar-inverse .navbar-nav .open .dropdown-menu>.active>a,.navbar-inverse .navbar-nav .open .dropdown-menu>.active>a:hover,.navbar-inverse .navbar-nav .open .dropdown-menu>.active>a:focus{color:#fff;background-color:#080808} .navbar-inverse .navbar-nav .open .dropdown-menu>.disabled>a,.navbar-inverse .navbar-nav .open .dropdown-menu>.disabled>a:hover,.navbar-inverse .navbar-nav .open .dropdown-menu>.disabled>a:focus{color:#444;background-color:transparent}}
-.navbar-inverse .navbar-link{color:#999}.navbar-inverse .navbar-link:hover{color:#fff}
-.breadcrumb{padding:8px 15px;margin-bottom:18px;list-style:none;background-color:#f5f5f5;border-radius:4px}.breadcrumb>li{display:inline-block}.breadcrumb>li+li:before{content:"/\00a0";padding:0 5px;color:#5e5e5e}
-.breadcrumb>.active{color:#999}
-.pagination{display:inline-block;padding-left:0;margin:18px 0;border-radius:4px}.pagination>li{display:inline}.pagination>li>a,.pagination>li>span{position:relative;float:left;padding:6px 12px;line-height:1.428571429;text-decoration:none;color:#428bca;background-color:#fff;border:1px solid #ddd;margin-left:-1px}
-.pagination>li:first-child>a,.pagination>li:first-child>span{margin-left:0;border-bottom-left-radius:4px;border-top-left-radius:4px}
-.pagination>li:last-child>a,.pagination>li:last-child>span{border-bottom-right-radius:4px;border-top-right-radius:4px}
-.pagination>li>a:hover,.pagination>li>span:hover,.pagination>li>a:focus,.pagination>li>span:focus{color:#2a6496;background-color:#eee;border-color:#ddd}
-.pagination>.active>a,.pagination>.active>span,.pagination>.active>a:hover,.pagination>.active>span:hover,.pagination>.active>a:focus,.pagination>.active>span:focus{z-index:2;color:#fff;background-color:#428bca;border-color:#428bca;cursor:default}
-.pagination>.disabled>span,.pagination>.disabled>span:hover,.pagination>.disabled>span:focus,.pagination>.disabled>a,.pagination>.disabled>a:hover,.pagination>.disabled>a:focus{color:#999;background-color:#fff;border-color:#ddd;cursor:not-allowed}
-.pagination-lg>li>a,.pagination-lg>li>span{padding:10px 16px;font-size:17px}
-.pagination-lg>li:first-child>a,.pagination-lg>li:first-child>span{border-bottom-left-radius:6px;border-top-left-radius:6px}
-.pagination-lg>li:last-child>a,.pagination-lg>li:last-child>span{border-bottom-right-radius:6px;border-top-right-radius:6px}
-.pagination-sm>li>a,.pagination-sm>li>span{padding:5px 10px;font-size:12px}
-.pagination-sm>li:first-child>a,.pagination-sm>li:first-child>span{border-bottom-left-radius:3px;border-top-left-radius:3px}
-.pagination-sm>li:last-child>a,.pagination-sm>li:last-child>span{border-bottom-right-radius:3px;border-top-right-radius:3px}
-.pager{padding-left:0;margin:18px 0;list-style:none;text-align:center}.pager li{display:inline}.pager li>a,.pager li>span{display:inline-block;padding:5px 14px;background-color:#fff;border:1px solid #ddd;border-radius:15px}
-.pager li>a:hover,.pager li>a:focus{text-decoration:none;background-color:#eee}
-.pager .next>a,.pager .next>span{float:right}
-.pager .previous>a,.pager .previous>span{float:left}
-.pager .disabled>a,.pager .disabled>a:hover,.pager .disabled>a:focus,.pager .disabled>span{color:#999;background-color:#fff;cursor:not-allowed}
-.label{display:inline;padding:.2em .6em .3em;font-size:75%;font-weight:bold;line-height:1;color:#fff;text-align:center;white-space:nowrap;vertical-align:baseline;border-radius:.25em}.label[href]:hover,.label[href]:focus{color:#fff;text-decoration:none;cursor:pointer}
-.label:empty{display:none}
-.btn .label{position:relative;top:-1px}
-.label-default{background-color:#999}.label-default[href]:hover,.label-default[href]:focus{background-color:#808080}
-.label-primary{background-color:#428bca}.label-primary[href]:hover,.label-primary[href]:focus{background-color:#3071a9}
-.label-success{background-color:#5cb85c}.label-success[href]:hover,.label-success[href]:focus{background-color:#449d44}
-.label-info{background-color:#5bc0de}.label-info[href]:hover,.label-info[href]:focus{background-color:#31b0d5}
-.label-warning{background-color:#f0ad4e}.label-warning[href]:hover,.label-warning[href]:focus{background-color:#ec971f}
-.label-danger{background-color:#d9534f}.label-danger[href]:hover,.label-danger[href]:focus{background-color:#c9302c}
-.badge{display:inline-block;min-width:10px;padding:3px 7px;font-size:12px;font-weight:bold;color:#fff;line-height:1;vertical-align:baseline;white-space:nowrap;text-align:center;background-color:#999;border-radius:10px}.badge:empty{display:none}
-.btn .badge{position:relative;top:-1px}
-.btn-xs .badge{top:0;padding:1px 5px}
-a.badge:hover,a.badge:focus{color:#fff;text-decoration:none;cursor:pointer}
-a.list-group-item.active>.badge,.nav-pills>.active>a>.badge{color:#428bca;background-color:#fff}
-.nav-pills>li>a>.badge{margin-left:3px}
-.jumbotron{padding:30px;margin-bottom:30px;color:inherit;background-color:#eee}.jumbotron h1,.jumbotron .h1{color:inherit}
-.jumbotron p{margin-bottom:15px;font-size:20px;font-weight:200}
-.container .jumbotron{border-radius:6px}
-.jumbotron .container{max-width:100%}
-@media screen and (min-width:768px){.jumbotron{padding-top:48px;padding-bottom:48px}.container .jumbotron{padding-left:60px;padding-right:60px} .jumbotron h1,.jumbotron .h1{font-size:58.5px}}
-.thumbnail{display:block;padding:4px;margin-bottom:18px;line-height:1.428571429;background-color:#fff;border:1px solid #ddd;border-radius:4px;-webkit-transition:all .2s ease-in-out;transition:all .2s ease-in-out}.thumbnail>img,.thumbnail a>img{margin-left:auto;margin-right:auto}
-a.thumbnail:hover,a.thumbnail:focus,a.thumbnail.active{border-color:#428bca}
-.thumbnail .caption{padding:9px;color:#000}
-.alert{padding:15px;margin-bottom:18px;border:1px solid transparent;border-radius:4px}.alert h4{margin-top:0;color:inherit}
-.alert .alert-link{font-weight:bold}
-.alert>p,.alert>ul{margin-bottom:0}
-.alert>p+p{margin-top:5px}
-.alert-dismissable{padding-right:35px}.alert-dismissable .close{position:relative;top:-2px;right:-21px;color:inherit}
-.alert-success{background-color:#dff0d8;border-color:#d6e9c6;color:#3c763d}.alert-success hr{border-top-color:#c9e2b3}
-.alert-success .alert-link{color:#2b542c}
-.alert-info{background-color:#d9edf7;border-color:#bce8f1;color:#31708f}.alert-info hr{border-top-color:#a6e1ec}
-.alert-info .alert-link{color:#245269}
-.alert-warning{background-color:#fcf8e3;border-color:#faebcc;color:#8a6d3b}.alert-warning hr{border-top-color:#f7e1b5}
-.alert-warning .alert-link{color:#66512c}
-.alert-danger{background-color:#f2dede;border-color:#ebccd1;color:#a94442}.alert-danger hr{border-top-color:#e4b9c0}
-.alert-danger .alert-link{color:#843534}
-@-webkit-keyframes progress-bar-stripes{from{background-position:40px 0} to{background-position:0 0}}@keyframes progress-bar-stripes{from{background-position:40px 0} to{background-position:0 0}}.progress{overflow:hidden;height:18px;margin-bottom:18px;background-color:#f5f5f5;border-radius:4px;-webkit-box-shadow:inset 0 1px 2px rgba(0,0,0,0.1);box-shadow:inset 0 1px 2px rgba(0,0,0,0.1)}
-.progress-bar{float:left;width:0;height:100%;font-size:12px;line-height:18px;color:#fff;text-align:center;background-color:#428bca;-webkit-box-shadow:inset 0 -1px 0 rgba(0,0,0,0.15);box-shadow:inset 0 -1px 0 rgba(0,0,0,0.15);-webkit-transition:width .6s ease;transition:width .6s ease}
-.progress-striped .progress-bar{background-image:-webkit-linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent);background-image:linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent);background-size:40px 40px}
-.progress.active .progress-bar{-webkit-animation:progress-bar-stripes 2s linear infinite;animation:progress-bar-stripes 2s linear infinite}
-.progress-bar-success{background-color:#5cb85c}.progress-striped .progress-bar-success{background-image:-webkit-linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent);background-image:linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent)}
-.progress-bar-info{background-color:#5bc0de}.progress-striped .progress-bar-info{background-image:-webkit-linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent);background-image:linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent)}
-.progress-bar-warning{background-color:#f0ad4e}.progress-striped .progress-bar-warning{background-image:-webkit-linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent);background-image:linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent)}
-.progress-bar-danger{background-color:#d9534f}.progress-striped .progress-bar-danger{background-image:-webkit-linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent);background-image:linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent)}
-.media,.media-body{overflow:hidden;zoom:1}
-.media,.media .media{margin-top:15px}
-.media:first-child{margin-top:0}
-.media-object{display:block}
-.media-heading{margin:0 0 5px}
-.media>.pull-left{margin-right:10px}
-.media>.pull-right{margin-left:10px}
-.media-list{padding-left:0;list-style:none}
-.list-group{margin-bottom:20px;padding-left:0}
-.list-group-item{position:relative;display:block;padding:10px 15px;margin-bottom:-1px;background-color:#fff;border:1px solid #ddd}.list-group-item:first-child{border-top-right-radius:4px;border-top-left-radius:4px}
-.list-group-item:last-child{margin-bottom:0;border-bottom-right-radius:4px;border-bottom-left-radius:4px}
-.list-group-item>.badge{float:right}
-.list-group-item>.badge+.badge{margin-right:5px}
-a.list-group-item{color:#555}a.list-group-item .list-group-item-heading{color:#333}
-a.list-group-item:hover,a.list-group-item:focus{text-decoration:none;background-color:#f5f5f5}
-a.list-group-item.active,a.list-group-item.active:hover,a.list-group-item.active:focus{z-index:2;color:#fff;background-color:#428bca;border-color:#428bca}a.list-group-item.active .list-group-item-heading,a.list-group-item.active:hover .list-group-item-heading,a.list-group-item.active:focus .list-group-item-heading{color:inherit}
-a.list-group-item.active .list-group-item-text,a.list-group-item.active:hover .list-group-item-text,a.list-group-item.active:focus .list-group-item-text{color:#e1edf7}
-.list-group-item-success{color:#3c763d;background-color:#dff0d8}a.list-group-item-success{color:#3c763d}a.list-group-item-success .list-group-item-heading{color:inherit}
-a.list-group-item-success:hover,a.list-group-item-success:focus{color:#3c763d;background-color:#d0e9c6}
-a.list-group-item-success.active,a.list-group-item-success.active:hover,a.list-group-item-success.active:focus{color:#fff;background-color:#3c763d;border-color:#3c763d}
-.list-group-item-info{color:#31708f;background-color:#d9edf7}a.list-group-item-info{color:#31708f}a.list-group-item-info .list-group-item-heading{color:inherit}
-a.list-group-item-info:hover,a.list-group-item-info:focus{color:#31708f;background-color:#c4e3f3}
-a.list-group-item-info.active,a.list-group-item-info.active:hover,a.list-group-item-info.active:focus{color:#fff;background-color:#31708f;border-color:#31708f}
-.list-group-item-warning{color:#8a6d3b;background-color:#fcf8e3}a.list-group-item-warning{color:#8a6d3b}a.list-group-item-warning .list-group-item-heading{color:inherit}
-a.list-group-item-warning:hover,a.list-group-item-warning:focus{color:#8a6d3b;background-color:#faf2cc}
-a.list-group-item-warning.active,a.list-group-item-warning.active:hover,a.list-group-item-warning.active:focus{color:#fff;background-color:#8a6d3b;border-color:#8a6d3b}
-.list-group-item-danger{color:#a94442;background-color:#f2dede}a.list-group-item-danger{color:#a94442}a.list-group-item-danger .list-group-item-heading{color:inherit}
-a.list-group-item-danger:hover,a.list-group-item-danger:focus{color:#a94442;background-color:#ebcccc}
-a.list-group-item-danger.active,a.list-group-item-danger.active:hover,a.list-group-item-danger.active:focus{color:#fff;background-color:#a94442;border-color:#a94442}
-.list-group-item-heading{margin-top:0;margin-bottom:5px}
-.list-group-item-text{margin-bottom:0;line-height:1.3}
-.panel{margin-bottom:18px;background-color:#fff;border:1px solid transparent;border-radius:4px;-webkit-box-shadow:0 1px 1px rgba(0,0,0,0.05);box-shadow:0 1px 1px rgba(0,0,0,0.05)}
-.panel-body{padding:15px}
-.panel-heading{padding:10px 15px;border-bottom:1px solid transparent;border-top-right-radius:3px;border-top-left-radius:3px}.panel-heading>.dropdown .dropdown-toggle{color:inherit}
-.panel-title{margin-top:0;margin-bottom:0;font-size:15px;color:inherit}.panel-title>a{color:inherit}
-.panel-footer{padding:10px 15px;background-color:#f5f5f5;border-top:1px solid #ddd;border-bottom-right-radius:3px;border-bottom-left-radius:3px}
-.panel>.list-group{margin-bottom:0}.panel>.list-group .list-group-item{border-width:1px 0;border-radius:0}
-.panel>.list-group:first-child .list-group-item:first-child{border-top:0;border-top-right-radius:3px;border-top-left-radius:3px}
-.panel>.list-group:last-child .list-group-item:last-child{border-bottom:0;border-bottom-right-radius:3px;border-bottom-left-radius:3px}
-.panel-heading+.list-group .list-group-item:first-child{border-top-width:0}
-.panel>.table,.panel>.table-responsive>.table{margin-bottom:0}
-.panel>.table:first-child,.panel>.table-responsive:first-child>.table:first-child{border-top-right-radius:3px;border-top-left-radius:3px}.panel>.table:first-child>thead:first-child>tr:first-child td:first-child,.panel>.table-responsive:first-child>.table:first-child>thead:first-child>tr:first-child td:first-child,.panel>.table:first-child>tbody:first-child>tr:first-child td:first-child,.panel>.table-responsive:first-child>.table:first-child>tbody:first-child>tr:first-child td:first-child,.panel>.table:first-child>thead:first-child>tr:first-child th:first-child,.panel>.table-responsive:first-child>.table:first-child>thead:first-child>tr:first-child th:first-child,.panel>.table:first-child>tbody:first-child>tr:first-child th:first-child,.panel>.table-responsive:first-child>.table:first-child>tbody:first-child>tr:first-child th:first-child{border-top-left-radius:3px}
-.panel>.table:first-child>thead:first-child>tr:first-child td:last-child,.panel>.table-responsive:first-child>.table:first-child>thead:first-child>tr:first-child td:last-child,.panel>.table:first-child>tbody:first-child>tr:first-child td:last-child,.panel>.table-responsive:first-child>.table:first-child>tbody:first-child>tr:first-child td:last-child,.panel>.table:first-child>thead:first-child>tr:first-child th:last-child,.panel>.table-responsive:first-child>.table:first-child>thead:first-child>tr:first-child th:last-child,.panel>.table:first-child>tbody:first-child>tr:first-child th:last-child,.panel>.table-responsive:first-child>.table:first-child>tbody:first-child>tr:first-child th:last-child{border-top-right-radius:3px}
-.panel>.table:last-child,.panel>.table-responsive:last-child>.table:last-child{border-bottom-right-radius:3px;border-bottom-left-radius:3px}.panel>.table:last-child>tbody:last-child>tr:last-child td:first-child,.panel>.table-responsive:last-child>.table:last-child>tbody:last-child>tr:last-child td:first-child,.panel>.table:last-child>tfoot:last-child>tr:last-child td:first-child,.panel>.table-responsive:last-child>.table:last-child>tfoot:last-child>tr:last-child td:first-child,.panel>.table:last-child>tbody:last-child>tr:last-child th:first-child,.panel>.table-responsive:last-child>.table:last-child>tbody:last-child>tr:last-child th:first-child,.panel>.table:last-child>tfoot:last-child>tr:last-child th:first-child,.panel>.table-responsive:last-child>.table:last-child>tfoot:last-child>tr:last-child th:first-child{border-bottom-left-radius:3px}
-.panel>.table:last-child>tbody:last-child>tr:last-child td:last-child,.panel>.table-responsive:last-child>.table:last-child>tbody:last-child>tr:last-child td:last-child,.panel>.table:last-child>tfoot:last-child>tr:last-child td:last-child,.panel>.table-responsive:last-child>.table:last-child>tfoot:last-child>tr:last-child td:last-child,.panel>.table:last-child>tbody:last-child>tr:last-child th:last-child,.panel>.table-responsive:last-child>.table:last-child>tbody:last-child>tr:last-child th:last-child,.panel>.table:last-child>tfoot:last-child>tr:last-child th:last-child,.panel>.table-responsive:last-child>.table:last-child>tfoot:last-child>tr:last-child th:last-child{border-bottom-right-radius:3px}
-.panel>.panel-body+.table,.panel>.panel-body+.table-responsive{border-top:1px solid #ddd}
-.panel>.table>tbody:first-child>tr:first-child th,.panel>.table>tbody:first-child>tr:first-child td{border-top:0}
-.panel>.table-bordered,.panel>.table-responsive>.table-bordered{border:0}.panel>.table-bordered>thead>tr>th:first-child,.panel>.table-responsive>.table-bordered>thead>tr>th:first-child,.panel>.table-bordered>tbody>tr>th:first-child,.panel>.table-responsive>.table-bordered>tbody>tr>th:first-child,.panel>.table-bordered>tfoot>tr>th:first-child,.panel>.table-responsive>.table-bordered>tfoot>tr>th:first-child,.panel>.table-bordered>thead>tr>td:first-child,.panel>.table-responsive>.table-bordered>thead>tr>td:first-child,.panel>.table-bordered>tbody>tr>td:first-child,.panel>.table-responsive>.table-bordered>tbody>tr>td:first-child,.panel>.table-bordered>tfoot>tr>td:first-child,.panel>.table-responsive>.table-bordered>tfoot>tr>td:first-child{border-left:0}
-.panel>.table-bordered>thead>tr>th:last-child,.panel>.table-responsive>.table-bordered>thead>tr>th:last-child,.panel>.table-bordered>tbody>tr>th:last-child,.panel>.table-responsive>.table-bordered>tbody>tr>th:last-child,.panel>.table-bordered>tfoot>tr>th:last-child,.panel>.table-responsive>.table-bordered>tfoot>tr>th:last-child,.panel>.table-bordered>thead>tr>td:last-child,.panel>.table-responsive>.table-bordered>thead>tr>td:last-child,.panel>.table-bordered>tbody>tr>td:last-child,.panel>.table-responsive>.table-bordered>tbody>tr>td:last-child,.panel>.table-bordered>tfoot>tr>td:last-child,.panel>.table-responsive>.table-bordered>tfoot>tr>td:last-child{border-right:0}
-.panel>.table-bordered>thead>tr:first-child>td,.panel>.table-responsive>.table-bordered>thead>tr:first-child>td,.panel>.table-bordered>tbody>tr:first-child>td,.panel>.table-responsive>.table-bordered>tbody>tr:first-child>td,.panel>.table-bordered>thead>tr:first-child>th,.panel>.table-responsive>.table-bordered>thead>tr:first-child>th,.panel>.table-bordered>tbody>tr:first-child>th,.panel>.table-responsive>.table-bordered>tbody>tr:first-child>th{border-bottom:0}
-.panel>.table-bordered>tbody>tr:last-child>td,.panel>.table-responsive>.table-bordered>tbody>tr:last-child>td,.panel>.table-bordered>tfoot>tr:last-child>td,.panel>.table-responsive>.table-bordered>tfoot>tr:last-child>td,.panel>.table-bordered>tbody>tr:last-child>th,.panel>.table-responsive>.table-bordered>tbody>tr:last-child>th,.panel>.table-bordered>tfoot>tr:last-child>th,.panel>.table-responsive>.table-bordered>tfoot>tr:last-child>th{border-bottom:0}
-.panel>.table-responsive{border:0;margin-bottom:0}
-.panel-group{margin-bottom:18px}.panel-group .panel{margin-bottom:0;border-radius:4px;overflow:hidden}.panel-group .panel+.panel{margin-top:5px}
-.panel-group .panel-heading{border-bottom:0}.panel-group .panel-heading+.panel-collapse .panel-body{border-top:1px solid #ddd}
-.panel-group .panel-footer{border-top:0}.panel-group .panel-footer+.panel-collapse .panel-body{border-bottom:1px solid #ddd}
-.panel-default{border-color:#ddd}.panel-default>.panel-heading{color:#333;background-color:#f5f5f5;border-color:#ddd}.panel-default>.panel-heading+.panel-collapse .panel-body{border-top-color:#ddd}
-.panel-default>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#ddd}
-.panel-primary{border-color:#428bca}.panel-primary>.panel-heading{color:#fff;background-color:#428bca;border-color:#428bca}.panel-primary>.panel-heading+.panel-collapse .panel-body{border-top-color:#428bca}
-.panel-primary>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#428bca}
-.panel-success{border-color:#d6e9c6}.panel-success>.panel-heading{color:#3c763d;background-color:#dff0d8;border-color:#d6e9c6}.panel-success>.panel-heading+.panel-collapse .panel-body{border-top-color:#d6e9c6}
-.panel-success>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#d6e9c6}
-.panel-info{border-color:#bce8f1}.panel-info>.panel-heading{color:#31708f;background-color:#d9edf7;border-color:#bce8f1}.panel-info>.panel-heading+.panel-collapse .panel-body{border-top-color:#bce8f1}
-.panel-info>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#bce8f1}
-.panel-warning{border-color:#faebcc}.panel-warning>.panel-heading{color:#8a6d3b;background-color:#fcf8e3;border-color:#faebcc}.panel-warning>.panel-heading+.panel-collapse .panel-body{border-top-color:#faebcc}
-.panel-warning>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#faebcc}
-.panel-danger{border-color:#ebccd1}.panel-danger>.panel-heading{color:#a94442;background-color:#f2dede;border-color:#ebccd1}.panel-danger>.panel-heading+.panel-collapse .panel-body{border-top-color:#ebccd1}
-.panel-danger>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#ebccd1}
-.well{min-height:20px;padding:19px;margin-bottom:20px;background-color:#f5f5f5;border:1px solid #e3e3e3;border-radius:4px;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.05);box-shadow:inset 0 1px 1px rgba(0,0,0,0.05)}.well blockquote{border-color:#ddd;border-color:rgba(0,0,0,0.15)}
-.well-lg{padding:24px;border-radius:6px}
-.well-sm{padding:9px;border-radius:3px}
-.close{float:right;font-size:19.5px;font-weight:bold;line-height:1;color:#000;text-shadow:0 1px 0 #fff;opacity:.2;filter:alpha(opacity=20)}.close:hover,.close:focus{color:#000;text-decoration:none;cursor:pointer;opacity:.5;filter:alpha(opacity=50)}
-button.close{padding:0;cursor:pointer;background:transparent;border:0;-webkit-appearance:none}
-.modal-open{overflow:hidden}
-.modal{display:none;overflow:auto;overflow-y:scroll;position:fixed;top:0;right:0;bottom:0;left:0;z-index:1050;-webkit-overflow-scrolling:touch;outline:0}.modal.fade .modal-dialog{-webkit-transform:translate(0, -25%);-ms-transform:translate(0, -25%);transform:translate(0, -25%);-webkit-transition:-webkit-transform 0.3s ease-out;-moz-transition:-moz-transform 0.3s ease-out;-o-transition:-o-transform 0.3s ease-out;transition:transform 0.3s ease-out}
-.modal.in .modal-dialog{-webkit-transform:translate(0, 0);-ms-transform:translate(0, 0);transform:translate(0, 0)}
-.modal-dialog{position:relative;width:auto;margin:10px}
-.modal-content{position:relative;background-color:#fff;border:1px solid #999;border:1px solid rgba(0,0,0,0.2);border-radius:6px;-webkit-box-shadow:0 3px 9px rgba(0,0,0,0.5);box-shadow:0 3px 9px rgba(0,0,0,0.5);background-clip:padding-box;outline:none}
-.modal-backdrop{position:fixed;top:0;right:0;bottom:0;left:0;z-index:1040;background-color:#000}.modal-backdrop.fade{opacity:0;filter:alpha(opacity=0)}
-.modal-backdrop.in{opacity:.5;filter:alpha(opacity=50)}
-.modal-header{padding:15px;border-bottom:1px solid #e5e5e5;min-height:16.428571429px}
-.modal-header .close{margin-top:-2px}
-.modal-title{margin:0;line-height:1.428571429}
-.modal-body{position:relative;padding:15px}
-.modal-footer{margin-top:15px;padding:14px 15px 15px;text-align:right;border-top:1px solid #e5e5e5}.modal-footer .btn+.btn{margin-left:5px;margin-bottom:0}
-.modal-footer .btn-group .btn+.btn{margin-left:-1px}
-.modal-footer .btn-block+.btn-block{margin-left:0}
-@media (min-width:768px){.modal-dialog{width:600px;margin:30px auto} .modal-content{-webkit-box-shadow:0 5px 15px rgba(0,0,0,0.5);box-shadow:0 5px 15px rgba(0,0,0,0.5)} .modal-sm{width:300px}}@media (min-width:992px){.modal-lg{width:900px}}.tooltip{position:absolute;z-index:1030;display:block;visibility:visible;font-size:12px;line-height:1.4;opacity:0;filter:alpha(opacity=0)}.tooltip.in{opacity:.9;filter:alpha(opacity=90)}
-.tooltip.top{margin-top:-3px;padding:5px 0}
-.tooltip.right{margin-left:3px;padding:0 5px}
-.tooltip.bottom{margin-top:3px;padding:5px 0}
-.tooltip.left{margin-left:-3px;padding:0 5px}
-.tooltip-inner{max-width:200px;padding:3px 8px;color:#fff;text-align:center;text-decoration:none;background-color:#000;border-radius:4px}
-.tooltip-arrow{position:absolute;width:0;height:0;border-color:transparent;border-style:solid}
-.tooltip.top .tooltip-arrow{bottom:0;left:50%;margin-left:-5px;border-width:5px 5px 0;border-top-color:#000}
-.tooltip.top-left .tooltip-arrow{bottom:0;left:5px;border-width:5px 5px 0;border-top-color:#000}
-.tooltip.top-right .tooltip-arrow{bottom:0;right:5px;border-width:5px 5px 0;border-top-color:#000}
-.tooltip.right .tooltip-arrow{top:50%;left:0;margin-top:-5px;border-width:5px 5px 5px 0;border-right-color:#000}
-.tooltip.left .tooltip-arrow{top:50%;right:0;margin-top:-5px;border-width:5px 0 5px 5px;border-left-color:#000}
-.tooltip.bottom .tooltip-arrow{top:0;left:50%;margin-left:-5px;border-width:0 5px 5px;border-bottom-color:#000}
-.tooltip.bottom-left .tooltip-arrow{top:0;left:5px;border-width:0 5px 5px;border-bottom-color:#000}
-.tooltip.bottom-right .tooltip-arrow{top:0;right:5px;border-width:0 5px 5px;border-bottom-color:#000}
-.popover{position:absolute;top:0;left:0;z-index:1010;display:none;max-width:276px;padding:1px;text-align:left;background-color:#fff;background-clip:padding-box;border:1px solid #ccc;border:1px solid rgba(0,0,0,0.2);border-radius:6px;-webkit-box-shadow:0 5px 10px rgba(0,0,0,0.2);box-shadow:0 5px 10px rgba(0,0,0,0.2);white-space:normal}.popover.top{margin-top:-10px}
-.popover.right{margin-left:10px}
-.popover.bottom{margin-top:10px}
-.popover.left{margin-left:-10px}
-.popover-title{margin:0;padding:8px 14px;font-size:13px;font-weight:normal;line-height:18px;background-color:#f7f7f7;border-bottom:1px solid #ebebeb;border-radius:5px 5px 0 0}
-.popover-content{padding:9px 14px}
-.popover>.arrow,.popover>.arrow:after{position:absolute;display:block;width:0;height:0;border-color:transparent;border-style:solid}
-.popover>.arrow{border-width:11px}
-.popover>.arrow:after{border-width:10px;content:""}
-.popover.top>.arrow{left:50%;margin-left:-11px;border-bottom-width:0;border-top-color:#999;border-top-color:rgba(0,0,0,0.25);bottom:-11px}.popover.top>.arrow:after{content:" ";bottom:1px;margin-left:-10px;border-bottom-width:0;border-top-color:#fff}
-.popover.right>.arrow{top:50%;left:-11px;margin-top:-11px;border-left-width:0;border-right-color:#999;border-right-color:rgba(0,0,0,0.25)}.popover.right>.arrow:after{content:" ";left:1px;bottom:-10px;border-left-width:0;border-right-color:#fff}
-.popover.bottom>.arrow{left:50%;margin-left:-11px;border-top-width:0;border-bottom-color:#999;border-bottom-color:rgba(0,0,0,0.25);top:-11px}.popover.bottom>.arrow:after{content:" ";top:1px;margin-left:-10px;border-top-width:0;border-bottom-color:#fff}
-.popover.left>.arrow{top:50%;right:-11px;margin-top:-11px;border-right-width:0;border-left-color:#999;border-left-color:rgba(0,0,0,0.25)}.popover.left>.arrow:after{content:" ";right:1px;border-right-width:0;border-left-color:#fff;bottom:-10px}
-.carousel{position:relative}
-.carousel-inner{position:relative;overflow:hidden;width:100%}.carousel-inner>.item{display:none;position:relative;-webkit-transition:.6s ease-in-out left;transition:.6s ease-in-out left}.carousel-inner>.item>img,.carousel-inner>.item>a>img{line-height:1}
-.carousel-inner>.active,.carousel-inner>.next,.carousel-inner>.prev{display:block}
-.carousel-inner>.active{left:0}
-.carousel-inner>.next,.carousel-inner>.prev{position:absolute;top:0;width:100%}
-.carousel-inner>.next{left:100%}
-.carousel-inner>.prev{left:-100%}
-.carousel-inner>.next.left,.carousel-inner>.prev.right{left:0}
-.carousel-inner>.active.left{left:-100%}
-.carousel-inner>.active.right{left:100%}
-.carousel-control{position:absolute;top:0;left:0;bottom:0;width:15%;opacity:.5;filter:alpha(opacity=50);font-size:20px;color:#fff;text-align:center;text-shadow:0 1px 2px rgba(0,0,0,0.6)}.carousel-control.left{background-image:-webkit-linear-gradient(left, color-stop(rgba(0,0,0,0.5) 0), color-stop(rgba(0,0,0,0.0001) 100%));background-image:linear-gradient(to right, rgba(0,0,0,0.5) 0, rgba(0,0,0,0.0001) 100%);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#80000000', endColorstr='#00000000', GradientType=1)}
-.carousel-control.right{left:auto;right:0;background-image:-webkit-linear-gradient(left, color-stop(rgba(0,0,0,0.0001) 0), color-stop(rgba(0,0,0,0.5) 100%));background-image:linear-gradient(to right, rgba(0,0,0,0.0001) 0, rgba(0,0,0,0.5) 100%);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#80000000', GradientType=1)}
-.carousel-control:hover,.carousel-control:focus{outline:none;color:#fff;text-decoration:none;opacity:.9;filter:alpha(opacity=90)}
-.carousel-control .icon-prev,.carousel-control .icon-next,.carousel-control .glyphicon-chevron-left,.carousel-control .glyphicon-chevron-right{position:absolute;top:50%;z-index:5;display:inline-block}
-.carousel-control .icon-prev,.carousel-control .glyphicon-chevron-left{left:50%}
-.carousel-control .icon-next,.carousel-control .glyphicon-chevron-right{right:50%}
-.carousel-control .icon-prev,.carousel-control .icon-next{width:20px;height:20px;margin-top:-10px;margin-left:-10px;font-family:serif}
-.carousel-control .icon-prev:before{content:'\2039'}
-.carousel-control .icon-next:before{content:'\203a'}
-.carousel-indicators{position:absolute;bottom:10px;left:50%;z-index:15;width:60%;margin-left:-30%;padding-left:0;list-style:none;text-align:center}.carousel-indicators li{display:inline-block;width:10px;height:10px;margin:1px;text-indent:-999px;border:1px solid #fff;border-radius:10px;cursor:pointer;background-color:#000 \9;background-color:rgba(0,0,0,0)}
-.carousel-indicators .active{margin:0;width:12px;height:12px;background-color:#fff}
-.carousel-caption{position:absolute;left:15%;right:15%;bottom:20px;z-index:10;padding-top:20px;padding-bottom:20px;color:#fff;text-align:center;text-shadow:0 1px 2px rgba(0,0,0,0.6)}.carousel-caption .btn{text-shadow:none}
-@media screen and (min-width:768px){.carousel-control .glyphicon-chevron-left,.carousel-control .glyphicon-chevron-right,.carousel-control .icon-prev,.carousel-control .icon-next{width:30px;height:30px;margin-top:-15px;margin-left:-15px;font-size:30px} .carousel-caption{left:20%;right:20%;padding-bottom:30px} .carousel-indicators{bottom:20px}}.clearfix:before,.clearfix:after,.container:before,.container:after,.container-fluid:before,.container-fluid:after,.row:before,.row:after,.form-horizontal .form-group:before,.form-horizontal .form-group:after,.btn-toolbar:before,.btn-toolbar:after,.btn-group-vertical>.btn-group:before,.btn-group-vertical>.btn-group:after,.nav:before,.nav:after,.navbar:before,.navbar:after,.navbar-header:before,.navbar-header:after,.navbar-collapse:before,.navbar-collapse:after,.pager:before,.pager:after,.panel-body:before,.panel-body:after,.modal-footer:before,.modal-footer:after{content:" ";display:table}
-.clearfix:after,.container:after,.container-fluid:after,.row:after,.form-horizontal .form-group:after,.btn-toolbar:after,.btn-group-vertical>.btn-group:after,.nav:after,.navbar:after,.navbar-header:after,.navbar-collapse:after,.pager:after,.panel-body:after,.modal-footer:after{clear:both}
-.center-block{display:block;margin-left:auto;margin-right:auto}
-.pull-right{float:right !important}
-.pull-left{float:left !important}
-.hide{display:none !important}
-.show{display:block !important}
-.invisible{visibility:hidden}
-.text-hide{font:0/0 a;color:transparent;text-shadow:none;background-color:transparent;border:0}
-.hidden{display:none !important;visibility:hidden !important}
-.affix{position:fixed}
-@-ms-viewport{width:device-width}.visible-xs,.visible-sm,.visible-md,.visible-lg{display:none !important}
-@media (max-width:767px){.visible-xs{display:block !important}table.visible-xs{display:table} tr.visible-xs{display:table-row !important} th.visible-xs,td.visible-xs{display:table-cell !important}}
-@media (min-width:768px) and (max-width:991px){.visible-sm{display:block !important}table.visible-sm{display:table} tr.visible-sm{display:table-row !important} th.visible-sm,td.visible-sm{display:table-cell !important}}
-@media (min-width:992px) and (max-width:1199px){.visible-md{display:block !important}table.visible-md{display:table} tr.visible-md{display:table-row !important} th.visible-md,td.visible-md{display:table-cell !important}}
-@media (min-width:1200px){.visible-lg{display:block !important}table.visible-lg{display:table} tr.visible-lg{display:table-row !important} th.visible-lg,td.visible-lg{display:table-cell !important}}
-@media (max-width:767px){.hidden-xs{display:none !important}}
-@media (min-width:768px) and (max-width:991px){.hidden-sm{display:none !important}}
-@media (min-width:992px) and (max-width:1199px){.hidden-md{display:none !important}}
-@media (min-width:1200px){.hidden-lg{display:none !important}}
-.visible-print{display:none !important}@media print{.visible-print{display:block !important}table.visible-print{display:table} tr.visible-print{display:table-row !important} th.visible-print,td.visible-print{display:table-cell !important}}
-@media print{.hidden-print{display:none !important}}
-@font-face{font-family:'FontAwesome';src:url('../components/font-awesome/fonts/fontawesome-webfont.eot?v=4.1.0');src:url('../components/font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=4.1.0') format('embedded-opentype'),url('../components/font-awesome/fonts/fontawesome-webfont.woff?v=4.1.0') format('woff'),url('../components/font-awesome/fonts/fontawesome-webfont.ttf?v=4.1.0') format('truetype'),url('../components/font-awesome/fonts/fontawesome-webfont.svg?v=4.1.0#fontawesomeregular') format('svg');font-weight:normal;font-style:normal}.fa{display:inline-block;font-family:FontAwesome;font-style:normal;font-weight:normal;line-height:1;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
-.fa-lg{font-size:1.3333333333333333em;line-height:.75em;vertical-align:-15%}
-.fa-2x{font-size:2em}
-.fa-3x{font-size:3em}
-.fa-4x{font-size:4em}
-.fa-5x{font-size:5em}
-.fa-fw{width:1.2857142857142858em;text-align:center}
-.fa-ul{padding-left:0;margin-left:2.142857142857143em;list-style-type:none}.fa-ul>li{position:relative}
-.fa-li{position:absolute;left:-2.142857142857143em;width:2.142857142857143em;top:.14285714285714285em;text-align:center}.fa-li.fa-lg{left:-1.8571428571428572em}
-.fa-border{padding:.2em .25em .15em;border:solid .08em #eee;border-radius:.1em}
-.pull-right{float:right}
-.pull-left{float:left}
-.fa.pull-left{margin-right:.3em}
-.fa.pull-right{margin-left:.3em}
-.fa-spin{-webkit-animation:spin 2s infinite linear;-moz-animation:spin 2s infinite linear;-o-animation:spin 2s infinite linear;animation:spin 2s infinite linear}
-@-moz-keyframes spin{0%{-moz-transform:rotate(0deg)} 100%{-moz-transform:rotate(359deg)}}@-webkit-keyframes spin{0%{-webkit-transform:rotate(0deg)} 100%{-webkit-transform:rotate(359deg)}}@-o-keyframes spin{0%{-o-transform:rotate(0deg)} 100%{-o-transform:rotate(359deg)}}@keyframes spin{0%{-webkit-transform:rotate(0deg);transform:rotate(0deg)} 100%{-webkit-transform:rotate(359deg);transform:rotate(359deg)}}.fa-rotate-90{filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=1);-webkit-transform:rotate(90deg);-moz-transform:rotate(90deg);-ms-transform:rotate(90deg);-o-transform:rotate(90deg);transform:rotate(90deg)}
-.fa-rotate-180{filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=2);-webkit-transform:rotate(180deg);-moz-transform:rotate(180deg);-ms-transform:rotate(180deg);-o-transform:rotate(180deg);transform:rotate(180deg)}
-.fa-rotate-270{filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=3);-webkit-transform:rotate(270deg);-moz-transform:rotate(270deg);-ms-transform:rotate(270deg);-o-transform:rotate(270deg);transform:rotate(270deg)}
-.fa-flip-horizontal{filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1);-webkit-transform:scale(-1, 1);-moz-transform:scale(-1, 1);-ms-transform:scale(-1, 1);-o-transform:scale(-1, 1);transform:scale(-1, 1)}
-.fa-flip-vertical{filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1);-webkit-transform:scale(1, -1);-moz-transform:scale(1, -1);-ms-transform:scale(1, -1);-o-transform:scale(1, -1);transform:scale(1, -1)}
-.fa-stack{position:relative;display:inline-block;width:2em;height:2em;line-height:2em;vertical-align:middle}
-.fa-stack-1x,.fa-stack-2x{position:absolute;left:0;width:100%;text-align:center}
-.fa-stack-1x{line-height:inherit}
-.fa-stack-2x{font-size:2em}
-.fa-inverse{color:#fff}
-.fa-glass:before{content:"\f000"}
-.fa-music:before{content:"\f001"}
-.fa-search:before{content:"\f002"}
-.fa-envelope-o:before{content:"\f003"}
-.fa-heart:before{content:"\f004"}
-.fa-star:before{content:"\f005"}
-.fa-star-o:before{content:"\f006"}
-.fa-user:before{content:"\f007"}
-.fa-film:before{content:"\f008"}
-.fa-th-large:before{content:"\f009"}
-.fa-th:before{content:"\f00a"}
-.fa-th-list:before{content:"\f00b"}
-.fa-check:before{content:"\f00c"}
-.fa-times:before{content:"\f00d"}
-.fa-search-plus:before{content:"\f00e"}
-.fa-search-minus:before{content:"\f010"}
-.fa-power-off:before{content:"\f011"}
-.fa-signal:before{content:"\f012"}
-.fa-gear:before,.fa-cog:before{content:"\f013"}
-.fa-trash-o:before{content:"\f014"}
-.fa-home:before{content:"\f015"}
-.fa-file-o:before{content:"\f016"}
-.fa-clock-o:before{content:"\f017"}
-.fa-road:before{content:"\f018"}
-.fa-download:before{content:"\f019"}
-.fa-arrow-circle-o-down:before{content:"\f01a"}
-.fa-arrow-circle-o-up:before{content:"\f01b"}
-.fa-inbox:before{content:"\f01c"}
-.fa-play-circle-o:before{content:"\f01d"}
-.fa-rotate-right:before,.fa-repeat:before{content:"\f01e"}
-.fa-refresh:before{content:"\f021"}
-.fa-list-alt:before{content:"\f022"}
-.fa-lock:before{content:"\f023"}
-.fa-flag:before{content:"\f024"}
-.fa-headphones:before{content:"\f025"}
-.fa-volume-off:before{content:"\f026"}
-.fa-volume-down:before{content:"\f027"}
-.fa-volume-up:before{content:"\f028"}
-.fa-qrcode:before{content:"\f029"}
-.fa-barcode:before{content:"\f02a"}
-.fa-tag:before{content:"\f02b"}
-.fa-tags:before{content:"\f02c"}
-.fa-book:before{content:"\f02d"}
-.fa-bookmark:before{content:"\f02e"}
-.fa-print:before{content:"\f02f"}
-.fa-camera:before{content:"\f030"}
-.fa-font:before{content:"\f031"}
-.fa-bold:before{content:"\f032"}
-.fa-italic:before{content:"\f033"}
-.fa-text-height:before{content:"\f034"}
-.fa-text-width:before{content:"\f035"}
-.fa-align-left:before{content:"\f036"}
-.fa-align-center:before{content:"\f037"}
-.fa-align-right:before{content:"\f038"}
-.fa-align-justify:before{content:"\f039"}
-.fa-list:before{content:"\f03a"}
-.fa-dedent:before,.fa-outdent:before{content:"\f03b"}
-.fa-indent:before{content:"\f03c"}
-.fa-video-camera:before{content:"\f03d"}
-.fa-photo:before,.fa-image:before,.fa-picture-o:before{content:"\f03e"}
-.fa-pencil:before{content:"\f040"}
-.fa-map-marker:before{content:"\f041"}
-.fa-adjust:before{content:"\f042"}
-.fa-tint:before{content:"\f043"}
-.fa-edit:before,.fa-pencil-square-o:before{content:"\f044"}
-.fa-share-square-o:before{content:"\f045"}
-.fa-check-square-o:before{content:"\f046"}
-.fa-arrows:before{content:"\f047"}
-.fa-step-backward:before{content:"\f048"}
-.fa-fast-backward:before{content:"\f049"}
-.fa-backward:before{content:"\f04a"}
-.fa-play:before{content:"\f04b"}
-.fa-pause:before{content:"\f04c"}
-.fa-stop:before{content:"\f04d"}
-.fa-forward:before{content:"\f04e"}
-.fa-fast-forward:before{content:"\f050"}
-.fa-step-forward:before{content:"\f051"}
-.fa-eject:before{content:"\f052"}
-.fa-chevron-left:before{content:"\f053"}
-.fa-chevron-right:before{content:"\f054"}
-.fa-plus-circle:before{content:"\f055"}
-.fa-minus-circle:before{content:"\f056"}
-.fa-times-circle:before{content:"\f057"}
-.fa-check-circle:before{content:"\f058"}
-.fa-question-circle:before{content:"\f059"}
-.fa-info-circle:before{content:"\f05a"}
-.fa-crosshairs:before{content:"\f05b"}
-.fa-times-circle-o:before{content:"\f05c"}
-.fa-check-circle-o:before{content:"\f05d"}
-.fa-ban:before{content:"\f05e"}
-.fa-arrow-left:before{content:"\f060"}
-.fa-arrow-right:before{content:"\f061"}
-.fa-arrow-up:before{content:"\f062"}
-.fa-arrow-down:before{content:"\f063"}
-.fa-mail-forward:before,.fa-share:before{content:"\f064"}
-.fa-expand:before{content:"\f065"}
-.fa-compress:before{content:"\f066"}
-.fa-plus:before{content:"\f067"}
-.fa-minus:before{content:"\f068"}
-.fa-asterisk:before{content:"\f069"}
-.fa-exclamation-circle:before{content:"\f06a"}
-.fa-gift:before{content:"\f06b"}
-.fa-leaf:before{content:"\f06c"}
-.fa-fire:before{content:"\f06d"}
-.fa-eye:before{content:"\f06e"}
-.fa-eye-slash:before{content:"\f070"}
-.fa-warning:before,.fa-exclamation-triangle:before{content:"\f071"}
-.fa-plane:before{content:"\f072"}
-.fa-calendar:before{content:"\f073"}
-.fa-random:before{content:"\f074"}
-.fa-comment:before{content:"\f075"}
-.fa-magnet:before{content:"\f076"}
-.fa-chevron-up:before{content:"\f077"}
-.fa-chevron-down:before{content:"\f078"}
-.fa-retweet:before{content:"\f079"}
-.fa-shopping-cart:before{content:"\f07a"}
-.fa-folder:before{content:"\f07b"}
-.fa-folder-open:before{content:"\f07c"}
-.fa-arrows-v:before{content:"\f07d"}
-.fa-arrows-h:before{content:"\f07e"}
-.fa-bar-chart-o:before{content:"\f080"}
-.fa-twitter-square:before{content:"\f081"}
-.fa-facebook-square:before{content:"\f082"}
-.fa-camera-retro:before{content:"\f083"}
-.fa-key:before{content:"\f084"}
-.fa-gears:before,.fa-cogs:before{content:"\f085"}
-.fa-comments:before{content:"\f086"}
-.fa-thumbs-o-up:before{content:"\f087"}
-.fa-thumbs-o-down:before{content:"\f088"}
-.fa-star-half:before{content:"\f089"}
-.fa-heart-o:before{content:"\f08a"}
-.fa-sign-out:before{content:"\f08b"}
-.fa-linkedin-square:before{content:"\f08c"}
-.fa-thumb-tack:before{content:"\f08d"}
-.fa-external-link:before{content:"\f08e"}
-.fa-sign-in:before{content:"\f090"}
-.fa-trophy:before{content:"\f091"}
-.fa-github-square:before{content:"\f092"}
-.fa-upload:before{content:"\f093"}
-.fa-lemon-o:before{content:"\f094"}
-.fa-phone:before{content:"\f095"}
-.fa-square-o:before{content:"\f096"}
-.fa-bookmark-o:before{content:"\f097"}
-.fa-phone-square:before{content:"\f098"}
-.fa-twitter:before{content:"\f099"}
-.fa-facebook:before{content:"\f09a"}
-.fa-github:before{content:"\f09b"}
-.fa-unlock:before{content:"\f09c"}
-.fa-credit-card:before{content:"\f09d"}
-.fa-rss:before{content:"\f09e"}
-.fa-hdd-o:before{content:"\f0a0"}
-.fa-bullhorn:before{content:"\f0a1"}
-.fa-bell:before{content:"\f0f3"}
-.fa-certificate:before{content:"\f0a3"}
-.fa-hand-o-right:before{content:"\f0a4"}
-.fa-hand-o-left:before{content:"\f0a5"}
-.fa-hand-o-up:before{content:"\f0a6"}
-.fa-hand-o-down:before{content:"\f0a7"}
-.fa-arrow-circle-left:before{content:"\f0a8"}
-.fa-arrow-circle-right:before{content:"\f0a9"}
-.fa-arrow-circle-up:before{content:"\f0aa"}
-.fa-arrow-circle-down:before{content:"\f0ab"}
-.fa-globe:before{content:"\f0ac"}
-.fa-wrench:before{content:"\f0ad"}
-.fa-tasks:before{content:"\f0ae"}
-.fa-filter:before{content:"\f0b0"}
-.fa-briefcase:before{content:"\f0b1"}
-.fa-arrows-alt:before{content:"\f0b2"}
-.fa-group:before,.fa-users:before{content:"\f0c0"}
-.fa-chain:before,.fa-link:before{content:"\f0c1"}
-.fa-cloud:before{content:"\f0c2"}
-.fa-flask:before{content:"\f0c3"}
-.fa-cut:before,.fa-scissors:before{content:"\f0c4"}
-.fa-copy:before,.fa-files-o:before{content:"\f0c5"}
-.fa-paperclip:before{content:"\f0c6"}
-.fa-save:before,.fa-floppy-o:before{content:"\f0c7"}
-.fa-square:before{content:"\f0c8"}
-.fa-navicon:before,.fa-reorder:before,.fa-bars:before{content:"\f0c9"}
-.fa-list-ul:before{content:"\f0ca"}
-.fa-list-ol:before{content:"\f0cb"}
-.fa-strikethrough:before{content:"\f0cc"}
-.fa-underline:before{content:"\f0cd"}
-.fa-table:before{content:"\f0ce"}
-.fa-magic:before{content:"\f0d0"}
-.fa-truck:before{content:"\f0d1"}
-.fa-pinterest:before{content:"\f0d2"}
-.fa-pinterest-square:before{content:"\f0d3"}
-.fa-google-plus-square:before{content:"\f0d4"}
-.fa-google-plus:before{content:"\f0d5"}
-.fa-money:before{content:"\f0d6"}
-.fa-caret-down:before{content:"\f0d7"}
-.fa-caret-up:before{content:"\f0d8"}
-.fa-caret-left:before{content:"\f0d9"}
-.fa-caret-right:before{content:"\f0da"}
-.fa-columns:before{content:"\f0db"}
-.fa-unsorted:before,.fa-sort:before{content:"\f0dc"}
-.fa-sort-down:before,.fa-sort-desc:before{content:"\f0dd"}
-.fa-sort-up:before,.fa-sort-asc:before{content:"\f0de"}
-.fa-envelope:before{content:"\f0e0"}
-.fa-linkedin:before{content:"\f0e1"}
-.fa-rotate-left:before,.fa-undo:before{content:"\f0e2"}
-.fa-legal:before,.fa-gavel:before{content:"\f0e3"}
-.fa-dashboard:before,.fa-tachometer:before{content:"\f0e4"}
-.fa-comment-o:before{content:"\f0e5"}
-.fa-comments-o:before{content:"\f0e6"}
-.fa-flash:before,.fa-bolt:before{content:"\f0e7"}
-.fa-sitemap:before{content:"\f0e8"}
-.fa-umbrella:before{content:"\f0e9"}
-.fa-paste:before,.fa-clipboard:before{content:"\f0ea"}
-.fa-lightbulb-o:before{content:"\f0eb"}
-.fa-exchange:before{content:"\f0ec"}
-.fa-cloud-download:before{content:"\f0ed"}
-.fa-cloud-upload:before{content:"\f0ee"}
-.fa-user-md:before{content:"\f0f0"}
-.fa-stethoscope:before{content:"\f0f1"}
-.fa-suitcase:before{content:"\f0f2"}
-.fa-bell-o:before{content:"\f0a2"}
-.fa-coffee:before{content:"\f0f4"}
-.fa-cutlery:before{content:"\f0f5"}
-.fa-file-text-o:before{content:"\f0f6"}
-.fa-building-o:before{content:"\f0f7"}
-.fa-hospital-o:before{content:"\f0f8"}
-.fa-ambulance:before{content:"\f0f9"}
-.fa-medkit:before{content:"\f0fa"}
-.fa-fighter-jet:before{content:"\f0fb"}
-.fa-beer:before{content:"\f0fc"}
-.fa-h-square:before{content:"\f0fd"}
-.fa-plus-square:before{content:"\f0fe"}
-.fa-angle-double-left:before{content:"\f100"}
-.fa-angle-double-right:before{content:"\f101"}
-.fa-angle-double-up:before{content:"\f102"}
-.fa-angle-double-down:before{content:"\f103"}
-.fa-angle-left:before{content:"\f104"}
-.fa-angle-right:before{content:"\f105"}
-.fa-angle-up:before{content:"\f106"}
-.fa-angle-down:before{content:"\f107"}
-.fa-desktop:before{content:"\f108"}
-.fa-laptop:before{content:"\f109"}
-.fa-tablet:before{content:"\f10a"}
-.fa-mobile-phone:before,.fa-mobile:before{content:"\f10b"}
-.fa-circle-o:before{content:"\f10c"}
-.fa-quote-left:before{content:"\f10d"}
-.fa-quote-right:before{content:"\f10e"}
-.fa-spinner:before{content:"\f110"}
-.fa-circle:before{content:"\f111"}
-.fa-mail-reply:before,.fa-reply:before{content:"\f112"}
-.fa-github-alt:before{content:"\f113"}
-.fa-folder-o:before{content:"\f114"}
-.fa-folder-open-o:before{content:"\f115"}
-.fa-smile-o:before{content:"\f118"}
-.fa-frown-o:before{content:"\f119"}
-.fa-meh-o:before{content:"\f11a"}
-.fa-gamepad:before{content:"\f11b"}
-.fa-keyboard-o:before{content:"\f11c"}
-.fa-flag-o:before{content:"\f11d"}
-.fa-flag-checkered:before{content:"\f11e"}
-.fa-terminal:before{content:"\f120"}
-.fa-code:before{content:"\f121"}
-.fa-mail-reply-all:before,.fa-reply-all:before{content:"\f122"}
-.fa-star-half-empty:before,.fa-star-half-full:before,.fa-star-half-o:before{content:"\f123"}
-.fa-location-arrow:before{content:"\f124"}
-.fa-crop:before{content:"\f125"}
-.fa-code-fork:before{content:"\f126"}
-.fa-unlink:before,.fa-chain-broken:before{content:"\f127"}
-.fa-question:before{content:"\f128"}
-.fa-info:before{content:"\f129"}
-.fa-exclamation:before{content:"\f12a"}
-.fa-superscript:before{content:"\f12b"}
-.fa-subscript:before{content:"\f12c"}
-.fa-eraser:before{content:"\f12d"}
-.fa-puzzle-piece:before{content:"\f12e"}
-.fa-microphone:before{content:"\f130"}
-.fa-microphone-slash:before{content:"\f131"}
-.fa-shield:before{content:"\f132"}
-.fa-calendar-o:before{content:"\f133"}
-.fa-fire-extinguisher:before{content:"\f134"}
-.fa-rocket:before{content:"\f135"}
-.fa-maxcdn:before{content:"\f136"}
-.fa-chevron-circle-left:before{content:"\f137"}
-.fa-chevron-circle-right:before{content:"\f138"}
-.fa-chevron-circle-up:before{content:"\f139"}
-.fa-chevron-circle-down:before{content:"\f13a"}
-.fa-html5:before{content:"\f13b"}
-.fa-css3:before{content:"\f13c"}
-.fa-anchor:before{content:"\f13d"}
-.fa-unlock-alt:before{content:"\f13e"}
-.fa-bullseye:before{content:"\f140"}
-.fa-ellipsis-h:before{content:"\f141"}
-.fa-ellipsis-v:before{content:"\f142"}
-.fa-rss-square:before{content:"\f143"}
-.fa-play-circle:before{content:"\f144"}
-.fa-ticket:before{content:"\f145"}
-.fa-minus-square:before{content:"\f146"}
-.fa-minus-square-o:before{content:"\f147"}
-.fa-level-up:before{content:"\f148"}
-.fa-level-down:before{content:"\f149"}
-.fa-check-square:before{content:"\f14a"}
-.fa-pencil-square:before{content:"\f14b"}
-.fa-external-link-square:before{content:"\f14c"}
-.fa-share-square:before{content:"\f14d"}
-.fa-compass:before{content:"\f14e"}
-.fa-toggle-down:before,.fa-caret-square-o-down:before{content:"\f150"}
-.fa-toggle-up:before,.fa-caret-square-o-up:before{content:"\f151"}
-.fa-toggle-right:before,.fa-caret-square-o-right:before{content:"\f152"}
-.fa-euro:before,.fa-eur:before{content:"\f153"}
-.fa-gbp:before{content:"\f154"}
-.fa-dollar:before,.fa-usd:before{content:"\f155"}
-.fa-rupee:before,.fa-inr:before{content:"\f156"}
-.fa-cny:before,.fa-rmb:before,.fa-yen:before,.fa-jpy:before{content:"\f157"}
-.fa-ruble:before,.fa-rouble:before,.fa-rub:before{content:"\f158"}
-.fa-won:before,.fa-krw:before{content:"\f159"}
-.fa-bitcoin:before,.fa-btc:before{content:"\f15a"}
-.fa-file:before{content:"\f15b"}
-.fa-file-text:before{content:"\f15c"}
-.fa-sort-alpha-asc:before{content:"\f15d"}
-.fa-sort-alpha-desc:before{content:"\f15e"}
-.fa-sort-amount-asc:before{content:"\f160"}
-.fa-sort-amount-desc:before{content:"\f161"}
-.fa-sort-numeric-asc:before{content:"\f162"}
-.fa-sort-numeric-desc:before{content:"\f163"}
-.fa-thumbs-up:before{content:"\f164"}
-.fa-thumbs-down:before{content:"\f165"}
-.fa-youtube-square:before{content:"\f166"}
-.fa-youtube:before{content:"\f167"}
-.fa-xing:before{content:"\f168"}
-.fa-xing-square:before{content:"\f169"}
-.fa-youtube-play:before{content:"\f16a"}
-.fa-dropbox:before{content:"\f16b"}
-.fa-stack-overflow:before{content:"\f16c"}
-.fa-instagram:before{content:"\f16d"}
-.fa-flickr:before{content:"\f16e"}
-.fa-adn:before{content:"\f170"}
-.fa-bitbucket:before{content:"\f171"}
-.fa-bitbucket-square:before{content:"\f172"}
-.fa-tumblr:before{content:"\f173"}
-.fa-tumblr-square:before{content:"\f174"}
-.fa-long-arrow-down:before{content:"\f175"}
-.fa-long-arrow-up:before{content:"\f176"}
-.fa-long-arrow-left:before{content:"\f177"}
-.fa-long-arrow-right:before{content:"\f178"}
-.fa-apple:before{content:"\f179"}
-.fa-windows:before{content:"\f17a"}
-.fa-android:before{content:"\f17b"}
-.fa-linux:before{content:"\f17c"}
-.fa-dribbble:before{content:"\f17d"}
-.fa-skype:before{content:"\f17e"}
-.fa-foursquare:before{content:"\f180"}
-.fa-trello:before{content:"\f181"}
-.fa-female:before{content:"\f182"}
-.fa-male:before{content:"\f183"}
-.fa-gittip:before{content:"\f184"}
-.fa-sun-o:before{content:"\f185"}
-.fa-moon-o:before{content:"\f186"}
-.fa-archive:before{content:"\f187"}
-.fa-bug:before{content:"\f188"}
-.fa-vk:before{content:"\f189"}
-.fa-weibo:before{content:"\f18a"}
-.fa-renren:before{content:"\f18b"}
-.fa-pagelines:before{content:"\f18c"}
-.fa-stack-exchange:before{content:"\f18d"}
-.fa-arrow-circle-o-right:before{content:"\f18e"}
-.fa-arrow-circle-o-left:before{content:"\f190"}
-.fa-toggle-left:before,.fa-caret-square-o-left:before{content:"\f191"}
-.fa-dot-circle-o:before{content:"\f192"}
-.fa-wheelchair:before{content:"\f193"}
-.fa-vimeo-square:before{content:"\f194"}
-.fa-turkish-lira:before,.fa-try:before{content:"\f195"}
-.fa-plus-square-o:before{content:"\f196"}
-.fa-space-shuttle:before{content:"\f197"}
-.fa-slack:before{content:"\f198"}
-.fa-envelope-square:before{content:"\f199"}
-.fa-wordpress:before{content:"\f19a"}
-.fa-openid:before{content:"\f19b"}
-.fa-institution:before,.fa-bank:before,.fa-university:before{content:"\f19c"}
-.fa-mortar-board:before,.fa-graduation-cap:before{content:"\f19d"}
-.fa-yahoo:before{content:"\f19e"}
-.fa-google:before{content:"\f1a0"}
-.fa-reddit:before{content:"\f1a1"}
-.fa-reddit-square:before{content:"\f1a2"}
-.fa-stumbleupon-circle:before{content:"\f1a3"}
-.fa-stumbleupon:before{content:"\f1a4"}
-.fa-delicious:before{content:"\f1a5"}
-.fa-digg:before{content:"\f1a6"}
-.fa-pied-piper-square:before,.fa-pied-piper:before{content:"\f1a7"}
-.fa-pied-piper-alt:before{content:"\f1a8"}
-.fa-drupal:before{content:"\f1a9"}
-.fa-joomla:before{content:"\f1aa"}
-.fa-language:before{content:"\f1ab"}
-.fa-fax:before{content:"\f1ac"}
-.fa-building:before{content:"\f1ad"}
-.fa-child:before{content:"\f1ae"}
-.fa-paw:before{content:"\f1b0"}
-.fa-spoon:before{content:"\f1b1"}
-.fa-cube:before{content:"\f1b2"}
-.fa-cubes:before{content:"\f1b3"}
-.fa-behance:before{content:"\f1b4"}
-.fa-behance-square:before{content:"\f1b5"}
-.fa-steam:before{content:"\f1b6"}
-.fa-steam-square:before{content:"\f1b7"}
-.fa-recycle:before{content:"\f1b8"}
-.fa-automobile:before,.fa-car:before{content:"\f1b9"}
-.fa-cab:before,.fa-taxi:before{content:"\f1ba"}
-.fa-tree:before{content:"\f1bb"}
-.fa-spotify:before{content:"\f1bc"}
-.fa-deviantart:before{content:"\f1bd"}
-.fa-soundcloud:before{content:"\f1be"}
-.fa-database:before{content:"\f1c0"}
-.fa-file-pdf-o:before{content:"\f1c1"}
-.fa-file-word-o:before{content:"\f1c2"}
-.fa-file-excel-o:before{content:"\f1c3"}
-.fa-file-powerpoint-o:before{content:"\f1c4"}
-.fa-file-photo-o:before,.fa-file-picture-o:before,.fa-file-image-o:before{content:"\f1c5"}
-.fa-file-zip-o:before,.fa-file-archive-o:before{content:"\f1c6"}
-.fa-file-sound-o:before,.fa-file-audio-o:before{content:"\f1c7"}
-.fa-file-movie-o:before,.fa-file-video-o:before{content:"\f1c8"}
-.fa-file-code-o:before{content:"\f1c9"}
-.fa-vine:before{content:"\f1ca"}
-.fa-codepen:before{content:"\f1cb"}
-.fa-jsfiddle:before{content:"\f1cc"}
-.fa-life-bouy:before,.fa-life-saver:before,.fa-support:before,.fa-life-ring:before{content:"\f1cd"}
-.fa-circle-o-notch:before{content:"\f1ce"}
-.fa-ra:before,.fa-rebel:before{content:"\f1d0"}
-.fa-ge:before,.fa-empire:before{content:"\f1d1"}
-.fa-git-square:before{content:"\f1d2"}
-.fa-git:before{content:"\f1d3"}
-.fa-hacker-news:before{content:"\f1d4"}
-.fa-tencent-weibo:before{content:"\f1d5"}
-.fa-qq:before{content:"\f1d6"}
-.fa-wechat:before,.fa-weixin:before{content:"\f1d7"}
-.fa-send:before,.fa-paper-plane:before{content:"\f1d8"}
-.fa-send-o:before,.fa-paper-plane-o:before{content:"\f1d9"}
-.fa-history:before{content:"\f1da"}
-.fa-circle-thin:before{content:"\f1db"}
-.fa-header:before{content:"\f1dc"}
-.fa-paragraph:before{content:"\f1dd"}
-.fa-sliders:before{content:"\f1de"}
-.fa-share-alt:before{content:"\f1e0"}
-.fa-share-alt-square:before{content:"\f1e1"}
-.fa-bomb:before{content:"\f1e2"}
-.modal.fade .modal-dialog{-webkit-transform:translate(0, 0);-ms-transform:translate(0, 0);transform:translate(0, 0)}
-code{color:#000}
-pre{font-size:inherit;line-height:inherit}
-label{font-weight:normal}
-.border-box-sizing{box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box}
-.corner-all{border-radius:4px}
-.no-padding{padding:0}
-.hbox{display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}
-.hbox>*{-webkit-box-flex:0;-moz-box-flex:0;box-flex:0;flex:none}
-.vbox{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}
-.vbox>*{-webkit-box-flex:0;-moz-box-flex:0;box-flex:0;flex:none}
-.hbox.reverse,.vbox.reverse,.reverse{-webkit-box-direction:reverse;-moz-box-direction:reverse;box-direction:reverse;flex-direction:row-reverse}
-.hbox.box-flex0,.vbox.box-flex0,.box-flex0{-webkit-box-flex:0;-moz-box-flex:0;box-flex:0;flex:none;width:auto}
-.hbox.box-flex1,.vbox.box-flex1,.box-flex1{-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}
-.hbox.box-flex,.vbox.box-flex,.box-flex{-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}
-.hbox.box-flex2,.vbox.box-flex2,.box-flex2{-webkit-box-flex:2;-moz-box-flex:2;box-flex:2;flex:2}
-.box-group1{-webkit-box-flex-group:1;-moz-box-flex-group:1;box-flex-group:1}
-.box-group2{-webkit-box-flex-group:2;-moz-box-flex-group:2;box-flex-group:2}
-.hbox.start,.vbox.start,.start{-webkit-box-pack:start;-moz-box-pack:start;box-pack:start;justify-content:flex-start}
-.hbox.end,.vbox.end,.end{-webkit-box-pack:end;-moz-box-pack:end;box-pack:end;justify-content:flex-end}
-.hbox.center,.vbox.center,.center{-webkit-box-pack:center;-moz-box-pack:center;box-pack:center;justify-content:center}
-.hbox.align-start,.vbox.align-start,.align-start{-webkit-box-align:start;-moz-box-align:start;box-align:start;align-items:flex-start}
-.hbox.align-end,.vbox.align-end,.align-end{-webkit-box-align:end;-moz-box-align:end;box-align:end;align-items:flex-end}
-.hbox.align-center,.vbox.align-center,.align-center{-webkit-box-align:center;-moz-box-align:center;box-align:center;align-items:center}
-div.error{margin:2em;text-align:center}
-div.error>h1{font-size:500%;line-height:normal}
-div.error>p{font-size:200%;line-height:normal}
-div.traceback-wrapper{text-align:left;max-width:800px;margin:auto}
-body{background-color:#fff;position:absolute;left:0;right:0;top:0;bottom:0;overflow:visible}
-div#header{display:none;margin-bottom:0;padding-left:30px;padding-bottom:5px;border-bottom:1px solid #e7e7e7}
-#ipython_notebook{padding-left:0}
-#noscript{width:auto;padding-top:16px;padding-bottom:16px;text-align:center;font-size:22px;color:#f00;font-weight:bold}
-#ipython_notebook img{font-family:Verdana,"Helvetica Neue",Arial,Helvetica,Geneva,sans-serif;height:24px;text-decoration:none;color:#000}
-#site{width:100%;display:none}
-.ui-button .ui-button-text{padding:.2em .8em;font-size:77%}
-input.ui-button{padding:.3em .9em}
-.navbar span{margin-top:3px}
-span#login_widget{float:right}
-.nav-header{text-transform:none}
-#header>span{margin-top:10px}
-.modal_stretch .modal-dialog{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch;min-height:80%}.modal_stretch .modal-dialog .modal-body{max-height:none;flex:1}
-@media (min-width:768px){.modal .modal-dialog{width:700px}}.center-nav{display:inline-block;margin-bottom:-4px}
-.alternate_upload{background-color:none;display:inline}
-.alternate_upload.form{padding:0;margin:0}
-.alternate_upload input.fileinput{background-color:#f00;position:relative;opacity:0;z-index:2;width:295px;margin-left:163px;cursor:pointer;height:26px}
-ul#tabs{margin-bottom:4px}
-ul#tabs a{padding-top:6px;padding-bottom:4px}
-ul.breadcrumb a:focus,ul.breadcrumb a:hover{text-decoration:none}
-ul.breadcrumb i.icon-home{font-size:16px;margin-right:4px}
-ul.breadcrumb span{color:#5e5e5e}
-.list_toolbar{padding:4px 0 4px 0;vertical-align:middle}.list_toolbar .tree-buttons{padding-top:2px}
-.list_toolbar [class*="span"]{min-height:24px}
-.list_header{font-weight:bold}
-.list_container{margin-top:4px;margin-bottom:20px;border:1px solid #ababab;border-radius:4px}
-.list_container>div{border-bottom:1px solid #ababab}.list_container>div:hover .list-item{background-color:#f00}
-.list_container>div:last-child{border:none}
-.list_item:hover .list_item{background-color:#ddd}
-.list_item a{text-decoration:none}
-.action_col{text-align:right}
-.list_header>div,.list_item>div{padding-top:4px;padding-bottom:4px;padding-left:7px;padding-right:7px;line-height:22px}
-.item_name{line-height:22px;height:24px}
-.item_icon{font-size:14px;color:#5e5e5e;margin-right:7px}
-.item_buttons{line-height:1em}
-.toolbar_info{height:24px;line-height:24px}
-input.nbname_input,input.engine_num_input{padding-top:3px;padding-bottom:3px;height:22px;line-height:14px;margin:0}
-input.engine_num_input{width:60px}
-.highlight_text{color:#00f}
-#project_name>.breadcrumb{padding:0;margin-bottom:0;background-color:transparent;font-weight:bold}
-.tab-content .row{margin-left:0;margin-right:0}
-.folder_icon:before{content:"\f114"}
-.notebook_icon:before{content:"\f02d"}
-.ansibold{font-weight:bold}
-.ansiblack{color:#000}
-.ansired{color:#8b0000}
-.ansigreen{color:#006400}
-.ansiyellow{color:#a52a2a}
-.ansiblue{color:#00008b}
-.ansipurple{color:#9400d3}
-.ansicyan{color:#4682b4}
-.ansigray{color:#808080}
-.ansibgblack{background-color:#000}
-.ansibgred{background-color:#f00}
-.ansibggreen{background-color:#008000}
-.ansibgyellow{background-color:#ff0}
-.ansibgblue{background-color:#00f}
-.ansibgpurple{background-color:#f0f}
-.ansibgcyan{background-color:#0ff}
-.ansibggray{background-color:#808080}
-div.cell{border:1px solid transparent;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch;border-radius:4px;border-width:thin;border-style:solid}div.cell.selected{border-color:#ababab}
-div.cell.edit_mode{border-color:#008000}
-div.cell{width:100%;padding:5px 5px 5px 0;margin:0;outline:none}
-div.prompt{min-width:15ex;padding:.4em;margin:0;font-family:monospace;text-align:right;line-height:1.21429em}
-@media (max-width:480px){div.prompt{text-align:left}}div.inner_cell{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}
-div.input_area{border:1px solid #cfcfcf;border-radius:4px;background:#f7f7f7;line-height:1.21429em}
-div.prompt:empty{padding-top:0;padding-bottom:0}
-div.input{page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}
-@media (max-width:480px){div.input{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}}div.input_prompt{color:#000080;border-top:1px solid transparent}
-div.input_area>div.highlight{margin:.4em;border:none;padding:0;background-color:transparent}
-div.input_area>div.highlight>pre{margin:0;border:none;padding:0;background-color:transparent}
-.CodeMirror{line-height:1.21429em;height:auto;background:none;}
-.CodeMirror-scroll{overflow-y:hidden;overflow-x:auto}
-.CodeMirror-lines{padding:.4em}
-.CodeMirror-linenumber{padding:0 8px 0 4px}
-.CodeMirror-gutters{border-bottom-left-radius:4px;border-top-left-radius:4px}
-.CodeMirror pre{padding:0;border:0;border-radius:0}
-.CodeMirror-vscrollbar,.CodeMirror-hscrollbar{display:none !important}
-pre code{display:block;padding:.5em}
-.highlight-base,pre code,pre .subst,pre .tag .title,pre .lisp .title,pre .clojure .built_in,pre .nginx .title{color:#000}
-.highlight-string,pre .string,pre .constant,pre .parent,pre .tag .value,pre .rules .value,pre .rules .value .number,pre .preprocessor,pre .ruby .symbol,pre .ruby .symbol .string,pre .aggregate,pre .template_tag,pre .django .variable,pre .smalltalk .class,pre .addition,pre .flow,pre .stream,pre .bash .variable,pre .apache .tag,pre .apache .cbracket,pre .tex .command,pre .tex .special,pre .erlang_repl .function_or_atom,pre .markdown .header{color:#ba2121}
-.highlight-comment,pre .comment,pre .annotation,pre .template_comment,pre .diff .header,pre .chunk,pre .markdown .blockquote{color:#408080;font-style:italic}
-.highlight-number,pre .number,pre .date,pre .regexp,pre .literal,pre .smalltalk .symbol,pre .smalltalk .char,pre .go .constant,pre .change,pre .markdown .bullet,pre .markdown .link_url{color:#080}
-pre .label,pre .javadoc,pre .ruby .string,pre .decorator,pre .filter .argument,pre .localvars,pre .array,pre .attr_selector,pre .important,pre .pseudo,pre .pi,pre .doctype,pre .deletion,pre .envvar,pre .shebang,pre .apache .sqbracket,pre .nginx .built_in,pre .tex .formula,pre .erlang_repl .reserved,pre .prompt,pre .markdown .link_label,pre .vhdl .attribute,pre .clojure .attribute,pre .coffeescript .property{color:#88f}
-.highlight-keyword,pre .keyword,pre .id,pre .phpdoc,pre .aggregate,pre .css .tag,pre .javadoctag,pre .phpdoc,pre .yardoctag,pre .smalltalk .class,pre .winutils,pre .bash .variable,pre .apache .tag,pre .go .typename,pre .tex .command,pre .markdown .strong,pre .request,pre .status{color:#008000;font-weight:bold}
-.highlight-builtin,pre .built_in{color:#008000}
-pre .markdown .emphasis{font-style:italic}
-pre .nginx .built_in{font-weight:normal}
-pre .coffeescript .javascript,pre .javascript .xml,pre .tex .formula,pre .xml .javascript,pre .xml .vbscript,pre .xml .css,pre .xml .cdata{opacity:.5}
-.cm-s-ipython span.cm-variable{color:#000}
-.cm-s-ipython span.cm-keyword{color:#008000;font-weight:bold}
-.cm-s-ipython span.cm-number{color:#080}
-.cm-s-ipython span.cm-comment{color:#408080;font-style:italic}
-.cm-s-ipython span.cm-string{color:#ba2121}
-.cm-s-ipython span.cm-builtin{color:#008000}
-.cm-s-ipython span.cm-error{color:#f00}
-.cm-s-ipython span.cm-operator{color:#a2f;font-weight:bold}
-.cm-s-ipython span.cm-meta{color:#a2f}
-.cm-s-ipython span.cm-tab{background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAMCAYAAAAkuj5RAAAAAXNSR0IArs4c6QAAAGFJREFUSMft1LsRQFAQheHPowAKoACx3IgEKtaEHujDjORSgWTH/ZOdnZOcM/sgk/kFFWY0qV8foQwS4MKBCS3qR6ixBJvElOobYAtivseIE120FaowJPN75GMu8j/LfMwNjh4HUpwg4LUAAAAASUVORK5CYII=);background-position:right;background-repeat:no-repeat}
-div.output_wrapper{position:relative;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}
-div.output_scroll{height:24em;width:100%;overflow:auto;border-radius:4px;-webkit-box-shadow:inset 0 2px 8px rgba(0,0,0,0.8);box-shadow:inset 0 2px 8px rgba(0,0,0,0.8);display:block}
-div.output_collapsed{margin:0;padding:0;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}
-div.out_prompt_overlay{height:100%;padding:0 .4em;position:absolute;border-radius:4px}
-div.out_prompt_overlay:hover{-webkit-box-shadow:inset 0 0 1px #000;box-shadow:inset 0 0 1px #000;background:rgba(240,240,240,0.5)}
-div.output_prompt{color:#8b0000}
-div.output_area{padding:0;page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}div.output_area .MathJax_Display{text-align:left !important}
-div.output_area .rendered_html table{margin-left:0;margin-right:0}
-div.output_area .rendered_html img{margin-left:0;margin-right:0}
-.output{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}
-@media (max-width:480px){div.output_area{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}}div.output_area pre{margin:0;padding:0;border:0;vertical-align:baseline;color:#000;background-color:transparent;border-radius:0}
-div.output_subarea{padding:.4em .4em 0 .4em;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}
-div.output_text{text-align:left;color:#000;line-height:1.21429em}
-div.output_stderr{background:#fdd;}
-div.output_latex{text-align:left}
-div.output_javascript:empty{padding:0}
-.js-error{color:#8b0000}
-div.raw_input_container{font-family:monospace;padding-top:5px}
-span.raw_input_prompt{}
-input.raw_input{font-family:inherit;font-size:inherit;color:inherit;width:auto;vertical-align:baseline;padding:0 .25em;margin:0 .25em}
-input.raw_input:focus{box-shadow:none}
-p.p-space{margin-bottom:10px}
-.rendered_html{color:#000;}.rendered_html em{font-style:italic}
-.rendered_html strong{font-weight:bold}
-.rendered_html u{text-decoration:underline}
-.rendered_html :link{text-decoration:underline}
-.rendered_html :visited{text-decoration:underline}
-.rendered_html h1{font-size:185.7%;margin:1.08em 0 0 0;font-weight:bold;line-height:1}
-.rendered_html h2{font-size:157.1%;margin:1.27em 0 0 0;font-weight:bold;line-height:1}
-.rendered_html h3{font-size:128.6%;margin:1.55em 0 0 0;font-weight:bold;line-height:1}
-.rendered_html h4{font-size:100%;margin:2em 0 0 0;font-weight:bold;line-height:1}
-.rendered_html h5{font-size:100%;margin:2em 0 0 0;font-weight:bold;line-height:1;font-style:italic}
-.rendered_html h6{font-size:100%;margin:2em 0 0 0;font-weight:bold;line-height:1;font-style:italic}
-.rendered_html h1:first-child{margin-top:.538em}
-.rendered_html h2:first-child{margin-top:.636em}
-.rendered_html h3:first-child{margin-top:.777em}
-.rendered_html h4:first-child{margin-top:1em}
-.rendered_html h5:first-child{margin-top:1em}
-.rendered_html h6:first-child{margin-top:1em}
-.rendered_html ul{list-style:disc;margin:0 2em;padding-left:0}
-.rendered_html ul ul{list-style:square;margin:0 2em}
-.rendered_html ul ul ul{list-style:circle;margin:0 2em}
-.rendered_html ol{list-style:decimal;margin:0 2em;padding-left:0}
-.rendered_html ol ol{list-style:upper-alpha;margin:0 2em}
-.rendered_html ol ol ol{list-style:lower-alpha;margin:0 2em}
-.rendered_html ol ol ol ol{list-style:lower-roman;margin:0 2em}
-.rendered_html ol ol ol ol ol{list-style:decimal;margin:0 2em}
-.rendered_html *+ul{margin-top:1em}
-.rendered_html *+ol{margin-top:1em}
-.rendered_html hr{color:#000;background-color:#000}
-.rendered_html pre{margin:1em 2em}
-.rendered_html pre,.rendered_html code{border:0;background-color:#fff;color:#000;font-size:100%;padding:0}
-.rendered_html blockquote{margin:1em 2em}
-.rendered_html table{margin-left:auto;margin-right:auto;border:1px solid #000;border-collapse:collapse}
-.rendered_html tr,.rendered_html th,.rendered_html td{border:1px solid #000;border-collapse:collapse;margin:1em 2em}
-.rendered_html td,.rendered_html th{text-align:left;vertical-align:middle;padding:4px}
-.rendered_html th{font-weight:bold}
-.rendered_html *+table{margin-top:1em}
-.rendered_html p{text-align:justify}
-.rendered_html *+p{margin-top:1em}
-.rendered_html img{display:block;margin-left:auto;margin-right:auto}
-.rendered_html *+img{margin-top:1em}
-div.text_cell{padding:5px 5px 5px 0;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}
-@media (max-width:480px){div.text_cell>div.prompt{display:none}}div.text_cell_render{outline:none;resize:none;width:inherit;border-style:none;padding:.5em .5em .5em .4em;color:#000}
-a.anchor-link:link{text-decoration:none;padding:0 20px;visibility:hidden}
-h1:hover .anchor-link,h2:hover .anchor-link,h3:hover .anchor-link,h4:hover .anchor-link,h5:hover .anchor-link,h6:hover .anchor-link{visibility:visible}
-div.cell.text_cell.rendered{padding:0}
-.widget-area{page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}.widget-area .widget-subarea{padding:.44em .4em .4em 1px;margin-left:6px;box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch;-webkit-box-flex:2;-moz-box-flex:2;box-flex:2;flex:2;-webkit-box-align:start;-moz-box-align:start;box-align:start;align-items:flex-start}
-.widget-hlabel{min-width:10ex;padding-right:8px;padding-top:5px;text-align:right;vertical-align:text-top}
-.widget-vlabel{padding-bottom:5px;text-align:center;vertical-align:text-bottom}
-.widget-hreadout{padding-left:8px;padding-top:5px;text-align:left;vertical-align:text-top}
-.widget-vreadout{padding-top:5px;text-align:center;vertical-align:text-top}
-.slide-track{border:1px solid #ccc;background:#fff;border-radius:4px;}
-.widget-hslider{padding-left:8px;padding-right:5px;overflow:visible;width:350px;height:5px;max-height:5px;margin-top:13px;margin-bottom:10px;border:1px solid #ccc;background:#fff;border-radius:4px;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}.widget-hslider .ui-slider{border:0 !important;background:none !important;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}.widget-hslider .ui-slider .ui-slider-handle{width:14px !important;height:28px !important;margin-top:-8px !important}
-.widget-vslider{padding-bottom:8px;overflow:visible;width:5px;max-width:5px;height:250px;margin-left:12px;border:1px solid #ccc;background:#fff;border-radius:4px;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}.widget-vslider .ui-slider{border:0 !important;background:none !important;margin-left:-4px;margin-top:5px;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}.widget-vslider .ui-slider .ui-slider-handle{width:28px !important;height:14px !important;margin-left:-9px}
-.widget-text{width:350px;margin:0 !important}
-.widget-listbox{width:350px;margin-bottom:0}
-.widget-numeric-text{width:150px;margin:0 !important}
-.widget-progress{margin-top:6px;width:350px}.widget-progress .progress-bar{-webkit-transition:none;-moz-transition:none;-ms-transition:none;-o-transition:none;transition:none}
-.widget-combo-btn{min-width:125px}
-.widget-box{margin:5px;-webkit-box-pack:start;-moz-box-pack:start;box-pack:start;justify-content:flex-start;box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;-webkit-box-align:start;-moz-box-align:start;box-align:start;align-items:flex-start}
-.widget-hbox{margin:5px;-webkit-box-pack:start;-moz-box-pack:start;box-pack:start;justify-content:flex-start;box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;-webkit-box-align:start;-moz-box-align:start;box-align:start;align-items:flex-start;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}
-.widget-hbox-single{margin:5px;-webkit-box-pack:start;-moz-box-pack:start;box-pack:start;justify-content:flex-start;box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;-webkit-box-align:start;-moz-box-align:start;box-align:start;align-items:flex-start;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch;height:30px}.widget-hbox-single input[type="checkbox"]{margin-top:9px}
-.widget-vbox{margin:5px;-webkit-box-pack:start;-moz-box-pack:start;box-pack:start;justify-content:flex-start;box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;-webkit-box-align:start;-moz-box-align:start;box-align:start;align-items:flex-start;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}
-.widget-vbox-single{margin:5px;-webkit-box-pack:start;-moz-box-pack:start;box-pack:start;justify-content:flex-start;box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;-webkit-box-align:start;-moz-box-align:start;box-align:start;align-items:flex-start;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch;width:30px}
-.widget-modal{overflow:hidden;position:absolute !important;top:0;left:0;margin-left:0 !important}
-.widget-modal-body{max-height:none !important}
-.widget-container{box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;-webkit-box-align:start;-moz-box-align:start;box-align:start;align-items:flex-start}
-.widget-radio-box{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch;box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;padding-top:4px}.widget-radio-box label{margin-top:0}
-.docked-widget-modal{overflow:hidden;position:relative !important;top:0 !important;left:0 !important;margin-left:0 !important}
-body{background-color:#fff}
-body.notebook_app{overflow:hidden}
-@media (max-width:767px){body.notebook_app{padding-left:0;padding-right:0}}span#notebook_name{height:1em;line-height:1em;padding:3px;border:none;font-size:146.5%}
-div#notebook_panel{margin:0 0 0 0;padding:0;-webkit-box-shadow:inset 1px 4px 9px -6px rgba(0,0,0,0.25);box-shadow:inset 1px 4px 9px -6px rgba(0,0,0,0.25)}
-div#notebook{font-size:14px;line-height:20px;overflow-y:scroll;overflow-x:auto;width:100%;padding:1em 0 1em 0;margin:0;border-top:1px solid #e7e7e7;outline:none;box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box}
-div.ui-widget-content{border:1px solid #ababab;outline:none}
-pre.dialog{background-color:#f7f7f7;border:1px solid #ddd;border-radius:4px;padding:.4em;padding-left:2em}
-p.dialog{padding:.2em}
-pre,code,kbd,samp{white-space:pre-wrap}
-#fonttest{font-family:monospace}
-p{margin-bottom:0}
-.end_space{height:200px}
-.celltoolbar{border:thin solid #cfcfcf;border-bottom:none;background:#eee;border-radius:3px 3px 0 0;width:100%;-webkit-box-pack:end;height:29px;padding-right:4px;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch;-webkit-box-direction:reverse;-moz-box-direction:reverse;box-direction:reverse;flex-direction:row-reverse}
-.ctb_hideshow{display:none;vertical-align:bottom}
-.ctb_global_show .ctb_show.ctb_hideshow{display:block}
-.ctb_global_show .ctb_show+.input_area,.ctb_global_show .ctb_show+div.text_cell_input{border-top-right-radius:0;border-top-left-radius:0}
-.celltoolbar{font-size:87%;padding-top:3px}
-.celltoolbar select{font-size:87%;height:22px}
-.celltoolbar label{margin-left:5px;margin-right:5px}
-.completions{position:absolute;z-index:10;overflow:hidden;border:1px solid #ababab;border-radius:4px;-webkit-box-shadow:0 6px 10px -1px #adadad;box-shadow:0 6px 10px -1px #adadad}
-.completions select{background:#fff;outline:none;border:none;padding:0;margin:0;overflow:auto;font-family:monospace;font-size:110%;color:#000;width:auto}
-.completions select option.context{color:#3071a9}
-#menubar{margin-top:0;margin-bottom:-19px;position:relative}#menubar .navbar{border-top:1px;border-radius:0 0 4px 4px}
-#menubar li.dropdown{line-height:12px}#menubar li.dropdown a{padding-top:6px;padding-bottom:5px}
-#menubar ul.navbar-right{padding-top:2px}
-.nav-wrapper{border-bottom:1px solid #e7e7e7}
-i.menu-icon{padding-top:4px}
-ul#help_menu li a{overflow:hidden;padding-right:2.2em}ul#help_menu li a i{margin-right:-1.2em}
-#menus{min-height:30px}
-.dropdown-submenu{position:relative}
-.dropdown-submenu>.dropdown-menu{top:0;left:100%;margin-top:-6px;margin-left:-1px;-webkit-border-radius:0 6px 6px 6px;-moz-border-radius:0 6px 6px 6px;border-radius:0 6px 6px 6px}
-.dropdown-submenu:hover>.dropdown-menu{display:block}
-.dropdown-submenu>a:after{display:block;content:" ";float:right;width:0;height:0;border-color:transparent;border-style:solid;border-width:5px 0 5px 5px;border-left-color:#ccc;margin-top:5px;margin-right:-10px}
-.dropdown-submenu:hover>a:after{border-left-color:#fff}
-.dropdown-submenu.pull-left{float:none}
-.dropdown-submenu.pull-left>.dropdown-menu{left:-100%;margin-left:10px;-webkit-border-radius:6px 0 6px 6px;-moz-border-radius:6px 0 6px 6px;border-radius:6px 0 6px 6px}
-#notification_area{float:right !important;float:right;z-index:10}
-.indicator_area{color:#777;padding:4px 3px;margin:0;width:11px;z-index:10;text-align:center}
-#kernel_indicator{float:right !important;float:right;color:#777;padding:4px 3px;margin:0;width:11px;z-index:10;text-align:center;margin-right:12px}
-#modal_indicator{float:right !important;float:right;color:#777;padding:4px 3px;margin:0;width:11px;z-index:10;text-align:center;margin-right:5px}
-.edit_mode_icon:before{content:"\f040"}
-.command_mode_icon:before{content:' '}
-.kernel_idle_icon:before{content:"\f10c"}
-.kernel_busy_icon:before{content:"\f111"}
-.notification_widget{color:#777;padding:1px 12px;margin:2px 4px;z-index:10;border:1px solid #ccc;border-radius:4px;background:rgba(240,240,240,0.5)}.notification_widget.span{padding-right:2px}
-div#pager_splitter{height:8px}
-#pager-container{position:relative;padding:15px 0}
-div#pager{font-size:14px;line-height:20px;overflow:auto;display:none}div#pager pre{line-height:1.21429em;color:#000;background-color:#f7f7f7;padding:.4em}
-.quickhelp{display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}
-.shortcut_key{display:inline-block;width:20ex;text-align:right;font-family:monospace}
-.shortcut_descr{display:inline-block;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}
-span#save_widget{padding:0 5px;margin-top:12px}
-span#checkpoint_status,span#autosave_status{font-size:small}
-@media (max-width:767px){span#save_widget{font-size:small} span#checkpoint_status,span#autosave_status{font-size:x-small}}@media (max-width:767px){span#checkpoint_status,span#autosave_status{display:none}}@media (min-width:768px) and (max-width:979px){span#checkpoint_status{display:none} span#autosave_status{font-size:x-small}}.toolbar{padding:0;margin-left:-5px;margin-top:-5px}.toolbar select,.toolbar label{width:auto;vertical-align:middle;margin-right:2px;margin-bottom:0;display:inline;font-size:92%;margin-left:.3em;margin-right:.3em;padding:0;padding-top:3px}
-.toolbar .btn{padding:2px 8px}
-.toolbar .btn-group{margin-top:0;margin-left:5px}
-#maintoolbar{margin-bottom:-3px;margin-top:-8px;border:0;min-height:27px;margin-left:32px;padding-top:6px;padding-bottom:8px}#maintoolbar .navbar-text{float:none;vertical-align:middle;text-align:right;margin-left:5px;margin-right:0;margin-top:0}
-#maintoolbar .toolbar{margin-top:0}
-.select-xs{height:24px}
-@-moz-keyframes fadeOut{from{opacity:1} to{opacity:0}}@-webkit-keyframes fadeOut{from{opacity:1} to{opacity:0}}@-moz-keyframes fadeIn{from{opacity:0} to{opacity:1}}@-webkit-keyframes fadeIn{from{opacity:0} to{opacity:1}}.bigtooltip{overflow:auto;height:200px;-webkit-transition-property:height;-webkit-transition-duration:500ms;-moz-transition-property:height;-moz-transition-duration:500ms;transition-property:height;transition-duration:500ms}
-.smalltooltip{-webkit-transition-property:height;-webkit-transition-duration:500ms;-moz-transition-property:height;-moz-transition-duration:500ms;transition-property:height;transition-duration:500ms;text-overflow:ellipsis;overflow:hidden;height:80px}
-.tooltipbuttons{position:absolute;padding-right:15px;top:0;right:0}
-.tooltiptext{padding-right:30px}
-.ipython_tooltip{max-width:700px;-webkit-animation:fadeOut 400ms;-moz-animation:fadeOut 400ms;animation:fadeOut 400ms;-webkit-animation:fadeIn 400ms;-moz-animation:fadeIn 400ms;animation:fadeIn 400ms;vertical-align:middle;background-color:#f7f7f7;overflow:visible;border:#ababab 1px solid;outline:none;padding:3px;margin:0;padding-left:7px;font-family:monospace;min-height:50px;-moz-box-shadow:0 6px 10px -1px #adadad;-webkit-box-shadow:0 6px 10px -1px #adadad;box-shadow:0 6px 10px -1px #adadad;border-radius:4px;position:absolute;z-index:1000}.ipython_tooltip a{float:right}
-.ipython_tooltip .tooltiptext pre{border:0;border-radius:0;font-size:100%;background-color:#f7f7f7}
-.pretooltiparrow{left:0;margin:0;top:-16px;width:40px;height:16px;overflow:hidden;position:absolute}
-.pretooltiparrow:before{background-color:#f7f7f7;border:1px #ababab solid;z-index:11;content:"";position:absolute;left:15px;top:10px;width:25px;height:25px;-webkit-transform:rotate(45deg);-moz-transform:rotate(45deg);-ms-transform:rotate(45deg);-o-transform:rotate(45deg)}
->>>>>>> fab css

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -7302,6 +7302,7 @@ universal implementation of the flexible box model is used when available (see
 `Modern browsers` comments below).  Browsers that are known to implement this 
 new spec completely include:
 
+<<<<<<< HEAD
     Firefox 28.0+
     Chrome 29.0+
     Internet Explorer 11+ 
@@ -10145,3 +10146,1591 @@ span#autosave_status {
   -o-transform: rotate(45deg);
 }
 /*# sourceMappingURL=../style/style.min.css.map */
+=======
+html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+body{margin:0}
+article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
+audio,canvas,progress,video{display:inline-block;vertical-align:baseline}
+audio:not([controls]){display:none;height:0}
+[hidden],template{display:none}
+a{background:transparent}
+a:active,a:hover{outline:0}
+abbr[title]{border-bottom:1px dotted}
+b,strong{font-weight:bold}
+dfn{font-style:italic}
+h1{font-size:2em;margin:.67em 0}
+mark{background:#ff0;color:#000}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-0.5em}
+sub{bottom:-0.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:1em 40px}
+hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+pre{overflow:auto}
+code,kbd,pre,samp{font-family:monospace,monospace;font-size:1em}
+button,input,optgroup,select,textarea{color:inherit;font:inherit;margin:0}
+button{overflow:visible}
+button,select{text-transform:none}
+button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+input{line-height:normal}
+input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
+input[type="number"]::-webkit-inner-spin-button,input[type="number"]::-webkit-outer-spin-button{height:auto}
+input[type="search"]{-webkit-appearance:textfield;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;box-sizing:content-box}
+input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}
+fieldset{border:1px solid #c0c0c0;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+textarea{overflow:auto}
+optgroup{font-weight:bold}
+table{border-collapse:collapse;border-spacing:0}
+td,th{padding:0}
+@media print{*{text-shadow:none !important;color:#000 !important;background:transparent !important;box-shadow:none !important} a,a:visited{text-decoration:underline} a[href]:after{content:" (" attr(href) ")"} abbr[title]:after{content:" (" attr(title) ")"} a[href^="javascript:"]:after,a[href^="#"]:after{content:""} pre,blockquote{border:1px solid #999;page-break-inside:avoid} thead{display:table-header-group} tr,img{page-break-inside:avoid} img{max-width:100% !important} p,h2,h3{orphans:3;widows:3} h2,h3{page-break-after:avoid} select{background:#fff !important} .navbar{display:none} .table td,.table th{background-color:#fff !important} .btn>.caret,.dropup>.btn>.caret{border-top-color:#000 !important} .label{border:1px solid #000} .table{border-collapse:collapse !important} .table-bordered th,.table-bordered td{border:1px solid #ddd !important}}*{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
+*:before,*:after{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
+html{font-size:62.5%;-webkit-tap-highlight-color:rgba(0,0,0,0)}
+body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:13px;line-height:1.428571429;color:#000;background-color:#fff}
+input,button,select,textarea{font-family:inherit;font-size:inherit;line-height:inherit}
+a{color:#428bca;text-decoration:none}a:hover,a:focus{color:#2a6496;text-decoration:underline}
+a:focus{outline:thin dotted;outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}
+figure{margin:0}
+img{vertical-align:middle}
+.img-responsive,.thumbnail>img,.thumbnail a>img,.carousel-inner>.item>img,.carousel-inner>.item>a>img{display:block;max-width:100%;height:auto}
+.img-rounded{border-radius:6px}
+.img-thumbnail{padding:4px;line-height:1.428571429;background-color:#fff;border:1px solid #ddd;border-radius:4px;-webkit-transition:all .2s ease-in-out;transition:all .2s ease-in-out;display:inline-block;max-width:100%;height:auto}
+.img-circle{border-radius:50%}
+hr{margin-top:18px;margin-bottom:18px;border:0;border-top:1px solid #eee}
+.sr-only{position:absolute;width:1px;height:1px;margin:-1px;padding:0;overflow:hidden;clip:rect(0, 0, 0, 0);border:0}
+h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6{font-family:inherit;font-weight:500;line-height:1.1;color:inherit}h1 small,h2 small,h3 small,h4 small,h5 small,h6 small,.h1 small,.h2 small,.h3 small,.h4 small,.h5 small,.h6 small,h1 .small,h2 .small,h3 .small,h4 .small,h5 .small,h6 .small,.h1 .small,.h2 .small,.h3 .small,.h4 .small,.h5 .small,.h6 .small{font-weight:normal;line-height:1;color:#999}
+h1,.h1,h2,.h2,h3,.h3{margin-top:18px;margin-bottom:9px}h1 small,.h1 small,h2 small,.h2 small,h3 small,.h3 small,h1 .small,.h1 .small,h2 .small,.h2 .small,h3 .small,.h3 .small{font-size:65%}
+h4,.h4,h5,.h5,h6,.h6{margin-top:9px;margin-bottom:9px}h4 small,.h4 small,h5 small,.h5 small,h6 small,.h6 small,h4 .small,.h4 .small,h5 .small,.h5 .small,h6 .small,.h6 .small{font-size:75%}
+h1,.h1{font-size:33px}
+h2,.h2{font-size:27px}
+h3,.h3{font-size:23px}
+h4,.h4{font-size:17px}
+h5,.h5{font-size:13px}
+h6,.h6{font-size:12px}
+p{margin:0 0 9px}
+.lead{margin-bottom:18px;font-size:14px;font-weight:200;line-height:1.4}@media (min-width:768px){.lead{font-size:19.5px}}
+small,.small{font-size:85%}
+cite{font-style:normal}
+.text-left{text-align:left}
+.text-right{text-align:right}
+.text-center{text-align:center}
+.text-justify{text-align:justify}
+.text-muted{color:#999}
+.text-primary{color:#428bca}a.text-primary:hover{color:#3071a9}
+.text-success{color:#3c763d}a.text-success:hover{color:#2b542c}
+.text-info{color:#31708f}a.text-info:hover{color:#245269}
+.text-warning{color:#8a6d3b}a.text-warning:hover{color:#66512c}
+.text-danger{color:#a94442}a.text-danger:hover{color:#843534}
+.bg-primary{color:#fff;background-color:#428bca}a.bg-primary:hover{background-color:#3071a9}
+.bg-success{background-color:#dff0d8}a.bg-success:hover{background-color:#c1e2b3}
+.bg-info{background-color:#d9edf7}a.bg-info:hover{background-color:#afd9ee}
+.bg-warning{background-color:#fcf8e3}a.bg-warning:hover{background-color:#f7ecb5}
+.bg-danger{background-color:#f2dede}a.bg-danger:hover{background-color:#e4b9b9}
+.page-header{padding-bottom:8px;margin:36px 0 18px;border-bottom:1px solid #eee}
+ul,ol{margin-top:0;margin-bottom:9px}ul ul,ol ul,ul ol,ol ol{margin-bottom:0}
+.list-unstyled{padding-left:0;list-style:none}
+.list-inline{padding-left:0;list-style:none;margin-left:-5px}.list-inline>li{display:inline-block;padding-left:5px;padding-right:5px}
+dl{margin-top:0;margin-bottom:18px}
+dt,dd{line-height:1.428571429}
+dt{font-weight:bold}
+dd{margin-left:0}
+@media (min-width:768px){.dl-horizontal dt{float:left;width:160px;clear:left;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap} .dl-horizontal dd{margin-left:180px}}abbr[title],abbr[data-original-title]{cursor:help;border-bottom:1px dotted #999}
+.initialism{font-size:90%;text-transform:uppercase}
+blockquote{padding:9px 18px;margin:0 0 18px;font-size:inherit;border-left:5px solid #eee}blockquote p:last-child,blockquote ul:last-child,blockquote ol:last-child{margin-bottom:0}
+blockquote footer,blockquote small,blockquote .small{display:block;font-size:80%;line-height:1.428571429;color:#999}blockquote footer:before,blockquote small:before,blockquote .small:before{content:'\2014 \00A0'}
+.blockquote-reverse,blockquote.pull-right{padding-right:15px;padding-left:0;border-right:5px solid #eee;border-left:0;text-align:right}.blockquote-reverse footer:before,blockquote.pull-right footer:before,.blockquote-reverse small:before,blockquote.pull-right small:before,.blockquote-reverse .small:before,blockquote.pull-right .small:before{content:''}
+.blockquote-reverse footer:after,blockquote.pull-right footer:after,.blockquote-reverse small:after,blockquote.pull-right small:after,.blockquote-reverse .small:after,blockquote.pull-right .small:after{content:'\00A0 \2014'}
+blockquote:before,blockquote:after{content:""}
+address{margin-bottom:18px;font-style:normal;line-height:1.428571429}
+code,kbd,pre,samp{font-family:monospace}
+code{padding:2px 4px;font-size:90%;color:#c7254e;background-color:#f9f2f4;white-space:nowrap;border-radius:4px}
+kbd{padding:2px 4px;font-size:90%;color:#fff;background-color:#333;border-radius:3px;box-shadow:inset 0 -1px 0 rgba(0,0,0,0.25)}
+pre{display:block;padding:8.5px;margin:0 0 9px;font-size:12px;line-height:1.428571429;word-break:break-all;word-wrap:break-word;color:#333;background-color:#f5f5f5;border:1px solid #ccc;border-radius:4px}pre code{padding:0;font-size:inherit;color:inherit;white-space:pre-wrap;background-color:transparent;border-radius:0}
+.pre-scrollable{max-height:340px;overflow-y:scroll}
+.container{margin-right:auto;margin-left:auto;padding-left:15px;padding-right:15px}@media (min-width:768px){.container{width:750px}}@media (min-width:992px){.container{width:970px}}@media (min-width:1200px){.container{width:1170px}}
+.container-fluid{margin-right:auto;margin-left:auto;padding-left:15px;padding-right:15px}
+.row{margin-left:-15px;margin-right:-15px}
+.col-xs-1, .col-sm-1, .col-md-1, .col-lg-1, .col-xs-2, .col-sm-2, .col-md-2, .col-lg-2, .col-xs-3, .col-sm-3, .col-md-3, .col-lg-3, .col-xs-4, .col-sm-4, .col-md-4, .col-lg-4, .col-xs-5, .col-sm-5, .col-md-5, .col-lg-5, .col-xs-6, .col-sm-6, .col-md-6, .col-lg-6, .col-xs-7, .col-sm-7, .col-md-7, .col-lg-7, .col-xs-8, .col-sm-8, .col-md-8, .col-lg-8, .col-xs-9, .col-sm-9, .col-md-9, .col-lg-9, .col-xs-10, .col-sm-10, .col-md-10, .col-lg-10, .col-xs-11, .col-sm-11, .col-md-11, .col-lg-11, .col-xs-12, .col-sm-12, .col-md-12, .col-lg-12{position:relative;min-height:1px;padding-left:15px;padding-right:15px}
+.col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6, .col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12{float:left}
+.col-xs-12{width:100%}
+.col-xs-11{width:91.66666666666666%}
+.col-xs-10{width:83.33333333333334%}
+.col-xs-9{width:75%}
+.col-xs-8{width:66.66666666666666%}
+.col-xs-7{width:58.333333333333336%}
+.col-xs-6{width:50%}
+.col-xs-5{width:41.66666666666667%}
+.col-xs-4{width:33.33333333333333%}
+.col-xs-3{width:25%}
+.col-xs-2{width:16.666666666666664%}
+.col-xs-1{width:8.333333333333332%}
+.col-xs-pull-12{right:100%}
+.col-xs-pull-11{right:91.66666666666666%}
+.col-xs-pull-10{right:83.33333333333334%}
+.col-xs-pull-9{right:75%}
+.col-xs-pull-8{right:66.66666666666666%}
+.col-xs-pull-7{right:58.333333333333336%}
+.col-xs-pull-6{right:50%}
+.col-xs-pull-5{right:41.66666666666667%}
+.col-xs-pull-4{right:33.33333333333333%}
+.col-xs-pull-3{right:25%}
+.col-xs-pull-2{right:16.666666666666664%}
+.col-xs-pull-1{right:8.333333333333332%}
+.col-xs-pull-0{right:0}
+.col-xs-push-12{left:100%}
+.col-xs-push-11{left:91.66666666666666%}
+.col-xs-push-10{left:83.33333333333334%}
+.col-xs-push-9{left:75%}
+.col-xs-push-8{left:66.66666666666666%}
+.col-xs-push-7{left:58.333333333333336%}
+.col-xs-push-6{left:50%}
+.col-xs-push-5{left:41.66666666666667%}
+.col-xs-push-4{left:33.33333333333333%}
+.col-xs-push-3{left:25%}
+.col-xs-push-2{left:16.666666666666664%}
+.col-xs-push-1{left:8.333333333333332%}
+.col-xs-push-0{left:0}
+.col-xs-offset-12{margin-left:100%}
+.col-xs-offset-11{margin-left:91.66666666666666%}
+.col-xs-offset-10{margin-left:83.33333333333334%}
+.col-xs-offset-9{margin-left:75%}
+.col-xs-offset-8{margin-left:66.66666666666666%}
+.col-xs-offset-7{margin-left:58.333333333333336%}
+.col-xs-offset-6{margin-left:50%}
+.col-xs-offset-5{margin-left:41.66666666666667%}
+.col-xs-offset-4{margin-left:33.33333333333333%}
+.col-xs-offset-3{margin-left:25%}
+.col-xs-offset-2{margin-left:16.666666666666664%}
+.col-xs-offset-1{margin-left:8.333333333333332%}
+.col-xs-offset-0{margin-left:0}
+@media (min-width:768px){.col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12{float:left} .col-sm-12{width:100%} .col-sm-11{width:91.66666666666666%} .col-sm-10{width:83.33333333333334%} .col-sm-9{width:75%} .col-sm-8{width:66.66666666666666%} .col-sm-7{width:58.333333333333336%} .col-sm-6{width:50%} .col-sm-5{width:41.66666666666667%} .col-sm-4{width:33.33333333333333%} .col-sm-3{width:25%} .col-sm-2{width:16.666666666666664%} .col-sm-1{width:8.333333333333332%} .col-sm-pull-12{right:100%} .col-sm-pull-11{right:91.66666666666666%} .col-sm-pull-10{right:83.33333333333334%} .col-sm-pull-9{right:75%} .col-sm-pull-8{right:66.66666666666666%} .col-sm-pull-7{right:58.333333333333336%} .col-sm-pull-6{right:50%} .col-sm-pull-5{right:41.66666666666667%} .col-sm-pull-4{right:33.33333333333333%} .col-sm-pull-3{right:25%} .col-sm-pull-2{right:16.666666666666664%} .col-sm-pull-1{right:8.333333333333332%} .col-sm-pull-0{right:0} .col-sm-push-12{left:100%} .col-sm-push-11{left:91.66666666666666%} .col-sm-push-10{left:83.33333333333334%} .col-sm-push-9{left:75%} .col-sm-push-8{left:66.66666666666666%} .col-sm-push-7{left:58.333333333333336%} .col-sm-push-6{left:50%} .col-sm-push-5{left:41.66666666666667%} .col-sm-push-4{left:33.33333333333333%} .col-sm-push-3{left:25%} .col-sm-push-2{left:16.666666666666664%} .col-sm-push-1{left:8.333333333333332%} .col-sm-push-0{left:0} .col-sm-offset-12{margin-left:100%} .col-sm-offset-11{margin-left:91.66666666666666%} .col-sm-offset-10{margin-left:83.33333333333334%} .col-sm-offset-9{margin-left:75%} .col-sm-offset-8{margin-left:66.66666666666666%} .col-sm-offset-7{margin-left:58.333333333333336%} .col-sm-offset-6{margin-left:50%} .col-sm-offset-5{margin-left:41.66666666666667%} .col-sm-offset-4{margin-left:33.33333333333333%} .col-sm-offset-3{margin-left:25%} .col-sm-offset-2{margin-left:16.666666666666664%} .col-sm-offset-1{margin-left:8.333333333333332%} .col-sm-offset-0{margin-left:0}}@media (min-width:992px){.col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12{float:left} .col-md-12{width:100%} .col-md-11{width:91.66666666666666%} .col-md-10{width:83.33333333333334%} .col-md-9{width:75%} .col-md-8{width:66.66666666666666%} .col-md-7{width:58.333333333333336%} .col-md-6{width:50%} .col-md-5{width:41.66666666666667%} .col-md-4{width:33.33333333333333%} .col-md-3{width:25%} .col-md-2{width:16.666666666666664%} .col-md-1{width:8.333333333333332%} .col-md-pull-12{right:100%} .col-md-pull-11{right:91.66666666666666%} .col-md-pull-10{right:83.33333333333334%} .col-md-pull-9{right:75%} .col-md-pull-8{right:66.66666666666666%} .col-md-pull-7{right:58.333333333333336%} .col-md-pull-6{right:50%} .col-md-pull-5{right:41.66666666666667%} .col-md-pull-4{right:33.33333333333333%} .col-md-pull-3{right:25%} .col-md-pull-2{right:16.666666666666664%} .col-md-pull-1{right:8.333333333333332%} .col-md-pull-0{right:0} .col-md-push-12{left:100%} .col-md-push-11{left:91.66666666666666%} .col-md-push-10{left:83.33333333333334%} .col-md-push-9{left:75%} .col-md-push-8{left:66.66666666666666%} .col-md-push-7{left:58.333333333333336%} .col-md-push-6{left:50%} .col-md-push-5{left:41.66666666666667%} .col-md-push-4{left:33.33333333333333%} .col-md-push-3{left:25%} .col-md-push-2{left:16.666666666666664%} .col-md-push-1{left:8.333333333333332%} .col-md-push-0{left:0} .col-md-offset-12{margin-left:100%} .col-md-offset-11{margin-left:91.66666666666666%} .col-md-offset-10{margin-left:83.33333333333334%} .col-md-offset-9{margin-left:75%} .col-md-offset-8{margin-left:66.66666666666666%} .col-md-offset-7{margin-left:58.333333333333336%} .col-md-offset-6{margin-left:50%} .col-md-offset-5{margin-left:41.66666666666667%} .col-md-offset-4{margin-left:33.33333333333333%} .col-md-offset-3{margin-left:25%} .col-md-offset-2{margin-left:16.666666666666664%} .col-md-offset-1{margin-left:8.333333333333332%} .col-md-offset-0{margin-left:0}}@media (min-width:1200px){.col-lg-1, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9, .col-lg-10, .col-lg-11, .col-lg-12{float:left} .col-lg-12{width:100%} .col-lg-11{width:91.66666666666666%} .col-lg-10{width:83.33333333333334%} .col-lg-9{width:75%} .col-lg-8{width:66.66666666666666%} .col-lg-7{width:58.333333333333336%} .col-lg-6{width:50%} .col-lg-5{width:41.66666666666667%} .col-lg-4{width:33.33333333333333%} .col-lg-3{width:25%} .col-lg-2{width:16.666666666666664%} .col-lg-1{width:8.333333333333332%} .col-lg-pull-12{right:100%} .col-lg-pull-11{right:91.66666666666666%} .col-lg-pull-10{right:83.33333333333334%} .col-lg-pull-9{right:75%} .col-lg-pull-8{right:66.66666666666666%} .col-lg-pull-7{right:58.333333333333336%} .col-lg-pull-6{right:50%} .col-lg-pull-5{right:41.66666666666667%} .col-lg-pull-4{right:33.33333333333333%} .col-lg-pull-3{right:25%} .col-lg-pull-2{right:16.666666666666664%} .col-lg-pull-1{right:8.333333333333332%} .col-lg-pull-0{right:0} .col-lg-push-12{left:100%} .col-lg-push-11{left:91.66666666666666%} .col-lg-push-10{left:83.33333333333334%} .col-lg-push-9{left:75%} .col-lg-push-8{left:66.66666666666666%} .col-lg-push-7{left:58.333333333333336%} .col-lg-push-6{left:50%} .col-lg-push-5{left:41.66666666666667%} .col-lg-push-4{left:33.33333333333333%} .col-lg-push-3{left:25%} .col-lg-push-2{left:16.666666666666664%} .col-lg-push-1{left:8.333333333333332%} .col-lg-push-0{left:0} .col-lg-offset-12{margin-left:100%} .col-lg-offset-11{margin-left:91.66666666666666%} .col-lg-offset-10{margin-left:83.33333333333334%} .col-lg-offset-9{margin-left:75%} .col-lg-offset-8{margin-left:66.66666666666666%} .col-lg-offset-7{margin-left:58.333333333333336%} .col-lg-offset-6{margin-left:50%} .col-lg-offset-5{margin-left:41.66666666666667%} .col-lg-offset-4{margin-left:33.33333333333333%} .col-lg-offset-3{margin-left:25%} .col-lg-offset-2{margin-left:16.666666666666664%} .col-lg-offset-1{margin-left:8.333333333333332%} .col-lg-offset-0{margin-left:0}}table{max-width:100%;background-color:transparent}
+th{text-align:left}
+.table{width:100%;margin-bottom:18px}.table>thead>tr>th,.table>tbody>tr>th,.table>tfoot>tr>th,.table>thead>tr>td,.table>tbody>tr>td,.table>tfoot>tr>td{padding:8px;line-height:1.428571429;vertical-align:top;border-top:1px solid #ddd}
+.table>thead>tr>th{vertical-align:bottom;border-bottom:2px solid #ddd}
+.table>caption+thead>tr:first-child>th,.table>colgroup+thead>tr:first-child>th,.table>thead:first-child>tr:first-child>th,.table>caption+thead>tr:first-child>td,.table>colgroup+thead>tr:first-child>td,.table>thead:first-child>tr:first-child>td{border-top:0}
+.table>tbody+tbody{border-top:2px solid #ddd}
+.table .table{background-color:#fff}
+.table-condensed>thead>tr>th,.table-condensed>tbody>tr>th,.table-condensed>tfoot>tr>th,.table-condensed>thead>tr>td,.table-condensed>tbody>tr>td,.table-condensed>tfoot>tr>td{padding:5px}
+.table-bordered{border:1px solid #ddd}.table-bordered>thead>tr>th,.table-bordered>tbody>tr>th,.table-bordered>tfoot>tr>th,.table-bordered>thead>tr>td,.table-bordered>tbody>tr>td,.table-bordered>tfoot>tr>td{border:1px solid #ddd}
+.table-bordered>thead>tr>th,.table-bordered>thead>tr>td{border-bottom-width:2px}
+.table-striped>tbody>tr:nth-child(odd)>td,.table-striped>tbody>tr:nth-child(odd)>th{background-color:#f9f9f9}
+.table-hover>tbody>tr:hover>td,.table-hover>tbody>tr:hover>th{background-color:#f5f5f5}
+table col[class*="col-"]{position:static;float:none;display:table-column}
+table td[class*="col-"],table th[class*="col-"]{position:static;float:none;display:table-cell}
+.table>thead>tr>td.active,.table>tbody>tr>td.active,.table>tfoot>tr>td.active,.table>thead>tr>th.active,.table>tbody>tr>th.active,.table>tfoot>tr>th.active,.table>thead>tr.active>td,.table>tbody>tr.active>td,.table>tfoot>tr.active>td,.table>thead>tr.active>th,.table>tbody>tr.active>th,.table>tfoot>tr.active>th{background-color:#f5f5f5}
+.table-hover>tbody>tr>td.active:hover,.table-hover>tbody>tr>th.active:hover,.table-hover>tbody>tr.active:hover>td,.table-hover>tbody>tr.active:hover>th{background-color:#e8e8e8}
+.table>thead>tr>td.success,.table>tbody>tr>td.success,.table>tfoot>tr>td.success,.table>thead>tr>th.success,.table>tbody>tr>th.success,.table>tfoot>tr>th.success,.table>thead>tr.success>td,.table>tbody>tr.success>td,.table>tfoot>tr.success>td,.table>thead>tr.success>th,.table>tbody>tr.success>th,.table>tfoot>tr.success>th{background-color:#dff0d8}
+.table-hover>tbody>tr>td.success:hover,.table-hover>tbody>tr>th.success:hover,.table-hover>tbody>tr.success:hover>td,.table-hover>tbody>tr.success:hover>th{background-color:#d0e9c6}
+.table>thead>tr>td.info,.table>tbody>tr>td.info,.table>tfoot>tr>td.info,.table>thead>tr>th.info,.table>tbody>tr>th.info,.table>tfoot>tr>th.info,.table>thead>tr.info>td,.table>tbody>tr.info>td,.table>tfoot>tr.info>td,.table>thead>tr.info>th,.table>tbody>tr.info>th,.table>tfoot>tr.info>th{background-color:#d9edf7}
+.table-hover>tbody>tr>td.info:hover,.table-hover>tbody>tr>th.info:hover,.table-hover>tbody>tr.info:hover>td,.table-hover>tbody>tr.info:hover>th{background-color:#c4e3f3}
+.table>thead>tr>td.warning,.table>tbody>tr>td.warning,.table>tfoot>tr>td.warning,.table>thead>tr>th.warning,.table>tbody>tr>th.warning,.table>tfoot>tr>th.warning,.table>thead>tr.warning>td,.table>tbody>tr.warning>td,.table>tfoot>tr.warning>td,.table>thead>tr.warning>th,.table>tbody>tr.warning>th,.table>tfoot>tr.warning>th{background-color:#fcf8e3}
+.table-hover>tbody>tr>td.warning:hover,.table-hover>tbody>tr>th.warning:hover,.table-hover>tbody>tr.warning:hover>td,.table-hover>tbody>tr.warning:hover>th{background-color:#faf2cc}
+.table>thead>tr>td.danger,.table>tbody>tr>td.danger,.table>tfoot>tr>td.danger,.table>thead>tr>th.danger,.table>tbody>tr>th.danger,.table>tfoot>tr>th.danger,.table>thead>tr.danger>td,.table>tbody>tr.danger>td,.table>tfoot>tr.danger>td,.table>thead>tr.danger>th,.table>tbody>tr.danger>th,.table>tfoot>tr.danger>th{background-color:#f2dede}
+.table-hover>tbody>tr>td.danger:hover,.table-hover>tbody>tr>th.danger:hover,.table-hover>tbody>tr.danger:hover>td,.table-hover>tbody>tr.danger:hover>th{background-color:#ebcccc}
+@media (max-width:767px){.table-responsive{width:100%;margin-bottom:13.5px;overflow-y:hidden;overflow-x:scroll;-ms-overflow-style:-ms-autohiding-scrollbar;border:1px solid #ddd;-webkit-overflow-scrolling:touch}.table-responsive>.table{margin-bottom:0}.table-responsive>.table>thead>tr>th,.table-responsive>.table>tbody>tr>th,.table-responsive>.table>tfoot>tr>th,.table-responsive>.table>thead>tr>td,.table-responsive>.table>tbody>tr>td,.table-responsive>.table>tfoot>tr>td{white-space:nowrap} .table-responsive>.table-bordered{border:0}.table-responsive>.table-bordered>thead>tr>th:first-child,.table-responsive>.table-bordered>tbody>tr>th:first-child,.table-responsive>.table-bordered>tfoot>tr>th:first-child,.table-responsive>.table-bordered>thead>tr>td:first-child,.table-responsive>.table-bordered>tbody>tr>td:first-child,.table-responsive>.table-bordered>tfoot>tr>td:first-child{border-left:0} .table-responsive>.table-bordered>thead>tr>th:last-child,.table-responsive>.table-bordered>tbody>tr>th:last-child,.table-responsive>.table-bordered>tfoot>tr>th:last-child,.table-responsive>.table-bordered>thead>tr>td:last-child,.table-responsive>.table-bordered>tbody>tr>td:last-child,.table-responsive>.table-bordered>tfoot>tr>td:last-child{border-right:0} .table-responsive>.table-bordered>tbody>tr:last-child>th,.table-responsive>.table-bordered>tfoot>tr:last-child>th,.table-responsive>.table-bordered>tbody>tr:last-child>td,.table-responsive>.table-bordered>tfoot>tr:last-child>td{border-bottom:0}}fieldset{padding:0;margin:0;border:0;min-width:0}
+legend{display:block;width:100%;padding:0;margin-bottom:18px;font-size:19.5px;line-height:inherit;color:#333;border:0;border-bottom:1px solid #e5e5e5}
+label{display:inline-block;margin-bottom:5px;font-weight:bold}
+input[type="search"]{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
+input[type="radio"],input[type="checkbox"]{margin:4px 0 0;margin-top:1px \9;line-height:normal}
+input[type="file"]{display:block}
+input[type="range"]{display:block;width:100%}
+select[multiple],select[size]{height:auto}
+input[type="file"]:focus,input[type="radio"]:focus,input[type="checkbox"]:focus{outline:thin dotted;outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}
+output{display:block;padding-top:7px;font-size:13px;line-height:1.428571429;color:#555}
+.form-control{display:block;width:100%;height:32px;padding:6px 12px;font-size:13px;line-height:1.428571429;color:#555;background-color:#fff;background-image:none;border:1px solid #ccc;border-radius:4px;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);-webkit-transition:border-color ease-in-out .15s, box-shadow ease-in-out .15s;transition:border-color ease-in-out .15s, box-shadow ease-in-out .15s}.form-control:focus{border-color:#66afe9;outline:0;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);box-shadow:inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6)}
+.form-control::-moz-placeholder{color:#999;opacity:1}
+.form-control:-ms-input-placeholder{color:#999}
+.form-control::-webkit-input-placeholder{color:#999}
+.form-control[disabled],.form-control[readonly],fieldset[disabled] .form-control{cursor:not-allowed;background-color:#eee;opacity:1}
+textarea.form-control{height:auto}
+input[type="search"]{-webkit-appearance:none}
+input[type="date"]{line-height:32px}
+.form-group{margin-bottom:15px}
+.radio,.checkbox{display:block;min-height:18px;margin-top:10px;margin-bottom:10px;padding-left:20px}.radio label,.checkbox label{display:inline;font-weight:normal;cursor:pointer}
+.radio input[type="radio"],.radio-inline input[type="radio"],.checkbox input[type="checkbox"],.checkbox-inline input[type="checkbox"]{float:left;margin-left:-20px}
+.radio+.radio,.checkbox+.checkbox{margin-top:-5px}
+.radio-inline,.checkbox-inline{display:inline-block;padding-left:20px;margin-bottom:0;vertical-align:middle;font-weight:normal;cursor:pointer}
+.radio-inline+.radio-inline,.checkbox-inline+.checkbox-inline{margin-top:0;margin-left:10px}
+input[type="radio"][disabled],input[type="checkbox"][disabled],.radio[disabled],.radio-inline[disabled],.checkbox[disabled],.checkbox-inline[disabled],fieldset[disabled] input[type="radio"],fieldset[disabled] input[type="checkbox"],fieldset[disabled] .radio,fieldset[disabled] .radio-inline,fieldset[disabled] .checkbox,fieldset[disabled] .checkbox-inline{cursor:not-allowed}
+.input-sm{height:30px;padding:5px 10px;font-size:12px;line-height:1.5;border-radius:3px}select.input-sm{height:30px;line-height:30px}
+textarea.input-sm,select[multiple].input-sm{height:auto}
+.input-lg{height:45px;padding:10px 16px;font-size:17px;line-height:1.33;border-radius:6px}select.input-lg{height:45px;line-height:45px}
+textarea.input-lg,select[multiple].input-lg{height:auto}
+.has-feedback{position:relative}.has-feedback .form-control{padding-right:40px}
+.has-feedback .form-control-feedback{position:absolute;top:23px;right:0;display:block;width:32px;height:32px;line-height:32px;text-align:center}
+.has-success .help-block,.has-success .control-label,.has-success .radio,.has-success .checkbox,.has-success .radio-inline,.has-success .checkbox-inline{color:#3c763d}
+.has-success .form-control{border-color:#3c763d;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075)}.has-success .form-control:focus{border-color:#2b542c;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #67b168;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #67b168}
+.has-success .input-group-addon{color:#3c763d;border-color:#3c763d;background-color:#dff0d8}
+.has-success .form-control-feedback{color:#3c763d}
+.has-warning .help-block,.has-warning .control-label,.has-warning .radio,.has-warning .checkbox,.has-warning .radio-inline,.has-warning .checkbox-inline{color:#8a6d3b}
+.has-warning .form-control{border-color:#8a6d3b;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075)}.has-warning .form-control:focus{border-color:#66512c;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #c0a16b;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #c0a16b}
+.has-warning .input-group-addon{color:#8a6d3b;border-color:#8a6d3b;background-color:#fcf8e3}
+.has-warning .form-control-feedback{color:#8a6d3b}
+.has-error .help-block,.has-error .control-label,.has-error .radio,.has-error .checkbox,.has-error .radio-inline,.has-error .checkbox-inline{color:#a94442}
+.has-error .form-control{border-color:#a94442;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075)}.has-error .form-control:focus{border-color:#843534;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #ce8483;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #ce8483}
+.has-error .input-group-addon{color:#a94442;border-color:#a94442;background-color:#f2dede}
+.has-error .form-control-feedback{color:#a94442}
+.form-control-static{margin-bottom:0}
+.help-block{display:block;margin-top:5px;margin-bottom:10px;color:#404040}
+@media (min-width:768px){.form-inline .form-group{display:inline-block;margin-bottom:0;vertical-align:middle} .form-inline .form-control{display:inline-block;width:auto;vertical-align:middle} .form-inline .input-group>.form-control{width:100%} .form-inline .control-label{margin-bottom:0;vertical-align:middle} .form-inline .radio,.form-inline .checkbox{display:inline-block;margin-top:0;margin-bottom:0;padding-left:0;vertical-align:middle} .form-inline .radio input[type="radio"],.form-inline .checkbox input[type="checkbox"]{float:none;margin-left:0} .form-inline .has-feedback .form-control-feedback{top:0}}
+.form-horizontal .control-label,.form-horizontal .radio,.form-horizontal .checkbox,.form-horizontal .radio-inline,.form-horizontal .checkbox-inline{margin-top:0;margin-bottom:0;padding-top:7px}
+.form-horizontal .radio,.form-horizontal .checkbox{min-height:25px}
+.form-horizontal .form-group{margin-left:-15px;margin-right:-15px}
+.form-horizontal .form-control-static{padding-top:7px}
+@media (min-width:768px){.form-horizontal .control-label{text-align:right}}.form-horizontal .has-feedback .form-control-feedback{top:0;right:15px}
+.btn{display:inline-block;margin-bottom:0;font-weight:normal;text-align:center;vertical-align:middle;cursor:pointer;background-image:none;border:1px solid transparent;white-space:nowrap;padding:6px 12px;font-size:13px;line-height:1.428571429;border-radius:4px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.btn:focus,.btn:active:focus,.btn.active:focus{outline:thin dotted;outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}
+.btn:hover,.btn:focus{color:#333;text-decoration:none}
+.btn:active,.btn.active{outline:0;background-image:none;-webkit-box-shadow:inset 0 3px 5px rgba(0,0,0,0.125);box-shadow:inset 0 3px 5px rgba(0,0,0,0.125)}
+.btn.disabled,.btn[disabled],fieldset[disabled] .btn{cursor:not-allowed;pointer-events:none;opacity:.65;filter:alpha(opacity=65);-webkit-box-shadow:none;box-shadow:none}
+.btn-default{color:#333;background-color:#fff;border-color:#ccc}.btn-default:hover,.btn-default:focus,.btn-default:active,.btn-default.active,.open .dropdown-toggle.btn-default{color:#333;background-color:#ebebeb;border-color:#adadad}
+.btn-default:active,.btn-default.active,.open .dropdown-toggle.btn-default{background-image:none}
+.btn-default.disabled,.btn-default[disabled],fieldset[disabled] .btn-default,.btn-default.disabled:hover,.btn-default[disabled]:hover,fieldset[disabled] .btn-default:hover,.btn-default.disabled:focus,.btn-default[disabled]:focus,fieldset[disabled] .btn-default:focus,.btn-default.disabled:active,.btn-default[disabled]:active,fieldset[disabled] .btn-default:active,.btn-default.disabled.active,.btn-default[disabled].active,fieldset[disabled] .btn-default.active{background-color:#fff;border-color:#ccc}
+.btn-default .badge{color:#fff;background-color:#333}
+.btn-primary{color:#fff;background-color:#428bca;border-color:#357ebd}.btn-primary:hover,.btn-primary:focus,.btn-primary:active,.btn-primary.active,.open .dropdown-toggle.btn-primary{color:#fff;background-color:#3276b1;border-color:#285e8e}
+.btn-primary:active,.btn-primary.active,.open .dropdown-toggle.btn-primary{background-image:none}
+.btn-primary.disabled,.btn-primary[disabled],fieldset[disabled] .btn-primary,.btn-primary.disabled:hover,.btn-primary[disabled]:hover,fieldset[disabled] .btn-primary:hover,.btn-primary.disabled:focus,.btn-primary[disabled]:focus,fieldset[disabled] .btn-primary:focus,.btn-primary.disabled:active,.btn-primary[disabled]:active,fieldset[disabled] .btn-primary:active,.btn-primary.disabled.active,.btn-primary[disabled].active,fieldset[disabled] .btn-primary.active{background-color:#428bca;border-color:#357ebd}
+.btn-primary .badge{color:#428bca;background-color:#fff}
+.btn-success{color:#fff;background-color:#5cb85c;border-color:#4cae4c}.btn-success:hover,.btn-success:focus,.btn-success:active,.btn-success.active,.open .dropdown-toggle.btn-success{color:#fff;background-color:#47a447;border-color:#398439}
+.btn-success:active,.btn-success.active,.open .dropdown-toggle.btn-success{background-image:none}
+.btn-success.disabled,.btn-success[disabled],fieldset[disabled] .btn-success,.btn-success.disabled:hover,.btn-success[disabled]:hover,fieldset[disabled] .btn-success:hover,.btn-success.disabled:focus,.btn-success[disabled]:focus,fieldset[disabled] .btn-success:focus,.btn-success.disabled:active,.btn-success[disabled]:active,fieldset[disabled] .btn-success:active,.btn-success.disabled.active,.btn-success[disabled].active,fieldset[disabled] .btn-success.active{background-color:#5cb85c;border-color:#4cae4c}
+.btn-success .badge{color:#5cb85c;background-color:#fff}
+.btn-info{color:#fff;background-color:#5bc0de;border-color:#46b8da}.btn-info:hover,.btn-info:focus,.btn-info:active,.btn-info.active,.open .dropdown-toggle.btn-info{color:#fff;background-color:#39b3d7;border-color:#269abc}
+.btn-info:active,.btn-info.active,.open .dropdown-toggle.btn-info{background-image:none}
+.btn-info.disabled,.btn-info[disabled],fieldset[disabled] .btn-info,.btn-info.disabled:hover,.btn-info[disabled]:hover,fieldset[disabled] .btn-info:hover,.btn-info.disabled:focus,.btn-info[disabled]:focus,fieldset[disabled] .btn-info:focus,.btn-info.disabled:active,.btn-info[disabled]:active,fieldset[disabled] .btn-info:active,.btn-info.disabled.active,.btn-info[disabled].active,fieldset[disabled] .btn-info.active{background-color:#5bc0de;border-color:#46b8da}
+.btn-info .badge{color:#5bc0de;background-color:#fff}
+.btn-warning{color:#fff;background-color:#f0ad4e;border-color:#eea236}.btn-warning:hover,.btn-warning:focus,.btn-warning:active,.btn-warning.active,.open .dropdown-toggle.btn-warning{color:#fff;background-color:#ed9c28;border-color:#d58512}
+.btn-warning:active,.btn-warning.active,.open .dropdown-toggle.btn-warning{background-image:none}
+.btn-warning.disabled,.btn-warning[disabled],fieldset[disabled] .btn-warning,.btn-warning.disabled:hover,.btn-warning[disabled]:hover,fieldset[disabled] .btn-warning:hover,.btn-warning.disabled:focus,.btn-warning[disabled]:focus,fieldset[disabled] .btn-warning:focus,.btn-warning.disabled:active,.btn-warning[disabled]:active,fieldset[disabled] .btn-warning:active,.btn-warning.disabled.active,.btn-warning[disabled].active,fieldset[disabled] .btn-warning.active{background-color:#f0ad4e;border-color:#eea236}
+.btn-warning .badge{color:#f0ad4e;background-color:#fff}
+.btn-danger{color:#fff;background-color:#d9534f;border-color:#d43f3a}.btn-danger:hover,.btn-danger:focus,.btn-danger:active,.btn-danger.active,.open .dropdown-toggle.btn-danger{color:#fff;background-color:#d2322d;border-color:#ac2925}
+.btn-danger:active,.btn-danger.active,.open .dropdown-toggle.btn-danger{background-image:none}
+.btn-danger.disabled,.btn-danger[disabled],fieldset[disabled] .btn-danger,.btn-danger.disabled:hover,.btn-danger[disabled]:hover,fieldset[disabled] .btn-danger:hover,.btn-danger.disabled:focus,.btn-danger[disabled]:focus,fieldset[disabled] .btn-danger:focus,.btn-danger.disabled:active,.btn-danger[disabled]:active,fieldset[disabled] .btn-danger:active,.btn-danger.disabled.active,.btn-danger[disabled].active,fieldset[disabled] .btn-danger.active{background-color:#d9534f;border-color:#d43f3a}
+.btn-danger .badge{color:#d9534f;background-color:#fff}
+.btn-link{color:#428bca;font-weight:normal;cursor:pointer;border-radius:0}.btn-link,.btn-link:active,.btn-link[disabled],fieldset[disabled] .btn-link{background-color:transparent;-webkit-box-shadow:none;box-shadow:none}
+.btn-link,.btn-link:hover,.btn-link:focus,.btn-link:active{border-color:transparent}
+.btn-link:hover,.btn-link:focus{color:#2a6496;text-decoration:underline;background-color:transparent}
+.btn-link[disabled]:hover,fieldset[disabled] .btn-link:hover,.btn-link[disabled]:focus,fieldset[disabled] .btn-link:focus{color:#999;text-decoration:none}
+.btn-lg,.btn-group-lg>.btn{padding:10px 16px;font-size:17px;line-height:1.33;border-radius:6px}
+.btn-sm,.btn-group-sm>.btn{padding:5px 10px;font-size:12px;line-height:1.5;border-radius:3px}
+.btn-xs,.btn-group-xs>.btn{padding:1px 5px;font-size:12px;line-height:1.5;border-radius:3px}
+.btn-block{display:block;width:100%;padding-left:0;padding-right:0}
+.btn-block+.btn-block{margin-top:5px}
+input[type="submit"].btn-block,input[type="reset"].btn-block,input[type="button"].btn-block{width:100%}
+.fade{opacity:0;-webkit-transition:opacity .15s linear;transition:opacity .15s linear}.fade.in{opacity:1}
+.collapse{display:none}.collapse.in{display:block}
+.collapsing{position:relative;height:0;overflow:hidden;-webkit-transition:height .35s ease;transition:height .35s ease}
+@font-face{font-family:'Glyphicons Halflings';src:url('../fonts/glyphicons-halflings-regular.eot');src:url('../fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'),url('../fonts/glyphicons-halflings-regular.woff') format('woff'),url('../fonts/glyphicons-halflings-regular.ttf') format('truetype'),url('../fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg')}.glyphicon{position:relative;top:1px;display:inline-block;font-family:'Glyphicons Halflings';font-style:normal;font-weight:normal;line-height:1;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
+.glyphicon-asterisk:before{content:"\2a"}
+.glyphicon-plus:before{content:"\2b"}
+.glyphicon-euro:before{content:"\20ac"}
+.glyphicon-minus:before{content:"\2212"}
+.glyphicon-cloud:before{content:"\2601"}
+.glyphicon-envelope:before{content:"\2709"}
+.glyphicon-pencil:before{content:"\270f"}
+.glyphicon-glass:before{content:"\e001"}
+.glyphicon-music:before{content:"\e002"}
+.glyphicon-search:before{content:"\e003"}
+.glyphicon-heart:before{content:"\e005"}
+.glyphicon-star:before{content:"\e006"}
+.glyphicon-star-empty:before{content:"\e007"}
+.glyphicon-user:before{content:"\e008"}
+.glyphicon-film:before{content:"\e009"}
+.glyphicon-th-large:before{content:"\e010"}
+.glyphicon-th:before{content:"\e011"}
+.glyphicon-th-list:before{content:"\e012"}
+.glyphicon-ok:before{content:"\e013"}
+.glyphicon-remove:before{content:"\e014"}
+.glyphicon-zoom-in:before{content:"\e015"}
+.glyphicon-zoom-out:before{content:"\e016"}
+.glyphicon-off:before{content:"\e017"}
+.glyphicon-signal:before{content:"\e018"}
+.glyphicon-cog:before{content:"\e019"}
+.glyphicon-trash:before{content:"\e020"}
+.glyphicon-home:before{content:"\e021"}
+.glyphicon-file:before{content:"\e022"}
+.glyphicon-time:before{content:"\e023"}
+.glyphicon-road:before{content:"\e024"}
+.glyphicon-download-alt:before{content:"\e025"}
+.glyphicon-download:before{content:"\e026"}
+.glyphicon-upload:before{content:"\e027"}
+.glyphicon-inbox:before{content:"\e028"}
+.glyphicon-play-circle:before{content:"\e029"}
+.glyphicon-repeat:before{content:"\e030"}
+.glyphicon-refresh:before{content:"\e031"}
+.glyphicon-list-alt:before{content:"\e032"}
+.glyphicon-lock:before{content:"\e033"}
+.glyphicon-flag:before{content:"\e034"}
+.glyphicon-headphones:before{content:"\e035"}
+.glyphicon-volume-off:before{content:"\e036"}
+.glyphicon-volume-down:before{content:"\e037"}
+.glyphicon-volume-up:before{content:"\e038"}
+.glyphicon-qrcode:before{content:"\e039"}
+.glyphicon-barcode:before{content:"\e040"}
+.glyphicon-tag:before{content:"\e041"}
+.glyphicon-tags:before{content:"\e042"}
+.glyphicon-book:before{content:"\e043"}
+.glyphicon-bookmark:before{content:"\e044"}
+.glyphicon-print:before{content:"\e045"}
+.glyphicon-camera:before{content:"\e046"}
+.glyphicon-font:before{content:"\e047"}
+.glyphicon-bold:before{content:"\e048"}
+.glyphicon-italic:before{content:"\e049"}
+.glyphicon-text-height:before{content:"\e050"}
+.glyphicon-text-width:before{content:"\e051"}
+.glyphicon-align-left:before{content:"\e052"}
+.glyphicon-align-center:before{content:"\e053"}
+.glyphicon-align-right:before{content:"\e054"}
+.glyphicon-align-justify:before{content:"\e055"}
+.glyphicon-list:before{content:"\e056"}
+.glyphicon-indent-left:before{content:"\e057"}
+.glyphicon-indent-right:before{content:"\e058"}
+.glyphicon-facetime-video:before{content:"\e059"}
+.glyphicon-picture:before{content:"\e060"}
+.glyphicon-map-marker:before{content:"\e062"}
+.glyphicon-adjust:before{content:"\e063"}
+.glyphicon-tint:before{content:"\e064"}
+.glyphicon-edit:before{content:"\e065"}
+.glyphicon-share:before{content:"\e066"}
+.glyphicon-check:before{content:"\e067"}
+.glyphicon-move:before{content:"\e068"}
+.glyphicon-step-backward:before{content:"\e069"}
+.glyphicon-fast-backward:before{content:"\e070"}
+.glyphicon-backward:before{content:"\e071"}
+.glyphicon-play:before{content:"\e072"}
+.glyphicon-pause:before{content:"\e073"}
+.glyphicon-stop:before{content:"\e074"}
+.glyphicon-forward:before{content:"\e075"}
+.glyphicon-fast-forward:before{content:"\e076"}
+.glyphicon-step-forward:before{content:"\e077"}
+.glyphicon-eject:before{content:"\e078"}
+.glyphicon-chevron-left:before{content:"\e079"}
+.glyphicon-chevron-right:before{content:"\e080"}
+.glyphicon-plus-sign:before{content:"\e081"}
+.glyphicon-minus-sign:before{content:"\e082"}
+.glyphicon-remove-sign:before{content:"\e083"}
+.glyphicon-ok-sign:before{content:"\e084"}
+.glyphicon-question-sign:before{content:"\e085"}
+.glyphicon-info-sign:before{content:"\e086"}
+.glyphicon-screenshot:before{content:"\e087"}
+.glyphicon-remove-circle:before{content:"\e088"}
+.glyphicon-ok-circle:before{content:"\e089"}
+.glyphicon-ban-circle:before{content:"\e090"}
+.glyphicon-arrow-left:before{content:"\e091"}
+.glyphicon-arrow-right:before{content:"\e092"}
+.glyphicon-arrow-up:before{content:"\e093"}
+.glyphicon-arrow-down:before{content:"\e094"}
+.glyphicon-share-alt:before{content:"\e095"}
+.glyphicon-resize-full:before{content:"\e096"}
+.glyphicon-resize-small:before{content:"\e097"}
+.glyphicon-exclamation-sign:before{content:"\e101"}
+.glyphicon-gift:before{content:"\e102"}
+.glyphicon-leaf:before{content:"\e103"}
+.glyphicon-fire:before{content:"\e104"}
+.glyphicon-eye-open:before{content:"\e105"}
+.glyphicon-eye-close:before{content:"\e106"}
+.glyphicon-warning-sign:before{content:"\e107"}
+.glyphicon-plane:before{content:"\e108"}
+.glyphicon-calendar:before{content:"\e109"}
+.glyphicon-random:before{content:"\e110"}
+.glyphicon-comment:before{content:"\e111"}
+.glyphicon-magnet:before{content:"\e112"}
+.glyphicon-chevron-up:before{content:"\e113"}
+.glyphicon-chevron-down:before{content:"\e114"}
+.glyphicon-retweet:before{content:"\e115"}
+.glyphicon-shopping-cart:before{content:"\e116"}
+.glyphicon-folder-close:before{content:"\e117"}
+.glyphicon-folder-open:before{content:"\e118"}
+.glyphicon-resize-vertical:before{content:"\e119"}
+.glyphicon-resize-horizontal:before{content:"\e120"}
+.glyphicon-hdd:before{content:"\e121"}
+.glyphicon-bullhorn:before{content:"\e122"}
+.glyphicon-bell:before{content:"\e123"}
+.glyphicon-certificate:before{content:"\e124"}
+.glyphicon-thumbs-up:before{content:"\e125"}
+.glyphicon-thumbs-down:before{content:"\e126"}
+.glyphicon-hand-right:before{content:"\e127"}
+.glyphicon-hand-left:before{content:"\e128"}
+.glyphicon-hand-up:before{content:"\e129"}
+.glyphicon-hand-down:before{content:"\e130"}
+.glyphicon-circle-arrow-right:before{content:"\e131"}
+.glyphicon-circle-arrow-left:before{content:"\e132"}
+.glyphicon-circle-arrow-up:before{content:"\e133"}
+.glyphicon-circle-arrow-down:before{content:"\e134"}
+.glyphicon-globe:before{content:"\e135"}
+.glyphicon-wrench:before{content:"\e136"}
+.glyphicon-tasks:before{content:"\e137"}
+.glyphicon-filter:before{content:"\e138"}
+.glyphicon-briefcase:before{content:"\e139"}
+.glyphicon-fullscreen:before{content:"\e140"}
+.glyphicon-dashboard:before{content:"\e141"}
+.glyphicon-paperclip:before{content:"\e142"}
+.glyphicon-heart-empty:before{content:"\e143"}
+.glyphicon-link:before{content:"\e144"}
+.glyphicon-phone:before{content:"\e145"}
+.glyphicon-pushpin:before{content:"\e146"}
+.glyphicon-usd:before{content:"\e148"}
+.glyphicon-gbp:before{content:"\e149"}
+.glyphicon-sort:before{content:"\e150"}
+.glyphicon-sort-by-alphabet:before{content:"\e151"}
+.glyphicon-sort-by-alphabet-alt:before{content:"\e152"}
+.glyphicon-sort-by-order:before{content:"\e153"}
+.glyphicon-sort-by-order-alt:before{content:"\e154"}
+.glyphicon-sort-by-attributes:before{content:"\e155"}
+.glyphicon-sort-by-attributes-alt:before{content:"\e156"}
+.glyphicon-unchecked:before{content:"\e157"}
+.glyphicon-expand:before{content:"\e158"}
+.glyphicon-collapse-down:before{content:"\e159"}
+.glyphicon-collapse-up:before{content:"\e160"}
+.glyphicon-log-in:before{content:"\e161"}
+.glyphicon-flash:before{content:"\e162"}
+.glyphicon-log-out:before{content:"\e163"}
+.glyphicon-new-window:before{content:"\e164"}
+.glyphicon-record:before{content:"\e165"}
+.glyphicon-save:before{content:"\e166"}
+.glyphicon-open:before{content:"\e167"}
+.glyphicon-saved:before{content:"\e168"}
+.glyphicon-import:before{content:"\e169"}
+.glyphicon-export:before{content:"\e170"}
+.glyphicon-send:before{content:"\e171"}
+.glyphicon-floppy-disk:before{content:"\e172"}
+.glyphicon-floppy-saved:before{content:"\e173"}
+.glyphicon-floppy-remove:before{content:"\e174"}
+.glyphicon-floppy-save:before{content:"\e175"}
+.glyphicon-floppy-open:before{content:"\e176"}
+.glyphicon-credit-card:before{content:"\e177"}
+.glyphicon-transfer:before{content:"\e178"}
+.glyphicon-cutlery:before{content:"\e179"}
+.glyphicon-header:before{content:"\e180"}
+.glyphicon-compressed:before{content:"\e181"}
+.glyphicon-earphone:before{content:"\e182"}
+.glyphicon-phone-alt:before{content:"\e183"}
+.glyphicon-tower:before{content:"\e184"}
+.glyphicon-stats:before{content:"\e185"}
+.glyphicon-sd-video:before{content:"\e186"}
+.glyphicon-hd-video:before{content:"\e187"}
+.glyphicon-subtitles:before{content:"\e188"}
+.glyphicon-sound-stereo:before{content:"\e189"}
+.glyphicon-sound-dolby:before{content:"\e190"}
+.glyphicon-sound-5-1:before{content:"\e191"}
+.glyphicon-sound-6-1:before{content:"\e192"}
+.glyphicon-sound-7-1:before{content:"\e193"}
+.glyphicon-copyright-mark:before{content:"\e194"}
+.glyphicon-registration-mark:before{content:"\e195"}
+.glyphicon-cloud-download:before{content:"\e197"}
+.glyphicon-cloud-upload:before{content:"\e198"}
+.glyphicon-tree-conifer:before{content:"\e199"}
+.glyphicon-tree-deciduous:before{content:"\e200"}
+.caret{display:inline-block;width:0;height:0;margin-left:2px;vertical-align:middle;border-top:4px solid;border-right:4px solid transparent;border-left:4px solid transparent}
+.dropdown{position:relative}
+.dropdown-toggle:focus{outline:0}
+.dropdown-menu{position:absolute;top:100%;left:0;z-index:1000;display:none;float:left;min-width:160px;padding:5px 0;margin:2px 0 0;list-style:none;font-size:13px;background-color:#fff;border:1px solid #ccc;border:1px solid rgba(0,0,0,0.15);border-radius:4px;-webkit-box-shadow:0 6px 12px rgba(0,0,0,0.175);box-shadow:0 6px 12px rgba(0,0,0,0.175);background-clip:padding-box}.dropdown-menu.pull-right{right:0;left:auto}
+.dropdown-menu .divider{height:1px;margin:8px 0;overflow:hidden;background-color:#e5e5e5}
+.dropdown-menu>li>a{display:block;padding:3px 20px;clear:both;font-weight:normal;line-height:1.428571429;color:#333;white-space:nowrap}
+.dropdown-menu>li>a:hover,.dropdown-menu>li>a:focus{text-decoration:none;color:#262626;background-color:#f5f5f5}
+.dropdown-menu>.active>a,.dropdown-menu>.active>a:hover,.dropdown-menu>.active>a:focus{color:#fff;text-decoration:none;outline:0;background-color:#428bca}
+.dropdown-menu>.disabled>a,.dropdown-menu>.disabled>a:hover,.dropdown-menu>.disabled>a:focus{color:#999}
+.dropdown-menu>.disabled>a:hover,.dropdown-menu>.disabled>a:focus{text-decoration:none;background-color:transparent;background-image:none;filter:progid:DXImageTransform.Microsoft.gradient(enabled = false);cursor:not-allowed}
+.open>.dropdown-menu{display:block}
+.open>a{outline:0}
+.dropdown-menu-right{left:auto;right:0}
+.dropdown-menu-left{left:0;right:auto}
+.dropdown-header{display:block;padding:3px 20px;font-size:12px;line-height:1.428571429;color:#999}
+.dropdown-backdrop{position:fixed;left:0;right:0;bottom:0;top:0;z-index:990}
+.pull-right>.dropdown-menu{right:0;left:auto}
+.dropup .caret,.navbar-fixed-bottom .dropdown .caret{border-top:0;border-bottom:4px solid;content:""}
+.dropup .dropdown-menu,.navbar-fixed-bottom .dropdown .dropdown-menu{top:auto;bottom:100%;margin-bottom:1px}
+@media (min-width:768px){.navbar-right .dropdown-menu{left:auto;right:0} .navbar-right .dropdown-menu-left{left:0;right:auto}}.btn-group,.btn-group-vertical{position:relative;display:inline-block;vertical-align:middle}.btn-group>.btn,.btn-group-vertical>.btn{position:relative;float:left}.btn-group>.btn:hover,.btn-group-vertical>.btn:hover,.btn-group>.btn:focus,.btn-group-vertical>.btn:focus,.btn-group>.btn:active,.btn-group-vertical>.btn:active,.btn-group>.btn.active,.btn-group-vertical>.btn.active{z-index:2}
+.btn-group>.btn:focus,.btn-group-vertical>.btn:focus{outline:none}
+.btn-group .btn+.btn,.btn-group .btn+.btn-group,.btn-group .btn-group+.btn,.btn-group .btn-group+.btn-group{margin-left:-1px}
+.btn-toolbar{margin-left:-5px}.btn-toolbar .btn-group,.btn-toolbar .input-group{float:left}
+.btn-toolbar>.btn,.btn-toolbar>.btn-group,.btn-toolbar>.input-group{margin-left:5px}
+.btn-group>.btn:not(:first-child):not(:last-child):not(.dropdown-toggle){border-radius:0}
+.btn-group>.btn:first-child{margin-left:0}.btn-group>.btn:first-child:not(:last-child):not(.dropdown-toggle){border-bottom-right-radius:0;border-top-right-radius:0}
+.btn-group>.btn:last-child:not(:first-child),.btn-group>.dropdown-toggle:not(:first-child){border-bottom-left-radius:0;border-top-left-radius:0}
+.btn-group>.btn-group{float:left}
+.btn-group>.btn-group:not(:first-child):not(:last-child)>.btn{border-radius:0}
+.btn-group>.btn-group:first-child>.btn:last-child,.btn-group>.btn-group:first-child>.dropdown-toggle{border-bottom-right-radius:0;border-top-right-radius:0}
+.btn-group>.btn-group:last-child>.btn:first-child{border-bottom-left-radius:0;border-top-left-radius:0}
+.btn-group .dropdown-toggle:active,.btn-group.open .dropdown-toggle{outline:0}
+.btn-group>.btn+.dropdown-toggle{padding-left:8px;padding-right:8px}
+.btn-group>.btn-lg+.dropdown-toggle{padding-left:12px;padding-right:12px}
+.btn-group.open .dropdown-toggle{-webkit-box-shadow:inset 0 3px 5px rgba(0,0,0,0.125);box-shadow:inset 0 3px 5px rgba(0,0,0,0.125)}.btn-group.open .dropdown-toggle.btn-link{-webkit-box-shadow:none;box-shadow:none}
+.btn .caret{margin-left:0}
+.btn-lg .caret{border-width:5px 5px 0;border-bottom-width:0}
+.dropup .btn-lg .caret{border-width:0 5px 5px}
+.btn-group-vertical>.btn,.btn-group-vertical>.btn-group,.btn-group-vertical>.btn-group>.btn{display:block;float:none;width:100%;max-width:100%}
+.btn-group-vertical>.btn-group>.btn{float:none}
+.btn-group-vertical>.btn+.btn,.btn-group-vertical>.btn+.btn-group,.btn-group-vertical>.btn-group+.btn,.btn-group-vertical>.btn-group+.btn-group{margin-top:-1px;margin-left:0}
+.btn-group-vertical>.btn:not(:first-child):not(:last-child){border-radius:0}
+.btn-group-vertical>.btn:first-child:not(:last-child){border-top-right-radius:4px;border-bottom-right-radius:0;border-bottom-left-radius:0}
+.btn-group-vertical>.btn:last-child:not(:first-child){border-bottom-left-radius:4px;border-top-right-radius:0;border-top-left-radius:0}
+.btn-group-vertical>.btn-group:not(:first-child):not(:last-child)>.btn{border-radius:0}
+.btn-group-vertical>.btn-group:first-child:not(:last-child)>.btn:last-child,.btn-group-vertical>.btn-group:first-child:not(:last-child)>.dropdown-toggle{border-bottom-right-radius:0;border-bottom-left-radius:0}
+.btn-group-vertical>.btn-group:last-child:not(:first-child)>.btn:first-child{border-top-right-radius:0;border-top-left-radius:0}
+.btn-group-justified{display:table;width:100%;table-layout:fixed;border-collapse:separate}.btn-group-justified>.btn,.btn-group-justified>.btn-group{float:none;display:table-cell;width:1%}
+.btn-group-justified>.btn-group .btn{width:100%}
+[data-toggle="buttons"]>.btn>input[type="radio"],[data-toggle="buttons"]>.btn>input[type="checkbox"]{display:none}
+.input-group{position:relative;display:table;border-collapse:separate}.input-group[class*="col-"]{float:none;padding-left:0;padding-right:0}
+.input-group .form-control{position:relative;z-index:2;float:left;width:100%;margin-bottom:0}
+.input-group-lg>.form-control,.input-group-lg>.input-group-addon,.input-group-lg>.input-group-btn>.btn{height:45px;padding:10px 16px;font-size:17px;line-height:1.33;border-radius:6px}select.input-group-lg>.form-control,select.input-group-lg>.input-group-addon,select.input-group-lg>.input-group-btn>.btn{height:45px;line-height:45px}
+textarea.input-group-lg>.form-control,textarea.input-group-lg>.input-group-addon,textarea.input-group-lg>.input-group-btn>.btn,select[multiple].input-group-lg>.form-control,select[multiple].input-group-lg>.input-group-addon,select[multiple].input-group-lg>.input-group-btn>.btn{height:auto}
+.input-group-sm>.form-control,.input-group-sm>.input-group-addon,.input-group-sm>.input-group-btn>.btn{height:30px;padding:5px 10px;font-size:12px;line-height:1.5;border-radius:3px}select.input-group-sm>.form-control,select.input-group-sm>.input-group-addon,select.input-group-sm>.input-group-btn>.btn{height:30px;line-height:30px}
+textarea.input-group-sm>.form-control,textarea.input-group-sm>.input-group-addon,textarea.input-group-sm>.input-group-btn>.btn,select[multiple].input-group-sm>.form-control,select[multiple].input-group-sm>.input-group-addon,select[multiple].input-group-sm>.input-group-btn>.btn{height:auto}
+.input-group-addon,.input-group-btn,.input-group .form-control{display:table-cell}.input-group-addon:not(:first-child):not(:last-child),.input-group-btn:not(:first-child):not(:last-child),.input-group .form-control:not(:first-child):not(:last-child){border-radius:0}
+.input-group-addon,.input-group-btn{width:1%;white-space:nowrap;vertical-align:middle}
+.input-group-addon{padding:6px 12px;font-size:13px;font-weight:normal;line-height:1;color:#555;text-align:center;background-color:#eee;border:1px solid #ccc;border-radius:4px}.input-group-addon.input-sm{padding:5px 10px;font-size:12px;border-radius:3px}
+.input-group-addon.input-lg{padding:10px 16px;font-size:17px;border-radius:6px}
+.input-group-addon input[type="radio"],.input-group-addon input[type="checkbox"]{margin-top:0}
+.input-group .form-control:first-child,.input-group-addon:first-child,.input-group-btn:first-child>.btn,.input-group-btn:first-child>.btn-group>.btn,.input-group-btn:first-child>.dropdown-toggle,.input-group-btn:last-child>.btn:not(:last-child):not(.dropdown-toggle),.input-group-btn:last-child>.btn-group:not(:last-child)>.btn{border-bottom-right-radius:0;border-top-right-radius:0}
+.input-group-addon:first-child{border-right:0}
+.input-group .form-control:last-child,.input-group-addon:last-child,.input-group-btn:last-child>.btn,.input-group-btn:last-child>.btn-group>.btn,.input-group-btn:last-child>.dropdown-toggle,.input-group-btn:first-child>.btn:not(:first-child),.input-group-btn:first-child>.btn-group:not(:first-child)>.btn{border-bottom-left-radius:0;border-top-left-radius:0}
+.input-group-addon:last-child{border-left:0}
+.input-group-btn{position:relative;font-size:0;white-space:nowrap}.input-group-btn>.btn{position:relative}.input-group-btn>.btn+.btn{margin-left:-1px}
+.input-group-btn>.btn:hover,.input-group-btn>.btn:focus,.input-group-btn>.btn:active{z-index:2}
+.input-group-btn:first-child>.btn,.input-group-btn:first-child>.btn-group{margin-right:-1px}
+.input-group-btn:last-child>.btn,.input-group-btn:last-child>.btn-group{margin-left:-1px}
+.nav{margin-bottom:0;padding-left:0;list-style:none}.nav>li{position:relative;display:block}.nav>li>a{position:relative;display:block;padding:10px 15px}.nav>li>a:hover,.nav>li>a:focus{text-decoration:none;background-color:#eee}
+.nav>li.disabled>a{color:#999}.nav>li.disabled>a:hover,.nav>li.disabled>a:focus{color:#999;text-decoration:none;background-color:transparent;cursor:not-allowed}
+.nav .open>a,.nav .open>a:hover,.nav .open>a:focus{background-color:#eee;border-color:#428bca}
+.nav .nav-divider{height:1px;margin:8px 0;overflow:hidden;background-color:#e5e5e5}
+.nav>li>a>img{max-width:none}
+.nav-tabs{border-bottom:1px solid #ddd}.nav-tabs>li{float:left;margin-bottom:-1px}.nav-tabs>li>a{margin-right:2px;line-height:1.428571429;border:1px solid transparent;border-radius:4px 4px 0 0}.nav-tabs>li>a:hover{border-color:#eee #eee #ddd}
+.nav-tabs>li.active>a,.nav-tabs>li.active>a:hover,.nav-tabs>li.active>a:focus{color:#555;background-color:#fff;border:1px solid #ddd;border-bottom-color:transparent;cursor:default}
+.nav-tabs.nav-justified{width:100%;border-bottom:0}.nav-tabs.nav-justified>li{float:none}.nav-tabs.nav-justified>li>a{text-align:center;margin-bottom:5px}
+.nav-tabs.nav-justified>.dropdown .dropdown-menu{top:auto;left:auto}
+@media (min-width:768px){.nav-tabs.nav-justified>li{display:table-cell;width:1%}.nav-tabs.nav-justified>li>a{margin-bottom:0}}.nav-tabs.nav-justified>li>a{margin-right:0;border-radius:4px}
+.nav-tabs.nav-justified>.active>a,.nav-tabs.nav-justified>.active>a:hover,.nav-tabs.nav-justified>.active>a:focus{border:1px solid #ddd}
+@media (min-width:768px){.nav-tabs.nav-justified>li>a{border-bottom:1px solid #ddd;border-radius:4px 4px 0 0} .nav-tabs.nav-justified>.active>a,.nav-tabs.nav-justified>.active>a:hover,.nav-tabs.nav-justified>.active>a:focus{border-bottom-color:#fff}}
+.nav-pills>li{float:left}.nav-pills>li>a{border-radius:4px}
+.nav-pills>li+li{margin-left:2px}
+.nav-pills>li.active>a,.nav-pills>li.active>a:hover,.nav-pills>li.active>a:focus{color:#fff;background-color:#428bca}
+.nav-stacked>li{float:none}.nav-stacked>li+li{margin-top:2px;margin-left:0}
+.nav-justified{width:100%}.nav-justified>li{float:none}.nav-justified>li>a{text-align:center;margin-bottom:5px}
+.nav-justified>.dropdown .dropdown-menu{top:auto;left:auto}
+@media (min-width:768px){.nav-justified>li{display:table-cell;width:1%}.nav-justified>li>a{margin-bottom:0}}
+.nav-tabs-justified{border-bottom:0}.nav-tabs-justified>li>a{margin-right:0;border-radius:4px}
+.nav-tabs-justified>.active>a,.nav-tabs-justified>.active>a:hover,.nav-tabs-justified>.active>a:focus{border:1px solid #ddd}
+@media (min-width:768px){.nav-tabs-justified>li>a{border-bottom:1px solid #ddd;border-radius:4px 4px 0 0} .nav-tabs-justified>.active>a,.nav-tabs-justified>.active>a:hover,.nav-tabs-justified>.active>a:focus{border-bottom-color:#fff}}
+.tab-content>.tab-pane{display:none}
+.tab-content>.active{display:block}
+.nav-tabs .dropdown-menu{margin-top:-1px;border-top-right-radius:0;border-top-left-radius:0}
+.navbar{position:relative;min-height:36px;margin-bottom:18px;border:1px solid transparent}@media (min-width:768px){.navbar{border-radius:4px}}
+@media (min-width:768px){.navbar-header{float:left}}
+.navbar-collapse{max-height:340px;overflow-x:visible;padding-right:15px;padding-left:15px;border-top:1px solid transparent;box-shadow:inset 0 1px 0 rgba(255,255,255,0.1);-webkit-overflow-scrolling:touch}.navbar-collapse.in{overflow-y:auto}
+@media (min-width:768px){.navbar-collapse{width:auto;border-top:0;box-shadow:none}.navbar-collapse.collapse{display:block !important;height:auto !important;padding-bottom:0;overflow:visible !important} .navbar-collapse.in{overflow-y:visible} .navbar-fixed-top .navbar-collapse,.navbar-static-top .navbar-collapse,.navbar-fixed-bottom .navbar-collapse{padding-left:0;padding-right:0}}
+.container>.navbar-header,.container-fluid>.navbar-header,.container>.navbar-collapse,.container-fluid>.navbar-collapse{margin-right:-15px;margin-left:-15px}@media (min-width:768px){.container>.navbar-header,.container-fluid>.navbar-header,.container>.navbar-collapse,.container-fluid>.navbar-collapse{margin-right:0;margin-left:0}}
+.navbar-static-top{z-index:1000;border-width:0 0 1px}@media (min-width:768px){.navbar-static-top{border-radius:0}}
+.navbar-fixed-top,.navbar-fixed-bottom{position:fixed;right:0;left:0;z-index:1030}@media (min-width:768px){.navbar-fixed-top,.navbar-fixed-bottom{border-radius:0}}
+.navbar-fixed-top{top:0;border-width:0 0 1px}
+.navbar-fixed-bottom{bottom:0;margin-bottom:0;border-width:1px 0 0}
+.navbar-brand{float:left;padding:9px 15px;font-size:17px;line-height:18px;height:36px}.navbar-brand:hover,.navbar-brand:focus{text-decoration:none}
+@media (min-width:768px){.navbar>.container .navbar-brand,.navbar>.container-fluid .navbar-brand{margin-left:-15px}}
+.navbar-toggle{position:relative;float:right;margin-right:15px;padding:9px 10px;margin-top:1px;margin-bottom:1px;background-color:transparent;background-image:none;border:1px solid transparent;border-radius:4px}.navbar-toggle:focus{outline:none}
+.navbar-toggle .icon-bar{display:block;width:22px;height:2px;border-radius:1px}
+.navbar-toggle .icon-bar+.icon-bar{margin-top:4px}
+@media (min-width:768px){.navbar-toggle{display:none}}
+.navbar-nav{margin:4.5px -15px}.navbar-nav>li>a{padding-top:10px;padding-bottom:10px;line-height:18px}
+@media (max-width:767px){.navbar-nav .open .dropdown-menu{position:static;float:none;width:auto;margin-top:0;background-color:transparent;border:0;box-shadow:none}.navbar-nav .open .dropdown-menu>li>a,.navbar-nav .open .dropdown-menu .dropdown-header{padding:5px 15px 5px 25px} .navbar-nav .open .dropdown-menu>li>a{line-height:18px}.navbar-nav .open .dropdown-menu>li>a:hover,.navbar-nav .open .dropdown-menu>li>a:focus{background-image:none}}@media (min-width:768px){.navbar-nav{float:left;margin:0}.navbar-nav>li{float:left}.navbar-nav>li>a{padding-top:9px;padding-bottom:9px} .navbar-nav.navbar-right:last-child{margin-right:-15px}}
+@media (min-width:768px){.navbar-left{float:left !important;float:left} .navbar-right{float:right !important;float:right}}.navbar-form{margin-left:-15px;margin-right:-15px;padding:10px 15px;border-top:1px solid transparent;border-bottom:1px solid transparent;-webkit-box-shadow:inset 0 1px 0 rgba(255,255,255,0.1),0 1px 0 rgba(255,255,255,0.1);box-shadow:inset 0 1px 0 rgba(255,255,255,0.1),0 1px 0 rgba(255,255,255,0.1);margin-top:2px;margin-bottom:2px}@media (min-width:768px){.navbar-form .form-group{display:inline-block;margin-bottom:0;vertical-align:middle} .navbar-form .form-control{display:inline-block;width:auto;vertical-align:middle} .navbar-form .input-group>.form-control{width:100%} .navbar-form .control-label{margin-bottom:0;vertical-align:middle} .navbar-form .radio,.navbar-form .checkbox{display:inline-block;margin-top:0;margin-bottom:0;padding-left:0;vertical-align:middle} .navbar-form .radio input[type="radio"],.navbar-form .checkbox input[type="checkbox"]{float:none;margin-left:0} .navbar-form .has-feedback .form-control-feedback{top:0}}@media (max-width:767px){.navbar-form .form-group{margin-bottom:5px}}
+@media (min-width:768px){.navbar-form{width:auto;border:0;margin-left:0;margin-right:0;padding-top:0;padding-bottom:0;-webkit-box-shadow:none;box-shadow:none}.navbar-form.navbar-right:last-child{margin-right:-15px}}
+.navbar-nav>li>.dropdown-menu{margin-top:0;border-top-right-radius:0;border-top-left-radius:0}
+.navbar-fixed-bottom .navbar-nav>li>.dropdown-menu{border-bottom-right-radius:0;border-bottom-left-radius:0}
+.navbar-btn{margin-top:2px;margin-bottom:2px}.navbar-btn.btn-sm{margin-top:3px;margin-bottom:3px}
+.navbar-btn.btn-xs{margin-top:7px;margin-bottom:7px}
+.navbar-text{margin-top:9px;margin-bottom:9px}@media (min-width:768px){.navbar-text{float:left;margin-left:15px;margin-right:15px}.navbar-text.navbar-right:last-child{margin-right:0}}
+.navbar-default{background-color:#f8f8f8;border-color:#e7e7e7}.navbar-default .navbar-brand{color:#777}.navbar-default .navbar-brand:hover,.navbar-default .navbar-brand:focus{color:#5e5e5e;background-color:transparent}
+.navbar-default .navbar-text{color:#777}
+.navbar-default .navbar-nav>li>a{color:#777}.navbar-default .navbar-nav>li>a:hover,.navbar-default .navbar-nav>li>a:focus{color:#333;background-color:transparent}
+.navbar-default .navbar-nav>.active>a,.navbar-default .navbar-nav>.active>a:hover,.navbar-default .navbar-nav>.active>a:focus{color:#555;background-color:#e7e7e7}
+.navbar-default .navbar-nav>.disabled>a,.navbar-default .navbar-nav>.disabled>a:hover,.navbar-default .navbar-nav>.disabled>a:focus{color:#ccc;background-color:transparent}
+.navbar-default .navbar-toggle{border-color:#ddd}.navbar-default .navbar-toggle:hover,.navbar-default .navbar-toggle:focus{background-color:#ddd}
+.navbar-default .navbar-toggle .icon-bar{background-color:#888}
+.navbar-default .navbar-collapse,.navbar-default .navbar-form{border-color:#e7e7e7}
+.navbar-default .navbar-nav>.open>a,.navbar-default .navbar-nav>.open>a:hover,.navbar-default .navbar-nav>.open>a:focus{background-color:#e7e7e7;color:#555}
+@media (max-width:767px){.navbar-default .navbar-nav .open .dropdown-menu>li>a{color:#777}.navbar-default .navbar-nav .open .dropdown-menu>li>a:hover,.navbar-default .navbar-nav .open .dropdown-menu>li>a:focus{color:#333;background-color:transparent} .navbar-default .navbar-nav .open .dropdown-menu>.active>a,.navbar-default .navbar-nav .open .dropdown-menu>.active>a:hover,.navbar-default .navbar-nav .open .dropdown-menu>.active>a:focus{color:#555;background-color:#e7e7e7} .navbar-default .navbar-nav .open .dropdown-menu>.disabled>a,.navbar-default .navbar-nav .open .dropdown-menu>.disabled>a:hover,.navbar-default .navbar-nav .open .dropdown-menu>.disabled>a:focus{color:#ccc;background-color:transparent}}
+.navbar-default .navbar-link{color:#777}.navbar-default .navbar-link:hover{color:#333}
+.navbar-inverse{background-color:#222;border-color:#080808}.navbar-inverse .navbar-brand{color:#999}.navbar-inverse .navbar-brand:hover,.navbar-inverse .navbar-brand:focus{color:#fff;background-color:transparent}
+.navbar-inverse .navbar-text{color:#999}
+.navbar-inverse .navbar-nav>li>a{color:#999}.navbar-inverse .navbar-nav>li>a:hover,.navbar-inverse .navbar-nav>li>a:focus{color:#fff;background-color:transparent}
+.navbar-inverse .navbar-nav>.active>a,.navbar-inverse .navbar-nav>.active>a:hover,.navbar-inverse .navbar-nav>.active>a:focus{color:#fff;background-color:#080808}
+.navbar-inverse .navbar-nav>.disabled>a,.navbar-inverse .navbar-nav>.disabled>a:hover,.navbar-inverse .navbar-nav>.disabled>a:focus{color:#444;background-color:transparent}
+.navbar-inverse .navbar-toggle{border-color:#333}.navbar-inverse .navbar-toggle:hover,.navbar-inverse .navbar-toggle:focus{background-color:#333}
+.navbar-inverse .navbar-toggle .icon-bar{background-color:#fff}
+.navbar-inverse .navbar-collapse,.navbar-inverse .navbar-form{border-color:#101010}
+.navbar-inverse .navbar-nav>.open>a,.navbar-inverse .navbar-nav>.open>a:hover,.navbar-inverse .navbar-nav>.open>a:focus{background-color:#080808;color:#fff}
+@media (max-width:767px){.navbar-inverse .navbar-nav .open .dropdown-menu>.dropdown-header{border-color:#080808} .navbar-inverse .navbar-nav .open .dropdown-menu .divider{background-color:#080808} .navbar-inverse .navbar-nav .open .dropdown-menu>li>a{color:#999}.navbar-inverse .navbar-nav .open .dropdown-menu>li>a:hover,.navbar-inverse .navbar-nav .open .dropdown-menu>li>a:focus{color:#fff;background-color:transparent} .navbar-inverse .navbar-nav .open .dropdown-menu>.active>a,.navbar-inverse .navbar-nav .open .dropdown-menu>.active>a:hover,.navbar-inverse .navbar-nav .open .dropdown-menu>.active>a:focus{color:#fff;background-color:#080808} .navbar-inverse .navbar-nav .open .dropdown-menu>.disabled>a,.navbar-inverse .navbar-nav .open .dropdown-menu>.disabled>a:hover,.navbar-inverse .navbar-nav .open .dropdown-menu>.disabled>a:focus{color:#444;background-color:transparent}}
+.navbar-inverse .navbar-link{color:#999}.navbar-inverse .navbar-link:hover{color:#fff}
+.breadcrumb{padding:8px 15px;margin-bottom:18px;list-style:none;background-color:#f5f5f5;border-radius:4px}.breadcrumb>li{display:inline-block}.breadcrumb>li+li:before{content:"/\00a0";padding:0 5px;color:#5e5e5e}
+.breadcrumb>.active{color:#999}
+.pagination{display:inline-block;padding-left:0;margin:18px 0;border-radius:4px}.pagination>li{display:inline}.pagination>li>a,.pagination>li>span{position:relative;float:left;padding:6px 12px;line-height:1.428571429;text-decoration:none;color:#428bca;background-color:#fff;border:1px solid #ddd;margin-left:-1px}
+.pagination>li:first-child>a,.pagination>li:first-child>span{margin-left:0;border-bottom-left-radius:4px;border-top-left-radius:4px}
+.pagination>li:last-child>a,.pagination>li:last-child>span{border-bottom-right-radius:4px;border-top-right-radius:4px}
+.pagination>li>a:hover,.pagination>li>span:hover,.pagination>li>a:focus,.pagination>li>span:focus{color:#2a6496;background-color:#eee;border-color:#ddd}
+.pagination>.active>a,.pagination>.active>span,.pagination>.active>a:hover,.pagination>.active>span:hover,.pagination>.active>a:focus,.pagination>.active>span:focus{z-index:2;color:#fff;background-color:#428bca;border-color:#428bca;cursor:default}
+.pagination>.disabled>span,.pagination>.disabled>span:hover,.pagination>.disabled>span:focus,.pagination>.disabled>a,.pagination>.disabled>a:hover,.pagination>.disabled>a:focus{color:#999;background-color:#fff;border-color:#ddd;cursor:not-allowed}
+.pagination-lg>li>a,.pagination-lg>li>span{padding:10px 16px;font-size:17px}
+.pagination-lg>li:first-child>a,.pagination-lg>li:first-child>span{border-bottom-left-radius:6px;border-top-left-radius:6px}
+.pagination-lg>li:last-child>a,.pagination-lg>li:last-child>span{border-bottom-right-radius:6px;border-top-right-radius:6px}
+.pagination-sm>li>a,.pagination-sm>li>span{padding:5px 10px;font-size:12px}
+.pagination-sm>li:first-child>a,.pagination-sm>li:first-child>span{border-bottom-left-radius:3px;border-top-left-radius:3px}
+.pagination-sm>li:last-child>a,.pagination-sm>li:last-child>span{border-bottom-right-radius:3px;border-top-right-radius:3px}
+.pager{padding-left:0;margin:18px 0;list-style:none;text-align:center}.pager li{display:inline}.pager li>a,.pager li>span{display:inline-block;padding:5px 14px;background-color:#fff;border:1px solid #ddd;border-radius:15px}
+.pager li>a:hover,.pager li>a:focus{text-decoration:none;background-color:#eee}
+.pager .next>a,.pager .next>span{float:right}
+.pager .previous>a,.pager .previous>span{float:left}
+.pager .disabled>a,.pager .disabled>a:hover,.pager .disabled>a:focus,.pager .disabled>span{color:#999;background-color:#fff;cursor:not-allowed}
+.label{display:inline;padding:.2em .6em .3em;font-size:75%;font-weight:bold;line-height:1;color:#fff;text-align:center;white-space:nowrap;vertical-align:baseline;border-radius:.25em}.label[href]:hover,.label[href]:focus{color:#fff;text-decoration:none;cursor:pointer}
+.label:empty{display:none}
+.btn .label{position:relative;top:-1px}
+.label-default{background-color:#999}.label-default[href]:hover,.label-default[href]:focus{background-color:#808080}
+.label-primary{background-color:#428bca}.label-primary[href]:hover,.label-primary[href]:focus{background-color:#3071a9}
+.label-success{background-color:#5cb85c}.label-success[href]:hover,.label-success[href]:focus{background-color:#449d44}
+.label-info{background-color:#5bc0de}.label-info[href]:hover,.label-info[href]:focus{background-color:#31b0d5}
+.label-warning{background-color:#f0ad4e}.label-warning[href]:hover,.label-warning[href]:focus{background-color:#ec971f}
+.label-danger{background-color:#d9534f}.label-danger[href]:hover,.label-danger[href]:focus{background-color:#c9302c}
+.badge{display:inline-block;min-width:10px;padding:3px 7px;font-size:12px;font-weight:bold;color:#fff;line-height:1;vertical-align:baseline;white-space:nowrap;text-align:center;background-color:#999;border-radius:10px}.badge:empty{display:none}
+.btn .badge{position:relative;top:-1px}
+.btn-xs .badge{top:0;padding:1px 5px}
+a.badge:hover,a.badge:focus{color:#fff;text-decoration:none;cursor:pointer}
+a.list-group-item.active>.badge,.nav-pills>.active>a>.badge{color:#428bca;background-color:#fff}
+.nav-pills>li>a>.badge{margin-left:3px}
+.jumbotron{padding:30px;margin-bottom:30px;color:inherit;background-color:#eee}.jumbotron h1,.jumbotron .h1{color:inherit}
+.jumbotron p{margin-bottom:15px;font-size:20px;font-weight:200}
+.container .jumbotron{border-radius:6px}
+.jumbotron .container{max-width:100%}
+@media screen and (min-width:768px){.jumbotron{padding-top:48px;padding-bottom:48px}.container .jumbotron{padding-left:60px;padding-right:60px} .jumbotron h1,.jumbotron .h1{font-size:58.5px}}
+.thumbnail{display:block;padding:4px;margin-bottom:18px;line-height:1.428571429;background-color:#fff;border:1px solid #ddd;border-radius:4px;-webkit-transition:all .2s ease-in-out;transition:all .2s ease-in-out}.thumbnail>img,.thumbnail a>img{margin-left:auto;margin-right:auto}
+a.thumbnail:hover,a.thumbnail:focus,a.thumbnail.active{border-color:#428bca}
+.thumbnail .caption{padding:9px;color:#000}
+.alert{padding:15px;margin-bottom:18px;border:1px solid transparent;border-radius:4px}.alert h4{margin-top:0;color:inherit}
+.alert .alert-link{font-weight:bold}
+.alert>p,.alert>ul{margin-bottom:0}
+.alert>p+p{margin-top:5px}
+.alert-dismissable{padding-right:35px}.alert-dismissable .close{position:relative;top:-2px;right:-21px;color:inherit}
+.alert-success{background-color:#dff0d8;border-color:#d6e9c6;color:#3c763d}.alert-success hr{border-top-color:#c9e2b3}
+.alert-success .alert-link{color:#2b542c}
+.alert-info{background-color:#d9edf7;border-color:#bce8f1;color:#31708f}.alert-info hr{border-top-color:#a6e1ec}
+.alert-info .alert-link{color:#245269}
+.alert-warning{background-color:#fcf8e3;border-color:#faebcc;color:#8a6d3b}.alert-warning hr{border-top-color:#f7e1b5}
+.alert-warning .alert-link{color:#66512c}
+.alert-danger{background-color:#f2dede;border-color:#ebccd1;color:#a94442}.alert-danger hr{border-top-color:#e4b9c0}
+.alert-danger .alert-link{color:#843534}
+@-webkit-keyframes progress-bar-stripes{from{background-position:40px 0} to{background-position:0 0}}@keyframes progress-bar-stripes{from{background-position:40px 0} to{background-position:0 0}}.progress{overflow:hidden;height:18px;margin-bottom:18px;background-color:#f5f5f5;border-radius:4px;-webkit-box-shadow:inset 0 1px 2px rgba(0,0,0,0.1);box-shadow:inset 0 1px 2px rgba(0,0,0,0.1)}
+.progress-bar{float:left;width:0;height:100%;font-size:12px;line-height:18px;color:#fff;text-align:center;background-color:#428bca;-webkit-box-shadow:inset 0 -1px 0 rgba(0,0,0,0.15);box-shadow:inset 0 -1px 0 rgba(0,0,0,0.15);-webkit-transition:width .6s ease;transition:width .6s ease}
+.progress-striped .progress-bar{background-image:-webkit-linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent);background-image:linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent);background-size:40px 40px}
+.progress.active .progress-bar{-webkit-animation:progress-bar-stripes 2s linear infinite;animation:progress-bar-stripes 2s linear infinite}
+.progress-bar-success{background-color:#5cb85c}.progress-striped .progress-bar-success{background-image:-webkit-linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent);background-image:linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent)}
+.progress-bar-info{background-color:#5bc0de}.progress-striped .progress-bar-info{background-image:-webkit-linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent);background-image:linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent)}
+.progress-bar-warning{background-color:#f0ad4e}.progress-striped .progress-bar-warning{background-image:-webkit-linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent);background-image:linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent)}
+.progress-bar-danger{background-color:#d9534f}.progress-striped .progress-bar-danger{background-image:-webkit-linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent);background-image:linear-gradient(45deg, rgba(255,255,255,0.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0.15) 75%, transparent 75%, transparent)}
+.media,.media-body{overflow:hidden;zoom:1}
+.media,.media .media{margin-top:15px}
+.media:first-child{margin-top:0}
+.media-object{display:block}
+.media-heading{margin:0 0 5px}
+.media>.pull-left{margin-right:10px}
+.media>.pull-right{margin-left:10px}
+.media-list{padding-left:0;list-style:none}
+.list-group{margin-bottom:20px;padding-left:0}
+.list-group-item{position:relative;display:block;padding:10px 15px;margin-bottom:-1px;background-color:#fff;border:1px solid #ddd}.list-group-item:first-child{border-top-right-radius:4px;border-top-left-radius:4px}
+.list-group-item:last-child{margin-bottom:0;border-bottom-right-radius:4px;border-bottom-left-radius:4px}
+.list-group-item>.badge{float:right}
+.list-group-item>.badge+.badge{margin-right:5px}
+a.list-group-item{color:#555}a.list-group-item .list-group-item-heading{color:#333}
+a.list-group-item:hover,a.list-group-item:focus{text-decoration:none;background-color:#f5f5f5}
+a.list-group-item.active,a.list-group-item.active:hover,a.list-group-item.active:focus{z-index:2;color:#fff;background-color:#428bca;border-color:#428bca}a.list-group-item.active .list-group-item-heading,a.list-group-item.active:hover .list-group-item-heading,a.list-group-item.active:focus .list-group-item-heading{color:inherit}
+a.list-group-item.active .list-group-item-text,a.list-group-item.active:hover .list-group-item-text,a.list-group-item.active:focus .list-group-item-text{color:#e1edf7}
+.list-group-item-success{color:#3c763d;background-color:#dff0d8}a.list-group-item-success{color:#3c763d}a.list-group-item-success .list-group-item-heading{color:inherit}
+a.list-group-item-success:hover,a.list-group-item-success:focus{color:#3c763d;background-color:#d0e9c6}
+a.list-group-item-success.active,a.list-group-item-success.active:hover,a.list-group-item-success.active:focus{color:#fff;background-color:#3c763d;border-color:#3c763d}
+.list-group-item-info{color:#31708f;background-color:#d9edf7}a.list-group-item-info{color:#31708f}a.list-group-item-info .list-group-item-heading{color:inherit}
+a.list-group-item-info:hover,a.list-group-item-info:focus{color:#31708f;background-color:#c4e3f3}
+a.list-group-item-info.active,a.list-group-item-info.active:hover,a.list-group-item-info.active:focus{color:#fff;background-color:#31708f;border-color:#31708f}
+.list-group-item-warning{color:#8a6d3b;background-color:#fcf8e3}a.list-group-item-warning{color:#8a6d3b}a.list-group-item-warning .list-group-item-heading{color:inherit}
+a.list-group-item-warning:hover,a.list-group-item-warning:focus{color:#8a6d3b;background-color:#faf2cc}
+a.list-group-item-warning.active,a.list-group-item-warning.active:hover,a.list-group-item-warning.active:focus{color:#fff;background-color:#8a6d3b;border-color:#8a6d3b}
+.list-group-item-danger{color:#a94442;background-color:#f2dede}a.list-group-item-danger{color:#a94442}a.list-group-item-danger .list-group-item-heading{color:inherit}
+a.list-group-item-danger:hover,a.list-group-item-danger:focus{color:#a94442;background-color:#ebcccc}
+a.list-group-item-danger.active,a.list-group-item-danger.active:hover,a.list-group-item-danger.active:focus{color:#fff;background-color:#a94442;border-color:#a94442}
+.list-group-item-heading{margin-top:0;margin-bottom:5px}
+.list-group-item-text{margin-bottom:0;line-height:1.3}
+.panel{margin-bottom:18px;background-color:#fff;border:1px solid transparent;border-radius:4px;-webkit-box-shadow:0 1px 1px rgba(0,0,0,0.05);box-shadow:0 1px 1px rgba(0,0,0,0.05)}
+.panel-body{padding:15px}
+.panel-heading{padding:10px 15px;border-bottom:1px solid transparent;border-top-right-radius:3px;border-top-left-radius:3px}.panel-heading>.dropdown .dropdown-toggle{color:inherit}
+.panel-title{margin-top:0;margin-bottom:0;font-size:15px;color:inherit}.panel-title>a{color:inherit}
+.panel-footer{padding:10px 15px;background-color:#f5f5f5;border-top:1px solid #ddd;border-bottom-right-radius:3px;border-bottom-left-radius:3px}
+.panel>.list-group{margin-bottom:0}.panel>.list-group .list-group-item{border-width:1px 0;border-radius:0}
+.panel>.list-group:first-child .list-group-item:first-child{border-top:0;border-top-right-radius:3px;border-top-left-radius:3px}
+.panel>.list-group:last-child .list-group-item:last-child{border-bottom:0;border-bottom-right-radius:3px;border-bottom-left-radius:3px}
+.panel-heading+.list-group .list-group-item:first-child{border-top-width:0}
+.panel>.table,.panel>.table-responsive>.table{margin-bottom:0}
+.panel>.table:first-child,.panel>.table-responsive:first-child>.table:first-child{border-top-right-radius:3px;border-top-left-radius:3px}.panel>.table:first-child>thead:first-child>tr:first-child td:first-child,.panel>.table-responsive:first-child>.table:first-child>thead:first-child>tr:first-child td:first-child,.panel>.table:first-child>tbody:first-child>tr:first-child td:first-child,.panel>.table-responsive:first-child>.table:first-child>tbody:first-child>tr:first-child td:first-child,.panel>.table:first-child>thead:first-child>tr:first-child th:first-child,.panel>.table-responsive:first-child>.table:first-child>thead:first-child>tr:first-child th:first-child,.panel>.table:first-child>tbody:first-child>tr:first-child th:first-child,.panel>.table-responsive:first-child>.table:first-child>tbody:first-child>tr:first-child th:first-child{border-top-left-radius:3px}
+.panel>.table:first-child>thead:first-child>tr:first-child td:last-child,.panel>.table-responsive:first-child>.table:first-child>thead:first-child>tr:first-child td:last-child,.panel>.table:first-child>tbody:first-child>tr:first-child td:last-child,.panel>.table-responsive:first-child>.table:first-child>tbody:first-child>tr:first-child td:last-child,.panel>.table:first-child>thead:first-child>tr:first-child th:last-child,.panel>.table-responsive:first-child>.table:first-child>thead:first-child>tr:first-child th:last-child,.panel>.table:first-child>tbody:first-child>tr:first-child th:last-child,.panel>.table-responsive:first-child>.table:first-child>tbody:first-child>tr:first-child th:last-child{border-top-right-radius:3px}
+.panel>.table:last-child,.panel>.table-responsive:last-child>.table:last-child{border-bottom-right-radius:3px;border-bottom-left-radius:3px}.panel>.table:last-child>tbody:last-child>tr:last-child td:first-child,.panel>.table-responsive:last-child>.table:last-child>tbody:last-child>tr:last-child td:first-child,.panel>.table:last-child>tfoot:last-child>tr:last-child td:first-child,.panel>.table-responsive:last-child>.table:last-child>tfoot:last-child>tr:last-child td:first-child,.panel>.table:last-child>tbody:last-child>tr:last-child th:first-child,.panel>.table-responsive:last-child>.table:last-child>tbody:last-child>tr:last-child th:first-child,.panel>.table:last-child>tfoot:last-child>tr:last-child th:first-child,.panel>.table-responsive:last-child>.table:last-child>tfoot:last-child>tr:last-child th:first-child{border-bottom-left-radius:3px}
+.panel>.table:last-child>tbody:last-child>tr:last-child td:last-child,.panel>.table-responsive:last-child>.table:last-child>tbody:last-child>tr:last-child td:last-child,.panel>.table:last-child>tfoot:last-child>tr:last-child td:last-child,.panel>.table-responsive:last-child>.table:last-child>tfoot:last-child>tr:last-child td:last-child,.panel>.table:last-child>tbody:last-child>tr:last-child th:last-child,.panel>.table-responsive:last-child>.table:last-child>tbody:last-child>tr:last-child th:last-child,.panel>.table:last-child>tfoot:last-child>tr:last-child th:last-child,.panel>.table-responsive:last-child>.table:last-child>tfoot:last-child>tr:last-child th:last-child{border-bottom-right-radius:3px}
+.panel>.panel-body+.table,.panel>.panel-body+.table-responsive{border-top:1px solid #ddd}
+.panel>.table>tbody:first-child>tr:first-child th,.panel>.table>tbody:first-child>tr:first-child td{border-top:0}
+.panel>.table-bordered,.panel>.table-responsive>.table-bordered{border:0}.panel>.table-bordered>thead>tr>th:first-child,.panel>.table-responsive>.table-bordered>thead>tr>th:first-child,.panel>.table-bordered>tbody>tr>th:first-child,.panel>.table-responsive>.table-bordered>tbody>tr>th:first-child,.panel>.table-bordered>tfoot>tr>th:first-child,.panel>.table-responsive>.table-bordered>tfoot>tr>th:first-child,.panel>.table-bordered>thead>tr>td:first-child,.panel>.table-responsive>.table-bordered>thead>tr>td:first-child,.panel>.table-bordered>tbody>tr>td:first-child,.panel>.table-responsive>.table-bordered>tbody>tr>td:first-child,.panel>.table-bordered>tfoot>tr>td:first-child,.panel>.table-responsive>.table-bordered>tfoot>tr>td:first-child{border-left:0}
+.panel>.table-bordered>thead>tr>th:last-child,.panel>.table-responsive>.table-bordered>thead>tr>th:last-child,.panel>.table-bordered>tbody>tr>th:last-child,.panel>.table-responsive>.table-bordered>tbody>tr>th:last-child,.panel>.table-bordered>tfoot>tr>th:last-child,.panel>.table-responsive>.table-bordered>tfoot>tr>th:last-child,.panel>.table-bordered>thead>tr>td:last-child,.panel>.table-responsive>.table-bordered>thead>tr>td:last-child,.panel>.table-bordered>tbody>tr>td:last-child,.panel>.table-responsive>.table-bordered>tbody>tr>td:last-child,.panel>.table-bordered>tfoot>tr>td:last-child,.panel>.table-responsive>.table-bordered>tfoot>tr>td:last-child{border-right:0}
+.panel>.table-bordered>thead>tr:first-child>td,.panel>.table-responsive>.table-bordered>thead>tr:first-child>td,.panel>.table-bordered>tbody>tr:first-child>td,.panel>.table-responsive>.table-bordered>tbody>tr:first-child>td,.panel>.table-bordered>thead>tr:first-child>th,.panel>.table-responsive>.table-bordered>thead>tr:first-child>th,.panel>.table-bordered>tbody>tr:first-child>th,.panel>.table-responsive>.table-bordered>tbody>tr:first-child>th{border-bottom:0}
+.panel>.table-bordered>tbody>tr:last-child>td,.panel>.table-responsive>.table-bordered>tbody>tr:last-child>td,.panel>.table-bordered>tfoot>tr:last-child>td,.panel>.table-responsive>.table-bordered>tfoot>tr:last-child>td,.panel>.table-bordered>tbody>tr:last-child>th,.panel>.table-responsive>.table-bordered>tbody>tr:last-child>th,.panel>.table-bordered>tfoot>tr:last-child>th,.panel>.table-responsive>.table-bordered>tfoot>tr:last-child>th{border-bottom:0}
+.panel>.table-responsive{border:0;margin-bottom:0}
+.panel-group{margin-bottom:18px}.panel-group .panel{margin-bottom:0;border-radius:4px;overflow:hidden}.panel-group .panel+.panel{margin-top:5px}
+.panel-group .panel-heading{border-bottom:0}.panel-group .panel-heading+.panel-collapse .panel-body{border-top:1px solid #ddd}
+.panel-group .panel-footer{border-top:0}.panel-group .panel-footer+.panel-collapse .panel-body{border-bottom:1px solid #ddd}
+.panel-default{border-color:#ddd}.panel-default>.panel-heading{color:#333;background-color:#f5f5f5;border-color:#ddd}.panel-default>.panel-heading+.panel-collapse .panel-body{border-top-color:#ddd}
+.panel-default>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#ddd}
+.panel-primary{border-color:#428bca}.panel-primary>.panel-heading{color:#fff;background-color:#428bca;border-color:#428bca}.panel-primary>.panel-heading+.panel-collapse .panel-body{border-top-color:#428bca}
+.panel-primary>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#428bca}
+.panel-success{border-color:#d6e9c6}.panel-success>.panel-heading{color:#3c763d;background-color:#dff0d8;border-color:#d6e9c6}.panel-success>.panel-heading+.panel-collapse .panel-body{border-top-color:#d6e9c6}
+.panel-success>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#d6e9c6}
+.panel-info{border-color:#bce8f1}.panel-info>.panel-heading{color:#31708f;background-color:#d9edf7;border-color:#bce8f1}.panel-info>.panel-heading+.panel-collapse .panel-body{border-top-color:#bce8f1}
+.panel-info>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#bce8f1}
+.panel-warning{border-color:#faebcc}.panel-warning>.panel-heading{color:#8a6d3b;background-color:#fcf8e3;border-color:#faebcc}.panel-warning>.panel-heading+.panel-collapse .panel-body{border-top-color:#faebcc}
+.panel-warning>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#faebcc}
+.panel-danger{border-color:#ebccd1}.panel-danger>.panel-heading{color:#a94442;background-color:#f2dede;border-color:#ebccd1}.panel-danger>.panel-heading+.panel-collapse .panel-body{border-top-color:#ebccd1}
+.panel-danger>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#ebccd1}
+.well{min-height:20px;padding:19px;margin-bottom:20px;background-color:#f5f5f5;border:1px solid #e3e3e3;border-radius:4px;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.05);box-shadow:inset 0 1px 1px rgba(0,0,0,0.05)}.well blockquote{border-color:#ddd;border-color:rgba(0,0,0,0.15)}
+.well-lg{padding:24px;border-radius:6px}
+.well-sm{padding:9px;border-radius:3px}
+.close{float:right;font-size:19.5px;font-weight:bold;line-height:1;color:#000;text-shadow:0 1px 0 #fff;opacity:.2;filter:alpha(opacity=20)}.close:hover,.close:focus{color:#000;text-decoration:none;cursor:pointer;opacity:.5;filter:alpha(opacity=50)}
+button.close{padding:0;cursor:pointer;background:transparent;border:0;-webkit-appearance:none}
+.modal-open{overflow:hidden}
+.modal{display:none;overflow:auto;overflow-y:scroll;position:fixed;top:0;right:0;bottom:0;left:0;z-index:1050;-webkit-overflow-scrolling:touch;outline:0}.modal.fade .modal-dialog{-webkit-transform:translate(0, -25%);-ms-transform:translate(0, -25%);transform:translate(0, -25%);-webkit-transition:-webkit-transform 0.3s ease-out;-moz-transition:-moz-transform 0.3s ease-out;-o-transition:-o-transform 0.3s ease-out;transition:transform 0.3s ease-out}
+.modal.in .modal-dialog{-webkit-transform:translate(0, 0);-ms-transform:translate(0, 0);transform:translate(0, 0)}
+.modal-dialog{position:relative;width:auto;margin:10px}
+.modal-content{position:relative;background-color:#fff;border:1px solid #999;border:1px solid rgba(0,0,0,0.2);border-radius:6px;-webkit-box-shadow:0 3px 9px rgba(0,0,0,0.5);box-shadow:0 3px 9px rgba(0,0,0,0.5);background-clip:padding-box;outline:none}
+.modal-backdrop{position:fixed;top:0;right:0;bottom:0;left:0;z-index:1040;background-color:#000}.modal-backdrop.fade{opacity:0;filter:alpha(opacity=0)}
+.modal-backdrop.in{opacity:.5;filter:alpha(opacity=50)}
+.modal-header{padding:15px;border-bottom:1px solid #e5e5e5;min-height:16.428571429px}
+.modal-header .close{margin-top:-2px}
+.modal-title{margin:0;line-height:1.428571429}
+.modal-body{position:relative;padding:15px}
+.modal-footer{margin-top:15px;padding:14px 15px 15px;text-align:right;border-top:1px solid #e5e5e5}.modal-footer .btn+.btn{margin-left:5px;margin-bottom:0}
+.modal-footer .btn-group .btn+.btn{margin-left:-1px}
+.modal-footer .btn-block+.btn-block{margin-left:0}
+@media (min-width:768px){.modal-dialog{width:600px;margin:30px auto} .modal-content{-webkit-box-shadow:0 5px 15px rgba(0,0,0,0.5);box-shadow:0 5px 15px rgba(0,0,0,0.5)} .modal-sm{width:300px}}@media (min-width:992px){.modal-lg{width:900px}}.tooltip{position:absolute;z-index:1030;display:block;visibility:visible;font-size:12px;line-height:1.4;opacity:0;filter:alpha(opacity=0)}.tooltip.in{opacity:.9;filter:alpha(opacity=90)}
+.tooltip.top{margin-top:-3px;padding:5px 0}
+.tooltip.right{margin-left:3px;padding:0 5px}
+.tooltip.bottom{margin-top:3px;padding:5px 0}
+.tooltip.left{margin-left:-3px;padding:0 5px}
+.tooltip-inner{max-width:200px;padding:3px 8px;color:#fff;text-align:center;text-decoration:none;background-color:#000;border-radius:4px}
+.tooltip-arrow{position:absolute;width:0;height:0;border-color:transparent;border-style:solid}
+.tooltip.top .tooltip-arrow{bottom:0;left:50%;margin-left:-5px;border-width:5px 5px 0;border-top-color:#000}
+.tooltip.top-left .tooltip-arrow{bottom:0;left:5px;border-width:5px 5px 0;border-top-color:#000}
+.tooltip.top-right .tooltip-arrow{bottom:0;right:5px;border-width:5px 5px 0;border-top-color:#000}
+.tooltip.right .tooltip-arrow{top:50%;left:0;margin-top:-5px;border-width:5px 5px 5px 0;border-right-color:#000}
+.tooltip.left .tooltip-arrow{top:50%;right:0;margin-top:-5px;border-width:5px 0 5px 5px;border-left-color:#000}
+.tooltip.bottom .tooltip-arrow{top:0;left:50%;margin-left:-5px;border-width:0 5px 5px;border-bottom-color:#000}
+.tooltip.bottom-left .tooltip-arrow{top:0;left:5px;border-width:0 5px 5px;border-bottom-color:#000}
+.tooltip.bottom-right .tooltip-arrow{top:0;right:5px;border-width:0 5px 5px;border-bottom-color:#000}
+.popover{position:absolute;top:0;left:0;z-index:1010;display:none;max-width:276px;padding:1px;text-align:left;background-color:#fff;background-clip:padding-box;border:1px solid #ccc;border:1px solid rgba(0,0,0,0.2);border-radius:6px;-webkit-box-shadow:0 5px 10px rgba(0,0,0,0.2);box-shadow:0 5px 10px rgba(0,0,0,0.2);white-space:normal}.popover.top{margin-top:-10px}
+.popover.right{margin-left:10px}
+.popover.bottom{margin-top:10px}
+.popover.left{margin-left:-10px}
+.popover-title{margin:0;padding:8px 14px;font-size:13px;font-weight:normal;line-height:18px;background-color:#f7f7f7;border-bottom:1px solid #ebebeb;border-radius:5px 5px 0 0}
+.popover-content{padding:9px 14px}
+.popover>.arrow,.popover>.arrow:after{position:absolute;display:block;width:0;height:0;border-color:transparent;border-style:solid}
+.popover>.arrow{border-width:11px}
+.popover>.arrow:after{border-width:10px;content:""}
+.popover.top>.arrow{left:50%;margin-left:-11px;border-bottom-width:0;border-top-color:#999;border-top-color:rgba(0,0,0,0.25);bottom:-11px}.popover.top>.arrow:after{content:" ";bottom:1px;margin-left:-10px;border-bottom-width:0;border-top-color:#fff}
+.popover.right>.arrow{top:50%;left:-11px;margin-top:-11px;border-left-width:0;border-right-color:#999;border-right-color:rgba(0,0,0,0.25)}.popover.right>.arrow:after{content:" ";left:1px;bottom:-10px;border-left-width:0;border-right-color:#fff}
+.popover.bottom>.arrow{left:50%;margin-left:-11px;border-top-width:0;border-bottom-color:#999;border-bottom-color:rgba(0,0,0,0.25);top:-11px}.popover.bottom>.arrow:after{content:" ";top:1px;margin-left:-10px;border-top-width:0;border-bottom-color:#fff}
+.popover.left>.arrow{top:50%;right:-11px;margin-top:-11px;border-right-width:0;border-left-color:#999;border-left-color:rgba(0,0,0,0.25)}.popover.left>.arrow:after{content:" ";right:1px;border-right-width:0;border-left-color:#fff;bottom:-10px}
+.carousel{position:relative}
+.carousel-inner{position:relative;overflow:hidden;width:100%}.carousel-inner>.item{display:none;position:relative;-webkit-transition:.6s ease-in-out left;transition:.6s ease-in-out left}.carousel-inner>.item>img,.carousel-inner>.item>a>img{line-height:1}
+.carousel-inner>.active,.carousel-inner>.next,.carousel-inner>.prev{display:block}
+.carousel-inner>.active{left:0}
+.carousel-inner>.next,.carousel-inner>.prev{position:absolute;top:0;width:100%}
+.carousel-inner>.next{left:100%}
+.carousel-inner>.prev{left:-100%}
+.carousel-inner>.next.left,.carousel-inner>.prev.right{left:0}
+.carousel-inner>.active.left{left:-100%}
+.carousel-inner>.active.right{left:100%}
+.carousel-control{position:absolute;top:0;left:0;bottom:0;width:15%;opacity:.5;filter:alpha(opacity=50);font-size:20px;color:#fff;text-align:center;text-shadow:0 1px 2px rgba(0,0,0,0.6)}.carousel-control.left{background-image:-webkit-linear-gradient(left, color-stop(rgba(0,0,0,0.5) 0), color-stop(rgba(0,0,0,0.0001) 100%));background-image:linear-gradient(to right, rgba(0,0,0,0.5) 0, rgba(0,0,0,0.0001) 100%);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#80000000', endColorstr='#00000000', GradientType=1)}
+.carousel-control.right{left:auto;right:0;background-image:-webkit-linear-gradient(left, color-stop(rgba(0,0,0,0.0001) 0), color-stop(rgba(0,0,0,0.5) 100%));background-image:linear-gradient(to right, rgba(0,0,0,0.0001) 0, rgba(0,0,0,0.5) 100%);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#80000000', GradientType=1)}
+.carousel-control:hover,.carousel-control:focus{outline:none;color:#fff;text-decoration:none;opacity:.9;filter:alpha(opacity=90)}
+.carousel-control .icon-prev,.carousel-control .icon-next,.carousel-control .glyphicon-chevron-left,.carousel-control .glyphicon-chevron-right{position:absolute;top:50%;z-index:5;display:inline-block}
+.carousel-control .icon-prev,.carousel-control .glyphicon-chevron-left{left:50%}
+.carousel-control .icon-next,.carousel-control .glyphicon-chevron-right{right:50%}
+.carousel-control .icon-prev,.carousel-control .icon-next{width:20px;height:20px;margin-top:-10px;margin-left:-10px;font-family:serif}
+.carousel-control .icon-prev:before{content:'\2039'}
+.carousel-control .icon-next:before{content:'\203a'}
+.carousel-indicators{position:absolute;bottom:10px;left:50%;z-index:15;width:60%;margin-left:-30%;padding-left:0;list-style:none;text-align:center}.carousel-indicators li{display:inline-block;width:10px;height:10px;margin:1px;text-indent:-999px;border:1px solid #fff;border-radius:10px;cursor:pointer;background-color:#000 \9;background-color:rgba(0,0,0,0)}
+.carousel-indicators .active{margin:0;width:12px;height:12px;background-color:#fff}
+.carousel-caption{position:absolute;left:15%;right:15%;bottom:20px;z-index:10;padding-top:20px;padding-bottom:20px;color:#fff;text-align:center;text-shadow:0 1px 2px rgba(0,0,0,0.6)}.carousel-caption .btn{text-shadow:none}
+@media screen and (min-width:768px){.carousel-control .glyphicon-chevron-left,.carousel-control .glyphicon-chevron-right,.carousel-control .icon-prev,.carousel-control .icon-next{width:30px;height:30px;margin-top:-15px;margin-left:-15px;font-size:30px} .carousel-caption{left:20%;right:20%;padding-bottom:30px} .carousel-indicators{bottom:20px}}.clearfix:before,.clearfix:after,.container:before,.container:after,.container-fluid:before,.container-fluid:after,.row:before,.row:after,.form-horizontal .form-group:before,.form-horizontal .form-group:after,.btn-toolbar:before,.btn-toolbar:after,.btn-group-vertical>.btn-group:before,.btn-group-vertical>.btn-group:after,.nav:before,.nav:after,.navbar:before,.navbar:after,.navbar-header:before,.navbar-header:after,.navbar-collapse:before,.navbar-collapse:after,.pager:before,.pager:after,.panel-body:before,.panel-body:after,.modal-footer:before,.modal-footer:after{content:" ";display:table}
+.clearfix:after,.container:after,.container-fluid:after,.row:after,.form-horizontal .form-group:after,.btn-toolbar:after,.btn-group-vertical>.btn-group:after,.nav:after,.navbar:after,.navbar-header:after,.navbar-collapse:after,.pager:after,.panel-body:after,.modal-footer:after{clear:both}
+.center-block{display:block;margin-left:auto;margin-right:auto}
+.pull-right{float:right !important}
+.pull-left{float:left !important}
+.hide{display:none !important}
+.show{display:block !important}
+.invisible{visibility:hidden}
+.text-hide{font:0/0 a;color:transparent;text-shadow:none;background-color:transparent;border:0}
+.hidden{display:none !important;visibility:hidden !important}
+.affix{position:fixed}
+@-ms-viewport{width:device-width}.visible-xs,.visible-sm,.visible-md,.visible-lg{display:none !important}
+@media (max-width:767px){.visible-xs{display:block !important}table.visible-xs{display:table} tr.visible-xs{display:table-row !important} th.visible-xs,td.visible-xs{display:table-cell !important}}
+@media (min-width:768px) and (max-width:991px){.visible-sm{display:block !important}table.visible-sm{display:table} tr.visible-sm{display:table-row !important} th.visible-sm,td.visible-sm{display:table-cell !important}}
+@media (min-width:992px) and (max-width:1199px){.visible-md{display:block !important}table.visible-md{display:table} tr.visible-md{display:table-row !important} th.visible-md,td.visible-md{display:table-cell !important}}
+@media (min-width:1200px){.visible-lg{display:block !important}table.visible-lg{display:table} tr.visible-lg{display:table-row !important} th.visible-lg,td.visible-lg{display:table-cell !important}}
+@media (max-width:767px){.hidden-xs{display:none !important}}
+@media (min-width:768px) and (max-width:991px){.hidden-sm{display:none !important}}
+@media (min-width:992px) and (max-width:1199px){.hidden-md{display:none !important}}
+@media (min-width:1200px){.hidden-lg{display:none !important}}
+.visible-print{display:none !important}@media print{.visible-print{display:block !important}table.visible-print{display:table} tr.visible-print{display:table-row !important} th.visible-print,td.visible-print{display:table-cell !important}}
+@media print{.hidden-print{display:none !important}}
+@font-face{font-family:'FontAwesome';src:url('../components/font-awesome/fonts/fontawesome-webfont.eot?v=4.1.0');src:url('../components/font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=4.1.0') format('embedded-opentype'),url('../components/font-awesome/fonts/fontawesome-webfont.woff?v=4.1.0') format('woff'),url('../components/font-awesome/fonts/fontawesome-webfont.ttf?v=4.1.0') format('truetype'),url('../components/font-awesome/fonts/fontawesome-webfont.svg?v=4.1.0#fontawesomeregular') format('svg');font-weight:normal;font-style:normal}.fa{display:inline-block;font-family:FontAwesome;font-style:normal;font-weight:normal;line-height:1;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
+.fa-lg{font-size:1.3333333333333333em;line-height:.75em;vertical-align:-15%}
+.fa-2x{font-size:2em}
+.fa-3x{font-size:3em}
+.fa-4x{font-size:4em}
+.fa-5x{font-size:5em}
+.fa-fw{width:1.2857142857142858em;text-align:center}
+.fa-ul{padding-left:0;margin-left:2.142857142857143em;list-style-type:none}.fa-ul>li{position:relative}
+.fa-li{position:absolute;left:-2.142857142857143em;width:2.142857142857143em;top:.14285714285714285em;text-align:center}.fa-li.fa-lg{left:-1.8571428571428572em}
+.fa-border{padding:.2em .25em .15em;border:solid .08em #eee;border-radius:.1em}
+.pull-right{float:right}
+.pull-left{float:left}
+.fa.pull-left{margin-right:.3em}
+.fa.pull-right{margin-left:.3em}
+.fa-spin{-webkit-animation:spin 2s infinite linear;-moz-animation:spin 2s infinite linear;-o-animation:spin 2s infinite linear;animation:spin 2s infinite linear}
+@-moz-keyframes spin{0%{-moz-transform:rotate(0deg)} 100%{-moz-transform:rotate(359deg)}}@-webkit-keyframes spin{0%{-webkit-transform:rotate(0deg)} 100%{-webkit-transform:rotate(359deg)}}@-o-keyframes spin{0%{-o-transform:rotate(0deg)} 100%{-o-transform:rotate(359deg)}}@keyframes spin{0%{-webkit-transform:rotate(0deg);transform:rotate(0deg)} 100%{-webkit-transform:rotate(359deg);transform:rotate(359deg)}}.fa-rotate-90{filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=1);-webkit-transform:rotate(90deg);-moz-transform:rotate(90deg);-ms-transform:rotate(90deg);-o-transform:rotate(90deg);transform:rotate(90deg)}
+.fa-rotate-180{filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=2);-webkit-transform:rotate(180deg);-moz-transform:rotate(180deg);-ms-transform:rotate(180deg);-o-transform:rotate(180deg);transform:rotate(180deg)}
+.fa-rotate-270{filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=3);-webkit-transform:rotate(270deg);-moz-transform:rotate(270deg);-ms-transform:rotate(270deg);-o-transform:rotate(270deg);transform:rotate(270deg)}
+.fa-flip-horizontal{filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1);-webkit-transform:scale(-1, 1);-moz-transform:scale(-1, 1);-ms-transform:scale(-1, 1);-o-transform:scale(-1, 1);transform:scale(-1, 1)}
+.fa-flip-vertical{filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1);-webkit-transform:scale(1, -1);-moz-transform:scale(1, -1);-ms-transform:scale(1, -1);-o-transform:scale(1, -1);transform:scale(1, -1)}
+.fa-stack{position:relative;display:inline-block;width:2em;height:2em;line-height:2em;vertical-align:middle}
+.fa-stack-1x,.fa-stack-2x{position:absolute;left:0;width:100%;text-align:center}
+.fa-stack-1x{line-height:inherit}
+.fa-stack-2x{font-size:2em}
+.fa-inverse{color:#fff}
+.fa-glass:before{content:"\f000"}
+.fa-music:before{content:"\f001"}
+.fa-search:before{content:"\f002"}
+.fa-envelope-o:before{content:"\f003"}
+.fa-heart:before{content:"\f004"}
+.fa-star:before{content:"\f005"}
+.fa-star-o:before{content:"\f006"}
+.fa-user:before{content:"\f007"}
+.fa-film:before{content:"\f008"}
+.fa-th-large:before{content:"\f009"}
+.fa-th:before{content:"\f00a"}
+.fa-th-list:before{content:"\f00b"}
+.fa-check:before{content:"\f00c"}
+.fa-times:before{content:"\f00d"}
+.fa-search-plus:before{content:"\f00e"}
+.fa-search-minus:before{content:"\f010"}
+.fa-power-off:before{content:"\f011"}
+.fa-signal:before{content:"\f012"}
+.fa-gear:before,.fa-cog:before{content:"\f013"}
+.fa-trash-o:before{content:"\f014"}
+.fa-home:before{content:"\f015"}
+.fa-file-o:before{content:"\f016"}
+.fa-clock-o:before{content:"\f017"}
+.fa-road:before{content:"\f018"}
+.fa-download:before{content:"\f019"}
+.fa-arrow-circle-o-down:before{content:"\f01a"}
+.fa-arrow-circle-o-up:before{content:"\f01b"}
+.fa-inbox:before{content:"\f01c"}
+.fa-play-circle-o:before{content:"\f01d"}
+.fa-rotate-right:before,.fa-repeat:before{content:"\f01e"}
+.fa-refresh:before{content:"\f021"}
+.fa-list-alt:before{content:"\f022"}
+.fa-lock:before{content:"\f023"}
+.fa-flag:before{content:"\f024"}
+.fa-headphones:before{content:"\f025"}
+.fa-volume-off:before{content:"\f026"}
+.fa-volume-down:before{content:"\f027"}
+.fa-volume-up:before{content:"\f028"}
+.fa-qrcode:before{content:"\f029"}
+.fa-barcode:before{content:"\f02a"}
+.fa-tag:before{content:"\f02b"}
+.fa-tags:before{content:"\f02c"}
+.fa-book:before{content:"\f02d"}
+.fa-bookmark:before{content:"\f02e"}
+.fa-print:before{content:"\f02f"}
+.fa-camera:before{content:"\f030"}
+.fa-font:before{content:"\f031"}
+.fa-bold:before{content:"\f032"}
+.fa-italic:before{content:"\f033"}
+.fa-text-height:before{content:"\f034"}
+.fa-text-width:before{content:"\f035"}
+.fa-align-left:before{content:"\f036"}
+.fa-align-center:before{content:"\f037"}
+.fa-align-right:before{content:"\f038"}
+.fa-align-justify:before{content:"\f039"}
+.fa-list:before{content:"\f03a"}
+.fa-dedent:before,.fa-outdent:before{content:"\f03b"}
+.fa-indent:before{content:"\f03c"}
+.fa-video-camera:before{content:"\f03d"}
+.fa-photo:before,.fa-image:before,.fa-picture-o:before{content:"\f03e"}
+.fa-pencil:before{content:"\f040"}
+.fa-map-marker:before{content:"\f041"}
+.fa-adjust:before{content:"\f042"}
+.fa-tint:before{content:"\f043"}
+.fa-edit:before,.fa-pencil-square-o:before{content:"\f044"}
+.fa-share-square-o:before{content:"\f045"}
+.fa-check-square-o:before{content:"\f046"}
+.fa-arrows:before{content:"\f047"}
+.fa-step-backward:before{content:"\f048"}
+.fa-fast-backward:before{content:"\f049"}
+.fa-backward:before{content:"\f04a"}
+.fa-play:before{content:"\f04b"}
+.fa-pause:before{content:"\f04c"}
+.fa-stop:before{content:"\f04d"}
+.fa-forward:before{content:"\f04e"}
+.fa-fast-forward:before{content:"\f050"}
+.fa-step-forward:before{content:"\f051"}
+.fa-eject:before{content:"\f052"}
+.fa-chevron-left:before{content:"\f053"}
+.fa-chevron-right:before{content:"\f054"}
+.fa-plus-circle:before{content:"\f055"}
+.fa-minus-circle:before{content:"\f056"}
+.fa-times-circle:before{content:"\f057"}
+.fa-check-circle:before{content:"\f058"}
+.fa-question-circle:before{content:"\f059"}
+.fa-info-circle:before{content:"\f05a"}
+.fa-crosshairs:before{content:"\f05b"}
+.fa-times-circle-o:before{content:"\f05c"}
+.fa-check-circle-o:before{content:"\f05d"}
+.fa-ban:before{content:"\f05e"}
+.fa-arrow-left:before{content:"\f060"}
+.fa-arrow-right:before{content:"\f061"}
+.fa-arrow-up:before{content:"\f062"}
+.fa-arrow-down:before{content:"\f063"}
+.fa-mail-forward:before,.fa-share:before{content:"\f064"}
+.fa-expand:before{content:"\f065"}
+.fa-compress:before{content:"\f066"}
+.fa-plus:before{content:"\f067"}
+.fa-minus:before{content:"\f068"}
+.fa-asterisk:before{content:"\f069"}
+.fa-exclamation-circle:before{content:"\f06a"}
+.fa-gift:before{content:"\f06b"}
+.fa-leaf:before{content:"\f06c"}
+.fa-fire:before{content:"\f06d"}
+.fa-eye:before{content:"\f06e"}
+.fa-eye-slash:before{content:"\f070"}
+.fa-warning:before,.fa-exclamation-triangle:before{content:"\f071"}
+.fa-plane:before{content:"\f072"}
+.fa-calendar:before{content:"\f073"}
+.fa-random:before{content:"\f074"}
+.fa-comment:before{content:"\f075"}
+.fa-magnet:before{content:"\f076"}
+.fa-chevron-up:before{content:"\f077"}
+.fa-chevron-down:before{content:"\f078"}
+.fa-retweet:before{content:"\f079"}
+.fa-shopping-cart:before{content:"\f07a"}
+.fa-folder:before{content:"\f07b"}
+.fa-folder-open:before{content:"\f07c"}
+.fa-arrows-v:before{content:"\f07d"}
+.fa-arrows-h:before{content:"\f07e"}
+.fa-bar-chart-o:before{content:"\f080"}
+.fa-twitter-square:before{content:"\f081"}
+.fa-facebook-square:before{content:"\f082"}
+.fa-camera-retro:before{content:"\f083"}
+.fa-key:before{content:"\f084"}
+.fa-gears:before,.fa-cogs:before{content:"\f085"}
+.fa-comments:before{content:"\f086"}
+.fa-thumbs-o-up:before{content:"\f087"}
+.fa-thumbs-o-down:before{content:"\f088"}
+.fa-star-half:before{content:"\f089"}
+.fa-heart-o:before{content:"\f08a"}
+.fa-sign-out:before{content:"\f08b"}
+.fa-linkedin-square:before{content:"\f08c"}
+.fa-thumb-tack:before{content:"\f08d"}
+.fa-external-link:before{content:"\f08e"}
+.fa-sign-in:before{content:"\f090"}
+.fa-trophy:before{content:"\f091"}
+.fa-github-square:before{content:"\f092"}
+.fa-upload:before{content:"\f093"}
+.fa-lemon-o:before{content:"\f094"}
+.fa-phone:before{content:"\f095"}
+.fa-square-o:before{content:"\f096"}
+.fa-bookmark-o:before{content:"\f097"}
+.fa-phone-square:before{content:"\f098"}
+.fa-twitter:before{content:"\f099"}
+.fa-facebook:before{content:"\f09a"}
+.fa-github:before{content:"\f09b"}
+.fa-unlock:before{content:"\f09c"}
+.fa-credit-card:before{content:"\f09d"}
+.fa-rss:before{content:"\f09e"}
+.fa-hdd-o:before{content:"\f0a0"}
+.fa-bullhorn:before{content:"\f0a1"}
+.fa-bell:before{content:"\f0f3"}
+.fa-certificate:before{content:"\f0a3"}
+.fa-hand-o-right:before{content:"\f0a4"}
+.fa-hand-o-left:before{content:"\f0a5"}
+.fa-hand-o-up:before{content:"\f0a6"}
+.fa-hand-o-down:before{content:"\f0a7"}
+.fa-arrow-circle-left:before{content:"\f0a8"}
+.fa-arrow-circle-right:before{content:"\f0a9"}
+.fa-arrow-circle-up:before{content:"\f0aa"}
+.fa-arrow-circle-down:before{content:"\f0ab"}
+.fa-globe:before{content:"\f0ac"}
+.fa-wrench:before{content:"\f0ad"}
+.fa-tasks:before{content:"\f0ae"}
+.fa-filter:before{content:"\f0b0"}
+.fa-briefcase:before{content:"\f0b1"}
+.fa-arrows-alt:before{content:"\f0b2"}
+.fa-group:before,.fa-users:before{content:"\f0c0"}
+.fa-chain:before,.fa-link:before{content:"\f0c1"}
+.fa-cloud:before{content:"\f0c2"}
+.fa-flask:before{content:"\f0c3"}
+.fa-cut:before,.fa-scissors:before{content:"\f0c4"}
+.fa-copy:before,.fa-files-o:before{content:"\f0c5"}
+.fa-paperclip:before{content:"\f0c6"}
+.fa-save:before,.fa-floppy-o:before{content:"\f0c7"}
+.fa-square:before{content:"\f0c8"}
+.fa-navicon:before,.fa-reorder:before,.fa-bars:before{content:"\f0c9"}
+.fa-list-ul:before{content:"\f0ca"}
+.fa-list-ol:before{content:"\f0cb"}
+.fa-strikethrough:before{content:"\f0cc"}
+.fa-underline:before{content:"\f0cd"}
+.fa-table:before{content:"\f0ce"}
+.fa-magic:before{content:"\f0d0"}
+.fa-truck:before{content:"\f0d1"}
+.fa-pinterest:before{content:"\f0d2"}
+.fa-pinterest-square:before{content:"\f0d3"}
+.fa-google-plus-square:before{content:"\f0d4"}
+.fa-google-plus:before{content:"\f0d5"}
+.fa-money:before{content:"\f0d6"}
+.fa-caret-down:before{content:"\f0d7"}
+.fa-caret-up:before{content:"\f0d8"}
+.fa-caret-left:before{content:"\f0d9"}
+.fa-caret-right:before{content:"\f0da"}
+.fa-columns:before{content:"\f0db"}
+.fa-unsorted:before,.fa-sort:before{content:"\f0dc"}
+.fa-sort-down:before,.fa-sort-desc:before{content:"\f0dd"}
+.fa-sort-up:before,.fa-sort-asc:before{content:"\f0de"}
+.fa-envelope:before{content:"\f0e0"}
+.fa-linkedin:before{content:"\f0e1"}
+.fa-rotate-left:before,.fa-undo:before{content:"\f0e2"}
+.fa-legal:before,.fa-gavel:before{content:"\f0e3"}
+.fa-dashboard:before,.fa-tachometer:before{content:"\f0e4"}
+.fa-comment-o:before{content:"\f0e5"}
+.fa-comments-o:before{content:"\f0e6"}
+.fa-flash:before,.fa-bolt:before{content:"\f0e7"}
+.fa-sitemap:before{content:"\f0e8"}
+.fa-umbrella:before{content:"\f0e9"}
+.fa-paste:before,.fa-clipboard:before{content:"\f0ea"}
+.fa-lightbulb-o:before{content:"\f0eb"}
+.fa-exchange:before{content:"\f0ec"}
+.fa-cloud-download:before{content:"\f0ed"}
+.fa-cloud-upload:before{content:"\f0ee"}
+.fa-user-md:before{content:"\f0f0"}
+.fa-stethoscope:before{content:"\f0f1"}
+.fa-suitcase:before{content:"\f0f2"}
+.fa-bell-o:before{content:"\f0a2"}
+.fa-coffee:before{content:"\f0f4"}
+.fa-cutlery:before{content:"\f0f5"}
+.fa-file-text-o:before{content:"\f0f6"}
+.fa-building-o:before{content:"\f0f7"}
+.fa-hospital-o:before{content:"\f0f8"}
+.fa-ambulance:before{content:"\f0f9"}
+.fa-medkit:before{content:"\f0fa"}
+.fa-fighter-jet:before{content:"\f0fb"}
+.fa-beer:before{content:"\f0fc"}
+.fa-h-square:before{content:"\f0fd"}
+.fa-plus-square:before{content:"\f0fe"}
+.fa-angle-double-left:before{content:"\f100"}
+.fa-angle-double-right:before{content:"\f101"}
+.fa-angle-double-up:before{content:"\f102"}
+.fa-angle-double-down:before{content:"\f103"}
+.fa-angle-left:before{content:"\f104"}
+.fa-angle-right:before{content:"\f105"}
+.fa-angle-up:before{content:"\f106"}
+.fa-angle-down:before{content:"\f107"}
+.fa-desktop:before{content:"\f108"}
+.fa-laptop:before{content:"\f109"}
+.fa-tablet:before{content:"\f10a"}
+.fa-mobile-phone:before,.fa-mobile:before{content:"\f10b"}
+.fa-circle-o:before{content:"\f10c"}
+.fa-quote-left:before{content:"\f10d"}
+.fa-quote-right:before{content:"\f10e"}
+.fa-spinner:before{content:"\f110"}
+.fa-circle:before{content:"\f111"}
+.fa-mail-reply:before,.fa-reply:before{content:"\f112"}
+.fa-github-alt:before{content:"\f113"}
+.fa-folder-o:before{content:"\f114"}
+.fa-folder-open-o:before{content:"\f115"}
+.fa-smile-o:before{content:"\f118"}
+.fa-frown-o:before{content:"\f119"}
+.fa-meh-o:before{content:"\f11a"}
+.fa-gamepad:before{content:"\f11b"}
+.fa-keyboard-o:before{content:"\f11c"}
+.fa-flag-o:before{content:"\f11d"}
+.fa-flag-checkered:before{content:"\f11e"}
+.fa-terminal:before{content:"\f120"}
+.fa-code:before{content:"\f121"}
+.fa-mail-reply-all:before,.fa-reply-all:before{content:"\f122"}
+.fa-star-half-empty:before,.fa-star-half-full:before,.fa-star-half-o:before{content:"\f123"}
+.fa-location-arrow:before{content:"\f124"}
+.fa-crop:before{content:"\f125"}
+.fa-code-fork:before{content:"\f126"}
+.fa-unlink:before,.fa-chain-broken:before{content:"\f127"}
+.fa-question:before{content:"\f128"}
+.fa-info:before{content:"\f129"}
+.fa-exclamation:before{content:"\f12a"}
+.fa-superscript:before{content:"\f12b"}
+.fa-subscript:before{content:"\f12c"}
+.fa-eraser:before{content:"\f12d"}
+.fa-puzzle-piece:before{content:"\f12e"}
+.fa-microphone:before{content:"\f130"}
+.fa-microphone-slash:before{content:"\f131"}
+.fa-shield:before{content:"\f132"}
+.fa-calendar-o:before{content:"\f133"}
+.fa-fire-extinguisher:before{content:"\f134"}
+.fa-rocket:before{content:"\f135"}
+.fa-maxcdn:before{content:"\f136"}
+.fa-chevron-circle-left:before{content:"\f137"}
+.fa-chevron-circle-right:before{content:"\f138"}
+.fa-chevron-circle-up:before{content:"\f139"}
+.fa-chevron-circle-down:before{content:"\f13a"}
+.fa-html5:before{content:"\f13b"}
+.fa-css3:before{content:"\f13c"}
+.fa-anchor:before{content:"\f13d"}
+.fa-unlock-alt:before{content:"\f13e"}
+.fa-bullseye:before{content:"\f140"}
+.fa-ellipsis-h:before{content:"\f141"}
+.fa-ellipsis-v:before{content:"\f142"}
+.fa-rss-square:before{content:"\f143"}
+.fa-play-circle:before{content:"\f144"}
+.fa-ticket:before{content:"\f145"}
+.fa-minus-square:before{content:"\f146"}
+.fa-minus-square-o:before{content:"\f147"}
+.fa-level-up:before{content:"\f148"}
+.fa-level-down:before{content:"\f149"}
+.fa-check-square:before{content:"\f14a"}
+.fa-pencil-square:before{content:"\f14b"}
+.fa-external-link-square:before{content:"\f14c"}
+.fa-share-square:before{content:"\f14d"}
+.fa-compass:before{content:"\f14e"}
+.fa-toggle-down:before,.fa-caret-square-o-down:before{content:"\f150"}
+.fa-toggle-up:before,.fa-caret-square-o-up:before{content:"\f151"}
+.fa-toggle-right:before,.fa-caret-square-o-right:before{content:"\f152"}
+.fa-euro:before,.fa-eur:before{content:"\f153"}
+.fa-gbp:before{content:"\f154"}
+.fa-dollar:before,.fa-usd:before{content:"\f155"}
+.fa-rupee:before,.fa-inr:before{content:"\f156"}
+.fa-cny:before,.fa-rmb:before,.fa-yen:before,.fa-jpy:before{content:"\f157"}
+.fa-ruble:before,.fa-rouble:before,.fa-rub:before{content:"\f158"}
+.fa-won:before,.fa-krw:before{content:"\f159"}
+.fa-bitcoin:before,.fa-btc:before{content:"\f15a"}
+.fa-file:before{content:"\f15b"}
+.fa-file-text:before{content:"\f15c"}
+.fa-sort-alpha-asc:before{content:"\f15d"}
+.fa-sort-alpha-desc:before{content:"\f15e"}
+.fa-sort-amount-asc:before{content:"\f160"}
+.fa-sort-amount-desc:before{content:"\f161"}
+.fa-sort-numeric-asc:before{content:"\f162"}
+.fa-sort-numeric-desc:before{content:"\f163"}
+.fa-thumbs-up:before{content:"\f164"}
+.fa-thumbs-down:before{content:"\f165"}
+.fa-youtube-square:before{content:"\f166"}
+.fa-youtube:before{content:"\f167"}
+.fa-xing:before{content:"\f168"}
+.fa-xing-square:before{content:"\f169"}
+.fa-youtube-play:before{content:"\f16a"}
+.fa-dropbox:before{content:"\f16b"}
+.fa-stack-overflow:before{content:"\f16c"}
+.fa-instagram:before{content:"\f16d"}
+.fa-flickr:before{content:"\f16e"}
+.fa-adn:before{content:"\f170"}
+.fa-bitbucket:before{content:"\f171"}
+.fa-bitbucket-square:before{content:"\f172"}
+.fa-tumblr:before{content:"\f173"}
+.fa-tumblr-square:before{content:"\f174"}
+.fa-long-arrow-down:before{content:"\f175"}
+.fa-long-arrow-up:before{content:"\f176"}
+.fa-long-arrow-left:before{content:"\f177"}
+.fa-long-arrow-right:before{content:"\f178"}
+.fa-apple:before{content:"\f179"}
+.fa-windows:before{content:"\f17a"}
+.fa-android:before{content:"\f17b"}
+.fa-linux:before{content:"\f17c"}
+.fa-dribbble:before{content:"\f17d"}
+.fa-skype:before{content:"\f17e"}
+.fa-foursquare:before{content:"\f180"}
+.fa-trello:before{content:"\f181"}
+.fa-female:before{content:"\f182"}
+.fa-male:before{content:"\f183"}
+.fa-gittip:before{content:"\f184"}
+.fa-sun-o:before{content:"\f185"}
+.fa-moon-o:before{content:"\f186"}
+.fa-archive:before{content:"\f187"}
+.fa-bug:before{content:"\f188"}
+.fa-vk:before{content:"\f189"}
+.fa-weibo:before{content:"\f18a"}
+.fa-renren:before{content:"\f18b"}
+.fa-pagelines:before{content:"\f18c"}
+.fa-stack-exchange:before{content:"\f18d"}
+.fa-arrow-circle-o-right:before{content:"\f18e"}
+.fa-arrow-circle-o-left:before{content:"\f190"}
+.fa-toggle-left:before,.fa-caret-square-o-left:before{content:"\f191"}
+.fa-dot-circle-o:before{content:"\f192"}
+.fa-wheelchair:before{content:"\f193"}
+.fa-vimeo-square:before{content:"\f194"}
+.fa-turkish-lira:before,.fa-try:before{content:"\f195"}
+.fa-plus-square-o:before{content:"\f196"}
+.fa-space-shuttle:before{content:"\f197"}
+.fa-slack:before{content:"\f198"}
+.fa-envelope-square:before{content:"\f199"}
+.fa-wordpress:before{content:"\f19a"}
+.fa-openid:before{content:"\f19b"}
+.fa-institution:before,.fa-bank:before,.fa-university:before{content:"\f19c"}
+.fa-mortar-board:before,.fa-graduation-cap:before{content:"\f19d"}
+.fa-yahoo:before{content:"\f19e"}
+.fa-google:before{content:"\f1a0"}
+.fa-reddit:before{content:"\f1a1"}
+.fa-reddit-square:before{content:"\f1a2"}
+.fa-stumbleupon-circle:before{content:"\f1a3"}
+.fa-stumbleupon:before{content:"\f1a4"}
+.fa-delicious:before{content:"\f1a5"}
+.fa-digg:before{content:"\f1a6"}
+.fa-pied-piper-square:before,.fa-pied-piper:before{content:"\f1a7"}
+.fa-pied-piper-alt:before{content:"\f1a8"}
+.fa-drupal:before{content:"\f1a9"}
+.fa-joomla:before{content:"\f1aa"}
+.fa-language:before{content:"\f1ab"}
+.fa-fax:before{content:"\f1ac"}
+.fa-building:before{content:"\f1ad"}
+.fa-child:before{content:"\f1ae"}
+.fa-paw:before{content:"\f1b0"}
+.fa-spoon:before{content:"\f1b1"}
+.fa-cube:before{content:"\f1b2"}
+.fa-cubes:before{content:"\f1b3"}
+.fa-behance:before{content:"\f1b4"}
+.fa-behance-square:before{content:"\f1b5"}
+.fa-steam:before{content:"\f1b6"}
+.fa-steam-square:before{content:"\f1b7"}
+.fa-recycle:before{content:"\f1b8"}
+.fa-automobile:before,.fa-car:before{content:"\f1b9"}
+.fa-cab:before,.fa-taxi:before{content:"\f1ba"}
+.fa-tree:before{content:"\f1bb"}
+.fa-spotify:before{content:"\f1bc"}
+.fa-deviantart:before{content:"\f1bd"}
+.fa-soundcloud:before{content:"\f1be"}
+.fa-database:before{content:"\f1c0"}
+.fa-file-pdf-o:before{content:"\f1c1"}
+.fa-file-word-o:before{content:"\f1c2"}
+.fa-file-excel-o:before{content:"\f1c3"}
+.fa-file-powerpoint-o:before{content:"\f1c4"}
+.fa-file-photo-o:before,.fa-file-picture-o:before,.fa-file-image-o:before{content:"\f1c5"}
+.fa-file-zip-o:before,.fa-file-archive-o:before{content:"\f1c6"}
+.fa-file-sound-o:before,.fa-file-audio-o:before{content:"\f1c7"}
+.fa-file-movie-o:before,.fa-file-video-o:before{content:"\f1c8"}
+.fa-file-code-o:before{content:"\f1c9"}
+.fa-vine:before{content:"\f1ca"}
+.fa-codepen:before{content:"\f1cb"}
+.fa-jsfiddle:before{content:"\f1cc"}
+.fa-life-bouy:before,.fa-life-saver:before,.fa-support:before,.fa-life-ring:before{content:"\f1cd"}
+.fa-circle-o-notch:before{content:"\f1ce"}
+.fa-ra:before,.fa-rebel:before{content:"\f1d0"}
+.fa-ge:before,.fa-empire:before{content:"\f1d1"}
+.fa-git-square:before{content:"\f1d2"}
+.fa-git:before{content:"\f1d3"}
+.fa-hacker-news:before{content:"\f1d4"}
+.fa-tencent-weibo:before{content:"\f1d5"}
+.fa-qq:before{content:"\f1d6"}
+.fa-wechat:before,.fa-weixin:before{content:"\f1d7"}
+.fa-send:before,.fa-paper-plane:before{content:"\f1d8"}
+.fa-send-o:before,.fa-paper-plane-o:before{content:"\f1d9"}
+.fa-history:before{content:"\f1da"}
+.fa-circle-thin:before{content:"\f1db"}
+.fa-header:before{content:"\f1dc"}
+.fa-paragraph:before{content:"\f1dd"}
+.fa-sliders:before{content:"\f1de"}
+.fa-share-alt:before{content:"\f1e0"}
+.fa-share-alt-square:before{content:"\f1e1"}
+.fa-bomb:before{content:"\f1e2"}
+.modal.fade .modal-dialog{-webkit-transform:translate(0, 0);-ms-transform:translate(0, 0);transform:translate(0, 0)}
+code{color:#000}
+pre{font-size:inherit;line-height:inherit}
+label{font-weight:normal}
+.border-box-sizing{box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box}
+.corner-all{border-radius:4px}
+.no-padding{padding:0}
+.hbox{display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}
+.hbox>*{-webkit-box-flex:0;-moz-box-flex:0;box-flex:0;flex:none}
+.vbox{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}
+.vbox>*{-webkit-box-flex:0;-moz-box-flex:0;box-flex:0;flex:none}
+.hbox.reverse,.vbox.reverse,.reverse{-webkit-box-direction:reverse;-moz-box-direction:reverse;box-direction:reverse;flex-direction:row-reverse}
+.hbox.box-flex0,.vbox.box-flex0,.box-flex0{-webkit-box-flex:0;-moz-box-flex:0;box-flex:0;flex:none;width:auto}
+.hbox.box-flex1,.vbox.box-flex1,.box-flex1{-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}
+.hbox.box-flex,.vbox.box-flex,.box-flex{-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}
+.hbox.box-flex2,.vbox.box-flex2,.box-flex2{-webkit-box-flex:2;-moz-box-flex:2;box-flex:2;flex:2}
+.box-group1{-webkit-box-flex-group:1;-moz-box-flex-group:1;box-flex-group:1}
+.box-group2{-webkit-box-flex-group:2;-moz-box-flex-group:2;box-flex-group:2}
+.hbox.start,.vbox.start,.start{-webkit-box-pack:start;-moz-box-pack:start;box-pack:start;justify-content:flex-start}
+.hbox.end,.vbox.end,.end{-webkit-box-pack:end;-moz-box-pack:end;box-pack:end;justify-content:flex-end}
+.hbox.center,.vbox.center,.center{-webkit-box-pack:center;-moz-box-pack:center;box-pack:center;justify-content:center}
+.hbox.align-start,.vbox.align-start,.align-start{-webkit-box-align:start;-moz-box-align:start;box-align:start;align-items:flex-start}
+.hbox.align-end,.vbox.align-end,.align-end{-webkit-box-align:end;-moz-box-align:end;box-align:end;align-items:flex-end}
+.hbox.align-center,.vbox.align-center,.align-center{-webkit-box-align:center;-moz-box-align:center;box-align:center;align-items:center}
+div.error{margin:2em;text-align:center}
+div.error>h1{font-size:500%;line-height:normal}
+div.error>p{font-size:200%;line-height:normal}
+div.traceback-wrapper{text-align:left;max-width:800px;margin:auto}
+body{background-color:#fff;position:absolute;left:0;right:0;top:0;bottom:0;overflow:visible}
+div#header{display:none;margin-bottom:0;padding-left:30px;padding-bottom:5px;border-bottom:1px solid #e7e7e7}
+#ipython_notebook{padding-left:0}
+#noscript{width:auto;padding-top:16px;padding-bottom:16px;text-align:center;font-size:22px;color:#f00;font-weight:bold}
+#ipython_notebook img{font-family:Verdana,"Helvetica Neue",Arial,Helvetica,Geneva,sans-serif;height:24px;text-decoration:none;color:#000}
+#site{width:100%;display:none}
+.ui-button .ui-button-text{padding:.2em .8em;font-size:77%}
+input.ui-button{padding:.3em .9em}
+.navbar span{margin-top:3px}
+span#login_widget{float:right}
+.nav-header{text-transform:none}
+#header>span{margin-top:10px}
+.modal_stretch .modal-dialog{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch;min-height:80%}.modal_stretch .modal-dialog .modal-body{max-height:none;flex:1}
+@media (min-width:768px){.modal .modal-dialog{width:700px}}.center-nav{display:inline-block;margin-bottom:-4px}
+.alternate_upload{background-color:none;display:inline}
+.alternate_upload.form{padding:0;margin:0}
+.alternate_upload input.fileinput{background-color:#f00;position:relative;opacity:0;z-index:2;width:295px;margin-left:163px;cursor:pointer;height:26px}
+ul#tabs{margin-bottom:4px}
+ul#tabs a{padding-top:6px;padding-bottom:4px}
+ul.breadcrumb a:focus,ul.breadcrumb a:hover{text-decoration:none}
+ul.breadcrumb i.icon-home{font-size:16px;margin-right:4px}
+ul.breadcrumb span{color:#5e5e5e}
+.list_toolbar{padding:4px 0 4px 0;vertical-align:middle}.list_toolbar .tree-buttons{padding-top:2px}
+.list_toolbar [class*="span"]{min-height:24px}
+.list_header{font-weight:bold}
+.list_container{margin-top:4px;margin-bottom:20px;border:1px solid #ababab;border-radius:4px}
+.list_container>div{border-bottom:1px solid #ababab}.list_container>div:hover .list-item{background-color:#f00}
+.list_container>div:last-child{border:none}
+.list_item:hover .list_item{background-color:#ddd}
+.list_item a{text-decoration:none}
+.action_col{text-align:right}
+.list_header>div,.list_item>div{padding-top:4px;padding-bottom:4px;padding-left:7px;padding-right:7px;line-height:22px}
+.item_name{line-height:22px;height:24px}
+.item_icon{font-size:14px;color:#5e5e5e;margin-right:7px}
+.item_buttons{line-height:1em}
+.toolbar_info{height:24px;line-height:24px}
+input.nbname_input,input.engine_num_input{padding-top:3px;padding-bottom:3px;height:22px;line-height:14px;margin:0}
+input.engine_num_input{width:60px}
+.highlight_text{color:#00f}
+#project_name>.breadcrumb{padding:0;margin-bottom:0;background-color:transparent;font-weight:bold}
+.tab-content .row{margin-left:0;margin-right:0}
+.folder_icon:before{content:"\f114"}
+.notebook_icon:before{content:"\f02d"}
+.ansibold{font-weight:bold}
+.ansiblack{color:#000}
+.ansired{color:#8b0000}
+.ansigreen{color:#006400}
+.ansiyellow{color:#a52a2a}
+.ansiblue{color:#00008b}
+.ansipurple{color:#9400d3}
+.ansicyan{color:#4682b4}
+.ansigray{color:#808080}
+.ansibgblack{background-color:#000}
+.ansibgred{background-color:#f00}
+.ansibggreen{background-color:#008000}
+.ansibgyellow{background-color:#ff0}
+.ansibgblue{background-color:#00f}
+.ansibgpurple{background-color:#f0f}
+.ansibgcyan{background-color:#0ff}
+.ansibggray{background-color:#808080}
+div.cell{border:1px solid transparent;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch;border-radius:4px;border-width:thin;border-style:solid}div.cell.selected{border-color:#ababab}
+div.cell.edit_mode{border-color:#008000}
+div.cell{width:100%;padding:5px 5px 5px 0;margin:0;outline:none}
+div.prompt{min-width:15ex;padding:.4em;margin:0;font-family:monospace;text-align:right;line-height:1.21429em}
+@media (max-width:480px){div.prompt{text-align:left}}div.inner_cell{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}
+div.input_area{border:1px solid #cfcfcf;border-radius:4px;background:#f7f7f7;line-height:1.21429em}
+div.prompt:empty{padding-top:0;padding-bottom:0}
+div.input{page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}
+@media (max-width:480px){div.input{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}}div.input_prompt{color:#000080;border-top:1px solid transparent}
+div.input_area>div.highlight{margin:.4em;border:none;padding:0;background-color:transparent}
+div.input_area>div.highlight>pre{margin:0;border:none;padding:0;background-color:transparent}
+.CodeMirror{line-height:1.21429em;height:auto;background:none;}
+.CodeMirror-scroll{overflow-y:hidden;overflow-x:auto}
+.CodeMirror-lines{padding:.4em}
+.CodeMirror-linenumber{padding:0 8px 0 4px}
+.CodeMirror-gutters{border-bottom-left-radius:4px;border-top-left-radius:4px}
+.CodeMirror pre{padding:0;border:0;border-radius:0}
+.CodeMirror-vscrollbar,.CodeMirror-hscrollbar{display:none !important}
+pre code{display:block;padding:.5em}
+.highlight-base,pre code,pre .subst,pre .tag .title,pre .lisp .title,pre .clojure .built_in,pre .nginx .title{color:#000}
+.highlight-string,pre .string,pre .constant,pre .parent,pre .tag .value,pre .rules .value,pre .rules .value .number,pre .preprocessor,pre .ruby .symbol,pre .ruby .symbol .string,pre .aggregate,pre .template_tag,pre .django .variable,pre .smalltalk .class,pre .addition,pre .flow,pre .stream,pre .bash .variable,pre .apache .tag,pre .apache .cbracket,pre .tex .command,pre .tex .special,pre .erlang_repl .function_or_atom,pre .markdown .header{color:#ba2121}
+.highlight-comment,pre .comment,pre .annotation,pre .template_comment,pre .diff .header,pre .chunk,pre .markdown .blockquote{color:#408080;font-style:italic}
+.highlight-number,pre .number,pre .date,pre .regexp,pre .literal,pre .smalltalk .symbol,pre .smalltalk .char,pre .go .constant,pre .change,pre .markdown .bullet,pre .markdown .link_url{color:#080}
+pre .label,pre .javadoc,pre .ruby .string,pre .decorator,pre .filter .argument,pre .localvars,pre .array,pre .attr_selector,pre .important,pre .pseudo,pre .pi,pre .doctype,pre .deletion,pre .envvar,pre .shebang,pre .apache .sqbracket,pre .nginx .built_in,pre .tex .formula,pre .erlang_repl .reserved,pre .prompt,pre .markdown .link_label,pre .vhdl .attribute,pre .clojure .attribute,pre .coffeescript .property{color:#88f}
+.highlight-keyword,pre .keyword,pre .id,pre .phpdoc,pre .aggregate,pre .css .tag,pre .javadoctag,pre .phpdoc,pre .yardoctag,pre .smalltalk .class,pre .winutils,pre .bash .variable,pre .apache .tag,pre .go .typename,pre .tex .command,pre .markdown .strong,pre .request,pre .status{color:#008000;font-weight:bold}
+.highlight-builtin,pre .built_in{color:#008000}
+pre .markdown .emphasis{font-style:italic}
+pre .nginx .built_in{font-weight:normal}
+pre .coffeescript .javascript,pre .javascript .xml,pre .tex .formula,pre .xml .javascript,pre .xml .vbscript,pre .xml .css,pre .xml .cdata{opacity:.5}
+.cm-s-ipython span.cm-variable{color:#000}
+.cm-s-ipython span.cm-keyword{color:#008000;font-weight:bold}
+.cm-s-ipython span.cm-number{color:#080}
+.cm-s-ipython span.cm-comment{color:#408080;font-style:italic}
+.cm-s-ipython span.cm-string{color:#ba2121}
+.cm-s-ipython span.cm-builtin{color:#008000}
+.cm-s-ipython span.cm-error{color:#f00}
+.cm-s-ipython span.cm-operator{color:#a2f;font-weight:bold}
+.cm-s-ipython span.cm-meta{color:#a2f}
+.cm-s-ipython span.cm-tab{background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAMCAYAAAAkuj5RAAAAAXNSR0IArs4c6QAAAGFJREFUSMft1LsRQFAQheHPowAKoACx3IgEKtaEHujDjORSgWTH/ZOdnZOcM/sgk/kFFWY0qV8foQwS4MKBCS3qR6ixBJvElOobYAtivseIE120FaowJPN75GMu8j/LfMwNjh4HUpwg4LUAAAAASUVORK5CYII=);background-position:right;background-repeat:no-repeat}
+div.output_wrapper{position:relative;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}
+div.output_scroll{height:24em;width:100%;overflow:auto;border-radius:4px;-webkit-box-shadow:inset 0 2px 8px rgba(0,0,0,0.8);box-shadow:inset 0 2px 8px rgba(0,0,0,0.8);display:block}
+div.output_collapsed{margin:0;padding:0;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}
+div.out_prompt_overlay{height:100%;padding:0 .4em;position:absolute;border-radius:4px}
+div.out_prompt_overlay:hover{-webkit-box-shadow:inset 0 0 1px #000;box-shadow:inset 0 0 1px #000;background:rgba(240,240,240,0.5)}
+div.output_prompt{color:#8b0000}
+div.output_area{padding:0;page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}div.output_area .MathJax_Display{text-align:left !important}
+div.output_area .rendered_html table{margin-left:0;margin-right:0}
+div.output_area .rendered_html img{margin-left:0;margin-right:0}
+.output{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}
+@media (max-width:480px){div.output_area{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}}div.output_area pre{margin:0;padding:0;border:0;vertical-align:baseline;color:#000;background-color:transparent;border-radius:0}
+div.output_subarea{padding:.4em .4em 0 .4em;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}
+div.output_text{text-align:left;color:#000;line-height:1.21429em}
+div.output_stderr{background:#fdd;}
+div.output_latex{text-align:left}
+div.output_javascript:empty{padding:0}
+.js-error{color:#8b0000}
+div.raw_input_container{font-family:monospace;padding-top:5px}
+span.raw_input_prompt{}
+input.raw_input{font-family:inherit;font-size:inherit;color:inherit;width:auto;vertical-align:baseline;padding:0 .25em;margin:0 .25em}
+input.raw_input:focus{box-shadow:none}
+p.p-space{margin-bottom:10px}
+.rendered_html{color:#000;}.rendered_html em{font-style:italic}
+.rendered_html strong{font-weight:bold}
+.rendered_html u{text-decoration:underline}
+.rendered_html :link{text-decoration:underline}
+.rendered_html :visited{text-decoration:underline}
+.rendered_html h1{font-size:185.7%;margin:1.08em 0 0 0;font-weight:bold;line-height:1}
+.rendered_html h2{font-size:157.1%;margin:1.27em 0 0 0;font-weight:bold;line-height:1}
+.rendered_html h3{font-size:128.6%;margin:1.55em 0 0 0;font-weight:bold;line-height:1}
+.rendered_html h4{font-size:100%;margin:2em 0 0 0;font-weight:bold;line-height:1}
+.rendered_html h5{font-size:100%;margin:2em 0 0 0;font-weight:bold;line-height:1;font-style:italic}
+.rendered_html h6{font-size:100%;margin:2em 0 0 0;font-weight:bold;line-height:1;font-style:italic}
+.rendered_html h1:first-child{margin-top:.538em}
+.rendered_html h2:first-child{margin-top:.636em}
+.rendered_html h3:first-child{margin-top:.777em}
+.rendered_html h4:first-child{margin-top:1em}
+.rendered_html h5:first-child{margin-top:1em}
+.rendered_html h6:first-child{margin-top:1em}
+.rendered_html ul{list-style:disc;margin:0 2em;padding-left:0}
+.rendered_html ul ul{list-style:square;margin:0 2em}
+.rendered_html ul ul ul{list-style:circle;margin:0 2em}
+.rendered_html ol{list-style:decimal;margin:0 2em;padding-left:0}
+.rendered_html ol ol{list-style:upper-alpha;margin:0 2em}
+.rendered_html ol ol ol{list-style:lower-alpha;margin:0 2em}
+.rendered_html ol ol ol ol{list-style:lower-roman;margin:0 2em}
+.rendered_html ol ol ol ol ol{list-style:decimal;margin:0 2em}
+.rendered_html *+ul{margin-top:1em}
+.rendered_html *+ol{margin-top:1em}
+.rendered_html hr{color:#000;background-color:#000}
+.rendered_html pre{margin:1em 2em}
+.rendered_html pre,.rendered_html code{border:0;background-color:#fff;color:#000;font-size:100%;padding:0}
+.rendered_html blockquote{margin:1em 2em}
+.rendered_html table{margin-left:auto;margin-right:auto;border:1px solid #000;border-collapse:collapse}
+.rendered_html tr,.rendered_html th,.rendered_html td{border:1px solid #000;border-collapse:collapse;margin:1em 2em}
+.rendered_html td,.rendered_html th{text-align:left;vertical-align:middle;padding:4px}
+.rendered_html th{font-weight:bold}
+.rendered_html *+table{margin-top:1em}
+.rendered_html p{text-align:justify}
+.rendered_html *+p{margin-top:1em}
+.rendered_html img{display:block;margin-left:auto;margin-right:auto}
+.rendered_html *+img{margin-top:1em}
+div.text_cell{padding:5px 5px 5px 0;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}
+@media (max-width:480px){div.text_cell>div.prompt{display:none}}div.text_cell_render{outline:none;resize:none;width:inherit;border-style:none;padding:.5em .5em .5em .4em;color:#000}
+a.anchor-link:link{text-decoration:none;padding:0 20px;visibility:hidden}
+h1:hover .anchor-link,h2:hover .anchor-link,h3:hover .anchor-link,h4:hover .anchor-link,h5:hover .anchor-link,h6:hover .anchor-link{visibility:visible}
+div.cell.text_cell.rendered{padding:0}
+.widget-area{page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}.widget-area .widget-subarea{padding:.44em .4em .4em 1px;margin-left:6px;box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch;-webkit-box-flex:2;-moz-box-flex:2;box-flex:2;flex:2;-webkit-box-align:start;-moz-box-align:start;box-align:start;align-items:flex-start}
+.widget-hlabel{min-width:10ex;padding-right:8px;padding-top:5px;text-align:right;vertical-align:text-top}
+.widget-vlabel{padding-bottom:5px;text-align:center;vertical-align:text-bottom}
+.widget-hreadout{padding-left:8px;padding-top:5px;text-align:left;vertical-align:text-top}
+.widget-vreadout{padding-top:5px;text-align:center;vertical-align:text-top}
+.slide-track{border:1px solid #ccc;background:#fff;border-radius:4px;}
+.widget-hslider{padding-left:8px;padding-right:5px;overflow:visible;width:350px;height:5px;max-height:5px;margin-top:13px;margin-bottom:10px;border:1px solid #ccc;background:#fff;border-radius:4px;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}.widget-hslider .ui-slider{border:0 !important;background:none !important;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}.widget-hslider .ui-slider .ui-slider-handle{width:14px !important;height:28px !important;margin-top:-8px !important}
+.widget-vslider{padding-bottom:8px;overflow:visible;width:5px;max-width:5px;height:250px;margin-left:12px;border:1px solid #ccc;background:#fff;border-radius:4px;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}.widget-vslider .ui-slider{border:0 !important;background:none !important;margin-left:-4px;margin-top:5px;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}.widget-vslider .ui-slider .ui-slider-handle{width:28px !important;height:14px !important;margin-left:-9px}
+.widget-text{width:350px;margin:0 !important}
+.widget-listbox{width:350px;margin-bottom:0}
+.widget-numeric-text{width:150px;margin:0 !important}
+.widget-progress{margin-top:6px;width:350px}.widget-progress .progress-bar{-webkit-transition:none;-moz-transition:none;-ms-transition:none;-o-transition:none;transition:none}
+.widget-combo-btn{min-width:125px}
+.widget-box{margin:5px;-webkit-box-pack:start;-moz-box-pack:start;box-pack:start;justify-content:flex-start;box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;-webkit-box-align:start;-moz-box-align:start;box-align:start;align-items:flex-start}
+.widget-hbox{margin:5px;-webkit-box-pack:start;-moz-box-pack:start;box-pack:start;justify-content:flex-start;box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;-webkit-box-align:start;-moz-box-align:start;box-align:start;align-items:flex-start;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}
+.widget-hbox-single{margin:5px;-webkit-box-pack:start;-moz-box-pack:start;box-pack:start;justify-content:flex-start;box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;-webkit-box-align:start;-moz-box-align:start;box-align:start;align-items:flex-start;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch;height:30px}.widget-hbox-single input[type="checkbox"]{margin-top:9px}
+.widget-vbox{margin:5px;-webkit-box-pack:start;-moz-box-pack:start;box-pack:start;justify-content:flex-start;box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;-webkit-box-align:start;-moz-box-align:start;box-align:start;align-items:flex-start;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}
+.widget-vbox-single{margin:5px;-webkit-box-pack:start;-moz-box-pack:start;box-pack:start;justify-content:flex-start;box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;-webkit-box-align:start;-moz-box-align:start;box-align:start;align-items:flex-start;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch;width:30px}
+.widget-modal{overflow:hidden;position:absolute !important;top:0;left:0;margin-left:0 !important}
+.widget-modal-body{max-height:none !important}
+.widget-container{box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;-webkit-box-align:start;-moz-box-align:start;box-align:start;align-items:flex-start}
+.widget-radio-box{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch;box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;padding-top:4px}.widget-radio-box label{margin-top:0}
+.docked-widget-modal{overflow:hidden;position:relative !important;top:0 !important;left:0 !important;margin-left:0 !important}
+body{background-color:#fff}
+body.notebook_app{overflow:hidden}
+@media (max-width:767px){body.notebook_app{padding-left:0;padding-right:0}}span#notebook_name{height:1em;line-height:1em;padding:3px;border:none;font-size:146.5%}
+div#notebook_panel{margin:0 0 0 0;padding:0;-webkit-box-shadow:inset 1px 4px 9px -6px rgba(0,0,0,0.25);box-shadow:inset 1px 4px 9px -6px rgba(0,0,0,0.25)}
+div#notebook{font-size:14px;line-height:20px;overflow-y:scroll;overflow-x:auto;width:100%;padding:1em 0 1em 0;margin:0;border-top:1px solid #e7e7e7;outline:none;box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box}
+div.ui-widget-content{border:1px solid #ababab;outline:none}
+pre.dialog{background-color:#f7f7f7;border:1px solid #ddd;border-radius:4px;padding:.4em;padding-left:2em}
+p.dialog{padding:.2em}
+pre,code,kbd,samp{white-space:pre-wrap}
+#fonttest{font-family:monospace}
+p{margin-bottom:0}
+.end_space{height:200px}
+.celltoolbar{border:thin solid #cfcfcf;border-bottom:none;background:#eee;border-radius:3px 3px 0 0;width:100%;-webkit-box-pack:end;height:29px;padding-right:4px;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch;-webkit-box-direction:reverse;-moz-box-direction:reverse;box-direction:reverse;flex-direction:row-reverse}
+.ctb_hideshow{display:none;vertical-align:bottom}
+.ctb_global_show .ctb_show.ctb_hideshow{display:block}
+.ctb_global_show .ctb_show+.input_area,.ctb_global_show .ctb_show+div.text_cell_input{border-top-right-radius:0;border-top-left-radius:0}
+.celltoolbar{font-size:87%;padding-top:3px}
+.celltoolbar select{font-size:87%;height:22px}
+.celltoolbar label{margin-left:5px;margin-right:5px}
+.completions{position:absolute;z-index:10;overflow:hidden;border:1px solid #ababab;border-radius:4px;-webkit-box-shadow:0 6px 10px -1px #adadad;box-shadow:0 6px 10px -1px #adadad}
+.completions select{background:#fff;outline:none;border:none;padding:0;margin:0;overflow:auto;font-family:monospace;font-size:110%;color:#000;width:auto}
+.completions select option.context{color:#3071a9}
+#menubar{margin-top:0;margin-bottom:-19px;position:relative}#menubar .navbar{border-top:1px;border-radius:0 0 4px 4px}
+#menubar li.dropdown{line-height:12px}#menubar li.dropdown a{padding-top:6px;padding-bottom:5px}
+#menubar ul.navbar-right{padding-top:2px}
+.nav-wrapper{border-bottom:1px solid #e7e7e7}
+i.menu-icon{padding-top:4px}
+ul#help_menu li a{overflow:hidden;padding-right:2.2em}ul#help_menu li a i{margin-right:-1.2em}
+#menus{min-height:30px}
+.dropdown-submenu{position:relative}
+.dropdown-submenu>.dropdown-menu{top:0;left:100%;margin-top:-6px;margin-left:-1px;-webkit-border-radius:0 6px 6px 6px;-moz-border-radius:0 6px 6px 6px;border-radius:0 6px 6px 6px}
+.dropdown-submenu:hover>.dropdown-menu{display:block}
+.dropdown-submenu>a:after{display:block;content:" ";float:right;width:0;height:0;border-color:transparent;border-style:solid;border-width:5px 0 5px 5px;border-left-color:#ccc;margin-top:5px;margin-right:-10px}
+.dropdown-submenu:hover>a:after{border-left-color:#fff}
+.dropdown-submenu.pull-left{float:none}
+.dropdown-submenu.pull-left>.dropdown-menu{left:-100%;margin-left:10px;-webkit-border-radius:6px 0 6px 6px;-moz-border-radius:6px 0 6px 6px;border-radius:6px 0 6px 6px}
+#notification_area{float:right !important;float:right;z-index:10}
+.indicator_area{color:#777;padding:4px 3px;margin:0;width:11px;z-index:10;text-align:center}
+#kernel_indicator{float:right !important;float:right;color:#777;padding:4px 3px;margin:0;width:11px;z-index:10;text-align:center;margin-right:12px}
+#modal_indicator{float:right !important;float:right;color:#777;padding:4px 3px;margin:0;width:11px;z-index:10;text-align:center;margin-right:5px}
+.edit_mode_icon:before{content:"\f040"}
+.command_mode_icon:before{content:' '}
+.kernel_idle_icon:before{content:"\f10c"}
+.kernel_busy_icon:before{content:"\f111"}
+.notification_widget{color:#777;padding:1px 12px;margin:2px 4px;z-index:10;border:1px solid #ccc;border-radius:4px;background:rgba(240,240,240,0.5)}.notification_widget.span{padding-right:2px}
+div#pager_splitter{height:8px}
+#pager-container{position:relative;padding:15px 0}
+div#pager{font-size:14px;line-height:20px;overflow:auto;display:none}div#pager pre{line-height:1.21429em;color:#000;background-color:#f7f7f7;padding:.4em}
+.quickhelp{display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}
+.shortcut_key{display:inline-block;width:20ex;text-align:right;font-family:monospace}
+.shortcut_descr{display:inline-block;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}
+span#save_widget{padding:0 5px;margin-top:12px}
+span#checkpoint_status,span#autosave_status{font-size:small}
+@media (max-width:767px){span#save_widget{font-size:small} span#checkpoint_status,span#autosave_status{font-size:x-small}}@media (max-width:767px){span#checkpoint_status,span#autosave_status{display:none}}@media (min-width:768px) and (max-width:979px){span#checkpoint_status{display:none} span#autosave_status{font-size:x-small}}.toolbar{padding:0;margin-left:-5px;margin-top:-5px}.toolbar select,.toolbar label{width:auto;vertical-align:middle;margin-right:2px;margin-bottom:0;display:inline;font-size:92%;margin-left:.3em;margin-right:.3em;padding:0;padding-top:3px}
+.toolbar .btn{padding:2px 8px}
+.toolbar .btn-group{margin-top:0;margin-left:5px}
+#maintoolbar{margin-bottom:-3px;margin-top:-8px;border:0;min-height:27px;margin-left:32px;padding-top:6px;padding-bottom:8px}#maintoolbar .navbar-text{float:none;vertical-align:middle;text-align:right;margin-left:5px;margin-right:0;margin-top:0}
+#maintoolbar .toolbar{margin-top:0}
+.select-xs{height:24px}
+@-moz-keyframes fadeOut{from{opacity:1} to{opacity:0}}@-webkit-keyframes fadeOut{from{opacity:1} to{opacity:0}}@-moz-keyframes fadeIn{from{opacity:0} to{opacity:1}}@-webkit-keyframes fadeIn{from{opacity:0} to{opacity:1}}.bigtooltip{overflow:auto;height:200px;-webkit-transition-property:height;-webkit-transition-duration:500ms;-moz-transition-property:height;-moz-transition-duration:500ms;transition-property:height;transition-duration:500ms}
+.smalltooltip{-webkit-transition-property:height;-webkit-transition-duration:500ms;-moz-transition-property:height;-moz-transition-duration:500ms;transition-property:height;transition-duration:500ms;text-overflow:ellipsis;overflow:hidden;height:80px}
+.tooltipbuttons{position:absolute;padding-right:15px;top:0;right:0}
+.tooltiptext{padding-right:30px}
+.ipython_tooltip{max-width:700px;-webkit-animation:fadeOut 400ms;-moz-animation:fadeOut 400ms;animation:fadeOut 400ms;-webkit-animation:fadeIn 400ms;-moz-animation:fadeIn 400ms;animation:fadeIn 400ms;vertical-align:middle;background-color:#f7f7f7;overflow:visible;border:#ababab 1px solid;outline:none;padding:3px;margin:0;padding-left:7px;font-family:monospace;min-height:50px;-moz-box-shadow:0 6px 10px -1px #adadad;-webkit-box-shadow:0 6px 10px -1px #adadad;box-shadow:0 6px 10px -1px #adadad;border-radius:4px;position:absolute;z-index:1000}.ipython_tooltip a{float:right}
+.ipython_tooltip .tooltiptext pre{border:0;border-radius:0;font-size:100%;background-color:#f7f7f7}
+.pretooltiparrow{left:0;margin:0;top:-16px;width:40px;height:16px;overflow:hidden;position:absolute}
+.pretooltiparrow:before{background-color:#f7f7f7;border:1px #ababab solid;z-index:11;content:"";position:absolute;left:15px;top:10px;width:25px;height:25px;-webkit-transform:rotate(45deg);-moz-transform:rotate(45deg);-ms-transform:rotate(45deg);-o-transform:rotate(45deg)}
+>>>>>>> fab css

--- a/IPython/html/static/tree/less/tree.less
+++ b/IPython/html/static/tree/less/tree.less
@@ -141,9 +141,9 @@ input.engine_num_input {
 }
 
 .folder_icon:before {
-    content: @fa-var-folder-o
+    .icon(@fa-var-folder-o)
 }
 
 .notebook_icon:before {
-    content: @fa-var-book
+    .icon(@fa-var-book)
 }

--- a/IPython/html/static/tree/less/tree.less
+++ b/IPython/html/static/tree/less/tree.less
@@ -141,9 +141,9 @@ input.engine_num_input {
 }
 
 .folder_icon:before {
-    .icon(@folder-close-alt)
+    content: @fa-var-folder-o
 }
 
 .notebook_icon:before {
-    .icon(@book)
+    content: @fa-var-book
 }

--- a/IPython/html/static/widgets/js/widget_container.js
+++ b/IPython/html/static/widgets/js/widget_container.js
@@ -88,7 +88,7 @@ define([
                     that.bring_to_front();
                 });
             this.$close = $('<button />')
-                .addClass('close icon-remove')
+                .addClass('close fa fa-remove')
                 .css('margin-left', '5px')
                 .appendTo(this.$title_bar)
                 .click(function(){
@@ -96,14 +96,14 @@ define([
                     event.stopPropagation();
                 });
             this.$minimize = $('<button />')
-                .addClass('close icon-arrow-down')
+                .addClass('close fa fa-arrow-down')
                 .appendTo(this.$title_bar)
                 .click(function(){
                     that.popped_out = !that.popped_out;
                     if (!that.popped_out) {
                         that.$minimize
-                            .removeClass('icon-arrow-down')
-                            .addClass('icon-arrow-up');
+                            .removeClass('fa fa-arrow-down')
+                            .addClass('fa fa-arrow-up');
                             
                         that.$window
                             .draggable('destroy')
@@ -116,8 +116,8 @@ define([
                         that.$close.hide();
                     } else {
                         that.$minimize
-                            .addClass('icon-arrow-down')
-                            .removeClass('icon-arrow-up');
+                            .addClass('fa fa-arrow-down')
+                            .removeClass('fa fa-arrow-up');
 
                         that.$window
                             .removeClass('docked-widget-modal')

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -243,7 +243,7 @@ class="notebook_app"
                         {% for helplinks in sections %}
                             {% for link in helplinks %}
                                 <li><a href="{{link[0]}}" {{'target="_blank" title="Opens in a new window"' if link[2]}}>
-                                {{'<i class="icon-external-link menu-icon pull-right"></i>' if link[2]}}
+                                {{'<i class="fa fa-external-link menu-icon pull-right"></i>' if link[2]}}
                                 {{link[1]}}
                                 </a></li>
                             {% endfor %}

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -42,7 +42,7 @@ data-notebook-path="{{notebook_path}}"
             <div class="col-sm-4 no-padding tree-buttons">
                 <span id="notebook_buttons" class="pull-right">
                     <button id="new_notebook" title="Create new notebook" class="btn btn-default btn-xs">New Notebook</button>
-                    <button id="refresh_notebook_list" title="Refresh notebook list" class="btn btn-default btn-xs"><i class="icon-refresh"></i></button>
+                    <button id="refresh_notebook_list" title="Refresh notebook list" class="btn btn-default btn-xs"><i class="fa fa-refresh"></i></button>
                 </span>
             </div>
         </div>
@@ -51,7 +51,7 @@ data-notebook-path="{{notebook_path}}"
           <div id="notebook_list_header" class="row list_header">
               <div id="project_name">
                 <ul class="breadcrumb">
-                    <li><a href="{{breadcrumbs[0][0]}}"><i class="icon-home"></i></a></li>
+                    <li><a href="{{breadcrumbs[0][0]}}"><i class="fa fa-home"></i></a></li>
                     {% for crumb in breadcrumbs[1:] %}
                         <li><a href="{{crumb[0]}}">{{crumb[1]}}</a></li>
                     {% endfor %}
@@ -69,7 +69,7 @@ data-notebook-path="{{notebook_path}}"
             </div>
             <div class="col-sm-4 no-padding tree-buttons">
                 <span id="running_buttons" class="pull-right">
-                    <button id="refresh_running_list" title="Refresh running list" class="btn btn-default btn-xs"><i class="icon-refresh"></i></button>
+                    <button id="refresh_running_list" title="Refresh running list" class="btn btn-default btn-xs"><i class="fa fa-refresh"></i></button>
                 </span>
             </div>
         </div>
@@ -89,7 +89,7 @@ data-notebook-path="{{notebook_path}}"
             </div>
             <div class="col-xs-4 no-padding tree-buttons">
                 <span id="cluster_buttons" class="pull-right">
-                    <button id="refresh_cluster_list" title="Refresh cluster list" class="btn btn-default btn-xs"><i class="icon-refresh"></i></button>
+                    <button id="refresh_cluster_list" title="Refresh cluster list" class="btn btn-default btn-xs"><i class="fa fa-refresh"></i></button>
                 </span>
             </div>
         </div>

--- a/IPython/nbconvert/templates/html/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/html/slides_reveal.tpl
@@ -78,7 +78,7 @@ if( window.location.search.match( /print-pdf/gi ) ) {
 <![endif]-->
 
 <!-- Get Font-awesome from cdn -->
-<link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css">
+<link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css">
 
 {% for css in resources.inlining.css -%}
     <style type="text/css">

--- a/examples/Notebook/Running Code.ipynb
+++ b/examples/Notebook/Running Code.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:344aa301a0ce679ebf87e2d1dd206cf3784854cde5fedc34109f38710aef680c"
+  "signature": "sha256:a52ac3735e5881fe8fe68f88d0113c3b1dca40cb809955db692fedb89b66a7fa"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -46,7 +46,7 @@
       "};\n",
       "</script>\n",
       "\n",
-      "Run a code cell using `shift-enter` or pressing the <button><i class=\"icon-play\"></i></button> button in the <a href=\"#\" onMouseover=\"hl('#maintoolbar-container', 1)\" onMouseout=\"hl('#maintoolbar-container', 0)\">toolbar</a> above:"
+      "Run a code cell using `shift-enter` or pressing the <button class='btn btn-default btn-xs'><i class=\"icon-play fa fa-play\"></i></button> button in the <a href=\"#\" onMouseover=\"hl('#maintoolbar-container', 1)\" onMouseout=\"hl('#maintoolbar-container', 0)\">toolbar</a> above:"
      ]
     },
     {
@@ -91,7 +91,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Code is run in a separate process called the IPython Kernel.  The Kernel can be interrupted or restarted.  Try running the following cell and then hit the <button><i class='icon-stop'></i></button> button in the <a href=\"#\" onMouseover=\"hl('#maintoolbar-container', 1)\" onMouseout=\"hl('#maintoolbar-container', 0)\">toolbar</a> above."
+      "Code is run in a separate process called the IPython Kernel.  The Kernel can be interrupted or restarted.  Try running the following cell and then hit the <button class='btn btn-default btn-xs'><i class='icon-stop fa fa-stop'></i></button> button in the <a href=\"#\" onMouseover=\"hl('#maintoolbar-container', 1)\" onMouseout=\"hl('#maintoolbar-container', 0)\">toolbar</a> above."
      ]
     },
     {

--- a/setupbase.py
+++ b/setupbase.py
@@ -150,7 +150,7 @@ def find_package_data():
         pjoin(components, "bootstrap", "js", "bootstrap.min.js"),
         pjoin(components, "bootstrap-tour", "build", "css", "bootstrap-tour.min.css"),
         pjoin(components, "bootstrap-tour", "build", "js", "bootstrap-tour.min.js"),
-        pjoin(components, "font-awesome", "font", "*.*"),
+        pjoin(components, "font-awesome", "fonts", "*.*"),
         pjoin(components, "google-caja", "html-css-sanitizer-minified.js"),
         pjoin(components, "highlight.js", "build", "highlight.pack.js"),
         pjoin(components, "jquery", "jquery.min.js"),


### PR DESCRIPTION
We only have fontawesome-4 at fedora and this commit should update ipython to it.
After updating fontawesome to version 4 (or in my case, I replaced the bundled fontawesome with symlinks to the locally installed rpm version) and running `fab css`, anything should work as expected.

While porting, the icon `plus-sign` was not found, so I took only `plus`...
