### PR TITLE
Better support for wrapped function signatures in help

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -40,6 +40,7 @@ from IPython.utils.text import indent
 from IPython.utils.wildcard import list_namespace
 from IPython.utils.coloransi import TermColors, ColorScheme, ColorSchemeTable
 from IPython.utils.py3compat import cast_unicode, string_types, PY3
+from IPython.utils.signatures import signature
 
 # builtin docstrings to ignore
 _func_call_docstring = types.FunctionType.__call__.__doc__
@@ -390,7 +391,7 @@ class Inspector:
         If any exception is generated, None is returned instead and the
         exception is suppressed."""
         try:
-            hdef = oname + inspect.formatargspec(*getargspec(obj))
+            hdef = oname + str(signature(obj))
             return cast_unicode(hdef)
         except:
             return None

--- a/IPython/utils/signatures.py
+++ b/IPython/utils/signatures.py
@@ -72,10 +72,13 @@ def signature(obj):
         raise TypeError('{0!r} is not a callable object'.format(obj))
 
     if isinstance(obj, types.MethodType):
-        # In this case we skip the first parameter of the underlying
-        # function (usually `self` or `cls`).
-        sig = signature(obj.__func__)
-        return sig.replace(parameters=tuple(sig.parameters.values())[1:])
+        if obj.__self__ is None:
+            # Unbound method - treat it as a function (no distinction in Py 3)
+            obj = obj.__func__
+        else:
+            # Bound method: trim off the first parameter (typically self or cls)
+            sig = signature(obj.__func__)
+            return sig.replace(parameters=tuple(sig.parameters.values())[1:])
 
     try:
         sig = obj.__signature__


### PR DESCRIPTION
This supersedes #6362, with an extra fix to our backported signatures module to handle unbound methods like functions instead of like bound methods.
