### PR TITLE
Note removal versions in deprecation warnings

### DIFF
--- a/IPython/core/builtin_trap.py
+++ b/IPython/core/builtin_trap.py
@@ -57,7 +57,7 @@ class BuiltinTrap(Configurable):
             from IPython.lib import deepreload
             if self.shell.deep_reload:
                 from warnings import warn
-                warn("Automatically replacing builtin `reload` by `deepreload.reload` is deprecated, please import `reload` explicitly from `IPython.lib.deeprelaod", DeprecationWarning)
+                warn("Automatically replacing builtin `reload` by `deepreload.reload` is deprecated and will be removed in IPython 6.0, please import `reload` explicitly from `IPython.lib.deeprelaod", DeprecationWarning)
                 self.auto_builtins['reload'] = deepreload._dreload
             else:
                 self.auto_builtins['dreload']= deepreload._dreload

--- a/IPython/core/excolors.py
+++ b/IPython/core/excolors.py
@@ -136,7 +136,7 @@ class Deprec(object):
 
     def __getattr__(self, name):
         val = getattr(self.wrapped, name)
-        warnings.warn("Using ExceptionColors global is deprecated", DeprecationWarning)
+        warnings.warn("Using ExceptionColors global is deprecated and will be removed in IPython 6.0", DeprecationWarning)
         # using getattr after warnings break ipydoctest in weird way for 3.5
         return val
 

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -62,6 +62,8 @@ class DisplayFormatter(Configurable):
     def _plain_text_only_changed(self, name, old, new):
         warnings.warn("""DisplayFormatter.plain_text_only is deprecated.
         
+        It will be removed in IPython 5.0
+
         Use DisplayFormatter.active_types = ['text/plain']
         for the same effect.
         """, DeprecationWarning)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -294,6 +294,8 @@ class InteractiveShell(SingletonConfigurable):
         """
         **Deprecated**
 
+        Will be removed in IPython 6.0
+
         Enable deep (recursive) reloading by default. IPython can use the
         deep_reload module which reloads changes in modules recursively (it
         replaces the reload() function, so you don't need to change anything to
@@ -365,13 +367,13 @@ class InteractiveShell(SingletonConfigurable):
     # deprecated prompt traits:
     
     prompt_in1 = Unicode('In [\\#]: ', config=True,
-        help="Deprecated, use PromptManager.in_template")
+        help="Deprecated, will be removed in IPython 5.0, use PromptManager.in_template")
     prompt_in2 = Unicode('   .\\D.: ', config=True,
-        help="Deprecated, use PromptManager.in2_template")
+        help="Deprecated, will be removed in IPython 5.0, use PromptManager.in2_template")
     prompt_out = Unicode('Out[\\#]: ', config=True,
-        help="Deprecated, use PromptManager.out_template")
+        help="Deprecated, will be removed in IPython 5.0, use PromptManager.out_template")
     prompts_pad_left = CBool(True, config=True,
-        help="Deprecated, use PromptManager.justify")
+        help="Deprecated, will be removed in IPython 5.0, use PromptManager.justify")
     
     def _prompt_trait_changed(self, name, old, new):
         table = {

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -433,6 +433,8 @@ class MagicsManager(Configurable):
     def define_magic(self, name, func):
         """[Deprecated] Expose own function as magic function for IPython.
 
+        Will be removed in IPython 5.0
+
         Example::
 
             def foo_impl(self, parameter_s=''):

--- a/IPython/core/magics/deprecated.py
+++ b/IPython/core/magics/deprecated.py
@@ -15,6 +15,7 @@ from __future__ import print_function
 
 # Our own packages
 from IPython.core.magic import Magics, magics_class, line_magic
+import warnings
 
 #-----------------------------------------------------------------------------
 # Magic implementation classes
@@ -28,7 +29,7 @@ class DeprecatedMagics(Magics):
     def install_profiles(self, parameter_s=''):
         """%install_profiles has been deprecated."""
         print('\n'.join([
-            "%install_profiles has been deprecated.",
+            "%install_profiles has been deprecated and will be removed in IPython 5.0.",
             "Use `ipython profile list` to view available profiles.",
             "Requesting a profile with `ipython profile create <name>`",
             "or `ipython --profile=<name>` will start with the bundled",
@@ -37,7 +38,7 @@ class DeprecatedMagics(Magics):
 
     @line_magic
     def install_default_config(self, parameter_s=''):
-        """%install_default_config has been deprecated."""
+        """%install_default_config has been deprecate and will be removed in IPython 5.0."""
         print('\n'.join([
             "%install_default_config has been deprecated.",
             "Use `ipython profile create <name>` to initialize a profile",

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -71,7 +71,9 @@ addflag('color-info', 'InteractiveShell.color_info',
     "Disable using colors for info related things."
 )
 addflag('deep-reload', 'InteractiveShell.deep_reload',
-    """ **Deprecated** Enable deep (recursive) reloading by default. IPython can use the
+    """ **Deprecated** and will be removed in IPython 5.0.
+    
+    Enable deep (recursive) reloading by default. IPython can use the
     deep_reload module which reloads changes in modules recursively (it
     replaces the reload() function, so you don't need to change anything to
     use it). deep_reload() forces a full reload of modules whose code may

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -30,7 +30,6 @@ from IPython.testing.decorators import (
     skipif, skip_win32, onlyif_unicode_paths, onlyif_cmds_exist,
 )
 from IPython.testing import tools as tt
-from IPython.utils import io
 from IPython.utils.process import find_cmd
 from IPython.utils import py3compat
 from IPython.utils.py3compat import unicode_type, PY3

--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -351,7 +351,8 @@ def _dreload(module, **kwargs):
 
     """
     warn("""
-injecting `dreload` in interactive namespace is deprecated, please import `reload` explicitly from `IPython.lib.deepreload`
+injecting `dreload` in interactive namespace is deprecated, and will be removed in IPython 5.0. 
+Please import `reload` explicitly from `IPython.lib.deepreload`.
 """, DeprecationWarning, stacklevel=2)
     reload(module, **kwargs)
 

--- a/IPython/lib/kernel.py
+++ b/IPython/lib/kernel.py
@@ -5,7 +5,7 @@ Moved to IPython.kernel.connect
 
 import warnings
 warnings.warn("IPython.lib.kernel moved to IPython.kernel.connect in IPython 1.0," 
-        "and will be removed in IPython 6.0.",
+        " and will be removed in IPython 6.0.",
     DeprecationWarning
 )
 

--- a/IPython/lib/kernel.py
+++ b/IPython/lib/kernel.py
@@ -4,7 +4,8 @@ Moved to IPython.kernel.connect
 """
 
 import warnings
-warnings.warn("IPython.lib.kernel moved to IPython.kernel.connect in IPython 1.0",
+warnings.warn("IPython.lib.kernel moved to IPython.kernel.connect in IPython 1.0," 
+        "and will be removed in IPython 6.0.",
     DeprecationWarning
 )
 

--- a/IPython/terminal/embed.py
+++ b/IPython/terminal/embed.py
@@ -63,7 +63,7 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
     
         if kw.get('user_global_ns', None) is not None:
             warnings.warn("user_global_ns has been replaced by user_module. The\
-                           parameter will be ignored.", DeprecationWarning)
+                           parameter will be ignored, and removed in IPython 5.0", DeprecationWarning)
 
         super(InteractiveShellEmbed,self).__init__(**kw)
 
@@ -158,7 +158,7 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
         """
         
         if (global_ns is not None) and (module is None):
-            warnings.warn("global_ns is deprecated, use module instead.", DeprecationWarning)
+            warnings.warn("global_ns is deprecated, and will be removed in IPython 5.0 use module instead.", DeprecationWarning)
             module = DummyMod()
             module.__dict__ = global_ns
 

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -200,22 +200,22 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
 
     deprecated_subcommands = dict(
         qtconsole=('qtconsole.qtconsoleapp.JupyterQtConsoleApp',
-            """DEPRECATD: Launch the Jupyter Qt Console."""
+            """DEPRECATED, Will be removed in IPython 6.0 : Launch the Jupyter Qt Console."""
         ),
         notebook=('notebook.notebookapp.NotebookApp',
-            """DEPRECATED: Launch the Jupyter HTML Notebook Server."""
+            """DEPRECATED, Will be removed in IPython 6.0 : Launch the Jupyter HTML Notebook Server."""
         ),
         console=('jupyter_console.app.ZMQTerminalIPythonApp',
-            """DEPRECATED: Launch the Jupyter terminal-based Console."""
+            """DEPRECATED, Will be removed in IPython 6.0 : Launch the Jupyter terminal-based Console."""
         ),
         nbconvert=('nbconvert.nbconvertapp.NbConvertApp',
-            "DEPRECATED: Convert notebooks to/from other formats."
+            "DEPRECATED, Will be removed in IPython 6.0 : Convert notebooks to/from other formats."
         ),
         trust=('nbformat.sign.TrustNotebookApp',
-            "DEPRECATED: Sign notebooks to trust their potentially unsafe contents at load."
+            "DEPRECATED, Will be removed in IPython 6.0 : Sign notebooks to trust their potentially unsafe contents at load."
         ),
         kernelspec=('jupyter_client.kernelspecapp.KernelSpecApp',
-            "DEPRECATED: Manage Jupyter kernel specifications."
+            "DEPRECATED, Will be removed in IPython 6.0 : Manage Jupyter kernel specifications."
         ),
     )
     subcommands = dict(
@@ -234,7 +234,7 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
     )
     deprecated_subcommands['install-nbextension'] = (
         "notebook.nbextensions.InstallNBExtensionApp",
-        "DEPRECATED: Install Jupyter notebook extension files"
+        "DEPRECATED, Will be removed in IPython 6.0 : Install Jupyter notebook extension files"
     )
     subcommands.update(deprecated_subcommands)
 

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -76,7 +76,7 @@ def apply_wrapper(wrapper,func):
     This will ensure that wrapped functions can still be well introspected via
     IPython, for example.
     """
-    warnings.warn("The function `apply_wrapper` is deprecated and might be removed in next major version of IPython", DeprecationWarning)
+    warnings.warn("The function `apply_wrapper` is deprecated and might be removed in IPython 5.0", DeprecationWarning)
 
     import nose.tools
 
@@ -128,7 +128,7 @@ def make_label_dec(label,ds=None):
     True
     """
 
-    warnings.warn("The function `make_label_dec` is deprecated and might be removed in next major version of IPython", DeprecationWarning)
+    warnings.warn("The function `make_label_dec` is deprecated and might be removed in IPython 5.0", DeprecationWarning)
     if isinstance(label, string_types):
         labels = [label]
     else:
@@ -284,7 +284,7 @@ def decorated_dummy(dec, name):
     import IPython.testing.decorators as dec
     setup = dec.decorated_dummy(dec.skip_if_no_x11, __name__)
     """
-    warnings.warn("The function `make_label_dec` is deprecated and might be removed in next major version of IPython", DeprecationWarning)
+    warnings.warn("The function `make_label_dec` is deprecated and might be removed in IPython 5.0", DeprecationWarning)
     dummy = lambda: None
     dummy.__name__ = name
     return dec(dummy)
@@ -317,7 +317,7 @@ skip_if_no_x11 = skipif(_x11_skip_cond, _x11_skip_msg)
 
 # not a decorator itself, returns a dummy function to be used as setup
 def skip_file_no_x11(name):
-    warnings.warn("The function `skip_file_no_x11` is deprecated and might be removed in next major version of IPython", DeprecationWarning)
+    warnings.warn("The function `skip_file_no_x11` is deprecated and might be removed in IPython 5.0", DeprecationWarning)
     return decorated_dummy(skip_if_no_x11, name) if _x11_skip_cond else None
 
 # Other skip decorators
@@ -371,7 +371,7 @@ def onlyif_any_cmd_exists(*commands):
     """
     Decorator to skip test unless at least one of `commands` is found.
     """
-    warnings.warn("The function `onlyif_any_cmd_exists` is deprecated and might be removed in next major version of IPython", DeprecationWarning)
+    warnings.warn("The function `onlyif_any_cmd_exists` is deprecated and might be removed in IPython 5.0", DeprecationWarning)
     for cmd in commands:
         if which(cmd):
             return null_deco

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -42,22 +42,6 @@ from IPython.external.decorators import KnownFailure, knownfailureif
 
 pjoin = path.join
 
-#-----------------------------------------------------------------------------
-# Warnings control
-#-----------------------------------------------------------------------------
-
-# Twisted generates annoying warnings with Python 2.6, as will do other code
-# that imports 'sets' as of today
-warnings.filterwarnings('ignore', 'the sets module is deprecated',
-                        DeprecationWarning )
-
-# This one also comes from Twisted
-warnings.filterwarnings('ignore', 'the sha module is deprecated',
-                        DeprecationWarning)
-
-# Wx on Fedora11 spits these out
-warnings.filterwarnings('ignore', 'wxPython/wxWidgets release number mismatch',
-                        UserWarning)
 
 # Enable printing all warnings raise by IPython's modules
 warnings.filterwarnings('default', message='.*', category=Warning, module='IPy.*')


### PR DESCRIPTION
Otherwise we never know when a feature will be removed.

Nothing prevent us to keep longer, but at least giving a version number
instead of "Next Major release" give a hint to users. And also when we
want to cleanup later, we don't have to wonder when the deprecation was
added.
## 

I've put 5.0 as a limit for things already deprecated for a while (like since 1.0). 
And 6.0 for things still potentially used. 
