### PR TITLE
Sort directory contents in test before assertion

### DIFF
--- a/IPython/html/services/contents/tests/test_manager.py
+++ b/IPython/html/services/contents/tests/test_manager.py
@@ -188,7 +188,7 @@ class TestContentsManager(TestCase):
         
         dir_model = cm.get_model(path)
         self.assertEqual(
-            dir_model['content'],
+            sorted(dir_model['content'], key=lambda x: x['name']),
             [symlink_model, file_model],
         )
     


### PR DESCRIPTION
Should fix recent test failures, but I can't replicate failure on my computer, so it's not clear that it's fixed.
