### PR TITLE
set ls aliases according to colors configuration (closes #11431)

### DIFF
--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -204,6 +204,8 @@ class AliasManager(Configurable):
     def init_aliases(self):
         # Load default & user aliases
         for name, cmd in self.default_aliases + self.user_aliases:
+            if cmd.startswith('ls ') and self.shell.colors == 'NoColor':
+                cmd = cmd.replace(' --color', '')
             self.soft_define_alias(name, cmd)
 
     @property


### PR DESCRIPTION
In Linux, a set of aliases are set to list files, such as `ls` and `ll` which uses `--color` even when `c.InteractiveShell.colors=NoColor` is used. This is to have the aliases respect the colors setting so that it will not mess up the terminal which do not support color.