### PR TITLE
Warn about .py/.json collisions in config

### DIFF
--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -6,6 +6,7 @@
 
 from __future__ import print_function
 
+import json
 import logging
 import os
 import re
@@ -535,8 +536,17 @@ class Application(SingletonConfigurable):
     def load_config_file(self, filename, path=None):
         """Load config files by filename and path."""
         filename, ext = os.path.splitext(filename)
+        loaded = []
         for config in self._load_config_files(filename, path=path, log=self.log):
+            loaded.append(config)
             self.update_config(config)
+        if len(loaded) > 1:
+            collisions = loaded[0].collisions(loaded[1])
+            if collisions:
+                self.log.warn("Collisions detected in {0}.py and {0}.json config files."
+                              " {0}.json has higher priority: {1}".format(
+                              filename, json.dumps(collisions, indent=2),
+                ))
 
 
     def generate_config_file(self):

--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -193,7 +193,27 @@ class Config(dict):
                     to_update[k] = copy.deepcopy(v)
 
         self.update(to_update)
-
+    
+    def collisions(self, other):
+        """Check for collisions between two config objects.
+        
+        Returns a dict of the form {"Class": {"trait": "collision message"}}`,
+        indicating which values have been ignored.
+        
+        An empty dict indicates no collisions.
+        """
+        collisions = {}
+        for section in self:
+            if section not in other:
+                continue
+            mine = self[section]
+            theirs = other[section]
+            for key in mine:
+                if key in theirs and mine[key] != theirs[key]:
+                    collisions.setdefault(section, {})
+                    collisions[section][key] = "%r ignored, using %r" % (mine[key], theirs[key])
+        return collisions
+    
     def __contains__(self, key):
         # allow nested contains of the form `"Section.key" in config`
         if '.' in key:
@@ -565,7 +585,7 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
 
 
     def _decode_argv(self, argv, enc=None):
-        """decode argv if bytes, using stin.encoding, falling back on default enc"""
+        """decode argv if bytes, using stdin.encoding, falling back on default enc"""
         uargv = []
         if enc is None:
             enc = DEFAULT_ENCODING


### PR DESCRIPTION
when two versions of the config file set the same value, warn about clobbering, with a message, such as:

```
[TerminalIPythonApp] WARNING | Collisions detected in ipython_config.py and ipython_config.json config files. ipython_config.json has higher priority: {
  "Klass": {
    "trait": "'python' ignored, using 'json'"
  }
}
```

In anticipation of more machine-written .json config
