### PR TITLE
run test on 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 # http://travis-ci.org/#!/ipython/ipython
 language: python
 python:
+    - "nightly"
     - 3.4
     - 3.3
     - 2.7
 sudo: false
+matrix:
+    allow_failures:
+        - python : "nightly"
 before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -50,6 +50,9 @@ ip = get_ipython()
 # Tests
 #-----------------------------------------------------------------------------
 
+class DerivedInterrupt(KeyboardInterrupt):
+    pass
+
 class InteractiveShellTestCase(unittest.TestCase):
     def test_naked_string_cells(self):
         """Test that cells with only naked strings are fully executed"""
@@ -502,8 +505,6 @@ class InteractiveShellTestCase(unittest.TestCase):
             msg = ip.get_exception_only()
         self.assertEqual(msg, 'KeyboardInterrupt\n')
 
-        class DerivedInterrupt(KeyboardInterrupt):
-            pass
         try:
             raise DerivedInterrupt("foo")
         except KeyboardInterrupt:


### PR DESCRIPTION
This should run test on python 3.5, but should not allow builds to be marked as failed. 
