### PR TITLE
Remove most of the ipyparallel info in the documentation. 

### DIFF
--- a/docs/source/config/integrating.rst
+++ b/docs/source/config/integrating.rst
@@ -43,10 +43,12 @@ For example::
 Custom exception tracebacks
 ===========================
 
-Rarely, you might want to display a different traceback with an exception -
-IPython's own parallel computing framework does this to display errors from the
-engines. To do this, define a ``_render_traceback_(self)`` method which returns
-a list of strings, each containing one line of the traceback.
+Rarely, you might want to display a custom traceback when reporting an
+exception. To do this, define the custom traceback using
+`_render_traceback_(self)` method which returns a list of strings, one string
+for each line of the traceback. For example, the `ipyparallel
+<http://ipyparallel.readthedocs.io/>`__ a parallel computing framework for
+IPython, does this to display errors from multiple engines.
 
 Please be conservative in using this feature; by replacing the default traceback
 you may hide important information from the user.

--- a/docs/source/development/config.rst
+++ b/docs/source/development/config.rst
@@ -41,20 +41,17 @@ The next thing you need to know is what to call your configuration file. The
 basic idea is that each application has its own default configuration filename.
 The default named used by the :command:`ipython` command line program is
 :file:`ipython_config.py`, and *all* IPython applications will use this file.
-Other applications, such as the parallel :command:`ipcluster` scripts or the
-QtConsole will load their own config files *after* :file:`ipython_config.py`. To
-load a particular configuration file instead of the default, the name can be
-overridden by the ``config_file`` command line flag.
+The IPython kernel will load its own config file *after*
+:file:`ipython_config.py`. To load a particular configuration file instead of
+the default, the name can be overridden by the ``config_file`` command line
+flag.
 
 To generate the default configuration files, do::
 
     $ ipython profile create
 
 and you will have a default :file:`ipython_config.py` in your IPython directory
-under :file:`profile_default`. If you want the default config files for the
-:mod:`IPython.parallel` applications, add ``--parallel`` to the end of the
-command-line args.
-
+under :file:`profile_default`.
 .. note::
 
     IPython configuration options are case sensitive, and IPython cannot

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -232,50 +232,9 @@ and clients.
 Interactive parallel computing
 ==============================
 
-.. note::
     
-    This functionality is optional and now part of the `ipyparallel
-    <http://ipyparallel.readthedocs.io/>`_ project.
-
-Increasingly, parallel computer hardware, such as multicore CPUs, clusters and
-supercomputers, is becoming ubiquitous. Over the last several years, we have
-developed an architecture within IPython that allows such hardware to be used
-quickly and easily from Python. Moreover, this architecture is designed to
-support interactive and collaborative parallel computing.
-
-The main features of this system are:
-
-* Quickly parallelize Python code from an interactive Python/IPython session.
-
-* A flexible and dynamic process model that be deployed on anything from 
-  multicore workstations to supercomputers.
-
-* An architecture that supports many different styles of parallelism, from
-  message passing to task farming.  And all of these styles can be handled
-  interactively.
-
-* Both blocking and fully asynchronous interfaces.
-
-* High level APIs that enable many things to be parallelized in a few lines
-  of code.
-
-* Write parallel code that will run unchanged on everything from multicore
-  workstations to supercomputers.
-
-* Full integration with Message Passing libraries (MPI).
-
-* Capabilities based security model with full encryption of network connections.
-
-* Share live parallel jobs with other users securely.  We call this
-  collaborative parallel computing.
-
-* Dynamically load balanced task farming system.
-
-* Robust error handling.  Python exceptions raised in parallel execution are
-  gathered and presented to the top-level code.
-
-For more information, see our :ref:`overview <parallel_index>` of using IPython
-for parallel computing.
+This functionality is optional and now part of the `ipyparallel
+<http://ipyparallel.readthedocs.io/>`_ project.
 
 Portability and Python requirements
 -----------------------------------


### PR DESCRIPTION
We already point to ipyparallel on RTD. 
