### PR TITLE
[doc] remove unused look_in_string from inputtransform doc

### DIFF
--- a/docs/source/config/inputtransforms.rst
+++ b/docs/source/config/inputtransforms.rst
@@ -109,7 +109,6 @@ line in a cell::
                 while line is not None:
                     line = (yield line)
 
-    leading_indent.look_in_string = True
 
 Token-based transformers
 ------------------------


### PR DESCRIPTION
cc @Carreau