### PR TITLE
DeprecationWarning on deprecated colors API

### DIFF
--- a/IPython/core/excolors.py
+++ b/IPython/core/excolors.py
@@ -3,6 +3,8 @@
 Color schemes for exception handling code in IPython.
 """
 
+import warnings
+
 #*****************************************************************************
 #       Copyright (C) 2005-2006 Fernando Perez <fperez@colorado.edu>
 #
@@ -127,9 +129,19 @@ def exception_colors():
 
     return ex_colors
 
+class Deprec(object):
+
+    def __init__(self, wrapped_obj):
+        self.wrapped=wrapped_obj
+
+    def __getattr__(self, name):
+        val = getattr(self.wrapped, name)
+        warnings.warn("Using ExceptionColors global is deprecated", DeprecationWarning)
+        # using getattr after warnings break ipydoctest in weird way for 3.5
+        return val
 
 # For backwards compatibility, keep around a single global object.  Note that
 # this should NOT be used, the factory function should be used instead, since
 # these objects are stateful and it's very easy to get strange bugs if any code
 # modifies the module-level object's state.
-ExceptionColors = exception_colors()
+ExceptionColors = Deprec(exception_colors())

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -128,11 +128,11 @@ class DocTestFinder(doctest.DocTestFinder):
         Find tests for the given object and any contained objects, and
         add them to `tests`.
         """
-        #print '_find for:', obj, name, module  # dbg
+        print('_find for:', obj, name, module)  # dbg
         if hasattr(obj,"skip_doctest"):
             #print 'SKIPPING DOCTEST FOR:',obj  # dbg
             obj = DocTestSkip(obj)
-
+        
         doctest.DocTestFinder._find(self,tests, obj, name, module,
                                     source_lines, globs, seen)
 


### PR DESCRIPTION
Ok, been deprecated since 2009.
We can probably remove it.
