### PR TITLE
DEV: Add support for profile-based jinja template overrides.

### DIFF
--- a/IPython/core/profiledir.py
+++ b/IPython/core/profiledir.py
@@ -40,11 +40,13 @@ class ProfileDir(LoggingConfigurable):
     startup_dir_name = Unicode('startup')
     pid_dir_name = Unicode('pid')
     static_dir_name = Unicode('static')
+    template_dir_name = Unicode('templates')
     security_dir = Unicode(u'')
     log_dir = Unicode(u'')
     startup_dir = Unicode(u'')
     pid_dir = Unicode(u'')
     static_dir = Unicode(u'')
+    template_dir = Unicode(u'')
 
     location = Unicode(u'', config=True,
         help="""Set the profile location directly. This overrides the logic used by the
@@ -65,6 +67,7 @@ class ProfileDir(LoggingConfigurable):
         self.startup_dir = os.path.join(new, self.startup_dir_name)
         self.pid_dir = os.path.join(new, self.pid_dir_name)
         self.static_dir = os.path.join(new, self.static_dir_name)
+        self.template_dir = os.path.join(new, self.template_dir_name)
         self.check_dirs()
 
     def _log_dir_changed(self, name, old, new):
@@ -151,12 +154,19 @@ class ProfileDir(LoggingConfigurable):
             if not os.path.exists(dest):
                 shutil.copy(src, dest)
 
+    def _template_dir_changed(self, name, old, new):
+        self.check_template_dir()
+
+    def check_template_dir(self):
+        self._mkdir(self.template_dir)
+
     def check_dirs(self):
         self.check_security_dir()
         self.check_log_dir()
         self.check_pid_dir()
         self.check_startup_dir()
         self.check_static_dir()
+        self.check_template_dir()
 
     def copy_config_file(self, config_file, path=None, overwrite=False):
         """Copy a default config file into the active profile directory.

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -138,7 +138,15 @@ class NotebookWebApplication(web.Application):
                       log, base_url, default_url, settings_overrides,
                       jinja_env_options=None):
 
-        _template_path = settings_overrides.get("template_path", os.path.join(os.path.dirname(__file__), "templates"))
+        _default_template_path = [
+            ipython_app.profile_dir.template_dir,
+            os.path.join(os.path.dirname(__file__), "templates"),
+        ]
+
+        _template_path = settings_overrides.get(
+            "template_path",
+            _default_template_path,
+        )
         if isinstance(_template_path, str):
             _template_path = (_template_path,)
         template_path = [os.path.expanduser(path) for path in _template_path]


### PR DESCRIPTION
Adds support for a `/templates` directory in ipython profiles that can override the default jinja templates.

Proposed solution for https://github.com/ipython/ipython/issues/6856
