### PR TITLE
Strip the IPY_MODEL_ prefix from widget IDs before referencing them.

### DIFF
--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -360,7 +360,7 @@ class Widget(LoggingConfigurable):
         elif isinstance(x, string_types) and x.startswith('IPY_MODEL_') and x[10:] in Widget.widgets:
             # we want to support having child widgets at any level in a hierarchy
             # trusting that a widget UUID will not appear out in the wild
-            return Widget.widgets[x]
+            return Widget.widgets[x[10:]]
         else:
             return x
 


### PR DESCRIPTION
This was a silly error, probably due to me.
