### PR TITLE
Fix user interface tour

### DIFF
--- a/IPython/html/static/notebook/js/tour.js
+++ b/IPython/html/static/notebook/js/tour.js
@@ -40,13 +40,11 @@ define([
             }, {
                 element: $("#menus").parent(),
                 placement: 'bottom',
-                backdrop: true,
                 title: "Notebook Menubar",
                 content: "The menubar has menus for actions on the notebook, its cells, and the kernel it communicates with."
             }, {
                 element: "#maintoolbar",
                 placement: 'bottom',
-                backdrop: true,
                 title: "Notebook Toolbar",
                 content: "The toolbar has buttons for the most common actions. Hover your mouse over each button for more information."
             }, {
@@ -88,13 +86,13 @@ define([
                 onHide: function(tour) { $('#help_menu').parent().children('a').click(); },
                 content: "You can click here to get a list of all of the keyboard shortcuts."
             }, {
-                element: "#kernel_indicator",
+                element: "#kernel_indicator_icon",
                 title: "Kernel Indicator",
                 placement: 'bottom',
                 onShow: function(tour) { events.trigger('kernel_idle.Kernel');},
                 content: "This is the Kernel indicator. It looks like this when the Kernel is idle."
             }, {
-                element: "#kernel_indicator",
+                element: "#kernel_indicator_icon",
                 title: "Kernel Indicator",
                 placement: 'bottom',
                 onShow: function(tour) { events.trigger('kernel_busy.Kernel'); },
@@ -120,12 +118,9 @@ define([
         ];
 
         this.tour = new Tour({
-            //orphan: true,
             storage: false, // start tour from beginning every time
-            //element: $("#ipython_notebook"),
             debug: true,
             reflex: true, // click on element to continue tour
-            //backdrop: true, // show dark behind popover
             animation: false,
             duration: this.step_duration,
             onStart: function() { console.log('tour started'); },

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -38,7 +38,7 @@ data-notebook-path="{{notebook_path}}"
 
 
 <span id="save_widget" class="pull-left save_widget">
-    <span class="filename"></span>
+    <span id="notebook_name" class="filename"></span>
     <span class="checkpoint_status"></span>
     <span class="autosave_status"></span>
 </span>


### PR DESCRIPTION
This fixes #7418 
- updates the version of bootstrap tour
- removes usage of the backdrop, since it seems to be broken
- fix various element ids so the tour points to the right element
