### PR TITLE
finish notebook files with a trailing newline

### DIFF
--- a/IPython/nbformat/__init__.py
+++ b/IPython/nbformat/__init__.py
@@ -158,4 +158,6 @@ def write(nb, fp, version=NO_CONVERT, **kwargs):
     s = writes(nb, version, **kwargs)
     if isinstance(s, bytes):
         s = s.decode('utf8')
-    return fp.write(s)
+    fp.write(s)
+    if not s.endswith(u'\n'):
+        fp.write(u'\n')


### PR DESCRIPTION
when writing to a file. Should make a few tools happier that can't handle simple things like this.

closes #7478
