### PR TITLE
Add --term-title-format flag to customize terminal title format

### DIFF
--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -352,7 +352,7 @@ class OSMagics(Magics):
             try:
                 os.chdir(os.path.expanduser(ps))
                 if hasattr(self.shell, 'term_title') and self.shell.term_title:
-                    set_term_title('IPython: ' + abbrev_cwd())
+                    set_term_title(self.shell.term_title_format.format(cwd=abbrev_cwd()))
             except OSError:
                 print(sys.exc_info()[1])
             else:
@@ -365,7 +365,7 @@ class OSMagics(Magics):
         else:
             os.chdir(self.shell.home_dir)
             if hasattr(self.shell, 'term_title') and self.shell.term_title:
-                set_term_title('IPython: ' + '~')
+                set_term_title(self.shell.term_title_format.format(cwd="~"))
             cwd = os.getcwd()
             dhist = self.shell.user_ns['_dh']
 

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -179,6 +179,11 @@ class TerminalInteractiveShell(InteractiveShell):
         help="Automatically set the terminal title"
     ).tag(config=True)
 
+    term_title_format = Unicode("IPython: {cwd}",
+        help="Customize the terminal title format.  This is a python format string. " +
+             "Available substitutions are: {cwd}."
+    ).tag(config=True)
+
     display_completions = Enum(('column', 'multicolumn','readlinelike'),
         help= ( "Options for displaying tab completions, 'column', 'multicolumn', and "
                 "'readlinelike'. These options are for `prompt_toolkit`, see "
@@ -206,7 +211,7 @@ class TerminalInteractiveShell(InteractiveShell):
         # Enable or disable the terminal title.
         if self.term_title:
             toggle_set_term_title(True)
-            set_term_title('IPython: ' + abbrev_cwd())
+            set_term_title(self.term_title_format.format(cwd=abbrev_cwd()))
         else:
             toggle_set_term_title(False)
 

--- a/docs/source/whatsnew/pr/term-title-format-feature.rst
+++ b/docs/source/whatsnew/pr/term-title-format-feature.rst
@@ -1,0 +1,2 @@
+An additional flag `--term-title-format` is introduced to allow the user to control the format of the terminal
+title.  It is specified as a python format string, and currently the only variable it will format is `{cwd}`.


### PR DESCRIPTION
Adds the feature described in #9796