### PR TITLE
Use ContentsManager to serve /files/

### DIFF
--- a/IPython/html/files/handlers.py
+++ b/IPython/html/files/handlers.py
@@ -9,12 +9,6 @@ import mimetypes
 import json
 import base64
 
-try:
-    # py3
-    from http.client import responses
-except ImportError:
-    from httplib import responses
-
 from tornado import web
 
 try:

--- a/IPython/html/files/handlers.py
+++ b/IPython/html/files/handlers.py
@@ -22,7 +22,6 @@ try:
 except ImportError:
     app_log = logging.getLogger()
 
-from IPython.html.utils import is_hidden
 from IPython.html.base.handlers import IPythonHandler
 
 class FilesHandler(IPythonHandler):
@@ -32,7 +31,7 @@ class FilesHandler(IPythonHandler):
     def get(self, path):
         cm = self.settings['contents_manager']
         abs_path = os.path.join(cm.root_dir, path)
-        if is_hidden(abs_path):
+        if cm.is_hidden(abs_path):
             self.log.info("Refusing to serve hidden file, via 404 Error")
             raise web.HTTPError(404)
 

--- a/IPython/html/files/handlers.py
+++ b/IPython/html/files/handlers.py
@@ -7,6 +7,8 @@ import logging
 import os
 import mimetypes
 import json
+import base64
+
 try:
     # py3
     from http.client import responses
@@ -47,7 +49,8 @@ class FilesHandler(IPythonHandler):
         self.set_header('Content-Disposition','attachment; filename="%s"' % name)
 
         if model['format'] == 'base64':
-            self.write(model['content'].decode('base64'))
+            b64_bytes = model['content'].encode('ascii')
+            self.write(base64.decodestring(b64_bytes))
         elif model['format'] == 'json':
             self.write(json.dumps(model['content']))
         else:

--- a/IPython/html/files/handlers.py
+++ b/IPython/html/files/handlers.py
@@ -1,0 +1,47 @@
+"""Base Tornado handlers for the notebook server."""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import logging
+import os
+import mimetypes
+try:
+    # py3
+    from http.client import responses
+except ImportError:
+    from httplib import responses
+
+from tornado import web
+
+try:
+    from tornado.log import app_log
+except ImportError:
+    app_log = logging.getLogger()
+
+from IPython.html.utils import is_hidden
+from IPython.html.base.handlers import IPythonHandler
+
+class FilesHandler(IPythonHandler):
+    """serve files via ContentsManager"""
+
+    @web.authenticated
+    def get(self, path):
+        cm = self.settings['contents_manager']
+        abs_path = os.path.join(cm.root_dir, path)
+        if is_hidden(abs_path):
+            self.log.info("Refusing to serve hidden file, via 404 Error")
+            raise web.HTTPError(404)
+
+        path, name = os.path.split(path)
+        if name.endswith('.ipynb'):
+            self.set_header('Content-Type', 'application/json')
+        else:
+            cur_mime = mimetypes.guess_type(name)[0]
+            if cur_mime is not None:
+                self.set_header('Content-Type', cur_mime)
+        
+        self.set_header('Content-Disposition','attachment; filename="%s"' % name)
+        self.write(cm.get_model(name, path)['content'])
+        self.flush()
+

--- a/IPython/html/files/handlers.py
+++ b/IPython/html/files/handlers.py
@@ -30,8 +30,7 @@ class FilesHandler(IPythonHandler):
     @web.authenticated
     def get(self, path):
         cm = self.settings['contents_manager']
-        abs_path = os.path.join(cm.root_dir, path)
-        if cm.is_hidden(abs_path):
+        if cm.is_hidden(path):
             self.log.info("Refusing to serve hidden file, via 404 Error")
             raise web.HTTPError(404)
 

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -34,6 +34,8 @@ from jinja2 import Environment, FileSystemLoader
 from zmq.eventloop import ioloop
 ioloop.install()
 
+from IPython.html.files.handlers import FilesHandler
+
 # check for tornado 3.1.0
 msg = "The IPython Notebook requires tornado >= 3.1.0"
 try:
@@ -195,11 +197,8 @@ class NotebookWebApplication(web.Application):
         handlers.extend(load_handlers('services.sessions.handlers'))
         handlers.extend(load_handlers('services.nbconvert.handlers'))
         handlers.extend(load_handlers('services.kernelspecs.handlers'))
-        # FIXME: /files/ should be handled by the Contents service when it exists
-        cm = settings['contents_manager']
-        if hasattr(cm, 'root_dir'):
-            handlers.append(
-            (r"/files/(.*)", AuthenticatedFileHandler, {'path' : cm.root_dir}),
+        handlers.append(
+            (r"/files/(.*)", FilesHandler),
         )
         handlers.append(
             (r"/nbextensions/(.*)", FileFindHandler, {'path' : settings['nbextensions_path']}),

--- a/IPython/html/tests/test_files.py
+++ b/IPython/html/tests/test_files.py
@@ -91,7 +91,6 @@ class FilesTest(NotebookTestBase):
         r = requests.get(url_path_join(base, 'files', 'test.bin'))
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.headers['content-type'], 'application/octet-stream')
-        # self.assertTrue(r.content[0] == 255 or r.content[0] == b'\xff')
         self.assertEqual(r.content[:1], b'\xff')
         self.assertEqual(len(r.content), 6)
 

--- a/IPython/html/tests/test_files.py
+++ b/IPython/html/tests/test_files.py
@@ -76,27 +76,27 @@ class FilesTest(NotebookTestBase):
             write(nb, f, format='ipynb')
 
         with io.open(pjoin(nbdir, 'test.bin'), 'wb') as f:
-            f.write(b"\x5F\x9D\x3E")
+            f.write(b"\x5F"*3) # \x5F = _
             f.close()
 
         with io.open(pjoin(nbdir, 'test.txt'), 'w') as f:
-            f.write(u'foo\nbar')
+            f.write(u'foobar')
             f.close()
 
         r = requests.get(url_path_join(base, 'files', 'testnb.ipynb'))
         self.assertEqual(r.status_code, 200)
-        self.assertIn(u'print(2*6)', r.text)
+        self.assertIn('print(2*6)', r.text)
         json.loads(r.text)
 
         r = requests.get(url_path_join(base, 'files', 'test.bin'))
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.headers['content-type'], 'application/octet-stream')
-        self.assertEqual(r.content, b'X50+\n')
+        self.assertEqual(r.text, '___')
 
         r = requests.get(url_path_join(base, 'files', 'test.txt'))
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.headers['content-type'], 'text/plain')
-        self.assertEqual(r.content, u'foo\nbar')
+        self.assertEqual(r.text, 'foobar')
 
 
     def test_old_files_redirect(self):

--- a/IPython/html/tests/test_files.py
+++ b/IPython/html/tests/test_files.py
@@ -92,7 +92,7 @@ class FilesTest(NotebookTestBase):
         r = requests.get(url_path_join(base, 'files', 'test.bin'))
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.headers['content-type'], 'application/octet-stream')
-        self.assertEqual(r.content[0], 255)
+        self.assertTrue(r.content[0] == 255 or r.content[0] == b'\xff')
         self.assertEqual(len(r.content), 6)
 
         r = requests.get(url_path_join(base, 'files', 'test.txt'))

--- a/IPython/html/tests/test_files.py
+++ b/IPython/html/tests/test_files.py
@@ -8,10 +8,16 @@ from unicodedata import normalize
 pjoin = os.path.join
 
 import requests
+import json
+
+from IPython.nbformat.current import (new_notebook, write, new_worksheet,
+                              new_heading_cell, new_code_cell,
+                              new_output)
 
 from IPython.html.utils import url_path_join
 from .launchnotebook import NotebookTestBase
 from IPython.utils import py3compat
+
 
 class FilesTest(NotebookTestBase):
     def test_hidden_files(self):
@@ -50,6 +56,49 @@ class FilesTest(NotebookTestBase):
                 r = requests.get(url_path_join(url, 'files', d, foo))
                 self.assertEqual(r.status_code, 404)
     
+    def test_contents_manager(self):
+        "make sure ContentsManager returns right files (ipynb, bin, txt)."
+
+        nbdir = self.notebook_dir.name
+        base = self.base_url()
+
+        nb = new_notebook(name='testnb')
+        
+        ws = new_worksheet()
+        nb.worksheets = [ws]
+        ws.cells.append(new_heading_cell(u'Created by test ³'))
+        cc1 = new_code_cell(input=u'print(2*6)')
+        cc1.outputs.append(new_output(output_text=u'12', output_type='stream'))
+        ws.cells.append(cc1)
+
+        with io.open(pjoin(nbdir, 'testnb.ipynb'), 'w', 
+            encoding='utf-8') as f:
+            write(nb, f, format='ipynb')
+
+        with io.open(pjoin(nbdir, 'test.bin'), 'wb') as f:
+            f.write(b"\x5F"*3) # \x5F = _
+            f.close()
+
+        with io.open(pjoin(nbdir, 'test.txt'), 'w') as f:
+            f.write(u'foobar')
+            f.close()
+
+        r = requests.get(url_path_join(base, 'files', 'testnb.ipynb'))
+        self.assertEqual(r.status_code, 200)
+        self.assertIn('print(2*6)', r.text)
+        json.loads(r.text)
+
+        r = requests.get(url_path_join(base, 'files', 'test.bin'))
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.headers['content-type'], 'application/octet-stream')
+        self.assertEqual(r.text, '___')
+
+        r = requests.get(url_path_join(base, 'files', 'test.txt'))
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.headers['content-type'], 'text/plain')
+        self.assertEqual(r.text, 'foobar')
+
+
     def test_old_files_redirect(self):
         """pre-2.0 'files/' prefixed links are properly redirected"""
         nbdir = self.notebook_dir.name

--- a/IPython/html/tests/test_files.py
+++ b/IPython/html/tests/test_files.py
@@ -76,7 +76,7 @@ class FilesTest(NotebookTestBase):
             write(nb, f, format='ipynb')
 
         with io.open(pjoin(nbdir, 'test.bin'), 'wb') as f:
-            f.write(b"\x5F"*3) # \x5F = _
+            f.write(b'\xFF' + os.urandom(5))
             f.close()
 
         with io.open(pjoin(nbdir, 'test.txt'), 'w') as f:
@@ -91,7 +91,7 @@ class FilesTest(NotebookTestBase):
         r = requests.get(url_path_join(base, 'files', 'test.bin'))
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.headers['content-type'], 'application/octet-stream')
-        self.assertEqual(r.text, '___')
+        self.assertTrue(r.content.startswith(b'\xFF'))
 
         r = requests.get(url_path_join(base, 'files', 'test.txt'))
         self.assertEqual(r.status_code, 200)

--- a/IPython/html/tests/test_files.py
+++ b/IPython/html/tests/test_files.py
@@ -76,7 +76,7 @@ class FilesTest(NotebookTestBase):
             write(nb, f, format='ipynb')
 
         with io.open(pjoin(nbdir, 'test.bin'), 'wb') as f:
-            f.write("\x5F\x9D\x3E")
+            f.write(b"\x5F\x9D\x3E")
             f.close()
 
         with io.open(pjoin(nbdir, 'test.txt'), 'w') as f:

--- a/IPython/html/tests/test_files.py
+++ b/IPython/html/tests/test_files.py
@@ -76,7 +76,7 @@ class FilesTest(NotebookTestBase):
             write(nb, f, format='ipynb')
 
         with io.open(pjoin(nbdir, 'test.bin'), 'wb') as f:
-            f.write(b'\xFF' + os.urandom(5))
+            f.write(b'\xff' + os.urandom(5))
             f.close()
 
         with io.open(pjoin(nbdir, 'test.txt'), 'w') as f:
@@ -91,7 +91,9 @@ class FilesTest(NotebookTestBase):
         r = requests.get(url_path_join(base, 'files', 'test.bin'))
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.headers['content-type'], 'application/octet-stream')
-        self.assertTrue(r.content.startswith(b'\xFF'))
+
+        self.assertEqual("{:02x}".format(ord(r.content[0])), 'ff')
+        self.assertEqual(len(r.content), 6)
 
         r = requests.get(url_path_join(base, 'files', 'test.txt'))
         self.assertEqual(r.status_code, 200)

--- a/IPython/html/tests/test_files.py
+++ b/IPython/html/tests/test_files.py
@@ -91,7 +91,8 @@ class FilesTest(NotebookTestBase):
         r = requests.get(url_path_join(base, 'files', 'test.bin'))
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.headers['content-type'], 'application/octet-stream')
-        self.assertTrue(r.content[0] == 255 or r.content[0] == b'\xff')
+        # self.assertTrue(r.content[0] == 255 or r.content[0] == b'\xff')
+        self.assertEqual(r.content[:1], b'\xff')
         self.assertEqual(len(r.content), 6)
 
         r = requests.get(url_path_join(base, 'files', 'test.txt'))

--- a/IPython/html/tests/test_files.py
+++ b/IPython/html/tests/test_files.py
@@ -9,6 +9,7 @@ pjoin = os.path.join
 
 import requests
 import json
+import binascii
 
 from IPython.nbformat.current import (new_notebook, write, new_worksheet,
                               new_heading_cell, new_code_cell,
@@ -92,7 +93,7 @@ class FilesTest(NotebookTestBase):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.headers['content-type'], 'application/octet-stream')
 
-        self.assertEqual("{:02x}".format(ord(r.content[0])), 'ff')
+        self.assertEqual(binascii.hexlify(r.content[0]), 'ff')
         self.assertEqual(len(r.content), 6)
 
         r = requests.get(url_path_join(base, 'files', 'test.txt'))

--- a/IPython/html/tests/test_files.py
+++ b/IPython/html/tests/test_files.py
@@ -91,7 +91,7 @@ class FilesTest(NotebookTestBase):
         r = requests.get(url_path_join(base, 'files', 'test.bin'))
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.headers['content-type'], 'application/octet-stream')
-        self.assertEqual(r.content, 'X50+\n')
+        self.assertEqual(r.content, b'X50+\n')
 
         r = requests.get(url_path_join(base, 'files', 'test.txt'))
         self.assertEqual(r.status_code, 200)

--- a/IPython/html/tests/test_files.py
+++ b/IPython/html/tests/test_files.py
@@ -9,7 +9,6 @@ pjoin = os.path.join
 
 import requests
 import json
-import binascii
 
 from IPython.nbformat.current import (new_notebook, write, new_worksheet,
                               new_heading_cell, new_code_cell,

--- a/IPython/html/tests/test_files.py
+++ b/IPython/html/tests/test_files.py
@@ -92,8 +92,7 @@ class FilesTest(NotebookTestBase):
         r = requests.get(url_path_join(base, 'files', 'test.bin'))
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.headers['content-type'], 'application/octet-stream')
-
-        self.assertEqual(binascii.hexlify(r.content[0]), 'ff')
+        self.assertEqual(r.content[0], 255)
         self.assertEqual(len(r.content), 6)
 
         r = requests.get(url_path_join(base, 'files', 'test.txt'))


### PR DESCRIPTION
In reference to #6613 I'm adding this PR. Rather than working on paths, it will use the current ContentsManager to get the contents of a file.

This includes the suggestions made by @Carreau and @minrk in #6620:
- set correct content-type when serving file
- use `os.path` instead of string operations.
- don't change `AuthenticatedFileHandler`, but add new class `FilesHandler` in `html/files/handlers.py`
- check if files are hidden (if they are real files)
- use extra branch

I tested this with the default FileContentsManager and the [MongoContentsManager](https://github.com/manuelRiel/mongo_notebook_manager/tree/ipython3) developed for iPython 2 by @laurenceputra and adapted to iPython 3 by myself (still in testing).

(new pull request on extra branch, closing #6620)
