### PR TITLE
Start refactoring handling of color.

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -239,7 +239,7 @@ class Pdb(OldPdb, object):
         if color_scheme is not None:
             warnings.warn(
                 "The `color_scheme` argument is deprecated since version 5.1",
-                DeprecationWarning)
+                DeprecationWarning, stacklevel=2)
         else:
             color_scheme = self.shell.colors
 
@@ -269,11 +269,11 @@ class Pdb(OldPdb, object):
         cst['Neutral'].colors.breakpoint_enabled = C.LightRed
         cst['Neutral'].colors.breakpoint_disabled = C.Red
 
-        self.set_colors(color_scheme)
 
         # Add a python parser so we can syntax highlight source while
         # debugging.
-        self.parser = PyColorize.Parser()
+        self.parser = PyColorize.Parser(style=color_scheme)
+        self.set_colors(color_scheme)
 
         # Set the prompt - the default prompt is '(Pdb)'
         self.prompt = prompt
@@ -281,6 +281,7 @@ class Pdb(OldPdb, object):
     def set_colors(self, scheme):
         """Shorthand access to the color table scheme selector method."""
         self.color_scheme_table.set_active_scheme(scheme)
+        self.parser.style = scheme
 
     def trace_dispatch(self, frame, event, arg):
         try:
@@ -451,9 +452,9 @@ class Pdb(OldPdb, object):
         bp_mark = ""
         bp_mark_color = ""
 
-        scheme = self.color_scheme_table.active_scheme_name
-        new_line, err = self.parser.format2(line, 'str', scheme)
-        if not err: line = new_line
+        new_line, err = self.parser.format2(line, 'str')
+        if not err:
+            line = new_line
 
         bp = None
         if lineno in self.get_file_breaks(filename):

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -473,10 +473,7 @@ class InteractiveShell(SingletonConfigurable):
 
         # The following was in post_config_initialization
         self.init_inspector()
-        if py3compat.PY3:
-            self.raw_input_original = input
-        else:
-            self.raw_input_original = raw_input
+        self.raw_input_original = input
         self.init_completer()
         # TODO: init_io() needs to happen before init_traceback handlers
         # because the traceback handlers hardcode the stdout/stderr streams.
@@ -577,10 +574,12 @@ class InteractiveShell(SingletonConfigurable):
         except AttributeError:
             self.stdin_encoding = 'ascii'
 
-    def init_syntax_highlighting(self):
+
+    @observe('colors')
+    def init_syntax_highlighting(self, changes=None):
         # Python source parser/formatter for syntax highlighting
-        pyformat = PyColorize.Parser().format
-        self.pycolorize = lambda src: pyformat(src,'str',self.colors)
+        pyformat = PyColorize.Parser(style=self.colors).format
+        self.pycolorize = lambda src: pyformat(src,'str')
 
     def refresh_style(self):
         # No-op here, used in subclass

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -132,7 +132,6 @@ def test_unicode_completions():
         nt.assert_true(isinstance(text, string_types))
         nt.assert_true(isinstance(matches, list))
 
-@dec.onlyif(sys.version_info[0] >= 3, 'This test only applies in Py>=3')
 def test_latex_completions():
     from IPython.core.latex_symbols import latex_symbols
     import random

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -41,9 +41,14 @@ ip = get_ipython()
 # updated.  Do NOT insert any whitespace between the next line and the function
 # definition below.
 THIS_LINE_NUMBER = 43  # Put here the actual number of this line
-def test_find_source_lines():
-    nt.assert_equal(oinspect.find_source_lines(test_find_source_lines), 
-                    THIS_LINE_NUMBER+1)
+
+from unittest import TestCase
+
+class Test(TestCase):
+
+    def test_find_source_lines(self):
+        self.assertEqual(oinspect.find_source_lines(Test.test_find_source_lines), 
+                    THIS_LINE_NUMBER+6)
 
 
 # A couple of utilities to ensure these tests work the same from a source or a
@@ -322,7 +327,7 @@ def test_bool_raise():
 
 def test_info_serialliar():
     fib_tracker = [0]
-    i = inspector.info(SerialLiar(fib_tracker))
+    inspector.info(SerialLiar(fib_tracker))
 
     # Nested attribute access should be cut off at 100 levels deep to avoid
     # infinite loops: https://github.com/ipython/ipython/issues/9122
@@ -335,10 +340,9 @@ def test_calldef_none():
         i = inspector.info(obj)
         nt.assert_is(i['call_def'], None)
 
-if py3compat.PY3:
-    exec("def f_kwarg(pos, *, kwonly): pass")
+def f_kwarg(pos, *, kwonly):
+    pass
 
-@skipif(not py3compat.PY3)
 def test_definition_kwonlyargs():
     i = inspector.info(f_kwarg, oname='f_kwarg')  # analysis:ignore
     nt.assert_equal(i['definition'], "f_kwarg(pos, *, kwonly)")

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -386,28 +386,18 @@ def _fixed_getinnerframes(etb, context=1, tb_offset=0):
 # can be recognized properly by ipython.el's py-traceback-line-re
 # (SyntaxErrors have to be treated specially because they have no traceback)
 
-_parser = PyColorize.Parser()
-
 
 def _format_traceback_lines(lnum, index, lines, Colors, lvals=None, scheme=None):
     numbers_width = INDENT_SIZE - 1
     res = []
     i = lnum - index
 
-    # This lets us get fully syntax-highlighted tracebacks.
-    if scheme is None:
-        ipinst = get_ipython()
-        if ipinst is not None:
-            scheme = ipinst.colors
-        else:
-            scheme = DEFAULT_SCHEME
-
-    _line_format = _parser.format2
+    _line_format = PyColorize.Parser(style=scheme).format2
 
     for line in lines:
         line = py3compat.cast_unicode(line)
 
-        new_line, err = _line_format(line, 'str', scheme)
+        new_line, err = _line_format(line, 'str')
         if not err: line = new_line
 
         if i == lnum:
@@ -1227,8 +1217,7 @@ class VerboseTB(TBTools):
 
         if force or self.call_pdb:
             if self.pdb is None:
-                self.pdb = self.debugger_cls(
-                    self.color_scheme_table.active_scheme_name)
+                self.pdb = self.debugger_cls()
             # the system displayhook may have changed, restore the original
             # for pdb
             display_trap = DisplayTrap(hook=sys.__displayhook__)

--- a/IPython/utils/colorable.py
+++ b/IPython/utils/colorable.py
@@ -22,5 +22,5 @@ class Colorable(Configurable):
     """
     A subclass of configurable for all the classes that have a `default_scheme`
     """
-    default_style=Unicode('lightbg').tag(config=True)
+    default_style=Unicode('LightBG').tag(config=True)
 

--- a/IPython/utils/tests/test_pycolorize.py
+++ b/IPython/utils/tests/test_pycolorize.py
@@ -49,28 +49,28 @@ class Bar(Super):
 
 def test_loop_colors():
 
-    for scheme in ('Linux', 'NoColor','LightBG', 'Neutral'):
+    for style in ('Linux', 'NoColor','LightBG', 'Neutral'):
 
         def test_unicode_colorize():
-            p = Parser()
-            f1 = p.format('1/0', 'str', scheme=scheme)
-            f2 = p.format(u'1/0', 'str', scheme=scheme)
+            p = Parser(style=style)
+            f1 = p.format('1/0', 'str')
+            f2 = p.format(u'1/0', 'str')
             nt.assert_equal(f1, f2)
 
         def test_parse_sample():
             """and test writing to a buffer"""
             buf = io.StringIO()
-            p = Parser()
-            p.format(sample, buf, scheme=scheme)
+            p = Parser(style=style)
+            p.format(sample, buf)
             buf.seek(0)
             f1 = buf.read()
 
             nt.assert_not_in('ERROR', f1)
 
         def test_parse_error():
-            p = Parser()
-            f1 = p.format(')', 'str', scheme=scheme)
-            if scheme != 'NoColor':
+            p = Parser(style=style)
+            f1 = p.format(')', 'str')
+            if style != 'NoColor':
                 nt.assert_in('ERROR', f1)
 
         yield test_unicode_colorize


### PR DESCRIPTION
This is one more step into getting rid of the old way of handling
colors in IPython, in particular here we move the scheme/style as a
configuration option of the parser instead of passing it around into the
formats functions.

Also remove our own usage of deprecated arguments.

That removes as well the IPython/utils/PyColorize.py standalone usage, drop a few "skip is not Py3" and a couple of Deprecation warning that were annoying me when testing locally.
