### PR TITLE
Replace pager_page() instead of page() for test suite

### DIFF
--- a/IPython/testing/globalipapp.py
+++ b/IPython/testing/globalipapp.py
@@ -170,7 +170,7 @@ def start_ipython():
     def nopage(strng, start=0, screen_lines=0, pager_cmd=None):
         print(strng)
     
-    page.orig_page = page.page
-    page.page = nopage
+    page.orig_page = page.pager_page
+    page.pager_page = nopage
 
     return _ip


### PR DESCRIPTION
Since gh-7009, pager_page is now the function that may actually launch external pagers. By replacing page(), we were hiding some bugs, as in gh-7166.
