### PR TITLE
add import hook to shims

### DIFF
--- a/IPython/frontend.py
+++ b/IPython/frontend.py
@@ -12,11 +12,7 @@ working, though a warning will be printed.
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
-
-# Stdlib
 import sys
-import types
 from warnings import warn
 
 warn("The top-level `frontend` package has been deprecated. "
@@ -27,5 +23,7 @@ from IPython.utils.shimmodule import ShimModule
 # Unconditionally insert the shim into sys.modules so that further import calls
 # trigger the custom attribute access above
 
-sys.modules['IPython.frontend.html.notebook'] = ShimModule('notebook', mirror='IPython.html')
-sys.modules['IPython.frontend'] = ShimModule('frontend', mirror='IPython')
+sys.modules['IPython.frontend.html.notebook'] = ShimModule(
+    src='IPython.frontend.html.notebook', mirror='IPython.html')
+sys.modules['IPython.frontend'] = ShimModule(
+    src='IPython.frontend', mirror='IPython')

--- a/IPython/kernel/__init__.py
+++ b/IPython/kernel/__init__.py
@@ -14,14 +14,18 @@ warn("The `IPython.kernel` package has been deprecated. "
 from IPython.utils.shimmodule import ShimModule
 
 # zmq subdir is gone
-sys.modules['IPython.kernel.zmq.session'] = ShimModule('session', mirror='jupyter_client.session')
-sys.modules['IPython.kernel.zmq'] = ShimModule('zmq', mirror='ipython_kernel')
+sys.modules['IPython.kernel.zmq.session'] = ShimModule(
+    src='IPython.kernel.zmq.session', mirror='jupyter_client.session')
+sys.modules['IPython.kernel.zmq'] = ShimModule(
+    src='IPython.kernel.zmq', mirror='ipython_kernel')
 
 for pkg in ('comm', 'inprocess'):
-    sys.modules['IPython.kernel.%s' % pkg] = ShimModule(pkg, mirror='ipython_kernel.%s' % pkg)
+    src = 'IPython.kernel.%s' % pkg
+    sys.modules[src] = ShimModule(src=src, mirror='ipython_kernel.%s' % pkg)
 
 for pkg in ('ioloop', 'blocking'):
-    sys.modules['IPython.kernel.%s' % pkg] = ShimModule(pkg, mirror='jupyter_client.%s' % pkg)
+    src = 'IPython.kernel.%s' % pkg
+    sys.modules[src] = ShimModule(src=src, mirror='jupyter_client.%s' % pkg)
 
 # required for `from IPython.kernel import PKG`
 from ipython_kernel import comm, inprocess

--- a/IPython/nbconvert.py
+++ b/IPython/nbconvert.py
@@ -4,8 +4,6 @@ Shim to maintain backwards compatibility with old IPython.nbconvert imports.
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
-
 import sys
 from warnings import warn
 
@@ -17,4 +15,5 @@ from IPython.utils.shimmodule import ShimModule
 # Unconditionally insert the shim into sys.modules so that further import calls
 # trigger the custom attribute access above
 
-sys.modules['IPython.nbconvert'] = ShimModule('nbconvert', mirror='jupyter_nbconvert')
+sys.modules['IPython.nbconvert'] = ShimModule(
+    src='IPython.nbconvert', mirror='jupyter_nbconvert')

--- a/IPython/nbformat.py
+++ b/IPython/nbformat.py
@@ -4,11 +4,7 @@ Shim to maintain backwards compatibility with old IPython.nbformat imports.
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
-
-# Stdlib
 import sys
-import types
 from warnings import warn
 
 warn("The `IPython.nbformat` package has been deprecated. "
@@ -19,4 +15,5 @@ from IPython.utils.shimmodule import ShimModule
 # Unconditionally insert the shim into sys.modules so that further import calls
 # trigger the custom attribute access above
 
-sys.modules['IPython.nbformat'] = ShimModule('nbformat', mirror='jupyter_nbformat')
+sys.modules['IPython.nbformat'] = ShimModule(
+    src='IPython.nbformat', mirror='jupyter_nbformat')

--- a/IPython/parallel.py
+++ b/IPython/parallel.py
@@ -4,8 +4,6 @@ Shim to maintain backwards compatibility with old IPython.parallel imports.
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
-
 import sys
 from warnings import warn
 
@@ -17,4 +15,6 @@ from IPython.utils.shimmodule import ShimModule
 # Unconditionally insert the shim into sys.modules so that further import calls
 # trigger the custom attribute access above
 
-sys.modules['IPython.parallel'] = ShimModule('parallel', mirror='ipython_parallel')
+sys.modules['IPython.parallel'] = ShimModule(
+    src='IPython.parallel', mirror='ipython_parallel')
+

--- a/IPython/qt.py
+++ b/IPython/qt.py
@@ -4,11 +4,7 @@ Shim to maintain backwards compatibility with old IPython.qt imports.
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
-
-# Stdlib
 import sys
-import types
 from warnings import warn
 
 warn("The `IPython.qt` package has been deprecated. "
@@ -19,4 +15,4 @@ from IPython.utils.shimmodule import ShimModule
 # Unconditionally insert the shim into sys.modules so that further import calls
 # trigger the custom attribute access above
 
-sys.modules['IPython.qt'] = ShimModule('qt', mirror='jupyter_qtconsole')
+sys.modules['IPython.qt'] = ShimModule(src='IPython.qt', mirror='jupyter_qtconsole')

--- a/IPython/terminal/console.py
+++ b/IPython/terminal/console.py
@@ -17,4 +17,5 @@ from IPython.utils.shimmodule import ShimModule
 # Unconditionally insert the shim into sys.modules so that further import calls
 # trigger the custom attribute access above
 
-sys.modules['IPython.terminal.console'] = ShimModule('console', mirror='jupyter_console')
+sys.modules['IPython.terminal.console'] = ShimModule(
+    src='IPython.terminal.console', mirror='jupyter_console')

--- a/IPython/utils/shimmodule.py
+++ b/IPython/utils/shimmodule.py
@@ -3,14 +3,65 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import sys
 import types
+
+
+class ShimImporter(object):
+    """Import hook for a shim.
+    
+    This ensures that submodule imports return the real target module,
+    not a clone that will confuse `is` and `isinstance` checks.
+    """
+    def __init__(self, src, mirror):
+        self.src = src
+        self.mirror = mirror
+    
+    def _mirror_name(self, fullname):
+        """get the name of the mirrored module"""
+        
+        return self.mirror + fullname[len(self.src):]
+
+    def find_module(self, fullname, path=None):
+        """Return self if we should be used to import the module."""
+        if fullname.startswith(self.src + '.'):
+            mirror_name = self._mirror_name(fullname)
+            try:
+                __import__(mirror_name)
+            except ImportError:
+                return
+            else:
+                return self
+
+    def load_module(self, fullname):
+        """Import the mirrored module, and insert it into sys.modules"""
+        mirror_name = self._mirror_name(fullname)
+        mod = __import__(mirror_name)
+        if '.' in mirror_name:
+            name = mirror_name.rsplit('.', 1)[-1]
+            mod = getattr(mod, name)
+        sys.modules[fullname] = mod
+        return mod
+
 
 class ShimModule(types.ModuleType):
 
     def __init__(self, *args, **kwargs):
         self._mirror = kwargs.pop("mirror")
+        src = kwargs.pop("src", None)
+        if src:
+            kwargs['name'] = src.rsplit('.', 1)[-1]
         super(ShimModule, self).__init__(*args, **kwargs)
-
+        # add import hook for descendent modules
+        if src:
+            sys.meta_path.append(
+                ShimImporter(src=src, mirror=self._mirror)
+            )
+    
+    @property
+    def __path__(self):
+        return []
+    
     @property
     def __spec__(self):
         """Don't produce __spec__ until requested"""

--- a/IPython/utils/shimmodule.py
+++ b/IPython/utils/shimmodule.py
@@ -29,10 +29,13 @@ class ShimImporter(object):
         if fullname.startswith(self.src + '.'):
             mirror_name = self._mirror_name(fullname)
             try:
-                __import__(mirror_name)
+                mod = import_item(mirror_name)
             except ImportError:
                 return
             else:
+                if not isinstance(mod, types.ModuleType):
+                    # not a module
+                    return None
                 return self
 
     def load_module(self, fullname):

--- a/IPython/utils/shimmodule.py
+++ b/IPython/utils/shimmodule.py
@@ -6,6 +6,8 @@
 import sys
 import types
 
+from .importstring import import_item
+
 
 class ShimImporter(object):
     """Import hook for a shim.
@@ -36,10 +38,7 @@ class ShimImporter(object):
     def load_module(self, fullname):
         """Import the mirrored module, and insert it into sys.modules"""
         mirror_name = self._mirror_name(fullname)
-        mod = __import__(mirror_name)
-        if '.' in mirror_name:
-            name = mirror_name.rsplit('.', 1)[-1]
-            mod = getattr(mod, name)
+        mod = import_item(mirror_name)
         sys.modules[fullname] = mod
         return mod
 
@@ -70,26 +69,7 @@ class ShimModule(types.ModuleType):
     def __getattr__(self, key):
         # Use the equivalent of import_item(name), see below
         name = "%s.%s" % (self._mirror, key)
-
-        # NOTE: the code below was copied *verbatim* from
-        # importstring.import_item. For some very strange reason that makes no
-        # sense to me, if we call it *as a function*, it doesn't work.  This
-        # has something to do with the deep bowels of the import machinery and
-        # I couldn't find a way to make the code work as a standard function
-        # call.  But at least since it's an unmodified copy of import_item,
-        # which is used extensively and has a test suite, we can be reasonably
-        # confident this is OK.  If anyone finds how to call the function, all
-        # the below could be replaced simply with:
-        #
-        # from IPython.utils.importstring import import_item
-        # return import_item('MIRROR.' + key)
-
-        parts = name.rsplit('.', 1)
-        if len(parts) == 2:
-            # called with 'foo.bar....'
-            package, obj = parts
-            module = __import__(package, fromlist=[obj])
-            return getattr(module, obj)
-        else:
-            # called with un-dotted string
-            return __import__(parts[0])
+        try:
+            return import_item(name)
+        except ImportError:
+            raise AttributeError(key)


### PR DESCRIPTION
This ensures that submodule imports return the real target module, not a clone that will confuse `is` and `isinstance` checks.
