### PR TITLE
Introduce some classes necessary for Pygments refactor

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -42,6 +42,7 @@ from IPython.utils.wildcard import list_namespace
 from IPython.utils.coloransi import TermColors, ColorScheme, ColorSchemeTable
 from IPython.utils.py3compat import cast_unicode, string_types, PY3
 from IPython.utils.signatures import signature
+from IPython.utils.colorable import Colorable
 
 # builtin docstrings to ignore
 _func_call_docstring = types.FunctionType.__call__.__doc__
@@ -365,13 +366,15 @@ def find_source_lines(obj):
     return lineno
 
 
-class Inspector:
+class Inspector(Colorable):
     def __init__(self, color_table=InspectColors,
                  code_color_table=PyColorize.ANSICodeColors,
                  scheme='NoColor',
-                 str_detail_level=0):
+                 str_detail_level=0, 
+                 parent=None, config=None):
+        super(Inspector, self).__init__(parent=parent, config=config)
         self.color_table = color_table
-        self.parser = PyColorize.Parser(code_color_table,out='str')
+        self.parser = PyColorize.Parser(out='str', parent=self, style=scheme)
         self.format = self.parser.format
         self.str_detail_level = str_detail_level
         self.set_active_scheme(scheme)

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -85,6 +85,7 @@ Inheritance diagram:
 # the file COPYING, distributed as part of this software.
 #*****************************************************************************
 
+from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
@@ -124,6 +125,8 @@ from IPython.utils import py3compat
 from IPython.utils import ulinecache
 from IPython.utils.data import uniq_stable
 from logging import info, error
+
+import IPython.utils.colorable as colorable
 
 # Globals
 # amount of space to put line numbers before verbose tracebacks
@@ -476,15 +479,16 @@ def find_recursion(etype, value, records):
 
 #---------------------------------------------------------------------------
 # Module classes
-class TBTools(object):
+class TBTools(colorable.Colorable):
     """Basic tools used by all traceback printer classes."""
 
     # Number of frames to skip when reporting tracebacks
     tb_offset = 0
 
-    def __init__(self, color_scheme='NoColor', call_pdb=False, ostream=None):
+    def __init__(self, color_scheme='NoColor', call_pdb=False, ostream=None, parent=None, config=None):
         # Whether to call the interactive pdb debugger after printing
         # tracebacks or not
+        super(TBTools, self).__init__(parent=parent, config=config)
         self.call_pdb = call_pdb
 
         # Output stream to write to.  Note that we store the original value in
@@ -590,9 +594,9 @@ class ListTB(TBTools):
     Because they are meant to be called without a full traceback (only a
     list), instances of this class can't call the interactive pdb debugger."""
 
-    def __init__(self, color_scheme='NoColor', call_pdb=False, ostream=None):
+    def __init__(self, color_scheme='NoColor', call_pdb=False, ostream=None, parent=None):
         TBTools.__init__(self, color_scheme=color_scheme, call_pdb=call_pdb,
-                         ostream=ostream)
+                         ostream=ostream, parent=parent)
 
     def __call__(self, etype, value, elist):
         self.ostream.flush()

--- a/IPython/utils/PyColorize.py
+++ b/IPython/utils/PyColorize.py
@@ -54,6 +54,8 @@ except AttributeError:
 from IPython.utils.coloransi import TermColors, InputTermColors ,ColorScheme, ColorSchemeTable
 from IPython.utils.py3compat import PY3
 
+from .colorable import Colorable
+
 if PY3:
     from io import StringIO
 else:
@@ -148,15 +150,18 @@ LightBGColors = ColorScheme(
 ANSICodeColors = ColorSchemeTable([NoColor,LinuxColors,LightBGColors],
                                   _scheme_default)
 
-class Parser:
+class Parser(Colorable):
     """ Format colored Python source.
     """
 
-    def __init__(self, color_table=None,out = sys.stdout):
+    def __init__(self, color_table=None, out = sys.stdout, parent=None, style=None):
         """ Create a parser with a specified color table and output channel.
 
         Call format() to process code.
         """
+
+        super(Parser, self).__init__(parent=parent)
+
         self.color_table = color_table and color_table or ANSICodeColors
         self.out = out
 

--- a/IPython/utils/colorable.py
+++ b/IPython/utils/colorable.py
@@ -1,0 +1,26 @@
+#*****************************************************************************
+# Copyright (C) 2016 The IPython Team <ipython-dev@scipy.org>
+#
+# Distributed under the terms of the BSD License.  The full license is in
+# the file COPYING, distributed as part of this software.
+#*****************************************************************************
+from __future__ import absolute_import
+
+"""
+Color managing related utilities
+"""
+
+import pygments
+
+from traitlets.config import Configurable
+from traitlets import Unicode
+
+
+available_themes = lambda : [s for s in pygments.styles.get_all_styles()]+['NoColor','LightBG','Linux']
+
+class Colorable(Configurable):
+    """
+    A subclass of configurable for all the classes that have a `default_scheme`
+    """
+    default_style=Unicode('lightbg', config=True)
+


### PR DESCRIPTION
Might make the further review simpler. 

This basically introduce "Colorable". 
It's basically the class from which all things that can have a **default** theme inherit. 
So that when you start IPython with `--color=foo`, you have consistent theme. 
