### PR TITLE
Fix globbed files in nbconvert FilesWriter

### DIFF
--- a/IPython/nbconvert/writers/files.py
+++ b/IPython/nbconvert/writers/files.py
@@ -82,7 +82,7 @@ class FilesWriter(WriterBase):
                     for matching_filename in glob.glob(filename):
 
                         # Make sure folder exists.
-                        dest = os.path.join(self.build_directory, filename)
+                        dest = os.path.join(self.build_directory, matching_filename)
                         path = os.path.dirname(dest)
                         self._makedir(path)
 

--- a/IPython/nbconvert/writers/tests/test_files.py
+++ b/IPython/nbconvert/writers/tests/test_files.py
@@ -162,3 +162,42 @@ class Testfiles(TestsBase):
             with open(dest, 'r') as f:
                 output = f.read()
                 self.assertEqual(output, 'd')
+
+    def test_glob(self):
+        """Can the FilesWriter handle globbed files correctly?"""
+
+        # Work in a temporary directory.
+        with self.create_temp_cwd():
+
+            # Create test files
+            os.mkdir('sub')
+            with open(os.path.join('sub', 'c'), 'w') as f:
+                f.write('e')
+            with open(os.path.join('sub', 'd'), 'w') as f:
+                f.write('e')
+
+            # Create the resoruces dictionary
+            res = {}
+
+            # Create files writer, test output
+            writer = FilesWriter()
+            writer.files = ['sub/*']
+            writer.build_directory = u'build'
+            writer.write(u'y', res, notebook_name="z")
+
+            # Check the output of the file
+            assert os.path.isdir(writer.build_directory)
+            dest = os.path.join(writer.build_directory, 'z')
+            with open(dest, 'r') as f:
+                output = f.read()
+                self.assertEqual(output, u'y')
+
+            # Check to make sure the globbed files were copied
+            path = os.path.join(writer.build_directory, 'sub')
+            assert os.path.isdir(path)
+            for filename in ['c', 'd']:
+                dest = os.path.join(path, filename)
+                assert os.path.isfile(dest)
+                with open(dest, 'r') as f:
+                    output = f.read()
+                    self.assertEqual(output, 'e')


### PR DESCRIPTION
In the `FilesWriter` for nbconvert, passing a file glob as one of the files doesn't actually work, because the destination of the file is incorrectly set to the original filename (the glob string) rather than the actual filename. This pull request adds a test to detect this bug, and then fixes it.
