### PR TITLE
use literal_eval parsing CLI args

### DIFF
--- a/IPython/config/loader.py
+++ b/IPython/config/loader.py
@@ -11,6 +11,7 @@ import os
 import re
 import sys
 import json
+from ast import literal_eval
 
 from IPython.utils.path import filefind, get_ipython_dir
 from IPython.utils import py3compat
@@ -487,7 +488,7 @@ class CommandLineConfigLoader(ConfigLoader):
         """execute self.config.<lhs> = <rhs>
         
         * expands ~ with expanduser
-        * tries to assign with raw eval, otherwise assigns with just the string,
+        * tries to assign with literal_eval, otherwise assigns with just the string,
           allowing `--C.a=foobar` and `--C.a="foobar"` to be equivalent.  *Not*
           equivalent are `--C.a=4` and `--C.a='4'`.
         """
@@ -496,8 +497,8 @@ class CommandLineConfigLoader(ConfigLoader):
             # Try to see if regular Python syntax will work. This
             # won't handle strings as the quote marks are removed
             # by the system shell.
-            value = eval(rhs)
-        except (NameError, SyntaxError):
+            value = literal_eval(rhs)
+        except (NameError, SyntaxError, ValueError):
             # This case happens if the rhs is a string.
             value = rhs
 


### PR DESCRIPTION
avoids 'all', 'str', etc. turning into builtins instead of strings

Thanks @takluyver for pointing me to literal_eval, which I didn't know about

closes #8025
