### PR TITLE
add py3compat.buffer_to_bytes_py2

### DIFF
--- a/IPython/utils/pickleutil.py
+++ b/IPython/utils/pickleutil.py
@@ -17,7 +17,7 @@ except ImportError:
 from . import codeutil  # This registers a hook when it's imported
 from . import py3compat
 from .importstring import import_item
-from .py3compat import string_types, iteritems
+from .py3compat import string_types, iteritems, buffer_to_bytes_py2
 
 from IPython.config import Application
 from IPython.utils.log import get_logger
@@ -260,8 +260,8 @@ class CannedArray(CannedObject):
         from numpy import frombuffer
         data = self.buffers[0]
         if self.pickled:
-            # no shape, we just pickled it
-            return pickle.loads(data)
+            # we just pickled it
+            return pickle.loads(buffer_to_bytes_py2(data))
         else:
             return frombuffer(data, dtype=self.dtype).reshape(self.shape)
 

--- a/IPython/utils/py3compat.py
+++ b/IPython/utils/py3compat.py
@@ -30,6 +30,12 @@ def cast_bytes(s, encoding=None):
         return encode(s, encoding)
     return s
 
+def buffer_to_bytes(buf):
+    """Cast a buffer object to bytes"""
+    if not isinstance(buf, bytes):
+        buf = bytes(buf)
+    return buf
+
 def _modify_str_or_docstring(str_change_func):
     @functools.wraps(str_change_func)
     def wrapper(func_or_str):
@@ -86,6 +92,7 @@ if sys.version_info[0] >= 3:
     bytes_to_str = decode
     cast_bytes_py2 = no_code
     cast_unicode_py2 = no_code
+    buffer_to_bytes_py2 = no_code
     
     string_types = (str,)
     unicode_type = str
@@ -151,6 +158,7 @@ else:
     bytes_to_str = no_code
     cast_bytes_py2 = cast_bytes
     cast_unicode_py2 = cast_unicode
+    buffer_to_bytes_py2 = buffer_to_bytes
     
     string_types = (str, unicode)
     unicode_type = unicode


### PR DESCRIPTION
casts buffer objects to bytes, which is needed for pickle.loads from buffers on Python 2.

closes #7101
