### PR TITLE
IPython.load_extensions is using a relative path

### DIFF
--- a/IPython/html/static/base/js/utils.js
+++ b/IPython/html/static/base/js/utils.js
@@ -17,7 +17,7 @@ define([
         var extensions = [];
         var extension_names = arguments;
         for (var i = 0; i < extension_names.length; i++) {
-            extensions.push("nbextensions/" + arguments[i]);
+            extensions.push("/nbextensions/" + arguments[i]);
         }
         
         require(extensions,


### PR DESCRIPTION
I was unable to load some extensions and was able to trace it to this problem:

```
    var load_extensions = function () {
        // load one or more IPython notebook extensions with requirejs
        var extensions = [];
        var extension_names = arguments;
        for (var i = 0; i < extension_names.length; i++) {
            extensions.push("nbextensions/" + arguments[i]);
        }
    ...
```

This creates a relative path which means that whenever you run the function within a notebook, it tries to fetch from <notebook_url>/nbextensions/<extension_path> and, thus, can't find it.

I'm not very familiar with the extensions codebase, but it seems like it should be:
extensions.push("/nbextensions/" + arguments[i]); instead. I'm submitting the PR but feel free to deny if this is correct and I'm just doing something wrong.
