### PR TITLE
Ridiculously easy notebook extension setup scripts.

### DIFF
--- a/IPython/html/nbextensions.py
+++ b/IPython/html/nbextensions.py
@@ -257,9 +257,9 @@ def make_cmdclass(path, enable=None):
     Usage
     -----
     setup(
-        name='cite2c',
+        name='flightwidgets',
         ...
-        cmdclass=make_cmdclass('cite2c', 'cite2c/main'),
+        cmdclass=make_cmdclass('flightwidgets', 'flightwidgets/init'),
     )
     """
 

--- a/IPython/html/nbextensions.py
+++ b/IPython/html/nbextensions.py
@@ -243,11 +243,13 @@ def install_nbextension(path, overwrite=False, symlink=False, user=False, prefix
             _maybe_copy(src, full_dest, verbose)
 
 
-def make_cmdclass(path, enable=None):
+def make_cmdclass(setupfile, path, enable=None):
     """Build nbextension cmdclass dict for the setuptools.setup method.
 
     Parameters
     ----------
+    setupfile: str
+        Path to the setup file.
     path: str
         Directory relative to the setup file that the nbextension code lives in.
     enable: [str=None]
@@ -259,7 +261,7 @@ def make_cmdclass(path, enable=None):
     setup(
         name='flightwidgets',
         ...
-        cmdclass=make_cmdclass('flightwidgets', 'flightwidgets/init'),
+        cmdclass=make_cmdclass(__file__, 'flightwidgets', 'flightwidgets/init'),
     )
     """
 
@@ -270,7 +272,7 @@ def make_cmdclass(path, enable=None):
     from .services.config import ConfigManager
 
     def run_nbextension_install(develop):
-        install_nbextension(join(dirname(abspath(__file__)), path), symlink=develop)
+        install_nbextension(join(dirname(abspath(setupfile)), path), symlink=develop)
         if enable is not None:
             print("Enabling the extension ...")
             cm = ConfigManager()


### PR DESCRIPTION
Hey guys,

I've been managing **a lot** of _Python module / nbextension_ combination plugins for the notebook, trying to update them all for the 3.0 release.  I'm copying and pasting code around which is always a bad sign.

This PR aims to completely eliminate that!
I think it's most convenient for the user if they can navigate into your package's directory and simply `pip install .` or `pip install -e .`!

Assuming your setup.py looks like this without nbextension support:

``` py
# -*- coding: utf-8 -*-
from setuptools import setup
setup(
    name='jsobject',
   # .. A bunch of stuff here ...
)
```

Adding nbextension support looks like this (only the last line changed):

``` py
# -*- coding: utf-8 -*-
from setuptools import setup
from IPython.html.nbextensions import make_cmdclass
setup(
    name='jsobject',
   # .. A bunch of stuff here ...
    cmdclass=make_cmdclass(__file__, 'jsobject', 'jsobject/backend_context'),
)
```

Alternatively, if I didn't want `jsobject/backend_context.js` to be ran on notebook load (such is the case with widget plugins), the command would just be `make_cmdclass(__file__, 'jsobject')`.

Ping @rgbkrk who will like this.

EDIT: I should clarify, in the example I give, all of the JS code exists in `./jsobject/` relative to `setup.py`.
