### PR TITLE
Allow password to be set on command line

### DIFF
--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -280,6 +280,7 @@ aliases.update({
     'notebook-dir': 'NotebookApp.notebook_dir',
     'browser': 'NotebookApp.browser',
     'pylab': 'NotebookApp.pylab',
+    'passwordHash': 'NotebookApp.password',
 })
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Adds the ability to set the password hash from the command line invocation of the notebook.

Example:

``` bash
$ ipython notebook --passwordHash='sha1:925aeaa9103e:0ef6d99e64ff182d367aa5298a72b49950b4c38a'
[I 23:08:26.453 NotebookApp] Using existing profile dir: u'/Users/kyle6475/.ipython/profile_default'
[I 23:08:26.538 NotebookApp] Using MathJax from CDN: //cdn.mathjax.org/mathjax/latest/MathJax.js
[I 23:08:26.557 NotebookApp] The port 8888 is already in use, trying another random port.
[I 23:08:26.560 NotebookApp] Serving notebooks from local directory: /Users/kyle6475/code/ipython
[I 23:08:26.560 NotebookApp] 0 active kernels
[I 23:08:26.560 NotebookApp] The IPython Notebook is running at: http://localhost:8889/
[I 23:08:26.560 NotebookApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
[I 23:08:26.811 tornado.access] 302 GET /tree (::1) 1.65ms
[I 23:08:29.328 tornado.access] 302 POST /login?next=%2Ftree (::1) 1.17ms
```
