### PR TITLE
Fix max_seq_length input to RepresentationPrinter

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -124,7 +124,7 @@ def pretty(obj, verbose=False, max_width=79, newline='\n', max_seq_length=MAX_SE
     Pretty print the object's representation.
     """
     stream = CUnicodeIO()
-    printer = RepresentationPrinter(stream, verbose, max_width, newline, max_seq_length)
+    printer = RepresentationPrinter(stream, verbose, max_width, newline, max_seq_length=max_seq_length)
     printer.pretty(obj)
     printer.flush()
     return stream.getvalue()
@@ -134,7 +134,7 @@ def pprint(obj, verbose=False, max_width=79, newline='\n', max_seq_length=MAX_SE
     """
     Like `pretty` but print to stdout.
     """
-    printer = RepresentationPrinter(sys.stdout, verbose, max_width, newline, max_seq_length)
+    printer = RepresentationPrinter(sys.stdout, verbose, max_width, newline, max_seq_length=max_seq_length)
     printer.pretty(obj)
     printer.flush()
     sys.stdout.write(newline)


### PR DESCRIPTION
`max_seq_length` is passed to RepresentationPrinter as a positional argument but the order is not correct for `RepresentationPrinter.__init__`. Currently the value passed for `max_seq_len` ends up being used wipes out any `singleton_pprinters` passed in. This fix just passes it as a keyword argument.
