### PR TITLE
Use raw string when invalid escape sequence present.

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1592,7 +1592,7 @@ class IPCompleter(Completer):
             $
             '''
             regexps = self.__dict_key_regexps = {
-                False: re.compile(dict_key_re_fmt % '''
+                False: re.compile(dict_key_re_fmt % r'''
                                   # identifiers separated by .
                                   (?!\d)\w+
                                   (?:\.(?!\d)\w+)*

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -176,7 +176,7 @@ class Tracer(object):
         self.debugger.set_trace(sys._getframe().f_back)
 
 
-RGX_EXTRA_INDENT = re.compile('(?<=\n)\s+')
+RGX_EXTRA_INDENT = re.compile(r'(?<=\n)\s+')
 
 
 def strip_indentation(multiline_string):

--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -65,7 +65,7 @@ ini_spaces_re = re.compile(r'^([ \t\r\f\v]+)')
 
 # regexp to match pure comment lines so we don't accidentally insert 'if 1:'
 # before pure comments
-comment_line_re = re.compile('^\s*\#')
+comment_line_re = re.compile(r'^\s*\#')
 
 
 def num_ini_spaces(s):

--- a/IPython/core/inputtransformer.py
+++ b/IPython/core/inputtransformer.py
@@ -171,7 +171,7 @@ class assemble_python_lines(TokenInputTransformer):
 
 @CoroutineInputTransformer.wrap
 def assemble_logical_lines():
-    """Join lines following explicit line continuations (\)"""
+    r"""Join lines following explicit line continuations (\)"""
     line = ''
     while True:
         line = (yield line)
@@ -361,7 +361,7 @@ def cellmagic(end_on_blank_line=False):
     reset (sent None).
     """
     tpl = 'get_ipython().run_cell_magic(%r, %r, %r)'
-    cellmagic_help_re = re.compile('%%\w+\?')
+    cellmagic_help_re = re.compile(r'%%\w+\?')
     line = ''
     while True:
         line = (yield line)

--- a/IPython/core/magics/config.py
+++ b/IPython/core/magics/config.py
@@ -24,7 +24,7 @@ from logging import error
 # Magic implementation classes
 #-----------------------------------------------------------------------------
 
-reg = re.compile('^\w+\.\w+$')
+reg = re.compile(r'^\w+\.\w+$')
 @magics_class
 class ConfigMagics(Magics):
 

--- a/IPython/core/splitinput.py
+++ b/IPython/core/splitinput.py
@@ -41,7 +41,7 @@ from IPython.utils.encoding import get_stream_enc
 # ! and !! trigger if they are first char(s) *or* follow an indent
 # ? triggers as first or last char.
 
-line_split = re.compile("""
+line_split = re.compile(r"""
              ^(\s*)               # any leading space
              ([,;/%]|!!?|\?\??)?  # escape character or characters
              \s*(%{0,2}[\w\.\*]*)     # function/method, possibly with leading %
@@ -68,7 +68,7 @@ def split_user_input(line, pattern=None):
         except ValueError:
             # print "split failed for line '%s'" % line
             ifun, the_rest = line, u''
-        pre = re.match('^(\s*)(.*)',line).groups()[0]
+        pre = re.match(r'^(\s*)(.*)',line).groups()[0]
         esc = ""
     else:
         pre, esc, ifun, the_rest = match.groups()

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -202,7 +202,7 @@ def get_home_dir(require_writable=False):
                 import _winreg as wreg  # Py 2
             key = wreg.OpenKey(
                 wreg.HKEY_CURRENT_USER,
-                "Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders"
+                r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders"
             )
             homedir = wreg.QueryValueEx(key,'Personal')[0]
             key.Close()

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -588,7 +588,7 @@ class DollarFormatter(FullEvalFormatter):
         In [4]: f.format('$a or {b}', a=1, b=2)
         Out[4]: '1 or 2'
     """
-    _dollar_pattern_ignore_single_quote = re.compile("(.*?)\$(\$?[\w\.]+)(?=([^']*'[^']*')*[^']*$)")
+    _dollar_pattern_ignore_single_quote = re.compile(r"(.*?)\$(\$?[\w\.]+)(?=([^']*'[^']*')*[^']*$)")
     def parse(self, fmt_string):
         for literal_txt, field_name, format_spec, conversion \
                     in Formatter.parse(self, fmt_string):

--- a/IPython/utils/tokenize2.py
+++ b/IPython/utils/tokenize2.py
@@ -47,7 +47,7 @@ from token import *
 from codecs import lookup, BOM_UTF8
 import collections
 from io import TextIOWrapper
-cookie_re = re.compile("coding[:=]\s*([-\w.]+)")
+cookie_re = re.compile(r"coding[:=]\s*([-\w.]+)")
 
 import token
 __all__ = token.__all__ + ["COMMENT", "tokenize", "detect_encoding",


### PR DESCRIPTION
Those emit deprecation warnings at import/compile time so unfortunately
we can't trap that with iptest as modules are already imported.

The way to test that is to start IPython via `python -We -m IPython`,
and we should try to likely do that in travis.

But first fix all places that raise an error