### PR TITLE
Give SyntaxError for naked return in timeit

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -1044,6 +1044,13 @@ python-profiler package from non-free.""")
         ast_setup = self.shell.transform_ast(ast_setup)
         ast_stmt = self.shell.transform_ast(ast_stmt)
 
+        # Check that these compile to valid Python code *outside* the timer func
+        # Invalid code may become valid when put inside the function & loop,
+        # which messes up error messages.
+        # https://github.com/ipython/ipython/issues/10636
+        self.shell.compile(ast_setup, "<magic-timeit-setup>", "exec")
+        self.shell.compile(ast_stmt, "<magic-timeit-stmt>", "exec")
+
         # This codestring is taken from timeit.template - we fill it in as an
         # AST, so that we can apply our AST transformations to the user code
         # without affecting the timing code.

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -576,6 +576,10 @@ def test_timeit_return_quiet():
         res = _ip.run_line_magic('timeit', '-n1 -r1 -q -o 1')
     assert (res is not None)
 
+def test_timeit_invalid_return():
+    with nt.assert_raises_regexp(SyntaxError, "outside function"):
+        _ip.run_line_magic('timeit', 'return')
+
 @dec.skipif(execution.profile is None)
 def test_prun_special_syntax():
     "Test %%prun with IPython special syntax"


### PR DESCRIPTION
We were missing invalid syntax because we put the code into a function before compiling it, leading to confusing error messages.

Closes gh-10636