### PR TITLE
Have Ctrl-C in search mode clear query, if present

### DIFF
--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -16,7 +16,7 @@ from IPython.utils.process import abbrev_cwd
 from traitlets import Bool, CBool, Unicode, Dict
 
 from prompt_toolkit.completion import Completer, Completion
-from prompt_toolkit.enums import DEFAULT_BUFFER
+from prompt_toolkit.enums import DEFAULT_BUFFER, SEARCH_BUFFER
 from prompt_toolkit.filters import HasFocus, HasSelection, Condition
 from prompt_toolkit.history import InMemoryHistory
 from prompt_toolkit.shortcuts import create_prompt_application, create_eventloop
@@ -181,6 +181,13 @@ class TerminalInteractiveShell(InteractiveShell):
         @kbmanager.registry.add_binding(Keys.ControlC, filter=HasFocus(DEFAULT_BUFFER))
         def _(event):
             event.current_buffer.reset()
+
+        @kbmanager.registry.add_binding(Keys.ControlC, filter=HasFocus(SEARCH_BUFFER))
+        def _(event):
+            if event.current_buffer.document.text:
+                event.current_buffer.reset()
+            else:
+                event.cli.push_focus(DEFAULT_BUFFER)
 
         supports_suspend = Condition(lambda cli: hasattr(signal, 'SIGTSTP'))
 


### PR DESCRIPTION
As suggested in ipython/ipython#9314, when pressing Ctrl-C within the
search-bar, the current search terms will be cleared but the search
buffer will remain focused.  Pressing Ctrl-C when the search buffer is
empty will return focus to the default buffer.
