### PR TITLE
use $(window).height() instead of window.innerHeight

### DIFF
--- a/IPython/html/static/base/js/page.js
+++ b/IPython/html/static/base/js/page.js
@@ -56,7 +56,7 @@ define([
 
     Page.prototype._resize_site = function() {
         // Update the site's size.
-        $('div#site').height(window.innerHeight - $('#header').height());
+        $('div#site').height($(window).height() - $('#header').height());
     };
 
     // Register self in the global namespace for convenience.

--- a/IPython/html/static/terminal/js/main.js
+++ b/IPython/html/static/terminal/js/main.js
@@ -36,7 +36,7 @@ require([
     
     var header = $("#header")[0]
     function calculate_size() {
-        var height = window.innerHeight - header.offsetHeight;
+        var height = $(window).height() - header.offsetHeight;
         var width = $('#terminado-container').width();
         var rows = Math.min(1000, Math.max(20, Math.floor(height/termRowHeight())-1));
         var cols = Math.min(1000, Math.max(40, Math.floor(width/termColWidth())-1));
@@ -57,7 +57,7 @@ require([
       var geom = calculate_size();
       terminal.term.resize(geom.cols, geom.rows);
       terminal.socket.send(JSON.stringify(["set_size", geom.rows, geom.cols,
-                                    window.innerHeight, window.innerWidth]));
+                                    $(window).height(), $(window).width()]));
     };
 
 });


### PR DESCRIPTION
to measure window height when resizing contents

Sometimes these values differ by a pixel, we may never know why.

window.innerHeight seems to be larger when they disagree, causing an extra scrollbar to be drawn at some zoom levels.
