### PR TITLE
don't store signatures in notebooks

### DIFF
--- a/IPython/html/services/contents/tests/test_manager.py
+++ b/IPython/html/services/contents/tests/test_manager.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import logging
 import os
+import time
 
 from tornado.web import HTTPError
 from unittest import TestCase
@@ -106,6 +107,7 @@ class TestContentsManager(TestCase):
 
         full_model = cm.get(path)
         nb = full_model['content']
+        nb['metadata']['counter'] = int(1e6 * time.time())
         self.add_code_cell(nb)
 
         cm.save(full_model, path)

--- a/IPython/nbformat/sign.py
+++ b/IPython/nbformat/sign.py
@@ -354,7 +354,7 @@ class NotebookNotary(LoggingConfigurable):
 trust_flags = {
     'reset' : (
         {'TrustNotebookApp' : { 'reset' : True}},
-        """Generate a new key for notebook signature.
+        """Delete the trusted notebook cache.
         All previously signed notebooks will become untrusted.
         """
     ),
@@ -383,7 +383,7 @@ class TrustNotebookApp(BaseIPythonApplication):
     flags = trust_flags
     
     reset = Bool(False, config=True,
-        help="""If True, generate a new key for notebook signature.
+        help="""If True, delete the trusted signature cache.
         After reset, all previously signed notebooks will become untrusted.
         """
     )
@@ -413,6 +413,9 @@ class TrustNotebookApp(BaseIPythonApplication):
     
     def start(self):
         if self.reset:
+            if os.path.exists(self.notary.db_file):
+                print("Removing trusted signature cache: %s" % self.notary.db_file)
+                os.remove(self.notary.db_file)
             self.generate_new_key()
             return
         if not self.extra_args:

--- a/IPython/nbformat/tests/test_sign.py
+++ b/IPython/nbformat/tests/test_sign.py
@@ -16,9 +16,9 @@ class TestNotary(TestsBase):
     
     def setUp(self):
         self.notary = sign.NotebookNotary(
+            db_file=':memory:',
             secret=b'secret',
             profile_dir=get_ipython().profile_dir,
-            db_file=':memory:'
         )
         with self.fopen(u'test3.ipynb', u'r') as f:
             self.nb = read(f, as_version=4)

--- a/IPython/nbformat/v4/convert.py
+++ b/IPython/nbformat/v4/convert.py
@@ -56,6 +56,7 @@ def upgrade(nb, from_version=3, from_minor=0):
                 cells.append(upgrade_cell(cell))
         # upgrade metadata
         nb.metadata.pop('name', '')
+        nb.metadata.pop('signature', '')
         # Validate the converted notebook before returning it
         _warn_if_invalid(nb, nbformat)
         return nb

--- a/IPython/nbformat/v4/nbformat.v4.schema.json
+++ b/IPython/nbformat/v4/nbformat.v4.schema.json
@@ -55,10 +55,6 @@
                     }
                   }
                 },
-                "signature": {
-                    "description": "Hash of the notebook.",
-                    "type": "string"
-                },
                 "orig_nbformat": {
                     "description": "Original notebook format (major number) before converting the notebook between versions. This should never be written to a file.",
                     "type": "integer",

--- a/IPython/nbformat/v4/rwbase.py
+++ b/IPython/nbformat/v4/rwbase.py
@@ -64,6 +64,7 @@ def strip_transient(nb):
     """
     nb.metadata.pop('orig_nbformat', None)
     nb.metadata.pop('orig_nbformat_minor', None)
+    nb.metadata.pop('signature', None)
     for cell in nb.cells:
         cell.metadata.pop('trusted', None)
     return nb

--- a/examples/Customization/Index.ipynb
+++ b/examples/Customization/Index.ipynb
@@ -95,9 +95,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:de8cb1aff3da9097ba3fc7afab4327fc589f2bb1c154feeeb5ed97c87e37486f"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/Embedding/Index.ipynb
+++ b/examples/Embedding/Index.ipynb
@@ -186,9 +186,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:627cdf03b8de558c9344f9d1e8f0beeb2448e37e492d676e6db7b07d33251a2b"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/IPython Kernel/Beyond Plain Python.ipynb
+++ b/examples/IPython Kernel/Beyond Plain Python.ipynb
@@ -1799,9 +1799,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:31071a05d0ecd75ed72fe3f0de0ad447a6f85cffe382c26efa5e68db1fee54ee"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/IPython Kernel/Capturing Output.ipynb
+++ b/examples/IPython Kernel/Capturing Output.ipynb
@@ -481,9 +481,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:df6354daf203e842bc040989d149760382d8ceec769160e4efe8cde9dfcb9107"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/IPython Kernel/Custom Display Logic.ipynb
+++ b/examples/IPython Kernel/Custom Display Logic.ipynb
@@ -1317,9 +1317,7 @@
    "source": []
   }
  ],
- "metadata": {
-  "signature": "sha256:86c779d5798c4a68bda7e71c8ef320cb7ba9d7e3d0f1bc4b828ee65f617a5ae3"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/IPython Kernel/Index.ipynb
+++ b/examples/IPython Kernel/Index.ipynb
@@ -160,9 +160,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:ee769d05a7e195e4b8546ef9a866ef03e59bff2f0fcba499d168c06b516aa79a"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/IPython Kernel/Plotting in the Notebook.ipynb
+++ b/examples/IPython Kernel/Plotting in the Notebook.ipynb
@@ -732,9 +732,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:74dbf5caa25c937be70dfe2ab509783a01f4a2044850d7044e729300a8c3644d"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/IPython Kernel/Raw Input in the Notebook.ipynb
+++ b/examples/IPython Kernel/Raw Input in the Notebook.ipynb
@@ -150,9 +150,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:ac5c21534f3dd013c78d4d201527f3ed4dea5b6fad4116b8d23c67ba107e48c3"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/IPython Kernel/Rich Output.ipynb
+++ b/examples/IPython Kernel/Rich Output.ipynb
@@ -3051,9 +3051,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:cf83dc9e6288480ac94c44a5983b4ee421f0ade792a9fac64bc00719263386c0"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/IPython Kernel/SymPy.ipynb
+++ b/examples/IPython Kernel/SymPy.ipynb
@@ -1647,9 +1647,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:a0f4cda82587c5b8e7a4502192d1210abedac9084077604eb60aea15f262a344"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/IPython Kernel/Terminal Usage.ipynb
+++ b/examples/IPython Kernel/Terminal Usage.ipynb
@@ -261,9 +261,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:993106eecfd7abe1920e1dbe670c4518189c26e7b29dcc541835f7dcf6fffbb2"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/IPython Kernel/Third Party Rich Output.ipynb
+++ b/examples/IPython Kernel/Third Party Rich Output.ipynb
@@ -517,9 +517,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:123d82ef0551f78e5dca94db6e00f1e10ae07d930467cf44709ccc6a9216776a"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/IPython Kernel/Trapezoid Rule.ipynb
+++ b/examples/IPython Kernel/Trapezoid Rule.ipynb
@@ -374,9 +374,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:cbf49a9ceac0258773ae0a652e9ac7c13e0d042debbf0115cdc081862b5f7308"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/IPython Kernel/Working With External Code.ipynb
+++ b/examples/IPython Kernel/Working With External Code.ipynb
@@ -333,9 +333,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:4352d4e1c693d919ce40b29ecf5a536917160df68b19a85caccedb1ea7ad06e1"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/Index.ipynb
+++ b/examples/Index.ipynb
@@ -41,9 +41,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:0b4b631419772e40e0f4893f5a0f0fe089a39e46c8862af0256164628394302d"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/Interactive Widgets/Beat Frequencies.ipynb
+++ b/examples/Interactive Widgets/Beat Frequencies.ipynb
@@ -591,9 +591,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:da6a3d73881e321e5ef406aea3e7d706c9dd405c94675318afde957d292f9cb9"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/Interactive Widgets/Exploring Graphs.ipynb
+++ b/examples/Interactive Widgets/Exploring Graphs.ipynb
@@ -830,9 +830,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:61f24f38b76cb12d46c178eadc5d85d61bd0fc27f959236ea756ef8e1adc2693"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/Interactive Widgets/Factoring.ipynb
+++ b/examples/Interactive Widgets/Factoring.ipynb
@@ -131,9 +131,7 @@
    "source": []
   }
  ],
- "metadata": {
-  "signature": "sha256:5f38c57d9570e4b6f6edf98c38a7bff81cd16365baa11fd40265f1504bfc008c"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/Interactive Widgets/Image Browser.ipynb
+++ b/examples/Interactive Widgets/Image Browser.ipynb
@@ -297,9 +297,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:4e9f4ce8fa9be2e33ffdae399daec11bf3ef63a6f0065b1d59739310ebfe8008"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/Interactive Widgets/Image Processing.ipynb
+++ b/examples/Interactive Widgets/Image Processing.ipynb
@@ -26762,9 +26762,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:d75ab1c53fa3389eeac78ecf8e89beb52871950f296aad25776699b6d6125037"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/Interactive Widgets/Lorenz Differential Equations.ipynb
+++ b/examples/Interactive Widgets/Lorenz Differential Equations.ipynb
@@ -13428,9 +13428,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:c6ccfb14927d633933da8b5c0f776a8da756d833654b5a3f8b6121b390ca6424"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/Notebook/Connecting with the Qt Console.ipynb
+++ b/examples/Notebook/Connecting with the Qt Console.ipynb
@@ -131,9 +131,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:9a1dd30de04270174c09ef33ca214e5b15ca3721547420087c1563ad557d78e3"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/Notebook/Index.ipynb
+++ b/examples/Notebook/Index.ipynb
@@ -68,9 +68,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:5a3c5ebae9154e13957e7c9d28bd3b7697c4b14f965482feb288d2cdf078983e"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/Notebook/Notebook Security.ipynb
+++ b/examples/Notebook/Notebook Security.ipynb
@@ -1,8 +1,6 @@
 {
  "cells": [],
- "metadata": {
-  "signature": "sha256:0abf067a20ebda26a671db997ac954770350d292dff7b7d6a4ace8808f70aca1"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/Notebook/Running the Notebook Server.ipynb
+++ b/examples/Notebook/Running the Notebook Server.ipynb
@@ -355,9 +355,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:ee4b22b4c949fe21b3e5cda24f0916ba59d8c09443f4a897d98b96d4a73ac335"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/Notebook/Working With Markdown Cells.ipynb
+++ b/examples/Notebook/Working With Markdown Cells.ipynb
@@ -296,9 +296,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:3b7cae0c0936f25e6ccb7acafe310c08a4162a1a7fd66fa9874a52cffa0f64f9"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/Parallel Computing/Index.ipynb
+++ b/examples/Parallel Computing/Index.ipynb
@@ -346,9 +346,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:1e9336d35cc07875300c5b876df6ce1f1971c2ee94870788c6ea32bbb789c42b"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/Parallel Computing/Monte Carlo Options.ipynb
+++ b/examples/Parallel Computing/Monte Carlo Options.ipynb
@@ -2533,9 +2533,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:1b19dedc6473d4e886e549020c6710f2d14c17296168a02e7e7fa9673912b893"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/examples/Parallel Computing/Parallel Decorator and map.ipynb
+++ b/examples/Parallel Computing/Parallel Decorator and map.ipynb
@@ -107,9 +107,7 @@
    "source": []
   }
  ],
- "metadata": {
-  "signature": "sha256:8781781d8835d77bf0f71b535b72ee2718405543c48e87ad0408242119cdb3cc"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }


### PR DESCRIPTION
store them in sqlite in .ipython instead.

While we are doing an nbformat revision, this information doesn't really fit in the notebook content, and causes problems for notebooks in VCS.

Only the signature (and the associated hash algorithm) are stored, not associated with any document or path. This means that moving or copying files doesn't affect trust, and every trusted change to a notebook remains trusted.

64k signatures are remembered by default, and when the size limit is reached the oldest 25% are discarded, meaning that notebooks you haven't opened in a long time can become untrusted. I don't think that's a big deal, because you can explicitly trust them again with the click of a button.

ping @ellisonbg, @fperez

This one's for you, @ahmadia
