### PR TITLE
Fixing display publisher (Python 3)

### DIFF
--- a/IPython/core/displaypub.py
+++ b/IPython/core/displaypub.py
@@ -114,11 +114,11 @@ class CapturingDisplayPublisher(DisplayPublisher):
     """A DisplayPublisher that stores"""
     outputs = List()
 
-    def publish(self, data, metadata=None, source=None):
+    def publish(self, data, metadata=None, source=None, *, transient=None, update=False):
         self.outputs.append((data, metadata))
-    
+
     def clear_output(self, wait=False):
         super(CapturingDisplayPublisher, self).clear_output(wait)
-        
+
         # empty the list, *do not* reassign a new list
         del self.outputs[:]

--- a/IPython/core/displaypub.py
+++ b/IPython/core/displaypub.py
@@ -115,10 +115,11 @@ class CapturingDisplayPublisher(DisplayPublisher):
     outputs = List()
 
     def publish(self, data, metadata=None, source=None, *, transient=None, update=False):
-        self.outputs.append((data, metadata))
+        self.outputs.append({'data':data, 'metadata':metadata,
+                             'transient':transient, 'update':update})
 
     def clear_output(self, wait=False):
         super(CapturingDisplayPublisher, self).clear_output(wait)
 
         # empty the list, *do not* reassign a new list
-        del self.outputs[:]
+        self.outputs.clear()

--- a/IPython/utils/capture.py
+++ b/IPython/utils/capture.py
@@ -14,14 +14,17 @@ from io import StringIO
 
 
 class RichOutput(object):
-    def __init__(self, data=None, metadata=None):
+    def __init__(self, data=None, metadata=None, transient=None, update=False):
         self.data = data or {}
         self.metadata = metadata or {}
-    
+        self.transient = transient or {}
+        self.update = update
+
     def display(self):
         from IPython.display import publish_display_data
-        publish_display_data(data=self.data, metadata=self.metadata)
-    
+        publish_display_data(data=self.data, metadata=self.metadata,
+                             transient=self.transient, update=self.update)
+
     def _repr_mime_(self, mime):
         if mime not in self.data:
             return
@@ -36,22 +39,22 @@ class RichOutput(object):
 
     def _repr_html_(self):
         return self._repr_mime_("text/html")
-    
+
     def _repr_latex_(self):
         return self._repr_mime_("text/latex")
-    
+
     def _repr_json_(self):
         return self._repr_mime_("application/json")
-    
+
     def _repr_javascript_(self):
         return self._repr_mime_("application/javascript")
-    
+
     def _repr_png_(self):
         return self._repr_mime_("image/png")
-    
+
     def _repr_jpeg_(self):
         return self._repr_mime_("image/jpeg")
-    
+
     def _repr_svg_(self):
         return self._repr_mime_("image/svg+xml")
 
@@ -68,35 +71,35 @@ class CapturedIO(object):
     Additionally, there's a ``c.show()`` method which will print all of the
     above in the same order, and can be invoked simply via ``c()``.
     """
-    
+
     def __init__(self, stdout, stderr, outputs=None):
         self._stdout = stdout
         self._stderr = stderr
         if outputs is None:
             outputs = []
         self._outputs = outputs
-    
+
     def __str__(self):
         return self.stdout
-    
+
     @property
     def stdout(self):
         "Captured standard output"
         if not self._stdout:
             return ''
         return self._stdout.getvalue()
-    
+
     @property
     def stderr(self):
         "Captured standard error"
         if not self._stderr:
             return ''
         return self._stderr.getvalue()
-    
+
     @property
     def outputs(self):
         """A list of the captured rich display outputs, if any.
-        
+
         If you have a CapturedIO object ``c``, these can be displayed in IPython
         using::
 
@@ -104,17 +107,17 @@ class CapturedIO(object):
             for o in c.outputs:
                 display(o)
         """
-        return [ RichOutput(d, md) for d, md in self._outputs ]
-    
+        return [ RichOutput(**kargs) for kargs in self._outputs ]
+
     def show(self):
         """write my output to sys.stdout/err as appropriate"""
         sys.stdout.write(self.stdout)
         sys.stderr.write(self.stderr)
         sys.stdout.flush()
         sys.stderr.flush()
-        for data, metadata in self._outputs:
-            RichOutput(data, metadata).display()
-    
+        for kargs in self._outputs:
+            RichOutput(**kargs).display()
+
     __call__ = show
 
 
@@ -123,27 +126,27 @@ class capture_output(object):
     stdout = True
     stderr = True
     display = True
-    
+
     def __init__(self, stdout=True, stderr=True, display=True):
         self.stdout = stdout
         self.stderr = stderr
         self.display = display
         self.shell = None
-    
+
     def __enter__(self):
         from IPython.core.getipython import get_ipython
         from IPython.core.displaypub import CapturingDisplayPublisher
         from IPython.core.displayhook import CapturingDisplayHook
-        
+
         self.sys_stdout = sys.stdout
         self.sys_stderr = sys.stderr
-        
+
         if self.display:
             self.shell = get_ipython()
             if self.shell is None:
                 self.save_display_pub = None
                 self.display = False
-        
+
         stdout = stderr = outputs = None
         if self.stdout:
             stdout = sys.stdout = StringIO()
@@ -156,9 +159,9 @@ class capture_output(object):
             self.save_display_hook = sys.displayhook
             sys.displayhook = CapturingDisplayHook(shell=self.shell,
                                                    outputs=outputs)
-        
+
         return CapturedIO(stdout, stderr, outputs)
-    
+
     def __exit__(self, exc_type, exc_value, traceback):
         sys.stdout = self.sys_stdout
         sys.stderr = self.sys_stderr


### PR DESCRIPTION
This fixes the CapturingDisplayPublisher by matching the signature with the regular DisplayPublisher (bug surfaced in #10813).