### PR TITLE
Fix an IndexError in the leading_indent input transformer

### DIFF
--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -20,11 +20,11 @@ _indent_re = re.compile(r'^[ \t]+')
 
 def leading_indent(lines):
     """Remove leading indentation.
-    
+
     If the first line starts with a spaces or tabs, the same whitespace will be
     removed from each following line in the cell.
     """
-    if not lines: 
+    if not lines:
         return lines
     m = _indent_re.match(lines[0])
     if not m:
@@ -36,7 +36,7 @@ def leading_indent(lines):
 
 class PromptStripper:
     """Remove matching input prompts from a block of input.
-    
+
     Parameters
     ----------
     prompt_re : regular expression
@@ -47,7 +47,7 @@ class PromptStripper:
         If no initial expression is given, prompt_re will be used everywhere.
         Used mainly for plain Python prompts (``>>>``), where the continuation prompt
         ``...`` is a valid Python expression in Python 3, so shouldn't be stripped.
-    
+
     If initial_re and prompt_re differ,
     only initial_re will be tested against the first line.
     If any prompt is found on the first two lines,
@@ -61,6 +61,8 @@ class PromptStripper:
         return [self.prompt_re.sub('', l, count=1) for l in lines]
 
     def __call__(self, lines):
+        if not lines:
+            return lines
         if self.initial_re.match(lines[0]) or \
                 (len(lines) > 1 and self.prompt_re.match(lines[1])):
             return self._strip(lines)
@@ -74,7 +76,7 @@ classic_prompt = PromptStripper(
 ipython_prompt = PromptStripper(re.compile(r'^(In \[\d+\]: |\s*\.{3,}: ?)'))
 
 def cell_magic(lines):
-    if not lines[0].startswith('%%'):
+    if not lines or not lines[0].startswith('%%'):
         return lines
     if re.match('%%\w+\?', lines[0]):
         # This case will be handled by help_end
@@ -94,7 +96,7 @@ def _find_assign_op(token_line):
     for i, ti in enumerate(token_line):
         s = ti.string
         if s == '=' and paren_level == 0:
-            return i 
+            return i
         if s in '([{':
             paren_level += 1
         elif s in ')]}':
@@ -114,7 +116,7 @@ def find_end_of_continued_line(lines, start_line: int):
     return end_line
 
 def assemble_continued_line(lines, start: Tuple[int, int], end_line: int):
-    """Assemble a single line from multiple continued line pieces 
+    """Assemble a single line from multiple continued line pieces
 
     Continued lines are lines ending in ``\``, and the line following the last
     ``\`` in the block.
@@ -204,7 +206,7 @@ class MagicAssign(TokenTransformBase):
                     and (line[assign_ix+1].string == '%') \
                     and (line[assign_ix+2].type == tokenize.NAME):
                 return cls(line[assign_ix+1].start)
-    
+
     def transform(self, lines: List[str]):
         """Transform a magic assignment found by the ``find()`` classmethod.
         """
@@ -214,12 +216,12 @@ class MagicAssign(TokenTransformBase):
         rhs = assemble_continued_line(lines, (start_line, start_col), end_line)
         assert rhs.startswith('%'), rhs
         magic_name, _, args = rhs[1:].partition(' ')
-        
+
         lines_before = lines[:start_line]
         call = "get_ipython().run_line_magic({!r}, {!r})".format(magic_name, args)
         new_line = lhs + call + '\n'
         lines_after = lines[end_line+1:]
-        
+
         return lines_before + [new_line] + lines_after
 
 
@@ -466,7 +468,7 @@ def make_tokens_by_line(lines):
         pass
     if not tokens_by_line[-1]:
         tokens_by_line.pop()
-    
+
     return tokens_by_line
 
 def show_linewise_tokens(s: str):
@@ -503,12 +505,12 @@ class TransformerManager:
             EscapedCommand,
             HelpEnd,
         ]
-    
+
     def do_one_token_transform(self, lines):
         """Find and run the transform earliest in the code.
-        
+
         Returns (changed, lines).
-        
+
         This method is called repeatedly until changed is False, indicating
         that all available transformations are complete.
 

--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -24,6 +24,8 @@ def leading_indent(lines):
     If the first line starts with a spaces or tabs, the same whitespace will be
     removed from each following line in the cell.
     """
+    if not lines: 
+        return lines
     m = _indent_re.match(lines[0])
     if not m:
         return lines

--- a/IPython/core/tests/test_inputtransformer2.py
+++ b/IPython/core/tests/test_inputtransformer2.py
@@ -101,6 +101,12 @@ b) = zip?
 [r"get_ipython().set_next_input('(a,\nb) = zip');get_ipython().run_line_magic('pinfo', 'zip')" + "\n"]
 )
 
+def null_cleanup_transformer(lines):
+    """
+    A cleanup transform that returns an empty list.
+    """
+    return []
+
 def check_make_token_by_line_never_ends_empty():
     """
     Check that not sequence of single or double characters ends up leading to en empty list of tokens
@@ -215,3 +221,7 @@ def test_check_complete():
         for k in short:
             cc(c+k)
 
+def test_null_cleanup_transformer():
+    manager = ipt2.TransformerManager()
+    manager.cleanup_transforms.insert(0, null_cleanup_transformer)
+    nt.assert_is(manager.transform_cell(""), "")


### PR DESCRIPTION
The new input_transform interface is so much easier to use.  Great work y'all.

I was experimenting with it and there was one small hiccup, `leading_indent` raises an `IndexError` when it receives an empty `list`.  [This notebook](http://nbviewer.jupyter.org/github/deathbeds/deathbeds.github.io/blob/master/deathbeds/2018-10-01-New-IPython-Input-Interface.ipynb?flush_cache=true#A-little-%F0%9F%90%9B) demonstrates a succesful demo and the `IndexError` situation.