### PR TITLE
DOC: Update %matplotlib for bbox_inches

### DIFF
--- a/IPython/core/magics/pylab.py
+++ b/IPython/core/magics/pylab.py
@@ -57,9 +57,17 @@ class PylabMagics(Magics):
             
             In [2]: set_matplotlib_formats('pdf', 'svg')
 
-        See the docstring of `IPython.display.set_matplotlib_formats` and
+        The default for inline figures sets `bbox_inches` to 'tight'. This can
+        cause discrepancies between the displayed image and the identical
+        image created using `savefig`. This behavior can be disabled using the
+        `%config` magic::
+            
+            In [3]: %config InlineBackend.print_figure_kwargs = {'bbox_inches':None}
+
+        In addition, see the docstring of
+        `IPython.display.set_matplotlib_formats` and
         `IPython.display.set_matplotlib_close` for more information on
-        changing the behavior of the inline backend.
+        changing additional behaviors of the inline backend.
 
         Examples
         --------


### PR DESCRIPTION
Added a couple of extra lines to the matplotlib magic doc string with instructions on how to shut off the default bbox_inches='tight' behavior.

A little background. Setting bbox_inches to 'tight' for inline figures produces figures that are not identical to ones produced using `savefig` in the same code block. This is problematic when, for example, you are trying to prepare a publication ready figure in the notebook. (You may want to display the figure in the notebook to share the code with collaborators but at the same time produce a very high resolution version for the manuscript.) Adding a couple of lines to the docs to address this problem could help here.
