### PR TITLE
catch IOError in addition to OSError

### DIFF
--- a/IPython/html/services/contents/fileio.py
+++ b/IPython/html/services/contents/fileio.py
@@ -61,7 +61,7 @@ class FileManagerMixin(object):
         """context manager for turning permission errors into 403."""
         try:
             yield
-        except OSError as e:
+        except (OSError, IOError) as e:
             if e.errno in {errno.EPERM, errno.EACCES}:
                 # make 403 error message without root prefix
                 # this may not work perfectly on unicode paths on Python 2,


### PR DESCRIPTION
IOError is a subclass of OSError on py3, but not py2

closes #7848
