### PR TITLE
rename webapp_settings to tornado_settings

### DIFF
--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -468,6 +468,13 @@ class NotebookApp(BaseIPythonApplication):
                       """)
     
     webapp_settings = Dict(config=True,
+        help="DEPRECATED, use tornado_settings"
+    )
+    def _webapp_settings_changed(self, name, old, new):
+        self.log.warn("\n    webapp_settings is deprecated, use tornado_settings.\n")
+        self.tornado_settings = new
+    
+    tornado_settings = Dict(config=True,
             help="Supply overrides for the tornado.web.Application that the "
                  "IPython notebook uses.")
 

--- a/docs/source/whatsnew/pr/tornado_settings.rst
+++ b/docs/source/whatsnew/pr/tornado_settings.rst
@@ -1,0 +1,2 @@
+- ``NotebookApp.webapp_settings`` is deprecated and replaced with
+  the more informatively named ``NotebookApp.tornado_settings``.


### PR DESCRIPTION
deprecate `webapp_settings`

More informative name to those who would actually use this feature. It sets overrides for the tornado global `settings` object.
