### PR TITLE
handle various permission failures

### DIFF
--- a/IPython/html/services/contents/filemanager.py
+++ b/IPython/html/services/contents/filemanager.py
@@ -57,7 +57,7 @@ class FileContentsManager(ContentsManager):
                 yield f
     
     @contextmanager
-    def open_w(self, os_path, *args, **kwargs):
+    def atomic_writing(self, os_path, *args, **kwargs):
         """wrapper around atomic_writing that turns permission errors into 403"""
         with self.perm_to_403(os_path):
             with atomic_writing(os_path, *args, **kwargs) as f:
@@ -358,7 +358,7 @@ class FileContentsManager(ContentsManager):
 
         self.check_and_sign(nb, path)
 
-        with self.open_w(os_path, encoding='utf-8') as f:
+        with self.atomic_writing(os_path, encoding='utf-8') as f:
             nbformat.write(nb, f, version=nbformat.NO_CONVERT)
 
     def _save_file(self, os_path, model, path=''):
@@ -375,7 +375,7 @@ class FileContentsManager(ContentsManager):
                 bcontent = base64.decodestring(b64_bytes)
         except Exception as e:
             raise web.HTTPError(400, u'Encoding error saving %s: %s' % (os_path, e))
-        with self.open_w(os_path, text=False) as f:
+        with self.atomic_writing(os_path, text=False) as f:
             f.write(bcontent)
 
     def _save_directory(self, os_path, model, path=''):

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -340,8 +340,11 @@ define([
         this.events.on('notebook_saved.Notebook', function () {
             nnw.set_message("Notebook saved",2000);
         });
-        this.events.on('notebook_save_failed.Notebook', function (evt, xhr, status, data) {
-            nnw.warning(data || "Notebook save failed");
+        this.events.on('notebook_save_failed.Notebook', function (evt, error) {
+            nnw.warning(error.message || "Notebook save failed");
+        });
+        this.events.on('notebook_copy_failed.Notebook', function (evt, error) {
+            nnw.warning(error.message || "Notebook copy failed");
         });
         
         // Checkpoint events

--- a/IPython/html/static/notebook/js/savewidget.js
+++ b/IPython/html/static/notebook/js/savewidget.js
@@ -46,6 +46,11 @@ define([
         this.events.on('notebook_save_failed.Notebook', function () {
             that.set_save_status('Autosave Failed!');
         });
+        this.events.on('notebook_read_only.Notebook', function () {
+            that.set_save_status('(read only)');
+            // disable future set_save_status
+            that.set_save_status = function () {};
+        });
         this.events.on('checkpoints_listed.Notebook', function (event, data) {
             that._set_last_checkpoint(data[0]);
         });

--- a/IPython/html/utils.py
+++ b/IPython/html/utils.py
@@ -1,16 +1,7 @@
-"""Notebook related utilities
+"""Notebook related utilities"""
 
-Authors:
-
-* Brian Granger
-"""
-
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2011  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 from __future__ import print_function
 
@@ -28,9 +19,6 @@ from IPython.utils import py3compat
 # It is used by BSD to indicate hidden files.
 UF_HIDDEN = getattr(stat, 'UF_HIDDEN', 32768)
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
 
 def url_path_join(*pieces):
     """Join components of url into a relative url
@@ -137,4 +125,17 @@ def to_os_path(path, root=''):
     parts = [p for p in parts if p != ''] # remove duplicate splits
     path = os.path.join(root, *parts)
     return path
+
+def to_api_path(os_path, root=''):
+    """Convert a filesystem path to an API path
     
+    If given, root will be removed from the path.
+    root must be a filesystem path already.
+    """
+    if os_path.startswith(root):
+        os_path = os_path[len(root):]
+    parts = os_path.strip(os.path.sep).split(os.path.sep)
+    parts = [p for p in parts if p != ''] # remove duplicate splits
+    path = '/'.join(parts)
+    return path
+


### PR DESCRIPTION
- turn various EPERM, EACCES errors into 403
- add `writable` bool field to contents models
- if a notebook is not `writable`, save is disabled

New notebook failed on read-only tree:

![screen shot 2014-11-11 at 17 19 48](https://cloud.githubusercontent.com/assets/151929/5003718/25dba100-69c7-11e4-9280-afd3fb6d0920.PNG)

"Last saved" text is replaced with 'read-only':

![screen shot 2014-11-11 at 17 19 23](https://cloud.githubusercontent.com/assets/151929/5003732/4890187a-69c7-11e4-8983-7a3f88076cb1.PNG)

An attempt to save sets a notification:

![screen shot 2014-11-11 at 16 35 56](https://cloud.githubusercontent.com/assets/151929/5003740/5b700cf2-69c7-11e4-977d-b63197a895d1.PNG)

Opening a notebook without read permissions:

![screen shot 2014-11-11 at 16 35 35](https://cloud.githubusercontent.com/assets/151929/5003741/65bf1d42-69c7-11e4-9152-c896ab60ba52.PNG)

Rename fails due to permissions:

![screen shot 2014-11-11 at 17 23 33](https://cloud.githubusercontent.com/assets/151929/5003749/87de6d38-69c7-11e4-9168-ee708af31888.PNG)

ping @ellisonbg 
