### PR TITLE
add some convenience to loading default config

### DIFF
--- a/IPython/config/__init__.py
+++ b/IPython/config/__init__.py
@@ -1,17 +1,7 @@
 # encoding: utf-8
 
-__docformat__ = "restructuredtext en"
-
-#-------------------------------------------------------------------------------
-#  Copyright (C) 2008  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-------------------------------------------------------------------------------
-
-#-------------------------------------------------------------------------------
-# Imports
-#-------------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 from .application import *
 from .configurable import *

--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -609,3 +609,13 @@ def boolean_flag(name, configurable, set_help='', unset_help=''):
     unsetter = {cls : {trait : False}}
     return {name : (setter, set_help), 'no-'+name : (unsetter, unset_help)}
 
+
+def get_config():
+    """Get the config object for the global Application instance, if there is one
+    
+    otherwise return an empty config object
+    """
+    if Application.initialized():
+        return Application.instance().config
+    else:
+        return Config()

--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -78,6 +78,9 @@ class Configurable(HasTraits):
             # making that a class attribute.
             # self.config = deepcopy(config)
             self.config = config
+        else:
+            # allow _config_default to return something
+            self._load_config(self.config)
         # This should go second so individual keyword arguments override
         # the values in config.
         super(Configurable, self).__init__(**kwargs)

--- a/IPython/config/tests/test_configurable.py
+++ b/IPython/config/tests/test_configurable.py
@@ -1,23 +1,8 @@
 # encoding: utf-8
-"""
-Tests for IPython.config.configurable
+"""Tests for IPython.config.configurable"""
 
-Authors:
-
-* Brian Granger
-* Fernando Perez (design help)
-"""
-
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2011  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 from unittest import TestCase
 
@@ -32,10 +17,6 @@ from IPython.utils.traitlets import (
 
 from IPython.config.loader import Config
 from IPython.utils.py3compat import PY3
-
-#-----------------------------------------------------------------------------
-# Test cases
-#-----------------------------------------------------------------------------
 
 
 class MyConfigurable(Configurable):
@@ -372,4 +353,26 @@ class TestConfigContainers(TestCase):
         m.update_config(c2)
         self.assertEqual(m.a, 15)
     
+    def test_config_default(self):
+        class SomeSingleton(SingletonConfigurable):
+            pass
+
+        class DefaultConfigurable(Configurable):
+            a = Integer(config=True)
+            def _config_default(self):
+                if SomeSingleton.initialized():
+                    return SomeSingleton.instance().config
+                return Config()
+
+        c = Config()
+        c.DefaultConfigurable.a = 5
+
+        d1 = DefaultConfigurable()
+        self.assertEqual(d1.a, 0)
+        
+        single = SomeSingleton.instance(config=c)
+        
+        d2 = DefaultConfigurable()
+        self.assertIs(d2.config, single.config)
+        self.assertEqual(d2.a, 5)
 


### PR DESCRIPTION
These are the pieces necessary for an object to get its default config from the global application if there is one, with:

``` python
from IPython.config import get_config, SingletonConfigurable

class MyObject(SingletonConfigurable):
    def _config_default(self):
        return get_config()
```

I am using this in a patch to lib.latextools, which I will open as a separate PR.
