### PR TITLE
bump pyzmq version dependency to 13

### DIFF
--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -24,9 +24,9 @@ import threading
 import webbrowser
 
 
-# check for pyzmq 2.1.11
+# check for pyzmq
 from IPython.utils.zmqrelated import check_for_zmq
-check_for_zmq('2.1.11', 'IPython.html')
+check_for_zmq('13', 'IPython.html')
 
 from jinja2 import Environment, FileSystemLoader
 

--- a/IPython/kernel/zmq/__init__.py
+++ b/IPython/kernel/zmq/__init__.py
@@ -1,17 +1,11 @@
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2013  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING.txt, distributed as part of this software.
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
-#-----------------------------------------------------------------------------
-# Verify zmq version dependency >= 2.1.11
-#-----------------------------------------------------------------------------
+# Verify zmq version dependency
 
 from IPython.utils.zmqrelated import check_for_zmq
 
-check_for_zmq('2.1.11', 'IPython.kernel.zmq')
+check_for_zmq('13', 'IPython.kernel.zmq')
 
 from .session import Session
 

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -143,7 +143,7 @@ have['casperjs'] = is_cmd_found('casperjs')
 have['phantomjs'] = is_cmd_found('phantomjs')
 have['slimerjs'] = is_cmd_found('slimerjs')
 
-min_zmq = (2,1,11)
+min_zmq = (13,)
 
 have['zmq'] = test_for('zmq.pyzmq_version_info', min_zmq, callback=lambda x: x())
 

--- a/IPython/utils/zmqrelated.py
+++ b/IPython/utils/zmqrelated.py
@@ -1,33 +1,8 @@
 """Utilities for checking zmq versions."""
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2013  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING.txt, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Verify zmq version dependency >= 2.1.11
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 from IPython.utils.version import check_version
-
-
-def patch_pyzmq():
-    """backport a few patches from newer pyzmq
-    
-    These can be removed as we bump our minimum pyzmq version
-    """
-    
-    import zmq
-    
-    # fallback on stdlib json if jsonlib is selected, because jsonlib breaks things.
-    # jsonlib support is removed from pyzmq >= 2.2.0
-
-    from zmq.utils import jsonapi
-    if jsonapi.jsonmod.__name__ == 'jsonlib':
-        import json
-        jsonapi.jsonmod = json
 
 
 def check_for_zmq(minimum_version, required_by='Someone'):
@@ -35,8 +10,6 @@ def check_for_zmq(minimum_version, required_by='Someone'):
         import zmq
     except ImportError:
         raise ImportError("%s requires pyzmq >= %s"%(required_by, minimum_version))
-    
-    patch_pyzmq()
     
     pyzmq_version = zmq.__version__
     

--- a/setup.py
+++ b/setup.py
@@ -246,15 +246,16 @@ setuptools_extra_args = {}
 
 # setuptools requirements
 
+pyzmq = 'pyzmq>=13'
+
 extras_require = dict(
-    parallel = ['pyzmq>=2.1.11'],
-    qtconsole = ['pyzmq>=2.1.11', 'pygments'],
-    zmq = ['pyzmq>=2.1.11'],
+    parallel = [pyzmq],
+    qtconsole = [pyzmq, 'pygments'],
     doc = ['Sphinx>=1.1', 'numpydoc'],
     test = ['nose>=0.10.1', 'requests'],
     terminal = [],
     nbformat = ['jsonschema>=2.0'],
-    notebook = ['tornado>=4.0', 'pyzmq>=2.1.11', 'jinja2', 'pygments', 'mistune>=0.5'],
+    notebook = ['tornado>=4.0', pyzmq, 'jinja2', 'pygments', 'mistune>=0.5'],
     nbconvert = ['pygments', 'jinja2', 'mistune>=0.3.1']
 )
 


### PR DESCRIPTION
pyzmq < 13 doesn't work with tornado >= 3, which we also require.

This results in clearer error messages when pyzmq is too old.
