### PR TITLE
use svg+xml

### DIFF
--- a/IPython/nbconvert/templates/markdown.tpl
+++ b/IPython/nbconvert/templates/markdown.tpl
@@ -31,7 +31,7 @@
 {% endblock stream %}
 
 {% block data_svg %}
-![svg]({{ output.svg_filename | path2url }})
+![svg]({{ output.metadata.filenames['image/svg+xml'] | path2url }})
 {% endblock data_svg %}
 
 {% block data_png %}


### PR DESCRIPTION
My `ipynb` contains a `svg` plot.
I got this error when converting `ipynb` to `markdown` via `nbconvert`.

```
  File "/Users/Randy/.pyenv/versions/3.4.3/Python.framework/Versions/3.4/lib/python3.4/site-packages/IPython/nbconvert/exporters/../templates/markdown.tpl", line 34, in <module>
    ![svg]({{ output.svg_filename | path2url }})
  File "/Users/Randy/.pyenv/versions/3.4.3/Python.framework/Versions/3.4/lib/python3.4/site-packages/IPython/nbconvert/filters/strings.py", line 205, in path2url
    parts = path.split(os.path.sep)
jinja2.exceptions.UndefinedError: 'IPython.nbformat.notebooknode.NotebookNode object' has no attribute 'svg_filename'
```

It turns out that it is solved by changing `![svg]({{ output.svg_filename | path2url }})` to `![svg]({{ output.metadata.filenames['image/svg+xml'] | path2url }})`.
