### PR TITLE
Update language info metadata in nbformat 4 schema

### DIFF
--- a/IPython/nbformat/v4/nbformat.v4.schema.json
+++ b/IPython/nbformat/v4/nbformat.v4.schema.json
@@ -10,24 +10,25 @@
             "type": "object",
             "additionalProperties": true,
             "properties": {
-                "kernel_info": {
+                "kernelspec": {
                     "description": "Kernel information.",
                     "type": "object",
-                    "required": ["name", "language"],
+                    "required": ["name", "display_name"],
                     "properties": {
                         "name": {
                             "description": "Name of the kernel specification.",
                             "type": "string"
                         },
-                        "language": {
-                            "description": "The programming language which this kernel runs.",
+                        "display_name": {
+                            "description": "Display name of the kernel specification.",
                             "type": "string"
                         },
-                        "codemirror_mode": {
-                            "description": "The codemirror mode to use for code in this language.",
-                            "type": "string"
-                        }
                     }
+                },
+                "language_info" : {
+                    "description": "Notebook programming language information."
+                    "type": "object",
+                    "additionalProperties": true
                 },
                 "signature": {
                     "description": "Hash of the notebook.",

--- a/IPython/nbformat/v4/nbformat.v4.schema.json
+++ b/IPython/nbformat/v4/nbformat.v4.schema.json
@@ -22,11 +22,11 @@
                         "display_name": {
                             "description": "Display name of the kernel specification.",
                             "type": "string"
-                        },
+                        }
                     }
                 },
                 "language_info" : {
-                    "description": "Notebook programming language information."
+                    "description": "Notebook programming language information.",
                     "type": "object",
                     "additionalProperties": true
                 },


### PR DESCRIPTION
I hadn't realised this was encoded in the schema, so I hadn't updated it when changing what we put in metadata.
