### PR TITLE
Make the favicon a template block

### DIFF
--- a/IPython/html/templates/page.html
+++ b/IPython/html/templates/page.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
 
     <title>{% block title %}IPython Notebook{% endblock %}</title>
-    <link rel="shortcut icon" type="image/x-icon" href="{{static_url("base/images/favicon.ico") }}">
+    {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="{{static_url("base/images/favicon.ico") }}">{% endblock %}
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <link rel="stylesheet" href="{{static_url("components/jquery-ui/themes/smoothness/jquery-ui.min.css") }}" type="text/css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
This is a follow-up on #6881, since the favicon change there disappeared in the rebase.  @jdfreder or @minrk, can you review this?
