### PR TITLE
Add display class for syntax-highlighted code

### DIFF
--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -558,6 +558,23 @@ class FileLinks(FileLink):
 
 
 class Code(TextDisplayObject):
+    """Display syntax-highlighted source code.
+
+    This uses Pygments to highlight the code for HTML and Latex output.
+
+    Parameters
+    ----------
+    data : str
+        The code as a string
+    url : str
+        A URL to fetch the code from
+    filename : str
+        A local filename to load the code from
+    language : str
+        The short name of a Pygments lexer to use for highlighting.
+        If not specified, it will guess the lexer based on the filename
+        or the code. Available lexers: http://pygments.org/docs/lexers/
+    """
     def __init__(self, data=None, url=None, filename=None, language=None):
         self.language = language
         super().__init__(data=data, url=url, filename=filename)

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -590,6 +590,9 @@ class Code(TextDisplayObject):
             from pygments.lexers import guess_lexer
             return guess_lexer(self.data)
 
+    def __repr__(self):
+        return self.data
+
     def _repr_html_(self):
         from pygments import highlight
         from pygments.formatters import HtmlFormatter

--- a/IPython/lib/tests/test_display.py
+++ b/IPython/lib/tests/test_display.py
@@ -175,3 +175,7 @@ def test_recursive_FileLinks():
 def test_audio_from_file():
     path = pjoin(dirname(__file__), 'test.wav')
     display.Audio(filename=path)
+
+def test_code_from_file():
+    c = display.Code(filename=__file__)
+    assert c._repr_html_().startswith('<style>')


### PR DESCRIPTION
Preparing some workshop materials, I've found myself wanting a better way to display a separate code file in a notebook.

* `!cat` doesn't highlight code, and it only works if cat is available.
* `%pycat` displays code in the pager, not as regular output, and its highlighting is specific to Python code.

There are many ways this could be extended - to add more output formats, or to let the user pick a pygments style, for instance. But I think what's there probably meets the 80% use case.