### PR TITLE
FIX: bare functions in callback registry on bogus unregister

### DIFF
--- a/IPython/core/events.py
+++ b/IPython/core/events.py
@@ -69,8 +69,11 @@ class EventManager(object):
 
         # Remove callback in case ``function`` was adapted by `backcall`.
         for callback in self.callbacks[event]:
-            if callback.__wrapped__ is function:
-                return self.callbacks[event].remove(callback)
+            try:
+                if callback.__wrapped__ is function:
+                    return self.callbacks[event].remove(callback)
+            except AttributeError:
+                pass
 
         raise ValueError('Function {!r} is not registered as a {} callback'.format(function, event))
 

--- a/IPython/core/tests/test_events.py
+++ b/IPython/core/tests/test_events.py
@@ -19,8 +19,10 @@ def event_with_argument(argument):
 
 class CallbackTests(unittest.TestCase):
     def setUp(self):
-        self.em = events.EventManager(get_ipython(), {'ping_received': ping_received, 'event_with_argument': event_with_argument})
-    
+        self.em = events.EventManager(get_ipython(),
+                                      {'ping_received': ping_received,
+                                       'event_with_argument': event_with_argument})
+
     def test_register_unregister(self):
         cb = Mock()
 

--- a/IPython/core/tests/test_events.py
+++ b/IPython/core/tests/test_events.py
@@ -1,6 +1,7 @@
 from backcall import callback_prototype
 import unittest
 from unittest.mock import Mock
+import nose.tools as nt
 
 from IPython.core import events
 import IPython.testing.tools as tt
@@ -30,7 +31,18 @@ class CallbackTests(unittest.TestCase):
         self.em.unregister('ping_received', cb)
         self.em.trigger('ping_received')
         self.assertEqual(cb.call_count, 1)
-    
+
+    def test_bare_function_missed_unregister(self):
+        def cb1():
+            ...
+
+        def cb2():
+            ...
+
+        self.em.register('ping_received', cb1)
+        nt.assert_raises(ValueError, self.em.unregister, 'ping_received', cb2)
+        self.em.unregister('ping_received', cb1)
+
     def test_cb_error(self):
         cb = Mock(side_effect=ValueError)
         self.em.register('ping_received', cb)


### PR DESCRIPTION
7de483b5fdaa99fa289b418ce0efc5102287ba64 added checking for the case
where the callback was wrapped by backcall, however if there are
un-wrapped functions registered and a non-registered function is
attempted to be unregistered then this fails by raise an uncaught
AttributeError.

Where should a test for this go?