### PR TITLE
Skip exceptions

### DIFF
--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -266,9 +266,13 @@ define([
      * Execute current code cell to the kernel
      * @method execute
      */
-    CodeCell.prototype.execute = function () {
+    CodeCell.prototype.execute = function (skip_exceptions) {
         this.output_area.clear_output();
         
+        if(typeof skip_exceptions === 'undefined') {
+            skip_exceptions = false;
+        }
+
         // Clear widget area
         this.widget_subarea.html('');
         this.widget_subarea.height('');
@@ -283,7 +287,7 @@ define([
         var callbacks = this.get_callbacks();
         
         var old_msg_id = this.last_msg_id;
-        this.last_msg_id = this.kernel.execute(this.get_text(), callbacks, {silent: false, store_history: true});
+        this.last_msg_id = this.kernel.execute(this.get_text(), callbacks, {silent: false, store_history: true, skip_exceptions : skip_exceptions});
         if (old_msg_id) {
             delete CodeCell.msg_cells[old_msg_id];
         }

--- a/IPython/html/tests/notebook/execute_code.js
+++ b/IPython/html/tests/notebook/execute_code.js
@@ -75,4 +75,23 @@ casper.notebook_test(function () {
         var result = this.get_output_cell(0);
         this.test.assertEquals(result.text, '13\n', 'cell execute (using "play" toolbar button)')
     });
+
+    this.thenEvaluate(function () {
+        var cell0 = IPython.notebook.get_cell(0);
+        cell0.set_text('raise IOError');
+        IPython.notebook.insert_cell_below('code',0);
+        var cell1 = IPython.notebook.get_cell(1);
+        cell1.set_text('a=14; print(a)');      
+        
+        cell0.execute(skip_exception=true);
+        cell1.execute();
+    });
+    
+    this.wait_for_output(1);
+    
+    this.then(function () {
+        var result = this.get_output_cell(1);
+        this.test.assertEquals(result.text, '14\n', 'cell execute, skip exceptions');
+    });
+    
 });

--- a/IPython/kernel/zmq/kernelbase.py
+++ b/IPython/kernel/zmq/kernelbase.py
@@ -341,6 +341,11 @@ class Kernel(Configurable):
             self.log.error("%s", parent)
             return
         
+        if u'skip_exceptions' in content and content[u'skip_exceptions']:
+            skip_exceptions = True
+        else:
+            skip_exceptions = False
+
         md = self._make_metadata(parent['metadata'])
         
         # Re-broadcast our input for the benefit of listening clients, and
@@ -375,7 +380,7 @@ class Kernel(Configurable):
         
         self.log.debug("%s", reply_msg)
 
-        if not silent and reply_msg['content']['status'] == u'error':
+        if not silent and reply_msg['content']['status'] == u'error' and not skip_exceptions:
             self._abort_queues()
 
     def do_execute(self, code, silent, store_history=True,

--- a/docs/source/development/messaging.rst
+++ b/docs/source/development/messaging.rst
@@ -281,6 +281,10 @@ Message type: ``execute_request``::
     # If raw_input is called from code executed from such a frontend,
     # a StdinNotImplementedError will be raised.
     'allow_stdin' : True,
+    
+    # A boolean flag, which, if True, does not abort the execution queue, if an exception is encountered.
+    # This allows the queued execution of multiple execute_requests, even if they generate exceptions.
+    'skip_exceptions' : True,
     }
 
 .. versionchanged:: 5.0


### PR DESCRIPTION
This PR implements a way to skip over exceptions when running codecells in a notebook, as discussed in https://github.com/ipython/ipython/pull/4993 by @astrofrog. This is a rebase of the two core files, adds documentation and a JS test.

The Javascript code to run all cells in a notebook while skipping exceptions then looks like this:

``` Javascript
for (var i=0; i < IPython.notebook.ncells(); i++) {
    IPython.notebook.select(i);
    var cell = IPython.notebook.get_selected_cell();
    cell.execute(skip_exceptions=true);
    }
```
