### PR TITLE
Fix broken show in pager button

### DIFF
--- a/IPython/html/static/notebook/js/tooltip.js
+++ b/IPython/html/static/notebook/js/tooltip.js
@@ -118,10 +118,7 @@ define([
     Tooltip.prototype.showInPager = function (cell) {
         // reexecute last call in pager by appending ? to show back in pager
         var that = this;
-        var payload = {};
-        payload.text = that._reply.content.data['text/plain'];
-        
-        this.events.trigger('open_with_text.Pager', payload);
+        this.events.trigger('open_with_text.Pager', that._reply.content);
         this.remove_and_cancel_tooltip();
     };
 


### PR DESCRIPTION
Clicking the little "show pager" button on the tooltip no longer causes the pager to be opened -- seems that the tooltip was expecting a slightly different object than it was getting. This pull request fixes that.

I was going to add tests, too, but I couldn't get it to trigger the shift-tab keypress appropriately. I might try again later to see if I can get it to work.

Fixes #6506
