### PR TITLE
Widget trait serialization

### DIFF
--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -213,7 +213,7 @@ define(["widgets/js/manager",
             var that = this;
             var packed;
             if (value instanceof Backbone.Model) {
-                return value.id;
+                return "IPY_MODEL_" + value.id;
 
             } else if ($.isArray(value)) {
                 packed = [];
@@ -252,13 +252,15 @@ define(["widgets/js/manager",
                 });
                 return unpacked;
 
+            } else if (typeof value === 'string' && value.slice(0,10) === "IPY_MODEL_") {
+		var model = this.widget_manager.get_model(value.slice(10, value.length));
+		if (model) {
+		    return model;
+		} else {
+		    return value;
+		}
             } else {
-                var model = this.widget_manager.get_model(value);
-                if (model) {
-                    return model;
-                } else {
                     return value;
-                }
             }
         },
 

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -322,7 +322,7 @@ class Widget(LoggingConfigurable):
         elif isinstance(x, (list, tuple)):
             return [self._serialize_trait(v) for v in x]
         elif isinstance(x, Widget):
-            return x.model_id
+            return "IPY_MODEL_" + x.model_id
         else:
             return x # Value must be JSON-able
 
@@ -335,7 +335,7 @@ class Widget(LoggingConfigurable):
             return {k: self._unserialize_trait(v) for k, v in x.items()}
         elif isinstance(x, (list, tuple)):
             return [self._unserialize_trait(v) for v in x]
-        elif isinstance(x, string_types) and x in Widget.widgets:
+        elif isinstance(x, string_types) and x.startswith('IPY_MODEL_') and x[10:] in Widget.widgets:
             # we want to support having child widgets at any level in a hierarchy
             # trusting that a widget UUID will not appear out in the wild
             return Widget.widgets[x]

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -198,11 +198,10 @@ class Widget(LoggingConfigurable):
         state = {}
         for k in keys:
             f = self.trait_metadata(k, 'serialize')
-            value = getattr(self, k)       
-            if f is not None:
-                state[k] = f(value)
-            else:
-                state[k] = self._serialize_trait(value)
+            if f is None:
+                f = self._serialize_trait
+            value = getattr(self, k)
+            state[k] = f(value)
         return state
     
     def send(self, content):
@@ -289,10 +288,9 @@ class Widget(LoggingConfigurable):
         for name in self.keys:
             if name in sync_data:
                 f = self.trait_metadata(name, 'deserialize')
-                if f is not None:
-                    value = f(sync_data[name])
-                else:
-                    value = self._deserialize_trait(sync_data[name])
+                if f is None:
+                    f = self._deserialize_trait
+                value = f(sync_data[name])
                 with self._lock_property(name, value):
                     setattr(self, name, value)
 

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -560,6 +560,27 @@ class TestInstance(TestCase):
         self.assertRaises(TraitError, setattr, a, 'inst', Bar)
         self.assertRaises(TraitError, setattr, a, 'inst', Bah())
 
+    def test_default_klass(self):
+        class Foo(object): pass
+        class Bar(Foo): pass
+        class Bah(object): pass
+
+        class FooInstance(Instance):
+            klass = Foo
+
+        class A(HasTraits):
+            inst = FooInstance()
+
+        a = A()
+        self.assertTrue(a.inst is None)
+        a.inst = Foo()
+        self.assertTrue(isinstance(a.inst, Foo))
+        a.inst = Bar()
+        self.assertTrue(isinstance(a.inst, Foo))
+        self.assertRaises(TraitError, setattr, a, 'inst', Foo)
+        self.assertRaises(TraitError, setattr, a, 'inst', Bar)
+        self.assertRaises(TraitError, setattr, a, 'inst', Bah())
+
     def test_unique_default_value(self):
         class Foo(object): pass
         class A(HasTraits):

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -809,7 +809,11 @@ class Instance(ClassBasedTraitType):
     """A trait whose value must be an instance of a specified class.
 
     The value can also be an instance of a subclass of the specified class.
+
+    Subclasses can declare default classes by overriding the klass attribute
     """
+
+    klass = None
 
     def __init__(self, klass=None, args=None, kw=None,
                  allow_none=True, **metadata ):
@@ -836,14 +840,17 @@ class Instance(ClassBasedTraitType):
         -----
         If both ``args`` and ``kw`` are None, then the default value is None.
         If ``args`` is a tuple and ``kw`` is a dict, then the default is
-        created as ``klass(*args, **kw)``.  If either ``args`` or ``kw`` is
-        not (but not both), None is replace by ``()`` or ``{}``.
+        created as ``klass(*args, **kw)``.  If exactly one of ``args`` or ``kw`` is
+        None, the None is replaced by ``()`` or ``{}``, respectively.
         """
-
-        if (klass is None) or (not (inspect.isclass(klass) or isinstance(klass, py3compat.string_types))):
-            raise TraitError('The klass argument must be a class'
-                                ' you gave: %r' % klass)
-        self.klass = klass
+        if klass is None:
+            klass = self.klass
+        
+        if (klass is not None) and (inspect.isclass(klass) or isinstance(klass, py3compat.string_types)):
+            self.klass = klass
+        else:
+            raise TraitError('The klass attribute must be a class'
+                                ' not: %r' % klass)
 
         # self.klass is a class, so handle default_value
         if args is None and kw is None:


### PR DESCRIPTION
Here's a rough draft of a pull request to enable custom serialization for traits on widgets.  I also added a default klass attribute to the Instance traitlet, so you could subclass Instance to easily get a new traitlet for a certain class.  Here is an example where this is useful:

``` python
def np_to_list(a):
    if a is not None:
        return a.tolist()
def np_from_list(a):
    if a is not None:
        return np.array(a)

class NDArray(Instance):
    klass = np.ndarray
    metadata = {'serialize': np_to_list,
                'deserialize': np_from_list}
```

Then the NDArray traitlet will by default have the klass and some custom metadata.

TODO:
- [x] Change "unserialize" to "deserialize".  It seems that everyone but PHP talks about deserialization rather than unserialization.
- [x] possibly change from/to_json to serialize/deserialize.  This leaves the door open to having binary buffers also transferred when the changes Min made last week regarding binary buffers in Comm messages percolate upwards to widgets.
- [ ] write tests for traitlets
