### PR TITLE
Load nbextensions from paths in frontend config

### DIFF
--- a/IPython/html/static/edit/js/main.js
+++ b/IPython/html/static/edit/js/main.js
@@ -7,6 +7,7 @@ require([
     'base/js/page',
     'base/js/events',
     'contents',
+    'services/config',
     'edit/js/editor',
     'edit/js/menubar',
     'edit/js/notificationarea',
@@ -17,6 +18,7 @@ require([
     page,
     events,
     contents,
+    configmod,
     editor,
     menubar,
     notificationarea
@@ -26,6 +28,8 @@ require([
     var base_url = utils.get_body_data('baseUrl');
     var file_path = utils.get_body_data('filePath');
     contents = new contents.Contents({base_url: base_url});
+    var config = new configmod.ConfigSection('edit', {base_url: base_url})
+    config.load();
     
     var editor = new editor.Editor('#texteditor-container', {
         base_url: base_url,
@@ -48,6 +52,13 @@ require([
     });
     notification_area.init_notification_widgets();
 
+    config.loaded.then(function() {
+        if (config.data.load_extensions) {
+            var nbextension_paths = Object.getOwnPropertyNames(
+                                        config.data.load_extensions);
+            IPython.load_extensions.apply(this, nbextension_paths);
+        }
+    });
     editor.load();
     page.show();
 });

--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -6,6 +6,7 @@ require([
     'jquery',
     'notebook/js/notebook',
     'contents',
+    'services/config',
     'base/js/utils',
     'base/js/page',
     'notebook/js/layoutmanager',
@@ -30,6 +31,7 @@ require([
     $,
     notebook, 
     contents,
+    configmod,
     utils, 
     page, 
     layoutmanager, 
@@ -79,6 +81,8 @@ require([
     var contents = new contents.Contents($.extend({
         events: events},
         common_options));
+    var config_section = new configmod.ConfigSection('notebook', common_options);
+    config_section.load();
     var notebook = new notebook.Notebook('div#notebook', $.extend({
         events: events,
         keyboard_manager: keyboard_manager,
@@ -158,6 +162,13 @@ require([
     IPython.tooltip = notebook.tooltip;
 
     events.trigger('app_initialized.NotebookApp');
+    config_section.loaded.then(function() {
+        if (config_section.data.load_extensions) {
+            var nbextension_paths = Object.getOwnPropertyNames(
+                                        config_section.data.load_extensions);
+            IPython.load_extensions.apply(this, nbextension_paths);
+        }
+    });
     notebook.load_notebook(common_options.notebook_path);
 
 });


### PR DESCRIPTION
So that instead of manually editing custom.js, extensions can be specified in declarative config:

```
~/.ipython/profile_default/nbconfig$ cat notebook.json 
{"load_extensions": {"cite2c/main": true}}
```

To come (probably in a separate PR): APIs to manipulate these config files from Python, so code installing an extension can easily enable it as well.

To come somewhat later: UI for listing and enabling/disabling extensions.
