### PR TITLE
Make sure tests aren't included twice as js and python

### DIFF
--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -431,9 +431,8 @@ def prepare_controllers(options):
     not to run."""
     testgroups = options.testgroups
     if testgroups:
-        alljs = all_js_groups()
         js_testgroups = [g for g in testgroups if g.startswith(js_prefix)]
-        py_testgroups = [g for g in testgroups if g not in alljs]
+        py_testgroups = [g for g in testgroups if g not in js_testgroups]
     else:
         py_testgroups = py_test_group_names
         if not options.all:


### PR DESCRIPTION
I'm using iptest for nbgrader javascript tests, which works by simply appending `js/` to the beginning of the path of my javascript tests. Currently, my javascript tests get detected as both javascript and python, because they are not in the list of tests returned by `all_js_groups()`. This PR fixes that so that python tests are only those tests which are not javascript tests.

As far as I'm aware, there aren't any javascript tests that don't start with the `js/` prefix, so this shouldn't actually change how IPython tests are run.
