### PR TITLE
fix left-margin on xxs screen

### DIFF
--- a/IPython/html/static/notebook/less/cell.less
+++ b/IPython/html/static/notebook/less/cell.less
@@ -23,15 +23,15 @@ div.cell {
     }
 
     width: 100%;
-    padding: 5px 5px 5px 0px;
+    padding: 5px;
     /* This acts as a spacer between cells, that is outside the border */
     margin: 0px;
     outline: none;
 }
 
-div.prompt {
+.prompt {
     /* This needs to be wide enough for 3 digit prompt numbers: In[100]: */
-    min-width: 15ex;
+    min-width: 14ex;
     /* This padding is tuned to match the padding on the CodeMirror editor. */
     padding: @code_padding;
     margin: 0px;
@@ -44,7 +44,7 @@ div.prompt {
 @media (max-width: @screen-xs-min) {
     // prompts are in the main column on small screens,
     // so text should be left-aligned
-    div.prompt {
+    .prompt {
         text-align: left;
     }
 }

--- a/IPython/html/static/notebook/less/textcell.less
+++ b/IPython/html/static/notebook/less/textcell.less
@@ -1,5 +1,4 @@
 div.text_cell {
-    padding: 5px 5px 5px 0px;
     .hbox();
 }
 @media (max-width: @screen-xs-min) {

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -359,7 +359,7 @@ div.cell {
   border-width: thin;
   border-style: solid;
   width: 100%;
-  padding: 5px 5px 5px 0px;
+  padding: 5px;
   /* This acts as a spacer between cells, that is outside the border */
   margin: 0px;
   outline: none;
@@ -382,9 +382,9 @@ div.cell.selected {
     border-color: transparent;
   }
 }
-div.prompt {
+.prompt {
   /* This needs to be wide enough for 3 digit prompt numbers: In[100]: */
-  min-width: 15ex;
+  min-width: 14ex;
   /* This padding is tuned to match the padding on the CodeMirror editor. */
   padding: 0.4em;
   margin: 0px;
@@ -394,7 +394,7 @@ div.prompt {
   line-height: 1.21429em;
 }
 @media (max-width: 540px) {
-  div.prompt {
+  .prompt {
     text-align: left;
   }
 }
@@ -1114,7 +1114,6 @@ div.output_unrecognized a:hover {
   margin-top: 1em;
 }
 div.text_cell {
-  padding: 5px 5px 5px 0px;
   /* Old browsers */
   display: -webkit-box;
   -webkit-box-orient: horizontal;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8872,7 +8872,7 @@ div.cell {
   border-width: thin;
   border-style: solid;
   width: 100%;
-  padding: 5px 5px 5px 0px;
+  padding: 5px;
   /* This acts as a spacer between cells, that is outside the border */
   margin: 0px;
   outline: none;
@@ -8895,9 +8895,9 @@ div.cell.selected {
     border-color: transparent;
   }
 }
-div.prompt {
+.prompt {
   /* This needs to be wide enough for 3 digit prompt numbers: In[100]: */
-  min-width: 15ex;
+  min-width: 14ex;
   /* This padding is tuned to match the padding on the CodeMirror editor. */
   padding: 0.4em;
   margin: 0px;
@@ -8907,7 +8907,7 @@ div.prompt {
   line-height: 1.21429em;
 }
 @media (max-width: 540px) {
-  div.prompt {
+  .prompt {
     text-align: left;
   }
 }
@@ -9627,7 +9627,6 @@ div.output_unrecognized a:hover {
   margin-top: 1em;
 }
 div.text_cell {
-  padding: 5px 5px 5px 0px;
   /* Old browsers */
   display: -webkit-box;
   -webkit-box-orient: horizontal;


### PR DESCRIPTION
On xxs screen spacing between border and codemirror was 0 for left. 
this fixes that by making 5px all around (and reducing prompt with a bit more (by 1ex instead of 5px), which still does not prevent 3 digit prompt. 

![capture d ecran 2015-01-23 a 19 08 06](https://cloud.githubusercontent.com/assets/335567/5879908/b71453b0-a333-11e4-98c4-7f56a0c42964.png)
