### PR TITLE
Disable output contents from overflowing page width.

### DIFF
--- a/IPython/html/static/notebook/less/outputarea.less
+++ b/IPython/html/static/notebook/less/outputarea.less
@@ -92,6 +92,8 @@ div.output_area pre {
 /* This class is for the output subarea inside the output_area and after
    the prompt div. */
 div.output_subarea {
+    // Don't let contents overflow page area.
+    overflow-x: auto;
     padding: @code_padding;
     .box-flex1();
 }

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -867,6 +867,7 @@ div.output_area pre {
 /* This class is for the output subarea inside the output_area and after
    the prompt div. */
 div.output_subarea {
+  overflow-x: auto;
   padding: 0.4em;
   /* Old browsers */
   -webkit-box-flex: 1;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -9643,6 +9643,7 @@ div.output_area pre {
 /* This class is for the output subarea inside the output_area and after
    the prompt div. */
 div.output_subarea {
+  overflow-x: auto;
   padding: 0.4em;
   /* Old browsers */
   -webkit-box-flex: 1;


### PR DESCRIPTION
A scrollbar will appear when the output is too wide.

closes #7701
alternative to #7721
