### PR TITLE
Do not pass down deprecated option.

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -1227,8 +1227,7 @@ class VerboseTB(TBTools):
 
         if force or self.call_pdb:
             if self.pdb is None:
-                self.pdb = self.debugger_cls(
-                    self.color_scheme_table.active_scheme_name)
+                self.pdb = self.debugger_cls()
             # the system displayhook may have changed, restore the original
             # for pdb
             display_trap = DisplayTrap(hook=sys.__displayhook__)


### PR DESCRIPTION
This lead to exception in `%debug` when Warnings are turned into errors.
Closes #10785

This is directly against the 5.x branch, as 6.x is already free of this bug.