### PR TITLE
add '?v=<date>' to require URLs

### DIFF
--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -130,6 +130,11 @@ class IPythonHandler(AuthenticatedHandler):
     #---------------------------------------------------------------
     
     @property
+    def version_hash(self):
+        """The version hash to use for cache hints for static files"""
+        return self.settings.get('version_hash', '')
+    
+    @property
     def mathjax_url(self):
         return self.settings.get('mathjax_url', '')
     
@@ -240,6 +245,7 @@ class IPythonHandler(AuthenticatedHandler):
             static_url=self.static_url,
             sys_info=sys_info,
             contents_js_source=self.contents_js_source,
+            version_hash=self.version_hash,
         )
     
     def get_json_body(self):

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -320,7 +320,7 @@ class AuthenticatedFileHandler(IPythonHandler, web.StaticFileHandler):
     
     def set_headers(self):
         super(AuthenticatedFileHandler, self).set_headers()
-        # disable browser caching, rely in 304 replies for savings
+        # disable browser caching, rely on 304 replies for savings
         if "v" not in self.request.arguments:
             self.add_header("Cache-Control", "no-cache")
     
@@ -394,11 +394,14 @@ class FileFindHandler(web.StaticFileHandler):
     
     def set_headers(self):
         super(FileFindHandler, self).set_headers()
-        # disable browser caching, rely in 304 replies for savings
-        if "v" not in self.request.arguments:
+        # disable browser caching, rely on 304 replies for savings
+        if "v" not in self.request.arguments or \
+                any(self.request.path.startswith(path) for path in self.no_cache_paths):
             self.add_header("Cache-Control", "no-cache")
     
-    def initialize(self, path, default_filename=None):
+    def initialize(self, path, default_filename=None, no_cache_paths=None):
+        self.no_cache_paths = no_cache_paths or []
+        
         if isinstance(path, string_types):
             path = [path]
         

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -312,6 +312,12 @@ class AuthenticatedFileHandler(IPythonHandler, web.StaticFileHandler):
         
         return web.StaticFileHandler.get(self, path)
     
+    def set_headers(self):
+        super(AuthenticatedFileHandler, self).set_headers()
+        # disable browser caching, rely in 304 replies for savings
+        if "v" not in self.request.arguments:
+            self.add_header("Cache-Control", "no-cache")
+    
     def compute_etag(self):
         return None
     
@@ -379,6 +385,12 @@ class FileFindHandler(web.StaticFileHandler):
     
     # cache search results, don't search for files more than once
     _static_paths = {}
+    
+    def set_headers(self):
+        super(FileFindHandler, self).set_headers()
+        # disable browser caching, rely in 304 replies for savings
+        if "v" not in self.request.arguments:
+            self.add_header("Cache-Control", "no-cache")
     
     def initialize(self, path, default_filename=None):
         if isinstance(path, string_types):

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -7,6 +7,7 @@
 from __future__ import print_function
 
 import base64
+import datetime
 import errno
 import io
 import json
@@ -84,6 +85,7 @@ from IPython.utils.traitlets import (
 )
 from IPython.utils import py3compat
 from IPython.utils.path import filefind, get_ipython_dir
+from IPython.utils.sysinfo import get_sys_info
 
 from .utils import url_path_join
 
@@ -151,6 +153,15 @@ class NotebookWebApplication(web.Application):
 
         jenv_opt = jinja_env_options if jinja_env_options else {}
         env = Environment(loader=FileSystemLoader(template_path), **jenv_opt)
+        
+        sys_info = get_sys_info()
+        if sys_info['commit_source'] == 'repository':
+            # don't cache (rely on 304) when working from master
+            version_hash = ''
+        else:
+            # reset the cache on server restart
+            version_hash = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+
         settings = dict(
             # basics
             log_function=log_request,
@@ -160,6 +171,7 @@ class NotebookWebApplication(web.Application):
             static_path=ipython_app.static_file_path,
             static_handler_class = FileFindHandler,
             static_url_prefix = url_path_join(base_url,'/static/'),
+            version_hash=version_hash,
             
             # authentication
             cookie_secret=ipython_app.cookie_secret,

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -171,6 +171,10 @@ class NotebookWebApplication(web.Application):
             static_path=ipython_app.static_file_path,
             static_handler_class = FileFindHandler,
             static_url_prefix = url_path_join(base_url,'/static/'),
+            static_handler_args = {
+                # don't cache custom.js
+                'no_cache_paths': [url_path_join(base_url, 'static', 'custom')],
+            },
             version_hash=version_hash,
             
             # authentication
@@ -218,8 +222,12 @@ class NotebookWebApplication(web.Application):
         handlers.extend(load_handlers('services.sessions.handlers'))
         handlers.extend(load_handlers('services.nbconvert.handlers'))
         handlers.extend(load_handlers('services.kernelspecs.handlers'))
+        
         handlers.append(
-            (r"/nbextensions/(.*)", FileFindHandler, {'path' : settings['nbextensions_path']}),
+            (r"/nbextensions/(.*)", FileFindHandler, {
+                'path': settings['nbextensions_path'],
+                'no_cache_paths': ['/'], # don't cache anything in nbextensions
+            }),
         )
         # register base handlers last
         handlers.extend(load_handlers('base.handlers'))

--- a/IPython/html/templates/page.html
+++ b/IPython/html/templates/page.html
@@ -18,6 +18,9 @@
     <script src="{{static_url("components/requirejs/require.js") }}" type="text/javascript" charset="utf-8"></script>
     <script>
       require.config({
+          {% if version_hash %}
+          urlArgs: "v={{version_hash}}",
+          {% endif %}
           baseUrl: '{{static_url("", include_version=False)}}',
           paths: {
             nbextensions : '{{ base_url }}nbextensions',


### PR DESCRIPTION
- cache all `/static/` files (except custom) for the lifetime of the server under normal circumstances
- resets cache on server restart
- don't cache any static file requests running from master (rely on 304 for caching content)
- don't cache files in /static/custom
- don't cache files in /nbextensions

This is much simpler than either #6580 or #6577. I do think we should consider compiling js, as in #6580, but I am skeptical of our ability to get it right in time for 3.0. This, however, seems pretty straightforward.
