### PR TITLE
Do not capture BdbQuit.

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -283,12 +283,6 @@ class Pdb(OldPdb, object):
         self.color_scheme_table.set_active_scheme(scheme)
         self.parser.style = scheme
 
-    def trace_dispatch(self, frame, event, arg):
-        try:
-            return super(Pdb, self).trace_dispatch(frame, event, arg)
-        except bdb.BdbQuit:
-            pass
-
     def interaction(self, frame, traceback):
         try:
             OldPdb.interaction(self, frame, traceback)

--- a/docs/source/whatsnew/version5.rst
+++ b/docs/source/whatsnew/version5.rst
@@ -2,6 +2,13 @@
  5.x Series
 ============
 
+
+IPython 5.2
+===========
+
+* restore IPython's debugger to raise on quit. :ghpull:`10009`
+
+
 IPython 5.1
 ===========
 


### PR DESCRIPTION
If one want to exit Pdb cleanly, it is possible to just use `continue`
(or `c`) that will keep up until a potential next invocation.

Quit is _meant_ to raise an error.

Closes #10006

---

Thanks @amueller for the report. Would that suit you ?
