### PR TITLE
make 'download as PDF' say 'via LaTeX'

### DIFF
--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -108,7 +108,7 @@ data-notebook-path="{{notebook_path}}"
                                 <li id="download_html"><a href="#">HTML (.html)</a></li>
                                 <li id="download_markdown"><a href="#">Markdown (.md)</a></li>
                                 <li id="download_rst"><a href="#">reST (.rst)</a></li>
-                                <li id="download_pdf"><a href="#">PDF (.pdf)</a></li>
+                                <li id="download_pdf"><a href="#">PDF via LaTeX (.pdf)</a></li>
                             </ul>
                         </li>
                         <li class="divider"></li>


### PR DESCRIPTION
so it's clear that LaTeX is required
