### PR TITLE
Fix ultratb when there are non-ascii filenames present in a traceback

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -248,7 +248,7 @@ def fix_frame_records_filenames(records):
         # Look inside the frame's globals dictionary for __file__,
         # which should be better. However, keep Cython filenames since
         # we prefer the source filenames over the compiled .so file.
-        filename = py3compat.cast_unicode(filename, "utf-8")
+        filename = py3compat.cast_unicode_py2(filename, "utf-8")
         if not filename.endswith(('.pyx', '.pxd', '.pxi')):
             better_fn = frame.f_globals.get('__file__', None)
             if isinstance(better_fn, str):
@@ -540,9 +540,9 @@ class ListTB(TBTools):
         list = []
         for filename, lineno, name, line in extracted_list[:-1]:
             item = '  File %s"%s"%s, line %s%d%s, in %s%s%s\n' % \
-                   (Colors.filename, py3compat.cast_unicode(filename, "utf-8"), Colors.Normal,
+                   (Colors.filename, py3compat.cast_unicode_py2(filename, "utf-8"), Colors.Normal,
                     Colors.lineno, lineno, Colors.Normal,
-                    Colors.name, py3compat.cast_unicode(name, "utf-8"), Colors.Normal)
+                    Colors.name, py3compat.cast_unicode_py2(name, "utf-8"), Colors.Normal)
             if line:
                 item += '    %s\n' % line.strip()
             list.append(item)
@@ -550,9 +550,9 @@ class ListTB(TBTools):
         filename, lineno, name, line = extracted_list[-1]
         item = '%s  File %s"%s"%s, line %s%d%s, in %s%s%s%s\n' % \
                (Colors.normalEm,
-                Colors.filenameEm, py3compat.cast_unicode(filename, "utf-8"), Colors.normalEm,
+                Colors.filenameEm, py3compat.cast_unicode_py2(filename, "utf-8"), Colors.normalEm,
                 Colors.linenoEm, lineno, Colors.normalEm,
-                Colors.nameEm, py3compat.cast_unicode(name, "utf-8"), Colors.normalEm,
+                Colors.nameEm, py3compat.cast_unicode_py2(name, "utf-8"), Colors.normalEm,
                 Colors.Normal)
         if line:
             item += '%s    %s%s\n' % (Colors.line, line.strip(),

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -248,6 +248,7 @@ def fix_frame_records_filenames(records):
         # Look inside the frame's globals dictionary for __file__,
         # which should be better. However, keep Cython filenames since
         # we prefer the source filenames over the compiled .so file.
+        filename = py3compat.cast_unicode(filename, "utf-8")
         if not filename.endswith(('.pyx', '.pxd', '.pxi')):
             better_fn = frame.f_globals.get('__file__', None)
             if isinstance(better_fn, str):
@@ -539,9 +540,9 @@ class ListTB(TBTools):
         list = []
         for filename, lineno, name, line in extracted_list[:-1]:
             item = '  File %s"%s"%s, line %s%d%s, in %s%s%s\n' % \
-                   (Colors.filename, filename, Colors.Normal,
+                   (Colors.filename, py3compat.cast_unicode(filename, "utf-8"), Colors.Normal,
                     Colors.lineno, lineno, Colors.Normal,
-                    Colors.name, name, Colors.Normal)
+                    Colors.name, py3compat.cast_unicode(name, "utf-8"), Colors.Normal)
             if line:
                 item += '    %s\n' % line.strip()
             list.append(item)
@@ -549,9 +550,9 @@ class ListTB(TBTools):
         filename, lineno, name, line = extracted_list[-1]
         item = '%s  File %s"%s"%s, line %s%d%s, in %s%s%s%s\n' % \
                (Colors.normalEm,
-                Colors.filenameEm, filename, Colors.normalEm,
+                Colors.filenameEm, py3compat.cast_unicode(filename, "utf-8"), Colors.normalEm,
                 Colors.linenoEm, lineno, Colors.normalEm,
-                Colors.nameEm, name, Colors.normalEm,
+                Colors.nameEm, py3compat.cast_unicode(name, "utf-8"), Colors.normalEm,
                 Colors.Normal)
         if line:
             item += '%s    %s%s\n' % (Colors.line, line.strip(),


### PR DESCRIPTION
This solves the simple problem of running a file with non-ascii chars in
its name that contains an error of any kind in it.

Example: A file called `á.py` with this content

```
foo('a')
```

run it with `%run á.py` and see a horrible error.

This was motivated by this SO post:

http://stackoverflow.com/questions/27834477/unicode-decode-error-report-in-spyder
