### PR TITLE
changelog for 4.2

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -201,7 +201,7 @@ html_additional_pages = {
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'ipythondoc'
 
-intersphinx_mapping = {'python': ('http://docs.python.org/2/', None),
+intersphinx_mapping = {'python': ('http://docs.python.org/3/', None),
                        'rpy2': ('http://rpy.sourceforge.net/rpy2/doc-2.4/html/', None),
                        'traitlets': ('http://traitlets.readthedocs.org/en/latest/', None),
                        'jupyterclient': ('http://jupyter-client.readthedocs.org/en/latest/', None),

--- a/docs/source/whatsnew/version4.rst
+++ b/docs/source/whatsnew/version4.rst
@@ -2,6 +2,19 @@
  4.x Series
 ============
 
+IPython 4.2
+===========
+
+IPython 4.2 (April, 2016) includes various bugfixes and improvements over 4.1.
+
+- Fix ``ipython -i`` on errors, which was broken in 4.1.
+- The delay meant to highlight deprecated commands that have moved to jupyter has been removed.
+- Improve compatibility with future versions of traitlets and matplotlib.
+- Use stdlib :func:`python:shutil.get_terminal_size` to measure terminal width when displaying tracebacks
+  (provided by ``backports.shutil_get_terminal_size`` on Python 2).
+
+You can see the rest `on GitHub <https://github.com/ipython/ipython/issues?q=milestone%3A4.2>`__.
+
 
 IPython 4.1
 ===========


### PR DESCRIPTION
This should start the release process for 4.2. This is quite a small release, but the `-i` fix is important to get out there. The only thing I see in between us and release is deciding on the path.py/pathlib change in #9408.
