### PR TITLE
resolve path to temporary directory to ensure that 'assert_equal' tests also work when $TMPDIR is a symlink

### DIFF
--- a/IPython/core/tests/test_paths.py
+++ b/IPython/core/tests/test_paths.py
@@ -17,7 +17,7 @@ from IPython import paths
 from IPython.testing.decorators import skip_win32
 from IPython.utils.tempdir import TemporaryDirectory
 
-TMP_TEST_DIR = tempfile.mkdtemp()
+TMP_TEST_DIR = os.path.realpath(tempfile.mkdtemp())
 HOME_TEST_DIR = os.path.join(TMP_TEST_DIR, "home_test_dir")
 XDG_TEST_DIR = os.path.join(HOME_TEST_DIR, "xdg_test_dir")
 XDG_CACHE_DIR = os.path.join(HOME_TEST_DIR, "xdg_cache_dir")


### PR DESCRIPTION
If `$TMPDIR` is a symlink (e.g. `TMPDIR=/local` with `/local` -> `/tmp`), one of the tests fails with the error below due to a hard string comparison of paths using `assert_equals` (see below)

this patch fixes the problem by resolving the path returned by `tempfile.mkdtemp()`

```
======================================================================
FAIL: IPython.core.tests.test_paths.test_get_ipython_cache_dir
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/SL6/sandybridge/software/IPython/5.0.0-foss-2016a-Python-2.7.11/lib/python2.7/site-packages/nose-1.3.7-py2.7.egg/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/SL6/sandybridge/software/IPython/5.0.0-foss-2016a-Python-2.7.11/lib/python2.7/site-packages/IPython/core/tests/test_paths.py", line 185, in test_get_ipython_cache_dir
    ipdir)
AssertionError: '/local/2541261X3368X.master15.delcatty.gent.vsc/eb-b7oBry/tmpoxweQW/tmpZurEih/home_test_dir/.cache/ipython' != u'/tmp/2541261X3368X.master15.delcatty.gent.vsc/eb-b7oBry/tmpoxweQW/tmpZurEih/home_test_dir/.cache/ipython'
    "'/local/2541261X3368X.master15.delcatty.gent.vsc/eb-b7oBry/tmpoxweQW/tmpZurEih/home_test_dir/.cache/ipython' != u'/tmp/2541261X3368X.master15.delcatty.gent.vsc/eb-b7oBry/tmpoxweQW/tmpZurEih/home_test_dir/.cache/ipython'" = '%s != %s' % (safe_repr('/local/2541261X3368X.master15.delcatty.gent.vsc/eb-b7oBry/tmpoxweQW/tmpZurEih/home_test_dir/.cache/ipython'), safe_repr(u'/tmp/2541261X3368X.master15.delcatty.gent.vsc/eb-b7oBry/tmpoxweQW/tmpZurEih/home_test_dir/.cache/ipython'))
    "'/local/2541261X3368X.master15.delcatty.gent.vsc/eb-b7oBry/tmpoxweQW/tmpZurEih/home_test_dir/.cache/ipython' != u'/tmp/2541261X3368X.master15.delcatty.gent.vsc/eb-b7oBry/tmpoxweQW/tmpZurEih/home_test_dir/.cache/ipython'" = self._formatMessage("'/local/2541261X3368X.master15.delcatty.gent.vsc/eb-b7oBry/tmpoxweQW/tmpZurEih/home_test_dir/.cache/ipython' != u'/tmp/2541261X3368X.master15.delcatty.gent.vsc/eb-b7oBry/tmpoxweQW/tmpZurEih/home_test_dir/.cache/ipython'", "'/local/2541261X3368X.master15.delcatty.gent.vsc/eb-b7oBry/tmpoxweQW/tmpZurEih/home_test_dir/.cache/ipython' != u'/tmp/2541261X3368X.master15.delcatty.gent.vsc/eb-b7oBry/tmpoxweQW/tmpZurEih/home_test_dir/.cache/ipython'")
>>  raise self.failureException("'/local/2541261X3368X.master15.delcatty.gent.vsc/eb-b7oBry/tmpoxweQW/tmpZurEih/home_test_dir/.cache/ipython' != u'/tmp/2541261X3368X.master15.delcatty.gent.vsc/eb-b7oBry/tmpoxweQW/tmpZurEih/home_test_dir/.cache/ipython'")


----------------------------------------------------------------------
Ran 520 tests in 34.490s

FAILED (SKIP=11, failures=1)
```
