### PR TITLE
Use system_raw in ptshell

### DIFF
--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -400,5 +400,10 @@ class TerminalInteractiveShell(InteractiveShell):
             return False
         return True
 
+    # Run !system commands directly, not through pipes, so terminal programs
+    # work correctly.
+    system = InteractiveShell.system_raw
+
+
 if __name__ == '__main__':
     TerminalInteractiveShell.instance().interact()


### PR DESCRIPTION
Closes gh-9391

We were using `system_piped`, which runs processes through pexpect. Within the terminal, we can use `system_raw`, which lets the child processes interact directly with the terminal we're running in.
