### PR TITLE
Fix undefined labels in docs

### DIFF
--- a/docs/source/interactive/python-ipython-diff.rst
+++ b/docs/source/interactive/python-ipython-diff.rst
@@ -7,7 +7,7 @@ language and what are the specific construct you can do only in IPython.
 
 Unless expressed otherwise all of the construct you will see here will raise a
 ``SyntaxError`` if run in a pure Python shell, or if executing in a Python
-script.
+script. 
 
 Each of these features are describe more in details in further part of the documentation.
 
@@ -56,7 +56,7 @@ All the following construct are valid IPython syntax:
     In [1]: %%perl magic --function
        ...: @months = ("July", "August", "September");
        ...: print $months[0];
-
+    
 
 Each of these construct is compile by IPython into valid python code and will
 do most of the time what you expect it will do. Let see each of these example
@@ -100,7 +100,7 @@ namespace will show help relative to this object:
 
 
 A double question mark will try to pull out more information about the object,
-and if possible display the python source code of this object.
+and if possible display the python source code of this object. 
 
 .. code-block:: ipython
 
@@ -143,7 +143,7 @@ Shell Assignment
 
 
 When doing interactive computing it is common to need to access the underlying shell.
-This is doable through the use of the exclamation mark ``!`` (or bang).
+This is doable through the use of the exclamation mark ``!`` (or bang). 
 
 This allow to execute simple command when present in beginning of line:
 
@@ -205,7 +205,7 @@ Magics
 Magics function are often present in the form of shell-like syntax, but are
 under the hood python function. The syntax and assignment possibility are
 similar to the one with the bang (``!``) syntax, but with more flexibility and
-power. Magic function start with a percent sign (``%``) or double percent (``%%``).
+power. Magic function start with a percent sign (``%``) or double percent (``%%``). 
 
 A magic call with a sign percent will act only one line:
 

--- a/docs/source/interactive/python-ipython-diff.rst
+++ b/docs/source/interactive/python-ipython-diff.rst
@@ -7,7 +7,7 @@ language and what are the specific construct you can do only in IPython.
 
 Unless expressed otherwise all of the construct you will see here will raise a
 ``SyntaxError`` if run in a pure Python shell, or if executing in a Python
-script. 
+script.
 
 Each of these features are describe more in details in further part of the documentation.
 
@@ -56,7 +56,7 @@ All the following construct are valid IPython syntax:
     In [1]: %%perl magic --function
        ...: @months = ("July", "August", "September");
        ...: print $months[0];
-    
+
 
 Each of these construct is compile by IPython into valid python code and will
 do most of the time what you expect it will do. Let see each of these example
@@ -100,7 +100,7 @@ namespace will show help relative to this object:
 
 
 A double question mark will try to pull out more information about the object,
-and if possible display the python source code of this object. 
+and if possible display the python source code of this object.
 
 .. code-block:: ipython
 
@@ -143,7 +143,7 @@ Shell Assignment
 
 
 When doing interactive computing it is common to need to access the underlying shell.
-This is doable through the use of the exclamation mark ``!`` (or bang). 
+This is doable through the use of the exclamation mark ``!`` (or bang).
 
 This allow to execute simple command when present in beginning of line:
 
@@ -179,7 +179,7 @@ The later form of expansion supports arbitrary python expression:
 The bang can also be present in the right hand side of an assignment, just
 after the equal sign, or separated from it by a white space. In which case the
 standard output of the command after the bang ``!`` will be split out into lines
-in a list-like object (:see:`IPython Slist`) and assign to the left hand side. 
+in a list-like object and assign to the left hand side.
 
 This allow you for example to put the list of files of the current working directory in a variable:
 
@@ -205,7 +205,7 @@ Magics
 Magics function are often present in the form of shell-like syntax, but are
 under the hood python function. The syntax and assignment possibility are
 similar to the one with the bang (``!``) syntax, but with more flexibility and
-power. Magic function start with a percent sign (``%``) or double percent (``%%``). 
+power. Magic function start with a percent sign (``%``) or double percent (``%%``).
 
 A magic call with a sign percent will act only one line:
 

--- a/docs/source/interactive/python-ipython-diff.rst
+++ b/docs/source/interactive/python-ipython-diff.rst
@@ -7,7 +7,7 @@ language and what are the specific construct you can do only in IPython.
 
 Unless expressed otherwise all of the construct you will see here will raise a
 ``SyntaxError`` if run in a pure Python shell, or if executing in a Python
-script. 
+script.
 
 Each of these features are describe more in details in further part of the documentation.
 
@@ -56,7 +56,7 @@ All the following construct are valid IPython syntax:
     In [1]: %%perl magic --function
        ...: @months = ("July", "August", "September");
        ...: print $months[0];
-    
+
 
 Each of these construct is compile by IPython into valid python code and will
 do most of the time what you expect it will do. Let see each of these example
@@ -100,7 +100,7 @@ namespace will show help relative to this object:
 
 
 A double question mark will try to pull out more information about the object,
-and if possible display the python source code of this object. 
+and if possible display the python source code of this object.
 
 .. code-block:: ipython
 
@@ -143,7 +143,7 @@ Shell Assignment
 
 
 When doing interactive computing it is common to need to access the underlying shell.
-This is doable through the use of the exclamation mark ``!`` (or bang). 
+This is doable through the use of the exclamation mark ``!`` (or bang).
 
 This allow to execute simple command when present in beginning of line:
 
@@ -205,7 +205,7 @@ Magics
 Magics function are often present in the form of shell-like syntax, but are
 under the hood python function. The syntax and assignment possibility are
 similar to the one with the bang (``!``) syntax, but with more flexibility and
-power. Magic function start with a percent sign (``%``) or double percent (``%%``). 
+power. Magic function start with a percent sign (``%``) or double percent (``%%``).
 
 A magic call with a sign percent will act only one line:
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -20,7 +20,7 @@ has three main components:
 * An enhanced interactive Python shell.
 * A decoupled :ref:`two-process communication model <ipythonzmq>`, which
   allows for multiple clients to connect to a computation kernel, most notably
-  the web-based :ref:`notebook <htmlnotebook>`
+  the web-based notebook.
 * An architecture for interactive parallel computing.
 
 All of IPython is open source (released under the revised BSD license).
@@ -38,19 +38,19 @@ amongst others:
    tries to be a very efficient environment both for Python code development
    and for exploration of problems using Python objects (in situations like
    data analysis).
-  
+
 2. Serve as an embeddable, ready to use interpreter for your own
    programs. An interactive IPython shell can be started with a single call
    from inside another program, providing access to the current namespace.
    This can be very useful both for debugging purposes and for situations
    where a blend of batch-processing and interactive exploration are needed.
-  
+
 3. Offer a flexible framework which can be used as the base
    environment for working with other systems, with Python as the underlying
    bridge language. Specifically scientific environments like Mathematica,
    IDL and Matlab inspired its design, but similar ideas can be
    useful in many fields.
-  
+
 4. Allow interactive testing of threaded graphical toolkits. IPython
    has support for interactive, non-blocking control of GTK, Qt, WX, GLUT, and
    OS X applications via special threading flags. The normal Python
@@ -63,14 +63,14 @@ Main features of the interactive shell
   definition prototypes, source code, source files and other details
   of any object accessible to the interpreter with a single
   keystroke (:samp:`?`, and using :samp:`??` provides additional detail).
-  
+
 * Searching through modules and namespaces with :samp:`*` wildcards, both
   when using the :samp:`?` system and via the :samp:`%psearch` command.
 
 * Completion in the local namespace, by typing :kbd:`TAB` at the prompt.
   This works for keywords, modules, methods, variables and files in the
   current directory. This is supported via the readline library, and
-  full access to configuring readline's behavior is provided. 
+  full access to configuring readline's behavior is provided.
   Custom completers can be implemented easily for different purposes
   (system commands, magic arguments etc.)
 
@@ -86,7 +86,7 @@ Main features of the interactive shell
 * Alias facility for defining your own system aliases.
 
 * Complete system shell access. Lines starting with :samp:`!` are passed
-  directly to the system shell, and using :samp:`!!` or :samp:`var = !cmd` 
+  directly to the system shell, and using :samp:`!!` or :samp:`var = !cmd`
   captures shell output into python variables for further use.
 
 * The ability to expand python variables when calling the system shell. In a
@@ -168,7 +168,7 @@ Main features of the interactive shell
 * Simple timing information. You can use the :samp:`%timeit` command to get
   the execution time of a Python statement or expression. This machinery is
   intelligent enough to do more repetitions for commands that finish very
-  quickly in order to get a better estimate of their running time. 
+  quickly in order to get a better estimate of their running time.
 
 .. sourcecode:: ipython
 
@@ -178,11 +178,11 @@ Main features of the interactive shell
     In [2]: %timeit [math.sin(x) for x in range(5000)]
     1000 loops, best of 3: 719 µs per loop
 
-.. 
+..
 
   To get the timing information for more than one expression, use the
   :samp:`%%timeit` cell magic command.
-  
+
 
 * Doctest support. The special :samp:`%doctest_mode` command toggles a mode
   to use doctest-compatible prompts, so you can use IPython sessions as
@@ -217,15 +217,15 @@ running, use the ``%connect_info`` magic to get the unique connection file,
 which will be something like ``--existing kernel-19732.json`` but with
 different numbers which correspond to the Process ID of the kernel.
 
-You can read more about using `ipython qtconsole 
+You can read more about using `ipython qtconsole
 <http://jupyter.org/qtconsole/>`_, and
-`ipython notebook <http://jupyter-notebook.readthedocs.io/en/latest/>`_. There 
-is also a :ref:`message spec <messaging>` which documents the protocol for 
+`ipython notebook <http://jupyter-notebook.readthedocs.io/en/latest/>`_. There
+is also a :ref:`message spec <messaging>` which documents the protocol for
 communication between kernels
 and clients.
 
 .. seealso::
-    
+
     `Frontend/Kernel Model`_ example notebook
 
 
@@ -242,7 +242,7 @@ The main features of this system are:
 
 * Quickly parallelize Python code from an interactive Python/IPython session.
 
-* A flexible and dynamic process model that be deployed on anything from 
+* A flexible and dynamic process model that be deployed on anything from
   multicore workstations to supercomputers.
 
 * An architecture that supports many different styles of parallelism, from

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -38,19 +38,19 @@ amongst others:
    tries to be a very efficient environment both for Python code development
    and for exploration of problems using Python objects (in situations like
    data analysis).
-
+  
 2. Serve as an embeddable, ready to use interpreter for your own
    programs. An interactive IPython shell can be started with a single call
    from inside another program, providing access to the current namespace.
    This can be very useful both for debugging purposes and for situations
    where a blend of batch-processing and interactive exploration are needed.
-
+  
 3. Offer a flexible framework which can be used as the base
    environment for working with other systems, with Python as the underlying
    bridge language. Specifically scientific environments like Mathematica,
    IDL and Matlab inspired its design, but similar ideas can be
    useful in many fields.
-
+  
 4. Allow interactive testing of threaded graphical toolkits. IPython
    has support for interactive, non-blocking control of GTK, Qt, WX, GLUT, and
    OS X applications via special threading flags. The normal Python
@@ -63,14 +63,14 @@ Main features of the interactive shell
   definition prototypes, source code, source files and other details
   of any object accessible to the interpreter with a single
   keystroke (:samp:`?`, and using :samp:`??` provides additional detail).
-
+  
 * Searching through modules and namespaces with :samp:`*` wildcards, both
   when using the :samp:`?` system and via the :samp:`%psearch` command.
 
 * Completion in the local namespace, by typing :kbd:`TAB` at the prompt.
   This works for keywords, modules, methods, variables and files in the
   current directory. This is supported via the readline library, and
-  full access to configuring readline's behavior is provided.
+  full access to configuring readline's behavior is provided. 
   Custom completers can be implemented easily for different purposes
   (system commands, magic arguments etc.)
 
@@ -86,7 +86,7 @@ Main features of the interactive shell
 * Alias facility for defining your own system aliases.
 
 * Complete system shell access. Lines starting with :samp:`!` are passed
-  directly to the system shell, and using :samp:`!!` or :samp:`var = !cmd`
+  directly to the system shell, and using :samp:`!!` or :samp:`var = !cmd` 
   captures shell output into python variables for further use.
 
 * The ability to expand python variables when calling the system shell. In a
@@ -168,7 +168,7 @@ Main features of the interactive shell
 * Simple timing information. You can use the :samp:`%timeit` command to get
   the execution time of a Python statement or expression. This machinery is
   intelligent enough to do more repetitions for commands that finish very
-  quickly in order to get a better estimate of their running time.
+  quickly in order to get a better estimate of their running time. 
 
 .. sourcecode:: ipython
 
@@ -178,11 +178,11 @@ Main features of the interactive shell
     In [2]: %timeit [math.sin(x) for x in range(5000)]
     1000 loops, best of 3: 719 µs per loop
 
-..
+.. 
 
   To get the timing information for more than one expression, use the
   :samp:`%%timeit` cell magic command.
-
+  
 
 * Doctest support. The special :samp:`%doctest_mode` command toggles a mode
   to use doctest-compatible prompts, so you can use IPython sessions as
@@ -217,15 +217,15 @@ running, use the ``%connect_info`` magic to get the unique connection file,
 which will be something like ``--existing kernel-19732.json`` but with
 different numbers which correspond to the Process ID of the kernel.
 
-You can read more about using `ipython qtconsole
+You can read more about using `ipython qtconsole 
 <http://jupyter.org/qtconsole/>`_, and
-`ipython notebook <http://jupyter-notebook.readthedocs.io/en/latest/>`_. There
-is also a :ref:`message spec <messaging>` which documents the protocol for
+`ipython notebook <http://jupyter-notebook.readthedocs.io/en/latest/>`_. There 
+is also a :ref:`message spec <messaging>` which documents the protocol for 
 communication between kernels
 and clients.
 
 .. seealso::
-
+    
     `Frontend/Kernel Model`_ example notebook
 
 
@@ -242,7 +242,7 @@ The main features of this system are:
 
 * Quickly parallelize Python code from an interactive Python/IPython session.
 
-* A flexible and dynamic process model that be deployed on anything from
+* A flexible and dynamic process model that be deployed on anything from 
   multicore workstations to supercomputers.
 
 * An architecture that supports many different styles of parallelism, from

--- a/docs/source/whatsnew/version0.12.rst
+++ b/docs/source/whatsnew/version0.12.rst
@@ -87,11 +87,11 @@ You can see all the relevant options with::
 
 and just like the Qt console, you can start the notebook server with pylab
 support by using::
-
+  
   ipython notebook --pylab
 
 for floating matplotlib windows or::
-
+  
   ipython notebook --pylab inline
 
 for plotting support with automatically inlined figures.  Note that it is now
@@ -117,7 +117,7 @@ have embedded an IPython kernel.
 This is also something that we have wanted for a long time, and which is a
 culmination (as a team effort) of the work started last year during the 2010
 Google Summer of Code project.
-
+  
 Tabbed QtConsole
 ~~~~~~~~~~~~~~~~
 
@@ -167,7 +167,7 @@ the area where PyPy still lags most behind.  But for everyday interactive use
 at the terminal, with this release and PyPy 1.7, things seem to work quite well
 from our admittedly limited testing.
 
-
+  
 Other important new features
 ----------------------------
 
@@ -287,7 +287,7 @@ Backwards incompatible changes
 
   The full path will still work, and is necessary for using custom launchers
   not in IPython's launcher module.
-
+  
   Further, MPIExec launcher names are now prefixed with just MPI, to better match
   other batch launchers, and be generally more intuitive.  The MPIExec names are
   deprecated, but continue to work.
@@ -361,7 +361,7 @@ had commits from the following 45 contributors, a mix of new and regular names
 * Timo Paulssen <timonator-at-perpetuum-immobile.de>
 * Valentin Haenel <valentin.haenel-at-gmx.de>
 * Yaroslav Halchenko <debian-at-onerussian.com>
-
+   
 .. note::
 
     This list was generated with the output of

--- a/docs/source/whatsnew/version0.12.rst
+++ b/docs/source/whatsnew/version0.12.rst
@@ -87,18 +87,17 @@ You can see all the relevant options with::
 
 and just like the Qt console, you can start the notebook server with pylab
 support by using::
-  
+
   ipython notebook --pylab
 
 for floating matplotlib windows or::
-  
+
   ipython notebook --pylab inline
 
 for plotting support with automatically inlined figures.  Note that it is now
 possible also to activate pylab support at runtime via ``%pylab``, so you do
 not need to make this decision when starting the server.
-  
-See :ref:`the Notebook docs <htmlnotebook>` for technical details.
+
 
 .. _two_process_console:
 
@@ -118,7 +117,7 @@ have embedded an IPython kernel.
 This is also something that we have wanted for a long time, and which is a
 culmination (as a team effort) of the work started last year during the 2010
 Google Summer of Code project.
-  
+
 Tabbed QtConsole
 ~~~~~~~~~~~~~~~~
 
@@ -168,13 +167,13 @@ the area where PyPy still lags most behind.  But for everyday interactive use
 at the terminal, with this release and PyPy 1.7, things seem to work quite well
 from our admittedly limited testing.
 
-  
+
 Other important new features
 ----------------------------
 
 * **SSH Tunnels**: In 0.11, the :mod:`IPython.parallel` Client could tunnel its
-  connections to the Controller via ssh. Now, the QtConsole :ref:`supports
-  <ssh_tunnels>` ssh tunneling, as do parallel engines.
+  connections to the Controller via ssh. Now, the QtConsole supports ssh tunneling,
+  as do parallel engines.
 
 * **relaxed command-line parsing**: 0.11 was released with overly-strict
   command-line parsing, preventing the ability to specify arguments with spaces,
@@ -288,7 +287,7 @@ Backwards incompatible changes
 
   The full path will still work, and is necessary for using custom launchers
   not in IPython's launcher module.
-  
+
   Further, MPIExec launcher names are now prefixed with just MPI, to better match
   other batch launchers, and be generally more intuitive.  The MPIExec names are
   deprecated, but continue to work.
@@ -362,7 +361,7 @@ had commits from the following 45 contributors, a mix of new and regular names
 * Timo Paulssen <timonator-at-perpetuum-immobile.de>
 * Valentin Haenel <valentin.haenel-at-gmx.de>
 * Yaroslav Halchenko <debian-at-onerussian.com>
-   
+
 .. note::
 
     This list was generated with the output of

--- a/docs/source/whatsnew/version1.0.rst
+++ b/docs/source/whatsnew/version1.0.rst
@@ -135,7 +135,7 @@ Backwards incompatible changes
 - For all kernel managers, the ``sub_channel`` attribute has been renamed to
   ``iopub_channel``.
 - Users on Python versions before 2.6.6, 2.7.1 or 3.2 will now need to call
-  :func:`IPython.utils.doctestreload.doctest_reload` to make doctests run
+  :func:`IPython.utils.doctestreload.doctest_reload` to make doctests run 
   correctly inside IPython. Python releases since those versions are unaffected.
   For details, see :ghpull:`3068` and `Python issue 8048 <http://bugs.python.org/issue8048>`_.
 - The ``InteractiveShell.cache_main_mod()`` method has been removed, and
@@ -275,7 +275,7 @@ whether this tradeoff is appropriate for their application.
 Parallel
 --------
 
-IPython.parallel has had some refactoring as well.
+IPython.parallel has had some refactoring as well.  
 There are many improvements and fixes, but these are the major changes:
 
 - Connections have been simplified. All ports and the serialization in use

--- a/docs/source/whatsnew/version1.0.rst
+++ b/docs/source/whatsnew/version1.0.rst
@@ -135,7 +135,7 @@ Backwards incompatible changes
 - For all kernel managers, the ``sub_channel`` attribute has been renamed to
   ``iopub_channel``.
 - Users on Python versions before 2.6.6, 2.7.1 or 3.2 will now need to call
-  :func:`IPython.utils.doctestreload.doctest_reload` to make doctests run 
+  :func:`IPython.utils.doctestreload.doctest_reload` to make doctests run
   correctly inside IPython. Python releases since those versions are unaffected.
   For details, see :ghpull:`3068` and `Python issue 8048 <http://bugs.python.org/issue8048>`_.
 - The ``InteractiveShell.cache_main_mod()`` method has been removed, and
@@ -163,10 +163,6 @@ To use nbconvert to convert various file formats::
 
 See ``ipython nbconvert --help`` for more information.
 nbconvert depends on `pandoc`_ for many of the translations to and from various formats.
-
-.. seealso::
-
-    :ref:`nbconvert`
 
 .. _pandoc: http://johnmacfarlane.net/pandoc/
 
@@ -279,7 +275,7 @@ whether this tradeoff is appropriate for their application.
 Parallel
 --------
 
-IPython.parallel has had some refactoring as well.  
+IPython.parallel has had some refactoring as well.
 There are many improvements and fixes, but these are the major changes:
 
 - Connections have been simplified. All ports and the serialization in use

--- a/docs/source/whatsnew/version2.0.rst
+++ b/docs/source/whatsnew/version2.0.rst
@@ -149,11 +149,11 @@ which can be started from the Help menu.
 Security
 ********
 
-2.0 introduces a :ref:`security model <notebook_security>` for notebooks,
+2.0 introduces a security model for notebooks,
 to prevent untrusted code from executing on users' behalf when notebooks open.
 A quick summary of the model:
 
-- Trust is determined by :ref:`signing notebooks<signing_notebooks>`.
+- Trust is determined by signing notebooks.
 - Untrusted HTML output is sanitized.
 - Untrusted Javascript is never executed.
 - HTML and Javascript in Markdown are never trusted.

--- a/docs/source/whatsnew/version3.rst
+++ b/docs/source/whatsnew/version3.rst
@@ -278,10 +278,10 @@ Backwards incompatible changes
   Adapters are included, so IPython frontends can still talk to kernels that
   implement protocol version 4.
 
-* The :ref:`notebook format <nbformat>` has been updated from version 3 to version 4.
+* The notebook format has been updated from version 3 to version 4.
   Read-only support for v4 notebooks has been backported to IPython 2.4.
   Notable changes:
-  
+
   * heading cells are removed in favor or markdown headings
   * notebook outputs and output messages are more consistent with each other
   * use :func:`IPython.nbformat.read` and :func:`~IPython.nbformat.write`
@@ -289,9 +289,9 @@ Backwards incompatible changes
     instead of the deprecated :mod:`IPython.nbformat.current` APIs.
 
   You can downgrade a notebook to v3 via ``nbconvert``::
-  
+
       ipython nbconvert --to notebook --nbformat 3 <notebook>
-  
+
   which will create :file:`notebook.v3.ipynb`, a copy of the notebook in v3 format.
 
 * :func:`IPython.core.oinspect.getsource` call specification has changed:

--- a/docs/source/whatsnew/version3.rst
+++ b/docs/source/whatsnew/version3.rst
@@ -281,7 +281,7 @@ Backwards incompatible changes
 * The notebook format has been updated from version 3 to version 4.
   Read-only support for v4 notebooks has been backported to IPython 2.4.
   Notable changes:
-
+  
   * heading cells are removed in favor or markdown headings
   * notebook outputs and output messages are more consistent with each other
   * use :func:`IPython.nbformat.read` and :func:`~IPython.nbformat.write`
@@ -289,9 +289,9 @@ Backwards incompatible changes
     instead of the deprecated :mod:`IPython.nbformat.current` APIs.
 
   You can downgrade a notebook to v3 via ``nbconvert``::
-
+  
       ipython nbconvert --to notebook --nbformat 3 <notebook>
-
+  
   which will create :file:`notebook.v3.ipynb`, a copy of the notebook in v3 format.
 
 * :func:`IPython.core.oinspect.getsource` call specification has changed:


### PR DESCRIPTION
Fixes for:

```
../ipython/docs/source/interactive/python-ipython-diff.rst:179: WARNING: undefined label: ipython slist (if the link has no caption the label must precede a section header)
../ipython/docs/source/overview.rst:21: WARNING: undefined label: htmlnotebook (if the link has no caption the label must precede a section header)
../ipython/docs/source/whatsnew/version0.12.rst:101: WARNING: undefined label: htmlnotebook (if the link has no caption the label must precede a section header)
../ipython/docs/source/whatsnew/version0.12.rst:175: WARNING: undefined label: ssh_tunnels (if the link has no caption the label must precede a section header)
../ipython/docs/source/whatsnew/version1.0.rst:169: WARNING: undefined label: nbconvert (if the link has no caption the label must precede a section header)
../ipython/docs/source/whatsnew/version2.0.rst:152: WARNING: undefined label: notebook_security (if the link has no caption the label must precede a section header)
../ipython/docs/source/whatsnew/version2.0.rst:156: WARNING: undefined label: signing_notebooks (if the link has no caption the label must precede a section header)
../ipython/docs/source/whatsnew/version3.rst:281: WARNING: undefined label: nbformat (if the link has no caption the label must precede a section header)
```

by simply removing non-existing reference labels.
