### PR TITLE
Make sure extensions start with a dot

### DIFF
--- a/IPython/nbconvert/exporters/markdown.py
+++ b/IPython/nbconvert/exporters/markdown.py
@@ -26,7 +26,7 @@ class MarkdownExporter(TemplateExporter):
     """
     
     def _file_extension_default(self):
-        return 'md'
+        return '.md'
 
     def _template_file_default(self):
         return 'markdown'

--- a/IPython/nbconvert/exporters/notebook.py
+++ b/IPython/nbconvert/exporters/notebook.py
@@ -18,7 +18,7 @@ class NotebookExporter(Exporter):
         """
     )
     def _file_extension_default(self):
-        return 'ipynb'
+        return '.ipynb'
 
     output_mimetype = 'application/json'
 


### PR DESCRIPTION
In nbconvert, it appears the filename extensions have to start with a dot. Mostly, I think this was changed in #6978, but these two files were missed.

I was thinking of ways to try to avoid this more generally -- maybe a specific `Extension` traitlet that makes sure it starts with a dot, or something? Or, is there a way to validate existing traitlets without creating a new traitlet class?
