### PR TITLE
use default kernel name in kernels service

### DIFF
--- a/IPython/html/services/kernels/handlers.py
+++ b/IPython/html/services/kernels/handlers.py
@@ -27,16 +27,16 @@ class MainKernelHandler(IPythonHandler):
     @web.authenticated
     @json_errors
     def post(self):
+        km = self.kernel_manager
         model = self.get_json_body()
         if model is None:
-            raise web.HTTPError(400, "No JSON data provided")
-        try:
-            name = model['name']
-        except KeyError:
-            raise web.HTTPError(400, "Missing field in JSON data: name")
+            model = {
+                'name': km.default_kernel_name
+            }
+        else:
+            model.setdefault('name', km.default_kernel_name)
 
-        km = self.kernel_manager
-        kernel_id = km.start_kernel(kernel_name=name)
+        kernel_id = km.start_kernel(kernel_name=model['name'])
         model = km.kernel_model(kernel_id)
         location = url_path_join(self.base_url, 'api', 'kernels', kernel_id)
         self.set_header('Location', url_escape(location))

--- a/IPython/html/services/kernels/tests/test_kernels_api.py
+++ b/IPython/html/services/kernels/tests/test_kernels_api.py
@@ -57,6 +57,16 @@ class KernelAPITest(NotebookTestBase):
         kernels = self.kern_api.list().json()
         self.assertEqual(kernels, [])
 
+    def test_default_kernel(self):
+        # POST request
+        r = self.kern_api._req('POST', '')
+        kern1 = r.json()
+        self.assertEqual(r.headers['location'], '/api/kernels/' + kern1['id'])
+        self.assertEqual(r.status_code, 201)
+        self.assertIsInstance(kern1, dict)
+
+        self.assertEqual(r.headers['x-frame-options'], "SAMEORIGIN")
+
     def test_main_kernel_handler(self):
         # POST request
         r = self.kern_api.start()


### PR DESCRIPTION
if kernel name is unspecified. Matches sessions API.
