### PR TITLE
Fix completing options for %colors magic

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1274,10 +1274,14 @@ class IPCompleter(Completer):
 
     def magic_color_matches(self, text:str) -> List[str] :
         """ Match color schemes for %colors magic"""
-        texts = text.strip().split()
+        texts = text.split()
+        if text.endswith(' '):
+            # .split() strips off the trailing whitespace. Add '' back
+            # so that: '%colors ' -> ['%colors', '']
+            texts.append('')
 
-        if len(texts) > 0 and (texts[0] == 'colors' or texts[0] == '%colors'):
-            prefix = texts[1] if len(texts) > 1 else ''
+        if len(texts) == 2 and (texts[0] == 'colors' or texts[0] == '%colors'):
+            prefix = texts[1]
             return [ color for color in InspectColors.keys()
                      if color.startswith(prefix) ]
         return []

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -628,6 +628,8 @@ def test_magic_color():
     nt.assert_in('%colors', matches)
     s, matches = c.complete(None, 'colo')
     nt.assert_not_in('NoColor', matches)
+    s, matches = c.complete(None, '%colors')  # No trailing space
+    nt.assert_not_in('NoColor', matches)
     s, matches = c.complete(None, 'colors ')
     nt.assert_in('NoColor', matches)
     s, matches = c.complete(None, '%colors ')


### PR DESCRIPTION
Don't complete until there's a space after the magic name.

Closes gh-10718