### PR TITLE
register default deprecation warning filter.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -665,16 +665,15 @@ class InteractiveShell(SingletonConfigurable):
         elif self.logstart:
             self.magic('logstart')
 
-    @staticmethod
-    def init_deprecation_warnings():
+    def init_deprecation_warnings(self):
         """
         register default filter for (pending) deprecation warning.
 
         This will allow deprecation warning of function used interactively to show
         warning to users, and still hide deprecation warning from libraries import.
         """
-        warnings.filterwarnings("default", category=DeprecationWarning, module="__main__")
-        warnings.filterwarnings("default", category=PendingDeprecationWarning, module="__main__")
+        warnings.filterwarnings("default", category=DeprecationWarning, module=self.user_ns.get("__name__"))
+        warnings.filterwarnings("default", category=PendingDeprecationWarning, module=self.user_ns.get("__name__"))
 
 
     def init_builtins(self):

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -25,6 +25,7 @@ import tempfile
 import traceback
 import types
 import subprocess
+import warnings
 from io import open as io_open
 
 from pickleshare import PickleShareDB
@@ -547,6 +548,7 @@ class InteractiveShell(SingletonConfigurable):
         self.init_pdb()
         self.init_extension_manager()
         self.init_payload()
+        self.init_deprecation_warnings()
         self.hooks.late_startup_hook()
         self.events.trigger('shell_initialized', self)
         atexit.register(self.atexit_operations)
@@ -662,6 +664,18 @@ class InteractiveShell(SingletonConfigurable):
             self.magic('logstart %s' % self.logfile)
         elif self.logstart:
             self.magic('logstart')
+
+    @staticmethod
+    def init_deprecation_warnings():
+        """
+        register default filter for (pending) deprecation warning.
+
+        This will allow deprecation warning of function used interactively to show
+        warning to users, and still hide deprecation warning from libraries import.
+        """
+        warnings.filterwarnings("default", category=DeprecationWarning, module="__main__")
+        warnings.filterwarnings("default", category=PendingDeprecationWarning, module="__main__")
+
 
     def init_builtins(self):
         # A single, static flag that we set to True.  Its presence indicates

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -667,14 +667,12 @@ class InteractiveShell(SingletonConfigurable):
 
     def init_deprecation_warnings(self):
         """
-        register default filter for (pending) deprecation warning.
+        register default filter for deprecation warning.
 
         This will allow deprecation warning of function used interactively to show
         warning to users, and still hide deprecation warning from libraries import.
         """
         warnings.filterwarnings("default", category=DeprecationWarning, module=self.user_ns.get("__name__"))
-        warnings.filterwarnings("default", category=PendingDeprecationWarning, module=self.user_ns.get("__name__"))
-
 
     def init_builtins(self):
         # A single, static flag that we set to True.  Its presence indicates

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -901,3 +901,20 @@ def test_warning_suppression():
             ip.run_cell("warnings.warn('asdf')")
     finally:
         ip.run_cell("del warnings")
+
+
+def test_deprecation_warning():
+    ip.run_cell("""
+import warnings
+def wrn():
+    warnings.warn(
+        "I AM  A WARNING",
+        DeprecationWarning
+    )
+        """)
+    try:
+        with tt.AssertPrints("I AM  A WARNING", channel="stderr"):
+            ip.run_cell("wrn()")
+    finally:
+        ip.run_cell("del warnings")
+        ip.run_cell("del wrn")

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -918,3 +918,27 @@ def wrn():
     finally:
         ip.run_cell("del warnings")
         ip.run_cell("del wrn")
+
+
+class TestImportNoDeprecate(tt.TempFileMixin):
+
+    def setup(self):
+        """Make a valid python temp file."""
+        self.mktmp("""
+import warnings
+def wrn():
+    warnings.warn(
+        "I AM  A WARNING",
+        DeprecationWarning
+    )
+""")
+
+    def test_no_dep(self):
+        """
+        No deprecation warning should be raised from imported functions
+        """
+        ip.run_cell("from {} import wrn".format(self.fname))
+
+        with tt.AssertNotPrints("I AM  A WARNING"):
+            ip.run_cell("wrn()")
+        ip.run_cell("del wrn")

--- a/docs/source/whatsnew/pr/deprecation_warning.rst
+++ b/docs/source/whatsnew/pr/deprecation_warning.rst
@@ -1,4 +1,4 @@
-Code raising ``DeprecationWarning`` or ``PendingDeprecationWarning`` that are
+Code raising ``DeprecationWarning`` 
 entered by the user in an interactive session will now display the warning by
 default. See :ghpull:`8480` an :ghissue:`8478`.
 

--- a/docs/source/whatsnew/pr/deprecation_warning.rst
+++ b/docs/source/whatsnew/pr/deprecation_warning.rst
@@ -1,0 +1,4 @@
+Code raising ``DeprecationWarning`` or ``PendingDeprecationWarning`` that are
+entered by the user in an interactive session will now display the warning by
+default. See :ghpull:`8480` an :ghissue:`8478`.
+


### PR DESCRIPTION
warn user if (s)he use a deprecated feature interactively.

Closes #8478

```
In [1]: %run -i foo
In [2]: foo()
foo.py:4: DeprecationWarning: using a non-integer number instead of an
    integer will result in an error in the future
    print('x'*np.float64(3.5))
xxx

In [3]: from foo import foo
In [4]: foo()
xxx
```

---

Not sure it is the exact right place though. 
