### PR TITLE
Cut more appveyor tests.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,14 +12,6 @@ environment:
      PYTHON_VERSION: "3.3.x"
      PYTHON_ARCH: "64"
 
-   - PYTHON: "C:\\Python34-x64"
-     PYTHON_VERSION: "3.4.x"
-     PYTHON_ARCH: "64"
-
-   - PYTHON: "C:\\Python35-x64"
-     PYTHON_VERSION: "3.5.x"
-     PYTHON_ARCH: "64"
-
    - PYTHON: "C:\\Python36-x64"
      PYTHON_VERSION: "3.6.x"
      PYTHON_ARCH: "64"


### PR DESCRIPTION
The sequential nature of Appveyor still make it way slower than Travis.
I'm thus proposing cutting 3.4 and 3.5 from the 64bit section. We thus
still test on older and newer Pythons which have the most chance of
catching bugs as 3.3 will fail if we use a non-existing yet feature and
3.6 fail on deprecated behaviors.