### PR TITLE
Only make .tar.gz sdists when releasing

### DIFF
--- a/tools/toollib.py
+++ b/tools/toollib.py
@@ -18,7 +18,7 @@ archive = '%s:%s' % (archive_user, archive_dir)
 
 # Build commands
 # Source dists
-sdists = './setup.py sdist --formats=gztar,zip'
+sdists = './setup.py sdist --formats=gztar'
 # Binary dists
 def buildwheels():
     sh('python3 setupegg.py bdist_wheel' % py)


### PR DESCRIPTION
PEP 527, which was just accepted, says that there can only be one sdist per release. Tarballs are already the more common sdist format on PyPI, so let's go with that.
