### PR TITLE
Remove old unused class

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -38,7 +38,7 @@ from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils import py3compat
 from IPython.utils.py3compat import builtin_mod, iteritems, PY3
 from IPython.utils.contexts import preserve_keys
-from IPython.utils.io import capture_output
+from IPython.utils.capture import capture_output
 from IPython.utils.ipstruct import Struct
 from IPython.utils.module_paths import find_mod
 from IPython.utils.path import get_py_filename, unquote_filename, shellglob

--- a/IPython/core/profiledir.py
+++ b/IPython/core/profiledir.py
@@ -226,8 +226,7 @@ class ProfileDir(LoggingConfigurable):
         Parameters
         ----------
         profile_dir : unicode or str
-            The path of the profile directory.  This is expanded using
-            :func:`IPython.utils.genutils.expand_path`.
+            The path of the profile directory.
         """
         profile_dir = expand_path(profile_dir)
         if not os.path.isdir(profile_dir):

--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -10,14 +10,9 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 
-import codecs
-from contextlib import contextmanager
-import io
 import os
-import shutil
 import sys
 import tempfile
-import warnings
 from warnings import warn
 from .capture import CapturedIO, capture_output
 from .py3compat import string_types, input, PY3
@@ -81,23 +76,6 @@ devnull = open(os.devnull, 'w')
 stdin = IOStream(sys.stdin, fallback=devnull)
 stdout = IOStream(sys.stdout, fallback=devnull)
 stderr = IOStream(sys.stderr, fallback=devnull)
-
-class IOTerm:
-    """ Term holds the file or file-like objects for handling I/O operations.
-
-    These are normally just sys.stdin, sys.stdout and sys.stderr but for
-    Windows they can can replaced to allow editing the strings before they are
-    displayed."""
-
-    # In the future, having IPython channel all its I/O operations through
-    # this class will make it easier to embed it into other environments which
-    # are not a normal terminal (such as a GUI-based shell)
-    def __init__(self, stdin=None, stdout=None, stderr=None):
-        mymodule = sys.modules[__name__]
-        self.stdin  = IOStream(stdin, mymodule.stdin)
-        self.stdout = IOStream(stdout, mymodule.stdout)
-        self.stderr = IOStream(stderr, mymodule.stderr)
-
 
 class Tee(object):
     """A class to duplicate an output stream to stdout/err.


### PR DESCRIPTION
It seem unused in our codebase. The only place where it is used in
github import from genutils which don't exist in IPython.

Closes ipython/ipython#14  

---

Yes it is our oldest open github issue. Next one is 17 :-) 
