### PR TITLE
Change defaults to be consistent with original defaults and REPL perf…

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -144,6 +144,7 @@ skip_doctest = True
 
 try:
     import jedi
+    jedi.settings.case_insensitive_completion = False
     import jedi.api.helpers
     import jedi.api.classes
     JEDI_INSTALLED = True


### PR DESCRIPTION
Happy to hear feedback on why whatever is currently going on is better but seems like generally it is best to not dramatically change the defaults. <dot>.<tab> is one of the most important operations in python (IPython) from a human perspective so everyone is quite sensitive about this stuff.

Case-insensitivity break tab-completion in the case when there is one case-sensitive choice but several case-insensitive choices.  Would be interesting to consider second <tab> to be case insensitive or something like that. Then you don't break that UX on the first tab completion.  

…ormance. #10728 #10988