### PR TITLE
Add all the metadata (esp. SVG)

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -574,6 +574,7 @@ class DisplayObject(object):
 
     _read_flags = 'r'
     _show_mem_addr = False
+    metadata = None
 
     def __init__(self, data=None, url=None, filename=None, metadata=None):
         """Create a display object given raw data.
@@ -607,10 +608,11 @@ class DisplayObject(object):
         self.data = data
         self.url = url
         self.filename = filename
+
         if metadata is not None:
-            self.metadata=metadata
-        else:
-            self.metadata={}
+            self.metadata = metadata
+        elif self.metadata is None:
+            self.metadata = {}
 
         self.reload()
         self._check_data()
@@ -725,9 +727,19 @@ class SVG(DisplayObject):
             pass
         svg = cast_unicode(svg)
         self._data = svg
+    
+    def _data_and_metadata(self):
+        """shortcut for returning metadata with shape information, if defined"""
+        md = {}
+        if self.metadata:
+            md.update(self.metadata)
+        if md:
+            return self.data, md
+        else:
+            return self.data
 
     def _repr_svg_(self):
-        return self.data
+        return self._data_and_metadata()
 
 
 class JSON(DisplayObject):
@@ -1071,8 +1083,8 @@ class Image(DisplayObject):
         self.height = height
         self.retina = retina
         self.unconfined = unconfined
-        self.metadata = metadata
-        super(Image, self).__init__(data=data, url=url, filename=filename)
+        super(Image, self).__init__(data=data, url=url, filename=filename, 
+                metadata=metadata)
 
         if retina:
             self._retina_shape()

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -281,6 +281,8 @@ def display(*objs, include=None, exclude=None, metadata=None, transient=None, di
     raw = kwargs.pop('raw', False)
     if transient is None:
         transient = {}
+    if metadata is None:
+        metadata={}
     if display_id:
         if display_id is True:
             display_id = _new_id()
@@ -296,6 +298,10 @@ def display(*objs, include=None, exclude=None, metadata=None, transient=None, di
         format = InteractiveShell.instance().display_formatter.format
 
     for obj in objs:
+        if obj.metadata:
+            temp_dict = obj.metadata.copy()
+            temp_dict.update(metadata)
+            metadata.update(temp_dict)
         if raw:
             publish_display_data(data=obj, metadata=metadata, **kwargs)
         else:
@@ -569,7 +575,7 @@ class DisplayObject(object):
     _read_flags = 'r'
     _show_mem_addr = False
 
-    def __init__(self, data=None, url=None, filename=None):
+    def __init__(self, data=None, url=None, filename=None, metadata=None):
         """Create a display object given raw data.
 
         When this object is returned by an expression or passed to the
@@ -601,6 +607,10 @@ class DisplayObject(object):
         self.data = data
         self.url = url
         self.filename = filename
+        if metadata is not None:
+            self.metadata=metadata
+        else:
+            self.metadata={}
 
         self.reload()
         self._check_data()

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -631,9 +631,7 @@ class DisplayObject(object):
     def _data_and_metadata(self):
         """shortcut for returning metadata with shape information, if defined"""
         if self.metadata:
-            md = deepcopy(self.metadata)
-        if md:
-            return self.data, md
+            return self.data, deepcopy(self.metadata)
         else:
             return self.data
 
@@ -737,9 +735,6 @@ class SVG(DisplayObject):
         self._data = svg
     
     def _repr_svg_(self):
-        return self._data_and_metadata()
-
-    def _repr_mimebundle(self):
         return self._data_and_metadata()
 
 

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -1082,6 +1082,12 @@ class Image(DisplayObject):
         super(Image, self).__init__(data=data, url=url, filename=filename, 
                 metadata=metadata)
 
+        if self.width is None and self.metadata.get('width', {}):
+            self.width = metadata['width']
+
+        if self.height is None and self.metadata.get('height', {}):
+            self.height = metadata['height']
+
         if retina:
             self._retina_shape()
 

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -17,6 +17,7 @@ import os
 import struct
 import sys
 import warnings
+from copy import deepcopy
 
 from IPython.utils.py3compat import cast_unicode
 from IPython.testing.skipdoctest import skip_doctest
@@ -298,8 +299,8 @@ def display(*objs, include=None, exclude=None, metadata=None, transient=None, di
         format = InteractiveShell.instance().display_formatter.format
 
     for obj in objs:
-        if obj.metadata:
-            temp_dict = obj.metadata.copy()
+        if isinstance(obj, DisplayObject) and obj.metadata:
+            temp_dict = obj.metadata.deepcopy()
             temp_dict.update(metadata)
             metadata.update(temp_dict)
         if raw:

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -736,9 +736,8 @@ class SVG(DisplayObject):
     
     def _data_and_metadata(self):
         """shortcut for returning metadata with shape information, if defined"""
-        md = {}
         if self.metadata:
-            md.update(self.metadata)
+            md = deepcopy(self.metadata)
         if md:
             return self.data, md
         else:

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -300,7 +300,7 @@ def display(*objs, include=None, exclude=None, metadata=None, transient=None, di
 
     for obj in objs:
         if isinstance(obj, DisplayObject) and obj.metadata:
-            temp_dict = obj.metadata.deepcopy()
+            temp_dict = deepcopy(obj.metadata)
             temp_dict.update(metadata)
             metadata.update(temp_dict)
         if raw:

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -1131,14 +1131,14 @@ class Image(DisplayObject):
     def _data_and_metadata(self):
         """shortcut for returning metadata with shape information, if defined"""
         md = {}
+        if self.metadata:
+            md.update(self.metadata)
         if self.width:
             md['width'] = self.width
         if self.height:
             md['height'] = self.height
         if self.unconfined:
             md['unconfined'] = self.unconfined
-        if self.metadata:
-            md.update(self.metadata)
         if md:
             return self.data, md
         else:

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -300,6 +300,9 @@ def display(*objs, include=None, exclude=None, metadata=None, transient=None, di
 
     for obj in objs:
         if isinstance(obj, DisplayObject) and obj.metadata:
+            # The following isneeded to give priority to display(metadata=…) 
+            # without overwriting the original metadata attached to the
+            # original object.
             temp_dict = deepcopy(obj.metadata)
             temp_dict.update(metadata)
             metadata.update(temp_dict)

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -598,6 +598,8 @@ class DisplayObject(object):
             A URL to download the data from.
         filename : unicode
             Path to a local file to load the data from.
+        metadata : dict
+            Dict of metadata associated to be the object when displayed
         """
         if data is not None and isinstance(data, str):
             if data.startswith('http') and url is None:

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -299,13 +299,6 @@ def display(*objs, include=None, exclude=None, metadata=None, transient=None, di
         format = InteractiveShell.instance().display_formatter.format
 
     for obj in objs:
-        if isinstance(obj, DisplayObject) and obj.metadata:
-            # The following isneeded to give priority to display(metadata=…) 
-            # without overwriting the original metadata attached to the
-            # original object.
-            temp_dict = deepcopy(obj.metadata)
-            temp_dict.update(metadata)
-            metadata.update(temp_dict)
         if raw:
             publish_display_data(data=obj, metadata=metadata, **kwargs)
         else:
@@ -635,6 +628,15 @@ class DisplayObject(object):
         """Override in subclasses if there's something to check."""
         pass
 
+    def _data_and_metadata(self):
+        """shortcut for returning metadata with shape information, if defined"""
+        if self.metadata:
+            md = deepcopy(self.metadata)
+        if md:
+            return self.data, md
+        else:
+            return self.data
+
     def reload(self):
         """Reload the raw data from file or URL."""
         if self.filename is not None:
@@ -734,16 +736,10 @@ class SVG(DisplayObject):
         svg = cast_unicode(svg)
         self._data = svg
     
-    def _data_and_metadata(self):
-        """shortcut for returning metadata with shape information, if defined"""
-        if self.metadata:
-            md = deepcopy(self.metadata)
-        if md:
-            return self.data, md
-        else:
-            return self.data
-
     def _repr_svg_(self):
+        return self._data_and_metadata()
+
+    def _repr_mimebundle(self):
         return self._data_and_metadata()
 
 

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -22,6 +22,8 @@ def test_image_size():
     thisurl = 'http://www.google.fr/images/srpr/logo3w.png'
     img = display.Image(url=thisurl, width=200, height=200)
     nt.assert_equal(u'<img src="%s" width="200" height="200"/>' % (thisurl), img._repr_html_())
+    img = display.Image(url=thisurl, metadata={'width':200, 'height':200})
+    nt.assert_equal(u'<img src="%s" width="200" height="200"/>' % (thisurl), img._repr_html_())
     img = display.Image(url=thisurl, width=200)
     nt.assert_equal(u'<img src="%s" width="200"/>' % (thisurl), img._repr_html_())
     img = display.Image(url=thisurl)


### PR DESCRIPTION
The aim of this PR is to get it so that DisplayObject has a metadata API that can be inherited by it's subclasses.

One of the challenges in designing this is to not destroy those subclasses that had already defined their own metadata API (such as `Image`).  Fortunately, @minrk helped me work through that design challenge (along with @Carreau helping a lot with with debugging whether any of this worked at all). 

Technically, this also adds a way for SVG objects to surface metadata when returned or displayed. If we want this to work more generally it will require adding a function like `_data_and_metadata` to other subclasses. 

### Open question: returning metadata information more generally

Should we try to figure out a way to implement a `_data_and_metadata` method on the base class so that that is just inherited? If we do so that would likely require a more substantial refactoring. Alternatively, we could keep with the current approach. That would entail handling this in a custom fashion for each of the potential Mimetype specific DisplayObject subclasses. 

Which approach would be preferred?