### PR TITLE
BUG: Don't allow ContentsManager to delete root.

### DIFF
--- a/IPython/html/services/contents/manager.py
+++ b/IPython/html/services/contents/manager.py
@@ -222,6 +222,9 @@ class ContentsManager(LoggingConfigurable):
 
     def delete(self, path):
         """Delete a file/directory and any associated checkpoints."""
+        path = path.strip('/')
+        if not path:
+            raise HTTPError(400, "Can't delete root")
         self.delete_file(path)
         self.checkpoints.delete_all_checkpoints(path)
 

--- a/IPython/html/services/contents/tests/test_manager.py
+++ b/IPython/html/services/contents/tests/test_manager.py
@@ -433,6 +433,12 @@ class TestContentsManager(TestCase):
         # Check that a 'get' on the deleted notebook raises and error
         self.assertRaises(HTTPError, cm.get, path)
 
+    def test_delete_root(self):
+        cm = self.contents_manager
+        with self.assertRaises(HTTPError) as err:
+            cm.delete('')
+        self.assertEqual(err.exception.status_code, 400)
+
     def test_copy(self):
         cm = self.contents_manager
         parent = u'å b'


### PR DESCRIPTION
Doing so leaves the notebook app in a bad state from which it can't recover.
