### PR TITLE
Using smartmenus restores submenus on small screens

### DIFF
--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -22,6 +22,8 @@ require([
     'notebook/js/kernelselector',
     'codemirror/lib/codemirror',
     'notebook/js/about',
+    'smartmenus/jquery.smartmenus.min',
+    'smartmenus/addons/bootstrap/jquery.smartmenus.bootstrap.min',
     // only loaded, not used, please keep sure this is loaded last
     'custom/custom'
 ], function(
@@ -45,6 +47,8 @@ require([
     kernelselector,
     CodeMirror,
     about,
+    smartmenus,
+    smartmenus_bs,
     // please keep sure that even if not used, this is loaded last
     custom
     ) {

--- a/IPython/html/static/notebook/less/menubar.less
+++ b/IPython/html/static/notebook/less/menubar.less
@@ -1,3 +1,5 @@
+@import (inline) "../components/smartmenus/dist/addons/bootstrap/jquery.smartmenus.bootstrap.css";
+
 #menubar {
   margin-top: 0px;
   margin-bottom: -19px;
@@ -51,12 +53,3 @@ ul#help_menu li a{
 #menus {
   min-height: 30px;
 }
-
-// Make sub menus work in BS3.
-// Credit: http://www.bootply.com/86684
-.dropdown-submenu{position:relative;}
-.dropdown-submenu>.dropdown-menu{top:0;left:100%;margin-top:-6px;margin-left:-1px;-webkit-border-radius:0 6px 6px 6px;-moz-border-radius:0 6px 6px 6px;border-radius:0 6px 6px 6px;}
-.dropdown-submenu:hover>.dropdown-menu{display:block;}
-.dropdown-submenu>a:after{display:block;content:" ";float:right;width:0;height:0;border-color:transparent;border-style:solid;border-width:5px 0 5px 5px;border-left-color:#cccccc;margin-top:5px;margin-right:-10px;}
-.dropdown-submenu:hover>a:after{border-left-color:#ffffff;}
-.dropdown-submenu.pull-left{float:none;}.dropdown-submenu.pull-left>.dropdown-menu{left:-100%;margin-left:10px;-webkit-border-radius:6px 0 6px 6px;-moz-border-radius:6px 0 6px 6px;border-radius:6px 0 6px 6px;}

--- a/IPython/html/templates/page.html
+++ b/IPython/html/templates/page.html
@@ -31,6 +31,7 @@
             codemirror: 'components/codemirror',
             termjs: "components/term.js/src/term",
             contents: '{{ contents_js_source }}',
+            smartmenus: 'components/smartmenus/dist',
           },
           shim: {
             underscore: {
@@ -55,6 +56,10 @@
             highlight: {
               exports: "hljs"
             },
+            smartmenus: {
+              deps: ["jquery"],
+              exports: "$"
+            }
           }
       });
     </script>


### PR DESCRIPTION
As one solution to #6759, this uses [smartmenus](https://github.com/vadikom/smartmenus) with its [bootstrap plugin](http://vadikom.github.io/smartmenus/src/demo/bootstrap-navbar.html) to make sure the menus work across devices.

iPhone example:
![2014-11-09_2123](https://cloud.githubusercontent.com/assets/45380/4970405/9e597faa-6880-11e4-8346-ad55ecd3e7d2.png)

Notes
- There are a few "extras" enabled by default, such as the caret and the show/hide effect, which can likely be turned off 
- This PR does not include the `components` upgrade, but smartmenus is listed on bower, etc.
