### PR TITLE
Add context manager for a kernel, and use it in nbconvert execute preprocessor

### DIFF
--- a/IPython/kernel/__init__.py
+++ b/IPython/kernel/__init__.py
@@ -6,6 +6,6 @@ from . import zmq
 from .connect import *
 from .launcher import *
 from .client import KernelClient
-from .manager import KernelManager
+from .manager import KernelManager, run_kernel
 from .blocking import BlockingKernelClient
 from .multikernelmanager import MultiKernelManager

--- a/IPython/nbconvert/preprocessors/execute.py
+++ b/IPython/nbconvert/preprocessors/execute.py
@@ -46,38 +46,15 @@ class ExecutePreprocessor(Preprocessor):
     }
     
     extra_arguments = List(Unicode)
-    
-    def _create_client(self):
-        from IPython.kernel import KernelManager
-        self.km = KernelManager()
-        self.km.write_connection_file()
-        self.kc = self.km.client()
-        self.kc.start_channels()
-        self.km.start_kernel(extra_arguments=self.extra_arguments, stderr=open(os.devnull, 'w'))
-        self.iopub = self.kc.iopub_channel
-        self.shell = self.kc.shell_channel
-        self.shell.kernel_info()
-        try:
-            self.shell.get_msg(timeout=self.timeout)
-        except Empty:
-            self.log.error("Timeout waiting for kernel_info reply")
-            raise
-        # flush IOPub
-        while True:
-            try:
-                self.iopub.get_msg(block=True, timeout=0.25)
-            except Empty:
-                break
-
-    def _shutdown_client(self):
-        self.kc.stop_channels()
-        self.km.shutdown_kernel()
-        del self.km
 
     def preprocess(self, nb, resources):
-        self._create_client()
-        nb, resources = super(ExecutePreprocessor, self).preprocess(nb, resources)
-        self._shutdown_client()
+        from IPython.kernel import run_kernel
+        kernel_name = nb.metadata.get('kernelspec', {}).get('name', 'python')
+        with run_kernel(kernel_name=kernel_name,
+                        extra_arguments=self.extra_arguments,
+                        stderr=open(os.devnull, 'w')) as kc:
+            self.kc = kc
+            nb, resources = super(ExecutePreprocessor, self).preprocess(nb, resources)
         return nb, resources
 
     def preprocess_cell(self, cell, resources, cell_index):
@@ -87,7 +64,7 @@ class ExecutePreprocessor(Preprocessor):
         if cell.cell_type != 'code':
             return cell, resources
         try:
-            outputs = self.run_cell(self.shell, self.iopub, cell)
+            outputs = self.run_cell(self.kc.shell_channel, self.kc.iopub_channel, cell)
         except Exception as e:
             self.log.error("failed to run cell: " + repr(e))
             self.log.error(str(cell.input))


### PR DESCRIPTION
The kernel tests have a handy context manager to start a kernel, use its client, and shut it down when the context exits. I've promoted this to a public API in IPython.kernel.manager, leaving a thin wrapper in the tests to integrate with our subprocess output capturing.

Using this context manager makes ExecutePreprocessor significantly simpler.

I've also added support for ExecutePreprocessor to start the appropriate kernel from the kernelspec of the notebook it's processing, closing #6447.
