### PR TITLE
Run autogen scripts on readthedocs

### DIFF
--- a/docs/autogen_api.py
+++ b/docs/autogen_api.py
@@ -1,19 +1,23 @@
 #!/usr/bin/env python
 """Script to auto-generate our API docs.
 """
-# stdlib imports
+
 import os
 import sys
 
-# local imports
-sys.path.append(os.path.abspath('sphinxext'))
+pjoin = os.path.join
+
+here = os.path.abspath(os.path.dirname(__file__))
+sys.path.append(pjoin(os.path.abspath(here), 'sphinxext'))
+
 from apigen import ApiDocWriter
+
+source = pjoin(here, 'source')
 
 #*****************************************************************************
 if __name__ == '__main__':
-    pjoin = os.path.join
     package = 'IPython'
-    outdir = pjoin('source','api','generated')
+    outdir = pjoin(source, 'api', 'generated')
     docwriter = ApiDocWriter(package,rst_extension='.rst')
     # You have to escape the . here because . is a special char for regexps.
     # You must do make clean if you change this!
@@ -67,6 +71,6 @@ if __name__ == '__main__':
     # Write index with .txt extension - we can include it, but Sphinx won't try
     # to compile it
     docwriter.write_index(outdir, 'gen.txt',
-                          relative_to = pjoin('source','api')
+                          relative_to = pjoin(source, 'api')
                           )
     print ('%d files written' % len(docwriter.written_modules))

--- a/docs/autogen_config.py
+++ b/docs/autogen_config.py
@@ -1,24 +1,30 @@
 #!/usr/bin/env python
 
+from os.path import join, dirname, abspath
+
 from IPython.terminal.ipapp import TerminalIPythonApp
 from ipykernel.kernelapp import IPKernelApp
 
+here = abspath(dirname(__file__))
+options = join(here, 'source', 'config', 'options')
+generated = join(options, 'generated.rst')
+
 def write_doc(name, title, app, preamble=None):
     filename = '%s.rst' % name
-    with open('source/config/options/%s' % filename, 'w') as f:
+    with open(join(options, filename), 'w') as f:
         f.write(title + '\n')
         f.write(('=' * len(title)) + '\n')
         f.write('\n')
         if preamble is not None:
             f.write(preamble + '\n\n')
         f.write(app.document_config_options())
-    with open('source/config/options/generated', 'a') as f:
+    with open(generated, 'a') as f:
         f.write(filename + '\n')
 
 
 if __name__ == '__main__':
     # create empty file
-    with open('source/config/options/generated', 'w'):
+    with open(generated, 'w'):
         pass
 
     write_doc('terminal', 'Terminal IPython options', TerminalIPythonApp())

--- a/docs/autogen_magics.py
+++ b/docs/autogen_magics.py
@@ -1,3 +1,5 @@
+import os
+
 from IPython.core.alias import Alias
 from IPython.core.interactiveshell import InteractiveShell
 from IPython.core.magic import MagicAlias
@@ -60,5 +62,7 @@ for name, func in sorted(magics['cell'].items(), key=sortkey):
                    format_docstring(func),
                    ""])
 
-with open("source/interactive/magics-generated.txt", "w") as f:
+here = os.path.dirname(__file__)
+dest = os.path.join(here, 'source', 'interactive', 'magics-generated.txt')
+with open(dest, "w") as f:
     f.write("\n".join(output))

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 numpydoc
 -e .
+ipykernel

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,10 @@ if ON_RTD:
         fname = 'autogen_{}.py'.format(name)
         fpath = os.path.abspath(os.path.join('..', fname))
         with open(fpath) as f:
-            exec(compile(f.read(), fname, 'exec'), {'__file__': fpath})
+            exec(compile(f.read(), fname, 'exec'), {
+                '__file__': fpath,
+                '__name__': '__main__',
+            })
 
 # If your extensions are in another directory, add it here. If the directory
 # is relative to the documentation root, use os.path.abspath to make it

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,14 @@ if ON_RTD:
     # see
     # http://read-the-docs.readthedocs.org/en/latest/faq.html
     tags.add('rtd')
-    
+
+    # RTD doesn't use the Makefile, so re-run autogen_{things}.py here.
+    for name in ('config', 'api', 'magics'):
+        fname = 'autogen_{}.py'.format(name)
+        fpath = os.path.abspath(os.path.join('..', fname))
+        with open(fpath) as f:
+            exec(compile(f.read(), fname, 'exec'), {'__file__': fpath})
+
 # If your extensions are in another directory, add it here. If the directory
 # is relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.


### PR DESCRIPTION
in conf.py

includes abspath fixes to remove CWD assumptions from the scripts.
