### PR TITLE
Dates and Strings are JavaScript objects, and _pack_models behaves incorrectly in these cases. 

### DIFF
--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -236,7 +236,8 @@ define(["widgets/js/manager",
                     packed.push(that._pack_models(sub_value));
                 });
                 return packed;
-
+            } else if (value instanceof Date) {
+                return value;
             } else if (value instanceof Object) {
                 packed = {};
                 _.each(value, function(sub_value, key) {

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -236,7 +236,7 @@ define(["widgets/js/manager",
                     packed.push(that._pack_models(sub_value));
                 });
                 return packed;
-            } else if (value instanceof Date) {
+            } else if (value instanceof Date || value instanceof String) {
                 return value;
             } else if (value instanceof Object) {
                 packed = {};

--- a/IPython/html/tests/widgets/widget.js
+++ b/IPython/html/tests/widgets/widget.js
@@ -81,6 +81,7 @@ casper.notebook_test(function () {
         test_packing([1, false]);
         test_packing([1, false, {a: 'hi'}]);
         test_packing([1, false, ['hi']]);
+        test_packing([String('hi'), Date("Thu Nov 13 2014 13:46:21 GMT-0500")])
 
         // Test multi-set, single touch code.  First create a custom widget.
         this.evaluate(function() {


### PR DESCRIPTION
JavaScript dates were not correctly serialized in the widget machinery. @ssunkara
