### PR TITLE
include docstring in detail_level=1 if no source is found

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -645,7 +645,7 @@ class Inspector(Colorable):
             # Functions, methods, classes
             append_field(_mime, 'Signature', 'definition', code_formatter)
             append_field(_mime, 'Init signature', 'init_definition', code_formatter)
-            if detail_level > 0:
+            if detail_level > 0 and info['source']:
                 append_field(_mime, 'Source', 'source', code_formatter)
             else:
                 append_field(_mime, 'Docstring', 'docstring', formatter)


### PR DESCRIPTION
We currently display source for ?? and docstring for ?, which means less info is displayed if no source is found (e.g. compiled functions).

This displays docstring for ?? as a fallback when no source is found.

This is a regression in 5.x

cc @pefarrell who reported the bug