### PR TITLE
Upgrade pip before setuptools for Python compat.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ group: edge
 before_install:
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
 install:
-    - pip install setuptools pip --upgrade
+    - pip install pip --upgrade
+    - pip install setuptools --upgrade
     - pip install -e file://$PWD#egg=ipython[test] --upgrade
     - pip install codecov check-manifest --upgrade
     - sudo apt-get install graphviz


### PR DESCRIPTION
Setuptools recently dropped Python 3.3 and with an out of date pip we
know install an incompatible setuptools on the 6.x branch.

This should avoid the same error on future python drops.

Likely to be backported to 5.x and 6.x