### PR TITLE
[Don't Merge] Set HSTS in the headers.

### DIFF
--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -40,6 +40,8 @@ class AuthenticatedHandler(web.RequestHandler):
     def set_default_headers(self):
         headers = self.settings.get('headers', {})
 
+        headers['Strict-Transport-Security'] =  "max-age=10886400; includeSubDomains"
+
         if "X-Frame-Options" not in headers:
             headers["X-Frame-Options"] = "SAMEORIGIN"
 


### PR DESCRIPTION
Related to #1460. Don't merge.

Just to try it out, I set the `Strict-Transport-Security` header. It doesn't seem to work on arbitrary ports. This is better used by nginx or another proxy to set up the right connections (when serving off of 80+443).

I'll be closing this just as quickly as I opened this.
