### PR TITLE
Generate fontweight enum values without an extraneous variable from a comprehension

### DIFF
--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -472,7 +472,7 @@ class DOMWidget(Widget):
         'bolder', 
         'lighter',
         'initial', 
-        'inherit', ''] + map(str, range(100,1000,100)),
+        'inherit', ''] + list(map(str, range(100,1000,100))),
         default_value='', sync=True)
     font_size = CUnicode(sync=True)
     font_family = Unicode(sync=True)

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -472,7 +472,7 @@ class DOMWidget(Widget):
         'bolder', 
         'lighter',
         'initial', 
-        'inherit', ''] + [str(100 * (i+1)) for i in range(9)], 
+        'inherit', ''] + map(str, range(100,1000,100)),
         default_value='', sync=True)
     font_size = CUnicode(sync=True)
     font_family = Unicode(sync=True)


### PR DESCRIPTION
In python 2, the comprehension will create a new class attribute, i.  Using map will not create the extra local variable.

Before this, every DOMWidget class (and descendant) had an `i` attribute that was set to 8.

ping @jdfreder 
