### PR TITLE
remove translateZ hack

### DIFF
--- a/IPython/html/static/base/less/page.less
+++ b/IPython/html/static/base/less/page.less
@@ -79,12 +79,6 @@ body {
 }
 
 #site {
-    // avoid repaints on size with translateZ(0)
-    -webkit-transform: translateZ(0);
-    -moz-transform: translateZ(0);
-    -ms-transform: translateZ(0);
-    -o-transform: translateZ(0);
-    transform: translateZ(0);
     width: 100%;
     display: none;
     .border-box-sizing();

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8454,11 +8454,6 @@ body {
   height: 28px;
 }
 #site {
-  -webkit-transform: translateZ(0);
-  -moz-transform: translateZ(0);
-  -ms-transform: translateZ(0);
-  -o-transform: translateZ(0);
-  transform: translateZ(0);
   width: 100%;
   display: none;
   box-sizing: border-box;


### PR DESCRIPTION
while it does improve repaint performance on _some_ setups (OS X+Chrome+Low-DPI), it seems to have no effect on most (OS X+FF, OS X+Chrome+High-DPI, Linux+Chrome), and the opposite effect on others (Linux+FF).

There is also apparently a bug in most browsers regarding the layout of `position:`ed elements whose parents have this property.

ping @jasongrout
