### PR TITLE
confine doctests to IPython.core

### DIFF
--- a/IPython/extensions/rmagic.py
+++ b/IPython/extensions/rmagic.py
@@ -69,7 +69,6 @@ except ImportError:
 from IPython.core.displaypub import publish_display_data
 from IPython.core.magic import (Magics, magics_class, line_magic,
                                 line_cell_magic, needs_local_scope)
-from IPython.testing.skipdoctest import skip_doctest
 from IPython.core.magic_arguments import (
     argument, magic_arguments, parse_argstring
 )
@@ -234,7 +233,6 @@ class RMagics(Magics):
         self.Rstdout_cache = []
         return value
 
-    @skip_doctest
     @needs_local_scope
     @line_magic
     def Rpush(self, line, local_ns=None):
@@ -275,7 +273,6 @@ class RMagics(Magics):
 
             self.r.assign(input, self.pyconverter(val))
 
-    @skip_doctest
     @magic_arguments()
     @argument(
         '-d', '--as_dataframe', action='store_true',
@@ -327,7 +324,6 @@ class RMagics(Magics):
         for output in outputs:
             self.shell.push({output:self.Rconverter(self.r(output),dataframe=args.as_dataframe)})
 
-    @skip_doctest
     @magic_arguments()
     @argument(
         '-d', '--as_dataframe', action='store_true',
@@ -370,7 +366,6 @@ class RMagics(Magics):
         return self.Rconverter(self.r(output[0]),dataframe=args.as_dataframe)
 
 
-    @skip_doctest
     @magic_arguments()
     @argument(
         '-i', '--input', action='append',

--- a/IPython/extensions/storemagic.py
+++ b/IPython/extensions/storemagic.py
@@ -28,7 +28,6 @@ import inspect, os, sys, textwrap
 # Our own
 from IPython.core.error import UsageError
 from IPython.core.magic import Magics, magics_class, line_magic
-from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.traitlets import Bool
 from IPython.utils.py3compat import string_types
 
@@ -87,7 +86,6 @@ class StoreMagics(Magics):
         if self.autorestore:
             restore_data(self.shell)
 
-    @skip_doctest
     @line_magic
     def store(self, parameter_s=''):
         """Lightweight persistence for python variables.

--- a/IPython/html/widgets/widget_link.py
+++ b/IPython/html/widgets/widget_link.py
@@ -7,7 +7,6 @@ Propagate changes between widgets on the javascript side
 # Distributed under the terms of the Modified BSD License.
 
 from .widget import Widget
-from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.traitlets import Unicode, Tuple, List,Instance, TraitError
 
 class WidgetTraitTuple(Tuple):
@@ -51,7 +50,6 @@ class Link(Widget):
         self.close()
 
 
-@skip_doctest
 def jslink(*args):
     """Link traits from different widgets together on the frontend so they remain in sync.
 
@@ -92,7 +90,6 @@ class DirectionalLink(Widget):
     def unlink(self):
         self.close()
 
-@skip_doctest
 def jsdlink(source, *targets):
     """Link the trait of a source widget with traits of target widgets in the frontend.
 

--- a/IPython/html/widgets/widget_output.py
+++ b/IPython/html/widgets/widget_output.py
@@ -10,10 +10,8 @@ from .widget import DOMWidget
 import sys
 from IPython.utils.traitlets import Unicode, List
 from IPython.display import clear_output
-from IPython.testing.skipdoctest import skip_doctest
 from IPython.kernel.zmq.session import Message
 
-@skip_doctest
 class Output(DOMWidget):
     """Widget used as a context manager to display output.
 

--- a/IPython/lib/lexers.py
+++ b/IPython/lib/lexers.py
@@ -44,7 +44,6 @@ from pygments.token import (
 from pygments.util import get_bool_opt
 
 # Local
-from IPython.testing.skipdoctest import skip_doctest
 
 line_re = re.compile('.*?\n')
 
@@ -190,7 +189,6 @@ class IPythonTracebackLexer(DelegatingLexer):
         DelegatingLexer.__init__(self, IPyLexer,
                                  IPythonPartialTracebackLexer, **options)
 
-@skip_doctest
 class IPythonConsoleLexer(Lexer):
     """
     An IPython console lexer for IPython code-blocks and doctests, such as:

--- a/IPython/lib/security.py
+++ b/IPython/lib/security.py
@@ -11,7 +11,6 @@ import random
 
 # Our own
 from IPython.core.error import UsageError
-from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.py3compat import cast_bytes, str_to_bytes
 
 #-----------------------------------------------------------------------------
@@ -26,7 +25,6 @@ salt_len = 12
 # Functions
 #-----------------------------------------------------------------------------
 
-@skip_doctest
 def passwd(passphrase=None, algorithm='sha1'):
     """Generate hashed password and salt for use in notebook configuration.
 

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -25,7 +25,6 @@ from IPython.core.inputsplitter import IPythonInputSplitter
 from IPython.core.interactiveshell import InteractiveShell, InteractiveShellABC
 from IPython.core.magic import Magics, magics_class, line_magic
 from IPython.lib.clipboard import ClipboardEmpty
-from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.encoding import get_stream_enc
 from IPython.utils import py3compat
 from IPython.utils.terminal import toggle_set_term_title, set_term_title
@@ -130,7 +129,6 @@ class TerminalMagics(Magics):
         self.shell.set_autoindent()
         print("Automatic indentation is:",['OFF','ON'][self.shell.autoindent])
 
-    @skip_doctest
     @line_magic
     def cpaste(self, parameter_s=''):
         """Paste & execute a pre-formatted code block from clipboard.

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -463,10 +463,6 @@ def run_iptest():
         
 
     argv = sys.argv + [ '--detailed-errors',  # extra info in tracebacks
-
-                        '--with-ipdoctest',
-                        '--ipdoctest-tests','--ipdoctest-extension=txt',
-
                         # We add --exe because of setuptools' imbecility (it
                         # blindly does chmod +x on ALL files).  Nose does the
                         # right thing and it tries to avoid executables,
@@ -489,10 +485,18 @@ def run_iptest():
         # for nose >= 0.11, though unfortunately nose 0.10 doesn't support it.
         argv.append('--traverse-namespace')
 
-    # use our plugin for doctesting.  It will remove the standard doctest plugin
-    # if it finds it enabled
-    plugins = [ExclusionPlugin(section.excludes), IPythonDoctest(), KnownFailure(),
+    plugins = [ ExclusionPlugin(section.excludes), KnownFailure(),
                SubprocessStreamCapturePlugin() ]
+    
+    # we still have some vestigial doctests in core
+    if (section.name.startswith(('core', 'IPython.core'))):
+        plugins.append(IPythonDoctest())
+        argv.extend([
+            '--with-ipdoctest',
+            '--ipdoctest-tests',
+            '--ipdoctest-extension=txt',
+        ])
+
     
     # Use working directory set by parent process (see iptestcontroller)
     if 'IPTEST_WORKING_DIR' in os.environ:

--- a/IPython/testing/tests/test_decorators.py
+++ b/IPython/testing/tests/test_decorators.py
@@ -12,7 +12,6 @@ import nose.tools as nt
 
 # Our own
 from IPython.testing import decorators as dec
-from IPython.testing.skipdoctest import skip_doctest
 
 #-----------------------------------------------------------------------------
 # Utilities
@@ -61,7 +60,6 @@ def test_deliberately_broken2():
 
 # Verify that we can correctly skip the doctest for a function at will, but
 # that the docstring itself is NOT destroyed by the decorator.
-@skip_doctest
 def doctest_bad(x,y=1,**k):
     """A function whose doctest we need to skip.
 
@@ -109,7 +107,6 @@ class FooClass(object):
     2
     """
 
-    @skip_doctest
     def __init__(self,x):
         """Make a FooClass.
 
@@ -121,7 +118,6 @@ class FooClass(object):
         print('Making a FooClass.')
         self.x = x
         
-    @skip_doctest
     def bar(self,y):
         """Example:
 

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -16,7 +16,6 @@ import glob
 from warnings import warn
 from hashlib import md5
 
-from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.process import system
 from IPython.utils import py3compat
 from IPython.utils.decorators import undoc
@@ -32,7 +31,6 @@ def _writable_dir(path):
     return os.path.isdir(path) and os.access(path, os.W_OK)
 
 if sys.platform == 'win32':
-    @skip_doctest
     def _get_long_path_name(path):
         """Get a long path name (expand ~) on Windows using ctypes.
 

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -646,7 +646,6 @@ def _get_or_default(mylist, i, default=None):
         return mylist[i]
 
 
-@skip_doctest
 def compute_item_matrix(items, empty=None, *args, **kwargs) :
     """Returns a nested list, and info to columnize items
 

--- a/ipython_kernel/zmqshell.py
+++ b/ipython_kernel/zmqshell.py
@@ -38,7 +38,6 @@ from ipython_kernel.inprocess.socket import SocketABC
 from ipython_kernel import (
     get_connection_file, get_connection_info, connect_qtconsole
 )
-from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils import openpy
 from jupyter_client.jsonutil import json_clean, encode_images
 from IPython.utils.process import arg_split
@@ -105,7 +104,6 @@ class KernelMagics(Magics):
 
     _find_edit_target = CodeMagics._find_edit_target
 
-    @skip_doctest
     @line_magic
     def edit(self, parameter_s='', last_call=['','']):
         """Bring up an editor and execute the resulting code.

--- a/ipython_parallel/client/magics.py
+++ b/ipython_parallel/client/magics.py
@@ -45,7 +45,6 @@ import re
 from IPython.core.error import UsageError
 from IPython.core.magic import Magics
 from IPython.core import magic_arguments
-from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.text import dedent
 
 #-----------------------------------------------------------------------------
@@ -190,7 +189,6 @@ class ParallelMagics(Magics):
 
     @magic_arguments.magic_arguments()
     @output_args
-    @skip_doctest
     def result(self, line=''):
         """Print the result of the last asynchronous %px command.
         
@@ -218,7 +216,6 @@ class ParallelMagics(Magics):
         self.last_result.get()
         self.last_result.display_outputs(groupby=args.groupby)
 
-    @skip_doctest
     def px(self, line=''):
         """Executes the given python command in parallel.
         
@@ -269,7 +266,6 @@ class ParallelMagics(Magics):
     @magic_arguments.magic_arguments()
     @exec_args
     @output_args
-    @skip_doctest
     def cell_px(self, line='', cell=None):
         """Executes the cell in parallel.
         
@@ -316,7 +312,6 @@ class ParallelMagics(Magics):
         if not block:
             return ar
     
-    @skip_doctest
     def autopx(self, line=''):
         """Toggles auto parallel mode.
 

--- a/ipython_parallel/client/remotefunction.py
+++ b/ipython_parallel/client/remotefunction.py
@@ -9,7 +9,6 @@ import sys
 import warnings
 
 from decorator import decorator
-from IPython.testing.skipdoctest import skip_doctest
 
 from . import map as Map
 from .asyncresult import AsyncMapResult
@@ -18,7 +17,6 @@ from .asyncresult import AsyncMapResult
 # Functions and Decorators
 #-----------------------------------------------------------------------------
 
-@skip_doctest
 def remote(view, block=None, **flags):
     """Turn a function into a remote function.
 
@@ -33,7 +31,6 @@ def remote(view, block=None, **flags):
         return RemoteFunction(view, f, block=block, **flags)
     return remote_function
 
-@skip_doctest
 def parallel(view, dist='b', block=None, ordered=True, **flags):
     """Turn a function into a parallel remote function.
 

--- a/ipython_parallel/client/view.py
+++ b/ipython_parallel/client/view.py
@@ -13,7 +13,6 @@ from types import ModuleType
 
 import zmq
 
-from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils import pickleutil
 from IPython.utils.traitlets import (
     HasTraits, Any, Bool, List, Dict, Set, Instance, CFloat, Integer
@@ -69,7 +68,6 @@ def spin_after(f, self, *args, **kwargs):
 # Classes
 #-----------------------------------------------------------------------------
 
-@skip_doctest
 class View(HasTraits):
     """Base View class for more convenint apply(f,*args,**kwargs) syntax via attributes.
 
@@ -377,7 +375,6 @@ class View(HasTraits):
         block = self.block if block is None else block
         return parallel(self, dist=dist, block=block, **flags)
 
-@skip_doctest
 class DirectView(View):
     """Direct Multiplexer View of one or more engines.
 
@@ -845,7 +842,6 @@ class DirectView(View):
         ip.magics_manager.register(M)
 
 
-@skip_doctest
 class LoadBalancedView(View):
     """An load-balancing View that only executes via the Task scheduler.
 

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -58,7 +58,6 @@ from IPython.utils import eventful
 from IPython.utils.getargspec import getargspec
 from IPython.utils.importstring import import_item
 from IPython.utils.py3compat import iteritems, string_types
-from IPython.testing.skipdoctest import skip_doctest
 
 from .sentinel import Sentinel
 SequenceTypes = (list, tuple, set, frozenset)
@@ -189,7 +188,6 @@ def _validate_link(*tuples):
         if not trait_name in obj.traits():
             raise TypeError("%r has no trait %r" % (obj, trait_name))
 
-@skip_doctest
 class link(object):
     """Link traits from different objects together so they remain in sync.
 
@@ -244,7 +242,6 @@ class link(object):
             (obj, attr) = key
             obj.on_trait_change(callback, attr, remove=True)
 
-@skip_doctest
 class directional_link(object):
     """Link the trait of a source object with traits of target objects.
 


### PR DESCRIPTION
since that's the only place we have any, which removes the need for `@skip_doctest` sprinkled all over things.
