### PR TITLE
Clear prompt numbers in ClearOutput preprocessor

### DIFF
--- a/IPython/nbconvert/preprocessors/clearoutput.py
+++ b/IPython/nbconvert/preprocessors/clearoutput.py
@@ -24,4 +24,6 @@ class ClearOutputPreprocessor(Preprocessor):
         """
         if cell.cell_type == 'code':
             cell.outputs = []
+            if 'prompt_number' in cell:
+                del cell['prompt_number']
         return cell, resources

--- a/IPython/nbconvert/preprocessors/clearoutput.py
+++ b/IPython/nbconvert/preprocessors/clearoutput.py
@@ -24,5 +24,5 @@ class ClearOutputPreprocessor(Preprocessor):
         """
         if cell.cell_type == 'code':
             cell.outputs = []
-            cell['prompt_number'] = None
+            cell.prompt_number = None
         return cell, resources

--- a/IPython/nbconvert/preprocessors/clearoutput.py
+++ b/IPython/nbconvert/preprocessors/clearoutput.py
@@ -24,6 +24,5 @@ class ClearOutputPreprocessor(Preprocessor):
         """
         if cell.cell_type == 'code':
             cell.outputs = []
-            if 'prompt_number' in cell:
-                del cell['prompt_number']
+            cell['prompt_number'] = None
         return cell, resources

--- a/IPython/nbconvert/preprocessors/tests/test_clearoutput.py
+++ b/IPython/nbconvert/preprocessors/tests/test_clearoutput.py
@@ -39,4 +39,4 @@ class TestClearOutput(PreprocessorTestsBase):
         preprocessor = self.build_preprocessor()
         nb, res = preprocessor(nb, res)
         assert nb.worksheets[0].cells[0].outputs == []
-        assert 'prompt_number' not in nb.worksheets[0].cells[0]
+        assert nb.worksheets[0].cells[0].prompt_number is None

--- a/IPython/nbconvert/preprocessors/tests/test_clearoutput.py
+++ b/IPython/nbconvert/preprocessors/tests/test_clearoutput.py
@@ -39,3 +39,4 @@ class TestClearOutput(PreprocessorTestsBase):
         preprocessor = self.build_preprocessor()
         nb, res = preprocessor(nb, res)
         assert nb.worksheets[0].cells[0].outputs == []
+        assert 'prompt_number' not in nb.worksheets[0].cells[0]


### PR DESCRIPTION
When choosing to clear all output in the notebook interface, it also clears all the prompt numbers. However, the `ClearOutput` preprocess does not currently clear prompt numbers -- only the outputs themselves. It seems like the behavior in these two places should be consistent, so this pull request modifies the `ClearOutput` preprocessor to also clear prompt numbers.
