### PR TITLE
Reinstate DeprecationClass

### DIFF
--- a/IPython/utils/warn.py
+++ b/IPython/utils/warn.py
@@ -55,3 +55,16 @@ def fatal(msg,exit_val=1):
 
     warn(msg,exit_val=exit_val,level=4)
 
+
+def DeprecatedClass(base, class_name):
+    # Hook the init method of the base class.
+    def init_hook(self, *pargs, **kwargs):
+        base.__init__(self, *pargs, **kwargs)
+
+        # Warn once per class.
+        if base not in DeprecatedClass._warned_classes:
+            DeprecatedClass._warned_classes.append(base)
+            warn('"{}" is deprecated, please use "{}" instead.'.format(
+                class_name, base.__name__))
+    return type(class_name, (base,), {'__init__': init_hook})
+DeprecatedClass._warned_classes = []


### PR DESCRIPTION
Fixes #8718.

``` python
In [1]: from IPython.html import widgets
/Users/ssilvester/workspace/ipython/IPython/html.py:14: ShimWarning: The `IPython.html` package has been deprecated. You should import from `notebook` instead. `IPython.html.widgets` has moved to `ipywidgets`.
  "`IPython.html.widgets` has moved to `ipywidgets`.", ShimWarning)
```
