### PR TITLE
make the default url customizable

### DIFF
--- a/IPython/html/tree/handlers.py
+++ b/IPython/html/tree/handlers.py
@@ -80,5 +80,4 @@ default_handlers = [
     (r"/tree%s" % notebook_path_regex, TreeHandler),
     (r"/tree%s" % path_regex, TreeHandler),
     (r"/tree", TreeHandler),
-    (r"/?", TreeRedirectHandler),
     ]

--- a/IPython/html/tree/handlers.py
+++ b/IPython/html/tree/handlers.py
@@ -59,18 +59,6 @@ class TreeHandler(IPythonHandler):
             ))
 
 
-class TreeRedirectHandler(IPythonHandler):
-    """Redirect a request to the corresponding tree URL"""
-
-    @web.authenticated
-    def get(self, path=''):
-        url = url_escape(url_path_join(
-            self.base_url, 'tree', path.strip('/')
-        ))
-        self.log.debug("Redirecting %s to %s", self.request.path, url)
-        self.redirect(url)
-
-
 #-----------------------------------------------------------------------------
 # URL to handler mappings
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
this is the page redirected to from `/`, which defaults to `/tree`.

also changes the redirect code to 302 from 301, which should cause less grumbling about caching.

Prompted by design discussions in the multi-user server.
