### PR TITLE
Pass the arguments to the callback in the on_some_change function

### DIFF
--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -416,7 +416,7 @@ define(["widgets/js/manager",
              */
             this.on('change', function() {
                 if (keys.some(this.hasChanged, this)) {
-                    callback.apply(context);
+                    callback.apply(context, arguments);
                 }
             }, this);
 


### PR DESCRIPTION
Currently on_some_change does not pass the arguments that are passed when the change event gets fired. This change simply passes the arguments to the callback.
