### PR TITLE
handle missing stream name in nbformat conversion

### DIFF
--- a/IPython/nbformat/v4/convert.py
+++ b/IPython/nbformat/v4/convert.py
@@ -186,7 +186,7 @@ def upgrade_output(output):
     elif output['output_type'] == 'pyerr':
         output['output_type'] = 'error'
     elif output['output_type'] == 'stream':
-        output['name'] = output.pop('stream')
+        output['name'] = output.pop('stream', 'stdout')
     return output
 
 def downgrade_output(output):


### PR DESCRIPTION
It was sometimes possible for this key to be absent. Even though that's never been officially valid, it happened, so might as well handle it.

closes #7490
