### PR TITLE
Better support for KeyboardInterrupt during prompt (continued)

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -429,6 +429,7 @@ class TerminalInteractiveShell(InteractiveShell):
                 break
             except KeyboardInterrupt as e:
                 print("\n%s escaped interact()\n" % type(e).__name__)
+            finally:
                 # An interrupt during the eventloop will mess up the
                 # internal state of the prompt_toolkit library.
                 # Stopping the eventloop fixes this, see

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -427,8 +427,14 @@ class TerminalInteractiveShell(InteractiveShell):
             try:
                 self.interact()
                 break
-            except KeyboardInterrupt:
-                print("\nKeyboardInterrupt escaped interact()\n")
+            except KeyboardInterrupt as e:
+                print("\n%s escaped interact()\n" % type(e).__name__)
+                # An interrupt during the eventloop will mess up the
+                # internal state of the prompt_toolkit library.
+                # Stopping the eventloop fixes this, see
+                # https://github.com/ipython/ipython/pull/9867
+                if hasattr(self, '_eventloop'):
+                    self._eventloop.stop()
 
     _inputhook = None
     def inputhook(self, context):


### PR DESCRIPTION
Continuation of #9867, incorporating Jonathan's suggestion to use a finally block.