### PR TITLE
Reset readline delimiters on exiting debugger

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -302,6 +302,8 @@ class Pdb(OldPdb):
         if hasattr(self, 'old_all_completions'):
             self.shell.Completer.all_completions=self.old_all_completions
 
+        # Pdb sets readline delimiters, so set them back to our own
+        self.shell.readline.set_completer_delims(self.shell.readline_delims)
 
         return OldPdb.do_quit(self, arg)
 


### PR DESCRIPTION
Pdb sets the readline delimiters - this may be new in Python 3.4, I haven't checked. This resets them when you leave the debugger.

Closes gh-8077
