### PR TITLE
Set name/date for served notebooks

### DIFF
--- a/IPython/html/nbconvert/handlers.py
+++ b/IPython/html/nbconvert/handlers.py
@@ -6,7 +6,6 @@
 import io
 import os
 import zipfile
-import collections
 
 from tornado import web
 

--- a/IPython/html/nbconvert/handlers.py
+++ b/IPython/html/nbconvert/handlers.py
@@ -6,6 +6,7 @@
 import io
 import os
 import zipfile
+import collections
 
 from tornado import web
 
@@ -16,6 +17,7 @@ from ..base.handlers import (
 from IPython.nbformat import from_dict
 
 from IPython.utils.py3compat import cast_bytes
+from IPython.utils import text
 
 def find_resource_files(output_files_dir):
     files = []
@@ -87,9 +89,18 @@ class NbconvertFileHandler(IPythonHandler):
             raise web.HTTPError(400, "Not a notebook: %s" % path)
 
         self.set_header('Last-Modified', model['last_modified'])
-        
+
         try:
-            output, resources = exporter.from_notebook_node(model['content'])
+            output, resources = exporter.from_notebook_node(
+                model['content'],
+                resources={
+                    "metadata": {
+                        "name": name[:name.rfind('.')],
+                        "modified_date": (model['last_modified']
+                            .strftime(text.date_format))
+                    }
+                }
+            )
         except Exception as e:
             raise web.HTTPError(500, "nbconvert failed: %s" % e)
 

--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -241,7 +241,9 @@ class Exporter(LoggingConfigurable):
         #Make sure the metadata extension exists in resources
         if 'metadata' in resources:
             if not isinstance(resources['metadata'], ResourcesDict):
-                resources['metadata'] = ResourcesDict(resources['metadata'])
+                new_metadata = ResourcesDict()
+                new_metadata.update(resources['metadata'])
+                resources['metadata'] = new_metadata
         else:
             resources['metadata'] = ResourcesDict()
             if not resources['metadata']['name']:


### PR DESCRIPTION
This fixes #7360 by explicitly providing `resources` when calling `from_notebook_node` in the nbconvert handlers. It sets the name and modified date in `metadata`, but none of the other stuff which didn't seem relevant in this case:

``` python
{
"unique_key": "Stuff",
"output_files_dir": "Stuff_files",
"metadata": defaultdict(None, {"name": "Stuff", "modified_date": "January 13, 2015"}),
"profile_dir": "/home/weg/.ipython/profile_default"
} 
```

This is normally populated by `from_filename`, but calling that didn't seem appropriate for a `model` coming off the contents manager.

Also uncovered a mis-construction of `ResourcesDict` (a subclass of `defaultdict`), using the pattern found immediately above... was getting the ever-helpful `first argument must be callable` error, as it should be the default value for missing. Another option would be to change the constructor to be like `dict`, but this seemed less surprising.
