### PR TITLE
Remove access to 'savefig.dpi', use figure.dpi

### DIFF
--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -97,9 +97,7 @@ def print_figure(fig, fmt='png', bbox_inches='tight', **kwargs):
     if not fig.axes and not fig.lines:
         return
 
-    dpi = rcParams['savefig.dpi']
-    if dpi == 'figure':
-        dpi = fig.dpi
+    dpi = fig.dpi
     if fmt == 'retina':
         dpi = dpi * 2
         fmt = 'png'


### PR DESCRIPTION
`ipykernel` now uses `figure.dpi` to control the dpi of the
image to be created. This means that `dpi` property of the
figure object is a reliable source of truth for the users
preferences.

Depends on ipython/ipykernel/pull/176
