### PR TITLE
Remove uses of with_metaclass compatibility hack

### DIFF
--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -28,9 +28,6 @@ from traitlets import (
     ForwardDeclaredInstance,
     default, observe,
 )
-from IPython.utils.py3compat import (
-    with_metaclass
-)
 
 
 class DisplayFormatter(Configurable):
@@ -202,7 +199,7 @@ def catch_format_error(method, self, *args, **kwargs):
     return self._check_return(r, args[0])
 
 
-class FormatterABC(with_metaclass(abc.ABCMeta, object)):
+class FormatterABC(metaclass=abc.ABCMeta):
     """ Abstract base class for Formatters.
 
     A formatter is a callable class that is responsible for computing the

--- a/IPython/core/inputtransformer.py
+++ b/IPython/core/inputtransformer.py
@@ -9,7 +9,7 @@ import re
 
 from IPython.core.splitinput import LineInfo
 from IPython.utils import tokenize2
-from IPython.utils.py3compat import with_metaclass, PY3
+from IPython.utils.py3compat import PY3
 from IPython.utils.tokenize2 import generate_tokens, untokenize, TokenError
 
 if PY3:
@@ -42,7 +42,7 @@ ESC_SEQUENCES = [ESC_SHELL, ESC_SH_CAP, ESC_HELP ,\
                  ESC_QUOTE, ESC_QUOTE2, ESC_PAREN ]
 
 
-class InputTransformer(with_metaclass(abc.ABCMeta, object)):
+class InputTransformer(metaclass=abc.ABCMeta):
     """Abstract base class for line-based input transformers."""
     
     @abc.abstractmethod

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -67,7 +67,7 @@ from IPython.utils.ipstruct import Struct
 from IPython.paths import get_ipython_dir
 from IPython.utils.path import get_home_dir, get_py_filename, ensure_dir_exists
 from IPython.utils.process import system, getoutput
-from IPython.utils.py3compat import builtin_mod, with_metaclass
+from IPython.utils.py3compat import builtin_mod
 from IPython.utils.strdispatch import StrDispatch
 from IPython.utils.syspathcontext import prepended_to_syspath
 from IPython.utils.text import format_screen, LSString, SList, DollarFormatter
@@ -3217,7 +3217,7 @@ class InteractiveShell(SingletonConfigurable):
         pass
 
 
-class InteractiveShellABC(with_metaclass(abc.ABCMeta, object)):
+class InteractiveShellABC(metaclass=abc.ABCMeta):
     """An abstract base class for InteractiveShell."""
 
 InteractiveShellABC.register(InteractiveShell)


### PR DESCRIPTION
Now we can do it the Python 3 way.