### PR TITLE
Updated Windows HOME folder

### DIFF
--- a/IPython/core/usage.py
+++ b/IPython/core/usage.py
@@ -47,7 +47,7 @@ Usage
     is a separate configuration directory for each profile. The default profile
     directory will be located in $IPYTHONDIR/profile_default. IPYTHONDIR
     defaults to to `$HOME/.ipython`.  For Windows users, $HOME resolves to
-    C:\\Documents and Settings\\YourUserName in most instances.
+    C:\\Users\\YourUserName in most instances.
 
     To initialize a profile with the default configuration file, do::
 


### PR DESCRIPTION
Starting from Vista, the Windows HOME folder was changed from
"C:\Documents and Settings" to "C:\Users"

See the bottom of this page:
https://msdn.microsoft.com/en-us/library/windows/desktop/dd378457%28v=vs.85%29.aspx

Since Windows XP is not supported anymore, IPython should update the displayed path.
