### PR TITLE
Clarify Qt import logic

### DIFF
--- a/IPython/external/qt_for_kernel.py
+++ b/IPython/external/qt_for_kernel.py
@@ -52,7 +52,7 @@ def matplotlib_options(mpl):
             return [QT_API_PYSIDE]
         elif mpqt.lower() == 'pyqt4':
             return [QT_API_PYQT_DEFAULT]
-        elif mpqt.lower() == 'pyqtv2':
+        elif mpqt.lower() == 'pyqt4v2':
             return [QT_API_PYQT]
         raise ImportError("unhandled value for backend.qt4 from matplotlib: %r" %
                           mpqt)

--- a/IPython/external/qt_for_kernel.py
+++ b/IPython/external/qt_for_kernel.py
@@ -19,7 +19,7 @@ if QT_API not set:
     else: (matplotlib said nothing)
         # this is the default path - nobody told us anything
         try in this order:
-            PyQt default version, PySide
+            PyQt default version, PySide, PyQt5
 else:
     use what QT_API says
 
@@ -83,8 +83,7 @@ def get_options():
     qt_api = os.environ.get('QT_API', None)
     if qt_api is None:
         #no ETS variable. Ask mpl, then use default fallback path
-        # TODO: should Qt5 be on the fallback path if there is no Qt4 API?
-        return matplotlib_options(mpl) or [QT_API_PYQT_DEFAULT, QT_API_PYSIDE]
+        return matplotlib_options(mpl) or [QT_API_PYQT_DEFAULT, QT_API_PYSIDE, QT_API_PYQT5]
     elif qt_api not in _qt_apis:
         raise RuntimeError("Invalid Qt API %r, valid values are: %r" %
                            (qt_api, ', '.join(_qt_apis)))

--- a/IPython/external/qt_for_kernel.py
+++ b/IPython/external/qt_for_kernel.py
@@ -13,18 +13,13 @@ if matplotlib has been imported and doesn't support v2 (<= 1.0.1):
 Next, ask QT_API env variable
 
 if QT_API not set:
-    ask matplotlib via rcParams['backend.qt4']
-    if it said PyQt:
-        use PyQt4 @v1
-    elif it said PySide:
-        use PySide
+    ask matplotlib what it's using. If Qt4Agg or Qt5Agg, then use the
+        version matplotlib is configured with
 
     else: (matplotlib said nothing)
         # this is the default path - nobody told us anything
-        try:
-            PyQt @v1
-        except:
-            fallback on PySide
+        try in this order:
+            PyQt default version, PySide
 else:
     use what QT_API says
 
@@ -45,22 +40,30 @@ _qt_apis = (QT_API_PYSIDE, QT_API_PYQT, QT_API_PYQT5, QT_API_PYQTv1,
             QT_API_PYQT_DEFAULT)
 
 #Constraints placed on an imported matplotlib
-# TODO: Make sure this logic is still in sync with matplotlib's requirements.
-# In particular, matplotlib can also now support a qt5 backend, and so this will
-# break if matplotlib is imported and running happily with qt5, because
-# it only queries for the preferred qt4 option.
 def matplotlib_options(mpl):
     if mpl is None:
         return
-    mpqt = mpl.rcParams.get('backend.qt4', None)
-    if mpqt is None:
-        return None
-    if mpqt.lower() == 'pyside':
-        return [QT_API_PYSIDE]
-    elif mpqt.lower() == 'pyqt4':
-        return [QT_API_PYQT_DEFAULT]
-    raise ImportError("unhandled value for backend.qt4 from matplotlib: %r" %
-                      mpqt)
+    backend = mpl.rcParams.get('backend', None)
+    if backend == 'Qt4Agg':
+        mpqt = mpl.rcParams.get('backend.qt4', None)
+        if mpqt is None:
+            return None
+        if mpqt.lower() == 'pyside':
+            return [QT_API_PYSIDE]
+        elif mpqt.lower() == 'pyqt4':
+            return [QT_API_PYQT_DEFAULT]
+        elif mpqt.lower() == 'pyqtv2':
+            return [QT_API_PYQT]
+        raise ImportError("unhandled value for backend.qt4 from matplotlib: %r" %
+                          mpqt)
+    elif backend == 'Qt5Agg':
+        mpqt = mpl.rcParams.get('backend.qt5', None)
+        if mpqt is None:
+            return None
+        if mpqt.lower() == 'pyqt5':
+            return [QT_API_PYQT5]
+        raise ImportError("unhandled value for backend.qt5 from matplotlib: %r" %
+                          mpqt)
 
 def get_options():
     """Return a list of acceptable QT APIs, in decreasing order of
@@ -79,7 +82,8 @@ def get_options():
 
     qt_api = os.environ.get('QT_API', None)
     if qt_api is None:
-        #no ETS variable. Ask mpl, then use either
+        #no ETS variable. Ask mpl, then use default fallback path
+        # TODO: should Qt5 be on the fallback path if there is no Qt4 API?
         return matplotlib_options(mpl) or [QT_API_PYQT_DEFAULT, QT_API_PYSIDE]
     elif qt_api not in _qt_apis:
         raise RuntimeError("Invalid Qt API %r, valid values are: %r" %

--- a/IPython/external/qt_loaders.py
+++ b/IPython/external/qt_loaders.py
@@ -15,10 +15,10 @@ from functools import partial
 from IPython.utils.version import check_version
 
 # Available APIs.
-QT_API_PYQT = 'pyqt'
+QT_API_PYQT = 'pyqt' # Force version 2
 QT_API_PYQT5 = 'pyqt5'
-QT_API_PYQTv1 = 'pyqtv1'
-QT_API_PYQT_DEFAULT = 'pyqtdefault' # don't set SIP explicitly
+QT_API_PYQTv1 = 'pyqtv1' # Force version 2
+QT_API_PYQT_DEFAULT = 'pyqtdefault' # use system default for version 1 vs. 2
 QT_API_PYSIDE = 'pyside'
 
 
@@ -73,7 +73,7 @@ def loaded_api():
 
     Returns
     -------
-    None, 'pyside', 'pyqt', or 'pyqtv1'
+    None, 'pyside', 'pyqt', 'pyqt5', or 'pyqtv1'
     """
     if 'PyQt4.QtCore' in sys.modules:
         if qtapi_version() == 2:


### PR DESCRIPTION
Address issue where matplotlib can specify Qt versions that qt_for_kernel.py did not previously recognize.

One outstanding question: if the user requests the "qt" GUI, should that be allowed to import Qt5 if Qt4 is not available? Or should Qt5 only be available if explicitly requested?
