### PR TITLE
Throw an error when a view is not registered, so it's clear why a view creation failed

### DIFF
--- a/IPython/html/static/widgets/js/manager.js
+++ b/IPython/html/static/widgets/js/manager.js
@@ -109,8 +109,9 @@ define([
             view.render();
             model.on('destroy', view.remove, view);
             return view;
+        } else {
+            throw new Error("View name "+view_name+" is not registered");
         }
-        return null;
     };
 
     WidgetManager.prototype.get_msg_cell = function (msg_id) {


### PR DESCRIPTION
Currently, if a view is not registered, then it just silently returns null and code fails later on.  This change makes the error more explicit and catchable.
