### PR TITLE
fix of display() instantiates a shell in pure Python #10617

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -280,7 +280,7 @@ def display(*objs, include=None, exclude=None, metadata=None, transient=None, di
     """
     from IPython.core.interactiveshell import InteractiveShell
     
-    if not InteractiveShell.is_instantiated:
+    if not InteractiveShell.initialized():
         # Directly print objects.
         print(*objs)
         return

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -278,6 +278,13 @@ def display(*objs, include=None, exclude=None, metadata=None, transient=None, di
         from IPython.display import display
 
     """
+    from IPython.core.interactiveshell import InteractiveShell
+    
+    if not InteractiveShell.is_instantiated:
+        # Directly print objects.
+        print(*objs)
+        return
+    
     raw = kwargs.pop('raw', False)
     if transient is None:
         transient = {}
@@ -289,8 +296,6 @@ def display(*objs, include=None, exclude=None, metadata=None, transient=None, di
         raise TypeError('display_id required for update_display')
     if transient:
         kwargs['transient'] = transient
-
-    from IPython.core.interactiveshell import InteractiveShell
 
     if not raw:
         format = InteractiveShell.instance().display_formatter.format


### PR DESCRIPTION
Directly fallback on print if InteractiveShell.initialized() is None. We are talking this Issue: #10617.
Though, this means that regardless of data being raw or not, we would be using print() in both cases.