### PR TITLE
apply `position: relative` to header

### DIFF
--- a/IPython/html/static/base/less/page.less
+++ b/IPython/html/static/base/less/page.less
@@ -23,6 +23,7 @@ body {
     background-color: @body-bg;
 
     /* Display over codemirror */
+    position: relative;
     z-index: 100;
 
     #header-container {

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8401,6 +8401,7 @@ body {
   display: none;
   background-color: #ffffff;
   /* Display over codemirror */
+  position: relative;
   z-index: 100;
 }
 #header #header-container {


### PR DESCRIPTION
otherwise z-index has no effect, causing header shadow to fall behind content.

closes #7590
