### PR TITLE
Replace Deprecated time.clock with time.perf_counter

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -912,7 +912,7 @@ python-profiler package from non-free.""")
             Number of times to execute `run`.
 
         """
-        twall0 = time.time()
+        twall0 = time.perf_counter()
         if nruns == 1:
             t0 = clock2()
             run()
@@ -935,7 +935,7 @@ python-profiler package from non-free.""")
             print("  Times  : %10s   %10s" % ('Total', 'Per run'))
             print("  User   : %10.2f s, %10.2f s." % (t_usr, t_usr / nruns))
             print("  System : %10.2f s, %10.2f s." % (t_sys, t_sys / nruns))
-        twall1 = time.time()
+        twall1 = time.perf_counter()
         print("Wall time: %10.2f s." % (twall1 - twall0))
 
     @skip_doctest

--- a/IPython/utils/timing.py
+++ b/IPython/utils/timing.py
@@ -58,12 +58,12 @@ try:
         return resource.getrusage(resource.RUSAGE_SELF)[:2]
 except ImportError:
     # There is no distinction of user/system time under windows, so we just use
-    # time.clock() for everything...
+    # time.perff_counter() for everything...
     clocku = clocks = clock = time.perf_counter
     def clock2():
         """Under windows, system CPU time can't be measured.
 
-        This just returns clock() and zero."""
+        This just returns perf_counter() and zero."""
         return time.perf_counter(),0.0
 
     

--- a/IPython/utils/timing.py
+++ b/IPython/utils/timing.py
@@ -59,12 +59,12 @@ try:
 except ImportError:
     # There is no distinction of user/system time under windows, so we just use
     # time.clock() for everything...
-    clocku = clocks = clock = time.clock
+    clocku = clocks = clock = time.perf_counter
     def clock2():
         """Under windows, system CPU time can't be measured.
 
         This just returns clock() and zero."""
-        return time.clock(),0.0
+        return time.perf_counter(),0.0
 
     
 def timings_out(reps,func,*args,**kw):


### PR DESCRIPTION
Ref: [Issue#11375](https://github.com/ipython/ipython/issues/11375)
This pull request contains following:

- Replaced deprecated time.clock with time.perf_counter
- Updated comments around it

 