### PR TITLE
Fix bug cell toolbars not redrawing on metadata change

### DIFF
--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -45,7 +45,18 @@ define([
         this.selected = false;
         this.rendered = false;
         this.mode = 'command';
-        this.metadata = {};
+
+        // Metadata property
+        var that = this;
+        this._metadata = {};
+        Object.defineProperty(this, 'metadata', {
+            get: function() { return that._metadata; },
+            set: function(value) {
+                that._metadata = value;
+                that.celltoolbar.rebuild();
+            }
+        });
+
         // load this from metadata later ?
         this.user_highlight = 'auto';
         this.cm_config = config.cm_config;
@@ -392,16 +403,6 @@ define([
      */
     Cell.prototype.set_text = function (text) {
     };
- 
-    /**
-     * Set the metadata of the cell and triggers the celltoolbars to update.
-     * @method set_metadata
-     * @param {dictionary} metadata
-     */
-    Cell.prototype.set_metadata = function (metadata) {
-       this.metadata = metadata;
-       this.celltoolbar.rebuild();
-    };
 
     /**
      * should be overritten by subclass
@@ -422,9 +423,8 @@ define([
      **/
     Cell.prototype.fromJSON = function (data) {
         if (data.metadata !== undefined) {
-            this.set_metadata(data.metadata);
+            this.metadata = data.metadata;
         }
-        this.celltoolbar.rebuild();
     };
 
 

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -392,6 +392,16 @@ define([
      */
     Cell.prototype.set_text = function (text) {
     };
+ 
+    /**
+     * Set the metadata of the cell and triggers the celltoolbars to update.
+     * @method set_metadata
+     * @param {dictionary} metadata
+     */
+    Cell.prototype.set_metadata = function (metadata) {
+       this.metadata = metadata;
+       this.celltoolbar.rebuild();
+    };
 
     /**
      * should be overritten by subclass
@@ -406,14 +416,13 @@ define([
         return data;
     };
 
-
     /**
      * should be overritten by subclass
      * @method fromJSON
      **/
     Cell.prototype.fromJSON = function (data) {
         if (data.metadata !== undefined) {
-            this.metadata = data.metadata;
+            this.set_metadata(data.metadata);
         }
         this.celltoolbar.rebuild();
     };

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -995,7 +995,7 @@ define([
                     text = '';
                 }
                 //metadata
-                target_cell.set_metadata(source_cell.metadata);
+                target_cell.metadata = source_cell.metadata;
 
                 target_cell.set_text(text);
                 // make this value the starting point, so that we can only undo
@@ -1029,7 +1029,7 @@ define([
                     text = '';
                 }
                 // metadata
-                target_cell.set_metadata(source_cell.metadata);
+                target_cell.metadata = source_cell.metadata;
                 // We must show the editor before setting its contents
                 target_cell.unrender();
                 target_cell.set_text(text);
@@ -1067,7 +1067,7 @@ define([
                     text = '';
                 }
                 //metadata
-                target_cell.set_metadata(source_cell.metadata);
+                target_cell.metadata = source_cell.metadata;
                 // We must show the editor before setting its contents
                 target_cell.unrender();
                 target_cell.set_text(text);

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -995,7 +995,7 @@ define([
                     text = '';
                 }
                 //metadata
-                target_cell.metadata = source_cell.metadata;
+                target_cell.set_metadata(source_cell.metadata);
 
                 target_cell.set_text(text);
                 // make this value the starting point, so that we can only undo
@@ -1029,7 +1029,7 @@ define([
                     text = '';
                 }
                 // metadata
-                target_cell.metadata = source_cell.metadata
+                target_cell.set_metadata(source_cell.metadata);
                 // We must show the editor before setting its contents
                 target_cell.unrender();
                 target_cell.set_text(text);
@@ -1067,7 +1067,7 @@ define([
                     text = '';
                 }
                 //metadata
-                target_cell.metadata = source_cell.metadata;
+                target_cell.set_metadata(source_cell.metadata);
                 // We must show the editor before setting its contents
                 target_cell.unrender();
                 target_cell.set_text(text);


### PR DESCRIPTION
Fix bug where cell toolbars are not redrawn when cell metadata is changed.

Extracted from https://github.com/ipython/ipython/pull/6638 which will be changed into an extension.
