### PR TITLE
Backport jupyter/notebook#89

### DIFF
--- a/IPython/html/static/notebook/js/cell.js
+++ b/IPython/html/static/notebook/js/cell.js
@@ -73,14 +73,25 @@ define([
             }
         });
 
+        // backward compat.
+        Object.defineProperty(this, 'cm_config', {
+            get: function() {
+                return that._options.cm_config;
+            },
+            set: function(value) {
+                that._options.cm_config = value;
+            }
+        });
+
         // load this from metadata later ?
         this.user_highlight = 'auto';
+
 
         var _local_cm_config = {};
         if(this.class_config){
             _local_cm_config = this.class_config.get_sync('cm_config');
         }
-        this.cm_config = utils.mergeopt({}, config.cm_config, _local_cm_config);
+        config.cm_config = utils.mergeopt({}, config.cm_config, _local_cm_config);
         this.cell_id = utils.uuid();
         this._options = config;
 

--- a/IPython/html/static/notebook/js/codecell.js
+++ b/IPython/html/static/notebook/js/codecell.js
@@ -125,7 +125,7 @@ define([
                 "Cmd-/" : "toggleComment",
                 "Ctrl-/" : "toggleComment"
             },
-            mode: 'ipython',
+            mode: 'text',
             theme: 'ipython',
             matchBrackets: true,
             autoCloseBrackets: true
@@ -163,7 +163,7 @@ define([
             notebook: this.notebook});
         inner_cell.append(this.celltoolbar.element);
         var input_area = $('<div/>').addClass('input_area');
-        this.code_mirror = new CodeMirror(input_area.get(0), this.cm_config);
+        this.code_mirror = new CodeMirror(input_area.get(0), this._options.cm_config);
         // In case of bugs that put the keyboard manager into an inconsistent state,
         // ensure KM is enabled when CodeMirror is focused:
         this.code_mirror.on('focus', function () {

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -135,7 +135,7 @@ define(function (require) {
         this.notebook_name_blacklist_re = /[\/\\:]/;
         this.nbformat = 4; // Increment this when changing the nbformat
         this.nbformat_minor = this.current_nbformat_minor = 0; // Increment this when changing the nbformat
-        this.codemirror_mode = 'ipython';
+        this.codemirror_mode = 'text';
         this.create_elements();
         this.bind_events();
         this.kernel_selector = null;

--- a/IPython/html/static/notebook/js/notebook.js
+++ b/IPython/html/static/notebook/js/notebook.js
@@ -1515,7 +1515,7 @@ define(function (require) {
                     // This is currently redundant, because cm_config ends up as
                     // codemirror's own .options object, but I don't want to
                     // rely on that.
-                    cell.cm_config.mode = spec;
+                    cell._options.cm_config.mode = spec;
                 }
             });
         });

--- a/IPython/html/static/notebook/js/textcell.js
+++ b/IPython/html/static/notebook/js/textcell.js
@@ -98,7 +98,7 @@ define([
             notebook: this.notebook});
         inner_cell.append(this.celltoolbar.element);
         var input_area = $('<div/>').addClass('input_area');
-        this.code_mirror = new CodeMirror(input_area.get(0), this.cm_config);
+        this.code_mirror = new CodeMirror(input_area.get(0), this._options.cm_config);
         // In case of bugs that put the keyboard manager into an inconsistent state,
         // ensure KM is enabled when CodeMirror is focused:
         this.code_mirror.on('focus', function () {


### PR DESCRIPTION
fix highlighting of non-python kernels.

mock the cm_config property also when set, unlike in non backported
version of this PR
