### PR TITLE
Safe input transformer

### DIFF
--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -526,12 +526,13 @@ class TransformerManager:
         if not candidates:
             # Nothing to transform
             return False, lines
-
-        transformer = min(candidates, key=TokenTransformBase.sortby)
-        transformed = transformer.transform(lines)
-        if transformed is None:
-            return False, lines
-        return True, transformer.transform(lines)
+        ordered_transformers = sorted(candidates, key=TokenTransformBase.sortby)
+        for transformer in ordered_transformers:
+            try:
+                return True, transformer.transform(lines)
+            except SyntaxError:
+                pass
+        return False, lines
 
     def do_token_transforms(self, lines):
         for _ in range(TRANSFORM_LOOP_LIMIT):


### PR DESCRIPTION
This should make the input transformer way more robust to invalid input. 

It now takes transformer's `find()` method purely as a hint, if the transformer actually fails in it's transformation it can raise a SyntaxError, and the next transformer in line will be run.

I also exhaustively try all combinations of 1 and 2 printables characters, including some escape sequence that may end up swallowed when running `--simple-prompt` for example emacs integration.