### PR TITLE
Validation on the python side

### DIFF
--- a/IPython/html/widgets/widget_float.py
+++ b/IPython/html/widgets/widget_float.py
@@ -38,13 +38,28 @@ class _BoundedFloat(_Float):
     def __init__(self, *pargs, **kwargs):
         """Constructor"""
         super(_BoundedFloat, self).__init__(*pargs, **kwargs)
-        self._validate('value', None, self.value)
-        self.on_trait_change(self._validate, ['value', 'min', 'max'])
+        self._value_changed('value', None, self.value)
+        self._min_changed('min', None, self.min)
+        self._max_changed('max', None, self.max)
 
-    def _validate(self, name, old, new):
-        """Validate value, max, min."""
+    def _value_changed(self, name, old, new):
+        """Validate value."""
         if self.min > new or new > self.max:
             self.value = min(max(new, self.min), self.max)
+
+    def _max_changed(self, name, old, new):
+        """Make sure the min is always <= the max."""
+        if new < self.min:
+            raise ValueError("setting max < min")
+        if new < self.value:
+            self.value = new
+
+    def _min_changed(self, name, old, new):
+        """Make sure the max is always >= the min."""
+        if new > self.max:
+            raise ValueError("setting min > max")
+        if new > self.value:
+            self.value = new
 
 
 @register('IPython.FloatText')

--- a/IPython/html/widgets/widget_float.py
+++ b/IPython/html/widgets/widget_float.py
@@ -21,7 +21,7 @@ from IPython.utils.warn import DeprecatedClass
 # Classes
 #-----------------------------------------------------------------------------
 class _Float(DOMWidget):
-    value = CFloat(0.0, help="Float value", sync=True) 
+    value = CFloat(0.0, help="Float value", sync=True)
     disabled = Bool(False, help="Enable or disable user changes", sync=True)
     description = Unicode(help="Description of the value this widget represents", sync=True)
 
@@ -38,23 +38,26 @@ class _BoundedFloat(_Float):
     def __init__(self, *pargs, **kwargs):
         """Constructor"""
         super(_BoundedFloat, self).__init__(*pargs, **kwargs)
-        self._value_changed('value', None, self.value)
-        self._min_changed('min', None, self.min)
-        self._max_changed('max', None, self.max)
+        self._handle_value_changed('value', None, self.value)
+        self._handle_max_changed('max', None, self.max)
+        self._handle_min_changed('min', None, self.min)
+        self.on_trait_change(self._handle_value_changed, 'value')
+        self.on_trait_change(self._handle_max_changed, 'max')
+        self.on_trait_change(self._handle_min_changed, 'min')
 
-    def _value_changed(self, name, old, new):
+    def _handle_value_changed(self, name, old, new):
         """Validate value."""
         if self.min > new or new > self.max:
             self.value = min(max(new, self.min), self.max)
 
-    def _max_changed(self, name, old, new):
+    def _handle_max_changed(self, name, old, new):
         """Make sure the min is always <= the max."""
         if new < self.min:
             raise ValueError("setting max < min")
         if new < self.value:
             self.value = new
 
-    def _min_changed(self, name, old, new):
+    def _handle_min_changed(self, name, old, new):
         """Make sure the max is always >= the min."""
         if new > self.max:
             raise ValueError("setting min > max")

--- a/IPython/html/widgets/widget_int.py
+++ b/IPython/html/widgets/widget_int.py
@@ -41,24 +41,28 @@ class _BoundedInt(_Int):
     def __init__(self, *pargs, **kwargs):
         """Constructor"""
         super(_BoundedInt, self).__init__(*pargs, **kwargs)
-        self.on_trait_change(self._validate_value, ['value'])
-        self.on_trait_change(self._handle_max_changed, ['max'])
-        self.on_trait_change(self._handle_min_changed, ['min'])
+        self._value_changed('value', None, self.value)
+        self._min_changed('min', None, self.min)
+        self._max_changed('max', None, self.max)
 
-    def _validate_value(self, name, old, new):
+    def _value_changed(self, name, old, new):
         """Validate value."""
         if self.min > new or new > self.max:
             self.value = min(max(new, self.min), self.max)
 
-    def _handle_max_changed(self, name, old, new):
+    def _max_changed(self, name, old, new):
         """Make sure the min is always <= the max."""
         if new < self.min:
             raise ValueError("setting max < min")
+        if new < self.value:
+            self.value = new
 
-    def _handle_min_changed(self, name, old, new):
+    def _min_changed(self, name, old, new):
         """Make sure the max is always >= the min."""
         if new > self.max:
             raise ValueError("setting min > max")
+        if new > self.value:
+            self.value = new
 
 @register('IPython.IntText')
 class IntText(_Int):

--- a/IPython/html/widgets/widget_int.py
+++ b/IPython/html/widgets/widget_int.py
@@ -22,7 +22,7 @@ from IPython.utils.warn import DeprecatedClass
 #-----------------------------------------------------------------------------
 class _Int(DOMWidget):
     """Base class used to create widgets that represent an int."""
-    value = CInt(0, help="Int value", sync=True) 
+    value = CInt(0, help="Int value", sync=True)
     disabled = Bool(False, help="Enable or disable user changes", sync=True)
     description = Unicode(help="Description of the value this widget represents", sync=True)
 
@@ -41,23 +41,26 @@ class _BoundedInt(_Int):
     def __init__(self, *pargs, **kwargs):
         """Constructor"""
         super(_BoundedInt, self).__init__(*pargs, **kwargs)
-        self._value_changed('value', None, self.value)
-        self._min_changed('min', None, self.min)
-        self._max_changed('max', None, self.max)
+        self._handle_value_changed('value', None, self.value)
+        self._handle_max_changed('max', None, self.max)
+        self._handle_min_changed('min', None, self.min)
+        self.on_trait_change(self._handle_value_changed, 'value')
+        self.on_trait_change(self._handle_max_changed, 'max')
+        self.on_trait_change(self._handle_min_changed, 'min')
 
-    def _value_changed(self, name, old, new):
+    def _handle_value_changed(self, name, old, new):
         """Validate value."""
         if self.min > new or new > self.max:
             self.value = min(max(new, self.min), self.max)
 
-    def _max_changed(self, name, old, new):
+    def _handle_max_changed(self, name, old, new):
         """Make sure the min is always <= the max."""
         if new < self.min:
             raise ValueError("setting max < min")
         if new < self.value:
             self.value = new
 
-    def _min_changed(self, name, old, new):
+    def _handle_min_changed(self, name, old, new):
         """Make sure the max is always >= the min."""
         if new > self.max:
             raise ValueError("setting min > max")


### PR DESCRIPTION
This is a simple fix for  #6814. In general, whenever a widget model may be modified by both the backend _and_ the frontend, if there is a validation stage that transform the set values, the logic should be implemented on both sides. 

On this regard, but outside of the scope of this small PR: 
- I don't think that what we currently have for the validation of values in widgets is good enough, because the validation happens AFTER we set the value, and it does not prevent the assignment. 
- Ideally, we should be able to hook up the custom validation logic in the traitlet validation, via the traitlet type metadata, so that in case of error, the assignment does not actually happen. 
  - EDIT: See #7603 for the early validation  hook
