### PR TITLE
makes dictionary key completion use same delimiters as splitter

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -416,7 +416,7 @@ def get__all__entries(obj):
     return [w for w in words if isinstance(w, string_types)]
 
 
-def match_dict_keys(keys, prefix):
+def match_dict_keys(keys, prefix, delims):
     """Used by dict_key_matches, matching the prefix to a list of keys"""
     if not prefix:
         return None, 0, [repr(k) for k in keys
@@ -427,8 +427,9 @@ def match_dict_keys(keys, prefix):
         prefix_str = eval(prefix + quote, {})
     except Exception:
         return None, 0, []
-    
-    token_match = re.search(r'\w*$', prefix, re.UNICODE)
+
+    pattern = '[^' + ''.join('\\' + c for c in delims) + ']*$'
+    token_match = re.search(pattern, prefix, re.UNICODE)
     token_start = token_match.start()
     token_prefix = token_match.group()
 
@@ -913,7 +914,7 @@ class IPCompleter(Completer):
         keys = get_keys(obj)
         if not keys:
             return keys
-        closing_quote, token_offset, matches = match_dict_keys(keys, prefix)
+        closing_quote, token_offset, matches = match_dict_keys(keys, prefix, self.splitter.delims)
         if not matches:
             return matches
         

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -490,6 +490,11 @@ def test_dict_key_completion_string():
     _, matches = complete(line_buffer="d[\"a'")
     nt.assert_in("b", matches)
 
+    # need to not split at delims that readline won't split at
+    if '-' not in ip.Completer.splitter.delims:
+        ip.user_ns['d'] = {'before-after': None}
+        _, matches = complete(line_buffer="d['before-af")
+        nt.assert_in('before-after', matches)
 
 def test_dict_key_completion_contexts():
     """Test expression contexts in which dict key completion occurs"""


### PR DESCRIPTION
If a dictionary key contains a `-`, `~`, or `/`, trying to tab-complete from a partially typed key that has made it past the problem character will replace the entire key with just the part after the problem character. This happens because these characters are by default removed from readline's delimiters but not from the relevant regexp pattern in `match_dict_keys`. This fixes this behavior by making `match_dict_keys` take its set of delimiters from the relevant `CompletionSplitter` and adds a test. 
