### PR TITLE
Let nbformat take care of opening the file

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2501,13 +2501,12 @@ class InteractiveShell(SingletonConfigurable):
             """generator for sequence of code blocks to run"""
             if fname.endswith('.ipynb'):
                 from nbformat import read
-                with io_open(fname) as f:
-                    nb = read(f, as_version=4)
-                    if not nb.cells:
-                        return
-                    for cell in nb.cells:
-                        if cell.cell_type == 'code':
-                            yield cell.source
+                nb = read(fname, as_version=4)
+                if not nb.cells:
+                    return
+                for cell in nb.cells:
+                    if cell.cell_type == 'code':
+                        yield cell.source
             else:
                 with open(fname) as f:
                     yield f.read()


### PR DESCRIPTION
Notebook files should always be read as utf-8, but the default for `io.open()` is to use a platform-dependent default encoding. The easiest way around this is to pass the filename to nbformat.read() and let it open the file correctly.

Bug identified at: http://stackoverflow.com/questions/43915006/encoding-error-in-jupyter-when-run-another-notebook