### PR TITLE
Open new windows before creating new notebooks

### DIFF
--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -88,19 +88,19 @@ define([
         //  File
         var that = this;
         this.element.find('#new_notebook').click(function () {
+            var w = window.open();
             // Create a new notebook in the same path as the current
             // notebook's path.
             var parent = utils.url_path_split(that.notebook.notebook_path)[0];
             that.contents.new_untitled(parent, {
                     type: "notebook",
-                    extra_settings: {async: false},  // So we can open a new window afterwards
                     success: function (data) {
-                        window.open(
-                            utils.url_join_encode(
+                        w.location = utils.url_join_encode(
                                 that.base_url, 'notebooks', data.path
-                            ), '_blank');
+                            );
                         },
                     error: function(error) {
+                        w.close();
                         dialog.modal({
                             title : 'Creating Notebook Failed',
                             body : "The error was: " + error.message,

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1892,7 +1892,7 @@ define([
      * 
      * @method save_notebook
      */
-    Notebook.prototype.save_notebook = function (extra_settings) {
+    Notebook.prototype.save_notebook = function () {
         // Create a JSON model to be sent to the server.
         var model = {
             type : "notebook",
@@ -1903,7 +1903,6 @@ define([
 
         var that = this;
         this.contents.save(this.notebook_path, model, {
-                extra_settings: extra_settings,
                 success: $.proxy(this.save_notebook_success, this, start),
                 error: function (error) {
                     that.events.trigger('notebook_save_failed.Notebook', error);
@@ -1977,7 +1976,7 @@ define([
      *
      * @method trust_notebook
      */
-    Notebook.prototype.trust_notebook = function (extra_settings) {
+    Notebook.prototype.trust_notebook = function () {
         var body = $("<div>").append($("<p>")
             .text("A trusted IPython notebook may execute hidden malicious code ")
             .append($("<strong>")
@@ -2024,15 +2023,18 @@ define([
 
     Notebook.prototype.copy_notebook = function(){
         var base_url = this.base_url;
+        var w = window.open();
         var parent = utils.url_path_split(this.notebook_path)[0];
         this.contents.copy(this.notebook_path, parent, {
-            // synchronous so we can open a new window on success
-            extra_settings: {async: false},
             success: function (data) {
-                window.open(utils.url_join_encode(
+                w.location = utils.url_join_encode(
                     base_url, 'notebooks', data.path
-                ), '_blank');
-            }
+                );
+            },
+            error : function(error) {
+                w.close();
+                console.log(error);
+            },
         });
     };
 

--- a/IPython/html/static/services/contents.js
+++ b/IPython/html/static/services/contents.js
@@ -114,9 +114,6 @@ define([
             success : options.success || function() {},
             error : this.create_basic_error_handler(options.error)
         };
-        if (options.extra_settings) {
-            $.extend(settings, options.extra_settings);
-        }
         $.ajax(this.api_url(path), settings);
     };
 

--- a/IPython/html/static/services/contents.js
+++ b/IPython/html/static/services/contents.js
@@ -162,9 +162,6 @@ define([
             success : options.success || function() {},
             error : this.create_basic_error_handler(options.error)
         };
-        if (options.extra_settings) {
-            $.extend(settings, options.extra_settings);
-        }
         var url = this.api_url(path);
         $.ajax(url, settings);
     };
@@ -182,9 +179,6 @@ define([
             success: options.success || function() {},
             error: this.create_basic_error_handler(options.error)
         };
-        if (options.extra_settings) {
-            $.extend(settings, options.extra_settings);
-        }
         $.ajax(url, settings);
     };
 

--- a/IPython/html/static/tree/js/main.js
+++ b/IPython/html/static/tree/js/main.js
@@ -64,17 +64,16 @@ require([
     var login_widget = new loginwidget.LoginWidget('#login_widget', common_options);
 
     $('#new_notebook').click(function (e) {
+        var w = window.open();
         contents.new_untitled(common_options.notebook_path, {
                 type: "notebook",
-                extra_settings: {async: false},  // So we can open a new window afterwards
                 success: function (data) {
-                    window.open(
-                        utils.url_join_encode(
-                            common_options.base_url, 'notebooks',
-                            data.path
-                        ), '_blank');
+                    w.location = utils.url_join_encode(
+                            common_options.base_url, 'notebooks', data.path
+                        );
                     },
                 error: function(error) {
+                    w.close();
                     dialog.modal({
                         title : 'Creating Notebook Failed',
                         body : "The error was: " + error.message,

--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -318,7 +318,7 @@ define([
                 // We use the filename from the parent list_item element's
                 // data because the outer scope's values change as we iterate through the loop.
                 var parent_item = that.parents('div.list_item');
-                var name = parent_item.data('nbname');
+                var name = parent_item.data('name');
                 var path = parent_item.data('path');
                 var message = 'Are you sure you want to permanently delete the file: ' + name + '?';
                 dialog.modal({
@@ -345,7 +345,7 @@ define([
 
     NotebookList.prototype.notebook_deleted = function(path) {
         // Remove the deleted notebook.
-        $( ":data(nbname)" ).each(function() {
+        $( ":data(path)" ).each(function() {
             var element = $(this);
             if (element.data("path") == path) {
                 element.remove();


### PR DESCRIPTION
Point the new window to the target location when the AJAX response arrives. Avoids the need for synchronous requests to beat pop-up blockers, and more cleanly separates the contents API from the UI.

Companion of #6854, which does the same for terminals. See also discussion in #6849.
