### PR TITLE
TEST: Move test_escape_root to TestFileContentsManager

### DIFF
--- a/IPython/html/services/contents/tests/test_manager.py
+++ b/IPython/html/services/contents/tests/test_manager.py
@@ -16,7 +16,6 @@ from IPython.nbformat import v4 as nbformat
 
 from IPython.utils.tempdir import TemporaryDirectory
 from IPython.utils.traitlets import TraitError
-from IPython.html.utils import url_path_join
 from IPython.testing import decorators as dec
 
 from ..filemanager import FileContentsManager


### PR DESCRIPTION
The tests for [pgcontents](https://github.com/quantopian/pgcontents) assume that `TestContentsManager` is written against only the public API of the ContentsManager base class. The `root_dir` attribute is specific to the FileContentsManager implementation.
