### PR TITLE
Allow to rebuild docs with Warning this is an old version.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -137,6 +137,8 @@ gh-pages: clean html
 	# if VERSION is unspecified, it will be dev
 	# For releases, VERSION should be just the major version,
 	# e.g. VERSION=2 make gh-pages
+	# use ARCHIVE=1 VERSION=3 gh-pages to build the
+	# docs with a warning that this is not stable docs anymore.
 	python gh-pages.py $(VERSION)
 
 texinfo:

--- a/docs/gh-pages.py
+++ b/docs/gh-pages.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 """Script to commit the doc build outputs into the github-pages repo.
 
 Use:
@@ -31,6 +32,12 @@ pages_dir = 'gh-pages'
 html_dir = 'build/html'
 pdf_dir = 'build/latex'
 pages_repo = 'git@github.com:ipython/ipython-doc.git'
+
+
+if sys.version_info[0] <= 3: 
+    getcwd = os.getcwd
+else:
+    getcwd = os.getcwdu
 
 #-----------------------------------------------------------------------------
 # Functions
@@ -69,7 +76,7 @@ def sh3(cmd):
 def init_repo(path):
     """clone the gh-pages repo if we haven't already."""
     sh("git clone %s %s"%(pages_repo, path))
-    here = os.getcwdu()
+    here = getcwd()
     cd(path)
     sh('git checkout gh-pages')
     cd(here)
@@ -84,7 +91,7 @@ if __name__ == '__main__':
     except IndexError:
         tag = "dev"
     
-    startdir = os.getcwdu()
+    startdir = getcwd()
     if not os.path.exists(pages_dir):
         # init the repo
         init_repo(pages_dir)
@@ -115,20 +122,20 @@ if __name__ == '__main__':
     try:
         cd(pages_dir)
         branch = sh2('git rev-parse --abbrev-ref HEAD').strip()
-        if branch != 'gh-pages':
+        if branch != b'gh-pages':
             e = 'On %r, git branch is %r, MUST be "gh-pages"' % (pages_dir,
                                                                  branch)
             raise RuntimeError(e)
 
         sh('git add -A %s' % tag)
         sh('git commit -m"Updated doc release: %s"' % tag)
-        print
-        print 'Most recent 3 commits:'
+        print()
+        print( 'Most recent 3 commits:')
         sys.stdout.flush()
         sh('git --no-pager log --oneline HEAD~3..')
     finally:
         cd(startdir)
 
-    print
-    print 'Now verify the build in: %r' % dest
-    print "If everything looks good, 'git push'"
+    print()
+    print( 'Now verify the build in: %r' % dest)
+    print( "If everything looks good, 'git push'")

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,9 @@
 numpydoc
 sphinx
 pygments
+scipy
+oct2py
+cython
+nose
+pymongo
+fabric

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+numpydoc
+sphinx
+pygments

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,6 +77,15 @@ if iprelease['_version_extra'] == 'dev':
 
     """
 
+elif os.environ.get('ARCHIVE', None):
+    rst_prolog = """
+    .. warning::
+
+        This documentation is for an old version of IPython.
+        You can find docs for newer versions `here <http://ipython.readthedocs.org/en/stable/>`_.
+        
+    """
+
 # The master toctree document.
 master_doc = 'index'
 


### PR DESCRIPTION
# PR against 2.x

Update 2.x branch to have a warning when rebuilding the docs that docs are out of date. 
