### PR TITLE
Speed up shutdown by eliminating unnecessary sleeping

### DIFF
--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -245,6 +245,8 @@ class ScriptMagics(Magics):
 
     def kill_bg_processes(self):
         """Kill all BG processes which are still running."""
+        if not self.bg_processes:
+            return
         for p in self.bg_processes:
             if p.poll() is None:
                 try:
@@ -252,6 +254,9 @@ class ScriptMagics(Magics):
                 except:
                     pass
         time.sleep(0.1)
+        self._gc_bg_processes()
+        if not self.bg_processes:
+            return
         for p in self.bg_processes:
             if p.poll() is None:
                 try:
@@ -259,6 +264,9 @@ class ScriptMagics(Magics):
                 except:
                     pass
         time.sleep(0.1)
+        self._gc_bg_processes()
+        if not self.bg_processes:
+            return
         for p in self.bg_processes:
             if p.poll() is None:
                 try:


### PR DESCRIPTION
Eliminate an annoying split-second pause when closing a shell session by reducing unnecessary sleeps while killing background scripts. If there are no bacgkround scripts running, or if they shut down on the first or second attempt, then we can eliminate some pauses.