### PR TITLE
minor correction: string "Fin.">"End of tour"

### DIFF
--- a/IPython/html/static/notebook/js/tour.js
+++ b/IPython/html/static/notebook/js/tour.js
@@ -112,7 +112,7 @@ define([
                 title: "Notification Area",
                 content: "Messages in response to user actions (Save, Interrupt, etc) appear here."
             }, {
-                title: "Fin.",
+                title: "End of Tour",
                 placement: 'bottom',
                 orphan: true,
                 content: "This concludes the IPython Notebook User Interface Tour. Happy hacking!"


### PR DESCRIPTION
I've found a Spanish word at the end of the IPython Notebook User Interface Tour. It appeared within the title of the last window.

Since I guess this was unintended, I have changed it.
