### PR TITLE
move sentinel out of IPython.utils.signature

### DIFF
--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -21,7 +21,7 @@ from decorator import decorator
 
 from IPython.config.configurable import Configurable
 from IPython.core.getipython import get_ipython
-from IPython.utils.signatures import Sentinel
+from IPython.utils.sentinel import Sentinel
 from IPython.lib import pretty
 from IPython.utils.traitlets import (
     Bool, Dict, Integer, Unicode, CUnicode, ObjectName, List,

--- a/IPython/utils/sentinel.py
+++ b/IPython/utils/sentinel.py
@@ -1,0 +1,17 @@
+"""Sentinel class for constants with useful reprs"""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+class Sentinel(object):
+
+    def __init__(self, name, module, docstring=None):
+        self.name = name
+        self.module = module
+        if docstring:
+            self.__doc__ = docstring
+
+
+    def __repr__(self):
+        return str(self.module)+'.'+self.name
+

--- a/IPython/utils/signatures.py
+++ b/IPython/utils/signatures.py
@@ -815,18 +815,3 @@ class Signature(object):
 
         return rendered
 
-## Fake unique value as KWargs, in some places.
-# do not put docstrings here or they will appear 
-# on created fake values.
-class Sentinel(object):
-
-    def __init__(self, name, module, docstring=None):
-        self.name = name
-        self.module = module
-        if docstring:
-            self.__doc__ = docstring
-
-
-    def __repr__(self):
-        return str(self.module)+'.'+self.name
-

--- a/jupyter_nbformat/__init__.py
+++ b/jupyter_nbformat/__init__.py
@@ -14,7 +14,7 @@ from . import v1
 from . import v2
 from . import v3
 from . import v4
-from IPython.utils.signatures import Sentinel
+from .sentinel import Sentinel
 
 __all__ = ['versions', 'validate', 'ValidationError', 'convert', 'from_dict',
            'NotebookNode', 'current_nbformat', 'current_nbformat_minor',

--- a/jupyter_nbformat/sentinel.py
+++ b/jupyter_nbformat/sentinel.py
@@ -1,0 +1,17 @@
+"""Sentinel class for constants with useful reprs"""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+class Sentinel(object):
+
+    def __init__(self, name, module, docstring=None):
+        self.name = name
+        self.module = module
+        if docstring:
+            self.__doc__ = docstring
+
+
+    def __repr__(self):
+        return str(self.module)+'.'+self.name
+

--- a/traitlets/sentinel.py
+++ b/traitlets/sentinel.py
@@ -1,0 +1,17 @@
+"""Sentinel class for constants with useful reprs"""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+class Sentinel(object):
+
+    def __init__(self, name, module, docstring=None):
+        self.name = name
+        self.module = module
+        if docstring:
+            self.__doc__ = docstring
+
+
+    def __repr__(self):
+        return str(self.module)+'.'+self.name
+

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -56,11 +56,11 @@ from warnings import warn
 from IPython.utils import py3compat
 from IPython.utils import eventful
 from IPython.utils.getargspec import getargspec
-from IPython.utils.signatures import Sentinel
 from IPython.utils.importstring import import_item
 from IPython.utils.py3compat import iteritems, string_types
 from IPython.testing.skipdoctest import skip_doctest
 
+from .sentinel import Sentinel
 SequenceTypes = (list, tuple, set, frozenset)
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
utils.signature is a backport of a stdlib file, and not an appropriate place for new code.

Further, to avoid adding a new trivial module to genutils, a copy is added each place we've used a sentinel.

The latter bit is debateable because it's obvious code duplication, but comes from the perspective that genutils is an unfortunate compromise that we have for now, and we will work toward phasing it out, adding no new content to it.
