### PR TITLE
Remove spurious print statement

### DIFF
--- a/IPython/kernel/blocking/client.py
+++ b/IPython/kernel/blocking/client.py
@@ -28,7 +28,6 @@ class BlockingKernelClient(KernelClient):
         while True:
             try:
                 msg = self.iopub_channel.get_msg(block=True, timeout=0.2)
-                print(msg['msg_type'])
             except Empty:
                 break
 


### PR DESCRIPTION
When running nbconvert, I see this output:

```
[NbConvertApp] Using existing profile dir: '/tmp'
[NbConvertApp] Converting notebook nbgrader assign.ipynb to notebook
[NbConvertApp] Support files will be in nbgrader assign_files/
[NbConvertApp] Executing notebook with kernel: python3
error
status
status
status
```

The "error" and "status" messages come from a print statement that appears to be a debug statement that wasn't removed. I've removed it in this pull request .
