### PR TITLE
Path to glyphicon fonts (used by Bootstrap) was incorrect. Fixed paths t...

### DIFF
--- a/IPython/html/static/base/less/variables.less
+++ b/IPython/html/static/base/less/variables.less
@@ -13,8 +13,9 @@
 @logo_height: 28px;
 @border-radius-small: 1px;
 @border-radius-base: 2px;
-@border-radius-large: 3px;;
+@border-radius-large: 3px;
 @grid-gutter-width: 0px;
+@icon-font-path: "../components/bootstrap/fonts/";
 
 // Disable modal slide-in from top animation.
 .modal {

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -260,8 +260,8 @@ th {
 }
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: url('../fonts/glyphicons-halflings-regular.eot');
-  src: url('../fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('../fonts/glyphicons-halflings-regular.woff') format('woff'), url('../fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('../fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
+  src: url('../components/bootstrap/fonts/glyphicons-halflings-regular.eot');
+  src: url('../components/bootstrap/fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('../components/bootstrap/fonts/glyphicons-halflings-regular.woff') format('woff'), url('../components/bootstrap/fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('../components/bootstrap/fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
 }
 .glyphicon {
   position: relative;


### PR DESCRIPTION
Path to glyphicon font resources incorrect (used by Bootstrap). Fixed paths to coincide with where the appropriate Bootstrap resources are when IPython-components is attached. Useful for those using Bootstrap classes in custom themes.
