### PR TITLE
use invoke instead of fabric

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get install -y -q build-essential make gcc zlib1g-dev git && \
 # In order to build from source, need less
 RUN npm install -g less
 
-RUN apt-get install -y -q fabric python-sphinx python3-sphinx
+RUN apt-get install -y -q python-sphinx python3-sphinx
+RUN pip install invoke
 
 RUN mkdir -p /srv/
 WORKDIR /srv/

--- a/IPython/html/README.md
+++ b/IPython/html/README.md
@@ -4,10 +4,9 @@
 
 Developers of the IPython Notebook will need to install the following tools:
 
-* fabric
+* invoke
 * node.js
 * less (`npm install -g less`)
-* bower (`npm install -g bower`)
 
 ## Components
 
@@ -15,14 +14,13 @@ We are moving to a model where our JavaScript dependencies are managed using
 [bower](http://bower.io/). These packages are installed in `static/components`
 and committed into a separate git repo [ipython/ipython-components](ipython/ipython-components).
 Our dependencies are described in the file
-`static/components/bower.json`. To update our bower packages, run `fab update`
+`static/components/bower.json`. To update our bower packages, run `bower install`
 in this directory.
 
 ## less
 
 If you edit our `.less` files you will need to run the less compiler to build
-our minified css files.  This can be done by running `fab css` from this directory,
-or `python setup.py css` from the root of the repository. 
+our minified css files.  This can be done by running `python setup.py css` from the root of the repository. 
 If you are working frequently with `.less` files please consider installing git hooks that
 rebuild the css files and corresponding maps in `${RepoRoot}/git-hooks/install-hooks.sh`.
 

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -259,7 +259,7 @@ sec.requires('zmq', 'tornado', 'requests', 'sqlite3', 'jsonschema')
 # file in there (MathJax ships a conf.py), so we might as
 # well play it safe and skip the whole thing.
 sec.exclude('static')
-sec.exclude('fabfile')
+sec.exclude('tasks')
 if not have['jinja2']:
     sec.exclude('notebookapp')
 if not have['pygments'] or not have['jinja2']:

--- a/docs/autogen_api.py
+++ b/docs/autogen_api.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
                                         r'\.core\.display',
                                         r'\.lib\.display',
                                         # This isn't actually a module
-                                        r'\.html\.fabfile',
+                                        r'\.html\.tasks',
                                         ]
 
     # These modules import functions and classes from other places to expose

--- a/git-hooks/post-checkout
+++ b/git-hooks/post-checkout
@@ -9,12 +9,12 @@ else
   PREVIOUS_HEAD=$1
 fi
 
-# if style changed (and less/fabric available), rebuild sourcemaps
+# if style changed (and less/invoke available), rebuild sourcemaps
 if [[
   ! -z "$(git diff $PREVIOUS_HEAD IPython/html/static/style/ipython.min.css)"
   && ! -z "$(git diff $PREVIOUS_HEAD IPython/html/static/style/style.min.css)"
   && ! -z $(which 2>/dev/null lessc)
-  && ! -z $(which 2>/dev/null fab)
+  && ! -z $(which 2>/dev/null invoke)
 ]]; then
   echo "rebuilding sourcemaps"
   cd IPython/html

--- a/setupbase.py
+++ b/setupbase.py
@@ -669,7 +669,7 @@ class CompileCSS(Command):
     
     Regenerate the compiled CSS from LESS sources.
     
-    Requires various dev dependencies, such as fabric and lessc.
+    Requires various dev dependencies, such as invoke and lessc.
     """
     description = "Recompile Notebook CSS"
     user_options = [
@@ -686,11 +686,12 @@ class CompileCSS(Command):
         self.force = bool(self.force)
     
     def run(self):
-        check_call([
-                "fab",
-                "css:minify=%s,force=%s" % (self.minify, self.force),
-            ], cwd=pjoin(repo_root, "IPython", "html"),
-        )
+        cmd = ['invoke', 'css']
+        if self.minify:
+            cmd.append('--minify')
+        if self.force:
+            cmd.append('--force')
+        check_call(cmd, cwd=pjoin(repo_root, "IPython", "html"))
 
 
 class JavascriptVersion(Command):

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,8 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 
-# Building the source distribution requires both fabric's fab binary
-# (http://www.fabfile.org/) and the lessc binary of the css preprocessor
-# less (http://lesscss.org/) in the PATH.
-# "pip install fabric" will install fabric. Less can be installed by
+# Building the source distribution requires `invoke` and `lessc` to be on your PATH.
+# "pip install invoke" will install invoke. Less can be installed by
 # node.js' (http://nodejs.org/) package manager npm:
 # "npm install -g less".
 


### PR DESCRIPTION
it's the descendant of the part of fabric we actually use, it doesn't have complex compiled dependencies like fabric, and it works on Python 3.
