### PR TITLE
%set_env should ensure environment variables are bytes on Python 2

### DIFF
--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -413,7 +413,7 @@ class OSMagics(Magics):
             err = "refusing to set env var with whitespace: '{0}'"
             err = err.format(val)
             raise UsageError(err)
-        os.environ[var] = py3compat.cast_bytes_py2(val)
+        os.environ[py3compat.cast_bytes_py2(var)] = py3compat.cast_bytes_py2(val)
         print('env: {0}={1}'.format(var,val))
 
     @line_magic

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -413,7 +413,7 @@ class OSMagics(Magics):
             err = "refusing to set env var with whitespace: '{0}'"
             err = err.format(val)
             raise UsageError(err)
-        os.environ[var] = val
+        os.environ[var] = py3compat.cast_bytes_py2(val)
         print('env: {0}={1}'.format(var,val))
 
     @line_magic


### PR DESCRIPTION
Should fix test failures on Python 2 + Windows
