### PR TITLE
Don't show dev version warning in 5.x docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -85,13 +85,6 @@ if is_stable(iprelease['_version_extra']):
     tags.add('ipystable')
 else:
     tags.add('ipydev')
-    rst_prolog = """
-    .. warning::
-
-        This documentation is for a development version of IPython. There may be
-        significant differences from the latest stable release.
-
-    """
 
 # The master toctree document.
 master_doc = 'index'


### PR DESCRIPTION
http://ipython.readthedocs.io/en/5.x/

The warning that "This documentation is for a development version" is technically accurate, but misleading - the docs for the 5.x branch should be almost entirely representative of the latest 5.x release.