### PR TITLE
Add some spacing below h3 headers in HTML docs

### DIFF
--- a/docs/source/_static/default.css
+++ b/docs/source/_static/default.css
@@ -277,7 +277,7 @@ h2 {
 }
 
 h3 {
-    margin: 1em 0 -0.3em 0;
+    margin: 1em 0 0.2em 0;
     font-size: 1.2em;
 }
 


### PR DESCRIPTION
Before, images immediately below an h3 header overlapped it:

![sphinx_header_overlap](https://cloud.githubusercontent.com/assets/327925/5990426/1fc54bbc-a965-11e4-8c3a-8bb217134999.png)

Fixed:

![sphinx_header_fixed](https://cloud.githubusercontent.com/assets/327925/5990427/239dde16-a965-11e4-9dc4-c2d6ab1e3fff.png)
