### PR TITLE
Regression: restore syntax highlighting of source in object_info

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -564,7 +564,10 @@ class Inspector:
             for title, key in fields:
                 field = info[key]
                 if field is not None:
-                    displayfields.append((title, field.rstrip()))
+                    if key == "source":
+                        displayfields.append((title, self.format(cast_unicode(field.rstrip()))))
+                    else:
+                        displayfields.append((title, field.rstrip()))
 
         if info['isalias']:
             add_fields([('Repr', "string_form")])


### PR DESCRIPTION
![screen shot 2015-11-04 at 11 54 09 am](https://cloud.githubusercontent.com/assets/7515301/10950049/d516863e-82ea-11e5-8246-6f66389728d1.png)
