### PR TITLE
Fix broken links on install/index.rst (Read The Docs IPython Documentation)

### DIFF
--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -14,8 +14,8 @@ Installation
 
 
 
-This sections will guide you through `installing IPython itself <install>`_, and
-installing `kernels for Jupyter <kernel_install>`_ if you wish to work with
+This sections will guide you through :ref:`installing IPython itself <install>`, and
+installing :ref:`kernels for Jupyter <kernel_install>` if you wish to work with
 multiple version of Python, or multiple environments.
 
 

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -1,3 +1,5 @@
+.. _install:
+
 Installing IPython
 ==================
 


### PR DESCRIPTION
# Summary/Description

Currently the links in the section summary on the index.rst/index.html
file are broken. Can be reproduced by going to
http://ipython.readthedocs.io/en/stable/install/index.html and clicking
on _installing IPython itself_, or _kernels for Jupyter_ links.
## Specific changes
- Added a reference label to the `install.rst` file
- Modified links from external link format to Sphinx arbitrary location
  cross-referencing format in the `index.rst` file
## Testing

Changes have been tested with a local sphinx build through the supplied
makefile and specific links touched are fixed. Tested a few possibly
overlapping links (Jupyter:install for instance) and they seem to be
unaffected by the change.
