### PR TITLE
support `%matplotlib qt5` and `%matplotlib nbagg`

### DIFF
--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -21,6 +21,7 @@ backends = {'tk': 'TkAgg',
             'qt4': 'Qt4Agg',
             'qt5': 'Qt5Agg',
             'osx': 'MacOSX',
+            'nbagg': 'nbAgg',
             'inline' : 'module://IPython.kernel.zmq.pylab.backend_inline'}
 
 # We also need a reverse backends2guis mapping that will properly choose which

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -1,24 +1,9 @@
 # -*- coding: utf-8 -*-
-"""Pylab (matplotlib) support utilities.
-
-Authors
--------
-
-* Fernando Perez.
-* Brian Granger
-"""
+"""Pylab (matplotlib) support utilities."""
 from __future__ import print_function
 
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2009  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 from io import BytesIO
 
@@ -34,6 +19,7 @@ backends = {'tk': 'TkAgg',
             'wx': 'WXAgg',
             'qt': 'Qt4Agg', # qt3 not supported
             'qt4': 'Qt4Agg',
+            'qt5': 'Qt5Agg',
             'osx': 'MacOSX',
             'inline' : 'module://IPython.kernel.zmq.pylab.backend_inline'}
 

--- a/IPython/kernel/zmq/eventloops.py
+++ b/IPython/kernel/zmq/eventloops.py
@@ -1,32 +1,17 @@
 # encoding: utf-8
-"""Event loop integration for the ZeroMQ-based kernels.
-"""
+"""Event loop integration for the ZeroMQ-based kernels."""
 
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2011  The IPython Development Team
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
-
+import os
 import sys
 
-# System library imports
 import zmq
 
-# Local imports
 from IPython.config.application import Application
 from IPython.utils import io
 
-
-#------------------------------------------------------------------------------
-# Eventloops for integrating the Kernel into different GUIs
-#------------------------------------------------------------------------------
 
 def _on_os_x_10_9():
     import platform
@@ -91,6 +76,12 @@ def loop_qt4(kernel):
         _notify_stream_qt(kernel, s)
     
     start_event_loop_qt4(kernel.app)
+
+@register_integration('qt5')
+def loop_qt5(kernel):
+    """Start a kernel with PyQt5 event loop integration."""
+    os.environ['QT_API'] = 'pyqt5'
+    return loop_qt4(kernel)
 
 
 @register_integration('wx')

--- a/IPython/kernel/zmq/eventloops.py
+++ b/IPython/kernel/zmq/eventloops.py
@@ -39,6 +39,7 @@ def _notify_stream_qt(kernel, stream):
 # mapping of keys to loop functions
 loop_map = {
     'inline': None,
+    'nbagg': None,
     None : None,
 }
 


### PR DESCRIPTION
just needed the key, since `%gui qt5` already works

also copy `%gui qt5` logic from #6496 to the kernel eventloop registry.

closes #6057
