### PR TITLE
Fix several small bugs in the notebook trust UI

### DIFF
--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1855,9 +1855,9 @@ define([
                 }
             }
         }
-        if (trusted != this.trusted) {
+        if (trusted !== this.trusted) {
             this.trusted = trusted;
-            this.events.trigger("trust_changed.Notebook", trusted);
+            this.events.trigger("trust_changed.Notebook", {value: trusted});
         }
         if (content.worksheets.length > 1) {
             dialog.modal({
@@ -2070,7 +2070,7 @@ define([
                                 cell.output_area.trusted = true;
                             }
                         }
-                        this.events.on('notebook_saved.Notebook', function () {
+                        nb.events.on('notebook_saved.Notebook', function () {
                             window.location.reload();
                         });
                         nb.save_notebook();


### PR DESCRIPTION
1. The trust dialog is not called with the notebook context, so we have to use the closure to bind to a notebook event.
2. Replace != with !==
3. The trust_changed.Notebook event default handler expects the trust value to be value key inside an object.  In fact, the event handler is redundant with the code--both seem to set the trust value of the current notebook.

Needless to say, you should scrutinize these changes carefully :).  In particular, I'm not sure why you had != instead of !==.
