### PR TITLE
Added fix for display hook call output format

### DIFF
--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -306,4 +306,4 @@ class CapturingDisplayHook(object):
         if result is None:
             return
         format_dict, md_dict = self.shell.display_formatter.format(result)
-        self.outputs.append((format_dict, md_dict))
+        self.outputs.append({ 'data': format_dict, 'metadata': md_dict })

--- a/IPython/core/tests/test_displayhook.py
+++ b/IPython/core/tests/test_displayhook.py
@@ -1,4 +1,7 @@
+import sys
 from IPython.testing.tools import AssertPrints, AssertNotPrints
+from IPython.core.displayhook import CapturingDisplayHook
+from IPython.utils.capture import CapturedIO
 
 ip = get_ipython()
 
@@ -26,3 +29,11 @@ def test_output_quiet():
 
     with AssertNotPrints('2'):
         ip.run_cell('1+1;\n#commented_out_function()', store_history=True)
+
+def test_capture_display_hook_format():
+    """Tests that the capture display hook conforms to the CapturedIO output format"""
+    hook = CapturingDisplayHook(ip)
+    hook({"foo": "bar"})
+    captured = CapturedIO(sys.stdout, sys.stderr, hook.outputs)
+    # Should not raise with RichOutput transformation error
+    captured.outputs


### PR DESCRIPTION
Hit an issue were under complex conditions, that are hard to express in a simple notebook, the displayhook was building output array elements in the old tuple format instead of the kwarg format. This causes:

```python-traceback
TypeErrorTraceback (most recent call last)
<ipython-input-7-dcf49c89b1af> in <module>()
----> 1 output.outputs[0]

/usr/local/lib/python2.7/dist-packages/IPython/utils/capture.pyc in outputs(self)
    112                 display(o)
    113         """
--> 114         return [ RichOutput(**kargs) for kargs in self._outputs ]
```

Tracing down the fix was to adjust the callable which was not updated. Tracing the capture code throughout the project was a real headache as the global state is touched a lot along the way, so I made a spec just to prove that the output format conforms rather than express where that hook callable is made consequentially.

Master variant of the same PR: https://github.com/ipython/ipython/pull/11101