### PR TITLE
Pin the version of less used in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install -y -q \
     npm
 
 # In order to build from source, need less
-RUN npm install -g less
+RUN npm install -g less@1.7.5
 
 RUN pip install invoke
 

--- a/IPython/html/tasks.py
+++ b/IPython/html/tasks.py
@@ -67,9 +67,9 @@ def _compile_less(source, target, sourcemap, minify=True, verbose=False):
     out = out.decode('utf8', 'replace')
     less_version = out.split()[1]
     if V(less_version) < V(min_less_version):
-        raise ValueError("lessc too old: %s < %s. Use `$ npm install lesscss@X.Y.Z` to install a specific version of less" % (less_version, min_less_version))
+        raise ValueError("lessc too old: %s < %s. Use `$ npm install less@X.Y.Z` to install a specific version of less" % (less_version, min_less_version))
     if V(less_version) >= V(max_less_version):
-        raise ValueError("lessc too new: %s >= %s. Use `$ npm install lesscss@X.Y.Z` to install a specific version of less" % (less_version, max_less_version))
+        raise ValueError("lessc too new: %s >= %s. Use `$ npm install less@X.Y.Z` to install a specific version of less" % (less_version, max_less_version))
     
     static_path = pjoin(here, static_dir)
     cwd = os.getcwd()


### PR DESCRIPTION
Until #7007 is merged/decided upon, this is necessary for our Docker builds. Otherwise we get a warning about being on the latest and greatest version of `less`.:

``` python-traceback
  Running setup.py install for ipython
    Traceback (most recent call last):
      File "/usr/local/bin/invoke", line 9, in <module>
        load_entry_point('invoke==0.9.0', 'console_scripts', 'invoke')()
      File "/usr/local/lib/python2.7/dist-packages/invoke/cli.py", line 304, in main
        dispatch(sys.argv)
      File "/usr/local/lib/python2.7/dist-packages/invoke/cli.py", line 297, in dispatch
        return executor.execute(*tasks, dedupe=dedupe)
      File "/usr/local/lib/python2.7/dist-packages/invoke/executor.py", line 90, in execute
        task=task, name=name, args=args, kwargs=kwargs
      File "/usr/local/lib/python2.7/dist-packages/invoke/executor.py", line 131, in _execute
        result = task(*args, **kwargs)
      File "/usr/local/lib/python2.7/dist-packages/invoke/tasks.py", line 111, in __call__
        result = self.body(*args, **kwargs)
      File "/tmp/pip_build_root/ipython/IPython/html/tasks.py", line 54, in css
        _compile_less(source, target, sourcemap, minify, verbose)
      File "/tmp/pip_build_root/ipython/IPython/html/tasks.py", line 72, in _compile_less
        raise ValueError("lessc too new: %s >= %s. Use `$ npm install lesscss@X.Y.Z` to install a specific version of less" % (less_version, max_less_version))
    ValueError: lessc too new: 2.0.0 >= 1.8.0. Use `$ npm install lesscss@X.Y.Z` to install a specific version of less
    Failed to build css sourcemaps: Command '['invoke', 'css', '--minify']' returned non-zero exit status 1
```

Also as part of this, I updated the help command to reflect the current name of the package on npm. It's `less`, not `lesscss`.
