### PR TITLE
Get /files/ unmodified from contents

### DIFF
--- a/IPython/html/files/handlers.py
+++ b/IPython/html/files/handlers.py
@@ -28,12 +28,12 @@ class FilesHandler(IPythonHandler):
         else:
             name = path
         
-        model = cm.get(path)
+        model = cm.get(path, type='file')
         
         if self.get_argument("download", False):
             self.set_header('Content-Disposition','attachment; filename="%s"' % name)
         
-        if model['type'] == 'notebook':
+        if model['type'] == 'notebook' or name.endswith('.ipynb'):
             self.set_header('Content-Type', 'application/json')
         else:
             cur_mime = mimetypes.guess_type(name)[0]

--- a/IPython/html/files/handlers.py
+++ b/IPython/html/files/handlers.py
@@ -33,7 +33,8 @@ class FilesHandler(IPythonHandler):
         if self.get_argument("download", False):
             self.set_header('Content-Disposition','attachment; filename="%s"' % name)
         
-        if model['type'] == 'notebook' or name.endswith('.ipynb'):
+        # get mimetype from filename
+        if name.endswith('.ipynb'):
             self.set_header('Content-Type', 'application/json')
         else:
             cur_mime = mimetypes.guess_type(name)[0]


### PR DESCRIPTION
request raw files instead of parsing notebooks

avoids reserializing (inconsistently) on download of notebooks.
