### PR TITLE
Removing useless help text from "-i" command line option.

### DIFF
--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -171,8 +171,7 @@ frontend_flags['quick']=(
 
 frontend_flags['i'] = (
     {'TerminalIPythonApp' : {'force_interact' : True}},
-    """If running code from the command line, become interactive afterwards.
-    Note: can also be given simply as '-i'."""
+    """If running code from the command line, become interactive afterwards."""
 )
 flags.update(frontend_flags)
 


### PR DESCRIPTION
The note here appears to be out of date, so I'm removing it.
