### PR TITLE
#8485: Don't import dreload by default

### DIFF
--- a/IPython/core/builtin_trap.py
+++ b/IPython/core/builtin_trap.py
@@ -52,17 +52,6 @@ class BuiltinTrap(Configurable):
                               'quit': HideBuiltin,
                               'get_ipython': self.shell.get_ipython,
                               }
-        # Recursive reload function
-        try:
-            from IPython.lib import deepreload
-            if self.shell.deep_reload:
-                from warnings import warn
-                warn("Automatically replacing builtin `reload` by `deepreload.reload` is deprecated since IPython 4.0, please import `reload` explicitly from `IPython.lib.deepreload", DeprecationWarning)
-                self.auto_builtins['reload'] = deepreload._dreload
-            else:
-                self.auto_builtins['dreload']= deepreload._dreload
-        except ImportError:
-            pass
 
     def __enter__(self):
         if self._nested_level == 0:

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -260,21 +260,6 @@ class InteractiveShell(SingletonConfigurable):
         help="Set the color scheme (NoColor, Neutral, Linux, or LightBG)."
     ).tag(config=True)
     debug = Bool(False).tag(config=True)
-    deep_reload = Bool(False, help=
-        """
-        **Deprecated**
-
-        Will be removed in IPython 6.0
-
-        Enable deep (recursive) reloading by default. IPython can use the
-        deep_reload module which reloads changes in modules recursively (it
-        replaces the reload() function, so you don't need to change anything to
-        use it). `deep_reload` forces a full reload of modules whose code may
-        have changed, which the default reload() function does not.  When
-        deep_reload is off, IPython will use the normal reload(), but
-        deep_reload will still be available as dreload().
-        """
-    ).tag(config=True)
     disable_failing_post_execute = Bool(False,
         help="Don't call post-execute functions that have failed in the past."
     ).tag(config=True)

--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -341,21 +341,3 @@ def reload(module, exclude=('sys', 'os.path', builtin_mod_name, '__main__')):
             return deep_reload_hook(module)
     finally:
         found_now = {}
-
-
-def _dreload(module, **kwargs):
-    """
-    **deprecated**
-
-    import reload explicitly from `IPython.lib.deepreload` to use it
-
-    """
-    # this was marked as deprecated and for 5.0 removal, but
-    # IPython.core_builtin_trap have a Deprecation warning for 6.0, so cannot
-    # remove that now.
-    warn("""
-injecting `dreload` in interactive namespace is deprecated since IPython 4.0. 
-Please import `reload` explicitly from `IPython.lib.deepreload`.
-""", DeprecationWarning, stacklevel=2)
-    reload(module, **kwargs)
-

--- a/docs/source/whatsnew/pr/incompat-no-dreload.rst
+++ b/docs/source/whatsnew/pr/incompat-no-dreload.rst
@@ -1,0 +1,3 @@
+The `--deep-reload` flag and the corresponding options to inject `dreload` or
+`reload` into the interactive namespace have been removed. You have to
+explicitly import `reload` from `IPython.lib.deepreload` to use it.


### PR DESCRIPTION
Hi guys!

I would like to contribute into ipython, so I started with sprint-friendly issue to learn your workflow and code.

This PR fixes #8485 - I've removed auto-import of deepreload function, no tests failed. Review it please.

Thanks!
