### PR TITLE
only check for formatters on instances

### DIFF
--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -50,9 +50,6 @@ def _valid_formatter(f):
     """
     if f is None:
         return False
-    elif isinstance(f, type(str.find)):
-        # unbound methods on compiled classes have type method_descriptor
-        return False
     elif isinstance(f, types.BuiltinFunctionType):
         # bound methods on compiled classes have type builtin_function
         return True
@@ -68,6 +65,9 @@ def _valid_formatter(f):
 
 def _safe_get_formatter_method(obj, name):
     """Safely get a formatter method"""
+    if inspect.isclass(obj):
+        # repr methods only make sense on instances, not classes
+        return None
     method = pretty._safe_getattr(obj, name, None)
     # formatter methods must be bound
     if _valid_formatter(method):

--- a/IPython/core/tests/test_formatters.py
+++ b/IPython/core/tests/test_formatters.py
@@ -348,8 +348,7 @@ def test_print_method_weird():
     with capture_output() as captured:
         result = f(call_hat)
     
-    nt.assert_equal(result, '_repr_html_')
-    nt.assert_not_in("FormatterWarning", captured.stderr)
+    nt.assert_equal(result, None)
 
     class BadReprArgs(object):
         def _repr_html_(self, extra, args):


### PR DESCRIPTION
use inspect.isclass to disallow unbound methods, not type checking on the method itself.

closes #6080
closes #7003
