### PR TITLE
Convert cpasted code to unicode on Python 2

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -66,7 +66,7 @@ def get_pasted_lines(sentinel, l_input=py3compat.input, quiet=False):
         prompt = ""
     while True:
         try:
-            l = l_input(prompt)
+            l = py3compat.str_to_unicode(l_input(prompt))
             if l == sentinel:
                 return
             else:
@@ -181,7 +181,7 @@ class TerminalMagics(Magics):
 
         quiet = ('q' in opts)
 
-        sentinel = opts.get('s', '--')
+        sentinel = opts.get('s', u'--')
         block = '\n'.join(get_pasted_lines(sentinel, quiet=quiet))
         self.store_or_execute(block, name)
 


### PR DESCRIPTION
Closes gh-7676

No test, because this is very awkward code to test, but I can't reproduce the error manually after this change.
