### PR TITLE
Make unicode repr test work on cp1252 Windows

### DIFF
--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -238,7 +238,7 @@ def test_metaclass_repr():
 
 
 def test_unicode_repr():
-    u = u"üniço∂é"
+    u = u"üniçodé"
     ustr = unicode_to_str(u)
     
     class C(object):


### PR DESCRIPTION
Just limit the unicode sample to characters that can be encoded in cp1252.

Should fix Windows + Python 2 test failures that we've been seeing.
