### PR TITLE
don't merge App.extra_extension into App.extensions

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -2,23 +2,10 @@
 """
 A mixin for :class:`~IPython.core.application.Application` classes that
 launch InteractiveShell instances, load extensions, etc.
-
-Authors
--------
-
-* Min Ragan-Kelley
 """
 
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2011  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 from __future__ import absolute_import
 from __future__ import print_function
@@ -152,10 +139,6 @@ class InteractiveShellApp(Configurable):
     extra_extension = Unicode('', config=True,
         help="dotted module name of an IPython extension to load."
     )
-    def _extra_extension_changed(self, name, old, new):
-        if new:
-            # add to self.extensions
-            self.extensions.append(new)
     
     # Extensions that are always loaded (not configurable)
     default_extensions = List(Unicode, [u'storemagic'], config=False)
@@ -269,6 +252,8 @@ class InteractiveShellApp(Configurable):
         try:
             self.log.debug("Loading IPython extensions...")
             extensions = self.default_extensions + self.extensions
+            if self.extra_extension:
+                extensions.append(self.extra_extension)
             for ext in extensions:
                 try:
                     self.log.info("Loading IPython extension: %s" % ext)


### PR DESCRIPTION
setting both values could result in extra_extension being omitted from the list

alternately, we could have `_extensions_changed` re-add it, but I don't think we use this list more than once.
