### PR TITLE
Detect string completion when no syntax error

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1355,7 +1355,7 @@ class IPCompleter(Completer):
                     raise ValueError("Don't understand self.omit__names == {}".format(self.omit__names))
 
         interpreter = jedi.Interpreter(
-            text, namespaces, column=cursor_column, line=cursor_line + 1)
+            text[:cursor_column], namespaces, column=cursor_column, line=cursor_line + 1)
         try_jedi = True
 
         try:


### PR DESCRIPTION
Previously the behaviour of completing would be different for `d['`
compared to `d['']`, because disabling of `jedi` relied on detecting a
syntax error, which isn't present in the latter. With this fix, this is
correctly detected.

Unfortunately, the change is very difficult to test, because there is
no easy way to test for _absence_ of any `jedi` completions.