### PR TITLE
fix nbserver kernels

### DIFF
--- a/IPython/kernel/connect.py
+++ b/IPython/kernel/connect.py
@@ -159,7 +159,7 @@ def get_connection_file(app=None):
     return filefind(app.connection_file, ['.', app.profile_dir.security_dir])
 
 
-def find_connection_file(filename='kernel-*.json', profile=None):
+def find_connection_file(filename='*-*.json', profile=None):
     """find a connection file, and return its absolute path.
     
     The current working directory and the profile's security


### PR DESCRIPTION
i saw [#7500](https://github.com/ipython/ipython/pull/7500). but it's has a error:

``` python
In [1]: from IPython.kernel import find_connection_file

In [2]: find_connection_file()
---------------------------------------------------------------------------
IOError                                   Traceback (most recent call last)
<ipython-input-2-ad1c79a21f6f> in <module>()
----> 1 find_connection_file()

/Library/Python/2.7/site-packages/IPython/kernel/connect.pyc in find_connection_file(filename, profile)
    222     matches = glob.glob( os.path.join(security_dir, pat) )
    223     if not matches:
--> 224         raise IOError("Could not find %r in %r" % (filename, security_dir))
    225     elif len(matches) == 1:
    226         return matches[0]

IOError: Could not find 'kernel-*.json' in u'/Users/dongweiming/.ipython/profile_default/security'

In [3]: ls -l /Users/dongweiming/.ipython/profile_default/security
total 24
-rw-r--r--  1 dongweiming  staff   188 Jan 20 08:49 nbserver-5220.json
-rw-r--r--  1 dongweiming  staff   188 Jan 20 08:49 nbserver-5258.json
-rw-------  1 dongweiming  staff  1386 Jan 20 08:49 notebook_cookie_secret
```
