### PR TITLE
Some mpl backends have no corresponding GUI

### DIFF
--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -39,6 +39,10 @@ backend2gui['GTK'] = backend2gui['GTKCairo'] = 'gtk'
 backend2gui['GTK3Cairo'] = 'gtk3'
 backend2gui['WX'] = 'wx'
 backend2gui['CocoaAgg'] = 'osx'
+# And some backends that don't need GUI integration
+del backend2gui['nbAgg']
+del backend2gui['agg']
+del backend2gui['module://ipykernel.pylab.backend_inline']
 
 #-----------------------------------------------------------------------------
 # Matplotlib utilities


### PR DESCRIPTION
Hopefully fixes a test failure on Windows where mpl tries to activate an `agg` gui.

Should we manually define the backend2gui dict instead of inverting backends and then modifying it?

Test failure:

```
Traceback (most recent call last):
  File "C:\Users\ADMINI~1\AppData\Local\Temp\2\1845\lib\unittest\case.py", line 58, in testPartExecutor
    yield
  File "C:\Users\ADMINI~1\AppData\Local\Temp\2\1845\lib\unittest\case.py", line 600, in run
    testMethod()
  File "C:\Users\ADMINI~1\AppData\Local\Temp\2\1845\lib\site-packages\nose\failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "C:\Users\ADMINI~1\AppData\Local\Temp\2\1845\lib\site-packages\nose\loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "C:\Users\ADMINI~1\AppData\Local\Temp\2\1845\lib\site-packages\nose\importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "C:\Users\ADMINI~1\AppData\Local\Temp\2\1845\lib\site-packages\nose\importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "C:\Users\ADMINI~1\AppData\Local\Temp\2\1845\lib\imp.py", line 234, in load_module
    return load_source(name, filename, file)
  File "C:\Users\ADMINI~1\AppData\Local\Temp\2\1845\lib\imp.py", line 172, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 693, in _load
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 665, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "c:\jenkins\workspace\windows-multi\_pyversion\3.5\label\windows\IPython\core\tests\test_pylabtools.py", line 18, in <module>
    from matplotlib import pyplot as plt
  File "C:\Users\ADMINI~1\AppData\Local\Temp\2\1845\lib\site-packages\matplotlib\pyplot.py", line 2512, in <module>
    install_repl_displayhook()
  File "C:\Users\ADMINI~1\AppData\Local\Temp\2\1845\lib\site-packages\matplotlib\pyplot.py", line 165, in install_repl_displayhook
    ip.enable_gui(ipython_gui_name)
  File "c:\jenkins\workspace\windows-multi\_pyversion\3.5\label\windows\IPython\terminal\interactiveshell.py", line 463, in enable_gui
    self._inputhook = get_inputhook_func(gui)
  File "c:\jenkins\workspace\windows-multi\_pyversion\3.5\label\windows\IPython\terminal\pt_inputhooks\__init__.py", line 38, in get_inputhook_func
    raise UnknownBackend(gui)
IPython.terminal.pt_inputhooks.UnknownBackend: No event loop integration for 'agg'. Supported event loops are: qt, qt4, qt5, gtk, gtk2, gtk3, tk, wx, pyglet, glut, osx
```
