### PR TITLE
pin tornado to < 4 on travis js tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ before_install:
     - time sudo add-apt-repository -y ppa:pcarrier/ppa
     - time sudo apt-get update
     - time sudo apt-get install pandoc casperjs nodejs libzmq3-dev
+    # pin tornado < 4 for js tests while phantom is on super old webkit
+    - if [[ $GROUP == 'js' ]]; then pip install 'tornado<4'; fi
     - time pip install -f https://nipy.bic.berkeley.edu/wheelhouse/travis jinja2 sphinx pygments tornado requests mock pyzmq jsonschema jsonpointer
     - time npm install -g requirejs jquery
 install:


### PR DESCRIPTION
Current phantom uses an old webkit that implemented draft76 of web sockets.

Tornado 4 drops support for draft76.

This doesn’t affect any real browsers, as far as I can tell.
