### PR TITLE
Misc. typo and whitespace fixes

### DIFF
--- a/IPython/core/compilerop.py
+++ b/IPython/core/compilerop.py
@@ -52,7 +52,7 @@ PyCF_MASK = functools.reduce(operator.or_,
 
 def code_name(code, number=0):
     """ Compute a (probably) unique name for code for caching.
-    
+
     This now expects code to be unicode.
     """
     hash_digest = hashlib.sha1(code.encode("utf-8")).hexdigest()
@@ -71,7 +71,7 @@ class CachingCompiler(codeop.Compile):
 
     def __init__(self):
         codeop.Compile.__init__(self)
-        
+
         # This is ugly, but it must be done this way to allow multiple
         # simultaneous ipython instances to coexist.  Since Python itself
         # directly accesses the data structures in the linecache module, and
@@ -95,7 +95,7 @@ class CachingCompiler(codeop.Compile):
     def _fix_module_ds(self, module):
         """
         Starting in python 3.7 the AST for mule have changed, and if
-        the first expressions encountered is a string it is attached to the 
+        the first expressions encountered is a string it is attached to the
         `docstring` attribute of the `Module` ast node.
 
         This breaks IPython, as if this string is the only expression, IPython
@@ -108,14 +108,14 @@ class CachingCompiler(codeop.Compile):
         new_body=[Expr(Str(docstring, lineno=1, col_offset=0), lineno=1, col_offset=0)]
         new_body.extend(module.body)
         return fix_missing_locations(Module(new_body))
-        
+
     def ast_parse(self, source, filename='<unknown>', symbol='exec'):
         """Parse code to an AST with the current compiler flags active.
-        
+
         Arguments are exactly the same as ast.parse (in the standard library),
         and are passed to the built-in compile function."""
         return self._fix_module_ds(compile(source, filename, symbol, self.flags | PyCF_ONLY_AST, 1))
-    
+
     def reset_compiler_flags(self):
         """Reset compiler flags to default state."""
         # This value is copied from codeop.Compile.__init__, so if that ever
@@ -127,10 +127,10 @@ class CachingCompiler(codeop.Compile):
         """Flags currently active in the compilation process.
         """
         return self.flags
-        
+
     def cache(self, code, number=0):
         """Make a name for a block of code, and cache the code.
-        
+
         Parameters
         ----------
         code : str
@@ -138,7 +138,7 @@ class CachingCompiler(codeop.Compile):
         number : int
           A number which forms part of the code's name. Used for the execution
           counter.
-          
+
         Returns
         -------
         The name of the cached code (as a string). Pass this as the filename

--- a/IPython/core/compilerop.py
+++ b/IPython/core/compilerop.py
@@ -40,7 +40,7 @@ import time
 # Constants
 #-----------------------------------------------------------------------------
 
-# Roughtly equal to PyCF_MASK | PyCF_MASK_OBSOLETE as defined in pythonrun.h,
+# Roughly equal to PyCF_MASK | PyCF_MASK_OBSOLETE as defined in pythonrun.h,
 # this is used as a bitmask to extract future-related code flags.
 PyCF_MASK = functools.reduce(operator.or_,
                              (getattr(__future__, fname).compiler_flag

--- a/IPython/core/hooks.py
+++ b/IPython/core/hooks.py
@@ -174,7 +174,7 @@ class CommandChainDispatcher:
 def shutdown_hook(self):
     """ default shutdown hook
 
-    Typically, shotdown hooks should raise TryNext so all shutdown ops are done
+    Typically, shutdown hooks should raise TryNext so all shutdown ops are done
     """
 
     #print "default shutdown hook ok" # dbg

--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -82,7 +82,7 @@ class PrefilterManager(Configurable):
     prefilter consumes lines of input and produces transformed lines of
     input.
 
-    The iplementation consists of two phases:
+    The implementation consists of two phases:
 
     1. Transformers
     2. Checkers and handlers

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -765,7 +765,7 @@ if _env_type is not dict:
 
 try:
     # In PyPy, types.DictProxyType is dict, setting the dictproxy printer
-    # using dict.setdefault avoids overwritting the dict printer
+    # using dict.setdefault avoids overwriting the dict printer
     _type_pprinters.setdefault(types.DictProxyType,
                                _dict_pprinter_factory('dict_proxy({', '})'))
     _type_pprinters[types.ClassType] = _type_pprint

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -104,7 +104,7 @@ _re_pattern_type = type(re.compile(''))
 
 def _safe_getattr(obj, attr, default=None):
     """Safe version of getattr.
-    
+
     Same as getattr, but will return ``default`` on any Exception,
     rather than raising.
     """
@@ -246,7 +246,7 @@ class PrettyPrinter(_PrettyPrinterBase):
             self.buffer.append(Breakable(sep, width, self))
             self.buffer_width += width
             self._break_outer_groups()
-            
+
     def break_(self):
         """
         Explicitly insert a newline into the output, maintaining correct indentation.
@@ -256,7 +256,7 @@ class PrettyPrinter(_PrettyPrinterBase):
         self.output.write(' ' * self.indentation)
         self.output_width = self.indentation
         self.buffer_width = 0
-        
+
 
     def begin_group(self, indent=0, open=''):
         """
@@ -282,7 +282,7 @@ class PrettyPrinter(_PrettyPrinterBase):
         self.group_stack.append(group)
         self.group_queue.enq(group)
         self.indentation += indent
-    
+
     def _enumerate(self, seq):
         """like enumerate, but with an upper limit on the number of items"""
         for idx, x in enumerate(seq):
@@ -292,7 +292,7 @@ class PrettyPrinter(_PrettyPrinterBase):
                 self.text('...')
                 return
             yield idx, x
-    
+
     def end_group(self, dedent=0, close=''):
         """End a group. See `begin_group` for more details."""
         self.indentation -= dedent

--- a/IPython/testing/plugin/test_refs.py
+++ b/IPython/testing/plugin/test_refs.py
@@ -19,7 +19,7 @@ def doctest_run():
     In [13]: run simplevars.py
     x is: 1
     """
-    
+
 def doctest_runvars():
     """Test that variables defined in scripts get loaded correclty via %run.
 

--- a/IPython/testing/plugin/test_refs.py
+++ b/IPython/testing/plugin/test_refs.py
@@ -21,7 +21,7 @@ def doctest_run():
     """
     
 def doctest_runvars():
-    """Test that variables defined in scripts get loaded correcly via %run.
+    """Test that variables defined in scripts get loaded correclty via %run.
 
     In [13]: run simplevars.py
     x is: 1

--- a/IPython/utils/frame.py
+++ b/IPython/utils/frame.py
@@ -49,7 +49,7 @@ def extract_vars(*names,**kw):
     """
 
     depth = kw.get('depth',0)
-    
+
     callerNS = sys._getframe(depth+1).f_locals
     return dict((k,callerNS[k]) for k in names)
 
@@ -58,7 +58,7 @@ def extract_vars_above(*names):
     """Extract a set of variables by name from another frame.
 
     Similar to extractVars(), but with a specified depth of 1, so that names
-    are exctracted exactly from above the caller.
+    are extracted exactly from above the caller.
 
     This is simply a convenience function so that the very common case (for us)
     of skipping exactly 1 frame doesn't have to construct a special dict for
@@ -93,4 +93,3 @@ def extract_module_locals(depth=0):
     global_ns = f.f_globals
     module = sys.modules[global_ns['__name__']]
     return (module, f.f_locals)
-


### PR DESCRIPTION
Found via `codespell -q 3` 