### PR TITLE
Upgrade default mathjax version.

### DIFF
--- a/IPython/external/mathjax.py
+++ b/IPython/external/mathjax.py
@@ -136,7 +136,7 @@ def extract_zip(fd, dest):
     os.rename(os.path.join(parent, topdir), dest)
 
 
-def install_mathjax(tag='v2.2', dest=default_dest, replace=False, file=None, extractor=extract_tar):
+def install_mathjax(tag='2.4.0', dest=default_dest, replace=False, file=None, extractor=extract_tar):
     """Download and/or install MathJax for offline use.
 
     This will install mathjax to the nbextensions dir in your IPYTHONDIR.
@@ -150,8 +150,8 @@ def install_mathjax(tag='v2.2', dest=default_dest, replace=False, file=None, ext
         Whether to remove and replace an existing install.
     dest : str [IPYTHONDIR/nbextensions/mathjax]
         Where to install mathjax
-    tag : str ['v2.2']
-        Which tag to download. Default is 'v2.2', the current stable release,
+    tag : str ['2.4.0']
+        Which tag to download. Default is '2.4.0', the current stable release,
         but alternatives include 'v1.1a' and 'master'.
     file : file like object [ defualt to content of https://github.com/mathjax/MathJax/tarball/#{tag}]
         File handle from which to untar/unzip/... mathjax


### PR DESCRIPTION
This also fixes an issue with `from IPython.external import mathjax; mathjax.install_mathjax()` not working properly, because of a changed version schema.
