### PR TITLE
disable `_ipython_display_` in terminal IPython

### DIFF
--- a/IPython/core/tests/test_formatters.py
+++ b/IPython/core/tests/test_formatters.py
@@ -407,6 +407,9 @@ def test_ipython_display_formatter():
         def _ipython_display_(self):
             raise NotImplementedError
     
+    save_enabled = f.ipython_display_formatter.enabled
+    f.ipython_display_formatter.enabled = True
+    
     yes = SelfDisplaying()
     no = NotSelfDisplaying()
     
@@ -419,6 +422,9 @@ def test_ipython_display_formatter():
     nt.assert_equal(d, {})
     nt.assert_equal(md, {})
     nt.assert_equal(catcher, [yes])
+
+    f.ipython_display_formatter.enabled = save_enabled
+
 
 def test_json_as_string_deprecated():
     class JSONString(object):

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -203,6 +203,8 @@ class TerminalInteractiveShell(InteractiveShell):
         super(TerminalInteractiveShell, self).init_display_formatter()
         # terminal only supports plain text
         self.display_formatter.active_types = ['text/plain']
+        # disable `_ipython_display_`
+        self.display_formatter.ipython_display_formatter.enabled = False
 
     def init_prompt_toolkit_cli(self):
         if self.simple_prompt:


### PR DESCRIPTION
We already try to disable all formatters other than text/plain. The ipython_display formatter is not in that mime-type list, so it was not being disabled with the others.

closes #10247