### PR TITLE
Create a dropdown widget from a list of tuples in interactive

### DIFF
--- a/IPython/html/widgets/interaction.py
+++ b/IPython/html/widgets/interaction.py
@@ -90,6 +90,8 @@ def _widget_abbrev(o):
     if isinstance(o, (list, tuple)):
         if o and all(isinstance(x, string_types) for x in o):
             return Dropdown(values=[unicode_type(k) for k in o])
+        elif o and all(isinstance(x, tuple) for x in o):
+            return Dropdown(values=o)
         elif _matches(o, (float_or_int, float_or_int)):
             min, max, value = _get_min_max_value(o[0], o[1])
             if all(isinstance(_, int) for _ in o):

--- a/IPython/html/widgets/tests/test_interaction.py
+++ b/IPython/html/widgets/tests/test_interaction.py
@@ -21,7 +21,7 @@ import IPython.testing.tools as tt
 # from IPython.core.getipython import get_ipython
 from IPython.html import widgets
 from IPython.html.widgets import interact, interactive, Widget, interaction
-from IPython.utils.py3compat import annotate
+from IPython.utils.py3compat import annotate, unicode_type
 
 #-----------------------------------------------------------------------------
 # Utility stuff
@@ -231,6 +231,17 @@ def test_list_tuple_str():
         value=first,
         values=dvalues
     )
+    check_widgets(c, tup=d, lis=d)
+
+def test_list_tuple_tuple():
+    values = [('name', 'bruce'), ('profession', 'batman')]
+    first = values[0]
+    dvalues = OrderedDict((unicode_type(v), v) for v in values)
+    c = interactive(f, tup=tuple(values), lis=list(values))
+    nt.assert_equal(len(c.children), 2)
+    d = dict(cls=widgets.Dropdown,
+             value=first,
+             values=dvalues)
     check_widgets(c, tup=d, lis=d)
 
 def test_list_tuple_invalid():

--- a/IPython/html/widgets/widget_selection.py
+++ b/IPython/html/widgets/widget_selection.py
@@ -57,7 +57,7 @@ class _Selection(DOMWidget):
         if 'values' in kwargs:
             values = kwargs['values']
             # convert list values to an dict of {str(v):v}
-            if isinstance(values, list):
+            if isinstance(values, (list, tuple)):
                 # preserve list order with an OrderedDict
                 kwargs['values'] = OrderedDict((unicode_type(v), v) for v in values)
             # python3.3 turned on hash randomization by default - this means that sometimes, randomly


### PR DESCRIPTION
This adds support for creating a dropdown box widget when `interactive` is passed a list of tuples. The tuples are presented in the dropdown box as the string equivalent of the tuple.
