### PR TITLE
Clarify display_html docs in case of no HTML repr

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -185,6 +185,9 @@ def display_pretty(*objs, **kwargs):
 
 def display_html(*objs, **kwargs):
     """Display the HTML representation of an object.
+    
+    Note: If raw=False and the object does not have a HTML
+    representation, no HTML will be shown.
 
     Parameters
     ----------


### PR DESCRIPTION
If there is no HTML representation for the object, nothing is shown.

See also #9172.
