### PR TITLE
Fix typo in automagic docstring

### DIFF
--- a/IPython/core/magics/auto.py
+++ b/IPython/core/magics/auto.py
@@ -34,7 +34,7 @@ class AutoMagics(Magics):
     def automagic(self, parameter_s=''):
         """Make magic functions callable without having to type the initial %.
 
-        Without argumentsl toggles on/off (when off, you must call it as
+        Without arguments toggles on/off (when off, you must call it as
         %automagic, of course).  With arguments it sets the value, and you can
         use any of (case insensitive):
 


### PR DESCRIPTION
Remove rogue "l" in "argumentsl".