### PR TITLE
Require path.py for tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ extras_require = dict(
     parallel = ['ipyparallel'],
     qtconsole = ['qtconsole'],
     doc = ['Sphinx>=1.3'],
-    test = ['nose>=0.10.1', 'requests', 'testpath', 'pygments'],
+    test = ['nose>=0.10.1', 'requests', 'testpath', 'pygments', 'path.py'],
     terminal = [],
     kernel = ['ipykernel'],
     nbformat = ['nbformat'],


### PR DESCRIPTION
This was previously hidden because pickleshare was pulling in path.py
