### PR TITLE
Fix custom keyboard shortcut examples.

### DIFF
--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -1009,6 +1009,15 @@ class IPythonDirective(Directive):
 
                 if figure is not None:
                     figures.append(figure)
+            else:
+                message = 'Code input with no code at {}, line {}'\
+                            .format(
+                                self.state.document.current_source,
+                                self.state.document.current_line)
+                if self.shell.warning_is_error:
+                    raise RuntimeError(message)
+                else:
+                    warnings.warn(message)
 
         for figure in figures:
             lines.append('')

--- a/docs/source/config/details.rst
+++ b/docs/source/config/details.rst
@@ -216,14 +216,34 @@ a :ref:`startup file <startup_files>`::
     def insert_unexpected(event):
         buf = event.current_buffer
         buf.insert_text('The Spanish Inquisition')
-
     # Register the shortcut if IPython is using prompt_toolkit
-    if getattr(ip, 'pt_cli'):
-        registry = ip.pt_cli.application.key_bindings_registry
+    if getattr(ip, 'pt_app', None):
+        registry = ip.pt_app.key_bindings
         registry.add_binding(Keys.ControlN,
                          filter=(HasFocus(DEFAULT_BUFFER)
                                  & ~HasSelection()
                                  & insert_mode))(insert_unexpected)
+
+
+Here is a second example that bind the key sequence ``j``, ``k`` to switch to
+VI input mode to ``Normal`` when in insert mode::
+
+   from IPython import get_ipython
+   from prompt_toolkit.enums import DEFAULT_BUFFER
+   from prompt_toolkit.filters import HasFocus, ViInsertMode
+   from prompt_toolkit.key_binding.vi_state import InputMode
+
+   ip = get_ipython()
+
+   def switch_to_navigation_mode(event):
+      vi_state = event.cli.vi_state
+      vi_state.input_mode = InputMode.NAVIGATION
+
+   if getattr(ip, 'pt_app', None):
+      registry = ip.pt_app.key_bindings
+      registry.add_binding(u'j',u'k',
+                           filter=(HasFocus(DEFAULT_BUFFER)
+                                    & ViInsertMode()))(switch_to_navigation_mode)
 
 For more information on filters and what you can do with the ``event`` object,
 `see the prompt_toolkit docs


### PR DESCRIPTION
Upgrading to prompt_toolkit 2 changed some internal API, update examples.

Also have sphinx directive raise/warn if code blocks have issues (no
leading prompt) which end-up stripping all code.

Closes #11405