### PR TITLE
[WIP] Add support for MathML mime type

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -473,7 +473,7 @@ class Math(TextDisplayObject):
         
     def _repr_html_(self):
         if self.format == u'mathml':
-            return self.data
+            return "<math>%s</math>" % self.data
 
 
 class Latex(TextDisplayObject):

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -25,10 +25,9 @@ from IPython.testing.skipdoctest import skip_doctest
 __all__ = ['display', 'display_pretty', 'display_html', 'display_markdown',
 'display_svg', 'display_png', 'display_jpeg', 'display_latex', 'display_json',
 'display_javascript', 'display_pdf', 'DisplayObject', 'TextDisplayObject',
-'Pretty', 'HTML', 'Markdown', 'Math', 'Latex', 'SVG', 'JSON', 'Javascript',
-'Image', 'clear_output', 'set_matplotlib_formats', 'set_matplotlib_close',
-'publish_display_data']
-
+'Pretty', 'HTML', 'Markdown', 'Math', 'Latex', 'MathML', 'SVG',
+'JSON', 'Javascript', 'Image', 'clear_output', 'set_matplotlib_formats',
+'set_matplotlib_close', 'publish_display_data'] 
 #-----------------------------------------------------------------------------
 # utility functions
 #-----------------------------------------------------------------------------
@@ -91,6 +90,7 @@ def publish_display_data(data, metadata=None, source=None):
     * text/html
     * text/markdown
     * text/latex
+    * application/mathml+xml
     * application/json
     * application/javascript
     * image/png
@@ -475,8 +475,13 @@ class Latex(TextDisplayObject):
 
     def _repr_latex_(self):
         return self.data
+        
+        
+class MathML(TextDisplayObject):
 
-
+    def _repr_html_(self):
+        return self.data
+        
 class SVG(DisplayObject):
 
     # wrap data in a property, which extracts the <svg> tag, discarding

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -467,8 +467,13 @@ class Markdown(TextDisplayObject):
 class Math(TextDisplayObject):
 
     def _repr_latex_(self):
-        s = self.data.strip('$')
-        return "$$%s$$" % s
+        if self.format == u'latex' or not self.format:
+            s = self.data.strip('$')
+            return "$$%s$$" % s
+        
+    def _repr_html_(self):
+        if self.format == u'mathml':
+            return self.data
 
 
 class Latex(TextDisplayObject):

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -775,6 +775,23 @@ class LatexFormatter(BaseFormatter):
     print_method = ObjectName('_repr_latex_')
 
 
+class MathMLFormatter(BaseFormatter):
+    """A MathML formatter.
+
+    To define the callables that compute the MathML representation of your
+    objects, define a :meth:`_repr_mathml_` method or use the :meth:`for_type`
+    or :meth:`for_type_by_name` methods to register functions that handle
+    this.
+
+    The return value of this formatter should be a valid HTML snippet that
+    could be injected into an existing DOM. It should *not* include the
+    ```<html>`` or ```<body>`` tags.
+    """
+    format_type = Unicode('application/mathml+xml')
+
+    print_method = ObjectName('_repr_html_')
+
+
 class JSONFormatter(BaseFormatter):
     """A JSON string formatter.
 

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -775,24 +775,6 @@ class LatexFormatter(BaseFormatter):
     print_method = ObjectName('_repr_latex_')
 
 
-class MathMLFormatter(BaseFormatter):
-    """A MathML formatter.
-
-    To define the callables that compute the MathML representation of your
-    objects, define a :meth:`_repr_mathml_` method or use the :meth:`for_type`
-    or :meth:`for_type_by_name` methods to register functions that handle
-    this.
-
-    The return value of this formatter should be a valid HTML snippet that
-    could be injected into an existing DOM. It should *not* include the
-    ```<html>`` or ```<body>`` tags.
-    """
-    # format_type = Unicode('application/mathml+xml')
-    format_type = Unicode('text/html')
-
-    print_method = ObjectName('_repr_html_')
-
-
 class JSONFormatter(BaseFormatter):
     """A JSON string formatter.
 

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -787,7 +787,8 @@ class MathMLFormatter(BaseFormatter):
     could be injected into an existing DOM. It should *not* include the
     ```<html>`` or ```<body>`` tags.
     """
-    format_type = Unicode('application/mathml+xml')
+    # format_type = Unicode('application/mathml+xml')
+    format_type = Unicode('text/html')
 
     print_method = ObjectName('_repr_html_')
 


### PR DESCRIPTION
Related to https://github.com/jupyter/notebook/pull/1672

I'd like to support the following usage: 

``` py
from IPython.core.display import MathML
MathML(r"""<math>
    <mrow>
        <mi>a</mi> <mo>&InvisibleTimes;</mo> <msup><mi>x</mi><mn>2</mn></msup>
        <mo>+</mo><mi>b</mi><mo>&InvisibleTimes;</mo><mi>x</mi>
        <mo>+</mo><mi>c</mi>
    </mrow>
<math>""")
```

MathML is rendered by MathJax, so the following currently works in the notebook:

``` py
from IPython.core.display import HTML
HTML(r"""<math>
    <mrow>
        <mi>a</mi> <mo>&InvisibleTimes;</mo> <msup><mi>x</mi><mn>2</mn></msup>
        <mo>+</mo><mi>b</mi><mo>&InvisibleTimes;</mo><mi>x</mi>
        <mo>+</mo><mi>c</mi>
    </mrow>
<math>""")
```

Therefore, the display method for `MathML` can just use the `_repr_html_`.

I would also like to support the MathML mime type which is `application/mathml+xml`.
