### PR TITLE
set z-index on output_wrapper

### DIFF
--- a/IPython/html/static/notebook/less/outputarea.less
+++ b/IPython/html/static/notebook/less/outputarea.less
@@ -1,7 +1,9 @@
 div.output_wrapper {
     /* this position must be relative to enable descendents to be absolute within it */
     position: relative;
-    .vbox()
+    .vbox();
+    // avoid scrolled output overlaying input in some strange circumstances
+    z-index: 1;
 }
 
 /* class for the output area when it should be height-limited */

--- a/IPython/html/static/style/ipython.min.css
+++ b/IPython/html/static/style/ipython.min.css
@@ -747,6 +747,7 @@ div.output_wrapper {
   display: flex;
   flex-direction: column;
   align-items: stretch;
+  z-index: 1;
 }
 /* class for the output area when it should be height-limited */
 div.output_scroll {

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -9536,6 +9536,7 @@ div.output_wrapper {
   display: flex;
   flex-direction: column;
   align-items: stretch;
+  z-index: 1;
 }
 /* class for the output area when it should be height-limited */
 div.output_scroll {


### PR DESCRIPTION
avoids scrolled output overlaying input in some strange circumstances

closes #8055 and JuliaLang/IJulia.jl#285
