### PR TITLE
Remove zenburn.css

### DIFF
--- a/IPython/nbconvert/templates/html/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/html/slides_reveal.tpl
@@ -58,9 +58,6 @@
 <link rel="stylesheet" href="{{resources.reveal.url_prefix}}/css/reveal.css">
 <link rel="stylesheet" href="{{resources.reveal.url_prefix}}/css/theme/simple.css" id="theme">
 
-<!-- For syntax highlighting -->
-<link rel="stylesheet" href="{{resources.reveal.url_prefix}}/lib/css/zenburn.css">
-
 <!-- If the query includes 'print-pdf', include the PDF print sheet -->
 <script>
 if( window.location.search.match( /print-pdf/gi ) ) {

--- a/IPython/nbconvert/templates/html/slides_reveal.tpl
+++ b/IPython/nbconvert/templates/html/slides_reveal.tpl
@@ -99,6 +99,9 @@ html {
   font-size: 80%;
   box-shadow: 0px 0px 0px rgba(0, 0, 0, 0);
 }
+.reveal pre code {
+  padding: 0px;
+}
 .reveal section img {
   border: 0px solid black;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0);


### PR DESCRIPTION
fixes #6350 

This is a highlighting css shipped with reveal which was causing some problem and highlighting things when it is not needed... this change make the highlighting behaviour consistent with the --to html output.
