### PR TITLE
Add a notebook option to keep non-ASCII characters

### DIFF
--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -500,6 +500,13 @@ class NotebookApp(BaseIPythonApplication):
     jinja_environment_options = Dict(config=True, 
             help="Supply extra arguments that will be passed to Jinja environment.")
 
+    ensure_ascii = Bool(True, config=True,
+        help="""Whether the output file only contains ASCII characters.
+        If ensure_ascii is True (the default), all non-ASCII characters
+        in the output are escaped with \\uXXXX sequences. If ensure_ascii
+        is False, these characters are represented using UTF-8.
+        """
+    )
     
     enable_mathjax = Bool(True, config=True,
         help="""Whether to enable MathJax for typesetting math/TeX

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -501,14 +501,6 @@ class NotebookApp(BaseIPythonApplication):
             help="Supply extra arguments that will be passed to Jinja environment.")
 
     
-    ensure_ascii = Bool(True, config=True,
-        help="""Whether the output file only contains ASCII characters.
-        If ensure_ascii is True (the default), all non-ASCII characters
-        in the output are escaped with \\uXXXX sequences. If ensure_ascii
-        is False, these characters are represented using UTF-8.
-        """
-    )
-    
     enable_mathjax = Bool(True, config=True,
         help="""Whether to enable MathJax for typesetting math/TeX
 

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -500,13 +500,6 @@ class NotebookApp(BaseIPythonApplication):
     jinja_environment_options = Dict(config=True, 
             help="Supply extra arguments that will be passed to Jinja environment.")
 
-    ensure_ascii = Bool(True, config=True,
-        help="""Whether the output file only contains ASCII characters.
-        If ensure_ascii is True (the default), all non-ASCII characters
-        in the output are escaped with \\uXXXX sequences. If ensure_ascii
-        is False, these characters are represented using UTF-8.
-        """
-    )
     
     enable_mathjax = Bool(True, config=True,
         help="""Whether to enable MathJax for typesetting math/TeX

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -501,6 +501,14 @@ class NotebookApp(BaseIPythonApplication):
             help="Supply extra arguments that will be passed to Jinja environment.")
 
     
+    ensure_ascii = Bool(True, config=True,
+        help="""Whether the output file only contains ASCII characters.
+        If ensure_ascii is True (the default), all non-ASCII characters
+        in the output are escaped with \\uXXXX sequences. If ensure_ascii
+        is False, these characters are represented using UTF-8.
+        """
+    )
+    
     enable_mathjax = Bool(True, config=True,
         help="""Whether to enable MathJax for typesetting math/TeX
 

--- a/IPython/nbformat/v4/nbjson.py
+++ b/IPython/nbformat/v4/nbjson.py
@@ -12,6 +12,7 @@ from .nbbase import from_dict
 from .rwbase import (
     NotebookReader, NotebookWriter, rejoin_lines, split_lines, strip_transient
 )
+from IPython.utils.traitlets import Bool
 
 
 class BytesEncoder(json.JSONEncoder):
@@ -42,6 +43,14 @@ class JSONReader(NotebookReader):
 
 
 class JSONWriter(NotebookWriter):
+
+    ensure_ascii = Bool(True, config=True,
+        help="""Whether the output file only contains ASCII characters.
+        If ensure_ascii is True (the default), all non-ASCII characters
+        in the output are escaped with \\uXXXX sequences. If ensure_ascii
+        is False, these characters are represented using UTF-8.
+        """
+    )
 
     def writes(self, nb, **kwargs):
         """Serialize a NotebookNode object as a JSON string"""

--- a/IPython/nbformat/v4/nbjson.py
+++ b/IPython/nbformat/v4/nbjson.py
@@ -49,6 +49,7 @@ class JSONWriter(NotebookWriter):
         kwargs['indent'] = 1
         kwargs['sort_keys'] = True
         kwargs['separators'] = (',',': ')
+        kwargs['ensure_ascii'] = self.ensure_ascii
         # don't modify in-memory dict
         nb = copy.deepcopy(nb)
         if kwargs.pop('split_lines', True):

--- a/IPython/nbformat/v4/rwbase.py
+++ b/IPython/nbformat/v4/rwbase.py
@@ -82,7 +82,7 @@ class NotebookReader(object):
         return self.reads(nbs, **kwargs)
 
 
-class NotebookWriter(object):
+class NotebookWriter(IPython.config.Configurable):
     """A class for writing notebooks."""
 
     def writes(self, nb, **kwargs):

--- a/IPython/nbformat/v4/rwbase.py
+++ b/IPython/nbformat/v4/rwbase.py
@@ -4,7 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from IPython.utils.py3compat import string_types, cast_unicode_py2
-
+import IPython.config
 
 def rejoin_lines(nb):
     """rejoin multiline text into strings


### PR DESCRIPTION
Following [this discussion on Stack Overflow](http://stackoverflow.com/questions/27186073/change-ipython-notebook-json-file-encoding) I tried to inject the ensure_ascii option of json.dump into the notebook options. Not sure if this makes the trick. This is my first pull request on GitHub, please be kind if I've done anything wrong. :-)
