### PR TITLE
Add docstring for IntRangeSlider

### DIFF
--- a/IPython/html/widgets/widget_int.py
+++ b/IPython/html/widgets/widget_int.py
@@ -186,6 +186,7 @@ class _BoundedIntRange(_IntRange):
 
 @register('IPython.IntRangeSlider')
 class IntRangeSlider(_BoundedIntRange):
+    """Slider widget that represents a pair of ints between a minimum and maximum value."""
     _view_name = Unicode('IntSliderView', sync=True)
     orientation = CaselessStrEnum(values=['horizontal', 'vertical'], 
         default_value='horizontal', allow_none=False, 


### PR DESCRIPTION
Closes gh-5381

This was the last remaining widget class I could see without a docstring
