### PR TITLE
Allow for None default value in Dict traitlets

### DIFF
--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -1088,6 +1088,13 @@ def test_dict_assignment():
     nt.assert_equal(d, c.value)
     nt.assert_true(c.value is d)
 
+def test_dict_default_value():
+    """Check that the `{}` default value of the Dict traitlet constructor is
+    actually copied."""
+
+    d1, d2 = Dict(), Dict()
+    nt.assert_false(d1.get_default_value() is d2.get_default_value())
+
 class TestLink(TestCase):
     def test_connect_same(self):
         """Verify two traitlets of the same type can be linked together using link."""

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -1635,14 +1635,14 @@ class Tuple(Container):
 class Dict(Instance):
     """An instance of a Python dict."""
 
-    def __init__(self, default_value=None, allow_none=True, **metadata):
+    def __init__(self, default_value={}, allow_none=True, **metadata):
         """Create a dict trait type from a dict.
 
         The default value is created by doing ``dict(default_value)``,
         which creates a copy of the ``default_value``.
         """
         if default_value is None:
-            args = ((),)
+            args = None
         elif isinstance(default_value, dict):
             args = (default_value,)
         elif isinstance(default_value, SequenceTypes):
@@ -1657,15 +1657,15 @@ class Dict(Instance):
 class EventfulDict(Instance):
     """An instance of an EventfulDict."""
 
-    def __init__(self, default_value=None, allow_none=True, **metadata):
+    def __init__(self, default_value={}, allow_none=True, **metadata):
         """Create a EventfulDict trait type from a dict.
 
-        The default value is created by doing 
-        ``eventful.EvenfulDict(default_value)``, which creates a copy of the 
+        The default value is created by doing
+        ``eventful.EvenfulDict(default_value)``, which creates a copy of the
         ``default_value``.
         """
         if default_value is None:
-            args = ((),)
+            args = None
         elif isinstance(default_value, dict):
             args = (default_value,)
         elif isinstance(default_value, SequenceTypes):


### PR DESCRIPTION
Meant to solve #7643. 

By the way, I think that it would be interesting if less trait types had `allow_none=True` (explicit is better than implicit).
