### PR TITLE
use >= instead of > when comparing dates

### DIFF
--- a/IPython/html/services/contents/tests/test_manager.py
+++ b/IPython/html/services/contents/tests/test_manager.py
@@ -271,7 +271,7 @@ class TestContentsManager(TestCase):
 
         # Reload notebook and verify that last_modified incremented.
         saved = cm.get(path)
-        self.assertGreater(saved['last_modified'], model['last_modified'])
+        self.assertGreaterEqual(saved['last_modified'], model['last_modified'])
 
         # Move the notebook and verify that last_modified stayed the same.
         # (The frontend fires a warning if last_modified increases on the


### PR DESCRIPTION
fast test runners can result in equal values.
