### PR TITLE
add terminado as [notebook] dep on non-Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -258,6 +258,9 @@ extras_require = dict(
     nbconvert = ['pygments', 'jinja2', 'mistune>=0.3.1']
 )
 
+if not sys.platform.startswith('win'):
+    extras_require['notebook'].append('terminado>=0.3.3')
+
 if sys.version_info < (3, 3):
     extras_require['test'].append('mock')
 

--- a/setup.py
+++ b/setup.py
@@ -264,11 +264,6 @@ if sys.version_info < (3, 3):
 extras_require['notebook'].extend(extras_require['nbformat'])
 extras_require['nbconvert'].extend(extras_require['nbformat'])
 
-everything = set()
-for deps in extras_require.values():
-    everything.update(deps)
-extras_require['all'] = everything
-
 install_requires = []
 
 # add readline
@@ -278,6 +273,10 @@ if sys.platform == 'darwin':
 elif sys.platform.startswith('win'):
     extras_require['terminal'].append('pyreadline>=2.0')
 
+everything = set()
+for deps in extras_require.values():
+    everything.update(deps)
+extras_require['all'] = everything
 
 if 'setuptools' in sys.modules:
     # setup.py develop should check for submodules

--- a/setupbase.py
+++ b/setupbase.py
@@ -670,9 +670,11 @@ def get_bdist_wheel():
                     if found:
                         lis.pop(idx)
                 
-                for pkg in ("gnureadline", "pyreadline", "mock"):
+                for pkg in ("gnureadline", "pyreadline", "mock", "terminado"):
                     _remove_startswith(requires, pkg)
                 requires.append("gnureadline; sys.platform == 'darwin' and platform.python_implementation == 'CPython'")
+                requires.append("terminado (>=0.3.3); extra == 'notebook' and sys.platform != 'win32'")
+                requires.append("terminado (>=0.3.3); extra == 'all' and sys.platform != 'win32'")
                 requires.append("pyreadline (>=2.0); extra == 'terminal' and sys.platform == 'win32' and platform.python_implementation == 'CPython'")
                 requires.append("pyreadline (>=2.0); extra == 'all' and sys.platform == 'win32' and platform.python_implementation == 'CPython'")
                 requires.append("mock; extra == 'test' and python_version < '3.3'")


### PR DESCRIPTION
It's not a dependency for the notebook to work, but neither is nbconvert and we express that as a dependency for [notebook]. This makes it ever so slightly simpler to get everything IPython uses.
