### PR TITLE
allow failures on nightly Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,7 @@ after_success:
     - cp /tmp/ipy_coverage.xml ./
     - cp /tmp/.coverage ./
     - codecov
+
+matrix:
+    allow_failures:
+        python: nightly


### PR DESCRIPTION
while it's useful to run the tests, failures on Python nightly are likely to be not our bugs, and shouldn't generally be considered CI failures.
