### PR TITLE
extract send_execute_reply method from Kernel.execute_request

### DIFF
--- a/IPython/kernel/zmq/kernelbase.py
+++ b/IPython/kernel/zmq/kernelbase.py
@@ -347,41 +347,43 @@ class Kernel(SingletonConfigurable):
             self.log.error("Got bad msg: ")
             self.log.error("%s", parent)
             return
-        
-        stop_on_error = content.get('stop_on_error', True)
 
         md = self._make_metadata(parent['metadata'])
-        
+
         # Re-broadcast our input for the benefit of listening clients, and
         # start computing output
         if not silent:
             self.execution_count += 1
             self._publish_execute_input(code, parent, self.execution_count)
-        
+
         reply_content = self.do_execute(code, silent, store_history,
                                         user_expressions, allow_stdin)
+        self.send_execute_reply(stream, ident, parent, md, reply_content)
+
+    def send_execute_reply(self, stream, ident, parent, md, reply_content):
+        """ Send a reply to execute_request """
 
         # Flush output before sending the reply.
-        sys.stdout.flush()
-        sys.stderr.flush()
-        # FIXME: on rare occasions, the flush doesn't seem to make it to the
-        # clients... This seems to mitigate the problem, but we definitely need
-        # to better understand what's going on.
-        if self._execute_sleep:
-            time.sleep(self._execute_sleep)
+        self._flush_execute_output()
 
-        # Send the reply.
+        # Cleanup the reply and prepare metadata
         reply_content = json_clean(reply_content)
-        
+
+        md = self._make_metadata(md)
         md['status'] = reply_content['status']
         if reply_content['status'] == 'error' and \
                         reply_content['ename'] == 'UnmetDependency':
                 md['dependencies_met'] = False
 
+        # Publish the reply
         reply_msg = self.session.send(stream, u'execute_reply',
                                       reply_content, parent, metadata=md,
                                       ident=ident)
-        
+        # Handle the reply message
+        content = parent[u'content']
+        stop_on_error = content.get('stop_on_error', True)
+        silent = content[u'silent']
+
         self.log.debug("%s", reply_msg)
 
         if not silent and reply_msg['content']['status'] == u'error' and stop_on_error:
@@ -699,3 +701,14 @@ class Kernel(SingletonConfigurable):
             self.session.send(self.iopub_socket, self._shutdown_message, ident=self._topic('shutdown'))
             self.log.debug("%s", self._shutdown_message)
         [ s.flush(zmq.POLLOUT) for s in self.shell_streams ]
+
+    def _flush_execute_output(self):
+        # Flush output before sending the reply.
+        sys.stdout.flush()
+        sys.stderr.flush()
+        # FIXME: on rare occasions, the flush doesn't seem to make it to the
+        # clients... This seems to mitigate the problem, but we definitely need
+        # to better understand what's going on.
+        if self._execute_sleep:
+            time.sleep(self._execute_sleep)
+


### PR DESCRIPTION
This is related to https://github.com/ipython/ipython/issues/7614: I want `do_execute`method to be async. Currently the whole `execute_request` should be copy-pasted to implement it; after this refactoring it is possible to return a deferred from `do_execute` and add a callback to it in overridden `send_execute_reply` which calls parent's `send_execute_reply`.

Example:

```
class MyKernel(Kernel):

    # ...

    def send_execute_reply(self, stream, ident, parent, md, reply_content):
        def done(result):
            return super(MyKernel, self).send_execute_reply(stream, ident, parent, md, result)
        assert isinstance(reply_content, defer.Deferred)
        reply_content.addCallback(done)

    def do_execute(self, code, silent, store_history=True, user_expressions=None,
                   allow_stdin=False):

        def publish_result(text):
            if not silent:
                stream_content = {'name': 'stdout', 'text': text}
                self.send_response(self.iopub_socket, 'stream', stream_content)

        def success(result):
            text = self.to_text(result)
            publish_result(text)
            return {
                'status': 'ok',
                'execution_count': self.execution_count,
                'payload': [],
                'user_expressions': {},
            }

        def error(failure):
            text = str(failure)
            publish_result(text)
            return {
                'status': 'error',
                'execution_count': self.execution_count,
                'ename': '',
                'evalue': text,
                'traceback': []
            }

        d = self.run_async(code)
        d.addCallbacks(success, error)
        return d
```
