### PR TITLE
Add set_trace to core debugger.

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -629,5 +629,4 @@ def set_trace(frame=None):
 
     If frame is not specified, debugging starts from caller's frame.
     """
-    pdb = Pdb()
-    pdb.set_trace()
+    Pdb().set_trace(frame or sys._getframe().f_back)

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -623,12 +623,11 @@ class Pdb(OldPdb, object):
         do_w = do_where
 
 
-def set_trace(frame=None, condition=True):
-	"""
-	Start debugging from `frame` if `condition` is satisfied.
+def set_trace(frame=None):
+    """
+    Start debugging from `frame`.
 
-	If frame is not specified, debugging starts from caller's frame.
-	"""
-	if condition:
-		pdb = Pdb()
-		pdb.set_trace()
+    If frame is not specified, debugging starts from caller's frame.
+    """
+    pdb = Pdb()
+    pdb.set_trace()

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -621,3 +621,14 @@ class Pdb(OldPdb, object):
                 self.print_stack_trace()
 
         do_w = do_where
+
+
+def set_trace(frame=None, condition=True):
+	"""
+	Start debugging from `frame` if `condition` is satisfied.
+
+	If frame is not specified, debugging starts from caller's frame.
+	"""
+	if condition:
+		pdb = Pdb()
+		pdb.set_trace()

--- a/IPython/terminal/debugger.py
+++ b/IPython/terminal/debugger.py
@@ -7,6 +7,8 @@ from prompt_toolkit.token import Token
 from prompt_toolkit.shortcuts import create_prompt_application
 from prompt_toolkit.interface import CommandLineInterface
 from prompt_toolkit.enums import EditingMode
+import sys
+
 
 class TerminalPdb(Pdb):
     def __init__(self, *args, **kwargs):
@@ -72,8 +74,14 @@ class TerminalPdb(Pdb):
         except Exception:
             raise
 
-def set_trace():
-    TerminalPdb().set_trace()
+
+def set_trace(frame=None):
+    """
+    Start debugging from `frame`.
+
+    If frame is not specified, debugging starts from caller's frame.
+    """
+    TerminalPdb().set_trace(frame or sys._getframe().f_back)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds a `set_trace` method to `IPython.core.debugger` to mirror the functionality of `IPython.terminal.debugger`. See #9940 for a discussion.
