### PR TITLE
add marked to require dependencies

### DIFF
--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -8,7 +8,8 @@ define([
     'base/js/security',
     'base/js/keyboard',
     'notebook/js/mathjaxutils',
-], function(IPython, $, utils, security, keyboard, mathjaxutils) {
+    'components/marked/lib/marked',
+], function(IPython, $, utils, security, keyboard, mathjaxutils, marked) {
     "use strict";
 
     /**


### PR DESCRIPTION
solves an error when doing the following

```
from IPython.core.display import Markdown
Markdown('#hey')
```
