### PR TITLE
Restore vi-insert mode `CtrlP` and  `CtrlN` to readline behavior.

### DIFF
--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -202,6 +202,24 @@ class TerminalInteractiveShell(InteractiveShell):
             else:
                 b.insert_text('\n' + (' ' * (indent or 0)))
 
+        @kbmanager.registry.add_binding(Keys.ControlP, filter=(ViInsertMode() & HasFocus(DEFAULT_BUFFER)))
+        def _previous_history_or_previous_completion(event):
+            """
+            Control-P in vi edit mode on readline is history next, unlike default prompt toolkit.
+
+            If completer is open this still select previous completion.
+            """
+            event.current_buffer.auto_up()
+
+        @kbmanager.registry.add_binding(Keys.ControlN, filter=(ViInsertMode() & HasFocus(DEFAULT_BUFFER)))
+        def _next_history_or_next_completion(event):
+            """
+            Control-N in vi edit mode on readline is history previous, unlike default prompt toolkit.
+
+            If completer is open this still select next completion.
+            """
+            event.current_buffer.auto_down()
+
         @kbmanager.registry.add_binding(Keys.ControlG, filter=(
             HasFocus(DEFAULT_BUFFER) & HasCompletions()
             ))
@@ -209,9 +227,6 @@ class TerminalInteractiveShell(InteractiveShell):
             b = event.current_buffer
             if b.complete_state:
                 b.cancel_completion()
-
-
-
 
         @kbmanager.registry.add_binding(Keys.ControlC, filter=HasFocus(DEFAULT_BUFFER))
         def _reset_buffer(event):


### PR DESCRIPTION
Vi key binding for readline are slightly different than the Vi Editor.
CtrlP and CtrlN in insert mode do recall previous or next history line
instead of calling the completer.

By default Prompt toolkit (1.0.0 at least) implement the Vi-editor
key bindings. Though muscle memory is hard and our vi-mode users[1] have a
hard time adapting. This though overwrite the PTK default and mimic the
readline behavior.

Completer can still be invoked with `<tab>`, and then CtrlP, CtrlN will
select previous / next.

Closes #9584

---

Can @matthew-brett confirm that this is what is desired ?
