### PR TITLE
Make numpy a test dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ extras_require = dict(
     parallel = ['ipyparallel'],
     qtconsole = ['qtconsole'],
     doc = ['Sphinx>=1.3'],
-    test = ['nose>=0.10.1', 'requests', 'testpath', 'pygments', 'nbformat', 'ipykernel'],
+    test = ['nose>=0.10.1', 'requests', 'testpath', 'pygments', 'nbformat', 'ipykernel', 'numpy'],
     terminal = [],
     kernel = ['ipykernel'],
     nbformat = ['nbformat'],


### PR DESCRIPTION
Since April 2016, numpy (1.11.0) have manylinux1  uploaded on PyPI.
There is thus no reasons not to require numpy for testing.
