### PR TITLE
Minor fixes on custom serialization, and traitlet hold_traits

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -215,7 +215,7 @@ class BaseIPythonApplication(Application):
             return crashhandler.crash_handler_lite(etype, evalue, tb)
     
     def _ipython_dir_changed(self, name, old, new):
-        if old is not None and old is not Undefined:
+        if old is not Undefined:
             str_old = py3compat.cast_bytes_py2(os.path.abspath(old),
                 sys.getfilesystemencoding()
             )

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -355,7 +355,7 @@ define(["widgets/js/manager",
                     this.pending_msgs++;
                 }
             }
-            // Since the comm is a one-way communication, assume the message 
+            // Since the comm is a one-way communication, assume the message
             // arrived.  Don't call success since we don't have a model back from the server
             // this means we miss out on the 'sync' event.
             this._buffered_state_diff = {};
@@ -383,11 +383,13 @@ define(["widgets/js/manager",
                 for (var i=0; i<keys.length; i++) {
                     var key = keys[i];
                     var value = state[key];
-                    if (value.buffer instanceof ArrayBuffer
-                        || value instanceof ArrayBuffer) {
-                        buffers.push(value);
-                        buffer_keys.push(key);
-                        delete state[key];
+                    if (value) {
+                        if (value.buffer instanceof ArrayBuffer
+                            || value instanceof ArrayBuffer) {
+                            buffers.push(value);
+                            buffer_keys.push(key);
+                            delete state[key];
+                        }
                     }
                 }
                 that.comm.send({method: 'backbone', sync_data: state, buffer_keys: buffer_keys}, callbacks, {}, buffers);
@@ -396,7 +398,7 @@ define(["widgets/js/manager",
                 return (utils.reject("Couldn't send widget sync message", true))(error);
             });
         },
-        
+
         save_changes: function(callbacks) {
             /**
              * Push this model's state to the back-end
@@ -410,7 +412,7 @@ define(["widgets/js/manager",
             /**
              * on_some_change(["key1", "key2"], foo, context) differs from
              * on("change:key1 change:key2", foo, context).
-             * If the widget attributes key1 and key2 are both modified, 
+             * If the widget attributes key1 and key2 are both modified,
              * the second form will result in foo being called twice
              * while the first will call foo only once.
              */

--- a/IPython/html/static/widgets/js/widget.js
+++ b/IPython/html/static/widgets/js/widget.js
@@ -369,7 +369,7 @@ define(["widgets/js/manager",
             // being the value or the promise of the serialized value
             var serializers = this.constructor.serializers;
             if (serializers) {
-                for (k in attrs) {
+                for (var k in attrs) {
                     if (serializers[k] && serializers[k].serialize) {
                         attrs[k] = (serializers[k].serialize)(attrs[k], this);
                     }

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -1374,7 +1374,25 @@ def test_hold_trait_notifications():
     except:
         pass
     nt.assert_equal(t.b, 0)
-    
+
+
+class RollBack(HasTraits):
+    bar = Int()
+    def _bar_validate(self, value, trait):
+        if value:
+            raise TraitError('foobar')
+        return value
+
+
+class TestRollback(TestCase):
+
+    def test_roll_back(self):
+
+        def assign_rollback():
+            RollBack(bar=1)
+
+        self.assertRaises(TraitError, assign_rollback)
+
 
 class OrderTraits(HasTraits):
     notified = Dict()

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -624,7 +624,7 @@ class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
                     if cache[name][1] is not Undefined:
                         setattr(self, name, cache[name][1])
                     else:
-                        delattr(self, name)
+                        self._trait_values.pop(name)
                 cache = {}
                 raise e
             finally:


### PR DESCRIPTION
- IPython/core/application
  `old` actually cannot be `None`
- widget.js
  missing `var`
- traitlets.py `delattr` cannot be used. I recall that @minrk mentioned it in an inline comment for the PR where the context manager was added, and this case was actually not triggered by the test. 
