### PR TITLE
Note use of -- for -i to behave like cpython

### DIFF
--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -156,7 +156,10 @@ frontend_flags['quick']=(
 
 frontend_flags['i'] = (
     {'TerminalIPythonApp' : {'force_interact' : True}},
-    """If running code from the command line, become interactive afterwards."""
+    """If running code from the command line, become interactive afterwards.
+    It is often useful to follow this with `--` to treat remaining flags as
+    script arguments.
+    """
 )
 flags.update(frontend_flags)
 


### PR DESCRIPTION
Providing script arguments is only really useful with -i, and while this is described in the main Usage section of ipython --help, it seems more directly helpful here
