### PR TITLE
Additional fixes for the ipython lexer

### DIFF
--- a/IPython/nbconvert/utils/lexers.py
+++ b/IPython/nbconvert/utils/lexers.py
@@ -57,7 +57,7 @@ ipython_tokens = [
                                        using(BashLexer), Text)),
   (r'(%)(\w+)(.*\n)', bygroups(Operator, Keyword, Text)),
   (r'^(!!)(.+)(\n)', bygroups(Operator, using(BashLexer), Text)),
-  (r'((?!=)!)(.+)(\n)', bygroups(Operator, using(BashLexer), Text)),
+  (r'(!)(?!=)(.+)(\n)', bygroups(Operator, using(BashLexer), Text)),
   (r'^(\s*)(\?\??)(\s*%{0,2}[\w\.\*]*)', bygroups(Text, Operator, Text)),
 ]
 

--- a/IPython/nbconvert/utils/lexers.py
+++ b/IPython/nbconvert/utils/lexers.py
@@ -58,6 +58,7 @@ ipython_tokens = [
   (r'(%)(\w+)(.*\n)', bygroups(Operator, Keyword, Text)),
   (r'^(!!)(.+)(\n)', bygroups(Operator, using(BashLexer), Text)),
   (r'((?!=)!)(.+)(\n)', bygroups(Operator, using(BashLexer), Text)),
+  (r'^(\s*)(\?\??)(\s*%{0,2}[\w\.\*]*)', bygroups(Text, Operator, Text)),
 ]
 
 def build_ipy_lexer(python3):

--- a/IPython/nbconvert/utils/lexers.py
+++ b/IPython/nbconvert/utils/lexers.py
@@ -57,7 +57,7 @@ ipython_tokens = [
                                        using(BashLexer), Text)),
   (r'(%)(\w+)(.*\n)', bygroups(Operator, Keyword, Text)),
   (r'^(!!)(.+)(\n)', bygroups(Operator, using(BashLexer), Text)),
-  (r'(!)(.+)(\n)', bygroups(Operator, using(BashLexer), Text)),
+  (r'((?!=)!)(.+)(\n)', bygroups(Operator, using(BashLexer), Text)),
 ]
 
 def build_ipy_lexer(python3):

--- a/IPython/nbconvert/utils/tests/test_lexers.py
+++ b/IPython/nbconvert/utils/tests/test_lexers.py
@@ -109,3 +109,23 @@ class TestLexers(TestsBase):
             (Token.Text, '\n'),
         ]
         self.assertEqual(tokens_2, list(self.lexer.get_tokens(fragment_2)))
+
+        fragment_2 = 'x != y\n'
+        tokens_2 = [
+            (Token.Name, 'x'),
+            (Token.Text, ' '),
+            (Token.Operator, '!='),
+            (Token.Text, ' '),
+            (Token.Name, 'y'),
+            (Token.Text, '\n'),
+        ]
+        self.assertEqual(tokens_2, list(self.lexer.get_tokens(fragment_2)))
+
+        fragment_2 = ' ?math.sin\n'
+        tokens_2 = [
+            (Token.Text, ' '),
+            (Token.Operator, '?'),
+            (Token.Text, 'math.sin'),
+            (Token.Text, '\n'),
+        ]
+        self.assertEqual(tokens_2, list(self.lexer.get_tokens(fragment_2)))


### PR DESCRIPTION
Two more cases added for #7548:
1. Don't confuse != with a shell escape.
2. Recognize leasing ? or ?? as starting a help line.
