### PR TITLE
Fix quoting tests on Windows.

### DIFF
--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -37,37 +37,37 @@ def greedy_completion():
 
 def test_protect_filename():
     if sys.platform == 'win32':
-        pairs = [ ('abc','abc'),
-                (' abc',"' abc'"),
-                ('a bc',"'a bc'"),
-                ('a  bc',"'a  bc'"),
-                ('  bc',"'  bc'"),
-                ]
+        pairs = [('abc','abc'),
+                 (' abc','" abc"'),
+                 ('a bc','"a bc"'),
+                 ('a  bc','"a  bc"'),
+                 ('  bc','"  bc"'),
+                 ]
     else:
-        pairs = [ ('abc','abc'),
-                (' abc',r'\ abc'),
-                ('a bc',r'a\ bc'),
-                ('a  bc',r'a\ \ bc'),
-                ('  bc',r'\ \ bc'),
-                # On posix, we also protect parens and other special characters
-                ('a(bc',r'a\(bc'),
-                ('a)bc',r'a\)bc'),
-                ('a( )bc',r'a\(\ \)bc'),
-                ('a[1]bc', r'a\[1\]bc'),
-                ('a{1}bc', r'a\{1\}bc'),
-                ('a#bc', r'a\#bc'),
-                ('a?bc', r'a\?bc'),
-                ('a=bc', r'a\=bc'),
-                ('a\\bc', r'a\\bc'),
-                ('a|bc', r'a\|bc'),
-                ('a;bc', r'a\;bc'),
-                ('a:bc', r'a\:bc'),
-                ("a'bc", r"a\'bc"),
-                ('a*bc', r'a\*bc'),
-                ('a"bc', r'a\"bc'),
-                ('a^bc', r'a\^bc'),
-                ('a&bc', r'a\&bc'),
-                ]
+        pairs = [('abc','abc'),
+                 (' abc',r'\ abc'),
+                 ('a bc',r'a\ bc'),
+                 ('a  bc',r'a\ \ bc'),
+                 ('  bc',r'\ \ bc'),
+                 # On posix, we also protect parens and other special characters.
+                 ('a(bc',r'a\(bc'),
+                 ('a)bc',r'a\)bc'),
+                 ('a( )bc',r'a\(\ \)bc'),
+                 ('a[1]bc', r'a\[1\]bc'),
+                 ('a{1}bc', r'a\{1\}bc'),
+                 ('a#bc', r'a\#bc'),
+                 ('a?bc', r'a\?bc'),
+                 ('a=bc', r'a\=bc'),
+                 ('a\\bc', r'a\\bc'),
+                 ('a|bc', r'a\|bc'),
+                 ('a;bc', r'a\;bc'),
+                 ('a:bc', r'a\:bc'),
+                 ("a'bc", r"a\'bc"),
+                 ('a*bc', r'a\*bc'),
+                 ('a"bc', r'a\"bc'),
+                 ('a^bc', r'a\^bc'),
+                 ('a&bc', r'a\&bc'),
+                 ]
     # run the actual tests
     for s1, s2 in pairs:
         s1p = completer.protect_filename(s1)


### PR DESCRIPTION
Quoting should be done with double quotes, not single quotes.

See #9632.
