### PR TITLE
Make sure outputs are cleared immediately before execution, rather than immediately after

### DIFF
--- a/IPython/nbconvert/exporters/exporter.py
+++ b/IPython/nbconvert/exporters/exporter.py
@@ -66,8 +66,8 @@ class Exporter(LoggingConfigurable):
     _preprocessors = List()
 
     default_preprocessors = List([
-                                  'IPython.nbconvert.preprocessors.ExecutePreprocessor',
                                   'IPython.nbconvert.preprocessors.ClearOutputPreprocessor',
+                                  'IPython.nbconvert.preprocessors.ExecutePreprocessor',
                                   'IPython.nbconvert.preprocessors.coalesce_streams',
                                   'IPython.nbconvert.preprocessors.SVG2PDFPreprocessor',
                                   'IPython.nbconvert.preprocessors.CSSHTMLHeaderPreprocessor',


### PR DESCRIPTION
Backport change from https://github.com/jupyter/nbconvert/pull/53 .
