### PR TITLE
handle setting Widget.comm = None

### DIFF
--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -175,7 +175,8 @@ class Widget(LoggingConfigurable):
 
     def _comm_changed(self, name, new):
         """Called when the comm is changed."""
-        self.comm = new
+        if new is None:
+            return
         self._model_id = self.model_id
         
         self.comm.on_msg(self._handle_msg)


### PR DESCRIPTION
which is done in `Widget.close`

fixes loads of warnings in widget test output, caused every time a widget is closed.
