### PR TITLE
Kernel and session javascript cleanup

### DIFF
--- a/IPython/html/services/sessions/handlers.py
+++ b/IPython/html/services/sessions/handlers.py
@@ -106,7 +106,11 @@ class SessionHandler(IPythonHandler):
     def delete(self, session_id):
         # Deletes the session with given session_id
         sm = self.session_manager
-        sm.delete_session(session_id)
+        try:
+            sm.delete_session(session_id)
+        except KeyError:
+            # the kernel was deleted but the session wasn't!
+            raise web.HTTPError(410, "Kernel deleted before session")
         self.set_status(204)
         self.finish()
 

--- a/IPython/html/static/base/js/dialog.js
+++ b/IPython/html/static/base/js/dialog.js
@@ -90,6 +90,15 @@ define([
         return modal.modal(options);
     };
 
+    var kernel_modal = function (options) {
+        // only one kernel dialog should be open at a time -- but
+        // other modal dialogs can still be open
+        $('.kernel-modal').modal('hide');
+        var dialog = modal(options);
+        dialog.addClass('kernel-modal');
+        return dialog;
+    };
+
     var edit_metadata = function (options) {
         options.name = options.name || "Cell";
         var error_div = $('<div/>').css('color', 'red');
@@ -153,6 +162,7 @@ define([
     
     var dialog = {
         modal : modal,
+        kernel_modal : kernel_modal,
         edit_metadata : edit_metadata,
     };
 

--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -523,12 +523,14 @@ define([
     var ajax_error_msg = function (jqXHR) {
         // Return a JSON error message if there is one,
         // otherwise the basic HTTP status text.
-        if (jqXHR.responseJSON && jqXHR.responseJSON.message) {
+        if (jqXHR.responseJSON && jqXHR.responseJSON.traceback) {
+            return jqXHR.responseJSON.traceback;
+        } else if (jqXHR.responseJSON && jqXHR.responseJSON.message) {
             return jqXHR.responseJSON.message;
         } else {
             return jqXHR.statusText;
         }
-    }
+    };
     var log_ajax_error = function (jqXHR, status, error) {
         // log ajax failures with informative messages
         var msg = "API request failed (" + jqXHR.status + "): ";

--- a/IPython/html/static/notebook/js/completer.js
+++ b/IPython/html/static/notebook/js/completer.js
@@ -82,10 +82,10 @@ define([
         this.cell = cell;
         this.editor = cell.code_mirror;
         var that = this;
-        events.on('status_busy.Kernel', function () {
+        events.on('kernel_busy.Kernel', function () {
             that.skip_kernel_completion = true;
         });
-        events.on('status_idle.Kernel', function () {
+        events.on('kernel_idle.Kernel', function () {
             that.skip_kernel_completion = false;
         });
     };

--- a/IPython/html/static/notebook/js/maintoolbar.js
+++ b/IPython/html/static/notebook/js/maintoolbar.js
@@ -117,7 +117,7 @@ define([
                     label : 'Interrupt',
                     icon : 'fa-stop',
                     callback : function () {
-                        that.notebook.session.interrupt_kernel();
+                        that.notebook.kernel.interrupt();
                         }
                 },
                 {

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -287,7 +287,7 @@ define([
         
         // Kernel
         this.element.find('#int_kernel').click(function () {
-            that.notebook.session.interrupt_kernel();
+            that.notebook.kernel.interrupt();
         });
         this.element.find('#restart_kernel').click(function () {
             that.notebook.restart_kernel();

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -258,7 +258,7 @@ define([
             // TODO: Make killing the kernel configurable.
             var kill_kernel = false;
             if (kill_kernel) {
-                that.kernel.kill();
+                that.session.delete();
             }
             // if we are autosaving, trigger an autosave on nav-away.
             // still warn, because if we don't the autosave may fail.

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -258,7 +258,7 @@ define([
             // TODO: Make killing the kernel configurable.
             var kill_kernel = false;
             if (kill_kernel) {
-                that.session.kill_kernel();
+                that.kernel.kill();
             }
             // if we are autosaving, trigger an autosave on nav-away.
             // still warn, because if we don't the autosave may fail.
@@ -1654,7 +1654,7 @@ define([
                 "Restart" : {
                     "class" : "btn-danger",
                     "click" : function() {
-                        that.session.restart_kernel();
+                        that.kernel.restart();
                     }
                 }
             }

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -205,20 +205,6 @@ define([
         this.events.on('command_mode.Cell', function (event, data) {
             that.handle_command_mode(data.cell);
         });
-
-        this.events.on('status_autorestarting.Kernel', function () {
-            dialog.modal({
-                notebook: that,
-                keyboard_manager: that.keyboard_manager,
-                title: "Kernel Restarting",
-                body: "The kernel appears to have died. It will restart automatically.",
-                buttons: {
-                    OK : {
-                        class : "btn-primary"
-                    }
-                }
-            });
-        });
         
         this.events.on('spec_changed.Kernel', function(event, data) {
             that.set_kernelspec_metadata(data);

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -163,13 +163,13 @@ define([
             });
         });
 
-        this.events.on('status_dead.Kernel',function () {
+        this.events.on('no_kernel.Kernel', function () {
             that.save_widget.update_document_title();
             knw.danger("Dead kernel");
             $kernel_ind_icon.attr('class','kernel_dead_icon').attr('title','Kernel Dead');
         });
 
-        this.events.on('status_dead.Kernel',function () {
+        this.events.on('status_dead.Kernel', function () {
             var msg = 'The kernel has died, and the automatic restart has failed.' +
                 ' It is possible the kernel cannot be restarted.' +
                 ' If you are not able to restart the kernel, you will still be able to save' +

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -142,8 +142,13 @@ define([
         });
 
         this.events.on('status_autorestarting.Kernel', function (evt, info) {
-            // only show the dialog on the first restart attempt
-            if (info.attempt == 1) {
+            // Only show the dialog on the first restart attempt. This
+            // number gets tracked by the `Kernel` object and passed
+            // along here, because we don't want to show the user 5
+            // dialogs saying the same thing (which is the number of
+            // times it tries restarting).
+            if (info.attempt === 1) {
+
                 // hide existing modal dialog
                 $(".modal").modal('hide');
 

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -226,7 +226,7 @@ define([
 
             var showMsg = function () {
                 var msg = $('<div/>').append($('<p/>').text(full));
-                var cm, cm_elem;
+                var cm, cm_elem, cm_open;
 
                 if (traceback) {
                     cm_elem = $('<div/>')
@@ -239,6 +239,7 @@ define([
                         readOnly : true
                     });
                     cm.setValue(traceback);
+                    cm_open = $.proxy(cm.refresh, cm);
                 }
 
                 dialog.modal({
@@ -246,7 +247,7 @@ define([
                     body : msg,
                     keyboard_manager: that.keyboard_manager,
                     notebook: that.notebook,
-                    open: $.proxy(cm.refresh, cm),
+                    open: cm_open,
                     buttons : {
                         "Ok": { class: 'btn-primary' }
                     }

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -175,37 +175,35 @@ define([
         });
 
         this.events.on('status_disconnected.Kernel', function () {
-            knw.danger("Disconnected", undefined, function () {
-                that.notebook.kernel.reconnect();
-                return false;
-            });
             $kernel_ind_icon
                 .attr('class', 'kernel_disconnected_icon')
                 .attr('title', 'No Connection to Kernel');
         });
 
-        this.events.on('connection_failed.Kernel', function () {
-            // hide existing dialog
-            $(".modal").modal('hide');
+        this.events.on('connection_failed.Kernel', function (evt, info) {
+            // only show the dialog if this is the first failed
+            // connect attempt, because the kernel will continue
+            // trying to reconnect and we don't want to spam the user
+            // with messages
+            if (info.attempt === 1) {
+                // hide existing dialog
+                $(".modal").modal('hide');
 
-            var msg = "A WebSocket connection could not be established." +
-                " You will NOT be able to run code. Check your" +
-                " network connection or notebook server configuration.";
+                var msg = "A connection to the notebook server could not be established." +
+                        " The notebook will continue trying to reconnect, but" +
+                        " until it does, you will NOT be able to run code. Check your" +
+                        " network connection or notebook server configuration.";
 
-            dialog.modal({
-                title: "WebSocket connection failed",
-                body: msg,
-                keyboard_manager: that.keyboard_manager,
-                notebook: that.notebook,
-                buttons : {
-                    "OK": {},
-                    "Reconnect": {
-                        click: function () {
-                            that.notebook.kernel.reconnect();
-                        }
+                dialog.modal({
+                    title: "Connection failed",
+                    body: msg,
+                    keyboard_manager: that.keyboard_manager,
+                    notebook: that.notebook,
+                    buttons : {
+                        "OK": {}
                     }
-                }
-            });
+                });
+            }
         });
 
         this.events.on('status_killed.Kernel status_killed.Session', function () {

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -108,12 +108,12 @@ define([
         var $modal_ind_icon = $("#modal_indicator_icon");
 
         // Command/Edit mode
-        this.events.on('edit_mode.Notebook',function () {
+        this.events.on('edit_mode.Notebook', function () {
             that.save_widget.update_document_title();
             $modal_ind_icon.attr('class','edit_mode_icon').attr('title','Edit Mode');
         });
 
-        this.events.on('command_mode.Notebook',function () {
+        this.events.on('command_mode.Notebook', function () {
             that.save_widget.update_document_title();
             $modal_ind_icon.attr('class','command_mode_icon').attr('title','Command Mode');
         });
@@ -123,9 +123,9 @@ define([
 
         // Kernel events 
 
-        // this can be either kernel_started.Kernel or kernel_started.Session
-        this.events.on('kernel_started.Kernel kernel_started.Session', function () {
-            knw.info("Kernel Started", 500);
+        // this can be either kernel_created.Kernel or kernel_created.Session
+        this.events.on('kernel_created.Kernel kernel_created.Session', function () {
+            knw.info("Kernel Created", 500);
         });
 
         this.events.on('status_reconnecting.Kernel', function () {
@@ -136,7 +136,7 @@ define([
             knw.info("Connected", 500);
         });
 
-        this.events.on('status_restarting.Kernel status_autorestarting.Kernel',function () {
+        this.events.on('status_restarting.Kernel', function () {
             that.save_widget.update_document_title();
             knw.set_message("Restarting kernel", 2000);
         });
@@ -153,9 +153,13 @@ define([
                     }
                 }
             });
+
+            that.save_widget.update_document_title();
+            knw.danger("Dead kernel");
+            $kernel_ind_icon.attr('class','kernel_dead_icon').attr('title','Kernel Dead');
         });
 
-        this.events.on('status_interrupting.Kernel',function () {
+        this.events.on('status_interrupting.Kernel', function () {
             knw.set_message("Interrupting kernel", 2000);
         });
 
@@ -261,12 +265,24 @@ define([
             knw.danger(short, undefined, showMsg);
         });
 
-        this.events.on('status_idle.Kernel',function () {
+        this.events.on('status_starting.Kernel', function () {
+            window.document.title='(Starting) '+window.document.title;
+            $kernel_ind_icon.attr('class','kernel_busy_icon').attr('title','Kernel Busy');
+            knw.set_message("Kernel starting, please wait...");
+        });
+
+        this.events.on('status_ready.Kernel', function () {
+            that.save_widget.update_document_title();
+            $kernel_ind_icon.attr('class','kernel_idle_icon').attr('title','Kernel Idle');
+            knw.info("Kernel ready", 500);
+        });
+
+        this.events.on('status_idle.Kernel', function () {
             that.save_widget.update_document_title();
             $kernel_ind_icon.attr('class','kernel_idle_icon').attr('title','Kernel Idle');
         });
 
-        this.events.on('status_busy.Kernel',function () {
+        this.events.on('status_busy.Kernel', function () {
             window.document.title='(Busy) '+window.document.title;
             $kernel_ind_icon.attr('class','kernel_busy_icon').attr('title','Kernel Busy');
         });

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -189,7 +189,7 @@ define([
             });
         });
 
-        this.events.on('kernel_dead.Kernel status_killed.Kernel kernel_dead.Session status_killed.Session', function () {
+        this.events.on('kernel_dead.Kernel status_killed.Kernel status_killed.Session', function () {
             that.save_widget.update_document_title();
             knw.danger("Dead kernel");
             $kernel_ind_icon.attr('class','kernel_dead_icon').attr('title','Kernel Dead');
@@ -219,10 +219,10 @@ define([
             });
         });
 
-        this.events.on('kernel_dead.Session',function (session, xhr, status, error) {
-            var full = status.responseJSON.message;
-            var short = status.responseJSON.short_message || 'Kernel error';
-            var traceback = status.responseJSON.traceback;
+        this.events.on('kernel_dead.Session', function (evt, info) {
+            var full = info.xhr.responseJSON.message;
+            var short = info.xhr.responseJSON.short_message || 'Kernel error';
+            var traceback = info.xhr.responseJSON.traceback;
 
             var showMsg = function () {
                 var msg = $('<div/>').append($('<p/>').text(full));

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -128,20 +128,20 @@ define([
             knw.info("Kernel Created", 500);
         });
 
-        this.events.on('status_reconnecting.Kernel', function () {
+        this.events.on('kernel_reconnecting.Kernel', function () {
             knw.warning("Connecting to kernel");
         });
 
-        this.events.on('status_connected.Kernel', function () {
+        this.events.on('kernel_connected.Kernel', function () {
             knw.info("Connected", 500);
         });
 
-        this.events.on('status_restarting.Kernel', function () {
+        this.events.on('kernel_restarting.Kernel', function () {
             that.save_widget.update_document_title();
             knw.set_message("Restarting kernel", 2000);
         });
 
-        this.events.on('status_autorestarting.Kernel', function (evt, info) {
+        this.events.on('kernel_autorestarting.Kernel', function (evt, info) {
             // Only show the dialog on the first restart attempt. This
             // number gets tracked by the `Kernel` object and passed
             // along here, because we don't want to show the user 5
@@ -167,17 +167,17 @@ define([
             $kernel_ind_icon.attr('class','kernel_dead_icon').attr('title','Kernel Dead');
         });
 
-        this.events.on('status_interrupting.Kernel', function () {
+        this.events.on('kernel_interrupting.Kernel', function () {
             knw.set_message("Interrupting kernel", 2000);
         });
 
-        this.events.on('status_disconnected.Kernel', function () {
+        this.events.on('kernel_disconnected.Kernel', function () {
             $kernel_ind_icon
                 .attr('class', 'kernel_disconnected_icon')
                 .attr('title', 'No Connection to Kernel');
         });
 
-        this.events.on('connection_failed.Kernel', function (evt, info) {
+        this.events.on('kernel_connection_failed.Kernel', function (evt, info) {
             // only show the dialog if this is the first failed
             // connect attempt, because the kernel will continue
             // trying to reconnect and we don't want to spam the user
@@ -201,7 +201,7 @@ define([
             }
         });
 
-        this.events.on('status_killed.Kernel status_killed.Session', function () {
+        this.events.on('kernel_killed.Kernel kernel_killed.Session', function () {
             that.save_widget.update_document_title();
             knw.danger("Dead kernel");
             $kernel_ind_icon.attr('class','kernel_dead_icon').attr('title','Kernel Dead');
@@ -285,24 +285,24 @@ define([
             knw.danger(short, undefined, showMsg);
         });
 
-        this.events.on('status_starting.Kernel', function () {
+        this.events.on('kernel_starting.Kernel', function () {
             window.document.title='(Starting) '+window.document.title;
             $kernel_ind_icon.attr('class','kernel_busy_icon').attr('title','Kernel Busy');
             knw.set_message("Kernel starting, please wait...");
         });
 
-        this.events.on('status_ready.Kernel', function () {
+        this.events.on('kernel_ready.Kernel', function () {
             that.save_widget.update_document_title();
             $kernel_ind_icon.attr('class','kernel_idle_icon').attr('title','Kernel Idle');
             knw.info("Kernel ready", 500);
         });
 
-        this.events.on('status_idle.Kernel', function () {
+        this.events.on('kernel_idle.Kernel', function () {
             that.save_widget.update_document_title();
             $kernel_ind_icon.attr('class','kernel_idle_icon').attr('title','Kernel Idle');
         });
 
-        this.events.on('status_busy.Kernel', function () {
+        this.events.on('kernel_busy.Kernel', function () {
             window.document.title='(Busy) '+window.document.title;
             $kernel_ind_icon.attr('class','kernel_busy_icon').attr('title','Kernel Busy');
         });

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -149,10 +149,7 @@ define([
             // times it tries restarting).
             if (info.attempt === 1) {
 
-                // hide existing modal dialog
-                $(".modal").modal('hide');
-
-                dialog.modal({
+                dialog.kernel_modal({
                     notebook: that.notebook,
                     keyboard_manager: that.keyboard_manager,
                     title: "Kernel Restarting",
@@ -186,15 +183,13 @@ define([
             // trying to reconnect and we don't want to spam the user
             // with messages
             if (info.attempt === 1) {
-                // hide existing dialog
-                $(".modal").modal('hide');
 
                 var msg = "A connection to the notebook server could not be established." +
                         " The notebook will continue trying to reconnect, but" +
                         " until it does, you will NOT be able to run code. Check your" +
                         " network connection or notebook server configuration.";
 
-                dialog.modal({
+                dialog.kernel_modal({
                     title: "Connection failed",
                     body: msg,
                     keyboard_manager: that.keyboard_manager,
@@ -215,8 +210,6 @@ define([
         this.events.on('kernel_dead.Kernel', function () {
 
             var showMsg = function () {
-                // hide existing dialog
-                $(".modal").modal('hide');
 
                 var msg = 'The kernel has died, and the automatic restart has failed.' +
                         ' It is possible the kernel cannot be restarted.' +
@@ -224,7 +217,7 @@ define([
                         ' the notebook, but running code will no longer work until the notebook' +
                         ' is reopened.';
 
-                dialog.modal({
+                dialog.kernel_modal({
                     title: "Dead kernel",
                     body : msg,
                     keyboard_manager: that.keyboard_manager,
@@ -273,10 +266,7 @@ define([
                     cm_open = $.proxy(cm.refresh, cm);
                 }
 
-                // hide existing modal dialog
-                $(".modal").modal('hide');
-
-                dialog.modal({
+                dialog.kernel_modal({
                     title: "Failed to start the kernel",
                     body : msg,
                     keyboard_manager: that.keyboard_manager,

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -152,6 +152,10 @@ define([
         $kernel_ind_icon.attr('class','kernel_busy_icon').attr('title','Kernel Busy');
 
         this.events.on('status_started.Kernel', function (evt, data) {
+            knw.info("Kernel Started", 500);
+        });
+
+        this.events.on('status_connected.Kernel', function (evt, data) {
             knw.info("Websockets Connected", 500);
             that.events.trigger('status_busy.Kernel');
             data.kernel.kernel_info(function () {
@@ -184,7 +188,7 @@ define([
             });
         });
 
-        this.events.on('start_failed.Session',function (session, xhr, status, error) {
+        this.events.on('kernel_dead.Session',function (session, xhr, status, error) {
             var full = status.responseJSON.message;
             var short = status.responseJSON.short_message || 'Kernel error';
             var traceback = status.responseJSON.traceback;
@@ -225,7 +229,7 @@ define([
             knw.danger(short, undefined, showMsg);
         });
 
-        this.events.on('websocket_closed.Kernel', function (event, data) {
+        this.events.on('status_disconnected.Kernel', function (event, data) {
             var kernel = data.kernel;
             var ws_url = data.ws_url;
             var early = data.early;

--- a/IPython/html/static/notebook/js/tour.js
+++ b/IPython/html/static/notebook/js/tour.js
@@ -91,19 +91,19 @@ define([
                 element: "#kernel_indicator",
                 title: "Kernel Indicator",
                 placement: 'bottom',
-                onShow: function(tour) { events.trigger('status_idle.Kernel');},
+                onShow: function(tour) { events.trigger('kernel_idle.Kernel');},
                 content: "This is the Kernel indicator. It looks like this when the Kernel is idle."
             }, {
                 element: "#kernel_indicator",
                 title: "Kernel Indicator",
                 placement: 'bottom',
-                onShow: function(tour) { events.trigger('status_busy.Kernel'); },
+                onShow: function(tour) { events.trigger('kernel_busy.Kernel'); },
                 content: "The Kernel indicator looks like this when the Kernel is busy."
             }, {
                 element: ".fa-stop",
                 placement: 'bottom',
                 title: "Interrupting the Kernel",
-                onHide: function(tour) { events.trigger('status_idle.Kernel'); },
+                onHide: function(tour) { events.trigger('kernel_idle.Kernel'); },
                 content: "To cancel a computation in progress, you can click here."
             }, {
                 element: "#notification_kernel",

--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -94,8 +94,8 @@ define([
             that.send_input_reply(data);
         });
 
-        var record_status = function (evt) {
-            console.log('Kernel: ' + evt.type + ' (' + that.id + ')');
+        var record_status = function (evt, info) {
+            console.log('Kernel: ' + evt.type + ' (' + info.kernel.id + ')');
         };
 
         this.events.on('kernel_created.Kernel', record_status);
@@ -397,7 +397,7 @@ define([
         // get kernel info so we know what state the kernel is in
         var that = this;
         this.kernel_info(function () {
-            that.events.trigger('kernel_ready.Kernel', {kernel: this});
+            that.events.trigger('kernel_ready.Kernel', {kernel: that});
         });
     };
 
@@ -451,7 +451,7 @@ define([
                 that.get_info(function () {
                     that._ws_closed(ws_host_url, false);
                 }, function () {
-                    that.events.trigger('kernel_dead.Kernel', {kernel: this});
+                    that.events.trigger('kernel_dead.Kernel', {kernel: that});
                     that._kernel_dead();
                 });
             }
@@ -539,7 +539,7 @@ define([
         var that = this;
         var close = function (c) {
             return function () {
-                if (that.channels[c].readyState === WebSocket.CLOSED) {
+                if (that.channels[c] && that.channels[c].readyState === WebSocket.CLOSED) {
                     that.channels[c] = null;
                 }
             };
@@ -715,7 +715,7 @@ define([
             content.allow_stdin = true;
         }
         $.extend(true, content, options);
-        this.events.trigger('execution_request.Kernel', {kernel: this, content:content});
+        this.events.trigger('execution_request.Kernel', {kernel: this, content: content});
         return this.send_shell_message("execute_request", content, callbacks);
     };
 
@@ -753,7 +753,7 @@ define([
         var content = {
             value : input
         };
-        this.events.trigger('input_reply.Kernel', {kernel: this, content:content});
+        this.events.trigger('input_reply.Kernel', {kernel: this, content: content});
         var msg = this._get_msg("input_reply", content);
         this.channels.stdin.send(JSON.stringify(msg));
         return msg.header.msg_id;
@@ -854,7 +854,7 @@ define([
      */
     Kernel.prototype._handle_shell_reply = function (e) {
         var reply = $.parseJSON(e.data);
-        this.events.trigger('shell_reply.Kernel', {kernel: this, reply:reply});
+        this.events.trigger('shell_reply.Kernel', {kernel: this, reply: reply});
         var content = reply.content;
         var metadata = reply.metadata;
         var parent_id = reply.parent_header.msg_id;

--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -158,7 +158,7 @@ define([
             cache: false,
             type: "DELETE",
             dataType: "json",
-            success: this._on_success(success),
+            success: this._on_success(on_success),
             error: this._on_error(error)
         });
     };
@@ -193,12 +193,6 @@ define([
                 success(data, status, xhr);
             }
         };
-        var on_error = function (xhr, status, err) {
-            that._handle_start_failure(xhr, status, err);
-            if (error) {
-                error(xhr, status, err);
-            }
-        };
 
         var url = utils.url_join_encode(this.kernel_url, 'restart');
         $.ajax(url, {
@@ -206,7 +200,7 @@ define([
             cache: false,
             type: "POST",
             dataType: "json",
-            success: this._on_success(success),
+            success: this._on_success(on_success),
             error: this._on_error(error)
         });
     };
@@ -214,8 +208,10 @@ define([
     Kernel.prototype._on_success = function (success) {
         var that = this;
         return function (data, status, xhr) {
-            that.id = data.id;
-            that.name = data.name;
+            if (data) {
+                that.id = data.id;
+                that.name = data.name;
+            }
             that.kernel_url = utils.url_join_encode(that.kernel_service_url, that.id);
             if (success) {
                 success(data, status, xhr);

--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -924,7 +924,7 @@ define([
             this.events.trigger('kernel_starting.Kernel', {kernel: this});
             var that = this;
             this.kernel_info(function () {
-                that.events.trigger('kernel_ready.Kernel', {kernel: this});
+                that.events.trigger('kernel_ready.Kernel', {kernel: that});
             });
 
         } else if (execution_state === 'restarting') {

--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -268,6 +268,7 @@ define([
 
     Kernel.prototype._kernel_dead = function () {
         this.events.trigger('status_dead.Kernel');
+        this.events.trigger('no_kernel.Kernel');
         this.stop_channels();
     };
 
@@ -693,6 +694,7 @@ define([
         
         if (execution_state === 'busy') {
             this.events.trigger('status_busy.Kernel', {kernel: this});
+
         } else if (execution_state === 'idle') {
             // signal that iopub callbacks are (probably) done
             // async output may still arrive,
@@ -701,6 +703,7 @@ define([
             
             // trigger status_idle event
             this.events.trigger('status_idle.Kernel', {kernel: this});
+
         } else if (execution_state === 'restarting') {
             // autorestarting is distinct from restarting,
             // in that it means the kernel died and the server is restarting it.
@@ -708,10 +711,9 @@ define([
             // autorestart shows the more prominent dialog.
             this.events.trigger('status_autorestarting.Kernel', {kernel: this});
             this.events.trigger('status_restarting.Kernel', {kernel: this});
+
         } else if (execution_state === 'dead') {
-            this.stop_channels();
-            this.events.trigger('status_dead.Kernel', {kernel: this});
-            this.events.trigger('status_restart_failed.Kernel', {kernel: this});
+            this._kernel_dead();
         }
     };
     

--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -103,8 +103,10 @@ define([
         this.events.on('status_autorestarting.Kernel', record_status);
         this.events.on('status_interrupting.Kernel', record_status);
         this.events.on('status_disconnected.Kernel', record_status);
-        this.events.on('status_idle.Kernel', record_status);
-        this.events.on('status_busy.Kernel', record_status);
+        // these are commented out because they are triggered a lot, but can
+        // be uncommented for debugging purposes
+        //this.events.on('status_idle.Kernel', record_status);
+        //this.events.on('status_busy.Kernel', record_status);
         this.events.on('status_killed.Kernel', record_status);
         this.events.on('kernel_dead.Kernel', record_status);
     };

--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -355,11 +355,18 @@ define([
      * @method stop_channels
      */
     Kernel.prototype.stop_channels = function () {
+        var that = this;
+        var close = function (c) {
+            return function () {
+                if (that.channels[c].readyState === WebSocket.CLOSED) {
+                    that.channels[c] = null;
+                }
+            };
+        };
         for (var c in this.channels) {
             if ( this.channels[c] !== null ) {
-                this.channels[c].onclose = null;
+                this.channels[c].onclose = close(c);
                 this.channels[c].close();
-                this.channels[c] = null;
             }
         }
     };
@@ -377,6 +384,15 @@ define([
             }
         }
         return true;
+    };
+
+    Kernel.prototype.is_fully_disconnected = function () {
+        for (var c in this.channels) {
+            if (this.channels[c] === null) {
+                return true;
+            }
+        }
+        return false;
     };
     
     // send a message on the Kernel's shell channel

--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -61,6 +61,8 @@ define([
         
         this.last_msg_id = null;
         this.last_msg_callbacks = {};
+
+        this._autorestart_attempt = 0;
     };
 
     /**
@@ -110,6 +112,10 @@ define([
         this.events.on('status_ready.Kernel', record_status);
         this.events.on('status_killed.Kernel', record_status);
         this.events.on('kernel_dead.Kernel', record_status);
+
+        this.events.on('status_ready.Kernel', function () {
+            that._autorestart_attempt = 0;
+        });
     };
 
     /**
@@ -922,8 +928,9 @@ define([
             // in that it means the kernel died and the server is restarting it.
             // status_restarting sets the notification widget,
             // autorestart shows the more prominent dialog.
+            this._autorestart_attempt = this._autorestart_attempt + 1;
             this.events.trigger('status_restarting.Kernel', {kernel: this});
-            this.events.trigger('status_autorestarting.Kernel', {kernel: this});
+            this.events.trigger('status_autorestarting.Kernel', {kernel: this, attempt: this._autorestart_attempt});
 
         } else if (execution_state === 'dead') {
             this.events.trigger('kernel_dead.Kernel', {kernel: this});

--- a/IPython/html/static/services/kernels/js/kernel.js
+++ b/IPython/html/static/services/kernels/js/kernel.js
@@ -249,7 +249,11 @@ define([
 
         var that = this;
         var on_success = function (data, status, xhr) {
-            that.kernel_info(); // get kernel info so we know what state the kernel is in
+            that.events.trigger('status_busy.Kernel', {kernel: this});
+            // get kernel info so we know what state the kernel is in
+            that.kernel_info(function () {
+                that.events.trigger('status_idle.Kernel', {kernel: this});
+            });
             if (success) {
                 success(data, status, xhr);
             }
@@ -380,7 +384,12 @@ define([
      */
     Kernel.prototype._kernel_connected = function () {
         this.events.trigger('status_connected.Kernel', {kernel: this});
-        this.kernel_info(); // get kernel info so we know what state the kernel is in
+        this.events.trigger('status_busy.Kernel', {kernel: this});
+        // get kernel info so we know what state the kernel is in
+        var that = this;
+        this.kernel_info(function () {
+            that.events.trigger('status_idle.Kernel', {kernel: this});
+        });
     };
 
     /**

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -54,7 +54,7 @@ define([
             console.log('Session: ' + evt.type + ' (' + that.id + ')');
         };
 
-        this.events.on('kernel_started.Session', record_status);
+        this.events.on('kernel_created.Session', record_status);
         this.events.on('kernel_dead.Session', record_status);
         this.events.on('status_killed.Session', record_status);
     };
@@ -98,8 +98,8 @@ define([
                 var kernel_service_url = utils.url_path_join(that.base_url, "api/kernels");
                 that.kernel = new kernel.Kernel(kernel_service_url, that.ws_url, that.notebook, that.kernel_model.name);
             }
-            that.events.trigger('kernel_started.Session', {session: that, kernel: that.kernel});
-            that.kernel._kernel_started(data.kernel);
+            that.events.trigger('kernel_created.Session', {session: that, kernel: that.kernel});
+            that.kernel._kernel_created(data.kernel);
             if (success) {
                 success(data, status, xhr);
             }

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -64,7 +64,7 @@ define([
             }
         };
         var on_error = function (xhr, status, err) {
-            that.events.trigger('status_dead.Kernel');
+            that.events.trigger('no_kernel.Kernel');
             if (error) {
                 error(xhr, status, err);
             }

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -44,7 +44,21 @@ define([
         this.notebook = options.notebook;
         this.kernel = null;
         this.events = options.notebook.events;
+
+        this.bind_events();
     };
+
+    Session.prototype.bind_events = function () {
+        var that = this;
+        var record_status = function (evt) {
+            console.log('Session: ' + evt.type + ' (' + that.id + ')');
+        };
+
+        this.events.on('kernel_started.Session', record_status);
+        this.events.on('kernel_dead.Session', record_status);
+        this.events.on('status_killed.Session', record_status);
+    };
+
 
     // Public REST api functions
 

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -198,6 +198,20 @@ define([
         });
     };
 
+    /**
+     * Restart the session by deleting it and the starting it
+     * fresh. If options are given, they can include any of the
+     * following:
+     *
+     * - notebook_name - the name of the notebook
+     * - notebook_path - the path to the notebook
+     * - kernel_name - the name (type) of the kernel
+     *
+     * @function restart
+     * @param {Object} [options] - options for the new kernel
+     * @param {function} [success] - function executed on ajax success
+     * @param {function} [error] - functon executed on ajax error
+     */
     Session.prototype.restart = function (options, success, error) {
         var that = this;
         var start = function () {

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -56,7 +56,7 @@ define([
 
         this.events.on('kernel_created.Session', record_status);
         this.events.on('kernel_dead.Session', record_status);
-        this.events.on('status_killed.Session', record_status);
+        this.events.on('kernel_killed.Session', record_status);
 
         // if the kernel dies, then also remove the session
         this.events.on('kernel_dead.Kernel', function () {
@@ -189,7 +189,7 @@ define([
      */
     Session.prototype.delete = function (success, error) {
         if (this.kernel) {
-            this.events.trigger('status_killed.Session', {session: this, kernel: this.kernel});
+            this.events.trigger('kernel_killed.Session', {session: this, kernel: this.kernel});
             this.kernel._kernel_dead();
         }
 

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -86,13 +86,14 @@ define([
         var on_success = function (data, status, xhr) {
             var kernel_service_url = utils.url_path_join(that.base_url, "api/kernels");
             that.kernel = new kernel.Kernel(kernel_service_url, that.ws_url, that.notebook, that.kernel_model.name);
+            that.events.trigger('kernel_started.Session', {session: that, kernel: that.kernel});
             that.kernel._kernel_started(data.kernel);
             if (success) {
                 success(data, status, xhr);
             }
         };
         var on_error = function (xhr, status, err) {
-            that.events.trigger('no_kernel.Kernel');
+            that.events.trigger('kernel_dead.Session', {session: that});
             if (error) {
                 error(xhr, status, err);
             }
@@ -171,6 +172,7 @@ define([
      */
     Session.prototype.delete = function (success, error) {
         if (this.kernel) {
+            this.events.trigger('status_killed.Session', {session: this, kernel: this.kernel});
             this.kernel._kernel_dead();
         }
 

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -88,7 +88,7 @@ define([
             that.kernel = new kernel.Kernel(
                 kernel_service_url, that.ws_url, that.notebook,
                 that.kernel_model.id, that.kernel_model.name);
-            that.kernel._kernel_started(data.kernel);
+            that.kernel._kernel_started();
             if (success) {
                 success(data, status, xhr);
             }

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -50,8 +50,8 @@ define([
 
     Session.prototype.bind_events = function () {
         var that = this;
-        var record_status = function (evt) {
-            console.log('Session: ' + evt.type + ' (' + that.id + ')');
+        var record_status = function (evt, info) {
+            console.log('Session: ' + evt.type + ' (' + info.session.id + ')');
         };
 
         this.events.on('kernel_created.Session', record_status);

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -105,7 +105,7 @@ define([
             }
         };
         var on_error = function (xhr, status, err) {
-            that.events.trigger('kernel_dead.Session', {session: that});
+            that.events.trigger('kernel_dead.Session', {session: that, xhr: xhr, status: status, error: err});
             if (error) {
                 error(xhr, status, err);
             }

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -48,6 +48,10 @@ define([
      * POST /api/sessions
      */
     Session.prototype.start = function (success, error) {
+        if (this.kernel !== null) {
+            throw new Error("session has already been started");
+        };
+
         var that = this;
         var on_success = function (data, status, xhr) {
             var kernel_service_url = utils.url_path_join(that.base_url, "api/kernels");
@@ -95,23 +99,31 @@ define([
      * PATCH /api/sessions/[:session_id]
      */
     Session.prototype.change = function (notebook_name, notebook_path, kernel_name, success, error) {
-        this.notebook_model.name = notebook_name;
-        this.notebook_model.path = notebook_path;
-        this.kernel_model.name = kernel_name;
+        if (notebook_name !== undefined) {
+            this.notebook_model.name = notebook_name;
+        }
+        if (notebook_path !== undefined) {
+            this.notebook_model.path = notebook_path;
+        }
+        if (kernel_name !== undefined) {
+            this.kernel_model.name = kernel_name;
+        }
+
+        console.log(JSON.stringify(this._get_model()));
 
         $.ajax(this.session_url, {
             processData: false,
             cache: false,
             type: "PATCH",
             data: JSON.stringify(this._get_model()),
-            dataType : "json",
+            dataType: "json",
             success: this._on_success(success),
             error: this._on_error(error)
         });
     };
 
     Session.prototype.rename_notebook = function (name, path, success, error) {
-        this.change(name, path, this.kernel_model.name, success, error);
+        this.change(name, path, undefined, success, error);
     };
 
     /**

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -50,7 +50,6 @@ define([
     Session.prototype.start = function (success, error) {
         var that = this;
         var on_success = function (data, status, xhr) {
-            console.log("Session started: ", data.id);
             var kernel_service_url = utils.url_path_join(that.base_url, "api/kernels");
             that.kernel = new kernel.Kernel(
                 kernel_service_url, that.ws_url, that.notebook,

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -85,10 +85,8 @@ define([
         var that = this;
         var on_success = function (data, status, xhr) {
             var kernel_service_url = utils.url_path_join(that.base_url, "api/kernels");
-            that.kernel = new kernel.Kernel(
-                kernel_service_url, that.ws_url, that.notebook,
-                that.kernel_model.id, that.kernel_model.name);
-            that.kernel._kernel_started();
+            that.kernel = new kernel.Kernel(kernel_service_url, that.ws_url, that.notebook, that.kernel_model.name);
+            that.kernel._kernel_started(data.kernel);
             if (success) {
                 success(data, status, xhr);
             }

--- a/IPython/html/static/services/sessions/js/session.js
+++ b/IPython/html/static/services/sessions/js/session.js
@@ -57,6 +57,11 @@ define([
         this.events.on('kernel_created.Session', record_status);
         this.events.on('kernel_dead.Session', record_status);
         this.events.on('status_killed.Session', record_status);
+
+        // if the kernel dies, then also remove the session
+        this.events.on('kernel_dead.Kernel', function () {
+            that.delete();
+        });
     };
 
 

--- a/IPython/html/tests/services/kernel.js
+++ b/IPython/html/tests/services/kernel.js
@@ -3,24 +3,127 @@
 // Kernel tests
 //
 casper.notebook_test(function () {
+    // test that the kernel is running
     this.then(function () {
-        this.test.assert(this.kernel_running(), 'kernel: kernel is running');
+        this.test.assert(this.kernel_running(), 'kernel is running');
     });
 
+    // test list
+    this.thenEvaluate(function () {
+        IPython._kernels = null;
+        IPython.notebook.kernel.list(function (data) {
+            IPython._kernels = data;
+        });
+    });
+    this.waitFor(function () {
+        return this.evaluate(function () {
+            return IPython._kernels !== null;
+        });
+    });
+    this.then(function () {
+        var num_kernels = this.evaluate(function () {
+            return IPython._kernels.length;
+        });
+        this.test.assertEquals(num_kernels, 1, 'one kernel running');
+    });
+    
+    // test get_info
+    var kernel_info = this.evaluate(function () {
+        return {
+            name: IPython.notebook.kernel.name,
+            id: IPython.notebook.kernel.id
+        };
+    });
+    this.thenEvaluate(function () {
+        IPython._kernel_info = null;
+        IPython.notebook.kernel.get_info(function (data) {
+            IPython._kernel_info = data;
+        });
+    });
+    this.waitFor(function () {
+        return this.evaluate(function () {
+            return IPython._kernel_info !== null;
+        });
+    });
+    this.then(function () {
+        var new_kernel_info = this.evaluate(function () {
+            return IPython._kernel_info;
+        });
+        this.test.assertEquals(kernel_info.name, new_kernel_info.name, 'kernel: name correct');
+        this.test.assertEquals(kernel_info.id, new_kernel_info.id, 'kernel: id correct');
+    });
+
+    // test interrupt
+    this.thenEvaluate(function () {
+        IPython._interrupted = false;
+        IPython.notebook.kernel.interrupt(function () {
+            IPython._interrupted = true;
+        });
+    });
+    this.waitFor(function () {
+        return this.evaluate(function () {
+            return IPython._interrupted;
+        });
+    });
+    this.then(function () {
+        var interrupted = this.evaluate(function () {
+            return IPython._interrupted;
+        });
+        this.test.assert(interrupted, 'kernel was interrupted');
+    });
+
+    // test restart
+    this.thenEvaluate(function () {
+        IPython.notebook.kernel.restart();
+    });
+    this.waitFor(function () {
+        return this.evaluate(function () {
+            return IPython.notebook.kernel.is_fully_disconnected();
+        });
+    });
+    this.waitFor(function () {
+        return this.evaluate(function () {
+            return IPython.notebook.kernel.is_connected();
+        });
+    });
+    this.then(function () {
+        this.test.assert(this.kernel_running(), 'kernel restarted');
+    });
+
+    // test reconnect
+    this.thenEvaluate(function () {
+        IPython.notebook.kernel.stop_channels();
+    });
+    this.waitFor(function () {
+        return this.evaluate(function () {
+            return IPython.notebook.kernel.is_fully_disconnected();
+        });
+    });
+    this.thenEvaluate(function () {
+        IPython.notebook.kernel.reconnect();
+    });
+    this.waitFor(function () {
+        return this.evaluate(function () {
+            return IPython.notebook.kernel.is_connected();
+        });
+    });
+    this.then(function () {
+        this.test.assert(this.kernel_running(), 'kernel reconnected');
+    });
+
+    // test kernel_info_request
     this.evaluate(function () {
         IPython.notebook.kernel.kernel_info(
             function(msg){
                 IPython._kernel_info_response = msg;
             });
     });
-
     this.waitFor(
         function () {
             return this.evaluate(function(){
                 return IPython._kernel_info_response;
         });
     });
-
     this.then(function () {
         var kernel_info_response =  this.evaluate(function(){
             return IPython._kernel_info_response;
@@ -28,18 +131,62 @@ casper.notebook_test(function () {
         this.test.assertTrue( kernel_info_response.msg_type === 'kernel_info_reply', 'Kernel info request return kernel_info_reply');
         this.test.assertTrue( kernel_info_response.content !== undefined, 'Kernel_info_reply is not undefined');
     });
-    
+
+    // test kill
     this.thenEvaluate(function () {
         IPython.notebook.kernel.kill();
     });
-    
     this.waitFor(function () {
         return this.evaluate(function () {
             return IPython.notebook.kernel.is_fully_disconnected();
         });
     });
-    
     this.then(function () {
         this.test.assert(!this.kernel_running(), 'kernel is not running');
+    });
+
+    // test start
+    var url;
+    this.then(function () {
+        url = this.evaluate(function () {
+            return IPython.notebook.kernel.start();
+        });
+    });
+    this.then(function () {
+        this.test.assertEquals(url, "/api/kernels", "start url is correct");
+    });
+    this.waitFor(function () {
+        return this.evaluate(function () {
+            return IPython.notebook.kernel.is_connected();
+        });
+    });
+    this.then(function () {
+        this.test.assert(this.kernel_running(), 'kernel is running');
+    });
+
+    // test start with parameters
+    this.thenEvaluate(function () {
+        IPython.notebook.kernel.kill();
+    });
+    this.waitFor(function () {
+        return this.evaluate(function () {
+            return IPython.notebook.kernel.is_fully_disconnected();
+        });
+    });
+    this.then(function () {
+        url = this.evaluate(function () {
+            return IPython.notebook.kernel.start({foo: "bar"});
+        });
+    });
+    this.then(function () {
+        this.test.assertEquals(url, "/api/kernels?foo=bar", "start url with params is correct");
+    });
+    this.waitFor(function () {
+        return this.evaluate(function () {
+            return IPython.notebook.kernel.is_connected();
+        });
+    });
+    this.then(function () {
+        this.test.assert(this.kernel_running(), 'kernel is running');
     });
 });

--- a/IPython/html/tests/services/kernel.js
+++ b/IPython/html/tests/services/kernel.js
@@ -76,16 +76,8 @@ casper.notebook_test(function () {
     this.thenEvaluate(function () {
         IPython.notebook.kernel.restart();
     });
-    this.waitFor(function () {
-        return this.evaluate(function () {
-            return IPython.notebook.kernel.is_fully_disconnected();
-        });
-    });
-    this.waitFor(function () {
-        return this.evaluate(function () {
-            return IPython.notebook.kernel.is_connected();
-        });
-    });
+    this.waitFor(this.kernel_disconnected);
+    this.wait_for_kernel_ready();
     this.then(function () {
         this.test.assert(this.kernel_running(), 'kernel restarted');
     });
@@ -94,19 +86,11 @@ casper.notebook_test(function () {
     this.thenEvaluate(function () {
         IPython.notebook.kernel.stop_channels();
     });
-    this.waitFor(function () {
-        return this.evaluate(function () {
-            return IPython.notebook.kernel.is_fully_disconnected();
-        });
-    });
+    this.waitFor(this.kernel_disconnected);
     this.thenEvaluate(function () {
         IPython.notebook.kernel.reconnect();
     });
-    this.waitFor(function () {
-        return this.evaluate(function () {
-            return IPython.notebook.kernel.is_connected();
-        });
-    });
+    this.wait_for_kernel_ready();
     this.then(function () {
         this.test.assert(this.kernel_running(), 'kernel reconnected');
     });
@@ -136,11 +120,7 @@ casper.notebook_test(function () {
     this.thenEvaluate(function () {
         IPython.notebook.kernel.kill();
     });
-    this.waitFor(function () {
-        return this.evaluate(function () {
-            return IPython.notebook.kernel.is_fully_disconnected();
-        });
-    });
+    this.waitFor(this.kernel_disconnected);
     this.then(function () {
         this.test.assert(!this.kernel_running(), 'kernel is not running');
     });
@@ -155,11 +135,7 @@ casper.notebook_test(function () {
     this.then(function () {
         this.test.assertEquals(url, "/api/kernels", "start url is correct");
     });
-    this.waitFor(function () {
-        return this.evaluate(function () {
-            return IPython.notebook.kernel.is_connected();
-        });
-    });
+    this.wait_for_kernel_ready();
     this.then(function () {
         this.test.assert(this.kernel_running(), 'kernel is running');
     });
@@ -168,11 +144,7 @@ casper.notebook_test(function () {
     this.thenEvaluate(function () {
         IPython.notebook.kernel.kill();
     });
-    this.waitFor(function () {
-        return this.evaluate(function () {
-            return IPython.notebook.kernel.is_fully_disconnected();
-        });
-    });
+    this.waitFor(this.kernel_disconnected);
     this.then(function () {
         url = this.evaluate(function () {
             return IPython.notebook.kernel.start({foo: "bar"});
@@ -181,16 +153,10 @@ casper.notebook_test(function () {
     this.then(function () {
         this.test.assertEquals(url, "/api/kernels?foo=bar", "start url with params is correct");
     });
-    this.waitFor(function () {
-        return this.evaluate(function () {
-            return IPython.notebook.kernel.is_connected();
-        });
-    });
+    this.wait_for_kernel_ready();
     this.then(function () {
         this.test.assert(this.kernel_running(), 'kernel is running');
     });
-    // wait for any last idle/busy messages to be handled
-    this.wait(1000);
 
     // check for events in kill/start cycle
     this.event_test(
@@ -213,7 +179,7 @@ casper.notebook_test(function () {
         }
     );
     // wait for any last idle/busy messages to be handled
-    this.wait(500);
+    this.wait_for_kernel_ready();
 
     // check for events in disconnect/connect cycle
     this.event_test(
@@ -221,8 +187,6 @@ casper.notebook_test(function () {
         [
             'status_reconnecting.Kernel',
             'status_connected.Kernel',
-            'status_busy.Kernel',
-            'status_idle.Kernel'
         ],
         function () {
             this.thenEvaluate(function () {
@@ -232,7 +196,7 @@ casper.notebook_test(function () {
         }
     );
     // wait for any last idle/busy messages to be handled
-    this.wait(500);
+    this.wait_for_kernel_ready();
 
     // check for events in the restart cycle
     this.event_test(
@@ -251,7 +215,7 @@ casper.notebook_test(function () {
         }
     );
     // wait for any last idle/busy messages to be handled
-    this.wait(500);
+    this.wait_for_kernel_ready();
 
     // TODO: test for failed restart, that it triggers
     // kernel_dead.Kernel? How to do this?
@@ -273,6 +237,7 @@ casper.notebook_test(function () {
             });
         }
     );
+    this.wait_for_kernel_ready();
 
     // check for events after ws close
     this.event_test(
@@ -291,7 +256,7 @@ casper.notebook_test(function () {
         }
     );
     // wait for any last idle/busy messages to be handled
-    this.wait(500);
+    this.wait_for_kernel_ready();
 
     // check for events after ws close (error)
     this.event_test(
@@ -306,6 +271,4 @@ casper.notebook_test(function () {
             });
         }
     );
-    // wait for any last idle/busy messages to be handled
-    this.wait(500);
 });

--- a/IPython/html/tests/services/kernel.js
+++ b/IPython/html/tests/services/kernel.js
@@ -195,15 +195,10 @@ casper.notebook_test(function () {
         'kill/start',
         [
             'status_killed.Kernel',
-            'kernel_started.Kernel',
+            'kernel_created.Kernel',
             'status_connected.Kernel',
-            // technically we should get this message, but sometimes the kernel
-            // finishes starting before we connect to it so then we don't receive
-            // this message
-            //
-            //'status_starting.Kernel',
-            'status_busy.Kernel',
-            'status_idle.Kernel'
+            'status_starting.Kernel',
+            'status_ready.Kernel'
         ],
         function () {
             this.thenEvaluate(function () {
@@ -242,15 +237,10 @@ casper.notebook_test(function () {
         'restart',
         [
             'status_restarting.Kernel',
-            'kernel_started.Kernel',
+            'kernel_created.Kernel',
             'status_connected.Kernel',
-            // technically we should get this message, but sometimes the kernel
-            // finishes starting before we connect to it so then we don't receive
-            // this message
-            //
-            //'status_starting.Kernel',
-            'status_busy.Kernel',
-            'status_idle.Kernel'
+            'status_starting.Kernel',
+            'status_ready.Kernel'
         ],
         function () {
             this.thenEvaluate(function () {

--- a/IPython/html/tests/services/kernel.js
+++ b/IPython/html/tests/services/kernel.js
@@ -197,7 +197,11 @@ casper.notebook_test(function () {
             'status_killed.Kernel',
             'kernel_started.Kernel',
             'status_connected.Kernel',
-            'status_starting.Kernel',
+            // technically we should get this message, but sometimes the kernel
+            // finishes starting before we connect to it so then we don't receive
+            // this message
+            //
+            //'status_starting.Kernel',
             'status_busy.Kernel',
             'status_idle.Kernel'
         ],
@@ -240,7 +244,11 @@ casper.notebook_test(function () {
             'status_restarting.Kernel',
             'kernel_started.Kernel',
             'status_connected.Kernel',
-            'status_starting.Kernel',
+            // technically we should get this message, but sometimes the kernel
+            // finishes starting before we connect to it so then we don't receive
+            // this message
+            //
+            //'status_starting.Kernel',
             'status_busy.Kernel',
             'status_idle.Kernel'
         ],

--- a/IPython/html/tests/services/kernel.js
+++ b/IPython/html/tests/services/kernel.js
@@ -162,11 +162,11 @@ casper.notebook_test(function () {
     this.event_test(
         'kill/start',
         [
-            'status_killed.Kernel',
+            'kernel_killed.Kernel',
             'kernel_created.Kernel',
-            'status_connected.Kernel',
-            'status_starting.Kernel',
-            'status_ready.Kernel'
+            'kernel_connected.Kernel',
+            'kernel_starting.Kernel',
+            'kernel_ready.Kernel'
         ],
         function () {
             this.thenEvaluate(function () {
@@ -185,8 +185,8 @@ casper.notebook_test(function () {
     this.event_test(
         'reconnect',
         [
-            'status_reconnecting.Kernel',
-            'status_connected.Kernel',
+            'kernel_reconnecting.Kernel',
+            'kernel_connected.Kernel',
         ],
         function () {
             this.thenEvaluate(function () {
@@ -202,11 +202,11 @@ casper.notebook_test(function () {
     this.event_test(
         'restart',
         [
-            'status_restarting.Kernel',
+            'kernel_restarting.Kernel',
             'kernel_created.Kernel',
-            'status_connected.Kernel',
-            'status_starting.Kernel',
-            'status_ready.Kernel'
+            'kernel_connected.Kernel',
+            'kernel_starting.Kernel',
+            'kernel_ready.Kernel'
         ],
         function () {
             this.thenEvaluate(function () {
@@ -221,9 +221,9 @@ casper.notebook_test(function () {
     this.event_test(
         'interrupt',
         [
-            'status_interrupting.Kernel',
-            'status_busy.Kernel',
-            'status_idle.Kernel'
+            'kernel_interrupting.Kernel',
+            'kernel_busy.Kernel',
+            'kernel_idle.Kernel'
         ],
         function () {
             this.thenEvaluate(function () {
@@ -237,11 +237,11 @@ casper.notebook_test(function () {
     this.event_test(
         'ws_closed_ok',
         [
-            'status_disconnected.Kernel',
-            'status_reconnecting.Kernel',
-            'status_connected.Kernel',
-            'status_busy.Kernel',
-            'status_idle.Kernel'
+            'kernel_disconnected.Kernel',
+            'kernel_reconnecting.Kernel',
+            'kernel_connected.Kernel',
+            'kernel_busy.Kernel',
+            'kernel_idle.Kernel'
         ],
         function () {
             this.thenEvaluate(function () {
@@ -256,8 +256,8 @@ casper.notebook_test(function () {
     this.event_test(
         'ws_closed_error',
         [
-            'status_disconnected.Kernel',
-            'connection_failed.Kernel'
+            'kernel_disconnected.Kernel',
+            'kernel_connection_failed.Kernel'
         ],
         function () {
             this.thenEvaluate(function () {
@@ -277,8 +277,8 @@ casper.notebook_test(function () {
     this.event_test(
         'autorestarting',
         [
-            'status_restarting.Kernel',
-            'status_autorestarting.Kernel',
+            'kernel_restarting.Kernel',
+            'kernel_autorestarting.Kernel',
         ],
         function () {
             this.thenEvaluate(function () {
@@ -294,8 +294,8 @@ casper.notebook_test(function () {
     this.event_test(
         'failed_restart',
         [
-            'status_restarting.Kernel',
-            'status_autorestarting.Kernel',
+            'kernel_restarting.Kernel',
+            'kernel_autorestarting.Kernel',
             'kernel_dead.Kernel'
         ],
         function () {

--- a/IPython/html/tests/services/kernel.js
+++ b/IPython/html/tests/services/kernel.js
@@ -189,6 +189,8 @@ casper.notebook_test(function () {
     this.then(function () {
         this.test.assert(this.kernel_running(), 'kernel is running');
     });
+    // wait for any last idle/busy messages to be handled
+    this.wait(1000);
 
     // check for events in kill/start cycle
     this.event_test(
@@ -304,4 +306,6 @@ casper.notebook_test(function () {
             });
         }
     );
+    // wait for any last idle/busy messages to be handled
+    this.wait(500);
 });

--- a/IPython/html/tests/services/session.js
+++ b/IPython/html/tests/services/session.js
@@ -4,21 +4,107 @@
 //
 
 casper.notebook_test(function () {
+    var that = this;
+    var get_info = function () {
+        return that.evaluate(function () {
+            return JSON.parse(JSON.stringify(IPython.notebook.session._get_model()));
+        });
+    };
+
+    // test that the kernel is running
     this.then(function () {
         this.test.assert(this.kernel_running(), 'session: kernel is running');
     });
 
+    // test list
+    this.thenEvaluate(function () {
+        IPython._sessions = null;
+        IPython.notebook.session.list(function (data) {
+            IPython._sessions = data;
+        });
+    });
+    this.waitFor(function () {
+        return this.evaluate(function () {
+            return IPython._sessions !== null;
+        });
+    });
+    this.then(function () {
+        var num_sessions = this.evaluate(function () {
+            return IPython._sessions.length;
+        });
+        this.test.assertEquals(num_sessions, 1, 'one session running');
+    });
+
+    // test get_info
+    var session_info = get_info();
+    this.thenEvaluate(function () {
+        IPython._session_info = null;
+        IPython.notebook.session.get_info(function (data) {
+            IPython._session_info = data;
+        });
+    });
+    this.waitFor(function () {
+        return this.evaluate(function () {
+            return IPython._session_info !== null;
+        });
+    });
+    this.then(function () {
+        var new_session_info = this.evaluate(function () {
+            return IPython._session_info;
+        });
+        this.test.assertEquals(session_info.notebook.name, new_session_info.notebook.name, 'session: notebook name correct');
+        this.test.assertEquals(session_info.notebook.path, new_session_info.notebook.path, 'session: notebook path correct');
+        this.test.assertEquals(session_info.kernel.name, new_session_info.kernel.name, 'session: kernel name correct');
+        this.test.assertEquals(session_info.kernel.id, new_session_info.kernel.id, 'session: kernel id correct');
+    });
+
+    // test rename_notebook
+    //
+    // TODO: the PATCH request isn't supported by phantom, so this test always
+    // fails, see https://github.com/ariya/phantomjs/issues/11384
+    // when this is fixed we can properly run this test
+    //
+    // this.thenEvaluate(function () {
+    //     IPython._renamed = false;
+    //     IPython.notebook.session.rename_notebook(
+    //         "foo",
+    //         "bar",
+    //         function (data) {
+    //             IPython._renamed = true;
+    //         }
+    //     );
+    // });
+    // this.waitFor(function () {
+    //     return this.evaluate(function () {
+    //         return IPython._renamed;
+    //     });
+    // });
+    // this.then(function () {
+    //     var info = get_info();
+    //     this.test.assertEquals(info.notebook.name, "foo", "notebook was renamed");
+    //     this.test.assertEquals(info.notebook.path, "bar", "notebook path was changed");
+    // });
+
+    // test delete
     this.thenEvaluate(function () {
         IPython.notebook.session.delete();
     });
-
     this.waitFor(function () {
         return this.evaluate(function () {
             return IPython.notebook.kernel.is_fully_disconnected();
         });
     });
-
     this.then(function () {
         this.test.assert(!this.kernel_running(), 'session deletes kernel');
+    });
+
+    // test start after delete -- should throw an error
+    this.then(function () {
+        var start = function () {
+            this.evaluate(function () {
+                IPython.notebook.session.start();
+            });
+        };
+        this.test.assertRaises(start, [], 'error raised on start after delete');
     });
 });

--- a/IPython/html/tests/services/session.js
+++ b/IPython/html/tests/services/session.js
@@ -4,40 +4,21 @@
 //
 
 casper.notebook_test(function () {
-    this.evaluate(function () {
-        var kernel = IPython.notebook.session.kernel;
-        IPython._channels = [
-            kernel.shell_channel,
-            kernel.iopub_channel,
-            kernel.stdin_channel
-        ];
+    this.then(function () {
+        this.test.assert(this.kernel_running(), 'session: kernel is running');
+    });
+
+    this.thenEvaluate(function () {
         IPython.notebook.session.delete();
     });
-    
+
     this.waitFor(function () {
-        return this.evaluate(function(){
-            for (var i=0; i < IPython._channels.length; i++) {
-                var ws = IPython._channels[i];
-                if (ws.readyState !== ws.CLOSED) {
-                    return false;
-                }
-            }
-            return true;
+        return this.evaluate(function () {
+            return IPython.notebook.kernel.is_fully_disconnected();
         });
     });
 
     this.then(function () {
-        var states = this.evaluate(function() {
-            var states = [];
-            for (var i = 0; i < IPython._channels.length; i++) {
-                states.push(IPython._channels[i].readyState);
-            }
-            return states;
-        });
-        
-        for (var i = 0; i < states.length; i++) {
-            this.test.assertEquals(states[i], WebSocket.CLOSED,
-                "Session.delete closes websockets[" + i + "]");
-        }
+        this.test.assert(!this.kernel_running(), 'session deletes kernel');
     });
 });

--- a/IPython/html/tests/services/session.js
+++ b/IPython/html/tests/services/session.js
@@ -99,9 +99,9 @@ casper.notebook_test(function () {
         'start_session',
         [
             'kernel_created.Session',
-            'status_connected.Kernel',
-            'status_starting.Kernel',
-            'status_ready.Kernel'
+            'kernel_connected.Kernel',
+            'kernel_starting.Kernel',
+            'kernel_ready.Kernel'
         ],
         function () {
             this.thenEvaluate(function () {
@@ -114,7 +114,7 @@ casper.notebook_test(function () {
     // check for events when killing the session
     this.event_test(
         'delete_session',
-        ['status_killed.Session'],
+        ['kernel_killed.Session'],
         function () {
             this.thenEvaluate(function () {
                 IPython.notebook.session.delete();
@@ -126,11 +126,11 @@ casper.notebook_test(function () {
     this.event_test(
         'restart_session',
         [
-            'status_killed.Session',
+            'kernel_killed.Session',
             'kernel_created.Session',
-            'status_connected.Kernel',
-            'status_starting.Kernel',
-            'status_ready.Kernel'
+            'kernel_connected.Kernel',
+            'kernel_starting.Kernel',
+            'kernel_ready.Kernel'
         ],
         function () {
             this.thenEvaluate(function () {
@@ -144,9 +144,9 @@ casper.notebook_test(function () {
     this.event_test(
         'failed_restart',
         [
-            'status_restarting.Kernel',
-            'status_autorestarting.Kernel',
-            'status_killed.Session',
+            'kernel_restarting.Kernel',
+            'kernel_autorestarting.Kernel',
+            'kernel_killed.Session',
             'kernel_dead.Kernel',
         ],
         function () {
@@ -170,7 +170,7 @@ casper.notebook_test(function () {
     this.event_test(
         'bad_start_session',
         [
-            'status_killed.Session',
+            'kernel_killed.Session',
             'kernel_dead.Session'
         ],
         function () {

--- a/IPython/html/tests/services/session.js
+++ b/IPython/html/tests/services/session.js
@@ -104,7 +104,11 @@ casper.notebook_test(function () {
         [
             'kernel_started.Session',
             'status_connected.Kernel',
-            'status_starting.Kernel',
+            // technically we should get this message, but sometimes the kernel
+            // finishes starting before we connect to it so then we don't receive
+            // this message
+            //
+            //'status_starting.Kernel',
             'status_busy.Kernel',
             'status_idle.Kernel'
         ],
@@ -135,7 +139,11 @@ casper.notebook_test(function () {
             'status_killed.Session',
             'kernel_started.Session',
             'status_connected.Kernel',
-            'status_starting.Kernel',
+            // technically we should get this message, but sometimes the kernel
+            // finishes starting before we connect to it so then we don't receive
+            // this message
+            //
+            //'status_starting.Kernel',
             'status_busy.Kernel',
             'status_idle.Kernel'
         ],

--- a/IPython/html/tests/services/session.js
+++ b/IPython/html/tests/services/session.js
@@ -89,11 +89,7 @@ casper.notebook_test(function () {
     this.thenEvaluate(function () {
         IPython.notebook.session.delete();
     });
-    this.waitFor(function () {
-        return this.evaluate(function () {
-            return IPython.notebook.kernel.is_fully_disconnected();
-        });
-    });
+    this.waitFor(this.kernel_disconnected);
     this.then(function () {
         this.test.assert(!this.kernel_running(), 'session deletes kernel');
     });
@@ -113,7 +109,7 @@ casper.notebook_test(function () {
             });
         }
     );
-    this.wait(500);
+    this.wait_for_kernel_ready();
 
     // check for events when killing the session
     this.event_test(
@@ -125,7 +121,6 @@ casper.notebook_test(function () {
             });
         }
     );
-    this.wait(500);
 
     // check for events when restarting the session
     this.event_test(
@@ -143,7 +138,7 @@ casper.notebook_test(function () {
             });
         }
     );
-    this.wait(500);
+    this.wait_for_kernel_ready();
 
     // check for events when starting a nonexistant kernel
     this.event_test(

--- a/IPython/html/tests/services/session.js
+++ b/IPython/html/tests/services/session.js
@@ -98,13 +98,52 @@ casper.notebook_test(function () {
         this.test.assert(!this.kernel_running(), 'session deletes kernel');
     });
 
-    // test start after delete -- should throw an error
-    this.then(function () {
-        var start = function () {
-            this.evaluate(function () {
+    // check for events when starting the session
+    this.event_test(
+        'start_session',
+        [
+            'kernel_started.Session',
+            'status_connected.Kernel',
+            'status_starting.Kernel',
+            'status_busy.Kernel',
+            'status_idle.Kernel'
+        ],
+        function () {
+            this.thenEvaluate(function () {
                 IPython.notebook.session.start();
             });
-        };
-        this.test.assertRaises(start, [], 'error raised on start after delete');
-    });
+        }
+    );
+    this.wait(500);
+
+    // check for events when killing the session
+    this.event_test(
+        'delete_session',
+        ['status_killed.Session'],
+        function () {
+            this.thenEvaluate(function () {
+                IPython.notebook.session.delete();
+            });
+        }
+    );
+    this.wait(500);
+
+    // check for events when restarting the session
+    this.event_test(
+        'restart_session',
+        [
+            'status_killed.Session',
+            'kernel_started.Session',
+            'status_connected.Kernel',
+            'status_starting.Kernel',
+            'status_busy.Kernel',
+            'status_idle.Kernel'
+        ],
+        function () {
+            this.thenEvaluate(function () {
+                IPython.notebook.session.restart();
+            });
+        }
+    );
+    this.wait(500);
 });

--- a/IPython/html/tests/services/session.js
+++ b/IPython/html/tests/services/session.js
@@ -140,6 +140,32 @@ casper.notebook_test(function () {
     );
     this.wait_for_kernel_ready();
 
+    // test handling of failed restart
+    this.event_test(
+        'failed_restart',
+        [
+            'status_restarting.Kernel',
+            'status_autorestarting.Kernel',
+            'status_killed.Session',
+            'kernel_dead.Kernel',
+        ],
+        function () {
+            this.thenEvaluate(function () {
+                var cell = IPython.notebook.get_cell(0);
+                cell.set_text("import os\n" +
+                              "from IPython.kernel.connect import get_connection_file\n" +
+                              "with open(get_connection_file(), 'w') as f:\n" +
+                              "    f.write('garbage')\n" +
+                              "os._exit(1)");
+                cell.execute();
+            });
+        },
+
+        // need an extra-long timeout, because it needs to try
+        // restarting the kernel 5 times!
+        20000
+    );
+
     // check for events when starting a nonexistant kernel
     this.event_test(
         'bad_start_session',

--- a/IPython/html/tests/services/session.js
+++ b/IPython/html/tests/services/session.js
@@ -102,15 +102,10 @@ casper.notebook_test(function () {
     this.event_test(
         'start_session',
         [
-            'kernel_started.Session',
+            'kernel_created.Session',
             'status_connected.Kernel',
-            // technically we should get this message, but sometimes the kernel
-            // finishes starting before we connect to it so then we don't receive
-            // this message
-            //
-            //'status_starting.Kernel',
-            'status_busy.Kernel',
-            'status_idle.Kernel'
+            'status_starting.Kernel',
+            'status_ready.Kernel'
         ],
         function () {
             this.thenEvaluate(function () {
@@ -137,15 +132,10 @@ casper.notebook_test(function () {
         'restart_session',
         [
             'status_killed.Session',
-            'kernel_started.Session',
+            'kernel_created.Session',
             'status_connected.Kernel',
-            // technically we should get this message, but sometimes the kernel
-            // finishes starting before we connect to it so then we don't receive
-            // this message
-            //
-            //'status_starting.Kernel',
-            'status_busy.Kernel',
-            'status_idle.Kernel'
+            'status_starting.Kernel',
+            'status_ready.Kernel'
         ],
         function () {
             this.thenEvaluate(function () {

--- a/IPython/html/tests/services/session.js
+++ b/IPython/html/tests/services/session.js
@@ -154,4 +154,18 @@ casper.notebook_test(function () {
         }
     );
     this.wait(500);
+
+    // check for events when starting a nonexistant kernel
+    this.event_test(
+        'bad_start_session',
+        [
+            'status_killed.Session',
+            'kernel_dead.Session'
+        ],
+        function () {
+            this.thenEvaluate(function () {
+                IPython.notebook.session.restart({kernel_name: 'foo'});
+            });
+        }
+    );
 });

--- a/IPython/html/tests/util.js
+++ b/IPython/html/tests/util.js
@@ -28,10 +28,10 @@ casper.open_new_notebook = function () {
     this.thenEvaluate(function () {
         require(['base/js/namespace', 'base/js/events'], function (IPython, events) {
         
-            events.on('status_idle.Kernel',function () {
+            events.on('kernel_idle.Kernel',function () {
                 IPython._status = 'idle';
             });
-            events.on('status_busy.Kernel',function () {
+            events.on('kernel_busy.Kernel',function () {
                 IPython._status = 'busy';
             });
         });

--- a/IPython/html/tests/util.js
+++ b/IPython/html/tests/util.js
@@ -606,7 +606,6 @@ casper.event_test = function (name, events, action) {
             return Object.keys(IPython._event_handlers);
         });
         this.test.assertEquals(triggered.length, events.length, name + ': ' + events.length + ' events were triggered');
-        this.echo(handlers);
         this.test.assertEquals(handlers.length, 0, name + ': all handlers triggered');
         for (var i=0; i < events.length; i++) {
             this.test.assertEquals(triggered[i], events[i], name + ': ' + events[i] + ' was triggered');

--- a/IPython/html/tests/util.js
+++ b/IPython/html/tests/util.js
@@ -58,7 +58,7 @@ casper.page_loaded = function() {
 casper.kernel_running = function() {
     // Return whether or not the kernel is running.
     return this.evaluate(function() {
-        return IPython.notebook.kernel.running;
+        return IPython.notebook.kernel.is_connected();
     });
 };
 

--- a/IPython/html/tests/util.js
+++ b/IPython/html/tests/util.js
@@ -584,7 +584,7 @@ casper.dashboard_test = function (test) {
 
 // note that this will only work for UNIQUE events -- if you want to
 // listen for the same event twice, this will not work!
-casper.event_test = function (name, events, action) {
+casper.event_test = function (name, events, action, timeout) {
 
     // set up handlers to listen for each of the events
     this.thenEvaluate(function (events) {
@@ -611,7 +611,7 @@ casper.event_test = function (name, events, action) {
         return this.evaluate(function (events) {
             return IPython._events_triggered.length >= events.length;
         }, [events]);
-    });
+    }, undefined, undefined, timeout);
 
     // test that the events were triggered in the proper order
     this.then(function () {

--- a/IPython/html/tests/util.js
+++ b/IPython/html/tests/util.js
@@ -68,6 +68,22 @@ casper.kernel_disconnected = function() {
     });
 };
 
+casper.wait_for_kernel_ready = function () {
+    this.waitFor(this.kernel_running);
+    this.thenEvaluate(function () {
+        IPython._kernel_ready = false;
+        IPython.notebook.kernel.kernel_info(
+            function () {
+                IPython._kernel_ready = true;
+            });
+    });
+    this.waitFor(function () {
+        return this.evaluate(function () {
+            return IPython._kernel_ready;
+        });
+    });
+};
+
 casper.shutdown_current_kernel = function () {
     // Shut down the current notebook's kernel.
     this.thenEvaluate(function() {

--- a/IPython/html/tests/util.js
+++ b/IPython/html/tests/util.js
@@ -687,4 +687,3 @@ casper.capture_log = function () {
 };
 
 casper.capture_log();
-casper.print_log();


### PR DESCRIPTION
This pull request fixes `kernel.js` and `session.js` to be more respectful of abstraction barriers, and makes it easier to track the kernel state. Some of this is just rearranging functions so they are in a more logical order, more major changes include:
- After the kernel has been started, all interaction should be through it, rather than through the session, with the exception of (1) renaming the notebook and (2) deleting the session
- Remove the `Kernel.running` variable, as its state was not always consistent. Instead, introduce the distinction between "kernel exists" and "kernel connected". For most intents and purposes, to check if the kernel is running you can now call `Kernel.is_connected()`
- Fully support all REST API functions for the kernel and the session.

I have additionally documented most of the event messages regarding the kernel here: https://github.com/ipython/ipython/wiki/Dev:-Javascript-Events

closes #6560
