### PR TITLE
Remove docs for deprecated extensions

### DIFF
--- a/docs/source/config/extensions/cythonmagic.rst
+++ b/docs/source/config/extensions/cythonmagic.rst
@@ -1,7 +1,0 @@
-.. _extensions_cythonmagic:
-
-===========
-cythonmagic
-===========
-
-The `cython` magic has been moved in the `Cython` package.

--- a/docs/source/config/extensions/index.rst
+++ b/docs/source/config/extensions/index.rst
@@ -89,7 +89,6 @@ Extensions bundled with IPython
 
    autoreload
    storemagic
-   sympyprinting
 
 * ``octavemagic`` used to be bundled, but is now part of `oct2py <http://blink1073.github.io/oct2py/docs/>`_.
   Use ``%load_ext oct2py.ipython`` to load it.
@@ -98,3 +97,5 @@ Extensions bundled with IPython
   details of how to use it.
 * ``cythonmagic`` used to be bundled, but is now part of `cython <https://github.com/cython/cython/>`_
   Use ``%load_ext Cython`` to load it.
+* ``sympyprinting`` used to be a bundled extension, but you should now use
+  :func:`sympy.init_printing` instead.

--- a/docs/source/config/extensions/sympyprinting.rst
+++ b/docs/source/config/extensions/sympyprinting.rst
@@ -1,7 +1,0 @@
-.. _extensions_sympyprinting:
-
-=============
-sympyprinting
-=============
-
-.. automodule:: IPython.extensions.sympyprinting


### PR DESCRIPTION
cythonmagic and sympyprinting are no longer part of our code.

In both cases, we deprecated it with a warning in 3.x, and in 4.x the extension won't work but will print a message pointing you to what to do instead. We can remove the modules entirely for 5.x.
