### PR TITLE
make default cell type configurable

### DIFF
--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -514,6 +514,12 @@ define([
         }
     };
     
+    var mergeopt = function(_class, options, overwrite){
+        options = options || {};
+        overwrite = overwrite || {};
+        return $.extend(true, {}, _class.options_default, options, overwrite);
+    };
+    
     var ajax_error_msg = function (jqXHR) {
         // Return a JSON error message if there is one,
         // otherwise the basic HTTP status text.
@@ -552,6 +558,7 @@ define([
         platform: platform,
         is_or_has : is_or_has,
         is_focused : is_focused,
+        mergeopt: mergeopt,
         ajax_error_msg : ajax_error_msg,
         log_ajax_error : log_ajax_error,
     };

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -42,7 +42,7 @@ define([
         options = options || {};
         this.keyboard_manager = options.keyboard_manager;
         this.events = options.events;
-        var config = this.mergeopt(Cell, options.config);
+        var config = utils.mergeopt(Cell, options.config);
         // superclass default overwrite our default
         
         this.placeholder = config.placeholder || '';
@@ -93,12 +93,6 @@ define([
     if (utils.browser[0] == "Safari") {
         Cell.options_default.cm_config.dragDrop = false;
     }
-
-    Cell.prototype.mergeopt = function(_class, options, overwrite){
-        options = options || {};
-        overwrite = overwrite || {};
-        return $.extend(true, {}, _class.options_default, options, overwrite);
-    };
 
     /**
      * Empty. Subclasses must implement create_element.

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -76,7 +76,7 @@ define([
             onKeyEvent: $.proxy(this.handle_keyevent,this)
         };
 
-        var config = this.mergeopt(CodeCell, this.config, {cm_config: cm_overwrite_options});
+        var config = utils.mergeopt(CodeCell, this.config, {cm_config: cm_overwrite_options});
         Cell.apply(this,[{
             config: config, 
             keyboard_manager: options.keyboard_manager, 

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -3,13 +3,14 @@
 
 define([
     'base/js/namespace',
+    'base/js/utils',
     'jquery',
     'notebook/js/cell',
     'base/js/security',
     'notebook/js/mathjaxutils',
     'notebook/js/celltoolbar',
     'components/marked/lib/marked',
-], function(IPython, $, cell, security, mathjaxutils, celltoolbar, marked) {
+], function(IPython, utils, $, cell, security, mathjaxutils, celltoolbar, marked) {
     "use strict";
     var Cell = cell.Cell;
 
@@ -40,7 +41,7 @@ define([
         var cm_overwrite_options  = {
             onKeyEvent: $.proxy(this.handle_keyevent,this)
         };
-        var config = this.mergeopt(TextCell, this.config, {cm_config:cm_overwrite_options});
+        var config = utils.mergeopt(TextCell, this.config, {cm_config:cm_overwrite_options});
         Cell.apply(this, [{
                     config: config, 
                     keyboard_manager: options.keyboard_manager, 
@@ -230,7 +231,7 @@ define([
         //          keyboard_manager: KeyboardManager instance 
         //          notebook: Notebook instance
         options = options || {};
-        var config = this.mergeopt(MarkdownCell, options.config);
+        var config = utils.mergeopt(MarkdownCell, options.config);
         TextCell.apply(this, [$.extend({}, options, {config: config})]);
 
         this.cell_type = 'markdown';
@@ -283,7 +284,7 @@ define([
         //          keyboard_manager: KeyboardManager instance 
         //          notebook: Notebook instance
         options = options || {};
-        var config = this.mergeopt(RawCell, options.config);
+        var config = utils.mergeopt(RawCell, options.config);
         TextCell.apply(this, [$.extend({}, options, {config: config})]);
 
         // RawCell should always hide its rendered div
@@ -343,7 +344,7 @@ define([
         //          keyboard_manager: KeyboardManager instance 
         //          notebook: Notebook instance
         options = options || {};
-        var config = this.mergeopt(HeadingCell, options.config);
+        var config = utils.mergeopt(HeadingCell, options.config);
         TextCell.apply(this, [$.extend({}, options, {config: config})]);
 
         this.level = 1;

--- a/IPython/html/tests/notebook/dualmode_cellinsert.js
+++ b/IPython/html/tests/notebook/dualmode_cellinsert.js
@@ -12,31 +12,66 @@ casper.notebook_test(function () {
     var c = 'print("c")';
     index = this.append_cell(c);
     this.execute_cell_then(index);
-
+    
+    this.thenEvaluate(function() {
+        IPython.notebook.default_cell_type = 'code';
+    });
+    
     this.then(function () {
         // Cell insertion
         this.select_cell(2);
+        this.trigger_keydown('m'); // Make it markdown
         this.trigger_keydown('a'); // Creates one cell
         this.test.assertEquals(this.get_cell_text(2), '', 'a; New cell 2 text is empty');
-        this.test.assertEquals(this.get_cell(2).cell_type, 'code', 'a; inserts a code cell when on code cell');
+        this.test.assertEquals(this.get_cell(2).cell_type, 'code', 'a; inserts a code cell');
         this.validate_notebook_state('a', 'command', 2);
         this.trigger_keydown('b'); // Creates one cell
         this.test.assertEquals(this.get_cell_text(2), '', 'b; Cell 2 text is still empty');
         this.test.assertEquals(this.get_cell_text(3), '', 'b; New cell 3 text is empty');
-        this.test.assertEquals(this.get_cell(3).cell_type, 'code', 'b; inserts a code cell when on code cell');
+        this.test.assertEquals(this.get_cell(3).cell_type, 'code', 'b; inserts a code cell');
         this.validate_notebook_state('b', 'command', 3);
     });
+    
+    this.thenEvaluate(function() {
+        IPython.notebook.default_cell_type = 'selected';
+    });
+    
     this.then(function () {
-        // Cell insertion
         this.select_cell(2);
         this.trigger_keydown('m'); // switch it to markdown for the next test
-        this.trigger_keydown('a'); // Creates one cell
-        this.test.assertEquals(this.get_cell_text(2), '', 'a; New cell 2 text is empty');
-        this.test.assertEquals(this.get_cell(2).cell_type, 'markdown', 'a; inserts a markdown cell when on markdown cell');
-        this.validate_notebook_state('a', 'command', 2);
-        this.trigger_keydown('b'); // Creates one cell
-        this.test.assertEquals(this.get_cell_text(2), '', 'b; Cell 2 text is still empty');
-        this.test.assertEquals(this.get_cell(3).cell_type, 'markdown', 'b; inserts a markdown cell when on markdown cell');
-        this.validate_notebook_state('b', 'command', 3);
+        this.test.assertEquals(this.get_cell(2).cell_type, 'markdown', 'test cell is markdown');
+        this.trigger_keydown('a'); // new cell above
+        this.test.assertEquals(this.get_cell(2).cell_type, 'markdown', 'a; inserts a markdown cell when markdown selected');
+        this.trigger_keydown('b'); // new cell below
+        this.test.assertEquals(this.get_cell(3).cell_type, 'markdown', 'b; inserts a markdown cell when markdown selected');
+    });
+    
+    this.thenEvaluate(function() {
+        IPython.notebook.default_cell_type = 'above';
+    });
+    
+    this.then(function () {
+        this.select_cell(2);
+        this.trigger_keydown('1'); // switch it to heading for the next test
+        this.test.assertEquals(this.get_cell(2).cell_type, 'heading', 'test cell is heading');
+        this.trigger_keydown('b'); // new cell below
+        this.test.assertEquals(this.get_cell(3).cell_type, 'heading', 'b; inserts a heading cell below heading cell');
+        this.trigger_keydown('a'); // new cell above
+        this.test.assertEquals(this.get_cell(3).cell_type, 'heading', 'a; inserts a heading cell below heading cell');
+    });
+    
+    this.thenEvaluate(function() {
+        IPython.notebook.default_cell_type = 'below';
+    });
+    
+    this.then(function () {
+        this.select_cell(2);
+        this.trigger_keydown('r'); // switch it to markdown for the next test
+        this.test.assertEquals(this.get_cell(2).cell_type, 'raw', 'test cell is raw');
+        this.trigger_keydown('a'); // new cell above
+        this.test.assertEquals(this.get_cell(2).cell_type, 'raw', 'a; inserts a raw cell above raw cell');
+        this.trigger_keydown('y'); // switch it to code for the next test
+        this.trigger_keydown('b'); // new cell below
+        this.test.assertEquals(this.get_cell(3).cell_type, 'raw', 'b; inserts a raw cell above raw cell');
     });
 });


### PR DESCRIPTION
and change the default behavior back to 2.x behavior of always 'code' (for @ellsonbg).
- adds `IPython.notebook.default_cell_type`
- default is 'code' (matching IPython 2.0)
- special heuristic values include:
  - 'selected': default to selected cell (current master behavior)
  - 'above': default to cell above
  - 'below': default to cell below

To change the value in custom.js:

``` javascript
$([IPython.events]).on("notebook_loaded.Notebook", function () {
    IPython.notebook.default_cell_type = 'selected';
    // or 'markdown' or 'above' or 'below', etc.
});
```
