### PR TITLE
Fix qtconsole shims

### DIFF
--- a/IPython/qt.py
+++ b/IPython/qt.py
@@ -15,6 +15,10 @@ from IPython.utils.shimmodule import ShimModule
 # Unconditionally insert the shim into sys.modules so that further import calls
 # trigger the custom attribute access above
 
-sys.modules['IPython.qt'] = _qt = ShimModule(src='IPython.qt', mirror='qtconsole')
-sys.modules['IPython.qt.console'] = _console = ShimModule(src='IPython.qt.console', mirror='qtconsole')
+_console = sys.modules['IPython.qt.console'] = ShimModule(
+    src='IPython.qt.console', mirror='qtconsole')
+
+_qt = ShimModule(src='IPython.qt', mirror='qtconsole')
+
 _qt.console = _console
+sys.modules['IPython.qt'] = _qt


### PR DESCRIPTION
This fixes the qtconsole shim. It is required for Spyder to work with IPython 4.0.
