### PR TITLE
Do not inject self in IPython namespace

### DIFF
--- a/IPython/html/static/services/contents.js
+++ b/IPython/html/static/services/contents.js
@@ -1,12 +1,12 @@
 // Copyright (c) IPython Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-define([
-    'base/js/namespace',
-    'jquery',
-    'base/js/utils',
-], function(IPython, $, utils) {
+define(function(require) {
     "use strict";
+
+    var $ = require('jquery');
+    var utils = require('base/js/utils');
+
     var Contents = function(options) {
         /**
          * Constructor
@@ -244,9 +244,6 @@ define([
     Contents.prototype.list_contents = function(path) {
         return this.get(path, {type: 'directory'});
     };
-
-
-    IPython.Contents = Contents;
 
     return {'Contents': Contents};
 });


### PR DESCRIPTION
And do not require namespace either
- this is bad practice, and this prevent from
  writing a blended content manager that works both
  with drive and localhost as they should both export
  themselves to `IPython.Contents` module.

If we really want `IPython.Contents` then the various `main.js` should set `IPython.Contents` to the `Contents` they import. 

Though it is unnecessary as one can still do `C = require('contents')` for the global content manager or even `var c = require('explicit/module/path')`
