### PR TITLE
Remove powershell from script magic defaults

### DIFF
--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -104,7 +104,6 @@ class ScriptMagics(Magics):
         if os.name == 'nt':
             defaults.extend([
                 'cmd',
-                'powershell',
             ])
         
         return defaults


### PR DESCRIPTION
The powershell script magic does not execute the cell (powershell.exe does not read from stdin, unlike python, bash, etc.).  Typing `%%powershell` has the same affect as typing `!powershell` -- it starts up powershell within IPython.
