### PR TITLE
shim widgets before shimming html

### DIFF
--- a/IPython/html.py
+++ b/IPython/html.py
@@ -13,11 +13,11 @@ warn("The `IPython.html` package has been deprecated. "
 
 from IPython.utils.shimmodule import ShimModule
 
-sys.modules['IPython.html'] = ShimModule(
-    src='IPython.html', mirror='jupyter_notebook')
-
 sys.modules['IPython.html.widgets'] = ShimModule(
     src='IPython.html.widgets', mirror='ipython_widgets')
+
+sys.modules['IPython.html'] = ShimModule(
+    src='IPython.html', mirror='jupyter_notebook')
 
 if __name__ == '__main__':
     from jupyter_notebook import notebookapp as app


### PR DESCRIPTION
otherwise weird namespace issues prevent the second shim from being created on Python 2

cc @SylvainCorlay
