### PR TITLE
Allow relative URLs in notebook extensions

### DIFF
--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -19,7 +19,7 @@ define([
             extensions.push("nbextensions/" + arguments[i]);
         }
         
-        require(extensions,
+        require({ paths : { nbextensions: '/nbextensions' }}, extensions,
             function () {
                 for (var i = 0; i < arguments.length; i++) {
                     var ext = arguments[i];


### PR DESCRIPTION
When loading notebook extensions, additional resources (like CSS) need to be specified as absolute URL. This forces people to put an extension in a prefined directory structure or they have to modify the javascript code to change the path.

Now require.js allows URLs relative to the module:

``` Javascript
define(["require"], function(require) {
    var cssUrl = require.toUrl("./style.css");
});
```

(see: http://requirejs.org/docs/api.html)

Unfortunately this does not work, like a simple example demonstrates:

``` Javascript
/* testmodule.js */
"use strict";

define([
    'base/js/namespace',
    'jquery',
    'require',    
], function(IPython, $, require) {
    console.log('Testext')
    require(['./submodule'])
})
```

If loaded as notebook extension, instead of additonally loading `/nbextensions/submodule.js`, the invalid path `/notebooks/nbextensions/submodule.js` is used.

This PR allows to use relative URLs by providing the correct path to '/nbextensions'.
