### PR TITLE
Define kernel_model within the MultiKernelManager

### DIFF
--- a/IPython/kernel/multikernelmanager.py
+++ b/IPython/kernel/multikernelmanager.py
@@ -112,6 +112,14 @@ class MultiKernelManager(LoggingConfigurable):
         km.start_kernel(**kwargs)
         self._kernels[kernel_id] = km
         return kernel_id
+    
+    def kernel_model(self, kernel_id):
+        """Return a dictionary of kernel information described in the
+        JSON standard model."""
+        self._check_kernel_id(kernel_id)
+        model = {"id":kernel_id,
+                 "name": self._kernels[kernel_id].kernel_name}
+        return model
 
     @kernel_method
     def shutdown_kernel(self, kernel_id, now=False, restart=False):


### PR DESCRIPTION
When trying to update minrk/singlecell to IPython3 I ran into issues with the MultiKernelManager not having `kernel_model` defined. At first I subclassed it,

```
class MicroKernelManager(MultiKernelManager):
    def kernel_model(self, kernel_id):
        """Return a dictionary of kernel information described in the
        JSON standard model."""
        self._check_kernel_id(kernel_id)
        model = {"id":kernel_id,
                 "name": self._kernels[kernel_id].kernel_name}
        return model
```

Then figured I could add it at the level of `MultiKernelManager`. Any objections? I freely admit that I don't know the scope of why its only in the `MappingKernelManager` (and subclasses).
