### PR TITLE
don't set bootstrap toggle on ToggleButtonsWidget

### DIFF
--- a/IPython/html/static/widgets/js/widget_selection.js
+++ b/IPython/html/static/widgets/js/widget_selection.js
@@ -287,7 +287,6 @@ define([
                 .hide();
             this.$buttongroup = $('<div />')
                 .addClass('btn-group')
-                .attr('data-toggle', 'buttons-radio')
                 .appendTo(this.$el);
 
             this.model.on('change:button_style', function(model, value) {

--- a/IPython/html/tests/widgets/widget_selection.js
+++ b/IPython/html/tests/widgets/widget_selection.js
@@ -7,7 +7,7 @@ casper.notebook_test(function () {
     this.execute_cell_then(index);
 
     var combo_selector = '.widget-area .widget-subarea .widget-hbox .btn-group .widget-combo-btn';
-    var multibtn_selector = '.widget-area .widget-subarea .widget-hbox .btn-group[data-toggle="buttons-radio"]';
+    var multibtn_selector = '.widget-area .widget-subarea .widget-hbox.widget-toggle-buttons .btn-group';
     var radio_selector = '.widget-area .widget-subarea .widget-hbox .widget-radio-box';
     var list_selector = '.widget-area .widget-subarea .widget-hbox .widget-listbox';
 


### PR DESCRIPTION
Model update already toggles active and data-toggle does the same, so clicking on a toggle toggles twice, setting it back to the original value.

closes #6562
