### PR TITLE
don't execute if kernel is not connected

### DIFF
--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -278,6 +278,11 @@ define([
      * @method execute
      */
     CodeCell.prototype.execute = function () {
+        if (!this.kernel || !this.kernel.is_connected()) {
+            console.log("Can't execute, kernel is not connected.");
+            return;
+        }
+        
         this.output_area.clear_output();
         
         // Clear widget area


### PR DESCRIPTION
Avoids weird behavior adding new lines with shift-enter when there is no kernel, or the kernel is not connected.

closes #6958
