### PR TITLE
fix `pdb` NameError

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import, print_function
 import __future__
 import abc
 import ast
+import pdb
 import atexit
 import functools
 import os
@@ -2179,6 +2180,7 @@ class InteractiveShell(SingletonConfigurable):
         else:
             self.Completer.namespace = self.user_ns
             self.Completer.global_namespace = self.user_global_ns
+        self.Completer.namespace.update({'pdb': pdb})
 
     #-------------------------------------------------------------------------
     # Things related to magics


### PR DESCRIPTION
I often see `*** NameError: name 'pdb' is not defined` when i debuging.

```
Python 2.7.5 (default, Mar  9 2014, 22:15:05) 
Type "copyright", "credits" or "license" for more information.

IPython 4.0.0-dev -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: 1/0
---------------------------------------------------------------------------
ZeroDivisionError                         Traceback (most recent call last)
<ipython-input-1-05c9758a9c21> in <module>()
----> 1 1/0

ZeroDivisionError: integer division or modulo by zero

In [2]: %debug
*** NameError: name 'pdb' is not defined
> <ipython-input-1-05c9758a9c21>(1)<module>()
----> 1 1/0

ipdb> 
*** NameError: name 'pdb' is not defined
ipdb> 

In [3]: 
Do you really want to exit ([y]/n)? y
```
