### PR TITLE
Fix HEAD requests for kernelspec resources

### DIFF
--- a/IPython/html/kernelspecs/handlers.py
+++ b/IPython/html/kernelspecs/handlers.py
@@ -20,7 +20,7 @@ class KernelSpecResourceHandler(web.StaticFileHandler, IPythonHandler):
 
     @web.authenticated
     def head(self, kernel_name, path):
-        self.get(kernel_name, path, include_body=False)
+        return self.get(kernel_name, path, include_body=False)
 
 default_handlers = [
     (r"/kernelspecs/%s/(?P<path>.*)" % kernel_name_regex, KernelSpecResourceHandler),


### PR DESCRIPTION
Closes gh-7237
Closes gh-7258

StaticFileHandler.get() is a coroutine. When Tornado calls a handler method, it uses the return value to determine whether or not it's a coroutine. So when head() calls get(), it needs to pass the return value on for Tornado to handle it properly.
