### PR TITLE
restore tab completion behavior

### DIFF
--- a/IPython/utils/dir2.py
+++ b/IPython/utils/dir2.py
@@ -41,6 +41,9 @@ def dir2(obj):
         # TypeError: dir(obj) does not return a list
         words = set()
 
+    if safe_hasattr(obj, '__class__'):
+        words |= set(dir(obj.__class__))
+
     # filter out non-string attributes which may be stuffed by dir() calls
     # and poor coding in third-party modules
 


### PR DESCRIPTION
this is a minimal patch to restore proper tab completion behavior, a
partial revert of #8355. I think avoiding the explicit poking into the
__bases__ classes address the concerns #8330.

This is a minimal patch that closes #10044, #9381, and partially addresses #9606.

It is a bug that IPython tab-completion does not provide a superset of the
completions provided by the built-in `rlcompleter` module in Python.

I'll put up another alternative version that reverts #8355 as an alternative to this patch.