### PR TITLE
Fix running %run -d twice

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -816,6 +816,11 @@ python-profiler package from non-free.""")
             self.shell.InteractiveTB.pdb = self.shell.InteractiveTB.debugger_cls()
             deb = self.shell.InteractiveTB.pdb
 
+        # deb.checkline() fails if deb.curframe exists but is None; it can
+        # handle it not existing. https://github.com/ipython/ipython/issues/10028
+        if hasattr(deb, 'curframe'):
+            del deb.curframe
+
         # reset Breakpoint state, which is moronically kept
         # in a class
         bdb.Breakpoint.next = 1

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -207,8 +207,15 @@ class TestMagicRunPass(tt.TempFileMixin):
     def test_run_profile( self ):
         """Test that the option -p, which invokes the profiler, do not
         crash by invoking execfile"""
-        get_ipython()
         self.run_tmpfile_p()
+
+    def test_run_debug_twice(self):
+        # https://github.com/ipython/ipython/issues/10028
+        _ip = get_ipython()
+        with tt.fake_input(['c']):
+            _ip.magic('run -d %s' % self.fname)
+        with tt.fake_input(['c']):
+            _ip.magic('run -d %s' % self.fname)
 
 
 class TestMagicRunSimple(tt.TempFileMixin):

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -6,16 +6,8 @@ Authors
 """
 
 
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2009 The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 import os
 import re
@@ -25,6 +17,7 @@ import tempfile
 from contextlib import contextmanager
 from io import StringIO
 from subprocess import Popen, PIPE
+from unittest.mock import patch
 
 try:
     # These tools are used by parts of the runtime, so we make the nose
@@ -45,9 +38,6 @@ from IPython.utils.encoding import DEFAULT_ENCODING
 from . import decorators as dec
 from . import skipdoctest
 
-#-----------------------------------------------------------------------------
-# Functions and classes
-#-----------------------------------------------------------------------------
 
 # The docstring for full_path doctests differently on win32 (different path
 # separator) so just skip the doctest there.  The example remains informative.
@@ -443,6 +433,25 @@ def make_tempfile(name):
     finally:
         os.unlink(name)
 
+def fake_input(inputs):
+    """Temporarily replace the input() function to return the given values
+
+    Use as a context manager:
+
+    with fake_input(['result1', 'result2']):
+        ...
+
+    Values are returned in order. If input() is called again after the last value
+    was used, EOFError is raised.
+    """
+    it = iter(inputs)
+    def mock_input(prompt=''):
+        try:
+            return next(it)
+        except StopIteration:
+            raise EOFError('No more inputs given')
+
+    return patch('builtins.input', mock_input)
 
 def help_output_test(subcommand=''):
     """test that `ipython [subcommand] -h` works"""


### PR DESCRIPTION
I suspect this is a bug in pdb; I'll try to get it fixed there too, but deleting `deb.curframe` seems to work around the issue.

Closes #10028 .
