### PR TITLE
IPython requires colorama on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -206,6 +206,7 @@ install_requires = [
 extras_require.update({
     ':sys_platform != "win32"': ['pexpect'],
     ':sys_platform == "darwin"': ['appnope'],
+    ':sys_platform == "win32"': ['colorama'],
     'test:python_version == "2.7"': ['mock'],
 })
 # FIXME: re-specify above platform dependencies for pip < 6


### PR DESCRIPTION
I forgot to add this to the dependencies in the prompt_toolkit PR.
