### PR TITLE
add `nbconvert --execute` flag

### DIFF
--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -59,6 +59,10 @@ nbconvert_aliases.update({
 nbconvert_flags = {}
 nbconvert_flags.update(base_flags)
 nbconvert_flags.update({
+    'execute' : (
+        {'ExecutePreprocessor' : {'enabled' : True}},
+        "Execute the notebook prior to export."
+        ),
     'stdout' : (
         {'NbConvertApp' : {'writer_class' : "StdoutWriter"}},
         "Write notebook output to stdout instead of files."

--- a/IPython/nbconvert/preprocessors/execute.py
+++ b/IPython/nbconvert/preprocessors/execute.py
@@ -50,6 +50,7 @@ class ExecutePreprocessor(Preprocessor):
     def preprocess(self, nb, resources):
         from IPython.kernel import run_kernel
         kernel_name = nb.metadata.get('kernelspec', {}).get('name', 'python')
+        self.log.info("Executing notebook with kernel: %s" % kernel_name)
         with run_kernel(kernel_name=kernel_name,
                         extra_arguments=self.extra_arguments,
                         stderr=open(os.devnull, 'w')) as kc:


### PR DESCRIPTION
Just enables the ExecutePreprocessor, but I think it deserves a special case of getting a convenient flag for enabling it, unlike most.
