### PR TITLE
fix javascript mime-type in HTML exporter

### DIFF
--- a/IPython/nbconvert/exporters/html.py
+++ b/IPython/nbconvert/exporters/html.py
@@ -37,7 +37,7 @@ class HTMLExporter(TemplateExporter):
     def default_config(self):
         c = Config({
             'NbConvertBase': {
-                'display_data_priority' : ['text/javascript', 'text/html', 'text/markdown', 'application/pdf', 'image/svg+xml', 'text/latex', 'image/png', 'image/jpeg', 'text/plain']
+                'display_data_priority' : ['application/javascript', 'text/html', 'text/markdown', 'application/pdf', 'image/svg+xml', 'text/latex', 'image/png', 'image/jpeg', 'text/plain']
                 },
             'CSSHTMLHeaderPreprocessor':{
                 'enabled':True

--- a/IPython/nbconvert/exporters/tests/test_html.py
+++ b/IPython/nbconvert/exporters/tests/test_html.py
@@ -5,6 +5,7 @@
 
 from .base import ExportersTestsBase
 from ..html import HTMLExporter
+from IPython.nbformat import v4
 import re
 
 
@@ -66,3 +67,19 @@ class TestHTMLExporter(ExportersTestsBase):
         (output, resources) = HTMLExporter(template_file='basic').from_filename(
             self._get_notebook(nb_name="pngmetadata.ipynb"))
         assert len(output) > 0
+
+    def test_javascript_output(self):
+        nb = v4.new_notebook(
+            cells=[
+                v4.new_code_cell(
+                    outputs=[v4.new_output(
+                        output_type='display_data',
+                        data={
+                            'application/javascript': "javascript_output();"
+                        }
+                    )]
+                )
+            ]
+        )
+        (output, resources) = HTMLExporter(template_file='basic').from_notebook_node(nb)
+        self.assertIn('javascript_output', output)

--- a/IPython/nbconvert/templates/html/basic.tpl
+++ b/IPython/nbconvert/templates/html/basic.tpl
@@ -192,7 +192,7 @@ height={{output.metadata['image/jpeg']['height']}}
 {%- block data_javascript scoped %}
 <div class="output_subarea output_javascript {{extra_class}}">
 <script type="text/javascript">
-{{ output.data['text/javascript'] }}
+{{ output.data['application/javascript'] }}
 </script>
 </div>
 {%- endblock -%}


### PR DESCRIPTION
It's application/javascript, not text/javascript. The result was javascript output never showing up in nbconvert.
