### PR TITLE
gh-7044: set TMPDIR to workingdir in tests

### DIFF
--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -170,6 +170,9 @@ class PyTestController(TestController):
         self.env['IPTEST_WORKING_DIR'] = workingdir.name
         # This means we won't get odd effects from our own matplotlib config
         self.env['MPLCONFIGDIR'] = workingdir.name
+        # For security reasons (http://bugs.python.org/issue16202), use
+        # a temporary directory to which other users have no access.
+        self.env['TMPDIR'] = workingdir.name
 
         # Add a non-accessible directory to PATH (see gh-7053)
         noaccess = os.path.join(self.workingdir.name, "_no_access_")

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -462,14 +462,13 @@ def test_not_writable_ipdir():
     env.pop('XDG_CONFIG_HOME', None)
     env['HOME'] = tmpdir
     ipdir = os.path.join(tmpdir, '.ipython')
-    os.mkdir(ipdir)
-    os.chmod(ipdir, 600)
+    os.mkdir(ipdir, 0o555)
     try:
-        os.listdir(ipdir)
-    except OSError:
+        open(os.path.join(ipdir, "_foo_"), 'w').close()
+    except IOError:
         pass
     else:
-        # I can still read an unreadable dir,
+        # I can still write to an unwritable dir,
         # assume I'm root and skip the test
         raise SkipTest("I can't create directories that I can't list")
     with AssertPrints('is not a writable location', channel='stderr'):

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -470,7 +470,7 @@ def test_not_writable_ipdir():
     else:
         # I can still write to an unwritable dir,
         # assume I'm root and skip the test
-        raise SkipTest("I can't create directories that I can't list")
+        raise SkipTest("I can't create directories that I can't write to")
     with AssertPrints('is not a writable location', channel='stderr'):
         ipdir = path.get_ipython_dir()
     env.pop('IPYTHON_DIR', None)


### PR DESCRIPTION
Fix https://github.com/ipython/ipython/issues/7044 and fix the broken test `test_not_writable_ipdir`.
