### PR TITLE
Updated tox.ini for local testing.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,19 +27,11 @@ deps =
   nose
   tornado<4.0
   jinja2
-  docutils
-  markupsafe
   sphinx
   pygments
-  cython
   jsonpointer
   jsonschema
-  matplotlib
   mistune
-  numpy
-  pymongo
-  requests
-  pyside
 
 # To avoid loading IPython module in the current directory, change
 # current directory to ".tox/py*/tmp" before running test.

--- a/tox.ini
+++ b/tox.ini
@@ -3,23 +3,52 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 
+# Building the source distribution requires both fabric's fab binary
+# (http://www.fabfile.org/) and the lessc binary of the css preprocessor
+# less (http://lesscss.org/) in the PATH.
+# "pip install fabric" will install fabric. Less can be installed by
+# node.js' (http://nodejs.org/) package manager npm:
+# "npm install -g less".
+
+# Javascript tests need additional dependencies that can be installed
+# using node.js' package manager npm:
+# [*] casperjs:  "npm install -g casperjs"
+# [*] slimerjs:  "npm install -g slimerjs"
+# [*] phantomjs: "npm install -g phantomjs"
+
+# Note: qt4 versions break some tests with tornado versions >=4.0.
+
 [tox]
-envlist = py27, py33
+envlist = py27, py33, py34
 
 [testenv]
-deps = 
+deps =
+  pyzmq
   nose
-  mock
-  tornado
+  tornado<4.0
   jinja2
+  docutils
+  markupsafe
   sphinx
   pygments
+  cython
+  jsonpointer
+  jsonschema
+  matplotlib
+  mistune
+  numpy
+  pymongo
+  requests
+  pyside
+
 # To avoid loading IPython module in the current directory, change
 # current directory to ".tox/py*/tmp" before running test.
 changedir = {envtmpdir}
 
 commands =
-    # As pip does not treat egg, use easy_install to install PyZMQ.
-    # See also: https://github.com/zeromq/pyzmq
-    easy_install -q pyzmq
-    iptest --all
+  iptest --all
+
+[testenv:py27]
+deps=
+  mock
+  {[testenv]deps}


### PR DESCRIPTION
I updated the tox.ini and tried to get all dependencies and to run as many of the test groups as possible. I also added a description how to install the dependencies for the javascript tests. This might need spelling and wording review.

I get all test groups but rpy2, which has a couple of failing tests. As this test group will be removed soon, this should not be an issue.

```
Tools and libraries available at test time:
   casperjs curses cython jinja2 jsonpointer jsonschema matplotlib mistune numpy pexpect phantomjs pygments pymongo qt requests slimerjs sphinx sqlite3 tornado zmq

Tools and libraries NOT available at test time:
   rpy2
```
