### PR TITLE
Sessions rest api fix

### DIFF
--- a/IPython/html/services/sessions/sessionmanager.py
+++ b/IPython/html/services/sessions/sessionmanager.py
@@ -188,7 +188,7 @@ class SessionManager(LoggingConfigurable):
     def row_to_model(self, row):
         """Takes sqlite database session row and turns it into a dictionary"""
         if row['kernel_id'] not in self.kernel_manager:
-            # The kernel was killed without deleting the session. Should never occur.
+            # The kernel was killed or died without deleting the session.
             self.delete_session(row['session_id'])
             raise KeyError
 

--- a/IPython/html/tests/launchnotebook.py
+++ b/IPython/html/tests/launchnotebook.py
@@ -95,7 +95,7 @@ def assert_http_error(status, msg=None):
     except requests.HTTPError as e:
         real_status = e.response.status_code
         assert real_status == status, \
-                    "Expected status %d, got %d" % (real_status, status)
+                    "Expected status %d, got %d" % (status, real_status)
         if msg:
             assert msg in str(e), e
     else:


### PR DESCRIPTION
This is an alternative to #6360, that I committed some time ago but apparently didn't make a PR for (sorry @minrk).

My fix gets rid of the row_factory, as it felt like too much complexity to push into the database API. Instead, it calls `row_to_model()` manually to build the model, and that can raise a KeyError if the session has a missing kernel.
