### PR TITLE
fix css checkbox vertical align, closes #8065

### DIFF
--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -8715,7 +8715,7 @@ ul.breadcrumb span {
   vertical-align: baseline;
   line-height: 22px;
   position: relative;
-  top: 1px;
+  top: -1px;
 }
 .list_header > div .item_link,
 .list_item > div .item_link {

--- a/IPython/html/static/tree/less/tree.less
+++ b/IPython/html/static/tree/less/tree.less
@@ -114,7 +114,7 @@ ul.breadcrumb {
         vertical-align: baseline;
         line-height: @btn_mini_height;
         position: relative;
-        top: 1px;
+        top: -1px;
     }
 
     .item_link {


### PR DESCRIPTION
Number does not seem miss-aligned to me. 

![capture d ecran 2015-03-14 a 14 35 43](https://cloud.githubusercontent.com/assets/335567/6653646/753adb76-ca57-11e4-9386-99a85ee6d918.png)
