### PR TITLE
CSS selectors

### DIFF
--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -462,6 +462,8 @@ define(["widgets/js/manager",
                 } else {
                     elements = this.$el_to_style;
                 }
+            } else if (selector===":top") {
+                elements = this.$el;
             } else {
                 elements = this.$el.find(selector).addBack(selector);
             }

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -463,7 +463,7 @@ define(["widgets/js/manager",
                     elements = this.$el_to_style;
                 }
             } else {
-                elements = this.$el.find(selector);
+                elements = this.$el.find(selector).addBack(selector);
             }
             return elements;
         },


### PR DESCRIPTION
Make the CSS selector syntax more powerful for DOMWidgets with two changes:
- Make the selector also act on the top-level widget, not just descendants of the top-level widget
- Introduce a `:top` selector that selects the top-level container (the `this.$el` of the view)
