### PR TITLE
define kernelpath for clientside notebook manager

### DIFF
--- a/IPython/html/services/contents/clientsidenbmanager.py
+++ b/IPython/html/services/contents/clientsidenbmanager.py
@@ -5,6 +5,8 @@
 
 from .manager import ContentsManager
 
+import os.path
+
 class ClientSideContentsManager(ContentsManager):
     """Dummy contents manager for use with client-side contents APIs like GDrive
 
@@ -21,3 +23,10 @@ class ClientSideContentsManager(ContentsManager):
 
     def file_exists(self, name, path=''):
         return True
+
+    def get_kernel_path(self, path, model=None):
+         """Return the initial working dir a kernel associated with a given notebook
+         
+         Here just alway return home directory
+         """
+         return os.path.expanduser('~')

--- a/IPython/html/services/contents/clientsidenbmanager.py
+++ b/IPython/html/services/contents/clientsidenbmanager.py
@@ -5,8 +5,6 @@
 
 from .manager import ContentsManager
 
-import os.path
-
 class ClientSideContentsManager(ContentsManager):
     """Dummy contents manager for use with client-side contents APIs like GDrive
 
@@ -25,8 +23,11 @@ class ClientSideContentsManager(ContentsManager):
         return True
 
     def get_kernel_path(self, path, model=None):
-         """Return the initial working dir a kernel associated with a given notebook
+         """Return the API path for the kernel
          
-         Here just alway return home directory
+         KernelManagers can turn this value into a filesystem path,
+         or ignore it altogether.
+         
+         Here just always return home directory
          """
-         return os.path.expanduser('~')
+         return '/'

--- a/IPython/html/services/contents/filemanager.py
+++ b/IPython/html/services/contents/filemanager.py
@@ -606,9 +606,9 @@ class FileContentsManager(ContentsManager):
         return "Serving notebooks from local directory: %s" % self.root_dir
 
     def get_kernel_path(self, path, model=None):
-        """Return the initial working dir a kernel associated with a given notebook"""
+        """Return the initial API path of  a kernel associated with a given notebook"""
         if '/' in path:
             parent_dir = path.rsplit('/', 1)[0]
         else:
             parent_dir = ''
-        return self._get_os_path(parent_dir)
+        return parent_dir


### PR DESCRIPTION
Otherwise starting the kernel choke on google drive path that are not localhost path.

I'm wondering if we should not make that the default behavior of `ContentsManager` instead of return `path`, 
or just verify that cwd is a dir in launch kernel or earlier. 
