### PR TITLE
qtconsole: Add vi-like key bindings to pager (fixes #6590)

### DIFF
--- a/IPython/qt/console/console_widget.py
+++ b/IPython/qt/console/console_widget.py
@@ -1490,6 +1490,22 @@ class ConsoleWidget(MetaQObjectHasTraits('NewBase', (LoggingConfigurable, QtGui.
             QtGui.qApp.sendEvent(self._page_control, new_event)
             return True
 
+        # vi/less -like key bindings
+        elif key == QtCore.Qt.Key_J:
+            new_event = QtGui.QKeyEvent(QtCore.QEvent.KeyPress,
+                                        QtCore.Qt.Key_Down,
+                                        QtCore.Qt.NoModifier)
+            QtGui.qApp.sendEvent(self._page_control, new_event)
+            return True
+
+        # vi/less -like key bindings
+        elif key == QtCore.Qt.Key_K:
+            new_event = QtGui.QKeyEvent(QtCore.QEvent.KeyPress,
+                                        QtCore.Qt.Key_Up,
+                                        QtCore.Qt.NoModifier)
+            QtGui.qApp.sendEvent(self._page_control, new_event)
+            return True
+
         return False
 
     def _on_flush_pending_stream_timer(self):


### PR DESCRIPTION
Since _event_fileter_page_keypress() already exists in ConsoleWidget
class of qtconsole, that change was pretty easy and isolated. We emulate
up/down arrow keys with k/j when we use pager.

Suggestion. A few more vi/less key bindings can be added: h/l for
horizontal scroll, Ctrl-F/Ctrl-B for PageDown/PageUp. What do you think?
