### PR TITLE
3.x shrink image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.git*
+.mailmap
+.travis.yml
+IPython/html/static/components/.git
+IPython/html/static/components/.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,36 +31,29 @@ RUN apt-get update -qq \
         python3-dev \
         sqlite3 \
         zlib1g-dev \
- && rm -rf /var/lib/apt/lists/*
-
-# Install the recent pip release
-RUN curl -O https://bootstrap.pypa.io/get-pip.py \
+ && rm -rf /var/lib/apt/lists/* \
+ \
+ `# Install the recent pip release` \
+ && curl -O https://bootstrap.pypa.io/get-pip.py \
  && python2 get-pip.py \
  && python3 get-pip.py \
- && rm get-pip.py
-
-# In order to build from source, need less
-RUN npm install -g 'less@<3.0' \
+ && rm get-pip.py \
+ \
+ `# In order to build from source, need less` \
+ && npm install -g 'less@<3.0' \
  && npm cache clean
 
-RUN pip install invoke
-
-RUN mkdir -p /srv/
-WORKDIR /srv/
 ADD . /srv/ipython
-WORKDIR /srv/ipython/
-RUN chmod -R +rX /srv/ipython
-
-# .[all] only works with -e, so use file://path#egg
-# Can't use -e because ipython2 and ipython3 will clobber each other
-RUN pip2 install --no-cache-dir file:///srv/ipython#egg=ipython[all] sphinx
-RUN pip3 install --no-cache-dir file:///srv/ipython#egg=ipython[all] sphinx
-
-# install kernels
-RUN python2 -m IPython kernelspec install-self
-RUN python3 -m IPython kernelspec install-self
+RUN chmod -R +rX /srv/ipython \
+\
+`# .[all] only works with -e, so use file://path#egg` \
+`# Cant use -e because ipython2 and ipython3 will clobber each other` \
+ && pip2 install --no-cache-dir file:///srv/ipython#egg=ipython[all] sphinx invoke \
+ && pip3 install --no-cache-dir file:///srv/ipython#egg=ipython[all] sphinx invoke \
+ \
+ `# install kernels` \
+ && python2 -m IPython kernelspec install-self \
+ && python3 -m IPython kernelspec install-self \
+ && iptest2 && iptest3
 
 WORKDIR /tmp/
-
-RUN iptest2
-RUN iptest3

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ RUN apt-get update -qq \
  && rm get-pip.py
 
 # Install IPython
-ADD . /srv/ipython
-RUN chmod -R +rX /srv/ipython \
+ADD . /ipython
+RUN chmod -R +rX /ipython \
  \
  `# Install build dependencies` \
  && BUILD_DEPS="nodejs nodejs-legacy npm" \
@@ -48,8 +48,8 @@ RUN chmod -R +rX /srv/ipython \
  \
  `# .[all] only works with -e, so use file://path#egg` \
  `# Cant use -e because ipython2 and ipython3 will clobber each other` \
- && pip2 install --no-cache-dir file:///srv/ipython#egg=ipython[all] \
- && pip3 install --no-cache-dir file:///srv/ipython#egg=ipython[all] \
+ && pip2 install --no-cache-dir file:///ipython#egg=ipython[all] \
+ && pip3 install --no-cache-dir file:///ipython#egg=ipython[all] \
  \
  `# Uninstall build dependencies` \
  && npm remove -g less \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,8 @@ RUN chmod -R +rX /srv/ipython \
  \
  `# .[all] only works with -e, so use file://path#egg` \
  `# Cant use -e because ipython2 and ipython3 will clobber each other` \
- && pip2 install --no-cache-dir file:///srv/ipython#egg=ipython[all] sphinx invoke \
- && pip3 install --no-cache-dir file:///srv/ipython#egg=ipython[all] sphinx invoke \
+ && pip2 install --no-cache-dir file:///srv/ipython#egg=ipython[all] \
+ && pip3 install --no-cache-dir file:///srv/ipython#egg=ipython[all] \
  \
  `# Uninstall build dependencies` \
  && npm remove -g less \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,6 @@ RUN apt-get update -qq \
         python \
         python-dev \
         python3-dev \
-        python-sphinx \
-        python3-sphinx \
         sqlite3 \
         zlib1g-dev \
  && rm -rf /var/lib/apt/lists/*
@@ -55,8 +53,8 @@ RUN chmod -R +rX /srv/ipython
 
 # .[all] only works with -e, so use file://path#egg
 # Can't use -e because ipython2 and ipython3 will clobber each other
-RUN pip2 install --no-cache-dir file:///srv/ipython#egg=ipython[all]
-RUN pip3 install --no-cache-dir file:///srv/ipython#egg=ipython[all]
+RUN pip2 install --no-cache-dir file:///srv/ipython#egg=ipython[all] sphinx
+RUN pip3 install --no-cache-dir file:///srv/ipython#egg=ipython[all] sphinx
 
 # install kernels
 RUN python2 -m IPython kernelspec install-self

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
 # Installs IPython from the current branch
-# Another Docker container should build from this one to get services like the notebook
+# Other Docker images should build from this one to get services like the notebook
 
 FROM ubuntu:14.04
 
 MAINTAINER IPython Project <ipython-dev@scipy.org>
-
-ENV DEBIAN_FRONTEND noninteractive
 
 # Not essential, but wise to set the lang
 # Note: Users with other languages should set this in their derivative image
@@ -14,27 +12,28 @@ ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
 # Python binary dependencies, developer tools
-RUN apt-get update && apt-get install -y -q \
-    build-essential \
-    curl \
-    language-pack-en \
-    make \
-    gcc \
-    zlib1g-dev \
-    git \
-    python \
-    python-dev \
-    python3-dev \
-    python-sphinx \
-    python3-sphinx \
-    libzmq3-dev \
-    sqlite3 \
-    libsqlite3-dev \
-    pandoc \
-    libcurl4-openssl-dev \
-    nodejs \
-    nodejs-legacy \
-    npm
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        language-pack-en \
+        libcurl4-openssl-dev \
+        libsqlite3-dev \
+        libzmq3-dev \
+        nodejs \
+        nodejs-legacy \
+        npm \
+        pandoc \
+        python \
+        python-dev \
+        python3-dev \
+        python-sphinx \
+        python3-sphinx \
+        sqlite3 \
+        zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
 
 # Install the recent pip release
 RUN curl -O https://bootstrap.pypa.io/get-pip.py \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,18 +9,15 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # Not essential, but wise to set the lang
 # Note: Users with other languages should set this in their derivative image
-RUN apt-get update && apt-get install -y language-pack-en
 ENV LANGUAGE en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
-
-RUN locale-gen en_US.UTF-8
-RUN dpkg-reconfigure locales
 
 # Python binary dependencies, developer tools
 RUN apt-get update && apt-get install -y -q \
     build-essential \
     curl \
+    language-pack-en \
     make \
     gcc \
     zlib1g-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,8 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py \
  && rm get-pip.py
 
 # In order to build from source, need less
-RUN npm install -g 'less@<3.0'
+RUN npm install -g 'less@<3.0' \
+ && npm cache clean
 
 RUN pip install invoke
 
@@ -54,8 +55,8 @@ RUN chmod -R +rX /srv/ipython
 
 # .[all] only works with -e, so use file://path#egg
 # Can't use -e because ipython2 and ipython3 will clobber each other
-RUN pip2 install file:///srv/ipython#egg=ipython[all]
-RUN pip3 install file:///srv/ipython#egg=ipython[all]
+RUN pip2 install --no-cache-dir file:///srv/ipython#egg=ipython[all]
+RUN pip3 install --no-cache-dir file:///srv/ipython#egg=ipython[all]
 
 # install kernels
 RUN python2 -m IPython kernelspec install-self


### PR DESCRIPTION
i admit, i may freaked out a little.

these commits reduce the image's layer's size from ~575MB to ~502MB and from 25 layers to 9.

i did no research what the removal of software could break in depending images. the `iptest`s are passing.

pick what you want. shall i open a similar pr against the master-branch?
