### PR TITLE
Fix save switch to command mode after shortcut

### DIFF
--- a/IPython/html/static/notebook/js/actions.js
+++ b/IPython/html/static/notebook/js/actions.js
@@ -381,7 +381,7 @@ define(function(require){
                 if(event){
                     event.preventDefault();
                 }
-                env.notebook.focus_cell();
+                env.notebook.ensure_focused();
                 return false;
             }
         },

--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -375,6 +375,12 @@ define([
             return false;
         }
     };
+
+    Cell.prototype.ensure_focused = function() {
+        if(this.element !== document.activeElement && !this.code_mirror.hasFocus()){
+            this.focus_cell();
+        }
+    }
     
     /**
      * Focus the cell in the DOM sense

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -695,6 +695,16 @@ define(function (require) {
             cell.focus_editor();
         }
     };
+    
+    /**
+     * Ensure either cell, or codemirror is focused. Is none 
+     * is focused, focus the cell.
+     */
+    Notebook.prototype.ensure_focused = function(){
+        var cell = this.get_selected_cell();
+        if (cell === null) {return;}  // No cell is selected
+        cell.ensure_focused();
+    }
 
     /**
      * Focus the currently selected cell.


### PR DESCRIPTION
When triggering actions with button one have to refocus the notebook
cell. Though with keyboard shortcut, you don't want cell to switch to
command mode.
