### PR TITLE
Prefer execution when there's only a single line entered

### DIFF
--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -108,8 +108,13 @@ def newline_or_execute_outer(shell):
                 b.cancel_completion()
             return
 
-        before_text = d.text[:d.cursor_position]
-        status, indent = shell.input_splitter.check_complete(before_text + '\n')
+        # If there's only one line, treat it as if the cursor is at the end.
+        # See https://github.com/ipython/ipython/issues/10425
+        if d.line_count == 1:
+            check_text = d.text
+        else:
+            check_text = d.text[:d.cursor_position]
+        status, indent = shell.input_splitter.check_complete(check_text + '\n')
 
         if not (d.on_last_line or
                 d.cursor_position_row >= d.line_count - d.empty_line_count_at_the_end()


### PR DESCRIPTION
Closes gh-10425

The heuristic here is to treat a single line specially, and always evaluate it as if the cursor was at the end. An alternative heuristic could be to do this if the cursor is on the last line of the input.

This could also cause some weird effects if you e.g. type `for a in range(5):`, move the cursor back a few places and press enter - you'll get a newline inserted in the text, but it will indent as if it were after the colon. I'm still trying to think if there's a better way to approach it.