### PR TITLE
use ?download=1 to trigger download in /files/

### DIFF
--- a/IPython/html/files/handlers.py
+++ b/IPython/html/files/handlers.py
@@ -24,7 +24,10 @@ class FilesHandler(IPythonHandler):
 
         path, name = os.path.split(path)
         model = cm.get_model(name, path)
-
+        
+        if self.get_argument("download", False):
+            self.set_header('Content-Disposition','attachment; filename="%s"' % name)
+        
         if model['type'] == 'notebook':
             self.set_header('Content-Type', 'application/json')
         else:
@@ -32,8 +35,6 @@ class FilesHandler(IPythonHandler):
             if cur_mime is not None:
                 self.set_header('Content-Type', cur_mime)
         
-        self.set_header('Content-Disposition','attachment; filename="%s"' % name)
-
         if model['format'] == 'base64':
             b64_bytes = model['content'].encode('ascii')
             self.write(base64.decodestring(b64_bytes))

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -112,7 +112,7 @@ define([
                 notebook_path,
                 notebook_name
             );
-            window.open(url);
+            window.open(url + '?download=1');
         });
         
         this.element.find('#print_preview').click(function () {

--- a/IPython/html/tests/test_files.py
+++ b/IPython/html/tests/test_files.py
@@ -98,7 +98,23 @@ class FilesTest(NotebookTestBase):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.headers['content-type'], 'text/plain')
         self.assertEqual(r.text, 'foobar')
+    
+    def test_download(self):
+        nbdir = self.notebook_dir.name
+        base = self.base_url()
+        
+        text = 'hello'
+        with open(pjoin(nbdir, 'test.txt'), 'w') as f:
+            f.write(text)
+        
+        r = requests.get(url_path_join(base, 'files', 'test.txt'))
+        disposition = r.headers.get('Content-Disposition', '')
+        self.assertNotIn('attachment', disposition)
 
+        r = requests.get(url_path_join(base, 'files', 'test.txt') + '?download=1')
+        disposition = r.headers.get('Content-Disposition', '')
+        self.assertIn('attachment', disposition)
+        self.assertIn('filename="test.txt"', disposition)
 
     def test_old_files_redirect(self):
         """pre-2.0 'files/' prefixed links are properly redirected"""


### PR DESCRIPTION
sets `Content-Disposition: attachment...`
- master sets this unconditionally
- 2.x sets this iff file is a notebook

closes #6826
