### PR TITLE
once-displayed

### DIFF
--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -275,6 +275,9 @@ define(["widgets/js/manager",
             this.child_views = {};
             this.model.views.push(this);
             this.id = this.id || IPython.utils.uuid();
+            this.on('displayed', function() { 
+                this.is_displayed = true; 
+            }, this);
         },
 
         update: function(){
@@ -385,6 +388,16 @@ define(["widgets/js/manager",
 
         touch: function () {
             this.model.save_changes(this.callbacks());
+        },
+
+        once_displayed: function (callback, context) {
+            // Calls the callback right away is the view is already displayed
+            // otherwise, register the callback to the 'displayed' event.
+            if (this.is_displayed) {
+                callback.apply(context);
+            } else {
+                this.on('displayed', callback, context);
+            }
         },
     });
 

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -390,7 +390,7 @@ define(["widgets/js/manager",
             this.model.save_changes(this.callbacks());
         },
 
-        once_displayed: function (callback, context) {
+        after_displayed: function (callback, context) {
             // Calls the callback right away is the view is already displayed
             // otherwise, register the callback to the 'displayed' event.
             if (this.is_displayed) {

--- a/IPython/html/static/widgets/js/widget_container.js
+++ b/IPython/html/static/widgets/js/widget_container.js
@@ -38,7 +38,7 @@ define([
             this.$el.append(view.$el);
 
             // Trigger the displayed event once this view is displayed.
-            this.once_displayed(function() {
+            this.after_displayed(function() {
                 view.trigger('displayed');
             });
         },
@@ -230,7 +230,7 @@ define([
             this.$body.append(view.$el);
 
             // Trigger the displayed event once this view is displayed.
-            this.once_displayed(function() {
+            this.after_displayed(function() {
                 view.trigger('displayed');
             });
         },

--- a/IPython/html/static/widgets/js/widget_container.js
+++ b/IPython/html/static/widgets/js/widget_container.js
@@ -37,7 +37,7 @@ define([
             var view = this.create_child_view(model);
             this.$el.append(view.$el);
 
-            // Trigger the displayed event once this model is displayed.
+            // Trigger the displayed event once this view is displayed.
             this.once_displayed(function() {
                 view.trigger('displayed');
             });
@@ -229,7 +229,7 @@ define([
             var view = this.create_child_view(model);
             this.$body.append(view.$el);
 
-            // Trigger the displayed event once this model is displayed.
+            // Trigger the displayed event once this view is displayed.
             this.once_displayed(function() {
                 view.trigger('displayed');
             });

--- a/IPython/html/static/widgets/js/widget_container.js
+++ b/IPython/html/static/widgets/js/widget_container.js
@@ -17,18 +17,6 @@ define([
                 this.update_children(model.previous('children'), value);
             }, this);
             this.update();
-
-            // Trigger model displayed events for any models that are child to 
-            // this model when this model is displayed.
-            var that = this;
-            this.on('displayed', function(){
-                that.is_displayed = true;
-                for (var property in that.child_views) {
-                    if (that.child_views.hasOwnProperty(property)) {
-                        that.child_views[property].trigger('displayed');
-                    }
-                }
-            });
         },
         
         update_children: function(old_list, new_list) {
@@ -49,10 +37,8 @@ define([
             var view = this.create_child_view(model);
             this.$el.append(view.$el);
 
-            // Trigger the displayed event if this model is displayed.
-            if (this.is_displayed) {
-                view.trigger('displayed');
-            }
+            // Trigger the displayed event once this model is displayed.
+            this.once_displayed(function() { view.trigger('displayed'); }, this);
         },
         
         update: function(){
@@ -179,17 +165,6 @@ define([
                 this.update_children(model.previous('children'), value);
             }, this);
             this.update();
-
-            // Trigger model displayed events for any models that are child to 
-            // this model when this model is displayed.
-            this.on('displayed', function(){
-                that.is_displayed = true;
-                for (var property in that.child_views) {
-                    if (that.child_views.hasOwnProperty(property)) {
-                        that.child_views[property].trigger('displayed');
-                    }
-                }
-            });
         },
         
         hide: function() {
@@ -252,10 +227,10 @@ define([
             var view = this.create_child_view(model);
             this.$body.append(view.$el);
 
-            // Trigger the displayed event if this model is displayed.
-            if (this.is_displayed) {
-                view.trigger('displayed');
-            }
+            // Trigger the displayed event once this model is displayed.
+            this.once_displayed(function() { 
+                view.trigger('displayed'); 
+            }, this);
         },
         
         update: function(){

--- a/IPython/html/static/widgets/js/widget_container.js
+++ b/IPython/html/static/widgets/js/widget_container.js
@@ -38,7 +38,9 @@ define([
             this.$el.append(view.$el);
 
             // Trigger the displayed event once this model is displayed.
-            this.once_displayed(function() { view.trigger('displayed'); }, this);
+            this.once_displayed(function() {
+                view.trigger('displayed');
+            });
         },
         
         update: function(){
@@ -228,9 +230,9 @@ define([
             this.$body.append(view.$el);
 
             // Trigger the displayed event once this model is displayed.
-            this.once_displayed(function() { 
-                view.trigger('displayed'); 
-            }, this);
+            this.once_displayed(function() {
+                view.trigger('displayed');
+            });
         },
         
         update: function(){


### PR DESCRIPTION
I often find myself writing:

``` JavaScript
if(this.is_displayed) {
   // do something which requires the dom to be populated
} else {
    this.on('displayed', function() {
        // do the same thing
    });
}
```

Moreover, the variable `is_displayed` is lacking in general widgets. The new function `once_displayed` is a helper for that. 
It also helps simplifying container widgets. 
