### PR TITLE
Fix jedi 0.11 – be optimistic.

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1346,8 +1346,7 @@ class IPCompleter(Completer):
 
         interpreter = jedi.Interpreter(
             text, namespaces, column=cursor_column, line=cursor_line + 1)
-
-        try_jedi = False
+        try_jedi = True
 
         try:
             # should we check the type of the node is Error ?


### PR DESCRIPTION
Instead of not trying Jedi completion if Jedi parsing of wether we are
in a string fails assume that we should alway try jedi, and do not only
if jedi manage to prove we are currently in a string.

This should give some false positive (like triggering jedi in some
unfinished strings), but no false negative – like for example with Jedi
0.11 which is just out.

In the end we should do a proper fix; but I'd like to get that soon as
otherwise Jedi is quasi deactivated when version 0.11 is installed
(released a few days ago).

--- 

I'm probably going to do a 6.2.1 and a 6.5.1 with that and #10823