### PR TITLE
codemirror repo moved, update links in comments

### DIFF
--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -11,7 +11,7 @@ define([
 
     // monkey patch CM to be able to syntax highlight cell magics
     // bug reported upstream,
-    // see https://github.com/marijnh/CodeMirror2/issues/670
+    // see https://github.com/codemirror/CodeMirror/issues/670
     if(CodeMirror.getMode(1,'text/plain').indent === undefined ){
         CodeMirror.modes.null = function() {
             return {token: function(stream) {stream.skipToEnd();},indent : function(){return 0;}};
@@ -89,7 +89,7 @@ define([
     
     // FIXME: Workaround CM Bug #332 (Safari segfault on drag)
     // by disabling drag/drop altogether on Safari
-    // https://github.com/marijnh/CodeMirror/issues/332    
+    // https://github.com/codemirror/CodeMirror/issues/332    
     if (utils.browser[0] == "Safari") {
         Cell.options_default.cm_config.dragDrop = false;
     }

--- a/IPython/html/static/notebook/js/codemirror-ipythongfm.js
+++ b/IPython/html/static/notebook/js/codemirror-ipythongfm.js
@@ -2,9 +2,9 @@
 // Mode with support for latex. 
 //
 // Latex support was supported by Codemirror GFM as of 
-//   https://github.com/marijnh/CodeMirror/pull/567
+//   https://github.com/codemirror/CodeMirror/pull/567
 // But was later removed in
-//   https://github.com/marijnh/CodeMirror/commit/d9c9f1b1ffe984aee41307f3e927f80d1f23590c
+//   https://github.com/codemirror/CodeMirror/commit/d9c9f1b1ffe984aee41307f3e927f80d1f23590c
 
 CodeMirror.requireMode('gfm', function(){ 
     CodeMirror.requireMode('stex', function(){ 


### PR DESCRIPTION
Should probably update IPython components too when bower repo up to date.
