### PR TITLE
Added multiple 'Undo Delete Cell' in Notebook 

### DIFF
--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1295,7 +1295,7 @@ define([
         if (!cell.is_mergeable()) {
             return;
         }
-        if (i > 0 && i< this.ncells()-1 && j > 0 && j< this.ncells()-1 && i!=j) {
+        if (i >= 0 && i< this.ncells() && j >= 0 && j< this.ncells() && i!=j) {
             var other_cell = this.get_cell(j);
             if (!other_cell.is_mergeable()) {
                 return;
@@ -1318,11 +1318,7 @@ define([
             this.delete_cell(other_index);
             this.undelete_history.pop();
             //we now have to update the indices in the undelete_history since we just deleted a object from it:
-            for (var i = 0; i<this.undelete_history.length;i++) {
-                if (this.undelete_history[i]["index"]>other_index) {
-                    this.undelete_history[i]["index"]=this.undelete_history[i]["index"] - 1;
-                }
-            }
+            this._fix_undelete_history(other_index,-1);
             this.select(this.find_cell_index(cell));
         }
     };


### PR DESCRIPTION
The 'Undo Delete Cell' function in the notebook currently only allows a single undo (issue #4924).
I modified the notebook.js file so that it is possible to restore the last `Notebook.undelete_max` deleted cells at the correct indices in the notebook.
I replaced the corresponding variables (`undelete_backup`, `undelete_index`, `undelete_below`) with arrays to store this deleted cell history and used the `push`, `pop` and `shift`  methods to establish the desired FIFO like behaviour.
As a side effect I fixed a off-by-one error in the `insert_element_at_index` function.
I set the deleted cell history size to 10 what seems reasonable to me (unless your 'd'-key gets stuck ;) ).
I tested everything in chromium-browser and checked the js-console for possible errrors. So far it just works as expected.
@ellisonbg 
