### PR TITLE
Add Markdown to the list of downloadable nbconverted formats.

### DIFF
--- a/IPython/html/static/notebook/js/menubar.js
+++ b/IPython/html/static/notebook/js/menubar.js
@@ -126,6 +126,10 @@ define([
             that._nbconvert('html', true);
         });
 
+        this.element.find('#download_markdown').click(function () {
+            that._nbconvert('markdown', true);
+        });
+
         this.element.find('#download_rst').click(function () {
             that._nbconvert('rst', true);
         });

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -106,6 +106,7 @@ data-notebook-path="{{notebook_path}}"
                                 <li id="download_ipynb"><a href="#">IPython Notebook (.ipynb)</a></li>
                                 <li id="download_script"><a href="#">Script</a></li>
                                 <li id="download_html"><a href="#">HTML (.html)</a></li>
+                                <li id="download_markdown"><a href="#">Markdown (.md)</a></li>
                                 <li id="download_rst"><a href="#">reST (.rst)</a></li>
                                 <li id="download_pdf"><a href="#">PDF (.pdf)</a></li>
                             </ul>


### PR DESCRIPTION
Seem it was just forgotten. The list was not auto generated on purpose
IIRC, as some format, like TeX were deemed not useful in menu.
