### PR TITLE
Handle kernel start failures more gracefully

### DIFF
--- a/IPython/html/services/sessions/handlers.py
+++ b/IPython/html/services/sessions/handlers.py
@@ -59,8 +59,10 @@ class SessionRootHandler(IPythonHandler):
                 msg = ("The '%s' kernel is not available. Please pick another "
                        "suitable kernel instead, or install that kernel." % kernel_name)
                 status_msg = 'Kernel not found'
-                msg = dict(full=msg, short=status_msg)
-                raise web.HTTPError(501, json.dumps(msg))
+                self.log.warn('Kernel not found: %s' % kernel_name)
+                self.set_status(501)
+                self.finish(json.dumps(dict(message=msg, short_message=status_msg)))
+                return
 
         location = url_path_join(self.base_url, 'api', 'sessions', model['id'])
         self.set_header('Location', url_escape(location))

--- a/IPython/html/services/sessions/handlers.py
+++ b/IPython/html/services/sessions/handlers.py
@@ -56,7 +56,11 @@ class SessionRootHandler(IPythonHandler):
             try:
                 model = sm.create_session(name=name, path=path, kernel_name=kernel_name)
             except NoSuchKernel:
-                raise web.HTTPError(400, "No such kernel: %s" % kernel_name)
+                msg = ("The '%s' kernel is not available. Please pick another "
+                       "suitable kernel instead, or install that kernel." % kernel_name)
+                status_msg = 'Kernel not found'
+                msg = dict(full=msg, short=status_msg)
+                raise web.HTTPError(400, json.dumps(msg))
 
         location = url_path_join(self.base_url, 'api', 'sessions', model['id'])
         self.set_header('Location', url_escape(location))

--- a/IPython/html/services/sessions/handlers.py
+++ b/IPython/html/services/sessions/handlers.py
@@ -60,7 +60,7 @@ class SessionRootHandler(IPythonHandler):
                        "suitable kernel instead, or install that kernel." % kernel_name)
                 status_msg = 'Kernel not found'
                 msg = dict(full=msg, short=status_msg)
-                raise web.HTTPError(400, json.dumps(msg))
+                raise web.HTTPError(501, json.dumps(msg))
 
         location = url_path_join(self.base_url, 'api', 'sessions', model['id'])
         self.set_header('Location', url_escape(location))

--- a/IPython/html/services/sessions/handlers.py
+++ b/IPython/html/services/sessions/handlers.py
@@ -58,7 +58,7 @@ class SessionRootHandler(IPythonHandler):
             except NoSuchKernel:
                 msg = ("The '%s' kernel is not available. Please pick another "
                        "suitable kernel instead, or install that kernel." % kernel_name)
-                status_msg = 'Kernel not found'
+                status_msg = '%s not found' % kernel_name
                 self.log.warn('Kernel not found: %s' % kernel_name)
                 self.set_status(501)
                 self.finish(json.dumps(dict(message=msg, short_message=status_msg)))

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -185,14 +185,25 @@ define([
         });
 
         this.events.on('start_failed.Session',function (session, xhr, status, error) {
-            var msg = JSON.parse(status.responseJSON.message);
+            var full = status.responseJSON.message;
+            var short = status.responseJSON.short_message || 'Kernel error';
+            var traceback = status.responseJSON.traceback;
+            var msg = $('<div/>');
 
-            that.save_widget.update_document_title();
-            $kernel_ind_icon.attr('class','kernel_dead_icon').attr('title','Kernel Dead');
-            knw.danger(msg.short, undefined, function () {
+            msg.append($('<p/>').text(full));
+            if (traceback) {
+                msg.append($('<textarea/>')
+                           .attr('rows', '13')
+                           .attr('cols', '80')
+                           .attr('readonly', 'true')
+                           .css('margin-top', '1em')
+                           .text(traceback));
+            }
+
+            var showMsg = function () {
                 dialog.modal({
                     title: "Failed to start the kernel",
-                    body : msg.full,
+                    body : msg,
                     keyboard_manager: that.keyboard_manager,
                     notebook: that.notebook,
                     buttons : {
@@ -200,7 +211,13 @@ define([
                     }
                 });
                 return false;
-            });
+            };
+
+            that.save_widget.update_document_title();
+            $kernel_ind_icon.attr('class','kernel_dead_icon').attr('title','Kernel Dead');
+            knw.danger(short, undefined, showMsg);
+
+            showMsg();
         });
 
         this.events.on('websocket_closed.Kernel', function (event, data) {

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -185,31 +185,21 @@ define([
         });
 
         this.events.on('start_failed.Session',function (session, xhr, status, error) {
-            var msg = $('<div/>');
-            msg.append($('<div/>')
-                       .text('The kernel could not be started. This might ' +
-                             'happen if the notebook was previously run with a kernel ' +
-                             'that you do not have installed. Please choose a different kernel, ' +
-                             'or install the needed kernel and then refresh this page.')
-                       .css('margin-bottom', '1em'));
+            var msg = JSON.parse(status.responseJSON.message);
 
-            msg.append($('<div/>')
-                       .text('The exact error was:')
-                       .css('margin-bottom', '1em'));
-
-            msg.append($('<div/>')
-                       .attr('class', 'alert alert-danger')
-                       .attr('role', 'alert')
-                       .text(JSON.parse(status.responseText).message));
-
-            dialog.modal({
-                title: "Failed to start the kernel",
-                body : msg,
-                keyboard_manager: that.keyboard_manager,
-                notebook: that.notebook,
-                buttons : {
-                    "Ok": { class: 'btn-primary' }
-                }
+            that.save_widget.update_document_title();
+            $kernel_ind_icon.attr('class','kernel_dead_icon').attr('title','Kernel Dead');
+            knw.danger(msg.short, undefined, function () {
+                dialog.modal({
+                    title: "Failed to start the kernel",
+                    body : msg.full,
+                    keyboard_manager: that.keyboard_manager,
+                    notebook: that.notebook,
+                    buttons : {
+                        "Ok": { class: 'btn-primary' }
+                    }
+                });
+                return false;
             });
         });
 

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -159,7 +159,7 @@ define([
             });
         });
 
-        this.events.on('status_dead.Kernel',function () {
+        this.events.on('status_restart_failed.Kernel',function () {
             var msg = 'The kernel has died, and the automatic restart has failed.' +
                 ' It is possible the kernel cannot be restarted.' +
                 ' If you are not able to restart the kernel, you will still be able to save' +
@@ -180,6 +180,23 @@ define([
                         }
                     },
                     "Don't restart": {}
+                }
+            });
+        });
+
+        this.events.on('start_failed.Session',function () {
+            var msg = 'We were unable to start the kernel. This might ' +
+                'happen if the notebook was previously run with a kernel ' +
+                'that you do not have installed. Please choose a different kernel, ' +
+                'or install the needed kernel and then refresh this page.';
+
+            dialog.modal({
+                title: "Failed to start the kernel",
+                body : msg,
+                keyboard_manager: that.keyboard_manager,
+                notebook: that.notebook,
+                buttons : {
+                    "Ok": { class: 'btn-primary' }
                 }
             });
         });

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -184,11 +184,23 @@ define([
             });
         });
 
-        this.events.on('start_failed.Session',function () {
-            var msg = 'We were unable to start the kernel. This might ' +
-                'happen if the notebook was previously run with a kernel ' +
-                'that you do not have installed. Please choose a different kernel, ' +
-                'or install the needed kernel and then refresh this page.';
+        this.events.on('start_failed.Session',function (session, xhr, status, error) {
+            var msg = $('<div/>');
+            msg.append($('<div/>')
+                       .text('We were unable to start the kernel. This might ' +
+                             'happen if the notebook was previously run with a kernel ' +
+                             'that you do not have installed. Please choose a different kernel, ' +
+                             'or install the needed kernel and then refresh this page.')
+                       .css('margin-bottom', '1em'));
+
+            msg.append($('<div/>')
+                       .text('The exact error was:')
+                       .css('margin-bottom', '1em'));
+
+            msg.append($('<div/>')
+                       .attr('class', 'alert alert-danger')
+                       .attr('role', 'alert')
+                       .text(JSON.parse(status.responseText).message));
 
             dialog.modal({
                 title: "Failed to start the kernel",

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -216,8 +216,6 @@ define([
             that.save_widget.update_document_title();
             $kernel_ind_icon.attr('class','kernel_dead_icon').attr('title','Kernel Dead');
             knw.danger(short, undefined, showMsg);
-
-            showMsg();
         });
 
         this.events.on('websocket_closed.Kernel', function (event, data) {

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -187,7 +187,7 @@ define([
         this.events.on('start_failed.Session',function (session, xhr, status, error) {
             var msg = $('<div/>');
             msg.append($('<div/>')
-                       .text('We were unable to start the kernel. This might ' +
+                       .text('The kernel could not be started. This might ' +
                              'happen if the notebook was previously run with a kernel ' +
                              'that you do not have installed. Please choose a different kernel, ' +
                              'or install the needed kernel and then refresh this page.')

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -188,28 +188,35 @@ define([
             var full = status.responseJSON.message;
             var short = status.responseJSON.short_message || 'Kernel error';
             var traceback = status.responseJSON.traceback;
-            var msg = $('<div/>');
-
-            msg.append($('<p/>').text(full));
-            if (traceback) {
-                msg.append($('<textarea/>')
-                           .attr('rows', '13')
-                           .attr('cols', '80')
-                           .attr('readonly', 'true')
-                           .css('margin-top', '1em')
-                           .text(traceback));
-            }
 
             var showMsg = function () {
+                var msg = $('<div/>').append($('<p/>').text(full));
+                var cm, cm_elem;
+
+                if (traceback) {
+                    cm_elem = $('<div/>')
+                        .css('margin-top', '1em')
+                        .css('padding', '1em')
+                        .addClass('output_scroll');
+                    msg.append(cm_elem);
+                    cm = CodeMirror(cm_elem.get(0), {
+                        mode:  "python",
+                        readOnly : true
+                    });
+                    cm.setValue(traceback);
+                }
+
                 dialog.modal({
                     title: "Failed to start the kernel",
                     body : msg,
                     keyboard_manager: that.keyboard_manager,
                     notebook: that.notebook,
+                    open: $.proxy(cm.refresh, cm),
                     buttons : {
                         "Ok": { class: 'btn-primary' }
                     }
                 });
+
                 return false;
             };
 

--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -560,6 +560,7 @@ define([
         } else if (execution_state === 'dead') {
             this.stop_channels();
             this.events.trigger('status_dead.Kernel', {kernel: this});
+            this.events.trigger('status_restart_failed.Kernel', {kernel: this});
         }
     };
     

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -112,7 +112,6 @@ define([
 
     Session.prototype._handle_start_failure = function (xhr, status, error) {
         this.events.trigger('start_failed.Session', [this, xhr, status, error]);
-        this.events.trigger('status_dead.Kernel');
     };
     
     /**


### PR DESCRIPTION
If a user does not have a kernel installed on their system, but they try to open a notebook with that kernel, they will get a "kernel died" error, which doesn't make a lot of sense because the kernel was never running. This pull request attempts to handle kernel start errors more gracefully, and give the user a more informative message.
