### PR TITLE
Proposal: add pre/post-save hooks

### DIFF
--- a/IPython/html/services/contents/filemanager.py
+++ b/IPython/html/services/contents/filemanager.py
@@ -111,9 +111,8 @@ class FileContentsManager(ContentsManager):
 
         to be called on the path of a file just saved.
 
-        This can be used to
         This can be used to process the file on disk,
-        such as converting the notebook to other formats, such as Python or HTML via nbconvert
+        such as converting the notebook to a script or HTML via nbconvert.
 
         It will be called as (all arguments passed by keyword):
 

--- a/IPython/html/services/contents/filemanager.py
+++ b/IPython/html/services/contents/filemanager.py
@@ -16,8 +16,9 @@ from tornado import web
 from .manager import ContentsManager
 from IPython import nbformat
 from IPython.utils.io import atomic_writing
+from IPython.utils.importstring import import_item
 from IPython.utils.path import ensure_dir_exists
-from IPython.utils.traitlets import Unicode, Bool, TraitError
+from IPython.utils.traitlets import Any, Unicode, Bool, TraitError
 from IPython.utils.py3compat import getcwd, str_to_unicode
 from IPython.utils import tz
 from IPython.html.utils import is_hidden, to_os_path, to_api_path
@@ -70,6 +71,40 @@ class FileContentsManager(ContentsManager):
         Automatically saving notebooks as scripts has been removed.
         Use `ipython nbconvert --to python [notebook]` instead.
         """)
+
+    post_save_hook = Any(None, config=True,
+        help="""Python callable or importstring thereof
+
+        to be called on the path of a file just saved.
+
+        This can be used to
+        This can be used to process the file on disk,
+        such as converting the notebook to other formats, such as Python or HTML via nbconvert
+
+        It will be called as (all arguments passed by keyword):
+
+            hook(os_path=os_path, model=model, contents_manager=instance)
+
+        path: the filesystem path to the file just written
+        model: the model representing the file
+        contents_manager: this ContentsManager instance
+        """
+    )
+    def _post_save_hook_changed(self, name, old, new):
+        if new and isinstance(new, string_types):
+            self.post_save_hook = import_item(self.post_save_hook)
+        elif new:
+            if not callable(new):
+                raise TraitError("post_save_hook must be callable")
+
+    def run_post_save_hook(self, model, os_path):
+        """Run the post-save hook if defined, and log errors"""
+        if self.post_save_hook:
+            try:
+                self.log.debug("Running post-save hook on %s", os_path)
+                self.post_save_hook(os_path=os_path, model=model, contents_manager=self)
+            except Exception:
+                self.log.error("Post-save hook failed on %s", os_path, exc_info=True)
 
     def _root_dir_changed(self, name, old, new):
         """Do a bit of validation of the root_dir."""
@@ -404,6 +439,8 @@ class FileContentsManager(ContentsManager):
         if 'content' not in model and model['type'] != 'directory':
             raise web.HTTPError(400, u'No file content provided')
 
+        self.run_pre_save_hook(model=model, path=path)
+
         # One checkpoint should always exist
         if self.file_exists(path) and not self.list_checkpoints(path):
             self.create_checkpoint(path)
@@ -433,6 +470,9 @@ class FileContentsManager(ContentsManager):
         model = self.get(path, content=False)
         if validation_message:
             model['message'] = validation_message
+
+        self.run_post_save_hook(model=model, os_path=os_path)
+
         return model
 
     def update(self, model, path):


### PR DESCRIPTION
We may not want to do this so close to 3.0, but it's a mitigation of the removed `--script` flag, so I thought it was worth discussing. Hooks are Python functions that are passed the model, path, and content_manager. I started with two hooks:
- `ContentsManager.pre_save_hook` runs on the path and model with content. This one can be used for things like stripping output that people don't like adding to VCS noise.
- `FileContentsManager.post_save_hook` runs on the filesystem path and model without content. This one can be used to replace `--script` with a call to nbconvert.

An example `ipython_notebook_config.py` that does both of these things:

A pre-save hook for stripping output:

``` python

def scrub_output_pre_save(model, **kwargs):
    """scrub output before saving notebooks"""
    # only run on notebooks
    if model['type'] != 'notebook':
        return
    # only run on nbformat v4
    if model['content']['nbformat'] != 4:
        return

    model['content']['metadata'].pop('signature', None)
    for cell in model['content']['cells']:
        if cell['cell_type'] != 'code':
            continue
        cell['outputs'] = []
        cell['execution_count'] = None

c.FileContentsManager.pre_save_hook = scrub_output_pre_save
```

A post-save hook to replace `--script` (this could be a simple call to `ipython nbconvert --to script`, but spawning the subprocess every time is quite slow):

``` python
import io
import os

_script_exporter = None

def script_post_save(model, os_path, contents_manager, **kwargs):
    """convert notebooks to Python script after save with nbconvert

    replaces `ipython notebook --script`
    """
    from IPython.nbconvert.exporters.script import ScriptExporter

    if model['type'] != 'notebook':
        return

    global _script_exporter
    if _script_exporter is None:
        _script_exporter = ScriptExporter(parent=contents_manager)
    log = contents_manager.log

    base, ext = os.path.splitext(os_path)
    py_fname = base + '.py'
    script, resources = _script_exporter.from_filename(os_path)
    script_fname = base + resources.get('output_extension', '.txt')
    log.info("Saving script /%s", to_api_path(script_fname, contents_manager.root_dir))
    with io.open(script_fname, 'w', encoding='utf-8') as f:
        f.write(script)
c.FileContentsManager.post_save_hook = script_post_save
```

closes #3111
closes #1280
