### PR TITLE
Fix empty figures in inline backend

### DIFF
--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -123,6 +123,10 @@ def print_figure(fig, fmt='png', bbox_inches='tight', **kwargs):
 def retina_figure(fig, **kwargs):
     """format a figure as a pixel-doubled (retina) PNG"""
     pngdata = print_figure(fig, fmt='retina', **kwargs)
+    # Make sure that retina_figure acts just like print_figure and returns
+    # None when the figure is empty.
+    if pngdata is None:
+        return
     w, h = _pngxy(pngdata)
     metadata = dict(width=w//2, height=h//2)
     return pngdata, metadata

--- a/IPython/core/tests/test_pylabtools.py
+++ b/IPython/core/tests/test_pylabtools.py
@@ -66,6 +66,11 @@ def test_figure_to_jpeg():
     assert jpeg.startswith(_JPEG)
 
 def test_retina_figure():
+    # simple empty-figure test
+    fig = plt.figure()
+    nt.assert_equal(pt.retina_figure(fig), None)
+    plt.close('all')
+
     fig = plt.figure()
     ax = fig.add_subplot(1,1,1)
     ax.plot([1,2,3])


### PR DESCRIPTION
closes #8871 

I recently ran into the same problem that @DanielLenz did in issue #8871. As @tacaswell suggested, I tried running the notebook with `%matplotlib notebook` and I am still getting the following error:

```
/Users/croach/anaconda/envs/mpl/lib/python2.7/site-packages/IPython/core/formatters.pyc in __call__(self, obj)
    335                 pass
    336             else:
--> 337                 return printer(obj)
    338             # Finally look for special method names
    339             method = _safe_get_formatter_method(obj, self.print_method)

/Users/croach/anaconda/envs/mpl/lib/python2.7/site-packages/IPython/core/pylabtools.pyc in <lambda>(fig)
    209         png_formatter.for_type(Figure, lambda fig: print_figure(fig, 'png', **kwargs))
    210     if 'retina' in formats or 'png2x' in formats:
--> 211         png_formatter.for_type(Figure, lambda fig: retina_figure(fig, **kwargs))
    212     if 'jpg' in formats or 'jpeg' in formats:
    213         jpg_formatter.for_type(Figure, lambda fig: print_figure(fig, 'jpg', **kwargs))

/Users/croach/anaconda/envs/mpl/lib/python2.7/site-packages/IPython/core/pylabtools.pyc in retina_figure(fig, **kwargs)
    126     # if pngdata is None:
    127     #     return
--> 128     w, h = _pngxy(pngdata)
    129     metadata = dict(width=w//2, height=h//2)
    130     return pngdata, metadata

/Users/croach/anaconda/envs/mpl/lib/python2.7/site-packages/IPython/core/display.pyc in _pngxy(data)
    607 def _pngxy(data):
    608     """read the (width, height) from a PNG header"""
--> 609     ihdr = data.index(b'IHDR')
    610     # next 8 bytes are width/height
    611     w4h4 = data[ihdr+4:ihdr+12]

AttributeError: 'NoneType' object has no attribute 'index'
```

I did a little further investigation and I was able to find the problem. The issue was that the `retina_figure` function was still trying to get the dimensions from the PNG data returned from `print_figure` even when `print_figure` returned `None` (the relevant lines from `print_figure` are shown below for reference).

``` python
# When there's an empty figure, we shouldn't return anything, otherwise we
# get big blank areas in the qt console.
if not fig.axes and not fig.lines:
    return
```

When the `retina_figure` function calls `print_figure` with an empty `Figure` object, `print_figure` returns `None` and the subsequent call to `_pngxy` fails with an "AttributeError: 'NoneType' object has no attribute 'index'" because the `pngdata` object passed in is `None` (`retina_figure` listed below for reference).

``` python
def retina_figure(fig, **kwargs):
    """format a figure as a pixel-doubled (retina) PNG"""
    pngdata = print_figure(fig, fmt='retina', **kwargs)
    w, h = _pngxy(pngdata)
    ...
```

It would be better if the `retina_figure` function acted the same way as the `print_figure` function since they are both used for the same purpose inside of the `select_figure_formats` (which is the only place the `retina_figure` function is used). So, to that end, I added a bit of code to check if the object returned from `print_figure` is `None`, and if so, I return `None` instead of continuing to process the bad data. This both solves the error I'm seeing, and has the nice side effect of making the behavior of `retina_figure` more like that of its non-retina counterpart `print_figure`.

I also added a bit of code to the `test_retina_figure` function that serves as a regression test. It turns out the `test_figure_to_svg` function already had a similar use case in it, so I just copied the bit of code there that makes sure an empty figure doesn't break the `print_figure` function over to the `test_retina_figure` and made sure it broke the test before adding my fix. 

This should fix the problem and allow the user to call either `plt.figure()` or `plt.gcf()` in a Jupyter notebook with the 'retina' format set.
