### PR TITLE
avoid the absolute_path AttributeError

### DIFF
--- a/IPython/html/kernelspecs/handlers.py
+++ b/IPython/html/kernelspecs/handlers.py
@@ -1,3 +1,4 @@
+import hashlib
 from tornado import web
 from ..base.handlers import IPythonHandler
 from ..services.kernelspecs.handlers import kernel_name_regex
@@ -21,6 +22,19 @@ class KernelSpecResourceHandler(web.StaticFileHandler, IPythonHandler):
     @web.authenticated
     def head(self, kernel_name, path):
         self.get(kernel_name, path, include_body=False)
+
+    def compute_etag(self):
+        """Computes the etag header to be used for this request.
+
+        By default uses a hash of the content written so far.
+
+        May be overridden to provide custom etag implementations,
+        or may return None to disable tornado's default etag support.
+        """
+        hasher = hashlib.sha1()
+        for part in self._write_buffer:
+            hasher.update(part)
+        return '"%s"' % hasher.hexdigest()
 
 default_handlers = [
     (r"/kernelspecs/%s/(?P<path>.*)" % kernel_name_regex, KernelSpecResourceHandler),


### PR DESCRIPTION
I use OS X and tornado 4.0.2. when i pull the newest code and open ipython notebook. i saw this error:

``` python
[E 18:45:05.487 NotebookApp] Uncaught exception HEAD /kernelspecs/python2/kernel.css (127.0.0.1)
    HTTPServerRequest(protocol='http', host='localhost:8888', method='HEAD', uri='/kernelspecs/python2/kernel.css', version='HTTP/1.1', remote_ip='127.0.0.1', headers={'Accept-Language': 'zh-cn,zh;q=0.8,en-us;q=0.5,en;q=0.3', 'Accept-Encoding': 'gzip, deflate', 'Host': 'localhost:8888', 'Accept': '*/*', 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:34.0) Gecko/20100101 Firefox/34.0', 'Connection': 'keep-alive', 'X-Requested-With': 'XMLHttpRequest', 'Referer': 'http://localhost:8888/notebooks/highchart.ipynb', 'Cookie': '_ga=GA1.1.2065628746.1410254883; dae_sdk_user=testuser'})
    Traceback (most recent call last):
      File "/Library/Python/2.7/site-packages/tornado/web.py", line 1340, in _execute
        self.finish()
      File "/Library/Python/2.7/site-packages/tornado/web.py", line 879, in finish
        self.set_etag_header()
      File "/Library/Python/2.7/site-packages/tornado/web.py", line 1259, in set_etag_header
        etag = self.compute_etag()
      File "/Library/Python/2.7/site-packages/tornado/web.py", line 2201, in compute_etag
        version_hash = self._get_cached_version(self.absolute_path)
    AttributeError: 'KernelSpecResourceHandler' object has no attribute 'absolute_path'
[E 18:45:05.493 NotebookApp] {
      "Accept-Language": "zh-cn,zh;q=0.8,en-us;q=0.5,en;q=0.3", 
      "Accept-Encoding": "gzip, deflate", 
      "Connection": "keep-alive", 
      "Accept": "*/*", 
      "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:34.0) Gecko/20100101 Firefox/34.0", 
      "Host": "localhost:8888", 
      "X-Requested-With": "XMLHttpRequest", 
      "Cookie": "_ga=GA1.1.2065628746.1410254883; dae_sdk_user=testuser", 
      "Referer": "http://localhost:8888/notebooks/highchart.ipynb"
    }

```

In [tornado issue826](https://github.com/tornadoweb/tornado/issues/826) is discussed this. 

$python -c "import IPython; print(IPython.sys_info())"
{'commit_hash': u'91c5746',
 'commit_source': 'repository',
 'default_encoding': 'UTF-8',
 'ipython_path': '/Users/dongweiming/ipython/IPython',
 'ipython_version': '3.0.0-dev',
 'os_name': 'posix',
 'platform': 'Darwin-13.4.0-x86_64-i386-64bit',
 'sys_executable': '/usr/bin/python',
 'sys_platform': 'darwin',
 'sys_version': '2.7.5 (default, Mar  9 2014, 22:15:05) \n[GCC 4.2.1 Compatible Apple LLVM 5.0 (clang-500.0.68)]'}
