### PR TITLE
Fix Issue #6530

### DIFF
--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -422,6 +422,8 @@ define(["widgets/js/manager",
     });
 
 
+    widgetmanager.WidgetManager.register_widget_view('WidgetView', WidgetView);
+
     var DOMWidgetView = WidgetView.extend({
         initialize: function (parameters) {
             // Public constructor
@@ -593,6 +595,8 @@ define(["widgets/js/manager",
         },
     });
 
+    widgetmanager.WidgetManager.register_widget_view('DOMWidgetView', DOMWidgetView);
+    
     var widget = {
         'WidgetModel': WidgetModel,
         'WidgetView': WidgetView,

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -422,8 +422,6 @@ define(["widgets/js/manager",
     });
 
 
-    widgetmanager.WidgetManager.register_widget_view('WidgetView', WidgetView);
-
     var DOMWidgetView = WidgetView.extend({
         initialize: function (parameters) {
             // Public constructor
@@ -595,7 +593,6 @@ define(["widgets/js/manager",
         },
     });
 
-    widgetmanager.WidgetManager.register_widget_view('DOMWidgetView', DOMWidgetView);
     
     var widget = {
         'WidgetModel': WidgetModel,

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -100,7 +100,7 @@ class Widget(LoggingConfigurable):
     #-------------------------------------------------------------------------
     _model_name = Unicode('WidgetModel', help="""Name of the backbone model 
         registered in the front-end to create and sync this widget with.""")
-    _view_name = Unicode('WidgetView', help="""Default view registered in the front-end
+    _view_name = Unicode(None, allow_none=True, help="""Default view registered in the front-end
         to use to represent the widget.""", sync=True)
     comm = Instance('IPython.kernel.comm.Comm')
     
@@ -368,10 +368,10 @@ class Widget(LoggingConfigurable):
 
     def _ipython_display_(self, **kwargs):
         """Called when `IPython.display.display` is called on the widget."""
-        # Show view.  By sending a display message, the comm is opened and the
-        # initial state is sent.
-        self._send({"method": "display"})
-        self._handle_displayed(**kwargs)
+        # Show view.
+        if self._view_name is not None:
+            self._send({"method": "display"})
+            self._handle_displayed(**kwargs)
 
     def _send(self, msg):
         """Sends a message to the model in the front-end."""


### PR DESCRIPTION
@jdfreder A quick fix to #6530. Widget and DOMWidget' s view name is set to None. Widgets without a view are not displayed anymore, like what Thomas suggested earlier
