### PR TITLE
Re enable multi line in PT-TerminalInteractiveShell

### DIFF
--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -283,7 +283,7 @@ class TerminalInteractiveShell(InteractiveShell):
                 'reserve_space_for_menu':self.space_for_menu,
                 'get_prompt_tokens':self.get_prompt_tokens,
                 'get_continuation_tokens':self.get_continuation_tokens,
-                'multiline':False,
+                'multiline':True,
                 }
 
 


### PR DESCRIPTION
Made it to false by mistake (mine) in #9423

Note that it "just" removed continuation prompt as "multiline" is just a
hint for prompt_toolkit.
