### PR TITLE
use \0 instead of 'wake up' to finish output

### DIFF
--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -388,7 +388,7 @@ class StreamCapturer(Thread):
             return
 
         self.stop.set()
-        os.write(self.writefd, b'wake up')  # Ensure we're not locked in a read()
+        os.write(self.writefd, b'\0')  # Ensure we're not locked in a read()
         self.join()
 
 class SubprocessStreamCapturePlugin(Plugin):


### PR DESCRIPTION
since we are now seeing the captured output, we don't need `wake up` at the end of all of our test outputs.
