### PR TITLE
Ignore failure of widget MathJax typesetting

### DIFF
--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -766,6 +766,33 @@ define([
         };
     };
 
+    var typeset = function(element, text) {
+        /**
+         * Apply MathJax rendering to an element, and optionally set its text
+         *
+         * If MathJax is not available, make no changes.
+         *
+         * Returns the output any number of typeset elements, or undefined if
+         * MathJax was not available.
+         *
+         * Parameters
+         * ----------
+         * element: Node, NodeList, or jQuery selection
+         * text: option string
+         */
+        if(!window.MathJax){
+            return;
+        }
+        var $el = element.jquery ? element : $(element);
+        if(arguments.length > 1){
+            $el.text(text);
+        }
+        return $el.map(function(){
+            // MathJax takes a DOM node: $.map makes `this` the context
+            return MathJax.Hub.Queue(["Typeset", MathJax.Hub, this]);
+        });
+    };
+
     var utils = {
         regex_split : regex_split,
         uuid : uuid,
@@ -799,6 +826,7 @@ define([
         load_class: load_class,
         resolve_promises_dict: resolve_promises_dict,
         reject: reject,
+        typeset: typeset,
     };
 
     // Backwards compatability.

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -220,10 +220,7 @@ define([
      * @method typeset
      */
     Cell.prototype.typeset = function () {
-        if (window.MathJax) {
-            var cell_math = this.element.get(0);
-            MathJax.Hub.Queue(["Typeset", MathJax.Hub, cell_math]);
-        }
+        utils.typeset(this.element);
     };
 
     /**

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -199,9 +199,7 @@ define([
 
     // typeset with MathJax if MathJax is available
     OutputArea.prototype.typeset = function () {
-        if (window.MathJax){
-            MathJax.Hub.Queue(["Typeset",MathJax.Hub]);
-        }
+        utils.typeset(this.element);
     };
 
 

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -577,19 +577,7 @@ define(["widgets/js/manager",
         },
 
         typeset: function(element, text){
-            // after (optionally) updating a node(list) or jQuery selection's 
-            // text, check if MathJax is available and typeset it
-            var $el = element.jquery ? element : $(element);
-
-            if(arguments.length > 1){
-                $el.text(text);
-            }
-            if(!window.MathJax){
-                return;
-            }
-            return $el.map(function(){
-                return MathJax.Hub.Queue(["Typeset", MathJax.Hub, this]);
-            });
+            utils.typeset.apply(null, arguments);
         },
     });
 

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -388,18 +388,6 @@ define(["widgets/js/manager",
             } else {
                 this.on('displayed', callback, context);
             }
-        },
-
-        typeset: function($el, text){
-            // after (optionally) updating a selection's text, check if 
-            // MathJax is available and typeset it
-            if(arguments.length > 1){
-                $el.text(text);
-            }
-            if(!window.MathJax){
-                return;
-            }
-            return MathJax.Hub.Queue(["Typeset", MathJax.Hub, $el.get(0)]);
         }
     });
 
@@ -586,6 +574,18 @@ define(["widgets/js/manager",
                 elements = this.$el.find(selector).addBack(selector);
             }
             return elements;
+        },
+
+        typeset: function($el, text){
+            // after (optionally) updating a selection's text, check if 
+            // MathJax is available and typeset it
+            if(arguments.length > 1){
+                $el.text(text);
+            }
+            if(!window.MathJax){
+                return;
+            }
+            return MathJax.Hub.Queue(["Typeset", MathJax.Hub, $el.get(0)]);
         },
     });
 

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -389,6 +389,17 @@ define(["widgets/js/manager",
                 this.on('displayed', callback, context);
             }
         },
+
+        typeset: function(element){
+            // check if MathJax is available, and if so use it to
+            // typeset some DOM
+            if(!window.MathJax){ return; }
+            return MathJax.Hub.Queue([
+                "Typeset",
+                MathJax.Hub,
+                element
+            ]);
+        }
     });
 
 

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -576,16 +576,20 @@ define(["widgets/js/manager",
             return elements;
         },
 
-        typeset: function($el, text){
-            // after (optionally) updating a selection's text, check if 
-            // MathJax is available and typeset it
+        typeset: function(element, text){
+            // after (optionally) updating a node(list) or jQuery selection's 
+            // text, check if MathJax is available and typeset it
+            var $el = element.jquery ? element : $(element);
+
             if(arguments.length > 1){
                 $el.text(text);
             }
             if(!window.MathJax){
                 return;
             }
-            return MathJax.Hub.Queue(["Typeset", MathJax.Hub, $el.get(0)]);
+            return $el.map(function(){
+                return MathJax.Hub.Queue(["Typeset", MathJax.Hub, this]);
+            });
         },
     });
 

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -390,15 +390,12 @@ define(["widgets/js/manager",
             }
         },
 
-        typeset: function(element){
+        typeset: function(text, $el){
             // check if MathJax is available, and if so use it to
-            // typeset some DOM
+            // typeset some jQuery selection
+            $el.text(text);
             if(!window.MathJax){ return; }
-            return MathJax.Hub.Queue([
-                "Typeset",
-                MathJax.Hub,
-                element
-            ]);
+            return MathJax.Hub.Queue(["Typeset", MathJax.Hub, $el.get(0)]);
         }
     });
 

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -390,11 +390,15 @@ define(["widgets/js/manager",
             }
         },
 
-        typeset: function(text, $el){
-            // check if MathJax is available, and if so use it to
-            // typeset some jQuery selection
-            $el.text(text);
-            if(!window.MathJax){ return; }
+        typeset: function($el, text){
+            // after (optionally) updating a selection's text, check if 
+            // MathJax is available and typeset it
+            if(arguments.length > 1){
+                $el.text(text);
+            }
+            if(!window.MathJax){
+                return;
+            }
             return MathJax.Hub.Queue(["Typeset", MathJax.Hub, $el.get(0)]);
         }
     });

--- a/IPython/html/static/widgets/js/widget_bool.js
+++ b/IPython/html/static/widgets/js/widget_bool.js
@@ -62,7 +62,7 @@ define([
                 if (description.trim().length === 0) {
                     this.$label.hide();
                 } else {
-                    this.typeset(description, this.$label);
+                    this.typeset(this.$label, description);
                     this.$label.show();
                 }
             }

--- a/IPython/html/static/widgets/js/widget_bool.js
+++ b/IPython/html/static/widgets/js/widget_bool.js
@@ -62,8 +62,7 @@ define([
                 if (description.trim().length === 0) {
                     this.$label.hide();
                 } else {
-                    this.$label.text(description);
-                    this.typeset(this.$label.get(0));
+                    this.typeset(description, this.$label);
                     this.$label.show();
                 }
             }

--- a/IPython/html/static/widgets/js/widget_bool.js
+++ b/IPython/html/static/widgets/js/widget_bool.js
@@ -63,7 +63,7 @@ define([
                     this.$label.hide();
                 } else {
                     this.$label.text(description);
-                    MathJax.Hub.Queue(["Typeset",MathJax.Hub,this.$label.get(0)]);
+                    this.typeset(this.$label.get(0));
                     this.$label.show();
                 }
             }

--- a/IPython/html/static/widgets/js/widget_box.js
+++ b/IPython/html/static/widgets/js/widget_box.js
@@ -319,8 +319,7 @@ define([
             if (description.trim().length === 0) {
                 this.$title.html("&nbsp;"); // Preserve title height
             } else {
-                this.$title.text(description);
-                this.typeset(this.$title.get(0));
+                this.typeset(description, this.$title);
             }
             
             var button_text = this.model.get('button_text');

--- a/IPython/html/static/widgets/js/widget_box.js
+++ b/IPython/html/static/widgets/js/widget_box.js
@@ -320,7 +320,7 @@ define([
                 this.$title.html("&nbsp;"); // Preserve title height
             } else {
                 this.$title.text(description);
-                MathJax.Hub.Queue(["Typeset",MathJax.Hub,this.$title.get(0)]);
+                this.typeset(this.$title.get(0));
             }
             
             var button_text = this.model.get('button_text');

--- a/IPython/html/static/widgets/js/widget_box.js
+++ b/IPython/html/static/widgets/js/widget_box.js
@@ -319,7 +319,7 @@ define([
             if (description.trim().length === 0) {
                 this.$title.html("&nbsp;"); // Preserve title height
             } else {
-                this.typeset(description, this.$title);
+                this.typeset(this.$title, description);
             }
             
             var button_text = this.model.get('button_text');

--- a/IPython/html/static/widgets/js/widget_int.js
+++ b/IPython/html/static/widgets/js/widget_int.js
@@ -156,7 +156,7 @@ define([
                     this.$label.hide();
                 } else {
                     this.$label.text(description);
-                    MathJax.Hub.Queue(["Typeset",MathJax.Hub,this.$label.get(0)]);
+                    this.typeset(this.$label.get(0));
                     this.$label.show();
                 }
                 
@@ -324,7 +324,7 @@ define([
                     this.$label.hide();
                 } else {
                     this.$label.text(description);
-                    MathJax.Hub.Queue(["Typeset",MathJax.Hub,this.$label.get(0)]);
+                    this.typeset(this.$label.get(0));
                     this.$label.show();
                 }
             }
@@ -444,7 +444,7 @@ define([
                 this.$label.hide();
             } else {
                 this.$label.text(description);
-                MathJax.Hub.Queue(["Typeset",MathJax.Hub,this.$label.get(0)]);
+                this.typeset(this.$label.get(0));
                 this.$label.show();
             }
             return ProgressView.__super__.update.apply(this);

--- a/IPython/html/static/widgets/js/widget_int.js
+++ b/IPython/html/static/widgets/js/widget_int.js
@@ -155,7 +155,7 @@ define([
                 if (description.length === 0) {
                     this.$label.hide();
                 } else {
-                    this.typeset(description, this.$label);
+                    this.typeset(this.$label, description);
                     this.$label.show();
                 }
                 
@@ -322,7 +322,7 @@ define([
                 if (description.length === 0) {
                     this.$label.hide();
                 } else {
-                    this.typeset(description, this.$label);
+                    this.typeset(this.$label, description);
                     this.$label.show();
                 }
             }
@@ -441,7 +441,7 @@ define([
             if (description.length === 0) {
                 this.$label.hide();
             } else {
-                this.typeset(description, this.$label);
+                this.typeset(this.$label, description);
                 this.$label.show();
             }
             return ProgressView.__super__.update.apply(this);

--- a/IPython/html/static/widgets/js/widget_int.js
+++ b/IPython/html/static/widgets/js/widget_int.js
@@ -155,8 +155,7 @@ define([
                 if (description.length === 0) {
                     this.$label.hide();
                 } else {
-                    this.$label.text(description);
-                    this.typeset(this.$label.get(0));
+                    this.typeset(description, this.$label);
                     this.$label.show();
                 }
                 
@@ -323,8 +322,7 @@ define([
                 if (description.length === 0) {
                     this.$label.hide();
                 } else {
-                    this.$label.text(description);
-                    this.typeset(this.$label.get(0));
+                    this.typeset(description, this.$label);
                     this.$label.show();
                 }
             }
@@ -443,8 +441,7 @@ define([
             if (description.length === 0) {
                 this.$label.hide();
             } else {
-                this.$label.text(description);
-                this.typeset(this.$label.get(0));
+                this.typeset(description, this.$label);
                 this.$label.show();
             }
             return ProgressView.__super__.update.apply(this);

--- a/IPython/html/static/widgets/js/widget_selection.js
+++ b/IPython/html/static/widgets/js/widget_selection.js
@@ -97,8 +97,7 @@ define([
                 if (description.length === 0) {
                     this.$label.hide();
                 } else {
-                    this.$label.text(description);
-                    this.typeset(this.$label.get(0));
+                    this.typeset(description, this.$label);
                     this.$label.show();
                 }
             }
@@ -231,7 +230,7 @@ define([
                     this.$label.hide();
                 } else {
                     this.$label.text(description);
-                   this.typeset(this.$label.get(0));
+                    this.typeset(description, this.$label);
                     this.$label.show();
                 }
             }
@@ -345,8 +344,8 @@ define([
                 if (description.length === 0) {
                     this.$label.hide();
                 } else {
-                    this.$label.text(description);
-                    this.typeset(this.$label.get(0));
+                    this.$label.text();
+                    this.typeset(description, this.$label);
                     this.$label.show();
                 }
             }
@@ -468,8 +467,7 @@ define([
                 if (description.length === 0) {
                     this.$label.hide();
                 } else {
-                    this.$label.text(description);
-                    this.typeset(this.$label.get(0));
+                    this.typeset(description, this.$label);
                     this.$label.show();
                 }
             }

--- a/IPython/html/static/widgets/js/widget_selection.js
+++ b/IPython/html/static/widgets/js/widget_selection.js
@@ -97,7 +97,7 @@ define([
                 if (description.length === 0) {
                     this.$label.hide();
                 } else {
-                    this.typeset(description, this.$label);
+                    this.typeset(this.$label, description);
                     this.$label.show();
                 }
             }
@@ -230,7 +230,7 @@ define([
                     this.$label.hide();
                 } else {
                     this.$label.text(description);
-                    this.typeset(description, this.$label);
+                    this.typeset(this.$label, description);
                     this.$label.show();
                 }
             }
@@ -345,7 +345,7 @@ define([
                     this.$label.hide();
                 } else {
                     this.$label.text();
-                    this.typeset(description, this.$label);
+                    this.typeset(this.$label, description);
                     this.$label.show();
                 }
             }
@@ -467,7 +467,7 @@ define([
                 if (description.length === 0) {
                     this.$label.hide();
                 } else {
-                    this.typeset(description, this.$label);
+                    this.typeset(this.$label, description);
                     this.$label.show();
                 }
             }

--- a/IPython/html/static/widgets/js/widget_selection.js
+++ b/IPython/html/static/widgets/js/widget_selection.js
@@ -98,7 +98,7 @@ define([
                     this.$label.hide();
                 } else {
                     this.$label.text(description);
-                    MathJax.Hub.Queue(["Typeset",MathJax.Hub,this.$label.get(0)]);
+                    this.typeset(this.$label.get(0));
                     this.$label.show();
                 }
             }
@@ -231,7 +231,7 @@ define([
                     this.$label.hide();
                 } else {
                     this.$label.text(description);
-                    MathJax.Hub.Queue(["Typeset",MathJax.Hub,this.$label.get(0)]);
+                   this.typeset(this.$label.get(0));
                     this.$label.show();
                 }
             }
@@ -346,7 +346,7 @@ define([
                     this.$label.hide();
                 } else {
                     this.$label.text(description);
-                    MathJax.Hub.Queue(["Typeset",MathJax.Hub,this.$label.get(0)]);
+                    this.typeset(this.$label.get(0));
                     this.$label.show();
                 }
             }
@@ -469,7 +469,7 @@ define([
                     this.$label.hide();
                 } else {
                     this.$label.text(description);
-                    MathJax.Hub.Queue(["Typeset",MathJax.Hub,this.$label.get(0)]);
+                    this.typeset(this.$label.get(0));
                     this.$label.show();
                 }
             }

--- a/IPython/html/static/widgets/js/widget_string.js
+++ b/IPython/html/static/widgets/js/widget_string.js
@@ -43,7 +43,7 @@ define([
              * Called when the model is changed.  The model may have been 
              * changed by another view or by a state update from the back-end.
              */
-            this.typeset(this.model.get('value'), this.$el);
+            this.typeset(this.$el, this.model.get('value'));
             return LatexView.__super__.update.apply(this);
         }, 
     });
@@ -114,7 +114,7 @@ define([
                 if (description.length === 0) {
                     this.$label.hide();
                 } else {
-                    this.typeset(description, this.$label);
+                    this.typeset(this.$label, description);
                     this.$label.show();
                 }
             }
@@ -197,7 +197,7 @@ define([
                 if (description.length === 0) {
                     this.$label.hide();
                 } else {
-                    this.typeset(description, this.$label);
+                    this.typeset(this.$label, description);
                     this.$label.show();
                 }
             }

--- a/IPython/html/static/widgets/js/widget_string.js
+++ b/IPython/html/static/widgets/js/widget_string.js
@@ -43,8 +43,7 @@ define([
              * Called when the model is changed.  The model may have been 
              * changed by another view or by a state update from the back-end.
              */
-            this.$el.text(this.model.get('value'));
-            this.typeset(this.$el.get(0));
+            this.typeset(this.model.get('value'), this.$el);
             return LatexView.__super__.update.apply(this);
         }, 
     });
@@ -115,8 +114,7 @@ define([
                 if (description.length === 0) {
                     this.$label.hide();
                 } else {
-                    this.$label.text(description);
-                    this.typeset(this.$label.get(0));
+                    this.typeset(description, this.$label);
                     this.$label.show();
                 }
             }
@@ -199,8 +197,7 @@ define([
                 if (description.length === 0) {
                     this.$label.hide();
                 } else {
-                    this.$label.text(description);
-                    this.typeset(this.$label.get(0));
+                    this.typeset(description, this.$label);
                     this.$label.show();
                 }
             }

--- a/IPython/html/static/widgets/js/widget_string.js
+++ b/IPython/html/static/widgets/js/widget_string.js
@@ -44,8 +44,7 @@ define([
              * changed by another view or by a state update from the back-end.
              */
             this.$el.text(this.model.get('value'));
-            MathJax.Hub.Queue(["Typeset",MathJax.Hub,this.$el.get(0)]);
-
+            this.typeset(this.$el.get(0));
             return LatexView.__super__.update.apply(this);
         }, 
     });
@@ -117,7 +116,7 @@ define([
                     this.$label.hide();
                 } else {
                     this.$label.text(description);
-                    MathJax.Hub.Queue(["Typeset",MathJax.Hub,this.$label.get(0)]);
+                    this.typeset(this.$label.get(0));
                     this.$label.show();
                 }
             }
@@ -201,7 +200,7 @@ define([
                     this.$label.hide();
                 } else {
                     this.$label.text(description);
-                    MathJax.Hub.Queue(["Typeset",MathJax.Hub,this.$label.get(0)]);
+                    this.typeset(this.$label.get(0));
                     this.$label.show();
                 }
             }


### PR DESCRIPTION
Having never known MathJax `$...$` could be used for _some_ of the core widgets, it was surprising and confusing when I was (trying) to give an impromptu, disconnected demo and nothing worked because MathJax wasn't available.

I understand the desire to make this fairly-heavyweight dependency an optional install. But widgets should probably not fail unusably when MathJax isn't available, for whatever reason.

This PR moves the actual, ungainly `MathJax.Hub.Queue` call from _n_ places around the core widgets to `DOMWidgetView`, under a much simpler API, `.typeset(element, [text])`, where the presence of MathJax is tested. Since typesetting brings with it more expectations (i.e., you won't have any other DOM children), `.typeset` also optionally accepts the text to set, and since jQuery is used so extensively throughout core, the element can be a jquery selector.
## Questions for other PRs
- Should typesetting-as-default be extended across all the core widgets (i.e. `Button.description`, `Accordion.titles`, probably more...)?
- Could this be made more explicit, such as with a traitlet type, e.g. `TypesetUnicode`...
  - Actually would there be any way for the downstream to know that was the case?
- Should this, one of the few, and most idiosyncratic, remaining uses of `window` globals, be wrapped, with a `util`, something like:
  
  ``` js
  require(["notebook/js/mathjaxutils"], function(mathjax){
  mathjax().then(
    function(yup){...},
    function(nope){...}
  )
  })
  ```
