### PR TITLE
Unregistering comms in Comm Manager

### DIFF
--- a/IPython/html/static/services/kernels/js/comm.js
+++ b/IPython/html/static/services/kernels/js/comm.js
@@ -56,9 +56,9 @@ define([
         return comm.comm_id;
     };
     
-    CommManager.prototype.unregister_comm = function (comm_id) {
+    CommManager.prototype.unregister_comm = function (comm) {
         // Remove a comm from the mapping
-        delete this.comms[comm_id];
+        delete this.comms[comm.comm_id];
     };
     
     // comm message handlers
@@ -88,7 +88,7 @@ define([
         if (comm === undefined) {
             return;
         }
-        delete this.comms[content.comm_id];
+        this.unregister_comm(comm);
         try {
             comm.handle_close(msg);
         } catch (e) {

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -127,6 +127,8 @@ class Widget(LoggingConfigurable):
     def __del__(self):
         """Object disposal"""
         self.close()
+        del Widget.widgets[self.model_id]
+        self._comm = None
 
     #-------------------------------------------------------------------------
     # Properties
@@ -141,7 +143,6 @@ class Widget(LoggingConfigurable):
             # Create a comm.
             self._comm = Comm(target_name=self._model_name)
             self._comm.on_msg(self._handle_msg)
-            self._comm.on_close(self._close)
             Widget.widgets[self.model_id] = self
 
             # first update
@@ -158,20 +159,15 @@ class Widget(LoggingConfigurable):
     #-------------------------------------------------------------------------
     # Methods
     #-------------------------------------------------------------------------
-    def _close(self):
-        """Private close - cleanup objects, registry entries"""
-        del Widget.widgets[self.model_id]
-        self._comm = None
 
     def close(self):
         """Close method.
 
-        Closes the widget which closes the underlying comm.
+        Closes the underlying comm.
         When the comm is closed, all of the widget views are automatically
         removed from the front-end."""
         if self._comm is not None:
             self._comm.close()
-            self._close()
 
     def send_state(self, key=None):
         """Sends the widget state, or a piece of it, to the front-end.

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -167,6 +167,7 @@ class Widget(LoggingConfigurable):
         del Widget.widgets[self.model_id]
         if self._comm is not None:
             self._comm.close()
+        self._comm = None
     
     def send_state(self, key=None):
         """Sends the widget state, or a piece of it, to the front-end.

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -127,8 +127,6 @@ class Widget(LoggingConfigurable):
     def __del__(self):
         """Object disposal"""
         self.close()
-        del Widget.widgets[self.model_id]
-        self._comm = None
 
     #-------------------------------------------------------------------------
     # Properties
@@ -166,9 +164,10 @@ class Widget(LoggingConfigurable):
         Closes the underlying comm.
         When the comm is closed, all of the widget views are automatically
         removed from the front-end."""
+        del Widget.widgets[self.model_id]
         if self._comm is not None:
             self._comm.close()
-
+    
     def send_state(self, key=None):
         """Sends the widget state, or a piece of it, to the front-end.
 

--- a/IPython/kernel/comm/comm.py
+++ b/IPython/kernel/comm/comm.py
@@ -50,7 +50,6 @@ class Comm(LoggingConfigurable):
         if target_name:
             kwargs['target_name'] = target_name
         super(Comm, self).__init__(**kwargs)
-        get_ipython().comm_manager.register_comm(self)
         if self.primary:
             # I am primary, open my peer.
             self.open(data)
@@ -70,7 +69,6 @@ class Comm(LoggingConfigurable):
     def __del__(self):
         """trigger close on gc"""
         self.close()
-        get_ipython().comm_manager.unregister_comm(self)
     
     # publishing messages
     
@@ -78,6 +76,8 @@ class Comm(LoggingConfigurable):
         """Open the frontend-side version of this comm"""
         if data is None:
             data = self._open_data
+        self._closed = False
+        get_ipython().comm_manager.register_comm(self)
         self._publish_msg('comm_open', data, metadata, target_name=self.target_name)
     
     def close(self, data=None, metadata=None):
@@ -88,6 +88,7 @@ class Comm(LoggingConfigurable):
         if data is None:
             data = self._close_data
         self._publish_msg('comm_close', data, metadata)
+        get_ipython().comm_manager.unregister_comm(self)
         self._closed = True
     
     def send(self, data=None, metadata=None):

--- a/IPython/kernel/comm/comm.py
+++ b/IPython/kernel/comm/comm.py
@@ -70,6 +70,7 @@ class Comm(LoggingConfigurable):
     def __del__(self):
         """trigger close on gc"""
         self.close()
+        get_ipython().comm_manager.unregister_comm(self)
     
     # publishing messages
     

--- a/IPython/kernel/comm/manager.py
+++ b/IPython/kernel/comm/manager.py
@@ -76,7 +76,6 @@ class CommManager(LoggingConfigurable):
         """Unregister a comm, and close its counterpart"""
         # unlike get_comm, this should raise a KeyError
         comm = self.comms.pop(comm_id)
-        comm.close()
     
     def get_comm(self, comm_id):
         """Get a comm with a particular id

--- a/IPython/kernel/comm/manager.py
+++ b/IPython/kernel/comm/manager.py
@@ -72,10 +72,10 @@ class CommManager(LoggingConfigurable):
         self.comms[comm_id] = comm
         return comm_id
     
-    def unregister_comm(self, comm_id):
+    def unregister_comm(self, comm):
         """Unregister a comm, and close its counterpart"""
         # unlike get_comm, this should raise a KeyError
-        comm = self.comms.pop(comm_id)
+        comm = self.comms.pop(comm.comm_id)
     
     def get_comm(self, comm_id):
         """Get a comm with a particular id
@@ -115,7 +115,7 @@ class CommManager(LoggingConfigurable):
         except Exception:
             self.log.error("Exception opening comm with target: %s", target_name, exc_info=True)
             comm.close()
-            self.unregister_comm(comm_id)
+            self.unregister_comm(comm)
     
     def comm_msg(self, stream, ident, msg):
         """Handler for comm_msg messages"""

--- a/IPython/kernel/comm/manager.py
+++ b/IPython/kernel/comm/manager.py
@@ -109,13 +109,11 @@ class CommManager(LoggingConfigurable):
             self.log.error("No such comm target registered: %s", target_name)
             comm.close()
             return
-        self.register_comm(comm)
         try:
             f(comm, msg)
         except Exception:
             self.log.error("Exception opening comm with target: %s", target_name, exc_info=True)
             comm.close()
-            self.unregister_comm(comm)
     
     def comm_msg(self, stream, ident, msg):
         """Handler for comm_msg messages"""


### PR DESCRIPTION
- [x] Deleting a comm now unregisters the comm (because creating it already registers it). 
    Unregistering the comm does not close it anymore (because registering the comm does not open it). 
- [x]  closing a widget should not remove it from the collection of widgets Widget.widgets. Closing, reopening a comm is independent of the lifetime of the widget. 
- [x] deleting a widget unregisters the widget from Widget.widgets. Decrements the ref count of the underlying comm. 
