### PR TITLE
Replace dead link to nose website in install.rst

### DIFF
--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -220,7 +220,7 @@ Another way of getting this is to do:
     $ pip install "ipython[test]"
 
 For more installation options, see the `nose website
-<http://somethingaboutorange.com/mrl/projects/nose/>`_.  
+<https://nose.readthedocs.org>`_.  
 
 Once you have nose installed, you can run IPython's test suite using the
 iptest command:


### PR DESCRIPTION
Hi, I noticed that the existing link (http://somethingaboutorange.com/mrl/projects/nose/) is dead, so I propose changing the link to https://nose.readthedocs.org, the first hit on a Google search for 'python nose'.

After my first commit, I tried a second commit that would reverse the spurious change of adding a newline to the end of file, but it looks like my second commit was a no-op. Sorry. I don't know how to undo the adding of a newline--I only indended to change the hyperlink to nose.
