### PR TITLE
initializing WidgetView.child_views as object

### DIFF
--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -283,7 +283,7 @@ function(WidgetManager, _, Backbone){
             // Public constructor.
             this.model.on('change',this.update,this);
             this.options = parameters.options;
-            this.child_views = [];
+            this.child_views = {};
             this.model.views.push(this);
         },
 


### PR DESCRIPTION
Based on [how it is used](https://github.com/ipython/ipython/search?q=child_views&ref=cmdform&type=Code), `child_views` should just be an object.

Specifically, I ran into this while trying to extend `ContainerView`, and needed a list of its contents. underscore freaks out and won't let you use any of its Collection methods (which could pull out the id: value pairs) in a meaningful way.
