### PR TITLE
fix some deprecations

### DIFF
--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -109,7 +109,7 @@ class DisplayHook(Configurable):
         """Write the output prompt.
 
         The default implementation simply writes the prompt to
-        ``io.stdout``.
+        ``sys.stdout``.
         """
         # Use write, not print which adds an extra space.
         sys.stdout.write(self.shell.separate_out)
@@ -156,7 +156,7 @@ class DisplayHook(Configurable):
         """Write the format data dict to the frontend.
 
         This default version of this method simply writes the plain text
-        representation of the object to ``io.stdout``. Subclasses should
+        representation of the object to ``sys.stdout``. Subclasses should
         override this method to send the entire `format_dict` to the
         frontends.
 

--- a/IPython/core/displaypub.py
+++ b/IPython/core/displaypub.py
@@ -91,7 +91,7 @@ class DisplayPublisher(Configurable):
             Unused.
         """
 
-        # The default is to simply write the plain text data using io.stdout.
+        # The default is to simply write the plain text data using sys.stdout.
         if 'text/plain' in data:
             print(data['text/plain'])
 

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -588,7 +588,8 @@ class PlainTextFormatter(BaseFormatter):
     # setter for float precision, either int or direct format-string
     float_precision = CUnicode('').tag(config=True)
 
-    def _float_precision_changed(self, name, old, new):
+    @observe('float_precision')
+    def _float_precision_changed(self, change):
         """float_precision changed, set float_format accordingly.
 
         float_precision can be set by int or str.
@@ -602,6 +603,7 @@ class PlainTextFormatter(BaseFormatter):
         This parameter can be set via the '%precision' magic.
         """
 
+        new = change['new']
         if '%' in new:
             # got explicit format string
             fmt = new

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -651,8 +651,12 @@ class InteractiveShell(SingletonConfigurable):
         # override sys.stdout and sys.stderr themselves, you need to do that
         # *before* instantiating this class, because io holds onto
         # references to the underlying streams.
-        io.stdout = io.IOStream(sys.stdout)
-        io.stderr = io.IOStream(sys.stderr)
+        # io.std* are deprecated, but don't show our own deprecation warnings
+        # during initialization of the deprecated API.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            io.stdout = io.IOStream(sys.stdout)
+            io.stderr = io.IOStream(sys.stderr)
 
     def init_prompts(self):
         # Set system prompts, so that scripts can decide if they are running

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -24,13 +24,13 @@ from IPython.utils.path import filefind
 from traitlets import (
     Unicode, Instance, List, Bool, CaselessStrEnum, observe,
 )
-from IPython.lib.inputhook import guis
+from IPython.terminal import pt_inputhooks
 
 #-----------------------------------------------------------------------------
 # Aliases and Flags
 #-----------------------------------------------------------------------------
 
-gui_keys = tuple(sorted([ key for key in guis if key is not None ]))
+gui_keys = tuple(sorted(pt_inputhooks.backends) + sorted(pt_inputhooks.aliases))
 
 backend_keys = sorted(pylabtools.backends.keys())
 backend_keys.insert(0, 'auto')

--- a/IPython/core/tests/test_debugger.py
+++ b/IPython/core/tests/test_debugger.py
@@ -1,24 +1,15 @@
 """Tests for debugging machinery.
 """
 from __future__ import print_function
-#-----------------------------------------------------------------------------
-#  Copyright (c) 2012, The IPython Development Team.
-#
-#  Distributed under the terms of the Modified BSD License.
-#
-#  The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 import sys
+import warnings
 
-# third-party
 import nose.tools as nt
 
-# Our own
 from IPython.core import debugger
 
 #-----------------------------------------------------------------------------
@@ -69,7 +60,9 @@ def test_longer_repr():
     nt.assert_equal(trepr(a), a_trunc)
     # The creation of our tracer modifies the repr module's repr function
     # in-place, since that global is used directly by the stdlib's pdb module.
-    debugger.Tracer()
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', DeprecationWarning)
+        debugger.Tracer()
     nt.assert_equal(trepr(a), ar)
 
 def test_ipdb_magics():

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -495,8 +495,8 @@ class TBTools(colorable.Colorable):
 
         # Output stream to write to.  Note that we store the original value in
         # a private attribute and then make the public ostream a property, so
-        # that we can delay accessing io.stdout until runtime.  The way
-        # things are written now, the io.stdout object is dynamically managed
+        # that we can delay accessing sys.stdout until runtime.  The way
+        # things are written now, the sys.stdout object is dynamically managed
         # so a reference to it should NEVER be stored statically.  This
         # property approach confines this detail to a single location, and all
         # subclasses can simply access self.ostream for writing.
@@ -509,7 +509,7 @@ class TBTools(colorable.Colorable):
         self.old_scheme = color_scheme  # save initial value for toggles
 
         if call_pdb:
-            self.pdb = debugger.Pdb(self.color_scheme_table.active_scheme_name)
+            self.pdb = debugger.Pdb()
         else:
             self.pdb = None
 
@@ -519,7 +519,7 @@ class TBTools(colorable.Colorable):
         Valid values are:
 
         - None: the default, which means that IPython will dynamically resolve
-          to io.stdout.  This ensures compatibility with most tools, including
+          to sys.stdout.  This ensures compatibility with most tools, including
           Windows (where plain stdout doesn't recognize ANSI escapes).
 
         - Any object with 'write' and 'flush' attributes.

--- a/IPython/lib/demo.py
+++ b/IPython/lib/demo.py
@@ -470,7 +470,7 @@ class Demo(object):
         if self.block_index == self.nblocks:
             mq1 = self.marquee('END OF DEMO')
             if mq1:
-                # avoid spurious print >>io.stdout,s if empty marquees are used
+                # avoid spurious print if empty marquees are used
                 print()
                 print(mq1)
                 print(self.marquee('Use <demo_name>.reset() if you want to rerun it.'))

--- a/IPython/lib/tests/test_latextools.py
+++ b/IPython/lib/tests/test_latextools.py
@@ -30,7 +30,7 @@ def check_latex_to_png_dvipng_fails_when_no_cmd(command):
             raise FindCmdError
 
     with patch.object(latextools, "find_cmd", mock_find_cmd):
-        nt.assert_equals(latextools.latex_to_png_dvipng("whatever", True),
+        nt.assert_equal(latextools.latex_to_png_dvipng("whatever", True),
                          None)
 
 
@@ -40,7 +40,7 @@ def test_latex_to_png_dvipng_runs():
     Test that latex_to_png_dvipng just runs without error.
     """
     def mock_kpsewhich(filename):
-        nt.assert_equals(filename, "breqn.sty")
+        nt.assert_equal(filename, "breqn.sty")
         return None
 
     for (s, wrap) in [(u"$$x^2$$", False), (u"x^2", True)]:
@@ -55,7 +55,7 @@ def test_latex_to_png_mpl_runs():
     Test that latex_to_png_mpl just runs without error.
     """
     def mock_kpsewhich(filename):
-        nt.assert_equals(filename, "breqn.sty")
+        nt.assert_equal(filename, "breqn.sty")
         return None
 
     for (s, wrap) in [("$x^2$", False), ("x^2", True)]:
@@ -79,7 +79,7 @@ def test_genelatex_no_wrap():
                        "(called with {0})".format(filename))
 
     with patch.object(latextools, "kpsewhich", mock_kpsewhich):
-        nt.assert_equals(
+        nt.assert_equal(
             '\n'.join(latextools.genelatex("body text", False)),
             r'''\documentclass{article}
 \usepackage{amsmath}
@@ -97,11 +97,11 @@ def test_genelatex_wrap_with_breqn():
     Test genelatex with wrap=True for the case breqn.sty is installed.
     """
     def mock_kpsewhich(filename):
-        nt.assert_equals(filename, "breqn.sty")
+        nt.assert_equal(filename, "breqn.sty")
         return "path/to/breqn.sty"
 
     with patch.object(latextools, "kpsewhich", mock_kpsewhich):
-        nt.assert_equals(
+        nt.assert_equal(
             '\n'.join(latextools.genelatex("x^2", True)),
             r'''\documentclass{article}
 \usepackage{amsmath}
@@ -122,11 +122,11 @@ def test_genelatex_wrap_without_breqn():
     Test genelatex with wrap=True for the case breqn.sty is not installed.
     """
     def mock_kpsewhich(filename):
-        nt.assert_equals(filename, "breqn.sty")
+        nt.assert_equal(filename, "breqn.sty")
         return None
 
     with patch.object(latextools, "kpsewhich", mock_kpsewhich):
-        nt.assert_equals(
+        nt.assert_equal(
             '\n'.join(latextools.genelatex("x^2", True)),
             r'''\documentclass{article}
 \usepackage{amsmath}

--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -294,14 +294,13 @@ class EmbeddedSphinxShell(object):
         IP = InteractiveShell.instance(config=config, profile_dir=profile)
         atexit.register(self.cleanup)
 
-        # io.stdout redirect must be done after instantiating InteractiveShell
-        io.stdout = self.cout
-        io.stderr = self.cout
+        sys.stdout = self.cout
+        sys.stderr = self.cout
 
         # For debugging, so we can see normal output, use this:
         #from IPython.utils.io import Tee
-        #io.stdout = Tee(self.cout, channel='stdout') # dbg
-        #io.stderr = Tee(self.cout, channel='stderr') # dbg
+        #sys.stdout = Tee(self.cout, channel='stdout') # dbg
+        #sys.stderr = Tee(self.cout, channel='stderr') # dbg
 
         # Store a few parts of IPython we'll need.
         self.IP = IP

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -3,9 +3,11 @@ from __future__ import print_function
 
 import os
 import sys
+import warnings
 from warnings import warn
 
 from IPython.core.interactiveshell import InteractiveShell, InteractiveShellABC
+from IPython.utils import io
 from IPython.utils.py3compat import PY3, cast_unicode_py2, input
 from IPython.utils.terminal import toggle_set_term_title, set_term_title
 from IPython.utils.process import abbrev_cwd
@@ -360,9 +362,12 @@ class TerminalInteractiveShell(InteractiveShell):
         # For some reason we make these wrappers around stdout/stderr.
         # For now, we need to reset them so all output gets coloured.
         # https://github.com/ipython/ipython/issues/8669
-        from IPython.utils import io
-        io.stdout = io.IOStream(sys.stdout)
-        io.stderr = io.IOStream(sys.stderr)
+        # io.std* are deprecated, but don't show our own deprecation warnings
+        # during initialization of the deprecated API.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            io.stdout = io.IOStream(sys.stdout)
+            io.stderr = io.IOStream(sys.stderr)
 
     def init_magics(self):
         super(TerminalInteractiveShell, self).init_magics()

--- a/IPython/testing/globalipapp.py
+++ b/IPython/testing/globalipapp.py
@@ -8,21 +8,12 @@ done.
 from __future__ import absolute_import
 from __future__ import print_function
 
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2009-2011  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
-
-# stdlib
 import sys
+import warnings
 
-# our own
 from . import tools
 
 from IPython.core import page
@@ -31,9 +22,6 @@ from IPython.utils import py3compat
 from IPython.utils.py3compat import builtin_mod
 from IPython.terminal.interactiveshell import TerminalInteractiveShell
 
-#-----------------------------------------------------------------------------
-# Functions
-#-----------------------------------------------------------------------------
 
 class StreamProxy(io.IOStream):
     """Proxy for sys.stdout/err.  This will request the stream *at call time*
@@ -46,6 +34,9 @@ class StreamProxy(io.IOStream):
     """
 
     def __init__(self, name):
+        warnings.warn("StreamProxy is deprecated and unused as of IPython 5", DeprecationWarning,
+            stacklevel=2,
+        )
         self.name=name
 
     @property
@@ -135,10 +126,6 @@ def start_ipython():
     builtin_mod._ip = _ip
     builtin_mod.get_ipython = get_ipython
 
-    # To avoid extra IPython messages during testing, suppress io.stdout/stderr
-    io.stdout = StreamProxy('stdout')
-    io.stderr = StreamProxy('stderr')
-    
     # Override paging, so we don't require user interaction during the tests.
     def nopage(strng, start=0, screen_lines=0, pager_cmd=None):
         if isinstance(strng, dict):

--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -14,6 +14,7 @@ import atexit
 import os
 import sys
 import tempfile
+import warnings
 from warnings import warn
 
 from IPython.utils.decorators import undoc
@@ -81,11 +82,16 @@ class IOStream:
         pass
 
 # setup stdin/stdout/stderr to sys.stdin/sys.stdout/sys.stderr
-devnull = open(os.devnull, 'w') 
+devnull = open(os.devnull, 'w')
 atexit.register(devnull.close)
-stdin = IOStream(sys.stdin, fallback=devnull)
-stdout = IOStream(sys.stdout, fallback=devnull)
-stderr = IOStream(sys.stderr, fallback=devnull)
+
+# io.std* are deprecated, but don't show our own deprecation warnings
+# during initialization of the deprecated API.
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore', DeprecationWarning)
+    stdin = IOStream(sys.stdin, fallback=devnull)
+    stdout = IOStream(sys.stdout, fallback=devnull)
+    stderr = IOStream(sys.stderr, fallback=devnull)
 
 class Tee(object):
     """A class to duplicate an output stream to stdout/err.

--- a/IPython/utils/warn.py
+++ b/IPython/utils/warn.py
@@ -18,7 +18,7 @@ def warn(msg,level=2,exit_val=1):
 
     Standard warning printer. Gives formatting consistency.
 
-    Output is sent to io.stderr (sys.stderr by default).
+    Output is sent to sys.stderr.
 
     Options:
 


### PR DESCRIPTION
various deprecations, especially our own usage of deprecated APIs within this package
- remove few remaining references to, uses of io.stdout
- suppress deprecation warnings when initializing deprecated `utils.io.std*`
- globalipapp.StreamProxy is now totally unused
- one missing traitlets 4.2 API update in core.formatters
- get gui keys from pt_inputhooks instead of deprecated lib.inputhook
- stop passing deprecated color_scheme to Pdb
- nt.assert_equals in test_latextools

closes #9817
