### PR TITLE
Calculate worst time in timeit unconditionally

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -1041,10 +1041,12 @@ python-profiler package from non-free.""")
                 number *= 10
         all_runs = timer.repeat(repeat, number)
         best = min(all_runs) / number
+
+        worst = max(all_runs) / number
+        if worst_tuning:
+            worst = max(worst, worst_tuning)
+
         if not quiet :
-            worst = max(all_runs) / number
-            if worst_tuning:
-                worst = max(worst, worst_tuning)
             # Check best timing is greater than zero to avoid a
             # ZeroDivisionError.
             # In cases where the slowest timing is lesser than a micosecond

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -568,6 +568,11 @@ def test_timeit_quiet():
     with tt.AssertNotPrints("loops"):
         _ip.run_cell("%timeit -n1 -r1 -q 1")
 
+def test_timeit_return_quiet():
+    with tt.AssertNotPrints("loops"):
+        res = _ip.run_line_magic('timeit', '-n1 -r1 -q -o 1')
+    assert (res is not None)
+
 @dec.skipif(sys.version_info[0] >= 3, "no differences with __future__ in py3")
 def test_timeit_futures():
     "Test %timeit with __future__ environments"


### PR DESCRIPTION
Otherwise `%timeit -o -q stmt` fails with `UnboundLocalError`
