### PR TITLE
Don't specify profile-dir for kernels

### DIFF
--- a/IPython/consoleapp.py
+++ b/IPython/consoleapp.py
@@ -18,20 +18,13 @@ from IPython.config.application import boolean_flag
 from IPython.core.profiledir import ProfileDir
 from IPython.kernel.blocking import BlockingKernelClient
 from IPython.kernel import KernelManager
-from IPython.kernel import tunnel_to_kernel, find_connection_file, swallow_argv
+from IPython.kernel import tunnel_to_kernel, find_connection_file
 from IPython.kernel.kernelspec import NoSuchKernel
 from IPython.utils.path import filefind
 from IPython.utils.traitlets import (
     Dict, List, Unicode, CUnicode, CBool, Any
 )
-from IPython.kernel.zmq.kernelapp import (
-    kernel_flags,
-    kernel_aliases,
-    IPKernelApp
-)
-from IPython.kernel.zmq.pylab.config import InlineBackend
 from IPython.kernel.zmq.session import Session
-from IPython.kernel.zmq.zmqshell import ZMQInteractiveShell
 from IPython.kernel.connect import ConnectionFileMixin
 
 from IPython.utils.localinterfaces import localhost
@@ -40,7 +33,7 @@ from IPython.utils.localinterfaces import localhost
 # Aliases and Flags
 #-----------------------------------------------------------------------------
 
-flags = dict(kernel_flags)
+flags = {}
 
 # the flags that are specific to the frontend
 # these must be scrubbed before being passed to the kernel,
@@ -60,7 +53,7 @@ app_flags.update(boolean_flag(
 ))
 flags.update(app_flags)
 
-aliases = dict(kernel_aliases)
+aliases = {}
 
 # also scrub aliases from the frontend
 app_aliases = dict(
@@ -140,19 +133,12 @@ class IPythonConsoleApp(ConnectionFileMixin):
         to force a direct exit without any confirmation.""",
     )
     
-    @property
-    def help_classes(self):
-        """ConsoleApps can configure kernels on the command-line
-        
-        But this shouldn't be written to a file
-        """
-        return self.classes + [IPKernelApp] + IPKernelApp.classes
-    
     def build_kernel_argv(self, argv=None):
-        """build argv to be passed to kernel subprocess"""
-        if argv is None:
-            argv = sys.argv[1:]
-        self.kernel_argv = swallow_argv(argv, self.frontend_aliases, self.frontend_flags)
+        """build argv to be passed to kernel subprocess
+        
+        Override in subclasses if any args should be passed to the kernel
+        """
+        self.kernel_argv = self.extra_args
     
     def init_connection_file(self):
         """find the connection file, and load the info if found.

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -354,8 +354,6 @@ class NotebookApp(BaseIPythonApplication):
         list=(NbserverListApp, NbserverListApp.description.splitlines()[0]),
     )
 
-    ipython_kernel_argv = List(Unicode)
-    
     _log_formatter_cls = LogFormatter
 
     def _log_level_default(self):
@@ -777,12 +775,6 @@ class NotebookApp(BaseIPythonApplication):
                 c.NotebookApp.file_to_run = f
             self.update_config(c)
 
-    def init_kernel_argv(self):
-        """add the profile-dir to arguments to be passed to IPython kernels"""
-        # FIXME: remove special treatment of IPython kernels
-        # Kernel should get *absolute* path to profile directory
-        self.ipython_kernel_argv = ["--profile-dir", self.profile_dir.location]
-
     def init_configurables(self):
         self.kernel_spec_manager = self.kernel_spec_manager_class(
             parent=self,
@@ -791,7 +783,6 @@ class NotebookApp(BaseIPythonApplication):
         self.kernel_manager = self.kernel_manager_class(
             parent=self,
             log=self.log,
-            ipython_kernel_argv=self.ipython_kernel_argv,
             connection_dir=self.profile_dir.security_dir,
         )
         self.contents_manager = self.contents_manager_class(
@@ -999,7 +990,6 @@ class NotebookApp(BaseIPythonApplication):
     def initialize(self, argv=None):
         super(NotebookApp, self).initialize(argv)
         self.init_logging()
-        self.init_kernel_argv()
         self.init_configurables()
         self.init_components()
         self.init_webapp()

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -3,25 +3,10 @@
 """
 The :class:`~IPython.core.application.Application` object for the command
 line :command:`ipython` program.
-
-Authors
--------
-
-* Brian Granger
-* Fernando Perez
-* Min Ragan-Kelley
 """
 
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2011  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 from __future__ import absolute_import
 from __future__ import print_function

--- a/jupyter_console/app.py
+++ b/jupyter_console/app.py
@@ -52,6 +52,7 @@ aliases = dict(aliases)
 frontend_aliases = dict(app_aliases)
 # load updated frontend flags into full dict
 aliases.update(frontend_aliases)
+aliases['colors'] = 'InteractiveShell.colors'
 
 # get flags&aliases into sets, and remove a couple that
 # shouldn't be scrubbed from backend flags:

--- a/jupyter_console/app.py
+++ b/jupyter_console/app.py
@@ -2,17 +2,11 @@
 
 This is not a complete console app, as subprocess will not be able to receive
 input, there is no real readline support, among other limitations.
-
-Authors:
-
-* Min RK
-* Paul Ivanov
-
 """
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 import signal
 
 from IPython.terminal.ipapp import TerminalIPythonApp, frontend_flags as term_flags
@@ -98,10 +92,12 @@ class ZMQTerminalIPythonApp(TerminalIPythonApp, IPythonConsoleApp):
     frontend_flags = Any(frontend_flags)
     
     subcommands = Dict()
+    
+    force_interact = True
 
     def parse_command_line(self, argv=None):
         super(ZMQTerminalIPythonApp, self).parse_command_line(argv)
-        self.build_kernel_argv(argv)
+        self.build_kernel_argv(self.extra_args)
 
     def init_shell(self):
         IPythonConsoleApp.initialize(self)

--- a/jupyter_qtconsole/console/qtconsoleapp.py
+++ b/jupyter_qtconsole/console/qtconsoleapp.py
@@ -5,13 +5,8 @@ input, there is no real readline support, among other limitations.
 """
 
 # Copyright (c) IPython Development Team.
-# Distributed under the terms of the Modified BSD License. 
+# Distributed under the terms of the Modified BSD License.
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
-
-# stdlib imports
 import os
 import signal
 import sys
@@ -46,10 +41,8 @@ if os.name == 'nt':
 
     sys.excepthook = gui_excepthook
 
-# System library imports
 from IPython.external.qt import QtCore, QtGui
 
-# Local imports
 from IPython.config.application import boolean_flag
 from IPython.config.application import catch_config_error
 from IPython.core.application import BaseIPythonApplication
@@ -191,7 +184,7 @@ class IPythonQtConsoleApp(BaseIPythonApplication, IPythonConsoleApp):
 
     def parse_command_line(self, argv=None):
         super(IPythonQtConsoleApp, self).parse_command_line(argv)
-        self.build_kernel_argv(argv)
+        self.build_kernel_argv(self.extra_args)
 
 
     def new_frontend_master(self):


### PR DESCRIPTION
we are passing `--profile-dir` to non-IPython kernels. This avoids specifying it to _any_ kernels, which includes IPython, which may be premature.

It does clean up something in the console frontends, which blended frontend and kernel args. Now the console frontends  no longer need to understand anything about kernel flags, and kernel args can only be passed after `--`, e.g.:

```
   ipython qtconsole -- --matplotlib inline

   ipython qtconsole --kernel julia -- --some-julia-kernel-flag
```

closes #6626
