### PR TITLE
Remove annoying unused variable

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -557,7 +557,6 @@ class Pdb(OldPdb):
 
     def do_longlist(self, arg):
         self.lastcmd = 'longlist'
-        filename = self.curframe.f_code.co_filename
         try:
             lines, lineno = self.getsourcelines(self.curframe)
         except OSError as err:


### PR DESCRIPTION
## 

Keep popping up red in my editor. And keep beeing a conflict on rebase/cherry-pick. 
