### PR TITLE
Ignore all exceptions in getargspec()

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -907,7 +907,7 @@ class Inspector(Colorable):
         if callable_obj is not None:
             try:
                 argspec = getargspec(callable_obj)
-            except (TypeError, AttributeError):
+            except Exception:
                 # For extensions/builtins we can't retrieve the argspec
                 pass
             else:


### PR DESCRIPTION
Sage overrides `getargspec()` and it can raise all kind of exceptions, not just `TypeError` or `AttributeError`.