### PR TITLE
Improve performance of InputSplitter

### DIFF
--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -313,8 +313,6 @@ class InputSplitter(object):
     _buffer = None
     # Command compiler
     _compile = None
-    # Mark when input has changed indentation all the way back to flush-left
-    _full_dedent = False
     # Boolean indicating whether the current block is complete
     _is_complete = None
     # Boolean indicating whether the current block has an unrecoverable syntax error
@@ -335,7 +333,6 @@ class InputSplitter(object):
         self.code = None
         self._is_complete = False
         self._is_invalid = False
-        self._full_dedent = False
 
     def source_reset(self):
         """Return the input source and perform a full reset.
@@ -494,7 +491,6 @@ class InputSplitter(object):
     def _update_indent(self):
         # self.source always has a trailing newline
         self.indent_spaces = find_next_indent(self.source[:-1])
-        self._full_dedent = (self.indent_spaces == 0)
 
     def _store(self, lines, buffer=None, store='source'):
         """Store one or more lines of input.

--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -290,10 +290,12 @@ class InputSplitter(object):
             isp.push(line)
         print 'Input source was:\n', isp.source_reset(),
     """
-    # A cache for calculating the current indentation.
-    # If the first value matches self.source, the second value is an integer
-    # number of spaces for the current indentation. If the first value does not
-    # match, self.source has changed, and the indentation must be recalculated.
+    # A cache for storing the current indentation
+    # The first value stores the most recently processed source input
+    # The second value is the number of spaces for the current indentation 
+    # If self.source matches the first value, the second value is a valid
+    # current indentation. Otherwise, the cache is invalid and the indentation
+    # must be recalculated.
     _indent_spaces_cache = None, None
     # String, indicating the default input encoding.  It is computed by default
     # at initialization time via get_input_encoding(), but it can be reset by a

--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -499,6 +499,11 @@ class InputSplitter(object):
         self._indent_spaces_cache = (self.source, n)
         return n
 
+    # Backwards compatibility. I think all code that used .indent_spaces was
+    # inside IPython, but we can leave this here until IPython 7 in case any
+    # other modules are using it. -TK, November 2017
+    indent_spaces = property(get_indent_spaces)
+
     def _store(self, lines, buffer=None, store='source'):
         """Store one or more lines of input.
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1940,7 +1940,7 @@ class InteractiveShell(SingletonConfigurable):
 
     def _indent_current_str(self):
         """return the current level of indentation as a string"""
-        return self.input_splitter.indent_spaces * ' '
+        return self.input_splitter.get_indent_spaces() * ' '
 
     #-------------------------------------------------------------------------
     # Things related to text completion

--- a/IPython/core/tests/test_inputsplitter.py
+++ b/IPython/core/tests/test_inputsplitter.py
@@ -37,7 +37,7 @@ def mini_interactive_loop(input_func):
     # input indefinitely, until some exit/quit command was issued.  Here we
     # only illustrate the basic inner loop.
     while isp.push_accepts_more():
-        indent = ' '*isp.indent_spaces
+        indent = ' '*isp.get_indent_spaces()
         prompt = '>>> ' + indent
         line = indent + input_func(prompt)
         isp.push(line)
@@ -132,7 +132,7 @@ class InputSplitterTestCase(unittest.TestCase):
         isp.push('x=1')
         isp.reset()
         self.assertEqual(isp._buffer, [])
-        self.assertEqual(isp.indent_spaces, 0)
+        self.assertEqual(isp.get_indent_spaces(), 0)
         self.assertEqual(isp.source, '')
         self.assertEqual(isp.code, None)
         self.assertEqual(isp._is_complete, False)
@@ -149,21 +149,21 @@ class InputSplitterTestCase(unittest.TestCase):
     def test_indent(self):
         isp = self.isp # shorthand
         isp.push('x=1')
-        self.assertEqual(isp.indent_spaces, 0)
+        self.assertEqual(isp.get_indent_spaces(), 0)
         isp.push('if 1:\n    x=1')
-        self.assertEqual(isp.indent_spaces, 4)
+        self.assertEqual(isp.get_indent_spaces(), 4)
         isp.push('y=2\n')
-        self.assertEqual(isp.indent_spaces, 0)
+        self.assertEqual(isp.get_indent_spaces(), 0)
 
     def test_indent2(self):
         isp = self.isp
         isp.push('if 1:')
-        self.assertEqual(isp.indent_spaces, 4)
+        self.assertEqual(isp.get_indent_spaces(), 4)
         isp.push('    x=1')
-        self.assertEqual(isp.indent_spaces, 4)
+        self.assertEqual(isp.get_indent_spaces(), 4)
         # Blank lines shouldn't change the indent level
         isp.push(' '*2)
-        self.assertEqual(isp.indent_spaces, 4)
+        self.assertEqual(isp.get_indent_spaces(), 4)
 
     def test_indent3(self):
         isp = self.isp
@@ -171,75 +171,75 @@ class InputSplitterTestCase(unittest.TestCase):
         # shouldn't get confused.
         isp.push("if 1:")
         isp.push("    x = (1+\n    2)")
-        self.assertEqual(isp.indent_spaces, 4)
+        self.assertEqual(isp.get_indent_spaces(), 4)
 
     def test_indent4(self):
         isp = self.isp
         # whitespace after ':' should not screw up indent level
         isp.push('if 1: \n    x=1')
-        self.assertEqual(isp.indent_spaces, 4)
+        self.assertEqual(isp.get_indent_spaces(), 4)
         isp.push('y=2\n')
-        self.assertEqual(isp.indent_spaces, 0)
+        self.assertEqual(isp.get_indent_spaces(), 0)
         isp.push('if 1:\t\n    x=1')
-        self.assertEqual(isp.indent_spaces, 4)
+        self.assertEqual(isp.get_indent_spaces(), 4)
         isp.push('y=2\n')
-        self.assertEqual(isp.indent_spaces, 0)
+        self.assertEqual(isp.get_indent_spaces(), 0)
 
     def test_dedent_pass(self):
         isp = self.isp # shorthand
         # should NOT cause dedent
         isp.push('if 1:\n    passes = 5')
-        self.assertEqual(isp.indent_spaces, 4)
+        self.assertEqual(isp.get_indent_spaces(), 4)
         isp.push('if 1:\n     pass')
-        self.assertEqual(isp.indent_spaces, 0)
+        self.assertEqual(isp.get_indent_spaces(), 0)
         isp.push('if 1:\n     pass   ')
-        self.assertEqual(isp.indent_spaces, 0)
+        self.assertEqual(isp.get_indent_spaces(), 0)
 
     def test_dedent_break(self):
         isp = self.isp # shorthand
         # should NOT cause dedent
         isp.push('while 1:\n    breaks = 5')
-        self.assertEqual(isp.indent_spaces, 4)
+        self.assertEqual(isp.get_indent_spaces(), 4)
         isp.push('while 1:\n     break')
-        self.assertEqual(isp.indent_spaces, 0)
+        self.assertEqual(isp.get_indent_spaces(), 0)
         isp.push('while 1:\n     break   ')
-        self.assertEqual(isp.indent_spaces, 0)
+        self.assertEqual(isp.get_indent_spaces(), 0)
 
     def test_dedent_continue(self):
         isp = self.isp # shorthand
         # should NOT cause dedent
         isp.push('while 1:\n    continues = 5')
-        self.assertEqual(isp.indent_spaces, 4)
+        self.assertEqual(isp.get_indent_spaces(), 4)
         isp.push('while 1:\n     continue')
-        self.assertEqual(isp.indent_spaces, 0)
+        self.assertEqual(isp.get_indent_spaces(), 0)
         isp.push('while 1:\n     continue   ')
-        self.assertEqual(isp.indent_spaces, 0)
+        self.assertEqual(isp.get_indent_spaces(), 0)
 
     def test_dedent_raise(self):
         isp = self.isp # shorthand
         # should NOT cause dedent
         isp.push('if 1:\n    raised = 4')
-        self.assertEqual(isp.indent_spaces, 4)
+        self.assertEqual(isp.get_indent_spaces(), 4)
         isp.push('if 1:\n     raise TypeError()')
-        self.assertEqual(isp.indent_spaces, 0)
+        self.assertEqual(isp.get_indent_spaces(), 0)
         isp.push('if 1:\n     raise')
-        self.assertEqual(isp.indent_spaces, 0)
+        self.assertEqual(isp.get_indent_spaces(), 0)
         isp.push('if 1:\n     raise      ')
-        self.assertEqual(isp.indent_spaces, 0)
+        self.assertEqual(isp.get_indent_spaces(), 0)
 
     def test_dedent_return(self):
         isp = self.isp # shorthand
         # should NOT cause dedent
         isp.push('if 1:\n    returning = 4')
-        self.assertEqual(isp.indent_spaces, 4)
+        self.assertEqual(isp.get_indent_spaces(), 4)
         isp.push('if 1:\n     return 5 + 493')
-        self.assertEqual(isp.indent_spaces, 0)
+        self.assertEqual(isp.get_indent_spaces(), 0)
         isp.push('if 1:\n     return')
-        self.assertEqual(isp.indent_spaces, 0)
+        self.assertEqual(isp.get_indent_spaces(), 0)
         isp.push('if 1:\n     return      ')
-        self.assertEqual(isp.indent_spaces, 0)
+        self.assertEqual(isp.get_indent_spaces(), 0)
         isp.push('if 1:\n     return(0)')
-        self.assertEqual(isp.indent_spaces, 0)
+        self.assertEqual(isp.get_indent_spaces(), 0)
 
     def test_push(self):
         isp = self.isp
@@ -508,7 +508,7 @@ if __name__ == '__main__':
         while True:
             prompt = start_prompt
             while isp.push_accepts_more():
-                indent = ' '*isp.indent_spaces
+                indent = ' '*isp.get_indent_spaces()
                 if autoindent:
                     line = indent + input(prompt+indent)
                 else:


### PR DESCRIPTION
This fixes some embarrassingly bad performance. @rpep pointed out to me that a 500-line cell he had in a notebook took tens of seconds even to start executing, e.g. to show a syntax error.

I tracked this down to our input processing in `IPython.core.inputsplitter`. We are doing large amounts of unnecessary work by calculating at each line processed:

- The indentation for the next line, which involves tokenisation. This was >90% of the time taken.
- Whether the input is complete, which involves byte-compilation.

We still need the ability to work out both of these things, but we don't need them for each line of a block passed to inputsplitter, and we don't need them at all when transforming code prior to execution.

This code avoids much of this unnecessary work, taking the processing time on the 500-line sample from ~40 seconds to ~0.2 seconds on my computer. The problematic code is roughly `O(N^2)` in the number of lines, so it's probably only noticeable with very long cells, but with a 40 line sample I measured an improvement from 0.05 s to 0.004 s.

I have changed a couple of methods and attributes on `InputSplitter` to do this. The automatic API docs do include the module, but I don't really consider it public API, and that code is already convoluted enough that I don't want to clutter it up with compatibility stuff and make it even harder to understand. I checked that ipykernel and rlipython are not using the pieces I changed.