### PR TITLE
Updating iopubwatcher.py to query for 'text' instead 'data' in the message dict

### DIFF
--- a/examples/Parallel Computing/iopubwatcher.py
+++ b/examples/Parallel Computing/iopubwatcher.py
@@ -59,7 +59,7 @@ def main(connection_file):
             # stdout/stderr
             # stream names are in msg['content']['name'], if you want to handle
             # them differently
-            print("%s: %s" % (topic, msg['content']['data']))
+            print("%s: %s" % (topic, msg['content']['text']))
         elif msg['msg_type'] == 'pyerr':
             # Python traceback
             c = msg['content']


### PR DESCRIPTION
It appears the message format has changed underneath this script, which I use with trivial changes to watch the progress of long-running computations.

Right now querying for `data` raises a `KeyError` for me on the current master branch.

I'm pretty ignorant of the low-level ZMQ messaging IPython uses -- please let me know if an alternative fix would be better.
