### PR TITLE
Allow widget models and views to be loaded from require modules

### DIFF
--- a/IPython/html/static/widgets/js/init.js
+++ b/IPython/html/static/widgets/js/init.js
@@ -18,7 +18,8 @@ define([
     for (var i = 1; i < arguments.length; i++) {
         for (var target_name in arguments[i]) {
             if (arguments[i].hasOwnProperty(target_name)) {
-                widgetmanager.WidgetManager.register_widget_view(target_name, arguments[i][target_name]);
+                widgetmanager.WidgetManager.register_widget_view(target_name, 
+                                                                 new widgetmanager.Loader(arguments[i][target_name]));
             }
         }
     }

--- a/IPython/html/static/widgets/js/manager.js
+++ b/IPython/html/static/widgets/js/manager.js
@@ -97,7 +97,7 @@ define([
         var loader = new Loader();
         WidgetManager.register_widget_model(target_name, loader);
         require([mod], function(m) {
-                loader.fire_loaded(m);
+                loader.fire_loaded(m[target_name]);
             }, function(err) { console.log(err);
         });
     };
@@ -107,7 +107,7 @@ define([
         var loader = new Loader();
         WidgetManager.register_widget_view(target_name, loader);
         require([mod], function(m) {
-                loader.fire_loaded(m);
+                loader.fire_loaded(m[target_name]);
             }, function(err) { console.log(err);
         });
     };

--- a/IPython/html/static/widgets/js/manager.js
+++ b/IPython/html/static/widgets/js/manager.js
@@ -10,6 +10,30 @@ define([
 
     "use strict";
 
+    var Loader = function (klass) {
+        this.klass = klass;
+        this._cb = [];
+        this._ctx = [];
+
+        this.after_loaded = function(cb, ctx) {
+            if (this.klass) {
+                cb.apply(ctx, [this.klass]);
+            } else {
+                this._cb.push(cb);
+                this._ctx.push(cb);
+            }
+        }
+
+        this.fire_loaded = function(klass) {
+            this.klass = klass;
+            for (var i=0; i<this._cb.length; i++) {
+                this._cb[i].apply(this._ctx[i], [this.klass]);
+            }
+            this._cb = [];
+            this._ctx = [];
+        }
+    };
+
     //--------------------------------------------------------------------
     // WidgetManager class
     //--------------------------------------------------------------------
@@ -70,16 +94,22 @@ define([
 
     WidgetManager._load_model = function(target_name, mod) {
         // Loads a widget model module and registers it.
+        var loader = new Loader();
+        WidgetManager.register_widget_model(target_name, loader);
         require([mod], function(m) {
-            WidgetManager.register_widget_model(target_name, m);
-        }, function(err) { console.log(err); });
+                loader.fire_loaded(m);
+            }, function(err) { console.log(err);
+        });
     };
 
     WidgetManager._load_view = function(target_name, mod) {
         // Loads a widget view module and registers it.
+        var loader = new Loader();
+        WidgetManager.register_widget_view(target_name, loader);
         require([mod], function(m) {
-            WidgetManager.register_widget_view(target_name, m);
-        }, function(err) { console.log(err); });
+                loader.fire_loaded(m);
+            }, function(err) { console.log(err);
+        });
     };
 
     //--------------------------------------------------------------------
@@ -92,15 +122,17 @@ define([
             console.log("Could not determine where the display" + 
                 " message was from.  Widget will not be displayed");
         } else {
-            var view = this.create_view(model, {cell: cell});
-            if (view === null) {
-                console.error("View creation failed", model);
-            }
-            this._handle_display_view(view);
-            if (cell.widget_subarea) {
-                cell.widget_subarea.append(view.$el);
-            }
-            view.trigger('displayed');
+            var that = this;
+            this.create_view(model, {cell: cell, callback: function(view) {
+                if (view === null) {
+                    console.error("View creation failed", model);
+                }
+                that._handle_display_view(view);
+                if (cell.widget_subarea) {
+                    cell.widget_subarea.append(view.$el);
+                }
+                view.trigger('displayed');
+            }});
         }
     };
 
@@ -110,36 +142,41 @@ define([
         // Note, this is only done on the outer most widgets.
         if (this.keyboard_manager) {
             this.keyboard_manager.register_events(view.$el);
-        
-        if (view.additional_elements) {
-            for (var i = 0; i < view.additional_elements.length; i++) {
+            if (view.additional_elements) {
+                for (var i = 0; i < view.additional_elements.length; i++) {
                     this.keyboard_manager.register_events(view.additional_elements[i]);
+                }
             }
-        } 
         }
     };
 
-    WidgetManager.prototype.create_view = function(model, options, view) {
+    WidgetManager.prototype.create_view = function(model, options) {
         // Creates a view for a particular model.
+
         var view_name = model.get('_view_name');
-        var ViewType = WidgetManager._view_types[view_name];
-        if (ViewType) {
+        var errback = options.errback || function(err) {console.log(err);};
 
-            // If a view is passed into the method, use that view's cell as
-            // the cell for the view that is created.
-            options = options || {};
-            if (view !== undefined) {
-                options.cell = view.options.cell;
+        var instantiate_view = function(ViewType) {
+            if (ViewType) {
+                // If a view is passed into the method, use that view's cell as
+                // the cell for the view that is created.
+                options = options || {};
+                if (options.parent !== undefined) {
+                    options.cell = options.parent.options.cell;
+                }
+
+                // Create and render the view...
+                var parameters = {model: model, options: options};
+                var view = new ViewType(parameters);
+                view.render();
+                model.on('destroy', view.remove, view);
+                options.callback(view);
+            } else {
+                errback({unknown_view: true, view_name: view_name });
             }
-
-            // Create and render the view...
-            var parameters = {model: model, options: options};
-            view = new ViewType(parameters);
-            view.render();
-            model.on('destroy', view.remove, view);
-            return view;
-        }
-        return null;
+        };
+        var loader = WidgetManager._view_types[view_name];
+        loader.after_loaded(instantiate_view);
     };
 
     WidgetManager.prototype.get_msg_cell = function (msg_id) {
@@ -215,16 +252,19 @@ define([
         // Handle when a comm is opened.
         var that = this;
         var model_id = comm.comm_id;
-        var widget_type_name = msg.content.target_name;
-        var widget_model = new WidgetManager._model_types[widget_type_name](this, model_id, comm);
-        widget_model.on('comm:close', function () {
-          delete that._models[model_id];
-        });
-        this._models[model_id] = widget_model;
+        var model_name = msg.content.target_name;
+        var loader = WidgetManager._model_types[model_name];
+        loader.after_loaded(function(ModelType) {
+             var widget_model = new ModelType(this, model_id, comm);
+             widget_model.on('comm:close', function () {
+                 delete that._models[model_id];
+             });
+             this._models[model_id] = widget_model;
+        }, this);
     };
 
     // Backwards compatability.
     IPython.WidgetManager = WidgetManager;
 
-    return {'WidgetManager': WidgetManager};
+    return {'WidgetManager': WidgetManager, 'Loader': Loader};
 });

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -285,8 +285,9 @@ define(["widgets/js/manager",
 
        },
     });
-    widgetmanager.WidgetManager.register_widget_model('WidgetModel', WidgetModel);
 
+    widgetmanager.WidgetManager.register_widget_model('WidgetModel',
+                                                      new widgetmanager.Loader(WidgetModel));
 
     var WidgetView = Backbone.View.extend({
         initialize: function(parameters) {
@@ -317,18 +318,19 @@ define(["widgets/js/manager",
             // TODO: this is hacky, and makes the view depend on this cell attribute and widget manager behavior
             // it would be great to have the widget manager add the cell metadata
             // to the subview without having to add it here.
-            options = $.extend({ parent: this }, options || {});
-            var child_view = this.model.widget_manager.create_view(child_model, options, this);
-            
-            // Associate the view id with the model id.
-            if (this.child_model_views[child_model.id] === undefined) {
-                this.child_model_views[child_model.id] = [];
-            }
-            this.child_model_views[child_model.id].push(child_view.id);
+            var that = this;
+            var old_callback = options.callback || function(view) {};
+            options = $.extend({ parent: this, callback: function(child_view) {
+                // Associate the view id with the model id.
+                if (that.child_model_views[child_model.id] === undefined) {
+                    that.child_model_views[child_model.id] = [];
+                }
+                that.child_model_views[child_model.id].push(child_view.id);
 
-            // Remember the view by id.
-            this.child_views[child_view.id] = child_view;
-            return child_view;
+                // Remember the view by id.
+                that.child_views[child_view.id] = child_view;
+                old_callback(child_view);
+             }}, options || {});
         },
 
         pop_child_view: function(child_model) {

--- a/IPython/html/static/widgets/js/widget_box.js
+++ b/IPython/html/static/widgets/js/widget_box.js
@@ -74,13 +74,15 @@ define([
 
         add_child_model: function(model) {
             // Called when a model is added to the children list.
-            var view = this.create_child_view(model);
-            this.$box.append(view.$el);
+            var that = this;
+            this.create_child_view(model, {callback: function(view) {
+                that.$box.append(view.$el);
 
-            // Trigger the displayed event of the child view.
-            this.after_displayed(function() {
-                view.trigger('displayed');
-            });
+                // Trigger the displayed event of the child view.
+                that.after_displayed(function() {
+                    view.trigger('displayed');
+                });
+            }});
         },
     });
 

--- a/IPython/html/static/widgets/js/widget_selectioncontainer.js
+++ b/IPython/html/static/widgets/js/widget_selectioncontainer.js
@@ -81,7 +81,6 @@ define([
 
         add_child_model: function(model) {
             // Called when a child is added to children list.
-            var view = this.create_child_view(model);
             var index = this.containers.length;
             var uuid = utils.uuid();
             var accordion_group = $('<div />')
@@ -114,15 +113,18 @@ define([
             var container_index = this.containers.push(accordion_group) - 1;
             accordion_group.container_index = container_index;
             this.model_containers[model.id] = accordion_group;
-            accordion_inner.append(view.$el);
+            
+            this.create_child_view(model, {callback: function(view) {
+                accordion_inner.append(view.$el);
 
-            this.update();
-            this.update_titles();
+                that.update();
+                that.update_titles();
 
-            // Trigger the displayed event of the child view.
-            this.after_displayed(function() {
-                view.trigger('displayed');
-            });
+                // Trigger the displayed event of the child view.
+                that.after_displayed(function() {
+                    view.trigger('displayed');
+                });
+            }});
         },
     });
     
@@ -176,7 +178,6 @@ define([
 
         add_child_model: function(model) {
             // Called when a child is added to children list.
-            var view = this.create_child_view(model);
             var index = this.containers.length;
             var uuid = utils.uuid();
 
@@ -184,34 +185,37 @@ define([
             var tab = $('<li />')
                 .css('list-style-type', 'none')
                 .appendTo(this.$tabs);
-            view.parent_tab = tab;
-
-            var tab_text = $('<a />')
-                .attr('href', '#' + uuid)
-                .attr('data-toggle', 'tab') 
-                .text('Page ' + index)
-                .appendTo(tab)
-                .click(function (e) {
             
-                    // Calling model.set will trigger all of the other views of the 
-                    // model to update.
-                    that.model.set("selected_index", index, {updated_view: this});
-                    that.touch();
-                    that.select_page(index);
+            this.create_child_view(model, {callback: function(view) {
+                view.parent_tab = tab;
+
+                var tab_text = $('<a />')
+                    .attr('href', '#' + uuid)
+                    .attr('data-toggle', 'tab') 
+                    .text('Page ' + index)
+                    .appendTo(tab)
+                    .click(function (e) {
+                
+                        // Calling model.set will trigger all of the other views of the 
+                        // model to update.
+                        that.model.set("selected_index", index, {updated_view: that});
+                        that.touch();
+                        that.select_page(index);
+                    });
+                tab.tab_text_index = that.containers.push(tab_text) - 1;
+
+                var contents_div = $('<div />', {id: uuid})
+                    .addClass('tab-pane')
+                    .addClass('fade')
+                    .append(view.$el)
+                    .appendTo(that.$tab_contents);
+                view.parent_container = contents_div;
+
+                // Trigger the displayed event of the child view.
+                that.after_displayed(function() {
+                    view.trigger('displayed');
                 });
-            tab.tab_text_index = this.containers.push(tab_text) - 1;
-
-            var contents_div = $('<div />', {id: uuid})
-                .addClass('tab-pane')
-                .addClass('fade')
-                .append(view.$el)
-                .appendTo(this.$tab_contents);
-            view.parent_container = contents_div;
-
-            // Trigger the displayed event of the child view.
-            this.after_displayed(function() {
-                view.trigger('displayed');
-            });
+            }});
         },
 
         update: function(options) {

--- a/IPython/html/widgets/__init__.py
+++ b/IPython/html/widgets/__init__.py
@@ -1,4 +1,4 @@
-from .widget import Widget, DOMWidget, CallbackDispatcher
+from .widget import Widget, DOMWidget, CallbackDispatcher, load_model_module, load_view_module
 
 from .widget_bool import Checkbox, ToggleButton
 from .widget_button import Button

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -74,6 +74,20 @@ def _show_traceback(method):
                 ip.showtraceback()
     return m
 
+def load_model_module(model_name, module):
+    """Loads the client-side module for a widget model
+    and register it with the given model name"""
+    comm = Comm(target_name='manager')
+    comm.send(dict(target_type='widget_model', target_name=model_name, path=module))
+    comm.close()
+
+def load_view_module(view_name, module):
+    """Loads the client-side module for a widget view
+    and register it with the given view name"""
+    comm = Comm(target_name='manager')
+    comm.send(dict(target_type='widget_view', target_name=view_name, path=module))
+    comm.close()
+
 class Widget(LoggingConfigurable):
     #-------------------------------------------------------------------------
     # Class attributes


### PR DESCRIPTION
@jasongrout @jdfreder @takluyver @ellisonbg 
This PR enables the loading of widget views and widget models from the backend. It differs from PR #6494 in that it 
 -allows for both models and views to be loaded from the backend.
 -the loading of the view modules happens at import time rather than display time. 
 -the JavaScript-specific requirejs path is not part of the widget class, but only present in the `load_***_module function`, which contains the abstraction leaking. 

How to use it: create two files in `/static/some/path` (or in nbextensions, it is not the point here)
- In some/path/TextView.js

``` JavaScript
define(["widgets/js/widget"], function(widget) {
    var TextView = widget.DOMWidgetView.extend({
        render: function(){
            this.$el.text("Hello World!");
        },
    });
    return { "MyTextView": TextView };
});
```
- In some/path/TextModel.js

``` JavaScript
define(["widgets/js/widget"], function(widget) {
    var TextModel = widget.WidgetModel.extend({ });
    return { "MyTextModel": TextModel };
});
```
-  In the Python module

``` Python
class MyText(DOMWidget):
    _view_name = Unicode('MyTextView', sync=True)
    _model_name = Unicode('MyTextModel', sync=True)

load_view_module('MyTextView', 'some/path/TextView')
load_model_module('MyTextModel', 'some/path/TextModel')
```
- The client code for the same widget in Thomas's PR #6494  would be

``` Python
class MyText(DOMWidget):
    _view_name = Unicode('MyTextView', sync=True)
    _model_name = Unicode('MyTextModel', sync=True)
    _view_module = Unicode('some/path/TextView', sync=True)
```

but the loading of the view module would happen at display time rather than import time. Besides, the abstraction leaking (the JavaScript requirejs path) goes all the way to the widget class itself instead of being contained in the loading function. Besides, PR #6494 introduces a difference in how you overload models and views. 

Besides, we should probably not introduce the change in the loading of views and later in the loading of the models. We should probably modify both at the same time so that people can change their code in one time. 
