### PR TITLE
deprecate heading cells in UI

### DIFF
--- a/IPython/html/static/notebook/js/maintoolbar.js
+++ b/IPython/html/static/notebook/js/maintoolbar.js
@@ -139,6 +139,7 @@ define([
                 .append($('<option/>').attr('value','code').text('Code'))
                 .append($('<option/>').attr('value','markdown').text('Markdown'))
                 .append($('<option/>').attr('value','raw').text('Raw NBConvert'))
+                .append($('<option/>').attr('value','heading').text('Heading'))
             );
     };
 
@@ -193,6 +194,11 @@ define([
                 break;
             case 'raw':
                 that.notebook.to_raw();
+                break;
+            case 'heading':
+                that.notebook._warn_heading();
+                that.notebook.to_heading();
+                that.element.find('#cell_type').val("markdown");
                 break;
             default:
                 console.log("unrecognized cell type:", cell_type);

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -246,24 +246,6 @@ define([
         this.element.find('#to_raw').click(function () {
             that.notebook.to_raw();
         });
-        this.element.find('#to_heading1').click(function () {
-            that.notebook.to_heading(undefined, 1);
-        });
-        this.element.find('#to_heading2').click(function () {
-            that.notebook.to_heading(undefined, 2);
-        });
-        this.element.find('#to_heading3').click(function () {
-            that.notebook.to_heading(undefined, 3);
-        });
-        this.element.find('#to_heading4').click(function () {
-            that.notebook.to_heading(undefined, 4);
-        });
-        this.element.find('#to_heading5').click(function () {
-            that.notebook.to_heading(undefined, 5);
-        });
-        this.element.find('#to_heading6').click(function () {
-            that.notebook.to_heading(undefined, 6);
-        });
         
         this.element.find('#toggle_current_output').click(function () {
             that.notebook.toggle_output();

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1080,49 +1080,40 @@ define([
             }
         }
     };
-
+    
+    Notebook.prototype._warn_heading = function () {
+        // warn about heading cells being removed
+        dialog.modal({
+            notebook: this,
+            keyboard_manager: this.keyboard_manager,
+            title : "Use markdown headings",
+            body : $("<p/>").text(
+                'IPython no longer uses special heading cells. ' + 
+                'Instead, write your headings in Markdown cells using # characters:'
+            ).append($('<pre/>').text(
+                '## This is a level 2 heading'
+            )),
+            buttons : {
+                "OK" : {},
+            }
+        });
+    };
+    
     /**
-     * Turn a cell into a heading cell.
+     * Turn a cell into a markdown cell with a heading.
      * 
      * @method to_heading
      * @param {Number} [index] A cell's index
-     * @param {Number} [level] A heading level (e.g., 1 becomes &lt;h1&gt;)
+     * @param {Number} [level] A heading level (e.g., 1 for h1)
      */
     Notebook.prototype.to_heading = function (index, level) {
+        this.to_markdown(index);
         level = level || 1;
         var i = this.index_or_selected(index);
         if (this.is_valid_cell_index(i)) {
-            var source_cell = this.get_cell(i);
-            var target_cell = null;
-            if (source_cell instanceof textcell.MarkdownCell) {
-                source_cell.set_heading_level(level);
-            } else {
-                target_cell = this.insert_cell_below('markdown',i);
-                var text = source_cell.get_text();
-                if (text === source_cell.placeholder) {
-                    text = '';
-                }
-                //metadata
-                target_cell.metadata = source_cell.metadata;
-                // We must show the editor before setting its contents
-                target_cell.unrender();
-                target_cell.set_text(text);
-                target_cell.set_heading_level(level);
-                // make this value the starting point, so that we can only undo
-                // to this state, instead of a blank cell
-                target_cell.code_mirror.clearHistory();
-                source_cell.element.remove();
-                this.select(i);
-                var cursor = source_cell.code_mirror.getCursor();
-                target_cell.code_mirror.setCursor(cursor);
-                if ((source_cell instanceof textcell.TextCell) && source_cell.rendered) {
-                    target_cell.render();
-                }
-            }
+            var cell = this.get_cell(i);
+            cell.set_heading_level(level);
             this.set_dirty(true);
-            this.events.trigger('selected_cell_type_changed.Notebook',
-                {'cell_type':'markdown',level:level}
-            );
         }
     };
 


### PR DESCRIPTION
- removed from Kernel Menu
- Main toolbar warns via shouty dialog
- keyboard shortcuts still work to make headings in markdown cells, with no warning
