### PR TITLE
fix widget description can not display when use --no-mathjax

### DIFF
--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -773,12 +773,12 @@ define([
          * element: Node, NodeList, or jQuery selection
          * text: option string
          */
-        if(!window.MathJax){
-            return;
-        }
         var $el = element.jquery ? element : $(element);
         if(arguments.length > 1){
             $el.text(text);
+        }
+        if(!window.MathJax){
+            return;
         }
         return $el.map(function(){
             // MathJax takes a DOM node: $.map makes `this` the context


### PR DESCRIPTION
when i use `--no-mathjax`: 

``` python
ipython notebook --no-mathjax
```

i found widget's description not work. the div with class `widget-label` is empty.
