### PR TITLE
Fixed the code mirror skipping Markdown cell bug

### DIFF
--- a/IPython/html/static/notebook/js/Untitled.ipynb
+++ b/IPython/html/static/notebook/js/Untitled.ipynb
@@ -1,0 +1,8 @@
+{
+ "cells": [],
+ "metadata": {
+  "signature": "sha256:e0b936bf1aba7d341bf3aaf2190cbb1372b3e8eefae31828e02b61ac479adc2c"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/IPython/html/static/notebook/js/Untitled.ipynb
+++ b/IPython/html/static/notebook/js/Untitled.ipynb
@@ -1,8 +1,0 @@
-{
- "cells": [],
- "metadata": {
-  "signature": "sha256:e0b936bf1aba7d341bf3aaf2190cbb1372b3e8eefae31828e02b61ac479adc2c"
- },
- "nbformat": 4,
- "nbformat_minor": 0
-}

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -227,9 +227,6 @@ define([
      *  @method handle_codemirror_keyevent
      */
 
-     /* Correction here */
-
-
     CodeCell.prototype.handle_codemirror_keyevent = function (editor, event) {
 
         var that = this;

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -226,6 +226,10 @@ define([
      *  true = ignore, false = don't ignore.
      *  @method handle_codemirror_keyevent
      */
+
+     /* Correction here */
+
+
     CodeCell.prototype.handle_codemirror_keyevent = function (editor, event) {
 
         var that = this;

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -41,10 +41,7 @@ define([
         this.config = options.config;
         
         // we cannot put this as a class key as it has handle to "this".
-        var cm_overwrite_options  = {
-            onKeyEvent: $.proxy(this.handle_keyevent,this)
-        };
-        var config = utils.mergeopt(TextCell, this.config, {cm_config:cm_overwrite_options});
+        var config = utils.mergeopt(TextCell, this.config);
         Cell.apply(this, [{
                     config: config, 
                     keyboard_manager: options.keyboard_manager, 
@@ -86,6 +83,7 @@ define([
         inner_cell.append(this.celltoolbar.element);
         var input_area = $('<div/>').addClass('input_area');
         this.code_mirror = new CodeMirror(input_area.get(0), this.cm_config);
+        this.code_mirror.on('keydown', $.proxy(this.handle_keyevent,this))
         // The tabindex=-1 makes this div focusable.
         var render_area = $('<div/>').addClass('text_cell_render rendered_html')
             .attr('tabindex','-1');


### PR DESCRIPTION
Code mirror bug fixed by copying the same code used in textcell.js in "onKeyDown"
