### PR TITLE
fix unicode literal in v4.test_convert

### DIFF
--- a/IPython/nbformat/v4/tests/test_convert.py
+++ b/IPython/nbformat/v4/tests/test_convert.py
@@ -35,7 +35,7 @@ def test_upgrade_heading():
             v4m(source='#### foo bar multi-line'),
         ),
         (
-            v3h(source='ünìcö∂e–cønvërsioñ', level=4),
+            v3h(source=u'ünìcö∂e–cønvërsioñ', level=4),
             v4m(source=u'#### ünìcö∂e–cønvërsioñ'),
         ),
     ]:


### PR DESCRIPTION
caused failure on Python 2 on Windows

because unicode!
