### PR TITLE
A little more V, a little less M in the text editor

### DIFF
--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -370,7 +370,8 @@ def json_errors(method):
             message = e.log_message
             self.log.warn(message)
             self.set_status(e.status_code)
-            self.finish(json.dumps(dict(message=message)))
+            reply = dict(message=message, reason=e.reason)
+            self.finish(json.dumps(reply))
         except Exception:
             self.log.error("Unhandled error in API request", exc_info=True)
             status = 500
@@ -378,7 +379,7 @@ def json_errors(method):
             t, value, tb = sys.exc_info()
             self.set_status(status)
             tb_text = ''.join(traceback.format_exception(t, value, tb))
-            reply = dict(message=message, traceback=tb_text)
+            reply = dict(message=message, reason=None, traceback=tb_text)
             self.finish(json.dumps(reply))
         else:
             return result

--- a/IPython/html/services/contents/filemanager.py
+++ b/IPython/html/services/contents/filemanager.py
@@ -282,7 +282,7 @@ class FileContentsManager(ContentsManager):
                     model['content'] = bcontent.decode('utf8')
                 except UnicodeError as e:
                     if format == 'text':
-                        raise web.HTTPError(400, "%s is not UTF-8 encoded" % path)
+                        raise web.HTTPError(400, "%s is not UTF-8 encoded" % path, reason='bad format')
                 else:
                     model['format'] = 'text'
 
@@ -345,14 +345,14 @@ class FileContentsManager(ContentsManager):
         if os.path.isdir(os_path):
             if type_ not in (None, 'directory'):
                 raise web.HTTPError(400,
-                                u'%s is a directory, not a %s' % (path, type_))
+                                u'%s is a directory, not a %s' % (path, type_), reason='bad type')
             model = self._dir_model(path, content=content)
         elif type_ == 'notebook' or (type_ is None and path.endswith('.ipynb')):
             model = self._notebook_model(path, content=content)
         else:
             if type_ == 'directory':
                 raise web.HTTPError(400,
-                                u'%s is not a directory')
+                                u'%s is not a directory', reason='bad type')
             model = self._file_model(path, content=content, format=format)
         return model
 

--- a/IPython/html/services/contents/handlers.py
+++ b/IPython/html/services/contents/handlers.py
@@ -47,6 +47,7 @@ class ContentsHandler(IPythonHandler):
             location = self.location_url(model['path'])
             self.set_header('Location', location)
         self.set_header('Last-Modified', model['last_modified'])
+        self.set_header('Content-Type', 'application/json')
         self.finish(json.dumps(model, default=date_default))
 
     @web.authenticated

--- a/IPython/html/static/base/js/notificationwidget.js
+++ b/IPython/html/static/base/js/notificationwidget.js
@@ -33,7 +33,10 @@ define([
      * @method style
      */
     NotificationWidget.prototype.style = function () {
-        this.element.addClass('notification_widget');
+        // use explicit bootstrap classes here,
+        // because multiple inheritance in LESS doesn't work
+        // for this particular combination
+        this.element.addClass('notification_widget btn btn-xs navbar-btn');
     };
 
     /**

--- a/IPython/html/static/base/less/page.less
+++ b/IPython/html/static/base/less/page.less
@@ -20,20 +20,15 @@ body {
 div#header {
     /* Initially hidden to prevent FLOUC */
     display: none;
-    margin-bottom: -6px;
-    position: fixed;
-    top: 0;
-    width: 100%;
     background-color: @body-bg;
-    min-height: 31px;
 
     /* Display over codemirror */
     z-index: 100;
 
     #header-container {
-        margin-bottom: 0px;
         padding-left: 30px;
         padding-bottom: 5px;
+        padding-top: 5px;
         .border-box-sizing();
     }
 
@@ -51,6 +46,8 @@ div#header {
 
 #ipython_notebook {
     padding-left: 0px;
+    padding-top: (@navbar-height - @logo_height) / 2;
+    padding-bottom: (@navbar-height - @logo_height) / 2;
 }
 
 #noscript {
@@ -65,8 +62,8 @@ div#header {
 
 #ipython_notebook img {
     font-family: Verdana, "Helvetica Neue", Arial, Helvetica, Geneva, sans-serif;
-    height: 24px;
-    text-decoration:none;
+    height: @logo_height;
+    text-decoration: none;
     color: black;
 }
 
@@ -85,9 +82,6 @@ div#header {
 input.ui-button {
     padding: 0.3em 0.9em;
 }
-.navbar span {
-  margin-top: 3px;
-}
 
 span#login_widget {
     float: right;
@@ -96,9 +90,7 @@ span#login_widget {
 span#login_widget > .button,
 #logout
 {
-    .btn();
     .btn-default();
-    .btn-sm();
 }
 
 .nav-header {

--- a/IPython/html/static/base/less/variables.less
+++ b/IPython/html/static/base/less/variables.less
@@ -4,11 +4,12 @@
 @text-color: @black;
 @font-size-base: 13px;
 @font-family-monospace: monospace;  // to allow user to customize their fonts
-@navbar-height: 36px;
+@navbar-height: 30px;
 @breadcrumb-color: darken(@border_color, 30%);
 @blockquote-font-size: inherit;
 @modal-inner-padding: 15px;
 @grid-float-breakpoint: 540px;
+@logo_height: 24px;
 
 // Disable modal slide-in from top animation.
 .modal {

--- a/IPython/html/static/edit/js/editor.js
+++ b/IPython/html/static/edit/js/editor.js
@@ -79,6 +79,14 @@ function($,
                 that.events.trigger("file_loaded.Editor", model);
             },
             function(error) {
+                that.events.trigger("file_load_failed.Editor", error);
+                if (error.xhr.responseJSON.reason === 'bad format') {
+                    window.location = utils.url_path_join(
+                        that.base_url,
+                        'files',
+                        that.file_path
+                    );
+                }
                 cm.setValue("Error! " + error.message +
                                 "\nSaving disabled.");
                 that.save_enabled = false;

--- a/IPython/html/static/edit/js/editor.js
+++ b/IPython/html/static/edit/js/editor.js
@@ -47,7 +47,7 @@ function($,
                 Editor.default_codemirror_options,
                 cfg.codemirror_options || {}
             );
-            that.set_codemirror_options(cmopts, false);
+            that._set_codemirror_options(cmopts);
             that.events.trigger('config_changed.Editor', {config: that.config});
         });
     };
@@ -113,6 +113,10 @@ function($,
     Editor.prototype._set_codemirror_options = function (options) {
         // update codemirror options from a dict
         for (var opt in options) {
+            if (!options.hasOwnProperty(opt)) {
+                continue;
+            }
+            console.log(opt, options[opt]);
             this.codemirror.setOption(opt, options[opt]);
         }
     };

--- a/IPython/html/static/edit/js/editor.js
+++ b/IPython/html/static/edit/js/editor.js
@@ -116,8 +116,11 @@ function($,
             if (!options.hasOwnProperty(opt)) {
                 continue;
             }
-            console.log(opt, options[opt]);
-            this.codemirror.setOption(opt, options[opt]);
+            var value = options[opt];
+            if (value === null) {
+                value = CodeMirror.defaults[opt];
+            }
+            this.codemirror.setOption(opt, value);
         }
     };
     

--- a/IPython/html/static/edit/js/editor.js
+++ b/IPython/html/static/edit/js/editor.js
@@ -155,16 +155,13 @@ function($,
     
     Editor.prototype._set_codemirror_options = function (options) {
         // update codemirror options from a dict
-        for (var opt in options) {
-            if (!options.hasOwnProperty(opt)) {
-                continue;
-            }
-            var value = options[opt];
+        var codemirror = this.codemirror;
+        $.map(options, function (value, opt) {
             if (value === null) {
                 value = CodeMirror.defaults[opt];
             }
-            this.codemirror.setOption(opt, value);
-        }
+            codemirror.setOption(opt, value);
+        });
     };
     
     Editor.prototype.update_codemirror_options = function (options) {

--- a/IPython/html/static/edit/js/editor.js
+++ b/IPython/html/static/edit/js/editor.js
@@ -31,6 +31,7 @@ function($,
         this.file_path = options.file_path;
         this.config = options.config;
         this.codemirror = new CodeMirror($(this.selector)[0]);
+        this.generation = -1;
         
         // It appears we have to set commands on the CodeMirror class, not the
         // instance. I'd like to be wrong, but since there should only be one CM
@@ -79,6 +80,7 @@ function($,
                     cm.setOption('mode', mode);
                 });
                 that.save_enabled = true;
+                that.generation = cm.changeGeneration();
             },
             function(error) {
                 cm.setValue("Error! " + error.message +
@@ -101,6 +103,8 @@ function($,
             content: this.codemirror.getValue(),
         };
         var that = this;
+        // record change generation for isClean
+        this.generation = this.codemirror.changeGeneration();
         return this.contents.save(this.file_path, model).then(function() {
             that.events.trigger("save_succeeded.TextEditor");
         });

--- a/IPython/html/static/edit/js/editor.js
+++ b/IPython/html/static/edit/js/editor.js
@@ -60,6 +60,7 @@ function($,
         indentUnit: 4,
         theme: "ipython",
         lineNumbers: true,
+        lineWrapping: true,
     };
     
     Editor.prototype.load = function() {

--- a/IPython/html/static/edit/js/editor.js
+++ b/IPython/html/static/edit/js/editor.js
@@ -81,6 +81,7 @@ function($,
                 });
                 that.save_enabled = true;
                 that.generation = cm.changeGeneration();
+                that.events.trigger("file_loaded.Editor", model);
             },
             function(error) {
                 cm.setValue("Error! " + error.message +
@@ -89,8 +90,26 @@ function($,
             }
         );
     };
+    
+    Editor.prototype.get_filename = function () {
+        return utils.url_path_split(this.file_path)[1];
 
-    Editor.prototype.save = function() {
+    }
+
+    Editor.prototype.rename = function (new_name) {
+        /** rename the file */
+        var that = this;
+        var parent = utils.url_path_split(this.file_path)[0];
+        var new_path = utils.url_path_join(parent, new_name);
+        return this.contents.rename(this.file_path, new_path).then(
+            function (json) {
+                that.file_path = json.path;
+                that.events.trigger('file_renamed.Editor', json);
+            }
+        );
+    };
+    
+    Editor.prototype.save = function () {
         /** save the file */
         if (!this.save_enabled) {
             console.log("Not saving, save disabled");
@@ -105,8 +124,8 @@ function($,
         var that = this;
         // record change generation for isClean
         this.generation = this.codemirror.changeGeneration();
-        return this.contents.save(this.file_path, model).then(function() {
-            that.events.trigger("save_succeeded.TextEditor");
+        return this.contents.save(this.file_path, model).then(function(data) {
+            that.events.trigger("file_saved.Editor", data);
         });
     };
     

--- a/IPython/html/static/edit/js/main.js
+++ b/IPython/html/static/edit/js/main.js
@@ -73,7 +73,7 @@ require([
     page.show();
 
     window.onbeforeunload = function () {
-        if (!editor.codemirror.isClean(editor.generation)) {
+        if (editor.save_enabled && !editor.codemirror.isClean(editor.generation)) {
             return "Unsaved changes will be lost. Close anyway?";
         }
     };

--- a/IPython/html/static/edit/js/main.js
+++ b/IPython/html/static/edit/js/main.js
@@ -19,7 +19,7 @@ require([
     events,
     contents,
     configmod,
-    editor,
+    editmod,
     menubar,
     notificationarea
     ){
@@ -28,10 +28,10 @@ require([
     var base_url = utils.get_body_data('baseUrl');
     var file_path = utils.get_body_data('filePath');
     contents = new contents.Contents({base_url: base_url});
-    var config = new configmod.ConfigSection('edit', {base_url: base_url})
+    var config = new configmod.ConfigSection('edit', {base_url: base_url});
     config.load();
     
-    var editor = new editor.Editor('#texteditor-container', {
+    var editor = new editmod.Editor('#texteditor-container', {
         base_url: base_url,
         events: events,
         contents: contents,
@@ -63,4 +63,11 @@ require([
     });
     editor.load();
     page.show();
+
+    window.onbeforeunload = function () {
+        if (!editor.codemirror.isClean(editor.generation)) {
+            return "Unsaved changes will be lost. Close anyway?";
+        }
+    };
+
 });

--- a/IPython/html/static/edit/js/main.js
+++ b/IPython/html/static/edit/js/main.js
@@ -10,6 +10,7 @@ require([
     'services/config',
     'edit/js/editor',
     'edit/js/menubar',
+    'edit/js/savewidget',
     'edit/js/notificationarea',
     'custom/custom',
 ], function(
@@ -21,6 +22,7 @@ require([
     configmod,
     editmod,
     menubar,
+    savewidget,
     notificationarea
     ){
     page = new page.Page();
@@ -44,6 +46,11 @@ require([
     
     var menus = new menubar.MenuBar('#menubar', {
         base_url: base_url,
+        editor: editor,
+        events: events,
+    });
+    
+    var save_widget = new savewidget.SaveWidget('span#save_widget', {
         editor: editor,
         events: events,
     });

--- a/IPython/html/static/edit/js/main.js
+++ b/IPython/html/static/edit/js/main.js
@@ -36,6 +36,7 @@ require([
         events: events,
         contents: contents,
         file_path: file_path,
+        config: config,
     });
     
     // Make it available for debugging
@@ -44,6 +45,7 @@ require([
     var menus = new menubar.MenuBar('#menubar', {
         base_url: base_url,
         editor: editor,
+        events: events,
     });
     
     var notification_area = new notificationarea.EditorNotificationArea(

--- a/IPython/html/static/edit/js/main.js
+++ b/IPython/html/static/edit/js/main.js
@@ -44,15 +44,16 @@ require([
     // Make it available for debugging
     IPython.editor = editor;
     
-    var menus = new menubar.MenuBar('#menubar', {
-        base_url: base_url,
+    var save_widget = new savewidget.SaveWidget('span#save_widget', {
         editor: editor,
         events: events,
     });
     
-    var save_widget = new savewidget.SaveWidget('span#save_widget', {
+    var menus = new menubar.MenuBar('#menubar', {
+        base_url: base_url,
         editor: editor,
         events: events,
+        save_widget: save_widget,
     });
     
     var notification_area = new notificationarea.EditorNotificationArea(

--- a/IPython/html/static/edit/js/menubar.js
+++ b/IPython/html/static/edit/js/menubar.js
@@ -125,7 +125,7 @@ define([
                 .text(modeinfo.name)
                 .attr(
                     'title',
-                    "The current highlighting mode is " + modeinfo.name
+                    "The current language is " + modeinfo.name
                 );
         });
     };
@@ -145,7 +145,7 @@ define([
                     .text(info.name)
                     .click(make_set_mode(info))
                     .attr('title',
-                        "Set highlighting mode to " + info.name
+                        "Set language to " + info.name
                     )
             ));
         }

--- a/IPython/html/static/edit/js/menubar.js
+++ b/IPython/html/static/edit/js/menubar.js
@@ -5,8 +5,9 @@ define([
     'base/js/namespace',
     'jquery',
     'base/js/utils',
+    'base/js/dialog',
     'bootstrap',
-], function(IPython, $, utils, bootstrap) {
+], function(IPython, $, utils, dialog, bootstrap) {
     "use strict";
     
     var MenuBar = function (selector, options) {
@@ -38,11 +39,30 @@ define([
     };
 
     MenuBar.prototype.bind_events = function () {
-        /**
-         *  File
-         */
         var that = this;
         var editor = that.editor;
+        
+        //  File
+        this.element.find('#new-file').click(function () {
+            var w = window.open();
+            // Create a new file in the current directory
+            var parent = utils.url_path_split(editor.file_path)[0];
+            editor.contents.new_untitled(parent, {type: "file"}).then(
+                function (data) {
+                    w.location = utils.url_join_encode(
+                        that.base_url, 'edit', data.path
+                    );
+                },
+                function(error) {
+                    w.close();
+                    dialog.modal({
+                        title : 'Creating New File Failed',
+                        body : "The error was: " + error.message,
+                        buttons : {'OK' : {'class' : 'btn-primary'}}
+                    });
+                }
+            );
+        });
         this.element.find('#save-file').click(function () {
             editor.save();
         });

--- a/IPython/html/static/edit/js/menubar.js
+++ b/IPython/html/static/edit/js/menubar.js
@@ -29,6 +29,7 @@ define([
         this.base_url = options.base_url || utils.get_body_data("baseUrl");
         this.selector = selector;
         this.editor = options.editor;
+        this.events = options.events;
 
         if (this.selector !== undefined) {
             this.element = $(selector);
@@ -41,8 +42,31 @@ define([
          *  File
          */
         var that = this;
-        this.element.find('#save_file').click(function () {
-            that.editor.save();
+        var editor = that.editor;
+        this.element.find('#save-file').click(function () {
+            editor.save();
+        });
+        
+        // Edit
+        this.element.find('#menu-find').click(function () {
+            editor.codemirror.execCommand("find");
+        });
+        this.element.find('#menu-replace').click(function () {
+            editor.codemirror.execCommand("replace");
+        });
+        
+        // View
+        this.element.find('#menu-line-numbers').click(function () {
+            var current = editor.codemirror.getOption('lineNumbers');
+            var value = Boolean(1-current);
+            editor.update_codemirror_options({lineNumbers: value});
+        });
+        
+        this.events.on("config_changed.Editor", function () {
+            var lineNumbers = editor.codemirror.getOption('lineNumbers');
+            var text = lineNumbers ? "Hide" : "Show";
+            text = text + " Line Numbers";
+            that.element.find('#menu-line-numbers').find("a").text(text);
         });
     };
 

--- a/IPython/html/static/edit/js/menubar.js
+++ b/IPython/html/static/edit/js/menubar.js
@@ -77,7 +77,7 @@ define([
         this.element.find('#menu-keymap-default').click(function () {
             editor.update_codemirror_options({
                 vimMode: false,
-                keyMap: null
+                keyMap: 'default'
             });
         });
         this.element.find('#menu-keymap-sublime').click(function () {

--- a/IPython/html/static/edit/js/menubar.js
+++ b/IPython/html/static/edit/js/menubar.js
@@ -2,12 +2,14 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'jquery',
+    'base/js/namespace',
     'base/js/utils',
     'base/js/dialog',
+    'codemirror/lib/codemirror',
+    'codemirror/mode/meta',
     'bootstrap',
-], function(IPython, $, utils, dialog, bootstrap) {
+], function($, IPython, utils, dialog, CodeMirror) {
     "use strict";
     
     var MenuBar = function (selector, options) {
@@ -37,6 +39,7 @@ define([
             this.element = $(selector);
             this.bind_events();
         }
+        this._load_mode_menu();
         Object.seal(this);
     };
 
@@ -120,6 +123,36 @@ define([
             that.element.find(".selected-keymap").removeClass("selected-keymap");
             that.element.find("#menu-keymap-" + keyMap).addClass("selected-keymap");
         });
+        
+        this.events.on("mode_changed.Editor", function (evt, modeinfo) {
+            that.element.find("#current-mode")
+                .text(modeinfo.name)
+                .attr(
+                    'title',
+                    "The current highlighting mode is " + modeinfo.name
+                );
+        });
+    };
+    
+    MenuBar.prototype._load_mode_menu = function () {
+        var list = this.element.find("#mode-menu");
+        var editor = this.editor;
+        function make_set_mode(info) {
+            return function () {
+                editor.set_codemirror_mode(info);
+            };
+        }
+        for (var i = 0; i < CodeMirror.modeInfo.length; i++) {
+            var info = CodeMirror.modeInfo[i];
+            list.append($("<li>").append(
+                $("<a>").attr("href", "#")
+                    .text(info.name)
+                    .click(make_set_mode(info))
+                    .attr('title',
+                        "Set highlighting mode to " + info.name
+                    )
+            ));
+        }
     };
 
     return {'MenuBar': MenuBar};

--- a/IPython/html/static/edit/js/menubar.js
+++ b/IPython/html/static/edit/js/menubar.js
@@ -54,6 +54,30 @@ define([
         this.element.find('#menu-replace').click(function () {
             editor.codemirror.execCommand("replace");
         });
+        this.element.find('#menu-keymap-default').click(function () {
+            editor.update_codemirror_options({
+                vimMode: false,
+                keyMap: null
+            });
+        });
+        this.element.find('#menu-keymap-sublime').click(function () {
+            editor.update_codemirror_options({
+                vimMode: false,
+                keyMap: 'sublime'
+            });
+        });
+        this.element.find('#menu-keymap-emacs').click(function () {
+            editor.update_codemirror_options({
+                vimMode: false,
+                keyMap: 'emacs'
+            });
+        });
+        this.element.find('#menu-keymap-vim').click(function () {
+            editor.update_codemirror_options({
+                vimMode: true,
+                keyMap: 'vim'
+            });
+        });
         
         // View
         this.element.find('#menu-line-numbers').click(function () {
@@ -67,6 +91,9 @@ define([
             var text = lineNumbers ? "Hide" : "Show";
             text = text + " Line Numbers";
             that.element.find('#menu-line-numbers').find("a").text(text);
+            var keyMap = editor.codemirror.getOption('keyMap') || "default";
+            that.element.find(".selected-keymap").removeClass("selected-keymap");
+            that.element.find("#menu-keymap-" + keyMap).addClass("selected-keymap");
         });
     };
 

--- a/IPython/html/static/edit/js/menubar.js
+++ b/IPython/html/static/edit/js/menubar.js
@@ -115,10 +115,6 @@ define([
         });
         
         this.events.on("config_changed.Editor", function () {
-            var lineNumbers = editor.codemirror.getOption('lineNumbers');
-            var text = lineNumbers ? "Hide" : "Show";
-            text = text + " Line Numbers";
-            that.element.find('#menu-line-numbers').find("a").text(text);
             var keyMap = editor.codemirror.getOption('keyMap') || "default";
             that.element.find(".selected-keymap").removeClass("selected-keymap");
             that.element.find("#menu-keymap-" + keyMap).addClass("selected-keymap");

--- a/IPython/html/static/edit/js/menubar.js
+++ b/IPython/html/static/edit/js/menubar.js
@@ -31,11 +31,13 @@ define([
         this.selector = selector;
         this.editor = options.editor;
         this.events = options.events;
+        this.save_widget = options.save_widget;
 
         if (this.selector !== undefined) {
             this.element = $(selector);
             this.bind_events();
         }
+        Object.seal(this);
     };
 
     MenuBar.prototype.bind_events = function () {
@@ -65,6 +67,9 @@ define([
         });
         this.element.find('#save-file').click(function () {
             editor.save();
+        });
+        this.element.find('#rename-file').click(function () {
+            that.save_widget.rename();
         });
         
         // Edit

--- a/IPython/html/static/edit/js/savewidget.js
+++ b/IPython/html/static/edit/js/savewidget.js
@@ -1,0 +1,202 @@
+// Copyright (c) IPython Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+define([
+    'base/js/namespace',
+    'jquery',
+    'base/js/utils',
+    'base/js/dialog',
+    'base/js/keyboard',
+    'moment',
+], function(IPython, $, utils, dialog, keyboard, moment) {
+    "use strict";
+
+    var SaveWidget = function (selector, options) {
+        this.editor = undefined;
+        this.selector = selector;
+        this.events = options.events;
+        this.editor = options.editor;
+        this._last_modified = undefined;
+        this.keyboard_manager = options.keyboard_manager;
+        if (this.selector !== undefined) {
+            this.element = $(selector);
+            this.bind_events();
+        }
+    };
+
+
+    SaveWidget.prototype.bind_events = function () {
+        var that = this;
+        this.element.find('span.filename').click(function () {
+            that.rename({editor: that.editor});
+        });
+        this.events.on('file_loaded.Editor', function (evt, model) {
+            that.update_filename(model.name);
+            that.update_document_title(model.name);
+            that.update_last_modified(model.last_modified);
+        });
+        this.events.on('file_saved.Editor', function (evt, model) {
+            that.update_filename(model.name);
+            that.update_document_title(model.name);
+            that.update_last_modified(model.last_modified);
+        });
+        this.events.on('file_renamed.Editor', function (evt, model) {
+            that.update_filename(model.name);
+            that.update_document_title(model.name);
+            that.update_address_bar(model.path);
+        });
+        this.events.on('file_save_failed.Editor', function () {
+            that.set_save_status('Save Failed!');
+        });
+    };
+
+
+    SaveWidget.prototype.rename = function (options) {
+        options = options || {};
+        var that = this;
+        var dialog_body = $('<div/>').append(
+            $("<p/>").addClass("rename-message")
+                .text('Enter a new filename:')
+        ).append(
+            $("<br/>")
+        ).append(
+            $('<input/>').attr('type','text').attr('size','25').addClass('form-control')
+            .val(options.editor.get_filename())
+        );
+        var d = dialog.modal({
+            title: "Rename File",
+            body: dialog_body,
+            buttons : {
+                "OK": {
+                    class: "btn-primary",
+                    click: function () {
+                        var new_name = d.find('input').val();
+                        d.find('.rename-message').text("Renaming...");
+                        d.find('input[type="text"]').prop('disabled', true);
+                        that.editor.rename(new_name).then(
+                            function () {
+                                d.modal('hide');
+                            }, function (error) {
+                                d.find('.rename-message').text(error.message || 'Unknown error');
+                                d.find('input[type="text"]').prop('disabled', false).focus().select();
+                            }
+                        );
+                        return false;
+                    }
+                },
+                "Cancel": {}
+                },
+            open : function () {
+                // Upon ENTER, click the OK button.
+                d.find('input[type="text"]').keydown(function (event) {
+                    if (event.which === keyboard.keycodes.enter) {
+                        d.find('.btn-primary').first().click();
+                        return false;
+                    }
+                });
+                d.find('input[type="text"]').focus().select();
+            }
+        });
+    };
+
+
+    SaveWidget.prototype.update_filename = function (filename) {
+        this.element.find('span.filename').text(filename);
+    };
+
+    SaveWidget.prototype.update_document_title = function (filename) {
+        document.title = filename;
+    };
+
+    SaveWidget.prototype.update_address_bar = function (path) {
+        var state = {path : path};
+        window.history.replaceState(state, "", utils.url_join_encode(
+            this.editor.base_url,
+            "edit",
+            path)
+        );
+    };
+
+    SaveWidget.prototype.update_last_modified = function (last_modified) {
+        if (last_modified) {
+            this._last_modified = new Date(last_modified);
+        } else {
+            this._last_modified = null;
+        }
+        this._render_last_modified();
+    };
+    
+    SaveWidget.prototype._render_last_modified = function () {
+        /** actually set the text in the element, from our _last_modified value
+        
+        called directly, and periodically in timeouts.
+        */
+        this._schedule_render_last_modified();
+        var el = this.element.find('span.last_modified');
+        if (!this._last_modified) {
+            el.text('').attr('title', 'never saved');
+            return;
+        }
+        var chkd = moment(this._last_modified);
+        var long_date = chkd.format('llll');
+        var human_date;
+        var tdelta = Math.ceil(new Date() - this._last_modified);
+        if (tdelta < 24 * H){
+            // less than 24 hours old, use relative date
+            human_date = chkd.fromNow();
+        } else {
+            // otherwise show calendar 
+            // otherwise update every hour and show
+            // <Today | yesterday|...> at hh,mm,ss
+            human_date = chkd.calendar();
+        }
+        el.text(human_date).attr('title', long_date);
+    };
+
+    
+    var S = 1000;
+    var M = 60*S;
+    var H = 60*M;
+    var thresholds = {
+        s: 45 * S,
+        m: 45 * M,
+        h: 22 * H
+    };
+    var _timeout_from_dt = function (ms) {
+        /** compute a timeout to update the last-modified timeout
+        
+        based on the delta in milliseconds
+        */
+        if (ms < thresholds.s) {
+            return 5 * S;
+        } else if (ms < thresholds.m) {
+            return M;
+        } else {
+            return 5 * M;
+        }
+    };
+    
+    SaveWidget.prototype._schedule_render_last_modified = function () {
+        /** schedule the next update to relative date
+        
+        periodically updated, so short values like 'a few seconds ago' don't get stale.
+        */
+        var that = this;
+        if (!this._last_modified) {
+            return;
+        }
+        if ((this._last_modified_timeout)) {
+            clearTimeout(this._last_modified_timeout);
+        }
+        var dt = Math.ceil(new Date() - this._last_modified);
+        if (dt < 24 * H) {
+            this._last_modified_timeout = setTimeout(
+                $.proxy(this._render_last_modified, this),
+                _timeout_from_dt(dt)
+            );
+        }
+    };
+
+    return {'SaveWidget': SaveWidget};
+
+});

--- a/IPython/html/static/edit/js/savewidget.js
+++ b/IPython/html/static/edit/js/savewidget.js
@@ -28,7 +28,7 @@ define([
     SaveWidget.prototype.bind_events = function () {
         var that = this;
         this.element.find('span.filename').click(function () {
-            that.rename({editor: that.editor});
+            that.rename();
         });
         this.events.on('file_loaded.Editor', function (evt, model) {
             that.update_filename(model.name);
@@ -61,7 +61,7 @@ define([
             $("<br/>")
         ).append(
             $('<input/>').attr('type','text').attr('size','25').addClass('form-control')
-            .val(options.editor.get_filename())
+            .val(that.editor.get_filename())
         );
         var d = dialog.modal({
             title: "Rename File",

--- a/IPython/html/static/edit/less/edit.less
+++ b/IPython/html/static/edit/less/edit.less
@@ -1,0 +1,9 @@
+#texteditor-container {
+    border-bottom: 1px solid #ccc;
+}
+
+#filename {
+    font-size: 16pt;
+    display: table;
+    padding: 0px 5px;
+}

--- a/IPython/html/static/edit/less/menubar.less
+++ b/IPython/html/static/edit/less/menubar.less
@@ -6,3 +6,9 @@
     content: @fa-var-check;
   }
 }
+
+#mode-menu {
+  // truncate mode-menu, so it doesn't get longer than the screen
+  overflow: auto;
+  max-height: 20em;
+}

--- a/IPython/html/static/edit/less/menubar.less
+++ b/IPython/html/static/edit/less/menubar.less
@@ -1,0 +1,8 @@
+.selected-keymap {
+  i.fa {
+    padding: 0px 5px;
+  }
+  i.fa:before {
+    content: @fa-var-check;
+  }
+}

--- a/IPython/html/static/edit/less/style.less
+++ b/IPython/html/static/edit/less/style.less
@@ -1,0 +1,7 @@
+/*!
+*
+* IPython text editor webapp
+*
+*/
+@import "menubar.less";
+@import "edit.less";

--- a/IPython/html/static/notebook/js/savewidget.js
+++ b/IPython/html/static/notebook/js/savewidget.js
@@ -223,7 +223,7 @@ define([
 
         // update regularly for the first 6hours and show
         // <x time> ago
-        if(tdelta < tdelta < 6*3600*1000){  
+        if(tdelta < 6*3600*1000){  
             recall(_next_timeago_update(tdelta));
             this._set_checkpoint_status(chkd.fromNow(), longdate);
         // otherwise update every hour and show

--- a/IPython/html/static/notebook/js/savewidget.js
+++ b/IPython/html/static/notebook/js/savewidget.js
@@ -29,7 +29,7 @@ define([
 
     SaveWidget.prototype.bind_events = function () {
         var that = this;
-        this.element.find('span#notebook_name').click(function () {
+        this.element.find('span.filename').click(function () {
             that.rename_notebook({notebook: that.notebook});
         });
         this.events.on('notebook_loaded.Notebook', function () {
@@ -130,7 +130,7 @@ define([
 
     SaveWidget.prototype.update_notebook_name = function () {
         var nbname = this.notebook.get_notebook_name();
-        this.element.find('span#notebook_name').text(nbname);
+        this.element.find('span.filename').text(nbname);
     };
 
 
@@ -152,11 +152,11 @@ define([
 
 
     SaveWidget.prototype.set_save_status = function (msg) {
-        this.element.find('span#autosave_status').text(msg);
+        this.element.find('span.autosave_status').text(msg);
     };
 
     SaveWidget.prototype._set_checkpoint_status = function (human_date, iso_date) {
-        var el = this.element.find('span#checkpoint_status');
+        var el = this.element.find('span.checkpoint_status');
         if(human_date){
             el.text("Last Checkpoint: "+human_date).attr('title',iso_date);
         } else {

--- a/IPython/html/static/notebook/less/kernelselector.less
+++ b/IPython/html/static/notebook/less/kernelselector.less
@@ -1,11 +1,9 @@
 #kernel_selector_widget {
     margin-right: 1em;
-    float:right;
+    float: right;
 
     & > button {
-        .btn();
         .btn-default();
-        .btn-sm();
         
         & > span.caret {
             margin-top:0px;

--- a/IPython/html/static/notebook/less/menubar.less
+++ b/IPython/html/static/notebook/less/menubar.less
@@ -1,13 +1,10 @@
 #menubar {
-  margin-top: 0px;
-  margin-bottom: -24px;
-  position: relative;
   .border-box-sizing();
 
   .navbar {
     border-top: 1px;
     border-radius: 0px 0px @border-radius-base @border-radius-base;
-    margin-bottom: 23px;
+    margin-bottom: 6px;
   }
   
   .navbar-toggle {
@@ -17,19 +14,6 @@
     clear: left;
   }
   
-  li.dropdown {
-    line-height: 12px;
-
-    a {
-      padding-top: 6px;
-      padding-bottom: 5px;
-    }
-  }
-
-  ul.navbar-right {
-    padding-top: 2px;
-    margin-bottom: 0px;
-  }
 }
 
 .nav-wrapper {
@@ -47,10 +31,6 @@ ul#help_menu li a{
     i {
         margin-right: -1.2em;
     }
-}
-
-#menus {
-  min-height: 30px;
 }
 
 // Make sub menus work in BS3.

--- a/IPython/html/static/notebook/less/notebook.less
+++ b/IPython/html/static/notebook/less/notebook.less
@@ -15,20 +15,6 @@ body {
     .border-box-sizing();
 }
 
-span#notebook_name {
-    height: 1em;
-    line-height: 1em;
-    padding: 3px;
-    border: none;
-    font-size: 146.5%;
-    &:hover{
-        // ensure body is lighter on dark palette, 
-        // and vice versa
-        background-color:contrast(@body-bg, lighten(@body-bg,30%), darken(@body-bg,10%));
-    }
-    .corner-all;
-}
-
 div#notebook_panel {
     margin: 0px 0px 0px 0px;
     padding: 0px;

--- a/IPython/html/static/notebook/less/notificationarea.less
+++ b/IPython/html/static/notebook/less/notificationarea.less
@@ -1,13 +1,12 @@
 #notification_area {
     .pull-right();
-    
     z-index: 10;
 }
 
 .indicator_area {
     color: @navbar-default-link-color;
-    padding: 4px 3px;
-    margin: 0px;
+    margin-left: 5px;
+    margin-right: 5px;
     width: 11px;
     z-index: 10;
     text-align: center;
@@ -16,15 +15,11 @@
 #kernel_indicator {
     .pull-right();
     .indicator_area();
-
-    margin-right: 12px;
 }
 
 #modal_indicator {
     .pull-right();
     .indicator_area();
-    
-    margin-right: 5px;
 }
 
 .edit_mode_icon:before {

--- a/IPython/html/static/notebook/less/notificationwidget.less
+++ b/IPython/html/static/notebook/less/notificationwidget.less
@@ -1,19 +1,8 @@
 .notification_widget {
     color: @navbar-default-link-color;
-    padding: 1px 12px;
-    margin: 2px 4px;
     z-index: 10;
-    border-radius: @border-radius-base;
     background: @notification_widget_bg;
-    .pull-right();
-    .border-box-sizing();
-    .btn();
     .btn-default();
-    .btn-xs();
-
-    &.span {
-        padding-right:2px;
-    }
 }
 
 .notification_widget.warning {

--- a/IPython/html/static/notebook/less/savewidget.less
+++ b/IPython/html/static/notebook/less/savewidget.less
@@ -1,33 +1,41 @@
-span#save_widget {
+span.save_widget {
     margin-top: 6px;
+    
+    span.filename {
+        height: 1em;
+        line-height: 1em;
+        padding: 3px;
+        border: none;
+        font-size: 146.5%;
+        &:hover{
+            // ensure body is lighter on dark palette, 
+            // and vice versa
+            background-color:contrast(@body-bg, lighten(@body-bg,30%), darken(@body-bg,10%));
+        }
+        .corner-all;
+    }
 }
 
-span#checkpoint_status, span#autosave_status {
+span.checkpoint_status, span.autosave_status {
     font-size: small;
 }
 
 @media (max-width: 767px) {
-    span#save_widget {
+    span.save_widget {
         font-size: small;
     }
-    span#checkpoint_status, span#autosave_status {
-        font-size: x-small;
-    }
-}
-
-@media (max-width: 767px) {
-    span#checkpoint_status, span#autosave_status {
-        display: none;
+    span.checkpoint_status, span.autosave_status {
+      display: none;
     }
 }
 
 @media (min-width: 768px) and (max-width: 979px) {
-    span#checkpoint_status {
+    span.checkpoint_status {
         display: none;
     }
-    span#autosave_status {
+    span.autosave_status {
         font-size: x-small;
     }
 }
 
-  
+

--- a/IPython/html/static/notebook/less/savewidget.less
+++ b/IPython/html/static/notebook/less/savewidget.less
@@ -1,6 +1,5 @@
 span#save_widget {
-    padding: 0px 5px;
-    margin-top: 12px;
+    margin-top: 6px;
 }
 
 span#checkpoint_status, span#autosave_status {

--- a/IPython/html/static/services/contents.js
+++ b/IPython/html/static/services/contents.js
@@ -161,6 +161,7 @@ define([
         var settings = {
             processData : false,
             type : "PUT",
+            dataType: "json",
             data : JSON.stringify(model),
             contentType: 'application/json',
         };

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -495,7 +495,7 @@ div.input {
 }
 /* input_area and input_prompt must match in top border and margin for alignment */
 div.input_prompt {
-  color: #000080;
+  color: navy;
   border-top: 1px solid transparent;
 }
 div.input_area > div.highlight {
@@ -767,7 +767,7 @@ div.out_prompt_overlay:hover {
   background: rgba(240, 240, 240, 0.5);
 }
 div.output_prompt {
-  color: #8b0000;
+  color: darkred;
 }
 /* This class is the outer container of all output sections. */
 div.output_area {
@@ -840,7 +840,7 @@ div.output_area pre {
   padding: 0;
   border: 0;
   vertical-align: baseline;
-  color: #000000;
+  color: black;
   background-color: transparent;
   border-radius: 0;
 }
@@ -1033,8 +1033,8 @@ div.output_unrecognized a:hover {
   margin-top: 1em;
 }
 .rendered_html hr {
-  color: #000000;
-  background-color: #000000;
+  color: black;
+  background-color: black;
 }
 .rendered_html pre {
   margin: 1em 2em;
@@ -1053,13 +1053,13 @@ div.output_unrecognized a:hover {
 .rendered_html table {
   margin-left: auto;
   margin-right: auto;
-  border: 1px solid #000000;
+  border: 1px solid black;
   border-collapse: collapse;
 }
 .rendered_html tr,
 .rendered_html th,
 .rendered_html td {
-  border: 1px solid #000000;
+  border: 1px solid black;
   border-collapse: collapse;
   margin: 1em 2em;
 }
@@ -1559,4 +1559,4 @@ h6:hover .anchor-link {
   left: 0px !important;
   margin-left: 0px !important;
 }
-/*# sourceMappingURL=../style/ipython.min.css.map */
+/*# sourceMappingURL=ipython.min.css.map */

--- a/IPython/html/static/style/style.less
+++ b/IPython/html/static/style/style.less
@@ -23,6 +23,9 @@
 // tree
 @import "../tree/less/style.less";
 
+// edit
+@import "../edit/less/style.less";
+
 // notebook
 @import "../notebook/less/style.less";
 

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8119,6 +8119,25 @@ ul#new-notebook-menu {
 }
 /*!
 *
+* IPython text editor webapp
+*
+*/
+.selected-keymap i.fa {
+  padding: 0px 5px;
+}
+.selected-keymap i.fa:before {
+  content: "\f00c";
+}
+#texteditor-container {
+  border-bottom: 1px solid #ccc;
+}
+#filename {
+  font-size: 16pt;
+  display: table;
+  padding: 0px 5px;
+}
+/*!
+*
 * IPython notebook
 *
 */

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -3636,7 +3636,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 }
 .navbar {
   position: relative;
-  min-height: 36px;
+  min-height: 30px;
   margin-bottom: 18px;
   border: 1px solid transparent;
 }
@@ -3733,10 +3733,10 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 }
 .navbar-brand {
   float: left;
-  padding: 9px 15px;
+  padding: 6px 15px;
   font-size: 17px;
   line-height: 18px;
-  height: 36px;
+  height: 30px;
 }
 .navbar-brand:hover,
 .navbar-brand:focus {
@@ -3753,8 +3753,8 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   float: right;
   margin-right: 15px;
   padding: 9px 10px;
-  margin-top: 1px;
-  margin-bottom: 1px;
+  margin-top: -2px;
+  margin-bottom: -2px;
   background-color: transparent;
   background-image: none;
   border: 1px solid transparent;
@@ -3778,7 +3778,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   }
 }
 .navbar-nav {
-  margin: 4.5px -15px;
+  margin: 3px -15px;
 }
 .navbar-nav > li > a {
   padding-top: 10px;
@@ -3816,8 +3816,8 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
     float: left;
   }
   .navbar-nav > li > a {
-    padding-top: 9px;
-    padding-bottom: 9px;
+    padding-top: 6px;
+    padding-bottom: 6px;
   }
   .navbar-nav.navbar-right:last-child {
     margin-right: -15px;
@@ -3841,8 +3841,8 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   border-bottom: 1px solid transparent;
   -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 1px 0 rgba(255, 255, 255, 0.1);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 1px 0 rgba(255, 255, 255, 0.1);
-  margin-top: 2px;
-  margin-bottom: 2px;
+  margin-top: -1px;
+  margin-bottom: -1px;
 }
 @media (min-width: 768px) {
   .navbar-form .form-group {
@@ -3909,20 +3909,20 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   border-bottom-left-radius: 0;
 }
 .navbar-btn {
-  margin-top: 2px;
-  margin-bottom: 2px;
+  margin-top: -1px;
+  margin-bottom: -1px;
 }
 .navbar-btn.btn-sm {
-  margin-top: 3px;
-  margin-bottom: 3px;
+  margin-top: 0px;
+  margin-bottom: 0px;
 }
 .navbar-btn.btn-xs {
-  margin-top: 7px;
-  margin-bottom: 7px;
+  margin-top: 4px;
+  margin-bottom: 4px;
 }
 .navbar-text {
-  margin-top: 9px;
-  margin-bottom: 9px;
+  margin-top: 6px;
+  margin-bottom: 6px;
 }
 @media (min-width: 540px) {
   .navbar-text {
@@ -7751,19 +7751,17 @@ body {
 div#header {
   /* Initially hidden to prevent FLOUC */
   display: none;
-  margin-bottom: -6px;
-  position: fixed;
-  top: 0;
-  width: 100%;
   background-color: #ffffff;
-  min-height: 31px;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
   /* Display over codemirror */
   z-index: 100;
 }
 div#header #header-container {
-  margin-bottom: 0px;
   padding-left: 30px;
   padding-bottom: 5px;
+  padding-top: 5px;
   box-sizing: border-box;
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
@@ -7779,6 +7777,8 @@ div#header .header-bar {
 }
 #ipython_notebook {
   padding-left: 0px;
+  padding-top: 3px;
+  padding-bottom: 3px;
 }
 #noscript {
   width: auto;
@@ -7810,77 +7810,14 @@ div#header .header-bar {
 input.ui-button {
   padding: 0.3em 0.9em;
 }
-.navbar span {
-  margin-top: 3px;
-}
 span#login_widget {
   float: right;
 }
 span#login_widget > .button,
 #logout {
-  display: inline-block;
-  margin-bottom: 0;
-  font-weight: normal;
-  text-align: center;
-  vertical-align: middle;
-  cursor: pointer;
-  background-image: none;
-  border: 1px solid transparent;
-  white-space: nowrap;
-  padding: 6px 12px;
-  font-size: 13px;
-  line-height: 1.42857143;
-  border-radius: 4px;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   color: #333333;
   background-color: #ffffff;
   border-color: #cccccc;
-  padding: 5px 10px;
-  font-size: 12px;
-  line-height: 1.5;
-  border-radius: 3px;
-}
-span#login_widget > .button:focus,
-#logout:focus,
-span#login_widget > .button:active:focus,
-#logout:active:focus,
-span#login_widget > .button.active:focus,
-#logout.active:focus {
-  outline: thin dotted;
-  outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px;
-}
-span#login_widget > .button:hover,
-#logout:hover,
-span#login_widget > .button:focus,
-#logout:focus {
-  color: #333333;
-  text-decoration: none;
-}
-span#login_widget > .button:active,
-#logout:active,
-span#login_widget > .button.active,
-#logout.active {
-  outline: 0;
-  background-image: none;
-  -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-}
-span#login_widget > .button.disabled,
-#logout.disabled,
-span#login_widget > .button[disabled],
-#logout[disabled],
-fieldset[disabled] span#login_widget > .button,
-fieldset[disabled] #logout {
-  cursor: not-allowed;
-  pointer-events: none;
-  opacity: 0.65;
-  filter: alpha(opacity=65);
-  -webkit-box-shadow: none;
-  box-shadow: none;
 }
 span#login_widget > .button:hover,
 #logout:hover,
@@ -8401,7 +8338,7 @@ div.input {
 }
 /* input_area and input_prompt must match in top border and margin for alignment */
 div.input_prompt {
-  color: #000080;
+  color: navy;
   border-top: 1px solid transparent;
 }
 div.input_area > div.highlight {
@@ -8673,7 +8610,7 @@ div.out_prompt_overlay:hover {
   background: rgba(240, 240, 240, 0.5);
 }
 div.output_prompt {
-  color: #8b0000;
+  color: darkred;
 }
 /* This class is the outer container of all output sections. */
 div.output_area {
@@ -8746,7 +8683,7 @@ div.output_area pre {
   padding: 0;
   border: 0;
   vertical-align: baseline;
-  color: #000000;
+  color: black;
   background-color: transparent;
   border-radius: 0;
 }
@@ -8939,8 +8876,8 @@ div.output_unrecognized a:hover {
   margin-top: 1em;
 }
 .rendered_html hr {
-  color: #000000;
-  background-color: #000000;
+  color: black;
+  background-color: black;
 }
 .rendered_html pre {
   margin: 1em 2em;
@@ -8959,13 +8896,13 @@ div.output_unrecognized a:hover {
 .rendered_html table {
   margin-left: auto;
   margin-right: auto;
-  border: 1px solid #000000;
+  border: 1px solid black;
   border-collapse: collapse;
 }
 .rendered_html tr,
 .rendered_html th,
 .rendered_html td {
-  border: 1px solid #000000;
+  border: 1px solid black;
   border-collapse: collapse;
   margin: 1em 2em;
 }
@@ -9700,59 +9637,9 @@ select[multiple].celltoolbar select {
   float: right;
 }
 #kernel_selector_widget > button {
-  display: inline-block;
-  margin-bottom: 0;
-  font-weight: normal;
-  text-align: center;
-  vertical-align: middle;
-  cursor: pointer;
-  background-image: none;
-  border: 1px solid transparent;
-  white-space: nowrap;
-  padding: 6px 12px;
-  font-size: 13px;
-  line-height: 1.42857143;
-  border-radius: 4px;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   color: #333333;
   background-color: #ffffff;
   border-color: #cccccc;
-  padding: 5px 10px;
-  font-size: 12px;
-  line-height: 1.5;
-  border-radius: 3px;
-}
-#kernel_selector_widget > button:focus,
-#kernel_selector_widget > button:active:focus,
-#kernel_selector_widget > button.active:focus {
-  outline: thin dotted;
-  outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px;
-}
-#kernel_selector_widget > button:hover,
-#kernel_selector_widget > button:focus {
-  color: #333333;
-  text-decoration: none;
-}
-#kernel_selector_widget > button:active,
-#kernel_selector_widget > button.active {
-  outline: 0;
-  background-image: none;
-  -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-}
-#kernel_selector_widget > button.disabled,
-#kernel_selector_widget > button[disabled],
-fieldset[disabled] #kernel_selector_widget > button {
-  cursor: not-allowed;
-  pointer-events: none;
-  opacity: 0.65;
-  filter: alpha(opacity=65);
-  -webkit-box-shadow: none;
-  box-shadow: none;
 }
 #kernel_selector_widget > button:hover,
 #kernel_selector_widget > button:focus,
@@ -9795,8 +9682,6 @@ fieldset[disabled] #kernel_selector_widget > button.active {
 }
 #menubar {
   margin-top: 0px;
-  margin-bottom: -24px;
-  position: relative;
   box-sizing: border-box;
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
@@ -9804,24 +9689,13 @@ fieldset[disabled] #kernel_selector_widget > button.active {
 #menubar .navbar {
   border-top: 1px;
   border-radius: 0px 0px 4px 4px;
-  margin-bottom: 23px;
+  margin-bottom: 6px;
 }
 #menubar .navbar-toggle {
   float: left;
 }
 #menubar .navbar-collapse {
   clear: left;
-}
-#menubar li.dropdown {
-  line-height: 12px;
-}
-#menubar li.dropdown a {
-  padding-top: 6px;
-  padding-bottom: 5px;
-}
-#menubar ul.navbar-right {
-  padding-top: 2px;
-  margin-bottom: 0px;
 }
 .nav-wrapper {
   border-bottom: 1px solid #e7e7e7;
@@ -9835,9 +9709,6 @@ ul#help_menu li a {
 }
 ul#help_menu li a i {
   margin-right: -1.2em;
-}
-#menus {
-  min-height: 30px;
 }
 .dropdown-submenu {
   position: relative;
@@ -9887,8 +9758,8 @@ ul#help_menu li a i {
 }
 .indicator_area {
   color: #777777;
-  padding: 4px 3px;
-  margin: 0px;
+  margin-left: 5px;
+  margin-right: 5px;
   width: 11px;
   z-index: 10;
   text-align: center;
@@ -9897,23 +9768,21 @@ ul#help_menu li a i {
   float: right !important;
   float: right;
   color: #777777;
-  padding: 4px 3px;
-  margin: 0px;
+  margin-left: 5px;
+  margin-right: 5px;
   width: 11px;
   z-index: 10;
   text-align: center;
-  margin-right: 12px;
 }
 #modal_indicator {
   float: right !important;
   float: right;
   color: #777777;
-  padding: 4px 3px;
-  margin: 0px;
+  margin-left: 5px;
+  margin-right: 5px;
   width: 11px;
   z-index: 10;
   text-align: center;
-  margin-right: 5px;
 }
 .edit_mode_icon:before {
   display: inline-block;
@@ -10007,68 +9876,11 @@ ul#help_menu li a i {
 }
 .notification_widget {
   color: #777777;
-  padding: 1px 12px;
-  margin: 2px 4px;
   z-index: 10;
   background: rgba(240, 240, 240, 0.5);
-  float: right !important;
-  float: right;
-  box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  display: inline-block;
-  margin-bottom: 0;
-  font-weight: normal;
-  text-align: center;
-  vertical-align: middle;
-  cursor: pointer;
-  background-image: none;
-  border: 1px solid transparent;
-  white-space: nowrap;
-  padding: 6px 12px;
-  font-size: 13px;
-  line-height: 1.42857143;
-  border-radius: 4px;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   color: #333333;
   background-color: #ffffff;
   border-color: #cccccc;
-  padding: 1px 5px;
-  font-size: 12px;
-  line-height: 1.5;
-  border-radius: 3px;
-}
-.notification_widget:focus,
-.notification_widget:active:focus,
-.notification_widget.active:focus {
-  outline: thin dotted;
-  outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px;
-}
-.notification_widget:hover,
-.notification_widget:focus {
-  color: #333333;
-  text-decoration: none;
-}
-.notification_widget:active,
-.notification_widget.active {
-  outline: 0;
-  background-image: none;
-  -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-}
-.notification_widget.disabled,
-.notification_widget[disabled],
-fieldset[disabled] .notification_widget {
-  cursor: not-allowed;
-  pointer-events: none;
-  opacity: 0.65;
-  filter: alpha(opacity=65);
-  -webkit-box-shadow: none;
-  box-shadow: none;
 }
 .notification_widget:hover,
 .notification_widget:focus,
@@ -10105,9 +9917,6 @@ fieldset[disabled] .notification_widget.active {
 .notification_widget .badge {
   color: #ffffff;
   background-color: #333333;
-}
-.notification_widget.span {
-  padding-right: 2px;
 }
 .notification_widget.warning {
   color: #ffffff;
@@ -10351,8 +10160,7 @@ div#pager .ui-resizable-handle {
   flex: 1;
 }
 span#save_widget {
-  padding: 0px 5px;
-  margin-top: 12px;
+  margin-top: 6px;
 }
 span#checkpoint_status,
 span#autosave_status {
@@ -10583,4 +10391,4 @@ span#autosave_status {
 #terminado-container {
   margin: 8px;
 }
-/*# sourceMappingURL=../style/style.min.css.map */
+/*# sourceMappingURL=style.min.css.map */

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8125,6 +8125,10 @@ ul#new-notebook-menu {
 .selected-keymap i.fa:before {
   content: "\f00c";
 }
+#mode-menu {
+  overflow: auto;
+  max-height: 20em;
+}
 #texteditor-container {
   border-bottom: 1px solid #ccc;
 }

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -7752,9 +7752,6 @@ div#header {
   /* Initially hidden to prevent FLOUC */
   display: none;
   background-color: #ffffff;
-  box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
   /* Display over codemirror */
   z-index: 100;
 }
@@ -9440,17 +9437,6 @@ body {
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
 }
-span#notebook_name {
-  height: 1em;
-  line-height: 1em;
-  padding: 3px;
-  border: none;
-  font-size: 146.5%;
-  border-radius: 4px;
-}
-span#notebook_name:hover {
-  background-color: #e6e6e6;
-}
 div#notebook_panel {
   margin: 0px 0px 0px 0px;
   padding: 0px;
@@ -9700,7 +9686,6 @@ fieldset[disabled] #kernel_selector_widget > button.active {
   margin-top: 0px;
 }
 #menubar {
-  margin-top: 0px;
   box-sizing: border-box;
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
@@ -10178,33 +10163,38 @@ div#pager .ui-resizable-handle {
   /* Modern browsers */
   flex: 1;
 }
-span#save_widget {
+span.save_widget {
   margin-top: 6px;
 }
-span#checkpoint_status,
-span#autosave_status {
+span.save_widget span.filename {
+  height: 1em;
+  line-height: 1em;
+  padding: 3px;
+  border: none;
+  font-size: 146.5%;
+  border-radius: 4px;
+}
+span.save_widget span.filename:hover {
+  background-color: #e6e6e6;
+}
+span.checkpoint_status,
+span.autosave_status {
   font-size: small;
 }
 @media (max-width: 767px) {
-  span#save_widget {
+  span.save_widget {
     font-size: small;
   }
-  span#checkpoint_status,
-  span#autosave_status {
-    font-size: x-small;
-  }
-}
-@media (max-width: 767px) {
-  span#checkpoint_status,
-  span#autosave_status {
+  span.checkpoint_status,
+  span.autosave_status {
     display: none;
   }
 }
 @media (min-width: 768px) and (max-width: 979px) {
-  span#checkpoint_status {
+  span.checkpoint_status {
     display: none;
   }
-  span#autosave_status {
+  span.autosave_status {
     font-size: x-small;
   }
 }

--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -229,7 +229,7 @@ define([
     NotebookList.uri_prefixes = {
         directory: 'tree',
         notebook: 'notebooks',
-        file: 'files',
+        file: 'edit',
     };
 
 

--- a/IPython/html/templates/edit.html
+++ b/IPython/html/templates/edit.html
@@ -63,7 +63,7 @@ data-file-path="{{file_path}}"
                 <li id="menu-line-numbers"><a href="#">Toggle Line Numbers</a></li>
               </ul>
             </li>
-            <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Mode</a>
+            <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Language</a>
               <ul id="mode-menu" class="dropdown-menu">
               </ul>
             </li>

--- a/IPython/html/templates/edit.html
+++ b/IPython/html/templates/edit.html
@@ -43,6 +43,7 @@ data-file-path="{{file_path}}"
               <ul id="file-menu" class="dropdown-menu">
                 <li id="new-file"><a href="#">New</a></li>
                 <li id="save-file"><a href="#">Save</a></li>
+                <li id="rename-file"><a href="#">Rename</a></li>
               </ul>
             </li>
             <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Edit</a>

--- a/IPython/html/templates/edit.html
+++ b/IPython/html/templates/edit.html
@@ -5,18 +5,6 @@
 {% block stylesheet %}
 <link rel="stylesheet" href="{{ static_url('components/codemirror/lib/codemirror.css') }}">
 <link rel="stylesheet" href="{{ static_url('components/codemirror/addon/dialog/dialog.css') }}">
-<style>
-#texteditor-container {
-    border-bottom: 1px solid #ccc;
-}
-
-#filename {
-    font-size: 16pt;
-    display: table;
-    padding: 0px 5px;
-}
-</style>
-
 {{super()}}
 {% endblock %}
 

--- a/IPython/html/templates/edit.html
+++ b/IPython/html/templates/edit.html
@@ -47,7 +47,7 @@ data-file-path="{{file_path}}"
                 <li id="menu-find"><a href="#">Find</a></li>
                 <li id="menu-replace"><a href="#">Find &amp; Replace</a></li>
                 <li class="divider"></li>
-                <li>Key Map</li>
+                <li class="dropdown-header">Key Map</li>
                 <li id="menu-keymap-default"><a href="#">Default<i class="fa"></i></a></li>
                 <li id="menu-keymap-sublime"><a href="#">Sublime Text<i class="fa"></i></a></li>
                 <li id="menu-keymap-vim"><a href="#">Vim<i class="fa"></i></a></li>

--- a/IPython/html/templates/edit.html
+++ b/IPython/html/templates/edit.html
@@ -63,7 +63,12 @@ data-file-path="{{file_path}}"
                 <li id="menu-line-numbers"><a href="#">Hide Line Numbers</a></li>
               </ul>
             </li>
+            <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Mode</a>
+              <ul id="mode-menu" class="dropdown-menu">
+              </ul>
+            </li>
           </ul>
+          <p id="current-mode" class="navbar-text navbar-right">current mode</p>
         </div>
       </div>
     </div>

--- a/IPython/html/templates/edit.html
+++ b/IPython/html/templates/edit.html
@@ -46,6 +46,12 @@ data-file-path="{{file_path}}"
               <ul id="edit-menu" class="dropdown-menu">
                 <li id="menu-find"><a href="#">Find</a></li>
                 <li id="menu-replace"><a href="#">Find &amp; Replace</a></li>
+                <li class="divider"></li>
+                <li>Key Map</li>
+                <li id="menu-keymap-default"><a href="#">Default<i class="fa"></i></a></li>
+                <li id="menu-keymap-sublime"><a href="#">Sublime Text<i class="fa"></i></a></li>
+                <li id="menu-keymap-vim"><a href="#">Vim<i class="fa"></i></a></li>
+                <li id="menu-keymap-emacs"><a href="#">emacs<i class="fa"></i></a></li>
               </ul>
             </li>
             <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">View</a>

--- a/IPython/html/templates/edit.html
+++ b/IPython/html/templates/edit.html
@@ -17,7 +17,10 @@ data-file-path="{{file_path}}"
 
 {% block header %}
 
-<span id="filename">{{ basename }}</span>
+<span id="save_widget" class="nav pull-left save_widget">
+    <span class="filename"></span>
+    <span class="last_modified"></span>
+</span>
 
 {% endblock %}
 

--- a/IPython/html/templates/edit.html
+++ b/IPython/html/templates/edit.html
@@ -36,28 +36,40 @@ data-file-path="{{file_path}}"
 {% block site %}
 
 <div id="menubar-container" class="container">
-<div id="menubar">
+  <div id="menubar">
     <div id="menus" class="navbar navbar-default" role="navigation">
-        <div class="container-fluid">
-            <button type="button" class="btn btn-default navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-              <i class="fa fa-bars"></i>
-              <span class="navbar-text">Menu</span>
-            </button>
-            <ul class="nav navbar-nav navbar-right">
-              <li id="notification_area"></li>
-            </ul>
-            <div class="navbar-collapse collapse">
-              <ul class="nav navbar-nav">
-                <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">File</a>
-                    <ul id="file_menu" class="dropdown-menu">
-                        <li id="save_file"><a href="#">Save</a></li>
-                    </ul>
-                </li>
+      <div class="container-fluid">
+        <button type="button" class="btn btn-default navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+          <i class="fa fa-bars"></i>
+          <span class="navbar-text">Menu</span>
+        </button>
+        <ul class="nav navbar-nav navbar-right">
+          <li id="notification_area"></li>
+        </ul>
+        <div class="navbar-collapse collapse">
+          <ul class="nav navbar-nav">
+            <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">File</a>
+              <ul id="file-menu" class="dropdown-menu">
+                <li id="new-file"><a href="#">New</a></li>
+                <li id="save-file"><a href="#">Save</a></li>
               </ul>
-            </div>
+            </li>
+            <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Edit</a>
+              <ul id="edit-menu" class="dropdown-menu">
+                <li id="menu-find"><a href="#">Find</a></li>
+                <li id="menu-replace"><a href="#">Find &amp; Replace</a></li>
+              </ul>
+            </li>
+            <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">View</a>
+              <ul id="view-menu" class="dropdown-menu">
+                <li id="menu-line-numbers"><a href="#">Hide Line Numbers</a></li>
+              </ul>
+            </li>
+          </ul>
         </div>
+      </div>
     </div>
-</div>
+  </div>
 </div>
 
 <div id="texteditor-container" class="container"></div>

--- a/IPython/html/templates/edit.html
+++ b/IPython/html/templates/edit.html
@@ -15,16 +15,16 @@ data-file-path="{{file_path}}"
 
 {% endblock %}
 
-{% block header %}
+{% block headercontainer %}
 
-<span id="save_widget" class="nav pull-left save_widget">
+<span id="save_widget" class="pull-left save_widget">
     <span class="filename"></span>
     <span class="last_modified"></span>
 </span>
 
 {% endblock %}
 
-{% block site %}
+{% block header %}
 
 <div id="menubar-container" class="container">
   <div id="menubar">
@@ -69,6 +69,11 @@ data-file-path="{{file_path}}"
     </div>
   </div>
 </div>
+
+{% endblock %}
+
+{% block site %}
+
 
 <div id="texteditor-container" class="container"></div>
 

--- a/IPython/html/templates/edit.html
+++ b/IPython/html/templates/edit.html
@@ -60,7 +60,7 @@ data-file-path="{{file_path}}"
             </li>
             <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">View</a>
               <ul id="view-menu" class="dropdown-menu">
-                <li id="menu-line-numbers"><a href="#">Hide Line Numbers</a></li>
+                <li id="menu-line-numbers"><a href="#">Toggle Line Numbers</a></li>
               </ul>
             </li>
             <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Mode</a>

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -42,12 +42,12 @@ class="notebook_app"
 </span>
 
 <span id="kernel_selector_widget" class="pull-right dropdown">
-    <button class="dropdown-toggle" data-toggle="dropdown" type='button' id="current_kernel_spec">
-        <span class='kernel_name'>Kernel</span>
-        <span class="caret"></span> 
-    </button>
-    <ul id="kernel_selector" class="dropdown-menu">
-    </ul>
+  <button class="dropdown-toggle btn btn-sm navbar-btn" data-toggle="dropdown" type='button' id="current_kernel_spec">
+    <span class='kernel_name'>Kernel</span>
+    <span class="caret"></span> 
+  </button>
+  <ul id="kernel_selector" class="dropdown-menu">
+  </ul>
 </span>
 
 {% endblock headercontainer %}
@@ -57,19 +57,17 @@ class="notebook_app"
 <div id="menubar">
     <div id="menus" class="navbar navbar-default" role="navigation">
         <div class="container-fluid">
-            <button type="button" class="btn btn-default navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+            <button type="button" class="btn btn-default navbar-btn navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
               <i class="fa fa-bars"></i>
               <span class="navbar-text">Menu</span>
             </button>
-            <ul class="nav navbar-nav navbar-right">
-              <li id="kernel_indicator">
-                <i id="kernel_indicator_icon"></i>
-              </li>
-              <li id="modal_indicator">
-                <i id="modal_indicator_icon"></i>
-              </li>
-              <li id="notification_area"></li>
-            </ul>
+            <p id="kernel_indicator" class="navbar-text">
+              <i id="kernel_indicator_icon"></i>
+            </p>
+            <p id="modal_indicator" class="navbar-text">
+              <i id="modal_indicator_icon"></i>
+            </p>
+            <span id="notification_area"></span>
             <div class="navbar-collapse collapse">
               <ul class="nav navbar-nav">
                 <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">File</a>

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -35,10 +35,10 @@ class="notebook_app"
 {% block headercontainer %}
 
 
-<span id="save_widget" class="nav pull-left">
-    <span id="notebook_name"></span>
-    <span id="checkpoint_status"></span>
-    <span id="autosave_status"></span>
+<span id="save_widget" class="nav pull-left save_widget">
+    <span class="filename"></span>
+    <span class="checkpoint_status"></span>
+    <span class="autosave_status"></span>
 </span>
 
 <span id="kernel_selector_widget" class="pull-right dropdown">

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -35,7 +35,7 @@ class="notebook_app"
 {% block headercontainer %}
 
 
-<span id="save_widget" class="nav pull-left save_widget">
+<span id="save_widget" class="pull-left save_widget">
     <span class="filename"></span>
     <span class="checkpoint_status"></span>
     <span class="autosave_status"></span>

--- a/IPython/html/templates/page.html
+++ b/IPython/html/templates/page.html
@@ -80,7 +80,7 @@
   </div>
 </noscript>
 
-<div id="header" class="navbar navbar-static-top">
+<div id="header" class="navbar navbar-fixed-top">
   <div id="header-container" class="container">
   <div id="ipython_notebook" class="nav navbar-brand pull-left"><a href="{{base_url}}tree" alt='dashboard'>{% block logo %}<img src='{{static_url("base/images/logo.png") }}' alt='Jupyter Notebook'/>{% endblock %}</a></div>
 
@@ -88,9 +88,9 @@
 
     <span id="login_widget">
       {% if logged_in %}
-        <button id="logout">Logout</button>
+        <button id="logout" class="btn btn-sm navbar-btn">Logout</button>
       {% elif login_available and not logged_in %}
-        <button id="login">Login</button>
+        <button id="login" class="btn btn-sm navbar-btn">Login</button>
       {% endif %}
     </span>
 


### PR DESCRIPTION
Requires PR #7109
- fill out basic menu items
- Add SaveWidget, copied from Notebook
- use config API to remember selections
- allow manual selection of CodeMirror mode

I tried to avoid making any style changes beyond what was necessary to get it working.

menus:
- File
  - New
  - Save
  - Rename
- Edit
  - Find
  - Find & Replace
  - Change keyMap (default, sublime, emacs, vim)
- View
  - Toggle Line Numbers
- Mode
  - listing of CodeMirror modes
