### PR TITLE
Standardize traceback.

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -870,7 +870,7 @@ class VerboseTB(TBTools):
                     pass
 
         file = py3compat.cast_unicode(file, util_path.fs_encoding)
-        link = tpl_link % file
+        link = tpl_link % util_path.compress_user(file)
         args, varargs, varkw, locals = inspect.getargvalues(frame)
 
         if func == '?':


### PR DESCRIPTION
Compress user and location of stdlib/sitepackage.
That should make traceback identical on all machines, hopefully making
Google a bit better at finding them, and a little less wide in many
case.

The drawback is that filename are not copy-pastable to edit files, unless
situated somewhere not in site packages but that should be the case for
__most__ dev install, so I expect that to not bother many people.

---- 
```
In [1]: import numpy; numpy.histogram('a')
---------------------------------------------------------------------------
With $STDLIB='/Users/bussonniermatthias/anaconda/lib/python3.6':
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-1-e5edd817948c> in <module>()
----> 1 import numpy; numpy.histogram('a')

$STDLIB/site-packages/numpy/lib/function_base.py in histogram(a, bins, range, normed, weights, density)
    659             mn, mx = 0.0, 1.0
    660         else:
--> 661             mn, mx = a.min() + 0.0, a.max() + 0.0
    662     else:
    663         mn, mx = [mi + 0.0 for mi in range]

$STDLIB/site-packages/numpy/core/_methods.py in _amin(a, axis, out, keepdims)
     27
     28 def _amin(a, axis=None, out=None, keepdims=False):
---> 29     return umr_minimum(a, axis, None, out, keepdims)
     30
     31 def _sum(a, axis=None, dtype=None, out=None, keepdims=False):

TypeError: cannot perform reduce with flexible type
```
---- 

@takluyver I feel like you will be opinionated on this one.

I'm flexible on the naming and what we compress, but I think it would be great to do that.