### PR TITLE
Fixed "data" to "text" change in message spec

### DIFF
--- a/docs/source/development/wrapperkernels.rst
+++ b/docs/source/development/wrapperkernels.rst
@@ -76,7 +76,7 @@ Example
         def do_execute(self, code, silent, store_history=True, user_expressions=None,
                        allow_stdin=False):
             if not silent:
-                stream_content = {'name': 'stdout', 'data':code}
+                stream_content = {'name': 'stdout', 'text': code}
                 self.send_response(self.iopub_socket, 'stream', stream_content)
 
             return {'status': 'ok',


### PR DESCRIPTION
This fix was accidentally omitted when the message spec recently changed.
