### PR TITLE
add ShimWarning for shimmed imports

### DIFF
--- a/IPython/config.py
+++ b/IPython/config.py
@@ -7,10 +7,11 @@ Shim to maintain backwards compatibility with old IPython.config imports.
 import sys
 from warnings import warn
 
-warn("The `IPython.config` package has been deprecated. "
-     "You should import from traitlets.config instead.")
+from IPython.utils.shimmodule import ShimModule, ShimWarning
 
-from IPython.utils.shimmodule import ShimModule
+warn("The `IPython.config` package has been deprecated. "
+     "You should import from traitlets.config instead.", ShimWarning)
+
 
 # Unconditionally insert the shim into sys.modules so that further import calls
 # trigger the custom attribute access above

--- a/IPython/frontend.py
+++ b/IPython/frontend.py
@@ -15,10 +15,10 @@ working, though a warning will be printed.
 import sys
 from warnings import warn
 
-warn("The top-level `frontend` package has been deprecated. "
-     "All its subpackages have been moved to the top `IPython` level.")
+from IPython.utils.shimmodule import ShimModule, ShimWarning
 
-from IPython.utils.shimmodule import ShimModule
+warn("The top-level `frontend` package has been deprecated. "
+     "All its subpackages have been moved to the top `IPython` level.", ShimWarning)
 
 # Unconditionally insert the shim into sys.modules so that further import calls
 # trigger the custom attribute access above

--- a/IPython/html.py
+++ b/IPython/html.py
@@ -7,11 +7,11 @@ Shim to maintain backwards compatibility with old IPython.html imports.
 import sys
 from warnings import warn
 
+from IPython.utils.shimmodule import ShimModule, ShimWarning
+
 warn("The `IPython.html` package has been deprecated. "
      "You should import from `notebook` instead. "
-     "`IPython.html.widgets` has moved to `ipywidgets`.")
-
-from IPython.utils.shimmodule import ShimModule
+     "`IPython.html.widgets` has moved to `ipywidgets`.", ShimWarning)
 
 _widgets = sys.modules['IPython.html.widgets'] = ShimModule(
     src='IPython.html.widgets', mirror='ipywidgets')

--- a/IPython/kernel/__init__.py
+++ b/IPython/kernel/__init__.py
@@ -7,11 +7,11 @@ Shim to maintain backwards compatibility with old IPython.kernel imports.
 import sys
 from warnings import warn
 
+from IPython.utils.shimmodule import ShimModule, ShimWarning
+
 warn("The `IPython.kernel` package has been deprecated. "
-     "You should import from ipykernel or jupyter_client instead.")
+     "You should import from ipykernel or jupyter_client instead.", ShimWarning)
 
-
-from IPython.utils.shimmodule import ShimModule
 
 # zmq subdir is gone
 sys.modules['IPython.kernel.zmq.session'] = ShimModule(

--- a/IPython/nbconvert.py
+++ b/IPython/nbconvert.py
@@ -7,10 +7,10 @@ Shim to maintain backwards compatibility with old IPython.nbconvert imports.
 import sys
 from warnings import warn
 
-warn("The `IPython.nbconvert` package has been deprecated. "
-     "You should import from ipython_nbconvert instead.")
+from IPython.utils.shimmodule import ShimModule, ShimWarning
 
-from IPython.utils.shimmodule import ShimModule
+warn("The `IPython.nbconvert` package has been deprecated. "
+     "You should import from ipython_nbconvert instead.", ShimWarning)
 
 # Unconditionally insert the shim into sys.modules so that further import calls
 # trigger the custom attribute access above

--- a/IPython/nbformat.py
+++ b/IPython/nbformat.py
@@ -7,10 +7,10 @@ Shim to maintain backwards compatibility with old IPython.nbformat imports.
 import sys
 from warnings import warn
 
-warn("The `IPython.nbformat` package has been deprecated. "
-     "You should import from nbformat instead.")
+from IPython.utils.shimmodule import ShimModule, ShimWarning
 
-from IPython.utils.shimmodule import ShimModule
+warn("The `IPython.nbformat` package has been deprecated. "
+     "You should import from nbformat instead.", ShimWarning)
 
 # Unconditionally insert the shim into sys.modules so that further import calls
 # trigger the custom attribute access above

--- a/IPython/parallel.py
+++ b/IPython/parallel.py
@@ -7,10 +7,10 @@ Shim to maintain backwards compatibility with old IPython.parallel imports.
 import sys
 from warnings import warn
 
-warn("The `IPython.parallel` package has been deprecated. "
-     "You should import from ipyparallel instead.")
+from IPython.utils.shimmodule import ShimModule, ShimWarning
 
-from IPython.utils.shimmodule import ShimModule
+warn("The `IPython.parallel` package has been deprecated. "
+     "You should import from ipyparallel instead.", ShimWarning)
 
 # Unconditionally insert the shim into sys.modules so that further import calls
 # trigger the custom attribute access above

--- a/IPython/qt.py
+++ b/IPython/qt.py
@@ -7,10 +7,10 @@ Shim to maintain backwards compatibility with old IPython.qt imports.
 import sys
 from warnings import warn
 
-warn("The `IPython.qt` package has been deprecated. "
-     "You should import from qtconsole instead.")
+from IPython.utils.shimmodule import ShimModule, ShimWarning
 
-from IPython.utils.shimmodule import ShimModule
+warn("The `IPython.qt` package has been deprecated. "
+     "You should import from qtconsole instead.", ShimWarning)
 
 # Unconditionally insert the shim into sys.modules so that further import calls
 # trigger the custom attribute access above

--- a/IPython/terminal/console.py
+++ b/IPython/terminal/console.py
@@ -4,15 +4,13 @@ Shim to maintain backwards compatibility with old IPython.terminal.console impor
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
-
 import sys
 from warnings import warn
 
-warn("The `IPython.terminal.console` package has been deprecated. "
-     "You should import from jupyter_console instead.")
+from IPython.utils.shimmodule import ShimModule, ShimWarning
 
-from IPython.utils.shimmodule import ShimModule
+warn("The `IPython.terminal.console` package has been deprecated. "
+     "You should import from jupyter_console instead.", ShimWarning)
 
 # Unconditionally insert the shim into sys.modules so that further import calls
 # trigger the custom attribute access above

--- a/IPython/utils/shimmodule.py
+++ b/IPython/utils/shimmodule.py
@@ -8,6 +8,8 @@ import types
 
 from .importstring import import_item
 
+class ShimWarning(Warning):
+    """A warning to show when a module has moved, and a shim is in its place."""
 
 class ShimImporter(object):
     """Import hook for a shim.

--- a/IPython/utils/tests/test_shimmodule.py
+++ b/IPython/utils/tests/test_shimmodule.py
@@ -1,0 +1,15 @@
+import sys
+import warnings
+
+import nose.tools as nt
+
+from IPython.utils.capture import capture_output
+from IPython.utils.shimmodule import ShimWarning
+
+def test_shim_warning():
+    sys.modules.pop('IPython.config', None)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        import IPython.config
+    assert len(w) == 1
+    assert issubclass(w[-1].category, ShimWarning)


### PR DESCRIPTION
makes it easier to catch/suppress warnings about shim imports

still shown by default (not a DeprecationWarning)
