### PR TITLE
Add closed property to outstream

### DIFF
--- a/IPython/kernel/zmq/iostream.py
+++ b/IPython/kernel/zmq/iostream.py
@@ -116,6 +116,10 @@ class OutStream(object):
     def close(self):
         self.pub_socket = None
 
+    @property
+    def closed(self):
+        return self.pub_socket is None
+
     def _flush_from_subprocesses(self):
         """flush possible pub data from subprocesses into my buffer"""
         if not self._pipe_flag or not self._is_master_process():


### PR DESCRIPTION
Some libraries, like colorama, expect that the stream has a closed property.

Closes: https://github.com/ipython/ipython/issues/7764
