### PR TITLE
allow slash in root->tree redirect

### DIFF
--- a/IPython/html/tree/handlers.py
+++ b/IPython/html/tree/handlers.py
@@ -80,5 +80,5 @@ default_handlers = [
     (r"/tree%s" % notebook_path_regex, TreeHandler),
     (r"/tree%s" % path_regex, TreeHandler),
     (r"/tree", TreeHandler),
-    (r"", TreeRedirectHandler),
+    (r"/?", TreeRedirectHandler),
     ]


### PR DESCRIPTION
- before #6117, only `/base_url/` worked
- after #6117, only `/base_url` worked
- after this PR, both should work.

closes #6329
