### PR TITLE
fix initial collapsed state on load

### DIFF
--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -908,9 +908,10 @@ define([
             this.append_output(outputs[i]);
         }
         if (metadata.collapsed !== undefined) {
-            this.collapsed = metadata.collapsed;
             if (metadata.collapsed) {
                 this.collapse();
+            } else {
+                this.expand();
             }
         }
         if (metadata.scrolled !== undefined) {


### PR DESCRIPTION
OutputArea.collapsed should only be assigned inside expand/collapse methods

setting `collapsed = false` when it actually is collapsed prevents expand from having any effect, resulting in apparently invisible output.

closes #7624
