### PR TITLE
use CodeMirror.runMode to highlight in markdown

### DIFF
--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -552,9 +552,10 @@ define([
         var text_and_math = mathjaxutils.remove_math(markdown);
         var text = text_and_math[0];
         var math = text_and_math[1];
-        var html = marked.parser(marked.lexer(text));
-        html = mathjaxutils.replace_math(html, math);
-        toinsert.append(html);
+        marked(text, function (err, html) {
+            html = mathjaxutils.replace_math(html, math);
+            toinsert.append(html);
+        });
         element.append(toinsert);
         return toinsert;
     };

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -241,34 +241,35 @@ define([
     MarkdownCell.prototype.render = function () {
         var cont = TextCell.prototype.render.apply(this);
         if (cont) {
+            var that = this;
             var text = this.get_text();
             var math = null;
             if (text === "") { text = this.placeholder; }
             var text_and_math = mathjaxutils.remove_math(text);
             text = text_and_math[0];
             math = text_and_math[1];
-            var html = marked.parser(marked.lexer(text));
-            html = mathjaxutils.replace_math(html, math);
-            html = security.sanitize_html(html);
-            html = $($.parseHTML(html));
-            // add anchors to headings
-            // console.log(html);
-            html.find(":header").addBack(":header").each(function (i, h) {
-                h = $(h);
-                var hash = h.text().replace(/ /g, '-');
-                h.attr('id', hash);
-                h.append(
-                    $('<a/>')
-                        .addClass('anchor-link')
-                        .attr('href', '#' + hash)
-                        .text('¶')
-                );
-            })
-            // links in markdown cells should open in new tabs
-            html.find("a[href]").not('[href^="#"]').attr("target", "_blank");
-            this.set_rendered(html);
-            this.typeset();
-            this.events.trigger("rendered.MarkdownCell", {cell: this})
+            marked(text, function (err, html) {
+                html = mathjaxutils.replace_math(html, math);
+                html = security.sanitize_html(html);
+                html = $($.parseHTML(html));
+                // add anchors to headings
+                html.find(":header").addBack(":header").each(function (i, h) {
+                    h = $(h);
+                    var hash = h.text().replace(/ /g, '-');
+                    h.attr('id', hash);
+                    h.append(
+                        $('<a/>')
+                            .addClass('anchor-link')
+                            .attr('href', '#' + hash)
+                            .text('¶')
+                    );
+                });
+                // links in markdown cells should open in new tabs
+                html.find("a[href]").not('[href^="#"]').attr("target", "_blank");
+                that.set_rendered(html);
+                that.typeset();
+                that.events.trigger("rendered.MarkdownCell", {cell: that});
+            });
         }
         return cont;
     };

--- a/IPython/html/templates/page.html
+++ b/IPython/html/templates/page.html
@@ -27,7 +27,6 @@
             bootstrap: 'components/bootstrap/js/bootstrap.min',
             bootstraptour: 'components/bootstrap-tour/build/js/bootstrap-tour.min',
             jqueryui: 'components/jquery-ui/ui/minified/jquery-ui.min',
-            highlight: 'components/highlight.js/build/highlight.pack',
             moment: "components/moment/moment",
             codemirror: 'components/codemirror',
             termjs: "components/term.js/src/term",
@@ -52,10 +51,7 @@
             jqueryui: {
               deps: ["jquery"],
               exports: "$"
-            },
-            highlight: {
-              exports: "hljs"
-            },
+            }
           }
       });
     </script>

--- a/setupbase.py
+++ b/setupbase.py
@@ -153,7 +153,6 @@ def find_package_data():
         pjoin(components, "es6-promise", "*.js"),
         pjoin(components, "font-awesome", "fonts", "*.*"),
         pjoin(components, "google-caja", "html-css-sanitizer-minified.js"),
-        pjoin(components, "highlight.js", "build", "highlight.pack.js"),
         pjoin(components, "jquery", "jquery.min.js"),
         pjoin(components, "jquery-ui", "ui", "minified", "jquery-ui.min.js"),
         pjoin(components, "jquery-ui", "themes", "smoothness", "jquery-ui.min.css"),


### PR DESCRIPTION
instead of highlight.js

removes highlight.js from components, as well.

closes #2919
