### PR TITLE
fix widget Popup position && the stack order

### DIFF
--- a/IPython/html/static/widgets/js/widget_box.js
+++ b/IPython/html/static/widgets/js/widget_box.js
@@ -71,7 +71,7 @@ define([
             };
             this.update_mapped_classes(class_map, 'box_style', previous_trait_value, this.$box);
         },
-        
+
         add_child_model: function(model) {
             /**
              * Called when a model is added to the children list.
@@ -89,7 +89,7 @@ define([
                 return view;
             }).catch(utils.reject("Couldn't add child view to box", true));
         },
-        
+
         remove: function() {
             /**
              * We remove this widget before removing the children as an optimization
@@ -153,7 +153,7 @@ define([
              * Called when view is rendered.
              */
             var that = this;
-            
+
             this.$el.on("remove", function(){
                     that.$backdrop.remove();
                 });
@@ -162,7 +162,8 @@ define([
                 .addClass('modal-dialog')
                 .css('position', 'absolute')
                 .css('left', '0px')
-                .css('top', '0px');
+                .css('top', $(window).scrollTop())
+                .css('z-index', 2);
             this.$window = $('<div />')
                 .appendTo(this.$backdrop)
                 .addClass('modal-content widget-modal')
@@ -200,7 +201,7 @@ define([
                         that.$minimize
                             .removeClass('fa-arrow-down')
                             .addClass('fa-arrow-up');
-                            
+
                         that.$window
                             .draggable('destroy')
                             .resizable('destroy')
@@ -232,14 +233,14 @@ define([
             this.$title = $('<div />')
                 .addClass('widget-modal-title')
                 .html("&nbsp;")
-                .appendTo(this.$title_bar);     
+                .appendTo(this.$title_bar);
             this.$box = $('<div />')
                 .addClass('modal-body')
                 .addClass('widget-modal-body')
                 .addClass('widget-box')
                 .addClass('vbox')
                 .appendTo(this.$window);
-            
+
             this.$show_button = $('<button />')
                 .html("&nbsp;")
                 .addClass('btn btn-info widget-modal-show')
@@ -247,7 +248,7 @@ define([
                 .click(function(){
                     that.show();
                 });
-            
+
             this.$window.draggable({handle: '.popover-title', snap: '#notebook, .modal', snapMode: 'both'});
             this.$window.resizable();
             this.$window.on('resize', function(){
@@ -259,7 +260,7 @@ define([
 
             this.children_views.update(this.model.get('children'))
         },
-        
+
         hide: function() {
             /**
              * Called when the modal hide button is clicked.
@@ -267,7 +268,7 @@ define([
             this.$window.hide();
             this.$show_button.removeClass('btn-info');
         },
-        
+
         show: function() {
             /**
              * Called when the modal show button is clicked.
@@ -277,12 +278,12 @@ define([
             if (this.popped_out) {
                 this.$window.css("positon", "absolute");
                 this.$window.css("top", "0px");
-                this.$window.css("left", Math.max(0, (($('body').outerWidth() - this.$window.outerWidth()) / 2) + 
-                    $(window).scrollLeft()) + "px");
+                this.$window.css("left", Math.max(0, (($('body').outerWidth() - this.$window.outerWidth()) / 2) +
+                                                  $(window).scrollLeft()) + "px");
                 this.bring_to_front();
             }
         },
-        
+
         bring_to_front: function() {
             /**
              * Make the modal top-most, z-ordered about the other modals.
@@ -295,10 +296,10 @@ define([
                     max_zindex = Math.max(max_zindex, zindex);
                 }
             });
-            
+
             // Start z-index of widget modals at 2000
             max_zindex = Math.max(max_zindex, 2000);
-            
+
             $widget_modals.each(function (index, el){
                 $el = $(el);
                 if (max_zindex == parseInt($el.css('z-index'))) {
@@ -307,12 +308,12 @@ define([
             });
             this.$window.css('z-index', max_zindex);
         },
-        
+
         update: function(){
             /**
              * Update the contents of this view
              *
-             * Called when the model is changed.  The model may have been 
+             * Called when the model is changed.  The model may have been
              * changed by another view or by a state update from the back-end.
              */
             var description = this.model.get('description');
@@ -321,22 +322,22 @@ define([
             } else {
                 this.typeset(this.$title, description);
             }
-            
+
             var button_text = this.model.get('button_text');
             if (button_text.trim().length === 0) {
                 this.$show_button.html("&nbsp;"); // Preserve button height
             } else {
                 this.$show_button.text(button_text);
             }
-            
+
             if (!this._shown_once) {
                 this._shown_once = true;
                 this.show();
             }
-            
+
             return PopupView.__super__.update.apply(this);
         },
-        
+
         _get_selector_element: function(selector) {
             /**
              * Get an element view a 'special' jquery selector.  (see widget.js)


### PR DESCRIPTION
When i test the widgets. the last is the popup widget like this:

``` python
counter = widgets.IntText(description='Counter:')
popup = widgets.Popup(children=[counter], description='Popup Demo', button_text='Popup Button')
display(popup)
```

but i can't see it. Finally i found it to be positioned in the upper-left. I'm confused. Other widgets are in the below the cell.  so. i think this Popup window must nearby this cell. at least you can see on the screen - no matter how far I have to scroll the screen. or it fixed to below the `maintoolbar`

and. when i first see the popup window. it's "z-index" less than the cell's. i can see the cell's code and can't click the close button

``` python
{'commit_hash': u'bb42d9a',
 'commit_source': 'repository',
 'default_encoding': 'UTF-8',
 'ipython_path': '/Users/dongweiming/ipython/IPython',
 'ipython_version': '3.0.0-dev',
 'os_name': 'posix',
 'platform': 'Darwin-13.4.0-x86_64-i386-64bit',
 'sys_executable': '/usr/bin/python',
 'sys_platform': 'darwin',
 'sys_version': '2.7.5 (default, Mar  9 2014, 22:15:05) \n[GCC 4.2.1 Compatible Apple LLVM 5.0 (clang-500.0.68)]'}
```
