### PR TITLE
Add explicit dependency on pygments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -196,6 +196,7 @@ install_requires = [
     'simplegeneric>0.8',
     'traitlets',
     'prompt_toolkit>=0.58',
+    'pygments',
 ]
 
 # Platform-specific dependencies:


### PR DESCRIPTION
It's used for the syntax highlighting, and prompt_toolkit no longer depends on it.
