### PR TITLE
When executing a cell, clear output and ignore queued animations.

### DIFF
--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -416,7 +416,7 @@ define([
             return;
         }
 
-        this.active_output_area.clear_output();
+        this.active_output_area.clear_output(false, true);
         
         // Clear widget area
         for (var i = 0; i < this.widget_views.length; i++) {

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -850,7 +850,7 @@ define([
     };
 
 
-    OutputArea.prototype.clear_output = function(wait) {
+    OutputArea.prototype.clear_output = function(wait, ignore_que) {
         if (wait) {
 
             // If a clear is queued, clear before adding another to the queue.
@@ -863,7 +863,7 @@ define([
 
             // Fix the output div's height if the clear_output is waiting for
             // new output (it is being used in an animation).
-            if (this.clear_queued) {
+            if (!ignore_que && this.clear_queued) {
                 var height = this.element.height();
                 this.element.height(height);
                 this.clear_queued = false;


### PR DESCRIPTION
closes #5892
