### PR TITLE
Provide the notebook being imported with "get_ipython"

### DIFF
--- a/examples/Notebook/Importing Notebooks.ipynb
+++ b/examples/Notebook/Importing Notebooks.ipynb
@@ -39,6 +39,7 @@
    },
    "outputs": [],
    "source": [
+    "from IPython import get_ipython\n",
     "from IPython.nbformat import current\n",
     "from IPython.core.interactiveshell import InteractiveShell"
    ]
@@ -138,6 +139,7 @@
     "        mod = types.ModuleType(fullname)\n",
     "        mod.__file__ = path\n",
     "        mod.__loader__ = self\n",
+    "        mod.__dict__['get_ipython'] = get_ipython\n",
     "        sys.modules[fullname] = mod\n",
     "        \n",
     "        # extra work to ensure that magics that would affect the user_ns\n",


### PR DESCRIPTION
The example code for importing notebooks will fail if the notebook being imported contains some ipython magic. Passing "get_ipython" in the dict to "exec" solves this (at least, it allows "%load_ext" to work).
