### PR TITLE
Avoid PyGIDeprecationWarning when using Gtk3 backend.

### DIFF
--- a/IPython/lib/inputhookgtk3.py
+++ b/IPython/lib/inputhookgtk3.py
@@ -29,6 +29,6 @@ def _main_quit(*args, **kwargs):
 
 
 def inputhook_gtk3():
-    GLib.io_add_watch(sys.stdin, GLib.IO_IN, _main_quit)
+    GLib.io_add_watch(sys.stdin, GLib.PRIORITY_DEFAULT, GLib.IO_IN, _main_quit)
     Gtk.main()
     return 0

--- a/IPython/terminal/pt_inputhooks/gtk3.py
+++ b/IPython/terminal/pt_inputhooks/gtk3.py
@@ -8,5 +8,5 @@ def _main_quit(*args, **kwargs):
     return False
 
 def inputhook(context):
-    GLib.io_add_watch(context.fileno(), GLib.IO_IN, _main_quit)
+    GLib.io_add_watch(context.fileno(), GLib.PRIORITY_DEFAULT, GLib.IO_IN, _main_quit)
     Gtk.main()


### PR DESCRIPTION
Since pygobject 3.7.3, which was [released ~5 years ago](https://piware.de/2012/12/pygobject-3-7-3-released/), the function `GLib.io_add_watch` has preferred a call signature other than the one that our input backends were using.

(Because the new API has been around for so long, I think it's OK to stop supporting older versions of `pygobject`.)

This seems to work fine in local testing.