### PR TITLE
Make it possible for AST transformers to reject input.

### DIFF
--- a/IPython/core/error.py
+++ b/IPython/core/error.py
@@ -51,3 +51,10 @@ class StdinNotImplementedError(IPythonCoreError, NotImplementedError):
     For use in IPython kernels, where only some frontends may support
     stdin requests.
     """
+
+class InputRejected(Exception):
+    """Input rejected by ast transformer.
+
+    Raise this in your NodeTransformer to indicate that InteractiveShell should
+    not execute the supplied input.
+    """

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -41,7 +41,7 @@ from IPython.core.compilerop import CachingCompiler, check_linecache_ipython
 from IPython.core.display_trap import DisplayTrap
 from IPython.core.displayhook import DisplayHook
 from IPython.core.displaypub import DisplayPublisher
-from IPython.core.error import UsageError
+from IPython.core.error import InputRejected, UsageError
 from IPython.core.extensions import ExtensionManager
 from IPython.core.formatters import DisplayFormatter
 from IPython.core.history import HistoryManager
@@ -54,7 +54,6 @@ from IPython.core.profiledir import ProfileDir
 from IPython.core.prompts import PromptManager
 from IPython.core.usage import default_banner
 from IPython.lib.latextools import LaTeXTool
-from IPython.lib.security import InputRejected
 from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils import PyColorize
 from IPython.utils import io

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -25,6 +25,7 @@ from os.path import join
 import nose.tools as nt
 
 from IPython.core.inputtransformer import InputTransformer
+from IPython.lib.security import InputRejected
 from IPython.testing.decorators import (
     skipif, skip_win32, onlyif_unicode_paths, onlyif_cmds_exist,
 )
@@ -694,6 +695,41 @@ class TestAstTransformError(unittest.TestCase):
         
         # This should have been removed.
         nt.assert_not_in(err_transformer, ip.ast_transformers)
+
+
+class StringRejector(ast.NodeTransformer):
+    """Throws an InputRejected when it sees a string literal.
+
+    Used to verify that NodeTransformers can signal that a piece of code should
+    not be executed by throwing an InputRejected.
+    """
+
+    def visit_Str(self, node):
+        raise InputRejected("test")
+
+
+class TestAstTransformInputRejection(unittest.TestCase):
+
+    def setUp(self):
+        self.transformer = StringRejector()
+        ip.ast_transformers.append(self.transformer)
+
+    def tearDown(self):
+        ip.ast_transformers.remove(self.transformer)
+
+    def test_input_rejection(self):
+        """Check that NodeTransformers can reject input."""
+
+        expect_exception_tb = tt.AssertPrints("InputRejected: test")
+        expect_no_cell_output = tt.AssertNotPrints("'unsafe'", suppress=False)
+
+        # Run the same check twice to verify that the transformer is not
+        # disabled after raising.
+        with expect_exception_tb, expect_no_cell_output:
+            ip.run_cell("'unsafe'")
+
+        with expect_exception_tb, expect_no_cell_output:
+            ip.run_cell("'unsafe'")
 
 def test__IPYTHON__():
     # This shouldn't raise a NameError, that's all

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -24,8 +24,8 @@ from os.path import join
 
 import nose.tools as nt
 
+from IPython.core.error import InputRejected
 from IPython.core.inputtransformer import InputTransformer
-from IPython.lib.security import InputRejected
 from IPython.testing.decorators import (
     skipif, skip_win32, onlyif_unicode_paths, onlyif_cmds_exist,
 )

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -681,7 +681,7 @@ class TestAstTransform2(unittest.TestCase):
 
 class ErrorTransformer(ast.NodeTransformer):
     """Throws an error when it sees a number."""
-    def visit_Num(self):
+    def visit_Num(self, node):
         raise ValueError("test")
 
 class TestAstTransformError(unittest.TestCase):

--- a/IPython/lib/security.py
+++ b/IPython/lib/security.py
@@ -114,13 +114,3 @@ def passwd_check(hashed_passphrase, passphrase):
     h.update(cast_bytes(passphrase, 'utf-8') + cast_bytes(salt, 'ascii'))
 
     return h.hexdigest() == pw_digest
-
-#-----------------------------------------------------------------------------
-# Exception classes
-#-----------------------------------------------------------------------------
-class InputRejected(Exception):
-    """Input rejected by ast transformer.
-
-    To be raised by user-supplied ast.NodeTransformers when an input should not
-    be executed.
-    """

--- a/IPython/lib/security.py
+++ b/IPython/lib/security.py
@@ -114,3 +114,13 @@ def passwd_check(hashed_passphrase, passphrase):
     h.update(cast_bytes(passphrase, 'utf-8') + cast_bytes(salt, 'ascii'))
 
     return h.hexdigest() == pw_digest
+
+#-----------------------------------------------------------------------------
+# Exception classes
+#-----------------------------------------------------------------------------
+class InputRejected(Exception):
+    """Input rejected by ast transformer.
+
+    To be raised by user-supplied ast.NodeTransformers when an input should not
+    be executed.
+    """


### PR DESCRIPTION
Makes it possible for user-supplied AST transformers to reject input by raising a new `InputRejected` exception, which resides in `IPython.lib.security` (not sure if this is the right place for the exception to live, but somewhere in `IPython.lib` seemed correct, and the primary motivation for adding this functionality is to facilitate the possibility of AST-based sandboxing.)

The PR also includes a minor whitespace cleanup in the touched files, as well as a pseudo-bugfix for a misleading test in `test_interactiveshell`.  I'm happy to rebase out either of those pieces if there's a desire to restrict PRs to just a single functional change.
