### PR TITLE
Release process tweaks

### DIFF
--- a/docs/source/coredev/release_process.rst
+++ b/docs/source/coredev/release_process.rst
@@ -102,7 +102,7 @@ release is: ``1.3rc1``. Notice that there is no separator between the '3' and
 the 'r'.
 
 
-Commit the changes to release.py and jsversion::
+Commit the changes to release.py::
 
     git commit -am "release $VERSION"
     git push origin $BRANCH

--- a/tools/build_release
+++ b/tools/build_release
@@ -4,7 +4,7 @@
 import os
 from shutil import rmtree
 
-from toollib import sh, pjoin, get_ipdir, cd, compile_tree, execfile, sdists, buildwheels
+from toollib import sh, pjoin, get_ipdir, cd, execfile, sdists, buildwheels
 
 def build_release():
 
@@ -14,9 +14,6 @@ def build_release():
 
     # Load release info
     execfile(pjoin('IPython', 'core', 'release.py'), globals())
-
-    # Check that everything compiles
-    compile_tree('*')
 
     # Cleanup
     for d in ['build', 'dist', pjoin('docs', 'build'), pjoin('docs', 'dist'),

--- a/tools/toollib.py
+++ b/tools/toollib.py
@@ -59,7 +59,7 @@ def compile_tree(folder='.'):
         raise SystemExit(msg)
 
 try:
-    execfile
+    execfile = execfile
 except NameError:
     def execfile(fname, globs, locs=None):
         locs = locs or globs

--- a/tools/toollib.py
+++ b/tools/toollib.py
@@ -49,15 +49,6 @@ def get_ipdir():
         raise SystemExit('Invalid ipython directory: %s' % ipdir)
     return ipdir
 
-
-def compile_tree(folder='.'):
-    """Compile all Python files below current directory."""
-    stat = os.system('python -m compileall {}'.format(folder))
-    if stat:
-        msg = '*** ERROR: Some Python files in tree do NOT compile! ***\n'
-        msg += 'See messages above for the actual file that produced it.\n'
-        raise SystemExit(msg)
-
 try:
     execfile = execfile
 except NameError:


### PR DESCRIPTION
Things I ran into while releasing 4.1.1.

The only one that might be controversial is removing the `python -m compileall` check before we build packages. Because this is hardcoded to `python`, it runs on Python 2 on my system, and fails on one of our tools scripts that happens to be Python 3 only. We could make this smarter, but I don't think it's worth it. We now have continuous integration and editors with built in static analysis, so if we make a file invalid Python syntax we'll know about it well before release.

I also ran into a problem in that I don't have access to archive.ipython.org (I'm sure I did on one of my other computers, but I forget which). There should probably be a check for that somewhere earlier in the build process, but I haven't included it here.
