### PR TITLE
Span in CellToolBar instead of div

### DIFF
--- a/IPython/html/static/notebook/js/celltoolbar.js
+++ b/IPython/html/static/notebook/js/celltoolbar.js
@@ -342,7 +342,7 @@ define([
                         setter(cell, !v);
                         chkb.attr("checked", !v);
             });
-            button_container.append($('<div/>').append(lbl));
+            button_container.append($('<span/>').append(lbl));
         };
     };
 
@@ -406,7 +406,7 @@ define([
             select.change(function(){
                         setter(cell, select.val());
                     });
-            button_container.append($('<div/>').append(lbl).append(select));
+            button_container.append($('<span/>').append(lbl).append(select));
         };
     };
 


### PR DESCRIPTION
I want to write an extension with multiple select bar. They are supposed to be displayed inline, not in block mode. The better way is to use span instead of div.
