### PR TITLE
Fix kernelspec test skip condition

### DIFF
--- a/IPython/kernel/tests/test_kernelspec.py
+++ b/IPython/kernel/tests/test_kernelspec.py
@@ -57,7 +57,7 @@ class KernelSpecTests(unittest.TestCase):
                                      kernel_name='tstinstalled',
                                      replace=True)
     
-    @onlyif(os.name != 'nt' and not os.access('/usr/share', os.W_OK), "needs Unix system without root privileges")
+    @onlyif(os.name != 'nt' and not os.access('/usr/local/share', os.W_OK), "needs Unix system without root privileges")
     def test_cant_install_kernel_spec(self):
         with self.assertRaises(OSError):
             self.ksm.install_kernel_spec(self.installable_kernel,


### PR DESCRIPTION
The code actually tries to write to /usr/local/share, but the test was still checking for /usr/share. @minrk will test, as access to these differs on his machine.
