### PR TITLE
Doc update. Add reasoning behind PopupWidget removal.

### DIFF
--- a/docs/source/whatsnew/version3_widget_migration.rst
+++ b/docs/source/whatsnew/version3_widget_migration.rst
@@ -11,7 +11,8 @@ Upgrading Notebooks
    "Widget" suffix was removed from the end of the class name. i.e.
    ``ButtonWidget`` is now ``Button``.
 3. ``ContainerWidget`` was renamed to ``Box``.
-4. ``PopupWidget`` was removed from IPython. If you use the
+4. ``PopupWidget`` was removed from IPython, because bootstrapjs was 
+   problematic (creates global variables, etc.). If you use the
    ``PopupWidget``, try using a ``Box`` widget instead. If your notebook
    can't live without the popup functionality, subclass the ``Box``
    widget (both in Python and JS) and use JQuery UI's ``draggable()``


### PR DESCRIPTION
Short explanation of [why it was removed](https://gitter.im/jupyter/jupyter?at=57e7075c7270539a6d843a4e).
