### PR TITLE
Handle unrecognized output and cell types

### DIFF
--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -636,7 +636,7 @@ define([
         } else {
             data.metadata = this.metadata;
         }
-        this.element.find('.inner_cell').text("Unrecognized cell type: " + data.cell_type);
+        this.element.find('.inner_cell').find("a").text("Unrecognized cell type: " + data.cell_type);
     };
     
     UnrecognizedCell.prototype.create_element = function () {
@@ -647,9 +647,22 @@ define([
         var prompt = $('<div/>').addClass('prompt input_prompt');
         cell.append(prompt);
         var inner_cell = $('<div/>').addClass('inner_cell');
-        inner_cell.text("Unrecognized cell type");
+        inner_cell.append(
+            $("<a>")
+                .attr("href", "#")
+                .text("Unrecognized cell type")
+        );
         cell.append(inner_cell);
         this.element = cell;
+    };
+    
+    UnrecognizedCell.prototype.bind_events = function () {
+        Cell.prototype.bind_events.apply(this, arguments);
+        var cell = this;
+        
+        this.element.find('.inner_cell').find("a").click(function () {
+            cell.events.trigger('unrecognized_cell.Cell', {cell: cell})
+        });
     };
 
     // Backwards compatibility.

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -53,7 +53,9 @@ define([
             get: function() { return that._metadata; },
             set: function(value) {
                 that._metadata = value;
-                that.celltoolbar.rebuild();
+                if (that.celltoolbar) {
+                    that.celltoolbar.rebuild();
+                }
             }
         });
 
@@ -194,11 +196,11 @@ define([
         if((cur.line !== 0 || cur.ch !==0) && event.keyCode === 38){
             event._ipkmIgnore = true;
         }
-        var nLastLine = editor.lastLine()
-        if(    ( event.keyCode === 40)
-            && (( cur.line !== nLastLine)
-            ||  ( cur.ch   !== editor.getLineHandle(nLastLine).text.length))
-          ){
+        var nLastLine = editor.lastLine();
+        if ((event.keyCode === 40) &&
+             ((cur.line !== nLastLine) ||
+               (cur.ch !== editor.getLineHandle(nLastLine).text.length))
+           ) {
             event._ipkmIgnore = true;
         }
         // if this is an edit_shortcuts shortcut, the global keyboard/shortcut
@@ -252,6 +254,14 @@ define([
         } else {
             return false;
         }
+    };
+
+    /**
+     * should be overritten by subclass
+     * @method execute
+     */
+    Cell.prototype.execute = function () {
+        return;
     };
 
     /**
@@ -386,7 +396,9 @@ define([
      * @method refresh
      */
     Cell.prototype.refresh = function () {
-        this.code_mirror.refresh();
+        if (this.code_mirror) {
+            this.code_mirror.refresh();
+        }
     };
 
     /**
@@ -590,8 +602,61 @@ define([
         this.code_mirror.setOption('mode', default_mode);
     };
 
+    var UnrecognizedCell = function (options) {
+        /** Constructor for unrecognized cells */
+        Cell.apply(this, arguments);
+        this.cell_type = 'unrecognized';
+        this.celltoolbar = null;
+        this.data = {};
+        
+        Object.seal(this);
+    };
+
+    UnrecognizedCell.prototype = Object.create(Cell.prototype);
+    
+    
+    // cannot merge or split unrecognized cells
+    UnrecognizedCell.prototype.is_mergeable = function () {
+        return false;
+    };
+    
+    UnrecognizedCell.prototype.is_splittable = function () {
+        return false;
+    };
+    
+    UnrecognizedCell.prototype.toJSON = function () {
+        // deepcopy the metadata so copied cells don't share the same object
+        return JSON.parse(JSON.stringify(this.data));
+    };
+
+    UnrecognizedCell.prototype.fromJSON = function (data) {
+        this.data = data;
+        if (data.metadata !== undefined) {
+            this.metadata = data.metadata;
+        } else {
+            data.metadata = this.metadata;
+        }
+        this.element.find('.inner_cell').text("Unrecognized cell type: " + data.cell_type);
+    };
+    
+    UnrecognizedCell.prototype.create_element = function () {
+        Cell.prototype.create_element.apply(this, arguments);
+        var cell = this.element = $("<div>").addClass('cell unrecognized_cell');
+        cell.attr('tabindex','2');
+
+        var prompt = $('<div/>').addClass('prompt input_prompt');
+        cell.append(prompt);
+        var inner_cell = $('<div/>').addClass('inner_cell');
+        inner_cell.text("Unrecognized cell type");
+        cell.append(inner_cell);
+        this.element = cell;
+    };
+
     // Backwards compatibility.
     IPython.Cell = Cell;
 
-    return {'Cell': Cell};
+    return {
+        Cell: Cell,
+        UnrecognizedCell: UnrecognizedCell
+    };
 });

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -147,7 +147,7 @@ define([
         this.minimum_autosave_interval = 120000;
         this.notebook_name_blacklist_re = /[\/\\:]/;
         this.nbformat = 4; // Increment this when changing the nbformat
-        this.nbformat_minor = 0; // Increment this when changing the nbformat
+        this.nbformat_minor = this.current_nbformat_minor = 0; // Increment this when changing the nbformat
         this.codemirror_mode = 'ipython';
         this.create_elements();
         this.bind_events();
@@ -205,6 +205,14 @@ define([
             var new_cell = that.insert_cell_below('code',index);
             new_cell.set_text(data.text);
             that.dirty = true;
+        });
+
+        this.events.on('unrecognized_cell.Cell', function () {
+            that.warn_nbformat_minor();
+        });
+
+        this.events.on('unrecognized_output.OutputArea', function () {
+            that.warn_nbformat_minor();
         });
 
         this.events.on('set_dirty.Notebook', function (event, data) {
@@ -300,6 +308,28 @@ define([
             return null;
         };
     };
+    
+    Notebook.prototype.warn_nbformat_minor = function (event) {
+        // trigger a warning dialog about missing functionality from newer minor versions
+        var v = 'v' + this.nbformat + '.';
+        var orig_vs = v + this.nbformat_minor;
+        var this_vs = v + this.current_nbformat_minor;
+        var msg = "This notebook is version " + orig_vs + ", but we only fully support up to " +
+        this_vs + ".  You can still work with this notebook, but cell and output types " +
+        "introduced in later notebook versions will not be available.";
+
+        dialog.modal({
+            notebook: this,
+            keyboard_manager: this.keyboard_manager,
+            title : "Newer Notebook",
+            body : msg,
+            buttons : {
+                OK : {
+                    "class" : "btn-danger"
+                }
+            }
+        });
+    }
 
     /**
      * Set the dirty flag, and trigger the set_dirty.Notebook event
@@ -2234,26 +2264,8 @@ define([
                     }
                 }
             });
-        } else if (orig_nbformat_minor !== undefined && nbmodel.nbformat_minor < orig_nbformat_minor) {
-            var that = this;
-            var orig_vs = 'v' + nbmodel.nbformat + '.' + orig_nbformat_minor;
-            var this_vs = 'v' + nbmodel.nbformat + '.' + this.nbformat_minor;
-            msg = "This notebook is version " + orig_vs + ", but we only fully support up to " +
-            this_vs + ".  You can still work with this notebook, but some features " +
-            "introduced in later notebook versions may not be available.";
-
-            dialog.modal({
-                notebook: this,
-                keyboard_manager: this.keyboard_manager,
-                title : "Newer Notebook",
-                body : msg,
-                buttons : {
-                    OK : {
-                        class : "btn-danger"
-                    }
-                }
-            });
-
+        } else if (this.nbformat_minor < nbmodel.nbformat_minor) {
+            this.nbformat_minor = nbmodel.nbformat_minor;
         }
         
         // Create the session after the notebook is completely loaded to prevent

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -6,6 +6,7 @@ define([
     'jquery',
     'base/js/utils',
     'base/js/dialog',
+    'notebook/js/cell',
     'notebook/js/textcell',
     'notebook/js/codecell',
     'services/sessions/session',
@@ -22,13 +23,14 @@ define([
     'notebook/js/scrollmanager'
 ], function (
     IPython, 
-    $, 
-    utils, 
-    dialog, 
-    textcell, 
-    codecell, 
+    $,
+    utils,
+    dialog,
+    cellmod,
+    textcell,
+    codecell,
     session, 
-    celltoolbar, 
+    celltoolbar,
     marked,
     CodeMirror,
     runMode,
@@ -894,7 +896,8 @@ define([
                 cell = new textcell.RawCell(cell_options);
                 break;
             default:
-                console.log("invalid cell type: ", type);
+                console.log("Unrecognized cell type: ", type, cellmod);
+                cell = new cellmod.UnrecognizedCell(cell_options);
             }
 
             if(this._insert_element_at_index(cell.element,index)) {

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -271,7 +271,6 @@ define([
         }
 
         var record_output = true;
-        console.log("appending", json);
         switch(json.output_type) {
             case 'execute_result':
                 json = this.validate_mimebundle(json);
@@ -490,10 +489,18 @@ define([
 
 
     OutputArea.prototype.append_unrecognized = function (json) {
+        var that = this;
         var toinsert = this.create_output_area();
         var subarea = $('<div/>').addClass('output_subarea output_unrecognized');
         toinsert.append(subarea);
-        subarea.text("Unrecognized output: " + json.output_type);
+        subarea.append(
+            $("<a>")
+                .attr("href", "#")
+                .text("Unrecognized output: " + json.output_type)
+                .click(function () {
+                    that.events.trigger('unrecognized_output.OutputArea', {output: json})
+                })
+        );
         this._safe_append(toinsert);
     };
 

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -340,7 +340,7 @@ define([
     var textcell = {
         TextCell: TextCell,
         MarkdownCell: MarkdownCell,
-        RawCell: RawCell,
+        RawCell: RawCell
     };
     return textcell;
 });

--- a/IPython/html/static/notebook/less/cell.less
+++ b/IPython/html/static/notebook/less/cell.less
@@ -61,3 +61,24 @@ div.prompt:empty {
     padding-top: 0;
     padding-bottom: 0;
 }
+
+div.unrecognized_cell {
+    // from text_cell
+    padding: 5px 5px 5px 0px;
+    .hbox();
+    
+    .inner_cell {
+        .border-radius(@border-radius-base);
+        padding: 5px;
+        font-weight: bold;
+        color: red;
+        border: 1px solid @light_border_color;
+        background: darken(@cell_background, 5%);
+    }
+}
+@media (max-width: 480px) {
+    // remove prompt indentation on small screens
+    div.unrecognized_cell > div.prompt {
+        display: none;
+    }
+}

--- a/IPython/html/static/notebook/less/cell.less
+++ b/IPython/html/static/notebook/less/cell.less
@@ -74,6 +74,16 @@ div.unrecognized_cell {
         color: red;
         border: 1px solid @light_border_color;
         background: darken(@cell_background, 5%);
+        // remove decoration from link
+        a {
+            color: inherit;
+            text-decoration: none;
+
+            &:hover {
+                color: inherit;
+                text-decoration: none;
+            }
+        }
     }
 }
 @media (max-width: 480px) {

--- a/IPython/html/static/notebook/less/outputarea.less
+++ b/IPython/html/static/notebook/less/outputarea.less
@@ -177,4 +177,14 @@ div.output_unrecognized {
   padding: 5px;
   font-weight: bold;
   color: red;
+  // remove decoration from link
+  a {
+      color: inherit;
+      text-decoration: none;
+
+      &:hover {
+          color: inherit;
+          text-decoration: none;
+      }
+  }
 }

--- a/IPython/html/static/notebook/less/outputarea.less
+++ b/IPython/html/static/notebook/less/outputarea.less
@@ -172,3 +172,9 @@ input.raw_input:focus {
 p.p-space {
     margin-bottom: 10px;
 }
+
+div.output_unrecognized {
+  padding: 5px;
+  font-weight: bold;
+  color: red;
+}

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -444,6 +444,14 @@ div.unrecognized_cell .inner_cell {
   border: 1px solid #cfcfcf;
   background: #eaeaea;
 }
+div.unrecognized_cell .inner_cell a {
+  color: inherit;
+  text-decoration: none;
+}
+div.unrecognized_cell .inner_cell a:hover {
+  color: inherit;
+  text-decoration: none;
+}
 @media (max-width: 480px) {
   div.unrecognized_cell > div.prompt {
     display: none;
@@ -919,10 +927,17 @@ p.p-space {
   margin-bottom: 10px;
 }
 div.output_unrecognized {
-  border-radius: 4px;
   padding: 5px;
   font-weight: bold;
   color: red;
+}
+div.output_unrecognized a {
+  color: inherit;
+  text-decoration: none;
+}
+div.output_unrecognized a:hover {
+  color: inherit;
+  text-decoration: none;
 }
 .rendered_html {
   color: #000000;

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -419,6 +419,36 @@ div.prompt:empty {
   padding-top: 0;
   padding-bottom: 0;
 }
+div.unrecognized_cell {
+  padding: 5px 5px 5px 0px;
+  /* Old browsers */
+  display: -webkit-box;
+  -webkit-box-orient: horizontal;
+  -webkit-box-align: stretch;
+  display: -moz-box;
+  -moz-box-orient: horizontal;
+  -moz-box-align: stretch;
+  display: box;
+  box-orient: horizontal;
+  box-align: stretch;
+  /* Modern browsers */
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+}
+div.unrecognized_cell .inner_cell {
+  border-radius: 4px;
+  padding: 5px;
+  font-weight: bold;
+  color: red;
+  border: 1px solid #cfcfcf;
+  background: #eaeaea;
+}
+@media (max-width: 480px) {
+  div.unrecognized_cell > div.prompt {
+    display: none;
+  }
+}
 /* any special styling for code cells that are currently running goes here */
 div.input {
   page-break-inside: avoid;
@@ -887,6 +917,12 @@ input.raw_input:focus {
 }
 p.p-space {
   margin-bottom: 10px;
+}
+div.output_unrecognized {
+  border-radius: 4px;
+  padding: 5px;
+  font-weight: bold;
+  color: red;
 }
 .rendered_html {
   color: #000000;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8288,6 +8288,36 @@ div.prompt:empty {
   padding-top: 0;
   padding-bottom: 0;
 }
+div.unrecognized_cell {
+  padding: 5px 5px 5px 0px;
+  /* Old browsers */
+  display: -webkit-box;
+  -webkit-box-orient: horizontal;
+  -webkit-box-align: stretch;
+  display: -moz-box;
+  -moz-box-orient: horizontal;
+  -moz-box-align: stretch;
+  display: box;
+  box-orient: horizontal;
+  box-align: stretch;
+  /* Modern browsers */
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+}
+div.unrecognized_cell .inner_cell {
+  border-radius: 4px;
+  padding: 5px;
+  font-weight: bold;
+  color: red;
+  border: 1px solid #cfcfcf;
+  background: #eaeaea;
+}
+@media (max-width: 480px) {
+  div.unrecognized_cell > div.prompt {
+    display: none;
+  }
+}
 /* any special styling for code cells that are currently running goes here */
 div.input {
   page-break-inside: avoid;
@@ -8756,6 +8786,12 @@ input.raw_input:focus {
 }
 p.p-space {
   margin-bottom: 10px;
+}
+div.output_unrecognized {
+  border-radius: 4px;
+  padding: 5px;
+  font-weight: bold;
+  color: red;
 }
 .rendered_html {
   color: #000000;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8313,6 +8313,14 @@ div.unrecognized_cell .inner_cell {
   border: 1px solid #cfcfcf;
   background: #eaeaea;
 }
+div.unrecognized_cell .inner_cell a {
+  color: inherit;
+  text-decoration: none;
+}
+div.unrecognized_cell .inner_cell a:hover {
+  color: inherit;
+  text-decoration: none;
+}
 @media (max-width: 480px) {
   div.unrecognized_cell > div.prompt {
     display: none;
@@ -8788,10 +8796,17 @@ p.p-space {
   margin-bottom: 10px;
 }
 div.output_unrecognized {
-  border-radius: 4px;
   padding: 5px;
   font-weight: bold;
   color: red;
+}
+div.output_unrecognized a {
+  color: inherit;
+  text-decoration: none;
+}
+div.output_unrecognized a:hover {
+  color: inherit;
+  text-decoration: none;
 }
 .rendered_html {
   color: #000000;

--- a/IPython/nbformat/tests/test4plus.ipynb
+++ b/IPython/nbformat/tests/test4plus.ipynb
@@ -306,6 +306,41 @@
     "from IPython.display import Image\n",
     "Image(\"http://ipython.org/_static/IPy_header.png\")"
    ]
+  },
+  {
+   "cell_type": "future cell",
+   "metadata": {},
+   "key": "value"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 99,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello\n"
+     ]
+    },
+    {
+     "output_type": "future output",
+     "some key": [
+      "some data"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello again\n"
+     ]
+    }
+   ],
+   "source": [
+    "future_output()"
+   ]
   }
  ],
  "metadata": {},

--- a/IPython/nbformat/v4/nbformat.v4.schema.json
+++ b/IPython/nbformat/v4/nbformat.v4.schema.json
@@ -54,18 +54,19 @@
         "cells": {
             "description": "Array of cells of the current notebook.",
             "type": "array",
-            "items": {
-                "type": "object",
-                "oneOf": [
-                    {"$ref": "#/definitions/raw_cell"},
-                    {"$ref": "#/definitions/markdown_cell"},
-                    {"$ref": "#/definitions/code_cell"}
-                ]
-            }
+            "items": {"$ref": "#/definitions/cell"}
         }
     },
 
     "definitions": {
+        "cell": {
+            "type": "object",
+            "oneOf": [
+                {"$ref": "#/definitions/raw_cell"},
+                {"$ref": "#/definitions/markdown_cell"},
+                {"$ref": "#/definitions/code_cell"}
+            ]
+        },
 
         "raw_cell": {
             "description": "Notebook raw nbconvert cell.",
@@ -157,6 +158,31 @@
                 }
             }
         },
+        
+        "unrecognized_cell": {
+            "description": "Unrecognized cell from a future minor-revision to the notebook format.",
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["cell_type", "metadata"],
+            "properties": {
+                "cell_type": {
+                    "description": "String identifying the type of cell.",
+                    "not" : {
+                      "enum": ["markdown", "code", "raw"]
+                    }
+                },
+                "metadata": {
+                    "description": "Cell-level metadata.",
+                    "type": "object",
+                    "properties": {
+                        "name": {"$ref": "#/definitions/misc/metadata_name"},
+                        "tags": {"$ref": "#/definitions/misc/metadata_tags"}
+                    },
+                    "additionalProperties": true
+                }
+            }
+        },
+        
         "output": {
             "type": "object",
             "oneOf": [
@@ -245,6 +271,21 @@
                     "description": "The error's traceback, represented as an array of strings.",
                     "type": "array",
                     "items": {"type": "string"}
+                }
+            }
+        },
+
+        "unrecognized_output": {
+            "description": "Unrecognized output from a future minor-revision to the notebook format.",
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["output_type"],
+            "properties": {
+                "output_type": {
+                    "description": "Type of cell output.",
+                    "not": {
+                        "enum": ["execute_result", "display_data", "stream", "error"]
+                    }
                 }
             }
         },


### PR DESCRIPTION
Makes adding new cell and output types a minor revision, rather than a major one.

A notebook with minor nbformat from the future will pass validation if it has cells or outputs that are unrecognized.

These cells and outputs are displayed with simple red-text placeholders. Their content is not touched nor displayed at all.
