### PR TITLE
Typo in sympyprinting `as move`-> `has moved`

### DIFF
--- a/IPython/extensions/sympyprinting.py
+++ b/IPython/extensions/sympyprinting.py
@@ -28,5 +28,5 @@ maintained here for backwards compatablitiy with old SymPy versions.
 import warnings
 
 def load_ipython_extension(ip):
-    warnings.warn("The sympyprinting extension as move to `sympy`, "
+    warnings.warn("The sympyprinting extension has moved to `sympy`, "
         "use `from sympy import init_printing; init_printing()`")


### PR DESCRIPTION
---

Note to self, don't fix PRs when too tired. 
