### PR TITLE
IPython/lib/editorhooks.py: wait for process even if wait=False

### DIFF
--- a/IPython/lib/editorhooks.py
+++ b/IPython/lib/editorhooks.py
@@ -53,7 +53,7 @@ def install_editor(template, wait=False):
         if sys.platform.startswith('win'):
             cmd = shlex.split(cmd)
         proc = subprocess.Popen(cmd, shell=True)
-        if wait and proc.wait() != 0:
+        if proc.wait() != 0:
             raise TryNext()
         if wait:
             py3compat.input("Press Enter when done editing:")

--- a/IPython/lib/tests/test_editorhooks.py
+++ b/IPython/lib/tests/test_editorhooks.py
@@ -14,6 +14,7 @@ def test_install_editor():
             'args': args,
             'kwargs': kwargs,
         })
+        return mock.MagicMock(**{'wait.return_value': 0})
     editorhooks.install_editor('foo -l {line} -f {filename}', wait=False)
     
     with mock.patch('subprocess.Popen', fake_popen):


### PR DESCRIPTION
The wait parameter is meant to add a prompt before returning from
the hook for editors that exit immediatly (fork/CreateProcess) but
it accidently prevented waiting at all for the process when it was
False. I think it was meant to be `not wait and proc.wait()` but we
might as well wait for the process in the `wait=True` case anyhow. It's
less confusing.

It would be nice if this is backported to 5.x.