### PR TITLE
a couple of nbformat 4 fixes I noticed while backporting v4 to 2.x

### DIFF
--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -2313,12 +2313,25 @@ define([
         var orig_nbformat = nbmodel.metadata.orig_nbformat;
         var orig_nbformat_minor = nbmodel.metadata.orig_nbformat_minor;
         if (orig_nbformat !== undefined && nbmodel.nbformat !== orig_nbformat) {
-            var msg = "This notebook has been converted from an older " +
-            "notebook format (v"+orig_nbformat+") to the current notebook " +
-            "format (v"+nbmodel.nbformat+"). The next time you save this notebook, the " +
-            "newer notebook format will be used and older versions of IPython " +
-            "may not be able to read it. To keep the older version, close the " +
-            "notebook without saving it.";
+            var src;
+            if (nb.nbformat > nb.orig_nbformat) {
+                src = " an older notebook format ";
+            } else {
+                src = " a newer notebook format ";
+            }
+            
+            var msg = "This notebook has been converted from" + src +
+            "(v"+nb.orig_nbformat+") to the current notebook " +
+            "format (v"+nb.nbformat+"). The next time you save this notebook, the " +
+            "current notebook format will be used.";
+            
+            if (nb.nbformat > nb.orig_nbformat) {
+                msg += " Older versions of IPython may not be able to read the new format.";
+            } else {
+                msg += " Some features of the original notebook may not be available.";
+            }
+            msg += " To preserve the original version, close the " +
+                "notebook without saving it.";
             dialog.modal({
                 notebook: this,
                 keyboard_manager: this.keyboard_manager,
@@ -2330,7 +2343,7 @@ define([
                     }
                 }
             });
-        } else if (orig_nbformat_minor !== undefined && nbmodel.nbformat_minor !== orig_nbformat_minor) {
+        } else if (orig_nbformat_minor !== undefined && nbmodel.nbformat_minor < orig_nbformat_minor) {
             var that = this;
             var orig_vs = 'v' + nbmodel.nbformat + '.' + orig_nbformat_minor;
             var this_vs = 'v' + nbmodel.nbformat + '.' + this.nbformat_minor;

--- a/IPython/nbformat/v3/nbformat.v3.schema.json
+++ b/IPython/nbformat/v3/nbformat.v3.schema.json
@@ -51,6 +51,11 @@
             "type": "integer",
             "minimum": 1
         },
+        "orig_nbformat_minor": {
+            "description": "Original notebook format (minor number) before converting the notebook between versions.",
+            "type": "integer",
+            "minimum": 0
+        },
         "worksheets" : {
             "description": "Array of worksheets",
             "type": "array",

--- a/IPython/nbformat/v4/convert.py
+++ b/IPython/nbformat/v4/convert.py
@@ -241,9 +241,11 @@ def downgrade(nb):
     cells = [ downgrade_cell(cell) for cell in nb.pop('cells') ]
     nb.worksheets = [v3.new_worksheet(cells=cells)]
     nb.metadata.setdefault('name', '')
-    nb.metadata.pop('orig_nbformat', None)
-    nb.metadata.pop('orig_nbformat_minor', None)
-
+    
     # Validate the converted notebook before returning it
     _warn_if_invalid(nb, v3.nbformat)
+    
+    nb.orig_nbformat = nb.metadata.pop('orig_nbformat', nbformat)
+    nb.orig_nbformat_minor = nb.metadata.pop('orig_nbformat_minor', nbformat_minor)
+    
     return nb


### PR DESCRIPTION
- don't assume converted notebooks are old in notebook UI
- set orig_nbformat keys when downgrading v4->v3
