### PR TITLE
enable quitting for -m IPython.terminal.debugger

### DIFF
--- a/IPython/terminal/debugger.py
+++ b/IPython/terminal/debugger.py
@@ -86,5 +86,11 @@ def set_trace(frame=None):
 
 if __name__ == '__main__':
     import pdb
+    # IPython.core.debugger.Pdb.trace_dispatch shall not catch
+    # bdb.BdbQuit. When started through __main__ and an exeption
+    # happend after hitting "c", this is needed in order to
+    # be able to quit the debugging session (see #9950).
+    old_trace_dispatch = pdb.Pdb.trace_dispatch
     pdb.Pdb = TerminalPdb
+    pdb.Pdb.trace_dispatch = old_trace_dispatch
     pdb.main()

--- a/IPython/terminal/debugger.py
+++ b/IPython/terminal/debugger.py
@@ -87,7 +87,7 @@ def set_trace(frame=None):
 if __name__ == '__main__':
     import pdb
     # IPython.core.debugger.Pdb.trace_dispatch shall not catch
-    # bdb.BdbQuit. When started through __main__ and an exeption
+    # bdb.BdbQuit. When started through __main__ and an exception
     # happend after hitting "c", this is needed in order to
     # be able to quit the debugging session (see #9950).
     old_trace_dispatch = pdb.Pdb.trace_dispatch

--- a/IPython/terminal/debugger.py
+++ b/IPython/terminal/debugger.py
@@ -88,7 +88,7 @@ if __name__ == '__main__':
     import pdb
     # IPython.core.debugger.Pdb.trace_dispatch shall not catch
     # bdb.BdbQuit. When started through __main__ and an exception
-    # happend after hitting "c", this is needed in order to
+    # happened after hitting "c", this is needed in order to
     # be able to quit the debugging session (see #9950).
     old_trace_dispatch = pdb.Pdb.trace_dispatch
     pdb.Pdb = TerminalPdb


### PR DESCRIPTION
When debugging with `python -m IPython.terminal.debugger myscript.py` and an exception occurs after hitting `c`, you cannot quit the debugger any more (see lower part of the description of #9942 for more detail).

The actual problem is that quit does not quit the debugging of the script but rather continues (affected [code line](https://github.com/ipython/ipython/blob/master/IPython/core/debugger.py#L285)). I guessed this is necessary for the notebook interface. However, it is the root cause for an never ending debugging session for this scenario.

This pull request re-enables quitting if debugging with `python -m IPython.terminal.debugger`.
