### PR TITLE
Test on travis with numpy installed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
 install:
     - pip install setuptools pip --upgrade
     - pip install -e file://$PWD#egg=ipython[test] --upgrade
+    - pip install numpy matplotlib
     - pip install codecov --upgrade
 script:
     - cd /tmp && iptest --coverage xml && cd -

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 10
+        threshold: 5
     patch:
       default:
         target: 0%


### PR DESCRIPTION
Apparently we got a large drop of coverage when we removed this from the
[test] dependency in setup.py.

It's still not a dep, but no reasons not to test with it.