### PR TITLE
Ensure that MimeBundleFormatter always returns a 2-tuple

### DIFF
--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -224,7 +224,7 @@ def catch_format_error(method, self, *args, **kwargs):
         r = method(self, *args, **kwargs)
     except NotImplementedError:
         # don't warn on NotImplementedErrors
-        return None
+        return self._check_return(None, args[0])
     except Exception:
         exc_info = sys.exc_info()
         ip = get_ipython()
@@ -232,7 +232,7 @@ def catch_format_error(method, self, *args, **kwargs):
             ip.showtraceback(exc_info)
         else:
             traceback.print_exception(*exc_info)
-        return None
+        return self._check_return(None, args[0])
     return self._check_return(r, args[0])
 
 

--- a/IPython/core/tests/test_formatters.py
+++ b/IPython/core/tests/test_formatters.py
@@ -521,3 +521,13 @@ def test_repr_mime_meta():
             'height': 10,
         }
     })
+
+def test_repr_mime_failure():
+    class BadReprMime(object):
+        def _repr_mimebundle_(self, include=None, exclude=None):
+            raise RuntimeError
+
+    f = get_ipython().display_formatter
+    obj = BadReprMime()
+    d, md = f.format(obj)
+    nt.assert_in('text/plain', d)


### PR DESCRIPTION
See [this comment](https://github.com/ipython/ipython/issues/10886#issuecomment-343760415) describing the error this fixes.