### PR TITLE
Only allow iframe embedding on same origin.

### DIFF
--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -39,6 +39,10 @@ class AuthenticatedHandler(web.RequestHandler):
 
     def set_default_headers(self):
         headers = self.settings.get('headers', {})
+
+        if "X-Frame-Options" not in headers:
+            headers["X-Frame-Options"] = "SAMEORIGIN"
+
         for header_name,value in headers.items() :
             try:
                 self.set_header(header_name, value)

--- a/IPython/html/services/kernels/tests/test_kernels_api.py
+++ b/IPython/html/services/kernels/tests/test_kernels_api.py
@@ -65,6 +65,8 @@ class KernelAPITest(NotebookTestBase):
         self.assertEqual(r.status_code, 201)
         self.assertIsInstance(kern1, dict)
 
+        self.assertEqual(r.headers['x-frame-options'], "SAMEORIGIN")
+
         # GET request
         r = self.kern_api.list()
         self.assertEqual(r.status_code, 200)

--- a/docs/source/whatsnew/pr/incompat-only-same-origin-iframe-embedding.rst
+++ b/docs/source/whatsnew/pr/incompat-only-same-origin-iframe-embedding.rst
@@ -1,0 +1,11 @@
+The IPython Notebook and its APIs by default will only be allowed to be
+embedded in an iframe on the same origin.
+
+To override this, set ``headers[X-Frame-Options]`` to one of
+
+* DENY
+* SAMEORIGIN
+* ALLOW-FROM uri
+
+See `Mozilla's guide to X-Frame-Options<https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options>`_ for more examples.
+


### PR DESCRIPTION
This sets the iframe security policy by default to only allow same origin embedding of the notebook. This can be overridden by changing `headers['X-Frame-Options']`.
