### PR TITLE
Allow widget views to be loaded from require modules

### DIFF
--- a/IPython/html/static/widgets/js/manager.js
+++ b/IPython/html/static/widgets/js/manager.js
@@ -65,9 +65,6 @@ define([
         } else {
             var that = this;
             this.create_view(model, {cell: cell, callback: function(view) {
-                if (view === null) {
-                    console.error("View creation failed", model);
-                }
                 that._handle_display_view(view);
                 if (cell.widget_subarea) {
                     cell.widget_subarea.append(view.$el);

--- a/IPython/html/static/widgets/js/manager.js
+++ b/IPython/html/static/widgets/js/manager.js
@@ -7,7 +7,7 @@ define([
     "jquery",
     "base/js/namespace"
 ], function (_, Backbone, $, IPython) {
-
+    "use strict";
     //--------------------------------------------------------------------
     // WidgetManager class
     //--------------------------------------------------------------------
@@ -93,37 +93,37 @@ define([
     };
     
 
-    WidgetManager.prototype.create_view = function(model, options, view) {
+    WidgetManager.prototype.create_view = function(model, options) {
         // Creates a view for a particular model.
         
         var view_name = model.get('_view_name');
         var view_mod = model.get('_view_module');
-        errback = options.errback || function(err) {console.log(err)};
+        var errback = options.errback || function(err) {console.log(err);};
 
         var instantiate_view = function(ViewType) {
             if (ViewType) {
                 // If a view is passed into the method, use that view's cell as
                 // the cell for the view that is created.
                 options = options || {};
-                if (view !== undefined) {
-                    options.cell = view.options.cell;
+                if (options.parent !== undefined) {
+                    options.cell = options.parent.options.cell;
                 }
 
                 // Create and render the view...
                 var parameters = {model: model, options: options};
-                view = new ViewType(parameters);
+                var view = new ViewType(parameters);
                 view.render();
                 model.on('destroy', view.remove, view);
                 options.callback(view);
             } else {
                 errback({unknown_view: true, view_name: view_name,
-                         view_module: view_mod})
+                         view_module: view_mod});
             }
-        }
+        };
 
         if (view_mod) {
             require([view_mod], function(module) {
-                instantiate_view(module[view_name])
+                instantiate_view(module[view_name]);
             }, errback);
         } else {
             instantiate_view(WidgetManager._view_types[view_name]);

--- a/IPython/html/static/widgets/js/manager.js
+++ b/IPython/html/static/widgets/js/manager.js
@@ -95,6 +95,11 @@ define([
 
     WidgetManager.prototype.create_view = function(model, options, view) {
         // Creates a view for a particular model.
+        
+        var view_name = model.get('_view_name');
+        var view_mod = model.get('_view_module');
+        errback = options.errback || function(err) {console.log(err)};
+
         var instantiate_view = function(ViewType) {
             if (ViewType) {
                 // If a view is passed into the method, use that view's cell as
@@ -110,15 +115,16 @@ define([
                 view.render();
                 model.on('destroy', view.remove, view);
                 options.callback(view);
+            } else {
+                errback({unknown_view: true, view_name: view_name,
+                         view_module: view_mod})
             }
         }
-        
-        var view_name = model.get('_view_name');
-        var view_mod = model.get('_view_module');
+
         if (view_mod) {
             require([view_mod], function(module) {
                 instantiate_view(module[view_name])
-            });
+            }, errback);
         } else {
             instantiate_view(WidgetManager._view_types[view_name]);
         }

--- a/IPython/html/static/widgets/js/manager.js
+++ b/IPython/html/static/widgets/js/manager.js
@@ -115,7 +115,7 @@ define([
         
         var view_name = model.get('_view_name');
         var view_mod = model.get('_view_module');
-        if (!view_mod) {
+        if (view_mod) {
             require([view_mod], function(module) {
                 instantiate_view(module[view_name])
             });

--- a/IPython/html/static/widgets/js/manager.js
+++ b/IPython/html/static/widgets/js/manager.js
@@ -115,8 +115,7 @@ define([
         
         var view_name = model.get('_view_name');
         var view_mod = model.get('_view_module');
-        if (view_mod !== '') {
-            console.log(view_mod);
+        if (!view_mod) {
             require([view_mod], function(module) {
                 instantiate_view(module[view_name])
             });

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -308,7 +308,7 @@ define(["widgets/js/manager",
             // Update view to be consistent with this.model
         },
 
-        create_child_view: function(child_model, callback, options) {
+        create_child_view: function(child_model, options) {
             // Create and return a child view.
             //
             // -given a model and (optionally) a view name if the view name is 
@@ -318,6 +318,7 @@ define(["widgets/js/manager",
             // it would be great to have the widget manager add the cell metadata
             // to the subview without having to add it here.
             var that = this;
+            var old_callback = options.callback || function(view) {};
             options = $.extend({ parent: this, callback: function(child_view) {
                 // Associate the view id with the model id.
                 if (that.child_model_views[child_model.id] === undefined) {
@@ -327,7 +328,7 @@ define(["widgets/js/manager",
 
                 // Remember the view by id.
                 that.child_views[child_view.id] = child_view;
-                callback(child_view);
+                old_callback(child_view);
              }}, options || {});
             
             this.model.widget_manager.create_view(child_model, options, this);

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -331,7 +331,7 @@ define(["widgets/js/manager",
                 old_callback(child_view);
              }}, options || {});
             
-            this.model.widget_manager.create_view(child_model, options, this);
+            this.model.widget_manager.create_view(child_model, options);
         },
 
         pop_child_view: function(child_model) {

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -308,7 +308,7 @@ define(["widgets/js/manager",
             // Update view to be consistent with this.model
         },
 
-        create_child_view: function(child_model, options) {
+        create_child_view: function(child_model, callback, options) {
             // Create and return a child view.
             //
             // -given a model and (optionally) a view name if the view name is 
@@ -317,18 +317,20 @@ define(["widgets/js/manager",
             // TODO: this is hacky, and makes the view depend on this cell attribute and widget manager behavior
             // it would be great to have the widget manager add the cell metadata
             // to the subview without having to add it here.
-            options = $.extend({ parent: this }, options || {});
-            var child_view = this.model.widget_manager.create_view(child_model, options, this);
-            
-            // Associate the view id with the model id.
-            if (this.child_model_views[child_model.id] === undefined) {
-                this.child_model_views[child_model.id] = [];
-            }
-            this.child_model_views[child_model.id].push(child_view.id);
+            var that = this;
+            options = $.extend({ parent: this, callback: function(child_view) {
+                // Associate the view id with the model id.
+                if (that.child_model_views[child_model.id] === undefined) {
+                    that.child_model_views[child_model.id] = [];
+                }
+                that.child_model_views[child_model.id].push(child_view.id);
 
-            // Remember the view by id.
-            this.child_views[child_view.id] = child_view;
-            return child_view;
+                // Remember the view by id.
+                that.child_views[child_view.id] = child_view;
+                callback(child_view);
+             }}, options || {});
+            
+            this.model.widget_manager.create_view(child_model, options, this);
         },
 
         pop_child_view: function(child_model) {

--- a/IPython/html/static/widgets/js/widget_box.js
+++ b/IPython/html/static/widgets/js/widget_box.js
@@ -74,12 +74,14 @@ define([
 
         add_child_model: function(model) {
             // Called when a model is added to the children list.
-            var view = this.create_child_view(model);
-            this.$box.append(view.$el);
+            var that = this;
+            this.create_child_view(model, function(view) {
+                that.$box.append(view.$el);
 
-            // Trigger the displayed event of the child view.
-            this.after_displayed(function() {
-                view.trigger('displayed');
+                // Trigger the displayed event of the child view.
+                that.after_displayed(function() {
+                    view.trigger('displayed');
+                });
             });
         },
     });

--- a/IPython/html/static/widgets/js/widget_box.js
+++ b/IPython/html/static/widgets/js/widget_box.js
@@ -75,14 +75,14 @@ define([
         add_child_model: function(model) {
             // Called when a model is added to the children list.
             var that = this;
-            this.create_child_view(model, function(view) {
+            this.create_child_view(model, {callback: function(view) {
                 that.$box.append(view.$el);
 
                 // Trigger the displayed event of the child view.
                 that.after_displayed(function() {
                     view.trigger('displayed');
                 });
-            });
+            }});
         },
     });
 

--- a/IPython/html/static/widgets/js/widget_selectioncontainer.js
+++ b/IPython/html/static/widgets/js/widget_selectioncontainer.js
@@ -81,7 +81,6 @@ define([
 
         add_child_model: function(model) {
             // Called when a child is added to children list.
-            var view = this.create_child_view(model);
             var index = this.containers.length;
             var uuid = utils.uuid();
             var accordion_group = $('<div />')
@@ -114,14 +113,17 @@ define([
             var container_index = this.containers.push(accordion_group) - 1;
             accordion_group.container_index = container_index;
             this.model_containers[model.id] = accordion_group;
-            accordion_inner.append(view.$el);
+            
+            this.create_child_view(model, function(view) {
+                accordion_inner.append(view.$el);
 
-            this.update();
-            this.update_titles();
+                that.update();
+                that.update_titles();
 
-            // Trigger the displayed event of the child view.
-            this.after_displayed(function() {
-                view.trigger('displayed');
+                // Trigger the displayed event of the child view.
+                that.after_displayed(function() {
+                    view.trigger('displayed');
+                });
             });
         },
     });
@@ -176,7 +178,6 @@ define([
 
         add_child_model: function(model) {
             // Called when a child is added to children list.
-            var view = this.create_child_view(model);
             var index = this.containers.length;
             var uuid = utils.uuid();
 
@@ -184,33 +185,36 @@ define([
             var tab = $('<li />')
                 .css('list-style-type', 'none')
                 .appendTo(this.$tabs);
-            view.parent_tab = tab;
-
-            var tab_text = $('<a />')
-                .attr('href', '#' + uuid)
-                .attr('data-toggle', 'tab') 
-                .text('Page ' + index)
-                .appendTo(tab)
-                .click(function (e) {
             
-                    // Calling model.set will trigger all of the other views of the 
-                    // model to update.
-                    that.model.set("selected_index", index, {updated_view: this});
-                    that.touch();
-                    that.select_page(index);
+            this.create_child_view(model, function(view) {
+                view.parent_tab = tab;
+
+                var tab_text = $('<a />')
+                    .attr('href', '#' + uuid)
+                    .attr('data-toggle', 'tab') 
+                    .text('Page ' + index)
+                    .appendTo(tab)
+                    .click(function (e) {
+                
+                        // Calling model.set will trigger all of the other views of the 
+                        // model to update.
+                        that.model.set("selected_index", index, {updated_view: that});
+                        that.touch();
+                        that.select_page(index);
+                    });
+                tab.tab_text_index = that.containers.push(tab_text) - 1;
+
+                var contents_div = $('<div />', {id: uuid})
+                    .addClass('tab-pane')
+                    .addClass('fade')
+                    .append(view.$el)
+                    .appendTo(that.$tab_contents);
+                view.parent_container = contents_div;
+
+                // Trigger the displayed event of the child view.
+                that.after_displayed(function() {
+                    view.trigger('displayed');
                 });
-            tab.tab_text_index = this.containers.push(tab_text) - 1;
-
-            var contents_div = $('<div />', {id: uuid})
-                .addClass('tab-pane')
-                .addClass('fade')
-                .append(view.$el)
-                .appendTo(this.$tab_contents);
-            view.parent_container = contents_div;
-
-            // Trigger the displayed event of the child view.
-            this.after_displayed(function() {
-                view.trigger('displayed');
             });
         },
 

--- a/IPython/html/static/widgets/js/widget_selectioncontainer.js
+++ b/IPython/html/static/widgets/js/widget_selectioncontainer.js
@@ -114,7 +114,7 @@ define([
             accordion_group.container_index = container_index;
             this.model_containers[model.id] = accordion_group;
             
-            this.create_child_view(model, function(view) {
+            this.create_child_view(model, {callback: function(view) {
                 accordion_inner.append(view.$el);
 
                 that.update();
@@ -124,7 +124,7 @@ define([
                 that.after_displayed(function() {
                     view.trigger('displayed');
                 });
-            });
+            }});
         },
     });
     
@@ -186,7 +186,7 @@ define([
                 .css('list-style-type', 'none')
                 .appendTo(this.$tabs);
             
-            this.create_child_view(model, function(view) {
+            this.create_child_view(model, {callback: function(view) {
                 view.parent_tab = tab;
 
                 var tab_text = $('<a />')
@@ -215,7 +215,7 @@ define([
                 that.after_displayed(function() {
                     view.trigger('displayed');
                 });
-            });
+            }});
         },
 
         update: function(options) {

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -100,6 +100,8 @@ class Widget(LoggingConfigurable):
     #-------------------------------------------------------------------------
     _model_name = Unicode('WidgetModel', help="""Name of the backbone model 
         registered in the front-end to create and sync this widget with.""")
+    _view_module = Unicode('', help="""A requirejs module in which to find _view_name.
+        If empty, look in the global registry.""", sync=True)
     _view_name = Unicode(None, allow_none=True, help="""Default view registered in the front-end
         to use to represent the widget.""", sync=True)
     comm = Instance('IPython.kernel.comm.Comm')

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -100,7 +100,7 @@ class Widget(LoggingConfigurable):
     #-------------------------------------------------------------------------
     _model_name = Unicode('WidgetModel', help="""Name of the backbone model 
         registered in the front-end to create and sync this widget with.""")
-    _view_module = Unicode('', help="""A requirejs module in which to find _view_name.
+    _view_module = Unicode(help="""A requirejs module in which to find _view_name.
         If empty, look in the global registry.""", sync=True)
     _view_name = Unicode(None, allow_none=True, help="""Default view registered in the front-end
         to use to represent the widget.""", sync=True)


### PR DESCRIPTION
As discussed previously, this is a significant improvement for building widgets outside of IPython, because from the Python side, you can install the Javascript, load it and display the widget all in one go - previously you had to leave an arbitrary gap between loading the nbextension and displaying the widget, to allow time for the extension to load asynchronously and register the widget view class. I have already adapted [mobilechelonian](https://github.com/takluyver/mobilechelonian/tree/require-widgets) to use this.

This required refactoring things that create widget views to use callbacks instead of return values, because require loads modules asynchronously.

I plan to do the same for comm targets, which have a similar global registry, and the same problem with async loading. But I wanted to get this up for review first.
