### PR TITLE
Fix bug in generating shortcuts

### DIFF
--- a/docs/autogen_shortcuts.py
+++ b/docs/autogen_shortcuts.py
@@ -60,7 +60,7 @@ for kb in ipy_bindings:
     if not doc or doc in dummy_docs:
         continue
 
-    shortcut = ' '.join([k if isinstance(k, str) else k.name for k in kb.keys])
+    shortcut = ' '.join([k if isinstance(k, (str, unicode)) else k.name for k in kb.keys])
     shortcut += shortcut.endswith('\\') and '\\' or ''
     if hasattr(kb.filter, 'filters'):
         flt = ' '.join(multi_filter_str(kb.filter))


### PR DESCRIPTION
Hello.
I found this bug during building RPM package for Fedora with Python 2 only. I think that key from KeyBindingManager registry can be `unicode` and not only `str`.

At least, this fixes my issue during build which failed with:
```
/usr/bin/python2 autogen_shortcuts.py
Traceback (most recent call last):
  File "autogen_shortcuts.py", line 63, in <module>
    shortcut = ' '.join([k if isinstance(k, str) else k.name for k in kb.keys])
AttributeError: 'unicode' object has no attribute 'name'
make: *** [Makefile:90: autogen_shortcuts] Error 1
```