### PR TITLE
add file arg to showtraceback

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1779,7 +1779,7 @@ class InteractiveShell(SingletonConfigurable):
         self.write_err("UsageError: %s" % exc)
     
     def showtraceback(self, exc_tuple=None, filename=None, tb_offset=None,
-                      exception_only=False):
+                      exception_only=False, file=None):
         """Display the exception that just occurred.
 
         If nothing is known about the exception, this is the method which
@@ -1820,25 +1820,27 @@ class InteractiveShell(SingletonConfigurable):
                         stb = self.InteractiveTB.structured_traceback(etype,
                                             value, tb, tb_offset=tb_offset)
 
-                    self._showtraceback(etype, value, stb)
+                    self._showtraceback(etype, value, stb, file=file)
                     if self.call_pdb:
                         # drop into debugger
                         self.debugger(force=True)
                     return
 
                 # Actually show the traceback
-                self._showtraceback(etype, value, stb)
+                self._showtraceback(etype, value, stb, file=file)
 
         except KeyboardInterrupt:
             self.write_err("\nKeyboardInterrupt\n")
 
-    def _showtraceback(self, etype, evalue, stb):
+    def _showtraceback(self, etype, evalue, stb, file=None):
         """Actually show a traceback.
 
         Subclasses may override this method to put the traceback on a different
         place, like a side channel.
         """
-        print(self.InteractiveTB.stb2text(stb), file=io.stdout)
+        if file is None:
+            file = io.stdout
+        print(self.InteractiveTB.stb2text(stb), file=file)
 
     def showsyntaxerror(self, filename=None):
         """Display the syntax error that just occurred.

--- a/IPython/kernel/zmq/zmqshell.py
+++ b/IPython/kernel/zmq/zmqshell.py
@@ -497,8 +497,12 @@ class ZMQInteractiveShell(InteractiveShell):
             )
         self.payload_manager.write_payload(payload)
 
-    def _showtraceback(self, etype, evalue, stb):
+    def _showtraceback(self, etype, evalue, stb, file=None):
         # try to preserve ordering of tracebacks and print statements
+
+        if file is not None:
+            return super(ZMQInteractiveShell, self)._showtraceback(self, etype, evalue, stb, file=file)
+
         sys.stdout.flush()
         sys.stderr.flush()
 

--- a/IPython/testing/globalipapp.py
+++ b/IPython/testing/globalipapp.py
@@ -102,10 +102,12 @@ def xsys(self, cmd):
     sys.stdout.flush()
 
 
-def _showtraceback(self, etype, evalue, stb):
+def _showtraceback(self, etype, evalue, stb, file=None):
     """Print the traceback purely on stdout for doctest to capture it.
     """
-    print(self.InteractiveTB.stb2text(stb), file=sys.stdout)
+    if file is None:
+        file = sys.stdout
+    print(self.InteractiveTB.stb2text(stb), file=file)
 
 
 def start_ipython():


### PR DESCRIPTION
allows capture of rendered tracebacks, matching things like `traceback.print_traceback`

I originally added this in #6394, but it didn't turn out to be necessary. I still think it's a good idea, so I gave it its own PR.
