### PR TITLE
Fixes #7503 - Cell magics fail to switch the language

### DIFF
--- a/IPython/nbconvert/filters/highlight.py
+++ b/IPython/nbconvert/filters/highlight.py
@@ -113,7 +113,7 @@ def _pygments_highlight(source, output_formatter, language='ipython', metadata=N
 
     # If the cell uses a magic extension language,
     # use the magic language instead.
-    if language == 'ipython' \
+    if language.startswith('ipython') \
         and metadata \
         and 'magics_language' in metadata:
 


### PR DESCRIPTION
Recognize "ipython3" as a default language to be replaced
in the presence of cell magic.
