### PR TITLE
Restore previous key bindings.

### DIFF
--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -199,9 +199,17 @@ class TerminalInteractiveShell(InteractiveShell):
             else:
                 b.insert_text('\n' + (' ' * (indent or 0)))
 
+        # We have to set eager to True for Escape this will lead to a delay to
+        # dismiss the completer or clear the buffer until next loop, or next input character.
+        # CtrlC will act immediately.
+        @kbmanager.registry.add_binding(Keys.Escape, filter=HasFocus(DEFAULT_BUFFER), eager=True)
         @kbmanager.registry.add_binding(Keys.ControlC, filter=HasFocus(DEFAULT_BUFFER))
         def _reset_buffer(event):
-            event.current_buffer.reset()
+            b = event.current_buffer
+            if b.complete_state:
+                b.cancel_completion()
+            else:
+                b.reset()
 
         @kbmanager.registry.add_binding(Keys.ControlC, filter=HasFocus(SEARCH_BUFFER))
         def _reset_search_buffer(event):

--- a/docs/source/whatsnew/version5.rst
+++ b/docs/source/whatsnew/version5.rst
@@ -84,3 +84,25 @@ the long term if possible dynamic examples that can contain math, images,
 widgets... As stated above this is nightly experimental feature with a lot of
 (fun) problem to solve. We would be happy to get your feedback and expertise on
 it.
+
+
+Known Issues:
+-------------
+
+ - ``<Esc>`` Key does not dismiss the completer and does not clear the current
+   buffer. This is an on purpose modification due to current technical
+   limitation. Cf :ghpull:`9572`. Escape the control character which is used
+   for other shortcut, and there is no practical way to distinguish. Use Ctr-G
+   or Ctrl-C as an alternative. 
+
+ - Cannot use ``Shift-Enter`` and ``Ctrl-Enter`` to submit code in terminal. cf
+   :gh:`9587` and :gh:`9401`. In terminal there is no practical way to
+   distinguish these key sequences from a normal new line return. 
+
+ - Dialog completion pop up even with a single completion. Cf :gh:`9540`. This
+   would automatically be resolved with the next minor revision of
+   ``prompt_toolkit``
+
+ - ``PageUp`` and ``pageDown`` do not move through completion menu.
+
+


### PR DESCRIPTION
Esc dismiss the completer on next loop tick, or next keypress (technical
limitation) then clear the prompt.

ControlC dismiss the completer without clearing the buffer first.

Closes #9564
Closes #9554
Bump #9556 To feature request.
## 

Thanks to @chris-b1 and @klonuo for pointing that out. 

@jonathanslenders, is there a way to get rid if the delay introduced after pressing escape ? 
