### PR TITLE
restore check for readline

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -288,7 +288,8 @@ class Pdb(OldPdb):
                 break
             finally:
                 # Pdb sets readline delimiters, so set them back to our own
-                self.shell.readline.set_completer_delims(self.shell.readline_delims)
+                if self.shell.readline is not None:
+                    self.shell.readline.set_completer_delims(self.shell.readline_delims)
 
     def new_do_up(self, arg):
         OldPdb.do_up(self, arg)


### PR DESCRIPTION
reapply #8470, which was inadvertently reverted by #8895
