### PR TITLE
'Restore `...:` as continuation prompt '

### DIFF
--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -79,7 +79,7 @@ class TerminalInteractiveShell(InteractiveShell):
 
     def get_continuation_tokens(self, cli, width):
         return [
-            (Token.Prompt, (' ' * (width - 2)) + ': '),
+            (Token.Prompt, (' ' * (width - 5)) + '...: '),
         ]
 
     def init_prompt_toolkit_cli(self):


### PR DESCRIPTION
I think it is more visually appealing. 
