### PR TITLE
adjust appearance of cell toolbar select

### DIFF
--- a/IPython/html/static/notebook/less/celltoolbar.less
+++ b/IPython/html/static/notebook/less/celltoolbar.less
@@ -50,9 +50,12 @@
 .celltoolbar select {
     .form-control();
     .input-sm();
+    // undo some of the sizing caused by the above mixins
     width: inherit;
-    font-size: 87%;
+    font-size: inherit;
     height: 22px;
+    padding: 0px;
+    
     display: inline-block;
 
 }

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -10525,8 +10525,9 @@ p {
   line-height: 1.5;
   border-radius: 1px;
   width: inherit;
-  font-size: 87%;
+  font-size: inherit;
   height: 22px;
+  padding: 0px;
   display: inline-block;
 }
 .celltoolbar select:focus {


### PR DESCRIPTION
undo some of the bootstrap mixin sizing, which should help the appearance on Firefox on Linux.

ping @takluyver for testing
