### PR TITLE
remove strict requirement for less,invoke when building wheel/sdist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -216,7 +216,7 @@ setup_args['cmdclass'] = {
     'build_py': css_js_prerelease(
             check_package_data_first(git_prebuild('IPython')),
         strict=False),
-    'sdist' : css_js_prerelease(git_prebuild('IPython', sdist)),
+    'sdist' : css_js_prerelease(git_prebuild('IPython', sdist), strict=False),
     'upload_wininst' : UploadWindowsInstallers,
     'submodule' : UpdateSubmodules,
     'css' : CompileCSS,
@@ -284,7 +284,7 @@ if 'setuptools' in sys.modules:
     # setup.py develop should check for submodules
     from setuptools.command.develop import develop
     setup_args['cmdclass']['develop'] = require_submodules(develop)
-    setup_args['cmdclass']['bdist_wheel'] = css_js_prerelease(get_bdist_wheel())
+    setup_args['cmdclass']['bdist_wheel'] = css_js_prerelease(get_bdist_wheel(), strict=False)
     
     setuptools_extra_args['zip_safe'] = False
     setuptools_extra_args['entry_points'] = {'console_scripts':find_entry_points()}

--- a/setup.py
+++ b/setup.py
@@ -214,9 +214,8 @@ class UploadWindowsInstallers(upload):
 
 setup_args['cmdclass'] = {
     'build_py': css_js_prerelease(
-            check_package_data_first(git_prebuild('IPython')),
-        strict=False),
-    'sdist' : css_js_prerelease(git_prebuild('IPython', sdist), strict=False),
+            check_package_data_first(git_prebuild('IPython'))),
+    'sdist' : css_js_prerelease(git_prebuild('IPython', sdist)),
     'upload_wininst' : UploadWindowsInstallers,
     'submodule' : UpdateSubmodules,
     'css' : CompileCSS,
@@ -284,7 +283,7 @@ if 'setuptools' in sys.modules:
     # setup.py develop should check for submodules
     from setuptools.command.develop import develop
     setup_args['cmdclass']['develop'] = require_submodules(develop)
-    setup_args['cmdclass']['bdist_wheel'] = css_js_prerelease(get_bdist_wheel(), strict=False)
+    setup_args['cmdclass']['bdist_wheel'] = css_js_prerelease(get_bdist_wheel())
     
     setuptools_extra_args['zip_safe'] = False
     setuptools_extra_args['entry_points'] = {'console_scripts':find_entry_points()}

--- a/setupbase.py
+++ b/setupbase.py
@@ -746,7 +746,7 @@ class JavascriptVersion(Command):
                 f.write(line)
 
 
-def css_js_prerelease(command, strict=True):
+def css_js_prerelease(command):
     """decorator for building js/minified css prior to a release"""
     class DecoratedCommand(command):
         def run(self):
@@ -756,10 +756,7 @@ def css_js_prerelease(command, strict=True):
             try:
                 self.distribution.run_command('css')
             except Exception as e:
-                if strict:
-                    raise
-                else:
-                    log.warn("rebuilding css and sourcemaps failed (not a problem)")
-                    log.warn(str(e))
+                log.warn("rebuilding css and sourcemaps failed (not a problem)")
+                log.warn(str(e))
             command.run(self)
     return DecoratedCommand

--- a/tools/release
+++ b/tools/release
@@ -50,6 +50,10 @@ sh('mv ipython-*.tgz %s' % ipbackupdir)
 # Build release files
 sh('./build_release %s' % ipdir)
 
+if 'upload' not in sys.argv:
+    print("`./release upload` to register and release")
+    sys.exit(0)
+
 # Register with the Python Package Index (PyPI)
 print( 'Registering with PyPI...')
 cd(ipdir)

--- a/tools/release
+++ b/tools/release
@@ -22,9 +22,11 @@ if not os.path.exists(ipbackupdir):
 cd(ipdir)
 
 # Load release info
-execfile(pjoin('IPython','core','release.py'))
+execfile(pjoin('IPython','core','release.py'), globals())
 # ensure js version is in sync
 sh('./setup.py jsversion')
+# build minified css and sourcemaps
+sh('./setup.py css -x -f')
 
 # Build site addresses for file uploads
 release_site = '%s/release/%s' % (archive, version)

--- a/tools/toollib.py
+++ b/tools/toollib.py
@@ -59,3 +59,10 @@ def compile_tree():
         msg = '*** ERROR: Some Python files in tree do NOT compile! ***\n'
         msg += 'See messages above for the actual file that produced it.\n'
         raise SystemExit(msg)
+
+try:
+    execfile
+except NameError:
+    def execfile(fname, globs, locs=None):
+        locs = locs or globs
+        exec(compile(open(fname).read(), fname, "exec"), globs, locs)


### PR DESCRIPTION
move the strictness to our release script

this means others can build personal wheels without less, invoke, but IPython releases still cannot be made without them, which is the real goal.
