### PR TITLE
set contentType='application/json'

### DIFF
--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1941,7 +1941,7 @@ define([
             cache : false,
             type : "PUT",
             data : JSON.stringify(model),
-            headers : {'Content-Type': 'application/json'},
+            contentType: 'application/json',
             dataType : "json",
             success : $.proxy(this.save_notebook_success, this, start),
             error : $.proxy(this.save_notebook_error, this)
@@ -2158,7 +2158,7 @@ define([
             type : "PATCH",
             data : JSON.stringify(data),
             dataType: "json",
-            headers : {'Content-Type': 'application/json'},
+            contentType: 'application/json',
             success : $.proxy(that.rename_success, this),
             error : $.proxy(that.rename_error, this)
         };

--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -434,7 +434,7 @@ define([
                     cache : false,
                     type : 'PUT',
                     data : JSON.stringify(model),
-                    headers : {'Content-Type': content_type},
+                    contentType: content_type,
                     success : function (data, status, xhr) {
                         item.removeClass('new-file');
                         that.add_link(model, item);

--- a/IPython/html/tests/notebook/save.js
+++ b/IPython/html/tests/notebook/save.js
@@ -8,7 +8,9 @@ casper.notebook_test(function () {
     // This causes no actual problems, but will break string comparison.
     var nbname = "has#hash and space and unicø∂e.ipynb";
     
-    this.evaluate(function (nbname) {
+    this.append_cell("s = '??'", 'code');
+    
+    this.thenEvaluate(function (nbname) {
         require(['base/js/events'], function (events) {
             IPython.notebook.notebook_name = nbname;
             IPython._save_success = IPython._save_failed = false;


### PR DESCRIPTION
instead of skipping straight to headers

avoids jQuery's crazy JSONP detection on `=.*??`, which was triggered because it assumed the contentType was unspecified, and thus should be guessed based on content.

closes #6689
