### PR TITLE
add tightlist command

### DIFF
--- a/IPython/nbconvert/templates/latex/base.tplx
+++ b/IPython/nbconvert/templates/latex/base.tplx
@@ -64,6 +64,8 @@ This template does not define a docclass, the inheriting class must define this.
     
     % commands and environments needed by pandoc snippets
     % extracted from the output of `pandoc -s`
+    \providecommand{\tightlist}{%
+      \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
     \DefineVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\{\}}
     % Add ',fontsize=\small' for more characters per line
     \newenvironment{Shaded}{}{}


### PR DESCRIPTION
provided by pandoc 1.14, causing failure to export to pdf
