### PR TITLE
don't trigger kernel_starting after kernel_connected

### DIFF
--- a/IPython/html/static/services/kernels/kernel.js
+++ b/IPython/html/static/services/kernels/kernel.js
@@ -180,6 +180,7 @@ define([
             url = url + "?" + qs;
         }
 
+        this.events.trigger('kernel_starting.Kernel', {kernel: this});
         var that = this;
         var on_success = function (data, status, xhr) {
             that.events.trigger('kernel_created.Kernel', {kernel: that});
@@ -402,7 +403,6 @@ define([
          * @function _kernel_connected
          */
         this.events.trigger('kernel_connected.Kernel', {kernel: this});
-        this.events.trigger('kernel_starting.Kernel', {kernel: this});
         // get kernel info so we know what state the kernel is in
         var that = this;
         this.kernel_info(function (reply) {

--- a/IPython/html/tests/services/kernel.js
+++ b/IPython/html/tests/services/kernel.js
@@ -163,9 +163,9 @@ casper.notebook_test(function () {
         'kill/start',
         [
             'kernel_killed.Kernel',
+            'kernel_starting.Kernel',
             'kernel_created.Kernel',
             'kernel_connected.Kernel',
-            'kernel_starting.Kernel',
             'kernel_ready.Kernel'
         ],
         function () {
@@ -205,7 +205,6 @@ casper.notebook_test(function () {
             'kernel_restarting.Kernel',
             'kernel_created.Kernel',
             'kernel_connected.Kernel',
-            'kernel_starting.Kernel',
             'kernel_ready.Kernel'
         ],
         function () {

--- a/IPython/html/tests/services/session.js
+++ b/IPython/html/tests/services/session.js
@@ -100,7 +100,6 @@ casper.notebook_test(function () {
         [
             'kernel_created.Session',
             'kernel_connected.Kernel',
-            'kernel_starting.Kernel',
             'kernel_ready.Kernel'
         ],
         function () {
@@ -129,7 +128,6 @@ casper.notebook_test(function () {
             'kernel_killed.Session',
             'kernel_created.Session',
             'kernel_connected.Kernel',
-            'kernel_starting.Kernel',
             'kernel_ready.Kernel'
         ],
         function () {


### PR DESCRIPTION
trigger instead at the beginning of Kernel.start

if a websocket is fully connected, the kernel has finished starting

addresses notification confusion when connecting to busy kernel in #7647
