### PR TITLE
Update parallel_multiengine.rst

### DIFF
--- a/docs/source/parallel/parallel_multiengine.rst
+++ b/docs/source/parallel/parallel_multiengine.rst
@@ -328,7 +328,7 @@ local Python/IPython session:
     Note the import inside the function. This is a common model, to ensure
     that the appropriate modules are imported where the task is run. You can
     also manually import modules into the engine(s) namespace(s) via 
-    :meth:`view.execute('import numpy')`.
+    `view.execute('import numpy')`.
 
 Often, it is desirable to wait until a set of :class:`AsyncResult` objects
 are done. For this, there is a the method :meth:`wait`. This method takes a


### PR DESCRIPTION
Using :meth: apparently adds parens, so in this example, the generated text in the help page looks like:

view.execute('import numpy')()

which is incorrect (note extra parens at end). Not sure what this should be, other than just marked as code.

![screenshot from 2014-12-30 09 24 22](https://cloud.githubusercontent.com/assets/168568/5579356/114b8e06-9007-11e4-936d-a23627fd9d4e.png)
