### PR TITLE
added filter warnings for older versions of python (<3.7)

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -803,7 +803,9 @@ class InteractiveShell(SingletonConfigurable):
         This will allow deprecation warning of function used interactively to show
         warning to users, and still hide deprecation warning from libraries import.
         """
-        warnings.filterwarnings("default", category=DeprecationWarning, module=self.user_ns.get("__name__"))
+        if sys.version_info < (3,7):
+            warnings.filterwarnings("default", category=DeprecationWarning, module=self.user_ns.get("__name__"))
+
 
     def init_builtins(self):
         # A single, static flag that we set to True.  Its presence indicates


### PR DESCRIPTION
I simply added the 

if sys.info_version < (3,7):
...code

mentioned in [this issue](https://github.com/ipython/ipython/issues/11333) on the init_deprecation_warnings() functions in the main IPython class. What i understood is that this issue is fixed for python 3.7 but not for older versions, so I guessed this should suffice. 

I wanted opinions from more experienced developers in this project to help to check it and to test it. 