### PR TITLE
Better support for wrapped function signatures in help

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -40,6 +40,7 @@ from IPython.utils.text import indent
 from IPython.utils.wildcard import list_namespace
 from IPython.utils.coloransi import TermColors, ColorScheme, ColorSchemeTable
 from IPython.utils.py3compat import cast_unicode, string_types, PY3
+from IPython.utils.signatures import signature
 
 # builtin docstrings to ignore
 _func_call_docstring = types.FunctionType.__call__.__doc__
@@ -390,7 +391,7 @@ class Inspector:
         If any exception is generated, None is returned instead and the
         exception is suppressed."""
         try:
-            hdef = oname + inspect.formatargspec(*getargspec(obj))
+            hdef = oname + str(signature(obj))
             return cast_unicode(hdef)
         except:
             return None


### PR DESCRIPTION
In Python 3.2 `functools.wraps` introduced adding a `__wrapped__` attribute to wrapper functions that explicitly references the original function being wrapped.  The standard module introspection tools, in turn, know how to handle this `__wrapped__` attribute.  For example, the `help()` built-in uses it to display the call signature of the wrapped function, rather than the _wrapper_ function, which is usually more useful.

The recently (for use by widgets) introduced `IPython.utils.signatures` module handles this all properly too.  But that code isn't used in the `oinspect` module which is used to implement the `?` and `??` magics.

There seems to be a lot of other dead and/or dying code in the `oinspect` module, but for starters this patch at least produces more helpful call signature documentation for functions that have been decorated with `functools.wraps`.  

This came up originally in the context of astropy/astropy#2849

closes #3678
