### PR TITLE
Fix undefined labels in docs #2

### DIFF
--- a/docs/source/interactive/python-ipython-diff.rst
+++ b/docs/source/interactive/python-ipython-diff.rst
@@ -179,7 +179,7 @@ The later form of expansion supports arbitrary python expression:
 The bang can also be present in the right hand side of an assignment, just
 after the equal sign, or separated from it by a white space. In which case the
 standard output of the command after the bang ``!`` will be split out into lines
-in a list-like object (:ref:`IPython Slist`) and assign to the left hand side.
+in a list-like object and assign to the left hand side.
 
 This allow you for example to put the list of files of the current working directory in a variable:
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -20,7 +20,7 @@ has three main components:
 * An enhanced interactive Python shell.
 * A decoupled :ref:`two-process communication model <ipythonzmq>`, which
   allows for multiple clients to connect to a computation kernel, most notably
-  the web-based :ref:`notebook <htmlnotebook>`
+  the web-based notebook.
 * An architecture for interactive parallel computing.
 
 All of IPython is open source (released under the revised BSD license).

--- a/docs/source/whatsnew/version0.12.rst
+++ b/docs/source/whatsnew/version0.12.rst
@@ -97,8 +97,7 @@ for floating matplotlib windows or::
 for plotting support with automatically inlined figures.  Note that it is now
 possible also to activate pylab support at runtime via ``%pylab``, so you do
 not need to make this decision when starting the server.
-  
-See :ref:`the Notebook docs <htmlnotebook>` for technical details.
+
 
 .. _two_process_console:
 
@@ -173,8 +172,8 @@ Other important new features
 ----------------------------
 
 * **SSH Tunnels**: In 0.11, the :mod:`IPython.parallel` Client could tunnel its
-  connections to the Controller via ssh. Now, the QtConsole :ref:`supports
-  <ssh_tunnels>` ssh tunneling, as do parallel engines.
+  connections to the Controller via ssh. Now, the QtConsole supports ssh tunneling,
+  as do parallel engines.
 
 * **relaxed command-line parsing**: 0.11 was released with overly-strict
   command-line parsing, preventing the ability to specify arguments with spaces,

--- a/docs/source/whatsnew/version1.0.rst
+++ b/docs/source/whatsnew/version1.0.rst
@@ -164,10 +164,6 @@ To use nbconvert to convert various file formats::
 See ``ipython nbconvert --help`` for more information.
 nbconvert depends on `pandoc`_ for many of the translations to and from various formats.
 
-.. seealso::
-
-    :ref:`nbconvert`
-
 .. _pandoc: http://johnmacfarlane.net/pandoc/
 
 Notebook

--- a/docs/source/whatsnew/version2.0.rst
+++ b/docs/source/whatsnew/version2.0.rst
@@ -149,11 +149,11 @@ which can be started from the Help menu.
 Security
 ********
 
-2.0 introduces a :ref:`security model <notebook_security>` for notebooks,
+2.0 introduces a security model for notebooks,
 to prevent untrusted code from executing on users' behalf when notebooks open.
 A quick summary of the model:
 
-- Trust is determined by :ref:`signing notebooks<signing_notebooks>`.
+- Trust is determined by signing notebooks.
 - Untrusted HTML output is sanitized.
 - Untrusted Javascript is never executed.
 - HTML and Javascript in Markdown are never trusted.

--- a/docs/source/whatsnew/version3.rst
+++ b/docs/source/whatsnew/version3.rst
@@ -278,7 +278,7 @@ Backwards incompatible changes
   Adapters are included, so IPython frontends can still talk to kernels that
   implement protocol version 4.
 
-* The :ref:`notebook format <nbformat>` has been updated from version 3 to version 4.
+* The notebook format has been updated from version 3 to version 4.
   Read-only support for v4 notebooks has been backported to IPython 2.4.
   Notable changes:
   


### PR DESCRIPTION
Fixes for:

```
../ipython/docs/source/interactive/python-ipython-diff.rst:179: WARNING: undefined label: ipython slist (if the link has no caption the label must precede a section header)
../ipython/docs/source/overview.rst:21: WARNING: undefined label: htmlnotebook (if the link has no caption the label must precede a section header)
../ipython/docs/source/whatsnew/version0.12.rst:101: WARNING: undefined label: htmlnotebook (if the link has no caption the label must precede a section header)
../ipython/docs/source/whatsnew/version0.12.rst:175: WARNING: undefined label: ssh_tunnels (if the link has no caption the label must precede a section header)
../ipython/docs/source/whatsnew/version1.0.rst:169: WARNING: undefined label: nbconvert (if the link has no caption the label must precede a section header)
../ipython/docs/source/whatsnew/version2.0.rst:152: WARNING: undefined label: notebook_security (if the link has no caption the label must precede a section header)
../ipython/docs/source/whatsnew/version2.0.rst:156: WARNING: undefined label: signing_notebooks (if the link has no caption the label must precede a section header)
../ipython/docs/source/whatsnew/version3.rst:281: WARNING: undefined label: nbformat (if the link has no caption the label must precede a section header)
```

by simply removing non-existing reference labels.
