### PR TITLE
Complete qtconsole PyQt5 port

### DIFF
--- a/IPython/kernel/channels.py
+++ b/IPython/kernel/channels.py
@@ -47,7 +47,7 @@ class HBChannel(Thread):
     _pause = None
     _beating = None
 
-    def __init__(self, context, session, address):
+    def __init__(self, context=None, session=None, address=None):
         """Create the heartbeat monitor thread.
 
         Parameters

--- a/IPython/qt/console/ipython_widget.py
+++ b/IPython/qt/console/ipython_widget.py
@@ -280,7 +280,8 @@ class IPythonWidget(FrontendWidget):
         """Handle kernel info replies."""
         content = rep['content']
         if not self._guiref_loaded:
-            if content.get('language') == 'python':
+            lang_info = content.get('language_info')
+            if lang_info.get('name') == 'python':
                 self._load_guiref_magic()
             self._guiref_loaded = True
         

--- a/IPython/qt/console/ipython_widget.py
+++ b/IPython/qt/console/ipython_widget.py
@@ -280,8 +280,7 @@ class IPythonWidget(FrontendWidget):
         """Handle kernel info replies."""
         content = rep['content']
         if not self._guiref_loaded:
-            lang_info = content.get('language_info')
-            if lang_info.get('name') == 'python':
+            if content.get('implementation') == 'ipython':
                 self._load_guiref_magic()
             self._guiref_loaded = True
         

--- a/IPython/qt/console/magic_helper.py
+++ b/IPython/qt/console/magic_helper.py
@@ -95,7 +95,7 @@ class MagicHelper(QtGui.QDockWidget):
         self.search_line.textChanged[str].connect(
             self.search_changed
         )
-        self.search_list.itemDoubleClicked[QtGui.QListWidgetItem].connect(
+        self.search_list.itemDoubleClicked.connect(
             self.paste_requested
         )
         self.paste_button.clicked[bool].connect(


### PR DESCRIPTION
This completes the work of PR #5458 to make qtconsole work with PyQt5. To test it you need to cd into your fork, checkout this branch and run:

`QT_API=pyqt5 python3 -m IPython qtconsole`

If `QT_API` is not set explicitly, IPython chooses Qt4 first.

~~There is still an error when opening new tabs, so please don't merge it yet. I'm investigating how to fix it.~~

Closes #6103
