### PR TITLE
don't send empty execute_result messages

### DIFF
--- a/IPython/kernel/zmq/displayhook.py
+++ b/IPython/kernel/zmq/displayhook.py
@@ -68,6 +68,7 @@ class ZMQShellDisplayHook(DisplayHook):
         """Finish up all displayhook activities."""
         sys.stdout.flush()
         sys.stderr.flush()
-        self.session.send(self.pub_socket, self.msg, ident=self.topic)
+        if self.msg['content']['data']:
+            self.session.send(self.pub_socket, self.msg, ident=self.topic)
         self.msg = None
 


### PR DESCRIPTION
if there's nothing to display, don't send the message.

can be triggered when displayhook is called on objects with `_ipython_display_`,
such as Widgets.

closes #7545
