### PR TITLE
disable screenKeys in term.js

### DIFF
--- a/IPython/html/static/terminal/js/terminado.js
+++ b/IPython/html/static/terminal/js/terminado.js
@@ -6,7 +6,7 @@ define ([], function() {
         var term = new Terminal({
           cols: size.cols,
           rows: size.rows,
-          screenKeys: true,
+          screenKeys: false,
           useStyle: false
         });
         ws.onopen = function(event) {


### PR DESCRIPTION
these capture ctrl-a and other keyboard shortcuts

closes #7753
