### PR TITLE
Fix ls_alias for certain BSDs

### DIFF
--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -69,6 +69,20 @@ def default_aliases():
                           # things which are executable
                           ('lx', 'ls -F -o --color %l | grep ^-..x'),
                           ]
+        elif sys.platform.startswith('openbsd'):
+            # OpenBSD 
+            ls_aliases = [('ls', 'ls -F'),
+                          # long ls
+                          ('ll', 'ls -F -l'),
+                          # ls normal files only
+                          ('lf', 'ls -F -l %l | grep ^-'),
+                          # ls symbolic links
+                          ('lk', 'ls -F -l %l | grep ^l'),
+                          # directories or links to directories,
+                          ('ldir', 'ls -F -l %l | grep /$'),
+                          # things which are executable
+                          ('lx', 'ls -F -l %l | grep ^-..x'),
+                          ]
         else:
             # BSD, OSX, etc.
             ls_aliases = [('ls', 'ls -F -G'),

--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -70,7 +70,8 @@ def default_aliases():
                           ('lx', 'ls -F -o --color %l | grep ^-..x'),
                           ]
         elif sys.platform.startswith('openbsd') or sys.platform.startswith('netbsd'):
-            # OpenBSD, NetBSD 
+            # OpenBSD, NetBSD. The ls implementation on these platforms do not support
+            # the -G switch and lack the ability to use colorized output.
             ls_aliases = [('ls', 'ls -F'),
                           # long ls
                           ('ll', 'ls -F -l'),

--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -69,8 +69,8 @@ def default_aliases():
                           # things which are executable
                           ('lx', 'ls -F -o --color %l | grep ^-..x'),
                           ]
-        elif sys.platform.startswith('openbsd'):
-            # OpenBSD 
+        elif sys.platform.startswith('openbsd') or sys.platform.startswith('netbsd'):
+            # OpenBSD, NetBSD 
             ls_aliases = [('ls', 'ls -F'),
                           # long ls
                           ('ll', 'ls -F -l'),


### PR DESCRIPTION
The ls implementation in both NetBSD and OpenBSD lack the -G switch, so the %ls magic doesn't work on them. Looking at the manual pages, it seems that the other two major BSDs support -G (FreeBSD, DragonflyBSD). 
