### PR TITLE
Don't show kernel-dead on manually shutdown kernel

### DIFF
--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -148,8 +148,8 @@ define([
 
         this.events.on('kernel_killed.Kernel kernel_killed.Session', function () {
             that.save_widget.update_document_title();
-            knw.danger("Dead kernel");
-            $kernel_ind_icon.attr('class','kernel_dead_icon').attr('title','Kernel Dead');
+            knw.warning("No kernel");
+            $kernel_ind_icon.attr('class','kernel_busy_icon').attr('title','Kernel is not running');
         });
 
         this.events.on('kernel_dead.Kernel', function () {


### PR DESCRIPTION
When there is no kernel, show 'No kernel', and set kernel-busy instead of showing read dead and bomb.

This is different from kernel-dead, which is caused when a kernel dies unexpectedly.

closes #7153

this includes #7455 for now
