### PR TITLE
Don't fail when completing modules ending with dot.

### DIFF
--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -159,6 +159,7 @@ def is_importable(module, attr, only_modules):
         return not(attr[:2] == '__' and attr[-2:] == '__')
 
 def try_import(mod, only_modules=False):
+    mod = mod.rstrip('.')
     try:
         m = __import__(mod)
     except:

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -780,6 +780,13 @@ def test_object_key_completion():
     nt.assert_in('qwerty', matches)
     nt.assert_in('qwick', matches)
 
+def test_tryimport():
+    """
+    Test that try-import don't crash on trailing dot, and import modules before
+    """
+    from IPython.core.completerlib import try_import
+    assert(try_import("IPython."))
+
 
 def test_aimport_module_completer():
     ip = get_ipython()


### PR DESCRIPTION
Mitigate #10170 don't considered as a fix as it does not populate the
completion, just prevent crash.

 Consider as a Backport of #10180