### PR TITLE
strip cell.trusted as a transient value

### DIFF
--- a/IPython/nbformat/v3/rwbase.py
+++ b/IPython/nbformat/v3/rwbase.py
@@ -150,6 +150,9 @@ def strip_transient(nb):
     for ws in nb['worksheets']:
         for cell in ws['cells']:
             cell.get('metadata', {}).pop('trusted', None)
+            # strip cell.trusted even though it shouldn't be used,
+            # since it's where the transient value used to be stored.
+            cell.pop('trusted', None)
     return nb
 
 


### PR DESCRIPTION
We store trust in cell.metadata.trusted now, but used to store it in cell.trusted. Just make sure we never write/read either to/from disk.
