### PR TITLE
Enable bracket matching by default

### DIFF
--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -146,7 +146,7 @@ class TerminalInteractiveShell(InteractiveShell):
         help="Display a multi column completion menu.",
     ).tag(config=True)
 
-    highlight_matching_brackets = Bool(False,
+    highlight_matching_brackets = Bool(True,
         help="Highlight matching brackets .",
     ).tag(config=True)
 


### PR DESCRIPTION
See #9496 - @jonathanslenders doesn't know of a reason not to do this.
