### PR TITLE
Remove broken downloads badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,6 @@
 .. image:: https://codecov.io/github/ipython/ipython/coverage.svg?branch=master
     :target: https://codecov.io/github/ipython/ipython?branch=master
 
-.. image:: https://img.shields.io/pypi/dm/IPython.svg
-    :target: https://pypi.python.org/pypi/ipython
-
 .. image:: https://img.shields.io/pypi/v/IPython.svg
     :target: https://pypi.python.org/pypi/ipython
 


### PR DESCRIPTION
It's showing:

![image](https://user-images.githubusercontent.com/1324225/31453500-0e26d4ee-aebb-11e7-94c3-fcd51878565e.png)

See https://github.com/badges/shields/issues/716 for more info.