### PR TITLE
Minor refactoring in FileContentsManager to allow for non-ipynb extensions

### DIFF
--- a/IPython/html/services/contents/filemanager.py
+++ b/IPython/html/services/contents/filemanager.py
@@ -55,6 +55,8 @@ def _post_save_script(model, os_path, contents_manager, **kwargs):
 class FileContentsManager(FileManagerMixin, ContentsManager):
 
     root_dir = Unicode(config=True)
+    
+    _nb_file_extensions = ['.ipynb']
 
     def _root_dir_default(self):
         try:
@@ -343,7 +345,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
                 raise web.HTTPError(400,
                                 u'%s is a directory, not a %s' % (path, type), reason='bad type')
             model = self._dir_model(path, content=content)
-        elif type == 'notebook' or (type is None and path.endswith('.ipynb')):
+        elif type == 'notebook' or (type is None and path.endswith(self._nb_file_extensions)):
             model = self._notebook_model(path, content=content)
         else:
             if type == 'directory':


### PR DESCRIPTION
Opening this just for discussion for now. In my [ipymd](https://github.com/rossant/ipymd) library, I'm replacing the ipynb format by Markdown. When deriving FileContentsManager, I need to copy-paste a couple of methods just to modify a few lines in them. This makes it a bit inconvenient to maintain.

Is it conceivable to refactor things a bit to facilitate the customization of notebook load/save?

Related to 7275.
