### PR TITLE
deprecate default_gui_banner

### DIFF
--- a/IPython/core/usage.py
+++ b/IPython/core/usage.py
@@ -346,3 +346,10 @@ default_banner_parts = [
 ]
 
 default_banner = ''.join(default_banner_parts)
+
+# deprecated GUI banner
+
+default_gui_banner = '\n'.join([
+    'DEPRECATED: IPython.core.usage.default_gui_banner is deprecated and will be removed',
+    default_banner,
+])


### PR DESCRIPTION
instead of removing it outright, which breaks things unnecessarily

closes #9239
