### PR TITLE
use `python -m IPython.kernel` in IPython kernelspec

### DIFF
--- a/IPython/kernel/kernelspec.py
+++ b/IPython/kernel/kernelspec.py
@@ -117,8 +117,7 @@ class KernelSpecManager(HasTraits):
         The native kernel is the kernel using the same Python runtime as this
         process. This will put its informatino in the user kernels directory.
         """
-        return {'argv':make_ipkernel_cmd(
-                       'from IPython.kernel.zmq.kernelapp import main; main()'),
+        return {'argv': make_ipkernel_cmd(),
                'display_name': 'IPython (Python %d)' % (3 if PY3 else 2),
                'language': 'python',
                'codemirror_mode': {'name': 'ipython',

--- a/IPython/kernel/launcher.py
+++ b/IPython/kernel/launcher.py
@@ -78,13 +78,13 @@ def swallow_argv(argv, aliases=None, flags=None):
     return stripped
 
 
-def make_ipkernel_cmd(code, executable=None, extra_arguments=[], **kw):
+def make_ipkernel_cmd(mod='IPython.kernel', executable=None, extra_arguments=[], **kw):
     """Build Popen command list for launching an IPython kernel.
 
     Parameters
     ----------
-    code : str,
-        A string of Python code that imports and executes a kernel entry point.
+    mod : str, optional (default 'IPython.kernel')
+        A string of an IPython module whose __main__ starts an IPython kernel
 
     executable : str, optional (default sys.executable)
         The Python executable to use for the kernel process.
@@ -99,7 +99,7 @@ def make_ipkernel_cmd(code, executable=None, extra_arguments=[], **kw):
     """
     if executable is None:
         executable = sys.executable
-    arguments = [ executable, '-c', code, '-f', '{connection_file}' ]
+    arguments = [ executable, '-m', mod, '-f', '{connection_file}' ]
     arguments.extend(extra_arguments)
 
     if sys.platform == 'win32':

--- a/IPython/kernel/manager.py
+++ b/IPython/kernel/manager.py
@@ -26,7 +26,6 @@ from IPython.utils.traitlets import (
     Any, Instance, Unicode, List, Bool, Type, DottedObjectName
 )
 from IPython.kernel import (
-    make_ipkernel_cmd,
     launch_kernel,
     kernelspec,
 )


### PR DESCRIPTION
instead of `-c [longer way to say the same thing]`
