### PR TITLE
Fix terminals with Tornado 3

### DIFF
--- a/IPython/html/terminal/handlers.py
+++ b/IPython/html/terminal/handlers.py
@@ -32,6 +32,10 @@ class TermSocket(terminado.TermSocket, IPythonHandler):
         # tornado 3 has no get, will raise 405
         if tornado.version_info >= (4,):
             return super(TermSocket, self).get(*args, **kwargs)
+    
+    def clear_cookie(self, *args, **kwargs):
+        """meaningless for websockets"""
+        pass
 
     def open(self, *args, **kwargs):
         if tornado.version_info < (4,):


### PR DESCRIPTION
The websocket handler auth checking was calling clear_cookie(), which threw an error because it doesn't make sense for Websockets. It doesn't seem important, and we silence it in our other websocket handlers, so silencing it here too.

Ping @fperez & @jhamrick who both reported this to me today.
