### PR TITLE
Fix an issue in the `kernel_running` function of the JS tests,

### DIFF
--- a/IPython/html/tests/util.js
+++ b/IPython/html/tests/util.js
@@ -58,7 +58,10 @@ casper.page_loaded = function() {
 casper.kernel_running = function() {
     // Return whether or not the kernel is running.
     return this.evaluate(function() {
-        return IPython.notebook.kernel.is_connected();
+        return IPython &&
+        IPython.notebook &&
+        IPython.notebook.kernel &&
+        IPython.notebook.kernel.is_connected();
     });
 };
 


### PR DESCRIPTION
This fix allows the JS test to be run against a remote server
with a higher than LAN latency.  This bug in our testing
framework was exposed when running `iptest js/widgets --url`
against tmpnb.

@rgbkrk
