### PR TITLE
terminal IPython display formatter is plain-text-only

### DIFF
--- a/IPython/terminal/ptshell.py
+++ b/IPython/terminal/ptshell.py
@@ -162,6 +162,11 @@ class TerminalInteractiveShell(InteractiveShell):
         else:
             toggle_set_term_title(False)
 
+    def init_display_formatter(self):
+        super(TerminalInteractiveShell, self).init_display_formatter()
+        # terminal only supports plain text
+        self.display_formatter.active_types = ['text/plain']
+
     def init_prompt_toolkit_cli(self):
         self._app = None
         if self.simple_prompt:

--- a/IPython/terminal/tests/test_interactivshell.py
+++ b/IPython/terminal/tests/test_interactivshell.py
@@ -95,6 +95,11 @@ class InteractiveShellTestCase(unittest.TestCase):
             ip.input_splitter.python_line_transforms.remove(transformer)
             ip.input_transformer_manager.python_line_transforms.remove(transformer)
 
+    def test_plain_text_only(self):
+        ip = get_ipython()
+        formatter = ip.display_formatter
+        assert formatter.active_types == ['text/plain']
+
 
 class SyntaxErrorTransformer(InputTransformer):
     def push(self, line):


### PR DESCRIPTION
this was lost in the ptshell transition

closes #9598
