### PR TITLE
Add OSX on 3.6 and 3.7 to travis, use addons.apt:packages for graphviz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ group: edge
 before_install:
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                    ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install pyenv             ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pyenv install "$PYENV_VERSION" ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pyenv local "$PYENV_VERSION"   ; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ group: edge
 before_install:
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                    ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update pyenv              ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade pyenv             ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pyenv install --list           ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pyenv install "$PYENV_VERSION" ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pyenv local "$PYENV_VERSION"   ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,32 +36,32 @@ before_install:
   - python --version
 
 install:
-    - pip install pip --upgrade
-    - pip install setuptools --upgrade
-    - pip install -e file://$PWD#egg=ipython[test] --upgrade
-    - pip install trio curio
-    - pip install codecov check-manifest --upgrade
+  - pip install pip --upgrade
+  - pip install setuptools --upgrade
+  - pip install -e file://$PWD#egg=ipython[test] --upgrade
+  - pip install trio curio
+  - pip install codecov check-manifest --upgrade
 
 script:
-    - check-manifest
-    - |
-      if [[ "$TRAVIS_PYTHON_VERSION" == "nightly" ]]; then
-         # on nightly fake parso known the grammar
-         cp /home/travis/virtualenv/python3.8-dev/lib/python3.8/site-packages/parso/python/grammar37.txt /home/travis/virtualenv/python3.8-dev/lib/python3.8/site-packages/parso/python/grammar38.txt
-      fi
-    - cd /tmp && iptest --coverage xml && cd -
-    # On the latest Python (on Linux) only, make sure that the docs build.
-    - |
-      if [[ "$TRAVIS_PYTHON_VERSION" == "3.7" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        pip install -r docs/requirements.txt
-        python tools/fixup_whats_new_pr.py
-        make -C docs/ html SPHINXOPTS="-W"
-      fi
+  - check-manifest
+  - |
+    if [[ "$TRAVIS_PYTHON_VERSION" == "nightly" ]]; then
+       # on nightly fake parso known the grammar
+       cp /home/travis/virtualenv/python3.8-dev/lib/python3.8/site-packages/parso/python/grammar37.txt /home/travis/virtualenv/python3.8-dev/lib/python3.8/site-packages/parso/python/grammar38.txt
+    fi
+  - cd /tmp && iptest --coverage xml && cd -
+  # On the latest Python (on Linux) only, make sure that the docs build.
+  - |
+    if [[ "$TRAVIS_PYTHON_VERSION" == "3.7" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      pip install -r docs/requirements.txt
+      python tools/fixup_whats_new_pr.py
+      make -C docs/ html SPHINXOPTS="-W"
+    fi
 
 after_success:
-    - cp /tmp/ipy_coverage.xml ./
-    - cp /tmp/.coverage ./
-    - codecov
+  - cp /tmp/ipy_coverage.xml ./
+  - cp /tmp/.coverage ./
+  - codecov
 
 matrix:
   include:
@@ -86,14 +86,14 @@ matrix:
     - python: nightly
 
 before_deploy:
-    - rm -rf dist/
-    - python setup.py sdist
-    - python setup.py bdist_wheel
+  - rm -rf dist/
+  - python setup.py sdist
+  - python setup.py bdist_wheel
 
 deploy:
   provider: releases
   api_key:
-      secure: Y/Ae9tYs5aoBU8bDjN2YrwGG6tCbezj/h3Lcmtx8HQavSbBgXnhnZVRb2snOKD7auqnqjfT/7QMm4ZyKvaOEgyggGktKqEKYHC8KOZ7yp8I5/UMDtk6j9TnXpSqqBxPiud4MDV76SfRYEQiaDoG4tGGvSfPJ9KcNjKrNvSyyxns=
+    secure: Y/Ae9tYs5aoBU8bDjN2YrwGG6tCbezj/h3Lcmtx8HQavSbBgXnhnZVRb2snOKD7auqnqjfT/7QMm4ZyKvaOEgyggGktKqEKYHC8KOZ7yp8I5/UMDtk6j9TnXpSqqBxPiud4MDV76SfRYEQiaDoG4tGGvSfPJ9KcNjKrNvSyyxns=
   file: dist/*
   file_glob: true
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,9 @@ script:
          cp /home/travis/virtualenv/python3.8-dev/lib/python3.8/site-packages/parso/python/grammar37.txt /home/travis/virtualenv/python3.8-dev/lib/python3.8/site-packages/parso/python/grammar38.txt
       fi
     - cd /tmp && iptest --coverage xml && cd -
-    # On the latest Python only, make sure that the docs build.
+    # On the latest Python (on Linux) only, make sure that the docs build.
     - |
-      if [[ "$TRAVIS_PYTHON_VERSION" == "3.7" ]]; then
+      if [[ "$TRAVIS_PYTHON_VERSION" == "3.7" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         pip install -r docs/requirements.txt
         python tools/fixup_whats_new_pr.py
         make -C docs/ html SPHINXOPTS="-W"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ group: edge
 before_install:
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                    ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update pyenv              ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pyenv install --list           ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pyenv install "$PYENV_VERSION" ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pyenv local "$PYENV_VERSION"   ; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,18 +18,12 @@ env:
 
 group: edge
 
-cache:
-  directories:
-    - $HOME/.cache/pyenv
-
 before_install:
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
     - |
       if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         brew update
         brew upgrade pyenv
-        mkdir -p $HOME/.cache/pyenv/versions $HOME/.pyenv
-        ln -s $HOME/.cache/pyenv/versions $HOME/.pyenv/versions
         eval "$(pyenv init -)"
         pyenv install --skip-existing "$PYENV_VERSION"
         pyenv global "$PYENV_VERSION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,18 @@ group: edge
 
 before_install:
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                    ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade pyenv             ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pyenv install "$PYENV_VERSION" ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pyenv global "$PYENV_VERSION"  ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python --version               ; fi
+    - |
+      if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        brew update
+        brew upgrade pyenv
+        eval "$(pyenv init -)"
+        pyenv install "$PYENV_VERSION"
+        pyenv global "$PYENV_VERSION"
+        pyenv shell "$PYENV_VERSION"
+        pyenv rehash
+        python --version
+        echo $(python --version)
+      fi
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ env:
 group: edge
 
 before_install:
-  - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
   - |
     # install Python on macOS
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ before_install:
       if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         brew update
         brew upgrade pyenv
-        mkdir -p $HOME/.cache/pyenv/versions
-        ln -s $HOME/.cache/pyenv/versions ~/.pyenv/versions
+        mkdir -p $HOME/.cache/pyenv/versions $HOME/.pyenv
+        ln -s $HOME/.cache/pyenv/versions $HOME/.pyenv/versions
         eval "$(pyenv init -)"
         pyenv install --skip-existing "$PYENV_VERSION"
         pyenv global "$PYENV_VERSION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,13 @@ sudo: false
 env:
   global:
     - PATH=$TRAVIS_BUILD_DIR/pandoc:$PATH
+    - PYTHON_BUILD_CACHE_PATH=$HOME/.pyenv_cache
 
 group: edge
+
+cache:
+  directories:
+    - $HOME/.pyenv_cache
 
 before_install:
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
@@ -56,6 +61,7 @@ script:
         python tools/fixup_whats_new_pr.py
         make -C docs/ html SPHINXOPTS="-W"
       fi
+
 after_success:
     - cp /tmp/ipy_coverage.xml ./
     - cp /tmp/.coverage ./

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 # http://travis-ci.org/#!/ipython/ipython
 language: python
+os: linux
 
 addons:
-    apt:
-        packages:
-            - graphviz
+  apt:
+    packages:
+      - graphviz
 
 python:
     - 3.6
@@ -19,18 +20,20 @@ env:
 group: edge
 
 before_install:
-    - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
-    - |
-      if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        brew update
-        brew upgrade pyenv
-        eval "$(pyenv init -)"
-        pyenv install --skip-existing "$PYENV_VERSION"
-        pyenv global "$PYENV_VERSION"
-        pyenv rehash
+  - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
+  - |
+    # install Python on macOS
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      env | sort
+      if ! which python$TRAVIS_PYTHON_VERSION; then
+        HOMEBREW_NO_AUTO_UPDATE=1 brew tap minrk/homebrew-python-frameworks
+        HOMEBREW_NO_AUTO_UPDATE=1 brew cask install python-framework-${TRAVIS_PYTHON_VERSION/./}
       fi
-    - python --version
-
+      python3 -m pip install virtualenv
+      python3 -m virtualenv -p $(which python$TRAVIS_PYTHON_VERSION) ~/travis-env
+      source ~/travis-env/bin/activate
+    fi
+  - python --version
 
 install:
     - pip install pip --upgrade
@@ -61,15 +64,26 @@ after_success:
     - codecov
 
 matrix:
-    include:
-        - { python: "3.6-dev", dist: xenial, sudo: true, os: linux }
-        - { python: "3.7", dist: xenial, sudo: true, os: linux }
-        - { python: "3.7-dev", dist: xenial, sudo: true, os: linux }
-        - { python: "nightly", dist: xenial, sudo: true, os: linux }
-        - { os: osx, language: generic, env: TRAVIS_PYTHON_VERSION="3.6" PYENV_VERSION="3.6.7" }
-        - { os: osx, language: generic, env: TRAVIS_PYTHON_VERSION="3.7" PYENV_VERSION="3.7.1" }
-    allow_failures:
-        - python: nightly
+  include:
+    - python: "3.7"
+      dist: xenial
+      sudo: true
+    - python: "3.7-dev"
+      dist: xenial
+      sudo: true
+    - python: "nightly"
+      dist: xenial
+      sudo: true
+    - os: osx
+      language: generic
+      python: 3.6
+      env: TRAVIS_PYTHON_VERSION=3.6
+    - os: osx
+      language: generic
+      python: 3.7
+      env: TRAVIS_PYTHON_VERSION=3.7
+  allow_failures:
+    - python: nightly
 
 before_deploy:
     - rm -rf dist/
@@ -77,15 +91,15 @@ before_deploy:
     - python setup.py bdist_wheel
 
 deploy:
-    provider: releases
-    api_key:
-        secure: Y/Ae9tYs5aoBU8bDjN2YrwGG6tCbezj/h3Lcmtx8HQavSbBgXnhnZVRb2snOKD7auqnqjfT/7QMm4ZyKvaOEgyggGktKqEKYHC8KOZ7yp8I5/UMDtk6j9TnXpSqqBxPiud4MDV76SfRYEQiaDoG4tGGvSfPJ9KcNjKrNvSyyxns=
-    file: dist/*
-    file_glob: true
-    skip_cleanup: true
-    on:
-        repo: ipython/ipython
-        all_branches: true  # Backports are released from e.g. 5.x branch
-        tags: true
-        python: 3.6  # Any version should work, but we only need one
-        condition: $TRAVIS_OS_NAME = "linux"
+  provider: releases
+  api_key:
+      secure: Y/Ae9tYs5aoBU8bDjN2YrwGG6tCbezj/h3Lcmtx8HQavSbBgXnhnZVRb2snOKD7auqnqjfT/7QMm4ZyKvaOEgyggGktKqEKYHC8KOZ7yp8I5/UMDtk6j9TnXpSqqBxPiud4MDV76SfRYEQiaDoG4tGGvSfPJ9KcNjKrNvSyyxns=
+  file: dist/*
+  file_glob: true
+  skip_cleanup: true
+  on:
+    repo: ipython/ipython
+    all_branches: true  # Backports are released from e.g. 5.x branch
+    tags: true
+    python: 3.6  # Any version should work, but we only need one
+    condition: $TRAVIS_OS_NAME = "linux"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade pyenv             ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pyenv install "$PYENV_VERSION" ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pyenv global "$PYENV_VERSION"  ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pyenv shell "$PYENV_VERSION"   ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python --version               ; fi
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,9 @@ before_install:
         brew upgrade pyenv
         eval "$(pyenv init -)"
         pyenv install "$PYENV_VERSION"
+        pyenv rehash
         pyenv global "$PYENV_VERSION"
         pyenv shell "$PYENV_VERSION"
-        pyenv rehash
-        python --version
-        echo $(python --version)
       fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ before_install:
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                    ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade pyenv             ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pyenv install --list           ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pyenv install "$PYENV_VERSION" ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pyenv local "$PYENV_VERSION"   ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pyenv global "$PYENV_VERSION"  ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pyenv shell "$PYENV_VERSION"   ; fi
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,12 @@ sudo: false
 env:
   global:
     - PATH=$TRAVIS_BUILD_DIR/pandoc:$PATH
-    - PYTHON_BUILD_CACHE_PATH=$HOME/.pyenv_cache
 
 group: edge
 
 cache:
   directories:
-    - $HOME/.pyenv_cache
+    - $HOME/.cache/pyenv
 
 before_install:
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
@@ -29,11 +28,12 @@ before_install:
       if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         brew update
         brew upgrade pyenv
+        mkdir -p $HOME/.cache/pyenv/versions
+        ln -s $HOME/.cache/pyenv/versions ~/.pyenv/versions
         eval "$(pyenv init -)"
-        pyenv install "$PYENV_VERSION"
-        pyenv rehash
+        pyenv install --skip-existing "$PYENV_VERSION"
         pyenv global "$PYENV_VERSION"
-        pyenv shell "$PYENV_VERSION"
+        pyenv rehash
       fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,38 @@
 # http://travis-ci.org/#!/ipython/ipython
 language: python
+
+os:
+    - linux
+    - osx
+
+addons:
+    apt:packages:
+        - graphviz
+
 python:
     - 3.6
     - 3.5
+
 sudo: false
+
 env:
   global:
     - PATH=$TRAVIS_BUILD_DIR/pandoc:$PATH
+
 group: edge
+
 before_install:
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install graphviz; fi
+
 install:
     - pip install pip --upgrade
     - pip install setuptools --upgrade
     - pip install -e file://$PWD#egg=ipython[test] --upgrade
     - pip install trio curio
     - pip install codecov check-manifest --upgrade
-    - sudo apt-get install graphviz
+
 script:
     - check-manifest
     - |
@@ -39,10 +55,10 @@ after_success:
 
 matrix:
     include:
-        - { python: "3.6-dev", dist: xenial, sudo: true }
-        - { python: "3.7", dist: xenial, sudo: true }
-        - { python: "3.7-dev", dist: xenial, sudo: true }
-        - { python: "nightly", dist: xenial, sudo: true }
+        - { python: "3.6-dev", dist: xenial, sudo: true, os: linux }
+        - { python: "3.7", dist: xenial, sudo: true, os: linux }
+        - { python: "3.7-dev", dist: xenial, sudo: true, os: linux }
+        - { python: "nightly", dist: xenial, sudo: true, os: linux }
     allow_failures:
         - python: nightly
 
@@ -63,3 +79,4 @@ deploy:
         all_branches: true  # Backports are released from e.g. 5.x branch
         tags: true
         python: 3.6  # Any version should work, but we only need one
+        condition: $TRAVIS_OS_NAME = "linux"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_install:
         pyenv global "$PYENV_VERSION"
         pyenv rehash
       fi
+    - python --version
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 # http://travis-ci.org/#!/ipython/ipython
 language: python
 
-os:
-    - linux
-    - osx
-
 addons:
-    apt:packages:
-        - graphviz
+    apt:
+        packages:
+            - graphviz
 
 python:
     - 3.6
@@ -23,8 +20,11 @@ group: edge
 
 before_install:
     - 'if [[ $GROUP != js* ]]; then COVERAGE=""; fi'
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install graphviz; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                    ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install pyenv             ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pyenv install "$PYENV_VERSION" ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pyenv local "$PYENV_VERSION"   ; fi
+
 
 install:
     - pip install pip --upgrade
@@ -59,6 +59,8 @@ matrix:
         - { python: "3.7", dist: xenial, sudo: true, os: linux }
         - { python: "3.7-dev", dist: xenial, sudo: true, os: linux }
         - { python: "nightly", dist: xenial, sudo: true, os: linux }
+        - { os: osx, language: generic, env: TRAVIS_PYTHON_VERSION="3.6" PYENV_VERSION="3.6.7" }
+        - { os: osx, language: generic, env: TRAVIS_PYTHON_VERSION="3.7" PYENV_VERSION="3.7.1" }
     allow_failures:
         - python: nightly
 


### PR DESCRIPTION
This adds 3.6/3.7 OSX builds to the travis-ci matrix. No doubt this comes at greater cost to shared resources per PR, but so it goes!

In reading the [Travis docs](https://docs.travis-ci.com/user/multi-os/), this also moves the `apt` install up to the addon level, since we weren't pinning or anything. ~~The equivalent `brew` command is also moved up to `before_install`.~~ (not building docs on osx)

c/f https://github.com/conda-forge/ipython-feedstock/pull/63#issuecomment-433657448