### PR TITLE
Improve local docs building docs to ensure all deps are installed

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -16,22 +16,17 @@ Requirements
 
 The documentation must be built using Python 3.
 
-The following tools are needed to build the documentation:
+In additions to :ref:`devinstall`,
+the following tools are needed to build the documentation:
 
  - sphinx
  - sphinx_rtd_theme
+ - docrepr
 
-On Debian-based systems, you should be able to run::
+In a conda environment, or a Python 3 ``venv``, you should be able to run::
 
-    sudo apt-get install python3-sphinx python3-sphinx-rtd-theme
-
-In a conda environment, you can use::
-
-    conda install sphinx sphinx_rtd_theme
-
-In a Python 3 ``venv``, you should be able to run::
-
-    pip install -U sphinx sphinx_rtd_theme
+  cd ipython
+  pip install -U -r docs/requirements.txt
 
 
 Build Commands


### PR DESCRIPTION
re: https://github.com/ipython/ipython/pull/10912#pullrequestreview-78043112

@jzf2101 @Carreau Working in a clean conda environment locally I found that it is necessary to do both a dev install and then add the deps from `docs/requirements.txt`. So, this change links to the dev install instructions and then the requirements install. 

Works for either conda env or venv, but doesn't make sense to me in the debian package manager context, so I took that out (assuming we don't actually want to encourage system-wide installs for dev work - though I guess it's relevant if you are provisioning a VM or building a container, but then you probably don't need to be told, right?)