### PR TITLE
Fix extension detection

### DIFF
--- a/IPython/utils/module_paths.py
+++ b/IPython/utils/module_paths.py
@@ -64,7 +64,7 @@ def find_mod(module_name):
         return None
     else:
         split_path = module_path.split(".")
-        if split_path[1] in ["py", "pyw"]:
+        if split_path[-1] in ["py", "pyw"]:
             return module_path
         else:
             return None

--- a/IPython/utils/tests/test_module_paths.py
+++ b/IPython/utils/tests/test_module_paths.py
@@ -28,7 +28,8 @@ import nose.tools as nt
 
 env = os.environ
 TEST_FILE_PATH = split(abspath(__file__))[0]
-TMP_TEST_DIR = tempfile.mkdtemp()
+
+TMP_TEST_DIR = tempfile.mkdtemp(suffix='with.dot')
 #
 # Setup/teardown functions/decorators
 #
@@ -65,6 +66,13 @@ def teardown():
     # that non-empty directories are all recursively removed.
     shutil.rmtree(TMP_TEST_DIR)
     sys.path = old_syspath
+
+def test_tempdir():
+    """
+    Ensure the test are done with a temporary file that have a dot somewhere.
+    """
+    nt.assert_in('.',TMP_TEST_DIR)
+
 
 def test_find_mod_1():
     """


### PR DESCRIPTION
If the path leading up to the Python installation's `site-packages` contains a `.`, this check does not do what it says it does :(

For instance, on macOS, the `site-packages` directory is located at `/usr/local/lib/python3.7/site-packages`, which means that trying to use the magic `%run -m my.module` will always fail, because `split_path[1]` will always start with `7/site-packages`.

There are better ways to check that a file extension matches expectations, but I thought it was cute that I could fix this bug by inserting a single character :)

My current workaround looks like this:
```python
import importlib
import_path = importlib.util.find_spec('my.module').origin
%run $import_path
```