### PR TITLE
use dev for maintenance branch version_extra

### DIFF
--- a/IPython/core/release.py
+++ b/IPython/core/release.py
@@ -22,7 +22,7 @@ name = 'ipython'
 _version_major = 3
 _version_minor = 2
 _version_patch = 0
-_version_extra = 'maint'
+_version_extra = 'dev'
 # _version_extra = 'rc1'
 # _version_extra = ''  # Uncomment this for full releases
 

--- a/IPython/html/static/base/js/namespace.js
+++ b/IPython/html/static/base/js/namespace.js
@@ -4,7 +4,7 @@
 var IPython = IPython || {};
 define([], function(){
     "use strict";
-    IPython.version = "3.1.0";
+    IPython.version = "3.2.0-dev";
     IPython._target = '_blank';
     return IPython;
 });


### PR DESCRIPTION
instead of 'maint'

PEP 440 helpfully made anything other than 'dev' unparseable, and evaluate as always less than zero.

cc @jhamrick
