### PR TITLE
fix the links to pythonxy

### DIFF
--- a/docs/source/links.txt
+++ b/docs/source/links.txt
@@ -48,7 +48,7 @@
 .. _scipy: http://www.scipy.org
 .. _scipy_conference: http://conference.scipy.org
 .. _matplotlib: http://matplotlib.org
-.. _pythonxy: http://www.pythonxy.com
+.. _pythonxy: https://code.google.com/p/pythonxy/
 .. _ETS: http://code.enthought.com/projects/tool-suite.php
 .. _EPD: http://www.enthought.com/products/epd.php
 .. _python: http://www.python.org


### PR DESCRIPTION
Hi, 
in the docs/source/links.txt, the links to pythonxy is not valid. I have change it to the right address which is https://code.google.com/p/pythonxy/
Thanks
