### PR TITLE
Update shim warnings to include IPython version.

### DIFF
--- a/IPython/config.py
+++ b/IPython/config.py
@@ -9,7 +9,7 @@ from warnings import warn
 
 from IPython.utils.shimmodule import ShimModule, ShimWarning
 
-warn("The `IPython.config` package has been deprecated. "
+warn("The `IPython.config` package has been deprecated since IPython 4.0. "
      "You should import from traitlets.config instead.", ShimWarning)
 
 

--- a/IPython/frontend.py
+++ b/IPython/frontend.py
@@ -17,7 +17,7 @@ from warnings import warn
 
 from IPython.utils.shimmodule import ShimModule, ShimWarning
 
-warn("The top-level `frontend` package has been deprecated. "
+warn("The top-level `frontend` package has been deprecated since IPython 1.0. "
      "All its subpackages have been moved to the top `IPython` level.", ShimWarning)
 
 # Unconditionally insert the shim into sys.modules so that further import calls

--- a/IPython/html.py
+++ b/IPython/html.py
@@ -9,7 +9,7 @@ from warnings import warn
 
 from IPython.utils.shimmodule import ShimModule, ShimWarning
 
-warn("The `IPython.html` package has been deprecated. "
+warn("The `IPython.html` package has been deprecated since IPython 4.0. "
      "You should import from `notebook` instead. "
      "`IPython.html.widgets` has moved to `ipywidgets`.", ShimWarning)
 

--- a/IPython/kernel/__init__.py
+++ b/IPython/kernel/__init__.py
@@ -9,7 +9,7 @@ from warnings import warn
 
 from IPython.utils.shimmodule import ShimModule, ShimWarning
 
-warn("The `IPython.kernel` package has been deprecated. "
+warn("The `IPython.kernel` package has been deprecated since IPython 4.0."
      "You should import from ipykernel or jupyter_client instead.", ShimWarning)
 
 

--- a/IPython/nbconvert.py
+++ b/IPython/nbconvert.py
@@ -9,7 +9,7 @@ from warnings import warn
 
 from IPython.utils.shimmodule import ShimModule, ShimWarning
 
-warn("The `IPython.nbconvert` package has been deprecated. "
+warn("The `IPython.nbconvert` package has been deprecated since IPython 4.0. "
      "You should import from nbconvert instead.", ShimWarning)
 
 # Unconditionally insert the shim into sys.modules so that further import calls

--- a/IPython/nbformat.py
+++ b/IPython/nbformat.py
@@ -9,7 +9,7 @@ from warnings import warn
 
 from IPython.utils.shimmodule import ShimModule, ShimWarning
 
-warn("The `IPython.nbformat` package has been deprecated. "
+warn("The `IPython.nbformat` package has been deprecated since IPython 4.0. "
      "You should import from nbformat instead.", ShimWarning)
 
 # Unconditionally insert the shim into sys.modules so that further import calls

--- a/IPython/parallel.py
+++ b/IPython/parallel.py
@@ -9,7 +9,7 @@ from warnings import warn
 
 from IPython.utils.shimmodule import ShimModule, ShimWarning
 
-warn("The `IPython.parallel` package has been deprecated. "
+warn("The `IPython.parallel` package has been deprecated since IPython 4.0. "
      "You should import from ipyparallel instead.", ShimWarning)
 
 # Unconditionally insert the shim into sys.modules so that further import calls

--- a/IPython/qt.py
+++ b/IPython/qt.py
@@ -9,7 +9,7 @@ from warnings import warn
 
 from IPython.utils.shimmodule import ShimModule, ShimWarning
 
-warn("The `IPython.qt` package has been deprecated. "
+warn("The `IPython.qt` package has been deprecated since IPython 4.0. "
      "You should import from qtconsole instead.", ShimWarning)
 
 # Unconditionally insert the shim into sys.modules so that further import calls

--- a/IPython/terminal/console.py
+++ b/IPython/terminal/console.py
@@ -9,7 +9,7 @@ from warnings import warn
 
 from IPython.utils.shimmodule import ShimModule, ShimWarning
 
-warn("The `IPython.terminal.console` package has been deprecated. "
+warn("The `IPython.terminal.console` package has been deprecated since IPython 4.0. "
      "You should import from jupyter_console instead.", ShimWarning)
 
 # Unconditionally insert the shim into sys.modules so that further import calls


### PR DESCRIPTION
It will soon be 2 major versions, and we are dropping,
I'm considering either dropping shims, or insert a filter to make them
raise and let a last chance for users to upgrade before removing.

Closes #10143

--- 

Apparently I had this branch lying around, I'm astonished to not have opened a PR. 
Backport ?