### PR TITLE
Don't re-implement option.click to trigger select.change

### DIFF
--- a/IPython/html/static/widgets/js/widget_selection.js
+++ b/IPython/html/static/widgets/js/widget_selection.js
@@ -557,6 +557,15 @@ define([
             SelectMultipleView.__super__.update.apply(this, arguments);
             this.$listbox.val(this.model.get('selected_labels'));
         },
+        
+        handle_click: function(){
+            /**
+             * Overload click from select
+             *
+             * Apparently it's needed from there for testing purposes,
+             * but breaks behavior of this.
+             */
+        },
 
         handle_change: function (e) {
             /**


### PR DESCRIPTION
This empties the click handler used by SelectMultiple's options, which appears to solve #8012.

I say appears because while I have [tests](https://gist.github.com/bollwyvl/5a6c0dab551f20aba3ac) for the ctrl/shift behavior, I can't make them work reliably. The keyboard stuff (which was working before) is unreliable, but at least seems to understand the event+modifier, but the mouse stuff is nothing. Still investigating casper/phantom APIs to get this right, but in the meantime, this is a pretty self-contained change.
