### PR TITLE
Add `pexpect` to  install_requires list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -205,6 +205,7 @@ install_requires = [
     'traitlets>=4.2',
     'prompt_toolkit>=1.0.3,<2.0.0',
     'pygments',
+    'pexpect'
 ]
 
 # Platform-specific dependencies:


### PR DESCRIPTION
`pexpect` package has been used here - https://github.com/ipython/ipython/blob/master/IPython/utils/_process_posix.py#L23