### PR TITLE
Remove the "autoedit_syntax" feature.

### DIFF
--- a/IPython/core/hooks.py
+++ b/IPython/core/hooks.py
@@ -37,6 +37,7 @@ example, you could use a startup file like this::
 
 import os
 import subprocess
+import warnings
 import sys
 
 from IPython.core.error import TryNext
@@ -83,13 +84,24 @@ def editor(self, filename, linenum=None, wait=True):
 
 import tempfile
 def fix_error_editor(self,filename,linenum,column,msg):
-    """Open the editor at the given filename, linenumber, column and
+    """DEPRECATED
+
+    Open the editor at the given filename, linenumber, column and
     show an error message. This is used for correcting syntax errors.
     The current implementation only has special support for the VIM editor,
     and falls back on the 'editor' hook if VIM is not used.
 
-    Call ip.set_hook('fix_error_editor',youfunc) to use your own function,
+    Call ip.set_hook('fix_error_editor',yourfunc) to use your own function,
     """
+
+    warnings.warn("""
+`fix_error_editor` is pending deprecation as of IPython 5.0 and will be removed
+in future versions. It appears to be used only for automatically fixing syntax
+error that has been broken for a few years and has thus been removed. If you
+happend to use this function and still need it please make your voice heard on
+the mailing list ipython-dev@scipy.org , or on the GitHub Issue tracker:
+https://github.com/ipython/ipython/issues/9649 """, UserWarning)
+
     def vim_quickfix_file():
         t = tempfile.NamedTemporaryFile()
         t.write('%s:%d:%d:%s\n' % (filename,linenum,column,msg))

--- a/docs/source/whatsnew/version5.rst
+++ b/docs/source/whatsnew/version5.rst
@@ -64,8 +64,6 @@ Most of the above remarks also affect `IPython.core.debugger.Pdb`, the `%debug`
 and `%pdb` magic which do not use readline anymore either.
 
 
-
-
 Provisional Changes
 -------------------
 
@@ -107,6 +105,34 @@ the long term if possible dynamic examples that can contain math, images,
 widgets... As stated above this is nightly experimental feature with a lot of
 (fun) problem to solve. We would be happy to get your feedback and expertise on
 it.
+
+
+Removed Feature
+---------------
+
+ - ``TerminalInteractiveShell.autoedit_syntax`` Has been broken for many years now
+apparently. It has been removed.
+
+
+Deprecated Features
+-------------------
+
+Some deprecated feature, don't forget to enable `DeprecationWarning` as error
+of you are using IPython in Continuous Integration setup or in your testing in general:
+
+.. code::
+    :python:
+
+    import warnings
+    warnings.filterwarnings('error', '.*', DeprecationWarning, module='yourmodule.*')
+
+
+ - `hooks.fix_error_editor` seem to be unused and is pending deprecation.
+ - `IPython/core/excolors.py:ExceptionColors` is  deprecated.
+ - `IPython.core.InteractiveShell:write()` is deprecated, use `sys.stdout` instead.
+ - `IPython.core.InteractiveShell:write_err()` is deprecated, use `sys.stderr` instead.
+ - The `formatter` keyword argument to `Inspector.info` in `IPython.core.oinspec` has now no effects.
+ - The `global_ns` keyword argument of IPython Embed was deprecated, and  will now have no effect. Use `module` keyword argument instead.
 
 
 Known Issues:


### PR DESCRIPTION
IPython used to (a long time ago, in a galaxy far far away) have the
ability to automatically open an editor in case a wild syntax error
appears. The configuration option to enable that was not working for a
few years, and apparently we by mistake re enabled it, to discover that
the feature is actually broken.

So this plainly remove the code to support this feature, at the
exception of the `fix_error_editor` hook. Indeed it is public API, so
for now  as it seem to be used only for this feature, we'll just raise a
UserWarning (there is roughly 0 chance of this being tested as it's used
mostly interactively, so DeprecationWarnings would be unseen).

We'll remove later if no complaints

Closes #9603
