### PR TITLE
Ensure commands needed for PDF/Bibtex are installed on the path.

### DIFF
--- a/IPython/nbconvert/exporters/pdf.py
+++ b/IPython/nbconvert/exporters/pdf.py
@@ -59,7 +59,7 @@ class PDFExporter(LatexExporter):
         command = [c.format(filename=filename) for c in command_list]
         #In windows and python 2.x there is a bug in subprocess.Popen and
         # unicode commands are not supported
-        if sys.platform == 'win32' and sys.version_info < (3,0):
+        if sys.platform == 'win32' or sys.version_info < (3,0):
             #We must use cp1252 encoding for calling subprocess.Popen
             #Note that sys.stdin.encoding and encoding.DEFAULT_ENCODING
             # could be different (cp437 in case of dos console)

--- a/IPython/nbconvert/exporters/pdf.py
+++ b/IPython/nbconvert/exporters/pdf.py
@@ -98,10 +98,8 @@ class PDFExporter(LatexExporter):
         def log_error(command, out):
             self.log.critical(u"%s failed: %s\n%s", command[0], command, out)
 
-        the_cmd = self.latex_command[0]
-        self.log.info("About to test shutil of Running : %s", self.latex_command[0])
         return self.run_command(self.latex_command, filename, 
-            self.latex_count, log_error) 
+            self.latex_count, log_error)
 
     def run_bib(self, filename):
         """Run bibtex self.latex_count times."""


### PR DESCRIPTION
Update; Changed Title 
from; [NBConvert] Bug Fix: PDF from Latex for Windows/Py2 change to or from and to or.
to; [NBConvert] Ensure commands needed for PDF/Bibtex are installed on the path.

See my second commit for the new fix. I was in error the problem that was occurring, thanks to @takluyver . 

//OLD INFO
I believe I found a small typo that causes errors for converting to PDF when running on a machine/python  with Unix/Python 2.x or Windows/3.x systems. The comment in the code says a popen error will occur without a given fix. The code should use 'or' not 'and' to test for that case. 

This patch makes the change to 'or'. It is not considered tested! So I have some questions for you if I may.

[]Q1.
I would like to add a test for this, but I do not know how to add the appropriate code to test for operating system and/or python version in this test file? 
https://github.com/ipython/ipython/blob/master/IPython/nbconvert/exporters/tests/test_pdf.py#L31

I do not see that Travis is even testing under different OS's? 
https://travis-ci.org/ipython/ipython

If Travis does give us OS/Python mix flavors, then maybe I can use distutils.version.LooseVersion to test the python version? 
https://github.com/ipython/ipython/blob/71256f5f771a542589ffe9780cba1dbea0bffafb/IPython/utils/version.py#L33
http://epydoc.sourceforge.net/stdlib/distutils.version.LooseVersion-class.html

To read the OS, it seems from sys import platform as _platform will work.
http://stackoverflow.com/questions/8220108/how-do-i-check-the-operating-system-in-python

[]Q2.Is another PR needed?
Note that my tests below are on IPython 2, wherein the PDF extractor has not yet been refactored to live in its new home, as per this patch. However, the code in question is the same on both IPython/master and on IPython/2 branch. I presume we only commit a PR to the master?

[]Q3. How will we know which parts should be part of Jupyter instead of IPython? 
https://github.com/jupyter

thank you!
AnneTheAgile

Details/Notes

Notice how the code said, before my commit; 
https://github.com/AnneTheAgile/ipython/blob/master/IPython/nbconvert/exporters/pdf.py#L60

```
 #In windows and python 2.x there is a bug in subprocess.Popen and
# unicode commands are not supported
 if sys.platform == 'win32' and sys.version_info < (3,0):
```

On Python 2 , Ipython 2, Mac system, I get the error that matches the #6263 bug report , "Failure of ipynb to PDF conversion · Issue #6263 on ipython/ipython", https://github.com/ipython/ipython/issues/6263

This is an edited output showing the failure; 

```
$ ipython nbconvert  try.ipynb --to latex --post PDF --debug

[NbConvertApp] Config changed:
[NbConvertApp] {'NbConvertApp': {'export_format': u'latex', 'log_level': 10, 'postprocessor_class': u'PDF'}}
[NbConvertApp] IPYTHONDIR set to: /Users/ME/.ipython
[NbConvertApp] Using existing profile dir: u'/Users/ME/.ipython/profile_default'
//etc
[NbConvertApp] Loaded template article.tplx
[NbConvertApp] Writing 32113 bytes to try.tex
[NbConvertApp] Building PDF
[NbConvertApp] Running pdflatex 3 times: [u'pdflatex', u'try.tex']
Traceback (most recent call last):
///etc
  File "/Users/ME/anaconda/lib/python2.7/site-packages/IPython/nbconvert/postprocessors/pdf.py", line 84, in run_command
    p = subprocess.Popen(command, stdout=stdout, stdin=null)
  File "/Users/ME/anaconda/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/Users/ME/anaconda/lib/python2.7/subprocess.py", line 1327, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory

```

FYI, the Latex part looks great, it can create a file and looking at it in the editor it looks ok.

```
$ ipython nbconvert --to latex try.ipynb

[NbConvertApp] Using existing profile dir: u'/Users/ME/.ipython/profile_default'
[NbConvertApp] Converting notebook try.ipynb to latex
[NbConvertApp] Support files will be in try_files/
[NbConvertApp] Loaded template article.tplx
[NbConvertApp] Writing 32113 bytes to try.tex

$ ls
a.txt       b.txt       try.ipynb   try.tex
$ nano try.tex
$ head ../bc-python/trygit/try.tex

% Default to the notebook output style
//etc
```

Previously I discussed this on SO, http://stackoverflow.com/questions/15998491/convert-ipython-notebooks-to-pdf-html/23984308?noredirect=1#comment42186512_23984308

Tip to find code related to this ticket; 
1.Search code 'exporter' https://github.com/ipython/ipython/search?utf8=%E2%9C%93&q=exporter
2.Search tix for 'pdf popen' https://github.com/ipython/ipython/issues?q=pdf+popen

//edit add Q3 Jupyter, one more ref.
