### PR TITLE
[do not merge] Raise if `log.warn` used during tests

### DIFF
--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -62,6 +62,7 @@ warnings.filterwarnings('ignore', 'wxPython/wxWidgets release number mismatch',
 # Enable printing all warnings raise by IPython's modules
 warnings.filterwarnings('default', message='.*', category=Warning, module='IPy.*')
 
+warnings.filterwarnings('error', "The 'warn' method is deprecated, use 'warning' instead", DeprecationWarning)
 
 if version_info < (4,2):
     # ignore some warnings from traitlets until 6.0


### PR DESCRIPTION
cf https://github.com/ipython/ipython/issues/9091,

`log.warn` is deprecated. This **should** make the test fail as it **should** turn usage of `self.warn` into an error.

Though it does not. Any insight as to why ?

[Do not merge]
