### PR TITLE
Create new terminals with POST request to API

### DIFF
--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -158,6 +158,10 @@ class IPythonHandler(AuthenticatedHandler):
         return self.settings['session_manager']
     
     @property
+    def terminal_manager(self):
+        return self.settings['terminal_manager']
+    
+    @property
     def kernel_spec_manager(self):
         return self.settings['kernel_spec_manager']
 

--- a/IPython/html/static/tree/js/terminallist.js
+++ b/IPython/html/static/tree/js/terminallist.js
@@ -49,7 +49,10 @@ define([
                 var name = data.name;
                 w.location = utils.url_join_encode(base_url, 'terminals', name);
             },
-            error : utils.log_ajax_error,
+            error : function(jqXHR, status, error){
+                w.close();
+                utils.log_ajax_error(jqXHR, status, error);
+            },
         };
         var url = utils.url_join_encode(
             this.base_url,

--- a/IPython/html/static/tree/js/terminallist.js
+++ b/IPython/html/static/tree/js/terminallist.js
@@ -40,19 +40,14 @@ define([
     };
 
     TerminalList.prototype.new_terminal = function () {
+        var w = window.open();
+        var base_url = this.base_url;
         var settings = {
             type : "POST",
-            cache : false,
-            async : false,
+            dataType: "json",
             success : function (data, status, xhr) {
                 var name = data.name;
-                window.open(
-                    utils.url_join_encode(
-                        this.base_url,
-                        'terminals',
-                        name),
-                    '_blank'
-                );
+                w.location = utils.url_join_encode(base_url, 'terminals', name);
             },
             error : utils.log_ajax_error,
         };

--- a/IPython/html/static/tree/js/terminallist.js
+++ b/IPython/html/static/tree/js/terminallist.js
@@ -39,11 +39,30 @@ define([
         $('#new_terminal').click($.proxy(this.new_terminal, this));
     };
 
-    TerminalList.prototype.new_terminal = function() {
-        var url = utils.url_join_encode(this.base_url, 'terminals/new');
-        window.open(url, '_blank');
+    TerminalList.prototype.new_terminal = function () {
+        var settings = {
+            type : "POST",
+            cache : false,
+            async : false,
+            success : function (data, status, xhr) {
+                var name = data.name;
+                window.open(
+                    utils.url_join_encode(
+                        this.base_url,
+                        'terminals',
+                        name),
+                    '_blank'
+                );
+            },
+            error : utils.log_ajax_error,
+        };
+        var url = utils.url_join_encode(
+            this.base_url,
+            'api/terminals'
+        );
+        $.ajax(url, settings);
     };
-
+    
     TerminalList.prototype.load_terminals = function() {
         var that = this;
         var url = utils.url_join_encode(this.base_url, 'api/terminals');

--- a/IPython/html/terminal/__init__.py
+++ b/IPython/html/terminal/__init__.py
@@ -1,18 +1,17 @@
 import os
 from terminado import NamedTermManager
 from IPython.html.utils import url_path_join as ujoin
-from .handlers import TerminalHandler, NewTerminalHandler, TermSocket
+from .handlers import TerminalHandler, TermSocket
 from . import api_handlers
 
 def initialize(webapp):
     shell = os.environ.get('SHELL', 'sh')
-    webapp.terminal_manager = NamedTermManager(shell_command=[shell])
+    terminal_manager = webapp.settings['terminal_manager'] = NamedTermManager(shell_command=[shell])
     base_url = webapp.settings['base_url']
     handlers = [
-        (ujoin(base_url, "/terminals/new"), NewTerminalHandler),
         (ujoin(base_url, r"/terminals/(\w+)"), TerminalHandler),
         (ujoin(base_url, r"/terminals/websocket/(\w+)"), TermSocket,
-             {'term_manager': webapp.terminal_manager}),
+             {'term_manager': terminal_manager}),
         (ujoin(base_url, r"/api/terminals"), api_handlers.TerminalRootHandler),
         (ujoin(base_url, r"/api/terminals/(\w+)"), api_handlers.TerminalHandler),
     ]

--- a/IPython/html/terminal/api_handlers.py
+++ b/IPython/html/terminal/api_handlers.py
@@ -1,14 +1,23 @@
 import json
 from tornado import web
 from ..base.handlers import IPythonHandler, json_errors
+from ..utils import url_path_join
 
 class TerminalRootHandler(IPythonHandler):
     @web.authenticated
     @json_errors
     def get(self):
-        tm = self.application.terminal_manager
+        tm = self.terminal_manager
         terms = [{'name': name} for name in tm.terminals]
         self.finish(json.dumps(terms))
+
+    @web.authenticated
+    @json_errors
+    def post(self):
+        """POST /terminals creates a new terminal and redirects to it"""
+        name, _ = self.terminal_manager.new_named_terminal()
+        self.finish(json.dumps({'name': name}))
+
 
 class TerminalHandler(IPythonHandler):
     SUPPORTED_METHODS = ('GET', 'DELETE')
@@ -16,7 +25,7 @@ class TerminalHandler(IPythonHandler):
     @web.authenticated
     @json_errors
     def get(self, name):
-        tm = self.application.terminal_manager
+        tm = self.terminal_manager
         if name in tm.terminals:
             self.finish(json.dumps({'name': name}))
         else:
@@ -25,7 +34,7 @@ class TerminalHandler(IPythonHandler):
     @web.authenticated
     @json_errors
     def delete(self, name):
-        tm = self.application.terminal_manager
+        tm = self.terminal_manager
         if name in tm.terminals:
             tm.kill(name)
             # XXX: Should this wait for terminal to finish before returning?

--- a/IPython/html/terminal/handlers.py
+++ b/IPython/html/terminal/handlers.py
@@ -16,13 +16,6 @@ class TerminalHandler(IPythonHandler):
         self.write(self.render_template('terminal.html',
                    ws_path="terminals/websocket/%s" % term_name))
 
-class NewTerminalHandler(IPythonHandler):
-    """Redirect to a new terminal."""
-    @web.authenticated
-    def get(self):
-        name, _ = self.application.terminal_manager.new_named_terminal()
-        self.redirect(name, permanent=False)
-
 class TermSocket(terminado.TermSocket, IPythonHandler):
     def get(self, *args, **kwargs):
         if not self.get_current_user():


### PR DESCRIPTION
This is an alternative to #6846, building on that PR.

In this variant, we create the new window immediately, and then direct it to the newly created terminal when the AJAX response comes back, thereby avoiding the need for synchronous requests to get round popup blockers. This is approach 2 discussed in issue #6849.
