### PR TITLE
Docs: Replace examples/lib and inprocess with examples/Embedding

### DIFF
--- a/docs/source/interactive/qtconsole.rst
+++ b/docs/source/interactive/qtconsole.rst
@@ -626,14 +626,14 @@ command-line application), there are a few options:
   objects in your application.
 
 * Start a standard IPython kernel in the process of the external Qt
-  application.  See :file:`examples/lib/ipkernel_qtapp.py` for an example.  Due
+  application. See :file:`examples/Embedding/ipkernel_qtapp.py` for an example. Due
   to IPython's two-process model, the QtConsole itself will live in another
   process with its own QApplication, and thus cannot be embedded in the main
   GUI.
 
 * Start a special IPython kernel, the
   :class:`IPython.kernel.inprocess.ipkernel.InProcessKernel`, that allows a
-  QtConsole in the same process. See :file:`examples/inprocess/embedded_qtconsole.py`
+  QtConsole in the same process. See :file:`examples/Embedding/inprocess_qtconsole.py`
   for an example. While the QtConsole can now be embedded in the main GUI, one
   cannot connect to the kernel from other consoles as there are no real ZMQ
   sockets anymore.

--- a/docs/source/interactive/reference.rst
+++ b/docs/source/interactive/reference.rst
@@ -853,7 +853,7 @@ Second, when using the ``PyOSInputHook`` approach, a GUI application should
 in IPython and as standalone apps need to have special code to detects how the
 application is being run. We highly recommend using IPython's support for this.
 Since the details vary slightly between toolkits, we point you to the various
-examples in our source directory :file:`examples/lib` that demonstrate
+examples in our source directory :file:`examples/Embedding` that demonstrate
 these capabilities.
 
 Third, unlike previous versions of IPython, we no longer "hijack" (replace
@@ -862,7 +862,7 @@ actually need to run the real event loops to do so. This is often needed to
 process pending events at critical points.
 
 Finally, we also have a number of examples in our source directory
-:file:`examples/lib` that demonstrate these capabilities.
+:file:`examples/Embedding` that demonstrate these capabilities.
 
 PyQt and PySide
 ---------------


### PR DESCRIPTION
There might be other instances in the docs that need file path updates, but these are the ones I've found while trying to figure out why matplotlib-related IPython processes hang around after I close my custom qtconsole app.
