### PR TITLE
[ALT] Add a notebook option to keep non-ASCII characters

### DIFF
--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -500,6 +500,13 @@ class NotebookApp(BaseIPythonApplication):
     jinja_environment_options = Dict(config=True, 
             help="Supply extra arguments that will be passed to Jinja environment.")
 
+    ensure_ascii = Bool(True, config=True,
+        help="""Whether the output file only contains ASCII characters.
+        If ensure_ascii is True (the default), all non-ASCII characters
+        in the output are escaped with \\uXXXX sequences. If ensure_ascii
+        is False, these characters are represented using UTF-8.
+        """
+    )
     
     enable_mathjax = Bool(True, config=True,
         help="""Whether to enable MathJax for typesetting math/TeX

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -501,14 +501,6 @@ class NotebookApp(BaseIPythonApplication):
             help="Supply extra arguments that will be passed to Jinja environment.")
 
     
-    ensure_ascii = Bool(True, config=True,
-        help="""Whether the output file only contains ASCII characters.
-        If ensure_ascii is True (the default), all non-ASCII characters
-        in the output are escaped with \\uXXXX sequences. If ensure_ascii
-        is False, these characters are represented using UTF-8.
-        """
-    )
-    
     enable_mathjax = Bool(True, config=True,
         help="""Whether to enable MathJax for typesetting math/TeX
 

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -500,13 +500,6 @@ class NotebookApp(BaseIPythonApplication):
     jinja_environment_options = Dict(config=True, 
             help="Supply extra arguments that will be passed to Jinja environment.")
 
-    ensure_ascii = Bool(True, config=True,
-        help="""Whether the output file only contains ASCII characters.
-        If ensure_ascii is True (the default), all non-ASCII characters
-        in the output are escaped with \\uXXXX sequences. If ensure_ascii
-        is False, these characters are represented using UTF-8.
-        """
-    )
     
     enable_mathjax = Bool(True, config=True,
         help="""Whether to enable MathJax for typesetting math/TeX

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -501,6 +501,14 @@ class NotebookApp(BaseIPythonApplication):
             help="Supply extra arguments that will be passed to Jinja environment.")
 
     
+    ensure_ascii = Bool(True, config=True,
+        help="""Whether the output file only contains ASCII characters.
+        If ensure_ascii is True (the default), all non-ASCII characters
+        in the output are escaped with \\uXXXX sequences. If ensure_ascii
+        is False, these characters are represented using UTF-8.
+        """
+    )
+    
     enable_mathjax = Bool(True, config=True,
         help="""Whether to enable MathJax for typesetting math/TeX
 

--- a/IPython/html/services/contents/filemanager.py
+++ b/IPython/html/services/contents/filemanager.py
@@ -27,6 +27,14 @@ class FileContentsManager(ContentsManager):
 
     root_dir = Unicode(config=True)
 
+    ensure_ascii = Bool(True, config=True,
+        help="""Whether the output file only contains ASCII characters.
+        If ensure_ascii is True (the default), all non-ASCII characters
+        in the output are escaped with \\uXXXX sequences. If ensure_ascii
+        is False, these characters are represented using UTF-8.
+        """
+    )
+
     def _root_dir_default(self):
         try:
             return self.parent.notebook_dir
@@ -364,7 +372,7 @@ class FileContentsManager(ContentsManager):
         self.check_and_sign(nb, path)
 
         with self.atomic_writing(os_path, encoding='utf-8') as f:
-            nbformat.write(nb, f, version=nbformat.NO_CONVERT)
+            nbformat.write(nb, f, version=nbformat.NO_CONVERT, ensure_ascii=self.ensure_ascii)
 
     def _save_file(self, os_path, model, path=''):
         """save a non-notebook file"""

--- a/IPython/nbconvert/exporters/notebook.py
+++ b/IPython/nbconvert/exporters/notebook.py
@@ -6,6 +6,8 @@
 from .exporter import Exporter
 from IPython import nbformat
 from IPython.utils.traitlets import Enum
+from IPython.utils.traitlets import Bool
+
 
 class NotebookExporter(Exporter):
     """Exports to an IPython notebook."""

--- a/IPython/nbconvert/exporters/notebook.py
+++ b/IPython/nbconvert/exporters/notebook.py
@@ -17,6 +17,15 @@ class NotebookExporter(Exporter):
         Use this to downgrade notebooks.
         """
     )
+
+    ensure_ascii = Bool(True, config=True,
+        help="""Whether the output file only contains ASCII characters.
+        If ensure_ascii is True (the default), all non-ASCII characters
+        in the output are escaped with \\uXXXX sequences. If ensure_ascii
+        is False, these characters are represented using UTF-8.
+        """
+    )
+
     def _file_extension_default(self):
         return 'ipynb'
 
@@ -28,5 +37,5 @@ class NotebookExporter(Exporter):
             resources['output_suffix'] = '.v%i' % self.nbformat_version
         else:
             resources['output_suffix'] = '.nbconvert'
-        output = nbformat.writes(nb_copy, version=self.nbformat_version)
+        output = nbformat.writes(nb_copy, version=self.nbformat_version, ensure_ascii=self.ensure_ascii)
         return output, resources

--- a/IPython/nbformat/v4/nbjson.py
+++ b/IPython/nbformat/v4/nbjson.py
@@ -12,6 +12,7 @@ from .nbbase import from_dict
 from .rwbase import (
     NotebookReader, NotebookWriter, rejoin_lines, split_lines, strip_transient
 )
+from IPython.utils.traitlets import Bool
 
 
 class BytesEncoder(json.JSONEncoder):

--- a/IPython/nbformat/v4/nbjson.py
+++ b/IPython/nbformat/v4/nbjson.py
@@ -12,7 +12,6 @@ from .nbbase import from_dict
 from .rwbase import (
     NotebookReader, NotebookWriter, rejoin_lines, split_lines, strip_transient
 )
-from IPython.utils.traitlets import Bool
 
 
 class BytesEncoder(json.JSONEncoder):
@@ -44,13 +43,6 @@ class JSONReader(NotebookReader):
 
 class JSONWriter(NotebookWriter):
 
-    ensure_ascii = Bool(True, config=True,
-        help="""Whether the output file only contains ASCII characters.
-        If ensure_ascii is True (the default), all non-ASCII characters
-        in the output are escaped with \\uXXXX sequences. If ensure_ascii
-        is False, these characters are represented using UTF-8.
-        """
-    )
 
     def writes(self, nb, **kwargs):
         """Serialize a NotebookNode object as a JSON string"""
@@ -58,7 +50,7 @@ class JSONWriter(NotebookWriter):
         kwargs['indent'] = 1
         kwargs['sort_keys'] = True
         kwargs['separators'] = (',',': ')
-        kwargs['ensure_ascii'] = self.ensure_ascii
+        kwargs.set_default('ensure_ascii', False)
         # don't modify in-memory dict
         nb = copy.deepcopy(nb)
         if kwargs.pop('split_lines', True):

--- a/IPython/nbformat/v4/nbjson.py
+++ b/IPython/nbformat/v4/nbjson.py
@@ -12,6 +12,7 @@ from .nbbase import from_dict
 from .rwbase import (
     NotebookReader, NotebookWriter, rejoin_lines, split_lines, strip_transient
 )
+from IPython.utils.traitlets import Bool
 
 
 class BytesEncoder(json.JSONEncoder):
@@ -42,6 +43,14 @@ class JSONReader(NotebookReader):
 
 
 class JSONWriter(NotebookWriter):
+
+    ensure_ascii = Bool(True, config=True,
+        help="""Whether the output file only contains ASCII characters.
+        If ensure_ascii is True (the default), all non-ASCII characters
+        in the output are escaped with \\uXXXX sequences. If ensure_ascii
+        is False, these characters are represented using UTF-8.
+        """
+    )
 
     def writes(self, nb, **kwargs):
         """Serialize a NotebookNode object as a JSON string"""

--- a/IPython/nbformat/v4/nbjson.py
+++ b/IPython/nbformat/v4/nbjson.py
@@ -50,7 +50,7 @@ class JSONWriter(NotebookWriter):
         kwargs['indent'] = 1
         kwargs['sort_keys'] = True
         kwargs['separators'] = (',',': ')
-        kwargs.set_default('ensure_ascii', False)
+        kwargs.setdefault('ensure_ascii', False)
         # don't modify in-memory dict
         nb = copy.deepcopy(nb)
         if kwargs.pop('split_lines', True):

--- a/IPython/nbformat/v4/nbjson.py
+++ b/IPython/nbformat/v4/nbjson.py
@@ -49,6 +49,7 @@ class JSONWriter(NotebookWriter):
         kwargs['indent'] = 1
         kwargs['sort_keys'] = True
         kwargs['separators'] = (',',': ')
+        kwargs['ensure_ascii'] = self.ensure_ascii
         # don't modify in-memory dict
         nb = copy.deepcopy(nb)
         if kwargs.pop('split_lines', True):

--- a/IPython/nbformat/v4/rwbase.py
+++ b/IPython/nbformat/v4/rwbase.py
@@ -74,7 +74,7 @@ class NotebookReader(object):
 
     def reads(self, s, **kwargs):
         """Read a notebook from a string."""
-        raise NotImplementedError("loads must be implemented in a subclass")
+        raise NotImplementedError("reads must be implemented in a subclass")
 
     def read(self, fp, **kwargs):
         """Read a notebook from a file like object"""
@@ -87,7 +87,7 @@ class NotebookWriter(IPython.config.Configurable):
 
     def writes(self, nb, **kwargs):
         """Write a notebook to a string."""
-        raise NotImplementedError("loads must be implemented in a subclass")
+        raise NotImplementedError("writes must be implemented in a subclass")
 
     def write(self, nb, fp, **kwargs):
         """Write a notebook to a file like object"""

--- a/IPython/nbformat/v4/rwbase.py
+++ b/IPython/nbformat/v4/rwbase.py
@@ -82,7 +82,7 @@ class NotebookReader(object):
         return self.reads(nbs, **kwargs)
 
 
-class NotebookWriter(object):
+class NotebookWriter(IPython.config.Configurable):
     """A class for writing notebooks."""
 
     def writes(self, nb, **kwargs):

--- a/IPython/nbformat/v4/rwbase.py
+++ b/IPython/nbformat/v4/rwbase.py
@@ -4,7 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from IPython.utils.py3compat import string_types, cast_unicode_py2
-
+import IPython.config
 
 def rejoin_lines(nb):
     """rejoin multiline text into strings


### PR DESCRIPTION
Alternative to #7064. I'm not a [huge fan](http://xkcd.com/1378/) of this approach, as I'm afraid it spread the configuration to both the notebook server and nbconvert. We could explicitly instantiate the JSONwriter in each place instead of importing write and read from the module.
