### PR TITLE
Add matplotlib cell magic

### DIFF
--- a/IPython/core/magics/pylab.py
+++ b/IPython/core/magics/pylab.py
@@ -38,7 +38,7 @@ magic_gui_arg = magic_arguments.argument(
 @magics_class
 class PylabMagics(Magics):
     """Magics related to matplotlib's pylab support"""
-    
+
     @skip_doctest
     @line_cell_magic
     @magic_arguments.magic_arguments()
@@ -88,7 +88,15 @@ class PylabMagics(Magics):
             In [4]: %%matplotlib inline
         """
         if cell is not None:
-            previous_gui = self.shell.pylab_gui_select
+            if self.shell.pylab_gui_select is None:
+                # Check if the inline backend is active
+                import matplotlib
+                if matplotlib.rcParams["backend"] == backends["inline"]:
+                    previous_gui = "inline"
+                else:
+                    previous_gui = None
+            else:
+                previous_gui = self.shell.pylab_gui_select
         args = magic_arguments.parse_argstring(self.matplotlib, line)
         gui, backend = self.shell.enable_matplotlib(args.gui)
         self._show_matplotlib_backend(args.gui, backend)

--- a/docs/source/whatsnew/pr/matplotlib_cell_magic.rst
+++ b/docs/source/whatsnew/pr/matplotlib_cell_magic.rst
@@ -1,0 +1,4 @@
+* The :magic:`matplotlib` magic can now act as a cell magic, in which case, the
+  matplotlib backend is reverted back to its previous value after the execution
+  of the cell. If matplotlib interactive support was not active, the choosen
+  backend remains active.


### PR DESCRIPTION
In my workflow I often activate the matplotlib inline backend to execute one cell and I go back to the previous backend afterwards. I use the maplotlib line magic for that but I find that this could be done more conveniently if there was a matplotlib cell magic. This pull request modifies the matplotlib line magic to make it work also as a cell magic.
