### PR TITLE
Add casting instance traitlet

### DIFF
--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -903,6 +903,18 @@ class Instance(ClassBasedTraitType):
         else:
             return dv
 
+class CInstance(Instance):
+    def _cast(self, value):
+        return self.klass(value)
+
+    def validate(self, obj, value):
+        if isinstance(value, self.klass):
+            return value
+        try:
+            return self._cast(value)
+        except:
+            self.error(obj, value)
+
 
 class This(ClassBasedTraitType):
     """A trait for instances of the class containing this trait.


### PR DESCRIPTION
This is useful if you want an instance trait, but don't want to always create an instance of the class before assigning.  I've made the casting function a method so that it is easily overridden in subclasses to provide custom casting logic.
