### PR TITLE
load kwarg traits before loading config

### DIFF
--- a/IPython/config/configurable.py
+++ b/IPython/config/configurable.py
@@ -69,6 +69,11 @@ class Configurable(HasTraits):
             self.parent = parent
         
         config = kwargs.pop('config', None)
+        
+        # load kwarg traits, other than config
+        super(Configurable, self).__init__(**kwargs)
+        
+        # load config
         if config is not None:
             # We used to deepcopy, but for now we are trying to just save
             # by reference.  This *could* have side effects as all components
@@ -81,9 +86,12 @@ class Configurable(HasTraits):
         else:
             # allow _config_default to return something
             self._load_config(self.config)
-        # This should go second so individual keyword arguments override
-        # the values in config.
-        super(Configurable, self).__init__(**kwargs)
+        
+        # Ensure explicit kwargs are applied after loading config.
+        # This is usually redundant, but ensures config doesn't override
+        # explicitly assigned values.
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
     #-------------------------------------------------------------------------
     # Static trait notifiations


### PR DESCRIPTION
in `Configurable.__init__`

avoids problems in the new init of traitlets that skips `_trait_default` if specified in kwargs, which means really nothing should be done before `HasTraits.__init__` has been called.

This does mean that such values are assigned twice. Typically, this will have no effect, except when a value is set by both config and kwarg.

/cc @takluyver because this should fix the failure of the parallel tests to start

I will work on a separate PR to make the traits init more robust to this behavior, because I think there can be other cases of order problems, where the dynamic init should still be called.
