### PR TITLE
add language name to kernelspec

### DIFF
--- a/IPython/html/static/base/less/page.less
+++ b/IPython/html/static/base/less/page.less
@@ -140,3 +140,10 @@ span#login_widget > .button,
     .fa();
     content: @ico;
 }
+
+@media (min-width: @screen-sm-min) {
+    select.form-control {
+        margin-left: @padding-base-horizontal;
+        margin-right: @padding-base-horizontal;
+    }
+}

--- a/IPython/html/static/notebook/js/kernelselector.js
+++ b/IPython/html/static/notebook/js/kernelselector.js
@@ -201,6 +201,12 @@ define([
             }
             if (matches.length === 1) {
                 ks = kernelspecs[matches[0]];
+                console.log("No exact match found for " + selected.name +
+                    ", using only kernel that matches language=" + selected.language, ks);
+                this.events.trigger("spec_match_found.Kernel", {
+                    selected: selected,
+                    found: ks,
+                });
             }
             // if still undefined, trigger failure event
             if (ks === undefined) {

--- a/IPython/html/static/notebook/js/kernelselector.js
+++ b/IPython/html/static/notebook/js/kernelselector.js
@@ -193,7 +193,7 @@ define([
             var available = _sorted_names(kernelspecs);
             var matches = [];
             if (selected.language && selected.language.length > 0) {
-                $.map(available, function (name) {
+                available.map(function (name) {
                     if (kernelspecs[name].spec.language.toLowerCase() === selected.language.toLowerCase()) {
                         matches.push(name);
                     }
@@ -230,7 +230,7 @@ define([
         } else {
             names = data.available;
         }
-        $.map(names, function (name) {
+        names.map(function (name) {
             var ks = that.kernelspecs[name];
             select.append(
                 $('<option/>').attr('value', ks.name).text(ks.spec.display_name || ks.name)

--- a/IPython/html/static/notebook/js/kernelselector.js
+++ b/IPython/html/static/notebook/js/kernelselector.js
@@ -164,7 +164,7 @@ define([
         /** set the kernel by name, ensuring kernelspecs have been loaded, first 
         
         kernel can be just a kernel name, or a notebook kernelspec metadata
-        (name, language_name, display_name).
+        (name, language, display_name).
         */
         var that = this;
         if (typeof selected === 'string') {
@@ -192,9 +192,9 @@ define([
         if (ks === undefined) {
             var available = _sorted_names(kernelspecs);
             var matches = [];
-            if (selected.language_name && selected.language_name.length > 0) {
+            if (selected.language && selected.language.length > 0) {
                 $.map(available, function (name) {
-                    if (kernelspecs[name].spec.language_name.toLowerCase() === selected.language_name.toLowerCase()) {
+                    if (kernelspecs[name].spec.language.toLowerCase() === selected.language.toLowerCase()) {
                         matches.push(name);
                     }
                 });

--- a/IPython/html/static/notebook/js/kernelselector.js
+++ b/IPython/html/static/notebook/js/kernelselector.js
@@ -248,6 +248,12 @@ define([
             title : 'Kernel not found',
             body : body,
             buttons : {
+                'No appropriate kernel' : {
+                    class : 'btn-danger',
+                    click : function () {
+                        that.events.trigger('no_kernel.Kernel');
+                    }
+                },
                 OK : {
                     class : 'btn-primary',
                     click : function () {

--- a/IPython/html/static/notebook/js/kernelselector.js
+++ b/IPython/html/static/notebook/js/kernelselector.js
@@ -248,7 +248,7 @@ define([
             title : 'Kernel not found',
             body : body,
             buttons : {
-                'No appropriate kernel' : {
+                'Continue without kernel' : {
                     class : 'btn-danger',
                     click : function () {
                         that.events.trigger('no_kernel.Kernel');

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -249,7 +249,7 @@ define([
             that.metadata.kernelspec = {
                 name: data.name,
                 display_name: data.spec.display_name,
-                language_name: data.spec.language_name,
+                language: data.spec.language,
             };
             // start session if the current session isn't already correct
             if (!(this.session && this.session.kernel && this.session.kernel.name === data.name)) {

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -249,7 +249,7 @@ define([
             that.metadata.kernelspec = {
                 name: data.name,
                 display_name: data.spec.display_name,
-                project_name: data.spec.project_name,
+                language_name: data.spec.language_name,
             };
             // start session if the current session isn't already correct
             if (!(this.session && this.session.kernel && this.session.kernel.name === data.name)) {

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -2192,18 +2192,14 @@ define([
         }
         
         if (this.session === null) {
-            var kernel_name;
-            if (this.metadata.kernelspec) {
-                var kernelspec = this.metadata.kernelspec || {};
-                kernel_name = kernelspec.name;
-            } else {
-                kernel_name = utils.get_url_param('kernel_name');
-            }
+            var kernel_name = utils.get_url_param('kernel_name');
             if (kernel_name) {
-                // setting kernel_name here triggers start_session
                 this.kernel_selector.set_kernel(kernel_name);
+            } else if (this.metadata.kernelspec) {
+                this.kernel_selector.set_kernel(this.metadata.kernelspec);
             } else {
-                // start a new session with the server's default kernel
+                // setting kernel via set_kernel above triggers start_session,
+                // otherwise start a new session with the server's default kernel
                 // spec_changed events will fire after kernel is loaded
                 this.start_session();
             }

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -246,8 +246,11 @@ define([
         });
         
         this.events.on('spec_changed.Kernel', function(event, data) {
-            that.metadata.kernelspec = 
-                {name: data.name, display_name: data.spec.display_name};
+            that.metadata.kernelspec = {
+                name: data.name,
+                display_name: data.spec.display_name,
+                project_name: data.spec.project_name,
+            };
             // start session if the current session isn't already correct
             if (!(this.session && this.session.kernel && this.session.kernel.name === data.name)) {
                 that.start_session(data.name);

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -14,7 +14,7 @@ define([
         this.save_widget = options.save_widget;
         this.notebook = options.notebook;
         this.keyboard_manager = options.keyboard_manager;
-    }
+    };
     
     NotebookNotificationArea.prototype = Object.create(NotificationArea.prototype);
     
@@ -38,7 +38,7 @@ define([
         var knw = this.new_notification_widget('kernel');
         var $kernel_ind_icon = $("#kernel_indicator_icon");
         var $modal_ind_icon = $("#modal_indicator");
-        var $body = $('body')
+        var $body = $('body');
 
         // Command/Edit mode
         this.events.on('edit_mode.Notebook', function () {
@@ -57,9 +57,9 @@ define([
 
         // Implicitly start off in Command mode, switching to Edit mode will trigger event
         $modal_ind_icon.addClass('modal_indicator').attr('title','Command Mode');
-        $body.addClass('command_mode')
+        $body.addClass('command_mode');
 
-        // Kernel events 
+        // Kernel events
 
         // this can be either kernel_created.Kernel or kernel_created.Session
         this.events.on('kernel_created.Kernel kernel_created.Session', function () {
@@ -105,7 +105,7 @@ define([
                         }
                     }
                 });
-            };
+            }
 
             that.save_widget.update_document_title();
             knw.danger("Dead kernel");
@@ -255,6 +255,13 @@ define([
             window.document.title='(Busy) '+window.document.title;
             $kernel_ind_icon.attr('class','kernel_busy_icon').attr('title','Kernel Busy');
         });
+
+        this.events.on('spec_match_found.Kernel', function (evt, data) {
+            that.widget('kernelspec').info("Using kernel: " + data.found.spec.display_name, 3000, undefined, {
+                title: "Only candidate for language: " + data.selected.language + " was " + data.found.spec.display_name
+            });
+        });
+
         
         // Start the kernel indicator in the busy state, and send a kernel_info request.
         // When the kernel_info reply arrives, the kernel is idle.

--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -187,6 +187,10 @@ define([
 
             showMsg();
         });
+        
+        this.events.on("no_kernel.Kernel", function (evt, data) {
+            $("#kernel_indicator").find('.kernel_indicator_name').text("No Kernel");
+        });
 
         this.events.on('kernel_dead.Session', function (evt, info) {
             var full = info.xhr.responseJSON.message;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8583,6 +8583,12 @@ span#login_widget > .button .badge,
     width: 700px;
   }
 }
+@media (min-width: 768px) {
+  select.form-control {
+    margin-left: 12px;
+    margin-right: 12px;
+  }
+}
 /*!
 *
 * IPython auth

--- a/IPython/kernel/kernelspec.py
+++ b/IPython/kernel/kernelspec.py
@@ -36,7 +36,7 @@ def _pythonfirst(s):
 class KernelSpec(HasTraits):
     argv = List()
     display_name = Unicode()
-    project_name = Unicode()
+    language_name = Unicode()
     env = Dict()
     resource_dir = Unicode()
     
@@ -55,7 +55,7 @@ class KernelSpec(HasTraits):
         d = dict(argv=self.argv,
                  env=self.env,
                  display_name=self.display_name,
-                 project_name=self.project_name,
+                 language_name=self.language_name,
                 )
 
         return d
@@ -114,7 +114,7 @@ class KernelSpecManager(HasTraits):
         return {
                 'argv': make_ipkernel_cmd(),
                 'display_name': 'Python %i' % (3 if PY3 else 2),
-                'project_name': 'ipython',
+                'language_name': 'python',
                }
 
     @property

--- a/IPython/kernel/kernelspec.py
+++ b/IPython/kernel/kernelspec.py
@@ -36,6 +36,7 @@ def _pythonfirst(s):
 class KernelSpec(HasTraits):
     argv = List()
     display_name = Unicode()
+    project_name = Unicode()
     env = Dict()
     resource_dir = Unicode()
     
@@ -54,6 +55,7 @@ class KernelSpec(HasTraits):
         d = dict(argv=self.argv,
                  env=self.env,
                  display_name=self.display_name,
+                 project_name=self.project_name,
                 )
 
         return d
@@ -109,8 +111,10 @@ class KernelSpecManager(HasTraits):
         The native kernel is the kernel using the same Python runtime as this
         process. This will put its information in the user kernels directory.
         """
-        return {'argv': make_ipkernel_cmd(),
+        return {
+                'argv': make_ipkernel_cmd(),
                 'display_name': 'Python %i' % (3 if PY3 else 2),
+                'project_name': 'ipython',
                }
 
     @property

--- a/IPython/kernel/kernelspec.py
+++ b/IPython/kernel/kernelspec.py
@@ -36,7 +36,7 @@ def _pythonfirst(s):
 class KernelSpec(HasTraits):
     argv = List()
     display_name = Unicode()
-    language_name = Unicode()
+    language = Unicode()
     env = Dict()
     resource_dir = Unicode()
     
@@ -55,7 +55,7 @@ class KernelSpec(HasTraits):
         d = dict(argv=self.argv,
                  env=self.env,
                  display_name=self.display_name,
-                 language_name=self.language_name,
+                 language=self.language,
                 )
 
         return d
@@ -114,7 +114,7 @@ class KernelSpecManager(HasTraits):
         return {
                 'argv': make_ipkernel_cmd(),
                 'display_name': 'Python %i' % (3 if PY3 else 2),
-                'language_name': 'python',
+                'language': 'python',
                }
 
     @property

--- a/docs/source/development/kernels.rst
+++ b/docs/source/development/kernels.rst
@@ -112,6 +112,11 @@ JSON serialised dictionary containing the following keys and values:
 - **display_name**: The kernel's name as it should be displayed in the UI.
   Unlike the kernel name used in the API, this can contain arbitrary unicode
   characters.
+- **language**: The name of the language of the kernel.
+  When loading notebooks, if no matching kernelspec key (may differ across machines)
+  is found, a kernel with a matching `language` will be used.
+  This allows a notebook written on any Python or Julia kernel to be properly associated
+  with the user's Python or Julia kernel, even if they aren't listed under the same name as the author's.
 - **env** (optional): A dictionary of environment variables to set for the kernel.
   These will be added to the current environment variables before the kernel is
   started.
@@ -121,7 +126,8 @@ For example, the kernel.json file for IPython looks like this::
     {
      "argv": ["python3", "-c", "from IPython.kernel.zmq.kernelapp import main; main()", 
               "-f", "{connection_file}"],
-     "display_name": "IPython (Python 3)"
+     "display_name": "IPython (Python 3)",
+     "language": "python"
     }
 
 To see the available kernel specs, run::


### PR DESCRIPTION
This should be the same for any kernel from a given project, indicating compatibility. If you don't have a kernel that matches exact name, a kernel with a matching project_name will be selected.

If no matching kernel is found, a dialog is shown:

![screen shot 2015-01-14 at 10 34 39](https://cloud.githubusercontent.com/assets/151929/5744840/f9646aa0-9bd8-11e4-9242-2d58999e09f0.PNG)

closes #7349
