### PR TITLE
use 'Python X' for IPython kernel display name

### DIFF
--- a/IPython/html/services/kernelspecs/tests/test_kernelspecs_api.py
+++ b/IPython/html/services/kernelspecs/tests/test_kernelspecs_api.py
@@ -102,7 +102,7 @@ class APITest(NotebookTestBase):
             return s['name'] == 'sample' and s['spec']['display_name'] == 'Test kernel'
 
         def is_default_kernelspec(s):
-            return s['name'] == NATIVE_KERNEL_NAME and s['spec']['display_name'].startswith("IPython")
+            return s['name'] == NATIVE_KERNEL_NAME and s['spec']['display_name'].startswith("Python")
 
         assert any(is_sample_kernelspec(s) for s in specs.values()), specs
         assert any(is_default_kernelspec(s) for s in specs.values()), specs

--- a/IPython/kernel/kernelspec.py
+++ b/IPython/kernel/kernelspec.py
@@ -107,10 +107,10 @@ class KernelSpecManager(HasTraits):
         """Makes a kernel directory for the native kernel.
         
         The native kernel is the kernel using the same Python runtime as this
-        process. This will put its informatino in the user kernels directory.
+        process. This will put its information in the user kernels directory.
         """
         return {'argv': make_ipkernel_cmd(),
-                'display_name': 'IPython (Python %d)' % (3 if PY3 else 2),
+                'display_name': 'Python %i' % (3 if PY3 else 2),
                }
 
     @property


### PR DESCRIPTION
instead of 'IPython (Python X)'

cf #7188

May not close that one entirely, since it doesn't add a separate field for 'project name', but I don't think we've decided on that yet.
