### PR TITLE
Prefixing model id in _pack/_unpack

### DIFF
--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -213,7 +213,7 @@ define(["widgets/js/manager",
             var that = this;
             var packed;
             if (value instanceof Backbone.Model) {
-                return value.id;
+                return "IPY_MODEL_".concat(value.id);
 
             } else if ($.isArray(value)) {
                 packed = [];
@@ -252,13 +252,15 @@ define(["widgets/js/manager",
                 });
                 return unpacked;
 
-            } else {
-                var model = this.widget_manager.get_model(value);
+            } else if (typeof(value) === 'string') {
+                var model = this.widget_manager.get_model(value.slice(10, value.length));
                 if (model) {
                     return model;
                 } else {
                     return value;
                 }
+            } else {
+                return value;
             }
         },
 

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -309,7 +309,7 @@ class Widget(LoggingConfigurable):
         elif isinstance(x, (list, tuple)):
             return [self._pack_widgets(v) for v in x]
         elif isinstance(x, Widget):
-            return x.model_id
+            return 'IPY_MODEL_' + x.model_id
         else:
             return x # Value must be JSON-able
 

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -323,7 +323,7 @@ class Widget(LoggingConfigurable):
         elif isinstance(x, (list, tuple)):
             return [self._unpack_widgets(v) for v in x]
         elif isinstance(x, string_types):
-            return x if x not in Widget.widgets else Widget.widgets[x]
+            return x if len(x) < 11 or x[10:] not in Widget.widgets else Widget.widgets[x[10:]]
         else:
             return x
 


### PR DESCRIPTION
This solves Issue #6150 by prefixing model ids with `IPY_MODEL` before packing widgets. 
