### PR TITLE
Allow starting the server with both file_to_run and notebook_dir

### DIFF
--- a/IPython/html/services/contents/filemanager.py
+++ b/IPython/html/services/contents/filemanager.py
@@ -23,7 +23,10 @@ from IPython.html.utils import is_hidden, to_os_path, url_path_join
 
 class FileContentsManager(ContentsManager):
 
-    root_dir = Unicode(getcwd(), config=True)
+    root_dir = Unicode(config=True)
+
+    def _root_dir_default(self):
+        return self.parent.notebook_dir
 
     save_script = Bool(False, config=True, help='DEPRECATED, IGNORED')
     def _save_script_changed(self):

--- a/IPython/html/services/contents/filemanager.py
+++ b/IPython/html/services/contents/filemanager.py
@@ -26,7 +26,10 @@ class FileContentsManager(ContentsManager):
     root_dir = Unicode(config=True)
 
     def _root_dir_default(self):
-        return self.parent.notebook_dir
+        try:
+            return self.parent.notebook_dir
+        except AttributeError:
+            return getcwd()
 
     save_script = Bool(False, config=True, help='DEPRECATED, IGNORED')
     def _save_script_changed(self):

--- a/IPython/html/services/kernels/kernelmanager.py
+++ b/IPython/html/services/kernels/kernelmanager.py
@@ -12,7 +12,7 @@ import os
 from tornado import web
 
 from IPython.kernel.multikernelmanager import MultiKernelManager
-from IPython.utils.traitlets import Unicode, TraitError
+from IPython.utils.traitlets import List, Unicode, TraitError
 
 from IPython.html.utils import to_os_path
 from IPython.utils.py3compat import getcwd
@@ -24,7 +24,12 @@ class MappingKernelManager(MultiKernelManager):
     def _kernel_manager_class_default(self):
         return "IPython.kernel.ioloop.IOLoopKernelManager"
 
-    root_dir = Unicode(getcwd(), config=True)
+    kernel_argv = List(Unicode)
+
+    root_dir = Unicode(config=True)
+
+    def _root_dir_default(self):
+        return self.parent.notebook_dir
 
     def _root_dir_changed(self, name, old, new):
         """Do a bit of validation of the root dir."""

--- a/IPython/html/services/kernels/kernelmanager.py
+++ b/IPython/html/services/kernels/kernelmanager.py
@@ -29,7 +29,10 @@ class MappingKernelManager(MultiKernelManager):
     root_dir = Unicode(config=True)
 
     def _root_dir_default(self):
-        return self.parent.notebook_dir
+        try:
+            return self.parent.notebook_dir
+        except AttributeError:
+            return getcwd()
 
     def _root_dir_changed(self, name, old, new):
         """Do a bit of validation of the root dir."""


### PR DESCRIPTION
file_to_run and notebook_dir would collide, with possible dictionary ordering randomness depending on how they were passed.

With this change, the default value of notebook_dir is pulled from file_to_run, instead of pushing the value when file_to_run is changed. This makes it possible to specify both and have the server behave as expected.
