### PR TITLE
fixes #6473

### DIFF
--- a/IPython/html/static/notebook/js/celltoolbar.js
+++ b/IPython/html/static/notebook/js/celltoolbar.js
@@ -254,6 +254,7 @@ var IPython = (function (IPython) {
         // which is probably inner_element
         // or this.element.
         this.inner_element.empty();
+        this.show();
 
         var callbacks = CellToolbar._callback_dict;
         var preset = CellToolbar._ui_controls_list;


### PR DESCRIPTION
## /!\ PR against 2.x /!\

Should just fix #6473, re-show all the toolbar when rebuilding.

I did not backport 3.0 fixes as the changes are too huge, have refactor and add functionalities.
