### PR TITLE
BF(BK): cleanup tempdir in EmbeddedSphinxShell atexit

### DIFF
--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -126,12 +126,14 @@ from __future__ import print_function
 #-----------------------------------------------------------------------------
 
 # Stdlib
+import atexit
 import os
 import re
 import sys
 import tempfile
 import ast
 import warnings
+import shutil
 
 # To keep compatibility with various python versions
 try:
@@ -295,6 +297,7 @@ class EmbeddedSphinxShell(object):
         # Create and initialize global ipython, but don't start its mainloop.
         # This will persist across different EmbededSphinxShell instances.
         IP = InteractiveShell.instance(config=config, profile_dir=profile)
+        atexit.register(self.cleanup)
 
         # io.stdout redirect must be done after instantiating InteractiveShell
         io.stdout = self.cout
@@ -312,6 +315,7 @@ class EmbeddedSphinxShell(object):
 
         self.input = ''
         self.output = ''
+        self.tmp_profile_dir = tmp_profile_dir
 
         self.is_verbatim = False
         self.is_doctest = False
@@ -331,6 +335,9 @@ class EmbeddedSphinxShell(object):
         # Prepopulate the namespace.
         for line in exec_lines:
             self.process_input_line(line, store_history=False)
+
+    def cleanup(self):
+        shutil.rmtree(self.tmp_profile_dir, ignore_errors=True)
 
     def clear_cout(self):
         self.cout.seek(0)


### PR DESCRIPTION
my testing server's /tmp was filling up with /tmp/profile_ directories left by statsmodels, pandas, etc  I guess due to this extension.  Unfortunately this fix (remove tempdir upon exit) has side-effect which experts might need to resolve properly anyways:

```
$> PYTHONPATH=$PWD python -c 'from IPython.sphinxext.ipython_directive import EmbeddedSphinxShell as ESS; _ = ESS(); '                                
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/usr/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "IPython/core/interactiveshell.py", line 3368, in atexit_operations
    self.history_manager.end_session()
  File "IPython/core/history.py", line 540, in end_session
    len(self.input_hist_parsed)-1, self.session_number))
OperationalError: attempt to write a readonly database
Error in sys.exitfunc:
Traceback (most recent call last):
  File "/usr/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "IPython/core/interactiveshell.py", line 3368, in atexit_operations
    self.history_manager.end_session()
  File "IPython/core/history.py", line 540, in end_session
    len(self.input_hist_parsed)-1, self.session_number))
sqlite3.OperationalError: attempt to write a readonly database
```
