### PR TITLE
DEV: Add toggles for reraising failures during extension loading

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -139,7 +139,13 @@ class InteractiveShellApp(Configurable):
     extra_extension = Unicode('', config=True,
         help="dotted module name of an IPython extension to load."
     )
-    
+
+    reraise_ipython_extension_failures = Bool(
+        False,
+        config=True,
+        help="If True, exit on failure to load any extensions.",
+    )
+
     # Extensions that are always loaded (not configurable)
     default_extensions = List(Unicode, [u'storemagic'], config=False)
     
@@ -259,6 +265,8 @@ class InteractiveShellApp(Configurable):
                     self.log.info("Loading IPython extension: %s" % ext)
                     self.shell.extension_manager.load_extension(ext)
                 except:
+                    if self.exit_on_extension_load_failure:
+                        raise
                     msg = ("Error in loading extension: {ext}\n"
                            "Check your config files in {location}".format(
                                ext=ext,
@@ -266,6 +274,8 @@ class InteractiveShellApp(Configurable):
                            ))
                     self.log.warn(msg, exc_info=True)
         except:
+            if self.exit_on_extension_load_failure:
+                raise
             self.log.warn("Unknown error in loading extensions:", exc_info=True)
 
     def init_code(self):

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -143,7 +143,7 @@ class InteractiveShellApp(Configurable):
     reraise_ipython_extension_failures = Bool(
         False,
         config=True,
-        help="If True, exit on failure to load any extensions.",
+        help="Reraise exceptions encountered loading IPython extensions?",
     )
 
     # Extensions that are always loaded (not configurable)
@@ -265,7 +265,7 @@ class InteractiveShellApp(Configurable):
                     self.log.info("Loading IPython extension: %s" % ext)
                     self.shell.extension_manager.load_extension(ext)
                 except:
-                    if self.exit_on_extension_load_failure:
+                    if self.reraise_ipython_extension_failures:
                         raise
                     msg = ("Error in loading extension: {ext}\n"
                            "Check your config files in {location}".format(
@@ -274,7 +274,7 @@ class InteractiveShellApp(Configurable):
                            ))
                     self.log.warn(msg, exc_info=True)
         except:
-            if self.exit_on_extension_load_failure:
+            if self.reraise_ipython_extension_failures:
                 raise
             self.log.warn("Unknown error in loading extensions:", exc_info=True)
 

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -751,6 +751,12 @@ class NotebookApp(BaseIPythonApplication):
               "This is an experimental API, and may change in future releases.")
     )
 
+    reraise_server_extension_failures = Bool(
+        False,
+        config=True,
+        help="Reraise exceptions encountered loading server extensions?",
+    )
+
     def parse_command_line(self, argv=None):
         super(NotebookApp, self).parse_command_line(argv)
         
@@ -984,6 +990,8 @@ class NotebookApp(BaseIPythonApplication):
                 if func is not None:
                     func(self)
             except Exception:
+                if self.reraise_server_extension_failures:
+                    raise
                 self.log.warn("Error loading server extension %s", modulename,
                               exc_info=True)
     


### PR DESCRIPTION
When deploying an IPython extension for use by other people, I'd rather have the server fail loudly instead of ignoring the error with a warning and carrying on.  This adds a `exit_on_extension_load_failure` flag to InteractiveShellApp that makes it barf if any extensions fail to load.
