### PR TITLE
Update custom.js for 3.0

### DIFF
--- a/IPython/html/static/custom/custom.js
+++ b/IPython/html/static/custom/custom.js
@@ -11,16 +11,20 @@
  * It will be executed by the ipython notebook at load time.
  *
  * Same thing with `profile/static/custom/custom.css` to inject custom css into the notebook.
- * 
- * Classes and functions are available at load time and may be accessed plainly: 
- * 
+ *
+ * Classes and functions are available at load time and may be accessed plainly:
+ *
  *     IPython.Cell.options_default.cm_config.extraKeys['Home'] = 'goLineLeft';
  *     IPython.Cell.options_default.cm_config.extraKeys['End'] = 'goLineRight';
- * 
+ *
  * Instances are created later however and must be accessed using events:
- * 
- *     $([IPython.events]).on("app_initialized.NotebookApp", function () {
- *         IPython.keyboard_manager....
+ *     require([
+ *        'base/js/namespace',
+ *        'base/js/events'
+ *     ], function(IPython, events) {
+ *         events.on("app_initialized.NotebookApp", function () {
+ *             IPython.keyboard_manager....
+ *         });
  *     });
  *
  * __Example 1:__
@@ -28,26 +32,35 @@
  * Create a custom button in toolbar that execute `%qtconsole` in kernel
  * and hence open a qtconsole attached to the same kernel as the current notebook
  *
- *    IPython.events.on('app_initialized.NotebookApp', function(){
- *        IPython.toolbar.add_buttons_group([
- *            {
- *                 'label'   : 'run qtconsole',
- *                 'icon'    : 'icon-terminal', // select your icon from http://fortawesome.github.io/Font-Awesome/icons
- *                 'callback': function () {
- *                     IPython.notebook.kernel.execute('%qtconsole')
- *                 }
- *            }
- *            // add more button here if needed.
- *            ]);
+ *    require([
+ *        'base/js/namespace',
+ *        'base/js/events'
+ *    ], function(IPython, events) {
+ *        events.on('app_initialized.NotebookApp', function(){
+ *            IPython.toolbar.add_buttons_group([
+ *                {
+ *                    'label'   : 'run qtconsole',
+ *                    'icon'    : 'icon-terminal', // select your icon from http://fortawesome.github.io/Font-Awesome/icons
+ *                    'callback': function () {
+ *                        IPython.notebook.kernel.execute('%qtconsole')
+ *                    }
+ *                }
+ *                // add more button here if needed.
+ *                ]);
+ *        });
  *    });
  *
  * __Example 2:__
  *
  * At the completion of the dashboard loading, load an unofficial javascript extension
- * that is installed in profile/static/custom/ 
+ * that is installed in profile/static/custom/
  *
- *    IPython.events.on('app_initialized.DashboardApp', function(){
- *        require(['custom/unofficial_extension.js'])
+ *    require([
+ *        'base/js/events'
+ *    ], function(events) {
+ *        events.on('app_initialized.DashboardApp', function(){
+ *            require(['custom/unofficial_extension.js'])
+ *        });
  *    });
  *
  * __Example 3:__


### PR DESCRIPTION
I use custom.js in development`3.0.0-dev`. but it not work. my custom.js like this:

``` python
IPython.events.on('app_initialized.NotebookApp', function(){                                                                                                   
        function to(mode) {                                                                                                                                    
            var mode = mode || 'vim'                                                                                                                           
            // first let's apply vim mode to all current cells                                                                                                 
            function to_mode(c) { return c.code_mirror.setOption('keyMap', mode);};                                                                            
            IPython.notebook.get_cells().map(to_mode);                                                                                                         
            // apply the mode to future cells created                                                                                                          
            IPython.Cell.options_default.cm_config.keyMap = mode;                                                                                              
        }                                                                                                                                                      

        require(["codemirror/keymap/emacs"],                                                                                                                   
                function (emacs) {                                                                                                                             
                    to('emacs');                                                                                                                               
                    console.log('emacs.js loaded');                                                                                                            
                });                                                                                                                                            
})                                                                                                                                                             

```

the broswer said: 

``` python
 IPython.events.on is not a function
```

If use `$([IPython.events])` said: 

``` python
ReferenceError: $ is not defined
```

I think `main.js` should not depend on the `custom.js`,  this make load custom.js first. but in custom.js, IPython has not been set up. I hope to have a better solution 

``` python
$python -c "import IPython; print(IPython.sys_info())"
{'commit_hash': u'7ab0a49',
 'commit_source': 'installation',
 'default_encoding': 'UTF-8',
 'ipython_path': '/Library/Python/2.7/site-packages/IPython',
 'ipython_version': '3.0.0-dev',
 'os_name': 'posix',
 'platform': 'Darwin-13.4.0-x86_64-i386-64bit',
 'sys_executable': '/usr/bin/python',
 'sys_platform': 'darwin',
 'sys_version': '2.7.5 (default, Mar  9 2014, 22:15:05) \n[GCC 4.2.1 Compatible Apple LLVM 5.0 (clang-500.0.68)]'}
```
