### PR TITLE
use single WebSocket connection for all channels

### DIFF
--- a/docs/source/whatsnew/pr/incompat-single-websocket.rst
+++ b/docs/source/whatsnew/pr/incompat-single-websocket.rst
@@ -1,0 +1,3 @@
+* The notebook now uses a single websocket at `/kernels/<kernel-id>/channels` instead of separate
+  `/kernels/<kernel-id>/{shell|iopub|stdin}` channels. Messages on each channel are identified by a
+  `channel` key in the message dict, for both send and recv.


### PR DESCRIPTION
multiplex on a 'channel' key in message, rather than separate websockets.

Unlike zmq, there aren't different message patterns that require the channels to be separate.

Reduces FD count by factor of 3 and connection complexity in js.

closes #6976
