### PR TITLE
install local mathjax on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,9 @@ before_install:
     # pin tornado < 4 for js tests while phantom is on super old webkit
     - if [[ $GROUP == 'js' ]]; then pip install 'tornado<4'; fi
     - time pip install -f https://nipy.bic.berkeley.edu/wheelhouse/travis jinja2 sphinx pygments tornado requests!=2.4.2 mock pyzmq jsonschema jsonpointer mistune
+    - if [[ $GROUP == 'js' ]]; then python -m IPython.external.mathjax; fi
 install:
-    - time python setup.py install -q 
+    - time python setup.py install -q
 script:
     - cd /tmp && iptest $GROUP
 


### PR DESCRIPTION
when running the js tests

I'm not sure why loading MathJax from the CDN is falling on Travis, but it's working fine locally, so I'm inclined to just workaround whatever weirdness is going on on Travis.
