### PR TITLE
Update `ptshell.py` to use new traitlets API & rename unnamed callback.

### DIFF
--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -13,7 +13,7 @@ from IPython.core.interactiveshell import InteractiveShell
 from IPython.utils.py3compat import PY3, cast_unicode_py2, input
 from IPython.utils.terminal import toggle_set_term_title, set_term_title
 from IPython.utils.process import abbrev_cwd
-from traitlets import Bool, CBool, Unicode, Dict, Integer
+from traitlets import Bool, CBool, Unicode, Dict, Integer, observe
 
 from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.enums import DEFAULT_BUFFER, SEARCH_BUFFER, EditingMode
@@ -91,7 +91,7 @@ class IPythonPTLexer(Lexer):
 class TerminalInteractiveShell(InteractiveShell):
     colors_force = True
 
-    space_for_menu = Integer(6, config=True, help='Number of line at the bottom of the screen '
+    space_for_menu = Integer(6).tag(config=True, help='Number of line at the bottom of the screen '
                                                   'to reserve for the completion menu')
 
     def _space_for_menu_changed(self, old, new):
@@ -99,47 +99,48 @@ class TerminalInteractiveShell(InteractiveShell):
 
     pt_cli = None
 
-    autoedit_syntax = CBool(False, config=True,
+    autoedit_syntax = CBool(False).tag(config=True,
                             help="auto editing of files with syntax errors.")
 
-    confirm_exit = CBool(True, config=True,
+    confirm_exit = CBool(True).tag(config=True,
         help="""
         Set to confirm when you try to exit IPython with an EOF (Control-D
         in Unix, Control-Z/Enter in Windows). By typing 'exit' or 'quit',
         you can force a direct exit without any confirmation.""",
     )
-    editing_mode = Unicode('emacs', config=True,
+    editing_mode = Unicode('emacs').tag(config=True,
         help="Shortcut style to use at the prompt. 'vi' or 'emacs'.",
     )
 
-    mouse_support = Bool(False, config=True,
+    mouse_support = Bool(False).tag(config=True,
         help="Enable mouse support in the prompt"
     )
 
-    highlighting_style = Unicode('default', config=True,
+    highlighting_style = Unicode('default').tag(config=True,
             help="The name of a Pygments style to use for syntax highlighting: \n %s" % ', '.join(get_all_styles())
     )
 
     def _highlighting_style_changed(self, old, new):
         self._style = self._make_style_from_name(self.highlighting_style)
 
-    highlighting_style_overrides = Dict(config=True,
+    highlighting_style_overrides = Dict().tag(config=True,
         help="Override highlighting format for specific tokens"
     )
 
-    editor = Unicode(get_default_editor(), config=True,
+    editor = Unicode(get_default_editor()).tag(config=True,
         help="Set the editor used by IPython (default to $EDITOR/vi/notepad)."
     )
     
-    term_title = Bool(True, config=True,
+    term_title = Bool(True).tag(config=True,
         help="Automatically set the terminal title"
     )
 
-    display_completions_in_columns = Bool(False, config=True,
+    display_completions_in_columns = Bool(False).tag(config=True,
         help="Display a multi column completion menu.",
     )
 
-    def _term_title_changed(self, name, new_value):
+    @observe('term_title')
+    def _term_title_changed(self, change):
         self.init_term_title()
     
     def init_term_title(self):

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -195,11 +195,11 @@ class TerminalInteractiveShell(InteractiveShell):
                 b.insert_text('\n' + (' ' * (indent or 0)))
 
         @kbmanager.registry.add_binding(Keys.ControlC, filter=HasFocus(DEFAULT_BUFFER))
-        def _(event):
+        def _reset_buffer(event):
             event.current_buffer.reset()
 
         @kbmanager.registry.add_binding(Keys.ControlC, filter=HasFocus(SEARCH_BUFFER))
-        def _(event):
+        def _reset_search_buffer(event):
             if event.current_buffer.document.text:
                 event.current_buffer.reset()
             else:
@@ -208,7 +208,7 @@ class TerminalInteractiveShell(InteractiveShell):
         supports_suspend = Condition(lambda cli: hasattr(signal, 'SIGTSTP'))
 
         @kbmanager.registry.add_binding(Keys.ControlZ, filter=supports_suspend)
-        def _(event):
+        def _suspend_to_bg(event):
             event.cli.suspend_to_background()
 
         @Condition
@@ -223,13 +223,13 @@ class TerminalInteractiveShell(InteractiveShell):
                                     & insert_mode
                                     & cursor_in_leading_ws
                                    ))
-        def _(event):
+        def _indent_buffer(event):
             event.current_buffer.insert_text(' ' * 4)
 
         # Pre-populate history from IPython's history database
         history = InMemoryHistory()
         last_cell = u""
-        for _, _, cell in self.history_manager.get_tail(self.history_load_length,
+        for __, ___, cell in self.history_manager.get_tail(self.history_load_length,
                                                         include_latest=True):
             # Ignore blank lines and consecutive duplicates
             cell = cell.rstrip()


### PR DESCRIPTION
I prefer to have named functions instead of `_` my guess is that if there is a crash one day, we'll have an explicit traceback with a function name. 

I'm ok removing this commit if it does not please someone. 
