### PR TITLE
Add About IPython

### DIFF
--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -37,6 +37,8 @@ from IPython.html.utils import is_hidden, url_path_join, url_escape
 #-----------------------------------------------------------------------------
 non_alphanum = re.compile(r'[^A-Za-z0-9]')
 
+sys_info = json.dumps(get_sys_info())
+
 class AuthenticatedHandler(web.RequestHandler):
     """A RequestHandler with an authenticated user."""
 
@@ -222,7 +224,7 @@ class IPythonHandler(AuthenticatedHandler):
             logged_in=self.logged_in,
             login_available=self.login_available,
             static_url=self.static_url,
-            sys_info=json.dumps(get_sys_info())
+            sys_info=sys_info
         )
     
     def get_json_body(self):

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -25,6 +25,7 @@ except ImportError:
     app_log = logging.getLogger()
 
 import IPython
+from IPython.utils.sysinfo import get_sys_info
 
 from IPython.config import Application
 from IPython.utils.path import filefind
@@ -221,6 +222,7 @@ class IPythonHandler(AuthenticatedHandler):
             logged_in=self.logged_in,
             login_available=self.login_available,
             static_url=self.static_url,
+            sys_info=json.dumps(get_sys_info())
         )
     
     def get_json_body(self):

--- a/IPython/html/static/notebook/js/about.js
+++ b/IPython/html/static/notebook/js/about.js
@@ -1,0 +1,38 @@
+// Copyright (c) IPython Development Team.
+// Distributed under the terms of the Modified BSD License.
+require([
+    'jquery',
+    'base/js/dialog',
+    'underscore',
+    'base/js/namespace'
+], function ($, dialog, _, IPython) {
+    'use strict';
+    $('#notebook_about').click(function () {
+        // use underscore template to auto html escape
+        var text = 'You are using IPython notebook.<br/><br/>';
+        text = text + 'The version of the notebook server is ';
+        text = text + _.template('<b><%- version %></b>')({ version: sys_info.ipython_version });
+        if (sys_info.commit_hash) {
+            text = text + _.template('-<%- hash %>')({ hash: sys_info.commit_hash });
+        }
+        text = text + _.template(' and is running on:<br/><pre>Python <%- pyver %></pre>')({ pyver: sys_info.sys_version });
+        var kinfo = $('<div/>').attr('id', '#about-kinfo').text('Waiting for kernel to be available...');
+        var body = $('<div/>');
+        body.append($('<h4/>').text('Server Information:'));
+        body.append($('<p/>').html(text));
+        body.append($('<h4/>').text('Current Kernel Information:'));
+        body.append(kinfo);
+        dialog.modal({
+            title: 'About IPython Notebook',
+            body: body,
+            buttons: { 'OK': {} }
+        });
+        try {
+            IPython.notebook.session.kernel.kernel_info(function (data) {
+                kinfo.html($('<pre/>').text(data.content.banner));
+            });
+        } catch (e) {
+            kinfo.html($('<p/>').text('unable to contact kernel'));
+        }
+    });
+});

--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -20,6 +20,7 @@ require([
     'notebook/js/config',
     'notebook/js/kernelselector',
     'codemirror/lib/codemirror',
+    'notebook/js/about',
     // only loaded, not used, please keep sure this is loaded last
     'custom/custom'
 ], function(
@@ -41,6 +42,7 @@ require([
     config,
     kernelselector,
     CodeMirror,
+    about,
     // please keep sure that even if not used, this is loaded last
     custom
     ) {

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -245,7 +245,7 @@ class="notebook_app"
                                     ("http://nbviewer.ipython.org/github/ipython/ipython/tree/2.x/examples/Index.ipynb", "Notebook Help", True),
                                 ),(
                                     ("http://docs.python.org","Python",True),
-                            ("http://help.github.com/articles/github-flavored-markdown","Markdown",True),
+                                    ("http://help.github.com/articles/github-flavored-markdown","Markdown",True),
                                     ("http://docs.scipy.org/doc/numpy/reference/","NumPy",True),
                                     ("http://docs.scipy.org/doc/scipy/reference/","SciPy",True),
                                     ("http://matplotlib.org/contents.html","Matplotlib",True),
@@ -266,7 +266,8 @@ class="notebook_app"
                                 <li class="divider"></li>
                             {% endif %}
                         {% endfor %}
-                        </li>
+                        <li class="divider"></li>
+                        <li title="About IPython Notebook"><a id="notebook_about" href="#">About</a></li>
                     </ul>
                 </li>
             </ul>
@@ -310,6 +311,9 @@ class="notebook_app"
 
 {% block script %}
 {{super()}}
+<script type="text/javascript">
+    sys_info = {{sys_info}};
+</script>
 
 
 <script src="{{ static_url("notebook/js/main.js") }}" charset="utf-8"></script>


### PR DESCRIPTION
Cause it is true that it is difficult by just staring at the screen to guess IPython version, will be even more as the UI stabilize.
Asking user to type things is kinda difficult sometime.

"Scroll down and look at the bottom-right corner of the screen, do you have 3.0 version or above" is easier. 

![capture d'écran 2014-09-26 a 15 42 56](https://cloud.githubusercontent.com/assets/335567/4421307/c6b1336a-4582-11e4-92ba-aee6aab2e7dd.png)

I'm wondering should we have `IPython-Server vX-Y-Z` less confusing than using IPython for everything.
Should I include commit-ish for dev ? 
Seriously considering a more informative `About` dialog.

Yes, the implementation is wonky, cause of that #$%^ pager that imply that not the same div scrolls depending on  pages. 
