### PR TITLE
Install on Windows without using setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -252,12 +252,6 @@ needs_setuptools = set(('develop', 'release', 'bdist_egg', 'bdist_rpm',
            'bdist', 'bdist_dumb', 'bdist_wininst', 'bdist_wheel',
            'egg_info', 'easy_install', 'upload', 'install_egg_info',
             ))
-if sys.platform == 'win32':
-    # Depend on setuptools for install on *Windows only*
-    # If we get script-installation working without setuptools,
-    # then we can back off, but until then use it.
-    # See Issue #369 on GitHub for more
-    needs_setuptools.add('install')
 
 if len(needs_setuptools.intersection(sys.argv)) > 0:
     import setuptools

--- a/setupbase.py
+++ b/setupbase.py
@@ -403,6 +403,16 @@ class build_scripts_entrypt(build_scripts):
             with open(outfile, 'w') as f:
                 f.write(script_src.format(executable=sys.executable,
                                           mod=mod, func=func))
+            
+            if sys.platform == 'win32':
+                # Write .cmd wrappers for Windows so 'ipython' etc. work at the
+                # command line
+                cmd_file = os.path.join(self.build_dir, name + '.cmd')
+                cmd = '@"{python}" "%~dp0\{script}" %*\r\n'.format(
+                        python=sys.executable, script=name)
+                log.info("Writing %s wrapper script" % cmd_file)
+                with open(cmd_file, 'w') as f:
+                    f.write(cmd)
 
         return outfiles, outfiles
 

--- a/setupbase.py
+++ b/setupbase.py
@@ -360,15 +360,14 @@ def target_update(target,deps,cmd):
 #---------------------------------------------------------------------------
 
 def find_entry_points():
-    """Find IPython's scripts.
+    """Defines the command line entry points for IPython
 
-    if entry_points is True:
-        return setuptools entry_point-style definitions
-    else:
-        return file paths of plain scripts [default]
+    This always uses setuptools-style entry points. When setuptools is not in
+    use, our own build_scripts_entrypt class below parses these and builds
+    command line scripts.
 
-    suffix is appended to script names if entry_points is True, so that the
-    Python 3 scripts get named "ipython3" etc.
+    Each of our entry points gets both a plain name, e.g. ipython, and one
+    suffixed with the Python major version number, e.g. ipython3. 
     """
     ep = [
             'ipython%s = IPython:start_ipython',
@@ -388,6 +387,14 @@ if __name__ == '__main__':
 """
 
 class build_scripts_entrypt(build_scripts):
+    """Build the command line scripts
+    
+    Parse setuptools style entry points and write simple scripts to run the
+    target functions.
+    
+    On Windows, this also creates .cmd wrappers for the scripts so that you can
+    easily launch them from a command line.
+    """
     def run(self):
         self.mkpath(self.build_dir)
         outfiles = []


### PR DESCRIPTION
This creates batch files, with a .cmd extension, to launch IPython from 'ipython' at a command line, replacing the .exe files created by setuptools.

This makes repeated installations much quicker on Windows.

Fixes issue #369, though it's already closed.
