### PR TITLE
ContentsManager type kwarg to match model key

### DIFF
--- a/IPython/html/services/contents/filemanager.py
+++ b/IPython/html/services/contents/filemanager.py
@@ -317,7 +317,7 @@ class FileContentsManager(ContentsManager):
             self.validate_notebook_model(model)
         return model
 
-    def get(self, path, content=True, type_=None, format=None):
+    def get(self, path, content=True, type=None, format=None):
         """ Takes a path for an entity and returns its model
 
         Parameters
@@ -326,7 +326,7 @@ class FileContentsManager(ContentsManager):
             the API path that describes the relative path for the target
         content : bool
             Whether to include the contents in the reply
-        type_ : str, optional
+        type : str, optional
             The requested type - 'file', 'notebook', or 'directory'.
             Will raise HTTPError 400 if the content doesn't match.
         format : str, optional
@@ -346,14 +346,14 @@ class FileContentsManager(ContentsManager):
 
         os_path = self._get_os_path(path)
         if os.path.isdir(os_path):
-            if type_ not in (None, 'directory'):
+            if type not in (None, 'directory'):
                 raise web.HTTPError(400,
-                                u'%s is a directory, not a %s' % (path, type_), reason='bad type')
+                                u'%s is a directory, not a %s' % (path, type), reason='bad type')
             model = self._dir_model(path, content=content)
-        elif type_ == 'notebook' or (type_ is None and path.endswith('.ipynb')):
+        elif type == 'notebook' or (type is None and path.endswith('.ipynb')):
             model = self._notebook_model(path, content=content)
         else:
-            if type_ == 'directory':
+            if type == 'directory':
                 raise web.HTTPError(400,
                                 u'%s is not a directory', reason='bad type')
             model = self._file_model(path, content=content, format=format)

--- a/IPython/html/services/contents/handlers.py
+++ b/IPython/html/services/contents/handlers.py
@@ -59,15 +59,15 @@ class ContentsHandler(IPythonHandler):
         of the files and directories it contains.
         """
         path = path or ''
-        type_ = self.get_query_argument('type', default=None)
-        if type_ not in {None, 'directory', 'file', 'notebook'}:
-            raise web.HTTPError(400, u'Type %r is invalid' % type_)
+        type = self.get_query_argument('type', default=None)
+        if type not in {None, 'directory', 'file', 'notebook'}:
+            raise web.HTTPError(400, u'Type %r is invalid' % type)
 
         format = self.get_query_argument('format', default=None)
         if format not in {None, 'text', 'base64'}:
             raise web.HTTPError(400, u'Format %r is invalid' % format)
 
-        model = self.contents_manager.get(path=path, type_=type_, format=format)
+        model = self.contents_manager.get(path=path, type=type, format=format)
         if model['type'] == 'directory':
             # group listing by type, then by name (case-insensitive)
             # FIXME: sorting should be done in the frontends

--- a/IPython/html/services/contents/manager.py
+++ b/IPython/html/services/contents/manager.py
@@ -137,7 +137,7 @@ class ContentsManager(LoggingConfigurable):
         """
         return self.file_exists(path) or self.dir_exists(path)
 
-    def get(self, path, content=True, type_=None, format=None):
+    def get(self, path, content=True, type=None, format=None):
         """Get the model of a file or directory with or without content."""
         raise NotImplementedError('must be implemented in a subclass')
 

--- a/IPython/html/services/contents/tests/test_contents_api.py
+++ b/IPython/html/services/contents/tests/test_contents_api.py
@@ -46,10 +46,10 @@ class API(object):
     def list(self, path='/'):
         return self._req('GET', path)
 
-    def read(self, path, type_=None, format=None):
+    def read(self, path, type=None, format=None):
         params = {}
-        if type_ is not None:
-            params['type'] = type_
+        if type is not None:
+            params['type'] = type
         if format is not None:
             params['format'] = format
         return self._req('GET', path, params=params)
@@ -250,7 +250,7 @@ class APITest(NotebookTestBase):
 
         # Specifying format=text should fail on a non-UTF-8 file
         with assert_http_error(400):
-            self.api.read('foo/bar/baz.blob', type_='file', format='text')
+            self.api.read('foo/bar/baz.blob', type='file', format='text')
 
     def test_get_binary_file_contents(self):
         for d, name in self.dirs_nbs:
@@ -270,10 +270,10 @@ class APITest(NotebookTestBase):
 
     def test_get_bad_type(self):
         with assert_http_error(400):
-            self.api.read(u'unicodé', type_='file')  # this is a directory
+            self.api.read(u'unicodé', type='file')  # this is a directory
 
         with assert_http_error(400):
-            self.api.read(u'unicodé/innonascii.ipynb', type_='directory')
+            self.api.read(u'unicodé/innonascii.ipynb', type='directory')
 
     def _check_created(self, resp, path, type='notebook'):
         self.assertEqual(resp.status_code, 201)

--- a/IPython/html/services/contents/tests/test_manager.py
+++ b/IPython/html/services/contents/tests/test_manager.py
@@ -159,13 +159,13 @@ class TestContentsManager(TestCase):
         self.assertEqual(model['name'], name)
         self.assertEqual(model['path'], path)
 
-        nb_as_file = cm.get(path, content=True, type_='file')
+        nb_as_file = cm.get(path, content=True, type='file')
         self.assertEqual(nb_as_file['path'], path)
         self.assertEqual(nb_as_file['type'], 'file')
         self.assertEqual(nb_as_file['format'], 'text')
         self.assertNotIsInstance(nb_as_file['content'], dict)
 
-        nb_as_bin_file = cm.get(path, content=True, type_='file', format='base64')
+        nb_as_bin_file = cm.get(path, content=True, type='file', format='base64')
         self.assertEqual(nb_as_bin_file['format'], 'base64')
 
         # Test in sub-directory
@@ -185,7 +185,7 @@ class TestContentsManager(TestCase):
         self.assertEqual(dirmodel['type'], 'directory')
 
         with self.assertRaises(HTTPError):
-            cm.get('foo', type_='file')
+            cm.get('foo', type='file')
 
     
     @dec.skip_win32


### PR DESCRIPTION
remove `_` suffix, making it consistent with models, REST API, etc. There's no reason to have the suffix to avoid collision, since it's not a language keyword.

ping @ssanderson and @dalejung as ContentsManager authors.
