### PR TITLE
Add JS config API

### DIFF
--- a/IPython/html/static/services/config.js
+++ b/IPython/html/static/services/config.js
@@ -24,7 +24,7 @@ function($, utils) {
     };
 
     ConfigSection.prototype.api_url = function() {
-        return utils.url_join_encode(this.base_url, 'api/config', that.section_name);
+        return utils.url_join_encode(this.base_url, 'api/config', this.section_name);
     };
     
     ConfigSection.prototype._load_done = function() {
@@ -35,18 +35,20 @@ function($, utils) {
     };
     
     ConfigSection.prototype.load = function() {
+        var that = this;
         return utils.promising_ajax(this.api_url(), {
             cache: false,
             type: "GET",
             dataType: "json",
         }).then(function(data) {
-            this.data = data;
-            this._load_done();
+            that.data = data;
+            that._load_done();
             return data;
         });
     };
     
     ConfigSection.prototype.update = function(newdata) {
+        var that = this;
         return utils.promising_ajax(this.api_url(), {
             processData: false,
             type : "PATCH",
@@ -54,8 +56,8 @@ function($, utils) {
             dataType : "json",
             contentType: 'application/json',
         }).then(function(data) {
-            this.data = data;
-            this._load_done();
+            that.data = data;
+            that._load_done();
             return data;
         });
     };

--- a/IPython/html/static/services/config.js
+++ b/IPython/html/static/services/config.js
@@ -35,45 +35,28 @@ function($, utils) {
     };
     
     ConfigSection.prototype.load = function() {
-        var p = new Promise(function(resolve, reject) {
-            $.ajax(this.api_url(), {
-                cache : false,
-                type : "GET",
-                dataType : "json",
-                success: function(data, status, jqXHR) {
-                    this.data = data;
-                    this._load_done();
-                    resolve(data);
-                },
-                error: function(jqXHR, status, error) {
-                    // Should never happen; mark as loaded so things don't keep
-                    // waiting.
-                    this._load_done();
-                    utils.log_ajax_error(jqXHR, status, error);
-                    reject(utils.wrap_ajax_error(jqXHR, status, error));
-                }
-            });
+        return utils.promising_ajax(this.api_url(), {
+            cache: false,
+            type: "GET",
+            dataType: "json",
+        }).then(function(data) {
+            this.data = data;
+            this._load_done();
+            return data;
         });
     };
     
     ConfigSection.prototype.update = function(newdata) {
-        return new Promise(function(resolve, reject) {
-            $.ajax(this.api_url(), {
-                processData: false,
-                type : "PATCH",
-                data: JSON.stringify(newdata),
-                dataType : "json",
-                contentType: 'application/json',
-                success: function(data, status, jqXHR) {
-                    this.data = data;
-                    this._load_done();
-                    resolve(data);
-                },
-                error: function(jqXHR, status, error) {
-                    utils.log_ajax_error(jqXHR, status, error);
-                    reject(utils.wrap_ajax_error(jqXHR, status, error));
-                }
-            });
+        return utils.promising_ajax(this.api_url(), {
+            processData: false,
+            type : "PATCH",
+            data: JSON.stringify(newdata),
+            dataType : "json",
+            contentType: 'application/json',
+        }).then(function(data) {
+            this.data = data;
+            this._load_done();
+            return data;
         });
     };
 

--- a/IPython/html/static/services/config.js
+++ b/IPython/html/static/services/config.js
@@ -1,0 +1,80 @@
+// Copyright (c) IPython Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+define([
+    'jquery',
+    'base/js/utils',
+    ],
+function($, utils) {
+    var ConfigSection = function(section_name, options) {
+        this.section_name = section_name;
+        this.base_url = options.base_url;
+        this.data = {};
+        
+        var that = this;
+        
+        /* .loaded is a promise, fulfilled the first time the config is loaded
+         * from the server. Code can do:
+         *      conf.loaded.then(function() { ... using conf.data ... });
+         */
+        this._one_load_finished = false;
+        this.loaded = new Promise(function(resolve, reject) {
+            that._finish_firstload = resolve;
+        });
+    };
+
+    ConfigSection.prototype.api_url = function() {
+        return utils.url_join_encode(this.base_url, 'api/config', that.section_name);
+    };
+    
+    ConfigSection.prototype._load_done = function() {
+        if (!this._one_load_finished) {
+            this._one_load_finished = true;
+            this._finish_firstload();
+        }
+    };
+    
+    ConfigSection.prototype.load = function() {
+        var p = new Promise(function(resolve, reject) {
+            $.ajax(this.api_url(), {
+                cache : false,
+                type : "GET",
+                dataType : "json",
+                success: function(data, status, jqXHR) {
+                    this.data = data;
+                    this._load_done();
+                    resolve(data);
+                },
+                error: function(jqXHR, status, error) {
+                    // Should never happen; mark as loaded so things don't keep
+                    // waiting.
+                    this._load_done();
+                    utils.log_ajax_error(jqXHR, status, error);
+                    reject(utils.wrap_ajax_error(jqXHR, status, error));
+                }
+            });
+        });
+    };
+    
+    ConfigSection.prototype.update = function(newdata) {
+        return new Promise(function(resolve, reject) {
+            $.ajax(this.api_url(), {
+                processData: false;
+                type : "PATCH",
+                data: JSON.stringify(newdata),
+                dataType : "json",
+                contentType: 'application/json',
+                success: function(data, status, jqXHR) {
+                    this.data = data;
+                    this._load_done();
+                    resolve(data);
+                },
+                error: function(jqXHR, status, error) {
+                    utils.log_ajax_error(jqXHR, status, error);
+                    reject(utils.wrap_ajax_error(jqXHR, status, error));
+                }
+            });
+        });
+    };
+
+});

--- a/IPython/html/static/services/config.js
+++ b/IPython/html/static/services/config.js
@@ -59,7 +59,7 @@ function($, utils) {
     ConfigSection.prototype.update = function(newdata) {
         return new Promise(function(resolve, reject) {
             $.ajax(this.api_url(), {
-                processData: false;
+                processData: false,
                 type : "PATCH",
                 data: JSON.stringify(newdata),
                 dataType : "json",

--- a/IPython/html/static/services/config.js
+++ b/IPython/html/static/services/config.js
@@ -59,5 +59,7 @@ function($, utils) {
             return data;
         });
     };
+    
+    return {ConfigSection: ConfigSection};
 
 });


### PR DESCRIPTION
This depends on #6694 for the server side part of the config API, and on #6818 for the promises polyfill for certain browsers.

It adds a JS API for the config service, which would be used like this:

``` javascript
// initialisation code in main.js
config = config.ConfigSection('notebook', {base_url: base_url});
config.load();  // async!


// later code that wants to use config
config.loaded.then(function() {
    do_something_with(config.data.key || default);
});

// Code changing config
config.update({key: 'new value'});  // async!
```

Both `load()` and `update()` return a promise. :horse: 
