### PR TITLE
Nbconvert to script for any kernel language

### DIFF
--- a/IPython/html/nbconvert/handlers.py
+++ b/IPython/html/nbconvert/handlers.py
@@ -43,7 +43,7 @@ def respond_zip(handler, name, output, resources):
     # Prepare the zip file
     buffer = io.BytesIO()
     zipf = zipfile.ZipFile(buffer, mode='w', compression=zipfile.ZIP_DEFLATED)
-    output_filename = os.path.splitext(name)[0] + '.' + resources['output_extension']
+    output_filename = os.path.splitext(name)[0] + resources['output_extension']
     zipf.writestr(output_filename, cast_bytes(output, 'utf-8'))
     for filename, data in output_files.items():
         zipf.writestr(os.path.basename(filename), data)
@@ -96,7 +96,7 @@ class NbconvertFileHandler(IPythonHandler):
 
         # Force download if requested
         if self.get_argument('download', 'false').lower() == 'true':
-            filename = os.path.splitext(name)[0] + '.' + resources['output_extension']
+            filename = os.path.splitext(name)[0] + resources['output_extension']
             self.set_header('Content-Disposition',
                                'attachment; filename="%s"' % filename)
 

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -69,17 +69,21 @@ define([
     MenuBar.prototype._nbconvert = function (format, download) {
         download = download || false;
         var notebook_path = this.notebook.notebook_path;
-        if (this.notebook.dirty) {
-            this.notebook.save_notebook({async : false});
-        }
         var url = utils.url_join_encode(
             this.base_url,
             'nbconvert',
             format,
             notebook_path
         ) + "?download=" + download.toString();
-
-        window.open(url);
+        
+        var w = window.open()
+        if (this.notebook.dirty) {
+            this.notebook.save_notebook().then(function() {
+                w.location = url;
+            });
+        } else {
+            w.location = url;
+        }
     };
 
     MenuBar.prototype.bind_events = function () {

--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -359,7 +359,7 @@ define([
         // Set menu entry text to e.g. "Python (.py)"
         var langname = (langinfo.name || 'Script')
         langname = langname.charAt(0).toUpperCase()+langname.substr(1) // Capitalise
-        el.find('a').text(langname + ' (.'+(langinfo.file_extension || 'txt')+')');
+        el.find('a').text(langname + ' ('+(langinfo.file_extension || 'txt')+')');
         
         // Unregister any previously registered handlers
         el.off('click');

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1922,7 +1922,7 @@ define([
         var start =  new Date().getTime();
 
         var that = this;
-        this.contents.save(this.notebook_path, model).then(
+        return this.contents.save(this.notebook_path, model).then(
                 $.proxy(this.save_notebook_success, this, start),
                 function (error) {
                     that.events.trigger('notebook_save_failed.Notebook', error);

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -105,7 +105,7 @@ class="notebook_app"
                         <li class="dropdown-submenu"><a href="#">Download as</a>
                             <ul class="dropdown-menu">
                                 <li id="download_ipynb"><a href="#">IPython Notebook (.ipynb)</a></li>
-                                <li id="download_py"><a href="#">Python (.py)</a></li>
+                                <li id="download_script"><a href="#">Script</a></li>
                                 <li id="download_html"><a href="#">HTML (.html)</a></li>
                                 <li id="download_rst"><a href="#">reST (.rst)</a></li>
                                 <li id="download_pdf"><a href="#">PDF (.pdf)</a></li>

--- a/IPython/kernel/zmq/ipkernel.py
+++ b/IPython/kernel/zmq/ipkernel.py
@@ -75,6 +75,8 @@ class IPythonKernel(KernelBase):
                      'codemirror_mode': {'name': 'ipython',
                                          'version': sys.version_info[0]},
                      'pygments_lexer': 'ipython%d' % (3 if PY3 else 2),
+                     'nbconvert_exporter': 'python',
+                     'file_extension': 'py'
                     }
     @property
     def banner(self):

--- a/IPython/kernel/zmq/ipkernel.py
+++ b/IPython/kernel/zmq/ipkernel.py
@@ -76,7 +76,7 @@ class IPythonKernel(KernelBase):
                                          'version': sys.version_info[0]},
                      'pygments_lexer': 'ipython%d' % (3 if PY3 else 2),
                      'nbconvert_exporter': 'python',
-                     'file_extension': 'py'
+                     'file_extension': '.py'
                     }
     @property
     def banner(self):

--- a/IPython/nbconvert/exporters/export.py
+++ b/IPython/nbconvert/exporters/export.py
@@ -19,6 +19,7 @@ from .markdown import MarkdownExporter
 from .python import PythonExporter
 from .rst import RSTExporter
 from .notebook import NotebookExporter
+from .script import ScriptExporter
 
 #-----------------------------------------------------------------------------
 # Classes
@@ -74,6 +75,7 @@ __all__ = [
     'export_pdf',
     'export_markdown',
     'export_python',
+    'export_script',
     'export_rst',
     'export_by_name',
     'get_export_names',
@@ -132,6 +134,7 @@ exporter_map = dict(
     python=PythonExporter,
     rst=RSTExporter,
     notebook=NotebookExporter,
+    script=ScriptExporter,
 )
 
 def _make_exporter(name, E):

--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -32,7 +32,7 @@ class Exporter(LoggingConfigurable):
     """
 
     file_extension = Unicode(
-        'txt', config=True,
+        '.txt', config=True,
         help="Extension of the file that should be written to disk"
         )
 

--- a/IPython/nbconvert/exporters/html.py
+++ b/IPython/nbconvert/exporters/html.py
@@ -32,7 +32,7 @@ class HTMLExporter(TemplateExporter):
     """
     
     def _file_extension_default(self):
-        return 'html'
+        return '.html'
 
     def _default_template_path_default(self):
         return os.path.join("..", "templates", "html")

--- a/IPython/nbconvert/exporters/latex.py
+++ b/IPython/nbconvert/exporters/latex.py
@@ -37,7 +37,7 @@ class LatexExporter(TemplateExporter):
     """
 
     def _file_extension_default(self):
-        return 'tex'
+        return '.tex'
 
     def _template_file_default(self):
         return 'article'

--- a/IPython/nbconvert/exporters/pdf.py
+++ b/IPython/nbconvert/exporters/pdf.py
@@ -135,7 +135,7 @@ class PDFExporter(LatexExporter):
         
         # convert output extension to pdf
         # the writer above required it to be tex
-        resources['output_extension'] = 'pdf'
+        resources['output_extension'] = '.pdf'
         
         return pdf_data, resources
     

--- a/IPython/nbconvert/exporters/python.py
+++ b/IPython/nbconvert/exporters/python.py
@@ -23,7 +23,7 @@ class PythonExporter(TemplateExporter):
     Exports a Python code file.
     """
     def _file_extension_default(self):
-        return 'py'
+        return '.py'
 
     def _template_file_default(self):
         return 'python'

--- a/IPython/nbconvert/exporters/rst.py
+++ b/IPython/nbconvert/exporters/rst.py
@@ -26,7 +26,7 @@ class RSTExporter(TemplateExporter):
     """
     
     def _file_extension_default(self):
-        return 'rst'
+        return '.rst'
 
     def _template_file_default(self):
         return 'rst'

--- a/IPython/nbconvert/exporters/script.py
+++ b/IPython/nbconvert/exporters/script.py
@@ -1,0 +1,14 @@
+"""Generic script exporter class for any kernel language"""
+
+from .templateexporter import TemplateExporter
+
+class ScriptExporter(TemplateExporter):
+    def _template_file_default(self):
+        return 'script'
+
+    def from_notebook_node(self, nb, resources=None, **kw):
+        langinfo = nb.metadata.get('language_info', {})
+        self.file_extension = langinfo.get('file_extension', 'txt')
+        self.output_mimetype = langinfo.get('mimetype', 'text/plain')
+
+        return super(ScriptExporter, self).from_notebook_node(nb, resources, **kw)

--- a/IPython/nbconvert/exporters/script.py
+++ b/IPython/nbconvert/exporters/script.py
@@ -8,7 +8,7 @@ class ScriptExporter(TemplateExporter):
 
     def from_notebook_node(self, nb, resources=None, **kw):
         langinfo = nb.metadata.get('language_info', {})
-        self.file_extension = langinfo.get('file_extension', 'txt')
+        self.file_extension = langinfo.get('file_extension', '.txt')
         self.output_mimetype = langinfo.get('mimetype', 'text/plain')
 
         return super(ScriptExporter, self).from_notebook_node(nb, resources, **kw)

--- a/IPython/nbconvert/exporters/slides.py
+++ b/IPython/nbconvert/exporters/slides.py
@@ -25,7 +25,7 @@ class SlidesExporter(HTMLExporter):
     """Exports HTML slides with reveal.js"""
     
     def _file_extension_default(self):
-        return 'slides.html'
+        return '.slides.html'
 
     def _template_file_default(self):
         return 'slides_reveal'

--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -286,7 +286,7 @@ class NbConvertApp(BaseIPythonApplication):
                 # strip duplicate extension from output_base, to avoid Basname.ext.ext
                 if getattr(exporter, 'file_extension', False):
                     base, ext = os.path.splitext(self.output_base)
-                    if ext == '.' + exporter.file_extension:
+                    if ext == exporter.file_extension:
                         self.output_base = base
                 notebook_name = self.output_base
             resources = {}

--- a/IPython/nbconvert/templates/script.tpl
+++ b/IPython/nbconvert/templates/script.tpl
@@ -1,0 +1,5 @@
+{%- extends 'null.tpl' -%}
+
+{% block input %}
+{{ cell.source }}
+{% endblock input %}

--- a/IPython/nbconvert/writers/files.py
+++ b/IPython/nbconvert/writers/files.py
@@ -93,7 +93,7 @@ class FilesWriter(WriterBase):
 
             # Determine where to write conversion results.
             if output_extension is not None:
-                dest = notebook_name + '.' + output_extension
+                dest = notebook_name + output_extension
             else:
                 dest = notebook_name
             if self.build_directory:

--- a/IPython/nbconvert/writers/tests/test_files.py
+++ b/IPython/nbconvert/writers/tests/test_files.py
@@ -59,7 +59,7 @@ class Testfiles(TestsBase):
         with self.create_temp_cwd():
 
             # Create the resoruces dictionary
-            res = {'output_extension': 'txt'}
+            res = {'output_extension': '.txt'}
 
             # Create files writer, test output
             writer = FilesWriter()

--- a/docs/source/development/messaging.rst
+++ b/docs/source/development/messaging.rst
@@ -689,6 +689,9 @@ Message type: ``kernel_info_reply``::
         'language_info': {
             'mimetype': str,
 
+            # Extension without the dot, e.g. 'py'
+            'file_extension': str,
+
             # Pygments lexer, for highlighting
             # Only needed if it differs from the top level 'language' field.
             'pygments_lexer': str,
@@ -696,6 +699,11 @@ Message type: ``kernel_info_reply``::
             # Codemirror mode, for for highlighting in the notebook.
             # Only needed if it differs from the top level 'language' field.
             'codemirror_mode': str or dict,
+
+            # Nbconvert exporter, if notebooks written with this kernel should
+            # be exported with something other than the general 'script'
+            # exporter.
+            'nbconvert_exporter': str,
         },
 
         # A banner of information about the kernel,

--- a/docs/source/development/wrapperkernels.rst
+++ b/docs/source/development/wrapperkernels.rst
@@ -38,9 +38,10 @@ following methods and attributes:
 
      Language information for :ref:`msging_kernel_info` replies, in a dictionary.
      This should contain the key ``mimetype`` with the mimetype of code in the
-     target language (e.g. ``'text/x-python'``). It may also contain keys
-     ``codemirror_mode`` and ``pygments_lexer`` if they need to differ from
-     :attr:`language`.
+     target language (e.g. ``'text/x-python'``), and ``file_extension`` (e.g.
+     ``'py'``).
+     It may also contain keys ``codemirror_mode`` and ``pygments_lexer`` if they
+     need to differ from :attr:`language`.
 
      Other keys may be added to this later.
 


### PR DESCRIPTION
This adds both `nbconvert --to script` and a 'Download as' menu option that updates to match the relevant kernel.
- The file extension is taken from kernel info, defaulting to `.txt` so as to degrade gracefully where kernels haven't added this feature.
- For now, it _just_ gives the contents of the code cells, with no extra metadata in comments. This keeps things simple, because we don't need to deal with different comment styles, but we can add that later if we feel it's necessary.
- The kernel info can also specify `nbconvert_exporter` to use from the menu instead of the 'script' exporter, and our own kernel specifies the 'python' exporter, which adds e.g. the `# coding: utf-8` header.

closes #6944
