### PR TITLE
Dockerfile for the example notebooks.

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,0 +1,8 @@
+FROM ipython/scipyserver
+
+MAINTAINER IPython Project <ipython-dev@scipy.org>
+
+# Requirements for some of the Example notebooks
+RUN pip install scikit-image
+
+ADD . /notebooks/

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,5 +1,5 @@
 # 
-# This Docker container brings up an entire environment with (almost) all fo the dependencies required by the example notebooks.
+# This Docker container brings up an entire environment with (almost) all of the dependencies required by the example notebooks.
 # 
 # To use this directly, run
 #   docker run -p 8888:8888 ipython/examples

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -10,6 +10,7 @@ FROM ipython/scipyserver
 MAINTAINER IPython Project <ipython-dev@scipy.org>
 
 # Requirements for some of the Example notebooks
-RUN pip install scikit-image
+RUN apt-get build-dep -y mpi4py
+RUN pip install scikit-image vincent dill networkx mpi4py
 
 ADD . /notebooks/

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,3 +1,10 @@
+# 
+# This Docker container brings up an entire environment with (almost) all fo the dependencies required by the example notebooks.
+# 
+# To use this directly, run
+#   docker run -p 8888:8888 ipython/examples
+#
+
 FROM ipython/scipyserver
 
 MAINTAINER IPython Project <ipython-dev@scipy.org>

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,4 +1,4 @@
-![IPython Logo](images/ipython_logo.png)
+![IPython Logo](http://ipython.org/_static/IPy_header.png)
 
 This directory/container contains [IPython's notebook-based documentation](http://nbviewer.ipython.org/github/ipython/ipython/blob/master/examples/Index.ipynb). This augments our [Sphinx-based documentation](http://ipython.org/ipython-doc/stable/index.html) with notebooks that contain interactive tutorials and examples. Over time, more of our documentation will be pulled into this format.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,11 @@
+![IPython Logo](images/ipython_logo.png)
+
+This directory/container contains [IPython's notebook-based documentation](http://nbviewer.ipython.org/github/ipython/ipython/blob/master/examples/Index.ipynb). This augments our [Sphinx-based documentation](http://ipython.org/ipython-doc/stable/index.html) with notebooks that contain interactive tutorials and examples. Over time, more of our documentation will be pulled into this format.
+
+This set of notebooks is also available as a Docker image with Python dependencies so you can try out the example notebooks without installing each set of packages manually. It relies on the [ipython/scipyserver Docker image](https://registry.hub.docker.com/u/ipython/scipyserver/). To run, you'll need to [install and configure Docker](https://docs.docker.com/installation/) then:
+
+```
+docker run -e "PASSWORD=SetYourPassword" -p 9999:8888 ipython/examples
+```
+
+This will run the IPython Notebook server on port 9999 on the Docker host.


### PR DESCRIPTION
This adds a Dockerfile (to be auto-built by the Docker hub), so that someone can bring up an entire environment with (almost) all the dependencies required by the example notebooks. For now I've added
- scikit-image
- vincent
- dill
- networkx
- mpi4py

My plan here, if people like this idea, would be to have a Docker image named `ipython/examples`. Someone would then:

```
docker run -p 8888:8888 ipython/examples
```

To bring up this setup and explore the example notebooks.
