### PR TITLE
Close handle on new temporary files before returning filename

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3086,6 +3086,7 @@ class InteractiveShell(SingletonConfigurable):
         self.tempdirs.append(dirname)
 
         handle, filename = tempfile.mkstemp('.py', prefix, dir=dirname)
+        os.close(handle)  # On Windows, there can only be one open handle on a file
         self.tempfiles.append(filename)
 
         if data:

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -462,6 +462,15 @@ class InteractiveShellTestCase(unittest.TestCase):
         ip.run_cell("d = 1/2", shell_futures=True)
         self.assertEqual(ip.user_ns['d'], 0)
 
+    def test_mktempfile(self):
+        filename = ip.mktempfile()
+        # Check that we can open the file again on Windows
+        with open(filename, 'w') as f:
+            f.write('abc')
+
+        filename = ip.mktempfile(data='blah')
+        with open(filename, 'r') as f:
+            self.assertEqual(f.read(), 'blah')
 
 class TestSafeExecfileNonAsciiPath(unittest.TestCase):
 


### PR DESCRIPTION
On Windows, a file can only have one open writable handle at a time, so we need to close the one created by mkstemp before anything else can use that file.

Closes gh-5946
