### PR TITLE
`ipython console` requests the history from ZMQ-based kernels

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -15,7 +15,6 @@ from __future__ import print_function
 # Stdlib imports
 import atexit
 import datetime
-import abc
 import os
 import re
 try:
@@ -103,22 +102,19 @@ def catch_corrupt_db(f, self, *a, **kw):
 class HistoryAccessorBase(Configurable):
     """An abstract class for History Accessors """
 
-    @abc.abstractmethod
     def get_tail(self, n=10, raw=True, output=False, include_latest=False):
-        pass
+        raise NotImplementedError
 
-    @abc.abstractmethod
     def search(self, pattern="*", raw=True, search_raw=True,
                output=False, n=None, unique=False):
-        pass
+        raise NotImplementedError
 
-    @abc.abstractmethod
     def get_range(self, session, start=1, stop=None, raw=True,output=False):
-        pass
+        raise NotImplementedError
 
-    @abc.abstractmethod
     def get_range_by_str(self, rangestr, raw=True, output=False):
-        pass
+        raise NotImplementedError
+
 
 class HistoryAccessor(HistoryAccessorBase):
     """Access the history database without adding to it.

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -32,7 +32,6 @@ from IPython.external.decorator import decorator
 from IPython.utils.decorators import undoc
 from IPython.utils.path import locate_profile
 from IPython.utils import py3compat
-from IPython.utils.py3compat import with_metaclass
 from IPython.utils.traitlets import (
     Any, Bool, Dict, Instance, Integer, List, Unicode, TraitError,
 )

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -424,7 +424,7 @@ class InteractiveShell(SingletonConfigurable):
     display_trap = Instance('IPython.core.display_trap.DisplayTrap')
     extension_manager = Instance('IPython.core.extensions.ExtensionManager')
     payload_manager = Instance('IPython.core.payload.PayloadManager')
-    history_manager = Instance('IPython.core.history.HistoryManager')
+    history_manager = Instance('IPython.core.history.HistoryAccessorBase')
     magics_manager = Instance('IPython.core.magic.MagicsManager')
 
     profile_dir = Instance('IPython.core.application.ProfileDir')

--- a/IPython/terminal/console/interactiveshell.py
+++ b/IPython/terminal/console/interactiveshell.py
@@ -23,7 +23,7 @@ except ImportError:
 
 from IPython.core import page
 from IPython.core import release
-from IPython.core.history import KernelHistoryManager
+from IPython.terminal.console.zmqhistory import ZMQHistoryManager
 from IPython.utils.warn import warn, error
 from IPython.utils import io
 from IPython.utils.py3compat import string_types, input
@@ -573,6 +573,6 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
 
     def init_history(self):
         """Sets up the command history. """
-        self.history_manager = KernelHistoryManager(client=self.client) 
+        self.history_manager = ZMQHistoryManager(client=self.client) 
         self.configurables.append(self.history_manager)
 

--- a/IPython/terminal/console/interactiveshell.py
+++ b/IPython/terminal/console/interactiveshell.py
@@ -23,6 +23,7 @@ except ImportError:
 
 from IPython.core import page
 from IPython.core import release
+from IPython.core.history import KernelHistoryManager
 from IPython.utils.warn import warn, error
 from IPython.utils import io
 from IPython.utils.py3compat import string_types, input
@@ -31,7 +32,6 @@ from IPython.utils.tempdir import NamedFileInTemporaryDirectory
 
 from IPython.terminal.interactiveshell import TerminalInteractiveShell
 from IPython.terminal.console.completer import ZMQCompleter
-
 
 class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
     """A subclass of TerminalInteractiveShell that uses the 0MQ kernel"""
@@ -570,3 +570,9 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
 
         # Turn off the exit flag, so the mainloop can be restarted if desired
         self.exit_now = False
+
+    def init_history(self):
+        """Sets up the command history. """
+        self.history_manager = KernelHistoryManager(client=self.client) 
+        self.configurables.append(self.history_manager)
+

--- a/IPython/terminal/console/zmqhistory.py
+++ b/IPython/terminal/console/zmqhistory.py
@@ -12,7 +12,6 @@
 #-----------------------------------------------------------------------------
 
 from IPython.core.history import HistoryAccessorBase
-from IPython.utils import py3compat
 from IPython.utils.traitlets import Dict, List
 
 try:
@@ -46,9 +45,6 @@ class ZMQHistoryManager(HistoryAccessorBase):
         Load the history over ZMQ from the kernel. Wraps the history
         messaging with loop to wait to get history results.
         """
-        # 'range' (fill in session, start and stop params), 
-        # 'tail' (fill in n)
-        # 'search' (fill in pattern param).
         msg_id = self.client.history(raw=raw, output=output, 
                                      hist_access_type=hist_access_type, 
                                      **kwargs)
@@ -63,12 +59,6 @@ class ZMQHistoryManager(HistoryAccessorBase):
                     history = reply['content'].get('history', [])
                     break
         return history
-
-    def writeout_cache(self):
-        """
-        Not needed for ZMQ-based histories.
-        """
-        pass
 
     def get_tail(self, n=10, raw=True, output=False, include_latest=False):
         return self._load_history(hist_access_type='tail', n=n, raw=raw, 
@@ -87,7 +77,7 @@ class ZMQHistoryManager(HistoryAccessorBase):
 
     def get_range_by_str(self, rangestr, raw=True, output=False):
         return self._load_history(hist_access_type='range', raw=raw, 
-                                  output=output, rangestr=rangetr)
+                                  output=output, rangestr=rangestr)
 
     def end_session(self):
         """
@@ -96,16 +86,8 @@ class ZMQHistoryManager(HistoryAccessorBase):
         pass
 
     def reset(self, new_session=True):
-        """Clear the session history, releasing all object references, and
-        optionally open a new session."""
-        self.output_hist.clear()
-        # The directory history can't be completely empty
-        self.dir_hist[:] = [py3compat.getcwd()]
-        
-        if new_session:
-            if self.session_number:
-                self.end_session()
-            self.input_hist_parsed[:] = [""]
-            self.input_hist_raw[:] = [""]
-            self.new_session()
+        """
+        Nothing to do for ZMQ-based histories.
+        """
+        pass
 

--- a/IPython/terminal/console/zmqhistory.py
+++ b/IPython/terminal/console/zmqhistory.py
@@ -45,19 +45,21 @@ class ZMQHistoryManager(HistoryAccessorBase):
         Load the history over ZMQ from the kernel. Wraps the history
         messaging with loop to wait to get history results.
         """
-        msg_id = self.client.history(raw=raw, output=output, 
-                                     hist_access_type=hist_access_type, 
-                                     **kwargs)
         history = []
-        while True:
-            try:
-                reply = self.client.get_shell_msg(timeout=1)
-            except Empty:
-                break
-            else:
-                if reply['parent_header'].get('msg_id') == msg_id:
-                    history = reply['content'].get('history', [])
+        if hasattr(self.client, "history"):
+            ## In tests, KernelClient may not have a history method
+            msg_id = self.client.history(raw=raw, output=output,
+                                         hist_access_type=hist_access_type,
+                                         **kwargs)
+            while True:
+                try:
+                    reply = self.client.get_shell_msg(timeout=1)
+                except Empty:
                     break
+                else:
+                    if reply['parent_header'].get('msg_id') == msg_id:
+                        history = reply['content'].get('history', [])
+                        break
         return history
 
     def get_tail(self, n=10, raw=True, output=False, include_latest=False):

--- a/IPython/terminal/console/zmqhistory.py
+++ b/IPython/terminal/console/zmqhistory.py
@@ -1,0 +1,111 @@
+""" ZMQ Kernel History accessor and manager. """
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2010-2011 The IPython Development Team.
+#
+#  Distributed under the terms of the BSD License.
+#
+#  The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+from IPython.core.history import HistoryAccessorBase
+from IPython.utils import py3compat
+from IPython.utils.traitlets import Dict, List
+
+try:
+    from queue import Empty  # Py 3
+except ImportError:
+    from Queue import Empty  # Py 2
+
+class ZMQHistoryManager(HistoryAccessorBase):
+    """History accessor and manager for ZMQ-based kernels"""
+    input_hist_parsed = List([""])
+    output_hist = Dict()
+    dir_hist = List()
+    output_hist_reprs = Dict()
+
+    def __init__(self, client):
+        """
+        Class to load the command-line history from a ZMQ-based kernel,
+        and access the history.
+
+        Parameters
+        ----------
+
+        client: `IPython.kernel.KernelClient`
+          The kernel client in order to request the history.
+        """
+        self.client = client
+
+    def _load_history(self, raw=True, output=False, hist_access_type='range',
+                      **kwargs):
+        """
+        Load the history over ZMQ from the kernel. Wraps the history
+        messaging with loop to wait to get history results.
+        """
+        # 'range' (fill in session, start and stop params), 
+        # 'tail' (fill in n)
+        # 'search' (fill in pattern param).
+        msg_id = self.client.history(raw=raw, output=output, 
+                                     hist_access_type=hist_access_type, 
+                                     **kwargs)
+        history = []
+        while True:
+            try:
+                reply = self.client.get_shell_msg(timeout=1)
+            except Empty:
+                break
+            else:
+                if reply['parent_header'].get('msg_id') == msg_id:
+                    history = reply['content'].get('history', [])
+                    break
+        return history
+
+    def writeout_cache(self):
+        """
+        Not needed for ZMQ-based histories.
+        """
+        pass
+
+    def get_tail(self, n=10, raw=True, output=False, include_latest=False):
+        return self._load_history(hist_access_type='tail', n=n, raw=raw, 
+                                  output=output)
+
+    def search(self, pattern="*", raw=True, search_raw=True,
+               output=False, n=None, unique=False):
+        return self._load_history(hist_access_type='search', pattern=pattern, 
+                                  raw=raw, search_raw=search_raw, 
+                                  output=output, n=n, unique=unique)
+
+    def get_range(self, session, start=1, stop=None, raw=True,output=False):
+        return self._load_history(hist_access_type='range', raw=raw, 
+                                  output=output, start=start, stop=stop,
+                                  session=session)
+
+    def get_range_by_str(self, rangestr, raw=True, output=False):
+        return self._load_history(hist_access_type='range', raw=raw, 
+                                  output=output, rangestr=rangetr)
+
+    def end_session(self):
+        """
+        Nothing to do for ZMQ-based histories.
+        """
+        pass
+
+    def reset(self, new_session=True):
+        """Clear the session history, releasing all object references, and
+        optionally open a new session."""
+        self.output_hist.clear()
+        # The directory history can't be completely empty
+        self.dir_hist[:] = [py3compat.getcwd()]
+        
+        if new_session:
+            if self.session_number:
+                self.end_session()
+            self.input_hist_parsed[:] = [""]
+            self.input_hist_raw[:] = [""]
+            self.new_session()
+


### PR DESCRIPTION
This PR sets the history_manager to ZMQHistoryManager to request the history from the kernel over ZMQ. Tested on metakernel-based kernels, and with `ipython console` default ipython kernel.
