### PR TITLE
Add shell.check_complete() method

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2985,6 +2985,26 @@ class InteractiveShell(SingletonConfigurable):
     # For backwards compatibility
     runcode = run_code
 
+    def check_complete(self, code):
+        """Return whether a block of code is ready to execute, or should be continued
+
+        Parameters
+        ----------
+        source : string
+          Python input code, which can be multiline.
+
+        Returns
+        -------
+        status : str
+          One of 'complete', 'incomplete', or 'invalid' if source is not a
+          prefix of valid code.
+        indent : str
+          When status is 'incomplete', this is some whitespace to insert on
+          the next line of the prompt.
+        """
+        status, nspaces = self.input_splitter.check_complete(code)
+        return status, ' ' * (nspaces or 0)
+
     #-------------------------------------------------------------------------
     # Things related to GUI support and pylab
     #-------------------------------------------------------------------------


### PR DESCRIPTION
This method is also added by #11041 for 7.0. This PR proposes adding the same method to 5.x and 6.x, to make it easier to switch ipykernel over to this instead of `shell.input_splitter.check_complete()`.