### PR TITLE
Remove _getAttributeNames special case for completion

### DIFF
--- a/IPython/utils/dir2.py
+++ b/IPython/utils/dir2.py
@@ -48,8 +48,7 @@ def dir2(obj):
     """dir2(obj) -> list of strings
 
     Extended version of the Python builtin dir(), which does a few extra
-    checks, and supports common objects with unusual internals that confuse
-    dir(), such as Traits and PyCrust.
+    checks, and handles Traits objects, which can confuse dir().
 
     This version is guaranteed to return only a list of true strings, whereas
     dir() returns anything that objects inject into themselves, even if they
@@ -72,15 +71,13 @@ def dir2(obj):
 
 
     # for objects with Enthought's traits, add trait_names() list
-    # for PyCrust-style, add _getAttributeNames() magic method list
-    for attr in ('trait_names', '_getAttributeNames'):
-        try:
-            func = getattr(obj, attr)
-            if callable(func):
-                words |= set(func())
-        except:
-            # TypeError: obj is class not instance
-            pass
+    try:
+        func = getattr(obj, 'trait_names')
+        if callable(func):
+            words |= set(func())
+    except:
+        # TypeError: obj is class not instance
+        pass
 
     # filter out non-string attributes which may be stuffed by dir() calls
     # and poor coding in third-party modules


### PR DESCRIPTION
`obj._getAttributeNames()` was an API convention used by PyCrust (a wxPython shell) to make dynamically looked up attributes available for tab completion. There should be no need for it since the [`__dir__()` method](https://docs.python.org/3/reference/datamodel.html#object.__dir__) was added to Python for 2.6.

I spent a while looking for code that still defines it, and found two examples:
- [In rosh](https://github.com/OSUrobotics/rosh_core/blob/hydro-devel/rosh/src/rosh/impl/namespace.py#L117), a shell for ROS, the robot operating system. This is probably the most concerning, but looking at the code I think it would need updating to work with current IPython anyway.
- [In a traceback](http://pastebin.com/e6VxHrA1) inside a package called pyriemann. But this isn't the same pyriemann that I can find by searching, so it's hard to tell more about this.

I also found a few examples of object-proxying code that have to explicitly avoid looking up `trait_names` and `_getAttributeNames`, e.g. https://github.com/PressLabs/zipa/commit/ce91363d0f233203caf236ba6bd2c8cf3abf07fe.

This isn't a major pain point if we do prefer to leave it in place. But if we decide to get rid of this check, I would also like to see if it's practical to get rid of the `trait_names` check.
