### PR TITLE
iTerm2 experimental backend support.

### DIFF
--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -24,7 +24,7 @@ backends = {'tk': 'TkAgg',
             'nbagg': 'nbAgg',
             'notebook': 'nbAgg',
             'inline' : 'module://ipython_kernel.pylab.backend_inline',
-            'iterm2': 'iTerm2'}
+            'iterm2' : 'module://matplotlib_iterm2.backend_iterm2'}
 
 # We also need a reverse backends2guis mapping that will properly choose which
 # GUI support to activate based on the desired matplotlib backend.  For the

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -23,7 +23,8 @@ backends = {'tk': 'TkAgg',
             'osx': 'MacOSX',
             'nbagg': 'nbAgg',
             'notebook': 'nbAgg',
-            'inline' : 'module://ipython_kernel.pylab.backend_inline'}
+            'inline' : 'module://ipython_kernel.pylab.backend_inline',
+            'iterm2': 'iTerm2'}
 
 # We also need a reverse backends2guis mapping that will properly choose which
 # GUI support to activate based on the desired matplotlib backend.  For the
@@ -84,10 +85,10 @@ def figsize(sizex, sizey):
 
 def print_figure(fig, fmt='png', bbox_inches='tight', **kwargs):
     """Print a figure to an image, and return the resulting file data
-    
+
     Returned data will be bytes unless ``fmt='svg'``,
     in which case it will be unicode.
-    
+
     Any keyword args are passed to fig.canvas.print_figure,
     such as ``quality`` or ``bbox_inches``.
     """
@@ -101,7 +102,7 @@ def print_figure(fig, fmt='png', bbox_inches='tight', **kwargs):
     if fmt == 'retina':
         dpi = dpi * 2
         fmt = 'png'
-    
+
     # build keyword args
     kw = dict(
         format=fmt,
@@ -112,14 +113,14 @@ def print_figure(fig, fmt='png', bbox_inches='tight', **kwargs):
     )
     # **kwargs get higher priority
     kw.update(kwargs)
-    
+
     bytes_io = BytesIO()
     fig.canvas.print_figure(bytes_io, **kw)
     data = bytes_io.getvalue()
     if fmt == 'svg':
         data = data.decode('utf-8')
     return data
-    
+
 def retina_figure(fig, **kwargs):
     """format a figure as a pixel-doubled (retina) PNG"""
     pngdata = print_figure(fig, fmt='retina', **kwargs)
@@ -143,7 +144,7 @@ def mpl_runner(safe_execfile):
     A function suitable for use as the ``runner`` argument of the %run magic
     function.
     """
-    
+
     def mpl_execfile(fname,*where,**kw):
         """matplotlib-aware wrapper around safe_execfile.
 
@@ -195,14 +196,14 @@ def select_figure_formats(shell, formats, **kwargs):
     formats = set(formats)
 
     [ f.pop(Figure, None) for f in shell.display_formatter.formatters.values() ]
-    
+
     supported = {'png', 'png2x', 'retina', 'jpg', 'jpeg', 'svg', 'pdf'}
     bad = formats.difference(supported)
     if bad:
         bs = "%s" % ','.join([repr(f) for f in bad])
         gs = "%s" % ','.join([repr(f) for f in supported])
         raise ValueError("supported formats are: %s not %s" % (gs, bs))
-    
+
     if 'png' in formats:
         png_formatter.for_type(Figure, lambda fig: print_figure(fig, 'png', **kwargs))
     if 'retina' in formats or 'png2x' in formats:
@@ -265,7 +266,7 @@ def activate_matplotlib(backend):
 
     import matplotlib
     matplotlib.interactive(True)
-    
+
     # Matplotlib had a bug where even switch_backend could not force
     # the rcParam to update. This needs to be set *before* the module
     # magic of switch_backend().
@@ -286,11 +287,11 @@ def activate_matplotlib(backend):
 
 def import_pylab(user_ns, import_all=True):
     """Populate the namespace with pylab-related values.
-    
+
     Imports matplotlib, pylab, numpy, and everything from pylab and numpy.
-    
+
     Also imports a few names from IPython (figsize, display, getfigs)
-    
+
     """
 
     # Import numpy as np/pyplot as plt are conventions we're trying to
@@ -303,12 +304,12 @@ def import_pylab(user_ns, import_all=True):
           "plt = pyplot\n"
           )
     exec(s, user_ns)
-    
+
     if import_all:
         s = ("from matplotlib.pylab import *\n"
              "from numpy import *\n")
         exec(s, user_ns)
-    
+
     # IPython symbols to add
     user_ns['figsize'] = figsize
     from IPython.core.display import display


### PR DESCRIPTION
Added support of iTerm2 experimental backend.

See:
https://github.com/matplotlib/matplotlib/pull/4397
