### PR TITLE
Add extension traitlet to force dotted names

### DIFF
--- a/IPython/nbconvert/exporters/__init__.py
+++ b/IPython/nbconvert/exporters/__init__.py
@@ -8,4 +8,4 @@ from .notebook import NotebookExporter
 from .pdf import PDFExporter
 from .python import PythonExporter
 from .rst import RSTExporter
-from .exporter import Exporter, Extension
+from .exporter import Exporter, FilenameExtension

--- a/IPython/nbconvert/exporters/__init__.py
+++ b/IPython/nbconvert/exporters/__init__.py
@@ -8,4 +8,4 @@ from .notebook import NotebookExporter
 from .pdf import PDFExporter
 from .python import PythonExporter
 from .rst import RSTExporter
-from .exporter import Exporter
+from .exporter import Exporter, Extension

--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -24,7 +24,7 @@ class ResourcesDict(collections.defaultdict):
         return ''
 
 
-class Extension(TraitType):
+class FilenameExtension(TraitType):
     """A trait for filename extensions."""
 
     default_value = u''
@@ -52,7 +52,7 @@ class Exporter(LoggingConfigurable):
     accompanying resources dict.
     """
 
-    file_extension = Extension(
+    file_extension = FilenameExtension(
         '.txt', config=True,
         help="Extension of the file that should be written to disk"
         )

--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -35,7 +35,7 @@ class FilenameExtension(Unicode):
         value = super(FilenameExtension, self).validate(obj, value)
 
         # check that it starts with a dot
-        if not value.startswith('.'):
+        if value and not value.startswith('.'):
             msg = "FileExtension trait '{}' does not begin with a dot: {!r}"
             raise TraitError(msg.format(self.name, value))
 

--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -32,7 +32,7 @@ class FilenameExtension(TraitType):
 
     def validate(self, obj, value):
         try:
-            value = py3compat.cast_bytes_py2(value)
+            value = py3compat.cast_unicode_py2(value)
         except UnicodeDecodeError:
             msg = "Could not decode {!r} for FileExtension trait '{}'."
             raise TraitError(msg.format(value, self.name))

--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -31,12 +31,11 @@ class FilenameExtension(TraitType):
     info_text = 'a filename extension, beginning with a dot'
 
     def validate(self, obj, value):
-        if isinstance(value, bytes):
-            try:
-                value = value.decode('ascii', 'strict')
-            except UnicodeDecodeError:
-                msg = "Could not decode {!r} for extension trait '{}'."
-                raise TraitError(msg.format(value, self.name))
+        try:
+            value = py3compat.cast_bytes_py2(value)
+        except UnicodeDecodeError:
+            msg = "Could not decode {!r} for extension trait '{}'."
+            raise TraitError(msg.format(value, self.name))
 
         if not value.startswith('.'):
             msg = "Extension trait '{}' does not begin with a dot: {!r}"

--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -34,11 +34,6 @@ class FilenameExtension(Unicode):
         # cast to proper unicode
         value = super(FilenameExtension, self).validate(obj, value)
 
-        # make sure the value is actually unicode
-        if not isinstance(value, py3compat.unicode_type):
-            msg = "FileExtension trait '{}' is not of type '{}'"
-            raise TraitError(msg.format(self.name, py3compat.unicode_type))
-
         # check that it starts with a dot
         if not value.startswith('.'):
             msg = "FileExtension trait '{}' does not begin with a dot: {!r}"

--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -14,7 +14,7 @@ import datetime
 from IPython.config.configurable import LoggingConfigurable
 from IPython.config import Config
 from IPython import nbformat
-from IPython.utils.traitlets import MetaHasTraits, TraitType, List, TraitError
+from IPython.utils.traitlets import MetaHasTraits, Unicode, List, TraitError
 from IPython.utils.importstring import import_item
 from IPython.utils import text, py3compat
 
@@ -24,19 +24,22 @@ class ResourcesDict(collections.defaultdict):
         return ''
 
 
-class FilenameExtension(TraitType):
+class FilenameExtension(Unicode):
     """A trait for filename extensions."""
 
     default_value = u''
     info_text = 'a filename extension, beginning with a dot'
 
     def validate(self, obj, value):
-        try:
-            value = py3compat.cast_unicode_py2(value)
-        except UnicodeDecodeError:
-            msg = "Could not decode {!r} for FileExtension trait '{}'."
-            raise TraitError(msg.format(value, self.name))
+        # cast to proper unicode
+        value = super(FilenameExtension, self).validate(obj, value)
 
+        # make sure the value is actually unicode
+        if not isinstance(value, py3compat.unicode_type):
+            msg = "FileExtension trait '{}' is not of type '{}'"
+            raise TraitError(msg.format(self.name, py3compat.unicode_type))
+
+        # check that it starts with a dot
         if not value.startswith('.'):
             msg = "FileExtension trait '{}' does not begin with a dot: {!r}"
             raise TraitError(msg.format(self.name, value))

--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -34,11 +34,11 @@ class FilenameExtension(TraitType):
         try:
             value = py3compat.cast_bytes_py2(value)
         except UnicodeDecodeError:
-            msg = "Could not decode {!r} for extension trait '{}'."
+            msg = "Could not decode {!r} for FileExtension trait '{}'."
             raise TraitError(msg.format(value, self.name))
 
         if not value.startswith('.'):
-            msg = "Extension trait '{}' does not begin with a dot: {!r}"
+            msg = "FileExtension trait '{}' does not begin with a dot: {!r}"
             raise TraitError(msg.format(self.name, value))
 
         return value


### PR DESCRIPTION
This addresses the problem from #7179 more generally. Tests will fail for this until that is merged.

I wasn't sure if this was really the best place for the custom trait, or if I should put it in `IPython.nbconvert.utils` or something instead.
