### PR TITLE
[Docs] Add link on how to register class magics.

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -167,6 +167,8 @@ resulting magic::
     def foo(...)
 
 will create a {1} magic named `bar`.
+
+To register a class magic use ``Interactiveshell.register_magic(class or instance)``.
 """
 
 # These two are decorator factories.  While they are conceptually very similar,


### PR DESCRIPTION
I also pushed a change on ipython.github.io that added rel=canonical to
the custommagic page which now point to readthedocs.

That should bias Google into not showing IPython docs version 3 for this
kind of searches.