### PR TITLE
Give the example for custom magics in the docs.

### DIFF
--- a/docs/source/config/custommagics.rst
+++ b/docs/source/config/custommagics.rst
@@ -84,12 +84,17 @@ IPython object:
 
 
     # In order to actually use these magics, you must register them with a
-    # running IPython.  This code must be placed in a file that is loaded once
-    # IPython is up and running:
-    ip = get_ipython()
-    # You can register the class itself without instantiating it.  IPython will
-    # call the default constructor on it.
-    ip.register_magics(MyMagics)
+    # running IPython.
+
+    def load_ipython_extension(ipython):
+        """
+        Any nodule file that define a function named load_ipython_extension can
+        be loaded via `load_ext` or be configured to be autoloaded by IPython at
+        startup time.
+        """
+        # You can register the class itself without instantiating it.  IPython will
+        # call the default constructor on it.
+        ipython.register_magics(MyMagics)
 
 If you want to create a class with a different constructor that holds
 additional state, then you should always call the parent constructor and
@@ -108,11 +113,16 @@ instantiate the class yourself before registration:
         
         # etc...
 
-    # This class must then be registered with a manually created instance,
-    # since its constructor has different arguments from the default:
-    ip = get_ipython()
-    magics = StatefulMagics(ip, some_data)
-    ip.register_magics(magics)
+    def load_ipython_extension(ipython):
+        """
+        Any nodule file that define a function named load_ipython_extension can
+        be loaded via `load_ext` or be configured to be autoloaded by IPython at
+        startup time.
+        """
+        # This class must then be registered with a manually created instance,
+        # since its constructor has different arguments from the default:
+        magics = StatefulMagics(ip, some_data)
+        ipython.register_magics(magics)
 
 
 .. note::

--- a/docs/source/config/custommagics.rst
+++ b/docs/source/config/custommagics.rst
@@ -88,9 +88,9 @@ IPython object:
 
     def load_ipython_extension(ipython):
         """
-        Any nodule file that define a function named load_ipython_extension can
-        be loaded via `load_ext` or be configured to be autoloaded by IPython at
-        startup time.
+        Any module file that define a function named `load_ipython_extension`
+        can be loaded via `%load_ext module.path` or be configured to be
+        autoloaded by IPython at startup time.
         """
         # You can register the class itself without instantiating it.  IPython will
         # call the default constructor on it.
@@ -115,13 +115,13 @@ instantiate the class yourself before registration:
 
     def load_ipython_extension(ipython):
         """
-        Any nodule file that define a function named load_ipython_extension can
-        be loaded via `load_ext` or be configured to be autoloaded by IPython at
-        startup time.
+        Any module file that define a function named `load_ipython_extension`
+        can be loaded via `%load_ext module.path` or be configured to be
+        autoloaded by IPython at startup time.
         """
         # This class must then be registered with a manually created instance,
         # since its constructor has different arguments from the default:
-        magics = StatefulMagics(ip, some_data)
+        magics = StatefulMagics(ipython, some_data)
         ipython.register_magics(magics)
 
 
@@ -133,3 +133,47 @@ instantiate the class yourself before registration:
    in IPython 5.  Maintainers of IPython extensions that still use the
    :func:`define_magic` function are advised to adjust their code
    for the current API.
+
+Complete Example
+================
+
+Here is a full example of a magic package. You can distribute magics using
+setuptools, distutils, or any other distribution tools like `flit
+<http://flit.readthedocs.io>` for pure Python packages.
+
+
+.. sourcecode::
+
+   .
+   ├── example_magic
+   │   ├── __init__.py
+   │   └── abracadabra.py
+   └── setup.py
+
+.. sourcecode::
+
+   $ cat example_magic/__init__.py
+   """An example magic"""
+   __version__ = '0.0.1'
+   
+   from .abracadabra import Abracadabra
+   
+   def load_ipython_extension(ipython):
+       ipython.register_magics(Abracadabra)
+
+.. sourcecode::
+
+    $ cat example_magic/abracadabra.py
+    from IPython.core.magic import (Magics, magics_class, line_magic, cell_magic)
+
+    @magics_class
+    class Abracadabra(Magics):
+
+        @line_magic
+        def abra(self, line):
+            return line
+
+        @cell_magic
+        def cadabra(self, line, cell):
+            return line, cell
+


### PR DESCRIPTION
The docs are registering magics by getting the current instance of
IPython and registering directly against it. A better approach is to
actually show the example on how to use the `load_ipython_extension`
function to correctly define a magic.