### PR TITLE
fix for PySide2 cannot be activated since it is directly deactivated …

### DIFF
--- a/IPython/external/qt_loaders.py
+++ b/IPython/external/qt_loaders.py
@@ -68,7 +68,7 @@ def commit_api(api):
         ID.forbid('PySide')
         ID.forbid('PyQt4')
         ID.forbid('PyQt5')
-    if api == QT_API_PYSIDE:
+    elif api == QT_API_PYSIDE:
         ID.forbid('PySide2')
         ID.forbid('PyQt4')
         ID.forbid('PyQt5')


### PR DESCRIPTION
…again in the else part

Before I got this error:

ImportError: 
    Importing PySide2 disabled by IPython, which has
    already imported an Incompatible QT Binding: pyside2
