### PR TITLE
deprecate dreload auto-injection.

### DIFF
--- a/IPython/core/builtin_trap.py
+++ b/IPython/core/builtin_trap.py
@@ -56,9 +56,11 @@ class BuiltinTrap(Configurable):
         try:
             from IPython.lib import deepreload
             if self.shell.deep_reload:
-                self.auto_builtins['reload'] = deepreload.reload
+                from warnings import warn
+                warn("Automatically replacing builtin `reload` by `deepreload.reload` is deprecated, please import `reload` explicitly from `IPython.lib.deeprelaod", DeprecationWarning)
+                self.auto_builtins['reload'] = deepreload._dreload
             else:
-                self.auto_builtins['dreload']= deepreload.reload
+                self.auto_builtins['dreload']= deepreload._dreload
         except ImportError:
             pass
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -284,10 +284,12 @@ class InteractiveShell(SingletonConfigurable):
     debug = CBool(False, config=True)
     deep_reload = CBool(False, config=True, help=
         """
+        **Deprecated**
+
         Enable deep (recursive) reloading by default. IPython can use the
         deep_reload module which reloads changes in modules recursively (it
         replaces the reload() function, so you don't need to change anything to
-        use it). deep_reload() forces a full reload of modules whose code may
+        use it). `deep_reload` forces a full reload of modules whose code may
         have changed, which the default reload() function does not.  When
         deep_reload is off, IPython will use the normal reload(), but
         deep_reload will still be available as dreload().

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -71,7 +71,7 @@ addflag('color-info', 'InteractiveShell.color_info',
     "Disable using colors for info related things."
 )
 addflag('deep-reload', 'InteractiveShell.deep_reload',
-    """Enable deep (recursive) reloading by default. IPython can use the
+    """ **Deprecated** Enable deep (recursive) reloading by default. IPython can use the
     deep_reload module which reloads changes in modules recursively (it
     replaces the reload() function, so you don't need to change anything to
     use it). deep_reload() forces a full reload of modules whose code may

--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -327,7 +327,7 @@ except AttributeError:
     original_reload = imp.reload    # Python 3
 
 # Replacement for reload()
-def reload(module, exclude=['sys', 'os.path', builtin_mod_name, '__main__']):
+def reload(module, exclude=('sys', 'os.path', builtin_mod_name, '__main__')):
     """Recursively reload all modules used in the given module.  Optionally
     takes a list of modules to exclude from reloading.  The default exclude
     list contains sys, __main__, and __builtin__, to prevent, e.g., resetting
@@ -341,6 +341,19 @@ def reload(module, exclude=['sys', 'os.path', builtin_mod_name, '__main__']):
             return deep_reload_hook(module)
     finally:
         found_now = {}
+
+
+def _dreload(module, **kwargs):
+    """
+    **deprecated**
+
+    import reload explicitly from `IPython.lib.deepreload` to use it
+
+    """
+    warn("""
+injecting `dreload` in interactive namespace is deprecated, please import `reload` explicitly from `IPython.lib.deepreload`
+""", DeprecationWarning, stacklevel=2)
+    reload(module, **kwargs)
 
 # Uncomment the following to automatically activate deep reloading whenever
 # this module is imported

--- a/docs/source/config/intro.rst
+++ b/docs/source/config/intro.rst
@@ -70,7 +70,6 @@ Example config file
     c.InteractiveShell.autoindent = True
     c.InteractiveShell.colors = 'LightBG'
     c.InteractiveShell.confirm_exit = False
-    c.InteractiveShell.deep_reload = True
     c.InteractiveShell.editor = 'nano'
     c.InteractiveShell.xmode = 'Context'
 

--- a/docs/source/whatsnew/pr/no-dreload.rst
+++ b/docs/source/whatsnew/pr/no-dreload.rst
@@ -1,0 +1,4 @@
+The `--deep-reload` flag and the corresponding options to inject `dreload` or
+`reload` into the interactive namespace have been deprecated, and will be
+removed in future versions. You should now explicitly import `reload` from
+`IPython.lib.deepreload` to use it. 


### PR DESCRIPTION
1) dreload is the last piece that uses python3.4+ deprecated features.
2) I'll add that to the hackpad I want @fperez though on that. 
