### PR TITLE
Add config option for vi/emacs style open-editor shortcuts

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -188,7 +188,12 @@ class TerminalInteractiveShell(InteractiveShell):
         default_value='multicolumn').tag(config=True)
 
     highlight_matching_brackets = Bool(True,
-        help="Highlight matching brackets .",
+        help="Highlight matching brackets.",
+    ).tag(config=True)
+
+    extra_open_editor_shortcuts = Bool(False,
+        help="Enable vi (v) or Emacs (C-X C-E) shortcuts to open an external editor. "
+             "This is in addition to the F2 binding, which is always enabled."
     ).tag(config=True)
 
     @observe('term_title')
@@ -217,7 +222,9 @@ class TerminalInteractiveShell(InteractiveShell):
             return
 
         # Set up keyboard shortcuts
-        kbmanager = KeyBindingManager.for_prompt()
+        kbmanager = KeyBindingManager.for_prompt(
+            enable_open_in_editor=self.extra_open_editor_shortcuts,
+        )
         register_ipython_shortcuts(kbmanager.registry, self)
 
         # Pre-populate history from IPython's history database

--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -77,10 +77,6 @@ def register_ipython_shortcuts(registry, shell):
                          filter=HasFocus(DEFAULT_BUFFER)
                         )(open_input_in_editor)
 
-    registry.add_binding('v',
-                         filter=HasFocus(DEFAULT_BUFFER) & ViNavigationMode()
-                        )(open_input_in_editor)
-
     if shell.display_completions == 'readlinelike':
         registry.add_binding(Keys.ControlI,
                              filter=(HasFocus(DEFAULT_BUFFER)


### PR DESCRIPTION
F2 is always enabled, but passing the option to prompt_toolkit binds `v` (in vi mode, overriding its 'visual mode' function), and `C-X C-E` in emacs mode.

Closes gh-10259
Closes gh-10278