### PR TITLE
Don't deep reload collections module on Python 3

### DIFF
--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -336,7 +336,7 @@ except AttributeError:
     original_reload = imp.reload    # Python 3
 
 # Replacement for reload()
-def reload(module, exclude=('sys', 'os.path', builtin_mod_name, '__main__')):
+def reload(module, exclude=('sys', builtin_mod_name, '__main__')):
     """Recursively reload all modules used in the given module.  Optionally
     takes a list of modules to exclude from reloading.  The default exclude
     list contains sys, __main__, and __builtin__, to prevent, e.g., resetting

--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -167,8 +167,15 @@ def load_next(mod, altmod, name, buf):
 
 stdlib_dir = os.path.dirname(os.__file__)
 
-def is_stdlib(mod):
+def is_stdlib(fullname):
+    top_level = fullname.split('.')[0]
+    if top_level not in sys.modules:
+        return False
+    mod = sys.modules[top_level]
     path = getattr(mod, '__file__', '')
+    if os.path.splitext(os.path.basename(path))[0] == '__init__':
+        # Package - use the directory path
+        path = os.path.dirname(path)
     return os.path.dirname(path) == stdlib_dir
 
 # Need to keep track of what we've already reloaded to prevent cyclic evil
@@ -183,7 +190,7 @@ def import_submodule(mod, subname, fullname):
     global found_now
     if fullname in found_now and fullname in sys.modules:
         m = sys.modules[fullname]
-    elif fullname in sys.modules and is_stdlib(sys.modules[fullname]):
+    elif is_stdlib(fullname):
         m = sys.modules[fullname]
     else:
         print('Reloading', fullname)

--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -173,6 +173,7 @@ def is_stdlib(fullname):
         return False
     mod = sys.modules[top_level]
     path = getattr(mod, '__file__', '')
+    print('stdlib check {}: {}'.format())
     if os.path.splitext(os.path.basename(path))[0] == '__init__':
         # Package - use the directory path
         path = os.path.dirname(path)
@@ -353,6 +354,7 @@ def reload(module, exclude=('sys', builtin_mod_name, '__main__')):
     for i in exclude:
         found_now[i] = 1
     try:
+        print('os is in:', stdlib_dir)
         with replace_import_hook(deep_import_hook):
             return deep_reload_hook(module)
     finally:

--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -165,7 +165,7 @@ def load_next(mod, altmod, name, buf):
 
     return result, next, buf
 
-stdlib_dir = os.path.realpath(os.path.dirname(os.__file__))
+stdlib_dir = os.path.dirname(os.path.realpath(os.__file__))
 
 def is_stdlib(fullname):
     top_level = fullname.split('.')[0]
@@ -177,7 +177,7 @@ def is_stdlib(fullname):
     if os.path.splitext(os.path.basename(path))[0] == '__init__':
         # Package - use the directory path
         path = os.path.dirname(path)
-    return os.path.realpath(os.path.dirname(path)) == stdlib_dir
+    return os.path.dirname(os.path.realpath(path)) == stdlib_dir
 
 # Need to keep track of what we've already reloaded to prevent cyclic evil
 found_now = {}

--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -35,7 +35,7 @@ from __future__ import print_function
 
 from contextlib import contextmanager
 import imp
-import os.path
+import os
 import sys
 
 from types import ModuleType
@@ -165,7 +165,7 @@ def load_next(mod, altmod, name, buf):
 
     return result, next, buf
 
-stdlib_dir = os.path.dirname(imp.__file__)
+stdlib_dir = os.path.dirname(os.__file__)
 
 def is_stdlib(mod):
     path = getattr(mod, '__file__', '')

--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -35,6 +35,7 @@ from __future__ import print_function
 
 from contextlib import contextmanager
 import imp
+import os.path
 import sys
 
 from types import ModuleType

--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -164,6 +164,12 @@ def load_next(mod, altmod, name, buf):
 
     return result, next, buf
 
+stdlib_dir = os.path.dirname(imp.__file__)
+
+def is_stdlib(mod):
+    path = getattr(mod, '__file__', '')
+    return os.path.dirname(path) == stdlib_dir
+
 # Need to keep track of what we've already reloaded to prevent cyclic evil
 found_now = {}
 
@@ -175,6 +181,8 @@ def import_submodule(mod, subname, fullname):
 
     global found_now
     if fullname in found_now and fullname in sys.modules:
+        m = sys.modules[fullname]
+    elif fullname in sys.modules and is_stdlib(sys.modules[fullname]):
         m = sys.modules[fullname]
     else:
         print('Reloading', fullname)

--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -173,7 +173,7 @@ def is_stdlib(fullname):
         return False
     mod = sys.modules[top_level]
     path = getattr(mod, '__file__', '')
-    print('stdlib check {}: {}'.format())
+    print('stdlib check {}: {}'.format(fullname, path))
     if os.path.splitext(os.path.basename(path))[0] == '__init__':
         # Package - use the directory path
         path = os.path.dirname(path)

--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -165,7 +165,7 @@ def load_next(mod, altmod, name, buf):
 
     return result, next, buf
 
-stdlib_dir = os.path.dirname(os.__file__)
+stdlib_dir = os.path.realpath(os.path.dirname(os.__file__))
 
 def is_stdlib(fullname):
     top_level = fullname.split('.')[0]
@@ -177,7 +177,7 @@ def is_stdlib(fullname):
     if os.path.splitext(os.path.basename(path))[0] == '__init__':
         # Package - use the directory path
         path = os.path.dirname(path)
-    return os.path.dirname(path) == stdlib_dir
+    return os.path.realpath(os.path.dirname(path)) == stdlib_dir
 
 # Need to keep track of what we've already reloaded to prevent cyclic evil
 found_now = {}

--- a/IPython/lib/tests/test_deepreload.py
+++ b/IPython/lib/tests/test_deepreload.py
@@ -33,8 +33,8 @@ def test_deepreload_numpy():
     # `collections` builtin shall not be reloaded to avoid failure
     # of lib.pretty collections related pretty printing.
     # of course this make nose crash on Py3 because of Py 2.3 compat...
-    if not PY3:
-        exclude.append('collections')
+    #if not PY3:
+    exclude.append('collections')
 
     dreload(numpy, exclude=exclude)
 

--- a/IPython/lib/tests/test_deepreload.py
+++ b/IPython/lib/tests/test_deepreload.py
@@ -25,16 +25,10 @@ def test_deepreload_numpy():
     import numpy
     exclude = [
         # Standard exclusions:
-        'sys', 'os.path', builtin_mod_name, '__main__',
+        'sys',  builtin_mod_name, '__main__',
         # Test-related exclusions:
-        'unittest', 'UserDict', '_collections_abc', 'tokenize'
+        '_collections_abc',
         ]
-
-    # `collections` builtin shall not be reloaded to avoid failure
-    # of lib.pretty collections related pretty printing.
-    # of course this make nose crash on Py3 because of Py 2.3 compat...
-    #if not PY3:
-    exclude.append('collections')
 
     dreload(numpy, exclude=exclude)
 

--- a/IPython/lib/tests/test_deepreload.py
+++ b/IPython/lib/tests/test_deepreload.py
@@ -28,6 +28,7 @@ def test_deepreload_numpy():
         'sys',  builtin_mod_name, '__main__',
         # Test-related exclusions:
         '_collections_abc',
+        'unittest', # Should be caught by stdlib excludes, but Travis is bizarre
         ]
 
     dreload(numpy, exclude=exclude)


### PR DESCRIPTION
@Carreau says this didn't work before, but it works on my machine, so I want to try debugging it on Travis
