### PR TITLE
msgspec 5: stream.data -> stream.text

### DIFF
--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -210,7 +210,7 @@ define([
         var msg_type = json.output_type = msg.header.msg_type;
         var content = msg.content;
         if (msg_type === "stream") {
-            json.text = content.data;
+            json.text = content.text;
             json.stream = content.name;
         } else if (msg_type === "display_data") {
             json = content.data;

--- a/IPython/kernel/adapter.py
+++ b/IPython/kernel/adapter.py
@@ -163,6 +163,11 @@ class V5toV4(Adapter):
     
     # iopub channel
     
+    def stream(self, msg):
+        content = msg['content']
+        content['data'] = content.pop('text')
+        return msg
+
     def display_data(self, msg):
         content = msg['content']
         content.setdefault("source", "display")
@@ -287,6 +292,11 @@ class V4toV5(Adapter):
     
     # iopub channel
     
+    def stream(self, msg):
+        content = msg['content']
+        content['text'] = content.pop('data')
+        return msg
+
     def display_data(self, msg):
         content = msg['content']
         content.pop("source", None)

--- a/IPython/kernel/inprocess/tests/test_kernel.py
+++ b/IPython/kernel/inprocess/tests/test_kernel.py
@@ -1,20 +1,11 @@
-#-------------------------------------------------------------------------------
-#  Copyright (C) 2012  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-------------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
 from __future__ import print_function
 
-# Standard library imports
 import sys
 import unittest
 
-# Local imports
 from IPython.kernel.inprocess.blocking import BlockingInProcessKernelClient
 from IPython.kernel.inprocess.manager import InProcessKernelManager
 from IPython.kernel.inprocess.ipkernel import InProcessKernel
@@ -27,9 +18,6 @@ if py3compat.PY3:
 else:
     from StringIO import StringIO
 
-#-----------------------------------------------------------------------------
-# Test case
-#-----------------------------------------------------------------------------
 
 class InProcessKernelTestCase(unittest.TestCase):
 
@@ -41,12 +29,11 @@ class InProcessKernelTestCase(unittest.TestCase):
 
     @skipif_not_matplotlib
     def test_pylab(self):
-        """ Does pylab work in the in-process kernel?
-        """
+        """Does %pylab work in the in-process kernel?"""
         kc = self.kc
         kc.execute('%pylab')
         msg = get_stream_message(kc)
-        self.assertIn('matplotlib', msg['content']['data'])
+        self.assertIn('matplotlib', msg['content']['text'])
 
     def test_raw_input(self):
         """ Does the in-process kernel handle raw_input correctly?
@@ -76,7 +63,7 @@ class InProcessKernelTestCase(unittest.TestCase):
         kernel.frontends.append(kc)
         kc.shell_channel.execute('print("bar")')
         msg = get_stream_message(kc)
-        self.assertEqual(msg['content']['data'], 'bar\n')
+        self.assertEqual(msg['content']['text'], 'bar\n')
 
 #-----------------------------------------------------------------------------
 # Utility functions

--- a/IPython/kernel/tests/test_message_spec.py
+++ b/IPython/kernel/tests/test_message_spec.py
@@ -172,7 +172,7 @@ Error = ExecuteReplyError
 
 class Stream(Reference):
     name = Enum((u'stdout', u'stderr'))
-    data = Unicode()
+    text = Unicode()
 
 
 class DisplayData(MimeBundle):
@@ -394,7 +394,7 @@ def test_stream():
     stdout = KC.iopub_channel.get_msg(timeout=TIMEOUT)
     validate_message(stdout, 'stream', msg_id)
     content = stdout['content']
-    nt.assert_equal(content['data'], u'hi\n')
+    nt.assert_equal(content['text'], u'hi\n')
 
 
 def test_display_data():

--- a/IPython/kernel/tests/utils.py
+++ b/IPython/kernel/tests/utils.py
@@ -140,9 +140,9 @@ def assemble_output(iopub):
             break
         elif msg['msg_type'] == 'stream':
             if content['name'] == 'stdout':
-                stdout += content['data']
+                stdout += content['text']
             elif content['name'] == 'stderr':
-                stderr += content['data']
+                stderr += content['text']
             else:
                 raise KeyError("bad stream: %r" % content['name'])
         else:

--- a/IPython/kernel/zmq/iostream.py
+++ b/IPython/kernel/zmq/iostream.py
@@ -163,7 +163,7 @@ class OutStream(object):
             data = self._flush_buffer()
             
             if data:
-                content = {u'name':self.name, u'data':data}
+                content = {u'name':self.name, u'text':data}
                 msg = self.session.send(self.pub_socket, u'stream', content=content,
                                        parent=self.parent_header, ident=self.topic)
             

--- a/IPython/nbconvert/preprocessors/execute.py
+++ b/IPython/nbconvert/preprocessors/execute.py
@@ -123,7 +123,7 @@ class ExecutePreprocessor(Preprocessor):
 
             if msg_type == 'stream':
                 out.stream = content['name']
-                out.text = content['data']
+                out.text = content['text']
             elif msg_type in ('display_data', 'execute_result'):
                 out['metadata'] = content['metadata']
                 for mime, data in content['data'].items():

--- a/IPython/parallel/client/client.py
+++ b/IPython/parallel/client/client.py
@@ -874,7 +874,7 @@ class Client(HasTraits):
             if msg_type == 'stream':
                 name = content['name']
                 s = md[name] or ''
-                md[name] = s + content['data']
+                md[name] = s + content['text']
             elif msg_type == 'error':
                 md.update({'error' : self._unwrap_exception(content)})
             elif msg_type == 'execute_input':

--- a/IPython/parallel/controller/hub.py
+++ b/IPython/parallel/controller/hub.py
@@ -862,7 +862,7 @@ class Hub(SessionFactory):
         if msg_type == 'stream':
             name = content['name']
             s = '' if rec is None else rec[name]
-            d[name] = s + content['data']
+            d[name] = s + content['text']
 
         elif msg_type == 'error':
             d['error'] = content

--- a/IPython/qt/console/frontend_widget.py
+++ b/IPython/qt/console/frontend_widget.py
@@ -531,7 +531,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         self.log.debug("stream: %s", msg.get('content', ''))
         if not self._hidden and self._is_from_this_session(msg):
             self.flush_clearoutput()
-            self.append_stream(msg['content']['data'])
+            self.append_stream(msg['content']['text'])
 
     def _handle_shutdown_reply(self, msg):
         """ Handle shutdown signal, only if from other console.

--- a/IPython/terminal/console/interactiveshell.py
+++ b/IPython/terminal/console/interactiveshell.py
@@ -235,13 +235,13 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
                         if self._pending_clearoutput:
                             print("\r", file=io.stdout, end="")
                             self._pending_clearoutput = False
-                        print(sub_msg["content"]["data"], file=io.stdout, end="")
+                        print(sub_msg["content"]["text"], file=io.stdout, end="")
                         io.stdout.flush()
-                    elif sub_msg["content"]["name"] == "stderr" :
+                    elif sub_msg["content"]["name"] == "stderr":
                         if self._pending_clearoutput:
                             print("\r", file=io.stderr, end="")
                             self._pending_clearoutput = False
-                        print(sub_msg["content"]["data"], file=io.stderr, end="")
+                        print(sub_msg["content"]["text"], file=io.stderr, end="")
                         io.stderr.flush()
 
                 elif msg_type == 'execute_result':

--- a/docs/source/development/messaging.rst
+++ b/docs/source/development/messaging.rst
@@ -711,9 +711,13 @@ Message type: ``stream``::
         # The name of the stream is one of 'stdout', 'stderr'
         'name' : str,
     
-        # The data is an arbitrary string to be written to that stream
-        'data' : str,
+        # The text is an arbitrary string to be written to that stream
+        'text' : str,
     }
+
+.. versionchanged:: 5.0
+
+    'data' key renamed to 'text' for conistency with the notebook format.
 
 Display Data
 ------------


### PR DESCRIPTION
for consistency with the nbformat.

msg spec 4 has `name, data`
nbformat 3 has `stream, text`
msg spec 5 has `name, text`
nbformat 4 has `name, text`

pulled out of the nbformat 4 PR
