### PR TITLE
Use Content Security Policies instead of X-Frame-Options

### DIFF
--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -63,7 +63,6 @@ class AuthenticatedHandler(web.RequestHandler):
                 # if method is unsupported (websocket and Access-Control-Allow-Origin
                 # for example, so just ignore)
                 self.log.debug(e)
-                pass
     
     def clear_login_cookie(self):
         self.clear_cookie(self.cookie_name)

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -50,9 +50,8 @@ class AuthenticatedHandler(web.RequestHandler):
         if "Content-Security-Policy" not in headers:
             headers["Content-Security-Policy"] = (
                     "frame-ancestors 'self'; "
-                    # Make sure the report-uri comes out on the base_url
-                    "report-uri " + url_path_join(self.base_url, csp_report_uri) + 
-                    ";"
+                    # Make sure the report-uri is relative to the base_url
+                    "report-uri " + url_path_join(self.base_url, csp_report_uri) + ";"
             )
 
         # Allow for overriding headers

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -48,7 +48,12 @@ class AuthenticatedHandler(web.RequestHandler):
         headers = self.settings.get('headers', {})
 
         if "Content-Security-Policy" not in headers:
-            headers["Content-Security-Policy"] = "frame-ancestors 'self'"
+            headers["Content-Security-Policy"] = (
+                    "frame-ancestors 'self'; "
+                    # Make sure the report-uri comes out on the base_url
+                    "report-uri " + url_path_join(self.base_url, csp_report_uri) + 
+                    ";"
+            )
 
         # Allow for overriding headers
         for header_name,value in headers.items() :

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -48,10 +48,9 @@ class AuthenticatedHandler(web.RequestHandler):
         headers = self.settings.get('headers', {})
 
         if "Content-Security-Policy" not in headers:
-            headers["Content-Security-Policy"] = ""
+            headers["Content-Security-Policy"] = "frame-ancestors 'self'"
 
         if "Content-Security-Policy-Report-Only" not in headers:
-
             reporter_policy = ("default-src 'self'; " +
                                "report-uri " + url_path_join(self.base_url, csp_report_uri) + 
                                ";"

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -32,7 +32,7 @@ from IPython.utils.path import filefind
 from IPython.utils.py3compat import string_types
 from IPython.html.utils import is_hidden, url_path_join, url_escape
 
-from IPython.html.services.security.handlers import csp_report_uri
+from IPython.html.services.security import csp_report_uri
 
 #-----------------------------------------------------------------------------
 # Top-level handlers

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -55,18 +55,17 @@ class AuthenticatedHandler(web.RequestHandler):
                                "report-uri " + url_path_join(self.base_url, csp_report_uri) + 
                                ";"
             )
-            self.log.debug(reporter_policy)
-
             headers["Content-Security-Policy-Report-Only"] = reporter_policy
 
         # Allow for overriding headers
         for header_name,value in headers.items() :
             try:
                 self.set_header(header_name, value)
-            except Exception:
+            except Exception as e:
                 # tornado raise Exception (not a subclass)
                 # if method is unsupported (websocket and Access-Control-Allow-Origin
                 # for example, so just ignore)
+                self.log.debug(e)
                 pass
     
     def clear_login_cookie(self):

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -50,13 +50,6 @@ class AuthenticatedHandler(web.RequestHandler):
         if "Content-Security-Policy" not in headers:
             headers["Content-Security-Policy"] = "frame-ancestors 'self'"
 
-        if "Content-Security-Policy-Report-Only" not in headers:
-            reporter_policy = ("default-src 'self'; " +
-                               "report-uri " + url_path_join(self.base_url, csp_report_uri) + 
-                               ";"
-            )
-            headers["Content-Security-Policy-Report-Only"] = reporter_policy
-
         # Allow for overriding headers
         for header_name,value in headers.items() :
             try:

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -56,7 +56,7 @@ class AuthenticatedHandler(web.RequestHandler):
                                "report-uri " + url_path_join(self.base_url, csp_report_uri) + 
                                ";"
             )
-            self.log.info(reporter_policy)
+            self.log.debug(reporter_policy)
 
             headers["Content-Security-Policy-Report-Only"] = reporter_policy
 

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -45,8 +45,8 @@ class AuthenticatedHandler(web.RequestHandler):
     def set_default_headers(self):
         headers = self.settings.get('headers', {})
 
-        if "X-Frame-Options" not in headers:
-            headers["X-Frame-Options"] = "SAMEORIGIN"
+        if "Content-Security-Policy" not in headers:
+            headers["Content-Security-Policy"] = "default-src 'self'"
 
         for header_name,value in headers.items() :
             try:

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -32,6 +32,8 @@ from IPython.utils.path import filefind
 from IPython.utils.py3compat import string_types
 from IPython.html.utils import is_hidden, url_path_join, url_escape
 
+from IPython.html.services.security.handlers import csp_report_uri
+
 #-----------------------------------------------------------------------------
 # Top-level handlers
 #-----------------------------------------------------------------------------
@@ -46,8 +48,20 @@ class AuthenticatedHandler(web.RequestHandler):
         headers = self.settings.get('headers', {})
 
         if "Content-Security-Policy" not in headers:
-            headers["Content-Security-Policy"] = "default-src 'self'"
+            #headers["Content-Security-Policy"] = ""
+            pass
 
+        if "Content-Security-Policy-Report-Only" not in headers:
+
+            reporter_policy = ("default-src 'self'; " +
+                               "report-uri " + url_path_join(self.base_url, csp_report_uri) + 
+                               ";"
+            )
+            self.log.info(reporter_policy)
+
+            headers["Content-Security-Policy-Report-Only"] = reporter_policy
+
+        # Allow for overriding headers
         for header_name,value in headers.items() :
             try:
                 self.set_header(header_name, value)

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -48,8 +48,7 @@ class AuthenticatedHandler(web.RequestHandler):
         headers = self.settings.get('headers', {})
 
         if "Content-Security-Policy" not in headers:
-            #headers["Content-Security-Policy"] = ""
-            pass
+            headers["Content-Security-Policy"] = ""
 
         if "Content-Security-Policy-Report-Only" not in headers:
 

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -225,7 +225,7 @@ class NotebookWebApplication(web.Application):
         handlers.extend(load_handlers('services.sessions.handlers'))
         handlers.extend(load_handlers('services.nbconvert.handlers'))
         handlers.extend(load_handlers('services.kernelspecs.handlers'))
-        
+        handlers.extend(load_handlers('services.security.handlers'))
         handlers.append(
             (r"/nbextensions/(.*)", FileFindHandler, {
                 'path': settings['nbextensions_path'],

--- a/IPython/html/services/kernels/tests/test_kernels_api.py
+++ b/IPython/html/services/kernels/tests/test_kernels_api.py
@@ -65,7 +65,7 @@ class KernelAPITest(NotebookTestBase):
         self.assertEqual(r.status_code, 201)
         self.assertIsInstance(kern1, dict)
 
-        self.assertEqual(r.headers['x-frame-options'], "SAMEORIGIN")
+        self.assertEqual(r.headers['Content-Security-Policy'], "frame-ancestors 'self'")
 
     def test_main_kernel_handler(self):
         # POST request
@@ -75,7 +75,7 @@ class KernelAPITest(NotebookTestBase):
         self.assertEqual(r.status_code, 201)
         self.assertIsInstance(kern1, dict)
 
-        self.assertEqual(r.headers['x-frame-options'], "SAMEORIGIN")
+        self.assertEqual(r.headers['Content-Security-Policy'], "frame-ancestors 'self'")
 
         # GET request
         r = self.kern_api.list()

--- a/IPython/html/services/kernels/tests/test_kernels_api.py
+++ b/IPython/html/services/kernels/tests/test_kernels_api.py
@@ -65,7 +65,10 @@ class KernelAPITest(NotebookTestBase):
         self.assertEqual(r.status_code, 201)
         self.assertIsInstance(kern1, dict)
 
-        self.assertEqual(r.headers['Content-Security-Policy'], "frame-ancestors 'self'")
+        self.assertEqual(r.headers['Content-Security-Policy'], (
+                            "frame-ancestors 'self'; "
+                            "report-uri /api/security/csp-report;"
+        ))
 
     def test_main_kernel_handler(self):
         # POST request
@@ -75,7 +78,10 @@ class KernelAPITest(NotebookTestBase):
         self.assertEqual(r.status_code, 201)
         self.assertIsInstance(kern1, dict)
 
-        self.assertEqual(r.headers['Content-Security-Policy'], "frame-ancestors 'self'")
+        self.assertEqual(r.headers['Content-Security-Policy'], (
+                            "frame-ancestors 'self'; "
+                            "report-uri /api/security/csp-report;"
+        ))
 
         # GET request
         r = self.kern_api.list()

--- a/IPython/html/services/security/__init__.py
+++ b/IPython/html/services/security/__init__.py
@@ -1,1 +1,4 @@
+# URI for the CSP Report. Included here to prevent a cyclic dependency.
+# csp_report_uri is needed both by the BaseHandler (for setting the report-uri)
+# and by the CSPReportHandler (which depends on the BaseHandler).
 csp_report_uri = r"/api/security/csp-report"

--- a/IPython/html/services/security/__init__.py
+++ b/IPython/html/services/security/__init__.py
@@ -1,0 +1,1 @@
+csp_report_uri = r"/api/security/csp-report"

--- a/IPython/html/services/security/handlers.py
+++ b/IPython/html/services/security/handlers.py
@@ -15,7 +15,8 @@ class CSPReportHandler(IPythonHandler):
     def post(self):
         '''Log a content security policy violation report'''
         csp_report = self.get_json_body()
-        self.log.warn(csp_report)
+        self.log.warn("Content security violation: %s",
+                      self.request.body.decode('utf8', 'replace'))
 
 default_handlers = [
     (csp_report_uri, CSPReportHandler)

--- a/IPython/html/services/security/handlers.py
+++ b/IPython/html/services/security/handlers.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+class CSPReportHandler(IPythonHandler):
+    '''Accepts a content security policy violation report'''
+    @web.authenticated
+    @json_errors
+    def post(self):
+        '''Log a content security policy violation report'''
+        csp_report = self.get_json_body()
+        self.log.debug(csp_report)
+
+csp_report_uri = r"/api/security/csp-report" 
+
+default_handlers = [
+    (csp_report_uri, CSPReportHandler)
+]

--- a/IPython/html/services/security/handlers.py
+++ b/IPython/html/services/security/handlers.py
@@ -15,7 +15,7 @@ class CSPReportHandler(IPythonHandler):
     def post(self):
         '''Log a content security policy violation report'''
         csp_report = self.get_json_body()
-        self.log.debug(csp_report)
+        self.log.warn(csp_report)
 
 default_handlers = [
     (csp_report_uri, CSPReportHandler)

--- a/IPython/html/services/security/handlers.py
+++ b/IPython/html/services/security/handlers.py
@@ -1,5 +1,11 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+"""Tornado handlers for security logging."""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from tornado import gen, web
+
+from ...base.handlers import IPythonHandler, json_errors
 
 class CSPReportHandler(IPythonHandler):
     '''Accepts a content security policy violation report'''

--- a/IPython/html/services/security/handlers.py
+++ b/IPython/html/services/security/handlers.py
@@ -6,6 +6,7 @@
 from tornado import gen, web
 
 from ...base.handlers import IPythonHandler, json_errors
+from . import csp_report_uri
 
 class CSPReportHandler(IPythonHandler):
     '''Accepts a content security policy violation report'''
@@ -15,8 +16,6 @@ class CSPReportHandler(IPythonHandler):
         '''Log a content security policy violation report'''
         csp_report = self.get_json_body()
         self.log.debug(csp_report)
-
-csp_report_uri = r"/api/security/csp-report" 
 
 default_handlers = [
     (csp_report_uri, CSPReportHandler)

--- a/docs/source/whatsnew/development.rst
+++ b/docs/source/whatsnew/development.rst
@@ -194,7 +194,7 @@ configuration to extend for alternate domains and security settings.::
 
     c.NotebookApp.tornado_settings = {
         'headers': {
-            'Content-Security-Policy': "default-src 'self' *.jupyter.org"
+            'Content-Security-Policy': "frame-ancestors 'self'"
         }
     }
 
@@ -204,6 +204,18 @@ Example policies::
 
 Matches embeddings on any subdomain of jupyter.org, so long as they are served
 over SSL.
+
+There is a `report-uri <https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives#report-uri>`_ endpoint available for logging CSP violations, located at
+``/api/security/csp-report``. To use it, set ``report-uri`` as part of the CSP::
+
+    c.NotebookApp.tornado_settings = {
+        'headers': {
+            'Content-Security-Policy': "frame-ancestors 'self'; report-uri /api/security/csp-report"
+        }
+    }
+
+It simply provides the CSP report as a warning in IPython's logs. The default
+CSP sets this report-uri relative to the ``base_url`` (not shown above).
 
 For a more thorough and accurate guide on Content Security Policies, check out
 `MDN's Using Content Security Policy <https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_Content_Security_Policy>`_ for more examples.

--- a/docs/source/whatsnew/development.rst
+++ b/docs/source/whatsnew/development.rst
@@ -186,10 +186,14 @@ IFrame embedding
 The IPython Notebook and its APIs by default will only be allowed to be
 embedded in an iframe on the same origin.
 
-To override this, set ``headers[X-Frame-Options]`` to one of
+Override ``headers['Content-Security-Policy']`` within your notebook
+configuration to extend for alternate domains and security settings.::
 
-* DENY
-* SAMEORIGIN
-* ALLOW-FROM uri
+    c.NotebookApp.tornado_settings = {
+        'headers': {
+            'Content-Security-Policy': "default-src 'self' *.jupyter.org
+        }
+    }
 
-See `Mozilla's guide to X-Frame-Options <https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options>`_ for more examples.
+For a more thorough and accurate guide on Content Security Policies, check out
+`MDN's Using Content Security Policy <https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_Content_Security_Policy>`_ for more examples.

--- a/docs/source/whatsnew/development.rst
+++ b/docs/source/whatsnew/development.rst
@@ -180,20 +180,30 @@ Backwards incompatible changes
 
 .. DO NOT EDIT THIS LINE BEFORE RELEASE. INCOMPAT INSERTION POINT.
 
-IFrame embedding
-````````````````
+Content Security Policy
+```````````````````````
 
-The IPython Notebook and its APIs by default will only be allowed to be
-embedded in an iframe on the same origin.
+The Content Security Policy is a web standard for adding a layer of security to
+detect and mitigate certain classes of attacks, including Cross Site Scripting
+(XSS) and data injection attacks. This was introduced into the notebook to
+ensure that the IPython Notebook and its APIs (by default) can only be embedded
+in an iframe on the same origin.
 
 Override ``headers['Content-Security-Policy']`` within your notebook
 configuration to extend for alternate domains and security settings.::
 
     c.NotebookApp.tornado_settings = {
         'headers': {
-            'Content-Security-Policy': "default-src 'self' *.jupyter.org
+            'Content-Security-Policy': "default-src 'self' *.jupyter.org"
         }
     }
+
+Example policies::
+
+    Content-Security-Policy: default-src 'self' https://*.jupyter.org
+
+Matches embeddings on any subdomain of jupyter.org, so long as they are served
+over SSL.
 
 For a more thorough and accurate guide on Content Security Policies, check out
 `MDN's Using Content Security Policy <https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_Content_Security_Policy>`_ for more examples.


### PR DESCRIPTION
Content Security Policies are supported by all major browsers while not all of X-Frame-Options is supported. For example, Chrome flat out ignores `ALLOW FROM` and just lets any site embed an iframe of the notebook (#6918).

This implements #6862, setting a default Content Security Policy and allowing for overrides in the same way that #6120 originally did for `X-Frame-Options`.
