### PR TITLE
Fix unicode trouble in is_recursion_error()

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -438,7 +438,7 @@ def is_recursion_error(etype, value, records):
     # by stack frames in IPython itself. >500 frames probably indicates
     # a recursion error.
     return (etype is recursion_error_type) \
-           and "recursion" in str(value).lower() \
+           and str("recursion") in str(value).lower() \
            and len(records) > 500
 
 def find_recursion(etype, value, records):


### PR DESCRIPTION
```
Python 2.7.13 (default, Jun 12 2017, 13:34:39) 
Type "copyright", "credits" or "license" for more information.

IPython 5.4.1 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: raise RuntimeError("€")
---------------------------------------------------------------------------
UnicodeDecodeError                        Traceback (most recent call last)
/usr/local/src/sage-git/local/lib/python2.7/site-packages/IPython/core/interactiveshell.pyc in run_code(self, code_obj, result)
   2897             if result is not None:
   2898                 result.error_in_exec = sys.exc_info()[1]
-> 2899             self.showtraceback()
   2900         else:
   2901             outflag = 0

/usr/local/src/sage-git/local/lib/python2.7/site-packages/IPython/core/interactiveshell.pyc in showtraceback(self, exc_tuple, filename, tb_offset, exception_only)
   1824                     except Exception:
   1825                         stb = self.InteractiveTB.structured_traceback(etype,
-> 1826                                             value, tb, tb_offset=tb_offset)
   1827 
   1828                     self._showtraceback(etype, value, stb)

/usr/local/src/sage-git/local/lib/python2.7/site-packages/IPython/core/ultratb.pyc in structured_traceback(self, etype, value, tb, tb_offset, number_of_lines_of_context)                                                                                                                                                                       
   1410         self.tb = tb
   1411         return FormattedTB.structured_traceback(
-> 1412             self, etype, value, tb, tb_offset, number_of_lines_of_context)
   1413 
   1414 

/usr/local/src/sage-git/local/lib/python2.7/site-packages/IPython/core/ultratb.pyc in structured_traceback(self, etype, value, tb, tb_offset, number_of_lines_of_context)
   1318             # Verbose modes need a full traceback
   1319             return VerboseTB.structured_traceback(
-> 1320                 self, etype, value, tb, tb_offset, number_of_lines_of_context
   1321             )
   1322         else:

/usr/local/src/sage-git/local/lib/python2.7/site-packages/IPython/core/ultratb.pyc in structured_traceback(self, etype, evalue, etb, tb_offset, number_of_lines_of_context)
   1168 
   1169         formatted_exception = self.format_exception_as_a_whole(etype, evalue, etb, number_of_lines_of_context,
-> 1170                                                                tb_offset)
   1171 
   1172         colors = self.Colors  # just a shorthand + quicker name lookup

/usr/local/src/sage-git/local/lib/python2.7/site-packages/IPython/core/ultratb.pyc in format_exception_as_a_whole(self, etype, evalue, etb, number_of_lines_of_context, tb_offset)
   1111             return ""
   1112 
-> 1113         last_unique, recursion_repeat = find_recursion(orig_etype, evalue, records)
   1114 
   1115         frames = self.format_records(records, last_unique, recursion_repeat)

/usr/local/src/sage-git/local/lib/python2.7/site-packages/IPython/core/ultratb.pyc in find_recursion(etype, value, records)
    453     # quarter of the traceback (250 frames by default) is repeats, and find the
    454     # first frame (from in to out) that looks different.
--> 455     if not is_recursion_error(etype, value, records):
    456         return len(records), 0
    457 

/usr/local/src/sage-git/local/lib/python2.7/site-packages/IPython/core/ultratb.pyc in is_recursion_error(etype, value, records)
    439     # a recursion error.
    440     return (etype is recursion_error_type) \
--> 441            and "recursion" in str(value).lower() \
    442            and len(records) > 500
    443 

UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 0: ordinal not in range(128)
```