### PR TITLE
Update viewlists to store a list of promises for views

### DIFF
--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -646,7 +646,7 @@ define(["widgets/js/manager",
              * returns a promise that resolves after this removal is done
              */
             var that = this;
-            Promise.all(this.views).then(function(views) {
+            return Promise.all(this.views).then(function(views) {
                 for (var i = 0; i < that.views.length; i++) {
                     that._remove_view.call(that._handler_context, views[i]);
                 }


### PR DESCRIPTION
Like all the other lists of views, this list is also more elegant if we store a list of promises.  We simplify the code a lot, and let code that doesn't have access to the update() call to also do things with the view promises.

ping @jdfreder for review.
