### PR TITLE
don't install test extension

### DIFF
--- a/IPython/core/tests/daft_extension/setup.py
+++ b/IPython/core/tests/daft_extension/setup.py
@@ -1,5 +1,0 @@
-from distutils.core import setup
-setup(name='daft_extension',
-      version='1.0',
-      py_modules=['daft_extension'],
-      )

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -605,13 +605,10 @@ def test_prun_quotes():
     nt.assert_equal(_ip.user_ns['x'], '\t')
 
 def test_extension():
-    tmpdir = TemporaryDirectory()
-    orig_ipython_dir = _ip.ipython_dir
+    nt.assert_raises(ImportError, _ip.magic, "load_ext daft_extension")
+    daft_path = os.path.join(os.path.dirname(__file__), "daft_extension")
+    sys.path.insert(0, daft_path)
     try:
-        _ip.ipython_dir = tmpdir.name
-        nt.assert_raises(ImportError, _ip.magic, "load_ext daft_extension")
-        url = os.path.join(os.path.dirname(__file__), "daft_extension")
-        _ip.system("%s -m pip install %s" % (sys.executable, url))
         _ip.user_ns.pop('arq', None)
         invalidate_caches()   # Clear import caches
         _ip.magic("load_ext daft_extension")
@@ -619,8 +616,7 @@ def test_extension():
         _ip.magic("unload_ext daft_extension")
         assert 'arq' not in _ip.user_ns
     finally:
-        _ip.ipython_dir = orig_ipython_dir
-        tmpdir.cleanup()
+        sys.path.remove(daft_path)
 
 
 @dec.skip_without('nbformat')

--- a/setupbase.py
+++ b/setupbase.py
@@ -126,7 +126,7 @@ def find_package_data():
     
     package_data = {
         'IPython.core' : ['profile/README*'],
-        'IPython.core.tests' : ['*.png', '*.jpg'],
+        'IPython.core.tests' : ['*.png', '*.jpg', 'daft_extension/*.py'],
         'IPython.lib.tests' : ['*.wav'],
         'IPython.testing.plugin' : ['*.txt'],
     }


### PR DESCRIPTION
which may require sudo and will pollute the system, causing subsequent runs to always fail.

Instead, make the module importable by putting it on sys.path.
