### PR TITLE
pin less to less than 1.7.5

### DIFF
--- a/IPython/html/fabfile.py
+++ b/IPython/html/fabfile.py
@@ -12,7 +12,7 @@ components_dir = pjoin(static_dir, 'components')
 here = os.path.dirname(__file__)
 
 min_less_version = '1.7.0'
-max_less_version = '1.8.0' # exclusive
+max_less_version = '1.7.5' # exclusive
 
 def _need_css_update():
     """Does less need to run?"""


### PR DESCRIPTION
1.7.5 drop all vendor-prefixed values that are set to the default value
of most browser leading to huge change in the number of lines in css and
pain everywhere.
