### PR TITLE
Skip pt_inputhooks apigen

### DIFF
--- a/docs/autogen_api.py
+++ b/docs/autogen_api.py
@@ -30,6 +30,7 @@ if __name__ == '__main__':
                                         r'\.sphinxext',
                                         # Shims
                                         r'\.kernel',
+                                        r'\.terminal\.pt_inputhooks',
                                         ]
 
     # The inputhook* modules often cause problems on import, such as trying to
@@ -37,8 +38,6 @@ if __name__ == '__main__':
     docwriter.module_skip_patterns += [ r'\.lib\.inputhook.+',
                                         r'\.ipdoctest',
                                         r'\.testing\.plugin',
-                                        # Deprecated:
-                                        r'\.core\.magics\.deprecated',
                                         # Backwards compat import for lib.lexers
                                         r'\.nbconvert\.utils\.lexers',
                                         # We document this manually.


### PR DESCRIPTION
Added `terminal/pt_inputhooks` to skipped packages.
Removed `core/magics/deprecated` from skip patterns as they are included in skipped packages.

`pt_inputhooks` raise exceptions on any incompatible backend, like:

``` pytb
Traceback (most recent call last):
  File "c:\python35\lib\site-packages\sphinx\cmdline.py", line 244, in main
    app.build(opts.force_all, filenames)
  File "c:\python35\lib\site-packages\sphinx\application.py", line 294, in build
    self.builder.build_update()
  File "c:\python35\lib\site-packages\sphinx\builders\__init__.py", line 251, in build_update
    'out of date' % len(to_build))
  File "c:\python35\lib\site-packages\sphinx\builders\__init__.py", line 265, in build
    self.doctreedir, self.app))
  File "c:\python35\lib\site-packages\sphinx\environment.py", line 548, in update
    self._read_serial(docnames, app)
  File "c:\python35\lib\site-packages\sphinx\environment.py", line 568, in _read_serial
    self.read_doc(docname, app)
  File "c:\python35\lib\site-packages\sphinx\environment.py", line 721, in read_doc
    pub.publish()
  File "c:\python35\lib\site-packages\docutils\core.py", line 217, in publish
    self.settings)
  File "c:\python35\lib\site-packages\sphinx\io.py", line 49, in read
    self.parse()
  File "c:\python35\lib\site-packages\docutils\readers\__init__.py", line 78, in parse
    self.parser.parse(self.input, document)
  File "c:\python35\lib\site-packages\docutils\parsers\rst\__init__.py", line 172, in parse
    self.statemachine.run(inputlines, document, inliner=self.inliner)
  File "c:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 170, in run
    input_source=document['source'])
  File "c:\python35\lib\site-packages\docutils\statemachine.py", line 239, in run
    context, state, transitions)
  File "c:\python35\lib\site-packages\docutils\statemachine.py", line 460, in check_line
    return method(match, context, next_state)
  File "c:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 2961, in text
    self.section(title.lstrip(), source, style, lineno + 1, messages)
  File "c:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 327, in section
    self.new_subsection(title, lineno, messages)
  File "c:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 395, in new_subsection
    node=section_node, match_titles=True)
  File "c:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 282, in nested_parse
    node=node, match_titles=match_titles)
  File "c:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 195, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "c:\python35\lib\site-packages\docutils\statemachine.py", line 239, in run
    context, state, transitions)
  File "c:\python35\lib\site-packages\docutils\statemachine.py", line 460, in check_line
    return method(match, context, next_state)
  File "c:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 2301, in explicit_markup
    self.explicit_list(blank_finish)
  File "c:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 2331, in explicit_list
    match_titles=self.state_machine.match_titles)
  File "c:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 319, in nested_list_parse
    node=node, match_titles=match_titles)
  File "c:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 195, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "c:\python35\lib\site-packages\docutils\statemachine.py", line 239, in run
    context, state, transitions)
  File "c:\python35\lib\site-packages\docutils\statemachine.py", line 460, in check_line
    return method(match, context, next_state)
  File "c:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 2604, in explicit_markup
    nodelist, blank_finish = self.explicit_construct(match)
  File "c:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 2311, in explicit_construct
    return method(self, expmatch)
  File "c:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 2054, in directive
    directive_class, match, type_name, option_presets)
  File "c:\python35\lib\site-packages\docutils\parsers\rst\states.py", line 2103, in run_directive
    result = directive_instance.run()
  File "c:\python35\lib\site-packages\sphinx\ext\autosummary\__init__.py", line 210, in run
    items = self.get_items(names)
  File "c:\python35\lib\site-packages\sphinx\ext\autosummary\__init__.py", line 256, in get_items
    real_name, obj, parent, modname = import_by_name(name, prefixes=prefixes)
  File "c:\python35\lib\site-packages\sphinx\ext\autosummary\__init__.py", line 473, in import_by_name
    obj, parent, modname = _import_by_name(prefixed_name)
  File "c:\python35\lib\site-packages\sphinx\ext\autosummary\__init__.py", line 502, in _import_by_name
    __import__(modname)
  File "c:\python35\lib\site-packages\IPython\terminal\pt_inputhooks\osx.py", line 11, in <module>
    objc = ctypes.cdll.LoadLibrary(ctypes.util.find_library('objc'))
  File "c:\python35\lib\ctypes\__init__.py", line 425, in LoadLibrary
    return self._dlltype(name)
  File "c:\python35\lib\ctypes\__init__.py", line 347, in __init__
    self._handle = _dlopen(self._name, mode)
TypeError: bad argument type for built-in operation
```
