### PR TITLE
Base64 video master

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -877,7 +877,7 @@ class Video(DisplayObject):
         output = """<video controls>
  <source src="data:{0};base64,{1}" type="{0}">
  Your browser does not support the video tag.
- </video>""".format(mimetype, video_encoded.decode('utf-8'))
+ </video>""".format(mimetype, video_encoded.decode('ASCII'))
         return output
 
     def reload(self):

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -6,6 +6,7 @@
 
 from __future__ import print_function
 
+import base64
 import json
 import mimetypes
 import os
@@ -869,14 +870,14 @@ class Video(DisplayObject):
             mimetype, encoding = mimetypes.guess_type(self.filename)
 
             video = open(self.filename, 'rb').read()
-            video_encoded = video.encode('base64')
+            video_encoded = base64.b64encode(video)
         else:
             video_encoded = self.data
             mimetype = self.mimetype
         output = """<video controls>
  <source src="data:{0};base64,{1}" type="{0}">
  Your browser does not support the video tag.
- </video>""".format(mimetype, video_encoded)
+ </video>""".format(mimetype, video_encoded.decode('utf-8'))
         return output
 
     def reload(self):

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -2,6 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import json
+import tempfile
 import os
 import warnings
 
@@ -149,4 +150,12 @@ def test_json():
         nt.assert_equal(len(w), 1)
         nt.assert_equal(j._repr_json_(), lis)
     
-    
+def test_video_embedding():
+    """use a tempfile, with dummy-data, to ensure that video embedding doesn't crash"""
+    with tempfile.NamedTemporaryFile(suffix='.mp4') as f:
+        with open(f.name,'wb') as f:
+            f.write(b'abc')
+
+        v = display.Video(f.name, embed=True)
+        html = v._repr_html_()
+        nt.assert_in('src="data:video/mp4;base64,YWJj"',html)


### PR DESCRIPTION
Embedding video was broken for python3, just giving a traceback.

It was loading the file's binary as bytes, then trying to ".encode" them to base64. Bytes don't have a ".encode" method. The "base64" module does this bytes-->bytes translation.

This is python2 compatible.

The decode transforms back to text form bytes for the ".format"

This is a copy of PR #8312, +1 test, re-based on master.
