### PR TITLE
Make recursive pdb properly invoke IPython's enhanced pdb

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -545,6 +545,25 @@ class Pdb(OldPdb):
         self.print_list_lines(self.curframe.f_code.co_filename, lineno, last)
     do_ll = do_longlist
 
+    def do_debug(self, arg):
+        """debug code
+        Enter a recursive debugger that steps through the code
+        argument (which is an arbitrary expression or statement to be
+        executed in the current environment).
+        """
+        sys.settrace(None)
+        globals = self.curframe.f_globals
+        locals = self.curframe_locals
+        p = self.__class__(completekey=self.completekey,
+                           stdin=self.stdin, stdout=self.stdout)
+        p.use_rawinput = self.use_rawinput
+        p.prompt = "(%s) " % self.prompt.strip()
+        self.message("ENTERING RECURSIVE DEBUGGER")
+        sys.call_tracing(p.run, (arg, globals, locals))
+        self.message("LEAVING RECURSIVE DEBUGGER")
+        sys.settrace(self.trace_dispatch)
+        self.lastcmd = p.lastcmd
+
     def do_pdef(self, arg):
         """Print the call signature for any callable object.
 


### PR DESCRIPTION
The problem is that `Pdb.do_debug` creates a new instance of the original `Pdb` rather than our derived `Pdb`/`TerminalPdb`. So I copied [Lib/pdb.py:1087-1102](https://github.com/python/cpython/blob/ceb93f4540981e3f9af66bd936920186aba813fc/Lib/pdb.py#L1087-L1102) and made it use our own class instead.

I had to:
1. Switch to keyword arguments because IPython changes `Pdb`'s init signature.
2. Add a line to propagate `use_rawinput`. Without that the propagation of `stdout` triggers `use_rawinput = 0`, breaking `TerminalPdb`. This is probably a bug in Python, see: [bpo-31078](http://bugs.python.org/issue31078).

For IPython 5, the `self.message` lines need to be changed to a `print`. See [Lib/pdb.py:712-722 (2.7)](https://github.com/python/cpython/blob/fa90179e071668c431e725a29f8c88d8d25ec887/Lib/pdb.py#L712-L722).

- [ ] Do we want to change the nested `Pdb`'s prompt calculation? Now it uses `(ipdb>) `, adding more parentheses to each nesting level (`Pdb`'s default prompt is `(Pdb) `).

Fixes #1273