### PR TITLE
Moving unpack_models to widget.js

### DIFF
--- a/IPython/html/static/widgets/js/widget_box.js
+++ b/IPython/html/static/widgets/js/widget_box.js
@@ -9,34 +9,10 @@ define([
     "bootstrap",
 ], function(widget, $, _, utils){
     "use strict";
-    var unpack_models = function unpack_models(value, model) {
-        /**
-         * Replace model ids with models recursively.
-         */
-        var unpacked;
-        if ($.isArray(value)) {
-            unpacked = [];
-            _.each(value, function(sub_value, key) {
-                unpacked.push(unpack_models(sub_value, model));
-            });
-            return Promise.all(unpacked);
-        } else if (value instanceof Object) {
-            unpacked = {};
-            _.each(value, function(sub_value, key) {
-                unpacked[key] = unpack_models(sub_value, model);
-            });
-            return utils.resolve_promises_dict(unpacked);
-        } else if (typeof value === 'string' && value.slice(0,10) === "IPY_MODEL_") {
-            // get_model returns a promise already
-            return model.widget_manager.get_model(value.slice(10, value.length));
-        } else {
-            return Promise.resolve(value);
-        }
-    };
 
     var BoxModel = widget.WidgetModel.extend({}, {
         serializers: _.extend({
-            children: {deserialize: unpack_models}
+            children: {deserialize: widget.unpack_models}
         }, widget.WidgetModel.serializers)
     });
 
@@ -179,7 +155,6 @@ define([
     });
 
     return {
-        'unpack_models': unpack_models,
         'BoxModel': BoxModel,
         'BoxView': BoxView,
         'FlexBoxView': FlexBoxView,

--- a/IPython/html/widgets/__init__.py
+++ b/IPython/html/widgets/__init__.py
@@ -1,4 +1,4 @@
-from .widget import Widget, DOMWidget, CallbackDispatcher, register
+from .widget import Widget, DOMWidget, CallbackDispatcher, register, widget_serialization
 
 from .trait_types import Color
 

--- a/IPython/html/widgets/widget.py
+++ b/IPython/html/widgets/widget.py
@@ -24,6 +24,33 @@ from IPython.utils.traitlets import Unicode, Dict, Instance, Bool, List, \
 from IPython.utils.py3compat import string_types
 from .trait_types import Color
 
+
+def _widget_to_json(x):
+    if isinstance(x, dict):
+        return {k: _widget_to_json(v) for k, v in x.items()}
+    elif isinstance(x, (list, tuple)):
+        return [_widget_to_json(v) for v in x]
+    elif isinstance(x, Widget):
+        return "IPY_MODEL_" + x.model_id
+    else:
+        return x
+
+def _json_to_widget(x):
+    if isinstance(x, dict):
+        return {k: _json_to_widget(v) for k, v in x.items()}
+    elif isinstance(x, (list, tuple)):
+        return [_json_to_widget(v) for v in x]
+    elif isinstance(x, string_types) and x.startswith('IPY_MODEL_') and x[10:] in Widget.widgets:
+        return Widget.widgets[x[10:]]
+    else:
+        return x
+
+widget_serialization = {
+    'from_json': _json_to_widget,
+    'to_json': _widget_to_json
+}
+
+
 #-----------------------------------------------------------------------------
 # Classes
 #-----------------------------------------------------------------------------

--- a/IPython/html/widgets/widget_box.py
+++ b/IPython/html/widgets/widget_box.py
@@ -6,34 +6,9 @@ Represents a container that can be used to group other widgets.
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from .widget import DOMWidget, Widget, register
+from .widget import DOMWidget, Widget, register, widget_serialization
 from IPython.utils.traitlets import Unicode, Tuple, TraitError, Int, CaselessStrEnum
 from .deprecated import DeprecatedClass
-
-def _widget_to_json(x):
-    if isinstance(x, dict):
-        return {k: _widget_to_json(v) for k, v in x.items()}
-    elif isinstance(x, (list, tuple)):
-        return [_widget_to_json(v) for v in x]
-    elif isinstance(x, Widget):
-        return "IPY_MODEL_" + x.model_id
-    else:
-        return x
-
-def _json_to_widget(x):
-    if isinstance(x, dict):
-        return {k: _json_to_widget(v) for k, v in x.items()}
-    elif isinstance(x, (list, tuple)):
-        return [_json_to_widget(v) for v in x]
-    elif isinstance(x, string_types) and x.startswith('IPY_MODEL_') and x[10:] in Widget.widgets:
-        return Widget.widgets[x[10:]]
-    else:
-        return x
-
-widget_serialization = {
-    'from_json': _json_to_widget,
-    'to_json': _widget_to_json
-}
 
 
 @register('IPython.Box')


### PR DESCRIPTION
Since every custom widget having child widgets will need the `unpack_model` function, introduced in #7757.
It could probably be in `widget.js` rather than in `widget_box.js`, especially since widget.js is already where ViewList is defined. 
