### PR TITLE
QtShellChannelMixin should emit kernel_info_reply signal not call it

### DIFF
--- a/IPython/qt/kernel_mixins.py
+++ b/IPython/qt/kernel_mixins.py
@@ -66,7 +66,7 @@ class QtShellChannelMixin(ChannelQObject):
         # Emit signals for specialized message types.
         msg_type = msg['header']['msg_type']
         if msg_type == 'kernel_info_reply':
-            self._handle_kernel_info_reply(msg)
+            self.kernel_info_reply.emit(msg)
         
         signal = getattr(self, msg_type, None)
         if signal:


### PR DESCRIPTION
QtShellChannelMixin incorrectly uses a callback approach to pass the
kernel_info_reply message, e.g.

   self._handle_kernel_info_reply(msg)

Qt kernels should emit Qt signals for this behaviour (as done elsewhere
in the class). This is fixed as follows, e.g.

   self.kernel_info_reply.emit(msg)

Relevant bug report: https://github.com/ipython/ipython/issues/6578
