### PR TITLE
TEST: Add test for handling of last_modified.

### DIFF
--- a/IPython/html/services/contents/tests/test_manager.py
+++ b/IPython/html/services/contents/tests/test_manager.py
@@ -279,7 +279,10 @@ class TestContentsManager(TestCase):
         new_path = 'renamed.ipynb'
         cm.rename(path, new_path)
         renamed = cm.get(new_path)
-        self.assertEqual(renamed['last_modified'], saved['last_modified'])
+        self.assertGreaterEqual(
+            renamed['last_modified'],
+            saved['last_modified'],
+        )
 
     def test_get(self):
         cm = self.contents_manager

--- a/IPython/html/services/contents/tests/test_manager.py
+++ b/IPython/html/services/contents/tests/test_manager.py
@@ -257,6 +257,30 @@ class TestContentsManager(TestCase):
         self.assertEqual(model['name'], 'untitled')
         self.assertEqual(model['path'], '%s/untitled' % sub_dir)
 
+    def test_modified_date(self):
+
+        cm = self.contents_manager
+
+        # Create a new notebook.
+        nb, name, path = self.new_notebook()
+        model = cm.get(path)
+
+        # Add a cell and save.
+        self.add_code_cell(model['content'])
+        cm.save(model, path)
+
+        # Reload notebook and verify that last_modified incremented.
+        saved = cm.get(path)
+        self.assertGreater(saved['last_modified'], model['last_modified'])
+
+        # Move the notebook and verify that last_modified stayed the same.
+        # (The frontend fires a warning if last_modified increases on the
+        # renamed file.)
+        new_path = 'renamed.ipynb'
+        cm.rename(path, new_path)
+        renamed = cm.get(new_path)
+        self.assertEqual(renamed['last_modified'], saved['last_modified'])
+
     def test_get(self):
         cm = self.contents_manager
         # Create a notebook


### PR DESCRIPTION
Saving should increment last_modified.  Renaming should not.  Noticed
because incrementing last_modified on rename results in a scary error
message from the frontend.
