### PR TITLE
Add test that quit and exit work in debugger.

### DIFF
--- a/IPython/core/tests/test_debugger.py
+++ b/IPython/core/tests/test_debugger.py
@@ -69,7 +69,7 @@ def test_longer_repr():
     nt.assert_equal(trepr(a), a_trunc)
     # The creation of our tracer modifies the repr module's repr function
     # in-place, since that global is used directly by the stdlib's pdb module.
-    t = debugger.Tracer()
+    debugger.Tracer()
     nt.assert_equal(trepr(a), ar)
 
 def test_ipdb_magics():
@@ -182,5 +182,52 @@ def test_ipdb_magics2():
     
     Restore previous trace function, e.g. for coverage.py    
     
+    >>> sys.settrace(old_trace)
+    '''
+
+def can_quit():
+    '''Test that quit work in ipydb
+
+    >>> old_trace = sys.gettrace()
+
+    >>> def bar():
+    ...     pass
+
+    >>> with PdbTestInput([
+    ...    'quit',
+    ... ]):
+    ...     debugger.Pdb().runcall(bar)
+    > <doctest ...>(2)bar()
+            1 def bar():
+    ----> 2    pass
+    <BLANKLINE>
+    ipdb> quit
+
+    Restore previous trace function, e.g. for coverage.py
+
+    >>> sys.settrace(old_trace)
+    '''
+
+
+def can_exit():
+    '''Test that quit work in ipydb
+
+    >>> old_trace = sys.gettrace()
+
+    >>> def bar():
+    ...     pass
+
+    >>> with PdbTestInput([
+    ...    'exit',
+    ... ]):
+    ...     debugger.Pdb().runcall(bar)
+    > <doctest ...>(2)bar()
+            1 def bar():
+    ----> 2    pass
+    <BLANKLINE>
+    ipdb> exit
+
+    Restore previous trace function, e.g. for coverage.py
+
     >>> sys.settrace(old_trace)
     '''


### PR DESCRIPTION
Closes #9625

Testing is difficult to do without doctests, and yielding 2 test
functions does not seem to work as the docstring seem to not be found
and the test does reliably pass even when it should not.
