### PR TITLE
handle zmq messages that may be processed after websocket is closed

### DIFF
--- a/IPython/html/base/zmqhandlers.py
+++ b/IPython/html/base/zmqhandlers.py
@@ -94,6 +94,19 @@ if os.environ.get('IPYTHON_ALLOW_DRAFT_WEBSOCKETS_FOR_PHANTOMJS', False):
 
 class ZMQStreamHandler(WebSocketHandler):
     
+    if tornado.version_info < (4,1):
+        """Backport send_error from tornado 4.1 to 4.0"""
+        def send_error(self, *args, **kwargs):
+            if self.stream is None:
+                super(WebSocketHandler, self).send_error(*args, **kwargs)
+            else:
+                # If we get an uncaught exception during the handshake,
+                # we have no choice but to abruptly close the connection.
+                # TODO: for uncaught exceptions after the handshake,
+                # we can close the connection more gracefully.
+                self.stream.close()
+
+
     def check_origin(self, origin):
         """Check Origin == Host or Access-Control-Allow-Origin.
         


### PR DESCRIPTION
closes #7697

This actually fixes #7697 twice
1. it prevents an exception from being raised if a zmq message arrives after the websocket has been closed
2. it fixes the handling of any exception raised in websocket handlers, to avoid "Method not supported by Web Sockets" message when tornado tries to send the error. This is done by backporting WebSocketHandler.send_error from tornado 4.1.
