### PR TITLE
Make shift-tab work as "indent-less" operation, too

### DIFF
--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -339,6 +339,12 @@ define([
                         return false;
                     }
                 }
+                var pre_cursor = editor.getRange({line:cur.line,ch:0},cur);
+                if (pre_cursor.trim() === "") {
+                    // Don't show tooltip if the part of the line before the cursor
+                    // is empty.  In this case, let CodeMirror handle indentation.
+                    return false;
+                } 
                 this.tooltip.request(that);
                 event.codemirrorIgnore = true;
                 event.preventDefault();


### PR DESCRIPTION
Currently IPython shadows the `shift-tab` operation of codemirror. This PR copies some of the logic of handling the `tab` key a few lines below in the code to "shift-tab", too.

Now you can still get the tooltip using `shift-tab` _and_ use it for indent-less.
