### PR TITLE
Switch master to development of 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,30 +5,12 @@ python:
     - 3.5
     - 3.4
     - 3.3
-    - 2.7
-    - pypy
 sudo: false
 before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
 install:
     - pip install "setuptools>=18.5"
-    # Installs PyPy (+ its Numpy). Based on @frol comment at:
-    # https://github.com/travis-ci/travis-ci/issues/5027
-    - |
-        if [ "$TRAVIS_PYTHON_VERSION" = "pypy" ]; then
-          export PYENV_ROOT="$HOME/.pyenv"
-          if [ -f "$PYENV_ROOT/bin/pyenv" ]; then
-            cd "$PYENV_ROOT" && git pull
-          else
-            rm -rf "$PYENV_ROOT" && git clone --depth 1 https://github.com/yyuu/pyenv.git "$PYENV_ROOT"
-          fi
-          export PYPY_VERSION="5.3.1"
-          "$PYENV_ROOT/bin/pyenv" install "pypy-$PYPY_VERSION"
-          virtualenv --python="$PYENV_ROOT/versions/pypy-$PYPY_VERSION/bin/python" "$HOME/virtualenvs/pypy-$PYPY_VERSION"
-          source "$HOME/virtualenvs/pypy-$PYPY_VERSION/bin/activate"
-          pip install https://bitbucket.org/pypy/numpy/get/master.zip
-        fi
     - pip install -f travis-wheels/wheelhouse -e file://$PWD#egg=ipython[test]
     - pip install codecov
 script:
@@ -41,4 +23,3 @@ after_success:
 matrix:
     allow_failures:
         - python: nightly
-        - python: pypy

--- a/IPython/core/release.py
+++ b/IPython/core/release.py
@@ -19,8 +19,8 @@ name = 'ipython'
 # IPython version information.  An empty _version_extra corresponds to a full
 # release.  'dev' as a _version_extra string means this is a development
 # version
-_version_major = 5
-_version_minor = 2
+_version_major = 6
+_version_minor = 0
 _version_patch = 0
 _version_extra = '.dev'
 # _version_extra = 'rc1'
@@ -116,8 +116,6 @@ classifiers = [
     'Intended Audience :: Science/Research',
     'License :: OSI Approved :: BSD License',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
     'Topic :: System :: Shells'
     ]


### PR DESCRIPTION
I'm thinking about this because we've just released 5.1, but I'm happy for it to wait a bit longer if we prefer. As planned, 6.0 will require Python 3, while we will continue to support 5.x for some time for Python 2 users.

Before merging this, we should send a message to the mailing list for any Python 2 users following master, and make a 5.x branch off master.
