### PR TITLE
file_extension in language_info should include the .

### DIFF
--- a/docs/source/development/messaging.rst
+++ b/docs/source/development/messaging.rst
@@ -743,7 +743,7 @@ Message type: ``kernel_info_reply``::
             # mimetype for script files in this language
             'mimetype': str,
 
-            # Extension without the dot, e.g. 'py'
+            # Extension including the dot, e.g. '.py'
             'file_extension': str,
 
             # Pygments lexer, for highlighting


### PR DESCRIPTION
closes ipython/ipython_kernel#12
