### PR TITLE
Remove py3compat.open

### DIFF
--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -6,6 +6,7 @@
 #-----------------------------------------------------------------------------
 
 # stdlib
+import io
 import os
 import sys
 import tempfile
@@ -124,7 +125,7 @@ def test_history():
             # Cross testing: check that magic %save can get previous session.
             testfilename = os.path.realpath(os.path.join(tmpdir, "test.py"))
             ip.magic("save " + testfilename + " ~1/1-3")
-            with py3compat.open(testfilename, encoding='utf-8') as testfile:
+            with io.open(testfilename, encoding='utf-8') as testfile:
                 nt.assert_equal(testfile.read(),
                                         u"# coding: utf-8\n" + u"\n".join(hist)+u"\n")
 

--- a/IPython/utils/py3compat.py
+++ b/IPython/utils/py3compat.py
@@ -8,8 +8,6 @@ import types
 
 from .encoding import DEFAULT_ENCODING
 
-orig_open = open
-
 def no_code(x, encoding=None):
     return x
 
@@ -96,8 +94,7 @@ if sys.version_info[0] >= 3:
         if dotted:
             return all(isidentifier(a) for a in s.split("."))
         return s.isidentifier()
-    
-    open = orig_open
+
     xrange = range
     def iteritems(d): return iter(d.items())
     def itervalues(d): return iter(d.values())
@@ -163,27 +160,6 @@ else:
         if dotted:
             return all(isidentifier(a) for a in s.split("."))
         return bool(_name_re.match(s))
-    
-    class open(object):
-        """Wrapper providing key part of Python 3 open() interface."""
-        def __init__(self, fname, mode="r", encoding="utf-8"):
-            self.f = orig_open(fname, mode)
-            self.enc = encoding
-        
-        def write(self, s):
-            return self.f.write(s.encode(self.enc))
-        
-        def read(self, size=-1):
-            return self.f.read(size).decode(self.enc)
-        
-        def close(self):
-            return self.f.close()
-        
-        def __enter__(self):
-            return self
-        
-        def __exit__(self, etype, value, traceback):
-            self.f.close()
     
     xrange = xrange
     def iteritems(d): return d.iteritems()

--- a/docs/autogen_api.py
+++ b/docs/autogen_api.py
@@ -43,6 +43,8 @@ if __name__ == '__main__':
                                         # These are exposed in display
                                         r'\.core\.display',
                                         r'\.lib\.display',
+                                        # This isn't actually a module
+                                        r'\.html\.fabfile',
                                         ]
 
     # These modules import functions and classes from other places to expose

--- a/docs/autogen_api.py
+++ b/docs/autogen_api.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
                                         # This just prints a deprecation msg:
                                         r'\.frontend$',
                                         # Deprecated:
-                                        r'\.core\.magics\.deprecated'
+                                        r'\.core\.magics\.deprecated',
                                         # We document this manually.
                                         r'\.utils\.py3compat',
                                         # These are exposed by nbformat.current

--- a/docs/source/whatsnew/pr/incompat-py3compat-open.rst
+++ b/docs/source/whatsnew/pr/incompat-py3compat-open.rst
@@ -1,0 +1,2 @@
+* ``IPython.utils.py3compat.open`` was removed: :func:`io.open` provides all
+  the same functionality.


### PR DESCRIPTION
This was redundant with `io.open`, and we only had one use of it left.

Also, a couple of doc fixes.
