### PR TITLE
Document highlight_style takes class.

### DIFF
--- a/docs/source/whatsnew/pr/highlight-pygments.rst
+++ b/docs/source/whatsnew/pr/highlight-pygments.rst
@@ -1,0 +1,3 @@
+The configuration value ``TerminalInteractiveShell.highlighting_style`` can now
+directly take a class argument for custom color style.
+


### PR DESCRIPTION
Closes #9901

Should backport to 5.x