### PR TITLE
fix margin in RadioButtons

### DIFF
--- a/IPython/html/static/widgets/less/widgets.less
+++ b/IPython/html/static/widgets/less/widgets.less
@@ -271,9 +271,6 @@
 
     label {
         margin-top: 0px;
+        margin-left: 20px;
     }
-}
-
-.widget-radio {
-    margin-left: 20px;
 }


### PR DESCRIPTION
This pull request is related to #7740. The change made there fails if the RadioWidget has a label to the left of the radio buttons. The label is set relative to the radio button labels with a padding of 8px but the radio buttons are set with a margin of -20px, thus overwriting the label on the left. This is resolved here by adding a margin of 20px to the radio button labels, thereby leaving space for the radio button and creating sufficient distance to the label on the left.
