### PR TITLE
Register input with keyboard manager

### DIFF
--- a/IPython/html/static/notebook/js/celltoolbar.js
+++ b/IPython/html/static/notebook/js/celltoolbar.js
@@ -376,6 +376,7 @@ define([
                 setter(cell, text.val());
             });
             button_container.append($('<span/>').append(lbl));
+            IPython.keyboard_manager.register_events(text);
         };
     };
 


### PR DESCRIPTION
This fixes #6426, which prevented users from typing into the input ui in practice.
