### PR TITLE
Switch to CodeMirror 4.6.0

### DIFF
--- a/IPython/html/static/base/js/dialog.js
+++ b/IPython/html/static/base/js/dialog.js
@@ -4,7 +4,8 @@
 define([
     'base/js/namespace',
     'jquery',
-], function(IPython, $) {
+    'codemirror/lib/codemirror',
+], function(IPython, $, CodeMirror) {
     "use strict";
     
     var modal = function (options) {

--- a/IPython/html/static/base/js/keyboard.js
+++ b/IPython/html/static/base/js/keyboard.js
@@ -1,5 +1,12 @@
 // Copyright (c) IPython Development Team.
 // Distributed under the terms of the Modified BSD License.
+/**
+ *
+ *
+ * @module keyboard
+ * @namespace keyboard
+ * @class ShortcutManager
+ */
 
 define([
     'base/js/namespace',
@@ -126,6 +133,12 @@ define([
     // Shortcut manager class
 
     var ShortcutManager = function (delay, events) {
+        /**
+         * A class to deal with keyboard event and shortcut
+         *
+         * @class ShortcutManager
+         * @constructor
+         */
         this._shortcuts = {};
         this._counts = {};
         this._timers = {};
@@ -201,6 +214,16 @@ define([
     };
 
     ShortcutManager.prototype.count_handler = function (shortcut, event, data) {
+        /**
+         * Seem to allow to call an handler only after several key press.
+         * like, I suppose `dd` that delete the current cell only after
+         * `d` has been pressed twice..
+         * @method count_handler
+         * @return {Boolean} `true|false`, whether or not the event has been handled.
+         * @param shortcut {shortcut}
+         * @param event {event}
+         * @param data {data}
+         */
         var that = this;
         var c = this._counts;
         var t = this._timers;
@@ -221,6 +244,12 @@ define([
     };
 
     ShortcutManager.prototype.call_handler = function (event) {
+        /**
+         * Call the corresponding shortcut handler for a keyboard event
+         * @method call_handler
+         * @return {Boolean} `true|false`, `false` if no handler was found, otherwise the  value return by the handler. 
+         * @param event {event}
+         */
         var shortcut = event_to_shortcut(event);
         var data = this._shortcuts[shortcut];
         if (data) {
@@ -252,7 +281,7 @@ define([
         event_to_shortcut : event_to_shortcut
     };
 
-    // For backwards compatability.
+    // For backwards compatibility.
     IPython.keyboard = keyboard;
 
     return keyboard;

--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -4,7 +4,8 @@
 define([
     'base/js/namespace',
     'jquery',
-], function(IPython, $){
+    'codemirror/lib/codemirror',
+], function(IPython, $, CodeMirror){
     "use strict";
     
     IPython.load_extensions = function () {

--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -539,6 +539,19 @@ define([
         msg += ajax_error_msg(jqXHR);
         console.log(msg);
     };
+    
+    var requireCodeMirrorMode = function (mode, callback, errback) {
+        // load a mode with requirejs
+        if (typeof mode != "string") mode = mode.name;
+        if (CodeMirror.modes.hasOwnProperty(mode)) {
+            callback(CodeMirror.modes.mode);
+            return;
+        }
+        require([
+                ['codemirror/mode', mode, mode].join('/'),
+            ], callback, errback
+        );
+    };
 
     var utils = {
         regex_split : regex_split,
@@ -564,6 +577,7 @@ define([
         mergeopt: mergeopt,
         ajax_error_msg : ajax_error_msg,
         log_ajax_error : log_ajax_error,
+        requireCodeMirrorMode : requireCodeMirrorMode,
     };
 
     // Backwards compatability.

--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -548,6 +548,7 @@ define([
             return;
         }
         require([
+                // might want to use CodeMirror.modeURL here
                 ['codemirror/mode', mode, mode].join('/'),
             ], callback, errback
         );

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -30,9 +30,9 @@ define([
          * @param:
          *  options: dictionary
          *      Dictionary of keyword arguments.
-         *          events: $(Events) instance 
+         *          events: $(Events) instance
          *          config: dictionary
-         *          keyboard_manager: KeyboardManager instance 
+         *          keyboard_manager: KeyboardManager instance
          */
         options = options || {};
         this.keyboard_manager = options.keyboard_manager;
@@ -183,7 +183,7 @@ define([
         if((cur.line !== 0 || cur.ch !==0) && event.keyCode === 38){
             event._ipkmIgnore = true;
         }
-        var nLastLine = editor.lastLine() 
+        var nLastLine = editor.lastLine()
         if(    ( event.keyCode === 40)
             && (( cur.line !== nLastLine)
             ||  ( cur.ch   !== editor.getLineHandle(nLastLine).text.length))
@@ -192,8 +192,8 @@ define([
         }
         // if this is an edit_shortcuts shortcut, the global keyboard/shortcut
         // manager will handle it
-        if (shortcuts.handles(event)) { 
-            return true; 
+        if (shortcuts.handles(event)) {
+            return true;
         }
         
         return false;
@@ -543,26 +543,26 @@ define([
                     }
                     var open = modes[mode].open || "%%";
                     var close = modes[mode].close || "%%end";
-                    var mmode = mode;
-                    mode = mmode.substr(6);
-                    if(current_mode == mmode){
+                    var magic_mode = mode;
+                    mode = magic_mode.substr(6);
+                    if(current_mode == magic_mode){
                         return;
                     }
                     utils.requireCodeMirrorMode(mode, function () {
                         // create on the fly a mode that switch between
                         // plain/text and something else, otherwise `%%` is
                         // source of some highlight issues.
-                        CodeMirror.defineMode(mmode, function(config) {
+                        CodeMirror.defineMode(magic_mode, function(config) {
                             return CodeMirror.multiplexingMode(
                                 CodeMirror.getMode(config, 'text/plain'),
-                                // always set someting on close
+                                // always set something on close
                                 {open: open, close: close,
                                  mode: CodeMirror.getMode(config, mode),
                                  delimStyle: "delimit"
                                 }
                             );
                         });
-                        that.code_mirror.setOption('mode', mmode);
+                        that.code_mirror.setOption('mode', magic_mode);
                     });
                     return;
                 }

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -198,9 +198,22 @@ define([
     Cell.prototype.handle_codemirror_keyevent = function (editor, event) {
         var shortcuts = this.keyboard_manager.edit_shortcuts;
 
+        var cur = editor.getCursor();
+        if((cur.line !== 0 || cur.ch !==0) && event.keyCode === 38){
+            event._ipkmIgnore = true;
+        }
+        var nLastLine = editor.lastLine() 
+        if(    ( event.keyCode === 40)
+            && (( cur.line !== nLastLine)
+            ||  ( cur.ch   !== editor.getLineHandle(nLastLine).text.length))
+          ){
+            event._ipkmIgnore = true;
+        }
         // if this is an edit_shortcuts shortcut, the global keyboard/shortcut
         // manager will handle it
-        if (shortcuts.handles(event)) { return true; }
+        if (shortcuts.handles(event)) { 
+            return true; 
+        }
         
         return false;
     };
@@ -291,7 +304,6 @@ define([
      * @return {Boolean} `true` if CodeMirror should ignore the event, `false` Otherwise
      */
     Cell.prototype.handle_keyevent = function (editor, event) {
-
         if (this.mode === 'command') {
             return true;
         } else if (this.mode === 'edit') {

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -18,7 +18,7 @@ define([
     'codemirror/addon/edit/matchbrackets',
     'codemirror/addon/edit/closebrackets',
     'codemirror/addon/comment/comment'
-], function(IPython, $, utils, CodeMirror, cm_match, cm_closeb, cm_comment, cm_load) {
+], function(IPython, $, utils, CodeMirror, cm_match, cm_closeb, cm_comment) {
     // TODO: remove IPython dependency here 
     "use strict";
 

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -1,11 +1,24 @@
 // Copyright (c) IPython Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+/**
+ *
+ *
+ * @module cell
+ * @namespace cell
+ * @class Cell
+ */
+
+
 define([
     'base/js/namespace',
     'jquery',
     'base/js/utils',
-], function(IPython, $, utils) {
+    'codemirror/lib/codemirror',
+    'codemirror/addon/edit/matchbrackets',
+    'codemirror/addon/edit/closebrackets',
+    'codemirror/addon/comment/comment'
+], function(IPython, $, utils, CodeMirror, cm_match, cm_closeb, cm_comment) {
     // TODO: remove IPython dependency here 
     "use strict";
 
@@ -29,16 +42,17 @@ define([
     // end monkey patching CodeMirror
 
     var Cell = function (options) {
-        // Constructor
-        //
-        // The Base `Cell` class from which to inherit.
-        //
-        // Parameters:
-        //  options: dictionary
-        //      Dictionary of keyword arguments.
-        //          events: $(Events) instance 
-        //          config: dictionary
-        //          keyboard_manager: KeyboardManager instance 
+        /* Constructor
+         *
+         * The Base `Cell` class from which to inherit.
+         * @constructor
+         * @param:
+         *  options: dictionary
+         *      Dictionary of keyword arguments.
+         *          events: $(Events) instance 
+         *          config: dictionary
+         *          keyboard_manager: KeyboardManager instance 
+         */
         options = options || {};
         this.keyboard_manager = options.keyboard_manager;
         this.events = options.events;
@@ -277,8 +291,6 @@ define([
      * @return {Boolean} `true` if CodeMirror should ignore the event, `false` Otherwise
      */
     Cell.prototype.handle_keyevent = function (editor, event) {
-
-        // console.log('CM', this.mode, event.which, event.type)
 
         if (this.mode === 'command') {
             return true;

--- a/IPython/html/static/notebook/js/celltoolbar.js
+++ b/IPython/html/static/notebook/js/celltoolbar.js
@@ -114,7 +114,7 @@ define([
      * @param name {String} name to use to refer to the callback. It is advised to use a prefix with the name
      * for easier sorting and avoid collision
      * @param callback {function(div, cell)} callback that will be called to generate the ui element
-     * @param [cell_types] {List of String|undefined} optional list of cell types. If present the UI element
+     * @param [cell_types] {List_of_String|undefined} optional list of cell types. If present the UI element
      * will be added only to cells of types in the list.
      *
      *
@@ -163,7 +163,7 @@ define([
      * @method register_preset
      * @param name {String} name to use to refer to the preset. It is advised to use a prefix with the name
      * for easier sorting and avoid collision
-     * @param  preset_list {List of String} reverse order of the button in the toolbar. Each String of the list
+     * @param  preset_list {List_of_String} reverse order of the button in the toolbar. Each String of the list
      *          should correspond to a name of a registerd callback.
      *
      * @private
@@ -288,8 +288,6 @@ define([
     };
 
 
-    /**
-     */
     CellToolbar.utils = {};
 
 
@@ -385,7 +383,7 @@ define([
      * @method utils.select_ui_generator
      * @static
      *
-     * @param list_list {list of sublist} List of sublist of metadata value and name in the dropdown list.
+     * @param list_list {list_of_sublist} List of sublist of metadata value and name in the dropdown list.
      *        subslit shoud contain 2 element each, first a string that woul be displayed in the dropdown list,
      *        and second the corresponding value to  be passed to setter/return by getter. the corresponding value 
      *        should not be "undefined" or behavior can be unexpected.

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -230,7 +230,7 @@ define([
             event.preventDefault();
             return true;
         } else if (event.keyCode === keycodes.tab && event.type === 'keydown' && event.shiftKey) {
-                if (editor.somethingSelected()){
+                if (editor.somethingSelected() || editor.getSelections().length !== 1){
                     var anchor = editor.getCursor("anchor");
                     var head = editor.getCursor("head");
                     if( anchor.line != head.line){
@@ -244,7 +244,9 @@ define([
         } else if (event.keyCode === keycodes.tab && event.type == 'keydown') {
             // Tab completion.
             this.tooltip.remove_and_cancel_tooltip();
-            if (editor.somethingSelected()) {
+
+            // completion does not work on multicursor, it might be possible though in some cases
+            if (editor.somethingSelected() || editor.getSelections().length > 1) {
                 return false;
             }
             var pre_cursor = editor.getRange({line:cur.line,ch:0},cur);

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -83,11 +83,7 @@ define([
         this.completer = null;
 
 
-        var cm_overwrite_options  = {
-            onKeyEvent: $.proxy(this.handle_keyevent,this)
-        };
-
-        var config = utils.mergeopt(CodeCell, this.config, {cm_config: cm_overwrite_options});
+        var config = utils.mergeopt(CodeCell, this.config);
         Cell.apply(this,[{
             config: config, 
             keyboard_manager: options.keyboard_manager, 
@@ -144,7 +140,7 @@ define([
         inner_cell.append(this.celltoolbar.element);
         var input_area = $('<div/>').addClass('input_area');
         this.code_mirror = new CodeMirror(input_area.get(0), this.cm_config);
-        this.code_mirror.on('keydown', $.proxy(this.handle_codemirror_keyevent,this))
+        this.code_mirror.on('keydown', $.proxy(this.handle_keyevent,this))
         $(this.code_mirror.getInputField()).attr("spellcheck", "false");
         inner_cell.append(input_area);
         input.append(prompt).append(inner_cell);

--- a/IPython/html/static/notebook/js/codemirror-ipython.js
+++ b/IPython/html/static/notebook/js/codemirror-ipython.js
@@ -5,18 +5,18 @@
 
 (function(mod) {
   if (typeof exports == "object" && typeof module == "object"){ // CommonJS
-    mod(require("codemirror/lib/codemirror"), 
+    mod(require("codemirror/lib/codemirror"),
         require("codemirror/mode/python/python")
         );
   } else if (typeof define == "function" && define.amd){ // AMD
-    define(["codemirror/lib/codemirror", 
+    define(["codemirror/lib/codemirror",
             "codemirror/mode/python/python"], mod);
   } else {// Plain browser env
     mod(CodeMirror);
   }
 })(function(CodeMirror) {
     "use strict";
-    
+
     CodeMirror.defineMode("ipython", function(conf, parserConf) {
         var pythonConf = {};
         for (var prop in parserConf) {
@@ -36,4 +36,3 @@
 
     CodeMirror.defineMIME("text/x-ipython", "ipython");
 })
-

--- a/IPython/html/static/notebook/js/codemirror-ipython.js
+++ b/IPython/html/static/notebook/js/codemirror-ipython.js
@@ -3,9 +3,20 @@
 // callback to auto-load python mode, which is more likely not the best things
 // to do, but at least the simple one for now.
 
-CodeMirror.requireMode('python',function(){
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object"){ // CommonJS
+    mod(require("codemirror/lib/codemirror"), 
+        require("codemirror/mode/python/python")
+        );
+  } else if (typeof define == "function" && define.amd){ // AMD
+    define(["codemirror/lib/codemirror", 
+            "codemirror/mode/python/python"], mod);
+  } else {// Plain browser env
+    mod(CodeMirror);
+  }
+})(function(CodeMirror) {
     "use strict";
-
+    
     CodeMirror.defineMode("ipython", function(conf, parserConf) {
         var pythonConf = {};
         for (var prop in parserConf) {
@@ -25,3 +36,4 @@ CodeMirror.requireMode('python',function(){
 
     CodeMirror.defineMIME("text/x-ipython", "ipython");
 })
+

--- a/IPython/html/static/notebook/js/codemirror-ipythongfm.js
+++ b/IPython/html/static/notebook/js/codemirror-ipythongfm.js
@@ -1,7 +1,7 @@
-// IPython GFM (GitHub Flavored Markdown) mode is just a slightly altered GFM 
-// Mode with support for latex. 
+// IPython GFM (GitHub Flavored Markdown) mode is just a slightly altered GFM
+// Mode with support for latex.
 //
-// Latex support was supported by Codemirror GFM as of 
+// Latex support was supported by Codemirror GFM as of
 //   https://github.com/codemirror/CodeMirror/pull/567
 // But was later removed in
 //   https://github.com/codemirror/CodeMirror/commit/d9c9f1b1ffe984aee41307f3e927f80d1f23590c
@@ -15,7 +15,7 @@
         ,require("codemirror/mode/stex/stex")
         );
   } else if (typeof define == "function" && define.amd){ // AMD
-    define(["codemirror/lib/codemirror" 
+    define(["codemirror/lib/codemirror"
             ,"codemirror/addon/mode/multiplex"
             ,"codemirror/mode/python/python"
             ,"codemirror/mode/stex/stex"
@@ -27,10 +27,10 @@
     "use strict";
 
     CodeMirror.defineMode("ipythongfm", function(config, parserConfig) {
-        
+
         var gfm_mode = CodeMirror.getMode(config, "gfm");
         var tex_mode = CodeMirror.getMode(config, "stex");
-        
+
         return CodeMirror.multiplexingMode(
             gfm_mode,
             {
@@ -57,8 +57,6 @@
             // .. more multiplexed styles can follow here
         );
     }, 'gfm');
-    
+
     CodeMirror.defineMIME("text/x-ipythongfm", "ipythongfm");
-
-
 })

--- a/IPython/html/static/notebook/js/codemirror-ipythongfm.js
+++ b/IPython/html/static/notebook/js/codemirror-ipythongfm.js
@@ -6,39 +6,59 @@
 // But was later removed in
 //   https://github.com/codemirror/CodeMirror/commit/d9c9f1b1ffe984aee41307f3e927f80d1f23590c
 
-CodeMirror.requireMode('gfm', function(){ 
-    CodeMirror.requireMode('stex', function(){ 
-        CodeMirror.defineMode("ipythongfm", function(config, parserConfig) {
-            
-            var gfm_mode = CodeMirror.getMode(config, "gfm");
-            var tex_mode = CodeMirror.getMode(config, "stex");
-            
-            return CodeMirror.multiplexingMode(
-                gfm_mode,
-                {
-                    open: "$", close: "$",
-                    mode: tex_mode,
-                    delimStyle: "delimit"
-                },
-                {
-                    open: "$$", close: "$$",
-                    mode: tex_mode,
-                    delimStyle: "delimit"
-                },
-                {
-                    open: "\\(", close: "\\)",
-                    mode: tex_mode,
-                    delimStyle: "delimit"
-                },
-                {
-                    open: "\\[", close: "\\]",
-                    mode: tex_mode,
-                    delimStyle: "delimit"
-                }
-                // .. more multiplexed styles can follow here
-            );
-        }, 'gfm');
+
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object"){ // CommonJS
+    mod(require("codemirror/lib/codemirror")
+        ,require("codemirror/addon/mode/multiplex")
+        ,require("codemirror/mode/gfm/gfm")
+        ,require("codemirror/mode/stex/stex")
+        );
+  } else if (typeof define == "function" && define.amd){ // AMD
+    define(["codemirror/lib/codemirror" 
+            ,"codemirror/addon/mode/multiplex"
+            ,"codemirror/mode/python/python"
+            ,"codemirror/mode/stex/stex"
+            ], mod);
+  } else {// Plain browser env
+    mod(CodeMirror);
+  }
+})( function(CodeMirror){
+    "use strict";
+
+    CodeMirror.defineMode("ipythongfm", function(config, parserConfig) {
         
-        CodeMirror.defineMIME("text/x-ipythongfm", "ipythongfm");
-    });
-});
+        var gfm_mode = CodeMirror.getMode(config, "gfm");
+        var tex_mode = CodeMirror.getMode(config, "stex");
+        
+        return CodeMirror.multiplexingMode(
+            gfm_mode,
+            {
+                open: "$", close: "$",
+                mode: tex_mode,
+                delimStyle: "delimit"
+            },
+            {
+                // not sure this works as $$ is interpreted at (opening $, closing $, as defined just above)
+                open: "$$", close: "$$",
+                mode: tex_mode,
+                delimStyle: "delimit"
+            },
+            {
+                open: "\\(", close: "\\)",
+                mode: tex_mode,
+                delimStyle: "delimit"
+            },
+            {
+                open: "\\[", close: "\\]",
+                mode: tex_mode,
+                delimStyle: "delimit"
+            }
+            // .. more multiplexed styles can follow here
+        );
+    }, 'gfm');
+    
+    CodeMirror.defineMIME("text/x-ipythongfm", "ipythongfm");
+
+
+})

--- a/IPython/html/static/notebook/js/completer.js
+++ b/IPython/html/static/notebook/js/completer.js
@@ -318,11 +318,13 @@ define([
         // Enter
         if (code == keycodes.enter) {
             event.codemirrorIgnore = true;
+            event._ipkmIgnore = true;
             event.preventDefault();
             this.pick();
         // Escape or backspace
         } else if (code == keycodes.esc || code == keycodes.backspace) {
             event.codemirrorIgnore = true;
+            event._ipkmIgnore = true;
             event.preventDefault();
             this.close();
         } else if (code == keycodes.tab) {
@@ -343,6 +345,7 @@ define([
             // need to do that to be able to move the arrow
             // when on the first or last line ofo a code cell
             event.codemirrorIgnore = true;
+            event._ipkmIgnore = true;
             event.preventDefault();
 
             var options = this.sel.find('option');
@@ -356,7 +359,7 @@ define([
             index = Math.min(Math.max(index, 0), options.length-1);
             this.sel[0].selectedIndex = index;
         } else if (code == keycodes.pageup || code == keycodes.pagedown) {
-            CodeMirror.e_stop(event);
+            event._ipkmIgnore = true;
 
             var options = this.sel.find('option');
             var index = this.sel[0].selectedIndex;

--- a/IPython/html/static/notebook/js/completer.js
+++ b/IPython/html/static/notebook/js/completer.js
@@ -143,7 +143,7 @@ define([
         }
 
         // We want a single cursor position.
-        if (this.editor.somethingSelected()|| editor.getSelections().length > 1) {
+        if (this.editor.somethingSelected()|| this.editor.getSelections().length > 1) {
             return;
         }
 

--- a/IPython/html/static/notebook/js/completer.js
+++ b/IPython/html/static/notebook/js/completer.js
@@ -7,7 +7,8 @@ define([
     'base/js/utils',
     'base/js/keyboard',
     'notebook/js/contexthint',
-], function(IPython, $, utils, keyboard) {
+    'codemirror/lib/codemirror',
+], function(IPython, $, utils, keyboard, CodeMirror) {
     "use strict";
 
     // easier key mapping
@@ -316,11 +317,13 @@ define([
 
         // Enter
         if (code == keycodes.enter) {
-            CodeMirror.e_stop(event);
+            event.codemirrorIgnore = true;
+            event.preventDefault();
             this.pick();
         // Escape or backspace
         } else if (code == keycodes.esc || code == keycodes.backspace) {
-            CodeMirror.e_stop(event);
+            event.codemirrorIgnore = true;
+            event.preventDefault();
             this.close();
         } else if (code == keycodes.tab) {
             //all the fastforwarding operation,
@@ -339,7 +342,8 @@ define([
         } else if (code == keycodes.up || code == keycodes.down) {
             // need to do that to be able to move the arrow
             // when on the first or last line ofo a code cell
-            CodeMirror.e_stop(event);
+            event.codemirrorIgnore = true;
+            event.preventDefault();
 
             var options = this.sel.find('option');
             var index = this.sel[0].selectedIndex;

--- a/IPython/html/static/notebook/js/completer.js
+++ b/IPython/html/static/notebook/js/completer.js
@@ -94,7 +94,7 @@ define([
     Completer.prototype.startCompletion = function () {
         // call for a 'first' completion, that will set the editor and do some
         // special behavior like autopicking if only one completion available.
-        if (this.editor.somethingSelected()) return;
+        if (this.editor.somethingSelected()|| this.editor.getSelections().length > 1) return;
         this.done = false;
         // use to get focus back on opera
         this.carry_on_completion(true);
@@ -143,7 +143,7 @@ define([
         }
 
         // We want a single cursor position.
-        if (this.editor.somethingSelected()) {
+        if (this.editor.somethingSelected()|| editor.getSelections().length > 1) {
             return;
         }
 

--- a/IPython/html/static/notebook/js/config.js
+++ b/IPython/html/static/notebook/js/config.js
@@ -1,6 +1,15 @@
 // Copyright (c) IPython Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+/**
+ *
+ *
+ * @module config
+ * @namespace config
+ * @class Config
+ */
+
+
 define([], function() {
     "use strict";
 

--- a/IPython/html/static/notebook/js/contexthint.js
+++ b/IPython/html/static/notebook/js/contexthint.js
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 // highly adapted for codemiror jshint
-define([], function() {
+define(['codemirror/lib/codemirror'], function(CodeMirror) {
     "use strict";
 
     var forEach = function(arr, f) {

--- a/IPython/html/static/notebook/js/keyboardmanager.js
+++ b/IPython/html/static/notebook/js/keyboardmanager.js
@@ -514,7 +514,8 @@ define([
     KeyboardManager.prototype.bind_events = function () {
         var that = this;
         $(document).keydown(function (event) {
-            if(event._ipkmIgnore==true||event.originalEvent._ipkmIgnore==true){
+
+            if(event._ipkmIgnore==true||(event.originalEvent||{})._ipkmIgnore==true){
                 return false;
             }
             return that.handle_keydown(event);

--- a/IPython/html/static/notebook/js/keyboardmanager.js
+++ b/IPython/html/static/notebook/js/keyboardmanager.js
@@ -227,6 +227,9 @@ define([
                 help    : 'select previous cell',
                 help_index : 'da',
                 handler : function (event) {
+                    if(event.codemirrorIgnore===true){
+                        return false;
+                    }
                     var index = that.notebook.get_selected_index();
                     if (index !== 0 && index !== null) {
                         that.notebook.select_prev();
@@ -239,6 +242,9 @@ define([
                 help    : 'select next cell',
                 help_index : 'db',
                 handler : function (event) {
+                    if(event.codemirrorIgnore===true){
+                        return false;
+                    }
                     var index = that.notebook.get_selected_index();
                     if (index !== (that.notebook.ncells()-1) && index !== null) {
                         that.notebook.select_next();
@@ -508,6 +514,9 @@ define([
     KeyboardManager.prototype.bind_events = function () {
         var that = this;
         $(document).keydown(function (event) {
+            if(event._ipkmIgnore==true||event.originalEvent._ipkmIgnore==true){
+                return false;
+            }
             return that.handle_keydown(event);
         });
     };

--- a/IPython/html/static/notebook/js/keyboardmanager.js
+++ b/IPython/html/static/notebook/js/keyboardmanager.js
@@ -227,9 +227,6 @@ define([
                 help    : 'select previous cell',
                 help_index : 'da',
                 handler : function (event) {
-                    if(event.codemirrorIgnore===true){
-                        return false;
-                    }
                     var index = that.notebook.get_selected_index();
                     if (index !== 0 && index !== null) {
                         that.notebook.select_prev();
@@ -242,9 +239,6 @@ define([
                 help    : 'select next cell',
                 help_index : 'db',
                 handler : function (event) {
-                    if(event.codemirrorIgnore===true){
-                        return false;
-                    }
                     var index = that.notebook.get_selected_index();
                     if (index !== (that.notebook.ncells()-1) && index !== null) {
                         that.notebook.select_next();

--- a/IPython/html/static/notebook/js/keyboardmanager.js
+++ b/IPython/html/static/notebook/js/keyboardmanager.js
@@ -1,5 +1,12 @@
 // Copyright (c) IPython Development Team.
 // Distributed under the terms of the Modified BSD License.
+/**
+ *
+ *
+ * @module keyboardmanager
+ * @namespace keyboardmanager
+ * @class KeyboardManager
+ */
 
 define([
     'base/js/namespace',
@@ -16,13 +23,15 @@ define([
     var keycodes = keyboard.keycodes;
 
     var KeyboardManager = function (options) {
-        // Constructor
-        //
-        // Parameters:
-        //  options: dictionary
-        //      Dictionary of keyword arguments.
-        //          events: $(Events) instance
-        //          pager: Pager instance
+        /**
+         * A class to deal with keyboard event and shortcut
+         *
+         * @class KeyboardManager
+         * @constructor
+         * @param options {dict} Dictionary of keyword arguments :
+         *    @param options.events {$(Events)} instance 
+         *    @param options.pager: {Pager}  pager instance
+         */
         this.mode = 'command';
         this.enabled = true;
         this.pager = options.pager;
@@ -37,6 +46,22 @@ define([
         this.edit_shortcuts.add_shortcuts(this.get_default_edit_shortcuts());
     };
 
+    /**
+     * Return a dict of common shortcut
+     * @method get_default_common_shortcuts
+     *
+     * @example Example of returned shortcut
+     * ```
+     * 'shortcut-key': // a string representing the shortcut as dash separated value.
+     *                 // e.g. 'shift' , 'shift-enter', 'cmd-t'
+     *  {
+     *     help: String // user facing help string 
+     *     help_index: String // string used internally to order the shortcut on the quickhelp
+     *     handler: function(event){return true|false} // function that takes an even as first and only parameter
+     *          // and return a boolean indicating whether or not the event should been handled further.
+     *   }
+     *```
+     */
     KeyboardManager.prototype.get_default_common_shortcuts = function() {
         var that = this;
         var shortcuts = {
@@ -125,19 +150,17 @@ define([
                 handler : function (event) {
                     var index = that.notebook.get_selected_index();
                     var cell = that.notebook.get_cell(index);
-                    if (cell && cell.at_top() && index !== 0) {
+                    var cm = that.notebook.get_selected_cell().code_mirror;
+                    var cur = cm.getCursor()
+                    if (cell && cell.at_top() && index !== 0 && cur.ch === 0) {
                         event.preventDefault();
                         that.notebook.command_mode();
                         that.notebook.select_prev();
                         that.notebook.edit_mode();
                         var cm = that.notebook.get_selected_cell().code_mirror;
                         cm.setCursor(cm.lastLine(), 0);
-                        return false;
-                    } else if (cell) {
-                        var cm = cell.code_mirror;
-                        cm.execCommand('goLineUp');
-                        return false;
                     }
+                    return false;
                 }
             },
             'down' : {
@@ -154,11 +177,8 @@ define([
                         var cm = that.notebook.get_selected_cell().code_mirror;
                         cm.setCursor(0, 0);
                         return false;
-                    } else {
-                        var cm = cell.code_mirror;
-                        cm.execCommand('goLineDown');
-                        return false;
                     }
+                    return false;
                 }
             },
             'ctrl-shift--' : {

--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -20,7 +20,6 @@ require([
     'notebook/js/config',
     'notebook/js/kernelselector',
     'codemirror/lib/codemirror',
-    'codemirror/addon/mode/loadmode',
     // only loaded, not used, please keep sure this is loaded last
     'custom/custom'
 ], function(
@@ -42,7 +41,6 @@ require([
     config,
     kernelselector,
     CodeMirror,
-    cm_loadmode,
     // please keep sure that even if not used, this is loaded last
     custom
     ) {

--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -46,13 +46,12 @@ require([
     ) {
     "use strict";
 
+    // compat with old IPython, remove for IPython > 3.0
     window.CodeMirror = CodeMirror;
-    $('#ipython-main-app').addClass('border-box-sizing');
-    $('div#notebook_panel').addClass('border-box-sizing');
 
     var common_options = {
+        ws_url : utils.get_body_data("wsUrl"),
         base_url : utils.get_body_data("baseUrl"),
-        ws_url : IPython.utils.get_body_data("wsUrl"),
         notebook_path : utils.get_body_data("notebookPath"),
         notebook_name : utils.get_body_data('notebookName')
     };

--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -19,8 +19,10 @@ require([
     'notebook/js/keyboardmanager',
     'notebook/js/config',
     'notebook/js/kernelselector',
-    // only loaded, not used:
-    'custom/custom',
+    'codemirror/lib/codemirror',
+    'codemirror/addon/mode/loadmode',
+    // only loaded, not used, please keep sure this is loaded last
+    'custom/custom'
 ], function(
     IPython, 
     $,
@@ -38,9 +40,17 @@ require([
     savewidget, 
     keyboardmanager,
     config,
-    kernelselector
+    kernelselector,
+    CodeMirror,
+    cm_loadmode,
+    // please keep sure that even if not used, this is loaded last
+    custom
     ) {
     "use strict";
+
+    window.CodeMirror = CodeMirror;
+    $('#ipython-main-app').addClass('border-box-sizing');
+    $('div#notebook_panel').addClass('border-box-sizing');
 
     var common_options = {
         base_url : utils.get_body_data("baseUrl"),

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1532,7 +1532,7 @@ define([
         modename = newmode.name || newmode
 
         that = this;
-        CodeMirror.requireMode(modename, function(){
+        utils.requireCodeMirrorMode(modename, function () {
             $.map(that.get_cells(), function(cell, i) {
                 if (cell.cell_type === 'code'){
                     cell.code_mirror.setOption('mode', newmode);

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -893,7 +893,7 @@ define([
      * Insert an element at given cell index.
      *
      * @method _insert_element_at_index
-     * @param element {dom element} a cell element
+     * @param element {dom_element} a cell element
      * @param [index] {int} a valid index where to inser cell
      * @private
      *

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -10,7 +10,10 @@ define([
     'notebook/js/mathjaxutils',
     'notebook/js/celltoolbar',
     'components/marked/lib/marked',
-], function(IPython, utils, $, cell, security, mathjaxutils, celltoolbar, marked) {
+    'codemirror/lib/codemirror',
+    'codemirror/mode/gfm/gfm',
+    'notebook/js/codemirror-ipythongfm'
+], function(IPython,utils , $, cell, security, mathjaxutils, celltoolbar, marked, CodeMirror, gfm, ipgfm) {
     "use strict";
     var Cell = cell.Cell;
 

--- a/IPython/html/static/notebook/js/toolbar.js
+++ b/IPython/html/static/notebook/js/toolbar.js
@@ -11,7 +11,7 @@ define([
      * A generic toolbar on which one can add button
      * @class ToolBar
      * @constructor
-     * @param {Dom object} selector
+     * @param {Dom_object} selector
      */
     var ToolBar = function (selector, layout_manager) {
         this.selector = selector;

--- a/IPython/html/static/notebook/js/tooltip.js
+++ b/IPython/html/static/notebook/js/tooltip.js
@@ -117,8 +117,7 @@ define([
 
     Tooltip.prototype.showInPager = function (cell) {
         // reexecute last call in pager by appending ? to show back in pager
-        var that = this;
-        this.events.trigger('open_with_text.Pager', that._reply.content);
+        this.events.trigger('open_with_text.Pager', this._reply.content);
         this.remove_and_cancel_tooltip();
     };
 
@@ -208,7 +207,7 @@ define([
         var msg_id = cell.kernel.inspect(text, cursor_pos, callbacks);
     };
 
-    // make an imediate completion request
+    // make an immediate completion request
     Tooltip.prototype.request = function (cell, hide_if_no_docstring) {
         // request(codecell)
         // Deal with extracting the text from the cell and counting
@@ -222,10 +221,11 @@ define([
         this._hide_if_no_docstring = hide_if_no_docstring;
 
         if(editor.somethingSelected()){
+            // get only the most recent selection.
             text = editor.getSelection();
         }
 
-        // need a permanent handel to code_mirror for future auto recall
+        // need a permanent handle to code_mirror for future auto recall
         this.code_mirror = editor;
 
         // now we treat the different number of keypress
@@ -325,7 +325,7 @@ define([
         this.text.scrollTop(0);
     };
 
-    // Backwards compatability.
+    // Backwards compatibility.
     IPython.Tooltip = Tooltip;
 
     return {'Tooltip': Tooltip};

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -311,25 +311,17 @@ class="notebook_app"
 {% block script %}
 {{super()}}
 
-<script src="{{ static_url("components/codemirror/lib/codemirror.js") }}" charset="utf-8"></script>
+
 <script type="text/javascript">
-    CodeMirror.modeURL = "{{ static_url("components/codemirror/mode/%N/%N.js", include_version=False) }}";
+	require(['codemirror/lib/codemirror',
+ 		], function(CodeMirror){
+    		CodeMirror.modeURL = "{{ static_url("components/codemirror/mode/%N/%N.js", include_version=False) }}";
+//		require([
+//			 'notebook/js/codemirror-ipython',
+//			 'notebook/js/codemirror-ipythongfm'
+//], function(){})
+	});
 </script>
-<script src="{{ static_url("components/codemirror/addon/mode/loadmode.js") }}" charset="utf-8"></script>
-<script src="{{ static_url("components/codemirror/addon/mode/multiplex.js") }}" charset="utf-8"></script>
-<script src="{{ static_url("components/codemirror/addon/mode/overlay.js") }}" charset="utf-8"></script>
-<script src="{{ static_url("components/codemirror/addon/edit/matchbrackets.js") }}" charset="utf-8"></script>
-<script src="{{ static_url("components/codemirror/addon/edit/closebrackets.js") }}" charset="utf-8"></script>
-<script src="{{ static_url("components/codemirror/addon/comment/comment.js") }}" charset="utf-8"></script>
-<script src="{{ static_url("components/codemirror/mode/htmlmixed/htmlmixed.js") }}" charset="utf-8"></script>
-<script src="{{ static_url("components/codemirror/mode/xml/xml.js") }}" charset="utf-8"></script>
-<script src="{{ static_url("components/codemirror/mode/javascript/javascript.js") }}" charset="utf-8"></script>
-<script src="{{ static_url("components/codemirror/mode/css/css.js") }}" charset="utf-8"></script>
-<script src="{{ static_url("components/codemirror/mode/rst/rst.js") }}" charset="utf-8"></script>
-<script src="{{ static_url("components/codemirror/mode/markdown/markdown.js") }}" charset="utf-8"></script>
-<script src="{{ static_url("components/codemirror/mode/python/python.js") }}" charset="utf-8"></script>
-<script src="{{ static_url("notebook/js/codemirror-ipython.js") }}" charset="utf-8"></script>
-<script src="{{ static_url("notebook/js/codemirror-ipythongfm.js") }}" charset="utf-8"></script>
 
 <script src="{{ static_url("notebook/js/main.js") }}" charset="utf-8"></script>
 

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -312,17 +312,6 @@ class="notebook_app"
 {{super()}}
 
 
-<script type="text/javascript">
-	require(['codemirror/lib/codemirror',
- 		], function(CodeMirror){
-    		CodeMirror.modeURL = "{{ static_url("components/codemirror/mode/%N/%N.js", include_version=False) }}";
-//		require([
-//			 'notebook/js/codemirror-ipython',
-//			 'notebook/js/codemirror-ipythongfm'
-//], function(){})
-	});
-</script>
-
 <script src="{{ static_url("notebook/js/main.js") }}" charset="utf-8"></script>
 
 {% endblock %}

--- a/IPython/html/templates/page.html
+++ b/IPython/html/templates/page.html
@@ -28,6 +28,7 @@
             jqueryui: 'components/jquery-ui/ui/minified/jquery-ui.min',
             highlight: 'components/highlight.js/build/highlight.pack',
             moment: "components/moment/moment",
+            codemirror: 'components/codemirror',
           },
           shim: {
             underscore: {


### PR DESCRIPTION
Update to CodeMirror 4

That mean multiple cursor ! Yeaaah. 

<del>On the dark side, we have to painfully recode ipythongfm and ipython mode (I'll appreciate help) .</del> (Done)

A few things have changed, in particular `event.stop()` does not exist, and I had to comment the `goLineUp` and `goLineDown` in kerboardmanager as returning `true`/`false`seem not to be the way to go anymore to prevent CM from handeling the events ( @ellisonbg your input on that )

<del>Completer does not intercept up/down anymore...</del>


Todo: 
- [x] update to cm 4.6
- [x] fix completer
- [x] search for "somethingSelected" add "or MultipleCursors" (like completion)
- [x] fix shift tab 4 time select previsous cell
- [x] fix tests.
- [x] remove deprecated logic since CM 2.x
- [x] ~~completer : insert at all cursors.~~
- [x] autohighlight (Carreau/ipython#10)

But globally it seem to work. 
