### PR TITLE
Prevent image outputs from being wider than their container.

### DIFF
--- a/IPython/html/static/notebook/less/outputarea.less
+++ b/IPython/html/static/notebook/less/outputarea.less
@@ -131,6 +131,13 @@ div.output_png {
 div.output_jpeg {
 }
 
+// Prevent the image outputs from being wider than the page.
+div.output_png div.ui-wrapper, 
+div.output_svg div.ui-wrapper, 
+div.output_jpeg div.ui-wrapper {
+    max-width: 100%
+}
+
 /* Empty output_javascript divs should have no height */
 div.output_javascript:empty {
     padding: 0;

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -892,6 +892,11 @@ div.output_stderr {
 div.output_latex {
   text-align: left;
 }
+div.output_png div.ui-wrapper,
+div.output_svg div.ui-wrapper,
+div.output_jpeg div.ui-wrapper {
+  max-width: 100%;
+}
 /* Empty output_javascript divs should have no height */
 div.output_javascript:empty {
   padding: 0;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -9668,6 +9668,11 @@ div.output_stderr {
 div.output_latex {
   text-align: left;
 }
+div.output_png div.ui-wrapper,
+div.output_svg div.ui-wrapper,
+div.output_jpeg div.ui-wrapper {
+  max-width: 100%;
+}
 /* Empty output_javascript divs should have no height */
 div.output_javascript:empty {
   padding: 0;


### PR DESCRIPTION
closes #7701
alternative to #7718 

@takluyver 
