### PR TITLE
catch any exception while waiting for server to start

### DIFF
--- a/IPython/html/tests/launchnotebook.py
+++ b/IPython/html/tests/launchnotebook.py
@@ -37,7 +37,7 @@ class NotebookTestBase(TestCase):
         for _ in range(int(MAX_WAITTIME/POLL_INTERVAL)):
             try:
                 requests.get(url)
-            except requests.exceptions.ConnectionError:
+            except Exception as e:
                 if cls.notebook.poll() is not None:
                     raise RuntimeError("The notebook server exited with status %s" \
                                         % cls.notebook.poll())


### PR DESCRIPTION
in html tests.

requests 2.4 changed the exception type for a failed connection, causing recent test failures.

ping @takluyver who pinged me about the failures on the test bots.
