### PR TITLE
Terminal interface based on prompt_toolkit

### DIFF
--- a/IPython/core/tests/test_shellapp.py
+++ b/IPython/core/tests/test_shellapp.py
@@ -52,8 +52,9 @@ class TestFileToRun(unittest.TestCase, tt.TempFileMixin):
         src = "True\n"
         self.mktmp(src)
 
+        out = 'In [1]: False\n\nIn [2]:'
         err = SQLITE_NOT_AVAILABLE_ERROR if sqlite_err_maybe else None
-        tt.ipexec_validate(self.fname, 'False', err, options=['-i'],
+        tt.ipexec_validate(self.fname, out, err, options=['-i'],
                            commands=['"__file__" in globals()', 'exit()'])
 
     @dec.skip_win32
@@ -63,6 +64,7 @@ class TestFileToRun(unittest.TestCase, tt.TempFileMixin):
         src = "from __future__ import division\n"
         self.mktmp(src)
 
+        out = 'In [1]: float\n\nIn [2]:'
         err = SQLITE_NOT_AVAILABLE_ERROR if sqlite_err_maybe else None
-        tt.ipexec_validate(self.fname, 'float', err, options=['-i'],
+        tt.ipexec_validate(self.fname, out, err, options=['-i'],
                            commands=['type(1/2)', 'exit()'])

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -32,7 +32,7 @@ from IPython.core.shellapp import (
     InteractiveShellApp, shell_flags, shell_aliases
 )
 from IPython.extensions.storemagic import StoreMagics
-from IPython.terminal.interactiveshell import TerminalInteractiveShell
+from .ptshell import PTInteractiveShell as TerminalInteractiveShell
 from IPython.utils import warn
 from IPython.paths import get_ipython_dir
 from traitlets import (

--- a/IPython/terminal/pt_inputhooks/__init__.py
+++ b/IPython/terminal/pt_inputhooks/__init__.py
@@ -1,0 +1,16 @@
+import importlib
+import os
+
+aliases = {
+    'qt4': 'qt'
+}
+
+def get_inputhook_func(gui):
+    if gui in aliases:
+        return get_inputhook_func(aliases[gui])
+
+    if gui == 'qt5':
+        os.environ['QT_API'] = 'pyqt5'
+
+    mod = importlib.import_module('IPython.terminal.pt_inputhooks.'+gui)
+    return mod.inputhook

--- a/IPython/terminal/pt_inputhooks/__init__.py
+++ b/IPython/terminal/pt_inputhooks/__init__.py
@@ -2,7 +2,7 @@ import importlib
 import os
 
 aliases = {
-    'qt4': 'qt'
+    'qt4': 'qt',
 }
 
 def get_inputhook_func(gui):

--- a/IPython/terminal/pt_inputhooks/glut.py
+++ b/IPython/terminal/pt_inputhooks/glut.py
@@ -1,0 +1,141 @@
+"""GLUT Input hook for interactive use with prompt_toolkit
+"""
+from __future__ import print_function
+
+
+# GLUT is quite an old library and it is difficult to ensure proper
+# integration within IPython since original GLUT does not allow to handle
+# events one by one. Instead, it requires for the mainloop to be entered
+# and never returned (there is not even a function to exit he
+# mainloop). Fortunately, there are alternatives such as freeglut
+# (available for linux and windows) and the OSX implementation gives
+# access to a glutCheckLoop() function that blocks itself until a new
+# event is received. This means we have to setup the idle callback to
+# ensure we got at least one event that will unblock the function.
+#
+# Furthermore, it is not possible to install these handlers without a window
+# being first created. We choose to make this window invisible. This means that
+# display mode options are set at this level and user won't be able to change
+# them later without modifying the code. This should probably be made available
+# via IPython options system.
+
+import sys
+import time
+import signal
+import OpenGL.GLUT as glut
+import OpenGL.platform as platform
+from timeit import default_timer as clock
+
+# Frame per second : 60
+# Should probably be an IPython option
+glut_fps = 60
+
+# Display mode : double buffeed + rgba + depth
+# Should probably be an IPython option
+glut_display_mode = (glut.GLUT_DOUBLE |
+                     glut.GLUT_RGBA   |
+                     glut.GLUT_DEPTH)
+
+glutMainLoopEvent = None
+if sys.platform == 'darwin':
+    try:
+        glutCheckLoop = platform.createBaseFunction(
+            'glutCheckLoop', dll=platform.GLUT, resultType=None,
+            argTypes=[],
+            doc='glutCheckLoop(  ) -> None',
+            argNames=(),
+            )
+    except AttributeError:
+        raise RuntimeError(
+            '''Your glut implementation does not allow interactive sessions'''
+            '''Consider installing freeglut.''')
+    glutMainLoopEvent = glutCheckLoop
+elif glut.HAVE_FREEGLUT:
+    glutMainLoopEvent = glut.glutMainLoopEvent
+else:
+    raise RuntimeError(
+        '''Your glut implementation does not allow interactive sessions. '''
+        '''Consider installing freeglut.''')
+
+
+def glut_display():
+    # Dummy display function
+    pass
+
+def glut_idle():
+    # Dummy idle function
+    pass
+
+def glut_close():
+    # Close function only hides the current window
+    glut.glutHideWindow()
+    glutMainLoopEvent()
+
+def glut_int_handler(signum, frame):
+    # Catch sigint and print the defaultipyt   message
+    signal.signal(signal.SIGINT, signal.default_int_handler)
+    print('\nKeyboardInterrupt')
+    # Need to reprint the prompt at this stage
+
+# Initialisation code
+glut.glutInit( sys.argv )
+glut.glutInitDisplayMode( glut_display_mode )
+# This is specific to freeglut
+if bool(glut.glutSetOption):
+    glut.glutSetOption( glut.GLUT_ACTION_ON_WINDOW_CLOSE,
+                        glut.GLUT_ACTION_GLUTMAINLOOP_RETURNS )
+glut.glutCreateWindow( b'ipython' )
+glut.glutReshapeWindow( 1, 1 )
+glut.glutHideWindow( )
+glut.glutWMCloseFunc( glut_close )
+glut.glutDisplayFunc( glut_display )
+glut.glutIdleFunc( glut_idle )
+
+
+def inputhook(context):
+    """Run the pyglet event loop by processing pending events only.
+
+    This keeps processing pending events until stdin is ready.  After
+    processing all pending events, a call to time.sleep is inserted.  This is
+    needed, otherwise, CPU usage is at 100%.  This sleep time should be tuned
+    though for best performance.
+    """
+    # We need to protect against a user pressing Control-C when IPython is
+    # idle and this is running. We trap KeyboardInterrupt and pass.
+
+    signal.signal(signal.SIGINT, glut_int_handler)
+
+    try:
+        t = clock()
+
+        # Make sure the default window is set after a window has been closed
+        if glut.glutGetWindow() == 0:
+            glut.glutSetWindow( 1 )
+            glutMainLoopEvent()
+            return 0
+
+        while not context.input_is_ready():
+            glutMainLoopEvent()
+            # We need to sleep at this point to keep the idle CPU load
+            # low.  However, if sleep to long, GUI response is poor.  As
+            # a compromise, we watch how often GUI events are being processed
+            # and switch between a short and long sleep time.  Here are some
+            # stats useful in helping to tune this.
+            # time    CPU load
+            # 0.001   13%
+            # 0.005   3%
+            # 0.01    1.5%
+            # 0.05    0.5%
+            used_time = clock() - t
+            if used_time > 10.0:
+                # print 'Sleep for 1 s'  # dbg
+                time.sleep(1.0)
+            elif used_time > 0.1:
+                # Few GUI events coming in, so we can sleep longer
+                # print 'Sleep for 0.05 s'  # dbg
+                time.sleep(0.05)
+            else:
+                # Many GUI events coming in, so sleep only very little
+                time.sleep(0.001)
+    except KeyboardInterrupt:
+        pass

--- a/IPython/terminal/pt_inputhooks/gtk.py
+++ b/IPython/terminal/pt_inputhooks/gtk.py
@@ -35,6 +35,7 @@ PyGTK input hook for prompt_toolkit.
 Listens on the pipe prompt_toolkit sets up for a notification that it should
 return control to the terminal event loop.
 """
+from __future__ import absolute_import
 
 import gtk, gobject
 

--- a/IPython/terminal/pt_inputhooks/gtk.py
+++ b/IPython/terminal/pt_inputhooks/gtk.py
@@ -1,0 +1,55 @@
+# Code borrowed from python-prompt-toolkit examples
+# https://github.com/jonathanslenders/python-prompt-toolkit/blob/77cdcfbc7f4b4c34a9d2f9a34d422d7152f16209/examples/inputhook.py
+
+# Copyright (c) 2014, Jonathan Slenders
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice, this
+#   list of conditions and the following disclaimer in the documentation and/or
+#   other materials provided with the distribution.
+#
+# * Neither the name of the {organization} nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+PyGTK input hook for prompt_toolkit.
+
+Listens on the pipe prompt_toolkit sets up for a notification that it should
+return control to the terminal event loop.
+"""
+
+import gtk, gobject
+
+def inputhook(context):
+    """
+    When the eventloop of prompt-toolkit is idle, call this inputhook.
+
+    This will run the GTK main loop until the file descriptor
+    `context.fileno()` becomes ready.
+
+    :param context: An `InputHookContext` instance.
+    """
+    def _main_quit(*a, **kw):
+        gtk.main_quit()
+        return False
+
+    gobject.io_add_watch(context.fileno(), gobject.IO_IN, _main_quit)
+    gtk.main()

--- a/IPython/terminal/pt_inputhooks/gtk.py
+++ b/IPython/terminal/pt_inputhooks/gtk.py
@@ -39,6 +39,9 @@ from __future__ import absolute_import
 
 import gtk, gobject
 
+# Enable threading in GTK. (Otherwise, GTK will keep the GIL.)
+gtk.gdk.threads_init()
+
 def inputhook(context):
     """
     When the eventloop of prompt-toolkit is idle, call this inputhook.

--- a/IPython/terminal/pt_inputhooks/gtk3.py
+++ b/IPython/terminal/pt_inputhooks/gtk3.py
@@ -1,0 +1,12 @@
+"""prompt_toolkit input hook for GTK 3
+"""
+
+from gi.repository import Gtk, GLib
+
+def _main_quit(*args, **kwargs):
+    Gtk.main_quit()
+    return False
+
+def inputhook(context):
+    GLib.io_add_watch(context.fileno(), GLib.IO_IN, _main_quit)
+    Gtk.main()

--- a/IPython/terminal/pt_inputhooks/pyglet.py
+++ b/IPython/terminal/pt_inputhooks/pyglet.py
@@ -1,0 +1,68 @@
+"""Enable pyglet to be used interacively with prompt_toolkit
+"""
+from __future__ import absolute_import
+
+import os
+import sys
+import time
+from timeit import default_timer as clock
+import pyglet
+
+# On linux only, window.flip() has a bug that causes an AttributeError on
+# window close.  For details, see:
+# http://groups.google.com/group/pyglet-users/browse_thread/thread/47c1aab9aa4a3d23/c22f9e819826799e?#c22f9e819826799e
+
+if sys.platform.startswith('linux'):
+    def flip(window):
+        try:
+            window.flip()
+        except AttributeError:
+            pass
+else:
+    def flip(window):
+        window.flip()
+
+
+def inputhook(context):
+    """Run the pyglet event loop by processing pending events only.
+
+    This keeps processing pending events until stdin is ready.  After
+    processing all pending events, a call to time.sleep is inserted.  This is
+    needed, otherwise, CPU usage is at 100%.  This sleep time should be tuned
+    though for best performance.
+    """
+    # We need to protect against a user pressing Control-C when IPython is
+    # idle and this is running. We trap KeyboardInterrupt and pass.
+    try:
+        t = clock()
+        while not context.input_is_ready():
+            pyglet.clock.tick()
+            for window in pyglet.app.windows:
+                window.switch_to()
+                window.dispatch_events()
+                window.dispatch_event('on_draw')
+                flip(window)
+
+            # We need to sleep at this point to keep the idle CPU load
+            # low.  However, if sleep to long, GUI response is poor.  As
+            # a compromise, we watch how often GUI events are being processed
+            # and switch between a short and long sleep time.  Here are some
+            # stats useful in helping to tune this.
+            # time    CPU load
+            # 0.001   13%
+            # 0.005   3%
+            # 0.01    1.5%
+            # 0.05    0.5%
+            used_time = clock() - t
+            if used_time > 10.0:
+                # print 'Sleep for 1 s'  # dbg
+                time.sleep(1.0)
+            elif used_time > 0.1:
+                # Few GUI events coming in, so we can sleep longer
+                # print 'Sleep for 0.05 s'  # dbg
+                time.sleep(0.05)
+            else:
+                # Many GUI events coming in, so sleep only very little
+                time.sleep(0.001)
+    except KeyboardInterrupt:
+        pass

--- a/IPython/terminal/pt_inputhooks/qt.py
+++ b/IPython/terminal/pt_inputhooks/qt.py
@@ -1,0 +1,11 @@
+from IPython.external.qt_for_kernel import QtCore, QtGui
+
+def inputhook(context):
+    app = QtCore.QCoreApplication.instance()
+    if not app:
+        return
+    event_loop = QtCore.QEventLoop(app)
+    notifier = QtCore.QSocketNotifier(context.fileno(), QtCore.QSocketNotifier.Read)
+    notifier.setEnabled(True)
+    notifier.activated.connect(event_loop.exit)
+    event_loop.exec_()

--- a/IPython/terminal/pt_inputhooks/tk.py
+++ b/IPython/terminal/pt_inputhooks/tk.py
@@ -1,0 +1,93 @@
+# Code borrowed from ptpython
+# https://github.com/jonathanslenders/ptpython/blob/86b71a89626114b18898a0af463978bdb32eeb70/ptpython/eventloop.py
+
+# Copyright (c) 2015, Jonathan Slenders
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice, this
+#   list of conditions and the following disclaimer in the documentation and/or
+#   other materials provided with the distribution.
+#
+# * Neither the name of the {organization} nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Wrapper around the eventloop that gives some time to the Tkinter GUI to process
+events when it's loaded and while we are waiting for input at the REPL. This
+way we don't block the UI of for instance ``turtle`` and other Tk libraries.
+
+(Normally Tkinter registeres it's callbacks in ``PyOS_InputHook`` to integrate
+in readline. ``prompt-toolkit`` doesn't understand that input hook, but this
+will fix it for Tk.)
+"""
+import time
+
+import _tkinter
+try:
+    import tkinter
+except ImportError:
+    import Tkinter as tkinter  # Python 2
+
+def inputhook(inputhook_context):
+    """
+    Inputhook for Tk.
+    Run the Tk eventloop until prompt-toolkit needs to process the next input.
+    """
+    # Get the current TK application.
+    root = tkinter._default_root
+
+    def wait_using_filehandler():
+        """
+        Run the TK eventloop until the file handler that we got from the
+        inputhook becomes readable.
+        """
+        # Add a handler that sets the stop flag when `prompt-toolkit` has input
+        # to process.
+        stop = [False]
+        def done(*a):
+            stop[0] = True
+
+        root.createfilehandler(inputhook_context.fileno(), _tkinter.READABLE, done)
+
+        # Run the TK event loop as long as we don't receive input.
+        while root.dooneevent(_tkinter.ALL_EVENTS):
+            if stop[0]:
+                break
+
+        root.deletefilehandler(inputhook_context.fileno())
+
+    def wait_using_polling():
+        """
+        Windows TK doesn't support 'createfilehandler'.
+        So, run the TK eventloop and poll until input is ready.
+        """
+        while not inputhook_context.input_is_ready():
+            while root.dooneevent(_tkinter.ALL_EVENTS | _tkinter.DONT_WAIT):
+                 pass
+            # Sleep to make the CPU idle, but not too long, so that the UI
+            # stays responsive.
+            time.sleep(.01)
+
+    if root is not None:
+        if hasattr(root, 'createfilehandler'):
+            wait_using_filehandler()
+        else:
+            wait_using_polling()

--- a/IPython/terminal/pt_inputhooks/wx.py
+++ b/IPython/terminal/pt_inputhooks/wx.py
@@ -1,0 +1,148 @@
+"""Enable wxPython to be used interacively in prompt_toolkit
+"""
+from __future__ import absolute_import
+
+import sys
+import signal
+import time
+from timeit import default_timer as clock
+import wx
+
+
+def inputhook_wx1(context):
+    """Run the wx event loop by processing pending events only.
+
+    This approach seems to work, but its performance is not great as it
+    relies on having PyOS_InputHook called regularly.
+    """
+    try:
+        app = wx.GetApp()
+        if app is not None:
+            assert wx.Thread_IsMain()
+
+            # Make a temporary event loop and process system events until
+            # there are no more waiting, then allow idle events (which
+            # will also deal with pending or posted wx events.)
+            evtloop = wx.EventLoop()
+            ea = wx.EventLoopActivator(evtloop)
+            while evtloop.Pending():
+                evtloop.Dispatch()
+            app.ProcessIdle()
+            del ea
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+class EventLoopTimer(wx.Timer):
+
+    def __init__(self, func):
+        self.func = func
+        wx.Timer.__init__(self)
+
+    def Notify(self):
+        self.func()
+
+class EventLoopRunner(object):
+
+    def Run(self, time, input_is_ready):
+        self.input_is_ready = input_is_ready
+        self.evtloop = wx.EventLoop()
+        self.timer = EventLoopTimer(self.check_stdin)
+        self.timer.Start(time)
+        self.evtloop.Run()
+
+    def check_stdin(self):
+        if self.input_is_ready():
+            self.timer.Stop()
+            self.evtloop.Exit()
+
+def inputhook_wx2(context):
+    """Run the wx event loop, polling for stdin.
+
+    This version runs the wx eventloop for an undetermined amount of time,
+    during which it periodically checks to see if anything is ready on
+    stdin.  If anything is ready on stdin, the event loop exits.
+
+    The argument to elr.Run controls how often the event loop looks at stdin.
+    This determines the responsiveness at the keyboard.  A setting of 1000
+    enables a user to type at most 1 char per second.  I have found that a
+    setting of 10 gives good keyboard response.  We can shorten it further,
+    but eventually performance would suffer from calling select/kbhit too
+    often.
+    """
+    try:
+        app = wx.GetApp()
+        if app is not None:
+            assert wx.Thread_IsMain()
+            elr = EventLoopRunner()
+            # As this time is made shorter, keyboard response improves, but idle
+            # CPU load goes up.  10 ms seems like a good compromise.
+            elr.Run(time=10,  # CHANGE time here to control polling interval
+                    input_is_ready=context.input_is_ready)
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+def inputhook_wx3(context):
+    """Run the wx event loop by processing pending events only.
+
+    This is like inputhook_wx1, but it keeps processing pending events
+    until stdin is ready.  After processing all pending events, a call to
+    time.sleep is inserted.  This is needed, otherwise, CPU usage is at 100%.
+    This sleep time should be tuned though for best performance.
+    """
+    # We need to protect against a user pressing Control-C when IPython is
+    # idle and this is running. We trap KeyboardInterrupt and pass.
+    try:
+        app = wx.GetApp()
+        if app is not None:
+            assert wx.Thread_IsMain()
+
+            # The import of wx on Linux sets the handler for signal.SIGINT
+            # to 0.  This is a bug in wx or gtk.  We fix by just setting it
+            # back to the Python default.
+            if not callable(signal.getsignal(signal.SIGINT)):
+                signal.signal(signal.SIGINT, signal.default_int_handler)
+
+            evtloop = wx.EventLoop()
+            ea = wx.EventLoopActivator(evtloop)
+            t = clock()
+            while not context.input_is_ready():
+                while evtloop.Pending():
+                    t = clock()
+                    evtloop.Dispatch()
+                app.ProcessIdle()
+                # We need to sleep at this point to keep the idle CPU load
+                # low.  However, if sleep to long, GUI response is poor.  As
+                # a compromise, we watch how often GUI events are being processed
+                # and switch between a short and long sleep time.  Here are some
+                # stats useful in helping to tune this.
+                # time    CPU load
+                # 0.001   13%
+                # 0.005   3%
+                # 0.01    1.5%
+                # 0.05    0.5%
+                used_time = clock() - t
+                if used_time > 10.0:
+                    # print 'Sleep for 1 s'  # dbg
+                    time.sleep(1.0)
+                elif used_time > 0.1:
+                    # Few GUI events coming in, so we can sleep longer
+                    # print 'Sleep for 0.05 s'  # dbg
+                    time.sleep(0.05)
+                else:
+                    # Many GUI events coming in, so sleep only very little
+                    time.sleep(0.001)
+            del ea
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+if sys.platform == 'darwin':
+    # On OSX, evtloop.Pending() always returns True, regardless of there being
+    # any events pending. As such we can't use implementations 1 or 3 of the
+    # inputhook as those depend on a pending/dispatch loop.
+    inputhook = inputhook_wx2
+else:
+    # This is our default implementation
+    inputhook = inputhook_wx3

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -1,0 +1,64 @@
+from IPython.core.interactiveshell import InteractiveShell
+
+from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.shortcuts import create_prompt_layout
+from prompt_toolkit.filters import Condition
+from prompt_toolkit.interface import AcceptAction, Application, CommandLineInterface
+from prompt_toolkit.layout.lexers import PygmentsLexer
+
+from pygments.lexers import Python3Lexer
+from pygments.token import Token
+
+
+class PTInteractiveShell(InteractiveShell):
+    def _multiline(self, cli):
+        doc = cli.current_buffer.document
+        if not doc.on_last_line:
+            cli.run_in_terminal(lambda: print('Not on last line'))
+            return False
+        status, indent = self.input_splitter.check_complete(doc.text)
+        return status == 'incomplete'
+
+    def _multiline2(self):
+        return self._multiline(self.pt_cli)
+
+    pt_cli = None
+
+    def get_prompt_tokens(self, cli):
+        return [
+            (Token.Prompt, 'In ['),
+            (Token.Prompt, str(self.execution_count)),
+            (Token.Prompt, ']: '),
+        ]
+
+
+    def init_prompt_toolkit_cli(self):
+        layout = create_prompt_layout(
+            get_prompt_tokens=self.get_prompt_tokens,
+            lexer=PygmentsLexer(Python3Lexer),
+            multiline=Condition(self._multiline),
+        )
+        buffer = Buffer(
+            is_multiline=Condition(self._multiline2),
+            accept_action=AcceptAction.RETURN_DOCUMENT,
+        )
+        app = Application(layout=layout, buffer=buffer)
+        self.pt_cli = CommandLineInterface(app)
+
+    def __init__(self, *args, **kwargs):
+        super(PTInteractiveShell, self).__init__(*args, **kwargs)
+        self.init_prompt_toolkit_cli()
+        self.keep_running = True
+
+    def ask_exit(self):
+        self.keep_running = False
+
+    def interact(self):
+        while self.keep_running:
+            document = self.pt_cli.run()
+            if document:
+                self.run_cell(document.text)
+
+
+if __name__ == '__main__':
+    PTInteractiveShell().interact()

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -106,6 +106,7 @@ class PTInteractiveShell(InteractiveShell):
             else:
                 if document:
                     self.run_cell(document.text, store_history=True)
+                    print(self.separate_in, end='')
 
 
 if __name__ == '__main__':

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -19,6 +19,9 @@ class IPythonPTCompleter(Completer):
         self.ipy_completer = ipy_completer
 
     def get_completions(self, document, complete_event):
+        if not document.current_line.strip():
+            return
+
         used, matches = self.ipy_completer.complete(
                             line_buffer=document.current_line,
                             cursor_pos=document.cursor_position_col

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import sys
 
 from IPython.core.interactiveshell import InteractiveShell
-from IPython.utils.py3compat import PY3
+from IPython.utils.py3compat import PY3, cast_unicode_py2
 from traitlets import Bool, Unicode, Dict
 
 from prompt_toolkit.completion import Completer, Completion
@@ -177,7 +177,7 @@ class PTInteractiveShell(InteractiveShell):
 
     def pre_prompt(self):
         if self.rl_next_input:
-            self.pt_cli.application.buffer.text = self.rl_next_input
+            self.pt_cli.application.buffer.text = cast_unicode_py2(self.rl_next_input)
             self.rl_next_input = None
 
     def interact(self):

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -1,5 +1,6 @@
 from IPython.core.interactiveshell import InteractiveShell
 
+from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.history import InMemoryHistory
 from prompt_toolkit.shortcuts import create_prompt_application
 from prompt_toolkit.interface import CommandLineInterface
@@ -9,6 +10,21 @@ from prompt_toolkit.layout.lexers import PygmentsLexer
 
 from pygments.lexers import Python3Lexer
 from pygments.token import Token
+
+
+class IPythonPTCompleter(Completer):
+    """Adaptor to provide IPython completions to prompt_toolkit"""
+    def __init__(self, ipy_completer):
+        self.ipy_completer = ipy_completer
+
+    def get_completions(self, document, complete_event):
+        used, matches = self.ipy_completer.complete(
+                            line_buffer=document.current_line,
+                            cursor_pos=document.cursor_position_col
+        )
+        start_pos = -len(used)
+        for m in matches:
+            yield Completion(m, start_position=start_pos)
 
 
 class PTInteractiveShell(InteractiveShell):
@@ -57,6 +73,7 @@ class PTInteractiveShell(InteractiveShell):
                             get_prompt_tokens=self.get_prompt_tokens,
                             key_bindings_registry=kbmanager.registry,
                             history=history,
+                            completer=IPythonPTCompleter(self.Completer),
         )
 
         self.pt_cli = CommandLineInterface(app)
@@ -83,4 +100,4 @@ class PTInteractiveShell(InteractiveShell):
 
 
 if __name__ == '__main__':
-    PTInteractiveShell().interact()
+    PTInteractiveShell.instance().interact()

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -1,6 +1,8 @@
 """IPython terminal interface using prompt_toolkit in place of readline"""
 from __future__ import print_function
 
+import sys
+
 from IPython.core.interactiveshell import InteractiveShell
 from IPython.utils.py3compat import PY3
 from traitlets import Bool, Unicode, Dict
@@ -143,6 +145,20 @@ class PTInteractiveShell(InteractiveShell):
 
         self.pt_cli = CommandLineInterface(app,
                            eventloop=create_eventloop(self.inputhook))
+
+    def init_io(self):
+        if sys.platform not in {'win32', 'cli'}:
+            return
+
+        import colorama
+        colorama.init()
+
+        # For some reason we make these wrappers around stdout/stderr.
+        # For now, we need to reset them so all output gets coloured.
+        # https://github.com/ipython/ipython/issues/8669
+        from IPython.utils import io
+        io.stdout = io.IOStream(sys.stdout)
+        io.stderr = io.IOStream(sys.stderr)
 
     def __init__(self, *args, **kwargs):
         super(PTInteractiveShell, self).__init__(*args, **kwargs)

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -1,6 +1,8 @@
 from IPython.core.interactiveshell import InteractiveShell
 
 from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.enums import DEFAULT_BUFFER
+from prompt_toolkit.filters import HasFocus, HasSelection
 from prompt_toolkit.history import InMemoryHistory
 from prompt_toolkit.shortcuts import create_prompt_application
 from prompt_toolkit.interface import CommandLineInterface
@@ -46,7 +48,9 @@ class PTInteractiveShell(InteractiveShell):
 
     def init_prompt_toolkit_cli(self):
         kbmanager = KeyBindingManager.for_prompt()
-        @kbmanager.registry.add_binding(Keys.ControlJ) # Ctrl+J == Enter, seemingly
+        # Ctrl+J == Enter, seemingly
+        @kbmanager.registry.add_binding(Keys.ControlJ,
+                            filter=HasFocus(DEFAULT_BUFFER) & ~HasSelection())
         def _(event):
             b = event.current_buffer
             if not b.document.on_last_line:

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -146,7 +146,9 @@ class PTInteractiveShell(InteractiveShell):
         app = create_prompt_application(multiline=True,
                             lexer=PygmentsLexer(Python3Lexer if PY3 else PythonLexer),
                             get_prompt_tokens=self.get_prompt_tokens,
-                            get_continuation_tokens=self.get_continuation_tokens,
+                            # The line below is waiting for a new release of
+                            # prompt_toolkit (> 0.57)
+                            #get_continuation_tokens=self.get_continuation_tokens,
                             key_bindings_registry=kbmanager.registry,
                             history=history,
                             completer=IPythonPTCompleter(self.Completer),

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -196,6 +196,16 @@ class PTInteractiveShell(InteractiveShell):
                 if document:
                     self.run_cell(document.text, store_history=True)
 
+    def mainloop(self):
+        # An extra layer of protection in case someone mashing Ctrl-C breaks
+        # out of our internal code.
+        while True:
+            try:
+                self.interact()
+                break
+            except KeyboardInterrupt:
+                print("\nKeyboardInterrupt escaped interact()\n")
+
     _inputhook = None
     def inputhook(self, context):
         if self._inputhook is not None:

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -82,7 +82,8 @@ class PTInteractiveShell(InteractiveShell):
             Token.Prompt: '#009900',
             Token.PromptNum: '#00ff00 bold',
             Token.Number: '#007700',
-            Token.Operator: '#bbbbbb',
+            Token.Operator: 'noinherit',
+            Token.String: '#BB6622',
         })
 
         app = create_prompt_application(multiline=True,

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -91,6 +91,7 @@ class PTInteractiveShell(InteractiveShell):
                             key_bindings_registry=kbmanager.registry,
                             history=history,
                             completer=IPythonPTCompleter(self.Completer),
+                            enable_history_search=True,
                             style=style,
         )
 

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -1,9 +1,9 @@
 from IPython.core.interactiveshell import InteractiveShell
 
-from prompt_toolkit.buffer import Buffer
-from prompt_toolkit.shortcuts import create_prompt_layout
-from prompt_toolkit.filters import Condition
-from prompt_toolkit.interface import AcceptAction, Application, CommandLineInterface
+from prompt_toolkit.shortcuts import create_prompt_application
+from prompt_toolkit.interface import CommandLineInterface
+from prompt_toolkit.key_binding.manager import KeyBindingManager
+from prompt_toolkit.keys import Keys
 from prompt_toolkit.layout.lexers import PygmentsLexer
 
 from pygments.lexers import Python3Lexer
@@ -11,17 +11,6 @@ from pygments.token import Token
 
 
 class PTInteractiveShell(InteractiveShell):
-    def _multiline(self, cli):
-        doc = cli.current_buffer.document
-        if not doc.on_last_line:
-            cli.run_in_terminal(lambda: print('Not on last line'))
-            return False
-        status, indent = self.input_splitter.check_complete(doc.text)
-        return status == 'incomplete'
-
-    def _multiline2(self):
-        return self._multiline(self.pt_cli)
-
     pt_cli = None
 
     def get_prompt_tokens(self, cli):
@@ -33,16 +22,27 @@ class PTInteractiveShell(InteractiveShell):
 
 
     def init_prompt_toolkit_cli(self):
-        layout = create_prompt_layout(
-            get_prompt_tokens=self.get_prompt_tokens,
-            lexer=PygmentsLexer(Python3Lexer),
-            multiline=Condition(self._multiline),
+        kbmanager = KeyBindingManager.for_prompt()
+        @kbmanager.registry.add_binding(Keys.ControlJ) # Ctrl+J == Enter, seemingly
+        def _(event):
+            b = event.current_buffer
+            if not b.document.on_last_line:
+                b.newline()
+                return
+
+            status, indent = self.input_splitter.check_complete(b.document.text)
+
+            if (status != 'incomplete') and b.accept_action.is_returnable:
+                b.accept_action.validate_and_handle(event.cli, b)
+            else:
+                b.insert_text('\n' + (' ' * indent))
+
+        app = create_prompt_application(multiline=True,
+                            lexer=PygmentsLexer(Python3Lexer),
+                            get_prompt_tokens=self.get_prompt_tokens,
+                            key_bindings_registry=kbmanager.registry,
         )
-        buffer = Buffer(
-            is_multiline=Condition(self._multiline2),
-            accept_action=AcceptAction.RETURN_DOCUMENT,
-        )
-        app = Application(layout=layout, buffer=buffer)
+
         self.pt_cli = CommandLineInterface(app)
 
     def __init__(self, *args, **kwargs):

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -89,11 +89,13 @@ class PTInteractiveShell(InteractiveShell):
                                    ))
         def _(event):
             b = event.current_buffer
-            if not b.document.on_last_line:
+            d = b.document
+            if not (d.on_last_line or d.cursor_position_row >= d.line_count
+                                           - d.empty_line_count_at_the_end()):
                 b.newline()
                 return
 
-            status, indent = self.input_splitter.check_complete(b.document.text)
+            status, indent = self.input_splitter.check_complete(d.text)
 
             if (status != 'incomplete') and b.accept_action.is_returnable:
                 b.accept_action.validate_and_handle(event.cli, b)

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -7,6 +7,7 @@ from prompt_toolkit.interface import CommandLineInterface
 from prompt_toolkit.key_binding.manager import KeyBindingManager
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.layout.lexers import PygmentsLexer
+from prompt_toolkit.styles import PygmentsStyle
 
 from pygments.lexers import Python3Lexer
 from pygments.token import Token
@@ -33,7 +34,7 @@ class PTInteractiveShell(InteractiveShell):
     def get_prompt_tokens(self, cli):
         return [
             (Token.Prompt, 'In ['),
-            (Token.Prompt, str(self.execution_count)),
+            (Token.PromptNum, str(self.execution_count)),
             (Token.Prompt, ']: '),
         ]
 
@@ -68,12 +69,20 @@ class PTInteractiveShell(InteractiveShell):
             if cell and (cell != last_cell):
                 history.append(cell)
 
+        style = PygmentsStyle.from_defaults({
+            Token.Prompt: '#009900',
+            Token.PromptNum: '#00ff00 bold',
+            Token.Number: '#007700',
+            Token.Operator: '#bbbbbb',
+        })
+
         app = create_prompt_application(multiline=True,
                             lexer=PygmentsLexer(Python3Lexer),
                             get_prompt_tokens=self.get_prompt_tokens,
                             key_bindings_registry=kbmanager.registry,
                             history=history,
                             completer=IPythonPTCompleter(self.Completer),
+                            style=style,
         )
 
         self.pt_cli = CommandLineInterface(app)

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -54,6 +54,10 @@ class PTInteractiveShell(InteractiveShell):
         help="Use vi style keybindings at the prompt",
     )
 
+    mouse_support = Bool(False, config=True,
+        help="Enable mouse support in the prompt"
+    )
+
     highlighting_style = Unicode('', config=True,
         help="The name of a Pygments style to use for syntax highlighting"
     )
@@ -148,6 +152,7 @@ class PTInteractiveShell(InteractiveShell):
                             completer=IPythonPTCompleter(self.Completer),
                             enable_history_search=True,
                             style=style,
+                            mouse_support=self.mouse_support,
         )
 
         self.pt_cli = CommandLineInterface(app,

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -152,11 +152,19 @@ class PTInteractiveShell(InteractiveShell):
     def ask_exit(self):
         self.keep_running = False
 
+    rl_next_input = None
+
+    def pre_prompt(self):
+        if self.rl_next_input:
+            self.pt_cli.application.buffer.text = self.rl_next_input
+            self.rl_next_input = None
+
     def interact(self):
         while self.keep_running:
             print(self.separate_in, end='')
+
             try:
-                document = self.pt_cli.run()
+                document = self.pt_cli.run(pre_run=self.pre_prompt)
             except EOFError:
                 if self.ask_yes_no('Do you really want to exit ([y]/n)?','y','n'):
                     self.ask_exit()

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -29,6 +29,8 @@ class IPythonPTCompleter(Completer):
 
 
 class PTInteractiveShell(InteractiveShell):
+    colors_force = True
+
     pt_cli = None
 
     def get_prompt_tokens(self, cli):

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -115,10 +115,16 @@ class PTInteractiveShell(InteractiveShell):
             style_cls = get_style_by_name(self.highlighting_style)
         else:
             style_cls = get_style_by_name('default')
+            # The default theme needs to be visible on both a dark background
+            # and a light background, because we can't tell what the terminal
+            # looks like. These tweaks to the default theme help with that.
             style_overrides.update({
                 Token.Number: '#007700',
                 Token.Operator: 'noinherit',
                 Token.String: '#BB6622',
+                Token.Name.Function: '#2080D0',
+                Token.Name.Class: 'bold #2080D0',
+                Token.Name.Namespace: 'bold #2080D0',
             })
         style_overrides.update(self.highlighting_style_overrides)
         style = PygmentsStyle.from_defaults(pygments_style_cls=style_cls,

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -1,4 +1,8 @@
+"""IPython terminal interface using prompt_toolkit in place of readline"""
+from __future__ import print_function
+
 from IPython.core.interactiveshell import InteractiveShell
+from IPython.utils.py3compat import PY3
 from traitlets import Bool, Unicode, Dict
 
 from prompt_toolkit.completion import Completer, Completion
@@ -15,7 +19,7 @@ from prompt_toolkit.layout.lexers import PygmentsLexer
 from prompt_toolkit.styles import PygmentsStyle
 
 from pygments.styles import get_style_by_name
-from pygments.lexers import Python3Lexer
+from pygments.lexers import Python3Lexer, PythonLexer
 from pygments.token import Token
 
 
@@ -116,7 +120,7 @@ class PTInteractiveShell(InteractiveShell):
                                             style_dict=style_overrides)
 
         app = create_prompt_application(multiline=True,
-                            lexer=PygmentsLexer(Python3Lexer),
+                            lexer=PygmentsLexer(Python3Lexer if PY3 else PythonLexer),
                             get_prompt_tokens=self.get_prompt_tokens,
                             key_bindings_registry=kbmanager.registry,
                             history=history,

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -25,6 +25,7 @@ from pygments.lexers import Python3Lexer, PythonLexer
 from pygments.token import Token
 
 from .pt_inputhooks import get_inputhook_func
+from .interactiveshell import get_default_editor
 
 
 class IPythonPTCompleter(Completer):
@@ -59,6 +60,10 @@ class PTInteractiveShell(InteractiveShell):
 
     highlighting_style_overrides = Dict(config=True,
         help="Override highlighting format for specific tokens"
+    )
+
+    editor = Unicode(get_default_editor(), config=True,
+        help="Set the editor used by IPython (default to $EDITOR/vi/notepad)."
     )
 
     def get_prompt_tokens(self, cli):

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -99,6 +99,7 @@ class PTInteractiveShell(InteractiveShell):
 
     def interact(self):
         while self.keep_running:
+            print(self.separate_in, end='')
             try:
                 document = self.pt_cli.run()
             except EOFError:
@@ -108,7 +109,6 @@ class PTInteractiveShell(InteractiveShell):
             else:
                 if document:
                     self.run_cell(document.text, store_history=True)
-                    print(self.separate_in, end='')
 
 
 if __name__ == '__main__':

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -65,6 +65,11 @@ class PTInteractiveShell(InteractiveShell):
             (Token.Prompt, ']: '),
         ]
 
+    def get_continuation_tokens(self, cli, width):
+        return [
+            (Token.Prompt, (' ' * (width - 2)) + ': '),
+        ]
+
 
     def init_prompt_toolkit_cli(self):
         kbmanager = KeyBindingManager.for_prompt(enable_vi_mode=self.vi_mode)
@@ -122,6 +127,7 @@ class PTInteractiveShell(InteractiveShell):
         app = create_prompt_application(multiline=True,
                             lexer=PygmentsLexer(Python3Lexer if PY3 else PythonLexer),
                             get_prompt_tokens=self.get_prompt_tokens,
+                            get_continuation_tokens=self.get_continuation_tokens,
                             key_bindings_registry=kbmanager.registry,
                             history=history,
                             completer=IPythonPTCompleter(self.Completer),

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -57,7 +57,7 @@ class PTInteractiveShell(InteractiveShell):
         while self.keep_running:
             document = self.pt_cli.run()
             if document:
-                self.run_cell(document.text)
+                self.run_cell(document.text, store_history=True)
 
 
 if __name__ == '__main__':

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -38,6 +38,10 @@ class PTInteractiveShell(InteractiveShell):
             else:
                 b.insert_text('\n' + (' ' * (indent or 0)))
 
+        @kbmanager.registry.add_binding(Keys.ControlC)
+        def _(event):
+            event.current_buffer.reset()
+
         # Pre-populate history from IPython's history database
         history = InMemoryHistory()
         last_cell = u""
@@ -67,9 +71,15 @@ class PTInteractiveShell(InteractiveShell):
 
     def interact(self):
         while self.keep_running:
-            document = self.pt_cli.run()
-            if document:
-                self.run_cell(document.text, store_history=True)
+            try:
+                document = self.pt_cli.run()
+            except EOFError:
+                if self.ask_yes_no('Do you really want to exit ([y]/n)?','y','n'):
+                    self.ask_exit()
+
+            else:
+                if document:
+                    self.run_cell(document.text, store_history=True)
 
 
 if __name__ == '__main__':

--- a/examples/IPython Kernel/gui/gui-glut.py
+++ b/examples/IPython Kernel/gui/gui-glut.py
@@ -38,7 +38,7 @@ if glut.glutGetWindow() > 0:
 else:
     interactive = False
 
-glut.glutCreateWindow('gui-glut')
+glut.glutCreateWindow(b'gui-glut')
 glut.glutDisplayFunc(display)
 glut.glutReshapeFunc(resize)
 # This is necessary on osx to be able to close the window

--- a/examples/IPython Kernel/gui/gui-gtk3.py
+++ b/examples/IPython Kernel/gui/gui-gtk3.py
@@ -20,10 +20,10 @@ def delete_event(widget, event, data=None):
 def destroy(widget, data=None):
     Gtk.main_quit()
 
-window = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+window = Gtk.Window(type=Gtk.WindowType.TOPLEVEL)
 window.connect("delete_event", delete_event)
 window.connect("destroy", destroy)
-button = Gtk.Button("Hello World")
+button = Gtk.Button(label="Hello World")
 button.connect("clicked", hello_world, None)
 
 window.add(button)

--- a/setup.py
+++ b/setup.py
@@ -195,6 +195,7 @@ install_requires = [
     'pickleshare',
     'simplegeneric>0.8',
     'traitlets',
+    'prompt_toolkit',  # We will require > 0.57 once a new release is made
 ]
 
 # Platform-specific dependencies:
@@ -204,8 +205,6 @@ install_requires = [
 extras_require.update({
     ':sys_platform != "win32"': ['pexpect'],
     ':sys_platform == "darwin"': ['appnope'],
-    ':sys_platform == "darwin" and platform_python_implementation == "CPython"': ['gnureadline'],
-    'terminal:sys_platform == "win32"': ['pyreadline>=2'],
     'test:python_version == "2.7"': ['mock'],
 })
 # FIXME: re-specify above platform dependencies for pip < 6


### PR DESCRIPTION
This adds a new terminal interface using prompt_toolkit in place of readline. It's on top of my refactoring in #9070.

You can test the new interface by running:

```
python3 -m IPython.terminal.ptshell
```

Multiline editing with syntax highlighting, persistent history and tab completion are all working. So far, I'm really impressed with prompt_toolkit: I've written about 100 lines to make that happen, and while it's taken some research, nothing I've had to do feels like a hack. Kudos to @jonathanslenders :-)
