### PR TITLE
Wait for any promises returned by a view's render method before considering the view created

### DIFF
--- a/IPython/html/static/widgets/js/manager.js
+++ b/IPython/html/static/widgets/js/manager.js
@@ -101,8 +101,7 @@ define([
                 var parameters = {model: model, options: options};
                 var view = new ViewType(parameters);
                 view.listenTo(model, 'destroy', view.remove);
-                view.render();
-                return view;
+                return Promise.resolve(view.render()).then(function() {return view;});
             }).catch(utils.reject("Couldn't create a view for model id '" + String(model.id) + "'", true));
         });
         return model.state_change;


### PR DESCRIPTION
This lets a view wait on children views to be created before considering itself created.

Thanks to @ssunkara for catching this.

@jdfreder - can you look at this simple change?
