### PR TITLE
Store last execution result in the interactive shell instance

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -431,6 +431,8 @@ class InteractiveShell(SingletonConfigurable):
 
     last_execution_succeeded = Bool(True, help='Did last executed command succeeded')
 
+    last_execution_result = Instance('IPython.core.interactiveshell.ExecutionResult', help='Result of executing the last command', allow_none=True)
+
     def __init__(self, ipython_dir=None, profile_dir=None,
                  user_module=None, user_ns=None,
                  custom_exceptions=((), None), **kwargs):
@@ -2613,7 +2615,7 @@ class InteractiveShell(SingletonConfigurable):
         result = ExecutionResult()
 
         if (not raw_cell) or raw_cell.isspace():
-            self.last_execution_succeeded = True
+            self.last_execution_succeeded, self.last_execution_result = True, result
             return result
         
         if silent:
@@ -2624,7 +2626,7 @@ class InteractiveShell(SingletonConfigurable):
 
         def error_before_exec(value):
             result.error_before_exec = value
-            self.last_execution_succeeded = False
+            self.last_execution_succeeded, self.last_execution_result = False, result
             return result
 
         self.events.trigger('pre_execute')
@@ -2714,7 +2716,7 @@ class InteractiveShell(SingletonConfigurable):
                 has_raised = self.run_ast_nodes(code_ast.body, cell_name,
                    interactivity=interactivity, compiler=compiler, result=result)
                 
-                self.last_execution_succeeded = not has_raised
+                self.last_execution_succeeded, self.last_execution_result = not has_raised, result
 
                 # Reset this so later displayed values do not modify the
                 # ExecutionResult

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1279,6 +1279,10 @@ class InteractiveShell(SingletonConfigurable):
                 for name in to_delete:
                     del ns[name]
 
+            # Ensure it is removed from the last execution result
+            if self.last_execution_result.result is obj:
+                self.last_execution_result = None
+
             # displayhook keeps extra references, but not in a dictionary
             for name in ('_', '__', '___'):
                 if getattr(self.displayhook, name) is obj:

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1213,6 +1213,10 @@ class InteractiveShell(SingletonConfigurable):
         if new_session:
             self.execution_count = 1
 
+        # Reset last execution result
+        self.last_execution_succeeded = True
+        self.last_execution_result = None
+        
         # Flush cached output items
         if self.displayhook.do_full_cache:
             self.displayhook.flush()
@@ -2619,7 +2623,8 @@ class InteractiveShell(SingletonConfigurable):
         result = ExecutionResult()
 
         if (not raw_cell) or raw_cell.isspace():
-            self.last_execution_succeeded, self.last_execution_result = True, result
+            self.last_execution_succeeded = True
+            self.last_execution_result = result
             return result
         
         if silent:
@@ -2630,7 +2635,8 @@ class InteractiveShell(SingletonConfigurable):
 
         def error_before_exec(value):
             result.error_before_exec = value
-            self.last_execution_succeeded, self.last_execution_result = False, result
+            self.last_execution_succeeded = False
+            self.last_execution_result = result
             return result
 
         self.events.trigger('pre_execute')
@@ -2720,7 +2726,8 @@ class InteractiveShell(SingletonConfigurable):
                 has_raised = self.run_ast_nodes(code_ast.body, cell_name,
                    interactivity=interactivity, compiler=compiler, result=result)
                 
-                self.last_execution_succeeded, self.last_execution_result = not has_raised, result
+                self.last_execution_succeeded = not has_raised
+                self.last_execution_result = result
 
                 # Reset this so later displayed values do not modify the
                 # ExecutionResult

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -470,6 +470,17 @@ class InteractiveShellTestCase(unittest.TestCase):
         text = ip.object_inspect_text('a')
         self.assertIsInstance(text, str)
 
+    def test_last_execution_result(self):
+        """ Check that last execution result gets set correctly (GH-10702) """
+        result = ip.run_cell('a = 5; a')
+        self.assertTrue(ip.last_execution_succeeded)
+        self.assertEqual(ip.last_execution_result.result, 5)
+
+        result = ip.run_cell('a = x_invalid_id_x')
+        self.assertFalse(ip.last_execution_succeeded)
+        self.assertFalse(ip.last_execution_result.success)
+        self.assertIsInstance(ip.last_execution_result.error_in_exec, NameError)
+
 
 class TestSafeExecfileNonAsciiPath(unittest.TestCase):
 


### PR DESCRIPTION
## Overview
Please see  #10702 for more context on this PR. 

The shell contains a ``last_execution_succeeded`` field which (for instances) lets event handlers know if a cell execution succeeded or not. 

However, if the execution failed, there is no way for an event handler to get to the error itself.  

This PR adds a ``last_execution_result`` field to the shell that stores a reference to the ``ExecutionResult`` object resulting from the evaluation of the last cell. If the execution failed, there is a way to get to the error using ``shell.last_execution_result.error_in_exec``.

## Validation
I added a simple unit test to verify both successful and failed runs based on existing tests. This is my first contribution to IPython so please let me know if I'm not doing something right :-) 

## Issues
I would like to access the full stack trace in addition to the final error. However, this seems like a fairly involved change. I'm guessing one might do this by adding the output of ``_get_exc_info`` to the ``ExecutionResult`` but I'm open to suggestions.