### PR TITLE
Fix invalid json in doc

### DIFF
--- a/docs/source/development/wrapperkernels.rst
+++ b/docs/source/development/wrapperkernels.rst
@@ -105,7 +105,7 @@ Example
 Here's the Kernel spec ``kernel.json`` file for this::
 
     {"argv":["python","-m","echokernel", "-f", "{connection_file}"],
-     "display_name":"Echo",
+     "display_name":"Echo"
     }
 
 


### PR DESCRIPTION
Should not have trailing comma.
