### PR TITLE
Allow to specify CodeMirror's syntax mode as MIME

### DIFF
--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1529,7 +1529,7 @@ define([
         }
         this.codemirror_mode = newmode;
         codecell.CodeCell.options_default.cm_config.mode = newmode;
-        modename = newmode.name || newmode
+        modename = newmode.mode || newmode.name || newmode
 
         that = this;
         utils.requireCodeMirrorMode(modename, function () {


### PR DESCRIPTION
This is required for e.g. Scala, where the mode is given as `text/x-scala`, but the actual implementation is in `clike` mode. This wouldn't be an issue, but IPython loads modes lazily, so you need both mode name and MIME to resolve correct file and configure CodeMirror.

I'm not sure if this is really necessary, but I couldn't find any other way to configure scala syntax highlight in notebook. In IScala's case, `codemirror_mode = {name: "text/x-scala", mode: "clike"}` (see [1]).

[1] https://github.com/mattpap/IScala/blob/master/project/Build.scala#L170
