### PR TITLE
add border to rendered markdown with cell toolbar

### DIFF
--- a/IPython/html/static/notebook/less/celltoolbar.less
+++ b/IPython/html/static/notebook/less/celltoolbar.less
@@ -31,10 +31,15 @@
 }
 
 .ctb_global_show .ctb_show + .input_area,
-.ctb_global_show .ctb_show + div.text_cell_input
-{
+.ctb_global_show .ctb_show + div.text_cell_input,
+.ctb_global_show .ctb_show ~ div.text_cell_render {
     border-top-right-radius: 0px;
     border-top-left-radius: 0px;
+}
+
+.ctb_global_show .ctb_show ~ div.text_cell_render {
+    // add border to rendered markdown cells
+    border: @border_width solid @light_border_color;
 }
 
 .celltoolbar {

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -10157,9 +10157,13 @@ p {
   display: block;
 }
 .ctb_global_show .ctb_show + .input_area,
-.ctb_global_show .ctb_show + div.text_cell_input {
+.ctb_global_show .ctb_show + div.text_cell_input,
+.ctb_global_show .ctb_show ~ div.text_cell_render {
   border-top-right-radius: 0px;
   border-top-left-radius: 0px;
+}
+.ctb_global_show .ctb_show ~ div.text_cell_render {
+  border: 1px solid #cfcfcf;
 }
 .celltoolbar {
   font-size: 87%;


### PR DESCRIPTION
matches unrendered markdown and code cells

![screen shot 2015-01-20 at 12 36 10](https://cloud.githubusercontent.com/assets/151929/5825584/597c95f8-a0a1-11e4-9751-eee42d347a1e.PNG)

ping @ellisonbg 

closes #7238
