### PR TITLE
implement GIF support without registering a new formatter

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -951,7 +951,8 @@ def _jpegxy(data):
             # read another block
             idx += 2
 
-    return struct.unpack('>HH', data[iSOF+5:iSOF+9])
+    h, w = struct.unpack('>HH', data[iSOF+5:iSOF+9])
+    return w, h
 
 def _gifxy(data):
     """read the (width, height) from a GIF header"""

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -257,7 +257,7 @@ def display(*objs, include=None, exclude=None, metadata=None, transient=None, di
       - `_repr_json_`: return a JSONable dict
       - `_repr_jpeg_`: return raw JPEG data
       - `_repr_png_`: return raw PNG data
-      - `_repr_gif_`: return raw PNG data
+      - `_repr_gif_`: return raw GIF data
       - `_repr_svg_`: return raw SVG data as a string
       - `_repr_latex_`: return LaTeX commands in a string surrounded by "$".
       - `_repr_mimebundle_`: return a full mimebundle containing the mapping
@@ -945,7 +945,7 @@ class Javascript(TextDisplayObject):
             raise TypeError('expected sequence, got: %r' % css)
         self.lib = lib
         self.css = css
-        superg(Javascript, self).__init__(data=data, url=url, filename=filename)
+        super(Javascript, self).__init__(data=data, url=url, filename=filename)
 
     def _repr_javascript_(self):
         r = ''

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -965,8 +965,7 @@ def _pngxy(data):
     """read the (width, height) from a PNG header"""
     ihdr = data.index(b'IHDR')
     # next 8 bytes are width/height
-    w4h4 = data[ihdr+4:ihdr+12]
-    return struct.unpack('>ii', w4h4)
+    return struct.unpack('>ii', data[ihdr+4:ihdr+12])
 
 def _jpegxy(data):
     """read the (width, height) from a JPEG header"""
@@ -984,8 +983,11 @@ def _jpegxy(data):
             # read another block
             idx += 2
 
-    h, w = struct.unpack('>HH', data[iSOF+5:iSOF+9])
-    return w, h
+    return struct.unpack('>HH', data[iSOF+5:iSOF+9])
+    
+def _gifxy(data):
+    """read the (width, height) from a GIF header"""
+    return struct.unpack('<HH', data[6:10])
 
 class Image(DisplayObject):
 
@@ -1126,7 +1128,7 @@ class Image(DisplayObject):
         elif self.format == self._FMT_JPEG:
             w, h = _jpegxy(self.data)
         elif self.format == self._FMT_GIF:
-            w, h = _pngxy(self.data)
+            w, h = _gifxy(self.data)
         else:
             # retina only supports png
             return

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -1079,8 +1079,7 @@ class Image(DisplayObject):
                 if ext == u'png':
                     format = self._FMT_PNG
                 if ext == u'gif':
-                    # use PNG format until we understand why GIF is not working
-                    format = self._FMT_PNG
+                    format = self._FMT_GIF
                 else:
                     format = ext.lower()
             elif isinstance(data, bytes):
@@ -1097,10 +1096,6 @@ class Image(DisplayObject):
             # jpg->jpeg
             format = self._FMT_JPEG
             
-        if format == self._FMT_GIF:
-            # use PNG format until we understand why GIF is not working
-            format = self._FMT_PNG
-
         self.format = format.lower()
         self.embed = embed if embed is not None else (url is None)
 
@@ -1130,6 +1125,8 @@ class Image(DisplayObject):
             w, h = _pngxy(self.data)
         elif self.format == self._FMT_JPEG:
             w, h = _jpegxy(self.data)
+        elif self.format == self._FMT_GIF:
+            w, h = _pngxy(self.data)
         else:
             # retina only supports png
             return
@@ -1184,7 +1181,7 @@ class Image(DisplayObject):
             return self._data_and_metadata()
             
     def _repr_gif_(self):
-        if self.embed and self.format == self._FMT_PNG:
+        if self.embed and self.format == self._FMT_GIF:
             return self._data_and_metadata()
 
     def _find_ext(self, s):

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -74,7 +74,6 @@ class DisplayFormatter(Configurable):
             MarkdownFormatter,
             SVGFormatter,
             PNGFormatter,
-            GIFFormatter,
             PDFFormatter,
             JPEGFormatter,
             LatexFormatter,
@@ -780,24 +779,6 @@ class JPEGFormatter(BaseFormatter):
     _return_type = (bytes, str)
 
 
-class GIFFormatter(BaseFormatter):
-    """A PNG formatter.
-
-    To define the callables that compute the GIF representation of your
-    objects, define a :meth:`_repr_gif_` method or use the :meth:`for_type`
-    or :meth:`for_type_by_name` methods to register functions that handle
-    this.
-
-    The return value of this formatter should be raw GIF data, *not*
-    base64 encoded.
-    """
-    format_type = Unicode('image/gif')
-
-    print_method = ObjectName('_repr_gif_')
-    
-    _return_type = (bytes, str)
-
-
 class LatexFormatter(BaseFormatter):
     """A LaTeX formatter.
 
@@ -977,10 +958,7 @@ class MimeBundleFormatter(BaseFormatter):
             method = get_real_method(obj, self.print_method)
 
             if method is not None:
-                d = {}
-                d['include'] = include
-                d['exclude'] = exclude
-                return method(**d)
+                return method(include=include, exclude=exclude)
             return None
         else:
             return None
@@ -992,7 +970,6 @@ FormatterABC.register(HTMLFormatter)
 FormatterABC.register(MarkdownFormatter)
 FormatterABC.register(SVGFormatter)
 FormatterABC.register(PNGFormatter)
-FormatterABC.register(GIFFormatter)
 FormatterABC.register(PDFFormatter)
 FormatterABC.register(JPEGFormatter)
 FormatterABC.register(LatexFormatter)
@@ -1006,19 +983,6 @@ def format_display_data(obj, include=None, exclude=None):
     """Return a format data dict for an object.
 
     By default all format types will be computed.
-
-    The following MIME types are currently implemented:
-
-    * text/plain
-    * text/html
-    * text/markdown
-    * text/latex
-    * application/json
-    * application/javascript
-    * application/pdf
-    * image/png
-    * image/jpeg
-    * image/svg+xml
 
     Parameters
     ----------

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -74,6 +74,7 @@ class DisplayFormatter(Configurable):
             MarkdownFormatter,
             SVGFormatter,
             PNGFormatter,
+            GIFFormatter,
             PDFFormatter,
             JPEGFormatter,
             LatexFormatter,
@@ -779,6 +780,24 @@ class JPEGFormatter(BaseFormatter):
     _return_type = (bytes, str)
 
 
+class GIFFormatter(BaseFormatter):
+    """A PNG formatter.
+
+    To define the callables that compute the GIF representation of your
+    objects, define a :meth:`_repr_gif_` method or use the :meth:`for_type`
+    or :meth:`for_type_by_name` methods to register functions that handle
+    this.
+
+    The return value of this formatter should be raw GIF data, *not*
+    base64 encoded.
+    """
+    format_type = Unicode('image/gif')
+
+    print_method = ObjectName('_repr_gif_')
+    
+    _return_type = (bytes, str)
+
+
 class LatexFormatter(BaseFormatter):
     """A LaTeX formatter.
 
@@ -973,6 +992,7 @@ FormatterABC.register(HTMLFormatter)
 FormatterABC.register(MarkdownFormatter)
 FormatterABC.register(SVGFormatter)
 FormatterABC.register(PNGFormatter)
+FormatterABC.register(GIFFormatter)
 FormatterABC.register(PDFFormatter)
 FormatterABC.register(JPEGFormatter)
 FormatterABC.register(LatexFormatter)

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -77,8 +77,8 @@ def test_base64image():
 def test_image_filename_defaults():
     '''test format constraint, and validity of jpeg and png'''
     tpath = ipath.get_ipython_package_dir()
-    # nt.assert_raises(ValueError, display.Image, filename=os.path.join(tpath, 'testing/tests/badformat.gif'),
-    #                  embed=True)
+    nt.assert_raises(ValueError, display.Image, filename=os.path.join(tpath, 'testing/tests/badformat.zip'),
+                     embed=True)
     nt.assert_raises(ValueError, display.Image)
     nt.assert_raises(ValueError, display.Image, data='this is not an image', format='badformat', embed=True)
     # check boths paths to allow packages to test at build and install time

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -32,6 +32,15 @@ def test_image_size():
     nt.assert_equal(u'<img src="%s" class="unconfined"/>' % (thisurl), img._repr_html_())
 
 
+def test_image_mimes():
+    fmt = get_ipython().display_formatter.format
+    for format in display.Image._ACCEPTABLE_EMBEDDINGS:
+        mime = display.Image._MIMETYPES[format]
+        img = display.Image(b'garbage', format=format)
+        data, metadata = fmt(img)
+        nt.assert_equal(sorted(data), sorted([mime, 'text/plain']))
+
+
 def test_geojson():
 
     gj = display.GeoJSON(data={
@@ -361,3 +370,4 @@ def test_display_handle():
         },
         'update': True,
     })
+

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -77,8 +77,8 @@ def test_base64image():
 def test_image_filename_defaults():
     '''test format constraint, and validity of jpeg and png'''
     tpath = ipath.get_ipython_package_dir()
-    nt.assert_raises(ValueError, display.Image, filename=os.path.join(tpath, 'testing/tests/badformat.gif'),
-                     embed=True)
+    # nt.assert_raises(ValueError, display.Image, filename=os.path.join(tpath, 'testing/tests/badformat.gif'),
+    #                  embed=True)
     nt.assert_raises(ValueError, display.Image)
     nt.assert_raises(ValueError, display.Image, data='this is not an image', format='badformat', embed=True)
     # check boths paths to allow packages to test at build and install time

--- a/IPython/utils/capture.py
+++ b/IPython/utils/capture.py
@@ -48,6 +48,9 @@ class RichOutput(object):
     
     def _repr_jpeg_(self):
         return self._repr_mime_("image/jpeg")
+        
+    def _repr_gif_(self):
+        return self._repr_mime_("image/gif")
     
     def _repr_svg_(self):
         return self._repr_mime_("image/svg+xml")
@@ -162,5 +165,3 @@ class capture_output(object):
         if self.display and self.shell:
             self.shell.display_pub = self.save_display_pub
             sys.displayhook = self.save_display_hook
-
-

--- a/IPython/utils/capture.py
+++ b/IPython/utils/capture.py
@@ -30,7 +30,10 @@ class RichOutput(object):
             return data, self.metadata[mime]
         else:
             return data
-            
+
+    def _repr_mimebundle_(self, include=None, exclude=None):
+        return self.data, self.metadata
+
     def _repr_html_(self):
         return self._repr_mime_("text/html")
     
@@ -48,9 +51,6 @@ class RichOutput(object):
     
     def _repr_jpeg_(self):
         return self._repr_mime_("image/jpeg")
-        
-    def _repr_gif_(self):
-        return self._repr_mime_("image/gif")
     
     def _repr_svg_(self):
         return self._repr_mime_("image/svg+xml")


### PR DESCRIPTION
finishes up PR #10716

we shouldn't need to define a new Formatter class or `_repr_foo_` method ever again now that we have `_repr_mimebundle_`