### PR TITLE
Make default kernel configurable

### DIFF
--- a/IPython/html/services/sessions/handlers.py
+++ b/IPython/html/services/sessions/handlers.py
@@ -45,7 +45,8 @@ class SessionRootHandler(IPythonHandler):
         try:
             kernel_name = model['kernel']['name']
         except KeyError:
-            raise web.HTTPError(400, "Missing field in JSON data: kernel.name")
+            self.log.debug("No kernel name specified, using default kernel")
+            kernel_name = None
 
         # Check to see if session exists
         if sm.session_exists(name=name, path=path):

--- a/IPython/html/services/sessions/sessionmanager.py
+++ b/IPython/html/services/sessions/sessionmanager.py
@@ -1,20 +1,7 @@
-"""A base class session manager.
+"""A base class session manager."""
 
-Authors:
-
-* Zach Sailer
-"""
-
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2013  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 import uuid
 import sqlite3
@@ -25,9 +12,6 @@ from IPython.config.configurable import LoggingConfigurable
 from IPython.utils.py3compat import unicode_type
 from IPython.utils.traitlets import Instance
 
-#-----------------------------------------------------------------------------
-# Classes
-#-----------------------------------------------------------------------------
 
 class SessionManager(LoggingConfigurable):
 
@@ -73,7 +57,7 @@ class SessionManager(LoggingConfigurable):
         "Create a uuid for a new session"
         return unicode_type(uuid.uuid4())
 
-    def create_session(self, name=None, path=None, kernel_name='python'):
+    def create_session(self, name=None, path=None, kernel_name=None):
         """Creates a session and returns its model"""
         session_id = self.new_session_id()
         # allow nbm to specify kernels cwd

--- a/IPython/html/static/notebook/js/kernelselector.js
+++ b/IPython/html/static/notebook/js/kernelselector.js
@@ -12,7 +12,7 @@ define([
         this.selector = selector;
         this.notebook = notebook;
         this.events = notebook.events;
-        this.current_selection = notebook.default_kernel_name;
+        this.current_selection = null;
         this.kernelspecs = {};
         if (this.selector !== undefined) {
             this.element = $(selector);

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -70,9 +70,6 @@ define([
         //  Create default scroll manager.
         this.scroll_manager = new scrollmanager.ScrollManager(this);
 
-        // default_kernel_name is a temporary measure while we implement proper
-        // kernel selection and delayed start. Do not rely on it.
-        this.default_kernel_name = 'python';
         // TODO: This code smells (and the other `= this` line a couple lines down)
         // We need a better way to deal with circular instance references.
         this.keyboard_manager.notebook = this;
@@ -1565,9 +1562,6 @@ define([
      */
     Notebook.prototype.start_session = function (kernel_name) {
         var that = this;
-        if (kernel_name === undefined) {
-            kernel_name = this.default_kernel_name;
-        }
         if (this._session_starting) {
             throw new session.SessionAlreadyStarting();
         }
@@ -2332,7 +2326,7 @@ define([
         // code execution upon loading, which is a security risk.
         if (this.session === null) {
             var kernelspec = this.metadata.kernelspec || {};
-            var kernel_name = kernelspec.name || this.default_kernel_name;
+            var kernel_name = kernelspec.name;
 
             this.start_session(kernel_name);
         }

--- a/IPython/kernel/multikernelmanager.py
+++ b/IPython/kernel/multikernelmanager.py
@@ -1,20 +1,7 @@
-"""A kernel manager for multiple kernels
+"""A kernel manager for multiple kernels"""
 
-Authors:
-
-* Brian Granger
-"""
-
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2013  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 from __future__ import absolute_import
 
@@ -30,13 +17,10 @@ from IPython.utils.traitlets import (
 )
 from IPython.utils.py3compat import unicode_type
 
-#-----------------------------------------------------------------------------
-# Classes
-#-----------------------------------------------------------------------------
+from .kernelspec import NATIVE_KERNEL_NAME
 
 class DuplicateKernelError(Exception):
     pass
-
 
 
 def kernel_method(f):
@@ -57,6 +41,10 @@ def kernel_method(f):
 
 class MultiKernelManager(LoggingConfigurable):
     """A class for managing multiple kernels."""
+    
+    default_kernel_name = Unicode(NATIVE_KERNEL_NAME, config=True,
+        help="The name of the default kernel to start"
+    )
     
     kernel_manager_class = DottedObjectName(
         "IPython.kernel.ioloop.IOLoopKernelManager", config=True,
@@ -92,7 +80,7 @@ class MultiKernelManager(LoggingConfigurable):
     def __contains__(self, kernel_id):
         return kernel_id in self._kernels
 
-    def start_kernel(self, kernel_name='python', **kwargs):
+    def start_kernel(self, kernel_name=None, **kwargs):
         """Start a new kernel.
 
         The caller can pick a kernel_id by passing one in as a keyword arg,
@@ -106,6 +94,9 @@ class MultiKernelManager(LoggingConfigurable):
         kernel_id = kwargs.pop('kernel_id', unicode_type(uuid.uuid4()))
         if kernel_id in self:
             raise DuplicateKernelError('Kernel already exists: %s' % kernel_id)
+        
+        if kernel_name is None:
+            kernel_name = self.default_kernel_name
         # kernel_manager_factory is the constructor for the KernelManager
         # subclass we are using. It can be configured as any Configurable,
         # including things like its transport and ip.


### PR DESCRIPTION
- The default value is stored in the MKM.default_kernel_name configurable.
- If `kernel_name` is left unspecified or specified as None,
  this value will be used, instead of hardcoding 'python'.
- A POST request to `/kernelspecs/:name` sets `name` as the default kernel.
- selecting a kernel from the menu sets the default kernel for new notebooks.

We will probably want to move where that POST request is called when we get the new-notebook-with-kernel dropdown menu, but I think everything else will remain the same.
