### PR TITLE
parse_filename: Fixed issues when file name contains dots.

### DIFF
--- a/IPython/nbformat/v2/__init__.py
+++ b/IPython/nbformat/v2/__init__.py
@@ -74,6 +74,7 @@ def parse_filename(fname):
     elif ext == u'.py':
         format = u'py'
     else:
+        basename = fname
         fname = fname + u'.ipynb'
         format = u'json'
     return fname, basename, format

--- a/IPython/nbformat/v2/__init__.py
+++ b/IPython/nbformat/v2/__init__.py
@@ -16,6 +16,8 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
+import os
+
 from .nbbase import (
     NotebookNode,
     new_code_cell, new_text_cell, new_notebook, new_output, new_worksheet,
@@ -64,15 +66,14 @@ def parse_filename(fname):
     (fname, name, format) : (unicode, unicode, unicode)
         The filename, notebook name and format.
     """
-    if fname.endswith(u'.ipynb'):
+    basename, ext = os.path.splitext(fname)
+    if ext == u'.ipynb':
         format = u'json'
-    elif fname.endswith(u'.json'):
+    elif ext == u'.json':
         format = u'json'
-    elif fname.endswith(u'.py'):
+    elif ext == u'.py':
         format = u'py'
     else:
         fname = fname + u'.ipynb'
         format = u'json'
-    name = fname.split('.')[0]
-    return fname, name, format
-
+    return fname, basename, format

--- a/IPython/nbformat/v3/__init__.py
+++ b/IPython/nbformat/v3/__init__.py
@@ -16,6 +16,8 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
+import os
+
 from .nbbase import (
     NotebookNode,
     new_code_cell, new_text_cell, new_notebook, new_output, new_worksheet,
@@ -61,15 +63,14 @@ def parse_filename(fname):
     (fname, name, format) : (unicode, unicode, unicode)
         The filename, notebook name and format.
     """
-    if fname.endswith(u'.ipynb'):
+    basename, ext = os.path.splitext(fname)
+    if ext == u'.ipynb':
         format = u'json'
-    elif fname.endswith(u'.json'):
+    elif ext == u'.json':
         format = u'json'
-    elif fname.endswith(u'.py'):
+    elif ext == u'.py':
         format = u'py'
     else:
         fname = fname + u'.ipynb'
         format = u'json'
-    name = fname.split('.')[0]
-    return fname, name, format
-
+    return fname, basename, format

--- a/IPython/nbformat/v3/__init__.py
+++ b/IPython/nbformat/v3/__init__.py
@@ -71,6 +71,7 @@ def parse_filename(fname):
     elif ext == u'.py':
         format = u'py'
     else:
+        basename = fname
         fname = fname + u'.ipynb'
         format = u'json'
     return fname, basename, format

--- a/IPython/nbformat/v3/tests/test_misc.py
+++ b/IPython/nbformat/v3/tests/test_misc.py
@@ -1,0 +1,31 @@
+from unittest import TestCase
+
+from IPython.utils.py3compat import unicode_type
+from .. import parse_filename
+
+
+class MiscTests(TestCase):
+
+    def check_filename(self, path, exp_fname, exp_bname, exp_format):
+        fname, bname, format = parse_filename(path)
+        self.assertEqual(fname, exp_fname)
+        self.assertEqual(bname, exp_bname)
+        self.assertEqual(format, exp_format)
+
+    def test_parse_filename(self):
+
+        # check format detection
+        self.check_filename("test.ipynb", "test.ipynb", "test", "json")
+        self.check_filename("test.json", "test.json", "test", "json")
+        self.check_filename("test.py", "test.py", "test", "py")
+
+        # check parsing an unknown format
+        self.check_filename("test.nb", "test.nb.ipynb", "test.nb", "json")
+
+        # check parsing a full file path
+        self.check_filename("/tmp/test.ipynb", "/tmp/test.ipynb", "/tmp/test",
+                            "json")
+
+        # check parsing a file name containing dots
+        self.check_filename("test.nb.ipynb", "test.nb.ipynb", "test.nb",
+                            "json")

--- a/IPython/nbformat/v3/tests/test_misc.py
+++ b/IPython/nbformat/v3/tests/test_misc.py
@@ -1,3 +1,4 @@
+import os
 from unittest import TestCase
 
 from IPython.utils.py3compat import unicode_type
@@ -23,8 +24,9 @@ class MiscTests(TestCase):
         self.check_filename("test.nb", "test.nb.ipynb", "test.nb", "json")
 
         # check parsing a full file path
-        self.check_filename("/tmp/test.ipynb", "/tmp/test.ipynb", "/tmp/test",
-                            "json")
+        abs_path = os.path.abspath("test.ipynb")
+        basename, ext = os.path.splitext(abs_path)
+        self.check_filename(abs_path, abs_path, basename, "json")
 
         # check parsing a file name containing dots
         self.check_filename("test.nb.ipynb", "test.nb.ipynb", "test.nb",


### PR DESCRIPTION
Unfortunately the code of `parse_filename` seems to be duplicated. This patch should fix problems that arise when the file name contains dots. Obviously `name = fname.split('.')[0]` will not work in this case.

This should fix issue #6260.
