### PR TITLE
API docs gardening

### DIFF
--- a/IPython/nbformat/__init__.py
+++ b/IPython/nbformat/__init__.py
@@ -13,6 +13,10 @@ from . import v2
 from . import v3
 from . import v4
 
+__all__ = ['versions', 'validate', 'ValidationError', 'convert', 'from_dict',
+           'NotebookNode', 'current_nbformat', 'current_nbformat_minor',
+           'NBFormatError', 'NO_CONVERT', 'reads', 'read', 'writes', 'write']
+
 versions = {
     1: v1,
     2: v2,

--- a/IPython/nbformat/v3/__init__.py
+++ b/IPython/nbformat/v3/__init__.py
@@ -1,20 +1,16 @@
 """The main API for the v3 notebook format.
-
-Authors:
-
-* Brian Granger
 """
 
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2011  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+__all__ = ['NotebookNode', 'new_code_cell', 'new_text_cell', 'new_notebook',
+           'new_output', 'new_worksheet', 'new_metadata', 'new_author',
+           'new_heading_cell', 'nbformat', 'nbformat_minor', 'nbformat_schema',
+           'reads_json', 'writes_json', 'read_json', 'write_json',
+           'to_notebook_json', 'reads_py', 'writes_py', 'read_py', 'write_py',
+           'to_notebook_py', 'downgrade', 'upgrade', 'parse_filename'
+        ]
 
 import os
 
@@ -35,9 +31,6 @@ from .nbpy import to_notebook as to_notebook_py
 
 from .convert import downgrade, upgrade
 
-#-----------------------------------------------------------------------------
-# Code
-#-----------------------------------------------------------------------------
 
 def parse_filename(fname):
     """Parse a notebook filename.

--- a/IPython/nbformat/v4/__init__.py
+++ b/IPython/nbformat/v4/__init__.py
@@ -3,6 +3,10 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+__all__ = ['nbformat', 'nbformat_minor', 'nbformat_schema', 'new_code_cell',
+           'new_markdown_cell', 'new_notebook', 'new_output', 'output_from_msg',
+           'reads', 'writes', 'to_notebook', 'downgrade', 'upgrade']
+
 from .nbbase import (
     nbformat, nbformat_minor, nbformat_schema,
     new_code_cell, new_markdown_cell, new_notebook,

--- a/IPython/nbformat/v4/convert.py
+++ b/IPython/nbformat/v4/convert.py
@@ -73,7 +73,8 @@ def upgrade(nb, from_version=3, from_minor=0):
 def upgrade_cell(cell):
     """upgrade a cell from v3 to v4
 
-    heading cell -> markdown heading
+    heading cell:
+        - -> markdown heading
     code cell:
         - remove language metadata
         - cell.input -> cell.source

--- a/docs/autogen_api.py
+++ b/docs/autogen_api.py
@@ -21,8 +21,8 @@ if __name__ == '__main__':
                                         # Extensions are documented elsewhere.
                                         r'\.extensions',
                                         r'\.config\.profile',
-                                        # These should be accessed via nbformat.current
-                                        r'\.nbformat\.v\d+',
+                                        # Old nbformat versions
+                                        r'\.nbformat\.v[1-2]',
                                         # Public API for this is in kernel.zmq.eventloops
                                         r'\.kernel\.zmq\.gui',
                                         # Magics are documented separately
@@ -41,14 +41,21 @@ if __name__ == '__main__':
                                         r'\.core\.magics\.deprecated',
                                         # We document this manually.
                                         r'\.utils\.py3compat',
-                                        # These are exposed by nbformat.current
+                                        # These are exposed by nbformat
                                         r'\.nbformat\.convert',
                                         r'\.nbformat\.validator',
+                                        r'\.nbformat\.notebooknode',
+                                        # Deprecated
+                                        r'\.nbformat\.current',
+                                        # Exposed by nbformat.vN
+                                        r'\.nbformat\.v[3-4]\.nbbase',
                                         # These are exposed in display
                                         r'\.core\.display',
                                         r'\.lib\.display',
                                         # This isn't actually a module
                                         r'\.html\.tasks',
+                                        # This is private
+                                        r'\.html\.allow76'
                                         ]
 
     # These modules import functions and classes from other places to expose
@@ -56,7 +63,9 @@ if __name__ == '__main__':
     # non-API modules they import from should be excluded by the skip patterns
     # above.
     docwriter.names_from__all__.update({
-        'IPython.nbformat.current',
+        'IPython.nbformat',
+        'IPython.nbformat.v3',
+        'IPython.nbformat.v4',
         'IPython.display',
     })
     


### PR DESCRIPTION
- Don't document nbformat.current (deprecated)
- Do document nbformat.v3 and nbformat.v4 again, except for nbbase modules (which are exposed at package level)
- Use `__all__` to get names exposed from nbformat, nbformat.v3 and nbformat.v4 packages.
- Don't document `html.allow76`, as it's not public API.
