### PR TITLE
Don't rely upon traitlets copying self.config

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -13,6 +13,7 @@ object and then create the configurable objects, passing the config to them.
 # Distributed under the terms of the Modified BSD License.
 
 import atexit
+from copy import deepcopy
 import glob
 import logging
 import os
@@ -447,7 +448,9 @@ class BaseIPythonApplication(Application):
         if self.subapp is not None:
             # stop here if subapp is taking over
             return
-        cl_config = self.config
+        # save a copy of CLI config to re-load after config files
+        # so that it has highest priority
+        cl_config = deepcopy(self.config)
         self.init_profile_dir()
         self.init_config_files()
         self.load_config_file()

--- a/IPython/core/tests/test_application.py
+++ b/IPython/core/tests/test_application.py
@@ -4,9 +4,15 @@
 import os
 import tempfile
 
+import nose.tools as nt
+
+from traitlets import Unicode
+
 from IPython.core.application import BaseIPythonApplication
 from IPython.testing import decorators as dec
 from IPython.utils import py3compat
+from IPython.utils.tempdir import TemporaryDirectory
+
 
 @dec.onlyif_unicode_paths
 def test_unicode_cwd():
@@ -48,3 +54,21 @@ def test_unicode_ipdir():
             os.environ["IPYTHONDIR"] = old_ipdir1
         if old_ipdir2:
             os.environ["IPYTHONDIR"] = old_ipdir2
+
+def test_cli_priority():
+    with TemporaryDirectory() as td:
+
+        class TestApp(BaseIPythonApplication):
+            test = Unicode().tag(config=True)
+
+        # Create the config file, so it tries to load it.
+        with open(os.path.join(td, 'ipython_config.py'), "w") as f:
+            f.write("c.TestApp.test = 'config file'")
+
+        app = TestApp()
+        app.initialize(['--profile-dir', td])
+        nt.assert_equal(app.test, 'config file')
+        app = TestApp()
+        app.initialize(['--profile-dir', td, '--TestApp.test=cli'])
+        nt.assert_equal(app.test, 'cli')
+


### PR DESCRIPTION
when saving CLI config to reload later for highest priority.

traitlets 4.1-4.2.1 don't recreate self.config in update_config (rightly so), so when saving CLI config for later re-loading, make sure it's a copy so it doesn't get changed during config file loading, which defeats the purpose.

To me, this is the real fix for ipython/traitlets#248
