### PR TITLE
Upgrade to prompt_toolkit 1.0.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -195,7 +195,7 @@ install_requires = [
     'pickleshare',
     'simplegeneric>0.8',
     'traitlets',
-    'prompt_toolkit>=0.60',
+    'prompt_toolkit>=1.0.0,<2.0.0',
     'pygments',
 ]
 


### PR DESCRIPTION
This merge requests upgrades prompt-toolkit to 1.0.0.

As said, there were a few backwards incompatible changes I had to do in the key bindings. (all backwards incompatible changes were done in a way that it would not crash, but the user would end up using Emacs instead of Vi bindings, for instance.) I think that we can consider prompt-toolkit to be stable at this point. 

It points to `'prompt_toolkit>=1.0.0,<2.0.0'`. I will ensure to do proper testing before pushing new releases.

For IPython, this release means that the decomposed unicode characters are properly displayed.
A full changelog is here:
https://github.com/jonathanslenders/python-prompt-toolkit/blob/master/CHANGELOG

Jonathan
