### PR TITLE
TAB on empty line causes crash; with test

### DIFF
--- a/IPython/utils/tests/test_tokenutil.py
+++ b/IPython/utils/tests/test_tokenutil.py
@@ -4,7 +4,7 @@
 
 import nose.tools as nt
 
-from IPython.utils.tokenutil import token_at_cursor
+from IPython.utils.tokenutil import token_at_cursor, line_at_cursor
 
 def expect_token(expected, cell, cursor_pos):
     token = token_at_cursor(cell, cursor_pos)
@@ -68,3 +68,9 @@ def test_attrs():
     expected = 'obj.attr.subattr'
     for i in range(idx, len(cell)):
         expect_token(expected, cell, i)
+
+def test_line_at_cursor():
+    cell = ""
+    (line, offset) = line_at_cursor(cell, cursor_pos=11)
+    assert line == "", ("Expected '', got %r" % line)
+    assert offset == 0, ("Expected '', got %r" % line)

--- a/IPython/utils/tokenutil.py
+++ b/IPython/utils/tokenutil.py
@@ -49,6 +49,8 @@ def line_at_cursor(cell, cursor_pos=0):
         if next_offset >= cursor_pos:
             break
         offset = next_offset
+    else:
+        line = ""
     return (line, offset)
 
 def token_at_cursor(cell, cursor_pos=0):


### PR DESCRIPTION
If you start `ipython console` and then press TAB, crash! This fixes the issue, and provides a test.
