### PR TITLE
Don't try to open temporary file twice in video embed test

### DIFF
--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -10,6 +10,7 @@ import nose.tools as nt
 
 from IPython.core import display
 from IPython.core.getipython import get_ipython
+from IPython.utils.tempdir import NamedFileInTemporaryDirectory
 from IPython import paths as ipath
 
 import IPython.testing.decorators as dec
@@ -164,9 +165,9 @@ def test_video_embedding():
     with nt.assert_raises(ValueError):
         v = display.Video(b'abc')
 
-    with tempfile.NamedTemporaryFile(suffix='.mp4') as f:
-        with open(f.name,'wb') as f:
-            f.write(b'abc')
+    with NamedFileInTemporaryDirectory('test.mp4') as f:
+        f.write(b'abc')
+        f.close()
 
         v = display.Video(f.name)
         assert not v.embed


### PR DESCRIPTION
This test fell foul of the Windows file locking behaviour where only one open handle is permitted on a file.
