### PR TITLE
close pager on escape on command mode

### DIFF
--- a/IPython/html/static/notebook/js/keyboardmanager.js
+++ b/IPython/html/static/notebook/js/keyboardmanager.js
@@ -97,6 +97,7 @@ define([
             'i,i' : 'ipython.interrupt-kernel',
             '0,0' : 'ipython.restart-kernel',
             'd,d' : 'ipython.delete-cell',
+            'esc': 'ipython.close-pager',
             'up' : 'ipython.select-previous-cell',
             'k' : 'ipython.select-previous-cell',
             'j' : 'ipython.select-next-cell',


### PR DESCRIPTION
Requested from @maxalbert  during sprint.

Seem like a sensible default.
