### PR TITLE
Allow starting TerminalInteractiveShell more than once

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -415,6 +415,7 @@ class TerminalInteractiveShell(InteractiveShell):
         if display_banner is not DISPLAY_BANNER_DEPRECATED:
             warn('interact `display_banner` argument is deprecated since IPython 5.0. Call `show_banner()` if needed.', DeprecationWarning, stacklevel=2)
 
+        self.keep_running = True
         while self.keep_running:
             print(self.separate_in, end='')
 
@@ -440,9 +441,6 @@ class TerminalInteractiveShell(InteractiveShell):
                 break
             except KeyboardInterrupt:
                 print("\nKeyboardInterrupt escaped interact()\n")
-        
-        if hasattr(self, '_eventloop'):
-            self._eventloop.close()
 
     _inputhook = None
     def inputhook(self, context):

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -238,7 +238,7 @@ class TerminalInteractiveShell(InteractiveShell):
                             editing_mode=editing_mode,
                             key_bindings_registry=kbmanager.registry,
                             history=history,
-                            completer=IPythonPTCompleter(self),
+                            completer=IPythonPTCompleter(shell=self),
                             enable_history_search=True,
                             style=style,
                             mouse_support=self.mouse_support,

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -238,7 +238,7 @@ class TerminalInteractiveShell(InteractiveShell):
                             editing_mode=editing_mode,
                             key_bindings_registry=kbmanager.registry,
                             history=history,
-                            completer=IPythonPTCompleter(self.Completer),
+                            completer=IPythonPTCompleter(self),
                             enable_history_search=True,
                             style=style,
                             mouse_support=self.mouse_support,

--- a/IPython/terminal/ptutils.py
+++ b/IPython/terminal/ptutils.py
@@ -3,6 +3,7 @@ from wcwidth import wcwidth
 
 from IPython.utils.py3compat import PY3
 
+from IPython.core.completer import IPCompleter
 from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.layout.lexers import Lexer
 from prompt_toolkit.layout.lexers import PygmentsLexer
@@ -13,8 +14,11 @@ import pygments.lexers as pygments_lexers
 class IPythonPTCompleter(Completer):
     """Adaptor to provide IPython completions to prompt_toolkit"""
     def __init__(self, shell):
+        if isinstance(shell, IPCompleter):
+            raise TypeError("IPythonPTCompleter expects an InteractiveShell"
+                            " instance in IPython 5.1, not a Completer")
         self.shell = shell
-    
+
     @property
     def ipy_completer(self):
         return self.shell.Completer

--- a/IPython/terminal/ptutils.py
+++ b/IPython/terminal/ptutils.py
@@ -12,8 +12,12 @@ import pygments.lexers as pygments_lexers
 
 class IPythonPTCompleter(Completer):
     """Adaptor to provide IPython completions to prompt_toolkit"""
-    def __init__(self, ipy_completer):
-        self.ipy_completer = ipy_completer
+    def __init__(self, shell):
+        self.shell = shell
+    
+    @property
+    def ipy_completer(self):
+        return self.shell.Completer
 
     def get_completions(self, document, complete_event):
         if not document.current_line.strip():

--- a/IPython/terminal/ptutils.py
+++ b/IPython/terminal/ptutils.py
@@ -1,3 +1,12 @@
+"""prompt-toolkit utilities
+
+Everything in this module is a private API,
+not to be used outside IPython.
+"""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 import unicodedata
 from wcwidth import wcwidth
 
@@ -13,15 +22,18 @@ import pygments.lexers as pygments_lexers
 
 class IPythonPTCompleter(Completer):
     """Adaptor to provide IPython completions to prompt_toolkit"""
-    def __init__(self, shell):
-        if isinstance(shell, IPCompleter):
-            raise TypeError("IPythonPTCompleter expects an InteractiveShell"
-                            " instance in IPython 5.1, not a Completer")
+    def __init__(self, ipy_completer=None, shell=None):
+        if shell is None and ipy_completer is None:
+            raise TypeError("Please pass shell=an InteractiveShell instance.")
+        self._ipy_completer = ipy_completer
         self.shell = shell
 
     @property
     def ipy_completer(self):
-        return self.shell.Completer
+        if self._ipy_completer:
+            return self._ipy_completer
+        else:
+            return self.shell.Completer
 
     def get_completions(self, document, complete_event):
         if not document.current_line.strip():

--- a/docs/autogen_api.py
+++ b/docs/autogen_api.py
@@ -56,6 +56,8 @@ if __name__ == '__main__':
                                         r'\.qt',
                                         # this is deprecated.
                                         r'\.utils\.warn',
+                                        # Private APIs (there should be a lot more here)
+                                        r'\.terminal\.ptutils',
                                         ]
     # main API is in the inputhook module, which is documented.
 


### PR DESCRIPTION
1. always start with `keep_running=True` in `interact()`, which avoids `interact()` being a no-op on all runs after the first.
2. don't close eventloop at end of mainloop (not sure this is the right thing to do)
3. pass `self`, not `self.Completer` to PTCompleter, to ensure that it's always hooked up to shell.Completer, which can be replaced over time (pudb).

cc @Carreau, @takluyver for the right thing to do about `_eventloop.close()`, since I doubt this is the right thing. Maybe register close with `atexit.register`?

cc @inducer this fixes https://github.com/inducer/pudb/issues/193
