### PR TITLE
fix sticky warning.

### DIFF
--- a/IPython/html/static/base/js/notificationwidget.js
+++ b/IPython/html/static/base/js/notificationwidget.js
@@ -99,19 +99,22 @@ define([
             }, timeout);
         }
 
-        // bind the click callback if it is given
-        if (click_callback !== undefined) {
-            this.element.click(function () {
-                if (click_callback() !== false) {
-                    that.element.fadeOut(100, function () {that.inner.text('');});
-                }
-                that.element.unbind('click');
-                if (that.timeout !== null) {
-                    clearTimeout(that.timeout);
-                    that.timeout = null;
-                }
-            });
+        // if no click callback assume we will just dismiss the notification
+        if (click_callback === undefined) {
+            click_callback = function(){return true};
         }
+        // on click, remove widget if click callback say so
+        // and unbind click event.
+        this.element.click(function () {
+            if (click_callback() !== false) {
+                that.element.fadeOut(100, function () {that.inner.text('');});
+                that.element.unbind('click');
+            }
+            if (that.timeout !== null) {
+                clearTimeout(that.timeout);
+                that.timeout = null;
+            }
+        });
     };
 
     /**


### PR DESCRIPTION
Widget.warning('text....') was infinitely sticky in some cases
like content manager raising 'not implemented' on copy.

The make default click_callback to dismiss notification,
and fix the logic to not unbind the click handler if it requests
the notification not to be dismissed.
