### PR TITLE
Automatically open a comm on creation of widgets

### DIFF
--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -123,6 +123,7 @@ class Widget(LoggingConfigurable):
 
         self.on_trait_change(self._handle_property_changed, self.keys)
         Widget._call_widget_constructed(self)
+        self.open()
 
     def __del__(self):
         """Object disposal"""
@@ -137,6 +138,11 @@ class Widget(LoggingConfigurable):
         """Gets the Comm associated with this widget.
 
         If a Comm doesn't exist yet, a Comm will be created automagically."""
+        self.open()
+        return self._comm
+    
+    def open(self):
+        """Open a comm to the frontend if one isn't already open."""
         if self._comm is None:
             # Create a comm.
             self._comm = Comm(target_name=self._model_name)
@@ -146,8 +152,7 @@ class Widget(LoggingConfigurable):
 
             # first update
             self.send_state()
-        return self._comm
-    
+
     @property
     def model_id(self):
         """Gets the model id of this widget.

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -100,7 +100,7 @@ class Widget(LoggingConfigurable):
         registered in the front-end to create and sync this widget with.""")
     _view_name = Unicode(help="""Default view registered in the front-end
         to use to represent the widget.""", sync=True)
-    _comm = Instance('IPython.kernel.comm.Comm')
+    comm = Instance('IPython.kernel.comm.Comm')
     
     msg_throttle = Int(3, sync=True, help="""Maximum number of msgs the 
         front-end can send before receiving an idle msg from the back-end.""")
@@ -133,21 +133,13 @@ class Widget(LoggingConfigurable):
     # Properties
     #-------------------------------------------------------------------------
 
-    @property
-    def comm(self):
-        """Gets the Comm associated with this widget.
-
-        If a Comm doesn't exist yet, a Comm will be created automagically."""
-        self.open()
-        return self._comm
-    
     def open(self):
         """Open a comm to the frontend if one isn't already open."""
-        if self._comm is None:
+        if self.comm is None:
             # Create a comm.
-            self._comm = Comm(target_name=self._model_name)
-            self._comm.on_msg(self._handle_msg)
-            self._comm.on_close(self._close)
+            self.comm = Comm(target_name=self._model_name)
+            self.comm.on_msg(self._handle_msg)
+            self.comm.on_close(self._close)
             Widget.widgets[self.model_id] = self
 
             # first update
@@ -166,7 +158,7 @@ class Widget(LoggingConfigurable):
     def _close(self):
         """Private close - cleanup objects, registry entries"""
         del Widget.widgets[self.model_id]
-        self._comm = None
+        self.comm = None
 
     def close(self):
         """Close method.
@@ -174,8 +166,8 @@ class Widget(LoggingConfigurable):
         Closes the widget which closes the underlying comm.
         When the comm is closed, all of the widget views are automatically
         removed from the front-end."""
-        if self._comm is not None:
-            self._comm.close()
+        if self.comm is not None:
+            self.comm.close()
             self._close()
 
     def send_state(self, key=None):

--- a/IPython/kernel/comm/comm.py
+++ b/IPython/kernel/comm/comm.py
@@ -50,7 +50,9 @@ class Comm(LoggingConfigurable):
         if target_name:
             kwargs['target_name'] = target_name
         super(Comm, self).__init__(**kwargs)
-        get_ipython().comm_manager.register_comm(self)
+        ip = get_ipython()
+        if hasattr(ip, 'comm_manager'):
+            ip.comm_manager.register_comm(self)
         if self.primary:
             # I am primary, open my peer.
             self.open(data)

--- a/IPython/kernel/comm/comm.py
+++ b/IPython/kernel/comm/comm.py
@@ -23,7 +23,7 @@ class Comm(LoggingConfigurable):
         return self.shell.kernel.iopub_socket
     session = Instance('IPython.kernel.zmq.session.Session')
     def _session_default(self):
-        if self.shell is None:
+        if self.shell is None or not hasattr(self.shell, 'kernel'):
             return
         return self.shell.kernel.session
     
@@ -59,15 +59,16 @@ class Comm(LoggingConfigurable):
     
     def _publish_msg(self, msg_type, data=None, metadata=None, **keys):
         """Helper for sending a comm message on IOPub"""
-        data = {} if data is None else data
-        metadata = {} if metadata is None else metadata
-        content = json_clean(dict(data=data, comm_id=self.comm_id, **keys))
-        self.session.send(self.iopub_socket, msg_type,
-            content,
-            metadata=json_clean(metadata),
-            parent=self.shell.get_parent(),
-            ident=self.topic,
-        )
+        if self.session is not None:
+            data = {} if data is None else data
+            metadata = {} if metadata is None else metadata
+            content = json_clean(dict(data=data, comm_id=self.comm_id, **keys))
+            self.session.send(self.iopub_socket, msg_type,
+                content,
+                metadata=json_clean(metadata),
+                parent=self.shell.get_parent(),
+                ident=self.topic,
+            )
     
     def __del__(self):
         """trigger close on gc"""


### PR DESCRIPTION
This will immediately create a model on the javascript side when a widget is created.  This means that, for example, a widget that only interacts with its model can work without "displaying" it.
