### PR TITLE
BUG: Set file encoding for IPython.html.terminal.handlers.

### DIFF
--- a/IPython/html/terminal/handlers.py
+++ b/IPython/html/terminal/handlers.py
@@ -1,3 +1,4 @@
+#encoding: utf-8
 """Tornado handlers for the terminal emulator."""
 
 # Copyright (c) IPython Development Team.


### PR DESCRIPTION
Fixes https://github.com/ipython/ipython/issues/6812.
