### PR TITLE
Add support for width and height arguments when displaying Video

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -1256,7 +1256,8 @@ class Image(DisplayObject):
 
 class Video(DisplayObject):
 
-    def __init__(self, data=None, url=None, filename=None, embed=False, mimetype=None):
+    def __init__(self, data=None, url=None, filename=None, embed=False,
+                 mimetype=None, width=None, height=None):
         """Create a video object given raw data or an URL.
 
         When this object is returned by an input cell or passed to the
@@ -1288,6 +1289,12 @@ class Video(DisplayObject):
         mimetype: unicode
             Specify the mimetype for embedded videos.
             Default will be guessed from file extension, if available.
+        width : int
+            Width in pixels to which to constrain the video in HTML.
+            If not supplied, defaults to the width of the video.
+        height : int
+            Height in pixels to which to constrain the video in html.
+            If not supplied, defaults to the height of the video.
 
         Examples
         --------
@@ -1314,16 +1321,24 @@ class Video(DisplayObject):
 
         self.mimetype = mimetype
         self.embed = embed
+        self.width = width
+        self.height = height
         super(Video, self).__init__(data=data, url=url, filename=filename)
 
     def _repr_html_(self):
+        width = height = ''
+        if self.width:
+            width = ' width="%d"' % self.width
+        if self.height:
+            height = ' height="%d"' % self.height
+
         # External URLs and potentially local files are not embedded into the
         # notebook output.
         if not self.embed:
             url = self.url if self.url is not None else self.filename
-            output = """<video src="{0}" controls>
+            output = """<video src="{0}" controls {1} {2}>
       Your browser does not support the <code>video</code> element.
-    </video>""".format(url)
+    </video>""".format(url, width, height)
             return output
 
         # Embedded videos are base64-encoded.
@@ -1342,10 +1357,10 @@ class Video(DisplayObject):
         else:
             b64_video = b2a_base64(video).decode('ascii').rstrip()
 
-        output = """<video controls>
- <source src="data:{0};base64,{1}" type="{0}">
+        output = """<video controls {0} {1}>
+ <source src="data:{2};base64,{3}" type="{2}">
  Your browser does not support the video tag.
- </video>""".format(mimetype, b64_video)
+ </video>""".format(width, height, mimetype, b64_video)
         return output
 
     def reload(self):

--- a/docs/source/whatsnew/pr/video-width-height.rst
+++ b/docs/source/whatsnew/pr/video-width-height.rst
@@ -1,0 +1,1 @@
+``IPython.display.Video`` now supports ``width`` and ``height`` arguments, allowing a custom width and height to be set instead of using the video's width and height


### PR DESCRIPTION
This PR adds `width` and `height` attributes to `IPython.display.Video`. The current behaviour is preserved if neither width nor height are specified. Otherwise, the specified integer will be used to set the width/height of the video in pixels, much like `IPython.display.Image`. This addresses the feature request asked for in #11328.

Example usage:

```
Video('https://archive.org/download/Sita_Sings_the_Blues/Sita_Sings_the_Blues_small.mp4', width=600, height=200)
```

Here's a notebook that exercises these attributes:
![video-width-height-test](https://user-images.githubusercontent.com/955189/46315059-38d90580-c581-11e8-9799-e0b274425370.png)
