### PR TITLE
use stdout.encoding for decoding pretty bytes

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -112,6 +112,7 @@ import datetime
 from collections import deque
 
 from IPython.utils.py3compat import PY3, cast_unicode
+from IPython.utils.encoding import get_stream_enc
 
 from io import StringIO
 
@@ -140,7 +141,8 @@ else:
     class CUnicodeIO(StringIO):
         """StringIO that casts str to unicode on Python 2"""
         def write(self, text):
-            return super(CUnicodeIO, self).write(cast_unicode(text))
+            return super(CUnicodeIO, self).write(
+                cast_unicode(text, encoding=get_stream_enc(sys.stdout)))
 
 
 def pretty(obj, verbose=False, max_width=79, newline='\n', max_seq_length=MAX_SEQ_LENGTH):


### PR DESCRIPTION
ensures correct decoding for objects that have queried sys.stdout.encoding for computing repr bytes.

closes #8259
