### PR TITLE
Document the process of having a reproducible build.

### DIFF
--- a/docs/source/coredev/index.rst
+++ b/docs/source/coredev/index.rst
@@ -105,6 +105,13 @@ for the release you are actually making::
     VERSION=5.0.0
     BRANCH=master
 
+For `reproducibility of builds <https://reproducible-builds.org/specs/source-date-epoch/>`_,
+we recommend setting ``SOURCE_DATE_EPOCH`` prior to running the build; record the used value
+of ``SOURCE_DATE_EPOCH`` as it may not be available from build artifact. You
+should be able to use ``date +%s`` to get a formatted timestamp::
+
+    SOURCE_DATE_EPOCH=$(date +%s)
+
 
 2. Create GitHub stats and finish release note
 ----------------------------------------------
@@ -215,8 +222,11 @@ We encourage creating a test build of the docs as well.
 
 Commit the changes to release.py::
 
-    git commit -am "release $VERSION"
+    git commit -am "release $VERSION\n\nReleased with SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH"
     git push origin $BRANCH
+
+Check that the commit message have the actual interpolated ``SOURCE_DATE_EPOCH``
+value.
 
 Create and push the tag::
 
@@ -246,6 +256,16 @@ folder. Be sure to test the ``wheels``  and the ``sdist`` locally before
 uploading them to PyPI. We do not use an universal wheel as each wheel
 installs an ``ipython2`` or ``ipython3`` script, depending on the version of
 Python it is built for. Using an universal wheel would prevent this.
+
+Check the shasum of files with::
+
+    shasum -a 256 dist/*
+
+and takes notes of them you might need them to update the conda-forge recipes.
+Rerun the command and check the hash have not changed::
+
+    ./tools/release
+    shasum -a 256 dist/*
 
 Use the following to actually upload the result of the build::
 

--- a/setup.py
+++ b/setup.py
@@ -228,7 +228,7 @@ everything = set()
 for key, deps in extras_require.items():
     if ':' not in key:
         everything.update(deps)
-extras_require['all'] = everything
+extras_require['all'] = list(sorted(everything))
 
 if 'setuptools' in sys.modules:
     setuptools_extra_args['python_requires'] = '>=3.3'

--- a/tools/build_release
+++ b/tools/build_release
@@ -2,6 +2,7 @@
 """IPython release build script.
 """
 import os
+import sys
 from shutil import rmtree
 
 from toollib import sh, pjoin, get_ipdir, cd, execfile, sdists, buildwheels
@@ -17,7 +18,7 @@ def build_release():
 
     with open('docs/source/whatsnew/index.rst') as f:
         if '   development' in f.read():
-            raise ValueError("Please remove `development` from what's new toctree for release")
+            raise ValueError("Please remove `development` from what's new toctree (docs/source/whatsnew/index.rst) for release")
 
     # Cleanup
     for d in ['build', 'dist', pjoin('docs', 'build'), pjoin('docs', 'dist'),
@@ -28,6 +29,7 @@ def build_release():
     # Build source and binary distros
     sh(sdists)
     buildwheels()
+    sh(' '.join([sys.executable, 'tools/retar.py', 'dist/*.gz']))
 
 if __name__ == '__main__':
     build_release()

--- a/tools/make_tarball.py
+++ b/tools/make_tarball.py
@@ -3,7 +3,6 @@
 """
 
 import subprocess
-import os
 
 from toollib import cd, sh
 

--- a/tools/release
+++ b/tools/release
@@ -79,12 +79,9 @@ else:
     sh('mv ipython-*.tgz %s' % ipbackupdir)
 
     # Build release files
-    sh('./build_release %s' % ipdir)
+    sh('./build_release')
 
     cd(ipdir)
-
-    # Upload all files
-    sh(sdists)
 
     buildwheels()
     print("`./release upload` to upload source distribution on PyPI and ipython archive")

--- a/tools/retar.py
+++ b/tools/retar.py
@@ -1,0 +1,54 @@
+"""
+Un-targz and retargz a targz file to ensure reproducible build. 
+
+usage: 
+
+    $ export SOURCE_DATE_EPOCH=$(date +%s)
+    ...
+    $ python retar.py <tarfile.gz>
+
+The process of creating an sdist can be non-reproducible:
+  - directory created during the process get a mtime of the creation date; 
+  - gziping files embed the timestamp of fo zip creation. 
+
+This will untar-retar; ensuring that all mtime > SOURCE_DATE_EPOCH will be set
+equal to SOURCE_DATE_EPOCH.
+
+"""
+
+import tarfile
+import sys
+import os
+import gzip
+import io
+
+if len(sys.argv) > 2:
+    raise ValueError('Too many arguments')
+
+
+timestamp = int(os.environ['SOURCE_DATE_EPOCH'])
+
+old_buf = io.BytesIO()
+with open(sys.argv[1], 'rb') as f:
+    old_buf.write(f.read())
+old_buf.seek(0)
+old = tarfile.open(fileobj=old_buf,mode='r:gz')
+
+buf = io.BytesIO()
+new = tarfile.open(fileobj=buf, mode='w')
+
+for i,m in enumerate(old):
+    data = None
+    if m.mtime > timestamp: 
+        m.mtime = timestamp
+    if m.isdir():
+        new.addfile(m)
+    else:
+        data = old.extractfile(m)
+        new.addfile(m, data)
+new.close()
+old.close()
+
+buf.seek(0)
+with gzip.GzipFile(sys.argv[1],"wb", mtime=timestamp) as gzf:
+    gzf.write(buf.read())


### PR DESCRIPTION
Next step should be to enforce the building with a set SOURCE_DATE_EPOCH
value.

Right now I'm extra careful in the process as I haven't tried it,
but we should make it a bit more strait forward.

-- 
cc @takluyver because you have experience with flit and were IIRC involved in the Python discussions, and @mpacer because I'm sure you'll want to do the same with Nbconvert. 

When we make our first reproducible build, I'd like to have a blog post about that. Thoughts?
Wondering if we should also set the same timestamp in the cond-forge recipes.