### PR TITLE
fix error permissions when use virtualenv

### DIFF
--- a/IPython/kernel/kernelspec.py
+++ b/IPython/kernel/kernelspec.py
@@ -187,6 +187,10 @@ class KernelSpecManager(Configurable):
             kernel_name = os.path.basename(source_dir)
         kernel_name = kernel_name.lower()
         
+        if 'VIRTUAL_ENV' in os.environ:
+            # In a virtualenv. maybe does not have appropriate permissions
+            # access to SYSTEM_KERNEL_DIRS
+            user=True
         destination = self._get_destination_dir(kernel_name, user=user)
 
         if replace and os.path.isdir(destination):


### PR DESCRIPTION
when i use virtualenv and install the [bash_kernel](https://github.com/takluyver/bash_kernel). i found this error:

``` python
pip install bash_kernel  
Collecting bash-kernel
  Using cached bash_kernel-0.3.tar.gz
Requirement already satisfied (use --upgrade to upgrade): pexpect>=3.3 in /Users/dongweiming/python3/lib/python3.4/site-packages (from bash-kernel)
Installing collected packages: bash-kernel
  Running setup.py install for bash-kernel
    Installing IPython kernel spec
    error: /usr/local/share/jupyter/kernels/bash/kernel.json: Permission denied
    Complete output from command /Users/dongweiming/python3/bin/python -c "import setuptools, tokenize;__file__='/private/var/folders/gs/l804wd353td_fbnh6rcy2hk40000gn/T/pip-build-j1eqmjec/bash-kernel/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /var/folders/gs/l804wd353td_fbnh6rcy2hk40000gn/T/pip-joz60tem-record/install-record.txt --single-version-externally-managed --compile --install-headers /Users/dongweiming/python3/bin/../include/site/python3.4:
    running install

    running build

    running build_py

    creating build

    creating build/lib

    creating build/lib/bash_kernel

    copying bash_kernel/__init__.py -> build/lib/bash_kernel

    copying bash_kernel/__main__.py -> build/lib/bash_kernel

    copying bash_kernel/images.py -> build/lib/bash_kernel

    copying bash_kernel/kernel.py -> build/lib/bash_kernel

    running install_lib

    creating /Users/dongweiming/python3/lib/python3.4/site-packages/bash_kernel

    copying build/lib/bash_kernel/__init__.py -> /Users/dongweiming/python3/lib/python3.4/site-packages/bash_kernel

    copying build/lib/bash_kernel/__main__.py -> /Users/dongweiming/python3/lib/python3.4/site-packages/bash_kernel

    copying build/lib/bash_kernel/images.py -> /Users/dongweiming/python3/lib/python3.4/site-packages/bash_kernel

    copying build/lib/bash_kernel/kernel.py -> /Users/dongweiming/python3/lib/python3.4/site-packages/bash_kernel

    byte-compiling /Users/dongweiming/python3/lib/python3.4/site-packages/bash_kernel/__init__.py to __init__.cpython-34.pyc

    byte-compiling /Users/dongweiming/python3/lib/python3.4/site-packages/bash_kernel/__main__.py to __main__.cpython-34.pyc

    byte-compiling /Users/dongweiming/python3/lib/python3.4/site-packages/bash_kernel/images.py to images.cpython-34.pyc

    byte-compiling /Users/dongweiming/python3/lib/python3.4/site-packages/bash_kernel/kernel.py to kernel.cpython-34.pyc

    running install_egg_info

    running egg_info

    creating bash_kernel.egg-info

    writing bash_kernel.egg-info/PKG-INFO

    writing top-level names to bash_kernel.egg-info/top_level.txt

    writing requirements to bash_kernel.egg-info/requires.txt

    writing dependency_links to bash_kernel.egg-info/dependency_links.txt

    writing manifest file 'bash_kernel.egg-info/SOURCES.txt'

    warning: manifest_maker: standard file '-c' not found



    reading manifest file 'bash_kernel.egg-info/SOURCES.txt'

    writing manifest file 'bash_kernel.egg-info/SOURCES.txt'

    Copying bash_kernel.egg-info to /Users/dongweiming/python3/lib/python3.4/site-packages/bash_kernel-0.3-py3.4.egg-info

    writing list of installed files to '/var/folders/gs/l804wd353td_fbnh6rcy2hk40000gn/T/pip-joz60tem-record/install-record.txt'

    Installing IPython kernel spec

    error: /usr/local/share/jupyter/kernels/bash/kernel.json: Permission denied

    ----------------------------------------
    Command "/Users/dongweiming/python3/bin/python -c "import setuptools, tokenize;__file__='/private/var/folders/gs/l804wd353td_fbnh6rcy2hk40000gn/T/pip-build-j1eqmjec/bash-kernel/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /var/folders/gs/l804wd353td_fbnh6rcy2hk40000gn/T/pip-joz60tem-record/install-record.txt --single-version-externally-managed --compile --install-headers /Users/dongweiming/python3/bin/../include/site/python3.4" failed with error code 1 in /private/var/folders/gs/l804wd353td_fbnh6rcy2hk40000gn/T/pip-build-j1eqmjec/bash-kernel
```

i think when use virtualenv we use `user_kernel_dir` can directly.
