### PR TITLE
is_complete messages

### DIFF
--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -248,6 +248,22 @@ class InputSplitter(object):
         self.reset()
         return out
 
+    def is_complete(self, source):
+        """Return whether a block of code is ready to execute, or should be continued
+        
+        This is a non-stateful API, and will reset the state of this InputSplitter.
+        """
+        self.reset()
+        try:
+            self.push(source)
+            return not self.push_accepts_more()
+        except SyntaxError:
+            # Transformers in IPythonInputSplitter can raise SyntaxError,
+            # which push() will not catch.
+            return True
+        finally:
+            self.reset()
+
     def push(self, lines):
         """Push one or more lines of input.
 

--- a/IPython/core/release.py
+++ b/IPython/core/release.py
@@ -40,7 +40,7 @@ version = __version__  # backwards compatibility name
 version_info = (_version_major, _version_minor, _version_patch, _version_extra)
 
 # Change this when incrementing the kernel protocol version
-kernel_protocol_version_info = (5, 1)
+kernel_protocol_version_info = (5, 0)
 kernel_protocol_version = "%i.%i" % kernel_protocol_version_info
 
 description = "IPython: Productive Interactive Computing"

--- a/IPython/core/release.py
+++ b/IPython/core/release.py
@@ -40,7 +40,7 @@ version = __version__  # backwards compatibility name
 version_info = (_version_major, _version_minor, _version_patch, _version_extra)
 
 # Change this when incrementing the kernel protocol version
-kernel_protocol_version_info = (5, 0)
+kernel_protocol_version_info = (5, 1)
 kernel_protocol_version = "%i.%i" % kernel_protocol_version_info
 
 description = "IPython: Productive Interactive Computing"

--- a/IPython/core/tests/test_inputsplitter.py
+++ b/IPython/core/tests/test_inputsplitter.py
@@ -355,12 +355,12 @@ class InputSplitterTestCase(unittest.TestCase):
         isp.push(r"(1 \ ")
         self.assertFalse(isp.push_accepts_more())
 
-    def test_is_complete(self):
+    def test_check_complete(self):
         isp = self.isp
-        assert isp.is_complete("a = 1")
-        assert not isp.is_complete("for a in range(5):")
-        assert isp.is_complete("raise = 2")  # SyntaxError should mean complete
-        assert not isp.is_complete("a = [1,\n2,")
+        self.assertEqual(isp.check_complete("a = 1"), ('complete', None))
+        self.assertEqual(isp.check_complete("for a in range(5):"), ('incomplete', 4))
+        self.assertEqual(isp.check_complete("raise = 2"), ('invalid', None))
+        self.assertEqual(isp.check_complete("a = [1,\n2,"), ('incomplete', 0))
 
 class InteractiveLoopTestCase(unittest.TestCase):
     """Tests for an interactive loop like a python shell.

--- a/IPython/core/tests/test_inputsplitter.py
+++ b/IPython/core/tests/test_inputsplitter.py
@@ -355,6 +355,13 @@ class InputSplitterTestCase(unittest.TestCase):
         isp.push(r"(1 \ ")
         self.assertFalse(isp.push_accepts_more())
 
+    def test_is_complete(self):
+        isp = self.isp
+        assert isp.is_complete("a = 1")
+        assert not isp.is_complete("for a in range(5):")
+        assert isp.is_complete("raise = 2")  # SyntaxError should mean complete
+        assert not isp.is_complete("a = [1,\n2,")
+
 class InteractiveLoopTestCase(unittest.TestCase):
     """Tests for an interactive loop like a python shell.
     """

--- a/IPython/kernel/channels.py
+++ b/IPython/kernel/channels.py
@@ -194,6 +194,7 @@ class ShellChannel(ZMQSocketChannel):
         'history',
         'kernel_info',
         'shutdown',
+        'is_complete',
     ]
 
     def __init__(self, context, session, address):
@@ -396,6 +397,10 @@ class ShellChannel(ZMQSocketChannel):
         self._queue_send(msg)
         return msg['header']['msg_id']
 
+    def is_complete(self, code):
+        msg = self.session.msg('is_complete_request', {'code': code})
+        self._queue_send(msg)
+        return msg['header']['msg_id']
 
 
 class IOPubChannel(ZMQSocketChannel):

--- a/IPython/kernel/tests/test_kernel.py
+++ b/IPython/kernel/tests/test_kernel.py
@@ -211,13 +211,14 @@ def test_is_complete():
         # that the kernel exposes the interface correctly.
         kc.is_complete('2+2')
         reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
-        assert reply['content']['complete']
+        assert reply['content']['status'] == 'complete'
 
         # SyntaxError should mean it's complete        
         kc.is_complete('raise = 2')
         reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
-        assert reply['content']['complete']
+        assert reply['content']['status'] == 'invalid'
         
         kc.is_complete('a = [1,\n2,')
         reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
-        assert not reply['content']['complete']
+        assert reply['content']['status'] == 'incomplete'
+        assert reply['content']['indent'] == ''

--- a/IPython/kernel/tests/test_kernel.py
+++ b/IPython/kernel/tests/test_kernel.py
@@ -205,3 +205,19 @@ def test_help_output():
     """ipython kernel --help-all works"""
     tt.help_all_output_test('kernel')
 
+def test_is_complete():
+    with kernel() as kc:
+        # There are more test cases for this in core - here we just check
+        # that the kernel exposes the interface correctly.
+        kc.is_complete('2+2')
+        reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
+        assert reply['content']['complete']
+
+        # SyntaxError should mean it's complete        
+        kc.is_complete('raise = 2')
+        reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
+        assert reply['content']['complete']
+        
+        kc.is_complete('a = [1,\n2,')
+        reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
+        assert not reply['content']['complete']

--- a/IPython/kernel/tests/test_message_spec.py
+++ b/IPython/kernel/tests/test_message_spec.py
@@ -160,6 +160,10 @@ class KernelInfoReply(Reference):
     banner = Unicode()
 
 
+class IsCompleteReply(Reference):
+    complete = Bool()
+
+
 # IOPub messages
 
 class ExecuteInput(Reference):
@@ -189,6 +193,7 @@ references = {
     'status' : Status(),
     'complete_reply' : CompleteReply(),
     'kernel_info_reply': KernelInfoReply(),
+    'is_complete_reply': IsCompleteReply(),
     'execute_input' : ExecuteInput(),
     'execute_result' : ExecuteResult(),
     'error' : Error(),
@@ -382,6 +387,12 @@ def test_single_payload():
     next_input_pls = [pl for pl in payload if pl["source"] == "set_next_input"]
     nt.assert_equal(len(next_input_pls), 1)
 
+def test_is_complete():
+    flush_channels()
+    
+    msg_id = KC.is_complete("a = 1")
+    reply = KC.get_shell_msg(timeout=TIMEOUT)
+    validate_message(reply, 'is_complete_reply', msg_id)
 
 # IOPub channel
 

--- a/IPython/kernel/tests/test_message_spec.py
+++ b/IPython/kernel/tests/test_message_spec.py
@@ -161,7 +161,15 @@ class KernelInfoReply(Reference):
 
 
 class IsCompleteReply(Reference):
-    complete = Bool()
+    status = Enum((u'complete', u'incomplete', u'invalid', u'unknown'))
+    
+    def check(self, d):
+        Reference.check(self, d)
+        if d['status'] == 'incomplete':
+            IsCompleteReplyIncomplete().check(d)
+
+class IsCompleteReplyIncomplete(Reference):
+    indent = Unicode()
 
 
 # IOPub messages

--- a/IPython/kernel/zmq/ipkernel.py
+++ b/IPython/kernel/zmq/ipkernel.py
@@ -229,6 +229,10 @@ class IPythonKernel(KernelBase):
         self.shell.exit_now = True
         return dict(status='ok', restart=restart)
 
+    def do_is_complete(self, code):
+        complete = self.shell.input_transformer_manager.is_complete(code)
+        return {'complete': complete}
+
     def do_apply(self, content, bufs, msg_id, reply_metadata):
         shell = self.shell
         try:

--- a/IPython/kernel/zmq/ipkernel.py
+++ b/IPython/kernel/zmq/ipkernel.py
@@ -230,8 +230,11 @@ class IPythonKernel(KernelBase):
         return dict(status='ok', restart=restart)
 
     def do_is_complete(self, code):
-        complete = self.shell.input_transformer_manager.is_complete(code)
-        return {'complete': complete}
+        status, indent_spaces = self.shell.input_transformer_manager.check_complete(code)
+        r = {'status': status}
+        if status == 'incomplete':
+            r['indent'] = ' ' * indent_spaces
+        return r
 
     def do_apply(self, content, bufs, msg_id, reply_metadata):
         shell = self.shell

--- a/IPython/kernel/zmq/kernelbase.py
+++ b/IPython/kernel/zmq/kernelbase.py
@@ -493,7 +493,7 @@ class Kernel(Configurable):
     def do_is_complete(self, code):
         """Override in subclasses to find completions.
         """
-        return {'complete' : True,
+        return {'status' : 'unknown',
                 }
 
     #---------------------------------------------------------------------------

--- a/IPython/kernel/zmq/kernelbase.py
+++ b/IPython/kernel/zmq/kernelbase.py
@@ -114,7 +114,7 @@ class Kernel(Configurable):
                       'inspect_request', 'history_request',
                       'kernel_info_request',
                       'connect_request', 'shutdown_request',
-                      'apply_request',
+                      'apply_request', 'is_complete_request',
                     ]
         self.shell_handlers = {}
         for msg_type in msg_types:
@@ -479,6 +479,22 @@ class Kernel(Configurable):
         kernel.
         """
         return {'status': 'ok', 'restart': restart}
+    
+    def is_complete_request(self, stream, ident, parent):
+        content = parent['content']
+        code = content['code']
+        
+        reply_content = self.do_is_complete(code)
+        reply_content = json_clean(reply_content)
+        reply_msg = self.session.send(stream, 'is_complete_reply',
+                                           reply_content, parent, ident)
+        self.log.debug("%s", reply_msg)
+
+    def do_is_complete(self, code):
+        """Override in subclasses to find completions.
+        """
+        return {'complete' : True,
+                }
 
     #---------------------------------------------------------------------------
     # Engine methods

--- a/docs/source/development/messaging.rst
+++ b/docs/source/development/messaging.rst
@@ -9,7 +9,7 @@ Versioning
 ==========
 
 The IPython message specification is versioned independently of IPython.
-The current version of the specification is 5.1.
+The current version of the specification is 5.0.
 
 
 Introduction
@@ -578,7 +578,7 @@ Message type: ``history_reply``::
 Code completeness
 -----------------
 
-.. versionadded:: 5.1
+.. versionadded:: 5.0
 
 When the user enters a line in a console style interface, the console must
 decide whether to immediately execute the current code, or whether to show a

--- a/docs/source/development/messaging.rst
+++ b/docs/source/development/messaging.rst
@@ -585,9 +585,19 @@ decide whether to immediately execute the current code, or whether to show a
 continuation prompt for further input. For instance, in Python ``a = 5`` would
 be executed immediately, while ``for i in range(5):`` would expect further input.
 
+There are four possible replies:
+
+- *complete* code is ready to be executed
+- *incomplete* code should prompt for another line
+- *invalid* code will typically be sent for execution, so that the user sees the
+  error soonest.
+- *unknown* - if the kernel is not able to determine this. The frontend should
+  also handle the kernel not replying promptly. It may default to sending the
+  code for execution, or it may implement simple fallback heuristics for whether
+  to execute the code (e.g. execute after a blank line).
+
 Frontends may have ways to override this, forcing the code to be sent for
-execution or forcing a continuation prompt. If the kernel does not reply promptly,
-the frontend will probably default to sending the code to be executed.
+execution or forcing a continuation prompt.
 
 Message type: ``is_complete_request``::
 
@@ -596,11 +606,17 @@ Message type: ``is_complete_request``::
         'code' : str,
     }
 
-Message type: ``complete_reply``::
+Message type: ``is_complete_reply``::
 
     content = {
-        # True if the code is ready to execute, False if not
-        'complete' : bool,
+        # One of 'complete', 'incomplete', 'invalid', 'unknown'
+        'status' : str,
+        
+        # If status is 'incomplete', indent should contain the characters to use
+        # to indent the next line. This is only a hint: frontends may ignore it
+        # and use their own autoindentation rules. For other statuses, this
+        # field does not exist.
+        'indent': str,
     }
 
 Connect

--- a/docs/source/development/messaging.rst
+++ b/docs/source/development/messaging.rst
@@ -9,7 +9,7 @@ Versioning
 ==========
 
 The IPython message specification is versioned independently of IPython.
-The current version of the specification is 5.0.
+The current version of the specification is 5.1.
 
 
 Introduction
@@ -573,6 +573,35 @@ Message type: ``history_reply``::
       'history' : list,
     }
 
+.. _msging_is_complete:
+
+Code completeness
+-----------------
+
+.. versionadded:: 5.1
+
+When the user enters a line in a console style interface, the console must
+decide whether to immediately execute the current code, or whether to show a
+continuation prompt for further input. For instance, in Python ``a = 5`` would
+be executed immediately, while ``for i in range(5):`` would expect further input.
+
+Frontends may have ways to override this, forcing the code to be sent for
+execution or forcing a continuation prompt. If the kernel does not reply promptly,
+the frontend will probably default to sending the code to be executed.
+
+Message type: ``is_complete_request``::
+
+    content = {
+        # The code entered so far as a multiline string
+        'code' : str,
+    }
+
+Message type: ``complete_reply``::
+
+    content = {
+        # True if the code is ready to execute, False if not
+        'complete' : bool,
+    }
 
 Connect
 -------

--- a/docs/source/development/wrapperkernels.rst
+++ b/docs/source/development/wrapperkernels.rst
@@ -141,6 +141,17 @@ relevant section of the :doc:`messaging spec <messaging>`.
      
         :ref:`msging_history` messages
 
+   .. method:: do_is_complete(code)
+   
+     Is code entered in a console-like interface complete and ready to execute,
+     or should a continuation prompt be shown?
+     
+     :param str code: The code entered so far - possibly multiple lines
+     
+     .. seealso::
+     
+        :ref:`msging_is_complete` messages
+
    .. method:: do_shutdown(restart)
 
      Shutdown the kernel. You only need to handle your own clean up - the kernel


### PR DESCRIPTION
This is the underlying machinery necessary for a console interface in the HTML UI, and more generally for console like interfaces to support multiple languages.

The problem: when the user types some code and presses enter, the console needs\* to determine whether that code is ready to execute, or whether a continuation prompt should be generated. At present, we determine this in our console frontends by running a copy of the inputsplitter machinery, but that's specific to Python code, and it can't practically be implemented in Javascript. We should instead determine this by querying the kernel, which is what this PR makes possible.

(\* We've previously debated whether this is a feature of console-style UIs, or a limitation of terminals where we can't give the user different key combinations to make the difference explicit. I believe that it's a feature, and the fact that we implemented this behaviour in the Qt console, where we can and do distinguish shift-enter/ctrl-enter, supports this)

This does not switch any frontends to use this new machinery. It adds the messages, and the handler within the IPython kernel.

Open questions:
- Naming
- Should the reply include hints about indentation?
