### PR TITLE
Only suggest a named argument once

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -916,7 +916,7 @@ class IPCompleter(Completer):
         # them again
         usedNamedArgs = set()
         par_level = -1
-        for token, next_token in itertools.izip(tokens, tokens[1:]):
+        for token, next_token in zip(tokens, tokens[1:]):
             if token == '(':
                 par_level += 1
             elif token == ')':


### PR DESCRIPTION
Added a check to the `python_func_kw_matches` completer to not show named arguments after they've been used in the function call.

So, for example, when writing:

``` python
def my_func(x=1, y=2, z=3):
    pass

my_func(x=1, y=2
```

The completer would suggest `z=`, but not `x=` or `y=`.
