### PR TITLE
Allow either okay or accept_role to be returned by QtConsole confirm exit.

### DIFF
--- a/IPython/qt/console/mainwindow.py
+++ b/IPython/qt/console/mainwindow.py
@@ -892,6 +892,7 @@ class MainWindow(QtGui.QMainWindow):
         title = self.window().windowTitle()
         cancel = QtGui.QMessageBox.Cancel
         okay = QtGui.QMessageBox.Ok
+        accept_role = QtGui.QMessageBox.AcceptRole
         
         if self.confirm_exit:
             if self.tab_widget.count() > 1:
@@ -917,7 +918,7 @@ class MainWindow(QtGui.QMainWindow):
         if reply == cancel:
             event.ignore()
             return
-        if reply == okay:
+        if reply == okay or reply == accept_role:
             while self.tab_widget.count() >= 1:
                 # prevent further confirmations:
                 widget = self.active_frontend


### PR DESCRIPTION
I am using Python 2.7.8 and PyQt 4.10.4 on Linux Mint 17 32 bit, and the latest master de3c13ca6e16aaa0624cfe007e3e326077991670.  When I close a QtConsole using the `X` button, it was not triggering the widgets to close.  When I clicked "Quit", it was returning `0`, which corresponds to `AcceptRole`.  
This problem was preventing the `do_shutdown` method of the [octave_kernel](https://github.com/blink1073/octave_kernel) from being called.
