### PR TITLE
Support echoing output from other clients

### DIFF
--- a/IPython/qt/console/console_widget.py
+++ b/IPython/qt/console/console_widget.py
@@ -519,7 +519,15 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, QtGui.
     #---------------------------------------------------------------------------
     # 'ConsoleWidget' public interface
     #---------------------------------------------------------------------------
-
+    
+    include_other_output = Bool(False, config=True,
+        help="""Whether to include output from clients
+        other than this one sharing the same kernel.
+        
+        Outputs are not displayed until enter is pressed.
+        """
+    )
+    
     def can_copy(self):
         """ Returns whether text can be copied to the clipboard.
         """

--- a/IPython/qt/console/frontend_widget.py
+++ b/IPython/qt/console/frontend_widget.py
@@ -350,7 +350,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
     #---------------------------------------------------------------------------
     def _handle_clear_output(self, msg):
         """Handle clear output messages."""
-        if not self._hidden and self._is_from_this_session(msg):
+        if include_output(msg):
             wait = msg['content'].get('wait', True)
             if wait:
                 self._pending_clearoutput = True
@@ -523,7 +523,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         """ Handle display hook output.
         """
         self.log.debug("execute_result: %s", msg.get('content', ''))
-        if not self._hidden and self._is_from_this_session(msg):
+        if self.include_output(msg):
             self.flush_clearoutput()
             text = msg['content']['data']
             self._append_plain_text(text + '\n', before_prompt=True)
@@ -532,7 +532,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         """ Handle stdout, stderr, and stdin.
         """
         self.log.debug("stream: %s", msg.get('content', ''))
-        if not self._hidden and self._is_from_this_session(msg):
+        if self.include_output(msg):
             self.flush_clearoutput()
             self.append_stream(msg['content']['text'])
 
@@ -541,7 +541,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         """
         self.log.info("shutdown: %s", msg.get('content', ''))
         restart = msg.get('content', {}).get('restart', False)
-        if not self._hidden and not self._is_from_this_session(msg):
+        if not self._hidden and not self.from_here(msg):
             # got shutdown reply, request came from session other than ours
             if restart:
                 # someone restarted the kernel, handle it

--- a/IPython/qt/console/ipython_widget.py
+++ b/IPython/qt/console/ipython_widget.py
@@ -219,16 +219,24 @@ class IPythonWidget(FrontendWidget):
                 items.append(cell)
                 last_cell = cell
         self._set_history(items)
-
+    
+    def _insert_other_input(self, cursor, content):
+        """Insert function for input from other frontends"""
+        cursor.beginEditBlock()
+        start = cursor.position()
+        n = content.get('execution_count', 0)
+        cursor.insertText('\n')
+        self._insert_html(cursor, self._make_in_prompt(n))
+        cursor.insertText(content['code'])
+        self._highlighter.rehighlightBlock(cursor.block())
+        cursor.endEditBlock()
+        
     def _handle_execute_input(self, msg):
         """Handle an execute_input message"""
         self.log.debug("execute_input: %s", msg.get('content', ''))
         if self.include_output(msg):
-            content = msg['content']
-            prompt_number = content.get('execution_count', 0)
-            self._append_html(self._make_in_prompt(prompt_number), True)
-            self._append_plain_text(content['code'], True)
-        
+            self._append_custom(self._insert_other_input, msg['content'], before_prompt=True)
+
     
     def _handle_execute_result(self, msg):
         """ Reimplemented for IPython-style "display hook".

--- a/IPython/qt/console/rich_ipython_widget.py
+++ b/IPython/qt/console/rich_ipython_widget.py
@@ -107,7 +107,7 @@ class RichIPythonWidget(IPythonWidget):
     def _handle_execute_result(self, msg):
         """ Overridden to handle rich data types, like SVG.
         """
-        if not self._hidden and self._is_from_this_session(msg):
+        if self.include_output(msg):
             self.flush_clearoutput()
             content = msg['content']
             prompt_number = content.get('execution_count', 0)
@@ -146,7 +146,7 @@ class RichIPythonWidget(IPythonWidget):
     def _handle_display_data(self, msg):
         """ Overridden to handle rich data types, like SVG.
         """
-        if not self._hidden and self._is_from_this_session(msg):
+        if self.include_output(msg):
             self.flush_clearoutput()
             data = msg['content']['data']
             metadata = msg['content']['metadata']


### PR DESCRIPTION
in the zmq console

Can result in outputs like:

```
In [1]: 1
[remote]In [1]: 1
[remote]Out[1]: 1
[remote]In [2]: 3
[remote]Out[2]: 3
Out[3]: 1
```

Note that there will be inconsistencies in prompt numbers because some execution may take place after the in-prompt is drawn.

closes #1873
- [x] support remote output in terminal
- [x] support remote output in qtconsole
- [x] finish sentences
