### PR TITLE
JSON formatter expects JSONable dict/list

### DIFF
--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -64,7 +64,7 @@ class MagicsDisplay(object):
         return magic_dict
         
     def _repr_json_(self):
-        return json.dumps(self._jsonable())
+        return self._jsonable()
 
 
 @magics_class

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -134,15 +134,20 @@ def test_json():
     lis = [d]
     j = display.JSON(d)
     nt.assert_equal(j._repr_json_(), d)
+    
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
         j = display.JSON(json.dumps(d))
         nt.assert_equal(len(w), 1)
-    nt.assert_equal(j._repr_json_(), d)
+        nt.assert_equal(j._repr_json_(), d)
+    
     j = display.JSON(lis)
     nt.assert_equal(j._repr_json_(), lis)
+    
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
         j = display.JSON(json.dumps(lis))
         nt.assert_equal(len(w), 1)
-    nt.assert_equal(j._repr_json_(), lis)
+        nt.assert_equal(j._repr_json_(), lis)
     
     

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -136,13 +136,13 @@ def test_json():
     nt.assert_equal(j._repr_json_(), d)
     with warnings.catch_warnings(record=True) as w:
         j = display.JSON(json.dumps(d))
-    assert len(w) == 1
+        nt.assert_equal(len(w), 1)
     nt.assert_equal(j._repr_json_(), d)
     j = display.JSON(lis)
     nt.assert_equal(j._repr_json_(), lis)
     with warnings.catch_warnings(record=True) as w:
         j = display.JSON(json.dumps(lis))
-    assert len(w) == 1
+        nt.assert_equal(len(w), 1)
     nt.assert_equal(j._repr_json_(), lis)
     
     

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -1,11 +1,9 @@
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2010-2011 The IPython Development Team.
-#
-#  Distributed under the terms of the BSD License.
-#
-#  The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import json
 import os
+import warnings
 
 import nose.tools as nt
 
@@ -130,3 +128,21 @@ def test_displayobject_repr():
     nt.assert_equal(repr(j), object.__repr__(j))
     j._show_mem_addr = False
     nt.assert_equal(repr(j), '<IPython.core.display.Javascript object>')
+
+def test_json():
+    d = {'a': 5}
+    lis = [d]
+    j = display.JSON(d)
+    nt.assert_equal(j._repr_json_(), d)
+    with warnings.catch_warnings(record=True) as w:
+        j = display.JSON(json.dumps(d))
+    assert len(w) == 1
+    nt.assert_equal(j._repr_json_(), d)
+    j = display.JSON(lis)
+    nt.assert_equal(j._repr_json_(), lis)
+    with warnings.catch_warnings(record=True) as w:
+        j = display.JSON(json.dumps(lis))
+    assert len(w) == 1
+    nt.assert_equal(j._repr_json_(), lis)
+    
+    

--- a/IPython/core/tests/test_formatters.py
+++ b/IPython/core/tests/test_formatters.py
@@ -1,5 +1,6 @@
 """Tests for the Formatters."""
 
+import warnings
 from math import pi
 
 try:
@@ -8,10 +9,11 @@ except:
     numpy = None
 import nose.tools as nt
 
+from IPython import get_ipython
 from IPython.config import Config
 from IPython.core.formatters import (
     PlainTextFormatter, HTMLFormatter, PDFFormatter, _mod_name_key,
-    DisplayFormatter,
+    DisplayFormatter, JSONFormatter,
 )
 from IPython.utils.io import capture_output
 
@@ -418,3 +420,14 @@ def test_ipython_display_formatter():
     nt.assert_equal(md, {})
     nt.assert_equal(catcher, [yes])
 
+def test_json_as_string_deprecated():
+    class JSONString(object):
+        def _repr_json_(self):
+            return '{}'
+    
+    f = JSONFormatter()
+    with warnings.catch_warnings(record=True) as w:
+        d = f(JSONString())
+    nt.assert_equal(d, {})
+    nt.assert_equal(len(w), 1)
+    

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 import io
 import os
 import sys
+import warnings
 from unittest import TestCase, skipIf
 
 try:
@@ -18,6 +19,7 @@ except ImportError:
 
 import nose.tools as nt
 
+from IPython import get_ipython
 from IPython.core import magic
 from IPython.core.error import UsageError
 from IPython.core.magic import (Magics, magics_class, line_magic,
@@ -980,3 +982,13 @@ def test_bookmark():
     with tt.AssertPrints('bmname'):
         ip.run_line_magic('bookmark', '-l')
     ip.run_line_magic('bookmark', '-d bmname')
+
+def test_ls_magic():
+    ip = get_ipython()
+    json_formatter = ip.display_formatter.formatters['application/json']
+    json_formatter.enabled = True
+    lsmagic = ip.magic('lsmagic')
+    with warnings.catch_warnings(record=True) as w:
+        j = json_formatter(lsmagic)
+    nt.assert_equal(sorted(j), ['cell', 'line'])
+    nt.assert_equal(w, []) # no warnings


### PR DESCRIPTION
not already-serialized JSON string

pre-3.0 case of JSON string is handled with a warning.

msgspec5 made this change, but Python APIs that publish JSON weren't updated to match.

closes #7209
