### PR TITLE
Remove colors_force attribute

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -649,6 +649,10 @@ class InteractiveShell(SingletonConfigurable):
         pyformat = PyColorize.Parser().format
         self.pycolorize = lambda src: pyformat(src,'str',self.colors)
 
+    def refresh_style(self):
+        # No-op here, used in subclass
+        pass
+
     def init_pushd_popd_magic(self):
         # for pushd/popd management
         self.home_dir = get_home_dir()

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -254,15 +254,6 @@ class InteractiveShell(SingletonConfigurable):
                              default_value=get_default_colors(),
         help="Set the color scheme (NoColor, Linux, or LightBG)."
     ).tag(config=True)
-    colors_force = Bool(False, help=
-        """
-        Force use of ANSI color codes, regardless of OS and readline
-        availability.
-        """
-        # FIXME: This is essentially a hack to allow ZMQShell to show colors
-        # without readline on Win32. When the ZMQ formatting system is
-        # refactored, this should be removed.
-    )
     debug = Bool(False).tag(config=True)
     deep_reload = Bool(False, help=
         """

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -335,31 +335,16 @@ Currently the magic system has the following functions:""",
         # local shortcut
         shell = self.shell
 
-
-
-        if not shell.colors_force:
-            if sys.platform in {'win32', 'cli'}:
-                import IPython.utils.rlineimpl as readline
-                if not readline.have_readline:
-                    msg = """\
-Proper color support under MS Windows requires the pyreadline library.
-You can find it at:
-http://ipython.org/pyreadline.html
-
-Defaulting color scheme to 'NoColor'"""
-                    new_scheme = 'NoColor'
-                    warn(msg)
-
-            elif not shell.has_readline:
-                # Coloured prompts get messed up without readline
-                # Will remove this check after switching to prompt_toolkit
-                new_scheme = 'NoColor'
+        # Set shell colour scheme
+        try:
+            shell.colors = new_scheme
+            shell.refresh_style()
+        except:
+            color_switch_err('shell')
 
         # Set exception colors
         try:
             shell.InteractiveTB.set_colors(scheme = new_scheme)
-            shell.colors = new_scheme
-            shell.refresh_style()
             shell.SyntaxTB.set_colors(scheme = new_scheme)
         except:
             color_switch_err('exception')

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -87,8 +87,6 @@ else:
 _use_simple_prompt = ('IPY_TEST_SIMPLE_PROMPT' in os.environ) or (not _is_tty)
 
 class TerminalInteractiveShell(InteractiveShell):
-    colors_force = True
-
     space_for_menu = Integer(6, help='Number of line at the bottom of the screen '
                                                   'to reserve for the completion menu'
                             ).tag(config=True)


### PR DESCRIPTION
We originally checked for readline to enable colour. When we created the kernel, the `colors_force` attribute was added to skip this check and always enable colour in the kernel.

Now both the kernel and the terminal interface are readline-free with colour enabled, so this flag is no longer needed.
