### PR TITLE
log.warn deprecated

### DIFF
--- a/IPython/core/profiledir.py
+++ b/IPython/core/profiledir.py
@@ -118,7 +118,7 @@ class ProfileDir(LoggingConfigurable):
         src = os.path.join(get_ipython_package_dir(), u'core', u'profile', u'README_STARTUP')
 
         if not os.path.exists(src):
-            self.log.warn("Could not copy README_STARTUP to startup dir. Source file %s does not exist.", src)
+            self.log.warning("Could not copy README_STARTUP to startup dir. Source file %s does not exist.", src)
 
         if os.path.exists(src) and not os.path.exists(readme):
             shutil.copy(src, readme)


### PR DESCRIPTION
Forgotten in  a previous PR.
## 

Do you think a 
`warnings.filterwarnings('default', "The 'warn' method is deprecated, use 'warning' instead", DeprecationWarning, IPython.*)` would be ok, if `'dev' in __version__` ?
