### PR TITLE
get signature from init if top-level signature fails

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -848,19 +848,26 @@ class Inspector(Colorable):
             except AttributeError:
                 init_def = None
 
-            if init_def:
-                out['init_definition'] = init_def
-
             # get the __init__ docstring
             try:
                 obj_init = obj.__init__
             except AttributeError:
                 init_ds = None
             else:
+                if init_def is None:
+                    # Get signature from init if top-level sig failed.
+                    # Can happen for built-in types (list, etc.).
+                    try:
+                        init_def = self._getdef(obj_init, oname)
+                    except AttributeError:
+                        pass
                 init_ds = getdoc(obj_init)
                 # Skip Python's auto-generated docstrings
                 if init_ds == _object_init_docstring:
                     init_ds = None
+
+            if init_def:
+                out['init_definition'] = init_def
 
             if init_ds:
                 out['init_docstring'] = init_ds

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -419,11 +419,13 @@ def test_pdef():
     def foo(): pass
     inspector.pdef(foo, 'foo')
 
+
 def test_pinfo_nonascii():
     # See gh-1177
     from . import nonascii2
     ip.user_ns['nonascii2'] = nonascii2
     ip._inspect('pinfo', 'nonascii2', detail_level=1)
+
 
 def test_pinfo_magic():
     with AssertPrints('Docstring:'):
@@ -431,3 +433,20 @@ def test_pinfo_magic():
 
     with AssertPrints('Source:'):
         ip._inspect('pinfo', 'lsmagic', detail_level=1)
+
+
+def test_init_colors():
+    # ensure colors are not present in signature info
+    info = inspector.info(HasSignature)
+    init_def = info['init_definition']
+    nt.assert_not_in('[0m', init_def)
+
+
+def test_builtin_init():
+    info = inspector.info(list)
+    init_def = info['init_definition']
+    # Python < 3.4 can't get init definition from builtins,
+    # but still exercise the inspection in case of error-raising bugs.
+    if sys.version_info >= (3,4):
+        nt.assert_is_not_none(init_def)
+


### PR DESCRIPTION
This shouldn't be necessary on most classes (arguably ever), but it appears to be for builtins (int, list).

closes #9616
