### PR TITLE
Js completion traceback, erase line on tab, and double complete.

### DIFF
--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -507,11 +507,12 @@ define([
         /**
          * turn absolute cursor postion into CodeMirror col, ch cursor
          */
-        var i, line;
+        var i, line, next_line;
         var offset = 0;
-        for (i = 0, line=cm.getLine(i); line !== undefined; i++, line=cm.getLine(i)) {
-            if (offset + line.length < cursor_pos) {
-                offset += line.length + 1;
+        for (i = 0, next_line=cm.getLine(i); next_line !== undefined; i++, next_line=cm.getLine(i)) {
+            line = next_line;
+            if (offset + next_line.length < cursor_pos) {
+                offset += next_line.length + 1;
             } else {
                 return {
                     line : i,
@@ -521,8 +522,8 @@ define([
         }
         // reached end, return endpoint
         return {
-            ch : line.length - 1,
             line : i - 1,
+            ch : line.length - 1,
         };
     };
     

--- a/IPython/html/static/notebook/js/completer.js
+++ b/IPython/html/static/notebook/js/completer.js
@@ -321,9 +321,10 @@ define([
 
     Completer.prototype.keydown = function (event) {
         var code = event.keyCode;
-        var that = this;
 
         // Enter
+        var options;
+        var index;
         if (code == keycodes.enter) {
             event.codemirrorIgnore = true;
             event._ipkmIgnore = true;
@@ -341,14 +342,11 @@ define([
             // like %pylab , pylab have no shred start, and ff will result in py<tab><tab>
             // to erase py
             var sh = shared_start(this.raw_result, true);
-            if (sh) {
+            if (sh.str !== '') {
                 this.insert(sh);
             }
             this.close();
-            //reinvoke self
-            setTimeout(function () {
-                that.carry_on_completion();
-            }, 50);
+            this.carry_on_completion();
         } else if (code == keycodes.up || code == keycodes.down) {
             // need to do that to be able to move the arrow
             // when on the first or last line ofo a code cell
@@ -356,8 +354,8 @@ define([
             event._ipkmIgnore = true;
             event.preventDefault();
 
-            var options = this.sel.find('option');
-            var index = this.sel[0].selectedIndex;
+            options = this.sel.find('option');
+            index = this.sel[0].selectedIndex;
             if (code == keycodes.up) {
                 index--;
             }
@@ -369,8 +367,8 @@ define([
         } else if (code == keycodes.pageup || code == keycodes.pagedown) {
             event._ipkmIgnore = true;
 
-            var options = this.sel.find('option');
-            var index = this.sel[0].selectedIndex;
+            options = this.sel.find('option');
+            index = this.sel[0].selectedIndex;
             if (code == keycodes.pageup) {
                 index -= 10; // As 10 is the hard coded size of the drop down menu
             } else {


### PR DESCRIPTION
The function in charge of actually converting cursor offset to
CodeMirror line number and character number was actually crashing when
the cursor was at the last character (loop until undefined, then access
length of variable, which is undefined).

This was hiding a bug in which when you would completer to a single
completion pressing tab after as-you-type filtering, the completion
would be completed twice.

The logic that was supposed to detect whether or not all completions had
a common prefix was actually faulty as the common prefix used to be a
string but was then changed to an object. Hence the logic to check
whether or not there was actually a common prefix was always true, even
for empty string, leading to the deletion of the line (replace by '') in
some cases.

---

This fixes both an issue which is less than a day old, and one which is more than a year old.

I'm slightly concerned by the 50 ms timeout, that **might** have been a workaround for firefox.

This does fix a bug, so I'm inclined for  3.1, but I'm also fine with 4.0
