### PR TITLE
remember and persist manual scroll state.

### DIFF
--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -624,14 +624,7 @@ define([
             }
             this.set_input_prompt(data.execution_count);
             this.output_area.trusted = data.metadata.trusted || false;
-            this.output_area.fromJSON(data.outputs);
-            if (data.metadata.collapsed !== undefined) {
-                if (data.metadata.collapsed) {
-                    this.collapse_output();
-                } else {
-                    this.expand_output();
-                }
-            }
+            this.output_area.fromJSON(data.outputs, data.metadata);
         }
     };
 
@@ -649,6 +642,11 @@ define([
         data.outputs = outputs;
         data.metadata.trusted = this.output_area.trusted;
         data.metadata.collapsed = this.output_area.collapsed;
+        if (this.output_area.scroll_state === 'auto') {
+            delete data.metadata.scrolled;
+        } else {
+            data.metadata.scrolled = this.output_area.scroll_state;
+        }
         return data;
     };
 

--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -188,7 +188,7 @@ define([
 
     OutputArea.prototype.toggle_scroll = function () {
         if (this.scroll_state == 'auto') {
-            this.scroll_state = false;
+            this.scroll_state = !this.scrolled;
         } else {
             this.scroll_state = !this.scroll_state;
         }

--- a/IPython/nbformat/v4/nbformat.v4.schema.json
+++ b/IPython/nbformat/v4/nbformat.v4.schema.json
@@ -159,7 +159,7 @@
                             "description": "Whether the cell is collapsed/expanded.",
                             "type": "boolean"
                         },
-                        "autoscroll": {
+                        "scrolled": {
                             "description": "Whether the cell's output is scrolled, unscrolled, or autoscrolled.",
                             "enum": [true, false, "auto"]
                         },


### PR DESCRIPTION
When user toggles the scroll state, the choice is remembered (in OutputArea.scroll_state) and persisted (in Notebook.metadata.scrolled).

There are three states:
- 'auto' (default, only state in master)
- true (always scroll if above minimum_scroll_threshold)
- false (never scroll)

true or false is persisted in cell.metadata.scrolled. "auto" may be persisted according to the schema, but isn't currently because it's the default state.

There is no UI for setting the value back to 'auto', and I'm not sure there's a good one, nor is there a need for one. That said, the scroll state can be cleared by collapsing and expanding the output.

closes #3657
closes #3659
closes #2105
closes #2172
