### PR TITLE
Remove matplotlib requirement for building docs

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -4,7 +4,7 @@
   The IPython API
 ###################
 
-.. htmlonly::
+.. only:: html
 
    :Release: |version|
    :Date: |today|

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,12 +17,10 @@
 
 import sys, os
 
+# http://read-the-docs.readthedocs.io/en/latest/faq.html
 ON_RTD = os.environ.get('READTHEDOCS', None) == 'True'
 
 if ON_RTD:
-    # Mock the presence of matplotlib, which we don't have on RTD
-    # see
-    # http://read-the-docs.readthedocs.io/en/latest/faq.html
     tags.add('rtd')
 
     # RTD doesn't use the Makefile, so re-run autogen_{things}.py here.
@@ -68,9 +66,6 @@ extensions = [
 
 if ON_RTD:
     # Remove extensions not currently supported on RTD
-    extensions.remove('matplotlib.sphinxext.only_directives')
-    extensions.remove('matplotlib.sphinxext.mathmpl')
-    extensions.remove('matplotlib.sphinxext.plot_directive')
     extensions.remove('IPython.sphinxext.ipython_directive')
     extensions.remove('IPython.sphinxext.ipython_console_highlighting')
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,9 +54,6 @@ exec(compile(open('../../IPython/core/release.py').read(), '../../IPython/core/r
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    'matplotlib.sphinxext.mathmpl',
-    'matplotlib.sphinxext.only_directives',
-    'matplotlib.sphinxext.plot_directive',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.doctest',

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,7 +4,7 @@
 IPython Documentation
 =====================
 
-.. htmlonly::
+.. only:: html
 
    :Release: |release|
    :Date: |today|
@@ -104,7 +104,7 @@ repository <http://github.com/ipython/ipython>`_.
      Formerly ``IPython.parallel``.
 
 
-.. htmlonly::
+.. only:: html
    * :ref:`genindex`
    * :ref:`modindex`
    * :ref:`search`


### PR DESCRIPTION
See gh-10003

We weren't actually using most of these extensions, and the one we were using can be replaced by a standard Sphinx directive.
