### PR TITLE
Highlight cell if in edit mode

### DIFF
--- a/IPython/html/static/notebook/less/cell.less
+++ b/IPython/html/static/notebook/less/cell.less
@@ -8,9 +8,11 @@ div.cell {
 
     &.selected {
         border-color: @border_color;
-        /* Don't border the cells when printing */
+        background-color: lightgreen;
+        /* Don't border or background the cells when printing */
         @media print {
             border-color: transparent;
+            background-color: transparent;
         }
     }
 

--- a/IPython/html/static/notebook/less/cell.less
+++ b/IPython/html/static/notebook/less/cell.less
@@ -7,9 +7,8 @@ div.cell {
     border-style: solid;
 
     &.selected {
-        border-color: @border_color;
-        background-color: lightgreen;
-        /* Don't border or background the cells when printing */
+        background-color: #efefef;
+        /* Don't show the background when printing */
         @media print {
             border-color: transparent;
             background-color: transparent;
@@ -17,10 +16,10 @@ div.cell {
     }
 
     .edit_mode &.selected {
-        border-color: green;
-        /* Don't border the cells when printing */
+        background-color: #ded;
+        /* Don't show the background when printing */
         @media print {
-            border-color: transparent;
+            background-color: transparent;
         }
     }
 


### PR DESCRIPTION
Currently, there are very few visual clues to inform the user which
mode the notebook is currently in: a thin line around the cell, and
a small 'edit' icon in the toolbar. This change adds a background
color to the cell, which makes the visual clue much clearer.
