### PR TITLE
Fix error message when failing to load a notebook

### DIFF
--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -514,15 +514,20 @@ define([
         }
     };
     
+    var ajax_error_msg = function (jqXHR) {
+        // Return a JSON error message if there is one,
+        // otherwise the basic HTTP status text.
+        if (jqXHR.responseJSON && jqXHR.responseJSON.message) {
+            return jqXHR.responseJSON.message;
+        } else {
+            return jqXHR.statusText;
+        }
+    }
     var log_ajax_error = function (jqXHR, status, error) {
         // log ajax failures with informative messages
         var msg = "API request failed (" + jqXHR.status + "): ";
         console.log(jqXHR);
-        if (jqXHR.responseJSON && jqXHR.responseJSON.message) {
-            msg += jqXHR.responseJSON.message;
-        } else {
-            msg += jqXHR.statusText;
-        }
+        msg += ajax_error_msg(jqXHR);
         console.log(msg);
     };
 
@@ -547,6 +552,7 @@ define([
         platform: platform,
         is_or_has : is_or_has,
         is_focused : is_focused,
+        ajax_error_msg : ajax_error_msg,
         log_ajax_error : log_ajax_error,
     };
 

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -2286,17 +2286,14 @@ define([
      */
     Notebook.prototype.load_notebook_error = function (xhr, status, error) {
         this.events.trigger('notebook_load_failed.Notebook', [xhr, status, error]);
+        utils.log_ajax_error(xhr, status, error);
         var msg;
         if (xhr.status === 400) {
-            if (xhr.responseJSON && xhr.responseJSON.message) {
-                msg = escape(xhr.responseJSON.message);
-            } else {
-                msg = escape(error);
-            }
+            msg = escape(utils.ajax_error_msg(xhr));
         } else if (xhr.status === 500) {
             msg = "An unknown error occurred while loading this notebook. " +
             "This version can load notebook formats " +
-            "v" + this.nbformat + " or earlier.";
+            "v" + this.nbformat + " or earlier. See the server log for details.";
         }
         dialog.modal({
             notebook: this,

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -2288,7 +2288,11 @@ define([
         this.events.trigger('notebook_load_failed.Notebook', [xhr, status, error]);
         var msg;
         if (xhr.status === 400) {
-            msg = error;
+            if (xhr.responseJSON && xhr.responseJSON.message) {
+                msg = escape(xhr.responseJSON.message);
+            } else {
+                msg = escape(error);
+            }
         } else if (xhr.status === 500) {
             msg = "An unknown error occurred while loading this notebook. " +
             "This version can load notebook formats " +
@@ -2567,10 +2571,10 @@ define([
      * @method delete_checkpoint_error
      * @param {jqXHR} xhr jQuery Ajax object
      * @param {String} status Description of response status
-     * @param {String} error_msg HTTP error message
+     * @param {String} error HTTP error message
      */
-    Notebook.prototype.delete_checkpoint_error = function (xhr, status, error_msg) {
-        this.events.trigger('checkpoint_delete_failed.Notebook');
+    Notebook.prototype.delete_checkpoint_error = function (xhr, status, error) {
+        this.events.trigger('checkpoint_delete_failed.Notebook', [xhr, status, error]);
     };
 
 

--- a/IPython/nbformat/reader.py
+++ b/IPython/nbformat/reader.py
@@ -80,6 +80,8 @@ def reads(s, **kwargs):
     nb : NotebookNode
         The notebook that was read.
     """
+    from .current import NBFormatError
+    
     nb_dict = parse_json(s, **kwargs)
     (major, minor) = get_version(nb_dict)
     if major in versions:


### PR DESCRIPTION
- fix missing import in nbformat.reader.reads
- show JSON error message if there is one

Before, opening a v4 notebook would show:

> Error: Bad Request

After, it shows the intended:

> Unreadable Notebook: /path/to/notebook.ipynb Unsupported nbformat version 4

Should be backported to 2.x
