### PR TITLE
Revert changes to ensure_dir_exists

### DIFF
--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -437,6 +437,13 @@ def ensure_dir_exists(path, mode=0o755):
 
     The default permissions are 755, which differ from os.makedirs default of 777.
     """
+    path_exists = False
+    try:
+        path_exists = os.path.exists(path)
+    except UnicodeEncodeError:
+        path = path.encode("utf8")
+        path_exists = os.path.exists(path)
+
     if not os.path.exists(path):
         try:
             os.makedirs(path, mode=mode)

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -441,7 +441,7 @@ def ensure_dir_exists(path, mode=0o755):
     try:
         path_exists = os.path.exists(path)
     except UnicodeEncodeError:
-        path = path.encode(sys.getfilesystemencoding() or "utf8")
+        path = path.encode("utf8")
         path_exists = os.path.exists(path)
 
     if not os.path.exists(path):

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -441,8 +441,12 @@ def ensure_dir_exists(path, mode=0o755):
     try:
         path_exists = os.path.exists(path)
     except UnicodeEncodeError:
-        path = path.encode(sys.getfilesystemencoding() or "utf8")
-        path_exists = os.path.exists(path)
+        try:
+            path = path.encode(sys.getfilesystemencoding() or "utf8")
+            path_exists = os.path.exists(path)
+        except UnicodeEncodeError:
+            path = path.encode("utf8")
+            path_exists = os.path.exists(path)
 
     if not os.path.exists(path):
         try:

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -441,7 +441,7 @@ def ensure_dir_exists(path, mode=0o755):
     try:
         path_exists = os.path.exists(path)
     except UnicodeEncodeError:
-        path = path.encode("utf8")
+        path = path.encode(sys.getfilesystemencoding() or "utf8")
         path_exists = os.path.exists(path)
 
     if not os.path.exists(path):

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -441,12 +441,8 @@ def ensure_dir_exists(path, mode=0o755):
     try:
         path_exists = os.path.exists(path)
     except UnicodeEncodeError:
-        try:
-            path = path.encode(sys.getfilesystemencoding() or "utf8")
-            path_exists = os.path.exists(path)
-        except UnicodeEncodeError:
-            path = path.encode("utf8")
-            path_exists = os.path.exists(path)
+        path = path.encode(sys.getfilesystemencoding() or "utf8")
+        path_exists = os.path.exists(path)
 
     if not os.path.exists(path):
         try:

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -437,13 +437,6 @@ def ensure_dir_exists(path, mode=0o755):
 
     The default permissions are 755, which differ from os.makedirs default of 777.
     """
-    path_exists = False
-    try:
-        path_exists = os.path.exists(path)
-    except UnicodeEncodeError:
-        path = path.encode("utf8")
-        path_exists = os.path.exists(path)
-
     if not os.path.exists(path):
         try:
             os.makedirs(path, mode=mode)

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -430,12 +430,12 @@ def test_unescape_glob():
 
 def test_ensure_dir_exists():
     with TemporaryDirectory() as td:
-        d = os.path.join(td, u'∂ir').encode("utf8")
+        d = os.path.join(td, u'∂ir')
         path.ensure_dir_exists(d) # create it
-        assert os.path.isdir(d)
+        assert os.path.isdir(d.encode("utf8"))
         path.ensure_dir_exists(d) # no-op
-        f = os.path.join(td, u'ƒile').encode("utf8")
-        open(f, 'w').close() # touch
+        f = os.path.join(td, u'ƒile')
+        open(f.encode("utf8"), 'w').close() # touch
         with nt.assert_raises(IOError):
             path.ensure_dir_exists(f)
 

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -430,12 +430,12 @@ def test_unescape_glob():
 
 def test_ensure_dir_exists():
     with TemporaryDirectory() as td:
-        d = os.path.join(td, u'∂ir')
+        d = os.path.join(td, u'∂ir').encode("utf8")
         path.ensure_dir_exists(d) # create it
-        assert os.path.isdir(d.encode("utf8"))
+        assert os.path.isdir(d)
         path.ensure_dir_exists(d) # no-op
-        f = os.path.join(td, u'ƒile')
-        open(f.encode("utf8"), 'w').close() # touch
+        f = os.path.join(td, u'ƒile').encode("utf8")
+        open(f, 'w').close() # touch
         with nt.assert_raises(IOError):
             path.ensure_dir_exists(f)
 

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -430,11 +430,11 @@ def test_unescape_glob():
 
 def test_ensure_dir_exists():
     with TemporaryDirectory() as td:
-        d = os.path.join(td, u'∂ir').encode("utf8")
+        d = os.path.join(td, u'∂ir')
         path.ensure_dir_exists(d) # create it
         assert os.path.isdir(d)
         path.ensure_dir_exists(d) # no-op
-        f = os.path.join(td, u'ƒile').encode("utf8")
+        f = os.path.join(td, u'ƒile')
         open(f, 'w').close() # touch
         with nt.assert_raises(IOError):
             path.ensure_dir_exists(f)


### PR DESCRIPTION
Only decodes inside system functions to make sure that `path.ensure_dir_exists` handles the case of non-unicode supporting systems.
