### PR TITLE
Restore the ability to use %colors to switch terminal theme.

### DIFF
--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -358,6 +358,8 @@ Defaulting color scheme to 'NoColor'"""
         # Set exception colors
         try:
             shell.InteractiveTB.set_colors(scheme = new_scheme)
+            shell.colors = new_scheme
+            shell.refresh_style()
             shell.SyntaxTB.set_colors(scheme = new_scheme)
         except:
             color_switch_err('exception')

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -603,6 +603,7 @@ class Inspector(Colorable):
         _len = max(len(h) for h in heads)
 
         for head, body in zip(heads, bodies):
+            body = body.strip('\n')
             delim = '\n' if '\n' in body else ' '
             text += self.__head(head+':') + (_len - len(head))*' ' +delim + body +'\n'
 

--- a/docs/source/config/details.rst
+++ b/docs/source/config/details.rst
@@ -36,34 +36,34 @@ These have shown problems:
       WinXP/2k command prompt works perfectly.
 
 IPython uses colors for various groups of things that may be
-controlled by different configuration options: prompts, tracebacks, as
-you type in the terminal and the object introspection system which
+controlled by different configuration options: prompts, tracebacks, "as
+you type" in the terminal, and the object introspection system which
 passes large sets of data through a pager. There are various way to
 change the colors.
 
 We can distinguish the coloration into 2 main categories:
 
-- The one that affect only the terminal client.
-- The ones that also affect client connected through the Jupyter
+- The one that affects only the terminal client.
+- The ones that also affect clients connected through the Jupyter
   protocol.
 
-Traceback, debugger, and pager are highlighted kernel-side so fall
-into the second category, for historical reasons they are often
+Traceback, debugger, and pager are highlighted kernel-side so they fall
+into the second category. For historical reasons they are often
 governed by a ``colors`` attribute or configuration option that can
 take one of 3 case insensitive values: ``NoColors``, ``Linux`` and
 ``LightBG``.
 
-Colors that affect only the terminal client are governed  mainly by
+Colors that affect only the terminal client are governed mainly by
 ``TerminalInteractiveShell.highlight_style`` taking the name of a
 ``Pygments`` style.
 
 As of IPython 5.0 the color configuration works as follows:
 
   - by default, ``TerminalInteractiveShell.highlight_style`` is set to
-    ``legacy`` which **try to** emulate the colors of IPython pre 5.0,
+    ``legacy`` which **trys to** emulate the colors of IPython pre 5.0
     and respect the ``.color`` configuration option.
-    The emulation is approximative as the current version of Pygments
-    (2.1) does only support extended ANSI escape sequence, hence the
+    The emulation is an approximation of the current version of Pygments
+    (2.1) and only supports extended ANSI escape sequence, hence the
     theme cannot adapt to your terminal custom mapping if you have
     one.
 

--- a/docs/source/config/details.rst
+++ b/docs/source/config/details.rst
@@ -21,15 +21,12 @@ The following terminals seem to handle the color sequences fine:
     * CDE terminal (tested under Solaris). This one boldfaces light colors.
     * (X)Emacs buffers. See the :ref:`emacs` section for more details on
       using IPython with (X)Emacs.
-    * A Windows (XP/2k) command prompt with pyreadline_.
     * A Windows (XP/2k) CygWin shell. Although some users have reported
       problems; it is not clear whether there is an issue for everyone
       or only under specific configurations. If you have full color
       support under cygwin, please post to the IPython mailing list so
       this issue can be resolved for all users.
 
-.. _pyreadline: https://code.launchpad.net/pyreadline
-      
 These have shown problems:
 
     * Windows command prompt in WinXP/2k logged into a Linux machine via
@@ -38,9 +35,56 @@ These have shown problems:
       extensions. Once Gary's readline library is installed, the normal
       WinXP/2k command prompt works perfectly.
 
-IPython uses colors for two main groups of things: prompts and
-tracebacks which are directly printed to the terminal, and the object
-introspection system which passes large sets of data through a pager.
+IPython uses colors for various groups of things that may be
+controlled by different configuration options: prompts, tracebacks, as
+you type in the terminal and the object introspection system which
+passes large sets of data through a pager. There are various way to
+change the colors.
+
+We can distinguish the coloration into 2 main categories:
+
+- The one that affect only the terminal client.
+- The ones that also affect client connected through the Jupyter
+  protocol.
+
+Traceback, debugger, and pager are highlighted kernel-side so fall
+into the second category, for historical reasons they are often
+governed by a ``colors`` attribute or configuration option that can
+take one of 3 case insensitive values: ``NoColors``, ``Linux`` and
+``LightBG``.
+
+Colors that affect only the terminal client are governed  mainly by
+``TerminalInteractiveShell.highlight_style`` taking the name of a
+``Pygments`` style.
+
+As of IPython 5.0 the color configuration works as follows:
+
+  - by default, ``TerminalInteractiveShell.highlight_style`` is set to
+    ``legacy`` which **try to** emulate the colors of IPython pre 5.0,
+    and respect the ``.color`` configuration option.
+    The emulation is approximative as the current version of Pygments
+    (2.1) does only support extended ANSI escape sequence, hence the
+    theme cannot adapt to your terminal custom mapping if you have
+    one.
+
+    The last extra difference being that the "as you type" coloration
+    is present using the theme "default" if `color` is `LightBG`, and
+    using the theme "monokai" if `Linux`.
+
+  - if ``TerminalInteractiveShell.highlight_style`` is set to any other
+    themes, this theme is used for "as you type" highlighting. The
+    prompt highlighting is then governed by
+    ``--TerminalInteractiveShell.highlighting_style_overrides``
+
+As a summary, by default IPython 5.0 should mostly behave unchanged
+from IPython 4.x and before. Use
+``TerminalInteractiveShell.highlight_style`` and
+``--TerminalInteractiveShell.highlighting_style_overrides`` for extra
+flexibility.
+
+With default configuration `--colors=[nocolors|linux|ightbg]` as well
+as the `%colors` magic should behave identically as before.
+
 
 Colors in the pager
 -------------------
@@ -53,6 +97,9 @@ To configure your default pager to allow these:
    you always want to pass to less by default). This tells less to
    properly interpret control sequences, which is how color
    information is given to your terminal.
+
+
+
 
 .. _editors:
 

--- a/docs/source/whatsnew/version5.rst
+++ b/docs/source/whatsnew/version5.rst
@@ -8,7 +8,7 @@ IPython 5.0
 Released June, 2016
 
 IPython 5.0 now uses `prompt-toolkit` for the command line interface, thus
-allowing real multi-line editing and syntactic coloration as you type. 
+allowing real multi-line editing and syntactic coloration as you type.
 
 
 When using IPython as a subprocess, like for emacs inferior-shell, IPython can
@@ -20,7 +20,7 @@ Backwards incompatible changes
 ------------------------------
 
 
-The `install_ext magic` function which was deprecated since 4.0 have now been deleted. 
+The `install_ext magic` function which was deprecated since 4.0 have now been deleted.
 You can still distribute and install extension as packages on PyPI.
 
 Update IPython event triggering to ensure callback registration and
@@ -63,6 +63,13 @@ See `TerminalInteractiveShell.prompts` configurable for how to setup your prompt
 Most of the above remarks also affect `IPython.core.debugger.Pdb`, the `%debug`
 and `%pdb` magic which do not use readline anymore either.
 
+The color handling has been slightly changed and is now exposed
+through, in particular the colors of prompts and as you type
+highlighting can be affected by :
+``TerminalInteractiveShell.highlight_style``. With default
+configuration the ``--colors`` flag and ``%colors`` magic behavior
+should be mostly unchanged. See the `colors <termcolour>`_ section of
+our documentation
 
 Provisional Changes
 -------------------

--- a/docs/source/whatsnew/version5.rst
+++ b/docs/source/whatsnew/version5.rst
@@ -7,13 +7,13 @@ IPython 5.0
 
 Released June, 2016
 
-IPython 5.0 now uses `prompt-toolkit` for the command line interface, thus
+IPython 5.0 now uses ``prompt-toolkit`` for the command line interface, thus
 allowing real multi-line editing and syntactic coloration as you type.
 
 
 When using IPython as a subprocess, like for emacs inferior-shell, IPython can
-be started with --simple-prompt flag, which will bypass the prompt_toolkit
-input layer. In this mode completion, prompt color and many other features are
+be started with a ``--simple-prompt`` flag, which will bypass the prompt_toolkit
+input layer. In this mode, prompt color and many other features are
 disabled.
 
 Backwards incompatible changes
@@ -21,10 +21,10 @@ Backwards incompatible changes
 
 
 The `install_ext magic` function which was deprecated since 4.0 has now been deleted.
-You can still distribute and install extension as packages on PyPI.
+You can still distribute and install extensions as packages on PyPI.
 
 Update IPython event triggering to ensure callback registration and
-unregistration only affects the set of callbacks the *next* time that event is
+unregistration will only affect the set of callbacks the *next* time that event is
 triggered. See :ghissue:`9447` and :ghpull:`9453`.
 
 This is a change to the existing semantics, wherein one callback registering a
@@ -32,7 +32,7 @@ second callback when triggered for an event would previously be invoked for
 that same event.
 
 Integration with pydb has been removed since pydb development has been stopped
-since 2012, and pydb is not installable from PyPI
+since 2012, and pydb is not installable from PyPI.
 
 
 
@@ -43,7 +43,7 @@ IPython 5.0 now uses ``prompt_toolkit``. The
 ``IPython.terminal.interactiveshell.TerminalInteractiveShell`` now uses
 ``prompt_toolkit``. It is an almost complete rewrite, so many settings have
 thus changed or disappeared. The class keep the same name to avoid breaking
-user configuration for the options which names is unchanged.
+user configuration for the options with names that are unchanged.
 
 The usage of ``prompt_toolkit`` is accompanied by a complete removal of all
 code, using ``readline``. A particular effect of not using `readline` anymore
@@ -56,15 +56,15 @@ See `TerminalInteractiveShell.prompts` configurable for how to setup your prompt
 
 .. note::
 
-    During developement and beta cycle, ``TerminalInteractiveShell`` was
-    temporarly moved to ``IPtyhon.terminal.ptshell``.
+    During development and beta cycle, ``TerminalInteractiveShell`` was
+    temporarly moved to ``IPython.terminal.ptshell``.
 
 
 Most of the above remarks also affect `IPython.core.debugger.Pdb`, the `%debug`
 and `%pdb` magic which do not use readline anymore either.
 
-The color handling has been slightly changed and is now exposed
-through, in particular the colors of prompts and as you type
+The color handling has been slightly changed and is now exposed,
+in particular the colors of prompts and as you type
 highlighting can be affected by :
 ``TerminalInteractiveShell.highlight_style``. With default
 configuration the ``--colors`` flag and ``%colors`` magic behavior
@@ -74,9 +74,9 @@ our documentation
 Provisional Changes
 -------------------
 
-Provisional changes are in experimental functionality that may, or may not make
-it to future version of IPython, and which API may change without warnings.
-Activating these feature and using these API is at your own risk, and may have
+Provisional changes are experimental functionality that may, or may not, make
+it into a future version of IPython, and which API may change without warnings.
+Activating these features and using these API are at your own risk, and may have
 security implication for your system, especially if used with the Jupyter notebook,
 
 When running via the Jupyter notebook interfaces, or other compatible client,

--- a/docs/source/whatsnew/version5.rst
+++ b/docs/source/whatsnew/version5.rst
@@ -20,7 +20,7 @@ Backwards incompatible changes
 ------------------------------
 
 
-The `install_ext magic` function which was deprecated since 4.0 have now been deleted.
+The `install_ext magic` function which was deprecated since 4.0 has now been deleted.
 You can still distribute and install extension as packages on PyPI.
 
 Update IPython event triggering to ensure callback registration and


### PR DESCRIPTION
And restore previous coloring of prompts on classical color themes.
Unlike 4.x this will **not** change with your terminal background.

If the hightligh_style of TerminalInteractiveSHell is set to `legacy`
then it uses the value of TermianlInteractiveShell.colors to select the
theme:

monokai for darkbg/linux (by decision of BDFL), and old prompt values.
default for lightbg

Closes #9648
