### PR TITLE
Dockerfile: install recent pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,15 +20,14 @@ RUN dpkg-reconfigure locales
 # Python binary dependencies, developer tools
 RUN apt-get update && apt-get install -y -q \
     build-essential \
+    curl \
     make \
     gcc \
     zlib1g-dev \
     git \
     python \
     python-dev \
-    python-pip \
     python3-dev \
-    python3-pip \
     python-sphinx \
     python3-sphinx \
     libzmq3-dev \
@@ -39,6 +38,12 @@ RUN apt-get update && apt-get install -y -q \
     nodejs \
     nodejs-legacy \
     npm
+
+# Install the recent pip release
+RUN curl -O https://bootstrap.pypa.io/get-pip.py \
+ && python2 get-pip.py \
+ && python3 get-pip.py \
+ && rm get-pip.py
 
 # In order to build from source, need less
 RUN npm install -g 'less@<3.0'


### PR DESCRIPTION
my motivation to submit this pr is to get a recent version of pip in a Docker-image i derive from https://github.com/ipython/docker-notebook which depends on this one here.

i'm aware that the installation of ipython fails when building, but this also happens with an old pip installed from Ubuntu's repos. therefore i consider this another issue.

i'm also not sure whether this is actually the correct branch to submit to, as i can't find an explicit reference from Docker's registry `ipython/ipython:3.x` to this branch. just a guess.
