### PR TITLE
"smart command mode" for ipdb (like pdb++).

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -311,6 +311,17 @@ class Pdb(OldPdb):
                 if self.shell.readline is not None:
                     self.shell.readline.set_completer_delims(self.shell.readline_delims)
 
+    def parseline(self, line):
+        if line.startswith("!!"):
+            # Force standard behavior.
+            return super(Pdb, self).parseline(line[2:])
+        # "Smart command mode" from pdb++: don't execute commands if a variable
+        # with the same name exists.
+        cmd, arg, newline = super(Pdb, self).parseline(line)
+        if cmd in self.curframe.f_globals or cmd in self.curframe.f_locals:
+            return super(Pdb, self).parseline("!" + line)
+        return super(Pdb, self).parseline(line)
+
     def new_do_up(self, arg):
         OldPdb.do_up(self, arg)
         self.shell.set_completer_frame(self.curframe)

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -206,7 +206,7 @@ def _file_lines(fname):
         return out
 
 
-class Pdb(OldPdb):
+class Pdb(OldPdb, object):
     """Modified Pdb class, does not load readline."""
 
     def __init__(self,color_scheme='NoColor',completekey=None,


### PR DESCRIPTION
If e.g. "c" is a variable currently visible, then "c" should print it
instead of running the "continue" Pdb command.  This idea was first
implemented by pdb++.

It is possible to force the standard pdb behavior (bypass variable
checking) by prefixing the command with "!!", e.g. "!!c" to continue.
