### PR TITLE
Always run the OS X loop even if no windows.

### DIFF
--- a/IPython/terminal/pt_inputhooks/osx.py
+++ b/IPython/terminal/pt_inputhooks/osx.py
@@ -127,12 +127,6 @@ def _stop_on_read(fd):
 def inputhook(context):
     """Inputhook for Cocoa (NSApp)"""
     NSApp = _NSApp()
-    window_count = msg(
-        msg(NSApp, n('windows')),
-        n('count')
-    )
-    if not window_count:
-        return
     _stop_on_read(context.fileno())
     msg(NSApp, n('run'))
     if not _triggered.is_set():


### PR DESCRIPTION
Otherwise this can trigger infinite Python-Icon-In-Dock bouncing.
See #10137. I will guess that this is because application on OS X may
not have windows and still need to process events.

It may be that an alternative is to run the loop only once the first
time, but I'm unsure.

---- 

Ping @minrk : I have no clue what I am doing. 