### PR TITLE
Promote keywords arguments completion.

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -190,6 +190,9 @@ def completions_sorting_key(word):
     elif word.startswith('_'):
         prio1 = 1
 
+    if word.endswith('='):
+        prio1 = -1
+
     if word.startswith('%%'):
         # If there's another % in there, this is something else, so leave it alone
         if not "%" in word[2:]:


### PR DESCRIPTION
Mostly when you are completing in a function call, it seem logical that
if keywords are available, they are the ones you are interested in.
## 

Pretty sure there is an issue where we discussed that with @takluyver 
