### PR TITLE
FIX: re-order qt eventloop hook a bit

### DIFF
--- a/IPython/terminal/pt_inputhooks/qt.py
+++ b/IPython/terminal/pt_inputhooks/qt.py
@@ -5,6 +5,7 @@ from IPython.external.qt_for_kernel import QtCore, QtGui
 # garbage collected.
 _appref = None
 
+
 def inputhook(context):
     global _appref
     app = QtCore.QCoreApplication.instance()
@@ -24,7 +25,11 @@ def inputhook(context):
     else:
         # On POSIX platforms, we can use a file descriptor to quit the event
         # loop when there is input ready to read.
-        notifier = QtCore.QSocketNotifier(context.fileno(), QtCore.QSocketNotifier.Read)
-        notifier.setEnabled(True)
+        notifier = QtCore.QSocketNotifier(context.fileno(),
+                                          QtCore.QSocketNotifier.Read)
+        # connect the callback we care about before we turn it on
         notifier.activated.connect(event_loop.exit)
-        event_loop.exec_()
+        notifier.setEnabled(True)
+        # only start the event loop we are not already flipped
+        if not context.input_is_ready():
+            event_loop.exec_()


### PR DESCRIPTION
try to reduce race conditions by:

 - connect the exit callback before enabling the notifier (this might
   not matter)
 - only bother starting the event loop if the input is not ready.

closes #10201 

I don't have a mac to test this on.  This may be complete cargo-culting.