### PR TITLE
Replace simplegeneric with functools.singledispatch

### DIFF
--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -115,7 +115,7 @@ def test_custom_completion_error():
     class A(object): pass
     ip.user_ns['a'] = A()
     
-    @complete_object.when_type(A)
+    @complete_object.register(A)
     def complete_A(a, existing_completions):
         raise TypeError("this should be silenced")
     

--- a/IPython/external/__init__.py
+++ b/IPython/external/__init__.py
@@ -2,4 +2,4 @@
 This package contains all third-party modules bundled with IPython.
 """
 
-__all__ = ["simplegeneric"]
+__all__ = []

--- a/IPython/utils/generics.py
+++ b/IPython/utils/generics.py
@@ -1,20 +1,18 @@
 # encoding: utf-8
 """Generic functions for extending IPython.
-
-See http://pypi.python.org/pypi/simplegeneric.
 """
 
 from IPython.core.error import TryNext
-from simplegeneric import generic
+from functools import singledispatch
 
 
-@generic
+@singledispatch
 def inspect_object(obj):
     """Called when you do obj?"""
     raise TryNext
 
 
-@generic
+@singledispatch
 def complete_object(obj, prev_completions):
     """Custom completer dispatching for python objects.
 
@@ -30,5 +28,3 @@ def complete_object(obj, prev_completions):
     own_attrs + prev_completions.
     """
     raise TryNext
-
-

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -81,7 +81,7 @@ class LSString(str):
 #     print arg
 #
 #
-# print_lsstring = result_display.when_type(LSString)(print_lsstring)
+# print_lsstring = result_display.register(LSString)(print_lsstring)
 
 
 class SList(list):
@@ -243,7 +243,7 @@ class SList(list):
 #
 #     nlprint(arg)   # This was a nested list printer, now removed.
 #
-# print_slist = result_display.when_type(SList)(print_slist)
+# print_slist = result_display.register(SList)(print_slist)
 
 
 def indent(instr,nspaces=4, ntabs=0, flatten=False):

--- a/setup.py
+++ b/setup.py
@@ -188,7 +188,6 @@ install_requires = [
     'jedi>=0.10',
     'decorator',
     'pickleshare',
-    'simplegeneric>0.8',
     'traitlets>=4.2',
     'prompt_toolkit>=2.0.0,<2.1.0',
     'pygments',


### PR DESCRIPTION
Fix #10293.

IPython has dropped Python 3.3 and lower, so the dependency on `simplegeneric` (which has no wheel and hasn't been updated in a long time) can be replaced with `functools.singledispatch` from the stdlib.

* https://www.python.org/dev/peps/pep-0443/
* https://mail.python.org/pipermail/python-dev/2013-June/126734.html
* https://github.com/python/cpython/commit/6f69251980f385beac9d6f3e8ff4775bd37a1779