### PR TITLE
DEV: Allow supplying jinja vars from python config.

### DIFF
--- a/IPython/html/base/handlers.py
+++ b/IPython/html/base/handlers.py
@@ -119,6 +119,11 @@ class IPythonHandler(AuthenticatedHandler):
             return Application.instance().log
         else:
             return app_log
+
+    @property
+    def jinja_template_vars(self):
+        """User-supplied values to supply to jinja templates."""
+        return self.settings.get('jinja_template_vars', {})
     
     #---------------------------------------------------------------
     # URLs
@@ -250,6 +255,7 @@ class IPythonHandler(AuthenticatedHandler):
             sys_info=sys_info,
             contents_js_source=self.contents_js_source,
             version_hash=self.version_hash,
+            **self.jinja_template_vars
         )
     
     def get_json_body(self):

--- a/IPython/html/notebookapp.py
+++ b/IPython/html/notebookapp.py
@@ -200,6 +200,7 @@ class NotebookWebApplication(web.Application):
             config_manager=config_manager,
 
             # IPython stuff
+            jinja_template_vars=ipython_app.jinja_template_vars,
             nbextensions_path=ipython_app.nbextensions_path,
             websocket_url=ipython_app.websocket_url,
             mathjax_url=ipython_app.mathjax_url,
@@ -525,6 +526,11 @@ class NotebookApp(BaseIPythonApplication):
     
     jinja_environment_options = Dict(config=True, 
             help="Supply extra arguments that will be passed to Jinja environment.")
+
+    jinja_template_vars = Dict(
+        config=True,
+        help="Extra variables to supply to jinja templates when rendering.",
+    )
     
     enable_mathjax = Bool(True, config=True,
         help="""Whether to enable MathJax for typesetting math/TeX

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -25,6 +25,7 @@ window.mathjax_url = "{{mathjax_url}}";
 
 {% block params %}
 
+{{super()}}
 data-project="{{project}}"
 data-base-url="{{base_url}}"
 data-ws-url="{{ws_url}}"

--- a/IPython/html/templates/tree.html
+++ b/IPython/html/templates/tree.html
@@ -4,7 +4,7 @@
 
 
 {% block params %}
-
+{{super()}}
 data-base-url="{{base_url}}"
 data-notebook-path="{{notebook_path}}"
 data-terminals-available="{{terminals_available}}"


### PR DESCRIPTION
This PR allows the user to specify a dictionary of values to `NotebookApp.jinja_template_vars` whose values are made available in the jinja templating environment.  This is primarily useful in conjunction with the `get_body_data` javascript function to allow programmatic access to Python-specified values from Javascript.  An example of where this is useful is when you want to use different constants in Javascript based on a deployment environment; this allows you to write code in your ipython_notebook_config that looks like:

```
env = os.environ['DEPLOYMENT_ENV']
if env == 'DEV':
    template_vars = dev_template_vars
elif env == 'STAGING':
    template_vars = staging_template_vars
else:
    template_vars = prod_template_vars
c.NotebookApp.jinja_template_vars = template_vars
```
