### PR TITLE
Fix config option TerminalInteractiveShell.display_completions

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -343,7 +343,7 @@ class TerminalInteractiveShell(InteractiveShell):
             'multicolumn': CompleteStyle.MULTI_COLUMN,
             'column': CompleteStyle.COLUMN,
             'readlinelike': CompleteStyle.READLINE_LIKE,
-        }[self.display_completions],
+        }[self.display_completions]
 
     def _extra_prompt_options(self):
         """


### PR DESCRIPTION
The extra comma in pt_complete_style() causes the option to be always
recognized as "column", because it compares equal to none of the three
values.