### PR TITLE
Allow the debugger to work in code which calls __import__("__main__")

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -227,10 +227,14 @@ class Pdb(OldPdb, object):
         self.shell = get_ipython()
 
         if self.shell is None:
+            save_main = sys.modules['__main__']
             # No IPython instance running, we must create one
             from IPython.terminal.interactiveshell import \
                 TerminalInteractiveShell
             self.shell = TerminalInteractiveShell.instance()
+            # needed by any code which calls __import__("__main__") after
+            # the debugger was entered. See also #9941.
+            sys.modules['__main__'] = save_main 
 
         if color_scheme is not None:
             warnings.warn(


### PR DESCRIPTION
this basically resolves #9941 as suggested by @takluyver in https://github.com/ipython/ipython/issues/9941#issuecomment-248071079.

In summary, it is needed to run e.g. standard unittests within the debugger. For more details see #9941.
