### PR TITLE
JSON: Include kwargs in metadata

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -622,7 +622,7 @@ class JSON(DisplayObject):
     """
     # wrap data in a property, which warns about passing already-serialized JSON
     _data = None
-    def __init__(self, data=None, url=None, filename=None, metadata=None, **kwargs):
+    def __init__(self, data=None, url=None, filename=None, expanded=False, metadata=None, **kwargs):
         """Create a JSON display object given raw data.
 
         Parameters
@@ -640,9 +640,11 @@ class JSON(DisplayObject):
         metadata: dict
             Specify extra metadata to attach to the json display object.
         """
-        self.metadata = kwargs
+        self.metadata = {'expanded': expanded}
         if metadata:
             self.metadata.update(metadata)
+        if kwargs:
+            self.metadata.update(kwargs)
         super(JSON, self).__init__(data=data, url=url, filename=filename)
 
     def _check_data(self):

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -622,7 +622,7 @@ class JSON(DisplayObject):
     """
     # wrap data in a property, which warns about passing already-serialized JSON
     _data = None
-    def __init__(self, data=None, url=None, filename=None, expanded=False, metadata=None):
+    def __init__(self, data=None, url=None, filename=None, metadata=None, **kwargs):
         """Create a JSON display object given raw data.
 
         Parameters
@@ -640,8 +640,9 @@ class JSON(DisplayObject):
         metadata: dict
             Specify extra metadata to attach to the json display object.
         """
-        self.expanded = expanded
-        self.metadata = metadata
+        self.metadata = kwargs
+        if metadata:
+            self.metadata.update(metadata)
         super(JSON, self).__init__(data=data, url=url, filename=filename)
 
     def _check_data(self):
@@ -661,10 +662,7 @@ class JSON(DisplayObject):
         self._data = data
 
     def _data_and_metadata(self):
-        md = {'expanded': self.expanded}
-        if self.metadata:
-            md.update(self.metadata)
-        return self.data, md
+        return self.data, self.metadata
 
     def _repr_json_(self):
         return self._data_and_metadata()
@@ -681,17 +679,15 @@ lib_t1 = """$.getScript("%s", function () {
 lib_t2 = """});
 """
 
-class GeoJSON(DisplayObject):
+class GeoJSON(JSON):
     """GeoJSON expects JSON-able dict
 
     not an already-serialized JSON string.
 
     Scalar types (None, number, string) are not allowed, only dict containers.
     """
-    # wrap data in a property, which warns about passing already-serialized JSON
-    _data = None
     
-    def __init__(self, data=None, url_template=None, layer_options=None, url=None, filename=None, metadata=None):
+    def __init__(self, *args, **kwargs):
         """Create a GeoJSON display object given raw data.
 
         Parameters
@@ -724,9 +720,6 @@ class GeoJSON(DisplayObject):
             ...     "geometry": {
             ...         "type": "Point",
             ...         "coordinates": [-81.327, 296.038]
-            ...     },
-            ...     "properties": {
-            ...         "name": "Inca City"
             ...     }
             ... },
             ... url_template="http://s3-eu-west-1.amazonaws.com/whereonmars.cartodb.net/{basemap_id}/{z}/{x}/{y}.png",
@@ -742,41 +735,17 @@ class GeoJSON(DisplayObject):
         the GeoJSON object.
 
         """
-        self.url_template = url_template
-        self.layer_options = layer_options
-        self.metadata = metadata
-        super(GeoJSON, self).__init__(data=data, url=url, filename=filename)
-
-    def _check_data(self):
-        if self.data is not None and not isinstance(self.data, dict):
-            raise TypeError("%s expects a JSONable dict, not %r" % (self.__class__.__name__, self.data))
         
-    @property
-    def data(self):
-        return self._data
-    
-    @data.setter
-    def data(self, data):
-        if isinstance(data, str):
-            if getattr(self, 'filename', None) is None:
-                warnings.warn("GeoJSON expects JSONable dict or list, not JSON strings")
-            data = json.loads(data)
-        self._data = data
+        super(GeoJSON, self).__init__(*args, **kwargs)
+
 
     def _ipython_display_(self):
-        md = {}
-        if self.url_template:
-            md['tileUrlTemplate'] = self.url_template
-        if self.layer_options:
-            md['tileLayerOptions'] = self.layer_options
-        if self.metadata:
-            md.update(self.metadata)
         bundle = {
             'application/geo+json': self.data,
-            'text/plain': '<jupyterlab_geojson.GeoJSON object>'
+            'text/plain': '<IPython.display.GeoJSON object>'
         }
         metadata = {
-            'application/geo+json': md
+            'application/geo+json': self.metadata
         }
         display(bundle, metadata=metadata, raw=True)
 

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -159,7 +159,7 @@ def test_displayobject_repr():
 def test_json():
     d = {'a': 5}
     lis = [d]
-    md = {'expanded': False}
+    md = {}
     md2 = {'expanded': True}
     j = display.JSON(d)
     j2 = display.JSON(d, expanded=True)

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -159,7 +159,7 @@ def test_displayobject_repr():
 def test_json():
     d = {'a': 5}
     lis = [d]
-    md = {}
+    md = {'expanded': False}
     md2 = {'expanded': True}
     j = display.JSON(d)
     j2 = display.JSON(d, expanded=True)


### PR DESCRIPTION
This cleans up both the `JSON` and `GeoJSON` display classes by including `kwargs` in the bundle’s `metadata`. This allows subclasses of `JSON`, such as `GeoJSON`, to support _arguments as metadata_ by default vs. requiring subclasses override several JSON methods.

Usage examples:

```py
# JSON
JSON({
    'string': 'string',
    'array': [1, 2, 3],
    'bool': True,
    'object': {
        'foo': 'bar'
    }
}, expanded=True)

# GeoJSON
GeoJSON({
    "type": "Feature",
    "geometry": {
        "type": "Point",
        "coordinates": [-118.4563712, 34.0163116]
    }
}, url_template="https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1Ijoic2Vub3JuZXN0b3IiLCJhIjoiY2l4MHU4MWJsMDIwcjJ0cGwybWQzbnhpeiJ9.beQ7B_WHe3K7_YMUJ684yg", 
layer_options={
    "id": "mapbox.streets",
    "attribution" : '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
    "minZoom" : 0,
    "maxZoom" : 18,
})