### PR TITLE
Don't fail when completing modules ending with dot.

### DIFF
--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -152,7 +152,12 @@ def is_importable(module, attr, only_modules):
     else:
         return not(attr[:2] == '__' and attr[-2:] == '__')
 
-def try_import(mod, only_modules=False):
+
+def try_import(mod: str, only_modules=False):
+    """
+    Try to import given module and return list of potential completions.
+    """
+    mod = mod.rstrip('.')
     try:
         m = import_module(mod)
     except:

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -712,6 +712,14 @@ def test_object_key_completion():
     nt.assert_in('qwick', matches)
 
 
+def test_tryimport():
+    """
+    Test that try-import don't crash on trailing dot, and import modules before
+    """
+    from IPython.core.completerlib import try_import
+    assert(try_import("IPython."))
+
+
 def test_aimport_module_completer():
     ip = get_ipython()
     _, matches = ip.complete('i', '%aimport i')


### PR DESCRIPTION
Mitigate #10170 don't considered as a fix as it does not populate the
completion, just prevent crash.

I'll submit a similar PR to 5.x so this is _mostly_ to now have a change of behavior in try_import between 5.2+ and 6.x