### PR TITLE
more minor fixes to release scripts

### DIFF
--- a/tools/build_release
+++ b/tools/build_release
@@ -3,6 +3,7 @@
 """
 
 import os
+from shutil import rmtree
 
 from toollib import *
 
@@ -20,7 +21,7 @@ compile_tree()
 for d in ['build', 'dist', pjoin('docs', 'build'), pjoin('docs', 'dist'),
           pjoin('docs', 'source', 'api', 'generated')]:
     if os.path.isdir(d):
-        remove_tree(d)
+        rmtree(d)
 
 # Build source and binary distros
 sh(sdists)

--- a/tools/release
+++ b/tools/release
@@ -56,7 +56,7 @@ sh('./setup.py register')
 # Upload all files
 sh(sdists + ' upload')
 for py in ('2.7', '3.4'):
-    sh('python%s setupegg.py bdist_wheel' % py)
+    sh('python%s setupegg.py bdist_wheel upload' % py)
 
 cd(distdir)
 print( 'Uploading distribution files...')

--- a/tools/toollib.py
+++ b/tools/toollib.py
@@ -42,7 +42,7 @@ def get_ipdir():
     try:
         ipdir = sys.argv[1]
     except IndexError:
-        ipdir = '..'
+        ipdir = pjoin(os.path.dirname(__file__), os.pardir)
 
     ipdir = os.path.abspath(ipdir)
 


### PR DESCRIPTION
after releasing 2.2.0
- allow `tools/release` to be run from top-level repo dir
- upload wheels
