### PR TITLE
Don't stop propagation in dashboard

### DIFF
--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -336,16 +336,11 @@ define([
             checkbox.css('visibility', 'hidden');
         } else if (selectable === true) {
             var that = this;
-            link.click(function(e) {
-                e.stopPropagation();
-            });
-            checkbox.click(function(e) {
-                e.stopPropagation();
-                that._selection_changed();
-            });
             row.click(function(e) {
-                e.stopPropagation();
-                checkbox.prop('checked', !checkbox.prop('checked'));
+                // toggle checkbox only if the click doesn't come from the checkbox or the link
+                if (!$(e.target).is('span[class=item_name]') && !$(e.target).is('input[type=checkbox]')) {
+                    checkbox.prop('checked', !checkbox.prop('checked'));
+                }
                 that._selection_changed();
             });
         }


### PR DESCRIPTION
Stopping click propagation should be avoided when used as a hack
for something else, as it interacts poorly with the open/close
mechanics of Bootstrap menus (amongst others).
(more [here](http://css-tricks.com/dangers-stopping-event-propagation/))

This code preserves the intended behaviour (toggling the checkbox when
clicking on the row, except for the link) without resorting to `stopPropagation()`
