### PR TITLE
preserve priority of user-registered per-mime renderers

### DIFF
--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -159,8 +159,17 @@ class DisplayFormatter(Configurable):
 
         for format_type, formatter in self.formatters.items():
             if format_type in format_dict:
-                # already got it from mimebundle, don't render again
-                continue
+                # already got it from mimebundle, maybe don't render again.
+                # exception: manually registered per-mime renderer
+                # check priority:
+                # 1. user-registered per-mime formatter
+                # 2. mime-bundle (user-registered or repr method)
+                # 3. default per-mime formatter (e.g. repr method)
+                try:
+                    formatter.lookup(obj)
+                except KeyError:
+                    # no special formatter, use mime-bundle-provided value
+                    continue
             if include and format_type not in include:
                 continue
             if exclude and format_type in exclude:


### PR DESCRIPTION
fixes case where `_repr_mimebundle_` method had higher priority than custom user-registered formatters for single mime-types.

There's one case that's ambiguous: user-registered *both* mime-bundle and single-mime for the same mime-type.

- Prioritizing mime-bundle matches the priority of methods
- Prioritizing single-mime allows the "more specific" choice to take precedence (current state)

I think both make sense, but I would lean slightly toward the second option, which this PR currently implements.

Brought up in comments in #10651

cc @Carreau