### PR TITLE
better underscore completion

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -718,7 +718,7 @@ class IPCompleter(Completer):
                     else:
                         # true if txt is _not_ a _ name, false otherwise:
                         no__name = (lambda txt:
-                                    re.match(r'.*\._.*?',txt[txt.rindex('.'):]) is None)
+                                    re.match(r'\._.*?',txt[txt.rindex('.'):]) is None)
                     matches = filter(no__name, matches)
             except NameError:
                 # catches <undefined attributes>.<tab>

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -46,25 +46,8 @@ Notes:
   used, and this module (and the readline module) are silently inactive.
 """
 
-#*****************************************************************************
-#
-# Since this file is essentially a minimally modified copy of the rlcompleter
-# module which is part of the standard Python distribution, I assume that the
-# proper procedure is to maintain its copyright as belonging to the Python
-# Software Foundation (in addition to my own, for all new code).
-#
-#       Copyright (C) 2008 IPython Development Team
-#       Copyright (C) 2001 Fernando Perez. <fperez@colorado.edu>
-#       Copyright (C) 2001 Python Software Foundation, www.python.org
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#
-#*****************************************************************************
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 import __main__
 import glob
@@ -735,7 +718,7 @@ class IPCompleter(Completer):
                     else:
                         # true if txt is _not_ a _ name, false otherwise:
                         no__name = (lambda txt:
-                                    re.match(r'.*\._.*?',txt) is None)
+                                    re.match(r'.*\._.*?',txt[txt.rindex('.'):]) is None)
                     matches = filter(no__name, matches)
             except NameError:
                 # catches <undefined attributes>.<tab>

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -48,6 +48,9 @@ Notes:
 
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
+#
+# Some of this code originated from rlcompleter in the Python standard library
+# Copyright (C) 2001 Python Software Foundation, www.python.org
 
 import __main__
 import glob

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -222,6 +222,7 @@ def test_omit__names():
     # also happens to test IPCompleter as a configurable
     ip = get_ipython()
     ip._hidden_attr = 1
+    ip._x = {}
     c = ip.Completer
     ip.ex('ip=get_ipython()')
     cfg = Config()
@@ -240,6 +241,8 @@ def test_omit__names():
     s,matches = c.complete('ip.')
     nt.assert_not_in('ip.__str__', matches)
     nt.assert_not_in('ip._hidden_attr', matches)
+    s,matches = c.complete('ip._x.')
+    nt.assert_in('ip._x.keys', matches)
     del ip._hidden_attr
 
 


### PR DESCRIPTION
While poking around matplotlib today, I noticed that IPython doesn't complete on attributes that start with an underscore.

Simplest example to reproduce this behavior on master:

``` python
class A(object):
    pass
a = A()
a._x = {}
```

`a._x.<tab>` doesn't return anything on master. This PR adds the necessary changes to make this work and also adds a test for it.
