### PR TITLE
Copy codemirror mode from kernelspec before passing to codemirror

### DIFF
--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1499,6 +1499,15 @@ define([
         if (newmode === this.codemirror_mode) {
             return;
         }
+        if ("object" === typeof newmode) {
+            // Copy the object so that codemirror can't modify the original
+            var newmode_copy = {};
+            for (var attr in newmode) {
+                if (newmode.hasOwnProperty(attr)) newmode_copy[attr] = newmode[attr];
+            }
+            newmode = newmode_copy;
+        }
+
         this.codemirror_mode = newmode;
         codecell.CodeCell.options_default.cm_config.mode = newmode;
         modename = newmode.name || newmode


### PR DESCRIPTION
This should fix the IPython mode embedded in notebooks when they're saved - codemirror (or our mode) was changing the object passed into it, which was the same object being stored in the notebook metadata.

Ping @jasongrout
