### PR TITLE
only complete on current line

### DIFF
--- a/IPython/kernel/tests/test_kernel.py
+++ b/IPython/kernel/tests/test_kernel.py
@@ -1,16 +1,8 @@
 # coding: utf-8
 """test the IPython Kernel"""
 
-#-------------------------------------------------------------------------------
-#  Copyright (C) 2013  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-------------------------------------------------------------------------------
-
-#-------------------------------------------------------------------------------
-# Imports
-#-------------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 import io
 import os.path
@@ -25,10 +17,6 @@ from IPython.utils.tempdir import TemporaryDirectory
 
 from .utils import (new_kernel, kernel, TIMEOUT, assemble_output, execute,
                     flush_channels, wait_for_idle)
-
-#-------------------------------------------------------------------------------
-# Tests
-#-------------------------------------------------------------------------------
 
 
 def _check_mp_mode(kc, expected=False, stream="stdout"):
@@ -213,7 +201,7 @@ def test_is_complete():
         reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
         assert reply['content']['status'] == 'complete'
 
-        # SyntaxError should mean it's complete        
+        # SyntaxError should mean it's complete
         kc.is_complete('raise = 2')
         reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
         assert reply['content']['status'] == 'invalid'
@@ -222,3 +210,19 @@ def test_is_complete():
         reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
         assert reply['content']['status'] == 'incomplete'
         assert reply['content']['indent'] == ''
+
+def test_complete():
+    with kernel() as kc:
+        execute(u'a = 1', kc=kc)
+        wait_for_idle(kc)
+        cell = 'import IPython\nb = a.'
+        kc.complete(cell)
+        reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
+        c = reply['content']
+        nt.assert_equal(c['status'], 'ok')
+        nt.assert_equal(c['cursor_start'], cell.find('a.'))
+        nt.assert_equal(c['cursor_end'], cell.find('a.') + 2)
+        matches = c['matches']
+        nt.assert_greater(len(matches), 0)
+        for match in matches:
+            nt.assert_equal(match[:2], 'a.')

--- a/IPython/kernel/tests/utils.py
+++ b/IPython/kernel/tests/utils.py
@@ -79,6 +79,8 @@ def start_global_kernel():
     if KM is None:
         KM, KC = start_new_kernel()
         atexit.register(stop_global_kernel)
+    else:
+        flush_channels(KC)
     return KC
 
 @contextmanager

--- a/IPython/utils/tokenutil.py
+++ b/IPython/utils/tokenutil.py
@@ -23,6 +23,34 @@ def generate_tokens(readline):
         # catch EOF error
         return
 
+def line_at_cursor(cell, cursor_pos=0):
+    """Return the line in a cell at a given cursor position
+    
+    Used for calling line-based APIs that don't support multi-line input, yet.
+    
+    Parameters
+    ----------
+    
+    cell: text
+        multiline block of text
+    cursor_pos: integer
+        the cursor position
+    
+    Returns
+    -------
+    
+    (line, offset): (text, integer)
+        The line with the current cursor, and the character offset of the start of the line.
+    """
+    offset = 0
+    lines = cell.splitlines(True)
+    for line in lines:
+        next_offset = offset + len(line)
+        if next_offset >= cursor_pos:
+            break
+        offset = next_offset
+    return (line, offset)
+
 def token_at_cursor(cell, cursor_pos=0):
     """Get the token at a given cursor
     


### PR DESCRIPTION
Completion messages are multi-line, but IPython completer code assumes single-line.

For now, just pass the current line to the underlying completer.

closes #6787
