### PR TITLE
Trait dict validation

### DIFF
--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -1079,6 +1079,19 @@ def test_dict_assignment():
     nt.assert_equal(d, c.value)
     nt.assert_true(c.value is d)
 
+class ValidatedDictTrait(HasTraits):
+
+    value = Dict(Unicode())
+
+class TestInstanceDict(TraitTestBase):
+
+    obj = ValidatedDictTrait()
+
+    _default_value = {}
+    _good_values = [{'0': 'foo'}, {'1': 'bar'}]
+    _bad_values = [{'0': 0}, {'1': 1}]
+
+
 def test_dict_default_value():
     """Check that the `{}` default value of the Dict traitlet constructor is
     actually copied."""

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -1716,6 +1716,13 @@ class Dict(Instance):
                 validated[key] = v
         return self.klass(validated)
 
+    def instance_init(self, obj):
+        if isinstance(self._trait, TraitType):
+            self._trait.this_class = self.this_class
+        if hasattr(self._trait, '_resolve_classes'):
+            self._trait._resolve_classes(obj)
+        super(Dict, self).instance_init(obj)
+
 
 class EventfulDict(Instance):
     """An instance of an EventfulDict."""


### PR DESCRIPTION
This allows the Dict trait types to have their elements validated in the same way as List elements, via a `trait` optional parameter.

Fixes #7671.  
