### PR TITLE
Use builtin_trap in safe_execfile

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2469,7 +2469,7 @@ class InteractiveShell(SingletonConfigurable):
         # Python inserts the script's directory into sys.path
         dname = os.path.dirname(fname)
 
-        with prepended_to_syspath(dname):
+        with prepended_to_syspath(dname), self.builtin_trap:
             try:
                 glob, loc = (where + (None, ))[:2]
                 py3compat.execfile(


### PR DESCRIPTION
This makes get_ipython() available as a builtin when startup files run.

Closes gh-9791
