### PR TITLE
Fix error when overwriting a bad symbolic link installing an nbextension

### DIFF
--- a/IPython/html/nbextensions.py
+++ b/IPython/html/nbextensions.py
@@ -211,7 +211,7 @@ def install_nbextension(path, overwrite=False, symlink=False, user=False, prefix
             destination = basename(path)
         destination = cast_unicode_py2(destination)
         full_dest = pjoin(nbext, destination)
-        if overwrite and os.path.exists(full_dest):
+        if overwrite and os.path.lexists(full_dest):
             if verbose >= 1:
                 print("removing %s" % full_dest)
             if os.path.isdir(full_dest) and not os.path.islink(full_dest):

--- a/IPython/html/tests/test_nbextensions.py
+++ b/IPython/html/tests/test_nbextensions.py
@@ -280,6 +280,22 @@ class TestInstallNBExtension(TestCase):
         self.assertEqual(link, src)
     
     @dec.skip_win32
+    def test_overwrite_broken_symlink(self):
+        with TemporaryDirectory() as d:
+            f = u'ƒ.js'
+            f2 = u'ƒ2.js'
+            src = pjoin(d, f)
+            src2 = pjoin(d, f2)
+            touch(src)
+            install_nbextension(src, symlink=True)
+            os.rename(src, src2)
+            install_nbextension(src2, symlink=True, overwrite=True, destination=f)
+        dest = pjoin(self.system_nbext, f)
+        assert os.path.islink(dest)
+        link = os.readlink(dest)
+        self.assertEqual(link, src2)
+
+    @dec.skip_win32
     def test_install_symlink_destination(self):
         with TemporaryDirectory() as d:
             f = u'ƒ.js'


### PR DESCRIPTION
The unit test fails before this fix and works after this fix.
Basically, if the already-installed symlink is a bad link, .exists()
returns False (so the existing link is not removed), while .lexists()
will return True (so the existing link is removed).

@takluyver or @minrk - can you look at this?  It's a simple bug to fix, and I provided a unit test to illustrate the bug and fix.
