### PR TITLE
Add __spec__ to DummyMod

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -170,7 +170,7 @@ class SeparateUnicode(Unicode):
 class DummyMod(object):
     """A dummy module used for IPython's interactive module when
     a namespace must be assigned to the module's __dict__."""
-    pass
+    __spec__ = None
 
 
 class ExecutionInfo(object):


### PR DESCRIPTION
Hello, I am having an issue while calling `multiprocessing.Process` with latest IPython version on python 3.6. **This bug does not happen with 2.7.14, and does not seem to be needed to be backported to 5.X. I don’t know about 6.X**

Specs: Python 3.6.0, Windows 10 x64

I'm calling a code looking similar to

```python
p = multiprocessing.Process(target=self.trace3D_notebook)
p.start()
```

### Stack trace
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-5260639d868d> in <module>
----> 1 a[0].trace3D()

Z:\Coding\github\scapy\scapy\layers\inet.py in trace3D(self, join)
   1165         import multiprocessing
   1166         p = multiprocessing.Process(target=self.trace3D_notebook)
-> 1167         p.start()
   1168         if join:
   1169             p.join()

D:\Programms\Python3\lib\multiprocessing\process.py in start(self)
    103                'daemonic processes are not allowed to have children'
    104         _cleanup()
--> 105         self._popen = self._Popen(self)
    106         self._sentinel = self._popen.sentinel
    107         _children.add(self)

D:\Programms\Python3\lib\multiprocessing\context.py in _Popen(process_obj)
    221     @staticmethod
    222     def _Popen(process_obj):
--> 223         return _default_context.get_context().Process._Popen(process_obj)
    224
    225 class DefaultContext(BaseContext):

D:\Programms\Python3\lib\multiprocessing\context.py in _Popen(process_obj)
    320         def _Popen(process_obj):
    321             from .popen_spawn_win32 import Popen
--> 322             return Popen(process_obj)
    323
    324     class SpawnContext(BaseContext):

D:\Programms\Python3\lib\multiprocessing\popen_spawn_win32.py in __init__(self, process_obj)
     31
     32     def __init__(self, process_obj):
---> 33         prep_data = spawn.get_preparation_data(process_obj._name)
     34
     35         # read end of pipe will be "stolen" by the child process

D:\Programms\Python3\lib\multiprocessing\spawn.py in get_preparation_data(name)
    170     # or through direct execution (or to leave it alone entirely)
    171     main_module = sys.modules['__main__']
--> 172     main_mod_name = getattr(main_module.__spec__, "name", None)
    173     if main_mod_name is not None:
    174         d['init_main_from_name'] = main_mod_name

AttributeError: 'DummyMod' object has no attribute '__spec__'
```

### Explanation
Multiprocessing fail as `DummyMod` does not contain a `__spec__` field.
According to Python's source code, the code will handle a `None` value properly: https://github.com/python/cpython/blob/bd73e72b4a9f019be514954b1d40e64dc3a5e81c/Lib/multiprocessing/spawn.py#L169-L183

**This patch fixes the issue on my end.**