### PR TITLE
Actually run some tests.

### DIFF
--- a/IPython/testing/ipunittest.py
+++ b/IPython/testing/ipunittest.py
@@ -146,7 +146,8 @@ class Doc2UnitTester(object):
             def test(self):
                 # Make a new runner per function to be tested
                 runner = DocTestRunner(verbose=d2u.verbose)
-                map(runner.run, d2u.finder.find(func, func.__name__))
+                for the_test in d2u.finder.find(func, func.__name__):
+                    runner.run(the_test)
                 failed = count_failures(runner)
                 if failed:
                     # Since we only looked at a single function's docstring,


### PR DESCRIPTION
The ipdoctest was relying on the side-effects of applying `map()` which
is lazy since Python3. Moving to an actual for loop.

Closes #11276