### PR TITLE
Don't require win_unicode_console on Python 3.6

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -340,6 +340,11 @@ class TerminalInteractiveShell(InteractiveShell):
         return document.text
 
     def enable_win_unicode_console(self):
+        if sys.version_info >= (3, 6):
+            # Since PEP 528, Python uses the unicode APIs for the Windows
+            # console by default, so WUC shouldn't be needed.
+            return
+
         import win_unicode_console
 
         if PY3:

--- a/setup.py
+++ b/setup.py
@@ -218,7 +218,8 @@ extras_require.update({
     ':python_version == "2.7" or python_version == "3.3"': ['pathlib2'],
     ':sys_platform != "win32"': ['pexpect'],
     ':sys_platform == "darwin"': ['appnope'],
-    ':sys_platform == "win32"': ['colorama', 'win_unicode_console>=0.5'],
+    ':sys_platform == "win32"': ['colorama'],
+    ':sys_platform == "win32" and python_version < "3.6"': ['win_unicode_console>=0.5'],
     'test:python_version == "2.7"': ['mock'],
 })
 # FIXME: re-specify above platform dependencies for pip < 6


### PR DESCRIPTION
It looks like the changes @Drekin's win_unicode_console makes have essentially been integrated into Python 3.6, so it will use the Unicode APIs for Windows console access by default. See [PEP 528](https://www.python.org/dev/peps/pep-0528/).

So we shouldn't need to load WUC on Python 3.6, and it may even have some strange interactions.
