### PR TITLE
stop %run foo.ipynb on exception

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2703,7 +2703,9 @@ class InteractiveShell(SingletonConfigurable):
                     # raised in user code.  It would be nice if there were
                     # versions of run_cell that did raise, so
                     # we could catch the errors.
-                    self.run_cell(cell, silent=True, shell_futures=shell_futures)
+                    result = self.run_cell(cell, silent=True, shell_futures=shell_futures)
+                    if not result.success:
+                        break
             except:
                 self.showtraceback()
                 warn('Unknown failure executing file: <%s>' % fname)


### PR DESCRIPTION
matches `Run All` behavior

closes #7100
