### PR TITLE
Fix indentation for nested code block

### DIFF
--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -655,7 +655,15 @@ class TransformerManager:
         if len(tokens_by_line) == 1 and not tokens_by_line[-1]:
             return 'incomplete', 0
 
-        if tokens_by_line[-1][-1].string == ':':
+        new_block = False
+        for token in reversed(tokens_by_line[-1]):
+            if token.type == tokenize.DEDENT:
+                continue
+            elif token.string == ':':
+                new_block = True
+            break
+
+        if new_block:
             # The last line starts a block (e.g. 'if foo:')
             ix = 0
             while tokens_by_line[-1][ix].type in {tokenize.INDENT, tokenize.DEDENT}:

--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -481,6 +481,17 @@ def make_tokens_by_line(lines):
     if not tokens_by_line[-1]:
         tokens_by_line.pop()
 
+    # Convert if using cpython tokenize
+    if (list(map(lambda x: x.type, tokens_by_line[-1])) == 
+            [tokenize.DEDENT] * (len(tokens_by_line[-1]) - 1) + [tokenize.ENDMARKER]):
+        if (
+            len(tokens_by_line) > 1 and
+            len(tokens_by_line[-2]) > 0 and
+            tokens_by_line[-2][-1].type == tokenize.NEWLINE
+        ):
+            tokens_by_line[-2].pop()
+            tokens_by_line[-2] += tokens_by_line[-1]
+            tokens_by_line.pop()
 
     return tokens_by_line
 
@@ -643,18 +654,6 @@ class TransformerManager:
             return 'incomplete', find_last_indent(lines)
 
         newline_types = {tokenize.NEWLINE, tokenize.COMMENT, tokenize.ENDMARKER}
-
-        # Convert if using cpython tokenize
-        if (list(map(lambda x: x.type, tokens_by_line[-1])) == 
-                [tokenize.DEDENT] * (len(tokens_by_line[-1]) - 1) + [tokenize.ENDMARKER]):
-            if (
-                len(tokens_by_line) > 1 and
-                len(tokens_by_line[-2]) > 0 and
-                tokens_by_line[-2][-1].type == tokenize.NEWLINE
-            ):
-                tokens_by_line[-2].pop()
-                tokens_by_line[-2] += tokens_by_line[-1]
-                tokens_by_line.pop()
 
         # Remove newline_types for the list of tokens
         while len(tokens_by_line) > 1 and len(tokens_by_line[-1]) == 1 \

--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -644,6 +644,18 @@ class TransformerManager:
 
         newline_types = {tokenize.NEWLINE, tokenize.COMMENT, tokenize.ENDMARKER}
 
+        # Convert if using cpython tokenize
+        if (list(map(lambda x: x.type, tokens_by_line[-1])) == 
+                [tokenize.DEDENT] * (len(tokens_by_line[-1]) - 1) + [tokenize.ENDMARKER]):
+            if (
+                len(tokens_by_line) > 1 and
+                len(tokens_by_line[-2]) > 0 and
+                tokens_by_line[-2][-1].type == tokenize.NEWLINE
+            ):
+                tokens_by_line[-2].pop()
+                tokens_by_line[-2] += tokens_by_line[-1]
+                tokens_by_line.pop()
+
         # Remove newline_types for the list of tokens
         while len(tokens_by_line) > 1 and len(tokens_by_line[-1]) == 1 \
                 and tokens_by_line[-1][-1].type in newline_types:

--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -482,6 +482,7 @@ def make_tokens_by_line(lines):
         tokens_by_line.pop()
 
     # Convert if using cpython tokenize
+    # upstream bug was fixed in Python 3.7.1, so once we drop 3.7 this can likely be removed. 
     if (list(map(lambda x: x.type, tokens_by_line[-1])) == 
             [tokenize.DEDENT] * (len(tokens_by_line[-1]) - 1) + [tokenize.ENDMARKER]):
         if (

--- a/IPython/core/tests/test_inputtransformer2.py
+++ b/IPython/core/tests/test_inputtransformer2.py
@@ -207,6 +207,7 @@ def test_check_complete():
     cc = ipt2.TransformerManager().check_complete
     nt.assert_equal(cc("a = 1"), ('complete', None))
     nt.assert_equal(cc("for a in range(5):"), ('incomplete', 4))
+    nt.assert_equal(cc("for a in range(5):\n    if a > 0:"), ('incomplete', 8))
     nt.assert_equal(cc("raise = 2"), ('invalid', None))
     nt.assert_equal(cc("a = [1,\n2,"), ('incomplete', 0))
     nt.assert_equal(cc(")"), ('incomplete', 0))


### PR DESCRIPTION
Fix #11416.

The problem was not just with class method but a nested block in general, for example an if else block inside a function definition. I'm not sure whether the workaround for the inconsistency between python's and cpython's module was perfect, but it works for the moment :)