### PR TITLE
Refactor autogen config to match autogen magic workflow

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -41,8 +41,7 @@ clean_api:
 
 clean: clean_api
 	-rm -rf build/* dist/*
-	-cd $(SRCDIR)/config/options; test -f generated && cat generated | xargs rm -f
-	-rm -rf $(SRCDIR)/config/options/generated
+	-rm -f $(SRCDIR)/config/options/config-generated.txt
 	-rm -f $(SRCDIR)/interactive/magics-generated.txt
 
 pdf: latex
@@ -75,7 +74,7 @@ source/interactive/magics-generated.txt: autogen_magics.py
 	$(PYTHON) autogen_magics.py
 	@echo "Created docs for line & cell magics"
 
-autoconfig: source/config/options/generated
+autoconfig: source/config/options/config-generated.txt
 
 source/config/options/generated:
 	$(PYTHON) autogen_config.py

--- a/docs/autogen_config.py
+++ b/docs/autogen_config.py
@@ -7,7 +7,6 @@ from ipykernel.kernelapp import IPKernelApp
 
 here = abspath(dirname(__file__))
 options = join(here, 'source', 'config', 'options')
-generated = join(options, 'generated.rst')
 
 def write_doc(name, title, app, preamble=None):
     filename = '%s.rst' % name
@@ -18,18 +17,12 @@ def write_doc(name, title, app, preamble=None):
         if preamble is not None:
             f.write(preamble + '\n\n')
         f.write(app.document_config_options())
-    with open(generated, 'a') as f:
-        f.write(filename + '\n')
 
 
 if __name__ == '__main__':
-    # create empty file
-    with open(generated, 'w'):
-        pass
 
     write_doc('terminal', 'Terminal IPython options', TerminalIPythonApp())
     write_doc('kernel', 'IPython kernel options', IPKernelApp(),
         preamble=("These options can be used in :file:`ipython_kernel_config.py`. "
                   "The kernel also respects any options in `ipython_config.py`"),
     )
-

--- a/docs/autogen_config.py
+++ b/docs/autogen_config.py
@@ -7,10 +7,11 @@ from ipykernel.kernelapp import IPKernelApp
 
 here = abspath(dirname(__file__))
 options = join(here, 'source', 'config', 'options')
+generated = join(options, 'config-generated.txt')
+
 
 def write_doc(name, title, app, preamble=None):
-    filename = '%s.rst' % name
-    with open(join(options, filename), 'w') as f:
+    with open(generated, 'a') as f:
         f.write(title + '\n')
         f.write(('=' * len(title)) + '\n')
         f.write('\n')
@@ -20,6 +21,9 @@ def write_doc(name, title, app, preamble=None):
 
 
 if __name__ == '__main__':
+    # create empty file
+    with open(generated, 'w'):
+        pass
 
     write_doc('terminal', 'Terminal IPython options', TerminalIPythonApp())
     write_doc('kernel', 'IPython kernel options', IPKernelApp(),

--- a/docs/source/config/options/index.rst
+++ b/docs/source/config/options/index.rst
@@ -6,7 +6,4 @@ Any of the options listed here can be set in config files, at the
 command line, or from inside IPython. See :ref:`setting_config` for
 details.
 
-.. toctree::
-
-   terminal
-   kernel
+.. include:: config-generated.txt


### PR DESCRIPTION
`autogen_config.py` generated unused `generated.rst`:

```
../ipython/docs/source/config/options/generated.rst:: WARNING: document isn't included in any toctree
```
