### PR TITLE
Remove %profile in perspective of using it in later IPython versions.

### DIFF
--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -294,13 +294,9 @@ Currently the magic system has the following functions:""",
         prun : run code using the Python profiler
                (:meth:`~IPython.core.magics.execution.ExecutionMagics.prun`)
         """
-        warn("The `%profile` magic has been deprecated since IPython 2.0. Please use "
-             "the value of `get_ipython().profile` instead to see current profile in use.")
-        from IPython.core.application import BaseIPythonApplication
-        if BaseIPythonApplication.initialized():
-            print(BaseIPythonApplication.instance().profile)
-        else:
-            error("profile is an application-level value, but you don't appear to be in an IPython application")
+        raise DeprecationWarning("The `%profile` magic has been deprecated since IPython 2.0. "
+            "and removed in IPython 6.0. Please use the value of `get_ipython().profile` instead "
+            "to see current profile in use. Perhaps you meant to use `%prun` to profile code ?")
 
     @line_magic
     def pprint(self, parameter_s=''):

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -294,7 +294,7 @@ Currently the magic system has the following functions:""",
         prun : run code using the Python profiler
                (:meth:`~IPython.core.magics.execution.ExecutionMagics.prun`)
         """
-        raise DeprecationWarning("The `%profile` magic has been deprecated since IPython 2.0. "
+        raise UsageError("The `%profile` magic has been deprecated since IPython 2.0. "
             "and removed in IPython 6.0. Please use the value of `get_ipython().profile` instead "
             "to see current profile in use. Perhaps you meant to use `%prun` to profile code?")
 

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -296,7 +296,7 @@ Currently the magic system has the following functions:""",
         """
         raise DeprecationWarning("The `%profile` magic has been deprecated since IPython 2.0. "
             "and removed in IPython 6.0. Please use the value of `get_ipython().profile` instead "
-            "to see current profile in use. Perhaps you meant to use `%prun` to profile code ?")
+            "to see current profile in use. Perhaps you meant to use `%prun` to profile code?")
 
     @line_magic
     def pprint(self, parameter_s=''):

--- a/docs/source/whatsnew/development.rst
+++ b/docs/source/whatsnew/development.rst
@@ -173,4 +173,9 @@ development cycle marked for Milestone 6.0.
   `reload` into the interactive namespace have been removed. You have to
   explicitly import `reload` from `IPython.lib.deepreload` to use it.
 
+- the :magic:`profile` used to print current IPython profile in use, and which
+  was deprecated in IPython 2.0 does now raise a `DeprecationWarning` error when
+  used. It is often confused with the :magic:`prun` and the deprecation remove
+  should free up the ``profile`` name in future versions.
+
 .. DO NOT EDIT THIS LINE BEFORE RELEASE. INCOMPAT INSERTION POINT.


### PR DESCRIPTION
Raise an informative error message with both legacy and new behavior.

Prompted by discussion with @stefanv who is not the only one that get confused by `%profile` and think it profiles code. I'm thinking on letting it raise for about a year or two, and then remove/replace by a %prun-like magic (or maybe something like Robert Kern line_profiler)