### PR TITLE
Remove import indirection and deprecated private function.

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -116,12 +116,13 @@ from IPython.core import debugger
 from IPython.core.display_trap import DisplayTrap
 from IPython.core.excolors import exception_colors
 from IPython.utils import PyColorize
-from IPython.utils import openpy
 from IPython.utils import path as util_path
 from IPython.utils import py3compat
 from IPython.utils.data import uniq_stable
 from IPython.utils.terminal import get_terminal_size
 from logging import info, error, debug
+
+from importlib.util import source_from_cache
 
 import IPython.utils.colorable as colorable
 
@@ -906,7 +907,7 @@ class VerboseTB(TBTools):
         elif file.endswith(('.pyc', '.pyo')):
             # Look up the corresponding source file.
             try:
-                file = openpy.source_from_cache(file)
+                file = source_from_cache(file)
             except ValueError:
                 # Failed to get the source file for some reason
                 # E.g. https://github.com/ipython/ipython/issues/9486

--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -116,9 +116,8 @@ import traceback
 import types
 import weakref
 from importlib import import_module
+from importlib.util import source_from_cache
 from imp import reload
-
-from IPython.utils import openpy
 
 #------------------------------------------------------------------------------
 # Autoreload functionality
@@ -195,7 +194,7 @@ class ModuleReloader(object):
             py_filename = filename
         else:
             try:
-                py_filename = openpy.source_from_cache(filename)
+                py_filename = source_from_cache(filename)
             except ValueError:
                 return None, None
 

--- a/IPython/utils/openpy.py
+++ b/IPython/utils/openpy.py
@@ -103,15 +103,3 @@ def read_py_url(url, errors='replace', skip_encoding_cookie=True):
     response = urlopen(url)
     buffer = io.BytesIO(response.read())
     return source_to_unicode(buffer, errors, skip_encoding_cookie)
-
-def _list_readline(x):
-    """Given a list, returns a readline() function that returns the next element
-    with each call.
-    """
-    x = iter(x)
-    def readline():
-        return next(x)
-    return readline
-
-# Code for going between .py files and cached .pyc files ----------------------
-from importlib.util import source_from_cache, cache_from_source

--- a/IPython/utils/tests/test_openpy.py
+++ b/IPython/utils/tests/test_openpy.py
@@ -29,11 +29,3 @@ def test_source_to_unicode():
 
     source_no_cookie = openpy.source_to_unicode(source_bytes, skip_encoding_cookie=True)
     nt.assert_not_in(u'coding: iso-8859-5', source_no_cookie)
-
-def test_list_readline():
-    l = ['a', 'b']
-    readline = openpy._list_readline(l)
-    nt.assert_equal(readline(), 'a')
-    nt.assert_equal(readline(), 'b')
-    with nt.assert_raises(StopIteration):
-        readline()


### PR DESCRIPTION
Since Python 3 openpy was just re-exposing functionality.
Use it directly now.