### PR TITLE
Fix for undefined method _handle_kernel_info_reply for the in-process kernel

### DIFF
--- a/IPython/qt/kernel_mixins.py
+++ b/IPython/qt/kernel_mixins.py
@@ -65,8 +65,6 @@ class QtShellChannelMixin(ChannelQObject):
 
         # Emit signals for specialized message types.
         msg_type = msg['header']['msg_type']
-        if msg_type == 'kernel_info_reply':
-            self._handle_kernel_info_reply(msg)
         
         signal = getattr(self, msg_type, None)
         if signal:


### PR DESCRIPTION
The method (signal) _handle_kernel_info_reply is undefined and 'kernel_info_reply' is also handled by the code below, which makes these two lines redundant.
