### PR TITLE
Remove separate 'GUI' banner for ipykernel

### DIFF
--- a/IPython/core/usage.py
+++ b/IPython/core/usage.py
@@ -336,10 +336,6 @@ help      -> Python's own help system.
 object?   -> Details about 'object', use 'object??' for extra details.
 """
 
-gui_note = """\
-%guiref   -> A brief reference about the graphical user interface.
-"""
-
 default_banner_parts = [
     'Python %s\n' % (sys.version.split('\n')[0],),
     'Type "copyright", "credits" or "license" for more information.\n\n',
@@ -349,8 +345,4 @@ default_banner_parts = [
     quick_guide
 ]
 
-default_gui_banner_parts = default_banner_parts + [gui_note]
-
 default_banner = ''.join(default_banner_parts)
-
-default_gui_banner = ''.join(default_gui_banner_parts)


### PR DESCRIPTION
See ipython/ipykernel#101

This will break compatibility with ipykernel releases before that PR is merged, so milestoning for 5.0.
