### PR TITLE
friendlier error messages when invoke/lessc are missing

### DIFF
--- a/IPython/html/tasks.py
+++ b/IPython/html/tasks.py
@@ -1,9 +1,15 @@
 """invoke task file to build CSS"""
 
-from invoke import task, run
+from __future__ import print_function
+
 import os
+import sys
 from distutils.version import LooseVersion as V
 from subprocess import check_output
+
+from invoke import task, run
+from invoke.runner import Result
+from invoke.exceptions import Failure
 
 pjoin = os.path.join
 static_dir = 'static'
@@ -12,6 +18,18 @@ here = os.path.dirname(__file__)
 
 min_less_version = '2.0'
 max_less_version = '3.0' # exclusive if string
+
+
+def _fail(msg=''):
+    """Fail a task, logging a message to stderr
+    
+    raises a special Failure Exception from invoke.
+    """
+    if msg:
+        print(msg, file=sys.stderr)
+    # raising a Failure allows us to avoid a traceback
+    # we only care about exited, but stdout, stderr, pty are required args
+    raise Failure(Result(stdout='', stderr='', pty=False, exited=1))
 
 def _need_css_update():
     """Does less need to run?"""
@@ -53,23 +71,30 @@ def css(minify=False, verbose=False, force=False):
         sourcemap = pjoin('style', "%s.min.css.map" % name)
         _compile_less(source, target, sourcemap, minify, verbose)
 
+
 def _compile_less(source, target, sourcemap, minify=True, verbose=False):
     """Compile a less file by source and target relative to static_dir"""
     min_flag = '-x' if minify else ''
     ver_flag = '--verbose' if verbose else ''
     
+    install = "(npm install -g 'less@<{}')".format(max_less_version)
     # pin less to version number from above
     try:
         out = check_output(['lessc', '--version'])
     except OSError as err:
-        raise ValueError("Unable to find lessc.  Please install lessc >= %s and < %s " \
-                         % (min_less_version, max_less_version))
+        _fail("Unable to find lessc.  Rebuilding css requires less >= {0} and < {1} {2}".format(
+            min_less_version, max_less_version, install
+        ))
     out = out.decode('utf8', 'replace')
     less_version = out.split()[1]
     if min_less_version and V(less_version) < V(min_less_version):
-        raise ValueError("lessc too old: %s < %s. Use `$ npm install less@X.Y.Z` to install a specific version of less" % (less_version, min_less_version))
+        _fail("lessc too old: {} < {} {}".format(
+            less_version, min_less_version, install,
+        ))
     if max_less_version and V(less_version) >= V(max_less_version):
-        raise ValueError("lessc too new: %s >= %s. Use `$ npm install less@X.Y.Z` to install a specific version of less" % (less_version, max_less_version))
+        _fail("lessc too new: {} >= {} {}".format(
+            less_version, max_less_version, install,
+        ))
     
     static_path = pjoin(here, static_dir)
     cwd = os.getcwd()


### PR DESCRIPTION
and not needed. Error messages gave the illusion (#7313) that these were dependencies when installing from dev.

Examples:
- no invoke

```
running jsversion
running css
rebuilding css and sourcemaps failed (not a problem)
invoke is required to rebuild css (pip install invoke)
checking package data
```
- invoke, no less

```
running css
rebuilding css and sourcemaps failed (not a problem)
Unable to find lessc.  Rebuilding css requires less >= 2.0 and < 3.0 (npm install -g 'less@<3.0')
checking package data
```
- less too old

```
running css
rebuilding css and sourcemaps failed (not a problem)
lessc too old: 1.7.5 < 2.0 (npm install -g 'less@<3.0')
checking package data
```
- less missing, but required (`setup.py css` or `sdist`):

```
running css
error: Unable to find lessc.  Rebuilding css requires less >= 2.0 and < 3.0 (npm install -g 'less@<3.0')
```

closes #7313
