### PR TITLE
Correct suggested git commands for checkout 5.x

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ use IPython from source. You need to checkout the remote 5.x branch. If you are
 using git the following should work:
 
   $ git fetch origin
-  $ git checkout -b origin/5.x
+  $ git checkout 5.x
 
 If you encounter this error message with a regular install of IPython, then you
 likely need to update your package manager, for example if you are using `pip`


### PR DESCRIPTION
The current instructions suggest `git checkout -b origin/5.x`, but this creates a new branch off of the current commit with the confusing name "origin/5.x" instead of creating a local branch with the default upstream of origin/5.x.

Some better options include:
1. `git checkout origin/5.x` - prints unnerving error message about detached head, but successfully checkout out 5.x
2. `git checkout -b 5.x origin/5.x` - create a new branch off of origin/5.x, tracking origin/5.x - unfortunately confusing to type
3. `git checkout 5.x` - for git 1.7.2.3 (2010) and higher (according to [second hand source](https://stackoverflow.com/questions/9537392/git-fetch-remote-branch)) does the same as command 2.
4. `git checkout --track origin/daves_branch` does the same for even older versions of git.

I propose `git checkout -b 5.x origin/5.x` so as to make no assumptions about git version and to avoid the "detached head" warning that can be unnerving, and to prepare users to later pull to a tracking branch for updates. But we can rely on git version installed being less than 7 years old, `git checkout 5.x` would be better.