### PR TITLE
stop using deprecated DelayedCallback

### DIFF
--- a/IPython/parallel/apps/baseapp.py
+++ b/IPython/parallel/apps/baseapp.py
@@ -1,31 +1,13 @@
 # encoding: utf-8
 """
 The Base Application class for IPython.parallel apps
-
-Authors:
-
-* Brian Granger
-* Min RK
-
 """
 
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2011  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
 
 import os
 import logging
 import re
 import sys
-
-from subprocess import Popen, PIPE
 
 from IPython.config.application import catch_config_error, LevelFormatter
 from IPython.core import release

--- a/IPython/parallel/apps/launcher.py
+++ b/IPython/parallel/apps/launcher.py
@@ -294,8 +294,7 @@ class LocalProcessLauncher(BaseLauncher):
         except Exception:
             self.log.debug("interrupt failed")
             pass
-        self.killer  = ioloop.DelayedCallback(lambda : self.signal(SIGKILL), delay*1000, self.loop)
-        self.killer.start()
+        self.killer  = self.loop.add_timeout(self.loop.time() + delay, lambda : self.signal(SIGKILL))
 
     # callbacks, etc:
 

--- a/IPython/parallel/controller/scheduler.py
+++ b/IPython/parallel/controller/scheduler.py
@@ -321,8 +321,9 @@ class TaskScheduler(SessionFactory):
         # wait 5 seconds before cleaning up pending jobs, since the results might
         # still be incoming
         if self.pending[uid]:
-            dc = ioloop.DelayedCallback(lambda : self.handle_stranded_tasks(uid), 5000, self.loop)
-            dc.start()
+            self.loop.add_timeout(self.loop.time() + 5,
+                lambda : self.handle_stranded_tasks(uid),
+            )
         else:
             self.completed.pop(uid)
             self.failed.pop(uid)


### PR DESCRIPTION
in favor of simpler IOLoop.add_timeout

It's unique to pyzmq, and deprecated in pyzmq-13 once I realized it was pointless and redundant.
