### PR TITLE
A simple context manager for using matplotlib backends

### DIFF
--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -22,6 +22,7 @@ from __future__ import print_function
 
 from io import BytesIO
 
+from IPython.core.interactiveshell import InteractiveShell
 from IPython.core.display import _pngxy
 from IPython.utils.decorators import flag_calls
 from IPython.utils import py3compat
@@ -379,3 +380,16 @@ def configure_inline_support(shell, backend):
     # Setup the default figure format
     select_figure_formats(shell, cfg.figure_formats, **cfg.print_figure_kwargs)
 
+class use_backend(object):
+
+    def __init__(self, backend):
+        from matplotlib import pyplot
+        self.shell = InteractiveShell.instance()
+        self.old_backend = backend2gui[str(pyplot.get_backend())]
+        self.new_backend = backend
+
+    def __enter__(self):
+        gui, backend = self.shell.enable_matplotlib(self.new_backend)
+
+    def __exit__(self, type, value, tb):
+        gui, backend = self.shell.enable_matplotlib(self.old_backend)


### PR DESCRIPTION
I'm often in the situation where most of the plots in my notebook are fine as static pngs (with `inline`), but it would be nice to interact with some (e.g., change view angle on 3D plots). The `nbagg` backend is nice, but a bit slow for interacting with some figures. I thought it would be nice to have a context manager that allowed code in a given cell to use a different backend.

This is a very simple implementation of something what works on my machine. Let me know if I overlooked something. Will add tests, but first want to make sure this simple approach is ok...

Also, curse my white-space nuker...
