### PR TITLE
Document automagic behaviour on unknown argument

### DIFF
--- a/IPython/core/magics/auto.py
+++ b/IPython/core/magics/auto.py
@@ -44,6 +44,8 @@ class AutoMagics(Magics):
 
          - off, 0, False: to deactivate.
 
+         - anything else: negate previous setting.
+
         Note that magic functions have lowest priority, so if there's a
         variable whose name collides with that of a magic fn, automagic won't
         work for that function (you get the variable instead). However, if you


### PR DESCRIPTION
Hey,

the `%automagic` command negates the previous setting if it is called with an argument that it does not understand. This behaviour, however, was previously undocumented. This PR addresses that.

Cheers
