### PR TITLE
Do not shadow explicit magic completion.

### DIFF
--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -589,6 +589,24 @@ def test_magic_completion_shadowing():
     text, matches = c.complete("mat")
     nt.assert_equal(matches, ["%matplotlib"])
 
+def test_magic_completion_shadowing_explicit():
+    """
+    If the user try to complete a shadowed magic, and explicit % start should
+    still return the completions.
+    """
+    ip = get_ipython()
+    c = ip.Completer
+
+    # Before importing matplotlib, %matplotlib magic should be the only option.
+    text, matches = c.complete("%mat")
+    nt.assert_equal(matches, ["%matplotlib"])
+
+    ip.run_cell("matplotlib = 1")
+
+    # After removing matplotlib from namespace, the magic should still be
+    # the only option.
+    text, matches = c.complete("%mat")
+    nt.assert_equal(matches, ["%matplotlib"])
 
 def test_magic_config():
     ip = get_ipython()


### PR DESCRIPTION
If a binding has the same name than a magic, the magic should be
shadowed; unless the use is explicitly requesting a magic with a leading
percent sign.

Closes #10754