### PR TITLE
Public server firewall configuration

### DIFF
--- a/docs/source/notebook/public_server.rst
+++ b/docs/source/notebook/public_server.rst
@@ -107,6 +107,18 @@ You can then start the notebook and access it later by pointing your browser
 to ``https://your.host.com:9999`` with ``ipython notebook 
 --profile=nbserver``.
 
+
+Firewall Setup
+``````````````
+
+To function correctly, the firewall on computer running the ipython server must be 
+configured to allow connections from client machines on the ``c.NotebookApp.port``
+port to allow connections to the web interface.  The firewall must also allow 
+connections from 127.0.0.1 on ports in the range of 10000 to 65535, which are used
+by the server to communicate with the notebook kernels.  The kernel communication
+ports are chosen randomly by ZeroMQ, and my require multiple connections per kernel
+so a large range of ports must be accessible.
+
 Running with a different URL prefix
 -----------------------------------
 

--- a/docs/source/notebook/public_server.rst
+++ b/docs/source/notebook/public_server.rst
@@ -111,13 +111,13 @@ to ``https://your.host.com:9999`` with ``ipython notebook
 Firewall Setup
 ``````````````
 
-To function correctly, the firewall on computer running the ipython server must be 
+To function correctly, the firewall on the computer running the ipython server must be 
 configured to allow connections from client machines on the ``c.NotebookApp.port``
 port to allow connections to the web interface.  The firewall must also allow 
-connections from 127.0.0.1 on ports in the range of 10000 to 65535, which are used
-by the server to communicate with the notebook kernels.  The kernel communication
-ports are chosen randomly by ZeroMQ, and my require multiple connections per kernel
-so a large range of ports must be accessible.
+connections from 127.0.0.1 (localhost) on ports from 49152 to 65535.
+These ports are used by the server to communicate with the notebook kernels.  
+The kernel communication ports are chosen randomly by ZeroMQ, and may require 
+multiple connections per kernel, so a large range of ports must be accessible.
 
 Running with a different URL prefix
 -----------------------------------


### PR DESCRIPTION
Added section on firewall configuration.  This should prevent users (like me) from struggling to figure out why their servers aren't executing code.

This documentation applies to current stable release and older releases, and so probably should be backported at some point.
