### PR TITLE
don't force instantiation of extra, unused contents manager

### DIFF
--- a/IPython/html/services/sessions/sessionmanager.py
+++ b/IPython/html/services/sessions/sessionmanager.py
@@ -16,7 +16,7 @@ from IPython.utils.traitlets import Instance
 class SessionManager(LoggingConfigurable):
 
     kernel_manager = Instance('IPython.html.services.kernels.kernelmanager.MappingKernelManager')
-    contents_manager = Instance('IPython.html.services.contents.manager.ContentsManager', args=())
+    contents_manager = Instance('IPython.html.services.contents.manager.ContentsManager')
     
     # Session database initialized below
     _cursor = None


### PR DESCRIPTION
this is never used and never needed, and results in the instantiation of a contents manager that is immediately discarded.

closes #7849
