### PR TITLE
Add the option expand the toc in the sidebar.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,6 +39,10 @@ else:
     html_theme = "sphinx_rtd_theme"
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
+html_theme_options = {
+    'collapse_navigation': False,
+}
+
 # If your extensions are in another directory, add it here. If the directory
 # is relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.


### PR DESCRIPTION
This add small `[+]` before each of the entry in the toctree in the
sidebar that can be expanded.

---

cc @willingc, i suppose we might want that on all the repos ? 

![rtd](https://cloud.githubusercontent.com/assets/335567/19009163/d28ca0c0-8725-11e6-95cb-4401b3e67df5.gif)
