### PR TITLE
DEV: Log tracebacks from extension errors in interactiveshellapp

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -278,13 +278,14 @@ class InteractiveShellApp(Configurable):
                     self.log.info("Loading IPython extension: %s" % ext)
                     self.shell.extension_manager.load_extension(ext)
                 except:
-                    self.log.warn("Error in loading extension: %s" % ext +
-                        "\nCheck your config files in %s" % self.profile_dir.location
-                    )
-                    self.shell.showtraceback()
+                    msg = ("Error in loading extension: {ext}\n"
+                           "Check your config files in {location}".format(
+                               ext=ext,
+                               location=self.profile_dir.location
+                           ))
+                    self.log.warn(msg, exc_info=True)
         except:
-            self.log.warn("Unknown error in loading extensions:")
-            self.shell.showtraceback()
+            self.log.warn("Unknown error in loading extensions:", exc_info=True)
 
     def init_code(self):
         """run the pre-flight code, specified via exec_lines"""


### PR DESCRIPTION
It's often frustrating working on IPython extensions designed for the html notebook (or in general, contexts where stdout of the InteractiveShell is not displayed), because if an extension fails to load due to an IPython error, the only message that appears in the logs is:

```
[IPKernelApp] WARNING | Error in loading extension: <extension_name>
```

**EDIT:** This now just adds an exc_info=True argument to the logger in init_extensions.
