### PR TITLE
IPython breaks import matplotlib.pyplot when there is no display

### DIFF
--- a/IPython/terminal/pt_inputhooks/qt.py
+++ b/IPython/terminal/pt_inputhooks/qt.py
@@ -22,9 +22,8 @@ def inputhook(context):
                     _already_warned = True
                     warnings.warn(
                         'The DISPLAY enviroment variable is not set or empty '
-                        'and qt requires this enviroment variable. '
-                        'Deaktivate qt code.\n'
-                        'Backend: {}'.format(QtGui)
+                        'and Qt5 requires this enviroment variable. '
+                        'Deaktivate Qt5 code.'
                     )
                 return
         _appref = app = QtGui.QApplication([" "])

--- a/IPython/terminal/pt_inputhooks/qt.py
+++ b/IPython/terminal/pt_inputhooks/qt.py
@@ -13,8 +13,8 @@ def inputhook(context):
     if not app:
         if sys.platform == 'linux':
             try:
-                os.environ['DISPLAY']  # DISPLAY is set
-                assert os.environ['DISPLAY'] != ''  # DISPLAY is not empty
+                # DISPLAY or WAYLAND_DISPLAY is set and not empty
+                assert os.environ.get('DISPLAY') or os.environ.get('WAYLAND_DISPLAY')
             except Exception:
                 import warnings
                 global _already_warned

--- a/IPython/terminal/pt_inputhooks/qt.py
+++ b/IPython/terminal/pt_inputhooks/qt.py
@@ -12,18 +12,16 @@ def inputhook(context):
     app = QtCore.QCoreApplication.instance()
     if not app:
         if sys.platform == 'linux':
-            try:
-                # DISPLAY or WAYLAND_DISPLAY is set and not empty
-                assert os.environ.get('DISPLAY') or os.environ.get('WAYLAND_DISPLAY')
-            except Exception:
+            if not os.environ.get('DISPLAY') \
+                    and not os.environ.get('WAYLAND_DISPLAY'):
                 import warnings
                 global _already_warned
                 if not _already_warned:
                     _already_warned = True
                     warnings.warn(
-                        'The DISPLAY enviroment variable is not set or empty '
-                        'and Qt5 requires this enviroment variable. '
-                        'Deactivate Qt5 code.'
+                        'The DISPLAY or WAYLAND_DISPLAY enviroment variable is '
+                        'not set or empty and Qt5 requires this enviroment '
+                        'variable. Deactivate Qt5 code.'
                     )
                 return
         _appref = app = QtGui.QApplication([" "])

--- a/IPython/terminal/pt_inputhooks/qt.py
+++ b/IPython/terminal/pt_inputhooks/qt.py
@@ -23,7 +23,7 @@ def inputhook(context):
                     warnings.warn(
                         'The DISPLAY enviroment variable is not set or empty '
                         'and Qt5 requires this enviroment variable. '
-                        'Deaktivate Qt5 code.'
+                        'Deactivate Qt5 code.'
                     )
                 return
         _appref = app = QtGui.QApplication([" "])

--- a/IPython/terminal/pt_inputhooks/qt.py
+++ b/IPython/terminal/pt_inputhooks/qt.py
@@ -1,15 +1,32 @@
 import sys
+import os
 from IPython.external.qt_for_kernel import QtCore, QtGui
 
 # If we create a QApplication, keep a reference to it so that it doesn't get
 # garbage collected.
 _appref = None
-
+_already_warned = False
 
 def inputhook(context):
     global _appref
     app = QtCore.QCoreApplication.instance()
     if not app:
+        if sys.platform == 'linux':
+            try:
+                os.environ['DISPLAY']  # DISPLAY is set
+                assert os.environ['DISPLAY'] != ''  # DISPLAY is not empty
+            except Exception:
+                import warnings
+                global _already_warned
+                if not _already_warned:
+                    _already_warned = True
+                    warnings.warn(
+                        'The DISPLAY enviroment variable is not set or empty '
+                        'and qt requires this enviroment variable. '
+                        'Deaktivate qt code.\n'
+                        'Backend: {}'.format(QtGui)
+                    )
+                return
         _appref = app = QtGui.QApplication([" "])
     event_loop = QtCore.QEventLoop(app)
 


### PR DESCRIPTION
First: This is more an Issue than a PR, I made a PR to show where the error occurs and suggest a workaround.

Related:
#10627
https://github.com/ContinuumIO/anaconda-issues/issues/1806

When someone starts ipython from the command line interface on a machine without a display and executes `import matplotlib.pyplot` the python interpreter breaks
```
In [1]: import matplotlib.pyplot
In [2]: QXcbConnection: Could not connect to display 
Abgebrochen (Speicherabzug geschrieben)
```
Since some libraries that have visualization functions require matplotlib and do not use a lazy import, in my mind IPython should handle this case correctly. At least with a Python exception and not an C/C++ Error.

