### PR TITLE
fix execution count when custom exception is caught during compile

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2752,23 +2752,25 @@ class InteractiveShell(SingletonConfigurable):
 
             with self.display_trap:
                 # Compile to bytecode
+                ast_error = None
                 try:
                     code_ast = compiler.ast_parse(cell, filename=cell_name)
                 except self.custom_exceptions as e:
                     etype, value, tb = sys.exc_info()
                     self.CustomTB(etype, value, tb)
-                    return error_before_exec(e)
+                    ast_error = e
                 except IndentationError as e:
                     self.showindentationerror()
-                    if store_history:
-                        self.execution_count += 1
-                    return error_before_exec(e)
+                    ast_error = e
                 except (OverflowError, SyntaxError, ValueError, TypeError,
                         MemoryError) as e:
                     self.showsyntaxerror()
+                    ast_error = e
+
+                if ast_error is not None:
                     if store_history:
                         self.execution_count += 1
-                    return error_before_exec(e)
+                    return error_before_exec(ast_error)
 
                 # Apply AST transformations
                 try:

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -929,5 +929,7 @@ def test_custom_exc_count():
     ip.set_custom_exc((SyntaxError,), hook)
     before = ip.execution_count
     ip.run_cell("def foo()", store_history=True)
+    # restore default excepthook
+    ip.set_custom_exc((), None)
     nt.assert_equal(hook.call_count, 1)
     nt.assert_equal(ip.execution_count, before + 1)

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -922,3 +922,12 @@ def wrn():
         with tt.AssertNotPrints("I AM  A WARNING"):
             ip.run_cell("wrn()")
         ip.run_cell("del wrn")
+
+
+def test_custom_exc_count():
+    hook = mock.Mock(return_value=None)
+    ip.set_custom_exc((SyntaxError,), hook)
+    before = ip.execution_count
+    ip.run_cell("def foo()", store_history=True)
+    nt.assert_equal(hook.call_count, 1)
+    nt.assert_equal(ip.execution_count, before + 1)


### PR DESCRIPTION
e.g. `set_custom_exc(SyntaxError)`

was causing history thread error due to repeated lines

consolidate handling of compilation errors to make deviations less likely in the future