### PR TITLE
Make IPython work with OpenSSL in FIPS mode

### DIFF
--- a/IPython/core/compilerop.py
+++ b/IPython/core/compilerop.py
@@ -55,7 +55,7 @@ def code_name(code, number=0):
     
     This now expects code to be unicode.
     """
-    hash_digest = hashlib.md5(code.encode("utf-8")).hexdigest()
+    hash_digest = hashlib.sha1(code.encode("utf-8")).hexdigest()
     # Include the number and 12 characters of the hash in the name.  It's
     # pretty much impossible that in a single session we'll have collisions
     # even with truncated hashes, and the full one makes tracebacks too long


### PR DESCRIPTION
`md5` is not supported with OpenSSL in FIPS mode, hence moving `md5` to `sha1`

closes  #10615