### PR TITLE
Fix rtd build and be more strict about builds (fail on warn).

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,8 +4,11 @@ dependencies:
 - setuptools>=18.5
 - sphinx>=1.8
 - sphinx_rtd_theme
+- numpy
+- nose
+- testpath
+- matplotlib
 - pip:
     - docrepr
     - prompt_toolkit
-    - ipython
     - ipykernel

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,11 +66,6 @@ extensions = [
     'configtraits',
 ]
 
-if ON_RTD:
-    # Remove extensions not currently supported on RTD
-    extensions.remove('IPython.sphinxext.ipython_directive')
-    extensions.remove('IPython.sphinxext.ipython_console_highlighting')
-
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
@@ -124,6 +119,7 @@ github_project_url = "https://github.com/ipython/ipython"
 # numpydoc config
 numpydoc_show_class_members = False # Otherwise Sphinx emits thousands of warnings
 numpydoc_class_members_toctree = False
+warning_is_error = True
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.


### PR DESCRIPTION
Readthedocs was silently just ignoring many errors and for exampel not
including .. automodule: when they couldn't be imported and not
rendering anything within the `.. ipython::` directive.

Make it work (and fail if it ever break again).