### PR TITLE
Don't pass IPython-specific args to non-IPython kernels

### DIFF
--- a/IPython/consoleapp.py
+++ b/IPython/consoleapp.py
@@ -291,7 +291,11 @@ class IPythonConsoleApp(ConnectionFileMixin):
             self.exit(1)
 
         self.kernel_manager.client_factory = self.kernel_client_class
-        self.kernel_manager.start_kernel(extra_arguments=self.kernel_argv)
+        # FIXME: remove special treatment of IPython kernels
+        kwargs = {}
+        if self.kernel_manager.ipython_kernel:
+            kwargs['extra_arguments'] = self.kernel_argv
+        self.kernel_manager.start_kernel(**kwargs)
         atexit.register(self.kernel_manager.cleanup_ipc_files)
 
         if self.sshserver:

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -324,7 +324,7 @@ class NotebookApp(BaseIPythonApplication):
         list=(NbserverListApp, NbserverListApp.description.splitlines()[0]),
     )
 
-    kernel_argv = List(Unicode)
+    ipython_kernel_argv = List(Unicode)
     
     _log_formatter_cls = LogFormatter
 
@@ -683,16 +683,17 @@ class NotebookApp(BaseIPythonApplication):
             self.update_config(c)
 
     def init_kernel_argv(self):
-        """construct the kernel arguments"""
+        """add the profile-dir to arguments to be passed to IPython kernels"""
+        # FIXME: remove special treatment of IPython kernels
         # Kernel should get *absolute* path to profile directory
-        self.kernel_argv = ["--profile-dir", self.profile_dir.location]
+        self.ipython_kernel_argv = ["--profile-dir", self.profile_dir.location]
 
     def init_configurables(self):
         # force Session default to be secure
         default_secure(self.config)
         kls = import_item(self.kernel_manager_class)
         self.kernel_manager = kls(
-            parent=self, log=self.log, kernel_argv=self.kernel_argv,
+            parent=self, log=self.log, ipython_kernel_argv=self.ipython_kernel_argv,
             connection_dir = self.profile_dir.security_dir,
         )
         kls = import_item(self.contents_manager_class)

--- a/IPython/html/services/kernels/kernelmanager.py
+++ b/IPython/html/services/kernels/kernelmanager.py
@@ -1,4 +1,8 @@
-"""A kernel manager relating notebooks and kernels"""
+"""A MultiKernelManager for use in the notebook webserver
+
+- raises HTTPErrors
+- creates REST API models
+"""
 
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.

--- a/IPython/html/services/kernels/kernelmanager.py
+++ b/IPython/html/services/kernels/kernelmanager.py
@@ -1,34 +1,17 @@
-"""A kernel manager relating notebooks and kernels
+"""A kernel manager relating notebooks and kernels"""
 
-Authors:
-
-* Brian Granger
-"""
-
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2013  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 import os
 
 from tornado import web
 
 from IPython.kernel.multikernelmanager import MultiKernelManager
-from IPython.utils.traitlets import List, Unicode, TraitError
+from IPython.utils.traitlets import Unicode, TraitError
 
 from IPython.html.utils import to_os_path
 from IPython.utils.py3compat import getcwd
-
-#-----------------------------------------------------------------------------
-# Classes
-#-----------------------------------------------------------------------------
 
 
 class MappingKernelManager(MultiKernelManager):
@@ -36,8 +19,6 @@ class MappingKernelManager(MultiKernelManager):
 
     def _kernel_manager_class_default(self):
         return "IPython.kernel.ioloop.IOLoopKernelManager"
-
-    kernel_argv = List(Unicode)
 
     root_dir = Unicode(getcwd(), config=True)
 
@@ -89,7 +70,6 @@ class MappingKernelManager(MultiKernelManager):
             an existing kernel is returned, but it may be checked in the future.
         """
         if kernel_id is None:
-            kwargs['extra_arguments'] = self.kernel_argv
             if path is not None:
                 kwargs['cwd'] = self.cwd_for_path(path)
             kernel_id = super(MappingKernelManager, self).start_kernel(

--- a/IPython/kernel/multikernelmanager.py
+++ b/IPython/kernel/multikernelmanager.py
@@ -13,7 +13,7 @@ import zmq
 from IPython.config.configurable import LoggingConfigurable
 from IPython.utils.importstring import import_item
 from IPython.utils.traitlets import (
-    Instance, Dict, Unicode, Any, DottedObjectName
+    Instance, Dict, List, Unicode, Any, DottedObjectName
 )
 from IPython.utils.py3compat import unicode_type
 
@@ -42,6 +42,8 @@ def kernel_method(f):
 class MultiKernelManager(LoggingConfigurable):
     """A class for managing multiple kernels."""
     
+    ipython_kernel_argv = List(Unicode)
+
     default_kernel_name = Unicode(NATIVE_KERNEL_NAME, config=True,
         help="The name of the default kernel to start"
     )
@@ -104,6 +106,9 @@ class MultiKernelManager(LoggingConfigurable):
                     self.connection_dir, "kernel-%s.json" % kernel_id),
                     parent=self, autorestart=True, log=self.log, kernel_name=kernel_name,
         )
+        # FIXME: remove special treatment of IPython kernels
+        if km.ipython_kernel:
+            kwargs.setdefault('extra_arguments', self.ipython_kernel_argv)
         km.start_kernel(**kwargs)
         self._kernels[kernel_id] = km
         return kernel_id

--- a/IPython/qt/console/qtconsoleapp.py
+++ b/IPython/qt/console/qtconsoleapp.py
@@ -193,8 +193,10 @@ class IPythonQtConsoleApp(BaseIPythonApplication, IPythonConsoleApp):
                                 autorestart=True,
         )
         # start the kernel
-        kwargs = dict()
-        kwargs['extra_arguments'] = self.kernel_argv
+        kwargs = {}
+        # FIXME: remove special treatment of IPython kernels
+        if self.kernel_manager.ipython_kernel:
+            kwargs['extra_arguments'] = self.kernel_argv
         kernel_manager.start_kernel(**kwargs)
         kernel_manager.client_factory = self.kernel_client_class
         kernel_client = kernel_manager.client()


### PR DESCRIPTION
add a few FIXME notes that the IPython-kernel special treatment
will probably want to be removed in the Jupyter explosion.

closes #6626
