### PR TITLE
enable keyboard manager when codemirror is focused

### DIFF
--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -150,6 +150,7 @@ define([
     /** @method create_element */
     CodeCell.prototype.create_element = function () {
         Cell.prototype.create_element.apply(this, arguments);
+        var that = this;
 
         var cell =  $('<div></div>').addClass('cell code_cell');
         cell.attr('tabindex','2');
@@ -163,6 +164,13 @@ define([
         inner_cell.append(this.celltoolbar.element);
         var input_area = $('<div/>').addClass('input_area');
         this.code_mirror = new CodeMirror(input_area.get(0), this.cm_config);
+        // In case of bugs that put the keyboard manager into an inconsistent state,
+        // ensure KM is enabled when CodeMirror is focused:
+        this.code_mirror.on('focus', function () {
+            if (that.keyboard_manager) {
+                that.keyboard_manager.enable();
+            }
+        });
         this.code_mirror.on('keydown', $.proxy(this.handle_keyevent,this));
         $(this.code_mirror.getInputField()).attr("spellcheck", "false");
         inner_cell.append(input_area);

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -85,6 +85,7 @@ define([
      */
     TextCell.prototype.create_element = function () {
         Cell.prototype.create_element.apply(this, arguments);
+        var that = this;
 
         var cell = $("<div>").addClass('cell text_cell');
         cell.attr('tabindex','2');
@@ -98,6 +99,13 @@ define([
         inner_cell.append(this.celltoolbar.element);
         var input_area = $('<div/>').addClass('input_area');
         this.code_mirror = new CodeMirror(input_area.get(0), this.cm_config);
+        // In case of bugs that put the keyboard manager into an inconsistent state,
+        // ensure KM is enabled when CodeMirror is focused:
+        this.code_mirror.on('focus', function () {
+            if (that.keyboard_manager) {
+                that.keyboard_manager.enable();
+            }
+        });
         this.code_mirror.on('keydown', $.proxy(this.handle_keyevent,this))
         // The tabindex=-1 makes this div focusable.
         var render_area = $('<div/>').addClass('text_cell_render rendered_html')


### PR DESCRIPTION
Clicking on an input area should always re-enable the keyboard manager. This should always be true, and mitigate focus-related keyboard bugs, such as #7555.

It shouldn't ever be necessary, but some bugs (ours or browsers') can cause problems, and when there are weird keyboard-related issues, clicking a cell is often my first instinct.
