### PR TITLE
Load the per kernel kernel.js and kernel.css

### DIFF
--- a/IPython/html/static/notebook/js/kernelselector.js
+++ b/IPython/html/static/notebook/js/kernelselector.js
@@ -81,8 +81,7 @@ define([
                 .attr('href',css_url);
             },
             error:function(){
-                console.warn(new_mode_url+' does not provide custom URL, you might see a 404 error that should not prevent '+
-                                     ' the Jupyter notebook from working :' ,css_url );
+                console.info("No custom kernel.css at URL:", css_url)
             }
         });
 
@@ -109,19 +108,22 @@ define([
                 if(new_mode && new_mode.onload){
                     new_mode.onload();
                 } else {
-                    console.warn("The current kernel defined a kernel.js file but does not contain"+
-                                 "any asynchronous module definition. This is undefined behavior"+
+                    console.warn("The current kernel defined a kernel.js file but does not contain "+
+                                 "any asynchronous module definition. This is undefined behavior "+
                                  "which is not recommended");
                 }
             },
             function(err){
                 // if new mode does not have custom.js
-                console.warn('Any above 404 on '+new_mode_url+'.js is normal');
+                console.info("No custom kernel.css at URL:", new_mode_url)
             }
         );
     };
 
     KernelSelector.prototype.lock_switch = function() {
+        // should set a flag and display warning+reload if user want to
+        // re-change kernel. As UI discussion never finish
+        // making that a separate PR.
         console.warn('switching kernel is not guaranteed to work !');
     };
 

--- a/IPython/html/static/notebook/js/kernelselector.js
+++ b/IPython/html/static/notebook/js/kernelselector.js
@@ -81,7 +81,7 @@ define([
                 .attr('href',css_url);
             },
             error:function(){
-                console.warn(new_mode_url+' does not provide custom URL, you might see a 404 error that shoudl not prevent '+
+                console.warn(new_mode_url+' does not provide custom URL, you might see a 404 error that should not prevent '+
                                      ' the Jupyter notebook from working :' ,css_url );
             }
         });
@@ -109,9 +109,9 @@ define([
                 if(new_mode && new_mode.onload){
                     new_mode.onload();
                 } else {
-                    console.warn("The current kernel seem to define a kernel.js file; though this file does"+
-                                 "not contain any asynchronous module definition. This is undefined behavior"+
-                                 "which is not recommeneded");
+                    console.warn("The current kernel defined a kernel.js file but does not contain"+
+                                 "any asynchronous module definition. This is undefined behavior"+
+                                 "which is not recommended");
                 }
             },
             function(err){
@@ -122,7 +122,7 @@ define([
     };
 
     KernelSelector.prototype.lock_switch = function() {
-        console.warn('switching kernel is not guarantied to work !');
+        console.warn('switching kernel is not guaranteed to work !');
     };
 
     KernelSelector.prototype.bind_events = function() {

--- a/IPython/html/static/notebook/js/kernelselector.js
+++ b/IPython/html/static/notebook/js/kernelselector.js
@@ -11,6 +11,7 @@ define([
     var KernelSelector = function(selector, notebook) {
         this.selector = selector;
         this.notebook = notebook;
+        this.notebook.set_kernelselector(this);
         this.events = notebook.events;
         this.current_selection = null;
         this.kernelspecs = {};

--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -113,7 +113,6 @@ require([
     notification_area.init_notification_widgets();
     var kernel_selector = new kernelselector.KernelSelector(
         '#kernel_selector_widget', notebook);
-    notebook.set_kernelselector(kernel_selector);
 
     $('body').append('<div id="fonttest"><pre><span id="test1">x</span>'+
                      '<span id="test2" style="font-weight: bold;">x</span>'+

--- a/IPython/html/static/notebook/js/main.js
+++ b/IPython/html/static/notebook/js/main.js
@@ -113,6 +113,7 @@ require([
     notification_area.init_notification_widgets();
     var kernel_selector = new kernelselector.KernelSelector(
         '#kernel_selector_widget', notebook);
+    notebook.set_kernelselector(kernel_selector);
 
     $('body').append('<div id="fonttest"><pre><span id="test1">x</span>'+
                      '<span id="test2" style="font-weight: bold;">x</span>'+

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1870,7 +1870,7 @@ define([
                 // technically not perfect, we should check that the kernelspec matches
                 this.kernel_selector.change_kernel(this.metadata.kernelspec.name);
             } else {
-                console.log('do not have handle on kernnel_selector');
+                console.log('do not have handle on kernel_selector');
             }
         }
         

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1864,7 +1864,14 @@ define([
         // Trigger an event changing the kernel spec - this will set the default
         // codemirror mode
         if (this.metadata.kernelspec !== undefined) {
-            this.events.trigger('spec_changed.Kernel', this.metadata.kernelspec);
+            // TODO shoudl probably not trigger here, 
+            // should call the kernel selector, or custom.{js|css} not loaded.
+            if(this.kernel_selector){
+                // technically not perfect, we should check that the kernelspec matches
+                this.kernel_selector.change_kernel(this.metadata.kernelspec.name);
+            } else {
+                console.log('do not have handle on kernnel_selector');
+            }
         }
         
         // Set the codemirror mode from language_info metadata
@@ -2306,6 +2313,10 @@ define([
         // now that we're fully loaded, it is safe to restore save functionality
         this._fully_loaded = true;
         this.events.trigger('notebook_loaded.Notebook');
+    };
+
+    Notebook.prototype.set_kernelselector = function(k_selector){
+        this.kernel_selector = k_selector;
     };
 
     /**

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -17,6 +17,7 @@ window.mathjax_url = "{{mathjax_url}}";
 {{super()}}
 
 <link rel="stylesheet" href="{{ static_url("notebook/css/override.css") }}" type="text/css" />
+<link rel="stylesheet" href=""  id='kernel-css'                             type="text/css" />
 
 {% endblock %}
 

--- a/IPython/html/templates/page.html
+++ b/IPython/html/templates/page.html
@@ -24,6 +24,7 @@
           baseUrl: '{{static_url("", include_version=False)}}',
           paths: {
             nbextensions : '{{ base_url }}nbextensions',
+            kernelspecs : '{{ base_url }}kernelspecs',
             underscore : 'components/underscore/underscore-min',
             backbone : 'components/backbone/backbone-min',
             jquery: 'components/jquery/jquery.min',


### PR DESCRIPTION
As per discussion, each kernel can provide a file name kernel.js that
we try to load at kernel switching. If such a file exist we assume that
the kernel patches the javascript and that this javascript cannot be
unpatched, and further switching of the kernel cannot be undone without
reloading the page. (separate PR for UI)

if a kernel provide kernel.js, the it should consist into a AMD module
definition that uses require.js the module should define a function name
`onload` that will be called at the appropriate moment before the kernel
starts.

Supersede #6354 
