### PR TITLE
upgrading >v4 header cells to unicode

### DIFF
--- a/IPython/nbformat/v4/convert.py
+++ b/IPython/nbformat/v4/convert.py
@@ -91,7 +91,7 @@ def upgrade_cell(cell):
     elif cell.cell_type == 'heading':
         cell.cell_type = 'markdown'
         level = cell.pop('level', 1)
-        cell.source = '{hashes} {single_line}'.format(
+        cell.source = u'{hashes} {single_line}'.format(
             hashes='#' * level,
             single_line = ' '.join(cell.get('source', '').splitlines()),
         )

--- a/IPython/nbformat/v4/tests/test_convert.py
+++ b/IPython/nbformat/v4/tests/test_convert.py
@@ -35,8 +35,8 @@ def test_upgrade_heading():
             v4m(source='#### foo bar multi-line'),
         ),
         (
-            v3h(source='unicode–conversion', level=4),
-            v4m(source=u'#### unicode–conversion'),
+            v3h(source='ünìcö∂e–cønvërsioñ', level=4),
+            v4m(source=u'#### ünìcö∂e–cønvërsioñ'),
         ),
     ]:
         upgraded = convert.upgrade_cell(v3cell)

--- a/IPython/nbformat/v4/tests/test_convert.py
+++ b/IPython/nbformat/v4/tests/test_convert.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import copy
 
 import nose.tools as nt
@@ -32,6 +33,10 @@ def test_upgrade_heading():
         (
             v3h(source='foo\nbar\nmulti-line\n', level=4),
             v4m(source='#### foo bar multi-line'),
+        ),
+        (
+            v3h(source='unicode–conversion', level=4),
+            v4m(source=u'#### unicode–conversion'),
         ),
     ]:
         upgraded = convert.upgrade_cell(v3cell)


### PR DESCRIPTION
These were causing errors downstream in nbviewer, specifically `test_url.URLTestCase`, specifically [this header](http://nbviewer.ipython.org/url/jdj.mit.edu/~stevenj/IJulia%20Preview.ipynb#Julia–Python-interoperability:-SciPy-and-Matplotlib).

I suppose the test could use a more visually recognizable unicode character than `\u2013`, but that was the example I had from the wild.
