### PR TITLE
Fix docstring of FileLink to match parameter name

### DIFF
--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -325,7 +325,7 @@ class FileLink(object):
             path to the file or directory that should be formatted
         url_prefix : str
             prefix to be prepended to all files to form a working link [default:
-            'files']
+            '']
         result_html_prefix : str
             text to append to beginning to link [default: none]
         result_html_suffix : str

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -327,7 +327,7 @@ class FileLink(object):
             prefix to be prepended to all files to form a working link [default:
             '']
         result_html_prefix : str
-            text to append to beginning to link [default: none]
+            text to append to beginning to link [default: '']
         result_html_suffix : str
             text to append at the end of link [default: '<br>']
         """

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -323,7 +323,7 @@ class FileLink(object):
         ----------
         path : str
             path to the file or directory that should be formatted
-        directory_prefix : str
+        url_prefix : str
             prefix to be prepended to all files to form a working link [default:
             'files']
         result_html_prefix : str


### PR DESCRIPTION
It used to be `directory_prefix`, but is currently `url_prefix`.