### PR TITLE
moment.js-related fixes

### DIFF
--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -5,9 +5,10 @@ define([
     'base/js/namespace',
     'jquery',
     'codemirror/lib/codemirror',
+    'moment',
     // silently upgrades CodeMirror
     'codemirror/mode/meta',
-], function(IPython, $, CodeMirror){
+], function(IPython, $, CodeMirror, moment){
     "use strict";
     
     IPython.load_extensions = function () {
@@ -824,7 +825,42 @@ define([
             return MathJax.Hub.Queue(["Typeset", MathJax.Hub, this]);
         });
     };
-
+    
+    var time = {};
+    time.milliseconds = {};
+    time.milliseconds.s = 1000;
+    time.milliseconds.m = 60 * time.milliseconds.s;
+    time.milliseconds.h = 60 * time.milliseconds.m;
+    time.milliseconds.d = 24 * time.milliseconds.h;
+    
+    time.thresholds = {
+        // moment.js thresholds in milliseconds
+        s: moment.relativeTimeThreshold('s') * time.milliseconds.s,
+        m: moment.relativeTimeThreshold('m') * time.milliseconds.m,
+        h: moment.relativeTimeThreshold('h') * time.milliseconds.h,
+        d: moment.relativeTimeThreshold('d') * time.milliseconds.d,
+    };
+    
+    time.timeout_from_dt = function (dt) {
+        /** compute a timeout based on dt
+        
+        input and output both in milliseconds
+        
+        use moment's relative time thresholds:
+        
+        - 10 seconds if in 'seconds ago' territory
+        - 1 minute if in 'minutes ago'
+        - 1 hour otherwise
+        */
+        if (dt < time.thresholds.s) {
+            return 10 * time.milliseconds.s;
+        } else if (dt < time.thresholds.m) {
+            return time.milliseconds.m;
+        } else {
+            return time.milliseconds.h;
+        }
+    };
+    
     var utils = {
         regex_split : regex_split,
         uuid : uuid,
@@ -860,6 +896,7 @@ define([
         resolve_promises_dict: resolve_promises_dict,
         reject: reject,
         typeset: typeset,
+        time: time,
     };
 
     // Backwards compatability.

--- a/IPython/html/static/edit/js/savewidget.js
+++ b/IPython/html/static/edit/js/savewidget.js
@@ -141,39 +141,15 @@ define([
         var long_date = chkd.format('llll');
         var human_date;
         var tdelta = Math.ceil(new Date() - this._last_modified);
-        if (tdelta < 24 * H){
+        if (tdelta < utils.time.milliseconds.d){
             // less than 24 hours old, use relative date
             human_date = chkd.fromNow();
         } else {
-            // otherwise show calendar 
-            // otherwise update every hour and show
+            // otherwise show calendar
             // <Today | yesterday|...> at hh,mm,ss
             human_date = chkd.calendar();
         }
         el.text(human_date).attr('title', long_date);
-    };
-
-    
-    var S = 1000;
-    var M = 60*S;
-    var H = 60*M;
-    var thresholds = {
-        s: 45 * S,
-        m: 45 * M,
-        h: 22 * H
-    };
-    var _timeout_from_dt = function (ms) {
-        /** compute a timeout to update the last-modified timeout
-        
-        based on the delta in milliseconds
-        */
-        if (ms < thresholds.s) {
-            return 5 * S;
-        } else if (ms < thresholds.m) {
-            return M;
-        } else {
-            return 5 * M;
-        }
     };
     
     SaveWidget.prototype._schedule_render_last_modified = function () {
@@ -181,7 +157,6 @@ define([
         
         periodically updated, so short values like 'a few seconds ago' don't get stale.
         */
-        var that = this;
         if (!this._last_modified) {
             return;
         }
@@ -189,12 +164,10 @@ define([
             clearTimeout(this._last_modified_timeout);
         }
         var dt = Math.ceil(new Date() - this._last_modified);
-        if (dt < 24 * H) {
-            this._last_modified_timeout = setTimeout(
-                $.proxy(this._render_last_modified, this),
-                _timeout_from_dt(dt)
-            );
-        }
+        this._last_modified_timeout = setTimeout(
+            $.proxy(this._render_last_modified, this),
+            utils.time.timeout_from_dt(dt)
+        );
     };
 
     return {'SaveWidget': SaveWidget};


### PR DESCRIPTION
- add utils.time with a few time-related utilities used in a few places
- fix regular update of checkpoint date, which was only updating every 10 hours, regardless of the relative date
- update moment.js to 2.8.4, required for relativeTimeThreshold getters, which were being used in master, but didn't exist in moment.js 2.7

There's a fair amount of very similar logic in the SaveWidget in editor and notebook, but there are enough small differences that it would be more of a pain to add enough abstractions that they could share a base class than to duplicate a relatively small amount of code.
