### PR TITLE
Allow text input on slider widgets

### DIFF
--- a/IPython/html/static/widgets/js/widget_float.js
+++ b/IPython/html/static/widgets/js/widget_float.js
@@ -9,9 +9,9 @@ define([
     var IntTextView = int_widgets.IntTextView;
 
     var FloatSliderView = IntSliderView.extend({
-        _validate_text_input: function(x) {
-            return parseFloat(x);
-        },
+        _parse_text_input: parseFloat,
+
+        _range_regex: /^\s*([+-]?\d*\.?\d+)\s*[-:]\s*([+-]?\d*\.?\d+)/,
 
         _validate_slide_value: function(x) {
             // Validate the value of the slider before sending it to the back-end

--- a/IPython/html/static/widgets/js/widget_float.js
+++ b/IPython/html/static/widgets/js/widget_float.js
@@ -9,6 +9,10 @@ define([
     var IntTextView = int_widgets.IntTextView;
 
     var FloatSliderView = IntSliderView.extend({
+        _validate_text_input: function(x) {
+            return parseFloat(x);
+        },
+
         _validate_slide_value: function(x) {
             // Validate the value of the slider before sending it to the back-end
             // and applying it to the other views on the page.

--- a/IPython/html/static/widgets/js/widget_float.js
+++ b/IPython/html/static/widgets/js/widget_float.js
@@ -9,9 +9,10 @@ define([
     var IntTextView = int_widgets.IntTextView;
 
     var FloatSliderView = IntSliderView.extend({
-        _parse_text_input: parseFloat,
+        _parse_value: parseFloat,
 
-        _range_regex: /^\s*([+-]?\d*\.?\d+)\s*[-:]\s*([+-]?\d*\.?\d+)/,
+        // matches: whitespace?, float, whitespace?, [-:], whitespace?, float
+        _range_regex: /^\s*([+-]?(?:\d*\.?\d+|\d+\.)(?:[eE][+-]?\d+)?)\s*[-:]\s*([+-]?(?:\d*\.?\d+|\d+\.)(?:[eE][+-]?\d+)?)/,
 
         _validate_slide_value: function(x) {
             // Validate the value of the slider before sending it to the back-end
@@ -21,10 +22,7 @@ define([
     });
 
     var FloatTextView = IntTextView.extend({
-        _parse_value: function(value) {
-            // Parse the value stored in a string.
-            return  parseFloat(value);
-        },
+        _parse_value: parseFloat
     });
 
     return {

--- a/IPython/html/static/widgets/js/widget_int.js
+++ b/IPython/html/static/widgets/js/widget_int.js
@@ -165,12 +165,12 @@ define([
         handleKeyDown: function(e) {
             if (e.keyCode == 13) {
                 e.preventDefault();
-                this.handleTextChange(e);
+                this.handleTextChange();
             }
         },
 
-        handleTextChange: function(e) {
-            var text = $(e.target).text().trim();
+        handleTextChange: function() {
+            var text = this.$readout.text();
             var value = this._validate_text_input(text);
             if (isNaN(value)) {
                 this.$readout.text(this.model.get('value'));

--- a/IPython/html/static/widgets/js/widget_int.js
+++ b/IPython/html/static/widgets/js/widget_int.js
@@ -188,8 +188,8 @@ define([
                 // ranges can be expressed either "val-val" or "val:val" (+spaces)
                 var match = this._range_regex.exec(text);
                 if (match) {
-                    var values = [this._parse_text_input(match[1]),
-                                  this._parse_text_input(match[2])];
+                    var values = [this._parse_value(match[1]),
+                                  this._parse_value(match[2])];
                     // reject input where NaN or lower > upper
                     if (isNaN(values[0]) ||
                         isNaN(values[1]) ||
@@ -214,7 +214,7 @@ define([
                 }
             } else {
                 // single value case
-                var value = this._parse_text_input(text);
+                var value = this._parse_value(text);
                 if (isNaN(value)) {
                     this.$readout.text(this.model.get('value'));
                 } else {
@@ -231,7 +231,7 @@ define([
             }
         },
 
-        _parse_text_input: parseInt,
+        _parse_value: parseInt,
 
         _range_regex: /^\s*([+-]?\d+)\s*[-:]\s*([+-]?\d+)/,
 
@@ -362,10 +362,7 @@ define([
             }
         },
 
-        _parse_value: function(value) {
-            // Parse the value stored in a string.
-            return  parseInt(value);
-        },
+        _parse_value: parseInt
     });
 
 

--- a/IPython/html/static/widgets/js/widget_int.js
+++ b/IPython/html/static/widgets/js/widget_int.js
@@ -158,8 +158,16 @@ define([
         events: {
             // Dictionary of events and their handlers.
             "slide" : "handleSliderChange",
-            "blur [contentEditable=true]": "handleTextChange"
+            "blur [contentEditable=true]": "handleTextChange",
+            "keydown [contentEditable=true]": "handleKeyDown"
         }, 
+
+        handleKeyDown: function(e) {
+            if (e.keyCode == 13) {
+                e.preventDefault();
+                this.handleTextChange(e);
+            }
+        },
 
         handleTextChange: function(e) {
             var text = $(e.target).text().trim();

--- a/IPython/html/static/widgets/js/widget_int.js
+++ b/IPython/html/static/widgets/js/widget_int.js
@@ -4,8 +4,9 @@
 define([
     "widgets/js/widget",
     "jqueryui",
-    "bootstrap",
-], function(widget, $){
+    "base/js/keyboard",
+    "bootstrap"
+], function(widget, $, keyboard){
     
     var IntSliderView = widget.DOMWidgetView.extend({
         render : function(){
@@ -163,7 +164,7 @@ define([
         }, 
 
         handleKeyDown: function(e) {
-            if (e.keyCode == 13) {
+            if (e.keyCode == keyboard.keycodes.enter) {
                 e.preventDefault();
                 this.handleTextChange();
             }


### PR DESCRIPTION
This adds "click-to-edit" to the text readout to the right of a slider, allowing precise values to be set.

Changes are entirely on the javascript. Editing is handled using the HTML5 `contentEditable` attribute rather than explicitly creating any input widget. The modified value is committed by either clicking outside the text, or pressing enter. Works for both `Int` and `FloatSliderView`.

The new value is validated for float/int and min/max, but the step size (if set) is not enforced.

This will need updating if #6050 is merged.
