### PR TITLE
Make the widget experimental error a real python warning

### DIFF
--- a/IPython/html/widgets/__init__.py
+++ b/IPython/html/widgets/__init__.py
@@ -25,6 +25,5 @@ from .widget_selectioncontainer import TabWidget, AccordionWidget
 from .widget_string import HTMLWidget, LatexWidget, TextWidget, TextareaWidget
 
 # Warn on import
-from IPython.utils.warn import warn
-warn("""The widget API is still considered experimental and 
-    may change by the next major release of IPython.""")
+from warnings import warn
+warn("""The widget API is still considered experimental and may change in the future.""", FutureWarning, stacklevel=2)


### PR DESCRIPTION
This means it can easily be turned off too.

If we are splitting off the widgets from IPython, then I still really think we shouldn't have a warning on import for the following reasons:
1. Since we are splitting off the widget library from IPython after 3.0, it makes little sense to say that it may change, because it is going to disappear
2. Once the widgets are split off, people are writing their code to a version of the widget library, not to a version of IPython.  It goes without saying that versions of the widget library may change over time.

I think the warning is only warranted if we split off the widgets, and then at some point want to backport semantic changes from the separate repo back to core IPython.  Is that what you see happening, @ellisonbg?

However, if @ellisonbg insists on an import warning, then this PR provides a more standard one that can be turned off once the point gets across. 
