### PR TITLE
Correctly set prompt numbers in execute preprocessor

### DIFF
--- a/IPython/nbconvert/preprocessors/execute.py
+++ b/IPython/nbconvert/preprocessors/execute.py
@@ -126,6 +126,13 @@ class ExecutePreprocessor(Preprocessor):
             msg_type = msg['msg_type']
             self.log.debug("output: %s", msg_type)
             content = msg['content']
+            out = NotebookNode(output_type=self.msg_type_map.get(msg_type, msg_type))
+
+            # set the prompt number for the input and the output
+            if 'execution_count' in content:
+                cell['prompt_number'] = content['execution_count']
+                out.prompt_number = content['execution_count']
+
             if msg_type == 'status':
                 if content['execution_state'] == 'idle':
                     break
@@ -136,13 +143,6 @@ class ExecutePreprocessor(Preprocessor):
             elif msg_type == 'clear_output':
                 outs = []
                 continue
-
-            out = NotebookNode(output_type=self.msg_type_map.get(msg_type, msg_type))
-
-            # set the prompt number for the input and the output
-            if 'execution_count' in content:
-                cell['prompt_number'] = content['execution_count']
-                out.prompt_number = content['execution_count']
 
             if msg_type == 'stream':
                 out.stream = content['name']

--- a/IPython/nbconvert/preprocessors/tests/test_execute.py
+++ b/IPython/nbconvert/preprocessors/tests/test_execute.py
@@ -55,6 +55,10 @@ class TestExecute(PreprocessorTestsBase):
             normalized_actual_outputs = list(map(self.normalize_output, actual_outputs))
             assert normalized_expected_outputs == normalized_actual_outputs
 
+            expected_prompt_number = expected_cell.get('prompt_number', None)
+            actual_prompt_number = actual_cell.get('prompt_number', None)
+            assert expected_prompt_number == actual_prompt_number
+
 
     def build_preprocessor(self):
         """Make an instance of a preprocessor"""
@@ -77,6 +81,10 @@ class TestExecute(PreprocessorTestsBase):
                 input_nb = nbformat.read(f, 'ipynb')
             res = self.build_resources()
             preprocessor = self.build_preprocessor()
-            output_nb, _ = preprocessor(copy.deepcopy(input_nb), res)
+            cleaned_input_nb = copy.deepcopy(input_nb)
+            for cell in cleaned_input_nb.worksheets[0].cells:
+                if 'prompt_number' in cell:
+                    del cell['prompt_number']
+                cell['outputs'] = []
+            output_nb, _ = preprocessor(cleaned_input_nb, res)
             self.assert_notebooks_equal(output_nb, input_nb)
-


### PR DESCRIPTION
Currently, the execute preprocessor doesn't actually always set the prompt numbers correctly, because it seems that when there is no `pyout` message, they are contained in the `execute_input` message, but the preprocessor essentially ignores this message.

This pull request modifies the tests for the execute preprocessor so that they actually detect when the prompt number isn't being set, and then fixes the problem in the execute preprocessor.
