### PR TITLE
os.scandir

### DIFF
--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -218,8 +218,9 @@ class OSMagics(Magics):
                         os.chdir(pdir)
                     except OSError:
                         continue
+
+                    # use with notation for python 3.6 onward
                     dirlist = os.scandir(path=pdir)
-                    #with os.scandir(pdir) as dirlist:
                     for ff in dirlist:
                         if self.isexec(ff):
                             fname = ff.name
@@ -240,21 +241,23 @@ class OSMagics(Magics):
                         os.chdir(pdir)
                     except OSError:
                         continue
-                    with os.scandir(pdir) as dirlist:
-                        for ff in dirlist:
-                            fname = ff.name
-                            base, ext = os.path.splitext(fname)
-                            if self.isexec(ff) and base.lower() not in no_alias:
-                                if ext.lower() == '.exe':
-                                    fname = base
-                                    try:
-                                        # Removes dots from the name since ipython
-                                        # will assume names with dots to be python.
-                                        self.shell.alias_manager.define_alias(
-                                            base.lower().replace('.',''), fname)
-                                    except InvalidAliasError:
-                                        pass
-                                    syscmdlist.append(fname)
+
+                    # use with notation for python 3.6 onward
+                    dirlist = os.scandir(pdir)
+                    for ff in dirlist:
+                        fname = ff.name
+                        base, ext = os.path.splitext(fname)
+                        if self.isexec(ff) and base.lower() not in no_alias:
+                            if ext.lower() == '.exe':
+                                fname = base
+                                try:
+                                    # Removes dots from the name since ipython
+                                    # will assume names with dots to be python.
+                                    self.shell.alias_manager.define_alias(
+                                        base.lower().replace('.',''), fname)
+                                except InvalidAliasError:
+                                    pass
+                                syscmdlist.append(fname)
             self.shell.db['syscmdlist'] = syscmdlist
         finally:
             os.chdir(savedir)

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -47,7 +47,7 @@ class OSMagics(Magics):
             self.execre = re.compile(r'(.*)\.(%s)$' % winext,re.IGNORECASE)
 
         # call up the chain
-        super(OSMagics, self).__init__(shell=shell, **kwargs)
+        super().__init__(shell=shell, **kwargs)
 
 
     @skip_doctest
@@ -520,7 +520,6 @@ class OSMagics(Magics):
 
         dh = self.shell.user_ns['_dh']
         if parameter_s:
-            args = []
             try:
                 args = map(int,parameter_s.split())
             except:

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -24,7 +24,6 @@ from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.openpy import source_to_unicode
 from IPython.utils.process import abbrev_cwd
 from IPython.utils.terminal import set_term_title
-from os import DirEntry
 
 
 @magics_class
@@ -35,7 +34,7 @@ class OSMagics(Magics):
     def __init__(self, shell=None, **kwargs):
 
         # Now define isexec in a cross platform manner.
-        self.is_posix: bool = False
+        self.is_posix = False
         self.execre = None
         if os.name == 'posix':
             self.is_posix = True
@@ -52,29 +51,29 @@ class OSMagics(Magics):
 
 
     @skip_doctest
-    def _isexec_POSIX(self, f:DirEntry) -> bool:
+    def _isexec_POSIX(self, file):
         """
             Test for executible on a POSIX system
         """
-        return f.is_file() and os.access(f.path, os.X_OK)
+        return file.is_file() and os.access(file.path, os.X_OK)
 
     
     @skip_doctest
-    def _isexec_WIN(self, f:DirEntry) -> int:
+    def _isexec_WIN(self, file):
         """
             Test for executible file on non POSIX system
         """
-        return f.is_file() and self.execre.match(f.name) is not None
+        return file.is_file() and self.execre.match(file.name) is not None
 
     @skip_doctest
-    def isexec(self, f:DirEntry) -> bool:
+    def isexec(self, file):
         """
             Test for executible file on non POSIX system
         """
         if self.is_posix:
-            return self._isexec_POSIX(f)
+            return self._isexec_POSIX(file)
         else:
-            return self._isexec_WIN(f)
+            return self._isexec_WIN(file)
 
 
     @skip_doctest
@@ -212,7 +211,7 @@ class OSMagics(Magics):
         try:
             # write the whole loop for posix/Windows so we don't have an if in
             # the innermost part
-            if os.name == 'posix':
+            if self.is_posix:
                 for pdir in path:
                     try:
                         os.chdir(pdir)

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -212,14 +212,13 @@ class OSMagics(Magics):
             # write the whole loop for posix/Windows so we don't have an if in
             # the innermost part
             if self.is_posix:
-                print(path)
                 for pdir in path:
                     try:
                         os.chdir(pdir)
                     except OSError:
                         continue
 
-                    # use with notation for python 3.6 onward
+                    # for python 3.6+ rewrite to: with os.scandir(pdir) as dirlist:
                     dirlist = os.scandir(path=pdir)
                     for ff in dirlist:
                         if self.isexec(ff):
@@ -242,7 +241,7 @@ class OSMagics(Magics):
                     except OSError:
                         continue
 
-                    # use with notation for python 3.6 onward
+                    # for python 3.6+ rewrite to: with os.scandir(pdir) as dirlist:
                     dirlist = os.scandir(pdir)
                     for ff in dirlist:
                         fname = ff.name
@@ -258,6 +257,7 @@ class OSMagics(Magics):
                                 except InvalidAliasError:
                                     pass
                                 syscmdlist.append(fname)
+
             self.shell.db['syscmdlist'] = syscmdlist
         finally:
             os.chdir(savedir)

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -212,25 +212,27 @@ class OSMagics(Magics):
             # write the whole loop for posix/Windows so we don't have an if in
             # the innermost part
             if self.is_posix:
+                print(path)
                 for pdir in path:
                     try:
                         os.chdir(pdir)
                     except OSError:
                         continue
-                    with os.scandir(pdir) as dirlist:
-                        for ff in dirlist:
-                            if self.isexec(ff):
-                                fname = ff.name
-                                try:
-                                    # Removes dots from the name since ipython
-                                    # will assume names with dots to be python.
-                                    if not self.shell.alias_manager.is_alias(fname):
-                                        self.shell.alias_manager.define_alias(
-                                            fname.replace('.',''), fname)
-                                except InvalidAliasError:
-                                    pass
-                                else:
-                                    syscmdlist.append(fname)
+                    dirlist = os.scandir(path=pdir)
+                    #with os.scandir(pdir) as dirlist:
+                    for ff in dirlist:
+                        if self.isexec(ff):
+                            fname = ff.name
+                            try:
+                                # Removes dots from the name since ipython
+                                # will assume names with dots to be python.
+                                if not self.shell.alias_manager.is_alias(fname):
+                                    self.shell.alias_manager.define_alias(
+                                        fname.replace('.',''), fname)
+                            except InvalidAliasError:
+                                pass
+                            else:
+                                syscmdlist.append(fname)
             else:
                 no_alias = Alias.blacklist
                 for pdir in path:

--- a/IPython/core/profileapp.py
+++ b/IPython/core/profileapp.py
@@ -96,27 +96,22 @@ ipython locate profile foo # print the path to the directory for profile 'foo'
 
 def list_profiles_in(path):
     """list profiles in a given root directory"""
-    files = os.listdir(path)
     profiles = []
-    for f in files:
-        try:
-            full_path = os.path.join(path, f)
-        except UnicodeError:
-            continue
-        if os.path.isdir(full_path) and f.startswith('profile_'):
-            profiles.append(f.split('_',1)[-1])
+    with os.scandir(path) as files:
+        for f in files:
+            if f.is_dir() and f.name.startswith('profile_'):
+                profiles.append(f.name.split('_', 1)[-1])
     return profiles
 
 
 def list_bundled_profiles():
     """list profiles that are bundled with IPython."""
     path = os.path.join(get_ipython_package_dir(), u'core', u'profile')
-    files = os.listdir(path)
     profiles = []
-    for profile in files:
-        full_path = os.path.join(path, profile)
-        if os.path.isdir(full_path) and profile != "__pycache__":
-            profiles.append(profile)
+    with os.scandir(path) as files:
+        for profile in files:
+            if profile.is_dir() and profile.name != "__pycache__":
+                profiles.append(profile.name)
     return profiles
 
 

--- a/IPython/core/profileapp.py
+++ b/IPython/core/profileapp.py
@@ -97,10 +97,12 @@ ipython locate profile foo # print the path to the directory for profile 'foo'
 def list_profiles_in(path):
     """list profiles in a given root directory"""
     profiles = []
-    with os.scandir(path) as files:
-        for f in files:
-            if f.is_dir() and f.name.startswith('profile_'):
-                profiles.append(f.name.split('_', 1)[-1])
+
+    # use with notation for python 3.6 onward
+    files = os.scandir(path)
+    for f in files:
+        if f.is_dir() and f.name.startswith('profile_'):
+            profiles.append(f.name.split('_', 1)[-1])
     return profiles
 
 
@@ -108,10 +110,12 @@ def list_bundled_profiles():
     """list profiles that are bundled with IPython."""
     path = os.path.join(get_ipython_package_dir(), u'core', u'profile')
     profiles = []
-    with os.scandir(path) as files:
-        for profile in files:
-            if profile.is_dir() and profile.name != "__pycache__":
-                profiles.append(profile.name)
+
+    # use with notation for python 3.6 onward
+    files =  os.scandir(path)
+    for profile in files:
+        if profile.is_dir() and profile.name != "__pycache__":
+            profiles.append(profile.name)
     return profiles
 
 

--- a/IPython/core/profileapp.py
+++ b/IPython/core/profileapp.py
@@ -98,7 +98,7 @@ def list_profiles_in(path):
     """list profiles in a given root directory"""
     profiles = []
 
-    # use with notation for python 3.6 onward
+    # for python 3.6+ rewrite to: with os.scandir(path) as dirlist:
     files = os.scandir(path)
     for f in files:
         if f.is_dir() and f.name.startswith('profile_'):
@@ -111,7 +111,7 @@ def list_bundled_profiles():
     path = os.path.join(get_ipython_package_dir(), u'core', u'profile')
     profiles = []
 
-    # use with notation for python 3.6 onward
+    # for python 3.6+ rewrite to: with os.scandir(path) as dirlist:
     files =  os.scandir(path)
     for profile in files:
         if profile.is_dir() and profile.name != "__pycache__":


### PR DESCRIPTION
FIX #9914 
I added os.scandir in two locations. I also updated how osm.py checked for executable `isexec`. I took advantage of some type hinting. I don't think type hinting is used elsewhere in the code, so I can remove this if needed.