### PR TITLE
Make suffixes be optional in nbconvert

### DIFF
--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -18,7 +18,7 @@ from IPython.core.application import BaseIPythonApplication, base_aliases, base_
 from IPython.core.profiledir import ProfileDir
 from IPython.config import catch_config_error, Configurable
 from IPython.utils.traitlets import (
-    Unicode, List, Instance, DottedObjectName, Type, CaselessStrEnum,
+    Unicode, List, Instance, DottedObjectName, Type, CaselessStrEnum, Bool,
 )
 from IPython.utils.importstring import import_item
 
@@ -66,6 +66,10 @@ nbconvert_flags.update({
     'stdout' : (
         {'NbConvertApp' : {'writer_class' : "StdoutWriter"}},
         "Write notebook output to stdout instead of files."
+        ),
+    'no-output-suffix' : (
+        {'NbConvertApp' : {'use_output_suffix' : False}},
+        "Do not apply a suffix to filenames when converting to notebook format."
         )
 })
 
@@ -99,6 +103,13 @@ class NbConvertApp(BaseIPythonApplication):
     output_base = Unicode('', config=True, help='''overwrite base name use for output files.
             can only be used when converting one notebook at a time.
             ''')
+
+    use_output_suffix = Bool(
+        True, 
+        config=True,
+        help="""Whether to apply a suffix prior to the extension (only relevant
+            when converting to notebook format). The suffix is determined by
+            the exporter, and is usually '.nbconvert'.""")
 
     examples = Unicode(u"""
         The simplest way to use nbconvert is
@@ -303,7 +314,7 @@ class NbConvertApp(BaseIPythonApplication):
                       exc_info=True)
                 self.exit(1)
             else:
-                if 'output_suffix' in resources and not self.output_base:
+                if self.use_output_suffix and 'output_suffix' in resources and not self.output_base:
                     notebook_name += resources['output_suffix']
                 write_results = self.writer.write(output, resources, notebook_name=notebook_name)
 

--- a/IPython/nbconvert/nbconvertapp.py
+++ b/IPython/nbconvert/nbconvertapp.py
@@ -67,9 +67,13 @@ nbconvert_flags.update({
         {'NbConvertApp' : {'writer_class' : "StdoutWriter"}},
         "Write notebook output to stdout instead of files."
         ),
-    'no-output-suffix' : (
-        {'NbConvertApp' : {'use_output_suffix' : False}},
-        "Do not apply a suffix to filenames when converting to notebook format."
+    'inplace' : (
+        {
+            'NbConvertApp' : {'use_output_suffix' : False},
+            'FilesWriter': {'build_directory': ''}
+        },
+        """Run nbconvert in place, overwriting the existing notebook (only 
+        relevant when converting to notebook format)"""
         )
 })
 
@@ -254,6 +258,8 @@ class NbConvertApp(BaseIPythonApplication):
         """
         self._writer_class_changed(None, self.writer_class, self.writer_class)
         self.writer = self.writer_factory(parent=self)
+        if hasattr(self.writer, 'build_directory') and self.writer.build_directory != '':
+            self.use_output_suffix = False
 
     def init_postprocessor(self):
         """

--- a/IPython/nbconvert/tests/test_nbconvertapp.py
+++ b/IPython/nbconvert/tests/test_nbconvertapp.py
@@ -210,3 +210,25 @@ class TestNbConvertApp(TestsBase):
             self.create_empty_notebook(u'empty.ipynb')
             self.call('nbconvert empty --to html --NbConvertApp.writer_class=\'hello.HelloWriter\'')
             assert os.path.isfile(u'hello.txt')
+
+    def test_output_suffix(self):
+        """
+        Verify that the output suffix is applied
+        """
+        with self.create_temp_cwd():
+            self.create_empty_notebook('empty.ipynb')
+            self.call('nbconvert empty.ipynb --to notebook')
+            assert os.path.isfile('empty.nbconvert.ipynb')
+
+    def test_no_output_suffix(self):
+        """
+        Verify that the output suffix is not applied
+        """
+        with self.create_temp_cwd():
+            self.create_empty_notebook('empty.ipynb')
+            os.mkdir('output')
+            self.call(
+                'nbconvert empty.ipynb --to notebook '
+                '--FilesWriter.build_directory=output '
+                '--no-output-suffix')
+            assert os.path.isfile('output/empty.ipynb')

--- a/IPython/nbconvert/tests/test_nbconvertapp.py
+++ b/IPython/nbconvert/tests/test_nbconvertapp.py
@@ -220,7 +220,7 @@ class TestNbConvertApp(TestsBase):
             self.call('nbconvert empty.ipynb --to notebook')
             assert os.path.isfile('empty.nbconvert.ipynb')
 
-    def test_no_output_suffix(self):
+    def test_different_build_dir(self):
         """
         Verify that the output suffix is not applied
         """
@@ -229,6 +229,15 @@ class TestNbConvertApp(TestsBase):
             os.mkdir('output')
             self.call(
                 'nbconvert empty.ipynb --to notebook '
-                '--FilesWriter.build_directory=output '
-                '--no-output-suffix')
+                '--FilesWriter.build_directory=output')
             assert os.path.isfile('output/empty.ipynb')
+
+    def test_inplace(self):
+        """
+        Verify that the notebook is converted in place
+        """
+        with self.create_temp_cwd():
+            self.create_empty_notebook('empty.ipynb')
+            self.call('nbconvert empty.ipynb --to notebook --inplace')
+            assert os.path.isfile('empty.ipynb')
+            assert not os.path.isfile('empty.nbconvert.ipynb')


### PR DESCRIPTION
The output suffix (e.g. `.nbconvert`) is currently _always_ applied, which is annoying because it's not always appropriate -- for example, when using a different build directory, you would expect the files to have the same name, and not always have an additional `.nbconvert` added on to them. This PR makes the output suffix be optional, and additionally adds a flag (`--no-output-suffix`) to make it easy to suppress this option on the command line.

I'm also fine not adding the flag and just having it be `--NbConvertApp.use_output_suffix=False` if you'd prefer to keep the number of command line flags minimal.
