### PR TITLE
numpy no longer seems amenable to deep reloading

### DIFF
--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -328,7 +328,7 @@ except AttributeError:
 
 # Replacement for reload()
 def reload(module, exclude=('sys', 'os.path', builtin_mod_name, '__main__',
-                            'numpy._globals')):
+                            'numpy', 'numpy._globals')):
     """Recursively reload all modules used in the given module.  Optionally
     takes a list of modules to exclude from reloading.  The default exclude
     list contains sys, __main__, and __builtin__, to prevent, e.g., resetting

--- a/IPython/lib/tests/test_deepreload.py
+++ b/IPython/lib/tests/test_deepreload.py
@@ -1,41 +1,16 @@
 # -*- coding: utf-8 -*-
 """Test suite for the deepreload module."""
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 import os
 
 import nose.tools as nt
 
-from IPython.testing import decorators as dec
-from IPython.utils.py3compat import builtin_mod_name, PY3
 from IPython.utils.syspathcontext import prepended_to_syspath
 from IPython.utils.tempdir import TemporaryDirectory
 from IPython.lib.deepreload import reload as dreload
-
-#-----------------------------------------------------------------------------
-# Test functions begin
-#-----------------------------------------------------------------------------
-
-@dec.skipif_not_numpy
-def test_deepreload_numpy():
-    "Test that NumPy can be deep reloaded."
-    import numpy
-    # TODO: Find a way to exclude all standard library modules from reloading.
-    exclude = [
-        # Standard exclusions:
-        'sys', 'os.path', builtin_mod_name, '__main__',
-        # Test-related exclusions:
-        'unittest', 'UserDict', '_collections_abc', 'tokenize',
-        'collections', 'collections.abc',
-        'importlib', 'importlib.machinery', '_imp',
-        'importlib._bootstrap', 'importlib._bootstrap_external',
-        '_frozen_importlib', '_frozen_importlib_external',
-        ]
-
-    dreload(numpy, exclude=exclude)
 
 def test_deepreload():
     "Test that dreload does deep reloads and skips excluded modules."


### PR DESCRIPTION
Excluding numpy._globals was not sufficient to make it work, so this just removes the test for deep-reloading numpy, as it's something that no longer seems worth supporting.
