### PR TITLE
Load comm targets and widget models from requirejs modules

### DIFF
--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -98,6 +98,8 @@ class Widget(LoggingConfigurable):
     #-------------------------------------------------------------------------
     # Traits
     #-------------------------------------------------------------------------
+    _model_module = Unicode(None, allow_none=True, help="""A requirejs module name
+        in which to find _model_name. If empty, look in the global registry.""")
     _model_name = Unicode('WidgetModel', help="""Name of the backbone model 
         registered in the front-end to create and sync this widget with.""")
     _view_module = Unicode(help="""A requirejs module in which to find _view_name.
@@ -142,7 +144,9 @@ class Widget(LoggingConfigurable):
     def open(self):
         """Open a comm to the frontend if one isn't already open."""
         if self.comm is None:
-            args = dict(target_name='ipython.widget', data={ 'model_name': self._model_name })
+            args = dict(target_name='ipython.widget',
+                        data={'model_name': self._model_name,
+                              'model_module': self._model_module})
             if self._model_id is not None:
                 args['comm_id'] = self._model_id
             self.comm = Comm(**args)

--- a/IPython/kernel/comm/comm.py
+++ b/IPython/kernel/comm/comm.py
@@ -31,6 +31,8 @@ class Comm(LoggingConfigurable):
             return self.kernel.session
     
     target_name = Unicode('comm')
+    target_module = Unicode(None, allow_none=True, help="""requirejs module from
+        which to load comm target.""")
     
     topic = Bytes()
     def _topic_default(self):
@@ -91,7 +93,9 @@ class Comm(LoggingConfigurable):
         try:
             self._publish_msg('comm_open',
                               data=data, metadata=metadata, buffers=buffers,
-                              target_name=self.target_name)
+                              target_name=self.target_name,
+                              target_module=self.target_module,
+                              )
             self._closed = False
         except:
             comm_manager.unregister_comm(self)


### PR DESCRIPTION
Ping @jdfreder @jasongrout @SylvainCorlay

This continues my work in #6494, where I did the same with widget views. These other parts were more straightforward.

I've not actually tested this with targets/models in modules, as I don't have a handy example. I have tested that instantiating a widget using the target & model registries still works.
