### PR TITLE
set kernel-busy on kernel_created

### DIFF
--- a/IPython/html/static/notebook/js/notificationarea.js
+++ b/IPython/html/static/notebook/js/notificationarea.js
@@ -230,7 +230,7 @@ define([
             knw.danger(short, undefined, showMsg);
         });
 
-        this.events.on('kernel_starting.Kernel', function () {
+        this.events.on('kernel_starting.Kernel kernel_created.Session', function () {
             window.document.title='(Starting) '+window.document.title;
             $kernel_ind_icon.attr('class','kernel_busy_icon').attr('title','Kernel Busy');
             knw.set_message("Kernel starting, please wait...");


### PR DESCRIPTION
rather than waiting for kernel_starting, which is only after kernel exists, but before connection is available

closes #7338
