### PR TITLE
Add 3.6 version target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 language: python
 python:
     - "nightly"
+    - 3.6
     - 3.5
     - 3.4
     - 3.3


### PR DESCRIPTION
Now that python 3.6  is released, I want to execute the test suite as on 3.6 as well and also nightly build points 3.7.0a  now. 