### PR TITLE
Add support for ipympl backend to magic

### DIFF
--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -23,7 +23,8 @@ backends = {'tk': 'TkAgg',
             'osx': 'MacOSX',
             'nbagg': 'nbAgg',
             'notebook': 'nbAgg',
-            'inline' : 'module://ipykernel.pylab.backend_inline'}
+            'inline': 'module://ipykernel.pylab.backend_inline',
+            'ipympl': 'module://ipympl.backend_nbagg'}
 
 # We also need a reverse backends2guis mapping that will properly choose which
 # GUI support to activate based on the desired matplotlib backend.  For the

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -212,8 +212,8 @@ def select_figure_formats(shell, formats, **kwargs):
     formats = set(formats)
 
     [ f.pop(Figure, None) for f in shell.display_formatter.formatters.values() ]
-
-    if matplotlib.get_backend().lower() == 'nbagg':
+    mplbackend = matplotlib.get_backend().lower()
+    if mplbackend == 'nbagg' or mplbackend == 'module://ipympl.backend_nbagg':
         formatter = shell.display_formatter.ipython_display_formatter
         formatter.for_type(Figure, _reshow_nbagg_figure)
 


### PR DESCRIPTION
This enables you to do `%matplotlib ipympl` to use https://github.com/matplotlib/jupyter-matplotlib backend. In the long term I expect that the 

Needs to go together with the matching change in ipykernel. Which I will open a pull request for in a moment. 

I am not sure how to best handle the interdependency between this and ipykernel
With this change the backend will be added to the list of available backends via
`%matplotlib --list` but will not actually be functional without the change in ipykernel
