### PR TITLE
Backport #8744 (Wrong string in nbconvert.py) to 4.0.x

### DIFF
--- a/IPython/nbconvert.py
+++ b/IPython/nbconvert.py
@@ -10,7 +10,7 @@ from warnings import warn
 from IPython.utils.shimmodule import ShimModule, ShimWarning
 
 warn("The `IPython.nbconvert` package has been deprecated. "
-     "You should import from ipython_nbconvert instead.", ShimWarning)
+     "You should import from nbconvert instead.", ShimWarning)
 
 # Unconditionally insert the shim into sys.modules so that further import calls
 # trigger the custom attribute access above


### PR DESCRIPTION
Asked by @ngoldbaum on #8744 

Not sure it will ever be release depending on when we release 4.1
