### PR TITLE
allow system-wide installtion of nbextensions

### DIFF
--- a/IPython/html/nbextensions.py
+++ b/IPython/html/nbextensions.py
@@ -37,14 +37,14 @@ if os.name == 'nt':
         SYSTEM_NBEXTENSIONS_DIRS = [pjoin(programdata, 'jupyter', 'nbextensions')]
     prefixes = []
 else:
-    prefixes = ['/usr/local', '/usr']
+    prefixes = [os.path.sep + pjoin('usr', 'local'), os.path.sep + 'usr']
 
 # add sys.prefix at the front
 if sys.prefix not in prefixes:
     prefixes.insert(0, sys.prefix)
 
 for prefix in prefixes:
-    nbext = os.path.join(prefix, 'share', 'jupyter', 'nbextensions')
+    nbext = pjoin(prefix, 'share', 'jupyter', 'nbextensions')
     if nbext not in SYSTEM_NBEXTENSIONS_DIRS:
         SYSTEM_NBEXTENSIONS_DIRS.append(nbext)
 

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -90,6 +90,7 @@ from IPython.utils import py3compat
 from IPython.utils.path import filefind, get_ipython_dir
 from IPython.utils.sysinfo import get_sys_info
 
+from .nbextensions import SYSTEM_NBEXTENSIONS_DIRS
 from .utils import url_path_join
 
 #-----------------------------------------------------------------------------
@@ -566,11 +567,14 @@ class NotebookApp(BaseIPythonApplication):
         """return extra paths + the default locations"""
         return self.extra_template_paths + DEFAULT_TEMPLATE_PATH_LIST
 
-    nbextensions_path = List(Unicode, config=True,
-        help="""paths for Javascript extensions. By default, this is just IPYTHONDIR/nbextensions"""
+    extra_nbextensions_path = List(Unicode, config=True,
+        help="""extra paths to look for Javascript notebook extensions"""
     )
-    def _nbextensions_path_default(self):
-        return [os.path.join(get_ipython_dir(), 'nbextensions')]
+    
+    @property
+    def nbextensions_path(self):
+        """The path to look for Javascript notebook extensions"""
+        return self.extra_nbextensions_path + [os.path.join(get_ipython_dir(), 'nbextensions')] + SYSTEM_NBEXTENSIONS_DIRS
 
     websocket_url = Unicode("", config=True,
         help="""The base URL for websockets,


### PR DESCRIPTION
- like kernelspecs, default install is `/usr/local/share/jupyter/nbextensions` (PROGRAMDATA on Windows)
- user install goes to .ipython/nbextensions
- unlike kernelspecs, arbitrary destinations are allowed, because the nbextension path is already configurable
