### PR TITLE
Added display_completions_in_columns option.

### DIFF
--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -134,6 +134,11 @@ class TerminalInteractiveShell(InteractiveShell):
     term_title = Bool(True, config=True,
         help="Automatically set the terminal title"
     )
+
+    display_completions_in_columns = Bool(False, config=True,
+        help="Display a multi column completion menu.",
+    )
+
     def _term_title_changed(self, name, new_value):
         self.init_term_title()
     
@@ -289,8 +294,8 @@ class TerminalInteractiveShell(InteractiveShell):
                 'get_prompt_tokens':self.get_prompt_tokens,
                 'get_continuation_tokens':self.get_continuation_tokens,
                 'multiline':True,
+                'display_completions_in_columns': self.display_completions_in_columns,
                 }
-
 
     def _update_layout(self):
         """


### PR DESCRIPTION
Added configuration option to get a multi-column completion menu.

This pull request should be fine, however I think there is a bug. For almost every completion, I get the following error. start_index=10 and cursor_pos=1. 
I think there is a bug at this line: https://github.com/ipython/ipython/blob/master/IPython/core/completer.py#L807 Not sure, but it could have to do that some completions are case insensitive.

``` python
Traceback (most recent call last):                                                            
  File "/usr/lib64/python3.5/threading.py", line 914, in _bootstrap_inner                     
    self.run()                                                                                
  File "/usr/lib64/python3.5/threading.py", line 862, in run                                  
    self._target(*self._args, **self._kwargs)                                                 
  File "/home/jonathan/git/python-prompt-toolkit/prompt_toolkit/interface.py", line 759, in rn
    completions = list(buffer.completer.get_completions(document, complete_event))            
  File "/home/jonathan/git/ipython/IPython/terminal/ptshell.py", line 49, in get_completions  
    cursor_pos=document.cursor_position_col                                                   
  File "/home/jonathan/git/ipython/IPython/core/completer.py", line 1265, in complete         
    self.matches.extend(self.python_jedi_matches(text, line_buffer, cursor_pos))              
  File "/home/jonathan/git/ipython/IPython/core/completer.py", line 827, in python_jedi_matchs
    return [trim_start(before + c_text) for c_text in completion_text]                        
  File "/home/jonathan/git/ipython/IPython/core/completer.py", line 827, in <listcomp>        
    return [trim_start(before + c_text) for c_text in completion_text]                        
  File "/home/jonathan/git/ipython/IPython/core/completer.py", line 809, in trim_start        
    assert start_index <  cursor_pos                                                          
AssertionError
```
