### PR TITLE
Support parallel sphinx building

### DIFF
--- a/IPython/sphinxext/ipython_console_highlighting.py
+++ b/IPython/sphinxext/ipython_console_highlighting.py
@@ -13,7 +13,8 @@ def setup(app):
     # But if somebody knows what the right API usage should be to do that via
     # sphinx, by all means fix it here.  At least having this setup.py
     # suppresses the sphinx warning we'd get without it.
-    pass
+    metadata = {'parallel_read_safe': True, 'parallel_write_safe': True}
+    return metadata
 
 # Register the extension as a valid pygments lexer.
 # Alternatively, we could register the lexer with pygments instead. This would

--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -1008,6 +1008,9 @@ def setup(app):
 
     app.add_config_value('ipython_holdcount', True, 'env')
 
+    metadata = {'parallel_read_safe': True, 'parallel_write_safe': True}
+    return metadata
+
 # Simple smoke test, needs to be converted to a proper automatic test.
 def test():
 

--- a/docs/sphinxext/github.py
+++ b/docs/sphinxext/github.py
@@ -143,7 +143,7 @@ def ghcommit_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
 
 def setup(app):
     """Install the plugin.
-    
+
     :param app: Sphinx application context.
     """
     app.info('Initializing GitHub plugin')
@@ -152,4 +152,6 @@ def setup(app):
     app.add_role('ghuser', ghuser_role)
     app.add_role('ghcommit', ghcommit_role)
     app.add_config_value('github_project_url', None, 'env')
-    return
+
+    metadata = {'parallel_read_safe': True, 'parallel_write_safe': True}
+    return metadata

--- a/docs/sphinxext/magics.py
+++ b/docs/sphinxext/magics.py
@@ -40,3 +40,6 @@ def setup(app):
     StandardDomain.roles['magic'] = LineMagicRole()
     app.add_object_type('cellmagic', 'cellmagic', 'pair: %s; cell magic', parse_cell_magic)
     StandardDomain.roles['cellmagic'] = CellMagicRole()
+
+    metadata = {'parallel_read_safe': True, 'parallel_write_safe': True}
+    return metadata


### PR DESCRIPTION
This marks the sphinx extensions that ship with IPython as being safe for parallel reading.

See [here](http://sphinx-doc.org/latest/extdev/index.html#extension-metadata) for the relevant part of the Sphinx spec.

See matplotlib/matplotlib#5597: We'd like to have this in matplotlib, since parallel doc building cuts the build time in half from 9 minutes to 4.5 minutes.
