### PR TITLE
Remove unneeded Pdb.checkline override

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -558,36 +558,3 @@ class Pdb(OldPdb):
         namespaces = [('Locals', self.curframe.f_locals),
                       ('Globals', self.curframe.f_globals)]
         self.shell.find_line_magic('psource')(arg, namespaces=namespaces)
-
-    def checkline(self, filename, lineno):
-        """Check whether specified line seems to be executable.
-
-        Return `lineno` if it is, 0 if not (e.g. a docstring, comment, blank
-        line or EOF). Warning: testing is not comprehensive.
-        """
-        #######################################################################
-        # XXX Hack!  Use python-2.5 compatible code for this call, because with
-        # all of our changes, we've drifted from the pdb api in 2.6.  For now,
-        # changing:
-        #
-        #line = linecache.getline(filename, lineno, self.curframe.f_globals)
-        # to:
-        #
-        line = linecache.getline(filename, lineno)
-        #
-        # does the trick.  But in reality, we need to fix this by reconciling
-        # our updates with the new Pdb APIs in Python 2.6.
-        #
-        # End hack.  The rest of this method is copied verbatim from 2.6 pdb.py
-        #######################################################################
-
-        if not line:
-            print('End of file', file=self.stdout)
-            return 0
-        line = line.strip()
-        # Don't allow setting breakpoint at a blank line
-        if (not line or (line[0] == '#') or
-             (line[:3] == '"""') or line[:3] == "'''"):
-            print('*** Blank or comment', file=self.stdout)
-            return 0
-        return lineno


### PR DESCRIPTION
Removed the Pdb.checkline override since support for Python 2.5/2.6 has been dropped. /cc @takluyver 

Closes #6572
