### PR TITLE
 Extend the completion layout to use a third readlinelike option

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -148,8 +148,9 @@ class TerminalInteractiveShell(InteractiveShell):
         help="Automatically set the terminal title"
     ).tag(config=True)
 
+    # Leaving that for beta/rc tester, shoudl remove for 5.0.0 final. 
     display_completions_in_columns = Bool(None,
-        help="Display a multi column completion menu.", allow_none=True
+        help="DEPRECATED", allow_none=True
     ).tag(config=True)
 
     @observe('display_completions_in_columns')


### PR DESCRIPTION
```
The `display_completions_in_columns` thus becomes deprecated, and the
Boolean is replaced by an Enum: `column`, `multicolumn`, `readlinelike`

which give us more freedom to implement extra-layout later.
```

---

On top of #9626, should help with #9597

I can see 4th layout for 6.0 that would be like readline, but where the cursor would move through the completions without redrawing the prompts. Much like QtConsole.

I also make multicolumn the default as seem to be popular.
