### PR TITLE
Make Container widgets take children as the first positional argument

### DIFF
--- a/IPython/html/widgets/widget_container.py
+++ b/IPython/html/widgets/widget_container.py
@@ -15,9 +15,9 @@ class ContainerWidget(DOMWidget):
     # Child widgets in the container.
     # Using a tuple here to force reassignment to update the list.
     # When a proper notifying-list trait exists, that is what should be used here.
-    children = Tuple(sync=True)
+    children = Tuple(sync=True, allow_none=False)
 
-    def __init__(self, children = None, **kwargs):
+    def __init__(self, children = (), **kwargs):
         kwargs['children'] = children
         super(ContainerWidget, self).__init__(**kwargs)
         self.on_displayed(ContainerWidget._fire_children_displayed)

--- a/IPython/html/widgets/widget_container.py
+++ b/IPython/html/widgets/widget_container.py
@@ -17,7 +17,8 @@ class ContainerWidget(DOMWidget):
     # When a proper notifying-list trait exists, that is what should be used here.
     children = Tuple(sync=True)
 
-    def __init__(self, **kwargs):
+    def __init__(self, children = None, **kwargs):
+        kwargs['children'] = children
         super(ContainerWidget, self).__init__(**kwargs)
         self.on_displayed(ContainerWidget._fire_children_displayed)
 


### PR DESCRIPTION
This makes creating containers less cumbersome: Container([list, of, children]), rather than Container(children=[list, of, children])
