### PR TITLE
fix overwriting modes in project like IJulia

### DIFF
--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1523,7 +1523,7 @@ define([
      * @method set_codemirror_mode
      */
     Notebook.prototype.set_codemirror_mode = function(newmode){
-        if (newmode === this.codemirror_mode) {
+        if (newmode === this.codemirror_mode || newmode === 'null') {
             return;
         }
         this.codemirror_mode = newmode;
@@ -1810,11 +1810,18 @@ define([
             this.events.trigger('spec_changed.Kernel', this.metadata.kernelspec);
         }
         
+        // IJulia, IHaskell, IRuby and a few other have stored that in MD. 
+        // we scan use it for now until they have language_info
+        var mdlang;
+        if(typeof(this.metadata.language)=='string'){
+            mdlang = this.metadata.language.toLowercase();
+        }
+
         // Set the codemirror mode from language_info metadata
-        if (this.metadata.language_info !== undefined) {
+        if (this.metadata.language_info !== undefined || mdlang !== undefined ) {
             var langinfo = this.metadata.language_info;
             // Mode 'null' should be plain, unhighlighted text.
-            var cm_mode = langinfo.codemirror_mode || langinfo.language || 'null'
+            var cm_mode = langinfo.codemirror_mode || langinfo.language || mdlang || 'null';
             this.set_codemirror_mode(cm_mode);
         }
         


### PR DESCRIPTION
Current IJulia custom.js works by setting the right option of CodeCell , but do not have (yet) kernelspec. 

This leads to master not using the mode set by IJulia, and defaulting to 'null' which remove highlight.

This seem to do the trick by leaving default highliht mode and/or respecting metadata.language which is set by  alot of projects. 
