### PR TITLE
always use HTTPS getting mathjax from CDN

### DIFF
--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -546,7 +546,7 @@ class NotebookApp(BaseIPythonApplication):
                 return url
         
         # no local mathjax, serve from CDN
-        url = u"//cdn.mathjax.org/mathjax/latest/MathJax.js"
+        url = u"https://cdn.mathjax.org/mathjax/latest/MathJax.js"
         self.log.info("Using MathJax from CDN: %s", url)
         return url
     


### PR DESCRIPTION
Is there any reason not to do this now?

closes #6246
