### PR TITLE
Reduce the number of test on Appveyor.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,18 +4,6 @@ matrix:
 
 environment:
   matrix:
-   - PYTHON: "C:\\Python33"
-     PYTHON_VERSION: "3.3.x"
-     PYTHON_ARCH: "32"
-
-   - PYTHON: "C:\\Python34"
-     PYTHON_VERSION: "3.4.x"
-     PYTHON_ARCH: "32"
-
-   - PYTHON: "C:\\Python35"
-     PYTHON_VERSION: "3.5.x"
-     PYTHON_ARCH: "32"
-
    - PYTHON: "C:\\Python36"
      PYTHON_VERSION: "3.6.x"
      PYTHON_ARCH: "32"


### PR DESCRIPTION
Appveyor is way slower than Travis, in part because we test on more
architecture. In particular 32 and 64 bits. And accumulate delay
sometime leading to 30 min between travis success and AppVeyor response.

32 Bits OSes are starting to be rare (or not our target, like tablets).
Less that 1/5 market share is some survey, and account for more than 2/3 of our
testing time.

So slash 3 out of 4 testing on 32 bits. Test only python 3.6 32 bits.
(I know that's paradoxal are mostly old system are 32 bits... but do we
expect people with old system and old python to use new IPython ?)

For example:
```
Windows         Arch    Share
Windows 10    64 bit    36.97%
Windows 7     64 bit    32.99%
Windows 8.1   64 bit    12.93%
Windows 8     64 bit    1.64%
Windows Vista 64 bit    0.13%
Windows 7     32 bit    6.97%
Windows XP    32 bit    2.00%
Windows 10    32 bit    1.31%
Windows 8.1   32 bit    0.34%
Windows Vista 32 bit    0.24%
Windows 8     32 bit    0.15%
```
Total about 83ish % of 64 bits.

Source:
http://www.digitaltrends.com/computing/steam-users-windows-10-market-share/
and http://store.steampowered.com/hwsurvey?platform=pc