### PR TITLE
Right-justify celltoolbar instead of reversing

### DIFF
--- a/IPython/html/static/notebook/less/celltoolbar.less
+++ b/IPython/html/static/notebook/less/celltoolbar.less
@@ -11,7 +11,7 @@
     height: @celltoolbar-height;
     padding-right: 4px;
     .hbox();
-    .reverse();
+    .end();
 }
 
 .ctb_hideshow {

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -9617,7 +9617,6 @@ p {
   background: #EEE;
   border-radius: 3px 3px 0px 0px;
   width: 100%;
-  -webkit-box-pack: end;
   height: 29px;
   padding-right: 4px;
   /* Old browsers */
@@ -9641,11 +9640,11 @@ p {
   /* Modern browsers */
   flex: none;
   /* Old browsers */
-  -webkit-box-direction: reverse;
-  -moz-box-direction: reverse;
-  box-direction: reverse;
+  -webkit-box-pack: end;
+  -moz-box-pack: end;
+  box-pack: end;
   /* Modern browsers */
-  flex-direction: row-reverse;
+  justify-content: flex-end;
 }
 .ctb_hideshow {
   display: none;


### PR DESCRIPTION
Fixes #6704 
