### PR TITLE
compare shell tokens with BashLexer output

### DIFF
--- a/IPython/lib/tests/test_lexers.py
+++ b/IPython/lib/tests/test_lexers.py
@@ -5,6 +5,7 @@
 
 from unittest import TestCase
 from pygments.token import Token
+from pygments.lexers import BashLexer
 
 from .. import lexers
 
@@ -13,16 +14,14 @@ class TestLexers(TestCase):
     """Collection of lexers tests"""
     def setUp(self):
         self.lexer = lexers.IPythonLexer()
+        self.bash_lexer = BashLexer()
 
     def testIPythonLexer(self):
         fragment = '!echo $HOME\n'
         tokens = [
             (Token.Operator, '!'),
-            (Token.Name.Builtin, 'echo'),
-            (Token.Text, ' '),
-            (Token.Name.Variable, '$HOME'),
-            (Token.Text, '\n'),
         ]
+        tokens.extend(self.bash_lexer.get_tokens(fragment[1:]))
         self.assertEqual(tokens, list(self.lexer.get_tokens(fragment)))
 
         fragment_2 = '!' + fragment

--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ extras_require = dict(
     parallel = ['ipyparallel'],
     qtconsole = ['qtconsole'],
     doc = ['Sphinx>=1.3'],
-    test = ['nose>=0.10.1', 'requests', 'testpath'],
+    test = ['nose>=0.10.1', 'requests', 'testpath', 'pygments'],
     terminal = [],
     kernel = ['ipykernel'],
     nbformat = ['nbformat'],


### PR DESCRIPTION
rather than assuming BashLexer's output will never change

closes #9201
