### PR TITLE
Fix a typo: plot_to_latex -> poly_to_latex

### DIFF
--- a/examples/IPython Kernel/Custom Display Logic.ipynb
+++ b/examples/IPython Kernel/Custom Display Logic.ipynb
@@ -1214,7 +1214,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "However, you can configure IPython to do this automatically by registering the `Polynomial` class and the `plot_to_latex` function with an IPython display formatter. Let's look at the default formatters provided by IPython:"
+    "However, you can configure IPython to do this automatically by registering the `Polynomial` class and the `poly_to_latex` function with an IPython display formatter. Let's look at the default formatters provided by IPython:"
    ]
   },
   {


### PR DESCRIPTION
It seems  it is `poly_to_latex` function to be registered, not `plot_to_latex`
