### PR TITLE
rethrow upstream HTTP errors

### DIFF
--- a/IPython/nbconvert/postprocessors/serve.py
+++ b/IPython/nbconvert/postprocessors/serve.py
@@ -1,16 +1,9 @@
 """PostProcessor for serving reveal.js HTML slideshows."""
-from __future__ import print_function
-#-----------------------------------------------------------------------------
-#Copyright (c) 2013, the IPython Development Team.
-#
-#Distributed under the terms of the Modified BSD License.
-#
-#The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from __future__ import print_function
 
 import os
 import webbrowser
@@ -22,9 +15,6 @@ from IPython.utils.traitlets import Bool, Unicode, Int
 
 from .base import PostProcessorBase
 
-#-----------------------------------------------------------------------------
-# Classes
-#-----------------------------------------------------------------------------
 
 class ProxyHandler(web.RequestHandler):
     """handler the proxies requests from a local prefix to a CDN"""
@@ -37,11 +27,14 @@ class ProxyHandler(web.RequestHandler):
     
     def finish_get(self, response):
         """finish the request"""
-        # copy potentially relevant headers
+        # rethrow errors
+        response.rethrow()
+        
         for header in ["Content-Type", "Cache-Control", "Date", "Last-Modified", "Expires"]:
             if header in response.headers:
                 self.set_header(header, response.headers[header])
         self.finish(response.body)
+
 
 class ServePostProcessor(PostProcessorBase):
     """Post processor designed to serve files


### PR DESCRIPTION
in ServePostProcessor

If the proxied request to the CDN fails, rethrow the error.

We were ignoring errors and sending an empty body. Re-raising the error shows the informative:

> The 'certifi' package is required to use https in simple_httpclient

Tornado requires certifi to make HTTPS requests. When installed via conda, it's possible to get tornado without certifi. If you `pip install tornado`, certifi is a dependency, so the failure in #7829 should only affect conda users. This is a bug in the conda package that tornado doesn't depend on certifi, but A `pip install certifi` after the fact makes HTTPS work, so it's not a big deal, and the error message makes it clear what to do.

closes #7829
