### PR TITLE
notebook: tree rename dialog - focus filename

### DIFF
--- a/IPython/html/static/tree/js/notebooklist.js
+++ b/IPython/html/static/tree/js/notebooklist.js
@@ -657,7 +657,12 @@ define([
                         return false;
                     }
                 });
-                input.focus().select();
+                input.focus();
+                if (input.val().indexOf(".") > 0) {
+                    input[0].setSelectionRange(0,input.val().indexOf("."));
+                } else {
+                    input.select();
+                }
             }
         });
     };


### PR DESCRIPTION
focus only the relevant part of the filename on rename dialog
this selects all prior to the first dot in the filename
