### PR TITLE
remove obsolete `onlyif_any_cmd_exists` on nbconvert tests

### DIFF
--- a/IPython/nbconvert/exporters/tests/base.py
+++ b/IPython/nbconvert/exporters/tests/base.py
@@ -1,26 +1,11 @@
 """Base TestCase class for testing Exporters"""
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, the IPython Development Team.
-#
+# Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
 
 import os
 
-from IPython.testing.decorators import onlyif_any_cmd_exists
-
 from ...tests.base import TestsBase
-
-#-----------------------------------------------------------------------------
-# Class
-#-----------------------------------------------------------------------------
 
 all_raw_mimetypes = {
     'text/x-python',
@@ -39,7 +24,6 @@ class ExportersTestsBase(TestsBase):
     def _get_notebook(self, nb_name='notebook2.ipynb'):
         return os.path.join(self._get_files_path(), nb_name)
     
-    @onlyif_any_cmd_exists('nodejs', 'node', 'pandoc')
     def test_raw_cell_inclusion(self):
         """test raw cell inclusion based on raw_mimetype metadata"""
         if self.should_include_raw is None:

--- a/IPython/nbconvert/exporters/tests/test_html.py
+++ b/IPython/nbconvert/exporters/tests/test_html.py
@@ -1,25 +1,12 @@
 """Tests for HTMLExporter"""
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, the IPython Development Team.
-#
+# Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
 
 from .base import ExportersTestsBase
 from ..html import HTMLExporter
-from IPython.testing.decorators import onlyif_any_cmd_exists
 import re
 
-#-----------------------------------------------------------------------------
-# Class
-#-----------------------------------------------------------------------------
 
 class TestHTMLExporter(ExportersTestsBase):
     """Tests for HTMLExporter"""
@@ -34,7 +21,6 @@ class TestHTMLExporter(ExportersTestsBase):
         HTMLExporter()
 
 
-    @onlyif_any_cmd_exists('nodejs', 'node', 'pandoc')
     def test_export(self):
         """
         Can a HTMLExporter export something?
@@ -43,7 +29,6 @@ class TestHTMLExporter(ExportersTestsBase):
         assert len(output) > 0
 
 
-    @onlyif_any_cmd_exists('nodejs', 'node', 'pandoc')
     def test_export_basic(self):
         """
         Can a HTMLExporter export using the 'basic' template?
@@ -52,7 +37,6 @@ class TestHTMLExporter(ExportersTestsBase):
         assert len(output) > 0
 
 
-    @onlyif_any_cmd_exists('nodejs', 'node', 'pandoc')
     def test_export_full(self):
         """
         Can a HTMLExporter export using the 'full' template?
@@ -60,7 +44,6 @@ class TestHTMLExporter(ExportersTestsBase):
         (output, resources) = HTMLExporter(template_file='full').from_filename(self._get_notebook())
         assert len(output) > 0
 
-    @onlyif_any_cmd_exists('nodejs', 'node', 'pandoc')
     def test_prompt_number(self):
         """
         Does HTMLExporter properly format input and output prompts?
@@ -76,7 +59,6 @@ class TestHTMLExporter(ExportersTestsBase):
         assert re.findall(in_regex, output) == ins
         assert re.findall(out_regex, output) == outs
 
-    @onlyif_any_cmd_exists('nodejs', 'node', 'pandoc')
     def test_png_metadata(self):
         """
         Does HTMLExporter with the 'basic' template treat pngs with width/height metadata correctly?

--- a/IPython/nbconvert/exporters/tests/test_slides.py
+++ b/IPython/nbconvert/exporters/tests/test_slides.py
@@ -1,24 +1,11 @@
 """Tests for SlidesExporter"""
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, the IPython Development Team.
-#
+# Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
 
 from .base import ExportersTestsBase
 from ..slides import SlidesExporter
-from IPython.testing.decorators import onlyif_any_cmd_exists
 
-#-----------------------------------------------------------------------------
-# Class
-#-----------------------------------------------------------------------------
 
 class TestSlidesExporter(ExportersTestsBase):
     """Tests for SlidesExporter"""
@@ -33,7 +20,6 @@ class TestSlidesExporter(ExportersTestsBase):
         SlidesExporter()
 
 
-    @onlyif_any_cmd_exists('nodejs', 'node', 'pandoc')
     def test_export(self):
         """
         Can a SlidesExporter export something?
@@ -42,7 +28,6 @@ class TestSlidesExporter(ExportersTestsBase):
         assert len(output) > 0
 
 
-    @onlyif_any_cmd_exists('nodejs', 'node', 'pandoc')
     def test_export_reveal(self):
         """
         Can a SlidesExporter export using the 'reveal' template?


### PR DESCRIPTION
it could prevent several tests from running that don't depend on external processes.
