### PR TITLE
fixes for different ways to import shims

### DIFF
--- a/IPython/html.py
+++ b/IPython/html.py
@@ -13,11 +13,15 @@ warn("The `IPython.html` package has been deprecated. "
 
 from IPython.utils.shimmodule import ShimModule
 
-sys.modules['IPython.html.widgets'] = ShimModule(
+_widgets = sys.modules['IPython.html.widgets'] = ShimModule(
     src='IPython.html.widgets', mirror='ipython_widgets')
 
-sys.modules['IPython.html'] = ShimModule(
+_html = ShimModule(
     src='IPython.html', mirror='jupyter_notebook')
+
+# hook up widgets
+_html.widgets = _widgets
+sys.modules['IPython.html'] = _html
 
 if __name__ == '__main__':
     from jupyter_notebook import notebookapp as app

--- a/IPython/utils/shimmodule.py
+++ b/IPython/utils/shimmodule.py
@@ -68,6 +68,18 @@ class ShimModule(types.ModuleType):
     def __spec__(self):
         """Don't produce __spec__ until requested"""
         return __import__(self._mirror).__spec__
+    
+    def __dir__(self):
+        return dir(__import__(self._mirror))
+    
+    @property
+    def __all__(self):
+        """Ensure __all__ is always defined"""
+        mod = __import__(self._mirror)
+        try:
+            return mod.__all__
+        except AttributeError:
+            return [name for name in dir(mod) if not name.startswith('_')]
 
     def __getattr__(self, key):
         # Use the equivalent of import_item(name), see below


### PR DESCRIPTION
- ensure `__all__` and `__dir__` are defined (needed for `import *` from shims)
- make `IPython.html.widget` shim an explicit attribute on the `IPython.html` shim

These ensure all of the following import patterns work:
- `from IPython.html.widgets import *`
- `from IPython.html.widgets import Widget`
- `from IPython.html import widgets`
- `import IPython.html.widgets`

cc @SylvainCorlay for verification
