### PR TITLE
fix paths in cleanup_ipc_files

### DIFF
--- a/IPython/kernel/connect.py
+++ b/IPython/kernel/connect.py
@@ -472,7 +472,7 @@ class ConnectionFileMixin(LoggingConfigurable):
         """Cleanup ipc files if we wrote them."""
         if self.transport != 'ipc':
             return
-        for port in self.ports:
+        for port in self.ports.values():
             ipcfile = "%s-%i" % (self.ip, port)
             try:
                 os.remove(ipcfile)


### PR DESCRIPTION
self.ports is a dict, not a list

closes #8538
