### PR TITLE
Rework get_kernel_path logic

### DIFF
--- a/IPython/html/services/contents/clientsidenbmanager.py
+++ b/IPython/html/services/contents/clientsidenbmanager.py
@@ -21,13 +21,3 @@ class ClientSideContentsManager(ContentsManager):
 
     def file_exists(self, name, path=''):
         return True
-
-    def get_kernel_path(self, path, model=None):
-         """Return the API path for the kernel
-         
-         KernelManagers can turn this value into a filesystem path,
-         or ignore it altogether.
-         
-         Here just always return home directory
-         """
-         return '/'

--- a/IPython/html/services/contents/clientsidenbmanager.py
+++ b/IPython/html/services/contents/clientsidenbmanager.py
@@ -5,6 +5,8 @@
 
 from .manager import ContentsManager
 
+import os.path
+
 class ClientSideContentsManager(ContentsManager):
     """Dummy contents manager for use with client-side contents APIs like GDrive
 
@@ -21,3 +23,10 @@ class ClientSideContentsManager(ContentsManager):
 
     def file_exists(self, name, path=''):
         return True
+
+    def get_kernel_path(self, path, model=None):
+         """Return the initial working dir a kernel associated with a given notebook
+         
+         Here just alway return home directory
+         """
+         return os.path.expanduser('~')

--- a/IPython/html/services/contents/clientsidenbmanager.py
+++ b/IPython/html/services/contents/clientsidenbmanager.py
@@ -5,8 +5,6 @@
 
 from .manager import ContentsManager
 
-import os.path
-
 class ClientSideContentsManager(ContentsManager):
     """Dummy contents manager for use with client-side contents APIs like GDrive
 
@@ -25,8 +23,11 @@ class ClientSideContentsManager(ContentsManager):
         return True
 
     def get_kernel_path(self, path, model=None):
-         """Return the initial working dir a kernel associated with a given notebook
+         """Return the API path for the kernel
          
-         Here just alway return home directory
+         KernelManagers can turn this value into a filesystem path,
+         or ignore it altogether.
+         
+         Here just always return home directory
          """
-         return os.path.expanduser('~')
+         return '/'

--- a/IPython/html/services/contents/filemanager.py
+++ b/IPython/html/services/contents/filemanager.py
@@ -606,9 +606,9 @@ class FileContentsManager(ContentsManager):
         return "Serving notebooks from local directory: %s" % self.root_dir
 
     def get_kernel_path(self, path, model=None):
-        """Return the initial working dir a kernel associated with a given notebook"""
+        """Return the initial API path of  a kernel associated with a given notebook"""
         if '/' in path:
             parent_dir = path.rsplit('/', 1)[0]
         else:
             parent_dir = ''
-        return self._get_os_path(parent_dir)
+        return parent_dir

--- a/IPython/html/services/contents/manager.py
+++ b/IPython/html/services/contents/manager.py
@@ -187,8 +187,12 @@ class ContentsManager(LoggingConfigurable):
         
         KernelManagers can turn this value into a filesystem path,
         or ignore it altogether.
+
+        The default value here will start kernels in the directory of the
+        notebook server. FileContentsManager overrides this to use the
+        directory containing the notebook.
         """
-        return path
+        return ''
 
     def increment_filename(self, filename, path='', insert=''):
         """Increment a filename until it is unique.

--- a/IPython/html/services/kernels/kernelmanager.py
+++ b/IPython/html/services/kernels/kernelmanager.py
@@ -54,14 +54,10 @@ class MappingKernelManager(MultiKernelManager):
 
     def cwd_for_path(self, path):
         """Turn API path into absolute OS path."""
-        # short circuit for NotebookManagers that pass in absolute paths
-        if os.path.exists(path):
-            return path
-
         os_path = to_os_path(path, self.root_dir)
         # in the case of notebooks and kernels not being on the same filesystem,
         # walk up to root_dir if the paths don't exist
-        while not os.path.exists(os_path) and os_path != self.root_dir:
+        while not os.path.isdir(os_path) and os_path != self.root_dir:
             os_path = os.path.dirname(os_path)
         return os_path
 


### PR DESCRIPTION
The contents manager is responsible for providing an API path where kernels can start. The base implementation always gives the empty string, causing kernels to be launched in the same directory as the server. FileContentsManager gives the API path to the directory containing the notebook, since it knows that that corresponds to a real filesystem path.

The contents manager no longer has the option of supplying an absolute filesystem path, since distinguishing between an API path and a filesystem path is not reliable. The kernel manager is responsible for turning the API path into a filesystem path, or ignoring it altogether.

Supersedes #6999.
