### PR TITLE
system-wide startup files and env config

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -43,6 +43,14 @@ else:
         "/etc/ipython",
     ]
 
+
+ENV_CONFIG_DIRS = []
+_env_config_dir = os.path.join(sys.prefix, 'etc', 'ipython')
+if _env_config_dir not in SYSTEM_CONFIG_DIRS:
+    # only add ENV_CONFIG if sys.prefix is not already included
+    ENV_CONFIG_DIRS.append(_env_config_dir)
+
+
 _envvar = os.environ.get('IPYTHON_SUPPRESS_CONFIG_ERRORS')
 if _envvar in {None, ''}:
     IPYTHON_SUPPRESS_CONFIG_ERRORS = None
@@ -398,6 +406,7 @@ class BaseIPythonApplication(Application):
 
     def init_config_files(self):
         """[optionally] copy default config files into profile dir."""
+        self.config_file_paths.extend(ENV_CONFIG_DIRS)
         self.config_file_paths.extend(SYSTEM_CONFIG_DIRS)
         # copy config files
         path = self.builtin_profile_dir

--- a/docs/source/whatsnew/pr/env-config.rst
+++ b/docs/source/whatsnew/pr/env-config.rst
@@ -1,0 +1,5 @@
+
+- IPython now looks for config files in ``{sys.prefix}/etc/ipython``
+  for environment-specific configuration.
+- Startup files can be found in ``/etc/ipython/startup`` or ``{sys.prefix}/etc/ipython/startup``
+  in addition to the profile directory, for system-wide or env-specific startup files.


### PR DESCRIPTION
- adds `{sys.prefix}/etc/ipython` to config-file path, which is commonly used for Jupyter applications in envs
- support startup files in system-wide config directories (e.g. `/etc/ipython/startup`, now `{sys.prefix}/etc/ipython/startup`)