### PR TITLE
Add option to force silence %cd

### DIFF
--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -24,12 +24,17 @@ from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.openpy import source_to_unicode
 from IPython.utils.process import abbrev_cwd
 from IPython.utils.terminal import set_term_title
+from traitlets import Bool
 
 
 @magics_class
 class OSMagics(Magics):
     """Magics to interact with the underlying OS (shell-type functionality).
     """
+
+    cd_force_quiet = Bool(False,
+        help="Force %cd magic to be quiet even if -q is not passed."
+    ).tag(config=True)
 
     def __init__(self, shell=None, **kwargs):
 
@@ -414,7 +419,7 @@ class OSMagics(Magics):
             if oldcwd != cwd:
                 dhist.append(cwd)
                 self.shell.db['dhist'] = compress_dhist(dhist)[-100:]
-        if not 'q' in opts and self.shell.user_ns['_dh']:
+        if not 'q' in opts and not self.cd_force_quiet and self.shell.user_ns['_dh']:
             print(self.shell.user_ns['_dh'][-1])
 
     @line_magic

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -23,7 +23,7 @@ from IPython.core.error import UsageError
 from IPython.core.magic import (Magics, magics_class, line_magic,
                                 cell_magic,
                                 register_line_magic, register_cell_magic)
-from IPython.core.magics import execution, script, code, logging
+from IPython.core.magics import execution, script, code, logging, osm
 from IPython.testing import decorators as dec
 from IPython.testing import tools as tt
 from IPython.utils.io import capture_output
@@ -433,7 +433,7 @@ def test_parse_options():
     nt.assert_equal(m.parse_options('foo', '')[1], 'foo')
     nt.assert_equal(m.parse_options(u'foo', '')[1], u'foo')
 
-    
+
 def test_dirops():
     """Test various directory handling operations."""
     # curpath = lambda :os.path.splitdrive(os.getcwd())[1].replace('\\','/')
@@ -449,6 +449,23 @@ def test_dirops():
         nt.assert_equal(curpath(), ipdir)
         _ip.magic('popd')
         nt.assert_equal(curpath(), startdir)
+    finally:
+        os.chdir(startdir)
+
+
+def test_cd_force_quiet():
+    """Test OSMagics.cd_force_quiet option"""
+    _ip.config.OSMagics.cd_force_quiet = True
+    osmagics = osm.OSMagics(shell=_ip)
+
+    startdir = os.getcwd()
+    ipdir = os.path.realpath(_ip.ipython_dir)
+
+    try:
+        with tt.AssertNotPrints(ipdir):
+            osmagics.cd('"%s"' % ipdir)
+        with tt.AssertNotPrints(startdir):
+            osmagics.cd('-')
     finally:
         os.chdir(startdir)
 

--- a/docs/source/whatsnew/pr/cd-force-quiet-config.rst
+++ b/docs/source/whatsnew/pr/cd-force-quiet-config.rst
@@ -1,0 +1,15 @@
+OSMagics.cd_force_quiet configuration option
+============================================
+
+You can set this option to force the %cd magic to behave as if ``-q`` was passed:
+::
+
+    In [1]: cd /
+    /
+    
+    In [2]: %config OSMagics.cd_force_quiet = True
+    
+    In [3]: cd /tmp
+    
+    In [4]:
+


### PR DESCRIPTION
This PR adds the `OSMagics.cd_force_quiet` configuration option to force `%cd` to be silent. This is useful when you already have the cwd in the prompt.