### PR TITLE
ensure data, metadata are set in execute_results

### DIFF
--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -243,11 +243,17 @@ define([
         'text/plain'
     ];
 
-    OutputArea.prototype.validate_mimebundle = function (json) {
-        /**
-         * scrub invalid outputs
-         */
-        var data = json.data;
+    OutputArea.prototype.validate_mimebundle = function (bundle) {
+        /** scrub invalid outputs */
+        if (typeof bundle.data !== 'object') {
+            console.warn("mimebundle missing data", bundle);
+            bundle.data = {};
+        }
+        if (typeof bundle.metadata !== 'object') {
+            console.warn("mimebundle missing metadata", bundle);
+            bundle.metadata = {};
+        }
+        var data = bundle.data;
         $.map(OutputArea.output_types, function(key){
             if (key !== 'application/json' &&
                 data[key] !== undefined &&
@@ -257,7 +263,7 @@ define([
                 delete data[key];
             }
         });
-        return json;
+        return bundle;
     };
     
     OutputArea.prototype.append_output = function (json) {

--- a/IPython/kernel/zmq/displayhook.py
+++ b/IPython/kernel/zmq/displayhook.py
@@ -51,7 +51,10 @@ class ZMQShellDisplayHook(DisplayHook):
         self.parent_header = extract_header(parent)
 
     def start_displayhook(self):
-        self.msg = self.session.msg(u'execute_result', {}, parent=self.parent_header)
+        self.msg = self.session.msg(u'execute_result', {
+            'data': {},
+            'metadata': {},
+        }, parent=self.parent_header)
 
     def write_output_prompt(self):
         """Write the output prompt."""


### PR DESCRIPTION
some circumstances such as `_ipython_display_` callers, can result in execute_result mimebundle data not being set, which confuses the javascript.

Added handling of this case to the Javascript, in case other kernels have similar bugs.
