### PR TITLE
Setting union traitlet metadata correctly

### DIFF
--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -1069,7 +1069,9 @@ class Union(TraitType):
     def validate(self, obj, value):
         for trait_type in self.trait_types:
             try:
-                return trait_type._validate(obj, value)
+                v = trait_type._validate(obj, value)
+                self._metadata = trait_type._metadata
+                return v
             except TraitError:
                 continue
         self.error(obj, value)


### PR DESCRIPTION
Rebinding union traitlet metadata to the one of the successfully validated trait type. This is useful for rebinding to the right version of `to_json` and `from_json` for example. 
