### PR TITLE
Add shortcut to edit cell

### DIFF
--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -62,6 +62,10 @@ def register_ipython_shortcuts(registry, shell):
                          filter=(HasFocus(DEFAULT_BUFFER)
                                 & EmacsInsertMode()))(newline_with_copy_margin)
 
+    registry.add_binding(Keys.F2,
+                         filter=HasFocus(DEFAULT_BUFFER)
+                        )(open_input_in_editor)
+
     if shell.display_completions == 'readlinelike':
         registry.add_binding(Keys.ControlI,
                              filter=(HasFocus(DEFAULT_BUFFER)
@@ -170,7 +174,9 @@ def newline_with_copy_margin(event):
         pos_diff = cursor_start_pos - cursor_end_pos
         b.cursor_right(count=pos_diff)
 
-
+def open_input_in_editor(event):
+    event.cli.current_buffer.tempfile_suffix = ".py"
+    event.cli.current_buffer.open_in_editor(event.cli)
 
 
 if sys.platform == 'win32':


### PR DESCRIPTION
I've integrated some code @carlsmith posted on the mailing list to open the current cell in a text editor to edit a larger chunk of code. This reduces the need for `%edit`, and has the benefit that edited code goes into the IPython history.

What should the shortcut be? Carl used **Ctrl-N**, but nothing about that says 'edit' to me. I've gone for **F2**, which is used in Excel to edit the selected cell, and I've enabled it for both emacs and vi keybindings. If we don't use an F-key (or something funky like Insert), we probably need separate emacs and vi shortcuts.
