### PR TITLE
Attempt to build documentation with Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 #group: edge
 before_install:
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
-    - 'if [[ $GROUP == docs ]]; then pip install -r docs/doc-requirements.txt; fi'
+    - 'if [[ $GROUP == docs ]]; then pip install -r docs/requirements.txt; fi'
 install:
     - pip install setuptools pip --upgrade
     - pip install -e file://$PWD#egg=ipython[test] --upgrade

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,13 @@ python:
     - 3.6
     - 3.5
     - 3.4
-    - 3.3
 sudo: false
 env:
   global:
     - PATH=$TRAVIS_BUILD_DIR/pandoc:$PATH
   matrix:
     - GROUP=docs
-#group: edge
+group: edge
 before_install:
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
     - 'if [[ $GROUP == docs ]]; then pip install -r docs/requirements.txt; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,22 @@ python:
     - 3.4
     - 3.3
 sudo: false
-group: edge
+env:
+  global:
+    - PATH=$TRAVIS_BUILD_DIR/pandoc:$PATH
+  matrix:
+    - GROUP=docs
+#group: edge
 before_install:
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
+    - 'if [[ $GROUP == docs ]]; then pip install -r docs/doc-requirements.txt; fi'
 install:
     - pip install setuptools pip --upgrade
     - pip install -e file://$PWD#egg=ipython[test] --upgrade
     - pip install codecov --upgrade
 script:
     - cd /tmp && iptest --coverage xml && cd -
+    - 'if [[ $GROUP == docs ]]; then make -C docs/ html; fi'
 after_success:
     - cp /tmp/ipy_coverage.xml ./
     - cp /tmp/.coverage ./
@@ -24,6 +31,9 @@ after_success:
 matrix:
     allow_failures:
         - python: nightly
+    exclude:
+        - python: 2.7
+          env: GROUP=docs
 
 before_deploy:
     - rm -rf dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - 3.6
     - 3.5
     - 3.4
+    - 3.3
 sudo: false
 env:
   global:
@@ -32,6 +33,8 @@ matrix:
         - python: nightly
     exclude:
         - python: 2.7
+          env: GROUP=docs
+        - python: 3.3
           env: GROUP=docs
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,19 +10,21 @@ sudo: false
 env:
   global:
     - PATH=$TRAVIS_BUILD_DIR/pandoc:$PATH
-  matrix:
-    - GROUP=docs
 group: edge
 before_install:
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
-    - 'if [[ $GROUP == docs ]]; then pip install -r docs/requirements.txt; fi'
 install:
     - pip install setuptools pip --upgrade
     - pip install -e file://$PWD#egg=ipython[test] --upgrade
     - pip install codecov --upgrade
 script:
     - cd /tmp && iptest --coverage xml && cd -
-    - 'if [[ $GROUP == docs ]]; then make -C docs/ html; fi'
+    # On the latest Python only, make sure that the docs build.
+    - |
+      if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
+        pip install -r docs/requirements.txt
+        make -C docs/ html
+      fi
 after_success:
     - cp /tmp/ipy_coverage.xml ./
     - cp /tmp/.coverage ./
@@ -31,11 +33,6 @@ after_success:
 matrix:
     allow_failures:
         - python: nightly
-    exclude:
-        - python: 2.7
-          env: GROUP=docs
-        - python: 3.3
-          env: GROUP=docs
 
 before_deploy:
     - rm -rf dist/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 -e .
 ipykernel
 setuptools>=18.5
-sphinx>=1.3.6
+sphinx
 sphinx-rtd-theme
-nbsphinx==0.2.14

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,6 @@
 -e .
 ipykernel
 setuptools>=18.5
+sphinx>=1.3.6
+sphinx-rtd-theme
+nbsphinx==0.2.14

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ ipykernel
 setuptools>=18.5
 sphinx
 sphinx-rtd-theme
+docrepr


### PR DESCRIPTION
This is attempt to solve https://github.com/ipython/ipython/issues/10895:
- Added building documentation, using https://github.com/jupyter/notebook/pull/2808 as an example
- Dropped support for Python 3.3 because Travis CI had issues building it ("The command "if [[ $GROUP == docs ]]; then make -C docs/ html; fi" exited with 2.") + saw that Travis CI had issue with Python 3.3 in https://github.com/jupyter/notebook/commit/1ec12f7215b25f03f799effd9be1b1687d1b0a6e
- Tests now produce warnings like "/home/travis/build/olesyabar/ipython/IPython/core/debugger.py:docstring of IPython.core.debugger.Pdb.do_q:3: WARNING: Unexpected indentation." but fixing the warnings is outside of this PR

@syutbai actively contributed to this during PyCon Canada sprinting