### PR TITLE
Release tools 2

### DIFF
--- a/IPython/core/release.py
+++ b/IPython/core/release.py
@@ -105,12 +105,10 @@ author_email = 'ipython-dev@scipy.org'
 
 url = 'http://ipython.org'
 
-download_url = 'https://github.com/ipython/ipython/downloads'
 
-platforms = ['Linux','Mac OSX','Windows XP/Vista/7/8']
+platforms = ['Linux','Mac OSX','Windows']
 
-keywords = ['Interactive','Interpreter','Shell','Parallel','Distributed',
-            'Web-based computing', 'Qt console', 'Embedding']
+keywords = ['Interactive','Interpreter','Shell', 'Embedding']
 
 classifiers = [
     'Framework :: IPython',

--- a/setupbase.py
+++ b/setupbase.py
@@ -80,7 +80,6 @@ setup_args = dict(
       author           = author,
       author_email     = author_email,
       url              = url,
-      download_url     = download_url,
       license          = license,
       platforms        = platforms,
       keywords         = keywords,

--- a/tools/build_release
+++ b/tools/build_release
@@ -15,7 +15,7 @@ cd(ipdir)
 execfile(pjoin('IPython', 'core', 'release.py'), globals())
 
 # Check that everything compiles
-compile_tree()
+compile_tree('*')
 
 # Cleanup
 for d in ['build', 'dist', pjoin('docs', 'build'), pjoin('docs', 'dist'),

--- a/tools/release
+++ b/tools/release
@@ -8,7 +8,7 @@ from __future__ import print_function
 import os
 import sys
 
-from toollib import (get_ipdir, pjoin, cd, execfile, version, sh, archive,
+from toollib import (get_ipdir, pjoin, cd, execfile, sh, archive,
         sdists, archive_user, archive_dir)
 from gh_api import post_download
 
@@ -26,6 +26,7 @@ if not os.path.exists(ipbackupdir):
 cd(ipdir)
 
 # Load release info
+version = None
 execfile(pjoin('IPython','core','release.py'), globals())
 
 # Build site addresses for file uploads
@@ -50,17 +51,18 @@ sh('mv ipython-*.tgz %s' % ipbackupdir)
 # Build release files
 sh('./build_release %s' % ipdir)
 
-if 'upload' not in sys.argv:
-    print("`./release upload` to register and release")
-    sys.exit(0)
-
 # Not Registering with PyPI, registering with setup.py is insecure as communication is not encrypted
 cd(ipdir)
 
 # Upload all files
 sh(sdists)
-for py in ('2.7', '3.4'):
+for py in ('2', '3'):
     sh('python%s setupegg.py bdist_wheel' % py)
+
+if 'upload' not in sys.argv:
+    print("`./release upload` to register and release")
+    sys.exit(0)
+
 
 print('Will not upload with setuptools as upload connection is insecure. Please use `twine upload dist/*` to upload the files to PyPI')
 

--- a/tools/toollib.py
+++ b/tools/toollib.py
@@ -48,9 +48,9 @@ def get_ipdir():
     return ipdir
 
 
-def compile_tree():
+def compile_tree(folder='.'):
     """Compile all Python files below current directory."""
-    stat = os.system('python -m compileall .')
+    stat = os.system('python -m compileall {}'.format(folder))
     if stat:
         msg = '*** ERROR: Some Python files in tree do NOT compile! ***\n'
         msg += 'See messages above for the actual file that produced it.\n'


### PR DESCRIPTION
A few more update to the build process:

Remove not relevant classifier, add (a few)  missing classifier.
Remove download url (pointing to GitHub releases).

Do not try to compile fiels in hidden folders like `.git`
