### PR TITLE
Toggle viewing files/folders/notebooks

### DIFF
--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -128,6 +128,9 @@ define([
             $('#tree-selector .select-files').click($.proxy(this.select_files, this));
             $('#tree-selector .select-directories').click($.proxy(this.select_directories, this));
             $('#tree-selector .deselect-all').click($.proxy(this.deselect_all, this));
+
+            // Bind events for view toggles
+            $("#toggle-view").change($.proxy(this.update_view, this));
         }
     };
 
@@ -537,6 +540,22 @@ define([
             $('#tree-selector input[type=checkbox]').prop('checked', false);
             $('#tree-selector input[type=checkbox]')[0].indeterminate = true;
         }
+    };
+
+    NotebookList.prototype.update_view = function () {
+        $('#notebook_list .list_item').each(function(index, item) {
+            var row_div = $(item);
+            // Exclude the breadcrumbs (Breadcrumbs path == '')
+            if (row_div.data('path') !== '') {
+                var display = $("#toggle-view-"+row_div.data('type')).is(":checked");
+                row_div.css('display', display ? '' : 'none');
+                if (!display) {
+                    console.log($(item));
+                    $(item).find('input[type=checkbox]').prop('checked',false);
+                }
+            }
+        });
+        this._selection_changed();
     };
 
     NotebookList.prototype.add_link = function (model, item) {

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -25,6 +25,11 @@ data-terminals-available="{{terminals_available}}"
         <div id="notebooks" class="tab-pane active">
           <div id="notebook_toolbar" class="row">
             <div class="col-sm-8 no-padding">
+              <div id="toggle-view" class="btn-group" data-toggle="buttons">
+                <label class="btn btn-default btn-xs active"><input id="toggle-view-directory" type="checkbox" autocomplete="off" checked><i class="folder_icon icon-fixed-width"></i></label>
+                <label class="btn btn-default btn-xs active"><input id="toggle-view-notebook" type="checkbox" autocomplete="off" checked><i class="notebook_icon icon-fixed-width"></i></label>
+                <label class="btn btn-default btn-xs active"><input id="toggle-view-file" type="checkbox" autocomplete="off" checked><i class="file_icon icon-fixed-width"></i></label>
+              </div>
               <form id='alternate_upload'  class='alternate_upload'>
                 <span id="notebook_list_info">
                 To import a notebook, drag the file onto the listing below or


### PR DESCRIPTION
Intended as a complement or replacement for #7681:
add toggles in File tab of Dashboard for viewing/hiding each type in the list.
- Selected items that become hidden get deselected.
- Can coexist with a simple select all/none button (no dropdown menu needed,
  the only lost functionality would be to select running notebooks)
- No persistance of toggle state

Going forward with this, remains TODO:
- [ ] The select all/none/... code should be edited so as not to select
  hidden elements.
- [ ] Decide on best positionning of the buttons

Possible extras:
- search button, revealing a "search" text field (e.g. to find ".py" files)

Behavior:
![toggle-view](https://cloud.githubusercontent.com/assets/7703352/6126757/1ce95728-b124-11e4-9140-dca736551b4a.gif)
