### PR TITLE
Add semantic classes to top-level containers for widgets

### DIFF
--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -1497,66 +1497,8 @@ div.cell.text_cell.rendered {
   /* ComboBox Main Button */
   min-width: 125px;
 }
-.widget-box {
-  /* The following section sets the style for the invisible div that
-    hold widgets and their accompanying labels.
-
-    Looks like this:
-    +-----------------------------+
-    | widget-box (or similar)     |
-    |  +-------+---------------+  |
-    |  | Label | Actual Widget |  |
-    |  +-------+---------------+  |
-    +-----------------------------+
-    */
-  margin: 5px;
-  /* Old browsers */
-  -webkit-box-pack: start;
-  -moz-box-pack: start;
-  box-pack: start;
-  /* Modern browsers */
-  justify-content: flex-start;
-  /* ContainerWidget */
-  box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  /* Old browsers */
-  -webkit-box-align: start;
-  -moz-box-align: start;
-  box-align: start;
-  /* Modern browsers */
-  align-items: flex-start;
-}
 .widget-hbox {
   /* Horizontal widgets */
-  /* The following section sets the style for the invisible div that
-    hold widgets and their accompanying labels.
-
-    Looks like this:
-    +-----------------------------+
-    | widget-box (or similar)     |
-    |  +-------+---------------+  |
-    |  | Label | Actual Widget |  |
-    |  +-------+---------------+  |
-    +-----------------------------+
-    */
-  margin: 5px;
-  /* Old browsers */
-  -webkit-box-pack: start;
-  -moz-box-pack: start;
-  box-pack: start;
-  /* Modern browsers */
-  justify-content: flex-start;
-  /* ContainerWidget */
-  box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  /* Old browsers */
-  -webkit-box-align: start;
-  -moz-box-align: start;
-  box-align: start;
-  /* Modern browsers */
-  align-items: flex-start;
   /* Old browsers */
   display: -webkit-box;
   -webkit-box-orient: horizontal;
@@ -1577,6 +1519,10 @@ div.cell.text_cell.rendered {
   box-flex: 0;
   /* Modern browsers */
   flex: none;
+  margin: 5px;
+}
+.widget-hbox input[type="checkbox"] {
+  margin-top: 9px;
 }
 .widget-hbox .widget-label {
   /* Horizontal Label */
@@ -1592,39 +1538,8 @@ div.cell.text_cell.rendered {
   text-align: left;
   vertical-align: text-top;
 }
-.widget-hbox input[type="checkbox"] {
-  margin-top: 9px;
-}
 .widget-vbox {
   /* Vertical widgets */
-  /* The following section sets the style for the invisible div that
-    hold widgets and their accompanying labels.
-
-    Looks like this:
-    +-----------------------------+
-    | widget-box (or similar)     |
-    |  +-------+---------------+  |
-    |  | Label | Actual Widget |  |
-    |  +-------+---------------+  |
-    +-----------------------------+
-    */
-  margin: 5px;
-  /* Old browsers */
-  -webkit-box-pack: start;
-  -moz-box-pack: start;
-  box-pack: start;
-  /* Modern browsers */
-  justify-content: flex-start;
-  /* ContainerWidget */
-  box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  /* Old browsers */
-  -webkit-box-align: start;
-  -moz-box-align: start;
-  box-align: start;
-  /* Modern browsers */
-  align-items: flex-start;
   /* Old browsers */
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -1659,7 +1574,7 @@ div.cell.text_cell.rendered {
   vertical-align: text-top;
 }
 .widget-popup .modal-content {
-  /* ContainerWidget - PopupView */
+  /* PopupView */
   overflow: hidden;
   position: absolute !important;
   top: 0px;
@@ -1667,7 +1582,7 @@ div.cell.text_cell.rendered {
   margin-left: 0px !important;
 }
 .widget-popup .modal-content .modal-body {
-  /* ContainerWidget - PopupView Body */
+  /* PopupView Body */
   max-height: none !important;
 }
 .widget-popup-docked {
@@ -1677,18 +1592,6 @@ div.cell.text_cell.rendered {
   top: 0px !important;
   left: 0px !important;
   margin-left: 0px !important;
-}
-.widget-container {
-  /* ContainerWidget */
-  box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  /* Old browsers */
-  -webkit-box-align: start;
-  -moz-box-align: start;
-  box-align: start;
-  /* Modern browsers */
-  align-items: flex-start;
 }
 .widget-radio :not(.widget-label) {
   /* Contains RadioButtonsWidget */

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -1277,7 +1277,7 @@ div.cell.text_cell.rendered {
 }
 /* THE CLASSES BELOW CAN APPEAR ANYWHERE IN THE DOM (POSSIBLEY OUTSIDE OF
    THE WIDGET AREA). */
-.widget-hlabel {
+.widget-label {
   /* Horizontal Label */
   min-width: 10ex;
   padding-right: 8px;
@@ -1285,7 +1285,7 @@ div.cell.text_cell.rendered {
   text-align: right;
   vertical-align: text-top;
 }
-.widget-vlabel {
+.widget-label {
   /* Vertical Label */
   padding-bottom: 5px;
   text-align: center;
@@ -1548,7 +1548,7 @@ div.cell.text_cell.rendered {
   /* Modern browsers */
   flex: none;
 }
-.widget-hbox-single {
+.widget-hbox {
   /* Single line horizontal widgets */
   /* Horizontal widgets */
   /* The following section sets the style for the invisible div that
@@ -1563,6 +1563,43 @@ div.cell.text_cell.rendered {
     +-----------------------------+
     */
   margin: 5px;
+  /* Old browsers */
+  -webkit-box-pack: start;
+  -moz-box-pack: start;
+  box-pack: start;
+  /* Modern browsers */
+  justify-content: flex-start;
+  /* ContainerWidget */
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  /* Old browsers */
+  -webkit-box-align: start;
+  -moz-box-align: start;
+  box-align: start;
+  /* Modern browsers */
+  align-items: flex-start;
+  /* Old browsers */
+  display: -webkit-box;
+  -webkit-box-orient: horizontal;
+  -webkit-box-align: stretch;
+  display: -moz-box;
+  -moz-box-orient: horizontal;
+  -moz-box-align: stretch;
+  display: box;
+  box-orient: horizontal;
+  box-align: stretch;
+  /* Modern browsers */
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  /* Old browsers */
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  /* Modern browsers */
+  flex: none;
+  height: 30px;
 }
 .widget-hbox input[type="checkbox"] {
   margin-top: 9px;
@@ -1604,7 +1641,7 @@ div.cell.text_cell.rendered {
   /* Modern browsers */
   flex: none;
 }
-.widget-vbox-single {
+.widget-vbox {
   /* For vertical slides */
   /* Vertical widgets */
   /* The following section sets the style for the invisible div that
@@ -1658,7 +1695,7 @@ div.cell.text_cell.rendered {
   width: 30px;
 }
 .widget-modal {
-  /* Box - ModalView */
+  /* ContainerWidget - ModalView */
   overflow: hidden;
   position: absolute !important;
   top: 0px;
@@ -1666,7 +1703,7 @@ div.cell.text_cell.rendered {
   margin-left: 0px !important;
 }
 .widget-modal-body {
-  /* Box - ModalView Body */
+  /* ContainerWidget - ModalView Body */
   max-height: none !important;
 }
 .widget-box {

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -1277,32 +1277,6 @@ div.cell.text_cell.rendered {
 }
 /* THE CLASSES BELOW CAN APPEAR ANYWHERE IN THE DOM (POSSIBLEY OUTSIDE OF
    THE WIDGET AREA). */
-.widget-label {
-  /* Horizontal Label */
-  min-width: 10ex;
-  padding-right: 8px;
-  padding-top: 5px;
-  text-align: right;
-  vertical-align: text-top;
-}
-.widget-label {
-  /* Vertical Label */
-  padding-bottom: 5px;
-  text-align: center;
-  vertical-align: text-bottom;
-}
-.widget-hreadout {
-  padding-left: 8px;
-  padding-top: 5px;
-  text-align: left;
-  vertical-align: text-top;
-}
-.widget-vreadout {
-  /* Vertical Label */
-  padding-top: 5px;
-  text-align: center;
-  vertical-align: text-top;
-}
 .slide-track {
   /* Slider Track */
   border: 1px solid #CCCCCC;
@@ -1310,7 +1284,7 @@ div.cell.text_cell.rendered {
   border-radius: 4px;
   /* Round the corners of the slide track */
 }
-.widget-hslider {
+.widget-hbox.widget-slider .slider-container {
   /* Horizontal jQuery Slider 
 
     Both the horizontal and vertical versions of the slider are characterized
@@ -1369,7 +1343,7 @@ div.cell.text_cell.rendered {
   /* Modern browsers */
   flex: none;
 }
-.widget-hslider .ui-slider {
+.widget-hbox.widget-slider .slider-container .ui-slider {
   /* Inner, invisible slide div */
   border: 0px !important;
   background: none !important;
@@ -1400,12 +1374,12 @@ div.cell.text_cell.rendered {
   /* Modern browsers */
   flex: 1;
 }
-.widget-hslider .ui-slider .ui-slider-handle {
+.widget-hbox.widget-slider .slider-container .ui-slider .ui-slider-handle {
   width: 14px !important;
   height: 28px !important;
   margin-top: -8px !important;
 }
-.widget-hslider .ui-slider .ui-slider-range {
+.widget-hbox.widget-slider .slider-container .ui-slider .ui-slider-range {
   height: 12px !important;
   margin-top: -4px !important;
 }
@@ -1490,27 +1464,28 @@ div.cell.text_cell.rendered {
   width: 12px !important;
   margin-left: -1px !important;
 }
-.widget-text {
+.widget-text input,
+.widget-textarea textarea {
   /* String Textbox - used for TextBoxView and TextAreaView */
   width: 350px;
   margin: 0px !important;
 }
-.widget-listbox {
+.widget-select .form-control {
   /* Listbox */
   width: 350px;
   margin-bottom: 0px;
 }
-.widget-numeric-text {
+.widget-numeric-text input {
   /* Single Line Textbox - used for IntTextView and FloatTextView */
   width: 150px;
   margin: 0px !important;
 }
-.widget-progress {
+.widget-progress .progress {
   /* Progress Bar */
   margin-top: 6px;
   width: 350px;
 }
-.widget-progress .progress-bar {
+.widget-progress .progress .progress-bar {
   /* Disable progress bar animation */
   -webkit-transition: none;
   -moz-transition: none;
@@ -1518,38 +1493,41 @@ div.cell.text_cell.rendered {
   -o-transition: none;
   transition: none;
 }
-.widget-combo-btn {
+.widget-dropdown .dropdown-label {
   /* ComboBox Main Button */
   min-width: 125px;
 }
-.widget_item .dropdown-menu li a {
-  color: inherit;
+.widget-box {
+  /* The following section sets the style for the invisible div that
+    hold widgets and their accompanying labels.
+
+    Looks like this:
+    +-----------------------------+
+    | widget-box (or similar)     |
+    |  +-------+---------------+  |
+    |  | Label | Actual Widget |  |
+    |  +-------+---------------+  |
+    +-----------------------------+
+    */
+  margin: 5px;
+  /* Old browsers */
+  -webkit-box-pack: start;
+  -moz-box-pack: start;
+  box-pack: start;
+  /* Modern browsers */
+  justify-content: flex-start;
+  /* ContainerWidget */
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  /* Old browsers */
+  -webkit-box-align: start;
+  -moz-box-align: start;
+  box-align: start;
+  /* Modern browsers */
+  align-items: flex-start;
 }
 .widget-hbox {
-  /* Horizontal widgets */
-  /* Old browsers */
-  display: -webkit-box;
-  -webkit-box-orient: horizontal;
-  -webkit-box-align: stretch;
-  display: -moz-box;
-  -moz-box-orient: horizontal;
-  -moz-box-align: stretch;
-  display: box;
-  box-orient: horizontal;
-  box-align: stretch;
-  /* Modern browsers */
-  display: flex;
-  flex-direction: row;
-  align-items: stretch;
-  /* Old browsers */
-  -webkit-box-flex: 0;
-  -moz-box-flex: 0;
-  box-flex: 0;
-  /* Modern browsers */
-  flex: none;
-}
-.widget-hbox {
-  /* Single line horizontal widgets */
   /* Horizontal widgets */
   /* The following section sets the style for the invisible div that
     hold widgets and their accompanying labels.
@@ -1599,10 +1577,6 @@ div.cell.text_cell.rendered {
   box-flex: 0;
   /* Modern browsers */
   flex: none;
-  height: 30px;
-}
-.widget-hbox input[type="checkbox"] {
-  margin-top: 9px;
 }
 .widget-hbox .widget-label {
   /* Horizontal Label */
@@ -1618,31 +1592,10 @@ div.cell.text_cell.rendered {
   text-align: left;
   vertical-align: text-top;
 }
-.widget-vbox {
-  /* Vertical widgets */
-  /* Old browsers */
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-box-align: stretch;
-  display: -moz-box;
-  -moz-box-orient: vertical;
-  -moz-box-align: stretch;
-  display: box;
-  box-orient: vertical;
-  box-align: stretch;
-  /* Modern browsers */
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  /* Old browsers */
-  -webkit-box-flex: 0;
-  -moz-box-flex: 0;
-  box-flex: 0;
-  /* Modern browsers */
-  flex: none;
+.widget-hbox input[type="checkbox"] {
+  margin-top: 9px;
 }
 .widget-vbox {
-  /* For vertical slides */
   /* Vertical widgets */
   /* The following section sets the style for the invisible div that
     hold widgets and their accompanying labels.
@@ -1692,22 +1645,41 @@ div.cell.text_cell.rendered {
   box-flex: 0;
   /* Modern browsers */
   flex: none;
-  width: 30px;
 }
-.widget-modal {
-  /* ContainerWidget - ModalView */
+.widget-vbox .widget-label {
+  /* Vertical Label */
+  padding-bottom: 5px;
+  text-align: center;
+  vertical-align: text-bottom;
+}
+.widget-vbox .widget-readout {
+  /* Vertical Label */
+  padding-top: 5px;
+  text-align: center;
+  vertical-align: text-top;
+}
+.widget-popup .modal-content {
+  /* ContainerWidget - PopupView */
   overflow: hidden;
   position: absolute !important;
   top: 0px;
   left: 0px;
   margin-left: 0px !important;
 }
-.widget-modal-body {
-  /* ContainerWidget - ModalView Body */
+.widget-popup .modal-content .modal-body {
+  /* ContainerWidget - PopupView Body */
   max-height: none !important;
 }
-.widget-box {
-  /* Box */
+.widget-popup-docked {
+  /* Horizontal Label */
+  overflow: hidden;
+  position: relative !important;
+  top: 0px !important;
+  left: 0px !important;
+  margin-left: 0px !important;
+}
+.widget-container {
+  /* ContainerWidget */
   box-sizing: border-box;
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
@@ -1718,7 +1690,7 @@ div.cell.text_cell.rendered {
   /* Modern browsers */
   align-items: flex-start;
 }
-.widget-radio-box {
+.widget-radio :not(.widget-label) {
   /* Contains RadioButtonsWidget */
   /* Old browsers */
   display: -webkit-box;
@@ -1745,7 +1717,7 @@ div.cell.text_cell.rendered {
   -webkit-box-sizing: border-box;
   padding-top: 4px;
 }
-.widget-radio-box label {
+.widget-radio :not(.widget-label) label {
   margin-top: 0px;
 }
 .docked-widget-modal {

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -1277,6 +1277,32 @@ div.cell.text_cell.rendered {
 }
 /* THE CLASSES BELOW CAN APPEAR ANYWHERE IN THE DOM (POSSIBLEY OUTSIDE OF
    THE WIDGET AREA). */
+.widget-hlabel {
+  /* Horizontal Label */
+  min-width: 10ex;
+  padding-right: 8px;
+  padding-top: 5px;
+  text-align: right;
+  vertical-align: text-top;
+}
+.widget-vlabel {
+  /* Vertical Label */
+  padding-bottom: 5px;
+  text-align: center;
+  vertical-align: text-bottom;
+}
+.widget-hreadout {
+  padding-left: 8px;
+  padding-top: 5px;
+  text-align: left;
+  vertical-align: text-top;
+}
+.widget-vreadout {
+  /* Vertical Label */
+  padding-top: 5px;
+  text-align: center;
+  vertical-align: text-top;
+}
 .slide-track {
   /* Slider Track */
   border: 1px solid #CCCCCC;
@@ -1521,6 +1547,21 @@ div.cell.text_cell.rendered {
   box-flex: 0;
   /* Modern browsers */
   flex: none;
+}
+.widget-hbox-single {
+  /* Single line horizontal widgets */
+  /* Horizontal widgets */
+  /* The following section sets the style for the invisible div that
+    hold widgets and their accompanying labels.
+
+    Looks like this:
+    +-----------------------------+
+    | widget-box (or similar)     |
+    |  +-------+---------------+  |
+    |  | Label | Actual Widget |  |
+    |  +-------+---------------+  |
+    +-----------------------------+
+    */
   margin: 5px;
 }
 .widget-hbox input[type="checkbox"] {
@@ -1563,17 +1604,58 @@ div.cell.text_cell.rendered {
   /* Modern browsers */
   flex: none;
 }
-.widget-vbox .widget-label {
-  /* Vertical Label */
-  padding-bottom: 5px;
-  text-align: center;
-  vertical-align: text-bottom;
-}
-.widget-vbox .widget-readout {
-  /* Vertical Label */
-  padding-top: 5px;
-  text-align: center;
-  vertical-align: text-top;
+.widget-vbox-single {
+  /* For vertical slides */
+  /* Vertical widgets */
+  /* The following section sets the style for the invisible div that
+    hold widgets and their accompanying labels.
+
+    Looks like this:
+    +-----------------------------+
+    | widget-box (or similar)     |
+    |  +-------+---------------+  |
+    |  | Label | Actual Widget |  |
+    |  +-------+---------------+  |
+    +-----------------------------+
+    */
+  margin: 5px;
+  /* Old browsers */
+  -webkit-box-pack: start;
+  -moz-box-pack: start;
+  box-pack: start;
+  /* Modern browsers */
+  justify-content: flex-start;
+  /* ContainerWidget */
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  /* Old browsers */
+  -webkit-box-align: start;
+  -moz-box-align: start;
+  box-align: start;
+  /* Modern browsers */
+  align-items: flex-start;
+  /* Old browsers */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-box-align: stretch;
+  display: -moz-box;
+  -moz-box-orient: vertical;
+  -moz-box-align: stretch;
+  display: box;
+  box-orient: vertical;
+  box-align: stretch;
+  /* Modern browsers */
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  /* Old browsers */
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  /* Modern browsers */
+  flex: none;
+  width: 30px;
 }
 .widget-modal {
   /* Box - ModalView */

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -9269,66 +9269,8 @@ div.cell.text_cell.rendered {
   /* ComboBox Main Button */
   min-width: 125px;
 }
-.widget-box {
-  /* The following section sets the style for the invisible div that
-    hold widgets and their accompanying labels.
-
-    Looks like this:
-    +-----------------------------+
-    | widget-box (or similar)     |
-    |  +-------+---------------+  |
-    |  | Label | Actual Widget |  |
-    |  +-------+---------------+  |
-    +-----------------------------+
-    */
-  margin: 5px;
-  /* Old browsers */
-  -webkit-box-pack: start;
-  -moz-box-pack: start;
-  box-pack: start;
-  /* Modern browsers */
-  justify-content: flex-start;
-  /* ContainerWidget */
-  box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  /* Old browsers */
-  -webkit-box-align: start;
-  -moz-box-align: start;
-  box-align: start;
-  /* Modern browsers */
-  align-items: flex-start;
-}
 .widget-hbox {
   /* Horizontal widgets */
-  /* The following section sets the style for the invisible div that
-    hold widgets and their accompanying labels.
-
-    Looks like this:
-    +-----------------------------+
-    | widget-box (or similar)     |
-    |  +-------+---------------+  |
-    |  | Label | Actual Widget |  |
-    |  +-------+---------------+  |
-    +-----------------------------+
-    */
-  margin: 5px;
-  /* Old browsers */
-  -webkit-box-pack: start;
-  -moz-box-pack: start;
-  box-pack: start;
-  /* Modern browsers */
-  justify-content: flex-start;
-  /* ContainerWidget */
-  box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  /* Old browsers */
-  -webkit-box-align: start;
-  -moz-box-align: start;
-  box-align: start;
-  /* Modern browsers */
-  align-items: flex-start;
   /* Old browsers */
   display: -webkit-box;
   -webkit-box-orient: horizontal;
@@ -9349,6 +9291,10 @@ div.cell.text_cell.rendered {
   box-flex: 0;
   /* Modern browsers */
   flex: none;
+  margin: 5px;
+}
+.widget-hbox input[type="checkbox"] {
+  margin-top: 9px;
 }
 .widget-hbox .widget-label {
   /* Horizontal Label */
@@ -9364,39 +9310,8 @@ div.cell.text_cell.rendered {
   text-align: left;
   vertical-align: text-top;
 }
-.widget-hbox input[type="checkbox"] {
-  margin-top: 9px;
-}
 .widget-vbox {
   /* Vertical widgets */
-  /* The following section sets the style for the invisible div that
-    hold widgets and their accompanying labels.
-
-    Looks like this:
-    +-----------------------------+
-    | widget-box (or similar)     |
-    |  +-------+---------------+  |
-    |  | Label | Actual Widget |  |
-    |  +-------+---------------+  |
-    +-----------------------------+
-    */
-  margin: 5px;
-  /* Old browsers */
-  -webkit-box-pack: start;
-  -moz-box-pack: start;
-  box-pack: start;
-  /* Modern browsers */
-  justify-content: flex-start;
-  /* ContainerWidget */
-  box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  /* Old browsers */
-  -webkit-box-align: start;
-  -moz-box-align: start;
-  box-align: start;
-  /* Modern browsers */
-  align-items: flex-start;
   /* Old browsers */
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -9431,7 +9346,7 @@ div.cell.text_cell.rendered {
   vertical-align: text-top;
 }
 .widget-popup .modal-content {
-  /* ContainerWidget - PopupView */
+  /* PopupView */
   overflow: hidden;
   position: absolute !important;
   top: 0px;
@@ -9439,7 +9354,7 @@ div.cell.text_cell.rendered {
   margin-left: 0px !important;
 }
 .widget-popup .modal-content .modal-body {
-  /* ContainerWidget - PopupView Body */
+  /* PopupView Body */
   max-height: none !important;
 }
 .widget-popup-docked {
@@ -9449,18 +9364,6 @@ div.cell.text_cell.rendered {
   top: 0px !important;
   left: 0px !important;
   margin-left: 0px !important;
-}
-.widget-container {
-  /* ContainerWidget */
-  box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  /* Old browsers */
-  -webkit-box-align: start;
-  -moz-box-align: start;
-  box-align: start;
-  /* Modern browsers */
-  align-items: flex-start;
 }
 .widget-radio :not(.widget-label) {
   /* Contains RadioButtonsWidget */

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -9049,32 +9049,6 @@ div.cell.text_cell.rendered {
 }
 /* THE CLASSES BELOW CAN APPEAR ANYWHERE IN THE DOM (POSSIBLEY OUTSIDE OF
    THE WIDGET AREA). */
-.widget-label {
-  /* Horizontal Label */
-  min-width: 10ex;
-  padding-right: 8px;
-  padding-top: 5px;
-  text-align: right;
-  vertical-align: text-top;
-}
-.widget-label {
-  /* Vertical Label */
-  padding-bottom: 5px;
-  text-align: center;
-  vertical-align: text-bottom;
-}
-.widget-hreadout {
-  padding-left: 8px;
-  padding-top: 5px;
-  text-align: left;
-  vertical-align: text-top;
-}
-.widget-vreadout {
-  /* Vertical Label */
-  padding-top: 5px;
-  text-align: center;
-  vertical-align: text-top;
-}
 .slide-track {
   /* Slider Track */
   border: 1px solid #CCCCCC;
@@ -9082,7 +9056,7 @@ div.cell.text_cell.rendered {
   border-radius: 4px;
   /* Round the corners of the slide track */
 }
-.widget-hslider {
+.widget-hbox.widget-slider .slider-container {
   /* Horizontal jQuery Slider 
 
     Both the horizontal and vertical versions of the slider are characterized
@@ -9141,7 +9115,7 @@ div.cell.text_cell.rendered {
   /* Modern browsers */
   flex: none;
 }
-.widget-hslider .ui-slider {
+.widget-hbox.widget-slider .slider-container .ui-slider {
   /* Inner, invisible slide div */
   border: 0px !important;
   background: none !important;
@@ -9172,12 +9146,12 @@ div.cell.text_cell.rendered {
   /* Modern browsers */
   flex: 1;
 }
-.widget-hslider .ui-slider .ui-slider-handle {
+.widget-hbox.widget-slider .slider-container .ui-slider .ui-slider-handle {
   width: 14px !important;
   height: 28px !important;
   margin-top: -8px !important;
 }
-.widget-hslider .ui-slider .ui-slider-range {
+.widget-hbox.widget-slider .slider-container .ui-slider .ui-slider-range {
   height: 12px !important;
   margin-top: -4px !important;
 }
@@ -9262,27 +9236,28 @@ div.cell.text_cell.rendered {
   width: 12px !important;
   margin-left: -1px !important;
 }
-.widget-text {
+.widget-text input,
+.widget-textarea textarea {
   /* String Textbox - used for TextBoxView and TextAreaView */
   width: 350px;
   margin: 0px !important;
 }
-.widget-listbox {
+.widget-select .form-control {
   /* Listbox */
   width: 350px;
   margin-bottom: 0px;
 }
-.widget-numeric-text {
+.widget-numeric-text input {
   /* Single Line Textbox - used for IntTextView and FloatTextView */
   width: 150px;
   margin: 0px !important;
 }
-.widget-progress {
+.widget-progress .progress {
   /* Progress Bar */
   margin-top: 6px;
   width: 350px;
 }
-.widget-progress .progress-bar {
+.widget-progress .progress .progress-bar {
   /* Disable progress bar animation */
   -webkit-transition: none;
   -moz-transition: none;
@@ -9290,38 +9265,41 @@ div.cell.text_cell.rendered {
   -o-transition: none;
   transition: none;
 }
-.widget-combo-btn {
+.widget-dropdown .dropdown-label {
   /* ComboBox Main Button */
   min-width: 125px;
 }
-.widget_item .dropdown-menu li a {
-  color: inherit;
+.widget-box {
+  /* The following section sets the style for the invisible div that
+    hold widgets and their accompanying labels.
+
+    Looks like this:
+    +-----------------------------+
+    | widget-box (or similar)     |
+    |  +-------+---------------+  |
+    |  | Label | Actual Widget |  |
+    |  +-------+---------------+  |
+    +-----------------------------+
+    */
+  margin: 5px;
+  /* Old browsers */
+  -webkit-box-pack: start;
+  -moz-box-pack: start;
+  box-pack: start;
+  /* Modern browsers */
+  justify-content: flex-start;
+  /* ContainerWidget */
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  /* Old browsers */
+  -webkit-box-align: start;
+  -moz-box-align: start;
+  box-align: start;
+  /* Modern browsers */
+  align-items: flex-start;
 }
 .widget-hbox {
-  /* Horizontal widgets */
-  /* Old browsers */
-  display: -webkit-box;
-  -webkit-box-orient: horizontal;
-  -webkit-box-align: stretch;
-  display: -moz-box;
-  -moz-box-orient: horizontal;
-  -moz-box-align: stretch;
-  display: box;
-  box-orient: horizontal;
-  box-align: stretch;
-  /* Modern browsers */
-  display: flex;
-  flex-direction: row;
-  align-items: stretch;
-  /* Old browsers */
-  -webkit-box-flex: 0;
-  -moz-box-flex: 0;
-  box-flex: 0;
-  /* Modern browsers */
-  flex: none;
-}
-.widget-hbox {
-  /* Single line horizontal widgets */
   /* Horizontal widgets */
   /* The following section sets the style for the invisible div that
     hold widgets and their accompanying labels.
@@ -9371,10 +9349,6 @@ div.cell.text_cell.rendered {
   box-flex: 0;
   /* Modern browsers */
   flex: none;
-  height: 30px;
-}
-.widget-hbox input[type="checkbox"] {
-  margin-top: 9px;
 }
 .widget-hbox .widget-label {
   /* Horizontal Label */
@@ -9390,31 +9364,10 @@ div.cell.text_cell.rendered {
   text-align: left;
   vertical-align: text-top;
 }
-.widget-vbox {
-  /* Vertical widgets */
-  /* Old browsers */
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-box-align: stretch;
-  display: -moz-box;
-  -moz-box-orient: vertical;
-  -moz-box-align: stretch;
-  display: box;
-  box-orient: vertical;
-  box-align: stretch;
-  /* Modern browsers */
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  /* Old browsers */
-  -webkit-box-flex: 0;
-  -moz-box-flex: 0;
-  box-flex: 0;
-  /* Modern browsers */
-  flex: none;
+.widget-hbox input[type="checkbox"] {
+  margin-top: 9px;
 }
 .widget-vbox {
-  /* For vertical slides */
   /* Vertical widgets */
   /* The following section sets the style for the invisible div that
     hold widgets and their accompanying labels.
@@ -9464,22 +9417,41 @@ div.cell.text_cell.rendered {
   box-flex: 0;
   /* Modern browsers */
   flex: none;
-  width: 30px;
 }
-.widget-modal {
-  /* ContainerWidget - ModalView */
+.widget-vbox .widget-label {
+  /* Vertical Label */
+  padding-bottom: 5px;
+  text-align: center;
+  vertical-align: text-bottom;
+}
+.widget-vbox .widget-readout {
+  /* Vertical Label */
+  padding-top: 5px;
+  text-align: center;
+  vertical-align: text-top;
+}
+.widget-popup .modal-content {
+  /* ContainerWidget - PopupView */
   overflow: hidden;
   position: absolute !important;
   top: 0px;
   left: 0px;
   margin-left: 0px !important;
 }
-.widget-modal-body {
-  /* ContainerWidget - ModalView Body */
+.widget-popup .modal-content .modal-body {
+  /* ContainerWidget - PopupView Body */
   max-height: none !important;
 }
-.widget-box {
-  /* Box */
+.widget-popup-docked {
+  /* Horizontal Label */
+  overflow: hidden;
+  position: relative !important;
+  top: 0px !important;
+  left: 0px !important;
+  margin-left: 0px !important;
+}
+.widget-container {
+  /* ContainerWidget */
   box-sizing: border-box;
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
@@ -9490,7 +9462,7 @@ div.cell.text_cell.rendered {
   /* Modern browsers */
   align-items: flex-start;
 }
-.widget-radio-box {
+.widget-radio :not(.widget-label) {
   /* Contains RadioButtonsWidget */
   /* Old browsers */
   display: -webkit-box;
@@ -9517,7 +9489,7 @@ div.cell.text_cell.rendered {
   -webkit-box-sizing: border-box;
   padding-top: 4px;
 }
-.widget-radio-box label {
+.widget-radio :not(.widget-label) label {
   margin-top: 0px;
 }
 .docked-widget-modal {

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -9049,7 +9049,7 @@ div.cell.text_cell.rendered {
 }
 /* THE CLASSES BELOW CAN APPEAR ANYWHERE IN THE DOM (POSSIBLEY OUTSIDE OF
    THE WIDGET AREA). */
-.widget-hlabel {
+.widget-label {
   /* Horizontal Label */
   min-width: 10ex;
   padding-right: 8px;
@@ -9057,7 +9057,7 @@ div.cell.text_cell.rendered {
   text-align: right;
   vertical-align: text-top;
 }
-.widget-vlabel {
+.widget-label {
   /* Vertical Label */
   padding-bottom: 5px;
   text-align: center;
@@ -9320,7 +9320,7 @@ div.cell.text_cell.rendered {
   /* Modern browsers */
   flex: none;
 }
-.widget-hbox-single {
+.widget-hbox {
   /* Single line horizontal widgets */
   /* Horizontal widgets */
   /* The following section sets the style for the invisible div that
@@ -9335,6 +9335,43 @@ div.cell.text_cell.rendered {
     +-----------------------------+
     */
   margin: 5px;
+  /* Old browsers */
+  -webkit-box-pack: start;
+  -moz-box-pack: start;
+  box-pack: start;
+  /* Modern browsers */
+  justify-content: flex-start;
+  /* ContainerWidget */
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  /* Old browsers */
+  -webkit-box-align: start;
+  -moz-box-align: start;
+  box-align: start;
+  /* Modern browsers */
+  align-items: flex-start;
+  /* Old browsers */
+  display: -webkit-box;
+  -webkit-box-orient: horizontal;
+  -webkit-box-align: stretch;
+  display: -moz-box;
+  -moz-box-orient: horizontal;
+  -moz-box-align: stretch;
+  display: box;
+  box-orient: horizontal;
+  box-align: stretch;
+  /* Modern browsers */
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  /* Old browsers */
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  /* Modern browsers */
+  flex: none;
+  height: 30px;
 }
 .widget-hbox input[type="checkbox"] {
   margin-top: 9px;
@@ -9376,7 +9413,7 @@ div.cell.text_cell.rendered {
   /* Modern browsers */
   flex: none;
 }
-.widget-vbox-single {
+.widget-vbox {
   /* For vertical slides */
   /* Vertical widgets */
   /* The following section sets the style for the invisible div that
@@ -9430,7 +9467,7 @@ div.cell.text_cell.rendered {
   width: 30px;
 }
 .widget-modal {
-  /* Box - ModalView */
+  /* ContainerWidget - ModalView */
   overflow: hidden;
   position: absolute !important;
   top: 0px;
@@ -9438,7 +9475,7 @@ div.cell.text_cell.rendered {
   margin-left: 0px !important;
 }
 .widget-modal-body {
-  /* Box - ModalView Body */
+  /* ContainerWidget - ModalView Body */
   max-height: none !important;
 }
 .widget-box {

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -9049,6 +9049,32 @@ div.cell.text_cell.rendered {
 }
 /* THE CLASSES BELOW CAN APPEAR ANYWHERE IN THE DOM (POSSIBLEY OUTSIDE OF
    THE WIDGET AREA). */
+.widget-hlabel {
+  /* Horizontal Label */
+  min-width: 10ex;
+  padding-right: 8px;
+  padding-top: 5px;
+  text-align: right;
+  vertical-align: text-top;
+}
+.widget-vlabel {
+  /* Vertical Label */
+  padding-bottom: 5px;
+  text-align: center;
+  vertical-align: text-bottom;
+}
+.widget-hreadout {
+  padding-left: 8px;
+  padding-top: 5px;
+  text-align: left;
+  vertical-align: text-top;
+}
+.widget-vreadout {
+  /* Vertical Label */
+  padding-top: 5px;
+  text-align: center;
+  vertical-align: text-top;
+}
 .slide-track {
   /* Slider Track */
   border: 1px solid #CCCCCC;
@@ -9293,6 +9319,21 @@ div.cell.text_cell.rendered {
   box-flex: 0;
   /* Modern browsers */
   flex: none;
+}
+.widget-hbox-single {
+  /* Single line horizontal widgets */
+  /* Horizontal widgets */
+  /* The following section sets the style for the invisible div that
+    hold widgets and their accompanying labels.
+
+    Looks like this:
+    +-----------------------------+
+    | widget-box (or similar)     |
+    |  +-------+---------------+  |
+    |  | Label | Actual Widget |  |
+    |  +-------+---------------+  |
+    +-----------------------------+
+    */
   margin: 5px;
 }
 .widget-hbox input[type="checkbox"] {
@@ -9335,17 +9376,58 @@ div.cell.text_cell.rendered {
   /* Modern browsers */
   flex: none;
 }
-.widget-vbox .widget-label {
-  /* Vertical Label */
-  padding-bottom: 5px;
-  text-align: center;
-  vertical-align: text-bottom;
-}
-.widget-vbox .widget-readout {
-  /* Vertical Label */
-  padding-top: 5px;
-  text-align: center;
-  vertical-align: text-top;
+.widget-vbox-single {
+  /* For vertical slides */
+  /* Vertical widgets */
+  /* The following section sets the style for the invisible div that
+    hold widgets and their accompanying labels.
+
+    Looks like this:
+    +-----------------------------+
+    | widget-box (or similar)     |
+    |  +-------+---------------+  |
+    |  | Label | Actual Widget |  |
+    |  +-------+---------------+  |
+    +-----------------------------+
+    */
+  margin: 5px;
+  /* Old browsers */
+  -webkit-box-pack: start;
+  -moz-box-pack: start;
+  box-pack: start;
+  /* Modern browsers */
+  justify-content: flex-start;
+  /* ContainerWidget */
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  /* Old browsers */
+  -webkit-box-align: start;
+  -moz-box-align: start;
+  box-align: start;
+  /* Modern browsers */
+  align-items: flex-start;
+  /* Old browsers */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-box-align: stretch;
+  display: -moz-box;
+  -moz-box-orient: vertical;
+  -moz-box-align: stretch;
+  display: box;
+  box-orient: vertical;
+  box-align: stretch;
+  /* Modern browsers */
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  /* Old browsers */
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  /* Modern browsers */
+  flex: none;
+  width: 30px;
 }
 .widget-modal {
   /* Box - ModalView */

--- a/IPython/html/static/widgets/js/widget_bool.js
+++ b/IPython/html/static/widgets/js/widget_bool.js
@@ -11,7 +11,7 @@ define([
         render : function(){
             // Called when view is rendered.
             this.$el
-                .addClass('widget-hbox');
+                .addClass('widget-hbox widget-checkbox');
             this.$label = $('<div />')
                 .addClass('widget-label')
                 .appendTo(this.$el)

--- a/IPython/html/static/widgets/js/widget_bool.js
+++ b/IPython/html/static/widgets/js/widget_bool.js
@@ -70,7 +70,7 @@ define([
             // Called when view is rendered.
             var that = this;
             this.setElement($('<button />')
-                .addClass('btn btn-default')
+                .addClass('btn btn-default widget-togglebutton')
                 .attr('type', 'button')
                 .on('click', function (e) {
                     e.preventDefault();

--- a/IPython/html/static/widgets/js/widget_box.js
+++ b/IPython/html/static/widgets/js/widget_box.js
@@ -136,6 +136,7 @@ define([
             var that = this;
             
             this.$el
+                .addClass('widget-popup-inline')
                 .on("remove", function(){
                     that.$backdrop.remove();
                 });

--- a/IPython/html/static/widgets/js/widget_box.js
+++ b/IPython/html/static/widgets/js/widget_box.js
@@ -83,7 +83,7 @@ define([
             });
         },
     });
-
+    
 
     var FlexBoxView = BoxView.extend({
         render: function(){
@@ -135,18 +135,20 @@ define([
             // Called when view is rendered.
             var that = this;
             
-            this.$el.on("remove", function(){
+            this.$el
+                .on("remove", function(){
                     that.$backdrop.remove();
                 });
             this.$backdrop = $('<div />')
                 .appendTo($('#notebook-container'))
                 .addClass('modal-dialog')
+                .addClass('widget-popup')
                 .css('position', 'absolute')
                 .css('left', '0px')
                 .css('top', '0px');
             this.$window = $('<div />')
                 .appendTo(this.$backdrop)
-                .addClass('modal-content widget-modal')
+                .addClass('modal-content')
                 .mousedown(function(){
                     that.bring_to_front();
                 });
@@ -179,26 +181,26 @@ define([
                     that.popped_out = !that.popped_out;
                     if (!that.popped_out) {
                         that.$minimize
-                            .removeClass('fa-arrow-down')
-                            .addClass('fa-arrow-up');
+                            .removeClass('fa fa-arrow-down')
+                            .addClass('fa fa-arrow-up');
                             
                         that.$window
                             .draggable('destroy')
                             .resizable('destroy')
-                            .removeClass('widget-modal modal-content')
-                            .addClass('docked-widget-modal')
+                            .removeClass('modal-content')
+                            .addClass('widget-popup-docked')
                             .detach()
                             .insertBefore(that.$show_button);
                         that.$show_button.hide();
                         that.$close.hide();
                     } else {
                         that.$minimize
-                            .addClass('fa-arrow-down')
-                            .removeClass('fa-arrow-up');
+                            .addClass('fa fa-arrow-down')
+                            .removeClass('fa fa-arrow-up');
 
                         that.$window
-                            .removeClass('docked-widget-modal')
-                            .addClass('widget-modal modal-content')
+                            .removeClass('widget-popup-docked')
+                            .addClass('modal-content')
                             .detach()
                             .appendTo(that.$backdrop)
                             .draggable({handle: '.popover-title', snap: '#notebook, .modal', snapMode: 'both'})
@@ -213,7 +215,7 @@ define([
             this.$title = $('<div />')
                 .addClass('widget-modal-title')
                 .html("&nbsp;")
-                .appendTo(this.$title_bar);     
+                .appendTo(this.$title_bar);
             this.$box = $('<div />')
                 .addClass('modal-body')
                 .addClass('widget-modal-body')
@@ -265,7 +267,7 @@ define([
         
         bring_to_front: function() {
             // Make the modal top-most, z-ordered about the other modals.
-            var $widget_modals = $(".widget-modal");
+            var $widget_modals = $(".widget-modal .widget-popup");
             var max_zindex = 0;
             $widget_modals.each(function (index, el){
                 var zindex = parseInt($(el).css('z-index'));
@@ -284,6 +286,29 @@ define([
                 }
             });
             this.$window.css('z-index', max_zindex);
+        },
+        
+        update_children: function(old_list, new_list) {
+            // Called when the children list is modified.
+            this.do_diff(old_list, new_list, 
+                $.proxy(this.remove_child_model, this),
+                $.proxy(this.add_child_model, this));
+        },
+
+        remove_child_model: function(model) {
+            // Called when a child is removed from children list.
+            this.pop_child_view(model).remove();
+        },
+
+        add_child_model: function(model) {
+            // Called when a child is added to children list.
+            var view = this.create_child_view(model);
+            this.$body.append(view.$el);
+
+            // Trigger the displayed event of the child view.
+            this.after_displayed(function() {
+                view.trigger('displayed');
+            });
         },
         
         update: function(){

--- a/IPython/html/static/widgets/js/widget_button.js
+++ b/IPython/html/static/widgets/js/widget_button.js
@@ -11,7 +11,7 @@ define([
         render : function(){
             // Called when view is rendered.
             this.setElement($("<button />")
-                .addClass('btn btn-default'));
+                .addClass('btn btn-default widget-button'));
 
             this.model.on('change:button_style', function(model, value) {
                 this.update_button_style();

--- a/IPython/html/static/widgets/js/widget_image.js
+++ b/IPython/html/static/widgets/js/widget_image.js
@@ -10,6 +10,7 @@ define([
         render : function(){
             // Called when view is rendered.
             this.setElement($("<img />"));
+            this.$el.addClass('widget-image');
             this.update(); // Set defaults.
         },
         

--- a/IPython/html/static/widgets/js/widget_int.js
+++ b/IPython/html/static/widgets/js/widget_int.js
@@ -107,8 +107,8 @@ define([
                     else if(value < min){ 
                         value = min; 
                     }
-                this.$slider.slider('option', 'value', value);
-                this.$readout.text(value);
+                    this.$slider.slider('option', 'value', value);
+                    this.$readout.text(value);
                 }
 
                 if(this.model.get('value')!=value) {
@@ -118,17 +118,11 @@ define([
 
                 // Use the right CSS classes for vertical & horizontal sliders
                 if (orientation=='vertical') {
-                    this.$slider_container
-                        .removeClass('widget-hslider')
-                        .addClass('widget-vslider');
                     this.$el
                         .removeClass('widget-hbox')
                         .addClass('widget-vbox');
 
                 } else {
-                    this.$slider_container
-                        .removeClass('widget-vslider')
-                        .addClass('widget-hslider');
                     this.$el
                         .removeClass('widget-vbox')
                         .addClass('widget-hbox');

--- a/IPython/html/static/widgets/js/widget_int.js
+++ b/IPython/html/static/widgets/js/widget_int.js
@@ -11,7 +11,7 @@ define([
         render : function(){
             // Called when view is rendered.
             this.$el
-                .addClass('widget-hbox');
+                .addClass('widget-hbox widget-slider');
             this.$label = $('<div />')
                 .appendTo(this.$el)
                 .addClass('widget-label')
@@ -30,7 +30,7 @@ define([
                 .appendTo(this.$el)
                 .addClass('widget-readout')
                 .hide();
-
+            
             this.model.on('change:slider_color', function(sender, value) {
                 this.$slider.find('a').css('background', value);
             }, this);
@@ -39,7 +39,7 @@ define([
             // Set defaults.
             this.update();
         },
-
+        
         update_attr: function(name, value) {
             // Set a css attr of the widget view.
             if (name == 'color') {
@@ -108,8 +108,8 @@ define([
                     else if(value < min){ 
                         value = min; 
                     }
-                    this.$slider.slider('option', 'value', value);
-                    this.$readout.text(value);
+                this.$slider.slider('option', 'value', value);
+                this.$readout.text(value);
                 }
 
                 if(this.model.get('value')!=value) {
@@ -168,7 +168,7 @@ define([
                 var actual_value = ui.values.map(this._validate_slide_value);
                 this.$readout.text(actual_value.join("-"));
             } else {
-                var actual_value = this._validate_slide_value(ui.value);
+            var actual_value = this._validate_slide_value(ui.value);
                 this.$readout.text(actual_value);
             }
             this.model.set('value', actual_value, {updated_view: this});
@@ -189,7 +189,7 @@ define([
         render : function(){
             // Called when view is rendered.
             this.$el
-                .addClass('widget-hbox');
+                .addClass('widget-hbox widget-text');
             this.$label = $('<div />')
                 .appendTo(this.$el)
                 .addClass('widget-label')
@@ -297,7 +297,7 @@ define([
         render : function(){
             // Called when view is rendered.
             this.$el
-                .addClass('widget-hbox');
+                .addClass('widget-hbox widget-progress');
             this.$label = $('<div />')
                 .appendTo(this.$el)
                 .addClass('widget-label')

--- a/IPython/html/static/widgets/js/widget_int.js
+++ b/IPython/html/static/widgets/js/widget_int.js
@@ -22,7 +22,6 @@ define([
                 .addClass('slider');
             // Put the slider in a container 
             this.$slider_container = $('<div />')
-                .addClass('widget-hslider')
                 .append(this.$slider);
             this.$el.append(this.$slider_container);
             
@@ -168,7 +167,7 @@ define([
                 var actual_value = ui.values.map(this._validate_slide_value);
                 this.$readout.text(actual_value.join("-"));
             } else {
-            var actual_value = this._validate_slide_value(ui.value);
+                var actual_value = this._validate_slide_value(ui.value);
                 this.$readout.text(actual_value);
             }
             this.model.set('value', actual_value, {updated_view: this});
@@ -189,14 +188,13 @@ define([
         render : function(){
             // Called when view is rendered.
             this.$el
-                .addClass('widget-hbox widget-text');
+                .addClass('widget-hbox widget-numeric-text');
             this.$label = $('<div />')
                 .appendTo(this.$el)
                 .addClass('widget-label')
                 .hide();
             this.$textbox = $('<input type="text" />')
                 .addClass('form-control')
-                .addClass('widget-numeric-text')
                 .appendTo(this.$el);
             this.update(); // Set defaults.
         },
@@ -304,7 +302,6 @@ define([
                 .hide();
             this.$progress = $('<div />')
                 .addClass('progress')
-                .addClass('widget-progress')
                 .appendTo(this.$el);
             this.$bar = $('<div />')
                 .addClass('progress-bar')

--- a/IPython/html/static/widgets/js/widget_int.js
+++ b/IPython/html/static/widgets/js/widget_int.js
@@ -21,9 +21,7 @@ define([
                 .slider({})
                 .addClass('slider');
             // Put the slider in a container 
-            this.$slider_container = $('<div />')
-                .append(this.$slider);
-            this.$el.append(this.$slider_container);
+            this.$el.append(this.$slider);
             
             this.$readout = $('<div/>')
                 .appendTo(this.$el)
@@ -47,9 +45,9 @@ define([
                 this.$readout.css(name, value);
             } else if (name.substring(0, 6) == 'border') {
                 this.$slider.find('a').css(name, value);
-                this.$slider_container.css(name, value);
+                this.$slider.css(name, value);
             } else if (name == 'width' || name == 'height' || name == 'background') {
-                this.$slider_container.css(name, value);
+                this.$slider.css(name, value);
             } else {
                 this.$slider.css(name, value);
             }

--- a/IPython/html/static/widgets/js/widget_selection.js
+++ b/IPython/html/static/widgets/js/widget_selection.js
@@ -12,7 +12,7 @@ define([
         render : function(){
             // Called when view is rendered.
             this.$el
-                .addClass('widget-hbox');
+                .addClass('widget-hbox widget-dropdown');
             this.$label = $('<div />')
                 .appendTo(this.$el)
                 .addClass('widget-label')
@@ -36,7 +36,7 @@ define([
             this.$droplist = $('<ul />')
                 .addClass('dropdown-menu')
                 .appendTo(this.$buttongroup);
-
+            
             this.model.on('change:button_style', function(model, value) {
                 this.update_button_style();
             }, this);
@@ -251,7 +251,7 @@ define([
         render: function() {
             // Called when view is rendered.
             this.$el
-                .addClass('widget-hbox');
+                .addClass('widget-hbox widget-toggle-buttons');
             this.$label = $('<div />')
                 .appendTo(this.$el)
                 .addClass('widget-label')

--- a/IPython/html/static/widgets/js/widget_selection.js
+++ b/IPython/html/static/widgets/js/widget_selection.js
@@ -18,7 +18,6 @@ define([
                 .addClass('widget-label')
                 .hide();
             this.$buttongroup = $('<div />')
-                .addClass('widget_item')
                 .addClass('btn-group')
                 .appendTo(this.$el);
             this.$droplabel = $('<button />')
@@ -29,7 +28,6 @@ define([
             this.$dropbutton = $('<button />')
                 .addClass('btn btn-default')
                 .addClass('dropdown-toggle')
-                .addClass('widget-combo-carrot-btn')
                 .attr('data-toggle', 'dropdown')
                 .append($('<span />').addClass("caret"))
                 .appendTo(this.$buttongroup);
@@ -152,14 +150,13 @@ define([
         render : function(){
             // Called when view is rendered.
             this.$el
-                .addClass('widget-hbox');
+                .addClass('widget-box widget-radio');
             this.$label = $('<div />')
                 .appendTo(this.$el)
                 .addClass('widget-label')
                 .hide();
             this.$container = $('<div />')
-                .appendTo(this.$el)
-                .addClass('widget-radio-box');
+                .appendTo(this.$el);
             this.update();
         },
         
@@ -243,12 +240,7 @@ define([
     
 
     var ToggleButtonsView = widget.DOMWidgetView.extend({
-        initialize: function() {
-            this._css_state = {};
-            ToggleButtonsView.__super__.initialize.apply(this, arguments);
-        },
-
-        render: function() {
+        render : function(){
             // Called when view is rendered.
             this.$el
                 .addClass('widget-hbox widget-toggle-buttons');
@@ -295,7 +287,6 @@ define([
                             .appendTo(that.$buttongroup)
                             .attr('data-value', item)
                             .on('click', $.proxy(that.handle_click, that));
-                        that.update_style_traits($item_element);
                     }
                     if (that.model.get('value_name') == item) {
                         $item_element.addClass('active');
@@ -381,13 +372,13 @@ define([
         render : function(){
             // Called when view is rendered.
             this.$el
-                .addClass('widget-hbox');
+                .addClass('widget-hbox widget-select');
             this.$label = $('<div />')
                 .appendTo(this.$el)
                 .addClass('widget-label')
                 .hide();
             this.$listbox = $('<select />')
-                .addClass('widget-listbox form-control')
+                .addClass('form-control')
                 .attr('size', 6)
                 .appendTo(this.$el);
             this.update();

--- a/IPython/html/static/widgets/js/widget_selection.js
+++ b/IPython/html/static/widgets/js/widget_selection.js
@@ -150,7 +150,7 @@ define([
         render : function(){
             // Called when view is rendered.
             this.$el
-                .addClass('widget-box widget-radio');
+                .addClass('widget-vbox widget-radio');
             this.$label = $('<div />')
                 .appendTo(this.$el)
                 .addClass('widget-label')

--- a/IPython/html/static/widgets/js/widget_selectioncontainer.js
+++ b/IPython/html/static/widgets/js/widget_selectioncontainer.js
@@ -14,7 +14,7 @@ define([
             var guid = 'panel-group' + utils.uuid();
             this.$el
                 .attr('id', guid)
-                .addClass('panel-group');
+                .addClass('panel-group widget-accordion');
             this.containers = [];
             this.model_containers = {};
             this.update_children([], this.model.get('children'));
@@ -138,6 +138,7 @@ define([
             // Called when view is rendered.
             var uuid = 'tabs'+utils.uuid();
             var that = this;
+            this.$el.addClass('widget-tabs');
             this.$tabs = $('<div />', {id: uuid})
                 .addClass('nav')
                 .addClass('nav-tabs')

--- a/IPython/html/static/widgets/js/widget_string.js
+++ b/IPython/html/static/widgets/js/widget_string.js
@@ -47,7 +47,7 @@ define([
         render: function(){
             // Called when view is rendered.
             this.$el
-                .addClass('widget-hbox');
+                .addClass('widget-hbox widget-textarea');
             this.$label = $('<div />')
                 .appendTo(this.$el)
                 .addClass('widget-label')
@@ -107,7 +107,7 @@ define([
             }
             return TextareaView.__super__.update.apply(this);
         },
-
+        
         update_attr: function(name, value) {
             // Set a css attr of the widget view.
             this.$textbox.css(name, value);
@@ -135,7 +135,7 @@ define([
         render: function(){
             // Called when view is rendered.
             this.$el
-                .addClass('widget-hbox');
+                .addClass('widget-hbox widget-text');
             this.$label = $('<div />')
                 .addClass('widget-label')
                 .appendTo(this.$el)
@@ -183,7 +183,7 @@ define([
             }
             return TextView.__super__.update.apply(this);
         },
-
+        
         update_attr: function(name, value) {
             // Set a css attr of the widget view.
             this.$textbox.css(name, value);

--- a/IPython/html/static/widgets/js/widget_string.js
+++ b/IPython/html/static/widgets/js/widget_string.js
@@ -11,6 +11,7 @@ define([
         render : function(){
             // Called when view is rendered.
             this.update(); // Set defaults.
+            this.$el.addClass('widget-html');
         },
         
         update : function(){
@@ -28,6 +29,7 @@ define([
         render : function(){
             // Called when view is rendered.
             this.update(); // Set defaults.
+            this.$el.addClass('widget-latex');
         },
         
         update : function(){
@@ -54,7 +56,7 @@ define([
                 .hide();
             this.$textbox = $('<textarea />')
                 .attr('rows', 5)
-                .addClass('widget-text form-control')
+                .addClass('form-control')
                 .appendTo(this.$el);
             this.update(); // Set defaults.
 
@@ -142,7 +144,7 @@ define([
                 .hide();
             this.$textbox = $('<input type="text" />')
                 .addClass('input')
-                .addClass('widget-text form-control')
+                .addClass('form-control')
                 .appendTo(this.$el);
             this.update(); // Set defaults.
             this.model.on('change:placeholder', function(model, value, options) {

--- a/IPython/html/static/widgets/less/widgets.less
+++ b/IPython/html/static/widgets/less/widgets.less
@@ -236,7 +236,7 @@
         padding-bottom : 5px;
         text-align     : center;
         vertical-align : text-bottom;
-}
+    }
 
     .widget-readout {
         /* Vertical Label */
@@ -253,11 +253,10 @@
     top         : 0px; 
     left        : 0px; 
     margin-left : 0px !important;
-}
 
     .modal-body {
         /* ContainerWidget - PopupView Body */
-    max-height: none !important;
+        max-height: none !important;
     }
 }
 

--- a/IPython/html/static/widgets/less/widgets.less
+++ b/IPython/html/static/widgets/less/widgets.less
@@ -39,7 +39,7 @@
     .corner-all(); /* Round the corners of the slide track */
 }
 
-.widget-hbox-single.widget-slider .slider-container {
+.widget-hbox.widget-slider .slider-container {
     /* Horizontal jQuery Slider 
 
     Both the horizontal and vertical versions of the slider are characterized

--- a/IPython/html/static/widgets/less/widgets.less
+++ b/IPython/html/static/widgets/less/widgets.less
@@ -39,7 +39,7 @@
     .corner-all(); /* Round the corners of the slide track */
 }
 
-.widget-hslider {
+.widget-hbox-single.widget-slider .slider-container {
     /* Horizontal jQuery Slider 
 
     Both the horizontal and vertical versions of the slider are characterized
@@ -149,19 +149,19 @@
     margin : 0px !important;
 }
 
-.widget-listbox {
+.widget-select .form-control {
     /* Listbox */
     width         : 350px;
     margin-bottom : 0px;
 }
 
-.widget-numeric-text {
+.widget-numeric-text input {
     /* Single Line Textbox - used for IntTextView and FloatTextView */
     width : 150px;
     margin : 0px !important;
 }
 
-.widget-progress {
+.widget-progress .progress {
     /* Progress Bar */
     margin-top: 6px;
     width : 350px;
@@ -176,23 +176,33 @@
     }
 }
 
-.widget-combo-btn {
+.widget-dropdown .dropdown-label {
     /* ComboBox Main Button */
     min-width : 125px;
 }
 
-.widget_item .dropdown-menu li a {
-    color: inherit;
+.widget-box {
+    /* The following section sets the style for the invisible div that
+    hold widgets and their accompanying labels.
+
+    Looks like this:
+    +-----------------------------+
+    | widget-box (or similar)     |
+    |  +-------+---------------+  |
+    |  | Label | Actual Widget |  |
+    |  +-------+---------------+  |
+    +-----------------------------+
+    */
+    margin : 5px;
+
+    .start();
+    .widget-container();
 }
 
 .widget-hbox {
     /* Horizontal widgets */
+    .widget-box();
     .hbox();
-    margin: 5px;
-
-    input[type="checkbox"] {
-        margin-top: 9px;
-    }
 
     .widget-label {
         /* Horizontal Label */
@@ -209,19 +219,23 @@
         text-align     : left;
         vertical-align : text-top;
     }
+
+    input[type="checkbox"] {
+        margin-top: 9px;
+    }
 }
 
 .widget-vbox {
     /* Vertical widgets */ 
+    .widget-box();
     .vbox();
-
 
     .widget-label {
         /* Vertical Label */
         padding-bottom : 5px;
         text-align     : center;
         vertical-align : text-bottom;
-    }
+}
 
     .widget-readout {
         /* Vertical Label */
@@ -229,11 +243,10 @@
         text-align     : center;
         vertical-align : text-top;
     }
-
 }
 
-.widget-modal {
-    /* Box - ModalView */   
+.widget-popup .modal-content {
+    /* ContainerWidget - PopupView */   
     overflow    : hidden; 
     position    : absolute !important;
     top         : 0px; 
@@ -241,18 +254,28 @@
     margin-left : 0px !important;
 }
 
-.widget-modal-body {
-    /* Box - ModalView Body */
+    .modal-body {
+        /* ContainerWidget - PopupView Body */
     max-height: none !important;
+    }
 }
 
-.widget-box {
-    /* Box */
+.widget-popup-docked {
+    /* Horizontal Label */
+    overflow: hidden; 
+    position: relative !important;
+    top: 0px !important; 
+    left: 0px !important; 
+    margin-left: 0px !important;
+}
+
+.widget-container {
+    /* ContainerWidget */
     .border-box-sizing();
     .align-start();
 }
 
-.widget-radio-box {
+.widget-radio :not(.widget-label) {
     /* Contains RadioButtonsWidget */
     .vbox();
     .border-box-sizing();

--- a/IPython/html/static/widgets/less/widgets.less
+++ b/IPython/html/static/widgets/less/widgets.less
@@ -182,28 +182,14 @@
     min-width : 125px;
 }
 
-.widget-box {
-    /* The following section sets the style for the invisible div that
-    hold widgets and their accompanying labels.
-
-    Looks like this:
-    +-----------------------------+
-    | widget-box (or similar)     |
-    |  +-------+---------------+  |
-    |  | Label | Actual Widget |  |
-    |  +-------+---------------+  |
-    +-----------------------------+
-    */
-    margin : 5px;
-
-    .start();
-    .widget-container();
-}
-
 .widget-hbox {
     /* Horizontal widgets */
-    .widget-box();
     .hbox();
+    margin : 5px;
+
+    input[type="checkbox"] {
+        margin-top: 9px;
+    }
 
     .widget-label {
         /* Horizontal Label */
@@ -220,15 +206,10 @@
         text-align     : left;
         vertical-align : text-top;
     }
-
-    input[type="checkbox"] {
-        margin-top: 9px;
-    }
 }
 
 .widget-vbox {
     /* Vertical widgets */ 
-    .widget-box();
     .vbox();
 
     .widget-label {
@@ -247,7 +228,7 @@
 }
 
 .widget-popup .modal-content {
-    /* ContainerWidget - PopupView */   
+    /* PopupView */   
     overflow    : hidden; 
     position    : absolute !important;
     top         : 0px; 
@@ -255,7 +236,7 @@
     margin-left : 0px !important;
 
     .modal-body {
-        /* ContainerWidget - PopupView Body */
+        /* PopupView Body */
         max-height: none !important;
     }
 }
@@ -267,12 +248,6 @@
     top: 0px !important; 
     left: 0px !important; 
     margin-left: 0px !important;
-}
-
-.widget-container {
-    /* ContainerWidget */
-    .border-box-sizing();
-    .align-start();
 }
 
 .widget-radio :not(.widget-label) {

--- a/IPython/html/static/widgets/less/widgets.less
+++ b/IPython/html/static/widgets/less/widgets.less
@@ -143,7 +143,8 @@
     }
 }
 
-.widget-text {
+.widget-text input, 
+.widget-textarea textarea {
     /* String Textbox - used for TextBoxView and TextAreaView */
     width         : 350px;
     margin : 0px !important;

--- a/IPython/html/tests/widgets/widget_selection.js
+++ b/IPython/html/tests/widgets/widget_selection.js
@@ -8,7 +8,7 @@ casper.notebook_test(function () {
 
     var combo_selector = '.widget-area .widget-subarea .widget-hbox .btn-group .widget-combo-btn';
     var multibtn_selector = '.widget-area .widget-subarea .widget-hbox .btn-group[data-toggle="buttons-radio"]';
-    var radio_selector = '.widget-area .widget-subarea .widget-hbox .widget-radio-box';
+    var radio_selector = '.widget-area .widget-subarea .widget-vbox .widget-radio-box';
     var list_selector = '.widget-area .widget-subarea .widget-hbox .widget-listbox';
 
     var selection_index;


### PR DESCRIPTION
Supersedes #6256

This makes it much easier to customize all widgets of a certain type using
CSS.  For example, to change just the IPython widget selects, a CSS
rule like .widget-select select {...} should work well.
