### PR TITLE
For upgrades of packages during testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
 install:
-    - pip install "setuptools>=18.5"
-    - pip install -f travis-wheels/wheelhouse -e file://$PWD#egg=ipython[test]
-    - pip install codecov
+    - pip install "setuptools>=18.5" --upgrade
+    - pip install -f travis-wheels/wheelhouse -e file://$PWD#egg=ipython[test] --upgrade
+    - pip install codecov --upgrade
 script:
     - cd /tmp && iptest --coverage xml && cd -
 after_success:


### PR DESCRIPTION
Otherwise we will catch regression upstream too late.
Drawback is that we might not catch usage of extremely recent API.
