### PR TITLE
handle unicode/str in pretty, str formatter

### DIFF
--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -27,13 +27,8 @@ from IPython.utils.traitlets import (
     ForwardDeclaredInstance,
 )
 from IPython.utils.py3compat import (
-    unicode_to_str, with_metaclass, PY3, string_types, unicode_type,
+    with_metaclass, string_types, unicode_type,
 )
-
-if PY3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
 
 
 #-----------------------------------------------------------------------------
@@ -681,13 +676,13 @@ class PlainTextFormatter(BaseFormatter):
         if not self.pprint:
             return repr(obj)
         else:
-            # This uses use StringIO, as cStringIO doesn't handle unicode.
-            stream = StringIO()
-            # self.newline.encode() is a quick fix for issue gh-597. We need to
-            # ensure that stream does not get a mix of unicode and bytestrings,
-            # or it will cause trouble.
+            # handle str and unicode on Python 2
+            # io.StringIO only accepts unicode,
+            # cStringIO doesn't handle unicode on py2,
+            # StringIO allows str, unicode but only ascii str
+            stream = pretty.CUnicodeIO()
             printer = pretty.RepresentationPrinter(stream, self.verbose,
-                self.max_width, unicode_to_str(self.newline),
+                self.max_width, self.newline,
                 max_seq_length=self.max_seq_length,
                 singleton_pprinters=self.singleton_printers,
                 type_pprinters=self.type_printers,

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -111,12 +111,9 @@ import re
 import datetime
 from collections import deque
 
-from IPython.utils.py3compat import PY3
+from IPython.utils.py3compat import PY3, cast_unicode
 
-if PY3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from io import StringIO
 
 
 __all__ = ['pretty', 'pprint', 'PrettyPrinter', 'RepresentationPrinter',
@@ -137,11 +134,20 @@ def _safe_getattr(obj, attr, default=None):
     except Exception:
         return default
 
+if PY3:
+    CUnicodeIO = StringIO
+else:
+    class CUnicodeIO(StringIO):
+        """StringIO that casts str to unicode on Python 2"""
+        def write(self, text):
+            return super(CUnicodeIO, self).write(cast_unicode(text))
+
+
 def pretty(obj, verbose=False, max_width=79, newline='\n', max_seq_length=MAX_SEQ_LENGTH):
     """
     Pretty print the object's representation.
     """
-    stream = StringIO()
+    stream = CUnicodeIO()
     printer = RepresentationPrinter(stream, verbose, max_width, newline, max_seq_length)
     printer.pretty(obj)
     printer.flush()

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 """Tests for IPython.lib.pretty."""
 
 # Copyright (c) IPython Development Team.
@@ -5,13 +6,11 @@
 
 from __future__ import print_function
 
-# Third-party imports
 import nose.tools as nt
 
-# Our own imports
 from IPython.lib import pretty
 from IPython.testing.decorators import skip_without
-from IPython.utils.py3compat import PY3
+from IPython.utils.py3compat import PY3, unicode_to_str
 
 if PY3:
     from io import StringIO
@@ -236,6 +235,21 @@ ClassWithMeta = MetaClass('ClassWithMeta')
 def test_metaclass_repr():
     output = pretty.pretty(ClassWithMeta)
     nt.assert_equal(output, "[CUSTOM REPR FOR CLASS ClassWithMeta]")
+
+
+def test_unicode_repr():
+    u = u"üniço∂é"
+    ustr = unicode_to_str(u)
+    
+    class C(object):
+        def __repr__(self):
+            return ustr
+    
+    c = C()
+    p = pretty.pretty(c)
+    nt.assert_equal(p, u)
+    p = pretty.pretty([c])
+    nt.assert_equal(p, u'[%s]' % u)
 
 
 def test_basic_class():


### PR DESCRIPTION
by casting str to unicode on Python 2

need to do some more thorough testing to see if this doesn't bork anything.

closes #7845
