### PR TITLE
Handle some tricky Comm lifecycle issues

### DIFF
--- a/IPython/kernel/comm/comm.py
+++ b/IPython/kernel/comm/comm.py
@@ -88,11 +88,14 @@ class Comm(LoggingConfigurable):
                         "and a comm_manager attached to that kernel.")
 
         comm_manager.register_comm(self)
-        self._publish_msg('comm_open',
-            data=data, metadata=metadata, buffers=buffers,
-            target_name=self.target_name,
-        )
-        self._closed = False
+        try:
+            self._publish_msg('comm_open',
+                              data=data, metadata=metadata, buffers=buffers,
+                              target_name=self.target_name)
+            self._closed = False
+        except:
+            comm_manager.unregister_comm(self)
+            raise
     
     def close(self, data=None, metadata=None, buffers=None):
         """Close the frontend-side version of this comm"""


### PR DESCRIPTION
- If the comm was a primary comm, but there was an error opening it, _closed was False, which is wrong
- If Comm.close() was called, but an error happened, it still appeared to be open

This change makes the _closed attribute more conservative.  If _closed is False, the comm is definitely open for messages.  If _closed is True, we either didn't initialize correctly, or we tried to close at some point.
