### PR TITLE
object_info_reply field is oname, not name

### DIFF
--- a/docs/source/development/messaging.rst
+++ b/docs/source/development/messaging.rst
@@ -518,7 +518,7 @@ Message type: ``object_info_reply``::
 
     content = {
     # The name the object was requested under
-    'name' : str,
+    'oname' : str,
     
     # Boolean flag indicating whether the named object was found or not.  If
     # it's false, all other fields will be empty.


### PR DESCRIPTION
PR against 2.x

Fix the message spec docs to match the implementation. See PR #6473 where the msgspec adapter was changed.
