### PR TITLE
various latextools fixes

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -54,7 +54,6 @@ from IPython.core.prefilter import PrefilterManager
 from IPython.core.profiledir import ProfileDir
 from IPython.core.prompts import PromptManager
 from IPython.core.usage import default_banner
-from IPython.lib.latextools import LaTeXTool
 from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils import PyColorize
 from IPython.utils import io
@@ -521,7 +520,6 @@ class InteractiveShell(SingletonConfigurable):
         self.init_display_pub()
         self.init_data_pub()
         self.init_displayhook()
-        self.init_latextool()
         self.init_magics()
         self.init_alias()
         self.init_logstart()
@@ -714,12 +712,6 @@ class InteractiveShell(SingletonConfigurable):
         # This is a context manager that installs/revmoes the displayhook at
         # the appropriate time.
         self.display_trap = DisplayTrap(hook=self.displayhook)
-
-    def init_latextool(self):
-        """Configure LaTeXTool."""
-        cfg = LaTeXTool.instance(parent=self)
-        if cfg not in self.configurables:
-            self.configurables.append(cfg)
 
     def init_virtualenv(self):
         """Add a virtualenv to sys.path so the user can import modules from it.

--- a/IPython/lib/latextools.py
+++ b/IPython/lib/latextools.py
@@ -12,7 +12,7 @@ import shutil
 import subprocess
 
 from IPython.utils.process import find_cmd, FindCmdError
-from IPython.config.application import Application
+from IPython.config import get_config
 from IPython.config.configurable import SingletonConfigurable
 from IPython.utils.traitlets import List, Bool, Unicode
 from IPython.utils.py3compat import cast_unicode, cast_unicode_py2 as u
@@ -20,7 +20,9 @@ from IPython.utils.py3compat import cast_unicode, cast_unicode_py2 as u
 
 class LaTeXTool(SingletonConfigurable):
     """An object to store configuration of the LaTeX tool."""
-
+    def _config_default(self):
+        return get_config()
+    
     backends = List(
         Unicode, ["matplotlib", "dvipng"],
         help="Preferred backend to draw LaTeX math equations. "
@@ -93,11 +95,12 @@ def latex_to_png_mpl(s, wrap):
         from matplotlib import mathtext
     except ImportError:
         return None
-
+    
     # mpl mathtext doesn't support display math, force inline
     s = s.replace('$$', '$')
     if wrap:
         s = u'${0}$'.format(s)
+    
     mt = mathtext.MathTextParser('bitmap')
     f = BytesIO()
     mt.to_png(f, s, fontsize=12)

--- a/IPython/lib/latextools.py
+++ b/IPython/lib/latextools.py
@@ -94,6 +94,8 @@ def latex_to_png_mpl(s, wrap):
     except ImportError:
         return None
 
+    # mpl mathtext doesn't support display math, force inline
+    s = s.replace('$$', '$')
     if wrap:
         s = u'${0}$'.format(s)
     mt = mathtext.MathTextParser('bitmap')

--- a/IPython/lib/latextools.py
+++ b/IPython/lib/latextools.py
@@ -1,23 +1,10 @@
 # -*- coding: utf-8 -*-
-"""Tools for handling LaTeX.
+"""Tools for handling LaTeX."""
 
-Authors:
-
-* Brian Granger
-"""
-#-----------------------------------------------------------------------------
-# Copyright (C) 2010 IPython Development Team.
-#
+# Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
-
-from io import BytesIO
+from io import BytesIO, open
 from base64 import encodestring
 import os
 import tempfile
@@ -25,20 +12,17 @@ import shutil
 import subprocess
 
 from IPython.utils.process import find_cmd, FindCmdError
+from IPython.config.application import Application
 from IPython.config.configurable import SingletonConfigurable
-from IPython.utils.traitlets import List, CBool, CUnicode
-from IPython.utils.py3compat import bytes_to_str
-
-#-----------------------------------------------------------------------------
-# Tools
-#-----------------------------------------------------------------------------
+from IPython.utils.traitlets import List, Bool, Unicode
+from IPython.utils.py3compat import cast_unicode, cast_unicode_py2 as u
 
 
 class LaTeXTool(SingletonConfigurable):
     """An object to store configuration of the LaTeX tool."""
 
     backends = List(
-        CUnicode, ["matplotlib", "dvipng"],
+        Unicode, ["matplotlib", "dvipng"],
         help="Preferred backend to draw LaTeX math equations. "
         "Backends in the list are checked one by one and the first "
         "usable one is used.  Note that `matplotlib` backend "
@@ -51,7 +35,7 @@ class LaTeXTool(SingletonConfigurable):
         # unicode pretty printing is used, you can use ["matplotlib"].
         config=True)
 
-    use_breqn = CBool(
+    use_breqn = Bool(
         True,
         help="Use breqn.sty to automatically break long equations. "
         "This configuration takes effect only for dvipng backend.",
@@ -63,7 +47,7 @@ class LaTeXTool(SingletonConfigurable):
         "'breqn' will be automatically appended when use_breqn=True.",
         config=True)
 
-    preamble = CUnicode(
+    preamble = Unicode(
         help="Additional preamble to use when generating LaTeX source "
         "for dvipng backend.",
         config=True)
@@ -74,10 +58,10 @@ def latex_to_png(s, encode=False, backend=None, wrap=False):
 
     Parameters
     ----------
-    s : str
+    s : text
         The raw string containing valid inline LaTeX.
     encode : bool, optional
-        Should the PNG data bebase64 encoded to make it JSON'able.
+        Should the PNG data base64 encoded to make it JSON'able.
     backend : {matplotlib, dvipng}
         Backend for producing PNG data.
     wrap : bool
@@ -86,6 +70,7 @@ def latex_to_png(s, encode=False, backend=None, wrap=False):
     None is returned when the backend cannot be used.
 
     """
+    s = cast_unicode(s)
     allowed_backends = LaTeXTool.instance().backends
     if backend is None:
         backend = allowed_backends[0]
@@ -110,7 +95,7 @@ def latex_to_png_mpl(s, wrap):
         return None
 
     if wrap:
-        s = '${0}$'.format(s)
+        s = u'${0}$'.format(s)
     mt = mathtext.MathTextParser('bitmap')
     f = BytesIO()
     mt.to_png(f, s, fontsize=12)
@@ -129,10 +114,10 @@ def latex_to_png_dvipng(s, wrap):
         dvifile = os.path.join(workdir, "tmp.dvi")
         outfile = os.path.join(workdir, "tmp.png")
 
-        with open(tmpfile, "w") as f:
+        with open(tmpfile, "w", encoding='utf8') as f:
             f.writelines(genelatex(s, wrap))
 
-        with open(os.devnull, 'w') as devnull:
+        with open(os.devnull, 'wb') as devnull:
             subprocess.check_call(
                 ["latex", "-halt-on-error", "-interaction", "batchmode", tmpfile],
                 cwd=workdir, stdout=devnull, stderr=devnull)
@@ -156,7 +141,7 @@ def kpsewhich(filename):
             ["kpsewhich", filename],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (stdout, stderr) = proc.communicate()
-        return stdout.strip()
+        return stdout.strip().decode('utf8', 'replace')
     except FindCmdError:
         pass
 
@@ -165,28 +150,28 @@ def genelatex(body, wrap):
     """Generate LaTeX document for dvipng backend."""
     lt = LaTeXTool.instance()
     breqn = wrap and lt.use_breqn and kpsewhich("breqn.sty")
-    yield r'\documentclass{article}'
+    yield u(r'\documentclass{article}')
     packages = lt.packages
     if breqn:
         packages = packages + ['breqn']
     for pack in packages:
-        yield r'\usepackage{{{0}}}'.format(pack)
-    yield r'\pagestyle{empty}'
+        yield u(r'\usepackage{{{0}}}'.format(pack))
+    yield u(r'\pagestyle{empty}')
     if lt.preamble:
         yield lt.preamble
-    yield r'\begin{document}'
+    yield u(r'\begin{document}')
     if breqn:
-        yield r'\begin{dmath*}'
+        yield u(r'\begin{dmath*}')
         yield body
-        yield r'\end{dmath*}'
+        yield u(r'\end{dmath*}')
     elif wrap:
-        yield '$${0}$$'.format(body)
+        yield u'$${0}$$'.format(body)
     else:
         yield body
-    yield r'\end{document}'
+    yield u'\end{document}'
 
 
-_data_uri_template_png = """<img src="data:image/png;base64,%s" alt=%s />"""
+_data_uri_template_png = u"""<img src="data:image/png;base64,%s" alt=%s />"""
 
 def latex_to_html(s, alt='image'):
     """Render LaTeX to HTML with embedded PNG data using data URIs.
@@ -198,54 +183,8 @@ def latex_to_html(s, alt='image'):
     alt : str
         The alt text to use for the HTML.
     """
-    base64_data = bytes_to_str(latex_to_png(s, encode=True), 'ascii')
+    base64_data = latex_to_png(s, encode=True).decode('ascii')
     if base64_data:
         return _data_uri_template_png  % (base64_data, alt)
 
-
-# From matplotlib, thanks to mdboom. Once this is in matplotlib releases, we
-# will remove.
-def math_to_image(s, filename_or_obj, prop=None, dpi=None, format=None):
-    """
-    Given a math expression, renders it in a closely-clipped bounding
-    box to an image file.
-
-    *s*
-       A math expression.  The math portion should be enclosed in
-       dollar signs.
-
-    *filename_or_obj*
-       A filepath or writable file-like object to write the image data
-       to.
-
-    *prop*
-       If provided, a FontProperties() object describing the size and
-       style of the text.
-
-    *dpi*
-       Override the output dpi, otherwise use the default associated
-       with the output format.
-
-    *format*
-       The output format, eg. 'svg', 'pdf', 'ps' or 'png'.  If not
-       provided, will be deduced from the filename.
-    """
-    from matplotlib import figure
-    # backend_agg supports all of the core output formats
-    from matplotlib.backends import backend_agg
-    from matplotlib.font_manager import FontProperties
-    from matplotlib.mathtext import MathTextParser
-
-    if prop is None:
-        prop = FontProperties()
-
-    parser = MathTextParser('path')
-    width, height, depth, _, _ = parser.parse(s, dpi=72, prop=prop)
-
-    fig = figure.Figure(figsize=(width / 72.0, height / 72.0))
-    fig.text(0, depth/height, s, fontproperties=prop)
-    backend_agg.FigureCanvasAgg(fig)
-    fig.savefig(filename_or_obj, dpi=dpi, format=format)
-
-    return depth
 

--- a/IPython/qt/console/ipython_widget.py
+++ b/IPython/qt/console/ipython_widget.py
@@ -239,9 +239,7 @@ class IPythonWidget(FrontendWidget):
 
     
     def _handle_execute_result(self, msg):
-        """ Reimplemented for IPython-style "display hook".
-        """
-        self.log.debug("execute_result: %s", msg.get('content', ''))
+        """Reimplemented for IPython-style "display hook"."""
         if self.include_output(msg):
             self.flush_clearoutput()
             content = msg['content']
@@ -258,9 +256,7 @@ class IPythonWidget(FrontendWidget):
                 self._append_plain_text(text + self.output_sep2, True)
 
     def _handle_display_data(self, msg):
-        """ The base handler for the ``display_data`` message.
-        """
-        self.log.debug("display: %s", msg.get('content', ''))
+        """The base handler for the ``display_data`` message."""
         # For now, we don't display data from other frontends, but we
         # eventually will as this allows all frontends to monitor the display
         # data. But we need to figure out how to handle this in the GUI.

--- a/IPython/qt/console/rich_ipython_widget.py
+++ b/IPython/qt/console/rich_ipython_widget.py
@@ -171,9 +171,7 @@ class RichIPythonWidget(IPythonWidget):
             png = latex_to_png(latex, wrap=False)
         except Exception as e:
             self.log.error("Failed to render latex: '%s'", latex, exc_info=True)
-            self._append_plain_text("Failed to render latex:\n%s\nError was: %s" % (
-                latex, e,
-            ), before_prompt)
+            self._append_plain_text("Failed to render latex: %s" % e, before_prompt)
         else:
             self._append_png(png, before_prompt, metadata)
 

--- a/IPython/qt/console/rich_ipython_widget.py
+++ b/IPython/qt/console/rich_ipython_widget.py
@@ -129,7 +129,11 @@ class RichIPythonWidget(IPythonWidget):
                 self._append_html(self.output_sep2, True)
             elif 'text/latex' in data:
                 self._pre_image_append(msg, prompt_number)
-                png = latex_to_png(data['text/latex'], wrap=False)
+                try:
+                    png = latex_to_png(data['text/latex'], wrap=False)
+                except Exception:
+                    self.log.error("Failed to render latex: %r", data['text/latex'], exc_info=True)
+                    png = None
                 if png is not None:
                     self._append_png(png, True)
                     self._append_html(self.output_sep2, True)

--- a/IPython/qt/console/rich_ipython_widget.py
+++ b/IPython/qt/console/rich_ipython_widget.py
@@ -129,9 +129,7 @@ class RichIPythonWidget(IPythonWidget):
                 self._append_html(self.output_sep2, True)
             elif 'text/latex' in data:
                 self._pre_image_append(msg, prompt_number)
-                # latex_to_png takes care of handling $
-                latex = latex.strip('$')
-                png = latex_to_png(latex, wrap=True)
+                png = latex_to_png(data['text/latex'], wrap=False)
                 if png is not None:
                     self._append_png(png, True)
                     self._append_html(self.output_sep2, True)

--- a/IPython/qt/console/rich_ipython_widget.py
+++ b/IPython/qt/console/rich_ipython_widget.py
@@ -129,7 +129,6 @@ class RichIPythonWidget(IPythonWidget):
                 self._append_html(self.output_sep2, True)
             elif 'text/latex' in data:
                 self._pre_image_append(msg, prompt_number)
-                latex = data['text/latex'].encode('ascii')
                 # latex_to_png takes care of handling $
                 latex = latex.strip('$')
                 png = latex_to_png(latex, wrap=True)


### PR DESCRIPTION
- support unicode text, not just bytes
- remove unused math_to_image copied from mpl
- load global config, instead of instantiating in shell (fixes config load in qtconsole)
- don't unwrap/rewrap math in qtconsole - this broke display of all non-math latex
- mpl math_to_png doesn't support display math, coerce to inline when found
