### PR TITLE
exit if cwd doesn't exist

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -170,9 +170,9 @@ class BaseIPythonApplication(Application):
         try:
             directory = py3compat.getcwd()
         except:
-            # raise exception
+            # exit if cwd doesn't exist
             self.log.error("Current working directory doesn't exist.")
-            raise
+            self.exit(1)
 
     #-------------------------------------------------------------------------
     # Various stages of Application creation


### PR DESCRIPTION
instead of raising the error

avoids traceback, leaving only:

```
[AppName] ERROR | Current working directory doesn't exist.
```

closes #7835
