### PR TITLE
Reverse hscrollbar min-height hack on OS X

### DIFF
--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -21,7 +21,22 @@ define([
 ], function(IPython, $, utils, CodeMirror, cm_match, cm_closeb, cm_comment) {
     // TODO: remove IPython dependency here 
     "use strict";
-
+    
+    var overlayHack = CodeMirror.scrollbarModel.native.prototype.overlayHack;
+    
+    CodeMirror.scrollbarModel.native.prototype.overlayHack = function () {
+        overlayHack.apply(this, arguments);
+        // Reverse `min-height: 18px` scrollbar hack on OS X
+        // which causes a dead area, making it impossible to click on the last line
+        // when there is horizontal scrolling to do and the "show scrollbar only when scrolling" behavior
+        // is enabled.
+        // This, in turn, has the undesirable behavior of never showing the horizontal scrollbar,
+        // even when it should, which is less problematic, at least.
+        if (/Mac/.test(navigator.platform)) {
+            this.horiz.style.minHeight = "";
+        }
+    };
+    
     var Cell = function (options) {
         /* Constructor
          *


### PR DESCRIPTION
OS X has optional behavior to only draw scrollbars during scroll, which causes problems for CodeMirror's scrollbars.  CodeMirror's solution is to set a minimum size for their scrollbars, which is always present.

The trade is that the container overlays most of the last line, creating a "dead zone" that swallows click events when there is scrolling to do, even when no scrollbar is visible.

This reverses the trade, recovering the click events at the expense of never showing the horizontal scrollbar on OS X when this option is enabled.

closes #7623
