### PR TITLE
[WIP] replace PyColorize with Pygments

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -566,6 +566,7 @@ class Inspector:
                 if field is not None:
                     if key == "source":
                         displayfields.append((title, self.format(cast_unicode(field.rstrip()))))
+                        displayfields.append((title, PyColorize.hl(cast_unicode(field.rstrip()))))
                     else:
                         displayfields.append((title, field.rstrip()))
 
@@ -621,6 +622,8 @@ class Inspector:
             if detail_level > 0 and info['source'] is not None:
                 displayfields.append(("Source",
                                       self.format(cast_unicode(info['source']))))
+                displayfields.append(("Source",
+                                      PyColorize.hl(cast_unicode(info['source']))))
             elif info['docstring'] is not None:
                 displayfields.append(("Docstring", info["docstring"]))
 

--- a/IPython/utils/PyColorize.py
+++ b/IPython/utils/PyColorize.py
@@ -87,6 +87,56 @@ NoColor = ColorScheme(
     'normal'         : Colors.NoColor  # color off (usu. Colors.Normal)
     }  )
 
+
+from pygments.token import Keyword, Name, Comment, String, Error, \
+    Number, Operator, Generic, Token, Whitespace
+
+_TERMINAL_COLORS = {
+    Token:              ('',            ''),
+
+    Whitespace:         ('lightgray',   'darkgray'),
+    Comment:            ('Red',         'darkRed'),
+    Comment.Preproc:    ('teal',        'teal'),
+    Keyword:            ('Green',       'darkGreen'),
+    Keyword.Type:       ('teal',        'teal'),
+    Operator:           ('Yellow',      'darkBlue'),
+    Operator.Word:      ('Yellow',      'darkGreen'),
+    Name.Builtin:       ('teal',        'teal'),
+    Name.Function:      ('darkgreen',   'black'),
+    Name.Namespace:     ('_teal_',      '_turquoise_'),
+    Name.Class:         ('_darkgreen_', '_green_'),
+    Name.Exception:     ('teal',        'teal'),
+    Name.Decorator:     ('darkgray',    'lightgray'),
+    Name.Variable:      ('darkred',     'darkred'),
+    Name.Constant:      ('darkred',     'darkred'),
+    Name.Attribute:     ('teal',        'teal'),
+    Name.Tag:           ('blue',        'blue'),
+    String:             ('Blue',        'darkBlue'),
+    Number:             ('Teal',        'Teal'),
+
+    Generic.Deleted:    ('red',         'darkred'),
+    Generic.Inserted:   ('darkgreen',   'green'),
+    Generic.Heading:    ('**',          '**'),
+    Generic.Subheading: ('*purple*',    '*fuchsia*'),
+    Generic.Error:      ('red',         'darkred'),
+
+    Error:              ('_red_',       '_red_'),
+}
+
+low = lambda x: (x[0].lower(), x[1].lower())
+
+TERMINAL_COLORS = {k:low(v) for k,v in _TERMINAL_COLORS.items() }
+
+from pygments import highlight
+from pygments.lexers import PythonLexer
+from pygments.formatters import TerminalFormatter
+
+PL = PythonLexer()
+TF = TerminalFormatter(bg='dark', colorscheme=TERMINAL_COLORS) 
+
+hl = lambda code : highlight(code, PL, TF )
+
+
 LinuxColors = ColorScheme(
     'Linux',{
     token.NUMBER     : Colors.LightCyan,


### PR DESCRIPTION
Just manually porting the color themes.

Just annoying because pygments `red` is "bold red", `darkgreen` is lighter than `green` on light background. `brown` is "yellow".  `turquoise` and `darkteal` are the same. `*foo*` is suppose to be the bold version of `foo` , and logically `*darkgreen*` == `green` ...and `*gray*` == `lightgray`

![screen shot 2015-11-05 at 09 40 09](https://cloud.githubusercontent.com/assets/335567/10976546/3aee0ff2-83a1-11e5-98b6-7e43fedf336e.png)

(this missing word is "blink", that as you expect blinks)
