### PR TITLE
Check setuptools version in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
 install:
+    - pip install "setuptools>=18.5"
     - pip install -f travis-wheels/wheelhouse -e file://$PWD#egg=ipython[test]
     - pip install codecov
 script:

--- a/setup.py
+++ b/setup.py
@@ -172,6 +172,9 @@ needs_setuptools = set(('develop', 'release', 'bdist_egg', 'bdist_rpm',
 
 if len(needs_setuptools.intersection(sys.argv)) > 0:
     import setuptools
+    v = tuple(int(x) for x in setuptools.__version__.split('.'))
+    if v < (18,5):
+        raise ValueError('Setuptools version >=18.5 is required, found: %s'%setuptools.__version__)
 
 # This dict is used for passing extra arguments that are setuptools
 # specific to setup
@@ -191,6 +194,7 @@ extras_require = dict(
     nbconvert = ['nbconvert'],
 )
 install_requires = [
+    'setuptools>=18.5'
     'decorator',
     'pickleshare',
     'simplegeneric>0.8',


### PR DESCRIPTION
Allow better error message when trying to build with old version of
setuptools.

Closes #9159

```
$ python setup.py bdist_wheel
Traceback (most recent call last):
  File "setup.py", line 177, in <module>
    raise ValueError('Setuptools version >18.5 is required')
ValueError: Setuptools version >18.5 is required
```
