### PR TITLE
display: Workaround handle case where `format` is `None`.

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -731,7 +731,7 @@ class Image(DisplayObject):
                 if data[:2] == _JPEG:
                     format = self._FMT_JPEG
 
-        if format.lower() == 'jpg':
+        if format and format.lower() == 'jpg':
             # jpg->jpeg
             format = self._FMT_JPEG
 

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -13,6 +13,10 @@ from IPython import paths as ipath
 
 import IPython.testing.decorators as dec
 
+def test_image_no_format():
+    i = display.Image(u"data")
+    nt.assert_equal(i.format,  u"png")
+
 def test_image_size():
     """Simple test for display.Image(args, width=x,height=y)"""
     thisurl = 'http://www.google.fr/images/srpr/logo3w.png'


### PR DESCRIPTION
Fixes https://github.com/jupyter/notebook/issues/1015

If `format` is `None` and `ext` is None and `data` is not of type `bytes`, then `format` could still be `None` at this line. Trying to change `None` to lowercase is not permissible. This should fix that.
