### PR TITLE
JS: close WebSockets when killing kernels

### DIFF
--- a/IPython/html/services/kernels/handlers.py
+++ b/IPython/html/services/kernels/handlers.py
@@ -84,6 +84,9 @@ class KernelActionHandler(IPythonHandler):
 
 class ZMQChannelHandler(AuthenticatedZMQStreamHandler):
     
+    def __repr__(self):
+        return "%s(%s)" % (self.__class__.__name__, getattr(self, 'kernel_id', 'uninitialized'))
+    
     def create_stream(self):
         km = self.kernel_manager
         meth = getattr(km, 'connect_%s' % self.channel)
@@ -145,6 +148,12 @@ class ZMQChannelHandler(AuthenticatedZMQStreamHandler):
             self.zmq_stream.on_recv(self._on_zmq_reply)
 
     def on_message(self, msg):
+        if self.zmq_stream is None:
+            return
+        elif self.zmq_stream.closed():
+            self.log.info("%s closed, closing websocket.", self)
+            self.close()
+            return
         msg = json.loads(msg)
         self.session.send(self.zmq_stream, msg)
 

--- a/IPython/html/static/notebook/js/kernelselector.js
+++ b/IPython/html/static/notebook/js/kernelselector.js
@@ -54,9 +54,19 @@ define([
             return;
         }
         var ks = this.kernelspecs[kernel_name];
+        try {
+            this.notebook.start_session(kernel_name);
+        } catch (e) {
+            if (e.name === 'SessionAlreadyStarting') {
+                console.log("Cannot change kernel while waiting for pending session start.");
+            } else {
+                // unhandled error
+                throw e;
+            }
+            // only trigger spec_changed if change was successful
+            return;
+        }
         this.events.trigger('spec_changed.Kernel', ks);
-        this.notebook.session.delete();
-        this.notebook.start_session(kernel_name);
     };
     
     KernelSelector.prototype.bind_events = function() {

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -157,12 +157,13 @@ define([
             }
         });
         this.element.find('#kill_and_exit').click(function () {
-            that.notebook.session.delete();
-            setTimeout(function(){
+            var close_window = function () {
                 // allow closing of new tabs in Chromium, impossible in FF
                 window.open('', '_self', '');
                 window.close();
-            }, 500);
+            };
+            // finish with close on success or failure
+            that.notebook.session.delete(close_window, close_window);
         });
         // Edit
         this.element.find('#cut_cell').click(function () {

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -109,6 +109,12 @@ define([
             knw.set_message("Restarting kernel", 2000);
         });
 
+        this.events.on('status_dead.Kernel',function () {
+            that.save_widget.update_document_title();
+            knw.danger("Dead kernel");
+            $kernel_ind_icon.attr('class','kernel_dead_icon').attr('title','Kernel Dead');
+        });
+
         this.events.on('status_interrupting.Kernel',function () {
             knw.set_message("Interrupting kernel", 2000);
         });
@@ -118,6 +124,8 @@ define([
         $kernel_ind_icon.attr('class','kernel_busy_icon').attr('title','Kernel Busy');
 
         this.events.on('status_started.Kernel', function (evt, data) {
+            knw.info("Websockets Connected", 500);
+            that.events.trigger('status_busy.Kernel');
             data.kernel.kernel_info(function () {
                 that.events.trigger('status_idle.Kernel');
             });
@@ -153,8 +161,13 @@ define([
             var ws_url = data.ws_url;
             var early = data.early;
             var msg;
+
+            $kernel_ind_icon
+                .attr('class', 'kernel_disconnected_icon')
+                .attr('title', 'No Connection to Kernel');
+            
             if (!early) {
-                    knw.set_message('Reconnecting WebSockets', 1000);
+                    knw.warning('Reconnecting');
                     setTimeout(function () {
                         kernel.start_channels();
                     }, 5000);
@@ -173,7 +186,7 @@ define([
                     "OK": {},
                     "Reconnect": {
                         click: function () {
-                            knw.set_message('Reconnecting WebSockets', 1000);
+                            knw.warning('Reconnecting');
                             setTimeout(function () {
                                 kernel.start_channels();
                             }, 5000);

--- a/IPython/html/static/notebook/less/notificationarea.less
+++ b/IPython/html/static/notebook/less/notificationarea.less
@@ -43,4 +43,12 @@
     .icon(@fa-var-circle);
 }
 
+.kernel_dead_icon:before {
+    .icon(@fa-var-bomb);
+}
+
+.kernel_disconnected_icon:before {
+    .icon(@fa-var-chain-broken);
+}
+
 

--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -385,13 +385,14 @@ define([
     };
 
 
-    Kernel.prototype.kill = function () {
+    Kernel.prototype.kill = function (success, faiure) {
         if (this.running) {
             this.running = false;
             var settings = {
                 cache : false,
                 type : "DELETE",
-                error : utils.log_ajax_error,
+                success : success,
+                error : error || utils.log_ajax_error,
             };
             $.ajax(utils.url_join_encode(this.kernel_url), settings);
             this.stop_channels();

--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -394,6 +394,7 @@ define([
                 error : utils.log_ajax_error,
             };
             $.ajax(utils.url_join_encode(this.kernel_url), settings);
+            this.stop_channels();
         }
     };
 

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -80,6 +80,7 @@ define([
             error : utils.log_ajax_error,
         };
         this.kernel.running = false;
+        this.kernel.stop_channels();
         var url = utils.url_join_encode(this.base_url, 'api/sessions', this.id);
         $.ajax(url, settings);
     };

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -21,7 +21,7 @@ define([
         this.ws_url = options.ws_url;
     };
     
-    Session.prototype.start = function(callback) {
+    Session.prototype.start = function (success, error) {
         var that = this;
         var model = {
             notebook : {
@@ -40,11 +40,11 @@ define([
             dataType : "json",
             success : function (data, status, xhr) {
                 that._handle_start_success(data);
-                if (callback) {
-                    callback(data, status, xhr);
+                if (success) {
+                    success(data, status, xhr);
                 }
             },
-            error : utils.log_ajax_error,
+            error : error || utils.log_ajax_error,
         };
         var url = utils.url_join_encode(this.base_url, 'api/sessions');
         $.ajax(url, settings);
@@ -71,13 +71,14 @@ define([
         $.ajax(url, settings);
     };
     
-    Session.prototype.delete = function() {
+    Session.prototype.delete = function (success, error) {
         var settings = {
             processData : false,
             cache : false,
             type : "DELETE",
             dataType : "json",
-            error : utils.log_ajax_error,
+            success : success,
+            error : error || utils.log_ajax_error,
         };
         this.kernel.running = false;
         this.kernel.stop_channels();
@@ -119,8 +120,18 @@ define([
         this.kernel.kill();
     };
     
+    var SessionAlreadyStarting = function (message) {
+        this.name = "SessionAlreadyStarting";
+        this.message = (message || "");
+    };
+    
+    SessionAlreadyStarting.prototype = Error.prototype;
+    
     // For backwards compatability.
     IPython.Session = Session;
 
-    return {'Session': Session};
+    return {
+        Session: Session,
+        SessionAlreadyStarting: SessionAlreadyStarting,
+    };
 });

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -9998,6 +9998,38 @@ ul#help_menu li a i {
 .kernel_busy_icon:before.pull-right {
   margin-left: .3em;
 }
+.kernel_dead_icon:before {
+  display: inline-block;
+  font-family: FontAwesome;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  content: "\f1e2";
+}
+.kernel_dead_icon:before.pull-left {
+  margin-right: .3em;
+}
+.kernel_dead_icon:before.pull-right {
+  margin-left: .3em;
+}
+.kernel_disconnected_icon:before {
+  display: inline-block;
+  font-family: FontAwesome;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  content: "\f127";
+}
+.kernel_disconnected_icon:before.pull-left {
+  margin-right: .3em;
+}
+.kernel_disconnected_icon:before.pull-right {
+  margin-left: .3em;
+}
 .notification_widget {
   color: #777777;
   padding: 1px 12px;

--- a/IPython/html/tests/services/session.js
+++ b/IPython/html/tests/services/session.js
@@ -1,38 +1,17 @@
 
 //
-// Kernel tests
+// Tests for the Session object
 //
+
 casper.notebook_test(function () {
     this.evaluate(function () {
-        IPython.notebook.kernel.kernel_info(
-            function(msg){
-                IPython._kernel_info_response = msg;
-            })
-    });
-
-    this.waitFor(
-        function () {
-            return this.evaluate(function(){
-                return IPython._kernel_info_response;
-        });
-    });
-
-    this.then(function () {
-        var kernel_info_response =  this.evaluate(function(){
-            return IPython._kernel_info_response;
-        });
-        this.test.assertTrue( kernel_info_response.msg_type === 'kernel_info_reply', 'Kernel info request return kernel_info_reply');
-        this.test.assertTrue( kernel_info_response.content !== undefined, 'Kernel_info_reply is not undefined');
-    });
-    
-    this.thenEvaluate(function () {
         var kernel = IPython.notebook.session.kernel;
         IPython._channels = [
             kernel.shell_channel,
             kernel.iopub_channel,
             kernel.stdin_channel
         ];
-        kernel.kill();
+        IPython.notebook.session.delete();
     });
     
     this.waitFor(function () {
@@ -46,7 +25,7 @@ casper.notebook_test(function () {
             return true;
         });
     });
-    
+
     this.then(function () {
         var states = this.evaluate(function() {
             var states = [];
@@ -58,7 +37,7 @@ casper.notebook_test(function () {
         
         for (var i = 0; i < states.length; i++) {
             this.test.assertEquals(states[i], WebSocket.CLOSED,
-                "Kernel.kill closes websockets[" + i + "]");
+                "Session.delete closes websockets[" + i + "]");
         }
     });
 });


### PR DESCRIPTION
by calling Kernel.stop_channels() in Session.delete and Kernel.kill.

Changing the kernel spec deletes and creates a new session, which previously left the old WebSockets open. This could lead to FD exhaustion in the server if done several times on a given notebook.

Tests included.
- [x] close websockets when killing / switching kernels
- [x] fix start/delete race condition when switching kernels
- [x] fix `'NoneType' object has no attribute 'send_multipart'` race condition when closing websockets immediately after opening htem

closes #6304
