### PR TITLE
Fix auto-rewrite-input (continues #5893)

### DIFF
--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -301,6 +301,7 @@ define([
                 reply : $.proxy(this._handle_execute_reply, this),
                 payload : {
                     set_next_input : $.proxy(this._handle_set_next_input, this),
+                    auto_rewrite_input : $.proxy(this._handle_auto_rewrite_input, this),
                     page : $.proxy(this._open_with_pager, this)
                 }
             },
@@ -333,6 +334,19 @@ define([
     CodeCell.prototype._handle_set_next_input = function (payload) {
         var data = {'cell': this, 'text': payload.text};
         this.events.trigger('set_next_input.Notebook', data);
+    };
+
+    /**
+     * @method _handle_auto_rewrite_input
+     * @private
+     */
+    CodeCell.prototype._handle_auto_rewrite_input = function (payload) {
+        var data = {
+            'cell': this, 
+            'transformed_input': payload.transformed_input,
+            'raw_input': payload.raw_input
+        };
+        this.events.trigger('auto_rewrite_input.Notebook', data);
     };
 
     /**

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -181,7 +181,9 @@ define([
         });
 
         this.events.on('auto_rewrite_input.Notebook', function (event, data) {
-            data.cell.set_text(data.raw_input);
+            if ( data.raw_input){
+                data.cell.set_text(data.raw_input);
+            }
             that.dirty = true;
         });
         

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -180,6 +180,11 @@ define([
             that.dirty = true;
         });
 
+        this.events.on('auto_rewrite_input.Notebook', function (event, data) {
+            data.cell.set_text(data.raw_input);
+            that.dirty = true;
+        });
+        
         this.events.on('set_dirty.Notebook', function (event, data) {
             that.dirty = data.value;
         });

--- a/IPython/kernel/zmq/zmqshell.py
+++ b/IPython/kernel/zmq/zmqshell.py
@@ -475,14 +475,11 @@ class ZMQInteractiveShell(InteractiveShell):
         install_payload_page()
 
     def auto_rewrite_input(self, cmd):
-        """Called to show the auto-rewritten input for autocall and friends.
-
-        FIXME: this payload is currently not correctly processed by the
-        frontend.
-        """
+        """Called to show the auto-rewritten input for autocall and friends.""" 
         new = self.prompt_manager.render('rewrite') + cmd
         payload = dict(
             source='auto_rewrite_input',
+            raw_input=cmd,
             transformed_input=new,
             )
         self.payload_manager.write_payload(payload)


### PR DESCRIPTION
Reissue #5893 rebased + fixes.

**But** rewrite_input is completely undocumented:
- %autocall is the only thing I know of that rewrite input, 
- notebook receive a `raw_input` field which is `undefined`. 
- And the `transformed_input` one has : 
  1. the color escape code
  2. a fancy leading `->` that you absolutely don't want to set as cell's text.

eg: 

```
%autocall
print 'a'
```

send to the notebook 

```
transformed_input: "[0;34m-> [0mprint('a')", 
raw_input: undefined
```

Me sad, and don't know what to do ... :-( @fperez ?
