### PR TITLE
Add %%js alias for %%javascript

### DIFF
--- a/IPython/core/magics/display.py
+++ b/IPython/core/magics/display.py
@@ -25,24 +25,29 @@ from IPython.core.magic import  (
 @magics_class
 class DisplayMagics(Magics):
     """Magics for displaying various output types with literals
-    
-    Defines javascript/latex/svg/html cell magics for writing 
+
+    Defines javascript/latex/svg/html cell magics for writing
     blocks in those languages, to be rendered in the frontend.
     """
-    
+
+    @cell_magic
+    def js(self, line, cell):
+        """Run the cell block of Javascript code"""
+        self.javascript(line, cell)
+
     @cell_magic
     def javascript(self, line, cell):
         """Run the cell block of Javascript code"""
         display(Javascript(cell))
-        
-    
+
+
     @cell_magic
     def latex(self, line, cell):
         """Render the cell as a block of latex
-        
+
         The subset of latex which is support depends on the implementation in
-        the client.  In the Jupyter Notebook, this magic only renders the subset 
-        of latex defined by MathJax 
+        the client.  In the Jupyter Notebook, this magic only renders the subset
+        of latex defined by MathJax
         [here](https://docs.mathjax.org/en/v2.5-latest/tex.html)."""
         display(Latex(cell))
 


### PR DESCRIPTION
`%%javascript` is a bit long to type, and not the first thing that comes to mind when looking for a JS cell magic.  Here I added a `%%js` magic which is an alias for the long named cousin.

Hey, where's our `%%hypertextmarkuplanguage` magic??? :trollface: 
