### PR TITLE
use default_url for logo link

### DIFF
--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -138,6 +138,10 @@ class IPythonHandler(AuthenticatedHandler):
         return self.settings.get('base_url', '/')
 
     @property
+    def default_url(self):
+        return self.settings.get('default_url', '/')
+
+    @property
     def ws_url(self):
         return self.settings.get('websocket_url', '')
 
@@ -238,6 +242,7 @@ class IPythonHandler(AuthenticatedHandler):
     def template_namespace(self):
         return dict(
             base_url=self.base_url,
+            default_url=self.default_url,
             ws_url=self.ws_url,
             logged_in=self.logged_in,
             login_available=self.login_available,

--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -139,7 +139,7 @@ class IPythonHandler(AuthenticatedHandler):
 
     @property
     def default_url(self):
-        return self.settings.get('default_url', '/')
+        return self.settings.get('default_url', '')
 
     @property
     def ws_url(self):

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -243,7 +243,7 @@ class NotebookWebApplication(web.Application):
         # set the URL that will be redirected from `/`
         handlers.append(
             (r'/?', web.RedirectHandler, {
-                'url' : url_path_join(settings['base_url'], settings['default_url']),
+                'url' : settings['default_url'],
                 'permanent': False, # want 302, not 301
             })
         )
@@ -816,6 +816,9 @@ class NotebookApp(BaseIPythonApplication):
         if self.allow_origin_pat:
             self.tornado_settings['allow_origin_pat'] = re.compile(self.allow_origin_pat)
         self.tornado_settings['allow_credentials'] = self.allow_credentials
+        # ensure default_url starts with base_url
+        if not self.default_url.startswith(self.base_url):
+            self.default_url = url_path_join(self.base_url, self.default_url)
         
         self.web_app = NotebookWebApplication(
             self, self.kernel_manager, self.contents_manager,

--- a/IPython/html/templates/page.html
+++ b/IPython/html/templates/page.html
@@ -83,7 +83,7 @@
 
 <div id="header">
   <div id="header-container" class="container">
-  <div id="ipython_notebook" class="nav navbar-brand pull-left"><a href="{{base_url}}tree" title='dashboard'>{% block logo %}<img src='{{static_url("base/images/logo.png") }}' alt='Jupyter Notebook'/>{% endblock %}</a></div>
+  <div id="ipython_notebook" class="nav navbar-brand pull-left"><a href="{{default_url}}" title='dashboard'>{% block logo %}<img src='{{static_url("base/images/logo.png") }}' alt='Jupyter Notebook'/>{% endblock %}</a></div>
 
   {% block login_widget %}
 


### PR DESCRIPTION
Now `/` and clicking the logo both take you do default_url, which is base_url/tree by default.

closes #7607
