### PR TITLE
[Do not merge] FYI. Fix IPython on Python 3.7.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2785,7 +2785,10 @@ class InteractiveShell(SingletonConfigurable):
 
         try:
             for i, node in enumerate(to_run_exec):
-                mod = ast.Module([node])
+                try:
+                    mod = ast.Module([node])
+                except TypeError:
+                    mod = ast.Module([node],'fake docstring workaround Python 3.7-master')
                 code = compiler(mod, cell_name, "exec")
                 if self.run_code(code, result):
                     return True


### PR DESCRIPTION
Recent Python 3.7 master broke the AST module.
Use this as a workaround if you are on 3.7.

See http://bugs.python.org/issue29622 for resolution upstream (if it get
resolved)

--- 

Just because I'm going to guess I might not be the only one and the error message is not obvious:

```
In [1]: import os
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
TypeError: Module constructor takes either 0 or 2 positional arguments
```