### PR TITLE
Add KernelSpecManager.whitelist

### DIFF
--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -345,6 +345,7 @@ class NotebookApp(BaseIPythonApplication):
     classes = [
         KernelManager, ProfileDir, Session, MappingKernelManager,
         ContentsManager, FileContentsManager, NotebookNotary,
+        KernelSpecManager,
     ]
     flags = Dict(flags)
     aliases = Dict(aliases)
@@ -650,9 +651,6 @@ class NotebookApp(BaseIPythonApplication):
 
     kernel_spec_manager = Instance(KernelSpecManager)
 
-    def _kernel_spec_manager_default(self):
-        return KernelSpecManager(ipython_dir=self.ipython_dir)
-
     kernel_spec_manager_class = Type(
         default_value=KernelSpecManager,
         config=True,
@@ -766,6 +764,7 @@ class NotebookApp(BaseIPythonApplication):
         default_secure(self.config)
 
         self.kernel_spec_manager = self.kernel_spec_manager_class(
+            parent=self,
             ipython_dir=self.ipython_dir,
         )
         self.kernel_manager = self.kernel_manager_class(

--- a/IPython/kernel/kernelspecapp.py
+++ b/IPython/kernel/kernelspecapp.py
@@ -22,7 +22,7 @@ class ListKernelSpecs(BaseIPythonApplication):
     flags = {'debug': base_flags['debug'],}
 
     def _kernel_spec_manager_default(self):
-        return KernelSpecManager(ipython_dir=self.ipython_dir)
+        return KernelSpecManager(parent=self, ipython_dir=self.ipython_dir)
 
     def start(self):
         print("Available kernels:")


### PR DESCRIPTION
set of allowed kernels by name

Mainly useful for excluding the 'native' python2/3 kernel, but it's generic.

This was requested somewhere, but I can't find an Issue for it, so I'm going to assume it was on gitter / mailing list.
