### PR TITLE
removed filehash in IPython/utils/path.py #10616

### DIFF
--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -13,7 +13,6 @@ import shutil
 import random
 import glob
 from warnings import warn
-from hashlib import md5
 
 from IPython.utils.process import system
 from IPython.utils import py3compat
@@ -365,13 +364,6 @@ def target_update(target,deps,cmd):
     if target_outdated(target,deps):
         system(cmd)
 
-@undoc
-def filehash(path):
-    """Make an MD5 hash of a file, ignoring any differences in line
-    ending characters."""
-    warn("filehash() is deprecated since IPython 4.0", DeprecationWarning, stacklevel=2)
-    with open(path, "rU") as f:
-        return md5(py3compat.str_to_bytes(f.read())).hexdigest()
 
 ENOLINK = 1998
 


### PR DESCRIPTION
removed filehash method and md5 import from IPython/utils/path.py.
Bug #10616 
@ivanov 