### PR TITLE
SQLite database is created/opened even if HistoryManager is disabled

### DIFF
--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -186,3 +186,26 @@ def test_hist_file_config():
             # delete it.  I have no clue why
             pass
 
+def test_histmanager_disabled():
+    """Ensure that disabling the history manager doesn't create a database."""
+    cfg = Config()
+    cfg.HistoryAccessor.enabled = False
+
+    ip = get_ipython()
+    with TemporaryDirectory() as tmpdir:
+        hist_manager_ori = ip.history_manager
+        hist_file = os.path.join(tmpdir, 'history.sqlite')
+        cfg.HistoryManager.hist_file = hist_file
+        try:
+            ip.history_manager = HistoryManager(shell=ip, config=cfg)
+            hist = [u'a=1', u'def f():\n    test = 1\n    return test', u"b='€Æ¾÷ß'"]
+            for i, h in enumerate(hist, start=1):
+                ip.history_manager.store_inputs(i, h)
+            nt.assert_equal(ip.history_manager.input_hist_raw, [''] + hist)
+            ip.history_manager.reset()
+            ip.history_manager.end_session()
+        finally:
+            ip.history_manager = hist_manager_ori
+
+    # hist_file should not be created
+    nt.assert_false(os.path.exists(hist_file))


### PR DESCRIPTION
We run Jupyter notebooks in our test suite. When running in multiple threads, we were getting issues with the SQLite database that manages history, so we added `c.HistoryAccessor.enabled = False` to the IPython config in our test scripts.

However, we still get the following error sporadically:

``` python
Traceback (most recent call last):
  File "/home/travis/miniconda/envs/test/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "/home/travis/miniconda/envs/test/lib/python2.7/site-packages/IPython/core/interactiveshell.py", line 3213, in atexit_operations
    self.history_manager.end_session()
  File "/home/travis/miniconda/envs/test/lib/python2.7/site-packages/IPython/core/history.py", line 549, in end_session
    self.writeout_cache()
  File "<decorator-gen-22>", line 2, in writeout_cache
  File "/home/travis/miniconda/envs/test/lib/python2.7/site-packages/IPython/core/history.py", line 68, in needs_sqlite
    return f(self, *a, **kw)
  File "/home/travis/miniconda/envs/test/lib/python2.7/site-packages/IPython/core/history.py", line 755, in writeout_cache
    self._writeout_input_cache(conn)
  File "/home/travis/miniconda/envs/test/lib/python2.7/site-packages/IPython/core/history.py", line 739, in _writeout_input_cache
    (self.session_number,)+line)
sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread.The object was created in thread id 140005330646784 and this is thread id 140005449897728
```

(see [this TravisCI build](https://travis-ci.org/nengo/nengo/jobs/118276959#L1975)) and `history.sqlite` is still created, even though printing `get_ipython().history_manager.enabled` prints `False`.

I attempted to investigate this a bit by adding a unit test to ensure that a `history.sqlite` file isn't created if the config option is set, but this test passes, so it does appear to be working. I'm at a bit of a loss for where to look next!

For reference, what we run in our test suite amounts to:

``` python
from nbformat import read
from nbconvert import PythonExporter
exporter = PythonExporter()
nb = read(filepointer)
body, resources = exporter.from_notebook_node(nb)
... save to .py file ...
execfile(pyfile, {})
```

Is this an issue in `nbconvert` perhaps? Any pointers to things to look at would be appreciated! If I can get a failing test then hopefully I can fix it ;)
