### PR TITLE
Update Python 3.5 testing to RC 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # http://travis-ci.org/#!/ipython/ipython
 language: python
 python:
-    - "3.5.0b4"
+    - "3.5.0rc4"
     - 3.4
     - 3.3
     - 2.7


### PR DESCRIPTION
Remember me? ;-)

I remembered that our 3.5 testing is pinned to a specific version, and thought we should probably update it. Hopefully Travis knows about this version.
