### PR TITLE
[WIP] add metadata to completions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ __pycache__
 \#*#
 .#*
 .coverage
+.idea


### PR DESCRIPTION
This PR is not ready to be merged, and is intended for discussion and review.

These changes allow for UI like this:

<img width="237" alt="screenshot 2015-08-12 12 22 27" src="https://cloud.githubusercontent.com/assets/597829/9230554/d4dbd9b2-40f0-11e5-9894-b3e22c4f46b5.png">

It pulls the names of parameters to a procedure out using `inspect`:

<img width="224" alt="screenshot 2015-08-12 12 19 16" src="https://cloud.githubusercontent.com/assets/597829/9230557/d4dce4ba-40f0-11e5-804d-f68938f55194.png">

<img width="302" alt="screenshot 2015-08-12 12 18 44" src="https://cloud.githubusercontent.com/assets/597829/9230555/d4dc6026-40f0-11e5-9096-560657243bc8.png">

Live values of variables are included as well:

<img width="230" alt="screenshot 2015-08-12 12 19 03" src="https://cloud.githubusercontent.com/assets/597829/9230556/d4dcaa2c-40f0-11e5-85eb-260b208bba19.png">

More information about these changes is available in this thread: https://github.com/jupyter/jupyter_client/issues/51

Presently this replaces the `matches` key in `complete_reply`. This is temporary and was only to save time in first getting this visible. We don't yet have a firm decision on where to put this information.
