### PR TITLE
Get GitHub stats since 5.1.0, and deduplicate mails in .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -105,6 +105,7 @@ Omar Andrés Zapata Mesa <andresete.chaos@gmail.com> Omar Andres Zapata Mesa <om
 Pankaj Pandey <pankaj86@gmail.com> Pankaj Pandey <pankaj@enthought.com>
 Pascal Schetelat <pascal.schetelat@gmail.com> pascal-schetelat <pascal.schetelat@gmail.com>
 Paul Ivanov <pi@berkeley.edu> Paul Ivanov <pivanov314@gmail.com>
+Paul Ivanov <pi@berkeley.edu> Paul Ivanov <pivanov5@bloomberg.net>
 Pauli Virtanen <pauli.virtanen@iki.fi> Pauli Virtanen <>
 Pauli Virtanen <pauli.virtanen@iki.fi> Pauli Virtanen <pav@iki.fi>
 Pierre Gerold <pierre.gerold@laposte.net> Pierre Gerold <gerold@crans.org>
@@ -128,8 +129,10 @@ S. Weber <s8weber@c4.usr.sh> s8weber <s8weber@c5.usr.sh>
 Stefan van der Walt <stefan@sun.ac.za> Stefan van der Walt <bzr@mentat.za.net>
 Silvia Vinyes <silvia.vinyes@gmail.com> Silvia <silvia@silvia-U44SG.(none)>
 Silvia Vinyes <silvia.vinyes@gmail.com> silviav12 <silvia.vinyes@gmail.com>
+Srinivas Reddy Thatiparthy <thatiparthysreenivas@gmail.com> Srinivas Reddy Thatiparthy <srinivasreddy@users.noreply.github.com>
 Sylvain Corlay <scorlay@bloomberg.net> <sylvain.corlay@gmail.com>
 Sylvain Corlay <scorlay@bloomberg.net> sylvain.corlay <sylvain.corlay@gmail.com>
+Tamir Bahar <tamir@north-bit.com> Tamir Bahar <tmr232@users.noreply.github.com>
 Ted Drain <ted.drain@gmail.com> TD22057 <ted.drain@gmail.com>
 Théophile Studer <theo.studer@gmail.com> Théophile Studer <studer@users.noreply.github.com>
 Thomas A Caswell <tcaswell@gmail.com> Thomas A Caswell <tcaswell@bnl.gov> 

--- a/docs/source/whatsnew/github-stats-5.rst
+++ b/docs/source/whatsnew/github-stats-5.rst
@@ -3,6 +3,60 @@
 Issues closed in the 5.x development cycle
 ==========================================
 
+Issues closed in 5.2
+--------------------
+
+GitHub stats for 2016/08/13 - 2017/01/29 (tag: 5.1.0)
+
+These lists are automatically generated, and may be incomplete or contain duplicates.
+
+We closed 30 issues and merged 74 pull requests.
+The full list can be seen `on GitHub <https://github.com/ipython/ipython/issues?q=milestone%3A5.2+>`__
+
+The following 40 authors contributed 434 commits.
+
+* Adam Eury
+* anantkaushik89
+* anatoly techtonik
+* Benjamin Ragan-Kelley
+* Bibo Hao
+* Carl Smith
+* Carol Willing
+* Chilaka Ramakrishna
+* Christopher Welborn
+* Denis S. Tereshchenko
+* Diego Garcia
+* fatData
+* Fermi paradox
+* Fernando Perez
+* fuho
+* Hassan Kibirige
+* Jamshed Vesuna
+* Jens Hedegaard Nielsen
+* Jeroen Demeyer
+* kaushikanant
+* Kenneth Hoste
+* Keshav Ramaswamy
+* Kyle Kelley
+* Matteo
+* Matthias Bussonnier
+* mbyt
+* memeplex
+* Moez Bouhlel
+* Pablo Galindo
+* Paul Ivanov
+* pietvo
+* Piotr Przetacznik
+* Rounak Banik
+* sachet-mittal
+* Srinivas Reddy Thatiparthy
+* Tamir Bahar
+* Thomas A Caswell
+* Thomas Kluyver
+* tillahoffmann
+* Yuri Numerov
+
+
 Issues closed in 5.1
 --------------------
 


### PR DESCRIPTION
(forward port of 94209687855db35455b84415fcc460d559585889)