### PR TITLE
TST: Decode UTF-8 paths before passing them to `os.path` functions

### DIFF
--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -430,11 +430,11 @@ def test_unescape_glob():
 
 def test_ensure_dir_exists():
     with TemporaryDirectory() as td:
-        d = os.path.join(td, u'∂ir')
+        d = os.path.join(td, u'∂ir').encode("utf8")
         path.ensure_dir_exists(d) # create it
         assert os.path.isdir(d)
         path.ensure_dir_exists(d) # no-op
-        f = os.path.join(td, u'ƒile')
+        f = os.path.join(td, u'ƒile').encode("utf8")
         open(f, 'w').close() # touch
         with nt.assert_raises(IOError):
             path.ensure_dir_exists(f)


### PR DESCRIPTION
Fixes an issue with this test under certain environments. This issue appeared in both Python 2 & 3. It's a bit surprising that this issue didn't show up sooner or, for that matter, shows up so infrequently.
