### PR TITLE
imp module deprecated in 3.4

### DIFF
--- a/IPython/core/extensions.py
+++ b/IPython/core/extensions.py
@@ -13,7 +13,11 @@ from IPython.utils.path import ensure_dir_exists
 from traitlets import Instance
 from IPython.utils.py3compat import PY3
 if PY3:
-    from imp import reload
+    try: 
+        from importlib import reload
+    except ImportError :
+        ## deprecated since 3.4
+        from imp import reload
 
 #-----------------------------------------------------------------------------
 # Main class

--- a/IPython/core/extensions.py
+++ b/IPython/core/extensions.py
@@ -11,13 +11,12 @@ import sys
 from traitlets.config.configurable import Configurable
 from IPython.utils.path import ensure_dir_exists
 from traitlets import Instance
-from IPython.utils.py3compat import PY3
-if PY3:
-    try: 
-        from importlib import reload
-    except ImportError :
-        ## deprecated since 3.4
-        from imp import reload
+
+try:
+    from importlib import reload
+except ImportError :
+    ## deprecated since 3.4
+    from imp import reload
 
 #-----------------------------------------------------------------------------
 # Main class

--- a/IPython/utils/openpy.py
+++ b/IPython/utils/openpy.py
@@ -228,7 +228,11 @@ def _list_readline(x):
 # Code for going between .py files and cached .pyc files ----------------------
 
 try:    # Python 3.2, see PEP 3147
-    from imp import source_from_cache, cache_from_source
+    try: 
+        from importlib.util import source_from_cache, cache_from_source
+    except ImportError :
+        ## deprecated since 3.4
+        from imp import source_from_cache, cache_from_source
 except ImportError:
     # Python <= 3.1: .pyc files go next to .py
     def source_from_cache(path):


### PR DESCRIPTION
We still use imp.find_module,(in IPython/utils/module_paths.py)  but
this as no newer drop-in replacement as far as I understand.

Some alternative suggested here:

https://docs.python.org/3/library/importlib.html#importlib.abc.Finder

Deprecated since version 3.3: Use MetaPathFinder or PathEntryFinder
instead.

The various error messages are not clear of the exact version where
this is deprecated.

---

Turned warning into errors to find some extra bad import of IPython.nbformat and found that.
