### PR TITLE
FileLink: accept path-like objects (#11059)

### DIFF
--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -3,7 +3,7 @@
 Authors : MinRK, gregcaporaso, dannystaple
 """
 from os.path import exists, isfile, splitext, abspath, join, isdir
-from os import walk, sep
+from os import walk, sep, fsdecode
 
 from IPython.core.display import DisplayObject
 
@@ -334,7 +334,7 @@ class FileLink(object):
         if isdir(path):
             raise ValueError("Cannot display a directory using FileLink. "
               "Use FileLinks to display '%s'." % path)
-        self.path = path
+        self.path = fsdecode(path)
         self.url_prefix = url_prefix
         self.result_html_prefix = result_html_prefix
         self.result_html_suffix = result_html_suffix

--- a/IPython/lib/tests/test_display.py
+++ b/IPython/lib/tests/test_display.py
@@ -14,6 +14,11 @@
 #-----------------------------------------------------------------------------
 from tempfile import NamedTemporaryFile, mkdtemp
 from os.path import split, join as pjoin, dirname
+import sys
+try:
+    import pathlib
+except ImportError:
+    pass
 
 # Third-party imports
 import nose.tools as nt
@@ -33,6 +38,9 @@ from IPython.testing.decorators import skipif_not_numpy
 def test_instantiation_FileLink():
     """FileLink: Test class can be instantiated"""
     fl = display.FileLink('example.txt')
+    # TODO: remove if when only Python >= 3.6 is supported
+    if sys.version_info >= (3, 6):
+        fl = display.FileLink(pathlib.PurePath('example.txt'))
 
 def test_warning_on_non_existant_path_FileLink():
     """FileLink: Calling _repr_html_ on non-existant files returns a warning


### PR DESCRIPTION
Accept path-like objects on Python >= 3.6.