### PR TITLE
Workaround for duplicate completions

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -390,11 +390,13 @@ def rectify_completions(text:str, completion:_IC, *, _debug=False)->_IC:
     seen_python_matches = set()
     for c in completions:
         new_text = text[new_start:c.start] + c.text + text[c.end:new_end]
+        toyield = new_text not in seen_jedi and new_text not in seen_python_matches
         if c._origin == 'jedi':
             seen_jedi.add(new_text)
         elif c._origin == 'IPCompleter.python_matches':
             seen_python_matches.add(new_text)
-        yield Completion(new_start, new_end, new_text, type=c.type, _origin=c._origin)
+        if toyield:
+            yield Completion(new_start, new_end, new_text, type=c.type, _origin=c._origin)
     diff = seen_python_matches.difference(seen_jedi)
     if diff and _debug:
         print('IPython.python matches have extras:', diff)


### PR DESCRIPTION
Workaround for #10282

I consider this a workaround as this works only on the regularized
completions that have been extended with surrounding text in order to
still match old API. The deduplication should happen earlier.

I can't just either "remove" the IPython completer as it gives results
Jedi does not.