### PR TITLE
run_cell returns an ExecutionResult instance

### DIFF
--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -30,6 +30,8 @@ class DisplayHook(Configurable):
     """
 
     shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
+    exec_result = Instance('IPython.core.interactiveshell.ExecutionResult',
+                           allow_none=True)
     cull_fraction = Float(0.2)
 
     def __init__(self, shell=None, cache_size=1000, **kwargs):
@@ -198,6 +200,10 @@ class DisplayHook(Configurable):
                 self.shell.push(to_main, interactive=False)
                 self.shell.user_ns['_oh'][self.prompt_count] = result
 
+    def fill_exec_result(self, result):
+        if self.exec_result is not None:
+            self.exec_result.result = result
+
     def log_output(self, format_dict):
         """Log the output."""
         if 'text/plain' not in format_dict:
@@ -225,6 +231,7 @@ class DisplayHook(Configurable):
             self.write_output_prompt()
             format_dict, md_dict = self.compute_format_data(result)
             self.update_user_ns(result)
+            self.fill_exec_result(result)
             if format_dict:
                 self.write_format_data(format_dict, md_dict)
                 self.log_output(format_dict)

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -71,8 +71,6 @@ class InteractiveShellTestCase(unittest.TestCase):
     def test_run_cell_multiline(self):
         """Multi-block, multi-line cells must execute correctly.
         """
-        print(ip.history_manager.input_hist_raw)
-        print(ip.history_manager.output_hist)
         src = '\n'.join(["x=1",
                          "y=2",
                          "if 1:",
@@ -82,8 +80,6 @@ class InteractiveShellTestCase(unittest.TestCase):
         self.assertEqual(ip.user_ns['x'], 2)
         self.assertEqual(ip.user_ns['y'], 3)
         self.assertEqual(res.success, True)
-        print(ip.history_manager.input_hist_raw)
-        print(ip.history_manager.output_hist)
         self.assertEqual(res.result, None)
 
     def test_multiline_string_cells(self):

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -64,35 +64,45 @@ class InteractiveShellTestCase(unittest.TestCase):
         """Just make sure we don't get a horrible error with a blank
         cell of input. Yes, I did overlook that."""
         old_xc = ip.execution_count
-        ip.run_cell('')
+        res = ip.run_cell('')
         self.assertEqual(ip.execution_count, old_xc)
+        self.assertEqual(res.execution_count, None)
 
     def test_run_cell_multiline(self):
         """Multi-block, multi-line cells must execute correctly.
         """
+        print(ip.history_manager.input_hist_raw)
+        print(ip.history_manager.output_hist)
         src = '\n'.join(["x=1",
                          "y=2",
                          "if 1:",
                          "    x += 1",
                          "    y += 1",])
-        ip.run_cell(src)
+        res = ip.run_cell(src)
         self.assertEqual(ip.user_ns['x'], 2)
         self.assertEqual(ip.user_ns['y'], 3)
+        self.assertEqual(res.success, True)
+        print(ip.history_manager.input_hist_raw)
+        print(ip.history_manager.output_hist)
+        self.assertEqual(res.result, None)
 
     def test_multiline_string_cells(self):
         "Code sprinkled with multiline strings should execute (GH-306)"
         ip.run_cell('tmp=0')
         self.assertEqual(ip.user_ns['tmp'], 0)
-        ip.run_cell('tmp=1;"""a\nb"""\n')
+        res = ip.run_cell('tmp=1;"""a\nb"""\n')
         self.assertEqual(ip.user_ns['tmp'], 1)
+        self.assertEqual(res.success, True)
+        self.assertEqual(res.result, "a\nb")
 
     def test_dont_cache_with_semicolon(self):
         "Ending a line with semicolon should not cache the returned object (GH-307)"
         oldlen = len(ip.user_ns['Out'])
         for cell in ['1;', '1;1;']:
-            ip.run_cell(cell, store_history=True)
+            res = ip.run_cell(cell, store_history=True)
             newlen = len(ip.user_ns['Out'])
             self.assertEqual(oldlen, newlen)
+            self.assertIsNone(res.result)
         i = 0
         #also test the default caching behavior
         for cell in ['1', '1;1']:
@@ -100,6 +110,10 @@ class InteractiveShellTestCase(unittest.TestCase):
             newlen = len(ip.user_ns['Out'])
             i += 1
             self.assertEqual(oldlen+i, newlen)
+
+    def test_syntax_error(self):
+        res = ip.run_cell("raise = 3")
+        self.assertIsInstance(res.error_before_exec, SyntaxError)
 
     def test_In_variable(self):
         "Verify that In variable grows with user input (GH-284)"
@@ -330,8 +344,9 @@ class InteractiveShellTestCase(unittest.TestCase):
         
         try:
             trap.hook = failing_hook
-            ip.run_cell("1", silent=True)
+            res = ip.run_cell("1", silent=True)
             self.assertFalse(d['called'])
+            self.assertIsNone(res.result)
             # double-check that non-silent exec did what we expected
             # silent to avoid
             ip.run_cell("1")
@@ -443,9 +458,11 @@ class InteractiveShellTestCase(unittest.TestCase):
         
         ip.set_custom_exc((ValueError,), my_handler)
         try:
-            ip.run_cell("raise ValueError('test')")
+            res = ip.run_cell("raise ValueError('test')")
             # Check that this was called, and only once.
             self.assertEqual(called, [ValueError])
+            # Check that the error is on the result object
+            self.assertIsInstance(res.error_in_exec, ValueError)
         finally:
             # Reset the custom exception hook
             ip.set_custom_exc((), None)
@@ -760,7 +777,9 @@ class TestAstTransformInputRejection(unittest.TestCase):
             ip.run_cell("'unsafe'")
 
         with expect_exception_tb, expect_no_cell_output:
-            ip.run_cell("'unsafe'")
+            res = ip.run_cell("'unsafe'")
+
+        self.assertIsInstance(res.error_before_exec, InputRejected)
 
 def test__IPYTHON__():
     # This shouldn't raise a NameError, that's all


### PR DESCRIPTION
#7256 asked for a boolean return value from run_cell() for whether code ran successfully. I discussed this with Min, who suggested that given the complexity of run_cell, it should return a result object that can store different pieces of information about what happened.

This currently stores `execution_count`, `error_before_exec` (i.e. errors transforming, parsing or compiling the code), `error_in_exec` and `result`. It calculates `success` as a boolean that's true if neither of the error fields are set.

Closes gh-7256
