### PR TITLE
re-add the rprint and rprinte alias.

### DIFF
--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -235,6 +235,11 @@ def raw_print_err(*args, **kw):
           file=sys.__stderr__)
     sys.__stderr__.flush()
 
+# used by IPykernel <- 4.9. Removed during IPython 7-dev period and re-added 
+# Keep for a version or two then should remove
+rprint = raw_print
+rprinte = raw_print_err
+
 @undoc
 def unicode_std_stream(stream='stdout'):
     """DEPRECATED, moved to nbconvert.utils.io"""


### PR DESCRIPTION
They are used in IPykernel 4.9 and I can see users upgrading IPython w/o
upgrading Ipykernel.