### PR TITLE
css spinner

### DIFF
--- a/IPython/html/static/style/style.less
+++ b/IPython/html/static/style/style.less
@@ -112,28 +112,119 @@
     margin-bottom: 2em;
 }
 
-.inner_cell::after {
-  transition: all 0.5s;
-  content:'';
-  -webkit-animation: spinner 1500ms infinite linear;
-  -moz-animation: spinner 1500ms infinite linear;
-  -ms-animation: spinner 1500ms infinite linear;
-  -o-animation: spinner 1500ms infinite linear;
-  animation: spinner 1500ms infinite linear;
+
+
+@-webkit-keyframes blink {
+    @cin : orange;
+    @cout : lightblue;
+    0%   { box-shadow: 10px 00px 0px rgba(0,0,0,0),
+                       20px 00px 0px @cin,
+                       30px 00px 0px @cout,
+                       40px 00px 0px @cout,
+                       50px 00px 0px @cout,
+                       60px 00px 0px @cout
+                       ;}
+    
+    30%{ box-shadow:   20px 00px 0px @cin,
+                       30px 00px 0px @cin,
+                       40px 00px 0px @cout,
+                       50px 00px 0px @cout,
+                       60px 00px 0px @cout,
+                       70px 00px 0px rgba(0,0,0,0)
+                       ;} 
+                       
+    35%{ box-shadow:   20px 00px 0px @cin,
+                       30px 05px 0px @cin,
+                       40px 00px 0px @cout,
+                       50px 00px 0px @cout,
+                       60px 00px 0px @cout,
+                       70px 00px 0px rgba(0,0,0,0)
+                       ;} 
+                       
+    70%{ box-shadow:   20px 00px 0px @cin,
+                       30px 05px 0px @cin,
+                       40px 00px 0px @cout,
+                       50px 00px 0px @cout,
+                       60px 00px 0px @cout,
+                       70px 00px 0px rgba(0,0,0,0)
+                       ;} 
+                       
+    100%{ box-shadow:  20px 00px 0px @cin,
+                       30px 00px 0px @cout,
+                       40px 00px 0px @cout,
+                       50px 00px 0px @cout,
+                       60px 00px 0px @cout,
+                       70px 00px 0px rgba(0,0,0,0)
+                       ;}  
+}
+
+.blink {
+  transform: translateZ(0);
+  content: ' ';
+  display:block;
+  -webkit-animation: blink 0.9s linear infinite;
+  animation: blink .3s linear infinite;
+}
+
+.spinner {
+  @spintime : 4500ms;
+  @spincolor: rgba(0, 0, 51, 0.3);
+  @spincolor: red; 
+  @ddist: 1.1em;
+  @hdist: 1.5em;
+  @ddist: 0.55em;
+  @hdist: 0.75em;
+  -webkit-animation: spinner @spintime infinite linear;
+  -moz-animation: spinner @spintime infinite linear;
+  -ms-animation: spinner @spintime infinite linear;
+  -o-animation: spinner @spintime infinite linear;
+  animation: spinner @spintime infinite linear;
   -webkit-border-radius: 0.5em;
   -moz-border-radius: 0.5em;
   -ms-border-radius: 0.5em;
   -o-border-radius: 0.5em;
   border-radius: 0.5em;
-  -webkit-box-shadow: rgba(0, 0, 51, 0.3) 1.5em 0 0 0, rgba(0, 0, 51, 0.3) 1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) 0 1.5em 0 0, rgba(0, 0, 51, 0.3) -1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) -1.5em 0 0 0, rgba(0, 0, 51, 0.3) -1.1em -1.1em 0 0, rgba(0, 0, 51, 0.3) 0 -1.5em 0 0, rgba(0, 0, 51, 0.3) 1.1em -1.1em 0 0;
-  -moz-box-shadow: rgba(0, 0, 51, 0.3) 1.5em 0 0 0, rgba(0, 0, 51, 0.3) 1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) 0 1.5em 0 0, rgba(0, 0, 51, 0.3) -1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) -1.5em 0 0 0, rgba(0, 0, 51, 0.3) -1.1em -1.1em 0 0, rgba(0, 0, 51, 0.3) 0 -1.5em 0 0, rgba(0, 0, 51, 0.3) 1.1em -1.1em 0 0;
-  box-shadow: rgba(0, 0, 51, 0.3) 1.5em 0 0 0, rgba(0, 0, 51, 0.3) 1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) 0 1.5em 0 0, rgba(0, 0, 51, 0.3) -1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) -1.5em 0 0 0, rgba(0, 0, 51, 0.3) -1.1em -1.1em 0 0, rgba(0, 0, 51, 0.3) 0 -1.5em 0 0, rgba(0, 0, 51, 0.3) 1.1em -1.1em 0 0;
+  -webkit-box-shadow: @spincolor @hdist 0 0 0, @spincolor @ddist @ddist 0 0, @spincolor 0 @hdist 0 0, @spincolor -@ddist @ddist 0 0, @spincolor -@hdist 0 0 0, @spincolor -@ddist -@ddist 0 0, @spincolor 0 -@hdist 0 0, @spincolor @ddist -@ddist 0 0;
+  -moz-box-shadow:    @spincolor @hdist 0 0 0, @spincolor @ddist @ddist 0 0, @spincolor 0 @hdist 0 0, @spincolor -@ddist @ddist 0 0, @spincolor -@hdist 0 0 0, @spincolor -@ddist -@ddist 0 0, @spincolor 0 -@hdist 0 0, @spincolor @ddist -@ddist 0 0;
+  box-shadow:         @spincolor @hdist 0 0 0, @spincolor @ddist @ddist 0 0, @spincolor 0 @hdist 0 0, @spincolor -@ddist @ddist 0 0, @spincolor -@hdist 0 0 0, @spincolor -@ddist -@ddist 0 0, @spincolor 0 -@hdist 0 0, @spincolor @ddist -@ddist 0 0;
   display: inline-block;
   font-size: 10px;
   width: 0;
   height: 0;
   margin: 0em;
-  margin-left:45%;
   overflow: hidden;
   text-indent: 100%;
+}
+
+.running .inner_cell::after {
+  /*.spinner();
+  margin-left:45%;
+  transition: all 0.5s ease;
+  content:'';*/
+}
+
+.input_prompt{
+  transition: all 0.3s ease;
+}
+
+.running .input_prompt{
+    color:rgba(0,0,0,0);
+}
+
+
+
+.input_prompt::before{
+  display:inline-block;
+  height:7px;
+  width:7px;
+  position: relative;
+  left: 10px;
+  top: 1px;
+  content:' ';
+  opacity:0;
+}
+
+.running .input_prompt::before{
+  .blink();
+  opacity:1;
 }

--- a/IPython/html/static/style/style.less
+++ b/IPython/html/static/style/style.less
@@ -31,3 +31,109 @@
 
 // terminal
 @import "../terminal/less/terminal.less";
+
+@-webkit-keyframes spinner {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    -o-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    -o-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+@-moz-keyframes spinner {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    -o-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    -o-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+@-o-keyframes spinner {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    -o-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    -o-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes spinner {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    -o-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    -o-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+
+.running .inner_cell::after {
+    width: 1em;
+    height: 1em;
+    margin-top: 2em;
+    margin-bottom: 2em;
+}
+
+.inner_cell::after {
+  transition: all 0.5s;
+  content:'';
+  -webkit-animation: spinner 1500ms infinite linear;
+  -moz-animation: spinner 1500ms infinite linear;
+  -ms-animation: spinner 1500ms infinite linear;
+  -o-animation: spinner 1500ms infinite linear;
+  animation: spinner 1500ms infinite linear;
+  -webkit-border-radius: 0.5em;
+  -moz-border-radius: 0.5em;
+  -ms-border-radius: 0.5em;
+  -o-border-radius: 0.5em;
+  border-radius: 0.5em;
+  -webkit-box-shadow: rgba(0, 0, 51, 0.3) 1.5em 0 0 0, rgba(0, 0, 51, 0.3) 1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) 0 1.5em 0 0, rgba(0, 0, 51, 0.3) -1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) -1.5em 0 0 0, rgba(0, 0, 51, 0.3) -1.1em -1.1em 0 0, rgba(0, 0, 51, 0.3) 0 -1.5em 0 0, rgba(0, 0, 51, 0.3) 1.1em -1.1em 0 0;
+  -moz-box-shadow: rgba(0, 0, 51, 0.3) 1.5em 0 0 0, rgba(0, 0, 51, 0.3) 1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) 0 1.5em 0 0, rgba(0, 0, 51, 0.3) -1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) -1.5em 0 0 0, rgba(0, 0, 51, 0.3) -1.1em -1.1em 0 0, rgba(0, 0, 51, 0.3) 0 -1.5em 0 0, rgba(0, 0, 51, 0.3) 1.1em -1.1em 0 0;
+  box-shadow: rgba(0, 0, 51, 0.3) 1.5em 0 0 0, rgba(0, 0, 51, 0.3) 1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) 0 1.5em 0 0, rgba(0, 0, 51, 0.3) -1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) -1.5em 0 0 0, rgba(0, 0, 51, 0.3) -1.1em -1.1em 0 0, rgba(0, 0, 51, 0.3) 0 -1.5em 0 0, rgba(0, 0, 51, 0.3) 1.1em -1.1em 0 0;
+  display: inline-block;
+  font-size: 10px;
+  width: 0;
+  height: 0;
+  margin: 0em;
+  margin-left:45%;
+  overflow: hidden;
+  text-indent: 100%;
+}

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -10572,29 +10572,80 @@ span.autosave_status {
   margin-top: 2em;
   margin-bottom: 2em;
 }
-.inner_cell::after {
-  transition: all 0.5s;
-  content: '';
-  -webkit-animation: spinner 1500ms infinite linear;
-  -moz-animation: spinner 1500ms infinite linear;
-  -ms-animation: spinner 1500ms infinite linear;
-  -o-animation: spinner 1500ms infinite linear;
-  animation: spinner 1500ms infinite linear;
+@-webkit-keyframes blink {
+  0% {
+    box-shadow: 10px 0px 0px rgba(0, 0, 0, 0), 20px 0px 0px orange, 30px 0px 0px lightblue, 40px 0px 0px lightblue, 50px 0px 0px lightblue, 60px 0px 0px lightblue;
+  }
+  30% {
+    box-shadow: 20px 0px 0px orange, 30px 0px 0px orange, 40px 0px 0px lightblue, 50px 0px 0px lightblue, 60px 0px 0px lightblue, 70px 0px 0px rgba(0, 0, 0, 0);
+  }
+  35% {
+    box-shadow: 20px 0px 0px orange, 30px 5px 0px orange, 40px 0px 0px lightblue, 50px 0px 0px lightblue, 60px 0px 0px lightblue, 70px 0px 0px rgba(0, 0, 0, 0);
+  }
+  70% {
+    box-shadow: 20px 0px 0px orange, 30px 5px 0px orange, 40px 0px 0px lightblue, 50px 0px 0px lightblue, 60px 0px 0px lightblue, 70px 0px 0px rgba(0, 0, 0, 0);
+  }
+  100% {
+    box-shadow: 20px 0px 0px orange, 30px 0px 0px lightblue, 40px 0px 0px lightblue, 50px 0px 0px lightblue, 60px 0px 0px lightblue, 70px 0px 0px rgba(0, 0, 0, 0);
+  }
+}
+.blink {
+  transform: translateZ(0);
+  content: ' ';
+  display: block;
+  -webkit-animation: blink 0.9s linear infinite;
+  animation: blink .3s linear infinite;
+}
+.spinner {
+  -webkit-animation: spinner 4500ms infinite linear;
+  -moz-animation: spinner 4500ms infinite linear;
+  -ms-animation: spinner 4500ms infinite linear;
+  -o-animation: spinner 4500ms infinite linear;
+  animation: spinner 4500ms infinite linear;
   -webkit-border-radius: 0.5em;
   -moz-border-radius: 0.5em;
   -ms-border-radius: 0.5em;
   -o-border-radius: 0.5em;
   border-radius: 0.5em;
-  -webkit-box-shadow: rgba(0, 0, 51, 0.3) 1.5em 0 0 0, rgba(0, 0, 51, 0.3) 1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) 0 1.5em 0 0, rgba(0, 0, 51, 0.3) -1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) -1.5em 0 0 0, rgba(0, 0, 51, 0.3) -1.1em -1.1em 0 0, rgba(0, 0, 51, 0.3) 0 -1.5em 0 0, rgba(0, 0, 51, 0.3) 1.1em -1.1em 0 0;
-  -moz-box-shadow: rgba(0, 0, 51, 0.3) 1.5em 0 0 0, rgba(0, 0, 51, 0.3) 1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) 0 1.5em 0 0, rgba(0, 0, 51, 0.3) -1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) -1.5em 0 0 0, rgba(0, 0, 51, 0.3) -1.1em -1.1em 0 0, rgba(0, 0, 51, 0.3) 0 -1.5em 0 0, rgba(0, 0, 51, 0.3) 1.1em -1.1em 0 0;
-  box-shadow: rgba(0, 0, 51, 0.3) 1.5em 0 0 0, rgba(0, 0, 51, 0.3) 1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) 0 1.5em 0 0, rgba(0, 0, 51, 0.3) -1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) -1.5em 0 0 0, rgba(0, 0, 51, 0.3) -1.1em -1.1em 0 0, rgba(0, 0, 51, 0.3) 0 -1.5em 0 0, rgba(0, 0, 51, 0.3) 1.1em -1.1em 0 0;
+  -webkit-box-shadow: red 0.75em 0 0 0, red 0.55em 0.55em 0 0, red 0 0.75em 0 0, red -0.55em 0.55em 0 0, red -0.75em 0 0 0, red -0.55em -0.55em 0 0, red 0 -0.75em 0 0, red 0.55em -0.55em 0 0;
+  -moz-box-shadow: red 0.75em 0 0 0, red 0.55em 0.55em 0 0, red 0 0.75em 0 0, red -0.55em 0.55em 0 0, red -0.75em 0 0 0, red -0.55em -0.55em 0 0, red 0 -0.75em 0 0, red 0.55em -0.55em 0 0;
+  box-shadow: red 0.75em 0 0 0, red 0.55em 0.55em 0 0, red 0 0.75em 0 0, red -0.55em 0.55em 0 0, red -0.75em 0 0 0, red -0.55em -0.55em 0 0, red 0 -0.75em 0 0, red 0.55em -0.55em 0 0;
   display: inline-block;
   font-size: 10px;
   width: 0;
   height: 0;
   margin: 0em;
-  margin-left: 45%;
   overflow: hidden;
   text-indent: 100%;
+}
+.running .inner_cell::after {
+  /*.spinner();
+  margin-left:45%;
+  transition: all 0.5s ease;
+  content:'';*/
+}
+.input_prompt {
+  transition: all 0.3s ease;
+}
+.running .input_prompt {
+  color: rgba(0, 0, 0, 0);
+}
+.input_prompt::before {
+  display: inline-block;
+  height: 7px;
+  width: 7px;
+  position: relative;
+  left: 10px;
+  top: 1px;
+  content: ' ';
+  opacity: 0;
+}
+.running .input_prompt::before {
+  transform: translateZ(0);
+  content: ' ';
+  display: block;
+  -webkit-animation: blink 0.9s linear infinite;
+  animation: blink .3s linear infinite;
+  opacity: 1;
 }
 /*# sourceMappingURL=style.min.css.map */

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -10502,4 +10502,99 @@ span.autosave_status {
 #terminado-container {
   margin-top: 20px;
 }
+@-webkit-keyframes spinner {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    -o-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    -o-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+@-moz-keyframes spinner {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    -o-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    -o-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+@-o-keyframes spinner {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    -o-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    -o-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+@keyframes spinner {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    -o-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    -o-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+.running .inner_cell::after {
+  width: 1em;
+  height: 1em;
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+.inner_cell::after {
+  transition: all 0.5s;
+  content: '';
+  -webkit-animation: spinner 1500ms infinite linear;
+  -moz-animation: spinner 1500ms infinite linear;
+  -ms-animation: spinner 1500ms infinite linear;
+  -o-animation: spinner 1500ms infinite linear;
+  animation: spinner 1500ms infinite linear;
+  -webkit-border-radius: 0.5em;
+  -moz-border-radius: 0.5em;
+  -ms-border-radius: 0.5em;
+  -o-border-radius: 0.5em;
+  border-radius: 0.5em;
+  -webkit-box-shadow: rgba(0, 0, 51, 0.3) 1.5em 0 0 0, rgba(0, 0, 51, 0.3) 1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) 0 1.5em 0 0, rgba(0, 0, 51, 0.3) -1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) -1.5em 0 0 0, rgba(0, 0, 51, 0.3) -1.1em -1.1em 0 0, rgba(0, 0, 51, 0.3) 0 -1.5em 0 0, rgba(0, 0, 51, 0.3) 1.1em -1.1em 0 0;
+  -moz-box-shadow: rgba(0, 0, 51, 0.3) 1.5em 0 0 0, rgba(0, 0, 51, 0.3) 1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) 0 1.5em 0 0, rgba(0, 0, 51, 0.3) -1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) -1.5em 0 0 0, rgba(0, 0, 51, 0.3) -1.1em -1.1em 0 0, rgba(0, 0, 51, 0.3) 0 -1.5em 0 0, rgba(0, 0, 51, 0.3) 1.1em -1.1em 0 0;
+  box-shadow: rgba(0, 0, 51, 0.3) 1.5em 0 0 0, rgba(0, 0, 51, 0.3) 1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) 0 1.5em 0 0, rgba(0, 0, 51, 0.3) -1.1em 1.1em 0 0, rgba(0, 0, 51, 0.3) -1.5em 0 0 0, rgba(0, 0, 51, 0.3) -1.1em -1.1em 0 0, rgba(0, 0, 51, 0.3) 0 -1.5em 0 0, rgba(0, 0, 51, 0.3) 1.1em -1.1em 0 0;
+  display: inline-block;
+  font-size: 10px;
+  width: 0;
+  height: 0;
+  margin: 0em;
+  margin-left: 45%;
+  overflow: hidden;
+  text-indent: 100%;
+}
 /*# sourceMappingURL=style.min.css.map */


### PR DESCRIPTION
@gibiansky said: 

> [...] Another user played around with the notebook, then accidentally set off a very long-running computation. He then was very confused as to why no more cells were evaluated – In[_] turns out to be a mediocre way to signal "I'm busy", and he just thought that everything had broken and he had to restart the application and that it was buggy. I think that at least might be easily fixed by letting cells have some sort of spinner indicating business instead of In[_], people are more used to that.

This is my attempt at fixing it with pure css : 

![capture d ecran 2014-12-24 a 14 06 38](https://cloud.githubusercontent.com/assets/335567/5548664/aa1c0942-8b77-11e4-82c8-586548113aab.png)

Smooth fade in/out and height change, rotate while the cell as the `.running` class.

technically I would prefer something like [that](http://css-spinners.com/#/spinner/throbber/) but it require to inject a placeholder for the spinner.

Design is of course to be discussed. 
