### PR TITLE
Drop support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
     - 3.6
     - 3.5
     - 3.4
-    - 3.3
 sudo: false
 env:
   global:

--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -30,9 +30,9 @@ import sys
 if sys.version_info < (3,4):
     raise ImportError(
 """
-IPython 6.3+ supports Python 3.4 and above.
+IPython 7.0+ supports Python 3.4 and above.
 When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
-Python 3.3 was supported up to IPython 6.2.
+Python 3.3 was supported up to IPython 6.x.
 
 See IPython `README.rst` file for more information:
 

--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -27,12 +27,12 @@ import sys
 #-----------------------------------------------------------------------------
 
 # Don't forget to also update setup.py when this changes!
-if sys.version_info < (3,3):
+if sys.version_info < (3,4):
     raise ImportError(
 """
-IPython 6.0+ does not support Python 2.6, 2.7, 3.0, 3.1, or 3.2.
+IPython 6.3+ supports Python 3.4 and above.
 When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
-Beginning with IPython 6.0, Python 3.3 and above is required.
+Python 3.3 was supported up to IPython 6.2.
 
 See IPython `README.rst` file for more information:
 

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -430,8 +430,5 @@ def test_init_colors():
 def test_builtin_init():
     info = inspector.info(list)
     init_def = info['init_definition']
-    # Python < 3.4 can't get init definition from builtins,
-    # but still exercise the inspection in case of error-raising bugs.
-    if sys.version_info >= (3,4):
-        nt.assert_is_not_none(init_def)
+    nt.assert_is_not_none(init_def)
 

--- a/IPython/external/qt_loaders.py
+++ b/IPython/external/qt_loaders.py
@@ -109,47 +109,6 @@ def loaded_api():
 def has_binding(api):
     """Safely check for PyQt4/5, PySide or PySide2, without importing submodules
 
-    Supports Python <= 3.3
-
-       Parameters
-       ----------
-       api : str [ 'pyqtv1' | 'pyqt' | 'pyqt5' | 'pyside' | 'pyside2' | 'pyqtdefault']
-            Which module to check for
-
-       Returns
-       -------
-       True if the relevant module appears to be importable
-    """
-    # we can't import an incomplete pyside and pyqt4
-    # this will cause a crash in sip (#1431)
-    # check for complete presence before importing
-    module_name = api_to_module[api]
-
-    import imp
-    try:
-        #importing top level PyQt4/PySide module is ok...
-        mod = import_module(module_name)
-        #...importing submodules is not
-        imp.find_module('QtCore', mod.__path__)
-        imp.find_module('QtGui', mod.__path__)
-        imp.find_module('QtSvg', mod.__path__)
-        if api in (QT_API_PYQT5, QT_API_PYSIDE2):
-            # QT5 requires QtWidgets too
-            imp.find_module('QtWidgets', mod.__path__)
-
-        #we can also safely check PySide version
-        if api == QT_API_PYSIDE:
-            return check_version(mod.__version__, '1.0.3')
-        else:
-            return True
-    except ImportError:
-        return False
-
-def has_binding_new(api):
-    """Safely check for PyQt4/5, PySide or PySide2, without importing submodules
-
-    Supports Python >= 3.4
-
         Parameters
         ----------
         api : str [ 'pyqtv1' | 'pyqt' | 'pyqt5' | 'pyside' | 'pyside2' | 'pyqtdefault']
@@ -185,8 +144,6 @@ def has_binding_new(api):
 
     return True
 
-if sys.version_info >= (3, 4):
-    has_binding = has_binding_new
 
 def qtapi_version():
     """Return which QString API has been set, if any

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -18,11 +18,7 @@ import random
 import sys
 
 import nose.tools as nt
-try:
-    from pathlib import Path
-except ImportError:
-    # for Python 3.3
-    from pathlib2 import Path
+from pathlib import Path
 
 from IPython.utils import text
 

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -133,13 +133,9 @@ def eval_formatter_no_slicing_check(f):
     
     s = f.format('{stuff[slice(1,4)]}', **ns)
     nt.assert_equal(s, 'ell')
-    
-    if sys.version_info >= (3, 4):
-        # String formatting has changed in Python 3.4, so this now works.
-        s = f.format("{a[:]}", a=[1, 2])
-        nt.assert_equal(s, "[1, 2]")
-    else:
-        nt.assert_raises(SyntaxError, f.format, "{a[:]}")
+
+    s = f.format("{a[:]}", a=[1, 2])
+    nt.assert_equal(s, "[1, 2]")
 
 def test_eval_formatter():
     f = text.EvalFormatter()

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -13,11 +13,7 @@ import re
 import sys
 import textwrap
 from string import Formatter
-try:
-    from pathlib import Path
-except ImportError:
-    # for Python 3.3
-    from pathlib2 import Path
+from pathlib import Path
 
 from IPython.utils import py3compat
 

--- a/README.rst
+++ b/README.rst
@@ -23,9 +23,9 @@ contribute to the project.
 
 **IPython versions and Python Support**
 
-**IPython 6.3** requires Python version 3.4 and above.
+**IPython 7.0** requires Python version 3.4 and above.
 
-**IPython 6.0-6.2** requires Python version 3.3 and above.
+**IPython 6.x** requires Python version 3.3 and above.
 
 **IPython 5.x LTS** is the compatible release for Python 2.7.
 If you require Python 2 support, you **must** use IPython 5.x LTS. Please

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,9 @@ contribute to the project.
 
 **IPython versions and Python Support**
 
-**IPython 6** requires Python version 3.3 and above.
+**IPython 6.3** requires Python version 3.4 and above.
+
+**IPython 6.0-6.2** requires Python version 3.3 and above.
 
 **IPython 5.x LTS** is the compatible release for Python 2.7.
 If you require Python 2 support, you **must** use IPython 5.x LTS. Please

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,8 @@ environment:
      PYTHON_VERSION: "3.6.x"
      PYTHON_ARCH: "32"
 
-   - PYTHON: "C:\\Python33-x64"
-     PYTHON_VERSION: "3.3.x"
+   - PYTHON: "C:\\Python34-x64"
+     PYTHON_VERSION: "3.4.x"
      PYTHON_ARCH: "64"
 
    - PYTHON: "C:\\Python36-x64"

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -239,8 +239,8 @@ This functionality is optional and now part of the `ipyparallel
 Portability and Python requirements
 -----------------------------------
 
-Version 6.3+ supports Python 3.4 and higher.
-Versions 6.0 to 6.2 support Python 3.3 and higher.
+Version 7.0+ supports Python 3.4 and higher.
+Versions 6.x support Python 3.3 and higher.
 Versions 2.0 to 5.x work with Python 2.7.x releases and Python 3.3 and higher.
 Version 1.0 additionally worked with Python 2.6 and 3.2.
 Version 0.12 was the first version to fully support Python 3.

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -217,29 +217,30 @@ running, use the ``%connect_info`` magic to get the unique connection file,
 which will be something like ``--existing kernel-19732.json`` but with
 different numbers which correspond to the Process ID of the kernel.
 
-You can read more about using `jupyter qtconsole 
+You can read more about using `jupyter qtconsole
 <http://jupyter.org/qtconsole/>`_, and
 `jupyter notebook <http://jupyter-notebook.readthedocs.io/en/latest/>`_. There
-is also a :ref:`message spec <messaging>` which documents the protocol for 
+is also a :ref:`message spec <messaging>` which documents the protocol for
 communication between kernels
 and clients.
 
 .. seealso::
-    
+
     `Frontend/Kernel Model`_ example notebook
 
 
 Interactive parallel computing
 ==============================
 
-    
+
 This functionality is optional and now part of the `ipyparallel
 <http://ipyparallel.readthedocs.io/>`_ project.
 
 Portability and Python requirements
 -----------------------------------
 
-Version 6.0+ supports compatibility with Python 3.3 and higher.
+Version 6.3+ supports Python 3.4 and higher.
+Versions 6.0 to 6.2 support Python 3.3 and higher.
 Versions 2.0 to 5.x work with Python 2.7.x releases and Python 3.3 and higher.
 Version 1.0 additionally worked with Python 2.6 and 3.2.
 Version 0.12 was the first version to fully support Python 3.

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,9 @@ if sys.version_info < (3, 4):
 
 
     error = """
-IPython 6.0+ does not support Python 2.6, 2.7, 3.0, 3.1, or 3.2.
+IPython 6.3+ supports Python 3.4 and above.
 When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
-Beginning with IPython 6.0, Python 3.3 and above is required.
+Python 3.3 was supported up to IPython 6.2.
 
 See IPython `README.rst` file for more information:
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ import sys
 #
 # This check is also made in IPython/__init__, don't forget to update both when
 # changing Python version requirements.
-if sys.version_info < (3, 3):
+if sys.version_info < (3, 4):
     pip_message = 'This may be due to an out of date pip. Make sure you have pip >= 9.0.1.'
     try:
         import pip
@@ -175,7 +175,7 @@ extras_require = dict(
     parallel = ['ipyparallel'],
     qtconsole = ['qtconsole'],
     doc = ['Sphinx>=1.3'],
-    test = ['nose>=0.10.1', 'requests', 'testpath', 'pygments', 'nbformat', 'ipykernel'],
+    test = ['nose>=0.10.1', 'requests', 'testpath', 'pygments', 'nbformat', 'ipykernel', 'numpy'],
     terminal = [],
     kernel = ['ipykernel'],
     nbformat = ['nbformat'],
@@ -200,8 +200,6 @@ install_requires = [
 # but requires pip >= 6. pip < 6 ignores these.
 
 extras_require.update({
-    'test:python_version >= "3.4"': ['numpy'],
-    ':python_version == "3.3"': ['pathlib2'],
     ':python_version <= "3.4"': ['typing'],
     ':sys_platform != "win32"': ['pexpect'],
     ':sys_platform == "darwin"': ['appnope'],
@@ -232,7 +230,7 @@ for key, deps in extras_require.items():
 extras_require['all'] = everything
 
 if 'setuptools' in sys.modules:
-    setuptools_extra_args['python_requires'] = '>=3.3'
+    setuptools_extra_args['python_requires'] = '>=3.4'
     setuptools_extra_args['zip_safe'] = False
     setuptools_extra_args['entry_points'] = {
         'console_scripts': find_entry_points(),

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,9 @@ if sys.version_info < (3, 4):
 
 
     error = """
-IPython 6.3+ supports Python 3.4 and above.
+IPython 7.0+ supports Python 3.4 and above.
 When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
-Python 3.3 was supported up to IPython 6.2.
+Python 3.3 was supported up to IPython 6.x.
 
 See IPython `README.rst` file for more information:
 

--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,7 @@ install_requires = [
 # but requires pip >= 6. pip < 6 ignores these.
 
 extras_require.update({
-    ':python_version <= "3.4"': ['typing'],
+    ':python_version == "3.4"': ['typing'],
     ':sys_platform != "win32"': ['pexpect'],
     ':sys_platform == "darwin"': ['appnope'],
     ':sys_platform == "win32"': ['colorama'],


### PR DESCRIPTION
This makes 3.4 the minimum required version of Python. See discussion on #10161.