### PR TITLE
scrolling workaround for Firefox

### DIFF
--- a/IPython/html/static/notebook/less/cell.less
+++ b/IPython/html/static/notebook/less/cell.less
@@ -54,6 +54,14 @@ div.inner_cell {
     .box-flex1();
 }
 
+@-moz-document url-prefix() {
+    div.inner_cell {
+        // hack around FF bug causing cell to expand when lines are long
+        // instead of scrolling
+        overflow-x: hidden;
+    }
+}
+
 /* input_area and input_prompt must match in top border and margin for alignment */
 div.input_area {
     border: 1px solid @light_border_color;

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -420,6 +420,11 @@ div.inner_cell {
   /* Modern browsers */
   flex: 1;
 }
+@-moz-document url-prefix() {
+  div.inner_cell {
+    overflow-x: hidden;
+  }
+}
 /* input_area and input_prompt must match in top border and margin for alignment */
 div.input_area {
   border: 1px solid #cfcfcf;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -9196,6 +9196,11 @@ div.inner_cell {
   /* Modern browsers */
   flex: 1;
 }
+@-moz-document url-prefix() {
+  div.inner_cell {
+    overflow-x: hidden;
+  }
+}
 /* input_area and input_prompt must match in top border and margin for alignment */
 div.input_area {
   border: 1px solid #cfcfcf;


### PR DESCRIPTION
setting overflow-x: hidden on Firefox prevents long input from growing the cell ever wider on Firefox.

CSS is only applied on Firefox

workaround is c/o @rsmith31415

closes #7724
closes #7546
