### PR TITLE
handle undefined when sorting quick help

### DIFF
--- a/IPython/html/static/base/js/keyboard.js
+++ b/IPython/html/static/base/js/keyboard.js
@@ -244,13 +244,13 @@ define([
             }
         }
         help.sort(function (a, b) {
-            if (a.help_index > b.help_index){
+            if (a.help_index === b.help_index) {
+                return 0;
+            }
+            if (a.help_index === undefined || a.help_index > b.help_index){
                 return 1;
             }
-            if (a.help_index < b.help_index){
-                return -1;
-            }
-            return 0;
+            return -1;
         });
         return help;
     };


### PR DESCRIPTION
Since undefined is neither less than nor greater than anything in Javascript, the sort function was treating it as equal to everything, causing inconsistent behavior depending on the sort algorithm of the browser.

closes #8089

This ensures undefined elements are sorted last in the sequence.
