### PR TITLE
BUG: extra blank line on dedenting keywords

### DIFF
--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -631,10 +631,6 @@ class IPythonInputSplitter(InputSplitter):
         if not lines_list:
             lines_list = ['']
 
-        # interpet trailing newline as a blank line
-        if lines.endswith('\n'):
-            lines_list += ['']
-
         # Store raw source before applying any transformations to it.  Note
         # that this must be done *after* the reset() call that would otherwise
         # flush the buffer.

--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -626,11 +626,14 @@ class IPythonInputSplitter(InputSplitter):
 
         # We must ensure all input is pure unicode
         lines = cast_unicode(lines, self.encoding)
-        
         # ''.splitlines() --> [], but we need to push the empty line to transformers
         lines_list = lines.splitlines()
         if not lines_list:
             lines_list = ['']
+
+        # interpet trailing newline as a blank line
+        if lines.endswith('\n'):
+            lines_list += ['']
 
         # Store raw source before applying any transformations to it.  Note
         # that this must be done *after* the reset() call that would otherwise

--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -195,7 +195,7 @@ class TerminalInteractiveShell(InteractiveShell):
                 b.newline()
                 return
 
-            status, indent = self.input_splitter.check_complete(d.text)
+            status, indent = self.input_splitter.check_complete(d.text + '\n')
 
             if (status != 'incomplete') and b.accept_action.is_returnable:
                 b.accept_action.validate_and_handle(event.cli, b)


### PR DESCRIPTION
closes #9586 
If I understand correctly, this worked in 4.x because because lines were pushed one at a time to the `IPythonInputSplitter`, where now the the entire block is passed at once, so an empty line gets dropped if there is no whitespace.  eg:

``` python
In [1]: "if True:\n    pass\n".splitlines()
Out[1]: ['if True:', '    pass']

In [2]: "if True:\n    a=4\n    ".splitlines()
Out[2]: ['if True:', '    a=4', '    ']
```

cc: @takluyver 
