### PR TITLE
Catch termios.error in pager

### DIFF
--- a/IPython/core/page.py
+++ b/IPython/core/page.py
@@ -100,7 +100,10 @@ def _detect_screen_size(screen_lines_def):
     # flags each time), we just save the initial terminal state and
     # unconditionally reset it every time.  It's cheaper than making
     # the checks.
-    term_flags = termios.tcgetattr(sys.stdout)
+    try:
+        term_flags = termios.tcgetattr(sys.stdout)
+    except termios.error as err:
+        raise TypeError
 
     # Curses modifies the stdout buffer size by default, which messes
     # up Python's normal stdout buffering.  This would manifest itself

--- a/IPython/core/page.py
+++ b/IPython/core/page.py
@@ -103,7 +103,8 @@ def _detect_screen_size(screen_lines_def):
     try:
         term_flags = termios.tcgetattr(sys.stdout)
     except termios.error as err:
-        raise TypeError
+        # can fail on Linux 2.6, pager_page will catch the TypeError
+        raise TypeError('termios error: {0}'.format(err))
 
     # Curses modifies the stdout buffer size by default, which messes
     # up Python's normal stdout buffering.  This would manifest itself


### PR DESCRIPTION
This error is raised by termios.tcgetattr on really old Linux versions
(here: Ubuntu 8.04.4) in doctests, that is, without a real stdout.

See http://trac.sagemath.org/ticket/17996#comment:11
