### PR TITLE
change keyboard help to use `esc` and adds key symbol table

### DIFF
--- a/IPython/html/static/notebook/js/quickhelp.js
+++ b/IPython/html/static/notebook/js/quickhelp.js
@@ -206,7 +206,7 @@ define([
                     //'⌫	Delete back'+
                     //'⌦	Delete forward'+
                     //'<div class="col-md-4">col3</div>'
-            );
+                    );
         }
         element.append(doc);
 
@@ -232,6 +232,21 @@ define([
         
         this.events.on('rebuild.QuickHelp', function() { that.force_rebuild = true;});
     };
+
+    QuickHelp.prototype.build_key_names = function () {
+       var key_names_mac =  [{ key:"⌘", name:"Command" },
+                    { key:"⌃", name:"Control" },
+                    { key:"⌥", name:"Option" },
+                    { key:"⇧", name:"Shift" },
+                    { key:"↩", name:"Return" },
+                    { key:"␣", name:"Space" },
+                    { key:"⇥", name:"Tab forward" },
+                    { key:"⇤", name:"Tab back" }];
+        return $('<div>').addClass('quickhelp').
+            append($('<span/>').addClass('shortcut_key').append($(key))).
+            append($('<span/>').addClass('shortcut_descr').text(' = ' + name));
+    };
+
 
     QuickHelp.prototype.build_command_help = function () {
         var command_shortcuts = this.keyboard_manager.command_shortcuts.help();

--- a/IPython/html/static/notebook/js/quickhelp.js
+++ b/IPython/html/static/notebook/js/quickhelp.js
@@ -214,8 +214,7 @@ define([
                     { shortcut:"⇧", help:"Shift" },
                     { shortcut:"↩", help:"Return" },
                     { shortcut:"␣", help:"Space" },
-                    { shortcut:"⇥", help:"Tab forward" },
-                    { shortcut:"⇤", help:"Tab back" }];
+                    { shortcut:"⇥", help:"Tab" }];
         var i, half, n;
         var div = $('<div/>').append('MacOS modifier keys:');
         var sub_div = $('<div/>').addClass('container-fluid');

--- a/IPython/html/static/notebook/js/quickhelp.js
+++ b/IPython/html/static/notebook/js/quickhelp.js
@@ -180,20 +180,15 @@ define([
         );
         if (platform === 'MacOS') {
             doc.append(
-                    '<h4>Modifier keys</h4>'+
-                    '<div class="col-md-4">'+
-                    '<div class="quickhelp">'+
-                    '<span class="shortcut_key">'+
-                    '<code>'+
-                    '<strong>⌘</strong>'+
-                    '</code>'+
-                    '</span>'+
-                    '<span class="shortcut_descr"> = Command</span>'+
-                    '</div>'+
-                    '</div>'+
-                    '<div class="col-md-4">'+
-                    'others here'+
-                    '</div>'
+                    //'<div class="quickhelp">'+
+                    //'<span class="shortcut_key">'+
+                    //'<code>'+
+                    //'<strong>⌘</strong>'+
+                    //'</code>'+
+                    //'</span>'+
+                    //'<span class="shortcut_descr"> = Command</span>'+
+                    //'</div>'+
+                    //'</div>'+
                     //'⌃	Control'+	
                     //'⌥	Option'+
                     //'⇧	Shift'+
@@ -206,6 +201,13 @@ define([
                     //'⌫	Delete back'+
                     //'⌦	Delete forward'+
                     //'<div class="col-md-4">col3</div>'
+                    );
+            var key_div = this.build_key_names();
+            doc.append(key_div);
+            doc.append(
+                    '<div class="col-md-4">'+
+                    'others here?'+
+                    '</div>'
                     );
         }
         element.append(doc);
@@ -235,16 +237,29 @@ define([
 
     QuickHelp.prototype.build_key_names = function () {
        var key_names_mac =  [{ key:"⌘", name:"Command" },
-                    { key:"⌃", name:"Control" },
-                    { key:"⌥", name:"Option" },
-                    { key:"⇧", name:"Shift" },
-                    { key:"↩", name:"Return" },
-                    { key:"␣", name:"Space" },
-                    { key:"⇥", name:"Tab forward" },
-                    { key:"⇤", name:"Tab back" }];
-        return $('<div>').addClass('quickhelp').
-            append($('<span/>').addClass('shortcut_key').append($(key))).
-            append($('<span/>').addClass('shortcut_descr').text(' = ' + name));
+                    { shortcut:"⌃", help:"Control" },
+                    { shortcut:"⌥", help:"Option" },
+                    { shortcut:"⇧", help:"Shift" },
+                    { shortcut:"↩", help:"Return" },
+                    { shortcut:"␣", help:"Space" },
+                    { shortcut:"⇥", help:"Tab forward" },
+                    { shortcut:"⇤", help:"Tab back" }];
+        var i, half, n;
+        var div = $('<div/>').append('Modifier keys');
+        var sub_div = $('<div/>').addClass('container-fluid');
+        var col1 = $('<div/>').addClass('col-md-6');
+        var col2 = $('<div/>').addClass('col-md-6');
+        n = key_names_mac.length;
+        half = ~~(n/2);  // Truncate :)
+        for (i=0; i<half; i++) { col1.append( 
+                build_one(key_names_mac[i]) 
+                ); }
+        for (i=half; i<n; i++) { col2.append( 
+                build_one(key_names_mac[i]) 
+                ); }
+        sub_div.append(col1).append(col2);
+        div.append(sub_div);
+        return div;
     };
 
 

--- a/IPython/html/static/notebook/js/quickhelp.js
+++ b/IPython/html/static/notebook/js/quickhelp.js
@@ -180,8 +180,19 @@ define([
         );
         if (platform === 'MacOS') {
             doc.append(
-                    'Keys'+
-                    '⇥	Tab forward'+	
+                    '<h4>Modifier keys</h4>'+
+                    '<div class="col-md-4">'+
+                    '<div class="quickhelp">'+
+                    '<span class="shortcut_key">'+
+                    '<code>'+
+                    '<strong>⇥</strong>'+
+                    '</code>'+
+                    '</span>'+
+                    '<span class="shortcut_descr"> = Tab forward</span>'+
+                    '</div>'+
+                    '</div>'+
+                    '<div class="col-md-4">'+
+                    '</div>'+
                     '⇤	Tab back'+
                     '⇪	Capslock'+
                     '⇧	Shift'+
@@ -192,7 +203,8 @@ define([
                     '␣	Space'+
                     '↩	Return'+	
                     '⌫	Delete back'+
-                    '⌦	Delete forward'
+                    '⌦	Delete forward'+
+                    '<div class="col-md-4">col3</div>'
             );
         }
         element.append(doc);

--- a/IPython/html/static/notebook/js/quickhelp.js
+++ b/IPython/html/static/notebook/js/quickhelp.js
@@ -185,26 +185,27 @@ define([
                     '<div class="quickhelp">'+
                     '<span class="shortcut_key">'+
                     '<code>'+
-                    '<strong>⇥</strong>'+
+                    '<strong>⌘</strong>'+
                     '</code>'+
                     '</span>'+
-                    '<span class="shortcut_descr"> = Tab forward</span>'+
+                    '<span class="shortcut_descr"> = Command</span>'+
                     '</div>'+
                     '</div>'+
                     '<div class="col-md-4">'+
-                    '</div>'+
-                    '⇤	Tab back'+
-                    '⇪	Capslock'+
-                    '⇧	Shift'+
-                    '⌃	Control'+	
-                    '⌥	Option'+
-                    '	Apple symbol'+ 
-                    '⌘	Command'+
-                    '␣	Space'+
-                    '↩	Return'+	
-                    '⌫	Delete back'+
-                    '⌦	Delete forward'+
-                    '<div class="col-md-4">col3</div>'
+                    'others here'+
+                    '</div>'
+                    //'⌃	Control'+	
+                    //'⌥	Option'+
+                    //'⇧	Shift'+
+                    //'↩	Return'+	
+                    //'␣	Space'+
+                    //'⇥	Tab forward'+
+                    //'⇤	Tab back'+
+                    //'⇪	Capslock'+
+                    //'	Apple symbol'+ 
+                    //'⌫	Delete back'+
+                    //'⌦	Delete forward'+
+                    //'<div class="col-md-4">col3</div>'
             );
         }
         element.append(doc);

--- a/IPython/html/static/notebook/js/quickhelp.js
+++ b/IPython/html/static/notebook/js/quickhelp.js
@@ -82,7 +82,7 @@ define([
         'tab':'⇥',
         'backtab':'⇤',
         'capslock':'⇪',
-        'esc':'⎋',
+        'esc':'esc',
         'ctrl':'⌃',
         'enter':'↩',
         'pageup':'⇞',
@@ -178,6 +178,23 @@ define([
             'border. <b>Command mode</b> binds the keyboard to notebook level actions '+
             'and is indicated by a grey cell border.'
         );
+        if (platform === 'MacOS') {
+            doc.append(
+                    'Keys'+
+                    '⇥	Tab forward'+	
+                    '⇤	Tab back'+
+                    '⇪	Capslock'+
+                    '⇧	Shift'+
+                    '⌃	Control'+	
+                    '⌥	Option'+
+                    '	Apple symbol'+ 
+                    '⌘	Command'+
+                    '␣	Space'+
+                    '↩	Return'+	
+                    '⌫	Delete back'+
+                    '⌦	Delete forward'
+            );
+        }
         element.append(doc);
 
         // Command mode

--- a/IPython/html/static/notebook/js/quickhelp.js
+++ b/IPython/html/static/notebook/js/quickhelp.js
@@ -179,36 +179,8 @@ define([
             'and is indicated by a grey cell border.'
         );
         if (platform === 'MacOS') {
-            doc.append(
-                    //'<div class="quickhelp">'+
-                    //'<span class="shortcut_key">'+
-                    //'<code>'+
-                    //'<strong>⌘</strong>'+
-                    //'</code>'+
-                    //'</span>'+
-                    //'<span class="shortcut_descr"> = Command</span>'+
-                    //'</div>'+
-                    //'</div>'+
-                    //'⌃	Control'+	
-                    //'⌥	Option'+
-                    //'⇧	Shift'+
-                    //'↩	Return'+	
-                    //'␣	Space'+
-                    //'⇥	Tab forward'+
-                    //'⇤	Tab back'+
-                    //'⇪	Capslock'+
-                    //'	Apple symbol'+ 
-                    //'⌫	Delete back'+
-                    //'⌦	Delete forward'+
-                    //'<div class="col-md-4">col3</div>'
-                    );
             var key_div = this.build_key_names();
             doc.append(key_div);
-            doc.append(
-                    '<div class="col-md-4">'+
-                    'others here?'+
-                    '</div>'
-                    );
         }
         element.append(doc);
 
@@ -236,7 +208,7 @@ define([
     };
 
     QuickHelp.prototype.build_key_names = function () {
-       var key_names_mac =  [{ key:"⌘", name:"Command" },
+       var key_names_mac =  [{ shortcut:"⌘", help:"Command" },
                     { shortcut:"⌃", help:"Control" },
                     { shortcut:"⌥", help:"Option" },
                     { shortcut:"⇧", help:"Shift" },
@@ -245,12 +217,12 @@ define([
                     { shortcut:"⇥", help:"Tab forward" },
                     { shortcut:"⇤", help:"Tab back" }];
         var i, half, n;
-        var div = $('<div/>').append('Modifier keys');
+        var div = $('<div/>').append('MacOS modifier keys:');
         var sub_div = $('<div/>').addClass('container-fluid');
         var col1 = $('<div/>').addClass('col-md-6');
         var col2 = $('<div/>').addClass('col-md-6');
         n = key_names_mac.length;
-        half = ~~(n/2);  // Truncate :)
+        half = ~~(n/2);  
         for (i=0; i<half; i++) { col1.append( 
                 build_one(key_names_mac[i]) 
                 ); }


### PR DESCRIPTION
Work in progress, this adds a key symbol table for MacOS as per #7322 

Should automate the creation of the symbol table. I've put the symbol table in the alert box at the top, this is a design choice that needs review but I feel it is on par with the modal information that is already there.
