### PR TITLE
Adding savef functionality for line-by-line writing of python script

### DIFF
--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -230,33 +230,44 @@ class CodeMagics(Magics):
         Options:
 
             -s: SET new file to write , otherwise would write to temp.py
-            -f: force create new file ( overwrite original )
-            -r: raw
 
+            -f: force create new file ( overwrite original to be used with -s )
+
+            -r: use 'raw' input.  By default, the 'processed' history is used,
+            so that magics are loaded in their transformed version to valid
+            Python.  If this option is given, the raw input as typed as the
+            command line is used instead.
+
+        It works in modes either you can start a file or write commands,not both simultaneously
         This function serves as an extension to %save magic function.It writes to
         a file line by line instead of block for rapid development.
-        Possible Enhancements (1) merge with save (2) add option to append Last N lines
+        Possible Enhancements (1) merge with save
 
         """
 
-        opts,args = self.parse_options(parameter_s, 'srf', mode='list')
+        opts, args = self.parse_options(parameter_s, 'srf', mode='list')
         set_f= 's' in opts
         raw = 'r' in opts
         force = 'f' in opts
         ext = u'.ipy' if raw else u'.py'
+        n = 1
         global filename
 
         if set_f:
-            filename, codefrom = unquote_filename(args[0]), " ".join(args[1:])
+            filename = unquote_filename(args[0])
             if not filename.endswith((u'.py',u'.ipy')):
                 filename += ext
+
+        elif args:
+            n = int(args[0])
+
         file_exists = os.path.isfile(filename)
 
-        newfile = force and file_exists
-        mode = 'w' if newfile else 'a'
+        new_file = (force and file_exists) or not file_exists
+        mode = 'w' if new_file else 'a'
 
         try:
-            hist = self.shell.history_manager.get_tail(1, raw)
+            hist = self.shell.history_manager.get_tail(n, raw)
             cmds = "\n".join([x[2] for x in hist])
 
         except (TypeError, ValueError) as e:
@@ -264,16 +275,15 @@ class CodeMagics(Magics):
             return
         out = py3compat.cast_unicode(cmds)
         with io.open(filename, mode, encoding="utf-8") as f:
-            if newfile:
+            if new_file:
                 print('Starting python file: `%s`' % filename)
                 f.write(u"# coding: utf-8\n")
             elif not set_f:
                 # Only allow setting of file in one command individual files can be pushed later
                 f.write(out)
-            # make sure we end on a newline
+                print(out)
             if not out.endswith(u'\n'):
                 f.write(u'\n')
-        print(cmds)
 
     @line_magic
     def pastebin(self, parameter_s=''):


### PR DESCRIPTION
This functionality enables us to write to a set file line by line instead of block ( with set commands ). In short , it pushes commands to the "stack" which is a file. We can extend this to last N line instead of just the last line. Note that this CANNOT be achieved via alias. We can only do  "save -a -f filename.py" however we would still need to supply the line range.    

I have seen that save is quite inefficient in command line operation since you would need to recheck the saved files for wrong commands ( since all commands do not work ) which becomes cumbersome to go through once you have obtained the result. It is hence much efficient to copy to the file then and there once we realize the set of commands work.  

Possible Enhancements (1) merge with save (2) add option to append Last N lines
Tests conducted: iptest with both python2 and python3. Solution works , kindly suggests improvements / coding changes or compatibility issue. Feel free to suggest alternatives ( names , variables ) 
