### PR TITLE
only use backports.shutil_get_terminal_size on Python 2

### DIFF
--- a/IPython/utils/terminal.py
+++ b/IPython/utils/terminal.py
@@ -9,22 +9,18 @@ Authors:
 * Alexander Belchenko (e-mail: bialix AT ukr.net)
 """
 
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2011  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 import os
 import struct
 import sys
 import warnings
-import backports.shutil_get_terminal_size
+try:
+    from shutil import get_terminal_size as _get_terminal_size
+except ImportError:
+    # use backport on Python 2
+    from backports.shutil_get_terminal_size import get_terminal_size as _get_terminal_size
 
 from . import py3compat
 
@@ -122,4 +118,4 @@ def freeze_term_title():
 
 
 def get_terminal_size(defaultx=80, defaulty=25):
-    return backports.shutil_get_terminal_size.get_terminal_size((defaultx, defaulty))
+    return _get_terminal_size((defaultx, defaulty))

--- a/setup.py
+++ b/setup.py
@@ -197,7 +197,6 @@ install_requires = [
     'traitlets',
     'prompt_toolkit>=0.60',
     'pygments',
-    'backports.shutil_get_terminal_size',
 ]
 
 # Platform-specific dependencies:
@@ -205,6 +204,7 @@ install_requires = [
 # but requires pip >= 6. pip < 6 ignores these.
 
 extras_require.update({
+    ':python_version == "2.7"': ['backports.shutil_get_terminal_size'],
     ':python_version == "2.7" or python_version == "3.3"': ['pathlib2'],
     ':sys_platform != "win32"': ['pexpect'],
     ':sys_platform == "darwin"': ['appnope'],


### PR DESCRIPTION
removes the backport dependency on Python 3, where it's not needed.

candidate for 4.2.1
