### PR TITLE
Don't skip tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
 install:
+    - pip install pip --upgrade
     - pip install "setuptools>=18.5"
-    - pip install -f travis-wheels/wheelhouse -e file://$PWD#egg=ipython[test]
+    - pip install  --upgrade --find-links travis-wheels/wheelhouse --find-links http://ccdd0ebb5a931e58c7c5-aae005c4999d7244ac63632f8b80e089.r77.cf2.rackcdn.com --trusted-host ccdd0ebb5a931e58c7c5-aae005c4999d7244ac63632f8b80e089.r77.cf2.rackcdn.com -e file://$PWD#egg=ipython[test] 
     - pip install codecov
 script:
     - cd /tmp && iptest --coverage xml && cd -

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # http://travis-ci.org/#!/ipython/ipython
 language: python
 python:
-    - 3.5
     - 3.4
     - 3.3
     - 2.7
@@ -12,10 +11,17 @@ before_install:
 install:
     - pip install pip --upgrade
     - pip install "setuptools>=18.5"
-    - pip install  --upgrade --find-links travis-wheels/wheelhouse --find-links http://ccdd0ebb5a931e58c7c5-aae005c4999d7244ac63632f8b80e089.r77.cf2.rackcdn.com --trusted-host ccdd0ebb5a931e58c7c5-aae005c4999d7244ac63632f8b80e089.r77.cf2.rackcdn.com -e file://$PWD#egg=ipython[test] 
+    - pip install  --upgrade --find-links travis-wheels/wheelhouse $EXTRA_PIP_ARGS -e file://$PWD#egg=ipython[test] $EXTRA_DEPS
     - pip install codecov
 script:
     - cd /tmp && iptest --coverage xml && cd -
+
+matrix:
+    include:
+      - python: 3.5
+        env: EXTRA_DEPS='matplotlib pillow pandas numpy' EXTRA_PIP_ARGS='--find-links http://ccdd0ebb5a931e58c7c5-aae005c4999d7244ac63632f8b80e089.r77.cf2.rackcdn.com --trusted-host ccdd0ebb5a931e58c7c5-aae005c4999d7244ac63632f8b80e089.r77.cf2.rackcdn.com'
+        
+
 after_success:
     - cp /tmp/ipy_coverage.xml ./
     - cp /tmp/.coverage ./

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -2,7 +2,6 @@
 # Distributed under the terms of the Modified BSD License.
 
 import json
-import tempfile
 import os
 import warnings
 

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -39,6 +39,8 @@ else:
     from StringIO import StringIO
 
 
+_ip = get_ipython()
+
 @magic.magics_class
 class DummyMagics(magic.Magics): pass
 
@@ -89,7 +91,6 @@ def test_config():
 
 def test_rehashx():
     # clear up everything
-    _ip = get_ipython()
     _ip.alias_manager.clear_aliases()
     del _ip.db['syscmdlist']
     
@@ -625,7 +626,6 @@ def test_extension():
         sys.path.remove(daft_path)
 
 
-@dec.skip_without('nbformat')
 def test_notebook_export_json():
     _ip = get_ipython()
     _ip.history_manager.reset()   # Clear any existing history.

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -254,22 +254,22 @@ class TestMagicRunSimple(tt.TempFileMixin):
 
         Returning from another run magic deletes the namespace"""
         # see ticket https://github.com/ipython/ipython/issues/238
-        class secondtmp(tt.TempFileMixin): pass
-        empty = secondtmp()
-        empty.mktmp('')
-        # On Windows, the filename will have \users in it, so we need to use the
-        # repr so that the \u becomes \\u.
-        src = ("ip = get_ipython()\n"
-               "for i in range(5):\n"
-               "   try:\n"
-               "       ip.magic(%r)\n"
-               "   except NameError as e:\n"
-               "       print(i)\n"
-               "       break\n" % ('run ' + empty.fname))
-        self.mktmp(src)
-        _ip.magic('run %s' % self.fname)
-        _ip.run_cell('ip == get_ipython()')
-        nt.assert_equal(_ip.user_ns['i'], 4)
+        
+        with tt.TempFileMixin() as empty:
+            empty.mktmp('')
+            # On Windows, the filename will have \users in it, so we need to use the
+            # repr so that the \u becomes \\u.
+            src = ("ip = get_ipython()\n"
+                   "for i in range(5):\n"
+                   "   try:\n"
+                   "       ip.magic(%r)\n"
+                   "   except NameError as e:\n"
+                   "       print(i)\n"
+                   "       break\n" % ('run ' + empty.fname))
+            self.mktmp(src)
+            _ip.magic('run %s' % self.fname)
+            _ip.run_cell('ip == get_ipython()')
+            nt.assert_equal(_ip.user_ns['i'], 4)
     
     def test_run_second(self):
         """Test that running a second file doesn't clobber the first, gh-3547
@@ -278,12 +278,12 @@ class TestMagicRunSimple(tt.TempFileMixin):
                    "def afunc():\n"
                    "  return avar\n")
 
-        empty = tt.TempFileMixin()
-        empty.mktmp("")
-        
-        _ip.magic('run %s' % self.fname)
-        _ip.magic('run %s' % empty.fname)
-        nt.assert_equal(_ip.user_ns['afunc'](), 1)
+        with tt.TempFileMixin() as empty:
+            empty.mktmp("")
+            
+            _ip.magic('run %s' % self.fname)
+            _ip.magic('run %s' % empty.fname)
+            nt.assert_equal(_ip.user_ns['afunc'](), 1)
 
     @dec.skip_win32
     def test_tclass(self):

--- a/IPython/terminal/tests/test_help.py
+++ b/IPython/terminal/tests/test_help.py
@@ -25,6 +25,5 @@ def test_locate_help():
 def test_locate_profile_help():
     tt.help_all_output_test("locate profile")
 
-@skip_without('nbformat')  # Requires jsonschema to be installed
 def test_trust_help():
     tt.help_all_output_test("trust")

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -44,6 +44,7 @@ pjoin = path.join
 
 
 # Enable printing all warnings raise by IPython's modules
+warnings.filterwarnings('ignore', message='.*Matplotlib is building the font cache.*', category=UserWarning, module='.*')
 if sys.version_info > (3,0):
     warnings.filterwarnings('error', message='.*', category=ResourceWarning, module='.*')
 warnings.filterwarnings('default', message='.*', category=Warning, module='IPy.*')

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -306,11 +306,8 @@ class TempFileMixin(object):
     def __enter__(self):
         return self
 
-
     def __exit__(self, exc_type, exc_value, traceback):
         self.tearDown()
-
-
 
 
 pair_fail_msg = ("Testing {0}\n\n"

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -303,6 +303,16 @@ class TempFileMixin(object):
                 # delete it.  I have no clue why
                 pass
 
+    def __enter__(self):
+        return self
+
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.tearDown()
+
+
+
+
 pair_fail_msg = ("Testing {0}\n\n"
                 "In:\n"
                 "  {1!r}\n"
@@ -421,16 +431,6 @@ class AssertNotPrints(AssertPrints):
             return False
         finally:
             self.tee.close()
-
-@contextmanager
-def mute_warn():
-    from IPython.utils import warn
-    save_warn = warn.warn
-    warn.warn = lambda *a, **kw: None
-    try:
-        yield
-    finally:
-        warn.warn = save_warn
 
 @contextmanager
 def make_tempfile(name):

--- a/setup.py
+++ b/setup.py
@@ -182,13 +182,14 @@ extras_require = dict(
     parallel = ['ipyparallel'],
     qtconsole = ['qtconsole'],
     doc = ['Sphinx>=1.3'],
-    test = ['nose>=0.10.1', 'requests', 'testpath', 'pygments'],
     terminal = [],
+    test = ['nose>=0.10.1', 'requests', 'testpath', 'pygments', 'numpy', 'matplotlib', 'pillow', 'pandas', 'nbformat', 'ipykernel'],
     kernel = ['ipykernel'],
     nbformat = ['nbformat'],
     notebook = ['notebook', 'ipywidgets'],
     nbconvert = ['nbconvert'],
 )
+
 install_requires = [
     'setuptools>=18.5',
     'decorator',

--- a/setup.py
+++ b/setup.py
@@ -183,7 +183,7 @@ extras_require = dict(
     qtconsole = ['qtconsole'],
     doc = ['Sphinx>=1.3'],
     terminal = [],
-    test = ['nose>=0.10.1', 'requests', 'testpath', 'pygments', 'numpy', 'matplotlib', 'pillow', 'pandas', 'nbformat', 'ipykernel'],
+    test = ['nose>=0.10.1', 'requests', 'testpath', 'pygments', 'nbformat', 'ipykernel'],
     kernel = ['ipykernel'],
     nbformat = ['nbformat'],
     notebook = ['notebook', 'ipywidgets'],


### PR DESCRIPTION
`deepreload` test is failing on my machine : 

```
Traceback (most recent call last):
  File "/Users/bussonniermatthias/anaconda/lib/python3.5/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/Users/bussonniermatthias/dev/ipython/IPython/lib/tests/test_deepreload.py", line 36, in test_deepreload_numpy
    dreload(numpy, exclude=exclude)
  File "/Users/bussonniermatthias/dev/ipython/IPython/lib/deepreload.py", line 341, in reload
    return deep_reload_hook(module)
  File "/Users/bussonniermatthias/dev/ipython/IPython/lib/deepreload.py", line 311, in deep_reload_hook
    newm = imp.load_module(name, fp, filename, stuff)
  File "/Users/bussonniermatthias/anaconda/lib/python3.5/imp.py", line 244, in load_module
    return load_package(name, filename)
  File "/Users/bussonniermatthias/anaconda/lib/python3.5/imp.py", line 214, in load_package
    return _exec(spec, sys.modules[name])
  File "<frozen importlib._bootstrap>", line 626, in _exec
  File "<frozen importlib._bootstrap_external>", line 662, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/Users/bussonniermatthias/anaconda/lib/python3.5/site-packages/numpy/__init__.py", line 212, in <module>
    if sys.version_info[0] >= 3:
NameError: name 'sys' is not defined
```

Likely due to (recent) numpy not available on travis. So let's try to see what we can get installed on travis. 

@takluyver I haven't found any manylinux1 available on PyPI. Do you know of any repo with them ? 
Otherwise it blow up the testing time to 8 minutes instead of 2. 
