### PR TITLE
Update parallel magic doc

### DIFF
--- a/docs/source/parallel/magics.rst
+++ b/docs/source/parallel/magics.rst
@@ -13,7 +13,8 @@ These magics will automatically become available when you create a Client:
 
 .. sourcecode:: ipython
 
-    In [2]: rc = parallel.Client()
+    In [1]: from IPython.parallel import Client
+    In [2]: rc = Client()
 
 The initially active View will have attributes ``targets='all', block=True``,
 which is a blocking view of all engines, evaluated at request time


### PR DESCRIPTION
I added the command to import `IPython.parallel` and imported `Client` from it to be consistent with this page:

http://ipython.org/ipython-doc/dev/parallel/parallel_multiengine.html#creating-a-directview-instance

It's pretty trivial, but people just starting with ipython parrallel may not have seen the appropriate import.

I checked, and `parallel.`... is not used elsewhere in the page, so it shouldn't break other commands to change the import.
