### PR TITLE
Improve our error messages for non compatibility.

### DIFF
--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -22,17 +22,24 @@ from __future__ import absolute_import
 
 import os
 import sys
-import warnings
 
 #-----------------------------------------------------------------------------
 # Setup everything
 #-----------------------------------------------------------------------------
 
 # Don't forget to also update setup.py when this changes!
-v = sys.version_info
-if v[:2] < (3,3):
-    raise ImportError('IPython requires Python version 3.3 or above.')
-del v
+if sys.version_info < (3,3):
+    raise ImportError(
+"""
+IPython 6.0+ does not support Python 2.6, 2.7, 3.0, 3.1, or 3.2.
+When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
+Beginning with IPython 6.0, Python 3.3 and above is required.
+
+See IPython `README.rst` file for more information:
+
+    https://github.com/ipython/ipython/blob/master/README.rst
+
+""")
 
 # Make it easy to import extensions - they are always directly on pythonpath.
 # Therefore, non-IPython modules can be added to extensions directory.
@@ -143,4 +150,3 @@ def start_kernel(argv=None, **kwargs):
     """
     from IPython.kernel.zmq.kernelapp import launch_new_instance
     return launch_new_instance(argv=argv, **kwargs)
-    

--- a/README.rst
+++ b/README.rst
@@ -36,16 +36,52 @@ Development and Instant runnimg
 ================================
 
 You can find the latest version of the development documentation on `readthedocs
-<http://ipython.readthedocs.io/en/latest/>`_. 
+<http://ipython.readthedocs.io/en/latest/>`_.
 
 You can run IPython from this directory without even installing it system-wide
 by typing at the terminal::
-    
+
    $ python -m IPython
 
 Or see the `development installation docs
 <http://ipython.readthedocs.io/en/latest/install/install.html#installing-the-development-version>`_
-for the latest revision on read the docs. 
+for the latest revision on read the docs.
 
 Documentation and installation instructions for older version of IPython can be
 found on the `IPython website <http://ipython.org/documentation.html>`_
+
+
+
+IPython requires Python version 3 or above
+==========================================
+
+Starting with version 6.0, IPython does not support Python 2.7, 3.0, 3.1, or
+3.2.
+
+For a version compatible with Python 2.7, please install the 5.x LTS Long Term
+Support version.
+
+If you are encountering this error message you are likely trying to install or
+use IPython from source. You need to checkout the remote 5.x branch. If you are
+using git the following should work:
+
+  $ git fetch origin
+  $ git checkout -b origin/5.x
+
+If you encounter this error message with a regular install of IPython, then you
+likely need to update your package manager, for example if you are using `pip`
+check the version of pip with
+
+  $ pip --version
+
+You will need to update pip to the version 8.2 or greater. If you are not using
+pip, please inquiry with the maintainers of the package for your package
+manager.
+
+For more information see one of our blog posts:
+
+    http://blog.jupyter.org/2016/07/08/ipython-5-0-released/
+
+As well as the following Pull-Request for discussion:
+
+    https://github.com/ipython/ipython/pull/9900

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,18 @@ import sys
 
 # This check is also made in IPython/__init__, don't forget to update both when
 # changing Python version requirements.
-v = sys.version_info
-if v[:2] < (3,3):
-    error = "ERROR: IPython requires Python version 3.3 or above."
+if sys.version_info < (3,3):
+    error = """
+IPython 6.0+ does not support Python 2.6, 2.7, 3.0, 3.1, or 3.2.
+When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
+Beginning with IPython 6.0, Python 3.3 and above is required.
+
+See IPython `README.rst` file for more information:
+
+    https://github.com/ipython/ipython/blob/master/README.rst
+
+"""
+
     print(error, file=sys.stderr)
     sys.exit(1)
 


### PR DESCRIPTION
I would like to have the transition (even on master) as smooth as possible, with good error message. 

There is a large number of instruction that explain how to install ipython from source on the internet, and we can make an effort for all the python 2 users around that will encounter that to have a seamless transition or at least a good error message.

Otherwise we will get a lot of bug report from users. 

One of the thing we can do, is to actually open an issue just for that, and point to this issue number in the error messag, plus update this issue with instructions. 

The following is not super friendly:

```
$ python2 -m pip install .
Processing /Users/bussonniermatthias/dev/ipython
    Complete output from command python setup.py egg_info:
    ERROR: IPython requires Python version 3.3 or above.

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /var/folders/ld/jy0c_5d91rl_s3jqh74tmqn00000gn/T/pip-_zeInP-build/
```
