### PR TITLE
fix find_connection_file exclude notebook_cookie_secret

### DIFF
--- a/IPython/kernel/connect.py
+++ b/IPython/kernel/connect.py
@@ -220,6 +220,8 @@ def find_connection_file(filename, profile=None):
         # accept any substring match
         pat = '*%s*' % filename
     matches = glob.glob( os.path.join(security_dir, pat) )
+    # exclude notebook_cookie_secret
+    matches = [m for m in matches if not m.endswith('notebook_cookie_secret')]
     if not matches:
         raise IOError("Could not find %r in %r" % (filename, security_dir))
     elif len(matches) == 1:


### PR DESCRIPTION
i has start a notebook server. but when i use `find_connection_file`. i found this error:

``` python
In [1]: from IPython.kernel import find_connection_file

In [2]: find_connection_file('*')
Out[2]: u'/Users/dongweiming/.ipython/profile_default/security/notebook_cookie_secret'

In [3]: find_connection_file('')
Out[3]: u'/Users/dongweiming/.ipython/profile_default/security/notebook_cookie_secret'

In [4]: ls /Users/dongweiming/.ipython/profile_default/security
nbserver-92188.json     notebook_cookie_secret
```

You can see the result is a cookie secret file. so need exclude it.

``` python
$python -c "import IPython; print(IPython.sys_info())"
{'commit_hash': u'e2778c5',
 'commit_source': 'repository',
 'default_encoding': 'UTF-8',
 'ipython_path': '/Users/dongweiming/ipython/IPython',
 'ipython_version': '3.0.0-dev',
 'os_name': 'posix',
 'platform': 'Darwin-13.4.0-x86_64-i386-64bit',
 'sys_executable': '/usr/bin/python',
 'sys_platform': 'darwin',
 'sys_version': '2.7.5 (default, Mar  9 2014, 22:15:05) \n[GCC 4.2.1 Compatible Apple LLVM 5.0 (clang-500.0.68)]'}

```
