### PR TITLE
Nested svg

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -492,12 +492,13 @@ class SVG(DisplayObject):
         x = minidom.parseString(svg)
         # get svg tag (should be 1)
         found_svg = x.getElementsByTagName('svg')
-        if found_svg:
-            svg = found_svg[0].toxml()
-        else:
-            # fallback on the input, trust the user
-            # but this is probably an error.
-            pass
+        # if found_svg:
+        #     svg = found_svg[0].toxml()
+        # else:
+        #     # fallback on the input, trust the user
+        #     # but this is probably an error.
+        #     pass
+        svg = found_svg[0].toxml()
         svg = cast_unicode(svg)
         self._data = svg
 
@@ -976,4 +977,3 @@ def set_matplotlib_close(close=True):
     from ipykernel.pylab.config import InlineBackend
     cfg = InlineBackend.instance()
     cfg.close_figures = close
-

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -492,17 +492,20 @@ class SVG(DisplayObject):
         x = minidom.parseString(svg)
         # get svg tag (should be 1)
         found_svg = x.getElementsByTagName('svg')
-        # if found_svg:
-        #     svg = found_svg[0].toxml()
-        # else:
-        #     # fallback on the input, trust the user
-        #     # but this is probably an error.
-        #     pass
+        if found_svg:
+            svg = found_svg[0].toxml()
+        else:
+            # fallback on the input, trust the user
+            # but this is probably an error.
+            pass
         svg = found_svg[0].toxml()
         svg = cast_unicode(svg)
         self._data = svg
 
     def _repr_svg_(self):
+        return self.data
+        
+    def _repr_html_(self):
         return self.data
 
 

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -498,7 +498,6 @@ class SVG(DisplayObject):
             # fallback on the input, trust the user
             # but this is probably an error.
             pass
-        svg = found_svg[0].toxml()
         svg = cast_unicode(svg)
         self._data = svg
 


### PR DESCRIPTION
Solve the issue "IPython notebook: unable to display nested SVG elements #8780" (FIX #8780 )

I know it is in a hacky way... The real problem come from the way SVG is sanitized in ipython, I am sure now after beeing tracking this bug throught notebook, ipykernel and eventally return in ipython :-).
