### PR TITLE
Revert Axis transparent

### DIFF
--- a/IPython/kernel/zmq/pylab/config.py
+++ b/IPython/kernel/zmq/pylab/config.py
@@ -54,7 +54,6 @@ class InlineBackend(InlineBackendConfig):
         # play nicely with white background in the Qt and notebook frontend
         'figure.facecolor': (1,1,1,0),
         'figure.edgecolor': (1,1,1,0),
-        'axes.facecolor': (1,1,1,0),
         # 12pt labels get cutoff on 6x4 logplots, so use 10pt.
         'font.size': 10,
         # 72 dpi matches SVG/qtconsole

--- a/docs/source/whatsnew/version3.rst
+++ b/docs/source/whatsnew/version3.rst
@@ -2,6 +2,19 @@
  3.x Series
 ============
 
+
+IPython 3.2
+===========
+
+
+Highlights:
+
+- A security improvement that set the secure attribute to login cookie to prevent them to be sent over http
+- Revert the face color of matplotlib axes in the inline backend to not be transparent.
+
+
+
+
 IPython 3.1
 ===========
 


### PR DESCRIPTION
```
    Revert "Set axis background to transparent in inlinebackend"

    This reverts commit 902c754fcbd0581ea33912e583cd3ccb8bdb9a5b.

    Making axis transparent seem to confuse and annoy lot of people,

    See #7964 (do not fix it, this will be a 4.0 or 5.0 thing),
    the real fix would be to use matplotlib themes.
```

---

See #7964 
this is a PR agains 3.x
