### PR TITLE
Creating a widget registry on the Python side.

### DIFF
--- a/IPython/html/widgets/__init__.py
+++ b/IPython/html/widgets/__init__.py
@@ -1,4 +1,4 @@
-from .widget import Widget, DOMWidget, CallbackDispatcher
+from .widget import Widget, DOMWidget, CallbackDispatcher, register
 
 from .widget_bool import Checkbox, ToggleButton
 from .widget_button import Button

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -79,7 +79,7 @@ def _show_traceback(method):
 def register(key=None):
     """Returns a decorator registering a widget class in the widget registry. 
     If no key is provided, the class name is used as a key. A key is
-    provided for each core Jupyter widget so that the frontend can use
+    provided for each core IPython widget so that the frontend can use
     this key regardless of the language of the kernel"""
     def wrap(widget):
         l = key if key is not None else widget.__module__ + widget.__name__

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -75,12 +75,22 @@ def _show_traceback(method):
                 ip.showtraceback()
     return m
 
+
+def register(key=None):
+    def wrap(widget):
+        l = key if key is not None else widget._model_name.default_value
+        Widget.widget_types[l] = widget
+        return widget
+    return wrap
+
+
 class Widget(LoggingConfigurable):
     #-------------------------------------------------------------------------
     # Class attributes
     #-------------------------------------------------------------------------
     _widget_construction_callback = None
     widgets = {}
+    widget_types = {}
 
     @staticmethod
     def on_widget_constructed(callback):

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -78,7 +78,7 @@ def _show_traceback(method):
 
 def register(key=None):
     def wrap(widget):
-        l = key if key is not None else widget._model_name.default_value
+        l = key if key is not None else widget._view_name.default_value
         Widget.widget_types[l] = widget
         return widget
     return wrap

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -77,8 +77,12 @@ def _show_traceback(method):
 
 
 def register(key=None):
+    """Returns a decorator registering a widget class in the widget registry. 
+    If no key is provided, the class name is used as a key. A key is
+    provided for each core Jupyter widget so that the frontend can use
+    this key regardless of the language of the kernel"""
     def wrap(widget):
-        l = key if key is not None else widget._view_name.default_value
+        l = key if key is not None else widget.__module__ + widget.__name__
         Widget.widget_types[l] = widget
         return widget
     return wrap

--- a/IPython/html/widgets/widget_bool.py
+++ b/IPython/html/widgets/widget_bool.py
@@ -13,13 +13,14 @@ Represents a boolean using a widget.
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
-from .widget import DOMWidget
+from .widget import DOMWidget, register
 from IPython.utils.traitlets import Unicode, Bool, CaselessStrEnum
 from IPython.utils.warn import DeprecatedClass
 
 #-----------------------------------------------------------------------------
 # Classes
 #-----------------------------------------------------------------------------
+@register()
 class _Bool(DOMWidget):
     """A base class for creating widgets that represent booleans."""
     value = Bool(False, help="Bool value", sync=True)
@@ -27,11 +28,13 @@ class _Bool(DOMWidget):
     disabled = Bool(False, help="Enable or disable user changes.", sync=True)
 
 
+@register()
 class Checkbox(_Bool):
     """Displays a boolean `value`."""
     _view_name = Unicode('CheckboxView', sync=True)
 
 
+@register()
 class ToggleButton(_Bool):
     """Displays a boolean `value`."""
     

--- a/IPython/html/widgets/widget_bool.py
+++ b/IPython/html/widgets/widget_bool.py
@@ -27,13 +27,13 @@ class _Bool(DOMWidget):
     disabled = Bool(False, help="Enable or disable user changes.", sync=True)
 
 
-@register('jupyter.Checkbox')
+@register('IPython.Checkbox')
 class Checkbox(_Bool):
     """Displays a boolean `value`."""
     _view_name = Unicode('CheckboxView', sync=True)
 
 
-@register('jupyter.ToggleButton')
+@register('IPython.ToggleButton')
 class ToggleButton(_Bool):
     """Displays a boolean `value`."""
     

--- a/IPython/html/widgets/widget_bool.py
+++ b/IPython/html/widgets/widget_bool.py
@@ -20,7 +20,6 @@ from IPython.utils.warn import DeprecatedClass
 #-----------------------------------------------------------------------------
 # Classes
 #-----------------------------------------------------------------------------
-@register()
 class _Bool(DOMWidget):
     """A base class for creating widgets that represent booleans."""
     value = Bool(False, help="Bool value", sync=True)
@@ -28,13 +27,13 @@ class _Bool(DOMWidget):
     disabled = Bool(False, help="Enable or disable user changes.", sync=True)
 
 
-@register()
+@register('jupyter.Checkbox')
 class Checkbox(_Bool):
     """Displays a boolean `value`."""
     _view_name = Unicode('CheckboxView', sync=True)
 
 
-@register()
+@register('jupyter.ToggleButton')
 class ToggleButton(_Bool):
     """Displays a boolean `value`."""
     

--- a/IPython/html/widgets/widget_box.py
+++ b/IPython/html/widgets/widget_box.py
@@ -10,7 +10,7 @@ from .widget import DOMWidget, register
 from IPython.utils.traitlets import Unicode, Tuple, TraitError, Int, CaselessStrEnum
 from IPython.utils.warn import DeprecatedClass
 
-@register('jupyter.Box')
+@register('IPython.Box')
 class Box(DOMWidget):
     """Displays multiple widgets in a group."""
     _view_name = Unicode('BoxView', sync=True)
@@ -45,7 +45,7 @@ class Box(DOMWidget):
             child._handle_displayed()
 
 
-@register('jupyter.Popup')
+@register('IPython.Popup')
 class Popup(Box):
     """Displays multiple widgets in an in page popup div."""
     _view_name = Unicode('PopupView', sync=True)
@@ -54,7 +54,7 @@ class Popup(Box):
     button_text = Unicode(sync=True)
 
 
-@register('jupyter.FlexBox')
+@register('IPython.FlexBox')
 class FlexBox(Box):
     """Displays multiple widgets using the flexible box model."""
     _view_name = Unicode('FlexBoxView', sync=True)

--- a/IPython/html/widgets/widget_box.py
+++ b/IPython/html/widgets/widget_box.py
@@ -10,7 +10,7 @@ from .widget import DOMWidget, register
 from IPython.utils.traitlets import Unicode, Tuple, TraitError, Int, CaselessStrEnum
 from IPython.utils.warn import DeprecatedClass
 
-@register()
+@register('jupyter.Box')
 class Box(DOMWidget):
     """Displays multiple widgets in a group."""
     _view_name = Unicode('BoxView', sync=True)
@@ -45,7 +45,7 @@ class Box(DOMWidget):
             child._handle_displayed()
 
 
-@register()
+@register('jupyter.Popup')
 class Popup(Box):
     """Displays multiple widgets in an in page popup div."""
     _view_name = Unicode('PopupView', sync=True)
@@ -54,7 +54,7 @@ class Popup(Box):
     button_text = Unicode(sync=True)
 
 
-@register()
+@register('jupyter.FlexBox')
 class FlexBox(Box):
     """Displays multiple widgets using the flexible box model."""
     _view_name = Unicode('FlexBoxView', sync=True)

--- a/IPython/html/widgets/widget_box.py
+++ b/IPython/html/widgets/widget_box.py
@@ -6,10 +6,11 @@ Represents a container that can be used to group other widgets.
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from .widget import DOMWidget
+from .widget import DOMWidget, register
 from IPython.utils.traitlets import Unicode, Tuple, TraitError, Int, CaselessStrEnum
 from IPython.utils.warn import DeprecatedClass
 
+@register()
 class Box(DOMWidget):
     """Displays multiple widgets in a group."""
     _view_name = Unicode('BoxView', sync=True)
@@ -44,6 +45,7 @@ class Box(DOMWidget):
             child._handle_displayed()
 
 
+@register()
 class Popup(Box):
     """Displays multiple widgets in an in page popup div."""
     _view_name = Unicode('PopupView', sync=True)
@@ -52,6 +54,7 @@ class Popup(Box):
     button_text = Unicode(sync=True)
 
 
+@register()
 class FlexBox(Box):
     """Displays multiple widgets using the flexible box model."""
     _view_name = Unicode('FlexBoxView', sync=True)

--- a/IPython/html/widgets/widget_button.py
+++ b/IPython/html/widgets/widget_button.py
@@ -21,7 +21,7 @@ from IPython.utils.warn import DeprecatedClass
 #-----------------------------------------------------------------------------
 # Classes
 #-----------------------------------------------------------------------------
-@register()
+@register('jupyter.Button')
 class Button(DOMWidget):
     """Button widget.
 

--- a/IPython/html/widgets/widget_button.py
+++ b/IPython/html/widgets/widget_button.py
@@ -21,7 +21,7 @@ from IPython.utils.warn import DeprecatedClass
 #-----------------------------------------------------------------------------
 # Classes
 #-----------------------------------------------------------------------------
-@register('jupyter.Button')
+@register('IPython.Button')
 class Button(DOMWidget):
     """Button widget.
 

--- a/IPython/html/widgets/widget_button.py
+++ b/IPython/html/widgets/widget_button.py
@@ -14,13 +14,14 @@ click events on the button and trigger backend code when the clicks are fired.
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
-from .widget import DOMWidget, CallbackDispatcher
+from .widget import DOMWidget, CallbackDispatcher, register
 from IPython.utils.traitlets import Unicode, Bool, CaselessStrEnum
 from IPython.utils.warn import DeprecatedClass
 
 #-----------------------------------------------------------------------------
 # Classes
 #-----------------------------------------------------------------------------
+@register()
 class Button(DOMWidget):
     """Button widget.
 

--- a/IPython/html/widgets/widget_float.py
+++ b/IPython/html/widgets/widget_float.py
@@ -13,7 +13,7 @@ Represents an unbounded float using a widget.
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
-from .widget import DOMWidget
+from .widget import DOMWidget, register
 from IPython.utils.traitlets import Unicode, CFloat, Bool, CaselessStrEnum, Tuple
 from IPython.utils.warn import DeprecatedClass
 
@@ -43,14 +43,17 @@ class _BoundedFloat(_Float):
             self.value = min(max(new, self.min), self.max)
 
 
+@register()
 class FloatText(_Float):
     _view_name = Unicode('FloatTextView', sync=True)
 
 
+@register()
 class BoundedFloatText(_BoundedFloat):
     _view_name = Unicode('FloatTextView', sync=True)
 
 
+@register()
 class FloatSlider(_BoundedFloat):
     _view_name = Unicode('FloatSliderView', sync=True)
     orientation = CaselessStrEnum(values=['horizontal', 'vertical'], 
@@ -61,6 +64,7 @@ class FloatSlider(_BoundedFloat):
     slider_color = Unicode(sync=True)
 
 
+@register()
 class FloatProgress(_BoundedFloat):
     _view_name = Unicode('ProgressView', sync=True)
 
@@ -163,6 +167,7 @@ class _BoundedFloatRange(_FloatRange):
             self.lower = low
 
 
+@register()
 class FloatRangeSlider(_BoundedFloatRange):
     _view_name = Unicode('FloatSliderView', sync=True)
     orientation = CaselessStrEnum(values=['horizontal', 'vertical'], 

--- a/IPython/html/widgets/widget_float.py
+++ b/IPython/html/widgets/widget_float.py
@@ -43,17 +43,17 @@ class _BoundedFloat(_Float):
             self.value = min(max(new, self.min), self.max)
 
 
-@register('jupyter.FloatText')
+@register('IPython.FloatText')
 class FloatText(_Float):
     _view_name = Unicode('FloatTextView', sync=True)
 
 
-@register('jupyter.BoundedFloatText')
+@register('IPython.BoundedFloatText')
 class BoundedFloatText(_BoundedFloat):
     _view_name = Unicode('FloatTextView', sync=True)
 
 
-@register('jupyter.FloatSlider')
+@register('IPython.FloatSlider')
 class FloatSlider(_BoundedFloat):
     _view_name = Unicode('FloatSliderView', sync=True)
     orientation = CaselessStrEnum(values=['horizontal', 'vertical'], 
@@ -64,7 +64,7 @@ class FloatSlider(_BoundedFloat):
     slider_color = Unicode(sync=True)
 
 
-@register('jupyter.FloatProgress')
+@register('IPython.FloatProgress')
 class FloatProgress(_BoundedFloat):
     _view_name = Unicode('ProgressView', sync=True)
 
@@ -167,7 +167,7 @@ class _BoundedFloatRange(_FloatRange):
             self.lower = low
 
 
-@register('jupyter.FloatRangeSlider')
+@register('IPython.FloatRangeSlider')
 class FloatRangeSlider(_BoundedFloatRange):
     _view_name = Unicode('FloatSliderView', sync=True)
     orientation = CaselessStrEnum(values=['horizontal', 'vertical'], 

--- a/IPython/html/widgets/widget_float.py
+++ b/IPython/html/widgets/widget_float.py
@@ -43,17 +43,17 @@ class _BoundedFloat(_Float):
             self.value = min(max(new, self.min), self.max)
 
 
-@register()
+@register('jupyter.FloatText')
 class FloatText(_Float):
     _view_name = Unicode('FloatTextView', sync=True)
 
 
-@register()
+@register('jupyter.BoundedFloatText')
 class BoundedFloatText(_BoundedFloat):
     _view_name = Unicode('FloatTextView', sync=True)
 
 
-@register()
+@register('jupyter.FloatSlider')
 class FloatSlider(_BoundedFloat):
     _view_name = Unicode('FloatSliderView', sync=True)
     orientation = CaselessStrEnum(values=['horizontal', 'vertical'], 
@@ -64,7 +64,7 @@ class FloatSlider(_BoundedFloat):
     slider_color = Unicode(sync=True)
 
 
-@register()
+@register('jupyter.FloatProgress')
 class FloatProgress(_BoundedFloat):
     _view_name = Unicode('ProgressView', sync=True)
 
@@ -167,7 +167,7 @@ class _BoundedFloatRange(_FloatRange):
             self.lower = low
 
 
-@register()
+@register('jupyter.FloatRangeSlider')
 class FloatRangeSlider(_BoundedFloatRange):
     _view_name = Unicode('FloatSliderView', sync=True)
     orientation = CaselessStrEnum(values=['horizontal', 'vertical'], 

--- a/IPython/html/widgets/widget_image.py
+++ b/IPython/html/widgets/widget_image.py
@@ -15,13 +15,14 @@ Represents an image in the frontend using a widget.
 #-----------------------------------------------------------------------------
 import base64
 
-from .widget import DOMWidget
+from .widget import DOMWidget, register
 from IPython.utils.traitlets import Unicode, CUnicode, Bytes
 from IPython.utils.warn import DeprecatedClass
 
 #-----------------------------------------------------------------------------
 # Classes
 #-----------------------------------------------------------------------------
+@register()
 class Image(DOMWidget):
     """Displays an image as a widget.
 

--- a/IPython/html/widgets/widget_image.py
+++ b/IPython/html/widgets/widget_image.py
@@ -22,7 +22,7 @@ from IPython.utils.warn import DeprecatedClass
 #-----------------------------------------------------------------------------
 # Classes
 #-----------------------------------------------------------------------------
-@register()
+@register('jupyter.Image')
 class Image(DOMWidget):
     """Displays an image as a widget.
 

--- a/IPython/html/widgets/widget_image.py
+++ b/IPython/html/widgets/widget_image.py
@@ -22,7 +22,7 @@ from IPython.utils.warn import DeprecatedClass
 #-----------------------------------------------------------------------------
 # Classes
 #-----------------------------------------------------------------------------
-@register('jupyter.Image')
+@register('IPython.Image')
 class Image(DOMWidget):
     """Displays an image as a widget.
 

--- a/IPython/html/widgets/widget_int.py
+++ b/IPython/html/widgets/widget_int.py
@@ -56,19 +56,19 @@ class _BoundedInt(_Int):
         if new > self.max:
             raise ValueError("setting min > max")
 
-@register()
+@register('jupyter.IntText')
 class IntText(_Int):
     """Textbox widget that represents a int."""
     _view_name = Unicode('IntTextView', sync=True)
 
 
-@register()
+@register('jupyter.BoundedIntText')
 class BoundedIntText(_BoundedInt):
     """Textbox widget that represents a int bounded by a minimum and maximum value."""
     _view_name = Unicode('IntTextView', sync=True)
 
 
-@register()
+@register('jupyter.IntSlider')
 class IntSlider(_BoundedInt):
     """Slider widget that represents a int bounded by a minimum and maximum value."""
     _view_name = Unicode('IntSliderView', sync=True)
@@ -80,7 +80,7 @@ class IntSlider(_BoundedInt):
     slider_color = Unicode(sync=True)
 
 
-@register()
+@register('jupyter.IntProgress')
 class IntProgress(_BoundedInt):
     """Progress bar that represents a int bounded by a minimum and maximum value."""
     _view_name = Unicode('ProgressView', sync=True)
@@ -180,7 +180,7 @@ class _BoundedIntRange(_IntRange):
             self.upper = high
             self.lower = low
 
-@register()
+@register('jupyter.IntRangeSlider')
 class IntRangeSlider(_BoundedIntRange):
     _view_name = Unicode('IntSliderView', sync=True)
     orientation = CaselessStrEnum(values=['horizontal', 'vertical'], 

--- a/IPython/html/widgets/widget_int.py
+++ b/IPython/html/widgets/widget_int.py
@@ -13,7 +13,7 @@ Represents an unbounded int using a widget.
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
-from .widget import DOMWidget
+from .widget import DOMWidget, register
 from IPython.utils.traitlets import Unicode, CInt, Bool, CaselessStrEnum, Tuple
 from IPython.utils.warn import DeprecatedClass
 
@@ -56,16 +56,19 @@ class _BoundedInt(_Int):
         if new > self.max:
             raise ValueError("setting min > max")
 
+@register()
 class IntText(_Int):
     """Textbox widget that represents a int."""
     _view_name = Unicode('IntTextView', sync=True)
 
 
+@register()
 class BoundedIntText(_BoundedInt):
     """Textbox widget that represents a int bounded by a minimum and maximum value."""
     _view_name = Unicode('IntTextView', sync=True)
 
 
+@register()
 class IntSlider(_BoundedInt):
     """Slider widget that represents a int bounded by a minimum and maximum value."""
     _view_name = Unicode('IntSliderView', sync=True)
@@ -77,6 +80,7 @@ class IntSlider(_BoundedInt):
     slider_color = Unicode(sync=True)
 
 
+@register()
 class IntProgress(_BoundedInt):
     """Progress bar that represents a int bounded by a minimum and maximum value."""
     _view_name = Unicode('ProgressView', sync=True)
@@ -176,6 +180,7 @@ class _BoundedIntRange(_IntRange):
             self.upper = high
             self.lower = low
 
+@register()
 class IntRangeSlider(_BoundedIntRange):
     _view_name = Unicode('IntSliderView', sync=True)
     orientation = CaselessStrEnum(values=['horizontal', 'vertical'], 

--- a/IPython/html/widgets/widget_int.py
+++ b/IPython/html/widgets/widget_int.py
@@ -56,19 +56,19 @@ class _BoundedInt(_Int):
         if new > self.max:
             raise ValueError("setting min > max")
 
-@register('jupyter.IntText')
+@register('IPython.IntText')
 class IntText(_Int):
     """Textbox widget that represents a int."""
     _view_name = Unicode('IntTextView', sync=True)
 
 
-@register('jupyter.BoundedIntText')
+@register('IPython.BoundedIntText')
 class BoundedIntText(_BoundedInt):
     """Textbox widget that represents a int bounded by a minimum and maximum value."""
     _view_name = Unicode('IntTextView', sync=True)
 
 
-@register('jupyter.IntSlider')
+@register('IPython.IntSlider')
 class IntSlider(_BoundedInt):
     """Slider widget that represents a int bounded by a minimum and maximum value."""
     _view_name = Unicode('IntSliderView', sync=True)
@@ -80,7 +80,7 @@ class IntSlider(_BoundedInt):
     slider_color = Unicode(sync=True)
 
 
-@register('jupyter.IntProgress')
+@register('IPython.IntProgress')
 class IntProgress(_BoundedInt):
     """Progress bar that represents a int bounded by a minimum and maximum value."""
     _view_name = Unicode('ProgressView', sync=True)
@@ -180,7 +180,7 @@ class _BoundedIntRange(_IntRange):
             self.upper = high
             self.lower = low
 
-@register('jupyter.IntRangeSlider')
+@register('IPython.IntRangeSlider')
 class IntRangeSlider(_BoundedIntRange):
     _view_name = Unicode('IntSliderView', sync=True)
     orientation = CaselessStrEnum(values=['horizontal', 'vertical'], 

--- a/IPython/html/widgets/widget_selection.py
+++ b/IPython/html/widgets/widget_selection.py
@@ -114,7 +114,7 @@ class _Selection(DOMWidget):
                 self.value_lock.release()
 
 
-@register('jupyter.ToggleButtons')
+@register('IPython.ToggleButtons')
 class ToggleButtons(_Selection):
     """Group of toggle buttons that represent an enumeration.  Only one toggle
     button can be toggled at any point in time.""" 
@@ -125,7 +125,7 @@ class ToggleButtons(_Selection):
         default_value='', allow_none=True, sync=True, help="""Use a
         predefined styling for the buttons.""")
 
-@register('jupyter.Dropdown')
+@register('IPython.Dropdown')
 class Dropdown(_Selection):
     """Allows you to select a single item from a dropdown."""
     _view_name = Unicode('DropdownView', sync=True)
@@ -135,7 +135,7 @@ class Dropdown(_Selection):
         default_value='', allow_none=True, sync=True, help="""Use a
         predefined styling for the buttons.""")
 
-@register('jupyter.RadioButtons')
+@register('IPython.RadioButtons')
 class RadioButtons(_Selection):
     """Group of radio buttons that represent an enumeration.  Only one radio
     button can be toggled at any point in time.""" 
@@ -143,7 +143,7 @@ class RadioButtons(_Selection):
     
 
 
-@register('jupyter.Select')
+@register('IPython.Select')
 class Select(_Selection):
     """Listbox that only allows one item to be selected at any given time."""
     _view_name = Unicode('SelectView', sync=True)

--- a/IPython/html/widgets/widget_selection.py
+++ b/IPython/html/widgets/widget_selection.py
@@ -114,7 +114,7 @@ class _Selection(DOMWidget):
                 self.value_lock.release()
 
 
-@register()
+@register('jupyter.ToggleButtons')
 class ToggleButtons(_Selection):
     """Group of toggle buttons that represent an enumeration.  Only one toggle
     button can be toggled at any point in time.""" 
@@ -125,7 +125,7 @@ class ToggleButtons(_Selection):
         default_value='', allow_none=True, sync=True, help="""Use a
         predefined styling for the buttons.""")
 
-@register()
+@register('jupyter.Dropdown')
 class Dropdown(_Selection):
     """Allows you to select a single item from a dropdown."""
     _view_name = Unicode('DropdownView', sync=True)
@@ -135,7 +135,7 @@ class Dropdown(_Selection):
         default_value='', allow_none=True, sync=True, help="""Use a
         predefined styling for the buttons.""")
 
-@register()
+@register('jupyter.RadioButtons')
 class RadioButtons(_Selection):
     """Group of radio buttons that represent an enumeration.  Only one radio
     button can be toggled at any point in time.""" 
@@ -143,7 +143,7 @@ class RadioButtons(_Selection):
     
 
 
-@register()
+@register('jupyter.Select')
 class Select(_Selection):
     """Listbox that only allows one item to be selected at any given time."""
     _view_name = Unicode('SelectView', sync=True)

--- a/IPython/html/widgets/widget_selection.py
+++ b/IPython/html/widgets/widget_selection.py
@@ -17,7 +17,7 @@ Represents an enumeration using a widget.
 from collections import OrderedDict
 from threading import Lock
 
-from .widget import DOMWidget
+from .widget import DOMWidget, register
 from IPython.utils.traitlets import Unicode, List, Bool, Any, Dict, TraitError, CaselessStrEnum
 from IPython.utils.py3compat import unicode_type
 from IPython.utils.warn import DeprecatedClass
@@ -114,6 +114,7 @@ class _Selection(DOMWidget):
                 self.value_lock.release()
 
 
+@register()
 class ToggleButtons(_Selection):
     """Group of toggle buttons that represent an enumeration.  Only one toggle
     button can be toggled at any point in time.""" 
@@ -124,7 +125,7 @@ class ToggleButtons(_Selection):
         default_value='', allow_none=True, sync=True, help="""Use a
         predefined styling for the buttons.""")
 
-
+@register()
 class Dropdown(_Selection):
     """Allows you to select a single item from a dropdown."""
     _view_name = Unicode('DropdownView', sync=True)
@@ -134,13 +135,15 @@ class Dropdown(_Selection):
         default_value='', allow_none=True, sync=True, help="""Use a
         predefined styling for the buttons.""")
 
-
+@register()
 class RadioButtons(_Selection):
     """Group of radio buttons that represent an enumeration.  Only one radio
     button can be toggled at any point in time.""" 
     _view_name = Unicode('RadioButtonsView', sync=True)
     
 
+
+@register()
 class Select(_Selection):
     """Listbox that only allows one item to be selected at any given time."""
     _view_name = Unicode('SelectView', sync=True)

--- a/IPython/html/widgets/widget_selectioncontainer.py
+++ b/IPython/html/widgets/widget_selectioncontainer.py
@@ -51,13 +51,13 @@ class _SelectionContainer(Box):
         else:
             return None
 
-@register('jupyter.Accordion')
+@register('IPython.Accordion')
 class Accordion(_SelectionContainer):
     """Displays children each on a separate accordion page."""
     _view_name = Unicode('AccordionView', sync=True)
 
 
-@register('jupyter.Tab')
+@register('IPython.Tab')
 class Tab(_SelectionContainer):
     """Displays children each on a separate accordion tab."""
     _view_name = Unicode('TabView', sync=True)

--- a/IPython/html/widgets/widget_selectioncontainer.py
+++ b/IPython/html/widgets/widget_selectioncontainer.py
@@ -51,13 +51,13 @@ class _SelectionContainer(Box):
         else:
             return None
 
-@register()
+@register('jupyter.Accordion')
 class Accordion(_SelectionContainer):
     """Displays children each on a separate accordion page."""
     _view_name = Unicode('AccordionView', sync=True)
 
 
-@register()
+@register('jupyter.Tab')
 class Tab(_SelectionContainer):
     """Displays children each on a separate accordion tab."""
     _view_name = Unicode('TabView', sync=True)

--- a/IPython/html/widgets/widget_selectioncontainer.py
+++ b/IPython/html/widgets/widget_selectioncontainer.py
@@ -14,7 +14,7 @@ pages.
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
-from .widget_box import Box
+from .widget_box import Box, register
 from IPython.utils.traitlets import Unicode, Dict, CInt
 from IPython.utils.warn import DeprecatedClass
 
@@ -51,12 +51,13 @@ class _SelectionContainer(Box):
         else:
             return None
 
-
+@register()
 class Accordion(_SelectionContainer):
     """Displays children each on a separate accordion page."""
     _view_name = Unicode('AccordionView', sync=True)
 
 
+@register()
 class Tab(_SelectionContainer):
     """Displays children each on a separate accordion tab."""
     _view_name = Unicode('TabView', sync=True)

--- a/IPython/html/widgets/widget_string.py
+++ b/IPython/html/widgets/widget_string.py
@@ -28,20 +28,20 @@ class _String(DOMWidget):
     placeholder = Unicode("", help="Placeholder text to display when nothing has been typed", sync=True)
 
 
-@register()
+@register('jupyter.HTML')
 class HTML(_String):
     """Renders the string `value` as HTML."""
     _view_name = Unicode('HTMLView', sync=True)
 
 
-@register()
+@register('jupyter.Latex')
 class Latex(_String):
     """Renders math inside the string `value` as Latex (requires $ $ or $$ $$ 
     and similar latex tags)."""
     _view_name = Unicode('LatexView', sync=True)
 
 
-@register()
+@register('jupyter.Textarea')
 class Textarea(_String):
     """Multiline text area widget."""
     _view_name = Unicode('TextareaView', sync=True)
@@ -50,7 +50,7 @@ class Textarea(_String):
         self.send({"method": "scroll_to_bottom"})
 
 
-@register()
+@register('jupyter.Text')
 class Text(_String):
     """Single line textbox widget."""
     _view_name = Unicode('TextView', sync=True)

--- a/IPython/html/widgets/widget_string.py
+++ b/IPython/html/widgets/widget_string.py
@@ -13,7 +13,7 @@ Represents a unicode string using a widget.
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
-from .widget import DOMWidget, CallbackDispatcher
+from .widget import DOMWidget, CallbackDispatcher, register
 from IPython.utils.traitlets import Unicode, Bool
 from IPython.utils.warn import DeprecatedClass
 
@@ -28,17 +28,20 @@ class _String(DOMWidget):
     placeholder = Unicode("", help="Placeholder text to display when nothing has been typed", sync=True)
 
 
+@register()
 class HTML(_String):
     """Renders the string `value` as HTML."""
     _view_name = Unicode('HTMLView', sync=True)
 
 
+@register()
 class Latex(_String):
     """Renders math inside the string `value` as Latex (requires $ $ or $$ $$ 
     and similar latex tags)."""
     _view_name = Unicode('LatexView', sync=True)
 
 
+@register()
 class Textarea(_String):
     """Multiline text area widget."""
     _view_name = Unicode('TextareaView', sync=True)
@@ -47,6 +50,7 @@ class Textarea(_String):
         self.send({"method": "scroll_to_bottom"})
 
 
+@register()
 class Text(_String):
     """Single line textbox widget."""
     _view_name = Unicode('TextView', sync=True)

--- a/IPython/html/widgets/widget_string.py
+++ b/IPython/html/widgets/widget_string.py
@@ -28,20 +28,20 @@ class _String(DOMWidget):
     placeholder = Unicode("", help="Placeholder text to display when nothing has been typed", sync=True)
 
 
-@register('jupyter.HTML')
+@register('IPython.HTML')
 class HTML(_String):
     """Renders the string `value` as HTML."""
     _view_name = Unicode('HTMLView', sync=True)
 
 
-@register('jupyter.Latex')
+@register('IPython.Latex')
 class Latex(_String):
     """Renders math inside the string `value` as Latex (requires $ $ or $$ $$ 
     and similar latex tags)."""
     _view_name = Unicode('LatexView', sync=True)
 
 
-@register('jupyter.Textarea')
+@register('IPython.Textarea')
 class Textarea(_String):
     """Multiline text area widget."""
     _view_name = Unicode('TextareaView', sync=True)
@@ -50,7 +50,7 @@ class Textarea(_String):
         self.send({"method": "scroll_to_bottom"})
 
 
-@register('jupyter.Text')
+@register('IPython.Text')
 class Text(_String):
     """Single line textbox widget."""
     _view_name = Unicode('TextView', sync=True)


### PR DESCRIPTION
Widgets classes are registered on definition of the class using a decorator called `register`.

``` Python
@register('custom.Baz')
class Baz(Widget)
    #   ....
```

When not specifying any argument, the view name is used as a key. 

``` Python
@register()
class Baz(Widget)
    #   ....
```

The motivation is twofold: 
1- Creation of Widgets from the JavaScript side
2- Graphical gui building interface, that needs to know about a registry of widgets. 

For the latter case rather than using a registry in the form of a `key: widget_class` dictionary as now, we could have some other metadata store with it:

``` Python
key: {
    class: widget_class, 
    metadata: {}
}
```

The metadata could be used for categorization of widget (control, visualization, container) etc...
