### PR TITLE
Kernel logo to the left

### DIFF
--- a/IPython/html/static/notebook/js/kernelselector.js
+++ b/IPython/html/static/notebook/js/kernelselector.js
@@ -129,9 +129,9 @@ define([
         $("#kernel_indicator").find('.kernel_indicator_name').text(ks.spec.display_name);
         if (ks.resources['logo-64x64']) {
             logo_img.attr("src", ks.resources['logo-64x64']);
-            logo_img.show();
+            logo_img.css('visibility', 'visible');
         } else {
-            logo_img.hide();
+            logo_img.css('visibility', 'hidden');
         }
         
         // load kernel css
@@ -314,10 +314,10 @@ define([
         
         var logo_img = this.element.find("img.current_kernel_logo");
         logo_img.on("load", function() {
-            logo_img.show();
+            logo_img.css('visibility', 'visible');
         });
         logo_img.on("error", function() {
-            logo_img.hide();
+            logo_img.css('visibility', 'hidden');
         });
     };
 

--- a/IPython/html/static/notebook/less/kernelselector.less
+++ b/IPython/html/static/notebook/less/kernelselector.less
@@ -3,7 +3,6 @@
     margin-left: 4px;
     
     .current_kernel_logo {
-        display: none;
         .navbar-vertical-align(32px);
         width: 32px;
         height: 32px;

--- a/IPython/html/static/notebook/less/kernelselector.less
+++ b/IPython/html/static/notebook/less/kernelselector.less
@@ -1,5 +1,6 @@
 #kernel_logo_widget {
-    .pull-right();
+    .pull-left();
+    margin-left: 4px;
     
     .current_kernel_logo {
         display: none;

--- a/IPython/html/static/notebook/less/savewidget.less
+++ b/IPython/html/static/notebook/less/savewidget.less
@@ -5,7 +5,7 @@ span.save_widget {
         height: 1em;
         line-height: 1em;
         padding: 3px;
-        margin-left: @padding-large-horizontal;
+        margin-left: 4px;
         border: none;
         font-size: 146.5%;
         &:hover{

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -10644,7 +10644,6 @@ select[multiple].celltoolbar select {
   margin-left: 4px;
 }
 #kernel_logo_widget .current_kernel_logo {
-  display: none;
   margin-top: -1px;
   margin-bottom: -1px;
   width: 32px;
@@ -11213,7 +11212,7 @@ span.save_widget span.filename {
   height: 1em;
   line-height: 1em;
   padding: 3px;
-  margin-left: 16px;
+  margin-left: 4px;
   border: none;
   font-size: 146.5%;
   border-radius: 2px;

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -10639,8 +10639,9 @@ select[multiple].celltoolbar select {
   color: #286090;
 }
 #kernel_logo_widget {
-  float: right !important;
-  float: right;
+  float: left !important;
+  float: left;
+  margin-left: 4px;
 }
 #kernel_logo_widget .current_kernel_logo {
   display: none;

--- a/IPython/html/templates/notebook.html
+++ b/IPython/html/templates/notebook.html
@@ -36,15 +36,14 @@ data-notebook-path="{{notebook_path}}"
 
 {% block headercontainer %}
 
+<span id="kernel_logo_widget">
+  <img class="current_kernel_logo" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"/>
+</span>
 
 <span id="save_widget" class="pull-left save_widget">
     <span id="notebook_name" class="filename"></span>
     <span class="checkpoint_status"></span>
     <span class="autosave_status"></span>
-</span>
-
-<span id="kernel_logo_widget">
-  <img class="current_kernel_logo" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"/>
 </span>
 
 {% endblock headercontainer %}


### PR DESCRIPTION
## before

![screen shot 2015-03-31 at 11 50 59](https://cloud.githubusercontent.com/assets/151929/6926627/712ab162-d79c-11e4-9cb7-984a07cd3eee.PNG)
## after
- logo

![screen shot 2015-03-31 at 11 50 12](https://cloud.githubusercontent.com/assets/151929/6926630/771bbbfc-d79c-11e4-8358-f0a5e3901468.PNG)
- no logo

![screen shot 2015-03-31 at 11 50 33](https://cloud.githubusercontent.com/assets/151929/6926633/7c6c478e-d79c-11e4-8482-14c73bcca3e1.PNG)

The display toggle is changed to visibility, so that changing kernels doesn't move the document name.

cc @ellisonbg 
