### PR TITLE
Fix broken jedi auto-completion with newest jedi

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1350,7 +1350,13 @@ class IPCompleter(Completer):
 
         try:
             # should we check the type of the node is Error ?
-            from parso.tree import ErrorLeaf
+            try:
+                # jedi >= 0.11
+                from parso.tree import ErrorLeaf
+            except ImportError:
+                # jedi < 0.11
+                from jedi.parser.tree import ErrorLeaf
+
             next_to_last_tree = interpreter._get_module().tree_node.children[-2]
             completing_string = False
             if isinstance(next_to_last_tree, ErrorLeaf):

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1350,11 +1350,11 @@ class IPCompleter(Completer):
 
         try:
             # should we check the type of the node is Error ?
-            from jedi.parser.tree import ErrorLeaf
+            from parso.tree import ErrorLeaf
             next_to_last_tree = interpreter._get_module().tree_node.children[-2]
             completing_string = False
             if isinstance(next_to_last_tree, ErrorLeaf):
-                completing_string = interpreter._get_module().tree_node.children[-2].value[0] in {'"', "'"}
+                completing_string = next_to_last_tree.value[0] in {'"', "'"}
             # if we are in a string jedi is likely not the right candidate for
             # now. Skip it.
             try_jedi = not completing_string

--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,7 @@ extras_require = dict(
 
 install_requires = [
     'setuptools>=18.5',
-    'jedi>=0.11',
+    'jedi>=0.10',
     'decorator',
     'pickleshare',
     'simplegeneric>0.8',

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ if sys.version_info < (3, 3):
     except Exception:
         pass
 
-        
+
     error = """
 IPython 6.0+ does not support Python 2.6, 2.7, 3.0, 3.1, or 3.2.
 When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
@@ -185,7 +185,7 @@ extras_require = dict(
 
 install_requires = [
     'setuptools>=18.5',
-    'jedi>=0.10',
+    'jedi>=0.11',
     'decorator',
     'pickleshare',
     'simplegeneric>0.8',


### PR DESCRIPTION
Inside `IPCompleter:_jedi_matches()`, we're including `jedi.parser.tree`, which has been removed from jedi version 0.11. As a **temporary fix**, specify jedi 0.10 as a requirement. This fixes: https://github.com/ipython/ipython/issues/10882

