### PR TITLE
allow_none=False by default for Instance and Type

### DIFF
--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -174,7 +174,7 @@ class Application(SingletonConfigurable):
         _log_handler.setFormatter(_log_formatter)
     
 
-    log = Instance(logging.Logger, allow_none=True)
+    log = Instance(logging.Logger)
     def _log_default(self):
         """Start logging for this application.
 

--- a/IPython/config/application.py
+++ b/IPython/config/application.py
@@ -174,7 +174,7 @@ class Application(SingletonConfigurable):
         _log_handler.setFormatter(_log_formatter)
     
 
-    log = Instance(logging.Logger)
+    log = Instance(logging.Logger, allow_none=True)
     def _log_default(self):
         """Start logging for this application.
 

--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -372,7 +372,7 @@ class LoggingConfigurable(Configurable):
     is to get the logger from the currently running Application.
     """
 
-    log = Instance('logging.Logger', allow_none=True)
+    log = Instance('logging.Logger')
     def _log_default(self):
         from IPython.utils import log
         return log.get_logger()

--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -34,7 +34,7 @@ class MultipleInstanceError(ConfigurableError):
 class Configurable(HasTraits):
 
     config = Instance(Config, (), {})
-    parent = Instance('IPython.config.configurable.Configurable')
+    parent = Instance('IPython.config.configurable.Configurable', allow_none=True)
 
     def __init__(self, **kwargs):
         """Create a configurable given a config config.
@@ -372,7 +372,7 @@ class LoggingConfigurable(Configurable):
     is to get the logger from the currently running Application.
     """
 
-    log = Instance('logging.Logger')
+    log = Instance('logging.Logger', allow_none=True)
     def _log_default(self):
         from IPython.utils import log
         return log.get_logger()

--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -193,7 +193,7 @@ class AliasManager(Configurable):
 
     default_aliases = List(default_aliases(), config=True)
     user_aliases = List(default_value=[], config=True)
-    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
+    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC', allow_none=True)
 
     def __init__(self, shell=None, **kwargs):
         super(AliasManager, self).__init__(shell=shell, **kwargs)

--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -146,7 +146,7 @@ class BaseIPythonApplication(Application):
         return d
     
     _in_init_profile_dir = False
-    profile_dir = Instance(ProfileDir)
+    profile_dir = Instance(ProfileDir, allow_none=True)
     def _profile_dir_default(self):
         # avoid recursion
         if self._in_init_profile_dir:

--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -146,7 +146,7 @@ class BaseIPythonApplication(Application):
         return d
     
     _in_init_profile_dir = False
-    profile_dir = Instance(ProfileDir, allow_none=True)
+    profile_dir = Instance(ProfileDir)
     def _profile_dir_default(self):
         # avoid recursion
         if self._in_init_profile_dir:

--- a/IPython/core/builtin_trap.py
+++ b/IPython/core/builtin_trap.py
@@ -36,7 +36,8 @@ HideBuiltin = __HideBuiltin()
 
 class BuiltinTrap(Configurable):
 
-    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
+    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC',
+                     allow_none=True)
 
     def __init__(self, shell=None):
         super(BuiltinTrap, self).__init__(shell=shell, config=None)

--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -29,7 +29,8 @@ class DisplayHook(Configurable):
     that gets called anytime user code returns a value.
     """
 
-    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
+    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC',
+                     allow_none=True)
     exec_result = Instance('IPython.core.interactiveshell.ExecutionResult',
                            allow_none=True)
     cull_fraction = Float(0.2)

--- a/IPython/core/extensions.py
+++ b/IPython/core/extensions.py
@@ -46,7 +46,8 @@ class ExtensionManager(Configurable):
     is added to ``sys.path`` automatically.
     """
 
-    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
+    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC',
+                     allow_none=True)
 
     def __init__(self, shell=None, **kwargs):
         super(ExtensionManager, self).__init__(shell=shell, **kwargs)

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -443,7 +443,8 @@ class HistoryManager(HistoryAccessor):
     # Public interface
 
     # An instance of the IPython shell we are attached to
-    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
+    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC',
+                     allow_none=True)
     # Lists to hold processed and raw history. These start with a blank entry
     # so that we can index them starting from 1
     input_hist_parsed = List([""])
@@ -477,11 +478,12 @@ class HistoryManager(HistoryAccessor):
     db_output_cache = List()
     
     # History saving in separate thread
-    save_thread = Instance('IPython.core.history.HistorySavingThread')
+    save_thread = Instance('IPython.core.history.HistorySavingThread',
+                           allow_none=True)
     try:               # Event is a function returning an instance of _Event...
-        save_flag = Instance(threading._Event)
+        save_flag = Instance(threading._Event, allow_none=True)
     except AttributeError:         # ...until Python 3.3, when it's a class.
-        save_flag = Instance(threading.Event)
+        save_flag = Instance(threading.Event, allow_none=True)
     
     # Private interface
     # Variables used to store the three last inputs from the user.  On each new

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -295,13 +295,13 @@ class InteractiveShell(SingletonConfigurable):
     disable_failing_post_execute = CBool(False, config=True,
         help="Don't call post-execute functions that have failed in the past."
     )
-    display_formatter = Instance(DisplayFormatter)
-    displayhook_class = Type(DisplayHook)
-    display_pub_class = Type(DisplayPublisher)
+    display_formatter = Instance(DisplayFormatter, allow_none=True)
+    displayhook_class = Type(DisplayHook, allow_none=True)
+    display_pub_class = Type(DisplayPublisher, allow_none=True)
     data_pub_class = None
 
     exit_now = CBool(False)
-    exiter = Instance(ExitAutocall)
+    exiter = Instance(ExitAutocall, allow_none=True)
     def _exiter_default(self):
         return ExitAutocall(self)
     # Monotonically increasing execution counter
@@ -435,16 +435,16 @@ class InteractiveShell(SingletonConfigurable):
                             default_value='Context', config=True)
 
     # Subcomponents of InteractiveShell
-    alias_manager = Instance('IPython.core.alias.AliasManager')
-    prefilter_manager = Instance('IPython.core.prefilter.PrefilterManager')
-    builtin_trap = Instance('IPython.core.builtin_trap.BuiltinTrap')
-    display_trap = Instance('IPython.core.display_trap.DisplayTrap')
-    extension_manager = Instance('IPython.core.extensions.ExtensionManager')
-    payload_manager = Instance('IPython.core.payload.PayloadManager')
-    history_manager = Instance('IPython.core.history.HistoryAccessorBase')
-    magics_manager = Instance('IPython.core.magic.MagicsManager')
+    alias_manager = Instance('IPython.core.alias.AliasManager', allow_none=True)
+    prefilter_manager = Instance('IPython.core.prefilter.PrefilterManager', allow_none=True)
+    builtin_trap = Instance('IPython.core.builtin_trap.BuiltinTrap', allow_none=True)
+    display_trap = Instance('IPython.core.display_trap.DisplayTrap', allow_none=True)
+    extension_manager = Instance('IPython.core.extensions.ExtensionManager', allow_none=True)
+    payload_manager = Instance('IPython.core.payload.PayloadManager', allow_none=True)
+    history_manager = Instance('IPython.core.history.HistoryAccessorBase', allow_none=True)
+    magics_manager = Instance('IPython.core.magic.MagicsManager', allow_none=True)
 
-    profile_dir = Instance('IPython.core.application.ProfileDir')
+    profile_dir = Instance('IPython.core.application.ProfileDir', allow_none=True)
     @property
     def profile(self):
         if self.profile_dir is not None:
@@ -453,7 +453,7 @@ class InteractiveShell(SingletonConfigurable):
 
 
     # Private interface
-    _post_execute = Instance(dict)
+    _post_execute = Instance(dict, allow_none=True)
 
     # Tracks any GUI loop loaded for pylab
     pylab_gui_select = None

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -301,7 +301,7 @@ class InteractiveShell(SingletonConfigurable):
     data_pub_class = None
 
     exit_now = CBool(False)
-    exiter = Instance(ExitAutocall, allow_none=True)
+    exiter = Instance(ExitAutocall)
     def _exiter_default(self):
         return ExitAutocall(self)
     # Monotonically increasing execution counter
@@ -453,7 +453,7 @@ class InteractiveShell(SingletonConfigurable):
 
 
     # Private interface
-    _post_execute = Instance(dict, allow_none=True)
+    _post_execute = Dict()
 
     # Tracks any GUI loop loaded for pylab
     pylab_gui_select = None

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -73,7 +73,7 @@ from IPython.utils.syspathcontext import prepended_to_syspath
 from IPython.utils.text import (format_screen, LSString, SList,
                                 DollarFormatter)
 from IPython.utils.traitlets import (Integer, Bool, CBool, CaselessStrEnum, Enum,
-                                     List, Unicode, Instance, Type)
+                                     List, Dict, Unicode, Instance, Type)
 from IPython.utils.warn import warn, error
 import IPython.core.hooks
 
@@ -296,8 +296,8 @@ class InteractiveShell(SingletonConfigurable):
         help="Don't call post-execute functions that have failed in the past."
     )
     display_formatter = Instance(DisplayFormatter, allow_none=True)
-    displayhook_class = Type(DisplayHook, allow_none=True)
-    display_pub_class = Type(DisplayPublisher, allow_none=True)
+    displayhook_class = Type(DisplayHook)
+    display_pub_class = Type(DisplayPublisher)
     data_pub_class = None
 
     exit_now = CBool(False)

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -301,7 +301,7 @@ class MagicsManager(Configurable):
     # A registry of the original objects that we've been given holding magics.
     registry = Dict
 
-    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
+    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC', allow_none=True)
 
     auto_magic = Bool(True, config=True, help=
         "Automatically call line magics without requiring explicit % prefix")
@@ -313,7 +313,7 @@ class MagicsManager(Configurable):
         'Automagic is OFF, % prefix IS needed for line magics.',
         'Automagic is ON, % prefix IS NOT needed for line magics.']
 
-    user_magics = Instance('IPython.core.magics.UserMagics')
+    user_magics = Instance('IPython.core.magics.UserMagics', allow_none=True)
 
     def __init__(self, shell=None, config=None, user_magics=None, **traits):
 

--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -130,7 +130,7 @@ class PrefilterManager(Configurable):
     """
 
     multi_line_specials = CBool(True, config=True)
-    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
+    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC', allow_none=True)
 
     def __init__(self, shell=None, **kwargs):
         super(PrefilterManager, self).__init__(shell=shell, **kwargs)
@@ -362,8 +362,8 @@ class PrefilterTransformer(Configurable):
     priority = Integer(100, config=True)
     # Transformers don't currently use shell or prefilter_manager, but as we
     # move away from checkers and handlers, they will need them.
-    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
-    prefilter_manager = Instance('IPython.core.prefilter.PrefilterManager')
+    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC', allow_none=True)
+    prefilter_manager = Instance('IPython.core.prefilter.PrefilterManager', allow_none=True)
     enabled = Bool(True, config=True)
 
     def __init__(self, shell=None, prefilter_manager=None, **kwargs):
@@ -390,8 +390,8 @@ class PrefilterChecker(Configurable):
     """Inspect an input line and return a handler for that line."""
 
     priority = Integer(100, config=True)
-    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
-    prefilter_manager = Instance('IPython.core.prefilter.PrefilterManager')
+    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC', allow_none=True)
+    prefilter_manager = Instance('IPython.core.prefilter.PrefilterManager', allow_none=True)
     enabled = Bool(True, config=True)
 
     def __init__(self, shell=None, prefilter_manager=None, **kwargs):
@@ -540,8 +540,8 @@ class PrefilterHandler(Configurable):
 
     handler_name = Unicode('normal')
     esc_strings = List([])
-    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
-    prefilter_manager = Instance('IPython.core.prefilter.PrefilterManager')
+    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC', allow_none=True)
+    prefilter_manager = Instance('IPython.core.prefilter.PrefilterManager', allow_none=True)
 
     def __init__(self, shell=None, prefilter_manager=None, **kwargs):
         super(PrefilterHandler, self).__init__(

--- a/IPython/core/prompts.py
+++ b/IPython/core/prompts.py
@@ -278,9 +278,9 @@ class UserNSFormatter(Formatter):
 
 class PromptManager(Configurable):
     """This is the primary interface for producing IPython's prompts."""
-    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
+    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC', allow_none=True)
     
-    color_scheme_table = Instance(coloransi.ColorSchemeTable)
+    color_scheme_table = Instance(coloransi.ColorSchemeTable, allow_none=True)
     color_scheme = Unicode('Linux', config=True)
     def _color_scheme_changed(self, name, new_value):
         self.color_scheme_table.set_active_scheme(new_value)

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -194,7 +194,8 @@ class InteractiveShellApp(Configurable):
         When False, pylab mode should not import any names into the user namespace.
         """
     )
-    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
+    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC',
+                     allow_none=True)
     
     user_ns = Instance(dict, args=None, allow_none=True)
     def _user_ns_changed(self, name, old, new):

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -665,7 +665,7 @@ class NotebookApp(BaseIPythonApplication):
         help='The config manager class to use'
     )
 
-    kernel_spec_manager = Instance(KernelSpecManager)
+    kernel_spec_manager = Instance(KernelSpecManager, allow_none=True)
 
     kernel_spec_manager_class = Type(
         default_value=KernelSpecManager,

--- a/IPython/html/services/clusters/clustermanager.py
+++ b/IPython/html/services/clusters/clustermanager.py
@@ -20,7 +20,7 @@ class ClusterManager(LoggingConfigurable):
     delay = Float(1., config=True,
         help="delay (in s) between starting the controller and the engines")
 
-    loop = Instance('zmq.eventloop.ioloop.IOLoop', allow_none=True)
+    loop = Instance('zmq.eventloop.ioloop.IOLoop')
     def _loop_default(self):
         from zmq.eventloop.ioloop import IOLoop
         return IOLoop.instance()

--- a/IPython/html/services/clusters/clustermanager.py
+++ b/IPython/html/services/clusters/clustermanager.py
@@ -20,7 +20,7 @@ class ClusterManager(LoggingConfigurable):
     delay = Float(1., config=True,
         help="delay (in s) between starting the controller and the engines")
 
-    loop = Instance('zmq.eventloop.ioloop.IOLoop')
+    loop = Instance('zmq.eventloop.ioloop.IOLoop', allow_none=True)
     def _loop_default(self):
         from zmq.eventloop.ioloop import IOLoop
         return IOLoop.instance()

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -129,7 +129,7 @@ class Widget(LoggingConfigurable):
         If empty, look in the global registry.""", sync=True)
     _view_name = Unicode(None, allow_none=True, help="""Default view registered in the front-end
         to use to represent the widget.""", sync=True)
-    comm = Instance('IPython.kernel.comm.Comm')
+    comm = Instance('IPython.kernel.comm.Comm', allow_none=True)
     
     msg_throttle = Int(3, sync=True, help="""Maximum number of msgs the 
         front-end can send before receiving an idle msg from the back-end.""")

--- a/IPython/kernel/inprocess/client.py
+++ b/IPython/kernel/inprocess/client.py
@@ -44,7 +44,8 @@ class InProcessKernelClient(KernelClient):
     stdin_channel_class = Type(InProcessChannel)
     hb_channel_class = Type(InProcessHBChannel)
 
-    kernel = Instance('IPython.kernel.inprocess.ipkernel.InProcessKernel')
+    kernel = Instance('IPython.kernel.inprocess.ipkernel.InProcessKernel', 
+                      allow_none=True)
 
     #--------------------------------------------------------------------------
     # Channel management methods

--- a/IPython/kernel/inprocess/ipkernel.py
+++ b/IPython/kernel/inprocess/ipkernel.py
@@ -46,7 +46,7 @@ class InProcessKernel(IPythonKernel):
     # Kernel interface
     #-------------------------------------------------------------------------
 
-    shell_class = Type()
+    shell_class = Type(allow_none=True)
     shell_streams = List()
     control_stream = Any()
     iopub_socket = Instance(DummySocket, ())

--- a/IPython/kernel/inprocess/ipkernel.py
+++ b/IPython/kernel/inprocess/ipkernel.py
@@ -27,7 +27,8 @@ class InProcessKernel(IPythonKernel):
 
     # The frontends connected to this kernel.
     frontends = List(
-        Instance('IPython.kernel.inprocess.client.InProcessKernelClient')
+        Instance('IPython.kernel.inprocess.client.InProcessKernelClient'
+                 allow_none=True)
     )
 
     # The GUI environment that the kernel is running under. This need not be
@@ -140,7 +141,8 @@ class InProcessKernel(IPythonKernel):
 
 class InProcessInteractiveShell(ZMQInteractiveShell):
 
-    kernel = Instance('IPython.kernel.inprocess.ipkernel.InProcessKernel')
+    kernel = Instance('IPython.kernel.inprocess.ipkernel.InProcessKernel',
+                      allow_none=True)
 
     #-------------------------------------------------------------------------
     # InteractiveShell interface

--- a/IPython/kernel/inprocess/ipkernel.py
+++ b/IPython/kernel/inprocess/ipkernel.py
@@ -27,7 +27,7 @@ class InProcessKernel(IPythonKernel):
 
     # The frontends connected to this kernel.
     frontends = List(
-        Instance('IPython.kernel.inprocess.client.InProcessKernelClient'
+        Instance('IPython.kernel.inprocess.client.InProcessKernelClient',
                  allow_none=True)
     )
 

--- a/IPython/kernel/inprocess/manager.py
+++ b/IPython/kernel/inprocess/manager.py
@@ -20,7 +20,8 @@ class InProcessKernelManager(KernelManager):
     """
 
     # The kernel process with which the KernelManager is communicating.
-    kernel = Instance('IPython.kernel.inprocess.ipkernel.InProcessKernel')
+    kernel = Instance('IPython.kernel.inprocess.ipkernel.InProcessKernel',
+                      allow_none=True)
     # the client class for KM.client() shortcut
     client_class = DottedObjectName('IPython.kernel.inprocess.BlockingInProcessKernelClient')
     

--- a/IPython/kernel/ioloop/manager.py
+++ b/IPython/kernel/ioloop/manager.py
@@ -36,11 +36,11 @@ def as_zmqstream(f):
 
 class IOLoopKernelManager(KernelManager):
 
-    loop = Instance('zmq.eventloop.ioloop.IOLoop', allow_none=False)
+    loop = Instance('zmq.eventloop.ioloop.IOLoop')
     def _loop_default(self):
         return ioloop.IOLoop.instance()
 
-    _restarter = Instance('IPython.kernel.ioloop.IOLoopKernelRestarter')
+    _restarter = Instance('IPython.kernel.ioloop.IOLoopKernelRestarter', allow_none=True)
 
     def start_restarter(self):
         if self.autorestart and self.has_kernel:

--- a/IPython/kernel/ioloop/restarter.py
+++ b/IPython/kernel/ioloop/restarter.py
@@ -32,7 +32,7 @@ from IPython.utils.traitlets import (
 class IOLoopKernelRestarter(KernelRestarter):
     """Monitor and autorestart a kernel."""
 
-    loop = Instance('zmq.eventloop.ioloop.IOLoop', allow_none=False)
+    loop = Instance('zmq.eventloop.ioloop.IOLoop')
     def _loop_default(self):
         return ioloop.IOLoop.instance()
 

--- a/IPython/kernel/manager.py
+++ b/IPython/kernel/manager.py
@@ -49,7 +49,7 @@ class KernelManager(ConnectionFileMixin):
 
     # the class to create with our `client` method
     client_class = DottedObjectName('IPython.kernel.blocking.BlockingKernelClient')
-    client_factory = Type()
+    client_factory = Type(allow_none=True)
     def _client_class_changed(self, name, old, new):
         self.client_factory = import_item(str(new))
 

--- a/IPython/kernel/zmq/datapub.py
+++ b/IPython/kernel/zmq/datapub.py
@@ -27,8 +27,8 @@ from IPython.kernel.zmq.session import Session, extract_header
 class ZMQDataPublisher(Configurable):
 
     topic = topic = CBytes(b'datapub')
-    session = Instance(Session)
-    pub_socket = Instance(SocketABC)
+    session = Instance(Session, allow_none=True)
+    pub_socket = Instance(SocketABC, allow_none=True)
     parent_header = Dict({})
 
     def set_parent(self, parent):

--- a/IPython/kernel/zmq/displayhook.py
+++ b/IPython/kernel/zmq/displayhook.py
@@ -42,8 +42,8 @@ class ZMQShellDisplayHook(DisplayHook):
     representations of the object."""
     topic=None
 
-    session = Instance(Session)
-    pub_socket = Instance(SocketABC)
+    session = Instance(Session, allow_none=True)
+    pub_socket = Instance(SocketABC, allow_none=True)
     parent_header = Dict({})
 
     def set_parent(self, parent):

--- a/IPython/kernel/zmq/ipkernel.py
+++ b/IPython/kernel/zmq/ipkernel.py
@@ -22,7 +22,8 @@ def lazy_import_handle_comm_opened(*args, **kwargs):
 
 
 class IPythonKernel(KernelBase):
-    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
+    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC',
+                     allow_none=True)
     shell_class = Type(ZMQInteractiveShell)
 
     user_module = Any()

--- a/IPython/kernel/zmq/kernelapp.py
+++ b/IPython/kernel/zmq/kernelapp.py
@@ -108,7 +108,7 @@ class IPKernelApp(BaseIPythonApplication, InteractiveShellApp,
     """)
     kernel = Any()
     poller = Any() # don't restrict this even though current pollers are all Threads
-    heartbeat = Instance(Heartbeat)
+    heartbeat = Instance(Heartbeat, allow_none=True)
     ports = Dict()
     
     # connection info:

--- a/IPython/kernel/zmq/kernelbase.py
+++ b/IPython/kernel/zmq/kernelbase.py
@@ -45,13 +45,13 @@ class Kernel(SingletonConfigurable):
         loop = ioloop.IOLoop.instance()
         loop.add_callback(self.enter_eventloop)
 
-    session = Instance(Session)
-    profile_dir = Instance('IPython.core.profiledir.ProfileDir')
+    session = Instance(Session, allow_none=True)
+    profile_dir = Instance('IPython.core.profiledir.ProfileDir', allow_none=True)
     shell_streams = List()
-    control_stream = Instance(ZMQStream)
-    iopub_socket = Instance(zmq.Socket)
-    stdin_socket = Instance(zmq.Socket)
-    log = Instance(logging.Logger)
+    control_stream = Instance(ZMQStream, allow_none=True)
+    iopub_socket = Instance(zmq.Socket, allow_none=True)
+    stdin_socket = Instance(zmq.Socket, allow_none=True)
+    log = Instance(logging.Logger, allow_none=True)
 
     # identities:
     int_id = Integer(-1)

--- a/IPython/kernel/zmq/pylab/config.py
+++ b/IPython/kernel/zmq/pylab/config.py
@@ -114,6 +114,7 @@ class InlineBackend(InlineBackendConfig):
         be explicit.
         """)
     
-    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
+    shell = Instance('IPython.core.interactiveshell.InteractiveShellABC',
+                     allow_none=True)
 
 

--- a/IPython/kernel/zmq/session.py
+++ b/IPython/kernel/zmq/session.py
@@ -148,9 +148,10 @@ class SessionFactory(LoggingConfigurable):
     def _context_default(self):
         return zmq.Context.instance()
 
-    session = Instance('IPython.kernel.zmq.session.Session')
+    session = Instance('IPython.kernel.zmq.session.Session',
+                       allow_none=True)
 
-    loop = Instance('zmq.eventloop.ioloop.IOLoop', allow_none=False)
+    loop = Instance('zmq.eventloop.ioloop.IOLoop')
     def _loop_default(self):
         return IOLoop.instance()
 

--- a/IPython/kernel/zmq/session.py
+++ b/IPython/kernel/zmq/session.py
@@ -341,7 +341,7 @@ class Session(Configurable):
     def _digest_mod_default(self):
         return hashlib.sha256
     
-    auth = Instance(hmac.HMAC)
+    auth = Instance(hmac.HMAC, allow_none=True)
     
     def _new_auth(self):
         if self.key:

--- a/IPython/kernel/zmq/zmqshell.py
+++ b/IPython/kernel/zmq/zmqshell.py
@@ -367,7 +367,7 @@ class ZMQInteractiveShell(InteractiveShell):
     # will print a warning in the absence of readline.
     autoindent = CBool(False)
 
-    exiter = Instance(ZMQExitAutocall, allow_none=True)
+    exiter = Instance(ZMQExitAutocall)
     def _exiter_default(self):
         return ZMQExitAutocall(self)
     

--- a/IPython/kernel/zmq/zmqshell.py
+++ b/IPython/kernel/zmq/zmqshell.py
@@ -58,8 +58,8 @@ from .session import Session
 class ZMQDisplayPublisher(DisplayPublisher):
     """A display publisher that publishes data using a ZeroMQ PUB socket."""
 
-    session = Instance(Session)
-    pub_socket = Instance(SocketABC)
+    session = Instance(Session, allow_none=True)
+    pub_socket = Instance(SocketABC, allow_none=True)
     parent_header = Dict({})
     topic = CBytes(b'display_data')
 
@@ -367,7 +367,7 @@ class ZMQInteractiveShell(InteractiveShell):
     # will print a warning in the absence of readline.
     autoindent = CBool(False)
 
-    exiter = Instance(ZMQExitAutocall)
+    exiter = Instance(ZMQExitAutocall, allow_none=True)
     def _exiter_default(self):
         return ZMQExitAutocall(self)
     

--- a/IPython/utils/tests/test_traitlets.py
+++ b/IPython/utils/tests/test_traitlets.py
@@ -445,7 +445,7 @@ class TestType(TestCase):
 
         class B(object): pass
         class A(HasTraits):
-            klass = Type
+            klass = Type(allow_none=True)
 
         a = A()
         self.assertEqual(a.klass, None)
@@ -472,7 +472,7 @@ class TestType(TestCase):
         class B(object): pass
         class C(B): pass
         class A(HasTraits):
-            klass = Type(B, allow_none=False)
+            klass = Type(B)
 
         a = A()
         self.assertEqual(a.klass, B)
@@ -501,7 +501,7 @@ class TestType(TestCase):
         self.assertRaises(ImportError, A)
 
         class C(HasTraits):
-            klass = Type(None, B, allow_none=False)
+            klass = Type(None, B)
 
         self.assertRaises(TraitError, C)
 
@@ -534,7 +534,7 @@ class TestInstance(TestCase):
         class Bah(object): pass
 
         class A(HasTraits):
-            inst = Instance(Foo)
+            inst = Instance(Foo, allow_none=True)
 
         a = A()
         self.assertTrue(a.inst is None)
@@ -555,7 +555,7 @@ class TestInstance(TestCase):
             klass = Foo
 
         class A(HasTraits):
-            inst = FooInstance()
+            inst = FooInstance(allow_none=True)
 
         a = A()
         self.assertTrue(a.inst is None)
@@ -596,7 +596,7 @@ class TestInstance(TestCase):
         self.assertEqual(b.inst.d, 20)
 
         class C(HasTraits):
-            inst = Instance(Foo)
+            inst = Instance(Foo, allow_none=True)
         c = C()
         self.assertTrue(c.inst is None)
 
@@ -604,7 +604,7 @@ class TestInstance(TestCase):
         class Foo(object): pass
 
         class A(HasTraits):
-            inst = Instance(Foo, allow_none=False)
+            inst = Instance(Foo)
 
         self.assertRaises(TraitError, A)
 
@@ -951,7 +951,7 @@ class Foo(object):
 
 class NoneInstanceListTrait(HasTraits):
     
-    value = List(Instance(Foo, allow_none=False))
+    value = List(Instance(Foo))
 
 class TestNoneInstanceList(TraitTestBase):
 
@@ -975,7 +975,7 @@ class TestInstanceList(TraitTestBase):
         self.assertIs(self.obj.traits()['value']._trait.klass, Foo)
 
     _default_value = []
-    _good_values = [[Foo(), Foo(), None], []]
+    _good_values = [[Foo(), Foo()], []]
     _bad_values = [['1', 2,], '1', [Foo], None]
 
 class UnionListTrait(HasTraits):
@@ -1120,7 +1120,7 @@ class TestValidationHook(TestCase):
         class Parity(HasTraits):
 
             value = Int(0)
-            parity = Enum(['odd', 'even'], default_value='even', allow_none=False)
+            parity = Enum(['odd', 'even'], default_value='even')
 
             def _value_validate(self, value, trait):
                 if self.parity == 'even' and value % 2:
@@ -1469,11 +1469,11 @@ class TestEventful(TestCase):
 ###
 class ForwardDeclaredInstanceTrait(HasTraits):
 
-    value = ForwardDeclaredInstance('ForwardDeclaredBar')
+    value = ForwardDeclaredInstance('ForwardDeclaredBar', allow_none=True)
 
 class ForwardDeclaredTypeTrait(HasTraits):
 
-    value = ForwardDeclaredType('ForwardDeclaredBar')
+    value = ForwardDeclaredType('ForwardDeclaredBar', allow_none=True)
 
 class ForwardDeclaredInstanceListTrait(HasTraits):
 
@@ -1525,16 +1525,16 @@ class TestForwardDeclaredInstanceList(TraitTestBase):
 
     _default_value = []
     _good_values = [
-        [ForwardDeclaredBar(), ForwardDeclaredBarSub(), None],
-        [None],
+        [ForwardDeclaredBar(), ForwardDeclaredBarSub()],
         [],
     ]
     _bad_values = [
         ForwardDeclaredBar(),
-        [ForwardDeclaredBar(), 3],
+        [ForwardDeclaredBar(), 3, None],
         '1',
         # Note that this is the type, not an instance.
         [ForwardDeclaredBar],
+        [None],
         None,
     ]
 
@@ -1548,9 +1548,8 @@ class TestForwardDeclaredTypeList(TraitTestBase):
 
     _default_value = []
     _good_values = [
-        [ForwardDeclaredBar, ForwardDeclaredBarSub, None],
+        [ForwardDeclaredBar, ForwardDeclaredBarSub],
         [],
-        [None],
     ]
     _bad_values = [
         ForwardDeclaredBar,
@@ -1558,6 +1557,7 @@ class TestForwardDeclaredTypeList(TraitTestBase):
         '1',
         # Note that this is an instance, not the type.
         [ForwardDeclaredBar()],
+        [None],
         None,
     ]
 ###

--- a/IPython/utils/traitlets.py
+++ b/IPython/utils/traitlets.py
@@ -852,7 +852,8 @@ class ClassBasedTraitType(TraitType):
 class Type(ClassBasedTraitType):
     """A trait whose value must be a subclass of a specified class."""
 
-    def __init__ (self, default_value=None, klass=None, allow_none=True, **metadata ):
+    def __init__ (self, default_value=None, klass=None, allow_none=False,
+                  **metadata):
         """Construct a Type trait
 
         A Type trait specifies that its values must be subclasses of
@@ -952,8 +953,8 @@ class Instance(ClassBasedTraitType):
 
     klass = None
 
-    def __init__(self, klass=None, args=None, kw=None,
-                 allow_none=True, **metadata ):
+    def __init__(self, klass=None, args=None, kw=None, allow_none=False,
+                 **metadata ):
         """Construct an Instance trait.
 
         This trait allows values that are instances of a particular
@@ -1656,7 +1657,7 @@ class Tuple(Container):
         if self._traits and default_value is None:
             # don't allow default to be an empty container if length is specified
             args = None
-        super(Container,self).__init__(klass=self.klass, args=args, **metadata)
+        super(Container,self).__init__(klass=self.klass, args=args, allow_none=allow_none, **metadata)
 
     def validate_elements(self, obj, value):
         if not self._traits:

--- a/ipython_parallel/apps/baseapp.py
+++ b/ipython_parallel/apps/baseapp.py
@@ -123,7 +123,7 @@ class BaseParallelApplication(BaseIPythonApplication):
     def _config_files_default(self):
         return ['ipcontroller_config.py', 'ipengine_config.py', 'ipcluster_config.py']
     
-    loop = Instance('zmq.eventloop.ioloop.IOLoop')
+    loop = Instance('zmq.eventloop.ioloop.IOLoop', allow_none=True)
     def _loop_default(self):
         from zmq.eventloop.ioloop import IOLoop
         return IOLoop.instance()

--- a/ipython_parallel/apps/baseapp.py
+++ b/ipython_parallel/apps/baseapp.py
@@ -123,7 +123,7 @@ class BaseParallelApplication(BaseIPythonApplication):
     def _config_files_default(self):
         return ['ipcontroller_config.py', 'ipengine_config.py', 'ipcluster_config.py']
     
-    loop = Instance('zmq.eventloop.ioloop.IOLoop', allow_none=True)
+    loop = Instance('zmq.eventloop.ioloop.IOLoop')
     def _loop_default(self):
         from zmq.eventloop.ioloop import IOLoop
         return IOLoop.instance()

--- a/ipython_parallel/apps/ipengineapp.py
+++ b/ipython_parallel/apps/ipengineapp.py
@@ -174,7 +174,7 @@ class IPEngineApp(BaseParallelApplication):
         logging to a central location.""")
     
     # an IPKernelApp instance, used to setup listening for shell frontends
-    kernel_app = Instance(IPKernelApp)
+    kernel_app = Instance(IPKernelApp, allow_none=True)
 
     aliases = Dict(aliases)
     flags = Dict(flags)

--- a/ipython_parallel/apps/launcher.py
+++ b/ipython_parallel/apps/launcher.py
@@ -102,7 +102,7 @@ class BaseLauncher(LoggingConfigurable):
     # controller_args, engine_args attributes of the launchers to add
     # the work_dir option.
     work_dir = Unicode(u'.')
-    loop = Instance('zmq.eventloop.ioloop.IOLoop')
+    loop = Instance('zmq.eventloop.ioloop.IOLoop', allow_none=True)
 
     start_data = Any()
     stop_data = Any()

--- a/ipython_parallel/apps/logwatcher.py
+++ b/ipython_parallel/apps/logwatcher.py
@@ -52,7 +52,7 @@ class LogWatcher(LoggingConfigurable):
     # internals
     stream = Instance('zmq.eventloop.zmqstream.ZMQStream', allow_none=True)
     
-    context = Instance(zmq.Context, allow_none=True)
+    context = Instance(zmq.Context)
     def _context_default(self):
         return zmq.Context.instance()
     

--- a/ipython_parallel/apps/logwatcher.py
+++ b/ipython_parallel/apps/logwatcher.py
@@ -56,7 +56,7 @@ class LogWatcher(LoggingConfigurable):
     def _context_default(self):
         return zmq.Context.instance()
     
-    loop = Instance(zmq.eventloop.ioloop.IOLoop, allow_none=True)
+    loop = Instance(zmq.eventloop.ioloop.IOLoop)
     def _loop_default(self):
         return ioloop.IOLoop.instance()
     

--- a/ipython_parallel/apps/logwatcher.py
+++ b/ipython_parallel/apps/logwatcher.py
@@ -50,13 +50,13 @@ class LogWatcher(LoggingConfigurable):
         return 'tcp://%s:20202' % localhost()
     
     # internals
-    stream = Instance('zmq.eventloop.zmqstream.ZMQStream')
+    stream = Instance('zmq.eventloop.zmqstream.ZMQStream', allow_none=True)
     
-    context = Instance(zmq.Context)
+    context = Instance(zmq.Context, allow_none=True)
     def _context_default(self):
         return zmq.Context.instance()
     
-    loop = Instance(zmq.eventloop.ioloop.IOLoop)
+    loop = Instance(zmq.eventloop.ioloop.IOLoop, allow_none=True)
     def _loop_default(self):
         return ioloop.IOLoop.instance()
     

--- a/ipython_parallel/client/view.py
+++ b/ipython_parallel/client/view.py
@@ -603,7 +603,7 @@ class DirectView(View):
 
 
         If block=False
-          An :class:`~IPython.parallel.client.asyncresult.AsyncMapResult` instance.
+          An :class:`~ipython_parallel.client.asyncresult.AsyncMapResult` instance.
           An object like AsyncResult, but which reassembles the sequence of results
           into a single list. AsyncMapResults can be iterated through before all
           results are complete.

--- a/ipython_parallel/client/view.py
+++ b/ipython_parallel/client/view.py
@@ -107,7 +107,7 @@ class View(HasTraits):
     history=List()
     outstanding = Set()
     results = Dict()
-    client = Instance('ipython_parallel.Client')
+    client = Instance('ipython_parallel.Client', allow_none=True)
 
     _socket = Instance('zmq.Socket')
     _flag_names = List(['targets', 'block', 'track'])
@@ -215,7 +215,7 @@ class View(HasTraits):
 
         This method sets all apply flags via this View's attributes.
 
-        Returns :class:`~ipython_parallel.client.asyncresult.AsyncResult`
+        Returns :class:`~IPython.parallel.client.asyncresult.AsyncResult`
         instance if ``self.block`` is False, otherwise the return value of
         ``f(*args, **kwargs)``.
         """
@@ -224,7 +224,7 @@ class View(HasTraits):
     def apply_async(self, f, *args, **kwargs):
         """calls ``f(*args, **kwargs)`` on remote engines in a nonblocking manner.
 
-        Returns :class:`~ipython_parallel.client.asyncresult.AsyncResult` instance.
+        Returns :class:`~IPython.parallel.client.asyncresult.AsyncResult` instance.
         """
         return self._really_apply(f, args, kwargs, block=False)
 
@@ -307,7 +307,7 @@ class View(HasTraits):
     def get_result(self, indices_or_msg_ids=None, block=None, owner=True):
         """return one or more results, specified by history index or msg_id.
 
-        See :meth:`ipython_parallel.client.client.Client.get_result` for details.
+        See :meth:`IPython.parallel.client.client.Client.get_result` for details.
         """
 
         if indices_or_msg_ids is None:
@@ -603,7 +603,7 @@ class DirectView(View):
 
 
         If block=False
-          An :class:`~ipython_parallel.client.asyncresult.AsyncMapResult` instance.
+          An :class:`~IPython.parallel.client.asyncresult.AsyncMapResult` instance.
           An object like AsyncResult, but which reassembles the sequence of results
           into a single list. AsyncMapResults can be iterated through before all
           results are complete.
@@ -832,7 +832,7 @@ class DirectView(View):
             on the even engines.
         """
         
-        from ipython_parallel.client.magics import ParallelMagics
+        from IPython.parallel.client.magics import ParallelMagics
         
         try:
             # This is injected into __builtins__.
@@ -1099,7 +1099,7 @@ class LoadBalancedView(View):
         -------
 
         if block=False
-          An :class:`~ipython_parallel.client.asyncresult.AsyncMapResult` instance.
+          An :class:`~IPython.parallel.client.asyncresult.AsyncMapResult` instance.
           An object like AsyncResult, but which reassembles the sequence of results
           into a single list. AsyncMapResults can be iterated through before all
           results are complete.

--- a/ipython_parallel/client/view.py
+++ b/ipython_parallel/client/view.py
@@ -1099,7 +1099,7 @@ class LoadBalancedView(View):
         -------
 
         if block=False
-          An :class:`~IPython.parallel.client.asyncresult.AsyncMapResult` instance.
+          An :class:`~ipython_parallel.client.asyncresult.AsyncMapResult` instance.
           An object like AsyncResult, but which reassembles the sequence of results
           into a single list. AsyncMapResults can be iterated through before all
           results are complete.

--- a/ipython_parallel/controller/heartmonitor.py
+++ b/ipython_parallel/controller/heartmonitor.py
@@ -79,7 +79,7 @@ class HeartMonitor(LoggingConfigurable):
 
     pingstream=Instance('zmq.eventloop.zmqstream.ZMQStream', allow_none=True)
     pongstream=Instance('zmq.eventloop.zmqstream.ZMQStream', allow_none=True)
-    loop = Instance('zmq.eventloop.ioloop.IOLoop', allow_none=True)
+    loop = Instance('zmq.eventloop.ioloop.IOLoop')
     def _loop_default(self):
         return ioloop.IOLoop.instance()
 

--- a/ipython_parallel/controller/heartmonitor.py
+++ b/ipython_parallel/controller/heartmonitor.py
@@ -77,9 +77,9 @@ class HeartMonitor(LoggingConfigurable):
         help='Allowed consecutive missed pings from controller Hub to engine before unregistering.',
     )
 
-    pingstream=Instance('zmq.eventloop.zmqstream.ZMQStream')
-    pongstream=Instance('zmq.eventloop.zmqstream.ZMQStream')
-    loop = Instance('zmq.eventloop.ioloop.IOLoop')
+    pingstream=Instance('zmq.eventloop.zmqstream.ZMQStream', allow_none=True)
+    pongstream=Instance('zmq.eventloop.zmqstream.ZMQStream', allow_none=True)
+    loop = Instance('zmq.eventloop.ioloop.IOLoop', allow_none=True)
     def _loop_default(self):
         return ioloop.IOLoop.instance()
 

--- a/ipython_parallel/controller/hub.py
+++ b/ipython_parallel/controller/hub.py
@@ -211,8 +211,8 @@ class HubFactory(RegistrationFactory):
         return max(30, int(.01 * self.heartmonitor.period))
 
     # not configurable
-    db = Instance('ipython_parallel.controller.dictdb.BaseDB')
-    heartmonitor = Instance('ipython_parallel.controller.heartmonitor.HeartMonitor')
+    db = Instance('ipython_parallel.controller.dictdb.BaseDB', allow_none=True)
+    heartmonitor = Instance('ipython_parallel.controller.heartmonitor.HeartMonitor', allow_none=True)
 
     def _ip_changed(self, name, old, new):
         self.engine_ip = new
@@ -382,12 +382,12 @@ class Hub(SessionFactory):
     _idcounter=Integer(0)
 
     # objects from constructor:
-    query=Instance(ZMQStream)
-    monitor=Instance(ZMQStream)
-    notifier=Instance(ZMQStream)
-    resubmit=Instance(ZMQStream)
-    heartmonitor=Instance(HeartMonitor)
-    db=Instance(object)
+    query=Instance(ZMQStream, allow_none=True)
+    monitor=Instance(ZMQStream, allow_none=True)
+    notifier=Instance(ZMQStream, allow_none=True)
+    resubmit=Instance(ZMQStream, allow_none=True)
+    heartmonitor=Instance(HeartMonitor, allow_none=True)
+    db=Instance(object, allow_none=True)
     client_info=Dict()
     engine_info=Dict()
 

--- a/ipython_parallel/controller/mongodb.py
+++ b/ipython_parallel/controller/mongodb.py
@@ -45,7 +45,7 @@ class MongoDB(BaseDB):
         in tasks from previous sessions being available via Clients' db_query and
         get_result methods.""")
 
-    _connection = Instance(Connection) # pymongo connection
+    _connection = Instance(Connection, allow_none=True) # pymongo connection
     
     def __init__(self, **kwargs):
         super(MongoDB, self).__init__(**kwargs)

--- a/ipython_parallel/controller/scheduler.py
+++ b/ipython_parallel/controller/scheduler.py
@@ -180,7 +180,7 @@ help="""select the task scheduler scheme  [default: Python LRU]
         self.scheme = globals()[new]
 
     # input arguments:
-    scheme = Instance(FunctionType, allow_none=True) # function for determining the destination
+    scheme = Instance(FunctionType) # function for determining the destination
     def _scheme_default(self):
         return leastload
     client_stream = Instance(zmqstream.ZMQStream, allow_none=True) # client-facing stream
@@ -190,7 +190,7 @@ help="""select the task scheduler scheme  [default: Python LRU]
     query_stream = Instance(zmqstream.ZMQStream, allow_none=True) # hub-facing DEALER stream
 
     # internals:
-    queue = Instance(deque, allow_none=True) # sorted list of Jobs
+    queue = Instance(deque) # sorted list of Jobs
     def _queue_default(self):
         return deque()
     queue_map = Dict() # dict by msg_id of Jobs (for O(1) access to the Queue)

--- a/ipython_parallel/controller/scheduler.py
+++ b/ipython_parallel/controller/scheduler.py
@@ -180,17 +180,17 @@ help="""select the task scheduler scheme  [default: Python LRU]
         self.scheme = globals()[new]
 
     # input arguments:
-    scheme = Instance(FunctionType) # function for determining the destination
+    scheme = Instance(FunctionType, allow_none=True) # function for determining the destination
     def _scheme_default(self):
         return leastload
-    client_stream = Instance(zmqstream.ZMQStream) # client-facing stream
-    engine_stream = Instance(zmqstream.ZMQStream) # engine-facing stream
-    notifier_stream = Instance(zmqstream.ZMQStream) # hub-facing sub stream
-    mon_stream = Instance(zmqstream.ZMQStream) # hub-facing pub stream
-    query_stream = Instance(zmqstream.ZMQStream) # hub-facing DEALER stream
+    client_stream = Instance(zmqstream.ZMQStream, allow_none=True) # client-facing stream
+    engine_stream = Instance(zmqstream.ZMQStream, allow_none=True) # engine-facing stream
+    notifier_stream = Instance(zmqstream.ZMQStream, allow_none=True) # hub-facing sub stream
+    mon_stream = Instance(zmqstream.ZMQStream, allow_none=True) # hub-facing pub stream
+    query_stream = Instance(zmqstream.ZMQStream, allow_none=True) # hub-facing DEALER stream
 
     # internals:
-    queue = Instance(deque) # sorted list of Jobs
+    queue = Instance(deque, allow_none=True) # sorted list of Jobs
     def _queue_default(self):
         return deque()
     queue_map = Dict() # dict by msg_id of Jobs (for O(1) access to the Queue)

--- a/ipython_parallel/controller/sqlitedb.py
+++ b/ipython_parallel/controller/sqlitedb.py
@@ -99,7 +99,7 @@ class SQLiteDB(BaseDB):
         get_result methods.""")
 
     if sqlite3 is not None:
-        _db = Instance('sqlite3.Connection')
+        _db = Instance('sqlite3.Connection', allow_none=True)
     else:
         _db = None
     # the ordered list of column names

--- a/ipython_parallel/engine/engine.py
+++ b/ipython_parallel/engine/engine.py
@@ -67,8 +67,8 @@ class EngineFactory(RegistrationFactory):
     connection_info = Dict()
     user_ns = Dict()
     id = Integer(allow_none=True)
-    registrar = Instance('zmq.eventloop.zmqstream.ZMQStream')
-    kernel = Instance(Kernel)
+    registrar = Instance('zmq.eventloop.zmqstream.ZMQStream', allow_none=True)
+    kernel = Instance(Kernel, allow_none=True)
     hb_check_period=Integer()
     
     # States for the heartbeat monitoring

--- a/jupyter_console/interactiveshell.py
+++ b/jupyter_console/interactiveshell.py
@@ -109,8 +109,8 @@ class ZMQTerminalInteractiveShell(TerminalInteractiveShell):
         """
     )
 
-    manager = Instance('IPython.kernel.KernelManager')
-    client = Instance('IPython.kernel.KernelClient')
+    manager = Instance('IPython.kernel.KernelManager', allow_none=True)
+    client = Instance('IPython.kernel.KernelClient', allow_none=True)
     def _client_changed(self, name, old, new):
         self.session_id = new.session.session
     session_id = Unicode()

--- a/jupyter_nbconvert/nbconvertapp.py
+++ b/jupyter_nbconvert/nbconvertapp.py
@@ -161,14 +161,14 @@ class NbConvertApp(BaseIPythonApplication):
     # Writer specific variables
     writer = Instance('jupyter_nbconvert.writers.base.WriterBase',  
                       help="""Instance of the writer class used to write the 
-                      results of the conversion.""")
+                      results of the conversion.""", allow_none=True)
     writer_class = DottedObjectName('FilesWriter', config=True, 
                                     help="""Writer class used to write the 
                                     results of the conversion""")
     writer_aliases = {'fileswriter': 'jupyter_nbconvert.writers.files.FilesWriter',
                       'debugwriter': 'jupyter_nbconvert.writers.debug.DebugWriter',
                       'stdoutwriter': 'jupyter_nbconvert.writers.stdout.StdoutWriter'}
-    writer_factory = Type()
+    writer_factory = Type(allow_none=True)
 
     def _writer_class_changed(self, name, old, new):
         if new.lower() in self.writer_aliases:
@@ -178,13 +178,13 @@ class NbConvertApp(BaseIPythonApplication):
     # Post-processor specific variables
     postprocessor = Instance('jupyter_nbconvert.postprocessors.base.PostProcessorBase',  
                       help="""Instance of the PostProcessor class used to write the 
-                      results of the conversion.""")
+                      results of the conversion.""", allow_none=True)
 
     postprocessor_class = DottedOrNone(config=True, 
                                     help="""PostProcessor class used to write the 
                                     results of the conversion""")
     postprocessor_aliases = {'serve': 'jupyter_nbconvert.postprocessors.serve.ServePostProcessor'}
-    postprocessor_factory = Type()
+    postprocessor_factory = Type(allow_none=True)
 
     def _postprocessor_class_changed(self, name, old, new):
         if new.lower() in self.postprocessor_aliases:

--- a/jupyter_nbformat/sign.py
+++ b/jupyter_nbformat/sign.py
@@ -87,7 +87,7 @@ def signature_removed(nb):
 class NotebookNotary(LoggingConfigurable):
     """A class for computing and verifying notebook signatures."""
     
-    profile_dir = Instance("IPython.core.profiledir.ProfileDir")
+    profile_dir = Instance("IPython.core.profiledir.ProfileDir", allow_none=True)
     def _profile_dir_default(self):
         from IPython.core.application import BaseIPythonApplication
         app = None
@@ -388,7 +388,7 @@ class TrustNotebookApp(BaseIPythonApplication):
         """
     )
     
-    notary = Instance(NotebookNotary)
+    notary = Instance(NotebookNotary, allow_none=True)
     def _notary_default(self):
         return NotebookNotary(parent=self, profile_dir=self.profile_dir)
     

--- a/jupyter_nbformat/sign.py
+++ b/jupyter_nbformat/sign.py
@@ -87,7 +87,7 @@ def signature_removed(nb):
 class NotebookNotary(LoggingConfigurable):
     """A class for computing and verifying notebook signatures."""
     
-    profile_dir = Instance("IPython.core.profiledir.ProfileDir", allow_none=True)
+    profile_dir = Instance("IPython.core.profiledir.ProfileDir")
     def _profile_dir_default(self):
         from IPython.core.application import BaseIPythonApplication
         app = None
@@ -388,7 +388,7 @@ class TrustNotebookApp(BaseIPythonApplication):
         """
     )
     
-    notary = Instance(NotebookNotary, allow_none=True)
+    notary = Instance(NotebookNotary)
     def _notary_default(self):
         return NotebookNotary(parent=self, profile_dir=self.profile_dir)
     

--- a/jupyter_nbformat/sign.py
+++ b/jupyter_nbformat/sign.py
@@ -87,7 +87,7 @@ def signature_removed(nb):
 class NotebookNotary(LoggingConfigurable):
     """A class for computing and verifying notebook signatures."""
     
-    profile_dir = Instance("IPython.core.profiledir.ProfileDir")
+    profile_dir = Instance("IPython.core.profiledir.ProfileDir", allow_none=True)
     def _profile_dir_default(self):
         from IPython.core.application import BaseIPythonApplication
         app = None

--- a/jupyter_qtconsole/console/frontend_widget.py
+++ b/jupyter_qtconsole/console/frontend_widget.py
@@ -145,7 +145,7 @@ class FrontendWidget(HistoryConsoleWidget, BaseFrontendMixin):
     _ExecutionRequest = namedtuple('_ExecutionRequest', ['id', 'kind'])
     _input_splitter_class = InputSplitter
     _local_kernel = False
-    _highlighter = Instance(FrontendHighlighter)
+    _highlighter = Instance(FrontendHighlighter, allow_none=True)
 
     #---------------------------------------------------------------------------
     # 'object' interface


### PR DESCRIPTION
The last trait types for which `allow_none` was `True` by default were `Type` and `Instance`. Since unused default values are not validated anymore, it makes sense to set it to False, so that there is no special case. 

After this, all trait types have `allow_none=False` by default.

having allow_none=False for `Instance` makes sense in  the following cases: 
- container trait types like
  `List(Instance(Foo))`, 
- when we want force the user to specify a value for an attribute

``` python
class Foo(HasTraits):
    # Foo must hold a reference to an instance of Bar provided
    # by the user.
    bar = Instance(Bar)

Foo()   # Trait Error
bar = Bar()
Foo(bar=bar)  # ok
```

This also corrects a bug which I just noticed: setting allow_none=False was not effective on `Tuple`.
