### PR TITLE
?? shall show docstring if source info is not available

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -648,7 +648,7 @@ class Inspector(Colorable):
             
             # Source or docstring, depending on detail level and whether
             # source found.
-            if detail_level > 0:
+            if detail_level > 0 and info['source']:
                 append_field(_mime, 'Source', 'source', code_formatter)
             else:
                 append_field(_mime, 'Docstring', 'docstring', formatter)


### PR DESCRIPTION
this is to fix the issue #10531. the reason is that when there is no source info. detail_level > 0 shall still show docstring. 
