### PR TITLE
Use mock and testpath for test_paths

### DIFF
--- a/IPython/core/tests/test_paths.py
+++ b/IPython/core/tests/test_paths.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 import errno
 import os
 import shutil
@@ -6,21 +5,18 @@ import sys
 import tempfile
 import warnings
 
-try:
-    reload
-except NameError:   # Python 3
-    from imp import reload
+try:                    # Python 3
+    from unittest.mock import patch
+except ImportError:     # Python 2
+    from mock import patch
 
-from nose import with_setup
 import nose.tools as nt
 from testpath import modified_env
 
-import IPython
 from IPython import paths
 from IPython.testing.decorators import skip_win32
 from IPython.utils.tempdir import TemporaryDirectory
 
-env = os.environ
 TMP_TEST_DIR = tempfile.mkdtemp()
 HOME_TEST_DIR = os.path.join(TMP_TEST_DIR, "home_test_dir")
 XDG_TEST_DIR = os.path.join(HOME_TEST_DIR, "xdg_test_dir")
@@ -49,89 +45,57 @@ def teardown():
     # that non-empty directories are all recursively removed.
     shutil.rmtree(TMP_TEST_DIR)
 
-
-def setup_environment():
-    """Setup testenvironment for some functions that are tested
-    in this module. In particular this functions stores attributes
-    and other things that we need to stub in some test functions.
-    This needs to be done on a function level and not module level because
-    each testfunction needs a pristine environment.
-    """
-    global oldstuff
-    oldstuff = (os.name, sys.platform, paths.get_home_dir, IPython.__file__, os.getcwd())
-
-def teardown_environment():
-    """Restore things that were remembered by the setup_environment function
-    """
-    (os.name, sys.platform, paths.get_home_dir, IPython.__file__, old_wd) = oldstuff
-    os.chdir(old_wd)
-    reload(paths)
-
-    if hasattr(sys, 'frozen'):
-        del sys.frozen
-
-# Build decorator that uses the setup_environment/setup_environment
-with_environment = with_setup(setup_environment, teardown_environment)
-
-@contextmanager
 def patch_get_home_dir(dirpath):
-    orig_get_home_dir = paths.get_home_dir
-    paths.get_home_dir = lambda : dirpath
-    try:
-        yield
-    finally:
-        paths.get_home_dir = orig_get_home_dir
+    return patch.object(paths, 'get_home_dir', return_value=dirpath)
+
 
 def test_get_ipython_dir_1():
     """test_get_ipython_dir_1, Testcase to see if we can call get_ipython_dir without Exceptions."""
     env_ipdir = os.path.join("someplace", ".ipython")
-    paths._writable_dir = lambda path: True
-    with modified_env({'IPYTHONDIR': env_ipdir}):
+    with patch.object(paths, '_writable_dir', return_value=True), \
+            modified_env({'IPYTHONDIR': env_ipdir}):
         ipdir = paths.get_ipython_dir()
 
     nt.assert_equal(ipdir, env_ipdir)
 
-@with_environment
 def test_get_ipython_dir_2():
     """test_get_ipython_dir_2, Testcase to see if we can call get_ipython_dir without Exceptions."""
-    with patch_get_home_dir('someplace'):
-        paths.get_xdg_dir = lambda : None
-        paths._writable_dir = lambda path: True
-        os.name = "posix"
-        with modified_env({'IPYTHON_DIR': None,
-                           'IPYTHONDIR': None,
-                           'XDG_CONFIG_HOME': None
-                          }):
-            ipdir = paths.get_ipython_dir()
+    with patch_get_home_dir('someplace'), \
+            patch.object(paths, 'get_xdg_dir', return_value=None), \
+            patch.object(paths, '_writable_dir', return_value=True), \
+            patch('os.name', "posix"), \
+            modified_env({'IPYTHON_DIR': None,
+                          'IPYTHONDIR': None,
+                          'XDG_CONFIG_HOME': None
+                         }):
+        ipdir = paths.get_ipython_dir()
 
-        nt.assert_equal(ipdir, os.path.join("someplace", ".ipython"))
+    nt.assert_equal(ipdir, os.path.join("someplace", ".ipython"))
 
-@with_environment
 def test_get_ipython_dir_3():
     """test_get_ipython_dir_3, move XDG if defined, and .ipython doesn't exist."""
     tmphome = TemporaryDirectory()
     try:
-        with patch_get_home_dir(tmphome.name):
-            os.name = "posix"
-            with modified_env({
-                'IPYTHON_DIR': None,
-                'IPYTHONDIR': None,
-                'XDG_CONFIG_HOME': XDG_TEST_DIR,
-            }), warnings.catch_warnings(record=True) as w:
-                ipdir = paths.get_ipython_dir()
+        with patch_get_home_dir(tmphome.name), \
+                patch('os.name', 'posix'), \
+                modified_env({
+                    'IPYTHON_DIR': None,
+                    'IPYTHONDIR': None,
+                    'XDG_CONFIG_HOME': XDG_TEST_DIR,
+                }), warnings.catch_warnings(record=True) as w:
+            ipdir = paths.get_ipython_dir()
 
-            nt.assert_equal(ipdir, os.path.join(tmphome.name, ".ipython"))
-            if sys.platform != 'darwin':
-                nt.assert_equal(len(w), 1)
-                nt.assert_in('Moving', str(w[0]))
+        nt.assert_equal(ipdir, os.path.join(tmphome.name, ".ipython"))
+        if sys.platform != 'darwin':
+            nt.assert_equal(len(w), 1)
+            nt.assert_in('Moving', str(w[0]))
     finally:
         tmphome.cleanup()
 
-@with_environment
 def test_get_ipython_dir_4():
     """test_get_ipython_dir_4, warn if XDG and home both exist."""
-    with patch_get_home_dir(HOME_TEST_DIR):
-        os.name = "posix"
+    with patch_get_home_dir(HOME_TEST_DIR), \
+            patch('os.name', 'posix'):
         try:
             os.mkdir(os.path.join(XDG_TEST_DIR, 'ipython'))
         except OSError as e:
@@ -151,11 +115,10 @@ def test_get_ipython_dir_4():
             nt.assert_equal(len(w), 1)
             nt.assert_in('Ignoring', str(w[0]))
 
-@with_environment
 def test_get_ipython_dir_5():
     """test_get_ipython_dir_5, use .ipython if exists and XDG defined, but doesn't exist."""
-    with patch_get_home_dir(HOME_TEST_DIR):
-        os.name = "posix"
+    with patch_get_home_dir(HOME_TEST_DIR), \
+            patch('os.name', 'posix'):
         try:
             os.rmdir(os.path.join(XDG_TEST_DIR, 'ipython'))
         except OSError as e:
@@ -171,55 +134,46 @@ def test_get_ipython_dir_5():
 
         nt.assert_equal(ipdir, IP_TEST_DIR)
 
-@with_environment
 def test_get_ipython_dir_6():
     """test_get_ipython_dir_6, use home over XDG if defined and neither exist."""
     xdg = os.path.join(HOME_TEST_DIR, 'somexdg')
     os.mkdir(xdg)
     shutil.rmtree(os.path.join(HOME_TEST_DIR, '.ipython'))
-    with patch_get_home_dir(HOME_TEST_DIR):
-        orig_get_xdg_dir = paths.get_xdg_dir
-        paths.get_xdg_dir = lambda : xdg
-        try:
-            os.name = "posix"
-            with modified_env({
+    print(paths._writable_dir)
+    with patch_get_home_dir(HOME_TEST_DIR), \
+            patch.object(paths, 'get_xdg_dir', return_value=xdg), \
+            patch('os.name', 'posix'), \
+            modified_env({
                 'IPYTHON_DIR': None,
                 'IPYTHONDIR': None,
                 'XDG_CONFIG_HOME': None,
             }), warnings.catch_warnings(record=True) as w:
-                ipdir = paths.get_ipython_dir()
+        ipdir = paths.get_ipython_dir()
 
-            nt.assert_equal(ipdir, os.path.join(HOME_TEST_DIR, '.ipython'))
-            nt.assert_equal(len(w), 0)
-        finally:
-            paths.get_xdg_dir = orig_get_xdg_dir
+    nt.assert_equal(ipdir, os.path.join(HOME_TEST_DIR, '.ipython'))
+    nt.assert_equal(len(w), 0)
 
 def test_get_ipython_dir_7():
     """test_get_ipython_dir_7, test home directory expansion on IPYTHONDIR"""
-    paths._writable_dir = lambda path: True
     home_dir = os.path.normpath(os.path.expanduser('~'))
-    with modified_env({'IPYTHONDIR': os.path.join('~', 'somewhere')}):
+    with modified_env({'IPYTHONDIR': os.path.join('~', 'somewhere')}), \
+            patch.object(paths, '_writable_dir', return_value=True):
         ipdir = paths.get_ipython_dir()
     nt.assert_equal(ipdir, os.path.join(home_dir, 'somewhere'))
 
 @skip_win32
 def test_get_ipython_dir_8():
     """test_get_ipython_dir_8, test / home directory"""
-    old = paths._writable_dir, paths.get_xdg_dir
-    try:
-        paths._writable_dir = lambda path: bool(path)
-        paths.get_xdg_dir = lambda: None
-        with modified_env({
-            'IPYTHON_DIR': None,
-            'IPYTHONDIR': None,
-            'HOME': '/',
-        }):
-            nt.assert_equal(paths.get_ipython_dir(), '/.ipython')
-    finally:
-        paths._writable_dir, paths.get_xdg_dir = old
+    with patch.object(paths, '_writable_dir', lambda path: bool(path)), \
+            patch.object(paths, 'get_xdg_dir', return_value=None), \
+            modified_env({
+                'IPYTHON_DIR': None,
+                'IPYTHONDIR': None,
+                'HOME': '/',
+            }):
+        nt.assert_equal(paths.get_ipython_dir(), '/.ipython')
 
 
-@with_environment
 def test_get_ipython_cache_dir():
     with modified_env({'HOME': HOME_TEST_DIR}):
         if os.name == 'posix' and sys.platform != 'darwin':

--- a/IPython/core/tests/test_paths.py
+++ b/IPython/core/tests/test_paths.py
@@ -11,7 +11,7 @@ except ImportError:     # Python 2
     from mock import patch
 
 import nose.tools as nt
-from testpath import modified_env
+from testpath import modified_env, assert_isdir, assert_isfile
 
 from IPython import paths
 from IPython.testing.decorators import skip_win32
@@ -183,12 +183,12 @@ def test_get_ipython_cache_dir():
                 ipdir = paths.get_ipython_cache_dir()
             nt.assert_equal(os.path.join(HOME_TEST_DIR, ".cache", "ipython"),
                             ipdir)
-            nt.assert_true(os.path.isdir(ipdir))
+            assert_isdir(ipdir)
 
             # test env override
             with modified_env({"XDG_CACHE_HOME": XDG_CACHE_DIR}):
                 ipdir = paths.get_ipython_cache_dir()
-            nt.assert_true(os.path.isdir(ipdir))
+            assert_isdir(ipdir)
             nt.assert_equal(ipdir, os.path.join(XDG_CACHE_DIR, "ipython"))
         else:
             nt.assert_equal(paths.get_ipython_cache_dir(),
@@ -196,9 +196,9 @@ def test_get_ipython_cache_dir():
 
 def test_get_ipython_package_dir():
     ipdir = paths.get_ipython_package_dir()
-    nt.assert_true(os.path.isdir(ipdir))
+    assert_isdir(ipdir)
 
 
 def test_get_ipython_module_path():
     ipapp_path = paths.get_ipython_module_path('IPython.terminal.ipapp')
-    nt.assert_true(os.path.isfile(ipapp_path))
+    assert_isfile(ipapp_path)

--- a/IPython/core/tests/test_paths.py
+++ b/IPython/core/tests/test_paths.py
@@ -13,6 +13,7 @@ except NameError:   # Python 3
 
 from nose import with_setup
 import nose.tools as nt
+from testpath import modified_env
 
 import IPython
 from IPython import paths
@@ -56,20 +57,16 @@ def setup_environment():
     This needs to be done on a function level and not module level because
     each testfunction needs a pristine environment.
     """
-    global oldstuff, platformstuff
-    oldstuff = (env.copy(), os.name, sys.platform, paths.get_home_dir, IPython.__file__, os.getcwd())
+    global oldstuff
+    oldstuff = (os.name, sys.platform, paths.get_home_dir, IPython.__file__, os.getcwd())
 
 def teardown_environment():
     """Restore things that were remembered by the setup_environment function
     """
-    (oldenv, os.name, sys.platform, paths.get_home_dir, IPython.__file__, old_wd) = oldstuff
+    (os.name, sys.platform, paths.get_home_dir, IPython.__file__, old_wd) = oldstuff
     os.chdir(old_wd)
     reload(paths)
 
-    for key in list(env):
-        if key not in oldenv:
-            del env[key]
-    env.update(oldenv)
     if hasattr(sys, 'frozen'):
         del sys.frozen
 
@@ -85,16 +82,14 @@ def patch_get_home_dir(dirpath):
     finally:
         paths.get_home_dir = orig_get_home_dir
 
-
-@with_environment
 def test_get_ipython_dir_1():
     """test_get_ipython_dir_1, Testcase to see if we can call get_ipython_dir without Exceptions."""
     env_ipdir = os.path.join("someplace", ".ipython")
     paths._writable_dir = lambda path: True
-    env['IPYTHONDIR'] = env_ipdir
-    ipdir = paths.get_ipython_dir()
-    nt.assert_equal(ipdir, env_ipdir)
+    with modified_env({'IPYTHONDIR': env_ipdir}):
+        ipdir = paths.get_ipython_dir()
 
+    nt.assert_equal(ipdir, env_ipdir)
 
 @with_environment
 def test_get_ipython_dir_2():
@@ -103,10 +98,12 @@ def test_get_ipython_dir_2():
         paths.get_xdg_dir = lambda : None
         paths._writable_dir = lambda path: True
         os.name = "posix"
-        env.pop('IPYTHON_DIR', None)
-        env.pop('IPYTHONDIR', None)
-        env.pop('XDG_CONFIG_HOME', None)
-        ipdir = paths.get_ipython_dir()
+        with modified_env({'IPYTHON_DIR': None,
+                           'IPYTHONDIR': None,
+                           'XDG_CONFIG_HOME': None
+                          }):
+            ipdir = paths.get_ipython_dir()
+
         nt.assert_equal(ipdir, os.path.join("someplace", ".ipython"))
 
 @with_environment
@@ -116,11 +113,11 @@ def test_get_ipython_dir_3():
     try:
         with patch_get_home_dir(tmphome.name):
             os.name = "posix"
-            env.pop('IPYTHON_DIR', None)
-            env.pop('IPYTHONDIR', None)
-            env['XDG_CONFIG_HOME'] = XDG_TEST_DIR
-
-            with warnings.catch_warnings(record=True) as w:
+            with modified_env({
+                'IPYTHON_DIR': None,
+                'IPYTHONDIR': None,
+                'XDG_CONFIG_HOME': XDG_TEST_DIR,
+            }), warnings.catch_warnings(record=True) as w:
                 ipdir = paths.get_ipython_dir()
 
             nt.assert_equal(ipdir, os.path.join(tmphome.name, ".ipython"))
@@ -135,16 +132,18 @@ def test_get_ipython_dir_4():
     """test_get_ipython_dir_4, warn if XDG and home both exist."""
     with patch_get_home_dir(HOME_TEST_DIR):
         os.name = "posix"
-        env.pop('IPYTHON_DIR', None)
-        env.pop('IPYTHONDIR', None)
-        env['XDG_CONFIG_HOME'] = XDG_TEST_DIR
         try:
             os.mkdir(os.path.join(XDG_TEST_DIR, 'ipython'))
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
 
-        with warnings.catch_warnings(record=True) as w:
+
+        with modified_env({
+            'IPYTHON_DIR': None,
+            'IPYTHONDIR': None,
+            'XDG_CONFIG_HOME': XDG_TEST_DIR,
+        }), warnings.catch_warnings(record=True) as w:
             ipdir = paths.get_ipython_dir()
 
         nt.assert_equal(ipdir, os.path.join(HOME_TEST_DIR, ".ipython"))
@@ -157,15 +156,19 @@ def test_get_ipython_dir_5():
     """test_get_ipython_dir_5, use .ipython if exists and XDG defined, but doesn't exist."""
     with patch_get_home_dir(HOME_TEST_DIR):
         os.name = "posix"
-        env.pop('IPYTHON_DIR', None)
-        env.pop('IPYTHONDIR', None)
-        env['XDG_CONFIG_HOME'] = XDG_TEST_DIR
         try:
             os.rmdir(os.path.join(XDG_TEST_DIR, 'ipython'))
         except OSError as e:
             if e.errno != errno.ENOENT:
                 raise
-        ipdir = paths.get_ipython_dir()
+
+        with modified_env({
+            'IPYTHON_DIR': None,
+            'IPYTHONDIR': None,
+            'XDG_CONFIG_HOME': XDG_TEST_DIR,
+        }):
+            ipdir = paths.get_ipython_dir()
+
         nt.assert_equal(ipdir, IP_TEST_DIR)
 
 @with_environment
@@ -179,10 +182,11 @@ def test_get_ipython_dir_6():
         paths.get_xdg_dir = lambda : xdg
         try:
             os.name = "posix"
-            env.pop('IPYTHON_DIR', None)
-            env.pop('IPYTHONDIR', None)
-            env.pop('XDG_CONFIG_HOME', None)
-            with warnings.catch_warnings(record=True) as w:
+            with modified_env({
+                'IPYTHON_DIR': None,
+                'IPYTHONDIR': None,
+                'XDG_CONFIG_HOME': None,
+            }), warnings.catch_warnings(record=True) as w:
                 ipdir = paths.get_ipython_dir()
 
             nt.assert_equal(ipdir, os.path.join(HOME_TEST_DIR, '.ipython'))
@@ -190,51 +194,51 @@ def test_get_ipython_dir_6():
         finally:
             paths.get_xdg_dir = orig_get_xdg_dir
 
-@with_environment
 def test_get_ipython_dir_7():
     """test_get_ipython_dir_7, test home directory expansion on IPYTHONDIR"""
     paths._writable_dir = lambda path: True
     home_dir = os.path.normpath(os.path.expanduser('~'))
-    env['IPYTHONDIR'] = os.path.join('~', 'somewhere')
-    ipdir = paths.get_ipython_dir()
+    with modified_env({'IPYTHONDIR': os.path.join('~', 'somewhere')}):
+        ipdir = paths.get_ipython_dir()
     nt.assert_equal(ipdir, os.path.join(home_dir, 'somewhere'))
 
 @skip_win32
-@with_environment
 def test_get_ipython_dir_8():
     """test_get_ipython_dir_8, test / home directory"""
     old = paths._writable_dir, paths.get_xdg_dir
     try:
         paths._writable_dir = lambda path: bool(path)
         paths.get_xdg_dir = lambda: None
-        env.pop('IPYTHON_DIR', None)
-        env.pop('IPYTHONDIR', None)
-        env['HOME'] = '/'
-        nt.assert_equal(paths.get_ipython_dir(), '/.ipython')
+        with modified_env({
+            'IPYTHON_DIR': None,
+            'IPYTHONDIR': None,
+            'HOME': '/',
+        }):
+            nt.assert_equal(paths.get_ipython_dir(), '/.ipython')
     finally:
         paths._writable_dir, paths.get_xdg_dir = old
 
 
 @with_environment
 def test_get_ipython_cache_dir():
-    os.environ["HOME"] = HOME_TEST_DIR
-    if os.name == 'posix' and sys.platform != 'darwin':
-        # test default
-        os.makedirs(os.path.join(HOME_TEST_DIR, ".cache"))
-        os.environ.pop("XDG_CACHE_HOME", None)
-        ipdir = paths.get_ipython_cache_dir()
-        nt.assert_equal(os.path.join(HOME_TEST_DIR, ".cache", "ipython"),
-                        ipdir)
-        nt.assert_true(os.path.isdir(ipdir))
+    with modified_env({'HOME': HOME_TEST_DIR}):
+        if os.name == 'posix' and sys.platform != 'darwin':
+            # test default
+            os.makedirs(os.path.join(HOME_TEST_DIR, ".cache"))
+            with modified_env({'XDG_CACHE_HOME': None}):
+                ipdir = paths.get_ipython_cache_dir()
+            nt.assert_equal(os.path.join(HOME_TEST_DIR, ".cache", "ipython"),
+                            ipdir)
+            nt.assert_true(os.path.isdir(ipdir))
 
-        # test env override
-        os.environ["XDG_CACHE_HOME"] = XDG_CACHE_DIR
-        ipdir = paths.get_ipython_cache_dir()
-        nt.assert_true(os.path.isdir(ipdir))
-        nt.assert_equal(ipdir, os.path.join(XDG_CACHE_DIR, "ipython"))
-    else:
-        nt.assert_equal(paths.get_ipython_cache_dir(),
-                        paths.get_ipython_dir())
+            # test env override
+            with modified_env({"XDG_CACHE_HOME": XDG_CACHE_DIR}):
+                ipdir = paths.get_ipython_cache_dir()
+            nt.assert_true(os.path.isdir(ipdir))
+            nt.assert_equal(ipdir, os.path.join(XDG_CACHE_DIR, "ipython"))
+        else:
+            nt.assert_equal(paths.get_ipython_cache_dir(),
+                            paths.get_ipython_dir())
 
 def test_get_ipython_package_dir():
     ipdir = paths.get_ipython_package_dir()

--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ extras_require = dict(
     parallel = ['ipython_parallel'],
     qtconsole = ['jupyter_qtconsole'],
     doc = ['Sphinx>=1.1', 'numpydoc'],
-    test = ['nose>=0.10.1', 'requests'],
+    test = ['nose>=0.10.1', 'requests', 'testpath'],
     terminal = [],
     kernel = ['ipython_kernel'],
     nbformat = ['jupyter_nbformat'],


### PR DESCRIPTION
This removes our handcoded monkeypatching/restoring code in test_paths, replacing it with context managers from unittest.mock and testpath. `testpath.modified_env` has one advantage over `unittest.mock.patch.dict`: it can temporarily _unset_ specific environment variables as well as setting them.

I also switched a couple of tests to use `assert_isfile` and `assert_isdir` from testpath. These functions should be more informative when the assertion fails than simply asserting on the equivalent os.path functions.

If this is accepted, I'll move testpath to Jupyter maintenance, as we discussed.
