### PR TITLE
fix bug in stale profile clean up for clusters

### DIFF
--- a/jupyter_notebook/services/clusters/clustermanager.py
+++ b/jupyter_notebook/services/clusters/clustermanager.py
@@ -71,7 +71,7 @@ class ClusterManager(LoggingConfigurable):
         for profile in stale:
             # remove profiles that no longer exist
             self.log.debug("Profile '%s' no longer exists", profile)
-            self.profiles.pop(stale)
+            self.profiles.pop(profile)
 
     def list_profiles(self):
         self.update_profiles()


### PR DESCRIPTION
"clusters" tab of my notebook wasn't rendering, so checked the log, found the stack trace:

```
[...]
      File "/usr/local/lib/python3.4/site-packages/ipython-3.0.0-py3.4.egg/IPython/html/services/clusters/handlers.py", line 21, in get
        self.finish(json.dumps(self.cluster_manager.list_profiles()))
      File "/usr/local/lib/python3.4/site-packages/ipython-3.0.0-py3.4.egg/IPython/html/services/clusters/clustermanager.py", line 77, in list_profiles
        self.update_profiles()
      File "/usr/local/lib/python3.4/site-packages/ipython-3.0.0-py3.4.egg/IPython/html/services/clusters/clustermanager.py", line 74, in update_profiles
        self.profiles.pop(stale)
    TypeError: unhashable type: 'set'
```

looks like a pretty straightforward mistake
