### PR TITLE
fix input_splitter error after KeyboardInterrupt with in --simple-prompt mode (issue #11475)

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -232,6 +232,7 @@ class TerminalInteractiveShell(InteractiveShell):
             # This is very limited, and only accepts a single line.
             def prompt():
                 isp = self.input_splitter
+                isp.reset()
                 prompt_text = "".join(x[1] for x in self.prompts.in_prompt_tokens())
                 prompt_continuation = "".join(x[1] for x in self.prompts.continuation_prompt_tokens())
                 while isp.push_accepts_more():


### PR DESCRIPTION
addresses [issue 11475](https://github.com/ipython/ipython/issues/11475)