### PR TITLE
Markdown citations

### DIFF
--- a/IPython/nbconvert/filters/markdown.py
+++ b/IPython/nbconvert/filters/markdown.py
@@ -61,7 +61,7 @@ def markdown2latex(source):
     out : string
       Output as returned by pandoc.
     """
-    return pandoc(source, 'markdown', 'latex')
+    return pandoc(source, 'markdown', 'latex', ('--natbib',))
 
 
 @undoc

--- a/IPython/nbconvert/templates/latex/base.tplx
+++ b/IPython/nbconvert/templates/latex/base.tplx
@@ -31,6 +31,7 @@ This template does not define a docclass, the inheriting class must define this.
     \usepackage{hyperref}
     \usepackage{longtable} % longtable support required by pandoc >1.10
     \usepackage{booktabs}  % table support for pandoc > 1.12.2
+    \usepackage{natbib} % citations
     ((* endblock packages *))
 
     ((* block definitions *))


### PR DESCRIPTION
see http://johnmacfarlane.net/pandoc/README.html#citations

> Citations go inside square brackets and are separated by semicolons. Each
> citation must have a key, composed of ‘@’ + the citation identifier from
> the database, and may optionally have a prefix, a locator, and a suffix.
> The citation key must begin with a letter or _, and may contain
> alphanumerics, _, and internal punctuation characters (:.#$%&-+?<>~/).
> Here are some examples:
> 
> ```
> Blah blah [see @doe99, pp. 33-35; also @smith04, ch. 1].
> 
> Blah blah [@doe99, pp. 33-35, 38-39 and *passim*].
> 
> Blah blah [@smith04; @doe99].
> ```
> 
> A minus sign (-) before the @ will suppress mention of the author in the
> citation. This can be useful when the author is already mentioned in the
> text:
> 
> ```
> Smith says blah [-@smith04].
> ```
> 
> You can also write an in-text citation, as follows:
> 
> ```
> @smith04 says blah.
> 
> @smith04 [p. 33] says blah.
> ```
