### PR TITLE
Fixed rendering of URL in append_stream function

### DIFF
--- a/IPython/html/static/notebook/js/outputarea.js
+++ b/IPython/html/static/notebook/js/outputarea.js
@@ -484,6 +484,7 @@ define([
                 last.text = utils.fixCarriageReturn(last.text + json.text);
                 var pre = this.element.find('div.'+subclass).last().find('pre');
                 var html = utils.fixConsole(last.text);
+                html = utils.autoLinkUrls(html);
                 // The only user content injected with this HTML call is
                 // escaped by the fixConsole() method.
                 pre.html(html);


### PR DESCRIPTION
Proposed fix for problem rendering URLs. Addition of call to utils.autoLinkUrls() to ensure correct formatting of HTML. See below for issue thread.

closes #5544
