### PR TITLE
un-nest the edit_mode div.cell.selected css selector

### DIFF
--- a/IPython/html/static/notebook/less/cell.less
+++ b/IPython/html/static/notebook/less/cell.less
@@ -14,19 +14,23 @@ div.cell {
         }
     }
 
-    .edit_mode &.selected {
-        border-color: green;
-        /* Don't border the cells when printing */
-        @media print {
-            border-color: transparent;
-        }
-    }
-
     width: 100%;
     padding: 5px 5px 5px 0px;
     /* This acts as a spacer between cells, that is outside the border */
     margin: 0px;
     outline: none;
+}
+
+
+/* we put this edit_mode selector outside of the above div.cell rule because & is the full
+   parent (not just div.cell), so `.edit_mode &.selected` prevents us from nesting this rule
+   within another selector */
+.edit_mode div.cell.selected {
+    border-color: green;
+    /* Don't border the cells when printing */
+    @media print {
+        border-color: transparent;
+    }
 }
 
 div.prompt {


### PR DESCRIPTION
If we tried nesting this into the div.cell rule by doing
`.edit_mode &.selected`, we would not be able to nest the IPython
css into another selector (since & would then be the full parent,
not just div.cell).

ping @Carreau.  I also tried to regenerate the css, but I ended up with a ton of changes that were not related to these changes.  Since basically all this should do is add a comment, I'll leave off the generating of the css.
