### PR TITLE
Reserved height

### DIFF
--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -194,6 +194,7 @@ class TerminalInteractiveShell(InteractiveShell):
                             enable_history_search=True,
                             style=style,
                             mouse_support=self.mouse_support,
+                            reserve_space_for_menu=6,
         )
 
         self.pt_cli = CommandLineInterface(app,

--- a/setup.py
+++ b/setup.py
@@ -195,7 +195,7 @@ install_requires = [
     'pickleshare',
     'simplegeneric>0.8',
     'traitlets',
-    'prompt_toolkit>=0.58',
+    'prompt_toolkit>=0.60',
     'pygments',
     'backports.shutil_get_terminal_size',
 ]


### PR DESCRIPTION
Two changes:
- Upgrade to the latest prompt-toolkit. (0.60, from 2016.03.14.)
- Specify the height that is reserved for displaying the completions.

Feel free to merge or not to merge what you like ;)

I'm also planning to move to a breaking.feature.fix style of version numbering. Hopefully before the next IPython release.
