### PR TITLE
reorder imports in IPython.kernel for backward-compat

### DIFF
--- a/IPython/kernel/connect.py
+++ b/IPython/kernel/connect.py
@@ -1,2 +1,2 @@
-from ipykernel.connect import *
 from jupyter_client.connect import *
+from ipykernel.connect import *


### PR DESCRIPTION
jupyter_client provides a new implementation of find_connection_file. The old (profile-aware) implementation comes from ipykernel now.

cc @SylvainCorlay
