### PR TITLE
remove unregister trait-change callback in ExtensionManager.__del__

### DIFF
--- a/IPython/core/extensions.py
+++ b/IPython/core/extensions.py
@@ -59,11 +59,6 @@ class ExtensionManager(Configurable):
         )
         self.loaded = set()
 
-    def __del__(self):
-        self.shell.on_trait_change(
-            self._on_ipython_dir_changed, 'ipython_dir', remove=True
-        )
-
     @property
     def ipython_extension_dir(self):
         return os.path.join(self.shell.ipython_dir, u'extensions')


### PR DESCRIPTION
Due to reference cycles, this can never be called at a time when it would matter, but seems to cause weird crashes sometimes during interpreter teardown on Python 3.5 with traitlets 4.1.

I have no idea what the relevant traitlets change is, and don't have 100% confidence that there even is one.

```
Fatal Python error: PyImport_GetModuleDict: no module dictionary!
Current thread 0x00007f3538110700 (most recent call first):
  File "/home/travis/virtualenv/python3.5.0/lib/python3.5/site-packages/traitlets/traitlets.py", line 1076 in on_trait_change
  File "/home/travis/virtualenv/python3.5.0/lib/python3.5/site-packages/IPython/core/extensions.py", line 64 in __del__
```

I haven't seen this outside Travis.

cf ipython/ipyparallel#77
