### PR TITLE
Refactor the do_diff and manual child view lists into a separate ViewList object

### DIFF
--- a/IPython/html/static/widgets/js/manager.js
+++ b/IPython/html/static/widgets/js/manager.js
@@ -62,7 +62,7 @@ define([
                     dummy.replaceWith(view.$el);
                     view.trigger('displayed');
                     return view;
-                }, utils.reject('Could not display view'));
+                }).catch(utils.reject('Could not display view', true));
         }
     };
 
@@ -103,7 +103,7 @@ define([
                 view.listenTo(model, 'destroy', view.remove);
                 view.render();
                 return view;
-            }, utils.reject("Couldn't create a view for model id '" + String(model.id) + "'"));
+            }).catch(utils.reject("Couldn't create a view for model id '" + String(model.id) + "'", true));
         });
         return model.state_change;
     };
@@ -178,7 +178,7 @@ define([
         return this.create_model({
             model_name: msg.content.data.model_name, 
             model_module: msg.content.data.model_module, 
-            comm: comm}).catch(utils.reject("Couldn't create a model."));
+            comm: comm}).catch(utils.reject("Couldn't create a model.", true));
     };
 
     WidgetManager.prototype.create_model = function (options) {

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -621,6 +621,9 @@ define(["widgets/js/manager",
             // returns a promise that resolves after this update is done
             var remove = remove_view || this._remove_view;
             var create = create_view || this._create_view;
+            if (create === undefined || remove === undefined){
+                console.error("Must define a create a remove function");
+            }
             var context = context || this._handler_context;
             var added_views = [];
             var that = this;

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -648,6 +648,7 @@ define(["widgets/js/manager",
                 that._models = new_models.slice();
                 return Promise.all(added_views, function(added) {
                     that.views = that.views.slice(0,first_removed).concat(added);
+                    return that.views;
                 });
             });
             return this.state_change;

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -613,7 +613,7 @@ define(["widgets/js/manager",
             this._models = [];
             this.views = [];
             this._create_view = create_view;
-            this._remove_view = remove_view || function(view) {view.remove()};
+            this._remove_view = remove_view || function(view) {view.remove();};
         },
 
         update: function(new_models, create_view, remove_view, context) {

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -604,11 +604,11 @@ define(["widgets/js/manager",
         //   will be called in that context.
 
         this.initialize.apply(this, arguments);
-        this.state_change = Promise.resolve();
     }
 
     _.extend(ViewList.prototype, {
         initialize: function(create_view, remove_view, context) {
+            this.state_change = Promise.resolve();
             this._handler_context = context || this;
             this._models = [];
             this.views = [];

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -292,8 +292,6 @@ define(["widgets/js/manager",
             // Public constructor.
             this.model.on('change',this.update,this);
             this.options = parameters.options;
-            this.child_model_views = {};
-            this.child_views = {};
             this.id = this.id || utils.uuid();
             this.model.views[this.id] = this;
             this.on('displayed', function() { 
@@ -311,38 +309,7 @@ define(["widgets/js/manager",
             // Create and promise that resolves to a child view of a given model
             var that = this;
             options = $.extend({ parent: this }, options || {});
-            return this.model.widget_manager.create_view(child_model, options).then(function(child_view) {
-                // Associate the view id with the model id.
-                if (that.child_model_views[child_model.id] === undefined) {
-                    that.child_model_views[child_model.id] = [];
-                }
-                that.child_model_views[child_model.id].push(child_view.id);
-                // Remember the view by id.
-                that.child_views[child_view.id] = child_view;
-                return child_view;
-            }, utils.reject("Couldn't create child view"));
-        },
-
-        pop_child_view: function(child_model) {
-            // Delete a child view that was previously created using create_child_view.
-            console.error("Deprecated pop_child_view; use a ViewList or similar class instead");
-            var view_ids = this.child_model_views[child_model.id];
-            if (view_ids !== undefined) {
-
-                // Only delete the first view in the list.
-                var view_id = view_ids[0];
-                var view = this.child_views[view_id];
-                delete this.child_views[view_id];
-                view_ids.splice(0,1);
-                delete child_model.views[view_id];
-            
-                // Remove the view list specific to this model if it is empty.
-                if (view_ids.length === 0) {
-                    delete this.child_model_views[child_model.id];
-                }
-                return view;
-            }
-            return null;
+            return this.model.widget_manager.create_view(child_model, options).catch(utils.reject("Couldn't create child view"));
         },
 
         callbacks: function(){

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -359,8 +359,6 @@ define(["widgets/js/manager",
             //      Callback that is called for each item added.
 
             // Walk the lists until an unequal entry is found.
-            console.error("Deprecated _do_diff; use a ViewList or similar class instead");
-
             var i;
             for (i = 0; i < new_list.length; i++) {
                 if (i >= old_list.length || new_list[i] !== old_list[i]) {
@@ -605,7 +603,7 @@ define(["widgets/js/manager",
         //   will be called in that context.
 
         this.initialize.apply(this, arguments);
-    }
+    };
 
     _.extend(ViewList.prototype, {
         initialize: function(create_view, remove_view, context) {
@@ -661,7 +659,7 @@ define(["widgets/js/manager",
             this.state_change = this.state_change.then(function() {
                 for (var i = 0, len=that.views.length; i <len; i++) {
                     that._remove_view.call(that._handler_context, that.views[i]);
-                };
+                }
                 that._models = [];
                 that.views = [];
             });

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -643,7 +643,8 @@ define(["widgets/js/manager",
                 for (; i < new_models.length; i++) {
                     added_views.push(create.call(context, new_models[i]));
                 }
-                that._models = new_models;
+                // make a copy of the input array
+                that._models = new_models.slice();
                 return Promise.all(added_views, function(added) {
                     that.views = that.views.slice(0,first_removed).concat(added);
                 });

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -95,7 +95,7 @@ define(["widgets/js/manager",
                 } finally {
                     that.state_lock = null;
                 }
-            }, utils.reject("Couldn't set model state", true));
+            }).catch(utils.reject("Couldn't set model state", true));
         },
 
         _handle_status: function (msg, callbacks) {
@@ -309,7 +309,7 @@ define(["widgets/js/manager",
             // Create and promise that resolves to a child view of a given model
             var that = this;
             options = $.extend({ parent: this }, options || {});
-            return this.model.widget_manager.create_view(child_model, options).catch(utils.reject("Couldn't create child view"));
+            return this.model.widget_manager.create_view(child_model, options).catch(utils.reject("Couldn't create child view"), true);
         },
 
         callbacks: function(){

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -594,13 +594,14 @@ define(["widgets/js/manager",
 
     var ViewList = function(create_view, remove_view, context) {
         // * create_view and remove_view are default functions called when adding or removing views
-        // * create_view takes a model and creates a view or a promise for a view for that model
-        // * remove_view takes a view and destroys it (including calling `.remove()`)
-        // * each time the update() function is called with a new list, the create and destroy
+        // * create_view takes a model and returns a view or a promise for a view for that model
+        // * remove_view takes a view and destroys it (including calling `view.remove()`)
+        // * each time the update() function is called with a new list, the create and remove
         //   callbacks will be called in an order so that if you append the views created in the
-        //   create callback, you will duplicate the order of the list.
-        // * the remove callback defaults to just removing the view (if you pass in null)
-        // * the context defaults to the ViewList.  If you pass another context, the create and remove
+        //   create callback and remove the views in the remove callback, you will duplicate 
+        //   the order of the list.
+        // * the remove callback defaults to just removing the view (e.g., pass in null for the second parameter)
+        // * the context defaults to the created ViewList.  If you pass another context, the create and remove
         //   will be called in that context.
 
         this.initialize.apply(this, arguments);
@@ -653,7 +654,7 @@ define(["widgets/js/manager",
         },
 
         remove: function() {
-            // removes every view in our list; convenience function for `.update([])`
+            // removes every view in the list; convenience function for `.update([])`
             // that should be faster
             // returns a promise that resolves after this removal is done
             var that = this;

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -593,7 +593,7 @@ define(["widgets/js/manager",
             // returns a promise that resolves after this removal is done
             var that = this;
             this.state_change = this.state_change.then(function() {
-                for (var i = 0, len=that.views.length; i <len; i++) {
+                for (var i = 0; i < that.views.length; i++) {
                     that._remove_view.call(that._handler_context, that.views[i]);
                 }
                 that._models = [];

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -345,7 +345,7 @@ define(["widgets/js/manager",
             return null;
         },
 
-        do_diff: function(old_list, new_list, removed_callback, added_callback) {
+        _do_diff: function(old_list, new_list, removed_callback, added_callback) {
             // Difference a changed list and call remove and add callbacks for 
             // each removed and added item in the new list.
             //
@@ -359,8 +359,6 @@ define(["widgets/js/manager",
             //      Callback that is called for each item added.
 
             // Walk the lists until an unequal entry is found.
-            console.error("Deprecated _do_diff; use a ViewList or similar class instead");
-
             var i;
             for (i = 0; i < new_list.length; i++) {
                 if (i >= old_list.length || new_list[i] !== old_list[i]) {
@@ -536,7 +534,7 @@ define(["widgets/js/manager",
             if ($el===undefined) {
                 $el = this.$el;
             }
-            this.do_diff(old_classes, new_classes, function(removed) {
+            this._do_diff(old_classes, new_classes, function(removed) {
                 $el.removeClass(removed);
             }, function(added) {
                 $el.addClass(added);

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -579,8 +579,8 @@ define(["widgets/js/manager",
                 }
                 // make a copy of the input array
                 that._models = new_models.slice();
-                return Promise.all(added_views, function(added) {
-                    that.views = that.views.slice(0,first_removed).concat(added);
+                return Promise.all(added_views).then(function(added) {
+                    Array.prototype.splice.apply(that.views, [first_removed, that.views.length].concat(added));
                     return that.views;
                 });
             });

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -345,38 +345,6 @@ define(["widgets/js/manager",
             return null;
         },
 
-        _do_diff: function(old_list, new_list, removed_callback, added_callback) {
-            // Difference a changed list and call remove and add callbacks for 
-            // each removed and added item in the new list.
-            //
-            // Parameters
-            // ----------
-            // old_list : array
-            // new_list : array
-            // removed_callback : Callback(item)
-            //      Callback that is called for each item removed.
-            // added_callback : Callback(item)
-            //      Callback that is called for each item added.
-
-            // Walk the lists until an unequal entry is found.
-            var i;
-            for (i = 0; i < new_list.length; i++) {
-                if (i >= old_list.length || new_list[i] !== old_list[i]) {
-                    break;
-                }
-            }
-
-            // Remove the non-matching items from the old list.
-            for (var j = i; j < old_list.length; j++) {
-                removed_callback(old_list[j]);
-            }
-
-            // Add the rest of the new list items.
-            for (; i < new_list.length; i++) {
-                added_callback(new_list[i]);
-            }
-        },
-
         callbacks: function(){
             // Create msg callbacks for a comm msg.
             return this.model.callbacks(this);
@@ -534,11 +502,8 @@ define(["widgets/js/manager",
             if ($el===undefined) {
                 $el = this.$el;
             }
-            this._do_diff(old_classes, new_classes, function(removed) {
-                $el.removeClass(removed);
-            }, function(added) {
-                $el.addClass(added);
-            });
+            _.difference(old_classes, new_classes).map(function(c) {$el.removeClass(c);})
+            _.difference(new_classes, old_classes).map(function(c) {$el.addClass(c);})
         },
 
         update_mapped_classes: function(class_map, trait_name, previous_trait_value, $el) {

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -325,7 +325,7 @@ define(["widgets/js/manager",
 
         pop_child_view: function(child_model) {
             // Delete a child view that was previously created using create_child_view.
-            console.error("Deprecated use of WidgetView.pop_child_view; use a ViewList instead");
+            console.error("Deprecated pop_child_view; use a ViewList or similar class instead");
             var view_ids = this.child_model_views[child_model.id];
             if (view_ids !== undefined) {
 
@@ -359,7 +359,7 @@ define(["widgets/js/manager",
             //      Callback that is called for each item added.
 
             // Walk the lists until an unequal entry is found.
-            console.error("Deprecated _do_diff; use a ViewList or related class instead");
+            console.error("Deprecated _do_diff; use a ViewList or similar class instead");
 
             var i;
             for (i = 0; i < new_list.length; i++) {

--- a/IPython/html/static/widgets/js/widget_box.js
+++ b/IPython/html/static/widgets/js/widget_box.js
@@ -75,7 +75,7 @@ define([
                     view.trigger('displayed');
                 });
                 return view;
-            }, utils.reject("Couldn't add child view to box", true));
+            }).catch(utils.reject("Couldn't add child view to box", true));
         },
         
         remove: function() {

--- a/IPython/html/static/widgets/js/widget_box.js
+++ b/IPython/html/static/widgets/js/widget_box.js
@@ -12,16 +12,17 @@ define([
         initialize: function(){
             // Public constructor
             BoxView.__super__.initialize.apply(this, arguments);
-            this.model.on('change:children', function(model, value) {
-                this.update_children(model.previous('children'), value);
+            this.children_views = new widget.ViewList(this.add_child_model, null, this);
+            this.listenTo(this.model, 'change:children', function(model, value) {
+                this.children_views.update(value);
             }, this);
-            this.model.on('change:overflow_x', function(model, value) {
+            this.listenTo(this.model, 'change:overflow_x', function(model, value) {
                 this.update_overflow_x();
             }, this);
-            this.model.on('change:overflow_y', function(model, value) {
+            this.listenTo(this.model, 'change:overflow_y', function(model, value) {
                 this.update_overflow_y();
             }, this);
-            this.model.on('change:box_style', function(model, value) {
+            this.listenTo(this.model, 'change:box_style', function(model, value) {
                 this.update_box_style();
             }, this);
         },
@@ -35,7 +36,7 @@ define([
             // Called when view is rendered.
             this.$box = this.$el;
             this.$box.addClass('widget-box');
-            this.update_children([], this.model.get('children'));
+            this.children_views.update(this.model.get('children'));
             this.update_overflow_x();
             this.update_overflow_y();
             this.update_box_style('');
@@ -61,18 +62,6 @@ define([
             this.update_mapped_classes(class_map, 'box_style', previous_trait_value, this.$box);
         },
         
-        update_children: function(old_list, new_list) {
-            // Called when the children list changes.
-            this.do_diff(old_list, new_list, 
-                $.proxy(this.remove_child_model, this),
-                $.proxy(this.add_child_model, this));
-        },
-
-        remove_child_model: function(model) {
-            // Called when a model is removed from the children list.
-            this.pop_child_view(model).remove();
-        },
-
         add_child_model: function(model) {
             // Called when a model is added to the children list.
             var that = this;
@@ -88,16 +77,21 @@ define([
                 return view;
             }, utils.reject("Couldn't add child view to box", true));
         },
+        
+        remove: function() {
+            BoxView.__super__.remove.apply(this, arguments);
+            this.children_views.remove();
+        },
     });
 
 
     var FlexBoxView = BoxView.extend({
         render: function(){
             FlexBoxView.__super__.render.apply(this);
-            this.model.on('change:orientation', this.update_orientation, this);
-            this.model.on('change:flex', this._flex_changed, this);
-            this.model.on('change:pack', this._pack_changed, this);
-            this.model.on('change:align', this._align_changed, this);
+            this.listenTo(this.model, 'change:orientation', this.update_orientation, this);
+            this.listenTo(this.model, 'change:flex', this._flex_changed, this);
+            this.listenTo(this.model, 'change:pack', this._pack_changed, this);
+            this.listenTo(this.model, 'change:align', this._align_changed, this);
             this._flex_changed();
             this._pack_changed();
             this._align_changed();
@@ -244,10 +238,7 @@ define([
             this._shown_once = false;
             this.popped_out = true;
 
-            this.update_children([], this.model.get('children'));
-            this.model.on('change:children', function(model, value) {
-                this.update_children(model.previous('children'), value);
-            }, this);
+            this.children_views.update(this.model.get('children'))
         },
         
         hide: function() {

--- a/IPython/html/static/widgets/js/widget_box.js
+++ b/IPython/html/static/widgets/js/widget_box.js
@@ -79,6 +79,9 @@ define([
         },
         
         remove: function() {
+            // We remove this widget before removing the children as an optimization
+            // we want to remove the entire container from the DOM first before
+            // removing each individual child separately.
             BoxView.__super__.remove.apply(this, arguments);
             this.children_views.remove();
         },

--- a/IPython/html/static/widgets/js/widget_selectioncontainer.js
+++ b/IPython/html/static/widgets/js/widget_selectioncontainer.js
@@ -14,7 +14,7 @@ define([
 
             this.containers = [];
             this.model_containers = {};
-            this.children_views = new widget.ViewList(this.add_child_model, this.remove_child_model, this);
+            this.children_views = new widget.ViewList(this.add_child_view, this.remove_child_view, this);
             this.listenTo(this.model, 'change:children', function(model, value) {
                 this.children_views.update(value);
             }, this);
@@ -68,16 +68,17 @@ define([
             }
         },
 
-        remove_child_model: function(model) {
+        remove_child_view: function(view) {
             // Called when a child is removed from children list.
+            // TODO: does this handle two different views of the same model as children?
+            var model = view.model;
             var accordion_group = this.model_containers[model.id];
             this.containers.splice(accordion_group.container_index, 1);
             delete this.model_containers[model.id];
             accordion_group.remove();
-            this.pop_child_view(model);
         },
 
-        add_child_model: function(model) {
+        add_child_view: function(model) {
             // Called when a child is added to children list.
             var index = this.containers.length;
             var uuid = utils.uuid();
@@ -143,7 +144,7 @@ define([
             TabView.__super__.initialize.apply(this, arguments);
             
             this.containers = [];
-            this.children_views = new widget.ViewList(this.add_child_model, this.remove_child_model, this);
+            this.children_views = new widget.ViewList(this.add_child_view, this.remove_child_view, this);
             this.listenTo(this.model, 'change:children', function(model, value) {
                 this.children_views.update(value);
             }, this);
@@ -168,16 +169,15 @@ define([
             this.$tabs.css(name, value);
         },
 
-        remove_child_model: function(model) {
+        remove_child_view: function(view) {
             // Called when a child is removed from children list.
-            var view = this.pop_child_view(model);
             this.containers.splice(view.parent_tab.tab_text_index, 1);
             view.parent_tab.remove();
             view.parent_container.remove();
             view.remove();
         },
 
-        add_child_model: function(model) {
+        add_child_view: function(model) {
             // Called when a child is added to children list.
             var index = this.containers.length;
             var uuid = utils.uuid();

--- a/IPython/html/static/widgets/js/widget_selectioncontainer.js
+++ b/IPython/html/static/widgets/js/widget_selectioncontainer.js
@@ -128,6 +128,9 @@ define([
         },
         
         remove: function() {
+            // We remove this widget before removing the children as an optimization
+            // we want to remove the entire container from the DOM first before
+            // removing each individual child separately.
             AccordionView.__super__.remove.apply(this, arguments);
             this.children_views.remove();
         },
@@ -252,6 +255,9 @@ define([
         },
         
         remove: function() {
+            // We remove this widget before removing the children as an optimization
+            // we want to remove the entire container from the DOM first before
+            // removing each individual child separately.
             TabView.__super__.remove.apply(this, arguments);
             this.children_views.remove();
         },

--- a/IPython/html/static/widgets/js/widget_selectioncontainer.js
+++ b/IPython/html/static/widgets/js/widget_selectioncontainer.js
@@ -9,18 +9,23 @@ define([
 ], function(widget, utils, $){
 
     var AccordionView = widget.DOMWidgetView.extend({
+        initialize: function(){
+            AccordionView.__super__.initialize.apply(this, arguments);
+
+            this.containers = [];
+            this.model_containers = {};
+            this.children_views = new widget.ViewList(this.add_child_model, this.remove_child_model, this);
+            this.listenTo(this.model, 'change:children', function(model, value) {
+                this.children_views.update(value);
+            }, this);
+        },
+
         render: function(){
             // Called when view is rendered.
             var guid = 'panel-group' + utils.uuid();
             this.$el
                 .attr('id', guid)
                 .addClass('panel-group');
-            this.containers = [];
-            this.model_containers = {};
-            this.update_children([], this.model.get('children'));
-            this.model.on('change:children', function(model, value, options) {
-                this.update_children(model.previous('children'), value);
-            }, this);
             this.model.on('change:selected_index', function(model, value, options) {
                 this.update_selected_index(model.previous('selected_index'), value, options);
             }, this);
@@ -31,6 +36,7 @@ define([
             this.on('displayed', function() {
                 this.update_titles();
             }, this);
+            this.children_views.update(this.model.get('children'));
         },
 
         update_titles: function(titles) {
@@ -60,14 +66,6 @@ define([
                     this.containers[new_index].find('.panel-collapse').collapse('show');
                 }
             }
-        },
-        
-        update_children: function(old_list, new_list) {
-            // Called when the children list is modified.
-            this.do_diff(old_list, 
-                new_list, 
-                $.proxy(this.remove_child_model, this),
-                $.proxy(this.add_child_model, this));
         },
 
         remove_child_model: function(model) {
@@ -128,14 +126,24 @@ define([
                 return view;
             }, utils.reject("Couldn't add child view to box", true));
         },
+        
+        remove: function() {
+            AccordionView.__super__.remove.apply(this, arguments);
+            this.children_views.remove();
+        },
     });
     
 
     var TabView = widget.DOMWidgetView.extend({    
         initialize: function() {
             // Public constructor.
-            this.containers = [];
             TabView.__super__.initialize.apply(this, arguments);
+            
+            this.containers = [];
+            this.children_views = new widget.ViewList(this.add_child_model, this.remove_child_model, this);
+            this.listenTo(this.model, 'change:children', function(model, value) {
+                this.children_views.update(value);
+            }, this);
         },
 
         render: function(){
@@ -149,24 +157,12 @@ define([
             this.$tab_contents = $('<div />', {id: uuid + 'Content'})
                 .addClass('tab-content')
                 .appendTo(this.$el);
-            this.containers = [];
-            this.update_children([], this.model.get('children'));
-            this.model.on('change:children', function(model, value, options) {
-                this.update_children(model.previous('children'), value);
-            }, this);
+            this.children_views.update(this.model.get('children'));
         },
 
         update_attr: function(name, value) {
             // Set a css attr of the widget view.
             this.$tabs.css(name, value);
-        },
-
-        update_children: function(old_list, new_list) {
-            // Called when the children list is modified.
-            this.do_diff(old_list, 
-                new_list, 
-                $.proxy(this.remove_child_model, this),
-                $.proxy(this.add_child_model, this));
         },
 
         remove_child_model: function(model) {
@@ -253,6 +249,11 @@ define([
             this.$tabs.find('li')
                 .removeClass('active');
             this.containers[index].tab('show');
+        },
+        
+        remove: function() {
+            TabView.__super__.remove.apply(this, arguments);
+            this.children_views.remove();
         },
     });
 

--- a/IPython/html/static/widgets/js/widget_selectioncontainer.js
+++ b/IPython/html/static/widgets/js/widget_selectioncontainer.js
@@ -125,7 +125,7 @@ define([
                     view.trigger('displayed');
                 });
                 return view;
-            }, utils.reject("Couldn't add child view to box", true));
+            }).catch(utils.reject("Couldn't add child view to box", true));
         },
         
         remove: function() {
@@ -220,7 +220,7 @@ define([
                     view.trigger('displayed');
                 });
                 return view;
-            }, utils.reject("Couldn't add child view to box", true));
+            }).catch(utils.reject("Couldn't add child view to box", true));
         },
 
         update: function(options) {


### PR DESCRIPTION
This PR attempts to factor out the maintaining of child view lists from the WidgetView class.  Advantages include:
- Ability to easily have different types of containers for child views
- Less code in WidgetView
- Most importantly, the ability to easily have multiple kinds of child view lists (for example, suppose you have a two-column widget, and you want a separate child list for the left and right).

CC @jdfreder, @ellisonbg 
