### PR TITLE
Minor change in widgets.less to fix alignment issue

### DIFF
--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -1527,7 +1527,10 @@ div.cell.text_cell.rendered {
   box-flex: 0;
   /* Modern browsers */
   flex: none;
-  margin: 5px;
+  margin-top: 0px !important;
+  margin-bottom: 0px !important;
+  margin-right: 5px;
+  margin-left: 5px;
 }
 .widget-hbox input[type="checkbox"] {
   margin-top: 9px;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -9299,7 +9299,10 @@ div.cell.text_cell.rendered {
   box-flex: 0;
   /* Modern browsers */
   flex: none;
-  margin: 5px;
+  margin-top: 0px !important;
+  margin-bottom: 0px !important;
+  margin-right: 5px;
+  margin-left: 5px;
 }
 .widget-hbox input[type="checkbox"] {
   margin-top: 9px;

--- a/IPython/html/static/widgets/less/widgets.less
+++ b/IPython/html/static/widgets/less/widgets.less
@@ -188,7 +188,10 @@
 .widget-hbox {
     /* Horizontal widgets */
     .hbox();
-    margin: 5px;
+    margin-top: 0px !important;
+    margin-bottom: 0px !important;
+    margin-right: 5px;
+    margin-left: 5px;
 
     input[type="checkbox"] {
         margin-top: 9px;


### PR DESCRIPTION
When aligning certain widget in an hbox, you would get this
![un-aligned](https://cloud.githubusercontent.com/assets/2397974/4601268/27d317b6-50f6-11e4-9dfa-6d6856978d6a.png)

With this change:
![aligned](https://cloud.githubusercontent.com/assets/2397974/4601276/83cb3152-50f6-11e4-9042-03e4570d6d8c.png)
@jdfreder 
