### PR TITLE
[Test] Try to debug issue that make no sens at all on travis:

### DIFF
--- a/IPython/core/tests/test_profile.py
+++ b/IPython/core/tests/test_profile.py
@@ -157,10 +157,10 @@ def test_profile_create_ipython_dir():
     """ipython profile create respects --ipython-dir"""
     with TemporaryDirectory() as td:
         import time
-        getoutput([sys.executable, '-m', 'IPython', 'profile', 'create',
-             'foo', '--ipython-dir=%s' % td])
+        val =  getoutput([sys.executable, '-m', 'IPython', 'profile', 'create',
+             'foo', '--ipython-dir=%s' % td ,'--debug'])
         profile_dir = os.path.join(td, 'profile_foo')
         nt.assert_true(os.path.exists(profile_dir))
-        time.sleep(5)
-        raise ValueError(str(os.listdir(profile_dir)))
+        #time.sleep(5)
+        raise ValueError(val)
         ipython_config = os.path.join(profile_dir, 'ipython_config.py')

--- a/IPython/core/tests/test_profile.py
+++ b/IPython/core/tests/test_profile.py
@@ -156,9 +156,11 @@ def test_list_bundled_profiles():
 def test_profile_create_ipython_dir():
     """ipython profile create respects --ipython-dir"""
     with TemporaryDirectory() as td:
+        import time
         getoutput([sys.executable, '-m', 'IPython', 'profile', 'create',
              'foo', '--ipython-dir=%s' % td])
         profile_dir = os.path.join(td, 'profile_foo')
         nt.assert_true(os.path.exists(profile_dir))
+        time.sleep(5)
         raise ValueError(str(os.listdir(profile_dir)))
         ipython_config = os.path.join(profile_dir, 'ipython_config.py')

--- a/IPython/core/tests/test_profile.py
+++ b/IPython/core/tests/test_profile.py
@@ -159,7 +159,6 @@ def test_profile_create_ipython_dir():
         getoutput([sys.executable, '-m', 'IPython', 'profile', 'create',
              'foo', '--ipython-dir=%s' % td])
         profile_dir = os.path.join(td, 'profile_foo')
-        assert os.path.exists(profile_dir)
+        nt.assert_true(os.path.exists(profile_dir))
         ipython_config = os.path.join(profile_dir, 'ipython_config.py')
-        assert os.path.exists(ipython_config)
-        
+        nt.assert_true(os.path.exists(ipython_config))

--- a/IPython/core/tests/test_profile.py
+++ b/IPython/core/tests/test_profile.py
@@ -160,5 +160,5 @@ def test_profile_create_ipython_dir():
              'foo', '--ipython-dir=%s' % td])
         profile_dir = os.path.join(td, 'profile_foo')
         nt.assert_true(os.path.exists(profile_dir))
+        raise ValueError(str(os.listdir(profile_dir)))
         ipython_config = os.path.join(profile_dir, 'ipython_config.py')
-        nt.assert_true(os.path.exists(ipython_config))

--- a/IPython/nbconvert.py
+++ b/IPython/nbconvert.py
@@ -10,7 +10,7 @@ from warnings import warn
 from IPython.utils.shimmodule import ShimModule, ShimWarning
 
 warn("The `IPython.nbconvert` package has been deprecated. "
-     "You should import from ipython_nbconvert instead.", ShimWarning)
+     "You should import from nbconvert instead.", ShimWarning)
 
 # Unconditionally insert the shim into sys.modules so that further import calls
 # trigger the custom attribute access above


### PR DESCRIPTION
```
FAIL: ipython profile create respects --ipython-dir
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/travis/build/ipython/ipython/IPython/core/tests/test_profile.py", line 164, in test_profile_create_ipython_dir
    assert os.path.exists(ipython_config)
AssertionError: 
    '/tmp/tmp16nfhU/tmp8Wu8Nq/profile_foo' = <module 'os' from '/home/travis/virtualenv/python2.7.9/lib/python2.7/os.pyc'>.path.join('/tmp/tmp16nfhU/tmp8Wu8Nq', 'profile_foo')
    assert <module 'os' from '/home/travis/virtualenv/python2.7.9/lib/python2.7/os.pyc'>.path.exists('/tmp/tmp16nfhU/tmp8Wu8Nq/profile_foo')
    '/tmp/tmp16nfhU/tmp8Wu8Nq/profile_foo/ipython_config.py' = <module 'os' from '/home/travis/virtualenv/python2.7.9/lib/python2.7/os.pyc'>.path.join('/tmp/tmp16nfhU/tmp8Wu8Nq/profile_foo', 'ipython_config.py')
>>  assert <module 'os' from '/home/travis/virtualenv/python2.7.9/lib/python2.7/os.pyc'>.path.exists('/tmp/tmp16nfhU/tmp8Wu8Nq/profile_foo/ipython_config.py')
```
