### PR TITLE
inspect_reply messages have 'oname', not 'name'

### DIFF
--- a/IPython/kernel/adapter.py
+++ b/IPython/kernel/adapter.py
@@ -160,7 +160,7 @@ class V5toV4(Adapter):
     
     def object_info_reply(self, msg):
         """inspect_reply can't be easily backward compatible"""
-        msg['content'] = {'found' : False, 'name' : 'unknown'}
+        msg['content'] = {'found' : False, 'oname' : 'unknown'}
         return msg
     
     # iopub channel
@@ -274,7 +274,7 @@ class V4toV5(Adapter):
         content = msg['content']
         new_content = msg['content'] = {'status' : 'ok'}
         found = new_content['found'] = content['found']
-        new_content['name'] = content['name']
+        new_content['name'] = content['oname']
         new_content['data'] = data = {}
         new_content['metadata'] = {}
         if found:

--- a/IPython/kernel/tests/test_adapter.py
+++ b/IPython/kernel/tests/test_adapter.py
@@ -155,7 +155,7 @@ class V4toV5TestCase(AdapterTest):
     
     def test_object_info_reply(self):
         msg = self.msg("object_info_reply", {
-            'name' : 'foo',
+            'oname' : 'foo',
             'found' : True,
             'status' : 'ok',
             'definition' : 'foo(a=5)',
@@ -302,7 +302,7 @@ class V5toV4TestCase(AdapterTest):
         self.assertEqual(v4['header']['msg_type'], 'object_info_reply')
         v4c = v4['content']
         v5c = v5['content']
-        self.assertEqual(sorted(v4c), ['found', 'name'])
+        self.assertEqual(sorted(v4c), ['found', 'oname'])
         self.assertEqual(v4c['found'], False)
     
     # iopub channel


### PR DESCRIPTION
update adapters accordingly.

The v4 message spec doc wrongly states that they key is 'name'.

closes #6738
