### PR TITLE
Let mistune match inline-block-inline math

### DIFF
--- a/IPython/nbconvert/filters/markdown_mistune.py
+++ b/IPython/nbconvert/filters/markdown_mistune.py
@@ -23,7 +23,7 @@ from IPython.utils.decorators import undoc
 
 @undoc
 class MathBlockGrammar(mistune.BlockGrammar):
-    block_math = re.compile("^\$\$([^\$]*?)\$\$", re.DOTALL)
+    block_math = re.compile(r"^\$\$(.*?)\$\$", re.DOTALL)
     latex_environment = re.compile(r"^\\begin\{([a-z]*\*?)\}(.*?)\\end\{\1\}",
                                                 re.DOTALL)
 
@@ -52,12 +52,13 @@ class MathBlockLexer(mistune.BlockLexer):
 
 @undoc
 class MathInlineGrammar(mistune.InlineGrammar):
-    math = re.compile("^\$([^\$]+?)\$")
+    math = re.compile(r"^\$(.+?)\$")
+    block_math = re.compile(r"^\$\$(.+?)\$\$", re.DOTALL)
     text = re.compile(r'^[\s\S]+?(?=[\\<!\[_*`~$]|https?://| {2,}\n|$)')
 
 @undoc
 class MathInlineLexer(mistune.InlineLexer):
-    default_rules = ['math'] + mistune.InlineLexer.default_rules
+    default_rules = ['math', 'block_math'] + mistune.InlineLexer.default_rules
 
     def __init__(self, renderer, rules=None, **kwargs):
         if rules is None:
@@ -66,6 +67,9 @@ class MathInlineLexer(mistune.InlineLexer):
 
     def output_math(self, m):
         return self.renderer.inline_math(m.group(1))
+
+    def output_block_math(self, m):
+        return self.renderer.block_math(m.group(1))
 
 @undoc
 class MarkdownWithMath(mistune.Markdown):

--- a/IPython/nbconvert/filters/markdown_mistune.py
+++ b/IPython/nbconvert/filters/markdown_mistune.py
@@ -23,7 +23,7 @@ from IPython.utils.decorators import undoc
 
 @undoc
 class MathBlockGrammar(mistune.BlockGrammar):
-    block_math = re.compile("^\$\$(.*?)\$\$", re.DOTALL)
+    block_math = re.compile("^\$\$([^\$]*?)\$\$", re.DOTALL)
     latex_environment = re.compile(r"^\\begin\{([a-z]*\*?)\}(.*?)\\end\{\1\}",
                                                 re.DOTALL)
 
@@ -52,7 +52,7 @@ class MathBlockLexer(mistune.BlockLexer):
 
 @undoc
 class MathInlineGrammar(mistune.InlineGrammar):
-    math = re.compile("^\$(.+?)\$")
+    math = re.compile("^\$([^\$]+?)\$")
     text = re.compile(r'^[\s\S]+?(?=[\\<!\[_*`~$]|https?://| {2,}\n|$)')
 
 @undoc

--- a/IPython/nbconvert/filters/tests/test_markdown.py
+++ b/IPython/nbconvert/filters/tests/test_markdown.py
@@ -124,11 +124,35 @@ class TestMarkdown(TestsBase):
             self.assertIn(case, markdown2html(case))
 
     def test_markdown2html_math_paragraph(self):
-        # https://github.com/ipython/ipython/issues/6724
-        a = """Water that is stored in $t$, $s_t$, must equal the storage content of the previous stage,
+        """these should all parse without modification"""
+        patterns = [
+            # https://github.com/ipython/ipython/issues/6724
+            """Water that is stored in $t$, $s_t$, must equal the storage content of the previous stage,
 $s_{t-1}$, plus a stochastic inflow, $I_t$, minus what is being released in $t$, $r_t$.
-With $s_0$ defined as the initial storage content in $t=1$, we have"""
-        self.assertIn(a, markdown2html(a))
+With $s_0$ defined as the initial storage content in $t=1$, we have""",
+            # https://github.com/jupyter/nbviewer/issues/420
+            """$C_{ik}$
+$$
+C_{ik} = \sum_{j=1}
+$$
+$C_{ik}$""",
+            """$m$
+$$
+C = \begin{pmatrix}
+          0 & 0 & 0 & \cdots & 0 & 0 & -c_0 \\
+          0 & 0 & 0 & \cdots & 0 & 1 & -c_{m-1}
+    \end{pmatrix}
+$$
+$x^m$""",
+            """$r=\overline{1,n}$
+$$ {\bf
+b}_{i}^{r}(t)=(1-t)\,{\bf b}_{i}^{r-1}(t)+t\,{\bf b}_{i+1}^{r-1}(t),\:
+ i=\overline{0,n-r}, $$
+i.e. the $i^{th}$"""
+        ]
+
+        for pattern in patterns:
+            self.assertIn(pattern, markdown2html(pattern))
 
     @dec.onlyif_cmds_exist('pandoc')
     def test_markdown2rst(self):

--- a/IPython/nbconvert/filters/tests/test_markdown.py
+++ b/IPython/nbconvert/filters/tests/test_markdown.py
@@ -122,10 +122,20 @@ class TestMarkdown(TestsBase):
                 ]
         for case in cases:
             self.assertIn(case, markdown2html(case))
+    
+    def test_markdown2html_math_mixed(self):
+        """ensure markdown between inline and inline-block math"""
+        case = """The entries of $C$ are given by the exact formula:
+$$
+C_{ik} = \sum_{j=1}^n A_{ij} B_{jk}
+$$
+but there are many ways to _implement_ this computation.   $\approx 2mnp$ flops"""
+        self._try_markdown(markdown2html, case,
+                           case.replace("_implement_", "<em>implement</em>"))
 
     def test_markdown2html_math_paragraph(self):
         """these should all parse without modification"""
-        patterns = [
+        cases = [
             # https://github.com/ipython/ipython/issues/6724
             """Water that is stored in $t$, $s_t$, must equal the storage content of the previous stage,
 $s_{t-1}$, plus a stochastic inflow, $I_t$, minus what is being released in $t$, $r_t$.
@@ -151,8 +161,8 @@ b}_{i}^{r}(t)=(1-t)\,{\bf b}_{i}^{r-1}(t)+t\,{\bf b}_{i+1}^{r-1}(t),\:
 i.e. the $i^{th}$"""
         ]
 
-        for pattern in patterns:
-            self.assertIn(pattern, markdown2html(pattern))
+        for case in cases:
+            self.assertIn(case, markdown2html(case))
 
     @dec.onlyif_cmds_exist('pandoc')
     def test_markdown2rst(self):


### PR DESCRIPTION
Adds fix for jupyter/nbviewer#420, apparently caused by the pattern of:

``` markdown
some paragraph $some inline math$
$$ some block math $$
some other paragraph $some more inline math$
```
