### PR TITLE
Deprecate CUnicodeIO

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -86,6 +86,7 @@ from collections import deque
 from io import StringIO
 from warnings import warn
 
+from IPython.utils.decorators import undoc
 from IPython.utils.py3compat import PYPY, cast_unicode
 from IPython.utils.encoding import get_stream_enc
 
@@ -108,6 +109,7 @@ def _safe_getattr(obj, attr, default=None):
     except Exception:
         return default
 
+@undoc
 class CUnicodeIO(StringIO):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -84,6 +84,7 @@ import re
 import datetime
 from collections import deque
 from io import StringIO
+from warnings import warn
 
 from IPython.utils.py3compat import PYPY, cast_unicode
 from IPython.utils.encoding import get_stream_enc
@@ -107,7 +108,12 @@ def _safe_getattr(obj, attr, default=None):
     except Exception:
         return default
 
-CUnicodeIO = StringIO
+class CUnicodeIO(StringIO):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        warn(("CUnicodeIO is deprecated since IPython 6.0. "
+              "Please use io.StringIO instead."),
+             DeprecationWarning, stacklevel=2)
 
 def pretty(obj, verbose=False, max_width=79, newline='\n', max_seq_length=MAX_SEQ_LENGTH):
     """


### PR DESCRIPTION
I don't see any usage of it, but it's easy enough to deprecate it for a cycle just in case.

Closes gh-10140