### PR TITLE
Add reveal.js slide formatting support

### DIFF
--- a/IPython/nbconvert/templates/html/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/html/slides_reveal.tpl
@@ -207,106 +207,113 @@ div.output_prompt {
 
 // Full list of configuration options available here: https://github.com/hakimel/reveal.js#configuration
 Reveal.initialize({
+    {% if nb.metadata.slideshow is defined %}
+        {%- if nb.metadata.slideshow.controls in ['true', 'false'] -%}
+            controls: {{ nb.metadata.slideshow.controls }},
+        {%- else -%}
+            controls: true,
+        {%- endif -%}
 
-    {%- if nb.metadata.slideshow.controls in ['true', 'false'] -%}
-        controls: {{ nb.metadata.slideshow.controls }},
+        {%- if nb.metadata.slideshow.progress in ['true', 'false'] -%}
+            progress: {{ nb.metadata.slideshow.progress }},
+        {%- else -%}
+            progress: true,
+        {%- endif -%}
+
+        {%- if nb.metadata.slideshow.history in ['true', 'false'] -%}
+            history: {{ nb.metadata.slideshow.history }},
+        {%- else -%}
+            history: true,
+        {%- endif -%}
+
+        {%- if nb.metadata.slideshow.slide_number in ['true', 'false'] -%}
+            slideNumber: {{ nb.metadata.slideshow.slide_number }},
+        {%- endif -%}
+
+        {%- if nb.metadata.slideshow.keyboard in ['true', 'false'] -%}
+            keyboard: {{ nb.metadata.slideshow.keyboard }},
+        {%- endif -%}
+
+        {%- if nb.metadata.slideshow.overview in ['true', 'false'] -%}
+            overview: {{ nb.metadata.slideshow.overview }},
+        {%- endif -%}
+
+        {%- if nb.metadata.slideshow.center in ['true', 'false'] -%}
+            center: {{ nb.metadata.slideshow.center }},
+        {%- endif -%}
+
+        {%- if nb.metadata.slideshow.touch in ['true', 'false'] -%}
+            touch: {{ nb.metadata.slideshow.touch }},
+        {%- endif -%}
+
+        {%- if nb.metadata.slideshow.loop in ['true', 'false'] -%}
+            loop: {{ nb.metadata.slideshow.loop }},
+        {%- endif -%}
+
+        {%- if nb.metadata.slideshow.rtl in ['true', 'false'] -%}
+            rtl: {{ nb.metadata.slideshow.rtl }},
+        {%- endif -%}
+
+        {%- if nb.metadata.slideshow.fragments in ['true', 'false'] -%}
+            fragments: {{ nb.metadata.slideshow.fragments }},
+        {%- endif -%}
+
+        {%- if nb.metadata.slideshow.embedded in ['true', 'false'] -%}
+            embedded: {{ nb.metadata.slideshow.embedded }},
+        {%- endif -%}
+
+        {%- if nb.metadata.slideshow.auto_slide -%}
+            autoSlide: {{ nb.metadata.slideshow.auto_slide }},
+        {%- endif -%}
+
+        {%- if nb.metadata.slideshow.auto_slide_stoppable in ['true', 'false'] -%}
+            autoSlideStoppable: {{ nb.metadata.slideshow.auto_slide_stoppable }},
+        {%- endif -%}
+
+        {%- if nb.metadata.slideshow.mouse_wheel in ['true', 'false'] -%}
+            mouseWheel: {{ nb.metadata.slideshow.mouse_wheel }},
+        {%- endif -%}
+
+        {%- if nb.metadata.slideshow.hide_address_bar in ['true', 'false'] -%}
+            hideAddressBar: {{ nb.metadata.slideshow.hide_address_bar }},
+        {%- endif -%}
+
+        {%- if nb.metadata.slideshow.preview_links in ['true', 'false'] -%}
+            previewLinks: {{ nb.metadata.slideshow.preview_links }},
+        {%- endif -%}
+
+        {%- if nb.metadata.slideshow.transition in ['default', 'cube', 'page', 'concave', 'zoom', 'linear', 'fade', 'none'] -%}
+            transition: {{ nb.metadata.slideshow.transition }},
+        {%- else -%}
+            transition: Reveal.getQueryHash().transition || 'linear',
+        {%- endif -%}
+
+        {%- if nb.metadata.slideshow.transition_speed in ['default', 'fast', 'slow'] -%}
+            transitionSpeed: {{ nb.metadata.slideshow.transition_speed }},
+        {%- endif -%}
+
+        {%- if nb.metadata.slideshow.background_transition in ['default', 'none', 'slide', 'concave', 'convex', 'zoom'] -%}
+            transition: {{ nb.metadata.slideshow.background_transition  }},
+        {%- endif -%}
+
+        {%- if nb.metadata.slideshow.view_distance in ['default', 'none', 'slide', 'concave', 'convex', 'zoom'] -%}
+            viewDistance: {{ nb.metadata.slideshow.view_distance }},
+        {%- endif -%}
+
+        {%- if nb.metadata.slideshow.parallax_background_image -%}
+            parallaxBackgroundImage: {{ nb.metadata.slideshow.parallax_background_image }},
+        {%- endif -%}
+
+
+        {%- if nb.metadata.slideshow.parallax_background_size -%}
+            parallaxBackgroundSize: {{ nb.metadata.slideshow.parallax_background_size }},
+        {%- endif -%}
+
     {%- else -%}
         controls: true,
-    {%- endif -%}
-
-    {%- if nb.metadata.slideshow.progress in ['true', 'false'] -%}
-        progress: {{ nb.metadata.slideshow.progress }},
-    {%- else -%}
         progress: true,
-    {%- endif -%}
-
-    {%- if nb.metadata.slideshow.history in ['true', 'false'] -%}
-        history: {{ nb.metadata.slideshow.history }},
-    {%- else -%}
         history: true,
-    {%- endif -%}
-    
-    {%- if nb.metadata.slideshow.slide_number in ['true', 'false'] -%}
-        slideNumber: {{ nb.metadata.slideshow.slide_number }},
-    {%- endif -%}
-    
-    {%- if nb.metadata.slideshow.keyboard in ['true', 'false'] -%}
-        keyboard: {{ nb.metadata.slideshow.keyboard }},
-    {%- endif -%}
-    
-    {%- if nb.metadata.slideshow.overview in ['true', 'false'] -%}
-        overview: {{ nb.metadata.slideshow.overview }},
-    {%- endif -%}
-    
-    {%- if nb.metadata.slideshow.center in ['true', 'false'] -%}
-        center: {{ nb.metadata.slideshow.center }},
-    {%- endif -%}
-    
-    {%- if nb.metadata.slideshow.touch in ['true', 'false'] -%}
-        touch: {{ nb.metadata.slideshow.touch }},
-    {%- endif -%}
-    
-    {%- if nb.metadata.slideshow.loop in ['true', 'false'] -%}
-        loop: {{ nb.metadata.slideshow.loop }},
-    {%- endif -%}
-
-    {%- if nb.metadata.slideshow.rtl in ['true', 'false'] -%}
-        rtl: {{ nb.metadata.slideshow.rtl }},
-    {%- endif -%}
-
-    {%- if nb.metadata.slideshow.fragments in ['true', 'false'] -%}
-        fragments: {{ nb.metadata.slideshow.fragments }},
-    {%- endif -%}
-
-    {%- if nb.metadata.slideshow.embedded in ['true', 'false'] -%}
-        embedded: {{ nb.metadata.slideshow.embedded }},
-    {%- endif -%}
-    
-    {%- if nb.metadata.slideshow.auto_slide -%}
-        autoSlide: {{ nb.metadata.slideshow.auto_slide }},
-    {%- endif -%}
-    
-    {%- if nb.metadata.slideshow.auto_slide_stoppable in ['true', 'false'] -%}
-        autoSlideStoppable: {{ nb.metadata.slideshow.auto_slide_stoppable }},
-    {%- endif -%}
-
-    {%- if nb.metadata.slideshow.mouse_wheel in ['true', 'false'] -%}
-        mouseWheel: {{ nb.metadata.slideshow.mouse_wheel }},
-    {%- endif -%}
-    
-    {%- if nb.metadata.slideshow.hide_address_bar in ['true', 'false'] -%}
-        hideAddressBar: {{ nb.metadata.slideshow.hide_address_bar }},
-    {%- endif -%}
-    
-    {%- if nb.metadata.slideshow.preview_links in ['true', 'false'] -%}
-        previewLinks: {{ nb.metadata.slideshow.preview_links }},
-    {%- endif -%}
-
-    {%- if nb.metadata.slideshow.transition in ['default', 'cube', 'page', 'concave', 'zoom', 'linear', 'fade', 'none'] -%}
-        transition: {{ nb.metadata.slideshow.transition }},
-    {%- else -%}
         transition: Reveal.getQueryHash().transition || 'linear',
-    {%- endif -%}
-
-    {%- if nb.metadata.slideshow.transition_speed in ['default', 'fast', 'slow'] -%}
-        transitionSpeed: {{ nb.metadata.slideshow.transition_speed }},
-    {%- endif -%}
-
-    {%- if nb.metadata.slideshow.background_transition in ['default', 'none', 'slide', 'concave', 'convex', 'zoom'] -%}
-        transition: {{ nb.metadata.slideshow.background_transition  }},
-    {%- endif -%}
-
-    {%- if nb.metadata.slideshow.view_distance in ['default', 'none', 'slide', 'concave', 'convex', 'zoom'] -%}
-        viewDistance: {{ nb.metadata.slideshow.view_distance }},
-    {%- endif -%}
-
-    {%- if nb.metadata.slideshow.parallax_background_image -%}
-        parallaxBackgroundImage: {{ nb.metadata.slideshow.parallax_background_image }},
-    {%- endif -%}
-
-
-    {%- if nb.metadata.slideshow.parallax_background_size -%}
-        parallaxBackgroundSize: {{ nb.metadata.slideshow.parallax_background_size }},
     {%- endif -%}
 
 

--- a/IPython/nbconvert/templates/html/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/html/slides_reveal.tpl
@@ -2,33 +2,36 @@
 {% from 'mathjax.tpl' import mathjax %}
 
 {%- block any_cell scoped -%}
+
+{% macro slide_opts(cell) -%}
+    {%- if cell.metadata.slideshow.slide_background -%}
+        {{" "}}data-background="{{ cell.metadata.slideshow.slide_background }}"
+    {%- endif -%}
+
+    {%- if cell.metadata.slideshow.slide_background_repeat -%}
+        {{" "}}data-background-repeat="{{ cell.metadata.slideshow.slide_background_repeat }}"
+    {%- endif -%}
+
+    {%- if cell.metadata.slideshow.slide_background_size -%}
+        {{" "}}data-background-size="{{ cell.metadata.slideshow.slide_background_size }}"
+    {%- endif -%}
+
+    {%- if cell.metadata.slideshow.slide_transition -%}
+        {{" "}}data-transition="{{ cell.metadata.slideshow.slide_transition }}"
+    {%- endif -%}
+
+    {%- if cell.metadata.slideshow.slide_transition_speed -%}
+        {{" "}}data-transition-speed="{{ cell.metadata.slideshow.slide_transition_speed }}"
+    {%- endif -%}
+{%- endmacro %}
+
 {%- if cell.metadata.slide_type in ['slide'] -%}
     <section>
-    <section
-        {%- if cell.metadata.slideshow.slide_background -%}
-            {{" "}}data-background="{{ cell.metadata.slideshow.slide_background }}"
-        {%- endif -%}
-
-        {%- if cell.metadata.slideshow.slide_background_repeat -%}
-            {{" "}}data-background-repeat="{{ cell.metadata.slideshow.slide_background_repeat }}"
-        {%- endif -%}
-
-        {%- if cell.metadata.slideshow.slide_background_size -%}
-            {{" "}}data-background-size="{{ cell.metadata.slideshow.slide_background_size }}"
-        {%- endif -%}
-
-        {%- if cell.metadata.slideshow.slide_transition -%}
-            {{" "}}data-transition="{{ cell.metadata.slideshow.slide_transition }}"
-        {%- endif -%}
-
-        {%- if cell.metadata.slideshow.slide_transition_speed -%}
-            {{" "}}data-transition-speed="{{ cell.metadata.slideshow.slide_transition_speed }}"
-        {%- endif -%}
-    >
+    <section {{ slide_opts(cell) }}>
 
     {{ super() }}
 {%- elif cell.metadata.slide_type in ['subslide'] -%}
-    <section>
+    <section {{ slide_opts(cell) }}>
     {{ super() }}
 {%- elif cell.metadata.slide_type in ['-'] -%}
     {%- if cell.metadata.frag_helper in ['fragment_end'] -%}

--- a/IPython/nbconvert/templates/html/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/html/slides_reveal.tpl
@@ -29,6 +29,12 @@
     {%- endif -%}
 {%- endmacro %}
 
+{%- macro fragment_style(cell) -%}
+    {%- if cell.metadata.slideshow.fragment_style -%}
+        {{" "+cell.metadata.slideshow.fragment_style}}
+    {%- endif -%}
+{%- endmacro %}
+
 {%- if cell.metadata.slide_type in ['slide'] -%}
     <section>
     <section {{ slide_opts(cell) }}>
@@ -39,7 +45,7 @@
     {{ super() }}
 {%- elif cell.metadata.slide_type in ['-'] -%}
     {%- if cell.metadata.frag_helper in ['fragment_end'] -%}
-        <div class="fragment" data-fragment-index="{{ cell.metadata.frag_number }}">
+        <div class="fragment{{ fragment_style(cell) }}" data-fragment-index="{{ cell.metadata.frag_number }}">
         {{ super() }}
         </div>
     {%- else -%}
@@ -54,7 +60,7 @@
     {{ super() }}
     </aside>
 {%- elif cell.metadata.slide_type in ['fragment'] -%}
-    <div class="fragment" data-fragment-index="{{ cell.metadata.frag_number }}">
+    <div class="fragment{{ fragment_style(cell) }}" data-fragment-index="{{ cell.metadata.frag_number }}">
     {{ super() }}
     </div>
 {%- endif -%}

--- a/IPython/nbconvert/templates/html/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/html/slides_reveal.tpl
@@ -5,36 +5,40 @@
 
 {% macro slide_opts(cell) -%}
 {# examines a slide cell's metadata for reveal.js formatting options #}
-    {%- if cell.metadata.slideshow.slide_background -%}
-        {{" "}}data-background="{{ cell.metadata.slideshow.slide_background }}"
-    {%- endif -%}
+    {%- if cell.metadata.slideshow is defined -%}
+        {%- if cell.metadata.slideshow.slide_background -%}
+            {{" "}}data-background="{{ cell.metadata.slideshow.slide_background }}"
+        {%- endif -%}
 
-    {%- if cell.metadata.slideshow.slide_background_repeat -%}
-        {{" "}}data-background-repeat="{{ cell.metadata.slideshow.slide_background_repeat }}"
-    {%- endif -%}
+        {%- if cell.metadata.slideshow.slide_background_repeat -%}
+            {{" "}}data-background-repeat="{{ cell.metadata.slideshow.slide_background_repeat }}"
+        {%- endif -%}
 
-    {%- if cell.metadata.slideshow.slide_background_size -%}
-        {{" "}}data-background-size="{{ cell.metadata.slideshow.slide_background_size }}"
-    {%- endif -%}
-    
-    {%- if cell.metadata.slideshow.slide_background_transition -%}
-        {{" "}}data-background-transition="{{ cell.metadata.slideshow.slide_background_transition }}"
-    {%- endif -%}
+        {%- if cell.metadata.slideshow.slide_background_size -%}
+            {{" "}}data-background-size="{{ cell.metadata.slideshow.slide_background_size }}"
+        {%- endif -%}
 
-    {%- if cell.metadata.slideshow.slide_transition -%}
-        {{" "}}data-transition="{{ cell.metadata.slideshow.slide_transition }}"
-    {%- endif -%}
+        {%- if cell.metadata.slideshow.slide_background_transition -%}
+            {{" "}}data-background-transition="{{ cell.metadata.slideshow.slide_background_transition }}"
+        {%- endif -%}
 
-    {%- if cell.metadata.slideshow.slide_transition_speed -%}
-        {{" "}}data-transition-speed="{{ cell.metadata.slideshow.slide_transition_speed }}"
+        {%- if cell.metadata.slideshow.slide_transition -%}
+            {{" "}}data-transition="{{ cell.metadata.slideshow.slide_transition }}"
+        {%- endif -%}
+
+        {%- if cell.metadata.slideshow.slide_transition_speed -%}
+            {{" "}}data-transition-speed="{{ cell.metadata.slideshow.slide_transition_speed }}"
+        {%- endif -%}
     {%- endif -%}
 {%- endmacro %}
 
 {%- macro fragment_style(cell) -%}
 {# examines a fragment cell's metadata for reveal.js fragment highlight style option.
 "higlight-red", "highlight-blue" and "higlight-green" not supported #}
-    {%- if cell.metadata.slideshow.fragment_style -%}
-        {{" "+cell.metadata.slideshow.fragment_style}}
+    {%- if cell.metadata.slideshow is defined -%}
+        {%- if cell.metadata.slideshow.fragment_style -%}
+            {{" "+cell.metadata.slideshow.fragment_style}}
+        {%- endif -%}
     {%- endif -%}
 {%- endmacro %}
 
@@ -303,7 +307,6 @@ Reveal.initialize({
         {%- if nb.metadata.slideshow.parallax_background_image -%}
             parallaxBackgroundImage: {{ nb.metadata.slideshow.parallax_background_image }},
         {%- endif -%}
-
 
         {%- if nb.metadata.slideshow.parallax_background_size -%}
             parallaxBackgroundSize: {{ nb.metadata.slideshow.parallax_background_size }},

--- a/IPython/nbconvert/templates/html/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/html/slides_reveal.tpl
@@ -4,6 +4,7 @@
 {%- block any_cell scoped -%}
 
 {% macro slide_opts(cell) -%}
+{# examines a slide cell's metadata for reveal.js formatting options #}
     {%- if cell.metadata.slideshow.slide_background -%}
         {{" "}}data-background="{{ cell.metadata.slideshow.slide_background }}"
     {%- endif -%}
@@ -30,6 +31,8 @@
 {%- endmacro %}
 
 {%- macro fragment_style(cell) -%}
+{# examines a fragment cell's metadata for reveal.js fragment highlight style option.
+"higlight-red", "highlight-blue" and "higlight-green" not supported #}
     {%- if cell.metadata.slideshow.fragment_style -%}
         {{" "+cell.metadata.slideshow.fragment_style}}
     {%- endif -%}
@@ -204,12 +207,110 @@ div.output_prompt {
 
 // Full list of configuration options available here: https://github.com/hakimel/reveal.js#configuration
 Reveal.initialize({
-controls: true,
-progress: true,
-history: true,
+
+    {%- if nb.metadata.slideshow.controls in ['true', 'false'] -%}
+        controls: {{ nb.metadata.slideshow.controls }},
+    {%- else -%}
+        controls: true,
+    {%- endif -%}
+
+    {%- if nb.metadata.slideshow.progress in ['true', 'false'] -%}
+        progress: {{ nb.metadata.slideshow.progress }},
+    {%- else -%}
+        progress: true,
+    {%- endif -%}
+
+    {%- if nb.metadata.slideshow.history in ['true', 'false'] -%}
+        history: {{ nb.metadata.slideshow.history }},
+    {%- else -%}
+        history: true,
+    {%- endif -%}
+    
+    {%- if nb.metadata.slideshow.slide_number in ['true', 'false'] -%}
+        slideNumber: {{ nb.metadata.slideshow.slide_number }},
+    {%- endif -%}
+    
+    {%- if nb.metadata.slideshow.keyboard in ['true', 'false'] -%}
+        keyboard: {{ nb.metadata.slideshow.keyboard }},
+    {%- endif -%}
+    
+    {%- if nb.metadata.slideshow.overview in ['true', 'false'] -%}
+        overview: {{ nb.metadata.slideshow.overview }},
+    {%- endif -%}
+    
+    {%- if nb.metadata.slideshow.center in ['true', 'false'] -%}
+        center: {{ nb.metadata.slideshow.center }},
+    {%- endif -%}
+    
+    {%- if nb.metadata.slideshow.touch in ['true', 'false'] -%}
+        touch: {{ nb.metadata.slideshow.touch }},
+    {%- endif -%}
+    
+    {%- if nb.metadata.slideshow.loop in ['true', 'false'] -%}
+        loop: {{ nb.metadata.slideshow.loop }},
+    {%- endif -%}
+
+    {%- if nb.metadata.slideshow.rtl in ['true', 'false'] -%}
+        rtl: {{ nb.metadata.slideshow.rtl }},
+    {%- endif -%}
+
+    {%- if nb.metadata.slideshow.fragments in ['true', 'false'] -%}
+        fragments: {{ nb.metadata.slideshow.fragments }},
+    {%- endif -%}
+
+    {%- if nb.metadata.slideshow.embedded in ['true', 'false'] -%}
+        embedded: {{ nb.metadata.slideshow.embedded }},
+    {%- endif -%}
+    
+    {%- if nb.metadata.slideshow.auto_slide -%}
+        autoSlide: {{ nb.metadata.slideshow.auto_slide }},
+    {%- endif -%}
+    
+    {%- if nb.metadata.slideshow.auto_slide_stoppable in ['true', 'false'] -%}
+        autoSlideStoppable: {{ nb.metadata.slideshow.auto_slide_stoppable }},
+    {%- endif -%}
+
+    {%- if nb.metadata.slideshow.mouse_wheel in ['true', 'false'] -%}
+        mouseWheel: {{ nb.metadata.slideshow.mouse_wheel }},
+    {%- endif -%}
+    
+    {%- if nb.metadata.slideshow.hide_address_bar in ['true', 'false'] -%}
+        hideAddressBar: {{ nb.metadata.slideshow.hide_address_bar }},
+    {%- endif -%}
+    
+    {%- if nb.metadata.slideshow.preview_links in ['true', 'false'] -%}
+        previewLinks: {{ nb.metadata.slideshow.preview_links }},
+    {%- endif -%}
+
+    {%- if nb.metadata.slideshow.transition in ['default', 'cube', 'page', 'concave', 'zoom', 'linear', 'fade', 'none'] -%}
+        transition: {{ nb.metadata.slideshow.transition }},
+    {%- else -%}
+        transition: Reveal.getQueryHash().transition || 'linear',
+    {%- endif -%}
+
+    {%- if nb.metadata.slideshow.transition_speed in ['default', 'fast', 'slow'] -%}
+        transitionSpeed: {{ nb.metadata.slideshow.transition_speed }},
+    {%- endif -%}
+
+    {%- if nb.metadata.slideshow.background_transition in ['default', 'none', 'slide', 'concave', 'convex', 'zoom'] -%}
+        transition: {{ nb.metadata.slideshow.background_transition  }},
+    {%- endif -%}
+
+    {%- if nb.metadata.slideshow.view_distance in ['default', 'none', 'slide', 'concave', 'convex', 'zoom'] -%}
+        viewDistance: {{ nb.metadata.slideshow.view_distance }},
+    {%- endif -%}
+
+    {%- if nb.metadata.slideshow.parallax_background_image -%}
+        parallaxBackgroundImage: {{ nb.metadata.slideshow.parallax_background_image }},
+    {%- endif -%}
+
+
+    {%- if nb.metadata.slideshow.parallax_background_size -%}
+        parallaxBackgroundSize: {{ nb.metadata.slideshow.parallax_background_size }},
+    {%- endif -%}
+
 
 theme: Reveal.getQueryHash().theme, // available themes are in /css/theme
-transition: Reveal.getQueryHash().transition || 'linear', // default/cube/page/concave/zoom/linear/none
 
 // Optional libraries used to extend on reveal.js
 dependencies: [

--- a/IPython/nbconvert/templates/html/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/html/slides_reveal.tpl
@@ -15,6 +15,10 @@
     {%- if cell.metadata.slideshow.slide_background_size -%}
         {{" "}}data-background-size="{{ cell.metadata.slideshow.slide_background_size }}"
     {%- endif -%}
+    
+    {%- if cell.metadata.slideshow.slide_background_transition -%}
+        {{" "}}data-background-transition="{{ cell.metadata.slideshow.slide_background_transition }}"
+    {%- endif -%}
 
     {%- if cell.metadata.slideshow.slide_transition -%}
         {{" "}}data-transition="{{ cell.metadata.slideshow.slide_transition }}"

--- a/IPython/nbconvert/templates/html/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/html/slides_reveal.tpl
@@ -4,7 +4,28 @@
 {%- block any_cell scoped -%}
 {%- if cell.metadata.slide_type in ['slide'] -%}
     <section>
-    <section>
+    <section
+        {%- if cell.metadata.slideshow.slide_background -%}
+            {{" "}}data-background="{{ cell.metadata.slideshow.slide_background }}"
+        {%- endif -%}
+
+        {%- if cell.metadata.slideshow.slide_background_repeat -%}
+            {{" "}}data-background-repeat="{{ cell.metadata.slideshow.slide_background_repeat }}"
+        {%- endif -%}
+
+        {%- if cell.metadata.slideshow.slide_background_size -%}
+            {{" "}}data-background-size="{{ cell.metadata.slideshow.slide_background_size }}"
+        {%- endif -%}
+
+        {%- if cell.metadata.slideshow.slide_transition -%}
+            {{" "}}data-transition="{{ cell.metadata.slideshow.slide_transition }}"
+        {%- endif -%}
+
+        {%- if cell.metadata.slideshow.slide_transition_speed -%}
+            {{" "}}data-transition-speed="{{ cell.metadata.slideshow.slide_transition_speed }}"
+        {%- endif -%}
+    >
+
     {{ super() }}
 {%- elif cell.metadata.slide_type in ['subslide'] -%}
     <section>


### PR DESCRIPTION
A quick attempt at adding support for various reveal.js formatting options to nbconvert's slideshow output.
- Formatting slide/sub-slide background and transitions
- Formatting highlighting of slideshow fragments
- Customising global slide options, e.g. auto-progress, showing/hiding controls etc...

A significant chunk of options documented on https://github.com/hakimel/reveal.js have been imple
mented.

Options are set in cell/notebook metadata, under a subsection "slideshow" e.g.

```
{
  "cell_type": "heading",
  "level": 2,
  "metadata": {
    "slideshow": {
      "slide_background": "http://ipython.org/ipython-doc/2/_images/ipynb_icon_128x128.png",
      "slide_type": "slide"
    }
  }, "source": [ "Background Images"]
}
```

Currently testing reveal.js formatting with https://gist.github.com/genericg/7ed51454b72f3199a851 

Current issues:
- fragment highlight css formatting can conflict with background settings/possibly being overriden by html formatter
- not all global slide options tested
- No unit tests, as not sure how to incorporate reveal.js output in to unit tests
- probably lots more...
