### PR TITLE
Patch stdout in interactive shell

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -372,8 +372,9 @@ class TerminalInteractiveShell(InteractiveShell):
             self._pt_app.layout = create_prompt_layout(**self._layout_options())
 
     def prompt_for_code(self):
-        document = self.pt_cli.run(
-            pre_run=self.pre_prompt, reset_current_buffer=True)
+        with self.pt_cli.patch_stdout_context(raw=True):
+            document = self.pt_cli.run(
+                pre_run=self.pre_prompt, reset_current_buffer=True)
         return document.text
 
     def enable_win_unicode_console(self):

--- a/setup.py
+++ b/setup.py
@@ -190,7 +190,7 @@ install_requires = [
     'pickleshare',
     'simplegeneric>0.8',
     'traitlets>=4.2',
-    'prompt_toolkit>=1.0.4,<2.0.0',
+    'prompt_toolkit>=1.0.15,<2.0.0',
     'pygments',
 ]
 


### PR DESCRIPTION
Now that
https://github.com/jonathanslenders/python-prompt-toolkit/issues/507
and https://github.com/jonathanslenders/python-prompt-toolkit/pull/520
are fixed and released in prompt_toolkit>=1.0.15, using
patch_stdout_context fixes the prompt and completers when background
threads are writing to stdout.