### PR TITLE
Actually warn that `ipython <subcommand>` is deprecated.

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -185,7 +185,7 @@ class BaseIPythonApplication(Application):
         super(BaseIPythonApplication, self).__init__(**kwargs)
         # ensure current working directory exists
         try:
-            directory = py3compat.getcwd()
+            py3compat.getcwd()
         except:
             # exit if cwd doesn't exist
             self.log.error("Current working directory doesn't exist.")
@@ -194,6 +194,16 @@ class BaseIPythonApplication(Application):
     #-------------------------------------------------------------------------
     # Various stages of Application creation
     #-------------------------------------------------------------------------
+
+    def initialize_subcommand(self, subc, argv=None):
+        if subc in self.deprecated_subcommands:
+            import time
+            self.log.warning("Subcommand `ipython {sub}` is deprecated and will be removed "
+                             "in future versions.".format(sub=subc))
+            self.log.warning("You likely want to use `jupyter {sub}`... continue "
+                             "in 5 sec".format(sub=subc))
+            time.sleep(5)
+        return super(BaseIPythonApplication, self).initialize_subcommand(subc, argv)
 
     def init_crash_handler(self):
         """Create a crash handler, typically setting sys.excepthook to it."""

--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -201,8 +201,11 @@ class BaseIPythonApplication(Application):
             self.log.warning("Subcommand `ipython {sub}` is deprecated and will be removed "
                              "in future versions.".format(sub=subc))
             self.log.warning("You likely want to use `jupyter {sub}`... continue "
-                             "in 5 sec".format(sub=subc))
-            time.sleep(5)
+                             "in 5 sec. Press Ctrl-C to quit now.".format(sub=subc))
+            try:
+                time.sleep(5)
+            except KeyboardInterrupt:
+                sys.exit(1)
         return super(BaseIPythonApplication, self).initialize_subcommand(subc, argv)
 
     def init_crash_handler(self):

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -50,22 +50,11 @@ ipython --matplotlib=qt    # enable matplotlib integration with qt4 backend
 ipython --log-level=DEBUG  # set logging to DEBUG
 ipython --profile=foo      # start with profile foo
 
-ipython qtconsole          # start the qtconsole GUI application
-ipython help qtconsole     # show the help for the qtconsole subcmd
-
-ipython console            # start the terminal-based console application
-ipython help console       # show the help for the console subcmd
-
-ipython notebook           # start the IPython notebook
-ipython help notebook      # show the help for the notebook subcmd
-
 ipython profile create foo # create profile foo w/ default config files
 ipython help profile       # show the help for the profile subcmd
 
 ipython locate             # print the path to the IPython directory
 ipython locate profile foo # print the path to the directory for profile `foo`
-
-ipython nbconvert          # convert notebooks to/from other formats
 """
 
 #-----------------------------------------------------------------------------
@@ -209,27 +198,15 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
             StoreMagics,
         ]
 
-    subcommands = dict(
+    deprecated_subcommands = dict(
         qtconsole=('qtconsole.qtconsoleapp.JupyterQtConsoleApp',
             """DEPRECATD: Launch the Jupyter Qt Console."""
         ),
         notebook=('notebook.notebookapp.NotebookApp',
             """DEPRECATED: Launch the Jupyter HTML Notebook Server."""
         ),
-        profile = ("IPython.core.profileapp.ProfileApp",
-            "Create and manage IPython profiles."
-        ),
-        kernel = ("ipykernel.kernelapp.IPKernelApp",
-            "Start a kernel without an attached frontend."
-        ),
         console=('jupyter_console.app.ZMQTerminalIPythonApp',
             """DEPRECATED: Launch the Jupyter terminal-based Console."""
-        ),
-        locate=('IPython.terminal.ipapp.LocateIPythonApp',
-            LocateIPythonApp.description
-        ),
-        history=('IPython.core.historyapp.HistoryApp',
-            "Manage the IPython history database."
         ),
         nbconvert=('nbconvert.nbconvertapp.NbConvertApp',
             "DEPRECATED: Convert notebooks to/from other formats."
@@ -241,10 +218,25 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
             "DEPRECATED: Manage Jupyter kernel specifications."
         ),
     )
-    subcommands['install-nbextension'] = (
+    subcommands = dict(
+        profile = ("IPython.core.profileapp.ProfileApp",
+            "Create and manage IPython profiles."
+        ),
+        kernel = ("ipykernel.kernelapp.IPKernelApp",
+            "Start a kernel without an attached frontend."
+        ),
+        locate=('IPython.terminal.ipapp.LocateIPythonApp',
+            LocateIPythonApp.description
+        ),
+        history=('IPython.core.historyapp.HistoryApp',
+            "Manage the IPython history database."
+        ),
+    )
+    deprecated_subcommands['install-nbextension'] = (
         "notebook.nbextensions.InstallNBExtensionApp",
         "DEPRECATED: Install Jupyter notebook extension files"
     )
+    subcommands.update(deprecated_subcommands)
 
     # *do* autocreate requested profile, but don't create the config file.
     auto_create=Bool(True)


### PR DESCRIPTION
Remove example, and add a 5 sec wait to have people actually read the
warning message.
## 

I see too many people using it, and I myself will continue doing it if I don't a carrot, or a stick. 
