### PR TITLE
allow requesting contents without body

### DIFF
--- a/IPython/html/services/contents/handlers.py
+++ b/IPython/html/services/contents/handlers.py
@@ -117,13 +117,19 @@ class ContentsHandler(IPythonHandler):
         format = self.get_query_argument('format', default=None)
         if format not in {None, 'text', 'base64'}:
             raise web.HTTPError(400, u'Format %r is invalid' % format)
-
-        model = yield gen.maybe_future(self.contents_manager.get(path=path, type=type, format=format))
-        if model['type'] == 'directory':
+        content = self.get_query_argument('content', default='1')
+        if content not in {'0', '1'}:
+            raise web.HTTPError(400, u'Content %r is invalid' % content)
+        content = int(content)
+        
+        model = yield gen.maybe_future(self.contents_manager.get(
+            path=path, type=type, format=format, content=content,
+        ))
+        if model['type'] == 'directory' and content:
             # group listing by type, then by name (case-insensitive)
             # FIXME: sorting should be done in the frontends
             model['content'].sort(key=sort_key)
-        validate_model(model, expect_content=True)
+        validate_model(model, expect_content=content)
         self._finish_model(model, location=False)
 
     @web.authenticated

--- a/IPython/html/static/services/contents.js
+++ b/IPython/html/static/services/contents.js
@@ -72,13 +72,12 @@ define(function(require) {
     /**
      * Get a file.
      *
-     * Calls success with file JSON model, or error with error.
-     *
      * @method get
      * @param {String} path
      * @param {Object} options
      *    type : 'notebook', 'file', or 'directory'
      *    format: 'text' or 'base64'; only relevant for type: 'file'
+     *    content: true or false; // whether to include the content
      */
     Contents.prototype.get = function (path, options) {
         /**
@@ -94,6 +93,7 @@ define(function(require) {
         var params = {};
         if (options.type) { params.type = options.type; }
         if (options.format) { params.format = options.format; }
+        if (options.content === false) { params.content = '0'; }
         return utils.promising_ajax(url + '?' + $.param(params), settings);
     };
 


### PR DESCRIPTION
adds `?content=0` to only fetch the metadata in the model.

The REST API now exposes all arguments to ContentsManager.get.

I'll open a separate PR that uses this to check if a file has been modified to avoid clobber on save.
