### PR TITLE
Fix to allow entering docstring into IPython.

### DIFF
--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -355,9 +355,14 @@ class EscapedCommand(TokenTransformBase):
         """Find the first escaped command (%foo, !foo, etc.) in the cell.
         """
         for line in tokens_by_line:
+            if not line:
+                continue
             ix = 0
-            while line[ix].type in {tokenize.INDENT, tokenize.DEDENT}:
+            ll = len(line)
+            while ll > ix and line[ix].type in {tokenize.INDENT, tokenize.DEDENT}:
                 ix += 1
+            if ix >= ll:
+                continue
             if line[ix].string in ESCAPE_SINGLES:
                 return cls(line[ix].start)
 

--- a/IPython/core/tests/test_inputtransformer2.py
+++ b/IPython/core/tests/test_inputtransformer2.py
@@ -233,6 +233,17 @@ def test_check_complete():
         for k in short:
             cc(c+k)
 
+def test_check_complete_II():
+    """
+    Test that multiple line strings are properly handled.
+
+    Separate test function for convenience
+
+    """
+    cc = ipt2.TransformerManager().check_complete
+    nt.assert_equal(cc('''def foo():\n    """'''), ('incomplete', 4))
+
+
 def test_null_cleanup_transformer():
     manager = ipt2.TransformerManager()
     manager.cleanup_transforms.insert(0, null_cleanup_transformer)


### PR DESCRIPTION
The EscapeTransformer find method was assuming incorrectly that every
line would end with either a NEWLINE or EOF, while this is not the case
when encountering multiple line string.

This fixes that by making sure we don't index outside of bounds.

With this IPython will correctly add a newline at the CLI.

Closes #11391