### PR TITLE
Fix color schemes in Linux

### DIFF
--- a/IPython/utils/PyColorize.py
+++ b/IPython/utils/PyColorize.py
@@ -88,11 +88,12 @@ NoColor = ColorScheme(
     'in_prompt'      : InputTermColors.NoColor,  # Input prompt
     'in_number'      : InputTermColors.NoColor,  # Input prompt number
     'in_prompt2'     : InputTermColors.NoColor, # Continuation prompt
+    'in_normal'      : InputTermColors.NoColor,  # color off (usu. Colors.Normal)
 
-    'out_prompt'     : InputTermColors.NoColor, # Output prompt
-    'out_number'     : InputTermColors.NoColor, # Output prompt number
+    'out_prompt'     : Colors.NoColor, # Output prompt
+    'out_number'     : Colors.NoColor, # Output prompt number
 
-    'normal'         : InputTermColors.NoColor  # color off (usu. Colors.Normal)
+    'normal'         : Colors.NoColor  # color off (usu. Colors.Normal)
     }  )
 
 LinuxColors = ColorScheme(
@@ -111,11 +112,12 @@ LinuxColors = ColorScheme(
     'in_prompt'      : InputTermColors.Green,
     'in_number'      : InputTermColors.LightGreen,
     'in_prompt2'     : InputTermColors.Green,
+    'in_normal'      : InputTermColors.Normal,  # color off (usu. Colors.Normal)
 
-    'out_prompt'     : InputTermColors.Red,
-    'out_number'     : InputTermColors.LightRed,
+    'out_prompt'     : Colors.Red,
+    'out_number'     : Colors.LightRed,
 
-    'normal'         : InputTermColors.Normal  # color off (usu. Colors.Normal)
+    'normal'         : Colors.Normal  # color off (usu. Colors.Normal)
     } )
 
 LightBGColors = ColorScheme(
@@ -134,11 +136,12 @@ LightBGColors = ColorScheme(
     'in_prompt'      : InputTermColors.Blue,
     'in_number'      : InputTermColors.LightBlue,
     'in_prompt2'     : InputTermColors.Blue,
+    'in_normal'      : InputTermColors.Normal,  # color off (usu. Colors.Normal)
 
-    'out_prompt'     : InputTermColors.Red,
-    'out_number'     : InputTermColors.LightRed,
+    'out_prompt'     : Colors.Red,
+    'out_number'     : Colors.LightRed,
 
-    'normal'         : InputTermColors.Normal  # color off (usu. Colors.Normal)
+    'normal'         : Colors.Normal  # color off (usu. Colors.Normal)
     }  )
 
 # Build table of color schemes (needed by the parser)


### PR DESCRIPTION
Object information found by prefixing object with a question mark (like
int?) was printing garbled characters.

git-bisect found 2b1c969628871300a4779963e8776b5a8e966f34 to be the
offending commit. A refactoring in that commit forgot to add one color
and also used the wrong object (it used InputTermColors instead of
TermColors).

![ipython-colors](https://cloud.githubusercontent.com/assets/55836/11381769/e542ddbc-92f5-11e5-9ac3-2f634752865c.png)
