### PR TITLE
Add handling of cursor_start and cursor_end for console completions

### DIFF
--- a/IPython/terminal/console/completer.py
+++ b/IPython/terminal/console/completer.py
@@ -44,15 +44,15 @@ class ZMQCompleter(IPCompleter):
         msg = self.client.shell_channel.get_msg(timeout=self.timeout)
         if msg['parent_header']['msg_id'] == msg_id:
             content = msg["content"]
+            matches = content["matches"]
             if content["cursor_start"] > 0:
-                content["matches"] = [line[:content["cursor_start"]] + m
-                                      for m in content["matches"]]
+                matches = [line[:content["cursor_start"]] + m
+                           for m in matches]
             if content["cursor_end"] < cursor_pos:
                 extra = line[content["cursor_end"]: cursor_pos]
-                content["matches"] = [m + extra
-                                      for m in content["matches"]]
+                matches = [m + extra for m in matches]
 
-            return content["matches"]
+            return matches
         return []
     
     def rlcomplete(self, text, state):

--- a/IPython/terminal/console/completer.py
+++ b/IPython/terminal/console/completer.py
@@ -50,7 +50,7 @@ class ZMQCompleter(IPCompleter):
             if content["cursor_end"] < cursor_pos:
                 extra = line[content["cursor_end"]: cursor_pos]
                 content["matches"] = [m + extra
-                                      for m in content["matches"]
+                                      for m in content["matches"]]
 
             return content["matches"]
         return []

--- a/IPython/terminal/console/completer.py
+++ b/IPython/terminal/console/completer.py
@@ -43,7 +43,11 @@ class ZMQCompleter(IPCompleter):
         
         msg = self.client.shell_channel.get_msg(timeout=self.timeout)
         if msg['parent_header']['msg_id'] == msg_id:
-            return msg["content"]["matches"]
+            content = msg["content"]
+            if content["cursor_start"] > 0:
+                content["matches"] = [line[:content["cursor_start"]] + m
+                                      for m in content["matches"]]
+            return content["matches"]
         return []
     
     def rlcomplete(self, text, state):

--- a/IPython/terminal/console/completer.py
+++ b/IPython/terminal/console/completer.py
@@ -47,6 +47,11 @@ class ZMQCompleter(IPCompleter):
             if content["cursor_start"] > 0:
                 content["matches"] = [line[:content["cursor_start"]] + m
                                       for m in content["matches"]]
+            if content["cursor_end"] < cursor_pos:
+                extra = line[content["cursor_end"]: cursor_pos]
+                content["matches"] = [m + extra
+                                      for m in content["matches"]
+
             return content["matches"]
         return []
     


### PR DESCRIPTION
This partially addresses #6690.
This handles `cursor_start` and `cursor_end` <= `cursor_pos`.
