### PR TITLE
Fix for Websocket.pre_get on tornado 3

### DIFF
--- a/IPython/html/base/zmqhandlers.py
+++ b/IPython/html/base/zmqhandlers.py
@@ -220,7 +220,9 @@ class AuthenticatedZMQStreamHandler(ZMQStreamHandler, IPythonHandler):
     @gen.coroutine
     def get(self, *args, **kwargs):
         # pre_get can be a coroutine in subclasses
-        yield gen.maybe_future(self.pre_get())
+        # assign and yield in two step to avoid tornado 3 issues
+        res = self.pre_get()
+        yield gen.maybe_future(res)
         # FIXME: only do super get on tornado ≥ 4
         # tornado 3 has no get, will raise 405
         if tornado.version_info >= (4,):


### PR DESCRIPTION
Ok, I would **really** like to understand this one. 

Is the statement after the yield done in completely different context that these two things do really differ ? 

I've tried and retried a few times and this **does** fix the fact that `pre_get()` is not called on my machine on Python 3.4.1, or at least does not have the side effect of adapting the messages.

Am I crazy ?

@minrk @takluyver ?
