### PR TITLE
Reform css 2

### DIFF
--- a/IPython/html/static/notebook/less/menubar.less
+++ b/IPython/html/static/notebook/less/menubar.less
@@ -44,31 +44,25 @@ ul#help_menu li a{
     left: 100%;
     margin-top: -6px;
     margin-left: -1px;
-    -webkit-border-radius: 0 6px 6px 6px;
-    -moz-border-radius: 0 6px 6px 6px;
-    border-radius: 0 6px 6px 6px;
 }
 
+// arrow that indicate presence of submenu
 .dropdown-submenu:hover>.dropdown-menu {
     display: block;
 }
 
 .dropdown-submenu>a:after {
+    .fa();
     display: block;
-    content: " ";
+    content: @fa-var-caret-right;
     float: right;
-    width: 0;
-    height: 0;
-    border-color: transparent;
-    border-style: solid;
-    border-width: 5px 0 5px 5px;
-    border-left-color: #cccccc;
-    margin-top: 5px;
+    color: @dropdown-link-color;
+    margin-top: 2px;
     margin-right: -10px;
 }
 
-.dropdown-submenu:hover>a:after{
-    border-left-color: #ffffff;
+.dropdown-submenu:hover>a:after {
+    color: @dropdown-link-hover-color;
 }
 
 .dropdown-submenu.pull-left {
@@ -78,7 +72,6 @@ ul#help_menu li a{
 .dropdown-submenu.pull-left>.dropdown-menu {
     left: -100%;
     margin-left: 10px;
-    -webkit-border-radius: 6px 0 6px 6px;
-    -moz-border-radius: 6px 0 6px 6px;
-    border-radius: 6px 0 6px 6px;
 }
+
+//end submenu

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -9795,28 +9795,32 @@ ul#help_menu li a i {
   left: 100%;
   margin-top: -6px;
   margin-left: -1px;
-  -webkit-border-radius: 0 6px 6px 6px;
-  -moz-border-radius: 0 6px 6px 6px;
-  border-radius: 0 6px 6px 6px;
 }
 .dropdown-submenu:hover > .dropdown-menu {
   display: block;
 }
 .dropdown-submenu > a:after {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   display: block;
-  content: " ";
+  content: "\f0da";
   float: right;
-  width: 0;
-  height: 0;
-  border-color: transparent;
-  border-style: solid;
-  border-width: 5px 0 5px 5px;
-  border-left-color: #cccccc;
-  margin-top: 5px;
+  color: #333333;
+  margin-top: 2px;
   margin-right: -10px;
 }
+.dropdown-submenu > a:after.pull-left {
+  margin-right: .3em;
+}
+.dropdown-submenu > a:after.pull-right {
+  margin-left: .3em;
+}
 .dropdown-submenu:hover > a:after {
-  border-left-color: #ffffff;
+  color: #262626;
 }
 .dropdown-submenu.pull-left {
   float: none;
@@ -9824,9 +9828,6 @@ ul#help_menu li a i {
 .dropdown-submenu.pull-left > .dropdown-menu {
   left: -100%;
   margin-left: 10px;
-  -webkit-border-radius: 6px 0 6px 6px;
-  -moz-border-radius: 6px 0 6px 6px;
-  border-radius: 6px 0 6px 6px;
 }
 #notification_area {
   float: right !important;


### PR DESCRIPTION
On top of #7308 : 

---

```
unify submenu style with menu style

closes #7303.

Also change the arrow that indicate submenu for a fontawesoem icon,
instead of the ugly hack that show only the left border of a rectangle element
which with is twice the one of its border to get a triangle.
```

---

![capture d ecran 2014-12-25 a 12 12 33](https://cloud.githubusercontent.com/assets/335567/5553792/5fe7e66c-8c2f-11e4-9b6b-5dfe676924bf.png)

See last commit: https://github.com/Carreau/ipython/commit/1d38586eaa599d19b84ec361e08d1737637d8840
that drop hardcoded style (let things inherit), use variable for submenu arrow color.
