### PR TITLE
Correct height for the checkbox widget

### DIFF
--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -1432,6 +1432,7 @@ div.cell.text_cell.rendered {
 }
 .widget-hbox input[type="checkbox"] {
   margin-top: 9px;
+  margin-bottom: 10px;
 }
 .widget-hbox .widget-label {
   /* Horizontal Label */

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -9301,6 +9301,7 @@ div.cell.text_cell.rendered {
 }
 .widget-hbox input[type="checkbox"] {
   margin-top: 9px;
+  margin-bottom: 10px;
 }
 .widget-hbox .widget-label {
   /* Horizontal Label */

--- a/IPython/html/static/widgets/less/widgets.less
+++ b/IPython/html/static/widgets/less/widgets.less
@@ -195,6 +195,7 @@
 
     input[type="checkbox"] {
         margin-top: 9px;
+        margin-bottom: 10px;
     }
 
     .widget-label {


### PR DESCRIPTION
Minor css fix. The checkbox bottom margin was not sufficient. 

(The correct value comes from bootstrap' s `.checkbox` class which cannot be applied here. )

Before:
![bad](https://cloud.githubusercontent.com/assets/2397974/5033453/e6a9004a-6b33-11e4-9c07-b4c242446f72.png)

After:
![better](https://cloud.githubusercontent.com/assets/2397974/5033455/eaa48552-6b33-11e4-8b89-d831201456ab.png)
