### PR TITLE
FIX: account for dpi == 'figure'

### DIFF
--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -98,6 +98,8 @@ def print_figure(fig, fmt='png', bbox_inches='tight', **kwargs):
         return
 
     dpi = rcParams['savefig.dpi']
+    if dpi == 'figure':
+        dpi = fig.dpi
     if fmt == 'retina':
         dpi = dpi * 2
         fmt = 'png'


### PR DESCRIPTION
In mpl 1.5.0 'figure' became a valid dpi value, in 2.0 it will
become the default.

xref https://github.com/matplotlib/matplotlib/issues/6113

This should be backported as far back as you are willing to backport.
