### PR TITLE
Don't refocus cell when restarting notebook from toolbar

### DIFF
--- a/IPython/html/static/notebook/js/actions.js
+++ b/IPython/html/static/notebook/js/actions.js
@@ -276,7 +276,6 @@ define(function(require){
             help_index : 'hb',
             handler : function (env) {
                 env.notebook.restart_kernel();
-                env.notebook.focus_cell();
             }
         },
         'undo-last-cell-deletion' : {


### PR DESCRIPTION
restart_kernel() brings up a modal dialog, so we don't want to focus a cell straight away, re-enabling the keyboard manager.

Addresses a small part of #8109
