### PR TITLE
Row-first option for columnize

### DIFF
--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -50,6 +50,15 @@ def test_columnize():
     out = text.columnize(items, row_first=True, displaywidth=10)
     nt.assert_equal(out, 'aaaaa\nbbbbb\nccccc\nddddd\n')
 
+    out = text.columnize(items, displaywidth=40, spread=True)
+    nt.assert_equal(out, 'aaaaa      bbbbb      ccccc      ddddd\n')
+    out = text.columnize(items, displaywidth=20, spread=True)
+    nt.assert_equal(out, 'aaaaa          ccccc\nbbbbb          ddddd\n')
+    out = text.columnize(items, displaywidth=12, spread=True)
+    nt.assert_equal(out, 'aaaaa  ccccc\nbbbbb  ddddd\n')
+    out = text.columnize(items, displaywidth=10, spread=True)
+    nt.assert_equal(out, 'aaaaa\nbbbbb\nccccc\nddddd\n')
+
 
 def test_columnize_random():
     """Test with random input to hopfully catch edge case """

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -30,44 +30,60 @@ from IPython.utils import text
 def test_columnize():
     """Basic columnize tests."""
     size = 5
-    items = [l*size for l in 'abc']
+    items = [l*size for l in 'abcd']
+
     out = text.columnize(items, displaywidth=80)
-    nt.assert_equal(out, 'aaaaa  bbbbb  ccccc\n')
+    nt.assert_equal(out, 'aaaaa  bbbbb  ccccc  ddddd\n')
+    out = text.columnize(items, displaywidth=25)
+    nt.assert_equal(out, 'aaaaa  ccccc\nbbbbb  ddddd\n')
     out = text.columnize(items, displaywidth=12)
-    nt.assert_equal(out, 'aaaaa  ccccc\nbbbbb\n')
+    nt.assert_equal(out, 'aaaaa  ccccc\nbbbbb  ddddd\n')
     out = text.columnize(items, displaywidth=10)
-    nt.assert_equal(out, 'aaaaa\nbbbbb\nccccc\n')
+    nt.assert_equal(out, 'aaaaa\nbbbbb\nccccc\nddddd\n')
+
+    out = text.columnize(items, row_first=True, displaywidth=80)
+    nt.assert_equal(out, 'aaaaa  bbbbb  ccccc  ddddd\n')
+    out = text.columnize(items, row_first=True, displaywidth=25)
+    nt.assert_equal(out, 'aaaaa  bbbbb\nccccc  ddddd\n')
+    out = text.columnize(items, row_first=True, displaywidth=12)
+    nt.assert_equal(out, 'aaaaa  bbbbb\nccccc  ddddd\n')
+    out = text.columnize(items, row_first=True, displaywidth=10)
+    nt.assert_equal(out, 'aaaaa\nbbbbb\nccccc\nddddd\n')
+
 
 def test_columnize_random():
     """Test with random input to hopfully catch edge case """
-    for nitems in [random.randint(2,70) for i in range(2,20)]:
-        displaywidth = random.randint(20,200)
-        rand_len = [random.randint(2,displaywidth) for i in range(nitems)]
-        items = ['x'*l for l in rand_len]
-        out = text.columnize(items, displaywidth=displaywidth)
-        longer_line = max([len(x) for x in out.split('\n')])
-        longer_element = max(rand_len)
-        if longer_line > displaywidth:
-            print("Columnize displayed something lager than displaywidth : %s " % longer_line)
-            print("longer element : %s " % longer_element)
-            print("displaywidth : %s " % displaywidth)
-            print("number of element : %s " % nitems)
-            print("size of each element :\n %s" % rand_len)
-            assert False
+    for row_first in [True, False]:
+        for nitems in [random.randint(2,70) for i in range(2,20)]:
+            displaywidth = random.randint(20,200)
+            rand_len = [random.randint(2,displaywidth) for i in range(nitems)]
+            items = ['x'*l for l in rand_len]
+            out = text.columnize(items, row_first=row_first, displaywidth=displaywidth)
+            longer_line = max([len(x) for x in out.split('\n')])
+            longer_element = max(rand_len)
+            if longer_line > displaywidth:
+                print("Columnize displayed something lager than displaywidth : %s " % longer_line)
+                print("longer element : %s " % longer_element)
+                print("displaywidth : %s " % displaywidth)
+                print("number of element : %s " % nitems)
+                print("size of each element :\n %s" % rand_len)
+                assert False, "row_first={0}".format(row_first)
 
 def test_columnize_medium():
-    """Test with inputs than shouldn't be wider tahn 80 """
+    """Test with inputs than shouldn't be wider than 80"""
     size = 40
     items = [l*size for l in 'abc']
-    out = text.columnize(items, displaywidth=80)
-    nt.assert_equal(out, '\n'.join(items+['']))
+    for row_first in [True, False]:
+        out = text.columnize(items, row_first=row_first, displaywidth=80)
+        nt.assert_equal(out, '\n'.join(items+['']), "row_first={0}".format(row_first))
 
 def test_columnize_long():
     """Test columnize with inputs longer than the display window"""
     size = 11
     items = [l*size for l in 'abc']
-    out = text.columnize(items, displaywidth=size-1)
-    nt.assert_equal(out, '\n'.join(items+['']))
+    for row_first in [True, False]:
+        out = text.columnize(items, row_first=row_first, displaywidth=size-1)
+        nt.assert_equal(out, '\n'.join(items+['']), "row_first={0}".format(row_first))
 
 def eval_formatter_check(f):
     ns = dict(n=12, pi=math.pi, stuff='hello there', os=os, u=u"café", b="café")

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -661,7 +661,7 @@ def compute_item_matrix(items, row_first=False, empty=None, *args, **kwargs) :
     items
         list of strings to columize
     row_first : (default False)
-        Whether to to compute columns for a row-first matrix instead ofr
+        Whether to compute columns for a row-first matrix instead of
         column-first (default).
     empty : (default None)
         default value to fill list if needed
@@ -726,7 +726,7 @@ def columnize(items, row_first=False, separator='  ', displaywidth=80):
         The strings to process.
 
     row_first : (default False)
-        Whether to to compute columns for a row-first matrix instead ofr
+        Whether to compute columns for a row-first matrix instead of
         column-first (default).
 
     separator : str, optional [default is two spaces]

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -618,28 +618,28 @@ class DollarFormatter(FullEvalFormatter):
 # Utils to columnize a list of string
 #-----------------------------------------------------------------------------
 
-def _col_chunks(l, nrows, row_first=False):
-    """Yield successive nrows-sized column chunks from l."""
+def _col_chunks(l, max_rows, row_first=False):
+    """Yield successive max_rows-sized column chunks from l."""
     if row_first:
-        ncols = (len(l) // nrows) + (len(l) % nrows > 0)
+        ncols = (len(l) // max_rows) + (len(l) % max_rows > 0)
         for i in py3compat.xrange(ncols):
             yield [l[j] for j in py3compat.xrange(i, len(l), ncols)]
     else:
-        for i in py3compat.xrange(0, len(l), nrows):
-            yield l[i:(i + nrows)]
+        for i in py3compat.xrange(0, len(l), max_rows):
+            yield l[i:(i + max_rows)]
 
 
 def _find_optimal(rlist, row_first=False, separator_size=2, displaywidth=80):
     """Calculate optimal info to columnize a list of string"""
-    for nrow in range(1, len(rlist) + 1):
-        col_widths = list(map(max, _col_chunks(rlist, nrow, row_first)))
+    for max_rows in range(1, len(rlist) + 1):
+        col_widths = list(map(max, _col_chunks(rlist, max_rows, row_first)))
         sumlength = sum(col_widths)
         ncols = len(col_widths)
         if sumlength + separator_size * (ncols - 1) <= displaywidth:
             break
     return {'num_columns': ncols,
             'optimal_separator_width': (displaywidth - sumlength) / (ncols - 1) if (ncols - 1) else 0,
-            'num_rows': nrow,
+            'max_rows': max_rows,
             'column_widths': col_widths
             }
 
@@ -685,8 +685,8 @@ def compute_item_matrix(items, row_first=False, empty=None, *args, **kwargs) :
 
         num_columns
           number of columns
-        num_rows
-          number of rows
+        max_rows
+          maximum number of rows (final number may be less)
         column_widths
           list of with of each columns
         optimal_separator_width
@@ -707,10 +707,10 @@ def compute_item_matrix(items, row_first=False, empty=None, *args, **kwargs) :
             {'num_columns': 3,
             'column_widths': [5, 1, 1],
             'optimal_separator_width': 2,
-            'num_rows': 5})
+            'max_rows': 5})
     """
     info = _find_optimal(list(map(len, items)), row_first, *args, **kwargs)
-    nrow, ncol = info['num_rows'], info['num_columns']
+    nrow, ncol = info['max_rows'], info['num_columns']
     if row_first:
         return ([[_get_or_default(items, r * ncol + c, default=empty) for c in range(ncol)] for r in range(nrow)], info)
     else:

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -717,7 +717,7 @@ def compute_item_matrix(items, row_first=False, empty=None, *args, **kwargs) :
         return ([[_get_or_default(items, c * nrow + r, default=empty) for c in range(ncol)] for r in range(nrow)], info)
 
 
-def columnize(items, row_first=False, separator='  ', displaywidth=80):
+def columnize(items, row_first=False, separator='  ', displaywidth=80, spread=False):
     """ Transform a list of strings into a single string with columns.
 
     Parameters
@@ -742,6 +742,8 @@ def columnize(items, row_first=False, separator='  ', displaywidth=80):
     if not items:
         return '\n'
     matrix, info = compute_item_matrix(items, row_first=row_first, separator_size=len(separator), displaywidth=displaywidth)
+    if spread:
+        separator = separator.ljust(int(info['optimal_separator_width']))
     fmatrix = [filter(None, x) for x in matrix]
     sjoin = lambda x : separator.join([ y.ljust(w, ' ') for y, w in zip(x, info['column_widths'])])
     return '\n'.join(map(sjoin, fmatrix))+'\n'

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -623,7 +623,7 @@ def _col_chunks(l, nrows, row_first=False):
     if row_first:
         ncols = (len(l) // nrows) + (len(l) % nrows > 0)
         for i in py3compat.xrange(ncols):
-            yield [l[j] for j in py3compat.xrange(i, len(l), nrows)]
+            yield [l[j] for j in py3compat.xrange(i, len(l), ncols)]
     else:
         for i in py3compat.xrange(0, len(l), nrows):
             yield l[i:(i + nrows)]
@@ -712,7 +712,7 @@ def compute_item_matrix(items, row_first=False, empty=None, *args, **kwargs) :
     info = _find_optimal(list(map(len, items)), row_first, *args, **kwargs)
     nrow, ncol = info['num_rows'], info['num_columns']
     if row_first:
-        return ([[_get_or_default(items, c * nrow + r, default=empty) for r in range(nrow)] for c in range(ncol)], info)
+        return ([[_get_or_default(items, r * ncol + c, default=empty) for c in range(ncol)] for r in range(nrow)], info)
     else:
         return ([[_get_or_default(items, c * nrow + r, default=empty) for c in range(ncol)] for r in range(nrow)], info)
 

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -618,25 +618,30 @@ class DollarFormatter(FullEvalFormatter):
 # Utils to columnize a list of string
 #-----------------------------------------------------------------------------
 
-def _chunks(l, n):
-    """Yield successive n-sized chunks from l."""
-    for i in py3compat.xrange(0, len(l), n):
-        yield l[i:i+n]
+def _col_chunks(l, nrows, row_first=False):
+    """Yield successive nrows-sized column chunks from l."""
+    if row_first:
+        ncols = (len(l) // nrows) + (len(l) % nrows > 0)
+        for i in py3compat.xrange(ncols):
+            yield [l[j] for j in py3compat.xrange(i, len(l), nrows)]
+    else:
+        for i in py3compat.xrange(0, len(l), nrows):
+            yield l[i:(i + nrows)]
 
 
-def _find_optimal(rlist , separator_size=2 , displaywidth=80):
+def _find_optimal(rlist, row_first=False, separator_size=2, displaywidth=80):
     """Calculate optimal info to columnize a list of string"""
-    for nrow in range(1, len(rlist)+1) :
-        chk = list(map(max,_chunks(rlist, nrow)))
-        sumlength = sum(chk)
-        ncols = len(chk)
-        if sumlength+separator_size*(ncols-1) <= displaywidth :
-            break;
-    return {'columns_numbers' : ncols,
-            'optimal_separator_width':(displaywidth - sumlength)/(ncols-1) if (ncols -1) else 0,
-            'rows_numbers' : nrow,
-            'columns_width' : chk
-           }
+    for nrow in range(1, len(rlist) + 1):
+        col_widths = list(map(max, _col_chunks(rlist, nrow, row_first)))
+        sumlength = sum(col_widths)
+        ncols = len(col_widths)
+        if sumlength + separator_size * (ncols - 1) <= displaywidth:
+            break
+    return {'num_columns': ncols,
+            'optimal_separator_width': (displaywidth - sumlength) / (ncols - 1) if (ncols - 1) else 0,
+            'num_rows': nrow,
+            'column_widths': col_widths
+            }
 
 
 def _get_or_default(mylist, i, default=None):
@@ -647,7 +652,7 @@ def _get_or_default(mylist, i, default=None):
         return mylist[i]
 
 
-def compute_item_matrix(items, empty=None, *args, **kwargs) :
+def compute_item_matrix(items, row_first=False, empty=None, *args, **kwargs) :
     """Returns a nested list, and info to columnize items
 
     Parameters
@@ -655,6 +660,9 @@ def compute_item_matrix(items, empty=None, *args, **kwargs) :
 
     items
         list of strings to columize
+    row_first : (default False)
+        Whether to to compute columns for a row-first matrix instead ofr
+        column-first (default).
     empty : (default None)
         default value to fill list if needed
     separator_size : int (default=2)
@@ -675,11 +683,11 @@ def compute_item_matrix(items, empty=None, *args, **kwargs) :
     dict_info
         some info to make columnize easier:
 
-        columns_numbers
+        num_columns
           number of columns
-        rows_numbers
+        num_rows
           number of rows
-        columns_width
+        column_widths
           list of with of each columns
         optimal_separator_width
           best separator width between columns
@@ -689,30 +697,37 @@ def compute_item_matrix(items, empty=None, *args, **kwargs) :
     ::
 
         In [1]: l = ['aaa','b','cc','d','eeeee','f','g','h','i','j','k','l']
-           ...: compute_item_matrix(l,displaywidth=12)
+           ...: compute_item_matrix(l, displaywidth=12)
         Out[1]:
             ([['aaa', 'f', 'k'],
             ['b', 'g', 'l'],
             ['cc', 'h', None],
             ['d', 'i', None],
             ['eeeee', 'j', None]],
-            {'columns_numbers': 3,
-            'columns_width': [5, 1, 1],
+            {'num_columns': 3,
+            'column_widths': [5, 1, 1],
             'optimal_separator_width': 2,
-            'rows_numbers': 5})
+            'num_rows': 5})
     """
-    info = _find_optimal(list(map(len, items)), *args, **kwargs)
-    nrow, ncol = info['rows_numbers'], info['columns_numbers']
-    return ([[ _get_or_default(items, c*nrow+i, default=empty) for c in range(ncol) ] for i in range(nrow) ], info)
+    info = _find_optimal(list(map(len, items)), row_first, *args, **kwargs)
+    nrow, ncol = info['num_rows'], info['num_columns']
+    if row_first:
+        return ([[_get_or_default(items, c * nrow + r, default=empty) for r in range(nrow)] for c in range(ncol)], info)
+    else:
+        return ([[_get_or_default(items, c * nrow + r, default=empty) for c in range(ncol)] for r in range(nrow)], info)
 
 
-def columnize(items, separator='  ', displaywidth=80):
+def columnize(items, row_first=False, separator='  ', displaywidth=80):
     """ Transform a list of strings into a single string with columns.
 
     Parameters
     ----------
     items : sequence of strings
         The strings to process.
+
+    row_first : (default False)
+        Whether to to compute columns for a row-first matrix instead ofr
+        column-first (default).
 
     separator : str, optional [default is two spaces]
         The string that separates columns.
@@ -724,11 +739,11 @@ def columnize(items, separator='  ', displaywidth=80):
     -------
     The formatted string.
     """
-    if not items :
+    if not items:
         return '\n'
-    matrix, info = compute_item_matrix(items, separator_size=len(separator), displaywidth=displaywidth)
+    matrix, info = compute_item_matrix(items, row_first=row_first, separator_size=len(separator), displaywidth=displaywidth)
     fmatrix = [filter(None, x) for x in matrix]
-    sjoin = lambda x : separator.join([ y.ljust(w, ' ') for y, w in zip(x, info['columns_width'])])
+    sjoin = lambda x : separator.join([ y.ljust(w, ' ') for y, w in zip(x, info['column_widths'])])
     return '\n'.join(map(sjoin, fmatrix))+'\n'
 
 


### PR DESCRIPTION
This adds a row-first sort to the columnize function, to address part of #8741 .

Original columnise: 

``` python
In [9]: print(columnize(items))
a  c  eeeeeeeeeeeeeeeeeeeeeee  eeeeeeeeeeeeeeeeeeeeeee
b  d  eeeeeeeeeeeeeeeeeeeeeee  eeeeeeeeeeeeeeeeeeeeeee
```

New addition:

``` python
In [10]: print(columnize(items, row_first=True))
a                        b                        c                      
d                        eeeeeeeeeeeeeeeeeeeeeee  eeeeeeeeeeeeeeeeeeeeeee
eeeeeeeeeeeeeeeeeeeeeee  eeeeeeeeeeeeeeeeeeeeeee
```
