### PR TITLE
handle zero-length match in v4 completions

### DIFF
--- a/IPython/html/static/notebook/js/completer.js
+++ b/IPython/html/static/notebook/js/completer.js
@@ -183,7 +183,9 @@ define([
             // interpret end=null as current position,
             // and negative start relative to that
             end = utils.to_absolute_cursor_pos(this.editor, cur);
-            if (start < 0) {
+            if (start === null) {
+                start = end;
+            } else if (start < 0) {
                 start = end + start;
             }
         }

--- a/IPython/kernel/adapter.py
+++ b/IPython/kernel/adapter.py
@@ -262,12 +262,17 @@ class V4toV5(Adapter):
     
     def complete_reply(self, msg):
         # complete_reply needs more context than we have to get cursor_start and end.
-        # use special value of `-1` to indicate to frontend that it should be at
-        # the current cursor position.
+        # use special end=null to indicate current cursor position and negative offset
+        # for start relative to the cursor.
+        # start=None indicates that start == end (accounts for no -0).
         content = msg['content']
         new_content = msg['content'] = {'status' : 'ok'}
         new_content['matches'] = content['matches']
-        new_content['cursor_start'] = -len(content['matched_text'])
+        if content['matched_text']:
+            new_content['cursor_start'] = -len(content['matched_text'])
+        else:
+            # no -0, use None to indicate that start == end
+            new_content['cursor_start'] = None
         new_content['cursor_end'] = None
         new_content['metadata'] = {}
         return msg


### PR DESCRIPTION
use start=None instead of `-0` to indicate start == end (which is already None indicating the same value).

closes #7719
