### PR TITLE
Prevent pygments loading pkg_resources for faster startup

### DIFF
--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -40,6 +40,10 @@ See IPython `README.rst` file for more information:
 
 """)
 
+# Monkeypatch pygments.plugin to avoid loading pkg_resources, which is slow.
+from . import pygments_plugin
+sys.modules['pygments.plugin'] = pygments_plugin
+
 # Make it easy to import extensions - they are always directly on pythonpath.
 # Therefore, non-IPython modules can be added to extensions directory.
 # This should probably be in ipapp.py.

--- a/IPython/pygments_plugin.py
+++ b/IPython/pygments_plugin.py
@@ -1,0 +1,70 @@
+"""
+Modified copy of pygments.plugin; doesn't load pkg_resources until its functions
+are called.
+
+    pygments.plugin
+    ~~~~~~~~~~~~~~~
+
+    Pygments setuptools plugin interface. The methods defined
+    here also work if setuptools isn't installed but they just
+    return nothing.
+
+    lexer plugins::
+
+        [pygments.lexers]
+        yourlexer = yourmodule:YourLexer
+
+    formatter plugins::
+
+        [pygments.formatters]
+        yourformatter = yourformatter:YourFormatter
+        /.ext = yourformatter:YourFormatter
+
+    As you can see, you can define extensions for the formatter
+    with a leading slash.
+
+    syntax plugins::
+
+        [pygments.styles]
+        yourstyle = yourstyle:YourStyle
+
+    filter plugin::
+
+        [pygments.filter]
+        yourfilter = yourfilter:YourFilter
+
+
+    :copyright: Copyright 2006-2015 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+LEXER_ENTRY_POINT = 'pygments.lexers'
+FORMATTER_ENTRY_POINT = 'pygments.formatters'
+STYLE_ENTRY_POINT = 'pygments.styles'
+FILTER_ENTRY_POINT = 'pygments.filters'
+
+def iter_entry_points(group_name):
+    try:
+        import pkg_resources
+    except ImportError:
+        return []
+
+    return pkg_resources.iter_entry_points(group_name)
+
+def find_plugin_lexers():
+    for entrypoint in iter_entry_points(LEXER_ENTRY_POINT):
+        yield entrypoint.load()
+
+
+def find_plugin_formatters():
+    for entrypoint in iter_entry_points(FORMATTER_ENTRY_POINT):
+        yield entrypoint.name, entrypoint.load()
+
+
+def find_plugin_styles():
+    for entrypoint in iter_entry_points(STYLE_ENTRY_POINT):
+        yield entrypoint.name, entrypoint.load()
+
+
+def find_plugin_filters():
+    for entrypoint in iter_entry_points(FILTER_ENTRY_POINT):
+        yield entrypoint.name, entrypoint.load()

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -21,7 +21,7 @@ from prompt_toolkit.key_binding.manager import KeyBindingManager
 from prompt_toolkit.layout.processors import ConditionalProcessor, HighlightMatchingBracketProcessor
 from prompt_toolkit.styles import PygmentsStyle, DynamicStyle
 
-from pygments.styles import get_style_by_name, get_all_styles
+from pygments.styles import get_style_by_name, STYLE_MAP
 from pygments.style import Style
 from pygments.token import Token
 
@@ -131,7 +131,7 @@ class TerminalInteractiveShell(InteractiveShell):
 
     highlighting_style = Union([Unicode('legacy'), Type(klass=Style)],
         help="""The name or class of a Pygments style to use for syntax
-        highlighting: \n %s""" % ', '.join(get_all_styles())
+        highlighting: \n %s (+ any styles from plugins)""" % ', '.join(STYLE_MAP)
     ).tag(config=True)
 
 


### PR DESCRIPTION
Following discussion on #9908, this avoids loading pkg_resources when IPython starts, making it faster to start.

How much faster? The timings vary quite a bit, but at a conservative estimate I see a drop from 7-8s cold start time to 5-6s, so ~25% saved. Here's how to test cold-start time on Linux:

```
sync ; echo 3 | sudo tee /proc/sys/vm/drop_caches; time ipython -c pass
```

This is an alternative to doing it with lazyasd (discussed on #9908). I looked into the code for that, but I was reminded of the maxim that debugging is harder than writing code, so if you write the cleverest code you can, you're not smart enough to debug it. I don't want to end up debugging lazy-loading module issues.

The downside of this is that I'm copying part of the API of pygments; if that API changes, things using it might be broken until we copy the changes. However, pygments development seems to be [slow](https://bitbucket.org/birkenfeld/pygments-main/commits/all), so for the moment this does not seem like a significant risk. I would submit this change to pygments itself, but as even my tiny bugfix PR has had no attention in months, so it seems unlikely that it will go anywhere.