### PR TITLE
Allow FileLinks to not recurse into subdirectories

### DIFF
--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -3,7 +3,7 @@
 Authors : MinRK, gregcaporaso, dannystaple
 """
 from os.path import exists, isfile, splitext, abspath, join, isdir
-from os import walk, sep
+from os import walk, sep, listdir
 
 from IPython.core.display import DisplayObject
 
@@ -368,7 +368,8 @@ class FileLinks(FileLink):
                  result_html_prefix='',
                  result_html_suffix='<br>',
                  notebook_display_formatter=None,
-                 terminal_display_formatter=None):
+                 terminal_display_formatter=None,
+                 recursive=True):
         """
         See :class:`FileLink` for the ``path``, ``url_prefix``,
         ``result_html_prefix`` and ``result_html_suffix`` parameters.
@@ -420,6 +421,8 @@ class FileLinks(FileLink):
              notebook_display_formatter or self._get_notebook_display_formatter()
         self.terminal_display_formatter = \
              terminal_display_formatter or self._get_terminal_display_formatter()
+
+        self.recursive = recursive
 
     def _get_display_formatter(self,
                                dirname_output_format,
@@ -516,7 +519,10 @@ class FileLinks(FileLink):
 
     def _format_path(self):
         result_lines = []
-        walked_dir = list(walk(self.path))
+        if self.recursive:
+            walked_dir = list(walk(self.path))
+        else:
+            walked_dir = [walk(self.path).next()]
         walked_dir.sort()
         for dirname, subdirs, fnames in walked_dir:
             result_lines += self.notebook_display_formatter(dirname, fnames, self.included_suffixes)
@@ -526,7 +532,10 @@ class FileLinks(FileLink):
         """return newline-separated absolute paths
         """
         result_lines = []
-        walked_dir = list(walk(self.path))
+        if self.recursive:
+            walked_dir = list(walk(self.path))
+        else:
+            walked_dir = [walk(self.path).next()]
         walked_dir.sort()
         for dirname, subdirs, fnames in walked_dir:
             result_lines += self.terminal_display_formatter(dirname, fnames, self.included_suffixes)

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -524,7 +524,7 @@ class FileLinks(FileLink):
         if self.recursive:
             walked_dir = list(walk(self.path))
         else:
-            walked_dir = [walk(self.path).next()]
+            walked_dir = [next(walk(self.path))]
         walked_dir.sort()
         for dirname, subdirs, fnames in walked_dir:
             result_lines += self.notebook_display_formatter(dirname, fnames, self.included_suffixes)
@@ -537,7 +537,7 @@ class FileLinks(FileLink):
         if self.recursive:
             walked_dir = list(walk(self.path))
         else:
-            walked_dir = [walk(self.path).next()]
+            walked_dir = [next(walk(self.path))]
         walked_dir.sort()
         for dirname, subdirs, fnames in walked_dir:
             result_lines += self.terminal_display_formatter(dirname, fnames, self.included_suffixes)

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -3,7 +3,7 @@
 Authors : MinRK, gregcaporaso, dannystaple
 """
 from os.path import exists, isfile, splitext, abspath, join, isdir
-from os import walk, sep, listdir
+from os import walk, sep
 
 from IPython.core.display import DisplayObject
 
@@ -397,6 +397,8 @@ class FileLinks(FileLink):
         included_suffixes : list
           The file suffixes that should be included in the output (passing None
           meansto include all suffixes in the output in the built-in formatters)
+        recursive : boolean
+          Whether to recurse into subdirectories. Default is True.
 
         The function should return a list of lines that will be printed in the
         notebook (if passing notebook_display_formatter) or the terminal (if

--- a/IPython/lib/tests/test_display.py
+++ b/IPython/lib/tests/test_display.py
@@ -156,6 +156,22 @@ def test_error_on_file_to_FileLinks():
     tf1 = NamedTemporaryFile(dir=td)
     nt.assert_raises(ValueError,display.FileLinks,tf1.name)
 
+def test_recursive_FileLinks():
+    """FileLinks: Does not recurse when recursive=False
+    """
+    td = mkdtemp()
+    tf = NamedTemporaryFile(dir=td)
+    subtd = mkdtemp(dir=td)
+    subtf = NamedTemporaryFile(dir=subtd)
+    fl = display.FileLinks(td)
+    actual = str(fl)
+    actual = actual.split('\n')
+    nt.assert_equal(len(actual), 4, actual)
+    fl = display.FileLinks(td, recursive=False)
+    actual = str(fl)
+    actual = actual.split('\n')
+    nt.assert_equal(len(actual), 2, actual)
+
 @skipif_not_numpy
 def test_audio_from_file():
     path = pjoin(dirname(__file__), 'test.wav')


### PR DESCRIPTION
FileLinks is useful to display files and directories. However, it would be more useful if it could be used in a non-recursive way. This PR adds a `recursive` options to FileLinks.

An alternative way to do this would be to pass in a recursive depth limit, so that you could control the depth of recursion. But that would be more complex of a change.
