### PR TITLE
add IPythonDisplayFormatter

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -164,20 +164,13 @@ def display(*objs, **kwargs):
         format = InteractiveShell.instance().display_formatter.format
 
     for obj in objs:
-
-        # If _ipython_display_ is defined, use that to display this object.
-        display_method = _safe_get_formatter_method(obj, '_ipython_display_')
-        if display_method is not None:
-            try:
-                display_method(**kwargs)
-            except NotImplementedError:
-                pass
-            else:
-                continue
         if raw:
             publish_display_data(data=obj, metadata=metadata)
         else:
             format_dict, md_dict = format(obj, include=include, exclude=exclude)
+            if not format_dict:
+                # nothing to display (e.g. _ipython_display_ took over)
+                continue
             if metadata:
                 # kwarg-specified metadata gets precedence
                 _merge(md_dict, metadata)

--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -221,20 +221,13 @@ class DisplayHook(Configurable):
         """
         self.check_for_underscore()
         if result is not None and not self.quiet():
-            # If _ipython_display_ is defined, use that to display this object.
-            display_method = _safe_get_formatter_method(result, '_ipython_display_')
-            if display_method is not None:
-                try:
-                    return display_method()
-                except NotImplementedError:
-                    pass
-            
             self.start_displayhook()
             self.write_output_prompt()
             format_dict, md_dict = self.compute_format_data(result)
-            self.write_format_data(format_dict, md_dict)
             self.update_user_ns(result)
-            self.log_output(format_dict)
+            if format_dict:
+                self.write_format_data(format_dict, md_dict)
+                self.log_output(format_dict)
             self.finish_displayhook()
 
     def cull_cache(self):

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -14,7 +14,6 @@ import abc
 import inspect
 import sys
 import traceback
-import types
 import warnings
 
 from IPython.external.decorator import decorator
@@ -24,7 +23,7 @@ from IPython.core.getipython import get_ipython
 from IPython.lib import pretty
 from IPython.utils.traitlets import (
     Bool, Dict, Integer, Unicode, CUnicode, ObjectName, List,
-    Instance,
+    ForwardDeclaredInstance,
 )
 from IPython.utils.py3compat import (
     unicode_to_str, with_metaclass, PY3, string_types, unicode_type,
@@ -90,9 +89,9 @@ class DisplayFormatter(Configurable):
             else:
                 formatter.enabled = False
     
-    self_formatter = Instance(__name__ +'.SelfDisplayingFormatter')
-    def _self_formatter_default(self):
-        return SelfDisplayingFormatter(parent=self)
+    ipython_display_formatter = ForwardDeclaredInstance('FormatterABC')
+    def _ipython_display_formatter_default(self):
+        return IPythonDisplayFormatter(parent=self)
     
     # A dict of formatter whose keys are format types (MIME types) and whose
     # values are subclasses of BaseFormatter.
@@ -164,7 +163,7 @@ class DisplayFormatter(Configurable):
         format_dict = {}
         md_dict = {}
         
-        if self.self_formatter(obj):
+        if self.ipython_display_formatter(obj):
             # object handled itself, don't proceed
             return {}, {}
         
@@ -840,7 +839,7 @@ class PDFFormatter(BaseFormatter):
 
     _return_type = (bytes, unicode_type)
 
-class SelfDisplayingFormatter(BaseFormatter):
+class IPythonDisplayFormatter(BaseFormatter):
     """A Formatter for objects that know how to display themselves.
     
     To define the callables that compute the representation of your
@@ -886,7 +885,7 @@ FormatterABC.register(JPEGFormatter)
 FormatterABC.register(LatexFormatter)
 FormatterABC.register(JSONFormatter)
 FormatterABC.register(JavascriptFormatter)
-FormatterABC.register(SelfDisplayingFormatter)
+FormatterABC.register(IPythonDisplayFormatter)
 
 
 def format_display_data(obj, include=None, exclude=None):


### PR DESCRIPTION
use it to dispatch `_ipython_display_`

closes #6687

Allows `for_type` registration for self-displaying functions, etc.

I'm not sure this is the way to go. It moves the `_ipython_display_` handling inside DisplayFormatter, and if the object does display itself, the DisplayFormatter will have no formatted data to return.

I can also look into the idea of `application/javascript` display data having access to the rest of the display message, in which case it could do things with other mime-type data on its own, including call `this.append_map['text/html'](data['text/html'])` to put HTML onto the page.

ping @ellisonbg, @jdfreder, @ssanderson
