### PR TITLE
disable set_default_headers on TermSocket

### DIFF
--- a/IPython/html/terminal/handlers.py
+++ b/IPython/html/terminal/handlers.py
@@ -17,6 +17,9 @@ class TerminalHandler(IPythonHandler):
                    ws_path="terminals/websocket/%s" % term_name))
 
 class TermSocket(terminado.TermSocket, IPythonHandler):
+    def set_default_headers(self):
+        pass
+    
     def get(self, *args, **kwargs):
         if not self.get_current_user():
             raise web.HTTPError(403)


### PR DESCRIPTION
set_default_headers is inherited from IPythonHandler, but doesn't make sense on websockets, and raises an error if there are any headers to set, e.g.:

```
ipython notebook --NotebookApp.allow_origin='*'
```
