### PR TITLE
Docs: Update info about nbconvert's latex/pdf conversion

### DIFF
--- a/docs/source/notebook/nbconvert.rst
+++ b/docs/source/notebook/nbconvert.rst
@@ -59,8 +59,7 @@ The currently supported export formats are:
 
 * ``--to pdf``
 
-  Generates a PDF via latex. Replaces ``--to latex --post PDF``, which is deprecated.
-  Supports the same templates as ``--to latex``.
+  Generates a PDF via latex. Supports the same templates as ``--to latex``.
 
 * ``--to slides``
 

--- a/docs/source/notebook/nbconvert.rst
+++ b/docs/source/notebook/nbconvert.rst
@@ -43,20 +43,24 @@ The currently supported export formats are:
 * ``--to latex``
 
   Latex export.  This generates ``NOTEBOOK_NAME.tex`` file,
-  ready for export.  You can automatically run latex on it to generate a PDF
-  by adding ``--post PDF``.
+  ready for export.
   
   - ``--template article`` (default)
   
     Latex article, derived from Sphinx's howto template.
 
-  - ``--template book``
+  - ``--template report``
   
-    Latex book, derived from Sphinx's manual template.
+    Latex report, providing a table of contents and chapters.
 
   - ``--template basic``
   
     Very basic latex output - mainly meant as a starting point for custom templates.
+
+* ``--to pdf``
+
+  Generates a PDF via latex. Replaces ``--to latex --post PDF``, which is deprecated.
+  Supports the same templates as ``--to latex``.
 
 * ``--to slides``
 


### PR DESCRIPTION
As discussed in #7973. While updating the info about `--to pdf` I noticed that the `book` template seems to have been replaced by `report`, so I've updated that as well. If anyone wants to provide a more detailed description of the report template, feel free.
