### PR TITLE
tests for ScriptExporter

### DIFF
--- a/IPython/nbconvert/exporters/tests/test_python.py
+++ b/IPython/nbconvert/exporters/tests/test_python.py
@@ -1,23 +1,11 @@
 """Tests for PythonExporter"""
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, the IPython Development Team.
-#
+# Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
 
 from .base import ExportersTestsBase
 from ..python import PythonExporter
 
-#-----------------------------------------------------------------------------
-# Class
-#-----------------------------------------------------------------------------
 
 class TestPythonExporter(ExportersTestsBase):
     """Tests for PythonExporter"""
@@ -26,15 +14,10 @@ class TestPythonExporter(ExportersTestsBase):
     should_include_raw = ['python']
 
     def test_constructor(self):
-        """
-        Can a PythonExporter be constructed?
-        """
-        PythonExporter()
-
+        """Can a PythonExporter be constructed?"""
+        self.exporter_class()
 
     def test_export(self):
-        """
-        Can a PythonExporter export something?
-        """
-        (output, resources) = PythonExporter().from_filename(self._get_notebook())
-        assert len(output) > 0
+        """Can a PythonExporter export something?"""
+        (output, resources) = self.exporter_class().from_filename(self._get_notebook())
+        self.assertIn("coding: utf-8", output)

--- a/IPython/nbconvert/exporters/tests/test_script.py
+++ b/IPython/nbconvert/exporters/tests/test_script.py
@@ -1,0 +1,45 @@
+"""Tests for ScriptExporter"""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import sys
+
+from IPython.nbformat import v4
+from IPython.utils.py3compat import PY3
+
+from .base import ExportersTestsBase
+from ..script import ScriptExporter
+
+
+class TestScriptExporter(ExportersTestsBase):
+    """Tests for ScriptExporter"""
+
+    exporter_class = ScriptExporter
+
+    def test_constructor(self):
+        """Construct ScriptExporter"""
+        e = self.exporter_class()
+
+    def test_export(self):
+        """ScriptExporter can export something"""
+        (output, resources) = self.exporter_class().from_filename(self._get_notebook())
+        assert len(output) > 0
+    
+    def test_export_python(self):
+        """delegate to custom exporter from language_info"""
+        exporter = self.exporter_class()
+        
+        pynb = v4.new_notebook()
+        (output, resources) = self.exporter_class().from_notebook_node(pynb)
+        self.assertNotIn('# coding: utf-8', output)
+        
+        pynb.metadata.language_info = {
+            'name': 'python',
+            'mimetype': 'text/x-python',
+            'nbconvert_exporter': 'python',
+        }
+        (output, resources) = self.exporter_class().from_notebook_node(pynb)
+        self.assertIn('# coding: utf-8', output)
+
+        


### PR DESCRIPTION
verify that it delegates to PythonExporter if specified in language_info

closes #7378
