### PR TITLE
colors in interactive shell

### DIFF
--- a/IPython/terminal/embed.py
+++ b/IPython/terminal/embed.py
@@ -295,7 +295,6 @@ def embed(**kwargs):
     if config is None:
         config = load_default_config()
         config.InteractiveShellEmbed = config.TerminalInteractiveShell
-        config.InteractiveShellEmbed.colors='nocolor'
         kwargs['config'] = config
     #save ps1/ps2 if defined
     ps1 = None


### PR DESCRIPTION
I'd like color in my embedded shell. Maybe there's a good reason why this is the default, but it seems strange that this is the only override.
