### PR TITLE
fix help-links on Firefox

### DIFF
--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -394,9 +394,11 @@ define([
                     .attr('target', '_blank')
                     .attr('title', 'Opens in a new window')
                     .attr('href', link.url)
-                    .text(link.text)
                     .append($("<i>")
                         .addClass("fa fa-external-link menu-icon pull-right")
+                    )
+                    .append($("<span>")
+                        .text(link.text)
                     )
                 )
             );


### PR DESCRIPTION
link text must come after icon to layout properly on Firefox

this makes help links from the kernel match those already populated from the template

closes #7612
