### PR TITLE
Suppress "not JSON strings" warning if `filename` argument is provided

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -655,7 +655,7 @@ class JSON(DisplayObject):
     @data.setter
     def data(self, data):
         if isinstance(data, str):
-            if getattr(self, 'filename') is None:
+            if getattr(self, 'filename', None) is None:
                 warnings.warn("JSON expects JSONable dict or list, not JSON strings")
             data = json.loads(data)
         self._data = data
@@ -690,7 +690,7 @@ class GeoJSON(JSON):
     @data.setter
     def data(self, data):
         if isinstance(data, str):
-            if getattr(self, 'filename') is None:
+            if getattr(self, 'filename', None) is None:
                 warnings.warn("GeoJSON expects JSONable dict or list, not JSON strings")
             data = json.loads(data)
         self._data = data

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -655,7 +655,8 @@ class JSON(DisplayObject):
     @data.setter
     def data(self, data):
         if isinstance(data, str):
-            warnings.warn("JSON expects JSONable dict or list, not JSON strings")
+            if self.filename is None:
+                warnings.warn("JSON expects JSONable dict or list, not JSON strings")
             data = json.loads(data)
         self._data = data
 
@@ -689,6 +690,8 @@ class GeoJSON(JSON):
     @data.setter
     def data(self, data):
         if isinstance(data, str):
+            if self.filename is None:
+                warnings.warn("GeoJSON expects JSONable dict or list, not JSON strings")
             data = json.loads(data)
         self._data = data
 

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -655,7 +655,7 @@ class JSON(DisplayObject):
     @data.setter
     def data(self, data):
         if isinstance(data, str):
-            if self.filename is None:
+            if getattr(self, 'filename') is None:
                 warnings.warn("JSON expects JSONable dict or list, not JSON strings")
             data = json.loads(data)
         self._data = data
@@ -690,7 +690,7 @@ class GeoJSON(JSON):
     @data.setter
     def data(self, data):
         if isinstance(data, str):
-            if self.filename is None:
+            if getattr(self, 'filename') is None:
                 warnings.warn("GeoJSON expects JSONable dict or list, not JSON strings")
             data = json.loads(data)
         self._data = data


### PR DESCRIPTION
I observed that this was not only affecting the `JSON` display class but any sub-class of `DisplayObject`. As a result, I would see a warning whenever trying to display data from a file:

![screencap](http://g.recordit.co/4d3VbqXPVU.gif)