### PR TITLE
Fix `up` through generators in postmortem debugger; closes #6251

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -1203,7 +1203,7 @@ class VerboseTB(TBTools):
                 if etb and etb.tb_next:
                     etb = etb.tb_next
                 self.pdb.botframe = etb.tb_frame
-                self.pdb.interaction(self.tb.tb_frame, self.tb)
+                self.pdb.interaction(None, etb)
 
         if hasattr(self, 'tb'):
             del self.tb

--- a/IPython/terminal/tests/test_debug_magic.py
+++ b/IPython/terminal/tests/test_debug_magic.py
@@ -1,0 +1,74 @@
+"""Test embedding of IPython"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2013 The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+import os
+import sys
+from IPython.testing.decorators import skip_win32
+
+#-----------------------------------------------------------------------------
+# Tests
+#-----------------------------------------------------------------------------
+
+@skip_win32
+def test_debug_magic_passes_through_generators():
+    """
+    This test that we can correctly pass through frames of a generator post-mortem.
+    """
+    import pexpect
+    import re
+    in_prompt = re.compile(b'In ?\[\\d+\]:')
+    ipdb_prompt = 'ipdb>'
+    env = os.environ.copy()
+    child = pexpect.spawn(sys.executable, ['-m', 'IPython', '--colors=nocolor', '--simple-prompt'],
+                          env=env)
+    child.timeout = 2
+
+    child.expect(in_prompt)
+    child.sendline("def f(x):")
+    child.sendline("    raise Exception")
+    child.sendline("")
+
+    child.expect(in_prompt)
+    child.sendline("gen = (f(x) for x in [0])")
+    child.sendline("")
+
+    child.expect(in_prompt)
+    child.sendline("for x in gen:")
+    child.sendline("    pass")
+    child.sendline("")
+
+    child.expect('Exception:')
+
+    child.expect(in_prompt)
+    child.sendline(r'%debug')
+    child.expect('----> 2     raise Exception')
+
+    child.expect(ipdb_prompt)
+    child.sendline('u')
+    child.expect_exact(r'----> 1 gen = (f(x) for x in [0])')
+
+    child.expect(ipdb_prompt)
+    child.sendline('u')
+    child.expect_exact('----> 1 for x in gen:')
+
+    child.expect(ipdb_prompt)
+    child.sendline('u')
+    child.expect_exact('*** Oldest frame')
+
+    child.expect(ipdb_prompt)
+    child.sendline('exit')
+
+    child.expect(in_prompt)
+    child.sendline('exit')
+
+    child.close()


### PR DESCRIPTION
By passing the lowest traceback element into the debugger, we require it to use frame.f_back to find older frames. However, [f_back is always None for generator frames in the postmortem context](https://github.com/python/cpython/blob/e42b705188271da108de42b55d9344642170aa2b/Objects/genobject.c#L226-L230). By providing a higher-up traceback element, pdb can traverse down the traceback.tb_next links, which do work correctly across generator calls.

...or at least, that's my understanding of the situation after spending half an hour researching the issue. This fix seems to work for my use cases, but I don't really understand the depths of pdb and can't tell if this may cause adverse affects elsewhere.

(I would also love to write a test for this, but I have no idea if we can or want to drive the debugger automatically for tests?)