### PR TITLE
Fixes for _display_banner when creating new qtconsole tabs

### DIFF
--- a/IPython/qt/console/frontend_widget.py
+++ b/IPython/qt/console/frontend_widget.py
@@ -171,6 +171,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
         self._request_info = {}
         self._request_info['execute'] = {};
         self._callback_dict = {}
+        self._display_banner = True
 
         # Configure the ConsoleWidget.
         self.tab_width = 4

--- a/IPython/qt/console/qtconsoleapp.py
+++ b/IPython/qt/console/qtconsoleapp.py
@@ -219,6 +219,7 @@ class IPythonQtConsoleApp(BaseIPythonApplication, IPythonConsoleApp):
         widget._existing = False
         widget._may_close = True
         widget._confirm_exit = self.confirm_exit
+        widget._display_banner = self.display_banner
         return widget
 
     def new_frontend_slave(self, current_widget):
@@ -241,6 +242,7 @@ class IPythonQtConsoleApp(BaseIPythonApplication, IPythonConsoleApp):
         widget._existing = True
         widget._may_close = False
         widget._confirm_exit = False
+        widget._display_banner = self.display_banner
         widget.kernel_client = kernel_client
         widget.kernel_manager = current_widget.kernel_manager
         return widget


### PR DESCRIPTION
- make sure _display_banner is set in FrontendWidget
- make sure _display_banner flag is passed in from console app

initialising it in the widget's `__init__` might be overkill but seemed safer.

ref: PR #7129
