### PR TITLE
Don't try to pass shell up kwargs from Magics class

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -520,7 +520,6 @@ class Magics(Configurable):
                 shell.configurables.append(self)
             if hasattr(shell, 'config'):
                 kwargs.setdefault('parent', shell)
-            kwargs['shell'] = shell
 
         self.shell = shell
         self.options_table = {}


### PR DESCRIPTION
See ipython/traitlets#176 - this is causing test failures.
