### PR TITLE
Do not update the unders if they are user defined

### DIFF
--- a/IPython/core/tests/test_displayhook.py
+++ b/IPython/core/tests/test_displayhook.py
@@ -26,3 +26,30 @@ def test_output_quiet():
 
     with AssertNotPrints('2'):
         ip.run_cell('1+1;\n#commented_out_function()', store_history=True)
+
+def test_underscore_no_overrite_user():
+    ip.run_cell('_ = 42', store_history=True)
+    ip.run_cell('1+1', store_history=True)
+
+    with AssertPrints('42'):
+        ip.run_cell('print(_)', store_history=True)
+
+    ip.run_cell('del _', store_history=True)
+    ip.run_cell('6+6', store_history=True)
+    with AssertPrints('12'):
+        ip.run_cell('_', store_history=True)
+
+
+def test_underscore_no_overrite_builtins():
+    ip.run_cell("import gettext ; gettext.install('foo')", store_history=True)
+    ip.run_cell('3+3', store_history=True)
+
+    with AssertPrints('gettext'):
+        ip.run_cell('print(_)', store_history=True)
+
+    ip.run_cell('_ = "userset"', store_history=True)
+
+    with AssertPrints('userset'):
+        ip.run_cell('print(_)', store_history=True)
+    ip.run_cell('import builtins; del builtins._')
+


### PR DESCRIPTION
Closes jupyter/notebook#1628 (once there are tests).

Still shift the internal reference to self._,__,___ but do not assign it
in user ns.

I would expect this to be a change of behavior and have the (slight)
side effect that if any of the _, __, or __ are defined, the none of
these are updated.

We could update the logic to do the right think on leapfrog _, __ or __
if user-set, but is it worth it.

---

Tagging as 6.0, but submitting now as it was lingering on my head and taking mental space. 
