### PR TITLE
doc fixes

### DIFF
--- a/IPython/lib/lexers.py
+++ b/IPython/lib/lexers.py
@@ -62,6 +62,7 @@ ipython_tokens = [
   (r'^(!!)(.+)(\n)', bygroups(Operator, using(BashLexer), Text)),
   (r'(!)(?!=)(.+)(\n)', bygroups(Operator, using(BashLexer), Text)),
   (r'^(\s*)(\?\??)(\s*%{0,2}[\w\.\*]*)', bygroups(Text, Operator, Text)),
+  (r'(\s*%{0,2}[\w\.\*]*)(\?\??)(\s*)$', bygroups(Text, Operator, Text)),
 ]
 
 def build_ipy_lexer(python3):

--- a/IPython/lib/tests/test_lexers.py
+++ b/IPython/lib/tests/test_lexers.py
@@ -120,3 +120,11 @@ class TestLexers(TestCase):
             (Token.Text, '\n'),
         ]
         self.assertEqual(tokens_2, list(self.lexer.get_tokens(fragment_2)))
+
+        fragment = ' *int*?\n'
+        tokens = [
+            (Token.Text, ' *int*'),
+            (Token.Operator, '?'),
+            (Token.Text, '\n'),
+        ]
+        self.assertEqual(tokens, list(self.lexer.get_tokens(fragment)))

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
-numpydoc
 -e .
 ipykernel

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,7 +60,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'IPython.sphinxext.ipython_console_highlighting',
     'IPython.sphinxext.ipython_directive',
-    'numpydoc',  # to preprocess docstrings
+    'sphinx.ext.napoleon',  # to preprocess docstrings
     'github',  # for easy GitHub links
     'magics',
 ]

--- a/docs/source/interactive/python-ipython-diff.rst
+++ b/docs/source/interactive/python-ipython-diff.rst
@@ -16,54 +16,51 @@ Quick overview:
 ===============
 
 
-All the following construct are valid IPython syntax :
+All the following construct are valid IPython syntax:
 
-.. code-block::
+.. code-block:: ipython
 
-    ?   
+    In [1]: ?
 
-.. code-block::
+.. code-block:: ipython
 
-    ?object
-
-
-.. code-block::
-
-    object?
-
-.. code-block::
-
-    *pattern*?
-
-.. code-block::
-
-    %shell like --syntax
-
-.. code-block::
-
-    !ls
-
-.. code-block::
-
-    my_files =! ls ~/
-    for i,file in enumerate(my_file):
-        raw = !echo $file
-        !echo {files[0].upper()} $raw
+    In [1]: ?object
 
 
-.. code-block::
+.. code-block:: ipython
 
-    %%perl magic --function
-    @months = ("July", "August", "September");
-    print $months[0];
+    In [1]: object?
+
+.. code-block:: ipython
+
+    In [1]: *pattern*?
+
+.. code-block:: ipython
+
+    In [1]: %shell like --syntax
+
+.. code-block:: ipython
+
+    In [1]: !ls
+
+.. code-block:: ipython
+
+    In [1]: my_files =! ls ~/
+    In [1]: for i,file in enumerate(my_file):
+       ...:     raw = !echo $file
+       ...:     !echo {files[0].upper()} $raw
+
+
+.. code-block:: ipython
+
+    In [1]: %%perl magic --function
+       ...: @months = ("July", "August", "September");
+       ...: print $months[0];
     
 
 Each of these construct is compile by IPython into valid python code and will
 do most of the time what you expect it will do. Let see each of these example
 in more detail.
-
-
-
 
 
 Accessing help
@@ -72,9 +69,9 @@ Accessing help
 As IPython is mostly an interactive shell, the question mark is a simple
 shortcut to get help. A question mark alone will bring up the IPython help:
 
-.. code-block::
+.. code-block:: ipython
 
-    In[1]:?
+    In [1]: ?
 
     IPython -- An enhanced Interactive Python
     =========================================
@@ -95,7 +92,7 @@ shortcut to get help. A question mark alone will bring up the IPython help:
 A single question mark before, or after an object available in current
 namespace will show help relative to this object:
 
-.. code-block::
+.. code-block:: ipython
 
     In [6]: object?
     Docstring: The most base type
@@ -105,7 +102,7 @@ namespace will show help relative to this object:
 A double question mark will try to pull out more information about the object,
 and if possible display the python source code of this object. 
 
-.. code-block::
+.. code-block:: ipython
 
     In[1]: import collections
     In[2]: collection.Counter??
@@ -133,7 +130,8 @@ If you are looking for an object, the use of wildcards ``*`` in conjunction
 with question mark will allow you to search current namespace for object with
 matching names:
 
-.. code-block::
+.. code-block:: ipython
+
     In [24]: *int*?
     FloatingPointError
     int
@@ -149,20 +147,20 @@ This is doable through the use of the exclamation mark ``!`` (or bang).
 
 This allow to execute simple command when present in beginning of line:
 
-.. code-block::
+.. code-block:: ipython
 
     In[1]: !pwd
     /User/home/
 
 Change directory:
 
-.. code-block::
+.. code-block:: ipython
 
     In[1]: !cd /var/etc
 
 Or edit file:
 
-.. code-block::
+.. code-block:: ipython
 
     In[1]: !mvim myfile.txt
 
@@ -171,7 +169,7 @@ The line after the bang can call any program installed in the underlying
 shell, and support variable expansion in the form of ``$variable`` or ``{variable}``.
 The later form of expansion supports arbitrary python expression:
 
-.. code-block::
+.. code-block:: ipython
 
     In[1]: file = 'myfile.txt'
 
@@ -185,14 +183,14 @@ in a list-like object (:see:`IPython Slist`) and assign to the left hand side.
 
 This allow you for example to put the list of files of the current working directory in a variable:
 
-.. code-block::
+.. code-block:: ipython
 
     In[1]: my_files != ls
 
 
 You can combine the different possibilities in for loops, condition, functions...:
 
-.. code-block::
+.. code-block:: ipython
 
     my_files =! ls ~/
     b = "backup file"
@@ -211,14 +209,14 @@ power. Magic function start with a percent sign (``%``) or double percent (``%%`
 
 A magic call with a sign percent will act only one line:
 
-.. code-block::
+.. code-block:: ipython
 
     In[1]: %xmode
     Exception reporting mode: Verbose
 
 And support assignment:
 
-.. code-block::
+.. code-block:: ipython
 
     In [1]: results = %timeit -r1 -n1 -o list(range(1000))
     1 loops, best of 1: 21.1 µs per loop
@@ -228,7 +226,7 @@ And support assignment:
 
 Magic with two percent sign can spread over multiple lines, but do not support assignment:
 
-.. code-block::
+.. code-block:: ipython
 
     In[1]: %%bash
     ...  : echo "My shell is:" $SHELL
@@ -246,6 +244,6 @@ Magic with two percent sign can spread over multiple lines, but do not support a
 Combining it all
 ----------------
 
-.. code-block::
+::
 
-    find a snippet that combine all that into one thing !
+    find a snippet that combine all that into one thing!

--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ setuptools_extra_args = {}
 extras_require = dict(
     parallel = ['ipyparallel'],
     qtconsole = ['qtconsole'],
-    doc = ['Sphinx>=1.1', 'numpydoc'],
+    doc = ['Sphinx>=1.3'],
     test = ['nose>=0.10.1', 'requests', 'testpath'],
     terminal = [],
     kernel = ['ipykernel'],


### PR DESCRIPTION
- use napoleon instead of numpydoc
- recognize `foo*??` in lexer (`??foo*` already worked)
- fix invalid code-blocks in python-ipython-diff
