### PR TITLE
Use default system shell to capture shell output.

### DIFF
--- a/IPython/utils/_process_common.py
+++ b/IPython/utils/_process_common.py
@@ -70,8 +70,14 @@ def process_handler(cmd, callback, stderr=subprocess.PIPE):
     sys.stderr.flush()
     # On win32, close_fds can't be true when using pipes for stdin/out/err
     close_fds = sys.platform != 'win32'
-    p = subprocess.Popen(cmd, shell=isinstance(cmd, py3compat.string_types),
-                         executable=os.environ.get('SHELL'),
+    # Determine if cmd should be run with system shell.
+    shell = isinstance(cmd, py3compat.string_types)
+    # On POSIX systems run shell commands with user-preferred shell.
+    executable = None
+    if shell and os.name == 'posix' and 'SHELL' in os.environ:
+        executable = os.environ['SHELL']
+    p = subprocess.Popen(cmd, shell=shell,
+                         executable=executable,
                          stdin=subprocess.PIPE,
                          stdout=subprocess.PIPE,
                          stderr=stderr,

--- a/IPython/utils/_process_common.py
+++ b/IPython/utils/_process_common.py
@@ -17,6 +17,7 @@ of subprocess utilities, and it contains tools that are common to all of them.
 import subprocess
 import shlex
 import sys
+import os
 
 from IPython.utils import py3compat
 
@@ -70,6 +71,7 @@ def process_handler(cmd, callback, stderr=subprocess.PIPE):
     # On win32, close_fds can't be true when using pipes for stdin/out/err
     close_fds = sys.platform != 'win32'
     p = subprocess.Popen(cmd, shell=isinstance(cmd, py3compat.string_types),
+                         executable=os.environ.get('SHELL'),
                          stdin=subprocess.PIPE,
                          stdout=subprocess.PIPE,
                          stderr=stderr,


### PR DESCRIPTION
Adhere to the user `$SHELL` preference when capturing output from system
commands.  This makes the getoutput() and system() interactive functions
behave in a consistent way.  It also makes user shell customizations, i.e.,
aliases and non-exported shell variables, available within the captured 
command.

Example of an inconsistent behavior when `SHELL=/bin/zsh`:

```
In [1]: !print -l a b
a
b

In [2]: out = !print -l a b

In [3]: out
Out[3]: ['/bin/sh: print: command not found']
```
