### PR TITLE
return global events from require(['base/js/events']).

### DIFF
--- a/IPython/html/static/base/js/events.js
+++ b/IPython/html/static/base/js/events.js
@@ -13,7 +13,7 @@ define(['base/js/namespace', 'jquery'], function(IPython, $) {
 
     var Events = function () {};
     
-    var events = $([new Events()]);
+    var events = new Events();
     
     // Backwards compatability.
     IPython.Events = Events;

--- a/IPython/html/static/base/js/events.js
+++ b/IPython/html/static/base/js/events.js
@@ -4,16 +4,20 @@
 // Give us an object to bind all events to. This object should be created
 // before all other objects so it exists when others register event handlers.
 // To trigger an event handler:
-// $([IPython.events]).trigger('event.Namespace');
-// To handle it:
-// $([IPython.events]).on('event.Namespace',function () {});
-define(['base/js/namespace'], function(IPython) {
+// require(['base/js/events'], function (events) {
+//     events.on("event.Namespace", function () {do_stuff(); });
+// })
+
+define(['base/js/namespace', 'jquery'], function(IPython, $) {
     "use strict";
 
     var Events = function () {};
     
+    var events = $([new Events()]);
+    
     // Backwards compatability.
     IPython.Events = Events;
+    IPython.events = events;
     
-    return {'Events': Events};
+    return $([events]);
 });

--- a/IPython/html/static/base/js/events.js
+++ b/IPython/html/static/base/js/events.js
@@ -3,10 +3,11 @@
 
 // Give us an object to bind all events to. This object should be created
 // before all other objects so it exists when others register event handlers.
-// To trigger an event handler:
+// To register an event handler:
+//
 // require(['base/js/events'], function (events) {
-//     events.on("event.Namespace", function () {do_stuff(); });
-// })
+//     events.on("event.Namespace", function () { do_stuff(); });
+// });
 
 define(['base/js/namespace', 'jquery'], function(IPython, $) {
     "use strict";

--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -50,7 +50,6 @@ require([
     var user_config = $.extend({}, config.default_config);
     var page = new page.Page();
     var layout_manager = new layoutmanager.LayoutManager();
-    var events = $([new events.Events()]);
     var pager = new pager.Pager('div#pager', 'div#pager_splitter', {
         layout_manager: layout_manager, 
         events: events});

--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -18,6 +18,7 @@ require([
     'notebook/js/savewidget',
     'notebook/js/keyboardmanager',
     'notebook/js/config',
+    // only loaded, not used:
     'custom/custom',
 ], function(
     IPython, 

--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -125,7 +125,6 @@ require([
     IPython.menubar = menubar;
     IPython.toolbar = toolbar;
     IPython.notification_area = notification_area;
-    IPython.events = events;
     IPython.keyboard_manager = keyboard_manager;
     IPython.save_widget = save_widget;
     IPython.config = user_config;

--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -18,6 +18,7 @@ require([
     'notebook/js/savewidget',
     'notebook/js/keyboardmanager',
     'notebook/js/config',
+    'custom/custom',
 ], function(
     IPython, 
     $,
@@ -113,11 +114,8 @@ require([
         // only do this once
         events.off('notebook_loaded.Notebook', first_load);
     };
-    
     events.on('notebook_loaded.Notebook', first_load);
-    events.trigger('app_initialized.NotebookApp');
-    notebook.load_notebook(common_options.notebook_name, common_options.notebook_path);
-
+    
     IPython.page = page;
     IPython.layout_manager = layout_manager;
     IPython.notebook = notebook;
@@ -132,4 +130,8 @@ require([
     IPython.save_widget = save_widget;
     IPython.config = user_config;
     IPython.tooltip = notebook.tooltip;
+
+    events.trigger('app_initialized.NotebookApp');
+    notebook.load_notebook(common_options.notebook_name, common_options.notebook_path);
+
 });

--- a/IPython/html/static/tree/js/main.js
+++ b/IPython/html/static/tree/js/main.js
@@ -99,7 +99,6 @@ require([
     IPython.session_list = session_list;
     IPython.kernel_list = kernel_list;
     IPython.login_widget = login_widget;
-    IPython.events = events;
 
     events.trigger('app_initialized.DashboardApp');
     

--- a/IPython/html/static/tree/js/main.js
+++ b/IPython/html/static/tree/js/main.js
@@ -32,7 +32,6 @@ require([
         base_url: utils.get_body_data("baseUrl"),
         notebook_path: utils.get_body_data("notebookPath"),
     };
-    events = $([new events.Events()]);
     session_list = new sesssionlist.SesssionList($.extend({
         events: events}, 
         common_options));

--- a/IPython/html/static/tree/js/main.js
+++ b/IPython/html/static/tree/js/main.js
@@ -12,6 +12,7 @@ require([
     'tree/js/sessionlist',
     'tree/js/kernellist',
     'auth/js/loginwidget',
+    // only loaded, not used:
     'jqueryui',
     'bootstrap',
     'custom/custom',

--- a/IPython/html/static/tree/js/main.js
+++ b/IPython/html/static/tree/js/main.js
@@ -14,6 +14,7 @@ require([
     'auth/js/loginwidget',
     'jqueryui',
     'bootstrap',
+    'custom/custom',
 ], function(
     IPython, 
     $, 
@@ -90,6 +91,16 @@ require([
     enable_autorefresh();
 
     page.show();
+
+    // For backwards compatability.
+    IPython.page = page;
+    IPython.notebook_list = notebook_list;
+    IPython.cluster_list = cluster_list;
+    IPython.session_list = session_list;
+    IPython.kernel_list = kernel_list;
+    IPython.login_widget = login_widget;
+    IPython.events = events;
+
     events.trigger('app_initialized.DashboardApp');
     
     // bound the upload method to the on change of the file select list
@@ -107,12 +118,4 @@ require([
         $("#tabs").find("a[href=" + window.location.hash + "]").click();
     }
 
-    // For backwards compatability.
-    IPython.page = page;
-    IPython.notebook_list = notebook_list;
-    IPython.cluster_list = cluster_list;
-    IPython.session_list = session_list;
-    IPython.kernel_list = kernel_list;
-    IPython.login_widget = login_widget;
-    IPython.events = events;
 });

--- a/IPython/html/templates/page.html
+++ b/IPython/html/templates/page.html
@@ -98,8 +98,6 @@
 {% block script %}
 {% endblock %}
 
-<script src="{{static_url("custom/custom.js") }}" type="text/javascript" charset="utf-8"></script>
-
 </body>
 
 </html>

--- a/IPython/html/tests/notebook/save.js
+++ b/IPython/html/tests/notebook/save.js
@@ -9,16 +9,18 @@ casper.notebook_test(function () {
     var nbname = "has#hash and space and unicø∂e.ipynb";
     
     this.evaluate(function (nbname) {
-        IPython.notebook.notebook_name = nbname;
-        IPython._save_success = IPython._save_failed = false;
-        IPython.events.on('notebook_saved.Notebook', function () {
-            IPython._save_success = true;
+        require(['base/js/events'], function (events) {
+            IPython.notebook.notebook_name = nbname;
+            IPython._save_success = IPython._save_failed = false;
+            events.on('notebook_saved.Notebook', function () {
+                IPython._save_success = true;
+            });
+            events.on('notebook_save_failed.Notebook',
+                function (event, xhr, status, error) {
+                    IPython._save_failed = "save failed with " + xhr.status + xhr.responseText;
+            });
+            IPython.notebook.save_notebook();
         });
-        IPython.events.on('notebook_save_failed.Notebook',
-            function (event, xhr, status, error) {
-                IPython._save_failed = "save failed with " + xhr.status + xhr.responseText;
-        });
-        IPython.notebook.save_notebook();
     }, {nbname:nbname});
     
     this.waitFor(function () {
@@ -41,10 +43,12 @@ casper.notebook_test(function () {
     });
     
     this.thenEvaluate(function(){
-        IPython.events.on('checkpoint_created.Notebook', function (evt, data) {
-            IPython._checkpoint_created = true;
-        });
         IPython._checkpoint_created = false;
+        require(['base/js/events'], function (events) {
+            events.on('checkpoint_created.Notebook', function (evt, data) {
+                IPython._checkpoint_created = true;
+            });
+        });
         IPython.notebook.save_checkpoint();
     });
     
@@ -71,7 +75,7 @@ casper.notebook_test(function () {
     this.then(function(){
         var notebook_url = this.evaluate(function(nbname){
             var escaped_name = encodeURIComponent(nbname);
-            var return_this_thing;
+            var return_this_thing = null;
             $("a.item_link").map(function (i,a) {
                 if (a.href.indexOf(escaped_name) >= 0) {
                     return_this_thing = a.href;

--- a/IPython/html/tests/util.js
+++ b/IPython/html/tests/util.js
@@ -47,9 +47,8 @@ casper.open_new_notebook = function () {
 casper.page_loaded = function() {
     // Return whether or not the kernel is running.
     return this.evaluate(function() {
-        return IPython !== undefined && 
-            IPython.page !== undefined && 
-            IPython.events !== undefined;
+        return IPython !== undefined &&
+            IPython.page !== undefined;
     });
 };
 

--- a/IPython/html/tests/util.js
+++ b/IPython/html/tests/util.js
@@ -26,11 +26,14 @@ casper.open_new_notebook = function () {
     this.waitFor(this.kernel_running);
     // track the IPython busy/idle state
     this.thenEvaluate(function () {
-        IPython.events.on('status_idle.Kernel',function () {
-            IPython._status = 'idle';
-        });
-        IPython.events.on('status_busy.Kernel',function () {
-            IPython._status = 'busy';
+        require(['base/js/namespace', 'base/js/events'], function (IPython, events) {
+        
+            events.on('status_idle.Kernel',function () {
+                IPython._status = 'idle';
+            });
+            events.on('status_busy.Kernel',function () {
+                IPython._status = 'busy';
+            });
         });
     });
 


### PR DESCRIPTION
In master, it is impossible to register with IPython events in custom.js without setting timeouts because the events doesn't exist yet.

You can now load events in custom.js with:

``` javascript
require(["base/js/events"], function (events) {

        events.on("notebook_loaded.Notebook", function () {
            console.log("The notebook finished loading!");
        });
});
```
