### PR TITLE
cleanup build process

### DIFF
--- a/tools/build_release
+++ b/tools/build_release
@@ -4,20 +4,13 @@
 import os
 from shutil import rmtree
 
-from toollib import sh, pjoin, get_ipdir, cd, execfile, sdists, buildwheels
+from toollib import sh, pjoin, get_ipdir, cd, sdists, buildwheels
 
 def build_release():
 
     # Get main ipython dir, this will raise if it doesn't pass some checks
     ipdir = get_ipdir()
     cd(ipdir)
-
-    # Load release info
-    execfile(pjoin('IPython', 'core', 'release.py'), globals())
-
-    with open('docs/source/whatsnew/index.rst') as f:
-        if '   development' in f.read():
-            raise ValueError("Please remove `development` from what's new toctree for release")
 
     # Cleanup
     for d in ['build', 'dist', pjoin('docs', 'build'), pjoin('docs', 'dist'),

--- a/tools/toollib.py
+++ b/tools/toollib.py
@@ -3,6 +3,7 @@
 
 # Library imports
 import os
+import sys
 
 # Useful shorthands
 pjoin = os.path.join
@@ -20,7 +21,7 @@ archive = '%s:%s' % (archive_user, archive_dir)
 sdists = './setup.py sdist --formats=gztar'
 # Binary dists
 def buildwheels():
-    sh('python3 setupegg.py bdist_wheel')
+    sh('{python} setupegg.py bdist_wheel'.format(python=sys.executable))
 
 # Utility functions
 def sh(cmd):
@@ -30,9 +31,6 @@ def sh(cmd):
     #stat = 0  # Uncomment this and comment previous to run in debug mode
     if stat:
         raise SystemExit("Command %s failed with code: %s" % (cmd, stat))
-
-# Backwards compatibility
-c = sh
 
 def get_ipdir():
     """Get IPython directory from command line, or assume it's the one above."""
@@ -47,9 +45,6 @@ def get_ipdir():
         raise SystemExit('Invalid ipython directory: %s' % ipdir)
     return ipdir
 
-try:
-    execfile = execfile
-except NameError:
-    def execfile(fname, globs, locs=None):
-        locs = locs or globs
-        exec(compile(open(fname).read(), fname, "exec"), globs, locs)
+def execfile(fname, globs, locs=None):
+    locs = locs or globs
+    exec(compile(open(fname).read(), fname, "exec"), globs, locs)


### PR DESCRIPTION
Some code in the release process seem to be artifacts of old time.

 - `execfile` does not exist in Python3, and was used in `setup.py`
 - `development` in index.rst is not taking care of automatically with a `.. only:` directive.