### PR TITLE
Indicate that terminals are unavailable

### DIFF
--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -53,6 +53,10 @@ data-terminals-available="{{terminals_available}}"
                     <li role="presentation" id="new-terminal">
                       <a role="menuitem" tabindex="-1" href="#">Terminal</a>
                     </li>
+                    {% else %}
+                    <li role="presentation" id="new-terminal-disabled" class="disabled">
+                      <a role="menuitem" tabindex="-1" href="#">Terminals Unavailable</a>
+                    </li>
                     {% endif %}
                     <li role="presentation" class="divider"></li>
                     <li role="presentation" class="dropdown-header" id="notebook-kernels">Notebooks</li>
@@ -97,13 +101,15 @@ data-terminals-available="{{terminals_available}}"
               </div>
               <div id="collapseOne" class=" collapse in">
                 <div class="panel-body">
-                  {% if terminals_available %}
-                    <div id="terminal_list">
-                      <div id="terminal_list_header" class="row list_header">
-                        <div> There are no terminals running. </div>
-                      </div>
-                    </div>
+                  <div id="terminal_list">
+                    <div id="terminal_list_header" class="row list_header">
+                    {% if terminals_available %}
+                      <div> There are no terminals running. </div>
+                    {% else %}
+                      <div> Terminals are unavailable. </div>
                     {% endif %}
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
rather than hiding any evidence of their existence

closes #7019

New dropdown:

![screen shot 2015-01-23 at 11 13 32](https://cloud.githubusercontent.com/assets/151929/5880914/fbd575e4-a2f0-11e4-8b6b-042af56a54c9.PNG)

Running tab:

![screen shot 2015-01-23 at 11 13 36](https://cloud.githubusercontent.com/assets/151929/5880925/021171c4-a2f1-11e4-9599-5b7d5bae2559.PNG)

ping @ellisonbg for UI

Presumably this will conflict with #7505, so I'm happy to wait for that one to land and rebase.
