### PR TITLE
Note additional packages for iptest to succeed

### DIFF
--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -107,6 +107,14 @@ the IPython source tree:
 
     $ iptest
 
+
+For the tests to succeed, you may also need to install :mod:`mock` and :mod:`gnureadline`:
+
+.. code-block:: bash
+
+    $ pip install mock gnureadline
+    
+
 .. _devinstall:
 
 Installing the development version


### PR DESCRIPTION
For a fresh install (e.g., new virtualenv) on python 2.7 (at least on OS X Sierra), you'll also need `mocks` and `gnureadline` in order for iptest to succeed.  Possibly this should be fixed via requirements for iptest, but until that happens, here's the documentation.

(And at the moment, the iptest for deep reloading of numpy fails too, but that's already addressed in https://github.com/ipython/ipython/issues/9983)
