### PR TITLE
Only handle Ctrl-C when in main input buffer

### DIFF
--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -132,7 +132,7 @@ class TerminalInteractiveShell(InteractiveShell):
             else:
                 b.insert_text('\n' + (' ' * (indent or 0)))
 
-        @kbmanager.registry.add_binding(Keys.ControlC)
+        @kbmanager.registry.add_binding(Keys.ControlC, filter=HasFocus(DEFAULT_BUFFER))
         def _(event):
             event.current_buffer.reset()
 


### PR DESCRIPTION
This allows Ctrl-C to work as normal within Ctrl-R search (see gh-9309)
