### PR TITLE
Add option to use 24bit color in prompt toolkit

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -14,7 +14,7 @@ from traitlets import Bool, Unicode, Dict, Integer, observe, Instance, Type, def
 from prompt_toolkit.enums import DEFAULT_BUFFER, EditingMode
 from prompt_toolkit.filters import (HasFocus, Condition, IsDone)
 from prompt_toolkit.history import InMemoryHistory
-from prompt_toolkit.shortcuts import create_prompt_application, create_eventloop, create_prompt_layout
+from prompt_toolkit.shortcuts import create_prompt_application, create_eventloop, create_prompt_layout, create_output
 from prompt_toolkit.interface import CommandLineInterface
 from prompt_toolkit.key_binding.manager import KeyBindingManager
 from prompt_toolkit.layout.processors import ConditionalProcessor, HighlightMatchingBracketProcessor
@@ -142,6 +142,13 @@ class TerminalInteractiveShell(InteractiveShell):
         help="Override highlighting format for specific tokens"
     ).tag(config=True)
 
+    true_color = Bool(False,
+        help=("Use 24bit colors instead of 256 colors in prompt highlighting. "
+              "If your terminal supports true color, the following command "
+              "should print 'TRUECOLOR' in orange: "
+              "printf \"\\x1b[38;2;255;100;0mTRUECOLOR\\x1b[0m\\n\"")
+    ).tag(config=True)
+
     editor = Unicode(get_default_editor(),
         help="Set the editor used by IPython (default to $EDITOR/vi/notepad)."
     ).tag(config=True)
@@ -235,7 +242,9 @@ class TerminalInteractiveShell(InteractiveShell):
                             **self._layout_options()
         )
         self._eventloop = create_eventloop(self.inputhook)
-        self.pt_cli = CommandLineInterface(self._pt_app, eventloop=self._eventloop)
+        self.pt_cli = CommandLineInterface(
+            self._pt_app, eventloop=self._eventloop,
+            output=create_output(true_color=self.true_color))
 
     def _make_style_from_name(self, name):
         """

--- a/docs/source/whatsnew/pr/truecolor-feature.rst
+++ b/docs/source/whatsnew/pr/truecolor-feature.rst
@@ -1,0 +1,9 @@
+prompt_toolkit uses pygments styles for syntax highlighting. By default, the
+colors specified in the style are approximated using a standard 256-color
+palette. prompt_toolkit also supports 24bit, a.k.a. "true", a.k.a. 16-million
+color escape sequences which enable compatible terminals to display the exact
+colors specified instead of an approximation. This true_color option exposes
+that capability in prompt_toolkit to the IPython shell.
+
+Here is a good source for the current state of true color support in various
+terminal emulators and software projects: https://gist.github.com/XVilka/8346728


### PR DESCRIPTION
This exposes the true (24-bit) color option in prompt_toolkit to IPython's configuration. Same change as this: https://github.com/jupyter/jupyter_console/pull/90
