### PR TITLE
Add event for Markdown cell rendered

### DIFF
--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -242,6 +242,7 @@ define([
             html.find("a[href]").not('[href^="#"]').attr("target", "_blank");
             this.set_rendered(html);
             this.typeset();
+            this.events.trigger("rendered.MarkdownCell", {cell: this})
         }
         return cont;
     };


### PR DESCRIPTION
I don't see anything like this at present, and it will be necessary for extensions like live citation support, which do extra things with the HTML produced by rendering Markdown cells.
