### PR TITLE
check if SIGINT handler is callable before triggering it

### DIFF
--- a/IPython/kernel/zmq/parentpoller.py
+++ b/IPython/kernel/zmq/parentpoller.py
@@ -132,6 +132,8 @@ class ParentPollerWindows(Thread):
                 handle = handles[result - WAIT_OBJECT_0]
 
                 if handle == self.interrupt_handle:
+                    # check if signal handler is callable
+                    # to avoid 'int not callable' error (Python issue #23395)
                     if callable(signal.getsignal(signal.SIGINT)):
                         interrupt_main()
 

--- a/IPython/kernel/zmq/parentpoller.py
+++ b/IPython/kernel/zmq/parentpoller.py
@@ -1,10 +1,13 @@
-# Standard library imports.
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 try:
     import ctypes
 except:
     ctypes = None
 import os
 import platform
+import signal
 import time
 try:
     from _thread import interrupt_main  # Py 3
@@ -129,7 +132,8 @@ class ParentPollerWindows(Thread):
                 handle = handles[result - WAIT_OBJECT_0]
 
                 if handle == self.interrupt_handle:
-                    interrupt_main()
+                    if callable(signal.getsignal(signal.SIGINT)):
+                        interrupt_main()
 
                 elif handle == self.parent_handle:
                     os._exit(1)


### PR DESCRIPTION
an apparent Python bug can cause `int not callable` when SIGINT handler is SIG_IGN

It's a bit baffling that this behavior appears to be dependent on pyzmq version in IPython's own use, but the bug can be reproduced in a tiny amount of pure Python without zmq or IPython.

closes #7685

@juhasch can you confirm that this fixes the issue?
