### PR TITLE
Make modal backdrop static by default.

### DIFF
--- a/IPython/html/static/base/js/dialog.js
+++ b/IPython/html/static/base/js/dialog.js
@@ -87,6 +87,8 @@ define([
         if (options.keyboard_manager) {
             options.keyboard_manager.disable();
         }
+
+        options.backdrop = options.backdrop || 'static';
         
         return modal.modal(options);
     };


### PR DESCRIPTION
does not dismiss dialog accidentally if click on faded area.

Closes #7403
