### PR TITLE
Do not duplicate '=' when tab completing a kwarg with the cursor on '='

### DIFF
--- a/IPython/terminal/ptutils.py
+++ b/IPython/terminal/ptutils.py
@@ -43,6 +43,11 @@ def _elide(string, *, min_elide=30):
     return '{}.{}\N{HORIZONTAL ELLIPSIS}{}.{}'.format(parts[0], parts[1][0], parts[-2][-1], parts[-1])
 
 
+def _adjust_completion_text_based_on_context(text, body, offset):
+    if text.endswith('=') and len(body) > offset and body[offset] is '=':
+        return text[:-1]
+    else:
+        return text
 
 
 class IPythonPTCompleter(Completer):
@@ -113,10 +118,11 @@ class IPythonPTCompleter(Completer):
             #                  display_meta=meta_text)
             display_text = c.text
 
+            adjusted_text = _adjust_completion_text_based_on_context(c.text, body, offset)
             if c.type == 'function':
                 display_text = display_text + '()'
 
-            yield Completion(c.text, start_position=c.start - offset, display=_elide(display_text), display_meta=c.type)
+            yield Completion(adjusted_text, start_position=c.start - offset, display=_elide(display_text), display_meta=c.type)
 
 class IPythonPTLexer(Lexer):
     """

--- a/IPython/terminal/tests/test_interactivshell.py
+++ b/IPython/terminal/tests/test_interactivshell.py
@@ -10,7 +10,7 @@ from IPython.core.inputtransformer import InputTransformer
 from IPython.testing import tools as tt
 from IPython.utils.capture import capture_output
 
-from IPython.terminal.ptutils import _elide
+from IPython.terminal.ptutils import _elide, _adjust_completion_text_based_on_context
 import nose.tools as nt
 
 class TestElide(unittest.TestCase):
@@ -19,6 +19,19 @@ class TestElide(unittest.TestCase):
         _elide('concatenate((a1, a2, ...), axis') # do not raise
         _elide('concatenate((a1, a2, ..), . axis') # do not raise
         nt.assert_equal(_elide('aaaa.bbbb.ccccc.dddddd.eeeee.fffff.gggggg.hhhhhh'), 'aaaa.b…g.hhhhhh')
+
+
+class TestContextAwareCompletion(unittest.TestCase):
+
+    def test_adjust_completion_text_based_on_context(self):
+        # Adjusted case
+        nt.assert_equal(_adjust_completion_text_based_on_context('arg1=', 'func1(a=)', 7), 'arg1')
+
+        # Untouched cases
+        nt.assert_equal(_adjust_completion_text_based_on_context('arg1=', 'func1(a)', 7), 'arg1=')
+        nt.assert_equal(_adjust_completion_text_based_on_context('arg1=', 'func1(a', 7), 'arg1=')
+        nt.assert_equal(_adjust_completion_text_based_on_context('%magic', 'func1(a=)', 7), '%magic')
+        nt.assert_equal(_adjust_completion_text_based_on_context('func2', 'func1(a=)', 7), 'func2')
 
 # Decorator for interaction loop tests -----------------------------------------
 


### PR DESCRIPTION
Fix for #9404:

Adjust completion text when the last character is an '=' and the cursor is on a '='