### PR TITLE
Fix the deprecation of IPython.utils.warn

### DIFF
--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -29,7 +29,7 @@ from IPython.core.error import UsageError
 
 from IPython.utils.py3compat import string_types
 from traitlets import List, Instance
-from IPython.utils.warn import error
+from logging import error
 
 #-----------------------------------------------------------------------------
 # Utilities

--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -18,7 +18,7 @@ from traitlets.config.configurable import Configurable
 from IPython.utils import io
 from IPython.utils.py3compat import builtin_mod, cast_unicode_py2
 from traitlets import Instance, Float
-from IPython.utils.warn import warn
+from warnings import warn
 
 # TODO: Move the various attributes (cache_size, [others now moved]). Some
 # of these are also attributes of InteractiveShell. They should be on ONE object
@@ -293,4 +293,3 @@ class DisplayHook(Configurable):
         # IronPython blocks here forever
         if sys.platform != "cli":
             gc.collect()
-

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -35,7 +35,7 @@ from IPython.utils import py3compat
 from traitlets import (
     Any, Bool, Dict, Instance, Integer, List, Unicode, TraitError,
 )
-from IPython.utils.warn import warn
+from warnings import warn
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -879,5 +879,3 @@ def _format_lineno(session, line):
     if session == 0:
         return str(line)
     return "%s#%s" % (session, line)
-
-

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -77,7 +77,8 @@ from IPython.utils.text import (format_screen, LSString, SList,
                                 DollarFormatter)
 from traitlets import (Integer, Bool, CBool, CaselessStrEnum, Enum,
                                      List, Dict, Unicode, Instance, Type)
-from IPython.utils.warn import warn, error
+from warnings import warn
+from logging import error
 import IPython.core.hooks
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -33,7 +33,7 @@ from IPython.utils.process import arg_split
 from IPython.utils.py3compat import string_types, iteritems
 from IPython.utils.text import dedent
 from traitlets import Bool, Dict, Instance
-from IPython.utils.warn import error
+from logging import error
 
 #-----------------------------------------------------------------------------
 # Globals

--- a/IPython/core/magics/auto.py
+++ b/IPython/core/magics/auto.py
@@ -1,6 +1,7 @@
 """Implementation of magic functions that control various automatic behaviors.
 """
 from __future__ import print_function
+from __future__ import absolute_import
 #-----------------------------------------------------------------------------
 #  Copyright (c) 2012 The IPython Development Team.
 #

--- a/IPython/core/magics/auto.py
+++ b/IPython/core/magics/auto.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 # Our own packages
 from IPython.core.magic import Bunch, Magics, magics_class, line_magic
 from IPython.testing.skipdoctest import skip_doctest
-from IPython.utils.warn import error
+from logging import error
 
 #-----------------------------------------------------------------------------
 # Magic implementation classes

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -14,7 +14,8 @@ from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.ipstruct import Struct
 from IPython.utils.path import unquote_filename
 from IPython.utils.py3compat import unicode_type
-from IPython.utils.warn import warn, error
+from warnings import warn
+from logging import error
 
 
 class MagicsDisplay(object):

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -1,6 +1,7 @@
 """Implementation of basic magic functions."""
 
 from __future__ import print_function
+from __future__ import absolute_import
 
 import io
 import sys

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -32,7 +32,8 @@ from IPython.utils import py3compat
 from IPython.utils.py3compat import string_types
 from IPython.utils.contexts import preserve_keys
 from IPython.utils.path import get_py_filename, unquote_filename
-from IPython.utils.warn import warn, error
+from warnings import warn
+from logging import error
 from IPython.utils.text import get_text_list
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -1,6 +1,7 @@
 """Implementation of code management magic functions.
 """
 from __future__ import print_function
+from __future__ import absolute_import
 #-----------------------------------------------------------------------------
 #  Copyright (c) 2012 The IPython Development Team.
 #

--- a/IPython/core/magics/config.py
+++ b/IPython/core/magics/config.py
@@ -1,6 +1,7 @@
 """Implementation of configuration-related magic functions.
 """
 from __future__ import print_function
+from __future__ import absolute_import
 #-----------------------------------------------------------------------------
 #  Copyright (c) 2012 The IPython Development Team.
 #

--- a/IPython/core/magics/config.py
+++ b/IPython/core/magics/config.py
@@ -19,7 +19,7 @@ import re
 # Our own packages
 from IPython.core.error import UsageError
 from IPython.core.magic import Magics, magics_class, line_magic
-from IPython.utils.warn import error
+from logging import error
 
 #-----------------------------------------------------------------------------
 # Magic implementation classes

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -43,7 +43,8 @@ from IPython.utils.ipstruct import Struct
 from IPython.utils.module_paths import find_mod
 from IPython.utils.path import get_py_filename, unquote_filename, shellglob
 from IPython.utils.timing import clock, clock2
-from IPython.utils.warn import warn, error
+from warnings import warn
+from logging import error
 
 if PY3:
     from io import StringIO

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -5,6 +5,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from __future__ import print_function
+from __future__ import absolute_import
 
 import ast
 import bdb

--- a/IPython/core/magics/logging.py
+++ b/IPython/core/magics/logging.py
@@ -18,7 +18,7 @@ import sys
 
 # Our own packages
 from IPython.core.magic import Magics, magics_class, line_magic
-from IPython.utils.warn import warn
+from warnings import warn
 from IPython.utils.py3compat import str_to_unicode
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/magics/pylab.py
+++ b/IPython/core/magics/pylab.py
@@ -18,7 +18,7 @@ from traitlets.config.application import Application
 from IPython.core import magic_arguments
 from IPython.core.magic import Magics, magics_class, line_magic
 from IPython.testing.skipdoctest import skip_doctest
-from IPython.utils.warn import warn
+from warnings import warn
 from IPython.core.pylabtools import backends
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -118,7 +118,7 @@ from IPython.utils import path as util_path
 from IPython.utils import py3compat
 from IPython.utils import ulinecache
 from IPython.utils.data import uniq_stable
-from IPython.utils.warn import info, error
+from logging import info, error
 
 # Globals
 # amount of space to put line numbers before verbose tracebacks

--- a/IPython/lib/backgroundjobs.py
+++ b/IPython/lib/backgroundjobs.py
@@ -36,7 +36,7 @@ import threading
 
 from IPython import get_ipython
 from IPython.core.ultratb import AutoFormattedTB
-from IPython.utils.warn import error
+from logging import error
 from IPython.utils.py3compat import string_types
 
 

--- a/IPython/lib/inputhook.py
+++ b/IPython/lib/inputhook.py
@@ -17,7 +17,7 @@ import platform
 import sys
 from distutils.version import LooseVersion as V
 
-from IPython.utils.warn import warn
+from warnings import warn
 
 #-----------------------------------------------------------------------------
 # Constants

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -22,7 +22,8 @@ from IPython.utils.encoding import get_stream_enc
 from IPython.utils import py3compat
 from IPython.utils.terminal import toggle_set_term_title, set_term_title
 from IPython.utils.process import abbrev_cwd
-from IPython.utils.warn import warn, error
+from warnings import warn
+from logging import error
 from IPython.utils.text import num_ini_spaces, SList, strip_email_quotes
 from traitlets import Integer, CBool, Unicode
 

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -212,7 +212,7 @@ test_group_names.append('autoreload')
 
 def check_exclusions_exist():
     from IPython.paths import get_ipython_package_dir
-    from IPython.utils.warn import warn
+    from warnings import warn
     parent = os.path.dirname(get_ipython_package_dir())
     for sec in test_sections:
         for pattern in sec.exclusions:
@@ -439,4 +439,3 @@ def run_iptest():
 
 if __name__ == '__main__':
     run_iptest()
-

--- a/IPython/utils/warn.py
+++ b/IPython/utils/warn.py
@@ -12,7 +12,7 @@ import sys
 
 from IPython.utils import io
 
-from warning import warn
+from warnings import warn
 
 warn("The module IPython.utils.warn is deprecated, use the standard warnings module instead", DeprecationWarning)
 

--- a/IPython/utils/warn.py
+++ b/IPython/utils/warn.py
@@ -12,6 +12,9 @@ import sys
 
 from IPython.utils import io
 
+from warning import warn
+
+warn("The module IPython.utils.warn is deprecated, use the standard warnings module instead", DeprecationWarning)
 
 def warn(msg,level=2,exit_val=1):
     """Standard warning printer. Gives formatting consistency.
@@ -29,7 +32,8 @@ def warn(msg,level=2,exit_val=1):
 
     -exit_val (1): exit value returned by sys.exit() for a level 4
     warning. Ignored for all other levels."""
-
+    
+    warn("The module IPython.utils.warn is deprecated, use the standard warnings module instead", DeprecationWarning)
     if level>0:
         header = ['','','WARNING: ','ERROR: ','FATAL ERROR: ']
         print(header[level], msg, sep='', file=io.stderr)
@@ -54,4 +58,3 @@ def fatal(msg,exit_val=1):
     """Equivalent to warn(msg,exit_val=exit_val,level=4)."""
 
     warn(msg,exit_val=exit_val,level=4)
-

--- a/IPython/utils/warn.py
+++ b/IPython/utils/warn.py
@@ -12,9 +12,9 @@ import sys
 
 from IPython.utils import io
 
-from warnings import warn
+import warnings
 
-warn("The module IPython.utils.warn is deprecated, use the standard warnings module instead", DeprecationWarning)
+warnings.warn("The module IPython.utils.warn is deprecated, use the standard warnings module instead", DeprecationWarning)
 
 def warn(msg,level=2,exit_val=1):
     """Standard warning printer. Gives formatting consistency.
@@ -33,7 +33,7 @@ def warn(msg,level=2,exit_val=1):
     -exit_val (1): exit value returned by sys.exit() for a level 4
     warning. Ignored for all other levels."""
     
-    warn("The module IPython.utils.warn is deprecated, use the standard warnings module instead", DeprecationWarning)
+    warnings.warn("The module IPython.utils.warn is deprecated, use the standard warnings module instead", DeprecationWarning)
     if level>0:
         header = ['','','WARNING: ','ERROR: ','FATAL ERROR: ']
         print(header[level], msg, sep='', file=io.stderr)


### PR DESCRIPTION
As the title said deprecate IPython.utils.warn, fixing #9090.
