### PR TITLE
Don't list pygments styles on import

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -25,7 +25,7 @@ from prompt_toolkit.key_binding.manager import KeyBindingManager
 from prompt_toolkit.layout.processors import ConditionalProcessor, HighlightMatchingBracketProcessor
 from prompt_toolkit.styles import PygmentsStyle, DynamicStyle
 
-from pygments.styles import get_style_by_name, get_all_styles
+from pygments.styles import get_style_by_name
 from pygments.style import Style
 from pygments.token import Token
 

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -129,9 +129,11 @@ class TerminalInteractiveShell(InteractiveShell):
         help="Enable mouse support in the prompt\n(Note: prevents selecting text with the mouse)"
     ).tag(config=True)
 
+    # We don't load the list of styles for the help string, because loading
+    # Pygments plugins takes time and can cause unexpected errors.
     highlighting_style = Union([Unicode('legacy'), Type(klass=Style)],
         help="""The name or class of a Pygments style to use for syntax
-        highlighting: \n %s""" % ', '.join(get_all_styles())
+        highlighting. To see available styles, run `pygmentize -L styles`."""
     ).tag(config=True)
 
 


### PR DESCRIPTION
Listing the styles forces pygments to load plugins, which slows startup and may cause unexpected errors from other packages. We shouldn't be calling this on import.

The list of available styles will also depend on what packages are installed, so building our config docs with one list may be misleading. I've made the help string point to `pygmentize -L styles` to see available styles on your system.

Closes jupyter/notebook#2926