### PR TITLE
Destroy backbone model on comm:close

### DIFF
--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -52,6 +52,7 @@ define(["widgets/js/manager",
         _handle_comm_closed: function (msg) {
             // Handle when a widget is closed.
             this.trigger('comm:close');
+            this.stopListening();
             this.trigger('destroy', this);
             delete this.comm.model; // Delete ref so GC will collect widget model.
             delete this.comm;

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -52,6 +52,7 @@ define(["widgets/js/manager",
         _handle_comm_closed: function (msg) {
             // Handle when a widget is closed.
             this.trigger('comm:close');
+            this.comm.model.trigger('destroy', this.comm.model);
             delete this.comm.model; // Delete ref so GC will collect widget model.
             delete this.comm;
             delete this.model_id; // Delete id from model so widget manager cleans up.

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -52,7 +52,7 @@ define(["widgets/js/manager",
         _handle_comm_closed: function (msg) {
             // Handle when a widget is closed.
             this.trigger('comm:close');
-            this.comm.model.trigger('destroy', this.comm.model);
+            this.trigger('destroy', this);
             delete this.comm.model; // Delete ref so GC will collect widget model.
             delete this.comm;
             delete this.model_id; // Delete id from model so widget manager cleans up.


### PR DESCRIPTION
Trigger the `destroy` event in backbone.js before deleting the model. 

Some other objects may still hold references to the model because they have registered to its events. In the implementation of backbone models, one can register an `on('destroy')` handler. 
