### PR TITLE
ENH: Add alias_magic parameters

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -426,7 +426,7 @@ class MagicsManager(Configurable):
         setattr(self.user_magics, magic_name, func)
         record_magic(self.magics, magic_kind, magic_name, func)
 
-    def register_alias(self, alias_name, magic_name, magic_kind='line'):
+    def register_alias(self, alias_name, magic_name, magic_kind='line', magic_params=None):
         """Register an alias to a magic function.
 
         The alias is an instance of :class:`MagicAlias`, which holds the
@@ -452,7 +452,7 @@ class MagicsManager(Configurable):
             raise ValueError('magic_kind must be one of %s, %s given' %
                              magic_kinds, magic_kind)
 
-        alias = MagicAlias(self.shell, magic_name, magic_kind)
+        alias = MagicAlias(self.shell, magic_name, magic_kind, magic_params)
         setattr(self.user_magics, alias_name, alias)
         record_magic(self.magics, magic_kind, alias_name, alias)
 
@@ -653,9 +653,10 @@ class MagicAlias(object):
     Use the :meth:`MagicsManager.register_alias` method or the
     `%alias_magic` magic function to create and register a new alias.
     """
-    def __init__(self, shell, magic_name, magic_kind):
+    def __init__(self, shell, magic_name, magic_kind, magic_params=None):
         self.shell = shell
         self.magic_name = magic_name
+        self.magic_params = magic_params
         self.magic_kind = magic_kind
 
         self.pretty_target = '%s%s' % (magic_escapes[self.magic_kind], self.magic_name)
@@ -675,6 +676,10 @@ class MagicAlias(object):
                              "magic aliases cannot call themselves.")
         self._in_call = True
         try:
+            if self.magic_params:
+                args_list = list(args)
+                args_list[0] = self.magic_params + " " + args[0]
+                args = tuple(args_list)
             return fn(*args, **kwargs)
         finally:
             self._in_call = False

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -6,6 +6,7 @@ Needs to be run by nose (to make ipython session available).
 
 import io
 import os
+import re
 import sys
 import warnings
 from unittest import TestCase
@@ -13,6 +14,8 @@ from importlib import invalidate_caches
 from io import StringIO
 
 import nose.tools as nt
+
+import shlex
 
 from IPython import get_ipython
 from IPython.core import magic
@@ -866,6 +869,11 @@ def test_alias_magic():
     ip.run_line_magic('alias_magic', '--line env_alias env')
     nt.assert_equal(ip.run_line_magic('env', ''),
                     ip.run_line_magic('env_alias', ''))
+
+    # Test that line alias with parameters passed in is created successfully.
+    ip.run_line_magic('alias_magic', '--line history_alias history --params ' + shlex.quote('3'))
+    nt.assert_in('history_alias', mm.magics['line'])
+
 
 def test_save():
     """Test %save."""

--- a/docs/source/whatsnew/pr/aliasmagicparams-feature.rst
+++ b/docs/source/whatsnew/pr/aliasmagicparams-feature.rst
@@ -1,0 +1,22 @@
+Added the ability to add parameters to alias_magic.
+
+e.g.:
+
+In [2]: %alias_magic hist history --params "-l 2" --line
+Created `%hist` as an alias for `%history -l 2`.
+
+In [3]: hist
+%alias_magic hist history --params "-l 30" --line
+%alias_magic hist history --params "-l 2" --line
+
+Previously it was only possible to have an alias attached to a single function, and you would have to pass in the given parameters every time.
+
+e.g.:
+
+In [4]: %alias_magic hist history --line
+Created `%hist` as an alias for `%history`.
+
+In [5]: hist -l 2
+hist
+%alias_magic hist history --line
+


### PR DESCRIPTION
Added functionality and tests to add the ability to save a magic function with parameters via `alias_magic`.  It was previously only possible to store the magic function itself with `alias_magic`.

Please see `aliasmagicparams-feature.rst` for details.

Fixes #2965.