### PR TITLE
Require recent enough traitlets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -195,7 +195,7 @@ install_requires = [
     'decorator',
     'pickleshare',
     'simplegeneric>0.8',
-    'traitlets',
+    'traitlets>=4.2',
     'prompt_toolkit>=1.0.0,<2.0.0',
     'pygments',
 ]


### PR DESCRIPTION
so we can start to force the new `.tag()` syntax.
