### PR TITLE
Reload list after creating a new folder in promises.

### DIFF
--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -82,8 +82,10 @@ define([
                 that.load_sessions();
             });
             $('#new-folder').click(function(e) {
-                that.contents.new_untitled(that.notebook_path || '', {type: 'directory'});
-                that.load_sessions();
+                that.contents.new_untitled(that.notebook_path || '', {type: 'directory'})
+                .then(function(){
+                    that.load_list();
+                });
             });
         }
     };


### PR DESCRIPTION
No need to reload session (I doubt creating a new folder create a
session), and does it once the creation drive promise return which make
the new directory appear in the listing for slow remote-backend (like
google drive)
