### PR TITLE
Dispatch to custom exporter in ScriptExporter

### DIFF
--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -154,6 +154,10 @@ define([
             that._nbconvert('pdf', true);
         });
 
+        this.element.find('#download_script').click(function () {
+            that._nbconvert('script', true);
+        });
+
         this.element.find('#rename_notebook').click(function () {
             that.save_widget.rename_notebook({notebook: that.notebook});
         });
@@ -373,20 +377,6 @@ define([
         var langname = (langinfo.name || 'Script')
         langname = langname.charAt(0).toUpperCase()+langname.substr(1) // Capitalise
         el.find('a').text(langname + ' ('+(langinfo.file_extension || 'txt')+')');
-        
-        // Unregister any previously registered handlers
-        el.off('click');
-        if (langinfo.nbconvert_exporter) {
-            // Metadata specifies a specific exporter, e.g. 'python'
-            el.click(function() {
-                that._nbconvert(langinfo.nbconvert_exporter, true);
-            });
-        } else {
-            // Use generic 'script' exporter
-            el.click(function() {
-                that._nbconvert('script', true);
-            });
-        }
     };
 
     // Backwards compatability.

--- a/IPython/nbconvert/exporters/script.py
+++ b/IPython/nbconvert/exporters/script.py
@@ -1,14 +1,33 @@
 """Generic script exporter class for any kernel language"""
 
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 from .templateexporter import TemplateExporter
 
+from IPython.utils.traitlets import Dict
+
 class ScriptExporter(TemplateExporter):
+    
+    _exporters = Dict()
+    
     def _template_file_default(self):
         return 'script'
 
     def from_notebook_node(self, nb, resources=None, **kw):
         langinfo = nb.metadata.get('language_info', {})
+        
+        # delegate to custom exporter, if specified
+        exporter_name = langinfo.get('nbconvert_exporter')
+        if exporter_name and exporter_name != 'script':
+            self.log.debug("Loading script exporter: %s", exporter_name)
+            from .export import exporter_map
+            if exporter_name not in self._exporters:
+                Exporter = exporter_map[exporter_name]
+                self._exporters[exporter_name] = Exporter(parent=self)
+            exporter = self._exporters[exporter_name]
+            return exporter.from_notebook_node(nb, resources, **kw)
+        
         self.file_extension = langinfo.get('file_extension', '.txt')
         self.output_mimetype = langinfo.get('mimetype', 'text/plain')
-
         return super(ScriptExporter, self).from_notebook_node(nb, resources, **kw)


### PR DESCRIPTION
The logic previously implemented in the menubar javascript is moved to the ScriptExporter itself.

This removes the need for Javascript to interpret `nbconvert_exporter` metadata at all, and ensures `--to script` is consistent with `Download as...script`, etc.

A side effect is that there should be no reason to use `--to python` anymore.
