### PR TITLE
Smarter documentation of config options

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -76,7 +76,7 @@ source/interactive/magics-generated.txt: autogen_magics.py
 
 autoconfig: source/config/options/config-generated.txt
 
-source/config/options/config-generated.txt:
+source/config/options/config-generated.txt: autogen_config.py
 	$(PYTHON) autogen_config.py
 	@echo "Created docs for config options"
 

--- a/docs/autogen_config.py
+++ b/docs/autogen_config.py
@@ -4,10 +4,64 @@ from os.path import join, dirname, abspath
 
 from IPython.terminal.ipapp import TerminalIPythonApp
 from ipykernel.kernelapp import IPKernelApp
+from traitlets import Undefined
 
 here = abspath(dirname(__file__))
 options = join(here, 'source', 'config', 'options')
 generated = join(options, 'config-generated.txt')
+
+from ipython_genutils.text import indent, dedent
+
+def interesting_default_value(dv):
+    if (dv is None) or (dv is Undefined):
+        return False
+    if isinstance(dv, (str, list, tuple, dict, set)):
+        return bool(dv)
+    return True
+
+def class_config_rst_doc(cls):
+    """Generate rST documentation for this class' config options.
+
+    Excludes traits defined on parent classes.
+    """
+    lines = []
+    classname = cls.__name__
+    for k, trait in sorted(cls.class_traits(config=True).items()):
+        ttype = trait.__class__.__name__
+
+        lines += ['.. configtrait:: ' + classname + '.' + trait.name,
+                  ''
+                 ]
+
+        help = trait.help.rstrip() or 'No description'
+        lines.append(indent(dedent(help), 4) + '\n')
+
+        # Choices or type
+        if 'Enum' in ttype:
+            # include Enum choices
+            lines.append(indent(
+                ':options: ' + ', '.join('``%r``' % x for x in trait.values), 4))
+        else:
+            lines.append(indent(':trait type: ' + ttype, 4))
+
+        # Default value
+        # Ignore boring default values like None, [] or ''
+        if interesting_default_value(trait.default_value):
+            try:
+                dvr = trait.default_value_repr()
+            except Exception:
+                dvr = None  # ignore defaults we can't construct
+            if dvr is not None:
+                if len(dvr) > 64:
+                    dvr = dvr[:61] + '...'
+                # Double up backslashes, so they get to the rendered docs
+                dvr = dvr.replace('\\n', '\\\\n')
+                lines.append(indent(':default: ``%s``' % dvr, 4))
+
+        # Blank line
+        lines.append('')
+
+    return '\n'.join(lines)
 
 
 def write_doc(name, title, app, preamble=None):
@@ -18,7 +72,11 @@ def write_doc(name, title, app, preamble=None):
         f.write('\n')
         if preamble is not None:
             f.write(preamble + '\n\n')
-        f.write(app.document_config_options())
+        #f.write(app.document_config_options())
+
+        for c in app._classes_inc_parents():
+            f.write(class_config_rst_doc(c))
+            f.write('\n')
 
 
 if __name__ == '__main__':

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,6 +62,7 @@ extensions = [
     'sphinx.ext.napoleon',  # to preprocess docstrings
     'github',  # for easy GitHub links
     'magics',
+    'configtraits',
 ]
 
 if ON_RTD:

--- a/docs/sphinxext/configtraits.py
+++ b/docs/sphinxext/configtraits.py
@@ -1,0 +1,17 @@
+"""Directives and roles for documenting traitlets config options.
+
+::
+
+    .. configtrait:: Application.log_datefmt
+
+        Description goes here.
+
+    Cross reference like this: :configtrait:`Application.log_datefmt`.
+"""
+from sphinx.locale import l_
+from sphinx.util.docfields import Field
+
+def setup(app):
+    app.add_object_type('configtrait', 'configtrait', objname='Config option')
+    metadata = {'parallel_read_safe': True, 'parallel_write_safe': True}
+    return metadata


### PR DESCRIPTION
* Make config options individually linkable (I've wanted this for ages)
  * As a side effect, they also show up as objects in Sphinx's search.
* Only show default values when they're interesting (not like `''` or `[]`)
* Show any command line aliases which map to a config option.

Before:

![screenshot from 2017-08-04 15-55-10](https://user-images.githubusercontent.com/327925/28974172-5df8ff88-792d-11e7-9b57-f614cf23dac2.png)

After:

![screenshot from 2017-08-04 15-55-17](https://user-images.githubusercontent.com/327925/28974178-632949ae-792d-11e7-9e3b-e28ef694378b.png)
