### PR TITLE
external/qt_loaders: list required Qt modules in import error message

### DIFF
--- a/IPython/external/qt_loaders.py
+++ b/IPython/external/qt_loaders.py
@@ -284,11 +284,11 @@ def load_qt(api_options):
     PyQt4 >= 4.7, PyQt5 or PySide >= 1.0.3 is available,
     and only one is imported per session.
 
-    Currently-imported Qt library:   %r
-    PyQt4 installed:                 %s
-    PyQt5 installed:                 %s
-    PySide >= 1.0.3 installed:       %s
-    Tried to load:                   %r
+    Currently-imported Qt library:                              %r
+    PyQt4 available (requires QtCore, QtGui, QtSvg):            %s
+    PyQt5 available (requires QtCore, QtGui, QtSvg, QtWidgets): %s
+    PySide >= 1.0.3 installed:                                  %s
+    Tried to load:                                              %r
     """ % (loaded_api(),
            has_binding(QT_API_PYQT),
            has_binding(QT_API_PYQT5),


### PR DESCRIPTION
This is probably the simplest/easiest way to provide a quick resolution for https://github.com/ipython/ipython/issues/8411.

A more thorough approach would probably be not to shield/hide specific import errors, but to really produce an error message in the moment a certain module cannot be imported. This would, however, require a larger refactoring of the `qt_loaders` module.
