### PR TITLE
add no-op every 5s on Windows

### DIFF
--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -1061,6 +1061,11 @@ class NotebookApp(BaseIPythonApplication):
                 threading.Thread(target=b).start()
         
         self.io_loop = ioloop.IOLoop.current()
+        if sys.platform.startswith('win'):
+            # add no-op to wake every 5s
+            # to handle signals that may be ignored by the inner loop
+            pc = ioloop.PeriodicCallback(lambda : None, 5000)
+            pc.start()
         try:
             self.io_loop.start()
         except KeyboardInterrupt:


### PR DESCRIPTION
signals don't interrupt the inner loop on Windows, so pump the eventloop every 5s

closes #7741
