### PR TITLE
Remove implicit dependency to ipython_genutils.

### DIFF
--- a/docs/autogen_config.py
+++ b/docs/autogen_config.py
@@ -11,7 +11,36 @@ here = abspath(dirname(__file__))
 options = join(here, 'source', 'config', 'options')
 generated = join(options, 'config-generated.txt')
 
-from ipython_genutils.text import indent, dedent
+import textwrap
+indent = lambda text,n: textwrap.indent(text,n*' ')
+
+def dedent(text):
+    """Equivalent of textwrap.dedent that ignores unindented first line.
+
+    This means it will still dedent strings like:
+    '''foo
+    is a bar
+    '''
+
+    For use in wrap_paragraphs.
+    """
+
+    if text.startswith('\n'):
+        # text starts with blank line, don't ignore the first line
+        return textwrap.dedent(text)
+
+    # split first line
+    splits = text.split('\n',1)
+    if len(splits) == 1:
+        # only one line
+        return textwrap.dedent(text)
+
+    first, rest = splits
+    # dedent everything but the first line
+    rest = textwrap.dedent(rest)
+    return '\n'.join([first, rest])
+
+
 
 def interesting_default_value(dv):
     if (dv is None) or (dv is Undefined):


### PR DESCRIPTION
This was installed because we rely on traitlets.

`indent` behavior is _slightly_ different in the sens that white lines
may not have the same number of whitespace.