### PR TITLE
Websockets are not started correctly on QtWebKit 4

### DIFF
--- a/IPython/html/allow76.py
+++ b/IPython/html/allow76.py
@@ -69,8 +69,7 @@ class AllowDraftWebSocketHandler(WebSocketHandler):
         self.stream.set_close_callback(self.on_connection_close)
 
         if self.request.headers.get("Sec-WebSocket-Version") in ("7", "8", "13"):
-            self.ws_connection = WebSocketProtocol13(
-                self, compression_options=self.get_compression_options())
+            self.ws_connection = WebSocketProtocol13(self)
             self.ws_connection.accept_connection()
         #--------------- BEGIN PATCH ----------------
         elif (self.allow_draft76() and


### PR DESCRIPTION
Draft76 was added to support QtWebKit 4 (and hence PhantomJS) a little
bit longer, but before this change kernel websockets failed to start on
that platform.
