### PR TITLE
Fix the rest of the colors used on Windows so they are more visible

### DIFF
--- a/IPython/core/excolors.py
+++ b/IPython/core/excolors.py
@@ -3,6 +3,7 @@
 Color schemes for exception handling code in IPython.
 """
 
+import os
 import warnings
 
 #*****************************************************************************
@@ -155,6 +156,12 @@ def exception_colors():
         Normal = C.Normal,
         ))
 
+    # Hack: the 'neutral' colours are not very visible on a dark background on
+    # Windows. Since Windows command prompts have a dark background by default, and
+    # relatively few users are likely to alter that, we will use the 'Linux' colours,
+    # designed for a dark background, as the default on Windows.
+    if os.name == "nt":
+        ex_colors.add_scheme(ex_colors['Linux'].copy('Neutral'))
 
     return ex_colors
 

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -286,6 +286,16 @@ class TerminalInteractiveShell(InteractiveShell):
                     Token.OutPrompt: '#990000',
                     Token.OutPromptNum: '#ff0000 bold',
                 })
+
+                # Hack: Due to limited color support on the Windows console
+                # the prompt colors will be wrong without this
+                if os.name == 'nt':
+                    style_overrides.update({
+                        Token.Prompt: '#ansidarkgreen',
+                        Token.PromptNum: '#ansigreen bold',
+                        Token.OutPrompt: '#ansidarkred',
+                        Token.OutPromptNum: '#ansired bold',
+                    })
             elif legacy =='nocolor':
                 style_cls=_NoStyle
                 style_overrides = {}


### PR DESCRIPTION
This applies a hack similar to the one in
7b7d560822d4e9b6ab486393e22e305c502ff6d1 to change the prompt colors
and exception colors so they are more visible as shown in issue #10238

If this fix is acceptable it would be nice if this is backported to IPython 5 as this is very visible. Every user I see using IPython on Windows sees this and most don't seem to understand that they can change it. And on top of that this is especially annoying when using IPython on a computer you don't own or a VM. Having to reconfigure on each one...

Fixes: #10238 