### PR TITLE
Better support for recursive/parameterized Traits.

### DIFF
--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -684,6 +684,20 @@ class TestThis(TestCase):
         self.assertEqual(f.t, b)
         self.assertRaises(TraitError, setattr, b, 't', f)
 
+    def test_this_in_container(self):
+
+        class Tree(HasTraits):
+            value = Unicode()
+            leaves = List(This())
+
+        tree = Tree(
+            value='foo',
+            leaves=[Tree('bar'), Tree('buzz')]
+        )
+
+        with self.assertRaises(TraitError):
+            tree.leaves = [1, 2]
+
 class TraitTestBase(TestCase):
     """A best testing class for basic trait types."""
 

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -969,23 +969,6 @@ class TestInstanceList(TraitTestBase):
     _good_values = [[Foo(), Foo(), None], None]
     _bad_values = [['1', 2,], '1', [Foo]]
 
-class ForwardDeclaredInstanceListTrait(HasTraits):
-
-    value = List(ForwardDeclaredInstance('Foo'))
-
-class TestForwardDeclaredInstanceList(TraitTestBase):
-
-    obj = ForwardDeclaredInstanceListTrait()
-
-    def test_klass(self):
-        """Test that the instance klass is properly assigned."""
-        self.assertIs(self.obj.traits()['value']._trait.klass, Foo)
-
-    _default_value = []
-    _good_values = [[Foo(), Foo(), None], None]
-    _bad_values = [['1', 2,], '1', [Foo]]
-
-
 class LenListTrait(HasTraits):
 
     value = List(Int, [0], minlen=1, maxlen=2)
@@ -1338,17 +1321,43 @@ class TestEventful(TestCase):
         # Is the output correct?
         self.assertEqual(a.x, {c: c for c in 'bz'})
 
+###
+# Traits for Forward Declaration Tests
+###
+class ForwardDeclaredInstanceTrait(HasTraits):
 
+    value = ForwardDeclaredInstance(klass='ForwardDeclaredBar')
+
+class ForwardDeclaredTypeTrait(HasTraits):
+
+    value = ForwardDeclaredType(klass='ForwardDeclaredBar')
+
+class ForwardDeclaredInstanceListTrait(HasTraits):
+
+    value = List(ForwardDeclaredInstance('ForwardDeclaredBar'))
+
+class ForwardDeclaredTypeListTrait(HasTraits):
+
+    value = List(ForwardDeclaredType('ForwardDeclaredBar'))
+###
+# End Traits for Forward Declaration Tests
+###
+
+###
+# Classes for Forward Declaration Tests
+###
 class ForwardDeclaredBar(object):
     pass
 
 class ForwardDeclaredBarSub(ForwardDeclaredBar):
     pass
+###
+# End Classes for Forward Declaration Tests
+###
 
-class ForwardDeclaredInstanceTrait(HasTraits):
-
-    value = ForwardDeclaredInstance(klass='ForwardDeclaredBar')
-
+###
+# Forward Declaration Tests
+###
 class TestForwardDeclaredInstanceTrait(TraitTestBase):
 
     obj = ForwardDeclaredInstanceTrait()
@@ -1356,14 +1365,58 @@ class TestForwardDeclaredInstanceTrait(TraitTestBase):
     _good_values = [None, ForwardDeclaredBar(), ForwardDeclaredBarSub()]
     _bad_values = ['foo', 3, ForwardDeclaredBar, ForwardDeclaredBarSub]
 
-
-class ForwardDeclaredTypeTrait(HasTraits):
-
-    value = ForwardDeclaredType(klass='ForwardDeclaredBar')
-
 class TestForwardDeclaredInstanceTrait(TraitTestBase):
 
     obj = ForwardDeclaredTypeTrait()
     _default_value = None
     _good_values = [None, ForwardDeclaredBar, ForwardDeclaredBarSub]
     _bad_values = ['foo', 3, ForwardDeclaredBar(), ForwardDeclaredBarSub()]
+
+class TestForwardDeclaredInstanceList(TraitTestBase):
+
+    obj = ForwardDeclaredInstanceListTrait()
+
+    def test_klass(self):
+        """Test that the instance klass is properly assigned."""
+        self.assertIs(self.obj.traits()['value']._trait.klass, ForwardDeclaredBar)
+
+    _default_value = []
+    _good_values = [
+        [ForwardDeclaredBar(), ForwardDeclaredBarSub(), None],
+        [None],
+        [],
+        None,
+    ]
+    _bad_values = [
+        ForwardDeclaredBar(),
+        [ForwardDeclaredBar(), 3],
+        '1',
+        # Note that this is the type, not an instance.
+        [ForwardDeclaredBar]
+    ]
+
+class TestForwardDeclaredTypeList(TraitTestBase):
+
+    obj = ForwardDeclaredTypeListTrait()
+
+    def test_klass(self):
+        """Test that the instance klass is properly assigned."""
+        self.assertIs(self.obj.traits()['value']._trait.klass, ForwardDeclaredBar)
+
+    _default_value = []
+    _good_values = [
+        [ForwardDeclaredBar, ForwardDeclaredBarSub, None],
+        [],
+        [None],
+        None,
+    ]
+    _bad_values = [
+        ForwardDeclaredBar,
+        [ForwardDeclaredBar, 3],
+        '1',
+        # Note that this is an instance, not the type.
+        [ForwardDeclaredBar()]
+    ]
+###
+# End Forward Declaration Tests
+###

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -1365,7 +1365,7 @@ class TestForwardDeclaredInstanceTrait(TraitTestBase):
     _good_values = [None, ForwardDeclaredBar(), ForwardDeclaredBarSub()]
     _bad_values = ['foo', 3, ForwardDeclaredBar, ForwardDeclaredBarSub]
 
-class TestForwardDeclaredInstanceTrait(TraitTestBase):
+class TestForwardDeclaredTypeTrait(TraitTestBase):
 
     obj = ForwardDeclaredTypeTrait()
     _default_value = None

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -20,7 +20,7 @@ from IPython.utils.traitlets import (
     Int, Long, Integer, Float, Complex, Bytes, Unicode, TraitError,
     Undefined, Type, This, Instance, TCPAddress, List, Tuple,
     ObjectName, DottedObjectName, CRegExp, link, directional_link,
-    EventfulList, EventfulDict
+    EventfulList, EventfulDict, ForwardDeclaredType, ForwardDeclaredInstance,
 )
 from IPython.utils import py3compat
 from IPython.testing.decorators import skipif
@@ -969,6 +969,23 @@ class TestInstanceList(TraitTestBase):
     _good_values = [[Foo(), Foo(), None], None]
     _bad_values = [['1', 2,], '1', [Foo]]
 
+class ForwardDeclaredInstanceListTrait(HasTraits):
+
+    value = List(ForwardDeclaredInstance('Foo'))
+
+class TestForwardDeclaredInstanceList(TraitTestBase):
+
+    obj = ForwardDeclaredInstanceListTrait()
+
+    def test_klass(self):
+        """Test that the instance klass is properly assigned."""
+        self.assertIs(self.obj.traits()['value']._trait.klass, Foo)
+
+    _default_value = []
+    _good_values = [[Foo(), Foo(), None], None]
+    _bad_values = [['1', 2,], '1', [Foo]]
+
+
 class LenListTrait(HasTraits):
 
     value = List(Int, [0], minlen=1, maxlen=2)
@@ -1320,3 +1337,33 @@ class TestEventful(TestCase):
 
         # Is the output correct?
         self.assertEqual(a.x, {c: c for c in 'bz'})
+
+
+class ForwardDeclaredBar(object):
+    pass
+
+class ForwardDeclaredBarSub(ForwardDeclaredBar):
+    pass
+
+class ForwardDeclaredInstanceTrait(HasTraits):
+
+    value = ForwardDeclaredInstance(klass='ForwardDeclaredBar')
+
+class TestForwardDeclaredInstanceTrait(TraitTestBase):
+
+    obj = ForwardDeclaredInstanceTrait()
+    _default_value = None
+    _good_values = [None, ForwardDeclaredBar(), ForwardDeclaredBarSub()]
+    _bad_values = ['foo', 3, ForwardDeclaredBar, ForwardDeclaredBarSub]
+
+
+class ForwardDeclaredTypeTrait(HasTraits):
+
+    value = ForwardDeclaredType(klass='ForwardDeclaredBar')
+
+class TestForwardDeclaredInstanceTrait(TraitTestBase):
+
+    obj = ForwardDeclaredTypeTrait()
+    _default_value = None
+    _good_values = [None, ForwardDeclaredBar, ForwardDeclaredBarSub]
+    _bad_values = ['foo', 3, ForwardDeclaredBar(), ForwardDeclaredBarSub()]

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -1326,11 +1326,11 @@ class TestEventful(TestCase):
 ###
 class ForwardDeclaredInstanceTrait(HasTraits):
 
-    value = ForwardDeclaredInstance(klass='ForwardDeclaredBar')
+    value = ForwardDeclaredInstance('ForwardDeclaredBar')
 
 class ForwardDeclaredTypeTrait(HasTraits):
 
-    value = ForwardDeclaredType(klass='ForwardDeclaredBar')
+    value = ForwardDeclaredType('ForwardDeclaredBar')
 
 class ForwardDeclaredInstanceListTrait(HasTraits):
 

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -819,7 +819,7 @@ class Type(ClassBasedTraitType):
         """Validates that the value is a valid object instance."""
         if isinstance(value, py3compat.string_types):
             try:
-                value = import_item(value)
+                value = self._resolve_string(value)
             except ImportError:
                 raise TraitError("The '%s' trait of %s instance must be a type, but "
                                 "%r could not be imported" % (self.name, obj, value))

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -967,6 +967,35 @@ class Instance(ClassBasedTraitType):
             return dv
 
 
+class ForwardDeclaredMixin(object):
+    """
+    Mixin for forward-declared versions of Instance and Type.
+    """
+    def _resolve_classes(self):
+        """
+        Find the specified class name by looking for it in the module in which
+        our this_class attribute was defined.
+        """
+        try:
+            modname = self.this_class.__module__
+            self.klass = import_item('.'.join([modname, self.klass]))
+        except AttributeError:
+            raise ImportError(
+                "Module {} has no attribute {}".format(modname, self.klass)
+            )
+
+class ForwardDeclaredType(ForwardDeclaredMixin, Type):
+    """
+    Forward-declared version of Type.
+    """
+    pass
+
+class ForwardDeclaredInstance(ForwardDeclaredMixin, Instance):
+    """
+    Forward-declared version of Instance.
+    """
+    pass
+
 class This(ClassBasedTraitType):
     """A trait for instances of the class containing this trait.
 

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -984,17 +984,20 @@ class ForwardDeclaredMixin(object):
                 "Module {} has no attribute {}".format(modname, self.klass)
             )
 
+
 class ForwardDeclaredType(ForwardDeclaredMixin, Type):
     """
     Forward-declared version of Type.
     """
     pass
 
+
 class ForwardDeclaredInstance(ForwardDeclaredMixin, Instance):
     """
     Forward-declared version of Instance.
     """
     pass
+
 
 class This(ClassBasedTraitType):
     """A trait for instances of the class containing this trait.

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -748,7 +748,10 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
 
 
 class ClassBasedTraitType(TraitType):
-    """A trait with error reporting for Type, Instance and This."""
+    """
+    A trait with error reporting and string -> type resolution for Type,
+    Instance and This.
+    """
 
     def _resolve_string(self, string):
         """

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -985,13 +985,8 @@ class ForwardDeclaredMixin(object):
         Find the specified class name by looking for it in the module in which
         our this_class attribute was defined.
         """
-        try:
-            modname = self.this_class.__module__
-            return import_item('.'.join([modname, string]))
-        except AttributeError:
-            raise ImportError(
-                "Module {} has no attribute {}".format(modname, string)
-            )
+        modname = self.this_class.__module__
+        return import_item('.'.join([modname, string]))
 
 
 class ForwardDeclaredType(ForwardDeclaredMixin, Type):

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -1388,7 +1388,7 @@ class Container(Instance):
     def instance_init(self, obj):
         if isinstance(self._trait, TraitType):
             self._trait.this_class = self.this_class
-        if isinstance(self._trait, Instance):
+        if hasattr(self._trait, '_resolve_classes'):
             self._trait._resolve_classes()
         super(Container, self).instance_init(obj)
 

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -1354,6 +1354,8 @@ class Container(Instance):
         return self.klass(validated)
 
     def instance_init(self, obj):
+        if isinstance(self._trait, TraitType):
+            self._trait.this_class = self.this_class
         if isinstance(self._trait, Instance):
             self._trait._resolve_classes()
         super(Container, self).instance_init(obj)


### PR DESCRIPTION
Makes subclasses of Container forward their `this_class` attribute to parameterized traits.  This makes it possible to express patterns like:

```
class Tree(HasTraits):

    value = Unicode()
    leaves = List(This())
```

Prior to this change, the above pattern would barf on instantiation with an AttributeError because the `This` inside the list wouldn't have a `this_class` attribute.

Also adds two new traits, `ForwardDeclaredType` and `ForwardDeclaredInstance`.  These use the existing runtime import machinery of `Type` and `Instance`, but automatically resolve relative to the module in which their containing class was defined.  For example, it's now possible to do something like:

```
class Foo(HasTraits):
    bar = ForwardDeclaredInstance('Bar')
    bartype = ForwardDeclaredType('Bar')

class Bar(object):
    pass
```

You could hack this previously by doing

```
bar = Instance(__name__ + '.Bar')
```

but I think the explicit forward-declaration syntax is a bit cleaner/clearer.
