### PR TITLE
make it clearer that we adapt to old messages

### DIFF
--- a/IPython/html/services/kernels/handlers.py
+++ b/IPython/html/services/kernels/handlers.py
@@ -160,7 +160,7 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
         protocol_version = info.get('protocol_version', kernel_protocol_version)
         if protocol_version != kernel_protocol_version:
             self.session.adapt_version = int(protocol_version.split('.')[0])
-            self.log.info("Kernel %s speaks protocol %s", self.kernel_id, protocol_version)
+            self.log.info("Adapting to protocol v%s for kernel %s", protocol_version, self.kernel_id)
         if not self._kernel_info_future.done():
             self._kernel_info_future.set_result(info)
     


### PR DESCRIPTION
> Adapting to protocol vX for kernel Y

instead of

> Kernel Y speaks protocol version X

some have interpreted the "Kernel speaks" statement was an error message; this should be clearer about what's happening, and that there is no error.
