### PR TITLE
Add running indication for notebook icon in dashboard

### DIFF
--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8668,6 +8668,7 @@ ul.breadcrumb span {
 }
 .list_header {
   font-weight: bold;
+  background-color: #eeeeee;
 }
 .list_container {
   margin-top: 4px;
@@ -8689,6 +8690,9 @@ ul.breadcrumb span {
 }
 .list_item a {
   text-decoration: none;
+}
+.list_item:nth-child(odd) {
+  background-color: #f6f6f6;
 }
 .action_col {
   text-align: right;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8691,8 +8691,8 @@ ul.breadcrumb span {
 .list_item a {
   text-decoration: none;
 }
-.list_item:nth-child(odd) {
-  background-color: #f6f6f6;
+.list_item:hover {
+  background-color: #fafafa;
 }
 .action_col {
   text-align: right;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8794,6 +8794,23 @@ input.engine_num_input {
 .notebook_icon:before.pull-right {
   margin-left: .3em;
 }
+.running_notebook_icon:before {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  transform: translate(0, 0);
+  content: "\f02d";
+  color: #5cb85c;
+}
+.running_notebook_icon:before.pull-left {
+  margin-right: .3em;
+}
+.running_notebook_icon:before.pull-right {
+  margin-left: .3em;
+}
 .file_icon:before {
   display: inline-block;
   font: normal normal normal 14px/1 FontAwesome;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8692,7 +8692,7 @@ ul.breadcrumb span {
   text-decoration: none;
 }
 .list_item:hover {
-  background-color: #fafafa;
+  background-color: #eeeeee;
 }
 .action_col {
   text-align: right;

--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -382,11 +382,16 @@ define([
     NotebookList.prototype.add_link = function (model, item) {
         var path = model.path,
             name = model.name;
+        var running = (model.type == 'notebook' && this.sessions[path] !== undefined);
+        
         item.data('name', name);
         item.data('path', path);
         item.data('type', model.type);
         item.find(".item_name").text(name);
         var icon = NotebookList.icons[model.type];
+        if (running) {
+            icon = 'running_' + icon;
+        }
         var uri_prefix = NotebookList.uri_prefixes[model.type];
         item.find(".item_icon").addClass(icon).addClass('icon-fixed-width');
         var link = item.find("a.item_link")
@@ -398,7 +403,6 @@ define([
                 )
             );
 
-        var running = (model.type == 'notebook' && this.sessions[path] !== undefined);
         item.find(".item_buttons .running-indicator").css('visibility', running ? '' : 'hidden');
 
         // directory nav doesn't open new tabs

--- a/IPython/html/static/tree/less/tree.less
+++ b/IPython/html/static/tree/less/tree.less
@@ -82,8 +82,8 @@ ul.breadcrumb {
     background-color: @table-border-color;
   };
   a {text-decoration: none;}
-  &:nth-child(odd) {
-    background-color: @list_stripe_color;
+  &:hover {
+    background-color: darken(white,2%);
   }
 }
 

--- a/IPython/html/static/tree/less/tree.less
+++ b/IPython/html/static/tree/less/tree.less
@@ -164,6 +164,12 @@ input.engine_num_input {
     .icon(@fa-var-book)
 }
 
+.running_notebook_icon:before {
+    .icon(@fa-var-book);
+    color: @brand-success
+}
+
+
 .file_icon:before {
     .icon(@fa-var-file-o)
 }

--- a/IPython/html/static/tree/less/tree.less
+++ b/IPython/html/static/tree/less/tree.less
@@ -12,6 +12,7 @@
 @btn_small_height: 24px;
 @btn_mini_height: 22px;
 @dark_dashboard_color: @breadcrumb-color;
+@list_stripe_color: lighten(@page-backdrop-color,3%);
 
 ul#tabs {
     margin-bottom: @dashboard_tb_pad;
@@ -55,6 +56,7 @@ ul.breadcrumb {
 
 .list_header {
     font-weight: bold;
+    background-color: @page-backdrop-color
 }
 
 .list_container {
@@ -80,6 +82,9 @@ ul.breadcrumb {
     background-color: @table-border-color;
   };
   a {text-decoration: none;}
+  &:nth-child(odd) {
+    background-color: @list_stripe_color;
+  }
 }
 
 .action_col {

--- a/IPython/html/static/tree/less/tree.less
+++ b/IPython/html/static/tree/less/tree.less
@@ -12,7 +12,6 @@
 @btn_small_height: 24px;
 @btn_mini_height: 22px;
 @dark_dashboard_color: @breadcrumb-color;
-@list_stripe_color: lighten(@page-backdrop-color,3%);
 
 ul#tabs {
     margin-bottom: @dashboard_tb_pad;
@@ -83,7 +82,7 @@ ul.breadcrumb {
   };
   a {text-decoration: none;}
   &:hover {
-    background-color: darken(white,2%);
+    background-color: @page-backdrop-color;
   }
 }
 


### PR DESCRIPTION
While the new dashboard UI #7505 mostly addresses the issues raised in #7613, it remains that on large screens, it is hard to determine which notebook is running from the current indicator.

This PR mitigates this by adding an extra indication that a notebook is running by changing the icon color like so:
![running-icon](https://cloud.githubusercontent.com/assets/7703352/5940034/5f71bc96-a708-11e4-99d2-cb4a7b90da55.png)
Maybe a different icon would be desirable, but the best alternative I could find is `fa-play`...
![alt-icon](https://cloud.githubusercontent.com/assets/7703352/5940070/986d61ee-a708-11e4-80f5-8269771ae625.png)
It has also been suggested that the notebook's kernel logo be used to indicate running notebooks (and possibly fall back to the above behavior in case of missing logo).
