### PR TITLE
adapt DisplayHook.quiet() for multiline input

### DIFF
--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -96,7 +96,7 @@ class DisplayHook(Configurable):
         tokens = list(tokenize.generate_tokens(sio.readline))
 
         for token in reversed(tokens):
-            if token[0] in (tokenize.ENDMARKER, tokenize.COMMENT):
+            if token[0] in (tokenize.ENDMARKER, tokenize.NL, tokenize.NEWLINE, tokenize.COMMENT):
                 continue
             if (token[0] == tokenize.OP) and (token[1] == ';'):
                 return True

--- a/IPython/core/tests/test_displayhook.py
+++ b/IPython/core/tests/test_displayhook.py
@@ -10,6 +10,10 @@ def test_output_displayed():
       
     with AssertPrints('2'):
         ip.run_cell('1+1 # comment with a semicolon;', store_history=True)
+
+    with AssertPrints('2'):
+        ip.run_cell('1+1\n#commented_out_function();', store_history=True)
+
       
 def test_output_quiet():
     """Checking to make sure that output is quiet"""
@@ -19,3 +23,6 @@ def test_output_quiet():
       
     with AssertNotPrints('2'):
         ip.run_cell('1+1; # comment with a semicolon', store_history=True)
+
+    with AssertNotPrints('2'):
+        ip.run_cell('1+1;\n#commented_out_function()', store_history=True)


### PR DESCRIPTION
Fixes #4525.

AFAICS [# inside strings](https://github.com/ipython/ipython/issues/4525#issuecomment-38192973) was already resolved by #8505 (and does not require a separate test?).
