### PR TITLE
Remove / from route of TreeRedirectHandler.

### DIFF
--- a/IPython/html/tree/handlers.py
+++ b/IPython/html/tree/handlers.py
@@ -97,5 +97,5 @@ default_handlers = [
     (r"/tree%s" % notebook_path_regex, TreeHandler),
     (r"/tree%s" % path_regex, TreeHandler),
     (r"/tree", TreeHandler),
-    (r"/", TreeRedirectHandler),
+    (r"", TreeRedirectHandler),
     ]


### PR DESCRIPTION
When base_url is set, navigating to http://{url}/{base_url} returns 404

This is due to the TreeRedirectHandler only picking up http://{url}/{base_url}/ and the TrailingSlashHandler being set to {base_url}/.*/.

This change will cause http://{url}/{base_url} to correctly redirect to http://{url}/{base_url}/tree, as expected.

When base_url is not set, the TrailingSlashHandler will redirect http://{url}/ to http://{url}, so this will not affect that situation.

This issue affects 2.x and 3.x.
