### PR TITLE
Adding iteration to ProgressBar to make it a more useful utility

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -774,6 +774,19 @@ class ProgressBar(DisplayObject):
         self._progress = value
         self.update()
 
+    def __iter__(self):
+        self.display()
+        self._progress = -1 # First iteration is 0
+        return self
+
+    def __next__(self):
+        """Returns current value and increments display by one."""
+        self.progress += 1
+        if self.progress < self.total:
+            return self.progress
+        else:
+            raise StopIteration()
+
 class JSON(DisplayObject):
     """JSON expects a JSON-able dict or list
 

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -196,10 +196,17 @@ def test_displayobject_repr():
 
 def test_progress():
     p = display.ProgressBar(10)
-    nt.assert_true('0/10' in repr(p))
+    nt.assert_in('0/10',repr(p))
     p.html_width = '100%'
     p.progress = 5
     nt.assert_equal(p._repr_html_(), "<progress style='width:100%' max='10' value='5'></progress>")
+
+def test_progress_iter(capsys):
+    for i in display.ProgressBar(5):
+        out, err = capsys.readouterr()
+        nt.assert_in('{0}/5'.format(i), out)
+    out, err = capsys.readouterr()
+    nt.assert_in('5/5', out)
 
 def test_json():
     d = {'a': 5}

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -11,6 +11,7 @@ import nose.tools as nt
 
 from IPython.core import display
 from IPython.core.getipython import get_ipython
+from IPython.utils.io import capture_output
 from IPython.utils.tempdir import NamedFileInTemporaryDirectory
 from IPython import paths as ipath
 from IPython.testing.tools import AssertPrints, AssertNotPrints
@@ -201,11 +202,12 @@ def test_progress():
     p.progress = 5
     nt.assert_equal(p._repr_html_(), "<progress style='width:100%' max='10' value='5'></progress>")
 
-def test_progress_iter(capsys):
-    for i in display.ProgressBar(5):
-        out, err = capsys.readouterr()
-        nt.assert_in('{0}/5'.format(i), out)
-    out, err = capsys.readouterr()
+def test_progress_iter():
+    with capture_output(display=False) as captured:
+        for i in display.ProgressBar(5):
+            out = captured.stdout
+            nt.assert_in('{0}/5'.format(i), out)
+    out = captured.stdout
     nt.assert_in('5/5', out)
 
 def test_json():

--- a/examples/IPython Kernel/Updating Displays.ipynb
+++ b/examples/IPython Kernel/Updating Displays.ipynb
@@ -21,10 +21,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 1,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from IPython.display import display, update_display"
@@ -32,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -50,7 +48,7 @@
        "<DisplayHandle display_id=update-me>"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -70,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -97,10 +95,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 4,
+   "metadata": {},
    "outputs": [],
    "source": [
     "handle.update('z')"
@@ -116,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -131,10 +127,10 @@
     {
      "data": {
       "text/plain": [
-       "<DisplayHandle display_id=07fc47b2ef652ccb70addeee3eb0981a>"
+       "<DisplayHandle display_id=118a56127f42348f8893440da7181c57>"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -154,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -173,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -200,10 +196,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 8,
+   "metadata": {},
    "outputs": [],
    "source": [
     "update_display('z', display_id='here')"
@@ -222,16 +216,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<progress style='width:100%' max='10' value='10'></progress>"
+       "<progress style='width:60ex' max='10' value='10'></progress>"
       ],
       "text/plain": [
-       "<IPython.core.display.ProgressBar object>"
+       "[============================================================] 10/10"
       ]
      },
      "metadata": {},
@@ -254,16 +248,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<progress style='width:100%' max='10' value='10'></progress>"
+       "<progress style='width:60ex' max='10' value='10'></progress>"
       ],
       "text/plain": [
-       "<IPython.core.display.ProgressBar object>"
+       "[============================================================] 10/10"
       ]
      },
      "metadata": {},
@@ -278,6 +272,36 @@
     "for i in range(11):\n",
     "    bar.progress = i\n",
     "    bar.update()\n",
+    "    time.sleep(0.25)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ProgressBar also has an update built into iteration:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<progress style='width:60ex' max='10' value='10'></progress>"
+      ],
+      "text/plain": [
+       "[============================================================] 10/10"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "for i in ProgressBar(10):\n",
     "    time.sleep(0.25)"
    ]
   },


### PR DESCRIPTION
As discussed in #10812, this simply adds the ability to iterate over a ProgessBar (no other API changes). Added a test and a mention in the relevant example.