### PR TITLE
Fix check for being inside string for jedi completions

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1371,7 +1371,7 @@ class IPCompleter(Completer):
             next_to_last_tree = interpreter._get_module().tree_node.children[-2]
             completing_string = False
             if isinstance(next_to_last_tree, ErrorLeaf):
-                completing_string = next_to_last_tree.value[0] in {'"', "'"}
+                completing_string = next_to_last_tree.value.lstrip()[0] in {'"', "'"}
             # if we are in a string jedi is likely not the right candidate for
             # now. Skip it.
             try_jedi = not completing_string


### PR DESCRIPTION
Completing something like `a = "/home/<tab>` gives a token ` "/home"` starting with a space, which wasn't being caught.

Closes gh-11032

@Carreau do you think you'll have time soon to get back to working on the jedi integration? I like the idea, but it seems to be making the user experience worse and the code feels hackish (we're using a private method to access Jedi's parse tree to decide when to ignore its suggestions entirely). If we can't commit to making it work well, I think we should drop it and go back to relying on the battle-tested IPython completion machinery.