### PR TITLE
Add ajax contentType parameters

### DIFF
--- a/IPython/html/static/services/contents.js
+++ b/IPython/html/static/services/contents.js
@@ -117,6 +117,7 @@ define(function(require) {
             processData : false,
             type : "POST",
             data: data,
+            contentType: 'application/json',
             dataType : "json",
         };
         return utils.promising_ajax(this.api_url(path), settings);
@@ -181,6 +182,7 @@ define(function(require) {
             processData : false,
             type: "POST",
             data: JSON.stringify({copy_from: from_file}),
+            contentType: 'application/json',
             dataType : "json",
         };
         return utils.promising_ajax(url, settings);
@@ -195,6 +197,7 @@ define(function(require) {
         var settings = {
             type : "POST",
             dataType : "json",
+            contentType: false,  // no data
         };
         return utils.promising_ajax(url, settings);
     };
@@ -213,6 +216,7 @@ define(function(require) {
         var url = this.api_url(path, 'checkpoints', checkpoint_id);
         var settings = {
             type : "POST",
+            contentType: false,  // no data
         };
         return utils.promising_ajax(url, settings);
     };

--- a/IPython/html/static/services/kernels/kernel.js
+++ b/IPython/html/static/services/kernels/kernel.js
@@ -196,6 +196,7 @@ define([
             cache: false,
             type: "POST",
             data: JSON.stringify({name: this.name}),
+            contentType: 'application/json',
             dataType: "json",
             success: this._on_success(on_success),
             error: this._on_error(error)
@@ -278,6 +279,7 @@ define([
             processData: false,
             cache: false,
             type: "POST",
+            contentType: false,  // no data
             dataType: "json",
             success: this._on_success(on_success),
             error: this._on_error(error)
@@ -319,6 +321,7 @@ define([
             processData: false,
             cache: false,
             type: "POST",
+            contentType: false,  // no data
             dataType: "json",
             success: this._on_success(on_success),
             error: this._on_error(on_error)

--- a/IPython/html/static/services/sessions/session.js
+++ b/IPython/html/static/services/sessions/session.js
@@ -121,6 +121,7 @@ define([
             cache: false,
             type: "POST",
             data: JSON.stringify(this._get_model()),
+            contentType: 'application/json',
             dataType: "json",
             success: this._on_success(on_success),
             error: this._on_error(on_error)
@@ -168,6 +169,7 @@ define([
             cache: false,
             type: "PATCH",
             data: JSON.stringify(this._get_model()),
+            contentType: 'application/json',
             dataType: "json",
             success: this._on_success(success),
             error: this._on_error(error)


### PR DESCRIPTION
Manually backport jupyter/jupyter_notebook#72 for 3.2
