### PR TITLE
Avoid crash on ctrl-c in text console IPython client with %gui and PyQt5.

### DIFF
--- a/IPython/lib/inputhook.py
+++ b/IPython/lib/inputhook.py
@@ -363,7 +363,7 @@ class Qt4InputHook(InputHookBase):
             app = QtGui.QApplication(sys.argv)
         """
         from IPython.lib.inputhookqt4 import create_inputhook_qt4
-        app, inputhook_qt4 = create_inputhook_qt4(self, app)
+        app, inputhook_qt4 = create_inputhook_qt4(self.manager, app)
         self.manager.set_inputhook(inputhook_qt4)
         if _use_appnope():
             from appnope import nope


### PR DESCRIPTION
create_inputhook_qt4 wants an InputHookManager object as its first argument, not an InputHookBase. However, we get away with supplying the wrong object until someone hits ctrl-c.  Passing the right object makes graceful ctrl-c event loop integration work properly, rather than causing IPython to exit.  This seems like a straightforward fix, but I may be missing something.

The issue addressed is only apparent in the text console IPython client after doing import PyQt5; %gui qt and pressing ctrl-c.  It does not impact qtconsole, which has its own mechanism for handling ctrl-c.

As far as I can tell, %gui in the console IPython client with PyQt4 and pyside should experience the same problem.  I don't have either installed, but I could find a couple hours this weekend to make venvs with PyQt4 and pyside to verify, if that would be helpful.
