### PR TITLE
Fix exception in cleanup_ipc_files for zmq

### DIFF
--- a/IPython/kernel/connect.py
+++ b/IPython/kernel/connect.py
@@ -472,7 +472,12 @@ class ConnectionFileMixin(LoggingConfigurable):
         """Cleanup ipc files if we wrote them."""
         if self.transport != 'ipc':
             return
-        for port in self.ports:
+        # handle self.ports as a list [port1, ...] or dictionary
+        # {label1: port1, ...}
+        ports = self.ports
+        if isinstance(ports, dict):
+            ports = ports.values()
+        for port in ports:
             ipcfile = "%s-%i" % (self.ip, port)
             try:
                 os.remove(ipcfile)


### PR DESCRIPTION
This fixes an exception in ConnectionFileMixin's cleanup_ipc_files method by supporting self.ports as a dict as well as a list.

The zmq module uses a dict for self.ports at [kernelapp.py#L271](https://github.com/ipython/ipython/blob/3.x/IPython/kernel/zmq/kernelapp.py#L271). ConnectionFileMixin expects a list, causing an exception in cleanup_ipc_files() whenever the kernel is shut down, as it uses the dict's key instead of the value (the port number).

```
ipcfile = "%s-%i" % (self.ip, port)
TypeError: %d format: a number is required, not str
```
