### PR TITLE
Avoid triggering jedi in string.

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1105,6 +1105,26 @@ class IPCompleter(Completer):
 
         interpreter = jedi.Interpreter(
             text, namespaces, column=cursor_column, line=cursor_line + 1)
+
+        try_jedi = False
+
+        try:
+            # should we check the type of the node is Error ?
+            from jedi.parser.tree import ErrorLeaf
+            next_to_last_tree = interpreter._get_module().tree_node.children[-2]
+            completing_string = False
+            if isinstance(next_to_last_tree, ErrorLeaf):
+                completing_string = interpreter._get_module().tree_node.children[-2].value[0] in {'"', "'"}
+            # if we are in a string jedi is likely not the right candidate for
+            # now. Skip it.
+            try_jedi = not completing_string
+        except Exception as e:
+            # many of things can go wrong, we are using private API just don't crash.
+            if self.debug:
+                print("Error detecting if completing a non-finished string :", e, '|')
+
+        if not try_jedi:
+            return []
         try:
             return filter(completion_filter, interpreter.completions())
         except Exception as e:


### PR DESCRIPTION
Rely on the fact that the net to last token is an error and starts with
", or '

@takluyver, can you try ? That should fix the `open('embed-<tab>` which is a regression,  but not the `open('<tab>` which also complete irrelevant things, but that's the case on master. 

Would that be sufficient to bump https://github.com/ipython/ipython/issues/10283 to 7.0 ?

If so I'll add tests and polish documentation.