### PR TITLE
add Dashboard to tree page title

### DIFF
--- a/IPython/html/tree/handlers.py
+++ b/IPython/html/tree/handlers.py
@@ -28,9 +28,9 @@ class TreeHandler(IPythonHandler):
                 comps.pop(0)
         page_title = url_path_join(*comps)
         if page_title:
-            return page_title+'/'
+            return 'Dashboard: %s/' % page_title
         else:
-            return 'Home'
+            return 'Dashboard: Home'
 
     @web.authenticated
     def get(self, path=''):


### PR DESCRIPTION
use `Dashboard: path/` instead of `path/`

counter-argument: this significantly reduces the amount of information in the page title. I don't feel strongly.

closes #6995
