### PR TITLE
Allow completion on the numpy struct itself

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -863,7 +863,8 @@ class IPCompleter(Completer):
                     return list(obj.keys())
                 except Exception:
                     return []
-            elif _safe_isinstance(obj, 'numpy', 'ndarray'):
+            elif _safe_isinstance(obj, 'numpy', 'ndarray') or\
+                 _safe_isinstance(obj, 'numpy', 'void'):
                 return obj.dtype.names or []
             return []
 

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -668,6 +668,20 @@ def test_struct_array_key_completion():
     _, matches = complete(line_buffer="d['")
     nt.assert_in("hello", matches)
     nt.assert_in("world", matches)
+    # complete on the numpy struct itself
+    dt = numpy.dtype([('my_head', [('my_dt', '>u4'), ('my_df', '>u4')]),
+                      ('my_data', '>f4', 5)])
+    x = numpy.zeros(2, dtype=dt)
+    ip.user_ns['d'] = x[1]
+    _, matches = complete(line_buffer="d['")
+    nt.assert_in("my_head", matches)
+    nt.assert_in("my_data", matches)
+    # complete on a nested level
+    with greedy_completion():
+        ip.user_ns['d'] = numpy.zeros(2, dtype=dt)
+        _, matches = complete(line_buffer="d[1]['my_head']['")
+        nt.assert_true(any(["my_dt" in m for m in matches]))
+        nt.assert_true(any(["my_df" in m for m in matches]))
 
 
 @dec.skip_without('pandas')


### PR DESCRIPTION
Removes the constraint to only allow completion on arrays of numpy structs, but not on numpy structs itself. Current master:

```
In [2]: import numpy as np
In [3]: dt_head = np.dtype([('dt', '>u4'), ('df', '>u4'), ('Fs', '>u4')])
In [4]: dt = np.dtype([('head', dt_head), ('data', '>u4', 10)])
In [5]: x = np.zeros(2, dtype=dt)
In [6]: x[<TAB> =>
x['data']  x['head']  
In [6]: y = x[0]
In [7]: y[<TAB>=> "nothing happens"
```

This pulls request allows completion for `In [7]`.

P.S.: Just happily discovered that dict and numpy structured array completion are supported in current master. For me, this is a killer feature.
