### PR TITLE
remove setuptools workaround for platform_python_implementation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -232,13 +232,6 @@ if not any(arg.startswith('bdist') for arg in sys.argv):
     else:
         install_requires.append('pexpect')
     
-    # workaround pypa/setuptools#147, where setuptools misspells
-    # platform_python_implementation as python_implementation
-    if 'setuptools' in sys.modules:
-        for key in list(extras_require):
-            if 'platform_python_implementation' in key:
-                new_key = key.replace('platform_python_implementation', 'python_implementation')
-                extras_require[new_key] = extras_require.pop(key)
 
 everything = set()
 for key, deps in extras_require.items():


### PR DESCRIPTION
This was a workaround for old setuptools, but we've added a dependency on 18.5,
so it shouldn't be required anymore.

Setuptools 20.2 has removed python_implementation (perhaps unintentionally),
so the workaround actually _breaks_ on more recent setuptools.

We should have only made this patch when setuptools needed it, but we can remove it outright, now.

closes #9281
