### PR TITLE
left-aligning text

### DIFF
--- a/IPython/html/static/notebook/less/renderedhtml.less
+++ b/IPython/html/static/notebook/less/renderedhtml.less
@@ -73,7 +73,7 @@
     th {font-weight: bold;}
     * + table {margin-top: 1em;}
 
-    p {text-align: justify;}
+    p {text-align: left;}
     * + p {margin-top: 1em;}
 
     img {

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -1100,7 +1100,7 @@ div.output_unrecognized a:hover {
   margin-top: 1em;
 }
 .rendered_html p {
-  text-align: justify;
+  text-align: left;
 }
 .rendered_html * + p {
   margin-top: 1em;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -9548,7 +9548,7 @@ div.output_unrecognized a:hover {
   margin-top: 1em;
 }
 .rendered_html p {
-  text-align: justify;
+  text-align: left;
 }
 .rendered_html * + p {
   margin-top: 1em;


### PR DESCRIPTION
Does as #7239 asks.

Here is an example, maybe not the most demonstrative... perhaps someone can suggest a better notebook?

Before:
![screenshot from 2015-01-13 18 57 42](https://cloud.githubusercontent.com/assets/45380/5731822/226683f8-9b56-11e4-98f0-a4af0622200f.png)

After:
![screenshot from 2015-01-13 18 57 00](https://cloud.githubusercontent.com/assets/45380/5731820/20bef490-9b56-11e4-874c-32a3fe936cd7.png)

Here is some light reading:
- [Nature](http://www.nature.com/srep/authors/submit.html): don't justify... manuscripts. 
- [Readability Do's and Don'ts](http://wmich.edu/writing/readability): meh... maybe use if it's long?
- [SO](http://graphicdesign.stackexchange.com/questions/16137/readability-and-appeal-of-justified-text): use justify. maybe.
- [Readability: Justified vs. Ragged](http://www.textproof.com/chronicle/Readability__Justified_vs__Ragged.html): justify if the lines are short
  - references [Readability of Computer-Generated Fill-Justified Text. Human Factors: The Journal of the Human Factors and Ergonomics Society April 1986 28: 159-163,](http://hfs.sagepub.com/content/28/2/159.full.pdf): behind paywall, don't have library proxy set up :)
  - [Tufte](http://www.edwardtufte.com/bboard/q-and-a-fetch-msg?msg_id=0001Au): don't justify... _and use serifs_

Line length is mentioned several times. While I have no idea what the metric should be, here's one from the michigan link above:

>  line length should be between 1.5 and two times the lowercase alphabet in the type and point size being used

For the normal text (14px) that would put the line length between 260 and 350. Well, that's not going to happen! However, it does raise the question of at some point providing a "responsive readability" mode (think flipboard, etc) that really went after the readability metrics, especially for devices, which are becoming such a popular way to read content.
