### PR TITLE
pin less to 2.x

### DIFF
--- a/IPython/html/tasks.py
+++ b/IPython/html/tasks.py
@@ -10,8 +10,8 @@ static_dir = 'static'
 components_dir = pjoin(static_dir, 'components')
 here = os.path.dirname(__file__)
 
-min_less_version = '1.7.5'
-max_less_version = None # exclusive if string
+min_less_version = '2.0'
+max_less_version = '3.0' # exclusive if string
 
 def _need_css_update():
     """Does less need to run?"""


### PR DESCRIPTION
1.7.x causes different results, and it's probable that 3.x will as well.

It might even be appropriate to pin to 2.1.x.
