### PR TITLE
upgrade pip on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ init:
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - "%CMD_IN_ENV%  pip install setuptools>=18.5 --upgrade"
+  - "%CMD_IN_ENV%  python -m pip install --upgrade setuptools pip"
   - "%CMD_IN_ENV%  pip install nose coverage"
   - "%CMD_IN_ENV%  pip install .[test]"
   - "%CMD_IN_ENV%  mkdir results"


### PR DESCRIPTION
use `python -m` to avoid locks on pip.exe