### PR TITLE
Pass inputhook to prompt_toolkit

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -367,6 +367,7 @@ class TerminalInteractiveShell(InteractiveShell):
                         processor=HighlightMatchingBracketProcessor(chars='[](){}'),
                         filter=HasFocus(DEFAULT_BUFFER) & ~IsDone() &
                             Condition(lambda: self.highlight_matching_brackets))],
+                'inputhook': self.inputhook,
                 }
 
     def prompt_for_code(self):


### PR DESCRIPTION
From simple grep searches, it look like `TerminalInteractiveShell.inputhook` used only for `TerminalPdb`.  Don't you need to pass it to `PromptSession` when creating `TerminalInteractiveShell.pt_app`?  This fixes `%matplotlib tk` for me.

ref #11180