### PR TITLE
Don't check for readline when setting autoindent

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -527,15 +527,9 @@ class InteractiveShell(SingletonConfigurable):
         ensure_dir_exists(new)
 
     def set_autoindent(self,value=None):
-        """Set the autoindent flag, checking for readline support.
+        """Set the autoindent flag.
 
         If called with no arguments, it acts as a toggle."""
-
-        if value != 0 and not self.has_readline:
-            if os.name == 'posix':
-                warn("The auto-indent feature requires the readline library")
-            self.autoindent = 0
-            return
         if value is None:
             self.autoindent = not self.autoindent
         else:


### PR DESCRIPTION
Autoindent is not strictly tied to readline any more, and this warning was annoying me.
