### PR TITLE
dynamic traits for HasTraits instance

### DIFF
--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -45,7 +45,6 @@ import inspect
 import re
 import sys
 import types
-from copy import copy
 from types import FunctionType
 try:
     from types import ClassType, InstanceType


### PR DESCRIPTION
A non-metaclass solution for creating dynamic traits in HasTraits instance. This overrides `__getattr__`, `__setattr__`, and `__hasattr__` in HasTraits to force the instance to utilize `__set__` and `__get__` from a trait in its dynamic trait dictionary (if such a trait exists).

closes #7875 
