### PR TITLE
fix when nbconvert --to pdf throws an error sometimes in windows

### DIFF
--- a/IPython/nbconvert/exporters/pdf.py
+++ b/IPython/nbconvert/exporters/pdf.py
@@ -19,7 +19,7 @@ class PDFExporter(LatexExporter):
         help="How many times latex will be called."
     )
 
-    latex_command = List([u"pdflatex", u"{filename}"], config=True, 
+    latex_command = List([u"pdflatex", u"{filename}", u"--interaction=batchmode"], config=True, 
         help="Shell command used to compile latex."
     )
 


### PR DESCRIPTION
got RuntimeError: PDF creating failed when run ipython nbconvert --to pdf
I'm using Windows 7, ipython 3.0.0 dev, python 2.7.6.
When I ran `ipython nbconvert --to pdf a.ipynb`  in command, I got a long error message, posted at the end.
After google around, I found [this](https://github.com/ipython/ipython/issues/3894/).
So I tried `ipython nbconvert --to latex`, it worked.
Then `pdflatex a.lex`, it failed.
But `pdflatex --interaction=batchmode a.lex` worked.
So the trick is `--interaction=batchmode`.

After added it to pdf.py, `ipython nbconvert --to pdf` worked.

Since I'm new to the whole `git` system, I know nothing about latex, I'm new to python, and I haven't tested under Linux, so this is only an info for somebody who have come up with the same problem.
Or somebody is willingly to help me make this a `real` contribute to ipython

> C:\Documents and Settings\wayangel\desktop\孙明\2>ipython nbconvert --to pdf fi
> 2.ipynb
> [NbConvertApp] Using existing profile dir: u'C:\Users\wayangel\.ipython\pro
> ile_default'
> [NbConvertApp] Converting notebook fig2.ipynb to pdf
> [NbConvertApp] Support files will be in fig2_files\
> [NbConvertApp] Loaded template article.tplx
> [NbConvertApp] Making directory fig2_files
> [NbConvertApp] Writing 24892 bytes to notebook.tex
> [NbConvertApp] Building PDF
> [NbConvertApp] Running pdflatex 3 times: ['pdflatex', 'notebook.tex']
> [NbConvertApp] CRITICAL | pdflatex failed: ['pdflatex', 'notebook.tex']
> This is pdfTeX, Version 3.1415926-2.3-1.40.12 (MiKTeX 2.9)
> entering extended mode
> (c:\users\wayangel\appdata\local\temp\tmpaqqunh\notebook.tex
> LaTeX2e <2011/06/27>
> Babel <v3.8m> and hyphenation patterns for loaded.
> (D:\CTEX\MiKTeX\tex\latex\base\article.cls
> Document Class: article 2007/10/19 v1.4h Standard LaTeX document class
> (D:\CTEX\MiKTeX\tex\latex\base\size10.clo))
> (D:\CTEX\MiKTeX\tex\latex\graphics\graphicx.sty
> (D:\CTEX\MiKTeX\tex\latex\graphics\keyval.sty)
> (D:\CTEX\MiKTeX\tex\latex\graphics\graphics.sty
> (D:\CTEX\MiKTeX\tex\latex\graphics\trig.sty)
> (D:\CTEX\MiKTeX\tex\latex\00miktex\graphics.cfg)
> (D:\CTEX\MiKTeX\tex\latex\pdftex-def\pdftex.def
> (D:\CTEX\MiKTeX\tex\generic\oberdiek\infwarerr.sty)
> (D:\CTEX\MiKTeX\tex\generic\oberdiek\ltxcmds.sty))))
> (D:\CTEX\MiKTeX\tex\latex\adjustbox\adjustbox.sty
> (D:\CTEX\MiKTeX\tex\latex\xkeyval\xkeyval.sty
> (D:\CTEX\MiKTeX\tex\generic\xkeyval\xkeyval.tex))
> (D:\CTEX\MiKTeX\tex\latex\adjustbox\adjcalc.sty)
> (D:\CTEX\MiKTeX\tex\latex\collectbox\collectbox.sty)
> (D:\CTEX\MiKTeX\tex\latex\adjustbox\adjpdftex.def)
> (D:\CTEX\MiKTeX\tex\latex\ltxmisc\varwidth.sty))
> (D:\CTEX\MiKTeX\tex\latex\graphics\color.sty
> (D:\CTEX\MiKTeX\tex\latex\00miktex\color.cfg))
> (D:\CTEX\MiKTeX\tex\latex\tools\enumerate.sty)
> (D:\CTEX\MiKTeX\tex\latex\geometry\geometry.sty
> (D:\CTEX\MiKTeX\tex\generic\oberdiek\ifpdf.sty)
> (D:\CTEX\MiKTeX\tex\generic\oberdiek\ifvtex.sty)
> (D:\CTEX\MiKTeX\tex\generic\ifxetex\ifxetex.sty)
> (D:\CTEX\MiKTeX\tex\latex\geometry\geometry.cfg))
> (D:\CTEX\MiKTeX\tex\latex\ams\math\amsmath.sty
> For additional information on amsmath, use the `?' option.
> (D:\CTEX\MiKTeX\tex\latex\ams\math\amstext.sty
> (D:\CTEX\MiKTeX\tex\latex\ams\math\amsgen.sty))
> (D:\CTEX\MiKTeX\tex\latex\ams\math\amsbsy.sty)
> (D:\CTEX\MiKTeX\tex\latex\ams\math\amsopn.sty))
> (D:\CTEX\MiKTeX\tex\latex\amsfonts\amssymb.sty
> (D:\CTEX\MiKTeX\tex\latex\amsfonts\amsfonts.sty))
> (D:\CTEX\MiKTeX\tex\latex\unicode\ucs.sty
> (D:\CTEX\MiKTeX\tex\latex\unicode\data\uni-global.def))
> (D:\CTEX\MiKTeX\tex\latex\base\inputenc.sty
> (D:\CTEX\MiKTeX\tex\latex\unicode\utf8x.def))
> (D:\CTEX\MiKTeX\tex\latex\fancyvrb\fancyvrb.sty
> Style option:`fancyvrb' v2.7a, with DG/SPQR fixes, and firstline=lastline fix
> <2008/02/07> (tvz)) (D:\CTEX\MiKTeX\tex\latex\oberdiek\grffile.sty
> (D:\CTEX\MiKTeX\tex\latex\oberdiek\kvoptions.sty
> (D:\CTEX\MiKTeX\tex\generic\oberdiek\kvsetkeys.sty
> (D:\CTEX\MiKTeX\tex\generic\oberdiek\etexcmds.sty
> (D:\CTEX\MiKTeX\tex\generic\oberdiek\ifluatex.sty))))
> (D:\CTEX\MiKTeX\tex\generic\oberdiek\pdftexcmds.sty))
> (D:\CTEX\MiKTeX\tex\latex\hyperref\hyperref.sty
> (D:\CTEX\MiKTeX\tex\generic\oberdiek\hobsub-hyperref.sty
> (D:\CTEX\MiKTeX\tex\generic\oberdiek\hobsub-generic.sty))
> (D:\CTEX\MiKTeX\tex\latex\hyperref\pd1enc.def)
> (D:\CTEX\MiKTeX\tex\latex\00miktex\hyperref.cfg)
> (D:\CTEX\MiKTeX\tex\latex\ltxmisc\url.sty))
> 
> Package hyperref Message: Driver (autodetected): hpdftex.
> 
> (D:\CTEX\MiKTeX\tex\latex\hyperref\hpdftex.def
> (D:\CTEX\MiKTeX\tex\latex\oberdiek\rerunfilecheck.sty))
> (D:\CTEX\MiKTeX\tex\latex\tools\longtable.sty)
> (D:\CTEX\MiKTeX\tex\latex\booktabs\booktabs.sty)
> No file notebook.aux.
> (D:\CTEX\MiKTeX\tex\context\base\supp-pdf.mkii
> [Loading MPS to PDF converter (version 2006.09.02).]
> )
> _geometry_ driver: auto-detecting
> _geometry_ detected driver: pdftex
> 
> Package geometry Warning: The marginal notes overrun the paper.
>      Add 3.73001pt and more to the right margin.
> 
> _geometry_ verbose mode - [ preamble ] result:
> - driver: pdftex
> - paper: <default>
> - layout: <same size as paper>
> - layoutoffset:(h,v)=(0.0pt,0.0pt)
> - modes:
> - h-part:(L,W,R)=(72.26999pt, 469.75502pt, 72.26999pt)
> - v-part:(T,H,B)=(72.26999pt, 650.43001pt, 72.26999pt)
> - \paperwidth=614.295pt
> - \paperheight=794.96999pt
> - \textwidth=469.75502pt
> - \textheight=650.43001pt
> - \oddsidemargin=0.0pt
> - \evensidemargin=0.0pt
> - \topmargin=-37.0pt
> - \headheight=12.0pt
> - \headsep=25.0pt
> - \topskip=10.0pt
> - \footskip=30.0pt
> - \marginparwidth=65.0pt
> - \marginparsep=11.0pt
> - \columnsep=10.0pt
> - \skip\footins=9.0pt plus 4.0pt minus 2.0pt
> - \hoffset=0.0pt
> - \voffset=0.0pt
> - \mag=1000
> - \@twocolumnfalse
> - \@twosidefalse
> - \@mparswitchfalse
> - \@reversemarginfalse
> - (1in=72.27pt=25.4mm, 1cm=28.453pt)
> 
> (D:\CTEX\MiKTeX\tex\latex\unicode\ucsencs.def)
> (D:\CTEX\MiKTeX\tex\latex\hyperref\nameref.sty
> (D:\CTEX\MiKTeX\tex\generic\oberdiek\gettitlestring.sty))
> (D:\CTEX\MiKTeX\tex\latex\amsfonts\umsa.fd)
> (D:\CTEX\MiKTeX\tex\latex\amsfonts\umsb.fd)
> 
> LaTeX Warning: No \author given.
> 
> [1{D:/CTEX/UserData/pdftex/config/pdftex.map{Unicode.sfd}{UGBK.sfd}}](D:CTEXMiKTeXtexlatexunicodedatauni-126.def)
> (D:\CTEX\MiKTeX\tex\latex\unicode\data\uninames.dat)
> (D:\CTEX\MiKTeX\tex\latex\unicode\data\uni-126.def)
> 
> ! Package ucs Error: Unknown Unicode character 32472 = U+7ED8,
> (ucs)                possibly declared in uni-126.def.
> (ucs)                Type H to see if it is available with options.
> 
> See the ucs package documentation for explanation.
> Type  H <return>  for immediate help.
>  ...
> 
> l.334          \PY{c}{\PYZsh{} 绘公式}
> 
> ?
> ! Emergency stop.
>  ...
> 
> l.334          \PY{c}{\PYZsh{} 绘公式}
> 
> !  ==> Fatal error occurred, no output PDF file produced!
> Transcript written on notebook.log.
> 
> [NbConvertApp] Running bibtex 1 time: ['bibtex', 'notebook']
> Traceback (most recent call last):
>   File "d:\Python\WinPython-32bit-2.7.6.3\python-2.7.6\Scripts\ipython-script.p
> ", line 9, in <module>
>     load_entry_point('ipython==3.0.0-dev', 'console_scripts', 'ipython')()
>   File "d:\softwares\python\ipython-master\ipython\IPython__init__.py", line 1
> 0, in start_ipython
>     return launch_new_instance(argv=argv, *_kwargs)
>   File "d:\softwares\python\ipython-master\ipython\IPython\config\application.p
> ", line 549, in launch_instance
>     app.start()
>   File "d:\softwares\python\ipython-master\ipython\IPython\terminal\ipapp.py",
> ine 368, in start
>     return self.subapp.start()
>   File "d:\softwares\python\ipython-master\ipython\IPython\nbconvert\nbconverta
> p.py", line 256, in start
>     self.convert_notebooks()
>   File "d:\softwares\python\ipython-master\ipython\IPython\nbconvert\nbconverta
> p.py", line 295, in convert_notebooks
>     output, resources = exporter.from_filename(notebook_filename, resources=res
> urces)
>   File "d:\softwares\python\ipython-master\ipython\IPython\nbconvert\exporters\
> xporter.py", line 152, in from_filename
>     return self.from_notebook_node(nbformat.read(f, 'json'), resources=resource
> , *_kw)
>   File "d:\softwares\python\ipython-master\ipython\IPython\nbconvert\exporters\
> df.py", line 131, in from_notebook_node
>     raise RuntimeError("PDF creating failed")
> RuntimeError: PDF creating failed
> 
> If you suspect this is an IPython bug, please report it at:
>     https://github.com/ipython/ipython/issues
> or send an email to the mailing list at ipython-dev@scipy.org
> 
> You can print a more detailed traceback right now with "%tb", or use "%debug"
> to interactively debug it.
> 
> Extra-detailed tracebacks for bug-reporting purposes can be enabled via:
>     c.Application.verbose_crash=True
