### PR TITLE
Adding a Color trait type and using it for widget styling

### DIFF
--- a/IPython/html/widgets/__init__.py
+++ b/IPython/html/widgets/__init__.py
@@ -1,5 +1,7 @@
 from .widget import Widget, DOMWidget, CallbackDispatcher, register
 
+from .trait_types import Color
+
 from .widget_bool import Checkbox, ToggleButton
 from .widget_button import Button
 from .widget_box import Box, FlexBox, HBox, VBox

--- a/IPython/html/widgets/tests/test_traits.py
+++ b/IPython/html/widgets/tests/test_traits.py
@@ -1,0 +1,20 @@
+"""Test trait types of the widget packages."""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from unittest import TestCase
+from IPython.utils.traitlets import HasTraits
+from IPython.utils.tests.test_traitlets import TraitTestBase
+from IPython.html.widgets import Color
+
+
+class ColorTrait(HasTraits):
+    value = Color("black")
+
+
+class TestColor(TraitTestBase):
+    obj = ColorTrait()
+
+    _good_values = ["blue", "#AA0", "#FFFFFF"]
+    _bad_values = ["vanilla", "blues"]

--- a/IPython/html/widgets/trait_types.py
+++ b/IPython/html/widgets/trait_types.py
@@ -1,0 +1,29 @@
+# encoding: utf-8
+"""
+Trait types for html widgets.
+"""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import re
+from IPython.utils import traitlets
+
+#-----------------------------------------------------------------------------
+# Utilities
+#-----------------------------------------------------------------------------
+
+_color_names = ['aliceblue', 'antiquewhite', 'aqua', 'aquamarine', 'azure', 'beige', 'bisque', 'black', 'blanchedalmond', 'blue', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'fuchsia', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'gray', 'green', 'greenyellow', 'honeydew', 'hotpink', 'indianred ', 'indigo ', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightsteelblue', 'lightyellow', 'lime', 'limegreen', 'linen', 'magenta', 'maroon', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'navy', 'oldlace', 'olive', 'olivedrab', 'orange', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'purple', 'rebeccapurple', 'red', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'silver', 'skyblue', 'slateblue', 'slategray', 'snow', 'springgreen', 'steelblue', 'tan', 'teal', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'white', 'whitesmoke', 'yellow', 'yellowgreen'] 
+_color_re = re.compile(r'#[a-fA-F0-9]{3}(?:[a-fA-F0-9]{3})?$')
+
+
+class Color(traitlets._CoercedString):
+    """A string holding a valid HTML color such as 'blue', '#060482', '#A80'"""
+ 
+    info_text = 'a valid HTML color'
+
+    def validate(self, obj, value):
+        value = self._coerce_str(obj, value)
+        if value.lower() in _color_names or _color_re.match(value):
+            return value
+        self.error(obj, value)

--- a/IPython/html/widgets/trait_types.py
+++ b/IPython/html/widgets/trait_types.py
@@ -17,13 +17,12 @@ _color_names = ['aliceblue', 'antiquewhite', 'aqua', 'aquamarine', 'azure', 'bei
 _color_re = re.compile(r'#[a-fA-F0-9]{3}(?:[a-fA-F0-9]{3})?$')
 
 
-class Color(traitlets._CoercedString):
+class Color(traitlets.Unicode):
     """A string holding a valid HTML color such as 'blue', '#060482', '#A80'"""
  
     info_text = 'a valid HTML color'
 
     def validate(self, obj, value):
-        value = self._coerce_str(obj, value)
         if value.lower() in _color_names or _color_re.match(value):
             return value
         self.error(obj, value)

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -20,7 +20,7 @@ from IPython.kernel.comm import Comm
 from IPython.config import LoggingConfigurable
 from IPython.utils.importstring import import_item
 from IPython.utils.traitlets import Unicode, Dict, Instance, Bool, List, \
-    CaselessStrEnum, Tuple, CUnicode, Int, Set
+    CaselessStrEnum, Tuple, CUnicode, Int, Set, Color
 from IPython.utils.py3compat import string_types
 
 #-----------------------------------------------------------------------------
@@ -438,9 +438,9 @@ class DOMWidget(Widget):
     padding = CUnicode(sync=True)
     margin = CUnicode(sync=True)
 
-    color = Unicode(sync=True)
-    background_color = Unicode(sync=True)
-    border_color = Unicode(sync=True)
+    color = Color(None, allow_none=True, sync=True)
+    background_color = Color(None, allow_none=True, sync=True)
+    border_color = Color(None, allow_none=True, sync=True)
 
     border_width = CUnicode(sync=True)
     border_radius = CUnicode(sync=True)

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -20,8 +20,9 @@ from IPython.kernel.comm import Comm
 from IPython.config import LoggingConfigurable
 from IPython.utils.importstring import import_item
 from IPython.utils.traitlets import Unicode, Dict, Instance, Bool, List, \
-    CaselessStrEnum, Tuple, CUnicode, Int, Set, Color
+    CaselessStrEnum, Tuple, CUnicode, Int, Set
 from IPython.utils.py3compat import string_types
+from .trait_types import Color
 
 #-----------------------------------------------------------------------------
 # Classes

--- a/IPython/html/widgets/widget_float.py
+++ b/IPython/html/widgets/widget_float.py
@@ -14,7 +14,8 @@ Represents an unbounded float using a widget.
 # Imports
 #-----------------------------------------------------------------------------
 from .widget import DOMWidget, register
-from IPython.utils.traitlets import Unicode, CFloat, Bool, CaselessStrEnum, Tuple, Color
+from .trait_types import Color
+from IPython.utils.traitlets import Unicode, CFloat, Bool, CaselessStrEnum, Tuple
 from IPython.utils.warn import DeprecatedClass
 
 #-----------------------------------------------------------------------------

--- a/IPython/html/widgets/widget_float.py
+++ b/IPython/html/widgets/widget_float.py
@@ -14,7 +14,7 @@ Represents an unbounded float using a widget.
 # Imports
 #-----------------------------------------------------------------------------
 from .widget import DOMWidget, register
-from IPython.utils.traitlets import Unicode, CFloat, Bool, CaselessStrEnum, Tuple
+from IPython.utils.traitlets import Unicode, CFloat, Bool, CaselessStrEnum, Tuple, Color
 from IPython.utils.warn import DeprecatedClass
 
 #-----------------------------------------------------------------------------
@@ -133,7 +133,7 @@ class FloatSlider(_BoundedFloat):
         default_value='horizontal', help="Vertical or horizontal.", sync=True)
     _range = Bool(False, help="Display a range selector", sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.", sync=True)
-    slider_color = Unicode(sync=True)
+    slider_color = Color(None, allow_none=True, sync=True)
 
 
 @register('IPython.FloatProgress')
@@ -287,7 +287,7 @@ class FloatRangeSlider(_BoundedFloatRange):
         default_value='horizontal', help="Vertical or horizontal.", sync=True)
     _range = Bool(True, help="Display a range selector", sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.", sync=True)
-    slider_color = Unicode(sync=True)
+    slider_color = Color(None, allow_none=True, sync=True)
 
 # Remove in IPython 4.0
 FloatTextWidget = DeprecatedClass(FloatText, 'FloatTextWidget')

--- a/IPython/html/widgets/widget_int.py
+++ b/IPython/html/widgets/widget_int.py
@@ -14,7 +14,7 @@ Represents an unbounded int using a widget.
 # Imports
 #-----------------------------------------------------------------------------
 from .widget import DOMWidget, register
-from IPython.utils.traitlets import Unicode, CInt, Bool, CaselessStrEnum, Tuple
+from IPython.utils.traitlets import Unicode, CInt, Bool, CaselessStrEnum, Tuple, Color
 from IPython.utils.warn import DeprecatedClass
 
 #-----------------------------------------------------------------------------
@@ -87,7 +87,7 @@ class IntSlider(_BoundedInt):
         default_value='horizontal', help="Vertical or horizontal.", sync=True)
     _range = Bool(False, help="Display a range selector", sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.", sync=True)
-    slider_color = Unicode(sync=True)
+    slider_color = Color(None, allow_none=True, sync=True)
 
 
 @register('IPython.IntProgress')
@@ -198,7 +198,7 @@ class IntRangeSlider(_BoundedIntRange):
         default_value='horizontal', help="Vertical or horizontal.", sync=True)
     _range = Bool(True, help="Display a range selector", sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.", sync=True)
-    slider_color = Unicode(sync=True)
+    slider_color = Color(None, allow_none=True, sync=True)
 
 # Remove in IPython 4.0
 IntTextWidget = DeprecatedClass(IntText, 'IntTextWidget')

--- a/IPython/html/widgets/widget_int.py
+++ b/IPython/html/widgets/widget_int.py
@@ -14,7 +14,8 @@ Represents an unbounded int using a widget.
 # Imports
 #-----------------------------------------------------------------------------
 from .widget import DOMWidget, register
-from IPython.utils.traitlets import Unicode, CInt, Bool, CaselessStrEnum, Tuple, Color
+from .trait_types import Color
+from IPython.utils.traitlets import Unicode, CInt, Bool, CaselessStrEnum, Tuple
 from IPython.utils.warn import DeprecatedClass
 
 #-----------------------------------------------------------------------------

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -17,7 +17,7 @@ from nose import SkipTest
 
 from IPython.utils.traitlets import (
     HasTraits, MetaHasTraits, TraitType, Any, Bool, CBytes, Dict, Enum,
-    Int, Long, Integer, Float, Complex, Bytes, Unicode, TraitError,
+    Int, Long, Integer, Float, Complex, Bytes, Unicode, Color, TraitError,
     Union, Undefined, Type, This, Instance, TCPAddress, List, Tuple,
     ObjectName, DottedObjectName, CRegExp, link, directional_link,
     EventfulList, EventfulDict, ForwardDeclaredType, ForwardDeclaredInstance,
@@ -918,8 +918,17 @@ class TestDottedObjectName(TraitTestBase):
         _good_values.append(u"t.þ")
 
 
-class TCPAddressTrait(HasTraits):
+class ColorTrait(HasTraits):
+    value = Color("black")
 
+class TestColor(TraitTestBase):
+    obj = ColorTrait()
+
+    _good_values = ["blue", "#AA0", "#FFFFFF"]
+    _bad_values = ["vanilla", "blues"]
+
+
+class TCPAddressTrait(HasTraits):
     value = TCPAddress()
 
 class TestTCPAddress(TraitTestBase):
@@ -978,6 +987,19 @@ class TestInstanceList(TraitTestBase):
     _default_value = []
     _good_values = [[Foo(), Foo(), None], []]
     _bad_values = [['1', 2,], '1', [Foo], None]
+
+class UnionListTrait(HasTraits):
+
+    value = List(Int() | Bool())
+
+class TestUnionListTrait(HasTraits):
+
+    obj = UnionListTrait()
+
+    _default_value = []
+    _good_values = [[True, 1], [False, True]]
+    _bad_values = [[1, 'True'], False]
+
 
 class LenListTrait(HasTraits):
 

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -17,7 +17,7 @@ from nose import SkipTest
 
 from IPython.utils.traitlets import (
     HasTraits, MetaHasTraits, TraitType, Any, Bool, CBytes, Dict, Enum,
-    Int, Long, Integer, Float, Complex, Bytes, Unicode, Color, TraitError,
+    Int, Long, Integer, Float, Complex, Bytes, Unicode, TraitError,
     Union, Undefined, Type, This, Instance, TCPAddress, List, Tuple,
     ObjectName, DottedObjectName, CRegExp, link, directional_link,
     EventfulList, EventfulDict, ForwardDeclaredType, ForwardDeclaredInstance,
@@ -916,16 +916,6 @@ class TestDottedObjectName(TraitTestBase):
         _bad_values.append(u"t.þ")
     else:
         _good_values.append(u"t.þ")
-
-
-class ColorTrait(HasTraits):
-    value = Color("black")
-
-class TestColor(TraitTestBase):
-    obj = ColorTrait()
-
-    _good_values = ["blue", "#AA0", "#FFFFFF"]
-    _bad_values = ["vanilla", "blues"]
 
 
 class TCPAddressTrait(HasTraits):

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -1288,14 +1288,19 @@ class CUnicode(Unicode):
             self.error(obj, value)
 
 
-class _CoercedString(TraitType):
+class ObjectName(TraitType):
+    """A string holding a valid object name in this version of Python.
+
+    This does not check that the name exists in any scope."""
+    info_text = "a valid object identifier in Python"
 
     if py3compat.PY3:
         # Python 3:
-        _coerce_str = staticmethod(lambda _,s: s)
+        coerce_str = staticmethod(lambda _,s: s)
+
     else:
         # Python 2:
-        def _coerce_str(self, obj, value):
+        def coerce_str(self, obj, value):
             "In Python 2, coerce ascii-only unicode to str"
             if isinstance(value, unicode):
                 try:
@@ -1304,27 +1309,17 @@ class _CoercedString(TraitType):
                     self.error(obj, value)
             return value
 
-
-class ObjectName(_CoercedString):
-    """A string holding a valid object name in this version of Python.
-
-    This does not check that the name exists in any scope."""
-
-    info_text = "a valid object identifier in Python"
-
     def validate(self, obj, value):
-        value = self._coerce_str(obj, value)
+        value = self.coerce_str(obj, value)
 
         if isinstance(value, string_types) and py3compat.isidentifier(value):
             return value
         self.error(obj, value)
 
-
 class DottedObjectName(ObjectName):
     """A string holding a valid dotted object name in Python, such as A.b3._c"""
-
     def validate(self, obj, value):
-        value = self._coerce_str(obj, value)
+        value = self.coerce_str(obj, value)
 
         if isinstance(value, string_types) and py3compat.isidentifier(value, dotted=True):
             return value

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -1331,22 +1331,6 @@ class DottedObjectName(ObjectName):
         self.error(obj, value)
 
 
-_color_names = ['aliceblue', 'antiquewhite', 'aqua', 'aquamarine', 'azure', 'beige', 'bisque', 'black', 'blanchedalmond', 'blue', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'fuchsia', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'gray', 'green', 'greenyellow', 'honeydew', 'hotpink', 'indianred ', 'indigo ', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightsteelblue', 'lightyellow', 'lime', 'limegreen', 'linen', 'magenta', 'maroon', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'navy', 'oldlace', 'olive', 'olivedrab', 'orange', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'purple', 'rebeccapurple', 'red', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'silver', 'skyblue', 'slateblue', 'slategray', 'snow', 'springgreen', 'steelblue', 'tan', 'teal', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'white', 'whitesmoke', 'yellow', 'yellowgreen'] 
-_color_re = re.compile(r'#[a-fA-F0-9]{3}(?:[a-fA-F0-9]{3})?$')
-
-
-class Color(_CoercedString):
-    """A string holding a valid HTML color such as 'blue', '#060482', '#A80'"""
- 
-    info_text = 'a valid HTML color'
-
-    def validate(self, obj, value):
-        value = self._coerce_str(obj, value)
-        if value.lower() in _color_names or _color_re.match(value):
-            return value
-        self.error(obj, value)
-
-
 class Bool(TraitType):
     """A boolean (True, False) trait."""
 

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -1288,19 +1288,14 @@ class CUnicode(Unicode):
             self.error(obj, value)
 
 
-class ObjectName(TraitType):
-    """A string holding a valid object name in this version of Python.
-
-    This does not check that the name exists in any scope."""
-    info_text = "a valid object identifier in Python"
+class _CoercedString(TraitType):
 
     if py3compat.PY3:
         # Python 3:
-        coerce_str = staticmethod(lambda _,s: s)
-
+        _coerce_str = staticmethod(lambda _,s: s)
     else:
         # Python 2:
-        def coerce_str(self, obj, value):
+        def _coerce_str(self, obj, value):
             "In Python 2, coerce ascii-only unicode to str"
             if isinstance(value, unicode):
                 try:
@@ -1309,19 +1304,45 @@ class ObjectName(TraitType):
                     self.error(obj, value)
             return value
 
+
+class ObjectName(_CoercedString):
+    """A string holding a valid object name in this version of Python.
+
+    This does not check that the name exists in any scope."""
+
+    info_text = "a valid object identifier in Python"
+
     def validate(self, obj, value):
-        value = self.coerce_str(obj, value)
+        value = self._coerce_str(obj, value)
 
         if isinstance(value, string_types) and py3compat.isidentifier(value):
             return value
         self.error(obj, value)
 
+
 class DottedObjectName(ObjectName):
     """A string holding a valid dotted object name in Python, such as A.b3._c"""
+
     def validate(self, obj, value):
-        value = self.coerce_str(obj, value)
+        value = self._coerce_str(obj, value)
 
         if isinstance(value, string_types) and py3compat.isidentifier(value, dotted=True):
+            return value
+        self.error(obj, value)
+
+
+_color_names = ['aliceblue', 'antiquewhite', 'aqua', 'aquamarine', 'azure', 'beige', 'bisque', 'black', 'blanchedalmond', 'blue', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'fuchsia', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'gray', 'green', 'greenyellow', 'honeydew', 'hotpink', 'indianred ', 'indigo ', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightsteelblue', 'lightyellow', 'lime', 'limegreen', 'linen', 'magenta', 'maroon', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'navy', 'oldlace', 'olive', 'olivedrab', 'orange', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'purple', 'rebeccapurple', 'red', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'silver', 'skyblue', 'slateblue', 'slategray', 'snow', 'springgreen', 'steelblue', 'tan', 'teal', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'white', 'whitesmoke', 'yellow', 'yellowgreen'] 
+_color_re = re.compile(r'#[a-fA-F0-9]{3}(?:[a-fA-F0-9]{3})?$')
+
+
+class Color(_CoercedString):
+    """A string holding a valid HTML color such as 'blue', '#060482', '#A80'"""
+ 
+    info_text = 'a valid HTML color'
+
+    def validate(self, obj, value):
+        value = self._coerce_str(obj, value)
+        if value.lower() in _color_names or _color_re.match(value):
             return value
         self.error(obj, value)
 


### PR DESCRIPTION
Adding a color trait type that validates that the provided string is a valid color.
In widgets, defaulting it to `None`. (And when it is None, the css naturally takes over.)
