### PR TITLE
Minor styling fix for IntText and FloatText widgets

### DIFF
--- a/IPython/html/static/widgets/js/widget_int.js
+++ b/IPython/html/static/widgets/js/widget_int.js
@@ -290,7 +290,7 @@ define([
              * Called when view is rendered.
              */
             this.$el
-                .addClass('widget-hbox widget-text');
+                .addClass('widget-hbox widget-numeric-text');
             this.$label = $('<div />')
                 .appendTo(this.$el)
                 .addClass('widget-label')


### PR DESCRIPTION
The class of the top div element for those widget was `widget-text`, instead of `widget-numeric-text`. 
However, the `Text` widget is wider than the `IntText` widget, causing the following mismatch between containing and contained div elements:

![wrong_size](https://cloud.githubusercontent.com/assets/2397974/6207564/2da10bc6-b573-11e4-9cee-453ea8041cc7.png)
