### PR TITLE
Remove Qt console package_data from setup

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -189,7 +189,6 @@ def find_package_data():
         'IPython.testing.plugin' : ['*.txt'],
         'IPython.html' : ['templates/*'] + static_data,
         'IPython.html.tests' : js_tests,
-        'IPython.qt.console' : ['resources/icon/*.svg'],
         'IPython.nbconvert' : nbconvert_templates +
             [
                 'tests/files/*.*',


### PR DESCRIPTION
We should remember this when the jupyter_qtconsole package gets its own setup.

Closes gh-8140
