### PR TITLE
fix #7986: error if folder exists

### DIFF
--- a/IPython/utils/pickleshare.py
+++ b/IPython/utils/pickleshare.py
@@ -54,7 +54,7 @@ class PickleShareDB(collections.MutableMapping):
         """ Return a db object that will manage the specied directory"""
         self.root = Path(root).expanduser().abspath()
         if not self.root.isdir():
-            self.root.makedirs()
+            self.root.makedirs_p()
         # cache has { 'key' : (obj, orig_mod_time) }
         self.cache = {}
 


### PR DESCRIPTION
this could avoid and error if try to create the folder if it exists when many processes at the same time going through the same lines.
