### PR TITLE
prioritize function token for inspection

### DIFF
--- a/IPython/utils/tests/test_tokenutil.py
+++ b/IPython/utils/tests/test_tokenutil.py
@@ -48,13 +48,28 @@ def test_multiline():
     start = cell.index(expected) + 1
     for i in range(start, start + len(expected)):
         expect_token(expected, cell, i)
-    expected = 'there'
+    expected = 'hello'
     start = cell.index(expected) + 1
     for i in range(start, start + len(expected)):
         expect_token(expected, cell, i)
 
+def test_nested_call():
+    cell = "foo(bar(a=5), b=10)"
+    expected = 'foo'
+    start = cell.index('bar') + 1
+    for i in range(start, start + 3):
+        expect_token(expected, cell, i)
+    expected = 'bar'
+    start = cell.index('a=')
+    for i in range(start, start + 3):
+        expect_token(expected, cell, i)
+    expected = 'foo'
+    start = cell.index(')') + 1
+    for i in range(start, len(cell)-1):
+        expect_token(expected, cell, i)
+
 def test_attrs():
-    cell = "foo(a=obj.attr.subattr)"
+    cell = "a = obj.attr.subattr"
     expected = 'obj'
     idx = cell.find('obj') + 1
     for i in range(idx, idx + 3):


### PR DESCRIPTION
```
foo(a=str.|
```

will now find `foo` instead of `str`

```
foo(a=bar(b=str|
```

will find `bar`

and

```
foo(a=bar(b=str()), c|
```

will find `foo` again

might close #7816
