### PR TITLE
ungroup button on dashboard

### DIFF
--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -5613,7 +5613,9 @@ button.close {
 .panel-body:before,
 .panel-body:after,
 .modal-footer:before,
-.modal-footer:after {
+.modal-footer:after,
+.item_buttons:before,
+.item_buttons:after {
   content: " ";
   display: table;
 }
@@ -5630,7 +5632,8 @@ button.close {
 .navbar-collapse:after,
 .pager:after,
 .panel-body:after,
-.modal-footer:after {
+.modal-footer:after,
+.item_buttons:after {
   clear: both;
 }
 .center-block {
@@ -8029,9 +8032,19 @@ ul.breadcrumb span {
 }
 .item_buttons {
   line-height: 1em;
+  margin-left: -5px;
 }
 .item_buttons .btn {
   min-width: 13ex;
+}
+.item_buttons .btn-group,
+.item_buttons .input-group {
+  float: left;
+}
+.item_buttons > .btn,
+.item_buttons > .btn-group,
+.item_buttons > .input-group {
+  margin-left: 5px;
 }
 .toolbar_info {
   height: 24px;

--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -227,7 +227,7 @@ define([
                 $("<span/>").addClass("item_name")
             )
         ).append(
-            $('<div/>').addClass("item_buttons btn-group pull-right")
+            $('<div/>').addClass("item_buttons  pull-right")
         ));
         
         if (index === -1) {

--- a/IPython/html/static/tree/less/tree.less
+++ b/IPython/html/static/tree/less/tree.less
@@ -106,6 +106,7 @@ ul.breadcrumb {
     .btn {
         min-width: 13ex;
     }
+    .btn-toolbar();
 }
 
 .toolbar_info {

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -42,7 +42,7 @@ data-terminals-available="{{terminals_available}}"
                 </span>
                 </span>
               </form>
-              <div id="notebook_buttons" class="pull-right">
+              <div id="notebook_buttons" class="pull-right btn-toolbar">
                 <div id="new-notebook-buttons" class="btn-group">
                   <button id="new_notebook" class="btn btn-default btn-xs">
                   New Notebook
@@ -53,7 +53,9 @@ data-terminals-available="{{terminals_available}}"
                   </button>
                   <ul id="new-notebook-menu" class="dropdown-menu"></ul>
                 </div>
-                <button id="refresh_notebook_list" title="Refresh notebook list" class="btn btn-default btn-xs"><i class="fa fa-refresh"></i></button>
+                <div class="btn-group">
+                    <button id="refresh_notebook_list" title="Refresh notebook list" class="btn btn-default btn-xs"><i class="fa fa-refresh"></i></button>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
My attempt at un-groupping button on dashboard. Though it does not work, and despite more than hals an hour of css-foo I am unable to understand why. 

Indeed there is no margin between button but there should be. I tried many things: wrapping on `btn-group`s, and so on and so forth. 

@jdfreder, I would appreciate your help seing the the code is the same as button on top of the page and don't work. I would prefer to avoid targetting these particular buttons with custom css. 

Space in between button.
![capture d ecran 2014-12-18 a 22 14 54](https://cloud.githubusercontent.com/assets/335567/5496026/6ec7ec1c-8703-11e4-8991-e42d649b1bd0.png)

Same code, but no space. 

![capture d ecran 2014-12-18 a 22 14 49](https://cloud.githubusercontent.com/assets/335567/5496027/6ee69644-8703-11e4-85e2-719d6c7358ca.png)
