### PR TITLE
Deprecate some methods from IPython.utils.io

### DIFF
--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -210,35 +210,34 @@ def temp_pyfile(src, ext='.py'):
     f.flush()
     return fname, f
 
+@undoc
 def atomic_writing(*args, **kwargs):
     """DEPRECATED: moved to notebook.services.contents.fileio"""
-    warn("IPython.utils.io.atomic_writing has moved to notebook.services.contents.fileio", stacklevel=2)
+    warn("IPython.utils.io.atomic_writing has moved to notebook.services.contents.fileio since IPython 4.0", DeprecationWarning, stacklevel=2)
     from notebook.services.contents.fileio import atomic_writing
     return atomic_writing(*args, **kwargs)
 
+@undoc
 def raw_print(*args, **kw):
-    """Raw print to sys.__stdout__, otherwise identical interface to print()."""
+    """DEPRECATED: Raw print to sys.__stdout__, otherwise identical interface to print()."""
+    warn("IPython.utils.io.raw_print has been deprecated since IPython 7.0", DeprecationWarning, stacklevel=2)
 
     print(*args, sep=kw.get('sep', ' '), end=kw.get('end', '\n'),
           file=sys.__stdout__)
     sys.__stdout__.flush()
 
-
+@undoc
 def raw_print_err(*args, **kw):
-    """Raw print to sys.__stderr__, otherwise identical interface to print()."""
+    """DEPRECATED: Raw print to sys.__stderr__, otherwise identical interface to print()."""
+    warn("IPython.utils.io.raw_print_err has been deprecated since IPython 7.0", DeprecationWarning, stacklevel=2)
 
     print(*args, sep=kw.get('sep', ' '), end=kw.get('end', '\n'),
           file=sys.__stderr__)
     sys.__stderr__.flush()
 
-
-# Short aliases for quick debugging, do NOT use these in production code.
-rprint = raw_print
-rprinte = raw_print_err
-
-
+@undoc
 def unicode_std_stream(stream='stdout'):
     """DEPRECATED, moved to nbconvert.utils.io"""
-    warn("IPython.utils.io.unicode_std_stream has moved to nbconvert.utils.io", stacklevel=2)
+    warn("IPython.utils.io.unicode_std_stream has moved to nbconvert.utils.io since IPython 4.0", DeprecationWarning, stacklevel=2)
     from nbconvert.utils.io import unicode_std_stream
     return unicode_std_stream(stream)

--- a/docs/source/whatsnew/pr/deprecations.rst
+++ b/docs/source/whatsnew/pr/deprecations.rst
@@ -1,0 +1,7 @@
+A couple of unused function and methods have been deprecated and will be removed
+in future versions:
+
+  - ``IPython.utils.io.raw_print_err``
+  - ``IPython.utils.io.raw_print``
+
+


### PR DESCRIPTION
stdin/err/out defined in this module ado not seem to be used and are
based on IOStream which is deprecated since 5.0. I'm considering that
for removal as well.