### PR TITLE
Set all QT4 SIP APIs

### DIFF
--- a/IPython/external/qt_loaders.py
+++ b/IPython/external/qt_loaders.py
@@ -168,14 +168,21 @@ def import_pyqt4(version=2):
     Parameters
     ----------
     version : 1, 2, or None
-      Which QString/QVariant API to use. Set to None to use the system
-      default
+      Which QT API to use. Set to None to use the system default.
+      The following APIs will be set using SIP:
+
+          QDate
+          QDateTime
+          QString
+          QTextStream
+          QTime
+          QUrl
+          QVariant
 
     ImportErrors rasied within this function are non-recoverable
     """
     # The new-style string API (version=2) automatically
-    # converts QStrings to Unicode Python strings. Also, automatically unpacks
-    # QVariants to their underlying objects.
+    # converts QStrings to Unicode Python strings.
     import sip
 
     if version is not None:
@@ -185,6 +192,7 @@ def import_pyqt4(version=2):
         sip.setapi('QTextStream', version)
         sip.setapi('QTime', version)
         sip.setapi('QUrl', version)
+        sip.setapi('QVariant', version)
 
     from PyQt4 import QtGui, QtCore, QtSvg
 

--- a/IPython/external/qt_loaders.py
+++ b/IPython/external/qt_loaders.py
@@ -179,8 +179,12 @@ def import_pyqt4(version=2):
     import sip
 
     if version is not None:
+        sip.setapi('QDate', version)
+        sip.setapi('QDateTime', version)
         sip.setapi('QString', version)
-        sip.setapi('QVariant', version)
+        sip.setapi('QTextStream', version)
+        sip.setapi('QTime', version)
+        sip.setapi('QUrl', version)
 
     from PyQt4 import QtGui, QtCore, QtSvg
 


### PR DESCRIPTION
After QT is imported the SIP API functions can no longer be
called to set the QT API. This change ensures that all of
the APIs are either set to 1 or 2 so that other packages
that may be imported after this function have a consistent
interface. This is consistent with other packages such as
pyside and is particularly relevant for IPython as the
%matplotlib magic means that one of the first set of imports
made in an IPython session is often from the %matplotlib
magic.

For example:
```
%matplotlib qt
from pyface.qt import QtGui, QtCore
```
fails without this change as only some of the required APIs have been set to version 2.