### PR TITLE
Force nocolor in some cases.

### DIFF
--- a/IPython/terminal/embed.py
+++ b/IPython/terminal/embed.py
@@ -270,6 +270,7 @@ def embed(**kwargs):
     if config is None:
         config = load_default_config()
         config.InteractiveShellEmbed = config.TerminalInteractiveShell
+        config.InteractiveShellEmbed.colors='nocolor'
         kwargs['config'] = config
     #save ps1/ps2 if defined
     ps1 = None

--- a/IPython/terminal/tests/test_embed.py
+++ b/IPython/terminal/tests/test_embed.py
@@ -64,7 +64,7 @@ def test_nest_embed():
     ipy_prompt = r']:' #ansi color codes give problems matching beyond this
 
 
-    child = pexpect.spawn('%s -m IPython'%(sys.executable, ))
+    child = pexpect.spawn('%s -m IPython --colors=nocolor'%(sys.executable, ))
     child.expect(ipy_prompt)
     child.sendline("from __future__ import print_function")
     child.expect(ipy_prompt)
@@ -123,3 +123,5 @@ def test_nest_embed():
     child.sendline("print('true' if IPython.get_ipython() is ip0 else 'false')")
     assert(child.expect(['true\r\n', 'false\r\n']) == 0)
     child.expect(ipy_prompt)
+    child.sendline('exit')
+    child.close()


### PR DESCRIPTION
will help for the refactoring using pygments.

Also clean exit of subprocess in tests.
