### PR TITLE
Copy codemirror mode configuration instead of changing it

### DIFF
--- a/IPython/html/static/notebook/js/codemirror-ipython.js
+++ b/IPython/html/static/notebook/js/codemirror-ipython.js
@@ -7,10 +7,15 @@ CodeMirror.requireMode('python',function(){
     "use strict";
 
     CodeMirror.defineMode("ipython", function(conf, parserConf) {
-
-        parserConf.singleOperators = new RegExp("^[\\+\\-\\*/%&|\\^~<>!\\?]");
-        parserConf.name = 'python'
-        return CodeMirror.getMode(conf, parserConf);
+        var pythonConf = {};
+        for (var prop in parserConf) {
+            if (parserConf.hasOwnProperty(prop)) {
+                pythonConf[prop] = parserConf[prop];
+            }
+        }
+        pythonConf.name = 'python';
+        pythonConf.singleOperators = new RegExp("^[\\+\\-\\*/%&|\\^~<>!\\?]");
+        return CodeMirror.getMode(conf, pythonConf);
     }, 'python');
 
     CodeMirror.defineMIME("text/x-ipython", "ipython");


### PR DESCRIPTION
If we change it, the modified (wrong) mode is saved in the notebook, which
wrecks havoc on highlighting once the notebook is saved and reopened.
