### PR TITLE
FIX : flip atexit registration

### DIFF
--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -297,8 +297,8 @@ class EmbeddedSphinxShell(object):
 
         # Create and initialize global ipython, but don't start its mainloop.
         # This will persist across different EmbededSphinxShell instances.
-        IP = InteractiveShell.instance(config=config, profile_dir=profile)
         atexit.register(self.cleanup)
+        IP = InteractiveShell.instance(config=config, profile_dir=profile)
 
         # io.stdout redirect must be done after instantiating InteractiveShell
         io.stdout = self.cout


### PR DESCRIPTION
Register the sphinx spcefic atexit function before InteractiveShell
can register it's clean up function.  The functions are executed
last-in, first-out which means in this case the temporary profile
directory is deleted before the final history writing can be done which
results in exceptions/warnings coming out of sphinx.
