### PR TITLE
Fix icons and typos in ui tour

### DIFF
--- a/IPython/html/static/notebook/js/tour.js
+++ b/IPython/html/static/notebook/js/tour.js
@@ -11,13 +11,13 @@ define([
     var tour_style = "<div class='popover tour'>\n" +
         "<div class='arrow'></div>\n" +
         "<div style='position:absolute; top:7px; right:7px'>\n" +
-            "<button class='btn btn-default btn-sm icon-remove' data-role='end'></button>\n" +
+            "<button class='btn btn-default btn-sm' data-role='end' href='#'><i class='fa fa-times fa-sm'></i></button>\n" +
         "</div><h3 class='popover-title'></h3>\n" +
         "<div class='popover-content'></div>\n" +
         "<div class='popover-navigation'>\n" +
-            "<button class='btn btn-default icon-step-backward' data-role='prev'></button>\n" +
-            "<button class='btn btn-default icon-step-forward pull-right' data-role='next'></button>\n" +
-            "<button id='tour-pause' class='btn btn-sm btn-default icon-pause' data-resume-text='' data-pause-text='' data-role='pause-resume'></button>\n" +
+            "<button class='btn btn-default' data-role='prev' href='#'><i class='fa fa-step-backward pull-left'></i></button>\n" +
+            "<button class='btn btn-default' data-role='next' href='#'><i class='fa fa-step-forward pull-right'></i></button>\n" +
+            "<button id='tour-pause' class='btn btn-sm btn-default' data-resume-text='' data-pause-text='' data-role='pause-resume' href='#'><i class='fa fa-pause'></i></button>\n" +
         "</div>\n" +
     "</div>";
 
@@ -31,7 +31,7 @@ define([
                 title: "Welcome to the Notebook Tour",
                 placement: 'bottom',
                 orphan: true,
-                content: "You can use the left and right arrow keys to go backwards and forwards.",
+                content: "You can use the left and right arrow keys to go backwards and forwards."
             }, {
                 element: "#notebook_name",
                 title: "Filename",
@@ -92,15 +92,15 @@ define([
                 title: "Kernel Indicator",
                 placement: 'bottom',
                 onShow: function(tour) { events.trigger('status_idle.Kernel');},
-                content: "This is the Kernel indicator. It looks like this when the Kernel is idle.",
+                content: "This is the Kernel indicator. It looks like this when the Kernel is idle."
             }, {
                 element: "#kernel_indicator",
                 title: "Kernel Indicator",
                 placement: 'bottom',
                 onShow: function(tour) { events.trigger('status_busy.Kernel'); },
-                content: "The Kernel indicator looks like this when the Kernel is busy.",
+                content: "The Kernel indicator looks like this when the Kernel is busy."
             }, {
-                element: ".icon-stop",
+                element: ".fa-stop",
                 placement: 'bottom',
                 title: "Interrupting the Kernel",
                 onHide: function(tour) { events.trigger('status_idle.Kernel'); },
@@ -108,14 +108,14 @@ define([
             }, {
                 element: "#notification_kernel",
                 placement: 'bottom',
-                onShow: function(tour) { $('.icon-stop').click(); },
+                onShow: function(tour) { $('.fa-stop').click(); },
                 title: "Notification Area",
                 content: "Messages in response to user actions (Save, Interrupt, etc) appear here."
             }, {
                 title: "Fin.",
                 placement: 'bottom',
                 orphan: true,
-                content: "This concludes the IPython Notebook User Interface tour.Tour. Happy hacking!",
+                content: "This concludes the IPython Notebook User Interface Tour. Happy hacking!"
             }
         ];
 
@@ -156,7 +156,7 @@ define([
     };
     
     NotebookTour.prototype.toggle_pause_play = function () { 
-        $('#tour-pause').toggleClass('icon-pause icon-play'); 
+        $('#tour-pause').toggleClass('fa-pause fa-play'); 
     };
     
     NotebookTour.prototype.edit_mode = function() { 

--- a/IPython/html/static/notebook/js/tour.js
+++ b/IPython/html/static/notebook/js/tour.js
@@ -11,13 +11,13 @@ define([
     var tour_style = "<div class='popover tour'>\n" +
         "<div class='arrow'></div>\n" +
         "<div style='position:absolute; top:7px; right:7px'>\n" +
-            "<button class='btn btn-default btn-sm' data-role='end' href='#'><i class='fa fa-times fa-sm'></i></button>\n" +
+            "<button class='btn btn-default btn-sm fa fa-times' data-role='end'></button>\n" +
         "</div><h3 class='popover-title'></h3>\n" +
         "<div class='popover-content'></div>\n" +
         "<div class='popover-navigation'>\n" +
-            "<button class='btn btn-default' data-role='prev' href='#'><i class='fa fa-step-backward pull-left'></i></button>\n" +
-            "<button class='btn btn-default' data-role='next' href='#'><i class='fa fa-step-forward pull-right'></i></button>\n" +
-            "<button id='tour-pause' class='btn btn-sm btn-default' data-resume-text='' data-pause-text='' data-role='pause-resume' href='#'><i class='fa fa-pause'></i></button>\n" +
+            "<button class='btn btn-default fa fa-step-backward' data-role='prev'></button>\n" +
+            "<button class='btn btn-default fa fa-step-forward pull-right' data-role='next'></button>\n" +
+            "<button id='tour-pause' class='btn btn-sm btn-default fa fa-pause' data-resume-text='' data-pause-text='' data-role='pause-resume'></button>\n" +
         "</div>\n" +
     "</div>";
 


### PR DESCRIPTION
Fixes #6639 , or tries to. The x icon is too large still, and the forward/backward buttons aren't aligned correctly:

![image](https://cloud.githubusercontent.com/assets/83444/4538577/18bfc12c-4df2-11e4-837e-b9483e3ab488.png)

I imagine this should be something pretty easy to fix with the right CSS classes, but my knowledge of CSS is lacking.
