### PR TITLE
Bump stack number on autoreload fail to 10.

### DIFF
--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -252,7 +252,7 @@ class ModuleReloader(object):
                         del self.failed[py_filename]
                 except:
                     print("[autoreload of %s failed: %s]" % (
-                            modname, traceback.format_exc(1)), file=sys.stderr)
+                            modname, traceback.format_exc(10)), file=sys.stderr)
                     self.failed[py_filename] = pymtime
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
This would allow for easier to debug error when encountered.