### PR TITLE
Enable chapters for latex report class

### DIFF
--- a/IPython/nbconvert/templates/latex/report.tplx
+++ b/IPython/nbconvert/templates/latex/report.tplx
@@ -20,3 +20,7 @@
 ((* block docclass *))
 \documentclass{report}
 ((* endblock docclass *))
+
+((* block markdowncell scoped *))
+((( cell.source | citation2latex | strip_files_prefix | markdown2latex(extra_args=["--chapters"]) )))
+((* endblock markdowncell *))


### PR DESCRIPTION
As shown in issue #7909 the latex report template misses chapter headings and thus results in headings always starting with _0_. This adds the required `--chapters` pandoc parameter as proposed by @minrk in the respective issue.
