### PR TITLE
ensure deprecated_subcommands is defined

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -194,7 +194,9 @@ class BaseIPythonApplication(Application):
     #-------------------------------------------------------------------------
     # Various stages of Application creation
     #-------------------------------------------------------------------------
-
+    
+    deprecated_subcommands = {}
+    
     def initialize_subcommand(self, subc, argv=None):
         if subc in self.deprecated_subcommands:
             import time


### PR DESCRIPTION
on the base Application class

cased AttributeError on subclasses other than TerminalIPythonApp
