### PR TITLE
ConfigManager class for frontend config

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -199,11 +199,12 @@ class BaseIPythonApplication(Application):
             return crashhandler.crash_handler_lite(etype, evalue, tb)
     
     def _ipython_dir_changed(self, name, old, new):
-        str_old = py3compat.cast_bytes_py2(os.path.abspath(old),
-            sys.getfilesystemencoding()
-        )
-        if str_old in sys.path:
-            sys.path.remove(str_old)
+        if old is not None:
+            str_old = py3compat.cast_bytes_py2(os.path.abspath(old),
+                sys.getfilesystemencoding()
+            )
+            if str_old in sys.path:
+                sys.path.remove(str_old)
         str_path = py3compat.cast_bytes_py2(os.path.abspath(new),
             sys.getfilesystemencoding()
         )

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -175,6 +175,10 @@ class IPythonHandler(AuthenticatedHandler):
     def kernel_spec_manager(self):
         return self.settings['kernel_spec_manager']
 
+    @property
+    def config_manager(self):
+        return self.settings['config_manager']
+
     #---------------------------------------------------------------
     # CORS
     #---------------------------------------------------------------

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -120,10 +120,6 @@ class IPythonHandler(AuthenticatedHandler):
             return Application.instance().log
         else:
             return app_log
-
-    @property
-    def profile_dir(self):
-        return self.settings.get('profile_dir', '')
     
     #---------------------------------------------------------------
     # URLs

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -183,7 +183,6 @@ class NotebookWebApplication(web.Application):
             config=ipython_app.config,
             jinja2_env=env,
             terminals_available=False,  # Set later if terminals are available
-            profile_dir = ipython_app.profile_dir.location,
         )
 
         # allow custom overrides for the tornado web app.

--- a/IPython/html/services/config/handlers.py
+++ b/IPython/html/services/config/handlers.py
@@ -11,85 +11,27 @@ from tornado import web
 from IPython.utils.py3compat import PY3
 from ...base.handlers import IPythonHandler, json_errors
 
-def recursive_update(target, new):
-    """Recursively update one dictionary using another.
-    
-    None values will delete their keys.
-    """
-    for k, v in new.items():
-        if isinstance(v, dict):
-            if k not in target:
-                target[k] = {}
-            recursive_update(target[k], v)
-            if not target[k]:
-                # Prune empty subdicts
-                del target[k]
-
-        elif v is None:
-            target.pop(k, None)
-
-        else:
-            target[k] = v
-
 class ConfigHandler(IPythonHandler):
     SUPPORTED_METHODS = ('GET', 'PUT', 'PATCH')
-
-    @property
-    def config_dir(self):
-        return os.path.join(self.profile_dir, 'nbconfig')
-
-    def ensure_config_dir_exists(self):
-        try:
-            os.mkdir(self.config_dir, 0o755)
-        except OSError as e:
-            if e.errno != errno.EEXIST:
-                raise
-
-    def file_name(self, section_name):
-        return os.path.join(self.config_dir, section_name+'.json')
 
     @web.authenticated
     @json_errors
     def get(self, section_name):
         self.set_header("Content-Type", 'application/json')
-        filename = self.file_name(section_name)
-        if os.path.isfile(filename):
-            with io.open(filename, encoding='utf-8') as f:
-                self.finish(f.read())
-        else:
-            self.finish("{}")
+        self.finish(json.dumps(self.config_manager.get(section_name)))
 
     @web.authenticated
     @json_errors
     def put(self, section_name):
-        self.get_json_body()  # Will raise 400 if content is not valid JSON
-        filename = self.file_name(section_name)
-        self.ensure_config_dir_exists()
-        with open(filename, 'wb') as f:
-            f.write(self.request.body)
+        data = self.get_json_body()  # Will raise 400 if content is not valid JSON
+        self.config_manager.set(section_name, data)
         self.set_status(204)
 
     @web.authenticated
     @json_errors
     def patch(self, section_name):
-        filename = self.file_name(section_name)
-        if os.path.isfile(filename):
-            with io.open(filename, encoding='utf-8') as f:
-                section = json.load(f)
-        else:
-            section = {}
-
-        update = self.get_json_body()
-        recursive_update(section, update)
-
-        self.ensure_config_dir_exists()
-        if PY3:
-            f = io.open(filename, 'w', encoding='utf-8')
-        else:
-            f = open(filename, 'wb')
-        with f:
-            json.dump(section, f)
-
+        new_data = self.get_json_body()
+        section = self.config_manager.update(section_name, new_data)
         self.finish(json.dumps(section))
 
 

--- a/IPython/html/services/config/manager.py
+++ b/IPython/html/services/config/manager.py
@@ -8,6 +8,7 @@ import json
 import os
 
 from IPython.config import LoggingConfigurable
+from IPython.utils.path import locate_profile
 from IPython.utils.py3compat import PY3
 from IPython.utils.traitlets import Unicode
 
@@ -35,6 +36,8 @@ def recursive_update(target, new):
 
 class ConfigManager(LoggingConfigurable):
     profile_dir = Unicode()
+    def _profile_dir_default(self):
+        return locate_profile()
 
     @property
     def config_dir(self):

--- a/IPython/html/services/config/manager.py
+++ b/IPython/html/services/config/manager.py
@@ -1,0 +1,87 @@
+"""Manager to read and modify frontend config data in JSON files.
+"""
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+import errno
+import io
+import json
+import os
+
+from IPython.config import LoggingConfigurable
+from IPython.utils.py3compat import PY3
+from IPython.utils.traitlets import Unicode
+
+
+def recursive_update(target, new):
+    """Recursively update one dictionary using another.
+
+    None values will delete their keys.
+    """
+    for k, v in new.items():
+        if isinstance(v, dict):
+            if k not in target:
+                target[k] = {}
+            recursive_update(target[k], v)
+            if not target[k]:
+                # Prune empty subdicts
+                del target[k]
+
+        elif v is None:
+            target.pop(k, None)
+
+        else:
+            target[k] = v
+
+
+class ConfigManager(LoggingConfigurable):
+    profile_dir = Unicode()
+
+    @property
+    def config_dir(self):
+        return os.path.join(self.profile_dir, 'nbconfig')
+
+    def ensure_config_dir_exists(self):
+        try:
+            os.mkdir(self.config_dir, 0o755)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+
+    def file_name(self, section_name):
+        return os.path.join(self.config_dir, section_name+'.json')
+
+    def get(self, section_name):
+        """Retrieve the config data for the specified section.
+
+        Returns the data as a dictionary, or an empty dictionary if the file
+        doesn't exist.
+        """
+        filename = self.file_name(section_name)
+        if os.path.isfile(filename):
+            with io.open(filename, encoding='utf-8') as f:
+                return json.load(f)
+        else:
+            return {}
+
+    def set(self, section_name, data):
+        """Store the given config data.
+        """
+        filename = self.file_name(section_name)
+        self.ensure_config_dir_exists()
+
+        if PY3:
+            f = io.open(filename, 'w', encoding='utf-8')
+        else:
+            f = open(filename, 'wb')
+        with f:
+            json.dump(data, f)
+
+    def update(self, section_name, new_data):
+        """Modify the config section by recursively updating it with new_data.
+
+        Returns the modified config data as a dictionary.
+        """
+        data = self.get(section_name)
+        recursive_update(data, new_data)
+        self.set(section_name, data)
+        return data

--- a/IPython/kernel/zmq/pylab/config.py
+++ b/IPython/kernel/zmq/pylab/config.py
@@ -13,6 +13,7 @@ This module does not import anything from matplotlib.
 # Imports
 #-----------------------------------------------------------------------------
 
+from IPython.config import Config
 from IPython.config.configurable import SingletonConfigurable
 from IPython.utils.traitlets import (
     Dict, Instance, CaselessStrEnum, Set, Bool, Int, TraitError, Unicode
@@ -42,7 +43,7 @@ class InlineBackend(InlineBackendConfig):
 
     def _config_changed(self, name, old, new):
         # warn on change of renamed config section
-        if new.InlineBackendConfig != old.InlineBackendConfig:
+        if new.InlineBackendConfig != getattr(old, 'InlineBackendConfig', Config()):
             warn("InlineBackendConfig has been renamed to InlineBackend")
         super(InlineBackend, self)._config_changed(name, old, new)
 

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -415,7 +415,11 @@ class TraitType(object):
 
     def __set__(self, obj, value):
         new_value = self._validate(obj, value)
-        old_value = self.__get__(obj)
+        try:
+            old_value = obj._trait_values[self.name]
+        except KeyError:
+            old_value = None
+
         obj._trait_values[self.name] = new_value
         try:
             silent = bool(old_value == new_value)


### PR DESCRIPTION
This separates out a ConfigManager class which the config handlers use.

My objective is to provide an API whereby Python code can modify frontend config, e.g. to enable an extension on installation. See also #7040.
