### PR TITLE
Included a way to 'comment out' an %s for a non-arg

### DIFF
--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -151,8 +151,8 @@ class Alias(object):
             raise InvalidAliasError("An alias command must be a string, "
                                     "got: %r" % self.cmd)
 
-        nargs = self.cmd.count('%s')
-
+        nargs = self.cmd.count('%s') - self.cmd.count('%%s')
+  
         if (nargs > 0) and (self.cmd.find('%l') >= 0):
             raise InvalidAliasError('The %s and %l specifiers are mutually '
                                     'exclusive in alias definitions.')

--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -169,6 +169,10 @@ class Alias(object):
         if cmd.find('%l') >= 0:
             cmd = cmd.replace('%l', rest)
             rest = ''
+         
+        if cmd.find('%%s') >= 1:
+            cmd = cmd.replace('%%s', '%s')
+            
         if nargs==0:
             # Simple, argument-less aliases
             cmd = '%s %s' % (cmd, rest)

--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -169,13 +169,12 @@ class Alias(object):
         if cmd.find('%l') >= 0:
             cmd = cmd.replace('%l', rest)
             rest = ''
-         
-        if cmd.find('%%s') >= 1:
-            cmd = cmd.replace('%%s', '%s')
-            
+		
         if nargs==0:
-            # Simple, argument-less aliases
-            cmd = '%s %s' % (cmd, rest)
+			if cmd.find('%%s') >= 1:
+				cmd = cmd.replace('%%s', '%s')
+			# Simple, argument-less aliases
+			cmd = '%s %s' % (cmd, rest)
         else:
             # Handle aliases with positional arguments
             args = rest.split(None, nargs)

--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -169,12 +169,12 @@ class Alias(object):
         if cmd.find('%l') >= 0:
             cmd = cmd.replace('%l', rest)
             rest = ''
-		
+        
         if nargs==0:
-			if cmd.find('%%s') >= 1:
-				cmd = cmd.replace('%%s', '%s')
-			# Simple, argument-less aliases
-			cmd = '%s %s' % (cmd, rest)
+            if cmd.find('%%s') >= 1:
+                cmd = cmd.replace('%%s', '%s')
+            # Simple, argument-less aliases
+            cmd = '%s %s' % (cmd, rest)
         else:
             # Handle aliases with positional arguments
             args = rest.split(None, nargs)

--- a/IPython/core/tests/test_alias.py
+++ b/IPython/core/tests/test_alias.py
@@ -53,7 +53,7 @@ def test_alias_args_commented_nargs():
     """Check that alias correctly counts args, excluding those commented out"""
     am = _ip.alias_manager
     alias_name = 'comargcount'
-    cmd = 'echo this is %%s a "commented out" arg and this is not %s'
+    cmd = 'echo this is %%s a commented out arg and this is not %s'
     
     am.define_alias(alias_name, cmd)
     assert am.is_alias(alias_name)

--- a/IPython/core/tests/test_alias.py
+++ b/IPython/core/tests/test_alias.py
@@ -39,3 +39,12 @@ def test_alias_args_error():
         _ip.run_cell('parts 1')
 
     nt.assert_equal(cap.stderr.split(':')[0], 'UsageError')
+    
+def test_alias_args_commented():
+    """Check that alias correctly ignores 'commented out' args"""
+    _ip.alias_manager.define_alias('commetarg', 'echo this is %%s a "commented out" arg')
+    
+    with capture_output as cap:
+        _ip.run_cell('commetarg')
+    
+    nt.assert_equal(cap.stdout, 'this is %s a "commented out" arg')

--- a/IPython/core/tests/test_alias.py
+++ b/IPython/core/tests/test_alias.py
@@ -42,12 +42,12 @@ def test_alias_args_error():
     
 def test_alias_args_commented():
     """Check that alias correctly ignores 'commented out' args"""
-    _ip.magic('alias commetarg echo this is %%s a "commented out" arg')
+    _ip.magic('alias commetarg echo this is %%s a commented out arg')
     
     with capture_output() as cap:
         _ip.run_cell('commetarg')
     
-    nt.assert_equal(cap.stdout, 'this is %s a "commented out" arg')
+    nt.assert_equal(cap.stdout, 'this is %s a commented out arg')
 
 def test_alias_args_commented_nargs():
     """Check that alias correctly counts args, excluding those commented out"""

--- a/IPython/core/tests/test_alias.py
+++ b/IPython/core/tests/test_alias.py
@@ -48,3 +48,15 @@ def test_alias_args_commented():
         _ip.run_cell('commetarg')
     
     nt.assert_equal(cap.stdout, 'this is %s a "commented out" arg')
+
+def test_alias_args_commented_nargs():
+    """Check that alias correctly counts args, excluding those commented out"""
+    am = _ip.alias_manager
+    alias_name = 'comargcount'
+    cmd = 'echo this is %%s a "commented out" arg and this is not %s'
+    
+    am.define_alias(alias_name, cmd)
+    assert am.is_alias(alias_name)
+    
+    thealias = am.get_alias(alias_name)
+    nt.assert_equal(thealias.nargs, 1)

--- a/IPython/core/tests/test_alias.py
+++ b/IPython/core/tests/test_alias.py
@@ -42,9 +42,9 @@ def test_alias_args_error():
     
 def test_alias_args_commented():
     """Check that alias correctly ignores 'commented out' args"""
-    _ip.alias_manager.define_alias('commetarg', 'echo this is %%s a "commented out" arg')
+    _ip.magic('alias commetarg echo this is %%s a "commented out" arg')
     
-    with capture_output as cap:
+    with capture_output() as cap:
         _ip.run_cell('commetarg')
     
     nt.assert_equal(cap.stdout, 'this is %s a "commented out" arg')


### PR DESCRIPTION
I had problems aliasing the following (because of an '%s' at the end as a mistaken arg): gitld git log --pretty=format:'%%C(yellow)%%h%%Cred%%ad%%Cgreen%%d%%reset%s'

I made this simple alteration to fix that.  I checked the guidelines and I'm not 100% sure if I was supposed to open an issue first(?), but this seems a small change.  This is my first (of hopefully many more) contribution to a project, so I apologize if my etiquette is off.

I tested the result with '%alias test echo %s' and it worked as expected.
