### PR TITLE
Allowing debugging with -m IPython.terminal.debugger

### DIFF
--- a/IPython/terminal/debugger.py
+++ b/IPython/terminal/debugger.py
@@ -75,3 +75,8 @@ class TerminalPdb(Pdb):
 def set_trace():
     TerminalPdb().set_trace()
 
+
+if __name__ == '__main__':
+    import pdb
+    pdb.Pdb = TerminalPdb
+    pdb.main()


### PR DESCRIPTION
I really enjoy using the IPython debugger with `pytest --pdbcls=IPython.terminal.debugger:TerminalPdb .` which was enabled through #9731.

I tried to go one step further and to create an alternative for `python -m pdb myscript` through `python -m IPython.terminal.debugger myscript`.

This pull request basically monkey patched the Pdb class (an alternative would be copy the source code of the pdb.main function). This works really fine as long as no exception occurs.

However, as soon as an exception occurs, the script cannot be exited / quit any more.

---

Steps to reproduce: `python -m IPython.terminal.debugger example_script.py` and hit `c` followed by some `q`. 

example_script.py:

``` python
msg = "hello world"

raise Exception(msg)

print(msg)
```

What is your generally feeling about the feature `python -m IPython.terminal.debugger`? And how would you support / implement such a feature. I am happy to revise what what be your implementation strategy. I am happy to revise and continue on this PR.
