### PR TITLE
Update docs location of rmagic in rpy2

### DIFF
--- a/docs/source/config/extensions/rmagic.rst
+++ b/docs/source/config/extensions/rmagic.rst
@@ -7,6 +7,6 @@ rmagic
 .. note::
 
    The rmagic extension has been moved to `rpy2 <http://rpy.sourceforge.net/rpy2.html>`_
-   as :mod:`rpy2.interactive.ipython`.
+   as :mod:`rpy2.ipython`.
 
 .. automodule:: IPython.extensions.rmagic


### PR DESCRIPTION
rmagic is now in [rpy2.ipython](https://bitbucket.org/lgautier/rpy2/src/default/rpy/ipython/)
