### PR TITLE
run test notebook server in thread

### DIFF
--- a/IPython/html/services/contents/tests/test_manager.py
+++ b/IPython/html/services/contents/tests/test_manager.py
@@ -78,7 +78,6 @@ class TestContentsManager(TestCase):
         self.td = self._temp_dir.name
         self.contents_manager = FileContentsManager(
             root_dir=self.td,
-            log=logging.getLogger()
         )
 
     def tearDown(self):


### PR DESCRIPTION
instead of a subprocess.
- better log capturing for nose
- saves a bit of time, especially on systems with slow process invocation
- gives the test access to the server objects, for mocking, prodding, and testing
