### PR TITLE
Clean up notification widget

### DIFF
--- a/IPython/html/static/notebook/js/notificationwidget.js
+++ b/IPython/html/static/notebook/js/notificationwidget.js
@@ -7,6 +7,13 @@ define([
 ], function(IPython, $) {
     "use strict";
 
+    /**
+     * Construct a NotificationWidget object.
+     *
+     * @constructor
+     * @param {string} selector - a jQuery selector string for the
+     * notification widget element
+     */
     var NotificationWidget = function (selector) {
         this.selector = selector;
         this.timeout = null;

--- a/IPython/html/static/notebook/js/notificationwidget.js
+++ b/IPython/html/static/notebook/js/notificationwidget.js
@@ -90,7 +90,7 @@ define([
 
         // bind the click callback if it is given
         if (click_callback !== undefined) {
-            this.element.click(function() {
+            this.element.click(function () {
                 if (click_callback() !== false) {
                     that.element.fadeOut(100, function () {that.inner.text('');});
                 }
@@ -105,7 +105,8 @@ define([
 
     /**
      * Display an information message (styled with the 'info'
-     * class). Arguments are the same as in set_message.
+     * class). Arguments are the same as in set_message. Default
+     * timeout is 3500 milliseconds.
      *
      * @method info
      */

--- a/IPython/html/static/notebook/js/notificationwidget.js
+++ b/IPython/html/static/notebook/js/notificationwidget.js
@@ -16,11 +16,8 @@ define([
             this.style();
         }
         this.element.hide();
-        var that = this;
-
         this.inner = $('<span/>');
         this.element.append(this.inner);
-
     };
 
     NotificationWidget.prototype.style = function () {
@@ -34,9 +31,8 @@ define([
     // click_callback : function called if user click on notification
     // could return false to prevent the notification to be dismissed
     NotificationWidget.prototype.set_message = function (msg, timeout, click_callback, options) {
-        var options = options || {};
-        var callback = click_callback || function() {return true;};
-        var that = this;
+        options = options || {};
+
         // unbind potential previous callback
         this.element.unbind('click');
         this.inner.attr('class', options.icon);
@@ -48,50 +44,58 @@ define([
         this.element.removeClass();
         this.style();
         if (options.class){
-
-            this.element.addClass(options.class)
+            this.element.addClass(options.class);
         }
+
+        // clear previous timer
         if (this.timeout !== null) {
             clearTimeout(this.timeout);
             this.timeout = null;
         }
-        if (timeout !== undefined && timeout >=0) {
+
+        // set the timer if a timeout is given
+        var that = this;
+        if (timeout !== undefined && timeout >= 0) {
             this.timeout = setTimeout(function () {
                 that.element.fadeOut(100, function () {that.inner.text('');});
+                that.element.unbind('click');
                 that.timeout = null;
             }, timeout);
-        } else {
+        }
+
+        // bind the click callback if it is given
+        if (click_callback !== undefined) {
             this.element.click(function() {
-                if( callback() !== false ) {
+                if (click_callback() !== false) {
                     that.element.fadeOut(100, function () {that.inner.text('');});
                     that.element.unbind('click');
                 }
-                if (that.timeout !== undefined) {
-                    that.timeout = undefined;
+                if (that.timeout !== null) {
                     clearTimeout(that.timeout);
+                    that.timeout = null;
                 }
             });
         }
     };
 
-
     NotificationWidget.prototype.info = function (msg, timeout, click_callback, options) {
-        var options = options || {};
-        options.class = options.class +' info';
-        var timeout = timeout || 3500;
+        options = options || {};
+        options.class = options.class + ' info';
+        timeout = timeout || 3500;
         this.set_message(msg, timeout, click_callback, options);
-    }
-    NotificationWidget.prototype.warning = function (msg, timeout, click_callback, options) {
-        var options = options || {};
-        options.class = options.class +' warning';
-        this.set_message(msg, timeout, click_callback, options);
-    }
-    NotificationWidget.prototype.danger = function (msg, timeout, click_callback, options) {
-        var options = options || {};
-        options.class = options.class +' danger';
-        this.set_message(msg, timeout, click_callback, options);
-    }
+    };
 
+    NotificationWidget.prototype.warning = function (msg, timeout, click_callback, options) {
+        options = options || {};
+        options.class = options.class + ' warning';
+        this.set_message(msg, timeout, click_callback, options);
+    };
+
+    NotificationWidget.prototype.danger = function (msg, timeout, click_callback, options) {
+        options = options || {};
+        options.class = options.class + ' danger';
+        this.set_message(msg, timeout, click_callback, options);
+    };
 
     NotificationWidget.prototype.get_message = function () {
         return this.inner.html();

--- a/IPython/html/static/notebook/js/notificationwidget.js
+++ b/IPython/html/static/notebook/js/notificationwidget.js
@@ -20,16 +20,34 @@ define([
         this.element.append(this.inner);
     };
 
+    /**
+     * Add the 'notification_widget' CSS class to the widget element.
+     *
+     * @method style
+     */
     NotificationWidget.prototype.style = function () {
         this.element.addClass('notification_widget');
     };
 
-    // msg : message to display
-    // timeout : time in ms before diseapearing
-    //
-    // if timeout <= 0
-    // click_callback : function called if user click on notification
-    // could return false to prevent the notification to be dismissed
+    /**
+     * Set the notification widget message to display for a certain
+     * amount of time (timeout).  The widget will be shown forever if
+     * timeout is <= 0 or undefined. If the widget is clicked while it
+     * is still displayed, execute an optional callback
+     * (click_callback). If the callback returns false, it will
+     * prevent the notification from being dismissed.
+     *
+     * Options:
+     *    class - CSS class name for styling
+     *    icon - CSS class name for the widget icon
+     *    title - HTML title attribute for the widget
+     *
+     * @method set_message
+     * @param {string} msg - The notification to display
+     * @param {integer} [timeout] - The amount of time in milliseconds to display the widget
+     * @param {function} [click_callback] - The function to run when the widget is clicked
+     * @param {Object} [options] - Additional options
+     */
     NotificationWidget.prototype.set_message = function (msg, timeout, click_callback, options) {
         options = options || {};
 
@@ -43,7 +61,7 @@ define([
         // reset previous set style
         this.element.removeClass();
         this.style();
-        if (options.class){
+        if (options.class) {
             this.element.addClass(options.class);
         }
 
@@ -68,8 +86,8 @@ define([
             this.element.click(function() {
                 if (click_callback() !== false) {
                     that.element.fadeOut(100, function () {that.inner.text('');});
-                    that.element.unbind('click');
                 }
+                that.element.unbind('click');
                 if (that.timeout !== null) {
                     clearTimeout(that.timeout);
                     that.timeout = null;
@@ -78,6 +96,12 @@ define([
         }
     };
 
+    /**
+     * Display an information message (styled with the 'info'
+     * class). Arguments are the same as in set_message.
+     *
+     * @method info
+     */
     NotificationWidget.prototype.info = function (msg, timeout, click_callback, options) {
         options = options || {};
         options.class = options.class + ' info';
@@ -85,18 +109,36 @@ define([
         this.set_message(msg, timeout, click_callback, options);
     };
 
+    /**
+     * Display a warning message (styled with the 'warning'
+     * class). Arguments are the same as in set_message.
+     *
+     * @method warning
+     */
     NotificationWidget.prototype.warning = function (msg, timeout, click_callback, options) {
         options = options || {};
         options.class = options.class + ' warning';
         this.set_message(msg, timeout, click_callback, options);
     };
 
+    /**
+     * Display a danger message (styled with the 'danger'
+     * class). Arguments are the same as in set_message.
+     *
+     * @method danger
+     */
     NotificationWidget.prototype.danger = function (msg, timeout, click_callback, options) {
         options = options || {};
         options.class = options.class + ' danger';
         this.set_message(msg, timeout, click_callback, options);
     };
 
+    /**
+     * Get the text of the widget message.
+     *
+     * @method get_message
+     * @return {string} - the message text
+     */
     NotificationWidget.prototype.get_message = function () {
         return this.inner.html();
     };

--- a/IPython/html/static/notebook/js/notificationwidget.js
+++ b/IPython/html/static/notebook/js/notificationwidget.js
@@ -119,7 +119,8 @@ define([
 
     /**
      * Display a warning message (styled with the 'warning'
-     * class). Arguments are the same as in set_message.
+     * class). Arguments are the same as in set_message. Messages are
+     * sticky by default.
      *
      * @method warning
      */
@@ -131,7 +132,8 @@ define([
 
     /**
      * Display a danger message (styled with the 'danger'
-     * class). Arguments are the same as in set_message.
+     * class). Arguments are the same as in set_message. Messages are
+     * sticky by default.
      *
      * @method danger
      */

--- a/IPython/html/tests/notebook/notifications.js
+++ b/IPython/html/tests/notebook/notifications.js
@@ -1,0 +1,116 @@
+// Test the notification area and widgets
+
+casper.notebook_test(function () {
+    var that = this;
+    var widget = function (name) {
+        return that.evaluate(function (name) {
+            return (IPython.notification_area.widget(name) !== undefined);
+        }, name);
+    };
+
+    var get_widget = function (name) {
+        return that.evaluate(function (name) {
+            return (IPython.notification_area.get_widget(name) !== undefined);
+        }, name);
+    };
+
+    var new_notification_widget = function (name) {
+        return that.evaluate(function (name) {
+            return (IPython.notification_area.new_notification_widget(name) !== undefined);
+        }, name);
+    };
+
+    var widget_has_class = function (name, class_name) {
+        return that.evaluate(function (name, class_name) {
+            var w = IPython.notification_area.get_widget(name);
+            return w.element.hasClass(class_name);
+        }, name, class_name);
+    };
+
+    var widget_message = function (name) {
+        return that.evaluate(function (name) {
+            var w = IPython.notification_area.get_widget(name);
+            return w.get_message();
+        }, name);
+    };
+
+    this.then(function () {
+        // check that existing widgets are there
+        this.test.assert(get_widget('kernel') && widget('kernel'), 'The kernel notification widget exists');
+        this.test.assert(get_widget('notebook') && widget('notbook'), 'The notebook notification widget exists');
+
+        // try getting a non-existant widget
+        this.test.assertRaises(get_widget, 'foo', 'get_widget: error is thrown');
+
+        // try creating a non-existant widget
+        this.test.assert(widget('bar'), 'widget: new widget is created');
+
+        // try creating a widget that already exists
+        this.test.assertRaises(new_notification_widget, 'kernel', 'new_notification_widget: error is thrown');
+    });
+
+    // test creating 'info' messages
+    this.thenEvaluate(function () {
+        var tnw = IPython.notification_area.widget('test');
+        tnw.info('test info');
+    });
+    this.waitUntilVisible('#notification_test', function () {
+        this.test.assert(widget_has_class('test', 'info'), 'info: class is correct');
+        this.test.assertEquals(widget_message('test'), 'test info', 'info: message is correct');
+    });
+
+    // test creating 'warning' messages
+    this.thenEvaluate(function () {
+        var tnw = IPython.notification_area.widget('test');
+        tnw.warning('test warning');
+    });
+    this.waitUntilVisible('#notification_test', function () {
+        this.test.assert(widget_has_class('test', 'warning'), 'warning: class is correct');
+        this.test.assertEquals(widget_message('test'), 'test warning', 'warning: message is correct');
+    });
+
+    // test creating 'danger' messages
+    this.thenEvaluate(function () {
+        var tnw = IPython.notification_area.widget('test');
+        tnw.danger('test danger');
+    });
+    this.waitUntilVisible('#notification_test', function () {
+        this.test.assert(widget_has_class('test', 'danger'), 'danger: class is correct');
+        this.test.assertEquals(widget_message('test'), 'test danger', 'danger: message is correct');
+    });
+
+    // test message timeout
+    this.thenEvaluate(function () {
+        var tnw = IPython.notification_area.widget('test');
+        tnw.set_message('test timeout', 1000);
+    });
+    this.waitUntilVisible('#notification_test', function () {
+        this.test.assertEquals(widget_message('test'), 'test timeout', 'timeout: message is correct');
+    });
+    this.waitWhileVisible('#notification_test', function () {
+        this.test.assertEquals(widget_message('test'), '', 'timeout: message was cleared');
+    });
+
+    // test click callback
+    this.thenEvaluate(function () {
+        var tnw = IPython.notification_area.widget('test');
+        tnw._clicked = false;
+        tnw.set_message('test click', undefined, function () {
+            tnw._clicked = true;
+            return true;
+        });
+    });
+    this.waitUntilVisible('#notification_test', function () {
+        this.test.assertEquals(widget_message('test'), 'test click', 'callback: message is correct');
+        this.click('#notification_test');
+    });
+    this.waitFor(function () {
+        return this.evaluate(function () {
+            return IPython.notification_area.widget('test')._clicked;
+        });
+    }, function () {
+        this.waitWhileVisible('#notification_test', function () {
+            this.test.assertEquals(widget_message('test'), '', 'callback: message was cleared');
+        });
+    });
+});


### PR DESCRIPTION
As I was working on #6488 and playing with the notification widget, I wanted to have notifications that were clickable _and_ still had a timeout. However, in the current implementation of the notification widget this isn't possible -- you can only have a clickable notification if the timeout is undefined, which means it will stick around forever, which isn't necessarily desirable.

This pull request makes those two features independent, as well as fixing some typos/syntax errors, and adds some documentation to the `NotificationWidget` object.

It doesn't look like there are any tests for `NotificationWidget`, so I might try to add some of those, too.
