### PR TITLE
Sanitize dialog text-body.

### DIFF
--- a/IPython/html/static/base/js/dialog.js
+++ b/IPython/html/static/base/js/dialog.js
@@ -8,6 +8,35 @@ define(function(require) {
     var IPython = require('base/js/namespace');
     var $ = require('jquery');
     
+    /**
+     * A wrapper around bootstrap modal for easier use
+     * Pass it an option dictionary with the following properties:
+     *
+     *    - body : <string> or <DOM node>, main content of the dialog
+     *            if pass a <string> it will be wrapped in a p tag and
+     *            html element escaped, unless you specify sanitize=false
+     *            option.
+     *    - title : Dialog title, default to empty string.
+     *    - buttons : dict of btn_options who keys are button label.
+     *            see btn_options below for description
+     *    - open : callback to trigger on dialog open.
+     *    - destroy:
+     *    - notebook : notebook instance
+     *    - keyboard_manager: keyboard manager instance.
+     *
+     *  Unlike bootstrap modals, the backdrop options is set by default 
+     *  to 'static'.
+     *
+     *  The rest of the options are passed as is to bootstrap modals. 
+     *
+     *  btn_options: dict with the following property:
+     *  
+     *    - click : callback to trigger on click
+     *    - class : css classes to add to button.
+     *
+     *
+     *
+     **/
     var modal = function (options) {
 
         var modal = $("<div/>")
@@ -20,7 +49,7 @@ define(function(require) {
         var dialog_content = $("<div/>")
             .addClass("modal-content")
             .appendTo(dialog);
-        if(typeof(options.body) === 'string'){
+        if(typeof(options.body) === 'string' && options.sanitize !== false){
             options.body = $("<p/>").text(options.body)
         }
         dialog_content.append(
@@ -35,7 +64,7 @@ define(function(require) {
                 ).append(
                     $("<h4/>")
                         .addClass('modal-title')
-                        .text(options.title || "No Title")
+                        .text(options.title || "")
                 )
         ).append(
             $("<div/>").addClass("modal-body").append(

--- a/IPython/html/static/base/js/dialog.js
+++ b/IPython/html/static/base/js/dialog.js
@@ -1,12 +1,12 @@
 // Copyright (c) IPython Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-define([
-    'base/js/namespace',
-    'jquery',
-    'codemirror/lib/codemirror',
-], function(IPython, $, CodeMirror) {
+define(function(require) {
     "use strict";
+
+    var CodeMirror = require('codemirror/lib/codemirror');
+    var IPython = require('base/js/namespace');
+    var $ = require('jquery');
     
     var modal = function (options) {
 
@@ -20,6 +20,9 @@ define([
         var dialog_content = $("<div/>")
             .addClass("modal-content")
             .appendTo(dialog);
+        if(typeof(options.body) === 'string'){
+            options.body = $("<p/>").text(options.body)
+        }
         dialog_content.append(
             $("<div/>")
                 .addClass("modal-header")
@@ -32,7 +35,7 @@ define([
                 ).append(
                     $("<h4/>")
                         .addClass('modal-title')
-                        .text(options.title || "")
+                        .text(options.title || "No Title")
                 )
         ).append(
             $("<div/>").addClass("modal-body").append(


### PR DESCRIPTION
Mitigate 7486, could probably be improved, but
treat text as pure text, but assume that when received a dom
element it actually come from a secure source.

Sanitizing all we get, including Dom Element break json-metadata editor
and a few others.
