### PR TITLE
Properly complete arguments to %cd.

### DIFF
--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -128,7 +128,7 @@ def test_unicode_completions():
         # depending on the state of the namespace, but at least no exceptions
         # should be thrown and the return value should be a pair of text, list
         # values.
-        text, matches = ip.complete(t)
+        text, matches = ip.complete(None, t)
         nt.assert_true(isinstance(text, string_types))
         nt.assert_true(isinstance(matches, list))
 

--- a/IPython/utils/process.py
+++ b/IPython/utils/process.py
@@ -104,3 +104,12 @@ def abbrev_cwd():
 
     return (drivepart + (
         cwd == '/' and '/' or tail))
+
+
+def arg_split_native(commandline, strict=True):
+    if sys.platform in ("win32", "cli"):
+        # Drop strictness, as it would bypass CommandLineToArgvW, which is
+        # non-strict anyways.
+        return arg_split(commandline, posix=False)
+    else:
+        return arg_split(commandline, posix=True, strict=strict)


### PR DESCRIPTION
Fixes #4519, #8364, #9316.

Rely on `arg_split` to re-split the entire line (up to the cursor) so
that directory names that include readline separators are properly
handled.

Because the completed symbol may not be the one that
`IPCompleter.complete` (which relies on naive splitting) believes to be,
it is necessary to tag each candidate completion with the symbol _it_
completes.  (Note that this symbol is not even necessarily a prefix of
the "original" symbol, e.g., on Windows, paths may get a double-quote
prepended upon completion.)  This is done using an attribute on an str
subclass.

Multiple completions may end up completing symbols of different length,
so the `_pad_completions` function is used to "pad" the completions,
pretending that they are all completing the same symbol.

Because completions no longer necessarily start with the completed
symbol, it is up to the individual completers to filter out
non-matching completions.
