### PR TITLE
don't use contains in SelectWidget item_query

### DIFF
--- a/IPython/html/static/widgets/js/widget_selection.js
+++ b/IPython/html/static/widgets/js/widget_selection.js
@@ -403,7 +403,7 @@ define([
                 var items = this.model.get('value_names');
                 var that = this;
                 _.each(items, function(item, index) {
-                   var item_query = ' :contains("' + item + '")';
+                   var item_query = 'option[value_name="' + item + '"]';
                     if (that.$listbox.find(item_query).length === 0) {
                         $('<option />')
                             .text(item)


### PR DESCRIPTION
gives false positive matches when some values are substrings of others

closes #6633
