### PR TITLE
InteractiveShell.object_inspect_text must return text

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1579,6 +1579,14 @@ class InteractiveShell(SingletonConfigurable):
 
     def object_inspect_text(self, oname, detail_level=0):
         """Get object info as formatted text"""
+        return self.object_inspect_mime(oname, detail_level)['text/plain']
+
+    def object_inspect_mime(self, oname, detail_level=0):
+        """Get object info as a mimebundle of formatted representations.
+
+        A mimebundle is a dictionary, keyed by mime-type.
+        It must always have the key `'text/plain'`.
+        """
         with self.builtin_trap:
             info = self._object_find(oname)
             if info.found:

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -607,7 +607,7 @@ class Inspector(Colorable):
             field = info[key]
             if field is not None:
                 formatted_field = self._mime_format(field, formatter)
-                bundle['text/plain'] += self.__head(title) + ':\n' + formatted_field['text/plain'] + '\n'
+                bundle['text/plain'] += self.__head(title + ':') + '\n' + formatted_field['text/plain'] + '\n'
                 bundle['text/html'] += '<h1>' + title + '</h1>\n' + formatted_field['text/html'] + '\n'
 
         def code_formatter(text):

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -514,6 +514,12 @@ class InteractiveShellTestCase(unittest.TestCase):
         else:
             self.assertEqual(msg, 'IPython.core.tests.test_interactiveshell.DerivedInterrupt: foo\n')
 
+    def test_inspect_text(self):
+        ip.run_cell('a = 5')
+        text = ip.object_inspect_text('a')
+        self.assertIsInstance(text, unicode_type)
+
+
 class TestSafeExecfileNonAsciiPath(unittest.TestCase):
 
     @onlyif_unicode_paths


### PR DESCRIPTION
since that's the whole point of it.

Adds object_inspect_mime for returning the the new mimebundle of formatted outputs, which `_get_info` now returns.

Follow-up of #9551, fixing bugs found in downstream tests in ipykernel.

Includes a minor style change for oinfo text output, moving the colon inside the header block, which is how it was before #9551.
