### PR TITLE
catch RuntimeError getting `obj._trait_validate`

### DIFF
--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -457,8 +457,13 @@ class TraitType(object):
             return value
         if hasattr(self, 'validate'):
             value = self.validate(obj, value)
-        if hasattr(obj, '_%s_validate' % self.name):
-            value = getattr(obj, '_%s_validate' % self.name)(value, self)
+        try:
+            obj_validate = getattr(obj, '_%s_validate' % self.name)
+        except (AttributeError, RuntimeError):
+            # Qt mixins raise RuntimeError on missing attrs accessed before __init__
+            pass
+        else:
+            value = obj_validate(value, self)
         return value
 
     def __or__(self, other):


### PR DESCRIPTION
Qt mixins raise RuntimeError on undefined methods when called before `__init__`. Methods defined in Python will be found correctly.
#7603 caused the QtConsole to fail to start.
