### PR TITLE
small focus/keyboard-related fixes for 3.1

### DIFF
--- a/IPython/html/static/notebook/js/actions.js
+++ b/IPython/html/static/notebook/js/actions.js
@@ -107,7 +107,6 @@ define(function(require){
                 var index = env.notebook.get_selected_index();
                 env.notebook.cut_cell();
                 env.notebook.select(index);
-                env.notebook.focus_cell();
             }
         },
         'copy-selected-cell' : {
@@ -115,7 +114,6 @@ define(function(require){
             help_index : 'ef',
             handler : function (env) {
                 env.notebook.copy_cell();
-                env.notebook.focus_cell();
             }
         },
         'paste-cell-before' : {
@@ -268,7 +266,6 @@ define(function(require){
             help_index : 'ha',
             handler : function (env) {
                 env.notebook.kernel.interrupt();
-                env.notebook.focus_cell();
             }
         },
         'restart-kernel':{
@@ -276,7 +273,6 @@ define(function(require){
             help_index : 'hb',
             handler : function (env) {
                 env.notebook.restart_kernel();
-                env.notebook.focus_cell();
             }
         },
         'undo-last-cell-deletion' : {

--- a/IPython/html/static/notebook/js/actions.js
+++ b/IPython/html/static/notebook/js/actions.js
@@ -377,7 +377,6 @@ define(function(require){
                 if(event){
                     event.preventDefault();
                 }
-                env.notebook.ensure_focused();
                 return false;
             }
         },

--- a/IPython/html/static/notebook/js/maintoolbar.js
+++ b/IPython/html/static/notebook/js/maintoolbar.js
@@ -25,7 +25,6 @@ define([
         this.events = options.events;
         this.notebook = options.notebook;
         this._make();
-        this.notebook.keyboard_manager.register_events(this.element);
         Object.seal(this);
     };
 
@@ -74,6 +73,7 @@ define([
             .append($('<option/>').attr('value','markdown').text('Markdown'))
             .append($('<option/>').attr('value','raw').text('Raw NBConvert'))
             .append($('<option/>').attr('value','heading').text('Heading'));
+        this.notebook.keyboard_manager.register_events(sel);
         this.events.on('selected_cell_type_changed.Notebook', function (event, data) {
             if (data.cell_type === 'heading') {
                 sel.val('Markdown');
@@ -126,6 +126,7 @@ define([
                 }
                 that.notebook.focus_cell();
             });
+        this.notebook.keyboard_manager.register_events(select);
         // Setup the currently registered presets.
         var presets = celltoolbar.CellToolbar.list_presets();
         for (var i=0; i<presets.length; i++) {

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -663,10 +663,9 @@ define(function (require) {
     Notebook.prototype.command_mode = function () {
         var cell = this.get_cell(this.get_edit_index());
         if (cell && this.mode !== 'command') {
-            // We don't call cell.command_mode, but rather call cell.focus_cell()
-            // which will blur and CM editor and trigger the call to
-            // handle_command_mode.
-            cell.focus_cell();
+            // We don't call cell.command_mode, but rather blur the CM editor
+            // which will trigger the call to handle_command_mode.
+            cell.code_mirror.getInputField().blur();
         }
     };
 


### PR DESCRIPTION
- don't disable keyboard shortcuts on main toolbar
- remove some extraneous focus_cell calls from actions.js

This restores most of the toolbar behavior of 2.x.

@ellisonbg can you enumerate some of the remaining focus problems that are still problematic in this PR? I'm trying to keep this reasonable for 3.1.
