### PR TITLE
BUG: Prevent users from undoing the initial document load with CTRL-Z.

### DIFF
--- a/IPython/html/static/edit/js/editor.js
+++ b/IPython/html/static/edit/js/editor.js
@@ -35,7 +35,11 @@ function($,
         this.contents.get(this.file_path, {type: 'file', format: 'text'})
             .then(function(model) {
                 cm.setValue(model.content);
-                
+
+                // Setting the file's initial value creates a history entry,
+                // which we don't want.
+                cm.clearHistory();
+
                 // Find and load the highlighting mode
                 var modeinfo = CodeMirror.findModeByMIME(model.mimetype);
                 if (modeinfo) {


### PR DESCRIPTION
Prior to this change, setting a document's initial content in the text
editor created a history entry, which meant that hitting CTRL-Z
repeatedly could clear the entire document.  This change clears document
history after loading so that repeated CTRL-Z applications return the
document to its state at load time.

ping @takluyver 
