### PR TITLE
API to replace current cell

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2003,7 +2003,7 @@ class InteractiveShell(SingletonConfigurable):
                     continue
 
     @skip_doctest
-    def set_next_input(self, s):
+    def set_next_input(self, s, replace=False):
         """ Sets the 'default' input string for the next command line.
 
         Requires readline.

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -353,7 +353,9 @@ class CodeMagics(Magics):
                 print('Operation cancelled.')
                 return
 
-        self.shell.set_next_input(contents)
+        contents = "# %load {}\n".format(arg_s) + contents
+
+        self.shell.set_next_input(contents, replace=True)
 
     @staticmethod
     def _find_edit_target(shell, args, opts, last_call):

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -389,7 +389,7 @@ define([
      * @private
      */
     CodeCell.prototype._handle_set_next_input = function (payload) {
-        var data = {'cell': this, 'text': payload.text};
+        var data = {'cell': this, 'text': payload.text, replace: payload.replace};
         this.events.trigger('set_next_input.Notebook', data);
     };
 

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -209,9 +209,13 @@ define([
         var that = this;
 
         this.events.on('set_next_input.Notebook', function (event, data) {
-            var index = that.find_cell_index(data.cell);
-            var new_cell = that.insert_cell_below('code',index);
-            new_cell.set_text(data.text);
+            if (data.replace) {
+                data.cell.set_text(data.text);
+            } else {
+                var index = that.find_cell_index(data.cell);
+                var new_cell = that.insert_cell_below('code',index);
+                new_cell.set_text(data.text);
+            }
             that.dirty = true;
         });
 

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -211,6 +211,7 @@ define([
         this.events.on('set_next_input.Notebook', function (event, data) {
             if (data.replace) {
                 data.cell.set_text(data.text);
+                data.cell.clear_output();
             } else {
                 var index = that.find_cell_index(data.cell);
                 var new_cell = that.insert_cell_below('code',index);

--- a/IPython/kernel/zmq/zmqshell.py
+++ b/IPython/kernel/zmq/zmqshell.py
@@ -447,12 +447,13 @@ class ZMQInteractiveShell(InteractiveShell):
 
         return exc_content
 
-    def set_next_input(self, text):
+    def set_next_input(self, text, replace=False):
         """Send the specified text to the frontend to be presented at the next
         input cell."""
         payload = dict(
             source='set_next_input',
-            text=text
+            text=text,
+            replace=replace,
         )
         self.payload_manager.write_payload(payload)
     

--- a/docs/source/development/messaging.rst
+++ b/docs/source/development/messaging.rst
@@ -429,6 +429,9 @@ The main example being ``%load``.
       "source": "set_next_input",
       # the text contents of the cell to create
       "text": "some cell content",
+      # If true, replace the current cell in document UIs instead of inserting
+      # a cell. Ignored in console UIs.
+      "replace": bool,
     }
 
 **edit**: open a file for editing.


### PR DESCRIPTION
`set_next_input()` makes sense in the terminal, but in the notebook, it's always seemed a bit odd to add a cell in response to things like the %load magic, because re-running the notebook will add the cell again and again.

This adds a `replace=` parameter to `set_next_input()`, defaulting to False. If True, it replaces the current cell contents instead of adding a new cell. In console frontends, the parameter is ignored. I've adapted the `%load` magic to use this, and to add a comment containing the load command at the top of the replacement text, so that it's obvious where it came from:

![screenshot from 2014-11-19 18 06 18](https://cloud.githubusercontent.com/assets/327925/5118411/d9f503f2-7016-11e4-9e28-420c9cb29ad9.png)
