### PR TITLE
Remove kernel config from parent config files

### DIFF
--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -123,7 +123,16 @@ class Application(SingletonConfigurable):
 
     # A sequence of Configurable subclasses whose config=True attributes will
     # be exposed at the command line.
-    classes = List([])
+    classes = []
+    @property
+    def _help_classes(self):
+        """Define `App.help_classes` if CLI classes should differ from config file classes"""
+        return getattr(self, 'help_classes', self.classes)
+    
+    @property
+    def _config_classes(self):
+        """Define `App.config_classes` if config file classes should differ from CLI classes."""
+        return getattr(self, 'config_classes', self.classes)
 
     # The version string of this application.
     version = Unicode(u'0.0')
@@ -256,7 +265,7 @@ class Application(SingletonConfigurable):
 
         lines = []
         classdict = {}
-        for cls in self.classes:
+        for cls in self._help_classes:
             # include all parents (up to, but excluding Configurable) in available names
             for c in cls.mro()[:-3]:
                 classdict[c.__name__] = c
@@ -331,7 +340,8 @@ class Application(SingletonConfigurable):
         self.print_options()
 
         if classes:
-            if self.classes:
+            help_classes = self._help_classes
+            if help_classes:
                 print("Class parameters")
                 print("----------------")
                 print()
@@ -339,7 +349,7 @@ class Application(SingletonConfigurable):
                     print(p)
                     print()
 
-            for cls in self.classes:
+            for cls in help_classes:
                 cls.class_print_help()
                 print()
         else:
@@ -412,7 +422,7 @@ class Application(SingletonConfigurable):
         # it will be a dict by parent classname of classes in our list
         # that are descendents
         mro_tree = defaultdict(list)
-        for cls in self.classes:
+        for cls in self._help_classes:
             clsname = cls.__name__
             for parent in cls.mro()[1:-3]:
                 # exclude cls itself and Configurable,HasTraits,object
@@ -530,7 +540,7 @@ class Application(SingletonConfigurable):
         lines.append('')
         lines.append('c = get_config()')
         lines.append('')
-        for cls in self.classes:
+        for cls in self._config_classes:
             lines.append(cls.class_config_section())
         return '\n'.join(lines)
 

--- a/IPython/consoleapp.py
+++ b/IPython/consoleapp.py
@@ -7,11 +7,6 @@ refactoring of what used to be the IPython/qt/console/qtconsoleapp.py
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
-
-# stdlib imports
 import atexit
 import os
 import signal
@@ -19,7 +14,6 @@ import sys
 import uuid
 
 
-# Local imports
 from IPython.config.application import boolean_flag
 from IPython.core.profiledir import ProfileDir
 from IPython.kernel.blocking import BlockingKernelClient
@@ -40,16 +34,7 @@ from IPython.kernel.zmq.session import Session, default_secure
 from IPython.kernel.zmq.zmqshell import ZMQInteractiveShell
 from IPython.kernel.connect import ConnectionFileMixin
 
-#-----------------------------------------------------------------------------
-# Network Constants
-#-----------------------------------------------------------------------------
-
 from IPython.utils.localinterfaces import localhost
-
-#-----------------------------------------------------------------------------
-# Globals
-#-----------------------------------------------------------------------------
-
 
 #-----------------------------------------------------------------------------
 # Aliases and Flags
@@ -98,11 +83,7 @@ aliases.update(app_aliases)
 # Classes
 #-----------------------------------------------------------------------------
 
-#-----------------------------------------------------------------------------
-# IPythonConsole
-#-----------------------------------------------------------------------------
-
-classes = [IPKernelApp, ZMQInteractiveShell, KernelManager, ProfileDir, Session, InlineBackend]
+classes = [KernelManager, ProfileDir, Session]
 
 class IPythonConsoleApp(ConnectionFileMixin):
     name = 'ipython-console-mixin'
@@ -158,8 +139,15 @@ class IPythonConsoleApp(ConnectionFileMixin):
         Set to display confirmation dialog on exit. You can always use 'exit' or 'quit',
         to force a direct exit without any confirmation.""",
     )
-
-
+    
+    @property
+    def help_classes(self):
+        """ConsoleApps can configure kernels on the command-line
+        
+        But this shouldn't be written to a file
+        """
+        return self.classes + [IPKernelApp] + IPKernelApp.classes
+    
     def build_kernel_argv(self, argv=None):
         """build argv to be passed to kernel subprocess"""
         if argv is None:

--- a/IPython/core/profileapp.py
+++ b/IPython/core/profileapp.py
@@ -261,6 +261,7 @@ class ProfileCreate(BaseIPythonApplication):
         from IPython.terminal.ipapp import TerminalIPythonApp
         apps = [TerminalIPythonApp]
         for app_path in (
+            'IPython.kernel.zmq.kernelapp.IPKernelApp',
             'IPython.qt.console.qtconsoleapp.IPythonQtConsoleApp',
             'IPython.html.notebookapp.NotebookApp',
             'IPython.nbconvert.nbconvertapp.NbConvertApp',

--- a/IPython/kernel/zmq/kernelapp.py
+++ b/IPython/kernel/zmq/kernelapp.py
@@ -97,7 +97,7 @@ To read more about this, see https://github.com/ipython/ipython/issues/2049
 
 class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
         ConnectionFileMixin):
-    name='ipkernel'
+    name='ipython-kernel'
     aliases = Dict(kernel_aliases)
     flags = Dict(kernel_flags)
     classes = [IPythonKernel, ZMQInteractiveShell, ProfileDir, Session]
@@ -113,10 +113,6 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
     poller = Any() # don't restrict this even though current pollers are all Threads
     heartbeat = Instance(Heartbeat)
     ports = Dict()
-    
-    # ipkernel doesn't get its own config file
-    def _config_file_name_default(self):
-        return 'ipython_config.py'
     
     # connection info:
     

--- a/docs/autogen_config.py
+++ b/docs/autogen_config.py
@@ -70,11 +70,12 @@ if __name__ == '__main__':
 
     write_doc('terminal', 'Terminal IPython options', TerminalIPythonApp().classes)
     write_doc('kernel', 'IPython kernel options', kernel_classes,
-              preamble="These options can be used in :file:`ipython_notebook_config.py` "
-              "or in :file:`ipython_qtconsole_config.py`")
+        preamble="These options can be used in :file:`ipython_kernel_config.py`",
+    )
     nbclasses = set(NotebookApp().classes) - set(kernel_classes)
     write_doc('notebook', 'IPython notebook options', nbclasses,
-              preamble="Any of the :doc:`kernel` can also be used.")
+        preamble="To configure the IPython kernel, see :doc:`kernel`."
+    )
 
     try:
         from IPython.qt.console.qtconsoleapp import IPythonQtConsoleApp
@@ -84,5 +85,6 @@ if __name__ == '__main__':
     else:
         qtclasses = set(IPythonQtConsoleApp().classes) - set(kernel_classes)
         write_doc('qtconsole', 'IPython Qt console options', qtclasses,
-                  preamble="Any of the :doc:`kernel` can also be used.")
+        preamble="To configure the IPython kernel, see :doc:`kernel`."
+    )
 

--- a/docs/source/notebook/public_server.rst
+++ b/docs/source/notebook/public_server.rst
@@ -95,9 +95,6 @@ commented; the minimum set you need to uncomment and edit is the following::
 
      c = get_config()
 
-     # Kernel config
-     c.IPKernelApp.pylab = 'inline'  # if you want plotting support always
-
      # Notebook config
      c.NotebookApp.certfile = u'/absolute/path/to/your/certificate/mycert.pem'
      c.NotebookApp.ip = '*'


### PR DESCRIPTION
those config files are no longer read by the kernel
- Allow `--help` and config_file class lists to differ (due to weird mixin behavior)
- Add `ipython_kernel_config.py`
- kernel config still shows up in `qtconsole --help`,
  but not in the `ipython_qtconsole_config.py`
- [x] Still need to check any docs that refer to putting kernel config in the parent app's config file.

closes #6533
