### PR TITLE
Disable Jedi completions by default

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -578,7 +578,7 @@ class Completer(Configurable):
 
     use_jedi = Bool(default_value=False,
                     help="Experimental: Use Jedi to generate autocompletions. "
-                    "Default to True if jedi is installed").tag(config=True)
+                    "Off by default.").tag(config=True)
 
     jedi_compute_type_timeout = Int(default_value=400,
         help="""Experimental: restrict time (in milliseconds) during which Jedi can compute types.

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -576,7 +576,7 @@ class Completer(Configurable):
         """
     ).tag(config=True)
 
-    use_jedi = Bool(default_value=JEDI_INSTALLED,
+    use_jedi = Bool(default_value=False,
                     help="Experimental: Use Jedi to generate autocompletions. "
                     "Default to True if jedi is installed").tag(config=True)
 

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -316,13 +316,17 @@ def test_jedi():
         start = start if start is not None else l
         end = end if end is not None else l
         with provisionalcompleter():
+            ip.Completer.use_jedi = True
             completions = set(ip.Completer.completions(s, l))
+            ip.Completer.use_jedi = False
             assert_in(Completion(start, end, comp), completions, reason)
 
     def _test_not_complete(reason, s, comp):
         l = len(s)
         with provisionalcompleter():
+            ip.Completer.use_jedi = True
             completions = set(ip.Completer.completions(s, l))
+            ip.Completer.use_jedi = False
             assert_not_in(Completion(l, l, comp), completions, reason)
 
     import jedi
@@ -341,7 +345,9 @@ def test_completion_have_signature():
     """
     ip = get_ipython()
     with provisionalcompleter():
+        ip.Completer.use_jedi = True
         completions = ip.Completer.completions('ope', 3)
+        ip.Completer.use_jedi = False
         c = next(completions)  # should be `open`
     assert 'file' in c.signature, "Signature of function was not found by completer"
     assert 'encoding' in c.signature, "Signature of function was not found by completer"
@@ -357,7 +363,9 @@ def test_deduplicate_completions():
         zoo = 1
     '''))
     with provisionalcompleter():
+        ip.Completer.use_jedi = True
         l = list(_deduplicate_completions('Z.z', ip.Completer.completions('Z.z', 3)))
+        ip.Completer.use_jedi = False
 
     assert len(l) == 1, 'Completions (Z.z<tab>) correctly deduplicate: %s ' % l
     assert l[0].text == 'zoo'  # and not `it.accumulate`

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -347,8 +347,8 @@ def test_completion_have_signature():
     with provisionalcompleter():
         ip.Completer.use_jedi = True
         completions = ip.Completer.completions('ope', 3)
-        ip.Completer.use_jedi = False
         c = next(completions)  # should be `open`
+        ip.Completer.use_jedi = False
     assert 'file' in c.signature, "Signature of function was not found by completer"
     assert 'encoding' in c.signature, "Signature of function was not found by completer"
 

--- a/docs/source/whatsnew/version6.rst
+++ b/docs/source/whatsnew/version6.rst
@@ -3,6 +3,18 @@
 ============
 
 
+.. _whatsnew631:
+
+IPython 6.3.1
+=============
+
+This is a bugfix release to switch the default completions back to IPython's
+own completion machinery. We discovered some problems with the completions
+from Jedi, including completing column names on pandas data frames.
+
+You can switch the completions source with the config option
+:configtrait:`Completer.use_jedi`.
+
 .. _whatsnew630:
 
 IPython 6.3


### PR DESCRIPTION
The release of IPython 6.3.0 changed to relying on jedi completions, whereas we had previously combined Jedi completions with our own (which caused issues with duplicate completions in some circumstances).

Unfortunately this exposed a bug in Jedi where it doesn't find dynamic attributes from `__dir__()`. This means that, among other things, completing `df.Column` on pandas dataframes is broken (e.g. https://github.com/jupyter/notebook/issues/2435#issuecomment-378940525 , #11070). It has been fixed in Jedi, but a new release is apparently still a few weeks away.

I'm therefore proposing that we release IPython 6.3.1 quickly with this change, disabling Jedi by default and switching back to our ugly but battle-tested completion machinery. That fixes the immediate problems for users, and we can reevaluate the options for future releases.