### PR TITLE
[ISSUE 11206] Change signature to be imported from inspect library

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -85,12 +85,12 @@ import re
 import sys
 import types
 from collections import deque
+from inspect import signature
 from io import StringIO
 from warnings import warn
 
 from IPython.utils.decorators import undoc
 from IPython.utils.py3compat import PYPY
-from IPython.utils.signatures import signature
 
 __all__ = ['pretty', 'pprint', 'PrettyPrinter', 'RepresentationPrinter',
     'for_type', 'for_type_by_name']


### PR DESCRIPTION
Closes: #11206 

Hi - this is my first open source contribution, as a part of the Jupyter Open Studio Day hosted by @ivanov!

Summary
- Replace import from deprecated `signatures.py` within utils in favor of a direct import from the `inspect` standard library
- Verified that: tests pass, `DeprecationWarning` message for this module no longer displays when opening ipython via: `PYTHONWARNINGS=default ipython` locally
- No additional tests added