### PR TITLE
fix typo in `python -m IPython.kernel`

### DIFF
--- a/IPython/kernel/__main__.py
+++ b/IPython/kernel/__main__.py
@@ -1,3 +1,3 @@
 if __name__ == '__main__':
-    from ipython_kernel.zmq import kernelapp as app
+    from ipython_kernel import kernelapp as app
     app.launch_new_instance()


### PR DESCRIPTION
zmq subpackage is gone
