### PR TITLE
removed expansion of function name when completing kw-args

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1538,24 +1538,20 @@ class IPCompleter(Completer):
 
             usedNamedArgs.add(token)
 
-        # lookup the candidate callable matches either using global_matches
-        # or attr_matches for dotted names
-        if len(ids) == 1:
-            callableMatches = self.global_matches(ids[0])
-        else:
-            callableMatches = self.attr_matches('.'.join(ids[::-1]))
         argMatches = []
-        for callableMatch in callableMatches:
-            try:
-                namedArgs = self._default_arguments(eval(callableMatch,
-                                                        self.namespace))
-            except:
-                continue
+        try:
+            callableObj = '.'.join(ids[::-1])
+            print(callableObj)
+            namedArgs = self._default_arguments(eval(callableObj,
+                                                    self.namespace))
 
             # Remove used named arguments from the list, no need to show twice
             for namedArg in set(namedArgs) - usedNamedArgs:
                 if namedArg.startswith(text):
                     argMatches.append(u"%s=" %namedArg)
+        except:
+            pass
+            
         return argMatches
 
     def dict_key_matches(self, text):

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1541,7 +1541,6 @@ class IPCompleter(Completer):
         argMatches = []
         try:
             callableObj = '.'.join(ids[::-1])
-            print(callableObj)
             namedArgs = self._default_arguments(eval(callableObj,
                                                     self.namespace))
 

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -1027,3 +1027,23 @@ def test_snake_case_completion():
     _, matches = ip.complete("s_", "print(s_f")
     nt.assert_in('some_three', matches)
     nt.assert_in('some_four', matches)
+
+def test_mix_terms():
+    ip = get_ipython()
+    from textwrap import dedent
+    ip.Completer.use_jedi = False
+    ip.ex(dedent("""
+        class Test:
+            def meth(self, meth_arg1):
+                print("meth")
+
+            def meth_1(self, meth1_arg1, meth1_arg2):
+                print("meth1")
+
+            def meth_2(self, meth2_arg1, meth2_arg2):
+                print("meth2")
+        test = Test()
+        """))
+    _, matches = ip.complete(None, "test.meth(")
+    nt.assert_in('meth_arg1=', matches)
+    nt.assert_not_in('meth2_arg1=', matches)


### PR DESCRIPTION
fix #11408 

There seems to be a function expansion when searching for kw-args, and that causes the bug.
I removed it and it solved it, but I'm not sure why it's there, so I'm not sure it's a complete solution.

Also, I'm not quite sure how to run tests, so I haven't done any regression tests yet.