### PR TITLE
Fix QtConsole tooltip formatting to deal with changed format

### DIFF
--- a/IPython/qt/console/call_tip_widget.py
+++ b/IPython/qt/console/call_tip_widget.py
@@ -1,6 +1,5 @@
 # Standard library imports
 import re
-import textwrap
 from unicodedata import category
 
 # System library imports
@@ -37,6 +36,7 @@ class CallTipWidget(QtGui.QLabel):
                 QtGui.QStyle.PM_ToolTipLabelFrameWidth, None, self))
         self.setWindowOpacity(self.style().styleHint(
                 QtGui.QStyle.SH_ToolTipLabel_Opacity, None, self, None) / 255.0)
+        self.setWordWrap(True)
 
     def eventFilter(self, obj, event):
         """ Reimplemented to hide on certain key presses and on text edit focus
@@ -244,16 +244,6 @@ class CallTipWidget(QtGui.QLabel):
 
     def _format_tooltip(self, doc):
         doc = re.sub(r'\033\[(\d|;)+?m', '', doc)
-
-        # make sure a long argument list does not make
-        # the first row overflow the width of the actual tip body
-        rows = doc.split("\n")
-        # An object which is not a callable has '<no docstring>' as doc
-        if len(rows) == 1:
-            return doc
-        max_text_width = max(80, max([len(x) for x in rows[1:]]))
-        rows= textwrap.wrap(rows[0],max_text_width) + rows[1:]
-        doc = "\n".join(rows)
         return doc
 
     #------ Signal handlers ----------------------------------------------------


### PR DESCRIPTION
looks like the tooltip message format was changed and the formatting/wrapping logic wasn't updated. 
the formatting function should generate it's output based on structured data not by mangling a formatted string,but that's ok.

tested with py2.7/3.3, checked long signature and with wide docstrings.
the original code tried never to mess with the docstring formatting, I did not change that.

fixes part of #6726. cc @takluyver @Carreau 
