### PR TITLE
Update wrapperkernels.rst

### DIFF
--- a/docs/source/development/wrapperkernels.rst
+++ b/docs/source/development/wrapperkernels.rst
@@ -68,7 +68,7 @@ Example
         language_version = '0.1'
         banner = "Echo kernel - as useful as a parrot"
 
-        def do_execute(self, code, silent, store_history=True, user_experssions=None,
+        def do_execute(self, code, silent, store_history=True, user_expressions=None,
                        allow_stdin=False):
             if not silent:
                 stream_content = {'name': 'stdout', 'data':code}


### PR DESCRIPTION
Fixed typo experssions -> expressions. 

This page also needs to mention the command to get started:

``` shell
ipython console --kernel echo
```

And needs to point to creating a profile to use the EchoKernel in a notebook.
