### PR TITLE
only show prompt overlay if there's a prompt

### DIFF
--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -138,7 +138,9 @@ define([
         if (this.collapsed) {
             this.collapse_button.hide();
             this.element.show();
-            this.prompt_overlay.show();
+            if (this.prompt_area) {
+                this.prompt_overlay.show();
+            }
             this.collapsed = false;
             this.scroll_if_long();
         }


### PR DESCRIPTION
on which to overlay

widgets don't have prompts, so the overlay doesn't make sense

closes #7659
