### PR TITLE
[WIP] Heuristic for better error messages

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -1044,8 +1044,10 @@ class VerboseTB(TBTools):
                     func = last_record[0].f_globals.get(function, None)
                 signature = inspect.signature(func)
                 matches = difflib.get_close_matches(kw, signature.parameters.keys(), 3, 0.3)
-                if matches:
-                    evalue.args = (evalue.args[0]+'. Did you meant one of %s ? ' % ', '.join(map(lambda x : "'"+x+"'",matches)), )
+                if len(matches) == 1:
+                    evalue.args = (evalue.args[0]+". Did you mean '%s' ? " % matches[0]), )
+                elif len(matches) > 1:
+                    evalue.args = (evalue.args[0]+'. Did you mean one of %s ? ' % ', '.join(map(lambda x : "'"+x+"'",matches)), )
         except Exception:
             pass
     

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -1036,20 +1036,18 @@ class VerboseTB(TBTools):
         # figure out what to do on len(args) > 1
         match = reg.match(evalue.args[0])
         if (etype == 'TypeError') and match:
-            last_record = records[-1]
-            function, kw = match.groups()
-            func = last_record[0].f_locals.get(function, None)
-            if not func:
-                func = last_record[0].f_globals.get(function, None)
-            signature = inspect.signature(func)
-            matches = difflib.get_close_matches(kw, signature.parameters.keys(), 3, 0.3)
-            if matches:
-                evalue.args = (evalue.args[0]+'. Did you meant one of %s ? ' % ', '.join(map(lambda x : "'"+x+"'",matches)), )
-            else:
-                import pdb; pdb.set_trace()
-        else:
-            import pdb; pdb.set_trace()
-
+            try:
+                last_record = records[-1]
+                function, kw = match.groups()
+                func = last_record[0].f_locals.get(function, None)
+                if not func:
+                    func = last_record[0].f_globals.get(function, None)
+                signature = inspect.signature(func)
+                matches = difflib.get_close_matches(kw, signature.parameters.keys(), 3, 0.3)
+                if matches:
+                    evalue.args = (evalue.args[0]+'. Did you meant one of %s ? ' % ', '.join(map(lambda x : "'"+x+"'",matches)), )
+            except Exception:
+                pass
     
     
     

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -1034,9 +1034,9 @@ class VerboseTB(TBTools):
         # record heuristics
         reg = re.compile("([a-zA-Z_]+)\(\) got an unexpected keyword argument '(.+)'")
         # figure out what to do on len(args) > 1
-        match = reg.match(evalue.args[0])
-        if (etype == 'TypeError') and match:
-            try:
+        try:
+            match = reg.match(evalue.args[0])
+            if (etype == 'TypeError') and match:
                 last_record = records[-1]
                 function, kw = match.groups()
                 func = last_record[0].f_locals.get(function, None)
@@ -1046,8 +1046,8 @@ class VerboseTB(TBTools):
                 matches = difflib.get_close_matches(kw, signature.parameters.keys(), 3, 0.3)
                 if matches:
                     evalue.args = (evalue.args[0]+'. Did you meant one of %s ? ' % ', '.join(map(lambda x : "'"+x+"'",matches)), )
-            except Exception:
-                pass
+        except Exception:
+            pass
     
     
     

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -1045,7 +1045,7 @@ class VerboseTB(TBTools):
                 signature = inspect.signature(func)
                 matches = difflib.get_close_matches(kw, signature.parameters.keys(), 3, 0.3)
                 if len(matches) == 1:
-                    evalue.args = (evalue.args[0]+". Did you mean '%s' ? " % matches[0]), )
+                    evalue.args = (evalue.args[0]+". Did you mean '%s' ? " % matches[0], )
                 elif len(matches) > 1:
                     evalue.args = (evalue.args[0]+'. Did you mean one of %s ? ' % ', '.join(map(lambda x : "'"+x+"'",matches)), )
         except Exception:


### PR DESCRIPTION
Proof of concept:

```
In [1]: from numpy import ones

In [2]: def stuff(**kwargs):
   ...:     return ones(**kwargs)
   ...:

In [3]: stuff(size=18)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-ee3c5cbdb6f2> in <module>()
----> 1 stuff(size=18)

<ipython-input-2-542e3f8f2f33> in stuff(**kwargs)
      1 def stuff(**kwargs):
----> 2     return ones(**kwargs)
      3

TypeError: ones() got an unexpected keyword argument 'size'. Did you meant one of 'shape' ?
```

See the `did you mean` at the end ? 
English need to be better of course, and here the `one of` is extra as it finds only 1 match. 

Anyway I **think** this would be tremendously useful for beginners to have a framework where before displaying a traceback we could spice it up with potential "fixes".
