### PR TITLE
Update version classifiers

### DIFF
--- a/IPython/core/release.py
+++ b/IPython/core/release.py
@@ -114,5 +114,10 @@ classifiers = [
     'License :: OSI Approved :: BSD License',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: Only',
+    'Programming Language :: Python :: Implementation :: CPython',
     'Topic :: System :: Shells'
     ]

--- a/IPython/core/release.py
+++ b/IPython/core/release.py
@@ -114,10 +114,6 @@ classifiers = [
     'License :: OSI Approved :: BSD License',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.4',
-    'Programming Language :: Python :: 3.5',
-    'Programming Language :: Python :: 3.6',
-    'Programming Language :: Python :: Only',
-    'Programming Language :: Python :: Implementation :: CPython',
+    'Programming Language :: Python :: 3 :: Only',
     'Topic :: System :: Shells'
     ]


### PR DESCRIPTION
Assumes https://github.com/ipython/ipython/pull/10833 (for https://github.com/ipython/ipython/issues/10161) will be merged and Python 3.4 is the minimum.