### PR TITLE
Math display: change $$...$$ -> $\displaystyle ...$

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -693,7 +693,7 @@ class Markdown(TextDisplayObject):
 class Math(TextDisplayObject):
 
     def _repr_latex_(self):
-        s = "$$%s$$" % self.data.strip('$')
+        s = "$\displaystyle %s$" % self.data.strip('$')
         if self.metadata:
             return s, deepcopy(self.metadata)
         else:


### PR DESCRIPTION
This makes math expressions align left when converted to LaTeX with e.g. `nbconvert`.

Also, it should avoid problems like https://github.com/jupyter/nbconvert/issues/275.