### PR TITLE
signature: use inspect instead of type checks

### DIFF
--- a/IPython/utils/_signatures.py
+++ b/IPython/utils/_signatures.py
@@ -21,6 +21,7 @@ import itertools
 import functools
 import re
 import types
+import inspect
 
 
 # patch for single-file
@@ -71,7 +72,7 @@ def signature(obj):
     if not callable(obj):
         raise TypeError('{0!r} is not a callable object'.format(obj))
 
-    if isinstance(obj, types.MethodType):
+    if inspect.ismethod(obj):
         if obj.__self__ is None:
             # Unbound method - treat it as a function (no distinction in Py 3)
             obj = obj.__func__
@@ -96,7 +97,7 @@ def signature(obj):
     else:
         return signature(wrapped)
 
-    if isinstance(obj, types.FunctionType):
+    if inspect.isfunction(obj):
         return Signature.from_function(obj)
 
     if isinstance(obj, functools.partial):
@@ -511,7 +512,7 @@ class Signature(object):
     def from_function(cls, func):
         '''Constructs Signature for the given python function'''
 
-        if not isinstance(func, types.FunctionType):
+        if not inspect.isfunction(func):
             raise TypeError('{0!r} is not a Python function'.format(func))
 
         Parameter = cls._parameter_cls


### PR DESCRIPTION
Using `inspect.isfunction` is more future-compatible in case that the implementation of `inspect.isfunction` ever changes.

In SageMath, we actually monkey-patch `inspect.isfunction` to allow for Cython functions. So while this patch doesn't change anything at all in vanilla Python, it is important for Cython support.

More context:
- https://opendreamkit.org/2017/06/09/CythonSphinx
- https://bugs.python.org/issue30071
- https://www.python.org/dev/peps/pep-0579/