### PR TITLE
Windows symlink test fixes

### DIFF
--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -260,7 +260,12 @@ def atomic_writing(path, text=True, encoding='utf-8', **kwargs):
     **kwargs
       Passed to :func:`io.open`.
     """
-    path = os.path.realpath(path)  # Dereference symlinks
+    # realpath doesn't work on Windows: http://bugs.python.org/issue9949
+    # Luckily, we only need to resolve the file itself being a symlink, not
+    # any of its directories, so this will suffice:
+    if os.path.islink(path):
+        path = os.path.join(os.path.dirname(path), os.readlink(path))
+
     dirname, basename = os.path.split(path)
     handle, tmp_path = tempfile.mkstemp(prefix=basename, dir=dirname, text=text)
     if text:

--- a/IPython/utils/tests/test_io.py
+++ b/IPython/utils/tests/test_io.py
@@ -144,7 +144,10 @@ def test_atomic_writing():
         try:
             os.symlink(f1, f2)
             have_symlink = True
-        except (AttributeError, NotImplementedError):
+        except (AttributeError, NotImplementedError, OSError):
+            # AttributeError: Python doesn't support it
+            # NotImplementedError: The system doesn't support it
+            # OSError: The user lacks the privilege (Windows)
             have_symlink = False
 
         with nt.assert_raises(CustomExc):


### PR DESCRIPTION
This should fix the Windows 3.x test failure we've been seeing recently, and another related failure I found when trying to reproduce it on my Windows VM.
