### PR TITLE
Move md-cell display logic to css

### DIFF
--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -278,7 +278,6 @@ define([
         var config = this.mergeopt(RawCell, options.config);
         TextCell.apply(this, [$.extend({}, options, {config: config})]);
 
-        // RawCell should always hide its rendered div
         this.cell_type = 'raw';
     };
 

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -130,8 +130,6 @@ define([
         if (cont) {
             var text_cell = this.element;
             var output = text_cell.find("div.text_cell_render");
-            output.hide();
-            text_cell.find('div.input_area').show();
             if (this.get_text() === this.placeholder) {
                 this.set_text('');
             }
@@ -260,8 +258,6 @@ define([
             // links in markdown cells should open in new tabs
             html.find("a[href]").not('[href^="#"]').attr("target", "_blank");
             this.set_rendered(html);
-            this.element.find('div.input_area').hide();
-            this.element.find("div.text_cell_render").show();
             this.typeset();
         }
         return cont;
@@ -283,7 +279,6 @@ define([
         TextCell.apply(this, [$.extend({}, options, {config: config})]);
 
         // RawCell should always hide its rendered div
-        this.element.find('div.text_cell_render').hide();
         this.cell_type = 'raw';
     };
 
@@ -426,8 +421,6 @@ define([
                     .text('¶')
             );
             this.set_rendered(h);
-            this.element.find('div.input_area').hide();
-            this.element.find("div.text_cell_render").show();
             this.typeset();
         }
         return cont;

--- a/IPython/html/static/notebook/less/textcell.less
+++ b/IPython/html/static/notebook/less/textcell.less
@@ -36,6 +36,15 @@ div.cell.text_cell.rendered {
     padding: 0px;
 }
 
+
+.text_cell.rendered .input_area {
+    display: none;
+}
+
+.text_cell.unrendered .text_cell_render {
+    display:none;
+}
+
 .cm-s-heading-1,
 .cm-s-heading-2,
 .cm-s-heading-3,

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -1170,6 +1170,12 @@ h6:hover .anchor-link {
 div.cell.text_cell.rendered {
   padding: 0px;
 }
+.text_cell.rendered .input_area {
+  display: none;
+}
+.text_cell.unrendered .text_cell_render {
+  display: none;
+}
 .cm-s-heading-1,
 .cm-s-heading-2,
 .cm-s-heading-3,

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8942,6 +8942,12 @@ h6:hover .anchor-link {
 div.cell.text_cell.rendered {
   padding: 0px;
 }
+.text_cell.rendered .input_area {
+  display: none;
+}
+.text_cell.unrendered .text_cell_render {
+  display: none;
+}
 .cm-s-heading-1,
 .cm-s-heading-2,
 .cm-s-heading-3,


### PR DESCRIPTION
Which technically is less code, allow nice css extension (never hide md input) , 
and should allow to share more code between code and text cell later.
