### PR TITLE
ipython[notebook] should depend on ipywidgets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -187,7 +187,7 @@ extras_require = dict(
     terminal = [],
     kernel = ['ipykernel'],
     nbformat = ['nbformat'],
-    notebook = ['notebook'],
+    notebook = ['notebook', 'ipywidgets'],
     nbconvert = ['nbconvert'],
 )
 install_requires = [


### PR DESCRIPTION
for 3.x compat. Closes #8905
