### PR TITLE
FIX: use mpl.get_backend() instead of a global

### DIFF
--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -211,7 +211,7 @@ def select_figure_formats(shell, formats, **kwargs):
 
     [ f.pop(Figure, None) for f in shell.display_formatter.formatters.values() ]
 
-    if matplotlib.backends.backend.lower() == 'nbagg':
+    if matplotlib.get_backend().lower() == 'nbagg':
         formatter = shell.display_formatter.ipython_display_formatter
         formatter.for_type(Figure, _reshow_nbagg_figure)
 


### PR DESCRIPTION
Use `matplotlib.get_backend()` to look up the current backend rather
than looking at a module-level golabl in `matplotlib.backends`.

Closes #9286
