### PR TITLE
show traceback for broken reprs

### DIFF
--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -2,25 +2,11 @@
 """Displayhook for IPython.
 
 This defines a callable class that IPython uses for `sys.displayhook`.
-
-Authors:
-
-* Fernando Perez
-* Brian Granger
-* Robert Kern
 """
 
-#-----------------------------------------------------------------------------
-#       Copyright (C) 2008-2011 The IPython Development Team
-#       Copyright (C) 2001-2007 Fernando Perez <fperez@colorado.edu>
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
 from __future__ import print_function
 
 import sys
@@ -31,10 +17,6 @@ from IPython.utils import io
 from IPython.utils.py3compat import builtin_mod
 from IPython.utils.traitlets import Instance
 from IPython.utils.warn import warn
-
-#-----------------------------------------------------------------------------
-# Main displayhook class
-#-----------------------------------------------------------------------------
 
 # TODO: Move the various attributes (cache_size, [others now moved]). Some
 # of these are also attributes of InteractiveShell. They should be on ONE object
@@ -168,6 +150,9 @@ class DisplayHook(Configurable):
         md_dict : dict (optional)
             The metadata dict to be associated with the display data.
         """
+        if 'text/plain' not in format_dict:
+            # nothing to do
+            return
         # We want to print because we want to always make sure we have a
         # newline, even if all the prompt separators are ''. This is the
         # standard IPython behavior.
@@ -221,6 +206,9 @@ class DisplayHook(Configurable):
 
     def log_output(self, format_dict):
         """Log the output."""
+        if 'text/plain' not in format_dict:
+            # nothing to do
+            return
         if self.shell.logger.log_output:
             self.shell.logger.log_write(format_dict['text/plain'], 'output')
         self.shell.history_manager.output_hist_reprs[self.prompt_count] = \

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -5,25 +5,11 @@ Inheritance diagram:
 
 .. inheritance-diagram:: IPython.core.formatters
    :parts: 3
-
-Authors:
-
-* Robert Kern
-* Brian Granger
 """
-#-----------------------------------------------------------------------------
-# Copyright (C) 2010-2011, IPython Development Team.
-#
+
+# Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
-
-# Stdlib imports
 import abc
 import inspect
 import sys
@@ -32,8 +18,8 @@ import warnings
 
 from IPython.external.decorator import decorator
 
-# Our own imports
 from IPython.config.configurable import Configurable
+from IPython.core.getipython import get_ipython
 from IPython.lib import pretty
 from IPython.utils.traitlets import (
     Bool, Dict, Integer, Unicode, CUnicode, ObjectName, List,
@@ -223,6 +209,18 @@ class DisplayFormatter(Configurable):
 # Formatters for specific format types (text, html, svg, etc.)
 #-----------------------------------------------------------------------------
 
+
+def _safe_repr(obj):
+    """Try to return a repr of an object
+
+    always returns a string, at least.
+    """
+    try:
+        return repr(obj)
+    except Exception as e:
+        return "un-repr-able object (%r)" % e
+
+
 class FormatterWarning(UserWarning):
     """Warning class for errors in formatters"""
 
@@ -234,10 +232,13 @@ def warn_format_error(method, self, *args, **kwargs):
     except NotImplementedError as e:
         # don't warn on NotImplementedErrors
         return None
-    except Exception as e:
-        warnings.warn("Exception in %s formatter: %s" % (self.format_type, e),
-            FormatterWarning,
-        )
+    except Exception:
+        exc_info = sys.exc_info()
+        ip = get_ipython()
+        if ip is not None:
+            ip.showtraceback(exc_info)
+        else:
+            traceback.print_exception(*exc_info)
         return None
     if r is None or isinstance(r, self._return_type) or \
         (isinstance(r, tuple) and r and isinstance(r[0], self._return_type)):
@@ -245,7 +246,7 @@ def warn_format_error(method, self, *args, **kwargs):
     else:
         warnings.warn(
             "%s formatter returned invalid type %s (expected %s) for object: %s" % \
-            (self.format_type, type(r), self._return_type, pretty._safe_repr(args[0])),
+            (self.format_type, type(r), self._return_type, _safe_repr(args[0])),
             FormatterWarning
         )
 
@@ -672,7 +673,7 @@ class PlainTextFormatter(BaseFormatter):
     def __call__(self, obj):
         """Compute the pretty representation of the object."""
         if not self.pprint:
-            return pretty._safe_repr(obj)
+            return repr(obj)
         else:
             # This uses use StringIO, as cStringIO doesn't handle unicode.
             stream = StringIO()

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -125,49 +125,6 @@ __all__ = ['pretty', 'pprint', 'PrettyPrinter', 'RepresentationPrinter',
 
 _re_pattern_type = type(re.compile(''))
 
-def _failed_repr(obj, e):
-    """Render a failed repr, including the exception.
-    
-    Tries to get exception and type info
-    """
-    # get exception name
-    if e.__class__.__module__ in ('exceptions', 'builtins'):
-        ename = e.__class__.__name__
-    else:
-        ename = '{}.{}'.format(
-            e.__class__.__module__,
-            e.__class__.__name__,
-        )
-    # and exception string, which sometimes fails
-    # (usually due to unicode error message)
-    try:
-        estr = str(e)
-    except Exception:
-        estr = "unknown"
-    
-    # and class name
-    try:
-        klass = _safe_getattr(obj, '__class__', None) or type(obj)
-        mod = _safe_getattr(klass, '__module__', None)
-        if mod in (None, '__builtin__', 'builtins', 'exceptions'):
-            classname = klass.__name__
-        else:
-            classname = mod + '.' + klass.__name__
-    except Exception:
-        # this may be paranoid, but we already know repr is broken
-        classname = "unknown type"
-    
-    # the informative repr
-    return "<repr(<{} at 0x{:x}>) failed: {}: {}>".format(
-        classname, id(obj), ename, estr,
-    )
-
-def _safe_repr(obj):
-    """Don't assume repr is not broken."""
-    try:
-        return repr(obj)
-    except Exception as e:
-        return _failed_repr(obj, e)
 
 def _safe_getattr(obj, attr, default=None):
     """Safe version of getattr.
@@ -560,7 +517,7 @@ def _default_pprint(obj, p, cycle):
     klass = _safe_getattr(obj, '__class__', None) or type(obj)
     if _safe_getattr(klass, '__repr__', None) not in _baseclass_reprs:
         # A user-provided repr. Find newlines and replace them with p.break_()
-        output = _safe_repr(obj)
+        output = repr(obj)
         for idx,output_line in enumerate(output.splitlines()):
             if idx:
                 p.break_()
@@ -736,7 +693,7 @@ def _type_pprint(obj, p, cycle):
 
 def _repr_pprint(obj, p, cycle):
     """A pprint that just redirects to the normal repr function."""
-    p.text(_safe_repr(obj))
+    p.text(repr(obj))
 
 
 def _function_pprint(obj, p, cycle):

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -1,16 +1,8 @@
-"""Tests for IPython.lib.pretty.
-"""
-#-----------------------------------------------------------------------------
-# Copyright (c) 2011, the IPython Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
+"""Tests for IPython.lib.pretty."""
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 from __future__ import print_function
 
 # Third-party imports
@@ -20,9 +12,6 @@ import nose.tools as nt
 from IPython.lib import pretty
 from IPython.testing.decorators import skip_without
 
-#-----------------------------------------------------------------------------
-# Classes and functions
-#-----------------------------------------------------------------------------
 
 class MyList(object):
     def __init__(self, content):
@@ -161,11 +150,9 @@ def test_pprint_break_repr():
     nt.assert_equal(output, expected)
 
 def test_bad_repr():
-    """Don't raise, even when repr fails"""
-    output = pretty.pretty(BadRepr())
-    nt.assert_in("failed", output)
-    nt.assert_in("at 0x", output)
-    nt.assert_in("test_pretty", output)
+    """Don't catch bad repr errors"""
+    with nt.assert_raises(ZeroDivisionError):
+        output = pretty.pretty(BadRepr())
 
 class BadException(Exception):
     def __str__(self):
@@ -181,10 +168,8 @@ class ReallyBadRepr(object):
         raise BadException()
 
 def test_really_bad_repr():
-    output = pretty.pretty(ReallyBadRepr())
-    nt.assert_in("failed", output)
-    nt.assert_in("BadException: unknown", output)
-    nt.assert_in("unknown type", output)
+    with nt.assert_raises(BadException):
+        output = pretty.pretty(ReallyBadRepr())
 
 
 class SA(object):


### PR DESCRIPTION
instead of short custom 'repr failed' message

and add file arg to showtraceback, allowing capture of rendered tracebacks.

closes #6384

Before:

``` python
In [1]: class Foo(object):
   ...:     def __repr__(self):
   ...:         raise Exception()
   ...:     

In [2]: Foo()
Out[2]: <repr(<__main__.Foo at 0x7f50f6bb69d0>) failed: Exception: oops>
```

After:

``` python
In [3]: class Foo(object):
   ...:     def __repr__(self):
   ...:         raise Exception('oops')
   ...:     

In [4]: Foo()
Out[4]: 
---------------------------------------------------------------------------
Exception                                 Traceback (most recent call last)
<ipython-input-3-e87811d6aa00> in __repr__(self)
      1 class Foo(object):
      2     def __repr__(self):
----> 3         raise Exception('oops')
      4 

Exception: oops
```

Note that the exception is still caught, it is just rendered as if it raised normally.
