### PR TITLE
Fix virtualenv warning for Cygwin

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -699,7 +699,14 @@ class InteractiveShell(SingletonConfigurable):
             p = os.path.normcase(os.path.join(os.path.dirname(p), os.readlink(p)))
             paths.append(p)
         p_venv = os.path.normcase(os.environ['VIRTUAL_ENV'])
-        if any(p.startswith(p_venv) for p in paths):
+        
+        # In Cygwin paths like "c:\..." and '\cygdrive\c\...' are possible
+        if p_venv.startswith('\\cygdrive'):
+            p_venv = p_venv[11:]
+        else if p_venv[1] == ':':
+            p_venv = p_venv[2:]
+
+        if any(p_venv in p for p in paths):
             # Running properly in the virtualenv, don't need to do anything
             return
         

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -703,7 +703,7 @@ class InteractiveShell(SingletonConfigurable):
         # In Cygwin paths like "c:\..." and '\cygdrive\c\...' are possible
         if p_venv.startswith('\\cygdrive'):
             p_venv = p_venv[11:]
-        else if p_venv[1] == ':':
+        elif p_venv[1] == ':':
             p_venv = p_venv[2:]
 
         if any(p_venv in p for p in paths):


### PR DESCRIPTION
Getting `Attempting to work in a virtualenv...` warnings when running in Cygwin and starting ipython in a virtualenv. (Also, using a virtualenvwrapper, not sure if it makes a difference)

Turns out `p_venv` looks like this `\cygdrive\c\users\igonato\envs\myenv` when `sys.executable` is like this `c:\users\igonato\envs\myenv\scripts\python.exe`.

This should make the check a bit more robust when running in Cygwin

Cheers!