### PR TITLE
[NOT FOR MERGING] Timeit output

### DIFF
--- a/IPython/core/magic_arguments.py
+++ b/IPython/core/magic_arguments.py
@@ -132,7 +132,7 @@ class MagicArgumentParser(argparse.ArgumentParser):
     def parse_argstring(self, argstring):
         """ Split a string into an argument list and parse that argument list.
         """
-        argv = arg_split(argstring)
+        argv = arg_split(argstring, strict=False)
         return self.parse_args(argv)
 
 

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -895,50 +895,50 @@ python-profiler package from non-free.""")
     @skip_doctest
     @magic_arguments.magic_arguments()
     @magic_arguments.argument('-n', '--number', type=int, default=0,
-        help="""11
+        help="""execute the given statement NUMBER times in a loop. If this value
+        is not given, a fitting value is chosen.
         """
     )
     @magic_arguments.argument('-r', '--repeat', type=int, default=timeit.default_repeat,
-        help="""1
+        help="""repeat the loop iteration REPEAT times and take the best result.
+        Default: 3
         """
     )
     @magic_arguments.argument('-p', '--precision', type=int, default=3,
-        help="""1
+        help="""use a precision of PRECISION digits to display the timing result.
+        Default: 3
         """
     )
     @magic_arguments.argument('-o', '--output', nargs='?', default=False, const=True,
-        help="""1
+        help="""return a TimeitResult that can be stored in a variable to inspect
+            the result in more details.
         """
     )
     @magic_arguments.argument('-t', '--use-time', action='store_true',
-        help="""1
+        help="""use time.time to measure the time, which is the default on Unix.
+        This function measures wall time.
         """
     )
     @magic_arguments.argument('-c', '--use-clock', action='store_true',
-        help="""1
+        help="""use time.clock to measure the time, which is the default on
+        Windows and measures wall time. On Unix, resource.getrusage is used
+        instead and returns the CPU user time.
         """
     )
     @magic_arguments.argument('-q', '--quiet', action='store_true',
-        help="""11
+        help="""Quiet, do not print result.
         """
     )
     @magic_arguments.argument('stmt', nargs='?', default="",
-        help="""1
+        help="""Statement to be executed (only in line magic mode.)
         """
     )    
     @line_cell_magic
     def timeit(self, line='', cell=None):
-        """Time execution of a Python statement or expression
-
-        Usage, in line mode:
-          %timeit [-n<N> -r<R> [-t|-c] -q -p<P> -o] statement
-        or in cell mode:
-          %%timeit [-n<N> -r<R> [-t|-c] -q -p<P> -o] setup_code
-          code
-          code...
-
-        Time execution of a Python statement or expression using the timeit
-        module.  This function can be used both as a line and cell magic:
+        """Time execution of a Python statement or expression.
+        
+        Time execution of Python code using the timeit module.  This function
+        can be used both as a line and cell magic:
 
         - In line mode you can time a single-line statement (though multiple
           ones can be chained with using semicolons).
@@ -946,29 +946,6 @@ python-profiler package from non-free.""")
         - In cell mode, the statement in the first line is used as setup code
           (executed but not timed) and the body of the cell is timed.  The cell
           body has access to any variables created in the setup code.
-
-        Options:
-        -n<N>: execute the given statement <N> times in a loop. If this value
-        is not given, a fitting value is chosen.
-
-        -r<R>: repeat the loop iteration <R> times and take the best result.
-        Default: 3
-
-        -t: use time.time to measure the time, which is the default on Unix.
-        This function measures wall time.
-
-        -c: use time.clock to measure the time, which is the default on
-        Windows and measures wall time. On Unix, resource.getrusage is used
-        instead and returns the CPU user time.
-
-        -p<P>: use a precision of <P> digits to display the timing result.
-        Default: 3
-
-        -q: Quiet, do not print result.
-
-        -o: return a TimeitResult that can be stored in a variable to inspect
-            the result in more details.
-
 
         Examples
         --------
@@ -997,30 +974,26 @@ python-profiler package from non-free.""")
         of the shell, compared with timeit.py, which uses a single setup
         statement to import function or create variables. Generally, the bias
         does not matter as long as results from timeit.py are not mixed with
-        those from %timeit."""
-        
-        args = magic_arguments.parse_argstring(self.timeit, line)
-        stmt = args.stmt
+        those from %timeit.
 
+        """
+
+        # Parse args and collect into local vars for further use
+        args = magic_arguments.parse_argstring(self.timeit, line)
+        
+        stmt = args.stmt
         if stmt == "" and cell is None:
             raise UsageError("You must provide a statement to execute and time, none was given.")
-            
-        timefunc = timeit.default_timer
-#        number = int(getattr(opts, "n", 0))
+
         number = args.number
-#        repeat = int(getattr(opts, "r", timeit.default_repeat))
         repeat = args.repeat
-#        precision = int(getattr(opts, "p", 3))
         precision = args.precision
-#        quiet = 'q' in opts
         quiet = args.quiet
         output = args.output
-#        return_result = 'o' in opts
-#        return_timing = getattr(opts, "o", None)
+        timefunc = timeit.default_timer
         if args.use_time:
             timefunc = time.time
         if args.use_clock:
-#        if 'c' in opts:
             timefunc = clock
 
         timer = Timer(timer=timefunc)
@@ -1081,7 +1054,7 @@ python-profiler package from non-free.""")
                 number *= 10
         all_runs = timer.repeat(repeat, number)
         best = min(all_runs) / number
-        if not quiet :
+        if not quiet:
             worst = max(all_runs) / number
             if worst_tuning:
                 worst = max(worst, worst_tuning)

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -1003,7 +1003,7 @@ python-profiler package from non-free.""")
         stmt = args.stmt
 
         if stmt == "" and cell is None:
-            return
+            raise UsageError("You must provide a statement to execute and time, none was given.")
             
         timefunc = timeit.default_timer
 #        number = int(getattr(opts, "n", 0))

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -893,6 +893,39 @@ python-profiler package from non-free.""")
         print("Wall time: %10.2f s." % (twall1 - twall0))
 
     @skip_doctest
+    @magic_arguments.magic_arguments()
+    @magic_arguments.argument('-n', '--number', type=int, default=0,
+        help="""11
+        """
+    )
+    @magic_arguments.argument('-r', '--repeat', type=int, default=timeit.default_repeat,
+        help="""1
+        """
+    )
+    @magic_arguments.argument('-p', '--precision', type=int, default=3,
+        help="""1
+        """
+    )
+    @magic_arguments.argument('-o', '--output', nargs='?', default=False, const=True,
+        help="""1
+        """
+    )
+    @magic_arguments.argument('-t', '--use-time', action='store_true',
+        help="""1
+        """
+    )
+    @magic_arguments.argument('-c', '--use-clock', action='store_true',
+        help="""1
+        """
+    )
+    @magic_arguments.argument('-q', '--quiet', action='store_true',
+        help="""11
+        """
+    )
+    @magic_arguments.argument('stmt', nargs='?', default="",
+        help="""1
+        """
+    )    
     @line_cell_magic
     def timeit(self, line='', cell=None):
         """Time execution of a Python statement or expression
@@ -965,21 +998,29 @@ python-profiler package from non-free.""")
         statement to import function or create variables. Generally, the bias
         does not matter as long as results from timeit.py are not mixed with
         those from %timeit."""
+        
+        args = magic_arguments.parse_argstring(self.timeit, line)
+        stmt = args.stmt
 
-        opts, stmt = self.parse_options(line,'n:r:tcp:qo',
-                                        posix=False, strict=False)
         if stmt == "" and cell is None:
             return
-        
+            
         timefunc = timeit.default_timer
-        number = int(getattr(opts, "n", 0))
-        repeat = int(getattr(opts, "r", timeit.default_repeat))
-        precision = int(getattr(opts, "p", 3))
-        quiet = 'q' in opts
-        return_result = 'o' in opts
-        if hasattr(opts, "t"):
+#        number = int(getattr(opts, "n", 0))
+        number = args.number
+#        repeat = int(getattr(opts, "r", timeit.default_repeat))
+        repeat = args.repeat
+#        precision = int(getattr(opts, "p", 3))
+        precision = args.precision
+#        quiet = 'q' in opts
+        quiet = args.quiet
+        output = args.output
+#        return_result = 'o' in opts
+#        return_timing = getattr(opts, "o", None)
+        if args.use_time:
             timefunc = time.time
-        if hasattr(opts, "c"):
+        if args.use_clock:
+#        if 'c' in opts:
             timefunc = clock
 
         timer = Timer(timer=timefunc)
@@ -1057,13 +1098,19 @@ python-profiler package from non-free.""")
                                                               _format_time(best, precision)))
             if tc > tc_min:
                 print("Compiler time: %.2f s" % tc)
-        if return_result:
-            return TimeitResult(number, repeat, best, all_runs, tc, precision)
+        if output == False:
+            return
+        else:
+            result = TimeitResult(number, repeat, best, all_runs, tc, precision)
+            if output == True:
+                return result
+            else:
+                self.shell.user_ns[output] = result
 
     @skip_doctest
     @needs_local_scope
     @line_cell_magic
-    def time(self,line='', cell=None, local_ns=None):
+    def time(self, line='', cell=None, local_ns=None):
         """Time execution of a Python statement or expression.
 
         The CPU and wall clock times are printed, and the value of the

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -935,7 +935,7 @@ python-profiler package from non-free.""")
     )    
     @line_cell_magic
     def timeit(self, line='', cell=None):
-        """Time execution of a Python statement or expression, using the timeit module.
+        """Time execution of Python code, using the timeit module.
         
         This function can be used both as a line and cell magic:
 
@@ -974,6 +974,7 @@ python-profiler package from non-free.""")
         statement to import function or create variables. Generally, the bias
         does not matter as long as results from timeit.py are not mixed with
         those from %timeit.
+
         """
 
         # Parse args and collect into local vars for further use

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -935,10 +935,9 @@ python-profiler package from non-free.""")
     )    
     @line_cell_magic
     def timeit(self, line='', cell=None):
-        """Time execution of a Python statement or expression.
+        """Time execution of a Python statement or expression, using the timeit module.
         
-        Time execution of Python code using the timeit module.  This function
-        can be used both as a line and cell magic:
+        This function can be used both as a line and cell magic:
 
         - In line mode you can time a single-line statement (though multiple
           ones can be chained with using semicolons).
@@ -975,7 +974,6 @@ python-profiler package from non-free.""")
         statement to import function or create variables. Generally, the bias
         does not matter as long as results from timeit.py are not mixed with
         those from %timeit.
-
         """
 
         # Parse args and collect into local vars for further use
@@ -1054,6 +1052,7 @@ python-profiler package from non-free.""")
                 number *= 10
         all_runs = timer.repeat(repeat, number)
         best = min(all_runs) / number
+        # print output to stdout
         if not quiet:
             worst = max(all_runs) / number
             if worst_tuning:
@@ -1071,6 +1070,7 @@ python-profiler package from non-free.""")
                                                               _format_time(best, precision)))
             if tc > tc_min:
                 print("Compiler time: %.2f s" % tc)
+        # output can be returned either directly, or stored in the user namespace
         if output == False:
             return
         else:

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -555,11 +555,19 @@ def test_timeit_special_syntax():
 
 def test_timeit_return():
     """
-    test wether timeit -o return object
+    test whether timeit -o returns object
     """
 
-    res = _ip.run_line_magic('timeit','-n10 -r10 -o 1')
+    res = _ip.run_line_magic('timeit', '-n10 -r10 -o 1')
     assert(res is not None)
+
+def test_timeit_return_store():
+    """
+    test that returned values are correctly stored in user namespace
+    """
+    assert('__timeit_output' not in _ip.user_ns)
+    _ip.run_line_magic('timeit', '-n1 -r1 -O __timeit_output 1')
+    assert('__timeit_output' in _ip.user_ns)
 
 def test_timeit_quiet():
     """

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -536,7 +536,7 @@ def test_timeit_shlex():
 
 def test_timeit_arguments():
     "Test valid timeit arguments, should not cause SyntaxError (GH #1269)"
-    _ip.magic("timeit ('#')")
+    _ip.magic("timeit -r1 -n1 ('#')")
 
 
 def test_timeit_special_syntax():

--- a/IPython/utils/_process_common.py
+++ b/IPython/utils/_process_common.py
@@ -178,7 +178,8 @@ def arg_split(s, posix=False, strict=True):
     This is because we sometimes use arg_split to parse things other than
     command-line args.
     """
-
+    print("arg_split, posix %s strict %s" % (posix, strict))
+    print("arg_split arg:<%s>" % s)  # dbg
     # Unfortunately, python's shlex module is buggy with unicode input:
     # http://bugs.python.org/issue1170
     # At least encoding the input when it's unicode seems to help, but there


### PR DESCRIPTION
This is just so we can study whether argparse will do the trick for magics in general, or not.

The original intent of this PR, started with @minrk, was to add an output flag to the timeit magics.

I (mistakenly, as it turns out) thought argparse could handle a simple `-o` and `-o NAME` without ambiguity, which getopt definitely can't, so I bit the bullet and rewrote `%timeit` to use argparse.

In the process, it turned out that I couldn't get the argparse-based version to correctly pass the tests, due to some inconsistencies in parsing input with python code in it.  I then ran out of time debugging the problem.

If we can make this work, we can merge this PR, and then we can use the experience to consider whether we want to unify (at least for new/updated code) on argparse in our magics option handling code.

**Important note:** bugs aside, this PR isn't finished in that, after all, we can NOT have `-o` handle both the no-args and the named-arg case, since a case like `-o pass` would be incorrectly interpreted as assigning to a variable named `pass` (unless we resorted to crazy shenanigans in the parsing code).

So in the end, if we can sort the other bugs, we need to handle the named output with a _separate_ flag, say `-O`. I was going to do that but ran out of time with the parsing bugs.

Pinging @Carreau @takluyver from today's conversation.
