### PR TITLE
Put savefig images back in source directory

### DIFF
--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -126,6 +126,7 @@ Authors
 
 # Stdlib
 import atexit
+import errno
 import os
 import re
 import sys
@@ -358,9 +359,9 @@ class EmbeddedSphinxShell(object):
         source_dir = self.source_dir
         saveargs = decorator.split(' ')
         filename = saveargs[1]
-        # insert relative path to image file in source
-        outfile = os.path.relpath(os.path.join(savefig_dir,filename),
-                    source_dir)
+        # insert relative path to image file in source (as absolute path for Sphinx)
+        outfile = '/' + os.path.relpath(os.path.join(savefig_dir,filename),
+                                        source_dir)
 
         imagerows = ['.. image:: %s'%outfile]
 
@@ -842,14 +843,9 @@ class IPythonDirective(Directive):
         config = self.state.document.settings.env.config
 
         # get config variables to set figure output directory
-        outdir = self.state.document.settings.env.app.outdir
         savefig_dir = config.ipython_savefig_dir
-        source_dir = os.path.dirname(self.state.document.current_source)
-        if savefig_dir is None:
-            savefig_dir = config.html_static_path or '_static'
-        if isinstance(savefig_dir, list):
-            savefig_dir = os.path.join(*savefig_dir)
-        savefig_dir = os.path.join(outdir, savefig_dir)
+        source_dir = self.state.document.settings.env.srcdir
+        savefig_dir = os.path.join(source_dir, savefig_dir)
 
         # get regex and prompt stuff
         rgxin      = config.ipython_rgxin
@@ -867,6 +863,12 @@ class IPythonDirective(Directive):
         # Get configuration values.
         (savefig_dir, source_dir, rgxin, rgxout, promptin, promptout,
          mplbackend, exec_lines, hold_count) = self.get_config_options()
+
+        try:
+            os.makedirs(savefig_dir)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
 
         if self.shell is None:
             # We will be here many times.  However, when the
@@ -976,7 +978,7 @@ def setup(app):
     setup.app = app
 
     app.add_directive('ipython', IPythonDirective)
-    app.add_config_value('ipython_savefig_dir', None, 'env')
+    app.add_config_value('ipython_savefig_dir', 'savefig', 'env')
     app.add_config_value('ipython_rgxin',
                          re.compile('In \[(\d+)\]:\s?(.*)\s*'), 'env')
     app.add_config_value('ipython_rgxout',


### PR DESCRIPTION
Simplifying the logic a bit.

I think there was an issue with the way we were finding the source directory: when it included a docstring from code, the source directory was that of the code. This always uses the main source directory of the docs.

Closes gh-8733