### PR TITLE
Improve deprecation warning.

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -9,10 +9,13 @@ from warnings import warn
 from IPython.utils.decorators import undoc
 from .ptshell import TerminalInteractiveShell as PromptToolkitShell
 
+warn("Since IPython 5.0 `IPython.terminal.interactiveshell` is deprecated in favor of `IPython.terminal.ptshell`.",
+      DeprecationWarning)
+
 @undoc
 class TerminalInteractiveShell(PromptToolkitShell):
     def __init__(self, *args, **kwargs):
-        warn("This is a deprecated alias for IPython.terminal.ptshell.TerminalInteractiveShell. "
+        warn("Since IPython 5.0 this is a deprecated alias for IPython.terminal.ptshell.TerminalInteractiveShell. "
              "The terminal interface of this class now uses prompt_toolkit instead of readline.",
              DeprecationWarning, stacklevel=2)
         PromptToolkitShell.__init__(self, *args, **kwargs)


### PR DESCRIPTION
Raise a warning no import, as it is common to have import that are
unused.

Also add since when this is deprecated.

Close #9526
