### PR TITLE
QtConsole Completion Fix - Do not force the "end" to be later than the "start"

### DIFF
--- a/IPython/qt/console/ipython_widget.py
+++ b/IPython/qt/console/ipython_widget.py
@@ -152,7 +152,7 @@ class IPythonWidget(FrontendWidget):
             end = content['cursor_end']
             
             start = max(start, 0)
-            end = max(end, start + 1)
+            end = max(end, start)
 
             # Move the control's cursor to the desired end point
             cursor_pos = self._get_input_buffer_cursor_pos()


### PR DESCRIPTION
This is a follow-on fix to #6692.  By forcing `end > start`, if the buffer ended with a non-python identifier, the last character would be eaten by the result: e.g.  `import <TAB>`, select `abc`, would result in `importabc`.  With this patch, we now get `import abc`.
