### PR TITLE
Fixes bug that would show "null" as the reason in the don't leave dialog

### DIFF
--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -301,9 +301,8 @@ define(function (require) {
                     return "Unsaved changes will be lost.";
                 }
             }
-            // Null is the *only* return value that will make the browser not
-            // pop up the "don't leave" dialog.
-            return null;
+            // IE treats null as a string.  Instead just return which will avoid the dialog.
+            return;
         };
     };
     


### PR DESCRIPTION
IE treats null as a string and displays it.  Instead simply return.  Fix verified in Chrome, FireFox, and IE 10.
