### PR TITLE
Split apart the body attributes and classes in the notebook templates

### DIFF
--- a/IPython/html/templates/edit.html
+++ b/IPython/html/templates/edit.html
@@ -8,12 +8,12 @@
 {{super()}}
 {% endblock %}
 
-{% block params %}
+{% block bodyclasses %}edit_app {{super()}}{% endblock %}
 
-class="edit_app"
+{% block params %}
 data-base-url="{{base_url}}"
 data-file-path="{{file_path}}"
-
+{{super()}}
 {% endblock %}
 
 {% block headercontainer %}

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -21,6 +21,8 @@ window.mathjax_url = "{{mathjax_url}}";
 
 {% endblock %}
 
+{% block bodyclasses %}notebook_app {{super()}}{% endblock %}
+
 {% block params %}
 
 data-project="{{project}}"
@@ -28,7 +30,6 @@ data-base-url="{{base_url}}"
 data-ws-url="{{ws_url}}"
 data-notebook-name="{{notebook_name}}"
 data-notebook-path="{{notebook_path}}"
-class="notebook_app"
 
 {% endblock %}
 

--- a/IPython/html/templates/page.html
+++ b/IPython/html/templates/page.html
@@ -72,7 +72,7 @@
 
 </head>
 
-<body {% block params %}{% endblock %}>
+<body class="{% block bodyclasses %}{% endblock %}" {% block params %}{% endblock %}>
 
 <noscript>
     <div id='noscript'>

--- a/IPython/html/templates/terminal.html
+++ b/IPython/html/templates/terminal.html
@@ -2,11 +2,12 @@
 
 {% block title %}{{page_title}}{% endblock %}
 
+{% block bodyclasses %}terminal-app {{super()}}{% endblock %}
+
 {% block params %}
 
 data-base-url="{{base_url}}"
 data-ws-path="{{ws_path}}"
-class="terminal-app"
 
 {% endblock %}
 


### PR DESCRIPTION
This makes it easier to selectively add classes and take advantage of template inheritance to inherit classes on the body element.

ping @Carreau and @ellisonbg 
