### PR TITLE
Fix link to /tree within notebooks

### DIFF
--- a/IPython/html/templates/page.html
+++ b/IPython/html/templates/page.html
@@ -75,7 +75,7 @@
 
 <div id="header" class="navbar navbar-static-top">
   <div class="container">
-  <div id="ipython_notebook" class="nav navbar-brand pull-left"><a href="{{base_url}}tree/{{notebook_path}}" alt='dashboard'><img src='{{static_url("base/images/ipynblogo.png") }}' alt='IPython Notebook'/></a></div>
+  <div id="ipython_notebook" class="nav navbar-brand pull-left"><a href="{{base_url}}tree" alt='dashboard'><img src='{{static_url("base/images/ipynblogo.png") }}' alt='IPython Notebook'/></a></div>
 
   {% block login_widget %}
 


### PR DESCRIPTION
When working with `master`, I noticed that clicking the IPython logo within the notebook, while editing a notebook tried to link to `/tree/NotebookName.ipynb` (404s) instead of `/tree` (intended behavior).
