### PR TITLE
Latextools: Make latex_to_png_mpl not fail on errors

### DIFF
--- a/IPython/lib/latextools.py
+++ b/IPython/lib/latextools.py
@@ -97,9 +97,10 @@ def latex_to_png(s, encode=False, backend=None, wrap=False):
 def latex_to_png_mpl(s, wrap):
     try:
         from matplotlib import mathtext
+        from pyparsing import ParseFatalException
     except ImportError:
         return None
-    
+
     # mpl mathtext doesn't support display math, force inline
     s = s.replace('$$', '$')
     if wrap:
@@ -110,7 +111,7 @@ def latex_to_png_mpl(s, wrap):
         f = BytesIO()
         mt.to_png(f, s, fontsize=12)
         return f.getvalue()
-    except:
+    except (ValueError, RuntimeError, ParseFatalException):
         return None
 
 
@@ -141,7 +142,7 @@ def latex_to_png_dvipng(s, wrap):
 
         with open(outfile, "rb") as f:
             return f.read()
-    except:
+    except subprocess.CalledProcessError:
         return None
     finally:
         shutil.rmtree(workdir)

--- a/IPython/lib/latextools.py
+++ b/IPython/lib/latextools.py
@@ -104,11 +104,14 @@ def latex_to_png_mpl(s, wrap):
     s = s.replace('$$', '$')
     if wrap:
         s = u'${0}$'.format(s)
-    
-    mt = mathtext.MathTextParser('bitmap')
-    f = BytesIO()
-    mt.to_png(f, s, fontsize=12)
-    return f.getvalue()
+
+    try:
+        mt = mathtext.MathTextParser('bitmap')
+        f = BytesIO()
+        mt.to_png(f, s, fontsize=12)
+        return f.getvalue()
+    except:
+        return None
 
 
 def latex_to_png_dvipng(s, wrap):
@@ -138,6 +141,8 @@ def latex_to_png_dvipng(s, wrap):
 
         with open(outfile, "rb") as f:
             return f.read()
+    except:
+        return None
     finally:
         shutil.rmtree(workdir)
 


### PR DESCRIPTION
- Also make make both `latex_to_foo` functions to return None on failure.
- This will help to solve the errors qtconsole is having to handle Latex (as reported in jupyter/qtconsole#56)
