### PR TITLE
Fix race condition in javascript kernel message processing

### DIFF
--- a/IPython/html/static/services/kernels/serialize.js
+++ b/IPython/html/static/services/kernels/serialize.js
@@ -30,7 +30,7 @@ define([
         return msg;
     };
     
-    var _deserialize_binary = function(data, callback) {
+    var _deserialize_binary = function(data) {
         /**
          * deserialize the binary message format
          * callback will be called with a message whose buffers attribute
@@ -39,28 +39,31 @@ define([
         if (data instanceof Blob) {
             // data is Blob, have to deserialize from ArrayBuffer in reader callback
             var reader = new FileReader();
-            reader.onload = function () {
-                var msg = _deserialize_array_buffer(this.result);
-                callback(msg);
-            };
+            var promise = new Promise(function(resolve, reject) {
+                reader.onload = function () {
+                    var msg = _deserialize_array_buffer(this.result);
+                    resolve(msg);
+                };
+            });
             reader.readAsArrayBuffer(data);
+            return promise;
         } else {
             // data is ArrayBuffer, can deserialize directly
             var msg = _deserialize_array_buffer(data);
-            callback(msg);
+            return msg;
         }
     };
 
-    var deserialize = function (data, callback) {
+    var deserialize = function (data) {
         /**
-         * deserialize a message and pass the unpacked message object to callback
+         * deserialize a message and return a promise for the unpacked message
          */
         if (typeof data === "string") {
             // text JSON message
-            callback(JSON.parse(data));
+            return Promise.resolve(JSON.parse(data));
         } else {
             // binary message
-            _deserialize_binary(data, callback);
+            return Promise.resolve(_deserialize_binary(data));
         }
     };
     

--- a/IPython/html/tests/services/serialize.js
+++ b/IPython/html/tests/services/serialize.js
@@ -110,7 +110,7 @@ casper.notebook_test(function () {
     // validate captured buffers Python-side
     this.then(function () {
         var index = this.append_cell([
-            "assert len(msgs) == 1, len(msgs)",
+            "assert len(msgs) == 3, len(msgs)",
             "bufs = msgs[0]['buffers']",
             "assert len(bufs) == len(buffers), bufs",
             "assert bufs[0].bytes == buffers[0], bufs[0].bytes",
@@ -121,7 +121,7 @@ casper.notebook_test(function () {
         this.wait_for_output(index);
         this.then(function () {
             var out = this.get_output_cell(index);
-            this.test.assertEquals(out['text/plain'], '1', "Python received buffers");
+            this.test.assertEquals(out.data['text/plain'], '1', "Python received buffers");
         });
     });
 });


### PR DESCRIPTION
Because the binary messages are now deserialized using the asynchronous FileReader API, we need to have some way to force the messages to still be processed in the order they are received.  This patch implements a simple processing queue using promises.
