### PR TITLE
document restarting, dead kernel status messages

### DIFF
--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -53,6 +53,10 @@ data-terminals-available="{{terminals_available}}"
                     <li role="presentation" id="new-terminal">
                       <a role="menuitem" tabindex="-1" href="#">Terminal</a>
                     </li>
+                    {% else %}
+                    <li role="presentation" id="new-terminal-disabled" class="disabled">
+                      <a role="menuitem" tabindex="-1" href="#">Terminals Unavailable</a>
+                    </li>
                     {% endif %}
                     <li role="presentation" class="divider"></li>
                     <li role="presentation" class="dropdown-header" id="notebook-kernels">Notebooks</li>
@@ -97,13 +101,15 @@ data-terminals-available="{{terminals_available}}"
               </div>
               <div id="collapseOne" class=" collapse in">
                 <div class="panel-body">
-                  {% if terminals_available %}
-                    <div id="terminal_list">
-                      <div id="terminal_list_header" class="row list_header">
-                        <div> There are no terminals running. </div>
-                      </div>
-                    </div>
+                  <div id="terminal_list">
+                    <div id="terminal_list_header" class="row list_header">
+                    {% if terminals_available %}
+                      <div> There are no terminals running. </div>
+                    {% else %}
+                      <div> Terminals are unavailable. </div>
                     {% endif %}
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/docs/source/development/messaging.rst
+++ b/docs/source/development/messaging.rst
@@ -1041,6 +1041,14 @@ Message type: ``status``::
     Busy and idle messages should be sent before/after handling every message,
     not just execution.
 
+.. note::
+
+    Extra status messages are added between the notebook webserver and websocket clients
+    that are not sent by the kernel. These are:
+    
+    - restarting (kernel has died, but will be automatically restarted)
+    - dead (kernel has died, restarting has failed)
+
 Clear output
 ------------
 


### PR DESCRIPTION
that are only sent over the websocket channel, not from the kernel.

closes #6603
