### PR TITLE
(IN PROGRESS) Refactor widget child view lists

### DIFF
--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -326,6 +326,7 @@ define(["widgets/js/manager",
 
         pop_child_view: function(child_model) {
             // Delete a child view that was previously created using create_child_view.
+            console.log("Deprecated use of WidgetView.pop_child_view; use a ViewList instead");
             var view_ids = this.child_model_views[child_model.id];
             if (view_ids !== undefined) {
 

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -591,7 +591,7 @@ define(["widgets/js/manager",
     });
 
     
-    var ViewList = function(create_view, remove_view) {
+    var ViewList = function(create_view, remove_view, context) {
         // * create_view takes a model and creates a view for that model, which we will store
         // * remove_view takes a view and destroys it (including calling .remove()
         // * each time the update() function is called with a new list, the create and destroy

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -606,7 +606,7 @@ define(["widgets/js/manager",
         initialize: function(create_view, remove_view, context) {
             this.handler_context = context || this;
             this.models = [];
-            this.views = {}; // key: model_id, value: view
+            this.views = {}; // key: model_id, value: list of views
             this.parent = parent;
             this._create_view = create_view;
             this._remove_view = remove_view || function(view) {view.remove()};
@@ -619,8 +619,14 @@ define(["widgets/js/manager",
         },
 
         remove: function(new_list) {
-            // removes each view
-            _.each(this.views, this.remove, this);
+            // removes each view that we've cached
+            _.each(this.views, function(view_list) {
+                _.each(view_list, function(view) {
+                    this._remove_view.call(this.handler_context, view);
+                }, this);
+            }, this);
+            this.models = [];
+            this.views = {};
         },
 
         _add: function(model) {

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -310,13 +310,6 @@ define(["widgets/js/manager",
 
         create_child_view: function(child_model, options) {
             // Create and return a child view.
-            //
-            // -given a model and (optionally) a view name if the view name is 
-            // not given, it defaults to the model's default view attribute.
-        
-            // TODO: this is hacky, and makes the view depend on this cell attribute and widget manager behavior
-            // it would be great to have the widget manager add the cell metadata
-            // to the subview without having to add it here.
             options = $.extend({ parent: this }, options || {});
             var child_view = this.model.widget_manager.create_view(child_model, options, this);
             

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -617,7 +617,7 @@ define(["widgets/js/manager",
         update: function(new_models, create_view, remove_view, context) {
             // the create_view, remove_view, and context arguments override the defaults
             // specified when the list is created.
-            var remove = remove_view || this._remove;
+            var remove = remove_view || this._remove_view;
             var create = create_view || this._create_view;
             var context = context || this._handler_context;
             this._do_diff(this._models, new_models,

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -591,13 +591,13 @@ define(["widgets/js/manager",
     });
 
     
-    var ViewList = function(create_view, destroy_view) {
+    var ViewList = function(create_view, remove_view) {
         // * create_view takes a model and creates a view for that model, which we will store
-        // * destroy_view takes a view and destroys it (including calling .remove()
+        // * remove_view takes a view and destroys it (including calling .remove()
         // * each time the update() function is called with a new list, the create and destroy
         //   callbacks will be called in an order so that if you append the views created in the
         //   create callback, you will duplicate the order of the list.
-        // * the destroy callback defaults to just removing the view.
+        // * the remove callback defaults to just removing the view.
 
         this.initialize.apply(this, arguments);
     }
@@ -609,13 +609,13 @@ define(["widgets/js/manager",
             this.views = {}; // key: model_id, value: view
             this.parent = parent;
             this._create_view = create_view;
-            this._remove_view = destroy_view || function(view) {view.remove()};
+            this._remove_view = remove_view || function(view) {view.remove()};
         },
 
-        update: function(new_list) {
-            this.do_diff(this.value, new_list,
+        update: function(new_models) {
+            this._do_diff(this.models, new_models,
                          this._remove, this._add, this);
-            this.models = new_list;
+            this.models = new_models;
         },
 
         remove: function(new_list) {
@@ -640,7 +640,7 @@ define(["widgets/js/manager",
                 if (views.length === 0) {
                     delete this.views[model.id]
                 }
-                this._destroy_view.call(this.handler_context, view);
+                this._remove_view.call(this.handler_context, view);
             }
         },
 
@@ -675,7 +675,7 @@ define(["widgets/js/manager",
                 added_callback.call(context||this, new_list[i]);
             }
         },
-    }
+    });
 
     var widget = {
         'WidgetModel': WidgetModel,

--- a/IPython/html/static/widgets/js/widget_box.js
+++ b/IPython/html/static/widgets/js/widget_box.js
@@ -12,9 +12,9 @@ define([
             // Public constructor
             BoxView.__super__.initialize.apply(this, arguments);
             // default remove handler removes the view
-            this.childrenViews = new widget.ViewList(this.add_child_model, null, this);
+            this.children_views = new widget.ViewList(this.add_child_model, null, this);
             this.listenTo(this.model, 'change:children', function(model, value) {
-                this.childrenViews.update(value);
+                this.children_views.update(value);
             }, this);
             this.listenTo(this.model, 'change:overflow_x', function(model, value) {
                 this.update_overflow_x();
@@ -36,7 +36,7 @@ define([
             // Called when view is rendered.
             this.$box = this.$el;
             this.$box.addClass('widget-box');
-            this.childrenViews.update(this.model.get('children'));
+            this.children_views.update(this.model.get('children'));
             this.update_overflow_x();
             this.update_overflow_y();
             this.update_box_style('');
@@ -75,7 +75,7 @@ define([
 
         remove: function() {
             BoxView.__super__.remove.apply(this, arguments);
-            this.childrenViews.remove();
+            this.children_views.remove();
         }
     });
 
@@ -233,7 +233,7 @@ define([
             this._shown_once = false;
             this.popped_out = true;
 
-            this.childrenViews.update(this.model.get('children'));
+            this.children_views.update(this.model.get('children'));
         },
         
         hide: function() {

--- a/IPython/html/static/widgets/js/widget_box.js
+++ b/IPython/html/static/widgets/js/widget_box.js
@@ -71,6 +71,7 @@ define([
             this.after_displayed(function() {
                 view.trigger('displayed');
             });
+            return view;
         },
 
         remove: function() {

--- a/IPython/html/static/widgets/js/widget_box.js
+++ b/IPython/html/static/widgets/js/widget_box.js
@@ -234,9 +234,6 @@ define([
             this.popped_out = true;
 
             this.childrenViews.update(this.model.get('children'));
-            this.model.on('change:children', function(model, value) {
-                this.update_children(model.previous('children'), value);
-            }, this);
         },
         
         hide: function() {

--- a/IPython/html/static/widgets/js/widget_box.js
+++ b/IPython/html/static/widgets/js/widget_box.js
@@ -12,7 +12,7 @@ define([
             // Public constructor
             BoxView.__super__.initialize.apply(this, arguments);
             // default remove handler removes the view
-            this.childrenViews = widget.ViewList(this.add_child, null, this);
+            this.childrenViews = new widget.ViewList(this.add_child_model, null, this);
             this.listenTo(this.model, 'change:children', function(model, value) {
                 this.childrenViews.update(value);
             }, this);


### PR DESCRIPTION
This PR attempts to factor out the maintaining of child view lists from the WidgetView class.  Advantages include:
- Ability to easily have different types of containers for child views
- Less code in WidgetView
- Most importantly, the ability to easily have multiple kinds of child view lists (for example, suppose you have a two-column widget, and you want a separate child list for the left and right).
