### PR TITLE
make deprecation more explicit

### DIFF
--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -17,6 +17,7 @@ from IPython.utils import py3compat
 from IPython.utils.encoding import DEFAULT_ENCODING
 from IPython.utils.py3compat import unicode_type, iteritems
 from IPython.utils.traitlets import HasTraits, List, Any
+from IPython.utils import deprecate
 
 #-----------------------------------------------------------------------------
 # Exceptions
@@ -173,7 +174,8 @@ class Config(dict):
                     and isinstance(obj, dict) \
                     and not isinstance(obj, Config):
                 setattr(self, key, Config(obj))
-    
+
+    @deprecate.on_call((4,0,0))
     def _merge(self, other):
         """deprecated alias, use Config.merge()"""
         self.merge(other)
@@ -205,7 +207,8 @@ class Config(dict):
         return super(Config, self).__contains__(key)
     
     # .has_key is deprecated for dictionaries.
-    has_key = __contains__
+    with deprecate.with_deprecate('2.7'):
+        has_key = __contains__
     
     def _has_section(self, key):
         return _is_section_key(key) and key in self

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -37,6 +37,8 @@ from IPython.utils import coloransi, io, py3compat
 from IPython.core.excolors import exception_colors
 from IPython.testing.skipdoctest import skip_doctest
 
+from IPython.utils import deprecate
+
 # See if we can use pydb.
 has_pydb = False
 prompt = 'ipdb> '
@@ -73,7 +75,8 @@ def BdbQuit_excepthook(et, ev, tb, excepthook=None):
         excepthook(et, ev, tb)
     else:
         # Backwards compatibility. Raise deprecation warning?
-        BdbQuit_excepthook.excepthook_ori(et,ev,tb)
+        with deprecate.with_deprecate((4,0,0)):
+            BdbQuit_excepthook.excepthook_ori(et,ev,tb)
 
 def BdbQuit_IPython_excepthook(self,et,ev,tb,tb_offset=None):
     print('Exiting Debugger.')

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -76,6 +76,9 @@ from IPython.utils.traitlets import (Integer, CBool, CaselessStrEnum, Enum,
 from IPython.utils.warn import warn, error
 import IPython.core.hooks
 
+from IPython.utils.deprecate import with_deprecate, dec_deprecated, WithClass
+from IPython.utils import deprecate
+
 #-----------------------------------------------------------------------------
 # Globals
 #-----------------------------------------------------------------------------
@@ -116,7 +119,6 @@ class SpaceInInput(Exception): pass
 
 @undoc
 class Bunch: pass
-
 
 def get_default_colors():
     if sys.platform=='darwin':
@@ -335,16 +337,19 @@ class InteractiveShell(SingletonConfigurable):
     )
 
     # deprecated prompt traits:
-    
-    prompt_in1 = Unicode('In [\\#]: ', config=True,
-        help="Deprecated, use PromptManager.in_template")
-    prompt_in2 = Unicode('   .\\D.: ', config=True,
-        help="Deprecated, use PromptManager.in2_template")
-    prompt_out = Unicode('Out[\\#]: ', config=True,
-        help="Deprecated, use PromptManager.out_template")
-    prompts_pad_left = CBool(True, config=True,
-        help="Deprecated, use PromptManager.justify")
-    
+
+    with WithClass((4,0,0), nocompat=False):
+     
+        prompt_in1 = Unicode('In [\\#]: ', config=True,
+            help="Deprecated, use PromptManager.in_template")
+        prompt_in2 = Unicode('   .\\D.: ', config=True,
+            help="Deprecated, use PromptManager.in2_template")
+        prompt_out = Unicode('Out[\\#]: ', config=True,
+            help="Deprecated, use PromptManager.out_template")
+        prompts_pad_left = CBool(True, config=True,
+            help="Deprecated, use PromptManager.justify")
+
+    #@dec_deprecated((3,0,0))
     def _prompt_trait_changed(self, name, old, new):
         table = {
             'prompt_in1' : 'in_template',
@@ -875,6 +880,7 @@ class InteractiveShell(SingletonConfigurable):
 
         self.events.register("pre_execute", self._clear_warning_registry)
 
+    @dec_deprecated((4,0,0)) 
     def register_post_execute(self, func):
         """DEPRECATED: Use ip.events.register('post_run_cell', func)
         

--- a/IPython/utils/deprecate.py
+++ b/IPython/utils/deprecate.py
@@ -1,0 +1,138 @@
+# encoding: utf-8
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2008-2011  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# from  IPython import version_info
+from contextlib import contextmanager
+version_info = (3,0,0)
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------
+
+
+# the goal here is to provide a set of deprecatoin utils 
+# that help in 
+# 1) warning the user/dev
+# 2) be explicit in when what will be dropped. 
+# 3) help getting rid of the deprecated code once reached the 
+#   targetted version. 
+#
+# To do so: 
+# 
+# The module/class should provide a global flag that warn or raise as soon as a depercated feature is **used**.
+# 
+# Each decorator/context manager/... should take a specific version as input to ensure above behavior and raise
+# if project behavior go above this point at compile time. (potetially being able to disble this)
+# Decorators/with 
+#
+#
+#
+# Ok so stages matrix are :
+#
+#
+# no decorator, notn deprecated.
+#
+# decorator with version V limit/
+#       X <  V (deprecation stage)
+#       X => V (deprecated  stage)  
+
+# deprecation stage:
+#       (lambda_user: nothing)
+#       lib_user: -warning
+#                 -raise on use if flag
+#
+# deprecated stage:
+#       raise as early as possible.
+
+
+
+class DeprecationSingleton(object):
+    pass
+    
+    _sing = None
+
+    @classmethod
+    def instance():
+        if not _sing:
+            _sig = DeprecationSingleton()
+        return _sing
+
+import os
+nocompat = os.environ.get('NO_COMPAT',False)
+more_time_please = os.environ.get('MORE_TIME_PLEASE',False)
+
+features = {'2.7', '3.x'}
+def should_cleanup(version):
+    if (version_info >= version) and not more_time_please:
+        raise DeprecationWarning('Deprecated feature, you can remove some code')
+
+
+def _comp(value):
+    if type(value) is tuple:
+        return version_info >= value 
+    elif type(value) is str:
+        return (value not in features)
+
+
+@contextmanager
+def with_deprecate(version):
+    if _comp(version):
+        raise DeprecationWarning('Deprecated feature')
+    yield
+
+
+class WithClass( object ):
+    def __init__( self, version, nocompat=True):
+        self.version = version
+        self._noc = nocompat
+        should_cleanup(version)
+
+
+    def __enter__( self ):
+        if _comp(self.version) or (nocompat and self._noc):
+            raise DeprecationWarning('You shoudl not use that')
+
+    def __exit__( self, type, value, tb ):
+        pass
+
+
+def dec_deprecated(version):
+
+    def _dec(func):
+        if _comp(version):
+            #raise DeprecationWarning('Deprecated feature')
+            def _raise(*args,**kwargs):
+                print("I raise an exeption")
+                #raise DeprecationWarning('Deprecated feature')
+                return func(*args, **kwargs)
+            print('should raise on call')
+            return _raise
+        else :
+            print('should return function as is')
+            return func
+    return _dec
+
+
+## this is a decorator that shoud do ...
+def on_call(version):
+    should_cleanup(version)
+    def _dec(func):
+        if True:
+            def _raise(*args,**kwargs):
+                if _comp(version) or nocompat:
+                    raise DeprecationWarning('This is a deprecated feature, it will eb removed after %s ' % str(version))
+                else:
+                    return func(*args,**kwargs)
+            return _raise
+        else :
+            return func
+    return _dec

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -21,6 +21,7 @@ from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.process import system
 from IPython.utils.importstring import import_item
 from IPython.utils import py3compat
+from IPython.utils import deprecate
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
@@ -269,10 +270,11 @@ def get_ipython_dir():
     home_dir = get_home_dir()
     xdg_dir = get_xdg_dir()
     
-    # import pdb; pdb.set_trace()  # dbg
-    if 'IPYTHON_DIR' in env:
-        warn('The environment variable IPYTHON_DIR is deprecated. '
-                'Please use IPYTHONDIR instead.')
+    with deprecate.WithClass((4,0,0), nocompat=False):
+        # import pdb; pdb.set_trace()  # dbg
+        if 'IPYTHON_DIR' in env:
+            warn('The environment variable IPYTHON_DIR is deprecated. '
+                    'Please use IPYTHONDIR instead.')
     ipdir = env.get('IPYTHONDIR', env.get('IPYTHON_DIR', None))
     if ipdir is None:
         # not set explicitly, use ~/.ipython


### PR DESCRIPTION
Just playing around a with decorator to mark deprecated feature and have an option that woudl actually make them Warn or raise if used : 

```
In [3]: ip = get_ipython();ip.config._merge({'z':3})

In [4]: from IPython.utils import deprecate; deprecate.nocompat=True

In [5]: ip = get_ipython();ip.config._merge({'z':3})
---------------------------------------------------------------------------
DeprecationWarning                        Traceback (most recent call last)
<ipython-input-5-4b0aa8f46ac3> in <module>()
----> 1 ip = get_ipython();ip.config._merge({'z':3})

/usr/local/lib/python3.4/site-packages/IPython/utils/deprecate.py in _raise(*args, **kwargs)
    130             def _raise(*args,**kwargs):
    131                 if _comp(version) or nocompat:
--> 132                     raise DeprecationWarning('This is a deprecated feature, it will eb removed after %s ' % str(version))
    133                 else:
    134                     return func(*args,**kwargs)

DeprecationWarning: This is a deprecated feature, it will eb removed after (4, 0, 0)
```

Also once we bump IPython version above the limit for the deprecation. The thing will raise even earlier to remind us that there is something to clean up. 

From a discussion with @ogrisel yesterday in the train. And about the fact that numpy turn their deprecation warning as real error during testing to ensure they don't usetheir own deprecated apis.
