### PR TITLE
remove separate 'path' and 'name' from ContentsManager

### DIFF
--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -463,8 +463,9 @@ class FilesRedirectHandler(IPythonHandler):
 # URL pattern fragments for re-use
 #-----------------------------------------------------------------------------
 
-path_regex = r"(?P<path>.*)"
-notebook_path_regex = r"(?P<path>.+\.ipynb)"
+# path matches any number of `/foo[/bar...]` or just `/` or ''
+path_regex = r"(?P<path>(?:(?:/[^/]+)+|/?))"
+notebook_path_regex = r"(?P<path>(?:/[^/]+)+\.ipynb)"
 
 #-----------------------------------------------------------------------------
 # URL to handler mappings

--- a/IPython/html/files/handlers.py
+++ b/IPython/html/files/handlers.py
@@ -17,13 +17,18 @@ class FilesHandler(IPythonHandler):
 
     @web.authenticated
     def get(self, path):
-        cm = self.settings['contents_manager']
+        cm = self.contents_manager
         if cm.is_hidden(path):
             self.log.info("Refusing to serve hidden file, via 404 Error")
             raise web.HTTPError(404)
-
-        path, name = os.path.split(path)
-        model = cm.get_model(name, path)
+        
+        path = path.strip('/')
+        if '/' in path:
+            _, name = path.rsplit('/', 1)
+        else:
+            name = path
+        
+        model = cm.get_model(path)
         
         if self.get_argument("download", False):
             self.set_header('Content-Disposition','attachment; filename="%s"' % name)

--- a/IPython/html/nbconvert/handlers.py
+++ b/IPython/html/nbconvert/handlers.py
@@ -76,12 +76,13 @@ class NbconvertFileHandler(IPythonHandler):
     SUPPORTED_METHODS = ('GET',)
     
     @web.authenticated
-    def get(self, format, path='', name=None):
+    def get(self, format, path):
         
         exporter = get_exporter(format, config=self.config, log=self.log)
         
         path = path.strip('/')
-        model = self.contents_manager.get_model(name=name, path=path)
+        model = self.contents_manager.get_model(path=path)
+        name = model['name']
 
         self.set_header('Last-Modified', model['last_modified'])
         
@@ -109,7 +110,7 @@ class NbconvertFileHandler(IPythonHandler):
 class NbconvertPostHandler(IPythonHandler):
     SUPPORTED_METHODS = ('POST',)
 
-    @web.authenticated 
+    @web.authenticated
     def post(self, format):
         exporter = get_exporter(format, config=self.config)
         

--- a/IPython/html/notebook/handlers.py
+++ b/IPython/html/notebook/handlers.py
@@ -17,7 +17,7 @@ from ..utils import url_escape
 class NotebookHandler(IPythonHandler):
 
     @web.authenticated
-    def get(self, path=''):
+    def get(self, path):
         """get renders the notebook template if a name is given, or 
         redirects to the '/files/' handler if the name is not given."""
         path = path.strip('/')

--- a/IPython/html/notebook/handlers.py
+++ b/IPython/html/notebook/handlers.py
@@ -17,18 +17,16 @@ from ..utils import url_escape
 class NotebookHandler(IPythonHandler):
 
     @web.authenticated
-    def get(self, path='', name=None):
+    def get(self, path=''):
         """get renders the notebook template if a name is given, or 
         redirects to the '/files/' handler if the name is not given."""
         path = path.strip('/')
         cm = self.contents_manager
-        if name is None:
-            raise web.HTTPError(500, "This shouldn't be accessible: %s" % self.request.uri)
         
         # a .ipynb filename was given
-        if not cm.file_exists(name, path):
-            raise web.HTTPError(404, u'Notebook does not exist: %s/%s' % (path, name))
-        name = url_escape(name)
+        if not cm.file_exists(path):
+            raise web.HTTPError(404, u'Notebook does not exist: %s' % path)
+        name = url_escape(path.rsplit('/', 1)[-1])
         path = url_escape(path)
         self.write(self.render_template('notebook.html',
             notebook_path=path,

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -189,7 +189,6 @@ class NotebookWebApplication(web.Application):
     def init_handlers(self, settings):
         # Load the (URL pattern, handler) tuples for each component.
         handlers = []
-        handlers.extend(load_handlers('base.handlers'))
         handlers.extend(load_handlers('tree.handlers'))
         handlers.extend(load_handlers('auth.login'))
         handlers.extend(load_handlers('auth.logout'))
@@ -206,6 +205,7 @@ class NotebookWebApplication(web.Application):
         handlers.append(
             (r"/nbextensions/(.*)", FileFindHandler, {'path' : settings['nbextensions_path']}),
         )
+        handlers.extend(load_handlers('base.handlers'))
         # set the URL that will be redirected from `/`
         handlers.append(
             (r'/?', web.RedirectHandler, {

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -187,7 +187,9 @@ class NotebookWebApplication(web.Application):
         return settings
 
     def init_handlers(self, settings):
-        # Load the (URL pattern, handler) tuples for each component.
+        """Load the (URL pattern, handler) tuples for each component."""
+        
+        # Order matters. The first handler to match the URL will handle the request.
         handlers = []
         handlers.extend(load_handlers('tree.handlers'))
         handlers.extend(load_handlers('auth.login'))
@@ -205,6 +207,7 @@ class NotebookWebApplication(web.Application):
         handlers.append(
             (r"/nbextensions/(.*)", FileFindHandler, {'path' : settings['nbextensions_path']}),
         )
+        # register base handlers last
         handlers.extend(load_handlers('base.handlers'))
         # set the URL that will be redirected from `/`
         handlers.append(

--- a/IPython/html/services/contents/handlers.py
+++ b/IPython/html/services/contents/handlers.py
@@ -92,18 +92,11 @@ class ContentsHandler(IPythonHandler):
         model = self.contents_manager.new(model, path)
         self.set_status(201)
         self._finish_model(model)
-
-    def _new(self, path, type='notebook', ext=''):
-        """Create an empty file or directory in directory specified by path
         
-        ContentsManager picks the filename.
-        """
+    def _new_untitled(self, path, type='', ext=''):
+        """Create a new, empty untitled entity"""
         self.log.info(u"Creating new %s in %s", type or 'file', path)
-        if type:
-            model = {'type': type}
-        else:
-            model = None
-        model = self.contents_manager.new(model, path=path, ext=ext)
+        model = self.contents_manager.new_untitled(path=path, type=type, ext=ext)
         self.set_status(201)
         self._finish_model(model)
 
@@ -140,13 +133,13 @@ class ContentsHandler(IPythonHandler):
         if model is not None:
             copy_from = model.get('copy_from')
             ext = model.get('ext', '')
-            type = model.get('type')
+            type = model.get('type', '')
             if copy_from:
                 self._copy(copy_from, path)
             else:
-                self._new(path, type=type, ext=ext)
+                self._new_untitled(path, type=type, ext=ext)
         else:
-            self._new(path)
+            self._new_untitled(path)
 
     @web.authenticated
     @json_errors
@@ -170,7 +163,7 @@ class ContentsHandler(IPythonHandler):
             else:
                 self._upload(model, path)
         else:
-            self._new(path)
+            self._new_untitled(path)
 
     @web.authenticated
     @json_errors

--- a/IPython/html/services/contents/handlers.py
+++ b/IPython/html/services/contents/handlers.py
@@ -158,23 +158,12 @@ class ContentsHandler(IPythonHandler):
           Save notebook at ``path/Name.ipynb``. Notebook structure is specified
           in `content` key of JSON request body. If content is not specified,
           create a new empty notebook.
-        PUT /api/contents/path/Name.ipynb
-          with JSON body::
-
-            {
-              "copy_from" : "[path/to/]OtherNotebook.ipynb"
-            }
-
-          Copy OtherNotebook to Name
         """
         model = self.get_json_body()
         if model:
-            copy_from = model.get('copy_from')
-            if copy_from:
-                if model.get('content'):
-                    raise web.HTTPError(400, "Can't upload and copy at the same time.")
-                self._copy(copy_from, path)
-            elif self.contents_manager.file_exists(path):
+            if model.get('copy_from'):
+                raise web.HTTPError(400, "Cannot copy with PUT, only POST")
+            if self.contents_manager.file_exists(path):
                 self._save(model, path)
             else:
                 self._upload(model, path)

--- a/IPython/html/services/contents/handlers.py
+++ b/IPython/html/services/contents/handlers.py
@@ -10,9 +10,9 @@ from tornado import web
 from IPython.html.utils import url_path_join, url_escape
 from IPython.utils.jsonutil import date_default
 
-from IPython.html.base.handlers import (IPythonHandler, json_errors,
-                                    file_path_regex, path_regex,
-                                    file_name_regex)
+from IPython.html.base.handlers import (
+    IPythonHandler, json_errors, path_regex,
+)
 
 
 def sort_key(model):
@@ -29,38 +29,36 @@ class ContentsHandler(IPythonHandler):
 
     SUPPORTED_METHODS = (u'GET', u'PUT', u'PATCH', u'POST', u'DELETE')
 
-    def location_url(self, name, path):
+    def location_url(self, path):
         """Return the full URL location of a file.
 
         Parameters
         ----------
-        name : unicode
-            The base name of the file, such as "foo.ipynb".
         path : unicode
-            The API path of the file, such as "foo/bar".
+            The API path of the file, such as "foo/bar.txt".
         """
         return url_escape(url_path_join(
-            self.base_url, 'api', 'contents', path, name
+            self.base_url, 'api', 'contents', path
         ))
 
     def _finish_model(self, model, location=True):
         """Finish a JSON request with a model, setting relevant headers, etc."""
         if location:
-            location = self.location_url(model['name'], model['path'])
+            location = self.location_url(model['path'])
             self.set_header('Location', location)
         self.set_header('Last-Modified', model['last_modified'])
         self.finish(json.dumps(model, default=date_default))
 
     @web.authenticated
     @json_errors
-    def get(self, path='', name=None):
+    def get(self, path=''):
         """Return a model for a file or directory.
 
         A directory model contains a list of models (without content)
         of the files and directories it contains.
         """
         path = path or ''
-        model = self.contents_manager.get_model(name=name, path=path)
+        model = self.contents_manager.get_model(path=path)
         if model['type'] == 'directory':
             # group listing by type, then by name (case-insensitive)
             # FIXME: sorting should be done in the frontends
@@ -69,91 +67,71 @@ class ContentsHandler(IPythonHandler):
 
     @web.authenticated
     @json_errors
-    def patch(self, path='', name=None):
-        """PATCH renames a notebook without re-uploading content."""
+    def patch(self, path=''):
+        """PATCH renames a file or directory without re-uploading content."""
         cm = self.contents_manager
-        if name is None:
-            raise web.HTTPError(400, u'Filename missing')
         model = self.get_json_body()
         if model is None:
             raise web.HTTPError(400, u'JSON body missing')
-        model = cm.update(model, name, path)
+        print('before', model)
+        model = cm.update(model, path)
+        print('after', model)
         self._finish_model(model)
 
-    def _copy(self, copy_from, path, copy_to=None):
-        """Copy a file, optionally specifying the new name.
+    def _copy(self, copy_from, copy_to=None):
+        """Copy a file, optionally specifying the new path.
         """
-        self.log.info(u"Copying {copy_from} to {path}/{copy_to}".format(
+        self.log.info(u"Copying {copy_from} to {copy_to}".format(
             copy_from=copy_from,
-            path=path,
             copy_to=copy_to or '',
         ))
-        model = self.contents_manager.copy(copy_from, copy_to, path)
+        model = self.contents_manager.copy(copy_from, copy_to)
         self.set_status(201)
         self._finish_model(model)
 
-    def _upload(self, model, path, name=None):
-        """Handle upload of a new file
-
-        If name specified, create it in path/name,
-        otherwise create a new untitled file in path.
-        """
-        self.log.info(u"Uploading file to %s/%s", path, name or '')
-        if name:
-            model['name'] = name
-
+    def _upload(self, model, path):
+        """Handle upload of a new file to path"""
+        self.log.info(u"Uploading file to %s", path)
         model = self.contents_manager.create_file(model, path)
         self.set_status(201)
         self._finish_model(model)
 
-    def _create_empty_file(self, path, name=None, ext='.ipynb'):
+    def _create_empty_file(self, path, ext='.ipynb'):
         """Create an empty file in path
 
-        If name specified, create it in path/name.
+        If name specified, create it in path.
         """
-        self.log.info(u"Creating new file in %s/%s", path, name or '')
-        model = {}
-        if name:
-            model['name'] = name
-        model = self.contents_manager.create_file(model, path=path, ext=ext)
+        self.log.info(u"Creating new file in %s", path)
+        model = self.contents_manager.create_file(path=path, ext=ext)
         self.set_status(201)
         self._finish_model(model)
 
-    def _save(self, model, path, name):
+    def _save(self, model, path):
         """Save an existing file."""
-        self.log.info(u"Saving file at %s/%s", path, name)
-        model = self.contents_manager.save(model, name, path)
-        if model['path'] != path.strip('/') or model['name'] != name:
-            # a rename happened, set Location header
-            location = True
-        else:
-            location = False
-        self._finish_model(model, location)
+        self.log.info(u"Saving file at %s", path)
+        model = self.contents_manager.save(model, path)
+        self._finish_model(model)
 
     @web.authenticated
     @json_errors
-    def post(self, path='', name=None):
+    def post(self, path=''):
         """Create a new file or directory in the specified path.
 
         POST creates new files or directories. The server always decides on the name.
 
         POST /api/contents/path
-          New untitled notebook in path. If content specified, upload a
-          notebook, otherwise start empty.
+          New untitled, empty file or directory.
         POST /api/contents/path
-          with body {"copy_from" : "OtherNotebook.ipynb"}
+          with body {"copy_from" : "/path/to/OtherNotebook.ipynb"}
           New copy of OtherNotebook in path
         """
-
-        if name is not None:
-            path = u'{}/{}'.format(path, name)
 
         cm = self.contents_manager
 
         if cm.file_exists(path):
             raise web.HTTPError(400, "Cannot POST to existing files, use PUT instead.")
 
-        if not cm.path_exists(path):
+        if not cm.dir_exists(path):
             raise web.HTTPError(404, "No such directory: %s" % path)
 
         model = self.get_json_body()
@@ -161,11 +139,7 @@ class ContentsHandler(IPythonHandler):
         if model is not None:
             copy_from = model.get('copy_from')
             ext = model.get('ext', '.ipynb')
-            if model.get('content') is not None:
-                if copy_from:
-                    raise web.HTTPError(400, "Can't upload and copy at the same time.")
-                self._upload(model, path)
-            elif copy_from:
+            if copy_from:
                 self._copy(copy_from, path)
             else:
                 self._create_empty_file(path, ext=ext)
@@ -174,7 +148,7 @@ class ContentsHandler(IPythonHandler):
 
     @web.authenticated
     @json_errors
-    def put(self, path='', name=None):
+    def put(self, path=''):
         """Saves the file in the location specified by name and path.
 
         PUT is very similar to POST, but the requester specifies the name,
@@ -193,30 +167,27 @@ class ContentsHandler(IPythonHandler):
 
           Copy OtherNotebook to Name
         """
-        if name is None:
-            raise web.HTTPError(400, "name must be specified with PUT.")
-
         model = self.get_json_body()
         if model:
             copy_from = model.get('copy_from')
             if copy_from:
                 if model.get('content'):
                     raise web.HTTPError(400, "Can't upload and copy at the same time.")
-                self._copy(copy_from, path, name)
-            elif self.contents_manager.file_exists(name, path):
-                self._save(model, path, name)
+                self._copy(copy_from, path)
+            elif self.contents_manager.file_exists(path):
+                self._save(model, path)
             else:
-                self._upload(model, path, name)
+                self._upload(model, path)
         else:
-            self._create_empty_file(path, name)
+            self._create_empty_file(path)
 
     @web.authenticated
     @json_errors
-    def delete(self, path='', name=None):
+    def delete(self, path=''):
         """delete a file in the given path"""
         cm = self.contents_manager
-        self.log.warn('delete %s:%s', path, name)
-        cm.delete(name, path)
+        self.log.warn('delete %s', path)
+        cm.delete(path)
         self.set_status(204)
         self.finish()
 
@@ -227,22 +198,22 @@ class CheckpointsHandler(IPythonHandler):
 
     @web.authenticated
     @json_errors
-    def get(self, path='', name=None):
+    def get(self, path=''):
         """get lists checkpoints for a file"""
         cm = self.contents_manager
-        checkpoints = cm.list_checkpoints(name, path)
+        checkpoints = cm.list_checkpoints(path)
         data = json.dumps(checkpoints, default=date_default)
         self.finish(data)
 
     @web.authenticated
     @json_errors
-    def post(self, path='', name=None):
+    def post(self, path=''):
         """post creates a new checkpoint"""
         cm = self.contents_manager
-        checkpoint = cm.create_checkpoint(name, path)
+        checkpoint = cm.create_checkpoint(path)
         data = json.dumps(checkpoint, default=date_default)
         location = url_path_join(self.base_url, 'api/contents',
-            path, name, 'checkpoints', checkpoint['id'])
+            path, 'checkpoints', checkpoint['id'])
         self.set_header('Location', url_escape(location))
         self.set_status(201)
         self.finish(data)
@@ -254,19 +225,19 @@ class ModifyCheckpointsHandler(IPythonHandler):
 
     @web.authenticated
     @json_errors
-    def post(self, path, name, checkpoint_id):
+    def post(self, path, checkpoint_id):
         """post restores a file from a checkpoint"""
         cm = self.contents_manager
-        cm.restore_checkpoint(checkpoint_id, name, path)
+        cm.restore_checkpoint(checkpoint_id, path)
         self.set_status(204)
         self.finish()
 
     @web.authenticated
     @json_errors
-    def delete(self, path, name, checkpoint_id):
+    def delete(self, path, checkpoint_id):
         """delete clears a checkpoint for a given file"""
         cm = self.contents_manager
-        cm.delete_checkpoint(checkpoint_id, name, path)
+        cm.delete_checkpoint(checkpoint_id, path)
         self.set_status(204)
         self.finish()
 
@@ -294,10 +265,9 @@ class NotebooksRedirectHandler(IPythonHandler):
 _checkpoint_id_regex = r"(?P<checkpoint_id>[\w-]+)"
 
 default_handlers = [
-    (r"/api/contents%s/checkpoints" % file_path_regex, CheckpointsHandler),
-    (r"/api/contents%s/checkpoints/%s" % (file_path_regex, _checkpoint_id_regex),
+    (r"/api/contents%s/checkpoints" % path_regex, CheckpointsHandler),
+    (r"/api/contents%s/checkpoints/%s" % (path_regex, _checkpoint_id_regex),
         ModifyCheckpointsHandler),
-    (r"/api/contents%s" % file_path_regex, ContentsHandler),
     (r"/api/contents%s" % path_regex, ContentsHandler),
     (r"/api/notebooks/?(.*)", NotebooksRedirectHandler),
 ]

--- a/IPython/html/services/contents/handlers.py
+++ b/IPython/html/services/contents/handlers.py
@@ -92,7 +92,7 @@ class ContentsHandler(IPythonHandler):
     def _upload(self, model, path):
         """Handle upload of a new file to path"""
         self.log.info(u"Uploading file to %s", path)
-        model = self.contents_manager.create_file(model, path)
+        model = self.contents_manager.new(model, path)
         self.set_status(201)
         self._finish_model(model)
 
@@ -102,7 +102,7 @@ class ContentsHandler(IPythonHandler):
         If name specified, create it in path.
         """
         self.log.info(u"Creating new file in %s", path)
-        model = self.contents_manager.create_file(path=path, ext=ext)
+        model = self.contents_manager.new(path=path, ext=ext)
         self.set_status(201)
         self._finish_model(model)
 

--- a/IPython/html/services/contents/manager.py
+++ b/IPython/html/services/contents/manager.py
@@ -33,14 +33,6 @@ class ContentsManager(LoggingConfigurable):
     - if unspecified, path defaults to '',
       indicating the root path.
 
-    name is also unicode, and refers to a specfic target:
-
-    - unicode, not url-escaped
-    - must not contain '/'
-    - It refers to an individual filename
-    - It may refer to a directory name,
-      in the case of listing or creating directories.
-
     """
 
     notary = Instance(sign.NotebookNotary)
@@ -69,7 +61,7 @@ class ContentsManager(LoggingConfigurable):
     # ContentsManager API part 1: methods that must be
     # implemented in subclasses.
 
-    def path_exists(self, path):
+    def dir_exists(self, path):
         """Does the API-style path (directory) actually exist?
 
         Like os.path.isdir
@@ -105,8 +97,8 @@ class ContentsManager(LoggingConfigurable):
         """
         raise NotImplementedError
 
-    def file_exists(self, name, path=''):
-        """Does a file exist at the given name and path?
+    def file_exists(self, path=''):
+        """Does a file exist at the given path?
 
         Like os.path.isfile
 
@@ -126,15 +118,13 @@ class ContentsManager(LoggingConfigurable):
         """
         raise NotImplementedError('must be implemented in a subclass')
 
-    def exists(self, name, path=''):
+    def exists(self, path):
         """Does a file or directory exist at the given name and path?
 
         Like os.path.exists
 
         Parameters
         ----------
-        name : string
-            The name of the file you are checking.
         path : string
             The relative path to the file's directory (with '/' as separator)
 
@@ -143,17 +133,17 @@ class ContentsManager(LoggingConfigurable):
         exists : bool
             Whether the target exists.
         """
-        return self.file_exists(name, path) or self.path_exists("%s/%s" % (path, name))
+        return self.file_exists(path) or self.dir_exists(path)
 
-    def get_model(self, name, path='', content=True):
+    def get_model(self, path, content=True):
         """Get the model of a file or directory with or without content."""
         raise NotImplementedError('must be implemented in a subclass')
 
-    def save(self, model, name, path=''):
+    def save(self, model, path):
         """Save the file or directory and return the model with no content."""
         raise NotImplementedError('must be implemented in a subclass')
 
-    def update(self, model, name, path=''):
+    def update(self, model, path):
         """Update the file or directory and return the model with no content.
 
         For use in PATCH requests, to enable renaming a file without
@@ -161,26 +151,26 @@ class ContentsManager(LoggingConfigurable):
         """
         raise NotImplementedError('must be implemented in a subclass')
 
-    def delete(self, name, path=''):
-        """Delete file or directory by name and path."""
+    def delete(self, path):
+        """Delete file or directory by path."""
         raise NotImplementedError('must be implemented in a subclass')
 
-    def create_checkpoint(self, name, path=''):
+    def create_checkpoint(self, path):
         """Create a checkpoint of the current state of a file
 
         Returns a checkpoint_id for the new checkpoint.
         """
         raise NotImplementedError("must be implemented in a subclass")
 
-    def list_checkpoints(self, name, path=''):
+    def list_checkpoints(self, path):
         """Return a list of checkpoints for a given file"""
         return []
 
-    def restore_checkpoint(self, checkpoint_id, name, path=''):
+    def restore_checkpoint(self, checkpoint_id, path):
         """Restore a file from one of its checkpoints"""
         raise NotImplementedError("must be implemented in a subclass")
 
-    def delete_checkpoint(self, checkpoint_id, name, path=''):
+    def delete_checkpoint(self, checkpoint_id, path):
         """delete a checkpoint for a file"""
         raise NotImplementedError("must be implemented in a subclass")
 
@@ -190,7 +180,7 @@ class ContentsManager(LoggingConfigurable):
     def info_string(self):
         return "Serving contents"
 
-    def get_kernel_path(self, name, path='', model=None):
+    def get_kernel_path(self, path, model=None):
         """ Return the path to start kernel in """
         return path
 
@@ -214,7 +204,7 @@ class ContentsManager(LoggingConfigurable):
         for i in itertools.count():
             name = u'{basename}{i}{ext}'.format(basename=basename, i=i,
                                                 ext=ext)
-            if not self.file_exists(name, path):
+            if not self.file_exists('{}/{}'.format(path, name)):
                 break
         return name
 
@@ -233,6 +223,8 @@ class ContentsManager(LoggingConfigurable):
         path = path.strip('/')
         if model is None:
             model = {}
+        else:
+            model.pop('path', None)
         if 'content' not in model and model.get('type', None) != 'directory':
             if ext == '.ipynb':
                 model['content'] = new_notebook()
@@ -242,7 +234,7 @@ class ContentsManager(LoggingConfigurable):
                 model['content'] = ''
                 model['type'] = 'file'
                 model['format'] = 'text'
-        if 'name' not in model:
+        if self.dir_exists(path):
             if model['type'] == 'directory':
                 untitled = self.untitled_directory
             elif model['type'] == 'notebook':
@@ -251,13 +243,13 @@ class ContentsManager(LoggingConfigurable):
                 untitled = self.untitled_file
             else:
                 raise HTTPError(400, "Unexpected model type: %r" % model['type'])
-            model['name'] = self.increment_filename(untitled + ext, path)
-
-        model['path'] = path
-        model = self.save(model, model['name'], model['path'])
+            
+            name = self.increment_filename(untitled + ext, path)
+            path = '{0}/{1}'.format(path, name)
+        model = self.save(model, path)
         return model
 
-    def copy(self, from_name, to_name=None, path=''):
+    def copy(self, from_path, to_path=None):
         """Copy an existing file and return its new model.
 
         If to_name not specified, increment `from_name-Copy#.ext`.
@@ -265,43 +257,48 @@ class ContentsManager(LoggingConfigurable):
         copy_from can be a full path to a file,
         or just a base name. If a base name, `path` is used.
         """
-        path = path.strip('/')
-        if '/' in from_name:
-            from_path, from_name = from_name.rsplit('/', 1)
+        path = from_path.strip('/')
+        if '/' in path:
+            from_dir, from_name = path.rsplit('/', 1)
         else:
-            from_path = path
-        model = self.get_model(from_name, from_path)
+            from_dir = ''
+            from_name = path
+        
+        model = self.get_model(path)
+        model.pop('path', None)
+        model.pop('name', None)
         if model['type'] == 'directory':
             raise HTTPError(400, "Can't copy directories")
-        if not to_name:
+        
+        if not to_path:
+            to_path = from_dir
+        if self.dir_exists(to_path):
             base, ext = os.path.splitext(from_name)
             copy_name = u'{0}-Copy{1}'.format(base, ext)
-            to_name = self.increment_filename(copy_name, path)
-        model['name'] = to_name
-        model['path'] = path
-        model = self.save(model, to_name, path)
+            to_name = self.increment_filename(copy_name, to_path)
+            to_path = '{0}/{1}'.format(to_path, to_name)
+        
+        model = self.save(model, to_path)
         return model
 
     def log_info(self):
         self.log.info(self.info_string())
 
-    def trust_notebook(self, name, path=''):
+    def trust_notebook(self, path):
         """Explicitly trust a notebook
 
         Parameters
         ----------
-        name : string
-            The filename of the notebook
         path : string
-            The notebook's directory
+            The path of a notebook
         """
-        model = self.get_model(name, path)
+        model = self.get_model(path)
         nb = model['content']
-        self.log.warn("Trusting notebook %s/%s", path, name)
+        self.log.warn("Trusting notebook %s", path)
         self.notary.mark_cells(nb, True)
-        self.save(model, name, path)
+        self.save(model, path)
 
-    def check_and_sign(self, nb, name='', path=''):
+    def check_and_sign(self, nb, path=''):
         """Check for trusted cells, and sign the notebook.
 
         Called as a part of saving notebooks.
@@ -310,17 +307,15 @@ class ContentsManager(LoggingConfigurable):
         ----------
         nb : dict
             The notebook dict
-        name : string
-            The filename of the notebook (for logging)
         path : string
-            The notebook's directory (for logging)
+            The notebook's path (for logging)
         """
         if self.notary.check_cells(nb):
             self.notary.sign(nb)
         else:
-            self.log.warn("Saving untrusted notebook %s/%s", path, name)
+            self.log.warn("Saving untrusted notebook %s", path)
 
-    def mark_trusted_cells(self, nb, name='', path=''):
+    def mark_trusted_cells(self, nb, path=''):
         """Mark cells as trusted if the notebook signature matches.
 
         Called as a part of loading notebooks.
@@ -329,14 +324,12 @@ class ContentsManager(LoggingConfigurable):
         ----------
         nb : dict
             The notebook object (in current nbformat)
-        name : string
-            The filename of the notebook (for logging)
         path : string
             The notebook's directory (for logging)
         """
         trusted = self.notary.check_signature(nb)
         if not trusted:
-            self.log.warn("Notebook %s/%s is not trusted", path, name)
+            self.log.warn("Notebook %s is not trusted", path)
         self.notary.mark_cells(nb, trusted)
 
     def should_list(self, name):

--- a/IPython/html/services/contents/manager.py
+++ b/IPython/html/services/contents/manager.py
@@ -218,7 +218,7 @@ class ContentsManager(LoggingConfigurable):
             )
         return model
 
-    def create_file(self, model=None, path='', ext='.ipynb'):
+    def new(self, model=None, path='', ext='.ipynb'):
         """Create a new file or directory and return its model with no content."""
         path = path.strip('/')
         if model is None:

--- a/IPython/html/services/contents/manager.py
+++ b/IPython/html/services/contents/manager.py
@@ -204,7 +204,7 @@ class ContentsManager(LoggingConfigurable):
         for i in itertools.count():
             name = u'{basename}{i}{ext}'.format(basename=basename, i=i,
                                                 ext=ext)
-            if not self.file_exists('{}/{}'.format(path, name)):
+            if not self.file_exists(u'{}/{}'.format(path, name)):
                 break
         return name
 
@@ -213,7 +213,7 @@ class ContentsManager(LoggingConfigurable):
         try:
             validate(model['content'])
         except ValidationError as e:
-            model['message'] = 'Notebook Validation failed: {}:\n{}'.format(
+            model['message'] = u'Notebook Validation failed: {}:\n{}'.format(
                 e.message, json.dumps(e.instance, indent=1, default=lambda obj: '<UNKNOWN>'),
             )
         return model
@@ -245,7 +245,7 @@ class ContentsManager(LoggingConfigurable):
                 raise HTTPError(400, "Unexpected model type: %r" % model['type'])
             
             name = self.increment_filename(untitled + ext, path)
-            path = '{0}/{1}'.format(path, name)
+            path = u'{0}/{1}'.format(path, name)
         model = self.save(model, path)
         return model
 
@@ -276,7 +276,7 @@ class ContentsManager(LoggingConfigurable):
             base, ext = os.path.splitext(from_name)
             copy_name = u'{0}-Copy{1}'.format(base, ext)
             to_name = self.increment_filename(copy_name, to_path)
-            to_path = '{0}/{1}'.format(to_path, to_name)
+            to_path = u'{0}/{1}'.format(to_path, to_name)
         
         model = self.save(model, to_path)
         return model

--- a/IPython/html/services/contents/tests/test_contents_api.py
+++ b/IPython/html/services/contents/tests/test_contents_api.py
@@ -55,7 +55,7 @@ class API(object):
             body = json.dumps({'ext': ext})
         return self._req('POST', path, body)
 
-    def copy_untitled(self, copy_from, path='/'):
+    def copy(self, copy_from, path='/'):
         body = json.dumps({'copy_from':copy_from})
         return self._req('POST', path, body)
 
@@ -68,7 +68,7 @@ class API(object):
     def mkdir(self, path='/'):
         return self._req('PUT', path, json.dumps({'type': 'directory'}))
 
-    def copy(self, copy_from, path):
+    def copy_put(self, copy_from, path='/'):
         body = json.dumps({'copy_from':copy_from})
         return self._req('PUT', path, body)
 
@@ -352,25 +352,25 @@ class APITest(NotebookTestBase):
         data = resp.json()
         self.assertEqual(data['content']['nbformat'], 4)
 
-    def test_copy_untitled(self):
-        resp = self.api.copy_untitled(u'å b/ç d.ipynb', u'unicodé')
+    def test_copy(self):
+        resp = self.api.copy(u'å b/ç d.ipynb', u'unicodé')
         self._check_created(resp, u'unicodé/ç d-Copy0.ipynb')
         
-        resp = self.api.copy_untitled(u'å b/ç d.ipynb', u'å b')
+        resp = self.api.copy(u'å b/ç d.ipynb', u'å b')
         self._check_created(resp, u'å b/ç d-Copy0.ipynb')
 
-    def test_copy(self):
-        resp = self.api.copy(u'å b/ç d.ipynb', u'å b/cøpy.ipynb')
-        self._check_created(resp, u'å b/cøpy.ipynb')
-
     def test_copy_path(self):
-        resp = self.api.copy(u'foo/a.ipynb', u'å b/cøpyfoo.ipynb')
-        self._check_created(resp, u'å b/cøpyfoo.ipynb')
+        resp = self.api.copy(u'foo/a.ipynb', u'å b')
+        self._check_created(resp, u'å b/a-Copy0.ipynb')
+
+    def test_copy_put_400(self):
+        with assert_http_error(400):
+            resp = self.api.copy_put(u'å b/ç d.ipynb', u'å b/cøpy.ipynb')
 
     def test_copy_dir_400(self):
         # can't copy directories
         with assert_http_error(400):
-            resp = self.api.copy(u'å b', u'å c')
+            resp = self.api.copy(u'å b', u'foo')
 
     def test_delete(self):
         for d, name in self.dirs_nbs:

--- a/IPython/html/services/contents/tests/test_contents_api.py
+++ b/IPython/html/services/contents/tests/test_contents_api.py
@@ -55,6 +55,9 @@ class API(object):
             body = json.dumps({'ext': ext})
         return self._req('POST', path, body)
 
+    def mkdir_untitled(self, path='/'):
+        return self._req('POST', path, json.dumps({'type': 'directory'}))
+
     def copy(self, copy_from, path='/'):
         body = json.dumps({'copy_from':copy_from})
         return self._req('POST', path, body)
@@ -64,6 +67,9 @@ class API(object):
 
     def upload(self, path, body):
         return self._req('PUT', path, body)
+
+    def mkdir_untitled(self, path='/'):
+        return self._req('POST', path, json.dumps({'type': 'directory'}))
 
     def mkdir(self, path='/'):
         return self._req('PUT', path, json.dumps({'type': 'directory'}))
@@ -193,8 +199,11 @@ class APITest(NotebookTestBase):
         self.assertEqual(nbnames, expected)
 
     def test_list_dirs(self):
+        print(self.api.list().json())
         dirs = dirs_only(self.api.list().json())
         dir_names = {normalize('NFC', d['name']) for d in dirs}
+        print(dir_names)
+        print(self.top_level_dirs)
         self.assertEqual(dir_names, self.top_level_dirs)  # Excluding hidden dirs
 
     def test_list_nonexistant_dir(self):
@@ -292,6 +301,18 @@ class APITest(NotebookTestBase):
         path = u'å b/Upload tést.ipynb'
         resp = self.api.upload(path, body=json.dumps(nbmodel))
         self._check_created(resp, path)
+
+    def test_mkdir_untitled(self):
+        resp = self.api.mkdir_untitled(path=u'å b')
+        self._check_created(resp, u'å b/Untitled Folder0', type='directory')
+
+        # Second time
+        resp = self.api.mkdir_untitled(path=u'å b')
+        self._check_created(resp, u'å b/Untitled Folder1', type='directory')
+
+        # And two directories down
+        resp = self.api.mkdir_untitled(path='foo/bar')
+        self._check_created(resp, 'foo/bar/Untitled Folder0', type='directory')
 
     def test_mkdir(self):
         path = u'å b/New ∂ir'

--- a/IPython/html/services/contents/tests/test_contents_api.py
+++ b/IPython/html/services/contents/tests/test_contents_api.py
@@ -49,7 +49,7 @@ class API(object):
     def read(self, path):
         return self._req('GET', path)
 
-    def create_untitled(self, path='/', ext=None):
+    def create_untitled(self, path='/', ext='.ipynb'):
         body = None
         if ext:
             body = json.dumps({'ext': ext})

--- a/IPython/html/services/contents/tests/test_manager.py
+++ b/IPython/html/services/contents/tests/test_manager.py
@@ -101,7 +101,7 @@ class TestContentsManager(TestCase):
 
     def new_notebook(self):
         cm = self.contents_manager
-        model = cm.create_file()
+        model = cm.new()
         name = model['name']
         path = model['path']
 
@@ -112,10 +112,10 @@ class TestContentsManager(TestCase):
         cm.save(full_model, path)
         return nb, name, path
 
-    def test_create_file(self):
+    def test_new(self):
         cm = self.contents_manager
         # Test in root directory
-        model = cm.create_file()
+        model = cm.new()
         assert isinstance(model, dict)
         self.assertIn('name', model)
         self.assertIn('path', model)
@@ -125,7 +125,7 @@ class TestContentsManager(TestCase):
         # Test in sub-directory
         sub_dir = '/foo/'
         self.make_dir(cm.root_dir, 'foo')
-        model = cm.create_file(path=sub_dir)
+        model = cm.new(path=sub_dir)
         assert isinstance(model, dict)
         self.assertIn('name', model)
         self.assertIn('path', model)
@@ -135,7 +135,7 @@ class TestContentsManager(TestCase):
     def test_get(self):
         cm = self.contents_manager
         # Create a notebook
-        model = cm.create_file()
+        model = cm.new()
         name = model['name']
         path = model['path']
 
@@ -150,7 +150,7 @@ class TestContentsManager(TestCase):
         # Test in sub-directory
         sub_dir = '/foo/'
         self.make_dir(cm.root_dir, 'foo')
-        model = cm.create_file(path=sub_dir, ext='.ipynb')
+        model = cm.new(path=sub_dir, ext='.ipynb')
         model2 = cm.get_model(sub_dir + name)
         assert isinstance(model2, dict)
         self.assertIn('name', model2)
@@ -165,7 +165,7 @@ class TestContentsManager(TestCase):
         path = 'test bad symlink'
         os_path = self.make_dir(cm.root_dir, path)
         
-        file_model = cm.create_file(path=path, ext='.txt')
+        file_model = cm.new(path=path, ext='.txt')
         
         # create a broken symlink
         os.symlink("target", os.path.join(os_path, "bad symlink"))
@@ -180,7 +180,7 @@ class TestContentsManager(TestCase):
         path = '{0}/{1}'.format(parent, name)
         os_path = self.make_dir(cm.root_dir, parent)
         
-        file_model = cm.create_file(path=parent, ext='.txt')
+        file_model = cm.new(path=parent, ext='.txt')
         
         # create a good symlink
         os.symlink(file_model['name'], os.path.join(os_path, name))
@@ -195,7 +195,7 @@ class TestContentsManager(TestCase):
     def test_update(self):
         cm = self.contents_manager
         # Create a notebook
-        model = cm.create_file()
+        model = cm.new()
         name = model['name']
         path = model['path']
 
@@ -214,7 +214,7 @@ class TestContentsManager(TestCase):
         # Create a directory and notebook in that directory
         sub_dir = '/foo/'
         self.make_dir(cm.root_dir, 'foo')
-        model = cm.create_file(None, sub_dir)
+        model = cm.new(None, sub_dir)
         name = model['name']
         path = model['path']
 
@@ -234,7 +234,7 @@ class TestContentsManager(TestCase):
     def test_save(self):
         cm = self.contents_manager
         # Create a notebook
-        model = cm.create_file()
+        model = cm.new()
         name = model['name']
         path = model['path']
 
@@ -253,7 +253,7 @@ class TestContentsManager(TestCase):
         # Create a directory and notebook in that directory
         sub_dir = '/foo/'
         self.make_dir(cm.root_dir, 'foo')
-        model = cm.create_file(None, sub_dir)
+        model = cm.new(None, sub_dir)
         name = model['name']
         path = model['path']
         model = cm.get_model(path)
@@ -283,7 +283,7 @@ class TestContentsManager(TestCase):
         name = u'nb √.ipynb'
         path = u'{0}/{1}'.format(parent, name)
         os.mkdir(os.path.join(cm.root_dir, parent))
-        orig = cm.create_file(path=path)
+        orig = cm.new(path=path)
 
         # copy with unspecified name
         copy = cm.copy(path)

--- a/IPython/html/services/sessions/handlers.py
+++ b/IPython/html/services/sessions/handlers.py
@@ -36,10 +36,6 @@ class SessionRootHandler(IPythonHandler):
         if model is None:
             raise web.HTTPError(400, "No JSON data provided")
         try:
-            name = model['notebook']['name']
-        except KeyError:
-            raise web.HTTPError(400, "Missing field in JSON data: notebook.name")
-        try:
             path = model['notebook']['path']
         except KeyError:
             raise web.HTTPError(400, "Missing field in JSON data: notebook.path")
@@ -50,11 +46,11 @@ class SessionRootHandler(IPythonHandler):
             kernel_name = None
 
         # Check to see if session exists
-        if sm.session_exists(name=name, path=path):
-            model = sm.get_session(name=name, path=path)
+        if sm.session_exists(path=path):
+            model = sm.get_session(path=path)
         else:
             try:
-                model = sm.create_session(name=name, path=path, kernel_name=kernel_name)
+                model = sm.create_session(path=path, kernel_name=kernel_name)
             except NoSuchKernel:
                 msg = ("The '%s' kernel is not available. Please pick another "
                        "suitable kernel instead, or install that kernel." % kernel_name)
@@ -92,8 +88,6 @@ class SessionHandler(IPythonHandler):
         changes = {}
         if 'notebook' in model:
             notebook = model['notebook']
-            if 'name' in notebook:
-                changes['name'] = notebook['name']
             if 'path' in notebook:
                 changes['path'] = notebook['path']
 

--- a/IPython/html/services/sessions/tests/test_sessionmanager.py
+++ b/IPython/html/services/sessions/tests/test_sessionmanager.py
@@ -32,24 +32,24 @@ class TestSessionManager(TestCase):
     
     def test_get_session(self):
         sm = SessionManager(kernel_manager=DummyMKM())
-        session_id = sm.create_session(name='test.ipynb', path='/path/to/',
+        session_id = sm.create_session(path='/path/to/test.ipynb',
                                        kernel_name='bar')['id']
         model = sm.get_session(session_id=session_id)
         expected = {'id':session_id,
-                    'notebook':{'name':u'test.ipynb', 'path': u'/path/to/'},
+                    'notebook':{'path': u'/path/to/test.ipynb'},
                     'kernel': {'id':u'A', 'name': 'bar'}}
         self.assertEqual(model, expected)
 
     def test_bad_get_session(self):
         # Should raise error if a bad key is passed to the database.
         sm = SessionManager(kernel_manager=DummyMKM())
-        session_id = sm.create_session(name='test.ipynb', path='/path/to/',
+        session_id = sm.create_session(path='/path/to/test.ipynb',
                                        kernel_name='foo')['id']
         self.assertRaises(TypeError, sm.get_session, bad_id=session_id) # Bad keyword
 
     def test_get_session_dead_kernel(self):
         sm = SessionManager(kernel_manager=DummyMKM())
-        session = sm.create_session(name='test1.ipynb', path='/path/to/1/', kernel_name='python')
+        session = sm.create_session(path='/path/to/1/test1.ipynb', kernel_name='python')
         # kill the kernel
         sm.kernel_manager.shutdown_kernel(session['kernel']['id'])
         with self.assertRaises(KeyError):
@@ -61,24 +61,33 @@ class TestSessionManager(TestCase):
     def test_list_sessions(self):
         sm = SessionManager(kernel_manager=DummyMKM())
         sessions = [
-            sm.create_session(name='test1.ipynb', path='/path/to/1/', kernel_name='python'),
-            sm.create_session(name='test2.ipynb', path='/path/to/2/', kernel_name='python'),
-            sm.create_session(name='test3.ipynb', path='/path/to/3/', kernel_name='python'),
+            sm.create_session(path='/path/to/1/test1.ipynb', kernel_name='python'),
+            sm.create_session(path='/path/to/2/test2.ipynb', kernel_name='python'),
+            sm.create_session(path='/path/to/3/test3.ipynb', kernel_name='python'),
         ]
         sessions = sm.list_sessions()
-        expected = [{'id':sessions[0]['id'], 'notebook':{'name':u'test1.ipynb', 
-                    'path': u'/path/to/1/'}, 'kernel':{'id':u'A', 'name':'python'}},
-                    {'id':sessions[1]['id'], 'notebook': {'name':u'test2.ipynb', 
-                    'path': u'/path/to/2/'}, 'kernel':{'id':u'B', 'name':'python'}},
-                    {'id':sessions[2]['id'], 'notebook':{'name':u'test3.ipynb', 
-                    'path': u'/path/to/3/'}, 'kernel':{'id':u'C', 'name':'python'}}]
+        expected = [
+            {
+                'id':sessions[0]['id'],
+                'notebook':{'path': u'/path/to/1/test1.ipynb'},
+                'kernel':{'id':u'A', 'name':'python'}
+            }, {
+                'id':sessions[1]['id'],
+                'notebook': {'path': u'/path/to/2/test2.ipynb'},
+                'kernel':{'id':u'B', 'name':'python'}
+            }, {
+                'id':sessions[2]['id'],
+                'notebook':{'path': u'/path/to/3/test3.ipynb'},
+                'kernel':{'id':u'C', 'name':'python'}
+            }
+        ]
         self.assertEqual(sessions, expected)
 
     def test_list_sessions_dead_kernel(self):
         sm = SessionManager(kernel_manager=DummyMKM())
         sessions = [
-            sm.create_session(name='test1.ipynb', path='/path/to/1/', kernel_name='python'),
-            sm.create_session(name='test2.ipynb', path='/path/to/2/', kernel_name='python'),
+            sm.create_session(path='/path/to/1/test1.ipynb', kernel_name='python'),
+            sm.create_session(path='/path/to/2/test2.ipynb', kernel_name='python'),
         ]
         # kill one of the kernels
         sm.kernel_manager.shutdown_kernel(sessions[0]['kernel']['id'])
@@ -87,8 +96,7 @@ class TestSessionManager(TestCase):
             {
                 'id': sessions[1]['id'],
                 'notebook': {
-                    'name': u'test2.ipynb',
-                    'path': u'/path/to/2/',
+                    'path': u'/path/to/2/test2.ipynb',
                 },
                 'kernel': {
                     'id': u'B',
@@ -100,41 +108,47 @@ class TestSessionManager(TestCase):
 
     def test_update_session(self):
         sm = SessionManager(kernel_manager=DummyMKM())
-        session_id = sm.create_session(name='test.ipynb', path='/path/to/',
+        session_id = sm.create_session(path='/path/to/test.ipynb',
                                        kernel_name='julia')['id']
-        sm.update_session(session_id, name='new_name.ipynb')
+        sm.update_session(session_id, path='/path/to/new_name.ipynb')
         model = sm.get_session(session_id=session_id)
         expected = {'id':session_id,
-                    'notebook':{'name':u'new_name.ipynb', 'path': u'/path/to/'},
+                    'notebook':{'path': u'/path/to/new_name.ipynb'},
                     'kernel':{'id':u'A', 'name':'julia'}}
         self.assertEqual(model, expected)
     
     def test_bad_update_session(self):
         # try to update a session with a bad keyword ~ raise error
         sm = SessionManager(kernel_manager=DummyMKM())
-        session_id = sm.create_session(name='test.ipynb', path='/path/to/',
+        session_id = sm.create_session(path='/path/to/test.ipynb',
                                        kernel_name='ir')['id']
         self.assertRaises(TypeError, sm.update_session, session_id=session_id, bad_kw='test.ipynb') # Bad keyword
 
     def test_delete_session(self):
         sm = SessionManager(kernel_manager=DummyMKM())
         sessions = [
-            sm.create_session(name='test1.ipynb', path='/path/to/1/', kernel_name='python'),
-            sm.create_session(name='test2.ipynb', path='/path/to/2/', kernel_name='python'),
-            sm.create_session(name='test3.ipynb', path='/path/to/3/', kernel_name='python'),
+            sm.create_session(path='/path/to/1/test1.ipynb', kernel_name='python'),
+            sm.create_session(path='/path/to/2/test2.ipynb', kernel_name='python'),
+            sm.create_session(path='/path/to/3/test3.ipynb', kernel_name='python'),
         ]
         sm.delete_session(sessions[1]['id'])
         new_sessions = sm.list_sessions()
-        expected = [{'id':sessions[0]['id'], 'notebook':{'name':u'test1.ipynb', 
-                    'path': u'/path/to/1/'}, 'kernel':{'id':u'A', 'name':'python'}},
-                    {'id':sessions[2]['id'], 'notebook':{'name':u'test3.ipynb', 
-                    'path': u'/path/to/3/'}, 'kernel':{'id':u'C', 'name':'python'}}]
+        expected = [{
+                'id': sessions[0]['id'],
+                'notebook': {'path': u'/path/to/1/test1.ipynb'},
+                'kernel': {'id':u'A', 'name':'python'}
+            }, {
+                'id': sessions[2]['id'],
+                'notebook': {'path': u'/path/to/3/test3.ipynb'},
+                'kernel': {'id':u'C', 'name':'python'}
+            }
+        ]
         self.assertEqual(new_sessions, expected)
 
     def test_bad_delete_session(self):
         # try to delete a session that doesn't exist ~ raise error
         sm = SessionManager(kernel_manager=DummyMKM())
-        sm.create_session(name='test.ipynb', path='/path/to/', kernel_name='python')
+        sm.create_session(path='/path/to/test.ipynb', kernel_name='python')
         self.assertRaises(TypeError, sm.delete_session, bad_kwarg='23424') # Bad keyword
         self.assertRaises(web.HTTPError, sm.delete_session, session_id='23424') # nonexistant
 

--- a/IPython/html/services/sessions/tests/test_sessions_api.py
+++ b/IPython/html/services/sessions/tests/test_sessions_api.py
@@ -38,13 +38,13 @@ class SessionAPI(object):
     def get(self, id):
         return self._req('GET', id)
 
-    def create(self, name, path, kernel_name='python'):
-        body = json.dumps({'notebook': {'name':name, 'path':path},
+    def create(self, path, kernel_name='python'):
+        body = json.dumps({'notebook': {'path':path},
                            'kernel': {'name': kernel_name}})
         return self._req('POST', '', body)
 
-    def modify(self, id, name, path):
-        body = json.dumps({'notebook': {'name':name, 'path':path}})
+    def modify(self, id, path):
+        body = json.dumps({'notebook': {'path':path}})
         return self._req('PATCH', id, body)
 
     def delete(self, id):
@@ -78,12 +78,11 @@ class SessionAPITest(NotebookTestBase):
         sessions = self.sess_api.list().json()
         self.assertEqual(len(sessions), 0)
 
-        resp = self.sess_api.create('nb1.ipynb', 'foo')
+        resp = self.sess_api.create('foo/nb1.ipynb')
         self.assertEqual(resp.status_code, 201)
         newsession = resp.json()
         self.assertIn('id', newsession)
-        self.assertEqual(newsession['notebook']['name'], 'nb1.ipynb')
-        self.assertEqual(newsession['notebook']['path'], 'foo')
+        self.assertEqual(newsession['notebook']['path'], 'foo/nb1.ipynb')
         self.assertEqual(resp.headers['Location'], '/api/sessions/{0}'.format(newsession['id']))
 
         sessions = self.sess_api.list().json()
@@ -95,7 +94,7 @@ class SessionAPITest(NotebookTestBase):
         self.assertEqual(got, newsession)
 
     def test_delete(self):
-        newsession = self.sess_api.create('nb1.ipynb', 'foo').json()
+        newsession = self.sess_api.create('foo/nb1.ipynb').json()
         sid = newsession['id']
 
         resp = self.sess_api.delete(sid)
@@ -108,10 +107,9 @@ class SessionAPITest(NotebookTestBase):
             self.sess_api.get(sid)
 
     def test_modify(self):
-        newsession = self.sess_api.create('nb1.ipynb', 'foo').json()
+        newsession = self.sess_api.create('foo/nb1.ipynb').json()
         sid = newsession['id']
 
-        changed = self.sess_api.modify(sid, 'nb2.ipynb', '').json()
+        changed = self.sess_api.modify(sid, 'nb2.ipynb').json()
         self.assertEqual(changed['id'], sid)
-        self.assertEqual(changed['notebook']['name'], 'nb2.ipynb')
-        self.assertEqual(changed['notebook']['path'], '')
+        self.assertEqual(changed['notebook']['path'], 'nb2.ipynb')

--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -272,11 +272,11 @@ define([
                 } else {
                     line = "background-color: ";
                 }
-                line = line + "rgb(" + r + "," + g + "," + b + ");"
-                if ( !attrs["style"] ) {
-                    attrs["style"] = line;
+                line = line + "rgb(" + r + "," + g + "," + b + ");";
+                if ( !attrs.style ) {
+                    attrs.style = line;
                 } else {
-                    attrs["style"] += " " + line;
+                    attrs.style += " " + line;
                 }
             }
         }
@@ -285,7 +285,7 @@ define([
     function ansispan(str) {
         // ansispan function adapted from github.com/mmalecki/ansispan (MIT License)
         // regular ansi escapes (using the table above)
-        var is_open = false
+        var is_open = false;
         return str.replace(/\033\[(0?[01]|22|39)?([;\d]+)?m/g, function(match, prefix, pattern) {
             if (!pattern) {
                 // [(01|22|39|)m close spans
@@ -313,7 +313,7 @@ define([
                 return span + ">";
             }
         });
-    };
+    }
 
     // Transform ANSI color escape codes into HTML <span> tags with css
     // classes listed in the above ansi_colormap object. The actual color used
@@ -390,6 +390,18 @@ define([
         }
         url = url.replace(/\/\/+/, '/');
         return url;
+    };
+    
+    var url_path_split = function (path) {
+        // Like os.path.split for URLs.
+        // Always returns two strings, the directory path and the base filename
+        
+        var idx = path.lastIndexOf('/');
+        if (idx === -1) {
+            return ['', path];
+        } else {
+            return [ path.slice(0, idx), path.slice(idx + 1) ];
+        }
     };
     
     var parse_url = function (url) {
@@ -577,7 +589,7 @@ define([
         wrapped_error.xhr_status = status;
         wrapped_error.xhr_error = error;
         return wrapped_error;
-    }
+    };
     
     var utils = {
         regex_split : regex_split,
@@ -588,6 +600,7 @@ define([
         points_to_pixels : points_to_pixels,
         get_body_data : get_body_data,
         parse_url : parse_url,
+        url_path_split : url_path_split,
         url_path_join : url_path_join,
         url_join_encode : url_join_encode,
         encode_uri_components : encode_uri_components,

--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -151,6 +151,6 @@ require([
     IPython.tooltip = notebook.tooltip;
 
     events.trigger('app_initialized.NotebookApp');
-    notebook.load_notebook(common_options.notebook_name, common_options.notebook_path);
+    notebook.load_notebook(common_options.notebook_path);
 
 });

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -2,13 +2,14 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'jquery',
+    'base/js/namespace',
+    'base/js/dialog',
     'base/js/utils',
     'notebook/js/tour',
     'bootstrap',
     'moment',
-], function(IPython, $, utils, tour, bootstrap, moment) {
+], function($, IPython, dialog, utils, tour, bootstrap, moment) {
     "use strict";
     
     var MenuBar = function (selector, options) {
@@ -89,14 +90,14 @@ define([
         this.element.find('#new_notebook').click(function () {
             // Create a new notebook in the same path as the current
             // notebook's path.
-            that.contents.new(that.notebook.notebook_path, null, {
+            var parent = utils.url_path_split(this.notebook_path)[0];
+            that.contents.new(parent, {
                     ext: ".ipynb",
                     extra_settings: {async: false},  // So we can open a new window afterwards
                     success: function (data) {
                         window.open(
                             utils.url_join_encode(
-                                that.base_url, 'notebooks',
-                                data.path, data.name
+                                that.base_url, 'notebooks', data.path
                             ), '_blank');
                         },
                     error: function(error) {

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -91,7 +91,7 @@ define([
             // Create a new notebook in the same path as the current
             // notebook's path.
             var parent = utils.url_path_split(that.notebook.notebook_path)[0];
-            that.contents.new(parent, {
+            that.contents.new_untitled(parent, {
                     type: "notebook",
                     extra_settings: {async: false},  // So we can open a new window afterwards
                     success: function (data) {

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -90,9 +90,9 @@ define([
         this.element.find('#new_notebook').click(function () {
             // Create a new notebook in the same path as the current
             // notebook's path.
-            var parent = utils.url_path_split(this.notebook_path)[0];
+            var parent = utils.url_path_split(that.notebook.notebook_path)[0];
             that.contents.new(parent, {
-                    ext: ".ipynb",
+                    type: "notebook",
                     extra_settings: {async: false},  // So we can open a new window afterwards
                     success: function (data) {
                         window.open(

--- a/IPython/html/static/notebook/js/savewidget.js
+++ b/IPython/html/static/notebook/js/savewidget.js
@@ -122,14 +122,12 @@ define([
 
     SaveWidget.prototype.update_address_bar = function(){
         var base_url = this.notebook.base_url;
-        var nbname = this.notebook.notebook_name;
         var path = this.notebook.notebook_path;
-        var state = {path : path, name: nbname};
+        var state = {path : path};
         window.history.replaceState(state, "", utils.url_join_encode(
             base_url,
             "notebooks",
-            path,
-            nbname)
+            path)
         );
     };
 
@@ -199,7 +197,7 @@ define([
                 $.proxy(that._regularly_update_checkpoint_date, that),
                 t + 1000
             );
-        }
+        };
         var tdelta = Math.ceil(new Date()-this._checkpoint_date);
 
         // update regularly for the first 6hours and show

--- a/IPython/html/static/services/contents.js
+++ b/IPython/html/static/services/contents.js
@@ -98,9 +98,13 @@ define([
      * @param {String} path The path to create the new notebook at
      * @param {Object} options:
      *      ext: file extension to use
+     *      type: model type to create ('notebook', 'file', or 'directory')
      */
     Contents.prototype.new = function(path, options) {
-        var data = JSON.stringify({ext: options.ext || ".ipynb"});
+        var data = JSON.stringify({
+          ext: options.ext,
+          type: options.type
+        });
 
         var settings = {
             processData : false,

--- a/IPython/html/static/services/contents.js
+++ b/IPython/html/static/services/contents.js
@@ -92,15 +92,15 @@ define([
 
 
     /**
-     * Creates a new file at the specified directory path.
+     * Creates a new untitled file or directory in the specified directory path.
      *
      * @method new
-     * @param {String} path The path to create the new notebook at
+     * @param {String} path: the directory in which to create the new file/directory
      * @param {Object} options:
      *      ext: file extension to use
      *      type: model type to create ('notebook', 'file', or 'directory')
      */
-    Contents.prototype.new = function(path, options) {
+    Contents.prototype.new_untitled = function(path, options) {
         var data = JSON.stringify({
           ext: options.ext,
           type: options.type

--- a/IPython/html/static/services/contents.js
+++ b/IPython/html/static/services/contents.js
@@ -29,8 +29,9 @@ define([
         // An error representing the result of attempting to delete a non-empty
         // directory.
         this.message = 'A directory must be empty before being deleted.';
-    }
-    Contents.DirectoryNotEmptyError.prototype = new Error;
+    };
+    
+    Contents.DirectoryNotEmptyError.prototype = Object.create(Error.prototype);
     Contents.DirectoryNotEmptyError.prototype.name =
         Contents.DIRECTORY_NOT_EMPTY_ERROR;
 
@@ -54,29 +55,28 @@ define([
      */
     Contents.prototype.create_basic_error_handler = function(callback) {
         if (!callback) {
-            return function(xhr, status, error) { };
+            return utils.log_ajax_error;
         }
         return function(xhr, status, error) {
             callback(utils.wrap_ajax_error(xhr, status, error));
         };
-    }
+    };
 
     /**
      * File Functions (including notebook operations)
      */
 
     /**
-     * Load a file.
+     * Get a file.
      *
      * Calls success with file JSON model, or error with error.
      *
-     * @method load_notebook
+     * @method get
      * @param {String} path
-     * @param {String} name
      * @param {Function} success
      * @param {Function} error
      */
-    Contents.prototype.load = function (path, name, options) {
+    Contents.prototype.get = function (path, options) {
         // We do the call with settings so we can set cache to false.
         var settings = {
             processData : false,
@@ -86,32 +86,25 @@ define([
             success : options.success,
             error : this.create_basic_error_handler(options.error)
         };
-        var url = this.api_url(path, name);
+        var url = this.api_url(path);
         $.ajax(url, settings);
     };
 
 
     /**
-     * Creates a new notebook file at the specified directory path.
+     * Creates a new file at the specified directory path.
      *
-     * @method scroll_to_cell
+     * @method new
      * @param {String} path The path to create the new notebook at
-     * @param {String} name Name for new file. Chosen by server if unspecified.
      * @param {Object} options:
-     *      ext: file extension to use if name unspecified
+     *      ext: file extension to use
      */
-    Contents.prototype.new = function(path, name, options) {
-        var method, data;
-        if (name) {
-            method = "PUT";
-        } else {
-            method = "POST";
-            data = JSON.stringify({ext: options.ext || ".ipynb"});
-        }
+    Contents.prototype.new = function(path, options) {
+        var data = JSON.stringify({ext: options.ext || ".ipynb"});
 
         var settings = {
             processData : false,
-            type : method,
+            type : "POST",
             data: data,
             dataType : "json",
             success : options.success || function() {},
@@ -123,9 +116,8 @@ define([
         $.ajax(this.api_url(path), settings);
     };
 
-    Contents.prototype.delete = function(name, path, options) {
+    Contents.prototype.delete = function(path, options) {
         var error_callback = options.error || function() {};
-        var that = this;
         var settings = {
             processData : false,
             type : "DELETE",
@@ -140,12 +132,12 @@ define([
                 error_callback(utils.wrap_ajax_error(xhr, status, error));
             }
         };
-        var url = this.api_url(path, name);
+        var url = this.api_url(path);
         $.ajax(url, settings);
     };
 
-    Contents.prototype.rename = function(path, name, new_path, new_name, options) {
-        var data = {name: new_name, path: new_path};
+    Contents.prototype.rename = function(path, new_path, options) {
+        var data = {path: new_path};
         var settings = {
             processData : false,
             type : "PATCH",
@@ -155,11 +147,11 @@ define([
             success : options.success || function() {},
             error : this.create_basic_error_handler(options.error)
         };
-        var url = this.api_url(path, name);
+        var url = this.api_url(path);
         $.ajax(url, settings);
     };
 
-    Contents.prototype.save = function(path, name, model, options) {
+    Contents.prototype.save = function(path, model, options) {
         // We do the call with settings so we can set cache to false.
         var settings = {
             processData : false,
@@ -172,24 +164,19 @@ define([
         if (options.extra_settings) {
             $.extend(settings, options.extra_settings);
         }
-        var url = this.api_url(path, name);
+        var url = this.api_url(path);
         $.ajax(url, settings);
     };
     
-    Contents.prototype.copy = function(to_path, to_name, from, options) {
-        var url, method;
-        if (to_name) {
-            url = this.api_url(to_path, to_name);
-            method = "PUT";
-        } else {
-            url = this.api_url(to_path);
-            method = "POST";
-        }
+    Contents.prototype.copy = function(from_file, to_dir, options) {
+        // Copy a file into a given directory via POST
+        // The server will select the name of the copied file
+        var url = this.api_url(to_dir);
         
         var settings = {
             processData : false,
-            type: method,
-            data: JSON.stringify({copy_from: from}),
+            type: "POST",
+            data: JSON.stringify({copy_from: from_file}),
             dataType : "json",
             success: options.success || function() {},
             error: this.create_basic_error_handler(options.error)
@@ -204,8 +191,8 @@ define([
      * Checkpointing Functions
      */
 
-    Contents.prototype.create_checkpoint = function(path, name, options) {
-        var url = this.api_url(path, name, 'checkpoints');
+    Contents.prototype.create_checkpoint = function(path, options) {
+        var url = this.api_url(path, 'checkpoints');
         var settings = {
             type : "POST",
             success: options.success || function() {},
@@ -214,8 +201,8 @@ define([
         $.ajax(url, settings);
     };
 
-    Contents.prototype.list_checkpoints = function(path, name, options) {
-        var url = this.api_url(path, name, 'checkpoints');
+    Contents.prototype.list_checkpoints = function(path, options) {
+        var url = this.api_url(path, 'checkpoints');
         var settings = {
             type : "GET",
             success: options.success,
@@ -224,8 +211,8 @@ define([
         $.ajax(url, settings);
     };
 
-    Contents.prototype.restore_checkpoint = function(path, name, checkpoint_id, options) {
-        var url = this.api_url(path, name, 'checkpoints', checkpoint_id);
+    Contents.prototype.restore_checkpoint = function(path, checkpoint_id, options) {
+        var url = this.api_url(path, 'checkpoints', checkpoint_id);
         var settings = {
             type : "POST",
             success: options.success || function() {},
@@ -234,8 +221,8 @@ define([
         $.ajax(url, settings);
     };
 
-    Contents.prototype.delete_checkpoint = function(path, name, checkpoint_id, options) {
-        var url = this.api_url(path, name, 'checkpoints', checkpoint_id);
+    Contents.prototype.delete_checkpoint = function(path, checkpoint_id, options) {
+        var url = this.api_url(path, 'checkpoints', checkpoint_id);
         var settings = {
             type : "DELETE",
             success: options.success || function() {},
@@ -255,10 +242,8 @@ define([
      * representing individual files or directories.  Each dictionary has
      * the keys:
      *     type: "notebook" or "directory"
-     *     name: the name of the file or directory
      *     created: created date
      *     last_modified: last modified dat
-     *     path: the path
      * @method list_notebooks
      * @param {String} path The path to list notebooks in
      * @param {Function} load_callback called with list of notebooks on success

--- a/IPython/html/static/services/sessions/session.js
+++ b/IPython/html/static/services/sessions/session.js
@@ -15,7 +15,6 @@ define([
      * all other operations, the kernel object should be used.
      *
      * Options should include:
-     *  - notebook_name: the notebook name
      *  - notebook_path: the path (not including name) to the notebook
      *  - kernel_name: the type of kernel (e.g. python3)
      *  - base_url: the root url of the notebook server
@@ -28,7 +27,6 @@ define([
     var Session = function (options) {
         this.id = null;
         this.notebook_model = {
-            name: options.notebook_name,
             path: options.notebook_path
         };
         this.kernel_model = {
@@ -154,15 +152,11 @@ define([
      * undefined, then they will not be changed.
      *
      * @function rename_notebook
-     * @param {string} [name] - new notebook name
-     * @param {string} [path] - new path to notebook
+     * @param {string} [path] - new notebook path
      * @param {function} [success] - function executed on ajax success
      * @param {function} [error] - functon executed on ajax error
      */
-    Session.prototype.rename_notebook = function (name, path, success, error) {
-        if (name !== undefined) {
-            this.notebook_model.name = name;
-        }
+    Session.prototype.rename_notebook = function (path, success, error) {
         if (path !== undefined) {
             this.notebook_model.path = path;
         }
@@ -208,7 +202,6 @@ define([
      * fresh. If options are given, they can include any of the
      * following:
      *
-     * - notebook_name - the name of the notebook
      * - notebook_path - the path to the notebook
      * - kernel_name - the name (type) of the kernel
      *
@@ -220,9 +213,6 @@ define([
     Session.prototype.restart = function (options, success, error) {
         var that = this;
         var start = function () {
-            if (options && options.notebook_name) {
-                that.notebook_model.name = options.notebook_name;
-            }
             if (options && options.notebook_path) {
                 that.notebook_model.path = options.notebook_path;
             }
@@ -238,8 +228,8 @@ define([
     // Helper functions
 
     /**
-     * Get the data model for the session, which includes the notebook
-     * (name and path) and kernel (name and id).
+     * Get the data model for the session, which includes the notebook path
+     * and kernel (name and id).
      *
      * @function _get_model
      * @returns {Object} - the data model
@@ -266,7 +256,6 @@ define([
             this.session_url = utils.url_join_encode(this.session_service_url, this.id);
         }
         if (data && data.notebook) {
-            this.notebook_model.name = data.notebook.name;
             this.notebook_model.path = data.notebook.path;
         }
         if (data && data.kernel) {

--- a/IPython/html/static/tree/js/main.js
+++ b/IPython/html/static/tree/js/main.js
@@ -65,7 +65,7 @@ require([
 
     $('#new_notebook').click(function (e) {
         contents.new(common_options.notebook_path, {
-                ext: ".ipynb",
+                type: "notebook",
                 extra_settings: {async: false},  // So we can open a new window afterwards
                 success: function (data) {
                     window.open(

--- a/IPython/html/static/tree/js/main.js
+++ b/IPython/html/static/tree/js/main.js
@@ -2,8 +2,9 @@
 // Distributed under the terms of the Modified BSD License.
 
 require([
-    'base/js/namespace',
     'jquery',
+    'base/js/namespace',
+    'base/js/dialog',
     'base/js/events',
     'base/js/page',
     'base/js/utils',
@@ -19,18 +20,20 @@ require([
     'bootstrap',
     'custom/custom',
 ], function(
-    IPython, 
-    $, 
+    $,
+    IPython,
+    dialog,
     events,
-    page, 
-    utils, 
-    contents,
+    page,
+    utils,
+    contents_service,
     notebooklist, 
     clusterlist, 
     sesssionlist, 
     kernellist,
     terminallist,
     loginwidget){
+    "use strict";
 
     page = new page.Page();
     
@@ -38,36 +41,37 @@ require([
         base_url: utils.get_body_data("baseUrl"),
         notebook_path: utils.get_body_data("notebookPath"),
     };
-    session_list = new sesssionlist.SesssionList($.extend({
+    var session_list = new sesssionlist.SesssionList($.extend({
         events: events}, 
         common_options));
-    contents = new contents.Contents($.extend({
+    var contents = new contents_service.Contents($.extend({
         events: events},
         common_options));
-    notebook_list = new notebooklist.NotebookList('#notebook_list', $.extend({
+    var notebook_list = new notebooklist.NotebookList('#notebook_list', $.extend({
         contents: contents,
         session_list:  session_list}, 
         common_options));
-    cluster_list = new clusterlist.ClusterList('#cluster_list', common_options);
-    kernel_list = new kernellist.KernelList('#running_list',  $.extend({
+    var cluster_list = new clusterlist.ClusterList('#cluster_list', common_options);
+    var kernel_list = new kernellist.KernelList('#running_list',  $.extend({
         session_list:  session_list}, 
         common_options));
     
+    var terminal_list;
     if (utils.get_body_data("terminalsAvailable") === "True") {
         terminal_list = new terminallist.TerminalList('#terminal_list', common_options);
     }
 
-    login_widget = new loginwidget.LoginWidget('#login_widget', common_options);
+    var login_widget = new loginwidget.LoginWidget('#login_widget', common_options);
 
     $('#new_notebook').click(function (e) {
-        contents.new(common_options.notebook_path, null, {
+        contents.new(common_options.notebook_path, {
                 ext: ".ipynb",
                 extra_settings: {async: false},  // So we can open a new window afterwards
                 success: function (data) {
                     window.open(
                         utils.url_join_encode(
                             common_options.base_url, 'notebooks',
-                            data.path, data.name
+                            data.path
                         ), '_blank');
                     },
                 error: function(error) {

--- a/IPython/html/static/tree/js/main.js
+++ b/IPython/html/static/tree/js/main.js
@@ -64,7 +64,7 @@ require([
     var login_widget = new loginwidget.LoginWidget('#login_widget', common_options);
 
     $('#new_notebook').click(function (e) {
-        contents.new(common_options.notebook_path, {
+        contents.new_untitled(common_options.notebook_path, {
                 type: "notebook",
                 extra_settings: {async: false},  // So we can open a new window afterwards
                 success: function (data) {

--- a/IPython/html/tests/notebook/save.js
+++ b/IPython/html/tests/notebook/save.js
@@ -12,14 +12,14 @@ casper.notebook_test(function () {
     
     this.thenEvaluate(function (nbname) {
         require(['base/js/events'], function (events) {
-            IPython.notebook.notebook_name = nbname;
+            IPython.notebook.set_notebook_name(nbname);
             IPython._save_success = IPython._save_failed = false;
             events.on('notebook_saved.Notebook', function () {
                 IPython._save_success = true;
             });
             events.on('notebook_save_failed.Notebook',
-                function (event, xhr, status, error) {
-                    IPython._save_failed = "save failed with " + xhr.status + xhr.responseText;
+                function (event, error) {
+                    IPython._save_failed = "save failed with " + error;
             });
             IPython.notebook.save_notebook();
         });
@@ -42,6 +42,10 @@ casper.notebook_test(function () {
             return IPython.notebook.notebook_name;
         });
         this.test.assertEquals(current_name, nbname, "Save with complicated name");
+        var current_path = this.evaluate(function(){
+            return IPython.notebook.notebook_path;
+        });
+        this.test.assertEquals(current_path, nbname, "path OK");
     });
     
     this.thenEvaluate(function(){
@@ -68,11 +72,8 @@ casper.notebook_test(function () {
     });
 
     this.then(function(){
-        var baseUrl = this.get_notebook_server();
-        this.open(baseUrl);
+        this.open_dashboard();
     });
-
-    this.waitForSelector('.list_item');
     
     this.then(function(){
         var notebook_url = this.evaluate(function(nbname){
@@ -92,11 +93,11 @@ casper.notebook_test(function () {
     });
     
     // wait for the notebook
-    this.waitForSelector("#notebook");
+    this.waitFor(this.kernel_running);
     
-    this.waitFor(function(){
-        return this.evaluate(function(){
-            return IPython.notebook || false;
+    this.waitFor(function() {
+        return this.evaluate(function () {
+            return IPython && IPython.notebook && true;
         });
     });
     

--- a/IPython/html/tests/test_nbextensions.py
+++ b/IPython/html/tests/test_nbextensions.py
@@ -75,22 +75,22 @@ class TestInstallNBExtension(TestCase):
             td.cleanup()
         nbextensions.get_ipython_dir = self.save_get_ipython_dir
     
-    def assert_path_exists(self, path):
+    def assert_dir_exists(self, path):
         if not os.path.exists(path):
             do_exist = os.listdir(os.path.dirname(path))
             self.fail(u"%s should exist (found %s)" % (path, do_exist))
     
-    def assert_not_path_exists(self, path):
+    def assert_not_dir_exists(self, path):
         if os.path.exists(path):
             self.fail(u"%s should not exist" % path)
     
     def assert_installed(self, relative_path, ipdir=None):
-        self.assert_path_exists(
+        self.assert_dir_exists(
             pjoin(ipdir or self.ipdir, u'nbextensions', relative_path)
         )
     
     def assert_not_installed(self, relative_path, ipdir=None):
-        self.assert_not_path_exists(
+        self.assert_not_dir_exists(
             pjoin(ipdir or self.ipdir, u'nbextensions', relative_path)
         )
     
@@ -99,7 +99,7 @@ class TestInstallNBExtension(TestCase):
         with TemporaryDirectory() as td:
             ipdir = pjoin(td, u'ipython')
             install_nbextension(self.src, ipython_dir=ipdir)
-            self.assert_path_exists(ipdir)
+            self.assert_dir_exists(ipdir)
             for file in self.files:
                 self.assert_installed(
                     pjoin(basename(self.src), file),

--- a/IPython/html/tests/test_paths.py
+++ b/IPython/html/tests/test_paths.py
@@ -1,0 +1,61 @@
+
+import re
+import nose.tools as nt
+
+from IPython.html.base.handlers import path_regex, notebook_path_regex
+
+try: # py3
+    assert_regex = nt.assert_regex
+    assert_not_regex = nt.assert_not_regex
+except AttributeError: # py2
+    assert_regex = nt.assert_regexp_matches
+    assert_not_regex = nt.assert_not_regexp_matches
+
+
+# build regexps that tornado uses:
+path_pat = re.compile('^' + '/x%s' % path_regex + '$')
+nb_path_pat = re.compile('^' + '/y%s' % notebook_path_regex + '$')
+
+def test_path_regex():
+    for path in (
+        '/x',
+        '/x/',
+        '/x/foo',
+        '/x/foo.ipynb',
+        '/x/foo/bar',
+        '/x/foo/bar.txt',
+    ):
+        assert_regex(path, path_pat)
+
+def test_path_regex_bad():
+    for path in (
+        '/xfoo',
+        '/xfoo/',
+        '/xfoo/bar',
+        '/xfoo/bar/',
+        '/x/foo/bar/',
+        '/x//foo',
+        '/y',
+        '/y/x/foo',
+    ):
+        assert_not_regex(path, path_pat)
+
+def test_notebook_path_regex():
+    for path in (
+        '/y/asdf.ipynb',
+        '/y/foo/bar.ipynb',
+        '/y/a/b/c/d/e.ipynb',
+    ):
+        assert_regex(path, nb_path_pat)
+
+def test_notebook_path_regex_bad():
+    for path in (
+        '/y',
+        '/y/',
+        '/y/.ipynb',
+        '/y/foo/.ipynb',
+        '/y/foo/bar',
+        '/yfoo.ipynb',
+        '/yfoo/bar.ipynb',
+    ):
+        assert_not_regex(path, nb_path_pat)

--- a/IPython/html/tests/tree/dashboard_nav.js
+++ b/IPython/html/tests/tree/dashboard_nav.js
@@ -11,13 +11,15 @@ casper.get_list_items = function () {
     });
 };
 
-casper.test_items = function (baseUrl) {
+casper.test_items = function (baseUrl, visited) {
+    visited = visited || {};
     casper.then(function () {
         var items = casper.get_list_items();
         casper.each(items, function (self, item) {
-            if (!item.label.match(/\.ipynb$/)) {
+            if (item.link.match(/^\/tree\//)) {
                 var followed_url = baseUrl+item.link;
-                if (!followed_url.match(/\/\.\.$/)) {
+                if (!visited[followed_url]) {
+                    visited[followed_url] = true;
                     casper.thenOpen(followed_url, function () {
                         this.waitFor(this.page_loaded);
                         casper.wait_for_dashboard();
@@ -25,7 +27,7 @@ casper.test_items = function (baseUrl) {
                         // but item.link is without host, and url-encoded
                         var expected = baseUrl + decodeURIComponent(item.link);
                         this.test.assertEquals(this.getCurrentUrl(), expected, 'Testing dashboard link: ' + expected);
-                        casper.test_items(baseUrl);
+                        casper.test_items(baseUrl, visited);
                         this.back();
                     });
                 }

--- a/IPython/html/tree/handlers.py
+++ b/IPython/html/tree/handlers.py
@@ -37,9 +37,12 @@ class TreeHandler(IPythonHandler):
         path = path.strip('/')
         cm = self.contents_manager
         if cm.file_exists(path):
-            # is a notebook, redirect to notebook handler
+            # it's not a directory, we have redirecting to do
+            model = cm.get(path, content=False)
+            # redirect to /api/notebooks if it's a notebook, otherwise /api/files
+            service = 'notebooks' if model['type'] == 'notebook' else 'files'
             url = url_escape(url_path_join(
-                self.base_url, 'notebooks', path,
+                self.base_url, service, path,
             ))
             self.log.debug("Redirecting %s to %s", self.request.path, url)
             self.redirect(url)

--- a/IPython/html/tree/handlers.py
+++ b/IPython/html/tree/handlers.py
@@ -4,7 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from tornado import web
-from ..base.handlers import IPythonHandler, notebook_path_regex, path_regex
+from ..base.handlers import IPythonHandler, path_regex
 from ..utils import url_path_join, url_escape
 
 
@@ -33,18 +33,18 @@ class TreeHandler(IPythonHandler):
             return 'Home'
 
     @web.authenticated
-    def get(self, path='', name=None):
+    def get(self, path=''):
         path = path.strip('/')
         cm = self.contents_manager
-        if name is not None:
+        if cm.file_exists(path):
             # is a notebook, redirect to notebook handler
             url = url_escape(url_path_join(
-                self.base_url, 'notebooks', path, name
+                self.base_url, 'notebooks', path,
             ))
             self.log.debug("Redirecting %s to %s", self.request.path, url)
             self.redirect(url)
         else:
-            if not cm.path_exists(path=path):
+            if not cm.dir_exists(path=path):
                 # Directory is hidden or does not exist.
                 raise web.HTTPError(404)
             elif cm.is_hidden(path):
@@ -66,7 +66,6 @@ class TreeHandler(IPythonHandler):
 
 
 default_handlers = [
-    (r"/tree%s" % notebook_path_regex, TreeHandler),
     (r"/tree%s" % path_regex, TreeHandler),
     (r"/tree", TreeHandler),
     ]


### PR DESCRIPTION
Opening now, so the plan is clear, but it will need to be rebased and finished after #6045 and #6783, which touch the same code. We should notify anyone who is already writing ContentsManagers that target 3.0.

Changes:
- ContentsManager APIs will only use a single 'path' argument, which is the full path
- `path` in the Contents model will become the full path, rather than the parent directory
- remove "untitled upload" via POST to a directory (only upload via PUT)
- remove copy via PUT(only POST)
