### PR TITLE
Fix #11334: Cannot make multi-line code blocks in ipython

### DIFF
--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -636,7 +636,7 @@ class TransformerManager:
                 MemoryError, SyntaxWarning):
             return 'invalid', None
         else:
-            if res is None:
+            if not lines[-1].strip().endswith(':'):
                 return 'incomplete', find_last_indent(lines)
         return 'complete', None
 

--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -631,7 +631,7 @@ class TransformerManager:
         try:
             with warnings.catch_warnings():
                 warnings.simplefilter('error', SyntaxWarning)
-                res = compile_command(''.join(lines), symbol='exec')
+                compile_command(''.join(lines), symbol='exec')
         except (SyntaxError, OverflowError, ValueError, TypeError,
                 MemoryError, SyntaxWarning):
             return 'invalid', None

--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -636,7 +636,7 @@ class TransformerManager:
                 MemoryError, SyntaxWarning):
             return 'invalid', None
         else:
-            if not lines[-1].strip().endswith(':'):
+            if len(lines) > 1 and not lines[-1].strip().endswith(':'):
                 return 'incomplete', find_last_indent(lines)
         return 'complete', None
 

--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -571,8 +571,7 @@ class TransformerManager:
           The number of spaces by which to indent the next line of code. If
           status is not 'incomplete', this is None.
         """
-        if not cell.endswith('\n'):
-            cell += '\n'  # Ensure the cell has a trailing newline
+        cell += '\n'  # Ensure the cell has a trailing newline
         lines = cell.splitlines(keepends=True)
         if lines[-1][:-1].endswith('\\'):
             # Explicit backslash continuation

--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -636,7 +636,8 @@ class TransformerManager:
                 MemoryError, SyntaxWarning):
             return 'invalid', None
         else:
-            if len(lines) > 1 and not lines[-1].strip().endswith(':'):
+            if len(lines) > 1 and not lines[-1].strip().endswith(':') \
+                              and not lines[-2][:-1].endswith('\\'):
                 return 'incomplete', find_last_indent(lines)
         return 'complete', None
 

--- a/IPython/core/tests/test_inputtransformer2.py
+++ b/IPython/core/tests/test_inputtransformer2.py
@@ -206,6 +206,7 @@ def test_check_complete():
     nt.assert_equal(cc("a = '''\n   hi"), ('incomplete', 3))
     nt.assert_equal(cc("def a():\n x=1\n global x"), ('invalid', None))
     nt.assert_equal(cc("a \\ "), ('invalid', None))  # Nothing allowed after backslash
+    nt.assert_equal(cc("1\\\n+2"), ('complete', None))
 
     # no need to loop on all the letters/numbers.
     short = '12abAB'+string.printable[62:]

--- a/IPython/core/tests/test_inputtransformer2.py
+++ b/IPython/core/tests/test_inputtransformer2.py
@@ -10,6 +10,8 @@ import string
 from IPython.core import inputtransformer2 as ipt2
 from IPython.core.inputtransformer2 import make_tokens_by_line
 
+from textwrap import dedent
+
 MULTILINE_MAGIC = ("""\
 a = f()
 %foo \\
@@ -207,6 +209,14 @@ def test_check_complete():
     nt.assert_equal(cc("def a():\n x=1\n global x"), ('invalid', None))
     nt.assert_equal(cc("a \\ "), ('invalid', None))  # Nothing allowed after backslash
     nt.assert_equal(cc("1\\\n+2"), ('complete', None))
+
+    example = dedent("""
+        if True:
+            a=1""" )
+
+    nt.assert_equal(cc(example), ('incomplete', 4))
+    nt.assert_equal(cc(example+'\n'), ('complete', None))
+    nt.assert_equal(cc(example+'\n    '), ('complete', None))
 
     # no need to loop on all the letters/numbers.
     short = '12abAB'+string.printable[62:]


### PR DESCRIPTION
When codeop.compile_command() returns None it actually says "at least
some part of the code was compiled successfully" which is not really important
for checking if it's complete or not.
Once we haven't got any errors during compilation process, we just want
to check if there will be another nested block of code or not by checking
a colon.