### PR TITLE
Display objects should emit metadata when it exists

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -667,7 +667,7 @@ class Pretty(TextDisplayObject):
 class HTML(TextDisplayObject):
 
     def _repr_html_(self):
-        return self.data
+        return self._data_and_metadata()
 
     def __html__(self):
         """
@@ -681,20 +681,23 @@ class HTML(TextDisplayObject):
 class Markdown(TextDisplayObject):
 
     def _repr_markdown_(self):
-        return self.data
+        return self._data_and_metadata()
 
 
 class Math(TextDisplayObject):
 
     def _repr_latex_(self):
-        s = self.data.strip('$')
-        return "$$%s$$" % s
+        s = "$$%s$$" % self.data.strip('$')
+        if self.metadata:
+            return s, deepcopy(self.metadata)
+        else:
+            return s
 
 
 class Latex(TextDisplayObject):
 
     def _repr_latex_(self):
-        return self.data
+        return self._data_and_metadata()
 
 
 class SVG(DisplayObject):

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -275,6 +275,10 @@ def test_video_embedding():
         html = v._repr_html_()
         nt.assert_in('src="data:video/xyz;base64,YWJj"',html)
 
+def test_html_metadata():
+    s = "<h1>Test</h1>"
+    h = display.HTML(s, metadata={"isolated": True})
+    nt.assert_equal(h._repr_html_(), (s, {"isolated": True}))
 
 def test_display_id():
     ip = get_ipython()


### PR DESCRIPTION
Investigating https://github.com/jupyter/notebook/issues/3413 , I realised that `HTML(x, metadata={"isolated": True})` was completely ignoring the metadata.