### PR TITLE
Cleanup oinspect II

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1365,10 +1365,9 @@ class InteractiveShell(SingletonConfigurable):
         Has special code to detect magic functions.
         """
         oname = oname.strip()
-        #print '1- oname: <%r>' % oname  # dbg
         if not oname.startswith(ESC_MAGIC) and \
-            not oname.startswith(ESC_MAGIC2) and \
-            not py3compat.isidentifier(oname, dotted=True):
+                not oname.startswith(ESC_MAGIC2) and \
+                not all(a.isidentifier() for a in oname.split(".")):
             return {'found': False}
 
         if namespaces is None:
@@ -1380,9 +1379,12 @@ class InteractiveShell(SingletonConfigurable):
                            ('Python builtin', builtin_mod.__dict__),
                            ]
 
-        # initialize results to 'null'
-        found = False; obj = None;  ospace = None;
-        ismagic = False; isalias = False; parent = None
+        ismagic = False
+        isalias = False
+        found = False
+        ospace = None
+        parent = None
+        obj = None
 
         # Look for the given name by splitting it in parts.  If the head is
         # found, then we look for all the remaining parts as members, and only
@@ -1395,7 +1397,6 @@ class InteractiveShell(SingletonConfigurable):
             except KeyError:
                 continue
             else:
-                #print 'oname_rest:', oname_rest  # dbg
                 for idx, part in enumerate(oname_rest):
                     try:
                         parent = obj
@@ -1436,12 +1437,6 @@ class InteractiveShell(SingletonConfigurable):
                 ospace = 'IPython internal'
                 ismagic = True
                 isalias = isinstance(obj, Alias)
-
-        # Last try: special-case some literals like '', [], {}, etc:
-        if not found and oname_head in ["''",'""','[]','{}','()']:
-            obj = eval(oname_head)
-            found = True
-            ospace = 'Interactive'
 
         return {'found':found, 'obj':obj, 'namespace':ospace,
                 'ismagic':ismagic, 'isalias':isalias, 'parent':parent}


### PR DESCRIPTION
Mostly formatting, and removal of comment and debug statements.

I remove a handling of "special case", as far as I can't tell these
can't occur as we are looking up things by name, and these special case
are invalid python name. Also they appear as not be tested (lines not in
coverage). Also eval-ing these seem to be a bit evil, a simple mapping
seem better suited if we need to reintegrate them.