### PR TITLE
remove on_first_message authentication

### DIFF
--- a/IPython/html/services/kernels/handlers.py
+++ b/IPython/html/services/kernels/handlers.py
@@ -126,16 +126,12 @@ class ZMQChannelHandler(AuthenticatedZMQStreamHandler):
         self.kernel_info_channel.close()
         self.kernel_info_channel = None
     
-    
-    def initialize(self, *args, **kwargs):
+    def initialize(self):
+        super(ZMQChannelHandler, self).initialize()
         self.zmq_stream = None
     
-    def on_first_message(self, msg):
-        try:
-            super(ZMQChannelHandler, self).on_first_message(msg)
-        except web.HTTPError:
-            self.close()
-            return
+    def open(self, kernel_id):
+        super(ZMQChannelHandler, self).open(kernel_id)
         try:
             self.create_stream()
         except web.HTTPError:


### PR DESCRIPTION
in ZMQStreams.
- use regular cookie auth
- use url param for session id

No need for weird, special first message.

I know cookies didn't used to work in websockets in Tornado. This may have been a limitation of tornado < 3.
