### PR TITLE
Add check for exe-in-virtualenv using os.path.samefile()

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -732,16 +732,23 @@ class InteractiveShell(SingletonConfigurable):
             # Not in a virtualenv
             return
         
-        # venv detection:
+        p = os.path.normcase(sys.executable)
+        p_venv = os.path.normcase(os.environ['VIRTUAL_ENV'])
+
+        # executable path should end like /bin/python or \\scripts\\python.exe
+        p_exe_up2 = os.path.dirname(os.path.dirname(p))
+        if p_exe_up2 and os.path.samefile(p_exe_up2, p_venv):
+            # Our exe is inside the virtualenv, don't need to do anything.
+            return
+
+        # fallback venv detection:
         # stdlib venv may symlink sys.executable, so we can't use realpath.
         # but others can symlink *to* the venv Python, so we can't just use sys.executable.
         # So we just check every item in the symlink tree (generally <= 3)
-        p = os.path.normcase(sys.executable)
         paths = [p]
         while os.path.islink(p):
             p = os.path.normcase(os.path.join(os.path.dirname(p), os.readlink(p)))
             paths.append(p)
-        p_venv = os.path.normcase(os.environ['VIRTUAL_ENV'])
         
         # In Cygwin paths like "c:\..." and '\cygdrive\c\...' are possible
         if p_venv.startswith('\\cygdrive'):


### PR DESCRIPTION
I think that using `samefile()` should be a better way to detect if our Python is in a virtualenv - it means we don't have to deal with resolving symlinks.

However, it depends on walking exactly two steps up the path from `sys.executable`. I think this is right in cases I know about - it should be either `.../bin/python` on Unix, or `...\Scripts\python.exe` on Windows. But given how many corner cases we've already hit with this, I've left the existing path munging code in there as well: if `samefile()` says sys.executable is *not* in a virtualenv, we'll check again with path munging.

Closes gh-10955