### PR TITLE
Fix #10666: Prepare for removal of sphinx.util.compat module at Sphinx 1.7

### DIFF
--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -138,13 +138,7 @@ from io import StringIO
 
 # Third-party
 from docutils.parsers.rst import directives
-import sphinx
-# sphinx.version_info available since 1.2, and we require 1.3
-# sphinx.util.compat deprecated at 1.6 and removed at 1.7
-if sphinx.version_info < (1, 5, 7):
-    from sphinx.util.compat import Directive
-else:
-    from docutils.parsers.rst import Directive
+from docutils.parsers.rst import Directive
 
 # Our own
 from traitlets.config import Config

--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -138,7 +138,13 @@ from io import StringIO
 
 # Third-party
 from docutils.parsers.rst import directives
-from sphinx.util.compat import Directive
+import sphinx
+# sphinx.version_info available since 1.2, and we require 1.3
+# sphinx.util.compat deprecated at 1.6 and removed at 1.7
+if sphinx.version_info < (1, 5, 7):
+    from sphinx.util.compat import Directive
+else:
+    from docutils.parsers.rst import Directive
 
 # Our own
 from traitlets.config import Config


### PR DESCRIPTION
Since Sphinx 1.6, the ``sphinx.util.compat.Directive`` class is deprecated. And the entire ``sphinx.util.compat`` module will be removed at 1.7. This PR follows [Sphinx CHANGES](http://www.sphinx-doc.org/en/master/changes.html) tip about using ``docutils.parsers.rst.Directive`` instead. 

Relates #10666 