### PR TITLE
Add kernel-select dropdown to new notebook button

### DIFF
--- a/IPython/html/services/kernelspecs/tests/test_kernelspecs_api.py
+++ b/IPython/html/services/kernelspecs/tests/test_kernelspecs_api.py
@@ -78,16 +78,22 @@ class APITest(NotebookTestBase):
         with open(pjoin(bad_kernel_dir, 'kernel.json'), 'w') as f:
             f.write("garbage")
         
-        specs = self.ks_api.list().json()
-        assert isinstance(specs, list)
+        model = self.ks_api.list().json()
+        assert isinstance(model, dict)
+        self.assertEqual(model['default'], NATIVE_KERNEL_NAME)
+        specs = model['kernelspecs']
+        assert isinstance(specs, dict)
         # 2: the sample kernelspec created in setUp, and the native Python kernel
         self.assertGreaterEqual(len(specs), 2)
         
         shutil.rmtree(bad_kernel_dir)
     
     def test_list_kernelspecs(self):
-        specs = self.ks_api.list().json()
-        assert isinstance(specs, list)
+        model = self.ks_api.list().json()
+        assert isinstance(model, dict)
+        self.assertEqual(model['default'], NATIVE_KERNEL_NAME)
+        specs = model['kernelspecs']
+        assert isinstance(specs, dict)
 
         # 2: the sample kernelspec created in setUp, and the native Python kernel
         self.assertGreaterEqual(len(specs), 2)
@@ -98,8 +104,8 @@ class APITest(NotebookTestBase):
         def is_default_kernelspec(s):
             return s['name'] == NATIVE_KERNEL_NAME and s['display_name'].startswith("IPython")
 
-        assert any(is_sample_kernelspec(s) for s in specs), specs
-        assert any(is_default_kernelspec(s) for s in specs), specs
+        assert any(is_sample_kernelspec(s) for s in specs.values()), specs
+        assert any(is_default_kernelspec(s) for s in specs.values()), specs
 
     def test_get_kernelspec(self):
         spec = self.ks_api.kernel_spec_info('Sample').json()  # Case insensitive

--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -541,7 +541,16 @@ define([
         if (navigator.appVersion.indexOf("Linux")!=-1) OSName="Linux";
         return OSName;
     })();
-
+    
+    var get_url_param = function (name) {
+        // get a URL parameter. I cannot believe we actually need this.
+        // Based on http://stackoverflow.com/a/25359264/938949
+        var match = new RegExp('[\?&]' + name + '=([^&]*)').exec(window.location.search);
+        if (match){
+            return decodeURIComponent(match[1] || '');
+        }
+    };
+    
     var is_or_has = function (a, b) {
         /**
          * Is b a child of a or a itself?
@@ -786,6 +795,7 @@ define([
         from_absolute_cursor_pos : from_absolute_cursor_pos,
         browser : browser,
         platform: platform,
+        get_url_param: get_url_param,
         is_or_has : is_or_has,
         is_focused : is_focused,
         mergeopt: mergeopt,

--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -641,6 +641,7 @@ define([
          * Like $.ajax, but returning an ES6 promise. success and error settings
          * will be ignored.
          */
+        settings = settings || {};
         return new Promise(function(resolve, reject) {
             settings.success = function(data, status, jqXHR) {
                 resolve(data);

--- a/IPython/html/static/notebook/js/kernelselector.js
+++ b/IPython/html/static/notebook/js/kernelselector.js
@@ -25,16 +25,27 @@ define([
     
     KernelSelector.prototype.request_kernelspecs = function() {
         var url = utils.url_join_encode(this.notebook.base_url, 'api/kernelspecs');
-        $.ajax(url, {success: $.proxy(this._got_kernelspecs, this)});
+        utils.promising_ajax(url).then($.proxy(this._got_kernelspecs, this));
     };
     
-    KernelSelector.prototype._got_kernelspecs = function(data, status, xhr) {
-        this.kernelspecs = {};
+    KernelSelector.prototype._got_kernelspecs = function(data) {
+        this.kernelspecs = data.kernelspecs;
         var menu = this.element.find("#kernel_selector");
         var change_kernel_submenu = $("#menu-change-kernel-submenu");
-        for (var i = 0; i < data.length; i++) {
-            var ks = data[i];
-            this.kernelspecs[ks.name] = ks;
+        var keys = Object.keys(data.kernelspecs).sort(function (a, b) {
+            // sort by display_name
+            var da = data.kernelspecs[a].display_name;
+            var db = data.kernelspecs[b].display_name;
+            if (da === db) {
+                return 0;
+            } else if (da > db) {
+                return 1;
+            } else {
+                return -1;
+            }
+        });
+        for (var i = 0; i < keys.length; i++) {
+            var ks = this.kernelspecs[keys[i]];
             var ksentry = $("<li>").attr("id", "kernel-" +ks.name).append($('<a>')
                 .attr('href', '#')
                 .click($.proxy(this.change_kernel, this, ks.name))

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -2275,9 +2275,13 @@ define([
         // Create the session after the notebook is completely loaded to prevent
         // code execution upon loading, which is a security risk.
         if (this.session === null) {
-            var kernelspec = this.metadata.kernelspec || {};
-            var kernel_name = kernelspec.name;
-
+            var kernel_name;
+            if (this.metadata.kernelspec) {
+                var kernelspec = this.metadata.kernelspec || {};
+                kernel_name = kernelspec.name;
+            } else {
+                kernel_name = utils.get_url_param('kernel_name');
+            }
             this.start_session(kernel_name);
         }
         // load our checkpoint list

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -7999,14 +7999,15 @@ span#login_widget > .button .badge,
   margin: 0;
 }
 .alternate_upload input.fileinput {
-  background-color: red;
-  position: relative;
+  display: inline;
   opacity: 0;
   z-index: 2;
-  width: 295px;
-  margin-left: 163px;
-  cursor: pointer;
-  height: 26px;
+  width: 12ex;
+  margin-right: -12ex;
+}
+.alternate_upload .input-overlay {
+  display: inline-block;
+  font-weight: bold;
 }
 /**
  * Primary styles

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8164,6 +8164,10 @@ input.engine_num_input {
 .file_icon:before.pull-right {
   margin-left: .3em;
 }
+ul#new-notebook-menu {
+  left: auto;
+  right: 0;
+}
 /*!
 *
 * IPython notebook

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8168,6 +8168,17 @@ ul#new-notebook-menu {
   left: auto;
   right: 0;
 }
+.kernel-menu-icon {
+  padding-right: 12px;
+  width: 24px;
+  content: "\f096";
+}
+.kernel-menu-icon:before {
+  content: "\f096";
+}
+.kernel-menu-icon-current:before {
+  content: "\f00c";
+}
 /*!
 *
 * IPython notebook

--- a/IPython/html/static/tree/js/main.js
+++ b/IPython/html/static/tree/js/main.js
@@ -14,6 +14,7 @@ require([
     'tree/js/sessionlist',
     'tree/js/kernellist',
     'tree/js/terminallist',
+    'tree/js/newnotebook',
     'auth/js/loginwidget',
     // only loaded, not used:
     'jqueryui',
@@ -27,11 +28,12 @@ require([
     page,
     utils,
     contents_service,
-    notebooklist, 
-    clusterlist, 
-    sesssionlist, 
+    notebooklist,
+    clusterlist,
+    sesssionlist,
     kernellist,
     terminallist,
+    newnotebook,
     loginwidget){
     "use strict";
 
@@ -63,24 +65,12 @@ require([
 
     var login_widget = new loginwidget.LoginWidget('#login_widget', common_options);
 
-    $('#new_notebook').click(function (e) {
-        var w = window.open();
-        contents.new_untitled(common_options.notebook_path, {type: "notebook"}).then(
-                function (data) {
-                    w.location = utils.url_join_encode(
-                            common_options.base_url, 'notebooks', data.path
-                        );
-                },
-                function(error) {
-                    w.close();
-                    dialog.modal({
-                        title : 'Creating Notebook Failed',
-                        body : "The error was: " + error.message,
-                        buttons : {'OK' : {'class' : 'btn-primary'}}
-                    });
-                }
-            );
-    });
+    var nnw = new newnotebook.NewNotebookWidget("#new-notebook-buttons",
+        $.extend(
+            {contents: contents},
+            common_options
+        )
+    );
 
     var interval_id=0;
     // auto refresh every xx secondes, no need to be fast,

--- a/IPython/html/static/tree/js/main.js
+++ b/IPython/html/static/tree/js/main.js
@@ -89,18 +89,18 @@ require([
          */
         session_list.load_sessions();
         cluster_list.load_list();
-	if (terminal_list) {
-	    terminal_list.load_terminals();
-	}
+        if (terminal_list) {
+            terminal_list.load_terminals();
+        }
         if (!interval_id){
             interval_id = setInterval(function(){
-                    session_list.load_sessions();
-                    cluster_list.load_list();
-		    if (terminal_list) {
-		        terminal_list.load_terminals();
-		    }
-                }, time_refresh*1000);
-            }
+                session_list.load_sessions();
+                cluster_list.load_list();
+                if (terminal_list) {
+                    terminal_list.load_terminals();
+                }
+            }, time_refresh*1000);
+        }
     };
 
     var disable_autorefresh = function(){

--- a/IPython/html/static/tree/js/main.js
+++ b/IPython/html/static/tree/js/main.js
@@ -130,6 +130,7 @@ require([
     IPython.session_list = session_list;
     IPython.kernel_list = kernel_list;
     IPython.login_widget = login_widget;
+    IPython.new_notebook_widget = nnw;
 
     events.trigger('app_initialized.DashboardApp');
     

--- a/IPython/html/static/tree/js/main.js
+++ b/IPython/html/static/tree/js/main.js
@@ -8,6 +8,7 @@ require([
     'base/js/events',
     'base/js/page',
     'base/js/utils',
+    'services/config',
     'contents',
     'tree/js/notebooklist',
     'tree/js/clusterlist',
@@ -27,6 +28,7 @@ require([
     events,
     page,
     utils,
+    config,
     contents_service,
     notebooklist,
     clusterlist,
@@ -43,6 +45,10 @@ require([
         base_url: utils.get_body_data("baseUrl"),
         notebook_path: utils.get_body_data("notebookPath"),
     };
+    var cfg = new config.ConfigSection('tree', common_options);
+    cfg.load();
+    common_options.config = cfg;
+    
     var session_list = new sesssionlist.SesssionList($.extend({
         events: events}, 
         common_options));

--- a/IPython/html/static/tree/js/newnotebook.js
+++ b/IPython/html/static/tree/js/newnotebook.js
@@ -43,13 +43,21 @@ define([
         for (var i = 0; i < data.length; i++) {
             var ks = data[i];
             this.kernelspecs[ks.name] = ks;
-            var ksentry = $("<li>").attr("id", "kernel-" +ks.name).append($('<a>')
-                .attr('href', '#')
-                .click($.proxy(this.new_with_kernel, this, ks.name))
-                .text(ks.display_name)
-                .attr('title', 'Create a new notebook with ' + ks.display_name)
+            var li = $("<li>")
+                .attr("id", "kernel-" +ks.name)
+                .data('kernelspec', ks).append(
+                    $('<a>').attr('href', '#').append($('<i>')
+                        .addClass('kernel-menu-icon fa')
+                        .attr('href', '#')
+                        .click($.proxy(this.select_kernel, this, ks.name))
+                    ).append($('<span>')
+                        .attr('href', '#')
+                        .click($.proxy(this.new_notebook, this, ks.name))
+                        .text(ks.display_name)
+                        .attr('title', 'Create a new notebook with ' + ks.display_name)
+                    )
             );
-            menu.append(ksentry);
+            menu.append(li);
         }
         this._load_default_kernelspec();
     };
@@ -75,11 +83,23 @@ define([
         this.element.find("#new_notebook").attr('title',
             'Create a new notebook with ' + display_name
         );
+        this.element.find("li").map(function (i, li) {
+            li = $(li);
+            var ks = li.data('kernelspec');
+            if (ks.name == kernel_name) {
+                li.find(".kernel-menu-icon")
+                    .attr('title', display_name + ' is the default kernel')
+                    .addClass("kernel-menu-icon-current");
+            } else {
+                li.find(".kernel-menu-icon")
+                    .attr('title', 'Make ' + ks.display_name + ' the default kernel')
+                    .removeClass("kernel-menu-icon-current");
+            }
+        });
     };
     
     NewNotebookWidget.prototype.new_with_kernel = function (kernel_name) {
         /** record current selection and open a new notebook */
-        this.select_kernel(kernel_name);
         this.new_notebook(kernel_name);
     };
     

--- a/IPython/html/static/tree/js/newnotebook.js
+++ b/IPython/html/static/tree/js/newnotebook.js
@@ -94,7 +94,9 @@ define([
         var display_name;
         if (spec) {
             display_name = spec.display_name;
-            this.element.find("#current-kernel").text(display_name);
+            this.element.find("#current-kernel")
+                .text(display_name)
+                .attr('title', display_name + " is the default kernel for new notebooks");
         } else {
             display_name = 'default kernel';
         }

--- a/IPython/html/static/tree/js/newnotebook.js
+++ b/IPython/html/static/tree/js/newnotebook.js
@@ -38,11 +38,21 @@ define([
     
     NewNotebookWidget.prototype._load_kernelspecs = function (data) {
         /** load kernelspec list */
-        this.kernelspecs = {};
+        this.kernelspecs = data.kernelspecs;
         var menu = this.element.find("#new-notebook-menu");
-        for (var i = 0; i < data.length; i++) {
-            var ks = data[i];
-            this.kernelspecs[ks.name] = ks;
+        var keys = Object.keys(data.kernelspecs).sort(function (a, b) {
+            var da = data.kernelspecs[a].display_name;
+            var db = data.kernelspecs[b].display_name;
+            if (da === db) {
+                return 0;
+            } else if (da > db) {
+                return 1;
+            } else {
+                return -1;
+            }
+        });
+        for (var i = 0; i < keys.length; i++) {
+            var ks = this.kernelspecs[keys[i]];
             var li = $("<li>")
                 .attr("id", "kernel-" +ks.name)
                 .data('kernelspec', ks).append(
@@ -59,12 +69,12 @@ define([
             );
             menu.append(li);
         }
-        this._load_default_kernelspec();
+        this._load_default_kernelspec(data['default']);
     };
     
-    NewNotebookWidget.prototype._load_default_kernelspec = function () {
+    NewNotebookWidget.prototype._load_default_kernelspec = function (default_name) {
         /** load default kernelspec name from localStorage, if defined */
-        this.select_kernel(localStorage.default_kernel_name);
+        this.select_kernel(localStorage.default_kernel_name || default_name);
     };
 
     NewNotebookWidget.prototype.select_kernel = function (kernel_name) {

--- a/IPython/html/static/tree/js/newnotebook.js
+++ b/IPython/html/static/tree/js/newnotebook.js
@@ -67,6 +67,7 @@ define([
         if (spec) {
             display_name = spec.display_name;
             localStorage.default_kernel_name = kernel_name;
+            this.element.find("#current-kernel").text(display_name);
         } else {
             display_name = 'default kernel';
             delete localStorage.default_kernel_name;

--- a/IPython/html/static/tree/js/newnotebook.js
+++ b/IPython/html/static/tree/js/newnotebook.js
@@ -15,6 +15,7 @@ define([
         this.notebook_path = options.notebook_path;
         this.contents = options.contents;
         this.current_selection = null;
+        this.config = options.config;
         this.kernelspecs = {};
         if (this.selector !== undefined) {
             this.element = $(selector);
@@ -38,6 +39,7 @@ define([
     
     NewNotebookWidget.prototype._load_kernelspecs = function (data) {
         /** load kernelspec list */
+        var that = this;
         this.kernelspecs = data.kernelspecs;
         var menu = this.element.find("#new-notebook-menu");
         var keys = Object.keys(data.kernelspecs).sort(function (a, b) {
@@ -69,17 +71,30 @@ define([
             );
             menu.append(li);
         }
-        this._load_default_kernelspec(data['default']);
+        this.config.loaded.then(function () {
+            that._load_default_kernelspec(data['default']);
+        });
     };
     
     NewNotebookWidget.prototype._load_default_kernelspec = function (default_name) {
         /** load default kernelspec name from localStorage, if defined */
-        this.select_kernel(localStorage.default_kernel_name || default_name);
+        if (this.config.data.NewNotebookWidget &&
+            this.config.data.NewNotebookWidget.current_selection &&
+            this.kernelspecs[this.config.data.NewNotebookWidget.current_selection] !== undefined
+        ) {
+            default_name = this.config.data.NewNotebookWidget.current_selection;
+        }
+        this.select_kernel(default_name);
     };
 
     NewNotebookWidget.prototype.select_kernel = function (kernel_name) {
         /** select the current default kernel */
         this.current_selection = kernel_name;
+        this.config.update({
+            NewNotebookWidget: {
+                current_selection: kernel_name
+            }
+        });
         var spec = this.kernelspecs[kernel_name];
         var display_name;
         if (spec) {

--- a/IPython/html/static/tree/js/newnotebook.js
+++ b/IPython/html/static/tree/js/newnotebook.js
@@ -1,0 +1,112 @@
+// Copyright (c) IPython Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+define([
+    'jquery',
+    'base/js/namespace',
+    'base/js/utils',
+    'base/js/dialog',
+], function ($, IPython, utils, dialog) {
+    "use strict";
+    
+    var NewNotebookWidget = function (selector, options) {
+        this.selector = selector;
+        this.base_url = options.base_url;
+        this.notebook_path = options.notebook_path;
+        this.contents = options.contents;
+        this.current_selection = null;
+        this.kernelspecs = {};
+        if (this.selector !== undefined) {
+            this.element = $(selector);
+            this.request_kernelspecs();
+        }
+        this.bind_events();
+    };
+    
+    NewNotebookWidget.prototype.bind_events = function () {
+        var that = this;
+        this.element.find('#new_notebook').click(function () {
+            that.new_notebook();
+        });
+    };
+    
+    NewNotebookWidget.prototype.request_kernelspecs = function () {
+        /** request and then load kernel specs */
+        var url = utils.url_join_encode(this.base_url, 'api/kernelspecs');
+        utils.promising_ajax(url).then($.proxy(this._load_kernelspecs, this));
+    };
+    
+    NewNotebookWidget.prototype._load_kernelspecs = function (data) {
+        /** load kernelspec list */
+        this.kernelspecs = {};
+        var menu = this.element.find("#new-notebook-menu");
+        for (var i = 0; i < data.length; i++) {
+            var ks = data[i];
+            this.kernelspecs[ks.name] = ks;
+            var ksentry = $("<li>").attr("id", "kernel-" +ks.name).append($('<a>')
+                .attr('href', '#')
+                .click($.proxy(this.new_with_kernel, this, ks.name))
+                .text(ks.display_name)
+                .attr('title', 'Create a new notebook with ' + ks.display_name)
+            );
+            menu.append(ksentry);
+        }
+        this._load_default_kernelspec();
+    };
+    
+    NewNotebookWidget.prototype._load_default_kernelspec = function () {
+        /** load default kernelspec name from localStorage, if defined */
+        this.select_kernel(localStorage.default_kernel_name);
+    };
+
+    NewNotebookWidget.prototype.select_kernel = function (kernel_name) {
+        /** select the current default kernel */
+        this.current_selection = kernel_name;
+        var spec = this.kernelspecs[kernel_name];
+        var display_name;
+        if (spec) {
+            display_name = spec.display_name;
+            localStorage.default_kernel_name = kernel_name;
+        } else {
+            display_name = 'default kernel';
+            delete localStorage.default_kernel_name;
+        }
+        this.element.find("#new_notebook").attr('title',
+            'Create a new notebook with ' + display_name
+        );
+    };
+    
+    NewNotebookWidget.prototype.new_with_kernel = function (kernel_name) {
+        /** record current selection and open a new notebook */
+        this.select_kernel(kernel_name);
+        this.new_notebook(kernel_name);
+    };
+    
+    NewNotebookWidget.prototype.new_notebook = function (kernel_name) {
+        /** create and open a new notebook */
+        var that = this;
+        kernel_name = kernel_name || this.current_selection;
+        var w = window.open();
+        this.contents.new_untitled(that.notebook_path, {type: "notebook"}).then(
+            function (data) {
+                var url = utils.url_join_encode(
+                    that.base_url, 'notebooks', data.path
+                );
+                if (kernel_name) {
+                    url += "?kernel_name=" + kernel_name;
+                }
+                w.location = url;
+            },
+            function (error) {
+                w.close();
+                dialog.modal({
+                    title : 'Creating Notebook Failed',
+                    body : "The error was: " + error.message,
+                    buttons : {'OK' : {'class' : 'btn-primary'}}
+                });
+            }
+        );
+    };
+    
+    return {'NewNotebookWidget': NewNotebookWidget};
+});

--- a/IPython/html/static/tree/js/newnotebook.js
+++ b/IPython/html/static/tree/js/newnotebook.js
@@ -58,17 +58,12 @@ define([
             var li = $("<li>")
                 .attr("id", "kernel-" +ks.name)
                 .data('kernelspec', ks).append(
-                    $('<a>').attr('href', '#').append($('<i>')
-                        .addClass('kernel-menu-icon fa')
-                        .attr('href', '#')
-                        .click($.proxy(this.select_kernel, this, ks.name))
-                    ).append($('<span>')
+                    $('<a>')
                         .attr('href', '#')
                         .click($.proxy(this.new_notebook, this, ks.name))
                         .text(ks.display_name)
                         .attr('title', 'Create a new notebook with ' + ks.display_name)
-                    )
-            );
+                );
             menu.append(li);
         }
         this.config.loaded.then(function () {
@@ -77,17 +72,17 @@ define([
     };
     
     NewNotebookWidget.prototype._load_default_kernelspec = function (default_name) {
-        /** load default kernelspec name from localStorage, if defined */
+        /** load default kernelspec name from config, if defined */
         if (this.config.data.NewNotebookWidget &&
             this.config.data.NewNotebookWidget.current_selection &&
             this.kernelspecs[this.config.data.NewNotebookWidget.current_selection] !== undefined
         ) {
             default_name = this.config.data.NewNotebookWidget.current_selection;
         }
-        this.select_kernel(default_name);
+        this.set_default_kernel(default_name);
     };
 
-    NewNotebookWidget.prototype.select_kernel = function (kernel_name) {
+    NewNotebookWidget.prototype.set_default_kernel = function (kernel_name) {
         /** select the current default kernel */
         this.current_selection = kernel_name;
         this.config.update({
@@ -99,33 +94,13 @@ define([
         var display_name;
         if (spec) {
             display_name = spec.display_name;
-            localStorage.default_kernel_name = kernel_name;
             this.element.find("#current-kernel").text(display_name);
         } else {
             display_name = 'default kernel';
-            delete localStorage.default_kernel_name;
         }
         this.element.find("#new_notebook").attr('title',
             'Create a new notebook with ' + display_name
         );
-        this.element.find("li").map(function (i, li) {
-            li = $(li);
-            var ks = li.data('kernelspec');
-            if (ks.name == kernel_name) {
-                li.find(".kernel-menu-icon")
-                    .attr('title', display_name + ' is the default kernel')
-                    .addClass("kernel-menu-icon-current");
-            } else {
-                li.find(".kernel-menu-icon")
-                    .attr('title', 'Make ' + ks.display_name + ' the default kernel')
-                    .removeClass("kernel-menu-icon-current");
-            }
-        });
-    };
-    
-    NewNotebookWidget.prototype.new_with_kernel = function (kernel_name) {
-        /** record current selection and open a new notebook */
-        this.new_notebook(kernel_name);
     };
     
     NewNotebookWidget.prototype.new_notebook = function (kernel_name) {

--- a/IPython/html/static/tree/js/newnotebook.js
+++ b/IPython/html/static/tree/js/newnotebook.js
@@ -14,7 +14,7 @@ define([
         this.base_url = options.base_url;
         this.notebook_path = options.notebook_path;
         this.contents = options.contents;
-        this.current_selection = null;
+        this.default_kernel = null;
         this.config = options.config;
         this.kernelspecs = {};
         if (this.selector !== undefined) {
@@ -74,20 +74,20 @@ define([
     NewNotebookWidget.prototype._load_default_kernelspec = function (default_name) {
         /** load default kernelspec name from config, if defined */
         if (this.config.data.NewNotebookWidget &&
-            this.config.data.NewNotebookWidget.current_selection &&
-            this.kernelspecs[this.config.data.NewNotebookWidget.current_selection] !== undefined
+            this.config.data.NewNotebookWidget.default_kernel &&
+            this.kernelspecs[this.config.data.NewNotebookWidget.default_kernel] !== undefined
         ) {
-            default_name = this.config.data.NewNotebookWidget.current_selection;
+            default_name = this.config.data.NewNotebookWidget.default_kernel;
         }
         this.set_default_kernel(default_name);
     };
 
     NewNotebookWidget.prototype.set_default_kernel = function (kernel_name) {
         /** select the current default kernel */
-        this.current_selection = kernel_name;
+        this.default_kernel = kernel_name;
         this.config.update({
             NewNotebookWidget: {
-                current_selection: kernel_name
+                default_kernel: kernel_name
             }
         });
         var spec = this.kernelspecs[kernel_name];
@@ -108,7 +108,7 @@ define([
     NewNotebookWidget.prototype.new_notebook = function (kernel_name) {
         /** create and open a new notebook */
         var that = this;
-        kernel_name = kernel_name || this.current_selection;
+        kernel_name = kernel_name || this.default_kernel;
         var w = window.open();
         this.contents.new_untitled(that.notebook_path, {type: "notebook"}).then(
             function (data) {

--- a/IPython/html/static/tree/less/altuploadform.less
+++ b/IPython/html/static/tree/less/altuploadform.less
@@ -15,12 +15,14 @@
 
 .alternate_upload input.fileinput
 {
-    background-color:red;
-    position:relative;
+    display: inline;
     opacity: 0;
     z-index: 2;
-    width: 295px;
-    margin-left:163px;
-    cursor: pointer;
-    height: 26px;
+    width: 12ex;
+    margin-right: -12ex;
+}
+
+.alternate_upload .input-overlay {
+    display: inline-block;
+    font-weight: bold;
 }

--- a/IPython/html/static/tree/less/tree.less
+++ b/IPython/html/static/tree/less/tree.less
@@ -154,3 +154,9 @@ input.engine_num_input {
 .file_icon:before {
     .icon(@fa-var-file-o)
 }
+
+ul#new-notebook-menu {
+    // align right instead of left
+    left: auto;
+    right: 0;
+}

--- a/IPython/html/static/tree/less/tree.less
+++ b/IPython/html/static/tree/less/tree.less
@@ -160,3 +160,17 @@ ul#new-notebook-menu {
     left: auto;
     right: 0;
 }
+
+.kernel-menu-icon {
+    padding-right: 12px;
+    width: 24px;
+    content: @fa-var-square-o;
+}
+
+.kernel-menu-icon:before {
+    content: @fa-var-square-o;
+}
+
+.kernel-menu-icon-current:before {
+  content: @fa-var-check;
+}

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -43,7 +43,7 @@ class="notebook_app"
 
 <span id="kernel_selector_widget" class="pull-right dropdown">
     <button class="dropdown-toggle" data-toggle="dropdown" type='button' id="current_kernel_spec">
-        <span class='kernel_name'>Python</span>
+        <span class='kernel_name'>Kernel</span>
         <span class="caret"></span> 
     </button>
     <ul id="kernel_selector" class="dropdown-menu">

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -34,15 +34,16 @@ data-terminals-available="{{terminals_available}}"
     <div class="tab-content">
     <div id="notebooks" class="tab-pane active">
         <div id="notebook_toolbar" class="row">
-            <div class="col-sm-8 no-padding">
-                <form id='alternate_upload'  class='alternate_upload' >
-                    <span id="notebook_list_info" style="position:absolute" >
-                        To import a notebook, drag the file onto the listing below or <strong>click here</strong>.
+            <div class="col-sm-12 no-padding">
+                <form id='alternate_upload'  class='alternate_upload'>
+                    <span id="notebook_list_info">
+                        To import a notebook, drag the file onto the listing below or
+                        <span class="input-overlay">
+                          <input type="file" name="datafile" class="fileinput" multiple='multiple'>
+                          click here.
+                        </span>
                     </span>
-                    <input type="file" name="datafile" class="fileinput" multiple='multiple'>
                 </form>
-            </div>
-            <div class="col-sm-4 no-padding tree-buttons">
               <span id="notebook_buttons" class="pull-right">
                 <div id="new-notebook-buttons" class="btn-group">
                   <button id="new_notebook" class="btn btn-default btn-xs">

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -49,7 +49,7 @@ data-terminals-available="{{terminals_available}}"
                     New Notebook
                   </button>
                   <button class="dropdown-toggle btn btn-default btn-xs" data-toggle="dropdown">
-                    <span id="current-kernel"></span>
+                    <span id="current-kernel">Loading...</span>
                     <span class="caret"></span>
                   </button>
                   <ul id="new-notebook-menu" class="dropdown-menu"></ul>

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -43,10 +43,20 @@ data-terminals-available="{{terminals_available}}"
                 </form>
             </div>
             <div class="col-sm-4 no-padding tree-buttons">
-                <span id="notebook_buttons" class="pull-right">
-                    <button id="new_notebook" title="Create new notebook" class="btn btn-default btn-xs">New Notebook</button>
-                    <button id="refresh_notebook_list" title="Refresh notebook list" class="btn btn-default btn-xs"><i class="fa fa-refresh"></i></button>
-                </span>
+              <span id="notebook_buttons" class="pull-right">
+                <div id="new-notebook-buttons" class="btn-group">
+                  <button id="new_notebook" class="btn btn-default btn-xs">
+                    New Notebook
+                  </button>
+                  <button class="dropdown-toggle btn btn-default btn-xs" data-toggle="dropdown">
+                    <span class="caret"></span>
+                  </button>
+                  <ul id="new-notebook-menu" class="dropdown-menu"></ul>
+                </div>
+
+                  
+                <button id="refresh_notebook_list" title="Refresh notebook list" class="btn btn-default btn-xs"><i class="fa fa-refresh"></i></button>
+              </span>
             </div>
         </div>
 

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -49,6 +49,7 @@ data-terminals-available="{{terminals_available}}"
                     New Notebook
                   </button>
                   <button class="dropdown-toggle btn btn-default btn-xs" data-toggle="dropdown">
+                    <span id="current-kernel"></span>
                     <span class="caret"></span>
                   </button>
                   <ul id="new-notebook-menu" class="dropdown-menu"></ul>


### PR DESCRIPTION
Depends on #6949
- most recent choice is remembered in localStorage
- kernel can be selected with a url parameter

I didn't add kernel icons because #6537 hasn't been merged. I also didn't remove the kernel selection widget on the notebook page, because I think that can be done as a single PR that addresses #6217.

Kernel selection dropdown:

![screen shot 2014-11-15 at 12 40 35](https://cloud.githubusercontent.com/assets/151929/5059178/d254c262-6cc5-11e4-98ed-94a4e15ddb58.PNG)

New notebook title-text with IPython currently selected:

![screen shot 2014-11-15 at 12 40 49](https://cloud.githubusercontent.com/assets/151929/5059172/bd739ae4-6cc5-11e4-8cf4-6506ebb39e36.PNG)

ping @ellisonbg @fperez
