### PR TITLE
Explicitly set the profile directory when running tests

### DIFF
--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -304,7 +304,7 @@ class JSController(TestController):
             command.append('--KernelManager.transport=ipc')
         self.stream_capturer = c = StreamCapturer()
         c.start()
-        self.server = subprocess.Popen(command, stdout=c.writefd, stderr=subprocess.STDOUT)
+        self.server = subprocess.Popen(command, stdout=c.writefd, stderr=subprocess.STDOUT, cwd=self.nbdir.name)
         self.server_info_file = os.path.join(self.ipydir.name,
             'profile_default', 'security', 'nbserver-%i.json' % self.server.pid
         )


### PR DESCRIPTION
Because of the profile directory searching algorithm, if the current working directory has a directory named 'profile_default', that will be used instead of the temporary profile directory the tests expect.  Setting the profile directory explicitly fixes this problem.
