### PR TITLE
Make inclusion of vi mode in prompt togglable.

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -225,6 +225,10 @@ class TerminalInteractiveShell(InteractiveShell):
         help="Allows to enable/disable the prompt toolkit history search"
     ).tag(config=True)
 
+    prompt_includes_vi_mode = Bool(True,
+        help="Display the current vi mode (when using vi editing mode)."
+    ).tag(config=True)
+
     @observe('term_title')
     def init_term_title(self, change=None):
         # Enable or disable the terminal title.

--- a/IPython/terminal/prompts.py
+++ b/IPython/terminal/prompts.py
@@ -14,9 +14,8 @@ class Prompts(object):
         self.shell = shell
 
     def vi_mode(self):
-        if not hasattr(self.shell.pt_app, 'editing_mode'):
-            return ''
-        if self.shell.pt_app.editing_mode == 'VI':
+        if (getattr(self.shell.pt_app, 'editing_mode', None) == 'VI'
+                and self.shell.prompt_includes_vi_mode):
             return '['+str(self.shell.pt_app.app.vi_state.input_mode)[3:6]+'] '
         return ''
 

--- a/docs/source/whatsnew/pr/prompt_includes_vi_mode.rst
+++ b/docs/source/whatsnew/pr/prompt_includes_vi_mode.rst
@@ -1,0 +1,5 @@
+In vi editing mode, whether the prompt includes the current vi mode can now be configured
+-----------------------------------------------------------------------------------------
+
+Set the ``TerminalInteractiveShell.prompt_includes_vi_mode`` to a boolean value
+(default: True) to control this feature.


### PR DESCRIPTION
See discussion in https://github.com/ipython/ipython/pull/11390#discussion_r232088166.

If we really want to make the prompt configurable I guess the config value could be a function taking an `InputMode` as argument and returning a string, but that feels a bit overkill?