### PR TITLE
Scroll overflow

### DIFF
--- a/IPython/html/static/notebook/less/outputarea.less
+++ b/IPython/html/static/notebook/less/outputarea.less
@@ -92,7 +92,7 @@ div.output_area pre {
 /* This class is for the output subarea inside the output_area and after
    the prompt div. */
 div.output_subarea {
-    padding: @code_padding @code_padding 0.0em @code_padding;
+    padding: @code_padding;
     .box-flex1();
 }
 

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -867,7 +867,7 @@ div.output_area pre {
 /* This class is for the output subarea inside the output_area and after
    the prompt div. */
 div.output_subarea {
-  padding: 0.4em 0.4em 0em 0.4em;
+  padding: 0.4em;
   /* Old browsers */
   -webkit-box-flex: 1;
   -moz-box-flex: 1;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -9491,7 +9491,7 @@ div.output_area pre {
 /* This class is for the output subarea inside the output_area and after
    the prompt div. */
 div.output_subarea {
-  padding: 0.4em 0.4em 0em 0.4em;
+  padding: 0.4em;
   /* Old browsers */
   -webkit-box-flex: 1;
   -moz-box-flex: 1;


### PR DESCRIPTION
I included @joelkim's fix to the less for issue #5967 and spent time trying to find a fix for the scrollbars overflowing the `output_area` on collapse/expand of the cell. I was only able to reproduce the bug in webkit browsers (Safari/Chrome) but not Firefox. From googling and experimentation, it appears webkit has some known problems in this area. Hacks abound on stackoverflow (http://stackoverflow.com/questions/3485365/how-can-i-force-webkit-to-redraw-repaint-to-propagate-style-changes) and the only rendition I got working is the one you see in the PR (insert an extra node, wait, remove it).

It's gross.

I'm not recommending it as the final fix, just something that seems to work in case all else fails.
