### PR TITLE
Support gif files, urls, and format

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -257,7 +257,7 @@ def display(*objs, include=None, exclude=None, metadata=None, transient=None, di
       - `_repr_json_`: return a JSONable dict
       - `_repr_jpeg_`: return raw JPEG data
       - `_repr_png_`: return raw PNG data
-      - `_repr_gif_`: return raw PNG data
+      - `_repr_gif_`: return raw GIF data
       - `_repr_svg_`: return raw SVG data as a string
       - `_repr_latex_`: return LaTeX commands in a string surrounded by "$".
       - `_repr_mimebundle_`: return a full mimebundle containing the mapping
@@ -945,7 +945,7 @@ class Javascript(TextDisplayObject):
             raise TypeError('expected sequence, got: %r' % css)
         self.lib = lib
         self.css = css
-        superg(Javascript, self).__init__(data=data, url=url, filename=filename)
+        super(Javascript, self).__init__(data=data, url=url, filename=filename)
 
     def _repr_javascript_(self):
         r = ''

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -965,8 +965,7 @@ def _pngxy(data):
     """read the (width, height) from a PNG header"""
     ihdr = data.index(b'IHDR')
     # next 8 bytes are width/height
-    w4h4 = data[ihdr+4:ihdr+12]
-    return struct.unpack('>ii', w4h4)
+    return struct.unpack('>ii', data[ihdr+4:ihdr+12])
 
 def _jpegxy(data):
     """read the (width, height) from a JPEG header"""
@@ -984,8 +983,11 @@ def _jpegxy(data):
             # read another block
             idx += 2
 
-    h, w = struct.unpack('>HH', data[iSOF+5:iSOF+9])
-    return w, h
+    return struct.unpack('>HH', data[iSOF+5:iSOF+9])
+    
+def _gifxy(data):
+    """read the (width, height) from a GIF header"""
+    return struct.unpack('<HH', data[6:10])
 
 class Image(DisplayObject):
 
@@ -1126,7 +1128,7 @@ class Image(DisplayObject):
         elif self.format == self._FMT_JPEG:
             w, h = _jpegxy(self.data)
         elif self.format == self._FMT_GIF:
-            w, h = _pngxy(self.data)
+            w, h = _gifxy(self.data)
         else:
             # retina only supports png
             return

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -1079,8 +1079,7 @@ class Image(DisplayObject):
                 if ext == u'png':
                     format = self._FMT_PNG
                 if ext == u'gif':
-                    # use PNG format until we understand why GIF is not working
-                    format = self._FMT_PNG
+                    format = self._FMT_GIF
                 else:
                     format = ext.lower()
             elif isinstance(data, bytes):
@@ -1097,10 +1096,6 @@ class Image(DisplayObject):
             # jpg->jpeg
             format = self._FMT_JPEG
             
-        if format == self._FMT_GIF:
-            # use PNG format until we understand why GIF is not working
-            format = self._FMT_PNG
-
         self.format = format.lower()
         self.embed = embed if embed is not None else (url is None)
 
@@ -1130,6 +1125,8 @@ class Image(DisplayObject):
             w, h = _pngxy(self.data)
         elif self.format == self._FMT_JPEG:
             w, h = _jpegxy(self.data)
+        elif self.format == self._FMT_GIF:
+            w, h = _pngxy(self.data)
         else:
             # retina only supports png
             return
@@ -1184,7 +1181,7 @@ class Image(DisplayObject):
             return self._data_and_metadata()
             
     def _repr_gif_(self):
-        if self.embed and self.format == self._FMT_PNG:
+        if self.embed and self.format == self._FMT_GIF:
             return self._data_and_metadata()
 
     def _find_ext(self, s):

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -74,6 +74,7 @@ class DisplayFormatter(Configurable):
             MarkdownFormatter,
             SVGFormatter,
             PNGFormatter,
+            GIFFormatter,
             PDFFormatter,
             JPEGFormatter,
             LatexFormatter,
@@ -779,6 +780,24 @@ class JPEGFormatter(BaseFormatter):
     _return_type = (bytes, str)
 
 
+class GIFFormatter(BaseFormatter):
+    """A PNG formatter.
+
+    To define the callables that compute the GIF representation of your
+    objects, define a :meth:`_repr_gif_` method or use the :meth:`for_type`
+    or :meth:`for_type_by_name` methods to register functions that handle
+    this.
+
+    The return value of this formatter should be raw GIF data, *not*
+    base64 encoded.
+    """
+    format_type = Unicode('image/gif')
+
+    print_method = ObjectName('_repr_gif_')
+    
+    _return_type = (bytes, str)
+
+
 class LatexFormatter(BaseFormatter):
     """A LaTeX formatter.
 
@@ -973,6 +992,7 @@ FormatterABC.register(HTMLFormatter)
 FormatterABC.register(MarkdownFormatter)
 FormatterABC.register(SVGFormatter)
 FormatterABC.register(PNGFormatter)
+FormatterABC.register(GIFFormatter)
 FormatterABC.register(PDFFormatter)
 FormatterABC.register(JPEGFormatter)
 FormatterABC.register(LatexFormatter)

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -77,8 +77,8 @@ def test_base64image():
 def test_image_filename_defaults():
     '''test format constraint, and validity of jpeg and png'''
     tpath = ipath.get_ipython_package_dir()
-    # nt.assert_raises(ValueError, display.Image, filename=os.path.join(tpath, 'testing/tests/badformat.gif'),
-    #                  embed=True)
+    nt.assert_raises(ValueError, display.Image, filename=os.path.join(tpath, 'testing/tests/badformat.zip'),
+                     embed=True)
     nt.assert_raises(ValueError, display.Image)
     nt.assert_raises(ValueError, display.Image, data='this is not an image', format='badformat', embed=True)
     # check boths paths to allow packages to test at build and install time

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -77,8 +77,8 @@ def test_base64image():
 def test_image_filename_defaults():
     '''test format constraint, and validity of jpeg and png'''
     tpath = ipath.get_ipython_package_dir()
-    nt.assert_raises(ValueError, display.Image, filename=os.path.join(tpath, 'testing/tests/badformat.gif'),
-                     embed=True)
+    # nt.assert_raises(ValueError, display.Image, filename=os.path.join(tpath, 'testing/tests/badformat.gif'),
+    #                  embed=True)
     nt.assert_raises(ValueError, display.Image)
     nt.assert_raises(ValueError, display.Image, data='this is not an image', format='badformat', embed=True)
     # check boths paths to allow packages to test at build and install time

--- a/IPython/utils/capture.py
+++ b/IPython/utils/capture.py
@@ -48,6 +48,9 @@ class RichOutput(object):
     
     def _repr_jpeg_(self):
         return self._repr_mime_("image/jpeg")
+        
+    def _repr_gif_(self):
+        return self._repr_mime_("image/gif")
     
     def _repr_svg_(self):
         return self._repr_mime_("image/svg+xml")
@@ -162,5 +165,3 @@ class capture_output(object):
         if self.display and self.shell:
             self.shell.display_pub = self.save_display_pub
             sys.displayhook = self.save_display_hook
-
-


### PR DESCRIPTION
This supports the following usage:

```py
from IPython.display import Image, HTML, display

Image(filename="../giphy.gif")

Image(url="https://media.giphy.com/media/xUA7b6vHi778bTElqg/giphy.gif")

with open('../giphy.gif','rb') as f:
    display(Image(data=f.read()), format="gif")
```

It uses the png format because it wasn't working otherwise.

Depends on a new ipykernel release that includes https://github.com/ipython/ipykernel/pull/254.

Closes https://github.com/ipython/ipython/issues/10045