### PR TITLE
Swap the check for Jedi versions around

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1351,11 +1351,11 @@ class IPCompleter(Completer):
         try:
             # should we check the type of the node is Error ?
             try:
-                # jedi >= 0.11
-                from parso.tree import ErrorLeaf
-            except ImportError:
                 # jedi < 0.11
                 from jedi.parser.tree import ErrorLeaf
+            except ImportError:
+                # jedi >= 0.11
+                from parso.tree import ErrorLeaf
 
             next_to_last_tree = interpreter._get_module().tree_node.children[-2]
             completing_string = False


### PR DESCRIPTION
It's possible to have Parso installed alongside an older version of Jedi which doesn't use it. I had this situation, and it was messing up my tab completions because it couldn't detect when it was in a string.

Jedi 0.11 doesn't have the `jedi.parser` subpackage, so I think checking it this way should be more reliable.