### PR TITLE
MAINT: Update locate_profile import to avoid warning

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -20,7 +20,7 @@ import threading
 from traitlets.config.configurable import LoggingConfigurable
 from decorator import decorator
 from IPython.utils.decorators import undoc
-from IPython.utils.path import locate_profile
+from IPython.paths import locate_profile
 from traitlets import (
     Any, Bool, Dict, Instance, Integer, List, Unicode, TraitError,
     default, observe,


### PR DESCRIPTION
## Description
Currently `IPython.core.history.HistoryAccessor` throws a `UserWarning` upon creation due to an import of `locate_profile`. I realize I can silence the warning in my application but figured this deserved a quick fix.
```
UserWarning: locate_profile has moved to the IPython.paths module since IPython 4.0.
  return os.path.join(locate_profile(profile), 'history.sqlite')
```
