### PR TITLE
FIX: Remove the non-interactive backends from pylabtools.backend2gui

### DIFF
--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -46,6 +46,9 @@ backend2gui['CocoaAgg'] = 'osx'
 # And some backends that don't need GUI integration
 del backend2gui['nbAgg']
 del backend2gui['agg']
+del backend2gui['svg']
+del backend2gui['pdf']
+del backend2gui['ps']
 del backend2gui['module://ipykernel.pylab.backend_inline']
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/tests/test_pylabtools.py
+++ b/IPython/core/tests/test_pylabtools.py
@@ -105,7 +105,7 @@ def test_select_figure_formats_kwargs():
     f = formatter.lookup_by_type(Figure)
     cell = f.__closure__[0].cell_contents
     nt.assert_equal(cell, kwargs)
-    
+
     # check that the formatter doesn't raise
     fig = plt.figure()
     ax = fig.add_subplot(1,1,1)
@@ -150,7 +150,7 @@ class TestPylabSwitch(object):
     class Shell(InteractiveShell):
         def enable_gui(self, gui):
             pass
-    
+
     def setup(self):
         import matplotlib
         def act_mpl(backend):
@@ -244,3 +244,7 @@ class TestPylabSwitch(object):
         nt.assert_equal(gui, 'qt')
         nt.assert_equal(s.pylab_gui_select, 'qt')
 
+
+def test_no_gui_backends():
+    for k in ['agg', 'svg', 'pdf', 'ps']:
+        assert k not in pt.backend2gui


### PR DESCRIPTION
This prevents trying to find a non-existent GUI framework.

Closes #11086