### PR TITLE
Close `devnull`at exit to avoid a `ResourceWarning` (Python 3)

### DIFF
--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 
+import atexit
 import os
 import sys
 import tempfile
@@ -73,6 +74,7 @@ class IOStream:
 
 # setup stdin/stdout/stderr to sys.stdin/sys.stdout/sys.stderr
 devnull = open(os.devnull, 'w') 
+atexit.register(devnull.close)
 stdin = IOStream(sys.stdin, fallback=devnull)
 stdout = IOStream(sys.stdout, fallback=devnull)
 stderr = IOStream(sys.stderr, fallback=devnull)


### PR DESCRIPTION
Fixes https://github.com/ipython/ipython/issues/8828
Related https://github.com/ipython/ipython/issues/5218

Simply registers the `close` method on the `devnull` filehandle with `atexit`. This fixes a `ResourceWarning` that was being raised when Python 3 versions tried to clean this module during exit.

This patch has also been provided for the 3.x line ( https://github.com/ipython/ipython/pull/8930 ). The same patch can easily be applied to the 2.x line if someone wished to do that or it can be found here for those who want it ( https://github.com/ipython/ipython/pull/8931 ).

**CMA:** This uses `atexit` to make sure the file is closed. This means the file handle will not be closed "when the program is killed by a signal not handled by Python, when a Python fatal internal error is detected, or when `os._exit()` is called." ( https://docs.python.org/2.7/library/atexit.html#module-atexit ). Only in cases that do not meet these criterion will the file handle be properly closed. In other words, it is possible this error may reappear if Python goes through some non-standard shutdown of the sort just described.
