### PR TITLE
widget default values

### DIFF
--- a/IPython/html/widgets/widget_bool.py
+++ b/IPython/html/widgets/widget_bool.py
@@ -26,6 +26,10 @@ class _Bool(DOMWidget):
     description = Unicode('', help="Description of the boolean (label).", sync=True)
     disabled = Bool(False, help="Enable or disable user changes.", sync=True)
 
+    def __init__(self, value=None, **kwargs):
+        if value is not None:
+            kwargs['value'] = value
+        super(_Bool, self).__init__(**kwargs)
 
 class Checkbox(_Bool):
     """Displays a boolean `value`."""

--- a/IPython/html/widgets/widget_float.py
+++ b/IPython/html/widgets/widget_float.py
@@ -25,6 +25,10 @@ class _Float(DOMWidget):
     disabled = Bool(False, help="Enable or disable user changes", sync=True)
     description = Unicode(help="Description of the value this widget represents", sync=True)
 
+    def __init__(self, value=None, **kwargs):
+        if value is not None:
+            kwargs['value'] = value
+        super(_Float, self).__init__(**kwargs)
 
 class _BoundedFloat(_Float):
     max = CFloat(100.0, help="Max value", sync=True)
@@ -33,7 +37,7 @@ class _BoundedFloat(_Float):
 
     def __init__(self, *pargs, **kwargs):
         """Constructor"""
-        DOMWidget.__init__(self, *pargs, **kwargs)
+        super(_BoundedFloat, self).__init__(*pargs, **kwargs)
         self._validate('value', None, self.value)
         self.on_trait_change(self._validate, ['value', 'min', 'max'])
 

--- a/IPython/html/widgets/widget_int.py
+++ b/IPython/html/widgets/widget_int.py
@@ -26,6 +26,10 @@ class _Int(DOMWidget):
     disabled = Bool(False, help="Enable or disable user changes", sync=True)
     description = Unicode(help="Description of the value this widget represents", sync=True)
 
+    def __init__(self, value=None, **kwargs):
+        if value is not None:
+            kwargs['value'] = value
+        super(_Int, self).__init__(**kwargs)
 
 class _BoundedInt(_Int):
     """Base class used to create widgets that represent a int that is bounded

--- a/IPython/html/widgets/widget_int.py
+++ b/IPython/html/widgets/widget_int.py
@@ -40,7 +40,7 @@ class _BoundedInt(_Int):
 
     def __init__(self, *pargs, **kwargs):
         """Constructor"""
-        DOMWidget.__init__(self, *pargs, **kwargs)
+        super(_BoundedInt, self).__init__(*pargs, **kwargs)
         self.on_trait_change(self._validate, ['value', 'min', 'max'])
 
     def _validate(self, name, old, new):
@@ -93,7 +93,7 @@ class _IntRange(_Int):
         if lower_given != upper_given:
             raise ValueError("Must specify both 'lower' and 'upper' for range widget")
         
-        DOMWidget.__init__(self, *pargs, **kwargs)
+        super(_BoundedInt, self).__init__(*pargs, **kwargs)
         
         # ensure the traits match, preferring whichever (if any) was given in kwargs
         if value_given:

--- a/IPython/html/widgets/widget_string.py
+++ b/IPython/html/widgets/widget_string.py
@@ -27,6 +27,10 @@ class _String(DOMWidget):
     description = Unicode(help="Description of the value this widget represents", sync=True)
     placeholder = Unicode("", help="Placeholder text to display when nothing has been typed", sync=True)
 
+    def __init__(self, value=None, **kwargs):
+        if value is not None:
+            kwargs['value'] = value
+        super(_String, self).__init__(**kwargs)
 
 class HTML(_String):
     """Renders the string `value` as HTML."""
@@ -51,8 +55,8 @@ class Text(_String):
     """Single line textbox widget."""
     _view_name = Unicode('TextView', sync=True)
 
-    def __init__(self, **kwargs):
-        super(Text, self).__init__(**kwargs)
+    def __init__(self, *parg, **kwargs):
+        super(Text, self).__init__(*parg, **kwargs)
         self._submission_callbacks = CallbackDispatcher()
         self.on_msg(self._handle_string_msg)
 


### PR DESCRIPTION
Changed some default parameters in applicable widgets to make them positional, to avoid being forced to pass verbose variable names when it should be obvious. 
