### PR TITLE
Don't allow PYTHONEXECUTABLE env to be inherited by kernel process

### DIFF
--- a/IPython/kernel/manager.py
+++ b/IPython/kernel/manager.py
@@ -228,12 +228,12 @@ class KernelManager(ConnectionFileMixin):
         # build the Popen cmd
         extra_arguments = kw.pop('extra_arguments', [])
         kernel_cmd = self.format_kernel_cmd(extra_arguments=extra_arguments)
-        if self.kernel_cmd:
+        env = os.environ.copy()
+        # Don't allow PYTHONEXECUTABLE to be passed to kernel process.
+        # If set, it can bork all the things.
+        env.pop('PYTHONEXECUTABLE', None)
+        if not self.kernel_cmd:
             # If kernel_cmd has been set manually, don't refer to a kernel spec
-            env = os.environ
-        else:
-            # Environment variables from kernel spec are added to os.environ
-            env = os.environ.copy()
             env.update(self.kernel_spec.env or {})
         # launch the kernel subprocess
         self.kernel = self._launch_kernel(kernel_cmd, env=env,


### PR DESCRIPTION
it can break Python.

backport of jupyter/jupyter_client#28
