### PR TITLE
Remove old rtd note specifying that RTD isn't official docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,13 +7,7 @@ IPython Documentation
    :Release: |release|
    :Date: |today|
 
-.. only:: not rtd
-
-    Welcome to the official IPython documentation.
-
-.. only:: rtd
-
-    This is a partial copy of IPython documentation, please visit `IPython official documentation <http://ipython.org/documentation.html>`_.
+Welcome to the official IPython documentation.
 
 Contents
 ========


### PR DESCRIPTION
Official docs are on RTD, now
