### PR TITLE
Allow objects to define their own key completions

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -937,8 +937,8 @@ class IPCompleter(Completer):
         def get_keys(obj):
             # Objects can define their own completions by defining an
             # _ipy_key_completions_() method.
-            if _safe_really_hasattr(obj, '_ipy_key_completions_'):
-                return obj._ipy_key_completions_()
+            if _safe_really_hasattr(obj, '_ipython_key_completions_'):
+                return obj._ipython_key_completions_()
 
             # Special case some common in-memory dict-like types
             if isinstance(obj, dict) or\

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -71,7 +71,7 @@ from IPython.core.latex_symbols import latex_symbols, reverse_latex_symbol
 from IPython.utils import generics
 from IPython.utils import io
 from IPython.utils.decorators import undoc
-from IPython.utils.dir2 import dir2
+from IPython.utils.dir2 import dir2, safe_hasattr
 from IPython.utils.process import arg_split
 from IPython.utils.py3compat import builtin_mod, string_types, PY3
 from traitlets import CBool, Enum
@@ -472,6 +472,18 @@ def _safe_isinstance(obj, module, class_name):
     return (module in sys.modules and
             isinstance(obj, getattr(__import__(module), class_name)))
 
+def _safe_really_hasattr(obj, name):
+    """Checks that an object genuinely has a given attribute.
+
+    Some objects claim to have any attribute that's requested, to act as a lazy
+    proxy for something else. We want to catch these cases and ignore their
+    claim to have the attribute we're interested in.
+    """
+    if safe_hasattr(obj, '_ipy_proxy_check_dont_define_this_'):
+        # If it claims this exists, don't trust it
+        return False
+
+    return safe_hasattr(obj, name)
 
 
 def back_unicode_name_matches(text):
@@ -923,7 +935,12 @@ class IPCompleter(Completer):
     def dict_key_matches(self, text):
         "Match string keys in a dictionary, after e.g. 'foo[' "
         def get_keys(obj):
-            # Only allow completion for known in-memory dict-like types
+            # Objects can define their own completions by defining an
+            # _ipy_key_completions_() method.
+            if _safe_really_hasattr(obj, '_ipy_key_completions_'):
+                return obj._ipy_key_completions_()
+
+            # Special case some common in-memory dict-like types
             if isinstance(obj, dict) or\
                _safe_isinstance(obj, 'pandas', 'DataFrame'):
                 try:

--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -13,7 +13,6 @@ import sys
 import io as _io
 import tokenize
 
-from IPython.core.formatters import _safe_get_formatter_method
 from traitlets.config.configurable import Configurable
 from IPython.utils import io
 from IPython.utils.py3compat import builtin_mod, cast_unicode_py2

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -765,7 +765,7 @@ class KeyCompletable(object):
     def __init__(self, things=()):
         self.things = things
 
-    def _ipy_key_completions_(self):
+    def _ipython_key_completions_(self):
         return list(self.things)
 
 def test_object_key_completion():

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -761,6 +761,22 @@ def test_dict_key_completion_invalids():
     _, matches = complete(line_buffer="name_error['")
     _, matches = complete(line_buffer="d['\\")  # incomplete escape
 
+class KeyCompletable(object):
+    def __init__(self, things=()):
+        self.things = things
+
+    def _ipy_key_completions_(self):
+        return list(self.things)
+
+def test_object_key_completion():
+    ip = get_ipython()
+    ip.user_ns['key_completable'] = KeyCompletable(['qwerty', 'qwick'])
+
+    _, matches = ip.Completer.complete(line_buffer="key_completable['qw")
+    nt.assert_in('qwerty', matches)
+    nt.assert_in('qwick', matches)
+
+
 def test_aimport_module_completer():
     ip = get_ipython()
     _, matches = ip.complete('i', '%aimport i')

--- a/IPython/utils/dir2.py
+++ b/IPython/utils/dir2.py
@@ -2,21 +2,11 @@
 """A fancy version of Python's builtin :func:`dir` function.
 """
 
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2011  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+import inspect
 from .py3compat import string_types
-
-#-----------------------------------------------------------------------------
-# Code
-#-----------------------------------------------------------------------------
 
 
 def safe_hasattr(obj, attr):
@@ -56,3 +46,36 @@ def dir2(obj):
 
     words = [w for w in words if isinstance(w, string_types)]
     return sorted(words)
+
+
+def get_real_method(obj, name):
+    """Like getattr, but with a few extra sanity checks:
+
+    - If obj is a class, ignore its methods
+    - Check if obj is a proxy that claims to have all attributes
+    - Catch attribute access failing with any exception
+    - Check that the attribute is a callable object
+
+    Returns the method or None.
+    """
+    if inspect.isclass(obj):
+        return None
+
+    try:
+        canary = getattr(obj, '_ipython_canary_method_should_not_exist_', None)
+    except Exception:
+        return None
+
+    if canary is not None:
+        # It claimed to have an attribute it should never have
+        return None
+
+    try:
+        m = getattr(obj, name, None)
+    except Exception:
+        return None
+
+    if callable(m):
+        return m
+
+    return None

--- a/docs/source/config/integrating.rst
+++ b/docs/source/config/integrating.rst
@@ -11,6 +11,14 @@ To change the attributes displayed by tab-completing your object, define a
 ``__dir__(self)`` method for it. For more details, see the documentation of the
 built-in `dir() function <http://docs.python.org/library/functions.html#dir>`_.
 
+You can also customise key completions for your objects, e.g. pressing tab after
+``obj["a``. To do so, define a method ``_ipython_key_completions_()``, which
+returns a list of objects which are possible keys in a subscript expression
+``obj[key]``.
+
+.. versionadded:: 5.0
+   Custom key completions
+
 Rich display
 ============
 


### PR DESCRIPTION
Objects can specify their own key completions by defining an `_ipy_key_completions_()` method that returns a list of objects which it expects in a subscript expression. E.g.

```
x._ipy_key_completions_() == ['foo']
x['f<TAB>  # completes foo
```

Closes gh-8865
