### PR TITLE
Add support for notebook server extensions

### DIFF
--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 import base64
 import datetime
 import errno
+import importlib
 import io
 import json
 import logging
@@ -709,6 +710,10 @@ class NotebookApp(BaseIPythonApplication):
         self.config.FileContentsManager.root_dir = new
         self.config.MappingKernelManager.root_dir = new
 
+    extensions = List(Unicode(), config=True,
+        help="Python modules to load as notebook server extensions"
+    )
+
     def parse_command_line(self, argv=None):
         super(NotebookApp, self).parse_command_line(argv)
         
@@ -915,6 +920,22 @@ class NotebookApp(BaseIPythonApplication):
         elif status == 'unclean':
             self.log.warn("components submodule unclean, you may see 404s on static/components")
             self.log.warn("run `setup.py submodule` or `git submodule update` to update")
+
+    def init_extensions(self):
+        """Load any extensions specified by config.
+
+        Import the module, then call the load_jupyter_server_extension function,
+        if one exists.
+        """
+        for modulename in self.extensions:
+            try:
+                mod = importlib.import_module(modulename)
+                func = getattr(mod, 'load_jupyter_server_extension', None)
+                if func is not None:
+                    func(self)
+            except Exception:
+                self.log.warn("Error loading server extension %s", modulename,
+                              exc_info=True)
     
     @catch_config_error
     def initialize(self, argv=None):
@@ -926,6 +947,7 @@ class NotebookApp(BaseIPythonApplication):
         self.init_webapp()
         self.init_terminals()
         self.init_signal()
+        self.init_extensions()
 
     def cleanup_kernels(self):
         """Shutdown all kernels.

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -710,7 +710,7 @@ class NotebookApp(BaseIPythonApplication):
         self.config.FileContentsManager.root_dir = new
         self.config.MappingKernelManager.root_dir = new
 
-    extensions = List(Unicode(), config=True,
+    server_extensions = List(Unicode(), config=True,
         help="Python modules to load as notebook server extensions"
     )
 
@@ -921,13 +921,13 @@ class NotebookApp(BaseIPythonApplication):
             self.log.warn("components submodule unclean, you may see 404s on static/components")
             self.log.warn("run `setup.py submodule` or `git submodule update` to update")
 
-    def init_extensions(self):
+    def init_server_extensions(self):
         """Load any extensions specified by config.
 
         Import the module, then call the load_jupyter_server_extension function,
         if one exists.
         """
-        for modulename in self.extensions:
+        for modulename in self.server_extensions:
             try:
                 mod = importlib.import_module(modulename)
                 func = getattr(mod, 'load_jupyter_server_extension', None)
@@ -947,7 +947,7 @@ class NotebookApp(BaseIPythonApplication):
         self.init_webapp()
         self.init_terminals()
         self.init_signal()
-        self.init_extensions()
+        self.init_server_extensions()
 
     def cleanup_kernels(self):
         """Shutdown all kernels.

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -711,7 +711,8 @@ class NotebookApp(BaseIPythonApplication):
         self.config.MappingKernelManager.root_dir = new
 
     server_extensions = List(Unicode(), config=True,
-        help="Python modules to load as notebook server extensions"
+        help=("Python modules to load as notebook server extensions. "
+              "This is an experimental API, and may change in future releases.")
     )
 
     def parse_command_line(self, argv=None):
@@ -926,6 +927,8 @@ class NotebookApp(BaseIPythonApplication):
 
         Import the module, then call the load_jupyter_server_extension function,
         if one exists.
+        
+        The extension API is experimental, and may change in future releases.
         """
         for modulename in self.server_extensions:
             try:


### PR DESCRIPTION
As some people may be tiring of my pointing out, it seems strange that we have extension points for the JS and the kernel, but none for the notebook server.

For cite2c, I want to add a handler which can serve a directory of style files for use by the nbextension part. With this PR, the extension for that looks like this:

``` python
from IPython.html.utils import url_path_join as ujoin
from tornado.web import StaticFileHandler

def load_jupyter_server_extension(nbapp):
    webapp = nbapp.web_app
    base_url = webapp.settings['base_url']
    webapp.add_handlers(".*$", [
        (ujoin(base_url, r"/cite2c/styles/(.*)"), StaticFileHandler, {'path': '...'})
    ])
```

Like our other extension APIs, the extension may define a single function, here `load_jupyter_server_extension()`, which we will call with a reference to the notebookapplication object. From that object you can access just about anything else of interest in the notebook application.

If adding handlers is a common use case, we may want to add a convenience method that does so correctly, taking account of base_url.
