### PR TITLE
Fixes #8743 (warning string)

### DIFF
--- a/IPython/nbconvert.py
+++ b/IPython/nbconvert.py
@@ -10,7 +10,7 @@ from warnings import warn
 from IPython.utils.shimmodule import ShimModule, ShimWarning
 
 warn("The `IPython.nbconvert` package has been deprecated. "
-     "You should import from ipython_nbconvert instead.", ShimWarning)
+     "You should import from nbconvert instead.", ShimWarning)
 
 # Unconditionally insert the shim into sys.modules so that further import calls
 # trigger the custom attribute access above


### PR DESCRIPTION
Corrects "IPython_nbconvert" to "nbconvert"
