### PR TITLE
QTConsole Fix calltip widget y-padding

### DIFF
--- a/IPython/qt/console/call_tip_widget.py
+++ b/IPython/qt/console/call_tip_widget.py
@@ -189,8 +189,9 @@ class CallTipWidget(QtGui.QLabel):
                 horizontal = 'Left'
         pos = getattr(cursor_rect, '%s%s' %(vertical, horizontal))
         point = text_edit.mapToGlobal(pos())
+        point.setY(point.y() + padding)
         if vertical == 'top':
-            point.setY(point.y() - tip_height - padding)
+            point.setY(point.y() - tip_height)
         if horizontal == 'Left':
             point.setX(point.x() - tip_width - padding)
 


### PR DESCRIPTION
![shot](https://cloud.githubusercontent.com/assets/7333933/4716296/d5d5cf8a-5906-11e4-8852-863b630e2432.png)

See how [L159/160](https://github.com/kalibri1798/ipython/blob/9ee4e4c16f3b6772238c2d87170a73a60b484b45/IPython/qt/console/call_tip_widget.py#L159)  also applies padding unconditionally, I restored that logic so it applies whether the `if` is taken or not.

Closes #6756
