### PR TITLE
Traitlet support for functools.partial as callback

### DIFF
--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -280,6 +280,86 @@ def dlink(source, *targets):
     """Shorter helper function returning a directional_link object"""
     return directional_link(source, *targets)
 
+
+# Alternative getargspec implementations taken from Sphinx
+if sys.version_info >= (3, 0):
+
+    from functools import partial
+
+    def getargspec(func):
+        """Like inspect.getargspec but supports functools.partial as well."""
+        if inspect.ismethod(func):
+            func = func.__func__
+        if type(func) is partial:
+            orig_func = func.func
+            argspec = getargspec(orig_func)
+            args = list(argspec[0])
+            defaults = list(argspec[3] or ())
+            kwoargs = list(argspec[4])
+            kwodefs = dict(argspec[5] or {})
+            if func.args:
+                args = args[len(func.args):]
+            for arg in func.keywords or ():
+                try:
+                    i = args.index(arg) - len(args)
+                    del args[i]
+                    try:
+                        del defaults[i]
+                    except IndexError:
+                        pass
+                except ValueError:   # must be a kwonly arg
+                    i = kwoargs.index(arg)
+                    del kwoargs[i]
+                    del kwodefs[arg]
+            return inspect.FullArgSpec(args, argspec[1], argspec[2],
+                                       tuple(defaults), kwoargs,
+                                       kwodefs, argspec[6])
+        while hasattr(func, '__wrapped__'):
+            func = func.__wrapped__
+        if not inspect.isfunction(func):
+            raise TypeError('%r is not a Python function' % func)
+        return inspect.getfullargspec(func)
+elif sys.version_info >= (2, 5):
+
+    from functools import partial
+
+    def getargspec(func):
+        """Like inspect.getargspec but supports functools.partial as well."""
+        if inspect.ismethod(func):
+            func = func.im_func
+        parts = 0, ()
+        if type(func) is partial:
+            keywords = func.keywords
+            if keywords is None:
+                keywords = {}
+            parts = len(func.args), keywords.keys()
+            func = func.func
+        if not inspect.isfunction(func):
+            raise TypeError('%r is not a Python function' % func)
+        args, varargs, varkw = inspect.getargs(func.func_code)
+        func_defaults = func.func_defaults
+        if func_defaults is None:
+            func_defaults = []
+        else:
+            func_defaults = list(func_defaults)
+        if parts[0]:
+            args = args[parts[0]:]
+        if parts[1]:
+            for arg in parts[1]:
+                i = args.index(arg) - len(args)
+                del args[i]
+                try:
+                    del func_defaults[i]
+                except IndexError:
+                    pass
+        if sys.version_info >= (2, 6):
+            return inspect.ArgSpec(args, varargs, varkw, func_defaults)
+        else:
+            return (args, varargs, varkw, func_defaults)
+else:
+    getargspec = inspect.getargspec
+
+
 #-----------------------------------------------------------------------------
 # Base TraitType for all traits
 #-----------------------------------------------------------------------------
@@ -570,7 +650,8 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
         for c in callables:
             # Traits catches and logs errors here.  I allow them to raise
             if callable(c):
-                argspec = inspect.getargspec(c)
+                argspec = getargspec(c)
+
                 nargs = len(argspec[0])
                 # Bound methods have an additional 'self' argument
                 # I don't know how to treat unbound methods, but they


### PR DESCRIPTION
When generating widgets programmatically, it can be convenient to be able to use functools.partial for callbacks, binding arguments to more generalised functions. However, traitlets do not support this due to inspect.getargspec not working on partials. This PR enables that functionality by adding some code taken from Sphinx - which presumably is battle-tested.

The functionality could of course also be imported from Sphinx but I guess it's desirable to keep Sphinx as a soft dependency.
