### PR TITLE
update dependency imports

### DIFF
--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -42,7 +42,6 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "extensions"))
 # Setup the top level names
 #-----------------------------------------------------------------------------
 
-from .config.loader import Config
 from .core.getipython import get_ipython
 from .core import release
 from .core.application import Application
@@ -88,7 +87,7 @@ def embed_kernel(module=None, local_ns=None, **kwargs):
         local_ns = caller_locals
     
     # Only import .zmq when we really need it
-    from IPython.kernel.zmq.embed import embed_kernel as real_embed_kernel
+    from ipython_kernel.embed import embed_kernel as real_embed_kernel
     real_embed_kernel(module=module, local_ns=local_ns, **kwargs)
 
 def start_ipython(argv=None, **kwargs):

--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -24,11 +24,11 @@ import os
 import re
 import sys
 
-from IPython.config.configurable import Configurable
+from traitlets.config.configurable import Configurable
 from IPython.core.error import UsageError
 
 from IPython.utils.py3compat import string_types
-from IPython.utils.traitlets import List, Instance
+from traitlets import List, Instance
 from IPython.utils.warn import error
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -19,13 +19,14 @@ import os
 import shutil
 import sys
 
-from IPython.config.application import Application, catch_config_error
-from IPython.config.loader import ConfigFileNotFound, PyFileConfigLoader
+from traitlets.config.application import Application, catch_config_error
+from traitlets.config.loader import ConfigFileNotFound, PyFileConfigLoader
 from IPython.core import release, crashhandler
 from IPython.core.profiledir import ProfileDir, ProfileDirError
-from IPython.utils.path import get_ipython_dir, get_ipython_package_dir, ensure_dir_exists
+from IPython.paths import get_ipython_dir, get_ipython_package_dir
+from IPython.utils.path import ensure_dir_exists
 from IPython.utils import py3compat
-from IPython.utils.traitlets import List, Unicode, Type, Bool, Dict, Set, Instance, Undefined
+from traitlets import List, Unicode, Type, Bool, Dict, Set, Instance, Undefined
 
 if os.name == 'nt':
     programdata = os.environ.get('PROGRAMDATA', None)

--- a/IPython/core/builtin_trap.py
+++ b/IPython/core/builtin_trap.py
@@ -18,10 +18,10 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
-from IPython.config.configurable import Configurable
+from traitlets.config.configurable import Configurable
 
 from IPython.utils.py3compat import builtin_mod, iteritems
-from IPython.utils.traitlets import Instance
+from traitlets import Instance
 
 #-----------------------------------------------------------------------------
 # Classes and functions

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -64,7 +64,7 @@ import sys
 import unicodedata
 import string
 
-from IPython.config.configurable import Configurable 
+from traitlets.config.configurable import Configurable 
 from IPython.core.error import TryNext
 from IPython.core.inputsplitter import ESC_MAGIC
 from IPython.core.latex_symbols import latex_symbols, reverse_latex_symbol
@@ -74,7 +74,7 @@ from IPython.utils.decorators import undoc
 from IPython.utils.dir2 import dir2
 from IPython.utils.process import arg_split
 from IPython.utils.py3compat import builtin_mod, string_types, PY3
-from IPython.utils.traitlets import CBool, Enum
+from traitlets import CBool, Enum
 
 #-----------------------------------------------------------------------------
 # Globals

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -930,9 +930,9 @@ def set_matplotlib_formats(*formats, **kwargs):
     """
     from IPython.core.interactiveshell import InteractiveShell
     from IPython.core.pylabtools import select_figure_formats
-    from IPython.kernel.zmq.pylab.config import InlineBackend
     # build kwargs, starting with InlineBackend config
     kw = {}
+    from ipython_kernel.pylab.config import InlineBackend
     cfg = InlineBackend.instance()
     kw.update(cfg.print_figure_kwargs)
     kw.update(**kwargs)
@@ -961,7 +961,7 @@ def set_matplotlib_close(close=True):
         Should all matplotlib figures be automatically closed after each cell is
         run?
     """
-    from IPython.kernel.zmq.pylab.config import InlineBackend
+    from ipython_kernel.pylab.config import InlineBackend
     cfg = InlineBackend.instance()
     cfg.close_figures = close
 

--- a/IPython/core/display_trap.py
+++ b/IPython/core/display_trap.py
@@ -21,8 +21,8 @@ Authors:
 
 import sys
 
-from IPython.config.configurable import Configurable
-from IPython.utils.traitlets import Any
+from traitlets.config.configurable import Configurable
+from traitlets import Any
 
 #-----------------------------------------------------------------------------
 # Classes and functions

--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -12,10 +12,10 @@ from __future__ import print_function
 import sys
 
 from IPython.core.formatters import _safe_get_formatter_method
-from IPython.config.configurable import Configurable
+from traitlets.config.configurable import Configurable
 from IPython.utils import io
 from IPython.utils.py3compat import builtin_mod
-from IPython.utils.traitlets import Instance, Float
+from traitlets import Instance, Float
 from IPython.utils.warn import warn
 
 # TODO: Move the various attributes (cache_size, [others now moved]). Some

--- a/IPython/core/displaypub.py
+++ b/IPython/core/displaypub.py
@@ -17,9 +17,9 @@ spec.
 
 from __future__ import print_function
 
-from IPython.config.configurable import Configurable
+from traitlets.config.configurable import Configurable
 from IPython.utils import io
-from IPython.utils.traitlets import List
+from traitlets import List
 
 # This used to be defined here - it is imported for backwards compatibility
 from .display import publish_display_data

--- a/IPython/core/extensions.py
+++ b/IPython/core/extensions.py
@@ -8,9 +8,9 @@ import os
 from shutil import copyfile
 import sys
 
-from IPython.config.configurable import Configurable
+from traitlets.config.configurable import Configurable
 from IPython.utils.path import ensure_dir_exists
-from IPython.utils.traitlets import Instance
+from traitlets import Instance
 from IPython.utils.py3compat import PY3
 if PY3:
     from imp import reload

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -19,11 +19,11 @@ import warnings
 
 from decorator import decorator
 
-from IPython.config.configurable import Configurable
+from traitlets.config.configurable import Configurable
 from IPython.core.getipython import get_ipython
 from IPython.utils.sentinel import Sentinel
 from IPython.lib import pretty
-from IPython.utils.traitlets import (
+from traitlets import (
     Bool, Dict, Integer, Unicode, CUnicode, ObjectName, List,
     ForwardDeclaredInstance,
 )

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -27,12 +27,12 @@ except ImportError:
 import threading
 
 # Our own packages
-from IPython.config.configurable import Configurable
+from traitlets.config.configurable import Configurable
 from decorator import decorator
 from IPython.utils.decorators import undoc
 from IPython.utils.path import locate_profile
 from IPython.utils import py3compat
-from IPython.utils.traitlets import (
+from traitlets import (
     Any, Bool, Dict, Instance, Integer, List, Unicode, TraitError,
 )
 from IPython.utils.warn import warn
@@ -177,7 +177,7 @@ class HistoryAccessor(HistoryAccessorBase):
         hist_file : str
           Path to an SQLite history database stored by IPython. If specified,
           hist_file overrides profile.
-        config : :class:`~IPython.config.loader.Config`
+        config : :class:`~traitlets.config.loader.Config`
           Config object. hist_file can also be set through this.
         """
         # We need a pointer back to the shell for various tasks.

--- a/IPython/core/historyapp.py
+++ b/IPython/core/historyapp.py
@@ -9,9 +9,9 @@ from __future__ import print_function
 import os
 import sqlite3
 
-from IPython.config.application import Application
+from traitlets.config.application import Application
 from IPython.core.application import BaseIPythonApplication
-from IPython.utils.traitlets import Bool, Int, Dict
+from traitlets import Bool, Int, Dict
 from IPython.utils.io import ask_yes_no
 
 trim_hist_help = """Trim the IPython history database to the last 1000 entries.

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -29,7 +29,7 @@ from io import open as io_open
 
 from pickleshare import PickleShareDB
 
-from IPython.config.configurable import SingletonConfigurable
+from traitlets.config.configurable import SingletonConfigurable
 from IPython.core import debugger, oinspect
 from IPython.core import magic
 from IPython.core import page
@@ -64,7 +64,8 @@ from IPython.utils import openpy
 from IPython.utils.decorators import undoc
 from IPython.utils.io import ask_yes_no
 from IPython.utils.ipstruct import Struct
-from IPython.utils.path import get_home_dir, get_ipython_dir, get_py_filename, unquote_filename, ensure_dir_exists
+from IPython.paths import get_ipython_dir
+from IPython.utils.path import get_home_dir, get_py_filename, unquote_filename, ensure_dir_exists
 from IPython.utils.process import system, getoutput
 from IPython.utils.py3compat import (builtin_mod, unicode_type, string_types,
                                      with_metaclass, iteritems)
@@ -72,7 +73,7 @@ from IPython.utils.strdispatch import StrDispatch
 from IPython.utils.syspathcontext import prepended_to_syspath
 from IPython.utils.text import (format_screen, LSString, SList,
                                 DollarFormatter)
-from IPython.utils.traitlets import (Integer, Bool, CBool, CaselessStrEnum, Enum,
+from traitlets import (Integer, Bool, CBool, CaselessStrEnum, Enum,
                                      List, Dict, Unicode, Instance, Type)
 from IPython.utils.warn import warn, error
 import IPython.core.hooks
@@ -2688,7 +2689,7 @@ class InteractiveShell(SingletonConfigurable):
         def get_cells():
             """generator for sequence of code blocks to run"""
             if fname.endswith('.ipynb'):
-                from IPython.nbformat import read
+                from jupyter_nbformat import read
                 with io_open(fname) as f:
                     nb = read(f, as_version=4)
                     if not nb.cells:

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -23,7 +23,7 @@ import types
 from getopt import getopt, GetoptError
 
 # Our own
-from IPython.config.configurable import Configurable
+from traitlets.config.configurable import Configurable
 from IPython.core import oinspect
 from IPython.core.error import UsageError
 from IPython.core.inputsplitter import ESC_MAGIC, ESC_MAGIC2
@@ -32,7 +32,7 @@ from IPython.utils.ipstruct import Struct
 from IPython.utils.process import arg_split
 from IPython.utils.py3compat import string_types, iteritems
 from IPython.utils.text import dedent
-from IPython.utils.traitlets import Bool, Dict, Instance, MetaHasTraits
+from traitlets import Bool, Dict, Instance, MetaHasTraits
 from IPython.utils.warn import error
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -596,7 +596,7 @@ Defaulting color scheme to 'NoColor'"""
         """
         args = magic_arguments.parse_argstring(self.notebook, s)
 
-        from IPython.nbformat import write, v4
+        from jupyter_nbformat import write, v4
         args.filename = unquote_filename(args.filename)
         if args.export:
             cells = []

--- a/IPython/core/magics/config.py
+++ b/IPython/core/magics/config.py
@@ -106,7 +106,7 @@ class ConfigMagics(Magics):
             In [5]: %config IPCompleter.greedy = feeling_greedy
 
         """
-        from IPython.config.loader import Config
+        from traitlets.config.loader import Config
         # some IPython objects are Configurable, but do not yet have
         # any configurable traits.  Exclude them from the effects of
         # this magic, as their presence is just noise:

--- a/IPython/core/magics/pylab.py
+++ b/IPython/core/magics/pylab.py
@@ -14,7 +14,7 @@ from __future__ import print_function
 #-----------------------------------------------------------------------------
 
 # Our own packages
-from IPython.config.application import Application
+from traitlets.config.application import Application
 from IPython.core import magic_arguments
 from IPython.core.magic import Magics, magics_class, line_magic
 from IPython.testing.skipdoctest import skip_doctest

--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -22,7 +22,7 @@ from subprocess import Popen, PIPE
 import atexit
 
 # Our own packages
-from IPython.config.configurable import Configurable
+from traitlets.config.configurable import Configurable
 from IPython.core import magic_arguments
 from IPython.core.magic import  (
     Magics, magics_class, line_magic, cell_magic
@@ -30,7 +30,7 @@ from IPython.core.magic import  (
 from IPython.lib.backgroundjobs import BackgroundJobManager
 from IPython.utils import py3compat
 from IPython.utils.process import arg_split
-from IPython.utils.traitlets import List, Dict
+from traitlets import List, Dict
 
 #-----------------------------------------------------------------------------
 # Magic implementation classes

--- a/IPython/core/payload.py
+++ b/IPython/core/payload.py
@@ -18,8 +18,8 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
-from IPython.config.configurable import Configurable
-from IPython.utils.traitlets import List
+from traitlets.config.configurable import Configurable
+from traitlets import List
 
 #-----------------------------------------------------------------------------
 # Main payload class

--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -28,7 +28,7 @@ from keyword import iskeyword
 import re
 
 from IPython.core.autocall import IPyAutocall
-from IPython.config.configurable import Configurable
+from traitlets.config.configurable import Configurable
 from IPython.core.inputsplitter import (
     ESC_MAGIC,
     ESC_QUOTE,
@@ -38,7 +38,7 @@ from IPython.core.inputsplitter import (
 from IPython.core.macro import Macro
 from IPython.core.splitinput import LineInfo
 
-from IPython.utils.traitlets import (
+from traitlets import (
     List, Integer, Unicode, CBool, Bool, Instance, CRegExp
 )
 

--- a/IPython/core/profileapp.py
+++ b/IPython/core/profileapp.py
@@ -24,15 +24,15 @@ from __future__ import print_function
 
 import os
 
-from IPython.config.application import Application
+from traitlets.config.application import Application
 from IPython.core.application import (
     BaseIPythonApplication, base_flags
 )
 from IPython.core.profiledir import ProfileDir
 from IPython.utils.importstring import import_item
-from IPython.utils.path import get_ipython_dir, get_ipython_package_dir
+from IPython.paths import get_ipython_dir, get_ipython_package_dir
 from IPython.utils import py3compat
-from IPython.utils.traitlets import Unicode, Bool, Dict
+from traitlets import Unicode, Bool, Dict
 
 #-----------------------------------------------------------------------------
 # Constants
@@ -261,25 +261,19 @@ class ProfileCreate(BaseIPythonApplication):
         from IPython.terminal.ipapp import TerminalIPythonApp
         apps = [TerminalIPythonApp]
         for app_path in (
-            'IPython.kernel.zmq.kernelapp.IPKernelApp',
-            'IPython.terminal.console.app.ZMQTerminalIPythonApp',
-            'IPython.qt.console.qtconsoleapp.IPythonQtConsoleApp',
-            'IPython.html.notebookapp.NotebookApp',
-            'IPython.nbconvert.nbconvertapp.NbConvertApp',
+            'ipython_kernel.kernelapp.IPKernelApp',
         ):
             app = self._import_app(app_path)
             if app is not None:
                 apps.append(app)
         if self.parallel:
-            from IPython.parallel.apps.ipcontrollerapp import IPControllerApp
-            from IPython.parallel.apps.ipengineapp import IPEngineApp
-            from IPython.parallel.apps.ipclusterapp import IPClusterStart
-            from IPython.parallel.apps.iploggerapp import IPLoggerApp
+            from ipython_parallel.apps.ipcontrollerapp import IPControllerApp
+            from ipython_parallel.apps.ipengineapp import IPEngineApp
+            from ipython_parallel.apps.ipclusterapp import IPClusterStart
             apps.extend([
                 IPControllerApp,
                 IPEngineApp,
                 IPClusterStart,
-                IPLoggerApp,
             ])
         for App in apps:
             app = App()

--- a/IPython/core/profiledir.py
+++ b/IPython/core/profiledir.py
@@ -8,10 +8,11 @@ import os
 import shutil
 import errno
 
-from IPython.config.configurable import LoggingConfigurable
-from IPython.utils.path import get_ipython_package_dir, expand_path, ensure_dir_exists
+from traitlets.config.configurable import LoggingConfigurable
+from IPython.paths import get_ipython_package_dir
+from IPython.utils.path import expand_path, ensure_dir_exists
 from IPython.utils import py3compat
-from IPython.utils.traitlets import Unicode, Bool
+from traitlets import Unicode, Bool
 
 #-----------------------------------------------------------------------------
 # Module errors
@@ -137,34 +138,16 @@ class ProfileDir(LoggingConfigurable):
     def _static_dir_changed(self, name, old, new):
         self.check_startup_dir()
 
-    def check_static_dir(self):
-        self._mkdir(self.static_dir)
-        custom = os.path.join(self.static_dir, 'custom')
-        self._mkdir(custom)
-        try:
-            from jupyter_notebook import DEFAULT_STATIC_FILES_PATH
-        except ImportError:
-            return
-        for fname in ('custom.js', 'custom.css'):
-            src = os.path.join(DEFAULT_STATIC_FILES_PATH, 'custom', fname)
-            dest = os.path.join(custom, fname)
-            if not os.path.exists(src):
-                self.log.warn("Could not copy default file to static dir. Source file %s does not exist.", src)
-                continue
-            if not os.path.exists(dest):
-                shutil.copy(src, dest)
-
     def check_dirs(self):
         self.check_security_dir()
         self.check_log_dir()
         self.check_pid_dir()
         self.check_startup_dir()
-        self.check_static_dir()
 
     def copy_config_file(self, config_file, path=None, overwrite=False):
         """Copy a default config file into the active profile directory.
 
-        Default configuration files are kept in :mod:`IPython.config.default`.
+        Default configuration files are kept in :mod:`IPython.core.profile`.
         This function moves these from that location to the working profile
         directory.
         """

--- a/IPython/core/prompts.py
+++ b/IPython/core/prompts.py
@@ -28,10 +28,10 @@ import time
 
 from string import Formatter
 
-from IPython.config.configurable import Configurable
+from traitlets.config.configurable import Configurable
 from IPython.core import release
 from IPython.utils import coloransi, py3compat
-from IPython.utils.traitlets import (Unicode, Instance, Dict, Bool, Int)
+from traitlets import (Unicode, Instance, Dict, Bool, Int)
 
 #-----------------------------------------------------------------------------
 # Color schemes for prompts

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -23,7 +23,7 @@ backends = {'tk': 'TkAgg',
             'osx': 'MacOSX',
             'nbagg': 'nbAgg',
             'notebook': 'nbAgg',
-            'inline' : 'module://IPython.kernel.zmq.pylab.backend_inline'}
+            'inline' : 'module://ipython_kernel.pylab.backend_inline'}
 
 # We also need a reverse backends2guis mapping that will properly choose which
 # GUI support to activate based on the desired matplotlib backend.  For the
@@ -182,7 +182,7 @@ def select_figure_formats(shell, formats, **kwargs):
         Extra keyword arguments to be passed to fig.canvas.print_figure.
     """
     from matplotlib.figure import Figure
-    from IPython.kernel.zmq.pylab import backend_inline
+    from ipython_kernel.pylab import backend_inline
 
     svg_formatter = shell.display_formatter.formatters['image/svg+xml']
     png_formatter = shell.display_formatter.formatters['image/png']
@@ -233,7 +233,7 @@ def find_gui_and_backend(gui=None, gui_select=None):
     Returns
     -------
     A tuple of (gui, backend) where backend is one of ('TkAgg','GTKAgg',
-    'WXAgg','Qt4Agg','module://IPython.kernel.zmq.pylab.backend_inline').
+    'WXAgg','Qt4Agg','module://ipython_kernel.pylab.backend_inline').
     """
 
     import matplotlib
@@ -334,7 +334,7 @@ def configure_inline_support(shell, backend):
     # continuing (such as in terminal-only shells in environments without
     # zeromq available).
     try:
-        from IPython.kernel.zmq.pylab.backend_inline import InlineBackend
+        from ipython_kernel.pylab.backend_inline import InlineBackend
     except ImportError:
         return
     from matplotlib import pyplot
@@ -345,7 +345,7 @@ def configure_inline_support(shell, backend):
         shell.configurables.append(cfg)
 
     if backend == backends['inline']:
-        from IPython.kernel.zmq.pylab.backend_inline import flush_figures
+        from ipython_kernel.pylab.backend_inline import flush_figures
         shell.events.register('post_execute', flush_figures)
 
         # Save rcParams that will be overwrittern
@@ -355,7 +355,7 @@ def configure_inline_support(shell, backend):
         # load inline_rc
         pyplot.rcParams.update(cfg.rc)
     else:
-        from IPython.kernel.zmq.pylab.backend_inline import flush_figures
+        from ipython_kernel.pylab.backend_inline import flush_figures
         try:
             shell.events.unregister('post_execute', flush_figures)
         except ValueError:

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -14,14 +14,14 @@ import glob
 import os
 import sys
 
-from IPython.config.application import boolean_flag
-from IPython.config.configurable import Configurable
-from IPython.config.loader import Config
+from traitlets.config.application import boolean_flag
+from traitlets.config.configurable import Configurable
+from traitlets.config.loader import Config
 from IPython.core import pylabtools
 from IPython.utils import py3compat
 from IPython.utils.contexts import preserve_keys
 from IPython.utils.path import filefind
-from IPython.utils.traitlets import (
+from traitlets import (
     Unicode, Instance, List, Bool, CaselessStrEnum
 )
 from IPython.lib.inputhook import guis

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 
 import nose.tools as nt
 
-from IPython.config.loader import Config
+from traitlets.config.loader import Config
 from IPython.core import completer
 from IPython.external.decorators import knownfailureif
 from IPython.utils.tempdir import TemporaryDirectory, TemporaryWorkingDirectory

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -9,7 +9,7 @@ import nose.tools as nt
 
 from IPython.core import display
 from IPython.core.getipython import get_ipython
-from IPython.utils import path as ipath
+from IPython import paths as ipath
 
 import IPython.testing.decorators as dec
 
@@ -60,7 +60,7 @@ def test_image_filename_defaults():
     nt.assert_is_none(img._repr_jpeg_())
 
 def _get_inline_config():
-    from IPython.kernel.zmq.pylab.config import InlineBackend
+    from ipython_kernel.pylab.config import InlineBackend
     return InlineBackend.instance()
     
 @dec.skip_without('matplotlib')

--- a/IPython/core/tests/test_formatters.py
+++ b/IPython/core/tests/test_formatters.py
@@ -10,7 +10,7 @@ except:
 import nose.tools as nt
 
 from IPython import get_ipython
-from IPython.config import Config
+from traitlets.config import Config
 from IPython.core.formatters import (
     PlainTextFormatter, HTMLFormatter, PDFFormatter, _mod_name_key,
     DisplayFormatter, JSONFormatter,

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -16,7 +16,7 @@ from datetime import datetime
 import nose.tools as nt
 
 # our own packages
-from IPython.config.loader import Config
+from traitlets.config.loader import Config
 from IPython.utils.tempdir import TemporaryDirectory
 from IPython.core.history import HistoryManager, extract_hist_ranges
 from IPython.utils import py3compat

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -607,8 +607,8 @@ class TestModules(unittest.TestCase, tt.TempFileMixin):
         """
         self.mktmp("import sys\n"
                    "print('numpy' in sys.modules)\n"
-                   "print('IPython.parallel' in sys.modules)\n"
-                   "print('IPython.kernel.zmq' in sys.modules)\n"
+                   "print('ipython_parallel' in sys.modules)\n"
+                   "print('ipython_kernel' in sys.modules)\n"
                    )
         out = "False\nFalse\nFalse\n"
         tt.ipexec_validate(self.fname, out)

--- a/IPython/extensions/storemagic.py
+++ b/IPython/extensions/storemagic.py
@@ -28,7 +28,7 @@ import inspect, os, sys, textwrap
 # Our own
 from IPython.core.error import UsageError
 from IPython.core.magic import Magics, magics_class, line_magic
-from IPython.utils.traitlets import Bool
+from traitlets import Bool
 from IPython.utils.py3compat import string_types
 
 #-----------------------------------------------------------------------------

--- a/IPython/extensions/tests/test_storemagic.py
+++ b/IPython/extensions/tests/test_storemagic.py
@@ -1,6 +1,6 @@
 import tempfile, os
 
-from IPython.config.loader import Config
+from traitlets.config.loader import Config
 import nose.tools as nt
 
 ip = get_ipython()

--- a/IPython/external/mathjax.py
+++ b/IPython/external/mathjax.py
@@ -60,7 +60,7 @@ import sys
 import tarfile
 import zipfile
 
-from IPython.utils.path import get_ipython_dir
+from IPython.paths import get_ipython_dir
 
 try:
     from urllib.request import urlopen # Py 3

--- a/IPython/lib/kernel.py
+++ b/IPython/lib/kernel.py
@@ -8,5 +8,5 @@ warnings.warn("IPython.lib.kernel moved to IPython.kernel.connect in IPython 1.0
     DeprecationWarning
 )
 
-from IPython.kernel.connect import *
+from ipython_kernel.connect import *
 

--- a/IPython/lib/latextools.py
+++ b/IPython/lib/latextools.py
@@ -12,9 +12,9 @@ import shutil
 import subprocess
 
 from IPython.utils.process import find_cmd, FindCmdError
-from IPython.config import get_config
-from IPython.config.configurable import SingletonConfigurable
-from IPython.utils.traitlets import List, Bool, Unicode
+from traitlets.config import get_config
+from traitlets.config.configurable import SingletonConfigurable
+from traitlets import List, Bool, Unicode
 from IPython.utils.py3compat import cast_unicode, cast_unicode_py2 as u
 
 

--- a/IPython/terminal/embed.py
+++ b/IPython/terminal/embed.py
@@ -18,7 +18,7 @@ from IPython.core.interactiveshell import InteractiveShell
 from IPython.terminal.interactiveshell import TerminalInteractiveShell
 from IPython.terminal.ipapp import load_default_config
 
-from IPython.utils.traitlets import Bool, CBool, Unicode
+from traitlets import Bool, CBool, Unicode
 from IPython.utils.io import ask_yes_no
 
 

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -31,7 +31,7 @@ from IPython.utils.terminal import toggle_set_term_title, set_term_title
 from IPython.utils.process import abbrev_cwd
 from IPython.utils.warn import warn, error
 from IPython.utils.text import num_ini_spaces, SList, strip_email_quotes
-from IPython.utils.traitlets import Integer, CBool, Unicode
+from traitlets import Integer, CBool, Unicode
 
 #-----------------------------------------------------------------------------
 # Utilities

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -15,8 +15,8 @@ import logging
 import os
 import sys
 
-from IPython.config.loader import Config
-from IPython.config.application import boolean_flag, catch_config_error, Application
+from traitlets.config.loader import Config
+from traitlets.config.application import boolean_flag, catch_config_error, Application
 from IPython.core import release
 from IPython.core import usage
 from IPython.core.completer import IPCompleter
@@ -34,8 +34,8 @@ from IPython.core.shellapp import (
 from IPython.extensions.storemagic import StoreMagics
 from IPython.terminal.interactiveshell import TerminalInteractiveShell
 from IPython.utils import warn
-from IPython.utils.path import get_ipython_dir
-from IPython.utils.traitlets import (
+from IPython.paths import get_ipython_dir
+from traitlets import (
     Bool, List, Dict,
 )
 
@@ -207,20 +207,20 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
         ]
 
     subcommands = dict(
-        qtconsole=('IPython.qt.console.qtconsoleapp.IPythonQtConsoleApp',
-            """Launch the IPython Qt Console."""
+        qtconsole=('jupyter_qtconsole.console.qtconsoleapp.IPythonQtConsoleApp',
+            """DEPRECATD: Launch the Jupyter Qt Console."""
         ),
-        notebook=('IPython.html.notebookapp.NotebookApp',
-            """Launch the IPython HTML Notebook Server."""
+        notebook=('jupyter_notebook.notebookapp.NotebookApp',
+            """DEPRECATED: Launch the IPython HTML Notebook Server."""
         ),
         profile = ("IPython.core.profileapp.ProfileApp",
             "Create and manage IPython profiles."
         ),
-        kernel = ("IPython.kernel.zmq.kernelapp.IPKernelApp",
+        kernel = ("ipython_kernel.kernelapp.IPKernelApp",
             "Start a kernel without an attached frontend."
         ),
-        console=('IPython.terminal.console.app.ZMQTerminalIPythonApp',
-            """Launch the IPython terminal-based Console."""
+        console=('jupyter_console.app.ZMQTerminalIPythonApp',
+            """DEPRECATED: Launch the Jupyter terminal-based Console."""
         ),
         locate=('IPython.terminal.ipapp.LocateIPythonApp',
             LocateIPythonApp.description
@@ -228,19 +228,19 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
         history=('IPython.core.historyapp.HistoryApp',
             "Manage the IPython history database."
         ),
-        nbconvert=('IPython.nbconvert.nbconvertapp.NbConvertApp',
-            "Convert notebooks to/from other formats."
+        nbconvert=('jupyter_nbconvert.nbconvertapp.NbConvertApp',
+            "DEPRECATED: Convert notebooks to/from other formats."
         ),
-        trust=('IPython.nbformat.sign.TrustNotebookApp',
-            "Sign notebooks to trust their potentially unsafe contents at load."
+        trust=('jupyter_nbformat.sign.TrustNotebookApp',
+            "DEPRECATED: Sign notebooks to trust their potentially unsafe contents at load."
         ),
-        kernelspec=('IPython.kernel.kernelspecapp.KernelSpecApp',
-            "Manage IPython kernel specifications."
+        kernelspec=('jupyter_client.kernelspecapp.KernelSpecApp',
+            "DEPRECATED: Manage Jupyter kernel specifications."
         ),
     )
     subcommands['install-nbextension'] = (
-        "IPython.html.nbextensions.NBExtensionApp",
-        "Install IPython notebook extension files"
+        "jupyter_notebook.nbextensions.NBExtensionApp",
+        "DEPRECATED: Install Jupyter notebook extension files"
     )
 
     # *do* autocreate requested profile, but don't create the config file.

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -209,7 +209,7 @@ test_group_names.append('autoreload')
 #-----------------------------------------------------------------------------
 
 def check_exclusions_exist():
-    from IPython.utils.path import get_ipython_package_dir
+    from IPython.paths import get_ipython_package_dir
     from IPython.utils.warn import warn
     parent = os.path.dirname(get_ipython_package_dir())
     for sec in test_sections:

--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -165,16 +165,6 @@ class PyTestController(TestController):
         ipydir = TemporaryDirectory()
         self.dirs.append(ipydir)
         self.env['IPYTHONDIR'] = ipydir.name
-        # FIXME: install IPython kernel in temporary IPython dir
-        # remove after big split
-        try:
-            from jupyter_client.kernelspec import KernelSpecManager
-        except ImportError:
-            pass
-        else:
-            ksm = KernelSpecManager(ipython_dir=ipydir.name)
-            ksm.install_native_kernel_spec(user=True)
-        
         self.workingdir = workingdir = TemporaryDirectory()
         self.dirs.append(workingdir)
         self.env['IPTEST_WORKING_DIR'] = workingdir.name

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -36,7 +36,7 @@ try:
 except ImportError:
     has_nose = False
 
-from IPython.config.loader import Config
+from traitlets.config.loader import Config
 from IPython.utils.process import get_output_error_code
 from IPython.utils.text import list_strings
 from IPython.utils.io import temp_pyfile, Tee

--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -213,9 +213,9 @@ def temp_pyfile(src, ext='.py'):
     return fname, f
 
 def atomic_writing(*args, **kwargs):
-    """DEPRECATED: moved to IPython.html.services.contents.fileio"""
-    warn("IPython.utils.io.atomic_writing has moved to IPython.html.services.contents.fileio")
-    from IPython.html.services.contents.fileio import atomic_writing
+    """DEPRECATED: moved to jupyter_notebook.services.contents.fileio"""
+    warn("IPython.utils.io.atomic_writing has moved to jupyter_notebook.services.contents.fileio")
+    from jupyter_notebook.services.contents.fileio import atomic_writing
     return atomic_writing(*args, **kwargs)
 
 def raw_print(*args, **kw):

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -25,6 +25,7 @@ import nose.tools as nt
 from nose import with_setup
 
 import IPython
+from IPython import paths
 from IPython.testing import decorators as dec
 from IPython.testing.decorators import (skip_if_not_win32, skip_win32,
                                         onlyif_unicode_paths,)
@@ -253,7 +254,7 @@ def test_filefind():
     """Various tests for filefind"""
     f = tempfile.NamedTemporaryFile()
     # print 'fname:',f.name
-    alt_dirs = path.get_ipython_dir()
+    alt_dirs = paths.get_ipython_dir()
     t = path.filefind(f.name, alt_dirs)
     # print 'found:',t
 
@@ -298,7 +299,7 @@ def test_not_writable_ipdir():
         # assume I'm root and skip the test
         raise SkipTest("I can't create directories that I can't write to")
     with AssertPrints('is not a writable location', channel='stderr'):
-        ipdir = path.get_ipython_dir()
+        ipdir = paths.get_ipython_dir()
     env.pop('IPYTHON_DIR', None)
 
 def test_unquote_filename():

--- a/docs/source/config/intro.rst
+++ b/docs/source/config/intro.rst
@@ -37,7 +37,7 @@ no error.
 
 To add to a collection which may have already been defined elsewhere,
 you can use methods like those found on lists, dicts and sets: append,
-extend, :meth:`~IPython.config.loader.LazyConfigValue.prepend` (like
+extend, :meth:`~traitlets.config.loader.LazyConfigValue.prepend` (like
 extend, but at the front), add and update (which works both for dicts
 and sets)::
 

--- a/docs/source/development/config.rst
+++ b/docs/source/development/config.rst
@@ -12,7 +12,7 @@ The main concepts
 There are a number of abstractions that the IPython configuration system uses.
 Each of these abstractions is represented by a Python class.
 
-Configuration object: :class:`~IPython.config.loader.Config`
+Configuration object: :class:`~traitlets.config.loader.Config`
     A configuration object is a simple dictionary-like class that holds
     configuration attributes and sub-configuration objects. These classes
     support dotted attribute style access (``cfg.Foo.bar``) in addition to the
@@ -20,7 +20,7 @@ Configuration object: :class:`~IPython.config.loader.Config`
     The Config object is a wrapper around a simple dictionary with some convenience methods,
     such as merging and automatic section creation.
 
-Application: :class:`~IPython.config.application.Application`
+Application: :class:`~traitlets.config.application.Application`
     An application is a process that does a specific job. The most obvious
     application is the :command:`ipython` command line program. Each
     application reads *one or more* configuration files and a single set of
@@ -34,30 +34,30 @@ Application: :class:`~IPython.config.application.Application`
     Applications always have a `log` attribute that is a configured Logger.
     This allows centralized logging configuration per-application.
 
-Configurable: :class:`~IPython.config.configurable.Configurable`
+Configurable: :class:`~traitlets.config.configurable.Configurable`
     A configurable is a regular Python class that serves as a base class for
     all main classes in an application. The
-    :class:`~IPython.config.configurable.Configurable` base class is
+    :class:`~traitlets.config.configurable.Configurable` base class is
     lightweight and only does one things.
 
-    This :class:`~IPython.config.configurable.Configurable` is a subclass
-    of :class:`~IPython.utils.traitlets.HasTraits` that knows how to configure
+    This :class:`~traitlets.config.configurable.Configurable` is a subclass
+    of :class:`~traitlets.HasTraits` that knows how to configure
     itself. Class level traits with the metadata ``config=True`` become
     values that can be configured from the command line and configuration
     files.
     
-    Developers create :class:`~IPython.config.configurable.Configurable`
+    Developers create :class:`~traitlets.config.configurable.Configurable`
     subclasses that implement all of the logic in the application. Each of
     these subclasses has its own configuration information that controls how
     instances are created.
 
-Singletons: :class:`~IPython.config.configurable.SingletonConfigurable`
+Singletons: :class:`~traitlets.config.configurable.SingletonConfigurable`
     Any object for which there is a single canonical instance. These are
     just like Configurables, except they have a class method 
-    :meth:`~IPython.config.configurable.SingletonConfigurable.instance`,
+    :meth:`~traitlets.config.configurable.SingletonConfigurable.instance`,
     that returns the current active instance (or creates one if it
     does not exist).  Examples of singletons include
-    :class:`~IPython.config.application.Application`s and
+    :class:`~traitlets.config.application.Application`s and
     :class:`~IPython.core.interactiveshell.InteractiveShell`.  This lets
     objects easily connect to the current running Application without passing
     objects around everywhere.  For instance, to get the current running 
@@ -100,7 +100,7 @@ Python configuration Files
 --------------------------
 
 A Python configuration file is a pure Python file that populates a configuration object.
-This configuration object is a :class:`~IPython.config.loader.Config` instance.
+This configuration object is a :class:`~traitlets.config.loader.Config` instance.
 While in a configuration file, to get a reference to this object, simply call the :func:`get_config`
 function, which is available in the global namespace of the script.
 
@@ -116,13 +116,13 @@ attributes on it.  All you have to know is:
 * The type of each attribute.
 
 The answers to these questions are provided by the various
-:class:`~IPython.config.configurable.Configurable` subclasses that an
+:class:`~traitlets.config.configurable.Configurable` subclasses that an
 application uses. Let's look at how this would work for a simple configurable
 subclass::
 
     # Sample configurable:
-    from IPython.config.configurable import Configurable
-    from IPython.utils.traitlets import Int, Float, Unicode, Bool
+    from traitlets.config.configurable import Configurable
+    from traitlets import Int, Float, Unicode, Bool
     
     class MyClass(Configurable):
         name = Unicode(u'defaultname', config=True)
@@ -145,16 +145,16 @@ to configure this class in a configuration file::
 After this configuration file is loaded, the values set in it will override
 the class defaults anytime a :class:`MyClass` is created.  Furthermore,
 these attributes will be type checked and validated anytime they are set.
-This type checking is handled by the :mod:`IPython.utils.traitlets` module,
+This type checking is handled by the :mod:`traitlets` module,
 which provides the :class:`Unicode`, :class:`Int` and :class:`Float` types.
-In addition to these traitlets, the :mod:`IPython.utils.traitlets` provides
+In addition to these traitlets, the :mod:`traitlets` provides
 traitlets for a number of other types.
 
 .. note::
 
     Underneath the hood, the :class:`Configurable` base class is a subclass of
-    :class:`IPython.utils.traitlets.HasTraits`. The
-    :mod:`IPython.utils.traitlets` module is a lightweight version of
+    :class:`traitlets.HasTraits`. The
+    :mod:`traitlets` module is a lightweight version of
     :mod:`enthought.traits`. Our implementation is a pure Python subset
     (mostly API compatible) of :mod:`enthought.traits` that does not have any
     of the automatic GUI generation capabilities. Our plan is to achieve 100%
@@ -172,17 +172,17 @@ Here, ``ClassName`` is the name of the class whose configuration attribute you
 want to set, ``attribute_name`` is the name of the attribute you want to set
 and ``attribute_value`` the the value you want it to have. The ``ClassName``
 attribute of ``c`` is not the actual class, but instead is another
-:class:`~IPython.config.loader.Config` instance.
+:class:`~traitlets.config.loader.Config` instance.
 
 .. note::
 
     The careful reader may wonder how the ``ClassName`` (``MyClass`` in
     the above example) attribute of the configuration object ``c`` gets
     created. These attributes are created on the fly by the
-    :class:`~IPython.config.loader.Config` instance, using a simple naming
-    convention. Any attribute of a :class:`~IPython.config.loader.Config`
+    :class:`~traitlets.config.loader.Config` instance, using a simple naming
+    convention. Any attribute of a :class:`~traitlets.config.loader.Config`
     instance whose name begins with an uppercase character is assumed to be a
-    sub-configuration and a new empty :class:`~IPython.config.loader.Config`
+    sub-configuration and a new empty :class:`~traitlets.config.loader.Config`
     instance is dynamically created for that attribute. This allows deeply
     hierarchical information created easily (``c.Foo.Bar.value``) on the fly.
 
@@ -190,7 +190,7 @@ JSON configuration Files
 ------------------------
 
 A JSON configuration file is simply a file that contains a
-:class:`~IPython.config.loader.Config` dictionary serialized to JSON.
+:class:`~traitlets.config.loader.Config` dictionary serialized to JSON.
 A JSON configuration file has the same base name as a Python configuration file,
 but with a .json extension.
 
@@ -261,8 +261,8 @@ There is another aspect of configuration where inheritance comes into play.
 Sometimes, your classes will have an inheritance hierarchy that you want
 to be reflected in the configuration system.  Here is a simple example::
 
-    from IPython.config.configurable import Configurable
-    from IPython.utils.traitlets import Int, Float, Unicode, Bool
+    from traitlets.config.configurable import Configurable
+    from traitlets import Int, Float, Unicode, Bool
     
     class Foo(Configurable):
         name = Unicode(u'fooname', config=True)
@@ -438,7 +438,7 @@ with a given Application.  Configuring IPython from the command-line may look
 very similar to an IPython config file
 
 IPython applications use a parser called
-:class:`~IPython.config.loader.KeyValueLoader` to load values into a Config
+:class:`~traitlets.config.loader.KeyValueLoader` to load values into a Config
 object.  Values are assigned in much the same way as in a config file:
 
 .. code-block:: bash

--- a/docs/source/development/pycompat.rst
+++ b/docs/source/development/pycompat.rst
@@ -184,7 +184,7 @@ not work with this. Instead, we do this::
         ...
 
 This gives the new class a metaclass of :class:`~IPython.qt.util.MetaQObjectHasTraits`,
-and the parent classes :class:`~IPython.utils.traitlets.HasTraits` and
+and the parent classes :class:`~traitlets.HasTraits` and
 :class:`~IPython.qt.util.SuperQObject`.
 
 

--- a/docs/source/whatsnew/version0.11.rst
+++ b/docs/source/whatsnew/version0.11.rst
@@ -268,11 +268,11 @@ As of this release, a signifiant portion of IPython has been refactored.  This
 refactoring is founded on a number of new abstractions.  The main new classes
 that implement these abstractions are:
 
-* :class:`IPython.utils.traitlets.HasTraits`.
-* :class:`IPython.config.configurable.Configurable`.
-* :class:`IPython.config.application.Application`.
-* :class:`IPython.config.loader.ConfigLoader`.
-* :class:`IPython.config.loader.Config`
+* :class:`traitlets.HasTraits`.
+* :class:`traitlets.config.configurable.Configurable`.
+* :class:`traitlets.config.application.Application`.
+* :class:`traitlets.config.loader.ConfigLoader`.
+* :class:`traitlets.config.loader.Config`
 
 We are still in the process of writing developer focused documentation about
 these classes, but for now our :ref:`configuration documentation
@@ -383,7 +383,7 @@ Additional new features
 
 .. sourcecode:: python
 
-    from IPython.config.application import Application
+    from traitlets.config.application import Application
     logger = Application.instance().log
 
 * You can now get help on an object halfway through typing a command. For
@@ -403,7 +403,7 @@ Additional new features
   configuration system :ref:`documentation <config_index>` for more details.
 
 * The :class:`~IPython.core.interactiveshell.InteractiveShell` class is now a
-  :class:`~IPython.config.configurable.Configurable` subclass and has traitlets
+  :class:`~traitlets.config.configurable.Configurable` subclass and has traitlets
   that determine the defaults and runtime environment. The ``__init__`` method
   has also been refactored so this class can be instantiated and run without
   the old :mod:`ipmaker` module.
@@ -426,7 +426,7 @@ Additional new features
   strings like ``foo.bar.Bar`` to the actual class.
 
 * Completely refactored the :mod:`IPython.core.prefilter` module into
-  :class:`~IPython.config.configurable.Configurable` subclasses. Added a new
+  :class:`~traitlets.config.configurable.Configurable` subclasses. Added a new
   layer into the prefilter system, called "transformations" that all new
   prefilter logic should use (rather than the older "checker/handler"
   approach).
@@ -439,22 +439,22 @@ Additional new features
   instance and call it. In later calls, it just calls the previously created
   :class:`~IPython.frontend.terminal.embed.InteractiveShellEmbed`.
 
-* Created a configuration system (:mod:`IPython.config.configurable`) that is
-  based on :mod:`IPython.utils.traitlets`. Configurables are arranged into a
+* Created a configuration system (:mod:`traitlets.config.configurable`) that is
+  based on :mod:`traitlets`. Configurables are arranged into a
   runtime containment tree (not inheritance) that i) automatically propagates
   configuration information and ii) allows singletons to discover each other in
   a loosely coupled manner. In the future all parts of IPython will be
-  subclasses of :class:`~IPython.config.configurable.Configurable`. All IPython
+  subclasses of :class:`~traitlets.config.configurable.Configurable`. All IPython
   developers should become familiar with the config system.
 
-* Created a new :class:`~IPython.config.loader.Config` for holding
+* Created a new :class:`~traitlets.config.loader.Config` for holding
   configuration information. This is a dict like class with a few extras: i)
   it supports attribute style access, ii) it has a merge function that merges
-  two :class:`~IPython.config.loader.Config` instances recursively and iii) it
-  will automatically create sub-:class:`~IPython.config.loader.Config`
+  two :class:`~traitlets.config.loader.Config` instances recursively and iii) it
+  will automatically create sub-:class:`~traitlets.config.loader.Config`
   instances for attributes that start with an uppercase character.
 
-* Created new configuration loaders in :mod:`IPython.config.loader`. These
+* Created new configuration loaders in :mod:`traitlets.config.loader`. These
   loaders provide a unified loading interface for all configuration
   information including command line arguments and configuration files. We
   have two default implementations based on :mod:`argparse` and plain python
@@ -474,12 +474,12 @@ Additional new features
   as strings, like ``foo.bar.Bar``. This is needed for forward declarations.
   But, this was implemented in a careful way so that string to class
   resolution is done at a single point, when the parent
-  :class:`~IPython.utils.traitlets.HasTraitlets` is instantiated.
+  :class:`~traitlets.HasTraitlets` is instantiated.
 
 * :mod:`IPython.utils.ipstruct` has been refactored to be a subclass of 
   dict.  It also now has full docstrings and doctests.
 
-* Created a Traits like implementation in :mod:`IPython.utils.traitlets`.  This
+* Created a Traits like implementation in :mod:`traitlets`.  This
   is a pure Python, lightweight version of a library that is similar to
   Enthought's Traits project, but has no dependencies on Enthought's code.  We
   are using this for validation, defaults and notification in our new component
@@ -511,7 +511,7 @@ Backwards incompatible changes
   ``ipython profile create <name>``.
 
 * All IPython applications have been rewritten to use
-  :class:`~IPython.config.loader.KeyValueConfigLoader`. This means that
+  :class:`~traitlets.config.loader.KeyValueConfigLoader`. This means that
   command-line options have changed. Now, all configurable values are accessible
   from the command-line with the same syntax as in a configuration file.
 

--- a/docs/source/whatsnew/version0.13.rst
+++ b/docs/source/whatsnew/version0.13.rst
@@ -517,7 +517,7 @@ Official Public API
 We have begun organizing our API for easier public use, with an eye towards an
 official IPython 1.0 release which will firmly maintain this API compatible for
 its entire lifecycle.  There is now an :mod:`IPython.display` module that
-aggregates all display routines, and the :mod:`IPython.config` namespace has
+aggregates all display routines, and the :mod:`traitlets.config` namespace has
 all public configuration tools.  We will continue improving our public API
 layout so that users only need to import names one level deeper than the main
 ``IPython`` package to access all public namespaces.

--- a/docs/source/whatsnew/version0.9.rst
+++ b/docs/source/whatsnew/version0.9.rst
@@ -78,7 +78,7 @@ New features
 
 * All of the parallel computing capabilities from `ipython1-dev` have been
   merged into IPython proper.  This resulted in the following new subpackages:
-  :mod:`IPython.kernel`, :mod:`IPython.kernel.core`, :mod:`IPython.config`,
+  :mod:`IPython.kernel`, :mod:`IPython.kernel.core`, :mod:`traitlets.config`,
   :mod:`IPython.tools` and :mod:`IPython.testing`.
 
 * As part of merging in the `ipython1-dev` stuff, the `setup.py` script and

--- a/examples/Embedding/embed_class_long.py
+++ b/examples/Embedding/embed_class_long.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 
 # Try running this code both at the command line and from inside IPython (with
 # %run example-embed.py)
-from IPython.config.loader import Config
+from traitlets.config.loader import Config
 try:
     get_ipython
 except NameError:

--- a/examples/Interactive Widgets/Custom Widget - Hello World.ipynb
+++ b/examples/Interactive Widgets/Custom Widget - Hello World.ipynb
@@ -110,7 +110,7 @@
    "outputs": [],
    "source": [
     "from IPython.html import widgets\n",
-    "from IPython.utils.traitlets import Unicode\n",
+    "from traitlets import Unicode\n",
     "\n",
     "class HelloWidget(widgets.DOMWidget):\n",
     "    _view_name = Unicode('HelloView', sync=True)"
@@ -570,7 +570,7 @@
    },
    "outputs": [],
    "source": [
-    "from IPython.utils.traitlets import CInt\n",
+    "from traitlets import CInt\n",
     "class SpinnerWidget(widgets.DOMWidget):\n",
     "    _view_name = Unicode('SpinnerView', sync=True)\n",
     "    value = CInt(0, sync=True)"
@@ -757,7 +757,7 @@
     "w2 = widgets.IntSlider()\n",
     "display(w1,w2)\n",
     "\n",
-    "from IPython.utils.traitlets import link\n",
+    "from traitlets import link\n",
     "mylink = link((w1, 'value'), (w2, 'value'))"
    ]
   },

--- a/examples/Interactive Widgets/Date Picker Widget.ipynb
+++ b/examples/Interactive Widgets/Date Picker Widget.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "from IPython.html import widgets # Widget definitions\n",
     "from IPython.display import display # Used to display widgets in the notebook\n",
-    "from IPython.utils.traitlets import Unicode # Used to declare attributes of our widget"
+    "from traitlets import Unicode # Used to declare attributes of our widget"
    ]
   },
   {

--- a/examples/Interactive Widgets/Export As (nbconvert).html
+++ b/examples/Interactive Widgets/Export As (nbconvert).html
@@ -11567,7 +11567,7 @@ div#notebook {
 <div class=" highlight hl-ipython3"><pre><span class="c"># Widget related imports</span>
 <span class="kn">from</span> <span class="nn">IPython.html</span> <span class="k">import</span> <span class="n">widgets</span>
 <span class="kn">from</span> <span class="nn">IPython.display</span> <span class="k">import</span> <span class="n">display</span><span class="p">,</span> <span class="n">clear_output</span><span class="p">,</span> <span class="n">Javascript</span>
-<span class="kn">from</span> <span class="nn">IPython.utils.traitlets</span> <span class="k">import</span> <span class="n">Unicode</span>
+<span class="kn">from</span> <span class="nn">traitlets</span> <span class="k">import</span> <span class="n">Unicode</span>
 
 <span class="c"># nbconvert related imports</span>
 <span class="kn">from</span> <span class="nn">IPython.nbconvert</span> <span class="k">import</span> <span class="n">get_export_names</span><span class="p">,</span> <span class="n">export_by_name</span>

--- a/examples/Interactive Widgets/Export As (nbconvert).ipynb
+++ b/examples/Interactive Widgets/Export As (nbconvert).ipynb
@@ -11,7 +11,7 @@
     "# Widget related imports\n",
     "from IPython.html import widgets\n",
     "from IPython.display import display, clear_output, Javascript\n",
-    "from IPython.utils.traitlets import Unicode\n",
+    "from traitlets import Unicode\n",
     "\n",
     "# nbconvert related imports\n",
     "from IPython.nbconvert import get_export_names, export_by_name\n",

--- a/examples/Interactive Widgets/File Upload Widget.ipynb
+++ b/examples/Interactive Widgets/File Upload Widget.ipynb
@@ -11,7 +11,7 @@
     "import base64\n",
     "from __future__ import print_function # py 2.7 compat.\n",
     "from IPython.html import widgets # Widget definitions.\n",
-    "from IPython.utils.traitlets import Unicode # Traitlet needed to add synced attributes to the widget."
+    "from traitlets import Unicode # Traitlet needed to add synced attributes to the widget."
    ]
   },
   {

--- a/examples/Interactive Widgets/Widget Basics.ipynb
+++ b/examples/Interactive Widgets/Widget Basics.ipynb
@@ -374,7 +374,7 @@
    },
    "outputs": [],
    "source": [
-    "from IPython.utils.traitlets import link\n",
+    "from traitlets import link\n",
     "a = FloatText()\n",
     "b = FloatSlider()\n",
     "c = FloatProgress()\n",

--- a/examples/Notebook/JavaScript Notebook Extensions.ipynb
+++ b/examples/Notebook/JavaScript Notebook Extensions.ipynb
@@ -297,8 +297,8 @@
     "I like my cython to be nicely highlighted\n",
     "\n",
     "```javascript\n",
-    "IPython.config.cell_magic_highlight['magic_text/x-cython'] = {}\n",
-    "IPython.config.cell_magic_highlight['magic_text/x-cython'].reg = [/^%%cython/]\n",
+    "traitlets.config.cell_magic_highlight['magic_text/x-cython'] = {}\n",
+    "traitlets.config.cell_magic_highlight['magic_text/x-cython'].reg = [/^%%cython/]\n",
     "```\n",
     "\n",
     "`text/x-cython` is the name of CodeMirror mode name, `magic_` prefix will just patch the mode so that the first line that contains a magic does not screw up the highlighting. `reg`is a list or regular expression that will trigger the change of mode."

--- a/examples/Notebook/Using nbconvert as a Library.ipynb
+++ b/examples/Notebook/Using nbconvert as a Library.ipynb
@@ -114,7 +114,7 @@
    },
    "outputs": [],
    "source": [
-    "from IPython.config import Config\n",
+    "from traitlets.config import Config\n",
     "from IPython.nbconvert import HTMLExporter\n",
     "\n",
     "# The `basic` template is used here.\n",
@@ -359,7 +359,7 @@
    },
    "outputs": [],
    "source": [
-    "from IPython.config import Config\n",
+    "from traitlets.config import Config\n",
     "\n",
     "c =  Config({\n",
     "            'ExtractOutputPreprocessor':{'enabled':True}\n",
@@ -409,7 +409,7 @@
    "outputs": [],
    "source": [
     "from IPython.nbconvert.preprocessors import Preprocessor\n",
-    "import IPython.config\n",
+    "import traitlets.config\n",
     "print(\"Four relevant docstring\")\n",
     "print('=============================')\n",
     "print(Preprocessor.__doc__)\n",
@@ -444,7 +444,7 @@
    },
    "outputs": [],
    "source": [
-    "from IPython.utils.traitlets import Integer"
+    "from traitlets import Integer"
    ]
   },
   {


### PR DESCRIPTION
Stop using shimmed, deprecated paths.

This should eliminate the shim warnings in IPython itself.
