### PR TITLE
Split js tests into subgroups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ python:
     - 2.7
     - 3.3
 env:
-    - GROUP=js
+    - GROUP=js/base
+    - GROUP=js/notebook
+    - GROUP=js/tree
+    - GROUP=js/widgets
     - GROUP=
 before_install:
     # workaround for https://github.com/travis-ci/travis-cookbooks/issues/155
@@ -27,7 +30,13 @@ script:
 matrix:
     exclude:
         - python: 3.3
-          env: GROUP=js
+          env: GROUP=js/base
+        - python: 3.3
+          env: GROUP=js/notebook
+        - python: 3.3
+          env: GROUP=js/tree
+        - python: 3.3
+          env: GROUP=js/widgets
 
 after_success:
     - cp /tmp/ipy_coverage.xml ./

--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -431,12 +431,9 @@ def prepare_controllers(options):
     not to run."""
     testgroups = options.testgroups
     if testgroups:
-        if 'js' in testgroups:
-            js_testgroups = all_js_groups()
-        else:
-            js_testgroups = [g for g in testgroups if g.startswith(js_prefix)]
-        
-        py_testgroups = [g for g in testgroups if g not in ['js'] + js_testgroups]
+        alljs = all_js_groups()
+        js_testgroups = [g for g in testgroups if g.startswith(js_prefix)]
+        py_testgroups = [g for g in testgroups if g not in alljs]
     else:
         py_testgroups = py_test_group_names
         if not options.all:


### PR DESCRIPTION
js test are the longer ~8 minutes vs ~3 for Python, and fails the more often.
Hopefully this will speedup the build and have less test relaunched when we
have a random faillure.  Splitting in 3 should make the js test a bit faster
and gave us some rooms without increasing the number of groups.
