### PR TITLE
Improve input transformer formatting of cell magics

### DIFF
--- a/IPython/core/inputtransformer.py
+++ b/IPython/core/inputtransformer.py
@@ -363,11 +363,11 @@ def help_end(line):
 @CoroutineInputTransformer.wrap
 def cellmagic(end_on_blank_line=False):
     """Captures & transforms cell magics.
-    
+
     After a cell magic is started, this stores up any lines it gets until it is
     reset (sent None).
     """
-    tpl = 'get_ipython().run_cell_magic(%r, %r, %r)'
+    tpl = 'get_ipython().run_cell_magic(%r, %r, u"""\\\n%s\n""")'
     cellmagic_help_re = re.compile('%%\w+\?')
     line = ''
     while True:


### PR DESCRIPTION
For internal use this doesn't much matter--the primary motivation behind this is conversion from the notebook format to plain Python modules.  For example given a cell like:

```
%%timeit
1 + 1 == 2
2 + 2 == 4
```

currently this is converted to:

```
# In[1]:

get_ipython().run_cell_magic(u'timeit', u'', u'1 + 1 == 2\n2 + 2 == 4')
```

With this PR it would instead be converted to:

```
# In[1]:

get_ipython().run_cell_magic(u'timeit', u'', u"""\
1 + 1 == 2
2 + 2 == 4
""")
```

thus improving readability and hand-editability at a cost of only about 6 extra characters.  There might still be some issues to work out here though.  I'm not sure if escaping will be fully handled properly without a little more tweaking.
