### PR TITLE
Stop stripping encoding cookie

### DIFF
--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -26,7 +26,6 @@ from IPython.utils.py3compat import cast_unicode
 from IPython.core.inputtransformer import (leading_indent,
                                            classic_prompt,
                                            ipy_prompt,
-                                           strip_encoding_cookie,
                                            cellmagic,
                                            assemble_logical_lines,
                                            help_end,
@@ -485,7 +484,6 @@ class IPythonInputSplitter(InputSplitter):
                                              classic_prompt(),
                                              ipy_prompt(),
                                              cellmagic(end_on_blank_line=line_input_checker),
-                                             strip_encoding_cookie(),
                                             ]
         
         self.assemble_logical_lines = assemble_logical_lines()

--- a/IPython/core/inputtransformer.py
+++ b/IPython/core/inputtransformer.py
@@ -9,7 +9,6 @@ import re
 
 from IPython.core.splitinput import LineInfo
 from IPython.utils import tokenize2
-from IPython.utils.openpy import cookie_comment_re
 from IPython.utils.py3compat import with_metaclass, PY3
 from IPython.utils.tokenize2 import generate_tokens, untokenize, TokenError
 
@@ -504,29 +503,6 @@ def leading_indent():
             while line is not None:
                 line = (yield line)
 
-
-@CoroutineInputTransformer.wrap
-def strip_encoding_cookie():
-    """Remove encoding comment if found in first two lines
-    
-    If the first or second line has the `# coding: utf-8` comment,
-    it will be removed.
-    """
-    line = ''
-    while True:
-        line = (yield line)
-        # check comment on first two lines
-        for i in range(2):
-            if line is None:
-                break
-            if cookie_comment_re.match(line):
-                line = (yield "")
-            else:
-                line = (yield line)
-        
-        # no-op on the rest of the cell
-        while line is not None:
-            line = (yield line)
 
 _assign_pat = \
 r'''(?P<lhs>(\s*)

--- a/IPython/core/tests/test_inputtransformer.py
+++ b/IPython/core/tests/test_inputtransformer.py
@@ -78,13 +78,6 @@ syntax = \
         ('    ','    '),  # blank lines are kept intact
         ],
 
-       strip_encoding_cookie =
-       [
-        ('# -*- encoding: utf-8 -*-', ''),
-        ('# coding: latin-1', ''),
-       ],
-
-
        # Tests for the escape transformer to leave normal code alone
        escaped_noesc =
        [ ('    ', '    '),
@@ -255,20 +248,6 @@ syntax_ml = \
           ],
          ],
 
-       strip_encoding_cookie =
-       [
-        [
-            ('# -*- coding: utf-8 -*-', ''),
-            ('foo', 'foo'),
-        ],
-        [
-            ('#!/usr/bin/env python', '#!/usr/bin/env python'),
-            ('# -*- coding: latin-1 -*-', ''),
-            # only the first-two lines
-            ('# -*- coding: latin-1 -*-', '# -*- coding: latin-1 -*-'),
-        ],
-       ],
-
        multiline_datastructure_prompt =
        [ [('>>> a = [1,','a = [1,'),
           ('... 2]','2]'),
@@ -378,11 +357,6 @@ def test_ipy_prompt():
         (u'%%foo', '%%foo'),
         (u'In [1]: bar', 'In [1]: bar'),
     ], ipt.ipy_prompt)
-
-def test_coding_cookie():
-    tt.check_pairs(transform_and_reset(ipt.strip_encoding_cookie), syntax['strip_encoding_cookie'])
-    for example in syntax_ml['strip_encoding_cookie']:
-        transform_checker(example, ipt.strip_encoding_cookie)
 
 def test_assemble_logical_lines():
     tests = \


### PR DESCRIPTION
As far as I can tell, it's no longer a syntax error to have the magic encoding comment when parsing a unicode string. Since IPython 6 doesn't support Python 2, we can simply stop making this change.

Closes gh-9919
