### PR TITLE
Add Julia to default script magics.

### DIFF
--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -89,6 +89,7 @@ class ScriptMagics(Magics):
             'python2',
             'python3',
             'pypy',
+            'julia',
         ]
         if os.name == 'nt':
             defaults.extend([


### PR DESCRIPTION
I have been adding this line manually to my local copies of IPython/Jupyter and even suggest to do so in a Stack Overflow question, it would be nice if this worked by default.

https://stackoverflow.com/questions/24091373/best-way-to-run-julia-code-in-an-ipython-notebook-or-python-code-in-an-ijulia-n/24106944#24106944

Should I also add R or any other language? Is this not the correct way to do it? Please let me know, cheers!