### PR TITLE
include mathjax in components

### DIFF
--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -546,25 +546,8 @@ class NotebookApp(BaseIPythonApplication):
         static_url_prefix = self.tornado_settings.get("static_url_prefix",
                          url_path_join(self.base_url, "static")
         )
-        
-        # try local mathjax, either in nbextensions/mathjax or static/mathjax
-        for (url_prefix, search_path) in [
-            (url_path_join(self.base_url, "nbextensions"), self.nbextensions_path),
-            (static_url_prefix, self.static_file_path),
-        ]:
-            self.log.debug("searching for local mathjax in %s", search_path)
-            try:
-                mathjax = filefind(os.path.join('mathjax', 'MathJax.js'), search_path)
-            except IOError:
-                continue
-            else:
-                url = url_path_join(url_prefix, u"mathjax/MathJax.js")
-                self.log.info("Serving local MathJax from %s at %s", mathjax, url)
-                return url
-        
-        # no local mathjax, serve from CDN
-        url = u"https://cdn.mathjax.org/mathjax/latest/MathJax.js"
-        self.log.info("Using MathJax from CDN: %s", url)
+        url = url_path_join(static_url_prefix, "components/mathjax/MathJax.js")
+        self.log.info("Using MathJax from components: %s", url)
         return url
     
     def _mathjax_url_changed(self, name, old, new):

--- a/IPython/html/static/notebook/js/mathjaxutils.js
+++ b/IPython/html/static/notebook/js/mathjaxutils.js
@@ -24,6 +24,9 @@ define([
                 displayAlign: 'center',
                 "HTML-CSS": {
                     styles: {'.MathJax_Display': {"margin": 0}},
+                    availableFonts: [], preferredFont: null, // force Web fonts
+                    webFont: 'STIX-Web',
+                    imageFont: null,
                     linebreaks: { automatic: true }
                 }
             });

--- a/setupbase.py
+++ b/setupbase.py
@@ -164,6 +164,12 @@ def find_package_data():
         pjoin(components, "moment", "min","moment.min.js"),
     ])
     
+    # Ship mathjax js, css, woff
+    for parent, dirs, files in os.walk(pjoin(components, 'mathjax')):
+        for f in files:
+            if f.endswith(('.js', '.css', '.woff')):
+                static_data.append(pjoin(parent, f))
+    
     # Ship all of Codemirror's CSS and JS
     for parent, dirs, files in os.walk(pjoin(components, 'codemirror')):
         for f in files:


### PR DESCRIPTION
increases IPython install size by 2 MB (11->13MB), and wheel size by 1.3MB (2.9->4.2MB)
