### PR TITLE
Back to explicit styles for the prompt tokens

### DIFF
--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -252,8 +252,8 @@ class TerminalInteractiveShell(InteractiveShell):
         """
         style_cls = get_style_by_name(name)
         style_overrides = {
-            Token.Prompt: style_cls.styles.get( Token.Keyword, '#009900'),
-            Token.PromptNum: style_cls.styles.get( Token.Literal.Number, '#00ff00 bold')
+            Token.Prompt: '#009900',
+            Token.PromptNum: '#00ff00 bold',
         }
         if name is 'default':
             style_cls = get_style_by_name('default')


### PR DESCRIPTION
I didn't notice these had changed in @Carreau's PR. The prompt number in particular was looking horrible with the default settings. I have reverted back to what we had before.

Wrong:

![screenshot from 2016-05-01 13-20-59](https://cloud.githubusercontent.com/assets/327925/14941761/bd57fd06-0f9f-11e6-997b-99e7f72c813c.png)

Right:

![screenshot from 2016-05-01 13-21-50](https://cloud.githubusercontent.com/assets/327925/14941764/c5a0469e-0f9f-11e6-8087-b170add7be3a.png)
