### PR TITLE
Streamline tree-selector menu

### DIFF
--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8781,10 +8781,21 @@ input.engine_num_input {
 }
 #tree-selector {
   display: inline-block;
-  padding-right: 0px;
+  padding-right: 5px;
 }
-#tree-selector input[type=checkbox] {
+#select-all {
+  margin-top: -1px;
   margin-left: 7px;
+  vertical-align: baseline;
+}
+#tree-selector-menu {
+  width: 200px;
+}
+#tree-selector-menu .menuitem label {
+  margin-bottom: 0px;
+}
+#tree-selector-menu input[type=checkbox] {
+  margin-left: 0px;
   vertical-align: baseline;
 }
 .tab-content .row {

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8780,23 +8780,20 @@ input.engine_num_input {
   font-weight: bold;
 }
 #tree-selector {
-  display: inline-block;
-  padding-right: 5px;
+  padding-right: 0px;
+}
+#button-select-all {
+  min-width: 50px;
 }
 #select-all {
-  margin-top: -1px;
   margin-left: 7px;
-  vertical-align: baseline;
+  margin-right: 2px;
 }
 #tree-selector-menu {
   width: 200px;
 }
-#tree-selector-menu .menuitem label {
-  margin-bottom: 0px;
-}
 #tree-selector-menu input[type=checkbox] {
   margin-left: 0px;
-  vertical-align: baseline;
 }
 .tab-content .row {
   margin-left: 0px;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8789,11 +8789,8 @@ input.engine_num_input {
   margin-left: 7px;
   margin-right: 2px;
 }
-#tree-selector-menu {
-  width: 200px;
-}
-#tree-selector-menu input[type=checkbox] {
-  margin-left: 0px;
+.menu_icon {
+  margin-right: 2px;
 }
 .tab-content .row {
   margin-left: 0px;

--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -499,12 +499,17 @@ define([
             if (selected_nums[i] === 0) {
                 $('#'+checkbox_ids[i])[0].indeterminate = false;
                 $('#'+checkbox_ids[i]).prop('checked', false);
-            } else if (selected_nums[i] === total_nums[i]) {
-                $('#'+checkbox_ids[i])[0].indeterminate = false;
-                $('#'+checkbox_ids[i]).prop('checked', true);
+                $('#badge-'+checkbox_ids[i]).text('');
             } else {
-                $('#'+checkbox_ids[i]).prop('checked', false);
-                $('#'+checkbox_ids[i])[0].indeterminate = true;
+                // Update badge
+                $('#badge-'+checkbox_ids[i]).text(selected_nums[i]);
+                if (selected_nums[i] === total_nums[i]) {
+                    $('#'+checkbox_ids[i])[0].indeterminate = false;
+                    $('#'+checkbox_ids[i]).prop('checked', true);
+                } else {
+                    $('#'+checkbox_ids[i]).prop('checked', false);
+                    $('#'+checkbox_ids[i])[0].indeterminate = true;
+                }
             }
         }
     };

--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -123,7 +123,15 @@ define([
 
             // Bind events for selection checkboxes.
             $('.tree-selector').change(function(){that.select($(this).attr('id'),$(this).is(':checked'))});
-            
+            $('#button-select-all').click(function(e) {
+                // toggle checkbox if the click doesn't come from the checkbox already
+                if (!$(e.target).is('input[type=checkbox]')) {
+                    var checkbox = $('#select-all');
+                    checkbox.prop('checked', !checkbox.prop('checked'));
+                    that.select('select-all',checkbox.prop('checked'));
+                }
+            });
+
             // Make the dropdown sticky
             // Dirty solution by stopping click propagation
             // $('#tree-selector-menu').click(function(event){event.stopPropagation();})
@@ -132,7 +140,8 @@ define([
                 $(this).parent().toggleClass('open');
             });
             $('body').on('click', function (e) {
-                if (!$('#tree-selector-btn').is(e.target) && $('#tree-selector-btn').has(e.target).length === 0 && $('.open').has(e.target).length === 0) {
+                // Close the menu if a click happens outside of the menu list (and of the tree-selector-btn)
+                if (!$('#tree-selector-btn').is(e.target) && $('#tree-selector-btn').has(e.target).length === 0 && $('#tree-selector-menu').has(e.target).length === 0) {
                     $('#tree-selector-btn').parent().removeClass('open');
                 }
             });
@@ -520,8 +529,13 @@ define([
                     $('#'+checkbox_ids[i]).parent().parent().removeClass('disabled');
                 }
             }
-            // Update badge
-            $('#badge-'+checkbox_ids[i]).text(selected_nums[i]===0 ? '' : selected_nums[i]);
+            // Update counters
+            // Turn empty counter into a '&nbsp;' on the main checkbox for correct button height.
+            var empty_counter = i===0 ? '&nbsp;' : '';
+            $('#counter-'+checkbox_ids[i]).html(selected_nums[i]===0 ? empty_counter : selected_nums[i]);
+            // Alternative : display selected/total
+            // $('#counter-'+checkbox_ids[i]).html(selected_nums[i]===0 ? empty_counter : selected_nums[i] + '/' + total_nums[i]);
+            
             // Update each checkbox status
             if (selected_nums[i] === 0) {
                 $('#'+checkbox_ids[i])[0].indeterminate = false;

--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -122,14 +122,14 @@ define([
             $('.delete-button').click($.proxy(this.delete_selected, this));
 
             // Bind events for selection menu buttons.
-            $('#selector-menu').click(function(event){that.select($(event.target).attr('id'),true)});
-            $('.tree-selector').change(function(){that.select($(this).attr('id'),$(this).is(':checked'))});
+            $('#selector-menu').click(function(event){that.select($(event.target).attr('id'))});
+            $('#select-all').change(function(){that.select($(this).is(':checked') ? 'select-all' : 'select-none')});
             $('#button-select-all').click(function(e) {
                 // toggle checkbox if the click doesn't come from the checkbox already
                 if (!$(e.target).is('input[type=checkbox]')) {
                     var checkbox = $('#select-all');
                     checkbox.prop('checked', !checkbox.prop('checked'));
-                    that.select('select-all',checkbox.prop('checked'));
+                    that.select(checkbox.prop('checked') ? 'select-all' : 'select-none');
                 }
             });
         }
@@ -387,21 +387,20 @@ define([
 
     /**
      * Select all items in the tree of specified type.
-     * selection_type : string among "select-all, "select-folders", "select-notebooks", "select-running-notebooks", "select-files"
-     * state : boolean, true to select and false to deselect
+     * selection_type : string among "select-all", "select-folders", "select-notebooks", "select-running-notebooks", "select-files"
+     *                  any other string (like "select-none") deselects all items
      */
-    NotebookList.prototype.select = function(selection_type,state) {
+    NotebookList.prototype.select = function(selection_type) {
         var that = this;
         $('.list_item').each(function(index, item) {
-            // For each item, determine if the state should be set, depending on the selection_type that triggered select
-            var set_state = (selection_type === "select-all");
-            set_state = set_state || (selection_type === "select-folders" && $(item).data('type') === 'directory');
-            set_state = set_state || (selection_type === "select-notebooks" && $(item).data('type') === 'notebook');
-            set_state = set_state || (selection_type === "select-running-notebooks" && $(item).data('type') === 'notebook' && that.sessions[$(item).data('path')] !== undefined);
-            set_state = set_state || (selection_type === "select-files" && $(item).data('type') === 'file');
-            if (set_state) {
-                $(item).find('input[type=checkbox]').prop('checked', state);
-            }
+            var item_type = $(item).data('type');
+            var state = false;
+            state = state || (selection_type === "select-all");
+            state = state || (selection_type === "select-folders" && item_type === 'directory');
+            state = state || (selection_type === "select-notebooks" && item_type === 'notebook');
+            state = state || (selection_type === "select-running-notebooks" && item_type === 'notebook' && that.sessions[$(item).data('path')] !== undefined);
+            state = state || (selection_type === "select-files" && item_type === 'file');
+            $(item).find('input[type=checkbox]').prop('checked', state);
         });
         this._selection_changed();
     };

--- a/IPython/html/static/tree/less/tree.less
+++ b/IPython/html/static/tree/less/tree.less
@@ -194,11 +194,8 @@ input.engine_num_input {
     margin-right: 2px;
 }
 
-#tree-selector-menu {
-    width: 200px;
-    input[type=checkbox] {
-        margin-left: 0px;
-    }
+.menu_icon {
+    margin-right: 2px;
 }
 
 .tab-content .row {

--- a/IPython/html/static/tree/less/tree.less
+++ b/IPython/html/static/tree/less/tree.less
@@ -184,12 +184,24 @@ input.engine_num_input {
 
 #tree-selector {
     display: inline-block;
-    padding-right: 0px;
+    padding-right: 5px;
+}
 
-    input[type=checkbox] {
-        margin-left: @dashboard_lr_pad;
-        vertical-align: baseline;
-    }
+#select-all {
+    margin-top:-1px;
+    margin-left: @dashboard_lr_pad;
+    vertical-align: baseline;
+}
+
+#tree-selector-menu {
+        width: 200px;
+        .menuitem label{
+            margin-bottom: 0px;
+        }
+        input[type=checkbox] {
+            margin-left: 0px;
+            vertical-align: baseline;
+        }
 }
 
 .tab-content .row {

--- a/IPython/html/static/tree/less/tree.less
+++ b/IPython/html/static/tree/less/tree.less
@@ -12,7 +12,6 @@
 @btn_small_height: 24px;
 @btn_mini_height: 22px;
 @dark_dashboard_color: @breadcrumb-color;
-@list_stripe_color: lighten(@page-backdrop-color,3%);
 
 // The left padding of the selector button's contents.
 @dashboard-selectorbtn-lpad: 7px;
@@ -183,25 +182,23 @@ input.engine_num_input {
 }
 
 #tree-selector {
-    display: inline-block;
-    padding-right: 5px;
+    padding-right: 0px;
+}
+
+#button-select-all {
+    min-width: 50px;
 }
 
 #select-all {
-    margin-top:-1px;
     margin-left: @dashboard_lr_pad;
-    vertical-align: baseline;
+    margin-right: 2px;
 }
 
 #tree-selector-menu {
-        width: 200px;
-        .menuitem label{
-            margin-bottom: 0px;
-        }
-        input[type=checkbox] {
-            margin-left: 0px;
-            vertical-align: baseline;
-        }
+    width: 200px;
+    input[type=checkbox] {
+        margin-left: 0px;
+    }
 }
 
 .tab-content .row {

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -76,19 +76,41 @@ data-terminals-available="{{terminals_available}}"
           </div>
           <div id="notebook_list">
             <div id="notebook_list_header" class="row list_header">
-              <div class="dropdown" id='tree-selector'>
+              <div class="btn-group dropdown" id='tree-selector'>
+                <button type="button" class="btn btn-default btn-xs"><input type="checkbox" class="tree-selector" id="select-all"></input></button>
                 <button class="btn btn-default btn-xs dropdown-toggle" type="button" id="tree-selector-btn" data-toggle="dropdown" aria-expanded="true">
-                  <input type='checkbox'></input>
                   <span class="caret"></span>
+                  <span class="sr-only">Toggle Dropdown</span>
                 </button>
-                <ul class="dropdown-menu" role="menu" aria-labelledby="tree-selector-btn">
-                  <li role="presentation" class="select-all"><a role="menuitem" tabindex="-1" href="#">Select all</a></li>
-                  <li role="presentation" class="select-notebooks"><a role="menuitem" tabindex="-1" href="#">Select notebooks</a></li>
-                  <li role="presentation" class="select-running-notebooks"><a role="menuitem" tabindex="-1" href="#">Select running notebooks</a></li>
-                  <li role="presentation" class="select-files"><a role="menuitem" tabindex="-1" href="#">Select files</a></li>
-                  <li role="presentation" class="select-directories"><a role="menuitem" tabindex="-1" href="#">Select directories</a></li>
-                  <li role="presentation" class="divider"></li>
-                  <li role="presentation" class="deselect-all"><a role="menuitem" tabindex="-1" href="#">Deselect all</a></li>
+                <ul id="tree-selector-menu" class="dropdown-menu" role="menu" aria-labelledby="tree-selector-btn">
+                  <li role="presentation">
+                    <input type="checkbox" class="tree-selector" id="select-folders"></input>
+                    <label for="select-folders">
+                      <i class="item_icon folder_icon icon-fixed-width"></i>
+                      Folders
+                    </label>
+                  </li>
+                  <li role="presentation">
+                    <input type="checkbox" class="tree-selector" id="select-notebooks"></input>
+                    <label for="select-notebooks">
+                      <i class="item_icon notebook_icon icon-fixed-width"></i>
+                      All Notebooks
+                    </label>
+                  </li>
+                  <li role="presentation">
+                    <input type="checkbox" class="tree-selector" id="select-running-notebooks"></input>
+                    <label for="select-running-notebooks">
+                      <i class="item_icon running_notebook_icon icon-fixed-width"></i>
+                      Running
+                    </label>
+                  </li>
+                  <li role="presentation">
+                    <input type="checkbox" class="tree-selector" id="select-files"></input>
+                    <label for="select-files">
+                      <i class="item_icon file_icon icon-fixed-width"></i>
+                      Files
+                    </label>
+                  </li>
                 </ul>
               </div>
               <div id="project_name">

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -85,42 +85,42 @@ data-terminals-available="{{terminals_available}}"
                 <ul id="tree-selector-menu" class="dropdown-menu" role="menu" aria-labelledby="tree-selector-btn">
                   <li role="presentation">
                     <a role="menuitem">
+                      <span class="badge pull-right" id="badge-select-folders"></span>
                       <input type="checkbox" class="tree-selector" id="select-folders"></input>
                       <label for="select-folders">
                         <i class="folder_icon icon-fixed-width"></i>
                         Folders
                       </label>
-                      <span class="badge pull-right" id="badge-select-folders"></span>
                     </a>
                   </li>
                   <li role="presentation">
                     <a role="menuitem">
+                      <span class="badge pull-right" id="badge-select-notebooks"></span>
                       <input type="checkbox" class="tree-selector" id="select-notebooks"></input>
                       <label for="select-notebooks">
                         <i class="notebook_icon icon-fixed-width"></i>
                         All Notebooks
                       </label>
-                      <span class="badge pull-right" id="badge-select-notebooks"></span>
                     </a>
                   </li>
                   <li role="presentation">
                     <a role="menuitem">
+                      <span class="badge pull-right" id="badge-select-running-notebooks"></span>
                       <input type="checkbox" class="tree-selector" id="select-running-notebooks"></input>
                       <label for="select-running-notebooks">
                         <i class="running_notebook_icon icon-fixed-width"></i>
                         Running
                       </label>
-                      <span class="badge pull-right" id="badge-select-running-notebooks"></span>
                     </a>
                   </li>
                   <li role="presentation">
                     <a role="menuitem">
+                      <span class="badge pull-right" id="badge-select-files"></span>
                       <input type="checkbox" class="tree-selector" id="select-files"></input>
                       <label for="select-files">
                         <i class="file_icon icon-fixed-width"></i>
                         Files  
                       </label>
-                      <span class="badge pull-right" id="badge-select-files"></span>
                     </a>
                   </li>
                 </ul>

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -77,18 +77,18 @@ data-terminals-available="{{terminals_available}}"
           <div id="notebook_list">
             <div id="notebook_list_header" class="row list_header">
               <div class="btn-group dropdown" id="tree-selector">
-                <button type="button" class="btn btn-default btn-xs" id="button-select-all">
+                <button title="Select All / None" type="button" class="btn btn-default btn-xs" id="button-select-all">
                   <input type="checkbox" class="pull-left tree-selector" id="select-all"><span id="counter-select-all">&nbsp;</span></input>
                 </button>
-                <button class="btn btn-default btn-xs dropdown-toggle" type="button" id="tree-selector-btn" data-toggle="dropdown" aria-expanded="true">
+                <button title="Select..." class="btn btn-default btn-xs dropdown-toggle" type="button" id="tree-selector-btn" data-toggle="dropdown" aria-expanded="true">
                   <span class="caret"></span>
                   <span class="sr-only">Toggle Dropdown</span>
                 </button>
                 <ul id='selector-menu' class="dropdown-menu" role="menu" aria-labelledby="tree-selector-btn">
-                  <li role="presentation"><a id="select-folders" role="menuitem" tabindex="-1" href="#"><i class="menu_icon folder_icon icon-fixed-width"></i> Folders</a></li>
-                  <li role="presentation"><a id="select-notebooks" role="menuitem" tabindex="-1" href="#"><i class="menu_icon notebook_icon icon-fixed-width"></i> All Notebooks</a></li>
-                  <li role="presentation"><a id="select-running-notebooks" role="menuitem" tabindex="-1" href="#"><i class="menu_icon running_notebook_icon icon-fixed-width"></i> Running</a></li>
-                  <li role="presentation"><a id="select-files" role="menuitem" tabindex="-1" href="#"><i class="menu_icon file_icon icon-fixed-width"></i> Files</a></li>
+                  <li role="presentation"><a id="select-folders" role="menuitem" tabindex="-1" href="#" title="Select All Folders"><i class="menu_icon folder_icon icon-fixed-width"></i> Folders</a></li>
+                  <li role="presentation"><a id="select-notebooks" role="menuitem" tabindex="-1" href="#" title="Select All Notebooks"><i class="menu_icon notebook_icon icon-fixed-width"></i> All Notebooks</a></li>
+                  <li role="presentation"><a id="select-running-notebooks" role="menuitem" tabindex="-1" href="#" title="Select Running Notebooks"><i class="menu_icon running_notebook_icon icon-fixed-width"></i> Running</a></li>
+                  <li role="presentation"><a id="select-files" role="menuitem" tabindex="-1" href="#" title="Select All Files"><i class="menu_icon file_icon icon-fixed-width"></i> Files</a></li>
                 </ul>
               </div>
               <div id="project_name">

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -78,42 +78,50 @@ data-terminals-available="{{terminals_available}}"
             <div id="notebook_list_header" class="row list_header">
               <div class="btn-group dropdown" id='tree-selector'>
                 <button type="button" class="btn btn-default btn-xs"><input type="checkbox" class="tree-selector" id="select-all"></input></button>
-                <button class="btn btn-default btn-xs dropdown-toggle" type="button" id="tree-selector-btn" data-toggle="dropdown" aria-expanded="true">
+                <button class="btn btn-default btn-xs dropdown-toggle" type="button" id="tree-selector-btn" aria-expanded="true">
                   <span class="caret"></span>
                   <span class="sr-only">Toggle Dropdown</span>
                 </button>
                 <ul id="tree-selector-menu" class="dropdown-menu" role="menu" aria-labelledby="tree-selector-btn">
                   <li role="presentation">
-                    <input type="checkbox" class="tree-selector" id="select-folders"></input>
-                    <label for="select-folders">
-                      <i class="item_icon folder_icon icon-fixed-width"></i>
-                      Folders
-                      <span class="badge" id="badge-select-folders"></span>
-                    </label>
+                    <a role="menuitem">
+                      <input type="checkbox" class="tree-selector" id="select-folders"></input>
+                      <label for="select-folders">
+                        <i class="folder_icon icon-fixed-width"></i>
+                        Folders
+                      </label>
+                      <span class="badge pull-right" id="badge-select-folders"></span>
+                    </a>
                   </li>
                   <li role="presentation">
-                    <input type="checkbox" class="tree-selector" id="select-notebooks"></input>
-                    <label for="select-notebooks">
-                      <i class="item_icon notebook_icon icon-fixed-width"></i>
-                      All Notebooks
-                      <span class="badge" id="badge-select-notebooks"></span>
-                    </label>
+                    <a role="menuitem">
+                      <input type="checkbox" class="tree-selector" id="select-notebooks"></input>
+                      <label for="select-notebooks">
+                        <i class="notebook_icon icon-fixed-width"></i>
+                        All Notebooks
+                      </label>
+                      <span class="badge pull-right" id="badge-select-notebooks"></span>
+                    </a>
                   </li>
                   <li role="presentation">
-                    <input type="checkbox" class="tree-selector" id="select-running-notebooks"></input>
-                    <label for="select-running-notebooks">
-                      <i class="item_icon running_notebook_icon icon-fixed-width"></i>
-                      Running
-                      <span class="badge" id="badge-select-running-notebooks"></span>
-                    </label>
+                    <a role="menuitem">
+                      <input type="checkbox" class="tree-selector" id="select-running-notebooks"></input>
+                      <label for="select-running-notebooks">
+                        <i class="running_notebook_icon icon-fixed-width"></i>
+                        Running
+                      </label>
+                      <span class="badge pull-right" id="badge-select-running-notebooks"></span>
+                    </a>
                   </li>
                   <li role="presentation">
-                    <input type="checkbox" class="tree-selector" id="select-files"></input>
-                    <label for="select-files">
-                      <i class="item_icon file_icon icon-fixed-width"></i>
-                      Files
-                      <span class="badge" id="badge-select-files"></span>
-                    </label>
+                    <a role="menuitem">
+                      <input type="checkbox" class="tree-selector" id="select-files"></input>
+                      <label for="select-files">
+                        <i class="file_icon icon-fixed-width"></i>
+                        Files  
+                      </label>
+                      <span class="badge pull-right" id="badge-select-files"></span>
+                    </a>
                   </li>
                 </ul>
               </div>

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -76,55 +76,19 @@ data-terminals-available="{{terminals_available}}"
           </div>
           <div id="notebook_list">
             <div id="notebook_list_header" class="row list_header">
-              <div class="btn-group dropdown" id='tree-selector'>
+              <div class="btn-group dropdown" id="tree-selector">
                 <button type="button" class="btn btn-default btn-xs" id="button-select-all">
-                  <input type="checkbox" class="tree-selector pull-left" id="select-all"><span id="counter-select-all">&nbsp;</span></input>
+                  <input type="checkbox" class="pull-left tree-selector" id="select-all"><span id="counter-select-all">&nbsp;</span></input>
                 </button>
-                <button class="btn btn-default btn-xs dropdown-toggle" type="button" id="tree-selector-btn" aria-expanded="true">
+                <button class="btn btn-default btn-xs dropdown-toggle" type="button" id="tree-selector-btn" data-toggle="dropdown" aria-expanded="true">
                   <span class="caret"></span>
                   <span class="sr-only">Toggle Dropdown</span>
                 </button>
-                <ul id="tree-selector-menu" class="dropdown-menu" role="menu" aria-labelledby="tree-selector-btn">
-                  <li role="presentation">
-                    <a role="menuitem">
-                      <span class="badge pull-right" id="counter-select-folders"></span>
-                      <input type="checkbox" class="tree-selector" id="select-folders"></input>
-                      <label for="select-folders">
-                        <i class="folder_icon icon-fixed-width"></i>
-                        Folders
-                      </label>
-                    </a>
-                  </li>
-                  <li role="presentation">
-                    <a role="menuitem">
-                      <span class="badge pull-right" id="counter-select-notebooks"></span>
-                      <input type="checkbox" class="tree-selector" id="select-notebooks"></input>
-                      <label for="select-notebooks">
-                        <i class="notebook_icon icon-fixed-width"></i>
-                        All Notebooks
-                      </label>
-                    </a>
-                  </li>
-                  <li role="presentation">
-                    <a role="menuitem">
-                      <span class="badge pull-right" id="counter-select-running-notebooks"></span>
-                      <input type="checkbox" class="tree-selector" id="select-running-notebooks"></input>
-                      <label for="select-running-notebooks">
-                        <i class="running_notebook_icon icon-fixed-width"></i>
-                        Running
-                      </label>
-                    </a>
-                  </li>
-                  <li role="presentation">
-                    <a role="menuitem">
-                      <span class="badge pull-right" id="counter-select-files"></span>
-                      <input type="checkbox" class="tree-selector" id="select-files"></input>
-                      <label for="select-files">
-                        <i class="file_icon icon-fixed-width"></i>
-                        Files  
-                      </label>
-                    </a>
-                  </li>
+                <ul id='selector-menu' class="dropdown-menu" role="menu" aria-labelledby="tree-selector-btn">
+                  <li role="presentation"><a id="select-folders" role="menuitem" tabindex="-1" href="#"><i class="menu_icon folder_icon icon-fixed-width"></i> Folders</a></li>
+                  <li role="presentation"><a id="select-notebooks" role="menuitem" tabindex="-1" href="#"><i class="menu_icon notebook_icon icon-fixed-width"></i> All Notebooks</a></li>
+                  <li role="presentation"><a id="select-running-notebooks" role="menuitem" tabindex="-1" href="#"><i class="menu_icon running_notebook_icon icon-fixed-width"></i> Running</a></li>
+                  <li role="presentation"><a id="select-files" role="menuitem" tabindex="-1" href="#"><i class="menu_icon file_icon icon-fixed-width"></i> Files</a></li>
                 </ul>
               </div>
               <div id="project_name">

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -88,6 +88,7 @@ data-terminals-available="{{terminals_available}}"
                     <label for="select-folders">
                       <i class="item_icon folder_icon icon-fixed-width"></i>
                       Folders
+                      <span class="badge" id="badge-select-folders"></span>
                     </label>
                   </li>
                   <li role="presentation">
@@ -95,6 +96,7 @@ data-terminals-available="{{terminals_available}}"
                     <label for="select-notebooks">
                       <i class="item_icon notebook_icon icon-fixed-width"></i>
                       All Notebooks
+                      <span class="badge" id="badge-select-notebooks"></span>
                     </label>
                   </li>
                   <li role="presentation">
@@ -102,6 +104,7 @@ data-terminals-available="{{terminals_available}}"
                     <label for="select-running-notebooks">
                       <i class="item_icon running_notebook_icon icon-fixed-width"></i>
                       Running
+                      <span class="badge" id="badge-select-running-notebooks"></span>
                     </label>
                   </li>
                   <li role="presentation">
@@ -109,6 +112,7 @@ data-terminals-available="{{terminals_available}}"
                     <label for="select-files">
                       <i class="item_icon file_icon icon-fixed-width"></i>
                       Files
+                      <span class="badge" id="badge-select-files"></span>
                     </label>
                   </li>
                 </ul>

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -77,9 +77,8 @@ data-terminals-available="{{terminals_available}}"
           <div id="notebook_list">
             <div id="notebook_list_header" class="row list_header">
               <div class="btn-group dropdown" id='tree-selector'>
-                <button type="button" class="btn btn-default btn-xs">
-                  <span class="badge pull-right" id="badge-select-all"></span>
-                  <input type="checkbox" class="tree-selector" id="select-all"></input>
+                <button type="button" class="btn btn-default btn-xs" id="button-select-all">
+                  <input type="checkbox" class="tree-selector pull-left" id="select-all"><span id="counter-select-all">&nbsp;</span></input>
                 </button>
                 <button class="btn btn-default btn-xs dropdown-toggle" type="button" id="tree-selector-btn" aria-expanded="true">
                   <span class="caret"></span>
@@ -88,7 +87,7 @@ data-terminals-available="{{terminals_available}}"
                 <ul id="tree-selector-menu" class="dropdown-menu" role="menu" aria-labelledby="tree-selector-btn">
                   <li role="presentation">
                     <a role="menuitem">
-                      <span class="badge pull-right" id="badge-select-folders"></span>
+                      <span class="badge pull-right" id="counter-select-folders"></span>
                       <input type="checkbox" class="tree-selector" id="select-folders"></input>
                       <label for="select-folders">
                         <i class="folder_icon icon-fixed-width"></i>
@@ -98,7 +97,7 @@ data-terminals-available="{{terminals_available}}"
                   </li>
                   <li role="presentation">
                     <a role="menuitem">
-                      <span class="badge pull-right" id="badge-select-notebooks"></span>
+                      <span class="badge pull-right" id="counter-select-notebooks"></span>
                       <input type="checkbox" class="tree-selector" id="select-notebooks"></input>
                       <label for="select-notebooks">
                         <i class="notebook_icon icon-fixed-width"></i>
@@ -108,7 +107,7 @@ data-terminals-available="{{terminals_available}}"
                   </li>
                   <li role="presentation">
                     <a role="menuitem">
-                      <span class="badge pull-right" id="badge-select-running-notebooks"></span>
+                      <span class="badge pull-right" id="counter-select-running-notebooks"></span>
                       <input type="checkbox" class="tree-selector" id="select-running-notebooks"></input>
                       <label for="select-running-notebooks">
                         <i class="running_notebook_icon icon-fixed-width"></i>
@@ -118,7 +117,7 @@ data-terminals-available="{{terminals_available}}"
                   </li>
                   <li role="presentation">
                     <a role="menuitem">
-                      <span class="badge pull-right" id="badge-select-files"></span>
+                      <span class="badge pull-right" id="counter-select-files"></span>
                       <input type="checkbox" class="tree-selector" id="select-files"></input>
                       <label for="select-files">
                         <i class="file_icon icon-fixed-width"></i>

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -77,7 +77,10 @@ data-terminals-available="{{terminals_available}}"
           <div id="notebook_list">
             <div id="notebook_list_header" class="row list_header">
               <div class="btn-group dropdown" id='tree-selector'>
-                <button type="button" class="btn btn-default btn-xs"><input type="checkbox" class="tree-selector" id="select-all"></input></button>
+                <button type="button" class="btn btn-default btn-xs">
+                  <span class="badge pull-right" id="badge-select-all"></span>
+                  <input type="checkbox" class="tree-selector" id="select-all"></input>
+                </button>
                 <button class="btn btn-default btn-xs dropdown-toggle" type="button" id="tree-selector-btn" aria-expanded="true">
                   <span class="caret"></span>
                   <span class="sr-only">Toggle Dropdown</span>


### PR DESCRIPTION
Streamlines the menu from #7667 with
- Shorter text, with icons.
- Main checkbox no longer opens the dropdown.
  Instead it just selects all/none.
- Fewer menu items but more actions possible by adding checkboxes
  in the menu
- Menu stays open until clicking outside.

Here's how it looks:
![tree-selector](https://cloud.githubusercontent.com/assets/7703352/6042002/ac0360f4-ac81-11e4-8de3-d52666f825d9.gif)

Of course, this needs some CSS work for it to look right, but let's see what you guys think about the mechanics first.
JS comments / CSS help and suggestions warmly welcome!

With more CSS tweaking, we could make that menu more compact so that this could be a dropup instead of a dropdown to avoid hiding the first items in the list (currently, the top of the menu is hidden behing Jupyter, see below)
![dropup](https://cloud.githubusercontent.com/assets/7703352/6042140/bec6bc62-ac82-11e4-9446-d70122b871fa.png)
