### PR TITLE
Skip our own Python completions when using Jedi

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1102,13 +1102,20 @@ class IPCompleter(Completer):
         #= re.compile(r'[\s|\[]*(\w+)(?:\s*=?\s*.*)')
 
         # All active matcher routines for completion
-        self.matchers = [
-                         self.python_matches,
-                         self.file_matches,
-                         self.magic_matches,
-                         self.python_func_kw_matches,
-                         self.dict_key_matches,
-                         ]
+        if self.use_jedi:
+            self.matchers = [
+                self.file_matches,
+                self.magic_matches,
+                self.dict_key_matches,
+            ]
+        else:
+            self.matchers = [
+                self.python_matches,
+                self.file_matches,
+                self.magic_matches,
+                self.python_func_kw_matches,
+                self.dict_key_matches,
+            ]
         self.magic_arg_matchers = [
             self.magic_config_matches,
             self.magic_color_matches,

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1101,21 +1101,6 @@ class IPCompleter(Completer):
         #use this if positional argument name is also needed
         #= re.compile(r'[\s|\[]*(\w+)(?:\s*=?\s*.*)')
 
-        # All active matcher routines for completion
-        if self.use_jedi:
-            self.matchers = [
-                self.file_matches,
-                self.magic_matches,
-                self.dict_key_matches,
-            ]
-        else:
-            self.matchers = [
-                self.python_matches,
-                self.file_matches,
-                self.magic_matches,
-                self.python_func_kw_matches,
-                self.dict_key_matches,
-            ]
         self.magic_arg_matchers = [
             self.magic_config_matches,
             self.magic_color_matches,
@@ -1123,6 +1108,24 @@ class IPCompleter(Completer):
 
         # This is set externally by InteractiveShell
         self.custom_completers = None
+
+    @property
+    def matchers(self):
+        """All active matcher routines for completion"""
+        if self.use_jedi:
+            return [
+                self.file_matches,
+                self.magic_matches,
+                self.dict_key_matches,
+            ]
+        else:
+            return [
+                self.python_matches,
+                self.file_matches,
+                self.magic_matches,
+                self.python_func_kw_matches,
+                self.dict_key_matches,
+            ]
 
     def all_completions(self, text):
         """

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1931,7 +1931,7 @@ class IPCompleter(Completer):
         return self._complete(line_buffer=line_buffer, cursor_pos=cursor_pos, text=text, cursor_line=0)[:2]
 
     def _complete(self, *, cursor_line, cursor_pos, line_buffer=None, text=None,
-                  full_text=None, return_jedi_results=True) -> Tuple[str, List[str], List[str], Iterable[_FakeJediCompletion]]:
+                  full_text=None) -> Tuple[str, List[str], List[str], Iterable[_FakeJediCompletion]]:
         """
 
         Like complete but can also returns raw jedi completions as well as the
@@ -1997,7 +1997,7 @@ class IPCompleter(Completer):
         # simply collapse the dict into a list for readline, but we'd have
         # richer completion semantics in other evironments.
         completions = ()
-        if self.use_jedi and return_jedi_results:
+        if self.use_jedi:
             if not full_text:
                 full_text = line_buffer
             completions = self._jedi_matches(

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1985,6 +1985,7 @@ class InteractiveShell(SingletonConfigurable):
         self.set_hook('complete_command', reset_completer, str_key = '%reset')
 
 
+    @skip_doctest
     def complete(self, text, line=None, cursor_pos=None):
         """Return the completed text and a list of completions.
 

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -380,10 +380,13 @@ def test_greedy_completions():
                     "Shouldn't have completed on a[0]: %s"%c)
     with greedy_completion(), provisionalcompleter():
         def _(line, cursor_pos, expect, message, completion):
+            ip.Completer.use_jedi = False
             _,c = ip.complete('.', line=line, cursor_pos=cursor_pos)
+            nt.assert_in(expect, c, message % c)
+
+            ip.Completer.use_jedi = True
             with provisionalcompleter():
                 completions = ip.Completer.completions(line, cursor_pos)
-            nt.assert_in(expect, c, message%c)
             nt.assert_in(completion, completions)
 
         yield _, 'a[0].', 5, 'a[0].real', "Should have completed on a[0].: %s", Completion(5,5, 'real')
@@ -404,13 +407,14 @@ def test_omit__names():
     cfg.IPCompleter.omit__names = 0
     c.update_config(cfg)
     with provisionalcompleter():
+        c.use_jedi = False
         s,matches = c.complete('ip.')
-        completions = set(c.completions('ip.', 3))
-
         nt.assert_in('ip.__str__', matches)
-        nt.assert_in(Completion(3, 3, '__str__'), completions)
-        
         nt.assert_in('ip._hidden_attr', matches)
+
+        c.use_jedi = True
+        completions = set(c.completions('ip.', 3))
+        nt.assert_in(Completion(3, 3, '__str__'), completions)
         nt.assert_in(Completion(3,3, "_hidden_attr"), completions)
 
 
@@ -418,33 +422,37 @@ def test_omit__names():
     cfg.IPCompleter.omit__names = 1
     c.update_config(cfg)
     with provisionalcompleter():
+        c.use_jedi = False
         s,matches = c.complete('ip.')
-        completions = set(c.completions('ip.', 3))
-
         nt.assert_not_in('ip.__str__', matches)
-        nt.assert_not_in(Completion(3,3,'__str__'), completions)
-
         # nt.assert_in('ip._hidden_attr', matches)
+
+        c.use_jedi = True
+        completions = set(c.completions('ip.', 3))
+        nt.assert_not_in(Completion(3,3,'__str__'), completions)
         nt.assert_in(Completion(3,3, "_hidden_attr"), completions)
 
     cfg = Config()
     cfg.IPCompleter.omit__names = 2
     c.update_config(cfg)
     with provisionalcompleter():
+        c.use_jedi = False
         s,matches = c.complete('ip.')
-        completions = set(c.completions('ip.', 3))
-
         nt.assert_not_in('ip.__str__', matches)
-        nt.assert_not_in(Completion(3,3,'__str__'), completions)
-
         nt.assert_not_in('ip._hidden_attr', matches)
+
+        c.use_jedi = True
+        completions = set(c.completions('ip.', 3))
+        nt.assert_not_in(Completion(3,3,'__str__'), completions)
         nt.assert_not_in(Completion(3,3, "_hidden_attr"), completions)
 
     with provisionalcompleter():
+        c.use_jedi = False
         s,matches = c.complete('ip._x.')
-        completions = set(c.completions('ip._x.', 6))
-
         nt.assert_in('ip._x.keys', matches)
+
+        c.use_jedi = True
+        completions = set(c.completions('ip._x.', 6))
         nt.assert_in(Completion(6,6, "keys"), completions)
 
     del ip._hidden_attr
@@ -457,6 +465,7 @@ def test_limit_to__all__False_ok():
     """
     ip = get_ipython()
     c = ip.Completer
+    c.use_jedi = False
     ip.ex('class D: x=24')
     ip.ex('d=D()')
     cfg = Config()
@@ -483,6 +492,7 @@ def test_get__all__entries_no__all__ok():
 def test_func_kw_completions():
     ip = get_ipython()
     c = ip.Completer
+    c.use_jedi = False
     ip.ex('def myfunc(a=1,b=2): return a+b')
     s, matches = c.complete(None, 'myfunc(1,b')
     nt.assert_in('b=', matches)
@@ -573,6 +583,7 @@ def test_magic_completion_order():
 def test_magic_completion_shadowing():
     ip = get_ipython()
     c = ip.Completer
+    c.use_jedi = False
 
     # Before importing matplotlib, %matplotlib magic should be the only option.
     text, matches = c.complete("mat")
@@ -1002,6 +1013,7 @@ def test_from_module_completer():
 
 def test_snake_case_completion():
     ip = get_ipython()
+    ip.Completer.use_jedi = False
     ip.user_ns['some_three'] = 3
     ip.user_ns['some_four'] = 4
     _, matches = ip.complete("s_", "print(s_f")


### PR DESCRIPTION
cc @Carreau 

At present, we combine our own completions with those from Jedi. This means we won't catch anything that Jedi is missing, making it harder to eventually drop our own completion machinery.

This makes the `use_jedi` option switch between Jedi and our own completion machinery, so by default the Jedi completions will be used, and our own completions will not. If people experience problems, they can configure `Completer.use_jedi = False` to go back to our completion machinery for now (and hopefully file issues so we're aware of the problems).

I also got rid of a parameter which doesn't appear to be used anywhere.