### PR TITLE
update new notebook button with kernelspec changes

### DIFF
--- a/IPython/html/static/tree/js/newnotebook.js
+++ b/IPython/html/static/tree/js/newnotebook.js
@@ -42,8 +42,8 @@ define([
         this.kernelspecs = data.kernelspecs;
         var menu = this.element.find("#notebook-kernels");
         var keys = Object.keys(data.kernelspecs).sort(function (a, b) {
-            var da = data.kernelspecs[a].display_name;
-            var db = data.kernelspecs[b].display_name;
+            var da = data.kernelspecs[a].spec.display_name;
+            var db = data.kernelspecs[b].spec.display_name;
             if (da === db) {
                 return 0;
             } else if (da > db) {
@@ -60,8 +60,8 @@ define([
                     $('<a>')
                         .attr('href', '#')
                         .click($.proxy(this.new_notebook, this, ks.name))
-                        .text(ks.display_name)
-                        .attr('title', 'Create a new notebook with ' + ks.display_name)
+                        .text(ks.spec.display_name)
+                        .attr('title', 'Create a new notebook with ' + ks.spec.display_name)
                 );
             menu.after(li);
         }


### PR DESCRIPTION
display_name is in the spec, not top-level.

The new notebook button is not showing any names right now,
a result of #7283 and #7279 being out of sync with each other.
