### PR TITLE
Reorganize dashboard buttons

### DIFF
--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8603,27 +8603,25 @@ span#login_widget > .button .badge,
 * IPython tree view
 *
 */
-/* We need an invisible input field on top of the sentense*/
-/* "Drag file onto the list ..." */
-.alternate_upload {
-  background-color: none;
-  display: inline;
+/* We need an invisible input field on top of fake Upload button */
+.btn-file {
+  position: relative;
+  overflow: hidden;
 }
-.alternate_upload.form {
-  padding: 0;
-  margin: 0;
-}
-.alternate_upload input.fileinput {
-  display: inline;
+.btn-file input[type=file] {
+  position: absolute;
+  top: 0;
+  right: 0;
+  min-width: 100%;
+  min-height: 100%;
+  font-size: 100px;
+  text-align: right;
+  filter: alpha(opacity=0);
   opacity: 0;
-  z-index: 2;
-  width: 12ex;
-  margin-right: -12ex;
-}
-.alternate_upload .input-overlay {
-  display: inline-block;
-  font-weight: bold;
-  line-height: 1em;
+  outline: none;
+  background: white;
+  cursor: inherit;
+  display: block;
 }
 /**
  * Primary styles
@@ -8865,10 +8863,6 @@ input.engine_num_input {
 #notebook_toolbar .pull-right {
   padding-top: 0px;
   margin-right: -1px;
-}
-ul#new-menu {
-  left: auto;
-  right: 0;
 }
 .kernel-menu-icon {
   padding-right: 12px;

--- a/IPython/html/static/tree/js/main.js
+++ b/IPython/html/static/tree/js/main.js
@@ -152,11 +152,11 @@ require([
     utils.load_extensions_from_config(cfg);
     utils.load_extensions_from_config(common_config);
     
-    // bound the upload method to the on change of the file select list
-    $("#alternate_upload").change(function (event){
-        notebook_list.handleFilesUpload(event,'form');
+    // bound the upload method to the on change of the file input
+    $("#upload-button :file").change(function (event){
+        notebook_list.handleFilesUpload(event,'button');
     });
-    
+
     // set hash on tab click
     $("#tabs").find("a").click(function(e) {
         // Prevent the document from jumping when the active tab is changed to a 

--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -131,13 +131,12 @@ define([
         }
     };
 
-    NotebookList.prototype.handleFilesUpload =  function(event, dropOrForm) {
+    NotebookList.prototype.handleFilesUpload =  function(event, source) {
         var that = this;
         var files;
-        if(dropOrForm =='drop'){
+        if(source =='drop'){
             files = event.originalEvent.dataTransfer.files;
-        } else 
-        {
+        } else {
             files = event.originalEvent.target.files;
         }
         for (var i = 0; i < files.length; i++) {

--- a/IPython/html/static/tree/less/altuploadform.less
+++ b/IPython/html/static/tree/less/altuploadform.less
@@ -1,29 +1,20 @@
-/* We need an invisible input field on top of the sentense*/
-/* "Drag file onto the list ..." */
-
-.alternate_upload
-{
-    background-color:none;
-    display: inline;
+/* We need an invisible input field on top of fake Upload button */
+.btn-file {
+    position: relative;
+    overflow: hidden;
 }
-
-.alternate_upload.form
-{
-    padding: 0;
-    margin:0;
-}
-
-.alternate_upload input.fileinput
-{
-    display: inline;
+.btn-file input[type=file] {
+    position: absolute;
+    top: 0;
+    right: 0;
+    min-width: 100%;
+    min-height: 100%;
+    font-size: 100px;
+    text-align: right;
+    filter: alpha(opacity=0);
     opacity: 0;
-    z-index: 2;
-    width: 12ex;
-    margin-right: -12ex;
-}
-
-.alternate_upload .input-overlay {
-    display: inline-block;
-    font-weight: bold;
-    line-height:1em;
+    outline: none;
+    background: white;
+    cursor: inherit;
+    display: block;
 }

--- a/IPython/html/static/tree/less/tree.less
+++ b/IPython/html/static/tree/less/tree.less
@@ -227,12 +227,6 @@ input.engine_num_input {
     margin-right: -1px;
 }
 
-ul#new-menu {
-    // align right instead of left
-    left: auto;
-    right: 0;
-}
-
 .kernel-menu-icon {
     padding-right: 12px;
     width: 24px;

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -24,54 +24,40 @@ data-terminals-available="{{terminals_available}}"
       <div class="tab-content">
         <div id="notebooks" class="tab-pane active">
           <div id="notebook_toolbar" class="row">
-            <div class="col-sm-8 no-padding">
-              <form id='alternate_upload'  class='alternate_upload'>
-                <span id="notebook_list_info">
-                To import a notebook, drag the file onto the listing below or
-                <span class="input-overlay">
-                <input type="file" name="datafile" class="fileinput" multiple='multiple'>
-                click here.
-                </span>
-                </span>
-              </form>
+            <button id="refresh_notebook_list" title="Refresh notebook list" class="btn btn-default btn-xs"><i class="fa fa-refresh"></i></button>
+            <div id="new-buttons" class="btn-group">
+              <button class="dropdown-toggle btn btn-default btn-xs" data-toggle="dropdown">
+                <span>New</span>
+                <span class="caret"></span>
+              </button>
+              <ul id="new-menu" class="dropdown-menu">
+                <li role="presentation" id="new-file">
+                  <a role="menuitem" tabindex="-1" href="#">Text File</a>
+                </li>
+                <li role="presentation" id="new-folder">
+                  <a role="menuitem" tabindex="-1" href="#">Folder</a>
+                </li>
+                {% if terminals_available %}
+                <li role="presentation" id="new-terminal">
+                  <a role="menuitem" tabindex="-1" href="#">Terminal</a>
+                </li>
+                {% else %}
+                <li role="presentation" id="new-terminal-disabled" class="disabled">
+                  <a role="menuitem" tabindex="-1" href="#">Terminals Unavailable</a>
+                </li>
+                {% endif %}
+                <li role="presentation" class="divider"></li>
+                <li role="presentation" class="dropdown-header" id="notebook-kernels">Notebooks</li>
+              </ul>
             </div>
-            <div class="col-sm-4 no-padding tree-buttons">
-              <div class="pull-right">
-                <div class="dynamic-buttons">
-                    <button title="Duplicate selected" class="duplicate-button btn btn-default btn-xs">Duplicate</button>
-                    <button title="Rename selected" class="rename-button btn btn-default btn-xs">Rename</button>
-                    <button title="Shutdown selected notebook(s)" class="shutdown-button btn btn-default btn-xs btn-warning">Shutdown</button>
-                    <button title="Deleted selected" class="delete-button btn btn-default btn-xs btn-danger"><i class="fa fa-trash"></i></button>
-                </div>
-                <div id="new-buttons" class="btn-group">
-                  <button class="dropdown-toggle btn btn-default btn-xs" data-toggle="dropdown">
-                  <span>New</span>
-                  <span class="caret"></span>
-                  </button>
-                  <ul id="new-menu" class="dropdown-menu">
-                    <li role="presentation" id="new-file">
-                      <a role="menuitem" tabindex="-1" href="#">Text File</a>
-                    </li>
-                    <li role="presentation" id="new-folder">
-                      <a role="menuitem" tabindex="-1" href="#">Folder</a>
-                    </li>
-                    {% if terminals_available %}
-                    <li role="presentation" id="new-terminal">
-                      <a role="menuitem" tabindex="-1" href="#">Terminal</a>
-                    </li>
-                    {% else %}
-                    <li role="presentation" id="new-terminal-disabled" class="disabled">
-                      <a role="menuitem" tabindex="-1" href="#">Terminals Unavailable</a>
-                    </li>
-                    {% endif %}
-                    <li role="presentation" class="divider"></li>
-                    <li role="presentation" class="dropdown-header" id="notebook-kernels">Notebooks</li>
-                  </ul>
-                </div>
-                <div class="btn-group">
-                    <button id="refresh_notebook_list" title="Refresh notebook list" class="btn btn-default btn-xs"><i class="fa fa-refresh"></i></button>
-                </div>
-              </div>
+            <span id="upload-button" class="btn btn-default btn-xs btn-file" title="Choose files to upload, or drag and drop them below">
+              Upload <input type="file" name="datafile" class="fileinput" multiple='multiple'>
+            </span>
+            <div class="dynamic-buttons">
+              <button title="Duplicate selected" class="duplicate-button btn btn-default btn-xs">Duplicate</button>
+              <button title="Rename selected" class="rename-button btn btn-default btn-xs">Rename</button>
+              <button title="Shutdown selected notebook(s)" class="shutdown-button btn btn-default btn-xs btn-warning">Shutdown</button>
+              <button title="Deleted selected" class="delete-button btn btn-default btn-xs btn-danger"><i class="fa fa-trash"></i></button>
             </div>
           </div>
           <div id="notebook_list">


### PR DESCRIPTION
Proposed solution for #7788
- Moves all dashboard buttons to the left side of the table
- Replaces long "import notebook" text with `Upload` button
- Always visible buttons placed leftmost.

In action:
![upload-button](https://cloud.githubusercontent.com/assets/7703352/6239179/9424ddca-b701-11e4-85f4-8cfaa8c6511f.gif)
