### PR TITLE
Deprecate and undocument install_ext

### DIFF
--- a/IPython/core/magics/extension.py
+++ b/IPython/core/magics/extension.py
@@ -19,6 +19,7 @@ import os
 # Our own packages
 from IPython.core.error import UsageError
 from IPython.core.magic import Magics, magics_class, line_magic
+from  warnings import warn
 
 #-----------------------------------------------------------------------------
 # Magic implementation classes
@@ -42,6 +43,8 @@ class ExtensionMagics(Magics):
           -n filename : Specify a name for the file, rather than taking it from
                         the URL.
         """
+        warn("%install_ext` is deprecated, please distribute your extension(s)"
+             "as a python packages.", UserWarning)
         opts, args = self.parse_options(parameter_s, 'n:')
         try:
             filename = self.shell.extension_manager.install_extension(args,

--- a/docs/source/config/extensions/index.rst
+++ b/docs/source/config/extensions/index.rst
@@ -19,9 +19,6 @@ the `Framework :: IPython tag <https://pypi.python.org/pypi?:action=browse&c=586
 on PyPI.
 
 Extensions on PyPI can be installed using ``pip``, like any other Python package.
-Other simple extensions can be installed with the ``%install_ext`` magic. The
-latter does no validation, so be careful using it on untrusted networks like
-public wifi.
 
 Using extensions
 ================


### PR DESCRIPTION
It seem to me that Python packaging has come up to a point where
actually telling peoples they can install python extensions not using
package manager is unreasonable.

Recent extension even recommend using `install_ext` as **the way** to
install things, which is unsecure, confusing, and there is no update
mechanisme, nor version conflict resolution.

---

As I think this might be historical I would like @fperez  input. 
