### PR TITLE
Define `_repr_mimebundle_`

### DIFF
--- a/IPython/core/tests/test_formatters.py
+++ b/IPython/core/tests/test_formatters.py
@@ -436,4 +436,55 @@ def test_json_as_string_deprecated():
         d = f(JSONString())
     nt.assert_equal(d, {})
     nt.assert_equal(len(w), 1)
+
+
+def test_repr_mime():
+    class HasReprMime(object):
+        def _repr_mimebundle_(self):
+            return {
+                'application/json+test.v2': {
+                    'x': 'y'
+                }
+            }
+        
+        def _repr_html_(self):
+            return '<b>hi!</b>'
+    
+    f = get_ipython().display_formatter
+    html_f = f.formatters['text/html']
+    save_enabled = html_f.enabled
+    html_f.enabled = True
+    obj = HasReprMime()
+    d, md = f.format(obj)
+    html_f.enabled = save_enabled
+    
+    nt.assert_equal(sorted(d), ['application/json+test.v2', 'text/html', 'text/plain'])
+    nt.assert_equal(md, {})
+
+
+def test_repr_mime_meta():
+    class HasReprMimeMeta(object):
+        def _repr_mimebundle_(self):
+            data = {
+                'image/png': 'base64-image-data',
+            }
+            metadata = {
+                'image/png': {
+                    'width': 5,
+                    'height': 10,
+                }
+            }
+            return (data, metadata)
+    
+    f = get_ipython().display_formatter
+    obj = HasReprMimeMeta()
+    d, md = f.format(obj)
+    nt.assert_equal(sorted(d), ['image/png', 'text/plain'])
+    nt.assert_equal(md, {
+        'image/png': {
+            'width': 5,
+            'height': 10,
+        }
+    })
+    
     


### PR DESCRIPTION
Allows objects to display arbitrary mime-types by returning a mimebundle. This is getting increasingly important as custom mime-types are growing in popularity.

- mime-bundle is computed first, but other formatters are still called
- if a mime-type is present in repr-mimebundle, `_repr_<mime>_` will not be called (avoids redundant calls for backward-compatible objects)

closes #10090

cc @rgbkrk

Alternative design: rather than single method returning the mimebundle itself, return mime-keyed mapping to callables, e.g.:

```python
def _repr_mime_methods_(self):
    return {
        'text/html': self._repr_html_,
    }
```

Another more minor alternative: rather than allowing return of `data` or `(data, metadata)`, require returning the full mime-bundle with `data`, `metadata` keys:

```python
def _repr_mimebundle(self):
    return {
        'data': {
            'application/vnd.foo+json': [1,2,3],
        },
    }
```