### PR TITLE
Use 'Linux' (dark bg) colours for Windows

### DIFF
--- a/IPython/utils/PyColorize.py
+++ b/IPython/utils/PyColorize.py
@@ -146,7 +146,15 @@ NeutralColors = ColorScheme(
     'normal'         : Colors.Normal  # color off (usu. Colors.Normal)
     }  )
 
+# Hack: the 'neutral' colours are not very visible on a dark background on
+# Windows. Since Windows command prompts have a dark background by default, and
+# relatively few users are likely to alter that, we will use the 'Linux' colours,
+# designed for a dark background, as the default on Windows. Changing it here
+# avoids affecting the prompt colours rendered by prompt_toolkit, where the
+# neutral defaults do work OK.
 
+if os.name == 'nt':
+    NeutralColors = LinuxColors.copy(name='Neutral')
 
 LightBGColors = ColorScheme(
     'LightBG',{


### PR DESCRIPTION
This puts the colours in inspect output and tracebacks back to what they were in IPython 4.x, but leaves the prompt colouring as in 5.0. I tried changing the colour scheme to 'Linux' entirely for Windows, but that selects Monokai as the theme for prompt_toolkit, which looks pretty horrible in 16 colours (at least to my eyes).

This is admittedly a hack, but hopefully our legacy colour system is on the way out anyway.

Closes gh-9723
