### PR TITLE
Install kernelspecs in environments and find them there

### DIFF
--- a/IPython/kernel/kernelspec.py
+++ b/IPython/kernel/kernelspec.py
@@ -26,8 +26,10 @@ NATIVE_KERNEL_NAME = 'python3' if PY3 else 'python2'
 
 def find_install_prefix():
     if sys.platform=='darwin' and sys.prefix.startswith('/System/Library/Frameworks/'):
+        # System Python on OS X has some crazy sys.prefix that we shouldn't use
         return '/usr/local'
     elif sys.prefix == '/usr':
+        # Install to /usr/local in preference to /usr
         # TODO: When building distro packages, /usr is OK
         return '/usr/local'
     else:
@@ -149,24 +151,24 @@ class KernelSpecManager(HasTraits):
             raise NoSuchKernel(kernel_name)
         return KernelSpec.from_resource_dir(resource_dir)
     
-    def _get_destination_dir(self, kernel_name, system=False):
-        if system:
-            if SYSTEM_KERNEL_DIRS:
-                return os.path.join(find_install_prefix(), 'share', 'ipython', 'kernels', kernel_name)
-            else:
-                raise EnvironmentError("No system kernel directory is available")
-        else:
+    def _get_destination_dir(self, kernel_name, user=False):
+        if user:
             return os.path.join(self.user_kernel_dir, kernel_name)
+        else:
+            return os.path.join(find_install_prefix(),
+                                'share', 'ipython', 'kernels', kernel_name)
 
-    def install_kernel_spec(self, source_dir, kernel_name=None, system=False,
+    def install_kernel_spec(self, source_dir, kernel_name=None, user=False,
                             replace=False):
         """Install a kernel spec by copying its directory.
         
         If ``kernel_name`` is not given, the basename of ``source_dir`` will
         be used.
         
-        If ``system`` is True, it will attempt to install into the systemwide
-        kernel registry. If the process does not have appropriate permissions,
+        If ``user`` is True, it will install into the user's kernel registry.
+        Otherwise, it will install into a systemwide location or a location
+        inside the active environment, using sys.prefix.
+        If the process does not have appropriate permissions,
         an :exc:`OSError` will be raised.
         
         If ``replace`` is True, this will replace an existing kernel of the same
@@ -177,25 +179,27 @@ class KernelSpecManager(HasTraits):
             kernel_name = os.path.basename(source_dir)
         kernel_name = kernel_name.lower()
         
-        destination = self._get_destination_dir(kernel_name, system=system)
+        destination = self._get_destination_dir(kernel_name, user=user)
 
         if replace and os.path.isdir(destination):
             shutil.rmtree(destination)
 
         shutil.copytree(source_dir, destination)
 
-    def install_native_kernel_spec(self, system=False):
+    def install_native_kernel_spec(self, user=False):
         """Install the native kernel spec to the filesystem
         
         This allows a Python 3 frontend to use a Python 2 kernel, or vice versa.
         The kernelspec will be written pointing to the Python executable on
         which this is run.
         
-        If ``system`` is True, it will attempt to install into the systemwide
-        kernel registry. If the process does not have appropriate permissions, 
+        If ``user`` is True, it will install into the user's kernel registry.
+        Otherwise, it will install into a systemwide location or a location
+        inside the active environment, using sys.prefix.
+        If the process does not have appropriate permissions, 
         an :exc:`OSError` will be raised.
         """
-        path = self._get_destination_dir(NATIVE_KERNEL_NAME, system=system)
+        path = self._get_destination_dir(NATIVE_KERNEL_NAME, user=user)
         os.makedirs(path, mode=0o755)
         with open(pjoin(path, 'kernel.json'), 'w') as f:
             json.dump(self._native_kernel_dict, f, indent=1)
@@ -213,13 +217,13 @@ def get_kernel_spec(kernel_name):
     """
     return KernelSpecManager().get_kernel_spec(kernel_name)
 
-def install_kernel_spec(source_dir, kernel_name=None, system=False, replace=False):
+def install_kernel_spec(source_dir, kernel_name=None, user=False, replace=False):
     return KernelSpecManager().install_kernel_spec(source_dir, kernel_name,
-                                                    system, replace)
+                                                    user, replace)
 
 install_kernel_spec.__doc__ = KernelSpecManager.install_kernel_spec.__doc__
 
-def install_native_kernel_spec(self, system=False):
-    return KernelSpecManager().install_native_kernel_spec(system=system)
+def install_native_kernel_spec(self, user=False):
+    return KernelSpecManager().install_native_kernel_spec(user=user)
 
 install_native_kernel_spec.__doc__ = KernelSpecManager.install_native_kernel_spec.__doc__

--- a/IPython/kernel/kernelspecapp.py
+++ b/IPython/kernel/kernelspecapp.py
@@ -45,10 +45,10 @@ class InstallKernelSpec(BaseIPythonApplication):
     def _kernel_name_default(self):
         return os.path.basename(self.sourcedir)
 
-    system = Bool(False, config=True,
+    user = Bool(False, config=True,
         help="""
-        Try to install the kernel spec to the systemwide directory instead of
-        the per-user directory.
+        Try to install the kernel spec to the per-user directory instead of
+        the system or environment directory.
         """
     )
     replace = Bool(False, config=True,
@@ -59,8 +59,8 @@ class InstallKernelSpec(BaseIPythonApplication):
     for k in ['ipython-dir', 'log-level']:
         aliases[k] = base_aliases[k]
 
-    flags = {'system': ({'InstallKernelSpec': {'system': True}},
-                "Install to the systemwide kernel registry"),
+    flags = {'user': ({'InstallKernelSpec': {'user': True}},
+                "Install to the per-user kernel registry"),
              'replace': ({'InstallKernelSpec': {'replace': True}},
                 "Replace any existing kernel spec with this name."),
              'debug': base_flags['debug'],
@@ -79,7 +79,7 @@ class InstallKernelSpec(BaseIPythonApplication):
         try:
             self.kernel_spec_manager.install_kernel_spec(self.sourcedir,
                                                  kernel_name=self.kernel_name,
-                                                 system=self.system,
+                                                 user=self.user,
                                                  replace=self.replace,
                                                 )
         except OSError as e:
@@ -98,23 +98,23 @@ class InstallNativeKernelSpec(BaseIPythonApplication):
     def _kernel_spec_manager_default(self):
         return KernelSpecManager(ipython_dir=self.ipython_dir)
 
-    system = Bool(False, config=True,
+    user = Bool(False, config=True,
         help="""
-        Try to install the kernel spec to the systemwide directory instead of
-        the per-user directory.
+        Try to install the kernel spec to the per-user directory instead of
+        the system or environment directory.
         """
     )
 
     # Not all of the base aliases are meaningful (e.g. profile)
     aliases = {k: base_aliases[k] for k in ['ipython-dir', 'log-level']}
-    flags = {'system': ({'InstallNativeKernelSpec': {'system': True}},
-                "Install to the systemwide kernel registry"),
+    flags = {'user': ({'InstallNativeKernelSpec': {'user': True}},
+                "Install to the per-user kernel registry"),
              'debug': base_flags['debug'],
             }
 
     def start(self):
         try:
-            self.kernel_spec_manager.install_native_kernel_spec(system=self.system)
+            self.kernel_spec_manager.install_native_kernel_spec(user=self.user)
         except OSError as e:
             self.exit(e)
 

--- a/IPython/kernel/tests/test_kernelspec.py
+++ b/IPython/kernel/tests/test_kernelspec.py
@@ -42,21 +42,25 @@ class KernelSpecTests(unittest.TestCase):
     
     def test_install_kernel_spec(self):
         self.ksm.install_kernel_spec(self.installable_kernel,
-                                     kernel_name='tstinstalled')
+                                     kernel_name='tstinstalled',
+                                     user=True)
         self.assertIn('tstinstalled', self.ksm.find_kernel_specs())
         
         with self.assertRaises(OSError):
             self.ksm.install_kernel_spec(self.installable_kernel,
-                                         kernel_name='tstinstalled')
+                                         kernel_name='tstinstalled',
+                                         user=True)
         
         # Smoketest that this succeeds
         self.ksm.install_kernel_spec(self.installable_kernel,
                                      kernel_name='tstinstalled',
-                                     replace=True)
-    
-    @onlyif(os.name != 'nt' and not os.access('/usr/local/share', os.W_OK), "needs Unix system without root privileges")
+                                     replace=True, user=True)
+
+    @onlyif(kernelspec.find_install_prefix() in {'/usr', '/usr/local'}
+            and not os.access('/usr/local/share', os.W_OK),
+            "needs Unix system without root privileges")
     def test_cant_install_kernel_spec(self):
         with self.assertRaises(OSError):
             self.ksm.install_kernel_spec(self.installable_kernel,
                                          kernel_name='tstinstalled',
-                                         system=True)
+                                         user=False)


### PR DESCRIPTION
With this change, we look in three types of location for kernelspecs:
1. Systemwide locations (`%PROGRAMDATA%` on Windows, `/usr` and `/usr/local` on Unix). This is for kernels installed with non-Python tools, like apt or executable installers.
2. Environment locations relative to sys.prefix. This is also where our Python machinery installs kernelspecs by default. In some cases where you're not using an environment, this will be the same as 1.
3. The per-user location inside $IPYTHONDIR. Our own machinery can install kernelspecs there with a flag.

The default is changed from installing for the user to installing for the environment. The `system` parameter for the install functions is replaced by a `user` parameter, which will require some kernel authors to make a change. An example for my bash_kernel is coming up. Ping @dsblank, @blink1073.

Supersedes #6966.
