### PR TITLE
Fix rename issues in dashboard

### DIFF
--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -438,8 +438,8 @@ define([
         });
         this.selected = selected;
 
-        // Rename is only visible when one item is selected.
-        if (selected.length==1) {
+        // Rename is only visible when one item is selected, and it is not a running notebook
+        if (selected.length==1 && !has_running_notebook) {
             $('.rename-button').css('display', 'inline-block');
         } else {
             $('.rename-button').css('display', 'none');
@@ -586,29 +586,32 @@ define([
         if (this.selected.length != 1) return;
 
         var that = this;
-        var path = this.selected[0].path;
+        var item_path = this.selected[0].path;
+        var item_name = this.selected[0].name;
+        var item_type = this.selected[0].type;
+        console.log(this.selected[0]);
         var input = $('<input/>').attr('type','text').attr('size','25').addClass('form-control')
-            .val(path);
+            .val(item_name);
         var dialog_body = $('<div/>').append(
             $("<p/>").addClass("rename-message")
-                .text('Enter a new directory name:')
+                .text('Enter a new '+ item_type + ' name:')
         ).append(
             $("<br/>")
         ).append(input);
         var d = dialog.modal({
-            title : "Rename directory",
+            title : "Rename "+ item_type,
             body : dialog_body,
             buttons : {
                 OK : {
                     class: "btn-primary",
                     click: function() {
-                        that.contents.rename(path, input.val()).then(function() {
+                        that.contents.rename(item_path, utils.url_path_join(that.notebook_path, input.val())).then(function() {
                             that.load_list();
                         }).catch(function(e) { 
                             dialog.modal({
                                 title: "Rename Failed",
                                 body: $('<div/>')
-                                    .text("An error occurred while renaming \"" + path + "\" to \"" + input.val() + "\".")
+                                    .text("An error occurred while renaming \"" + item_name + "\" to \"" + input.val() + "\".")
                                     .append($('<div/>')
                                         .addClass('alert alert-danger')
                                         .text(e.message || e)),

--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -589,7 +589,6 @@ define([
         var item_path = this.selected[0].path;
         var item_name = this.selected[0].name;
         var item_type = this.selected[0].type;
-        console.log(this.selected[0]);
         var input = $('<input/>').attr('type','text').attr('size','25').addClass('form-control')
             .val(item_name);
         var dialog_body = $('<div/>').append(


### PR DESCRIPTION
- Do not display the full path of the selected item in the text box (**warning** : this removes the possibility of moving a file/folder using the rename dialog. Maybe someone finds this helpful)
- Adapt dialog for files and notebook.
- Do not allow renaming a running notebook (currently, renaming a running notebook would result in duplication instead of renaming after the open notebook saves/autosaves using the old name)
