### PR TITLE
Upload to PyPI in release upload script

### DIFF
--- a/docs/source/coredev/release_process.rst
+++ b/docs/source/coredev/release_process.rst
@@ -168,16 +168,10 @@ Get a fresh clone of the tag for building the release::
 
 .. note::
 
-    You can aslo cleanup the current working repository with ``git clean -xfdi``
+    You can also cleanup the current working repository with ``git clean -xfdi``
 
 8. Run the release script
 -------------------------
-
-.. important::
-
-    These steps cover instructions for creating releases of IPython 5.x LTS and
-    IPython 6.x. Ignore release steps for Python 2 when releasing IPython 6.x
-    which no longer supports Python 2. 
 
 Run the ``release`` script, this step requires having a current wheel, Python
 >=3.4 and Python 2.7.::
@@ -194,14 +188,7 @@ Use the following to actually upload the result of the build::
 
     ./tools/release upload
 
-It should posts them to ``archive.ipython.org``.
-
-You will need to use `twine <https://github.com/pypa/twine>`_ ) manually to
-actually upload on PyPI. Unlike setuptools, twine is able to upload packages
-over SSL::
-
-    twine upload dist/*
-
+It should posts them to ``archive.ipython.org`` and to PyPI.
 
 PyPI/Warehouse will automatically hide previous releases. If you are uploading
 a non-stable version, make sure to log-in to PyPI and un-hide previous version.

--- a/tools/release
+++ b/tools/release
@@ -6,6 +6,7 @@ This should ONLY be run at real release time.
 from __future__ import print_function
 
 import os
+from subprocess import call
 import sys
 
 from toollib import (get_ipdir, pjoin, cd, execfile, sh, archive,
@@ -48,7 +49,7 @@ cd(tooldir)
 
 if 'upload' in sys.argv:
     cd(distdir)
-    print( 'Uploading distribution files to GitHub...')
+    #print( 'Uploading distribution files to GitHub...')
 
     for fname in os.listdir('.'):
         # TODO: update to GitHub releases API
@@ -58,31 +59,35 @@ if 'upload' in sys.argv:
         post_download("ipython/ipython", fname, description=desc)
 
     # Make target dir if it doesn't exist
-    print('Uploading IPython to backup site.')
+    print('1. Uploading IPython to archive.ipython.org')
     sh('ssh %s "mkdir -p %s/release/%s" ' % (archive_user, archive_dir, version))
     sh('scp * %s' % release_site)
 
-    print( 'Uploading backup files...')
+    print('2. Uploading backup files...')
     cd(ipbackupdir)
     sh('scp `ls -1tr *tgz | tail -1` %s' % backup_site)
 
-    print('Done!')
-    print('Use `twine upload dist/*` to upload the files to PyPI')
+    print('3. Uploading to PyPI using twine')
+    cd(distdir)
+    call(['twine', 'upload'] + os.listdir('.'))
+
 else:
+    # Build, but don't upload
+
+    # Make backup tarball
     sh('./make_tarball.py')
     sh('mv ipython-*.tgz %s' % ipbackupdir)
 
     # Build release files
     sh('./build_release %s' % ipdir)
 
-    # Not Registering with PyPI, registering with setup.py is insecure as communication is not encrypted
     cd(ipdir)
 
     # Upload all files
     sh(sdists)
 
     buildwheels()
-    print("`./release upload` to upload source distribution on github and ipython archive")
+    print("`./release upload` to upload source distribution on PyPI and ipython archive")
     sys.exit(0)
 
 


### PR DESCRIPTION
There's no obvious reason that this should be a separate manual step