### PR TITLE
Improve the debugger command 'list', support '.' as argument of l(ist) in ipdb.

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -498,7 +498,7 @@ class Pdb(OldPdb):
         """
         self.lastcmd = 'list'
         last = None
-        if arg:
+        if arg and arg != '.':
             try:
                 x = eval(arg, {}, {})
                 if type(x) == type(()):
@@ -513,7 +513,7 @@ class Pdb(OldPdb):
             except:
                 print('*** Error in argument:', repr(arg))
                 return
-        elif self.lineno is None:
+        elif self.lineno is None or arg == '.':
             first = max(1, self.curframe.f_lineno - 5)
         else:
             first = self.lineno + 1


### PR DESCRIPTION
According to [Debugger Commands](https://docs.python.org/3/library/pdb.html#pdbcommand-list) in the Python documentation, the pdb support `.` as argument of `l(ist)` to list 11 lines around the current line. But the ipdb does not support it.

Reference to [the `do_list()` function in Lib/pdb.py](https://github.com/python/cpython/blob/cede1e19bdfb8ddc3d9c0ab536643073f20e53f0/Lib/pdb.py#L1194), I add the support for `.` as argument of `l(ist)` in ipdb.