### PR TITLE
Use bash shebang line for git hooks

### DIFF
--- a/git-hooks/post-checkout
+++ b/git-hooks/post-checkout
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 git submodule init
 git submodule update


### PR DESCRIPTION
Git hooks use bash specific syntax, so the shebang line needs to point to bash, or I get syntax errors.
