### PR TITLE
Fix font-awesome icons in examples notebook

### DIFF
--- a/examples/Notebook/Notebook Basics.ipynb
+++ b/examples/Notebook/Notebook Basics.ipynb
@@ -1,7 +1,16 @@
 {
  "metadata": {
+  "kernelspec": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "display_name": "IPython (Python 3)",
+   "language": "python",
+   "name": "python3"
+  },
   "name": "",
-  "signature": "sha256:1a6a6a01ea6dbb9b101174c11ba522cb145e4a070685a43a71b5ccdb75672909"
+  "signature": "sha256:6e4f35a8bc2cb1408b995bc3c006369dd3c3e31a3e6212088f3d1e2abef36407"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -198,9 +207,9 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "The second idea of mouse based navigation is that **cell actions usually apply to the currently selected cell**. Thus if you want to run the code in a cell, you would select it and click the <button><i class=\"icon-play\"></i></button> button in the toolbar or the \"Cell:Run\" menu item. Similarly, to copy a cell you would select it and click the <button><i class=\"icon-copy\"></i></button> button in the toolbar or the \"Edit:Copy\" menu item. With this simple pattern, you should be able to do most everything you need with the mouse.\n",
+      "The second idea of mouse based navigation is that **cell actions usually apply to the currently selected cell**. Thus if you want to run the code in a cell, you would select it and click the <button class='btn btn-default btn-xs'><i class=\"fa fa-play icon-play\"></i></button> button in the toolbar or the \"Cell:Run\" menu item. Similarly, to copy a cell you would select it and click the <button class='btn btn-default btn-xs'><i class=\"fa fa-copy icon-copy\"></i></button> button in the toolbar or the \"Edit:Copy\" menu item. With this simple pattern, you should be able to do most everything you need with the mouse.\n",
       "\n",
-      "Markdown and heading cells have one other state that can be modified with the mouse. These cells can either be rendered or unrendered. When they are rendered, you will see a nice formatted representation of the cell's contents. When they are unrendered, you will see the raw text source of the cell. To render the selected cell with the mouse, click the <button><i class=\"icon-play\"></i></button> button in the toolbar or the \"Cell:Run\" menu item. To unrender the selected cell, double click on the cell."
+      "Markdown and heading cells have one other state that can be modified with the mouse. These cells can either be rendered or unrendered. When they are rendered, you will see a nice formatted representation of the cell's contents. When they are unrendered, you will see the raw text source of the cell. To render the selected cell with the mouse, click the <button class='btn btn-default btn-xs'><i class=\"fa fa-play icon-play\"></i></button> button in the toolbar or the \"Cell:Run\" menu item. To unrender the selected cell, double click on the cell."
      ]
     },
     {

--- a/examples/Notebook/Running Code.ipynb
+++ b/examples/Notebook/Running Code.ipynb
@@ -1,7 +1,16 @@
 {
  "metadata": {
+  "kernelspec": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "display_name": "IPython (Python 3)",
+   "language": "python",
+   "name": "python3"
+  },
   "name": "",
-  "signature": "sha256:f04198d3d69e0ecb1f8e08c92dcaf5942793c65e81e19e168b2b53e6fecaf223"
+  "signature": "sha256:55c4f2c75812ec42ca18dcd7e895a056a3faa0e6d567893faf8c85345016be06"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -35,7 +44,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Run a code cell using `Shift-Enter` or pressing the <button><i class=\"icon-play fa fa-play\"></i></button> button in the toolbar above:"
+      "Run a code cell using `Shift-Enter` or pressing the <button class='btn btn-default btn-xs'><i class=\"icon-play fa fa-play\"></i></button> button in the toolbar above:"
      ]
     },
     {
@@ -90,7 +99,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Code is run in a separate process called the IPython Kernel.  The Kernel can be interrupted or restarted.  Try running the following cell and then hit the <button><i class='icon-stop fa fa-stop'></i></button> button in the toolbar above."
+      "Code is run in a separate process called the IPython Kernel.  The Kernel can be interrupted or restarted.  Try running the following cell and then hit the <button class='btn btn-default btn-xs'><i class='icon-stop fa fa-stop'></i></button> button in the toolbar above."
      ]
     },
     {
@@ -161,7 +170,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "The kernel maintains the state of a notebook's computations. You can reset this state by restarting the kernel. This is done by clicking on the <button><i class='icon-repeat'></i></button> in the toolbar above."
+      "The kernel maintains the state of a notebook's computations. You can reset this state by restarting the kernel. This is done by clicking on the <button class='btn btn-default btn-xs'><i class='fa fa-repeat icon-repeat'></i></button> in the toolbar above."
      ]
     },
     {
@@ -250,62 +259,13 @@
        "stream": "stdout",
        "text": [
         "0\n",
-        "1"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "2"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "3"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "4"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "5"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "6"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "7"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n"
+        "1\n",
+        "2\n",
+        "3\n",
+        "4\n",
+        "5\n",
+        "6\n",
+        "7\n"
        ]
       }
      ],


### PR DESCRIPTION
just add `class="btn btn-default btn-xs"` and `fa fa-xxx` to all `<buttons><i></i><button>`.

Closes #6417

@ellisonbg if you work on docs, you might want to cherry-pick that so that there is no conflict ! 
