### PR TITLE
Stay in edit mode if tooltip is open

### DIFF
--- a/IPython/html/static/notebook/js/actions.js
+++ b/IPython/html/static/notebook/js/actions.js
@@ -65,6 +65,13 @@ define(function(require){
                 env.notebook.command_mode();
             }
         },
+        'close-tooltip-or-go-to-command-mode': {
+            help    : 'command mode',
+            help_index : 'aa',
+            handler : function (env) {
+                env.notebook.close_tooltip_or_command_mode();
+            }
+        },
         'split-cell-at-cursor': {
             help    : 'split cell',
             help_index : 'ea',

--- a/IPython/html/static/notebook/js/keyboardmanager.js
+++ b/IPython/html/static/notebook/js/keyboardmanager.js
@@ -74,7 +74,7 @@ define([
 
     KeyboardManager.prototype.get_default_edit_shortcuts = function() {
         return {
-            'esc'                 : 'ipython.go-to-command-mode',
+            'esc'                 : 'ipython.close-tooltip-or-go-to-command-mode',
             'ctrl-m'              : 'ipython.go-to-command-mode',
             'up'                  : 'ipython.move-cursor-up-or-previous-cell',
             'down'                : 'ipython.move-cursor-down-or-next-cell',

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -672,6 +672,19 @@ define(function (require) {
     };
 
     /**
+     * Make the notebook enter command mode if the tooltip is not open.
+     */
+    Notebook.prototype.close_tooltip_or_command_mode = function () {
+        var cell = this.get_cell(this.get_edit_index());
+        if (!$('#tooltip').is(':visible') && cell && this.mode !== 'command') {
+            // We don't call cell.command_mode, but rather call cell.focus_cell()
+            // which will blur and CM editor and trigger the call to
+            // handle_command_mode.
+            cell.focus_cell();
+        }
+    };
+
+    /**
      * Handle when a cell fires it's edit_mode event.
      *
      * @param {Cell} [cell] Cell to enter edit mode on.


### PR DESCRIPTION
Do not go to command mode on pressing 'Esc' if tooltip is open (same behaviour as pressing 'Esc' while completion list is open)
closes #7723
