### PR TITLE
Only force gnureadline in setup.py with bdist_wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -289,7 +289,7 @@ install_requires = []
 
 # add readline
 if sys.platform == 'darwin':
-    if not setupext.check_for_readline():
+    if 'bdist_wheel' in sys.argv[1:] or not setupext.check_for_readline():
         install_requires.append('gnureadline')
 elif sys.platform.startswith('win'):
     extras_require['terminal'].append('pyreadline>=2.0')

--- a/setup.py
+++ b/setup.py
@@ -289,7 +289,7 @@ install_requires = []
 
 # add readline
 if sys.platform == 'darwin':
-    if any(arg.startswith('bdist') for arg in sys.argv) or not setupext.check_for_readline():
+    if not setupext.check_for_readline():
         install_requires.append('gnureadline')
 elif sys.platform.startswith('win'):
     extras_require['terminal'].append('pyreadline>=2.0')


### PR DESCRIPTION
The asymmetry (inconsistency) of unconditionally adding `gnureadline` as a dependency of binary (but not source) distributions in `setup.py` can cause issues like reported at paylogic/pip-accel/issues/34. Would you be willing to accept this pull request to remove the asymmetry? For reference, it seems that this was introduced in ba0cd52c with the following comment:

> adjust dependency check for gnureadline on OS X
> - always depend when making a bdist (for consistency)
> - otherwise only depend if missing (e.g. pip install -e)

I guess it's kind of ironic that the original reasoning was consistency and now I'm calling this inconsistent :-). I'm interested to hear whether you agree about the asymmetry though. If you need more context about why I want to fix the asymmetry please refer to paylogic/pip-accel/issues/34, I'm posting a detailed explanation there.
