### PR TITLE
[Prototype] Generalize magic machinery to allow completion.

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1802,6 +1802,15 @@ class IPCompleter(Completer):
         have lots of processing to do.
 
         """
+        if full_text.startswith('%%') and '\n' in full_text:
+            line, *rest = full_text.split('\n')
+            magic = line.split(' ')[0][2:]
+            magic_completer = self.shell.magics_manager.magics['completer'].get(magic, None)
+            if magic_completer:
+                for c in magic_completer(line, '\n'.join(rest), offset):
+                    assert c.start <= offset
+                    yield c
+            return
         deadline = time.monotonic() + _timeout
 
 

--- a/IPython/core/magics/display.py
+++ b/IPython/core/magics/display.py
@@ -14,12 +14,13 @@
 # Our own packages
 from IPython.core.display import display, Javascript, Latex, SVG, HTML, Markdown
 from IPython.core.magic import  (
-    Magics, magics_class, cell_magic
+    Magics, magics_class, cell_magic, completer_for
 )
 
 #-----------------------------------------------------------------------------
 # Magic implementation classes
 #-----------------------------------------------------------------------------
+
 
 
 @magics_class

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -1028,7 +1028,7 @@ def test_ls_magic():
     lsmagic = ip.magic('lsmagic')
     with warnings.catch_warnings(record=True) as w:
         j = json_formatter(lsmagic)
-    nt.assert_equal(sorted(j), ['cell', 'line'])
+    nt.assert_equal(sorted(j), ['cell', 'completer', 'line'])
     nt.assert_equal(w, []) # no warnings
 
 def test_strip_initial_indent():

--- a/IPython/terminal/ptutils.py
+++ b/IPython/terminal/ptutils.py
@@ -8,6 +8,7 @@ not to be used outside IPython.
 # Distributed under the terms of the Modified BSD License.
 
 import unicodedata
+
 from wcwidth import wcwidth
 
 from IPython.core.completer import (

--- a/docs/source/config/custommagics.rst
+++ b/docs/source/config/custommagics.rst
@@ -249,3 +249,16 @@ Now try the following::
 
 You should get ``Shazam`` and ``Supercalifragilisticexpialidocious`` as
 potential completions.
+
+Limitations
+~~~~~~~~~~~
+
+The ability to complete magics is still limited but should improve with time,
+here are a number of current limitations:
+
+  - Completion will not work while the kernel is busy.
+  - Completions are registered for a given magic, but the magics may be renamed
+    by the user in which case the completion will not dispatch correctly.
+  - If a custom completer is added to a magic, there the normal Python
+    completions will not be triggered.
+


### PR DESCRIPTION
In particular useful for multi language integration. One of defect is
that you can't really complete. But what you can do is actually
dispatch the completion to the Magic Class (if you really interested in
integration anyway you go with a magic Class. And dispatch to the class.

So far it completes only for cell magics. I need to poke at
InputSpliter to know if we can figure out we're completing a line magic
which is not at the beginning of the line.

There are a few question remaining:
  - How to tell IPython to give-up (or not) on completing using jedi and
  Python completion. Indeed for %%timeit you just want to __extend__
  completion with your own. For %%sql, you don't want to include Python
  completions.
  - What API should we provide ?
    - here is line/cell/cursor figure things out with a single function
    - Allow user to register a separate completer for the first line,
    and the core of the cell independently.

I'd like to have a prototype that can forward the completion to another
kernel (hook into the python2 magic and have a Python 3 kernel that
control a Python2 kernel ?

-- 
CC @ivanov 