### PR TITLE
MNT: only try to use mpl.use if safe

### DIFF
--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -881,10 +881,8 @@ class IPythonDirective(Directive):
             # EmbeddedSphinxShell is created, its interactive shell member
             # is the same for each instance.
 
-            if mplbackend:
+            if mplbackend and 'matplotlib.backends' not in sys.modules:
                 import matplotlib
-                # Repeated calls to use() will not hurt us since `mplbackend`
-                # is the same each time.
                 matplotlib.use(mplbackend)
 
             # Must be called after (potentially) importing matplotlib and


### PR DESCRIPTION
If the library you are documenting sets the backend and imports
mpl this `use` will spam the doc build with warnings.  This guards
the call the same way it is done above.
