### PR TITLE
Changes in hold_trait_notification context manager

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1366,7 +1366,7 @@ def test_hold_trait_notifications():
         nt.assert_equal(t.a, 4)
         nt.assert_equal(changes, [])
 
-    nt.assert_equal(changes, [(3,4)])
+    nt.assert_equal(changes, [(0, 4)])
     # Test roll-back
     try:
          with t.hold_trait_notifications():


### PR DESCRIPTION
- Now, cached notifications are merged, rather than replaced
  (so that the eventual handler gets the correct value for `old`).
- It should be a bit more memory efficient since only one cache is used now.
- Besides it handles better the case of validation errors which are not cross validation errors.
