### PR TITLE
added absolute_import to utils.text module + test

### DIFF
--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -180,7 +180,7 @@ def test_LSString():
     lss = text.LSString("abc\ndef")
     nt.assert_equal(lss.l, ['abc', 'def'])
     nt.assert_equal(lss.s, 'abc def')
-    nt.assert_in("path", sys.modules)
+    nt.assert_isinstance(lss.p[0], path.path)
 
 def test_SList():
     sl = text.SList(['a 11', 'b 1', 'a 2'])

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -188,3 +188,6 @@ def test_SList():
     nt.assert_equal(sl.grep(lambda x: x.startswith('a')), text.SList(['a 11', 'a 2']))
     nt.assert_equal(sl.fields(0), text.SList(['a', 'b', 'a']))
     nt.assert_equal(sl.sort(field=1, nums=True), text.SList(['b 1', 'a 2', 'a 11']))
+
+def test_non_local_path_import():
+    nt.assert_in("path", sys.modules)

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -80,13 +80,13 @@ def eval_formatter_check(f):
     nt.assert_equal(s, ns['stuff'])
     s = f.format("{stuff!r}", **ns)
     nt.assert_equal(s, repr(ns['stuff']))
-    
+
     # Check with unicode:
     s = f.format("{u}", **ns)
     nt.assert_equal(s, ns['u'])
     # This decodes in a platform dependent manner, but it shouldn't error out
     s = f.format("{b}", **ns)
-        
+
     nt.assert_raises(NameError, f.format, '{dne}', **ns)
 
 def eval_formatter_slicing_check(f):
@@ -97,18 +97,18 @@ def eval_formatter_slicing_check(f):
     nt.assert_equal(s, " ['there', 'hello'] ")
     s = f.format("{stuff[::2]}", **ns)
     nt.assert_equal(s, ns['stuff'][::2])
-    
+
     nt.assert_raises(SyntaxError, f.format, "{n:x}", **ns)
 
 def eval_formatter_no_slicing_check(f):
     ns = dict(n=12, pi=math.pi, stuff='hello there', os=os)
-    
+
     s = f.format('{n:x} {pi**2:+f}', **ns)
     nt.assert_equal(s, "c +9.869604")
-    
+
     s = f.format('{stuff[slice(1,4)]}', **ns)
     nt.assert_equal(s, 'ell')
-    
+
     if sys.version_info >= (3, 4):
         # String formatting has changed in Python 3.4, so this now works.
         s = f.format("{a[:]}", a=[1, 2])
@@ -130,7 +130,7 @@ def test_dollar_formatter():
     f = text.DollarFormatter()
     eval_formatter_check(f)
     eval_formatter_slicing_check(f)
-    
+
     ns = dict(n=12, pi=math.pi, stuff='hello there', os=os)
     s = f.format("$n", **ns)
     nt.assert_equal(s, "12")
@@ -161,12 +161,12 @@ def test_strip_email():
     src = """\
         >> >>> def f(x):
         >> ...   return x+1
-        >> ... 
+        >> ...
         >> >>> zz = f(2.5)"""
     cln = """\
 >>> def f(x):
 ...   return x+1
-... 
+...
 >>> zz = f(2.5)"""
     nt.assert_equal(text.strip_email_quotes(src), cln)
 
@@ -188,3 +188,6 @@ def test_SList():
     nt.assert_equal(sl.grep(lambda x: x.startswith('a')), text.SList(['a 11', 'a 2']))
     nt.assert_equal(sl.fields(0), text.SList(['a', 'b', 'a']))
     nt.assert_equal(sl.sort(field=1, nums=True), text.SList(['b 1', 'a 2', 'a 11']))
+
+def test_non_local_path_import():
+    nt.assert_in("path", sys.modules)

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -180,6 +180,7 @@ def test_LSString():
     lss = text.LSString("abc\ndef")
     nt.assert_equal(lss.l, ['abc', 'def'])
     nt.assert_equal(lss.s, 'abc def')
+    nt.assert_in("path", sys.modules)
 
 def test_SList():
     sl = text.SList(['a 11', 'b 1', 'a 2'])
@@ -188,6 +189,3 @@ def test_SList():
     nt.assert_equal(sl.grep(lambda x: x.startswith('a')), text.SList(['a 11', 'a 2']))
     nt.assert_equal(sl.fields(0), text.SList(['a', 'b', 'a']))
     nt.assert_equal(sl.sort(field=1, nums=True), text.SList(['b 1', 'a 2', 'a 11']))
-
-def test_non_local_path_import():
-    nt.assert_in("path", sys.modules)

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -180,6 +180,7 @@ def test_LSString():
     lss = text.LSString("abc\ndef")
     nt.assert_equal(lss.l, ['abc', 'def'])
     nt.assert_equal(lss.s, 'abc def')
+    lss = text.LSString(os.getcwd())
     nt.assert_is_instance(lss.p[0], path.path)
 
 def test_SList():

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -80,13 +80,13 @@ def eval_formatter_check(f):
     nt.assert_equal(s, ns['stuff'])
     s = f.format("{stuff!r}", **ns)
     nt.assert_equal(s, repr(ns['stuff']))
-
+    
     # Check with unicode:
     s = f.format("{u}", **ns)
     nt.assert_equal(s, ns['u'])
     # This decodes in a platform dependent manner, but it shouldn't error out
     s = f.format("{b}", **ns)
-
+        
     nt.assert_raises(NameError, f.format, '{dne}', **ns)
 
 def eval_formatter_slicing_check(f):
@@ -97,18 +97,18 @@ def eval_formatter_slicing_check(f):
     nt.assert_equal(s, " ['there', 'hello'] ")
     s = f.format("{stuff[::2]}", **ns)
     nt.assert_equal(s, ns['stuff'][::2])
-
+    
     nt.assert_raises(SyntaxError, f.format, "{n:x}", **ns)
 
 def eval_formatter_no_slicing_check(f):
     ns = dict(n=12, pi=math.pi, stuff='hello there', os=os)
-
+    
     s = f.format('{n:x} {pi**2:+f}', **ns)
     nt.assert_equal(s, "c +9.869604")
-
+    
     s = f.format('{stuff[slice(1,4)]}', **ns)
     nt.assert_equal(s, 'ell')
-
+    
     if sys.version_info >= (3, 4):
         # String formatting has changed in Python 3.4, so this now works.
         s = f.format("{a[:]}", a=[1, 2])
@@ -130,7 +130,7 @@ def test_dollar_formatter():
     f = text.DollarFormatter()
     eval_formatter_check(f)
     eval_formatter_slicing_check(f)
-
+    
     ns = dict(n=12, pi=math.pi, stuff='hello there', os=os)
     s = f.format("$n", **ns)
     nt.assert_equal(s, "12")
@@ -161,12 +161,12 @@ def test_strip_email():
     src = """\
         >> >>> def f(x):
         >> ...   return x+1
-        >> ...
+        >> ... 
         >> >>> zz = f(2.5)"""
     cln = """\
 >>> def f(x):
 ...   return x+1
-...
+... 
 >>> zz = f(2.5)"""
     nt.assert_equal(text.strip_email_quotes(src), cln)
 
@@ -188,6 +188,3 @@ def test_SList():
     nt.assert_equal(sl.grep(lambda x: x.startswith('a')), text.SList(['a 11', 'a 2']))
     nt.assert_equal(sl.fields(0), text.SList(['a', 'b', 'a']))
     nt.assert_equal(sl.sort(field=1, nums=True), text.SList(['b 1', 'a 2', 'a 11']))
-
-def test_non_local_path_import():
-    nt.assert_in("path", sys.modules)

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -19,6 +19,7 @@ import random
 import sys
 
 import nose.tools as nt
+import path
 
 from IPython.utils import text
 

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -180,7 +180,7 @@ def test_LSString():
     lss = text.LSString("abc\ndef")
     nt.assert_equal(lss.l, ['abc', 'def'])
     nt.assert_equal(lss.s, 'abc def')
-    nt.assert_isinstance(lss.p[0], path.path)
+    nt.assert_is_instance(lss.p[0], path.path)
 
 def test_SList():
     sl = text.SList(['a 11', 'b 1', 'a 2'])

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -7,7 +7,6 @@ Inheritance diagram:
 .. inheritance-diagram:: IPython.utils.text
    :parts: 3
 """
-from __future__ import absolute_import
 
 import os
 import re
@@ -412,7 +411,7 @@ def wrap_paragraphs(text, ncols=80):
 
 def long_substr(data):
     """Return the longest common substring in a list of strings.
-
+    
     Credit: http://stackoverflow.com/questions/2892931/longest-common-substring-from-more-than-two-strings-python
     """
     substr = ''
@@ -454,7 +453,7 @@ def strip_email_quotes(text):
 
     So if any line has no quote marks ('>') , then none are stripped from any
     of them ::
-
+    
         In [5]: strip_email_quotes('> > text\\n> > more\\nlast different')
         Out[5]: '> > text\\n> > more\\nlast different'
     """
@@ -476,7 +475,7 @@ def strip_email_quotes(text):
 def strip_ansi(source):
     """
     Remove ansi escape codes from text.
-
+    
     Parameters
     ----------
     source : str
@@ -487,11 +486,11 @@ def strip_ansi(source):
 
 class EvalFormatter(Formatter):
     """A String Formatter that allows evaluation of simple expressions.
-
+    
     Note that this version interprets a : as specifying a format string (as per
     standard string formatting), so if slicing is required, you must explicitly
     create a slice.
-
+    
     This is to be used in templating cases, such as the parallel batch
     script templates, where simple arithmetic on arguments is useful.
 
@@ -517,13 +516,13 @@ class EvalFormatter(Formatter):
 @skip_doctest_py3
 class FullEvalFormatter(Formatter):
     """A String Formatter that allows evaluation of simple expressions.
-
+    
     Any time a format key is not found in the kwargs,
     it will be tried as an expression in the kwargs namespace.
-
+    
     Note that this version allows slicing using [1:2], so you cannot specify
     a format string. Use :class:`EvalFormatter` to permit format strings.
-
+    
     Examples
     --------
     ::
@@ -597,7 +596,7 @@ class DollarFormatter(FullEvalFormatter):
     def parse(self, fmt_string):
         for literal_txt, field_name, format_spec, conversion \
                     in Formatter.parse(self, fmt_string):
-
+            
             # Find $foo patterns in the literal text.
             continue_from = 0
             txt = ""
@@ -610,7 +609,7 @@ class DollarFormatter(FullEvalFormatter):
                     yield (txt + new_txt, new_field, "", None)
                     txt = ""
                 continue_from = m.end()
-
+            
             # Re-yield the {foo} style pattern
             yield (txt + literal_txt[continue_from:], field_name, format_spec, conversion)
 

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -7,6 +7,7 @@ Inheritance diagram:
 .. inheritance-diagram:: IPython.utils.text
    :parts: 3
 """
+from __future__ import absolute_import
 
 import os
 import re
@@ -411,7 +412,7 @@ def wrap_paragraphs(text, ncols=80):
 
 def long_substr(data):
     """Return the longest common substring in a list of strings.
-    
+
     Credit: http://stackoverflow.com/questions/2892931/longest-common-substring-from-more-than-two-strings-python
     """
     substr = ''
@@ -453,7 +454,7 @@ def strip_email_quotes(text):
 
     So if any line has no quote marks ('>') , then none are stripped from any
     of them ::
-    
+
         In [5]: strip_email_quotes('> > text\\n> > more\\nlast different')
         Out[5]: '> > text\\n> > more\\nlast different'
     """
@@ -475,7 +476,7 @@ def strip_email_quotes(text):
 def strip_ansi(source):
     """
     Remove ansi escape codes from text.
-    
+
     Parameters
     ----------
     source : str
@@ -486,11 +487,11 @@ def strip_ansi(source):
 
 class EvalFormatter(Formatter):
     """A String Formatter that allows evaluation of simple expressions.
-    
+
     Note that this version interprets a : as specifying a format string (as per
     standard string formatting), so if slicing is required, you must explicitly
     create a slice.
-    
+
     This is to be used in templating cases, such as the parallel batch
     script templates, where simple arithmetic on arguments is useful.
 
@@ -516,13 +517,13 @@ class EvalFormatter(Formatter):
 @skip_doctest_py3
 class FullEvalFormatter(Formatter):
     """A String Formatter that allows evaluation of simple expressions.
-    
+
     Any time a format key is not found in the kwargs,
     it will be tried as an expression in the kwargs namespace.
-    
+
     Note that this version allows slicing using [1:2], so you cannot specify
     a format string. Use :class:`EvalFormatter` to permit format strings.
-    
+
     Examples
     --------
     ::
@@ -596,7 +597,7 @@ class DollarFormatter(FullEvalFormatter):
     def parse(self, fmt_string):
         for literal_txt, field_name, format_spec, conversion \
                     in Formatter.parse(self, fmt_string):
-            
+
             # Find $foo patterns in the literal text.
             continue_from = 0
             txt = ""
@@ -609,7 +610,7 @@ class DollarFormatter(FullEvalFormatter):
                     yield (txt + new_txt, new_field, "", None)
                     txt = ""
                 continue_from = m.end()
-            
+
             # Re-yield the {foo} style pattern
             yield (txt + literal_txt[continue_from:], field_name, format_spec, conversion)
 

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -7,6 +7,7 @@ Inheritance diagram:
 .. inheritance-diagram:: IPython.utils.text
    :parts: 3
 """
+from __future__ import absolute_import
 
 import os
 import re


### PR DESCRIPTION
Fix the `utils.text` module to use absolute import in python 2.7. Also added the test that the `path` module is properly imported.
Seems also deleted a lot of whitespace trailing.
