### PR TITLE
a few 1 pixel fixes.

### DIFF
--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -7953,6 +7953,7 @@ span#login_widget > .button .badge,
 .alternate_upload .input-overlay {
   display: inline-block;
   font-weight: bold;
+  line-height: 1em;
 }
 /**
  * Primary styles

--- a/IPython/html/static/tree/less/altuploadform.less
+++ b/IPython/html/static/tree/less/altuploadform.less
@@ -25,4 +25,5 @@
 .alternate_upload .input-overlay {
     display: inline-block;
     font-weight: bold;
+    line-height:1em;
 }

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -32,7 +32,7 @@ data-terminals-available="{{terminals_available}}"
       <div class="tab-content">
         <div id="notebooks" class="tab-pane active">
           <div id="notebook_toolbar" class="row">
-            <div class="col-sm-12 no-padding">
+            <div class="col-sm-8 no-padding">
               <form id='alternate_upload'  class='alternate_upload'>
                 <span id="notebook_list_info">
                 To import a notebook, drag the file onto the listing below or
@@ -42,6 +42,8 @@ data-terminals-available="{{terminals_available}}"
                 </span>
                 </span>
               </form>
+            </div>
+            <div class="col-sm-4 no-padding tree-buttons">
               <div class="pull-right">
                 <div id="new-buttons" class="btn-group">
                   <button class="dropdown-toggle btn btn-default btn-xs" data-toggle="dropdown">


### PR DESCRIPTION
this uses the same html/css structure across the tabs, and reduce the overlay
click zone that expended the size of the header to 25px instead of 24px

ping @jdfreder, @ellisonbg 

Before that the `refresh` and table between tabs were jumping around by 1px.
