### PR TITLE
Finish up Deprecation of `IPython.core.oinspect.py:call_tip`

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -236,8 +236,8 @@ def format_argspec(argspec):
 def call_tip(oinfo, format_call=True):
     """DEPRECATED. Extract call tip data from an oinfo dict.
     """
-    warnings.warn('`call_tip` function is deprecated as of IPython 5.2 '
-                  'and will have no effects.', DeprecationWarning, stacklevel=2)
+    warnings.warn('`call_tip` function is deprecated as of IPython 6.0'
+                  'and will remove in future versions.', DeprecationWarning, stacklevel=2)
     # Get call definition
     argspec = oinfo.get('argspec')
     if argspec is None:

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -237,7 +237,7 @@ def call_tip(oinfo, format_call=True):
     """DEPRECATED. Extract call tip data from an oinfo dict.
     """
     warnings.warn('`call_tip` function is deprecated as of IPython 6.0'
-                  'and will remove in future versions.', DeprecationWarning, stacklevel=2)
+                  'and will be removed in future versions.', DeprecationWarning, stacklevel=2)
     # Get call definition
     argspec = oinfo.get('argspec')
     if argspec is None:

--- a/docs/source/whatsnew/pr/deprecate-calltip.rst
+++ b/docs/source/whatsnew/pr/deprecate-calltip.rst
@@ -1,0 +1,3 @@
+- The function `IPython.core.oinspect.py:call_tip` is unused, was marked as
+  Deprecated (raising a Deprecation Warning) and marked for later removal
+  :ghpull:`10104`


### PR DESCRIPTION
Mainly fix version number since Deprecation, remove the incorrect fact that it will have no effects, and add a What's new to list the deprecation. 