### PR TITLE
Don't use widget.description as kwarg key

### DIFF
--- a/IPython/html/widgets/interaction.py
+++ b/IPython/html/widgets/interaction.py
@@ -155,6 +155,7 @@ def _widgets_from_abbreviations(seq):
         widget = _widget_from_abbrev(abbrev, default)
         if not widget.description:
             widget.description = name
+        widget._kwarg = name
         result.append(widget)
     return result
 
@@ -194,7 +195,7 @@ def interactive(__interact_f, **kwargs):
         container.kwargs = {}
         for widget in kwargs_widgets:
             value = widget.value
-            container.kwargs[widget.description] = value
+            container.kwargs[widget._kwarg] = value
         if co:
             clear_output(wait=True)
         if manual:

--- a/IPython/html/widgets/tests/test_interaction.py
+++ b/IPython/html/widgets/tests/test_interaction.py
@@ -489,13 +489,20 @@ def test_default_description():
     )
 
 def test_custom_description():
-    c = interactive(f, b=widgets.Text(value='text', description='foo'))
+    d = {}
+    def record_kwargs(**kwargs):
+        d.clear()
+        d.update(kwargs)
+    
+    c = interactive(record_kwargs, b=widgets.Text(value='text', description='foo'))
     w = c.children[0]
     check_widget(w,
         cls=widgets.Text,
         value='text',
         description='foo',
     )
+    w.value = 'different text'
+    nt.assert_equal(d, {'b': 'different text'})
 
 def test_interact_manual_button():
     c = interactive(f, __manual=True)


### PR DESCRIPTION
in interact.

description can be set manually, so it cannot be relied upon to store the kwarg key. Add a `widget._kwarg` attribute instead.

closes #7507
