### PR TITLE
Fix random test failure.

### DIFF
--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -17,6 +17,7 @@ import functools
 import os
 from os.path import join as pjoin
 import random
+import string
 import sys
 import textwrap
 import unittest
@@ -415,8 +416,8 @@ class TestMagicRunWithPackage(unittest.TestCase):
             f.write(textwrap.dedent(content))
 
     def setUp(self):
-        self.package = package = 'tmp{0}'.format(repr(random.random())[2:])
-        """Temporary valid python package name."""
+        self.package = package = 'tmp{0}'.format(''.join([random.choice(string.ascii_letters) for i in range(10)]))
+        """Temporary  (probably) valid python package name."""
 
         self.value = int(random.random() * 10000)
 


### PR DESCRIPTION
The filename was generated taking the last digits of a randomly
generated number between 0 and 1, if the number is small enough, it's
repr ends with `e-5`, or less (the probability is actually close to
1/1000 because the biggest number we can get with e-5 is (1e-4 -
epsilon).

We actually did hit that on our CI:

- https://ci.appveyor.com/project/IPython/ipython/build/1.0.839/job/mk4l08s295ynkfs5

```
======================================================================
ERROR: test_run_submodule_with_absolute_import (IPython.core.tests.test_run.TestMagicRunWithPackage)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\python36-x64\lib\site-packages\IPython\core\tests\test_run.py", line 455, in test_run_submodule_with_absolute_import
    self.check_run_submodule('absolute')
  File "c:\python36-x64\lib\site-packages\IPython\core\tests\test_run.py", line 450, in check_run_submodule
    self.assertEqual(_ip.user_ns['x'], self.value,
KeyError: 'x'
-------------------- >> begin captured stdout << ---------------------
  File "C:\Users\appveyor\AppData\Local\Temp\1\tmp4asmvv33\tmpqpswwe9n\tmp065832886952393e-05\absolute.py", line 2
    from tmp065832886952393e-05.sub import x
                            ^
SyntaxError: invalid syntax
```

Actually pick a random string now we should have less chance of being
invalid identifier.