### PR TITLE
move some responsive bootstrap transitions

### DIFF
--- a/IPython/html/static/tree/js/clusterlist.js
+++ b/IPython/html/static/tree/js/clusterlist.js
@@ -92,16 +92,16 @@ define([
 
     ClusterItem.prototype.state_stopped = function () {
         var that = this;
-        var profile_col = $('<div/>').addClass('profile_col col-md-4').text(this.data.profile);
-        var status_col = $('<div/>').addClass('status_col col-md-3').text('stopped');
-        var engines_col = $('<div/>').addClass('engine_col col-md-3');
+        var profile_col = $('<div/>').addClass('profile_col col-xs-4').text(this.data.profile);
+        var status_col = $('<div/>').addClass('status_col col-xs-3').text('stopped');
+        var engines_col = $('<div/>').addClass('engine_col col-xs-3');
         var input = $('<input/>').attr('type','number')
                 .attr('min',1)
                 .attr('size',3)
                 .addClass('engine_num_input form-control');
         engines_col.append(input);
         var start_button = $('<button/>').addClass("btn btn-default btn-xs").text("Start");
-        var action_col = $('<div/>').addClass('action_col col-md-2').append(
+        var action_col = $('<div/>').addClass('action_col col-xs-2').append(
             $("<span/>").addClass("item_buttons btn-group").append(
                 start_button
             )
@@ -144,11 +144,11 @@ define([
 
     ClusterItem.prototype.state_running = function () {
         var that = this;
-        var profile_col = $('<div/>').addClass('profile_col col-md-4').text(this.data.profile);
-        var status_col = $('<div/>').addClass('status_col col-md-3').text('running');
-        var engines_col = $('<div/>').addClass('engines_col col-md-3').text(this.data.n);
+        var profile_col = $('<div/>').addClass('profile_col col-xs-4').text(this.data.profile);
+        var status_col = $('<div/>').addClass('status_col col-xs-3').text('running');
+        var engines_col = $('<div/>').addClass('engines_col col-xs-3').text(this.data.n);
         var stop_button = $('<button/>').addClass("btn btn-default btn-xs").text("Stop");
-        var action_col = $('<div/>').addClass('action_col col-md-2').append(
+        var action_col = $('<div/>').addClass('action_col col-xs-2').append(
             $("<span/>").addClass("item_buttons btn-group").append(
                 stop_button
             )

--- a/IPython/html/templates/login.html
+++ b/IPython/html/templates/login.html
@@ -15,7 +15,7 @@
 
     {% if login_available %}
     <div class="row">
-    <div class="navbar col-md-8 col-md-offset2">
+    <div class="navbar col-sm-8 col-sm-offset2">
       <div class="navbar-inner">
         <div class="container">
           <div class="center-nav">

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -31,7 +31,7 @@ data-notebook-path="{{notebook_path}}"
     <div class="tab-content">
     <div id="notebooks" class="tab-pane active">
         <div id="notebook_toolbar" class="row">
-            <div class="col-md-8 no-padding">
+            <div class="col-sm-8 no-padding">
                 <form id='alternate_upload'  class='alternate_upload' >
                     <span id="notebook_list_info" style="position:absolute" >
                         To import a notebook, drag the file onto the listing below or <strong>click here</strong>.
@@ -39,7 +39,7 @@ data-notebook-path="{{notebook_path}}"
                     <input type="file" name="datafile" class="fileinput" multiple='multiple'>
                 </form>
             </div>
-            <div class="col-md-4 no-padding tree-buttons">
+            <div class="col-sm-4 no-padding tree-buttons">
                 <span id="notebook_buttons" class="pull-right">
                     <button id="new_notebook" title="Create new notebook" class="btn btn-default btn-xs">New Notebook</button>
                     <button id="refresh_notebook_list" title="Refresh notebook list" class="btn btn-default btn-xs"><i class="icon-refresh"></i></button>
@@ -64,10 +64,10 @@ data-notebook-path="{{notebook_path}}"
     <div id="running" class="tab-pane">
 
         <div id="running_toolbar" class="row">
-            <div class="col-md-8 no-padding">
+            <div class="col-sm-8 no-padding">
                 <span id="running_list_info">Currently running IPython notebooks</span>
             </div>
-            <div class="col-md-4 no-padding tree-buttons">
+            <div class="col-sm-4 no-padding tree-buttons">
                 <span id="running_buttons" class="pull-right">
                     <button id="refresh_running_list" title="Refresh running list" class="btn btn-default btn-xs"><i class="icon-refresh"></i></button>
                 </span>
@@ -84,10 +84,10 @@ data-notebook-path="{{notebook_path}}"
     <div id="clusters" class="tab-pane">
 
         <div id="cluster_toolbar" class="row">
-            <div class="col-md-8 no-padding">
+            <div class="col-xs-8 no-padding">
                 <span id="cluster_list_info">IPython parallel computing clusters</span>
             </div>
-            <div class="col-md-4 no-padding tree-buttons">
+            <div class="col-xs-4 no-padding tree-buttons">
                 <span id="cluster_buttons" class="pull-right">
                     <button id="refresh_cluster_list" title="Refresh cluster list" class="btn btn-default btn-xs"><i class="icon-refresh"></i></button>
                 </span>
@@ -96,10 +96,10 @@ data-notebook-path="{{notebook_path}}"
 
         <div id="cluster_list">
             <div id="cluster_list_header" class="row list_header">
-                <div class="profile_col col-md-4">profile</div>
-                <div class="status_col col-md-3">status</div>
-                <div class="engines_col col-md-3" title="Enter the number of engines to start or empty for default"># of engines</div>
-                <div class="action_col col-md-2">action</div>
+                <div class="profile_col col-xs-4">profile</div>
+                <div class="status_col col-xs-3">status</div>
+                <div class="engines_col col-xs-3" title="Enter the number of engines to start or empty for default"># of engines</div>
+                <div class="action_col col-xs-2">action</div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
ref: [bootstrap grid media queries](http://getbootstrap.com/css/#grid-media-queries)
- `-md-` puts the transition at 970px, which is pretty wide.
- `-sm-` puts the transition at 768px

I moved most of the `md` transitions to `sm`, which seems more reasonable in most cases. I also moved the cluster list to `xs` because the columns will never be wider than a dozen or so characters.

before:

![screen shot 2014-07-24 at 13 03 48](https://cloud.githubusercontent.com/assets/151929/3693986/c60bd84e-136d-11e4-80cd-4b9fd1cd0677.PNG)

after:

![screen shot 2014-07-24 at 13 04 09](https://cloud.githubusercontent.com/assets/151929/3693989/cb832700-136d-11e4-8636-1088f4c53772.PNG)
