### PR TITLE
Let keyboard interrupt stop custom dispatch of completer.

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1715,6 +1715,12 @@ class IPCompleter(Completer):
                     return [r for r in res if r.lower().startswith(text_low)]
             except TryNext:
                 pass
+            except KeyboardInterrupt:
+                """
+                If custom completer take too long,
+                let keyboard interrupt abort and return nothing.
+                """
+                break
 
         return None
 


### PR DESCRIPTION
See #10733, interruption during custom completer can crash the
kernel. Technically we should likely even protect normal completion
(like jedi taking a while), but let's get something that fix an actual
bug.

This can lead to some inconsistencies in the frontend, as you interrupt
the kernel in Command mode, and interrupting the current custom
completer will lead to normal completion being (still) returned and the
completer poping up in command mode. It's not optimal but at least we do
not loose user state.


Alternative to #10792, I like to have a better, more general fix, but that will actually fix a case with crash where we do have bug reports, and can be backported to 5.x