### PR TITLE
Fix some warnings in the docs

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -406,7 +406,7 @@ def rectify_completions(text: str, completions: _IC, *, _debug=False)->_IC:
 
     :any:`jedi.api.classes.Completion` s returned by Jedi may not have the same start and end, though
     the Jupyter Protocol requires them to behave like so. This will readjust
-    the completion to have the same ``start`` and ``end` by padding both
+    the completion to have the same ``start`` and ``end`` by padding both
     extremities with surrounding text.
 
     During stabilisation should support a ``_debug`` option to log which
@@ -744,8 +744,8 @@ def cursor_to_position(text:int, line:int, column:int)->int:
     Convert the (line,column) position of the cursor in text to an offset in a
     string.
 
-    Parameter
-    ---------
+    Parameters
+    ----------
 
     text : str
         The text in which to calculate the cursor offset
@@ -775,8 +775,8 @@ def position_to_cursor(text:str, offset:int)->(int, int):
 
     Position should be a valid position in ``text``.
 
-    Parameter
-    ---------
+    Parameters
+    ----------
 
     text : str
         The text in which to calculate the cursor offset

--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -21,6 +21,7 @@ from prompt_toolkit.key_binding.bindings.completion import display_completions_l
 
 from IPython.utils.decorators import undoc
 
+@undoc
 @Condition
 def cursor_in_leading_ws(cli):
     before = cli.application.buffer.document.current_line_before_cursor

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -230,6 +230,7 @@ intersphinx_mapping = {'python': ('https://docs.python.org/3/', None),
                        'jupyter': ('https://jupyter.readthedocs.io/en/latest/', None),
                        'jedi': ('https://jedi.readthedocs.io/en/latest/', None),
                        'traitlets': ('https://traitlets.readthedocs.io/en/latest/', None),
+                       'ipykernel': ('https://ipykernel.readthedocs.io/en/latest/', None),
                       }
 
 # Options for LaTeX output

--- a/docs/source/whatsnew/development.rst
+++ b/docs/source/whatsnew/development.rst
@@ -56,12 +56,12 @@ completer interface:
 
 The appearance of the completer is controlled by the
 ``c.TerminalInteractiveShell.display_completions`` option that will show the
-type differently depending on the value among ``'column'``,``'multicolumn'``
+type differently depending on the value among ``'column'``, ``'multicolumn'``
 and ``'readlinelike'``
 
 The use of Jedi also full fill a number of request and fix a number of bugs
 like case insensitive completion, completion after division operator: See
-:ghpull:`ipython/ipython#10182`.
+:ghpull:`10182`.
 
 Extra patches and updates will be needed to the :any:`ipykernel` package for
 this feature to be available to other clients like jupyter Notebook, Lab,
@@ -149,7 +149,7 @@ Functions Deprecated in 6.x Development cycle
 
 
 - ``IPython.utils.warn`` was deprecated in IPython 4.0, and has now been removed.
-  instead of ``IPython.utils.warn`` inbuilt :any:`warning` module is used.
+  instead of ``IPython.utils.warn`` inbuilt :any:`warnings` module is used.
 
 
 - The function `IPython.core.oinspect.py:call_tip` is unused, was marked as
@@ -169,7 +169,7 @@ development cycle marked for Milestone 6.0.
 - ``IPython/utils/process.py`` - ``pycmd2argv``
 
 - The `--deep-reload` flag and the corresponding options to inject `dreload` or
-`reload` into the interactive namespace have been removed. You have to
-explicitly import `reload` from `IPython.lib.deepreload` to use it.
+  `reload` into the interactive namespace have been removed. You have to
+  explicitly import `reload` from `IPython.lib.deepreload` to use it.
 
 .. DO NOT EDIT THIS LINE BEFORE RELEASE. INCOMPAT INSERTION POINT.


### PR DESCRIPTION
Some other fixes have been sent upstream to prompt_toolkit.

This make a the docs build cleanly on my machine.