### PR TITLE
Contents API get as type

### DIFF
--- a/IPython/html/files/handlers.py
+++ b/IPython/html/files/handlers.py
@@ -28,7 +28,7 @@ class FilesHandler(IPythonHandler):
         else:
             name = path
         
-        model = cm.get_model(path)
+        model = cm.get(path)
         
         if self.get_argument("download", False):
             self.set_header('Content-Disposition','attachment; filename="%s"' % name)

--- a/IPython/html/nbconvert/handlers.py
+++ b/IPython/html/nbconvert/handlers.py
@@ -81,7 +81,7 @@ class NbconvertFileHandler(IPythonHandler):
         exporter = get_exporter(format, config=self.config, log=self.log)
         
         path = path.strip('/')
-        model = self.contents_manager.get_model(path=path)
+        model = self.contents_manager.get(path=path)
         name = model['name']
 
         self.set_header('Last-Modified', model['last_modified'])

--- a/IPython/html/services/contents/filemanager.py
+++ b/IPython/html/services/contents/filemanager.py
@@ -277,7 +277,7 @@ class FileContentsManager(ContentsManager):
             Whether to include the contents in the reply
         type_ : str, optional
             The requested type - 'file', 'notebook', or 'directory'.
-            Will raise HTTPError 406 if the content doesn't match.
+            Will raise HTTPError 400 if the content doesn't match.
         format : str, optional
             The requested format for file contents. 'text' or 'base64'.
             Ignored if this returns a notebook or directory model.

--- a/IPython/html/services/contents/filemanager.py
+++ b/IPython/html/services/contents/filemanager.py
@@ -200,7 +200,7 @@ class FileContentsManager(ContentsManager):
                     self.log.debug("%s not a regular file", os_path)
                     continue
                 if self.should_list(name) and not is_hidden(os_path, self.root_dir):
-                    contents.append(self.get_model(
+                    contents.append(self.get(
                         path='%s/%s' % (path, name),
                         content=False)
                     )
@@ -266,7 +266,7 @@ class FileContentsManager(ContentsManager):
             self.validate_notebook_model(model)
         return model
 
-    def get_model(self, path, content=True, type_=None, format=None):
+    def get(self, path, content=True, type_=None, format=None):
         """ Takes a path for an entity and returns its model
 
         Parameters
@@ -380,7 +380,7 @@ class FileContentsManager(ContentsManager):
             self.validate_notebook_model(model)
             validation_message = model.get('message', None)
 
-        model = self.get_model(path, content=False)
+        model = self.get(path, content=False)
         if validation_message:
             model['message'] = validation_message
         return model
@@ -395,7 +395,7 @@ class FileContentsManager(ContentsManager):
         new_path = model.get('path', path).strip('/')
         if path != new_path:
             self.rename(path, new_path)
-        model = self.get_model(new_path, content=False)
+        model = self.get(new_path, content=False)
         return model
 
     def delete(self, path):

--- a/IPython/html/services/contents/handlers.py
+++ b/IPython/html/services/contents/handlers.py
@@ -66,7 +66,7 @@ class ContentsHandler(IPythonHandler):
         if format not in {None, 'text', 'base64'}:
             raise web.HTTPError(400, u'Format %r is invalid' % format)
 
-        model = self.contents_manager.get_model(path=path, type_=type_, format=format)
+        model = self.contents_manager.get(path=path, type_=type_, format=format)
         if model['type'] == 'directory':
             # group listing by type, then by name (case-insensitive)
             # FIXME: sorting should be done in the frontends

--- a/IPython/html/services/contents/handlers.py
+++ b/IPython/html/services/contents/handlers.py
@@ -58,7 +58,11 @@ class ContentsHandler(IPythonHandler):
         of the files and directories it contains.
         """
         path = path or ''
-        model = self.contents_manager.get_model(path=path)
+        type_ = self.get_query_argument('type', default=None)
+        if type_ not in {None, 'directory', 'file', 'notebook'}:
+            raise web.HTTPError(400, u'Type %r is invalid' % type_)
+
+        model = self.contents_manager.get_model(path=path, type_=type_)
         if model['type'] == 'directory':
             # group listing by type, then by name (case-insensitive)
             # FIXME: sorting should be done in the frontends

--- a/IPython/html/services/contents/handlers.py
+++ b/IPython/html/services/contents/handlers.py
@@ -62,7 +62,11 @@ class ContentsHandler(IPythonHandler):
         if type_ not in {None, 'directory', 'file', 'notebook'}:
             raise web.HTTPError(400, u'Type %r is invalid' % type_)
 
-        model = self.contents_manager.get_model(path=path, type_=type_)
+        format = self.get_query_argument('format', default=None)#
+        if format not in {None, 'text', 'base64'}:
+            raise web.HTTPError(400, u'Format %r is invalid' % format)
+
+        model = self.contents_manager.get_model(path=path, type_=type_, format=format)
         if model['type'] == 'directory':
             # group listing by type, then by name (case-insensitive)
             # FIXME: sorting should be done in the frontends

--- a/IPython/html/services/contents/manager.py
+++ b/IPython/html/services/contents/manager.py
@@ -135,7 +135,7 @@ class ContentsManager(LoggingConfigurable):
         """
         return self.file_exists(path) or self.dir_exists(path)
 
-    def get_model(self, path, content=True):
+    def get_model(self, path, content=True, type_=None):
         """Get the model of a file or directory with or without content."""
         raise NotImplementedError('must be implemented in a subclass')
 

--- a/IPython/html/services/contents/manager.py
+++ b/IPython/html/services/contents/manager.py
@@ -135,7 +135,7 @@ class ContentsManager(LoggingConfigurable):
         """
         return self.file_exists(path) or self.dir_exists(path)
 
-    def get_model(self, path, content=True, type_=None):
+    def get_model(self, path, content=True, type_=None, format=None):
         """Get the model of a file or directory with or without content."""
         raise NotImplementedError('must be implemented in a subclass')
 

--- a/IPython/html/services/contents/manager.py
+++ b/IPython/html/services/contents/manager.py
@@ -135,7 +135,7 @@ class ContentsManager(LoggingConfigurable):
         """
         return self.file_exists(path) or self.dir_exists(path)
 
-    def get_model(self, path, content=True, type_=None, format=None):
+    def get(self, path, content=True, type_=None, format=None):
         """Get the model of a file or directory with or without content."""
         raise NotImplementedError('must be implemented in a subclass')
 
@@ -300,7 +300,7 @@ class ContentsManager(LoggingConfigurable):
             from_dir = ''
             from_name = path
         
-        model = self.get_model(path)
+        model = self.get(path)
         model.pop('path', None)
         model.pop('name', None)
         if model['type'] == 'directory':
@@ -328,7 +328,7 @@ class ContentsManager(LoggingConfigurable):
         path : string
             The path of a notebook
         """
-        model = self.get_model(path)
+        model = self.get(path)
         nb = model['content']
         self.log.warn("Trusting notebook %s", path)
         self.notary.mark_cells(nb, True)

--- a/IPython/html/services/contents/tests/test_contents_api.py
+++ b/IPython/html/services/contents/tests/test_contents_api.py
@@ -46,9 +46,14 @@ class API(object):
     def list(self, path='/'):
         return self._req('GET', path)
 
-    def read(self, path, type_=None):
+    def read(self, path, type_=None, format=None):
+        query = []
         if type_ is not None:
-            path += '?type=' + type_
+            query.append('type=' + type_)
+        if format is not None:
+            query.append('format=' + format)
+        if query:
+            path += '?' + '&'.join(query)
         return self._req('GET', path)
 
     def create_untitled(self, path='/', ext='.ipynb'):
@@ -244,6 +249,10 @@ class APITest(NotebookTestBase):
         # Name that doesn't exist - should be a 404
         with assert_http_error(404):
             self.api.read('foo/q.txt')
+
+        # Specifying format=text should fail on a non-UTF-8 file
+        with assert_http_error(400):
+            self.api.read('foo/bar/baz.blob', type_='file', format='text')
 
     def test_get_binary_file_contents(self):
         for d, name in self.dirs_nbs:

--- a/IPython/html/services/contents/tests/test_contents_api.py
+++ b/IPython/html/services/contents/tests/test_contents_api.py
@@ -38,7 +38,7 @@ class API(object):
     def _req(self, verb, path, body=None, params=None):
         response = requests.request(verb,
                 url_path_join(self.base_url, 'api/contents', path),
-                data=body,
+                data=body, params=params,
         )
         response.raise_for_status()
         return response

--- a/IPython/html/services/contents/tests/test_contents_api.py
+++ b/IPython/html/services/contents/tests/test_contents_api.py
@@ -46,7 +46,9 @@ class API(object):
     def list(self, path='/'):
         return self._req('GET', path)
 
-    def read(self, path):
+    def read(self, path, type_=None):
+        if type_ is not None:
+            path += '?type=' + type_
         return self._req('GET', path)
 
     def create_untitled(self, path='/', ext='.ipynb'):
@@ -258,6 +260,13 @@ class APITest(NotebookTestBase):
         # Name that doesn't exist - should be a 404
         with assert_http_error(404):
             self.api.read('foo/q.txt')
+
+    def test_get_bad_type(self):
+        with assert_http_error(400):
+            self.api.read(u'unicodé', type_='file')  # this is a directory
+
+        with assert_http_error(400):
+            self.api.read(u'unicodé/innonascii.ipynb', type_='directory')
 
     def _check_created(self, resp, path, type='notebook'):
         self.assertEqual(resp.status_code, 201)

--- a/IPython/html/services/contents/tests/test_contents_api.py
+++ b/IPython/html/services/contents/tests/test_contents_api.py
@@ -35,7 +35,7 @@ class API(object):
     def __init__(self, base_url):
         self.base_url = base_url
 
-    def _req(self, verb, path, body=None):
+    def _req(self, verb, path, body=None, params=None):
         response = requests.request(verb,
                 url_path_join(self.base_url, 'api/contents', path),
                 data=body,
@@ -47,14 +47,12 @@ class API(object):
         return self._req('GET', path)
 
     def read(self, path, type_=None, format=None):
-        query = []
+        params = {}
         if type_ is not None:
-            query.append('type=' + type_)
+            params['type'] = type_
         if format is not None:
-            query.append('format=' + format)
-        if query:
-            path += '?' + '&'.join(query)
-        return self._req('GET', path)
+            params['format'] = format
+        return self._req('GET', path, params=params)
 
     def create_untitled(self, path='/', ext='.ipynb'):
         body = None

--- a/IPython/html/services/contents/tests/test_manager.py
+++ b/IPython/html/services/contents/tests/test_manager.py
@@ -165,6 +165,9 @@ class TestContentsManager(TestCase):
         self.assertEqual(nb_as_file['format'], 'text')
         self.assertNotIsInstance(nb_as_file['content'], dict)
 
+        nb_as_bin_file = cm.get_model(path, content=True, type_='file', format='base64')
+        self.assertEqual(nb_as_bin_file['format'], 'base64')
+
         # Test in sub-directory
         sub_dir = '/foo/'
         self.make_dir(cm.root_dir, 'foo')

--- a/IPython/html/services/contents/tests/test_manager.py
+++ b/IPython/html/services/contents/tests/test_manager.py
@@ -105,7 +105,7 @@ class TestContentsManager(TestCase):
         name = model['name']
         path = model['path']
 
-        full_model = cm.get_model(path)
+        full_model = cm.get(path)
         nb = full_model['content']
         self.add_code_cell(nb)
 
@@ -152,27 +152,27 @@ class TestContentsManager(TestCase):
         path = model['path']
 
         # Check that we 'get' on the notebook we just created
-        model2 = cm.get_model(path)
+        model2 = cm.get(path)
         assert isinstance(model2, dict)
         self.assertIn('name', model2)
         self.assertIn('path', model2)
         self.assertEqual(model['name'], name)
         self.assertEqual(model['path'], path)
 
-        nb_as_file = cm.get_model(path, content=True, type_='file')
+        nb_as_file = cm.get(path, content=True, type_='file')
         self.assertEqual(nb_as_file['path'], path)
         self.assertEqual(nb_as_file['type'], 'file')
         self.assertEqual(nb_as_file['format'], 'text')
         self.assertNotIsInstance(nb_as_file['content'], dict)
 
-        nb_as_bin_file = cm.get_model(path, content=True, type_='file', format='base64')
+        nb_as_bin_file = cm.get(path, content=True, type_='file', format='base64')
         self.assertEqual(nb_as_bin_file['format'], 'base64')
 
         # Test in sub-directory
         sub_dir = '/foo/'
         self.make_dir(cm.root_dir, 'foo')
         model = cm.new_untitled(path=sub_dir, ext='.ipynb')
-        model2 = cm.get_model(sub_dir + name)
+        model2 = cm.get(sub_dir + name)
         assert isinstance(model2, dict)
         self.assertIn('name', model2)
         self.assertIn('path', model2)
@@ -181,11 +181,11 @@ class TestContentsManager(TestCase):
         self.assertEqual(model2['path'], '{0}/{1}'.format(sub_dir.strip('/'), name))
 
         # Test getting directory model
-        dirmodel = cm.get_model('foo')
+        dirmodel = cm.get('foo')
         self.assertEqual(dirmodel['type'], 'directory')
 
         with self.assertRaises(HTTPError):
-            cm.get_model('foo', type_='file')
+            cm.get('foo', type_='file')
 
     
     @dec.skip_win32
@@ -198,7 +198,7 @@ class TestContentsManager(TestCase):
         
         # create a broken symlink
         os.symlink("target", os.path.join(os_path, "bad symlink"))
-        model = cm.get_model(path)
+        model = cm.get(path)
         self.assertEqual(model['content'], [file_model])
     
     @dec.skip_win32
@@ -213,8 +213,8 @@ class TestContentsManager(TestCase):
         
         # create a good symlink
         os.symlink(file_model['name'], os.path.join(os_path, name))
-        symlink_model = cm.get_model(path, content=False)
-        dir_model = cm.get_model(parent)
+        symlink_model = cm.get(path, content=False)
+        dir_model = cm.get(parent)
         self.assertEqual(
             sorted(dir_model['content'], key=lambda x: x['name']),
             [symlink_model, file_model],
@@ -236,7 +236,7 @@ class TestContentsManager(TestCase):
         self.assertEqual(model['name'], 'test.ipynb')
 
         # Make sure the old name is gone
-        self.assertRaises(HTTPError, cm.get_model, path)
+        self.assertRaises(HTTPError, cm.get, path)
 
         # Test in sub-directory
         # Create a directory and notebook in that directory
@@ -257,7 +257,7 @@ class TestContentsManager(TestCase):
         self.assertEqual(model['path'], new_path)
 
         # Make sure the old name is gone
-        self.assertRaises(HTTPError, cm.get_model, path)
+        self.assertRaises(HTTPError, cm.get, path)
 
     def test_save(self):
         cm = self.contents_manager
@@ -267,7 +267,7 @@ class TestContentsManager(TestCase):
         path = model['path']
 
         # Get the model with 'content'
-        full_model = cm.get_model(path)
+        full_model = cm.get(path)
 
         # Save the notebook
         model = cm.save(full_model, path)
@@ -284,7 +284,7 @@ class TestContentsManager(TestCase):
         model = cm.new_untitled(path=sub_dir, type='notebook')
         name = model['name']
         path = model['path']
-        model = cm.get_model(path)
+        model = cm.get(path)
 
         # Change the name in the model for rename
         model = cm.save(model, path)
@@ -303,7 +303,7 @@ class TestContentsManager(TestCase):
         cm.delete(path)
 
         # Check that a 'get' on the deleted notebook raises and error
-        self.assertRaises(HTTPError, cm.get_model, path)
+        self.assertRaises(HTTPError, cm.get, path)
 
     def test_copy(self):
         cm = self.contents_manager
@@ -326,12 +326,12 @@ class TestContentsManager(TestCase):
         cm = self.contents_manager
         nb, name, path = self.new_notebook()
 
-        untrusted = cm.get_model(path)['content']
+        untrusted = cm.get(path)['content']
         assert not cm.notary.check_cells(untrusted)
 
         # print(untrusted)
         cm.trust_notebook(path)
-        trusted = cm.get_model(path)['content']
+        trusted = cm.get(path)['content']
         # print(trusted)
         assert cm.notary.check_cells(trusted)
 
@@ -345,7 +345,7 @@ class TestContentsManager(TestCase):
                 assert not cell.metadata.trusted
 
         cm.trust_notebook(path)
-        nb = cm.get_model(path)['content']
+        nb = cm.get(path)['content']
         for cell in nb.cells:
             if cell.cell_type == 'code':
                 assert cell.metadata.trusted
@@ -359,7 +359,7 @@ class TestContentsManager(TestCase):
         assert not cm.notary.check_signature(nb)
 
         cm.trust_notebook(path)
-        nb = cm.get_model(path)['content']
+        nb = cm.get(path)['content']
         cm.mark_trusted_cells(nb, path)
         cm.check_and_sign(nb, path)
         assert cm.notary.check_signature(nb)

--- a/IPython/html/services/contents/tests/test_manager.py
+++ b/IPython/html/services/contents/tests/test_manager.py
@@ -159,6 +159,12 @@ class TestContentsManager(TestCase):
         self.assertEqual(model['name'], name)
         self.assertEqual(model['path'], path)
 
+        nb_as_file = cm.get_model(path, content=True, type_='file')
+        self.assertEqual(nb_as_file['path'], path)
+        self.assertEqual(nb_as_file['type'], 'file')
+        self.assertEqual(nb_as_file['format'], 'text')
+        self.assertNotIsInstance(nb_as_file['content'], dict)
+
         # Test in sub-directory
         sub_dir = '/foo/'
         self.make_dir(cm.root_dir, 'foo')
@@ -170,6 +176,14 @@ class TestContentsManager(TestCase):
         self.assertIn('content', model2)
         self.assertEqual(model2['name'], 'Untitled0.ipynb')
         self.assertEqual(model2['path'], '{0}/{1}'.format(sub_dir.strip('/'), name))
+
+        # Test getting directory model
+        dirmodel = cm.get_model('foo')
+        self.assertEqual(dirmodel['type'], 'directory')
+
+        with self.assertRaises(HTTPError):
+            cm.get_model('foo', type_='file')
+
     
     @dec.skip_win32
     def test_bad_symlink(self):

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -110,11 +110,8 @@ define([
                 });
         });
         this.element.find('#open_notebook').click(function () {
-            window.open(utils.url_join_encode(
-                that.notebook.base_url,
-                'tree',
-                that.notebook.notebook_path
-            ));
+            var parent = utils.url_path_split(that.notebook.notebook_path)[0];
+            window.open(utils.url_join_encode(that.base_url, 'tree', parent));
         });
         this.element.find('#copy_notebook').click(function () {
             that.notebook.copy_notebook();

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -2102,6 +2102,7 @@ define([
         this.notebook_name = utils.url_path_split(this.notebook_path)[1];
         this.events.trigger('notebook_loading.Notebook');
         this.contents.get(notebook_path, {
+            type: 'notebook',
             success: $.proxy(this.load_notebook_success, this),
             error: $.proxy(this.load_notebook_error, this)
         });

--- a/IPython/html/static/services/contents.js
+++ b/IPython/html/static/services/contents.js
@@ -87,6 +87,9 @@ define([
             error : this.create_basic_error_handler(options.error)
         };
         var url = this.api_url(path);
+        if (options.type) {
+            url += '?type=' + options.type;
+        }
         $.ajax(url, settings);
     };
 
@@ -250,20 +253,11 @@ define([
      *     last_modified: last modified dat
      * @method list_notebooks
      * @param {String} path The path to list notebooks in
-     * @param {Function} load_callback called with list of notebooks on success
-     * @param {Function} error called with ajax results on error
+     * @param {Object} options including success and error callbacks
      */
     Contents.prototype.list_contents = function(path, options) {
-        var settings = {
-            processData : false,
-            cache : false,
-            type : "GET",
-            dataType : "json",
-            success : options.success,
-            error : this.create_basic_error_handler(options.error)
-        };
-
-        $.ajax(this.api_url(path), settings);
+        options.type = 'directory';
+        this.get(path, options);
     };
 
 

--- a/IPython/html/static/services/contents.js
+++ b/IPython/html/static/services/contents.js
@@ -87,10 +87,10 @@ define([
             error : this.create_basic_error_handler(options.error)
         };
         var url = this.api_url(path);
-        if (options.type) {
-            url += '?type=' + options.type;
-        }
-        $.ajax(url, settings);
+        params = {};
+        if (options.type) { params.type = options.type; }
+        if (options.format) { params.format = options.format; }
+        $.ajax(url + '?' + $.param(params), settings);
     };
 
 

--- a/IPython/html/tree/handlers.py
+++ b/IPython/html/tree/handlers.py
@@ -38,7 +38,7 @@ class TreeHandler(IPythonHandler):
         cm = self.contents_manager
         if cm.file_exists(path):
             # it's not a directory, we have redirecting to do
-            model = cm.get(path, content=False)
+            model = cm.get_model(path, content=False)
             # redirect to /api/notebooks if it's a notebook, otherwise /api/files
             service = 'notebooks' if model['type'] == 'notebook' else 'files'
             url = url_escape(url_path_join(

--- a/IPython/html/tree/handlers.py
+++ b/IPython/html/tree/handlers.py
@@ -38,7 +38,7 @@ class TreeHandler(IPythonHandler):
         cm = self.contents_manager
         if cm.file_exists(path):
             # it's not a directory, we have redirecting to do
-            model = cm.get_model(path, content=False)
+            model = cm.get(path, content=False)
             # redirect to /api/notebooks if it's a notebook, otherwise /api/files
             service = 'notebooks' if model['type'] == 'notebook' else 'files'
             url = url_escape(url_path_join(

--- a/IPython/html/tree/tests/test_tree_handler.py
+++ b/IPython/html/tree/tests/test_tree_handler.py
@@ -1,0 +1,32 @@
+"""Test the /tree handlers"""
+import os
+import io
+from IPython.html.utils import url_path_join
+from IPython.nbformat import write
+from IPython.nbformat.v4 import new_notebook
+
+import requests
+
+from IPython.html.tests.launchnotebook import NotebookTestBase
+
+class TreeTest(NotebookTestBase):
+    def setUp(self):
+        nbdir = self.notebook_dir.name
+        d = os.path.join(nbdir, 'foo')
+        os.mkdir(d)
+
+        with io.open(os.path.join(d, 'bar.ipynb'), 'w', encoding='utf-8') as f:
+            nb = new_notebook()
+            write(nb, f, version=4)
+
+        with io.open(os.path.join(d, 'baz.txt'), 'w', encoding='utf-8') as f:
+            f.write(u'flamingo')
+
+        self.base_url()
+
+    def test_redirect(self):
+        r = requests.get(url_path_join(self.base_url(), 'tree/foo/bar.ipynb'))
+        self.assertEqual(r.url, self.base_url() + 'notebooks/foo/bar.ipynb')
+
+        r = requests.get(url_path_join(self.base_url(), 'tree/foo/baz.txt'))
+        self.assertEqual(r.url, url_path_join(self.base_url(), 'files/foo/baz.txt'))


### PR DESCRIPTION
This adds a `type` parameter to GET requests to the contents API. There are two main benefits:
1. Clearer failures if you try to fetch a directory but the path points to a file, or vice versa.
2. Notebooks can be opened as text files (`type=file`), and notebooks without a `.ipynb` extension can be opened as notebooks (`type=notebook`)
