### PR TITLE
Adapt pager payloads from v4 to v5

### DIFF
--- a/IPython/core/payloadpage.py
+++ b/IPython/core/payloadpage.py
@@ -37,7 +37,6 @@ def page(strng, start=0, screen_lines=0, pager_cmd=None):
     payload = dict(
         source='page',
         data=data,
-        text=strng,
         start=start,
         screen_lines=screen_lines,
         )

--- a/IPython/kernel/adapter.py
+++ b/IPython/kernel/adapter.py
@@ -222,6 +222,14 @@ class V4toV5(Adapter):
         user_variables = content.pop('user_variables', {})
         if user_variables:
             user_expressions.update(user_variables)
+
+        # Pager payloads became a mime bundle
+        for payload in content.get('payload', []):
+            if payload.get('source', None) == 'page' and ('text' in payload):
+                if 'data' not in payload:
+                    payload['data'] = {}
+                payload['data']['text/plain'] = payload.pop('text')
+
         return msg
     
     def complete_request(self, msg):

--- a/IPython/kernel/tests/test_adapter.py
+++ b/IPython/kernel/tests/test_adapter.py
@@ -86,6 +86,22 @@ class V4toV5TestCase(AdapterTest):
         self.assertEqual(v5c['user_expressions'], {'a' : 'apple', 'b': 'b'})
         self.assertNotIn('user_variables', v5c)
         self.assertEqual(v5c['code'], v4c['code'])
+
+    def test_execute_reply(self):
+        msg = self.msg("execute_reply", {
+            'status': 'ok',
+            'execution_count': 7,
+            'user_variables': {'a': 1},
+            'user_expressions': {'a+a': 2},
+            'payload': [{'source':'page', 'text':'blah'}]
+        })
+        v4, v5 = self.adapt(msg)
+        v5c = v5['content']
+        self.assertNotIn('user_variables', v5c)
+        self.assertEqual(v5c['user_expressions'], {'a': 1, 'a+a': 2})
+        self.assertEqual(v5c['payload'], [{'source': 'page',
+                                           'data': {'text/plain': 'blah'}}
+                                         ])
     
     def test_complete_request(self):
         msg = self.msg("complete_request", {


### PR DESCRIPTION
This was the cause of takluyver/IRkernel#37.

I also noticed that the text key was left over in our own pager payloads, so I removed that.
