### PR TITLE
Instances of WidgetView do not trigger widget_area.show anymore.

### DIFF
--- a/IPython/html/static/widgets/js/manager.js
+++ b/IPython/html/static/widgets/js/manager.js
@@ -66,12 +66,11 @@ define([
             if (view === null) {
                 console.error("View creation failed", model);
             }
+            this._handle_display_view(view);
             if (cell.widget_subarea) {
-                cell.widget_area.show();
-                this._handle_display_view(view);
                 cell.widget_subarea.append(view.$el);
-                    view.trigger('displayed');
             }
+            view.trigger('displayed');
         }
     };
 

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -370,6 +370,14 @@ define(["widgets/js/manager",
             // By default, this is only called the first time the view is created
         },
 
+        show: function(){
+            // Show the widget-area
+            if (this.options && this.options.cell &&
+                this.options.cell.widget_area !== undefined) {
+                this.options.cell.widget_area.show();
+            }
+        },
+
         send: function (content) {
             // Send a custom msg associated with this view.
             this.model.send(content, this.callbacks());
@@ -390,6 +398,7 @@ define(["widgets/js/manager",
             this.model.on('change', this.update, this);
             this.model.on('msg:custom', this.on_msg, this);
             DOMWidgetView.__super__.initialize.apply(this, arguments);
+            this.on('displayed', this.show, this);
         },
         
         on_msg: function(msg) {


### PR DESCRIPTION
This solves Issue #5997. 
The call to `widget_area.show` is triggered by the `displayed` event of the DOMWidgetView.  
