### PR TITLE
Add newline if missing to end of script magic cell

### DIFF
--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -193,6 +193,8 @@ class ScriptMagics(Magics):
             else:
                 raise
         
+        if not cell.endswith('\n'):
+            cell += '\n'
         cell = cell.encode('utf8', 'replace')
         if args.bg:
             self.bg_processes.append(p)


### PR DESCRIPTION
The script magic %%cmd fails in IPython notebook if trailing newlines are omitted.

In IPython console, %%cmd behaves correctly:

```
In [1]: %%cmd
   ...: echo foo
   ...:
Microsoft Windows [Version 6.1.7601]
Copyright (c) 2009 Microsoft Corporation.  All rights reserved.

C:\Users\Eric>echo foo
foo

C:\Users\Eric>
```

In IPython notebook,  %%cmd fails if a cell is not terminated with two blank lines:

```
In [1]: %%cmd
   ...: echo foo
   ...:
Microsoft Windows [Version 6.1.7601]
Copyright (c) 2009 Microsoft Corporation.  All rights reserved.

C:\Users\Eric\Documents\Code\notebooks>More? 
```
