### PR TITLE
Make Selection widgets respect values order.

### DIFF
--- a/IPython/html/static/widgets/js/widget_selection.js
+++ b/IPython/html/static/widgets/js/widget_selection.js
@@ -60,7 +60,7 @@ define([
                     this.$droplabel.text(selected_item_text);
                 }
                 
-                var items = this.model.get('value_names');
+                var items = this.model.get('_value_names');
                 var $replace_droplist = $('<ul />')
                     .addClass('dropdown-menu');
                 // Copy the style
@@ -170,7 +170,7 @@ define([
             // changed by another view or by a state update from the back-end.
             if (options === undefined || options.updated_view != this) {
                 // Add missing items to the DOM.
-                var items = this.model.get('value_names');
+                var items = this.model.get('_value_names');
                 var disabled = this.model.get('disabled');
                 var that = this;
                 _.each(items, function(item, index) {
@@ -275,7 +275,7 @@ define([
             // changed by another view or by a state update from the back-end.
             if (options === undefined || options.updated_view != this) {
                 // Add missing items to the DOM.
-                var items = this.model.get('value_names');
+                var items = this.model.get('_value_names');
                 var disabled = this.model.get('disabled');
                 var that = this;
                 var item_html;
@@ -400,7 +400,7 @@ define([
             // changed by another view or by a state update from the back-end.
             if (options === undefined || options.updated_view != this) {
                 // Add missing items to the DOM.
-                var items = this.model.get('value_names');
+                var items = this.model.get('_value_names');
                 var that = this;
                 _.each(items, function(item, index) {
                    var item_query = 'option[value_name="' + item + '"]';

--- a/IPython/html/tests/widgets/widget_selection.js
+++ b/IPython/html/tests/widgets/widget_selection.js
@@ -134,9 +134,10 @@ casper.notebook_test(function () {
     this.wait_for_idle();
 
     index = this.append_cell(
+        'from copy import copy\n' +
         'for widget in selection:\n' +
-        '    d = widget.values.copy()\n' +
-        '    d["z"] = "z"\n' +
+        '    d = copy(widget.values)\n' +
+        '    d.append("z")\n' +
         '    widget.values = d\n' +
         'selection[0].value = "z"');
     this.execute_cell_then(index, function(index){

--- a/IPython/html/widgets/tests/test_interaction.py
+++ b/IPython/html/widgets/tests/test_interaction.py
@@ -223,13 +223,12 @@ def test_list_tuple_3_float():
 def test_list_tuple_str():
     values = ['hello', 'there', 'guy']
     first = values[0]
-    dvalues = OrderedDict((v,v) for v in values)
     c = interactive(f, tup=tuple(values), lis=list(values))
     nt.assert_equal(len(c.children), 2)
     d = dict(
         cls=widgets.Dropdown,
         value=first,
-        values=dvalues
+        values=values
     )
     check_widgets(c, tup=d, lis=d)
 
@@ -292,7 +291,7 @@ def test_default_values():
         ),
         j=dict(
             cls=widgets.Dropdown,
-            values={'hi':'hi', 'there':'there'},
+            values=['hi', 'there'],
             value='there'
         ),
     )
@@ -315,7 +314,7 @@ def test_default_out_of_bounds():
         ),
         j=dict(
             cls=widgets.Dropdown,
-            values={'hi':'hi', 'there':'there'},
+            values=['hi', 'there'],
             value='hi',
         ),
     )

--- a/IPython/html/widgets/widget_selection.py
+++ b/IPython/html/widgets/widget_selection.py
@@ -42,12 +42,12 @@ class _Selection(DOMWidget):
     The keys of this list are the strings that will be displayed in the UI,
     representing the actual Python choices.
     
-    The keys of this list are also available as value_names.
+    The keys of this list are also available as _value_names.
     """)
     
-    values_dict = Dict()
-    value_names = Tuple(sync=True)
-    value_values = Tuple()
+    _values_dict = Dict()
+    _value_names = Tuple(sync=True)
+    _value_values = Tuple()
 
     disabled = Bool(False, help="Enable or disable user changes", sync=True)
     description = Unicode(help="Description of the value this widget represents", sync=True)
@@ -55,7 +55,7 @@ class _Selection(DOMWidget):
     def __init__(self, *args, **kwargs):
         self.value_lock = Lock()
         self.values_lock = Lock()
-        self.on_trait_change(self._values_readonly_changed, ['values_dict', 'value_names', 'value_values', '_values'])
+        self.on_trait_change(self._values_readonly_changed, ['_values_dict', '_value_names', '_value_values', '_values'])
         if 'values' in kwargs:
             self.values = kwargs.pop('values')
         DOMWidget.__init__(self, *args, **kwargs)
@@ -88,18 +88,18 @@ class _Selection(DOMWidget):
                 self.values = new
 
                 values = self._make_values(new)
-                self.values_dict = {i[0]: i[1] for i in values}
-                self.value_names = [i[0] for i in values]
-                self.value_values = [i[1] for i in values]
+                self._values_dict = {i[0]: i[1] for i in values}
+                self._value_names = [i[0] for i in values]
+                self._value_values = [i[1] for i in values]
                 self._value_in_values()
             finally:
                 self.values_lock.release()
         
     def _value_in_values(self):
         # ensure that the chosen value is one of the choices
-        if self.value_values:
-            if self.value not in self.value_values:
-                self.value = next(iter(self.value_values))
+        if self._value_values:
+            if self.value not in self._value_values:
+                self.value = next(iter(self._value_values))
     
     def _values_readonly_changed(self, name, old, new):
         if not self.values_lock.locked():
@@ -110,7 +110,7 @@ class _Selection(DOMWidget):
         if self.value_lock.acquire(False):
             try:
                 # Reverse dictionary lookup for the value name
-                for k,v in self.values_dict.items():
+                for k,v in self._values_dict.items():
                     if new == v:
                         # set the selected value name
                         self.value_name = k
@@ -125,7 +125,7 @@ class _Selection(DOMWidget):
         """Called when the value name has been changed (typically by the frontend)."""
         if self.value_lock.acquire(False):
             try:
-                self.value = self.values_dict[new]
+                self.value = self._values_dict[new]
             finally:
                 self.value_lock.release()
 

--- a/IPython/html/widgets/widget_selection.py
+++ b/IPython/html/widgets/widget_selection.py
@@ -33,68 +33,81 @@ class _Selection(DOMWidget):
     """
     
     value = Any(help="Selected value")
-    values = Dict(help="""Dictionary of {name: value} the user can select.
+    value_name = Unicode(help="The name of the selected value", sync=True)
+    values = Any(sync=True, help="""List of (key, value) tuples the user can select.
     
-    The keys of this dictionary are the strings that will be displayed in the UI,
+    The keys of this list are the strings that will be displayed in the UI,
     representing the actual Python choices.
     
-    The keys of this dictionary are also available as value_names.
+    The keys of this list are also available as value_names.
     """)
-    value_name = Unicode(help="The name of the selected value", sync=True)
-    value_names = List(Unicode, help="""Read-only list of names for each value.
-        
-        If values is specified as a list, this is the string representation of each element.
-        Otherwise, it is the keys of the values dictionary.
-        
-        These strings are used to display the choices in the front-end.""", sync=True)
+    
+    values_dict = Dict()
+    values_names = Tuple()
+    values_values = Tuple()
+
     disabled = Bool(False, help="Enable or disable user changes", sync=True)
     description = Unicode(help="Description of the value this widget represents", sync=True)
-    
-    
+        
     def __init__(self, *args, **kwargs):
         self.value_lock = Lock()
-        self._in_values_changed = False
+        self.values_lock = Lock()
+        self.on_trait_change(self._values_readonly_changed, ['values_dict', 'values_names', 'values_values', '_values'])
         if 'values' in kwargs:
-            values = kwargs['values']
-            # convert list values to an dict of {str(v):v}
-            if isinstance(values, list):
-                # preserve list order with an OrderedDict
-                kwargs['values'] = OrderedDict((unicode_type(v), v) for v in values)
-            # python3.3 turned on hash randomization by default - this means that sometimes, randomly
-            # we try to set value before setting values, due to dictionary ordering.  To fix this, force
-            # the setting of self.values right now, before anything else runs
             self.values = kwargs.pop('values')
         DOMWidget.__init__(self, *args, **kwargs)
         self._value_in_values()
     
+    def _make_values(self, x):
+        # If x is a dict, convert it to list format.
+        if isinstance(x, (OrderedDict, dict)):
+            return [(k, v) for k, v in x.items()]
+        
+        # Make sure x is a list or tuple.
+        if not isinstance(x, (list, tuple)):
+            raise ValueError('x')
+        
+        # If x is an ordinary list, use the values as names.
+        for y in x:
+            if not isinstance(y, (list, tuple)) or len(y) < 2:
+                return [(i, i) for i in x]
+        
+        # Value is already in the correct format.
+        return x
+
     def _values_changed(self, name, old, new):
-        """Handles when the values dict has been changed.
+        """Handles when the values tuple has been changed.
 
         Setting values implies setting value names from the keys of the dict.
-        """
-        self._in_values_changed = True
-        try:
-            self.value_names = list(new.keys())
-        finally:
-            self._in_values_changed = False
-        self._value_in_values()
+        """        
+        if self.values_lock.acquire(False):
+            try:
+                
 
+            self.values = self._make_values(x)
+            self.values_dict = {i[0]: i[1] for i in self.values}
+            self.values_names = [i[0] for i in self.values]
+            self.values_values = [i[1] for i in self.values]
+            self._value_in_values()
+        
     def _value_in_values(self):
         # ensure that the chosen value is one of the choices
-        if self.values:
-            if self.value not in self.values.values():
-                self.value = next(iter(self.values.values()))
+        if self.values_values:
+            if self.value not in self.values_values:
+                self.value = next(iter(self.values_values))
     
-    def _value_names_changed(self, name, old, new):
-        if not self._in_values_changed:
-            raise TraitError("value_names is a read-only proxy to values.keys(). Use the values dict instead.")
+    def _values_readonly_changed(self, name, old, new):
+        if not self.values_lock.acquire(False):
+            raise TraitError("`.%s` is a read-only trait. Use the `.values` tuple instead." % name)
+        else:
+            self.values_lock.release()
 
     def _value_changed(self, name, old, new):
         """Called when value has been changed"""
         if self.value_lock.acquire(False):
             try:
                 # Reverse dictionary lookup for the value name
-                for k,v in self.values.items():
+                for k,v in self.values_dict.items():
                     if new == v:
                         # set the selected value name
                         self.value_name = k
@@ -109,7 +122,7 @@ class _Selection(DOMWidget):
         """Called when the value name has been changed (typically by the frontend)."""
         if self.value_lock.acquire(False):
             try:
-                self.value = self.values[new]
+                self.value = self.values_dict[new]
             finally:
                 self.value_lock.release()
 

--- a/IPython/html/widgets/widget_selection.py
+++ b/IPython/html/widgets/widget_selection.py
@@ -99,10 +99,8 @@ class _Selection(DOMWidget):
                 self.value = next(iter(self.values_values))
     
     def _values_readonly_changed(self, name, old, new):
-        if not self.values_lock.acquire(False):
+        if not self.values_lock.locked():
             raise TraitError("`.%s` is a read-only trait. Use the `.values` tuple instead." % name)
-        else:
-            self.values_lock.release()
 
     def _value_changed(self, name, old, new):
         """Called when value has been changed"""

--- a/IPython/html/widgets/widget_selection.py
+++ b/IPython/html/widgets/widget_selection.py
@@ -43,7 +43,7 @@ class _Selection(DOMWidget):
     """)
     
     values_dict = Dict()
-    values_names = Tuple()
+    values_names = Tuple(sync=True)
     values_values = Tuple()
 
     disabled = Bool(False, help="Enable or disable user changes", sync=True)
@@ -82,13 +82,13 @@ class _Selection(DOMWidget):
         """        
         if self.values_lock.acquire(False):
             try:
-                
-
-            self.values = self._make_values(x)
-            self.values_dict = {i[0]: i[1] for i in self.values}
-            self.values_names = [i[0] for i in self.values]
-            self.values_values = [i[1] for i in self.values]
-            self._value_in_values()
+                self.values = self._make_values(x)
+                self.values_dict = {i[0]: i[1] for i in self.values}
+                self.values_names = [i[0] for i in self.values]
+                self.values_values = [i[1] for i in self.values]
+                self._value_in_values()
+            finally:
+                self.values_lock.release()
         
     def _value_in_values(self):
         # ensure that the chosen value is one of the choices

--- a/IPython/html/widgets/widget_selection.py
+++ b/IPython/html/widgets/widget_selection.py
@@ -18,7 +18,9 @@ from collections import OrderedDict
 from threading import Lock
 
 from .widget import DOMWidget, register
-from IPython.utils.traitlets import Unicode, List, Bool, Any, Dict, TraitError, CaselessStrEnum
+from IPython.utils.traitlets import (
+    Unicode, Bool, Any, Dict, TraitError, CaselessStrEnum, Tuple
+)
 from IPython.utils.py3compat import unicode_type
 from IPython.utils.warn import DeprecatedClass
 

--- a/IPython/html/widgets/widget_selection.py
+++ b/IPython/html/widgets/widget_selection.py
@@ -46,8 +46,8 @@ class _Selection(DOMWidget):
     """)
     
     values_dict = Dict()
-    values_names = Tuple(sync=True)
-    values_values = Tuple()
+    value_names = Tuple(sync=True)
+    value_values = Tuple()
 
     disabled = Bool(False, help="Enable or disable user changes", sync=True)
     description = Unicode(help="Description of the value this widget represents", sync=True)
@@ -55,7 +55,7 @@ class _Selection(DOMWidget):
     def __init__(self, *args, **kwargs):
         self.value_lock = Lock()
         self.values_lock = Lock()
-        self.on_trait_change(self._values_readonly_changed, ['values_dict', 'values_names', 'values_values', '_values'])
+        self.on_trait_change(self._values_readonly_changed, ['values_dict', 'value_names', 'value_values', '_values'])
         if 'values' in kwargs:
             self.values = kwargs.pop('values')
         DOMWidget.__init__(self, *args, **kwargs)
@@ -86,20 +86,20 @@ class _Selection(DOMWidget):
         if self.values_lock.acquire(False):
             try:
                 self.values = new
-                
+
                 values = self._make_values(new)
                 self.values_dict = {i[0]: i[1] for i in values}
-                self.values_names = [i[0] for i in values]
-                self.values_values = [i[1] for i in values]
+                self.value_names = [i[0] for i in values]
+                self.value_values = [i[1] for i in values]
                 self._value_in_values()
             finally:
                 self.values_lock.release()
         
     def _value_in_values(self):
         # ensure that the chosen value is one of the choices
-        if self.values_values:
-            if self.value not in self.values_values:
-                self.value = next(iter(self.values_values))
+        if self.value_values:
+            if self.value not in self.value_values:
+                self.value = next(iter(self.value_values))
     
     def _values_readonly_changed(self, name, old, new):
         if not self.values_lock.locked():

--- a/IPython/html/widgets/widget_selection.py
+++ b/IPython/html/widgets/widget_selection.py
@@ -36,7 +36,8 @@ class _Selection(DOMWidget):
     
     value = Any(help="Selected value")
     value_name = Unicode(help="The name of the selected value", sync=True)
-    values = Any(sync=True, help="""List of (key, value) tuples the user can select.
+    values = Any(help="""List of (key, value) tuples or dict of values that the 
+        user can select.
     
     The keys of this list are the strings that will be displayed in the UI,
     representing the actual Python choices.
@@ -84,10 +85,12 @@ class _Selection(DOMWidget):
         """        
         if self.values_lock.acquire(False):
             try:
-                self.values = self._make_values(new)
-                self.values_dict = {i[0]: i[1] for i in self.values}
-                self.values_names = [i[0] for i in self.values]
-                self.values_values = [i[1] for i in self.values]
+                self.values = new
+                
+                values = self._make_values(new)
+                self.values_dict = {i[0]: i[1] for i in values}
+                self.values_names = [i[0] for i in values]
+                self.values_values = [i[1] for i in values]
                 self._value_in_values()
             finally:
                 self.values_lock.release()

--- a/IPython/html/widgets/widget_selection.py
+++ b/IPython/html/widgets/widget_selection.py
@@ -84,7 +84,7 @@ class _Selection(DOMWidget):
         """        
         if self.values_lock.acquire(False):
             try:
-                self.values = self._make_values(x)
+                self.values = self._make_values(new)
                 self.values_dict = {i[0]: i[1] for i in self.values}
                 self.values_names = [i[0] for i in self.values]
                 self.values_values = [i[1] for i in self.values]


### PR DESCRIPTION
This PR suggests an alternative method for storing selection widget state in the backend.  Instead of the primary store being a dictionary, a tuple of tuples is used. i.e. ((k1, v1), (k2, v2), (k3, v3), ...)

@rmenegaux and @jasongrout
