### PR TITLE
Hide widget area when closing a widget

### DIFF
--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -418,7 +418,7 @@ define(["widgets/js/manager",
             // Public constructor
             DOMWidgetView.__super__.initialize.apply(this, [parameters]);
             this.on('displayed', this.show, this);
-            this.model.on('destroy', this.hide, this);
+            this.model.once('destroy', this.hide, this);
             this.after_displayed(function() {
                 this.update_visible(this.model, this.model.get("visible"));
                 this.update_css(this.model, this.model.get("_css"));

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -418,6 +418,7 @@ define(["widgets/js/manager",
             // Public constructor
             DOMWidgetView.__super__.initialize.apply(this, [parameters]);
             this.on('displayed', this.show, this);
+            this.model.on('destroy', this.hide, this);
             this.after_displayed(function() {
                 this.update_visible(this.model, this.model.get("visible"));
                 this.update_css(this.model, this.model.get("_css"));

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -384,6 +384,14 @@ define(["widgets/js/manager",
             }
         },
 
+        hide: function(){
+            // Hide the widget-area
+            if (this.options && this.options.cell &&
+                this.options.cell.widget_area !== undefined) {
+                this.options.cell.widget_area.hide();
+            }
+        },
+
         send: function (content) {
             // Send a custom msg associated with this view.
             this.model.send(content, this.callbacks());
@@ -394,7 +402,7 @@ define(["widgets/js/manager",
         },
 
         after_displayed: function (callback, context) {
-            // Calls the callback right away is the view is already displayed
+            // Calls the callback right away if the view is already displayed
             // otherwise, register the callback to the 'displayed' event.
             if (this.is_displayed) {
                 callback.apply(context);


### PR DESCRIPTION
After closing a widget, the widget area is empty, and should be hidden. Added the `hide` function in `WidgetView` next to `show`, and call on close of the model. 
