### PR TITLE
Better support for KeyboardInterrupt during prompt

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -439,8 +439,14 @@ class TerminalInteractiveShell(InteractiveShell):
             try:
                 self.interact()
                 break
-            except KeyboardInterrupt:
-                print("\nKeyboardInterrupt escaped interact()\n")
+            except KeyboardInterrupt as e:
+                print("\n%s escaped interact()\n" % type(e).__name__)
+                # An interrupt during the eventloop will mess up the
+                # internal state of the prompt_toolkit library.
+                # Stopping the eventloop fixes this, see
+                # https://github.com/ipython/ipython/pull/9867
+                if hasattr(self, '_eventloop'):
+                    self._eventloop.stop()
 
     _inputhook = None
     def inputhook(self, context):


### PR DESCRIPTION
The `prompt_toolkit` library catches the CTRL-C key and handles it specifically. However, when an interrupt happens by other means or at another time, the internal state is no longer consistent. To reproduce:

```
In [1]: from signal import *

In [2]: def handler(num, frame): raise KeyboardInterrupt

In [3]: signal(SIGALRM, handler); alarm(1)
Out[3]: 0

In [4]:                                                                                                                                                                 

KeyboardInterrupt escaped interact()


In [4]:                                                                                                                                                                 
Traceback (most recent call last):
  File "/usr/local/src/sage-config/local/bin/ipython", line 5, in <module>
    start_ipython()
  File "/usr/local/src/sage-config/local/lib/python2.7/site-packages/IPython/__init__.py", line 119, in start_ipython
    return launch_new_instance(argv=argv, **kwargs)
  File "/usr/local/src/sage-config/local/lib/python2.7/site-packages/traitlets/config/application.py", line 596, in launch_instance
    app.start()
  File "/usr/local/src/sage-config/local/lib/python2.7/site-packages/IPython/terminal/ipapp.py", line 348, in start
    self.shell.mainloop()
  File "/usr/local/src/sage-config/local/lib/python2.7/site-packages/IPython/terminal/interactiveshell.py", line 402, in mainloop
    self.interact()
  File "/usr/local/src/sage-config/local/lib/python2.7/site-packages/IPython/terminal/interactiveshell.py", line 385, in interact
    code = self.prompt_for_code()
  File "/usr/local/src/sage-config/local/lib/python2.7/site-packages/IPython/terminal/interactiveshell.py", line 321, in prompt_for_code
    pre_run=self.pre_prompt, reset_current_buffer=True)
  File "build/bdist.linux-x86_64/egg/prompt_toolkit/interface.py", line 389, in run
    self.eventloop.run(self.input, self.create_eventloop_callbacks())
  File "build/bdist.linux-x86_64/egg/prompt_toolkit/eventloop/posix.py", line 55, in run
    assert not self._running
AssertionError
```

This patch fixes this by explicitly stopping the prompt.
