### PR TITLE
get_body_data: fix for undefined

### DIFF
--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -483,7 +483,10 @@ define([
          * we should never have any encoded URLs anywhere else in code
          * until we are building an actual request
          */
-        return decodeURIComponent($('body').data(key));
+        var val = $('body').data(key);
+        if (!val)
+            return val;
+        return decodeURIComponent(val);
     };
     
     var to_absolute_cursor_pos = function (cm, cursor) {


### PR DESCRIPTION
return undefined instead of "undefined"

useful to fix this line in kernel.js:
    this.ws_url = ws_url || IPython.utils.get_body_data("wsUrl");
