### PR TITLE
override the emptyline method

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -307,6 +307,14 @@ class Pdb(OldPdb, object):
             return super(Pdb, self).parseline("!" + line)
         return super(Pdb, self).parseline(line)
 
+    def emptyline(self):
+        # Fix for #9449: If the commands are conflicted with the variable,
+        # such as `n` command and `n` variable, then the emptyline behavior as
+        # `!n` which print the value of variable, it performs not as we usually
+        # expect. Just add the "!!" prefix force standard behavior.
+        if self.lastcmd:
+            return self.onecmd("!!" + self.lastcmd)
+
     def new_do_up(self, arg):
         OldPdb.do_up(self, arg)
     do_u = do_up = decorate_fn_with_doc(new_do_up, OldPdb.do_up)


### PR DESCRIPTION
# What's the problem

When the command name is conflicted with variable name, the behavior of `emptyline` is print the value of the variable even the variable is not `lastcmd`. 

```
> /home/v-zit/test.py(1)<module>()
----> 1 n = 1
      2 next = 11
      3 print('end')

ipdb> n
> /home/v-zit/test.py(2)<module>()
      1 n = 1
----> 2 next = 11
      3 print('end')

ipdb>
1
ipdb>
```
# What did I do

I override the default `emptyline` method, which come from `cmd` module and not be called neither `pdb` nor `ipython`. As #9449, always add the "!!" prefix to force the standard behavior.
