### PR TITLE
Change some if -> elif in display Image code

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -1098,9 +1098,9 @@ class Image(DisplayObject):
             if ext is not None:
                 if ext == u'jpg' or ext == u'jpeg':
                     format = self._FMT_JPEG
-                if ext == u'png':
+                elif ext == u'png':
                     format = self._FMT_PNG
-                if ext == u'gif':
+                elif ext == u'gif':
                     format = self._FMT_GIF
                 else:
                     format = ext.lower()


### PR DESCRIPTION
I just happened to notice this. I'm pretty sure they were meant to be elifs; otherwise the value set for jpeg/png images is immediately overridden by the `else` clause below.