### PR TITLE
Fix action do not provide icon.

### DIFF
--- a/IPython/html/static/notebook/js/toolbar.js
+++ b/IPython/html/static/notebook/js/toolbar.js
@@ -124,7 +124,7 @@ define([
                     .addClass('btn btn-default')
                     .attr("title", el.label||action.help)
                     .append(
-                        $("<i/>").addClass(el.icon||action.icon).addClass('fa')
+                        $("<i/>").addClass(el.icon||(action||{icon:'fa-exclamation-triangle'}).icon).addClass('fa')
                     );
                 var id = el.id;
                 if( id !== undefined ){


### PR DESCRIPTION
action might be undefined then button will get no icon.
Prevent throwing an uncatched error and insert warning sign on button

Will do better one I allow text instead of icon
