### PR TITLE
remove duplicated border in indicator area

### DIFF
--- a/IPython/html/static/notebook/less/notificationarea.less
+++ b/IPython/html/static/notebook/less/notificationarea.less
@@ -12,11 +12,12 @@
     z-index: 10;
     text-align: center;
     width: auto;
-    border-left: 1px solid;
 }
 
 #kernel_indicator {
     .indicator_area();
+    
+    border-left: 1px solid;
     
     .kernel_indicator_name {
         padding-left: 5px;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -10530,7 +10530,6 @@ ul#help_menu li a i {
   z-index: 10;
   text-align: center;
   width: auto;
-  border-left: 1px solid;
 }
 #kernel_indicator {
   float: right !important;
@@ -10558,7 +10557,6 @@ ul#help_menu li a i {
   z-index: 10;
   text-align: center;
   width: auto;
-  border-left: 1px solid;
 }
 .edit_mode .modal_indicator:before {
   display: inline-block;


### PR DESCRIPTION
looks like it was added accidentally, when doing some refactoring in #7586.

master:

![screen shot 2015-01-26 at 10 56 51](https://cloud.githubusercontent.com/assets/151929/5906144/3dc04406-a54a-11e4-8c70-72a97d862767.PNG)

this PR:

![screen shot 2015-01-26 at 10 56 30](https://cloud.githubusercontent.com/assets/151929/5906149/457bbfc2-a54a-11e4-982b-a78bda3dc848.PNG)
