### PR TITLE
clarify release notes regarding backports

### DIFF
--- a/docs/source/whatsnew/version4.rst
+++ b/docs/source/whatsnew/version4.rst
@@ -7,7 +7,7 @@ IPython 4.2.1
 
 IPython 4.2.1 (July, 2016) includes various bugfixes and improvements over 4.2.0
 
-- Only requires ``backports`` package on Python 2.
+- Only requires backports packages on Python 2.
 - Bugfix(feature regression): Configuration options on CLI get precedence on configuration options. 
 
 IPython 4.2


### PR DESCRIPTION
backports is just a namespace, not a package. 
https://gitter.im/ipython/ipython?at=577e633d3eaf66535e3b3845
