### PR TITLE
only exit on error if `interact` is False

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -198,6 +198,8 @@ class InteractiveShellApp(Configurable):
     )
     shell = Instance('IPython.core.interactiveshell.InteractiveShellABC',
                      allow_none=True)
+    # whether interact-loop should start
+    interact = Bool(True)
     
     user_ns = Instance(dict, args=None, allow_none=True)
     def _user_ns_changed(self, name, old, new):

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -413,6 +413,8 @@ class InteractiveShellApp(Configurable):
                 self.log.warning("Error in executing line in user namespace: %s" %
                               line)
                 self.shell.showtraceback()
+                if not self.interact:
+                    self.exit(1)
 
         # Like Python itself, ignore the second if the first of these is present
         elif self.file_to_run:
@@ -421,7 +423,8 @@ class InteractiveShellApp(Configurable):
                 self._exec_file(fname, shell_futures=True)
             except:
                 self.shell.showtraceback(tb_offset=4)
-                self.exit(1)
+                if not self.interact:
+                    self.exit(1)
 
     def _run_module(self):
         """Run module specified at the command-line."""

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -272,7 +272,6 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
     _module_to_run_changed = _file_to_run_changed
 
     # internal, not-configurable
-    interact=Bool(True)
     something_to_run=Bool(False)
 
     def parse_command_line(self, argv=None):


### PR DESCRIPTION
fixes `ipython -i failing-script.py`
closes #9223
