### PR TITLE
Early validation hook

### DIFF
--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -89,28 +89,6 @@ class TestTraitType(TestCase):
             tt = MyIntTT('bad default')
         self.assertRaises(TraitError, B)
 
-    def test_is_valid_for(self):
-        class MyTT(TraitType):
-            def is_valid_for(self, value):
-                return True
-        class A(HasTraits):
-            tt = MyTT
-
-        a = A()
-        a.tt = 10
-        self.assertEqual(a.tt, 10)
-
-    def test_value_for(self):
-        class MyTT(TraitType):
-            def value_for(self, value):
-                return 20
-        class A(HasTraits):
-            tt = MyTT
-
-        a = A()
-        a.tt = 10
-        self.assertEqual(a.tt, 20)
-
     def test_info(self):
         class A(HasTraits):
             tt = TraitType

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -447,20 +447,11 @@ class TraitType(object):
     def _validate(self, obj, value):
         if value is None and self.allow_none:
             return value
+        if hasattr(self, 'validate'):
+            value = self.validate(obj, value)
         if 'validate' in self._metadata:
             value = self._metadata['validate'](obj, value, self)
-        if hasattr(self, 'validate'):
-            return self.validate(obj, value)
-        elif hasattr(self, 'is_valid_for'):
-            valid = self.is_valid_for(value)
-            if valid:
-                return value
-            else:
-                raise TraitError('invalid value for type: %r' % value)
-        elif hasattr(self, 'value_for'):
-            return self.value_for(value)
-        else:
-            return value
+        return value
 
     def __or__(self, other):
         if isinstance(other, Union):

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -447,6 +447,8 @@ class TraitType(object):
     def _validate(self, obj, value):
         if value is None and self.allow_none:
             return value
+        if 'validate' in self._metadata:
+            return self._metadata['validate'](obj, value, self)
         if hasattr(self, 'validate'):
             return self.validate(obj, value)
         elif hasattr(self, 'is_valid_for'):
@@ -1054,7 +1056,8 @@ class Union(TraitType):
         """Construct a Union  trait.
 
         This trait allows values that are allowed by at least one of the
-        specified trait types.
+        specified trait types. A Union traitlet cannot have metadata on
+        its own, besides the metadata of the listed types.
 
         Parameters
         ----------

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -449,8 +449,8 @@ class TraitType(object):
             return value
         if hasattr(self, 'validate'):
             value = self.validate(obj, value)
-        if 'validate' in self._metadata:
-            value = self._metadata['validate'](obj, value, self)
+        if hasattr(obj, '_%s_validate' % self.name):
+            value = getattr(obj, '_%s_validate' % self.name)(value, self)
         return value
 
     def __or__(self, other):

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -448,7 +448,7 @@ class TraitType(object):
         if value is None and self.allow_none:
             return value
         if 'validate' in self._metadata:
-            return self._metadata['validate'](obj, value, self)
+            value = self._metadata['validate'](obj, value, self)
         if hasattr(self, 'validate'):
             return self.validate(obj, value)
         elif hasattr(self, 'is_valid_for'):


### PR DESCRIPTION
This allows one to add a validation hook in the traitlet metadata. 

For example, define a "Parity" HasTraits instance:

<del>
```Python
from IPython.utils.traitlets import *

def validate(self, value, trait):
    if self.parity == 'even' and value % 2:
        raise TraitError('Expected an even number')
    if self.parity == 'odd' and (value % 2 == 0):
        raise TraitError('Expected an odd number')
    return value

class Parity(HasTraits):
    value = Int(0, validate=validate)
    parity = Enum(['odd', 'even'], default_value='even', allow_none=False)
```
</del>


``` python
from IPython.utils.traitlets import *

class Parity(HasTraits):

    value = Int(0)
    parity = Enum(['odd', 'even'], default_value='even', allow_none=False)

    def _value_validate(self, value, trait):
        if self.parity == 'even' and value % 2:
            raise TraitError('Expected an even number')
        if self.parity == 'odd' and (value % 2 == 0):
            raise TraitError('Expected an odd number')
        return value 

u = Parity()
```

``` Python
u = Parity()
u.value = 1 # should raise a TraitError
```

``` Python
u.parity = 'odd'
u.value = 1 # OK
u.value = 2 # should raise a TraitError
```

This is meant to allow custom attribute validation prior to assignment, for issues such as #6814.
