### PR TITLE
Add kernel resources (logos) to package_data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,7 +14,6 @@ prune IPython/html/static/mathjax
 # Include some specific files and data resources we need
 include IPython/.git_commit_info.ini
 include IPython/qt/console/resources/icon/IPythonConsole.svg
-include IPython/nbformat/v3/v3.withref.json
 
 # Documentation
 graft docs

--- a/setupbase.py
+++ b/setupbase.py
@@ -200,7 +200,8 @@ def find_package_data():
             'tests/*.ipynb',
             'v3/nbformat.v3.schema.json',
             'v4/nbformat.v4.schema.json',
-            ]
+            ],
+        'IPython.kernel': ['resources/*.*'],
     }
     
     return package_data


### PR DESCRIPTION
So that it gets installed. See discussion on #6537 where the problem came up.

It looks like we don't need to add this to MANIFEST.in - presumably package_data is included in the tarball automatically. I removed an outdated include path in there while I was looking.
