### PR TITLE
Use low overhead object heritence in Js (Object.create vs new)

### DIFF
--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -115,7 +115,7 @@ define([
 
     CodeCell.msg_cells = {};
 
-    CodeCell.prototype = new Cell();
+    CodeCell.prototype = Object.create(Cell.prototype);
 
     /**
      * @method auto_highlight

--- a/IPython/html/static/notebook/js/maintoolbar.js
+++ b/IPython/html/static/notebook/js/maintoolbar.js
@@ -27,7 +27,7 @@ define([
         this.bind_events();
     };
 
-    MainToolBar.prototype = new toolbar.ToolBar();
+    MainToolBar.prototype = Object.create(toolbar.ToolBar.prototype);
 
     MainToolBar.prototype.construct = function () {
         var that = this;

--- a/IPython/html/static/notebook/js/scrollmanager.js
+++ b/IPython/html/static/notebook/js/scrollmanager.js
@@ -68,7 +68,7 @@ define(['jquery'], function($){
         // Public constructor.
         ScrollManager.apply(this, [notebook, options]);
     };
-    TargetScrollManager.prototype = new ScrollManager();
+    TargetScrollManager.prototype = Object.create(ScrollManager.prototype);
 
     TargetScrollManager.prototype.is_target = function (index) {
         // Check if a cell should be a scroll stop.
@@ -114,7 +114,7 @@ define(['jquery'], function($){
         // Public constructor.
         TargetScrollManager.apply(this, [notebook, options]);
     };
-    SlideScrollManager.prototype = new TargetScrollManager();
+    SlideScrollManager.prototype = Object.create(TargetScrollManager.prototype);
 
     SlideScrollManager.prototype.is_target = function (index) {
         var cell = this.notebook.get_cell(index);
@@ -131,7 +131,7 @@ define(['jquery'], function($){
         options = options || {};
         this._level = options.heading_level || 1;
     };
-    HeadingScrollManager.prototype = new ScrollManager();
+    HeadingScrollManager.prototype = Object.create(ScrollManager.prototype)
 
     HeadingScrollManager.prototype.scroll = function (delta) {
         // Scroll the document.

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -55,7 +55,7 @@ define([
         this.rendered = false;
     };
 
-    TextCell.prototype = new Cell();
+    TextCell.prototype = Object.create(Cell.prototype);
 
     TextCell.options_default = {
         cm_config : {
@@ -220,7 +220,7 @@ define([
         placeholder: "Type *Markdown* and LaTeX: $\\alpha^2$"
     };
 
-    MarkdownCell.prototype = new TextCell();
+    MarkdownCell.prototype = Object.create(TextCell.prototype);
 
     /**
      * @method render
@@ -270,7 +270,7 @@ define([
             "When passing through nbconvert, a Raw Cell's content is added to the output unmodified."
     };
 
-    RawCell.prototype = new TextCell();
+    RawCell.prototype = Object.create(TextCell.prototype);
 
     /** @method bind_events **/
     RawCell.prototype.bind_events = function () {
@@ -330,7 +330,7 @@ define([
         placeholder: "Type Heading Here"
     };
 
-    HeadingCell.prototype = new TextCell();
+    HeadingCell.prototype = Object.create(TextCell.prototype);
 
     /** @method fromJSON */
     HeadingCell.prototype.fromJSON = function (data) {


### PR DESCRIPTION
the use of

```
XX.prototype = new YY();
```

Does trigger the constructor of YY without the nead for it. `Object.create`
does go around this limitation and target browser that are relatively Old.

Cf https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create

for more info

It might help to get rid of some logic in constructors that check wether some
options are passed in, that were causing errors on noteboko load.  Typically
`if(element){ }` on Abstract  `Cell` constructor.

---

Compat table : http://kangax.github.io/compat-table/es5/

IE9, FF21, Saf6, Ch23, OP15 are compatible.
