### PR TITLE
skip permission error -> 403 test on Windows

### DIFF
--- a/IPython/html/services/contents/tests/test_manager.py
+++ b/IPython/html/services/contents/tests/test_manager.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 import os
+import sys
 import time
 
 from nose import SkipTest
@@ -134,6 +135,8 @@ class TestFileContentsManager(TestCase):
         if hasattr(os, 'getuid'):
             if os.getuid() == 0:
                 raise SkipTest("Can't test permissions as root")
+        if sys.platform.startswith('win'):
+            raise SkipTest("Can't test permissions on Windows")
         
         with TemporaryDirectory() as td:
             cm = FileContentsManager(root_dir=td)


### PR DESCRIPTION
The test actually passes on my VM (Win 7), but not on Jenkins (Server 2012),
where cleanup of the read-only file fails.

I haven't figured out how to identify the subset of Windows systems where it won't work, but since the problem appears to be in the test, not the tested code, skipping on Windows seems the right way to go.
