### PR TITLE
Use some more informative asserts in inprocess kernel tests

### DIFF
--- a/IPython/kernel/inprocess/tests/test_kernel.py
+++ b/IPython/kernel/inprocess/tests/test_kernel.py
@@ -46,7 +46,7 @@ class InProcessKernelTestCase(unittest.TestCase):
         kc = self.kc
         kc.execute('%pylab')
         msg = get_stream_message(kc)
-        self.assert_('matplotlib' in msg['content']['data'])
+        self.assertIn('matplotlib', msg['content']['data'])
 
     def test_raw_input(self):
         """ Does the in-process kernel handle raw_input correctly?

--- a/IPython/kernel/inprocess/tests/test_kernelmanager.py
+++ b/IPython/kernel/inprocess/tests/test_kernelmanager.py
@@ -32,7 +32,7 @@ class InProcessKernelManagerTestCase(unittest.TestCase):
 
         old_kernel = km.kernel
         km.restart_kernel()
-        self.assert_(km.kernel is not None)
+        self.assertIsNotNone(km.kernel)
         self.assertNotEquals(km.kernel, old_kernel)
 
         km.shutdown_kernel()


### PR DESCRIPTION
Prompted by gh-6552 (but doesn't fix it)
