### PR TITLE
Add pprint support for containers from collections

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -816,6 +816,51 @@ _singleton_pprinters = dict.fromkeys(map(id, [None, True, False, Ellipsis,
                                       NotImplemented]), _repr_pprint)
 
 
+def _defaultdict_pprint(obj, p, cycle):
+    name = 'defaultdict'
+    p.begin_group(len(name) + 1, name + '(')
+    if cycle:
+        p.text('...')
+    else:
+        p.pretty(obj.default_factory)
+        p.text(',')
+        p.breakable()
+        p.pretty(dict(obj))
+    p.end_group(len(name) + 1, ')')
+
+def _ordereddict_pprint(obj, p, cycle):
+    name = 'OrderedDict'
+    p.begin_group(len(name) + 1, name + '(')
+    if cycle:
+        p.text('...')
+    elif len(obj):
+            p.pretty(list(obj.items()))
+    p.end_group(len(name) + 1, ')')
+
+def _deque_pprint(obj, p, cycle):
+    name = 'deque'
+    p.begin_group(len(name) + 1, name + '(')
+    if cycle:
+        p.text('...')
+    else:
+        p.pretty(list(obj))
+    p.end_group(len(name) + 1, ')')
+
+
+def _counter_pprint(obj, p, cycle):
+    name = 'Counter'
+    p.begin_group(len(name) + 1, name + '(')
+    if cycle:
+        p.text('...')
+    elif len(obj):
+            p.pretty(dict(obj))
+    p.end_group(len(name) + 1, ')')
+
+for_type_by_name('collections', 'defaultdict', _defaultdict_pprint)
+for_type_by_name('collections', 'OrderedDict', _ordereddict_pprint)
+for_type_by_name('collections', 'deque', _deque_pprint)
+for_type_by_name('collections', 'Counter', _counter_pprint)
+
 if __name__ == '__main__':
     from random import randrange
     class Foo(object):

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -34,14 +34,8 @@ pretty printer passed::
         def _repr_pretty_(self, p, cycle):
             ...
 
-Depending on the python version you want to support you have two
-possibilities.  The following list shows the python 2.5 version and the
-compatibility one.
-
-
-Here the example implementation of a `_repr_pretty_` method for a list
-subclass for python 2.5 and higher (python 2.5 requires the with statement
-__future__ import)::
+Here is an example implementation of a `_repr_pretty_` method for a list
+subclass::
 
     class MyList(list):
 
@@ -64,35 +58,15 @@ default space.  `p.pretty` prettyprints another object using the pretty print
 method.
 
 The first parameter to the `group` function specifies the extra indentation
-of the next line.  In this example the next item will either be not
-breaked (if the items are short enough) or aligned with the right edge of
-the opening bracked of `MyList`.
-
-If you want to support python 2.4 and lower you can use this code::
-
-    class MyList(list):
-
-        def _repr_pretty_(self, p, cycle):
-            if cycle:
-                p.text('MyList(...)')
-            else:
-                p.begin_group(8, 'MyList([')
-                for idx, item in enumerate(self):
-                    if idx:
-                        p.text(',')
-                        p.breakable()
-                    p.pretty(item)
-                p.end_group(8, '])')
+of the next line.  In this example the next item will either be on the same
+line (if the items are short enough) or aligned with the right edge of the
+opening bracket of `MyList`.
 
 If you just want to indent something you can use the group function
-without open / close parameters.  Under python 2.5 you can also use this
-code::
+without open / close parameters.  Yu can also use this code::
 
     with p.indent(2):
         ...
-
-Or under python2.4 you might want to modify ``p.indentation`` by hand but
-this is rather ugly.
 
 Inheritance diagram:
 
@@ -818,43 +792,39 @@ _singleton_pprinters = dict.fromkeys(map(id, [None, True, False, Ellipsis,
 
 def _defaultdict_pprint(obj, p, cycle):
     name = 'defaultdict'
-    p.begin_group(len(name) + 1, name + '(')
-    if cycle:
-        p.text('...')
-    else:
-        p.pretty(obj.default_factory)
-        p.text(',')
-        p.breakable()
-        p.pretty(dict(obj))
-    p.end_group(len(name) + 1, ')')
+    with p.group(len(name) + 1, name + '(', ')'):
+        if cycle:
+            p.text('...')
+        else:
+            p.pretty(obj.default_factory)
+            p.text(',')
+            p.breakable()
+            p.pretty(dict(obj))
 
 def _ordereddict_pprint(obj, p, cycle):
     name = 'OrderedDict'
-    p.begin_group(len(name) + 1, name + '(')
-    if cycle:
-        p.text('...')
-    elif len(obj):
-            p.pretty(list(obj.items()))
-    p.end_group(len(name) + 1, ')')
+    with p.group(len(name) + 1, name + '(', ')'):
+        if cycle:
+            p.text('...')
+        elif len(obj):
+                p.pretty(list(obj.items()))
 
 def _deque_pprint(obj, p, cycle):
     name = 'deque'
-    p.begin_group(len(name) + 1, name + '(')
-    if cycle:
-        p.text('...')
-    else:
-        p.pretty(list(obj))
-    p.end_group(len(name) + 1, ')')
+    with p.group(len(name) + 1, name + '(', ')'):
+        if cycle:
+            p.text('...')
+        else:
+            p.pretty(list(obj))
 
 
 def _counter_pprint(obj, p, cycle):
     name = 'Counter'
-    p.begin_group(len(name) + 1, name + '(')
-    if cycle:
-        p.text('...')
-    elif len(obj):
-            p.pretty(dict(obj))
-    p.end_group(len(name) + 1, ')')
+    with p.group(len(name) + 1, name + '(', ')'):
+        if cycle:
+            p.text('...')
+        elif len(obj):
+                p.pretty(dict(obj))
 
 for_type_by_name('collections', 'defaultdict', _defaultdict_pprint)
 for_type_by_name('collections', 'OrderedDict', _ordereddict_pprint)

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -807,7 +807,7 @@ def _ordereddict_pprint(obj, p, cycle):
         if cycle:
             p.text('...')
         elif len(obj):
-                p.pretty(list(obj.items()))
+            p.pretty(list(obj.items()))
 
 def _deque_pprint(obj, p, cycle):
     name = 'deque'
@@ -824,7 +824,7 @@ def _counter_pprint(obj, p, cycle):
         if cycle:
             p.text('...')
         elif len(obj):
-                p.pretty(dict(obj))
+            p.pretty(dict(obj))
 
 for_type_by_name('collections', 'defaultdict', _defaultdict_pprint)
 for_type_by_name('collections', 'OrderedDict', _ordereddict_pprint)

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -6,6 +6,8 @@
 
 from __future__ import print_function
 
+from collections import Counter, defaultdict, deque, OrderedDict
+
 import nose.tools as nt
 
 from IPython.lib import pretty
@@ -268,3 +270,89 @@ def test_basic_class():
 
     nt.assert_equal(output, '%s.MyObj' % __name__)
     nt.assert_true(type_pprint_wrapper.called)
+
+
+def test_collections_defaultdict():
+    # Create defaultdicts with cycles
+    a = defaultdict()
+    a.default_factory = a
+    b = defaultdict(list)
+    b['key'] = b
+
+    # Dictionary order cannot be relied on, test against single keys.
+    cases = [
+        (defaultdict(list), 'defaultdict(list, {})'),
+        (defaultdict(list, {'key': '-' * 50}),
+         "defaultdict(list,\n"
+         "            {'key': '--------------------------------------------------'})"),
+        (a, 'defaultdict(defaultdict(...), {})'),
+        (b, "defaultdict(list, {'key': defaultdict(...)})"),
+    ]
+    for obj, expected in cases:
+        nt.assert_equal(pretty.pretty(obj), expected)
+
+
+def test_collections_ordereddict():
+    # Create OrderedDict with cycle
+    a = OrderedDict()
+    a['key'] = a
+
+    cases = [
+        (OrderedDict(), 'OrderedDict()'),
+        (OrderedDict((i, i) for i in range(1000, 1010)),
+         'OrderedDict([(1000, 1000),\n'
+         '             (1001, 1001),\n'
+         '             (1002, 1002),\n'
+         '             (1003, 1003),\n'
+         '             (1004, 1004),\n'
+         '             (1005, 1005),\n'
+         '             (1006, 1006),\n'
+         '             (1007, 1007),\n'
+         '             (1008, 1008),\n'
+         '             (1009, 1009)])'),
+        (a, "OrderedDict([('key', OrderedDict(...))])"),
+    ]
+    for obj, expected in cases:
+        nt.assert_equal(pretty.pretty(obj), expected)
+
+
+def test_collections_deque():
+    # Create deque with cycle
+    a = deque()
+    a.append(a)
+
+    cases = [
+        (deque(), 'deque([])'),
+        (deque(i for i in range(1000, 1020)),
+         'deque([1000,\n'
+         '       1001,\n'
+         '       1002,\n'
+         '       1003,\n'
+         '       1004,\n'
+         '       1005,\n'
+         '       1006,\n'
+         '       1007,\n'
+         '       1008,\n'
+         '       1009,\n'
+         '       1010,\n'
+         '       1011,\n'
+         '       1012,\n'
+         '       1013,\n'
+         '       1014,\n'
+         '       1015,\n'
+         '       1016,\n'
+         '       1017,\n'
+         '       1018,\n'
+         '       1019])'),
+        (a, 'deque([deque(...)])'),
+    ]
+    for obj, expected in cases:
+        nt.assert_equal(pretty.pretty(obj), expected)
+
+def test_collections_counter():
+    cases = [
+        (Counter(), 'Counter()'),
+        (Counter(a=1), "Counter({'a': 1})"),
+    ]
+    for obj, expected in cases:
+        nt.assert_equal(pretty.pretty(obj), expected)


### PR DESCRIPTION
`for_type_by_name` used to keep compatiblity with Python 2.4 rather than catching ImportError.

`deque` is already imported in _pretty.py_, but uses same mechanism for consistency.

Tests have been added for each type.
