### PR TITLE
MAINT: Use `Type` instead of `DottedObjectName` for managers.

### DIFF
--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -67,6 +67,8 @@ from .services.clusters.clustermanager import ClusterManager
 from .services.sessions.sessionmanager import SessionManager
 
 from .base.handlers import AuthenticatedFileHandler, FileFindHandler
+from .auth.login import LoginHandler
+from .auth.logout import LogoutHandler
 
 from IPython.config import Config
 from IPython.config.application import catch_config_error, boolean_flag
@@ -83,7 +85,7 @@ from IPython.utils import submodule
 from IPython.utils.process import check_pid
 from IPython.utils.traitlets import (
     Dict, Unicode, Integer, List, Bool, Bytes, Instance,
-    DottedObjectName, TraitError, Type,
+    TraitError, Type,
 )
 from IPython.utils import py3compat
 from IPython.utils.path import filefind, get_ipython_dir
@@ -660,13 +662,17 @@ class NotebookApp(BaseIPythonApplication):
         """
     )
 
-    login_handler = DottedObjectName('IPython.html.auth.login.LoginHandler',
+    login_handler = Type(
+        default_value=LoginHandler,
         config=True,
-        help='The login handler class to use.')
+        help='The login handler class to use.',
+    )
 
-    logout_handler = DottedObjectName('IPython.html.auth.logout.LogoutHandler',
+    logout_handler = Type(
+        default_value=LogoutHandler,
         config=True,
-        help='The logout handler class to use.')
+        help='The logout handler class to use.',
+    )
 
     trust_xheaders = Bool(False, config=True,
         help=("Whether to trust or not X-Scheme/X-Forwarded-Proto and X-Real-Ip/X-Forwarded-For headers"
@@ -777,8 +783,10 @@ class NotebookApp(BaseIPythonApplication):
             parent=self,
             log=self.log,
         )
-        self.login_handler_class = import_item(self.login_handler)
-        self.logout_handler_class = import_item(self.logout_handler)
+
+        # Maintaining this naming convention for backwards compatibility.
+        self.login_handler_class = self.login_handler
+        self.logout_handler_class = self.logout_handler
 
         self.config_manager = self.config_manager_class(
             parent=self,

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -21,7 +21,6 @@ import signal
 import socket
 import sys
 import threading
-import time
 import webbrowser
 
 
@@ -66,9 +65,9 @@ from .services.contents.filemanager import FileContentsManager
 from .services.clusters.clustermanager import ClusterManager
 from .services.sessions.sessionmanager import SessionManager
 
-from .base.handlers import AuthenticatedFileHandler, FileFindHandler
 from .auth.login import LoginHandler
 from .auth.logout import LogoutHandler
+from .base.handlers import FileFindHandler
 
 from IPython.config import Config
 from IPython.config.application import catch_config_error, boolean_flag

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -661,16 +661,16 @@ class NotebookApp(BaseIPythonApplication):
         """
     )
 
-    login_handler = Type(
+    login_handler_class = Type(
         default_value=LoginHandler,
-        klass=object,
+        klass=web.RequestHandler,
         config=True,
         help='The login handler class to use.',
     )
 
-    logout_handler = Type(
+    logout_handler_class = Type(
         default_value=LogoutHandler,
-        klass=object,
+        klass=web.RequestHandler,
         config=True,
         help='The logout handler class to use.',
     )
@@ -784,10 +784,6 @@ class NotebookApp(BaseIPythonApplication):
             parent=self,
             log=self.log,
         )
-
-        # Maintaining this naming convention for backwards compatibility.
-        self.login_handler_class = self.login_handler
-        self.logout_handler_class = self.logout_handler
 
         self.config_manager = self.config_manager_class(
             parent=self,

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -67,7 +67,7 @@ from .services.sessions.sessionmanager import SessionManager
 
 from .auth.login import LoginHandler
 from .auth.logout import LogoutHandler
-from .base.handlers import FileFindHandler
+from .base.handlers import IPythonHandler, FileFindHandler
 
 from IPython.config import Config
 from IPython.config.application import catch_config_error, boolean_flag
@@ -663,12 +663,14 @@ class NotebookApp(BaseIPythonApplication):
 
     login_handler = Type(
         default_value=LoginHandler,
+        klass=object,
         config=True,
         help='The login handler class to use.',
     )
 
     logout_handler = Type(
         default_value=LogoutHandler,
+        klass=object,
         config=True,
         help='The logout handler class to use.',
     )


### PR DESCRIPTION
`Type` is strictly more powerful than `DottedObjectName` and is easier for users to override.

This specifically came up in the context of wanting to pass a class object for `contents_manager_class`, but it seemed reasonable to change the rest of the managers for consistency.

Ported from https://github.com/minrk/ipython/pull/21.
ping @minrk 
