### PR TITLE
Allow model id to be set externally on creation of the widget. 

### DIFF
--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -123,6 +123,7 @@ class Widget(LoggingConfigurable):
 
         self.on_trait_change(self._handle_property_changed, self.keys)
         Widget._call_widget_constructed(self)
+        self.open()
 
     def __del__(self):
         """Object disposal"""
@@ -137,6 +138,11 @@ class Widget(LoggingConfigurable):
         """Gets the Comm associated with this widget.
 
         If a Comm doesn't exist yet, a Comm will be created automagically."""
+        self.open()
+        return self._comm
+    
+    def open(self):
+        """Open a comm to the frontend if one isn't already open."""
         if self._comm is None:
             # Create a comm.
             self._comm = Comm(target_name=self._model_name)
@@ -145,8 +151,7 @@ class Widget(LoggingConfigurable):
 
             # first update
             self.send_state()
-        return self._comm
-    
+
     @property
     def model_id(self):
         """Gets the model id of this widget.

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -119,6 +119,7 @@ class Widget(LoggingConfigurable):
     #-------------------------------------------------------------------------
     def __init__(self, **kwargs):
         """Public constructor"""
+        self._model_id = kwargs.pop('model_id', None)
         super(Widget, self).__init__(**kwargs)
 
         self.on_trait_change(self._handle_property_changed, self.keys)
@@ -136,8 +137,11 @@ class Widget(LoggingConfigurable):
     def open(self):
         """Open a comm to the frontend if one isn't already open."""
         if self.comm is None:
-            # Create a comm.
-            self.comm = Comm(target_name=self._model_name)
+            if self._model_id is None:
+                self.comm = Comm(target_name=self._model_name)
+                self._model_id = self.model_id
+            else:
+                self.comm = Comm(target_name=self._model_name, comm_id=self._model_id)
             self.comm.on_msg(self._handle_msg)
             Widget.widgets[self.model_id] = self
 

--- a/IPython/kernel/comm/comm.py
+++ b/IPython/kernel/comm/comm.py
@@ -77,7 +77,9 @@ class Comm(LoggingConfigurable):
         if data is None:
             data = self._open_data
         self._closed = False
-        get_ipython().comm_manager.register_comm(self)
+        ip = get_ipython()
+        if hasattr(ip, 'comm_manager'):
+            ip.comm_manager.register_comm(self)
         self._publish_msg('comm_open', data, metadata, target_name=self.target_name)
     
     def close(self, data=None, metadata=None):
@@ -88,7 +90,9 @@ class Comm(LoggingConfigurable):
         if data is None:
             data = self._close_data
         self._publish_msg('comm_close', data, metadata)
-        get_ipython().comm_manager.unregister_comm(self)
+        ip = get_ipython()
+        if hasattr(ip, 'comm_manager'):
+            ip.comm_manager.unregister_comm(self)
         self._closed = True
     
     def send(self, data=None, metadata=None):


### PR DESCRIPTION
- This depends on PR #6151. and PR #6216

With this change, the `model_id` of a widget to be set externally when creating the widget. (It is especially useful in cases where you want the `model_id` to correspond to some other object's uuid that you don't control, and you don't want to rely on a lookup table. )

Another feature is that if a widget is closed and reopened, the new model_id/comm_id will be the same as the previous one. 
