### PR TITLE
Reset the interactive namespace __warningregistry__ before executing code

### DIFF
--- a/IPython/core/events.py
+++ b/IPython/core/events.py
@@ -63,14 +63,6 @@ class EventManager(object):
         """Remove a callback from the given event."""
         self.callbacks[event].remove(function)
     
-    def reset(self, event):
-        """Clear all callbacks for the given event."""
-        self.callbacks[event] = []
-    
-    def reset_all(self):
-        """Clear all callbacks for all events."""
-        self.callbacks = {n:[] for n in self.callbacks}
-    
     def trigger(self, event, *args, **kwargs):
         """Call callbacks for ``event``.
         

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -874,6 +874,8 @@ class InteractiveShell(SingletonConfigurable):
     def init_events(self):
         self.events = EventManager(self, available_events)
 
+        self.events.register("pre_execute", self._clear_warning_registry)
+
     def register_post_execute(self, func):
         """DEPRECATED: Use ip.events.register('post_run_cell', func)
         
@@ -883,6 +885,13 @@ class InteractiveShell(SingletonConfigurable):
              "ip.events.register('post_run_cell', func) instead.")
         self.events.register('post_run_cell', func)
     
+    def _clear_warning_registry(self):
+        # clear the warning registry, so that different code blocks with
+        # overlapping line number ranges don't cause spurious suppression of
+        # warnings (see gh-6611 for details)
+        if "__warningregistry__" in self.user_global_ns:
+            del self.user_global_ns["__warningregistry__"]
+
     #-------------------------------------------------------------------------
     # Things related to the "main" module
     #-------------------------------------------------------------------------

--- a/IPython/core/tests/test_events.py
+++ b/IPython/core/tests/test_events.py
@@ -25,20 +25,6 @@ class CallbackTests(unittest.TestCase):
         self.em.trigger('ping_received')
         self.assertEqual(cb.call_count, 1)
     
-    def test_reset(self):
-        cb = Mock()
-        self.em.register('ping_received', cb)
-        self.em.reset('ping_received')
-        self.em.trigger('ping_received')
-        assert not cb.called
-    
-    def test_reset_all(self):
-        cb = Mock()
-        self.em.register('ping_received', cb)
-        self.em.reset_all()
-        self.em.trigger('ping_received')
-        assert not cb.called
-    
     def test_cb_error(self):
         cb = Mock(side_effect=ValueError)
         self.em.register('ping_received', cb)

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -843,3 +843,17 @@ class TestSyntaxErrorTransformer(unittest.TestCase):
 
 
 
+def test_warning_suppression():
+    ip.run_cell("import warnings")
+    try:
+        with tt.AssertPrints("UserWarning: asdf", channel="stderr"):
+            ip.run_cell("warnings.warn('asdf')")
+        # Here's the real test -- if we run that again, we should get the
+        # warning again. Traditionally, each warning was only issued once per
+        # IPython session (approximately), even if the user typed in new and
+        # different code that should have also triggered the warning, leading
+        # to much confusion.
+        with tt.AssertPrints("UserWarning: asdf", channel="stderr"):
+            ip.run_cell("warnings.warn('asdf')")
+    finally:
+        ip.run_cell("del warnings")

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -301,7 +301,10 @@ class InteractiveShellTestCase(unittest.TestCase):
             assert post_explicit.called
         finally:
             # remove post-exec
-            ip.events.reset_all()
+            ip.events.unregister('pre_run_cell', pre_explicit)
+            ip.events.unregister('pre_execute', pre_always)
+            ip.events.unregister('post_run_cell', post_explicit)
+            ip.events.unregister('post_execute', post_always)
     
     def test_silent_noadvance(self):
         """run_cell(silent=True) doesn't advance execution_count"""


### PR DESCRIPTION
Fixes #6611.

Idea:

Right now, people often don't see important warnings when running
code in IPython, because (to a first approximation) any given warning
will only issue once per session. Blink and you'll miss it! This is a
very common contributor to confused emails to numpy-discussion. E.g.:

```
In [5]: 1 / my_array_with_random_contents
/home/njs/.user-python2.7-64bit-3/bin/ipython:1: RuntimeWarning: divide by zero encountered in divide
  #!/home/njs/.user-python2.7-64bit-3/bin/python
Out[5]:
array([ 1.77073316, -2.29765021, -2.01800811, ...,  1.13871243,
       -1.08302964, -8.6185091 ])
```

Oo, right, guess I gotta be careful of those zeros -- thanks, numpy,
for giving me that warning!

A few days later:

```
In [592]: 1 / some_other_array
Out[592]:
array([ 3.07735763,  0.50769289,  0.83984078, ..., -0.67563917,
       -0.85736257, -1.36511271])
```

Oops, it turns out that this array had a zero in it too, and that's
going to bite me later. But no warning this time!

The effect of this commit is to make it so that warnings triggered by
the code in cell 5 do _not_ suppress warnings triggered by the code in
cell 592. Note that this only applies to warnings triggered _directly_
by code entered interactively -- if `somepkg.foo()` calls
`anotherpkg.bad_func()` which issues a warning, then this warning will
still only be displayed once, even if multiple cells call
`somepkg.foo()`. But if cell 5 and cell 592 both call
`anotherpkg.bad_func()` directly, then both will get warnings.

(Important exception: if `foo()` is defined _interactively_, and calls
`anotherpkg.bad_func()`, then every cell that calls `foo()` will display
the warning again. This is unavoidable without fixes to CPython
upstream.)

Explanation:

Python's warning system has some weird quirks. By default, it tries to
suppress duplicate warnings, where "duplicate" means the same warning
message triggered twice by the same line of code. This requires
determining which line of code is responsible for triggering a
warning, and this is controlled by the stacklevel= argument to
warnings.warn. Basically, though, the idea is that if `foo()` calls
`bar()` which calls `baz()` which calls `some_deprecated_api()`, then `baz()`
will get counted as being "responsible", and the warning system will
make a note that the usage of `some_deprecated_api()` inside `baz()` has
already been warned about and doesn't need to be warned about
again. So far so good.

To accomplish this, obviously, there has to be a record of somewhere
which line this was. You might think that this would be done by
recording the filename:linenumber pair in a dict inside the warnings
module, or something like that. You would be wrong.

What actually happens is that the warnings module will use stack
introspection to reach into `baz()`'s execution environment, create a
global (module-level) variable there named `__warningregistry__`, and
then, inside this dictionary, record just the line number. Basically,
it assumes that any given module contains only one line 1, only one
line 2, etc., so storing the filename is irrelevant. Obviously for
interactive code this is totally wrong -- all cells share the same
execution environment and global namespace, and they all contain a new
line 1. Currently the warnings module treats these as if they were all
the same line.

In fact they are not the same line; once we have executed a given
chunk of code, we will never see those particular lines again. As soon
as a given chunk of code finishes executing, its line number labels
become meaningless, and the corresponding warning registry entries
become meaningless as well. Therefore, with this patch we delete the
`__warningregistry__` each time we execute a new block of code.
