### PR TITLE
Removing extra `client.` in example code

### DIFF
--- a/IPython/parallel/client/view.py
+++ b/IPython/parallel/client/view.py
@@ -855,7 +855,7 @@ class LoadBalancedView(View):
 
     or targets can be specified, to restrict the potential destinations:
 
-    >>> v = client.client.load_balanced_view([1,3])
+    >>> v = client.load_balanced_view([1,3])
 
     which would restrict loadbalancing to between engines 1 and 3.
 


### PR DESCRIPTION
I am not 100% sure this is correct in this context.
