### PR TITLE
Fix IPython.utils.ansispan() to ignore stray [0m

### DIFF
--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -284,27 +284,36 @@ define([
     function ansispan(str) {
         // ansispan function adapted from github.com/mmalecki/ansispan (MIT License)
         // regular ansi escapes (using the table above)
+        var is_open = false
         return str.replace(/\033\[(0?[01]|22|39)?([;\d]+)?m/g, function(match, prefix, pattern) {
             if (!pattern) {
                 // [(01|22|39|)m close spans
-                return "</span>";
+                if (is_open) {
+                    is_open = false;
+                    return "</span>";
+                } else {
+                    return "";
+                }
+            } else {
+                is_open = true;
+
+                // consume sequence of color escapes
+                var numbers = pattern.match(/\d+/g);
+                var attrs = {};
+                while (numbers.length > 0) {
+                    _process_numbers(attrs, numbers);
+                }
+
+                var span = "<span ";
+                for (var attr in attrs) {
+                    var value = attrs[attr];
+                    span = span + " " + attr + '="' + attrs[attr] + '"';
+                }
+                return span + ">";
             }
-            // consume sequence of color escapes
-            var numbers = pattern.match(/\d+/g);
-            var attrs = {};
-            while (numbers.length > 0) {
-                _process_numbers(attrs, numbers);
-            }
-            
-            var span = "<span ";
-            for (var attr in attrs) {
-                var value = attrs[attr];
-                span = span + " " + attr + '="' + attrs[attr] + '"';
-            }
-            return span + ">";
         });
     };
-    
+
     // Transform ANSI color escape codes into HTML <span> tags with css
     // classes listed in the above ansi_colormap object. The actual color used
     // are set in the css file.

--- a/IPython/html/static/notebook/less/ansicolors.less
+++ b/IPython/html/static/notebook/less/ansicolors.less
@@ -1,13 +1,12 @@
 /* CSS font colors for translated ANSI colors. */
 
-
 .ansibold {font-weight: bold;}
 
 /* use dark versions for foreground, to improve visibility */
 .ansiblack {color: black;}
 .ansired {color: darkred;}
 .ansigreen {color: darkgreen;}
-.ansiyellow {color: brown;}
+.ansiyellow {color: #c4a000;}
 .ansiblue {color: darkblue;}
 .ansipurple {color: darkviolet;}
 .ansicyan {color: steelblue;}
@@ -22,4 +21,3 @@
 .ansibgpurple {background-color: magenta;}
 .ansibgcyan {background-color: cyan;}
 .ansibggray {background-color: gray;}
-

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -294,7 +294,7 @@ div.traceback-wrapper {
   color: darkgreen;
 }
 .ansiyellow {
-  color: brown;
+  color: #c4a000;
 }
 .ansiblue {
   color: darkblue;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8066,7 +8066,7 @@ input.engine_num_input {
   color: darkgreen;
 }
 .ansiyellow {
-  color: brown;
+  color: #c4a000;
 }
 .ansiblue {
   color: darkblue;

--- a/IPython/html/tests/base/utils.js
+++ b/IPython/html/tests/base/utils.js
@@ -19,5 +19,5 @@ casper.notebook_test(function () {
         return IPython.utils.fixConsole(input);
     }, input);
 
-    this.test.assertEquals(result, output, "IPython.util.fixConsole() handles [0m correctly");
+    this.test.assertEquals(result, output, "IPython.utils.fixConsole() handles [0m correctly");
 });

--- a/IPython/html/tests/base/utils.js
+++ b/IPython/html/tests/base/utils.js
@@ -1,0 +1,23 @@
+casper.notebook_test(function () {
+    var input = [
+        "\033[0m[\033[0minfo\033[0m] \033[0mtext\033[0m",
+        "\033[0m[\033[33mwarn\033[0m] \033[0m\tmore text\033[0m",
+        "\033[0m[\033[33mwarn\033[0m] \033[0m  https://some/url/to/a/file.ext\033[0m",
+        "\033[0m[\033[31merror\033[0m] \033[0m\033[0m",
+        "\033[0m[\033[31merror\033[0m] \033[0m\teven more text\033[0m",
+        "\033[0m[\033[31merror\033[0m] \033[0m\t\tand more more text\033[0m"].join("\n");
+
+    var output = [
+        "[info] text",
+        "[<span  class=\"ansiyellow\">warn</span>] \tmore text",
+        "[<span  class=\"ansiyellow\">warn</span>]   https://some/url/to/a/file.ext",
+        "[<span  class=\"ansired\">error</span>] ",
+        "[<span  class=\"ansired\">error</span>] \teven more text",
+        "[<span  class=\"ansired\">error</span>] \t\tand more more text"].join("\n");
+
+    var result = this.evaluate(function (input) {
+        return IPython.utils.fixConsole(input);
+    }, input);
+
+    this.test.assertEquals(result, output, "IPython.util.fixConsole() handles [0m correctly");
+});


### PR DESCRIPTION
Previously, `IPython.utils.fixConsole("\033[0m")` (I use `fixConsole()` because `ansispan()` is private) gave `"</span>"`. I also changed `ansiyellow` to something that looks actually yellow (but still dark). I'm submitting this to `master`, but it would be good to backport this to 2.x (whatever the procedure is).
