### PR TITLE
Prototype: show signature with Jedi.

### DIFF
--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -37,6 +37,8 @@ from IPython.utils._process_common import arg_split
 # FIXME: this should be pulled in with the right call via the component system
 from IPython import get_ipython
 
+from typing import List
+
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
@@ -153,7 +155,7 @@ def is_importable(module, attr, only_modules):
         return not(attr[:2] == '__' and attr[-2:] == '__')
 
 
-def try_import(mod: str, only_modules=False):
+def try_import(mod: str, only_modules=False) -> List[str]:
     """
     Try to import given module and return list of potential completions.
     """
@@ -173,9 +175,9 @@ def try_import(mod: str, only_modules=False):
     completions.extend(getattr(m, '__all__', []))
     if m_is_init:
         completions.extend(module_list(os.path.dirname(m.__file__)))
-    completions = {c for c in completions if isinstance(c, str)}
-    completions.discard('__init__')
-    return list(completions)
+    completions_set = {c for c in completions if isinstance(c, str)}
+    completions_set.discard('__init__')
+    return list(completions_set)
 
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -335,6 +335,18 @@ def test_jedi():
 
     yield _test_not_complete, 'does not mix types', 'a=(1,"foo");a[0].', 'capitalize'
 
+def test_completion_have_signature():
+    """
+    Lets make sure jedi is capable of pulling out the signature of the function we are completing.
+    """
+    ip = get_ipython()
+    with provisionalcompleter():
+        completions = ip.Completer.completions('ope', 3)
+        c = next(completions)  # should be `open`
+    assert 'file' in c.signature, "Signature of function was not found by completer"
+    assert 'encoding' in c.signature, "Signature of function was not found by completer"
+
+
 def test_deduplicate_completions():
     """
     Test that completions are correctly deduplicated (even if ranges are not the same)

--- a/IPython/terminal/ptutils.py
+++ b/IPython/terminal/ptutils.py
@@ -120,9 +120,9 @@ class IPythonPTCompleter(Completer):
 
             adjusted_text = _adjust_completion_text_based_on_context(c.text, body, offset)
             if c.type == 'function':
-                display_text = display_text + '()'
-
-            yield Completion(adjusted_text, start_position=c.start - offset, display=_elide(display_text), display_meta=c.type)
+                yield Completion(adjusted_text, start_position=c.start - offset, display=_elide(display_text+'()'), display_meta=c.type+c.signature)
+            else:
+                yield Completion(adjusted_text, start_position=c.start - offset, display=_elide(display_text), display_meta=c.type)
 
 class IPythonPTLexer(Lexer):
     """

--- a/docs/source/interactive/tutorial.rst
+++ b/docs/source/interactive/tutorial.rst
@@ -100,6 +100,8 @@ IPython and Jedi will be able to infer that ``data[0]`` is actually a string
 and should show relevant completions like ``upper()``, ``lower()`` and other
 string methods. You can use the :kbd:`Tab` key to cycle through completions,
 and while a completion is highlighted, its type will be shown as well.
+When the type of the completion is a function, the completer will also show the
+signature of the function when highlighted.
 
 Exploring your objects
 ======================

--- a/docs/source/whatsnew/pr/jedi-signature.rst
+++ b/docs/source/whatsnew/pr/jedi-signature.rst
@@ -1,0 +1,4 @@
+Terminal IPython will now show the signature of the function while completing.
+Only the currently highlighted function will show its signature on the line
+below the completer by default. The functionality is recent so might be
+limited, we welcome bug report and enhancement request on it.


### PR DESCRIPTION
That (unsurprisingly), change the APIs that were marked as unstable for 6.0. 
Not in a big way. 

In the terminal I stick the signature of functions (not callables, sorry numpy ufuncs..) into the meta-display (ie, next to the type), which make multicolumn compact (you see the sig only when selecting), and column a bit ugly, sig still in the type in the right column.  

![sig](https://cloud.githubusercontent.com/assets/335567/25767863/0ef0a124-31b2-11e7-9eb0-39e449618090.gif)

