### PR TITLE
generate `ipython console` config file

### DIFF
--- a/IPython/core/profileapp.py
+++ b/IPython/core/profileapp.py
@@ -262,6 +262,7 @@ class ProfileCreate(BaseIPythonApplication):
         apps = [TerminalIPythonApp]
         for app_path in (
             'IPython.kernel.zmq.kernelapp.IPKernelApp',
+            'IPython.terminal.console.app.ZMQTerminalIPythonApp',
             'IPython.qt.console.qtconsoleapp.IPythonQtConsoleApp',
             'IPython.html.notebookapp.NotebookApp',
             'IPython.nbconvert.nbconvertapp.NbConvertApp',


### PR DESCRIPTION
when populating a profile

closes #3827
