### PR TITLE
Improve IFrame warnings in IPython/core/display.py

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -667,7 +667,19 @@ class Pretty(TextDisplayObject):
 class HTML(TextDisplayObject):
 
     def __init__(self, data=None, url=None, filename=None, metadata=None):
-        if data and data.startswith("<iframe ") and data.endswith("</iframe>"):
+        def warn():
+            if not data:
+                return False
+
+            #
+            # Avoid calling lower() on the entire data, because it could be a
+            # long string and we're only interested in its beginning and end.
+            #
+            prefix = data[:10].lower()
+            suffix = data[-10:].lower()
+            return prefix.startswith("<iframe ") and suffix.endswith("</iframe>")
+
+        if warn():
             warnings.warn("Consider using IPython.display.IFrame instead")
         super(HTML, self).__init__(data=data, url=url, filename=filename, metadata=metadata)
 

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -667,7 +667,7 @@ class Pretty(TextDisplayObject):
 class HTML(TextDisplayObject):
 
     def __init__(self, data=None, url=None, filename=None, metadata=None):
-        if data and "<iframe " in data and "</iframe>" in data:
+        if data and data.startswith("<iframe ") and data.endswith("</iframe>"):
             warnings.warn("Consider using IPython.display.IFrame instead")
         super(HTML, self).__init__(data=data, url=url, filename=filename, metadata=metadata)
 

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -200,6 +200,9 @@ def test_encourage_iframe_over_html(m_warn):
     display.HTML('<br />')
     m_warn.assert_not_called()
 
+    display.HTML('<html><p>Lots of content here</p><iframe src="http://a.com"></iframe>')
+    m_warn.assert_not_called()
+
     display.HTML('<iframe src="http://a.com"></iframe>')
     m_warn.assert_called_with('Consider using IPython.display.IFrame instead')
 

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -197,6 +197,9 @@ def test_displayobject_repr():
 
 @mock.patch('warnings.warn')
 def test_encourage_iframe_over_html(m_warn):
+    display.HTML()
+    m_warn.assert_not_called()
+
     display.HTML('<br />')
     m_warn.assert_not_called()
 
@@ -204,6 +207,10 @@ def test_encourage_iframe_over_html(m_warn):
     m_warn.assert_not_called()
 
     display.HTML('<iframe src="http://a.com"></iframe>')
+    m_warn.assert_called_with('Consider using IPython.display.IFrame instead')
+
+    m_warn.reset_mock()
+    display.HTML('<IFRAME SRC="http://a.com"></IFRAME>')
     m_warn.assert_called_with('Consider using IPython.display.IFrame instead')
 
 def test_progress():


### PR DESCRIPTION
- Continuation of #11350 
- Fix #9343 