### PR TITLE
Exclude numpy._globals from deepreload

### DIFF
--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -327,7 +327,8 @@ except AttributeError:
     original_reload = imp.reload    # Python 3
 
 # Replacement for reload()
-def reload(module, exclude=('sys', 'os.path', builtin_mod_name, '__main__')):
+def reload(module, exclude=('sys', 'os.path', builtin_mod_name, '__main__',
+                            'numpy._globals')):
     """Recursively reload all modules used in the given module.  Optionally
     takes a list of modules to exclude from reloading.  The default exclude
     list contains sys, __main__, and __builtin__, to prevent, e.g., resetting


### PR DESCRIPTION
Closes gh-9983, though not in a terribly satisfying way.
