### PR TITLE
Disable stdin in ExecutePreprocessor

### DIFF
--- a/IPython/nbconvert/preprocessors/execute.py
+++ b/IPython/nbconvert/preprocessors/execute.py
@@ -26,11 +26,6 @@ class ExecutePreprocessor(Preprocessor):
         help="The time to wait (in seconds) for output from executions."
     )
 
-    allow_stdin = Bool(
-        False, config=True, 
-        help="Whether stdin should be enabled when executing cells"
-    )
-    
     extra_arguments = List(Unicode)
 
     def preprocess(self, nb, resources):
@@ -41,7 +36,7 @@ class ExecutePreprocessor(Preprocessor):
                         extra_arguments=self.extra_arguments,
                         stderr=open(os.devnull, 'w')) as kc:
             self.kc = kc
-            self.kc.allow_stdin = self.allow_stdin
+            self.kc.allow_stdin = False
             nb, resources = super(ExecutePreprocessor, self).preprocess(nb, resources)
         return nb, resources
 

--- a/IPython/nbconvert/preprocessors/execute.py
+++ b/IPython/nbconvert/preprocessors/execute.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     from Queue import Empty  # Py 2
 
-from IPython.utils.traitlets import List, Unicode, Bool
+from IPython.utils.traitlets import List, Unicode
 
 from IPython.nbformat.v4 import output_from_msg
 from .base import Preprocessor
@@ -25,7 +25,7 @@ class ExecutePreprocessor(Preprocessor):
     timeout = Integer(30, config=True,
         help="The time to wait (in seconds) for output from executions."
     )
-
+    
     extra_arguments = List(Unicode)
 
     def preprocess(self, nb, resources):

--- a/IPython/nbconvert/preprocessors/execute.py
+++ b/IPython/nbconvert/preprocessors/execute.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     from Queue import Empty  # Py 2
 
-from IPython.utils.traitlets import List, Unicode
+from IPython.utils.traitlets import List, Unicode, Bool
 
 from IPython.nbformat.v4 import output_from_msg
 from .base import Preprocessor
@@ -25,6 +25,11 @@ class ExecutePreprocessor(Preprocessor):
     timeout = Integer(30, config=True,
         help="The time to wait (in seconds) for output from executions."
     )
+
+    allow_stdin = Bool(
+        False, config=True, 
+        help="Whether stdin should be enabled when executing cells"
+    )
     
     extra_arguments = List(Unicode)
 
@@ -36,6 +41,7 @@ class ExecutePreprocessor(Preprocessor):
                         extra_arguments=self.extra_arguments,
                         stderr=open(os.devnull, 'w')) as kc:
             self.kc = kc
+            self.kc.allow_stdin = self.allow_stdin
             nb, resources = super(ExecutePreprocessor, self).preprocess(nb, resources)
         return nb, resources
 

--- a/IPython/nbconvert/preprocessors/tests/files/Disable Stdin.ipynb
+++ b/IPython/nbconvert/preprocessors/tests/files/Disable Stdin.ipynb
@@ -8,29 +8,16 @@
    },
    "outputs": [],
    "source": [
+    "try:\n",
+    "    input = raw_input\n",
+    "except:\n",
+    "    pass\n",
+    "\n",
     "name = input(\"name: \")"
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.2"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/IPython/nbconvert/preprocessors/tests/files/Disable Stdin.ipynb
+++ b/IPython/nbconvert/preprocessors/tests/files/Disable Stdin.ipynb
@@ -1,0 +1,36 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "name = input(\"name: \")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/IPython/nbconvert/preprocessors/tests/test_execute.py
+++ b/IPython/nbconvert/preprocessors/tests/test_execute.py
@@ -89,4 +89,18 @@ class TestExecute(PreprocessorTestsBase):
                     del cell['execution_count']
                 cell['outputs'] = []
             output_nb, _ = preprocessor(cleaned_input_nb, res)
-            self.assert_notebooks_equal(output_nb, input_nb)
+
+            if os.path.basename(filename) == "Disable Stdin.ipynb":
+                # We need to special-case this particular notebook, because the
+                # traceback contains machine-specific stuff like where IPython
+                # is installed. It is sufficient here to just check that an error
+                # was thrown, and that it was a StdinNotImplementedError
+                self.assertEqual(len(output_nb['cells']), 1)
+                self.assertEqual(len(output_nb['cells'][0]['outputs']), 1)
+                output = output_nb['cells'][0]['outputs'][0]
+                self.assertEqual(output['output_type'], 'error')
+                self.assertEqual(output['ename'], 'StdinNotImplementedError')
+                self.assertEqual(output['evalue'], 'raw_input was called, but this frontend does not support input requests.')
+
+            else:
+                self.assert_notebooks_equal(output_nb, input_nb)


### PR DESCRIPTION
Fixes #7880 

I made `allow_stdin` be false by default, because it seems to me that for executing a notebook on the command line, that makes the most sense.
