### PR TITLE
Fix Tuple trait type behavior with None

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1010,15 +1010,15 @@ class TestLenList(TraitTestBase):
 
 class TupleTrait(HasTraits):
 
-    value = Tuple(Int(allow_none=True))
+    value = Tuple(Int(allow_none=True), default_value=(1,))
 
 class TestTupleTrait(TraitTestBase):
 
     obj = TupleTrait()
 
-    _default_value = None
-    _good_values = [(1,), None, (0,), [1], (None,)]
-    _bad_values = [10, (1,2), ('a'), ()]
+    _default_value = (1,) 
+    _good_values = [(1,), (0,), [1]]
+    _bad_values = [10, (1, 2), ('a'), (), None]
 
     def coerce(self, value):
         if value is not None:
@@ -1039,8 +1039,8 @@ class TestLooseTupleTrait(TraitTestBase):
     obj = LooseTupleTrait()
 
     _default_value = (1,2,3)
-    _good_values = [(1,), None, [1], (0,), tuple(range(5)), tuple('hello'), ('a',5), ()]
-    _bad_values = [10, 'hello', {}]
+    _good_values = [(1,), [1], (0,), tuple(range(5)), tuple('hello'), ('a',5), ()]
+    _bad_values = [10, 'hello', {}, None]
 
     def coerce(self, value):
         if value is not None:

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -886,8 +886,7 @@ class ClassBasedTraitType(TraitType):
 class Type(ClassBasedTraitType):
     """A trait whose value must be a subclass of a specified class."""
 
-    def __init__ (self, default_value=None, klass=None, allow_none=False,
-                  **metadata):
+    def __init__ (self, default_value=None, klass=None, **metadata):
         """Construct a Type trait
 
         A Type trait specifies that its values must be subclasses of
@@ -923,7 +922,7 @@ class Type(ClassBasedTraitType):
 
         self.klass       = klass
 
-        super(Type, self).__init__(default_value, allow_none=allow_none, **metadata)
+        super(Type, self).__init__(default_value, **metadata)
 
     def validate(self, obj, value):
         """Validates that the value is a valid object instance."""
@@ -987,8 +986,7 @@ class Instance(ClassBasedTraitType):
 
     klass = None
 
-    def __init__(self, klass=None, args=None, kw=None, allow_none=False,
-                 **metadata ):
+    def __init__(self, klass=None, args=None, kw=None, **metadata):
         """Construct an Instance trait.
 
         This trait allows values that are instances of a particular
@@ -1042,7 +1040,7 @@ class Instance(ClassBasedTraitType):
 
             default_value = DefaultValueGenerator(*args, **kw)
 
-        super(Instance, self).__init__(default_value, allow_none=allow_none, **metadata)
+        super(Instance, self).__init__(default_value, **metadata)
 
     def validate(self, obj, value):
         if isinstance(value, self.klass):
@@ -1461,8 +1459,7 @@ class Container(Instance):
     _valid_defaults = SequenceTypes
     _trait = None
 
-    def __init__(self, trait=None, default_value=None, allow_none=False,
-                **metadata):
+    def __init__(self, trait=None, default_value=None, **metadata):
         """Create a container trait type from a list, set, or tuple.
 
         The default value is created by doing ``List(default_value)``,
@@ -1512,8 +1509,7 @@ class Container(Instance):
         elif trait is not None:
             raise TypeError("`trait` must be a Trait or None, got %s"%repr_type(trait))
 
-        super(Container,self).__init__(klass=self.klass, args=args,
-                                  allow_none=allow_none, **metadata)
+        super(Container,self).__init__(klass=self.klass, args=args, **metadata)
 
     def element_error(self, obj, element, validator):
         e = "Element of the '%s' trait of %s instance must be %s, but a value of %s was specified." \
@@ -1668,7 +1664,6 @@ class Tuple(Container):
 
         """
         default_value = metadata.pop('default_value', None)
-        allow_none = metadata.pop('allow_none', True)
 
         # allow Tuple((values,)):
         if len(traits) == 1 and default_value is None and not is_trait(traits[0]):
@@ -1691,7 +1686,7 @@ class Tuple(Container):
         if self._traits and default_value is None:
             # don't allow default to be an empty container if length is specified
             args = None
-        super(Container,self).__init__(klass=self.klass, args=args, allow_none=allow_none, **metadata)
+        super(Container,self).__init__(klass=self.klass, args=args, **metadata)
 
     def validate_elements(self, obj, value):
         if not self._traits:
@@ -1724,7 +1719,7 @@ class Dict(Instance):
     """An instance of a Python dict."""
     _trait = None
 
-    def __init__(self, trait=None, default_value=NoDefaultSpecified, allow_none=False, **metadata):
+    def __init__(self, trait=None, default_value=NoDefaultSpecified, **metadata):
         """Create a dict trait type from a dict.
 
         The default value is created by doing ``dict(default_value)``,
@@ -1764,8 +1759,7 @@ class Dict(Instance):
         elif trait is not None:
             raise TypeError("`trait` must be a Trait or None, got %s"%repr_type(trait))
 
-        super(Dict,self).__init__(klass=dict, args=args,
-                                  allow_none=allow_none, **metadata)
+        super(Dict,self).__init__(klass=dict, args=args, **metadata)
 
     def element_error(self, obj, element, validator):
         e = "Element of the '%s' trait of %s instance must be %s, but a value of %s was specified." \
@@ -1803,7 +1797,7 @@ class Dict(Instance):
 class EventfulDict(Instance):
     """An instance of an EventfulDict."""
 
-    def __init__(self, default_value={}, allow_none=False, **metadata):
+    def __init__(self, default_value={}, **metadata):
         """Create a EventfulDict trait type from a dict.
 
         The default value is created by doing
@@ -1820,13 +1814,13 @@ class EventfulDict(Instance):
             raise TypeError('default value of EventfulDict was %s' % default_value)
 
         super(EventfulDict, self).__init__(klass=eventful.EventfulDict, args=args,
-                                  allow_none=allow_none, **metadata)
+                                           **metadata)
 
 
 class EventfulList(Instance):
     """An instance of an EventfulList."""
 
-    def __init__(self, default_value=None, allow_none=False, **metadata):
+    def __init__(self, default_value=None, **metadata):
         """Create a EventfulList trait type from a dict.
 
         The default value is created by doing 
@@ -1839,7 +1833,7 @@ class EventfulList(Instance):
             args = (default_value,)
 
         super(EventfulList, self).__init__(klass=eventful.EventfulList, args=args,
-                                  allow_none=allow_none, **metadata)
+                                           **metadata)
 
 
 class TCPAddress(TraitType):


### PR DESCRIPTION
Tuple's behavior with respect to allow_none was incorect. The following code should raise a trait error:

``` python
from traitlets import Tuple, HasTraits
class Foo(HasTraits):
    bar = Tuple()

u = Foo()
u.bar = None
```
