### PR TITLE
FIX/API: use inspect.signature for python3

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -843,21 +843,22 @@ class IPCompleter(Completer):
                  getattr(call_obj, '__doc__', ''))
 
         if PY3:
-            _keepers = (inspect.Parameter.KEYWORD_ONLY,
-                        inspect.Parameter.POSITIONAL_OR_KEYWORD)
-            try:
-                sig = inspect.signature(call_obj)
-                ret.extend(k for k, v in sig.parameters.items() if
-                           v.kind in _keepers)
-            except ValueError:
-                pass
+            _keeps = (inspect.Parameter.KEYWORD_ONLY,
+                      inspect.Parameter.POSITIONAL_OR_KEYWORD)
+            signature = inspect.signature
         else:
-            try:
-                args, _, _1, defaults = inspect.getargspec(call_obj)
-                if defaults:
-                    ret += args[-len(defaults):]
-            except TypeError:
-                pass
+            import IPython.utils.signatures
+            _keeps = (IPython.utils.signatures.Parameter.KEYWORD_ONLY,
+                      IPython.utils.signatures.Parameter.POSITIONAL_OR_KEYWORD)
+            signature = IPython.utils.signatures.signature
+
+        try:
+            sig = signature(call_obj)
+            ret.extend(k for k, v in sig.parameters.items() if
+                       v.kind in _keeps)
+        except ValueError:
+            pass
+
         return list(set(ret))
 
     def python_func_kw_matches(self,text):

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -841,24 +841,28 @@ class IPCompleter(Completer):
                 call_obj = obj.__call__
         ret += self._default_arguments_from_docstring(
                  getattr(call_obj, '__doc__', ''))
-        try:
-            if PY3:
-                _keepers = (inspect.Parameter.KEYWORD_ONLY,
-                            inspect.Parameter.POSITIONAL_OR_KEYWORD)
+
+        if PY3:
+            _keepers = (inspect.Parameter.KEYWORD_ONLY,
+                        inspect.Parameter.POSITIONAL_OR_KEYWORD)
+            try:
                 sig = inspect.signature(call_obj)
                 ret.extend(k for k, v in sig.parameters.items() if
                            v.kind in _keepers)
-            else:
+            except ValueError:
+                pass
+        else:
+            try:
                 args, _, _1, defaults = inspect.getargspec(call_obj)
                 if defaults:
                     ret += args[-len(defaults):]
-        except TypeError:
-            pass
+            except TypeError:
+                pass
         return list(set(ret))
 
     def python_func_kw_matches(self,text):
         """Match named parameters (kwargs) of the last open function"""
-        
+
         if "." in text: # a parameter cannot be dotted
             return []
         try: regexp = self.__funcParamsRegex

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -839,17 +839,21 @@ class IPCompleter(Completer):
             # for all others, check if they are __call__able
             elif hasattr(obj, '__call__'):
                 call_obj = obj.__call__
-
         ret += self._default_arguments_from_docstring(
                  getattr(call_obj, '__doc__', ''))
-
         try:
-            args,_,_1,defaults = inspect.getargspec(call_obj)
-            if defaults:
-                ret+=args[-len(defaults):]
+            if PY3:
+                _keepers = (inspect.Parameter.KEYWORD_ONLY,
+                            inspect.Parameter.POSITIONAL_OR_KEYWORD)
+                sig = inspect.signature(call_obj)
+                ret.extend(k for k, v in sig.parameters.items() if
+                           v.kind in _keepers)
+            else:
+                args, _, _1, defaults = inspect.getargspec(call_obj)
+                if defaults:
+                    ret += args[-len(defaults):]
         except TypeError:
             pass
-
         return list(set(ret))
 
     def python_func_kw_matches(self,text):


### PR DESCRIPTION
This allows functions with keyword-only arguments to have their signatures introspected.

Also makes this bit of code 3.6 compatible  (@Carreau I see your 3.5 and raise you a 3.6 :stuck_out_tongue_winking_eye: )

Found this via working on https://github.com/matplotlib/matplotlib/pull/4829 where for python 3.3+ we mark the `data` kwarg as keyword-only.

This is a slight change in behavior as it makes all arguments, not just the optional ones.  This can easily be changed back, but leaving it for now as I would propose that including all arguments is a better behavior.
