### PR TITLE
Issue #11068 : Cleanup extra logic that handle python <=3.3 in IPython/core/extensions.py

### DIFF
--- a/IPython/core/extensions.py
+++ b/IPython/core/extensions.py
@@ -7,18 +7,13 @@
 import os
 import os.path
 import sys
-from importlib import import_module
+from importlib import import_module, reload
 
 from traitlets.config.configurable import Configurable
 from IPython.utils.path import ensure_dir_exists, compress_user
 from IPython.utils.decorators import undoc
 from traitlets import Instance
 
-try:
-    from importlib import reload
-except ImportError :
-    ## deprecated since 3.4
-    from imp import reload
 
 #-----------------------------------------------------------------------------
 # Main class


### PR DESCRIPTION
Issue #11068 : Cleanup extra logic that handle python <=3.3 in IPython/core/extensions.py