### PR TITLE
avoid unregistering widget model twice

### DIFF
--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -164,8 +164,8 @@ class Widget(LoggingConfigurable):
         Closes the underlying comm.
         When the comm is closed, all of the widget views are automatically
         removed from the front-end."""
-        del Widget.widgets[self.model_id]
         if self._comm is not None:
+            Widget.widgets.pop(self.model_id, None)
             self._comm.close()
         self._comm = None
     


### PR DESCRIPTION
widgets are registered when the comm is created; closing unregisters them. Calling `close` a second time should be a no-op.
