### PR TITLE
add CWD to sys.path *after* stdlib

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -181,9 +181,26 @@ class InteractiveShellApp(Configurable):
             self.shell.init_user_ns()
 
     def init_path(self):
-        """Add current working directory, '', to sys.path"""
-        if sys.path[0] != '':
-            sys.path.insert(0, '')
+        """Add current working directory, '', to sys.path
+
+        Unlike Python's default, we insert before the first `site-packages`
+        or `dist-packages` directory,
+        so that it is after the standard library.
+
+        .. versionchanged:: 7.2
+            Try to insert after the standard library, instead of first.
+        """
+        if '' in sys.path:
+            return
+        for idx, path in enumerate(sys.path):
+            parent, last_part = os.path.split(path)
+            if last_part in {'site-packages', 'dist-packages'}:
+                break
+        else:
+            # no site-packages or dist-packages found (?!)
+            # back to original behavior of inserting at the front
+            idx = 0
+        sys.path.insert(idx, '')
 
     def init_shell(self):
         raise NotImplementedError("Override in subclasses")


### PR DESCRIPTION
this deviates from Python's own interactive behavior, but seems to avoid problems where folks create stdlib-names like `email.py`.

They can still collide with packages, but that seems less common than generic names like `email` and `code`.

I'm not entirely sure if it's a good idea to deviate from Python like this, but it would solve a problem that confuses our users from time to time.