### PR TITLE
Fix configurability of codecell

### DIFF
--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -567,7 +567,14 @@ define([
             // only one key every time but regexp can't be keys...
             for(var i=0; i<regs.length; i++) {
                 // here we handle non magic_modes
-                if(first_line.match(regs[i]) !== null) {
+                // on 3.0 and below, things were regex.
+                // but shodl be string for config. 
+                // get rid of direct re handeling later. 
+                var re = regs[i];
+                if(typeof(re) === 'string'){
+                    re = new RegExp(re) 
+                }
+                if(first_line.match(re) !== null) {
                     if(current_mode == mode){
                         return;
                     }

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -566,10 +566,12 @@ define([
             var regs = modes[mode].reg;
             // only one key every time but regexp can't be keys...
             for(var i=0; i<regs.length; i++) {
-                // here we handle non magic_modes
-                // on 3.0 and below, things were regex.
-                // but shodl be string for config. 
-                // get rid of direct re handeling later. 
+                // here we handle non magic_modes.
+                // TODO :
+                // On 3.0 and below, these things were regex.
+                // But now should be string for json-able config. 
+                // We should get rid of assuming they might be already 
+                // in a later version of IPython. 
                 var re = regs[i];
                 if(typeof(re) === 'string'){
                     re = new RegExp(re) 

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -147,17 +147,6 @@ define([
 
     CodeCell.prototype = Object.create(Cell.prototype);
     
-    /**
-     * @private
-     * Update the current state of the config file in the profile with current config. 
-     **/
-    CodeCell.prototype._fill_config_with_current = function(){
-        var keys = ['cm_config','highlight_modes'];
-        for(var i in keys){
-            this.class_config.set(keys[i], this.class_config.get_sync(keys[i]));
-        }
-    }
-
     /** @method create_element */
     CodeCell.prototype.create_element = function () {
         Cell.prototype.create_element.apply(this, arguments);

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -127,25 +127,36 @@ define([
             },
             mode: 'ipython',
             theme: 'ipython',
-            matchBrackets: true
-        }
-    };
-
-    CodeCell.config_defaults = {
+            matchBrackets: true,
+            autoCloseBrackets: true
+        },
         highlight_modes : {
-            'magic_javascript'    :{'reg':[/^%%javascript/]},
-            'magic_perl'          :{'reg':[/^%%perl/]},
-            'magic_ruby'          :{'reg':[/^%%ruby/]},
-            'magic_python'        :{'reg':[/^%%python3?/]},
-            'magic_shell'         :{'reg':[/^%%bash/]},
-            'magic_r'             :{'reg':[/^%%R/]},
-            'magic_text/x-cython' :{'reg':[/^%%cython/]},
+            'magic_javascript'    :{'reg':['^%%javascript']},
+            'magic_perl'          :{'reg':['^%%perl']},
+            'magic_ruby'          :{'reg':['^%%ruby']},
+            'magic_python'        :{'reg':['^%%python3?']},
+            'magic_shell'         :{'reg':['^%%bash']},
+            'magic_r'             :{'reg':['^%%R']},
+            'magic_text/x-cython' :{'reg':['^%%cython']},
         },
     };
+
+    CodeCell.config_defaults = CodeCell.options_default;
 
     CodeCell.msg_cells = {};
 
     CodeCell.prototype = Object.create(Cell.prototype);
+    
+    /**
+     * @private
+     * Update the current state of the config file in the profile with current config. 
+     **/
+    CodeCell.prototype._fill_config_with_current = function(){
+        var keys = ['cm_config','highlight_modes'];
+        for(var i in keys){
+            this.class_config.set(keys[i], this.class_config.get_sync(keys[i]));
+        }
+    }
 
     /** @method create_element */
     CodeCell.prototype.create_element = function () {
@@ -163,7 +174,7 @@ define([
             notebook: this.notebook});
         inner_cell.append(this.celltoolbar.element);
         var input_area = $('<div/>').addClass('input_area');
-        this.code_mirror = new CodeMirror(input_area.get(0), this.cm_config);
+        this.code_mirror = new CodeMirror(input_area.get(0), this.class_config.get_sync('cm_config'));
         // In case of bugs that put the keyboard manager into an inconsistent state,
         // ensure KM is enabled when CodeMirror is focused:
         this.code_mirror.on('focus', function () {


### PR DESCRIPTION
code cell where actually not configurable,
this fixes that + add a convenient methods to dump the
content of the configuration in the config file.

this also close #7896 by defaulting closebracket to true,
which is now configurable :-)

It also switches the default magic highlight mode to string so that they
could also be configured.
