### PR TITLE
Update prompts.py

### DIFF
--- a/IPython/terminal/prompts.py
+++ b/IPython/terminal/prompts.py
@@ -71,4 +71,4 @@ class RichPromptDisplayHook(DisplayHook):
             if self.shell.pt_cli:
                 self.shell.pt_cli.print_tokens(tokens)
             else:
-                print(*(s for t, s in tokens), sep='')
+                sys.stdout.write(''.join(s for t, s in tokens))


### PR DESCRIPTION
Get rid of spurious newline after the output prompt (Out[n]: ) in cases where prompt_toolkit is not used (e.g. running ipython inside Emacs)
