### PR TITLE
Fix input transformer bug when pasting ipython promts (issue #6674).

### DIFF
--- a/IPython/core/inputtransformer.py
+++ b/IPython/core/inputtransformer.py
@@ -461,7 +461,7 @@ def classic_prompt():
 def ipy_prompt():
     """Strip IPython's In [1]:/...: prompts."""
     # FIXME: non-capturing version (?:...) usable?
-    prompt_re = re.compile(r'^(In \[\d+\]: |\ {3,}\.{3,}: )')
+    prompt_re = re.compile(r'^(In \[\d+\]: |\s*\.{3,}: )')
     return _strip_prompts(prompt_re)
 
 

--- a/IPython/core/inputtransformer.py
+++ b/IPython/core/inputtransformer.py
@@ -461,7 +461,7 @@ def classic_prompt():
 def ipy_prompt():
     """Strip IPython's In [1]:/...: prompts."""
     # FIXME: non-capturing version (?:...) usable?
-    prompt_re = re.compile(r'^(In \[\d+\]: |\s*\.{3,}: )')
+    prompt_re = re.compile(r'^(In \[\d+\]: |\s*\.{3,}: ?)')
     return _strip_prompts(prompt_re)
 
 

--- a/IPython/core/tests/test_inputtransformer.py
+++ b/IPython/core/tests/test_inputtransformer.py
@@ -233,6 +233,11 @@ syntax_ml = \
           ('...:     print i','    print i'),
           ('...: ', ''),
           ],
+         [('In [24]: for i in range(10):','for i in range(10):'),
+          # Space after last continuation prompt has been removed (issue #6674)
+          ('...:     print i','    print i'),
+          ('...:', ''),
+          ],
          [('In [2]: a="""','a="""'),
           ('   ...: 123"""','123"""'),
           ],

--- a/IPython/core/tests/test_inputtransformer.py
+++ b/IPython/core/tests/test_inputtransformer.py
@@ -229,7 +229,7 @@ syntax_ml = \
           ('    ...: ', ''),
           ],
          [('In [24]: for i in range(10):','for i in range(10):'),
-          # Sometimes whitespace preceding '...' has been removed (issue #6674)
+          # Sometimes whitespace preceding '...' has been removed
           ('...:     print i','    print i'),
           ('...: ', ''),
           ],

--- a/IPython/core/tests/test_inputtransformer.py
+++ b/IPython/core/tests/test_inputtransformer.py
@@ -228,6 +228,11 @@ syntax_ml = \
           ('    ...:     print i','    print i'),
           ('    ...: ', ''),
           ],
+         [('In [24]: for i in range(10):','for i in range(10):'),
+          # Sometimes whitespace preceding '...' has been removed (issue #6674)
+          ('...:     print i','    print i'),
+          ('...: ', ''),
+          ],
          [('In [2]: a="""','a="""'),
           ('   ...: 123"""','123"""'),
           ],


### PR DESCRIPTION
Fixes a SyntaxError that arose when pasting code containing the IPython
continuation prompt without preceding spaces, eg.:

In [1]: if True:
...:     print "No spaces before the '...:' prompt."

This issue was brought up in
"http://stackoverflow.com/questions/26297356/how-can-i-paste-the-ipython-output-in-ipython#comment41270724_26297356"

This commit adds a test for the bug, and fixes the regular expression
that strips continuation prompts.
