### PR TITLE
DollarFormatter supresses `NameError`s, allowing other expressions to be substituted

### DIFF
--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -561,7 +561,10 @@ class FullEvalFormatter(Formatter):
 
                 # eval the contents of the field for the object
                 # to be formatted
-                obj = eval(field_name, kwargs)
+                try:
+                    obj = eval(field_name, kwargs)
+                except NameError:
+                    obj = field_name
 
                 # do any conversion on the resulting object
                 obj = self.convert_field(obj, conversion)

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -619,7 +619,7 @@ class DollarFormatter(FullEvalFormatter):
             # Re-yield the {foo} style pattern
             yield (txt + literal_txt[continue_from:], field_name, format_spec, conversion)
     def _vformat(self, format_string, args, kwargs, used_args, recursion_depth, supressExceptions=True):
-        return super(FullEvalFormatter,self)._vformat(format_string, args, kwargs, used_args, recursion_depth, supressExceptions)
+        return super(DollarFormatter,self)._vformat(format_string, args, kwargs, used_args, recursion_depth, supressExceptions)
 
 #-----------------------------------------------------------------------------
 # Utils to columnize a list of string

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -619,7 +619,7 @@ class DollarFormatter(FullEvalFormatter):
             # Re-yield the {foo} style pattern
             yield (txt + literal_txt[continue_from:], field_name, format_spec, conversion)
     def _vformat(self, format_string, args, kwargs, used_args, recursion_depth, supressExceptions=True):
-        return super(FullEvalFormatter,self)._vformat(self, format_string, args, kwargs, used_args, recursion_depth, supressExceptions)
+        return super(FullEvalFormatter,self)._vformat(format_string, args, kwargs, used_args, recursion_depth, supressExceptions)
 
 #-----------------------------------------------------------------------------
 # Utils to columnize a list of string

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -539,7 +539,7 @@ class FullEvalFormatter(Formatter):
     """
     # copied from Formatter._vformat with minor changes to allow eval
     # and replace the format_spec code with slicing
-    def _vformat(self, format_string, args, kwargs, used_args, recursion_depth):
+    def _vformat(self, format_string, args, kwargs, used_args, recursion_depth, supressExceptions=False):
         if recursion_depth < 0:
             raise ValueError('Max string recursion exceeded')
         result = []
@@ -564,7 +564,10 @@ class FullEvalFormatter(Formatter):
                 try:
                     obj = eval(field_name, kwargs)
                 except NameError:
-                    obj = field_name
+                    if supressExceptions:
+                       obj = field_name
+                    else:
+                       raise
 
                 # do any conversion on the resulting object
                 obj = self.convert_field(obj, conversion)
@@ -615,6 +618,8 @@ class DollarFormatter(FullEvalFormatter):
             
             # Re-yield the {foo} style pattern
             yield (txt + literal_txt[continue_from:], field_name, format_spec, conversion)
+    def _vformat(self, format_string, args, kwargs, used_args, recursion_depth, supressExceptions=True):
+        return super(FullEvalFormatter,self)._vformat(self, format_string, args, kwargs, used_args, recursion_depth, supressExceptions)
 
 #-----------------------------------------------------------------------------
 # Utils to columnize a list of string


### PR DESCRIPTION
Relates to issue #8492 

Suppress exceptoins in DollarFormatter, used for cell magic parsing. This allows one expression to raise a NameError (eg: misspelled variable name) while another expression gets substituted. Currently any exceptions prevent any substitutions.

The code that does the `eval` call is in FullEvalFormatter. I thought it best if that class raises all  exceptions by default, so I added a `supressExceptions` parameter, defaulting to `False`, to it's _vformat method. In the DollarFormatter, ~vformat is overridden (simply calling the super version), with this parameter defaulting to True. If suppressExceptions is True, NameErrors during eval() are caught and the evaluated expression is left unchanged in the formatted text.

It only catches NameErrors - perhaps it'd be better to catch all exceptions? 

It may also be a good idea for cell magics to emit a warning if an exception is raised during variable substitution. For that, we'd have to collect the exceptions here and somehow pass them on to the cell magics...
