### PR TITLE
remove references to defunct layout_manager in ToolBar

### DIFF
--- a/IPython/html/static/notebook/js/toolbar.js
+++ b/IPython/html/static/notebook/js/toolbar.js
@@ -13,9 +13,8 @@ define([
      * @constructor
      * @param {Dom object} selector
      */
-    var ToolBar = function (selector, layout_manager) {
+    var ToolBar = function (selector) {
         this.selector = selector;
-        this.layout_manager = layout_manager;
         if (this.selector !== undefined) {
             this.element = $(selector);
             this.style();
@@ -88,9 +87,6 @@ define([
      */
     ToolBar.prototype.toggle = function () {
         this.element.toggle();
-        if (this.layout_manager !== undefined) {
-            this.layout_manager.do_resize();
-        }
     };
 
     // Backwards compatibility.


### PR DESCRIPTION
the layout manager is no more
