### PR TITLE
Catch if module file is not set (issue #6984)

### DIFF
--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -183,7 +183,7 @@ class ModuleReloader(object):
         return top_module, top_name
 
     def filename_and_mtime(self, module):
-        if not hasattr(module, '__file__'):
+        if not hasattr(module, '__file__') or module.__file__ is None:
             return None, None
 
         if module.__name__ == '__main__':


### PR DESCRIPTION
When loading .net assemblies after `import clr`, the `__file__` attribute is present but not set, causing the autoreload module to not work appropriately.
