### PR TITLE
Backport PR #11185 on branch 6.x 

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -170,7 +170,7 @@ class SeparateUnicode(Unicode):
 class DummyMod(object):
     """A dummy module used for IPython's interactive module when
     a namespace must be assigned to the module's __dict__."""
-    pass
+    __spec__ = None
 
 
 class ExecutionInfo(object):


### PR DESCRIPTION
The bug of #11185 is also present with Python:
- [3.7](https://github.com/python/cpython/blob/3.7/Lib/multiprocessing/spawn.py#L172)
- [3.6](https://github.com/python/cpython/blob/3.6/Lib/multiprocessing/spawn.py#L172)
- [3.5](https://github.com/python/cpython/blob/3.5/Lib/multiprocessing/spawn.py#L173)
- [3.4](https://github.com/python/cpython/blob/3.4/Lib/multiprocessing/spawn.py#L173)
(not present in 2.7-)