### PR TITLE
Fix ReferenceError in js tests

### DIFF
--- a/IPython/html/tests/util.js
+++ b/IPython/html/tests/util.js
@@ -50,7 +50,7 @@ casper.open_new_notebook = function () {
 casper.page_loaded = function() {
     // Return whether or not the kernel is running.
     return this.evaluate(function() {
-        return IPython !== undefined &&
+        return typeof IPython !== "undefined" &&
             IPython.page !== undefined;
     });
 };


### PR DESCRIPTION
The issue with #6542 is that the variable IPython isn't defined yet, so a ReferenceError gets raised. This pull request makes sure it's actually defined using `typeof`, which makes these errors go away.
