### PR TITLE
Traceback printing change `in <module>()` to `in <module>`.

### DIFF
--- a/IPython/core/tests/test_iplib.py
+++ b/IPython/core/tests/test_iplib.py
@@ -72,7 +72,7 @@ In [4]: run simpleerr.py
 ---------------------------------------------------------------------------
 ZeroDivisionError                         Traceback (most recent call last)
 <BLANKLINE>
-... in <module>()
+... in <module>
      30         mode = 'div'
      31 
 ---> 32     bar(mode)
@@ -104,7 +104,7 @@ In [6]: run simpleerr.py
 ---------------------------------------------------------------------------
 ZeroDivisionError                         Traceback (most recent call last)
 <BLANKLINE>
-... in <module>()
+... in <module>
      30         mode = 'div'
      31 
 ---> 32     bar(mode)
@@ -161,7 +161,7 @@ In [22]: %tb
 ---------------------------------------------------------------------------
 SystemExit                                Traceback (most recent call last)
 <BLANKLINE>
-...<module>()
+...<module>
      30         mode = 'div'
      31 
 ---> 32     bar(mode)
@@ -189,7 +189,7 @@ In [24]: %tb
 ---------------------------------------------------------------------------
 SystemExit                                Traceback (most recent call last)
 <BLANKLINE>
-... in <module>()
+... in <module>
      30         mode = 'div'
      31 
 ---> 32     bar(mode)

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -873,6 +873,8 @@ class VerboseTB(TBTools):
 
         if func == '?':
             call = ''
+        elif func == '<module>':
+            call = tpl_call % (func, '')
         else:
             # Decide whether to include variable details or not
             var_repr = self.include_vars and eqrepr or nullrepr

--- a/IPython/lib/lexers.py
+++ b/IPython/lib/lexers.py
@@ -217,7 +217,7 @@ class IPythonConsoleLexer(Lexer):
 
             ---------------------------------------------------------------------------
             Exception                                 Traceback (most recent call last)
-            <ipython-input-1-fca2ab0ca76b> in <module>()
+            <ipython-input-1-fca2ab0ca76b> in <module>
             ----> 1 raise Exception
 
             Exception:

--- a/docs/source/interactive/reference.rst
+++ b/docs/source/interactive/reference.rst
@@ -765,7 +765,7 @@ context line to show. This allows to a many line of context on shallow stack tra
     In[6]: foo(1)
     # ...
     ipdb> where 8
-    <ipython-input-6-9e45007b2b59>(1)<module>()
+    <ipython-input-6-9e45007b2b59>(1)<module>
     ----> 1 foo(1)
 
     <ipython-input-5-7baadc3d1465>(5)foo()
@@ -794,7 +794,7 @@ And less context on shallower Stack Trace:
 .. code::
 
     ipdb> where 1
-    <ipython-input-13-afa180a57233>(1)<module>()
+    <ipython-input-13-afa180a57233>(1)<module>
     ----> 1 foo(7)
 
     <ipython-input-5-7baadc3d1465>(5)foo()


### PR DESCRIPTION
Modules are usually not callable