### PR TITLE
Rename PTInteractiveShell to TerminalInteractiveShell

### DIFF
--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -32,7 +32,7 @@ from IPython.core.shellapp import (
     InteractiveShellApp, shell_flags, shell_aliases
 )
 from IPython.extensions.storemagic import StoreMagics
-from .ptshell import PTInteractiveShell as TerminalInteractiveShell
+from .ptshell import TerminalInteractiveShell
 from IPython.utils import warn
 from IPython.paths import get_ipython_dir
 from traitlets import (

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -45,7 +45,7 @@ class IPythonPTCompleter(Completer):
         for m in matches:
             yield Completion(m, start_position=start_pos)
 
-class PTInteractiveShell(InteractiveShell):
+class TerminalInteractiveShell(InteractiveShell):
     colors_force = True
 
     pt_cli = None
@@ -187,7 +187,7 @@ class PTInteractiveShell(InteractiveShell):
         io.stderr = io.IOStream(sys.stderr)
 
     def __init__(self, *args, **kwargs):
-        super(PTInteractiveShell, self).__init__(*args, **kwargs)
+        super(TerminalInteractiveShell, self).__init__(*args, **kwargs)
         self.init_prompt_toolkit_cli()
         self.keep_running = True
 
@@ -237,4 +237,4 @@ class PTInteractiveShell(InteractiveShell):
             self._inputhook = None
 
 if __name__ == '__main__':
-    PTInteractiveShell.instance().interact()
+    TerminalInteractiveShell.instance().interact()


### PR DESCRIPTION
This means that existing config will get applied, even if not all of it has the desired effect. I haven't thought of any adverse effects of renaming this.

Ping @asmeurer, who requested this.
