### PR TITLE
Trim anchor link in heading cells, fixes #6324

### DIFF
--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -418,7 +418,7 @@ define([
             html = security.sanitize_html(html);
             var h = $($.parseHTML(html));
             // add id and linkback anchor
-            var hash = h.text().replace(/ /g, '-');
+            var hash = h.text().trim().replace(/ /g, '-');
             h.attr('id', hash);
             h.append(
                 $('<a/>')


### PR DESCRIPTION
This should fix #6324, which was really irritating me :smiley: I used `.trim()` as suggested by @minrk.
