### PR TITLE
remove pagemain.js

### DIFF
--- a/IPython/html/static/base/js/pagemain.js
+++ b/IPython/html/static/base/js/pagemain.js
@@ -1,7 +1,0 @@
-// Copyright (c) IPython Development Team.
-// Distributed under the terms of the Modified BSD License.
-
-require(['base/js/page'], function(page) {
-    var page_instance = new page.Page();
-    page_instance.show();
-});

--- a/IPython/html/templates/page.html
+++ b/IPython/html/templates/page.html
@@ -90,7 +90,6 @@
 </div>
 
 {% block script %}
-<script src="{{static_url("base/js/pagemain.js") }}" type="text/javascript" charset="utf-8"></script>
 {% endblock %}
 
 <script src="{{static_url("custom/custom.js") }}" type="text/javascript" charset="utf-8"></script>


### PR DESCRIPTION
It does not seem to be usefull anymore.

The different main.js of /tree /notebook /etc do create an instance of
`page` themselves, error pages do have hardcoded styles that show header
and sites.
