### PR TITLE
expedite installation on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ before_install:
     # workaround for https://github.com/travis-ci/travis-cookbooks/issues/155
     - sudo rm -rf /dev/shm && sudo ln -s /run/shm /dev/shm
     # Pierre Carrier's PPA for PhantomJS and CasperJS
-    - time sudo add-apt-repository -y ppa:pcarrier/ppa
+    - sudo add-apt-repository -y ppa:pcarrier/ppa
     # Needed to get recent version of pandoc in ubntu 12.04
-    - time sudo add-apt-repository -y ppa:marutter/c2d4u
-    - time sudo apt-get update
-    - time sudo apt-get install pandoc casperjs libzmq3-dev
+    - sudo add-apt-repository -y ppa:marutter/c2d4u
+    - sudo apt-get update
+    - sudo apt-get install pandoc casperjs libzmq3-dev
     # pin tornado < 4 for js tests while phantom is on super old webkit
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
     - if [[ $GROUP == 'js' ]]; then pip install -f travis-wheels/wheelhouse 'tornado<4'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ before_install:
     - time sudo apt-get update
     - time sudo apt-get install pandoc casperjs libzmq3-dev
     # pin tornado < 4 for js tests while phantom is on super old webkit
-    - if [[ $GROUP == 'js' ]]; then pip install 'tornado<4'; fi
-    - time pip install -f https://nipy.bic.berkeley.edu/wheelhouse/travis jinja2 sphinx pygments tornado requests!=2.4.2 mock pyzmq jsonschema jsonpointer mistune
+    - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
+    - if [[ $GROUP == 'js' ]]; then pip install -f travis-wheels/wheelhouse 'tornado<4'; fi
     - if [[ $GROUP == 'js' ]]; then python -m IPython.external.mathjax; fi
 install:
-    - time python setup.py install -q
+    - time pip install -f travis-wheels/wheelhouse file://$PWD#egg=ipython[all]
 script:
     - cd /tmp && iptest $GROUP
 

--- a/setup.py
+++ b/setup.py
@@ -273,7 +273,7 @@ extras_require = dict(
     qtconsole = ['pyzmq>=2.1.11', 'pygments'],
     zmq = ['pyzmq>=2.1.11'],
     doc = ['Sphinx>=1.1', 'numpydoc'],
-    test = ['nose>=0.10.1'],
+    test = ['nose>=0.10.1', 'requests'],
     terminal = [],
     nbformat = ['jsonschema>=2.0'],
     notebook = ['tornado>=3.1', 'pyzmq>=2.1.11', 'jinja2', 'pygments', 'mistune>=0.3.1'],


### PR DESCRIPTION
- get wheels from [minrk/travis-wheels](https://github.com/minrk/travis-wheels)
- install dependencies with `pip install .[all]`[1], rather than a big explicit `pip install ...` line, which can get out of sync.
- add requests as a dependency in `ipython[test]` because it's needed for several tests

Shaves about 6 minutes off the serial runtime, or 90 seconds per run.

[1] can't actually use `.[all]` syntax for whatever weird pip reason, instead using `file://$PWD#egg=ipython[all]`, but the principal is the same.
