### PR TITLE
add msgspec to kernelspecs

### DIFF
--- a/IPython/kernel/kernelspec.py
+++ b/IPython/kernel/kernelspec.py
@@ -42,7 +42,7 @@ class KernelSpec(HasTraits):
     pygments_lexer = Unicode()
     env = Dict()
     resource_dir = Unicode()
-    msgspec = Unicode(kernel_protocol_version)
+    protocol_version = Unicode(kernel_protocol_version)
     
     def _codemirror_mode_default(self):
         return self.language
@@ -65,8 +65,8 @@ class KernelSpec(HasTraits):
         d = dict(argv=self.argv,
                  display_name=self.display_name,
                  language=self.language,
-                 msgspec=self.msgspec,
-                )
+                 protocol_version=self.protocol_version,
+        )
         if self.env:
             d['env'] = self.env
         if self.codemirror_mode != self.language:

--- a/IPython/kernel/tests/test_kernelspec.py
+++ b/IPython/kernel/tests/test_kernelspec.py
@@ -10,6 +10,7 @@ from IPython.kernel import kernelspec
 sample_kernel_json = {'argv':['cat', '{connection_file}'],
                       'display_name':'Test kernel',
                       'language':'bash',
+                      'msgspec': '4.0',
                      }
 
 class KernelSpecTests(unittest.TestCase):

--- a/IPython/kernel/tests/test_kernelspec.py
+++ b/IPython/kernel/tests/test_kernelspec.py
@@ -10,7 +10,7 @@ from IPython.kernel import kernelspec
 sample_kernel_json = {'argv':['cat', '{connection_file}'],
                       'display_name':'Test kernel',
                       'language':'bash',
-                      'msgspec': '4.0',
+                      'protocol_version': '4.0',
                      }
 
 class KernelSpecTests(unittest.TestCase):

--- a/docs/source/development/kernels.rst
+++ b/docs/source/development/kernels.rst
@@ -116,6 +116,8 @@ JSON serialised dictionary containing the following keys and values:
   stored in notebook metadata. This may be used by syntax highlighters to guess
   how to parse code in a notebook, and frontends may eventually use it to
   identify alternative kernels that can run some code.
+- **msgspec**: The version of the :ref:`message spec <messaging>` implemented by the kernel
+  as a version string, e.g. `'5.0'`.
 - **codemirror_mode** (optional): The `codemirror mode <http://codemirror.net/mode/index.html>`_
   to use for code in this language. This can be a string or a dictionary, as
   passed to codemirror config. This only needs to be specified if it does not
@@ -132,14 +134,21 @@ JSON serialised dictionary containing the following keys and values:
 For example, the kernel.json file for IPython looks like this::
 
     {
-     "argv": ["python3", "-c", "from IPython.kernel.zmq.kernelapp import main; main()", 
-              "-f", "{connection_file}"], 
+     "argv": [
+      "python3",
+      "-m",
+      "IPython.kernel",
+      "-f",
+      "{connection_file}"
+     ],
      "codemirror_mode": {
-      "version": 3, 
-      "name": "ipython"
-     }, 
-     "display_name": "IPython (Python 3)", 
-     "language": "python"
+      "name": "ipython",
+      "version": 3
+     },
+     "display_name": "IPython (Python 3)",
+     "language": "python",
+     "msgspec": "5.0",
+     "pygments_lexer": "ipython3"
     }
 
 To see the available kernel specs, run::

--- a/docs/source/development/kernels.rst
+++ b/docs/source/development/kernels.rst
@@ -116,8 +116,8 @@ JSON serialised dictionary containing the following keys and values:
   stored in notebook metadata. This may be used by syntax highlighters to guess
   how to parse code in a notebook, and frontends may eventually use it to
   identify alternative kernels that can run some code.
-- **msgspec**: The version of the :ref:`message spec <messaging>` implemented by the kernel
-  as a version string, e.g. `'5.0'`.
+- **protocol_version**: The version of the :ref:`message protocol <messaging>`
+  implemented by the kernel as a version string, e.g. `'5.0'`.
 - **codemirror_mode** (optional): The `codemirror mode <http://codemirror.net/mode/index.html>`_
   to use for code in this language. This can be a string or a dictionary, as
   passed to codemirror config. This only needs to be specified if it does not
@@ -134,20 +134,14 @@ JSON serialised dictionary containing the following keys and values:
 For example, the kernel.json file for IPython looks like this::
 
     {
-     "argv": [
-      "python3",
-      "-m",
-      "IPython.kernel",
-      "-f",
-      "{connection_file}"
-     ],
+     "argv": ["python3", "-m", "IPython.kernel", "-f", "{connection_file}"],
      "codemirror_mode": {
       "name": "ipython",
       "version": 3
      },
      "display_name": "IPython (Python 3)",
      "language": "python",
-     "msgspec": "5.0",
+     "protocol_version": "5.0",
      "pygments_lexer": "ipython3"
     }
 


### PR DESCRIPTION
This will enable knowing the msg spec version of the kernel before making any requests,
so that adaptation can be configured right away.
