### PR TITLE
don't prevent spec_changed from firing on load

### DIFF
--- a/IPython/html/static/notebook/js/kernelselector.js
+++ b/IPython/html/static/notebook/js/kernelselector.js
@@ -218,7 +218,8 @@ define([
                 return;
             }
         }
-        if (this.notebook._session_starting) {
+        if (this.notebook._session_starting &&
+            this.notebook.session.kernel.name !== ks.name) {
             console.error("Cannot change kernel while waiting for pending session start.");
             return;
         }

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -232,7 +232,7 @@ define(function (require) {
                 language: data.spec.language,
             };
             // start session if the current session isn't already correct
-            if (!(this.session && this.session.kernel && this.session.kernel.name === data.name)) {
+            if (!(that.session && that.session.kernel && that.session.kernel.name === data.name)) {
                 that.start_session(data.name);
             }
         });


### PR DESCRIPTION
Fixes check for the case where kernelspec info is coming from the kernel, rather than notebook metadata.

This case was getting skipped by a bad check on `_session_starting`.

closes #7645
