### PR TITLE
Tagging

### DIFF
--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -394,6 +394,16 @@ define([
     };
 
     /**
+     * Set the metadata of the cell and triggers the celltoolbars to update.
+     * @method set_metadata
+     * @param {dictionary} metadata
+     */
+    Cell.prototype.set_metadata = function (metadata) {
+        this.metadata = metadata;
+        this.celltoolbar.rebuild();
+    };
+
+    /**
      * should be overritten by subclass
      * serialise cell to json.
      * @method toJSON

--- a/IPython/html/static/notebook/js/celltoolbar.js
+++ b/IPython/html/static/notebook/js/celltoolbar.js
@@ -244,7 +244,7 @@ define([
     };
 
     /**
-     * Rebuild all the button on the toolbar to update its state.
+     * Rebuild all the buttons on the toolbar to update its state.
      * @method rebuild
      */
     CellToolbar.prototype.rebuild = function(){

--- a/IPython/html/static/notebook/js/celltoolbarpresets/tags.js
+++ b/IPython/html/static/notebook/js/celltoolbarpresets/tags.js
@@ -8,27 +8,8 @@ define([
 ], function($, celltoolbar, bootstraptags) {
     "use strict";
 
-    var init_cell_toolbar = function(notebook, keyboard_manager){
-        var tags = toolbar_tag_ui_generator(keyboard_manager, 
-            function(cell, tags){ // Setter
-                cell.metadata.tags = tags;
-                console.log(cell, tags);
-                
-                var $tag_inputs = $('.celltoolbar .bootstrap-tags');
-                var suggestions = get_suggestions();
-                for (var i =0; i < $tag_inputs.length; i++) {
-                    $($tag_inputs[i]).data('tags').suggestions = suggestions;
-                }
-            },
-            function(cell){ // Getter
-                return cell.metadata.tags;
-            });
-        celltoolbar.CellToolbar.register_callback('default.tags', tags);
-        celltoolbar.CellToolbar.register_preset('Cell tags', ['default.tags'], notebook);
-        console.log('Cell tags extension loaded.');
-    };
-
     var get_suggestions = function() {
+        // Get a list of suggestions to use in the tags toolbar.
         var suggestions = [];
         var cells = IPython.notebook.get_cells();
         for (var i = 0; i < cells.length; i++) {
@@ -48,22 +29,26 @@ define([
     };
 
     var toolbar_tag_ui_generator = function(keyboard_manager, setter, getter){
+        // Generate a tags cell toolbar control.
         return function(div, cell, celltoolbar) {
-            var button_container = $(div).addClass('box-flex1');
-            
+            var $button_container = $(div).addClass('box-flex1');
             var $tag_list = $('<div/>')
                 .addClass('tag-list');
+            $button_container.append($tag_list);
+
             var tags = $tag_list.tags({
                 tagData: getter(cell),
                 suggestions: get_suggestions(),
                 caseInsensitive: true
             });
             $tag_list.data('tags', tags);
+            $tag_list.click(function(){
+                tags.renderTags();
+            })
             $tag_list.keyup(function(){
                 setter(cell, tags.getTags());
             });
             $tag_list.find('input').width('100%');
-            button_container.append($tag_list);
             keyboard_manager.register_events($tag_list);
         };
     };
@@ -80,7 +65,23 @@ define([
         };
 
         // Register the cell tagging toolbar.
-        init_cell_toolbar(notebook, keyboard_manager);
+        var tags = toolbar_tag_ui_generator(keyboard_manager, 
+            function(cell, tags){ // Setter
+                cell.metadata.tags = tags;
+                console.log(cell, tags);
+                
+                var $tag_inputs = $('.celltoolbar .bootstrap-tags');
+                var suggestions = get_suggestions();
+                for (var i =0; i < $tag_inputs.length; i++) {
+                    $($tag_inputs[i]).data('tags').suggestions = suggestions;
+                }
+            },
+            function(cell){ // Getter
+                return cell.metadata.tags;
+            });
+        celltoolbar.CellToolbar.register_callback('default.tags', tags);
+        celltoolbar.CellToolbar.register_preset('Cell tags', ['default.tags'], notebook);
+        console.log('Cell tags extension loaded.');
     };
     return {'register': register};
 });

--- a/IPython/html/static/notebook/js/celltoolbarpresets/tags.js
+++ b/IPython/html/static/notebook/js/celltoolbarpresets/tags.js
@@ -1,0 +1,86 @@
+// Copyright (c) IPython Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+define([
+    'jquery',
+    'notebook/js/celltoolbar',
+    'bootstraptags',
+], function($, celltoolbar, bootstraptags) {
+    "use strict";
+
+    var init_cell_toolbar = function(notebook, keyboard_manager){
+        var tags = toolbar_tag_ui_generator(keyboard_manager, 
+            function(cell, tags){ // Setter
+                cell.metadata.tags = tags;
+                console.log(cell, tags);
+                
+                var $tag_inputs = $('.celltoolbar .bootstrap-tags');
+                var suggestions = get_suggestions();
+                for (var i =0; i < $tag_inputs.length; i++) {
+                    $($tag_inputs[i]).data('tags').suggestions = suggestions;
+                }
+            },
+            function(cell){ // Getter
+                return cell.metadata.tags;
+            });
+        celltoolbar.CellToolbar.register_callback('default.tags', tags);
+        celltoolbar.CellToolbar.register_preset('Cell tags', ['default.tags'], notebook);
+        console.log('Cell tags extension loaded.');
+    };
+
+    var get_suggestions = function() {
+        var suggestions = [];
+        var cells = IPython.notebook.get_cells();
+        for (var i = 0; i < cells.length; i++) {
+            if (cells[i].metadata.tags) {
+                suggestions = $.merge(suggestions, cells[i].metadata.tags);
+            }
+        }
+
+        if (IPython.notebook.tag_suggestions) {
+            if (IPython.notebook.tag_suggestions instanceof Function) {
+                suggestions = $.merge(suggestions, IPython.notebook.tag_suggestions.apply(this, []));
+            } else {
+                suggestions = $.merge(suggestions, IPython.notebook.tag_suggestions);
+            }
+        }
+        return suggestions;
+    };
+
+    var toolbar_tag_ui_generator = function(keyboard_manager, setter, getter){
+        return function(div, cell, celltoolbar) {
+            var button_container = $(div).addClass('box-flex1');
+            
+            var $tag_list = $('<div/>')
+                .addClass('tag-list');
+            var tags = $tag_list.tags({
+                tagData: getter(cell),
+                suggestions: get_suggestions(),
+                caseInsensitive: true
+            });
+            $tag_list.data('tags', tags);
+            $tag_list.keyup(function(){
+                setter(cell, tags.getTags());
+            });
+            $tag_list.find('input').width('100%');
+            button_container.append($tag_list);
+            keyboard_manager.register_events($tag_list);
+        };
+    };
+
+    var register = function (notebook, keyboard_manager) {
+        // Register the cell tagging toolbar.
+
+        // Change the tag template so font-awesome icons are used.
+        bootstraptags.Templates = bootstraptags.Templates || {};
+        bootstraptags.Templates['3'] = bootstraptags.Templates['3'] || {};
+        bootstraptags.Templates['3'].tag = function(options) {
+            options = options || {};
+            return "<div class='tag label " + options.tagClass + " " + options.tagSize + "' " + (options.isPopover ? "rel='popover'" : "") + ">    <span>" + Tags.Helpers.addPadding(options.tag, 2, options.isReadOnly) + "</span>    " + (options.isReadOnly ? "" : "<a><i style='color: white;' class='remove fa fa-times' /></a>") + "  </div>";
+        };
+
+        // Register the cell tagging toolbar.
+        init_cell_toolbar(notebook, keyboard_manager);
+    };
+    return {'register': register};
+});

--- a/IPython/html/static/notebook/js/maintoolbar.js
+++ b/IPython/html/static/notebook/js/maintoolbar.js
@@ -218,7 +218,7 @@ define([
         // Evaluate the filter for each cell.
         var cells = this.notebook.get_cells();
         for (var i = 0; i < cells.length; i++) {
-            var tags = $.merge([], cells[i].metadata.tags);
+            var tags = $.merge([], cells[i].metadata.tags || []);
             // Add the cell type as a tag that can be filtered by.
             tags.push(cells[i].cell_type);
             cells[i].element.css('display', this._eval_expression(tags, filter) ? '' : 'none');
@@ -274,7 +274,7 @@ define([
                 // re-embed the sub-expression's results into the location in
                 // the expression that it existed in initially.
                 var start = expression.substring(0, parenthesis_start-1);
-                var mid_results = eval_filter(truths, expression.substring(parenthesis_start+1, parenthesis_end-1));
+                var mid_results = this._eval_expression(truths, expression.substring(parenthesis_start+1, parenthesis_end-1));
                 var end = expression.substring(parenthesis_end+1);
                 expression = start + ' ' + mid_results.toString().toLowerCase() && end;
             } else {

--- a/IPython/html/static/notebook/js/maintoolbar.js
+++ b/IPython/html/static/notebook/js/maintoolbar.js
@@ -135,49 +135,53 @@ define([
             label : 'Filter based on cell tags',
             icon : 'fa-filter',
             callback : $.proxy(this._handle_filter_click, this)}]);
+        this.$filter_text = null;
     };
     
     MainToolBar.prototype._handle_filter_click = function (e) {
         // Handles when the filter button is clicked.
 
+        // If the filter textbox hasn't been created yet, create it now.
         var $filter_button = $(e.currentTarget);
-        var $filter_text;
-
-        // If a filter textbox already exists, remove the textbox.
-        if ($filter_button.data('filter_text')) {
-
-            // Animate the textbox 'closing', and then remove it from the DOM.
-            $filter_text = $filter_button.data('filter_text')
-            var that = this;
-            $filter_text.animate({width: 0}, 200, 
-                'swing', function() {
-                that._handle_filter();
-                $filter_text.remove();
-            });
-            $filter_button.data('filter_text', false);
-            
-        // A filter textbox doesn't exist yet.  Create a filter textbox here.
-        } else {
-            $filter_text = $('<input/>')
+        if (!this.$filter_text) {
+            this.$filter_text = $('<input/>')
                 .attr('type', 'text')
                 .attr('placeholder', 'Tag filter expression...')
+                .css('display', 'none')
                 .width(0)
                 .addClass('form-control input-sm');
-            $filter_button.data('filter_text', $filter_text);
-            $filter_button.after($filter_text);
+        }
+
+        // If the filter textbox is visible, hide it.
+        if (this.$filter_text.css('display') != 'none') {
+
+            // Animate the textbox 'closing', and then remove it from the DOM.
+            var that = this;
+            this.$filter_text.animate({width: 0}, 200, 
+                'swing', function() {
+                that.$filter_text.val('');
+                that._handle_filter();
+                that.$filter_text.css('display', 'none');
+                that.$filter_text.detach();
+            });
+            
+        // The filter textbox is not visible, show it.
+        } else {
+            this.$filter_text.css('display', '');
+            $filter_button.after(this.$filter_text);
             
             // Prevent notebook events from firing when the user types in the 
             // filter textbox.
-            this.notebook.keyboard_manager.register_events($filter_text);
+            this.notebook.keyboard_manager.register_events(this.$filter_text);
 
             // Make sure the button group has a css class that we can style.
             $filter_button.parent().addClass('filter-control');
 
             // Animate the textbox's display.
-            $filter_text.animate({width: 200}, 200, 'swing');
+            this.$filter_text.animate({width: 200}, 200, 'swing');
 
             // Handle when the filter is changed.
-            $filter_text.on('change', $.proxy(this._handle_filter, this));
+            this.$filter_text.on('change', $.proxy(this._handle_filter, this));
         }
     };
 

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -18,6 +18,7 @@ define([
     'notebook/js/celltoolbarpresets/default',
     'notebook/js/celltoolbarpresets/rawcell',
     'notebook/js/celltoolbarpresets/slideshow',
+    'notebook/js/celltoolbarpresets/tags',
     'notebook/js/scrollmanager'
 ], function (
     IPython, 
@@ -36,6 +37,7 @@ define([
     default_celltoolbar,
     rawcell_celltoolbar,
     slideshow_celltoolbar,
+    tags_celltoolbar,
     scrollmanager
     ) {
 
@@ -137,6 +139,7 @@ define([
         default_celltoolbar.register(this);
         rawcell_celltoolbar.register(this);
         slideshow_celltoolbar.register(this);
+        tags_celltoolbar.register(this, this.keyboard_manager);
     };
 
     Notebook.options_default = {

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -995,7 +995,7 @@ define([
                     text = '';
                 }
                 //metadata
-                target_cell.metadata = source_cell.metadata;
+                target_cell.set_metadata(source_cell.metadata);
 
                 target_cell.set_text(text);
                 // make this value the starting point, so that we can only undo
@@ -1029,7 +1029,7 @@ define([
                     text = '';
                 }
                 // metadata
-                target_cell.metadata = source_cell.metadata
+                target_cell.set_metadata(source_cell.metadata);
                 // We must show the editor before setting its contents
                 target_cell.unrender();
                 target_cell.set_text(text);
@@ -1067,7 +1067,7 @@ define([
                     text = '';
                 }
                 //metadata
-                target_cell.metadata = source_cell.metadata;
+                target_cell.set_metadata(source_cell.metadata);
                 // We must show the editor before setting its contents
                 target_cell.unrender();
                 target_cell.set_text(text);
@@ -1105,7 +1105,7 @@ define([
                     text = '';
                 }
                 //metadata
-                target_cell.metadata = source_cell.metadata;
+                target_cell.set_metadata(source_cell.metadata);
                 // We must show the editor before setting its contents
                 target_cell.set_level(level);
                 target_cell.unrender();

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -139,7 +139,7 @@ define([
         default_celltoolbar.register(this);
         rawcell_celltoolbar.register(this);
         slideshow_celltoolbar.register(this);
-        tags_celltoolbar.register(this, this.keyboard_manager);
+        tags_celltoolbar.register(this);
     };
 
     Notebook.options_default = {

--- a/IPython/html/static/notebook/less/celltoolbar.less
+++ b/IPython/html/static/notebook/less/celltoolbar.less
@@ -70,3 +70,8 @@
     box-shadow: none;
     -webkit-box-shadow: none;
 }
+
+.tags-suggestion-list {
+    /* Make sure tag suggestions are always above the CodeMirror editor. */
+    z-index: 100;
+}

--- a/IPython/html/static/notebook/less/celltoolbar.less
+++ b/IPython/html/static/notebook/less/celltoolbar.less
@@ -71,7 +71,7 @@
     -webkit-box-shadow: none;
 }
 
-.tags-suggestion-list {
+.bootstrap-tags ul.tags-suggestion-list.dropdown-menu {
     /* Make sure tag suggestions are always above the CodeMirror editor. */
     z-index: 100;
 }

--- a/IPython/html/static/notebook/less/celltoolbar.less
+++ b/IPython/html/static/notebook/less/celltoolbar.less
@@ -66,6 +66,7 @@
     background: none;
     border: none;
     margin-left: 1px;
+    width: 100%;
     
     box-shadow: none;
     -webkit-box-shadow: none;

--- a/IPython/html/static/notebook/less/celltoolbar.less
+++ b/IPython/html/static/notebook/less/celltoolbar.less
@@ -48,7 +48,25 @@
 
 }
 
+/* Cell tagging toolbar style */
 .celltoolbar label {
     margin-left: 5px;
     margin-right: 5px;
+}
+
+.celltoolbar .bootstrap-tags .tags {
+    margin-left: 1px;
+}
+
+.celltoolbar .bootstrap-tags .tag {
+    font-size: 12px;
+}
+
+.celltoolbar .bootstrap-tags input {
+    background: none;
+    border: none;
+    margin-left: 1px;
+    
+    box-shadow: none;
+    -webkit-box-shadow: none;
 }

--- a/IPython/html/static/notebook/less/toolbar.less
+++ b/IPython/html/static/notebook/less/toolbar.less
@@ -28,6 +28,8 @@
         border-bottom-left-radius: 0px;
         border-top-left-radius: 0px;
         border-left-width: 0px;
+        -webkit-box-shadow: none;
+        box-shadow: none;
     }
 }
 

--- a/IPython/html/static/notebook/less/toolbar.less
+++ b/IPython/html/static/notebook/less/toolbar.less
@@ -15,11 +15,20 @@
         padding: 0px;
         padding-top: 3px;
     }
+
     .btn {
         padding: 2px 8px;
     }
 
     .border-box-sizing();
+
+    .filter-control input {
+        width: 0px;
+        height: 24px;
+        border-bottom-left-radius: 0px;
+        border-top-left-radius: 0px;
+        border-left-width: 0px;
+    }
 }
 
 .toolbar .btn-group {

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -9726,9 +9726,23 @@ textarea.celltoolbar select,
 select[multiple].celltoolbar select {
   height: auto;
 }
+/* Cell tagging toolbar style */
 .celltoolbar label {
   margin-left: 5px;
   margin-right: 5px;
+}
+.celltoolbar .bootstrap-tags .tags {
+  margin-left: 1px;
+}
+.celltoolbar .bootstrap-tags .tag {
+  font-size: 12px;
+}
+.celltoolbar .bootstrap-tags input {
+  background: none;
+  border: none;
+  margin-left: 1px;
+  box-shadow: none;
+  -webkit-box-shadow: none;
 }
 .completions {
   position: absolute;
@@ -10443,6 +10457,13 @@ span#autosave_status {
 }
 .toolbar .btn {
   padding: 2px 8px;
+}
+.toolbar .filter-control input {
+  width: 0px;
+  height: 24px;
+  border-bottom-left-radius: 0px;
+  border-top-left-radius: 0px;
+  border-left-width: 0px;
 }
 .toolbar .btn-group {
   margin-top: 0px;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -9744,6 +9744,10 @@ select[multiple].celltoolbar select {
   box-shadow: none;
   -webkit-box-shadow: none;
 }
+.tags-suggestion-list {
+  /* Make sure tag suggestions are always above the CodeMirror editor. */
+  z-index: 100;
+}
 .completions {
   position: absolute;
   z-index: 10;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -10468,6 +10468,8 @@ span#autosave_status {
   border-bottom-left-radius: 0px;
   border-top-left-radius: 0px;
   border-left-width: 0px;
+  -webkit-box-shadow: none;
+  box-shadow: none;
 }
 .toolbar .btn-group {
   margin-top: 0px;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -9744,7 +9744,7 @@ select[multiple].celltoolbar select {
   box-shadow: none;
   -webkit-box-shadow: none;
 }
-.tags-suggestion-list {
+.bootstrap-tags ul.tags-suggestion-list.dropdown-menu {
   /* Make sure tag suggestions are always above the CodeMirror editor. */
   z-index: 100;
 }

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -9741,6 +9741,7 @@ select[multiple].celltoolbar select {
   background: none;
   border: none;
   margin-left: 1px;
+  width: 100%;
   box-shadow: none;
   -webkit-box-shadow: none;
 }

--- a/IPython/html/templates/page.html
+++ b/IPython/html/templates/page.html
@@ -8,6 +8,7 @@
     <link rel="shortcut icon" type="image/x-icon" href="{{static_url("base/images/favicon.ico") }}">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <link rel="stylesheet" href="{{static_url("components/jquery-ui/themes/smoothness/jquery-ui.min.css") }}" type="text/css" />
+    <link rel="stylesheet" href="{{static_url("components/bootstrap-tags/dist/css/bootstrap-tags.css") }}" type="text/css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     {% block stylesheet %}
@@ -25,6 +26,7 @@
             jquery: 'components/jquery/jquery.min',
             bootstrap: 'components/bootstrap/js/bootstrap.min',
             bootstraptour: 'components/bootstrap-tour/build/js/bootstrap-tour.min',
+            bootstraptags: 'components/bootstrap-tags/dist/js/bootstrap-tags.min',
             jqueryui: 'components/jquery-ui/ui/minified/jquery-ui.min',
             highlight: 'components/highlight.js/build/highlight.pack',
             moment: "components/moment/moment",
@@ -45,6 +47,10 @@
             bootstraptour: {
               deps: ["bootstrap"],
               exports: "Tour"
+            },
+            bootstraptags: {
+              deps: ["bootstrap"],
+              exports: "Tags"
             },
             jqueryui: {
               deps: ["jquery"],

--- a/IPython/html/templates/page.html
+++ b/IPython/html/templates/page.html
@@ -25,8 +25,8 @@
             backbone : 'components/backbone/backbone-min',
             jquery: 'components/jquery/jquery.min',
             bootstrap: 'components/bootstrap/js/bootstrap.min',
-            bootstraptour: 'components/bootstrap-tour/build/js/bootstrap-tour.min',
             bootstraptags: 'components/bootstrap-tags/dist/js/bootstrap-tags.min',
+            bootstraptour: 'components/bootstrap-tour/build/js/bootstrap-tour.min',
             jqueryui: 'components/jquery-ui/ui/minified/jquery-ui.min',
             highlight: 'components/highlight.js/build/highlight.pack',
             moment: "components/moment/moment",
@@ -42,15 +42,18 @@
             },
             bootstrap: {
               deps: ["jquery"],
-              exports: "bootstrap"
+              // Bootstrap doesn't export a global variable.  It only extends
+              // jQuery with new functions.  Use one of those functions to verify
+              // that bootstrap has indeed loaded.
+              exports: "$.fn.popover", 
+            },
+            bootstraptags: {
+              deps: ["bootstrap"],
+              exports: "Tags", 
             },
             bootstraptour: {
               deps: ["bootstrap"],
               exports: "Tour"
-            },
-            bootstraptags: {
-              deps: ["bootstrap"],
-              exports: "Tags"
             },
             jqueryui: {
               deps: ["jquery"],


### PR DESCRIPTION
With the addition of cell tags to nbformat v4, it's probably a good time to discuss adding a GUI for tagging and filtering cells.  This PR adds a cell toolbar that uses the Bootstrap-Tags library to enable tagging of cells.  It also adds a filter GUI to the main toolbar that allows you to quickly filter cells by tag.

Ping @jasongrout and @sylvaincorlay who requested this, and @ellisonbg who took a look in person and gave me some suggestions.
