### PR TITLE
Rearrange info display to put most useful fields first

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -34,7 +34,7 @@ from IPython.core import page
 from IPython.core import prefilter
 from IPython.core import shadowns
 from IPython.core import ultratb
-from IPython.core.alias import AliasManager, AliasError
+from IPython.core.alias import Alias, AliasManager
 from IPython.core.autocall import ExitAutocall
 from IPython.core.builtin_trap import BuiltinTrap
 from IPython.core.events import EventManager, available_events
@@ -1502,6 +1502,7 @@ class InteractiveShell(SingletonConfigurable):
                 found = True
                 ospace = 'IPython internal'
                 ismagic = True
+                isalias = isinstance(obj, Alias)
 
         # Last try: special-case some literals like '', [], {}, etc:
         if not found and oname_head in ["''",'""','[]','{}','()']:

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -554,23 +554,6 @@ class Inspector:
                 title = header((title+":").ljust(title_width))
             out.append(cast_unicode(title) + cast_unicode(content))
         return "\n".join(out)
-
-    # The fields to be displayed by pinfo: (fancy_name, key_in_info_dict)
-    pinfo_fields1 = [("Type", "type_name"),
-                    ]
-                    
-    pinfo_fields2 = [("String form", "string_form"),
-                    ]
-
-    pinfo_fields3 = [("Length", "length"),
-                    ("File", "file"),
-                    ("Definition", "definition"),
-                    ]
-
-    pinfo_fields_obj = [("Class docstring", "class_docstring"),
-                        ("Init docstring", "init_docstring"),
-                        ("Call def", "call_def"),
-                        ("Call docstring", "call_docstring")]
     
     def _format_info(self, obj, oname='', formatter=None, info=None, detail_level=0):
         """Format an info dict as text"""
@@ -582,41 +565,62 @@ class Inspector:
                 field = info[key]
                 if field is not None:
                     displayfields.append((title, field.rstrip()))
-        
-        add_fields(self.pinfo_fields1)
-        
-        # Base class for old-style instances
-        if (not py3compat.PY3) and isinstance(obj, types.InstanceType) and info['base_class']:
-            displayfields.append(("Base Class", info['base_class'].rstrip()))
-        
-        add_fields(self.pinfo_fields2)
-        
-        # Namespace
-        if info['namespace'] != 'Interactive':
-            displayfields.append(("Namespace", info['namespace'].rstrip()))
 
-        add_fields(self.pinfo_fields3)
-        if info['isclass'] and info['init_definition']:
-            displayfields.append(("Init definition",
-                            info['init_definition'].rstrip()))
-        
-        # Source or docstring, depending on detail level and whether
-        # source found.
-        if detail_level > 0 and info['source'] is not None:
-            displayfields.append(("Source", 
-                                  self.format(cast_unicode(info['source']))))
-        elif info['docstring'] is not None:
-            displayfields.append(("Docstring", info["docstring"]))
+        if info['isalias']:
+            add_fields([('Repr', "string_form")])
 
-        # Constructor info for classes
-        if info['isclass']:
-            if info['init_docstring'] is not None:
-                displayfields.append(("Init docstring",
-                                    info['init_docstring']))
+        elif info['ismagic']:
+            add_fields([("Docstring", "docstring"),
+                        ("File", "file")
+                       ])
 
-        # Info for objects:
+        elif info['isclass'] or is_simple_callable(obj):
+            # Functions, methods, classes
+            add_fields([("Signature", "definition"),
+                        ("Init signature", "init_definition"),
+                       ])
+            if detail_level > 0 and info['source'] is not None:
+                add_fields([("Source", "source")])
+            else:
+                add_fields([("Docstring", "docstring"),
+                            ("Init docstring", "init_docstring"),
+                           ])
+
+            add_fields([('File', 'file'),
+                        ('Type', 'type_name'),
+                       ])
+
         else:
-            add_fields(self.pinfo_fields_obj)
+            # General Python objects
+            add_fields([("Type", "type_name")])
+
+            # Base class for old-style instances
+            if (not py3compat.PY3) and isinstance(obj, types.InstanceType) and info['base_class']:
+                displayfields.append(("Base Class", info['base_class'].rstrip()))
+
+            add_fields([("String form", "string_form")])
+
+            # Namespace
+            if info['namespace'] != 'Interactive':
+                displayfields.append(("Namespace", info['namespace'].rstrip()))
+
+            add_fields([("Length", "length"),
+                        ("File", "file"),
+                        ("Definition", "definition"),
+                       ])
+
+            # Source or docstring, depending on detail level and whether
+            # source found.
+            if detail_level > 0 and info['source'] is not None:
+                displayfields.append(("Source",
+                                      self.format(cast_unicode(info['source']))))
+            elif info['docstring'] is not None:
+                displayfields.append(("Docstring", info["docstring"]))
+
+            add_fields([("Class docstring", "class_docstring"),
+                        ("Init docstring", "init_docstring"),
+                        ("Call def", "call_def"),
+                        ("Call docstring", "call_docstring")])
         
         if displayfields:
             return self._format_fields(displayfields)

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -607,7 +607,7 @@ class Inspector:
 
             add_fields([("Length", "length"),
                         ("File", "file"),
-                        ("Definition", "definition"),
+                        ("Signature", "definition"),
                        ])
 
             # Source or docstring, depending on detail level and whether

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -36,6 +36,7 @@ from IPython.utils import io
 from IPython.utils import openpy
 from IPython.utils import py3compat
 from IPython.utils.dir2 import safe_hasattr
+from IPython.utils.path import compress_user
 from IPython.utils.text import indent
 from IPython.utils.wildcard import list_namespace
 from IPython.utils.coloransi import TermColors, ColorScheme, ColorSchemeTable
@@ -741,7 +742,7 @@ class Inspector:
                 binary_file = True
             elif fname.endswith('<string>'):
                 fname = 'Dynamically generated function. No source code available.'
-            out['file'] = fname
+            out['file'] = compress_user(fname)
 
         # Original source code for a callable, class or property.
         if detail_level:

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -620,7 +620,7 @@ class Inspector:
 
             add_fields([("Class docstring", "class_docstring"),
                         ("Init docstring", "init_docstring"),
-                        ("Call def", "call_def"),
+                        ("Call signature", "call_def"),
                         ("Call docstring", "call_docstring")])
         
         if displayfields:

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -47,7 +47,7 @@ ip = get_ipython()
 # defined, if any code is inserted above, the following line will need to be
 # updated.  Do NOT insert any whitespace between the next line and the function
 # definition below.
-THIS_LINE_NUMBER = 49  # Put here the actual number of this line
+THIS_LINE_NUMBER = 50  # Put here the actual number of this line
 def test_find_source_lines():
     nt.assert_equal(oinspect.find_source_lines(test_find_source_lines), 
                     THIS_LINE_NUMBER+1)

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -28,6 +28,7 @@ from IPython.core.magic import (Magics, magics_class, line_magic,
                                 register_line_cell_magic)
 from IPython.external.decorator import decorator
 from IPython.testing.decorators import skipif
+from IPython.utils.path import compress_user
 from IPython.utils import py3compat
 
 
@@ -241,7 +242,7 @@ def test_info():
         fname = fname[:-1]
     # case-insensitive comparison needed on some filesystems
     # e.g. Windows:
-    nt.assert_equal(i['file'].lower(), fname.lower())
+    nt.assert_equal(i['file'].lower(), compress_user(fname.lower()))
     nt.assert_equal(i['definition'], None)
     nt.assert_equal(i['docstring'], Call.__doc__)
     nt.assert_equal(i['source'], None)

--- a/IPython/kernel/tests/test_message_spec.py
+++ b/IPython/kernel/tests/test_message_spec.py
@@ -384,7 +384,7 @@ def test_oinfo_detail():
     content = reply['content']
     assert content['found']
     text = content['data']['text/plain']
-    nt.assert_in('Definition:', text)
+    nt.assert_in('Signature:', text)
     nt.assert_in('Source:', text)
 
 


### PR DESCRIPTION
Closes #7817 and #7759.

This adds specific orderings of fields for basic callables (classes, functions, methods), magics and aliases, to put the most useful information first. Inspecting any other object will still produce the same info as before.

Before and after pics - function:
![scatter_before_after](https://cloud.githubusercontent.com/assets/327925/6427716/81064014-bf3d-11e4-8980-bce7508193d3.png)

And magic:
![timeit_before_after](https://cloud.githubusercontent.com/assets/327925/6427717/86b20dc2-bf3d-11e4-86aa-6834cfa4ce67.png)
