### PR TITLE
Pull shortcut definitions out to a separate module

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -3,28 +3,22 @@ from __future__ import print_function
 
 import os
 import sys
-import signal
 from warnings import warn
 
-from IPython.core.error import TryNext
 from IPython.core.interactiveshell import InteractiveShell, InteractiveShellABC
 from IPython.utils.py3compat import PY3, cast_unicode_py2, input
 from IPython.utils.terminal import toggle_set_term_title, set_term_title
 from IPython.utils.process import abbrev_cwd
 from traitlets import Bool, Unicode, Dict, Integer, observe, Instance, Type, default, Enum
 
-from prompt_toolkit.enums import DEFAULT_BUFFER, SEARCH_BUFFER, EditingMode
-from prompt_toolkit.filters import (HasFocus, HasSelection, Condition,
-    ViInsertMode, EmacsInsertMode, IsDone, HasCompletions)
-from prompt_toolkit.filters.cli import ViMode
+from prompt_toolkit.enums import DEFAULT_BUFFER, EditingMode
+from prompt_toolkit.filters import (HasFocus, Condition, IsDone)
 from prompt_toolkit.history import InMemoryHistory
 from prompt_toolkit.shortcuts import create_prompt_application, create_eventloop, create_prompt_layout
 from prompt_toolkit.interface import CommandLineInterface
 from prompt_toolkit.key_binding.manager import KeyBindingManager
-from prompt_toolkit.keys import Keys
 from prompt_toolkit.layout.processors import ConditionalProcessor, HighlightMatchingBracketProcessor
 from prompt_toolkit.styles import PygmentsStyle, DynamicStyle
-from prompt_toolkit.key_binding.bindings.completion import display_completions_like_readline
 
 from pygments.styles import get_style_by_name, get_all_styles
 from pygments.token import Token
@@ -34,6 +28,7 @@ from .magics import TerminalMagics
 from .pt_inputhooks import get_inputhook_func
 from .prompts import Prompts, ClassicPrompts, RichPromptDisplayHook
 from .ptutils import IPythonPTCompleter, IPythonPTLexer
+from .shortcuts import register_ipython_shortcuts
 
 DISPLAY_BANNER_DEPRECATED = object()
 
@@ -212,128 +207,9 @@ class TerminalInteractiveShell(InteractiveShell):
             self.prompt_for_code = prompt
             return
 
+        # Set up keyboard shortcuts
         kbmanager = KeyBindingManager.for_prompt()
-        insert_mode = ViInsertMode() | EmacsInsertMode()
-        # Ctrl+J == Enter, seemingly
-        @kbmanager.registry.add_binding(Keys.ControlJ,
-                            filter=(HasFocus(DEFAULT_BUFFER)
-                                    & ~HasSelection()
-                                    & insert_mode
-                                   ))
-        def _(event):
-            b = event.current_buffer
-            d = b.document
-
-            if b.complete_state:
-                cc = b.complete_state.current_completion
-                if cc:
-                    b.apply_completion(cc)
-                else:
-                    b.cancel_completion()
-                return
-
-            if not (d.on_last_line or d.cursor_position_row >= d.line_count
-                                           - d.empty_line_count_at_the_end()):
-                b.newline()
-                return
-
-            status, indent = self.input_splitter.check_complete(d.text + '\n')
-
-            if (status != 'incomplete') and b.accept_action.is_returnable:
-                b.accept_action.validate_and_handle(event.cli, b)
-            else:
-                b.insert_text('\n' + (' ' * (indent or 0)))
-
-        @kbmanager.registry.add_binding(Keys.ControlP, filter=(ViInsertMode() & HasFocus(DEFAULT_BUFFER)))
-        def _previous_history_or_previous_completion(event):
-            """
-            Control-P in vi edit mode on readline is history next, unlike default prompt toolkit.
-
-            If completer is open this still select previous completion.
-            """
-            event.current_buffer.auto_up()
-
-        @kbmanager.registry.add_binding(Keys.ControlN, filter=(ViInsertMode() & HasFocus(DEFAULT_BUFFER)))
-        def _next_history_or_next_completion(event):
-            """
-            Control-N in vi edit mode on readline is history previous, unlike default prompt toolkit.
-
-            If completer is open this still select next completion.
-            """
-            event.current_buffer.auto_down()
-
-        @kbmanager.registry.add_binding(Keys.ControlG, filter=(
-            HasFocus(DEFAULT_BUFFER) & HasCompletions()
-            ))
-        def _dismiss_completion(event):
-            b = event.current_buffer
-            if b.complete_state:
-                b.cancel_completion()
-
-        @kbmanager.registry.add_binding(Keys.ControlC, filter=HasFocus(DEFAULT_BUFFER))
-        def _reset_buffer(event):
-            b = event.current_buffer
-            if b.complete_state:
-                b.cancel_completion()
-            else:
-                b.reset()
-
-        @kbmanager.registry.add_binding(Keys.ControlC, filter=HasFocus(SEARCH_BUFFER))
-        def _reset_search_buffer(event):
-            if event.current_buffer.document.text:
-                event.current_buffer.reset()
-            else:
-                event.cli.push_focus(DEFAULT_BUFFER)
-
-        supports_suspend = Condition(lambda cli: hasattr(signal, 'SIGTSTP'))
-
-        @kbmanager.registry.add_binding(Keys.ControlZ, filter=supports_suspend)
-        def _suspend_to_bg(event):
-            event.cli.suspend_to_background()
-
-        @Condition
-        def cursor_in_leading_ws(cli):
-            before = cli.application.buffer.document.current_line_before_cursor
-            return (not before) or before.isspace()
-
-        # Ctrl+I == Tab
-        @kbmanager.registry.add_binding(Keys.ControlI,
-                            filter=(HasFocus(DEFAULT_BUFFER)
-                                    & ~HasSelection()
-                                    & insert_mode
-                                    & cursor_in_leading_ws
-                                   ))
-        def _indent_buffer(event):
-            event.current_buffer.insert_text(' ' * 4)
-
-
-        if self.display_completions == 'readlinelike':
-            @kbmanager.registry.add_binding(Keys.ControlI,
-                            filter=(HasFocus(DEFAULT_BUFFER)
-                                    & ~HasSelection()
-                                    & insert_mode
-                                    & ~cursor_in_leading_ws
-                                   ))
-            def _disaply_compl(ev):
-                display_completions_like_readline(ev)
-
-
-        if sys.platform == 'win32':
-            from IPython.lib.clipboard import (ClipboardEmpty,
-                           win32_clipboard_get, tkinter_clipboard_get)
-            @kbmanager.registry.add_binding(Keys.ControlV,
-                                filter=(HasFocus(DEFAULT_BUFFER) & ~ViMode()))
-            def _paste(event):
-                try:
-                    text = win32_clipboard_get()
-                except TryNext:
-                    try:
-                        text = tkinter_clipboard_get()
-                    except (TryNext, ClipboardEmpty):
-                        return
-                except ClipboardEmpty:
-                    return
-                event.current_buffer.insert_text(text.replace('\t', ' ' * 4))
+        register_ipython_shortcuts(kbmanager.registry, self)
 
         # Pre-populate history from IPython's history database
         history = InMemoryHistory()

--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -1,0 +1,165 @@
+import signal
+import sys
+
+from prompt_toolkit.enums import DEFAULT_BUFFER, SEARCH_BUFFER
+from prompt_toolkit.filters import (HasFocus, HasSelection, Condition,
+    ViInsertMode, EmacsInsertMode, HasCompletions)
+from prompt_toolkit.filters.cli import ViMode
+from prompt_toolkit.keys import Keys
+from prompt_toolkit.key_binding.bindings.completion import display_completions_like_readline
+
+@Condition
+def cursor_in_leading_ws(cli):
+    before = cli.application.buffer.document.current_line_before_cursor
+    return (not before) or before.isspace()
+
+def register_ipython_shortcuts(registry, shell):
+    """Set up the prompt_toolkit keyboard shortcuts for IPython"""
+    insert_mode = ViInsertMode() | EmacsInsertMode()
+
+    # Ctrl+J == Enter, seemingly
+    registry.add_binding(Keys.ControlJ,
+                         filter=(HasFocus(DEFAULT_BUFFER)
+                                 & ~HasSelection()
+                                 & insert_mode
+                        ))(newline_or_execute_outer(shell))
+
+    registry.add_binding(Keys.ControlP,
+                         filter=(ViInsertMode() & HasFocus(DEFAULT_BUFFER)
+                        ))(previous_history_or_previous_completion)
+
+    registry.add_binding(Keys.ControlN,
+                         filter=(ViInsertMode() & HasFocus(DEFAULT_BUFFER)
+                        ))(next_history_or_next_completion)
+
+    registry.add_binding(Keys.ControlG,
+                         filter=(HasFocus(DEFAULT_BUFFER) & HasCompletions()
+                        ))(dismiss_completion)
+
+    registry.add_binding(Keys.ControlC, filter=HasFocus(DEFAULT_BUFFER)
+                        )(reset_buffer)
+
+    registry.add_binding(Keys.ControlC, filter=HasFocus(SEARCH_BUFFER)
+                        )(reset_search_buffer)
+
+    supports_suspend = Condition(lambda cli: hasattr(signal, 'SIGTSTP'))
+    registry.add_binding(Keys.ControlZ, filter=supports_suspend
+                        )(suspend_to_bg)
+
+    # Ctrl+I == Tab
+    registry.add_binding(Keys.ControlI,
+                         filter=(HasFocus(DEFAULT_BUFFER)
+                                 & ~HasSelection()
+                                 & insert_mode
+                                 & cursor_in_leading_ws
+                        ))(indent_buffer)
+
+    if shell.display_completions == 'readlinelike':
+        registry.add_binding(Keys.ControlI,
+                             filter=(HasFocus(DEFAULT_BUFFER)
+                                     & ~HasSelection()
+                                     & insert_mode
+                                     & ~cursor_in_leading_ws
+                            ))(display_completions_like_readline)
+
+    if sys.platform == 'win32':
+        registry.add_binding(Keys.ControlV,
+                             filter=(
+                             HasFocus(
+                             DEFAULT_BUFFER) & ~ViMode()
+                            ))(win_paste)
+
+
+def newline_or_execute_outer(shell):
+    def newline_or_execute(event):
+        """When the user presses return, insert a newline or execute the code."""
+        b = event.current_buffer
+        d = b.document
+
+        if b.complete_state:
+            cc = b.complete_state.current_completion
+            if cc:
+                b.apply_completion(cc)
+            else:
+                b.cancel_completion()
+            return
+
+        if not (d.on_last_line or d.cursor_position_row >= d.line_count
+            - d.empty_line_count_at_the_end()):
+            b.newline()
+            return
+
+        status, indent = shell.input_splitter.check_complete(d.text + '\n')
+
+        if (status != 'incomplete') and b.accept_action.is_returnable:
+            b.accept_action.validate_and_handle(event.cli, b)
+        else:
+            b.insert_text('\n' + (' ' * (indent or 0)))
+    return newline_or_execute
+
+
+def previous_history_or_previous_completion(event):
+    """
+    Control-P in vi edit mode on readline is history next, unlike default prompt toolkit.
+
+    If completer is open this still select previous completion.
+    """
+    event.current_buffer.auto_up()
+
+
+def next_history_or_next_completion(event):
+    """
+    Control-N in vi edit mode on readline is history previous, unlike default prompt toolkit.
+
+    If completer is open this still select next completion.
+    """
+    event.current_buffer.auto_down()
+
+
+def dismiss_completion(event):
+    b = event.current_buffer
+    if b.complete_state:
+        b.cancel_completion()
+
+
+def reset_buffer(event):
+    b = event.current_buffer
+    if b.complete_state:
+        b.cancel_completion()
+    else:
+        b.reset()
+
+
+def reset_search_buffer(event):
+    if event.current_buffer.document.text:
+        event.current_buffer.reset()
+    else:
+        event.cli.push_focus(DEFAULT_BUFFER)
+
+def suspend_to_bg(event):
+    event.cli.suspend_to_background()
+
+def indent_buffer(event):
+    event.current_buffer.insert_text(' ' * 4)
+
+
+
+
+if sys.platform == 'win32':
+    from IPython.core.error import TryNext
+    from IPython.lib.clipboard import (ClipboardEmpty,
+                                       win32_clipboard_get,
+                                       tkinter_clipboard_get)
+
+
+    def win_paste(event):
+        try:
+            text = win32_clipboard_get()
+        except TryNext:
+            try:
+                text = tkinter_clipboard_get()
+            except (TryNext, ClipboardEmpty):
+                return
+        except ClipboardEmpty:
+            return
+        event.current_buffer.insert_text(text.replace('\t', ' ' * 4))


### PR DESCRIPTION
I felt like this was a lot of code to be inside one giant method, so I've pulled the shortcut definitions out to a separate module.
