### PR TITLE
load the per kernel custom.js

### DIFF
--- a/IPython/html/static/notebook/js/kernelselector.js
+++ b/IPython/html/static/notebook/js/kernelselector.js
@@ -21,6 +21,7 @@ define([
         this.bind_events();
         // Make the object globally available for user convenience & inspection
         IPython.kernelselector = this;
+        Object.seal(this);
     };
     
     KernelSelector.prototype.request_kernelspecs = function() {
@@ -50,10 +51,34 @@ define([
     };
 
     KernelSelector.prototype.change_kernel = function(kernel_name) {
+        /**
+         * TODO, have a methods to set kernel spec directly ?
+         **/
+        var that = this;
         if (kernel_name === this.current_selection) {
             return;
         }
         var ks = this.kernelspecs[kernel_name];
+        var new_mod = 'kernelspecs/'+ks.name+'/custom';
+        var old_mod;
+        if(this.current_selection){
+            old_mod = 'kernelspecs/'+this.current_selection+'/custom';
+        }
+
+        var css_url = this.notebook.base_url+new_mod+'.css';
+        console.warn();
+        $.ajax({
+            type: 'HEAD',
+            url: css_url,
+            success: function(){
+                $('#kernel-css')
+                .attr('href',css_url);
+            },
+            error:function(){
+                console.warn('Having a 404 on the following url is normal:',css_url );
+            }
+        });
+
         try {
             this.notebook.start_session(kernel_name);
         } catch (e) {
@@ -67,6 +92,39 @@ define([
             return;
         }
         this.events.trigger('spec_changed.Kernel', ks);
+
+        // we need a handle on both the old and new kernel 
+        // the old one might want to undo some things
+        // set up the callback that will be trigger once 
+        // the new mode is loaded, ie patch. 
+        var require_new_mode_and_patch = function(){
+            require([new_mod], 
+                // if new mode has custom.js
+                function(new_mode){
+                    if(new_mode.patch){new_mode.patch();}
+                }, function(err){
+                    // if new mode does not have custom.js
+                    console.warn('Any above 404 on ',new_mod+'.js is normal');
+                }
+        );};
+
+        // finally require the 'old/current' mode, 
+        // - call its unpatch method if it exist.
+        // - after call newmode.patch
+        if(!old_mod){
+            require_new_mode_and_patch();
+        } else {
+            require([old_mod], 
+                    function(old_mode){
+                        console.warn(old_mod, new_mod);
+                        if(old_mode.unpatch){ old_mode.unpatch();}
+                        require_new_mode_and_patch();
+                    }, function(err){
+                        require_new_mode_and_patch();
+                    }
+
+             );
+        }
     };
     
     KernelSelector.prototype.bind_events = function() {

--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -98,6 +98,7 @@ require([
     notification_area.init_notification_widgets();
     var kernel_selector = new kernelselector.KernelSelector(
         '#kernel_selector_widget', notebook);
+    notebook.set_kernelselector(kernel_selector);
 
     $('body').append('<div id="fonttest"><pre><span id="test1">x</span>'+
                      '<span id="test2" style="font-weight: bold;">x</span>'+

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1808,7 +1808,14 @@ define([
         // Trigger an event changing the kernel spec - this will set the default
         // codemirror mode
         if (this.metadata.kernelspec !== undefined) {
-            this.events.trigger('spec_changed.Kernel', this.metadata.kernelspec);
+            // TODO shoudl probably not trigger here, 
+            // should call the kernel selector, or custom.{js|css} not loaded.
+            if(this.kernel_selector){
+                // technically not perfect, we should check that the kernelspec matches
+                this.kernel_selector.change_kernel(this.metadata.kernelspec.name);
+            } else {
+                console.log('do not have handle on kernnel_selector');
+            }
         }
         
         // Only handle 1 worksheet for now.
@@ -2392,6 +2399,10 @@ define([
         // now that we're fully loaded, it is safe to restore save functionality
         delete(this.save_notebook);
         this.events.trigger('notebook_loaded.Notebook');
+    };
+
+    Notebook.prototype.set_kernelselector = function(k_selector){
+        this.kernel_selector = k_selector;
     };
 
     /**

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -17,6 +17,7 @@ window.mathjax_url = "{{mathjax_url}}";
 {{super()}}
 
 <link rel="stylesheet" href="{{ static_url("notebook/css/override.css") }}" type="text/css" />
+<link rel="stylesheet" href=""  id='kernel-css'                             type="text/css" />
 
 {% endblock %}
 

--- a/IPython/html/templates/page.html
+++ b/IPython/html/templates/page.html
@@ -20,6 +20,7 @@
           baseUrl: '{{static_url("", include_version=False)}}',
           paths: {
             nbextensions : '{{ base_url }}nbextensions',
+            kernelspecs : '{{ base_url }}kernelspecs',
             underscore : 'components/underscore/underscore-min',
             backbone : 'components/backbone/backbone-min',
             jquery: 'components/jquery/jquery.min',


### PR DESCRIPTION
Work in progress. 

Try to load the custom.js from kernel spec when switching kernels in the notebook.
Does not do it at load time as IIUC, @takluyver implementation load the kernelspec directly from metadata.
which would need a bit more refactor. 

from a design point of view the per kernel custom.js **may** define 2 methods `patch` and `unpatch` that are respectively called when switching to/away from the kernel. 

The arguments the `patch` function takes is still to be defined. 
I'm leaning toward having the first argument of `unpatch` being something returned by `patch`. 
Indeed as module are dynamically loaded by require it is hard to have a stateful object returned by require.

I would them propose something along the following.

`patch` get as arguments the current version of IPython as well as a handle to instances of (.. notebook? IPython? to complete ..).
Handles to IPython javascript modules could be accessed by defining them as dependencies of your `custom.js`. The `patch` get called when the user decide to switch to your kernel, and can return an object that will be passed to `unpatch` method

`custom.js` should also define an `unpatch`method that takes as first argument the object returned by `patch` and is responsible to restore any modification done by `patch`.

this would lead to custom.js looking like : 

```
define(['base/js/tooltip'],{
    patch: function(){
        console.log('patch from bash');
        var param = {tooltip_orig_foo:Tooltip.foo}
        Tooltip.foo = 'xzt'
        return param
    },
    unpatch: function(orig){
       console.log('unpatch from bash')
       Tooltip.foo = orig.tooltip_orig_foo
    }
});
```
