### PR TITLE
Expose ConfigManager one level up the hierarchy

### DIFF
--- a/IPython/html/services/config/__init__.py
+++ b/IPython/html/services/config/__init__.py
@@ -1,0 +1,1 @@
+from .manager import ConfigManager


### PR DESCRIPTION
Because `from IPython.html.services.config import ConfigManager` is long enough.
