### PR TITLE
Add ability to Embed to raise an exception. 

### DIFF
--- a/IPython/terminal/embed.py
+++ b/IPython/terminal/embed.py
@@ -46,37 +46,41 @@ class EmbeddedMagics(Magics):
             print ("This embedded IPython will not reactivate anymore "
                    "once you exit.")
 
-    @line_magic
-    def raise_on_exit(self, parameter_s=''):
-        """%raise_on_exit [True|False]: Make the current embeded kernel to raise an exception on exit.
+    if sys.version_info > (3,):
 
-        You can change that again during current session by calling `%raise_on_exit` with `True`/`False` as parameter 
+        @line_magic
+        def raise_on_exit(self, parameter_s=''):
+            """%raise_on_exit [True|False]: Make the current embeded kernel to raise an exception on exit.
 
-        This function (after asking for confirmation) sets an internal flag so
-        that an embedded IPython will raise a `KillEmbeded` Exception on exit.  This is useful to
-        permanently exit a loop that create IPython embed instance.
-        """
-        parameter_s = parameter_s.strip().lower()
+            You can change that again during current session by calling `%raise_on_exit` with `True`/`False` as parameter
 
-        should_raise = None
-        if parameter_s in {'yes', 'raise', 'true', '1'}:
-            should_raise = True
-        elif parameter_s in {'no', 'false', '0', 'None'}:
-            should_raise = False
-        else:
-            if self.shell.should_raise :
-                print("The current embed instance will raise on exit, use `%raise_on_exit False` to disable")
-                return 
+            This function (after asking for confirmation) sets an internal flag so
+            that an embedded IPython will raise a `KillEmbeded` Exception on exit.  This is useful to
+            permanently exit a loop that create IPython embed instance.
+
+            Available only for Python 3.
+            """
+            parameter_s = parameter_s.strip().lower()
+
+            should_raise = None
+            if parameter_s in {'yes', 'raise', 'true', '1'}:
+                should_raise = True
+            elif parameter_s in {'no', 'false', '0', 'None'}:
+                should_raise = False
             else:
-                print("The current embed instance will not raise on exit, use `%raise_on_exit True` to enable")
-                return 
+                if self.shell.should_raise :
+                    print("The current embed instance will raise on exit, use `%raise_on_exit False` to disable")
+                    return
+                else:
+                    print("The current embed instance will not raise on exit, use `%raise_on_exit True` to enable")
+                    return
 
-        if should_raise:
-            self.shell.should_raise = True
-            print ("This embedded IPython will raise while exiting.")
-        else :
-            self.shell.should_raise = False
-            print ("This embedded IPython will not raise while exiting.")
+            if should_raise:
+                self.shell.should_raise = True
+                print ("This embedded IPython will raise while exiting.")
+            else :
+                self.shell.should_raise = False
+                print ("This embedded IPython will not raise while exiting.")
 
 
 

--- a/IPython/terminal/embed.py
+++ b/IPython/terminal/embed.py
@@ -51,10 +51,9 @@ class EmbeddedMagics(Magics):
     def exit_raise(self, parameter_s=''):
         """%exit_raise Make the current embedded kernel exit and raise and exception.
 
-        This function (after asking for confirmation) sets an internal flag so
-        that an embedded IPython will raise a `KillEmbeded` Exception on exit.
-        This is useful to permanently exit a loop that create IPython embed
-        instance.
+        This function sets an internal flag so that an embedded IPython will
+        raise a `IPython.terminal.embed.KillEmbeded` Exception on exit, and then exit the current I. This is
+        useful to permanently exit a loop that create IPython embed instance.
         """
 
         self.shell.should_raise = True
@@ -148,7 +147,7 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
             print(self.exit_msg)
 
         if self.should_raise:
-            raise KillEmbeded('This instance has been marked as must raise on exit.')
+            raise KillEmbeded('Embedded IPython raising error, as user requested.')
 
 
     def mainloop(self, local_ns=None, module=None, stack_depth=0,

--- a/IPython/terminal/embed.py
+++ b/IPython/terminal/embed.py
@@ -46,41 +46,19 @@ class EmbeddedMagics(Magics):
             print ("This embedded IPython will not reactivate anymore "
                    "once you exit.")
 
-    if sys.version_info > (3,):
 
-        @line_magic
-        def raise_on_exit(self, parameter_s=''):
-            """%raise_on_exit [True|False]: Make the current embeded kernel to raise an exception on exit.
+    @line_magic
+    def exit_raise(self, parameter_s=''):
+        """%exit_raise Make the current embedded kernel exit and raise and exception.
 
-            You can change that again during current session by calling `%raise_on_exit` with `True`/`False` as parameter
+        This function (after asking for confirmation) sets an internal flag so
+        that an embedded IPython will raise a `KillEmbeded` Exception on exit.
+        This is useful to permanently exit a loop that create IPython embed
+        instance.
+        """
 
-            This function (after asking for confirmation) sets an internal flag so
-            that an embedded IPython will raise a `KillEmbeded` Exception on exit.  This is useful to
-            permanently exit a loop that create IPython embed instance.
-
-            Available only for Python 3.
-            """
-            parameter_s = parameter_s.strip().lower()
-
-            should_raise = None
-            if parameter_s in {'yes', 'raise', 'true', '1'}:
-                should_raise = True
-            elif parameter_s in {'no', 'false', '0', 'None'}:
-                should_raise = False
-            else:
-                if self.shell.should_raise :
-                    print("The current embed instance will raise on exit, use `%raise_on_exit False` to disable")
-                    return
-                else:
-                    print("The current embed instance will not raise on exit, use `%raise_on_exit True` to enable")
-                    return
-
-            if should_raise:
-                self.shell.should_raise = True
-                print ("This embedded IPython will raise while exiting.")
-            else :
-                self.shell.should_raise = False
-                print ("This embedded IPython will not raise while exiting.")
+        self.shell.should_raise = True
+        self.shell.ask_exit()
 
 
 


### PR DESCRIPTION
Allow Embeded instances to raise on exit.

This is use full in case where an IPython embed instance is created in a loop:

```
from IPython import embed
while True:
    embed(header="You will be stuck there")
```

Now using `%raise_on_exist True` in an embeded shell allows the embeded
instannce to raise on exit.

Potential improvement would be flags to pass a custom exception type as
well as a custom message to raise.

Closes #9149
