### PR TITLE
Use simplified prompt in test_embed

### DIFF
--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -101,9 +101,9 @@ class TerminalInteractiveShell(InteractiveShell):
         ]
 
     def init_prompt_toolkit_cli(self):
-        if not sys.stdin.isatty():
-            # Piped input - e.g. for tests. Fall back to plain non-interactive
-            # output. This is very limited, and only accepts a single line.
+        if ('IPY_TEST_SIMPLE_PROMPT' in os.environ) or not sys.stdin.isatty():
+            # Fall back to plain non-interactive output for tests.
+            # This is very limited, and only accepts a single line.
             def prompt():
                 return cast_unicode_py2(input('In [%d]: ' % self.execution_count))
             self.prompt_for_code = prompt

--- a/IPython/terminal/tests/test_embed.py
+++ b/IPython/terminal/tests/test_embed.py
@@ -12,9 +12,9 @@
 #-----------------------------------------------------------------------------
 
 import os
+import subprocess
 import sys
 import nose.tools as nt
-from IPython.utils.process import process_handler
 from IPython.utils.tempdir import NamedFileInTemporaryDirectory
 from IPython.testing.decorators import skip_win32
 
@@ -47,9 +47,14 @@ def test_ipython_embed():
 
         # run `python file_with_embed.py`
         cmd = [sys.executable, f.name]
+        env = os.environ.copy()
+        env['IPY_TEST_SIMPLE_PROMPT'] = '1'
 
-        out, p = process_handler(cmd, lambda p: (p.communicate(_exit), p))
-        std = out[0].decode('UTF-8')
+        p = subprocess.Popen(cmd, env=env, stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = p.communicate(_exit)
+        std = out.decode('UTF-8')
+
         nt.assert_equal(p.returncode, 0)
         nt.assert_in('3 . 14', std)
         if os.name != 'nt':
@@ -62,9 +67,12 @@ def test_nest_embed():
     """test that `IPython.embed()` is nestable"""
     import pexpect
     ipy_prompt = r']:' #ansi color codes give problems matching beyond this
+    env = os.environ.copy()
+    env['IPY_TEST_SIMPLE_PROMPT'] = '1'
 
 
-    child = pexpect.spawn('%s -m IPython --colors=nocolor'%(sys.executable, ))
+    child = pexpect.spawn(sys.executable, ['-m', 'IPython', '--colors=nocolor'],
+                          env=env)
     child.expect(ipy_prompt)
     child.sendline("from __future__ import print_function")
     child.expect(ipy_prompt)


### PR DESCRIPTION
This should avoid the intermittent failures we saw. Ping @minrk 

I also reworked how the tests were dealing with subprocesses a bit.
