### PR TITLE
Fix list of union validation

### DIFF
--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -1001,6 +1001,19 @@ class TestInstanceList(TraitTestBase):
     _good_values = [[Foo(), Foo(), None], None]
     _bad_values = [['1', 2,], '1', [Foo]]
 
+class UnionListTrait(HasTraits):
+
+    value = List(Int() | Bool())
+
+class TestUnionListTrait(HasTraits):
+
+    obj = UnionListTrait()
+
+    _default_value = []
+    _good_values = [[True, 1], [False, True]]
+    _bad_values = [[1, 'True'], False]
+
+
 class LenListTrait(HasTraits):
 
     value = List(Int, [0], minlen=1, maxlen=2)

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -1071,12 +1071,15 @@ class Union(TraitType):
         self.default_value = self.trait_types[0].get_default_value()
         super(Union, self).__init__(**metadata)
 
-    def instance_init(self, obj):
+    def _resolve_classes(self):
         for trait_type in self.trait_types:
             trait_type.name = self.name
             trait_type.this_class = self.this_class
             if hasattr(trait_type, '_resolve_classes'):
                 trait_type._resolve_classes()
+
+    def instance_init(self, obj):
+        self._resolve_classes()
         super(Union, self).instance_init(obj)
 
     def validate(self, obj, value):


### PR DESCRIPTION
In the case of e.g. `List(Int() | Bool())` the `name` attribute if `Int()` and `Bool()` was never set. Moving it from `instance_init` to `_resolve_classes` solves the issue. I also added a test. 

Note: this is a simple fix for this specific bug, but the whole instance-init / decoration is reworked in other traitlet PRs to avoid the instantiation of unused default values. 
