### PR TITLE
use `-c` to launch ipengine/ipcontroller on Windows Python 2

### DIFF
--- a/IPython/parallel/apps/launcher.py
+++ b/IPython/parallel/apps/launcher.py
@@ -68,10 +68,12 @@ ipengine_cmd_argv = [sys.executable, "-m", "IPython.parallel.engine"]
 ipcontroller_cmd_argv = [sys.executable, "-m", "IPython.parallel.controller"]
 
 if WINDOWS and sys.version_info < (3,):
-    # `python -m package` doesn't work on Windows Python 2,
-    # but `python -m module` does.
-    ipengine_cmd_argv = [sys.executable, "-m", "IPython.parallel.apps.ipengineapp"]
-    ipcontroller_cmd_argv = [sys.executable, "-m", "IPython.parallel.apps.ipcontrollerapp"]
+    # `python -m package` doesn't work on Windows Python 2
+    # due to weird multiprocessing bugs
+    # and python -m module puts classes in the `__main__` module,
+    # so instance checks get confused
+    ipengine_cmd_argv = [sys.executable, "-c", "from IPython.parallel.engine.__main__ import main; main()"]
+    ipcontroller_cmd_argv = [sys.executable, "-c", "from IPython.parallel.controller.__main__ import main; main()"]
 
 #-----------------------------------------------------------------------------
 # Base launchers and errors

--- a/IPython/parallel/controller/__main__.py
+++ b/IPython/parallel/controller/__main__.py
@@ -1,3 +1,6 @@
-if __name__ == '__main__':
+def main():
     from IPython.parallel.apps import ipcontrollerapp as app
     app.launch_new_instance()
+    
+if __name__ == '__main__':
+    main()

--- a/IPython/parallel/engine/__main__.py
+++ b/IPython/parallel/engine/__main__.py
@@ -1,3 +1,6 @@
-if __name__ == '__main__':
+def main():
     from IPython.parallel.apps import ipengineapp as app
     app.launch_new_instance()
+    
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The previous behavior, introduced to workaround multiprocessing bugs (#4911), caused an instance check failure, preventing `bind_kernel` from being able to tell if the kernel is an engine.

closes #7198
