### PR TITLE
use `import_module` instead of `__import__` 

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -26,6 +26,7 @@ import sys
 import unicodedata
 import string
 import warnings
+from importlib import import_module
 
 from traitlets.config.configurable import Configurable
 from IPython.core.error import TryNext
@@ -481,7 +482,7 @@ def _safe_isinstance(obj, module, class_name):
     """Checks if obj is an instance of module.class_name if loaded
     """
     return (module in sys.modules and
-            isinstance(obj, getattr(__import__(module), class_name)))
+            isinstance(obj, getattr(import_module(module), class_name)))
 
 
 def back_unicode_name_matches(text):

--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -22,6 +22,7 @@ import inspect
 import os
 import re
 import sys
+from importlib import import_module
 
 try:
     # Python >= 3.3
@@ -155,7 +156,7 @@ def is_importable(module, attr, only_modules):
 
 def try_import(mod, only_modules=False):
     try:
-        m = __import__(mod)
+        m = import_module(mod)
     except:
         return []
     mods = mod.split('.')

--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -159,9 +159,6 @@ def try_import(mod, only_modules=False):
         m = import_module(mod)
     except:
         return []
-    mods = mod.split('.')
-    for module in mods[1:]:
-        m = getattr(m, module)
 
     m_is_init = hasattr(m, '__file__') and '__init__' in m.__file__
 

--- a/IPython/core/extensions.py
+++ b/IPython/core/extensions.py
@@ -7,6 +7,7 @@
 import os
 from shutil import copyfile
 import sys
+from importlib import import_module
 
 from traitlets.config.configurable import Configurable
 from IPython.utils.path import ensure_dir_exists
@@ -80,7 +81,7 @@ class ExtensionManager(Configurable):
         with self.shell.builtin_trap:
             if module_str not in sys.modules:
                 with prepended_to_syspath(self.ipython_extension_dir):
-                    __import__(module_str)
+                    import_module(module_str)
             mod = sys.modules[module_str]
             if self._call_load_ipython_extension(mod):
                 self.loaded.add(module_str)

--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -112,6 +112,7 @@ import sys
 import traceback
 import types
 import weakref
+from importlib import import_module
 
 try:
     # Reload is not defined by default in Python3.
@@ -177,7 +178,7 @@ class ModuleReloader(object):
         """
         self.mark_module_reloadable(module_name)
 
-        __import__(module_name)
+        import_module(module_name)
         top_name = module_name.split('.')[0]
         top_module = sys.modules[top_name]
         return top_module, top_name

--- a/IPython/external/qt_loaders.py
+++ b/IPython/external/qt_loaders.py
@@ -11,6 +11,7 @@ be accessed directly from the outside
 import sys
 import types
 from functools import partial
+from importlib import import_module
 
 from IPython.utils.version import check_version
 
@@ -113,7 +114,7 @@ def has_binding(api):
     import imp
     try:
         #importing top level PyQt4/PySide module is ok...
-        mod = __import__(module_name)
+        mod = import_module(module_name)
         #...importing submodules is not
         imp.find_module('QtCore', mod.__path__)
         imp.find_module('QtGui', mod.__path__)

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -36,6 +36,7 @@ import os
 import tempfile
 import unittest
 import warnings
+from importlib import import_module
 
 from decorator import decorator
 
@@ -268,7 +269,7 @@ def module_not_available(module):
     available, but delay the 'import numpy' to test execution time.
     """
     try:
-        mod = __import__(module)
+        mod = import_module(module)
         mod_not_avail = False
     except ImportError:
         mod_not_avail = True

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -25,6 +25,7 @@ import logging
 import os
 import re
 import sys
+from importlib import import_module
 
 from testpath import modified_env
 
@@ -646,7 +647,7 @@ class ExtensionDoctest(doctests.Doctest):
         modname = os.path.splitext(mod)[0]
         try:
             sys.path.append(bpath)
-            module = __import__(modname)
+            module = import_module(modname)
             tests = list(self.loadTestsFromModule(module))
         finally:
             sys.path.pop()

--- a/IPython/utils/shimmodule.py
+++ b/IPython/utils/shimmodule.py
@@ -5,8 +5,10 @@
 
 import sys
 import types
+from importlib import import_module
 
 from .importstring import import_item
+
 
 class ShimWarning(Warning):
     """A warning to show when a module has moved, and a shim is in its place."""
@@ -69,15 +71,15 @@ class ShimModule(types.ModuleType):
     @property
     def __spec__(self):
         """Don't produce __spec__ until requested"""
-        return __import__(self._mirror).__spec__
+        return import_module(self._mirror).__spec__
     
     def __dir__(self):
-        return dir(__import__(self._mirror))
+        return dir(import_module(self._mirror))
     
     @property
     def __all__(self):
         """Ensure __all__ is always defined"""
-        mod = __import__(self._mirror)
+        mod = import_module(self._mirror)
         try:
             return mod.__all__
         except AttributeError:

--- a/docs/sphinxext/apigen.py
+++ b/docs/sphinxext/apigen.py
@@ -24,6 +24,8 @@ import ast
 import inspect
 import os
 import re
+from importlib import import_module
+
 
 class Obj(object):
     '''Namespace to hold arbitrary information.'''
@@ -147,7 +149,7 @@ class ApiDocWriter(object):
         '''
         # It's also possible to imagine caching the module parsing here
         self._package_name = package_name
-        self.root_module = __import__(package_name)
+        self.root_module = import_module(package_name)
         self.root_path = self.root_module.__path__[0]
         self.written_modules = None
 


### PR DESCRIPTION
FIX #10008

I think it's a pythonic way to dynamic import a module.
