### PR TITLE
Fix Crash: Eliding string with consecutive dots.

### DIFF
--- a/IPython/terminal/ptutils.py
+++ b/IPython/terminal/ptutils.py
@@ -26,8 +26,12 @@ def _elide(string, *, min_elide=30):
     If a string is long enough, and has at least 2 dots,
     replace the middle part with ellipses.
 
-    For example:
+    If three consecutive dots, or two consecutive dots are encountered these are
+    replaced by the equivalents HORIZONTAL ELLIPSIS or TWO DOT LEADER unicode
+    equivalents
     """
+    string = string.replace('...','\N{HORIZONTAL ELLIPSIS}')
+    string = string.replace('..','\N{TWO DOT LEADER}')
     if len(string) < min_elide:
         return string
 

--- a/IPython/terminal/tests/test_interactivshell.py
+++ b/IPython/terminal/tests/test_interactivshell.py
@@ -10,6 +10,16 @@ from IPython.core.inputtransformer import InputTransformer
 from IPython.testing import tools as tt
 from IPython.utils.capture import capture_output
 
+from IPython.terminal.ptutils import _elide
+import nose.tools as nt
+
+class TestElide(unittest.TestCase):
+
+    def test_elide(self):
+        _elide('concatenate((a1, a2, ...), axis') # do not raise
+        _elide('concatenate((a1, a2, ..), . axis') # do not raise
+        nt.assert_equal(_elide('aaaa.bbbb.ccccc.dddddd.eeeee.fffff.gggggg.hhhhhh'), 'aaaa.b…g.hhhhhh')
+
 # Decorator for interaction loop tests -----------------------------------------
 
 class mock_input_helper(object):


### PR DESCRIPTION
Spiting a string with consecutive dots would lead to empty parts, which
you can't subslice when recombining and lead to `IndexError`.

Should not happened on 6.0, but could if the completer is refactored to
display completions that can contain the ellipsis symbol in Python 3 or
arbitrary string in default arguments.