### PR TITLE
Add relpath option to FilesWriter

### DIFF
--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -142,9 +142,10 @@ class Exporter(LoggingConfigurable):
             resources = ResourcesDict()
         if not 'metadata' in resources or resources['metadata'] == '':
             resources['metadata'] = ResourcesDict()
-        basename = os.path.basename(filename)
+        path, basename = os.path.split(filename)
         notebook_name = basename[:basename.rfind('.')]
         resources['metadata']['name'] = notebook_name
+        resources['metadata']['path'] = path
 
         modified_date = datetime.datetime.fromtimestamp(os.path.getmtime(filename))
         resources['metadata']['modified_date'] = modified_date.strftime(text.date_format)

--- a/IPython/nbconvert/writers/files.py
+++ b/IPython/nbconvert/writers/files.py
@@ -29,7 +29,9 @@ class FilesWriter(WriterBase):
         "", config=True, 
         help="""When copying files that the notebook depends on, copy them in
         relation to this path, such that the destination filename will be
-        os.path.relpath(filename, relpath).""")
+        os.path.relpath(filename, relpath). If FilesWriter is operating on a
+        notebook that already exists elsewhere on disk, then the default will be
+        the directory containing that notebook.""")
 
 
     # Make sure that the output directory exists.
@@ -65,6 +67,12 @@ class FilesWriter(WriterBase):
             # Pull the extension and subdir from the resources dict.
             output_extension = resources.get('output_extension', None)
 
+            # Get the relative path for copying files
+            if self.relpath == '':
+                relpath = resources.get('metadata', {}).get('path', '')
+            else:
+                relpath = self.relpath
+
             # Write all of the extracted resources to the destination directory.
             # NOTE: WE WRITE EVERYTHING AS-IF IT'S BINARY.  THE EXTRACT FIG
             # PREPROCESSOR SHOULD HANDLE UNIX/WINDOWS LINE ENDINGS...
@@ -88,8 +96,8 @@ class FilesWriter(WriterBase):
                     for matching_filename in glob.glob(filename):
 
                         # compute the relative path for the filename
-                        if self.relpath:
-                            dest_filename = os.path.relpath(matching_filename, self.relpath)
+                        if relpath != '':
+                            dest_filename = os.path.relpath(matching_filename, relpath)
                         else:
                             dest_filename = matching_filename
 

--- a/IPython/nbconvert/writers/files.py
+++ b/IPython/nbconvert/writers/files.py
@@ -25,6 +25,12 @@ class FilesWriter(WriterBase):
                               help="""Directory to write output to.  Leave blank
                               to output to the current directory""")
 
+    relpath = Unicode(
+        "", config=True, 
+        help="""When copying files that the notebook depends on, copy them in
+        relation to this path, such that the destination filename will be
+        os.path.relpath(filename, relpath).""")
+
 
     # Make sure that the output directory exists.
     def _build_directory_changed(self, name, old, new):
@@ -81,8 +87,14 @@ class FilesWriter(WriterBase):
                     # Copy files that match search pattern
                     for matching_filename in glob.glob(filename):
 
+                        # compute the relative path for the filename
+                        if self.relpath:
+                            dest_filename = os.path.relpath(matching_filename, self.relpath)
+                        else:
+                            dest_filename = matching_filename
+
                         # Make sure folder exists.
-                        dest = os.path.join(self.build_directory, matching_filename)
+                        dest = os.path.join(self.build_directory, dest_filename)
                         path = os.path.dirname(dest)
                         self._makedir(path)
 

--- a/IPython/nbconvert/writers/tests/test_files.py
+++ b/IPython/nbconvert/writers/tests/test_files.py
@@ -236,3 +236,72 @@ class Testfiles(TestsBase):
             with open(dest, 'r') as f:
                 output = f.read()
                 self.assertEqual(output, 'd')
+
+    def test_relpath_default(self):
+        """Is the FilesWriter default relative path correct?"""
+
+        # Work in a temporary directory.
+        with self.create_temp_cwd():
+
+            # Create test file
+            os.mkdir('sub')
+            with open(os.path.join('sub', 'c'), 'w') as f:
+                f.write('d')
+
+            # Create the resoruces dictionary
+            res = dict(metadata=dict(path="sub"))
+
+            # Create files writer, test output
+            writer = FilesWriter()
+            writer.files = [os.path.join('sub', 'c')]
+            writer.build_directory = u'build'
+            writer.write(u'y', res, notebook_name="z")
+
+            # Check the output of the file
+            assert os.path.isdir(writer.build_directory)
+            dest = os.path.join(writer.build_directory, 'z')
+            with open(dest, 'r') as f:
+                output = f.read()
+                self.assertEqual(output, u'y')
+
+            # Check to make sure the linked file was copied
+            dest = os.path.join(writer.build_directory, 'c')
+            assert os.path.isfile(dest)
+            with open(dest, 'r') as f:
+                output = f.read()
+                self.assertEqual(output, 'd')
+
+    def test_relpath_default(self):
+        """Does the FilesWriter relpath option take precedence over the path?"""
+
+        # Work in a temporary directory.
+        with self.create_temp_cwd():
+
+            # Create test file
+            os.mkdir('sub')
+            with open(os.path.join('sub', 'c'), 'w') as f:
+                f.write('d')
+
+            # Create the resoruces dictionary
+            res = dict(metadata=dict(path="other_sub"))
+
+            # Create files writer, test output
+            writer = FilesWriter()
+            writer.files = [os.path.join('sub', 'c')]
+            writer.build_directory = u'build'
+            writer.relpath = 'sub'
+            writer.write(u'y', res, notebook_name="z")
+
+            # Check the output of the file
+            assert os.path.isdir(writer.build_directory)
+            dest = os.path.join(writer.build_directory, 'z')
+            with open(dest, 'r') as f:
+                output = f.read()
+                self.assertEqual(output, u'y')
+
+            # Check to make sure the linked file was copied
+            dest = os.path.join(writer.build_directory, 'c')
+            assert os.path.isfile(dest)
+            with open(dest, 'r') as f:
+                output = f.read()
+                self.assertEqual(output, 'd')

--- a/IPython/nbconvert/writers/tests/test_files.py
+++ b/IPython/nbconvert/writers/tests/test_files.py
@@ -201,3 +201,38 @@ class Testfiles(TestsBase):
                 with open(dest, 'r') as f:
                     output = f.read()
                     self.assertEqual(output, 'e')
+
+    def test_relpath(self):
+        """Can the FilesWriter handle relative paths for linked files correctly?"""
+
+        # Work in a temporary directory.
+        with self.create_temp_cwd():
+
+            # Create test file
+            os.mkdir('sub')
+            with open(os.path.join('sub', 'c'), 'w') as f:
+                f.write('d')
+
+            # Create the resoruces dictionary
+            res = {}
+
+            # Create files writer, test output
+            writer = FilesWriter()
+            writer.files = [os.path.join('sub', 'c')]
+            writer.build_directory = u'build'
+            writer.relpath = 'sub'
+            writer.write(u'y', res, notebook_name="z")
+
+            # Check the output of the file
+            assert os.path.isdir(writer.build_directory)
+            dest = os.path.join(writer.build_directory, 'z')
+            with open(dest, 'r') as f:
+                output = f.read()
+                self.assertEqual(output, u'y')
+
+            # Check to make sure the linked file was copied
+            dest = os.path.join(writer.build_directory, 'c')
+            assert os.path.isfile(dest)
+            with open(dest, 'r') as f:
+                output = f.read()
+                self.assertEqual(output, 'd')


### PR DESCRIPTION
Currently, if you specify files that a notebook is dependent on, the current behavior is to copy the files relative to the directory that you are running nbconvert from. However, you may want them to be relative to a different directory -- for example, in the case where you're converting `source_dir/*.ipynb` (and there are dependent files in `source_dir`) to a build directory of `build_dir/`, then currently you'll get the dependent files as `build_dir/source_dir/some_dependent_file`. This is not always what you want, so you should be able to specify what the relative path is.

This PR adds an option for a relative path, so in the example above, you could specify `FilesWriter.relpath="source_dir"`, and it would properly link the files to `build_dir/`, rather than `build_dir/source_dir/`.
