### PR TITLE
Fixes mathjax cdn link so latex images load

### DIFF
--- a/IPython/nbconvert/templates/html/mathjax.tpl
+++ b/IPython/nbconvert/templates/html/mathjax.tpl
@@ -1,6 +1,6 @@
 {%- macro mathjax() -%}
     <!-- Load mathjax -->
-    <script src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
+    <script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <!-- MathJax configuration -->
     <script type="text/x-mathjax-config">
     MathJax.Hub.Config({


### PR DESCRIPTION
Updated the mathjax cdn link to the one given here, http://docs.mathjax.org/en/v1.1-latest/start.html#mathjax-cdn
Previous link gave a 404
