### PR TITLE
Use metaclass repr [master]

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -517,11 +517,7 @@ def _default_pprint(obj, p, cycle):
     klass = _safe_getattr(obj, '__class__', None) or type(obj)
     if _safe_getattr(klass, '__repr__', None) not in _baseclass_reprs:
         # A user-provided repr. Find newlines and replace them with p.break_()
-        output = repr(obj)
-        for idx,output_line in enumerate(output.splitlines()):
-            if idx:
-                p.break_()
-            p.text(output_line)
+        _repr_pprint(obj, p, cycle)
         return
     p.begin_group(1, '<')
     p.pretty(klass)
@@ -685,7 +681,7 @@ def _type_pprint(obj, p, cycle):
 
     # Checks for a __repr__ override in the metaclass
     if type(obj).__repr__ is not type.__repr__:
-        p.text(repr(obj))
+        _repr_pprint(obj, p, cycle)
         return
 
     mod = _safe_getattr(obj, '__module__', None)
@@ -699,7 +695,12 @@ def _type_pprint(obj, p, cycle):
 
 def _repr_pprint(obj, p, cycle):
     """A pprint that just redirects to the normal repr function."""
-    p.text(repr(obj))
+    # Find newlines and replace them with p.break_()
+    output = repr(obj)
+    for idx,output_line in enumerate(output.splitlines()):
+        if idx:
+            p.break_()
+        p.text(output_line)
 
 
 def _function_pprint(obj, p, cycle):

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -682,6 +682,12 @@ def _type_pprint(obj, p, cycle):
     """The pprint for classes and types."""
     # Heap allocated types might not have the module attribute,
     # and others may set it to None.
+
+    # Checks for a __repr__ override in the metaclass
+    if type(obj).__repr__ is not type.__repr__:
+        p.text(repr(obj))
+        return
+
     mod = _safe_getattr(obj, '__module__', None)
     name = _safe_getattr(obj, '__qualname__', obj.__name__)
 

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -214,3 +214,19 @@ def test_long_dict():
 def test_unbound_method():
     output = pretty.pretty(MyObj.somemethod)
     nt.assert_in('MyObj.somemethod', output)
+
+
+class MetaClass(type):
+    def __new__(cls, name):
+        return type.__new__(cls, name, (object,), {'name': name})
+
+    def __repr__(self):
+        return "[CUSTOM REPR FOR CLASS %s]" % self.name
+
+
+ClassWithMeta = MetaClass('ClassWithMeta')
+
+
+def test_metaclass_repr():
+    output = pretty.pretty(ClassWithMeta)
+    nt.assert_equal(output, "[CUSTOM REPR FOR CLASS ClassWithMeta]")


### PR DESCRIPTION
Checks for metaclass's `__repr__` in `_type_pprint`

`RepresentationPrinter` has a type pprinter for 'type' subclasses. It will thus be called to print a class object (instance of 'type'), avoiding the `__repr__` of the metaclass.

This patch checks for an overridden `__repr__` before using the custom type-representation logic.

Fixes #6709

This is the same as #6716 but rebased on master.
