### PR TITLE
Correctly tearDown some test cases with multiple inheritance.

### DIFF
--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -546,6 +546,10 @@ class ExitCodeChecks(tt.TempFileMixin):
             else:
                 del os.environ['SHELL']
 
+    def tearDown(self):
+        tt.TempFileMixin.tearDown(self)
+
+
 class TestSystemRaw(unittest.TestCase, ExitCodeChecks):
     system = ip.system_raw
 
@@ -566,9 +570,15 @@ class TestSystemRaw(unittest.TestCase, ExitCodeChecks):
                       "keyboard interrupt from subprocess.call")
         self.assertEqual(ip.user_ns['_exit_code'], -signal.SIGINT)
 
+    def tearDown(self):
+        ExitCodeChecks.tearDown(self)
+
 # TODO: Exit codes are currently ignored on Windows.
 class TestSystemPipedExitCode(unittest.TestCase, ExitCodeChecks):
     system = ip.system_piped
+
+    def tearDown(self):
+        ExitCodeChecks.tearDown(self)
 
     @skip_win32
     def test_exit_code_ok(self):
@@ -593,6 +603,9 @@ class TestModules(unittest.TestCase, tt.TempFileMixin):
                    )
         out = "False\nFalse\nFalse\n"
         tt.ipexec_validate(self.fname, out)
+
+    def tearDown(self):
+        tt.TempFileMixin.tearDown(self)
 
 class Negator(ast.NodeTransformer):
     """Negates all number literals in an AST."""

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -546,11 +546,8 @@ class ExitCodeChecks(tt.TempFileMixin):
             else:
                 del os.environ['SHELL']
 
-    def tearDown(self):
-        tt.TempFileMixin.tearDown(self)
 
-
-class TestSystemRaw(unittest.TestCase, ExitCodeChecks):
+class TestSystemRaw(ExitCodeChecks, unittest.TestCase):
     system = ip.system_raw
 
     @onlyif_unicode_paths
@@ -570,15 +567,9 @@ class TestSystemRaw(unittest.TestCase, ExitCodeChecks):
                       "keyboard interrupt from subprocess.call")
         self.assertEqual(ip.user_ns['_exit_code'], -signal.SIGINT)
 
-    def tearDown(self):
-        ExitCodeChecks.tearDown(self)
-
 # TODO: Exit codes are currently ignored on Windows.
-class TestSystemPipedExitCode(unittest.TestCase, ExitCodeChecks):
+class TestSystemPipedExitCode(ExitCodeChecks, unittest.TestCase):
     system = ip.system_piped
-
-    def tearDown(self):
-        ExitCodeChecks.tearDown(self)
 
     @skip_win32
     def test_exit_code_ok(self):
@@ -592,7 +583,7 @@ class TestSystemPipedExitCode(unittest.TestCase, ExitCodeChecks):
     def test_exit_code_signal(self):
         ExitCodeChecks.test_exit_code_signal(self)
 
-class TestModules(unittest.TestCase, tt.TempFileMixin):
+class TestModules(tt.TempFileMixin, unittest.TestCase):
     def test_extraneous_loads(self):
         """Test we're not loading modules on startup that we shouldn't.
         """
@@ -603,9 +594,6 @@ class TestModules(unittest.TestCase, tt.TempFileMixin):
                    )
         out = "False\nFalse\nFalse\n"
         tt.ipexec_validate(self.fname, out)
-
-    def tearDown(self):
-        tt.TempFileMixin.tearDown(self)
 
 class Negator(ast.NodeTransformer):
     """Negates all number literals in an AST."""

--- a/IPython/core/tests/test_shellapp.py
+++ b/IPython/core/tests/test_shellapp.py
@@ -24,11 +24,8 @@ sqlite_err_maybe = dec.module_not_available('sqlite3')
 SQLITE_NOT_AVAILABLE_ERROR = ('WARNING: IPython History requires SQLite,'
                               ' your history will not be saved\n')
 
-class TestFileToRun(unittest.TestCase, tt.TempFileMixin):
+class TestFileToRun(tt.TempFileMixin, unittest.TestCase):
     """Test the behavior of the file_to_run parameter."""
-
-    def tearDown(self):
-        tt.TempFileMixin.tearDown(self)
 
     def test_py_script_file_attribute(self):
         """Test that `__file__` is set when running `ipython file.py`"""

--- a/IPython/core/tests/test_shellapp.py
+++ b/IPython/core/tests/test_shellapp.py
@@ -27,6 +27,9 @@ SQLITE_NOT_AVAILABLE_ERROR = ('WARNING: IPython History requires SQLite,'
 class TestFileToRun(unittest.TestCase, tt.TempFileMixin):
     """Test the behavior of the file_to_run parameter."""
 
+    def tearDown(self):
+        tt.TempFileMixin.tearDown(self)
+
     def test_py_script_file_attribute(self):
         """Test that `__file__` is set when running `ipython file.py`"""
         src = "print(__file__)\n"


### PR DESCRIPTION
On Python 3.7+ this leads to Resources warnings at testing suite
shutdown. Fix this at least for IPython.core.tests.test_interactiveshell.

-- 

I'm not really sure why the teardown is not done correctly when the first class we inherit from is `unittest.TestCase` as it does not have a tearDown.