### PR TITLE
PyPy-ready IPython.lib.pretty, new tox.ini and consistent dict/mapping proxies pretty printing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,14 @@ python:
     - 3.4
     - 3.3
     - 2.7
+    - pypy
 sudo: false
 before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
 install:
     - pip install "setuptools>=18.5"
+    - if [ $TRAVIS_PYTHON_VERSION == pypy ] ; then pip install https://bitbucket.org/pypy/numpy/get/pypy-4.0.1.zip ; fi
     - pip install -f travis-wheels/wheelhouse -e file://$PWD#egg=ipython[test]
     - pip install codecov
 script:
@@ -23,4 +25,5 @@ after_success:
 
 matrix:
     allow_failures:
-        python: nightly
+        - python: nightly
+        - python: pypy

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,22 @@ before_install:
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
 install:
     - pip install "setuptools>=18.5"
-    - if [ $TRAVIS_PYTHON_VERSION == pypy ] ; then pip install https://bitbucket.org/pypy/numpy/get/pypy-4.0.1.zip ; fi
+    # Installs PyPy (+ its Numpy). Based on @frol comment at:
+    # https://github.com/travis-ci/travis-ci/issues/5027
+    - |
+        if [ "$TRAVIS_PYTHON_VERSION" = "pypy" ]; then
+          export PYENV_ROOT="$HOME/.pyenv"
+          if [ -f "$PYENV_ROOT/bin/pyenv" ]; then
+            cd "$PYENV_ROOT" && git pull
+          else
+            rm -rf "$PYENV_ROOT" && git clone --depth 1 https://github.com/yyuu/pyenv.git "$PYENV_ROOT"
+          fi
+          export PYPY_VERSION="5.3.1"
+          "$PYENV_ROOT/bin/pyenv" install "pypy-$PYPY_VERSION"
+          virtualenv --python="$PYENV_ROOT/versions/pypy-$PYPY_VERSION/bin/python" "$HOME/virtualenvs/pypy-$PYPY_VERSION"
+          source "$HOME/virtualenvs/pypy-$PYPY_VERSION/bin/activate"
+          pip install https://bitbucket.org/pypy/numpy/get/master.zip
+        fi
     - pip install -f travis-wheels/wheelhouse -e file://$PWD#egg=ipython[test]
     - pip install codecov
 script:

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -670,8 +670,10 @@ def _type_pprint(obj, p, cycle):
     # Heap allocated types might not have the module attribute,
     # and others may set it to None.
 
-    # Checks for a __repr__ override in the metaclass
-    if type(obj).__repr__ is not type.__repr__:
+    # Checks for a __repr__ override in the metaclass. Can't compare the
+    # type(obj).__repr__ directly because in PyPy the representation function
+    # inherited from type isn't the same type.__repr__
+    if [m for m in _get_mro(type(obj)) if "__repr__" in vars(m)][:1] != [type]:
         _repr_pprint(obj, p, cycle)
         return
 

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -605,7 +605,8 @@ def _dict_pprinter_factory(start, end, basetype=None):
 
         if cycle:
             return p.text('{...}')
-        p.begin_group(1, start)
+        step = len(start)
+        p.begin_group(step, start)
         keys = obj.keys()
         # if dict isn't large enough to be truncated, sort keys before displaying
         if not (p.max_seq_length and len(obj) >= p.max_seq_length):
@@ -621,7 +622,7 @@ def _dict_pprinter_factory(start, end, basetype=None):
             p.pretty(key)
             p.text(': ')
             p.pretty(obj[key])
-        p.end_group(1, end)
+        p.end_group(step, end)
     return inner
 
 
@@ -760,6 +761,8 @@ try:
     _type_pprinters[types.ClassType] = _type_pprint
     _type_pprinters[types.SliceType] = _repr_pprint
 except AttributeError: # Python 3
+    _type_pprinters[types.MappingProxyType] = \
+        _dict_pprinter_factory('mappingproxy({', '})')
     _type_pprinters[slice] = _repr_pprint
     
 try:

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -753,7 +753,10 @@ _type_pprinters = {
 }
 
 try:
-    _type_pprinters[types.DictProxyType] = _dict_pprinter_factory('<dictproxy {', '}>')
+    # In PyPy, types.DictProxyType is dict, setting the dictproxy printer
+    # using dict.setdefault avoids overwritting the dict printer
+    _type_pprinters.setdefault(types.DictProxyType,
+                               _dict_pprinter_factory('<dictproxy {', '}>'))
     _type_pprinters[types.ClassType] = _type_pprint
     _type_pprinters[types.SliceType] = _repr_pprint
 except AttributeError: # Python 3

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -632,7 +632,7 @@ def _super_pprint(obj, p, cycle):
     p.pretty(obj.__thisclass__)
     p.text(',')
     p.breakable()
-    if PYPY: # In PyPy, super() objects doesn't have __self__ attributes
+    if PYPY: # In PyPy, super() objects don't have __self__ attributes
         dself = obj.__repr__.__self__
         p.pretty(None if dself is obj else dself)
     else:

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -85,7 +85,7 @@ import re
 import datetime
 from collections import deque
 
-from IPython.utils.py3compat import PY3, cast_unicode, string_types
+from IPython.utils.py3compat import PY3, PYPY, cast_unicode, string_types
 from IPython.utils.encoding import get_stream_enc
 
 from io import StringIO
@@ -632,7 +632,11 @@ def _super_pprint(obj, p, cycle):
     p.pretty(obj.__thisclass__)
     p.text(',')
     p.breakable()
-    p.pretty(obj.__self__)
+    if PYPY: # In PyPy, super() objects doesn't have __self__ attributes
+        dself = obj.__repr__.__self__
+        p.pretty(None if dself is obj else dself)
+    else:
+        p.pretty(obj.__self__)
     p.end_group(8, '>')
 
 

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -757,7 +757,7 @@ try:
     # In PyPy, types.DictProxyType is dict, setting the dictproxy printer
     # using dict.setdefault avoids overwritting the dict printer
     _type_pprinters.setdefault(types.DictProxyType,
-                               _dict_pprinter_factory('<dictproxy {', '}>'))
+                               _dict_pprinter_factory('dict_proxy({', '})'))
     _type_pprinters[types.ClassType] = _type_pprint
     _type_pprinters[types.SliceType] = _repr_pprint
 except AttributeError: # Python 3

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -7,11 +7,12 @@
 from __future__ import print_function
 
 from collections import Counter, defaultdict, deque, OrderedDict
+import types, string
 
 import nose.tools as nt
 
 from IPython.lib import pretty
-from IPython.testing.decorators import skip_without, py2_only
+from IPython.testing.decorators import skip_without, py2_only, py3_only
 from IPython.utils.py3compat import PY3, unicode_to_str
 
 if PY3:
@@ -433,6 +434,51 @@ def test_collections_counter():
         (Counter(), 'Counter()'),
         (Counter(a=1), "Counter({'a': 1})"),
         (MyCounter(a=1), "MyCounter({'a': 1})"),
+    ]
+    for obj, expected in cases:
+        nt.assert_equal(pretty.pretty(obj), expected)
+
+@py3_only
+def test_mappingproxy():
+    MP = types.MappingProxyType
+    underlying_dict = {}
+    mp_recursive = MP(underlying_dict)
+    underlying_dict[2] = mp_recursive
+    underlying_dict[3] = underlying_dict
+
+    cases = [
+        (MP({}), "mappingproxy({})"),
+        (MP({None: MP({})}), "mappingproxy({None: mappingproxy({})})"),
+        (MP({k: k.upper() for k in string.ascii_lowercase}),
+         "mappingproxy({'a': 'A',\n"
+         "              'b': 'B',\n"
+         "              'c': 'C',\n"
+         "              'd': 'D',\n"
+         "              'e': 'E',\n"
+         "              'f': 'F',\n"
+         "              'g': 'G',\n"
+         "              'h': 'H',\n"
+         "              'i': 'I',\n"
+         "              'j': 'J',\n"
+         "              'k': 'K',\n"
+         "              'l': 'L',\n"
+         "              'm': 'M',\n"
+         "              'n': 'N',\n"
+         "              'o': 'O',\n"
+         "              'p': 'P',\n"
+         "              'q': 'Q',\n"
+         "              'r': 'R',\n"
+         "              's': 'S',\n"
+         "              't': 'T',\n"
+         "              'u': 'U',\n"
+         "              'v': 'V',\n"
+         "              'w': 'W',\n"
+         "              'x': 'X',\n"
+         "              'y': 'Y',\n"
+         "              'z': 'Z'})"),
+        (mp_recursive, "mappingproxy({2: {...}, 3: {2: {...}, 3: {...}}})"),
+        (underlying_dict,
+         "{2: mappingproxy({2: {...}, 3: {...}}), 3: {...}}"),
     ]
     for obj, expected in cases:
         nt.assert_equal(pretty.pretty(obj), expected)

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -12,7 +12,8 @@ import types, string, ctypes
 import nose.tools as nt
 
 from IPython.lib import pretty
-from IPython.testing.decorators import skip_without, py2_only, py3_only
+from IPython.testing.decorators import (skip_without, py2_only, py3_only,
+                                        cpython2_only)
 from IPython.utils.py3compat import PY3, unicode_to_str
 
 if PY3:
@@ -483,7 +484,7 @@ def test_mappingproxy():
     for obj, expected in cases:
         nt.assert_equal(pretty.pretty(obj), expected)
 
-@py2_only
+@cpython2_only # In PyPy, types.DictProxyType is dict
 def test_dictproxy():
     # This is the dictproxy constructor itself from the Python API,
     DP = ctypes.pythonapi.PyDictProxy_New

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -188,12 +188,14 @@ class SB(SA):
     pass
 
 def test_super_repr():
+    # "<super: module_name.SA, None>"
     output = pretty.pretty(super(SA))
-    nt.assert_in("SA", output)
+    nt.assert_regexp_matches(output, r"<super: \S+.SA, None>")
 
+    # "<super: module_name.SA, <module_name.SB at 0x...>>"
     sb = SB()
     output = pretty.pretty(super(SA, sb))
-    nt.assert_in("SA", output)
+    nt.assert_regexp_matches(output, r"<super: \S+.SA,\s+<\S+.SB at 0x\S+>>")
 
 
 def test_long_list():

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -48,7 +48,7 @@ from .ipunittest import ipdoctest, ipdocstring
 from IPython.external.decorators import *
 
 # For onlyif_cmd_exists decorator
-from IPython.utils.py3compat import string_types, which, PY2, PY3
+from IPython.utils.py3compat import string_types, which, PY2, PY3, PYPY
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -336,6 +336,7 @@ skip_known_failure = knownfailureif(True,'This test is known to fail')
 known_failure_py3 = knownfailureif(sys.version_info[0] >= 3, 
                                     'This test is known to fail on Python 3.')
 
+cpython2_only = skipif(PY3 or PYPY, "This test only runs on CPython 2.")
 py2_only = skipif(PY3, "This test only runs on Python 2.")
 py3_only = skipif(PY2, "This test only runs on Python 3.")
 

--- a/IPython/utils/py3compat.py
+++ b/IPython/utils/py3compat.py
@@ -292,6 +292,7 @@ else:
 
 
 PY2 = not PY3
+PYPY = any(k.startswith("pypy") for k in dir(sys))
 
 
 def annotate(**kwargs):

--- a/IPython/utils/py3compat.py
+++ b/IPython/utils/py3compat.py
@@ -6,6 +6,7 @@ import sys
 import re
 import shutil
 import types
+import platform
 
 from .encoding import DEFAULT_ENCODING
 
@@ -292,7 +293,7 @@ else:
 
 
 PY2 = not PY3
-PYPY = any(k.startswith("pypy") for k in dir(sys))
+PYPY = platform.python_implementation() == "PyPy"
 
 
 def annotate(**kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 ;  -- Commands --
 ; pip install tox  # Installs tox
 ; tox              # Runs the tests (call from the directory with tox.ini)
-; tox -r           # Runs rebuilding virtual environments
+; tox -r           # Ditto, but forcing the virtual environments to be rebuilt
 ; tox -e py35,pypy # Runs only in the selected environments
 ; tox -- --all -j  # Runs "iptest --all -j" in every environment
 
@@ -22,7 +22,7 @@ deps =
   py{36,35,34,33,27}: matplotlib
   .[test]
 
-; It's just to avoid loading IPython module in the current directory
+; It's just to avoid loading the IPython package in the current directory
 changedir = {envtmpdir}
 
 commands = iptest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,44 +1,28 @@
-# Tox (http://tox.testrun.org/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
-
-# Building the source distribution requires `invoke` and `lessc` to be on your PATH.
-# "pip install invoke" will install invoke. Less can be installed by
-# node.js' (http://nodejs.org/) package manager npm:
-# "npm install -g less".
-
-# Javascript tests need additional dependencies that can be installed
-# using node.js' package manager npm:
-# [*] casperjs:  "npm install -g casperjs"
-# [*] slimerjs:  "npm install -g slimerjs"
-# [*] phantomjs: "npm install -g phantomjs"
-
-# Note: qt4 versions break some tests with tornado versions >=4.0.
+; Tox (http://tox.testrun.org/) is a virtualenv manager for running tests in
+; multiple environments. This configuration file gets the requirements from
+; setup.py like a "pip install ipython[test]". To create the environments, it
+; requires every interpreter available/installed.
+;  -- Commands --
+; pip install tox  # Installs tox
+; tox              # Runs the tests (call from the directory with tox.ini)
+; tox -r           # Runs rebuilding virtual environments
+; tox -e py35,pypy # Runs only in the selected environments
+; tox -- --all -j  # Runs "iptest --all -j" in every environment
 
 [tox]
-envlist = py27, py33, py34
+envlist = py{36,35,34,33,27,py}
+skip_missing_interpreters = True
+toxworkdir = /tmp/tox_ipython
 
 [testenv]
+; PyPy requires its Numpy fork instead of "pip install numpy"
+; Other IPython/testing dependencies should be in setup.py, not here
 deps =
-  pyzmq
-  nose
-  tornado<4.0
-  jinja2
-  sphinx
-  pygments
-  jsonpointer
-  jsonschema
-  mistune
+  pypy: https://bitbucket.org/pypy/numpy/get/master.zip
+  py{36,35,34,33,27}: matplotlib
+  .[test]
 
-# To avoid loading IPython module in the current directory, change
-# current directory to ".tox/py*/tmp" before running test.
+; It's just to avoid loading IPython module in the current directory
 changedir = {envtmpdir}
 
-commands =
-  iptest --all
-
-[testenv:py27]
-deps=
-  mock
-  {[testenv]deps}
+commands = iptest {posargs}


### PR DESCRIPTION
- Fix #9821  (Python 3 only: add a `types.MappingProxyType` pretty printer + tests)
- Fix #9776  (In PyPy, avoid replacing the `dict` representation formatter/printer by the `types.DictProxyType` one)
- Add a new `tox.ini`, easier to test multiple environments (e.g. `tox -e py36,pypy -- lib utils` call "iptest lib utils" in CPython 3.6 and PyPy) including matplotlib (but in PyPy)
- Update `.travis.yml` to test with PyPy (still known to fail, so it's in `allow_failures`)
- Fixed everything needed to ensure that `test_pretty.py` tests passes in every environment (including PyPy)
- Fixed pretty printing `super(...)` objects in PyPy. Previously, it was like:

``` python
In [1]: class A(object): pass

In [2]: super(A)
Out[2]: ---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
[...]
--> 634     p.pretty(obj.__self__)
[...]
AttributeError: 'super' object has no attribute '__self__'
```
- (Python 2 only) Add consistency to pretty print bogus named classes with `"<unknown type>"`. This can be further enhanced to get the definition name, as it's stored at least in the object `__repr__`
- Fixed `IPython.lib.pretty._dict_pprinter_factory` indentation size to be equal to the prefix size
- (CPython 2 only) Consistent pretty printing for `types.DictProxyType` with an extra `ctypes`-based test to instantiate it directly with the Python API. The pretty printing uses the format used by dict proxies `types.DictProxyType.__repr__` in CPython 2.7, printing it as `"dict_proxy({...})"`, but with the sorting and line-breaking pretty printing features.
