### PR TITLE
restore more tab completion behavior

### DIFF
--- a/IPython/utils/dir2.py
+++ b/IPython/utils/dir2.py
@@ -19,6 +19,18 @@ def safe_hasattr(obj, attr):
     except:
         return False
 
+def get_class_members(cls):
+    ret = dir(cls)
+    if safe_hasattr(cls, '__bases__'):
+        try:
+            bases = cls.__bases__
+        except AttributeError:
+            # `obj` lied claiming to have __bases__ attr, ignore
+            pass
+        else:
+            for base in bases:
+                ret.extend(get_class_members(base))
+    return ret
 
 def dir2(obj):
     """dir2(obj) -> list of strings
@@ -40,6 +52,9 @@ def dir2(obj):
     except Exception:
         # TypeError: dir(obj) does not return a list
         words = set()
+
+    if safe_hasattr(obj, '__class__'):
+        words |= set(get_class_members(obj.__class__))
 
     # filter out non-string attributes which may be stuffed by dir() calls
     # and poor coding in third-party modules


### PR DESCRIPTION
An alternative to #10046, which closes #10044, #9381, and partially adresses #9606.

This is a complete revert of #8355, which resolved #8330, but instead
lead to completions not matching the set provided by standard libarary's
`rlcompleter`, which is in conflict with the behavior reported in #8330.