### PR TITLE
remove external notebook apps

### DIFF
--- a/IPython/core/profileapp.py
+++ b/IPython/core/profileapp.py
@@ -264,8 +264,6 @@ class ProfileCreate(BaseIPythonApplication):
             'IPython.kernel.zmq.kernelapp.IPKernelApp',
             'IPython.terminal.console.app.ZMQTerminalIPythonApp',
             'IPython.qt.console.qtconsoleapp.IPythonQtConsoleApp',
-            'IPython.html.notebookapp.NotebookApp',
-            'IPython.nbconvert.nbconvertapp.NbConvertApp',
         ):
             app = self._import_app(app_path)
             if app is not None:


### PR DESCRIPTION
Running `ipython profile create` generated this traceback:

``` shell
Traceback (most recent call last):
  File "bin/ipython", line 9, in <module>
    load_entry_point('ipython==4.0.0.dev0', 'console_scripts', 'ipython')()
  File "src/ipython/IPython/__init__.py", line 120, in start_ipython
    return launch_new_instance(argv=argv, **kwargs)
  File "src/traitlets/traitlets/config/application.py", line 574, in launch_instance
    app.initialize(argv)
  File "<string>", line 2, in initialize
  File "src/traitlets/traitlets/config/application.py", line 75, in catch_config_error
    return method(app, *args, **kwargs)
  File "src/ipython/IPython/terminal/ipapp.py", line 302, in initialize
    super(TerminalIPythonApp, self).initialize(argv)
  File "<string>", line 2, in initialize
  File "src/traitlets/traitlets/config/application.py", line 75, in catch_config_error
    return method(app, *args, **kwargs)
  File "src/ipython/IPython/core/application.py", line 385, in initialize
    self.parse_command_line(argv)
  File "src/ipython/IPython/terminal/ipapp.py", line 297, in parse_command_line
    return super(TerminalIPythonApp, self).parse_command_line(argv)
  File "<string>", line 2, in parse_command_line
  File "src/traitlets/traitlets/config/application.py", line 75, in catch_config_error
    return method(app, *args, **kwargs)
  File "src/traitlets/traitlets/config/application.py", line 474, in parse_command_line
    return self.initialize_subcommand(subc, subargv)
  File "<string>", line 2, in initialize_subcommand
  File "src/traitlets/traitlets/config/application.py", line 75, in catch_config_error
    return method(app, *args, **kwargs)
  File "src/traitlets/traitlets/config/application.py", line 412, in initialize_subcommand
    self.subapp.initialize(argv)
  File "<string>", line 2, in initialize
  File "src/traitlets/traitlets/config/application.py", line 75, in catch_config_error
    return method(app, *args, **kwargs)
  File "src/traitlets/traitlets/config/application.py", line 254, in initialize
    self.parse_command_line(argv)
  File "<string>", line 2, in parse_command_line
  File "src/traitlets/traitlets/config/application.py", line 75, in catch_config_error
    return method(app, *args, **kwargs)
  File "src/traitlets/traitlets/config/application.py", line 474, in parse_command_line
    return self.initialize_subcommand(subc, subargv)
  File "<string>", line 2, in initialize_subcommand
  File "src/traitlets/traitlets/config/application.py", line 75, in catch_config_error
    return method(app, *args, **kwargs)
  File "src/traitlets/traitlets/config/application.py", line 412, in initialize_subcommand
    self.subapp.initialize(argv)
  File "<string>", line 2, in initialize
  File "src/traitlets/traitlets/config/application.py", line 75, in catch_config_error
    return method(app, *args, **kwargs)
  File "src/ipython/IPython/core/application.py", line 392, in initialize
    self.init_config_files()
  File "src/ipython/IPython/core/profileapp.py", line 292, in init_config_files
    app.init_config_files()
AttributeError: 'NotebookApp' object has no attribute 'init_config_files'
```

This removes the notebook apps which do not have the `init_config_files` method, since we shouldn't be invoking these classes.
