### PR TITLE
Fix incompatibility with the python-future package

### DIFF
--- a/IPython/kernel/zmq/parentpoller.py
+++ b/IPython/kernel/zmq/parentpoller.py
@@ -7,9 +7,9 @@ import os
 import platform
 import time
 try:
-    from _thread import interrupt_main  # Py 3
-except ImportError:
     from thread import interrupt_main  # Py 2
+except ImportError:
+    from _thread import interrupt_main  # Py 3
 from threading import Thread
 
 from IPython.utils.warn import warn


### PR DESCRIPTION
The python-future ( http://python-future.org/ )  package provides a dummy version the _thread module for python2. This causes the dummy library to be loaded instead. The effect is that for example the 'Interrupt' button in ipython notebook doesn't work.

This fix ensures that we try to import the python 2 code first, thus preventing the _thread module from being imported when the future package is installed.
