### PR TITLE
Fix AttriuteError for widgets.[js][d]link in Widget Events.ipynb

### DIFF
--- a/examples/Interactive Widgets/Widget Events.ipynb
+++ b/examples/Interactive Widgets/Widget Events.ipynb
@@ -307,7 +307,7 @@
     "range1, range2, range3 = widgets.IntSlider(description='Range 1'),\\\n",
     "                         widgets.IntSlider(description='Range 2'),\\\n",
     "                         widgets.IntSlider(description='Range 3')\n",
-    "l = widgets.link((range1, 'value'), (range2, 'value'), (range3, 'value'))\n",
+    "l = widgets.jslink((range1, 'value'), (range2, 'value'), (range3, 'value'))\n",
     "display(caption, range1, range2, range3)"
    ]
   },
@@ -323,7 +323,7 @@
     "source_range, target_range1, target_range2 = widgets.IntSlider(description='Source range'),\\\n",
     "                                             widgets.IntSlider(description='Target range 1'),\\\n",
     "                                             widgets.IntSlider(description='Target range 2')\n",
-    "widgets.dlink((source_range, 'value'), (target_range1, 'value'), (target_range2, 'value'))\n",
+    "widgets.jsdlink((source_range, 'value'), (target_range1, 'value'), (target_range2, 'value'))\n",
     "display(caption, source_range, target_range1, target_range2)"
    ]
   },


### PR DESCRIPTION
Running <Widget Events.ipynb> in http://try.jupyter.org/ raises the following errors (first two code cells under Widget%20Events.ipynb#Linking-widgets-attributes-from-the-client-side):

In [11]: AttributeError: 'module' object has no attribute 'link'
In [12]: AttributeError: 'module' object has no attribute 'dlink'

In [13]: widgets.<Tab> shows that `jsdlink` and `jslink` functions are available.

Substituting these function names generates the expected linked sliders.
