### PR TITLE
Add version trait to Widget base,

### DIFF
--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -107,6 +107,7 @@ class Widget(LoggingConfigurable):
     msg_throttle = Int(3, sync=True, help="""Maximum number of msgs the 
         front-end can send before receiving an idle msg from the back-end.""")
     
+    version = Int(0, sync=True, help="""Widget's version""")
     keys = List()
     def _keys_default(self):
         return [name for name in self.traits(sync=True)]


### PR DESCRIPTION
From widget Trello: version numbers for widget models;
when reloaded, will give the widget a chance to do
something intelligent or fail (by default) if the
version number doesn't match.

https://trello.com/c/joYVGd4d/49-version-numbers-for-widget-models-when-reloaded-will-give-the-widget-a-chance-to-do-something-intelligent-or-fail-by-default-if-
