### PR TITLE
rely on 304 for caching, optionally compile javascript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@ docs/source/config/options
 docs/source/interactive/magics-generated.txt
 docs/gh-pages
 IPython/html/notebook/static/mathjax
-IPython/html/static/style/*.map
+IPython/html/static/**/*.map
+IPython/html/static/**/*.min.js
 *.py[co]
 __pycache__
 *.egg-info

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -312,6 +312,12 @@ class AuthenticatedFileHandler(IPythonHandler, web.StaticFileHandler):
         
         return web.StaticFileHandler.get(self, path)
     
+    def set_headers(self):
+        super(AuthenticatedFileHandler, self).set_headers()
+        # disable browser caching, rely in 304 replies for savings
+        if "v" not in self.request.arguments:
+            self.add_header("Cache-Control", "no-cache")
+    
     def compute_etag(self):
         return None
     
@@ -379,6 +385,12 @@ class FileFindHandler(web.StaticFileHandler):
     
     # cache search results, don't search for files more than once
     _static_paths = {}
+    
+    def set_headers(self):
+        super(FileFindHandler, self).set_headers()
+        # disable browser caching, rely in 304 replies for savings
+        if "v" not in self.request.arguments:
+            self.add_header("Cache-Control", "no-cache")
     
     def initialize(self, path, default_filename=None):
         if isinstance(path, string_types):

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -239,16 +239,19 @@ class IPythonHandler(AuthenticatedHandler):
         static_path = self.settings.get('static_path', 'static')
         normal_path = StaticHandler.get_absolute_path(static_path, path)
         minified_path = StaticHandler.get_absolute_path(static_path, path[:-3] + '.min.js')
-        try:
-            norm_mtime = os.stat(normal_path).st_mtime
-        except OSError as e:
-            norm_mtime = 0
-        try:
-            min_mtime = os.stat(minified_path).st_mtime
-        except OSError as e:
-            min_mtime = 0
-        if min_mtime >= norm_mtime:
-            path = path[:-3] + '.min.js'
+        if os.path.exists(minified_path):
+            try:
+                norm_mtime = os.stat(normal_path).st_mtime
+            except OSError as e:
+                norm_mtime = 0
+            try:
+                min_mtime = os.stat(minified_path).st_mtime
+            except OSError as e:
+                min_mtime = 0
+            if min_mtime >= norm_mtime:
+                path = path[:-3] + '.min.js'
+            else:
+                self.log.debug("Not serving out-of-date %s", minified_path)
         return self.static_url(path, *args, **kwargs)
     
     @property

--- a/IPython/html/build.js
+++ b/IPython/html/build.js
@@ -7,10 +7,11 @@
     jquery: 'components/jquery/jquery.min',
     bootstrap: 'components/bootstrap/js/bootstrap.min',
     bootstraptour: 'components/bootstrap-tour/build/js/bootstrap-tour.min',
-    dateformat: 'dateformat/date.format',
     jqueryui: 'components/jquery-ui/ui/minified/jquery-ui.min',
-    highlight: 'components/highlight.js/build/highlight.pack',
-    moment: "components/moment/moment",
+    moment: 'components/moment/moment',
+    codemirror: 'components/codemirror',
+    termjs: 'components/term.js/src/term',
+    contents: 'services/contents'
   },
   shim: {
     underscore: {
@@ -28,20 +29,14 @@
       deps: ["bootstrap"],
       exports: "Tour"
     },
-    dateformat: {
-      exports: "dateFormat"
-    },
     jqueryui: {
       deps: ["jquery"],
       exports: "$"
-    },
-    highlight: {
-      exports: "hljs"
-    },
+    }
   },
-    
+
   exclude: [
-  "custom/custom",
+    "custom/custom",
   ],
   optimize: "none",
 })

--- a/IPython/html/build.js
+++ b/IPython/html/build.js
@@ -1,0 +1,47 @@
+({
+  baseUrl: 'static',
+  generateSourceMaps: true,
+  paths: {
+    underscore : 'components/underscore/underscore-min',
+    backbone : 'components/backbone/backbone-min',
+    jquery: 'components/jquery/jquery.min',
+    bootstrap: 'components/bootstrap/js/bootstrap.min',
+    bootstraptour: 'components/bootstrap-tour/build/js/bootstrap-tour.min',
+    dateformat: 'dateformat/date.format',
+    jqueryui: 'components/jquery-ui/ui/minified/jquery-ui.min',
+    highlight: 'components/highlight.js/build/highlight.pack',
+    moment: "components/moment/moment",
+  },
+  shim: {
+    underscore: {
+      exports: '_'
+    },
+    backbone: {
+      deps: ["underscore", "jquery"],
+      exports: "Backbone"
+    },
+    bootstrap: {
+      deps: ["jquery"],
+      exports: "bootstrap"
+    },
+    bootstraptour: {
+      deps: ["bootstrap"],
+      exports: "Tour"
+    },
+    dateformat: {
+      exports: "dateFormat"
+    },
+    jqueryui: {
+      deps: ["jquery"],
+      exports: "$"
+    },
+    highlight: {
+      exports: "hljs"
+    },
+  },
+    
+  exclude: [
+  "custom/custom",
+  ],
+  optimize: "none",
+})

--- a/IPython/html/tasks.py
+++ b/IPython/html/tasks.py
@@ -81,3 +81,16 @@ def _compile_less(source, target, sourcemap, minify=True, verbose=False):
     finally:
         os.chdir(cwd)
 
+def _rjs(name):
+    with lcd(here):
+        local("r.js -o build.js 'name={name}' 'out=static/{name}.min.js'".format(name=name))
+
+def js():
+    """Compile minified javascript"""
+    for name in ['notebook', 'tree']:
+        _rjs(pjoin(name, 'js', 'main'))
+
+    for name in ['logout', 'login']:
+        _rjs(pjoin('auth', 'js', name + 'main'))
+    
+

--- a/IPython/html/tasks.py
+++ b/IPython/html/tasks.py
@@ -1,9 +1,11 @@
-"""invoke task file to build CSS"""
+"""invoke task file to build CSS/JS"""
 
-from invoke import task, run
 import os
+from contextlib import contextmanager
 from distutils.version import LooseVersion as V
 from subprocess import check_output
+
+from invoke import task, run
 
 pjoin = os.path.join
 static_dir = 'static'
@@ -12,6 +14,17 @@ here = os.path.dirname(__file__)
 
 min_less_version = '1.7.5'
 max_less_version = '1.8.0' # exclusive
+
+@contextmanager
+def lcd(path):
+    """Context manager for setting CWD"""
+    cwd = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(cwd)
+
 
 def _need_css_update():
     """Does less need to run?"""
@@ -72,25 +85,26 @@ def _compile_less(source, target, sourcemap, minify=True, verbose=False):
         raise ValueError("lessc too new: %s >= %s. Use `$ npm install lesscss@X.Y.Z` to install a specific version of less" % (less_version, max_less_version))
     
     static_path = pjoin(here, static_dir)
-    cwd = os.getcwd()
-    try:
-        os.chdir(static_dir)
+    with lcd(static_path):
         run('lessc {min_flag} {ver_flag} --source-map={sourcemap} --source-map-basepath={static_path} --source-map-rootpath="../" {source} {target}'.format(**locals()),
             echo=True,
         )
-    finally:
-        os.chdir(cwd)
 
 def _rjs(name):
     with lcd(here):
-        local("r.js -o build.js 'name={name}' 'out=static/{name}.min.js'".format(name=name))
+        run("r.js -o build.js 'name={name}' 'out=static/{name}.min.js'".format(name=name))
 
+@task
 def js():
     """Compile minified javascript"""
+    try:
+        out = check_output(['r.js', '-v'])
+    except OSError as err:
+        raise ValueError("Unable to find r.js.  Please install with `npm install -g requirejs`")
+    
     for name in ['notebook', 'tree']:
         _rjs(pjoin(name, 'js', 'main'))
 
     for name in ['logout', 'login']:
         _rjs(pjoin('auth', 'js', name + 'main'))
-    
 

--- a/IPython/html/templates/login.html
+++ b/IPython/html/templates/login.html
@@ -48,6 +48,6 @@
 {% block script %}
 {{super()}}
 
-<script src="{{static_url("auth/js/loginmain.js") }}" type="text/javascript" charset="utf-8"></script>
+<script src="{{maybe_minified("auth/js/loginmain.js") }}" type="text/javascript" charset="utf-8"></script>
 
 {% endblock %}

--- a/IPython/html/templates/logout.html
+++ b/IPython/html/templates/logout.html
@@ -34,6 +34,6 @@
 {% block script %}
 {{super()}}
 
-<script src="{{static_url("auth/js/logoutmain.js") }}" type="text/javascript" charset="utf-8"></script>
+<script src="{{maybe_minified("auth/js/logoutmain.js") }}" type="text/javascript" charset="utf-8"></script>
 
 {% endblock %}

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -323,6 +323,6 @@ class="notebook_app"
 
 <script src="{{ static_url("components/text-encoding/lib/encoding.js") }}" charset="utf-8"></script>
 
-<script src="{{ static_url("notebook/js/main.js") }}" charset="utf-8"></script>
+<script src="{{ maybe_minified("notebook/js/main.js") }}" charset="utf-8"></script>
 
 {% endblock %}

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -138,5 +138,5 @@ data-terminals-available="{{terminals_available}}"
 {% block script %}
     {{super()}}
 
-<script src="{{ static_url("tree/js/main.js") }}" type="text/javascript" charset="utf-8"></script>
+<script src="{{ maybe_minified("tree/js/main.js") }}" type="text/javascript" charset="utf-8"></script>
 {% endblock %}


### PR DESCRIPTION
Another example implementation of cache behavior described in #6576

This does two things:
1. set no-cache header in StaticFileHandlers, relying on 304 Not Modified for caching content.
2. compile javascript with `r.js`, which is not required, but used if present and newer than main
   (note it doesn't compare itself to _other_ files in the directory, so maybe we want to reconsider
   the selection logic), reducing the number of requests per page load.

The second change mitigates the increased page-load latency caused by the first. I will do some more profiling to quantify the impact.

The minified results are not tracked.

There are still decisions to make about minification:
1. should each minified js include all of the components, or not?
2. should it be minified, or simply concatenated?
