### PR TITLE
Move most readline code from InteractiveShell to terminal subclass

### DIFF
--- a/IPython/utils/contexts.py
+++ b/IPython/utils/contexts.py
@@ -1,22 +1,9 @@
 # encoding: utf-8
-"""
-Context managers for temporarily updating dictionaries.
-
-Authors:
-
-* Bradley Froehle
+"""Miscellaneous context managers.
 """
 
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2012  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Code
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 class preserve_keys(object):
     """Preserve a set of keys in a dictionary.
@@ -69,3 +56,9 @@ class preserve_keys(object):
         for k in self.to_delete:
             d.pop(k, None)
         d.update(self.to_update)
+
+
+class NoOpContext(object):
+    """Context manager that does nothing."""
+    def __enter__(self): pass
+    def __exit__(self, type, value, traceback): pass


### PR DESCRIPTION
This is the first stage of my effort to use prompt_toolkit for the terminal interface.

My plan is to create a new subclass of InteractiveShell which deals with the terminal using prompt_toolkit instead of readline. To facilitate this, I am first trying to separate as much of the readline code as possible out of InteractiveShell to the TerminalInteractiveShell subclass (I don't intend the new subclass to inherit from TIS).

I haven't moved any of the config options relating to readline yet, because moving them will break some people's existing config files. But if we're switching to prompt_toolkit by default, readline related config is going to be broken anyway.
