### PR TITLE
Shell command formatting.

### DIFF
--- a/docs/source/interactive/qtconsole.rst
+++ b/docs/source/interactive/qtconsole.rst
@@ -6,7 +6,7 @@ A Qt Console for IPython
 
 To start the Qt Console::
 
-    ipython qtconsole
+    $> ipython qtconsole
 
 We now have a version of IPython, using the new two-process :ref:`ZeroMQ Kernel
 <ipythonzmq>`, running in a PyQt_ GUI.  This is a very lightweight widget that


### PR DESCRIPTION
Makes the command to start the qtconsole consistent with the rest of the
shell commands in this document.
