### PR TITLE
fix editorhooks typo

### DIFF
--- a/IPython/lib/editorhooks.py
+++ b/IPython/lib/editorhooks.py
@@ -10,13 +10,14 @@ import os
 import pipes
 import shlex
 import subprocess
+import sys
 
 from IPython import get_ipython
 from IPython.core.error import TryNext
 from IPython.utils import py3compat
 
 
-def install_editor(template_list, wait=False):
+def install_editor(template, wait=False):
     """Installs the editor that is called by IPython for the %edit magic.
 
     This overrides the default editor, which is generally set by your EDITOR

--- a/IPython/lib/tests/test_editorhooks.py
+++ b/IPython/lib/tests/test_editorhooks.py
@@ -1,0 +1,37 @@
+"""Test installing editor hooks"""
+import sys
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+import nose.tools as nt
+
+from IPython import get_ipython
+from IPython.lib import editorhooks
+
+def test_install_editor():
+    called = []
+    def fake_popen(*args, **kwargs):
+        called.append({
+            'args': args,
+            'kwargs': kwargs,
+        })
+    editorhooks.install_editor('foo -l {line} -f {filename}', wait=False)
+    
+    with mock.patch('subprocess.Popen', fake_popen):
+        get_ipython().hooks.editor('the file', 64)
+    
+    nt.assert_equal(len(called), 1)
+    args = called[0]['args']
+    kwargs = called[0]['kwargs']
+    
+    nt.assert_equal(kwargs, {'shell': True})
+    
+    if sys.platform.startswith('win'):
+        expected = ['foo', '-l', '64', '-f', 'the file']
+    else:
+        expected = "foo -l 64 -f 'the file'"
+    cmd = args[0]
+    nt.assert_equal(cmd, expected)


### PR DESCRIPTION
and add simple exercise test that would have caught the typo

I introduced a typo in #6927 with the tried-and-true method of
1. get it to work and tested on Windows
2. commit and push something completely different from my real computer
