### PR TITLE
notebook.start_kernel is undefined

### DIFF
--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -2650,6 +2650,10 @@ define([
         this.events.trigger('checkpoint_delete_failed.Notebook', [xhr, status, error]);
     };
 
+    Notebook.prototype.restart_session = function(){                                                                                          var kernelspec = this.metadata.kernelspec || {};
+        var kernel_name = kernelspec.name || this.default_kernel_name;
+        this.start_session(kernel_name);
+    }
 
     // For backwards compatability.
     IPython.Notebook = Notebook;

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -147,7 +147,7 @@ define([
                         class: "btn-danger",
                         click: function () {
                             that.events.trigger('status_restarting.Kernel');
-                            that.notebook.start_kernel();
+                            that.notebook.restart_session();
                         }
                     },
                     "Don't restart": {}


### PR DESCRIPTION
Hi, in notificationarea.js, when we need to restart a kernel we call `notebook.start_kernel` which doesn't exist.  Not sure how you guys were planning to handle this, but I took a stab at it.

thanks!
