### PR TITLE
BUG: Fix broken codemirror highlighting on file rename.

### DIFF
--- a/IPython/html/static/edit/js/editor.js
+++ b/IPython/html/static/edit/js/editor.js
@@ -100,7 +100,9 @@ function($,
 
         // Find and load the highlighting mode,
         // first by mime-type, then by file extension
+
         var modeinfo;
+        // mimetype is unset on file rename
         if (model.mimetype) {
             modeinfo = CodeMirror.findModeByMIME(model.mimetype);
         }

--- a/IPython/html/static/edit/js/editor.js
+++ b/IPython/html/static/edit/js/editor.js
@@ -97,14 +97,17 @@ function($,
 
     Editor.prototype._set_mode_for_model = function (model) {
         /** Set the CodeMirror mode based on the file model */
-        
+
         // Find and load the highlighting mode,
         // first by mime-type, then by file extension
-        var modeinfo = CodeMirror.findModeByMIME(model.mimetype);
-        if (modeinfo.mode === "null") {
+        var modeinfo;
+        if (model.mimetype) {
+            modeinfo = CodeMirror.findModeByMIME(model.mimetype);
+        }
+        if (!modeinfo || modeinfo.mode === "null") {
             // find by mime failed, use find by ext
             var ext_idx = model.name.lastIndexOf('.');
-            
+
             if (ext_idx > 0) {
                 // CodeMirror.findModeByExtension wants extension without '.'
                 modeinfo = CodeMirror.findModeByExtension(model.name.slice(ext_idx + 1));
@@ -114,7 +117,7 @@ function($,
             this.set_codemirror_mode(modeinfo);
         }
     };
-    
+
     Editor.prototype.set_codemirror_mode = function (modeinfo) {
         /** set the codemirror mode from a modeinfo struct */
         var that = this;


### PR DESCRIPTION
When a users uses the rename dialog in the text editor, we call
_set_mode_for_model on the returned model.  The model returned from 
python (correctly) has no mimetype, which causes us to pass
`undefined` to `CodeMirror.findModeByMIME`, which returns `undefined`
back.  We then try access an attribute of the (undefined) return value,
causing an error.

This now properly checks whether the `mimetype` attribute is set on the
input model.
