### PR TITLE
Bulk update of widget attributes

### DIFF
--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -266,8 +266,8 @@ define(["widgets/js/manager",
             }
         },
 
-        on_change: function(keys, callback, context) {
-            // on_change(["key1", "key2"], foo, context) differs from
+        on_atomic_change: function(keys, callback, context) {
+            // on__atomic_change(["key1", "key2"], foo, context) differs from
             // on("change:key1 change:key2", foo, context).
             // If the widget attributes key1 and key2 are both modified, 
             // the second form will result in foo being called twice

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -152,11 +152,12 @@ define(["widgets/js/manager",
             var attrs = (method === 'patch') ? options.attrs : model.toJSON(options);
             if (this.state_lock !== null) {
                 var keys = Object.keys(this.state_lock);
-                for (var i=0; i<keys.length; i++)
+                for (var i=0; i<keys.length; i++) {
                     var key = keys[i];
                     if (attrs[key] === this.state_lock[key]) {
                         delete attrs[key];
                     }
+                }
             }
 
             // Only sync if there are attributes to send to the back-end.

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -264,6 +264,14 @@ define(["widgets/js/manager",
             }
         },
 
+        on_bulk_change: function(keys, callback, context) {
+            this.on('change', function() {
+                if (keys.some(this.hasChanged, this)) {
+                    callback.apply(context);
+                }
+            }, this);
+
+       },
     });
     widgetmanager.WidgetManager.register_widget_model('WidgetModel', WidgetModel);
 

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -266,7 +266,12 @@ define(["widgets/js/manager",
             }
         },
 
-        on_bulk_change: function(keys, callback, context) {
+        on_change: function(keys, callback, context) {
+            // on_change(["key1", "key2"], foo, context) differs from
+            // on("change:key1 change:key2", foo, context).
+            // If the widget attributes key1 and key2 are both modified, 
+            // the second form will result in foo being called twice
+            // while the first will call foo only once.
             this.on('change', function() {
                 if (keys.some(this.hasChanged, this)) {
                     callback.apply(context);

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -24,7 +24,7 @@ define(["widgets/js/manager",
             this._buffered_state_diff = {};
             this.pending_msgs = 0;
             this.msg_buffer = null;
-            this.key_value_lock = null;
+            this.state_lock = null;
             this.id = model_id;
             this.views = [];
 
@@ -78,15 +78,16 @@ define(["widgets/js/manager",
 
         apply_update: function (state) {
             // Handle when a widget is updated via the python side.
-            var that = this;
-            _.each(state, function(value, key) {
-                that.key_value_lock = [key, value];
-                try {
-                    WidgetModel.__super__.set.apply(that, [key, that._unpack_models(value)]);
-                } finally {
-                    that.key_value_lock = null;
-                }
-            });
+            this.state_lock = state;
+            try {
+                var that = this;
+                WidgetModel.__super__.set.apply(this, [Object.keys(state).reduce(function(obj, key) {
+                    obj[key] = that._unpack_models(state[key]);
+                    return obj;
+                }, {})]);
+            } finally {
+               this.state_lock = null;
+            }
         },
 
         _handle_status: function (msg, callbacks) {
@@ -149,12 +150,13 @@ define(["widgets/js/manager",
 
             // Delete any key value pairs that the back-end already knows about.
             var attrs = (method === 'patch') ? options.attrs : model.toJSON(options);
-            if (this.key_value_lock !== null) {
-                var key = this.key_value_lock[0];
-                var value = this.key_value_lock[1];
-                if (attrs[key] === value) {
-                    delete attrs[key];
-                }
+            if (this.state_lock !== null) {
+                var keys = Object.keys(this.state_lock);
+                for (var i=0; i<keys.length; i++)
+                    var key = keys[i];
+                    if (attrs[key] === this.state_lock[key]) {
+                        delete attrs[key];
+                    }
             }
 
             // Only sync if there are attributes to send to the back-end.


### PR DESCRIPTION
This PR is an optimization in the way widget attributes are updated from the Python side. 
The motivation is the following: Let us say that `chart` is a widget, which has a `width` and a `height` attribute among others. In the JavaScript implementation of the widget, we may have:

``` JavaScript
render: function() {
    // ...
    this.model.on("change:width change:height", this.update_layout, this); 
    // ...
}
```

Then, in the Python side, if one wants to change both width and height at once:

``` Python
with chart.hold_sync():
    chart.width = 1000
    chart.height = 500
```

With the current behavior, the `update_layout` function, which essentially redraws the entire chart , is called twice. 

This PR is meant to allow one to do the following in the implementation of the widget:

``` JavaScript
render: function() {
    // ...
    this.model.on_bulk_change(["width", "height"], this.update_layout, this); 
    // ...
}
```

A way to test this in a notebook is the following:
In a Python cell

``` Python
from IPython.html.widgets import Widget, DOMWidget
from IPython.utils.traitlets import Unicode, Bool
from IPython.display import display
class TestWidget(DOMWidget):
    _view_name = Unicode('TestWidget', sync=True)
    a = Bool(False, sync=True)
    b = Bool(False, sync=True)
```

``` JavaScript
%%javascript
var TestWidget = IPython.DOMWidgetView.extend({
    render: function() {
        this.model.on_bulk_change(['a', 'b'], function() {
            console.log('bulk change');
        });
        this.model.on("change:a change:b", function() {
            console.log('normal change');
        });        
    },
});
IPython.WidgetManager.register_widget_view('TestWidget', TestWidget);
```

``` Python
wid = TestWidget()
display(wid)
with wid.hold_sync():
    wid.a = True
    wid.b = True
```

You will see that `bulk change` is displayed only once while `normal change` is displayed twice in the JavaScript console. 
