### PR TITLE
qtconsole: strip newline on text copy (fixes #6234)

### DIFF
--- a/IPython/qt/console/frontend_widget.py
+++ b/IPython/qt/console/frontend_widget.py
@@ -217,7 +217,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
             if text:
                 was_newline = text[-1] == '\n'
                 text = self._prompt_transformer.transform_cell(text)
-                if not was_newline: # user don't need newline
+                if not was_newline: # user doesn't need newline
                     text = text[:-1]
                 QtGui.QApplication.clipboard().setText(text)
         else:

--- a/IPython/qt/console/frontend_widget.py
+++ b/IPython/qt/console/frontend_widget.py
@@ -215,7 +215,10 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         elif self._control.hasFocus():
             text = self._control.textCursor().selection().toPlainText()
             if text:
+                was_newline = text[-1] == '\n'
                 text = self._prompt_transformer.transform_cell(text)
+                if not was_newline: # user don't need newline
+                    text = text[:-1]
                 QtGui.QApplication.clipboard().setText(text)
         else:
             self.log.debug("frontend widget : unknown copy target")


### PR DESCRIPTION
IPython's inputsplitter inserts newline at the end of string passed to
it. So, if user didn't select newline before copying, we must strip it.
