### PR TITLE
Add tests for history_request in message spec

### DIFF
--- a/IPython/kernel/tests/test_message_spec.py
+++ b/IPython/kernel/tests/test_message_spec.py
@@ -199,7 +199,7 @@ class ExecuteResult(MimeBundle):
     execution_count = Integer()
 
 class HistoryReply(Reference):
-    history = List(Unicode)
+    history = List(List())
 
 
 references = {
@@ -412,23 +412,29 @@ def test_is_complete():
 def test_history_range():
     flush_channels()
     
-    msg_id = KC.history("range", True, True)
+    msg_id = KC.history(hist_access_type = 'range', raw = True, output = True, start = 1, stop = 2, session = 0)
     reply = KC.get_shell_msg(timeout=TIMEOUT)
     validate_message(reply, 'history_reply', msg_id)
+    content = reply['content']
+    nt.assert_equal(len(content['history']), 1)
 
 def test_history_tail():
     flush_channels()
     
-    msg_id = KC.history("tail", True, True, n = 1)
+    msg_id = KC.history(hist_access_type = 'tail', raw = True, output = True, n = 1, session = 0)
     reply = KC.get_shell_msg(timeout=TIMEOUT)
     validate_message(reply, 'history_reply', msg_id)
+    content = reply['content']
+    nt.assert_equal(len(content['history']), 1)
 
 def test_history_search():
     flush_channels()
     
-    msg_id = KC.history("search", True, True, n = 1, pattern = "*")
+    msg_id = KC.history(hist_access_type = 'search', raw = True, output = True, n = 1, pattern = '*', session = 0)
     reply = KC.get_shell_msg(timeout=TIMEOUT)
     validate_message(reply, 'history_reply', msg_id)
+    content = reply['content']
+    nt.assert_equal(len(content['history']), 1)
 
 # IOPub channel
 

--- a/IPython/kernel/tests/test_message_spec.py
+++ b/IPython/kernel/tests/test_message_spec.py
@@ -198,6 +198,9 @@ class DisplayData(MimeBundle):
 class ExecuteResult(MimeBundle):
     execution_count = Integer()
 
+class HistoryReply(MimeBundle):
+    history = List(Unicode)
+
 
 references = {
     'execute_reply' : ExecuteReply(),
@@ -208,6 +211,7 @@ references = {
     'is_complete_reply': IsCompleteReply(),
     'execute_input' : ExecuteInput(),
     'execute_result' : ExecuteResult(),
+    'history_reply' : HistoryReply(),
     'error' : Error(),
     'stream' : Stream(),
     'display_data' : DisplayData(),
@@ -401,10 +405,17 @@ def test_single_payload():
 
 def test_is_complete():
     flush_channels()
-    
+    a
     msg_id = KC.is_complete("a = 1")
     reply = KC.get_shell_msg(timeout=TIMEOUT)
     validate_message(reply, 'is_complete_reply', msg_id)
+
+def test_history():
+    flush_channels()
+    
+    msg_id = KC.history("range", True, True)
+    reply = KC.get_shell_msg(timeout=TIMEOUT)
+    validate_message(reply, 'history_reply', msg_id)
 
 # IOPub channel
 

--- a/IPython/kernel/tests/test_message_spec.py
+++ b/IPython/kernel/tests/test_message_spec.py
@@ -198,7 +198,7 @@ class DisplayData(MimeBundle):
 class ExecuteResult(MimeBundle):
     execution_count = Integer()
 
-class HistoryReply(MimeBundle):
+class HistoryReply(Reference):
     history = List(Unicode)
 
 
@@ -405,15 +405,28 @@ def test_single_payload():
 
 def test_is_complete():
     flush_channels()
-    a
     msg_id = KC.is_complete("a = 1")
     reply = KC.get_shell_msg(timeout=TIMEOUT)
     validate_message(reply, 'is_complete_reply', msg_id)
 
-def test_history():
+def test_history_range():
     flush_channels()
     
     msg_id = KC.history("range", True, True)
+    reply = KC.get_shell_msg(timeout=TIMEOUT)
+    validate_message(reply, 'history_reply', msg_id)
+
+def test_history_tail():
+    flush_channels()
+    
+    msg_id = KC.history("tail", True, True, n = 1)
+    reply = KC.get_shell_msg(timeout=TIMEOUT)
+    validate_message(reply, 'history_reply', msg_id)
+
+def test_history_search():
+    flush_channels()
+    
+    msg_id = KC.history("search", True, True, n = 1, pattern = "*")
     reply = KC.get_shell_msg(timeout=TIMEOUT)
     validate_message(reply, 'history_reply', msg_id)
 

--- a/IPython/kernel/tests/test_message_spec.py
+++ b/IPython/kernel/tests/test_message_spec.py
@@ -405,12 +405,16 @@ def test_single_payload():
 
 def test_is_complete():
     flush_channels()
+
     msg_id = KC.is_complete("a = 1")
     reply = KC.get_shell_msg(timeout=TIMEOUT)
     validate_message(reply, 'is_complete_reply', msg_id)
 
 def test_history_range():
     flush_channels()
+    
+    msg_id_exec = KC.execute(code='x=1', store_history = True)
+    reply_exec = KC.get_shell_msg(timeout=TIMEOUT)
     
     msg_id = KC.history(hist_access_type = 'range', raw = True, output = True, start = 1, stop = 2, session = 0)
     reply = KC.get_shell_msg(timeout=TIMEOUT)
@@ -421,6 +425,9 @@ def test_history_range():
 def test_history_tail():
     flush_channels()
     
+    msg_id_exec = KC.execute(code='x=1', store_history = True)
+    reply_exec = KC.get_shell_msg(timeout=TIMEOUT)
+    
     msg_id = KC.history(hist_access_type = 'tail', raw = True, output = True, n = 1, session = 0)
     reply = KC.get_shell_msg(timeout=TIMEOUT)
     validate_message(reply, 'history_reply', msg_id)
@@ -429,6 +436,9 @@ def test_history_tail():
 
 def test_history_search():
     flush_channels()
+    
+    msg_id_exec = KC.execute(code='x=1', store_history = True)
+    reply_exec = KC.get_shell_msg(timeout=TIMEOUT)
     
     msg_id = KC.history(hist_access_type = 'search', raw = True, output = True, n = 1, pattern = '*', session = 0)
     reply = KC.get_shell_msg(timeout=TIMEOUT)


### PR DESCRIPTION
I was going through the tests to understand how the do_history call works and found that there is no message spec test for history_request. I added 3 simple tests to check this request. I have run iptest and confirmed there are no issues.
