### PR TITLE
fix clientside notebook manager and assume tree is dir by default

### DIFF
--- a/IPython/html/services/contents/clientsidenbmanager.py
+++ b/IPython/html/services/contents/clientsidenbmanager.py
@@ -13,8 +13,8 @@ class ClientSideContentsManager(ContentsManager):
     this class as the contents manager allows those pages to render without
     checking something that the server doesn't know about.
     """
-    def path_exists(self, path):
-       return True
+    def dir_exists(self, path):
+        return True
 
     def is_hidden(self, path):
         return False


### PR DESCRIPTION
Assume tree url are dir by default instead of file, and if
not do a redirect. Usefull for Clientside manager where the server
does not know the content of the drive, and think that everythong exists.
