### PR TITLE
Fix argument type in docsting

### DIFF
--- a/IPython/lib/latextools.py
+++ b/IPython/lib/latextools.py
@@ -64,7 +64,7 @@ def latex_to_png(s, encode=False, backend=None, wrap=False):
 
     Parameters
     ----------
-    s : text
+    s : str
         The raw string containing valid inline LaTeX.
     encode : bool, optional
         Should the PNG data base64 encoded to make it JSON'able.

--- a/IPython/utils/tokenutil.py
+++ b/IPython/utils/tokenutil.py
@@ -31,7 +31,7 @@ def line_at_cursor(cell, cursor_pos=0):
     Parameters
     ----------
     
-    cell: text
+    cell: str
         multiline block of text
     cursor_pos: integer
         the cursor position


### PR DESCRIPTION
Fixes for these warnings while building docs:

```
..IPython/lib/latextools.py:docstring of IPython.lib.latextools.latex_to_png:None: 
WARNING: more than one target found for cross-reference 'text': IPython.core.ultratb.TBTools.text, IPython.lib.pretty.PrettyPrinter.text, IPython.utils.text
..IPython/utils/tokenutil.py:docstring of IPython.utils.tokenutil.line_at_cursor:None: 
WARNING: more than one target found for cross-reference 'text': IPython.core.ultratb.TBTools.text, IPython.lib.pretty.PrettyPrinter.text, IPython.utils.text
```

As `text` is not valid type, I've set it to `str`, following other docstrings where cell is referenced, otherwise these arguments get referenced to `IPython.core.ultratb.TBTools.text`

While fixing these I noticed that there are arguments with mixed type `str or unicode`, `str`, `unicode`. `str` type gets referenced to Python's `str`, while `unicode` not (for Python 3).
Maybe we could unify these argument types, and maybe that's overkill.
