### PR TITLE
Fix "TypeError: data is undefined" when loading a notebook in Firefox

### DIFF
--- a/IPython/html/static/notebook/js/kernelselector.js
+++ b/IPython/html/static/notebook/js/kernelselector.js
@@ -126,6 +126,7 @@ define([
             return;
         }
         var ks = this.kernelspecs[kernel_name];
+        if (ks === undefined) return;        
         
         try {
             this.notebook.start_session(kernel_name);


### PR DESCRIPTION
Fixes https://github.com/ipython/ipython/issues/7328 for me.
