### PR TITLE
Don't allow stdin in Execute Preprocessor

### DIFF
--- a/IPython/nbconvert/preprocessors/execute.py
+++ b/IPython/nbconvert/preprocessors/execute.py
@@ -55,7 +55,7 @@ class ExecutePreprocessor(Preprocessor):
         return cell, resources
 
     def run_cell(self, cell):
-        msg_id = self.kc.execute(cell.source)
+        msg_id = self.kc.execute(cell.source, allow_stdin=False)
         self.log.debug("Executing cell:\n%s", cell.source)
         # wait for finish, with timeout
         while True:


### PR DESCRIPTION
Execute Preprocessor is most likely not interactive, so
it make sens not to allow `stdin`, or execution will hang.

Should close #7880 if I understand the problem correctly.

Should we make that a configurable ?
