### PR TITLE
fixed import issue in case of installing via pip in user directory

### DIFF
--- a/IPython/utils/terminal.py
+++ b/IPython/utils/terminal.py
@@ -18,8 +18,12 @@ import warnings
 try:
     from shutil import get_terminal_size as _get_terminal_size
 except ImportError:
-    # use backport on Python 2
-    from backports.shutil_get_terminal_size import get_terminal_size as _get_terminal_size
+    try:
+        # use backport on Python 2
+        from backports.shutil_get_terminal_size import get_terminal_size as _get_terminal_size
+    except ImportError:
+        # ubuntu 16.04, python2.7, latest ipython installed in user directory via pip
+        from shutil_backports import get_terminal_size as _get_terminal_size
 
 from . import py3compat
 


### PR DESCRIPTION
Machine info:
```
$ python -c "import IPython; print(IPython.sys_info())"
{'commit_hash': u'5c9c918',
 'commit_source': 'installation',
 'default_encoding': 'UTF-8',
 'ipython_path': '/home/oleg/.local/lib/python2.7/site-packages/IPython',
 'ipython_version': '5.1.0',
 'os_name': 'posix',
 'platform': 'Linux-4.4.0-57-generic-x86_64-with-Ubuntu-16.04-xenial',
 'sys_executable': '/usr/bin/python',
 'sys_platform': 'linux2',
 'sys_version': '2.7.12 (default, Nov 19 2016, 06:48:10) \n[GCC 5.4.0 20160609]'}
```
Reproduction scenario:
```
sudo apt install ipython
# hmm, wait it's 2.4.11 verison, 5.1.0 way more cool!
pip install --user --upgrade ipython
ipython
...
ImportError: No module named shutil_get_terminal_size
```

I don't know if this code clean or good enough, I just make it work on my machine and thought that it will be useful for other ubuntu users.

I didn't want to broke something, because I didn't tested this code somewhere else (only ubuntu 16.04) and added one more try/except block instead of import replacement.