### PR TITLE
prevent esc from bubbling up when dismissing tooltip

### DIFF
--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -329,6 +329,7 @@ define([
             // If we closed the tooltip, don't let CM or the global handlers
             // handle this event.
             event.codemirrorIgnore = true;
+            event._ipkmIgnore = true;
             event.preventDefault();
             return true;
         } else if (event.keyCode === keycodes.tab && event.type === 'keydown' && event.shiftKey) {


### PR DESCRIPTION
prevents esc from entering command mode when it's meant to dismiss the tooltip.

The logic for the event was already there, it just lacked the `ipkmIgnore` bit.

alternative to #7728
closes #7723
