### PR TITLE
Switch tkinter import based on Python version

### DIFF
--- a/IPython/terminal/pt_inputhooks/tk.py
+++ b/IPython/terminal/pt_inputhooks/tk.py
@@ -40,10 +40,12 @@ will fix it for Tk.)
 """
 import time
 
+from IPython.utils.py3compat import PY3
+
 import _tkinter
-try:
+if PY3:
     import tkinter
-except ImportError:
+else:
     import Tkinter as tkinter  # Python 2
 
 def inputhook(inputhook_context):


### PR DESCRIPTION
Rather than try/except, which can cause issues if python-future is installed, because that includes a `tkinter` module on Python 2.

Closes gh-9822
